### PR TITLE
fix(tts): segment non-Latin sentences correctly for streaming synthesis

### DIFF
--- a/assistant/src/calls/__tests__/tts-text-sanitizer.test.ts
+++ b/assistant/src/calls/__tests__/tts-text-sanitizer.test.ts
@@ -98,6 +98,19 @@ describe("sanitizeForTts", () => {
         "use some_function_name here",
       );
     });
+
+    test("strips italic with accented content", () => {
+      expect(sanitizeForTts("Hello *café* there")).toBe("Hello café there");
+    });
+
+    test("strips underscore italic with CJK content", () => {
+      expect(sanitizeForTts("値は _変数_ です")).toBe("値は 変数 です");
+    });
+
+    test("does not strip a span whose marker touches a non-ASCII word char", () => {
+      expect(sanitizeForTts("*強調*です")).toBe("*強調*です");
+      expect(sanitizeForTts("café*note* x")).toBe("café*note* x");
+    });
   });
 
   describe("headers", () => {

--- a/assistant/src/calls/tts-text-sanitizer.ts
+++ b/assistant/src/calls/tts-text-sanitizer.ts
@@ -49,11 +49,18 @@ export function sanitizeForTts(text: string): string {
   result = result.replace(/^[-*]\s+/gm, "");
 
   // 7. Italic: *text* or _text_ → text
-  //    Word-boundary-aware with non-whitespace content edges, so arithmetic
-  //    like `5 * 3 and 4 * 2` and identifiers like `my_var` survive. Mirrors
-  //    the open-span rule in tts/speakable-segments.ts.
-  result = result.replace(/(?<!\w)\*([^\s*](?:[^*]*[^\s*])?)\*(?!\w)/g, "$1");
-  result = result.replace(/(?<!\w)_([^\s_](?:[^_]*[^\s_])?)_(?!\w)/g, "$1");
+  //    Word-boundary-aware (Unicode letters/digits, so café and 変数 count as
+  //    word chars) with non-whitespace content edges, so arithmetic like
+  //    `5 * 3 and 4 * 2` and identifiers like `my_var` survive. Mirrors the
+  //    open-span rule in tts/speakable-segments.ts.
+  result = result.replace(
+    /(?<![\p{L}\p{N}_])\*([^\s*](?:[^*]*[^\s*])?)\*(?![\p{L}\p{N}_])/gu,
+    "$1",
+  );
+  result = result.replace(
+    /(?<![\p{L}\p{N}_])_([^\s_](?:[^_]*[^\s_])?)_(?![\p{L}\p{N}_])/gu,
+    "$1",
+  );
 
   // 8. Emojis: strip extended pictographic characters, variation selectors,
   //    zero-width joiners, skin tone modifiers, and regional indicator symbols (flags).

--- a/assistant/src/tts/__tests__/speakable-segments.test.ts
+++ b/assistant/src/tts/__tests__/speakable-segments.test.ts
@@ -386,6 +386,38 @@ describe("extractSpeakableSegments", () => {
       expect(remainder).toBe("次です");
     });
 
+    test("the halfwidth ideographic full stop ends a sentence", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "こんにちは｡次です",
+        false,
+      );
+
+      expect(segments).toEqual(["こんにちは｡"]);
+      expect(remainder).toBe("次です");
+    });
+
+    test("non-Latin enders inside a Markdown link URL do not split", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "[記事](https://example.com/前編。後編)を読んで。次",
+        false,
+      );
+
+      expect(segments).toEqual([
+        "[記事](https://example.com/前編。後編)を読んで。",
+      ]);
+      expect(remainder).toBe("次");
+    });
+
+    test("an unclosed link URL still splits at a newline", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "[x](https://a。b\n次",
+        false,
+      );
+
+      expect(segments).toEqual(["[x](https://a。b"]);
+      expect(remainder).toBe("次");
+    });
+
     test("adjacent enders stay in one segment", () => {
       // 本当！？ must not emit 本当！ and then a punctuation-only ？ segment.
       const { segments, remainder } = extractSpeakableSegments(

--- a/assistant/src/tts/__tests__/speakable-segments.test.ts
+++ b/assistant/src/tts/__tests__/speakable-segments.test.ts
@@ -36,6 +36,16 @@ describe("extractSpeakableSegments", () => {
     expect(remainder).toBe("Version 3.5 is out");
   });
 
+  test("does not split inside a decimal number", () => {
+    const { segments, remainder } = extractSpeakableSegments(
+      "3.14 is pi.",
+      false,
+    );
+
+    expect(segments).toEqual(["3.14 is pi."]);
+    expect(remainder).toBe("");
+  });
+
   test("treats a newline as a segment boundary", () => {
     const { segments, remainder } = extractSpeakableSegments(
       "First line\nsecond line still going",
@@ -177,6 +187,96 @@ describe("extractSpeakableSegments", () => {
 
     test("non-eager extraction ignores clause punctuation", () => {
       const text = "Sure, I can help with that, and here is more";
+
+      const { segments, remainder } = extractSpeakableSegments(text, false);
+
+      expect(segments).toEqual([]);
+      expect(remainder).toBe(text);
+    });
+  });
+
+  describe("non-Latin scripts", () => {
+    test("splits Hindi at the danda", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "नमस्ते। आप कैसे हैं?",
+        false,
+      );
+
+      expect(segments).toEqual(["नमस्ते।", "आप कैसे हैं?"]);
+      expect(remainder).toBe("");
+    });
+
+    test("splits Japanese at the ideographic full stop with no whitespace", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "こんにちは。今日はいい天気ですね。",
+        false,
+      );
+
+      expect(segments).toEqual(["こんにちは。", "今日はいい天気ですね。"]);
+      expect(remainder).toBe("");
+    });
+
+    test("the Arabic question mark terminates a segment", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "كيف حالك؟ الطقس جميل",
+        false,
+      );
+
+      expect(segments).toEqual(["كيف حالك؟"]);
+      expect(remainder).toBe(" الطقس جميل");
+    });
+
+    test("eager mode splits at an ideographic comma with no whitespace", () => {
+      const text = `${"あ".repeat(30)}、まだ続く`;
+
+      const { segments, remainder } = extractSpeakableSegments(text, false, {
+        eager: true,
+      });
+
+      expect(segments).toEqual([`${"あ".repeat(30)}、`]);
+      expect(remainder).toBe("まだ続く");
+    });
+
+    test("hard-cap splits never break a surrogate pair", () => {
+      // "犬" shifts every non-BMP pair to an odd offset so the 180-unit cap
+      // lands mid-pair without the step-back.
+      const text = `犬${"𠮟".repeat(120)}`;
+
+      const { segments, remainder } = extractSpeakableSegments(text, false);
+
+      expect(segments).toHaveLength(1);
+      for (const segment of segments) {
+        expect(segment.isWellFormed()).toBe(true);
+      }
+      expect(remainder.isWellFormed()).toBe(true);
+      // No text is lost or reordered across the split.
+      expect(segments.join("") + remainder).toBe(text);
+    });
+
+    test("accented italic spans toggle like ASCII ones", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "*café. crème* done. And more",
+        false,
+      );
+
+      expect(segments).toEqual(["*café. crème* done."]);
+      expect(remainder).toBe(" And more");
+    });
+
+    test("CJK underscore spans toggle like ASCII ones", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "_変数_ です。まだ続きます",
+        false,
+      );
+
+      expect(segments).toEqual(["_変数_ です。"]);
+      expect(remainder).toBe("まだ続きます");
+    });
+
+    test("a span closer touching a CJK word char keeps the span open", () => {
+      // Mirrors the sanitizer's Unicode lookarounds: it leaves *強調*です
+      // unstripped, so splitting after the 。 would leak the markers.
+      const text = "*強調*です。まだ続く";
 
       const { segments, remainder } = extractSpeakableSegments(text, false);
 

--- a/assistant/src/tts/__tests__/speakable-segments.test.ts
+++ b/assistant/src/tts/__tests__/speakable-segments.test.ts
@@ -418,6 +418,21 @@ describe("extractSpeakableSegments", () => {
       expect(remainder).toBe("次");
     });
 
+    test("balanced parens inside a link URL keep suppressing boundaries", () => {
+      // The sanitizer's link pattern accepts balanced parens inside URLs
+      // (Wikipedia-style paths), so the segmenter must not exit the URL at
+      // the inner closing paren and split at a later terminator.
+      const { segments, remainder } = extractSpeakableSegments(
+        "[記事](https://example.com/a_(b)/前編。後編)を読んで。次",
+        false,
+      );
+
+      expect(segments).toEqual([
+        "[記事](https://example.com/a_(b)/前編。後編)を読んで。",
+      ]);
+      expect(remainder).toBe("次");
+    });
+
     test("adjacent enders stay in one segment", () => {
       // 本当！？ must not emit 本当！ and then a punctuation-only ？ segment.
       const { segments, remainder } = extractSpeakableSegments(

--- a/assistant/src/tts/__tests__/speakable-segments.test.ts
+++ b/assistant/src/tts/__tests__/speakable-segments.test.ts
@@ -215,11 +215,37 @@ describe("extractSpeakableSegments", () => {
 
     test("splits Japanese at the ideographic full stop with no whitespace", () => {
       const { segments, remainder } = extractSpeakableSegments(
-        "こんにちは。今日はいい天気ですね。",
+        "こんにちは。今日はいい天気ですね。続き",
         false,
       );
 
       expect(segments).toEqual(["こんにちは。", "今日はいい天気ですね。"]);
+      expect(remainder).toBe("続き");
+    });
+
+    test("a buffer ending at a non-Latin ender keeps buffering for closers", () => {
+      // Streaming deltas can split a quoted sentence: `「こんにちは。`
+      // arrives first and `」次です。` in the next delta. A boundary at the
+      // buffer-final 。 would orphan the 」 into the next segment.
+      const firstDelta = extractSpeakableSegments("「こんにちは。", false);
+      expect(firstDelta.segments).toEqual([]);
+      expect(firstDelta.remainder).toBe("「こんにちは。");
+
+      const afterNextDelta = extractSpeakableSegments(
+        `${firstDelta.remainder}」次です。`,
+        false,
+      );
+      expect(afterNextDelta.segments).toEqual(["「こんにちは。」"]);
+      expect(afterNextDelta.remainder).toBe("次です。");
+    });
+
+    test("force still flushes a buffer ending at an ideographic full stop", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "終わりです。",
+        true,
+      );
+
+      expect(segments).toEqual(["終わりです。"]);
       expect(remainder).toBe("");
     });
 
@@ -241,6 +267,42 @@ describe("extractSpeakableSegments", () => {
       });
 
       expect(segments).toEqual([`${"あ".repeat(30)}、`]);
+      expect(remainder).toBe("まだ続く");
+    });
+
+    test("eager mode keeps a fullwidth grouping comma inside a number", () => {
+      const text =
+        "これは長い導入文で二十四文字を確実に超えています１，０００円です";
+
+      const { segments, remainder } = extractSpeakableSegments(text, false, {
+        eager: true,
+      });
+
+      expect(segments).toEqual([]);
+      expect(remainder).toBe(text);
+    });
+
+    test("eager mode defers a digit-final fullwidth comma at the buffer edge", () => {
+      // The grouped digits may arrive in the next delta (`１，` then
+      // `０００円`), so a buffer-final comma after a digit keeps buffering.
+      const text = "これは長い導入文で二十四文字を確実に超えています１，";
+
+      const { segments, remainder } = extractSpeakableSegments(text, false, {
+        eager: true,
+      });
+
+      expect(segments).toEqual([]);
+      expect(remainder).toBe(text);
+    });
+
+    test("eager mode still splits at a fullwidth comma between non-digits", () => {
+      const text = `${"あ".repeat(30)}，まだ続く`;
+
+      const { segments, remainder } = extractSpeakableSegments(text, false, {
+        eager: true,
+      });
+
+      expect(segments).toEqual([`${"あ".repeat(30)}，`]);
       expect(remainder).toBe("まだ続く");
     });
 
@@ -300,11 +362,11 @@ describe("extractSpeakableSegments", () => {
       expect(firstDelta.remainder).toBe("３．");
 
       const afterNextDelta = extractSpeakableSegments(
-        `${firstDelta.remainder}１４です。`,
+        `${firstDelta.remainder}１４です。次`,
         false,
       );
       expect(afterNextDelta.segments).toEqual(["３．１４です。"]);
-      expect(afterNextDelta.remainder).toBe("");
+      expect(afterNextDelta.remainder).toBe("次");
     });
 
     test("force still flushes a buffer ending at a fullwidth full stop", () => {
@@ -330,8 +392,10 @@ describe("extractSpeakableSegments", () => {
         false,
       );
 
-      expect(segments).toEqual(["「こんにちは。」", "次です。"]);
-      expect(remainder).toBe("");
+      expect(segments).toEqual(["「こんにちは。」"]);
+      // The trailing sentence ends at the buffer edge, so it keeps
+      // buffering in case the next delta opens with a closer.
+      expect(remainder).toBe("次です。");
     });
 
     test("keeps a CJK double angle bracket with its sentence", () => {
@@ -340,8 +404,8 @@ describe("extractSpeakableSegments", () => {
         false,
       );
 
-      expect(segments).toEqual(["《こんにちは。》", "次です。"]);
-      expect(remainder).toBe("");
+      expect(segments).toEqual(["《こんにちは。》"]);
+      expect(remainder).toBe("次です。");
     });
 
     test("keeps a closing curly quote with its sentence", () => {

--- a/assistant/src/tts/__tests__/speakable-segments.test.ts
+++ b/assistant/src/tts/__tests__/speakable-segments.test.ts
@@ -5,6 +5,12 @@ import { extractSpeakableSegments } from "../speakable-segments.js";
 const DEFAULT_CHAR_THRESHOLD = 180;
 const EAGER_CHAR_THRESHOLD = 60;
 
+// The compile target's lib predates String.prototype.isWellFormed; Bun
+// supports it at runtime.
+function isWellFormedUtf16(value: string): boolean {
+  return (value as string & { isWellFormed(): boolean }).isWellFormed();
+}
+
 describe("extractSpeakableSegments", () => {
   test("splits complete sentences and keeps the trailing fragment as remainder", () => {
     const { segments, remainder } = extractSpeakableSegments(
@@ -246,9 +252,9 @@ describe("extractSpeakableSegments", () => {
 
       expect(segments).toHaveLength(1);
       for (const segment of segments) {
-        expect(segment.isWellFormed()).toBe(true);
+        expect(isWellFormedUtf16(segment)).toBe(true);
       }
-      expect(remainder.isWellFormed()).toBe(true);
+      expect(isWellFormedUtf16(remainder)).toBe(true);
       // No text is lost or reordered across the split.
       expect(segments.join("") + remainder).toBe(text);
     });

--- a/assistant/src/tts/__tests__/speakable-segments.test.ts
+++ b/assistant/src/tts/__tests__/speakable-segments.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import { sanitizeForTts } from "../../calls/tts-text-sanitizer.js";
 import { extractSpeakableSegments } from "../speakable-segments.js";
 
 const DEFAULT_CHAR_THRESHOLD = 180;
@@ -277,6 +278,81 @@ describe("extractSpeakableSegments", () => {
 
       expect(segments).toEqual(["_変数_ です。"]);
       expect(remainder).toBe("まだ続きます");
+    });
+
+    test("does not split a fullwidth decimal number", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "３．１４です",
+        false,
+      );
+
+      expect(segments).toEqual([]);
+      expect(remainder).toBe("３．１４です");
+    });
+
+    test("the fullwidth full stop still ends a genuine sentence", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "終わりです．次です",
+        false,
+      );
+
+      expect(segments).toEqual(["終わりです．"]);
+      expect(remainder).toBe("次です");
+    });
+
+    test("keeps a CJK closing bracket with its sentence", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "「こんにちは。」次です。",
+        false,
+      );
+
+      expect(segments).toEqual(["「こんにちは。」", "次です。"]);
+      expect(remainder).toBe("");
+    });
+
+    test("keeps a closing curly quote with its sentence", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "“早く！”と言った。まだ続く",
+        false,
+      );
+
+      expect(segments).toEqual(["“早く！”", "と言った。"]);
+      expect(remainder).toBe("まだ続く");
+    });
+
+    test("a span closer touching an astral word char keeps the span open", () => {
+      // 𠮟 is a non-BMP letter (surrogate pair). The sanitizer's Unicode
+      // lookarounds see it as \p{L} and leave *note*𠮟 unstripped, so the
+      // segmenter must agree and defer the boundary at the period.
+      const text = "*note*𠮟. Next";
+
+      const { segments, remainder } = extractSpeakableSegments(text, false);
+
+      expect(segments).toEqual([]);
+      expect(remainder).toBe(text);
+
+      // Forced flush keeps the whole span in one segment, so per-segment
+      // sanitization matches whole-text sanitization: no unbalanced marker
+      // is spoken.
+      const forced = extractSpeakableSegments(text, true);
+      expect(forced.segments.map(sanitizeForTts).join("")).toBe(
+        sanitizeForTts(text),
+      );
+    });
+
+    test("astral underscore spans toggle like BMP ones", () => {
+      // prev/next of both `_` markers are surrogate-pair halves; assembled
+      // code points make the span open and close exactly as the sanitizer's
+      // lookarounds do, so the split after 。 leaks no markers.
+      const { segments, remainder } = extractSpeakableSegments(
+        "_𠮟_ です。まだ続く",
+        false,
+      );
+
+      expect(segments).toEqual(["_𠮟_ です。"]);
+      expect(remainder).toBe("まだ続く");
+      // The sanitizer strips the balanced span, so nothing leaks.
+      expect(sanitizeForTts(segments[0] ?? "")).toBe("𠮟 です。");
     });
 
     test("a span closer touching a CJK word char keeps the span open", () => {

--- a/assistant/src/tts/__tests__/speakable-segments.test.ts
+++ b/assistant/src/tts/__tests__/speakable-segments.test.ts
@@ -290,6 +290,30 @@ describe("extractSpeakableSegments", () => {
       expect(remainder).toBe("３．１４です");
     });
 
+    test("a buffer ending exactly at a fullwidth full stop keeps buffering", () => {
+      // Streaming deltas can split a fullwidth decimal: `３．` arrives
+      // first and `１４です` in the next delta. The trailing ．must not be
+      // classified as a sentence boundary until the next character shows
+      // whether it is a decimal point.
+      const firstDelta = extractSpeakableSegments("３．", false);
+      expect(firstDelta.segments).toEqual([]);
+      expect(firstDelta.remainder).toBe("３．");
+
+      const afterNextDelta = extractSpeakableSegments(
+        `${firstDelta.remainder}１４です。`,
+        false,
+      );
+      expect(afterNextDelta.segments).toEqual(["３．１４です。"]);
+      expect(afterNextDelta.remainder).toBe("");
+    });
+
+    test("force still flushes a buffer ending at a fullwidth full stop", () => {
+      const { segments, remainder } = extractSpeakableSegments("３．", true);
+
+      expect(segments).toEqual(["３．"]);
+      expect(remainder).toBe("");
+    });
+
     test("the fullwidth full stop still ends a genuine sentence", () => {
       const { segments, remainder } = extractSpeakableSegments(
         "終わりです．次です",
@@ -307,6 +331,16 @@ describe("extractSpeakableSegments", () => {
       );
 
       expect(segments).toEqual(["「こんにちは。」", "次です。"]);
+      expect(remainder).toBe("");
+    });
+
+    test("keeps a CJK double angle bracket with its sentence", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "《こんにちは。》次です。",
+        false,
+      );
+
+      expect(segments).toEqual(["《こんにちは。》", "次です。"]);
       expect(remainder).toBe("");
     });
 

--- a/assistant/src/tts/__tests__/speakable-segments.test.ts
+++ b/assistant/src/tts/__tests__/speakable-segments.test.ts
@@ -386,6 +386,37 @@ describe("extractSpeakableSegments", () => {
       expect(remainder).toBe("次です");
     });
 
+    test("adjacent enders stay in one segment", () => {
+      // 本当！？ must not emit 本当！ and then a punctuation-only ？ segment.
+      const { segments, remainder } = extractSpeakableSegments(
+        "本当！？次です",
+        false,
+      );
+
+      expect(segments).toEqual(["本当！？"]);
+      expect(remainder).toBe("次です");
+    });
+
+    test("adjacent enders followed by a closer stay together", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "「本当！？」次です",
+        false,
+      );
+
+      expect(segments).toEqual(["「本当！？」"]);
+      expect(remainder).toBe("次です");
+    });
+
+    test("a fullwidth stop inside a filename-style token does not split", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "添付のreport．pdfを見てください。次です",
+        false,
+      );
+
+      expect(segments).toEqual(["添付のreport．pdfを見てください。"]);
+      expect(remainder).toBe("次です");
+    });
+
     test("keeps a CJK closing bracket with its sentence", () => {
       const { segments, remainder } = extractSpeakableSegments(
         "「こんにちは。」次です。",

--- a/assistant/src/tts/speakable-segments.ts
+++ b/assistant/src/tts/speakable-segments.ts
@@ -152,8 +152,11 @@ function findSpeakableBoundary(
   // Inside a Markdown link URL (`](...)`), non-Latin terminators are path
   // characters, not sentence enders: splitting there leaves both fragments
   // unmatchable by the sanitizer's complete-link pattern, so markup or the
-  // raw URL gets spoken.
-  let inLinkUrl = false;
+  // raw URL gets spoken. Tracked as a paren depth, not a boolean, because
+  // the sanitizer's link pattern accepts balanced parens inside the URL
+  // (https://example.com/a_(b)/c) and the suppression must cover the same
+  // links. 0 = not inside a URL.
+  let linkUrlDepth = 0;
 
   for (let index = 0; index < text.length; index += 1) {
     const char = text[index];
@@ -165,20 +168,24 @@ function findSpeakableBoundary(
     if (char === "\n") {
       // A URL never spans a line: an unclosed link stops suppressing here so
       // malformed markup cannot defer the newline split.
-      inLinkUrl = false;
+      linkUrlDepth = 0;
       if (!inOpenSpan) {
         return index + 1;
       }
     }
 
-    if (inLinkUrl) {
-      if (char === ")") {
-        inLinkUrl = false;
+    if (linkUrlDepth > 0) {
+      if (char === "(") {
+        linkUrlDepth += 1;
+      } else if (char === ")") {
+        linkUrlDepth -= 1;
       }
       continue;
     }
     if (char === "]" && text[index + 1] === "(") {
-      inLinkUrl = true;
+      linkUrlDepth = 1;
+      // Skip the opening paren so it does not double-count the depth.
+      index += 1;
       continue;
     }
 

--- a/assistant/src/tts/speakable-segments.ts
+++ b/assistant/src/tts/speakable-segments.ts
@@ -7,20 +7,55 @@
  * as soon as it is complete, so speech starts before the full response lands.
  */
 
+import { isHighSurrogate } from "../util/unicode.js";
+
 const DEFAULT_CHAR_THRESHOLD = 180;
 const EAGER_CHAR_THRESHOLD = 60;
 
-const SENTENCE_ENDING_PUNCTUATION = new Set([".", "!", "?"]);
+// Sentence enders in scripts without inter-word whitespace (CJK, Thai) or
+// with their own terminators (Devanagari danda, Arabic-script marks). Unlike
+// ASCII `. ! ?`, these are unambiguous: a boundary after one is valid even
+// with no following whitespace.
+const NON_LATIN_SENTENCE_ENDING_PUNCTUATION = new Set([
+  "。", // ideographic full stop
+  "！", // fullwidth exclamation mark
+  "？", // fullwidth question mark
+  "．", // fullwidth full stop
+  "।", // Devanagari danda
+  "॥", // Devanagari double danda
+  "؟", // Arabic question mark
+  "۔", // Arabic full stop
+]);
+const SENTENCE_ENDING_PUNCTUATION = new Set([
+  ".",
+  "!",
+  "?",
+  ...NON_LATIN_SENTENCE_ENDING_PUNCTUATION,
+]);
 const TRAILING_SENTENCE_PUNCTUATION = new Set(['"', "'", ")", "]"]);
-const EAGER_CLAUSE_PUNCTUATION = new Set([",", ";", ":"]);
+// Clause punctuation in whitespace-free scripts is likewise a valid eager
+// boundary regardless of what follows.
+const NON_LATIN_EAGER_CLAUSE_PUNCTUATION = new Set([
+  "、", // ideographic comma
+  "，", // fullwidth comma
+  "；", // fullwidth semicolon
+  "،", // Arabic comma
+]);
+const EAGER_CLAUSE_PUNCTUATION = new Set([
+  ",",
+  ";",
+  ":",
+  ...NON_LATIN_EAGER_CLAUSE_PUNCTUATION,
+]);
 // A clause boundary only counts in eager mode once this much text precedes
 // it — "Sure, " alone would be a one-word blip.
 const EAGER_MIN_CLAUSE_PREFIX_CHARS = 24;
 
 export interface ExtractSpeakableSegmentsOptions {
   /**
-   * Trade segment quality for onset latency: clause punctuation (`,` `;` `:`)
-   * followed by whitespace also ends a segment once at least
+   * Trade segment quality for onset latency: clause punctuation (`,` `;` `:`
+   * followed by whitespace, or a non-Latin clause mark like `、` `，` `،`
+   * regardless of what follows) also ends a segment once at least
    * ~24 chars precede it, and the max buffered length before a forced split
    * drops from 180 to 60 chars. Applies only until the
    * first segment of the call is found — later segments keep full-sentence
@@ -96,7 +131,8 @@ function findSpeakableBoundary(
       eager &&
       EAGER_CLAUSE_PUNCTUATION.has(char) &&
       index >= EAGER_MIN_CLAUSE_PREFIX_CHARS &&
-      isWhitespace(text[index + 1] ?? "")
+      (NON_LATIN_EAGER_CLAUSE_PUNCTUATION.has(char) ||
+        isWhitespace(text[index + 1] ?? ""))
     ) {
       return index + 1;
     }
@@ -109,7 +145,14 @@ function findSpeakableBoundary(
       ) {
         boundary += 1;
       }
-      if (boundary === text.length || isWhitespace(text[boundary] ?? "")) {
+      // ASCII enders require following whitespace so decimals (3.14) and
+      // file names don't split; the non-Latin enders are valid boundaries
+      // regardless of what follows.
+      if (
+        NON_LATIN_SENTENCE_ENDING_PUNCTUATION.has(char) ||
+        boundary === text.length ||
+        isWhitespace(text[boundary] ?? "")
+      ) {
         return boundary;
       }
     }
@@ -162,13 +205,21 @@ function findSpeakableBoundary(
   }
 
   // Length-threshold splits are a hard cap and must flush even inside an
-  // open span — unbalanced markers there are an accepted edge.
+  // open span: unbalanced markers there are an accepted edge.
   const preferredBoundary = findLastWhitespaceBoundary(text, charThreshold);
-  return preferredBoundary ?? charThreshold;
+  if (preferredBoundary !== null) {
+    return preferredBoundary;
+  }
+  // Never split a UTF-16 surrogate pair: if the cap lands mid-pair, step
+  // back one unit so both halves stay in the same segment.
+  if (isHighSurrogate(text.charCodeAt(charThreshold - 1))) {
+    return charThreshold - 1;
+  }
+  return charThreshold;
 }
 
 function isWordChar(value: string | undefined): boolean {
-  return value !== undefined && /\w/.test(value);
+  return value !== undefined && /[\p{L}\p{N}_]/u.test(value);
 }
 
 function findLastWhitespaceBoundary(

--- a/assistant/src/tts/speakable-segments.ts
+++ b/assistant/src/tts/speakable-segments.ts
@@ -52,6 +52,11 @@ const NON_LATIN_TRAILING_SENTENCE_PUNCTUATION = new Set([
   "〕",
   "〙",
   "〗",
+  "〛",
+  "》",
+  "〉",
+  "］",
+  "｝",
   "”",
   "’",
   "»",
@@ -164,9 +169,16 @@ function findSpeakableBoundary(
       const isNonLatinEnder = NON_LATIN_SENTENCE_ENDING_PUNCTUATION.has(char);
       // The fullwidth full stop doubles as a decimal point in fullwidth
       // numbers (３．１４です), so a following digit suppresses the boundary.
-      const isDecimalPoint =
-        char === FULLWIDTH_FULL_STOP && isDecimalDigit(text[index + 1]);
-      if (isNonLatinEnder && !isDecimalPoint) {
+      // A buffer-final ． is equally ambiguous while streaming: the digits
+      // may arrive in the next delta (e.g. `３．` then `１４です`), so wait
+      // for another character. The `force` flush path still emits a genuine
+      // sentence-final ．at end of turn. The ideographic 。 never marks
+      // decimals and stays unconditional.
+      const charAfterStop = text[index + 1];
+      const isAmbiguousDecimalPoint =
+        char === FULLWIDTH_FULL_STOP &&
+        (charAfterStop === undefined || isDecimalDigit(charAfterStop));
+      if (isNonLatinEnder && !isAmbiguousDecimalPoint) {
         // Non-Latin enders are valid boundaries regardless of what follows;
         // consume locale closers so they stay with their sentence.
         let boundary = index + 1;

--- a/assistant/src/tts/speakable-segments.ts
+++ b/assistant/src/tts/speakable-segments.ts
@@ -18,6 +18,7 @@ const EAGER_CHAR_THRESHOLD = 60;
 // with no following whitespace.
 const NON_LATIN_SENTENCE_ENDING_PUNCTUATION = new Set([
   "。", // ideographic full stop
+  "｡", // halfwidth ideographic full stop
   "！", // fullwidth exclamation mark
   "？", // fullwidth question mark
   "．", // fullwidth full stop (digit-guarded below: also a decimal point)
@@ -46,6 +47,7 @@ const TRAILING_SENTENCE_PUNCTUATION = new Set(['"', "'", ")", "]"]);
 const NON_LATIN_TRAILING_SENTENCE_PUNCTUATION = new Set([
   ...TRAILING_SENTENCE_PUNCTUATION,
   "」",
+  "｣", // halfwidth corner bracket closer
   "』",
   "）",
   "】",
@@ -65,6 +67,7 @@ const NON_LATIN_TRAILING_SENTENCE_PUNCTUATION = new Set([
 // boundary regardless of what follows.
 const NON_LATIN_EAGER_CLAUSE_PUNCTUATION = new Set([
   "、", // ideographic comma
+  "､", // halfwidth ideographic comma
   "，", // fullwidth comma
   "；", // fullwidth semicolon
   "،", // Arabic comma
@@ -146,6 +149,11 @@ function findSpeakableBoundary(
   let inItalic = false;
   let inUnderscore = false;
   let skipSpanChar = false;
+  // Inside a Markdown link URL (`](...)`), non-Latin terminators are path
+  // characters, not sentence enders: splitting there leaves both fragments
+  // unmatchable by the sanitizer's complete-link pattern, so markup or the
+  // raw URL gets spoken.
+  let inLinkUrl = false;
 
   for (let index = 0; index < text.length; index += 1) {
     const char = text[index];
@@ -154,8 +162,24 @@ function findSpeakableBoundary(
     }
     const inOpenSpan = inBacktick || inBold || inItalic || inUnderscore;
 
-    if (!inOpenSpan && char === "\n") {
-      return index + 1;
+    if (char === "\n") {
+      // A URL never spans a line: an unclosed link stops suppressing here so
+      // malformed markup cannot defer the newline split.
+      inLinkUrl = false;
+      if (!inOpenSpan) {
+        return index + 1;
+      }
+    }
+
+    if (inLinkUrl) {
+      if (char === ")") {
+        inLinkUrl = false;
+      }
+      continue;
+    }
+    if (char === "]" && text[index + 1] === "(") {
+      inLinkUrl = true;
+      continue;
     }
 
     if (

--- a/assistant/src/tts/speakable-segments.ts
+++ b/assistant/src/tts/speakable-segments.ts
@@ -174,15 +174,25 @@ function findSpeakableBoundary(
       const isNonLatinEnder = NON_LATIN_SENTENCE_ENDING_PUNCTUATION.has(char);
       // The fullwidth full stop doubles as a decimal point in fullwidth
       // numbers (３．１４です), so a following digit suppresses the boundary.
+      // It also appears inside Latin filename-style tokens (report．pdf):
+      // ASCII word chars on both sides mark it as part of the token, not a
+      // sentence end. CJK neighbors keep the boundary, since Japanese
+      // sentences legitimately end in ． between CJK words.
       const isAmbiguousDecimalPoint =
-        char === FULLWIDTH_FULL_STOP && isDecimalDigit(text[index + 1]);
+        char === FULLWIDTH_FULL_STOP &&
+        (isDecimalDigit(text[index + 1]) ||
+          (isAsciiWordChar(text[index - 1]) &&
+            isAsciiWordChar(text[index + 1])));
       if (isNonLatinEnder && !isAmbiguousDecimalPoint) {
         // Non-Latin enders are valid boundaries regardless of what follows;
+        // consume adjacent enders (本当！？) so combined punctuation keeps
+        // its prosody and never becomes a punctuation-only segment, then
         // consume locale closers so they stay with their sentence.
         let boundary = index + 1;
         while (
           boundary < text.length &&
-          NON_LATIN_TRAILING_SENTENCE_PUNCTUATION.has(text[boundary] ?? "")
+          (NON_LATIN_SENTENCE_ENDING_PUNCTUATION.has(text[boundary] ?? "") ||
+            NON_LATIN_TRAILING_SENTENCE_PUNCTUATION.has(text[boundary] ?? ""))
         ) {
           boundary += 1;
         }
@@ -285,6 +295,12 @@ function isWordChar(value: string | undefined): boolean {
 
 function isDecimalDigit(value: string | undefined): boolean {
   return value !== undefined && /[0-9０-９]/.test(value);
+}
+
+// ASCII-only on purpose: filename-style tokens (report．pdf) are Latin
+// script, while CJK neighbors around ． mark real sentence text.
+function isAsciiWordChar(value: string | undefined): boolean {
+  return value !== undefined && /[A-Za-z0-9_]/.test(value);
 }
 
 /**

--- a/assistant/src/tts/speakable-segments.ts
+++ b/assistant/src/tts/speakable-segments.ts
@@ -75,6 +75,10 @@ const EAGER_CLAUSE_PUNCTUATION = new Set([
   ":",
   ...NON_LATIN_EAGER_CLAUSE_PUNCTUATION,
 ]);
+// The fullwidth comma also serves as a thousands separator in fullwidth
+// numbers (１，０００円), so it is not a clause boundary inside a number. The
+// ideographic comma 、 never appears in numbers and needs no guard.
+const FULLWIDTH_COMMA = "，";
 // A clause boundary only counts in eager mode once this much text precedes
 // it — "Sure, " alone would be a one-word blip.
 const EAGER_MIN_CLAUSE_PREFIX_CHARS = 24;
@@ -160,7 +164,8 @@ function findSpeakableBoundary(
       EAGER_CLAUSE_PUNCTUATION.has(char) &&
       index >= EAGER_MIN_CLAUSE_PREFIX_CHARS &&
       (NON_LATIN_EAGER_CLAUSE_PUNCTUATION.has(char) ||
-        isWhitespace(text[index + 1] ?? ""))
+        isWhitespace(text[index + 1] ?? "")) &&
+      !isFullwidthGroupingComma(text, index)
     ) {
       return index + 1;
     }
@@ -169,15 +174,8 @@ function findSpeakableBoundary(
       const isNonLatinEnder = NON_LATIN_SENTENCE_ENDING_PUNCTUATION.has(char);
       // The fullwidth full stop doubles as a decimal point in fullwidth
       // numbers (３．１４です), so a following digit suppresses the boundary.
-      // A buffer-final ． is equally ambiguous while streaming: the digits
-      // may arrive in the next delta (e.g. `３．` then `１４です`), so wait
-      // for another character. The `force` flush path still emits a genuine
-      // sentence-final ．at end of turn. The ideographic 。 never marks
-      // decimals and stays unconditional.
-      const charAfterStop = text[index + 1];
       const isAmbiguousDecimalPoint =
-        char === FULLWIDTH_FULL_STOP &&
-        (charAfterStop === undefined || isDecimalDigit(charAfterStop));
+        char === FULLWIDTH_FULL_STOP && isDecimalDigit(text[index + 1]);
       if (isNonLatinEnder && !isAmbiguousDecimalPoint) {
         // Non-Latin enders are valid boundaries regardless of what follows;
         // consume locale closers so they stay with their sentence.
@@ -188,7 +186,16 @@ function findSpeakableBoundary(
         ) {
           boundary += 1;
         }
-        return boundary;
+        // A buffer-final ender is ambiguous while streaming: the next delta
+        // may open with closers that belong to this sentence (`「こんにちは。`
+        // then `」`) or, for ．, with decimal digits (`３．` then `１４です`).
+        // Keep buffering; the `force` flush path still emits a buffer-final
+        // sentence at end of turn, and the length cap below still bounds the
+        // buffer. ASCII enders keep their end-of-text boundary: whitespace
+        // scripts do not attach closers across deltas the same way.
+        if (boundary < text.length) {
+          return boundary;
+        }
       }
       if (!isNonLatinEnder) {
         // ASCII enders require following whitespace so decimals (3.14) and
@@ -278,6 +285,19 @@ function isWordChar(value: string | undefined): boolean {
 
 function isDecimalDigit(value: string | undefined): boolean {
   return value !== undefined && /[0-9０-９]/.test(value);
+}
+
+/**
+ * A fullwidth comma acting as a thousands separator (１，０００円): a digit
+ * precedes it and a digit follows, or the buffer ends right after it while
+ * streaming (the digits may arrive in the next delta, so keep buffering).
+ */
+function isFullwidthGroupingComma(text: string, index: number): boolean {
+  if (text[index] !== FULLWIDTH_COMMA || !isDecimalDigit(text[index - 1])) {
+    return false;
+  }
+  const next = text[index + 1];
+  return next === undefined || isDecimalDigit(next);
 }
 
 /**

--- a/assistant/src/tts/speakable-segments.ts
+++ b/assistant/src/tts/speakable-segments.ts
@@ -7,7 +7,7 @@
  * as soon as it is complete, so speech starts before the full response lands.
  */
 
-import { isHighSurrogate } from "../util/unicode.js";
+import { isHighSurrogate, isLowSurrogate } from "../util/unicode.js";
 
 const DEFAULT_CHAR_THRESHOLD = 180;
 const EAGER_CHAR_THRESHOLD = 60;
@@ -20,7 +20,7 @@ const NON_LATIN_SENTENCE_ENDING_PUNCTUATION = new Set([
   "。", // ideographic full stop
   "！", // fullwidth exclamation mark
   "？", // fullwidth question mark
-  "．", // fullwidth full stop
+  "．", // fullwidth full stop (digit-guarded below: also a decimal point)
   "।", // Devanagari danda
   "॥", // Devanagari double danda
   "؟", // Arabic question mark
@@ -32,7 +32,30 @@ const SENTENCE_ENDING_PUNCTUATION = new Set([
   "?",
   ...NON_LATIN_SENTENCE_ENDING_PUNCTUATION,
 ]);
+// Unlike the other non-Latin enders, the fullwidth full stop also serves as
+// a decimal point in fullwidth numbers (３．１４), so it is not a boundary
+// when a digit follows. The ideographic full stop 。 never marks decimals
+// and stays unconditional.
+const FULLWIDTH_FULL_STOP = "．";
 const TRAILING_SENTENCE_PUNCTUATION = new Set(['"', "'", ")", "]"]);
+// After a non-Latin ender, locale closers (CJK corner brackets, curly
+// quotes, guillemets) belong to the sentence they follow, exactly like the
+// ASCII closers above; without this, 「こんにちは。」 would orphan 」 into
+// the next segment. Superset of the ASCII closers so mixed-script text still
+// consumes those too.
+const NON_LATIN_TRAILING_SENTENCE_PUNCTUATION = new Set([
+  ...TRAILING_SENTENCE_PUNCTUATION,
+  "」",
+  "』",
+  "）",
+  "】",
+  "〕",
+  "〙",
+  "〗",
+  "”",
+  "’",
+  "»",
+]);
 // Clause punctuation in whitespace-free scripts is likewise a valid eager
 // boundary regardless of what follows.
 const NON_LATIN_EAGER_CLAUSE_PUNCTUATION = new Set([
@@ -138,22 +161,36 @@ function findSpeakableBoundary(
     }
 
     if (!inOpenSpan && SENTENCE_ENDING_PUNCTUATION.has(char)) {
-      let boundary = index + 1;
-      while (
-        boundary < text.length &&
-        TRAILING_SENTENCE_PUNCTUATION.has(text[boundary] ?? "")
-      ) {
-        boundary += 1;
-      }
-      // ASCII enders require following whitespace so decimals (3.14) and
-      // file names don't split; the non-Latin enders are valid boundaries
-      // regardless of what follows.
-      if (
-        NON_LATIN_SENTENCE_ENDING_PUNCTUATION.has(char) ||
-        boundary === text.length ||
-        isWhitespace(text[boundary] ?? "")
-      ) {
+      const isNonLatinEnder = NON_LATIN_SENTENCE_ENDING_PUNCTUATION.has(char);
+      // The fullwidth full stop doubles as a decimal point in fullwidth
+      // numbers (３．１４です), so a following digit suppresses the boundary.
+      const isDecimalPoint =
+        char === FULLWIDTH_FULL_STOP && isDecimalDigit(text[index + 1]);
+      if (isNonLatinEnder && !isDecimalPoint) {
+        // Non-Latin enders are valid boundaries regardless of what follows;
+        // consume locale closers so they stay with their sentence.
+        let boundary = index + 1;
+        while (
+          boundary < text.length &&
+          NON_LATIN_TRAILING_SENTENCE_PUNCTUATION.has(text[boundary] ?? "")
+        ) {
+          boundary += 1;
+        }
         return boundary;
+      }
+      if (!isNonLatinEnder) {
+        // ASCII enders require following whitespace so decimals (3.14) and
+        // file names don't split.
+        let boundary = index + 1;
+        while (
+          boundary < text.length &&
+          TRAILING_SENTENCE_PUNCTUATION.has(text[boundary] ?? "")
+        ) {
+          boundary += 1;
+        }
+        if (boundary === text.length || isWhitespace(text[boundary] ?? "")) {
+          return boundary;
+        }
       }
     }
 
@@ -162,8 +199,8 @@ function findSpeakableBoundary(
     } else if (char === "`") {
       inBacktick = !inBacktick;
     } else if (char === "*") {
-      const prev = text[index - 1];
-      const next = text[index + 1];
+      const prev = codePointBefore(text, index);
+      const next = codePointAfter(text, index);
       if (next === "*") {
         inBold = !inBold;
         skipSpanChar = true;
@@ -184,8 +221,8 @@ function findSpeakableBoundary(
     } else if (char === "_") {
       // Same word-boundary rule as `*`. Since `_` neighbors in identifiers
       // like `my_var` are word chars, they never open or close a span.
-      const prev = text[index - 1];
-      const next = text[index + 1];
+      const prev = codePointBefore(text, index);
+      const next = codePointAfter(text, index);
       if (inUnderscore) {
         if (prev !== undefined && !isWhitespace(prev) && !isWordChar(next)) {
           inUnderscore = false;
@@ -218,8 +255,54 @@ function findSpeakableBoundary(
   return charThreshold;
 }
 
+/**
+ * Accepts a full code point (one or two UTF-16 units) so non-BMP letters
+ * like 𠮟 count as word chars, matching the sanitizer's Unicode lookarounds
+ * in calls/tts-text-sanitizer.ts.
+ */
 function isWordChar(value: string | undefined): boolean {
   return value !== undefined && /[\p{L}\p{N}_]/u.test(value);
+}
+
+function isDecimalDigit(value: string | undefined): boolean {
+  return value !== undefined && /[0-9０-９]/.test(value);
+}
+
+/**
+ * The full code point ending just before `index`. When the preceding unit is
+ * a low surrogate, includes its high surrogate so `isWordChar` sees the
+ * whole character instead of half a pair.
+ */
+function codePointBefore(text: string, index: number): string | undefined {
+  const unit = text[index - 1];
+  if (unit === undefined) {
+    return undefined;
+  }
+  if (isLowSurrogate(unit.charCodeAt(0))) {
+    const high = text[index - 2];
+    if (high !== undefined && isHighSurrogate(high.charCodeAt(0))) {
+      return high + unit;
+    }
+  }
+  return unit;
+}
+
+/**
+ * The full code point starting just after `index`. When the following unit
+ * is a high surrogate, includes its low surrogate.
+ */
+function codePointAfter(text: string, index: number): string | undefined {
+  const unit = text[index + 1];
+  if (unit === undefined) {
+    return undefined;
+  }
+  if (isHighSurrogate(unit.charCodeAt(0))) {
+    const low = text[index + 2];
+    if (low !== undefined && isLowSurrogate(low.charCodeAt(0))) {
+      return unit + low;
+    }
+  }
+  return unit;
 }
 
 function findLastWhitespaceBoundary(

--- a/assistant/src/util/unicode.ts
+++ b/assistant/src/util/unicode.ts
@@ -20,7 +20,7 @@ export function isHighSurrogate(code: number): boolean {
   return code >= HIGH_SURROGATE_START && code <= HIGH_SURROGATE_END;
 }
 
-function isLowSurrogate(code: number): boolean {
+export function isLowSurrogate(code: number): boolean {
   return code >= LOW_SURROGATE_START && code <= LOW_SURROGATE_END;
 }
 


### PR DESCRIPTION
## Summary
- Adds CJK, Devanagari, and Arabic sentence/clause punctuation to speakable-segment extraction
- Boundary checks no longer require trailing whitespace for scripts that have none; hard-cap splits are surrogate-safe
- Unicode-aware word-char rules in both the segmenter and the TTS text sanitizer

Part of plan: voice-multilingual-pipeline.md (PR 3 of 6)