### PR TITLE
feat(assistant): register the voice_picker surface type

### DIFF
--- a/assistant/src/api/surfaces.ts
+++ b/assistant/src/api/surfaces.ts
@@ -591,6 +591,7 @@ export const SURFACE_TYPES = [
   "skill_card",
   "call_summary",
   "visual",
+  "voice_picker",
 ] as const;
 
 export const SurfaceTypeSchema = z.enum(SURFACE_TYPES);
@@ -662,9 +663,10 @@ export type SurfaceData =
  * and serves verbatim but whose shape it does not model, which is why they
  * are absent from the renderable `SurfaceData` union: `channel_setup` (a
  * side-effect command forwarded to the setup panel), `task_preferences` (a
- * fixed grid that reads no data), and `skill_card` / `call_summary` (cards
- * the daemon appends to history directly — the memory retrospective and a
- * call summary — and whose data shape is owned by their client renderers).
+ * fixed grid that reads no data), `voice_picker` (a settings card that reads
+ * its own config), and `skill_card` / `call_summary` (cards the daemon appends
+ * to history directly — the memory retrospective and a call summary — and
+ * whose data shape is owned by their client renderers).
  */
 export interface SurfaceDataByType {
   card: CardSurfaceData;
@@ -684,6 +686,7 @@ export interface SurfaceDataByType {
   skill_card: Record<string, unknown>;
   call_summary: Record<string, unknown>;
   visual: VisualSurfaceData;
+  voice_picker: Record<string, unknown>;
 }
 
 /** Any surface `data` payload, including the opaque (non-renderable) types. */
@@ -717,6 +720,7 @@ export const SURFACE_DATA_SCHEMAS: {
   skill_card: z.record(z.string(), z.unknown()),
   call_summary: z.record(z.string(), z.unknown()),
   visual: VisualSurfaceDataSchema,
+  voice_picker: z.record(z.string(), z.unknown()),
 };
 
 /**

--- a/assistant/src/api/surfaces.ts
+++ b/assistant/src/api/surfaces.ts
@@ -665,8 +665,8 @@ export type SurfaceData =
  * side-effect command forwarded to the setup panel), `task_preferences` (a
  * fixed grid that reads no data), `voice_picker` (a settings card that reads
  * its own config), and `skill_card` / `call_summary` (cards the daemon appends
- * to history directly — the memory retrospective and a call summary — and
- * whose data shape is owned by their client renderers).
+ * to history directly, the memory retrospective and a call summary, whose
+ * data shape is owned by their client renderers).
  */
 export interface SurfaceDataByType {
   card: CardSurfaceData;


### PR DESCRIPTION
## Summary

- Adds `voice_picker` to the canonical `SURFACE_TYPES` registry in `assistant/src/api/surfaces.ts`, plus the two mapped types the compiler forces alongside it: `SurfaceDataByType` and `SURFACE_DATA_SCHEMAS`.
- Modeled as an opaque `Record<string, unknown>`, exactly like `task_preferences` — the card reads the current voice and the catalog itself, so the surface carries no payload. The doc comment enumerating the opaque types now covers it.
- Deliberately NOT added to `DAEMON_INTERNAL_SURFACE_TYPES` (it must stay model-invokable) or `INTERACTIVE_SURFACE_TYPES` (a settings card has no terminal action). Registry plumbing only: `SURFACE_SHAPE_DOCS` is untouched, so `ui_show`'s enum is unchanged and the model still cannot invoke the type — that is PR 4.

Part of plan: inline-voice-picker-surface.md (PR 3 of 5)