### PR TITLE
feat(live-voice): carry the utterance's detected language to the answering model, TTS, and the front model

### DIFF
--- a/assistant/src/calls/__tests__/voice-triage-escalate.test.ts
+++ b/assistant/src/calls/__tests__/voice-triage-escalate.test.ts
@@ -290,6 +290,15 @@ describe("capEscalationBridge", () => {
     expect(capEscalationBridge("[END_CALL] One moment.")).toBe("One moment.");
   });
 
+  test("the Unicode ellipsis still terminates a bridge", () => {
+    // Regression pin: widening the terminator class for non-Latin enders
+    // must not drop the ellipsis the original regex recognized.
+    expect(capEscalationBridge("One moment… and some rambling")).toBe(
+      "One moment…",
+    );
+    expect(isEscalationBridgeComplete("One moment…")).toBe(true);
+  });
+
   test("cuts just after a non-Latin sentence terminator", () => {
     expect(capEscalationBridge("少し考えさせてください。その間の余談")).toBe(
       "少し考えさせてください。",

--- a/assistant/src/calls/__tests__/voice-triage-escalate.test.ts
+++ b/assistant/src/calls/__tests__/voice-triage-escalate.test.ts
@@ -289,6 +289,15 @@ describe("capEscalationBridge", () => {
   test("strips internal markers before capping", () => {
     expect(capEscalationBridge("[END_CALL] One moment.")).toBe("One moment.");
   });
+
+  test("cuts just after a non-Latin sentence terminator", () => {
+    expect(capEscalationBridge("少し考えさせてください。その間の余談")).toBe(
+      "少し考えさせてください。",
+    );
+    expect(capEscalationBridge("मुझे एक पल सोचने दीजिए। और कुछ बातें")).toBe(
+      "मुझे एक पल सोचने दीजिए।",
+    );
+  });
 });
 
 describe("isEscalationBridgeComplete", () => {
@@ -303,6 +312,23 @@ describe("isEscalationBridgeComplete", () => {
     expect(
       isEscalationBridgeComplete("a".repeat(MAX_ESCALATION_BRIDGE_CHARS)),
     ).toBe(true);
+  });
+
+  test("a Japanese bridge ending in 。 completes without waiting for the cap", () => {
+    expect(isEscalationBridgeComplete("少し考えさせてください")).toBe(false);
+    expect(isEscalationBridgeComplete("少し考えさせてください。")).toBe(true);
+  });
+
+  test("every localized fallback bridge ends in a recognized terminator", () => {
+    // A model-spoken bridge in any roster language must hand off at its
+    // terminator, never by buffering to the char cap; the canned bridges are
+    // the canonical sample of each language's ender.
+    for (const bridge of Object.values(
+      FALLBACK_ESCALATION_BRIDGE_BY_LANGUAGE,
+    )) {
+      expect(isEscalationBridgeComplete(bridge)).toBe(true);
+      expect(capEscalationBridge(bridge)).toBe(bridge);
+    }
   });
 });
 

--- a/assistant/src/calls/voice-triage-escalate.ts
+++ b/assistant/src/calls/voice-triage-escalate.ts
@@ -108,8 +108,13 @@ export const MIN_SPOKEN_BRIDGE_CHARS = 3;
  */
 export const MAX_ESCALATION_BRIDGE_CHARS = 140;
 
-/** Sentence terminators that end an escalation bridge. */
-const BRIDGE_SENTENCE_END_REGEX = /[.!?…]/;
+/**
+ * Sentence terminators that end an escalation bridge, including the
+ * non-Latin enders the localized bridges use (the set mirrors
+ * tts/speakable-segments.ts). Without them a Japanese or Hindi bridge never
+ * hits a terminator and buffers to the char cap before hand-off.
+ */
+const BRIDGE_SENTENCE_END_REGEX = /[.!?…。｡！？．।॥؟۔]/;
 
 /**
  * Normalize a raw post-`[1]` stream into the bridge that is actually

--- a/assistant/src/live-voice/__tests__/live-voice-events.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-events.test.ts
@@ -260,7 +260,7 @@ describe("LiveVoiceSession archive and metrics events", () => {
       // room-minimize teaching is deliberately absent — only the escalated
       // leg learns it (see live-voice-triage-escalate.test.ts).
       voiceControlPrompt:
-        "You are speaking in a local live voice session. Keep replies brief and conversational. Speech is the main channel: say the answer, and do not narrate a surface instead of answering. You can also put something on screen when it genuinely helps (a form, a list to pick from, a progress card for long work); the call overlay minimizes by itself once you finish speaking, so the user sees it without doing anything. Never tell the user you cannot show them something. " +
+        "You are speaking in a local live voice session. Keep replies brief and conversational. Speech is the main channel: say the answer, and do not narrate a surface instead of answering. You can also put something on screen when it genuinely helps (a form, a list to pick from, a progress card for long work); the call overlay minimizes by itself once you finish speaking, so the user sees it without doing anything. Never tell the user you cannot show them something. Reply in the language the caller is speaking; if they switch languages, switch with them. " +
         VOICE_NO_SETUP_FLOWS_RULE,
     });
     callbacks?.assistant_text_delta?.(makeTextDelta("Hello there."));

--- a/assistant/src/live-voice/__tests__/live-voice-progress.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-progress.test.ts
@@ -14,6 +14,7 @@ import type {
   SttStreamServerEvent,
 } from "../../stt/types.js";
 import type {
+  VoiceAckTextInput,
   VoiceFrontDecider,
   VoiceProgressTextInput,
 } from "../front-decision.js";
@@ -62,6 +63,13 @@ class MockStreamingTranscriber implements StreamingTranscriber {
   readonly boundaryId = "daemon-streaming" as const;
   private onEvent: ((event: SttStreamServerEvent) => void) | null = null;
 
+  constructor(
+    private readonly stopEvents: SttStreamServerEvent[] = [
+      { type: "final", text: "hello" },
+      { type: "closed" },
+    ],
+  ) {}
+
   async start(onEvent: (event: SttStreamServerEvent) => void): Promise<void> {
     this.onEvent = onEvent;
   }
@@ -69,8 +77,9 @@ class MockStreamingTranscriber implements StreamingTranscriber {
   sendAudio(): void {}
 
   stop(): void {
-    this.onEvent?.({ type: "final", text: "hello" });
-    this.onEvent?.({ type: "closed" });
+    for (const event of this.stopEvents) {
+      this.onEvent?.(event);
+    }
   }
 }
 
@@ -166,6 +175,9 @@ function createProgressHarness(options: {
   frontDecider: VoiceFrontDecider;
   emitMetrics?: boolean;
   gateTtsText?: (text: string) => Promise<void> | null;
+  // Events the transcriber flushes at utterance release; defaults to a plain
+  // untagged "hello" final.
+  sttStopEvents?: SttStreamServerEvent[];
 }) {
   const { startVoiceTurn, getCallbacks } = createCapturingTurnStarter();
   const { streamTtsAudio, ttsTexts } = createRecordingTtsStreamer(
@@ -173,7 +185,9 @@ function createProgressHarness(options: {
   );
   const { context, frames } = createContext();
   const session = new LiveVoiceSession(context, {
-    resolveTranscriber: mock(async () => new MockStreamingTranscriber()),
+    resolveTranscriber: mock(
+      async () => new MockStreamingTranscriber(options.sttStopEvents),
+    ),
     startVoiceTurn,
     streamTtsAudio,
     frontModelConfig: options.frontModelConfig,
@@ -478,6 +492,99 @@ describe("LiveVoiceSession progress narration", () => {
     expect(
       PROGRESS_FALLBACK_PHRASES.map((phrase) => sanitizeForTts(phrase).trim()),
     ).toContain(ttsTexts[0]);
+
+    emitMessageComplete(getCallbacks);
+  });
+
+  test("a Hindi turn's idle fallback speaks the Hindi phrase and hints the decider", async () => {
+    const inputs: VoiceProgressTextInput[] = [];
+    const generateProgressText = mock(async (input: VoiceProgressTextInput) => {
+      inputs.push(input);
+      return null;
+    });
+    const { session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: progressConfig({
+        idleIntervalMs: 40,
+        minGapMs: 60_000,
+      }),
+      frontDecider: makeProgressDecider(generateProgressText),
+      sttStopEvents: [
+        { type: "final", text: "नमस्ते", languages: ["hi"] },
+        { type: "closed" },
+      ],
+    });
+
+    await startReleasedTurn(session, getCallbacks);
+    await waitFor(() => ttsTexts.length === 1);
+
+    // The static fallback rotates through the caller's language's list, not
+    // the English default, and the decider was told the language too.
+    expect(pickProgressPhrase(0, "hi")).toBe(
+      PROGRESS_FALLBACK_PHRASES_BY_LANGUAGE.hi![0]!,
+    );
+    expect(ttsTexts).toEqual([
+      sanitizeForTts(pickProgressPhrase(0, "hi")).trim(),
+    ]);
+    expect(inputs[0]?.languageHint).toBe("hi");
+
+    emitMessageComplete(getCallbacks);
+  });
+
+  test("the tool-start ack passes the turn's language hint to the decider", async () => {
+    const ackInputs: VoiceAckTextInput[] = [];
+    const frontDecider: VoiceFrontDecider = {
+      generateAckText: async (input) => {
+        ackInputs.push(input);
+        return GENERATED_TOOL_ACK;
+      },
+      generateProgressText: async () => null,
+    };
+    const { session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: progressConfig(),
+      frontDecider,
+      sttStopEvents: [
+        { type: "final", text: "नमस्ते", languages: ["hi"] },
+        { type: "closed" },
+      ],
+    });
+
+    await startReleasedTurn(session, getCallbacks);
+    emitToolStart(getCallbacks, "web_search", "tool-1");
+    await waitFor(() => ttsTexts.length === 1);
+
+    expect(ackInputs[0]?.languageHint).toBe("hi");
+
+    emitMessageComplete(getCallbacks);
+  });
+
+  test("with no detected language the decider inputs carry no hint and the fallback stays English", async () => {
+    const inputs: VoiceProgressTextInput[] = [];
+    const ackInputs: VoiceAckTextInput[] = [];
+    const frontDecider: VoiceFrontDecider = {
+      generateAckText: async (input) => {
+        ackInputs.push(input);
+        return GENERATED_TOOL_ACK;
+      },
+      generateProgressText: async (input) => {
+        inputs.push(input);
+        return null;
+      },
+    };
+    const { session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: progressConfig({ idleIntervalMs: 40, minGapMs: 10 }),
+      frontDecider,
+    });
+
+    await startReleasedTurn(session, getCallbacks);
+    emitToolStart(getCallbacks, "web_search", "tool-1");
+    await waitFor(() => ttsTexts.length === 1);
+    await waitFor(() => ttsTexts.length === 2);
+
+    // Language unknown: the inputs are exactly the language-blind shape (no
+    // languageHint key at all) and the static fallback is the English list.
+    expect(ackInputs[0]).not.toHaveProperty("languageHint");
+    expect(inputs[0]).not.toHaveProperty("languageHint");
+    expect(ttsTexts).toEqual([EXPECTED_TOOL_ACK, EXPECTED_PROGRESS_FALLBACK]);
 
     emitMessageComplete(getCallbacks);
   });

--- a/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
@@ -1394,6 +1394,50 @@ describe("LiveVoiceSession STT", () => {
     );
   });
 
+  test("a tagged partial supplies the turn language when finals carry no tags", async () => {
+    // Speculative turns dispatch from partials before the first tagged
+    // final, so the latest tagged partial must resolve the language.
+    const transcriber = new MockStreamingTranscriber();
+    const startVoiceTurn = speakingVoiceTurnStarter();
+    const { streamTtsAudio, ttsCalls } = recordingTtsStreamer();
+    const { context } = createContext();
+    const session = new LiveVoiceSession(context, {
+      resolveTranscriber: mock(async () => transcriber),
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(new Uint8Array([1]));
+    transcriber.emit({ type: "partial", text: "hola", languages: ["es"] });
+    transcriber.emit({ type: "final", text: "hola amigo" });
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(() => ttsCalls.length >= 1);
+
+    expect(ttsCalls[0]?.language).toBe("es");
+  });
+
+  test("a tagged final outranks an earlier tagged partial", async () => {
+    const transcriber = new MockStreamingTranscriber();
+    const startVoiceTurn = speakingVoiceTurnStarter();
+    const { streamTtsAudio, ttsCalls } = recordingTtsStreamer();
+    const { context } = createContext();
+    const session = new LiveVoiceSession(context, {
+      resolveTranscriber: mock(async () => transcriber),
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(new Uint8Array([1]));
+    transcriber.emit({ type: "partial", text: "hola", languages: ["es"] });
+    transcriber.emit({ type: "final", text: "नमस्ते", languages: ["hi"] });
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(() => ttsCalls.length >= 1);
+
+    expect(ttsCalls[0]?.language).toBe("hi");
+  });
+
   test("a monolingual services.stt.language pin is the turn language when finals carry no tags", async () => {
     const originalRaw = loadRawConfig();
     const rawServices = (originalRaw.services ?? {}) as Record<string, unknown>;

--- a/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
@@ -1417,6 +1417,30 @@ describe("LiveVoiceSession STT", () => {
     expect(ttsCalls[0]?.language).toBe("es");
   });
 
+  test("empty finals carrying language tags do not vote", async () => {
+    // Silence frames can carry container-level tags describing no emitted
+    // words; they must not outvote the language of real speech.
+    const transcriber = new MockStreamingTranscriber();
+    const startVoiceTurn = speakingVoiceTurnStarter();
+    const { streamTtsAudio, ttsCalls } = recordingTtsStreamer();
+    const { context } = createContext();
+    const session = new LiveVoiceSession(context, {
+      resolveTranscriber: mock(async () => transcriber),
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(new Uint8Array([1]));
+    transcriber.emit({ type: "final", text: "", languages: ["es"] });
+    transcriber.emit({ type: "final", text: "", languages: ["es"] });
+    transcriber.emit({ type: "final", text: "hello there", languages: ["en"] });
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(() => ttsCalls.length >= 1);
+
+    expect(ttsCalls[0]?.language).toBe("en");
+  });
+
   test("a tagged final outranks an earlier tagged partial", async () => {
     const transcriber = new MockStreamingTranscriber();
     const startVoiceTurn = speakingVoiceTurnStarter();

--- a/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
@@ -12,6 +12,7 @@ import {
   type LiveVoiceStreamingTranscriberResolver,
 } from "../live-voice-session.js";
 import type { LiveVoiceSessionFactoryContext } from "../live-voice-session-manager.js";
+import type { LiveVoiceTtsOptions } from "../live-voice-tts.js";
 import {
   createLiveVoiceServerFrameSequencer,
   type LiveVoiceClientStartFrame,
@@ -133,6 +134,39 @@ function completingVoiceTurnStarter() {
     });
     return { turnId: "bridge-turn-1", abort: mock() };
   });
+}
+
+// A starter whose leg streams one spoken sentence so the turn reaches TTS.
+function speakingVoiceTurnStarter(reply = "Okay.") {
+  return mock(async (options: VoiceTurnOptions) => {
+    options.callbacks?.assistant_text_delta?.({
+      type: "assistant_text_delta",
+      text: reply,
+      conversationId: options.conversationId,
+    });
+    options.callbacks?.message_complete?.({
+      type: "message_complete",
+      conversationId: options.conversationId,
+      messageId: "assistant-message-123",
+    });
+    return { turnId: "bridge-turn-1", abort: mock() };
+  });
+}
+
+// Records the exact options object of every TTS synthesis request.
+function recordingTtsStreamer() {
+  const ttsCalls: LiveVoiceTtsOptions[] = [];
+  const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+    ttsCalls.push(options);
+    return {
+      provider: "fish-audio" as const,
+      contentType: "audio/pcm",
+      sampleRate: 24_000,
+      chunks: 0,
+      bytes: 0,
+    };
+  });
+  return { streamTtsAudio, ttsCalls };
 }
 
 function createContext(overrides: Partial<LiveVoiceClientStartFrame> = {}): {
@@ -1335,6 +1369,93 @@ describe("LiveVoiceSession STT", () => {
       "utterance 1",
       "utterance 1",
     ]);
+  });
+
+  test("finals tagged with a detected language carry it to TTS and the control prompt", async () => {
+    const transcriber = new MockStreamingTranscriber();
+    const startVoiceTurn = speakingVoiceTurnStarter();
+    const { streamTtsAudio, ttsCalls } = recordingTtsStreamer();
+    const { context } = createContext();
+    const session = new LiveVoiceSession(context, {
+      resolveTranscriber: mock(async () => transcriber),
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(new Uint8Array([1]));
+    transcriber.emit({ type: "final", text: "नमस्ते", languages: ["hi"] });
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(() => ttsCalls.length >= 1);
+
+    expect(ttsCalls[0]?.language).toBe("hi");
+    expect(startVoiceTurn.mock.calls[0]?.[0]?.voiceControlPrompt).toContain(
+      'speaking the language with code "hi"',
+    );
+  });
+
+  test("a monolingual services.stt.language pin is the turn language when finals carry no tags", async () => {
+    const originalRaw = loadRawConfig();
+    const rawServices = (originalRaw.services ?? {}) as Record<string, unknown>;
+    saveRawConfig({
+      ...originalRaw,
+      services: {
+        ...rawServices,
+        stt: {
+          ...((rawServices.stt ?? {}) as Record<string, unknown>),
+          language: "ja",
+        },
+      },
+    });
+    const transcriber = new MockStreamingTranscriber();
+    const startVoiceTurn = speakingVoiceTurnStarter();
+    const { streamTtsAudio, ttsCalls } = recordingTtsStreamer();
+    const { context } = createContext();
+    const session = new LiveVoiceSession(context, {
+      resolveTranscriber: mock(async () => transcriber),
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    try {
+      await session.start();
+      await session.handleBinaryAudio(new Uint8Array([1]));
+      await session.handleClientFrame({ type: "ptt_release" });
+      await waitFor(() => ttsCalls.length >= 1);
+
+      expect(ttsCalls[0]?.language).toBe("ja");
+      expect(startVoiceTurn.mock.calls[0]?.[0]?.voiceControlPrompt).toContain(
+        'speaking the language with code "ja"',
+      );
+    } finally {
+      await session.close("websocket_close");
+      saveRawConfig(originalRaw);
+    }
+  });
+
+  test('the default "multi" with tag-less finals leaves every language-aware path untouched', async () => {
+    const transcriber = new MockStreamingTranscriber();
+    const startVoiceTurn = speakingVoiceTurnStarter();
+    const { streamTtsAudio, ttsCalls } = recordingTtsStreamer();
+    const { context } = createContext();
+    const session = new LiveVoiceSession(context, {
+      resolveTranscriber: mock(async () => transcriber),
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(new Uint8Array([1]));
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(() => ttsCalls.length >= 1);
+
+    // With the language unknown the TTS request carries no language key at
+    // all and the control prompt has no per-turn language note: byte-for-byte
+    // the language-blind behavior.
+    expect("language" in ttsCalls[0]!).toBe(false);
+    expect(startVoiceTurn.mock.calls[0]?.[0]?.voiceControlPrompt).not.toContain(
+      "language with code",
+    );
   });
 
   test("uses the production streaming transcriber resolver by default", () => {

--- a/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
@@ -1530,6 +1530,45 @@ describe("LiveVoiceSession STT", () => {
     }
   });
 
+  test("a pin on an auto-detecting provider does not become the turn language", async () => {
+    // google-gemini and openai-whisper ignore services.stt.language, so a
+    // stale persisted pin must not force every turn into that language.
+    const originalRaw = loadRawConfig();
+    const rawServices = (originalRaw.services ?? {}) as Record<string, unknown>;
+    saveRawConfig({
+      ...originalRaw,
+      services: {
+        ...rawServices,
+        stt: {
+          ...((rawServices.stt ?? {}) as Record<string, unknown>),
+          provider: "google-gemini",
+          language: "es",
+        },
+      },
+    });
+    const transcriber = new MockStreamingTranscriber();
+    const startVoiceTurn = speakingVoiceTurnStarter();
+    const { streamTtsAudio, ttsCalls } = recordingTtsStreamer();
+    const { context } = createContext();
+    const session = new LiveVoiceSession(context, {
+      resolveTranscriber: mock(async () => transcriber),
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    try {
+      await session.start();
+      await session.handleBinaryAudio(new Uint8Array([1]));
+      await session.handleClientFrame({ type: "ptt_release" });
+      await waitFor(() => ttsCalls.length >= 1);
+
+      expect(ttsCalls[0] && "language" in ttsCalls[0]).toBe(false);
+    } finally {
+      await session.close("websocket_close");
+      saveRawConfig(originalRaw);
+    }
+  });
+
   test('the default "multi" with tag-less finals leaves every language-aware path untouched', async () => {
     const transcriber = new MockStreamingTranscriber();
     const startVoiceTurn = speakingVoiceTurnStarter();

--- a/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
@@ -30,13 +30,19 @@ const START_FRAME = {
 } as const satisfies LiveVoiceClientStartFrame;
 
 class MockStreamingTranscriber implements StreamingTranscriber {
-  readonly providerId = "deepgram" as const;
+  // Configurable: the session gates the language-pin fallback on the DIALED
+  // transcriber's providerId (see turnLanguageFor).
+  readonly providerId: StreamingTranscriber["providerId"];
   readonly boundaryId = "daemon-streaming" as const;
   readonly audioChunks: Buffer[] = [];
   readonly mimeTypes: string[] = [];
   started = false;
   stopped = false;
   private onEvent: ((event: SttStreamServerEvent) => void) | null = null;
+
+  constructor(providerId: StreamingTranscriber["providerId"] = "deepgram") {
+    this.providerId = providerId;
+  }
 
   async start(onEvent: (event: SttStreamServerEvent) => void): Promise<void> {
     this.started = true;
@@ -1546,7 +1552,7 @@ describe("LiveVoiceSession STT", () => {
         },
       },
     });
-    const transcriber = new MockStreamingTranscriber();
+    const transcriber = new MockStreamingTranscriber("google-gemini");
     const startVoiceTurn = speakingVoiceTurnStarter();
     const { streamTtsAudio, ttsCalls } = recordingTtsStreamer();
     const { context } = createContext();
@@ -1563,6 +1569,46 @@ describe("LiveVoiceSession STT", () => {
       await waitFor(() => ttsCalls.length >= 1);
 
       expect(ttsCalls[0] && "language" in ttsCalls[0]).toBe(false);
+    } finally {
+      await session.close("websocket_close");
+      saveRawConfig(originalRaw);
+    }
+  });
+
+  test("the pin gate follows the dialed provider, not the configured one", async () => {
+    // A BYOK gemini config without credentials silently dials the managed
+    // vellum transcriber, which DOES honor the pin; the gate must follow
+    // what was dialed, not what was configured.
+    const originalRaw = loadRawConfig();
+    const rawServices = (originalRaw.services ?? {}) as Record<string, unknown>;
+    saveRawConfig({
+      ...originalRaw,
+      services: {
+        ...rawServices,
+        stt: {
+          ...((rawServices.stt ?? {}) as Record<string, unknown>),
+          provider: "google-gemini",
+          language: "es",
+        },
+      },
+    });
+    const transcriber = new MockStreamingTranscriber("vellum");
+    const startVoiceTurn = speakingVoiceTurnStarter();
+    const { streamTtsAudio, ttsCalls } = recordingTtsStreamer();
+    const { context } = createContext();
+    const session = new LiveVoiceSession(context, {
+      resolveTranscriber: mock(async () => transcriber),
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    try {
+      await session.start();
+      await session.handleBinaryAudio(new Uint8Array([1]));
+      await session.handleClientFrame({ type: "ptt_release" });
+      await waitFor(() => ttsCalls.length >= 1);
+
+      expect(ttsCalls[0]?.language).toBe("es");
     } finally {
       await session.close("websocket_close");
       saveRawConfig(originalRaw);

--- a/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
@@ -1441,6 +1441,35 @@ describe("LiveVoiceSession STT", () => {
     expect(ttsCalls[0]?.language).toBe("en");
   });
 
+  test("only each final's dominant language votes", async () => {
+    // `languages` is dominance-ranked per event: a Spanish-dominant segment
+    // tagged ["es", "en"] plus a short English segment tagged ["en"] must
+    // resolve to Spanish (one vote each, tie broken by first appearance),
+    // not English by counting the secondary tag as a full vote.
+    const transcriber = new MockStreamingTranscriber();
+    const startVoiceTurn = speakingVoiceTurnStarter();
+    const { streamTtsAudio, ttsCalls } = recordingTtsStreamer();
+    const { context } = createContext();
+    const session = new LiveVoiceSession(context, {
+      resolveTranscriber: mock(async () => transcriber),
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(new Uint8Array([1]));
+    transcriber.emit({
+      type: "final",
+      text: "hola amigo como estas hoy",
+      languages: ["es", "en"],
+    });
+    transcriber.emit({ type: "final", text: "ok", languages: ["en"] });
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(() => ttsCalls.length >= 1);
+
+    expect(ttsCalls[0]?.language).toBe("es");
+  });
+
   test("a tagged final outranks an earlier tagged partial", async () => {
     const transcriber = new MockStreamingTranscriber();
     const startVoiceTurn = speakingVoiceTurnStarter();

--- a/assistant/src/live-voice/__tests__/live-voice-triage-escalate.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-triage-escalate.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, mock, test } from "bun:test";
 
+import { sanitizeForTts } from "../../calls/tts-text-sanitizer.js";
 import type { VoiceTurnOptions } from "../../calls/voice-session-bridge.js";
 import {
   ESCALATION_CONTINUATION_CONTENT,
   FALLBACK_ESCALATION_BRIDGE,
+  FALLBACK_ESCALATION_BRIDGE_BY_LANGUAGE,
 } from "../../calls/voice-triage-escalate.js";
 import type {
   StreamingTranscriber,
@@ -11,9 +13,11 @@ import type {
 } from "../../stt/types.js";
 import {
   LiveVoiceSession,
+  type LiveVoiceTtsStreamer,
   type LiveVoiceTurnStarter,
 } from "../live-voice-session.js";
 import type { LiveVoiceSessionFactoryContext } from "../live-voice-session-manager.js";
+import type { LiveVoiceTtsOptions } from "../live-voice-tts.js";
 import {
   createLiveVoiceServerFrameSequencer,
   type LiveVoiceClientStartFrame,
@@ -57,7 +61,13 @@ class MockStreamingTranscriber implements StreamingTranscriber {
   }
 }
 
-function createHarness(startVoiceTurn: LiveVoiceTurnStarter) {
+function createHarness(
+  startVoiceTurn: LiveVoiceTurnStarter,
+  opts: {
+    transcriber?: MockStreamingTranscriber;
+    streamTtsAudio?: LiveVoiceTtsStreamer;
+  } = {},
+) {
   const sequencer = createLiveVoiceServerFrameSequencer();
   const frames: LiveVoiceServerFrame[] = [];
   const context: LiveVoiceSessionFactoryContext = {
@@ -69,10 +79,11 @@ function createHarness(startVoiceTurn: LiveVoiceTurnStarter) {
       return frame;
     }),
   };
-  const transcriber = new MockStreamingTranscriber();
+  const transcriber = opts.transcriber ?? new MockStreamingTranscriber();
   const session = new LiveVoiceSession(context, {
     resolveTranscriber: mock(async () => transcriber),
     startVoiceTurn,
+    ...(opts.streamTtsAudio ? { streamTtsAudio: opts.streamTtsAudio } : {}),
     createTurnId: () => "live-turn-1",
     emitMetrics: false,
   });
@@ -311,6 +322,50 @@ describe("live-voice triage-and-escalate routing", () => {
     // The verdict itself is never shown; the fallback bridge is audio-only.
     expect(spokenText(frames)).not.toContain("[1]");
     expect(spokenText(frames)).not.toContain(FALLBACK_ESCALATION_BRIDGE);
+  });
+
+  test("escalating a Hindi turn speaks the Hindi fallback bridge and quotes it to the escalated leg", async () => {
+    const { starter } = scriptedStartVoiceTurn({
+      frontDoor: ["[1]"],
+      escalated: ["तैयार उत्तर।"],
+    });
+    const ttsCalls: LiveVoiceTtsOptions[] = [];
+    const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+      ttsCalls.push(options);
+      return {
+        provider: "fish-audio" as const,
+        contentType: "audio/pcm",
+        sampleRate: 24_000,
+        chunks: 0,
+        bytes: 0,
+      };
+    });
+    const { frames, session } = createHarness(starter, {
+      transcriber: new MockStreamingTranscriber([
+        { type: "final", text: "नमस्ते", languages: ["hi"] },
+        { type: "closed" },
+      ]),
+      streamTtsAudio,
+    });
+
+    await driveTurn(session);
+    await waitFor(() => starter.mock.calls.length >= 2);
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    const hindiBridge = FALLBACK_ESCALATION_BRIDGE_BY_LANGUAGE.hi!;
+    // The escalated leg is told the exact phrase the caller heard, so its
+    // continuation rule can quote it and ban a re-announcing echo.
+    expect(starter.mock.calls[1]?.[0]?.spokenEscalationBridge).toBe(
+      hindiBridge,
+    );
+    // The caller hears the Hindi fallback; like every canned bridge it is
+    // audio-only, so it reaches TTS but never a caption frame.
+    expect(ttsCalls.map((call) => call.text)).toContain(
+      sanitizeForTts(hindiBridge).trim(),
+    );
+    expect(spokenText(frames)).not.toContain(hindiBridge);
+    // The detected language rides every synthesis request of the turn.
+    expect(ttsCalls.every((call) => call.language === "hi")).toBe(true);
   });
 
   test("barge-in during the escalated leg aborts it", async () => {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -25,7 +25,7 @@ import {
   classifyFrontDoorLeading,
   ESCALATE_VERDICT_TOKEN,
   ESCALATION_CONTINUATION_CONTENT,
-  FALLBACK_ESCALATION_BRIDGE,
+  fallbackEscalationBridgeFor,
   isEscalationBridgeComplete,
   MIN_SPOKEN_BRIDGE_CHARS,
   type VoiceRoutingLeg,
@@ -51,6 +51,7 @@ import {
 import type { ResolveStreamingTranscriberOptions } from "../providers/speech-to-text/resolve.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { publishConversationListAndMetadataChanged } from "../runtime/sync/resource-sync-events.js";
+import { normalizeLanguageTag } from "../stt/language-metadata.js";
 import { detectPcm16SpeechActivity } from "../stt/speech-energy.js";
 import type {
   StreamingTranscriber,
@@ -369,6 +370,10 @@ interface UtteranceCycle {
   // text replays the boundary immediately — the hold was judged on stale
   // text, so waiting out the extension only adds silence.
   heldSpeculativeContent: string | null;
+  // Count per normalized detected-language tag (see normalizeLanguageTag)
+  // across this cycle's final transcript events. Resolves the turn's spoken
+  // language (see turnLanguageFor); empty when the provider tags nothing.
+  languageTally: Map<string, number>;
   turnId: string | null;
   userMessageId: string | null;
   userAudioChunks: Buffer[];
@@ -483,6 +488,13 @@ interface ActiveAssistantTurn {
   token: symbol;
   turnId: string;
   utterance: UtteranceCycle;
+  // The caller's spoken language for this turn as a lowercase base subtag
+  // (see turnLanguageFor): the dominant STT-detected language, else a
+  // monolingual services.stt.language pin. Undefined when unknown, which
+  // disables every language-aware path (prompt note, TTS hint, localized
+  // fallbacks). Re-resolved when a speculative turn commits, since finals
+  // can land between dispatch and verdict.
+  language: string | undefined;
   abortController: AbortController;
   handle: VoiceTurnHandle | null;
   // When the turn launched, for narration's turnElapsedMs.
@@ -688,7 +700,7 @@ function createControlMarkerHoldback(
 const APPROVAL_PENDING_PHRASE = "I need your okay for that one. Take a look.";
 
 const LIVE_VOICE_CONTROL_PROMPT_BASE =
-  "You are speaking in a local live voice session. Keep replies brief and conversational. Speech is the main channel: say the answer, and do not narrate a surface instead of answering. You can also put something on screen when it genuinely helps (a form, a list to pick from, a progress card for long work); the call overlay minimizes by itself once you finish speaking, so the user sees it without doing anything. Never tell the user you cannot show them something. ";
+  "You are speaking in a local live voice session. Keep replies brief and conversational. Speech is the main channel: say the answer, and do not narrate a surface instead of answering. You can also put something on screen when it genuinely helps (a form, a list to pick from, a progress card for long work); the call overlay minimizes by itself once you finish speaking, so the user sees it without doing anything. Never tell the user you cannot show them something. Reply in the language the caller is speaking; if they switch languages, switch with them. ";
 
 // Appended for the legs that can actually put something on screen: the main
 // leg and the escalated leg. The front-door (fast) leg never receives it, for
@@ -777,6 +789,9 @@ function buildVoiceControlPrompt(
     LIVE_VOICE_CONTROL_PROMPT_BASE +
     (leg.frontDoor === true ? "" : LIVE_VOICE_SCREEN_REVEAL_TEACHING) +
     VOICE_NO_SETUP_FLOWS_RULE;
+  if (turn.language !== undefined) {
+    prompt = `${prompt}\n\nThe caller has been speaking the language with code "${turn.language}" this turn. Reply in that language unless they clearly switch to another.`;
+  }
   if (turn.interruptedRequest) {
     prompt = `${prompt}\n\n${buildInterruptionMergeNote(turn.interruptedRequest)}`;
   }
@@ -825,6 +840,7 @@ function createUtteranceCycle(): UtteranceCycle {
     latestPartialText: null,
     endpointExtensionCount: 0,
     heldSpeculativeContent: null,
+    languageTally: new Map(),
     turnId: null,
     userMessageId: null,
     userAudioChunks: [],
@@ -2851,6 +2867,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // are skipped; the thinking frame and timers still apply.
     const alreadyReleased = utterance.released;
     turn.speculativePending = false;
+    // Finals can land between the speculative dispatch and this verdict, so
+    // the committed turn re-reads the tally: TTS, the front model, and any
+    // escalated leg see the full utterance's language.
+    turn.language = this.turnLanguageFor(utterance);
     if (turn.verdictDeadlineTimer !== null) {
       clearTimeout(turn.verdictDeadlineTimer);
       turn.verdictDeadlineTimer = null;
@@ -3193,7 +3213,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         await this.sendFrame({ type: "stt_partial", text: event.text });
         return;
       case "final":
-        await this.recordFinalTranscript(utterance, event.text);
+        await this.recordFinalTranscript(
+          utterance,
+          event.text,
+          event.languages,
+        );
         return;
       case "finalized":
         // Per-cycle transcribers are torn down with stop(); the finalize
@@ -3277,7 +3301,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           // newer cycle.
           const owner = this.finalizeQueue[0];
           if (owner && !owner.assistantTurnStarted && !owner.completed) {
-            await this.recordFinalTranscript(owner, event.text);
+            await this.recordFinalTranscript(
+              owner,
+              event.text,
+              event.languages,
+            );
           } else {
             log.warn(
               "Dropping a late finalize flush segment: its assistant turn already dispatched",
@@ -3294,7 +3322,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           );
           return;
         }
-        await this.recordFinalTranscript(target, event.text);
+        await this.recordFinalTranscript(target, event.text, event.languages);
         return;
       }
       case "finalized": {
@@ -3363,10 +3391,21 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private async recordFinalTranscript(
     utterance: UtteranceCycle,
     text: string,
+    languages?: readonly string[],
   ): Promise<void> {
     const transcript = text.trim();
     if (transcript.length > 0) {
       utterance.finalTranscriptSegments.push(transcript);
+    }
+    for (const tag of languages ?? []) {
+      const normalized = normalizeLanguageTag(tag);
+      if (!normalized) {
+        continue;
+      }
+      utterance.languageTally.set(
+        normalized,
+        (utterance.languageTally.get(normalized) ?? 0) + 1,
+      );
     }
     // The final commits (and supersedes) whatever partial was trailing it.
     utterance.latestPartialText = null;
@@ -3403,6 +3442,35 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       }
     }
     await this.startAssistantTurnIfReady();
+  }
+
+  /**
+   * The caller's spoken language for a turn on this utterance, as a
+   * lowercase base subtag: the dominant tallied STT-detected language
+   * (most final-event counts, ties by first appearance), else a monolingual
+   * `services.stt.language` pin (a pinned language IS the spoken language),
+   * else undefined ("multi" with no tags, non-tagging providers, silence).
+   */
+  private turnLanguageFor(utterance: UtteranceCycle): string | undefined {
+    let dominant: string | undefined;
+    let dominantCount = 0;
+    for (const [tag, count] of utterance.languageTally) {
+      if (count > dominantCount) {
+        dominant = tag;
+        dominantCount = count;
+      }
+    }
+    if (dominant !== undefined) {
+      return dominant;
+    }
+    const configured = getConfig().services.stt.language;
+    if (configured && configured !== "multi") {
+      const normalized = normalizeLanguageTag(configured);
+      if (normalized) {
+        return normalized;
+      }
+    }
+    return undefined;
   }
 
   // Providers emit `error` mid-stream and may keep streaming; `closed` /
@@ -3660,6 +3728,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       token,
       turnId,
       utterance,
+      language: this.turnLanguageFor(utterance),
       abortController,
       handle: null,
       launchedAtMs: Date.now(),
@@ -4312,7 +4381,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // deleted row for a bridge the model never produced).
     const usesFallbackBridge = cappedBridge.length < MIN_SPOKEN_BRIDGE_CHARS;
     const spokenBridge = usesFallbackBridge
-      ? FALLBACK_ESCALATION_BRIDGE
+      ? fallbackEscalationBridgeFor(activeTurn.language)
       : cappedBridge;
     if (!usesFallbackBridge) {
       this.markFirstAssistantDelta(activeTurn.utterance, activeTurn.turnId);
@@ -4690,6 +4759,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           : null,
         turnElapsedMs: now - turn.launchedAtMs,
         updateIndex: progress.updatesSpoken + 1,
+        ...(turn.language !== undefined ? { languageHint: turn.language } : {}),
       };
       const generated = await frontDecider
         .generateProgressText(input, turn.abortController.signal)
@@ -4722,7 +4792,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         if (trigger !== "idle") {
           return;
         }
-        raw = pickProgressPhrase(this.progressPhraseCounter++);
+        raw = pickProgressPhrase(this.progressPhraseCounter++, turn.language);
       }
       if (!this.enqueueFillerPhrase(turn, raw)) {
         return;
@@ -4784,6 +4854,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           {
             transcriptSoFar: transcript,
             toolName,
+            ...(activeTurn.language !== undefined
+              ? { languageHint: activeTurn.language }
+              : {}),
           },
           activeTurn.abortController.signal,
         )
@@ -5012,6 +5085,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       try {
         synthesis = streamTtsAudio({
           text: job.text,
+          ...(activeTurn.language !== undefined
+            ? { language: activeTurn.language }
+            : {}),
           signal: activeTurn.abortController.signal,
           outputFormat: "pcm",
           sampleRate: this.context.startFrame.audio.sampleRate,

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -3409,15 +3409,15 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // Tally only finals that committed transcript: empty silence frames
       // can still carry container-level language tags describing no emitted
       // words, and counting those would let silence outvote real speech
-      // (same choice as the adapter's boundary-final aggregation).
-      for (const tag of languages ?? []) {
-        const normalized = normalizeLanguageTag(tag);
-        if (!normalized) {
-          continue;
-        }
+      // (same choice as the adapter's boundary-final aggregation). Each
+      // final casts one vote, for its dominant language only: `languages`
+      // is dominance-ranked, so giving secondary tags full votes would let
+      // a minority language outvote the utterance's dominant one.
+      const dominant = normalizeLanguageTag(languages?.[0] ?? "");
+      if (dominant) {
         utterance.languageTally.set(
-          normalized,
-          (utterance.languageTally.get(normalized) ?? 0) + 1,
+          dominant,
+          (utterance.languageTally.get(dominant) ?? 0) + 1,
         );
       }
     }

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -383,6 +383,12 @@ interface UtteranceCycle {
   // outranks it once finals arrive, and a revising partial without tags
   // must not wipe an earlier partial's detection.
   latestPartialLanguages: readonly string[] | null;
+  // The provider that actually transcribed this cycle, recorded when its
+  // transcriber is assigned and kept after teardown nulls `transcriber`.
+  // The resolver can silently dial managed vellum when a BYOK provider has
+  // no credential, so the language-pin gate in turnLanguageFor must follow
+  // this, not the configured provider.
+  dialedSttProvider: SttProviderId | null;
   turnId: string | null;
   userMessageId: string | null;
   userAudioChunks: Buffer[];
@@ -851,6 +857,7 @@ function createUtteranceCycle(): UtteranceCycle {
     heldSpeculativeContent: null,
     languageTally: new Map(),
     latestPartialLanguages: null,
+    dialedSttProvider: null,
     turnId: null,
     userMessageId: null,
     userAudioChunks: [],
@@ -1413,6 +1420,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         // Persistent re-arm: the shared stream is already open, so the cycle
         // goes straight to streaming with no resolve/start round-trip.
         utterance.transcriber = shared;
+        utterance.dialedSttProvider = shared.providerId;
         return await this.activateUtterance(utterance, replayTurnEnd);
       }
       // The shared stream is pinned to the old language, so retire it and
@@ -1445,6 +1453,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       }
 
       utterance.transcriber = transcriber;
+      utterance.dialedSttProvider = transcriber.providerId;
       if (
         this.turnDetector &&
         typeof transcriber.finalizeUtterance === "function"
@@ -3509,16 +3518,23 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (partialDominant !== undefined) {
       return partialDominant;
     }
-    // A persisted pin only counts when the active provider honors manual
-    // language selection: auto-detecting providers (gemini, whisper) ignore
-    // the setting entirely, so treating it as the caller's language would
-    // force every turn into a stale pin. Same gate as the telephony
-    // pre-speech rule (voice-session-bridge.ts).
+    // A persisted pin only counts when the provider that actually
+    // transcribed honors manual language selection: auto-detecting
+    // providers (gemini, whisper) ignore the setting entirely, so treating
+    // it as the caller's language would force every turn into a stale pin.
+    // The DIALED transcriber's providerId is authoritative, because the
+    // resolver silently falls back to managed vellum (which honors the pin)
+    // when a BYOK provider has no credential; the configured provider is
+    // only the last resort when no transcriber reference survives. Same
+    // gate as the telephony pre-speech rule (voice-session-bridge.ts).
     const { language: configured, provider: sttProvider } =
       getConfig().services.stt;
+    const dialedProvider =
+      utterance.dialedSttProvider ??
+      this.sharedTranscriber?.providerId ??
+      (sttProvider as SttProviderId);
     const providerHonorsLanguagePin =
-      getProviderEntry(sttProvider as SttProviderId)?.languageSelection ===
-      "manual";
+      getProviderEntry(dialedProvider)?.languageSelection === "manual";
     if (providerHonorsLanguagePin && configured && configured !== "multi") {
       const normalized = normalizeLanguageTag(configured);
       if (normalized) {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -45,6 +45,7 @@ import {
 import { isInstalledStaticSkillLoad } from "../permissions/checker.js";
 import { ensureConversationExists } from "../persistence/conversation-crud.js";
 import {
+  getProviderEntry,
   listProviderIds,
   supportsBoundary,
 } from "../providers/speech-to-text/provider-catalog.js";
@@ -55,6 +56,7 @@ import { normalizeLanguageTag } from "../stt/language-metadata.js";
 import { detectPcm16SpeechActivity } from "../stt/speech-energy.js";
 import type {
   StreamingTranscriber,
+  SttProviderId,
   SttStreamServerErrorEvent,
   SttStreamServerEvent,
 } from "../stt/types.js";
@@ -3507,8 +3509,17 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (partialDominant !== undefined) {
       return partialDominant;
     }
-    const configured = getConfig().services.stt.language;
-    if (configured && configured !== "multi") {
+    // A persisted pin only counts when the active provider honors manual
+    // language selection: auto-detecting providers (gemini, whisper) ignore
+    // the setting entirely, so treating it as the caller's language would
+    // force every turn into a stale pin. Same gate as the telephony
+    // pre-speech rule (voice-session-bridge.ts).
+    const { language: configured, provider: sttProvider } =
+      getConfig().services.stt;
+    const providerHonorsLanguagePin =
+      getProviderEntry(sttProvider as SttProviderId)?.languageSelection ===
+      "manual";
+    if (providerHonorsLanguagePin && configured && configured !== "multi") {
       const normalized = normalizeLanguageTag(configured);
       if (normalized) {
         return normalized;

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -374,6 +374,13 @@ interface UtteranceCycle {
   // across this cycle's final transcript events. Resolves the turn's spoken
   // language (see turnLanguageFor); empty when the provider tags nothing.
   languageTally: Map<string, number>;
+  // Detected languages of the most recent partial that carried any, already
+  // normalized, dominance order. Speculative turns dispatch from partials
+  // before the first tagged final lands, so turnLanguageFor falls back to
+  // this when the final tally is still empty. Never cleared: the tally
+  // outranks it once finals arrive, and a revising partial without tags
+  // must not wipe an earlier partial's detection.
+  latestPartialLanguages: readonly string[] | null;
   turnId: string | null;
   userMessageId: string | null;
   userAudioChunks: Buffer[];
@@ -841,6 +848,7 @@ function createUtteranceCycle(): UtteranceCycle {
     endpointExtensionCount: 0,
     heldSpeculativeContent: null,
     languageTally: new Map(),
+    latestPartialLanguages: null,
     turnId: null,
     userMessageId: null,
     userAudioChunks: [],
@@ -3209,6 +3217,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     switch (event.type) {
       case "partial":
         utterance.latestPartialText = event.text;
+        this.capturePartialLanguages(utterance, event.languages);
         this.markFirstPartial(utterance);
         await this.sendFrame({ type: "stt_partial", text: event.text });
         return;
@@ -3286,6 +3295,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           return;
         }
         target.latestPartialText = event.text;
+        this.capturePartialLanguages(target, event.languages);
         this.markFirstPartial(target);
         await this.sendFrame({ type: "stt_partial", text: event.text });
         return;
@@ -3444,12 +3454,35 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     await this.startAssistantTurnIfReady();
   }
 
+  // Record a partial event's detected languages (normalized, deduped,
+  // order preserved) so speculative dispatch has a detection before the
+  // first tagged final. Partials revise each other, so this overwrites
+  // rather than tallies, and a tag-less partial keeps the previous value.
+  private capturePartialLanguages(
+    utterance: UtteranceCycle,
+    languages: readonly string[] | undefined,
+  ): void {
+    if (!languages || languages.length === 0) {
+      return;
+    }
+    const normalized = [
+      ...new Set(
+        languages.map(normalizeLanguageTag).filter((tag) => tag.length > 0),
+      ),
+    ];
+    if (normalized.length > 0) {
+      utterance.latestPartialLanguages = normalized;
+    }
+  }
+
   /**
    * The caller's spoken language for a turn on this utterance, as a
    * lowercase base subtag: the dominant tallied STT-detected language
-   * (most final-event counts, ties by first appearance), else a monolingual
-   * `services.stt.language` pin (a pinned language IS the spoken language),
-   * else undefined ("multi" with no tags, non-tagging providers, silence).
+   * (most final-event counts, ties by first appearance), else the latest
+   * tagged partial's dominant language (speculative turns dispatch from
+   * partials), else a monolingual `services.stt.language` pin (a pinned
+   * language IS the spoken language), else undefined ("multi" with no tags,
+   * non-tagging providers, silence).
    */
   private turnLanguageFor(utterance: UtteranceCycle): string | undefined {
     let dominant: string | undefined;
@@ -3462,6 +3495,13 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
     if (dominant !== undefined) {
       return dominant;
+    }
+    // No tagged final yet (speculative turns dispatch from partials): the
+    // latest tagged partial is the best detection available and outranks a
+    // static pin for the same reason the tally does.
+    const partialDominant = utterance.latestPartialLanguages?.[0];
+    if (partialDominant !== undefined) {
+      return partialDominant;
     }
     const configured = getConfig().services.stt.language;
     if (configured && configured !== "multi") {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -3406,16 +3406,20 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     const transcript = text.trim();
     if (transcript.length > 0) {
       utterance.finalTranscriptSegments.push(transcript);
-    }
-    for (const tag of languages ?? []) {
-      const normalized = normalizeLanguageTag(tag);
-      if (!normalized) {
-        continue;
+      // Tally only finals that committed transcript: empty silence frames
+      // can still carry container-level language tags describing no emitted
+      // words, and counting those would let silence outvote real speech
+      // (same choice as the adapter's boundary-final aggregation).
+      for (const tag of languages ?? []) {
+        const normalized = normalizeLanguageTag(tag);
+        if (!normalized) {
+          continue;
+        }
+        utterance.languageTally.set(
+          normalized,
+          (utterance.languageTally.get(normalized) ?? 0) + 1,
+        );
       }
-      utterance.languageTally.set(
-        normalized,
-        (utterance.languageTally.get(normalized) ?? 0) + 1,
-      );
     }
     // The final commits (and supersedes) whatever partial was trailing it.
     utterance.latestPartialText = null;


### PR DESCRIPTION
## Summary
- Tallies detected languages per utterance from STT events and resolves a turn language (detected, then monolingual pin, then unknown)
- Feeds the turn language to TTS, the front model's ack/progress generation, localized fallbacks, and the answering model's control prompt
- Widens escalation-bridge sentence terminators so non-Latin bridges hand off promptly

Part of plan: voice-multilingual-pipeline.md (PR 5 of 6)