### PR TITLE
feat(web): open the assistant chooser to platform and remote-gateway modes with remembered-origin cards

### DIFF
--- a/clients/web/src/assistant/selection.ts
+++ b/clients/web/src/assistant/selection.ts
@@ -70,7 +70,7 @@ export function resolveSelectedAssistantId(
  * must agree with the lifecycle on which assistant is selected. Honors the
  * stored selection when the multi-platform-assistant flag is on, or when the
  * assistant-switcher flag is on (its chooser stores the same selection and
- * now runs on local clients and the platform hub alike).
+ * runs on local clients and the platform hub alike).
  * Gateway-auth mode and a missing org id return null, as does a closed gate:
  * callers apply their own fallback. The org id comes from the same derivation
  * the `Vellum-Organization-Id` header uses (the resolved selection, or the

--- a/clients/web/src/assistant/selection.ts
+++ b/clients/web/src/assistant/selection.ts
@@ -15,7 +15,6 @@
 import { isGatewayAuthMode } from "@/lib/auth/gateway-session";
 import {
   getActiveAssistant,
-  isLocalClient,
   setActiveLockfileAssistant,
 } from "@/lib/local-mode";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
@@ -70,8 +69,8 @@ export function resolveSelectedAssistantId(
  * Reactive, flag-gated read of the selection, shared by every consumer that
  * must agree with the lifecycle on which assistant is selected. Honors the
  * stored selection when the multi-platform-assistant flag is on, or when the
- * assistant-switcher flag is on for a local client (its Switch Assistant
- * chooser stores the same selection, and the switcher is local-client-only).
+ * assistant-switcher flag is on (its chooser stores the same selection and
+ * now runs on local clients and the platform hub alike).
  * Gateway-auth mode and a missing org id return null, as does a closed gate:
  * callers apply their own fallback. The org id comes from the same derivation
  * the `Vellum-Organization-Id` header uses (the resolved selection, or the
@@ -90,9 +89,11 @@ export function useGatedSelectedAssistantId(): string | null {
   useResolvedAssistantsStore.use.selectedAssistantId();
   useResolvedAssistantsStore.use.assistants();
   useResolvedAssistantsStore.use.assistantsHydrated();
+  // assistant-switcher opens the gate on every surface that hosts the
+  // chooser (local clients and the platform hub); gateway-auth mode always
+  // resolves null regardless.
   const gateOpen =
-    (multiAssistantEnabled || (assistantSwitcherEnabled && isLocalClient())) &&
-    !isGatewayAuthMode();
+    (multiAssistantEnabled || assistantSwitcherEnabled) && !isGatewayAuthMode();
   return gateOpen && organizationId
     ? resolveSelectedAssistantId(organizationId)
     : null;

--- a/clients/web/src/assistant/switch-origin.ts
+++ b/clients/web/src/assistant/switch-origin.ts
@@ -1,0 +1,35 @@
+/**
+ * Origin switching for the assistant chooser. A remembered origin is a
+ * separate SPA deployment, so selecting one is a full navigation to that
+ * base, not an in-app route change. Kept dependency-light: native shells
+ * fork this module for their own navigation primitive.
+ */
+
+import { remoteGatewayPublicBaseUrl } from "@/lib/auth/remote-gateway-session";
+import { isRemoteGatewayMode } from "@/lib/local-mode";
+import {
+  normalizeOriginUrl,
+  type RememberedOrigin,
+} from "@/stores/remembered-origins-store";
+import { routes } from "@/utils/routes";
+
+/**
+ * Navigate to the SPA root at the origin's base. An unpaired or expired
+ * session bounces to that origin's own pair page via its resolver, which is
+ * the intended degraded state.
+ */
+export function switchToOrigin(origin: RememberedOrigin): void {
+  window.location.assign(`${origin.url}${routes.assistant}`);
+}
+
+/**
+ * Whether `origin` is the deployment serving the running app. In
+ * remote-gateway mode the app's base carries the public path prefix, so the
+ * comparison includes it.
+ */
+export function isCurrentOrigin(origin: RememberedOrigin): boolean {
+  const currentBase = isRemoteGatewayMode()
+    ? remoteGatewayPublicBaseUrl()
+    : window.location.origin;
+  return normalizeOriginUrl(origin.url) === currentBase;
+}

--- a/clients/web/src/components/remove-from-device-dialog.tsx
+++ b/clients/web/src/components/remove-from-device-dialog.tsx
@@ -3,9 +3,10 @@ import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialo
 /**
  * Shared "Remove from this device?" confirmation, mounted by both the
  * assistant chooser and the tray-command handler in `RootLayout` so the copy
- * cannot drift. A paired entry is a pairing record on this machine and a
- * platform entry is a device-local listing; neither removal touches the
- * assistant itself, which is what the per-kind copy explains.
+ * cannot drift. A paired entry is a pairing record on this machine, a
+ * platform entry is a device-local listing, and an origin entry is a
+ * remembered remote address; no removal touches the assistant itself, which
+ * is what the per-kind copy explains.
  */
 export function RemoveFromDeviceDialog({
   open,
@@ -17,8 +18,11 @@ export function RemoveFromDeviceDialog({
   onCancel,
 }: {
   open: boolean;
-  /** Which removal copy applies: a pairing or a platform listing. */
-  kind: "paired" | "platform";
+  /**
+   * Which removal copy applies: a pairing, a platform listing, or a
+   * remembered remote origin.
+   */
+  kind: "paired" | "platform" | "origin";
   assistantName: string;
   /** Inline failure line under the message when a removal attempt failed. */
   errorMessage?: string;
@@ -37,6 +41,11 @@ export function RemoveFromDeviceDialog({
               This won&rsquo;t affect {assistantName} on its host machine. It
               only forgets the pairing on this device. Pair again anytime with
               vellum connect import.
+            </>
+          ) : kind === "origin" ? (
+            <>
+              This won&rsquo;t affect {assistantName} or sign you out there. It
+              only forgets the entry on this device. Add it again anytime.
             </>
           ) : (
             <>

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
@@ -1033,4 +1033,15 @@ describe("SelectAssistantScreen platform-mode gate", () => {
 
     await waitFor(() => expect(navigateMock).toHaveBeenCalledWith("/assistant"));
   });
+
+  test("hides the local-only create action on non-local clients", async () => {
+    assistantSwitcherValue = true;
+
+    render(<SelectAssistantScreen />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Choose an Assistant")).toBeTruthy(),
+    );
+    expect(screen.queryByText("Create a new assistant")).toBeNull();
+  });
 });

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
@@ -34,6 +34,7 @@ let isLocalClientValue = true;
 let assistantSwitcherValue = false;
 let flagsHydratedValue = true;
 let originsValue: RememberedOrigin[] = [];
+let originsHydratedValue = true;
 /** The origin url `isCurrentOrigin` reports as the serving deployment. */
 let currentOriginUrl: string | null = null;
 let activeAssistantIdValue: string | null = null;
@@ -125,7 +126,10 @@ mock.module("@/stores/client-feature-flag-store", () => ({
 
 mock.module("@/stores/remembered-origins-store", () => ({
   useRememberedOriginsStore: {
-    use: { origins: () => originsValue },
+    use: {
+      origins: () => originsValue,
+      hydrated: () => originsHydratedValue,
+    },
     getState: () => ({
       origins: originsValue,
       hydrate: hydrateOriginsMock,
@@ -371,6 +375,7 @@ beforeEach(() => {
   assistantSwitcherValue = false;
   flagsHydratedValue = true;
   originsValue = [];
+  originsHydratedValue = true;
   currentOriginUrl = null;
   hydrateOriginsMock.mockClear();
   removeOriginMock.mockClear();
@@ -981,6 +986,20 @@ describe("SelectAssistantScreen remembered origins", () => {
     await waitFor(() =>
       expect(connectPairedAssistantMock).toHaveBeenCalledWith(PAIRED_ID),
     );
+  });
+
+  test("auto-skip holds until the origins store hydrates when the flag is on", async () => {
+    assistantSwitcherValue = true;
+    originsHydratedValue = false;
+    originsValue = [];
+    assistantsValue = [makePairedAssistant()];
+
+    render(<SelectAssistantScreen />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Choose an Assistant")).toBeTruthy(),
+    );
+    expect(connectPairedAssistantMock).not.toHaveBeenCalled();
   });
 });
 

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
@@ -20,6 +20,7 @@ import {
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { ReactNode } from "react";
 
+import type { RememberedOrigin } from "@/stores/remembered-origins-store";
 import type { ResolvedAssistant } from "@/stores/resolved-assistants-store";
 
 // --- Mutable per-test state, reset in beforeEach ------------------------------
@@ -29,6 +30,12 @@ let searchParams = new URLSearchParams();
 let hasPlatformSessionValue = false;
 let assistantsValue: ResolvedAssistant[] = [];
 let localModeHostAvailableValue = false;
+let isLocalClientValue = true;
+let assistantSwitcherValue = false;
+let flagsHydratedValue = true;
+let originsValue: RememberedOrigin[] = [];
+/** The origin url `isCurrentOrigin` reports as the serving deployment. */
+let currentOriginUrl: string | null = null;
 let activeAssistantIdValue: string | null = null;
 const setActiveAssistantIdMock = mock((id: string | null) => {
   activeAssistantIdValue = id;
@@ -48,6 +55,13 @@ const removePlatformAssistantFromLockfileMock = mock(
 const connectPairedAssistantMock = mock(async (_id: string) => {});
 const connectLocalAssistantMock = mock(async (_id: string) => {});
 const connectPlatformAssistantMock = mock(async (_id: string) => {});
+
+const hydrateOriginsMock = mock(async () => {});
+// Success path mirrors the real store: the removed entry leaves the list.
+const removeOriginMock = mock(async (url: string) => {
+  originsValue = originsValue.filter((o) => o.url !== url);
+});
+const switchToOriginMock = mock((_origin: RememberedOrigin) => {});
 
 // Stands in for the real error class (the screen's `instanceof` check runs
 // against this mocked module's export).
@@ -92,11 +106,38 @@ mock.module("@/lib/local-mode", () => ({
   getLockfileAssistant: () => undefined,
   getSelectedAssistant: () => undefined,
   isCliWakeableAssistant: () => false,
+  isLocalClient: () => isLocalClientValue,
   isPairedAssistant: (a: { cloud?: string }) => a?.cloud === "paired",
   loadLockfile: async () => ({ assistants: [], activeAssistant: null }),
   removePairedAssistantFromLockfile: removePairedAssistantFromLockfileMock,
   removePlatformAssistantFromLockfile: removePlatformAssistantFromLockfileMock,
   UnresolvedLocalGatewayError: MockUnresolvedLocalGatewayError,
+}));
+
+mock.module("@/stores/client-feature-flag-store", () => ({
+  useClientFeatureFlagStore: {
+    use: {
+      assistantSwitcher: () => assistantSwitcherValue,
+      hydrated: () => flagsHydratedValue,
+    },
+  },
+}));
+
+mock.module("@/stores/remembered-origins-store", () => ({
+  useRememberedOriginsStore: {
+    use: { origins: () => originsValue },
+    getState: () => ({
+      origins: originsValue,
+      hydrate: hydrateOriginsMock,
+      removeOrigin: removeOriginMock,
+    }),
+  },
+}));
+
+mock.module("@/assistant/switch-origin", () => ({
+  switchToOrigin: switchToOriginMock,
+  isCurrentOrigin: (origin: RememberedOrigin) =>
+    origin.url === currentOriginUrl,
 }));
 
 mock.module("@/domains/onboarding/components/connect-recovery-dialog", () => ({
@@ -302,32 +343,54 @@ function makePlatformAssistant(
 const REPAIR_COPY =
   "This pairing has expired. Run vellum pair on the assistant's machine and import it again with vellum connect import.";
 
+function makeOrigin(
+  overrides: Partial<RememberedOrigin> = {},
+): RememberedOrigin {
+  return {
+    url: "https://assistant.example.com",
+    name: "Home Server",
+    addedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
 // --- Suite --------------------------------------------------------------------
 
-describe("SelectAssistantScreen paired assistants", () => {
-  beforeEach(() => {
-    navigateMock.mockClear();
-    connectPairedAssistantMock.mockClear();
-    connectPairedAssistantMock.mockImplementation(async () => {});
-    connectLocalAssistantMock.mockClear();
-    connectPlatformAssistantMock.mockClear();
-    searchParams = new URLSearchParams();
-    hasPlatformSessionValue = false;
-    assistantsValue = [];
-    localModeHostAvailableValue = false;
-    isElectronValue = false;
-    removePairedAssistantFromLockfileMock.mockClear();
-    removePairedAssistantFromLockfileMock.mockImplementation(async () => ({
-      ok: true,
-    }));
-    removePlatformAssistantFromLockfileMock.mockClear();
-    activeAssistantIdValue = null;
-    setActiveAssistantIdMock.mockClear();
-    __resetConnectDialogForTesting();
+beforeEach(() => {
+  navigateMock.mockClear();
+  connectPairedAssistantMock.mockClear();
+  connectPairedAssistantMock.mockImplementation(async () => {});
+  connectLocalAssistantMock.mockClear();
+  connectPlatformAssistantMock.mockClear();
+  searchParams = new URLSearchParams();
+  hasPlatformSessionValue = false;
+  assistantsValue = [];
+  localModeHostAvailableValue = false;
+  isElectronValue = false;
+  isLocalClientValue = true;
+  assistantSwitcherValue = false;
+  flagsHydratedValue = true;
+  originsValue = [];
+  currentOriginUrl = null;
+  hydrateOriginsMock.mockClear();
+  removeOriginMock.mockClear();
+  removeOriginMock.mockImplementation(async (url: string) => {
+    originsValue = originsValue.filter((o) => o.url !== url);
   });
+  switchToOriginMock.mockClear();
+  removePairedAssistantFromLockfileMock.mockClear();
+  removePairedAssistantFromLockfileMock.mockImplementation(async () => ({
+    ok: true,
+  }));
+  removePlatformAssistantFromLockfileMock.mockClear();
+  activeAssistantIdValue = null;
+  setActiveAssistantIdMock.mockClear();
+  __resetConnectDialogForTesting();
+});
 
-  afterEach(cleanup);
+afterEach(cleanup);
 
+describe("SelectAssistantScreen paired assistants", () => {
   test("a paired card renders unlocked with the paired subtitle and no login button while logged out", () => {
     assistantsValue = [makePairedAssistant(), makePlatformAssistant()];
 
@@ -770,5 +833,204 @@ describe("SelectAssistantScreen paired assistants", () => {
       ),
     );
     expect(removePairedAssistantFromLockfileMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("SelectAssistantScreen remembered origins", () => {
+  test("origin cards render from the store when the assistant-switcher flag is on", () => {
+    assistantSwitcherValue = true;
+    originsValue = [makeOrigin()];
+    assistantsValue = [makePairedAssistant(), makePlatformAssistant()];
+
+    render(<SelectAssistantScreen />);
+
+    expect(screen.getByText("Home Server")).toBeTruthy();
+    expect(
+      screen.getByText("Remote · assistant.example.com"),
+    ).toBeTruthy();
+    expect(hydrateOriginsMock).toHaveBeenCalled();
+  });
+
+  test("no origin UI renders with the flag off, even with stored origins", () => {
+    originsValue = [makeOrigin()];
+    assistantsValue = [makePairedAssistant(), makePlatformAssistant()];
+
+    render(<SelectAssistantScreen />);
+
+    expect(screen.queryByText("Home Server")).toBeNull();
+    expect(screen.queryByText(/assistant\.example\.com/)).toBeNull();
+    expect(hydrateOriginsMock).not.toHaveBeenCalled();
+  });
+
+  test("an unnamed origin falls back to its hostname as the title", () => {
+    assistantSwitcherValue = true;
+    originsValue = [makeOrigin({ name: undefined })];
+    assistantsValue = [makePairedAssistant(), makePlatformAssistant()];
+
+    render(<SelectAssistantScreen />);
+
+    expect(screen.getByText("assistant.example.com")).toBeTruthy();
+  });
+
+  test("Continue on a selected origin card performs the origin switch", async () => {
+    assistantSwitcherValue = true;
+    originsValue = [makeOrigin()];
+    assistantsValue = [makePairedAssistant(), makePlatformAssistant()];
+
+    render(<SelectAssistantScreen />);
+
+    fireEvent.click(screen.getByText("Home Server"));
+    fireEvent.click(screen.getByText("Continue"));
+
+    await waitFor(() =>
+      expect(switchToOriginMock).toHaveBeenCalledWith(
+        expect.objectContaining({ url: "https://assistant.example.com" }),
+      ),
+    );
+    expect(connectPairedAssistantMock).not.toHaveBeenCalled();
+    expect(connectPlatformAssistantMock).not.toHaveBeenCalled();
+  });
+
+  test("the current-origin card shows Current and Continue stays in-app", async () => {
+    assistantSwitcherValue = true;
+    currentOriginUrl = "https://assistant.example.com";
+    originsValue = [makeOrigin()];
+    assistantsValue = [makePairedAssistant(), makePlatformAssistant()];
+
+    render(<SelectAssistantScreen />);
+
+    expect(
+      screen.getByText("Current · assistant.example.com"),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByText("Home Server"));
+    fireEvent.click(screen.getByText("Continue"));
+
+    await waitFor(() =>
+      expect(navigateMock).toHaveBeenCalledWith("/assistant", {
+        replace: true,
+      }),
+    );
+    expect(switchToOriginMock).not.toHaveBeenCalled();
+  });
+
+  test("removing an origin shows the origin copy and forgets the entry", async () => {
+    assistantSwitcherValue = true;
+    originsValue = [makeOrigin()];
+    assistantsValue = [makePairedAssistant(), makePlatformAssistant()];
+
+    render(<SelectAssistantScreen />);
+
+    fireEvent.click(screen.getByLabelText("Actions for Home Server"));
+    fireEvent.click(screen.getByText("Remove from this device…"));
+
+    expect(
+      screen.getByText(/It only forgets the entry on this device/),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByText("Confirm remove"));
+
+    await waitFor(() =>
+      expect(removeOriginMock).toHaveBeenCalledWith(
+        "https://assistant.example.com",
+      ),
+    );
+  });
+
+  test("a persistence failure keeps the dialog open with an error", async () => {
+    assistantSwitcherValue = true;
+    originsValue = [makeOrigin()];
+    assistantsValue = [makePairedAssistant(), makePlatformAssistant()];
+    // The store's removeOrigin resolves silently on failure and leaves the
+    // entry listed, which is the screen's failure signal.
+    removeOriginMock.mockImplementation(async () => {});
+
+    render(<SelectAssistantScreen />);
+
+    fireEvent.click(screen.getByLabelText("Actions for Home Server"));
+    fireEvent.click(screen.getByText("Remove from this device…"));
+    fireEvent.click(screen.getByText("Confirm remove"));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("Failed to remove. Please try again."),
+      ).toBeTruthy(),
+    );
+  });
+
+  test("a flagged origin suppresses the sole-assistant auto-skip", async () => {
+    assistantSwitcherValue = true;
+    originsValue = [makeOrigin()];
+    assistantsValue = [makePairedAssistant()];
+
+    render(<SelectAssistantScreen />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Choose an Assistant")).toBeTruthy(),
+    );
+    expect(connectPairedAssistantMock).not.toHaveBeenCalled();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  test("with the flag off, stored origins leave the auto-skip untouched", async () => {
+    originsValue = [makeOrigin()];
+    assistantsValue = [makePairedAssistant()];
+
+    render(<SelectAssistantScreen />);
+
+    await waitFor(() =>
+      expect(connectPairedAssistantMock).toHaveBeenCalledWith(PAIRED_ID),
+    );
+  });
+});
+
+describe("SelectAssistantScreen platform-mode gate", () => {
+  beforeEach(() => {
+    isLocalClientValue = false;
+    hasPlatformSessionValue = true;
+    assistantsValue = [makePlatformAssistant()];
+  });
+
+  test("holds on the connecting state until the flag hydrates", () => {
+    flagsHydratedValue = false;
+
+    render(<SelectAssistantScreen />);
+
+    expect(screen.getByText("Connecting to your assistant…")).toBeTruthy();
+    expect(screen.queryByText("Choose an Assistant")).toBeNull();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  test("redirects to /assistant once hydration lands with the flag off", async () => {
+    render(<SelectAssistantScreen />);
+
+    await waitFor(() =>
+      expect(navigateMock).toHaveBeenCalledWith("/assistant", {
+        replace: true,
+      }),
+    );
+    expect(screen.queryByText("Choose an Assistant")).toBeNull();
+  });
+
+  test("with the flag on the hub renders the chooser and never auto-connects", async () => {
+    assistantSwitcherValue = true;
+
+    render(<SelectAssistantScreen />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Choose an Assistant")).toBeTruthy(),
+    );
+    expect(connectPlatformAssistantMock).not.toHaveBeenCalled();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  test("Back leaves for /assistant instead of the local-only welcome", async () => {
+    assistantSwitcherValue = true;
+
+    render(<SelectAssistantScreen />);
+
+    fireEvent.click(screen.getByText("Back"));
+
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledWith("/assistant"));
   });
 });

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -106,6 +106,7 @@ export function SelectAssistantScreen() {
   const assistantSwitcher = useClientFeatureFlagStore.use.assistantSwitcher();
   const flagsHydrated = useClientFeatureFlagStore.use.hydrated();
   const origins = useRememberedOriginsStore.use.origins();
+  const originsHydrated = useRememberedOriginsStore.use.hydrated();
   // Origin-UI gate: every remembered-origin surface renders only behind the
   // flag, in every mode, so the flag-off screen is pixel-identical to a
   // build without origin support.
@@ -439,7 +440,11 @@ export function SelectAssistantScreen() {
       return;
     }
     // Remembered origins are alternatives a sole assistant does not account
-    // for, so the chooser stays up whenever any exist.
+    // for, so the chooser stays up whenever any exist. Persisted entries
+    // publish only after hydration, so hold the skip until then.
+    if (assistantSwitcher && !originsHydrated) {
+      return;
+    }
     if (originEntries.length > 0) {
       return;
     }
@@ -466,6 +471,8 @@ export function SelectAssistantScreen() {
     deepLinkDrainSettled,
     localClient,
     originEntries.length,
+    assistantSwitcher,
+    originsHydrated,
   ]);
 
   const onContinue = () => {

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -593,16 +593,18 @@ export function SelectAssistantScreen() {
               />
             );
           })}
-          <DashedActionButton
-            icon={<Plus className="h-4 w-4" />}
-            label="Create a new assistant"
-            disabled={connecting || loginLoading}
-            onClick={() =>
-              void navigate(
-                `${routes.onboarding.hosting}?from=select-assistant`,
-              )
-            }
-          />
+          {isLocalClient() && (
+            <DashedActionButton
+              icon={<Plus className="h-4 w-4" />}
+              label="Create a new assistant"
+              disabled={connecting || loginLoading}
+              onClick={() =>
+                void navigate(
+                  `${routes.onboarding.hosting}?from=select-assistant`,
+                )
+              }
+            />
+          )}
           {localModeHostAvailable && (
             <DashedActionButton
               icon={<Link2 className="h-4 w-4" />}

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -2,6 +2,7 @@ import {
   Check,
   Cloud,
   EllipsisVertical,
+  Globe,
   Laptop,
   Link2,
   Plus,
@@ -11,6 +12,7 @@ import { useNavigate, useSearchParams } from "react-router";
 
 import { resolveSelectedAssistantId } from "@/assistant/selection";
 import { retireAssistant } from "@/assistant/retire-service";
+import { isCurrentOrigin, switchToOrigin } from "@/assistant/switch-origin";
 import { removePairedAssistant } from "@/assistant/switch-service";
 import { RemoveFromDeviceDialog } from "@/components/remove-from-device-dialog";
 import {
@@ -19,6 +21,7 @@ import {
 } from "@/lib/auth/gateway-session";
 import {
   isCliWakeableAssistant,
+  isLocalClient,
   removePlatformAssistantFromLockfile,
   UnresolvedLocalGatewayError,
 } from "@/lib/local-mode";
@@ -35,8 +38,13 @@ import {
   wakeLocalAssistantHost,
 } from "@/runtime/local-mode-host";
 import { useAuthStore, useHasPlatformSession } from "@/stores/auth-store";
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { useConnectDialogStore } from "@/stores/connect-dialog-store";
 import { useOrganizationStore } from "@/stores/organization-store";
+import {
+  useRememberedOriginsStore,
+  type RememberedOrigin,
+} from "@/stores/remembered-origins-store";
 import {
   useResolvedAssistantsStore,
   type ResolvedAssistant,
@@ -68,16 +76,40 @@ function assistantSubtitle(a: ResolvedAssistant): string {
   return `${hosting} · Created ${formatRelativeDate(a.hatchedAt)}`;
 }
 
+function originLabel(origin: RememberedOrigin): string {
+  return origin.name ?? new URL(origin.url).hostname;
+}
+
+/**
+ * Selection key for a remembered-origin card in the shared radio group.
+ * Assistant ids never carry a scheme, so the prefixed url cannot collide.
+ */
+function originSelectionKey(origin: RememberedOrigin): string {
+  return `origin:${origin.url}`;
+}
+
+// Stable empty list for the flag-off render so effects keyed on the origin
+// entries do not re-run every render.
+const NO_ORIGINS: RememberedOrigin[] = [];
+
 export function SelectAssistantScreen() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const fromLogin = searchParams.get("fromLogin") === "1";
   const noAutoSkip = searchParams.get("noAutoSkip") === "1";
   const electron = isElectron();
+  const localClient = isLocalClient();
   const hasPlatformSession = useHasPlatformSession();
   const assistants = useResolvedAssistantsStore.use.assistants();
   const currentOrganizationId =
     useOrganizationStore.use.currentOrganizationId();
+  const assistantSwitcher = useClientFeatureFlagStore.use.assistantSwitcher();
+  const flagsHydrated = useClientFeatureFlagStore.use.hydrated();
+  const origins = useRememberedOriginsStore.use.origins();
+  // Origin-UI gate: every remembered-origin surface renders only behind the
+  // flag, in every mode, so the flag-off screen is pixel-identical to a
+  // build without origin support.
+  const originEntries = assistantSwitcher ? origins : NO_ORIGINS;
   const {
     loading: loginLoading,
     error: loginError,
@@ -89,6 +121,10 @@ export function SelectAssistantScreen() {
     a.isLocal || a.isPaired || hasPlatformSession;
 
   const accessibleAssistants = assistants.filter(isAccessible);
+  // Origin cards are always selectable, so either kind of entry gives
+  // Continue something to act on.
+  const hasSelectableEntries =
+    accessibleAssistants.length > 0 || originEntries.length > 0;
 
   // Unpairing and importing a pairing bundle both rewrite the lockfile
   // through the local-mode host, and a pairing is device-local regardless of
@@ -115,6 +151,13 @@ export function SelectAssistantScreen() {
   );
   const [removePending, setRemovePending] = useState(false);
   const [removeError, setRemoveError] = useState<string | null>(null);
+  // Target of the remembered-origin removal confirmation dialog.
+  const [removeOriginTarget, setRemoveOriginTarget] =
+    useState<RememberedOrigin | null>(null);
+  const [removeOriginPending, setRemoveOriginPending] = useState(false);
+  const [removeOriginError, setRemoveOriginError] = useState<string | null>(
+    null,
+  );
   // The "Connect a remote assistant" paste-a-bundle dialog. Store-driven
   // rather than local state so a `<scheme>://connect` deep link parked by
   // the global consumer opens it on mount, carrying a bundle prefill or
@@ -131,11 +174,36 @@ export function SelectAssistantScreen() {
   // the auto-skip stands down for the rest of the visit.
   const removedThisVisitRef = useRef(false);
 
+  // Platform-mode access gate: the hub chooser exists only behind the
+  // assistant-switcher flag, whose real value lands asynchronously, so a
+  // flag-off decision waits for hydration before bouncing. Local clients
+  // (including the packaged remote-gateway dist) skip this gate.
+  const platformGateBlocked =
+    !localClient && (!flagsHydrated || !assistantSwitcher);
+  useEffect(() => {
+    if (!localClient && flagsHydrated && !assistantSwitcher) {
+      void navigate(routes.assistant, { replace: true });
+    }
+  }, [localClient, flagsHydrated, assistantSwitcher, navigate]);
+
+  useEffect(() => {
+    if (assistantSwitcher) {
+      void useRememberedOriginsStore.getState().hydrate();
+    }
+  }, [assistantSwitcher]);
+
   // Default selection: the app's known selected assistant when accessible,
   // else the first accessible assistant. Also reconciles an existing
   // selection that stops being accessible (an in-place logout locks the
-  // platform cards), so Continue can never target a locked assistant.
+  // platform cards), so Continue can never target a locked assistant. A
+  // selected remembered origin needs no session, so it stands.
   useEffect(() => {
+    if (
+      selected != null &&
+      originEntries.some((o) => originSelectionKey(o) === selected)
+    ) {
+      return;
+    }
     if (accessibleAssistants.length === 0) {
       if (selected != null) {
         setSelected(null);
@@ -151,7 +219,7 @@ export function SelectAssistantScreen() {
     const resolved = resolveSelectedAssistantId(currentOrganizationId);
     const match = accessibleAssistants.find((a) => a.id === resolved);
     setSelected(match?.id ?? accessibleAssistants[0].id);
-  }, [selected, accessibleAssistants, currentOrganizationId]);
+  }, [selected, accessibleAssistants, currentOrganizationId, originEntries]);
 
   const handleConnect = async (assistant: ResolvedAssistant) => {
     setConnecting(true);
@@ -312,6 +380,35 @@ export function SelectAssistantScreen() {
     setRemovePending(false);
   };
 
+  const closeRemoveOriginDialog = () => {
+    if (removeOriginPending) {
+      return;
+    }
+    setRemoveOriginTarget(null);
+    setRemoveOriginError(null);
+  };
+
+  const handleRemoveOriginConfirm = async () => {
+    if (!removeOriginTarget || removeOriginPending) {
+      return;
+    }
+    setRemoveOriginPending(true);
+    setRemoveOriginError(null);
+    await useRememberedOriginsStore.getState().removeOrigin(removeOriginTarget.url);
+    // removeOrigin resolves silently on a persistence failure, so the entry
+    // still being listed is the failure signal.
+    const stillListed = useRememberedOriginsStore
+      .getState()
+      .origins.some((o) => o.url === removeOriginTarget.url);
+    if (stillListed) {
+      setRemoveOriginError("Failed to remove. Please try again.");
+    } else {
+      removedThisVisitRef.current = true;
+      setRemoveOriginTarget(null);
+    }
+    setRemoveOriginPending(false);
+  };
+
   const handleImported = (assistantId: string) => {
     useConnectDialogStore.getState().closeConnectDialog();
     // The import refreshes the lockfile before resolving, so the store already
@@ -337,6 +434,15 @@ export function SelectAssistantScreen() {
     if (fromLogin || noAutoSkip || removedThisVisitRef.current) {
       return;
     }
+    // The platform hub always shows the chooser rather than auto-connecting.
+    if (!localClient) {
+      return;
+    }
+    // Remembered origins are alternatives a sole assistant does not account
+    // for, so the chooser stays up whenever any exist.
+    if (originEntries.length > 0) {
+      return;
+    }
     // On a cold Electron start the buffered deep links publish after mount;
     // hold the skip until the drain settles so a parked connect link wins
     // (it opens the dialog, which stands the auto-skip down below).
@@ -354,9 +460,26 @@ export function SelectAssistantScreen() {
       void handleConnect(accessibleAssistants[0]);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [assistants.length, accessibleAssistants.length, deepLinkDrainSettled]);
+  }, [
+    assistants.length,
+    accessibleAssistants.length,
+    deepLinkDrainSettled,
+    localClient,
+    originEntries.length,
+  ]);
 
   const onContinue = () => {
+    const origin = originEntries.find(
+      (o) => originSelectionKey(o) === selected,
+    );
+    if (origin) {
+      if (isCurrentOrigin(origin)) {
+        void navigate(routes.assistant, { replace: true });
+      } else {
+        switchToOrigin(origin);
+      }
+      return;
+    }
     const assistant = assistants.find((a) => a.id === selected);
     if (assistant) {
       void handleConnect(assistant);
@@ -364,23 +487,23 @@ export function SelectAssistantScreen() {
   };
 
   const onBack = () => {
-    void navigate(routes.welcome);
+    // welcome is local-only; the platform hub's way back is the app itself.
+    void navigate(localClient ? routes.welcome : routes.assistant);
   };
 
   const displayError = loginError ?? error;
 
+  // Holding state while the platform gate waits on flag hydration (and while
+  // the flag-off redirect above lands), so a direct URL on the cloud origin
+  // shows nothing new when the flag is off.
+  if (platformGateBlocked) {
+    return <ConnectingHold />;
+  }
+
   // Loading state during auto-skip. A pending recovery falls through to the
   // chooser so the dialog can render.
   if (autoSkipping && !displayError && !recoveryAssistant) {
-    return (
-      <OnboardingLayout>
-        <div className="mx-auto flex min-h-screen w-full max-w-xl flex-col items-center justify-center px-6 text-[var(--content-default)]">
-          <p className="text-body-medium-lighter text-[var(--content-tertiary)]">
-            Connecting to your assistant…
-          </p>
-        </div>
-      </OnboardingLayout>
-    );
+    return <ConnectingHold />;
   }
 
   return (
@@ -452,6 +575,24 @@ export function SelectAssistantScreen() {
               />
             );
           })}
+          {originEntries.map((origin, index) => {
+            const key = originSelectionKey(origin);
+            return (
+              <RemoteOriginCard
+                key={origin.url}
+                origin={origin}
+                selected={selected === key}
+                current={isCurrentOrigin(origin)}
+                tabStop={
+                  selected == null
+                    ? accessibleAssistants.length === 0 && index === 0
+                    : selected === key
+                }
+                onSelect={() => setSelected(key)}
+                onRemove={() => setRemoveOriginTarget(origin)}
+              />
+            );
+          })}
           <DashedActionButton
             icon={<Plus className="h-4 w-4" />}
             label="Create a new assistant"
@@ -474,7 +615,7 @@ export function SelectAssistantScreen() {
           )}
         </div>
 
-        {accessibleAssistants.length > 0 && (
+        {hasSelectableEntries && (
           <div
             className="mt-8 w-full"
             style={{ animation: "fadeInUp 0.5s ease-out 0.4s both" }}
@@ -492,7 +633,7 @@ export function SelectAssistantScreen() {
           </div>
         )}
         <div
-          className={accessibleAssistants.length > 0 ? "mt-3" : "mt-8"}
+          className={hasSelectableEntries ? "mt-3" : "mt-8"}
           style={{ animation: "fadeInUp 0.5s ease-out 0.5s both" }}
         >
           <Button
@@ -536,6 +677,30 @@ export function SelectAssistantScreen() {
         onConfirm={() => void handleRemoveConfirm()}
         onCancel={closeRemoveDialog}
       />
+      <RemoveFromDeviceDialog
+        open={removeOriginTarget != null}
+        kind="origin"
+        assistantName={
+          removeOriginTarget ? originLabel(removeOriginTarget) : "the assistant"
+        }
+        errorMessage={removeOriginError ?? undefined}
+        isPending={removeOriginPending}
+        onConfirm={() => void handleRemoveOriginConfirm()}
+        onCancel={closeRemoveOriginDialog}
+      />
+    </OnboardingLayout>
+  );
+}
+
+/** Full-screen "Connecting…" hold shown while a decision or connect lands. */
+function ConnectingHold() {
+  return (
+    <OnboardingLayout>
+      <div className="mx-auto flex min-h-screen w-full max-w-xl flex-col items-center justify-center px-6 text-[var(--content-default)]">
+        <p className="text-body-medium-lighter text-[var(--content-tertiary)]">
+          Connecting to your assistant…
+        </p>
+      </div>
     </OnboardingLayout>
   );
 }
@@ -736,6 +901,128 @@ function AssistantCard({
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+/**
+ * Chooser card for a remembered remote origin, in the `AssistantCard` visual
+ * language. An origin is only an address remembered on this device: it is
+ * always selectable (no session is needed to navigate away), and its menu
+ * removal only forgets the entry here.
+ */
+function RemoteOriginCard({
+  origin,
+  selected,
+  current,
+  tabStop,
+  onSelect,
+  onRemove,
+}: {
+  origin: RememberedOrigin;
+  selected: boolean;
+  /** Whether this origin is the deployment serving the running app. */
+  current: boolean;
+  /** The radiogroup's single roving tab stop lands on this card. */
+  tabStop: boolean;
+  onSelect: () => void;
+  /** Opens the remove-from-this-device confirmation. */
+  onRemove: () => void;
+}) {
+  const electron = isElectron();
+  const hostname = new URL(origin.url).hostname;
+
+  return (
+    <div
+      role="radio"
+      aria-checked={selected}
+      tabIndex={tabStop ? 0 : -1}
+      onClick={onSelect}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onSelect();
+        }
+      }}
+      className={[
+        "group flex w-full items-center border text-left",
+        electron
+          ? "gap-3 rounded-lg px-[10px] py-3"
+          : "gap-4 rounded-2xl px-[18px] py-4",
+        "transition-all duration-200 ease-out",
+        "cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--primary-base)]",
+        selected
+          ? "border-[var(--primary-base)] bg-[var(--surface-lift)]"
+          : "border-[var(--border-base)] bg-[var(--surface-lift)]/60 hover:border-[var(--border-element)] hover:bg-[var(--surface-lift)]",
+      ].join(" ")}
+    >
+      <div
+        className={[
+          "flex shrink-0 items-center justify-center transition-colors duration-200",
+          "h-12 w-12 rounded-[10px]",
+          selected
+            ? "bg-[var(--primary-base)] text-[var(--surface-base)]"
+            : "bg-[var(--surface-active)]/40 text-[var(--content-secondary)]",
+        ].join(" ")}
+      >
+        <Globe className="h-5 w-5" />
+      </div>
+
+      <div className="min-w-0 flex-1">
+        <span className="block text-body-medium-default text-[var(--content-default)]">
+          {originLabel(origin)}
+        </span>
+        <span
+          className={`mt-1 block text-[var(--content-tertiary)] ${electron ? "text-label-medium-default font-normal" : "text-body-small-lighter"}`}
+        >
+          {`${current ? "Current" : "Remote"} · ${hostname}`}
+        </span>
+      </div>
+
+      <div className="flex shrink-0 items-center gap-2">
+        {/* The trigger sits inside the radio card: stop clicks and keys from
+            bubbling so opening the menu never selects the card and the
+            radio's Enter/Space handler never swallows the trigger. */}
+        <div
+          onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => e.stopPropagation()}
+        >
+          <Menu.Root>
+            <Menu.Trigger asChild>
+              <Button
+                variant="ghost"
+                size="regular"
+                className="text-[var(--content-tertiary)]"
+                iconOnly={<EllipsisVertical />}
+                aria-label={`Actions for ${originLabel(origin)}`}
+              />
+            </Menu.Trigger>
+            <Menu.Content align="end" sideOffset={4}>
+              <Menu.Item
+                onSelect={onRemove}
+                className="text-[var(--system-negative-strong)] data-[highlighted]:text-[var(--system-negative-strong)]"
+              >
+                Remove from this device…
+              </Menu.Item>
+            </Menu.Content>
+          </Menu.Root>
+        </div>
+        <div
+          className={[
+            "flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 transition-all duration-200",
+            selected
+              ? "border-[var(--primary-base)] bg-[var(--primary-base)]"
+              : "border-[var(--border-element)] group-hover:border-[var(--content-tertiary)]",
+          ].join(" ")}
+        >
+          {selected && (
+            <Check
+              className="h-3 w-3 text-[var(--surface-base)]"
+              strokeWidth={3}
+            />
+          )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/clients/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.test.ts
@@ -238,14 +238,44 @@ describe("resolveNavigation", () => {
         to: "/assistant",
       });
       expect(
-        guard(s({ isLocalClient: false }), "/assistant/select-assistant"),
-      ).toEqual({ action: "redirect", to: "/assistant" });
-      expect(
         guard(s({ isLocalClient: false }), "/assistant/onboarding/hosting"),
       ).toEqual({ action: "redirect", to: "/assistant" });
       expect(
         guard(s({ isLocalClient: false }), "/assistant/onboarding/api-key"),
       ).toEqual({ action: "redirect", to: "/assistant" });
+    });
+
+    // The platform build hosts the hub chooser: the route admits an
+    // authenticated user in every mode. The assistant-switcher flag gate for
+    // platform-mode access lives in the screen, which can wait on flag
+    // hydration; the resolver has no hydration signal to gate on.
+    test("allows an authenticated non-local user on select-assistant", () => {
+      expect(
+        guard(s({ isLocalClient: false }), "/assistant/select-assistant"),
+      ).toEqual(ALLOW);
+      // The hub shows the chooser even with nothing resolved for this org.
+      expect(
+        guard(
+          s({
+            isLocalClient: false,
+            hasAssistants: false,
+            hasPlatformHostedAssistant: false,
+          }),
+          "/assistant/select-assistant",
+        ),
+      ).toEqual(ALLOW);
+    });
+
+    test("sends an unauthenticated non-local select-assistant visit to login with returnTo", () => {
+      expect(
+        guard(
+          s({ isLocalClient: false, isAuthenticated: false }),
+          "/assistant/select-assistant",
+        ),
+      ).toEqual({
+        action: "redirect",
+        to: "/account/login?returnTo=%2Fassistant%2Fselect-assistant",
+      });
     });
 
     test("allows non-local user on onboarding screens regardless of assistant count", () => {

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -112,10 +112,7 @@ const LOCAL_ONLY_ONBOARDING_PATHS: Set<string> = new Set([
   routes.onboarding.apiKey,
 ]);
 
-const LOCAL_ONLY_STANDALONE_PATHS: Set<string> = new Set([
-  routes.welcome,
-  routes.selectAssistant,
-]);
+const LOCAL_ONLY_STANDALONE_PATHS: Set<string> = new Set([routes.welcome]);
 
 function isOnboardingPath(pathname: string): boolean {
   return (
@@ -514,7 +511,9 @@ function requireAuth(
 
   if (
     state.isLocalClient &&
-    (isOnboardingPath(path) || LOCAL_ONLY_STANDALONE_PATHS.has(path))
+    (isOnboardingPath(path) ||
+      LOCAL_ONLY_STANDALONE_PATHS.has(path) ||
+      path === routes.selectAssistant)
   ) {
     if (path === routes.selectAssistant && !state.hasAssistants) {
       return { action: "redirect", to: routes.onboarding.hosting };
@@ -537,12 +536,21 @@ function enforceModeBoundary(
   state: NavigationState,
   path: string,
 ): NavigationDecision | null {
+  // The chooser is reachable in every mode: local clients keep their
+  // lockfile-driven picker (a no-assistant local visit still funnels to
+  // hosting), and the platform build hosts the hub chooser. The screen owns
+  // the assistant-switcher flag gate for platform-mode access, because the
+  // flag hydrates asynchronously and this resolver has no hydration signal.
+  if (path === routes.selectAssistant) {
+    if (state.isLocalClient && !state.hasAssistants) {
+      return { action: "redirect", to: routes.onboarding.hosting };
+    }
+    return { action: "allow" };
+  }
+
   if (LOCAL_ONLY_STANDALONE_PATHS.has(path)) {
     if (!state.isLocalClient) {
       return { action: "redirect", to: routes.assistant };
-    }
-    if (path === routes.selectAssistant && !state.hasAssistants) {
-      return { action: "redirect", to: routes.onboarding.hosting };
     }
     return { action: "allow" };
   }
@@ -854,7 +862,8 @@ function resolvePostAuth(
 
 function resolvePostRetire(state: NavigationState): NavigationDecision {
   if (state.hasAssistants) {
-    // select-assistant is local-only; platform users go straight to /assistant
+    // Platform users land on /assistant post-retire; the chooser is an
+    // explicit destination there, not the retire landing.
     return {
       action: "redirect",
       to: state.isLocalClient ? routes.selectAssistant : routes.assistant,


### PR DESCRIPTION
## Summary
- selectAssistant leaves LOCAL_ONLY_STANDALONE_PATHS; platform-mode access is flag-gated in the screen (redirects to /assistant when assistant-switcher is off)
- RemoteOriginCard renders remembered origins behind the assistant-switcher flag in every mode; switching navigates to <url>/assistant
- Auto-skip stands down for the platform hub and when flagged origins exist; non-local Back goes to /assistant

Part of plan: origin-model-chooser.md (PR 2 of 7)