### PR TITLE
fix(cli,web,ios): review follow-ups for the origin-model chooser foundations

### DIFF
--- a/cli/src/__tests__/pair.test.ts
+++ b/cli/src/__tests__/pair.test.ts
@@ -976,7 +976,9 @@ describe("pair command", () => {
     ).toBe(
       "vellum-assistant-dev://connect?url=https%3A%2F%2Fhost.example.ts.net%2Fassistant-123&code=a%2Bb%2Fc%3D",
     );
-    // A label rides along as an encoded `name` param; an empty one is omitted.
+    // A label rides along as an encoded `name` param (spaces percent-encoded,
+    // not form-encoded, for the app's URLComponents parser); an empty one is
+    // omitted.
     expect(
       buildAppConnectUrl(
         "vellum-assistant",
@@ -985,7 +987,7 @@ describe("pair command", () => {
         "My Homelab",
       ),
     ).toBe(
-      "vellum-assistant://connect?url=https%3A%2F%2Fpair.example.ts.net&code=device-code&name=My+Homelab",
+      "vellum-assistant://connect?url=https%3A%2F%2Fpair.example.ts.net&code=device-code&name=My%20Homelab",
     );
     expect(
       buildAppConnectUrl(

--- a/cli/src/commands/pair.ts
+++ b/cli/src/commands/pair.ts
@@ -158,7 +158,10 @@ export function buildAppConnectUrl(
   if (name) {
     params.set("name", name);
   }
-  return `${scheme}://connect?${params.toString()}`;
+  // Percent-encode spaces: URLSearchParams form-encodes them as `+`, which
+  // the app's Foundation URLComponents parser keeps as a literal plus.
+  const query = params.toString().replace(/\+/g, "%20");
+  return `${scheme}://connect?${query}`;
 }
 
 /**

--- a/cli/src/lib/tunnel-edge.ts
+++ b/cli/src/lib/tunnel-edge.ts
@@ -56,9 +56,11 @@ function wantsTunnelEdge(workspaceDir: string): boolean {
  * URL; `ensureTunnelEdge` picks SPA vs webhooks-only mode off the
  * `web-remote-ingress` flag, retrying the lookup through the gateway's startup
  * window. A healthy edge whose recorded state already targets the requested
- * gateway port is reused without any flag lookup; flag-driven mode drift is
- * repaired by the next explicit `vellum tunnel` or `vellum nginx-ingress up`
- * (which always resolve the flag), not by background wakes. Edge failures warn
+ * gateway port is reused without the flag lookup or the `remoteWebConfigHash`
+ * comparison `startRemoteWebIngress` performs; both flag-driven mode drift
+ * and injected-config drift (a renamed assistant, a changed hub URL) are
+ * repaired by the next explicit `vellum tunnel` or `vellum nginx-ingress up`,
+ * not by background wakes. Edge failures warn
  * (with the error's install or diagnostic text) and fall back to tunneling the
  * gateway port directly, which `maybeStartNgrokTunnel` only does when webhook
  * integrations are configured, so webhook channels on nginx-less machines

--- a/clients/ios/App/App/AppDelegate.swift
+++ b/clients/ios/App/App/AppDelegate.swift
@@ -144,6 +144,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     /// Parse `<scheme>://connect?url=&code=` into the validated https server
     /// base, the pair-page URL to load, and the optional `name` label for the
     /// remembered-server list. Returns `nil` for a malformed or non-https link.
+    ///
+    /// `name` alone tolerates form encoding: a raw `+` (a space from a sender
+    /// that form-encoded the query) decodes to a space, while an encoded
+    /// `%2B` stays a literal plus. `url` and `code` are machine-generated and
+    /// never form-encoded, so they take the strict percent decode.
     private static func parseConnectDeepLink(_ url: URL) -> (base: URL, pairURL: URL, name: String?)? {
         guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
               let serverParam = components.queryItems?.first(where: { $0.name == "url" })?.value,
@@ -154,7 +159,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         else {
             return nil
         }
-        let name = components.queryItems?.first(where: { $0.name == "name" })?.value
+        let name = components.percentEncodedQueryItems?
+            .first(where: { $0.name == "name" })?.value?
+            .replacingOccurrences(of: "+", with: "%20")
+            .removingPercentEncoding
         return (base, pairURL, name)
     }
 

--- a/clients/ios/App/App/SelfHostedServer.swift
+++ b/clients/ios/App/App/SelfHostedServer.swift
@@ -71,6 +71,11 @@ enum SelfHostedServer {
         components.password = nil
         components.query = nil
         components.fragment = nil
+        // The web's URL.origin collapses the scheme default port; match it
+        // (validate only admits https).
+        if components.port == 443 {
+            components.port = nil
+        }
         // Trim through the percent-encoded path so escaped separators
         // (e.g. %2F) survive the round-trip instead of being decoded.
         while components.percentEncodedPath.hasSuffix("/") {

--- a/clients/ios/App/App/SelfHostedServer.swift
+++ b/clients/ios/App/App/SelfHostedServer.swift
@@ -54,6 +54,42 @@ enum SelfHostedServer {
         return url
     }
 
+    /// Canonical identity of a server URL, shared with the web chooser's
+    /// remembered-origins store (`normalizeOriginUrl`): lowercase scheme and
+    /// host, userinfo dropped, trailing slashes stripped from the path, query
+    /// and fragment dropped, path and port preserved. Every list-identity and
+    /// active-slot comparison goes through this so the iOS list and the web
+    /// store agree on which strings mean the same server. The active slot
+    /// itself stores the raw validated URL (the `Settings.bundle` contract).
+    static func canonicalize(_ url: URL) -> URL {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return url
+        }
+        components.scheme = components.scheme?.lowercased()
+        components.host = components.host?.lowercased()
+        components.user = nil
+        components.password = nil
+        components.query = nil
+        components.fragment = nil
+        while components.path.hasSuffix("/") {
+            components.path = String(components.path.dropLast())
+        }
+        return components.url ?? url
+    }
+
+    /// `canonicalize` as the string used for list entries and equality.
+    static func canonicalString(_ url: URL) -> String {
+        return canonicalize(url).absoluteString
+    }
+
+    /// Whether a URL canonically matches the active slot.
+    static func isActive(_ url: URL, defaults: UserDefaults = .standard) -> Bool {
+        guard let active = configuredURL(defaults: defaults) else {
+            return false
+        }
+        return canonicalString(active) == canonicalString(url)
+    }
+
     /// Persist a validated origin under the shared defaults key.
     static func store(_ url: URL, defaults: UserDefaults = .standard) {
         defaults.set(url.absoluteString, forKey: defaultsKey)
@@ -64,52 +100,60 @@ enum SelfHostedServer {
         defaults.removeObject(forKey: defaultsKey)
     }
 
-    /// The remembered server list. Entries failing `validate` are dropped, and
-    /// a legacy active URL absent from the stored list is included (name nil)
+    /// The remembered server list, entries keyed by canonical URL. Entries
+    /// failing `validate` are dropped, stored urls re-canonicalize on read
+    /// (deduping any pre-canonical duplicates, first entry wins), and a
+    /// legacy active URL absent from the stored list is included (name nil)
     /// without writing back until the next mutation.
     static func servers(defaults: UserDefaults = .standard) -> [Entry] {
         var entries: [Entry] = []
         if let data = defaults.data(forKey: serversKey),
            let decoded = try? JSONDecoder().decode([Entry].self, from: data) {
             for item in decoded {
-                guard let url = validate(item.url),
-                      !entries.contains(where: { $0.url == url.absoluteString })
-                else {
+                guard let url = validate(item.url) else {
                     continue
                 }
-                entries.append(Entry(name: normalizedName(item.name), url: url.absoluteString))
+                let canonical = canonicalString(url)
+                guard !entries.contains(where: { $0.url == canonical }) else {
+                    continue
+                }
+                entries.append(Entry(name: normalizedName(item.name), url: canonical))
             }
         }
-        if let active = configuredURL(defaults: defaults),
-           !entries.contains(where: { $0.url == active.absoluteString }) {
-            entries.append(Entry(name: nil, url: active.absoluteString))
+        if let active = configuredURL(defaults: defaults) {
+            let canonical = canonicalString(active)
+            if !entries.contains(where: { $0.url == canonical }) {
+                entries.append(Entry(name: nil, url: canonical))
+            }
         }
         return entries
     }
 
-    /// Remember an origin, deduped by absolute string. A re-append with a name
+    /// Remember an origin, deduped by canonical URL. A re-append with a name
     /// updates the label; a nameless re-append keeps the existing one, so
     /// switching to a remembered server never wipes its label.
     static func append(url: URL, name: String?, defaults: UserDefaults = .standard) {
         var entries = servers(defaults: defaults)
         let name = normalizedName(name)
-        if let index = entries.firstIndex(where: { $0.url == url.absoluteString }) {
+        let canonical = canonicalString(url)
+        if let index = entries.firstIndex(where: { $0.url == canonical }) {
             if let name {
                 entries[index].name = name
             }
         } else {
-            entries.append(Entry(name: name, url: url.absoluteString))
+            entries.append(Entry(name: name, url: canonical))
         }
         persist(entries, defaults: defaults)
     }
 
-    /// Forget an origin. When it is also the active URL, the active slot is
-    /// cleared so the shell falls back to the baked default.
+    /// Forget an origin, matched by canonical URL. When it is also the active
+    /// URL, the active slot is cleared so the shell falls back to the baked
+    /// default.
     static func remove(url: URL, defaults: UserDefaults = .standard) {
         var entries = servers(defaults: defaults)
-        entries.removeAll { $0.url == url.absoluteString }
+        entries.removeAll { $0.url == canonicalString(url) }
         persist(entries, defaults: defaults)
-        if configuredURL(defaults: defaults)?.absoluteString == url.absoluteString {
+        if isActive(url, defaults: defaults) {
             clear(defaults: defaults)
         }
     }

--- a/clients/ios/App/App/SelfHostedServer.swift
+++ b/clients/ios/App/App/SelfHostedServer.swift
@@ -71,8 +71,10 @@ enum SelfHostedServer {
         components.password = nil
         components.query = nil
         components.fragment = nil
-        while components.path.hasSuffix("/") {
-            components.path = String(components.path.dropLast())
+        // Trim through the percent-encoded path so escaped separators
+        // (e.g. %2F) survive the round-trip instead of being decoded.
+        while components.percentEncodedPath.hasSuffix("/") {
+            components.percentEncodedPath = String(components.percentEncodedPath.dropLast())
         }
         return components.url ?? url
     }

--- a/clients/ios/App/App/SelfHostedServersPlugin.swift
+++ b/clients/ios/App/App/SelfHostedServersPlugin.swift
@@ -63,7 +63,7 @@ public class SelfHostedServersPlugin: CAPPlugin, CAPBridgedPlugin {
     @objc public func remove(_ call: CAPPluginCall) {
         var removedActive = false
         if let url = SelfHostedServer.validate(call.getString("url")) {
-            removedActive = SelfHostedServer.configuredURL()?.absoluteString == url.absoluteString
+            removedActive = SelfHostedServer.isActive(url)
             SelfHostedServer.remove(url: url)
         }
         guard removedActive else {

--- a/clients/web/src/domains/remote-web/pairing-page.test.tsx
+++ b/clients/web/src/domains/remote-web/pairing-page.test.tsx
@@ -418,6 +418,9 @@ describe("RemoteWebPairingPage", () => {
     const query = new URLSearchParams(href.slice(href.indexOf("?") + 1));
     expect(query.get("name")).toBe("My Homelab");
     expect(query.get("code")).toBe("device-1");
+    // Spaces are percent-encoded, not form-encoded: iOS URLComponents keeps
+    // a raw `+` as a literal plus.
+    expect(href).toContain("name=My%20Homelab");
   });
 
   test("the Android app handoff url carries the assistant name too", async () => {

--- a/clients/web/src/domains/remote-web/pairing-page.tsx
+++ b/clients/web/src/domains/remote-web/pairing-page.tsx
@@ -158,21 +158,24 @@ function buildAppHandoffUrl(
   deviceCode: string,
   platform: AppHandoffPlatform,
 ): string {
-  const query = new URLSearchParams({
+  const params = new URLSearchParams({
     url: remoteGatewayPublicBaseUrl(),
     code: deviceCode,
   });
   const assistantName = getRemoteGatewayAssistantName();
   if (assistantName) {
-    query.set("name", assistantName);
+    params.set("name", assistantName);
   }
+  // Percent-encode spaces: URLSearchParams form-encodes them as `+`, which
+  // the iOS app's Foundation URLComponents parser keeps as a literal plus.
+  const query = params.toString().replace(/\+/g, "%20");
   if (platform === "ios") {
-    return `${VELLUM_APP_SCHEME}://connect?${query.toString()}`;
+    return `${VELLUM_APP_SCHEME}://connect?${query}`;
   }
 
   const fallbackUrl = encodeURIComponent(window.location.href);
   return (
-    `intent://connect?${query.toString()}` +
+    `intent://connect?${query}` +
     `#Intent;scheme=${VELLUM_APP_SCHEME};` +
     `package=${VELLUM_ANDROID_PACKAGE};` +
     `S.browser_fallback_url=${fallbackUrl};end`

--- a/clients/web/src/stores/remembered-origins-store.ts
+++ b/clients/web/src/stores/remembered-origins-store.ts
@@ -36,8 +36,10 @@ export const REMEMBERED_ORIGINS_STORAGE_KEY = "vellum:remembered-origins";
 
 /**
  * Normalize a candidate origin URL to its canonical stored form, or `null`
- * when it is not a usable `https:` base (mirrors the validation stance of
- * `SelfHostedServer.validate` in the iOS shell).
+ * when it is not a usable `https:` base. Mirrors the iOS shell: the
+ * validation stance of `SelfHostedServer.validate` and the canonical form
+ * of `SelfHostedServer.canonicalize`, so both stores agree on which
+ * strings mean the same server.
  *
  * Canonical form: lowercase scheme and host (via `URL.origin`, which also
  * drops any userinfo), path prefix preserved with trailing slashes


### PR DESCRIPTION
## Summary
Fixes three findings from the interim review of the origin-model-chooser Wave 1 merges:
- connect/handoff links percent-encode the assistant label (URLSearchParams form-encoded spaces as +, which iOS URLComponents does not decode); the iOS parser also decodes + for the name item from stale senders
- SelfHostedServer canonicalizes server URL identity (case, trailing slash, query/fragment) so the iOS list and the web remembered-origins store agree once the chooser bridges them
- tunnel-edge wake-restore doc now states injected-config drift defers to the next explicit tunnel/nginx-ingress command, like mode drift

Part of plan: origin-model-chooser.md (review remediation, Wave 1)