### PR TITLE
feat(cli,web): thread assistant label and hub URL through connect links and the remote-web config

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -222,6 +222,7 @@
         "@tiptap/starter-kit": "3.23.5",
         "@vellumai/assistant-api": "workspace:*",
         "@vellumai/design-library": "workspace:*",
+        "@vellumai/environments": "workspace:*",
         "@vellumai/ipc-contract": "workspace:*",
         "@vellumai/local-mode": "workspace:*",
         "@vellumai/service-contracts": "workspace:*",

--- a/cli/src/__tests__/nginx-ingress.test.ts
+++ b/cli/src/__tests__/nginx-ingress.test.ts
@@ -1,5 +1,6 @@
 import * as childProcess from "node:child_process";
 import type { ChildProcess } from "node:child_process";
+import { createHash } from "node:crypto";
 import * as fsModule from "node:fs";
 import {
   existsSync,
@@ -618,7 +619,12 @@ function mockWebDistPresent(): void {
 /** Record a running edge: ingress state, live pidfile, matching ps output. */
 function mockRunningEdge(
   ws: string,
-  opts: { listenPort: number; includeWebApp?: boolean; gatewayPort?: number },
+  opts: {
+    listenPort: number;
+    includeWebApp?: boolean;
+    gatewayPort?: number;
+    remoteWebConfigHash?: string;
+  },
 ): number {
   const pid = 123_460;
   writeFileSync(
@@ -633,6 +639,9 @@ function mockRunningEdge(
           ...(opts.gatewayPort === undefined
             ? {}
             : { gatewayPort: opts.gatewayPort }),
+          ...(opts.remoteWebConfigHash === undefined
+            ? {}
+            : { remoteWebConfigHash: opts.remoteWebConfigHash }),
         },
       },
     }) + "\n",
@@ -660,6 +669,27 @@ function mockUnkillableNginx(pid: number): void {
 }
 
 const PRODUCTION_HUB_URL = "https://www.vellum.ai/assistant";
+
+/**
+ * Mirror of the SPA config fingerprint the edge records in its ingress state
+ * (sha256 over the injected config JSON). Pins both the injected config
+ * shape and the hash format; assumes the production-pinned environment.
+ */
+function spaConfigHash(assistantName?: string): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        mode: "remote-gateway",
+        apiBaseUrl: "/v1",
+        platformDisabled: true,
+        disablePlatform: true,
+        ...(assistantName ? { assistantName } : {}),
+        hubUrl: PRODUCTION_HUB_URL,
+      }),
+    )
+    .digest("hex");
+}
+
 const originalEnvironment = process.env.VELLUM_ENVIRONMENT;
 
 /** Pin the build environment so the stamped hubUrl is deterministic. */
@@ -775,6 +805,7 @@ describe("startRemoteWebIngress", () => {
       listenPort: 7845,
       includeWebApp: true,
       gatewayPort: 7830,
+      remoteWebConfigHash: spaConfigHash(),
     });
   });
 
@@ -982,7 +1013,11 @@ describe("startRemoteWebIngress", () => {
     const ws = makeWorkspace();
     mockNginxInstalled();
     mockNginxSpawn();
-    const pid = mockRunningEdge(ws, { listenPort: 7845, gatewayPort: 7830 });
+    const pid = mockRunningEdge(ws, {
+      listenPort: 7845,
+      gatewayPort: 7830,
+      remoteWebConfigHash: spaConfigHash(),
+    });
     const edge = mockKillableNginx(pid);
 
     const result = await startRemoteWebIngress({
@@ -998,6 +1033,130 @@ describe("startRemoteWebIngress", () => {
       gatewayPort: 7830,
     });
     expect(edge.killed()).toBe(false);
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  test("short-circuits when the running SPA edge already serves the requested config", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockNginxSpawn();
+    mockWebDistPresent();
+    const pid = mockRunningEdge(ws, {
+      listenPort: 7845,
+      includeWebApp: true,
+      gatewayPort: 7830,
+      remoteWebConfigHash: spaConfigHash("My Homelab"),
+    });
+    const edge = mockKillableNginx(pid);
+
+    const result = await startRemoteWebIngress({
+      workspaceDir: ws,
+      gatewayPort: 7830,
+      listenPort: 7845,
+      assistantName: "My Homelab",
+    });
+
+    expect(result).toEqual({
+      status: "already-running",
+      listenPort: 7845,
+      includeWebApp: true,
+      gatewayPort: 7830,
+    });
+    expect(edge.killed()).toBe(false);
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  test("restarts the edge when the injected SPA config drifts from the recorded one", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockNginxSpawn();
+    mockWebDistPresent();
+    const pid = mockRunningEdge(ws, {
+      listenPort: 7845,
+      includeWebApp: true,
+      gatewayPort: 7830,
+      remoteWebConfigHash: spaConfigHash("Old Name"),
+    });
+    const edge = mockKillableNginx(pid);
+
+    const result = await startRemoteWebIngress({
+      workspaceDir: ws,
+      gatewayPort: 7830,
+      listenPort: 7845,
+      assistantName: "New Name",
+    });
+
+    expect(result.status).toBe("started");
+    expect(edge.killed()).toBe(true);
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const indexHtml = realFs.readFileSync(
+      join(ws, "data", "ingress", "assistant-index.html"),
+      "utf-8",
+    );
+    expect(indexHtml).toContain('"assistantName":"New Name"');
+    expect((readConfig(ws).ingress as Record<string, unknown>).nginx).toEqual({
+      listenPort: 7845,
+      includeWebApp: true,
+      gatewayPort: 7830,
+      remoteWebConfigHash: spaConfigHash("New Name"),
+    });
+  });
+
+  test("restarts an SPA edge whose state predates the config fingerprint", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockNginxSpawn();
+    mockWebDistPresent();
+    const pid = mockRunningEdge(ws, {
+      listenPort: 7845,
+      includeWebApp: true,
+      gatewayPort: 7830,
+    });
+    const edge = mockKillableNginx(pid);
+
+    const result = await startRemoteWebIngress({
+      workspaceDir: ws,
+      gatewayPort: 7830,
+      listenPort: 7845,
+    });
+
+    expect(result.status).toBe("started");
+    expect(edge.killed()).toBe(true);
+    expect((readConfig(ws).ingress as Record<string, unknown>).nginx).toEqual({
+      listenPort: 7845,
+      includeWebApp: true,
+      gatewayPort: 7830,
+      remoteWebConfigHash: spaConfigHash(),
+    });
+  });
+
+  test("a config-drifted edge that survives the restart attempt reports it as stale", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockNginxSpawn();
+    mockWebDistPresent();
+    const pid = mockRunningEdge(ws, {
+      listenPort: 7845,
+      includeWebApp: true,
+      gatewayPort: 7830,
+      remoteWebConfigHash: spaConfigHash("Old Name"),
+    });
+    mockUnkillableNginx(pid);
+
+    const result = await startRemoteWebIngress({
+      workspaceDir: ws,
+      gatewayPort: 7830,
+      listenPort: 7845,
+      assistantName: "New Name",
+    });
+
+    expect(result).toEqual({
+      status: "already-running",
+      listenPort: 7845,
+      includeWebApp: true,
+      gatewayPort: 7830,
+      staleRemoteWebConfig: true,
+    });
     expect(spawnMock).not.toHaveBeenCalled();
   });
 
@@ -1101,6 +1260,7 @@ describe("startRemoteWebIngress", () => {
       listenPort: 7845,
       includeWebApp: true,
       gatewayPort: 7830,
+      remoteWebConfigHash: spaConfigHash(),
     });
   });
 
@@ -1151,7 +1311,8 @@ describe("startRemoteWebIngress", () => {
     });
     expect(spawnMock).toHaveBeenCalledTimes(1);
     const ingress = readConfig(ws).ingress as
-      Record<string, unknown> | undefined;
+      | Record<string, unknown>
+      | undefined;
     expect(ingress?.nginx).toBeUndefined();
   });
 
@@ -1179,7 +1340,8 @@ describe("startRemoteWebIngress", () => {
     });
     expect(spawnMock).toHaveBeenCalledTimes(1);
     const ingress = readConfig(ws).ingress as
-      Record<string, unknown> | undefined;
+      | Record<string, unknown>
+      | undefined;
     expect(ingress?.nginx).toBeUndefined();
   });
 
@@ -1359,6 +1521,7 @@ describe("ensureTunnelEdge", () => {
       listenPort: 7845,
       includeWebApp: true,
       gatewayPort: 7830,
+      remoteWebConfigHash: spaConfigHash(),
     });
     const edge = mockKillableNginx(pid);
 
@@ -1402,6 +1565,81 @@ describe("ensureTunnelEdge", () => {
       includesWebApp: false,
     });
     expect(edge.killed()).toBe(false);
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  test("restarts the edge when the lockfile display name changes", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockNginxSpawn();
+    mockWebDistPresent();
+    const writeLockfile = (name: string) =>
+      writeFileSync(
+        join(lockfileDir, ".vellum.lock.json"),
+        JSON.stringify({
+          assistants: [
+            {
+              assistantId: ASSISTANT_ID,
+              name,
+              cloud: "local",
+              runtimeUrl: "http://127.0.0.1:7830",
+              localUrl: "http://127.0.0.1:7830",
+            },
+          ],
+          activeAssistant: ASSISTANT_ID,
+        }),
+      );
+    writeLockfile("Homelab");
+
+    const first = await ensureTunnelEdge({
+      assistantId: ASSISTANT_ID,
+      workspaceDir: ws,
+      gatewayPort: 7830,
+    });
+    expect(first.started).toBe(true);
+
+    // Same port and mode, renamed assistant: the edge must restart so the
+    // served index carries the new label instead of reporting already-running.
+    writeLockfile("Renamed");
+    const second = await ensureTunnelEdge({
+      assistantId: ASSISTANT_ID,
+      workspaceDir: ws,
+      gatewayPort: 7830,
+    });
+
+    expect(second.started).toBe(true);
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+    const indexHtml = realFs.readFileSync(
+      join(ws, "data", "ingress", "assistant-index.html"),
+      "utf-8",
+    );
+    expect(indexHtml).toContain('"assistantName":"Renamed"');
+    expect(indexHtml).not.toContain('"assistantName":"Homelab"');
+  });
+
+  test("a config-drifted edge that survives the restart attempt throws", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockNginxSpawn();
+    mockWebDistPresent();
+    const pid = mockRunningEdge(ws, {
+      listenPort: REQUESTED_PORT,
+      includeWebApp: true,
+      gatewayPort: 7830,
+      remoteWebConfigHash: spaConfigHash("Stale Name"),
+    });
+    mockUnkillableNginx(pid);
+
+    const promise = ensureTunnelEdge({
+      assistantId: ASSISTANT_ID,
+      workspaceDir: ws,
+      gatewayPort: 7830,
+    });
+
+    await expect(promise).rejects.toThrow(
+      "still serving an outdated remote web config",
+    );
+    await expect(promise).rejects.toThrow("vellum nginx-ingress down");
     expect(spawnMock).not.toHaveBeenCalled();
   });
 
@@ -1546,6 +1784,7 @@ describe("ensureTunnelEdge", () => {
       listenPort: REQUESTED_PORT,
       includeWebApp: true,
       gatewayPort: 7830,
+      remoteWebConfigHash: spaConfigHash(),
     });
   });
 

--- a/cli/src/__tests__/nginx-ingress.test.ts
+++ b/cli/src/__tests__/nginx-ingress.test.ts
@@ -80,6 +80,7 @@ afterAll(() => {
 import {
   buildIngressNginxConfig,
   buildRemoteWebIndexHtml,
+  cloudWebHubUrl,
   ensureTunnelEdge,
   startRemoteWebIngress,
   stopIngressNginx,
@@ -246,6 +247,21 @@ describe("buildIngressNginxConfig", () => {
     );
   });
 
+  test("stamps assistantName and hubUrl into the served config when provided", () => {
+    const named = buildIngressNginxConfig({
+      gatewayPort: 7830,
+      listenPort: 7840,
+      remoteWebIngress: {
+        webDistDir: "/tmp/vellum web/dist",
+        assistantName: "Homelab",
+        hubUrl: "https://www.vellum.ai/assistant",
+      },
+    });
+    expect(named).toContain(
+      'return 200 "{\\"mode\\":\\"remote-gateway\\",\\"apiBaseUrl\\":\\"/v1\\",\\"platformDisabled\\":true,\\"disablePlatform\\":true,\\"assistantName\\":\\"Homelab\\",\\"hubUrl\\":\\"https://www.vellum.ai/assistant\\"}";',
+    );
+  });
+
   test("proxies health and public API traffic to the gateway in remote web mode", () => {
     expect(remoteConf).toContain("location = /healthz {");
     expect(remoteConf).toContain("location ^~ /v1/ {");
@@ -344,6 +360,26 @@ describe("buildRemoteWebIndexHtml", () => {
 
     expect(result).not.toContain("</script><script>alert(1)</script>");
     expect(result).toContain("\\u003c/script\\u003e");
+  });
+});
+
+describe("cloudWebHubUrl", () => {
+  test("maps build environments to their cloud SPA base", () => {
+    expect(cloudWebHubUrl("production")).toBe(
+      "https://www.vellum.ai/assistant",
+    );
+    expect(cloudWebHubUrl("staging")).toBe(
+      "https://staging-assistant.vellum.ai/assistant",
+    );
+    expect(cloudWebHubUrl("dev")).toBe(
+      "https://dev-assistant.vellum.ai/assistant",
+    );
+    expect(cloudWebHubUrl("local")).toBe(
+      "https://dev-assistant.vellum.ai/assistant",
+    );
+    expect(cloudWebHubUrl(undefined)).toBe(
+      "https://dev-assistant.vellum.ai/assistant",
+    );
   });
 });
 
@@ -623,7 +659,26 @@ function mockUnkillableNginx(pid: number): void {
   installKillMock();
 }
 
+const PRODUCTION_HUB_URL = "https://www.vellum.ai/assistant";
+const originalEnvironment = process.env.VELLUM_ENVIRONMENT;
+
+/** Pin the build environment so the stamped hubUrl is deterministic. */
+function pinProductionEnvironment(): void {
+  beforeEach(() => {
+    process.env.VELLUM_ENVIRONMENT = "production";
+  });
+  afterEach(() => {
+    if (originalEnvironment === undefined) {
+      delete process.env.VELLUM_ENVIRONMENT;
+    } else {
+      process.env.VELLUM_ENVIRONMENT = originalEnvironment;
+    }
+  });
+}
+
 describe("startRemoteWebIngress", () => {
+  pinProductionEnvironment();
+
   test("webhooks-only mode starts the denylist+proxy edge without a web dist", async () => {
     const ws = makeWorkspace();
     mockNginxInstalled();
@@ -702,22 +757,49 @@ describe("startRemoteWebIngress", () => {
         remoteWebIngress: {
           webDistDir,
           indexHtmlPath: join(ws, "data", "ingress", "assistant-index.html"),
+          hubUrl: PRODUCTION_HUB_URL,
         },
       }),
     );
     expect(conf).toContain("location ^~ /assistant/ {");
     expect(conf).toContain("location ^~ /webhooks/ {");
-    expect(
-      realFs.readFileSync(
-        join(ws, "data", "ingress", "assistant-index.html"),
-        "utf-8",
-      ),
-    ).toContain("remote-gateway");
+    const indexHtml = realFs.readFileSync(
+      join(ws, "data", "ingress", "assistant-index.html"),
+      "utf-8",
+    );
+    expect(indexHtml).toContain("remote-gateway");
+    expect(indexHtml).toContain(`"hubUrl":"${PRODUCTION_HUB_URL}"`);
+    // No assistant name was provided, so the served config omits the label.
+    expect(indexHtml).not.toContain("assistantName");
     expect((readConfig(ws).ingress as Record<string, unknown>).nginx).toEqual({
       listenPort: 7845,
       includeWebApp: true,
       gatewayPort: 7830,
     });
+  });
+
+  test("stamps the assistant label into the served config when provided", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockNginxSpawn();
+    mockWebDistPresent();
+
+    const result = await startRemoteWebIngress({
+      workspaceDir: ws,
+      gatewayPort: 7830,
+      listenPort: 7845,
+      assistantName: "My Homelab",
+    });
+
+    expect(result.status).toBe("started");
+    const indexHtml = realFs.readFileSync(
+      join(ws, "data", "ingress", "assistant-index.html"),
+      "utf-8",
+    );
+    expect(indexHtml).toContain('"assistantName":"My Homelab"');
+    expect(indexHtml).toContain(`"hubUrl":"${PRODUCTION_HUB_URL}"`);
+    const conf = realFs.readFileSync(ingressConfPath(ws), "utf-8");
+    expect(conf).toContain('\\"assistantName\\":\\"My Homelab\\"');
   });
 
   test("default mode still requires the web dist", async () => {
@@ -1186,9 +1268,17 @@ describe("ensureTunnelEdge", () => {
   const ASSISTANT_ID = "assistant-1";
   const REQUESTED_PORT = 7846;
   const originalIngressPort = process.env.VELLUM_NGINX_INGRESS_PORT;
+  const originalLockfileDir = process.env.VELLUM_LOCKFILE_DIR;
+  let lockfileDir: string;
+
+  pinProductionEnvironment();
 
   beforeEach(() => {
     process.env.VELLUM_NGINX_INGRESS_PORT = String(REQUESTED_PORT);
+    // Isolated lockfile dir so the assistant-name lookup never reads a real
+    // machine lockfile.
+    lockfileDir = makeWorkspace();
+    process.env.VELLUM_LOCKFILE_DIR = lockfileDir;
   });
 
   afterEach(() => {
@@ -1197,6 +1287,68 @@ describe("ensureTunnelEdge", () => {
     } else {
       process.env.VELLUM_NGINX_INGRESS_PORT = originalIngressPort;
     }
+    if (originalLockfileDir === undefined) {
+      delete process.env.VELLUM_LOCKFILE_DIR;
+    } else {
+      process.env.VELLUM_LOCKFILE_DIR = originalLockfileDir;
+    }
+  });
+
+  test("threads the lockfile display name into the served SPA config", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockNginxSpawn();
+    mockWebDistPresent();
+    writeFileSync(
+      join(lockfileDir, ".vellum.lock.json"),
+      JSON.stringify({
+        assistants: [
+          {
+            assistantId: ASSISTANT_ID,
+            name: "Homelab",
+            cloud: "local",
+            runtimeUrl: "http://127.0.0.1:7830",
+            localUrl: "http://127.0.0.1:7830",
+          },
+        ],
+        activeAssistant: ASSISTANT_ID,
+      }),
+    );
+
+    const result = await ensureTunnelEdge({
+      assistantId: ASSISTANT_ID,
+      workspaceDir: ws,
+      gatewayPort: 7830,
+    });
+
+    expect(result.includesWebApp).toBe(true);
+    const indexHtml = realFs.readFileSync(
+      join(ws, "data", "ingress", "assistant-index.html"),
+      "utf-8",
+    );
+    expect(indexHtml).toContain('"assistantName":"Homelab"');
+    expect(indexHtml).toContain(`"hubUrl":"${PRODUCTION_HUB_URL}"`);
+  });
+
+  test("omits the assistant label when the lockfile has no matching entry", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockNginxSpawn();
+    mockWebDistPresent();
+
+    const result = await ensureTunnelEdge({
+      assistantId: ASSISTANT_ID,
+      workspaceDir: ws,
+      gatewayPort: 7830,
+    });
+
+    expect(result.includesWebApp).toBe(true);
+    const indexHtml = realFs.readFileSync(
+      join(ws, "data", "ingress", "assistant-index.html"),
+      "utf-8",
+    );
+    expect(indexHtml).not.toContain("assistantName");
+    expect(indexHtml).toContain(`"hubUrl":"${PRODUCTION_HUB_URL}"`);
   });
 
   test("reuses a running edge that matches the flag-resolved mode", async () => {

--- a/cli/src/__tests__/pair.test.ts
+++ b/cli/src/__tests__/pair.test.ts
@@ -11,9 +11,13 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-// Real assistant-config reads the lockfile from VELLUM_LOCKFILE_DIR.
+// Real assistant-config reads the lockfile from VELLUM_LOCKFILE_DIR. Pin the
+// environment too: the lockfile filename is environment-dependent, and a dev
+// machine's persisted default environment would otherwise redirect the lookup.
 const testDir = mkdtempSync(join(tmpdir(), "pair-command-test-"));
 process.env.VELLUM_LOCKFILE_DIR = testDir;
+const originalEnvironment = process.env.VELLUM_ENVIRONMENT;
+process.env.VELLUM_ENVIRONMENT = "production";
 
 import { buildAppConnectUrl, pair } from "../commands/pair.js";
 
@@ -55,6 +59,11 @@ describe("pair command", () => {
   afterAll(() => {
     rmSync(testDir, { recursive: true, force: true });
     delete process.env.VELLUM_LOCKFILE_DIR;
+    if (originalEnvironment === undefined) {
+      delete process.env.VELLUM_ENVIRONMENT;
+    } else {
+      process.env.VELLUM_ENVIRONMENT = originalEnvironment;
+    }
   });
 
   test("POSTs a cli device-bound pair request and prints a decodable bundle", async () => {
@@ -967,6 +976,27 @@ describe("pair command", () => {
     ).toBe(
       "vellum-assistant-dev://connect?url=https%3A%2F%2Fhost.example.ts.net%2Fassistant-123&code=a%2Bb%2Fc%3D",
     );
+    // A label rides along as an encoded `name` param; an empty one is omitted.
+    expect(
+      buildAppConnectUrl(
+        "vellum-assistant",
+        "https://pair.example.ts.net",
+        "device-code",
+        "My Homelab",
+      ),
+    ).toBe(
+      "vellum-assistant://connect?url=https%3A%2F%2Fpair.example.ts.net&code=device-code&name=My+Homelab",
+    );
+    expect(
+      buildAppConnectUrl(
+        "vellum-assistant",
+        "https://pair.example.ts.net",
+        "device-code",
+        "",
+      ),
+    ).toBe(
+      "vellum-assistant://connect?url=https%3A%2F%2Fpair.example.ts.net&code=device-code",
+    );
   });
 
   test("--qr --app emits an app connect URL alongside the browser URL", async () => {
@@ -1032,14 +1062,84 @@ describe("pair command", () => {
     }
 
     const out = JSON.parse(logs.join("\n"));
+    // Without --label the connect link names the assistant after its lockfile
+    // display name (the id here, since the entry has no name).
     expect(out.appUrl).toBe(
-      "vellum-assistant-dev://connect?url=https%3A%2F%2Fpair.example.ts.net&code=device-code",
+      "vellum-assistant-dev://connect?url=https%3A%2F%2Fpair.example.ts.net&code=device-code&name=pair-test",
     );
     // The browser URL stays available as the no-app fallback.
     expect(out.pairUrl).toBe(
       "https://pair.example.ts.net/assistant/pair#device_code=device-code",
     );
     expect(out.deviceCode).toBe("device-code");
+  });
+
+  test("--qr --app --label overrides the assistant name in the connect link", async () => {
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string) => {
+      if (url === `${LOCAL_URL}/v1/assistants/pair-test/feature-flags`) {
+        return new Response(
+          JSON.stringify({
+            flags: [{ key: "web-remote-ingress", enabled: true }],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      if (url === `${LOCAL_URL}/v1/remote-web/pairing-challenge`) {
+        return new Response(
+          JSON.stringify({
+            deviceCode: "device-code",
+            userCode: "ABCD-EFGH",
+            verificationUri: "https://pair.example.ts.net/assistant/pair",
+            expiresAt: "2026-06-04T00:10:00.000Z",
+            expiresInSeconds: 600,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      if (url === `${LOCAL_URL}/v1/remote-web/pairing-verification`) {
+        return new Response(
+          JSON.stringify({
+            status: "approved",
+            verificationUri: "https://pair.example.ts.net/assistant/pair",
+            expiresAt: "2026-06-04T00:10:00.000Z",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const logs: string[] = [];
+    const logSpy = spyOn(console, "log").mockImplementation(
+      (...a: unknown[]) => {
+        logs.push(a.join(" "));
+      },
+    );
+
+    process.argv = [
+      "bun",
+      "vellum",
+      "pair",
+      "--qr",
+      "--app",
+      "--label",
+      "Homelab",
+      "--url",
+      "https://pair.example.ts.net",
+      "--json",
+    ];
+    try {
+      await pair();
+    } finally {
+      logSpy.mockRestore();
+      globalThis.fetch = origFetch;
+    }
+
+    const out = JSON.parse(logs.join("\n"));
+    expect(out.appUrl).toBe(
+      "vellum-assistant://connect?url=https%3A%2F%2Fpair.example.ts.net&code=device-code&name=Homelab",
+    );
   });
 
   test("--app without --qr is refused", async () => {

--- a/cli/src/commands/pair.ts
+++ b/cli/src/commands/pair.ts
@@ -89,7 +89,8 @@ ARGUMENTS:
 OPTIONS:
     --url <url>      Reachable gateway URL to advertise in the bundle
                     (default: the assistant's runtime URL, not loopback)
-    --label <name>   Human label for this pairing (echoed in the output)
+    --label <name>   Human label for this pairing (echoed in the output; with
+                    --qr --app it also names the assistant in the connect link)
     --web            Create a browser pairing URL for remote web access
     --web-approve <code>
                     Approve a browser pairing code shown by /assistant/pair
@@ -100,8 +101,10 @@ OPTIONS:
                     loopback or non-https URLs.
     --app            With --qr: encode the QR as a vellum-assistant://connect
                     link that opens the Vellum iOS app directly (the plain
-                    https pairing URL is printed as a fallback). Requires an
-                    app build with the connect handler installed on the phone.
+                    https pairing URL is printed as a fallback). The link
+                    carries the assistant's name (--label overrides it) so the
+                    app can label the pairing. Requires an app build with the
+                    connect handler installed on the phone.
     --app-scheme <scheme>
                     URL scheme for --app links (default: vellum-assistant;
                     dev/staging app builds use vellum-assistant-dev /
@@ -138,15 +141,20 @@ const DEFAULT_APP_CONNECT_SCHEME = "vellum-assistant";
 
 /**
  * Compose the custom-scheme link the iOS app's connect handler accepts:
- * `<scheme>://connect?url=<base>&code=<device code>`. The app persists the
- * base as its self-hosted server and opens the pair page with the code.
+ * `<scheme>://connect?url=<base>&code=<device code>[&name=<label>]`. The app
+ * persists the base (and the label, when present) as its self-hosted server
+ * and opens the pair page with the code.
  */
 export function buildAppConnectUrl(
   scheme: string,
   baseUrl: string,
   deviceCode: string,
+  name?: string,
 ): string {
   const params = new URLSearchParams({ url: baseUrl, code: deviceCode });
+  if (name) {
+    params.set("name", name);
+  }
   return `${scheme}://connect?${params.toString()}`;
 }
 
@@ -502,6 +510,7 @@ export async function pair(): Promise<void> {
           appSchemeOverride ?? DEFAULT_APP_CONNECT_SCHEME,
           qrBaseUrl,
           challenge.deviceCode,
+          label || assistantDisplayName(entry),
         )
       : null;
 

--- a/cli/src/lib/nginx-ingress.ts
+++ b/cli/src/lib/nginx-ingress.ts
@@ -4,6 +4,7 @@ import {
   spawnSync,
   type ChildProcess,
 } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
   closeSync,
   existsSync,
@@ -15,6 +16,8 @@ import {
 } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
+
+import { cloudAssistantHubUrl } from "@vellumai/environments";
 
 import {
   getAssistantDisplayName,
@@ -162,18 +165,12 @@ export interface RemoteWebIngressOptions {
 }
 
 /**
- * Cloud web SPA base URL for a build environment. Same mapping as
- * `clients/web/capacitor.config.ts`: unknown and non-cloud environments fall
- * back to the dev SPA.
+ * Cloud web SPA base URL for a build environment. The mapping lives in
+ * `@vellumai/environments` (`cloudAssistantHubUrl`) and is shared with the
+ * Capacitor shell's `server.url`, so the two consumers cannot drift.
  */
 export function cloudWebHubUrl(env: string | undefined): string {
-  if (env === "production") {
-    return "https://www.vellum.ai/assistant";
-  }
-  if (env === "staging") {
-    return "https://staging-assistant.vellum.ai/assistant";
-  }
-  return "https://dev-assistant.vellum.ai/assistant";
+  return cloudAssistantHubUrl(env);
 }
 
 function remoteWebIngressConfig(
@@ -188,6 +185,16 @@ function remoteWebIngressConfig(
     ...(opts.hubUrl ? { hubUrl: opts.hubUrl } : {}),
     ...opts.config,
   };
+}
+
+/**
+ * Stable fingerprint of the SPA config injected into the served index and
+ * `/assistant/__config`. Recorded alongside the edge state so a reuse
+ * decision can tell whether a running edge already serves the requested
+ * config (see `IngressState.remoteWebConfigHash`).
+ */
+function remoteWebConfigFingerprint(config: Record<string, unknown>): string {
+  return createHash("sha256").update(JSON.stringify(config)).digest("hex");
 }
 
 function safeScriptJson(value: unknown): string {
@@ -453,6 +460,13 @@ export interface IngressState {
    * port and the state is stamped for future comparisons.
    */
   gatewayPort?: number;
+  /**
+   * Fingerprint of the SPA config injected into the served index. Undefined
+   * for webhooks-only edges and for SPA records that predate the field; an
+   * SPA edge without a recorded fingerprint is treated as drifted and
+   * restarted so the served index provably carries the requested config.
+   */
+  remoteWebConfigHash?: string;
 }
 
 export function readIngressState(workspaceDir: string): IngressState | null {
@@ -462,10 +476,12 @@ export function readIngressState(workspaceDir: string): IngressState | null {
   const listenPort = nginx?.listenPort;
   if (typeof listenPort !== "number") return null;
   const gatewayPort = nginx?.gatewayPort;
+  const remoteWebConfigHash = nginx?.remoteWebConfigHash;
   return {
     listenPort,
     includeWebApp: nginx?.includeWebApp !== false,
     ...(typeof gatewayPort === "number" ? { gatewayPort } : {}),
+    ...(typeof remoteWebConfigHash === "string" ? { remoteWebConfigHash } : {}),
   };
 }
 
@@ -477,6 +493,9 @@ function saveIngressState(workspaceDir: string, state: IngressState): void {
     includeWebApp: state.includeWebApp,
     ...(state.gatewayPort !== undefined
       ? { gatewayPort: state.gatewayPort }
+      : {}),
+    ...(state.remoteWebConfigHash !== undefined
+      ? { remoteWebConfigHash: state.remoteWebConfigHash }
       : {}),
   };
   config.ingress = ingress;
@@ -549,6 +568,13 @@ export function startIngressNginx(opts: {
     listenPort: opts.listenPort,
     includeWebApp: opts.remoteWebIngress !== undefined,
     gatewayPort: opts.gatewayPort,
+    ...(remoteWebIngress
+      ? {
+          remoteWebConfigHash: remoteWebConfigFingerprint(
+            remoteWebIngress.config,
+          ),
+        }
+      : {}),
   });
   return child;
 }
@@ -649,6 +675,12 @@ export type StartRemoteWebIngressResult =
       includeWebApp: boolean;
       /** Recorded gateway upstream; undefined when the record predates the field. */
       gatewayPort?: number;
+      /**
+       * Set when the surviving edge matches the requested mode and gateway
+       * port but serves a different injected SPA config than requested (a
+       * restart was attempted and failed), so the served index is stale.
+       */
+      staleRemoteWebConfig?: true;
     }
   | { status: "nginx-missing" }
   | { status: "web-dist-missing" }
@@ -662,10 +694,12 @@ export type StartRemoteWebIngressResult =
  * spawned but unreachable or unowned nginx is rolled back so a failed attempt
  * leaves no half-up edge behind.
  *
- * An edge already running in the requested mode against the requested gateway
- * port short-circuits as `already-running`; one running in the other mode
- * (SPA vs webhooks-only) or against a different gateway port is stopped and
- * restarted with the requested config.
+ * An edge already running in the requested mode, against the requested
+ * gateway port, and serving the requested injected SPA config short-circuits
+ * as `already-running`; one running in the other mode (SPA vs webhooks-only),
+ * against a different gateway port, or serving a drifted SPA config (e.g. a
+ * renamed assistant or an updated hub URL) is stopped and restarted with the
+ * requested config.
  *
  * Pure mechanism: it performs no console output and never exits the process, so
  * every edge caller (`vellum tunnel`, `nginx-ingress up`, the wake restore
@@ -712,6 +746,20 @@ export async function startRemoteWebIngress(opts: {
   const running = isIngressRunning(opts.workspaceDir);
   const recorded = running ? readIngressState(opts.workspaceDir) : null;
   const recordedMode = recorded?.includeWebApp ?? true;
+  // The SPA config the served index must carry, computed up front so the
+  // reuse decision and the actual spawn share one value and cannot drift.
+  const spaOptions = includeWebApp
+    ? {
+        hubUrl: cloudWebHubUrl(getCurrentEnvironment().name),
+        ...(opts.assistantName ? { assistantName: opts.assistantName } : {}),
+      }
+    : undefined;
+  const requestedConfigHash = spaOptions
+    ? remoteWebConfigFingerprint(remoteWebIngressConfig(spaOptions))
+    : undefined;
+  // Both sides are undefined in webhooks-only mode; an SPA record without a
+  // fingerprint predates the field and counts as drifted (see IngressState).
+  const configMatches = recorded?.remoteWebConfigHash === requestedConfigHash;
   const alreadyRunning = (): StartRemoteWebIngressResult => ({
     status: "already-running",
     listenPort: recorded?.listenPort ?? listenPort,
@@ -719,12 +767,18 @@ export async function startRemoteWebIngress(opts: {
     ...(recorded?.gatewayPort !== undefined
       ? { gatewayPort: recorded.gatewayPort }
       : {}),
+    ...(recordedMode === includeWebApp &&
+    recorded?.gatewayPort === opts.gatewayPort &&
+    !configMatches
+      ? { staleRemoteWebConfig: true as const }
+      : {}),
   });
   // An unknown recorded gateway port is unverified (see IngressState).
   if (
     running &&
     recordedMode === includeWebApp &&
-    recorded?.gatewayPort === opts.gatewayPort
+    recorded?.gatewayPort === opts.gatewayPort &&
+    configMatches
   ) {
     return alreadyRunning();
   }
@@ -737,10 +791,10 @@ export async function startRemoteWebIngress(opts: {
     }
   }
 
-  // The running edge serves the other mode or targets a different gateway
-  // port; restart it with the requested config. A false stop can mean the old
-  // edge exited on its own after the check above, so recheck liveness and only
-  // bail when it is still serving.
+  // The running edge serves the other mode, targets a different gateway
+  // port, or injects a stale SPA config; restart it with the requested
+  // config. A false stop can mean the old edge exited on its own after the
+  // check above, so recheck liveness and only bail when it is still serving.
   if (
     running &&
     !(await stopIngressNginx(opts.workspaceDir)) &&
@@ -755,13 +809,7 @@ export async function startRemoteWebIngress(opts: {
     workspaceDir: opts.workspaceDir,
     gatewayPort: opts.gatewayPort,
     listenPort,
-    remoteWebIngress: webDistDir
-      ? {
-          webDistDir,
-          hubUrl: cloudWebHubUrl(getCurrentEnvironment().name),
-          ...(opts.assistantName ? { assistantName: opts.assistantName } : {}),
-        }
-      : undefined,
+    remoteWebIngress: webDistDir ? { webDistDir, ...spaOptions } : undefined,
   });
   let exited = false;
   child.once("exit", () => {
@@ -899,8 +947,8 @@ export interface TunnelEdge {
  * proxy, disabled: webhooks-only proxy); an entry without an assistant id
  * cannot have the flag verified and gets the webhooks-only edge. The resolved
  * mode is always delegated to `startRemoteWebIngress`, which reuses a running
- * edge that already serves that mode against the requested gateway port and
- * restarts one that drifted in either respect, so the returned port always
+ * edge that already serves that mode, gateway port, and injected SPA config
+ * and restarts one that drifted in any respect, so the returned port always
  * fronts the flag-resolved config. `started` is false when a matching edge was
  * reused; a drifted edge that survives the restart attempt throws rather than
  * reporting the wrong config. Failures throw with actionable install or
@@ -966,6 +1014,13 @@ export async function ensureTunnelEdge(opts: {
         throw new Error(
           `The nginx edge is ${upstream} ` +
             `and could not be restarted against port ${opts.gatewayPort}. ` +
+            "Run `vellum nginx-ingress down` and retry.",
+        );
+      }
+      if (result.staleRemoteWebConfig) {
+        throw new Error(
+          "The nginx edge is still serving an outdated remote web config " +
+            "and could not be restarted with the updated one. " +
             "Run `vellum nginx-ingress down` and retry.",
         );
       }

--- a/cli/src/lib/nginx-ingress.ts
+++ b/cli/src/lib/nginx-ingress.ts
@@ -17,6 +17,11 @@ import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 
 import {
+  getAssistantDisplayName,
+  lookupAssistantByIdentifier,
+} from "./assistant-config.js";
+import { getCurrentEnvironment } from "./environments/resolve.js";
+import {
   isAssistantFeatureFlagEnabled,
   WEB_REMOTE_INGRESS_FLAG,
 } from "./feature-flags.js";
@@ -148,17 +153,40 @@ export interface RemoteWebIngressOptions {
   webDistDir: string;
   indexHtmlPath?: string;
   config?: Record<string, unknown>;
+  /** Serving assistant's display name, stamped into the served config so
+   *  remote clients can label this origin. Absent in older served configs. */
+  assistantName?: string;
+  /** Cloud web SPA base the remote client can hand this origin to (see
+   *  `cloudWebHubUrl`). Absent in older served configs. */
+  hubUrl?: string;
+}
+
+/**
+ * Cloud web SPA base URL for a build environment. Same mapping as
+ * `clients/web/capacitor.config.ts`: unknown and non-cloud environments fall
+ * back to the dev SPA.
+ */
+export function cloudWebHubUrl(env: string | undefined): string {
+  if (env === "production") {
+    return "https://www.vellum.ai/assistant";
+  }
+  if (env === "staging") {
+    return "https://staging-assistant.vellum.ai/assistant";
+  }
+  return "https://dev-assistant.vellum.ai/assistant";
 }
 
 function remoteWebIngressConfig(
-  config: Record<string, unknown> | undefined,
+  opts: Pick<RemoteWebIngressOptions, "config" | "assistantName" | "hubUrl">,
 ): Record<string, unknown> {
   return {
     mode: "remote-gateway",
     apiBaseUrl: "/v1",
     platformDisabled: true,
     disablePlatform: true,
-    ...config,
+    ...(opts.assistantName ? { assistantName: opts.assistantName } : {}),
+    ...(opts.hubUrl ? { hubUrl: opts.hubUrl } : {}),
+    ...opts.config,
   };
 }
 
@@ -194,7 +222,7 @@ export function buildIngressNginxConfig(opts: {
         gatewayPort: opts.gatewayPort,
         webDistDir: remoteWebIngress.webDistDir,
         indexHtmlPath: remoteWebIngress.indexHtmlPath,
-        config: remoteWebIngressConfig(remoteWebIngress.config),
+        config: remoteWebIngressConfig(remoteWebIngress),
       })
     : `${DENYLIST_LOCATIONS}
 
@@ -486,7 +514,7 @@ export function startIngressNginx(opts: {
   const remoteWebIngress = opts.remoteWebIngress
     ? {
         ...opts.remoteWebIngress,
-        config: remoteWebIngressConfig(opts.remoteWebIngress.config),
+        config: remoteWebIngressConfig(opts.remoteWebIngress),
         indexHtmlPath: join(paths.dir, "assistant-index.html"),
       }
     : undefined;
@@ -655,6 +683,12 @@ export async function startRemoteWebIngress(opts: {
    */
   includeWebApp?: boolean;
   /**
+   * Serving assistant's display name, stamped into the served remote-web
+   * config (`__VELLUM_CONFIG__.assistantName`) so remote clients can label
+   * this origin. Omitted when unknown; consumers tolerate its absence.
+   */
+  assistantName?: string;
+  /**
    * Invoked once, after every preflight check passes and immediately before
    * nginx is spawned, so callers can emit their own "starting" progress line
    * with the resolved version/dist/port (webDistDir is null in webhooks-only
@@ -721,7 +755,13 @@ export async function startRemoteWebIngress(opts: {
     workspaceDir: opts.workspaceDir,
     gatewayPort: opts.gatewayPort,
     listenPort,
-    remoteWebIngress: webDistDir ? { webDistDir } : undefined,
+    remoteWebIngress: webDistDir
+      ? {
+          webDistDir,
+          hubUrl: cloudWebHubUrl(getCurrentEnvironment().name),
+          ...(opts.assistantName ? { assistantName: opts.assistantName } : {}),
+        }
+      : undefined,
   });
   let exited = false;
   child.once("exit", () => {
@@ -826,6 +866,17 @@ async function resolveEdgeIncludesWebApp(
   );
 }
 
+/**
+ * Display name recorded for the assistant in the CLI lockfile; undefined when
+ * no entry matches, so the served config omits the label rather than guessing.
+ */
+function lockfileAssistantName(assistantId: string): string | undefined {
+  const result = lookupAssistantByIdentifier(assistantId);
+  return result.status === "found"
+    ? getAssistantDisplayName(result.entry)
+    : undefined;
+}
+
 /** User-facing label for the edge mode, shared by every edge status line. */
 export function formatEdgeMode(includesWebApp: boolean): string {
   return includesWebApp ? "remote web + webhooks" : "webhooks only";
@@ -876,10 +927,16 @@ export async function ensureTunnelEdge(opts: {
       )
     : false;
 
+  const assistantName =
+    includeWebApp && opts.assistantId
+      ? lockfileAssistantName(opts.assistantId)
+      : undefined;
+
   const result = await startRemoteWebIngress({
     workspaceDir: opts.workspaceDir,
     gatewayPort: opts.gatewayPort,
     includeWebApp,
+    ...(assistantName ? { assistantName } : {}),
     ...(opts.onStarting ? { onStarting: opts.onStarting } : {}),
   });
 

--- a/clients/web/capacitor.config.ts
+++ b/clients/web/capacitor.config.ts
@@ -1,22 +1,22 @@
 import type { CapacitorConfig } from "@capacitor/cli";
 import { KeyboardResize, KeyboardStyle } from "@capacitor/keyboard";
+// The `/seeds` subpath (not the package index) is deliberate: Capacitor's
+// node-based TS config loader transpiles one file at a time and cannot
+// resolve the index's `.js`-suffixed runtime re-exports, while the seeds
+// module is self-contained (type-only imports) and loads cleanly.
+import { cloudAssistantHubUrl } from "@vellumai/environments/seeds";
 
 // `server.url` is baked into native Capacitor config by `cap sync`, so
 // whatever URL resolves here at sync time is what the archived mobile build
 // ships with. Defaults to dev; set `VELLUM_ENVIRONMENT=production` before
 // syncing a production mobile build.
 //
-// The `/assistant` suffix is deliberate — booting on the bare host lands
-// on the marketing page, whose CTA redirects to `www.vellum.ai/assistant`
-// and bounces non-prod shells off their own host.
+// The environment-to-hub mapping (including the deliberate `/assistant`
+// suffix) is shared with the CLI's remote-web edge via
+// `@vellumai/environments`; see `cloudAssistantHubUrl` for the rationale.
 const env = process.env.VELLUM_ENVIRONMENT ?? "dev";
 
-const ENV_SERVER_URL =
-  env === "production"
-    ? "https://www.vellum.ai/assistant"
-    : env === "staging"
-      ? "https://staging-assistant.vellum.ai/assistant"
-      : "https://dev-assistant.vellum.ai/assistant";
+const ENV_SERVER_URL = cloudAssistantHubUrl(env);
 
 // `VELLUM_SERVER_URL` points the shell at a self-hosted assistant's own HTTPS
 // origin, taking precedence over the environment-derived Vellum Cloud URL. It

--- a/clients/web/package.json
+++ b/clients/web/package.json
@@ -70,6 +70,7 @@
     "@tiptap/starter-kit": "3.23.5",
     "@vellumai/assistant-api": "workspace:*",
     "@vellumai/design-library": "workspace:*",
+    "@vellumai/environments": "workspace:*",
     "@vellumai/ipc-contract": "workspace:*",
     "@vellumai/local-mode": "workspace:*",
     "@vellumai/service-contracts": "workspace:*",

--- a/clients/web/src/domains/remote-web/pairing-page.test.tsx
+++ b/clients/web/src/domains/remote-web/pairing-page.test.tsx
@@ -11,11 +11,13 @@ import { MemoryRouter } from "react-router";
 import type { RemoteWebPairingTokenResult } from "@/lib/auth/remote-gateway-session";
 
 let remoteGatewayMode = false;
+let injectedAssistantName: string | undefined;
 let nativePlatform = false;
 let nativePlatformName: "ios" | "android" = "ios";
 
 mock.module("@/lib/local-mode", () => ({
   isRemoteGatewayMode: () => remoteGatewayMode,
+  getRemoteGatewayAssistantName: () => injectedAssistantName,
 }));
 
 mock.module("@/runtime/native-auth", () => ({
@@ -125,6 +127,7 @@ const { RemoteWebPairingPage } =
 afterEach(() => {
   cleanup();
   remoteGatewayMode = false;
+  injectedAssistantName = undefined;
   nativePlatform = false;
   nativePlatformName = "ios";
   setUserAgent(ORIGINAL_USER_AGENT);
@@ -354,6 +357,8 @@ describe("RemoteWebPairingPage", () => {
     const query = new URLSearchParams(href.slice(href.indexOf("?") + 1));
     expect(query.get("url")).toBe(window.location.origin);
     expect(query.get("code")).toBe("device-1");
+    // The served config carries no assistant name, so the link omits it.
+    expect(query.has("name")).toBe(false);
 
     // The single-use code stays unspent while the choice is pending.
     expect(exchangeRemoteWebPairingTokenMock).not.toHaveBeenCalled();
@@ -391,6 +396,48 @@ describe("RemoteWebPairingPage", () => {
     );
     expect(androidIntentFallback(href)).toBe(window.location.href);
     expect(exchangeRemoteWebPairingTokenMock).not.toHaveBeenCalled();
+  });
+
+  test("the app handoff url carries the assistant name from the served config", async () => {
+    remoteGatewayMode = true;
+    injectedAssistantName = "My Homelab";
+    setUserAgent(IPHONE_USER_AGENT);
+
+    render(
+      <MemoryRouter
+        initialEntries={["/assistant/pair?deviceCode=device-1&userCode=ABCD"]}
+      >
+        <RemoteWebPairingPage />
+      </MemoryRouter>,
+    );
+
+    const link = await screen.findByRole("link", {
+      name: "Open in the Vellum app",
+    });
+    const href = link.getAttribute("href") ?? "";
+    const query = new URLSearchParams(href.slice(href.indexOf("?") + 1));
+    expect(query.get("name")).toBe("My Homelab");
+    expect(query.get("code")).toBe("device-1");
+  });
+
+  test("the Android app handoff url carries the assistant name too", async () => {
+    remoteGatewayMode = true;
+    injectedAssistantName = "My Homelab";
+    setUserAgent(ANDROID_USER_AGENT);
+
+    render(
+      <MemoryRouter
+        initialEntries={["/assistant/pair?deviceCode=device-1&userCode=ABCD"]}
+      >
+        <RemoteWebPairingPage />
+      </MemoryRouter>,
+    );
+
+    const link = await screen.findByRole("link", {
+      name: "Open in the Vellum app",
+    });
+    const href = link.getAttribute("href") ?? "";
+    expect(androidIntentQuery(href).get("name")).toBe("My Homelab");
   });
 
   test("the app handoff url keeps a served path prefix", async () => {

--- a/clients/web/src/domains/remote-web/pairing-page.tsx
+++ b/clients/web/src/domains/remote-web/pairing-page.tsx
@@ -18,7 +18,10 @@ import {
   remoteGatewayPublicBaseUrl,
   RemoteWebPairingError,
 } from "@/lib/auth/remote-gateway-session";
-import { isRemoteGatewayMode } from "@/lib/local-mode";
+import {
+  getRemoteGatewayAssistantName,
+  isRemoteGatewayMode,
+} from "@/lib/local-mode";
 import { isNativePlatform } from "@/runtime/native-auth";
 import { isAndroidBrowser, isIOSBrowser } from "@/runtime/platform-detection";
 import { sanitizeReturnTo } from "@/utils/return-to";
@@ -148,7 +151,8 @@ type AppHandoffPlatform = "ios" | "android";
  * link the mobile app consumes to persist this server and finish pairing inside
  * the app. `url` is the page's own public base (origin + served path prefix)
  * so the app reconnects to the same self-hosted assistant this browser is
- * already on.
+ * already on. When the served config carries the assistant's display name, a
+ * `name` param rides along so the app can label the server.
  */
 function buildAppHandoffUrl(
   deviceCode: string,
@@ -158,6 +162,10 @@ function buildAppHandoffUrl(
     url: remoteGatewayPublicBaseUrl(),
     code: deviceCode,
   });
+  const assistantName = getRemoteGatewayAssistantName();
+  if (assistantName) {
+    query.set("name", assistantName);
+  }
   if (platform === "ios") {
     return `${VELLUM_APP_SCHEME}://connect?${query.toString()}`;
   }

--- a/clients/web/src/env.d.ts
+++ b/clients/web/src/env.d.ts
@@ -79,6 +79,10 @@ interface Window {
     disablePlatform?: boolean;
     mode?: string;
     platformUrl?: string;
+    /** Serving assistant's display name (remote-web ingress configs only). */
+    assistantName?: string;
+    /** Cloud web SPA base for this build's environment (remote-web ingress configs only). */
+    hubUrl?: string;
   };
   /**
    * SDK-defined override for the session-replay recorder script URL. Set before

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -77,6 +77,8 @@ function getInjectedConfig(): {
   disablePlatform?: boolean;
   mode?: string;
   platformUrl?: string;
+  assistantName?: string;
+  hubUrl?: string;
 } {
   return (
     (
@@ -85,6 +87,8 @@ function getInjectedConfig(): {
           disablePlatform?: boolean;
           mode?: string;
           platformUrl?: string;
+          assistantName?: string;
+          hubUrl?: string;
         };
       }
     ).__VELLUM_CONFIG__ ?? {}
@@ -93,6 +97,16 @@ function getInjectedConfig(): {
 
 export function isRemoteGatewayMode(): boolean {
   return getInjectedConfig().mode === "remote-gateway";
+}
+
+/**
+ * Display name of the serving assistant, when the served remote-gateway config
+ * carries one. Older served configs omit it, so callers must tolerate
+ * `undefined`.
+ */
+export function getRemoteGatewayAssistantName(): string | undefined {
+  const name = getInjectedConfig().assistantName;
+  return typeof name === "string" && name.trim() !== "" ? name : undefined;
 }
 
 function getRemoteGatewayLockfile(): Lockfile {

--- a/packages/environments/package.json
+++ b/packages/environments/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./seeds": "./src/seeds.ts"
   },
   "scripts": {
     "typecheck": "bunx tsc --noEmit",

--- a/packages/environments/src/__tests__/cloud-assistant-hub-url.test.ts
+++ b/packages/environments/src/__tests__/cloud-assistant-hub-url.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Pins the environment-to-cloud-hub mapping in one place. Both consumers
+ * (the Capacitor shell's `server.url` and the CLI remote-web edge's
+ * `hubUrl`) read this helper, so this matrix is the single behavioral pin
+ * for the served URLs.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { cloudAssistantHubUrl, SEEDS } from "../index.js";
+
+describe("cloudAssistantHubUrl", () => {
+  test("cloud environments resolve to their own web origin", () => {
+    expect(cloudAssistantHubUrl("production")).toBe(
+      "https://www.vellum.ai/assistant",
+    );
+    expect(cloudAssistantHubUrl("staging")).toBe(
+      "https://staging-assistant.vellum.ai/assistant",
+    );
+  });
+
+  test("every other environment falls back to the dev SPA", () => {
+    for (const name of ["dev", "test", "local", "unknown-env", undefined]) {
+      expect(cloudAssistantHubUrl(name)).toBe(
+        "https://dev-assistant.vellum.ai/assistant",
+      );
+    }
+  });
+
+  test("cloud hub URLs derive from the seed web URLs", () => {
+    for (const name of ["production", "staging"]) {
+      expect(cloudAssistantHubUrl(name)).toBe(
+        `${SEEDS[name].webUrl}/assistant`,
+      );
+    }
+    expect(cloudAssistantHubUrl("local")).toBe(`${SEEDS.dev.webUrl}/assistant`);
+  });
+});

--- a/packages/environments/src/seeds.ts
+++ b/packages/environments/src/seeds.ts
@@ -25,6 +25,35 @@ function portBlock(base: number): PortMap {
 }
 
 /**
+ * Base URL of the cloud-hosted assistant SPA (the "hub") for a deployment
+ * environment. The Capacitor mobile shell bakes this into native builds as
+ * `server.url`, and the CLI's remote-web edge stamps it into the served
+ * config as `hubUrl`, so the environment-to-hub mapping lives here exactly
+ * once.
+ *
+ * Only the cloud deployments (production, staging) serve the hosted SPA at
+ * their own web origin; every other environment (dev, test, local, unknown)
+ * falls back to the dev SPA, whose host serves remote clients that cannot
+ * reach a local or per-developer web URL.
+ *
+ * The `/assistant` suffix is deliberate: booting on the bare host lands on
+ * the marketing page, whose CTA redirects to `www.vellum.ai/assistant` and
+ * bounces non-prod shells off their own host.
+ *
+ * NOTE: this module is loaded by Capacitor's single-file TS config loader
+ * (via the `@vellumai/environments/seeds` subpath), which cannot follow the
+ * package index's `.js`-suffixed runtime re-exports. Keep this file's
+ * imports type-only so it stays loadable on its own.
+ */
+export function cloudAssistantHubUrl(envName: string | undefined): string {
+  const seed =
+    envName === "production" || envName === "staging"
+      ? SEEDS[envName]
+      : SEEDS.dev;
+  return `${seed.webUrl}/assistant`;
+}
+
+/**
  * Built-in environment definitions and the source of truth for the
  * set of known environment names.
  *


### PR DESCRIPTION
## Summary
- remoteWebIngressConfig gains optional assistantName + hubUrl (cloudWebHubUrl env mapping helper); served __VELLUM_CONFIG__ carries them
- vellum pair --qr --app connect links carry name=<label> (from --label or the assistant name)
- Pair page app-handoff link forwards the config's assistantName; all consumers tolerate absent fields

Part of plan: origin-model-chooser.md (PR 4 of 7)