### PR TITLE
fix(web): stop the bell tooltip sticking open after leaving for a conversation

### DIFF
--- a/clients/web/src/domains/home/components/notifications-bell.tsx
+++ b/clients/web/src/domains/home/components/notifications-bell.tsx
@@ -185,29 +185,27 @@ export function NotificationsBell() {
   }, []);
 
   // Radix restores focus to the trigger when the popover closes, and Radix
-  // Tooltip opens on focus unless the focus followed a pointerdown on the
-  // trigger itself. Closing by clicking inside the panel (or outside it) puts
-  // focus back on the bell while the cursor is somewhere else entirely, so the
-  // "Notifications" tooltip springs open with no pointerleave ever coming to
-  // dismiss it, and it then rides along over whatever the click navigated to.
-  // This ref marks those pointer-driven closes so the focus restore can be
-  // skipped; Escape still restores focus, which keyboard users need to keep
-  // their place in the top bar. Same shape as the fix in the design library's
-  // `Menu.Content`.
-  //
-  // Not covered by a test: happy-dom's `fireEvent.click` never moves focus, so
-  // the FocusScope this turns on captures `<body>` rather than the trigger and
-  // no test in this file can reproduce the restore. Verified in Chromium
-  // instead. Unguarded left the tooltip open indefinitely after the close,
-  // guarded left it shut, and Escape still landed focus back on the trigger.
+  // Tooltip opens on focus unless that focus followed a pointerdown on the
+  // trigger. A close driven by a pointer that is somewhere else (a click on a
+  // panel control, or outside the panel) therefore lands focus on the bell
+  // with the cursor away from it, opening the "Notifications" tooltip with no
+  // pointerleave coming to dismiss it. Marks such a close so the focus
+  // restore can be skipped for it.
   const closedByPointerRef = useRef(false);
+
+  // Activation modality of the last interaction inside the panel. The panel's
+  // controls close it from `onClick`, which fires for Enter and Space as well
+  // as for a pointer, so the close handlers cannot infer a pointer on their
+  // own. Keyboard closes keep the focus restore, which keyboard users need to
+  // hold their place in the top bar.
+  const isPointerInteractionRef = useRef(false);
 
   const handleOpenChange = (open: boolean) => {
     setIsOpen(open);
     if (open) {
-      // Reopening starts a fresh close cycle. Guards against a stale `true`
-      // left behind by a close whose focus restore never ran.
+      // A fresh close cycle: neither flag carries over from the last one.
       closedByPointerRef.current = false;
+      isPointerInteractionRef.current = false;
     } else {
       // Reopening always lands on the list, at the top.
       setSelectedItemId(null);
@@ -215,9 +213,8 @@ export function NotificationsBell() {
     }
   };
 
-  // Every in-panel close is a click, so each one needs the tooltip suppressed.
-  const closePanelFromPointer = () => {
-    closedByPointerRef.current = true;
+  const closePanel = () => {
+    closedByPointerRef.current = isPointerInteractionRef.current;
     handleOpenChange(false);
   };
 
@@ -229,12 +226,12 @@ export function NotificationsBell() {
   };
 
   const handleGoToConversation = (conversationId: string) => {
-    closePanelFromPointer();
+    closePanel();
     navigateToConversation(navigate, conversationId);
   };
 
   const handleViewSchedule = (scheduleId: string) => {
-    closePanelFromPointer();
+    closePanel();
     navigate(routes.schedules.detail(scheduleId));
   };
 
@@ -265,7 +262,7 @@ export function NotificationsBell() {
       { itemId: selectedItem.id, actionId },
       {
         onSuccess: (data) => {
-          closePanelFromPointer();
+          closePanel();
           navigateToConversation(navigate, data.conversationId);
         },
         onError: () => {
@@ -464,6 +461,12 @@ export function NotificationsBell() {
           const content = event.currentTarget as HTMLElement | null;
           event.preventDefault();
           content?.focus();
+        }}
+        onPointerDownCapture={() => {
+          isPointerInteractionRef.current = true;
+        }}
+        onKeyDownCapture={() => {
+          isPointerInteractionRef.current = false;
         }}
         onPointerDownOutside={() => {
           closedByPointerRef.current = true;

--- a/clients/web/src/domains/home/components/notifications-bell.tsx
+++ b/clients/web/src/domains/home/components/notifications-bell.tsx
@@ -184,13 +184,41 @@ export function NotificationsBell() {
     }
   }, []);
 
+  // Radix restores focus to the trigger when the popover closes, and Radix
+  // Tooltip opens on focus unless the focus followed a pointerdown on the
+  // trigger itself. Closing by clicking inside the panel (or outside it) puts
+  // focus back on the bell while the cursor is somewhere else entirely, so the
+  // "Notifications" tooltip springs open with no pointerleave ever coming to
+  // dismiss it, and it then rides along over whatever the click navigated to.
+  // This ref marks those pointer-driven closes so the focus restore can be
+  // skipped; Escape still restores focus, which keyboard users need to keep
+  // their place in the top bar. Same shape as the fix in the design library's
+  // `Menu.Content`.
+  //
+  // Not covered by a test: happy-dom's `fireEvent.click` never moves focus, so
+  // the FocusScope this turns on captures `<body>` rather than the trigger and
+  // no test in this file can reproduce the restore. Verified in Chromium
+  // instead. Unguarded left the tooltip open indefinitely after the close,
+  // guarded left it shut, and Escape still landed focus back on the trigger.
+  const closedByPointerRef = useRef(false);
+
   const handleOpenChange = (open: boolean) => {
     setIsOpen(open);
-    if (!open) {
+    if (open) {
+      // Reopening starts a fresh close cycle. Guards against a stale `true`
+      // left behind by a close whose focus restore never ran.
+      closedByPointerRef.current = false;
+    } else {
       // Reopening always lands on the list, at the top.
       setSelectedItemId(null);
       listScrollTopRef.current = 0;
     }
+  };
+
+  // Every in-panel close is a click, so each one needs the tooltip suppressed.
+  const closePanelFromPointer = () => {
+    closedByPointerRef.current = true;
+    handleOpenChange(false);
   };
 
   const handleSelectItem = (item: FeedItem) => {
@@ -201,12 +229,12 @@ export function NotificationsBell() {
   };
 
   const handleGoToConversation = (conversationId: string) => {
-    handleOpenChange(false);
+    closePanelFromPointer();
     navigateToConversation(navigate, conversationId);
   };
 
   const handleViewSchedule = (scheduleId: string) => {
-    handleOpenChange(false);
+    closePanelFromPointer();
     navigate(routes.schedules.detail(scheduleId));
   };
 
@@ -237,7 +265,7 @@ export function NotificationsBell() {
       { itemId: selectedItem.id, actionId },
       {
         onSuccess: (data) => {
-          handleOpenChange(false);
+          closePanelFromPointer();
           navigateToConversation(navigate, data.conversationId);
         },
         onError: () => {
@@ -436,6 +464,15 @@ export function NotificationsBell() {
           const content = event.currentTarget as HTMLElement | null;
           event.preventDefault();
           content?.focus();
+        }}
+        onPointerDownOutside={() => {
+          closedByPointerRef.current = true;
+        }}
+        onCloseAutoFocus={(event) => {
+          if (closedByPointerRef.current) {
+            closedByPointerRef.current = false;
+            event.preventDefault();
+          }
         }}
         className="w-96 max-w-[calc(100vw-2rem)] rounded-lg p-2"
       >


### PR DESCRIPTION
## Summary

Clicking **Go to Conversation** in the notification bell detail left the "Notifications" tooltip stuck on screen, riding along over the conversation you just navigated to, until you hovered the bell again.

Radix restores focus to the trigger when a popover closes, and Radix Tooltip opens on focus *unless* that focus followed a `pointerdown` on the trigger itself (`react-tooltip` `onFocus`):

```js
onFocus: composeEventHandlers(props.onFocus, () => {
  if (!isPointerDownRef.current) context.onOpen();
}),
```

The pointerdown lands on the button *inside* the panel, not on the bell, so the flag is false, the tooltip opens on the focus restore, and the cursor is nowhere near the bell to send the `pointerleave` that would dismiss it.

## Changes

- Skip the focus restore for pointer-driven closes only, via `onCloseAutoFocus`. Same shape as the existing fix in the design library's `Menu.Content`.
- Route the three in-panel closes (Go to Conversation, View schedule, assistant action items) through one `closePanel` helper so a fourth added later cannot silently miss the guard.
- Track the activation modality of the last in-panel interaction (`onPointerDownCapture` / `onKeyDownCapture`) and have `closePanel` consult it. The panel's controls close it from `onClick`, which fires for Enter and Space too, so the handlers cannot infer a pointer on their own.
- Cover `onPointerDownOutside`: dismissing by clicking outside had the identical defect.

Keyboard closes keep their focus restore, which keyboard users need to hold their place in the top bar.

## Verification

No unit test. happy-dom's `fireEvent.click` never moves focus, so Radix's `FocusScope` captures `<body>` instead of the trigger and no test in this file can reproduce the restore. A test written against it passed identically with and without the fix, so it was dropped rather than shipped as vacuous coverage.

Verified in Chromium instead, against a harness mirroring the bell's exact composition.

Before the fix, both arms side by side:

| scenario | unguarded | guarded |
|---|---|---|
| close via in-panel click | tooltip open, still open after 3s | tooltip closed |
| close via Escape | n/a | focus back on trigger |
| plain hover on the bell | tooltip opens | tooltip opens |

After the review fix, each activation modality driven end to end:

| path | popover | focus after close | tooltip |
|---|---|---|---|
| Enter on Go to Conversation (Tab to it) | closed | restored to bell | n/a |
| mouse click on Go to Conversation | closed | not restored | closed |

Scoped checks: bell tests 48 pass / 0 fail, ESLint clean on the changed file.

> Local `tsc` reports 3 errors in `settings/ai` about `Select`'s `label` prop. These are a worktree artifact, not from this change: the worktree's `clients/web/node_modules` symlinks into the main checkout, whose `design-library` sits on an older branch that predates that prop. Zero errors reference the changed file; CI resolves correctly.

## Known remaining nuance

A mouse user who dismisses the panel with **Escape** still gets a briefly stuck tooltip, since that path keeps its focus restore by design. It clears on the next click or Tab, unlike the navigate case which stranded it over another page. Suppressing it there would mean breaking keyboard focus return, which seemed the worse trade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)