### PR TITLE
Fail closed when a notification channel is enabled but unwired

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -1903,7 +1903,7 @@ Producer → NotificationSignal → Candidate Generation → Decision Engine (LL
 
 `assistant/src/channels/config.ts` is the **single source of truth** for per-channel notification behavior. Every `ChannelId` must have an entry in the `CHANNEL_POLICIES` map (enforced at compile time via `satisfies Record<ChannelId, ChannelNotificationPolicy>`). Each policy defines:
 
-- **`deliveryEnabled`** — whether the channel can receive notification deliveries. The `NotificationChannel` type is derived from this flag: only channels with `deliveryEnabled: true` are valid notification targets.
+- **`deliveryEnabled`**: whether the assistant may **proactively** start a notification on the channel. It does not describe whether the channel can carry outbound messages at all: replying to an inbound message routes by the `replyCallbackUrl` the gateway stamped on the event, through `messaging/providers`, and consults this registry not at all. A channel can therefore reply while sitting at `deliveryEnabled: false`, which is the normal state for one that has a transport but no guardian binding to notify. The `NotificationChannel` type is derived from this flag, and the destination resolver and connectivity check are exhaustive over it, so enabling a channel without wiring both is a compile error.
 - **`conversationStrategy`** — how the notification pipeline materializes conversations for the channel:
   - `start_new_conversation` — creates a fresh conversation per delivery (e.g. vellum desktop/mobile conversations)
   - `continue_existing_conversation` — intended to append to an existing channel-scoped conversation; currently materializes a background audit conversation per delivery (e.g. Telegram)

--- a/assistant/src/notifications/README.md
+++ b/assistant/src/notifications/README.md
@@ -83,10 +83,10 @@ The broadcaster (`broadcaster.ts`) iterates over selected channels (vellum first
 
 Each policy defines:
 
-| Field                               | Type                   | Description                                                       |
-| ----------------------------------- | ---------------------- | ----------------------------------------------------------------- |
-| `notification.deliveryEnabled`      | `boolean`              | Whether the channel can receive notification deliveries           |
-| `notification.conversationStrategy` | `ConversationStrategy` | How conversations are materialized for deliveries on this channel |
+| Field                               | Type                   | Description                                                                                                                                                                                   |
+| ----------------------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `notification.deliveryEnabled`      | `boolean`              | Whether the assistant may **proactively** notify on this channel. Not "can this channel send at all": replies route via `replyCallbackUrl` through `messaging/providers` and never read this. |
+| `notification.conversationStrategy` | `ConversationStrategy` | How conversations are materialized for deliveries on this channel                                                                                                                             |
 
 ### Conversation Strategy Types
 
@@ -110,6 +110,8 @@ Each policy defines:
 3. If `deliveryEnabled: true`, add an adapter in `adapters/` and register it in `emit-signal.ts` `getBroadcaster()`.
 4. Add a connectivity check in `getConnectedChannels()` in `emit-signal.ts`.
 5. Add a destination resolver case in `destination-resolver.ts`.
+
+Steps 4 and 5 are compiler-enforced: both switches are exhaustive over `NotificationChannel`, so setting `deliveryEnabled: true` without them fails the build rather than leaving the channel silently unreachable.
 
 ## Conversation Pairing Invariant
 

--- a/assistant/src/notifications/destination-resolver.ts
+++ b/assistant/src/notifications/destination-resolver.ts
@@ -68,8 +68,9 @@ export function resolveDestinations(
 
     // After the deliverability check, `channel` is guaranteed to be a
     // NotificationChannel — TypeScript cannot infer this from the runtime
-    // guard, so we narrow with a switch over known deliverable values.
-    switch (channel as NotificationChannel) {
+    // guard, so the cast carries it into an exhaustive switch.
+    const notificationChannel = channel as NotificationChannel;
+    switch (notificationChannel) {
       case "vellum": {
         // Vellum delivery is local — no external endpoint required.
         // Include the guardianPrincipalId so the adapter can annotate
@@ -180,7 +181,15 @@ export function resolveDestinations(
         break;
       }
       default: {
-        // Future deliverable channels without a resolver — skip silently.
+        // Exhaustive over NotificationChannel. Setting `deliveryEnabled: true`
+        // without adding a case here fails to compile on this assignment,
+        // which is step 5 of "How to Add a New Channel" in the README turned
+        // into a build error rather than a message that goes nowhere.
+        const unresolved: never = notificationChannel;
+        log.error(
+          { channel: String(unresolved) },
+          "no destination resolver for notification channel",
+        );
         break;
       }
     }

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -120,7 +120,10 @@ export async function getConnectedChannels(): Promise<NotificationChannel[]> {
   // getDeliverableChannels() returns ChannelId[] but every returned channel
   // has deliveryEnabled: true, making it a valid NotificationChannel at
   // runtime. We iterate over the broad type and narrow via the switch.
-  for (const channel of getDeliverableChannels()) {
+  // Cast to the derived union so the switch below is exhaustive: the helper
+  // is typed ChannelId[], but every channel it returns has
+  // `deliveryEnabled: true` and is therefore a NotificationChannel.
+  for (const channel of getDeliverableChannels() as NotificationChannel[]) {
     switch (channel) {
       case "vellum":
         // Vellum is always considered connected (the local transport is
@@ -153,10 +156,18 @@ export async function getConnectedChannels(): Promise<NotificationChannel[]> {
         }
         break;
       }
-      default:
-        // Future deliverable channels — skip until a connectivity check
-        // is implemented for them.
+      default: {
+        // Exhaustive over NotificationChannel. Setting `deliveryEnabled: true`
+        // without adding a case here fails to compile on this assignment,
+        // which is step 4 of "How to Add a New Channel" in the README turned
+        // into a build error rather than a channel silently never connected.
+        const unchecked: never = channel;
+        log.error(
+          { channel: String(unchecked) },
+          "no connectivity check for notification channel",
+        );
         break;
+      }
     }
   }
 


### PR DESCRIPTION
## TL;DR

Two `default` branches in the notification pipeline silently skipped an unwired channel. They become `never`-typed exhaustiveness checks, so the two steps the README already documents are enforced by the build instead of by memory. Plus a docs correction where `deliveryEnabled` is described as something it is not.

Four files, no behaviour change, enabled set unchanged.

## What this is not

An earlier revision of this PR claimed it fixed a live bug and renamed the flag across 14 files. **Both were wrong, and both are gone.** Recording it here because the reasoning matters more than the diff:

- I claimed enabling a channel made it "a selectable notification destination that silently drops". It is not reachable. A channel absent from the resolver is blocked three times first: `getConnectedChannels()` never adds it; that list becomes the decision tool's `enum`, so the model cannot emit the name; and `validateDecisionOutput` filters against the same list. Enabling the flag alone is **inert**.
- I claimed the follow-up steps were unguarded. They are documented, in order, in `assistant/src/notifications/README.md` under "How to Add a New Channel", steps 3 through 5. Not reading that README first is what caused my confusion in the first place.

The rename was justified by that misdiagnosis, so it has been dropped rather than defended.

## What is actually worth fixing

Documentation is guidance; the compiler is enforcement. Correctness here rests on two independent silent `default` branches staying in agreement. Add the connectivity check without the destination resolver, which is the natural order when a channel gains a guardian binding, and the drop stops being hypothetical.

So both defaults now fail closed:

```
src/notifications/destination-resolver.ts(188,15): error TS2322: Type '"discord"' is not assignable to type 'never'.
src/notifications/emit-signal.ts(164,15):          error TS2322: Type '"discord"' is not assignable to type 'never'.
```

That is `deliveryEnabled: true` set on discord with neither step done, then reverted. README steps 4 and 5 are now build failures.

They **log rather than throw**, so if a cast elsewhere ever routes an unexpected channel here, it degrades to a loud skip instead of taking down an unrelated delivery.

## The docs fix

`ARCHITECTURE.md` described `deliveryEnabled` as *"whether the channel can receive notification deliveries"*. That reads as a general outbound capability and is the sentence most likely to mislead the next person the way it misled me. It governs proactive notification only: replies route by `replyCallbackUrl` through `messaging/providers` and never consult this registry, so a channel can reply perfectly well while sitting at `deliveryEnabled: false`.

`notifications/README.md` gets the same correction, plus a line noting that steps 4 and 5 are now compiler-enforced. This also resolves the stale-docs findings both review bots raised against the earlier revision.

## Testing

Full notification-area suite passes (every `notifications/__tests__` and `notification-*` file, plus `channel-policy`, `emit-signal-routing-intent`, `conversation-pairing`). Typecheck clean; the exhaustiveness behaviour is verified by the flip-and-revert above.

## Merge order

Independent of #40332 (Discord egress), which does not touch this flag. Either can land first, with no reconciliation needed in either direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
