### PR TITLE
feat(web): add remembered-origins store for the origin-model chooser

### DIFF
--- a/clients/web/src/stores/remembered-origins-store.test.ts
+++ b/clients/web/src/stores/remembered-origins-store.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+
+import {
+  REMEMBERED_ORIGINS_STORAGE_KEY,
+  localStorageProvider,
+  normalizeOriginUrl,
+  setRememberedOriginsProvider,
+  useRememberedOriginsStore,
+  type RememberedOrigin,
+  type RememberedOriginsProvider,
+} from "@/stores/remembered-origins-store";
+
+const store = () => useRememberedOriginsStore.getState();
+
+beforeEach(async () => {
+  window.localStorage.clear();
+  setRememberedOriginsProvider(localStorageProvider);
+  await store().hydrate();
+});
+
+describe("normalizeOriginUrl", () => {
+  it("accepts a plain https origin", () => {
+    expect(normalizeOriginUrl("https://example.com")).toBe(
+      "https://example.com",
+    );
+  });
+
+  it("rejects http", () => {
+    expect(normalizeOriginUrl("http://example.com")).toBeNull();
+  });
+
+  it("rejects non-https schemes and garbage", () => {
+    expect(normalizeOriginUrl("ftp://example.com")).toBeNull();
+    expect(normalizeOriginUrl("not a url")).toBeNull();
+    expect(normalizeOriginUrl("example.com")).toBeNull();
+    expect(normalizeOriginUrl("")).toBeNull();
+    expect(normalizeOriginUrl("   ")).toBeNull();
+    expect(normalizeOriginUrl("https://")).toBeNull();
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(normalizeOriginUrl("  https://example.com  ")).toBe(
+      "https://example.com",
+    );
+  });
+
+  it("strips trailing slashes", () => {
+    expect(normalizeOriginUrl("https://example.com/")).toBe(
+      "https://example.com",
+    );
+    expect(normalizeOriginUrl("https://example.com/assistant-123///")).toBe(
+      "https://example.com/assistant-123",
+    );
+  });
+
+  it("preserves the path prefix and port", () => {
+    expect(normalizeOriginUrl("https://example.com/assistant-123")).toBe(
+      "https://example.com/assistant-123",
+    );
+    expect(normalizeOriginUrl("https://example.com:8443/assistant-123")).toBe(
+      "https://example.com:8443/assistant-123",
+    );
+  });
+
+  it("drops query and hash", () => {
+    expect(normalizeOriginUrl("https://example.com/a?register=1#frag")).toBe(
+      "https://example.com/a",
+    );
+  });
+
+  it("lowercases scheme and host but preserves path case", () => {
+    expect(normalizeOriginUrl("HTTPS://Example.COM/Assistant-123")).toBe(
+      "https://example.com/Assistant-123",
+    );
+  });
+
+  it("strips userinfo credentials", () => {
+    expect(normalizeOriginUrl("https://alice:secret@example.com/a")).toBe(
+      "https://example.com/a",
+    );
+  });
+});
+
+describe("addOrigin", () => {
+  it("adds a normalized entry with an ISO addedAt", async () => {
+    const result = await store().addOrigin({
+      url: "https://Example.com/assistant-123/",
+      name: "Home box",
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.origin.url).toBe("https://example.com/assistant-123");
+    expect(result.origin.name).toBe("Home box");
+    expect(Number.isNaN(Date.parse(result.origin.addedAt))).toBe(false);
+    expect(store().origins).toEqual([result.origin]);
+  });
+
+  it("returns { ok: false } for invalid urls and leaves state alone", async () => {
+    expect(await store().addOrigin({ url: "http://example.com" })).toEqual({
+      ok: false,
+    });
+    expect(await store().addOrigin({ url: "garbage" })).toEqual({ ok: false });
+    expect(store().origins).toEqual([]);
+  });
+
+  it("dedupes by normalized url, keeping the original addedAt", async () => {
+    const first = await store().addOrigin({ url: "https://example.com/a" });
+    if (!first.ok) {
+      throw new Error("expected ok");
+    }
+    const again = await store().addOrigin({
+      url: "HTTPS://EXAMPLE.COM/a/?x=1",
+    });
+    if (!again.ok) {
+      throw new Error("expected ok");
+    }
+    expect(store().origins).toHaveLength(1);
+    expect(again.origin.addedAt).toBe(first.origin.addedAt);
+  });
+
+  it("re-adding updates the name only when a new one is provided", async () => {
+    await store().addOrigin({ url: "https://example.com/a", name: "Old" });
+    await store().addOrigin({ url: "https://example.com/a" });
+    expect(store().origins[0]?.name).toBe("Old");
+
+    await store().addOrigin({ url: "https://example.com/a", name: "New" });
+    expect(store().origins[0]?.name).toBe("New");
+    expect(store().origins).toHaveLength(1);
+  });
+});
+
+describe("removeOrigin", () => {
+  it("removes by normalized url", async () => {
+    await store().addOrigin({ url: "https://example.com/a" });
+    await store().addOrigin({ url: "https://example.com/b" });
+
+    await store().removeOrigin("HTTPS://example.com/a/");
+    expect(store().origins.map((o) => o.url)).toEqual([
+      "https://example.com/b",
+    ]);
+  });
+
+  it("is a no-op for unknown or invalid urls", async () => {
+    await store().addOrigin({ url: "https://example.com/a" });
+    await store().removeOrigin("https://example.com/other");
+    await store().removeOrigin("not a url");
+    expect(store().origins).toHaveLength(1);
+  });
+});
+
+describe("localStorage persistence", () => {
+  const rehydrate = async () => {
+    setRememberedOriginsProvider(localStorageProvider);
+    await store().hydrate();
+  };
+
+  it("round-trips entries through localStorage", async () => {
+    await store().addOrigin({ url: "https://example.com/a", name: "A" });
+    await store().addOrigin({ url: "https://example.com/b" });
+    const before = store().origins;
+
+    await rehydrate();
+    expect(store().hydrated).toBe(true);
+    expect(store().origins).toEqual(before);
+  });
+
+  it("persists only { name?, url, addedAt } fields", async () => {
+    await store().addOrigin({ url: "https://example.com/a", name: "A" });
+    const raw = window.localStorage.getItem(REMEMBERED_ORIGINS_STORAGE_KEY);
+    const stored = JSON.parse(raw ?? "[]") as Record<string, unknown>[];
+    expect(stored).toHaveLength(1);
+    expect(Object.keys(stored[0] ?? {}).sort()).toEqual([
+      "addedAt",
+      "name",
+      "url",
+    ]);
+  });
+
+  it("recovers from corrupt JSON", async () => {
+    window.localStorage.setItem(REMEMBERED_ORIGINS_STORAGE_KEY, "{not json");
+    await rehydrate();
+    expect(store().hydrated).toBe(true);
+    expect(store().origins).toEqual([]);
+  });
+
+  it("drops non-array payloads and invalid entries", async () => {
+    window.localStorage.setItem(
+      REMEMBERED_ORIGINS_STORAGE_KEY,
+      JSON.stringify({ url: "https://example.com" }),
+    );
+    await rehydrate();
+    expect(store().origins).toEqual([]);
+
+    window.localStorage.setItem(
+      REMEMBERED_ORIGINS_STORAGE_KEY,
+      JSON.stringify([
+        { url: "https://example.com/good", addedAt: "2026-01-01T00:00:00Z" },
+        { url: "http://example.com/insecure", addedAt: "x" },
+        { name: "no url" },
+        "not an object",
+        null,
+      ]),
+    );
+    await rehydrate();
+    expect(store().origins.map((o) => o.url)).toEqual([
+      "https://example.com/good",
+    ]);
+  });
+});
+
+describe("providers and hydration", () => {
+  const makeFakeProvider = (initial: RememberedOrigin[]) => {
+    let entries = initial;
+    let loadCount = 0;
+    const provider: RememberedOriginsProvider = {
+      load: async () => {
+        loadCount += 1;
+        return entries;
+      },
+      save: async (next) => {
+        entries = next;
+      },
+    };
+    return {
+      provider,
+      getEntries: () => entries,
+      getLoadCount: () => loadCount,
+    };
+  };
+
+  it("setRememberedOriginsProvider re-hydrates from the new provider", async () => {
+    await store().addOrigin({ url: "https://old.example.com" });
+
+    const fake = makeFakeProvider([
+      {
+        url: "https://new.example.com/assistant-1",
+        name: "Fake",
+        addedAt: "2026-01-01T00:00:00Z",
+      },
+    ]);
+    setRememberedOriginsProvider(fake.provider);
+    await store().hydrate();
+
+    expect(store().origins.map((o) => o.url)).toEqual([
+      "https://new.example.com/assistant-1",
+    ]);
+  });
+
+  it("writes go through the active provider", async () => {
+    const fake = makeFakeProvider([]);
+    setRememberedOriginsProvider(fake.provider);
+    await store().hydrate();
+
+    await store().addOrigin({ url: "https://example.com/a" });
+    expect(fake.getEntries().map((o) => o.url)).toEqual([
+      "https://example.com/a",
+    ]);
+    expect(window.localStorage.getItem(REMEMBERED_ORIGINS_STORAGE_KEY)).toBe(
+      null,
+    );
+
+    await store().removeOrigin("https://example.com/a");
+    expect(fake.getEntries()).toEqual([]);
+  });
+
+  it("concurrent hydrate calls share one provider load", async () => {
+    const fake = makeFakeProvider([]);
+    setRememberedOriginsProvider(fake.provider);
+
+    await Promise.all([store().hydrate(), store().hydrate()]);
+    await store().hydrate();
+    expect(fake.getLoadCount()).toBe(1);
+    expect(store().hydrated).toBe(true);
+  });
+});

--- a/clients/web/src/stores/remembered-origins-store.test.ts
+++ b/clients/web/src/stores/remembered-origins-store.test.ts
@@ -301,6 +301,35 @@ describe("providers and hydration", () => {
     ]);
   });
 
+  it("a synchronous load() throw still allows a later hydrate to retry", async () => {
+    let failLoads = true;
+    const provider: RememberedOriginsProvider = {
+      load: () => {
+        if (failLoads) {
+          throw new Error("synchronous failure");
+        }
+        return Promise.resolve([
+          {
+            url: "https://example.com/recovered",
+            addedAt: "2026-01-01T00:00:00Z",
+          },
+        ]);
+      },
+      save: async () => {},
+    };
+    setRememberedOriginsProvider(provider);
+
+    await store().hydrate();
+    expect(store().hydrated).toBe(false);
+
+    failLoads = false;
+    await store().hydrate();
+    expect(store().hydrated).toBe(true);
+    expect(store().origins.map((o) => o.url)).toEqual([
+      "https://example.com/recovered",
+    ]);
+  });
+
   it("a mutation after a failed hydration does not overwrite provider data", async () => {
     let saved: RememberedOrigin[] | null = null;
     const provider: RememberedOriginsProvider = {

--- a/clients/web/src/stores/remembered-origins-store.test.ts
+++ b/clients/web/src/stores/remembered-origins-store.test.ts
@@ -390,4 +390,75 @@ describe("providers and hydration", () => {
       "https://example.com/b",
     ]);
   });
+
+  it("aborts a mutation when the provider is swapped mid-mutation", async () => {
+    let loads = 0;
+    let releaseMutationLoad = () => {};
+    const gate = new Promise<void>((resolve) => {
+      releaseMutationLoad = resolve;
+    });
+    let oldProviderSaved = false;
+    const oldProvider: RememberedOriginsProvider = {
+      load: async () => {
+        loads += 1;
+        if (loads > 1) {
+          await gate;
+        }
+        return [
+          { url: "https://old.example.com/a", addedAt: "2026-01-01T00:00:00Z" },
+        ];
+      },
+      save: async () => {
+        oldProviderSaved = true;
+      },
+    };
+    setRememberedOriginsProvider(oldProvider);
+    await store().hydrate();
+
+    const pending = store().addOrigin({ url: "https://example.com/new" });
+    // Wait until the mutation is awaiting the old provider's load, then swap.
+    while (loads < 2) {
+      await new Promise((resolve) => setTimeout(resolve, 1));
+    }
+    const fresh = makeFakeProvider([
+      { url: "https://fresh.example.com/x", addedAt: "2026-01-01T00:00:00Z" },
+    ]);
+    setRememberedOriginsProvider(fresh.provider);
+    releaseMutationLoad();
+
+    expect(await pending).toEqual({ ok: false });
+    expect(oldProviderSaved).toBe(false);
+    expect(fresh.getEntries().map((o) => o.url)).toEqual([
+      "https://fresh.example.com/x",
+    ]);
+  });
+
+  it("runs mutations inside a Web Lock when navigator.locks exists", async () => {
+    const requested: string[] = [];
+    const fakeLocks = {
+      request: (name: string, callback: () => Promise<unknown>) => {
+        requested.push(name);
+        return callback();
+      },
+    } as unknown as LockManager;
+    const original = Object.getOwnPropertyDescriptor(navigator, "locks");
+    Object.defineProperty(navigator, "locks", {
+      value: fakeLocks,
+      configurable: true,
+    });
+    try {
+      await store().addOrigin({ url: "https://example.com/locked" });
+      await store().removeOrigin("https://example.com/locked");
+    } finally {
+      if (original) {
+        Object.defineProperty(navigator, "locks", original);
+      } else {
+        delete (navigator as { locks?: unknown }).locks;
+      }
+    }
+    expect(requested).toEqual([
+      "vellum:remembered-origins:mutate",
+      "vellum:remembered-origins:mutate",
+    ]);
+  });
 });

--- a/clients/web/src/stores/remembered-origins-store.test.ts
+++ b/clients/web/src/stores/remembered-origins-store.test.ts
@@ -552,9 +552,11 @@ describe("providers and hydration", () => {
         delete (navigator as { locks?: unknown }).locks;
       }
     }
-    expect(requested).toEqual([
-      "vellum:remembered-origins:mutate",
-      "vellum:remembered-origins:mutate",
-    ]);
+    // The two mutations acquire the lock; watch-triggered refreshes from
+    // our own saves may acquire it additional times.
+    expect(requested.length).toBeGreaterThanOrEqual(2);
+    expect(new Set(requested)).toEqual(
+      new Set(["vellum:remembered-origins:mutate"]),
+    );
   });
 });

--- a/clients/web/src/stores/remembered-origins-store.test.ts
+++ b/clients/web/src/stores/remembered-origins-store.test.ts
@@ -433,6 +433,59 @@ describe("providers and hydration", () => {
     ]);
   });
 
+  it("does not publish state when the provider's save fails", async () => {
+    const seeded = [
+      { url: "https://example.com/kept", addedAt: "2026-01-01T00:00:00Z" },
+    ];
+    let failSaves = false;
+    let entries = seeded;
+    const provider: RememberedOriginsProvider = {
+      load: async () => entries,
+      save: async (next) => {
+        if (failSaves) {
+          throw new Error("save failed");
+        }
+        entries = next;
+      },
+    };
+    setRememberedOriginsProvider(provider);
+    await store().hydrate();
+
+    failSaves = true;
+    const result = await store().addOrigin({ url: "https://example.com/new" });
+    expect(result).toEqual({ ok: false });
+    expect(store().origins.map((o) => o.url)).toEqual([
+      "https://example.com/kept",
+    ]);
+    expect(store().hydrated).toBe(true);
+
+    await store().removeOrigin("https://example.com/kept");
+    expect(store().origins.map((o) => o.url)).toEqual([
+      "https://example.com/kept",
+    ]);
+    expect(entries).toEqual(seeded);
+  });
+
+  it("refreshes hydrated state when another tab changes localStorage", async () => {
+    // beforeEach hydrated the default localStorage provider with an empty
+    // list. Simulate another tab writing an entry, which the browser
+    // announces via a storage event.
+    window.localStorage.setItem(
+      REMEMBERED_ORIGINS_STORAGE_KEY,
+      JSON.stringify([
+        { url: "https://other-tab.example.com", addedAt: "2026-01-01T00:00:00Z" },
+      ]),
+    );
+    window.dispatchEvent(
+      new StorageEvent("storage", { key: REMEMBERED_ORIGINS_STORAGE_KEY }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(store().origins.map((o) => o.url)).toEqual([
+      "https://other-tab.example.com",
+    ]);
+  });
+
   it("runs mutations inside a Web Lock when navigator.locks exists", async () => {
     const requested: string[] = [];
     const fakeLocks = {

--- a/clients/web/src/stores/remembered-origins-store.test.ts
+++ b/clients/web/src/stores/remembered-origins-store.test.ts
@@ -486,6 +486,49 @@ describe("providers and hydration", () => {
     ]);
   });
 
+  it("serializes watch refreshes with mutations so a slow refresh cannot publish stale state", async () => {
+    let entries: RememberedOrigin[] = [
+      { url: "https://example.com/a", addedAt: "2026-01-01T00:00:00Z" },
+    ];
+    let watchCallback: (() => void) | null = null;
+    let gate: Promise<void> | null = null;
+    let releaseGate = () => {};
+    const provider: RememberedOriginsProvider = {
+      load: async () => {
+        if (gate) {
+          const pending = gate;
+          gate = null;
+          await pending;
+        }
+        return entries;
+      },
+      save: async (next) => {
+        entries = next;
+      },
+      watch: (onChange) => {
+        watchCallback = onChange;
+        return () => {};
+      },
+    };
+    setRememberedOriginsProvider(provider);
+    await store().hydrate();
+
+    // A watch-triggered refresh starts a slow load, then a mutation runs.
+    gate = new Promise((resolve) => {
+      releaseGate = resolve;
+    });
+    watchCallback?.();
+    const add = store().addOrigin({ url: "https://example.com/b" });
+    releaseGate();
+    await add;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    expect(store().origins.map((o) => o.url)).toEqual([
+      "https://example.com/a",
+      "https://example.com/b",
+    ]);
+  });
+
   it("runs mutations inside a Web Lock when navigator.locks exists", async () => {
     const requested: string[] = [];
     const fakeLocks = {

--- a/clients/web/src/stores/remembered-origins-store.test.ts
+++ b/clients/web/src/stores/remembered-origins-store.test.ts
@@ -515,6 +515,51 @@ describe("providers and hydration", () => {
     ]);
   });
 
+  it("re-refreshes after hydration when a watch event fired mid-hydration", async () => {
+    let entries: RememberedOrigin[] = [
+      { url: "https://example.com/new", addedAt: "2026-01-02T00:00:00Z" },
+    ];
+    let watchCallback: (() => void) | null = null;
+    let releaseHydrateLoad = () => {};
+    const hydrateGate = new Promise<void>((resolve) => {
+      releaseHydrateLoad = resolve;
+    });
+    let loads = 0;
+    const provider: RememberedOriginsProvider = {
+      load: async () => {
+        loads += 1;
+        if (loads === 1) {
+          // The initial hydration load is slow and returns a snapshot that
+          // is already stale by the time it resolves.
+          await hydrateGate;
+          return [
+            { url: "https://example.com/old", addedAt: "2026-01-01T00:00:00Z" },
+          ];
+        }
+        return entries;
+      },
+      save: async (next) => {
+        entries = next;
+      },
+      watch: (onChange) => {
+        watchCallback = onChange;
+        return () => {};
+      },
+    };
+    setRememberedOriginsProvider(provider);
+
+    // The provider's value changes while hydration is still loading.
+    watchCallback?.();
+    await new Promise((resolve) => setTimeout(resolve, 1));
+    releaseHydrateLoad();
+    await store().hydrate();
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    expect(store().origins.map((o) => o.url)).toEqual([
+      "https://example.com/new",
+    ]);
+  });
+
   it("serializes watch refreshes with mutations so a slow refresh cannot publish stale state", async () => {
     let entries: RememberedOrigin[] = [
       { url: "https://example.com/a", addedAt: "2026-01-01T00:00:00Z" },

--- a/clients/web/src/stores/remembered-origins-store.test.ts
+++ b/clients/web/src/stores/remembered-origins-store.test.ts
@@ -274,4 +274,120 @@ describe("providers and hydration", () => {
     expect(fake.getLoadCount()).toBe(1);
     expect(store().hydrated).toBe(true);
   });
+
+  it("a failed load leaves the store unhydrated and a later hydrate retries", async () => {
+    let failLoads = true;
+    const provider: RememberedOriginsProvider = {
+      load: async () => {
+        if (failLoads) {
+          throw new Error("provider unavailable");
+        }
+        return [
+          { url: "https://example.com/real", addedAt: "2026-01-01T00:00:00Z" },
+        ];
+      },
+      save: async () => {},
+    };
+    setRememberedOriginsProvider(provider);
+
+    await store().hydrate();
+    expect(store().hydrated).toBe(false);
+
+    failLoads = false;
+    await store().hydrate();
+    expect(store().hydrated).toBe(true);
+    expect(store().origins.map((o) => o.url)).toEqual([
+      "https://example.com/real",
+    ]);
+  });
+
+  it("a mutation after a failed hydration does not overwrite provider data", async () => {
+    let saved: RememberedOrigin[] | null = null;
+    const provider: RememberedOriginsProvider = {
+      load: async () => {
+        throw new Error("provider unavailable");
+      },
+      save: async (next) => {
+        saved = next;
+      },
+    };
+    setRememberedOriginsProvider(provider);
+
+    const result = await store().addOrigin({ url: "https://example.com/b" });
+    expect(result).toEqual({ ok: false });
+    await store().removeOrigin("https://example.com/b");
+    expect(saved).toBeNull();
+    expect(store().hydrated).toBe(false);
+  });
+
+  it("merges the provider's latest value before saving a mutation", async () => {
+    const fake = makeFakeProvider([]);
+    setRememberedOriginsProvider(fake.provider);
+    await store().hydrate();
+
+    // Another tab persists A after this tab hydrated.
+    await fake.provider.save([
+      { url: "https://example.com/a", addedAt: "2026-01-01T00:00:00Z" },
+    ]);
+
+    await store().addOrigin({ url: "https://example.com/b" });
+    expect(fake.getEntries().map((o) => o.url)).toEqual([
+      "https://example.com/a",
+      "https://example.com/b",
+    ]);
+    expect(store().origins.map((o) => o.url)).toEqual([
+      "https://example.com/a",
+      "https://example.com/b",
+    ]);
+
+    // Same for removals: the other tab's entry survives.
+    await fake.provider.save([
+      { url: "https://example.com/a", addedAt: "2026-01-01T00:00:00Z" },
+      { url: "https://example.com/b", addedAt: "2026-01-02T00:00:00Z" },
+      { url: "https://example.com/c", addedAt: "2026-01-03T00:00:00Z" },
+    ]);
+    await store().removeOrigin("https://example.com/b");
+    expect(fake.getEntries().map((o) => o.url)).toEqual([
+      "https://example.com/a",
+      "https://example.com/c",
+    ]);
+  });
+
+  it("serializes async saves so a later mutation's save always lands last", async () => {
+    let entries: RememberedOrigin[] = [];
+    const saveLog: string[][] = [];
+    let pendingSaves = 0;
+    const provider: RememberedOriginsProvider = {
+      load: async () => entries,
+      save: async (next) => {
+        // First save is slow; without serialization it would finish after
+        // the second save and roll persisted state back to just [a].
+        pendingSaves += 1;
+        const delayMs = pendingSaves === 1 ? 20 : 0;
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+        entries = next;
+        saveLog.push(next.map((o) => o.url));
+      },
+    };
+    setRememberedOriginsProvider(provider);
+    await store().hydrate();
+
+    await Promise.all([
+      store().addOrigin({ url: "https://example.com/a" }),
+      store().addOrigin({ url: "https://example.com/b" }),
+    ]);
+
+    expect(saveLog).toEqual([
+      ["https://example.com/a"],
+      ["https://example.com/a", "https://example.com/b"],
+    ]);
+    expect(entries.map((o) => o.url)).toEqual([
+      "https://example.com/a",
+      "https://example.com/b",
+    ]);
+    expect(store().origins.map((o) => o.url)).toEqual([
+      "https://example.com/a",
+      "https://example.com/b",
+    ]);
+  });
 });

--- a/clients/web/src/stores/remembered-origins-store.test.ts
+++ b/clients/web/src/stores/remembered-origins-store.test.ts
@@ -515,6 +515,43 @@ describe("providers and hydration", () => {
     ]);
   });
 
+  it("a watch event after a failed hydration retries hydration", async () => {
+    let failLoads = true;
+    let watchCallback: (() => void) | null = null;
+    const provider: RememberedOriginsProvider = {
+      load: async () => {
+        if (failLoads) {
+          throw new Error("provider unavailable");
+        }
+        return [
+          {
+            url: "https://example.com/recovered",
+            addedAt: "2026-01-01T00:00:00Z",
+          },
+        ];
+      },
+      save: async () => {},
+      watch: (onChange) => {
+        watchCallback = onChange;
+        return () => {};
+      },
+    };
+    setRememberedOriginsProvider(provider);
+    await store().hydrate();
+    expect(store().hydrated).toBe(false);
+
+    // The provider recovers and announces a change; no caller invokes
+    // hydrate() manually.
+    failLoads = false;
+    watchCallback?.();
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    expect(store().hydrated).toBe(true);
+    expect(store().origins.map((o) => o.url)).toEqual([
+      "https://example.com/recovered",
+    ]);
+  });
+
   it("re-refreshes after hydration when a watch event fired mid-hydration", async () => {
     let entries: RememberedOrigin[] = [
       { url: "https://example.com/new", addedAt: "2026-01-02T00:00:00Z" },

--- a/clients/web/src/stores/remembered-origins-store.ts
+++ b/clients/web/src/stores/remembered-origins-store.ts
@@ -188,6 +188,11 @@ function refreshFromProvider(epoch: number): Promise<void> {
       }
       if (useRememberedOriginsStoreBase.getState().hydrated) {
         useRememberedOriginsStoreBase.setState({ origins });
+      } else if (hydrationPromise === null) {
+        // A failed hydration already settled, so nothing would consume the
+        // skip flag; this event signals the provider recovered, so retry
+        // hydration now (its load is at least as fresh as this one).
+        void useRememberedOriginsStoreBase.getState().hydrate();
       } else {
         refreshSkippedWhileUnhydrated = true;
       }

--- a/clients/web/src/stores/remembered-origins-store.ts
+++ b/clients/web/src/stores/remembered-origins-store.ts
@@ -171,15 +171,25 @@ let unwatchProvider: (() => void) | null = null;
  * through the mutation queue so a slow refresh load can never publish
  * state that a later mutation's save has already superseded.
  */
+/**
+ * Set when a watch event arrives while the initial hydration load is still
+ * pending: the refresh cannot publish yet (the store is unhydrated), so
+ * hydration completion triggers a follow-up refresh instead of leaving the
+ * store on its possibly older snapshot.
+ */
+let refreshSkippedWhileUnhydrated = false;
+
 function refreshFromProvider(epoch: number): Promise<void> {
   return enqueueMutation(async () => {
     try {
       const origins = await activeProvider.load();
-      if (
-        epoch === hydrationEpoch &&
-        useRememberedOriginsStoreBase.getState().hydrated
-      ) {
+      if (epoch !== hydrationEpoch) {
+        return;
+      }
+      if (useRememberedOriginsStoreBase.getState().hydrated) {
         useRememberedOriginsStoreBase.setState({ origins });
+      } else {
+        refreshSkippedWhileUnhydrated = true;
       }
     } catch {
       // Keep current state; the next mutation or hydrate retries.
@@ -204,6 +214,7 @@ export function setRememberedOriginsProvider(
   activeProvider = provider;
   hydrationEpoch += 1;
   hydrationPromise = null;
+  refreshSkippedWhileUnhydrated = false;
   useRememberedOriginsStoreBase.setState({ hydrated: false });
   watchActiveProvider();
   void useRememberedOriginsStoreBase.getState().hydrate();
@@ -259,6 +270,12 @@ const useRememberedOriginsStoreBase = create<RememberedOriginsStore>()(
           const origins = await activeProvider.load();
           if (epoch === hydrationEpoch) {
             set({ origins, hydrated: true });
+            if (refreshSkippedWhileUnhydrated) {
+              // A watch event fired mid-hydration; our snapshot may already
+              // be stale, so reconcile with the provider's latest.
+              refreshSkippedWhileUnhydrated = false;
+              void refreshFromProvider(epoch);
+            }
           }
         } catch {
           // Stay unhydrated so a later hydrate() retries; never persist a

--- a/clients/web/src/stores/remembered-origins-store.ts
+++ b/clients/web/src/stores/remembered-origins-store.ts
@@ -167,20 +167,24 @@ let unwatchProvider: (() => void) | null = null;
 
 /**
  * Re-load the provider's current value into already-hydrated state, e.g.
- * after another tab or the native shell changed the persisted list.
+ * after another tab or the native shell changed the persisted list. Runs
+ * through the mutation queue so a slow refresh load can never publish
+ * state that a later mutation's save has already superseded.
  */
-async function refreshFromProvider(epoch: number): Promise<void> {
-  try {
-    const origins = await activeProvider.load();
-    if (
-      epoch === hydrationEpoch &&
-      useRememberedOriginsStoreBase.getState().hydrated
-    ) {
-      useRememberedOriginsStoreBase.setState({ origins });
+function refreshFromProvider(epoch: number): Promise<void> {
+  return enqueueMutation(async () => {
+    try {
+      const origins = await activeProvider.load();
+      if (
+        epoch === hydrationEpoch &&
+        useRememberedOriginsStoreBase.getState().hydrated
+      ) {
+        useRememberedOriginsStoreBase.setState({ origins });
+      }
+    } catch {
+      // Keep current state; the next mutation or hydrate retries.
     }
-  } catch {
-    // Keep current state; the next mutation or hydrate retries.
-  }
+  });
 }
 
 function watchActiveProvider(): void {

--- a/clients/web/src/stores/remembered-origins-store.ts
+++ b/clients/web/src/stores/remembered-origins-store.ts
@@ -21,6 +21,7 @@
 import { create } from "zustand";
 
 import { createSelectors } from "@/utils/create-selectors";
+import { watchSetting } from "@/utils/local-settings";
 import { createStorageAccessor } from "@/utils/typed-storage";
 
 export interface RememberedOrigin {
@@ -66,6 +67,12 @@ export function normalizeOriginUrl(raw: string): string | null {
 export interface RememberedOriginsProvider {
   load: () => Promise<RememberedOrigin[]>;
   save: (entries: RememberedOrigin[]) => Promise<void>;
+  /**
+   * Optional: report changes to the persisted value made outside this
+   * handle (another tab, the native shell) so hydrated store state can
+   * refresh. Returns an unsubscribe function.
+   */
+  watch?: (onChange: () => void) => () => void;
 }
 
 /**
@@ -118,6 +125,7 @@ export const localStorageProvider: RememberedOriginsProvider = {
   save: async (entries) => {
     storage.save(entries);
   },
+  watch: (onChange) => watchSetting(REMEMBERED_ORIGINS_STORAGE_KEY, onChange),
 };
 
 let activeProvider: RememberedOriginsProvider = localStorageProvider;
@@ -155,6 +163,33 @@ function enqueueMutation<T>(mutation: () => Promise<T>): Promise<T> {
   return run;
 }
 
+let unwatchProvider: (() => void) | null = null;
+
+/**
+ * Re-load the provider's current value into already-hydrated state, e.g.
+ * after another tab or the native shell changed the persisted list.
+ */
+async function refreshFromProvider(epoch: number): Promise<void> {
+  try {
+    const origins = await activeProvider.load();
+    if (
+      epoch === hydrationEpoch &&
+      useRememberedOriginsStoreBase.getState().hydrated
+    ) {
+      useRememberedOriginsStoreBase.setState({ origins });
+    }
+  } catch {
+    // Keep current state; the next mutation or hydrate retries.
+  }
+}
+
+function watchActiveProvider(): void {
+  unwatchProvider?.();
+  const epoch = hydrationEpoch;
+  unwatchProvider =
+    activeProvider.watch?.(() => void refreshFromProvider(epoch)) ?? null;
+}
+
 /**
  * Swap the persistence provider (e.g. for a native Capacitor-backed store)
  * and re-hydrate from it.
@@ -166,6 +201,7 @@ export function setRememberedOriginsProvider(
   hydrationEpoch += 1;
   hydrationPromise = null;
   useRememberedOriginsStoreBase.setState({ hydrated: false });
+  watchActiveProvider();
   void useRememberedOriginsStoreBase.getState().hydrate();
 }
 
@@ -262,8 +298,16 @@ const useRememberedOriginsStoreBase = create<RememberedOriginsStore>()(
         const origins = existing
           ? current.map((o) => (o.url === normalized ? origin : o))
           : [...current, origin];
-        set({ origins });
-        await provider.save(origins);
+        // Publish state only after persistence succeeds so the chooser never
+        // shows an entry the provider does not actually hold.
+        try {
+          await provider.save(origins);
+        } catch {
+          return { ok: false };
+        }
+        if (epoch === hydrationEpoch) {
+          set({ origins });
+        }
         return { ok: true, origin };
       });
     },
@@ -290,14 +334,24 @@ const useRememberedOriginsStoreBase = create<RememberedOriginsStore>()(
           return;
         }
         const remaining = current.filter((o) => o.url !== normalized);
-        set({ origins: remaining });
         if (remaining.length !== current.length) {
-          await provider.save(remaining);
+          try {
+            await provider.save(remaining);
+          } catch {
+            return;
+          }
+        }
+        if (epoch === hydrationEpoch) {
+          set({ origins: remaining });
         }
       });
     },
   }),
 );
+
+// Watch the default provider from the start so a hydrated tab picks up
+// changes other tabs persist.
+watchActiveProvider();
 
 export const useRememberedOriginsStore = createSelectors(
   useRememberedOriginsStoreBase,

--- a/clients/web/src/stores/remembered-origins-store.ts
+++ b/clients/web/src/stores/remembered-origins-store.ts
@@ -309,9 +309,12 @@ const useRememberedOriginsStoreBase = create<RememberedOriginsStore>()(
         } catch {
           return { ok: false };
         }
-        if (epoch === hydrationEpoch) {
-          set({ origins });
+        // A provider swap during the save supersedes this mutation: the
+        // active provider does not hold the origin, so report failure.
+        if (epoch !== hydrationEpoch) {
+          return { ok: false };
         }
+        set({ origins });
         return { ok: true, origin };
       });
     },

--- a/clients/web/src/stores/remembered-origins-store.ts
+++ b/clients/web/src/stores/remembered-origins-store.ts
@@ -1,5 +1,5 @@
 /**
- * Remembered-origins store — the client-local list of remote assistant
+ * Remembered-origins store: the client-local list of remote assistant
  * origins the chooser can offer alongside platform-API assistants and the
  * same-machine lockfile.
  *
@@ -126,6 +126,18 @@ let hydrationPromise: Promise<void> | null = null;
 let hydrationEpoch = 0;
 
 /**
+ * Mutations run one at a time through this chain so a slow async save can
+ * never land after a later mutation's save and roll persisted state back.
+ */
+let mutationQueue: Promise<unknown> = Promise.resolve();
+
+function enqueueMutation<T>(mutation: () => Promise<T>): Promise<T> {
+  const run = mutationQueue.then(mutation, mutation);
+  mutationQueue = run.catch(() => undefined);
+  return run;
+}
+
+/**
  * Swap the persistence provider (e.g. for a native Capacitor-backed store)
  * and re-hydrate from it.
  */
@@ -153,12 +165,17 @@ export type AddOriginResult =
   | { ok: false };
 
 export interface RememberedOriginsActions {
-  /** Load from the provider once; concurrent calls share one promise. */
+  /**
+   * Load from the provider; concurrent calls share one promise. A failed
+   * load leaves the store unhydrated and a later call retries.
+   */
   hydrate: () => Promise<void>;
   /**
-   * Remember an origin. Invalid urls return `{ ok: false }`. Re-adding an
-   * already-remembered url keeps its original `addedAt` and updates `name`
-   * only when a new one is provided.
+   * Remember an origin. Invalid urls return `{ ok: false }`, as does a
+   * mutation attempted while the provider cannot be read (so a failed load
+   * can never be overwritten with a list built from empty state). Re-adding
+   * an already-remembered url keeps its original `addedAt` and updates
+   * `name` only when a new one is provided.
    */
   addOrigin: (input: { url: string; name?: string }) => Promise<AddOriginResult>;
   removeOrigin: (url: string) => Promise<void>;
@@ -175,14 +192,17 @@ const useRememberedOriginsStoreBase = create<RememberedOriginsStore>()(
     hydrate: () => {
       hydrationPromise ??= (async () => {
         const epoch = hydrationEpoch;
-        let origins: RememberedOrigin[] = [];
         try {
-          origins = await activeProvider.load();
+          const origins = await activeProvider.load();
+          if (epoch === hydrationEpoch) {
+            set({ origins, hydrated: true });
+          }
         } catch {
-          // A failed load hydrates empty rather than blocking callers.
-        }
-        if (epoch === hydrationEpoch) {
-          set({ origins, hydrated: true });
+          // Stay unhydrated so a later hydrate() retries; never persist a
+          // list built from state the provider was not able to load.
+          if (epoch === hydrationEpoch) {
+            hydrationPromise = null;
+          }
         }
       })();
       return hydrationPromise;
@@ -193,21 +213,33 @@ const useRememberedOriginsStoreBase = create<RememberedOriginsStore>()(
       if (normalized === null) {
         return { ok: false };
       }
-      await get().hydrate();
-      const trimmedName = name?.trim();
-      const current = get().origins;
-      const existing = current.find((o) => o.url === normalized);
-      const base: RememberedOrigin = existing ?? {
-        url: normalized,
-        addedAt: new Date().toISOString(),
-      };
-      const origin = trimmedName ? { ...base, name: trimmedName } : base;
-      const origins = existing
-        ? current.map((o) => (o.url === normalized ? origin : o))
-        : [...current, origin];
-      set({ origins });
-      await activeProvider.save(origins);
-      return { ok: true, origin };
+      return enqueueMutation(async (): Promise<AddOriginResult> => {
+        await get().hydrate();
+        if (!get().hydrated) {
+          return { ok: false };
+        }
+        // Re-load so the working list includes entries another tab (or
+        // provider client) persisted after this tab hydrated.
+        let current: RememberedOrigin[];
+        try {
+          current = await activeProvider.load();
+        } catch {
+          return { ok: false };
+        }
+        const trimmedName = name?.trim();
+        const existing = current.find((o) => o.url === normalized);
+        const base: RememberedOrigin = existing ?? {
+          url: normalized,
+          addedAt: new Date().toISOString(),
+        };
+        const origin = trimmedName ? { ...base, name: trimmedName } : base;
+        const origins = existing
+          ? current.map((o) => (o.url === normalized ? origin : o))
+          : [...current, origin];
+        set({ origins });
+        await activeProvider.save(origins);
+        return { ok: true, origin };
+      });
     },
 
     removeOrigin: async (url) => {
@@ -215,13 +247,23 @@ const useRememberedOriginsStoreBase = create<RememberedOriginsStore>()(
       if (normalized === null) {
         return;
       }
-      await get().hydrate();
-      const remaining = get().origins.filter((o) => o.url !== normalized);
-      if (remaining.length === get().origins.length) {
-        return;
-      }
-      set({ origins: remaining });
-      await activeProvider.save(remaining);
+      await enqueueMutation(async () => {
+        await get().hydrate();
+        if (!get().hydrated) {
+          return;
+        }
+        let current: RememberedOrigin[];
+        try {
+          current = await activeProvider.load();
+        } catch {
+          return;
+        }
+        const remaining = current.filter((o) => o.url !== normalized);
+        set({ origins: remaining });
+        if (remaining.length !== current.length) {
+          await activeProvider.save(remaining);
+        }
+      });
     },
   }),
 );

--- a/clients/web/src/stores/remembered-origins-store.ts
+++ b/clients/web/src/stores/remembered-origins-store.ts
@@ -128,11 +128,29 @@ let hydrationEpoch = 0;
 /**
  * Mutations run one at a time through this chain so a slow async save can
  * never land after a later mutation's save and roll persisted state back.
+ * The chain serializes this tab only; {@link withCrossTabLock} extends the
+ * guarantee across tabs sharing the localStorage-backed provider.
  */
 let mutationQueue: Promise<unknown> = Promise.resolve();
 
+const MUTATION_LOCK_NAME = "vellum:remembered-origins:mutate";
+
+/**
+ * Make the read-modify-write mutation atomic across tabs via the Web Locks
+ * API. Without it (non-browser test envs, very old engines) the in-tab
+ * queue still applies and concurrent-tab writes fall back to last-writer.
+ */
+function withCrossTabLock<T>(mutation: () => Promise<T>): Promise<T> {
+  const locks = typeof navigator === "undefined" ? undefined : navigator.locks;
+  if (!locks) {
+    return mutation();
+  }
+  return locks.request(MUTATION_LOCK_NAME, mutation);
+}
+
 function enqueueMutation<T>(mutation: () => Promise<T>): Promise<T> {
-  const run = mutationQueue.then(mutation, mutation);
+  const locked = () => withCrossTabLock(mutation);
+  const run = mutationQueue.then(locked, locked);
   mutationQueue = run.catch(() => undefined);
   return run;
 }
@@ -218,12 +236,20 @@ const useRememberedOriginsStoreBase = create<RememberedOriginsStore>()(
         if (!get().hydrated) {
           return { ok: false };
         }
+        // Pin the provider and epoch for the whole mutation: a provider swap
+        // while we await its load must abort rather than save a list derived
+        // from the old provider into the new one.
+        const provider = activeProvider;
+        const epoch = hydrationEpoch;
         // Re-load so the working list includes entries another tab (or
         // provider client) persisted after this tab hydrated.
         let current: RememberedOrigin[];
         try {
-          current = await activeProvider.load();
+          current = await provider.load();
         } catch {
+          return { ok: false };
+        }
+        if (epoch !== hydrationEpoch) {
           return { ok: false };
         }
         const trimmedName = name?.trim();
@@ -237,7 +263,7 @@ const useRememberedOriginsStoreBase = create<RememberedOriginsStore>()(
           ? current.map((o) => (o.url === normalized ? origin : o))
           : [...current, origin];
         set({ origins });
-        await activeProvider.save(origins);
+        await provider.save(origins);
         return { ok: true, origin };
       });
     },
@@ -252,16 +278,21 @@ const useRememberedOriginsStoreBase = create<RememberedOriginsStore>()(
         if (!get().hydrated) {
           return;
         }
+        const provider = activeProvider;
+        const epoch = hydrationEpoch;
         let current: RememberedOrigin[];
         try {
-          current = await activeProvider.load();
+          current = await provider.load();
         } catch {
+          return;
+        }
+        if (epoch !== hydrationEpoch) {
           return;
         }
         const remaining = current.filter((o) => o.url !== normalized);
         set({ origins: remaining });
         if (remaining.length !== current.length) {
-          await activeProvider.save(remaining);
+          await provider.save(remaining);
         }
       });
     },

--- a/clients/web/src/stores/remembered-origins-store.ts
+++ b/clients/web/src/stores/remembered-origins-store.ts
@@ -1,0 +1,231 @@
+/**
+ * Remembered-origins store — the client-local list of remote assistant
+ * origins the chooser can offer alongside platform-API assistants and the
+ * same-machine lockfile.
+ *
+ * Each entry is `{ name?, url, addedAt }` and nothing else. The `url` is the
+ * assistant's public base (origin plus optional path prefix, e.g.
+ * `https://host/assistant-123`) and never carries credentials: the
+ * credential for an origin is its origin-scoped HttpOnly refresh cookie,
+ * which never passes through this store.
+ *
+ * Persistence is pluggable via {@link RememberedOriginsProvider}. The
+ * default {@link localStorageProvider} stores per-origin browser state,
+ * which is what makes the cloud origin act as the browser's hub; native
+ * shells swap in their own provider via
+ * {@link setRememberedOriginsProvider}.
+ *
+ * Leaf module: must not import from chooser/screen modules.
+ */
+
+import { create } from "zustand";
+
+import { createSelectors } from "@/utils/create-selectors";
+import { createStorageAccessor } from "@/utils/typed-storage";
+
+export interface RememberedOrigin {
+  name?: string;
+  /** Normalized public base URL: origin plus optional path prefix. */
+  url: string;
+  /** ISO-8601 timestamp of when the origin was first remembered. */
+  addedAt: string;
+}
+
+export const REMEMBERED_ORIGINS_STORAGE_KEY = "vellum:remembered-origins";
+
+/**
+ * Normalize a candidate origin URL to its canonical stored form, or `null`
+ * when it is not a usable `https:` base (mirrors the validation stance of
+ * `SelfHostedServer.validate` in the iOS shell).
+ *
+ * Canonical form: lowercase scheme and host (via `URL.origin`, which also
+ * drops any userinfo), path prefix preserved with trailing slashes
+ * stripped, query and hash dropped.
+ */
+export function normalizeOriginUrl(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (trimmed === "") {
+    return null;
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "https:" || parsed.hostname === "") {
+    return null;
+  }
+  return `${parsed.origin}${parsed.pathname.replace(/\/+$/, "")}`;
+}
+
+// ---------------------------------------------------------------------------
+// Persistence providers
+// ---------------------------------------------------------------------------
+
+export interface RememberedOriginsProvider {
+  load: () => Promise<RememberedOrigin[]>;
+  save: (entries: RememberedOrigin[]) => Promise<void>;
+}
+
+/**
+ * Defensive parse of persisted JSON: anything that isn't an array becomes
+ * empty, and entries whose `url` fails {@link normalizeOriginUrl} (or that
+ * duplicate an earlier entry's url) are dropped.
+ */
+function parseStoredEntries(raw: string): RememberedOrigin[] | null {
+  const parsed: unknown = JSON.parse(raw);
+  if (!Array.isArray(parsed)) {
+    return null;
+  }
+  const entries: RememberedOrigin[] = [];
+  const seen = new Set<string>();
+  for (const item of parsed) {
+    if (typeof item !== "object" || item === null) {
+      continue;
+    }
+    const { url, name, addedAt } = item as Record<string, unknown>;
+    if (typeof url !== "string") {
+      continue;
+    }
+    const normalized = normalizeOriginUrl(url);
+    if (normalized === null || seen.has(normalized)) {
+      continue;
+    }
+    seen.add(normalized);
+    entries.push({
+      url: normalized,
+      ...(typeof name === "string" && name !== "" ? { name } : {}),
+      addedAt:
+        typeof addedAt === "string" ? addedAt : new Date().toISOString(),
+    });
+  }
+  return entries;
+}
+
+// Device-scoped: the remembered list is this device's client-local view of
+// its assistants (like the same-machine lockfile), so it survives hub logout.
+const storage = createStorageAccessor<RememberedOrigin[]>({
+  key: REMEMBERED_ORIGINS_STORAGE_KEY,
+  scope: "device",
+  parse: parseStoredEntries,
+  serialize: JSON.stringify,
+  fallback: [],
+});
+
+export const localStorageProvider: RememberedOriginsProvider = {
+  load: async () => storage.load(),
+  save: async (entries) => {
+    storage.save(entries);
+  },
+};
+
+let activeProvider: RememberedOriginsProvider = localStorageProvider;
+let hydrationPromise: Promise<void> | null = null;
+/** Bumped on provider swap so an in-flight stale load can't clobber state. */
+let hydrationEpoch = 0;
+
+/**
+ * Swap the persistence provider (e.g. for a native Capacitor-backed store)
+ * and re-hydrate from it.
+ */
+export function setRememberedOriginsProvider(
+  provider: RememberedOriginsProvider,
+): void {
+  activeProvider = provider;
+  hydrationEpoch += 1;
+  hydrationPromise = null;
+  useRememberedOriginsStoreBase.setState({ hydrated: false });
+  void useRememberedOriginsStoreBase.getState().hydrate();
+}
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+export interface RememberedOriginsState {
+  origins: RememberedOrigin[];
+  hydrated: boolean;
+}
+
+export type AddOriginResult =
+  | { ok: true; origin: RememberedOrigin }
+  | { ok: false };
+
+export interface RememberedOriginsActions {
+  /** Load from the provider once; concurrent calls share one promise. */
+  hydrate: () => Promise<void>;
+  /**
+   * Remember an origin. Invalid urls return `{ ok: false }`. Re-adding an
+   * already-remembered url keeps its original `addedAt` and updates `name`
+   * only when a new one is provided.
+   */
+  addOrigin: (input: { url: string; name?: string }) => Promise<AddOriginResult>;
+  removeOrigin: (url: string) => Promise<void>;
+}
+
+export type RememberedOriginsStore = RememberedOriginsState &
+  RememberedOriginsActions;
+
+const useRememberedOriginsStoreBase = create<RememberedOriginsStore>()(
+  (set, get) => ({
+    origins: [],
+    hydrated: false,
+
+    hydrate: () => {
+      hydrationPromise ??= (async () => {
+        const epoch = hydrationEpoch;
+        let origins: RememberedOrigin[] = [];
+        try {
+          origins = await activeProvider.load();
+        } catch {
+          // A failed load hydrates empty rather than blocking callers.
+        }
+        if (epoch === hydrationEpoch) {
+          set({ origins, hydrated: true });
+        }
+      })();
+      return hydrationPromise;
+    },
+
+    addOrigin: async ({ url, name }) => {
+      const normalized = normalizeOriginUrl(url);
+      if (normalized === null) {
+        return { ok: false };
+      }
+      await get().hydrate();
+      const trimmedName = name?.trim();
+      const current = get().origins;
+      const existing = current.find((o) => o.url === normalized);
+      const base: RememberedOrigin = existing ?? {
+        url: normalized,
+        addedAt: new Date().toISOString(),
+      };
+      const origin = trimmedName ? { ...base, name: trimmedName } : base;
+      const origins = existing
+        ? current.map((o) => (o.url === normalized ? origin : o))
+        : [...current, origin];
+      set({ origins });
+      await activeProvider.save(origins);
+      return { ok: true, origin };
+    },
+
+    removeOrigin: async (url) => {
+      const normalized = normalizeOriginUrl(url);
+      if (normalized === null) {
+        return;
+      }
+      await get().hydrate();
+      const remaining = get().origins.filter((o) => o.url !== normalized);
+      if (remaining.length === get().origins.length) {
+        return;
+      }
+      set({ origins: remaining });
+      await activeProvider.save(remaining);
+    },
+  }),
+);
+
+export const useRememberedOriginsStore = createSelectors(
+  useRememberedOriginsStoreBase,
+);

--- a/clients/web/src/stores/remembered-origins-store.ts
+++ b/clients/web/src/stores/remembered-origins-store.ts
@@ -250,6 +250,11 @@ const useRememberedOriginsStoreBase = create<RememberedOriginsStore>()(
     hydrate: () => {
       hydrationPromise ??= (async () => {
         const epoch = hydrationEpoch;
+        // Yield before calling the provider so a synchronous load() throw is
+        // caught only after the ??= above has installed this promise;
+        // otherwise the catch's reset would be overwritten and later
+        // hydrate() calls could never retry.
+        await Promise.resolve();
         try {
           const origins = await activeProvider.load();
           if (epoch === hydrationEpoch) {


### PR DESCRIPTION
## Summary
- New leaf zustand store of remembered remote-assistant origins ({name?, url, addedAt}, no secrets) with pluggable persistence provider (localStorage default)
- normalizeOriginUrl validation (https-only, host required, strips trailing slash/query/hash, preserves path prefix)
- Inert scaffolding: unused by app code until the chooser PRs land

Part of plan: origin-model-chooser.md (PR 1 of 7)