### PR TITLE
feat(web): carry the page surface across the top navigation bar

### DIFF
--- a/clients/web/src/domains/chat/chat-layout-header.test.tsx
+++ b/clients/web/src/domains/chat/chat-layout-header.test.tsx
@@ -11,6 +11,8 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 
+import { usePageSurfaceStore } from "@/stores/page-surface-store";
+
 let mockIsElectron = false;
 mock.module("@/runtime/is-electron", () => ({
   isElectron: () => mockIsElectron,
@@ -30,11 +32,18 @@ mock.module("@/stores/title-bar-store", () => ({
   },
 }));
 
+let mockIsNativeMobile = false;
+mock.module("@/runtime/platform-detection", () => ({
+  isNativeMobile: () => mockIsNativeMobile,
+}));
+
 // Imported after the mocks so the header picks up the mocked modules.
 const { ChatLayoutHeader } = await import("@/domains/chat/chat-layout-header");
 
 beforeEach(() => {
   mockIsElectron = false;
+  mockIsNativeMobile = false;
+  usePageSurfaceStore.getState().setSurface(null);
   toggleCommandPaletteSpy.mockClear();
 });
 
@@ -88,5 +97,40 @@ describe("ChatLayoutHeader mobile affordances", () => {
     expect(
       screen.getByRole("button", { name: "Search (Ctrl+K)" }),
     ).toBeTruthy();
+  });
+});
+
+describe("ChatLayoutHeader page surface", () => {
+  function headerElement() {
+    return document.querySelector<HTMLElement>(
+      '[data-slot="chat-layout-header"]',
+    );
+  }
+
+  test("takes the route's published surface on the native shells", () => {
+    mockIsNativeMobile = true;
+    usePageSurfaceStore.getState().setSurface("var(--surface-overlay)");
+
+    renderHeader();
+
+    // Continuous with the safe-area strips, which resolve the same way.
+    expect(headerElement()?.style.background).toBe("var(--surface-overlay)");
+  });
+
+  test("keeps the neutral chrome off the native shells", () => {
+    mockIsNativeMobile = false;
+    usePageSurfaceStore.getState().setSurface("var(--surface-overlay)");
+
+    renderHeader();
+
+    expect(headerElement()?.style.background).toBe("var(--surface-base)");
+  });
+
+  test("keeps the neutral chrome on a route that publishes nothing", () => {
+    mockIsNativeMobile = true;
+
+    renderHeader();
+
+    expect(headerElement()?.style.background).toBe("var(--surface-base)");
   });
 });

--- a/clients/web/src/domains/chat/chat-layout-header.tsx
+++ b/clients/web/src/domains/chat/chat-layout-header.tsx
@@ -10,7 +10,12 @@ import { useCallback, useEffect, type ReactNode } from "react";
 
 import { NATIVE_MOBILE_BARE_ICON_BUTTON } from "@/domains/chat/utils/native-mobile-button-constants";
 import { isElectron } from "@/runtime/is-electron";
+import { isNativeMobile } from "@/runtime/platform-detection";
 import { useCommandPaletteStore } from "@/stores/command-palette-store";
+import {
+  resolveShellBackground,
+  usePageSurfaceStore,
+} from "@/stores/page-surface-store";
 import { useTitleBarStore } from "@/stores/title-bar-store";
 
 // On macOS the native window controls (traffic lights) overlay the top-left of
@@ -109,6 +114,14 @@ export function ChatLayoutHeader({
     return () => setInlineTitleBarActive(false);
   }, [electron, setInlineTitleBarActive]);
 
+  // The header sits between the safe-area strips and the page content, both of
+  // which take the route's published surface on the native shells. Painting it
+  // from the same resolver is what makes the color continuous instead of a
+  // neutral band across the top. Off native mobile, and on any route that
+  // publishes nothing, this resolves to the usual neutral chrome.
+  const pageSurface = usePageSurfaceStore.use.surface();
+  const headerBackground = resolveShellBackground(pageSurface, isNativeMobile());
+
   return (
     <header
       data-slot="chat-layout-header"
@@ -118,7 +131,7 @@ export function ChatLayoutHeader({
           : ""
       }`}
       style={{
-        background: "var(--surface-base)",
+        background: headerBackground,
         minHeight: electron ? "44px" : "40px",
         paddingTop: electron ? 0 : undefined,
       }}


### PR DESCRIPTION
Follow-up to #40273, which merged while this was being written. Rebased onto
main, so this is a single commit against the merged base.

On the native shells a route publishes its canvas color and the app shell
paints it into the safe-area strips, so the status bar and the page content
match. The header between them painted `--surface-base` outright, which left a
neutral band across the top of every themed page: the two ends agree and the
bar separating them does not.

The header now resolves its background through `resolveShellBackground`, the
same function the shell uses for the strips. Passing both through one resolver
means they cannot disagree by construction, rather than by two call sites
happening to pick the same token.

## Scope

Unchanged off the native shells and on any route that publishes no surface
(the chat pages), where the resolver returns the neutral chrome it paints
today. Desktop web and Electron are untouched.

## Testing

Typecheck, lint, and `test:ci` clean in an isolated worktree. Three new cases
on the header: it takes a published surface on native mobile, keeps the
neutral chrome off native mobile, and keeps it on a route that publishes
nothing.

## Needs a look on device

The affected pages are the themed ones, and two are worth eyeballing before
this ships:

- **Personality.** Its canvas is the assistant's avatar color, which can be
  saturated (a strong orange on the assistant these screenshots came from).
  The header's icons are dark chrome and the bell sits on a white disc; both
  were drawn for a neutral bar. They may read fine, or the header may want the
  stage's own foreground tone. That is a design call best made against the real
  color.
- **Identity overview with a custom photo avatar.** That page publishes no
  surface by design (a flat color cannot continue a blurred photo), so its
  header stays neutral while its content does not. Confirm that reads as
  deliberate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
