### PR TITLE
fix(live-voice): let a voice session run an account connection

### DIFF
--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -425,7 +425,7 @@ const VOICE_APPROVAL_TIMEOUT_MS = 45_000;
  *
  * Scoped to the phone because the screen is what decides it. A phone call has
  * no screen, so the `open_url` signal a CLI tool can reach lands somewhere the
- * caller will never see — and that signal bus carries no capability or
+ * caller will never see, and that signal bus carries no capability or
  * conversation context, so this rule is the only thing standing in front of it
  * here. A live-voice call is the opposite case: the user is holding the screen,
  * and the room minimizes itself to hand it back (see

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -432,7 +432,7 @@ const VOICE_APPROVAL_TIMEOUT_MS = 45_000;
  * LIVE_VOICE_SETUP_FLOW_TEACHING).
  */
 const PHONE_NO_SETUP_FLOWS_RULE =
-  "Never start account connections, OAuth or sign-in flows, or any other action that opens a browser window or needs the user's screen during this call — not even through shell or CLI tools. If the task needs one, say so briefly and offer to finish it in text chat after the call.";
+  "Never start account connections, OAuth or sign-in flows, or any other action that opens a browser window or needs the user's screen during this call, not even through shell or CLI tools. If the task needs one, say so briefly and offer to finish it in text chat after the call.";
 
 function buildVoiceCallControlPrompt(opts: {
   isInbound: boolean;

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -407,18 +407,6 @@ export interface VoiceTurnHandle {
  * provides assistant identity) and guardian context (injected separately).
  */
 /**
- * Steering shared by every voice channel. A sign-in flow opens a browser
- * window mid-call that the caller may be unable to see or complete, whether it
- * is reached through a ui-surface tool or through shell and CLI tools (e.g.
- * `assistant oauth connect`). Tell the model to speak the limitation and defer
- * the flow to text chat instead.
- *
- * This outlives the ui-surface restriction it was written alongside: a
- * live-voice call can now show surfaces, but a browser window handing control
- * to a third party mid-call is a different problem, and one a minimized room
- * does not solve.
- */
-/**
  * How long a live-voice call waits on an approval before deciding it itself.
  *
  * Long enough to pick the phone up and read the card, short enough that a turn
@@ -428,7 +416,22 @@ export interface VoiceTurnHandle {
  */
 const VOICE_APPROVAL_TIMEOUT_MS = 45_000;
 
-export const VOICE_NO_SETUP_FLOWS_RULE =
+/**
+ * Telephony-only steering. A sign-in flow opens a browser window on a screen
+ * the caller does not have in front of them, whether it is reached through a
+ * ui-surface tool or through shell and CLI tools (e.g. `assistant oauth
+ * connect`). Tell the model to speak the limitation and defer the flow to text
+ * chat instead.
+ *
+ * Scoped to the phone because the screen is what decides it. A phone call has
+ * no screen, so the `open_url` signal a CLI tool can reach lands somewhere the
+ * caller will never see — and that signal bus carries no capability or
+ * conversation context, so this rule is the only thing standing in front of it
+ * here. A live-voice call is the opposite case: the user is holding the screen,
+ * and the room minimizes itself to hand it back (see
+ * LIVE_VOICE_SETUP_FLOW_TEACHING).
+ */
+const PHONE_NO_SETUP_FLOWS_RULE =
   "Never start account connections, OAuth or sign-in flows, or any other action that opens a browser window or needs the user's screen during this call — not even through shell or CLI tools. If the task needs one, say so briefly and offer to finish it in text chat after the call.";
 
 function buildVoiceCallControlPrompt(opts: {
@@ -523,7 +526,7 @@ function buildVoiceCallControlPrompt(opts: {
     "9. After the opening greeting turn, treat the Task field as background context only — do not re-execute its instructions on subsequent turns.",
     '10. Do not make up information. If you are unsure, use [ASK_GUARDIAN: your question] to consult your guardian. For tool permission requests, use [ASK_GUARDIAN_APPROVAL: {"question":"...","toolName":"...","input":{...}}].',
     `11. Your text is sent directly to a text-to-speech engine. Never use markdown formatting (asterisks, headers, backticks, links) or emojis in your spoken responses. Write plain conversational text only. Protocol markers like ${opts.isCallerGuardian ? "[END_CALL]" : "[ASK_GUARDIAN: ...] and [END_CALL]"} are not spoken text and should still be used normally.`,
-    `12. ${VOICE_NO_SETUP_FLOWS_RULE}`,
+    `12. ${PHONE_NO_SETUP_FLOWS_RULE}`,
   );
 
   // Triage-and-escalate routing rules. The front-door leg decides and may

--- a/assistant/src/live-voice/__tests__/live-voice-events.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-events.test.ts
@@ -255,7 +255,7 @@ describe("LiveVoiceSession archive and metrics events", () => {
       // Pins the full production control prompt for the FRONT-DOOR leg (the
       // first leg of every routed turn): the speech-first rule, and nothing
       // else. This leg is toolless, so both the screen-reveal and setup-flow
-      // teachings are deliberately absent — it has nothing to show and no
+      // teachings are deliberately absent. It has nothing to show and no
       // connection to run, and its capability digest already routes anything
       // needing a tool to the escalated leg (see
       // live-voice-triage-escalate.test.ts).

--- a/assistant/src/live-voice/__tests__/live-voice-events.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-events.test.ts
@@ -4,7 +4,6 @@ import type {
   VoiceTurnCallbacks,
   VoiceTurnOptions,
 } from "../../calls/voice-session-bridge.js";
-import { VOICE_NO_SETUP_FLOWS_RULE } from "../../calls/voice-session-bridge.js";
 import type {
   StreamingTranscriber,
   SttStreamServerEvent,
@@ -254,14 +253,14 @@ describe("LiveVoiceSession archive and metrics events", () => {
       userMessageInterface: "macos",
       assistantMessageInterface: "macos",
       // Pins the full production control prompt for the FRONT-DOOR leg (the
-      // first leg of every routed turn): the speech-first rule (which now
-      // permits a surface, since the room reveals one by itself) and the
-      // shared no-setup-flows rule (no OAuth/browser flows mid-call). The [-1]
-      // room-minimize teaching is deliberately absent — only the escalated
-      // leg learns it (see live-voice-triage-escalate.test.ts).
+      // first leg of every routed turn): the speech-first rule, and nothing
+      // else. This leg is toolless, so both the screen-reveal and setup-flow
+      // teachings are deliberately absent — it has nothing to show and no
+      // connection to run, and its capability digest already routes anything
+      // needing a tool to the escalated leg (see
+      // live-voice-triage-escalate.test.ts).
       voiceControlPrompt:
-        "You are speaking in a local live voice session. Keep replies brief and conversational. Speech is the main channel: say the answer, and do not narrate a surface instead of answering. You can also put something on screen when it genuinely helps (a form, a list to pick from, a progress card for long work); the call overlay minimizes by itself once you finish speaking, so the user sees it without doing anything. Never tell the user you cannot show them something. " +
-        VOICE_NO_SETUP_FLOWS_RULE,
+        "You are speaking in a local live voice session. Keep replies brief and conversational. Speech is the main channel: say the answer, and do not narrate a surface instead of answering. You can also put something on screen when it genuinely helps (a form, a list to pick from, a progress card for long work); the call overlay minimizes by itself once you finish speaking, so the user sees it without doing anything. Never tell the user you cannot show them something. ",
     });
     callbacks?.assistant_text_delta?.(makeTextDelta("Hello there."));
     callbacks?.message_complete?.(makeMessageComplete());

--- a/assistant/src/live-voice/__tests__/live-voice-triage-escalate.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-triage-escalate.test.ts
@@ -190,6 +190,36 @@ describe("live-voice triage-and-escalate routing", () => {
     expect(escalated?.content).toBe(ESCALATION_CONTINUATION_CONTENT);
   });
 
+  test("no leg is told to refuse setup flows, and the escalated leg is told to run them", async () => {
+    const { starter } = scriptedStartVoiceTurn({
+      frontDoor: ["[1] ", "Let me think about that."],
+      escalated: ["The detailed answer is 42."],
+    });
+    const { frames, session } = createHarness(starter);
+
+    await driveTurn(session);
+    await waitFor(() => starter.mock.calls.length >= 2);
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    const frontDoorPrompt =
+      starter.mock.calls[0]?.[0]?.voiceControlPrompt ?? "";
+    const escalatedPrompt =
+      starter.mock.calls[1]?.[0]?.voiceControlPrompt ?? "";
+    // The phone's no-setup-flows rule must not leak onto a channel that has a
+    // screen. It contradicts the base prompt's "never tell the user you cannot
+    // show them something", and it is what made the model decline an account
+    // connection and offer to finish it in text instead.
+    expect(frontDoorPrompt).not.toContain("Never start account connections");
+    expect(escalatedPrompt).not.toContain("Never start account connections");
+    expect(frontDoorPrompt).not.toContain("finish it in text chat");
+    expect(escalatedPrompt).not.toContain("finish it in text chat");
+    // The leg that can actually run one is told to.
+    expect(escalatedPrompt).toContain("This includes connecting accounts");
+    // The toolless fast leg is not — a connection is not its to run, and its
+    // capability digest already routes anything needing a tool here.
+    expect(frontDoorPrompt).not.toContain("This includes connecting accounts");
+  });
+
   test("the screen-reveal teaching reaches the escalated leg's prompt but never the front-door leg's", async () => {
     const { starter } = scriptedStartVoiceTurn({
       frontDoor: ["[1] ", "Let me think about that."],

--- a/assistant/src/live-voice/__tests__/live-voice-triage-escalate.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-triage-escalate.test.ts
@@ -206,16 +206,15 @@ describe("live-voice triage-and-escalate routing", () => {
     const escalatedPrompt =
       starter.mock.calls[1]?.[0]?.voiceControlPrompt ?? "";
     // The phone's no-setup-flows rule must not leak onto a channel that has a
-    // screen. It contradicts the base prompt's "never tell the user you cannot
-    // show them something", and it is what made the model decline an account
-    // connection and offer to finish it in text instead.
+    // screen: it contradicts the base prompt's "never tell the user you cannot
+    // show them something".
     expect(frontDoorPrompt).not.toContain("Never start account connections");
     expect(escalatedPrompt).not.toContain("Never start account connections");
     expect(frontDoorPrompt).not.toContain("finish it in text chat");
     expect(escalatedPrompt).not.toContain("finish it in text chat");
     // The leg that can actually run one is told to.
     expect(escalatedPrompt).toContain("This includes connecting accounts");
-    // The toolless fast leg is not — a connection is not its to run, and its
+    // The toolless fast leg is not: a connection is not its to run, and its
     // capability digest already routes anything needing a tool here.
     expect(frontDoorPrompt).not.toContain("This includes connecting accounts");
   });

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -17,7 +17,6 @@ import type {
 import {
   getConversationTurnTeardown,
   resolveProcessingWaitMs,
-  VOICE_NO_SETUP_FLOWS_RULE,
   waitForPriorTurnTeardown,
 } from "../calls/voice-session-bridge.js";
 import {
@@ -744,6 +743,20 @@ const LIVE_VOICE_CONTROL_PROMPT_BASE =
 const LIVE_VOICE_SCREEN_REVEAL_TEACHING =
   "The call renders as a full-screen overlay covering the app. Whenever you put something on screen, the overlay minimizes by itself as soon as you finish speaking, and the user is looking at what you made. So speak as if you are showing it to them right now (for example, close with something like: take a look), and never say you cannot show it, that this is a voice call, or that they should check it later. Never emit bracketed markers of any kind. ";
 
+// The setup-flow case, spelled out because it is the one the model gets wrong
+// on its own: connecting an account reads as something a call cannot do, so
+// without this it declines and offers to do it later in text — while the base
+// prompt above is telling it never to say exactly that.
+//
+// It can do it. The connect card is a ui surface like any other, so showing it
+// minimizes the room on the same latch (`revealsUiSurface`), and the user is at
+// the screen the browser window opens on. Appended alongside the screen-reveal
+// teaching, to the same legs, for the same reason: the front-door leg is
+// toolless, so a setup flow is not its to run — its capability digest already
+// tells it to escalate anything needing a tool rather than refuse.
+const LIVE_VOICE_SETUP_FLOW_TEACHING =
+  "This includes connecting accounts. If a task needs an account connected or a sign-in completed, put the connection up on screen and let the user do it now — do not decline it, and do not defer it to text chat. Say what you are connecting and that it is in front of them. ";
+
 // System-level guidance appended to a barge-in turn's control prompt so the
 // model treats the new utterance as a continuation of the request it was cut
 // off answering, rather than a fresh follow-up. Reaches the model only; it is
@@ -800,21 +813,21 @@ function buildLiveDeliveryNote(request: string, answer: string): string {
   return `The user interrupted you earlier, and in the background you finished ${what}. The call is still live and nobody is speaking, so tell them briefly that it is done and give them the result. Do not re-run any tool calls; the work is already complete, and do not repeat it verbatim if it no longer fits. What you produced was:\n\n${answer}`;
 }
 
-// Assemble a leg's model-facing control prompt: the base live-voice rules,
-// the screen-reveal teaching (withheld from the front-door leg, see
-// LIVE_VOICE_SCREEN_REVEAL_TEACHING), the shared no-setup-flows rule, plus
-// any pending barge-in merge context, completed-continuation context, and/or
-// the announcement instruction. A turn can carry several (a barge-in follow-up
-// that also has a continuation result waiting); the notes are model-only and
-// never render as user bubbles.
+// Assemble a leg's model-facing control prompt: the base live-voice rules, the
+// screen-reveal and setup-flow teaching (both withheld from the front-door leg,
+// see LIVE_VOICE_SCREEN_REVEAL_TEACHING), plus any pending barge-in merge
+// context, completed-continuation context, and/or the announcement instruction.
+// A turn can carry several (a barge-in follow-up that also has a continuation
+// result waiting); the notes are model-only and never render as user bubbles.
 function buildVoiceControlPrompt(
   turn: ActiveAssistantTurn,
   leg: { frontDoor?: boolean },
 ): string {
   let prompt =
     LIVE_VOICE_CONTROL_PROMPT_BASE +
-    (leg.frontDoor === true ? "" : LIVE_VOICE_SCREEN_REVEAL_TEACHING) +
-    VOICE_NO_SETUP_FLOWS_RULE;
+    (leg.frontDoor === true
+      ? ""
+      : LIVE_VOICE_SCREEN_REVEAL_TEACHING + LIVE_VOICE_SETUP_FLOW_TEACHING);
   if (turn.interruptedRequest) {
     prompt = `${prompt}\n\n${buildInterruptionMergeNote(turn.interruptedRequest)}`;
   }

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -744,18 +744,18 @@ const LIVE_VOICE_SCREEN_REVEAL_TEACHING =
   "The call renders as a full-screen overlay covering the app. Whenever you put something on screen, the overlay minimizes by itself as soon as you finish speaking, and the user is looking at what you made. So speak as if you are showing it to them right now (for example, close with something like: take a look), and never say you cannot show it, that this is a voice call, or that they should check it later. Never emit bracketed markers of any kind. ";
 
 // The setup-flow case, spelled out because it is the one the model gets wrong
-// on its own: connecting an account reads as something a call cannot do, so
-// without this it declines and offers to do it later in text — while the base
-// prompt above is telling it never to say exactly that.
+// on its own: connecting an account reads as something a call cannot do, so it
+// declines and offers to do it later in text, which is the exact thing the base
+// prompt above forbids.
 //
 // It can do it. The connect card is a ui surface like any other, so showing it
 // minimizes the room on the same latch (`revealsUiSurface`), and the user is at
 // the screen the browser window opens on. Appended alongside the screen-reveal
 // teaching, to the same legs, for the same reason: the front-door leg is
-// toolless, so a setup flow is not its to run — its capability digest already
-// tells it to escalate anything needing a tool rather than refuse.
+// toolless, so a setup flow is not its to run, and its capability digest
+// already tells it to escalate anything needing a tool rather than refuse.
 const LIVE_VOICE_SETUP_FLOW_TEACHING =
-  "This includes connecting accounts. If a task needs an account connected or a sign-in completed, put the connection up on screen and let the user do it now — do not decline it, and do not defer it to text chat. Say what you are connecting and that it is in front of them. ";
+  "This includes connecting accounts. If a task needs an account connected or a sign-in completed, put the connection up on screen and let the user do it now. Do not decline it, and do not defer it to text chat. Say what you are connecting and that it is in front of them. ";
 
 // System-level guidance appended to a barge-in turn's control prompt so the
 // model treats the new utterance as a continuation of the request it was cut


### PR DESCRIPTION
Closes JARVIS-1469

## Problem

Ask the assistant to connect an account during a live-voice session and it declines, saying it can't do that on a call and offering to finish in text chat. That hasn't been true since the room learned to minimize itself:

- `startVoiceTurn` resolves `supportsDynamicUi` from the channel rather than forcing it off (`voice-session-bridge.ts:1006-1021`), so a voice turn can show an `oauth_connect` surface.
- A clean `ui_show` / `ui_update` / `app_open` latches `minimizeRequested` (`live-voice-session.ts:4160-4165`, `activity-label.ts:40`), so the room gets out of the way once the reply's TTS drains and the user is looking at the card.

The plumbing works. What was left was the prompt: `VOICE_NO_SETUP_FLOWS_RULE` was appended to **every** live-voice leg, and it contradicted the two teachings immediately above it — `LIVE_VOICE_CONTROL_PROMPT_BASE` ("Never tell the user you cannot show them something") and `LIVE_VOICE_SCREEN_REVEAL_TEACHING` ("never say you cannot show it, that this is a voice call, or that they should check it later").

## Change

Scope the rule to the channel whose screen the caller genuinely does not have.

- Renamed to `PHONE_NO_SETUP_FLOWS_RULE`, unchanged in wording, still phone protocol rule 12.
- Live voice gets `LIVE_VOICE_SETUP_FLOW_TEACHING` instead: put the connection on screen and let the user do it now.
- Appended to the same legs as the screen-reveal teaching. The toolless front-door leg gets neither — a connection is not its to run, and `frontDoorCapabilityDigest` already tells it to escalate anything needing a tool "instead of refusing or guessing."

## Why phone keeps it

Not symmetry-for-its-own-sake. A phone call has no screen, so a browser window opened by `bash` → `assistant oauth connect` → `openInHostBrowser` lands somewhere the caller will never see. That `open_url` signal bus carries no capability or conversation context (JARVIS-1291), so on the phone this prompt rule is the only thing in front of it. On live voice the user is holding the screen, which is what makes the same flow the desired behavior rather than a leak.

## Tests

- New assertion in `live-voice-triage-escalate.test.ts`: neither leg carries the refusal, the escalated leg carries the affirmative teaching, the front-door leg does not.
- `live-voice-events.test.ts` pins the front-door prompt exactly; updated to the now-shorter string.
- `bun run typecheck` clean; `voice-session-bridge` + `live-voice` suites pass (79 tests across the 3 touched files). Three `live-voice-stt.test.ts` `waitFor` timeouts appear when the full 24-file live-voice directory runs in parallel and pass when that file runs alone — pre-existing timing flake, unrelated to this diff.

## Not covered

Prompt-level only, same as the rule it replaces. If a live-voice leg ever needs a *structural* guarantee about setup flows, that belongs at the `open_url` signal bus, which still has no capability context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)