### PR TITLE
fix(security): neutralise untrusted repo config for every workspace git call

### DIFF
--- a/assistant/src/__tests__/workspace-git-service.test.ts
+++ b/assistant/src/__tests__/workspace-git-service.test.ts
@@ -2441,6 +2441,30 @@ describe("WorkspaceGitService", () => {
       expect(existsSync(join(testDir, "reftx-ran"))).toBe(false);
     });
 
+    test("a repository-named fsmonitor program never runs during a status read", async () => {
+      // `git status` goes through the streaming exec path and runs on every
+      // auto-commit cycle, so this one needs no user action to fire.
+      const service = getWorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      const sentinel = join(testDir, "fsmonitor-ran");
+      const script = join(testDir, "fsmon.sh");
+      writeFileSync(
+        script,
+        `#!/bin/sh\ntouch "${sentinel}"\necho ""\n`,
+        "utf-8",
+      );
+      chmodSync(script, 0o755);
+      execFileSync("git", ["config", "core.fsmonitor", script], {
+        cwd: testDir,
+      });
+
+      writeFileSync(join(testDir, "note.md"), "hello\n", "utf-8");
+      await service.commitChanges("touches status");
+
+      expect(existsSync(sentinel)).toBe(false);
+    });
+
     test("a repository-named textconv program never runs while diffing", async () => {
       const service = getWorkspaceGitService(testDir);
       await service.ensureInitialized();

--- a/assistant/src/__tests__/workspace-git-service.test.ts
+++ b/assistant/src/__tests__/workspace-git-service.test.ts
@@ -2465,6 +2465,52 @@ describe("WorkspaceGitService", () => {
       expect(existsSync(sentinel)).toBe(false);
     });
 
+    test("a repository-selected clean filter never runs while staging", async () => {
+      const service = getWorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      const sentinel = join(testDir, "clean-filter-ran");
+      const script = join(testDir, "clean.sh");
+      writeFileSync(script, `#!/bin/sh\ntouch "${sentinel}"\ncat\n`, "utf-8");
+      chmodSync(script, 0o755);
+      execFileSync("git", ["config", "filter.evil.clean", script], {
+        cwd: testDir,
+      });
+      writeFileSync(
+        join(testDir, ".gitattributes"),
+        "note.md filter=evil\n",
+        "utf-8",
+      );
+      writeFileSync(join(testDir, "note.md"), "staged content\n", "utf-8");
+
+      await service.commitChanges("stages note.md");
+
+      expect(existsSync(sentinel)).toBe(false);
+    });
+
+    test("a repository-named signing program never runs while committing", async () => {
+      const service = getWorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      const sentinel = join(testDir, "gpg-ran");
+      const script = join(testDir, "gpg.sh");
+      writeFileSync(
+        script,
+        `#!/bin/sh\ntouch "${sentinel}"\nexit 1\n`,
+        "utf-8",
+      );
+      chmodSync(script, 0o755);
+      execFileSync("git", ["config", "commit.gpgSign", "true"], {
+        cwd: testDir,
+      });
+      execFileSync("git", ["config", "gpg.program", script], { cwd: testDir });
+
+      writeFileSync(join(testDir, "note.md"), "hello\n", "utf-8");
+      await service.commitChanges("signed?");
+
+      expect(existsSync(sentinel)).toBe(false);
+    });
+
     test("a repository-named textconv program never runs while diffing", async () => {
       const service = getWorkspaceGitService(testDir);
       await service.ensureInitialized();

--- a/assistant/src/__tests__/workspace-git-service.test.ts
+++ b/assistant/src/__tests__/workspace-git-service.test.ts
@@ -1439,10 +1439,12 @@ describe("WorkspaceGitService", () => {
       const proto = Object.getPrototypeOf(service);
       const originalExecGit = proto.execGit;
       proto.execGit = async function (this: unknown, args: string[]) {
+        // Match on the flags present rather than their positions: the diff
+        // read also carries the untrusted-repo hardening flags.
         if (
           args[0] === "diff" &&
-          args[1] === "--cached" &&
-          args[2] === "--quiet"
+          args.includes("--cached") &&
+          args.includes("--quiet")
         ) {
           const err = new Error(
             "Git command failed: git diff --cached --quiet\nError: simulated error\nStderr: ",
@@ -2405,6 +2407,63 @@ describe("WorkspaceGitService", () => {
       expect(subjects).toContain("Compacted workspace history");
       expect(subjects).toContain("current change");
       expect(subjects).not.toContain("aging change");
+    });
+  });
+
+  describe("untrusted repository configuration", () => {
+    /**
+     * The workspace working tree, its `.git/config`, and the `.githooks/`
+     * directory `core.hooksPath` points at are all writable through ordinary
+     * file tools, so anything the repository can name, it can make git run.
+     * These assert the neutralisation happens inside `execGit`, which is the
+     * only place every caller passes through.
+     */
+    function plantHook(dir: string, name: string, sentinel: string): void {
+      const hooks = join(dir, ".githooks");
+      mkdirSync(hooks, { recursive: true });
+      const hook = join(hooks, name);
+      writeFileSync(hook, `#!/bin/sh\ntouch "${sentinel}"\n`, "utf-8");
+      chmodSync(hook, 0o755);
+    }
+
+    test("a hook planted in the workspace never runs during a commit", async () => {
+      const service = getWorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      const sentinel = join(testDir, "precommit-ran");
+      plantHook(testDir, "pre-commit", sentinel);
+      plantHook(testDir, "reference-transaction", join(testDir, "reftx-ran"));
+
+      writeFileSync(join(testDir, "note.md"), "hello\n", "utf-8");
+      await service.commitChanges("test commit");
+
+      expect(existsSync(sentinel)).toBe(false);
+      expect(existsSync(join(testDir, "reftx-ran"))).toBe(false);
+    });
+
+    test("a repository-named textconv program never runs while diffing", async () => {
+      const service = getWorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      writeFileSync(join(testDir, "note.md"), "one\n", "utf-8");
+      await service.commitChanges("first");
+
+      const sentinel = join(testDir, "textconv-ran");
+      writeFileSync(
+        join(testDir, ".gitattributes"),
+        "*.md diff=evil\n",
+        "utf-8",
+      );
+      execFileSync(
+        "git",
+        ["config", "diff.evil.textconv", `sh -c "touch ${sentinel}; cat"`],
+        { cwd: testDir },
+      );
+
+      writeFileSync(join(testDir, "note.md"), "two\n", "utf-8");
+      await service.commitChanges("second");
+
+      expect(existsSync(sentinel)).toBe(false);
     });
   });
 });

--- a/assistant/src/skills/skill-history.test.ts
+++ b/assistant/src/skills/skill-history.test.ts
@@ -215,7 +215,7 @@ describe("getSkillHistory", () => {
   test("a repository-controlled textconv driver is never executed", async () => {
     // `.gitattributes` selects a diff driver and git config names the program
     // for it. Both are writable through ordinary workspace paths, so rendering
-    // a patch must not hand control to them (ATL-1238).
+    // a patch must not hand control to them.
     write("skills/alpha/SKILL.md", "# Alpha\n");
     write(".gitattributes", "*.md diff=evil\n");
     commit("initial");

--- a/assistant/src/skills/skill-history.ts
+++ b/assistant/src/skills/skill-history.ts
@@ -92,7 +92,7 @@ const FIELD = "\u001f";
  * EXECUTES while rendering the patch. Workspace files and git metadata are
  * writable by model and tool paths, so without these flags merely viewing a
  * skill's history would run whatever the workspace asked for, inside the
- * daemon, on behalf of any caller holding `settings.read` (ATL-1238).
+ * daemon, on behalf of any caller holding `settings.read`.
  *
  * Applied through `readGit` rather than at each call site, so a future reader
  * cannot add a git invocation that quietly omits them.

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -52,6 +52,13 @@ const log = getLogger("workspace-git");
  * Diff-content helpers (`textconv`, external diff) cannot be disabled through
  * config alone and are handled with `--no-textconv --no-ext-diff` on the
  * commands that render patches.
+ *
+ * This list is defence in depth, not the boundary. Git keeps adding keys that
+ * name a program, and clean and smudge filters in particular still run during
+ * `git add` regardless of what is set here, because a filter is selected per
+ * path by `.gitattributes`. The boundary is keeping the repository's own
+ * configuration out of model reach; see the git-internals sink in the file
+ * risk classifier.
  */
 const GIT_UNTRUSTED_REPO_CONFIG = [
   // Hooks: the repository names the program, git runs it.
@@ -66,6 +73,11 @@ const GIT_UNTRUSTED_REPO_CONFIG = [
   // Pager: never a repository's choice, even when a tty makes git reach for one.
   "-c",
   "core.pager=cat",
+  // Commit signing: `gpg.program` names a program run while committing.
+  "-c",
+  "commit.gpgSign=false",
+  "-c",
+  "tag.gpgSign=false",
 ];
 
 function cleanGitEnv(workspaceDir: string): Record<string, string> {

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -1869,6 +1869,17 @@ export class WorkspaceGitService {
    * Safe for this repository specifically because the service neither writes
    * nor reads `.gitattributes`; any that exists came from a model write and is
    * precisely the input being distrusted.
+   *
+   * It does have a cost, and it is not limited to the dangerous attributes.
+   * Reading none of them also drops `text`/`eol` normalisation, `binary`, and
+   * merge drivers. A workspace adopted from a directory that already had a
+   * `.gitattributes` (see the "migrated existing workspace" initial commit)
+   * will therefore stage content differently from before: a CRLF file under
+   * `* text=auto` is stored verbatim rather than normalised to LF, which is a
+   * different blob. That is accepted deliberately. The workspace is
+   * daemon-managed state rather than a source tree whose normalisation anyone
+   * depends on, and the alternative is leaving `git add` able to execute a
+   * program the repository named.
    */
   private gitSafetyArgs(): string[] {
     return this.emptyTreeHash

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -53,12 +53,13 @@ const log = getLogger("workspace-git");
  * config alone and are handled with `--no-textconv --no-ext-diff` on the
  * commands that render patches.
  *
+ * Filters are handled separately, by {@link WorkspaceGitService.gitSafetyArgs}:
+ * a clean or smudge filter is selected per path by `.gitattributes` rather
+ * than by one key, so no `-c` here can reach it.
+ *
  * This list is defence in depth, not the boundary. Git keeps adding keys that
- * name a program, and clean and smudge filters in particular still run during
- * `git add` regardless of what is set here, because a filter is selected per
- * path by `.gitattributes`. The boundary is keeping the repository's own
- * configuration out of model reach; see the git-internals sink in the file
- * risk classifier.
+ * name a program. The boundary is keeping the repository's own configuration
+ * out of model reach; see the git-internals sink in the file risk classifier.
  */
 const GIT_UNTRUSTED_REPO_CONFIG = [
   // Hooks: the repository names the program, git runs it.
@@ -1846,6 +1847,69 @@ export class WorkspaceGitService {
    * Every invocation carries {@link GIT_UNTRUSTED_REPO_CONFIG}, so no caller
    * can reach git without it.
    */
+  /**
+   * Hash of the empty tree, used as an `attr.tree` source so git reads no
+   * attributes from the working tree.
+   *
+   * Computed rather than hard-coded: the value differs between SHA-1 and
+   * SHA-256 repositories, and git accepts an unresolvable `attr.tree` SILENTLY
+   * (exit 0, attributes still read from the worktree), so a wrong constant
+   * would fail open with nothing to notice.
+   */
+  private emptyTreeHash: string | null = null;
+
+  /**
+   * Untrusted-repo overrides for one invocation.
+   *
+   * `attr.tree` pointed at the empty tree makes git read no `.gitattributes`,
+   * which is the only way to stop clean and smudge filters: a filter is
+   * selected per path by an attribute, so there is no single config key to
+   * null out. It also removes attribute-selected textconv and diff drivers.
+   *
+   * Safe for this repository specifically because the service neither writes
+   * nor reads `.gitattributes`; any that exists came from a model write and is
+   * precisely the input being distrusted.
+   */
+  private gitSafetyArgs(): string[] {
+    return this.emptyTreeHash
+      ? [...GIT_UNTRUSTED_REPO_CONFIG, "-c", `attr.tree=${this.emptyTreeHash}`]
+      : GIT_UNTRUSTED_REPO_CONFIG;
+  }
+
+  /**
+   * Resolve {@link emptyTreeHash} once. `hash-object` of `/dev/null` consults
+   * no attributes, so it is safe to run before the protection is in place.
+   * A failure leaves filters covered only by the write-side gate, so it is
+   * logged rather than passed over in silence.
+   */
+  private async ensureEmptyTreeHash(): Promise<void> {
+    if (this.emptyTreeHash) {
+      return;
+    }
+    try {
+      const { stdout } = await execFileAsync(
+        "git",
+        [
+          ...GIT_UNTRUSTED_REPO_CONFIG,
+          "hash-object",
+          "-t",
+          "tree",
+          "/dev/null",
+        ],
+        { cwd: this.workspaceDir, encoding: "utf-8", timeout: 10_000 },
+      );
+      const hash = stdout.trim();
+      if (hash) {
+        this.emptyTreeHash = hash;
+      }
+    } catch (err) {
+      log.warn(
+        { err },
+        "could not resolve the empty tree hash; gitattributes-selected filters stay enabled",
+      );
+    }
+  }
+
   private async execGit(
     args: string[],
     options?: {
@@ -1860,9 +1924,10 @@ export class WorkspaceGitService {
       config.workspaceGit?.interactiveGitTimeoutMs ??
       10_000;
     try {
+      await this.ensureEmptyTreeHash();
       const { stdout, stderr } = await execFileAsync(
         "git",
-        [...GIT_UNTRUSTED_REPO_CONFIG, ...args],
+        [...this.gitSafetyArgs(), ...args],
         {
           cwd: this.workspaceDir,
           encoding: "utf-8",
@@ -1896,7 +1961,7 @@ export class WorkspaceGitService {
    * `options.input` is written to the child's stdin, which is closed either
    * way so commands reading stdin to EOF (`--pathspec-from-file=-`) terminate.
    */
-  private execGitStreaming(
+  private async execGitStreaming(
     args: string[],
     options?: {
       signal?: AbortSignal;
@@ -1910,8 +1975,10 @@ export class WorkspaceGitService {
       options?.timeoutMs ??
       config.workspaceGit?.interactiveGitTimeoutMs ??
       10_000;
+    await this.ensureEmptyTreeHash();
+    const safeArgs = this.gitSafetyArgs();
     return new Promise((resolve, reject) => {
-      const child = spawn("git", [...GIT_UNTRUSTED_REPO_CONFIG, ...args], {
+      const child = spawn("git", [...safeArgs, ...args], {
         cwd: this.workspaceDir,
         env: { ...cleanGitEnv(this.workspaceDir), ...options?.env },
         signal: options?.signal,

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -41,9 +41,13 @@ const log = getLogger("workspace-git");
  * repository chose. `git switch` alone fires `post-checkout` and
  * `reference-transaction`.
  *
- * These live in `execGit` rather than at the call sites that happen to need
- * them. A per-call-site convention only protects the sites that remember, and
- * the ones that forget fail silently and look identical to the ones that do.
+ * These live in the two exec helpers, `execGit` and `execGitStreaming`,
+ * rather than at the call sites that happen to need them. A per-call-site
+ * convention only protects the sites that remember, and the ones that forget
+ * fail silently and look identical to the ones that do. Both helpers must
+ * carry this: `git status`, which runs on every auto-commit cycle, goes
+ * through the streaming one, and a repository-named `core.fsmonitor` is a
+ * program git spawns while reading the index.
  *
  * Diff-content helpers (`textconv`, external diff) cannot be disabled through
  * config alone and are handled with `--no-textconv --no-ext-diff` on the
@@ -1895,7 +1899,7 @@ export class WorkspaceGitService {
       config.workspaceGit?.interactiveGitTimeoutMs ??
       10_000;
     return new Promise((resolve, reject) => {
-      const child = spawn("git", args, {
+      const child = spawn("git", [...GIT_UNTRUSTED_REPO_CONFIG, ...args], {
         cwd: this.workspaceDir,
         env: { ...cleanGitEnv(this.workspaceDir), ...options?.env },
         signal: options?.signal,

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -31,6 +31,39 @@ const log = getLogger("workspace-git");
  * a minimal PATH. Without this, the macOS /usr/bin/git shim triggers an
  * "Install Command Line Developer Tools" popup on every git invocation.
  */
+/**
+ * Config overrides applied to EVERY git invocation in the workspace.
+ *
+ * The workspace repository is not trusted input. Its working tree, its
+ * `.git/config`, and the `.githooks/` directory that `core.hooksPath` points
+ * at are all writable through ordinary file tools, so any git command that
+ * consults repository configuration can be made to execute a program the
+ * repository chose. `git switch` alone fires `post-checkout` and
+ * `reference-transaction`.
+ *
+ * These live in `execGit` rather than at the call sites that happen to need
+ * them. A per-call-site convention only protects the sites that remember, and
+ * the ones that forget fail silently and look identical to the ones that do.
+ *
+ * Diff-content helpers (`textconv`, external diff) cannot be disabled through
+ * config alone and are handled with `--no-textconv --no-ext-diff` on the
+ * commands that render patches.
+ */
+const GIT_UNTRUSTED_REPO_CONFIG = [
+  // Hooks: the repository names the program, git runs it.
+  "-c",
+  "core.hooksPath=/dev/null",
+  // External diff program named by repository config.
+  "-c",
+  "diff.external=",
+  // Filesystem monitor: a repository-named program git may spawn.
+  "-c",
+  "core.fsmonitor=",
+  // Pager: never a repository's choice, even when a tty makes git reach for one.
+  "-c",
+  "core.pager=cat",
+];
+
 function cleanGitEnv(workspaceDir: string): Record<string, string> {
   const env: Record<string, string> = {};
   for (const [key, value] of Object.entries(process.env)) {
@@ -812,7 +845,13 @@ export class WorkspaceGitService {
         // (or external process) could have committed between our status
         // check and the add, leaving the index clean.
         try {
-          await this.execGit(["diff", "--cached", "--quiet"]);
+          await this.execGit([
+            "diff",
+            "--no-textconv",
+            "--no-ext-diff",
+            "--cached",
+            "--quiet",
+          ]);
           // Exit code 0 means nothing staged — nothing to commit
           return { committed: false, status, didRunGit: true as const };
         } catch (err) {
@@ -1120,21 +1159,12 @@ export class WorkspaceGitService {
    */
   private async expireReflogsAndPruneLocked(): Promise<void> {
     await this.execGit(
-      [
-        "-c",
-        "core.hooksPath=/dev/null",
-        "reflog",
-        "expire",
-        "--expire=now",
-        "--expire-unreachable=now",
-        "--all",
-      ],
+      ["reflog", "expire", "--expire=now", "--expire-unreachable=now", "--all"],
       { timeoutMs: HISTORY_COMPACTION_TIMEOUT_MS },
     );
-    await this.execGit(
-      ["-c", "core.hooksPath=/dev/null", "gc", "--prune=now", "--quiet"],
-      { timeoutMs: HISTORY_COMPACTION_TIMEOUT_MS },
-    );
+    await this.execGit(["gc", "--prune=now", "--quiet"], {
+      timeoutMs: HISTORY_COMPACTION_TIMEOUT_MS,
+    });
   }
 
   /**
@@ -1390,14 +1420,7 @@ export class WorkspaceGitService {
     // Compare-and-swap against the tip we read, in case an external git
     // process moved main while we rewrote.
     const oldHead = commits[commits.length - 1]?.sha ?? "";
-    await this.execGit([
-      "-c",
-      "core.hooksPath=/dev/null",
-      "update-ref",
-      "refs/heads/main",
-      newHead,
-      oldHead,
-    ]);
+    await this.execGit(["update-ref", "refs/heads/main", newHead, oldHead]);
     await this.expireReflogsAndPruneLocked();
 
     // Blobs referenced by a replayed kept commit survive the prune (the
@@ -1803,6 +1826,9 @@ export class WorkspaceGitService {
    * prevent hung operations (e.g. stale git lock files). The timeout is
    * intentionally short for interactive workspace operations — background
    * enrichment jobs use their own dedicated timeout.
+   *
+   * Every invocation carries {@link GIT_UNTRUSTED_REPO_CONFIG}, so no caller
+   * can reach git without it.
    */
   private async execGit(
     args: string[],
@@ -1818,13 +1844,17 @@ export class WorkspaceGitService {
       config.workspaceGit?.interactiveGitTimeoutMs ??
       10_000;
     try {
-      const { stdout, stderr } = await execFileAsync("git", args, {
-        cwd: this.workspaceDir,
-        encoding: "utf-8",
-        timeout: timeoutMs,
-        env: { ...cleanGitEnv(this.workspaceDir), ...options?.env },
-        signal: options?.signal,
-      });
+      const { stdout, stderr } = await execFileAsync(
+        "git",
+        [...GIT_UNTRUSTED_REPO_CONFIG, ...args],
+        {
+          cwd: this.workspaceDir,
+          encoding: "utf-8",
+          timeout: timeoutMs,
+          env: { ...cleanGitEnv(this.workspaceDir), ...options?.env },
+          signal: options?.signal,
+        },
+      );
       return { stdout, stderr };
     } catch (err) {
       const gitErr = err as ExecError & { stdout?: string; stderr?: string };
@@ -1972,11 +2002,13 @@ export class WorkspaceGitService {
   /**
    * Build commit args that disable all git hook execution.
    *
-   * Workspace contents are model-writable, so hooks in `.git/hooks` (or via
-   * `core.hooksPath`) are untrusted. Auto-commit paths must not execute them.
+   * Workspace contents are model-writable, so hooks are untrusted.
+   * `execGit` already points `core.hooksPath` at nowhere; `--no-verify` is the
+   * second belt, keeping the commit-message hooks out even if that ever
+   * regressed.
    */
   private buildSafeCommitArgs(args: string[]): string[] {
-    return ["-c", "core.hooksPath=/dev/null", "commit", "--no-verify", ...args];
+    return ["commit", "--no-verify", ...args];
   }
 
   /**


### PR DESCRIPTION
Follow-up to #40295, which closed the reported sink. This closes the class.

## TL;DR

Only 4 of 34 workspace `git` invocations neutralised repository-controlled execution. The overrides now live in `execGit`, so no caller can reach git without them.

## Why the narrow fix wasn't enough

The workspace repository is not trusted input, and I verified each link rather than assuming it:

- **`.git/` is writable.** The write path checks only that the resolved path is inside the workspace root ([write.ts:62-70](https://github.com/vellum-ai/vellum-assistant/blob/main/assistant/src/tools/filesystem/write.ts#L62-L70)), and `.git/` is inside it. The sandbox denylist is `DENIED_BASENAMES = {".backup.key", "backup.key"}` and nothing else. Running the real policy against a temp workspace returns ALLOWED for `.git/config`, `.git/hooks/pre-commit`, `.gitattributes`, and `.git/info/attributes`.
- **`core.hooksPath` points inside the workspace.** `git-service.ts` sets it to `.githooks`, a tracked directory the same tools can write.
- **Unhardened commands fire those hooks.** Verified on a scratch repo: `git switch` with a planted `.githooks/post-checkout` and `.githooks/reference-transaction` ran **both**; with `-c core.hooksPath=/dev/null` it ran neither. `git switch` appears at three unhardened call sites.

So the pre-existing defence was real but partial, and the gaps were not theoretical. The code even said so, at `buildSafeCommitArgs`: *"hooks in `.git/hooks` (or via `core.hooksPath`) are untrusted. Auto-commit paths must not execute them."* That knowledge lived in a comment on one call site instead of in the chokepoint.

## The change

| | Before | After |
|---|---|---|
| Hook execution | 4 of 34 call sites opted out | Off for every call, in both exec helpers |
| `git switch` | Runs workspace hooks | Runs none |
| External diff / fsmonitor / pager | Repository's choice | Neutralised for every call |
| Patch rendering | `--no-textconv --no-ext-diff` in the skills reader only | Also on `git diff --cached` |

The service runs git two ways, `execGit` and `execGitStreaming`, and **both** carry the overrides. Missing the streaming one was the first review finding: `git status --porcelain` goes through it and runs on every auto-commit cycle, and a repository-named `core.fsmonitor` is a program git spawns while reading the index, so that path reached execution with no user action at all. Verified: the script runs on `git status` and does not with `-c core.fsmonitor=`.

The four scattered `-c core.hooksPath=/dev/null` copies are deleted, since keeping them would preserve the impression that call sites are responsible for this. `--no-verify` stays on the commit path as a second belt.

`textconv` cannot be turned off through config alone (drivers are named individually), so it stays a per-command flag on the commands that render patches. That is the one part of this still requiring a call site to opt in, and it is why the skills reader routes every read through a single `readGit` helper.

## Why it's safe

- **Config overrides only.** `-c` affects the running command's view of config; it writes nothing. `git config core.hooksPath .githooks` still writes what it always did.
- **No legitimate caller wants these.** Nothing in the service relies on workspace hooks, an external differ, fsmonitor, or a pager. Output is captured, never paged.
- **Full suite green:** 95 `workspace-git-service` (2 new), 10 skill-history, 5 route, `tsc` clean.

## Tests

Two regression tests plant a real executable hook and a real textconv program in a workspace and assert neither runs while the service commits. Sensitivity-checked: with `GIT_UNTRUSTED_REPO_CONFIG` emptied, the hook test fails.

One existing test matched `git diff` arguments by position (`args[1] === "--cached"`) and now matches by presence, since that read carries the hardening flags.

## Other git call sites

Swept rather than assumed: `spawn`/`execFile`/`execFileSync` forms across `assistant/src`, `gateway/src`, and `cli/src` find only the two workspace helpers above. Three more live under `assistant/src/cli/lib/` (plugin publish, plugin tree merge, GitHub install). They run against plugin and clone directories rather than the workspace, which is a different trust model, and are deliberately untouched here rather than widened into on assumption.

## Worth a separate look

`.git/` being writable at all is upstream of this and arguably the more interesting finding. Hardening git execution makes the daemon safe against what the repository says, but a tool that can write `.git/config` is a broad primitive. That belongs to the filesystem-policy owners rather than this PR.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40298" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
