### PR TITLE
feat(web): add-remote-assistant dialog and self-registration handoff on the chooser

### DIFF
--- a/clients/web/src/domains/onboarding/components/add-remote-origin-dialog.test.tsx
+++ b/clients/web/src/domains/onboarding/components/add-remote-origin-dialog.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * Behavioral tests for the URL-only add-remote-origin dialog: the address is
+ * normalized through the real `normalizeOriginUrl` before the store add,
+ * invalid input renders the inline error without touching the store, a store
+ * failure keeps the dialog open with its copy, and a successful add completes
+ * via `onAdded`. Self-contained mocks: run this file solo (`mock.module`
+ * leaks across a shared `bun test` run).
+ */
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { ComponentProps, ReactNode } from "react";
+
+import type {
+  AddOriginResult,
+  RememberedOrigin,
+} from "@/stores/remembered-origins-store";
+
+// --- Mutable per-test state, reset in beforeEach ------------------------------
+
+const addOriginMock = mock(
+  async (input: { url: string; name?: string }): Promise<AddOriginResult> => ({
+    ok: true,
+    origin: { url: input.url, addedAt: "2026-01-01T00:00:00.000Z" },
+  }),
+);
+
+const onCloseMock = mock(() => {});
+const onAddedMock = mock((_origin: RememberedOrigin) => {});
+
+// --- Mocks --------------------------------------------------------------------
+
+// The real normalizer, captured before the module mock below replaces the
+// registry entry, so the dialog validates with production semantics.
+const { normalizeOriginUrl } = await import("@/stores/remembered-origins-store");
+
+mock.module("@/stores/remembered-origins-store", () => ({
+  normalizeOriginUrl,
+  useRememberedOriginsStore: {
+    getState: () => ({ addOrigin: addOriginMock }),
+  },
+}));
+
+mock.module("@vellumai/design-library/components/button", () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children?: ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}));
+
+mock.module("@vellumai/design-library/components/input", () => ({
+  Input: ({
+    fullWidth: _fullWidth,
+    ...props
+  }: ComponentProps<"input"> & { fullWidth?: boolean }) => <input {...props} />,
+}));
+
+mock.module("@vellumai/design-library/components/modal", () => ({
+  Modal: {
+    Root: ({ open, children }: { open: boolean; children: ReactNode }) =>
+      open ? <div>{children}</div> : null,
+    Content: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    Header: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    Title: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+    Description: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+    Body: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    Footer: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  },
+}));
+
+const { AddRemoteOriginDialog } = await import(
+  "@/domains/onboarding/components/add-remote-origin-dialog"
+);
+
+// --- Helpers ------------------------------------------------------------------
+
+const INVALID_COPY =
+  "Enter the full https address, like https://example.com/assistant-1.";
+const FAILED_COPY = "Failed to add the assistant. Please try again.";
+
+function renderDialog(
+  overrides: Partial<ComponentProps<typeof AddRemoteOriginDialog>> = {},
+) {
+  return render(
+    <AddRemoteOriginDialog
+      open
+      onClose={onCloseMock}
+      onAdded={onAddedMock}
+      {...overrides}
+    />,
+  );
+}
+
+function fillAddress(value: string): void {
+  fireEvent.change(screen.getByLabelText("Assistant address"), {
+    target: { value },
+  });
+}
+
+// --- Suite --------------------------------------------------------------------
+
+describe("AddRemoteOriginDialog", () => {
+  beforeEach(() => {
+    addOriginMock.mockClear();
+    addOriginMock.mockImplementation(async (input) => ({
+      ok: true,
+      origin: { url: input.url, addedAt: "2026-01-01T00:00:00.000Z" },
+    }));
+    onCloseMock.mockClear();
+    onAddedMock.mockClear();
+  });
+
+  afterEach(cleanup);
+
+  test("submits the normalized address and completes via onAdded", async () => {
+    renderDialog();
+
+    fillAddress("  HTTPS://Host.Example/assistant-1/  ");
+    fireEvent.click(screen.getByText("Add"));
+
+    await waitFor(() =>
+      expect(addOriginMock).toHaveBeenCalledWith({
+        url: "https://host.example/assistant-1",
+      }),
+    );
+    await waitFor(() =>
+      expect(onAddedMock).toHaveBeenCalledWith(
+        expect.objectContaining({ url: "https://host.example/assistant-1" }),
+      ),
+    );
+  });
+
+  test.each([
+    "http://host.example/assistant-1",
+    "javascript:alert(1)",
+    "not a url",
+  ])("invalid input renders the inline error without a store add: %s", async (value) => {
+    renderDialog();
+
+    fillAddress(value);
+    fireEvent.click(screen.getByText("Add"));
+
+    await waitFor(() => expect(screen.getByText(INVALID_COPY)).toBeTruthy());
+    expect(addOriginMock).not.toHaveBeenCalled();
+    expect(onAddedMock).not.toHaveBeenCalled();
+  });
+
+  test("a store failure keeps the dialog open with the failure copy", async () => {
+    addOriginMock.mockImplementation(async () => ({ ok: false }));
+    renderDialog();
+
+    fillAddress("https://host.example/assistant-1");
+    fireEvent.click(screen.getByText("Add"));
+
+    await waitFor(() => expect(screen.getByText(FAILED_COPY)).toBeTruthy());
+    expect(onAddedMock).not.toHaveBeenCalled();
+    // The form is still up for a retry.
+    expect(screen.getByLabelText("Assistant address")).toBeTruthy();
+  });
+
+  test("Add stays disabled until an address is typed", () => {
+    renderDialog();
+
+    expect((screen.getByText("Add") as HTMLButtonElement).disabled).toBe(true);
+
+    fillAddress("https://host.example");
+
+    expect((screen.getByText("Add") as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  test("Cancel closes without adding", () => {
+    renderDialog();
+
+    fireEvent.click(screen.getByText("Cancel"));
+
+    expect(onCloseMock).toHaveBeenCalled();
+    expect(addOriginMock).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/domains/onboarding/components/add-remote-origin-dialog.tsx
+++ b/clients/web/src/domains/onboarding/components/add-remote-origin-dialog.tsx
@@ -1,0 +1,149 @@
+import { Globe } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import { Button } from "@vellumai/design-library/components/button";
+import { Input } from "@vellumai/design-library/components/input";
+import { Modal } from "@vellumai/design-library/components/modal";
+
+import {
+  normalizeOriginUrl,
+  useRememberedOriginsStore,
+  type RememberedOrigin,
+} from "@/stores/remembered-origins-store";
+
+const ADD_FAILED_COPY = "Failed to add the assistant. Please try again.";
+
+interface AddRemoteOriginDialogProps {
+  open: boolean;
+  onClose: () => void;
+  /**
+   * Fired once the origin is remembered on this device, so the caller can
+   * navigate to it.
+   */
+  onAdded: (origin: RememberedOrigin) => void;
+}
+
+/**
+ * URL-only dialog for remembering a remote assistant origin in the hub
+ * chooser. The address is validated as an https base on submit; invalid
+ * input renders inline. No name field: the label arrives via pairing
+ * artifacts (a `?register` handoff), so the hostname stands in as the
+ * entry's title until then.
+ */
+function AddRemoteOriginDialog({
+  open,
+  onClose,
+  onAdded,
+}: AddRemoteOriginDialogProps) {
+  const [url, setUrl] = useState("");
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setUrl("");
+      setPending(false);
+      setError(null);
+    }
+  }, [open]);
+
+  const handleClose = () => {
+    if (!pending) {
+      onClose();
+    }
+  };
+
+  const handleSubmit = async () => {
+    // pending also guards re-entry: a second click can land before React
+    // flushes the pending state into the disabled buttons.
+    if (!url.trim() || pending) {
+      return;
+    }
+    const normalized = normalizeOriginUrl(url);
+    if (normalized === null) {
+      setError(
+        "Enter the full https address, like https://example.com/assistant-1.",
+      );
+      return;
+    }
+    setPending(true);
+    setError(null);
+    try {
+      const result = await useRememberedOriginsStore
+        .getState()
+        .addOrigin({ url: normalized });
+      if (result.ok) {
+        onAdded(result.origin);
+        return;
+      }
+      setError(ADD_FAILED_COPY);
+    } catch (err) {
+      console.error("addRemoteOriginDialog.add failed", err);
+      setError(ADD_FAILED_COPY);
+    }
+    setPending(false);
+  };
+
+  return (
+    <Modal.Root
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) {
+          handleClose();
+        }
+      }}
+    >
+      <Modal.Content size="md">
+        <Modal.Header>
+          <Modal.Title icon={Globe}>Add a Remote Assistant</Modal.Title>
+          <Modal.Description>
+            Paste the https link your assistant&rsquo;s pairing page gave you.
+          </Modal.Description>
+        </Modal.Header>
+
+        <Modal.Body>
+          <div className="space-y-4">
+            <div className="space-y-1.5">
+              <label
+                className="text-body-small-default text-[var(--content-secondary)]"
+                htmlFor="add-remote-origin-url"
+              >
+                Assistant address
+              </label>
+              <Input
+                id="add-remote-origin-url"
+                type="url"
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                placeholder="https://example.com/assistant-1"
+                fullWidth
+                autoFocus
+              />
+            </div>
+
+            {error && (
+              <p className="text-body-small-default text-[var(--system-negative-strong)]">
+                {error}
+              </p>
+            )}
+          </div>
+        </Modal.Body>
+
+        <Modal.Footer>
+          <Button variant="ghost" onClick={handleClose} disabled={pending}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            onClick={() => void handleSubmit()}
+            disabled={!url.trim() || pending}
+          >
+            {pending ? "Adding…" : "Add"}
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal.Root>
+  );
+}
+
+export { AddRemoteOriginDialog };

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
@@ -1188,6 +1188,22 @@ describe("SelectAssistantScreen register handoff", () => {
     expect(navigateMock).not.toHaveBeenCalled();
   });
 
+  test("a failed add keeps the register params for a retry", async () => {
+    assistantSwitcherValue = true;
+    assistantsValue = [makePairedAssistant(), makePlatformAssistant()];
+    searchParams = new URLSearchParams(
+      "register=https%3A%2F%2Fhost.example%2Fassistant-1&name=Homelab",
+    );
+    addOriginMock.mockImplementation(async () => ({ ok: false }) as const);
+
+    render(<SelectAssistantScreen />);
+
+    await waitFor(() => expect(addOriginMock).toHaveBeenCalled());
+    // The handoff params are the only copy of the registration; a failed
+    // persistence keeps them so a reload retries.
+    expect(replaceStateSpy).not.toHaveBeenCalled();
+  });
+
   test("a name-less register param records the origin without a label", async () => {
     assistantSwitcherValue = true;
     assistantsValue = [makePairedAssistant(), makePlatformAssistant()];

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
@@ -62,6 +62,21 @@ const hydrateOriginsMock = mock(async () => {});
 const removeOriginMock = mock(async (url: string) => {
   originsValue = originsValue.filter((o) => o.url !== url);
 });
+const addOriginMock = mock(
+  async (input: {
+    url: string;
+    name?: string;
+  }): Promise<
+    { ok: true; origin: RememberedOrigin } | { ok: false }
+  > => ({
+    ok: true,
+    origin: {
+      url: input.url,
+      ...(input.name ? { name: input.name } : {}),
+      addedAt: "2026-01-01T00:00:00.000Z",
+    },
+  }),
+);
 const switchToOriginMock = mock((_origin: RememberedOrigin) => {});
 
 // Stands in for the real error class (the screen's `instanceof` check runs
@@ -124,7 +139,15 @@ mock.module("@/stores/client-feature-flag-store", () => ({
   },
 }));
 
+// The real normalizer, captured before the module mock below replaces the
+// registry entry, so the screen's register-param validation runs with
+// production semantics.
+const { normalizeOriginUrl } = await import(
+  "@/stores/remembered-origins-store"
+);
+
 mock.module("@/stores/remembered-origins-store", () => ({
+  normalizeOriginUrl,
   useRememberedOriginsStore: {
     use: {
       origins: () => originsValue,
@@ -133,6 +156,7 @@ mock.module("@/stores/remembered-origins-store", () => ({
     getState: () => ({
       origins: originsValue,
       hydrate: hydrateOriginsMock,
+      addOrigin: addOriginMock,
       removeOrigin: removeOriginMock,
     }),
   },
@@ -173,6 +197,36 @@ mock.module("@/domains/onboarding/components/connect-assistant-dialog", () => ({
         <button onClick={onClose}>Close dialog</button>
         <button onClick={() => onImported("paired-new")}>
           Simulate import
+        </button>
+      </div>
+    ) : null,
+}));
+
+// A stub surfacing the open state that lets tests drive close and the
+// added callback the way real dialog interactions would.
+mock.module("@/domains/onboarding/components/add-remote-origin-dialog", () => ({
+  AddRemoteOriginDialog: ({
+    open,
+    onClose,
+    onAdded,
+  }: {
+    open: boolean;
+    onClose: () => void;
+    onAdded: (origin: RememberedOrigin) => void;
+  }) =>
+    open ? (
+      <div>
+        Add origin dialog open
+        <button onClick={onClose}>Close add dialog</button>
+        <button
+          onClick={() =>
+            onAdded({
+              url: "https://added.example/assistant-1",
+              addedAt: "2026-01-01T00:00:00.000Z",
+            })
+          }
+        >
+          Simulate origin add
         </button>
       </div>
     ) : null,
@@ -382,6 +436,15 @@ beforeEach(() => {
   removeOriginMock.mockImplementation(async (url: string) => {
     originsValue = originsValue.filter((o) => o.url !== url);
   });
+  addOriginMock.mockClear();
+  addOriginMock.mockImplementation(async (input) => ({
+    ok: true,
+    origin: {
+      url: input.url,
+      ...(input.name ? { name: input.name } : {}),
+      addedAt: "2026-01-01T00:00:00.000Z",
+    },
+  }));
   switchToOriginMock.mockClear();
   removePairedAssistantFromLockfileMock.mockClear();
   removePairedAssistantFromLockfileMock.mockImplementation(async () => ({
@@ -1000,6 +1063,184 @@ describe("SelectAssistantScreen remembered origins", () => {
       expect(screen.getByText("Choose an Assistant")).toBeTruthy(),
     );
     expect(connectPairedAssistantMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("SelectAssistantScreen add-remote-assistant affordance", () => {
+  test("renders on hostless surfaces with the flag on and opens the dialog", () => {
+    assistantSwitcherValue = true;
+    assistantsValue = [makePairedAssistant(), makePlatformAssistant()];
+
+    render(<SelectAssistantScreen />);
+
+    expect(screen.queryByText("Add origin dialog open")).toBeNull();
+    // The local bundle-paste affordance needs a local-mode host.
+    expect(screen.queryByText("Connect a remote assistant")).toBeNull();
+
+    fireEvent.click(screen.getByText("Add a remote assistant"));
+
+    expect(screen.getByText("Add origin dialog open")).toBeTruthy();
+  });
+
+  test("renders on the platform hub", () => {
+    assistantSwitcherValue = true;
+    isLocalClientValue = false;
+    hasPlatformSessionValue = true;
+    assistantsValue = [makePlatformAssistant()];
+
+    render(<SelectAssistantScreen />);
+
+    expect(screen.getByText("Add a remote assistant")).toBeTruthy();
+  });
+
+  test("is hidden where a local-mode host offers the bundle-paste connect instead", () => {
+    assistantSwitcherValue = true;
+    localModeHostAvailableValue = true;
+    assistantsValue = [makePairedAssistant(), makePlatformAssistant()];
+
+    render(<SelectAssistantScreen />);
+
+    expect(screen.queryByText("Add a remote assistant")).toBeNull();
+    expect(screen.getByText("Connect a remote assistant")).toBeTruthy();
+  });
+
+  test("is hidden with the flag off", () => {
+    assistantsValue = [makePairedAssistant(), makePlatformAssistant()];
+
+    render(<SelectAssistantScreen />);
+
+    expect(screen.queryByText("Add a remote assistant")).toBeNull();
+  });
+
+  test("an added origin closes the dialog and switches to it", async () => {
+    assistantSwitcherValue = true;
+    assistantsValue = [makePairedAssistant(), makePlatformAssistant()];
+
+    render(<SelectAssistantScreen />);
+
+    fireEvent.click(screen.getByText("Add a remote assistant"));
+    fireEvent.click(screen.getByText("Simulate origin add"));
+
+    await waitFor(() =>
+      expect(switchToOriginMock).toHaveBeenCalledWith(
+        expect.objectContaining({ url: "https://added.example/assistant-1" }),
+      ),
+    );
+    expect(screen.queryByText("Add origin dialog open")).toBeNull();
+  });
+
+  test("closing the dialog leaves the chooser untouched", () => {
+    assistantSwitcherValue = true;
+    assistantsValue = [makePairedAssistant(), makePlatformAssistant()];
+
+    render(<SelectAssistantScreen />);
+
+    fireEvent.click(screen.getByText("Add a remote assistant"));
+    fireEvent.click(screen.getByText("Close add dialog"));
+
+    expect(screen.queryByText("Add origin dialog open")).toBeNull();
+    expect(switchToOriginMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("SelectAssistantScreen register handoff", () => {
+  const replaceStateSpy = mock(
+    (_data: unknown, _unused: string, _url?: string | URL | null) => {},
+  );
+  let originalReplaceState: typeof window.history.replaceState;
+
+  beforeEach(() => {
+    replaceStateSpy.mockClear();
+    originalReplaceState = window.history.replaceState;
+    Object.defineProperty(window.history, "replaceState", {
+      configurable: true,
+      value: replaceStateSpy,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window.history, "replaceState", {
+      configurable: true,
+      value: originalReplaceState,
+    });
+  });
+
+  test("a valid register param records the origin with its label and cleans the address bar", async () => {
+    assistantSwitcherValue = true;
+    assistantsValue = [makePairedAssistant(), makePlatformAssistant()];
+    searchParams = new URLSearchParams(
+      "register=https%3A%2F%2Fhost.example%2Fassistant-1&name=Homelab",
+    );
+
+    render(<SelectAssistantScreen />);
+
+    // The rename-vs-add decision lives in the store: `addOrigin` on an
+    // already-remembered url updates its name in place.
+    await waitFor(() =>
+      expect(addOriginMock).toHaveBeenCalledWith({
+        url: "https://host.example/assistant-1",
+        name: "Homelab",
+      }),
+    );
+    expect(replaceStateSpy).toHaveBeenCalled();
+    // Records only; the user stays on the chooser to see the updated list.
+    expect(switchToOriginMock).not.toHaveBeenCalled();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  test("a name-less register param records the origin without a label", async () => {
+    assistantSwitcherValue = true;
+    assistantsValue = [makePairedAssistant(), makePlatformAssistant()];
+    searchParams = new URLSearchParams(
+      "register=https%3A%2F%2Fhost.example%2Fassistant-1",
+    );
+
+    render(<SelectAssistantScreen />);
+
+    await waitFor(() =>
+      expect(addOriginMock).toHaveBeenCalledWith({
+        url: "https://host.example/assistant-1",
+        name: undefined,
+      }),
+    );
+  });
+
+  test.each([
+    "javascript:alert(1)",
+    "http://host.example/assistant-1",
+    "not a url",
+  ])(
+    "an invalid register value is ignored without error UI: %s",
+    async (value) => {
+      assistantSwitcherValue = true;
+      assistantsValue = [makePairedAssistant(), makePlatformAssistant()];
+      searchParams = new URLSearchParams([["register", value]]);
+
+      render(<SelectAssistantScreen />);
+
+      await waitFor(() =>
+        expect(screen.getByText("Choose an Assistant")).toBeTruthy(),
+      );
+      expect(addOriginMock).not.toHaveBeenCalled();
+      expect(screen.queryByText(/Failed|Please try again/)).toBeNull();
+      // The consumed params still leave the address bar.
+      expect(replaceStateSpy).toHaveBeenCalled();
+    },
+  );
+
+  test("with the flag off the register params are ignored and left untouched", async () => {
+    assistantsValue = [makePairedAssistant(), makePlatformAssistant()];
+    searchParams = new URLSearchParams(
+      "register=https%3A%2F%2Fhost.example%2Fassistant-1&name=Homelab",
+    );
+
+    render(<SelectAssistantScreen />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Choose an Assistant")).toBeTruthy(),
+    );
+    expect(addOriginMock).not.toHaveBeenCalled();
+    expect(replaceStateSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -25,6 +25,7 @@ import {
   removePlatformAssistantFromLockfile,
   UnresolvedLocalGatewayError,
 } from "@/lib/local-mode";
+import { AddRemoteOriginDialog } from "@/domains/onboarding/components/add-remote-origin-dialog";
 import { ConnectAssistantDialog } from "@/domains/onboarding/components/connect-assistant-dialog";
 import { ConnectRecoveryDialog } from "@/domains/onboarding/components/connect-recovery-dialog";
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
@@ -42,6 +43,7 @@ import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { useConnectDialogStore } from "@/stores/connect-dialog-store";
 import { useOrganizationStore } from "@/stores/organization-store";
 import {
+  normalizeOriginUrl,
   useRememberedOriginsStore,
   type RememberedOrigin,
 } from "@/stores/remembered-origins-store";
@@ -91,6 +93,27 @@ function originSelectionKey(origin: RememberedOrigin): string {
 // Stable empty list for the flag-off render so effects keyed on the origin
 // entries do not re-run every render.
 const NO_ORIGINS: RememberedOrigin[] = [];
+
+/**
+ * Strip the consumed `register`/`name` handoff params from the address bar,
+ * preserving everything else, so a reload does not re-run the registration.
+ * Mirrors `clearDeviceCodeFromUrl` on the pairing page: a plain
+ * `history.replaceState`, never a navigation.
+ */
+function clearRegisterParamsFromUrl(): void {
+  try {
+    const url = new URL(window.location.href);
+    url.searchParams.delete("register");
+    url.searchParams.delete("name");
+    window.history.replaceState(
+      null,
+      "",
+      `${url.pathname}${url.search}${url.hash}`,
+    );
+  } catch {
+    // history.replaceState unavailable; the leftover params are inert.
+  }
+}
 
 export function SelectAssistantScreen() {
   const navigate = useNavigate();
@@ -152,6 +175,9 @@ export function SelectAssistantScreen() {
   );
   const [removePending, setRemovePending] = useState(false);
   const [removeError, setRemoveError] = useState<string | null>(null);
+  // The URL-only "Add a remote assistant" dialog (hub surfaces without a
+  // local-mode host).
+  const [addOriginOpen, setAddOriginOpen] = useState(false);
   // Target of the remembered-origin removal confirmation dialog.
   const [removeOriginTarget, setRemoveOriginTarget] =
     useState<RememberedOrigin | null>(null);
@@ -192,6 +218,33 @@ export function SelectAssistantScreen() {
       void useRememberedOriginsStore.getState().hydrate();
     }
   }, [assistantSwitcher]);
+
+  // `?register=<url>&name=<label>` handoff: another origin's Switch
+  // Assistant action self-registers here so the hub lists it. Records the
+  // entry (renaming an existing one) and cleans the address bar; it never
+  // navigates, so the user sees the updated list. Consumed at most once,
+  // and only once the flag is known on: with the flag off the params are
+  // ignored and left untouched. Only a name and an https URL ride the
+  // params; anything failing `normalizeOriginUrl` is dropped silently.
+  const registerHandledRef = useRef(false);
+  useEffect(() => {
+    if (!assistantSwitcher || registerHandledRef.current) {
+      return;
+    }
+    registerHandledRef.current = true;
+    const register = searchParams.get("register");
+    if (register === null) {
+      return;
+    }
+    const normalized = normalizeOriginUrl(register);
+    if (normalized !== null) {
+      void useRememberedOriginsStore.getState().addOrigin({
+        url: normalized,
+        name: searchParams.get("name") ?? undefined,
+      });
+    }
+    clearRegisterParamsFromUrl();
+  }, [assistantSwitcher, searchParams]);
 
   // Default selection: the app's known selected assistant when accessible,
   // else the first accessible assistant. Also reconciles an existing
@@ -427,6 +480,12 @@ export function SelectAssistantScreen() {
     );
   };
 
+  const handleOriginAdded = (origin: RememberedOrigin) => {
+    setAddOriginOpen(false);
+    // Landing on the origin runs its own pair flow when no session exists.
+    switchToOrigin(origin);
+  };
+
   // Auto-skip when there's exactly one assistant and it's accessible.
   // Don't skip when the user just logged in or navigated here deliberately
   // (e.g. from settings or the Developer menu): let them see the chooser.
@@ -622,6 +681,17 @@ export function SelectAssistantScreen() {
               }
             />
           )}
+          {/* Hostless surfaces (hub browser, remote-gateway mode, native
+              mobile) add origins by URL; local desktop clients keep the
+              bundle-paste connect flow above instead. */}
+          {assistantSwitcher && !localModeHostAvailable && (
+            <DashedActionButton
+              icon={<Globe className="h-4 w-4" />}
+              label="Add a remote assistant"
+              disabled={connecting || loginLoading}
+              onClick={() => setAddOriginOpen(true)}
+            />
+          )}
         </div>
 
         {hasSelectableEntries && (
@@ -657,6 +727,11 @@ export function SelectAssistantScreen() {
         </div>
         </div>
       </div>
+      <AddRemoteOriginDialog
+        open={addOriginOpen}
+        onClose={() => setAddOriginOpen(false)}
+        onAdded={handleOriginAdded}
+      />
       <ConnectAssistantDialog
         open={connectDialogOpen}
         initialBundle={connectInitialBundle ?? undefined}

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -225,7 +225,9 @@ export function SelectAssistantScreen() {
   // navigates, so the user sees the updated list. Consumed at most once,
   // and only once the flag is known on: with the flag off the params are
   // ignored and left untouched. Only a name and an https URL ride the
-  // params; anything failing `normalizeOriginUrl` is dropped silently.
+  // params; anything failing `normalizeOriginUrl` is dropped silently
+  // (and stripped, since retrying cannot fix it). A failed add keeps the
+  // params and releases the ref so a reload can retry the registration.
   const registerHandledRef = useRef(false);
   useEffect(() => {
     if (!assistantSwitcher || registerHandledRef.current) {
@@ -237,13 +239,26 @@ export function SelectAssistantScreen() {
       return;
     }
     const normalized = normalizeOriginUrl(register);
-    if (normalized !== null) {
-      void useRememberedOriginsStore.getState().addOrigin({
+    if (normalized === null) {
+      clearRegisterParamsFromUrl();
+      return;
+    }
+    void useRememberedOriginsStore
+      .getState()
+      .addOrigin({
         url: normalized,
         name: searchParams.get("name") ?? undefined,
+      })
+      .then((result) => {
+        if (result.ok) {
+          clearRegisterParamsFromUrl();
+        } else {
+          registerHandledRef.current = false;
+        }
+      })
+      .catch(() => {
+        registerHandledRef.current = false;
       });
-    }
-    clearRegisterParamsFromUrl();
   }, [assistantSwitcher, searchParams]);
 
   // Default selection: the app's known selected assistant when accessible,


### PR DESCRIPTION
## Summary
- URL-only Add a remote assistant dialog (labels arrive via pairing artifacts) behind the assistant-switcher flag on non-local-host surfaces
- ?register=<url>&name=<label> handoff records/renames the entry and cleans the address bar; invalid values ignored silently
- Flag off: no add button, register params untouched

Part of plan: origin-model-chooser.md (PR 3 of 7)