### PR TITLE
feat(ios): SelfHostedServers plugin generalizing the single self-hosted slot into a switchable list

### DIFF
--- a/clients/ios/App/App/AppDelegate.swift
+++ b/clients/ios/App/App/AppDelegate.swift
@@ -90,12 +90,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     /// ready.
     private var pendingConnectPairURL: URL?
 
-    /// Handle `<scheme>://connect?url=<https-base>&code=<device-code>` — the
-    /// custom-scheme QR path that pairs the shell to a self-hosted assistant. The
-    /// `url` parameter is the server base (host, optionally with a path prefix
-    /// like `/assistant-123` for Velay-style hosting); it is both persisted and
-    /// the value the pair-page URL is derived from, so there is one source of
-    /// truth.
+    /// Handle `<scheme>://connect?url=<https-base>&code=<device-code>` (with an
+    /// optional `name=<label>`), the custom-scheme QR path that pairs the shell
+    /// to a self-hosted assistant. The `url` parameter is the server base (host,
+    /// optionally with a path prefix like `/assistant-123` for Velay-style
+    /// hosting); it is both persisted and the value the pair-page URL is derived
+    /// from, so there is one source of truth.
     ///
     /// One handler serves both entry points: a warm open via
     /// `application(_:open:)` and a cold launch via `launchOptions[.url]`. The
@@ -120,6 +120,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         SelfHostedServer.store(connect.base)
+        SelfHostedServer.append(url: connect.base, name: connect.name)
         pendingConnectPairURL = connect.pairURL
         deliverPendingConnectNavigation()
         return true
@@ -140,10 +141,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         webView.load(URLRequest(url: pairURL))
     }
 
-    /// Parse `<scheme>://connect?url=&code=` into the validated https server base
-    /// and the pair-page URL to load. Returns `nil` for a malformed or non-https
-    /// link.
-    private static func parseConnectDeepLink(_ url: URL) -> (base: URL, pairURL: URL)? {
+    /// Parse `<scheme>://connect?url=&code=` into the validated https server
+    /// base, the pair-page URL to load, and the optional `name` label for the
+    /// remembered-server list. Returns `nil` for a malformed or non-https link.
+    private static func parseConnectDeepLink(_ url: URL) -> (base: URL, pairURL: URL, name: String?)? {
         guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
               let serverParam = components.queryItems?.first(where: { $0.name == "url" })?.value,
               let code = components.queryItems?.first(where: { $0.name == "code" })?.value,
@@ -153,7 +154,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         else {
             return nil
         }
-        return (base, pairURL)
+        let name = components.queryItems?.first(where: { $0.name == "name" })?.value
+        return (base, pairURL, name)
     }
 
     /// Build the standalone SPA pairing route that completes the pre-approved

--- a/clients/ios/App/App/MyViewController.swift
+++ b/clients/ios/App/App/MyViewController.swift
@@ -5,8 +5,9 @@ import WebKit
 /// Custom `CAPBridgeViewController` subclass that:
 ///
 /// 1. Registers `NativeAuthPlugin`, `NativeBiometricPlugin`,
-///    `VoiceAudioSessionPlugin`, `VoiceLiveActivityPlugin`, and
-///    `ApnsEnvironmentPlugin` as local plugin instances at bridge init time.
+///    `VoiceAudioSessionPlugin`, `VoiceLiveActivityPlugin`,
+///    `ApnsEnvironmentPlugin`, and `SelfHostedServersPlugin` as local plugin
+///    instances at bridge init time.
 ///    These plugins live inside the App target (no SPM module) so the bridge
 ///    won't discover them automatically.
 ///
@@ -55,6 +56,12 @@ class MyViewController: CAPBridgeViewController {
     /// any self-hosted override is applied so a cleared preference and the "Use
     /// Vellum Cloud" fallback can always return here.
     private var bakedServerURL: URL?
+
+    /// The baked Vellum Cloud URL as a string, exposed for the
+    /// `SelfHostedServers` plugin's `list` result.
+    var bakedServerURLString: String? {
+        return bakedServerURL?.absoluteString
+    }
 
     /// Retains the navigation-delegate decorator. Capacitor stores its
     /// `navigationDelegate` weakly, so the proxy must be owned here to stay
@@ -160,6 +167,7 @@ class MyViewController: CAPBridgeViewController {
         bridge?.registerPluginInstance(VoiceAudioSessionPlugin())
         bridge?.registerPluginInstance(VoiceLiveActivityPlugin())
         bridge?.registerPluginInstance(ApnsEnvironmentPlugin())
+        bridge?.registerPluginInstance(SelfHostedServersPlugin())
         installNavigationDelegateProxy()
         installInputZoomPreventionUserScript()
         installViewportZoomLockUserScript()
@@ -191,12 +199,12 @@ class MyViewController: CAPBridgeViewController {
     /// useful offline state.
     @objc private func reloadIfConfiguredOriginChanged() {
         let destination = SelfHostedServer.configuredURL() ?? bakedServerURL
-        guard let destination else { return }
-        guard destination.absoluteString != appliedServerURL?.absoluteString else {
+        guard let destination,
+              destination.absoluteString != appliedServerURL?.absoluteString
+        else {
             return
         }
-        appliedServerURL = destination
-        webView?.load(URLRequest(url: destination))
+        applyConfiguredOrigin()
     }
 
     /// Apply any deep link that arrived before the web view was ready. A cold
@@ -217,6 +225,17 @@ class MyViewController: CAPBridgeViewController {
     /// re-detected as a change on the next foreground.
     func bindServerTrackingToConfiguredOrigin() {
         appliedServerURL = SelfHostedServer.configuredURL() ?? bakedServerURL
+    }
+
+    /// Load the effective server URL (the configured self-hosted origin or the
+    /// baked default) and re-arm foreground change detection against it. Backs
+    /// the `SelfHostedServers` plugin's `switchTo`; must run on the main queue.
+    func applyConfiguredOrigin() {
+        bindServerTrackingToConfiguredOrigin()
+        guard let destination = appliedServerURL else {
+            return
+        }
+        webView?.load(URLRequest(url: destination))
     }
 
     // MARK: - Quote-and-reply edit menu

--- a/clients/ios/App/App/SelfHostedServer.swift
+++ b/clients/ios/App/App/SelfHostedServer.swift
@@ -3,17 +3,32 @@ import Foundation
 /// The self-hosted assistant origin the shell points its `WKWebView` at instead
 /// of the baked Vellum Cloud URL.
 ///
-/// The value lives in `UserDefaults` under `self_hosted_server_url`, written
-/// either from the native Settings pane (`Settings.bundle`) or the
-/// `vellum-assistant://connect` deep link. An empty or absent value means the
-/// shell uses its baked default (Vellum Cloud), which is the unchanged default
-/// experience. This type is the single reader/validator shared by
-/// `MyViewController` (boot + foreground override) and `AppDelegate` (connect
-/// deep link) so the key and the validation rules live in exactly one place.
+/// The active value lives in `UserDefaults` under `self_hosted_server_url`,
+/// written either from the native Settings pane (`Settings.bundle`), the
+/// `vellum-assistant://connect` deep link, or the `SelfHostedServers` plugin.
+/// An empty or absent value means the shell uses its baked default (Vellum
+/// Cloud), which is the unchanged default experience. Alongside the active
+/// slot, `self_hosted_servers` remembers every paired origin as a
+/// `{name?, url}` list so the web chooser can switch between them. This type
+/// is the single reader/validator shared by `MyViewController` (boot +
+/// foreground override), `AppDelegate` (connect deep link), and
+/// `SelfHostedServersPlugin` so the keys and the validation rules live in
+/// exactly one place.
 enum SelfHostedServer {
     /// `UserDefaults` key shared with the `Settings.bundle` pane. This exact
     /// string is the read/write contract with the settings `Root.plist`.
     static let defaultsKey = "self_hosted_server_url"
+
+    /// `UserDefaults` key holding the remembered server list as a JSON array
+    /// of `{"name": String?, "url": String}`.
+    static let serversKey = "self_hosted_servers"
+
+    /// A remembered self-hosted server: a validated https origin plus an
+    /// optional user-facing label (from the pairing deep link's `name` param).
+    struct Entry: Codable, Equatable {
+        var name: String?
+        var url: String
+    }
 
     /// The validated self-hosted origin, or `nil` when the preference is unset
     /// or invalid so callers fall back to the baked default.
@@ -47,5 +62,72 @@ enum SelfHostedServer {
     /// Clear the preference, returning the shell to the baked Vellum Cloud URL.
     static func clear(defaults: UserDefaults = .standard) {
         defaults.removeObject(forKey: defaultsKey)
+    }
+
+    /// The remembered server list. Entries failing `validate` are dropped, and
+    /// a legacy active URL absent from the stored list is included (name nil)
+    /// without writing back until the next mutation.
+    static func servers(defaults: UserDefaults = .standard) -> [Entry] {
+        var entries: [Entry] = []
+        if let data = defaults.data(forKey: serversKey),
+           let decoded = try? JSONDecoder().decode([Entry].self, from: data) {
+            for item in decoded {
+                guard let url = validate(item.url),
+                      !entries.contains(where: { $0.url == url.absoluteString })
+                else {
+                    continue
+                }
+                entries.append(Entry(name: normalizedName(item.name), url: url.absoluteString))
+            }
+        }
+        if let active = configuredURL(defaults: defaults),
+           !entries.contains(where: { $0.url == active.absoluteString }) {
+            entries.append(Entry(name: nil, url: active.absoluteString))
+        }
+        return entries
+    }
+
+    /// Remember an origin, deduped by absolute string. A re-append with a name
+    /// updates the label; a nameless re-append keeps the existing one, so
+    /// switching to a remembered server never wipes its label.
+    static func append(url: URL, name: String?, defaults: UserDefaults = .standard) {
+        var entries = servers(defaults: defaults)
+        let name = normalizedName(name)
+        if let index = entries.firstIndex(where: { $0.url == url.absoluteString }) {
+            if let name {
+                entries[index].name = name
+            }
+        } else {
+            entries.append(Entry(name: name, url: url.absoluteString))
+        }
+        persist(entries, defaults: defaults)
+    }
+
+    /// Forget an origin. When it is also the active URL, the active slot is
+    /// cleared so the shell falls back to the baked default.
+    static func remove(url: URL, defaults: UserDefaults = .standard) {
+        var entries = servers(defaults: defaults)
+        entries.removeAll { $0.url == url.absoluteString }
+        persist(entries, defaults: defaults)
+        if configuredURL(defaults: defaults)?.absoluteString == url.absoluteString {
+            clear(defaults: defaults)
+        }
+    }
+
+    private static func persist(_ entries: [Entry], defaults: UserDefaults) {
+        guard let data = try? JSONEncoder().encode(entries) else {
+            return
+        }
+        defaults.set(data, forKey: serversKey)
+    }
+
+    /// Trim a label and collapse an empty one to nil.
+    private static func normalizedName(_ name: String?) -> String? {
+        guard let trimmed = name?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty
+        else {
+            return nil
+        }
+        return trimmed
     }
 }

--- a/clients/ios/App/App/SelfHostedServersPlugin.swift
+++ b/clients/ios/App/App/SelfHostedServersPlugin.swift
@@ -58,12 +58,22 @@ public class SelfHostedServersPlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     /// Forgetting a URL that is not (or cannot be) in the list is a no-op, so
-    /// this never rejects.
+    /// this never rejects. Removing the active server clears the active slot,
+    /// so the shell reloads back to the baked origin like `switchTo({})`.
     @objc public func remove(_ call: CAPPluginCall) {
+        var removedActive = false
         if let url = SelfHostedServer.validate(call.getString("url")) {
+            removedActive = SelfHostedServer.configuredURL()?.absoluteString == url.absoluteString
             SelfHostedServer.remove(url: url)
         }
-        call.resolve(["ok": true])
+        guard removedActive else {
+            call.resolve(["ok": true])
+            return
+        }
+        DispatchQueue.main.async { [weak self] in
+            (self?.bridge?.viewController as? MyViewController)?.applyConfiguredOrigin()
+            call.resolve(["ok": true])
+        }
     }
 
     /// Switching to a URL implies remembering it, so the target is appended to

--- a/clients/ios/App/App/SelfHostedServersPlugin.swift
+++ b/clients/ios/App/App/SelfHostedServersPlugin.swift
@@ -1,0 +1,97 @@
+import Capacitor
+import Foundation
+
+/// Capacitor plugin exposing the remembered self-hosted server list to the web
+/// layer, which installs it as the assistant chooser's storage provider. The
+/// active slot stays `SelfHostedServer.defaultsKey` (the `Settings.bundle`
+/// contract); this plugin generalizes it into a switchable `{name?, url}` list.
+///
+/// Methods:
+/// - `list` resolves `{ servers: [{name?, url}], activeUrl, bakedUrl }`
+/// - `add({url, name?})` remembers an origin
+/// - `remove({url})` forgets one (clearing the active slot when it matches)
+/// - `switchTo({url?})` swaps the shell's origin and reloads in place; an
+///   absent/empty url returns to the baked Vellum Cloud origin
+///
+/// Per the skew rule in `clients/web/docs/CAPACITOR.md`, one result shape
+/// encodes every state: empty state resolves with an empty list and nulls
+/// rather than rejecting, so only genuinely invalid caller input (an `add` or
+/// `switchTo` URL failing `SelfHostedServer.validate`) rejects.
+@objc(SelfHostedServersPlugin)
+public class SelfHostedServersPlugin: CAPPlugin, CAPBridgedPlugin {
+    public let identifier = "SelfHostedServersPlugin"
+    public let jsName = "SelfHostedServers"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "list", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "add", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "remove", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "switchTo", returnType: CAPPluginReturnPromise),
+    ]
+
+    @objc public func list(_ call: CAPPluginCall) {
+        let servers: [[String: Any]] = SelfHostedServer.servers().map { entry in
+            var item: [String: Any] = ["url": entry.url]
+            if let name = entry.name {
+                item["name"] = name
+            }
+            return item
+        }
+        // The baked URL lives on the bridge view controller, so read it on the
+        // main queue.
+        DispatchQueue.main.async { [weak self] in
+            let baked = (self?.bridge?.viewController as? MyViewController)?.bakedServerURLString
+            call.resolve([
+                "servers": servers,
+                "activeUrl": Self.nullable(SelfHostedServer.configuredURL()?.absoluteString),
+                "bakedUrl": Self.nullable(baked),
+            ])
+        }
+    }
+
+    @objc public func add(_ call: CAPPluginCall) {
+        guard let url = SelfHostedServer.validate(call.getString("url")) else {
+            call.reject("invalid url")
+            return
+        }
+        SelfHostedServer.append(url: url, name: call.getString("name"))
+        call.resolve(["ok": true])
+    }
+
+    /// Forgetting a URL that is not (or cannot be) in the list is a no-op, so
+    /// this never rejects.
+    @objc public func remove(_ call: CAPPluginCall) {
+        if let url = SelfHostedServer.validate(call.getString("url")) {
+            SelfHostedServer.remove(url: url)
+        }
+        call.resolve(["ok": true])
+    }
+
+    /// Switching to a URL implies remembering it, so the target is appended to
+    /// the list alongside the active-slot write. The reload itself runs on the
+    /// main queue via `MyViewController.applyConfiguredOrigin()`; the runtime
+    /// navigation allowance (`NavigationDelegateProxy`) checks the
+    /// currently-configured host, so the new origin loads in-app.
+    @objc public func switchTo(_ call: CAPPluginCall) {
+        let raw = call.getString("url")?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if raw.isEmpty {
+            SelfHostedServer.clear()
+        } else if let url = SelfHostedServer.validate(raw) {
+            SelfHostedServer.store(url)
+            SelfHostedServer.append(url: url, name: nil)
+        } else {
+            call.reject("invalid url")
+            return
+        }
+        DispatchQueue.main.async { [weak self] in
+            (self?.bridge?.viewController as? MyViewController)?.applyConfiguredOrigin()
+            call.resolve(["ok": true])
+        }
+    }
+
+    private static func nullable(_ value: String?) -> Any {
+        if let value {
+            return value
+        }
+        return NSNull()
+    }
+}

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -43,9 +43,10 @@ which URL is baked into the build.
   process. With `server.url`, only native shell changes (Swift code,
   entitlements, Capacitor plugin updates) require a store submission.
 - **Thin native surface** — the IPC bridge between the WKWebView and
-  native code is minimal (five plugins: `NativeAuthPlugin`,
+  native code is minimal (six plugins: `NativeAuthPlugin`,
   `NativeBiometricPlugin`, `VoiceAudioSessionPlugin`,
-  `VoiceLiveActivityPlugin`, and `ApnsEnvironmentPlugin`), so version
+  `VoiceLiveActivityPlugin`, `ApnsEnvironmentPlugin`, and
+  `SelfHostedServersPlugin`), so version
   skew risk between the web app and native shell is low. Every plugin
   call from the web side must still be capability-probed, because a new
   web bundle always ships ahead of the shell that hosts it. Contrast
@@ -150,7 +151,7 @@ Apple's reference for the toolbar controls:
 
 The app has two layers — the **WKWebView contents** (the React app loaded
 from the configured server URL) and the **native Swift shell** (Capacitor
-bridge, `MyViewController`, the five native plugins). Each has its own
+bridge, `MyViewController`, the six native plugins). Each has its own
 debugger.
 
 ### Safari Web Inspector — for the web side (JS / CSS / network / `console.log`)
@@ -198,8 +199,9 @@ For a **physical iPhone**:
 ⌘R runs with `lldb` already attached. Click in the gutter next to any
 line in `AppDelegate.swift`, `MyViewController.swift`,
 `NativeAuthPlugin.swift`, `NativeBiometricPlugin.swift`,
-`VoiceAudioSessionPlugin.swift`, `VoiceLiveActivityPlugin.swift`, or
-`ApnsEnvironmentPlugin.swift` to set a breakpoint.
+`VoiceAudioSessionPlugin.swift`, `VoiceLiveActivityPlugin.swift`,
+`ApnsEnvironmentPlugin.swift`, or `SelfHostedServersPlugin.swift` to set
+a breakpoint.
 
 - **Console / log output**: View → Debug Area → Activate Console (⇧⌘Y),
   or click the bottom-right console toggle. `print()` and `NSLog()` from
@@ -218,7 +220,8 @@ line in `AppDelegate.swift`, `MyViewController.swift`,
 ### Common debugging recipes
 
 - **A native plugin call (`NativeAuth`, `NativeBiometric`,
-  `VoiceAudioSession`, `VoiceLiveActivity`, `ApnsEnvironment`) seems broken**:
+  `VoiceAudioSession`, `VoiceLiveActivity`, `ApnsEnvironment`,
+  `SelfHostedServers`) seems broken**:
   set a Swift breakpoint in the relevant `@objc func` inside the plugin
   file and trigger the action from the web app. If the breakpoint never
   hits, the JS-side `Capacitor.Plugins.NativeAuth` lookup is wrong (check
@@ -699,6 +702,8 @@ clients/
     │   │   ├── VoiceAudioSessionPlugin.swift # AVAudioSession for live voice
     │   │   ├── VoiceLiveActivityPlugin.swift # Dynamic Island for live voice
     │   │   ├── ApnsEnvironmentPlugin.swift # APNs entitlement environment
+    │   │   ├── SelfHostedServer.swift      # Active + remembered self-hosted origins
+    │   │   ├── SelfHostedServersPlugin.swift # Server list / origin switching bridge
     │   │   ├── Intents/              # App Intents + AppShortcutsProvider
     │   │   ├── Shared/               # Compiled into app + widget extension
     │   │   └── Info.plist

--- a/clients/web/docs/CAPACITOR.md
+++ b/clients/web/docs/CAPACITOR.md
@@ -146,7 +146,7 @@ References:
 
 Live voice is a web feature with native accessories. The session, including mic capture, the velay socket, TTS playback, and every user-facing string, lives entirely under `src/domains/chat/voice/live-voice/`. iOS adds interruption reporting, a Dynamic Island and Lock Screen presence, and App Intents. Android adds foreground audio focus and an ongoing status notification.
 
-The shell registers **five** Capacitor plugins in [`MyViewController.capacitorDidLoad()`](../../../clients/ios/App/App/MyViewController.swift) (count them there, not from prose):
+The shell registers **six** Capacitor plugins in [`MyViewController.capacitorDidLoad()`](../../../clients/ios/App/App/MyViewController.swift) (count them there, not from prose):
 
 | Plugin | Web module | What it does |
 | --- | --- | --- |
@@ -155,6 +155,7 @@ The shell registers **five** Capacitor plugins in [`MyViewController.capacitorDi
 | `VoiceAudioSession` | [`src/runtime/native-audio-session.ts`](../src/runtime/native-audio-session.ts) | iOS interruption events and Android foreground audio focus. See the background-audio contract below |
 | `VoiceLiveActivity` | [`src/runtime/native-live-activity.ts`](../src/runtime/native-live-activity.ts) | One ActivityKit activity on iOS or ongoing notification on Android |
 | `ApnsEnvironment` | [`src/runtime/apns-environment.ts`](../src/runtime/apns-environment.ts) | The build's real APNs entitlement environment (`development` / `production` / `unknown`), read from the embedded provisioning profile |
+| `SelfHostedServers` | none yet (web wiring ships separately) | List, add, remove, and switch between self-hosted server origins; `switchTo` swaps the shell's configured origin and reloads in place |
 
 The two voice plugins are consumed only through `use-live-voice-session-controller.ts` (audio session) and `use-live-activity-mirror.ts` (Live Activity), both mounted at `ChatLayout` scope so their lifetime is exactly the session's.
 


### PR DESCRIPTION
## Summary
- SelfHostedServer gains a self_hosted_servers JSON list (legacy active-slot migration, dedupe-by-url append, remove clears active when matching)
- New SelfHostedServersPlugin (list/add/remove/switchTo) with in-place WKWebView origin swap via MyViewController.applyConfiguredOrigin()
- connect deep link reads optional name= and appends {name, url} to the list

Part of plan: origin-model-chooser.md (PR 6 of 7)