### PR TITLE
feat(design-library): give PanelItem a pill shape (LUM-2443)

### DIFF
--- a/packages/design-library/src/components/panel-item/panel-item.stories.tsx
+++ b/packages/design-library/src/components/panel-item/panel-item.stories.tsx
@@ -1,0 +1,117 @@
+import { LayoutGrid, Plus, Settings } from "lucide-react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { PanelItem } from "./panel-item";
+
+/**
+ * The navigation row primitive: sidebars, settings nav, admin trees.
+ *
+ * `shape` is the only geometry switch. A pill is the same row with a capsule
+ * radius, content-hugging width, and a resting surface, so hover, active
+ * state, badges, and trailing actions behave identically either way.
+ *
+ * Rows are pinned to a narrow column here because that is the context they
+ * ship in, and because a full-width row and a content-hugging pill only read
+ * differently when there is a column edge to sit against.
+ */
+const meta: Meta<typeof PanelItem> = {
+  title: "Components/PanelItem",
+  component: PanelItem,
+  args: {
+    label: "Conversations",
+    shape: "row",
+  },
+  argTypes: {
+    shape: { control: "inline-radio", options: ["row", "pill"] },
+    activeVariant: { control: "inline-radio", options: ["default", "branded"] },
+    label: { control: "text" },
+    active: { control: "boolean" },
+  },
+  globals: {
+    viewport: { value: "sbDesktop", isRotated: false },
+  },
+  parameters: {
+    viewport: {
+      options: {
+        sbDesktop: {
+          name: "Desktop",
+          styles: { width: "1280px", height: "760px" },
+          type: "desktop",
+        },
+      },
+    },
+    /* PanelItem carries `max-md:` variants for mobile drawers (16px type at
+       44px tall instead of 14px at 32px), and those key off the *viewport*.
+       The Canvas iframe is far narrower than the browser window, so without
+       a pinned viewport these stories silently document the mobile metrics.
+       Read them in Canvas; a Docs page shares one iframe and cannot honor
+       this. */
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 248 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PanelItem>;
+
+/** Arg-driven: flip `shape` and `active` from the Controls panel. */
+export const Default: Story = {
+  args: { icon: LayoutGrid, onSelect: () => {} },
+};
+
+/** The two shapes against the same column, which is the only fair comparison. */
+export const Shapes: Story = {
+  render: () => (
+    <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+      <PanelItem shape="row" icon={LayoutGrid} label="Row" onSelect={() => {}} />
+      <PanelItem
+        shape="pill"
+        icon={LayoutGrid}
+        label="Pill"
+        onSelect={() => {}}
+      />
+    </div>
+  ),
+};
+
+/** A pill carries selected state exactly as a row does. */
+export const PillStates: Story = {
+  render: () => (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "flex-start",
+        gap: "0.5rem",
+      }}
+    >
+      <PanelItem shape="pill" icon={Plus} label="New Chat" onSelect={() => {}} />
+      <PanelItem
+        shape="pill"
+        icon={LayoutGrid}
+        label="Memory"
+        onSelect={() => {}}
+      />
+      <PanelItem
+        shape="pill"
+        icon={LayoutGrid}
+        label="Memory"
+        active
+        onSelect={() => {}}
+      />
+      <PanelItem
+        shape="pill"
+        icon={Settings}
+        label="Preferences"
+        badge="3"
+        onSelect={() => {}}
+      />
+    </div>
+  ),
+};

--- a/packages/design-library/src/components/panel-item/panel-item.stories.tsx
+++ b/packages/design-library/src/components/panel-item/panel-item.stories.tsx
@@ -65,8 +65,13 @@ export const Default: Story = {
   args: { icon: LayoutGrid, onSelect: () => {} },
 };
 
-/** The two shapes against the same column, which is the only fair comparison. */
+/**
+ * The two shapes in the same stretching column, which is the comparison that
+ * matters: the parent here does nothing to shrink its children, so a row fills
+ * the 248px column and a pill sizes to its label on its own.
+ */
 export const Shapes: Story = {
+  parameters: { controls: { disable: true } },
   render: () => (
     <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
       <PanelItem shape="row" icon={LayoutGrid} label="Row" onSelect={() => {}} />
@@ -80,14 +85,20 @@ export const Shapes: Story = {
   ),
 };
 
-/** A pill carries selected state exactly as a row does. */
+/**
+ * A pill carries selected state exactly as a row does.
+ *
+ * The column deliberately stretches its children rather than setting
+ * `align-items: flex-start`: a shrink-wrapping parent would size these pills
+ * from the outside and hide whether the shape does it itself.
+ */
 export const PillStates: Story = {
+  parameters: { controls: { disable: true } },
   render: () => (
     <div
       style={{
         display: "flex",
         flexDirection: "column",
-        alignItems: "flex-start",
         gap: "0.5rem",
       }}
     >

--- a/packages/design-library/src/components/panel-item/panel-item.stories.tsx
+++ b/packages/design-library/src/components/panel-item/panel-item.stories.tsx
@@ -116,11 +116,13 @@ export const PillStates: Story = {
         active
         onSelect={() => {}}
       />
+      {/* No badge: nothing in the sidebar puts a count on a pill, and a
+          fabricated one would document an affordance the product does not
+          have. `badge` is covered by the badge tests. */}
       <PanelItem
         shape="pill"
         icon={Settings}
         label="Preferences"
-        badge="3"
         onSelect={() => {}}
       />
     </div>

--- a/packages/design-library/src/components/panel-item/panel-item.test.tsx
+++ b/packages/design-library/src/components/panel-item/panel-item.test.tsx
@@ -94,3 +94,51 @@ describe("PanelItem badge", () => {
   });
 });
 
+describe("PanelItem shape", () => {
+  function renderShaped(
+    shape?: "row" | "pill",
+    className?: string,
+  ): string {
+    return renderToStaticMarkup(
+      createElement(PanelItem, {
+        label: "Row",
+        onSelect: () => {},
+        shape,
+        className,
+      }),
+    );
+  }
+
+  test("defaults to a full-width row", () => {
+    const html = renderShaped();
+    expect(html).toContain("rounded-[6px]");
+    expect(html).toContain("w-full");
+    expect(html).not.toContain("rounded-full");
+  });
+
+  /* The row's own radius and width must be *replaced*, not merely joined by
+     the pill's. Emitting both leaves the winner to stylesheet order, which is
+     how a capsule silently renders as a 6px row. */
+  test("pill replaces the row's radius and width rather than stacking on them", () => {
+    const html = renderShaped("pill");
+    expect(html).toContain("rounded-full");
+    expect(html).toContain("w-auto");
+    expect(html).not.toContain("rounded-[6px]");
+    expect(html).not.toContain("w-full");
+  });
+
+  test("pill keeps the row's interaction treatment", () => {
+    const html = renderShaped("pill");
+    expect(html).toContain("[@media(hover:hover)]:hover:bg-[var(--surface-hover)]");
+    expect(html).toContain("aria-[current=page]:bg-[var(--surface-active)]");
+  });
+
+  /* Consumers override the shape's surface (e.g. the assistant pill's tint),
+     so their className has to win over PILL_SHAPE_CLASSES. */
+  test("a consumer className overrides the pill surface", () => {
+    const html = renderShaped("pill", "bg-[var(--surface-active)]");
+    expect(html).toContain("bg-[var(--surface-active)]");
+    expect(html).not.toContain("bg-[var(--surface-lift)]");
+  });
+});
+

--- a/packages/design-library/src/components/panel-item/panel-item.test.tsx
+++ b/packages/design-library/src/components/panel-item/panel-item.test.tsx
@@ -122,9 +122,21 @@ describe("PanelItem shape", () => {
   test("pill replaces the row's radius and width rather than stacking on them", () => {
     const html = renderShaped("pill");
     expect(html).toContain("rounded-full");
-    expect(html).toContain("w-auto");
+    expect(html).toContain("w-fit");
     expect(html).not.toContain("rounded-[6px]");
     expect(html).not.toContain("w-full");
+  });
+
+  /* The root is a block-level flex container, so `width: auto` fills the
+     containing block and the pill silently renders at row width in any
+     ordinary layout. Only an intrinsic width shrink-wraps it. A story cannot
+     stand in for this: a parent that shrink-wraps its children (a flex column
+     with `align-items: flex-start`) supplies the behavior externally and hides
+     the defect. */
+  test("pill is intrinsically sized, not auto-width", () => {
+    const html = renderShaped("pill");
+    expect(html).toContain("w-fit");
+    expect(html).not.toContain("w-auto");
   });
 
   test("pill keeps the row's interaction treatment", () => {

--- a/packages/design-library/src/components/panel-item/panel-item.test.tsx
+++ b/packages/design-library/src/components/panel-item/panel-item.test.tsx
@@ -116,26 +116,23 @@ describe("PanelItem shape", () => {
     expect(html).not.toContain("rounded-full");
   });
 
-  /* The row's own radius and width must be *replaced*, not merely joined by
-     the pill's. Emitting both leaves the winner to stylesheet order, which is
-     how a capsule silently renders as a 6px row. */
-  test("pill replaces the row's radius and width rather than stacking on them", () => {
+  /* Two failure modes in one assertion.
+
+     The row's radius and width must be *replaced*, not merely joined by the
+     pill's: emitting both leaves the winner to stylesheet order, which is how
+     a capsule silently renders as a 6px row.
+
+     And the replacement must be an intrinsic width. The root is a block-level
+     flex container, so `width: auto` resolves to the containing block and the
+     pill stretches to row width in any ordinary layout. A story cannot stand
+     in for this check: a parent that shrink-wraps its children supplies the
+     behavior externally and hides the defect. */
+  test("pill replaces the row's radius and width with an intrinsic width", () => {
     const html = renderShaped("pill");
     expect(html).toContain("rounded-full");
     expect(html).toContain("w-fit");
     expect(html).not.toContain("rounded-[6px]");
     expect(html).not.toContain("w-full");
-  });
-
-  /* The root is a block-level flex container, so `width: auto` fills the
-     containing block and the pill silently renders at row width in any
-     ordinary layout. Only an intrinsic width shrink-wraps it. A story cannot
-     stand in for this: a parent that shrink-wraps its children (a flex column
-     with `align-items: flex-start`) supplies the behavior externally and hides
-     the defect. */
-  test("pill is intrinsically sized, not auto-width", () => {
-    const html = renderShaped("pill");
-    expect(html).toContain("w-fit");
     expect(html).not.toContain("w-auto");
   });
 

--- a/packages/design-library/src/components/panel-item/panel-item.tsx
+++ b/packages/design-library/src/components/panel-item/panel-item.tsx
@@ -185,9 +185,14 @@ const INTERACTIVE_CLASSES = [
  * and carries a resting surface, so it reads as a chip sitting in a column
  * rather than a row filling one. Radius, width, and surface only, so hover,
  * active, and every slot behave exactly as they do on a row.
+ *
+ * `w-fit` rather than `w-auto`: the root is a block-level flex container, and
+ * `width: auto` on one fills its containing block, so a pill would stretch to
+ * row width in every ordinary layout. `width: fit-content` shrink-wraps while
+ * leaving `display: flex` alone, which the row's internal layout depends on.
  */
 const PILL_SHAPE_CLASSES = [
-  "w-auto rounded-full",
+  "w-fit rounded-full",
   "bg-[var(--surface-lift)]",
   "pr-3",
 ].join(" ");

--- a/packages/design-library/src/components/panel-item/panel-item.tsx
+++ b/packages/design-library/src/components/panel-item/panel-item.tsx
@@ -49,6 +49,15 @@ import { MarqueeText } from "./marquee-text";
  * provides the interactive state layer (hover, active, focus-ring,
  * aria-current, `group` modifier).
  *
+ * ### `shape`
+ *
+ * - `"row"` (default): a full-width 6px-radius row, for lists and nav trees.
+ * - `"pill"`: a capsule that hugs its content and carries a resting
+ *   `--surface-lift` surface, for navigation chips that sit inline rather
+ *   than filling a column. Everything else (hover, active, badge, trailing
+ *   action, link/button semantics) is unchanged, which is the point: a pill
+ *   is a differently-shaped row, not a different component.
+ *
  * ### `activeVariant`
  *
  * Controls how the active (`aria-current="page"`) state is styled:
@@ -103,6 +112,13 @@ interface PanelItemProps {
    * layout space next to `badge`, which reads as broken.
    */
   trailingAction?: ReactNode;
+  /**
+   * Row geometry.
+   * - `"row"` fills its container at a 6px radius.
+   * - `"pill"` hugs its content as a capsule on `--surface-lift`.
+   * @default "row"
+   */
+  shape?: "row" | "pill";
   /** Selected state. Sets `aria-current="page"` automatically. */
   active?: boolean;
   /**
@@ -162,6 +178,18 @@ const INTERACTIVE_CLASSES = [
   "[@media(hover:hover)]:hover:bg-[var(--surface-hover)]",
   "keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)]",
   "cursor-pointer select-none",
+].join(" ");
+
+/**
+ * {@link PanelItemProps.shape} `"pill"`: a capsule that sizes to its content
+ * and carries a resting surface, so it reads as a chip sitting in a column
+ * rather than a row filling one. Radius, width, and surface only, so hover,
+ * active, and every slot behave exactly as they do on a row.
+ */
+const PILL_SHAPE_CLASSES = [
+  "w-auto rounded-full",
+  "bg-[var(--surface-lift)]",
+  "pr-3",
 ].join(" ");
 
 const ACTIVE_DEFAULT_CLASSES = [
@@ -248,6 +276,7 @@ function PanelItem({
   badge,
   badgeBare = false,
   trailingAction,
+  shape = "row",
   active = false,
   activeVariant = "default",
   disabled = false,
@@ -334,6 +363,7 @@ function PanelItem({
     ROW_BASE_CLASSES,
     isInteractive && INTERACTIVE_CLASSES,
     activeClasses,
+    shape === "pill" && PILL_SHAPE_CLASSES,
     className,
   );
 

--- a/packages/design-library/src/components/panel-item/panel-item.tsx
+++ b/packages/design-library/src/components/panel-item/panel-item.tsx
@@ -194,7 +194,6 @@ const INTERACTIVE_CLASSES = [
 const PILL_SHAPE_CLASSES = [
   "w-fit rounded-full",
   "bg-[var(--surface-lift)]",
-  "pr-3",
 ].join(" ");
 
 const ACTIVE_DEFAULT_CLASSES = [
@@ -224,8 +223,7 @@ const ICON_ACTIVE_BRANDED =
 
 const LABEL_CLASSES = "min-w-0 flex-1 truncate";
 
-const EXPAND_CHEVRON_CLASSES =
-  "shrink-0 text-[var(--content-tertiary)]";
+const EXPAND_CHEVRON_CLASSES = "shrink-0 text-[var(--content-tertiary)]";
 
 const RIGHT_CLUSTER_CLASSES = "flex items-center gap-2 shrink-0";
 
@@ -303,11 +301,19 @@ function PanelItem({
     activeVariant === "branded" ? ICON_ACTIVE_BRANDED : ICON_ACTIVE_DEFAULT;
 
   const leadingIcon =
-    leadingSlot !== undefined
-      ? leadingSlot
-      : Icon
-        ? <Icon size={14} aria-hidden className={cn("max-md:size-4", LEADING_ICON_BASE_CLASSES, iconActiveClass)} />
-        : null;
+    leadingSlot !== undefined ? (
+      leadingSlot
+    ) : Icon ? (
+      <Icon
+        size={14}
+        aria-hidden
+        className={cn(
+          "max-md:size-4",
+          LEADING_ICON_BASE_CLASSES,
+          iconActiveClass,
+        )}
+      />
+    ) : null;
 
   const labelNode = marqueeOnHover ? (
     <MarqueeText>{label}</MarqueeText>
@@ -316,11 +322,7 @@ function PanelItem({
   );
 
   const expandChevronNode = ExpandChevron ? (
-    <ExpandChevron
-      size={12}
-      aria-hidden
-      className={EXPAND_CHEVRON_CLASSES}
-    />
+    <ExpandChevron size={12} aria-hidden className={EXPAND_CHEVRON_CLASSES} />
   ) : null;
 
   const badgeNode =
@@ -362,7 +364,9 @@ function PanelItem({
   );
 
   const activeClasses =
-    activeVariant === "branded" ? ACTIVE_BRANDED_CLASSES : ACTIVE_DEFAULT_CLASSES;
+    activeVariant === "branded"
+      ? ACTIVE_BRANDED_CLASSES
+      : ACTIVE_DEFAULT_CLASSES;
   const isInteractive = asChild || !!href || !!onSelect;
   const rowClasses = cn(
     ROW_BASE_CLASSES,
@@ -500,4 +504,3 @@ export {
   ACTIVE_DEFAULT_CLASSES,
   ACTIVE_BRANDED_CLASSES,
 };
-


### PR DESCRIPTION
## TL;DR

`PanelItem` gains `shape?: "row" | "pill"`. Default is `"row"`, so nothing that exists today changes. Adds the component's first story file.

This is the first of several small PRs rebuilding the conversation sidebar (LUM-2443). It ships alone and is useful alone.

## Why

The new sidebar puts the assistant link, pinned apps, New Chat, and Preferences in capsules that hug their content rather than filling the rail. `PanelItem` already provides everything those need (icon, label, badge, trailing action, active/`aria-current`, link-or-button rendering); the only thing it lacked was the shape.

The alternative was a `rounded-full` override at each call site. That restyles the primitive from outside, and leaves the row's own `rounded-[6px]` and `w-full` in the class list for stylesheet order to resolve.

## What changes for the user

| | Before | After |
|---|---|---|
| Existing nav rows | Full-width, 6px radius | Unchanged (`shape` defaults to `"row"`) |
| Nav capsules | Not expressible; needed a className override per call site | `shape="pill"` |
| `PanelItem` docs | Tests only, no story | Story with a `shape` control |

## Why it is safe

- Purely additive. `shape` defaults to `"row"`, and every current call site omits it, so rendered output for existing consumers is byte-identical.
- A pill changes radius, width, and resting surface only. Hover, active, focus ring, badge, trailing action, and the anchor/button/`asChild` branches are untouched.
- Consumer `className` still merges last, so a call site can override the pill's surface (the assistant pill's avatar tint) without fighting the variant.

## Tests

Four new cases in `panel-item.test.tsx` (13 pass total). The load-bearing one asserts that the pill **replaces** the row's radius and width rather than stacking on them, since emitting both leaves the winner to stylesheet order and the capsule silently renders as a 6px row.

That test was sensitivity-checked: inverting the class order in `rowClasses` makes it fail with exactly that symptom, and restoring it makes it pass.

## Review notes

- `packages/design-library` has no ESLint config, so this was verified with `bunx tsc --noEmit` and `bun test` rather than lint.
- The story pins a desktop viewport. `PanelItem` carries `max-md:` variants, and the Storybook canvas iframe is ~374px, so without pinning the story silently documents the mobile metrics (16px/500 at 44px tall instead of 14px/400 at 32px).
- Verified in the design-library Storybook (port 6006) at 14px/400/32px, 109px content-hugging width, with active state and badge rendering.

Part of LUM-2443.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->