### PR TITLE
fix(web): say when an app is already deployed to Vercel

### DIFF
--- a/clients/web/src/components/app-nav-bar.test.tsx
+++ b/clients/web/src/components/app-nav-bar.test.tsx
@@ -121,7 +121,7 @@ const TypographyMock = ({ children, ...rest }: Record<string, unknown>) =>
   createElement("span", rest, children as ReactNode);
 
 // `mock.module` replaces the module process-wide, so the stub also carries
-// the `toast` export other modules pull from this entry point — without it,
+// the `toast` export other modules pull from this entry point. Without it,
 // any test file loaded after this one fails to resolve it.
 mock.module("@vellumai/design-library", () => ({
   Menu: MenuMock,

--- a/clients/web/src/components/app-nav-bar.test.tsx
+++ b/clients/web/src/components/app-nav-bar.test.tsx
@@ -120,12 +120,16 @@ const ButtonMock = ({
 const TypographyMock = ({ children, ...rest }: Record<string, unknown>) =>
   createElement("span", rest, children as ReactNode);
 
+// `mock.module` replaces the module process-wide, so the stub also carries
+// the `toast` export other modules pull from this entry point — without it,
+// any test file loaded after this one fails to resolve it.
 mock.module("@vellumai/design-library", () => ({
   Menu: MenuMock,
   BottomSheet: BottomSheetMock,
   PanelItem: PanelItemMock,
   Button: ButtonMock,
   Typography: TypographyMock,
+  toast: { success: () => {}, error: () => {} },
 }));
 
 const { AppNavBar } = await import("@/components/app-nav-bar");
@@ -364,5 +368,111 @@ describe("AppNavBar share + deploy", () => {
     );
     expect(html).toContain("disabled");
     expect(html).toContain("lucide-loader");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Already-deployed state
+//
+// Once an app has an active Vercel deployment the affordance stops offering a
+// first-time deploy: it reports the deployment and hands the link back, with
+// redeploying moved to its own entry.
+// ---------------------------------------------------------------------------
+
+describe("AppNavBar deployed state", () => {
+  const DEPLOYED_URL = "https://my-app.vercel.app";
+
+  test("reports the deployment and offers Redeploy instead of Deploy (desktop)", () => {
+    mockIsMobile = false;
+    const html = renderToStaticMarkup(
+      <AppNavBar
+        appName="My App"
+        onClose={() => {}}
+        onShare={() => {}}
+        onDeploy={() => {}}
+        deployedUrl={DEPLOYED_URL}
+        onCopyDeployedLink={() => {}}
+      />,
+    );
+    expect(html).toContain(">Deployed to Vercel<");
+    expect(html).toContain(">Redeploy<");
+    expect(html).not.toContain(">Deploy to Vercel<");
+  });
+
+  test("shows the deployed URL in the mobile sheet", () => {
+    mockIsMobile = true;
+    const html = renderToStaticMarkup(
+      <AppNavBar
+        appName="My App"
+        onClose={() => {}}
+        onShare={() => {}}
+        onDeploy={() => {}}
+        deployedUrl={DEPLOYED_URL}
+        onCopyDeployedLink={() => {}}
+      />,
+    );
+    expect(html).toContain("Deployed to Vercel");
+    expect(html).toContain(DEPLOYED_URL);
+    expect(html).toContain("Redeploy");
+    expect(html).not.toContain("Publish as a static page");
+  });
+
+  test("falls back to the deploy entry when no link can be handed back", () => {
+    mockIsMobile = false;
+    const html = renderToStaticMarkup(
+      <AppNavBar
+        appName="My App"
+        onClose={() => {}}
+        onShare={() => {}}
+        onDeploy={() => {}}
+        deployedUrl={DEPLOYED_URL}
+      />,
+    );
+    expect(html).toContain(">Deploy to Vercel<");
+    expect(html).not.toContain(">Deployed to Vercel<");
+  });
+
+  test("the standalone deploy button copies the link once deployed", () => {
+    mockIsMobile = false;
+    const onCopyDeployedLink = mock(() => {});
+    const onDeploy = mock(() => {});
+    render(
+      <AppNavBar
+        appName="My App"
+        onClose={() => {}}
+        onDeploy={onDeploy}
+        deployedUrl={DEPLOYED_URL}
+        onCopyDeployedLink={onCopyDeployedLink}
+      />,
+    );
+
+    const copyButton = document.querySelector(
+      '[aria-label="Deployed to Vercel, copy link"]',
+    );
+    expect(copyButton).not.toBeNull();
+
+    fireEvent.click(copyButton as HTMLButtonElement);
+    expect(onCopyDeployedLink).toHaveBeenCalledTimes(1);
+    expect(onDeploy).not.toHaveBeenCalled();
+  });
+
+  test("the standalone deploy button still deploys when nothing is published", () => {
+    mockIsMobile = false;
+    const onDeploy = mock(() => {});
+    render(
+      <AppNavBar
+        appName="My App"
+        onClose={() => {}}
+        onDeploy={onDeploy}
+        deployedUrl={null}
+        onCopyDeployedLink={() => {}}
+      />,
+    );
+
+    const deployButton = document.querySelector('[aria-label="Deploy"]');
+    expect(deployButton).not.toBeNull();
+
+    fireEvent.click(deployButton as HTMLButtonElement);
+    expect(onDeploy).toHaveBeenCalledTimes(1);
   });
 });

--- a/clients/web/src/components/app-nav-bar.tsx
+++ b/clients/web/src/components/app-nav-bar.tsx
@@ -2,9 +2,11 @@ import {
   ChevronUp,
   Expand,
   Globe,
+  Link2,
   Loader2,
   Maximize2,
   Pencil,
+  RefreshCw,
   Share,
   X,
 } from "lucide-react";
@@ -34,6 +36,15 @@ export interface AppNavBarProps {
   isSharing?: boolean;
   onDeploy?: () => void;
   isDeploying?: boolean;
+  /**
+   * Live URL of the app's active Vercel deployment, when it has one. Turns
+   * the deploy affordance into "Deployed to Vercel" (which hands back the
+   * link) plus an explicit Redeploy, instead of offering a first-time deploy
+   * for an app that is already published.
+   */
+  deployedUrl?: string | null;
+  /** Invoked by the deployed-state item; copies the link and shows it. */
+  onCopyDeployedLink?: () => void;
   /** When provided, renders a fullscreen toggle button in the right group. */
   onToggleFullscreen?: () => void;
   onClose: () => void;
@@ -47,6 +58,8 @@ export function AppNavBar({
   isSharing,
   onDeploy,
   isDeploying,
+  deployedUrl,
+  onCopyDeployedLink,
   onToggleFullscreen,
   onClose,
 }: AppNavBarProps) {
@@ -61,6 +74,11 @@ export function AppNavBar({
   // two actions live behind one affordance — matching the library card's
   // `...` menu shape.
   const showShareDeployMenu = onShare != null && onDeploy != null;
+
+  // An app is only treated as deployed when the caller can also hand the link
+  // back — otherwise the affordance would report a deployment it can't reach.
+  const isDeployed =
+    deployedUrl != null && deployedUrl !== "" && onCopyDeployedLink != null;
 
   return (
     <div className="flex items-center justify-between rounded-t-xl bg-[var(--surface-lift)] px-4 py-3">
@@ -98,22 +116,37 @@ export function AppNavBar({
             isSharing={isSharing}
             onDeploy={onDeploy}
             isDeploying={isDeploying}
+            deployedUrl={deployedUrl}
+            onCopyDeployedLink={onCopyDeployedLink}
             isMobile={isMobile}
           />
         ) : (
           <>
-            {onDeploy != null && (
-              <Button
-                variant="outlined"
-                iconOnly={
-                  isDeploying ? <Loader2 className="animate-spin" /> : <Globe />
-                }
-                onClick={onDeploy}
-                disabled={isDeploying}
-                tooltip={isDeploying ? "Deploying…" : "Deploy"}
-                aria-label={isDeploying ? "Deploying…" : "Deploy"}
-              />
-            )}
+            {onDeploy != null &&
+              (isDeployed ? (
+                <Button
+                  variant="outlined"
+                  iconOnly={<Link2 />}
+                  onClick={onCopyDeployedLink}
+                  tooltip="Deployed — copy link"
+                  aria-label="Deployed to Vercel, copy link"
+                />
+              ) : (
+                <Button
+                  variant="outlined"
+                  iconOnly={
+                    isDeploying ? (
+                      <Loader2 className="animate-spin" />
+                    ) : (
+                      <Globe />
+                    )
+                  }
+                  onClick={onDeploy}
+                  disabled={isDeploying}
+                  tooltip={isDeploying ? "Deploying…" : "Deploy"}
+                  aria-label={isDeploying ? "Deploying…" : "Deploy"}
+                />
+              ))}
             {onShare != null && (
               <Button
                 variant="outlined"
@@ -174,6 +207,8 @@ interface ShareDeployMenuTriggerProps {
   isSharing?: boolean;
   onDeploy: () => void;
   isDeploying?: boolean;
+  deployedUrl?: string | null;
+  onCopyDeployedLink?: () => void;
   isMobile: boolean;
 }
 
@@ -182,9 +217,13 @@ function ShareDeployMenuTrigger({
   isSharing,
   onDeploy,
   isDeploying,
+  deployedUrl,
+  onCopyDeployedLink,
   isMobile,
 }: ShareDeployMenuTriggerProps) {
   const [open, setOpen] = useState(false);
+  const isDeployed =
+    deployedUrl != null && deployedUrl !== "" && onCopyDeployedLink != null;
   const isBusy = isSharing || isDeploying;
   const triggerIcon = isBusy ? <Loader2 className="animate-spin" /> : <Share />;
   const triggerTooltip = isSharing
@@ -225,21 +264,56 @@ function ShareDeployMenuTrigger({
                 onShare();
               }}
             />
-            <PanelItem
-              icon={Globe}
-              label={
-                <span className="flex flex-col gap-0.5 overflow-visible whitespace-normal">
-                  <span>Deploy to Vercel</span>
-                  <span className="text-body-small-default text-[var(--content-tertiary)]">
-                    Publish as a static page
+            {isDeployed ? (
+              <>
+                <PanelItem
+                  icon={Link2}
+                  label={
+                    <span className="flex flex-col gap-0.5 overflow-visible whitespace-normal">
+                      <span>Deployed to Vercel</span>
+                      <span className="break-all text-body-small-default text-[var(--content-tertiary)]">
+                        {deployedUrl}
+                      </span>
+                    </span>
+                  }
+                  onSelect={() => {
+                    setOpen(false);
+                    onCopyDeployedLink?.();
+                  }}
+                />
+                <PanelItem
+                  icon={RefreshCw}
+                  label={
+                    <span className="flex flex-col gap-0.5 overflow-visible whitespace-normal">
+                      <span>Redeploy</span>
+                      <span className="text-body-small-default text-[var(--content-tertiary)]">
+                        Publish the current version
+                      </span>
+                    </span>
+                  }
+                  onSelect={() => {
+                    setOpen(false);
+                    onDeploy();
+                  }}
+                />
+              </>
+            ) : (
+              <PanelItem
+                icon={Globe}
+                label={
+                  <span className="flex flex-col gap-0.5 overflow-visible whitespace-normal">
+                    <span>Deploy to Vercel</span>
+                    <span className="text-body-small-default text-[var(--content-tertiary)]">
+                      Publish as a static page
+                    </span>
                   </span>
-                </span>
-              }
-              onSelect={() => {
-                setOpen(false);
-                onDeploy();
-              }}
-            />
+                }
+                onSelect={() => {
+                  setOpen(false);
+                  onDeploy();
+                }}
+              />
+            )}
           </BottomSheet.Body>
         </BottomSheet.Content>
       </BottomSheet.Root>
@@ -265,13 +339,33 @@ function ShareDeployMenuTrigger({
         >
           Share
         </Menu.Item>
-        <Menu.Item
-          leftIcon={<Globe size={14} />}
-          onSelect={() => onDeploy()}
-          className="whitespace-nowrap"
-        >
-          Deploy to Vercel
-        </Menu.Item>
+        {isDeployed ? (
+          <>
+            <Menu.Item
+              leftIcon={<Link2 size={14} />}
+              shortcut="Copy link"
+              onSelect={() => onCopyDeployedLink?.()}
+              className="whitespace-nowrap"
+            >
+              Deployed to Vercel
+            </Menu.Item>
+            <Menu.Item
+              leftIcon={<RefreshCw size={14} />}
+              onSelect={() => onDeploy()}
+              className="whitespace-nowrap"
+            >
+              Redeploy
+            </Menu.Item>
+          </>
+        ) : (
+          <Menu.Item
+            leftIcon={<Globe size={14} />}
+            onSelect={() => onDeploy()}
+            className="whitespace-nowrap"
+          >
+            Deploy to Vercel
+          </Menu.Item>
+        )}
       </Menu.Content>
     </Menu.Root>
   );

--- a/clients/web/src/components/app-nav-bar.tsx
+++ b/clients/web/src/components/app-nav-bar.tsx
@@ -76,7 +76,7 @@ export function AppNavBar({
   const showShareDeployMenu = onShare != null && onDeploy != null;
 
   // An app is only treated as deployed when the caller can also hand the link
-  // back — otherwise the affordance would report a deployment it can't reach.
+  // back. Otherwise the affordance would report a deployment it can't reach.
   const isDeployed =
     deployedUrl != null && deployedUrl !== "" && onCopyDeployedLink != null;
 
@@ -128,7 +128,7 @@ export function AppNavBar({
                   variant="outlined"
                   iconOnly={<Link2 />}
                   onClick={onCopyDeployedLink}
-                  tooltip="Deployed — copy link"
+                  tooltip="Deployed: copy link"
                   aria-label="Deployed to Vercel, copy link"
                 />
               ) : (

--- a/clients/web/src/components/app-viewer-container.test.tsx
+++ b/clients/web/src/components/app-viewer-container.test.tsx
@@ -15,6 +15,7 @@
 
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, cleanup, fireEvent, render } from "@testing-library/react";
 
 let capturedOptions:
@@ -58,15 +59,23 @@ afterEach(() => {
 });
 
 function renderViewer(props?: { enableFullscreen?: boolean; appId?: string }) {
+  // The viewer reads the app's Vercel deployment status through TanStack
+  // Query, so it needs a client in scope even when the read is disabled (no
+  // deploy handler is passed here).
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
   return render(
-    <AppViewerContainer
-      appId={props?.appId ?? "app-1"}
-      appName="My App"
-      html="<html><body>hi</body></html>"
-      assistantId="assistant-1"
-      onClose={() => {}}
-      enableFullscreen={props?.enableFullscreen}
-    />,
+    <QueryClientProvider client={queryClient}>
+      <AppViewerContainer
+        appId={props?.appId ?? "app-1"}
+        appName="My App"
+        html="<html><body>hi</body></html>"
+        assistantId="assistant-1"
+        onClose={() => {}}
+        enableFullscreen={props?.enableFullscreen}
+      />
+    </QueryClientProvider>,
   );
 }
 
@@ -150,14 +159,18 @@ describe("AppViewerContainer app actions", () => {
   test("forwards onAction to the sandbox fetch proxy", () => {
     const onAction = () => {};
     render(
-      <AppViewerContainer
-        appId="app-1"
-        appName="My App"
-        html="<html><body>hi</body></html>"
-        assistantId="assistant-1"
-        onClose={() => {}}
-        onAction={onAction}
-      />,
+      <QueryClientProvider
+        client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+      >
+        <AppViewerContainer
+          appId="app-1"
+          appName="My App"
+          html="<html><body>hi</body></html>"
+          assistantId="assistant-1"
+          onClose={() => {}}
+          onAction={onAction}
+        />
+      </QueryClientProvider>,
     );
 
     expect(capturedOptions?.onAction).toBe(onAction);

--- a/clients/web/src/components/app-viewer-container.tsx
+++ b/clients/web/src/components/app-viewer-container.tsx
@@ -3,6 +3,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Minimize2 } from "lucide-react";
 
 import { AppNavBar } from "@/components/app-nav-bar";
+import {
+  copyDeployedAppLink,
+  useAppDeployment,
+} from "@/hooks/use-app-deployment";
 import { useSandboxFetchProxy } from "@/hooks/use-sandbox-fetch-proxy";
 import { useAppIframeSandboxDisabled } from "@/lib/app-sandbox-debug-flag";
 import { cn } from "@/utils/misc";
@@ -110,6 +114,17 @@ export function AppViewerContainer({
     onAction,
   });
 
+  // Only asked for when the viewer actually offers a deploy — read-only
+  // (plugin-bundled) apps get no deploy handler and so need no status read.
+  const { deployedUrl } = useAppDeployment(assistantId, appId, {
+    enabled: onDeploy != null,
+  });
+  const handleCopyDeployedLink = useCallback(() => {
+    if (deployedUrl != null) {
+      copyDeployedAppLink(deployedUrl);
+    }
+  }, [deployedUrl]);
+
   return (
     <div
       data-testid="app-viewer-root"
@@ -127,6 +142,8 @@ export function AppViewerContainer({
           isSharing={isSharing}
           onDeploy={onDeploy}
           isDeploying={isDeploying}
+          deployedUrl={deployedUrl}
+          onCopyDeployedLink={handleCopyDeployedLink}
           onToggleFullscreen={enableFullscreen ? toggleFullscreen : undefined}
           onClose={onClose}
         />

--- a/clients/web/src/components/app-viewer-container.tsx
+++ b/clients/web/src/components/app-viewer-container.tsx
@@ -114,7 +114,7 @@ export function AppViewerContainer({
     onAction,
   });
 
-  // Only asked for when the viewer actually offers a deploy — read-only
+  // Only asked for when the viewer actually offers a deploy: read-only
   // (plugin-bundled) apps get no deploy handler and so need no status read.
   const { deployedUrl } = useAppDeployment(assistantId, appId, {
     enabled: onDeploy != null,

--- a/clients/web/src/domains/library/components/library-app-card.tsx
+++ b/clients/web/src/domains/library/components/library-app-card.tsx
@@ -90,7 +90,7 @@ export function LibraryAppCard({
   // The library renders one card per app, so the deployment status is fetched
   // lazily rather than N-at-a-time on mount: the first hover (or menu open)
   // arms it, and it stays armed so the answer is already in hand when the
-  // menu is reopened — including right after a deploy.
+  // menu is reopened, including right after a deploy.
   const [deployStatusArmed, setDeployStatusArmed] = useState(false);
   const armDeployStatus = useCallback(() => setDeployStatusArmed(true), []);
   const { deployedUrl } = useAppDeployment(assistantId, app.id, {
@@ -238,8 +238,8 @@ export function LibraryAppCardActionsMenu({
   onCopyDeployedLink,
   isMobile,
 }: LibraryAppCardActionsMenuProps) {
-  // Only treated as deployed when the caller can also hand the link back —
-  // otherwise the entry would report a deployment it can't reach.
+  // Only treated as deployed when the caller can also hand the link back.
+  // Otherwise the entry would report a deployment it can't reach.
   const isDeployed =
     deployedUrl != null && deployedUrl !== "" && onCopyDeployedLink != null;
   if (isMobile) {

--- a/clients/web/src/domains/library/components/library-app-card.tsx
+++ b/clients/web/src/domains/library/components/library-app-card.tsx
@@ -1,8 +1,21 @@
-import { ArrowUp, Ellipsis, Globe, Pin, PinOff, Trash2 } from "lucide-react";
+import {
+  ArrowUp,
+  Ellipsis,
+  Globe,
+  Link2,
+  Pin,
+  PinOff,
+  RefreshCw,
+  Trash2,
+} from "lucide-react";
 import { type MouseEvent, useCallback, useState } from "react";
 
 import { AppPreviewThumbnail } from "@/components/app-card";
 import { SwipeActionReveal } from "@/components/swipe-action-reveal";
+import {
+  copyDeployedAppLink,
+  useAppDeployment,
+} from "@/hooks/use-app-deployment";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { type AppSummary, isReadOnlyApp } from "@/types/app-types";
 import { getCachedAppHtml } from "@/utils/app-html-cache";
@@ -74,6 +87,21 @@ export function LibraryAppCard({
   const [menuOpen, setMenuOpen] = useState(false);
   const isMobile = useIsMobile();
 
+  // The library renders one card per app, so the deployment status is fetched
+  // lazily rather than N-at-a-time on mount: the first hover (or menu open)
+  // arms it, and it stays armed so the answer is already in hand when the
+  // menu is reopened — including right after a deploy.
+  const [deployStatusArmed, setDeployStatusArmed] = useState(false);
+  const armDeployStatus = useCallback(() => setDeployStatusArmed(true), []);
+  const { deployedUrl } = useAppDeployment(assistantId, app.id, {
+    enabled: deployStatusArmed && deployAction != null,
+  });
+  const handleCopyDeployedLink = useCallback(() => {
+    if (deployedUrl != null) {
+      copyDeployedAppLink(deployedUrl);
+    }
+  }, [deployedUrl]);
+
   // Leading swipe actions are intentionally omitted. On mobile chat-side
   // routes, ChatLayout enables a document-level drawer edge swipe
   // (useEdgeSwipe) that captures rightward swipes starting in the left 50vw.
@@ -111,6 +139,7 @@ export function LibraryAppCard({
           justImported && "animate-[card-entrance_400ms_ease-out]",
         )}
         onAnimationEnd={justImported ? onAnimationEnd : undefined}
+        onPointerEnter={armDeployStatus}
       >
         <button
           type="button"
@@ -139,11 +168,18 @@ export function LibraryAppCard({
             appName={app.name}
             isPinned={isPinned}
             open={menuOpen}
-            onOpenChange={setMenuOpen}
+            onOpenChange={(next) => {
+              if (next) {
+                armDeployStatus();
+              }
+              setMenuOpen(next);
+            }}
             onPin={() => onPin(app)}
             onDelete={deleteAction ? () => deleteAction(app) : undefined}
             onShare={readOnly ? undefined : handleShare}
             onDeploy={deployAction}
+            deployedUrl={deployedUrl}
+            onCopyDeployedLink={handleCopyDeployedLink}
             isMobile={isMobile}
           />
         </div>
@@ -178,6 +214,14 @@ export interface LibraryAppCardActionsMenuProps {
   onDelete?: () => void;
   onShare?: () => void;
   onDeploy?: () => void;
+  /**
+   * Live URL of the app's active Vercel deployment, when it has one. Swaps
+   * the deploy entry for a "Deployed to Vercel" entry that hands back the
+   * link, plus an explicit Redeploy.
+   */
+  deployedUrl?: string | null;
+  /** Invoked by the deployed-state entry; copies the link and shows it. */
+  onCopyDeployedLink?: () => void;
   isMobile: boolean;
 }
 
@@ -190,8 +234,14 @@ export function LibraryAppCardActionsMenu({
   onDelete,
   onShare,
   onDeploy,
+  deployedUrl,
+  onCopyDeployedLink,
   isMobile,
 }: LibraryAppCardActionsMenuProps) {
+  // Only treated as deployed when the caller can also hand the link back —
+  // otherwise the entry would report a deployment it can't reach.
+  const isDeployed =
+    deployedUrl != null && deployedUrl !== "" && onCopyDeployedLink != null;
   if (isMobile) {
     return (
       <BottomSheet.Root open={open} onOpenChange={onOpenChange}>
@@ -234,7 +284,40 @@ export function LibraryAppCardActionsMenu({
                 }}
               />
             ) : null}
-            {onDeploy ? (
+            {onDeploy && isDeployed ? (
+              <>
+                <PanelItem
+                  icon={Link2}
+                  label={
+                    <span className="flex flex-col gap-0.5 overflow-visible whitespace-normal">
+                      <span>Deployed to Vercel</span>
+                      <span className="break-all text-body-small-default text-[var(--content-tertiary)]">
+                        {deployedUrl}
+                      </span>
+                    </span>
+                  }
+                  onSelect={() => {
+                    onOpenChange(false);
+                    onCopyDeployedLink?.();
+                  }}
+                />
+                <PanelItem
+                  icon={RefreshCw}
+                  label={
+                    <span className="flex flex-col gap-0.5 overflow-visible whitespace-normal">
+                      <span>Redeploy</span>
+                      <span className="text-body-small-default text-[var(--content-tertiary)]">
+                        Publish the current version
+                      </span>
+                    </span>
+                  }
+                  onSelect={() => {
+                    onOpenChange(false);
+                    onDeploy();
+                  }}
+                />
+              </>
+            ) : onDeploy ? (
               <PanelItem
                 icon={Globe}
                 label={
@@ -294,7 +377,25 @@ export function LibraryAppCardActionsMenu({
             Share
           </Menu.Item>
         ) : null}
-        {onDeploy ? (
+        {onDeploy && isDeployed ? (
+          <>
+            <Menu.Item
+              leftIcon={<Link2 size={14} />}
+              shortcut="Copy link"
+              onSelect={() => onCopyDeployedLink?.()}
+              className="whitespace-nowrap"
+            >
+              Deployed to Vercel
+            </Menu.Item>
+            <Menu.Item
+              leftIcon={<RefreshCw size={14} />}
+              onSelect={() => onDeploy()}
+              className="whitespace-nowrap"
+            >
+              Redeploy
+            </Menu.Item>
+          </>
+        ) : onDeploy ? (
           <Menu.Item
             leftIcon={<Globe size={14} />}
             onSelect={() => onDeploy()}

--- a/clients/web/src/hooks/use-app-deployment.test.ts
+++ b/clients/web/src/hooks/use-app-deployment.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for `useAppDeployment` / `copyDeployedAppLink`.
+ *
+ * Covers:
+ *   1. Reporting an app's active deployment (and the absent case), so the
+ *      deploy surfaces can say "already deployed" instead of offering a
+ *      first-time deploy.
+ *   2. Refreshing that answer when a deploy settles — the regression this
+ *      hook exists for: right after publishing, the menu must stop saying
+ *      "Deploy to Vercel".
+ *   3. `enabled: false` issuing no request, which is what keeps the library
+ *      grid from firing one status read per card on mount.
+ *   4. The copy helper putting the URL on the clipboard *and* showing it.
+ *
+ * The generated query factory is mocked with a controllable response
+ * (mirroring `use-stt-language-selection.test.ts`); the QueryClientProvider
+ * and the deploy store are real.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { createElement, type ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+
+const ASSISTANT_ID = "asst-test";
+const APP_ID = "app-1";
+const PUBLISH_STATUS_KEY = ["publish-status", APP_ID];
+
+interface PublishStatus {
+  published: boolean;
+  publicUrl?: string;
+}
+
+let status: PublishStatus = { published: false };
+let fetchCount = 0;
+
+mock.module("@/generated/daemon/@tanstack/react-query.gen", () => ({
+  appsByIdPublishstatusGetOptions: () => ({
+    queryKey: PUBLISH_STATUS_KEY,
+    queryFn: () => {
+      fetchCount += 1;
+      return Promise.resolve(status);
+    },
+  }),
+  appsByIdPublishstatusGetQueryKey: () => PUBLISH_STATUS_KEY,
+}));
+
+const copiedText: string[] = [];
+mock.module("@/lib/copy-to-clipboard", () => ({
+  copyToClipboard: (
+    text: string,
+    options: { onCopied?: () => void; errorMessage: string },
+  ) => {
+    copiedText.push(text);
+    options.onCopied?.();
+  },
+}));
+
+const successToasts: { title: string; description?: string }[] = [];
+mock.module("@vellumai/design-library/components/toast", () => ({
+  toast: {
+    success: (title: string, options?: { description?: string }) => {
+      successToasts.push({ title, description: options?.description });
+    },
+    error: () => {},
+  },
+}));
+
+const { copyDeployedAppLink, useAppDeployment } = await import(
+  "@/hooks/use-app-deployment"
+);
+const { useDeployStore } = await import("@/stores/deploy-store");
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+beforeEach(() => {
+  status = { published: false };
+  fetchCount = 0;
+  copiedText.length = 0;
+  successToasts.length = 0;
+  useDeployStore.setState({ isDeploying: false });
+});
+
+describe("useAppDeployment", () => {
+  test("reports the live URL of an active deployment", async () => {
+    status = { published: true, publicUrl: "https://my-app.vercel.app" };
+    const { result } = renderHook(
+      () => useAppDeployment(ASSISTANT_ID, APP_ID),
+      { wrapper },
+    );
+
+    await waitFor(() =>
+      expect(result.current.deployedUrl).toBe("https://my-app.vercel.app"),
+    );
+  });
+
+  test("reports no deployment when the app was never published", async () => {
+    const { result } = renderHook(
+      () => useAppDeployment(ASSISTANT_ID, APP_ID),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.deployedUrl).toBeNull();
+  });
+
+  test("picks up the deployment as soon as a deploy settles", async () => {
+    const { result } = renderHook(
+      () => useAppDeployment(ASSISTANT_ID, APP_ID),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.deployedUrl).toBeNull();
+
+    // A deploy runs to completion through the store; the daemon now has a
+    // published record for this app.
+    status = { published: true, publicUrl: "https://my-app.vercel.app" };
+    act(() => {
+      useDeployStore.setState({ isDeploying: true });
+    });
+    act(() => {
+      useDeployStore.setState({ isDeploying: false });
+    });
+
+    await waitFor(() =>
+      expect(result.current.deployedUrl).toBe("https://my-app.vercel.app"),
+    );
+  });
+
+  test("issues no request while disabled", async () => {
+    const { result } = renderHook(
+      () => useAppDeployment(ASSISTANT_ID, APP_ID, { enabled: false }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(fetchCount).toBe(0);
+    expect(result.current.deployedUrl).toBeNull();
+  });
+
+  test("issues no request without an app", async () => {
+    renderHook(() => useAppDeployment(ASSISTANT_ID, null), { wrapper });
+    await waitFor(() => expect(fetchCount).toBe(0));
+  });
+});
+
+describe("copyDeployedAppLink", () => {
+  test("copies the URL and shows it back to the user", () => {
+    copyDeployedAppLink("https://my-app.vercel.app");
+
+    expect(copiedText).toEqual(["https://my-app.vercel.app"]);
+    expect(successToasts).toHaveLength(1);
+    expect(successToasts[0]?.description).toBe("https://my-app.vercel.app");
+  });
+});

--- a/clients/web/src/hooks/use-app-deployment.test.ts
+++ b/clients/web/src/hooks/use-app-deployment.test.ts
@@ -5,7 +5,7 @@
  *   1. Reporting an app's active deployment (and the absent case), so the
  *      deploy surfaces can say "already deployed" instead of offering a
  *      first-time deploy.
- *   2. Refreshing that answer when a deploy settles — the regression this
+ *   2. Refreshing that answer when a deploy settles, the regression this
  *      hook exists for: right after publishing, the menu must stop saying
  *      "Deploy to Vercel".
  *   3. `enabled: false` issuing no request, which is what keeps the library
@@ -56,6 +56,9 @@ mock.module("@/lib/copy-to-clipboard", () => ({
 }));
 
 const successToasts: { title: string; description?: string }[] = [];
+// The stub stands in for the whole toast module, so it carries every export
+// the design-library index re-exports from it. A partial stub breaks any
+// module that pulls `Toaster` / `ToastContent` through that index.
 mock.module("@vellumai/design-library/components/toast", () => ({
   toast: {
     success: (title: string, options?: { description?: string }) => {
@@ -63,6 +66,8 @@ mock.module("@vellumai/design-library/components/toast", () => ({
     },
     error: () => {},
   },
+  Toaster: () => null,
+  ToastContent: () => null,
 }));
 
 const { copyDeployedAppLink, useAppDeployment } = await import(

--- a/clients/web/src/hooks/use-app-deployment.ts
+++ b/clients/web/src/hooks/use-app-deployment.ts
@@ -1,0 +1,100 @@
+/**
+ * Read side of an app's Vercel deployment: whether it is already published
+ * and, if so, where it lives.
+ *
+ * The deploy *write* path lives in {@link useDeployStore} (it owns the
+ * in-flight dialogs and the publish request). The published URL is server
+ * state, so it is read straight from its query cache rather than mirrored
+ * into the store — see `docs/STATE_MANAGEMENT.md`.
+ *
+ * Surfaces that offer a deploy affordance (the app viewer's nav bar, the
+ * library card's actions menu) call this so they can say "Deployed to
+ * Vercel" and hand back the link instead of offering a first-time deploy
+ * for an app that already has one.
+ */
+
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
+
+import {
+  appsByIdPublishstatusGetOptions,
+  appsByIdPublishstatusGetQueryKey,
+} from "@/generated/daemon/@tanstack/react-query.gen";
+import { copyToClipboard } from "@/lib/copy-to-clipboard";
+import { useDeployStore } from "@/stores/deploy-store";
+import { toast } from "@vellumai/design-library/components/toast";
+
+export interface AppDeployment {
+  /** Live URL of the active deployment, or `null` when nothing is published. */
+  deployedUrl: string | null;
+  /** True while the first status read for this app is still in flight. */
+  isLoading: boolean;
+}
+
+/**
+ * Report the active Vercel deployment for `appId`.
+ *
+ * `enabled` exists because the library renders one card per app: fetching a
+ * status for every card on mount would be an N+1 against the daemon, so the
+ * card only asks once its actions menu is reachable (hover / open).
+ */
+export function useAppDeployment(
+  assistantId: string,
+  appId: string | null,
+  { enabled = true }: { enabled?: boolean } = {},
+): AppDeployment {
+  const queryClient = useQueryClient();
+  const active = enabled && assistantId !== "" && appId != null;
+  const path = { assistant_id: assistantId, id: appId ?? "" };
+
+  const query = useQuery({
+    ...appsByIdPublishstatusGetOptions({ path }),
+    enabled: active,
+  });
+
+  // A publish rewrites the record this query reads, so refresh once the
+  // deploy settles. `isDeploying` is a single global flag (the store admits
+  // one deploy at a time), which is why the transition — not the value — is
+  // the signal: every mounted status query refetches when any deploy ends.
+  const isDeploying = useDeployStore.use.isDeploying();
+  const wasDeploying = useRef(isDeploying);
+  useEffect(() => {
+    const settled = wasDeploying.current && !isDeploying;
+    wasDeploying.current = isDeploying;
+    if (settled && active) {
+      void queryClient.invalidateQueries({
+        queryKey: appsByIdPublishstatusGetQueryKey({
+          path: { assistant_id: assistantId, id: appId ?? "" },
+        }),
+      });
+    }
+  }, [isDeploying, active, assistantId, appId, queryClient]);
+
+  return {
+    deployedUrl: query.data?.published ? (query.data.publicUrl ?? null) : null,
+    isLoading: active && query.isPending,
+  };
+}
+
+/**
+ * Put a deployed app's URL on the clipboard and show it to the user.
+ *
+ * The toast carries the URL itself (the link is the point — the user asked
+ * for it) plus an Open action. The failure toast repeats the URL for the
+ * same reason: a clipboard the browser refused shouldn't cost the user the
+ * link they clicked for.
+ */
+export function copyDeployedAppLink(url: string): void {
+  copyToClipboard(url, {
+    errorMessage: `Couldn't copy the link — ${url}`,
+    onCopied: () => {
+      toast.success("Link copied", {
+        description: url,
+        action: {
+          label: "Open",
+          onClick: () => window.open(url, "_blank"),
+        },
+      });
+    },
+  });
+}

--- a/clients/web/src/hooks/use-app-deployment.ts
+++ b/clients/web/src/hooks/use-app-deployment.ts
@@ -5,7 +5,7 @@
  * The deploy *write* path lives in {@link useDeployStore} (it owns the
  * in-flight dialogs and the publish request). The published URL is server
  * state, so it is read straight from its query cache rather than mirrored
- * into the store — see `docs/STATE_MANAGEMENT.md`.
+ * into the store. See `docs/STATE_MANAGEMENT.md`.
  *
  * Surfaces that offer a deploy affordance (the app viewer's nav bar, the
  * library card's actions menu) call this so they can say "Deployed to
@@ -54,7 +54,7 @@ export function useAppDeployment(
 
   // A publish rewrites the record this query reads, so refresh once the
   // deploy settles. `isDeploying` is a single global flag (the store admits
-  // one deploy at a time), which is why the transition — not the value — is
+  // one deploy at a time), which is why the transition (not the value) is
   // the signal: every mounted status query refetches when any deploy ends.
   const isDeploying = useDeployStore.use.isDeploying();
   const wasDeploying = useRef(isDeploying);
@@ -79,14 +79,14 @@ export function useAppDeployment(
 /**
  * Put a deployed app's URL on the clipboard and show it to the user.
  *
- * The toast carries the URL itself (the link is the point — the user asked
- * for it) plus an Open action. The failure toast repeats the URL for the
+ * The toast carries the URL itself (the link is the point, and what the user
+ * asked for) plus an Open action. The failure toast repeats the URL for the
  * same reason: a clipboard the browser refused shouldn't cost the user the
  * link they clicked for.
  */
 export function copyDeployedAppLink(url: string): void {
   copyToClipboard(url, {
-    errorMessage: `Couldn't copy the link — ${url}`,
+    errorMessage: `Couldn't copy the link. Open it at ${url}`,
     onCopied: () => {
       toast.success("Link copied", {
         description: url,


### PR DESCRIPTION
## Prompt / plan

Reported: "After deploying apps to Vercel, it should say already deployed, and if you click it it shows you the link and puts it in your clipboard. Instead, it still shows Deploy to Vercel like I haven't."

The deploy affordance was stateless. Whether or not an app had a live Vercel deployment, both the app viewer's nav bar menu and the library card's `...` menu offered "Deploy to Vercel". The daemon has known the answer all along (`GET /v1/apps/:id/publish-status` returns the active `publishedPages` record), but nothing on the client read it outside `publishApp`'s URL-enrichment fallback.

Approach:

- **New `useAppDeployment` hook** (`clients/web/src/hooks/use-app-deployment.ts`) reads the publish status for an app. Deployment state is server state, so it is read from its TanStack Query cache rather than mirrored into `useDeployStore` (per `docs/STATE_MANAGEMENT.md`); the store's `isDeploying` flag only drives the refresh, so the label flips as soon as a deploy settles instead of showing a stale "not deployed".
- **`copyDeployedAppLink`** copies the URL through `lib/copy-to-clipboard` and toasts it back with the URL as the description plus an Open action. The failure toast repeats the URL for the same reason: a clipboard the browser refused shouldn't cost the user the link they clicked for.
- **Both deploy surfaces** (`AppNavBar` via `AppViewerContainer`, which owns the read for the chat viewer, the mobile overlay, and the library detail page; and `LibraryAppCardActionsMenu`) swap "Deploy to Vercel" for "Deployed to Vercel". Selecting it copies the link, and mobile also shows the URL inline. A separate **Redeploy** entry keeps publishing the current version one click away.
- The library fetches lazily. The first hover or menu open arms the query, and it stays armed so the answer is in hand when the menu is reopened right after a deploy. Without that, one status request would fire per card on mount.

No wire or daemon changes: this uses the existing `apps_publish_status` route the client already depends on.

Design-library note: the deployed entry uses the existing `Menu.Item` `shortcut` slot for the "Copy link" hint and `PanelItem`'s two-line label on mobile. No new custom components.

## Test plan

- `bun test src/hooks/use-app-deployment.test.ts src/components/app-nav-bar.test.tsx src/components/app-viewer-container.test.tsx`, each also run in isolation: 35 pass, 0 fail. New coverage: reporting an active deployment, the never-published case, **refetching when a deploy settles** (verified this test fails when the invalidation is removed), `enabled: false` issuing no request, and the copy helper copying *and* surfacing the URL; plus nav-bar rendering for deployed vs. not-deployed on desktop and mobile.
- `bunx tsc --noEmit` clean; `bun run lint` reports nothing new on the changed files.

Two test-side fixes went in as a second commit after the first CI run:

1. `AppViewerContainer` now calls a query hook, so `app-viewer-container.test.tsx` renders under a `QueryClientProvider` at both render sites. Mocking the hook would have been the cheaper fix, but the provider keeps the real code path covered.
2. `app-nav-bar.test.tsx` replaces `@vellumai/design-library` process-wide and the deployment-hook test replaces its toast module, so both stubs now carry every export the design-library index re-exports (`toast`, `Toaster`, `ToastContent`). Partial stubs broke isolated runs of unrelated files.

The `Build` job failure on the first run was a GitHub Actions infrastructure error ("Failed to resolve action download info"), unrelated to the diff.