### PR TITLE
Serve a plugin webhook whose caller appended a trailing slash

### DIFF
--- a/assistant/src/__tests__/plugin-api-webhook-url.test.ts
+++ b/assistant/src/__tests__/plugin-api-webhook-url.test.ts
@@ -124,6 +124,36 @@ describe("resolveWebhookUrl", () => {
     }
   });
 
+  test("hands the vendor a URL with no trailing slash", async () => {
+    // The platform appends one, and a provider delivers to the URL it was
+    // given verbatim. The gateway matches the declared path, which never ends
+    // in a slash, so a registration carrying one 404s every delivery.
+    const spy = spyOn(registration, "resolveCallbackUrl").mockResolvedValue(
+      "https://callbacks.vellum.ai/abc/webhooks/plugins/imessage/events-comms/",
+    );
+
+    await expect(
+      resolveWebhookUrl({ plugin: "imessage", path: "events-comms" }),
+    ).resolves.toBe(
+      "https://callbacks.vellum.ai/abc/webhooks/plugins/imessage/events-comms",
+    );
+    spy.mockRestore();
+  });
+
+  test("leaves a URL carrying a query string alone", async () => {
+    // Trimming there would cut into the query rather than the path.
+    const spy = spyOn(registration, "resolveCallbackUrl").mockResolvedValue(
+      "https://example.test/webhooks/plugins/imessage/events-comms?token=abc/",
+    );
+
+    await expect(
+      resolveWebhookUrl({ plugin: "imessage", path: "events-comms" }),
+    ).resolves.toBe(
+      "https://example.test/webhooks/plugins/imessage/events-comms?token=abc/",
+    );
+    spy.mockRestore();
+  });
+
   test("propagates the failure when nothing can answer", async () => {
     // No ingress and no platform connection means there is no URL that works.
     // Returning a plausible one would produce a vendor registration that

--- a/assistant/src/plugin-api/webhook-url.ts
+++ b/assistant/src/plugin-api/webhook-url.ts
@@ -90,6 +90,25 @@ function registrationType(plugin: string, route: string): string {
 }
 
 /**
+ * Drop a trailing slash from a resolved callback URL.
+ *
+ * The platform appends one to the callback URLs it hands back, and a provider
+ * given `.../events-comms/` delivers to that spelling verbatim. The gateway
+ * matches a plugin route against its declared path, which may never end in a
+ * slash (see `IngressRouteSchema`), so the slash comes off once here rather
+ * than at each plugin that registers a URL.
+ *
+ * Only the path is ever trimmed: this resolver passes no query parameters, and
+ * a URL carrying one is left alone rather than truncated.
+ */
+function withoutTrailingSlash(url: string): string {
+  if (url.includes("?") || url.includes("#")) {
+    return url;
+  }
+  return url.replace(/\/+$/, "");
+}
+
+/**
  * Resolve the public URL a third party should deliver to for `path`.
  *
  * On the managed branches this registers a callback route with the platform,
@@ -121,11 +140,12 @@ export async function resolveWebhookUrl(
 
   const callbackPath = `${PLUGIN_WEBHOOK_PREFIX}/${plugin}/${path}`;
 
-  return resolveCallbackUrl(
+  const resolved = await resolveCallbackUrl(
     () => `${getPublicBaseUrl(getConfig())}/${callbackPath}`,
     callbackPath,
     registrationType(plugin, path),
     undefined,
     sourceIdentifier,
   );
+  return withoutTrailingSlash(resolved);
 }

--- a/gateway/src/channels/plugin-ingress-approvals.test.ts
+++ b/gateway/src/channels/plugin-ingress-approvals.test.ts
@@ -466,6 +466,29 @@ describe("findServableRoute", () => {
     expect(findServableRoute(res, "other", "hook", "http")).toBeUndefined();
   });
 
+  it("ignores one trailing slash on the requested path", () => {
+    // Senders add it: a provider handed `.../hook` may call `.../hook/`.
+    const res = resolution({
+      approved: [
+        { plugin: "p", routes: [http("plugin")], digest: "d".repeat(32) },
+      ],
+    });
+    expect(findServableRoute(res, "p", "hook/", "http")?.path).toBe("hook");
+  });
+
+  it("does not let a trailing slash reach past a declaration", () => {
+    // A declared path may not end in a slash (see `IngressRouteSchema`), so
+    // dropping one can only ever land back on the path that was declared.
+    const res = resolution({
+      approved: [
+        { plugin: "p", routes: [http("plugin")], digest: "d".repeat(32) },
+      ],
+    });
+    expect(findServableRoute(res, "p", "hook//", "http")).toBeUndefined();
+    expect(findServableRoute(res, "p", "hook/more", "http")).toBeUndefined();
+    expect(findServableRoute(res, "p", "hook/more/", "http")).toBeUndefined();
+  });
+
   it("serves nothing for a declaration that failed validation", () => {
     // A malformed manifest lands in `problems`, never in either list, so a
     // vellum signer cannot smuggle an invalid route through.

--- a/gateway/src/channels/plugin-ingress-approvals.ts
+++ b/gateway/src/channels/plugin-ingress-approvals.ts
@@ -172,6 +172,13 @@ function resolveDiscoveredPluginIngress(
  *
  * Declarations that failed validation are in `problems` and are never
  * servable, regardless of signer.
+ *
+ * The requested path matches a declaration exactly, except that one trailing
+ * slash is ignored. Senders add it: a provider handed `.../events-comms` may
+ * store and call `.../events-comms/`, which is the same resource to them.
+ * Ignoring it cannot widen reach, because `IngressRouteSchema` refuses a
+ * declared path ending in a slash, so `<declared>/` has no other declaration
+ * it could have meant.
  */
 export function findServableRoute(
   resolution: PluginIngressResolution,
@@ -179,8 +186,9 @@ export function findServableRoute(
   path: string,
   kind: IngressRouteKind,
 ): IngressRoute | undefined {
+  const requested = path.endsWith("/") ? path.slice(0, -1) : path;
   const matches = (routes: readonly IngressRoute[]) =>
-    routes.find((route) => route.kind === kind && route.path === path);
+    routes.find((route) => route.kind === kind && route.path === requested);
 
   const approved = resolution.approved.find((d) => d.plugin === plugin);
   const fromApproved = approved && matches(approved.routes);

--- a/gateway/src/http/routes/plugin-webhook.test.ts
+++ b/gateway/src/http/routes/plugin-webhook.test.ts
@@ -136,6 +136,30 @@ describe("approved routes", () => {
 
     expect(calls[0]!.url).toContain("?token=abc");
   });
+
+  it("serves a trailing-slash request under the declared path", async () => {
+    // Providers store the URL we hand them and may call it back with a
+    // slash appended. The plugin serves what it declared, so the forward
+    // uses the declared spelling rather than the requested one.
+    const { calls, fetchImpl } = recordingFetch();
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      credentials: CREDENTIALS,
+      resolve: () => approvedWith([ROUTE]),
+      fetchImpl,
+    });
+
+    const res = await handle(
+      post("/webhooks/plugins/meeting-bot/realtime/", '{"event":"joined"}'),
+      "meeting-bot",
+      "realtime/",
+    );
+
+    expect(res.status).toBe(200);
+    expect(calls[0]!.url).toBe(
+      "http://runtime.test:7821/v1/x/plugins/meeting-bot/realtime",
+    );
+  });
 });
 
 describe("the gate", () => {
@@ -295,7 +319,6 @@ describe("the gate", () => {
       "realtime/../../secret",
       "realtime%2fextra",
       "REALTIME",
-      "realtime/",
     ]) {
       const res = await handle(
         post(`/webhooks/plugins/meeting-bot/${path}`),

--- a/gateway/src/http/routes/plugin-webhook.ts
+++ b/gateway/src/http/routes/plugin-webhook.ts
@@ -98,12 +98,12 @@ export interface PluginWebhookHandlerDeps {
 /**
  * Handle `/webhooks/plugins/:plugin/:path`.
  *
- * The requested path must equal a servable route's declared path. Matching
- * is exact rather than prefix-based: a declaration covers the paths it
- * listed, so serving `<declared>/anything` would hand out reach nobody
- * granted. Exact matching also disposes of traversal, since no `..` segment
- * equals a declared path, and of percent-encoded spellings, which fail
- * closed rather than being decoded into a match.
+ * The requested path must equal a servable route's declared path, up to one
+ * trailing slash. Matching is exact rather than prefix-based: a declaration
+ * covers the paths it listed, so serving `<declared>/anything` would hand out
+ * reach nobody granted. Exact matching also disposes of traversal, since no
+ * `..` segment equals a declared path, and of percent-encoded spellings,
+ * which fail closed rather than being decoded into a match.
  */
 export function createPluginWebhookHandler(deps: PluginWebhookHandlerDeps) {
   const { config, resolve, credentials, fetchImpl } = deps;
@@ -193,7 +193,9 @@ export function createPluginWebhookHandler(deps: PluginWebhookHandlerDeps) {
       return Response.json({ error: "Forbidden" }, { status: 403 });
     }
 
-    const upstreamPath = pluginRouteUpstreamPath(plugin, path);
+    // Forward under the declared path, not the requested spelling: matching
+    // ignores a trailing slash, and the plugin serves the path it declared.
+    const upstreamPath = pluginRouteUpstreamPath(plugin, route.path);
     const search = new URL(req.url).search;
     const start = performance.now();
     // The body is already drained, so hand the proxy a request carrying the


### PR DESCRIPTION
## Why

Comms delivers `comms.ping` to `/webhooks/plugins/imessage/events-comms/` and gets a 404 back, so the line never reaches the assistant.

The slash is the whole bug. `PLUGIN_WEBHOOK_PATH_PATTERN`'s second group is `(.+)`, so it captures `events-comms/` including the slash; `findServableRoute` then compares that with `===` against the declared `events-comms`, finds nothing, and the handler 404s — indistinguishable from a route nobody declared, which is exactly the case the gate is quiet about.

The slash originates with us, not with Comms. `registerCallbackRoute` returns a slash-terminated `callback_url` (the platform's own routing convention), `resolveWebhookUrl` passes it straight through, the plugin registers it, and Comms delivers to the address it was given.

## What changed

**Gateway — tolerate it.** `findServableRoute` drops one trailing slash off the requested path before matching. This cannot widen reach: `IngressRouteSchema` refuses a declared path ending in a slash, so `<declared>/` has no other declaration it could have meant. Both the HTTP handler and the WebSocket upgrade resolve through that one function, so a single change covers both. The HTTP forward now composes the upstream path from `route.path` rather than the requested spelling, so the plugin is called at the path it declared.

**Assistant — stop emitting it.** `resolveWebhookUrl` trims the trailing slash off what `resolveCallbackUrl` returns, so a plugin hands the vendor a URL that is correct on its own rather than one that depends on the gateway being lenient. A URL carrying a query or fragment is left alone, since trimming there would cut into the query rather than the path.

Registrations already stored on a provider's side keep working via the gateway half; new ones are clean via the assistant half.

## Tests

- `findServableRoute` matches `hook/` against a declared `hook`, and still refuses `hook//`, `hook/more`, `hook/more/`.
- The webhook handler serves a trailing-slash request and forwards it to `/v1/x/plugins/meeting-bot/realtime`.
- The existing "does not carry its subtree" case keeps `realtime/extra`, `realtime/../../secret`, `realtime%2fextra` and `REALTIME` as 404s; `realtime/` moved out of that list into the case above, which is the behaviour change.
- `resolveWebhookUrl` returns a slash-free URL, and leaves a query-carrying URL untouched.

Two pre-existing failures in `gateway/src/channels` + `gateway/src/http/routes` reproduce unchanged on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013p1nTdvsuAtTJ7zyCSDLbx

---
_Generated by [Claude Code](https://claude.ai/code/session_013p1nTdvsuAtTJ7zyCSDLbx)_