### PR TITLE
fix(web): default a missing response Content-Type instead of forcing parseAs

### DIFF
--- a/clients/web/src/lib/api-interceptors.test.ts
+++ b/clients/web/src/lib/api-interceptors.test.ts
@@ -118,6 +118,7 @@ import {
   authorizeRemoteGatewayRequest,
   daemonErrorInterceptor,
   daemonRequestInterceptor,
+  jsonContentTypeFallbackInterceptor,
   localGatewayAuthRecoveryInterceptor,
   platformAuthRecoveryInterceptor,
   platformFeaturesGate,
@@ -2107,4 +2108,88 @@ describe("api-interceptors / post-resume request counting", () => {
     expect(output.url).toBe(input.url);
     expect(output.headers.get("X-Vellum-Client-Id")).toBe(getClientId());
   });
+});
+
+describe("api-interceptors / jsonContentTypeFallbackInterceptor", () => {
+  test("defaults an absent Content-Type to application/json", async () => {
+    const input = new Response('{"ok":true}', { status: 200 });
+    input.headers.delete("content-type");
+
+    const output = jsonContentTypeFallbackInterceptor(input);
+
+    expect(output.headers.get("content-type")).toBe("application/json");
+    expect(await output.text()).toBe('{"ok":true}');
+  });
+
+  test("an absent Content-Type with an empty body still parses as JSON", async () => {
+    // The LUM-2371 shape: under `parseAs: "auto"` a missing header selects
+    // "stream", handing back `response.body` (which serializes to `null`).
+    // With the header defaulted, the client's JSON branch yields `{}`.
+    const input = new Response("", { status: 200 });
+    input.headers.delete("content-type");
+
+    const output = jsonContentTypeFallbackInterceptor(input);
+
+    expect(output.headers.get("content-type")).toBe("application/json");
+    expect(await output.text()).toBe("");
+  });
+
+  test("preserves status and statusText", () => {
+    const input = new Response("{}", { status: 201, statusText: "Created" });
+    input.headers.delete("content-type");
+
+    const output = jsonContentTypeFallbackInterceptor(input);
+
+    expect(output.status).toBe(201);
+    expect(output.statusText).toBe("Created");
+  });
+
+  test("preserves other headers while adding Content-Type", () => {
+    const input = new Response("{}", {
+      status: 200,
+      headers: { "x-vellum-request-id": "abc123" },
+    });
+    input.headers.delete("content-type");
+
+    const output = jsonContentTypeFallbackInterceptor(input);
+
+    expect(output.headers.get("x-vellum-request-id")).toBe("abc123");
+    expect(output.headers.get("content-type")).toBe("application/json");
+  });
+
+  test.each([
+    ["application/zip"],
+    ["application/pdf"],
+    ["image/png"],
+    ["application/octet-stream"],
+    ["application/gzip"],
+    ["text/event-stream"],
+    ["application/json"],
+  ])("leaves a declared %s response untouched", (contentType) => {
+    // Load-bearing: rewriting these would break `auto` inference, which is
+    // the whole reason binary downloads need no per-call-site `parseAs`.
+    const input = new Response("payload", {
+      status: 200,
+      headers: { "content-type": contentType },
+    });
+
+    const output = jsonContentTypeFallbackInterceptor(input);
+
+    expect(output).toBe(input);
+    expect(output.headers.get("content-type")).toBe(contentType);
+  });
+
+  test.each([[204], [205], [304]])(
+    "returns a %i response untouched rather than rebuilding it",
+    (status) => {
+      // Constructing a Response with a body and a null-body status throws.
+      const input = new Response(null, { status });
+      input.headers.delete("content-type");
+
+      const output = jsonContentTypeFallbackInterceptor(input);
+
+      expect(output).toBe(input);
+      expect(output.status).toBe(status);
+    },
+  );
 });

--- a/clients/web/src/lib/api-interceptors.ts
+++ b/clients/web/src/lib/api-interceptors.ts
@@ -468,6 +468,49 @@ export function daemonUnreachableInterceptor(response: Response): Response {
 }
 
 /**
+ * Statuses that must not carry a body. Constructing a `Response` with a body
+ * and one of these throws, so they are handed back untouched.
+ */
+const NULL_BODY_STATUSES = new Set([204, 205, 304]);
+
+/**
+ * Default a missing response `Content-Type` to `application/json`.
+ *
+ * The generated clients parse with HeyAPI's `parseAs: "auto"`, which picks the
+ * strategy from the response `Content-Type`: `application/json` parses as JSON,
+ * `application/zip` / `image/png` / `application/pdf` and friends as a blob,
+ * and an unrecognized type falls back to JSON. That inference is correct for
+ * every endpoint in these specs, and it is what lets a binary download work
+ * without the call site restating what the route already declares in its
+ * `RouteDefinition.responseBody` `contentType`.
+ *
+ * Its one wrong answer is an **absent** header, where `getParseAs()` returns
+ * `"stream"` and the client hands back `response.body` as data (a value that
+ * serializes to `null` when the body is empty). Defaulting the header here
+ * fixes that single case at the seam, so no call site has to compensate for it.
+ *
+ * The response is only rebuilt when the header is genuinely missing; otherwise
+ * the original object is returned as-is.
+ *
+ * Reference: https://heyapi.dev/openapi-ts/clients/fetch#parser
+ */
+export function jsonContentTypeFallbackInterceptor(response: Response): Response {
+  if (response.headers.get("content-type")) {
+    return response;
+  }
+  if (NULL_BODY_STATUSES.has(response.status)) {
+    return response;
+  }
+  const headers = new Headers(response.headers);
+  headers.set("content-type", "application/json");
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+/**
  * Daemon response interceptor for local gateway 401 recovery.
  *
  * When the local gateway rejects a request with 401 (stale or invalid
@@ -903,24 +946,23 @@ gatewayClient.interceptors.response.use(daemonUnreachableInterceptor);
 gatewayClient.interceptors.response.use(platformAuthRecoveryInterceptor);
 gatewayClient.interceptors.error.use(daemonErrorInterceptor);
 
-// Force JSON body parsing for all three generated clients. The default
-// `parseAs: 'auto'` infers the parsing strategy from the Content-Type
-// response header. When the header is absent (observed on iOS WKWebView
-// under concurrent fetch load), the client falls back to `'stream'`
-// mode and returns `response.body` (a ReadableStream or null) as
-// `data` — producing the "body=null" errors reported in LUM-2371.
+// Keep HeyAPI's `parseAs: "auto"` (the client default) so each response is
+// parsed according to the Content-Type the route declares, and repair the one
+// case `auto` gets wrong: an absent header, which it treats as `"stream"`.
 //
-// Every endpoint in these OpenAPI specs returns JSON; non-JSON call
-// sites (blob downloads) explicitly override `parseAs` per-request.
+// Forcing `parseAs: "json"` here instead would discard correct inference for
+// every binary endpoint (zip / pdf / png / octet-stream / gzip) and make each
+// download depend on its call site restating a content type the route already
+// declares in `RouteDefinition.responseBody`.
 //
-// Reference: https://heyapi.dev/openapi-ts/clients/fetch#parser
+// See {@link jsonContentTypeFallbackInterceptor}.
 for (const apiClient of [
   daemonClient,
   gatewayClient,
   platformClient,
   authClient,
 ]) {
-  apiClient.setConfig({ parseAs: "json" });
+  apiClient.interceptors.response.use(jsonContentTypeFallbackInterceptor);
 }
 
 for (const apiClient of [authClient, platformClient]) {


### PR DESCRIPTION
## TL;DR

The generated clients are pinned to `parseAs: "json"`, which throws away correct per-response parsing for every binary endpoint and makes each binary download depend on its call site restating a content type the route already declares. This replaces that blunt override with a fix at the seam: default the one thing HeyAPI's `auto` gets wrong (an **absent** `Content-Type`) and let inference do the rest.

Supersedes #40318, which added a CI guard policing the call sites instead of removing the need for them.

## The problem with the current override

`api-interceptors.ts` set `parseAs: "json"` on all four clients (PR #34662). The intent was sound: `auto` infers from the response `Content-Type`, and when that header is **missing** it returns `"stream"`, handing back `response.body` as data, which serializes to `null` on an empty body.

But `auto` is right about everything else. `getParseAs()` maps `application/zip`, `application/pdf`, `image/png`, `application/octet-stream` and `application/gzip` to `"blob"`, and an unrecognized type already falls back to JSON. Forcing `"json"` globally to fix one edge case:

- deleted correct inference for all 7 daemon + 2 platform binary endpoints,
- made 11 hand-written `parseAs` overrides load-bearing,
- and left a trap where the next binary endpoint silently `JSON.parse`s its own bytes.

## The fix

A response interceptor that defaults an absent `Content-Type` to `application/json`, with `auto` restored.

This mirrors how request bodies already work. LUM-2796 / LUM-2923 landed `parseBody()`, whose docstring states the declared schema is *"the single source of truth for both the OpenAPI/wire contract and runtime validation."* The contract is applied **once, at the boundary**, not restated at each call site. Response parsing now works the same way: the content type the route declares in `RouteDefinition.responseBody` drives parsing, and no call site has to compensate.

## Before / after

| | Before | After |
|---|---|---|
| Binary endpoint (zip/pdf/png/gzip) | Parsed as JSON unless the call site says `parseAs: "blob"` | Inferred from its own declared Content-Type |
| New binary endpoint, no override | Silently runs `JSON.parse` over bytes | Just works |
| Response with no Content-Type | Masked by the global `json` | Defaulted to `application/json` at the seam |
| SSE / explicit `parseAs: "stream"` | Per-request override wins | Unchanged |
| 204 / 205 / 304 | — | Returned untouched (a body + null-body status throws) |

## Why this is safe

- The interceptor **rebuilds the response only when the header is genuinely missing**; otherwise the original object is returned by identity. Declared content types are never rewritten.
- Null-body statuses are returned untouched, so no `Response` is constructed with a body it cannot carry.
- Status, statusText, and all other headers are preserved.
- **Existing per-call-site `parseAs` overrides are deliberately left in place.** They are redundant under `auto` but harmless, so every binary path keeps belt-and-braces while this bakes. They can be removed later as cleanup.

## Verification

- `src/lib/api-interceptors.test.ts` — **123 pass, 0 fail** (14 new)
- `bunx tsc --noEmit` — clean
- `bun run lint` — clean
- Call-site suites that depend on parse behavior, run per-file: `avatar-api` (25), `stream-greeting` (6), `use-local-file-info` (7), `chat-markdown-message` (24), `file-preview-container` (10) — all pass
- **Sensitivity-checked**: removing the passthrough early-return (so the interceptor rewrites every response) fails exactly the 7 "leaves a declared `<type>` response untouched" cases. Those assertions are load-bearing, not decorative.

New coverage pins: header defaulting, empty-body-with-no-header (the shape behind LUM-2371), status/statusText preservation, other-header preservation, passthrough for 7 declared content types, and untouched 204/205/304.

## Relationship to LUM-2371

This does **not** close [LUM-2371](https://linear.app/vellum/issue/LUM-2371). That error required a body that was literally `null`, and the producer was never identified; it may sit downstream of the daemon. This removes one mechanism that could yield a `null`-ish parse and takes away the reason call sites had to hand-manage parsing. LUM-2371 stays closed on impact grounds with its full writeup on the ticket.

## Follow-up

[LUM-3088](https://linear.app/vellum/issue/LUM-3088) tracks the larger sibling: 407 of 507 shared routes declare a `responseBody` Zod schema that nothing validates at runtime, unlike `requestBody`. Filed with a survey plan rather than shipped, because the violation count is unknown and no existing harness can measure it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40325" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->