### PR TITLE
fix(design-library): mark PanelItem's slot and handler args non-editable

### DIFF
--- a/packages/design-library/src/components/panel-item/panel-item.stories.tsx
+++ b/packages/design-library/src/components/panel-item/panel-item.stories.tsx
@@ -26,6 +26,17 @@ const meta: Meta<typeof PanelItem> = {
     activeVariant: { control: "inline-radio", options: ["default", "branded"] },
     label: { control: "text" },
     active: { control: "boolean" },
+    marqueeOnHover: { control: "boolean" },
+    disabled: { control: "boolean" },
+    // Slots and handlers: a component, a node, or a function, none of which a
+    // Controls field can produce. Autodocs surfaces them otherwise.
+    icon: { control: false },
+    leadingSlot: { control: false },
+    expandChevron: { control: false },
+    badge: { control: false },
+    trailingAction: { control: false },
+    onSelect: { control: false },
+    ref: { control: false },
   },
   globals: {
     viewport: { value: "sbDesktop", isRotated: false },

--- a/packages/design-library/src/components/panel-item/panel-item.stories.tsx
+++ b/packages/design-library/src/components/panel-item/panel-item.stories.tsx
@@ -36,6 +36,7 @@ const meta: Meta<typeof PanelItem> = {
     badge: { control: false },
     trailingAction: { control: false },
     onSelect: { control: false },
+    children: { control: false },
     ref: { control: false },
   },
   globals: {


### PR DESCRIPTION
## TL;DR

`PanelItem`'s story exposed slot and handler props as editable Controls. They now carry `control: false`, and the two missing booleans got real controls.

Closes a P3 Codex finding on #40319 that arrived after that PR merged.

## Why

`packages/design-library/AGENTS.md` rule 4:

> set `control: false` for slot/handler props that aren't editable (icons, refs)

The story configured `shape`, `activeVariant`, `label`, and `active`, so autodocs inferred the rest. `icon`, `leadingSlot`, `expandChevron`, `badge`, `trailingAction`, `onSelect`, and `ref` each want a component, a node, or a function — nothing a Controls field can produce. They appeared editable and did nothing, which is the same defect as the dead controls already fixed on the gallery stories, arriving by a different route.

Also adds `marqueeOnHover` and `disabled` controls, which are booleans a reader would reasonably want to toggle.

## What changes for the user

| | Before | After |
|---|---|---|
| Controls panel | Slots and handlers listed as editable fields | Only props a control can actually set |
| `marqueeOnHover`, `disabled` | Inferred, untyped | Boolean toggles |
| Component | Unchanged | Unchanged |

Stories only. 13 tests pass, `tsc` clean.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->