### PR TITLE
feat(tts): accept a language on synthesis requests and enforce it where providers support it

### DIFF
--- a/assistant/src/live-voice/live-voice-tts.ts
+++ b/assistant/src/live-voice/live-voice-tts.ts
@@ -30,6 +30,7 @@ export interface LiveVoiceTtsOptions {
   useCase?: TtsUseCase;
   outputFormat?: TtsSynthesisRequest["outputFormat"];
   sampleRate?: number;
+  language?: string;
   config?: LiveVoiceTtsConfig;
   onAudioChunk: (chunk: LiveVoiceTtsAudioChunk) => void;
 }
@@ -92,6 +93,7 @@ export async function streamLiveVoiceTtsAudio(
     voiceId: options.voiceId,
     outputFormat: options.outputFormat,
     sampleRateHz: requestedSampleRate,
+    language: options.language,
     signal: options.signal,
   });
   const sampleRate = providerSampleRate ?? requestedSampleRate;
@@ -141,6 +143,7 @@ export async function streamLiveVoiceTtsAudio(
       voiceId: options.voiceId,
       outputFormat: options.outputFormat,
       sampleRateHz: requestedSampleRate,
+      language: options.language,
       signal: options.signal,
       onChunk: (chunk) => {
         if (canStreamChunks) {

--- a/assistant/src/tts/__tests__/provider-adapters.test.ts
+++ b/assistant/src/tts/__tests__/provider-adapters.test.ts
@@ -549,6 +549,45 @@ describe("ElevenLabs TTS provider adapter", () => {
 
     const body = JSON.parse(capturedBody);
     expect(body.model_id).toBe("eleven_flash_v2_5");
+    expect("language_code" in body).toBe(false);
+  });
+
+  test("synthesizeStream sends language_code when the effective model supports enforcement", async () => {
+    let capturedBody = "";
+
+    globalThis.fetch = mock(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        capturedBody = init?.body as string;
+        return new Response(streamOf(new Uint8Array([0x01])), { status: 200 });
+      },
+    ) as unknown as typeof globalThis.fetch;
+
+    const provider = createElevenLabsProvider();
+    await provider.synthesizeStream!(makeRequest({ language: "hi" }), () => {});
+
+    const body = JSON.parse(capturedBody);
+    expect(body.model_id).toBe("eleven_flash_v2_5");
+    expect(body.language_code).toBe("hi");
+  });
+
+  test("omits language_code when the configured model does not support enforcement", async () => {
+    mockElevenLabsConfig.voiceModelId = "eleven_multilingual_v2";
+    seedTtsConfig();
+    let capturedBody = "";
+
+    globalThis.fetch = mock(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        capturedBody = init?.body as string;
+        return new Response(streamOf(new Uint8Array([0x01])), { status: 200 });
+      },
+    ) as unknown as typeof globalThis.fetch;
+
+    const provider = createElevenLabsProvider();
+    await provider.synthesizeStream!(makeRequest({ language: "hi" }), () => {});
+
+    const body = JSON.parse(capturedBody);
+    expect(body.model_id).toBe("eleven_multilingual_v2");
+    expect("language_code" in body).toBe(false);
   });
 
   test("synthesizeStream respects configured voiceModelId over flash default", async () => {
@@ -1685,6 +1724,24 @@ describe("xAI TTS provider adapter", () => {
     expect(body.voice_id).toBe("ara");
   });
 
+  test("request language overrides config language", async () => {
+    const audioPayload = new Uint8Array([0x49, 0x44, 0x33]);
+    let capturedBody = "";
+
+    globalThis.fetch = mock(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        capturedBody = init?.body as string;
+        return new Response(audioPayload, { status: 200 });
+      },
+    ) as unknown as typeof globalThis.fetch;
+
+    const provider = createXaiProvider();
+    await provider.synthesize(makeRequest({ language: "es" }));
+
+    const body = JSON.parse(capturedBody);
+    expect(body.language).toBe("es");
+  });
+
   test("wav config format produces codec=wav without bit_rate", async () => {
     mockXaiConfig.format = "wav";
     seedTtsConfig();
@@ -1900,6 +1957,16 @@ describe("xAI TTS provider adapter", () => {
       );
 
       expect(capturedSocketOptions().url).toContain("sample_rate=22050");
+    });
+
+    test("request language overrides config language in the stream URL", async () => {
+      const provider = createXaiProvider();
+      await provider.synthesizeStream!(
+        makeRequest({ language: "es" }),
+        () => {},
+      );
+
+      expect(capturedSocketOptions().url).toContain("language=es");
     });
 
     test("mp3 requests carry codec=mp3 and bit_rate and resolve audio/mpeg", async () => {

--- a/assistant/src/tts/providers/elevenlabs-provider.ts
+++ b/assistant/src/tts/providers/elevenlabs-provider.ts
@@ -169,6 +169,17 @@ function resolveVoiceId(
   return voiceId;
 }
 
+/**
+ * Models that accept the `language_code` request parameter for language
+ * enforcement (per the ElevenLabs text-to-speech API docs). Other models
+ * (e.g. `eleven_multilingual_v2`) reject the field, so it is omitted for
+ * anything not listed here.
+ */
+const LANGUAGE_ENFORCEMENT_MODEL_IDS = new Set([
+  "eleven_flash_v2_5",
+  "eleven_turbo_v2_5",
+]);
+
 /** ElevenLabs `pcm_*` rates available on every subscription tier. */
 const UNRESTRICTED_PCM_SAMPLE_RATES_HZ = [16_000, 22_050, 24_000] as const;
 
@@ -251,16 +262,20 @@ async function performTtsRequest(
   const defaultModelId = stream
     ? "eleven_flash_v2_5"
     : "eleven_multilingual_v2";
+  const modelId = config.voiceModelId?.trim() || defaultModelId;
 
   const body: Record<string, unknown> = {
     text: request.text,
-    model_id: config.voiceModelId?.trim() || defaultModelId,
+    model_id: modelId,
     voice_settings: {
       stability: config.stability,
       similarity_boost: config.similarityBoost,
       speed: config.speed,
     },
   };
+  if (request.language && LANGUAGE_ENFORCEMENT_MODEL_IDS.has(modelId)) {
+    body.language_code = request.language;
+  }
 
   log.info(
     { voiceId, outputFormat, stream, textLength: request.text.length },

--- a/assistant/src/tts/providers/xai-provider.ts
+++ b/assistant/src/tts/providers/xai-provider.ts
@@ -149,6 +149,14 @@ function resolveVoiceId(
   return request.voiceId?.trim() || config.voiceId || "eve";
 }
 
+/** Resolve the synthesis language: request override > configured default. */
+function resolveLanguage(
+  request: TtsSynthesisRequest,
+  config: TtsXaiProviderConfig,
+): string {
+  return request.language ?? config.language;
+}
+
 /** Resolve the xAI API key, throwing `XAI_TTS_NO_API_KEY` when unset. */
 async function requireApiKey(): Promise<string> {
   const apiKey = await getSecureKeyAsync(credentialKey("xai", "api_key"));
@@ -173,7 +181,7 @@ function buildStreamUrl(
   outputParams: XaiOutputParams,
 ): string {
   const params = new URLSearchParams({
-    language: config.language,
+    language: resolveLanguage(request, config),
     voice: resolveVoiceId(request, config),
     codec: outputParams.codec,
     sample_rate: String(outputParams.sample_rate),
@@ -209,7 +217,7 @@ export function createXaiProvider(
       const body = {
         text: request.text,
         voice_id: voiceId,
-        language: config.language,
+        language: resolveLanguage(request, config),
         output_format: {
           codec: output.codec,
           sample_rate: output.sample_rate,

--- a/assistant/src/tts/synthesis-stream.ts
+++ b/assistant/src/tts/synthesis-stream.ts
@@ -56,6 +56,12 @@ export interface SynthesisEmitOptions {
   /** Preferred PCM sample rate in Hz, forwarded on the provider request. */
   sampleRateHz?: number;
 
+  /**
+   * Language hint forwarded on the provider request
+   * (see {@link TtsSynthesisRequest.language}).
+   */
+  language?: string;
+
   /** Abort signal forwarded to the provider and checked before each emit. */
   signal?: AbortSignal;
 
@@ -106,6 +112,7 @@ export async function synthesizeAndEmit(
     voiceId: options.voiceId,
     outputFormat: options.outputFormat,
     sampleRateHz: options.sampleRateHz,
+    language: options.language,
     signal,
   };
 

--- a/assistant/src/tts/types.ts
+++ b/assistant/src/tts/types.ts
@@ -113,6 +113,13 @@ export interface TtsSynthesisRequest {
    * on provider-documented behavior (see each provider's format mapping).
    */
   sampleRateHz?: number;
+
+  /**
+   * Optional lowercase BCP-47 base subtag (e.g. `"es"`, `"hi"`) hinting the
+   * language of `text`. Providers that support language enforcement apply
+   * it; providers that cannot use it must ignore it.
+   */
+  language?: string;
 }
 
 /** Output of a completed TTS synthesis call. */


### PR DESCRIPTION
## Summary
- Adds optional language hint to TtsSynthesisRequest, synthesis-stream, and LiveVoiceTtsOptions
- ElevenLabs sends language_code on models that support enforcement (flash v2.5, turbo v2.5)
- xAI request-level language now overrides the configured default

Part of plan: voice-multilingual-pipeline.md (PR 2 of 6)