### PR TITLE
fix(voice): let dev builds see the camera, keep 0.11.2 stable out

### DIFF
--- a/clients/web/src/lib/backwards-compat/use-supports-voice-camera.test.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-voice-camera.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Pins what `MIN_VERSION` admits.
+ *
+ * The constant is `0.11.2-dev.0`, a pre-release, which is not the obvious
+ * shape for a minimum-version gate and is easy to "tidy" into a plain
+ * `0.11.2` by someone who reads it as a typo. That edit would silently offer
+ * the camera to every assistant on the released 0.11.2, where the daemon has
+ * no `attach_image` handler and refuses every photo.
+ *
+ * These assert against `versionSupports` rather than the hook: the hook adds
+ * store hydration and owner-scoping, which are `useAssistantScopedSupports`'s
+ * concern and already covered by `utils.test.ts`. What is specific to this
+ * gate is which VERSIONS pass, so that is what is tested.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { versionSupports } from "./utils";
+import { MIN_VERSION } from "./use-supports-voice-camera";
+
+describe("voice camera version gate", () => {
+  test("admits a dev build of the release it was cut against", () => {
+    // The reason for the pre-release suffix. A dev build carries unreleased
+    // commits on top of 0.11.2, including the camera, so it must pass before
+    // 0.11.3 exists.
+    expect(
+      versionSupports("0.11.2-dev.202608061530.5cf8576", MIN_VERSION),
+    ).toBe(true);
+  });
+
+  test("excludes the 0.11.2 stable release", () => {
+    // Cut 2026-08-04 without the frame. This is the row that makes the
+    // pre-release suffix necessary rather than decorative.
+    expect(versionSupports("0.11.2", MIN_VERSION)).toBe(false);
+  });
+
+  test("excludes everything below 0.11.2", () => {
+    expect(versionSupports("0.11.1", MIN_VERSION)).toBe(false);
+    expect(versionSupports("0.10.12", MIN_VERSION)).toBe(false);
+    // A dev build of an older base is still an older base.
+    expect(
+      versionSupports("0.11.1-dev.202608061530.5cf8576", MIN_VERSION),
+    ).toBe(false);
+  });
+
+  test("admits the release it ships in and everything after", () => {
+    expect(versionSupports("0.11.3", MIN_VERSION)).toBe(true);
+    expect(versionSupports("0.11.4", MIN_VERSION)).toBe(true);
+    // Guards the string-compare trap: "0.12.0" < "0.11.2" lexically, and only
+    // a real numeric comparison gets this right.
+    expect(versionSupports("0.12.0", MIN_VERSION)).toBe(true);
+    expect(versionSupports("1.0.0", MIN_VERSION)).toBe(true);
+  });
+
+  test("stays closed on an unknown or unparseable version", () => {
+    expect(versionSupports(null, MIN_VERSION)).toBe(false);
+    expect(versionSupports(undefined, MIN_VERSION)).toBe(false);
+    expect(versionSupports("not-a-version", MIN_VERSION)).toBe(false);
+  });
+});

--- a/clients/web/src/lib/backwards-compat/use-supports-voice-camera.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-voice-camera.ts
@@ -23,21 +23,38 @@
  * shows no camera control at all. A camera that opens and silently drops every
  * photo is worse than one that isn't offered.
  *
- * MIN_VERSION is 0.11.3, the release this ships in. It is a minimum, so every
- * later version (0.11.4, 0.12.0, and up) passes too.
+ * MIN_VERSION is `0.11.2-dev.0`, which reads as "anything after 0.11.2
+ * stable". The pre-release suffix is doing real work here, so it is worth
+ * being explicit about what it buys:
  *
- * Not 0.11.2: that was cut on 2026-08-04 without the frame, so gating there
- * would offer a camera to every assistant already on the current release, and
- * every photo taken with it would be refused. Not a higher number either,
- * which is the mistake this originally made. The reflex is to pick the next
- * MINOR as the first release "guaranteed" to contain the change, but 0.10 ran
- * to twelve patches, so on this cadence that hides a working camera across
- * potentially months of releases that have it.
+ * - A **dev build** of 0.11.2 passes. `versionSupports` treats a
+ *   `0.11.2-dev.*` build as NEWER than 0.11.2 stable (see its JSDoc: a dev
+ *   build carries unreleased commits on top of the release it is named for),
+ *   and two dev pre-releases compare by the timestamp in the suffix, so any
+ *   real `dev.<timestamp>.<sha>` is above `dev.0`. That is what lets this be
+ *   exercised on a local build before the release exists.
+ * - **0.11.2 stable is excluded**, which is the whole point. It was cut on
+ *   2026-08-04 without the frame. A plain `0.11.2` minimum would offer a
+ *   camera to everyone already on the current release and refuse every photo
+ *   taken with it. Dev-vs-stable at the same base resolves in the dev build's
+ *   favour, so naming a dev suffix here excludes the stable release.
+ * - **0.11.3 and up pass** on the base comparison alone, before any of the
+ *   pre-release logic is reached.
  *
- * The number has to track the release that actually carries the change, and
- * releases here are cut as `release/vX.Y.Z` branches with cherry-picks: this
- * merging to main is NOT by itself enough to put it in a given release. If it
- * slips past the 0.11.3 branch cut, this constant has to move with it.
+ * Deliberately NOT a higher number, which is the mistake this originally
+ * made. The reflex is to pick the next MINOR as the first release
+ * "guaranteed" to contain the change, but 0.10 ran to twelve patches, so on
+ * this cadence that hides a working camera across potentially months of
+ * releases that have it.
+ *
+ * Accepted edge: a STALE dev build of 0.11.2, made before the camera landed,
+ * also passes and shows a camera that errors on every photo. Pinning a
+ * timestamp (`dev.202608060000`) would exclude it, at the cost of a constant
+ * nobody can reason about later. Rebuilding fixes it, and only developers on
+ * dev builds are exposed.
+ *
+ * The rows above are pinned by `use-supports-voice-camera.test.ts` so a
+ * change to the comparison rules cannot silently reopen the stable release.
  *
  * The gate is scoped to the assistant that owns the live voice session via
  * `useAssistantScopedSupports`. See its JSDoc in `./utils.ts` for the atomic
@@ -48,7 +65,7 @@
  */
 import { useAssistantScopedSupports } from "./utils";
 
-export const MIN_VERSION = "0.11.3";
+export const MIN_VERSION = "0.11.2-dev.0";
 
 /**
  * Returns `true` when the assistant that owns the live voice session


### PR DESCRIPTION
Follow-up to #40261, so the voice-room camera can be exercised on a local dev build before 0.11.3 exists.

## The change

`MIN_VERSION` goes from `0.11.3` to **`0.11.2-dev.0`**, which reads as "anything after 0.11.2 stable".

There is no strictly-greater form of the gate (`useAssistantScopedSupports` is a `>=` minimum), but the pre-release suffix gets there exactly. `versionSupports` treats a `0.11.2-dev.*` build as **newer** than 0.11.2 stable, because a dev build carries unreleased commits on top of the release it is named for:

```ts
if (versionIsDev !== minIsDev) {
  // Dev is ahead of stable with the same base.
  return versionIsDev;
}
```

So a dev minimum admits dev builds and excludes the stable release at the same base.

| Version | Result | Why |
|---|---|---|
| `0.11.2-dev.202608061530.5cf8576` | shows | both dev; `comparePreRelease` is numeric, `202608… > 0` |
| `0.11.2` (released 2026-08-04, no `attach_image`) | hidden | dev-vs-stable at the same base resolves for the dev build |
| `0.11.3`, `0.11.4`, `0.12.0`, `1.0.0` | shows | base comparison, before any pre-release logic |
| unknown / unparseable | hidden | unchanged conservative default |

The obvious move is a plain `0.11.2`, and it is the one to avoid: it admits the released 0.11.2, where every photo taken would be refused by a daemon that has no handler for the frame.

## Test

Adds `use-supports-voice-camera.test.ts` pinning those rows. The constant is an odd shape and reads like a typo someone would tidy into `0.11.2`; that edit now fails a test rather than shipping a camera that cannot work. The suite also covers `0.12.0`, which is *below* `0.11.2` under string comparison and only passes with a real numeric one.

## Accepted edge

A **stale** dev build of 0.11.2, made before the camera landed, also passes and shows a camera that errors on every photo. Excluding it means pinning a timestamp (`dev.202608060000`), which trades a real but developer-only annoyance for a constant nobody can reason about later. Rebuilding fixes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)