### PR TITLE
feat(web): add the sidebar section card (LUM-2443)

### DIFF
--- a/clients/web/src/domains/chat/components/sidebar-section-card.stories.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-section-card.stories.tsx
@@ -1,0 +1,208 @@
+/**
+ * Visual reference for the sidebar's section card.
+ *
+ * Every sidebar section is this card: Pinned, each custom group, each
+ * channel, and the chat list. The card is only the surface; the header,
+ * collapse, indicator, and menus come from `CollapsibleNavSection.Section`,
+ * so these stories mount the real section machinery and the real
+ * {@link ConversationRow} rather than stand-in markup.
+ *
+ * Sections share one `CollapsibleNavSection.Root`, which is how the sidebar
+ * mounts them, so `defaultValue` decides which cards start open.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Folder } from "lucide-react";
+
+import { ContextMenu } from "@vellumai/design-library";
+
+import { CollapsibleNavSection } from "@/components/collapsible-nav-section";
+import { GroupIndicatorDot } from "@/domains/chat/components/collapsed-group-icon";
+import { ConversationListProvider } from "@/domains/chat/components/conversation-list-context";
+import { ConversationRow } from "@/domains/chat/components/conversation-row";
+import { SidebarSectionCard } from "@/domains/chat/components/sidebar-section-card";
+import type { Conversation } from "@/types/conversation-types";
+
+function conversation(
+  conversationId: string,
+  title: string,
+  overrides: Partial<Conversation> = {},
+): Conversation {
+  return { conversationId, title, ...overrides };
+}
+
+const PINNED: Conversation[] = [
+  conversation("p1", "Fernweh Coffee landing page", { isPinned: true }),
+  conversation("p2", "Weekend hike recommendations for the coast", {
+    isPinned: true,
+  }),
+];
+
+const CHATS: Conversation[] = [
+  conversation("c1", "Various topics"),
+  conversation("c2", "Lease renewal"),
+  conversation("c3", "Resume feedback"),
+  conversation("c4", "Weekly meal plan", {
+    hasUnseenLatestAssistantMessage: true,
+  }),
+  conversation("c5", "Home gym setup"),
+  conversation("c6", "Wedding toast draft"),
+  conversation("c7", "Budget spreadsheet help"),
+  conversation("c8", "Book recommendations"),
+];
+
+/**
+ * Rows read their callbacks and active/processing state from context, so
+ * every story provides one. Drag-reorder is off, which is what a
+ * non-reorderable section passes in the app.
+ */
+const LIST_CONTEXT = {
+  activeConversationId: "c1",
+  onSelect: () => {},
+  canReorder: false,
+  dragReorder: {
+    draggingId: null,
+    dropIndicator: null,
+    getItemProps: () => ({}),
+  },
+} as unknown as React.ComponentProps<
+  typeof ConversationListProvider
+>["value"];
+
+function rows(items: Conversation[]) {
+  return items.map((c) => (
+    <ConversationRow key={c.conversationId} conversation={c} />
+  ));
+}
+
+const SECTION_MENU = (
+  <>
+    <ContextMenu.Item>Mark all as read</ContextMenu.Item>
+    <ContextMenu.Item>Archive all</ContextMenu.Item>
+    <ContextMenu.Separator />
+    <ContextMenu.Label>Group by</ContextMenu.Label>
+    <ContextMenu.Item>None</ContextMenu.Item>
+    <ContextMenu.Item>Channel</ContextMenu.Item>
+  </>
+);
+
+const meta = {
+  title: "Chat/SidebarSectionCard",
+  component: SidebarSectionCard,
+  globals: {
+    viewport: { value: "sbDesktop", isRotated: false },
+  },
+  parameters: {
+    layout: "padded",
+    viewport: {
+      options: {
+        sbDesktop: {
+          name: "Desktop",
+          styles: { width: "1280px", height: "760px" },
+          type: "desktop",
+        },
+      },
+    },
+    /* Conversation rows and section headers carry `max-md:` variants for the
+       mobile drawer (16px type at 36px tall instead of 14px at 30px). Those
+       key off the *viewport*, so in a narrow Canvas iframe these stories
+       would render the drawer's metrics inside the desktop rail, a
+       combination the app never ships.
+
+       It does not reach the Docs canvas: every story on a docs page shares
+       one iframe. Read these in Canvas. Tracked in LUM-2921. */
+  },
+  decorators: [
+    (Story) => (
+      <ConversationListProvider value={LIST_CONTEXT}>
+        {/* The rail's real width, so title truncation reads truthfully. */}
+        <div style={{ width: 248 }}>
+          <Story />
+        </div>
+      </ConversationListProvider>
+    ),
+  ],
+} satisfies Meta<typeof SidebarSectionCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Pinned: Story = {
+  args: { value: "pinned", label: "Pinned" },
+  render: (args) => (
+    <CollapsibleNavSection.Root type="multiple" defaultValue={["pinned"]}>
+      <SidebarSectionCard {...args}>{rows(PINNED)}</SidebarSectionCard>
+    </CollapsibleNavSection.Root>
+  ),
+};
+
+/** A custom group, collapsed, carrying its unread dot in the header. */
+export const CollapsedGroup: Story = {
+  args: {
+    value: "car-chat",
+    label: "Car Chat",
+    icon: Folder,
+    collapsedIndicator: <GroupIndicatorDot state="unread" />,
+  },
+  render: (args) => (
+    <CollapsibleNavSection.Root type="multiple" defaultValue={[]}>
+      <SidebarSectionCard {...args} />
+    </CollapsibleNavSection.Root>
+  ),
+};
+
+/** Expanded, the header dot gives way to the row's own indicator. */
+export const Chats: Story = {
+  args: {
+    value: "chats",
+    label: "Chats",
+    collapsedIndicator: <GroupIndicatorDot state="unread" />,
+  },
+  render: (args) => (
+    <CollapsibleNavSection.Root type="multiple" defaultValue={["chats"]}>
+      <SidebarSectionCard {...args}>{rows(CHATS)}</SidebarSectionCard>
+    </CollapsibleNavSection.Root>
+  ),
+};
+
+/**
+ * Right-click anywhere on the header opens the section's own menu, so
+ * "Archive all" reaches this section's rows and no others.
+ */
+export const WithSectionMenu: Story = {
+  args: {
+    value: "chats",
+    label: "Chats",
+    contextMenuContent: SECTION_MENU,
+    touchMenuContent: () => SECTION_MENU,
+  },
+  render: (args) => (
+    <CollapsibleNavSection.Root type="multiple" defaultValue={["chats"]}>
+      <SidebarSectionCard {...args}>{rows(CHATS.slice(0, 3))}</SidebarSectionCard>
+    </CollapsibleNavSection.Root>
+  ),
+};
+
+/** The sidebar's stack: curated cards above, the chat list below. */
+export const Composed: Story = {
+  args: { value: "pinned", label: "Pinned" },
+  render: () => (
+    <CollapsibleNavSection.Root
+      type="multiple"
+      defaultValue={["pinned", "chats"]}
+    >
+      <SidebarSectionCard value="pinned" label="Pinned">
+        {rows(PINNED)}
+      </SidebarSectionCard>
+      <SidebarSectionCard
+        value="car-chat"
+        label="Car Chat"
+        icon={Folder}
+        collapsedIndicator={<GroupIndicatorDot state="unread" />}
+      />
+      <SidebarSectionCard value="chats" label="Chats">
+        {rows(CHATS)}
+      </SidebarSectionCard>
+    </CollapsibleNavSection.Root>
+  ),
+};

--- a/clients/web/src/domains/chat/components/sidebar-section-card.stories.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-section-card.stories.tsx
@@ -14,13 +14,18 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Folder } from "lucide-react";
 
-import { ContextMenu } from "@vellumai/design-library";
+import { cn } from "@vellumai/design-library";
 
 import { CollapsibleNavSection } from "@/components/collapsible-nav-section";
+import { SIDEBAR_SECTION_TITLE_TEXT_CLASSES } from "@/components/sidebar-nav-geometry";
 import { GroupIndicatorDot } from "@/domains/chat/components/collapsed-group-icon";
 import { ConversationListProvider } from "@/domains/chat/components/conversation-list-context";
-import { ConversationRow } from "@/domains/chat/components/conversation-row";
+import {
+  GroupActionsMenu,
+  type GroupMenuItemsProps,
+} from "@/domains/chat/components/group-actions-menu";
 import { SidebarSectionCard } from "@/domains/chat/components/sidebar-section-card";
+import { SidebarViewModeSelect } from "@/domains/chat/components/sidebar-view-mode-select";
 import type { Conversation } from "@/types/conversation-types";
 
 function conversation(
@@ -69,21 +74,40 @@ const LIST_CONTEXT = {
   typeof ConversationListProvider
 >["value"];
 
-function rows(items: Conversation[]) {
-  return items.map((c) => (
-    <ConversationRow key={c.conversationId} conversation={c} />
-  ));
-}
+/**
+ * A section's own actions, as the sidebar wires them. Deliberately the real
+ * `GroupMenuItemsProps`, not a hand-written item list: `ConversationNavSection`
+ * renders these into the header's right-click menu and, on touch, its
+ * long-press sheet, and `GroupActionsMenu` renders the same set behind the
+ * hover "…". Faking the items here would document a menu the app never shows.
+ *
+ * These are section actions. A row's actions (pin, archive, move to group,
+ * inspect) live on `ConversationRow` and are a different set entirely.
+ */
+const GROUP_MENU: GroupMenuItemsProps = {
+  onMarkAllRead: () => {},
+  hasUnreadConversations: true,
+  onArchiveAll: () => {},
+  hasConversations: true,
+  onRename: () => {},
+  onDelete: () => {},
+  onCopyGroupId: () => {},
+  onMoveDown: () => {},
+};
 
-const SECTION_MENU = (
-  <>
-    <ContextMenu.Item>Mark all as read</ContextMenu.Item>
-    <ContextMenu.Item>Archive all</ContextMenu.Item>
-    <ContextMenu.Separator />
-    <ContextMenu.Label>Group by</ContextMenu.Label>
-    <ContextMenu.Item>None</ContextMenu.Item>
-    <ContextMenu.Item>Channel</ContextMenu.Item>
-  </>
+/**
+ * The Chats card additionally carries the view-mode toggle. It is a property
+ * of the section rather than a bulk action, so it rides in the menu's footer
+ * slot, which is where the deleted sidebar-wide "Conversations" header used
+ * to keep it.
+ */
+const GROUP_BY_FOOTER = (
+  <div className="px-2 pb-1">
+    <div className={cn("mt-3 mb-2", SIDEBAR_SECTION_TITLE_TEXT_CLASSES)}>
+      Group by
+    </div>
+    <SidebarViewModeSelect value="all" onChange={() => {}} />
+  </div>
 );
 
 const meta = {
@@ -127,11 +151,22 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+/**
+ * Pinned carries the hover "…" and grows to fit its rows rather than
+ * capping and scrolling within itself, as it does in the sidebar today.
+ */
 export const Pinned: Story = {
-  args: { value: "pinned", label: "Pinned" },
+  args: {
+    value: "pinned",
+    label: "Pinned",
+    items: PINNED,
+    unbounded: true,
+    groupMenu: GROUP_MENU,
+    trailing: <GroupActionsMenu label="Pinned" {...GROUP_MENU} />,
+  },
   render: (args) => (
     <CollapsibleNavSection.Root type="multiple" defaultValue={["pinned"]}>
-      <SidebarSectionCard {...args}>{rows(PINNED)}</SidebarSectionCard>
+      <SidebarSectionCard {...args} />
     </CollapsibleNavSection.Root>
   ),
 };
@@ -142,7 +177,10 @@ export const CollapsedGroup: Story = {
     value: "car-chat",
     label: "Car Chat",
     icon: Folder,
+    items: [],
     collapsedIndicator: <GroupIndicatorDot state="unread" />,
+    groupMenu: GROUP_MENU,
+    trailing: <GroupActionsMenu label="Car Chat" {...GROUP_MENU} />,
   },
   render: (args) => (
     <CollapsibleNavSection.Root type="multiple" defaultValue={[]}>
@@ -156,53 +194,83 @@ export const Chats: Story = {
   args: {
     value: "chats",
     label: "Chats",
+    items: CHATS,
     collapsedIndicator: <GroupIndicatorDot state="unread" />,
   },
   render: (args) => (
     <CollapsibleNavSection.Root type="multiple" defaultValue={["chats"]}>
-      <SidebarSectionCard {...args}>{rows(CHATS)}</SidebarSectionCard>
+      <SidebarSectionCard {...args} />
     </CollapsibleNavSection.Root>
   ),
 };
 
 /**
- * Right-click anywhere on the header opens the section's own menu, so
- * "Archive all" reaches this section's rows and no others.
+ * The two menus, which are not the same menu.
+ *
+ * The header's actions are the section's: mark all read, archive all,
+ * rename, delete, reorder, plus the Group by toggle this card owns now that
+ * the sidebar-wide "Conversations" header is gone. They are reachable from
+ * the hover "…", from right-clicking the header, and from a long-press on
+ * touch, all rendered from one `groupMenu`.
+ *
+ * A row's actions are its own (pin, archive, move to group, inspect) and
+ * come from `ConversationRow`. Right-click a row here to see the difference.
  */
-export const WithSectionMenu: Story = {
+export const SectionMenuVersusRowMenu: Story = {
   args: {
     value: "chats",
     label: "Chats",
-    contextMenuContent: SECTION_MENU,
-    touchMenuContent: () => SECTION_MENU,
+    items: CHATS.slice(0, 4),
+    groupMenu: GROUP_MENU,
+    trailing: (
+      <GroupActionsMenu label="Chats" footer={GROUP_BY_FOOTER} {...GROUP_MENU} />
+    ),
   },
   render: (args) => (
     <CollapsibleNavSection.Root type="multiple" defaultValue={["chats"]}>
-      <SidebarSectionCard {...args}>{rows(CHATS.slice(0, 3))}</SidebarSectionCard>
+      <SidebarSectionCard {...args} />
     </CollapsibleNavSection.Root>
   ),
 };
 
 /** The sidebar's stack: curated cards above, the chat list below. */
 export const Composed: Story = {
-  args: { value: "pinned", label: "Pinned" },
+  args: { value: "pinned", label: "Pinned", items: PINNED },
   render: () => (
     <CollapsibleNavSection.Root
       type="multiple"
       defaultValue={["pinned", "chats"]}
     >
-      <SidebarSectionCard value="pinned" label="Pinned">
-        {rows(PINNED)}
-      </SidebarSectionCard>
+      <SidebarSectionCard
+        value="pinned"
+        label="Pinned"
+        items={PINNED}
+        unbounded
+        groupMenu={GROUP_MENU}
+        trailing={<GroupActionsMenu label="Pinned" {...GROUP_MENU} />}
+      />
       <SidebarSectionCard
         value="car-chat"
         label="Car Chat"
         icon={Folder}
+        items={[]}
         collapsedIndicator={<GroupIndicatorDot state="unread" />}
+        groupMenu={GROUP_MENU}
+        trailing={<GroupActionsMenu label="Car Chat" {...GROUP_MENU} />}
       />
-      <SidebarSectionCard value="chats" label="Chats">
-        {rows(CHATS)}
-      </SidebarSectionCard>
+      <SidebarSectionCard
+        value="chats"
+        label="Chats"
+        items={CHATS}
+        groupMenu={GROUP_MENU}
+        trailing={
+          <GroupActionsMenu
+            label="Chats"
+            footer={GROUP_BY_FOOTER}
+            {...GROUP_MENU}
+          />
+        }
+      />
     </CollapsibleNavSection.Root>
   ),
 };

--- a/clients/web/src/domains/chat/components/sidebar-section-card.stories.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-section-card.stories.tsx
@@ -12,7 +12,6 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { Folder } from "lucide-react";
 
 import { cn } from "@vellumai/design-library";
 
@@ -171,12 +170,20 @@ export const Pinned: Story = {
   ),
 };
 
-/** A custom group, collapsed, carrying its unread dot in the header. */
+/**
+ * A custom group, collapsed, carrying its unread dot in the header.
+ *
+ * No leading icon: `CollapsibleNavSection.Section` renders `icon` only in its
+ * non-collapsible branch, so a collapsible section drops it. The design gives
+ * custom groups a folder glyph, which means the shared section component needs
+ * to render icons on collapsible headers before these cards can show one. That
+ * is a change to a component the current sidebar renders through, so it is
+ * tracked separately rather than folded into this presentational slice.
+ */
 export const CollapsedGroup: Story = {
   args: {
     value: "car-chat",
     label: "Car Chat",
-    icon: Folder,
     items: [],
     collapsedIndicator: <GroupIndicatorDot state="unread" />,
     groupMenu: GROUP_MENU,
@@ -252,7 +259,6 @@ export const Composed: Story = {
       <SidebarSectionCard
         value="car-chat"
         label="Car Chat"
-        icon={Folder}
         items={[]}
         collapsedIndicator={<GroupIndicatorDot state="unread" />}
         groupMenu={GROUP_MENU}

--- a/clients/web/src/domains/chat/components/sidebar-section-card.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-section-card.tsx
@@ -1,0 +1,48 @@
+/**
+ * One sidebar section, drawn as a card.
+ *
+ * The card is the unit of the sidebar: Pinned, each custom group, each
+ * channel, and the chat list are all this same shell with different contents.
+ *
+ * This component owns *only* the card surface. The header, chevron, collapse
+ * behavior, collapsed-only indicator, right-click and long-press menus, and
+ * drag-to-reorder all come from {@link CollapsibleNavSection.Section}, which
+ * every sidebar section already uses. Anything that belongs to "a sidebar
+ * section" belongs there, not here, so the card and the sections it replaces
+ * can never drift in typography, geometry, or pointer behavior.
+ *
+ * Sections stay members of one {@link CollapsibleNavSection.Root} so their
+ * open state is managed in a single place; the card surface sits between the
+ * root and the item.
+ *
+ * Purely presentational. It owns no query and no membership rule: rows and
+ * indicator are handed in, which is what lets every section load from its own
+ * server-filtered query (LUM-2443) without this component knowing the others
+ * exist. Its menu is scoped to this section alone, so a section's bulk actions
+ * and its contents always describe the same rows (LUM-3008).
+ */
+
+import type { ComponentProps } from "react";
+
+import { Card } from "@vellumai/design-library";
+import { cn } from "@vellumai/design-library/utils/cn";
+
+import { CollapsibleNavSection } from "@/components/collapsible-nav-section";
+
+export type SidebarSectionCardProps = ComponentProps<
+  typeof CollapsibleNavSection.Section
+> & {
+  /** Extra classes for the card surface, not the section inside it. */
+  cardClassName?: string;
+};
+
+export function SidebarSectionCard({
+  cardClassName,
+  ...section
+}: SidebarSectionCardProps) {
+  return (
+    <Card.Root bordered={false} noPadding className={cn("p-2", cardClassName)}>
+      <CollapsibleNavSection.Section {...section} />
+    </Card.Root>
+  );
+}

--- a/clients/web/src/domains/chat/components/sidebar-section-card.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-section-card.tsx
@@ -5,11 +5,19 @@
  * channel, and the chat list are all this same shell with different contents.
  *
  * This component owns *only* the card surface. The header, chevron, collapse
- * behavior, collapsed-only indicator, right-click and long-press menus, and
- * drag-to-reorder all come from {@link CollapsibleNavSection.Section}, which
- * every sidebar section already uses. Anything that belongs to "a sidebar
- * section" belongs there, not here, so the card and the sections it replaces
- * can never drift in typography, geometry, or pointer behavior.
+ * behavior, collapsed-only indicator, row list, and drag-to-reorder all come
+ * from {@link ConversationNavSection}, which every sidebar section already
+ * uses. Anything that belongs to "a sidebar section" belongs there, not here,
+ * so the card and the sections it replaces can never drift in typography,
+ * geometry, or pointer behavior.
+ *
+ * That layer is also what keeps the two menus distinct. A section's own
+ * actions (mark all read, archive all, rename, delete, reorder) come from a
+ * single `groupMenu`, which it renders into both the header's right-click
+ * menu and, on touch, its long-press sheet. A conversation's actions (pin,
+ * archive, move to group, inspect) stay on {@link ConversationRow}. The two
+ * never share a surface: right-clicking a header offers section actions,
+ * right-clicking a row offers that row's.
  *
  * Sections stay members of one {@link CollapsibleNavSection.Root} so their
  * open state is managed in a single place; the card surface sits between the
@@ -27,10 +35,10 @@ import type { ComponentProps } from "react";
 import { Card } from "@vellumai/design-library";
 import { cn } from "@vellumai/design-library/utils/cn";
 
-import { CollapsibleNavSection } from "@/components/collapsible-nav-section";
+import { ConversationNavSection } from "@/domains/chat/components/conversation-nav-section";
 
 export type SidebarSectionCardProps = ComponentProps<
-  typeof CollapsibleNavSection.Section
+  typeof ConversationNavSection
 > & {
   /** Extra classes for the card surface, not the section inside it. */
   cardClassName?: string;
@@ -42,7 +50,7 @@ export function SidebarSectionCard({
 }: SidebarSectionCardProps) {
   return (
     <Card.Root bordered={false} noPadding className={cn("p-2", cardClassName)}>
-      <CollapsibleNavSection.Section {...section} />
+      <ConversationNavSection {...section} />
     </Card.Root>
   );
 }

--- a/clients/web/src/domains/chat/components/sidebar-section-card.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-section-card.tsx
@@ -6,10 +6,10 @@
  *
  * This component owns *only* the card surface. The header, chevron, collapse
  * behavior, collapsed-only indicator, row list, and drag-to-reorder all come
- * from {@link ConversationNavSection}, which every sidebar section already
- * uses. Anything that belongs to "a sidebar section" belongs there, not here,
- * so the card and the sections it replaces can never drift in typography,
- * geometry, or pointer behavior.
+ * from {@link ConversationNavSection}. Anything that belongs to "a sidebar
+ * section" belongs there, not here, so every section reads identically in
+ * typography, geometry, and pointer behavior whether or not it sits on a
+ * card.
  *
  * That layer is also what keeps the two menus distinct. A section's own
  * actions (mark all read, archive all, rename, delete, reorder) come from a


### PR DESCRIPTION
## TL;DR

Adds `SidebarSectionCard`, the card shell every section of the new sidebar is drawn with, plus its stories. **Nothing imports it**, so it is inert and needs no feature flag.

Second of several small PRs rebuilding the conversation sidebar (LUM-2443). Independent of #40319.

## Why

`groupConversations` currently derives every sidebar section by filtering one fully-drained conversation list, which is why a complete list is a *requirement* for the sidebar to render correctly. LUM-2443 removes that coupling by giving each section its own server-filtered query. Cards are per-section by nature, so the presentational shell lands first and the queries follow.

## What changes for the user

Nothing yet. This PR adds an unreferenced component and its stories. Reviewable in Storybook under **Chat / SidebarSectionCard**.

| | Before | After (once wired) |
|---|---|---|
| Section chrome | Collapsible header in the rail | Same header, on a card surface |
| Section menu | One sidebar-wide "Conversations" menu | Per-card menu, scoped to that section |
| Unread, collapsed | Dot on the section header | Unchanged |
| Unread, expanded | Dot on the row | Unchanged |

## Why it is safe

The component is ~20 lines and owns **only** the card surface:

```tsx
<Card.Root bordered={false} noPadding className={cn("p-2", cardClassName)}>
  <CollapsibleNavSection.Section {...section} />
</Card.Root>
```

Everything that belongs to "a sidebar section" stays in `CollapsibleNavSection.Section`, which every section already uses, so the card cannot drift from the sections it replaces in typography, geometry, or pointer behavior. Its props are that component's props.

An earlier draft reimplemented the header. Delegating instead keeps three things a reimplementation had lost or would have had to rebuild:

- the **touch long-press bottom sheet**; Radix `ContextMenu` alone renders a pointer-positioned popover on touch, which this codebase treats as the wrong surface on mobile
- **drag-to-reorder**, including the documented `dragleave` handling that keeps the drop indicator correct when the pointer crosses an expanded section's own rows
- **one accessible toggle per section**, with the chevron kept out of the accessibility tree so sections are not announced twice

## Review notes

- The stories mount the real `ConversationRow` and the real section machinery, not stand-in markup, per `docs/CONVENTIONS.md`.
- They pin a desktop viewport. Rows and headers carry `max-md:` variants, and the Storybook canvas iframe is ~374px, so without pinning the stories silently document the mobile drawer's metrics (16px/500 at 36px tall) inside a desktop rail, a combination the app never ships.
- Verified in Storybook: card 248px, rows 14px/400/30px, header 14px/350 via the shared `SIDEBAR_SECTION_TITLE_TEXT_CLASSES`, chevron hidden at rest, section right-click menu opening with `Group by → None | Channel`.

## Deferred, deliberately

- **Right-click is header-scoped, not whole-card.** `CollapsibleNavSection` wraps the header in the `ContextMenu.Trigger`, so right-clicking a row gives that row's menu and the card's padding gives nothing. Extending the target to the whole card surface is a follow-up if we want it.
- **Wiring.** Query hooks belong in `hooks/conversation-queries.ts` and land with their first consumer rather than as unused code.

Part of LUM-2443.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40321" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->