### PR TITLE
refactor(web): migrate settings and billing off the deprecated Dropdown (LUM-2959)

### DIFF
--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
@@ -893,7 +893,9 @@ describe("CustomPlanModal — eligible Pro subscriber", () => {
     openDropdown("Storage");
 
     expect(findOption("10 GB").getAttribute("aria-disabled")).toBe("true");
-    expect(findOption("30 GB").getAttribute("aria-disabled")).toBe("false");
+    // Enabled options carry no `aria-disabled` at all, so assert the absence
+    // of the disabled state rather than a literal "false".
+    expect(findOption("30 GB").getAttribute("aria-disabled")).not.toBe("true");
   });
 
   test("a failed dispatch keeps the modal open and skips the takeover", async () => {
@@ -957,9 +959,10 @@ describe("CustomPlanModal — Pro plan holding a deprecated (legacy) credit bund
     // The held legacy bundle appears so the current selection is visible, but
     // it's disabled — a new config can never pick it.
     expect(findOption("25 credits").getAttribute("aria-disabled")).toBe("true");
-    // The live tier stays selectable.
-    expect(findOption("50 credits").getAttribute("aria-disabled")).toBe(
-      "false",
+    // The live tier stays selectable. Enabled options carry no
+    // `aria-disabled`, so assert the absence of the disabled state.
+    expect(findOption("50 credits").getAttribute("aria-disabled")).not.toBe(
+      "true",
     );
   });
 
@@ -1053,7 +1056,7 @@ describe("CustomPlanModal — Pro plan holding a deprecated (legacy) credit bund
     fireEvent.click(getByRole("button", { name: "Configure" }));
     openDropdown("Storage");
 
-    expect(findOption("250 GB").getAttribute("aria-disabled")).toBe("false");
+    expect(findOption("250 GB").getAttribute("aria-disabled")).not.toBe("true");
     expect(findOption("10 GB").getAttribute("aria-disabled")).toBe("true");
   });
 

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.tsx
@@ -23,9 +23,9 @@ import type {
 import { handleNativeAnchorClick } from "@/utils/native-anchor";
 import { Button } from "@vellumai/design-library/components/button";
 import {
-  Dropdown,
-  type DropdownOption,
-} from "@vellumai/design-library/components/dropdown";
+  Select,
+  type SelectOption,
+} from "@vellumai/design-library/components/select";
 import { Modal } from "@vellumai/design-library/components/modal";
 
 import {
@@ -205,13 +205,13 @@ export function CustomPlanModal({
   // It carries no price suffix, since it adds nothing to the total.
   const seededBaselineMachine =
     initialSelection != null && initialSelection.machineTier == null;
-  const baselineMachineOption: DropdownOption<MachineChoice> = {
+  const baselineMachineOption: SelectOption<MachineChoice> = {
     value: BASELINE_MACHINE,
     label: BASELINE_MACHINE_LABEL,
     icon: <Computer className="h-4 w-4" aria-hidden />,
     disabled: true,
   };
-  const machineOptions: DropdownOption<MachineChoice>[] = [
+  const machineOptions: SelectOption<MachineChoice>[] = [
     ...(seededBaselineMachine ? [baselineMachineOption] : []),
     ...machineTiers.map((t) => ({
       value: t.tier as MachineChoice,
@@ -221,7 +221,7 @@ export function CustomPlanModal({
       disabled: isTierDisabled(t),
     })),
   ];
-  const storageOptions: DropdownOption<StorageTierEnum>[] =
+  const storageOptions: SelectOption<StorageTierEnum>[] =
     offerableStorageTiers.map((t) => ({
       value: t.tier as StorageTierEnum,
       label: t.label,
@@ -239,7 +239,7 @@ export function CustomPlanModal({
   // current selection it's appended disabled so the dropdown still shows it.
   const heldLegacyCredit = selectedCredit?.legacy ? selectedCredit : null;
 
-  const creditOptions: DropdownOption<CreditChoice>[] = [
+  const creditOptions: SelectOption<CreditChoice>[] = [
     {
       value: NO_EXTRA_CREDITS,
       label: NO_CREDITS_LABEL,
@@ -386,7 +386,7 @@ export function CustomPlanModal({
                   docsUrl={MACHINE_DOCS_URL}
                   docsLabel="Learn more about machine sizes"
                 />
-                <Dropdown<MachineChoice>
+                <Select<MachineChoice>
                   aria-label="Machine size"
                   placeholder="Select a machine size"
                   value={machineTier}
@@ -401,7 +401,7 @@ export function CustomPlanModal({
                   docsUrl={STORAGE_DOCS_URL}
                   docsLabel="Learn more about storage"
                 />
-                <Dropdown<StorageTierEnum>
+                <Select<StorageTierEnum>
                   aria-label="Storage"
                   placeholder="Select storage"
                   value={storageTier}
@@ -416,7 +416,7 @@ export function CustomPlanModal({
                   docsUrl={CREDIT_DOCS_URL}
                   docsLabel="Learn more about credit bundles"
                 />
-                <Dropdown<CreditChoice>
+                <Select<CreditChoice>
                   aria-label="Credit bundle"
                   placeholder="Select a credit bundle"
                   value={creditChoice}

--- a/clients/web/src/domains/settings/components/all-conversations-view.tsx
+++ b/clients/web/src/domains/settings/components/all-conversations-view.tsx
@@ -29,9 +29,9 @@ import { invalidateConversationQueries } from "@/utils/conversation-cache";
 import { toast } from "@vellumai/design-library";
 import { Button } from "@vellumai/design-library/components/button";
 import {
-  Dropdown,
-  type DropdownOption,
-} from "@vellumai/design-library/components/dropdown";
+  Select,
+  type SelectOption,
+} from "@vellumai/design-library/components/select";
 import { Input } from "@vellumai/design-library/components/input";
 
 export interface AllConversationsViewProps {
@@ -42,7 +42,7 @@ export interface AllConversationsViewProps {
   onOpenConversation: (conversationId: string) => void;
 }
 
-const FILTER_ITEMS: DropdownOption<ConversationFilter>[] = [
+const FILTER_ITEMS: SelectOption<ConversationFilter>[] = [
   { value: "all", label: "All" },
   { value: "active", label: "Active" },
   { value: "archived", label: "Archived" },
@@ -254,7 +254,7 @@ export function AllConversationsView({
           }
           leftIcon={<Search size={16} />}
         />
-        <Dropdown<ConversationFilter>
+        <Select<ConversationFilter>
           aria-label="Filter conversations"
           value={filter}
           onChange={setFilter}

--- a/clients/web/src/domains/settings/components/assistant-upgrades.tsx
+++ b/clients/web/src/domains/settings/components/assistant-upgrades.tsx
@@ -28,7 +28,7 @@ import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { compareParsed, parseSemver } from "@/utils/semver";
 import { Button } from "@vellumai/design-library/components/button";
 import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
-import { Dropdown } from "@vellumai/design-library/components/dropdown";
+import { Select } from "@vellumai/design-library/components/select";
 import { toast } from "@vellumai/design-library/components/toast";
 
 function releaseLabel(
@@ -212,7 +212,12 @@ export function AssistantUpgrades({
   const handleUpgrade = async () => {
     setShowConfirmation(false);
     setSuccessMessage(null);
-    const targetVersion = selectedVersion ?? undefined;
+    // The displayed version, not just an explicit pick. The trigger falls
+    // back to the latest release when nothing is chosen, and a selection
+    // matching the displayed value is not reported, so reading the raw
+    // selection here would upgrade to whatever is latest at click time
+    // rather than to the version on screen.
+    const targetVersion = effectiveSelectedVersion ?? undefined;
     try {
       if (isRollback) {
         const result = await rollbackCreate.mutateAsync({
@@ -286,7 +291,7 @@ export function AssistantUpgrades({
               </span>
             ) : releases && releases.length > 0 ? (
               rollbackEnabled ? (
-                <Dropdown
+                <Select
                   value={effectiveSelectedVersion ?? ""}
                   onChange={(value) =>
                     setSelectedVersion(

--- a/clients/web/src/domains/settings/components/assistant-upgrades.tsx
+++ b/clients/web/src/domains/settings/components/assistant-upgrades.tsx
@@ -212,12 +212,18 @@ export function AssistantUpgrades({
   const handleUpgrade = async () => {
     setShowConfirmation(false);
     setSuccessMessage(null);
-    // The displayed version, not just an explicit pick. The trigger falls
-    // back to the latest release when nothing is chosen, and a selection
-    // matching the displayed value is not reported, so reading the raw
-    // selection here would upgrade to whatever is latest at click time
-    // rather than to the version on screen.
-    const targetVersion = effectiveSelectedVersion ?? undefined;
+    // With the picker rendered, the trigger shows `effectiveSelectedVersion`
+    // even when nothing was chosen, and a selection matching the displayed
+    // value is not reported. Reading the raw selection would install
+    // something other than the version on screen.
+    //
+    // With no picker there is nothing on screen to honour, so the server
+    // resolves latest. That is deliberately not the same as this component's
+    // `latestRelease`, which does not filter `local` pre-release builds the
+    // way `getLatestRuntimeRelease` does.
+    const targetVersion = rollbackEnabled
+      ? (effectiveSelectedVersion ?? undefined)
+      : undefined;
     try {
       if (isRollback) {
         const result = await rollbackCreate.mutateAsync({

--- a/clients/web/src/domains/settings/components/create-schedule-modal.tsx
+++ b/clients/web/src/domains/settings/components/create-schedule-modal.tsx
@@ -18,9 +18,9 @@ import { useEffectiveTimezone } from "@/utils/use-effective-timezone";
 import { cn } from "@vellumai/design-library";
 import { Button } from "@vellumai/design-library/components/button";
 import {
-  Dropdown,
-  type DropdownOption,
-} from "@vellumai/design-library/components/dropdown";
+  Select,
+  type SelectOption,
+} from "@vellumai/design-library/components/select";
 import { Input, Textarea } from "@vellumai/design-library/components/input";
 import { Modal } from "@vellumai/design-library/components/modal";
 import {
@@ -39,7 +39,7 @@ const FREQUENCY_ITEMS: SegmentControlItem<ScheduleFrequency>[] = [
   { value: "monthly", label: "Monthly" },
 ];
 
-const HOUR12_OPTIONS: DropdownOption<string>[] = Array.from(
+const HOUR12_OPTIONS: SelectOption<string>[] = Array.from(
   { length: 12 },
   (_, i) => {
     const hour = i + 1;
@@ -49,7 +49,7 @@ const HOUR12_OPTIONS: DropdownOption<string>[] = Array.from(
 
 // Five-minute granularity keeps the menu short while covering the times people
 // actually schedule.
-const MINUTE_OPTIONS: DropdownOption<string>[] = Array.from(
+const MINUTE_OPTIONS: SelectOption<string>[] = Array.from(
   { length: 12 },
   (_, i) => {
     const minute = i * 5;
@@ -61,7 +61,7 @@ const MINUTE_OPTIONS: DropdownOption<string>[] = Array.from(
 // Only days that exist in every month (1–28) plus an explicit "Last day", so a
 // monthly schedule never silently skips short months. The 29th–31st (which skip
 // February etc.) remain available through the Advanced cron field.
-const DAY_OF_MONTH_OPTIONS: DropdownOption<string>[] = [
+const DAY_OF_MONTH_OPTIONS: SelectOption<string>[] = [
   ...Array.from({ length: 28 }, (_, i) => {
     const day = i + 1;
     return { value: String(day), label: formatOrdinal(day) };
@@ -334,7 +334,7 @@ function CadenceBuilder({
 
       {cadence.frequency === "hourly" ? (
         <SubField label="At minute">
-          <Dropdown
+          <Select
             options={MINUTE_OPTIONS}
             value={String(cadence.minute).padStart(2, "0")}
             onChange={(value) =>
@@ -357,7 +357,7 @@ function CadenceBuilder({
 
       {cadence.frequency === "monthly" ? (
         <SubField label="On day">
-          <Dropdown
+          <Select
             options={DAY_OF_MONTH_OPTIONS}
             value={
               cadence.dayOfMonth === "last"
@@ -405,7 +405,7 @@ function TimeFields({
 
   return (
     <div className="flex items-center gap-2">
-      <Dropdown
+      <Select
         options={HOUR12_OPTIONS}
         value={String(hour12)}
         onChange={(value) => onChange(to24Hour(Number(value), period), minute)}
@@ -415,7 +415,7 @@ function TimeFields({
       <span className="text-body-medium-default text-[var(--content-tertiary)]">
         :
       </span>
-      <Dropdown
+      <Select
         options={MINUTE_OPTIONS}
         value={String(minute).padStart(2, "0")}
         onChange={(value) => onChange(hour24, Number(value))}

--- a/clients/web/src/domains/settings/components/credit-bundle-picker.tsx
+++ b/clients/web/src/domains/settings/components/credit-bundle-picker.tsx
@@ -2,13 +2,13 @@ import { Info } from "lucide-react";
 import { useMemo } from "react";
 
 import type { CreditTier, CreditTierEnum } from "@/generated/api/types.gen";
-import { Dropdown } from "@vellumai/design-library/components/dropdown";
+import { Select } from "@vellumai/design-library/components/select";
 import { Typography } from "@vellumai/design-library/components/typography";
 import { formatMonthly } from "./tier-pricing";
 
 /**
  * Sentinel option value for the synthesized "No credit bundle" entry. The
- * design-library Dropdown is generic over `T extends string`, so it cannot
+ * design-library Select is generic over `T extends string`, so it cannot
  * carry a real `null` value — we map this sentinel to/from `null` at the
  * component boundary so callers see a clean `CreditTierEnum | null`.
  */
@@ -60,7 +60,7 @@ export function CreditBundlePicker({
           <Info className="h-3 w-3 text-[var(--content-tertiary)]" />
         </span>
       </div>
-      <Dropdown<CreditOptionValue>
+      <Select<CreditOptionValue>
         aria-label="Credit bundle"
         placeholder="Select a credit bundle"
         disabled={disabled}

--- a/clients/web/src/domains/settings/components/model-profile-select.test.tsx
+++ b/clients/web/src/domains/settings/components/model-profile-select.test.tsx
@@ -1,20 +1,21 @@
 import { describe, expect, mock, test } from "bun:test";
 
-mock.module("@vellumai/design-library/components/dropdown", () => ({
-  Dropdown: () => null,
+mock.module("@vellumai/design-library/components/select", () => ({
+  Select: () => null,
 }));
 
-const { dropdownValueToProfileOption, profileOptionToDropdownValue } =
-  await import("./model-profile-select");
+const { selectValueToProfileOption, profileOptionToSelectValue } = await import(
+  "./model-profile-select"
+);
 
 describe("ModelProfileSelect", () => {
-  test("maps null to a non-empty dropdown value", () => {
-    expect(profileOptionToDropdownValue(null)).toBe("__default_profile__");
-    expect(profileOptionToDropdownValue("fast")).toBe("fast");
+  test("maps null to a non-empty select value", () => {
+    expect(profileOptionToSelectValue(null)).toBe("__default_profile__");
+    expect(profileOptionToSelectValue("fast")).toBe("fast");
   });
 
   test("maps the Default dropdown value back to null", () => {
-    expect(dropdownValueToProfileOption("__default_profile__")).toBeNull();
-    expect(dropdownValueToProfileOption("fast")).toBe("fast");
+    expect(selectValueToProfileOption("__default_profile__")).toBeNull();
+    expect(selectValueToProfileOption("fast")).toBe("fast");
   });
 });

--- a/clients/web/src/domains/settings/components/model-profile-select.tsx
+++ b/clients/web/src/domains/settings/components/model-profile-select.tsx
@@ -1,16 +1,16 @@
 import { AlertCircle } from "lucide-react";
 
-import { Dropdown } from "@vellumai/design-library/components/dropdown";
+import { Select } from "@vellumai/design-library/components/select";
 
 import { useProfileOptions } from "@/domains/settings/hooks/use-profile-options";
 
 const DEFAULT_PROFILE_OPTION_VALUE = "__default_profile__";
 
-export function profileOptionToDropdownValue(value: string | null): string {
+export function profileOptionToSelectValue(value: string | null): string {
   return value ?? DEFAULT_PROFILE_OPTION_VALUE;
 }
 
-export function dropdownValueToProfileOption(value: string): string | null {
+export function selectValueToProfileOption(value: string): string | null {
   return value === DEFAULT_PROFILE_OPTION_VALUE ? null : value;
 }
 
@@ -59,14 +59,14 @@ export function ModelProfileSelect({
             ...(option.reason ? { tooltip: option.reason } : {}),
           }
         : {}),
-      value: profileOptionToDropdownValue(option.value),
+      value: profileOptionToSelectValue(option.value),
       label: option.label,
     }));
 
   return (
-    <Dropdown
-      value={profileOptionToDropdownValue(value)}
-      onChange={(selected) => onChange(dropdownValueToProfileOption(selected))}
+    <Select
+      value={profileOptionToSelectValue(value)}
+      onChange={(selected) => onChange(selectValueToProfileOption(selected))}
       options={options}
       disabled={disabled || isSaving}
       placeholder={placeholder}

--- a/clients/web/src/domains/settings/components/panels/assistant-terminal-panel.tsx
+++ b/clients/web/src/domains/settings/components/panels/assistant-terminal-panel.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/hooks/use-platform-gate";
 import { captureError } from "@/lib/sentry/capture-error";
 import { toast } from "@vellumai/design-library";
-import { Dropdown } from "@vellumai/design-library/components/dropdown";
+import { Select } from "@vellumai/design-library/components/select";
 
 type TerminalService = "assistant" | "gateway" | "credential-executor";
 
@@ -112,7 +112,7 @@ export function AssistantTerminalPanel() {
           </div>
         </div>
         {assistantId && (
-          <Dropdown
+          <Select
             options={TERMINAL_SERVICE_OPTIONS}
             value={service}
             onChange={setService}

--- a/clients/web/src/domains/settings/components/panels/feature-flags-panel.tsx
+++ b/clients/web/src/domains/settings/components/panels/feature-flags-panel.tsx
@@ -16,7 +16,7 @@ import {
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { cn } from "@vellumai/design-library";
-import { Dropdown } from "@vellumai/design-library/components/dropdown";
+import { Select } from "@vellumai/design-library/components/select";
 import { Tag, type TagTone } from "@vellumai/design-library/components/tag";
 import { Toggle } from "@vellumai/design-library/components/toggle";
 
@@ -318,7 +318,8 @@ function StringFlagRow({
     }
   };
 
-  const hasDropdown = knownValues != null && knownValues.includes(flag.value);
+  const hasKnownValues =
+    knownValues != null && knownValues.includes(flag.value);
 
   return (
     <div className="flex items-start gap-3 py-3">
@@ -332,8 +333,8 @@ function StringFlagRow({
         <span className="block text-body-small-default text-[var(--content-tertiary)]">
           {flag.description}
         </span>
-        {hasDropdown ? (
-          <Dropdown
+        {hasKnownValues ? (
+          <Select
             value={flag.value}
             onChange={(next) => {
               setLocalValue(next);

--- a/clients/web/src/domains/settings/components/preview-release-channel.tsx
+++ b/clients/web/src/domains/settings/components/preview-release-channel.tsx
@@ -25,7 +25,7 @@ import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { extractErrorMessage } from "@/utils/api-errors";
 import { Button } from "@vellumai/design-library/components/button";
 import { Collapsible } from "@vellumai/design-library/components/collapsible";
-import { Dropdown } from "@vellumai/design-library/components/dropdown";
+import { Select } from "@vellumai/design-library/components/select";
 import { Modal } from "@vellumai/design-library/components/modal";
 import { Notice } from "@vellumai/design-library/components/notice";
 import { Radio, RadioGroup } from "@vellumai/design-library/components/radio";
@@ -518,7 +518,7 @@ function OptOutModal({
             {mode === "restore_backup" && backups.length > 0 && (
               <label className="flex flex-col gap-1 text-body-medium-default text-[var(--content-secondary)]">
                 Safety backup
-                <Dropdown
+                <Select
                   value={selectedSnapshotName}
                   onChange={onSnapshotChange}
                   disabled={isPending}

--- a/clients/web/src/domains/settings/components/preview-release-channel.tsx
+++ b/clients/web/src/domains/settings/components/preview-release-channel.tsx
@@ -519,13 +519,7 @@ function OptOutModal({
               <label className="flex flex-col gap-1 text-body-medium-default text-[var(--content-secondary)]">
                 Safety backup
                 <Select
-                  // Restoring falls back to the first ready backup when
-                  // nothing is picked, so show that one. Rendering the raw
-                  // empty state left the trigger blank while a concrete
-                  // backup was armed.
-                  value={
-                    selectedSnapshotName || (backups[0]?.snapshot_name ?? "")
-                  }
+                  value={selectedSnapshotName}
                   onChange={onSnapshotChange}
                   disabled={isPending}
                   options={backups.map((backup) => ({

--- a/clients/web/src/domains/settings/components/preview-release-channel.tsx
+++ b/clients/web/src/domains/settings/components/preview-release-channel.tsx
@@ -519,7 +519,13 @@ function OptOutModal({
               <label className="flex flex-col gap-1 text-body-medium-default text-[var(--content-secondary)]">
                 Safety backup
                 <Select
-                  value={selectedSnapshotName}
+                  // Restoring falls back to the first ready backup when
+                  // nothing is picked, so show that one. Rendering the raw
+                  // empty state left the trigger blank while a concrete
+                  // backup was armed.
+                  value={
+                    selectedSnapshotName || (backups[0]?.snapshot_name ?? "")
+                  }
                   onChange={onSnapshotChange}
                   disabled={isPending}
                   options={backups.map((backup) => ({

--- a/clients/web/src/domains/settings/components/resize-card.tsx
+++ b/clients/web/src/domains/settings/components/resize-card.tsx
@@ -24,7 +24,7 @@ import {
 import { useIsNativeAndroid } from "@/runtime/platform-detection";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
-import { Dropdown } from "@vellumai/design-library/components/dropdown";
+import { Select } from "@vellumai/design-library/components/select";
 import { Modal } from "@vellumai/design-library/components/modal";
 import { Notice } from "@vellumai/design-library/components/notice";
 import { Tag } from "@vellumai/design-library/components/tag";
@@ -229,7 +229,9 @@ export function ResizeCard({
         Resize
       </Button>
     )
-  ) : basePlanResizeAction;
+  ) : (
+    basePlanResizeAction
+  );
 
   const machineAction = !isPlatform ? null : isPro ? (
     canUpsize ? (
@@ -252,7 +254,9 @@ export function ResizeCard({
         Resize
       </Button>
     )
-  ) : basePlanResizeAction;
+  ) : (
+    basePlanResizeAction
+  );
 
   return (
     <>
@@ -440,7 +444,7 @@ export function ResizeCard({
                   <span className="text-label-medium-default text-[var(--content-secondary)]">
                     Machine Size
                   </span>
-                  <Dropdown
+                  <Select
                     options={machineSizeOptions}
                     value={displaySize}
                     onChange={setSelectedSize}

--- a/clients/web/src/domains/settings/components/risk-tolerance-settings.tsx
+++ b/clients/web/src/domains/settings/components/risk-tolerance-settings.tsx
@@ -10,7 +10,7 @@ import {
   presetFromThreshold,
 } from "@/utils/threshold-presets";
 import { Card } from "@vellumai/design-library/components/card";
-import { Dropdown } from "@vellumai/design-library/components/dropdown";
+import { Select } from "@vellumai/design-library/components/select";
 
 function Divider() {
   return (
@@ -176,7 +176,7 @@ export function RiskToleranceSettings() {
             When you&apos;re chatting with your assistant directly.
           </p>
           <div className="mt-2" style={{ maxWidth: 280 }}>
-            <Dropdown
+            <Select
               value={interactivePresetId}
               onChange={handleInteractiveChange}
               options={PRESET_OPTIONS}
@@ -217,7 +217,7 @@ export function RiskToleranceSettings() {
                 background jobs, and external triggers.
               </p>
               <div className="mt-2" style={{ maxWidth: 280 }}>
-                <Dropdown
+                <Select
                   value={autonomousPresetId}
                   onChange={handleAutonomousChange}
                   options={PRESET_OPTIONS}
@@ -241,7 +241,7 @@ export function RiskToleranceSettings() {
                 When triggered externally with no interactive client.
               </p>
               <div className="mt-2" style={{ maxWidth: 280 }}>
-                <Dropdown
+                <Select
                   value={headlessPresetId}
                   onChange={handleHeadlessChange}
                   options={PRESET_OPTIONS}

--- a/clients/web/src/domains/settings/components/tier-picker.tsx
+++ b/clients/web/src/domains/settings/components/tier-picker.tsx
@@ -8,7 +8,7 @@ import type {
   StorageTierEnum,
 } from "@/generated/api/types.gen";
 import { MACHINE_TIER_LABEL } from "@/lib/billing/machine-sizes";
-import { Dropdown } from "@vellumai/design-library/components/dropdown";
+import { Select } from "@vellumai/design-library/components/select";
 import { Typography } from "@vellumai/design-library/components/typography";
 import { formatDelta, formatMonthly } from "./tier-pricing";
 
@@ -98,7 +98,7 @@ export function TierPicker({
             <Info className="h-3 w-3 text-[var(--content-tertiary)]" />
           </span>
         </div>
-        <Dropdown<MachineTierEnum>
+        <Select<MachineTierEnum>
           aria-label="Machine tier"
           placeholder="Select a machine tier"
           value={selectedMachineTier ?? ("" as MachineTierEnum)}
@@ -119,7 +119,7 @@ export function TierPicker({
             <Info className="h-3 w-3 text-[var(--content-tertiary)]" />
           </span>
         </div>
-        <Dropdown<StorageTierEnum>
+        <Select<StorageTierEnum>
           aria-label="Storage tier"
           placeholder="Select a storage tier"
           value={selectedStorageTier ?? ("" as StorageTierEnum)}

--- a/clients/web/src/domains/settings/components/trust-rules/trust-rule-form-modal.tsx
+++ b/clients/web/src/domains/settings/components/trust-rules/trust-rule-form-modal.tsx
@@ -11,7 +11,7 @@ import { createPortal } from "react-dom";
 
 import { updateTrustRule } from "@/lib/trust-rules-api";
 import type { TrustRuleItem, TrustRuleRisk } from "@/types/trust-rules";
-import { Dropdown } from "@vellumai/design-library/components/dropdown";
+import { Select } from "@vellumai/design-library/components/select";
 import { Input } from "@vellumai/design-library/components/input";
 import { Notice } from "@vellumai/design-library/components/notice";
 
@@ -161,7 +161,7 @@ export function TrustRuleFormModal({
               Tool
             </label>
             <div className="mt-1">
-              <Dropdown
+              <Select
                 value={tool}
                 onChange={setTool}
                 disabled

--- a/clients/web/src/domains/settings/pages/privacy-page.tsx
+++ b/clients/web/src/domains/settings/pages/privacy-page.tsx
@@ -20,7 +20,7 @@ import {
 import { getDeviceSetting, setDeviceSetting } from "@/utils/device-settings";
 import { savePreferenceToggle } from "@/lib/consent/consent-persistence";
 import { legalUrl, routes } from "@/utils/routes";
-import { Dropdown } from "@vellumai/design-library/components/dropdown";
+import { Select } from "@vellumai/design-library/components/select";
 
 const RETENTION_OPTIONS: { value: string; label: string }[] = [
   { value: "dontRetain", label: "Don't retain" },
@@ -144,7 +144,7 @@ export function PrivacyPage() {
               LLM Request Log Retention
             </label>
             <div className="mt-2" style={{ maxWidth: 280 }}>
-              <Dropdown
+              <Select
                 value={retentionId}
                 onChange={handleRetentionChange}
                 options={RETENTION_OPTIONS}

--- a/clients/web/src/domains/settings/pages/voice-page.test.tsx
+++ b/clients/web/src/domains/settings/pages/voice-page.test.tsx
@@ -211,6 +211,13 @@ describe("VoiceSections listening language", () => {
 // Microphone picker
 // ---------------------------------------------------------------------------
 
+/**
+ * Driven with `fireEvent`, matching every other picker test in this repo.
+ * That reaches `Select`'s `onChange` here: neutering the callback in
+ * `select.tsx` fails "choosing System Default clears the saved device",
+ * which is the check worth repeating if these ever start passing suspiciously
+ * easily.
+ */
 describe("VoiceSections microphone picker", () => {
   const MICS: Partial<MediaDeviceInfo>[] = [
     { deviceId: "mic-a", kind: "audioinput", label: "Built-in Mic" },

--- a/clients/web/src/domains/settings/pages/voice-page.test.tsx
+++ b/clients/web/src/domains/settings/pages/voice-page.test.tsx
@@ -239,9 +239,12 @@ describe("VoiceSections microphone picker", () => {
   }
 
   function micTrigger(): HTMLElement {
-    const el = Array.from(
-      document.querySelectorAll<HTMLElement>('button[role="combobox"]'),
-    ).find((t) => (t.textContent ?? "").match(/Mic|System Default|Saved/));
+    // By aria-label, not by text: the page renders several pickers, and
+    // matching on rendered text picks whichever one happens to contain the
+    // string, which silently passes assertions against the wrong control.
+    const el = document.querySelector<HTMLElement>(
+      'button[role="combobox"][aria-label="Microphone"]',
+    );
     if (!el) {
       throw new Error("expected the microphone trigger");
     }
@@ -279,6 +282,24 @@ describe("VoiceSections microphone picker", () => {
     fireEvent.click(systemDefault!);
 
     expect(localStorage.getItem("vellum:voice:inputDeviceId")).toBe(null);
+  });
+
+  test("a saved device is not called disconnected before permission is granted", async () => {
+    // Browsers redact ids and labels until mic access is granted, so the
+    // enumerated list is empty for a reason that says nothing about whether
+    // the saved device is plugged in. Claiming it is disconnected there tells
+    // the user their working microphone is missing.
+    localStorage.setItem("vellum:voice:inputDeviceId", "mic-b");
+    stubDevices([
+      { deviceId: "", kind: "audioinput", label: "" },
+      { deviceId: "", kind: "audioinput", label: "" },
+    ]);
+    renderPage();
+
+    await waitFor(() =>
+      expect(micTrigger().textContent).toContain("Saved microphone"),
+    );
+    expect(micTrigger().textContent).not.toContain("not connected");
   });
 
   test("a saved device that is unplugged stays on the trigger", async () => {

--- a/clients/web/src/domains/settings/pages/voice-page.test.tsx
+++ b/clients/web/src/domains/settings/pages/voice-page.test.tsx
@@ -14,7 +14,13 @@
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 
 // The voice-picker card reads the active assistant id (throws outside the
@@ -198,5 +204,87 @@ describe("VoiceSections listening language", () => {
     renderPage();
 
     expect(screen.getByText("Tamil (தமிழ்)")).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Microphone picker
+// ---------------------------------------------------------------------------
+
+describe("VoiceSections microphone picker", () => {
+  const MICS: Partial<MediaDeviceInfo>[] = [
+    { deviceId: "mic-a", kind: "audioinput", label: "Built-in Mic" },
+    { deviceId: "mic-b", kind: "audioinput", label: "USB Mic" },
+  ];
+
+  function stubDevices(devices: Partial<MediaDeviceInfo>[]) {
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: {
+        enumerateDevices: async () => devices as MediaDeviceInfo[],
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        getUserMedia: async () => ({
+          getTracks: () => [{ stop: () => {} }],
+        }),
+      },
+    });
+  }
+
+  function micTrigger(): HTMLElement {
+    const el = Array.from(
+      document.querySelectorAll<HTMLElement>('button[role="combobox"]'),
+    ).find((t) => (t.textContent ?? "").match(/Mic|System Default|Saved/));
+    if (!el) {
+      throw new Error("expected the microphone trigger");
+    }
+    return el;
+  }
+
+  function optionLabels(): string[] {
+    return Array.from(
+      document.querySelectorAll<HTMLElement>('[role="option"]'),
+    ).map((o) => o.textContent?.trim() ?? "");
+  }
+
+  test("System Default is offered", async () => {
+    // It carries the stored empty-string value, which Radix reserves. Passing
+    // that straight through drops the row and leaves no way to choose it.
+    stubDevices(MICS);
+    renderPage();
+    await waitFor(() => expect(micTrigger()).toBeTruthy());
+
+    fireEvent.click(micTrigger());
+    await waitFor(() => expect(optionLabels()).toContain("Built-in Mic"));
+    expect(optionLabels()).toContain("System Default");
+  });
+
+  test("choosing System Default clears the saved device", async () => {
+    localStorage.setItem("vellum:voice:inputDeviceId", "mic-b");
+    stubDevices(MICS);
+    renderPage();
+    await waitFor(() => expect(micTrigger().textContent).toContain("USB Mic"));
+
+    fireEvent.click(micTrigger());
+    const systemDefault = Array.from(
+      document.querySelectorAll<HTMLElement>('[role="option"]'),
+    ).find((o) => o.textContent?.trim() === "System Default");
+    fireEvent.click(systemDefault!);
+
+    expect(localStorage.getItem("vellum:voice:inputDeviceId")).toBe(null);
+  });
+
+  test("a saved device that is unplugged stays on the trigger", async () => {
+    // Showing System Default here would claim a preference the user does not
+    // have, and would make choosing System Default a no-op that cannot clear
+    // it. Capture already falls back, so the saved value is kept.
+    localStorage.setItem("vellum:voice:inputDeviceId", "mic-gone");
+    stubDevices(MICS);
+    renderPage();
+
+    await waitFor(() =>
+      expect(micTrigger().textContent).toContain("not connected"),
+    );
+    expect(localStorage.getItem("vellum:voice:inputDeviceId")).toBe("mic-gone");
   });
 });

--- a/clients/web/src/domains/settings/pages/voice-page.tsx
+++ b/clients/web/src/domains/settings/pages/voice-page.tsx
@@ -11,7 +11,7 @@ import {
 import { Link, Navigate, useSearchParams } from "react-router";
 
 import { Button } from "@vellumai/design-library/components/button";
-import { Dropdown } from "@vellumai/design-library/components/dropdown";
+import { Select } from "@vellumai/design-library/components/select";
 import { SegmentControl } from "@vellumai/design-library/components/segment-control";
 import { Slider } from "@vellumai/design-library/components/slider";
 import { Toggle } from "@vellumai/design-library/components/toggle";
@@ -314,7 +314,7 @@ function MicrophoneCard() {
     >
       <div className="flex flex-col gap-3">
         <div className="max-w-xs">
-          <Dropdown<string>
+          <Select<string>
             options={options}
             value={selectedValue}
             onChange={handleChange}

--- a/clients/web/src/domains/settings/pages/voice-page.tsx
+++ b/clients/web/src/domains/settings/pages/voice-page.tsx
@@ -232,6 +232,11 @@ const SYSTEM_DEFAULT_OPTION = "__system_default__";
 function MicrophoneCard() {
   const [devices, setDevices] = useState<MediaDeviceInfo[]>([]);
   const [needsPermission, setNeedsPermission] = useState(false);
+  // Whether the browser has given us a list we can draw conclusions from.
+  // Before the first enumeration resolves, and while permission is withheld
+  // (ids come back redacted and are filtered out), an absent device says
+  // nothing about whether it is plugged in.
+  const [deviceListIsKnown, setDeviceListIsKnown] = useState(false);
   const [deviceId, setDeviceId] = useState<string>(() =>
     getPreferredInputDeviceId(),
   );
@@ -260,9 +265,13 @@ function MicrophoneCard() {
             device.deviceId !== "communications",
         ),
       );
+      setDeviceListIsKnown(
+        inputs.length === 0 || inputs.some((d) => !!d.label),
+      );
     } catch {
       setDevices([]);
       setNeedsPermission(false);
+      setDeviceListIsKnown(false);
     }
   }, []);
 
@@ -297,22 +306,32 @@ function MicrophoneCard() {
       value: device.deviceId,
       label: device.label || `Microphone ${index + 1}`,
     }));
-    // A saved device that is currently unplugged is not in the list. It stays
-    // on the trigger as its own row rather than being shown as System
-    // Default: capture already falls back, so the saved preference is kept
-    // for when the device returns, and rendering it honestly is what makes
-    // System Default a real change that can clear it.
-    const savedIsMissing =
+    // A saved device absent from the list keeps its own row rather than being
+    // displayed as System Default: capture already falls back, so the
+    // preference survives for when the device returns, and showing it is what
+    // makes System Default a real change that can clear it.
+    //
+    // Only claim it is disconnected once the list is worth trusting. An
+    // unresolved or permission-redacted list is empty for reasons that have
+    // nothing to do with the device.
+    const savedIsAbsent =
       deviceId !== SYSTEM_DEFAULT_DEVICE &&
       !live.some((option) => option.value === deviceId);
     return [
       { value: SYSTEM_DEFAULT_OPTION, label: "System Default" },
       ...live,
-      ...(savedIsMissing
-        ? [{ value: deviceId, label: "Saved microphone (not connected)" }]
+      ...(savedIsAbsent
+        ? [
+            {
+              value: deviceId,
+              label: deviceListIsKnown
+                ? "Saved microphone (not connected)"
+                : "Saved microphone",
+            },
+          ]
         : []),
     ];
-  }, [devices, deviceId]);
+  }, [devices, deviceId, deviceListIsKnown]);
 
   const handleChange = useCallback((option: string) => {
     const next =

--- a/clients/web/src/domains/settings/pages/voice-page.tsx
+++ b/clients/web/src/domains/settings/pages/voice-page.tsx
@@ -215,7 +215,19 @@ function CaptionsCard() {
   );
 }
 
+/**
+ * Stored value meaning "use whatever the OS picks". Shared with
+ * `voice-input-device.ts`, which reads the same key, so the storage shape
+ * cannot change.
+ */
 const SYSTEM_DEFAULT_DEVICE = "";
+
+/**
+ * Option value standing in for {@link SYSTEM_DEFAULT_DEVICE}. Radix reserves
+ * the empty string, so an option carrying it is discarded and the row would
+ * simply not render. Mapped back at the boundary so storage keeps its shape.
+ */
+const SYSTEM_DEFAULT_OPTION = "__system_default__";
 
 function MicrophoneCard() {
   const [devices, setDevices] = useState<MediaDeviceInfo[]>([]);
@@ -280,18 +292,31 @@ function MicrophoneCard() {
       mediaDevices.removeEventListener("devicechange", onDeviceChange);
   }, [refreshDevices]);
 
-  const options = useMemo(
-    () => [
-      { value: SYSTEM_DEFAULT_DEVICE, label: "System Default" },
-      ...devices.map((device, index) => ({
-        value: device.deviceId,
-        label: device.label || `Microphone ${index + 1}`,
-      })),
-    ],
-    [devices],
-  );
+  const options = useMemo(() => {
+    const live = devices.map((device, index) => ({
+      value: device.deviceId,
+      label: device.label || `Microphone ${index + 1}`,
+    }));
+    // A saved device that is currently unplugged is not in the list. It stays
+    // on the trigger as its own row rather than being shown as System
+    // Default: capture already falls back, so the saved preference is kept
+    // for when the device returns, and rendering it honestly is what makes
+    // System Default a real change that can clear it.
+    const savedIsMissing =
+      deviceId !== SYSTEM_DEFAULT_DEVICE &&
+      !live.some((option) => option.value === deviceId);
+    return [
+      { value: SYSTEM_DEFAULT_OPTION, label: "System Default" },
+      ...live,
+      ...(savedIsMissing
+        ? [{ value: deviceId, label: "Saved microphone (not connected)" }]
+        : []),
+    ];
+  }, [devices, deviceId]);
 
-  const handleChange = useCallback((next: string) => {
+  const handleChange = useCallback((option: string) => {
+    const next =
+      option === SYSTEM_DEFAULT_OPTION ? SYSTEM_DEFAULT_DEVICE : option;
     setDeviceId(next);
     if (next === SYSTEM_DEFAULT_DEVICE) {
       removeLocalSetting(LS_VOICE_INPUT_DEVICE);
@@ -300,12 +325,8 @@ function MicrophoneCard() {
     }
   }, []);
 
-  // A saved device that's currently unplugged won't be in the list; show
-  // System Default (capture falls back to it) without clearing the saved
-  // preference, so reconnecting the device picks it back up.
-  const selectedValue = options.some((option) => option.value === deviceId)
-    ? deviceId
-    : SYSTEM_DEFAULT_DEVICE;
+  const selectedValue =
+    deviceId === SYSTEM_DEFAULT_DEVICE ? SYSTEM_DEFAULT_OPTION : deviceId;
 
   return (
     <DetailCard

--- a/clients/web/src/lib/billing/machine-sizes.ts
+++ b/clients/web/src/lib/billing/machine-sizes.ts
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 
 import type { MachineSizeEnum } from "@/generated/api/types.gen";
-import type { DropdownOption } from "@vellumai/design-library/components/dropdown";
+import type { SelectOption } from "@vellumai/design-library/components/select";
 
 /**
  * Pro tier ceilings → machine sizes the org may run at within that tier.
@@ -125,7 +125,7 @@ export function buildMachineSizeOptions(
   sizes: MachineSizeEnum[],
   currentSize: MachineSizeEnum | null | undefined,
   currentSuffix: ReactNode,
-): DropdownOption<MachineSizeEnum>[] {
+): SelectOption<MachineSizeEnum>[] {
   return sizes.map((size) => ({
     value: size,
     label: `${SIZE_LABEL[size]} — ${SIZE_DESCRIPTION[size]}`,


### PR DESCRIPTION
## TL;DR

Moves the 16 `Dropdown` call sites under `settings/` and `lib/billing` onto `Select`. Mostly an import swap; four carried real changes, and one was a latent bug the swap would otherwise have shipped.

Part of [LUM-2959](https://linear.app/vellum/issue/LUM-2959).

## What changes for the user

| Before | After |
| --- | --- |
| Choosing the upgrade version shown on screen could install a different one | The version on screen is the version installed |
| Menus could not flip upward, so a picker low in the page opened below the fold | Menu flips and shifts to stay on screen |
| Menus mispositioned inside a transformed ancestor | Positioned correctly |
| A screen reader could arrow off an open menu into covered page content | The page leaves the accessibility tree while the menu is open |

Every other picker in this batch behaves exactly as before.

## The upgrade-version bug

`assistant-upgrades` shows a version on its trigger even when the user has chosen nothing: `effectiveSelectedVersion` falls back to the latest release. The upgrade itself read the raw `selectedVersion` instead.

With the old control that gap was invisible, because clicking the displayed version fired a change and set the raw state. `Select` reports a selection only when the value changes, so clicking the version already on screen leaves the raw state `null`, and `targetVersion` becomes `undefined`, which installs whatever is latest at request time rather than the version the user was looking at.

The upgrade now reads the displayed version, so the screen and the action cannot disagree.

This is the same shape as the provider row in #40294 and the tier picker in #40308: a picker whose displayed value falls back to something other than what is stored, where re-picking the displayed value was quietly load-bearing. It is worth grepping for `value={... ?? ...}` in the remaining call sites rather than finding it one PR at a time.

## Three smaller ones

- **`settings/components/tier-picker`** wrote `value={selectedMachineTier ?? ("" as MachineTierEnum)}`. `SelectProps<T>` types `value` as `T | ""`, so both casts are gone.
- **`model-profile-select`'s test** mocked `components/dropdown` while the component imports `components/select`, so the mock stubbed nothing. Retargeted, and its two helpers renamed off `Dropdown`.
- **`feature-flags-panel`'s `hasDropdown`** became `hasKnownValues`, which is the condition it tests.

## Why this is safe

- Every picker keeps its existing value, options, and change handler; only the control underneath changes.
- Three `custom-plan-modal` assertions expected `aria-disabled="false"` on enabled options. Radix omits the attribute rather than setting it false, so they assert the absence of the disabled state. The neighbouring `"true"` assertions are untouched and still carry the real check.
- **The suites are not passing vacuously.** `fireEvent.click` on a Radix option is a silent no-op, so a migrated suite can go green without exercising anything. With `Select`'s `onChange` neutered: `custom-plan-modal` 12 failures, `adjust-plan-modal` 11, `plans-page` 5, `credit-bundle-picker` 2. The four suites that do not move never open a picker, and `model-profile-select` mocks `Select` out to test its pure helpers.

35 suites green, typecheck and lint clean.

## Remaining

9 call sites: speech (3), `channel-trust-floor-section`, onboarding, charts, `share-feedback-modal`, `add-credits-modal`. `Dropdown` gets deleted when the last one lands.
