### PR TITLE
feat(web): add an inline voice picker surface component

### DIFF
--- a/clients/web/src/components/speech/byo-voice-note.tsx
+++ b/clients/web/src/components/speech/byo-voice-note.tsx
@@ -1,0 +1,30 @@
+/**
+ * Where a bring-your-own provider's voice is set. BYO assistants get no managed
+ * catalog to pick from: their voice is a field on the provider form, which
+ * lives with every other provider on Models & Services. Rendered by each
+ * surface that would otherwise offer the picker, so none of them leaves an
+ * empty box.
+ *
+ * Lives under `components/speech/` alongside the picker it stands in for, since
+ * both the `chat` and `settings` domains render it.
+ */
+
+import { Link } from "react-router";
+
+import { routes } from "@/utils/routes";
+
+export function ByoVoiceNote() {
+  return (
+    <p className="text-body-small-default text-[var(--content-tertiary)]">
+      Your assistant speaks through a provider you configured yourself. Set its
+      voice on{" "}
+      <Link
+        to={`${routes.settings.ai}#text-to-speech`}
+        className="text-[var(--primary-base)] hover:underline"
+      >
+        Models &amp; Services
+      </Link>
+      .
+    </p>
+  );
+}

--- a/clients/web/src/domains/chat/components/surfaces/voice-picker-surface.test.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/voice-picker-surface.test.tsx
@@ -1,0 +1,215 @@
+/**
+ * Tests for `VoicePickerSurface`, the inline chat card that hosts the shared
+ * managed-voice picker.
+ *
+ * Load-bearing behavior:
+ *   - a managed assistant gets the fetched voice rows inside the surface card,
+ *   - picking a voice PATCHes `services.tts.providers.vellum.model`,
+ *   - picking a voice submits no surface action, so auditioning several voices
+ *     never fires an assistant turn,
+ *   - a BYO assistant gets the Models & Services pointer, not an empty card.
+ *
+ * The daemon queries, the config PATCH, and audio playback are mocked.
+ */
+
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+
+import type { Surface } from "@/domains/chat/types/types";
+
+const ASSISTANT_ID = "asst_1";
+
+let orgReady = true;
+mock.module("@/hooks/use-is-org-ready", () => ({
+  useIsOrgReady: () => orgReady,
+}));
+mock.module("@vellumai/design-library/components/toast", () => ({
+  toast: { success: () => {}, error: () => {} },
+  Toaster: () => null,
+  ToastContent: () => null,
+}));
+
+let daemonConfigData: { services: Record<string, unknown> } = {
+  services: { tts: { provider: "vellum" } },
+};
+let providersData: { providers: unknown[] } = {
+  providers: [
+    { id: "vellum", displayName: "Vellum", supportsVoiceSelection: true },
+  ],
+};
+let managedVoicesData: { voices: unknown[]; defaultModel: string | null } = {
+  voices: [],
+  defaultModel: null,
+};
+mock.module("@/generated/daemon/@tanstack/react-query.gen", () => ({
+  ttsProvidersGetOptions: () => ({
+    queryKey: ["tts-providers-test"],
+    queryFn: () => Promise.resolve(providersData),
+    initialData: providersData,
+  }),
+  configGetOptions: () => ({
+    queryKey: ["config-get-test"],
+    queryFn: () => Promise.resolve(daemonConfigData),
+    initialData: daemonConfigData,
+  }),
+  configGetQueryKey: () => ["config-get-test"],
+  ttsManagedvoicesGetOptions: () => ({
+    queryKey: ["tts-managed-voices-test"],
+    queryFn: () => Promise.resolve(managedVoicesData),
+    initialData: managedVoicesData,
+  }),
+}));
+
+const configPatchCalls: { path?: unknown; body?: unknown }[] = [];
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  configPatch: async (opts: { path?: unknown; body?: unknown }) => {
+    configPatchCalls.push(opts);
+    return { response: { ok: true, status: 200 } };
+  },
+}));
+
+const { VoicePickerSurface } =
+  await import("@/domains/chat/components/surfaces/voice-picker-surface");
+
+const SURFACE: Surface = {
+  surfaceId: "surface-voice-1",
+  surfaceType: "voice_picker",
+  title: "Pick a voice",
+  data: {},
+};
+
+beforeAll(() => {
+  (
+    window.HTMLMediaElement.prototype as unknown as {
+      play: () => Promise<void>;
+    }
+  ).play = () => Promise.resolve();
+  (
+    window.HTMLMediaElement.prototype as unknown as { pause: () => void }
+  ).pause = () => {};
+});
+
+const onActionCalls: unknown[][] = [];
+
+function renderSurface(assistantId: string | null = ASSISTANT_ID) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <VoicePickerSurface
+          surface={SURFACE}
+          onAction={(...args) => {
+            onActionCalls.push(args);
+          }}
+          assistantId={assistantId}
+        />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+function pickZeus() {
+  const zeus = screen
+    .getAllByRole("option")
+    .find((o) => o.textContent?.includes("Deep, trustworthy"));
+  if (!zeus) {
+    throw new Error("expected the Zeus option");
+  }
+  fireEvent.click(zeus);
+}
+
+beforeEach(() => {
+  orgReady = true;
+  configPatchCalls.length = 0;
+  onActionCalls.length = 0;
+  daemonConfigData = { services: { tts: { provider: "vellum" } } };
+  providersData = {
+    providers: [
+      { id: "vellum", displayName: "Vellum", supportsVoiceSelection: true },
+    ],
+  };
+  managedVoicesData = {
+    voices: [
+      {
+        model: "EXAVITQu4vr4xnSDxMaL",
+        label: "Sarah",
+        description: "American · professional, reassuring, confident",
+        sampleUrl: "https://example.test/sarah.mp3",
+        source: "elevenlabs",
+      },
+      {
+        model: "aura-2-zeus-en",
+        label: "Zeus",
+        description: "American · deep, trustworthy, smooth",
+        sampleUrl: "https://example.test/zeus.wav",
+        source: "elevenlabs",
+      },
+    ],
+    defaultModel: "EXAVITQu4vr4xnSDxMaL",
+  };
+});
+afterEach(cleanup);
+
+describe("VoicePickerSurface", () => {
+  test("renders the fetched voices inside the surface card", () => {
+    renderSurface();
+
+    expect(screen.getByText("Pick a voice")).toBeTruthy();
+    const rows = screen.getAllByRole("option");
+    expect(rows.length).toBe(2);
+    expect(rows.map((r) => r.textContent ?? "").join(" ")).toContain(
+      "Deep, trustworthy, smooth",
+    );
+  });
+
+  test("picking a voice PATCHes services.tts.providers.vellum.model", async () => {
+    renderSurface();
+    pickZeus();
+
+    await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    expect(configPatchCalls[0]!.path).toEqual({ assistant_id: ASSISTANT_ID });
+    expect(configPatchCalls[0]!.body).toEqual({
+      services: { tts: { providers: { vellum: { model: "aura-2-zeus-en" } } } },
+    });
+  });
+
+  test("picking a voice submits no surface action", async () => {
+    renderSurface();
+    pickZeus();
+
+    // The write is what the card does instead of an action. Waiting for it
+    // means the action would have been submitted by now if the card submitted
+    // one, and every audition click would cost an assistant turn.
+    await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    expect(onActionCalls.length).toBe(0);
+  });
+
+  test("a BYO assistant gets the Models & Services pointer, not an empty card", () => {
+    daemonConfigData = { services: { tts: { provider: "elevenlabs" } } };
+    renderSurface();
+
+    expect(screen.queryByRole("listbox")).toBeNull();
+    const link = screen.getByRole("link", { name: "Models & Services" });
+    expect(link.getAttribute("href")).toBe(
+      "/assistant/settings/ai#text-to-speech",
+    );
+  });
+});

--- a/clients/web/src/domains/chat/components/surfaces/voice-picker-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/voice-picker-surface.tsx
@@ -1,0 +1,62 @@
+/**
+ * The voice picker, rendered inline in the transcript: a user who asks to hear
+ * or change a voice gets the working picker in the conversation instead of a
+ * pointer to Settings. Same {@link VoiceList} the Voice settings page and the
+ * voice room render, so a voice is chosen the same way everywhere.
+ *
+ * **Fires no surface action.** `handleSurfaceAction` requests a send on every
+ * non-guardian action, so a per-selection action would cost an assistant turn
+ * on every audition click. It needs none: `VoiceList` writes
+ * `services.tts.providers.vellum.model` to daemon config itself, and that
+ * hot-applies on the assistant's next spoken turn. `onAction` is accepted only
+ * to satisfy {@link SurfaceContainer}'s required prop and to keep the router's
+ * call shape uniform across surfaces. This component never invokes it.
+ *
+ * The assistant arrives as a prop rather than from `useActiveAssistantId()`,
+ * which throws when nothing is resolved and answers with the globally-active
+ * assistant, not necessarily the one that owns this surface's stream.
+ */
+
+import { ByoVoiceNote } from "@/components/speech/byo-voice-note";
+import { useManagedVoiceSelection } from "@/components/speech/use-managed-voice-selection";
+import { VoiceList } from "@/components/speech/voice-list";
+import { SurfaceContainer } from "@/domains/chat/components/surfaces/surface-container";
+import type { Surface } from "@/domains/chat/types/types";
+
+interface VoicePickerSurfaceProps {
+  surface: Surface;
+  onAction: (
+    surfaceId: string,
+    actionId: string,
+    data?: Record<string, unknown>,
+  ) => void | Promise<void>;
+  assistantId?: string | null;
+}
+
+export function VoicePickerSurface({
+  surface,
+  onAction,
+  assistantId,
+}: VoicePickerSurfaceProps) {
+  const { available, isByok } = useManagedVoiceSelection(assistantId ?? null);
+
+  return (
+    <SurfaceContainer surface={surface} onAction={onAction}>
+      {available && (
+        // Uncontrolled (no `value`/`onChange`) so the list commits the pick
+        // itself and it hot-applies, the mode the Settings picker and the voice
+        // room use. `showSource` stays off because `filterBySource` already
+        // labels the whole list with the chosen provider and drops the per-row
+        // badge. Capped so a long catalog can't take over the transcript.
+        <VoiceList
+          assistantId={assistantId ?? null}
+          filterBySource
+          className="max-h-[22rem] overflow-y-auto"
+        />
+      )}
+      {/* Gated on `isByok` rather than `!available` so the BYO pointer never
+          flashes while config is still loading. */}
+      {isByok && <ByoVoiceNote />}
+    </SurfaceContainer>
+  );
+}

--- a/clients/web/src/domains/settings/pages/voice-picker-card.tsx
+++ b/clients/web/src/domains/settings/pages/voice-picker-card.tsx
@@ -15,18 +15,16 @@
 
 import { useState } from "react";
 
-import { Link } from "react-router";
-
 import { Button } from "@vellumai/design-library/components/button";
 
 import { DetailCard } from "@/components/detail-card";
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
+import { ByoVoiceNote } from "@/components/speech/byo-voice-note";
 import { useManagedVoiceSelection } from "@/components/speech/use-managed-voice-selection";
 import { MANAGED_VOICE_CREDITS_NOTE } from "@/lib/tts/managed-voice-catalog";
 import { VoiceLabel } from "@/components/speech/voice-list";
 import { VoicePickerModal } from "@/components/speech/voice-picker-modal";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
-import { routes } from "@/utils/routes";
 
 export function VoicePickerCard() {
   const assistantId = useActiveAssistantId();
@@ -72,17 +70,7 @@ export function VoicePickerCard() {
 
   return (
     <DetailCard title={voiceTitle}>
-      <p className="text-body-small-default text-[var(--content-tertiary)]">
-        Your assistant speaks through a provider you configured yourself. Set
-        its voice on{" "}
-        <Link
-          to={`${routes.settings.ai}#text-to-speech`}
-          className="text-[var(--primary-base)] hover:underline"
-        >
-          Models &amp; Services
-        </Link>
-        .
-      </p>
+      <ByoVoiceNote />
     </DetailCard>
   );
 }


### PR DESCRIPTION
## Summary

- Adds `VoicePickerSurface`, a chat surface that renders the shared managed-voice `VoiceList` inline in the transcript, so a user who asks to change or hear a voice gets a working picker in the conversation instead of a pointer to Settings.
- The card submits **no** surface action. `handleSurfaceAction` requests a send on every non-guardian action, so a per-selection action would cost an assistant turn on every audition click. `VoiceList` already writes `services.tts.providers.vellum.model` through the daemon config patch and that hot-applies on the next spoken turn, so the card is fully functional with no round trip. A test asserts `onAction` is called zero times after a selection.
- A bring-your-own-provider assistant gets a pointer to Models & Services instead of an empty card. That note was duplicated from the Settings `VoicePickerCard`, so it is extracted into a shared `ByoVoiceNote` and both surfaces now render it.
- Not yet wired into the surface router (that is PR 2), so the component is dead-but-compiling at the end of this PR.

Part of plan: inline-voice-picker-surface.md (PR 1 of 5)