### PR TITLE
feat(stt): surface Deepgram per-word detected languages on streaming transcript events

### DIFF
--- a/assistant/src/providers/speech-to-text/deepgram-realtime.test.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-realtime.test.ts
@@ -835,6 +835,134 @@ describe("DeepgramRealtimeTranscriber", () => {
         "second utterance",
       ]);
     });
+
+    test("aggregated final ranks language tags across all withheld frames", async () => {
+      const { events } = await startSession({ utteranceBoundaryFinals: true });
+
+      // Raw per-word tags are accumulated, so "es" (2 words) outranks
+      // "en" (1 word) even though "en" arrived in the earlier frame.
+      mockWs.simulateMessage(
+        resultsFrame("hello", {
+          is_final: true,
+          words: [{ word: "hello", language: "en" }],
+        }),
+      );
+      mockWs.simulateMessage(
+        resultsFrame("hola amigo", {
+          is_final: true,
+          speech_final: true,
+          words: [
+            { word: "hola", language: "es" },
+            { word: "amigo", language: "es" },
+          ],
+        }),
+      );
+
+      const finals = events.filter((e) => e.type === "final");
+      expect(finals).toHaveLength(1);
+      expect(finals[0]).toEqual({
+        type: "final",
+        text: "hello hola amigo",
+        language: "es",
+        languages: ["es", "en"],
+      });
+    });
+
+    test("UtteranceEnd flush carries the accumulated language metadata", async () => {
+      const { events } = await startSession({ utteranceBoundaryFinals: true });
+
+      mockWs.simulateMessage(
+        resultsFrame("bonjour", {
+          is_final: true,
+          words: [{ word: "bonjour", language: "fr" }],
+        }),
+      );
+      mockWs.simulateMessage(
+        resultsFrame("hello there", {
+          is_final: true,
+          alternativeLanguages: ["en"],
+        }),
+      );
+      mockWs.simulateMessage(utteranceEndFrame());
+
+      const finals = events.filter((e) => e.type === "final");
+      expect(finals).toHaveLength(1);
+      expect(finals[0]).toEqual({
+        type: "final",
+        text: "bonjour hello there",
+        language: "fr",
+        languages: ["fr", "en"],
+      });
+    });
+
+    test("aggregated final omits language fields when no withheld frame carried tags", async () => {
+      const { events } = await startSession({ utteranceBoundaryFinals: true });
+
+      mockWs.simulateMessage(resultsFrame("no tags", { is_final: true }));
+      mockWs.simulateMessage(
+        resultsFrame("at all", { is_final: true, speech_final: true }),
+      );
+
+      const finals = events.filter((e) => e.type === "final");
+      expect(finals).toHaveLength(1);
+      expect(finals[0]).toEqual({ type: "final", text: "no tags at all" });
+      expect("language" in finals[0]!).toBe(false);
+      expect("languages" in finals[0]!).toBe(false);
+    });
+
+    test("tags on empty-text frames do not leak into the aggregated final", async () => {
+      const { events } = await startSession({ utteranceBoundaryFinals: true });
+
+      // A silence segment may still carry container-level tags; only
+      // frames that contributed transcript text feed the metadata.
+      mockWs.simulateMessage(
+        resultsFrame("", { is_final: true, alternativeLanguages: ["fr"] }),
+      );
+      mockWs.simulateMessage(
+        resultsFrame("hello", {
+          is_final: true,
+          speech_final: true,
+          words: [{ word: "hello", language: "en" }],
+        }),
+      );
+
+      const finals = events.filter((e) => e.type === "final");
+      expect(finals).toHaveLength(1);
+      expect(finals[0]).toEqual({
+        type: "final",
+        text: "hello",
+        language: "en",
+        languages: ["en"],
+      });
+    });
+
+    test("language tags reset between aggregated utterances", async () => {
+      const { events } = await startSession({ utteranceBoundaryFinals: true });
+
+      mockWs.simulateMessage(
+        resultsFrame("hola", {
+          is_final: true,
+          speech_final: true,
+          words: [{ word: "hola", language: "es" }],
+        }),
+      );
+      mockWs.simulateMessage(
+        resultsFrame("hello", {
+          is_final: true,
+          speech_final: true,
+          words: [{ word: "hello", language: "en" }],
+        }),
+      );
+
+      const finals = events.filter((e) => e.type === "final");
+      expect(finals).toHaveLength(2);
+      expect(finals[1]).toEqual({
+        type: "final",
+        text: "hello",
+        language: "en",
+        languages: ["en"],
+      });
+    });
   });
 
   // ─────────────────────────────────────────────────────────────────

--- a/assistant/src/providers/speech-to-text/deepgram-realtime.test.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-realtime.test.ts
@@ -102,7 +102,11 @@ function resultsFrame(
     is_final?: boolean;
     speech_final?: boolean;
     from_finalize?: boolean;
-    words?: { word: string; speaker?: number }[];
+    words?: { word: string; speaker?: number; language?: string }[];
+    /** Container-level detected languages on the alternative. */
+    alternativeLanguages?: string[];
+    /** Container-level detected languages on the channel. */
+    channelLanguages?: string[];
   } = {},
 ): string {
   return JSON.stringify({
@@ -121,8 +125,14 @@ function resultsFrame(
           transcript,
           confidence: 0.95,
           ...(options.words ? { words: options.words } : {}),
+          ...(options.alternativeLanguages
+            ? { languages: options.alternativeLanguages }
+            : {}),
         },
       ],
+      ...(options.channelLanguages
+        ? { languages: options.channelLanguages }
+        : {}),
     },
   });
 }
@@ -540,6 +550,160 @@ describe("DeepgramRealtimeTranscriber", () => {
     expect(url.searchParams.get("diarize")).toBeNull();
 
     (globalThis as Record<string, unknown>).WebSocket = origWs;
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Language metadata (nova-3 multi code-switching)
+  // ─────────────────────────────────────────────────────────────────
+
+  describe("language metadata", () => {
+    test("ranks per-word language tags by dominance on final events", async () => {
+      const { events } = await startSession();
+
+      mockWs.simulateMessage(
+        resultsFrame("hello world hola", {
+          is_final: true,
+          words: [
+            { word: "hello", language: "en" },
+            { word: "world", language: "en" },
+            { word: "hola", language: "es" },
+          ],
+        }),
+      );
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({
+        type: "final",
+        text: "hello world hola",
+        confidence: 0.95,
+        language: "en",
+        languages: ["en", "es"],
+      });
+    });
+
+    test("omits both fields entirely when no language metadata is present", async () => {
+      const { events } = await startSession();
+
+      mockWs.simulateMessage(
+        resultsFrame("hello world", {
+          is_final: true,
+          words: [{ word: "hello" }, { word: "world" }],
+        }),
+      );
+      mockWs.simulateMessage(resultsFrame("still typing", { is_final: false }));
+
+      expect(events).toHaveLength(2);
+      for (const event of events) {
+        // The keys must not exist at all, not just be undefined-valued.
+        expect("language" in event).toBe(false);
+        expect("languages" in event).toBe(false);
+      }
+    });
+
+    test("normalizes regional tags to their base subtag", async () => {
+      const { events } = await startSession();
+
+      mockWs.simulateMessage(
+        resultsFrame("hello", {
+          is_final: true,
+          words: [{ word: "hello", language: "en-US" }],
+        }),
+      );
+
+      expect(events[0]).toEqual({
+        type: "final",
+        text: "hello",
+        confidence: 0.95,
+        language: "en",
+        languages: ["en"],
+      });
+    });
+
+    test("partial events carry the fields when interim results are enabled", async () => {
+      const { events } = await startSession();
+
+      mockWs.simulateMessage(
+        resultsFrame("namaste hello", {
+          is_final: false,
+          words: [
+            { word: "namaste", language: "hi" },
+            { word: "hello", language: "en" },
+            { word: "there", language: "en" },
+          ],
+        }),
+      );
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({
+        type: "partial",
+        text: "namaste hello",
+        confidence: 0.95,
+        language: "en",
+        languages: ["en", "hi"],
+      });
+    });
+
+    test("falls back to the alternative-level languages array when words carry no tags", async () => {
+      const { events } = await startSession();
+
+      mockWs.simulateMessage(
+        resultsFrame("mixed speech", {
+          is_final: true,
+          words: [{ word: "mixed" }, { word: "speech" }],
+          alternativeLanguages: ["es-419", "en", "ES"],
+        }),
+      );
+
+      expect(events[0]).toEqual({
+        type: "final",
+        text: "mixed speech",
+        confidence: 0.95,
+        language: "es",
+        languages: ["es", "en"],
+      });
+    });
+
+    test("falls back to the channel-level languages array when the alternative has none", async () => {
+      const { events } = await startSession();
+
+      mockWs.simulateMessage(
+        resultsFrame("bonjour", {
+          is_final: true,
+          channelLanguages: ["fr", "en"],
+        }),
+      );
+
+      expect(events[0]).toEqual({
+        type: "final",
+        text: "bonjour",
+        confidence: 0.95,
+        language: "fr",
+        languages: ["fr", "en"],
+      });
+    });
+
+    test("per-word tags take precedence over container arrays", async () => {
+      const { events } = await startSession();
+
+      mockWs.simulateMessage(
+        resultsFrame("hola amigo", {
+          is_final: true,
+          words: [
+            { word: "hola", language: "es" },
+            { word: "amigo", language: "es" },
+          ],
+          alternativeLanguages: ["en", "es"],
+        }),
+      );
+
+      expect(events[0]).toEqual({
+        type: "final",
+        text: "hola amigo",
+        confidence: 0.95,
+        language: "es",
+        languages: ["es"],
+      });
+    });
   });
 
   // ─────────────────────────────────────────────────────────────────

--- a/assistant/src/providers/speech-to-text/deepgram-realtime.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-realtime.ts
@@ -29,6 +29,10 @@
  * - All timers and listeners are cleaned up on close to prevent leaks.
  */
 
+import {
+  normalizeLanguageTag,
+  rankLanguages,
+} from "../../stt/language-metadata.js";
 import type {
   StreamingTranscriber,
   SttStreamServerEvent,
@@ -208,6 +212,11 @@ interface DeepgramStreamWord {
   confidence?: number;
   start?: number;
   end?: number;
+  /**
+   * BCP-47 tag of the language this word was spoken in. Present only on
+   * code-switching models (nova-3 with `language=multi`).
+   */
+  language?: string;
 }
 
 /**
@@ -225,11 +234,23 @@ interface DeepgramStreamAlternative {
   speaker?: number;
   /** Per-word speaker tags when diarization is enabled. */
   words?: DeepgramStreamWord[];
+  /**
+   * Detected languages for the chunk in dominance order. Emitted by
+   * code-switching models; the container varies by API version, so
+   * {@link DeepgramStreamChannel.languages} is checked as well.
+   */
+  languages?: string[];
 }
 
 /** A channel within a Deepgram streaming response. */
 interface DeepgramStreamChannel {
   alternatives?: DeepgramStreamAlternative[];
+  /**
+   * Detected languages for the chunk in dominance order. Alternate
+   * container for {@link DeepgramStreamAlternative.languages} on some
+   * API versions.
+   */
+  languages?: string[];
 }
 
 /**
@@ -748,6 +769,12 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
    * words — see {@link extractSpeakerLabel}. Confidence is taken from
    * the top alternative when present.
    *
+   * Code-switching models (nova-3 with `language=multi`) tag detected
+   * languages per word and per container. When present, these become
+   * dominance-ranked `language` / `languages` fields on the emitted
+   * events (see {@link extractLanguages}). Both fields are omitted when
+   * the frame carries no language metadata.
+   *
    * We emit:
    * - `partial` for `is_final: false` frames (if interim results enabled).
    * - `final` for `is_final: true` frames.
@@ -788,6 +815,8 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
       typeof alternative?.confidence === "number"
         ? alternative.confidence
         : undefined;
+    const languages = extractLanguages(frame.channel, alternative);
+    const language = languages[0];
 
     if (frame.is_final) {
       if (this.utteranceBoundaryFinals) {
@@ -807,6 +836,7 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
           text,
           ...(speakerLabel !== undefined ? { speakerLabel } : {}),
           ...(confidence !== undefined ? { confidence } : {}),
+          ...(language !== undefined ? { language, languages } : {}),
           // Mark the finalize flush so consumers can attribute it to the
           // utterance that requested the flush rather than new speech.
           ...(fromFinalize ? { fromFinalize: true } : {}),
@@ -819,6 +849,7 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
         text,
         ...(speakerLabel !== undefined ? { speakerLabel } : {}),
         ...(confidence !== undefined ? { confidence } : {}),
+        ...(language !== undefined ? { language, languages } : {}),
       });
     }
 
@@ -1222,6 +1253,47 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
  * contract on {@link SttStreamServerPartialEvent} /
  * {@link SttStreamServerFinalEvent}.
  */
+/**
+ * Derive the detected languages for a chunk, most dominant first.
+ *
+ * Code-switching models tag languages in two shapes:
+ *   1. Per-word `language` tags on `alternatives[0].words[]`, the richest
+ *      signal; ranked by frequency via {@link rankLanguages} (ties broken
+ *      by first appearance).
+ *   2. A container-level `languages` array in dominance order, attached to
+ *      the alternative or (on some API versions) the channel. Used as the
+ *      fallback when no word carries a tag; normalized and deduped with
+ *      the provider's order preserved.
+ *
+ * Returns `[]` when the frame carries no language metadata: callers omit
+ * the event fields entirely so absence stays distinguishable from a
+ * detected language.
+ */
+function extractLanguages(
+  channel: DeepgramStreamChannel | undefined,
+  alternative: DeepgramStreamAlternative | undefined,
+): string[] {
+  const wordTags = (alternative?.words ?? []).flatMap((word) =>
+    typeof word.language === "string" ? [word.language] : [],
+  );
+  if (wordTags.length > 0) {
+    return rankLanguages(wordTags);
+  }
+
+  const container = Array.isArray(alternative?.languages)
+    ? alternative.languages
+    : Array.isArray(channel?.languages)
+      ? channel.languages
+      : [];
+  const deduped = new Set(
+    container
+      .filter((tag): tag is string => typeof tag === "string")
+      .map(normalizeLanguageTag)
+      .filter((tag) => tag !== ""),
+  );
+  return [...deduped];
+}
+
 function extractSpeakerLabel(
   alternative: DeepgramStreamAlternative | undefined,
 ): string | undefined {

--- a/assistant/src/providers/speech-to-text/deepgram-realtime.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-realtime.ts
@@ -364,6 +364,15 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
    */
   private pendingFinalSegments: string[] = [];
 
+  /**
+   * Raw detected-language tags for the withheld segments, accumulated
+   * alongside {@link pendingFinalSegments} and ranked into `language` /
+   * `languages` when the utterance flushes. Cleared wherever the pending
+   * segments are cleared. Only populated when
+   * {@link utteranceBoundaryFinals} is enabled.
+   */
+  private pendingLanguageTags: string[] = [];
+
   /** The live WebSocket connection, set during start(). */
   private ws: WsLike | null = null;
 
@@ -824,6 +833,16 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
         // Finalize flush is a forced boundary — flush what is pending.
         if (text.length > 0) {
           this.pendingFinalSegments.push(text);
+          // Collect language tags only from frames that contributed text
+          // so the flushed metadata stays aligned with the emitted
+          // transcript (empty frames may still carry tags, but they
+          // describe no emitted words). Raw per-word tags are preferred
+          // over the frame's ranked list so cross-frame frequency
+          // weighting survives until the flush ranks the whole utterance.
+          const wordTags = collectWordLanguageTags(alternative);
+          this.pendingLanguageTags.push(
+            ...(wordTags.length > 0 ? wordTags : languages),
+          );
         }
         if (frame.speech_final || fromFinalize) {
           this.flushPendingUtterance();
@@ -948,16 +967,27 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
 
   /**
    * Emit a single aggregated `final` for the withheld `is_final` segments
-   * of the current utterance. No-op when nothing is pending, so boundary
-   * signals over silence emit nothing.
+   * of the current utterance, carrying the dominance-ranked detected
+   * languages accumulated alongside them (fields omitted when no segment
+   * carried language metadata). No-op when nothing is pending, so
+   * boundary signals over silence emit nothing.
    */
   private flushPendingUtterance(): void {
     if (this.pendingFinalSegments.length === 0) {
+      // Tags accumulate only alongside text, but clear defensively so a
+      // future drift cannot leak one utterance's tags into the next.
+      this.pendingLanguageTags = [];
       return;
     }
     const text = this.pendingFinalSegments.join(" ");
+    const languages = rankLanguages(this.pendingLanguageTags);
     this.pendingFinalSegments = [];
-    this.emitEvent({ type: "final", text });
+    this.pendingLanguageTags = [];
+    this.emitEvent({
+      type: "final",
+      text,
+      ...(languages.length > 0 ? { language: languages[0], languages } : {}),
+    });
   }
 
   /**
@@ -1273,9 +1303,7 @@ function extractLanguages(
   channel: DeepgramStreamChannel | undefined,
   alternative: DeepgramStreamAlternative | undefined,
 ): string[] {
-  const wordTags = (alternative?.words ?? []).flatMap((word) =>
-    typeof word.language === "string" ? [word.language] : [],
-  );
+  const wordTags = collectWordLanguageTags(alternative);
   if (wordTags.length > 0) {
     return rankLanguages(wordTags);
   }
@@ -1292,6 +1320,21 @@ function extractLanguages(
       .filter((tag) => tag !== ""),
   );
   return [...deduped];
+}
+
+/**
+ * Collect the raw per-word `language` tags of a chunk, in word order and
+ * without ranking or normalization. Used both for per-frame ranking in
+ * {@link extractLanguages} and for cross-frame accumulation in
+ * utterance-boundary mode, where ranking is deferred to the flush so
+ * frequency weighting spans the whole utterance.
+ */
+function collectWordLanguageTags(
+  alternative: DeepgramStreamAlternative | undefined,
+): string[] {
+  return (alternative?.words ?? []).flatMap((word) =>
+    typeof word.language === "string" ? [word.language] : [],
+  );
 }
 
 function extractSpeakerLabel(

--- a/assistant/src/stt/__tests__/language-metadata.test.ts
+++ b/assistant/src/stt/__tests__/language-metadata.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+
+import { normalizeLanguageTag, rankLanguages } from "../language-metadata.js";
+
+describe("normalizeLanguageTag", () => {
+  test("lowercases a bare base subtag", () => {
+    expect(normalizeLanguageTag("EN")).toBe("en");
+  });
+
+  test("strips the region subtag", () => {
+    expect(normalizeLanguageTag("en-US")).toBe("en");
+  });
+
+  test("handles mixed-case regional tags", () => {
+    expect(normalizeLanguageTag("PT-br")).toBe("pt");
+  });
+
+  test("trims surrounding whitespace", () => {
+    expect(normalizeLanguageTag("  hi ")).toBe("hi");
+  });
+
+  test("returns empty string for blank input", () => {
+    expect(normalizeLanguageTag("")).toBe("");
+    expect(normalizeLanguageTag("   ")).toBe("");
+  });
+});
+
+describe("rankLanguages", () => {
+  test("returns empty array for empty input", () => {
+    expect(rankLanguages([])).toEqual([]);
+  });
+
+  test("ranks by frequency, most frequent first", () => {
+    expect(rankLanguages(["es", "en", "en", "en", "es"])).toEqual(["en", "es"]);
+  });
+
+  test("breaks ties by first appearance", () => {
+    expect(rankLanguages(["hi", "en", "en", "hi"])).toEqual(["hi", "en"]);
+  });
+
+  test("counts regional variants toward their base subtag", () => {
+    expect(rankLanguages(["en-US", "es", "en", "en-GB"])).toEqual(["en", "es"]);
+  });
+
+  test("skips blank tags", () => {
+    expect(rankLanguages(["", "  ", "ja"])).toEqual(["ja"]);
+  });
+
+  test("accepts any iterable", () => {
+    expect(rankLanguages(new Set(["fr", "de"]))).toEqual(["fr", "de"]);
+  });
+});

--- a/assistant/src/stt/language-metadata.ts
+++ b/assistant/src/stt/language-metadata.ts
@@ -1,0 +1,34 @@
+/**
+ * Pure helpers for normalizing and ranking detected-language tags emitted
+ * by streaming STT providers (e.g. Deepgram nova-3 `multi` per-word tags).
+ *
+ * Dependency-free leaf so provider adapters and event consumers can share
+ * one notion of a normalized language tag without coupling to each other.
+ */
+
+/**
+ * Normalize a BCP-47 language tag to its lowercase base subtag:
+ * "en-US" -> "en", "PT-br" -> "pt". Returns "" for blank input.
+ */
+export function normalizeLanguageTag(tag: string): string {
+  return tag.trim().toLowerCase().split("-")[0] ?? "";
+}
+
+/**
+ * Tally normalized language tags and return them most-frequent-first.
+ * Ties are broken by first appearance in the input. Blank tags are
+ * skipped; regional variants count toward their base subtag.
+ */
+export function rankLanguages(tags: Iterable<string>): string[] {
+  // Map iteration order is insertion order, so a stable sort by count
+  // leaves tied tags in first-appearance order.
+  const counts = new Map<string, number>();
+  for (const tag of tags) {
+    const normalized = normalizeLanguageTag(tag);
+    if (!normalized) {
+      continue;
+    }
+    counts.set(normalized, (counts.get(normalized) ?? 0) + 1);
+  }
+  return [...counts.entries()].sort((a, b) => b[1] - a[1]).map(([tag]) => tag);
+}

--- a/assistant/src/stt/types.ts
+++ b/assistant/src/stt/types.ts
@@ -263,6 +263,19 @@ export interface SttStreamServerPartialEvent {
    * provider does not surface confidence on interim chunks.
    */
   readonly confidence?: number;
+  /**
+   * Dominant detected language of this chunk as a lowercase base subtag
+   * (e.g. "en", "hi"). Only providers with code-switching metadata
+   * (currently Deepgram nova-3 `multi`) populate this. Consumers must
+   * treat absence as "unknown", never as English.
+   */
+  readonly language?: string;
+  /**
+   * All detected languages of this chunk in dominance order, normalized
+   * to lowercase base subtags. Populated under the same conditions as
+   * {@link language}; absence means "unknown", never English.
+   */
+  readonly languages?: readonly string[];
 }
 
 /**
@@ -279,6 +292,19 @@ export interface SttStreamServerFinalEvent {
    * provider does not surface confidence on this chunk.
    */
   readonly confidence?: number;
+  /**
+   * Dominant detected language of this chunk as a lowercase base subtag
+   * (e.g. "en", "hi"). Only providers with code-switching metadata
+   * (currently Deepgram nova-3 `multi`) populate this. Consumers must
+   * treat absence as "unknown", never as English.
+   */
+  readonly language?: string;
+  /**
+   * All detected languages of this chunk in dominance order, normalized
+   * to lowercase base subtags. Populated under the same conditions as
+   * {@link language}; absence means "unknown", never English.
+   */
+  readonly languages?: readonly string[];
   /**
    * True when this final is the flush response to
    * {@link StreamingTranscriber.finalizeUtterance} — i.e. it commits audio


### PR DESCRIPTION
## Summary
- Adds optional language / languages fields to STT streaming partial and final events
- Parses Deepgram nova-3 multi per-word language tags into dominance-ranked event metadata
- New pure helpers in stt/language-metadata.ts (normalize + rank), no consumers yet

Part of plan: voice-multilingual-pipeline.md (PR 1 of 6)