### PR TITLE
feat(web): back the chooser with the native SelfHostedServers plugin on mobile shells

### DIFF
--- a/clients/web/docs/CAPACITOR.md
+++ b/clients/web/docs/CAPACITOR.md
@@ -155,7 +155,7 @@ The shell registers **six** Capacitor plugins in [`MyViewController.capacitorDid
 | `VoiceAudioSession` | [`src/runtime/native-audio-session.ts`](../src/runtime/native-audio-session.ts) | iOS interruption events and Android foreground audio focus. See the background-audio contract below |
 | `VoiceLiveActivity` | [`src/runtime/native-live-activity.ts`](../src/runtime/native-live-activity.ts) | One ActivityKit activity on iOS or ongoing notification on Android |
 | `ApnsEnvironment` | [`src/runtime/apns-environment.ts`](../src/runtime/apns-environment.ts) | The build's real APNs entitlement environment (`development` / `production` / `unknown`), read from the embedded provisioning profile |
-| `SelfHostedServers` | none yet (web wiring ships separately) | List, add, remove, and switch between self-hosted server origins; `switchTo` swaps the shell's configured origin and reloads in place |
+| `SelfHostedServers` | [`src/runtime/self-hosted-servers.ts`](../src/runtime/self-hosted-servers.ts) | List, add, remove, and switch between self-hosted server origins; `switchTo` swaps the shell's configured origin and reloads in place. See the section below |
 
 The two voice plugins are consumed only through `use-live-voice-session-controller.ts` (audio session) and `use-live-activity-mirror.ts` (Live Activity), both mounted at `ChatLayout` scope so their lifetime is exactly the session's.
 
@@ -209,6 +209,81 @@ References:
 - Apple — [Playing audio in the background](https://developer.apple.com/documentation/avfaudio/audio_session/enabling_background_audio).
 - Apple — [`AVAudioSession.Mode.voiceChat`](https://developer.apple.com/documentation/avfaudio/avaudiosession/mode/voicechat).
 - Apple — [ActivityKit](https://developer.apple.com/documentation/activitykit).
+
+---
+
+## Self-hosted origins (`SelfHostedServers`)
+
+The assistant chooser offers every origin this device knows about. On a native
+mobile shell those origins live natively, not in web storage, because the shell
+is the only thing that can point its `WKWebView` somewhere else without leaving
+the app, and because the same list is written by the native Settings pane and
+the `<scheme>://connect` deep link. The web side is
+[`src/runtime/self-hosted-servers.ts`](../src/runtime/self-hosted-servers.ts);
+the native side is
+[`SelfHostedServersPlugin.swift`](../../../clients/ios/App/App/SelfHostedServersPlugin.swift)
+over [`SelfHostedServer.swift`](../../../clients/ios/App/App/SelfHostedServer.swift).
+
+The bridge contract:
+
+| Method | Resolves | Notes |
+| --- | --- | --- |
+| `list()` | `{ servers: [{name?, url}], activeUrl, bakedUrl }` | `activeUrl` is the configured self-hosted slot (`null` means the shell serves its baked origin); `bakedUrl` is the Vellum Cloud origin the build ships with |
+| `add({url, name?})` | `{ ok }` | Deduped by canonical url. A nameless re-add keeps the stored label |
+| `remove({url})` | `{ ok }` | Forgetting the active url also clears the active slot, so the shell returns to the baked origin |
+| `switchTo({url?})` | `{ ok }` | Swaps the active slot and reloads in place. An absent or empty `url` returns to the baked origin |
+
+Only genuinely invalid caller input rejects (an `add` or `switchTo` url that
+fails `SelfHostedServer.validate`). Empty state resolves with an empty list and
+nulls, so there is no "not configured" error branch to write.
+
+Urls cross the bridge in one canonical form: `SelfHostedServer.canonicalize` and
+the store's `normalizeOriginUrl` implement the same rules (lowercase scheme and
+host, userinfo dropped, trailing slashes stripped, query and fragment dropped,
+path and port preserved), so both sides agree on which strings mean the same
+server. Changing one means changing the other.
+
+**Switching is per surface, and every surface has a working answer.**
+
+- Browser and Electron: `switchToOrigin` navigates to the origin's SPA root. A
+  remembered origin is a separate deployment, so this is a full navigation, not
+  a route change.
+- Native mobile with the plugin: `nativeSwitchToOrigin` hands the url to the
+  shell, which reloads the web view in place. The user never leaves the app,
+  and a "Vellum Cloud" card sourced from `list().bakedUrl` is the way back.
+- Native mobile without the plugin: the same navigation the browser takes. That
+  leaves the app for the system browser, which is degraded but is exactly what
+  the pair-page path already does there.
+
+**Storage follows the same fork.** The chooser calls
+`installNativeRememberedOrigins()` from its flag-gated mount, which swaps the
+remembered-origins store onto a plugin-backed provider on native mobile only.
+The store persists a whole list while the plugin exposes per-entry `add` and
+`remove`, so the provider's `save` diffs the desired list against `list()` and
+issues the delta. A rejected write propagates, because the store treats a failed
+save as a failed mutation and must not publish an entry the shell does not hold.
+
+**The skew rule from the voice section applies verbatim.** The plugin may always
+be absent, so every bridge call is wrapped: a failure logs `console.debug`
+(never `captureError`, since an older App Store shell is an expected state on
+every web deploy) and falls back to the behavior that shell already had, which
+is the localStorage provider for storage and a plain navigation for switching.
+`load()` in particular degrades to localStorage data rather than rejecting: the
+store treats a rejected load as transient and would otherwise stay unhydrated
+and retry forever.
+
+**No availability probe.** There is no `isAvailable` and there must not be one:
+a probe can itself be absent, and the failure of the call the caller wanted to
+make is the same answer one turn earlier. `nativeSwitchToOrigin` resolving
+`false` and `nativeVellumCloudOrigin` resolving `null` already cover every
+reason there is no native side.
+
+The plugin module is reached lazily. `switch-origin.ts` imports it with a
+dynamic `import()` inside the native branch so a browser surface never pulls it
+into its graph, and `registerPlugin` itself only builds the bridge Proxy, so
+nothing reaches the shell before the flag-gated install. The inline-destructure
+rule at the top of this document applies to every call: only results cross an
+`async` boundary, never the plugin Proxy.
 
 ---
 

--- a/clients/web/src/assistant/switch-origin.test.ts
+++ b/clients/web/src/assistant/switch-origin.test.ts
@@ -1,0 +1,122 @@
+/**
+ * The per-surface switch fork: a browser navigates, a native mobile shell
+ * swaps its own origin, and a shell too old to carry the plugin degrades to
+ * the same navigation the browser takes.
+ *
+ * Self-contained mocks: run this file solo (`mock.module` leaks across a
+ * shared `bun test` run).
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { RememberedOrigin } from "@/stores/remembered-origins-store";
+
+let isNativeMobileValue = false;
+mock.module("@/runtime/platform-detection", () => ({
+  isNativeMobile: () => isNativeMobileValue,
+}));
+
+let nativeSwitchAccepts = true;
+const nativeSwitchToOriginMock = mock(
+  async (_url: string | null) => nativeSwitchAccepts,
+);
+mock.module("@/runtime/self-hosted-servers", () => ({
+  nativeSwitchToOrigin: nativeSwitchToOriginMock,
+}));
+
+let remoteGatewayMode = false;
+mock.module("@/lib/local-mode", () => ({
+  isRemoteGatewayMode: () => remoteGatewayMode,
+}));
+
+mock.module("@/lib/auth/remote-gateway-session", () => ({
+  remoteGatewayPublicBaseUrl: () => "https://gateway.example/assistant-1",
+}));
+
+const assignMock = mock((_url: string) => {});
+Object.defineProperty(window.location, "assign", {
+  configurable: true,
+  value: assignMock,
+});
+
+// Every real deployment serves the SPA over https, which is the only scheme a
+// remembered origin can carry; the harness default is http.
+window.location.href = "https://app.example/select-assistant";
+
+const { isCurrentOrigin, switchToOrigin, switchToVellumCloud } = await import(
+  "@/assistant/switch-origin"
+);
+
+function origin(url: string): RememberedOrigin {
+  return { url, addedAt: "2026-01-01T00:00:00.000Z" };
+}
+
+beforeEach(() => {
+  isNativeMobileValue = false;
+  nativeSwitchAccepts = true;
+  remoteGatewayMode = false;
+  assignMock.mockClear();
+  nativeSwitchToOriginMock.mockClear();
+});
+
+describe("switchToOrigin", () => {
+  test("navigates to the origin's SPA root on the web, without touching the bridge", async () => {
+    await switchToOrigin(origin("https://host.example/assistant-1"));
+
+    expect(assignMock).toHaveBeenCalledWith(
+      "https://host.example/assistant-1/assistant",
+    );
+    expect(nativeSwitchToOriginMock).not.toHaveBeenCalled();
+  });
+
+  test("the web navigation is issued synchronously", () => {
+    void switchToOrigin(origin("https://host.example"));
+
+    expect(assignMock).toHaveBeenCalled();
+  });
+
+  test("a native mobile shell swaps its origin in place", async () => {
+    isNativeMobileValue = true;
+
+    await switchToOrigin(origin("https://host.example"));
+
+    expect(nativeSwitchToOriginMock).toHaveBeenCalledWith(
+      "https://host.example",
+    );
+    expect(assignMock).not.toHaveBeenCalled();
+  });
+
+  test("a shell without the plugin falls back to plain navigation", async () => {
+    isNativeMobileValue = true;
+    nativeSwitchAccepts = false;
+
+    await switchToOrigin(origin("https://host.example"));
+
+    expect(assignMock).toHaveBeenCalledWith("https://host.example/assistant");
+  });
+});
+
+describe("switchToVellumCloud", () => {
+  test("asks the shell for its baked origin", async () => {
+    isNativeMobileValue = true;
+
+    expect(await switchToVellumCloud()).toBe(true);
+    expect(nativeSwitchToOriginMock).toHaveBeenCalledWith(null);
+  });
+});
+
+describe("isCurrentOrigin", () => {
+  test("compares against the running deployment's base", () => {
+    expect(isCurrentOrigin(origin("https://app.example"))).toBe(true);
+    expect(isCurrentOrigin(origin("https://elsewhere.example"))).toBe(false);
+  });
+
+  test("remote-gateway mode compares against the public path prefix", () => {
+    remoteGatewayMode = true;
+
+    expect(isCurrentOrigin(origin("https://gateway.example/assistant-1"))).toBe(
+      true,
+    );
+    expect(isCurrentOrigin(origin("https://gateway.example"))).toBe(false);
+  });
+});

--- a/clients/web/src/assistant/switch-origin.ts
+++ b/clients/web/src/assistant/switch-origin.ts
@@ -1,12 +1,17 @@
 /**
  * Origin switching for the assistant chooser. A remembered origin is a
  * separate SPA deployment, so selecting one is a full navigation to that
- * base, not an in-app route change. Kept dependency-light: native shells
- * fork this module for their own navigation primitive.
+ * base, not an in-app route change. Native mobile shells swap the WKWebView's
+ * configured origin instead, which keeps the switch inside the app.
+ *
+ * Kept dependency-light on the web path: the native seam is reached through a
+ * dynamic import, so a browser surface never pulls the Capacitor plugin module
+ * into its graph.
  */
 
 import { remoteGatewayPublicBaseUrl } from "@/lib/auth/remote-gateway-session";
 import { isRemoteGatewayMode } from "@/lib/local-mode";
+import { isNativeMobile } from "@/runtime/platform-detection";
 import {
   normalizeOriginUrl,
   type RememberedOrigin,
@@ -17,9 +22,38 @@ import { routes } from "@/utils/routes";
  * Navigate to the SPA root at the origin's base. An unpaired or expired
  * session bounces to that origin's own pair page via its resolver, which is
  * the intended degraded state.
+ *
+ * On a native mobile shell the switch goes through the `SelfHostedServers`
+ * plugin so the shell reloads in place. A shell too old to carry the plugin
+ * falls back to the same navigation the web takes: leaving the app for the
+ * system browser is degraded, but it is what the pair-page path already does
+ * there.
  */
-export function switchToOrigin(origin: RememberedOrigin): void {
-  window.location.assign(`${origin.url}${routes.assistant}`);
+export async function switchToOrigin(origin: RememberedOrigin): Promise<void> {
+  const navigate = () =>
+    window.location.assign(`${origin.url}${routes.assistant}`);
+  if (!isNativeMobile()) {
+    navigate();
+    return;
+  }
+  const { nativeSwitchToOrigin } = await import(
+    "@/runtime/self-hosted-servers"
+  );
+  if (!(await nativeSwitchToOrigin(origin.url))) {
+    navigate();
+  }
+}
+
+/**
+ * Return a native mobile shell to its baked Vellum Cloud origin, resolving
+ * whether the shell took the switch. Offered only where the baked origin is
+ * known, which is a shell that carries the plugin.
+ */
+export async function switchToVellumCloud(): Promise<boolean> {
+  const { nativeSwitchToOrigin } = await import(
+    "@/runtime/self-hosted-servers"
+  );
+  return nativeSwitchToOrigin(null);
 }
 
 /**

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
@@ -77,7 +77,12 @@ const addOriginMock = mock(
     },
   }),
 );
-const switchToOriginMock = mock((_origin: RememberedOrigin) => {});
+const switchToOriginMock = mock(async (_origin: RememberedOrigin) => {});
+const switchToVellumCloudMock = mock(async () => true);
+let isNativeMobileValue = false;
+const installNativeRememberedOriginsMock = mock(() => {});
+/** What the native shell reports as its baked Vellum Cloud origin, if any. */
+let nativeCloudOriginValue: string | null = null;
 
 // Stands in for the real error class (the screen's `instanceof` check runs
 // against this mocked module's export).
@@ -164,8 +169,18 @@ mock.module("@/stores/remembered-origins-store", () => ({
 
 mock.module("@/assistant/switch-origin", () => ({
   switchToOrigin: switchToOriginMock,
+  switchToVellumCloud: switchToVellumCloudMock,
   isCurrentOrigin: (origin: RememberedOrigin) =>
     origin.url === currentOriginUrl,
+}));
+
+mock.module("@/runtime/platform-detection", () => ({
+  useIsNativeMobile: () => isNativeMobileValue,
+}));
+
+mock.module("@/runtime/self-hosted-servers", () => ({
+  installNativeRememberedOrigins: installNativeRememberedOriginsMock,
+  nativeVellumCloudOrigin: async () => nativeCloudOriginValue,
 }));
 
 mock.module("@/domains/onboarding/components/connect-recovery-dialog", () => ({
@@ -446,6 +461,10 @@ beforeEach(() => {
     },
   }));
   switchToOriginMock.mockClear();
+  switchToVellumCloudMock.mockClear();
+  isNativeMobileValue = false;
+  nativeCloudOriginValue = null;
+  installNativeRememberedOriginsMock.mockClear();
   removePairedAssistantFromLockfileMock.mockClear();
   removePairedAssistantFromLockfileMock.mockImplementation(async () => ({
     ok: true,
@@ -1063,6 +1082,70 @@ describe("SelectAssistantScreen remembered origins", () => {
       expect(screen.getByText("Choose an Assistant")).toBeTruthy(),
     );
     expect(connectPairedAssistantMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("SelectAssistantScreen native mobile", () => {
+  test("the flag-gated mount installs the native origins provider", () => {
+    assistantSwitcherValue = true;
+    assistantsValue = [makePairedAssistant()];
+
+    render(<SelectAssistantScreen />);
+
+    expect(installNativeRememberedOriginsMock).toHaveBeenCalled();
+  });
+
+  test("with the flag off nothing reaches the native bridge", () => {
+    assistantsValue = [makePairedAssistant()];
+
+    render(<SelectAssistantScreen />);
+
+    expect(installNativeRememberedOriginsMock).not.toHaveBeenCalled();
+  });
+
+  test("a shell serving a self-hosted origin offers a Vellum Cloud card", async () => {
+    assistantSwitcherValue = true;
+    isNativeMobileValue = true;
+    nativeCloudOriginValue = "https://app.vellum.ai";
+    assistantsValue = [];
+
+    render(<SelectAssistantScreen />);
+
+    await waitFor(() => expect(screen.getByText("Vellum Cloud")).toBeTruthy());
+    // No device-local entry to forget, so the card carries no actions menu.
+    expect(screen.queryByLabelText("Actions for Vellum Cloud")).toBeNull();
+
+    fireEvent.click(screen.getByText("Vellum Cloud"));
+    fireEvent.click(screen.getByText("Continue"));
+
+    await waitFor(() => expect(switchToVellumCloudMock).toHaveBeenCalled());
+    expect(switchToOriginMock).not.toHaveBeenCalled();
+  });
+
+  test("no Vellum Cloud card when the shell already serves the baked origin", async () => {
+    assistantSwitcherValue = true;
+    isNativeMobileValue = true;
+    assistantsValue = [makePairedAssistant(), makePlatformAssistant()];
+
+    render(<SelectAssistantScreen />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Choose an Assistant")).toBeTruthy(),
+    );
+    expect(screen.queryByText("Vellum Cloud")).toBeNull();
+  });
+
+  test("no Vellum Cloud card on a browser surface", async () => {
+    assistantSwitcherValue = true;
+    nativeCloudOriginValue = "https://app.vellum.ai";
+    assistantsValue = [makePairedAssistant(), makePlatformAssistant()];
+
+    render(<SelectAssistantScreen />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Choose an Assistant")).toBeTruthy(),
+    );
+    expect(screen.queryByText("Vellum Cloud")).toBeNull();
   });
 });
 

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
@@ -1122,6 +1122,43 @@ describe("SelectAssistantScreen native mobile", () => {
     expect(switchToOriginMock).not.toHaveBeenCalled();
   });
 
+  test("a rejected cloud switch falls back to a plain navigation", async () => {
+    assistantSwitcherValue = true;
+    isNativeMobileValue = true;
+    nativeCloudOriginValue = "https://app.vellum.ai";
+    assistantsValue = [];
+    switchToVellumCloudMock.mockImplementation(async () => false);
+    const assignSpy = mock((_url: string) => {});
+    const originalLocation = window.location;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...originalLocation, assign: assignSpy },
+    });
+
+    try {
+      render(<SelectAssistantScreen />);
+
+      await waitFor(() =>
+        expect(screen.getByText("Vellum Cloud")).toBeTruthy(),
+      );
+      fireEvent.click(screen.getByText("Vellum Cloud"));
+      fireEvent.click(screen.getByText("Continue"));
+
+      await waitFor(() =>
+        expect(assignSpy).toHaveBeenCalledWith(
+          "https://app.vellum.ai/assistant",
+        ),
+      );
+    } finally {
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: originalLocation,
+      });
+      // mockClear keeps the implementation, so restore the default here.
+      switchToVellumCloudMock.mockImplementation(async () => true);
+    }
+  });
+
   test("no Vellum Cloud card when the shell already serves the baked origin", async () => {
     assistantSwitcherValue = true;
     isNativeMobileValue = true;

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -12,7 +12,11 @@ import { useNavigate, useSearchParams } from "react-router";
 
 import { resolveSelectedAssistantId } from "@/assistant/selection";
 import { retireAssistant } from "@/assistant/retire-service";
-import { isCurrentOrigin, switchToOrigin } from "@/assistant/switch-origin";
+import {
+  isCurrentOrigin,
+  switchToOrigin,
+  switchToVellumCloud,
+} from "@/assistant/switch-origin";
 import { removePairedAssistant } from "@/assistant/switch-service";
 import { RemoveFromDeviceDialog } from "@/components/remove-from-device-dialog";
 import {
@@ -38,6 +42,11 @@ import {
   requiresGuardianReprovision,
   wakeLocalAssistantHost,
 } from "@/runtime/local-mode-host";
+import { useIsNativeMobile } from "@/runtime/platform-detection";
+import {
+  installNativeRememberedOrigins,
+  nativeVellumCloudOrigin,
+} from "@/runtime/self-hosted-servers";
 import { useAuthStore, useHasPlatformSession } from "@/stores/auth-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { useConnectDialogStore } from "@/stores/connect-dialog-store";
@@ -78,7 +87,14 @@ function assistantSubtitle(a: ResolvedAssistant): string {
   return `${hosting} · Created ${formatRelativeDate(a.hatchedAt)}`;
 }
 
-function originLabel(origin: RememberedOrigin): string {
+/**
+ * What an origin card renders from. The baked Vellum Cloud origin a native
+ * shell reports has no `addedAt` of its own, so the card asks only for the
+ * identity and the label.
+ */
+type OriginCardEntry = Pick<RememberedOrigin, "name" | "url">;
+
+function originLabel(origin: OriginCardEntry): string {
   return origin.name ?? new URL(origin.url).hostname;
 }
 
@@ -86,9 +102,12 @@ function originLabel(origin: RememberedOrigin): string {
  * Selection key for a remembered-origin card in the shared radio group.
  * Assistant ids never carry a scheme, so the prefixed url cannot collide.
  */
-function originSelectionKey(origin: RememberedOrigin): string {
+function originSelectionKey(origin: OriginCardEntry): string {
   return `origin:${origin.url}`;
 }
+
+/** Selection key for the native shell's baked Vellum Cloud card. */
+const CLOUD_SELECTION_KEY = "origin:vellum-cloud";
 
 // Stable empty list for the flag-off render so effects keyed on the origin
 // entries do not re-run every render.
@@ -130,6 +149,7 @@ export function SelectAssistantScreen() {
   const flagsHydrated = useClientFeatureFlagStore.use.hydrated();
   const origins = useRememberedOriginsStore.use.origins();
   const originsHydrated = useRememberedOriginsStore.use.hydrated();
+  const nativeMobile = useIsNativeMobile();
   // Origin-UI gate: every remembered-origin surface renders only behind the
   // flag, in every mode, so the flag-off screen is pixel-identical to a
   // build without origin support.
@@ -141,14 +161,25 @@ export function SelectAssistantScreen() {
     cancel: cancelLogin,
   } = useOnboardingLogin();
 
+  // The native shell's baked Vellum Cloud origin, present only while the shell
+  // is pointed somewhere else and only on a build carrying the plugin. Behind
+  // the same origin-UI gate as the remembered entries.
+  const [cloudOriginUrl, setCloudOriginUrl] = useState<string | null>(null);
+  const cloudOrigin: OriginCardEntry | null =
+    assistantSwitcher && cloudOriginUrl !== null
+      ? { url: cloudOriginUrl, name: "Vellum Cloud" }
+      : null;
+
   const isAccessible = (a: ResolvedAssistant): boolean =>
     a.isLocal || a.isPaired || hasPlatformSession;
 
   const accessibleAssistants = assistants.filter(isAccessible);
-  // Origin cards are always selectable, so either kind of entry gives
-  // Continue something to act on.
+  // Origin cards are always selectable, so any kind of entry gives Continue
+  // something to act on.
   const hasSelectableEntries =
-    accessibleAssistants.length > 0 || originEntries.length > 0;
+    accessibleAssistants.length > 0 ||
+    originEntries.length > 0 ||
+    cloudOrigin !== null;
 
   // Unpairing and importing a pairing bundle both rewrite the lockfile
   // through the local-mode host, and a pairing is device-local regardless of
@@ -215,9 +246,30 @@ export function SelectAssistantScreen() {
 
   useEffect(() => {
     if (assistantSwitcher) {
+      // Native mobile keeps its origins in the shell rather than in web
+      // storage, so the provider swap happens before the first load. Both
+      // calls sit behind the flag so nothing reaches the bridge with it off.
+      installNativeRememberedOrigins();
       void useRememberedOriginsStore.getState().hydrate();
     }
   }, [assistantSwitcher]);
+
+  // The way back to Vellum Cloud, offered only by a shell that is currently
+  // serving a self-hosted origin.
+  useEffect(() => {
+    if (!assistantSwitcher || !nativeMobile) {
+      return;
+    }
+    let cancelled = false;
+    void nativeVellumCloudOrigin().then((url) => {
+      if (!cancelled) {
+        setCloudOriginUrl(url);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [assistantSwitcher, nativeMobile]);
 
   // `?register=<url>&name=<label>` handoff: another origin's Switch
   // Assistant action self-registers here so the hub lists it. Records the
@@ -267,6 +319,9 @@ export function SelectAssistantScreen() {
   // platform cards), so Continue can never target a locked assistant. A
   // selected remembered origin needs no session, so it stands.
   useEffect(() => {
+    if (selected === CLOUD_SELECTION_KEY && cloudOriginUrl !== null) {
+      return;
+    }
     if (
       selected != null &&
       originEntries.some((o) => originSelectionKey(o) === selected)
@@ -288,7 +343,13 @@ export function SelectAssistantScreen() {
     const resolved = resolveSelectedAssistantId(currentOrganizationId);
     const match = accessibleAssistants.find((a) => a.id === resolved);
     setSelected(match?.id ?? accessibleAssistants[0].id);
-  }, [selected, accessibleAssistants, currentOrganizationId, originEntries]);
+  }, [
+    selected,
+    accessibleAssistants,
+    currentOrganizationId,
+    originEntries,
+    cloudOriginUrl,
+  ]);
 
   const handleConnect = async (assistant: ResolvedAssistant) => {
     setConnecting(true);
@@ -498,7 +559,7 @@ export function SelectAssistantScreen() {
   const handleOriginAdded = (origin: RememberedOrigin) => {
     setAddOriginOpen(false);
     // Landing on the origin runs its own pair flow when no session exists.
-    switchToOrigin(origin);
+    void switchToOrigin(origin);
   };
 
   // Auto-skip when there's exactly one assistant and it's accessible.
@@ -550,6 +611,10 @@ export function SelectAssistantScreen() {
   ]);
 
   const onContinue = () => {
+    if (selected === CLOUD_SELECTION_KEY) {
+      void switchToVellumCloud();
+      return;
+    }
     const origin = originEntries.find(
       (o) => originSelectionKey(o) === selected,
     );
@@ -557,7 +622,7 @@ export function SelectAssistantScreen() {
       if (isCurrentOrigin(origin)) {
         void navigate(routes.assistant, { replace: true });
       } else {
-        switchToOrigin(origin);
+        void switchToOrigin(origin);
       }
       return;
     }
@@ -674,6 +739,21 @@ export function SelectAssistantScreen() {
               />
             );
           })}
+          {cloudOrigin && (
+            <RemoteOriginCard
+              origin={cloudOrigin}
+              icon={<Cloud className="h-5 w-5" />}
+              selected={selected === CLOUD_SELECTION_KEY}
+              current={false}
+              tabStop={
+                selected == null
+                  ? accessibleAssistants.length === 0 &&
+                    originEntries.length === 0
+                  : selected === CLOUD_SELECTION_KEY
+              }
+              onSelect={() => setSelected(CLOUD_SELECTION_KEY)}
+            />
+          )}
           {isLocalClient() && (
             <DashedActionButton
               icon={<Plus className="h-4 w-4" />}
@@ -1005,28 +1085,32 @@ function AssistantCard({
 }
 
 /**
- * Chooser card for a remembered remote origin, in the `AssistantCard` visual
- * language. An origin is only an address remembered on this device: it is
- * always selectable (no session is needed to navigate away), and its menu
- * removal only forgets the entry here.
+ * Chooser card for a remote origin, in the `AssistantCard` visual language. An
+ * origin is only an address: it is always selectable (no session is needed to
+ * navigate away), and its menu removal only forgets the entry on this device.
+ * The native shell's baked Vellum Cloud origin reuses the card without a menu,
+ * since there is no device-local entry to forget.
  */
 function RemoteOriginCard({
   origin,
+  icon,
   selected,
   current,
   tabStop,
   onSelect,
   onRemove,
 }: {
-  origin: RememberedOrigin;
+  origin: OriginCardEntry;
+  /** Defaults to the remote-origin globe. */
+  icon?: ReactNode;
   selected: boolean;
   /** Whether this origin is the deployment serving the running app. */
   current: boolean;
   /** The radiogroup's single roving tab stop lands on this card. */
   tabStop: boolean;
   onSelect: () => void;
-  /** Opens the remove-from-this-device confirmation. */
-  onRemove: () => void;
+  /** Opens the remove-from-this-device confirmation, when there is one. */
+  onRemove?: () => void;
 }) {
   const electron = isElectron();
   const hostname = new URL(origin.url).hostname;
@@ -1064,7 +1148,7 @@ function RemoteOriginCard({
             : "bg-[var(--surface-active)]/40 text-[var(--content-secondary)]",
         ].join(" ")}
       >
-        <Globe className="h-5 w-5" />
+        {icon ?? <Globe className="h-5 w-5" />}
       </div>
 
       <div className="min-w-0 flex-1">
@@ -1079,33 +1163,35 @@ function RemoteOriginCard({
       </div>
 
       <div className="flex shrink-0 items-center gap-2">
-        {/* The trigger sits inside the radio card: stop clicks and keys from
-            bubbling so opening the menu never selects the card and the
-            radio's Enter/Space handler never swallows the trigger. */}
-        <div
-          onClick={(e) => e.stopPropagation()}
-          onKeyDown={(e) => e.stopPropagation()}
-        >
-          <Menu.Root>
-            <Menu.Trigger asChild>
-              <Button
-                variant="ghost"
-                size="regular"
-                className="text-[var(--content-tertiary)]"
-                iconOnly={<EllipsisVertical />}
-                aria-label={`Actions for ${originLabel(origin)}`}
-              />
-            </Menu.Trigger>
-            <Menu.Content align="end" sideOffset={4}>
-              <Menu.Item
-                onSelect={onRemove}
-                className="text-[var(--system-negative-strong)] data-[highlighted]:text-[var(--system-negative-strong)]"
-              >
-                Remove from this device…
-              </Menu.Item>
-            </Menu.Content>
-          </Menu.Root>
-        </div>
+        {onRemove && (
+          /* The trigger sits inside the radio card: stop clicks and keys from
+             bubbling so opening the menu never selects the card and the
+             radio's Enter/Space handler never swallows the trigger. */
+          <div
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => e.stopPropagation()}
+          >
+            <Menu.Root>
+              <Menu.Trigger asChild>
+                <Button
+                  variant="ghost"
+                  size="regular"
+                  className="text-[var(--content-tertiary)]"
+                  iconOnly={<EllipsisVertical />}
+                  aria-label={`Actions for ${originLabel(origin)}`}
+                />
+              </Menu.Trigger>
+              <Menu.Content align="end" sideOffset={4}>
+                <Menu.Item
+                  onSelect={onRemove}
+                  className="text-[var(--system-negative-strong)] data-[highlighted]:text-[var(--system-negative-strong)]"
+                >
+                  Remove from this device…
+                </Menu.Item>
+              </Menu.Content>
+            </Menu.Root>
+          </div>
+        )}
         <div
           className={[
             "flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 transition-all duration-200",

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -612,7 +612,13 @@ export function SelectAssistantScreen() {
 
   const onContinue = () => {
     if (selected === CLOUD_SELECTION_KEY) {
-      void switchToVellumCloud();
+      // A rejected bridge switch leaves the shell where it is, so fall back
+      // to the plain navigation the card's url already gives us.
+      void switchToVellumCloud().then((switched) => {
+        if (!switched && cloudOriginUrl !== null) {
+          window.location.assign(`${cloudOriginUrl}/assistant`);
+        }
+      });
       return;
     }
     const origin = originEntries.find(

--- a/clients/web/src/runtime/self-hosted-servers.test.ts
+++ b/clients/web/src/runtime/self-hosted-servers.test.ts
@@ -159,6 +159,63 @@ describe("nativeRememberedOriginsProvider load", () => {
     // debug line rather than a captured error.
     expect(consoleDebugSpy).toHaveBeenCalled();
   });
+
+  test("migrates pre-plugin localStorage entries into the native list once", async () => {
+    await localStorageProvider.save([
+      { url: "https://legacy.example", name: "Legacy", addedAt: EPOCH },
+      { url: "https://shared.example", addedAt: EPOCH },
+    ]);
+    listResult = {
+      servers: [{ url: "https://shared.example" }],
+      activeUrl: null,
+      bakedUrl: null,
+    };
+
+    const provider = nativeRememberedOriginsProvider();
+    const first = await provider.load();
+
+    // The entry the native list already holds is not re-added.
+    expect(addMock).toHaveBeenCalledTimes(1);
+    expect(addMock).toHaveBeenCalledWith({
+      url: "https://legacy.example",
+      name: "Legacy",
+    });
+    expect(first.map((o) => o.url)).toEqual([
+      "https://shared.example",
+      "https://legacy.example",
+    ]);
+
+    // Migration is one-time: a later load issues no further writes.
+    addMock.mockClear();
+    listResult = {
+      servers: [
+        { url: "https://shared.example" },
+        { name: "Legacy", url: "https://legacy.example" },
+      ],
+      activeUrl: null,
+      bakedUrl: null,
+    };
+    await provider.load();
+    expect(addMock).not.toHaveBeenCalled();
+  });
+
+  test("retries the migration when a native add fails", async () => {
+    await localStorageProvider.save([
+      { url: "https://legacy.example", addedAt: EPOCH },
+    ]);
+    addRejects = true;
+
+    const provider = nativeRememberedOriginsProvider();
+    // The entry still shows up so the user does not see it vanish.
+    expect((await provider.load()).map((o) => o.url)).toEqual([
+      "https://legacy.example",
+    ]);
+
+    addRejects = false;
+    addMock.mockClear();
+    await provider.load();
+    expect(addMock).toHaveBeenCalledWith({ url: "https://legacy.example" });
+  });
 });
 
 describe("nativeRememberedOriginsProvider save", () => {

--- a/clients/web/src/runtime/self-hosted-servers.test.ts
+++ b/clients/web/src/runtime/self-hosted-servers.test.ts
@@ -1,0 +1,353 @@
+/**
+ * The `SelfHostedServers` bridge seam: the store provider's mapping and
+ * diff-save, the switch and baked-origin reads, and the skew fallbacks that
+ * keep an older shell (no plugin) on the localStorage behavior it already had.
+ *
+ * Self-contained mocks: run this file solo (`mock.module` leaks across a
+ * shared `bun test` run).
+ */
+
+import {
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
+
+let isNativeMobileValue = true;
+mock.module("@/runtime/platform-detection", () => ({
+  isNativeMobile: () => isNativeMobileValue,
+}));
+
+interface NativeEntry {
+  name?: string;
+  url: string;
+}
+interface NativeList {
+  servers: NativeEntry[];
+  activeUrl: string | null;
+  bakedUrl: string | null;
+}
+
+let listResult: NativeList = { servers: [], activeUrl: null, bakedUrl: null };
+/** Simulates a shell whose build predates the plugin: every call rejects. */
+let bridgeRejects = false;
+let addRejects = false;
+
+function bridgeFailure(method: string): Error {
+  return new Error(`SelfHostedServers.${method}() is not implemented on ios`);
+}
+
+const listMock = mock(async (): Promise<NativeList> => {
+  if (bridgeRejects) {
+    throw bridgeFailure("list");
+  }
+  return listResult;
+});
+const addMock = mock(async (_options: { url: string; name?: string }) => {
+  if (bridgeRejects || addRejects) {
+    throw bridgeFailure("add");
+  }
+  return { ok: true };
+});
+const removeMock = mock(async (_options: { url: string }) => {
+  if (bridgeRejects) {
+    throw bridgeFailure("remove");
+  }
+  return { ok: true };
+});
+const switchToMock = mock(async (_options: { url?: string }) => {
+  if (bridgeRejects) {
+    throw bridgeFailure("switchTo");
+  }
+  return { ok: true };
+});
+
+mock.module("@capacitor/core", () => ({
+  registerPlugin: (name: string) =>
+    name === "SelfHostedServers"
+      ? {
+          list: listMock,
+          add: addMock,
+          remove: removeMock,
+          switchTo: switchToMock,
+        }
+      : {},
+}));
+
+const {
+  installNativeRememberedOrigins,
+  nativeRememberedOriginsProvider,
+  nativeSwitchToOrigin,
+  nativeVellumCloudOrigin,
+} = await import("@/runtime/self-hosted-servers");
+
+const {
+  REMEMBERED_ORIGINS_STORAGE_KEY,
+  localStorageProvider,
+  setRememberedOriginsProvider,
+  useRememberedOriginsStore,
+} = await import("@/stores/remembered-origins-store");
+
+const consoleDebugSpy = spyOn(console, "debug").mockImplementation(() => {});
+
+const EPOCH = "1970-01-01T00:00:00.000Z";
+
+beforeEach(() => {
+  isNativeMobileValue = true;
+  listResult = { servers: [], activeUrl: null, bakedUrl: null };
+  bridgeRejects = false;
+  addRejects = false;
+  listMock.mockClear();
+  addMock.mockClear();
+  removeMock.mockClear();
+  switchToMock.mockClear();
+  consoleDebugSpy.mockClear();
+  window.localStorage.clear();
+});
+
+describe("nativeRememberedOriginsProvider load", () => {
+  test("maps the native list onto store entries in canonical form", async () => {
+    listResult = {
+      servers: [
+        { name: "Homelab", url: "https://host.example/assistant-1" },
+        { url: "HTTPS://Other.Example/" },
+      ],
+      activeUrl: "https://host.example/assistant-1",
+      bakedUrl: "https://app.vellum.ai",
+    };
+
+    expect(await nativeRememberedOriginsProvider().load()).toEqual([
+      {
+        name: "Homelab",
+        url: "https://host.example/assistant-1",
+        addedAt: EPOCH,
+      },
+      { url: "https://other.example", addedAt: EPOCH },
+    ]);
+  });
+
+  test("drops unusable and duplicate native entries", async () => {
+    listResult = {
+      servers: [
+        { url: "https://host.example" },
+        { url: "https://host.example/" },
+        { url: "http://insecure.example" },
+        { url: "not a url" },
+      ],
+      activeUrl: null,
+      bakedUrl: null,
+    };
+
+    expect(
+      (await nativeRememberedOriginsProvider().load()).map((o) => o.url),
+    ).toEqual(["https://host.example"]);
+  });
+
+  test("falls back to the localStorage provider on an older shell", async () => {
+    bridgeRejects = true;
+    await localStorageProvider.save([
+      { url: "https://stored.example", name: "Stored", addedAt: EPOCH },
+    ]);
+
+    expect(await nativeRememberedOriginsProvider().load()).toEqual([
+      { url: "https://stored.example", name: "Stored", addedAt: EPOCH },
+    ]);
+    // An older shell is an expected state on every web deploy, so it is a
+    // debug line rather than a captured error.
+    expect(consoleDebugSpy).toHaveBeenCalled();
+  });
+});
+
+describe("nativeRememberedOriginsProvider save", () => {
+  test("issues only the add and remove deltas", async () => {
+    listResult = {
+      servers: [
+        { url: "https://keep.example", name: "Keep" },
+        { url: "https://drop.example" },
+      ],
+      activeUrl: null,
+      bakedUrl: null,
+    };
+
+    await nativeRememberedOriginsProvider().save([
+      { url: "https://keep.example", name: "Keep", addedAt: EPOCH },
+      { url: "https://new.example", name: "New", addedAt: EPOCH },
+    ]);
+
+    expect(removeMock).toHaveBeenCalledTimes(1);
+    expect(removeMock).toHaveBeenCalledWith({ url: "https://drop.example" });
+    expect(addMock).toHaveBeenCalledTimes(1);
+    expect(addMock).toHaveBeenCalledWith({
+      url: "https://new.example",
+      name: "New",
+    });
+  });
+
+  test("writes nothing when the desired list already matches", async () => {
+    listResult = {
+      servers: [{ url: "https://keep.example", name: "Keep" }],
+      activeUrl: null,
+      bakedUrl: null,
+    };
+
+    await nativeRememberedOriginsProvider().save([
+      { url: "https://keep.example", name: "Keep", addedAt: EPOCH },
+    ]);
+
+    expect(addMock).not.toHaveBeenCalled();
+    expect(removeMock).not.toHaveBeenCalled();
+  });
+
+  test("re-adds an entry whose label changed", async () => {
+    listResult = {
+      servers: [{ url: "https://keep.example", name: "Old" }],
+      activeUrl: null,
+      bakedUrl: null,
+    };
+
+    await nativeRememberedOriginsProvider().save([
+      { url: "https://keep.example", name: "New", addedAt: EPOCH },
+    ]);
+
+    expect(addMock).toHaveBeenCalledWith({
+      url: "https://keep.example",
+      name: "New",
+    });
+    expect(removeMock).not.toHaveBeenCalled();
+  });
+
+  test("surfaces a rejected write instead of dropping the entry", async () => {
+    addRejects = true;
+
+    await expect(
+      nativeRememberedOriginsProvider().save([
+        { url: "https://new.example", addedAt: EPOCH },
+      ]),
+    ).rejects.toThrow();
+  });
+
+  test("falls back to the localStorage provider on an older shell", async () => {
+    bridgeRejects = true;
+
+    await nativeRememberedOriginsProvider().save([
+      { url: "https://stored.example", addedAt: EPOCH },
+    ]);
+
+    expect(addMock).not.toHaveBeenCalled();
+    const raw = window.localStorage.getItem(REMEMBERED_ORIGINS_STORAGE_KEY);
+    expect(raw).toContain("https://stored.example");
+  });
+});
+
+describe("nativeSwitchToOrigin", () => {
+  test("swaps the shell origin and reports success", async () => {
+    expect(await nativeSwitchToOrigin("https://host.example")).toBe(true);
+    expect(switchToMock).toHaveBeenCalledWith({
+      url: "https://host.example",
+    });
+  });
+
+  test("a null url asks for the baked origin", async () => {
+    expect(await nativeSwitchToOrigin(null)).toBe(true);
+    expect(switchToMock).toHaveBeenCalledWith({});
+  });
+
+  test("resolves false on an older shell so the caller can fall back", async () => {
+    bridgeRejects = true;
+
+    expect(await nativeSwitchToOrigin("https://host.example")).toBe(false);
+    expect(consoleDebugSpy).toHaveBeenCalled();
+  });
+
+  test("never reaches the bridge off native mobile", async () => {
+    isNativeMobileValue = false;
+
+    expect(await nativeSwitchToOrigin("https://host.example")).toBe(false);
+    expect(switchToMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("nativeVellumCloudOrigin", () => {
+  test("reports the baked origin while a self-hosted origin is active", async () => {
+    listResult = {
+      servers: [],
+      activeUrl: "https://host.example",
+      bakedUrl: "https://app.vellum.ai/",
+    };
+
+    expect(await nativeVellumCloudOrigin()).toBe("https://app.vellum.ai");
+  });
+
+  test("reports nothing when the shell already serves the baked origin", async () => {
+    listResult = {
+      servers: [],
+      activeUrl: null,
+      bakedUrl: "https://app.vellum.ai",
+    };
+
+    expect(await nativeVellumCloudOrigin()).toBeNull();
+  });
+
+  test("reports nothing when the baked origin is unreadable", async () => {
+    listResult = {
+      servers: [],
+      activeUrl: "https://host.example",
+      bakedUrl: null,
+    };
+
+    expect(await nativeVellumCloudOrigin()).toBeNull();
+  });
+
+  test("reports nothing on an older shell or off native mobile", async () => {
+    bridgeRejects = true;
+    expect(await nativeVellumCloudOrigin()).toBeNull();
+
+    bridgeRejects = false;
+    isNativeMobileValue = false;
+    listResult = {
+      servers: [],
+      activeUrl: "https://host.example",
+      bakedUrl: "https://app.vellum.ai",
+    };
+    expect(await nativeVellumCloudOrigin()).toBeNull();
+    expect(listMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+// Installing swaps the process-wide store provider, so this runs last.
+describe("installNativeRememberedOrigins", () => {
+  test("leaves the localStorage provider in place off native mobile", async () => {
+    isNativeMobileValue = false;
+    await localStorageProvider.save([
+      { url: "https://stored.example", addedAt: EPOCH },
+    ]);
+
+    installNativeRememberedOrigins();
+    await useRememberedOriginsStore.getState().hydrate();
+
+    expect(
+      useRememberedOriginsStore.getState().origins.map((o) => o.url),
+    ).toEqual(["https://stored.example"]);
+    expect(listMock).not.toHaveBeenCalled();
+  });
+
+  test("points the store at the native list on a mobile shell", async () => {
+    listResult = {
+      servers: [{ url: "https://host.example", name: "Homelab" }],
+      activeUrl: "https://host.example",
+      bakedUrl: "https://app.vellum.ai",
+    };
+
+    installNativeRememberedOrigins();
+    await useRememberedOriginsStore.getState().hydrate();
+
+    expect(useRememberedOriginsStore.getState().origins).toEqual([
+      { url: "https://host.example", name: "Homelab", addedAt: EPOCH },
+    ]);
+
+    setRememberedOriginsProvider(localStorageProvider);
+  });
+});

--- a/clients/web/src/runtime/self-hosted-servers.ts
+++ b/clients/web/src/runtime/self-hosted-servers.ts
@@ -1,0 +1,199 @@
+/**
+ * JS side of the `SelfHostedServers` Capacitor plugin
+ * (`clients/ios/App/App/SelfHostedServersPlugin.swift`), which owns the
+ * remembered assistant origins on a native mobile shell.
+ *
+ * On a shell that has the plugin, the native list is the source of truth: it
+ * survives a web-storage clear, it is the same list the native Settings pane
+ * and the `<scheme>://connect` deep link write, and only the shell can point
+ * its `WKWebView` at another origin without leaving the app. So the chooser
+ * installs {@link nativeRememberedOriginsProvider} over the store's default
+ * localStorage provider, and `switchToOrigin` routes through
+ * {@link nativeSwitchToOrigin}.
+ *
+ * **Skew contract** (`docs/CAPACITOR.md` § The skew rule): this bundle is live
+ * for every user on their next app load while the installed shell only changes
+ * after App Store review, so the plugin may always be absent. Every bridge call
+ * is wrapped: a failure is an expected older shell, so it logs `console.debug`
+ * (never `captureError`) and degrades to the behavior that shell already had,
+ * which is the localStorage provider for storage and a plain navigation for
+ * switching. There is no availability probe: a probe can itself be absent, and
+ * the failure of the call the caller wanted to make is the same answer.
+ */
+
+import { registerPlugin } from "@capacitor/core";
+
+import { isNativeMobile } from "@/runtime/platform-detection";
+import {
+  localStorageProvider,
+  normalizeOriginUrl,
+  setRememberedOriginsProvider,
+  toRememberedOrigins,
+  type RememberedOriginsProvider,
+} from "@/stores/remembered-origins-store";
+
+/** One remembered server as the plugin reports it. */
+interface SelfHostedServerEntry {
+  name?: string;
+  url: string;
+}
+
+interface SelfHostedServersList {
+  servers: SelfHostedServerEntry[];
+  /** The configured self-hosted origin, or `null` when on the baked default. */
+  activeUrl: string | null;
+  /** The Vellum Cloud origin the shell ships with, or `null` if unreadable. */
+  bakedUrl: string | null;
+}
+
+interface SelfHostedServersPlugin {
+  list(): Promise<SelfHostedServersList>;
+  add(options: { url: string; name?: string }): Promise<{ ok: boolean }>;
+  remove(options: { url: string }): Promise<{ ok: boolean }>;
+  /** An absent `url` returns the shell to its baked Vellum Cloud origin. */
+  switchTo(options: { url?: string }): Promise<{ ok: boolean }>;
+}
+
+/**
+ * `registerPlugin` only builds the bridge Proxy, so this is inert until a
+ * method is called: nothing reaches the shell before the flag-gated
+ * {@link installNativeRememberedOrigins}.
+ */
+const SelfHostedServers =
+  registerPlugin<SelfHostedServersPlugin>("SelfHostedServers");
+
+/**
+ * `addedAt` for natively-stored entries. The plugin records `{name?, url}` and
+ * nothing else, so the timestamp is unknowable here; a stable constant keeps
+ * the entry identity (its url) stable across loads, which is all the store and
+ * the chooser read it for.
+ */
+const NATIVE_ADDED_AT = "1970-01-01T00:00:00.000Z";
+
+/**
+ * Read the native list, or `null` when the bridge is unavailable. Only the
+ * result crosses the `async` boundary, never the plugin Proxy itself, per
+ * `docs/CAPACITOR.md` § "Capacitor plugins must be destructured inline".
+ */
+async function listNativeServers(): Promise<SelfHostedServersList | null> {
+  try {
+    return await SelfHostedServers.list();
+  } catch (err) {
+    console.debug("[self-hosted-servers] bridge unavailable:", err);
+    return null;
+  }
+}
+
+/**
+ * Store provider backed by the native list, falling back to the localStorage
+ * provider whenever the bridge is unavailable.
+ *
+ * `save` receives the full desired list and diffs it against what the shell
+ * currently holds, because the plugin exposes per-entry `add`/`remove` rather
+ * than a whole-list write. A rejected `add`/`remove` propagates so the store
+ * reports the mutation as failed instead of publishing an entry the shell does
+ * not hold.
+ */
+export function nativeRememberedOriginsProvider(): RememberedOriginsProvider {
+  return {
+    load: async () => {
+      const listed = await listNativeServers();
+      if (listed === null) {
+        return localStorageProvider.load();
+      }
+      return toRememberedOrigins(listed.servers, NATIVE_ADDED_AT);
+    },
+
+    save: async (entries) => {
+      const listed = await listNativeServers();
+      if (listed === null) {
+        await localStorageProvider.save(entries);
+        return;
+      }
+      const current = new Map(
+        toRememberedOrigins(listed.servers, NATIVE_ADDED_AT).map((o) => [
+          o.url,
+          o.name,
+        ]),
+      );
+      const desired = new Set(entries.map((o) => o.url));
+      // Serial, not concurrent: each native write is a read-modify-write of
+      // one stored list, so overlapping calls would drop each other's edit.
+      for (const url of current.keys()) {
+        if (!desired.has(url)) {
+          await SelfHostedServers.remove({ url });
+        }
+      }
+      for (const entry of entries) {
+        // A nameless re-add keeps the stored label natively, so only a new or
+        // changed name is worth a write.
+        if (
+          !current.has(entry.url) ||
+          (entry.name && entry.name !== current.get(entry.url))
+        ) {
+          await SelfHostedServers.add({
+            url: entry.url,
+            ...(entry.name ? { name: entry.name } : {}),
+          });
+        }
+      }
+    },
+
+    // The native list changes only through this provider, so the forwarded
+    // localStorage watch matters solely on the fallback path, where it keeps
+    // the default provider's cross-tab behavior intact.
+    watch: localStorageProvider.watch,
+  };
+}
+
+let providerInstalled = false;
+
+/**
+ * Point the remembered-origins store at the native list on a mobile shell.
+ * Idempotent, and a no-op everywhere else so web and Electron keep the
+ * localStorage provider.
+ */
+export function installNativeRememberedOrigins(): void {
+  if (providerInstalled || !isNativeMobile()) {
+    return;
+  }
+  providerInstalled = true;
+  setRememberedOriginsProvider(nativeRememberedOriginsProvider());
+}
+
+/**
+ * Swap the shell's origin in place, `null` meaning "back to the baked Vellum
+ * Cloud origin". Resolves whether the shell took the switch, so a caller on an
+ * older shell (or off native mobile) can fall back to a plain navigation.
+ */
+export async function nativeSwitchToOrigin(
+  url: string | null,
+): Promise<boolean> {
+  if (!isNativeMobile()) {
+    return false;
+  }
+  try {
+    await SelfHostedServers.switchTo(url === null ? {} : { url });
+    return true;
+  } catch (err) {
+    console.debug("[self-hosted-servers] switchTo unavailable:", err);
+    return false;
+  }
+}
+
+/**
+ * The baked Vellum Cloud origin to offer as a way back, or `null` when there
+ * is nothing to offer: off native mobile, on a shell without the plugin, or
+ * when the shell is already serving the baked origin (no configured
+ * self-hosted slot).
+ */
+export async function nativeVellumCloudOrigin(): Promise<string | null> {
+  if (!isNativeMobile()) {
+    return null;
+  }
+  const listed = await listNativeServers();
+  if (listed === null || !listed.activeUrl) {
+    return null;
+  }
+  return listed.bakedUrl ? normalizeOriginUrl(listed.bakedUrl) : null;
+}

--- a/clients/web/src/runtime/self-hosted-servers.ts
+++ b/clients/web/src/runtime/self-hosted-servers.ts
@@ -29,6 +29,7 @@ import {
   normalizeOriginUrl,
   setRememberedOriginsProvider,
   toRememberedOrigins,
+  type RememberedOrigin,
   type RememberedOriginsProvider,
 } from "@/stores/remembered-origins-store";
 
@@ -85,6 +86,66 @@ async function listNativeServers(): Promise<SelfHostedServersList | null> {
 }
 
 /**
+ * Marker for the one-time localStorage-to-native migration. Shells that
+ * predate the plugin remembered their origins in web storage, so the first
+ * successful native load folds those entries in rather than letting the
+ * native list silently drop them.
+ */
+const MIGRATION_MARKER_KEY = "vellum:remembered-origins:native-migrated";
+
+function migrationDone(): boolean {
+  try {
+    return window.localStorage.getItem(MIGRATION_MARKER_KEY) === "true";
+  } catch {
+    // No web storage means nothing to migrate from.
+    return true;
+  }
+}
+
+function markMigrationDone(): void {
+  try {
+    window.localStorage.setItem(MIGRATION_MARKER_KEY, "true");
+  } catch {
+    // A failed marker write only costs a repeat merge, which is idempotent.
+  }
+}
+
+/**
+ * Fold pre-plugin localStorage entries into the native list once, returning
+ * the merged view. Native entries win on name conflicts, since the shell and
+ * its deep links are the newer writer.
+ */
+async function migrateLocalOriginsIntoNative(
+  native: RememberedOrigin[],
+): Promise<RememberedOrigin[]> {
+  if (migrationDone()) {
+    return native;
+  }
+  let local: RememberedOrigin[] = [];
+  try {
+    local = await localStorageProvider.load();
+  } catch {
+    local = [];
+  }
+  const knownUrls = new Set(native.map((o) => o.url));
+  const missing = local.filter((o) => !knownUrls.has(o.url));
+  for (const entry of missing) {
+    try {
+      await SelfHostedServers.add({
+        url: entry.url,
+        ...(entry.name ? { name: entry.name } : {}),
+      });
+    } catch (err) {
+      // Leave the marker unset so the next load retries the merge.
+      console.debug("[self-hosted-servers] migration add failed:", err);
+      return [...native, ...missing];
+    }
+  }
+  markMigrationDone();
+  return [...native, ...missing];
+}
+
+/**
  * Store provider backed by the native list, falling back to the localStorage
  * provider whenever the bridge is unavailable.
  *
@@ -101,7 +162,8 @@ export function nativeRememberedOriginsProvider(): RememberedOriginsProvider {
       if (listed === null) {
         return localStorageProvider.load();
       }
-      return toRememberedOrigins(listed.servers, NATIVE_ADDED_AT);
+      const native = toRememberedOrigins(listed.servers, NATIVE_ADDED_AT);
+      return migrateLocalOriginsIntoNative(native);
     },
 
     save: async (entries) => {

--- a/clients/web/src/stores/remembered-origins-store.ts
+++ b/clients/web/src/stores/remembered-origins-store.ts
@@ -78,18 +78,23 @@ export interface RememberedOriginsProvider {
 }
 
 /**
- * Defensive parse of persisted JSON: anything that isn't an array becomes
- * empty, and entries whose `url` fails {@link normalizeOriginUrl} (or that
- * duplicate an earlier entry's url) are dropped.
+ * Defensive read of untrusted entry items (persisted JSON, a native bridge
+ * payload): non-object items and urls failing {@link normalizeOriginUrl} are
+ * dropped, and the first entry for a url wins. Every provider funnels its raw
+ * items through here so the backends agree on entry identity.
+ *
+ * @param fallbackAddedAt Stamped on items carrying no `addedAt`. Defaults to
+ *   now; a provider whose backend cannot record the timestamp passes a
+ *   constant so the value is stable across loads.
  */
-function parseStoredEntries(raw: string): RememberedOrigin[] | null {
-  const parsed: unknown = JSON.parse(raw);
-  if (!Array.isArray(parsed)) {
-    return null;
-  }
+export function toRememberedOrigins(
+  items: unknown[],
+  fallbackAddedAt?: string,
+): RememberedOrigin[] {
   const entries: RememberedOrigin[] = [];
   const seen = new Set<string>();
-  for (const item of parsed) {
+  const fallback = fallbackAddedAt ?? new Date().toISOString();
+  for (const item of items) {
     if (typeof item !== "object" || item === null) {
       continue;
     }
@@ -105,11 +110,16 @@ function parseStoredEntries(raw: string): RememberedOrigin[] | null {
     entries.push({
       url: normalized,
       ...(typeof name === "string" && name !== "" ? { name } : {}),
-      addedAt:
-        typeof addedAt === "string" ? addedAt : new Date().toISOString(),
+      addedAt: typeof addedAt === "string" ? addedAt : fallback,
     });
   }
   return entries;
+}
+
+/** Anything that isn't a JSON array reads as unusable, not as empty. */
+function parseStoredEntries(raw: string): RememberedOrigin[] | null {
+  const parsed: unknown = JSON.parse(raw);
+  return Array.isArray(parsed) ? toRememberedOrigins(parsed) : null;
 }
 
 // Device-scoped: the remembered list is this device's client-local view of


### PR DESCRIPTION
## Summary
- Native remembered-origins provider backed by the SelfHostedServers Capacitor plugin, installed from the flag-gated chooser mount with a localStorage fallback on older shells
- switchToOrigin forks to the native bridge (in-app origin swap) with plain-navigation fallback; new Vellum Cloud card returns the shell to the baked origin
- CAPACITOR.md documents the plugin contract and per-surface switch behavior

Part of plan: origin-model-chooser.md (PR 7 of 7)