### PR TITLE
test(web): guard that binary SDK operations declare an explicit parseAs

### DIFF
--- a/clients/web/src/lib/api-parse-as-guard.test.ts
+++ b/clients/web/src/lib/api-parse-as-guard.test.ts
@@ -1,0 +1,144 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+/**
+ * Guard test: every generated SDK operation whose success response is binary
+ * must be called with an explicit `parseAs`.
+ *
+ * `api-interceptors.ts` sets `parseAs: "json"` on all four generated clients.
+ * That is deliberate (HeyAPI's default `parseAs: "auto"` infers the strategy
+ * from the response `Content-Type`, and falls back to `"stream"` when the
+ * header is absent, handing back `response.body` as data), but it removes the
+ * runtime inference that used to make binary downloads work on their own.
+ * Under `"json"`, a binary endpoint called without an override runs
+ * `JSON.parse` over its bytes.
+ *
+ * The route's content type is already declared once, in the assistant's
+ * `RouteDefinition.responseBody` (`{ contentType: "application/zip", ... }`),
+ * and flows through the OpenAPI spec into the generated response type. This
+ * test reads that generated type rather than a hand-maintained list, so a new
+ * binary endpoint is covered the moment codegen runs.
+ *
+ * If this fails: add `parseAs: "blob"` (or `"stream"`/`"arrayBuffer"`) to the
+ * reported call site. Do not add the operation to an allowlist.
+ */
+
+const GENERATED_ROOT = join(import.meta.dir, "..", "generated");
+const CLIENTS = ["daemon", "gateway", "api", "auth"] as const;
+
+/** Source roots scanned for call sites. */
+const SOURCE_ROOT = join(import.meta.dir, "..");
+
+/** Any of these satisfies the requirement for a non-JSON response. */
+const BINARY_PARSE_MODES = ["blob", "stream", "arrayBuffer", "text", "formData"];
+
+/**
+ * Operation names (generated SDK function names) whose declared success
+ * response is binary, derived from `export type XResponses = { … Blob | File }`.
+ */
+function binaryOperations(): string[] {
+  const ops: string[] = [];
+  for (const client of CLIENTS) {
+    let source: string;
+    try {
+      source = readFileSync(
+        join(GENERATED_ROOT, client, "types.gen.ts"),
+        "utf-8",
+      );
+    } catch {
+      continue; // client not generated in this checkout
+    }
+    // Each response type is a block: `export type FooResponses = { … };`
+    const blocks = source.matchAll(
+      /export type (\w+)Responses = \{([\s\S]*?)\n\};/g,
+    );
+    for (const [, name, body] of blocks) {
+      if (!name || !body) {
+        continue;
+      }
+      if (/\bBlob \| File\b/.test(body)) {
+        ops.push(`${name.charAt(0).toLowerCase()}${name.slice(1)}`);
+      }
+    }
+  }
+  return [...new Set(ops)];
+}
+
+/** Non-generated, non-test TypeScript sources under `src/`. */
+function sourceFiles(): string[] {
+  const glob = new Bun.Glob("**/*.{ts,tsx}");
+  const files: string[] = [];
+  for (const rel of glob.scanSync(SOURCE_ROOT)) {
+    if (rel.startsWith("generated/")) {
+      continue;
+    }
+    if (rel.includes(".test.") || rel.includes(".stories.")) {
+      continue;
+    }
+    files.push(rel);
+  }
+  return files;
+}
+
+/**
+ * The argument object of a call spans multiple lines. Take a bounded window
+ * from the call site and stop at the first line that closes it, so a later
+ * unrelated `parseAs` cannot mask a missing one.
+ */
+function callArguments(lines: string[], startIndex: number): string {
+  const window: string[] = [];
+  for (let i = startIndex; i < Math.min(startIndex + 25, lines.length); i++) {
+    const line = lines[i] ?? "";
+    window.push(line);
+    if (i > startIndex && /^\s*\}\)/.test(line)) {
+      break;
+    }
+  }
+  return window.join("\n");
+}
+
+describe("binary SDK operations declare parseAs", () => {
+  const operations = binaryOperations();
+
+  test("the generated types expose at least one binary operation", () => {
+    // Sensitivity check: if codegen output or its shape changes, the guard
+    // must fail loudly rather than silently pass over an empty set.
+    expect(operations.length).toBeGreaterThan(0);
+  });
+
+  test("every call site passes an explicit parseAs", () => {
+    const files = sourceFiles();
+    const violations: string[] = [];
+
+    for (const rel of files) {
+      const source = readFileSync(join(SOURCE_ROOT, rel), "utf-8");
+      const lines = source.split("\n");
+
+      for (const op of operations) {
+        if (!source.includes(`${op}(`)) {
+          continue;
+        }
+        for (let i = 0; i < lines.length; i++) {
+          if (!lines[i]?.includes(`${op}(`)) {
+            continue;
+          }
+          const args = callArguments(lines, i);
+          const match = args.match(/parseAs:\s*"(\w+)"/);
+          if (!match) {
+            violations.push(
+              `${rel}:${i + 1} calls ${op}() without parseAs (binary response)`,
+            );
+          } else if (!BINARY_PARSE_MODES.includes(match[1] ?? "")) {
+            violations.push(
+              `${rel}:${i + 1} calls ${op}() with parseAs: "${match[1]}" (binary response)`,
+            );
+          }
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## TL;DR

`parseAs: "json"` is forced on all four generated clients, which means any binary endpoint called without an explicit `parseAs` override runs `JSON.parse` over its bytes. Every call site today is correct, so **this fixes no live defect** — it adds a CI guard so the next binary endpoint can't be added without one.

## Why this exists

PR #34662 set `parseAs: "json"` on all four clients in `api-interceptors.ts`. That is correct hardening on its own merits: HeyAPI's default `parseAs: "auto"` infers the strategy from the response `Content-Type` and falls back to `"stream"` when the header is absent, handing `response.body` back as data.

But `auto` was also what made binary downloads work unaided — `getParseAs()` maps `application/zip`, `application/pdf`, `image/png`, and `application/octet-stream` all to `"blob"`. Forcing `json` deleted that inference and made all eleven existing `parseAs` overrides load-bearing. They're all present and correct; the safety net under them is gone.

## Why it reads the generated type

The content type is already declared **once**, in the assistant's `RouteDefinition.responseBody`:

```ts
responseBody: { contentType: "application/zip", schema: … }
```

That flows through `generate-openapi.ts` → `daemon.json` → codegen, which types the response `Blob | File`. The guard derives the operation list from that generated type rather than a hand-maintained allowlist, so **a new binary endpoint is covered the moment codegen runs** — no list to keep in sync.

## Before / after

| | Before | After |
|---|---|---|
| Adding a binary endpoint and forgetting `parseAs` | Ships. The download silently returns a `JSON.parse` failure or garbage at runtime. | Fails CI, naming the file and line. |
| Passing `parseAs: "json"` to a binary endpoint | Ships. | Fails CI, naming the wrong mode. |
| Existing 11 call sites | Correct | Unchanged — all pass |
| Runtime behavior | — | No change. This is a test-only addition. |

## Verification

- `bun test src/lib/api-parse-as-guard.test.ts` — 2 pass
- `bunx tsc --noEmit` — clean
- `bun run lint` — clean
- **Sensitivity-checked both branches** against a real call site (`utils/share-app.ts`), since a guard that cannot fail is worthless:
  - `parseAs` removed → `utils/share-app.ts:30 calls appsSharedByTokenGet() without parseAs (binary response)`
  - `parseAs: "json"` → `utils/share-app.ts:30 calls appsSharedByTokenGet() with parseAs: "json" (binary response)`
- A third test asserts the derived operation set is non-empty, so a change in codegen output shape fails loudly instead of silently passing over nothing.

## Audit result (no action needed)

All seven daemon binary endpoints and both platform ones were checked. Every live call site already overrides `parseAs`: `share-app.ts`, `chat-markdown-message.tsx`, `download-attachment.ts`, `document-viewer-page.tsx`, `conversation-asset-actions.tsx`, `share-feedback-modal.tsx`, `use-plugin-icon-src.ts`, `invoices-table.tsx`, and four `workspace_file_content_get` sites. `export_post` and `assistantsManagedSpeechTtsSynthesizeCreate` have no web caller.

## Deferred, and why

**Runtime enforcement of `responseBody` schemas is deliberately not in this PR.** 407 of 507 shared routes declare a zod `responseBody`, but nothing validates a handler's actual output against it — `http-adapter.ts` calls `Response.json(result)` unconditionally. Enforcing that is the larger version of this same idea.

It is not here because:
1. It would change a **documented, deliberate** contract. `routes/types.ts` states the field "is a codegen signal only and does not change runtime response handling."
2. The violation count is unknown and **cannot be surveyed cheaply**. Route tests call `route.handler()` directly off each module's `ROUTES` export, bypassing both adapters, so instrumenting either yields zero coverage (measured). Only 2 tests in the repo exercise `routeDefinitionsToHTTPRoutes` end to end.
3. Schemas authored for OpenAPI fidelity may not be exact enough to enforce, so turning it on blind risks breaking live responses or flooding logs.

Filed separately with the survey plan rather than shipped on a guess.

## Context

Surfaced while investigating [LUM-2371](https://linear.app/vellum/issue/LUM-2371) (`ApiError: Conversation detail payload was malformed`). That issue is unrelated to this change and stays closed — its full writeup is on the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40318" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->