### PR TITLE
refactor(web): migrate the tier picker off the deprecated Dropdown (LUM-2959)

### DIFF
--- a/clients/web/src/domains/channels/components/tier-picker.test.tsx
+++ b/clients/web/src/domains/channels/components/tier-picker.test.tsx
@@ -103,10 +103,10 @@ describe("TierPicker with a resolved default", () => {
       "default",
     );
 
-    // Re-picking the level already shown reports nothing, so this writes
-    // neither call. The cell is already absent here, so the reset it used to
-    // fire was a no-op; Default remains available for the case where it is
-    // not.
+    // A selection matching the displayed level is not reported, so neither
+    // callback runs. Nothing is lost here: the cell is already absent, so a
+    // reset would clear nothing. "Default" covers the case where a cell does
+    // exist.
     fireEvent.click(optionLabeled(options, CONSERVATIVE));
     expect(onReset).not.toHaveBeenCalled();
     expect(onTierChange).not.toHaveBeenCalled();
@@ -146,11 +146,11 @@ describe("TierPicker with an unresolved default (defaultTier null)", () => {
   });
 
   test("re-selecting the current level writes nothing", () => {
-    // It used to re-pin the same value, which changed nothing. Radix reports
-    // no selection when the value already matches, so neither callback runs.
-    // Clearing still goes through the explicit Default entry, which is the
-    // only choice that can mean "follow the default" without guessing at
-    // whether the unresolved default matches this level.
+    // A selection matching the displayed level is not reported, so neither
+    // callback runs. Re-pinning the same value would change nothing anyway.
+    // Clearing goes through the "Default" entry, which is the only choice
+    // that means "follow the default" without guessing at whether the
+    // unresolved default matches this level.
     const { onTierChange, onReset } = renderPicker({ tier: "low" });
     fireEvent.click(optionLabeled(openMenu(), CONSERVATIVE));
     expect(onTierChange).not.toHaveBeenCalled();

--- a/clients/web/src/domains/channels/components/tier-picker.test.tsx
+++ b/clients/web/src/domains/channels/components/tier-picker.test.tsx
@@ -29,10 +29,10 @@ function renderPicker(props: Partial<TierPickerProps> = {}) {
 
 function openMenu(): HTMLElement[] {
   const trigger = document.querySelector<HTMLElement>(
-    '[data-slot="dropdown-trigger"]',
+    '[data-slot="select-trigger"]',
   );
   if (!trigger) {
-    throw new Error("No dropdown trigger rendered");
+    throw new Error("No select trigger rendered");
   }
   fireEvent.click(trigger);
   return Array.from(document.querySelectorAll<HTMLElement>('[role="option"]'));
@@ -52,16 +52,31 @@ afterEach(() => {
 });
 
 describe("TierPicker with a resolved default", () => {
-  test("marks the default level and offers no separate Default entry", () => {
+  test("marks the default level and still offers a Default entry", () => {
     renderPicker({ defaultTier: "low" });
     const options = openMenu();
-    expect(options).toHaveLength(2);
+    expect(options).toHaveLength(3);
     expect(optionLabeled(options, CONSERVATIVE).textContent).toContain(
       "default",
     );
+    // Offered even with the default resolved. Radix reports no selection
+    // when the chosen value already matches the shown one, so this row is
+    // the only way to clear a cell pinned to the default's own level.
     expect(
       options.some((el) => el.textContent?.startsWith("Default")),
-    ).toBeFalse();
+    ).toBeTrue();
+  });
+
+  test("a cell pinned to the default's own level can still be cleared", () => {
+    // The state with no way out otherwise: the trigger shows Conservative
+    // either way, so re-picking it reports nothing.
+    const { onTierChange, onReset } = renderPicker({
+      tier: "low",
+      defaultTier: "low",
+    });
+    fireEvent.click(optionLabeled(openMenu(), "Default"));
+    expect(onReset).toHaveBeenCalledTimes(1);
+    expect(onTierChange).not.toHaveBeenCalled();
   });
 
   test("selecting the default-marked level resets instead of pinning", () => {
@@ -87,8 +102,13 @@ describe("TierPicker with a resolved default", () => {
     expect(optionLabeled(options, CONSERVATIVE).textContent).toContain(
       "default",
     );
+
+    // Re-picking the level already shown reports nothing, so this writes
+    // neither call. The cell is already absent here, so the reset it used to
+    // fire was a no-op; Default remains available for the case where it is
+    // not.
     fireEvent.click(optionLabeled(options, CONSERVATIVE));
-    expect(onReset).toHaveBeenCalledTimes(1);
+    expect(onReset).not.toHaveBeenCalled();
     expect(onTierChange).not.toHaveBeenCalled();
   });
 });
@@ -125,14 +145,15 @@ describe("TierPicker with an unresolved default (defaultTier null)", () => {
     expect(onReset).not.toHaveBeenCalled();
   });
 
-  test("re-selecting the current level pins rather than guessing a reset", () => {
-    // The picker cannot know whether the unresolved default matches the
-    // current level, and clearing the cell on a guess could silently change
-    // effective access once the default resolves. Only the explicit Default
-    // entry resets.
+  test("re-selecting the current level writes nothing", () => {
+    // It used to re-pin the same value, which changed nothing. Radix reports
+    // no selection when the value already matches, so neither callback runs.
+    // Clearing still goes through the explicit Default entry, which is the
+    // only choice that can mean "follow the default" without guessing at
+    // whether the unresolved default matches this level.
     const { onTierChange, onReset } = renderPicker({ tier: "low" });
     fireEvent.click(optionLabeled(openMenu(), CONSERVATIVE));
-    expect(onTierChange).toHaveBeenCalledWith("low");
+    expect(onTierChange).not.toHaveBeenCalled();
     expect(onReset).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/channels/components/tier-picker.tsx
+++ b/clients/web/src/domains/channels/components/tier-picker.tsx
@@ -33,11 +33,10 @@ export interface TierPickerProps {
   /** The persisted tier for this scope, or `undefined` when it follows the default. */
   tier: RiskThreshold | undefined;
   /**
-   * The tier this scope falls through to when it has no cell of its own — the
+   * The tier this scope falls through to when it has no cell of its own: the
    * level shown with a muted "default" marker. `null` while still unknown, in
-   * which case no level is marked, the trigger shows a "Default" placeholder,
-   * and the menu carries an explicit "Default" entry so {@link onReset} stays
-   * reachable.
+   * which case no level carries the marker and the trigger shows a "Default"
+   * placeholder.
    */
   defaultTier: RiskThreshold | null;
   disabled?: boolean;
@@ -50,23 +49,26 @@ export interface TierPickerProps {
 
 /**
  * The compact Assistant Access picker shared by the per-channel rows and the
- * channel-type default rows. Lists {@link CHANNEL_TIER_VALUES} only — no
- * separate "Default" option: the level equal to the resolved default carries a
- * muted "default" marker, selecting it clears this scope's cell (follow the
- * default), and selecting any other level pins an override. This keeps "follow
- * the default" and "pick the level it resolves to" the same choice, and is safe
- * because resolution is most-specific-wins and value-only (see
- * `slack-channel-overrides` and the gateway's `ChannelPermissionStore.resolve`).
+ * channel-type default rows.
+ *
+ * The menu carries a leading "Default" entry that clears this scope's cell,
+ * plus one row per {@link CHANNEL_TIER_VALUES} level. The level the default
+ * resolves to also carries a muted "default" marker, and selecting it clears
+ * the cell too: "follow the default" and "pick the level it resolves to" are
+ * the same choice, which is safe because resolution is most-specific-wins and
+ * value-only (see `slack-channel-overrides` and the gateway's
+ * `ChannelPermissionStore.resolve`).
+ *
+ * The "Default" entry is the only choice that means "follow the default"
+ * without naming a level. It is the sole route out of a cell pinned to the
+ * level the default already resolves to: that cell renders identically to an
+ * absent one, and `Select` reports no selection when the chosen value matches
+ * the value already shown, so re-picking the level cannot clear it. The entry
+ * is also what keeps {@link onReset} reachable while `defaultTier` is null and
+ * no level carries the marker.
  *
  * A stored `medium`/`high` cell is shown as the level it behaves as, so the
  * picker never displays a level it cannot offer.
- *
- * While the default is unresolved (`defaultTier` null) no level can carry the
- * marker, and the picker cannot tell which level the default resolves to, so
- * selecting a level always pins it. The menu instead carries an explicit
- * "Default" entry that clears this scope's cell: the one selection that means
- * "follow the default" without guessing at a level, keeping {@link onReset}
- * reachable in this state.
  */
 export function TierPicker({
   tier,
@@ -90,11 +92,10 @@ export function TierPicker({
       tooltip: CAPABILITY_TIER_META[value].sublabel,
     }),
   );
-  // Always offered, not just when the default is unresolved. Radix reports
-  // no selection when the chosen value already matches the one shown, so a
-  // cell pinned to the level the default resolves to cannot be cleared by
-  // re-picking that level: without this row there is no way out of that
-  // state at all.
+  // The only choice that clears the cell without naming a level, and the sole
+  // route out of a cell pinned to the level the default resolves to: that
+  // cell looks identical to an absent one, and a selection matching the
+  // displayed value is not reported.
   options.unshift({
     value: DEFAULT_ENTRY,
     label: "Default",
@@ -106,15 +107,10 @@ export function TierPicker({
   const handleChange = (next: TierOptionValue) => {
     // Picking the level the default resolves to means "follow the default",
     // which is the absence of a cell: clear it rather than pinning an equal
-    // one. The explicit "Default" entry is that same choice for when the
-    // default is unresolved and no level carries the marker.
-    //
-    // Radix does not report a selection that matches the value already shown,
-    // so re-picking the displayed level is inert. Every case that reaches is
-    // a no-op anyway except one: a cell pinned to the level the default
-    // already resolves to no longer clears itself. Both states render
-    // identically, so nothing the user can see changes; the cell just stays
-    // pinned if the default later moves.
+    // one. The "Default" entry is that same choice, and the only one
+    // available when a selection matching the displayed value goes
+    // unreported. `onReset` is safe to call on a scope with no cell: both
+    // call sites skip the round-trip when nothing is persisted.
     if (next === DEFAULT_ENTRY || next === shownDefault) {
       onReset();
     } else {

--- a/clients/web/src/domains/channels/components/tier-picker.tsx
+++ b/clients/web/src/domains/channels/components/tier-picker.tsx
@@ -1,7 +1,7 @@
 import {
-  Dropdown,
-  type DropdownOption,
-} from "@vellumai/design-library/components/dropdown";
+  Select,
+  type SelectOption,
+} from "@vellumai/design-library/components/select";
 
 import {
   CAPABILITY_TIER_META,
@@ -78,7 +78,7 @@ export function TierPicker({
 }: TierPickerProps) {
   const effectiveTier = channelTierBehavesAs(tier ?? defaultTier ?? undefined);
   const shownDefault = channelTierBehavesAs(defaultTier ?? undefined) ?? null;
-  const options: DropdownOption<TierOptionValue>[] = CHANNEL_TIER_VALUES.map(
+  const options: SelectOption<TierOptionValue>[] = CHANNEL_TIER_VALUES.map(
     (value) => ({
       value,
       label: CAPABILITY_TIER_META[value].label,
@@ -90,21 +90,31 @@ export function TierPicker({
       tooltip: CAPABILITY_TIER_META[value].sublabel,
     }),
   );
-  if (shownDefault === null) {
-    options.unshift({
-      value: DEFAULT_ENTRY,
-      label: "Default",
-      // Invisible dot so the label aligns with the level rows.
-      icon: <TierDot color="transparent" />,
-      tooltip: "follows the default level",
-    });
-  }
+  // Always offered, not just when the default is unresolved. Radix reports
+  // no selection when the chosen value already matches the one shown, so a
+  // cell pinned to the level the default resolves to cannot be cleared by
+  // re-picking that level: without this row there is no way out of that
+  // state at all.
+  options.unshift({
+    value: DEFAULT_ENTRY,
+    label: "Default",
+    // Invisible dot so the label aligns with the level rows.
+    icon: <TierDot color="transparent" />,
+    tooltip: "follows the default level",
+  });
 
   const handleChange = (next: TierOptionValue) => {
     // Picking the level the default resolves to means "follow the default",
     // which is the absence of a cell: clear it rather than pinning an equal
     // one. The explicit "Default" entry is that same choice for when the
     // default is unresolved and no level carries the marker.
+    //
+    // Radix does not report a selection that matches the value already shown,
+    // so re-picking the displayed level is inert. Every case that reaches is
+    // a no-op anyway except one: a cell pinned to the level the default
+    // already resolves to no longer clears itself. Both states render
+    // identically, so nothing the user can see changes; the cell just stays
+    // pinned if the default later moves.
     if (next === DEFAULT_ENTRY || next === shownDefault) {
       onReset();
     } else {
@@ -113,7 +123,7 @@ export function TierPicker({
   };
 
   return (
-    <Dropdown<TierOptionValue>
+    <Select<TierOptionValue>
       value={effectiveTier ?? ""}
       onChange={handleChange}
       options={options}


### PR DESCRIPTION
## TL;DR

Moves the channel Assistant Access picker off the deprecated `Dropdown` onto `Select`, and makes "follow the default" reachable from every scope.

Part of [LUM-2959](https://linear.app/vellum/issue/LUM-2959).

## What the user hits today

Each channel row and channel-type row picks an access level. A row either pins a level or follows the default, and both render as the same level on the trigger, because a row following a `low` default and a row pinned to `low` behave identically.

Clearing a pin was done by picking the level the default resolves to. That worked because the old control fired its change callback on every click, including a click on the value already shown.

`Select` reports a selection only when the value actually changes. So on a row pinned to the level its default already resolves to, clicking that level does nothing, and the "Default" row that would clear it was only rendered when the default was **unresolved**. That combination leaves the row with no way back to following the default.

## What changes for the user

| Before | After |
| --- | --- |
| "Default" appeared only while the default was still loading | Always in the menu, so "follow the default" is always one click |
| A row pinned to its default's own level could be cleared by re-picking that level | Cleared with the "Default" row |
| Menus could not flip upward, so a picker low in the page opened below the fold | Menu flips and shifts to stay on screen |
| Menus mispositioned inside a transformed ancestor | Positioned correctly |
| A screen reader could arrow off an open menu into covered page content | The page leaves the accessibility tree while the menu is open |

The trigger still shows the level the row behaves as, and the muted `default` marker still sits on the level the default resolves to. Nothing about the displayed state changes.

## Why this is safe

- **Clearing is idempotent.** Picking "Default" on a row that already follows it calls `onReset`, and both call sites return before any mutation when nothing is persisted (`use-channel-permission-overrides.ts`). No request, no pending state, no error surface.
- **Pinning is unchanged.** Picking any level other than the one displayed is a real change and reports normally.
- **Resolution is untouched.** Most-specific-wins and value-only, as before; this only changes which choices the menu offers.
- The one case where behaviour differs is a row pinned to the level its default already resolves to. Both states render identically, so nothing visible changes; the row simply stays pinned if the default later moves, and the "Default" row clears it.

## Tests

Selectors move from the `dropdown-*` data-slots to `select-*`.

Three tests asserted that re-picking the displayed level fired a callback. They now assert it writes nothing, with the reasoning recorded. A fourth covers a row pinned to its default's own level being cleared through "Default", which is the state this change exists for and which nothing exercised before.

Verified by making the "Default" row conditional again: both new assertions fail. Six channels suites pass, typecheck and lint clean.
