### PR TITLE
feat(memory): referential conversation forking behind forkStrategy

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -25220,7 +25220,7 @@ paths:
         `nextRunAt` is always null and no run-now endpoint exists. `intervalMs` is the per-conversation time threshold
         (`memory.retrospective.timeThresholdMs`), `lastRunAt` is the `createdAt` of the most recent retrospective
         conversation across both legacy and fork sources, `available` gates on `memory.enabled` (not
-        `memory.v2.enabled`), and `enabled` narrows that by `memory.retrospective.enabled` — the per-pass kill switch
+        `memory.v2.enabled`), and `enabled` narrows that by `memory.retrospective.enabled`, the per-pass kill switch
         that stops retrospectives without disabling the rest of memory.
       tags:
         - retrospective

--- a/assistant/src/__tests__/conversation-fork-referential.test.ts
+++ b/assistant/src/__tests__/conversation-fork-referential.test.ts
@@ -1,0 +1,266 @@
+/**
+ * End-to-end guards over referential forking: `forkStrategy: "reference"`
+ * builds a fork that copies no rows and reads its inherited window back
+ * through `fork_parent_message_id`.
+ *
+ * The load-bearing claim is equivalence. A referential fork must present the
+ * same message list a copied fork presents, because the retrospective agent
+ * reads the fork natively and every downstream consumer (accounting, dedup,
+ * the fork-boundary scan) reads it through the same helpers. The parity test
+ * against the cloning path is what pins that.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { eq } from "drizzle-orm";
+
+import {
+  addMessage,
+  countMessagesAfter,
+  createConversation,
+  deleteConversation,
+  forkConversationForRetrospective,
+  getMessages,
+  getMessagesAfter,
+  getMessagesPaginated,
+  hasMessages,
+  listReferentialForkChildren,
+} from "../persistence/conversation-crud.js";
+import { getDb, getLogsDb, getMemoryDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import {
+  conversations,
+  llmRequestLogs,
+  memoryJobs,
+  memoryRetrospectiveState,
+  messages,
+} from "../persistence/schema/index.js";
+
+await initializeDb();
+
+function resetTables(): void {
+  const db = getDb();
+  getMemoryDb()!.delete(memoryRetrospectiveState).run();
+  getMemoryDb()!.delete(memoryJobs).run();
+  getLogsDb()!.delete(llmRequestLogs).run();
+  db.run("DELETE FROM message_attachments");
+  db.run("DELETE FROM attachments");
+  db.run("DELETE FROM conversation_compaction_events");
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+}
+
+async function seedSource(title: string): Promise<{ id: string }> {
+  const source = createConversation(title);
+  await addMessage(source.id, "user", "draft a launch plan", {
+    skipIndexing: true,
+  });
+  await addMessage(source.id, "assistant", "here is a first pass", {
+    skipIndexing: true,
+  });
+  await addMessage(source.id, "user", "tweak the timeline", {
+    skipIndexing: true,
+  });
+  await addMessage(source.id, "assistant", "updated", { skipIndexing: true });
+  return source;
+}
+
+/** Rows physically stored on a conversation, ignoring anything inherited. */
+function ownedRowCount(conversationId: string): number {
+  return getDb()
+    .select()
+    .from(messages)
+    .where(eq(messages.conversationId, conversationId))
+    .all().length;
+}
+
+/** Flatten each row's content blocks down to their text, for readable asserts. */
+function textOf(rows: Array<{ content: unknown }>): string[] {
+  return rows.map((row) => {
+    if (typeof row.content === "string") {
+      return row.content;
+    }
+    const blocks = Array.isArray(row.content) ? row.content : [];
+    return blocks
+      .map((block: unknown) =>
+        typeof block === "object" && block !== null && "text" in block
+          ? String((block as { text: unknown }).text)
+          : "",
+      )
+      .join("");
+  });
+}
+
+describe("referential forking", () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test("copies no message rows and stamps the strategy", async () => {
+    const source = await seedSource("Launch");
+
+    const fork = await forkConversationForRetrospective({
+      conversationId: source.id,
+      forkStrategy: "reference",
+    });
+
+    expect(ownedRowCount(fork.id)).toBe(0);
+    expect(fork.forkStrategy).toBe("reference");
+    expect(fork.forkParentConversationId).toBe(source.id);
+    expect(fork.forkParentMessageId).not.toBeNull();
+  });
+
+  test("reads the source's history through the fork pointer", async () => {
+    const source = await seedSource("Launch");
+
+    const fork = await forkConversationForRetrospective({
+      conversationId: source.id,
+      forkStrategy: "reference",
+    });
+
+    expect(textOf(getMessages(fork.id))).toEqual([
+      "draft a launch plan",
+      "here is a first pass",
+      "tweak the timeline",
+      "updated",
+    ]);
+    expect(hasMessages(fork.id)).toBe(true);
+  });
+
+  test("presents the same messages a cloning fork does", async () => {
+    const source = await seedSource("Launch");
+
+    const cloned = await forkConversationForRetrospective({
+      conversationId: source.id,
+      forkStrategy: "cloning",
+    });
+    const referenced = await forkConversationForRetrospective({
+      conversationId: source.id,
+      forkStrategy: "reference",
+    });
+
+    expect(textOf(getMessages(referenced.id))).toEqual(
+      textOf(getMessages(cloned.id)),
+    );
+    expect(countMessagesAfter(referenced.id, null)).toBe(
+      countMessagesAfter(cloned.id, null),
+    );
+  });
+
+  test("rows written on the fork interleave after the inherited ones", async () => {
+    const source = await seedSource("Launch");
+    const fork = await forkConversationForRetrospective({
+      conversationId: source.id,
+      forkStrategy: "reference",
+    });
+
+    await addMessage(fork.id, "user", "review this conversation", {
+      skipIndexing: true,
+    });
+
+    expect(textOf(getMessages(fork.id)).at(-1)).toBe(
+      "review this conversation",
+    );
+    expect(ownedRowCount(fork.id)).toBe(1);
+  });
+
+  test("messages written on the source after the fork point are excluded", async () => {
+    const source = await seedSource("Launch");
+    const fork = await forkConversationForRetrospective({
+      conversationId: source.id,
+      forkStrategy: "reference",
+    });
+
+    await addMessage(source.id, "user", "written after the fork", {
+      skipIndexing: true,
+    });
+
+    const forkText = textOf(getMessages(fork.id));
+    expect(forkText).not.toContain("written after the fork");
+    expect(textOf(getMessages(source.id))).toContain("written after the fork");
+  });
+
+  test("a cutoff bounds the inherited window", async () => {
+    const source = await seedSource("Launch");
+    const sourceRows = getMessages(source.id);
+
+    const fork = await forkConversationForRetrospective({
+      conversationId: source.id,
+      throughMessageId: sourceRows[1]!.id,
+      forkStrategy: "reference",
+    });
+
+    expect(textOf(getMessages(fork.id))).toEqual([
+      "draft a launch plan",
+      "here is a first pass",
+    ]);
+  });
+
+  test("getMessagesAfter and countMessagesAfter cross the lineage boundary", async () => {
+    const source = await seedSource("Launch");
+    const sourceRows = getMessages(source.id);
+    const fork = await forkConversationForRetrospective({
+      conversationId: source.id,
+      forkStrategy: "reference",
+    });
+    await addMessage(fork.id, "user", "own row", { skipIndexing: true });
+
+    // The cursor sits on an ancestor row while the rows it must return span
+    // both the ancestor's tail and the fork's own writes.
+    const after = getMessagesAfter(fork.id, sourceRows[1]!.id);
+
+    expect(textOf(after)).toEqual(["tweak the timeline", "updated", "own row"]);
+    expect(countMessagesAfter(fork.id, sourceRows[1]!.id)).toBe(3);
+  });
+
+  test("pagination returns the inherited rows", async () => {
+    const source = await seedSource("Launch");
+    const fork = await forkConversationForRetrospective({
+      conversationId: source.id,
+      forkStrategy: "reference",
+    });
+
+    const unlimited = getMessagesPaginated(fork.id, undefined);
+    expect(textOf(unlimited.messages)).toHaveLength(4);
+
+    const page = getMessagesPaginated(fork.id, 2);
+    expect(page.messages).toHaveLength(2);
+    expect(page.hasMore).toBe(true);
+    // Newest-first paging, so the page holds the tail of the inherited window.
+    expect(textOf(page.messages)).toContain("updated");
+  });
+
+  test("deleting the source is refused while a referential fork reads it", async () => {
+    const source = await seedSource("Launch");
+    const fork = await forkConversationForRetrospective({
+      conversationId: source.id,
+      forkStrategy: "reference",
+    });
+
+    expect(listReferentialForkChildren(source.id)).toEqual([fork.id]);
+    expect(() => deleteConversation(source.id)).toThrow(/referential fork/);
+
+    // Deleting the fork first releases the source.
+    deleteConversation(fork.id);
+    expect(listReferentialForkChildren(source.id)).toEqual([]);
+    deleteConversation(source.id);
+    expect(
+      getDb()
+        .select()
+        .from(conversations)
+        .where(eq(conversations.id, source.id))
+        .all(),
+    ).toHaveLength(0);
+  });
+
+  test("a cloning fork does not block deleting its source", async () => {
+    const source = await seedSource("Launch");
+    await forkConversationForRetrospective({
+      conversationId: source.id,
+      forkStrategy: "cloning",
+    });
+
+    expect(listReferentialForkChildren(source.id)).toEqual([]);
+    expect(() => deleteConversation(source.id)).not.toThrow();
+  });
+});

--- a/assistant/src/config/__tests__/memory-retrospective-schema.test.ts
+++ b/assistant/src/config/__tests__/memory-retrospective-schema.test.ts
@@ -3,7 +3,7 @@
  * retrospective pass runs at all, and how its fork is materialized.
  *
  * The defaults are the contract: a workspace that says nothing must behave
- * exactly as it did before the fields existed — retrospectives on, forks
+ * exactly as it did before the fields existed: retrospectives on, forks
  * cloned.
  */
 

--- a/assistant/src/config/schemas/memory-retrospective.ts
+++ b/assistant/src/config/schemas/memory-retrospective.ts
@@ -11,7 +11,7 @@ export const MemoryRetrospectiveConfigSchema = z
       .boolean({ error: "memory.retrospective.enabled must be a boolean" })
       .default(true)
       .describe(
-        "Whether the memory-retrospective background pass runs. When false, no retrospective is enqueued by any trigger (interval, message count, pre-compaction, scheduled sweep), the scheduled sweep job stops being queued, and any row already queued completes as a no-op. The rest of the memory system (extraction, retrieval, embeddings, `<memory>` injection) is unaffected — use `memory.enabled` to disable memory as a whole.",
+        "Whether the memory-retrospective background pass runs. When false, no retrospective is enqueued by any trigger (interval, message count, pre-compaction, scheduled sweep), the scheduled sweep job stops being queued, and any row already queued completes as a no-op. The rest of the memory system (extraction, retrieval, embeddings, `<memory>` injection) is unaffected. Use `memory.enabled` to disable memory as a whole.",
       ),
 
     forkStrategy: z
@@ -21,7 +21,7 @@ export const MemoryRetrospectiveConfigSchema = z
       })
       .default("cloning")
       .describe(
-        "How a retrospective's fork of the source conversation is materialized. `cloning` (default) full-copies the source conversation's messages and attachments into the fork. `reference` is reserved for the referential fork — the fork holds only its own messages and reads the source's through `fork_parent_message_id` — and is NOT yet implemented; it currently behaves as `cloning`.",
+        "How a retrospective's fork of the source conversation is materialized. `cloning` (default) full-copies the source conversation's messages and attachments into the fork. `reference` makes the fork referential: it holds only its own messages and reads the source's through `fork_parent_message_id`, so a fork costs a single row instead of a full copy of the conversation.",
       ),
 
     timeThresholdMs: z
@@ -130,3 +130,6 @@ export const MemoryRetrospectiveConfigSchema = z
 export type MemoryRetrospectiveConfig = z.infer<
   typeof MemoryRetrospectiveConfigSchema
 >;
+
+/** How a retrospective materializes its fork of the source conversation. */
+export type MemoryForkStrategy = MemoryRetrospectiveConfig["forkStrategy"];

--- a/assistant/src/daemon/__tests__/turn-tail-deleted-conversation.test.ts
+++ b/assistant/src/daemon/__tests__/turn-tail-deleted-conversation.test.ts
@@ -56,6 +56,7 @@ function makeConversation(): ConversationRow {
     originInterface: null,
     forkParentConversationId: null,
     forkParentMessageId: null,
+    forkStrategy: null,
     isAutoTitle: 0,
     scheduleJobId: null,
     lastMessageAt: null,

--- a/assistant/src/notifications/__tests__/assistant-reply-producer.test.ts
+++ b/assistant/src/notifications/__tests__/assistant-reply-producer.test.ts
@@ -135,6 +135,7 @@ function makeConversation(
     originInterface: null,
     forkParentConversationId: null,
     forkParentMessageId: null,
+    forkStrategy: null,
     isAutoTitle: 0,
     scheduleJobId: null,
     lastMessageAt: null,

--- a/assistant/src/persistence/__tests__/conversation-lineage.test.ts
+++ b/assistant/src/persistence/__tests__/conversation-lineage.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Guards over the lineage walk that gives referential forks their message
+ * history. The stop conditions carry the weight here: each one degrades to a
+ * SHORTER lineage, and the tests pin that direction, because the opposite
+ * failure (walking past a missing bound, or following a cloned fork's parent
+ * pointer) splices in rows the conversation must not show.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  isReferentialFork,
+  isSingleSegmentLineage,
+  type LineageBound,
+  type LineageConversationRow,
+  MAX_LINEAGE_DEPTH,
+  resolveConversationLineage,
+} from "../conversation-lineage.js";
+
+function row(
+  id: string,
+  overrides: Partial<LineageConversationRow> = {},
+): LineageConversationRow {
+  return {
+    id,
+    forkStrategy: null,
+    forkParentConversationId: null,
+    forkParentMessageId: null,
+    ...overrides,
+  };
+}
+
+function referential(
+  id: string,
+  parentId: string,
+  forkMessageId: string,
+): LineageConversationRow {
+  return row(id, {
+    forkStrategy: "reference",
+    forkParentConversationId: parentId,
+    forkParentMessageId: forkMessageId,
+  });
+}
+
+/** Resolver over in-memory maps, standing in for the two DB lookups. */
+function resolverFor(
+  rows: LineageConversationRow[],
+  bounds: Record<string, LineageBound> = {},
+) {
+  const byId = new Map(rows.map((r) => [r.id, r]));
+  return {
+    loadConversation: (id: string) => byId.get(id) ?? null,
+    loadMessageBound: (messageId: string) => bounds[messageId] ?? null,
+  };
+}
+
+describe("isReferentialFork", () => {
+  test("a null fork_strategy reads as cloning, so legacy forks stop the walk", () => {
+    expect(
+      isReferentialFork({
+        forkStrategy: null,
+        forkParentConversationId: "parent",
+        forkParentMessageId: "m1",
+      }),
+    ).toBe(false);
+  });
+
+  test("reference without both pointers is not referential", () => {
+    expect(
+      isReferentialFork({
+        forkStrategy: "reference",
+        forkParentConversationId: null,
+        forkParentMessageId: "m1",
+      }),
+    ).toBe(false);
+    expect(
+      isReferentialFork({
+        forkStrategy: "reference",
+        forkParentConversationId: "parent",
+        forkParentMessageId: null,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("resolveConversationLineage", () => {
+  test("a plain conversation is one unbounded segment", () => {
+    const segments = resolveConversationLineage("c1", resolverFor([row("c1")]));
+
+    expect(segments).toEqual([{ conversationId: "c1", through: null }]);
+    expect(isSingleSegmentLineage(segments)).toBe(true);
+  });
+
+  test("a referential fork adds its parent bounded at the fork message", () => {
+    const segments = resolveConversationLineage(
+      "fork",
+      resolverFor([referential("fork", "src", "m5"), row("src")], {
+        m5: { createdAt: 500, id: "m5" },
+      }),
+    );
+
+    expect(segments).toEqual([
+      { conversationId: "fork", through: null },
+      { conversationId: "src", through: { createdAt: 500, id: "m5" } },
+    ]);
+  });
+
+  test("a cloned fork stops the walk so its copied prefix is not read twice", () => {
+    const cloned = row("fork", {
+      forkStrategy: "cloning",
+      forkParentConversationId: "src",
+      forkParentMessageId: "m5",
+    });
+
+    const segments = resolveConversationLineage(
+      "fork",
+      resolverFor([cloned, row("src")], { m5: { createdAt: 500, id: "m5" } }),
+    );
+
+    expect(isSingleSegmentLineage(segments)).toBe(true);
+  });
+
+  test("a fork of a referential fork walks the whole chain", () => {
+    const segments = resolveConversationLineage(
+      "c",
+      resolverFor(
+        [referential("c", "b", "m9"), referential("b", "a", "m4"), row("a")],
+        {
+          m9: { createdAt: 900, id: "m9" },
+          m4: { createdAt: 400, id: "m4" },
+        },
+      ),
+    );
+
+    expect(segments.map((s) => s.conversationId)).toEqual(["c", "b", "a"]);
+    expect(segments[2]!.through).toEqual({ createdAt: 400, id: "m4" });
+  });
+
+  test("a vanished fork message truncates instead of splicing in all of the parent", () => {
+    // Without the bound there is nothing scoping the parent's contribution, so
+    // continuing would pull in messages written AFTER the fork was taken.
+    const segments = resolveConversationLineage(
+      "fork",
+      resolverFor([referential("fork", "src", "gone"), row("src")]),
+    );
+
+    expect(isSingleSegmentLineage(segments)).toBe(true);
+  });
+
+  test("a deleted parent truncates the lineage", () => {
+    const segments = resolveConversationLineage(
+      "fork",
+      resolverFor([referential("fork", "src", "m5")], {
+        m5: { createdAt: 500, id: "m5" },
+      }),
+    );
+
+    expect(isSingleSegmentLineage(segments)).toBe(true);
+  });
+
+  test("a pointer cycle terminates instead of spinning", () => {
+    const segments = resolveConversationLineage(
+      "a",
+      resolverFor([referential("a", "b", "m2"), referential("b", "a", "m1")], {
+        m1: { createdAt: 100, id: "m1" },
+        m2: { createdAt: 200, id: "m2" },
+      }),
+    );
+
+    expect(segments.map((s) => s.conversationId)).toEqual(["a", "b"]);
+  });
+
+  test("the walk is bounded at MAX_LINEAGE_DEPTH", () => {
+    const chainLength = MAX_LINEAGE_DEPTH + 10;
+    const rows: LineageConversationRow[] = [];
+    const bounds: Record<string, LineageBound> = {};
+    for (let i = 0; i < chainLength; i++) {
+      rows.push(referential(`c${i}`, `c${i + 1}`, `m${i}`));
+      bounds[`m${i}`] = { createdAt: i, id: `m${i}` };
+    }
+    rows.push(row(`c${chainLength}`));
+
+    const segments = resolveConversationLineage(
+      "c0",
+      resolverFor(rows, bounds),
+    );
+
+    expect(segments).toHaveLength(MAX_LINEAGE_DEPTH);
+  });
+});

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -16,6 +16,7 @@ import {
   lte,
   notInArray,
   or,
+  type SQL,
   sql,
 } from "drizzle-orm";
 import { v4 as uuid, v7 as uuidv7 } from "uuid";
@@ -25,6 +26,7 @@ import type { ChannelId, InterfaceId } from "../channels/types.js";
 import { parseChannelId, parseInterfaceId } from "../channels/types.js";
 import { CHANNEL_IDS, isChannelId } from "../channels/types.js";
 import { getConfig } from "../config/loader.js";
+import type { MemoryForkStrategy } from "../config/schemas/memory-retrospective.js";
 import { findDisplayTurnEndIndex } from "../conversations/message-consolidation.js";
 import { findConversation } from "../daemon/conversation-registry.js";
 import { conversationMetadataSyncTag } from "../daemon/message-types/sync.js";
@@ -70,6 +72,15 @@ import {
 } from "./conversation-disk-view.js";
 import { ensureDisplayOrderMigration } from "./conversation-display-order-migration.js";
 import { ensureGroupMigration } from "./conversation-group-migration.js";
+import {
+  type LineageBound,
+  type LineageConversationRow,
+  lineageMessageFilter,
+  lineageMessagesAfterFilter,
+  type LineageSegment,
+  REFERENTIAL_FORK_STRATEGY,
+  resolveConversationLineage,
+} from "./conversation-lineage.js";
 import { deleteConversationRowsInBatches } from "./conversation-row-batch-delete.js";
 import {
   BACKGROUND_CONVERSATION_TYPES,
@@ -589,6 +600,8 @@ export interface ConversationRow {
   originInterface: string | null;
   forkParentConversationId: string | null;
   forkParentMessageId: string | null;
+  /** `"reference"` on referential forks; `"cloning"` or null on copied ones. */
+  forkStrategy: string | null;
   isAutoTitle: number;
   scheduleJobId: string | null;
   lastMessageAt: number | null;
@@ -629,6 +642,7 @@ export const parseConversation = createRowMapper<
   originInterface: "originInterface",
   forkParentConversationId: "forkParentConversationId",
   forkParentMessageId: "forkParentMessageId",
+  forkStrategy: "forkStrategy",
   isAutoTitle: "isAutoTitle",
   scheduleJobId: "scheduleJobId",
   lastMessageAt: "lastMessageAt",
@@ -1713,6 +1727,13 @@ export async function forkConversationForRetrospective(params: {
   title?: string;
   conversationType?: ConversationCreateType;
   groupId?: string;
+  /**
+   * `"reference"` builds the fork referentially: the inherited window stays on
+   * the source and is read through `forkParentMessageId`, so the fork writes
+   * one conversation row and copies no messages or attachments. Defaults to
+   * `memory.retrospective.forkStrategy`.
+   */
+  forkStrategy?: MemoryForkStrategy;
 }): Promise<ConversationRow> {
   const { conversationId, throughMessageId } = params;
   const db = getDb();
@@ -1789,9 +1810,23 @@ export async function forkConversationForRetrospective(params: {
   const hiddenRowIds = new Set(
     loadOrderIds.slice(0, inheritedCompaction?.compactedMessageCount ?? 0),
   );
-  const rowsToCopy = messagesToCopy.filter(
-    (message) => !hiddenRowIds.has(message.id),
-  );
+  const isReferential =
+    (params.forkStrategy ?? getConfig().memory.retrospective.forkStrategy) ===
+    "reference";
+  // A referential fork copies nothing: its inherited window is read back
+  // through `forkParentMessageId` by the lineage resolver.
+  const rowsToCopy = isReferential
+    ? []
+    : messagesToCopy.filter((message) => !hiddenRowIds.has(message.id));
+  // The compacted prefix is dropped from a copied fork, so its own row count
+  // behind the boundary is 0. A referential fork reads the source's rows
+  // through the fork point, prefix included, so it must carry the source's
+  // own count for the render to hide the same rows the source hides. Getting
+  // this wrong does not lose data, it re-shows compacted history the summary
+  // already covers.
+  const forkCompactedMessageCount = isReferential
+    ? (inheritedCompaction?.compactedMessageCount ?? 0)
+    : 0;
   const forkParentMessageId = messagesToCopy.at(-1)?.id ?? null;
   const forkTitle =
     params.title ?? `${sourceConversation.title ?? "Untitled"} (Fork)`;
@@ -1832,11 +1867,12 @@ export async function forkConversationForRetrospective(params: {
             // value from the copied rows when the tail is non-empty.
             lastMessageAt: boundaryMessageCreatedAt,
             contextSummary: inheritedCompaction?.summary ?? null,
-            // Zero of the fork's own rows sit behind the boundary (the
-            // compacted prefix is not copied). The summary still renders:
-            // the history render keys on `contextSummary` presence, not on
-            // this count.
-            contextCompactedMessageCount: 0,
+            // On a copied fork zero of its own rows sit behind the boundary
+            // (the compacted prefix is not copied). The summary still
+            // renders: the history render keys on `contextSummary` presence,
+            // not on this count.
+            contextCompactedMessageCount: forkCompactedMessageCount,
+            forkStrategy: isReferential ? REFERENTIAL_FORK_STRATEGY : null,
             contextCompactedAt: inheritedCompaction?.compactedAt ?? null,
             slackContextCompactionWatermarkTs: inheritsLatestCompaction
               ? sourceConversation.slackContextCompactionWatermarkTs
@@ -1861,15 +1897,20 @@ export async function forkConversationForRetrospective(params: {
 
   try {
     // Phase 2 (off the event loop): copy the message rows in a sqlite3
-    // subprocess so the daemon stays responsive during the heavy copy.
-    const copy = await copyForkMessagesViaSubprocess({
-      forkConversationId: fork.id,
-      idPairs,
-    });
-    if (!copy.ok) {
-      throw new Error(
-        `fork message copy failed (${copy.backend}): ${copy.error ?? "unknown"}`,
-      );
+    // subprocess so the daemon stays responsive during the heavy copy. The
+    // referential fork has no rows to copy, which is the whole point of it:
+    // the write burst this phase exists to keep off the event loop does not
+    // happen at all.
+    if (!isReferential) {
+      const copy = await copyForkMessagesViaSubprocess({
+        forkConversationId: fork.id,
+        idPairs,
+      });
+      if (!copy.ok) {
+        throw new Error(
+          `fork message copy failed (${copy.backend}): ${copy.error ?? "unknown"}`,
+        );
+      }
     }
 
     // Phase 3 (in-process): attachments + memory-state seeding, reusing the
@@ -1901,7 +1942,7 @@ export async function forkConversationForRetrospective(params: {
               isFullHistoryFork:
                 copyBoundaryIndex === sourceMessages.length - 1,
               // The copied range already starts at the visible window.
-              inheritedCompactedMessageCount: 0,
+              inheritedCompactedMessageCount: forkCompactedMessageCount,
               skipCompactionLedgerCopy: inheritedCompaction != null,
             });
             // The fork owns none of the source's ledger events — their
@@ -1919,7 +1960,7 @@ export async function forkConversationForRetrospective(params: {
               appendCompactionEvent(fork.id, {
                 compactedAt: inheritedCompaction.compactedAt,
                 summary: inheritedCompaction.summary,
-                compactedMessageCount: 0,
+                compactedMessageCount: forkCompactedMessageCount,
               });
             }
           },
@@ -1950,12 +1991,45 @@ export async function forkConversationForRetrospective(params: {
  * artifacts (embeddings). Returns segment IDs so callers can clean up
  * the corresponding Qdrant vector entries.
  */
+/**
+ * Ids of the referential forks whose inherited history lives on this
+ * conversation. Deleting it would strip those forks of every message before
+ * their fork point, so the delete is refused while any exist.
+ */
+export function listReferentialForkChildren(conversationId: string): string[] {
+  return getDb()
+    .select({ id: conversations.id })
+    .from(conversations)
+    .where(
+      and(
+        eq(conversations.forkParentConversationId, conversationId),
+        eq(conversations.forkStrategy, REFERENTIAL_FORK_STRATEGY),
+      ),
+    )
+    .all()
+    .map((row) => row.id);
+}
+
 export function deleteConversation(id: string): DeletedMemoryIds {
   const db = getDb();
   const result: DeletedMemoryIds = {
     segmentIds: [],
     deletedSummaryIds: [],
   };
+
+  // Block rather than cascade or copy-on-delete. A referential fork reads its
+  // prefix from this conversation, so deleting it silently truncates every
+  // child; cascading would instead delete conversations the caller never named.
+  // Refusing keeps the destructive choice with the caller, and costs one
+  // indexed lookup on a path that is already doing far more work.
+  const referentialChildren = listReferentialForkChildren(id);
+  if (referentialChildren.length > 0) {
+    throw new UserError(
+      `Conversation ${id} cannot be deleted while ${referentialChildren.length} ` +
+        `referential fork(s) read their history from it: ` +
+        `${referentialChildren.join(", ")}. Delete those first.`,
+    );
+  }
 
   // Capture createdAt before the transaction deletes the row — needed to
   // resolve the conversation's disk-view directory path after deletion.
@@ -2286,18 +2360,73 @@ export async function addMessage(
   return message;
 }
 
+/**
+ * Load only the columns the lineage walk reads. A conversation-row primary-key
+ * lookup per message read is the cost of referential forks; selecting four
+ * columns instead of the full row keeps it to an index hit.
+ */
+function loadLineageRow(id: string): LineageConversationRow | null {
+  const row = getDb()
+    .select({
+      id: conversations.id,
+      forkStrategy: conversations.forkStrategy,
+      forkParentConversationId: conversations.forkParentConversationId,
+      forkParentMessageId: conversations.forkParentMessageId,
+    })
+    .from(conversations)
+    .where(eq(conversations.id, id))
+    .get();
+  return row ?? null;
+}
+
+/** The `(createdAt, id)` bound of a single message, or null when it is gone. */
+function loadMessageBound(messageId: string): LineageBound | null {
+  const row = getDb()
+    .select({ createdAt: messages.createdAt, id: messages.id })
+    .from(messages)
+    .where(eq(messages.id, messageId))
+    .get();
+  return row ?? null;
+}
+
+/**
+ * The segments making up a conversation's logical message set. Non-forks and
+ * copied forks resolve to a single unbounded segment after one row lookup, so
+ * the referential path costs them nothing beyond that lookup.
+ */
+function resolveLineage(conversationId: string): LineageSegment[] {
+  return resolveConversationLineage(conversationId, {
+    loadConversation: loadLineageRow,
+    loadMessageBound,
+  });
+}
+
+/** `messages` predicate covering every row a conversation logically owns. */
+function lineageFilter(conversationId: string): SQL {
+  return lineageMessageFilter(resolveLineage(conversationId));
+}
+
 export function getMessages(conversationId: string): MessageRow[] {
   const db = getDb();
   // Synchronous read of every row for the conversation — the dominant
   // per-turn main-thread cost on large conversations. Timed so a freeze the
   // event-loop watchdog detects can be attributed here (see slow-sync-log).
+  //
+  // Ordered by `createdAt` ALONE. Rows sharing a millisecond fall back to
+  // SQLite's rowid order, which is insertion order, and callers depend on
+  // that: the compaction render slices a row count off the front of this
+  // exact order, and a fork's copied prefix must match the order the source
+  // renders. Adding an `id` tiebreak here reorders same-millisecond rows and
+  // silently shifts that boundary. A lineage read inherits the same rule, and
+  // an ancestor's rows sort ahead of the fork's own on a tie because they were
+  // inserted first.
   return timeSyncSection(
     "conversation-crud:get-messages",
     () =>
       db
         .select()
         .from(messages)
-        .where(eq(messages.conversationId, conversationId))
+        .where(lineageFilter(conversationId))
         .orderBy(asc(messages.createdAt))
         .all()
         .map(parseMessage),
@@ -2330,7 +2459,7 @@ export function selectSlackMetaCandidateMetadata(
     .from(messages)
     .where(
       and(
-        eq(messages.conversationId, conversationId),
+        lineageFilter(conversationId),
         opts?.includeFlatLegacy
           ? or(
               like(messages.metadata, '%"slackMeta"%'),
@@ -2368,19 +2497,16 @@ export function countMessagesAfter(
   afterMessageId: string | null,
 ): number {
   const db = getDb();
+  const segments = resolveLineage(conversationId);
   if (afterMessageId === null || afterMessageId === "") {
     const row = db
       .select({ c: count() })
       .from(messages)
-      .where(eq(messages.conversationId, conversationId))
+      .where(lineageMessageFilter(segments))
       .get();
     return row?.c ?? 0;
   }
-  const ref = db
-    .select({ createdAt: messages.createdAt })
-    .from(messages)
-    .where(eq(messages.id, afterMessageId))
-    .get();
+  const ref = loadMessageBound(afterMessageId);
   if (!ref) {
     return 0;
   }
@@ -2391,18 +2517,7 @@ export function countMessagesAfter(
   const row = db
     .select({ c: count() })
     .from(messages)
-    .where(
-      and(
-        eq(messages.conversationId, conversationId),
-        or(
-          gt(messages.createdAt, ref.createdAt),
-          and(
-            eq(messages.createdAt, ref.createdAt),
-            gt(messages.id, afterMessageId),
-          ),
-        ),
-      ),
-    )
+    .where(lineageMessagesAfterFilter(segments, ref))
     .get();
   return row?.c ?? 0;
 }
@@ -2419,6 +2534,7 @@ export function getMessagesAfter(
   afterMessageId: string | null,
 ): MessageRow[] {
   const db = getDb();
+  const segments = resolveLineage(conversationId);
   if (afterMessageId === null || afterMessageId === "") {
     // Secondary `asc(messages.id)` matches the non-null path's cursor
     // ordering, so callers tracking `cutoffMessageId` across runs see a
@@ -2426,16 +2542,12 @@ export function getMessagesAfter(
     return db
       .select()
       .from(messages)
-      .where(eq(messages.conversationId, conversationId))
+      .where(lineageMessageFilter(segments))
       .orderBy(asc(messages.createdAt), asc(messages.id))
       .all()
       .map(parseMessage);
   }
-  const ref = db
-    .select({ createdAt: messages.createdAt })
-    .from(messages)
-    .where(eq(messages.id, afterMessageId))
-    .get();
+  const ref = loadMessageBound(afterMessageId);
   if (!ref) {
     return [];
   }
@@ -2444,18 +2556,7 @@ export function getMessagesAfter(
   return db
     .select()
     .from(messages)
-    .where(
-      and(
-        eq(messages.conversationId, conversationId),
-        or(
-          gt(messages.createdAt, ref.createdAt),
-          and(
-            eq(messages.createdAt, ref.createdAt),
-            gt(messages.id, afterMessageId),
-          ),
-        ),
-      ),
-    )
+    .where(lineageMessagesAfterFilter(segments, ref))
     .orderBy(asc(messages.createdAt), asc(messages.id))
     .all()
     .map(parseMessage);
@@ -2471,7 +2572,7 @@ export function hasMessages(conversationId: string): boolean {
   const row = db
     .select({ one: sql`1` })
     .from(messages)
-    .where(eq(messages.conversationId, conversationId))
+    .where(lineageFilter(conversationId))
     .limit(1)
     .get();
   return row !== undefined;
@@ -2512,8 +2613,10 @@ export function getMessagesPaginated(
 ): PaginatedMessagesResult {
   const db = getDb();
 
+  const segments = resolveLineage(conversationId);
+
   if (limit === undefined) {
-    const conditions = [eq(messages.conversationId, conversationId)];
+    const conditions = [lineageMessageFilter(segments)];
     if (beforeTimestamp !== undefined) {
       conditions.push(lt(messages.createdAt, beforeTimestamp));
     }
@@ -2573,7 +2676,7 @@ export function getMessagesPaginated(
     const chunk = db
       .select()
       .from(messages)
-      .where(and(eq(messages.conversationId, conversationId), cursorPredicate))
+      .where(and(lineageMessageFilter(segments), cursorPredicate))
       .orderBy(desc(messages.createdAt), desc(messages.id))
       .limit(chunkSize)
       .all()

--- a/assistant/src/persistence/conversation-lineage.ts
+++ b/assistant/src/persistence/conversation-lineage.ts
@@ -1,0 +1,209 @@
+// ---------------------------------------------------------------------------
+// Conversation lineage: the read model for referential forks.
+// ---------------------------------------------------------------------------
+//
+// A referential fork holds only the rows written after it was created. The
+// history it inherits stays on its parent and is read through
+// `fork_parent_message_id`, so forking costs one conversation row instead of a
+// copy of every message and attachment in the source.
+//
+// A conversation's logical message set is therefore a chain of segments:
+//
+//   [C (unbounded), parent(C) through its fork point, parent(parent(C)), ...]
+//
+// where each ancestor contributes only the rows at or before the fork point
+// the child was taken from. `resolveConversationLineage` walks that chain and
+// `lineageMessageFilter` turns it into one SQL predicate, so a lineage read is
+// a single indexed query rather than a fetch per generation.
+//
+// Copied forks stop the walk. Their inherited prefix is physically present on
+// their own row, so following the parent pointer would return those rows a
+// second time. `fork_strategy` is the discriminator, and its NULL default
+// reads as `cloning`, which is what every fork created before referential
+// forking existed is.
+
+import { and, eq, gt, lt, or, type SQL } from "drizzle-orm";
+
+import { messages } from "./schema/index.js";
+
+/**
+ * Upper bound of an ancestor's contribution to a lineage, as the
+ * `(createdAt, id)` pair of the message the child was forked from. The
+ * composite bound mirrors the cursor ordering used everywhere else in this
+ * module: `createdAt` alone cannot separate rows written inside the same
+ * millisecond, which would make a fork boundary include or drop a sibling row
+ * depending on insertion order.
+ */
+export interface LineageBound {
+  createdAt: number;
+  id: string;
+}
+
+/**
+ * One conversation's contribution to a lineage. `through` is null for the
+ * conversation the lineage was resolved for, which contributes all of its own
+ * rows; ancestors carry the bound their child was forked at.
+ */
+export interface LineageSegment {
+  conversationId: string;
+  through: LineageBound | null;
+}
+
+/**
+ * Maximum ancestors walked from the starting conversation. A fork of a fork is
+ * already rare and the retrospective never creates one, so this is a guard
+ * against a malformed pointer chain rather than a real depth limit: exceeding
+ * it truncates the lineage, which renders a short history, instead of walking
+ * unboundedly on a hot read path.
+ */
+export const MAX_LINEAGE_DEPTH = 32;
+
+/** The `fork_strategy` value that makes a fork read through its parent. */
+export const REFERENTIAL_FORK_STRATEGY = "reference";
+
+/**
+ * Whether a conversation reads its inherited history from its parent.
+ *
+ * All three pointers must be present: a row claiming `reference` without a
+ * parent conversation or fork message has no resolvable bound, and reading it
+ * as referential would silently drop the prefix instead of surfacing the
+ * inconsistency as a short conversation.
+ */
+export function isReferentialFork(row: {
+  forkStrategy: string | null;
+  forkParentConversationId: string | null;
+  forkParentMessageId: string | null;
+}): boolean {
+  return (
+    row.forkStrategy === REFERENTIAL_FORK_STRATEGY &&
+    row.forkParentConversationId !== null &&
+    row.forkParentMessageId !== null
+  );
+}
+
+/**
+ * Row shape the lineage walk needs. Declared structurally so this module can
+ * be driven by a caller's already-loaded conversation row without importing
+ * `conversation-crud.ts`, which imports this module.
+ */
+export interface LineageConversationRow {
+  id: string;
+  forkStrategy: string | null;
+  forkParentConversationId: string | null;
+  forkParentMessageId: string | null;
+}
+
+export interface LineageResolverDeps {
+  /** Load a conversation row, or null when it no longer exists. */
+  loadConversation: (id: string) => LineageConversationRow | null;
+  /** Load a message's `(createdAt, id)` bound, or null when it is gone. */
+  loadMessageBound: (messageId: string) => LineageBound | null;
+}
+
+/**
+ * Walk a conversation's fork chain into the ordered segments that make up its
+ * logical message set. The first segment is always the conversation itself.
+ *
+ * The walk stops at the first conversation that is not a referential fork, at
+ * a parent row or fork message that no longer exists, at a repeated
+ * conversation id (a cycle a corrupted pointer could otherwise spin on), and
+ * at {@link MAX_LINEAGE_DEPTH}. Every stop degrades the same way: the lineage
+ * is shorter than it should be, so the conversation renders without part of
+ * its inherited prefix. None of them throw, because a read path that raises on
+ * a dangling pointer takes down a conversation the user can still partly see.
+ *
+ * A vanished fork message is worth calling out: the bound is what scopes the
+ * parent's contribution, so continuing without it would splice in the parent's
+ * ENTIRE history, including messages written after the fork was taken. Cutting
+ * the lineage short is the conservative direction.
+ */
+export function resolveConversationLineage(
+  conversationId: string,
+  deps: LineageResolverDeps,
+): LineageSegment[] {
+  const segments: LineageSegment[] = [{ conversationId, through: null }];
+  const visited = new Set<string>([conversationId]);
+
+  let current = deps.loadConversation(conversationId);
+  while (current !== null && segments.length < MAX_LINEAGE_DEPTH) {
+    if (!isReferentialFork(current)) {
+      break;
+    }
+    const parentId = current.forkParentConversationId as string;
+    if (visited.has(parentId)) {
+      break;
+    }
+    const bound = deps.loadMessageBound(current.forkParentMessageId as string);
+    if (bound === null) {
+      break;
+    }
+    const parent = deps.loadConversation(parentId);
+    if (parent === null) {
+      break;
+    }
+    segments.push({ conversationId: parentId, through: bound });
+    visited.add(parentId);
+    current = parent;
+  }
+
+  return segments;
+}
+
+/**
+ * Whether a lineage is a single unbounded segment, i.e. the conversation owns
+ * every row it reads. Lets callers keep the plain `conversation_id = ?`
+ * predicate for the overwhelmingly common non-fork case instead of paying for
+ * the OR-of-segments form.
+ */
+export function isSingleSegmentLineage(segments: LineageSegment[]): boolean {
+  return segments.length === 1;
+}
+
+/**
+ * Build the `messages` predicate selecting every row in a lineage.
+ *
+ * Each ancestor segment is scoped by a `(createdAt, id)` upper bound applied
+ * the same way the cursor comparisons elsewhere in this module apply theirs:
+ * strictly-earlier `createdAt`, or an equal `createdAt` with an id that does
+ * not sort after the bound. The fork message itself is included, because a
+ * fork is taken THROUGH that message.
+ */
+export function lineageMessageFilter(segments: LineageSegment[]): SQL {
+  const clauses = segments.map((segment) => {
+    const owner = eq(messages.conversationId, segment.conversationId);
+    if (segment.through === null) {
+      return owner;
+    }
+    const { createdAt, id } = segment.through;
+    return and(
+      owner,
+      or(
+        lt(messages.createdAt, createdAt),
+        and(
+          eq(messages.createdAt, createdAt),
+          or(eq(messages.id, id), lt(messages.id, id)),
+        ),
+      ),
+    ) as SQL;
+  });
+  return (clauses.length === 1 ? clauses[0]! : or(...clauses)!) as SQL;
+}
+
+/**
+ * Predicate for rows in a lineage created strictly after a cursor, in the
+ * lineage's global `(createdAt, id)` order rather than per conversation. Used
+ * by the "everything after message X" reads, whose cursor can sit on an
+ * ancestor while the rows it must return live on the descendant.
+ */
+export function lineageMessagesAfterFilter(
+  segments: LineageSegment[],
+  after: LineageBound,
+): SQL {
+  return and(
+    lineageMessageFilter(segments),
+    or(
+      gt(messages.createdAt, after.createdAt),
+      and(eq(messages.createdAt, after.createdAt), gt(messages.id, after.id)),
+    ),
+  ) as SQL;
+}

--- a/assistant/src/persistence/migrations/365-add-conversation-fork-strategy.ts
+++ b/assistant/src/persistence/migrations/365-add-conversation-fork-strategy.ts
@@ -1,0 +1,27 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { tableHasColumn } from "./schema-introspection.js";
+
+/**
+ * Add `fork_strategy` to `conversations`, the discriminator that says whether
+ * a fork's inherited history lives on the fork (copied) or on its parent
+ * (read through `fork_parent_message_id`).
+ *
+ * The column is required even though `fork_parent_conversation_id` and
+ * `fork_parent_message_id` already exist, because both are set on copied
+ * forks too. Without a discriminator, a lineage read cannot tell a fork whose
+ * prefix it must fetch from the parent from one that already holds its own
+ * copy of that prefix, and would return the copied rows twice.
+ *
+ * Nullable with no backfill: every fork that exists when this runs was
+ * materialized by copying, and `isReferentialFork` reads NULL as `cloning`.
+ * A backfill would have to write a value to every historical conversation row
+ * to encode what the absence of a value already means.
+ *
+ * Idempotent: the column add is guarded with `tableHasColumn`, so a crash
+ * partway through does not break the next boot.
+ */
+export function migrateAddConversationForkStrategy(database: DrizzleDb): void {
+  if (!tableHasColumn(database, "conversations", "fork_strategy")) {
+    database.run(`ALTER TABLE conversations ADD COLUMN fork_strategy TEXT`);
+  }
+}

--- a/assistant/src/persistence/schema/conversations.ts
+++ b/assistant/src/persistence/schema/conversations.ts
@@ -38,6 +38,16 @@ export const conversations = sqliteTable(
     forkParentConversationId: text("fork_parent_conversation_id"),
     forkParentMessageId: text("fork_parent_message_id"),
     /**
+     * How this conversation's fork was materialized: `reference` means the
+     * rows at-or-before `forkParentMessageId` live on the parent and are read
+     * through it, `cloning` (and NULL, the value every pre-existing fork
+     * carries) means they were physically copied onto this row. Read through
+     * `isReferentialFork` in `conversation-lineage.ts`, never directly: the
+     * NULL-is-cloning default is what keeps existing forks from being read
+     * twice, once from their copies and once through their parent.
+     */
+    forkStrategy: text("fork_strategy"),
+    /**
      * Id of the conversation that spawned this one (subagent spawns stamp
      * their parent's conversation id). Distinct from
      * `forkParentConversationId`, which records message-history inheritance;

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -472,6 +472,7 @@ import { migrateNormalizeManagedConnectionRows } from "./migrations/361-normaliz
 import { migrateAddConversationSubagentKind } from "./migrations/362-add-conversation-subagent-kind.js";
 import { migrateBackfillScheduleInferenceProfile } from "./migrations/363-backfill-schedule-inference-profile.js";
 import { migrateAddScheduleSourceKey } from "./migrations/364-add-schedule-source-key.js";
+import { migrateAddConversationForkStrategy } from "./migrations/365-add-conversation-fork-strategy.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1571,4 +1572,5 @@ export const migrationSteps: MigrationStep[] = [
     dependsOn: ["migrateScheduleInferenceProfile"],
   },
   migrateAddScheduleSourceKey,
+  migrateAddConversationForkStrategy,
 ];

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-enqueue.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-enqueue.test.ts
@@ -115,7 +115,7 @@ describe("enqueueMemoryRetrospectiveIfEnabled", () => {
     expect(call.runAfter).toBeLessThanOrEqual(after);
   });
 
-  test("enabled=false — every trigger is declined before any other gate", () => {
+  test("enabled=false declines every trigger before any other gate", () => {
     cfgRetrospectiveEnabled = false;
 
     for (const trigger of [
@@ -135,7 +135,7 @@ describe("enqueueMemoryRetrospectiveIfEnabled", () => {
     expect(gateProbeCalls).toHaveLength(0);
   });
 
-  test("unreadable config — the kill switch fails closed", () => {
+  test("unreadable config: the kill switch fails closed", () => {
     cfgThrows = true;
     const result = enqueueMemoryRetrospectiveIfEnabled({
       conversationId: "c1",

--- a/assistant/src/plugins/defaults/memory/jobs-worker.ts
+++ b/assistant/src/plugins/defaults/memory/jobs-worker.ts
@@ -926,7 +926,7 @@ export const RETROSPECTIVE_SWEEP_CHECKPOINT = "retro_sweep:last_run";
  * `memory.retrospective.enabled` is checked here as well as inside the
  * enqueue funnel, so a disabled retrospective costs no scan at all rather
  * than a full conversation scan whose every enqueue is then declined. The
- * checkpoint is left untouched while disabled — re-enabling then fires the
+ * checkpoint is left untouched while disabled, so re-enabling fires the
  * first sweep on the next tick, which is the desired catch-up.
  *
  * Exported for tests; the worker calls it on every idle/drain tick. Returns

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
@@ -157,7 +157,7 @@ export async function memoryRetrospectiveJob(
   // Execution-time twin of the enqueue funnel's `memory.retrospective.enabled`
   // gate: rows queued before the flag was turned off drain as no-ops instead
   // of forking. The CLI's manual `memory retrospective run` calls
-  // `runForkBasedRetrospective` directly and so is unaffected — an operator's
+  // `runForkBasedRetrospective` directly and so is unaffected: an operator's
   // explicit request overrides the flag, matching the lookback and
   // user-activity gates.
   if (!config.memory.retrospective.enabled) {
@@ -413,6 +413,7 @@ export async function runForkBasedRetrospective(
       title: `${sourceConversation.title ?? "Untitled"} (Retrospective)`,
       conversationType: "background",
       groupId: MEMORY_RETROSPECTIVE_GROUP_ID,
+      forkStrategy: config.memory.retrospective.forkStrategy,
     });
   } catch (err) {
     await bumpRetrospectiveLastRunAt(sourceConversationId, Date.now());

--- a/assistant/src/runtime/routes/__tests__/retrospective-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/retrospective-routes.test.ts
@@ -426,7 +426,7 @@ describe("getRetrospectiveConfig handler", () => {
     const handler = findHandler("getRetrospectiveConfig");
     const result = (await handler({})) as ConfigResponse;
 
-    // `available` stays true so the Settings row still renders — it reads
+    // `available` stays true so the Settings row still renders. It reads
     // "Paused" rather than disappearing as it would with memory off.
     expect(result.available).toBe(true);
     expect(result.enabled).toBe(false);

--- a/assistant/src/runtime/routes/retrospective-routes.ts
+++ b/assistant/src/runtime/routes/retrospective-routes.ts
@@ -13,7 +13,7 @@
  * `available` gates on `memory.enabled` alone (matching `isMemoryEnabled` in
  * the enqueue path). Retrospectives do NOT depend on `memory.v2.enabled`.
  * `enabled` narrows `available` by `memory.retrospective.enabled`, the
- * per-pass kill switch — so a memory-on assistant with retrospectives turned
+ * per-pass kill switch, so a memory-on assistant with retrospectives turned
  * off reports `available: true, enabled: false` and the Settings row reads
  * "Paused" rather than implying memory itself is off.
  */
@@ -115,7 +115,7 @@ export const ROUTES: RouteDefinition[] = [
       "`createdAt` of the most recent retrospective conversation across " +
       "both legacy and fork sources, `available` gates on `memory.enabled` " +
       "(not `memory.v2.enabled`), and `enabled` narrows that by " +
-      "`memory.retrospective.enabled` — the per-pass kill switch that stops " +
+      "`memory.retrospective.enabled`, the per-pass kill switch that stops " +
       "retrospectives without disabling the rest of memory.",
     tags: ["retrospective"],
     responseBody: z.object({

--- a/assistant/src/runtime/services/__tests__/conversation-serializer.test.ts
+++ b/assistant/src/runtime/services/__tests__/conversation-serializer.test.ts
@@ -38,6 +38,7 @@ function makeConversationRow(
     originInterface: null,
     forkParentConversationId: null,
     forkParentMessageId: null,
+    forkStrategy: null,
     isAutoTitle: 0,
     scheduleJobId: null,
     lastMessageAt: 3000,

--- a/clients/web/src/domains/schedules/components/system-task-detail-panel.tsx
+++ b/clients/web/src/domains/schedules/components/system-task-detail-panel.tsx
@@ -120,9 +120,10 @@ export function SystemTaskDetailPanel({
 
   // Consolidation and retrospective are owned by Memory: no toggle in this
   // panel, paused when Memory is off. Retrospective additionally has no global
-  // schedule (so it hides Next run) and its own config switch
-  // (`memory.retrospective.enabled`), which pauses it while Memory stays on —
-  // `available` is what tells the two pauses apart.
+  // schedule (so it hides Next run) and its own persisted switch
+  // (`memory.retrospective.enabled`), which pauses it while Memory stays on.
+  // `available` is what tells the two pauses apart, and each pause sends the
+  // user to the control that actually unpauses it.
   const isMemoryManaged = kind !== "heartbeat";
   const isRetrospective = kind === "retrospective";
   const isMemoryPaused = isMemoryManaged && !enabled;
@@ -134,11 +135,13 @@ export function SystemTaskDetailPanel({
     : enabled
       ? "Enabled"
       : "Disabled";
-  const pausedNotice = isRetrospective
-    ? retrospectiveConfig?.available === true
-      ? "Retrospectives are turned off in this assistant's memory settings. Turn them back on to resume them."
-      : "Memory is off, so retrospectives are paused. Turn Memory back on to resume them."
-    : "Memory is off, so consolidation is paused. Turn Memory back on to resume consolidation.";
+  const isRetrospectiveSwitchedOff =
+    isRetrospective && retrospectiveConfig?.available === true;
+  const pausedNotice = isRetrospectiveSwitchedOff
+    ? "Retrospectives are turned off. Turn them back on under Memory in settings."
+    : isRetrospective
+      ? "Memory is off, so retrospectives are paused. Turn Memory back on to resume them."
+      : "Memory is off, so consolidation is paused. Turn Memory back on to resume consolidation.";
   const showMemorySettings =
     isMemoryManaged && enabled && canOpenMemorySettings;
 
@@ -276,7 +279,9 @@ export function SystemTaskDetailPanel({
                       navigate(`${routes.settings.developer}?tab=memory`)
                     }
                   >
-                    Turn on Memory
+                    {isRetrospectiveSwitchedOff
+                      ? "Open Memory settings"
+                      : "Turn on Memory"}
                   </Button>
                 ) : undefined
               }

--- a/clients/web/src/domains/settings/components/memory-card.tsx
+++ b/clients/web/src/domains/settings/components/memory-card.tsx
@@ -3,6 +3,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { DetailCard } from "@/components/detail-card";
 import { useAssistantWithHealthz } from "@/domains/settings/components/assistant-status-panel";
+import { MemoryRetrospectiveToggle } from "@/domains/settings/components/memory-retrospective-toggle";
 import { MemoryWorkerToggle } from "@/domains/settings/components/memory-worker-toggle";
 import {
   configGetOptions,
@@ -35,6 +36,12 @@ export function MemoryCard() {
     },
   });
   const memoryEnabled = config?.memory?.enabled !== false;
+  // The generated config type stops at `memory.retrospective` (the daemon's
+  // config response schema does not enumerate the block's fields), so the read
+  // is narrowed here. Absent means the schema default, which is on.
+  const retrospectiveEnabled =
+    (config?.memory?.retrospective as { enabled?: boolean } | undefined)
+      ?.enabled !== false;
 
   const handleMemoryToggle = async (enabled: boolean) => {
     try {
@@ -67,6 +74,10 @@ export function MemoryCard() {
       }
       compactAccessory
     >
+      <MemoryRetrospectiveToggle
+        memoryEnabled={memoryEnabled}
+        retrospectiveEnabled={retrospectiveEnabled}
+      />
       <MemoryWorkerToggle memoryEnabled={memoryEnabled} />
     </DetailCard>
   );

--- a/clients/web/src/domains/settings/components/memory-retrospective-toggle.tsx
+++ b/clients/web/src/domains/settings/components/memory-retrospective-toggle.tsx
@@ -1,0 +1,86 @@
+import { useQueryClient } from "@tanstack/react-query";
+
+import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
+import {
+  configGetSetQueryData,
+  useConfigPatchMutation,
+} from "@/generated/daemon/@tanstack/react-query.gen";
+import { captureError } from "@/lib/sentry/capture-error";
+import { toast } from "@vellumai/design-library/components/toast";
+import { Toggle } from "@vellumai/design-library/components/toggle";
+
+export interface MemoryRetrospectiveToggleProps {
+  /**
+   * Whether long-term memory is enabled. Retrospectives are a memory
+   * background pass, so their toggle is disabled while memory is off (memory
+   * being off already pauses them).
+   */
+  memoryEnabled: boolean;
+  /** Current `memory.retrospective.enabled`, defaulting to on when unset. */
+  retrospectiveEnabled: boolean;
+}
+
+/**
+ * Sub-row of the Memory settings card controlling
+ * `memory.retrospective.enabled`. Unlike the background-worker row next to it,
+ * this writes a persisted config value, so the state survives restarts.
+ *
+ * This row is what makes the Schedules "Memory retrospective" task's paused
+ * notice actionable: that notice sends the user here, and without a control on
+ * this page the only way back on would be editing config.json by hand.
+ */
+export function MemoryRetrospectiveToggle({
+  memoryEnabled,
+  retrospectiveEnabled,
+}: MemoryRetrospectiveToggleProps) {
+  const assistantId = useActiveAssistantId();
+  const queryClient = useQueryClient();
+
+  const configMutation = useConfigPatchMutation({
+    onSuccess: (data) => {
+      configGetSetQueryData(
+        queryClient,
+        { path: { assistant_id: assistantId } },
+        data,
+      );
+    },
+  });
+
+  const handleToggle = async (enabled: boolean) => {
+    try {
+      await configMutation.mutateAsync({
+        path: { assistant_id: assistantId },
+        body: { memory: { retrospective: { enabled } } },
+      });
+      toast.success(
+        enabled
+          ? "Memory retrospectives enabled."
+          : "Memory retrospectives paused.",
+      );
+    } catch (error) {
+      captureError(error, { context: "settings-memory-retrospective-toggle" });
+      toast.error("Failed to update memory retrospectives.");
+    }
+  };
+
+  return (
+    <div className="flex flex-row items-start justify-between gap-4 border-t border-[var(--border-subtle)] pt-4">
+      <div className="flex min-w-0 flex-col gap-2">
+        <h3 className="text-body-medium-default text-[var(--content-emphasised)]">
+          Retrospectives
+        </h3>
+        <p className="text-body-medium-default text-[var(--content-tertiary)]">
+          Let your assistant re-read recent conversations in the background and
+          save what it missed in the moment. Pausing this keeps the rest of
+          memory working.
+        </p>
+      </div>
+      <Toggle
+        checked={retrospectiveEnabled}
+        onChange={(enabled) => void handleToggle(enabled)}
+        aria-label="Enable memory retrospectives"
+        disabled={!memoryEnabled || configMutation.isPending}
+      />
+    </div>
+  );
+}

--- a/clients/web/src/domains/settings/components/system-tasks-section.tsx
+++ b/clients/web/src/domains/settings/components/system-tasks-section.tsx
@@ -211,8 +211,8 @@ export function SystemTasksSection({
               ? undefined
               : // The row only renders when `available` is true (memory is on),
                 // so a false `enabled` here means the retrospective's own
-                // switch — `memory.retrospective.enabled` — is off.
-                "Retrospectives are turned off in this assistant's memory settings."
+                // switch is off, not memory itself.
+                "Retrospectives are turned off in Memory settings."
           }
           // Always null — retrospectives are event-driven, not scheduled;
           // the row simply omits the "Next:" timestamp.


### PR DESCRIPTION
Follow-up to #40287. Implements the referential fork behind the `memory.retrospective.forkStrategy` config that PR reserved, and addresses both review comments on it.

## Prompt / plan

A retrospective forks its source conversation every few minutes, and a fork full-copies the conversation: every message row, every attachment link. On a 3k-message conversation that write burst holds the SQLite write lock long enough to stall other writers, and it spends disk the user does not have. This makes the fork referential instead, so it costs one conversation row.

**Read model.** A conversation's logical message set becomes a chain of segments: its own rows, then each referential ancestor's rows up to the `(createdAt, id)` of the message it was forked through. `conversation-lineage.ts` resolves that chain and compiles it into a single `messages` predicate, so a lineage read stays one indexed query rather than a fetch per generation. `getMessages`, `getMessagesAfter`, `getMessagesPaginated`, `countMessagesAfter`, `hasMessages`, and `selectSlackMetaCandidateMetadata` all read through it. (The proposal also listed `collectImageManifest` and `listMessages`; both reach messages through these helpers rather than querying `messages` themselves, so they inherit the change.)

Every stop condition in the walk shortens the lineage rather than lengthening it: a cloned ancestor, a vanished fork message, a deleted parent, a pointer cycle, and a depth cap all truncate. The missing-bound case is worth naming, since the bound is what scopes an ancestor's contribution, and continuing without it would splice in messages written *after* the fork was taken.

**Schema — one deviation from the proposal.** The proposal notes no schema change is needed because the fork pointers already exist. That holds for the read model but not for the migration: `fork_parent_conversation_id` and `fork_parent_message_id` are set on copied forks too, so the existing pointers cannot say whether a prefix lives on the fork or on its parent, and a lineage read over a legacy fork would return its copied rows twice. `conversations.fork_strategy` (migration 365) is the discriminator. NULL reads as cloning, which is what every fork predating this is, so there is no backfill and existing forks keep reading their own copies.

**Write path.** `forkConversationForRetrospective` accepts a strategy, defaulting to `memory.retrospective.forkStrategy`. The referential branch copies no rows and skips the subprocess copy entirely: the work that phase exists to keep off the event loop does not happen at all. It does carry the source's `contextCompactedMessageCount` onto the fork, where a copied fork carries 0, because a referential fork reads the compacted prefix through its parent and the render must hide the same rows the source hides.

**Deletion** takes option (1) from the proposal: block. Deleting a conversation that referential forks read from would silently truncate them, and cascading would delete conversations the caller never named. `listReferentialForkChildren` is exported so callers can surface what is blocking.

`forkStrategy` still defaults to `cloning`, so behavior is unchanged until an operator opts in.

### Review comments from #40287

- **P1, em dashes.** Removed from the config descriptions, comments, tests, and generated API copy that PR added. Correct call, and it was a documented repo-wide rule I broke.
- **P2, no way to re-enable.** Also correct: the notice told users to turn retrospectives back on while its action navigated to a page exposing only the global memory and worker toggles. Memory settings now carries a **Retrospectives** toggle writing `memory.retrospective.enabled` through the existing config PATCH, and the notice's action reads "Open Memory settings" when that switch (rather than memory itself) is what is off.

## Test plan

- New `assistant/src/persistence/__tests__/conversation-lineage.test.ts` (10 cases): the resolver over in-memory fixtures, with a case per stop condition asserting the lineage truncates rather than over-reads, plus the NULL-is-cloning default and the cycle/depth guards.
- New `assistant/src/__tests__/conversation-fork-referential.test.ts` (10 cases) against a real DB: a referential fork stores zero message rows, reads the source's history through the pointer, **presents the same message list a cloning fork of the same source presents**, excludes rows written on the source after the fork point, honors a cutoff, crosses the lineage boundary in `getMessagesAfter`/`countMessagesAfter` when the cursor sits on an ancestor, paginates, and blocks deletion of its source while a cloning fork does not.
- Regression: `conversation-fork-crud`, `conversation-fork-retrospective`, the retrospective job/enqueue/sweep/provider-path/wake-chain suites, `retrospective-routes`, the compaction suites (`compaction-events`, `compaction-ledger-store`, `compaction-summary-head-persisted-count`, `compaction-direct`, `agent-loop-compaction-events`), the conversation delete suites, and `conversation-attachments` all pass.
- One regression caught and fixed mid-change: I had added an `id` tiebreak to `getMessages`, which broke `forkConversation > preserves source order when source messages share a timestamp`. That ordering is load-bearing (the compaction render slices a row count off the front of exactly this order), so the tiebreak is reverted and the invariant is now documented at the query.
- `bun run typecheck` green in `assistant/` and `clients/web/`; prettier and eslint clean; `assistant/openapi.yaml` regenerated.

Test files were run individually, matching how `scripts/test.ts` runs them in CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCQm4gtVzomviYhiw5qyd8)_