### PR TITLE
fix(memory): tighten nested fork bounds and share the delete guard

### DIFF
--- a/assistant/src/__tests__/conversation-fork-referential.test.ts
+++ b/assistant/src/__tests__/conversation-fork-referential.test.ts
@@ -10,15 +10,18 @@
  * against the cloning path is what pins that.
  */
 
-import { beforeEach, describe, expect, test } from "bun:test";
+import { rmSync, writeFileSync } from "node:fs";
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 
 import { eq } from "drizzle-orm";
 
+import { invalidateConfigCache } from "../config/loader.js";
 import {
   addMessage,
   countMessagesAfter,
   createConversation,
   deleteConversation,
+  deleteConversationGently,
   forkConversationForRetrospective,
   getMessages,
   getMessagesAfter,
@@ -35,8 +38,35 @@ import {
   memoryRetrospectiveState,
   messages,
 } from "../persistence/schema/index.js";
+import { getWorkspaceConfigPath } from "../util/platform.js";
 
 await initializeDb();
+
+const configPath = getWorkspaceConfigPath();
+
+/**
+ * Point `memory.retrospective.forkStrategy` at a strategy. The fork path reads
+ * it from config rather than taking a parameter, so exercising both branches
+ * means writing the workspace config the loader reads.
+ */
+function setForkStrategy(strategy: "cloning" | "reference"): void {
+  writeFileSync(
+    configPath,
+    JSON.stringify(
+      { memory: { retrospective: { forkStrategy: strategy } } },
+      null,
+      2,
+    ) + "\n",
+  );
+  invalidateConfigCache();
+}
+
+function clearConfig(): void {
+  rmSync(configPath, { force: true });
+  invalidateConfigCache();
+}
+
+afterAll(clearConfig);
 
 function resetTables(): void {
   const db = getDb();
@@ -94,14 +124,15 @@ function textOf(rows: Array<{ content: unknown }>): string[] {
 describe("referential forking", () => {
   beforeEach(() => {
     resetTables();
+    clearConfig();
   });
 
   test("copies no message rows and stamps the strategy", async () => {
     const source = await seedSource("Launch");
 
+    setForkStrategy("reference");
     const fork = await forkConversationForRetrospective({
       conversationId: source.id,
-      forkStrategy: "reference",
     });
 
     expect(ownedRowCount(fork.id)).toBe(0);
@@ -113,9 +144,9 @@ describe("referential forking", () => {
   test("reads the source's history through the fork pointer", async () => {
     const source = await seedSource("Launch");
 
+    setForkStrategy("reference");
     const fork = await forkConversationForRetrospective({
       conversationId: source.id,
-      forkStrategy: "reference",
     });
 
     expect(textOf(getMessages(fork.id))).toEqual([
@@ -130,13 +161,13 @@ describe("referential forking", () => {
   test("presents the same messages a cloning fork does", async () => {
     const source = await seedSource("Launch");
 
+    setForkStrategy("cloning");
     const cloned = await forkConversationForRetrospective({
       conversationId: source.id,
-      forkStrategy: "cloning",
     });
+    setForkStrategy("reference");
     const referenced = await forkConversationForRetrospective({
       conversationId: source.id,
-      forkStrategy: "reference",
     });
 
     expect(textOf(getMessages(referenced.id))).toEqual(
@@ -149,9 +180,9 @@ describe("referential forking", () => {
 
   test("rows written on the fork interleave after the inherited ones", async () => {
     const source = await seedSource("Launch");
+    setForkStrategy("reference");
     const fork = await forkConversationForRetrospective({
       conversationId: source.id,
-      forkStrategy: "reference",
     });
 
     await addMessage(fork.id, "user", "review this conversation", {
@@ -166,9 +197,9 @@ describe("referential forking", () => {
 
   test("messages written on the source after the fork point are excluded", async () => {
     const source = await seedSource("Launch");
+    setForkStrategy("reference");
     const fork = await forkConversationForRetrospective({
       conversationId: source.id,
-      forkStrategy: "reference",
     });
 
     await addMessage(source.id, "user", "written after the fork", {
@@ -184,10 +215,10 @@ describe("referential forking", () => {
     const source = await seedSource("Launch");
     const sourceRows = getMessages(source.id);
 
+    setForkStrategy("reference");
     const fork = await forkConversationForRetrospective({
       conversationId: source.id,
       throughMessageId: sourceRows[1]!.id,
-      forkStrategy: "reference",
     });
 
     expect(textOf(getMessages(fork.id))).toEqual([
@@ -199,9 +230,9 @@ describe("referential forking", () => {
   test("getMessagesAfter and countMessagesAfter cross the lineage boundary", async () => {
     const source = await seedSource("Launch");
     const sourceRows = getMessages(source.id);
+    setForkStrategy("reference");
     const fork = await forkConversationForRetrospective({
       conversationId: source.id,
-      forkStrategy: "reference",
     });
     await addMessage(fork.id, "user", "own row", { skipIndexing: true });
 
@@ -215,9 +246,9 @@ describe("referential forking", () => {
 
   test("pagination returns the inherited rows", async () => {
     const source = await seedSource("Launch");
+    setForkStrategy("reference");
     const fork = await forkConversationForRetrospective({
       conversationId: source.id,
-      forkStrategy: "reference",
     });
 
     const unlimited = getMessagesPaginated(fork.id, undefined);
@@ -232,9 +263,9 @@ describe("referential forking", () => {
 
   test("deleting the source is refused while a referential fork reads it", async () => {
     const source = await seedSource("Launch");
+    setForkStrategy("reference");
     const fork = await forkConversationForRetrospective({
       conversationId: source.id,
-      forkStrategy: "reference",
     });
 
     expect(listReferentialForkChildren(source.id)).toEqual([fork.id]);
@@ -253,11 +284,24 @@ describe("referential forking", () => {
     ).toHaveLength(0);
   });
 
+  test("the gentle delete path enforces the same guard", async () => {
+    const source = await seedSource("Launch");
+    setForkStrategy("reference");
+    await forkConversationForRetrospective({ conversationId: source.id });
+
+    // `deleteConversationGently` is a separate implementation of the same
+    // operation and is what the plugin facade exposes, so the invariant has to
+    // hold there too or plugins can strip a fork of its history.
+    await expect(deleteConversationGently(source.id)).rejects.toThrow(
+      /referential fork/,
+    );
+  });
+
   test("a cloning fork does not block deleting its source", async () => {
     const source = await seedSource("Launch");
+    setForkStrategy("cloning");
     await forkConversationForRetrospective({
       conversationId: source.id,
-      forkStrategy: "cloning",
     });
 
     expect(listReferentialForkChildren(source.id)).toEqual([]);

--- a/assistant/src/persistence/__tests__/conversation-lineage.test.ts
+++ b/assistant/src/persistence/__tests__/conversation-lineage.test.ts
@@ -136,6 +136,64 @@ describe("resolveConversationLineage", () => {
     expect(segments[2]!.through).toEqual({ createdAt: 400, id: "m4" });
   });
 
+  test("a nested fork tightens ancestor bounds instead of widening them", () => {
+    // C forks B through m2, a row B inherited from A and which sits BEFORE
+    // B's own fork point m4. Carrying B's m4 into A's segment would re-expose
+    // m3 and m4, which C explicitly forked before.
+    const segments = resolveConversationLineage(
+      "c",
+      resolverFor(
+        [referential("c", "b", "m2"), referential("b", "a", "m4"), row("a")],
+        {
+          m2: { createdAt: 200, id: "m2" },
+          m4: { createdAt: 400, id: "m4" },
+        },
+      ),
+    );
+
+    expect(segments).toEqual([
+      { conversationId: "c", through: null },
+      { conversationId: "b", through: { createdAt: 200, id: "m2" } },
+      { conversationId: "a", through: { createdAt: 200, id: "m2" } },
+    ]);
+  });
+
+  test("a nested fork keeps the ancestor's own bound when it is the tighter one", () => {
+    // The mirror case: C forks B through m9, past B's fork point m4, so A's
+    // contribution stays capped at m4 rather than loosening to m9.
+    const segments = resolveConversationLineage(
+      "c",
+      resolverFor(
+        [referential("c", "b", "m9"), referential("b", "a", "m4"), row("a")],
+        {
+          m9: { createdAt: 900, id: "m9" },
+          m4: { createdAt: 400, id: "m4" },
+        },
+      ),
+    );
+
+    expect(segments[2]!.through).toEqual({ createdAt: 400, id: "m4" });
+  });
+
+  test("bounds sharing a millisecond tighten on id", () => {
+    const segments = resolveConversationLineage(
+      "c",
+      resolverFor(
+        [
+          referential("c", "b", "m-aaa"),
+          referential("b", "a", "m-zzz"),
+          row("a"),
+        ],
+        {
+          "m-aaa": { createdAt: 500, id: "m-aaa" },
+          "m-zzz": { createdAt: 500, id: "m-zzz" },
+        },
+      ),
+    );
+
+    expect(segments[2]!.through).toEqual({ createdAt: 500, id: "m-aaa" });
+  });
+
   test("a vanished fork message truncates instead of splicing in all of the parent", () => {
     // Without the bound there is nothing scoping the parent's contribution, so
     // continuing would pull in messages written AFTER the fork was taken.

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -26,7 +26,6 @@ import type { ChannelId, InterfaceId } from "../channels/types.js";
 import { parseChannelId, parseInterfaceId } from "../channels/types.js";
 import { CHANNEL_IDS, isChannelId } from "../channels/types.js";
 import { getConfig } from "../config/loader.js";
-import type { MemoryForkStrategy } from "../config/schemas/memory-retrospective.js";
 import { findDisplayTurnEndIndex } from "../conversations/message-consolidation.js";
 import { findConversation } from "../daemon/conversation-registry.js";
 import { conversationMetadataSyncTag } from "../daemon/message-types/sync.js";
@@ -1727,13 +1726,6 @@ export async function forkConversationForRetrospective(params: {
   title?: string;
   conversationType?: ConversationCreateType;
   groupId?: string;
-  /**
-   * `"reference"` builds the fork referentially: the inherited window stays on
-   * the source and is read through `forkParentMessageId`, so the fork writes
-   * one conversation row and copies no messages or attachments. Defaults to
-   * `memory.retrospective.forkStrategy`.
-   */
-  forkStrategy?: MemoryForkStrategy;
 }): Promise<ConversationRow> {
   const { conversationId, throughMessageId } = params;
   const db = getDb();
@@ -1810,9 +1802,12 @@ export async function forkConversationForRetrospective(params: {
   const hiddenRowIds = new Set(
     loadOrderIds.slice(0, inheritedCompaction?.compactedMessageCount ?? 0),
   );
+  // Read straight from config rather than taking a caller-supplied strategy:
+  // how a fork is materialized is a workspace-wide storage decision, and a
+  // per-call override would let two callers disagree about it on the same
+  // workspace.
   const isReferential =
-    (params.forkStrategy ?? getConfig().memory.retrospective.forkStrategy) ===
-    "reference";
+    getConfig().memory.retrospective.forkStrategy === "reference";
   // A referential fork copies nothing: its inherited window is read back
   // through `forkParentMessageId` by the lineage resolver.
   const rowsToCopy = isReferential
@@ -2010,6 +2005,31 @@ export function listReferentialForkChildren(conversationId: string): string[] {
     .map((row) => row.id);
 }
 
+/**
+ * Refuse to delete a conversation that referential forks read their history
+ * from. Shared by both delete paths: `deleteConversation` and the off-loop
+ * `deleteConversationGently` are separate implementations of the same
+ * operation, so an invariant living in only one of them is enforced only for
+ * whichever callers happen to pick that one.
+ *
+ * Blocking rather than cascading or copying on delete. A referential fork
+ * reads its prefix from this conversation, so deleting it silently truncates
+ * every child; cascading would instead delete conversations the caller never
+ * named. Refusing keeps the destructive choice with the caller, and costs one
+ * indexed lookup on a path already doing far more work.
+ */
+function assertNoReferentialForkChildren(id: string): void {
+  const children = listReferentialForkChildren(id);
+  if (children.length === 0) {
+    return;
+  }
+  throw new UserError(
+    `Conversation ${id} cannot be deleted while ${children.length} ` +
+      `referential fork(s) read their history from it: ` +
+      `${children.join(", ")}. Delete those first.`,
+  );
+}
+
 export function deleteConversation(id: string): DeletedMemoryIds {
   const db = getDb();
   const result: DeletedMemoryIds = {
@@ -2017,19 +2037,7 @@ export function deleteConversation(id: string): DeletedMemoryIds {
     deletedSummaryIds: [],
   };
 
-  // Block rather than cascade or copy-on-delete. A referential fork reads its
-  // prefix from this conversation, so deleting it silently truncates every
-  // child; cascading would instead delete conversations the caller never named.
-  // Refusing keeps the destructive choice with the caller, and costs one
-  // indexed lookup on a path that is already doing far more work.
-  const referentialChildren = listReferentialForkChildren(id);
-  if (referentialChildren.length > 0) {
-    throw new UserError(
-      `Conversation ${id} cannot be deleted while ${referentialChildren.length} ` +
-        `referential fork(s) read their history from it: ` +
-        `${referentialChildren.join(", ")}. Delete those first.`,
-    );
-  }
+  assertNoReferentialForkChildren(id);
 
   // Capture createdAt before the transaction deletes the row — needed to
   // resolve the conversation's disk-view directory path after deletion.
@@ -2140,6 +2148,8 @@ export async function deleteConversationGently(
     segmentIds: [],
     deletedSummaryIds: [],
   };
+
+  assertNoReferentialForkChildren(id);
 
   // Capture createdAt before deletion — needed to resolve the conversation's
   // disk-view directory path afterwards.

--- a/assistant/src/persistence/conversation-lineage.ts
+++ b/assistant/src/persistence/conversation-lineage.ts
@@ -116,6 +116,13 @@ export interface LineageResolverDeps {
  * parent's contribution, so continuing without it would splice in the parent's
  * ENTIRE history, including messages written after the fork was taken. Cutting
  * the lineage short is the conservative direction.
+ *
+ * Bounds TIGHTEN down the chain rather than being replaced. A fork taken
+ * through an inherited message cuts at a point that lies inside its parent's
+ * own inherited window, and each further ancestor must respect that narrower
+ * cut as well as its own: if B reads A through m4 and C reads B through the
+ * inherited m2, then C sees A only through m2. Carrying B's m4 into A's
+ * segment would re-expose m3 and m4, which C explicitly forked before.
  */
 export function resolveConversationLineage(
   conversationId: string,
@@ -125,6 +132,7 @@ export function resolveConversationLineage(
   const visited = new Set<string>([conversationId]);
 
   let current = deps.loadConversation(conversationId);
+  let tightest: LineageBound | null = null;
   while (current !== null && segments.length < MAX_LINEAGE_DEPTH) {
     if (!isReferentialFork(current)) {
       break;
@@ -141,12 +149,21 @@ export function resolveConversationLineage(
     if (parent === null) {
       break;
     }
-    segments.push({ conversationId: parentId, through: bound });
+    tightest = tightest === null ? bound : earlierBound(tightest, bound);
+    segments.push({ conversationId: parentId, through: tightest });
     visited.add(parentId);
     current = parent;
   }
 
   return segments;
+}
+
+/** The earlier of two bounds in `(createdAt, id)` order. */
+function earlierBound(a: LineageBound, b: LineageBound): LineageBound {
+  if (a.createdAt !== b.createdAt) {
+    return a.createdAt < b.createdAt ? a : b;
+  }
+  return a.id <= b.id ? a : b;
 }
 
 /**

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
@@ -413,7 +413,6 @@ export async function runForkBasedRetrospective(
       title: `${sourceConversation.title ?? "Untitled"} (Retrospective)`,
       conversationType: "background",
       groupId: MEMORY_RETROSPECTIVE_GROUP_ID,
-      forkStrategy: config.memory.retrospective.forkStrategy,
     });
   } catch (err) {
     await bumpRetrospectiveLastRunAt(sourceConversationId, Date.now());


### PR DESCRIPTION
Follow-up to #40300, addressing all three review comments.

## Prompt / plan

**Nested referential forks read too much** (Codex P2, real bug). The walk applied each step's own fork-point bound to the ancestor it stepped into, rather than carrying the tightest bound seen so far. Codex's example is exact: if B reads A through `m4` and C reads B through the inherited `m2`, resolving C returned A bounded at `m4`, re-exposing `m3` and `m4` that C had explicitly forked before. Bounds now tighten monotonically down the chain, comparing on `(createdAt, id)` so a same-millisecond pair resolves on id.

Not reachable from the retrospective, which never forks a fork, but it is reachable through UI-driven forks once those move to referential, and it is wrong in the module either way.

**The delete guard covered one of two delete paths** (Codex P2, also real). `deleteConversationGently` is a separate implementation of the same operation and is the one `conversation-plugin-facade.ts` exposes to plugins, so a plugin could delete a parent and leave its referential forks pointing at nothing. Both paths now call a single `assertNoReferentialForkChildren`.

**`forkConversationForRetrospective` no longer takes a strategy parameter** (your comment) and reads `memory.retrospective.forkStrategy` directly. How a fork is materialized is a workspace-wide storage decision, and a per-call override would let two callers disagree about it on the same workspace. The tests now drive config the way the route tests do instead of passing an argument.

## Test plan

- Three new cases in `conversation-lineage.test.ts`: the tightening case from Codex's example, the mirror case where the ancestor's own bound is already tighter and must be kept, and a same-millisecond pair tightening on id.
- New case in `conversation-fork-referential.test.ts` asserting `deleteConversationGently` rejects with the same guard.
- The referential fork suite now sets `memory.retrospective.forkStrategy` through the workspace config rather than a parameter, so it exercises the same read path production uses.
- Regression: the lineage, referential-fork, fork-crud, fork-retrospective, all three conversation-delete suites, the retrospective job/provider-path/wake-chain/startup-cleanup suites, and the config schema suite all pass. `bun run typecheck` clean; prettier and eslint clean.

## Note on the deletion policy

Worth stating plainly since this PR extends its reach: with option (1), a live referential retrospective fork blocks deleting its source conversation. Superseded runs are GC'd by default (`keepSupersededRuns: false`), so the window is short, but a user deleting a chat while a retrospective fork exists will hit the error rather than a silent truncation. That is the intended trade from the proposal, and the message names the blocking fork ids.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCQm4gtVzomviYhiw5qyd8)_