### PR TITLE
Let a guardian see which ingress declarations are waiting

### DIFF
--- a/gateway/openapi.json
+++ b/gateway/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Vellum Gateway API",
-    "version": "0.10.12",
+    "version": "0.11.2",
     "description": "Auto-generated OpenAPI specification for the Vellum Gateway HTTP endpoints."
   },
   "servers": [{ "url": "", "description": "Same-origin (gateway)" }],
@@ -340,6 +340,94 @@
                     }
                   },
                   "required": ["policy"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/channel-ingress": {
+      "get": {
+        "operationId": "channelIngressList",
+        "summary": "List ingress declarations and their approval state",
+        "tags": ["channel-ingress"],
+        "description": "Every declaration the gateway can see, each with the digest a guardian would approve, the public paths it would open, and the credential its signatures are verified against. This is the only way to learn that a declaration is waiting: on the public surface a route held back by approval 404s exactly like one nobody declared.",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "sources": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "source": { "type": "string" },
+                          "state": {
+                            "type": "string",
+                            "enum": ["approved", "pending"]
+                          },
+                          "digest": { "type": "string" },
+                          "approvedAt": { "type": "number" },
+                          "approvedDigest": { "type": "string" },
+                          "routes": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "path": { "type": "string" },
+                                "publicPath": { "type": "string" },
+                                "kind": { "type": "string" },
+                                "signer": { "type": "string" },
+                                "handshake": { "type": "string" },
+                                "description": { "type": "string" },
+                                "credential": { "type": "string" },
+                                "verification": {
+                                  "type": "object",
+                                  "properties": {
+                                    "algorithm": { "type": "string" },
+                                    "signatureHeader": { "type": "string" }
+                                  },
+                                  "required": ["algorithm", "signatureHeader"],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "path",
+                                "publicPath",
+                                "kind",
+                                "signer",
+                                "handshake",
+                                "description",
+                                "credential"
+                              ],
+                              "additionalProperties": false
+                            }
+                          }
+                        },
+                        "required": ["source", "state", "digest", "routes"],
+                        "additionalProperties": false
+                      }
+                    },
+                    "problems": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "source": { "type": "string" },
+                          "reason": { "type": "string" }
+                        },
+                        "required": ["source", "reason"],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": ["sources", "problems"],
                   "additionalProperties": false
                 }
               }

--- a/gateway/openapi.json
+++ b/gateway/openapi.json
@@ -387,6 +387,7 @@
                                 "handshake": { "type": "string" },
                                 "description": { "type": "string" },
                                 "credential": { "type": "string" },
+                                "served": { "type": "boolean" },
                                 "verification": {
                                   "type": "object",
                                   "properties": {
@@ -404,7 +405,8 @@
                                 "signer",
                                 "handshake",
                                 "description",
-                                "credential"
+                                "credential",
+                                "served"
                               ],
                               "additionalProperties": false
                             }

--- a/gateway/src/http/routes/channel-ingress-routes.ts
+++ b/gateway/src/http/routes/channel-ingress-routes.ts
@@ -42,7 +42,50 @@ const ApprovalViewSchema = z.object({
   approvedAt: z.number(),
 });
 
+const IngressRouteViewSchema = z.object({
+  path: z.string(),
+  /** Absolute path the gateway would serve, which is the reach being granted. */
+  publicPath: z.string(),
+  kind: z.string(),
+  signer: z.string(),
+  handshake: z.string(),
+  description: z.string(),
+  /** Credential the route's signatures are verified against. */
+  credential: z.string(),
+  /** Present when the route declares its own verification scheme. */
+  verification: z
+    .object({ algorithm: z.string(), signatureHeader: z.string() })
+    .optional(),
+});
+
+const IngressSourceViewSchema = z.object({
+  source: z.string(),
+  state: z.enum(["approved", "pending"]),
+  /** Digest of what the source declares now — the one to approve. */
+  digest: z.string(),
+  approvedAt: z.number().optional(),
+  /** On a pending source holding a grant for an earlier declaration. */
+  approvedDigest: z.string().optional(),
+  routes: z.array(IngressRouteViewSchema),
+});
+
+const ChannelIngressListSchema = z.object({
+  sources: z.array(IngressSourceViewSchema),
+  /** Declarations that failed validation. Unservable regardless of approval. */
+  problems: z.array(z.object({ source: z.string(), reason: z.string() })),
+});
+
 export const ROUTES: GatewayRouteDefinition[] = [
+  {
+    path: "/v1/channel-ingress",
+    method: "get",
+    operationId: "channelIngressList",
+    summary: "List ingress declarations and their approval state",
+    description:
+      "Every declaration the gateway can see, each with the digest a guardian would approve, the public paths it would open, and the credential its signatures are verified against. This is the only way to learn that a declaration is waiting: on the public surface a route held back by approval 404s exactly like one nobody declared.",
+    tags: ["channel-ingress"],
+    responseBody: ChannelIngressListSchema,
+  },
   {
     path: "/v1/channel-ingress/{source}/approve",
     method: "post",

--- a/gateway/src/http/routes/channel-ingress-routes.ts
+++ b/gateway/src/http/routes/channel-ingress-routes.ts
@@ -52,6 +52,11 @@ const IngressRouteViewSchema = z.object({
   description: z.string(),
   /** Credential the route's signatures are verified against. */
   credential: z.string(),
+  /**
+   * Whether the gateway serves this route right now. Not implied by the
+   * source's state: a `vellum`-signed route is served without approval.
+   */
+  served: z.boolean(),
   /** Present when the route declares its own verification scheme. */
   verification: z
     .object({ algorithm: z.string(), signatureHeader: z.string() })
@@ -60,8 +65,9 @@ const IngressRouteViewSchema = z.object({
 
 const IngressSourceViewSchema = z.object({
   source: z.string(),
+  /** Approval state. Whether a given route is live is per-route `served`. */
   state: z.enum(["approved", "pending"]),
-  /** Digest of what the source declares now — the one to approve. */
+  /** Digest of what the source declares now: the one to approve. */
   digest: z.string(),
   approvedAt: z.number().optional(),
   /** On a pending source holding a grant for an earlier declaration. */

--- a/gateway/src/http/routes/channel-ingress.test.ts
+++ b/gateway/src/http/routes/channel-ingress.test.ts
@@ -22,6 +22,7 @@ import {
 import { pluginIngressApprovals } from "../../db/schema.js";
 import {
   createChannelIngressApproveHandler,
+  createChannelIngressListHandler,
   createChannelIngressRevokeHandler,
 } from "./channel-ingress.js";
 
@@ -45,6 +46,9 @@ const approve = createChannelIngressApproveHandler(() =>
   resolvePluginIngress({ workspaceDir }),
 );
 const revoke = createChannelIngressRevokeHandler();
+const list = createChannelIngressListHandler(() =>
+  resolvePluginIngress({ workspaceDir }),
+);
 
 function writePlugin(plugin: string, routes: unknown = ROUTES): void {
   const pluginDir = join(workspaceDir, "plugins", plugin);
@@ -197,5 +201,112 @@ describe("revoke", () => {
 
     expect(await res.json()).toMatchObject({ revoked: true });
     expect(getPluginIngressApproval("meeting-bot")).toBeUndefined();
+  });
+});
+
+describe("list", () => {
+  it("says what is pending and which digest would approve it", async () => {
+    // The only place this is visible. On the public surface a route held back
+    // by approval 404s exactly like one nobody declared.
+    writePlugin("meeting-bot");
+
+    const body = (await (await list()).json()) as {
+      sources: { source: string; state: string; digest: string }[];
+    };
+
+    expect(body.sources).toEqual([
+      {
+        source: "meeting-bot",
+        state: "pending",
+        digest: ingressDeclarationDigest(ROUTES),
+        routes: [
+          {
+            path: "realtime",
+            publicPath: "/webhooks/plugins/meeting-bot/realtime",
+            kind: "websocket",
+            signer: "plugin",
+            handshake: "signed-headers",
+            description: "events",
+            credential: "credential/meeting-bot/webhook_secret",
+          },
+        ],
+      },
+    ] as never);
+  });
+
+  it("names the credential a declared verification scheme keys on", async () => {
+    // A route can be approved and still 409 on a secret nobody set, so the
+    // key it reads is part of what makes the state diagnosable.
+    writePlugin("meeting-bot", [
+      {
+        path: "events-comms",
+        kind: "http",
+        description: "inbound",
+        verification: {
+          kind: "hmac",
+          algorithm: "sha256",
+          secret: { field: "comms_webhook_secret" },
+          signature: { header: "X-Osis-Signature", encoding: "hex" },
+          payload: ["body"],
+        },
+      },
+    ]);
+
+    const body = (await (await list()).json()) as {
+      sources: { routes: Record<string, unknown>[] }[];
+    };
+
+    expect(body.sources[0]!.routes[0]).toMatchObject({
+      credential: "credential/meeting-bot/comms_webhook_secret",
+      verification: {
+        algorithm: "sha256",
+        signatureHeader: "X-Osis-Signature",
+      },
+    });
+  });
+
+  it("reports an approved declaration as approved", async () => {
+    writePlugin("meeting-bot");
+    approvePluginIngress({
+      plugin: "meeting-bot",
+      digest: ingressDeclarationDigest(ROUTES),
+    });
+
+    const body = (await (await list()).json()) as {
+      sources: { state: string; approvedAt: number }[];
+    };
+
+    expect(body.sources[0]!.state).toBe("approved");
+    expect(body.sources[0]!.approvedAt).toBeGreaterThan(0);
+  });
+
+  it("distinguishes an edited declaration from one never approved", async () => {
+    // Both are pending. Only one of them is a guardian re-reading a change
+    // they already decided on once.
+    writePlugin("meeting-bot");
+    approvePluginIngress({ plugin: "meeting-bot", digest: "a".repeat(32) });
+
+    const body = (await (await list()).json()) as {
+      sources: { state: string; digest: string; approvedDigest?: string }[];
+    };
+
+    expect(body.sources[0]!.state).toBe("pending");
+    expect(body.sources[0]!.approvedDigest).toBe("a".repeat(32));
+    expect(body.sources[0]!.digest).toBe(ingressDeclarationDigest(ROUTES));
+  });
+
+  it("reports a declaration that failed validation and why", async () => {
+    // Unservable regardless of approval, so a guardian hunting a missing
+    // route needs the reason rather than an absence.
+    writePlugin("meeting-bot", [{ path: "/absolute", kind: "http" }]);
+
+    const body = (await (await list()).json()) as {
+      sources: unknown[];
+      problems: { source: string; reason: string }[];
+    };
+
+    expect(body.sources).toEqual([]);
+    expect(body.problems[0]!.source).toBe("meeting-bot");
+    expect(body.problems[0]!.reason).toContain("path");
   });
 });

--- a/gateway/src/http/routes/channel-ingress.test.ts
+++ b/gateway/src/http/routes/channel-ingress.test.ts
@@ -228,6 +228,7 @@ describe("list", () => {
             handshake: "signed-headers",
             description: "events",
             credential: "credential/meeting-bot/webhook_secret",
+            served: false,
           },
         ],
       },
@@ -308,5 +309,41 @@ describe("list", () => {
     expect(body.sources).toEqual([]);
     expect(body.problems[0]!.source).toBe("meeting-bot");
     expect(body.problems[0]!.reason).toContain("path");
+  });
+
+  it("reports a vellum-signed route as served while its source waits", async () => {
+    // Approval is the general gate, and a vellum-signed route is the
+    // exception: only a caller holding the platform secret can open it. A
+    // listing that read servability off the source's state would call a live
+    // route dormant, and say nothing about which half of a mixed declaration
+    // is already reachable.
+    writePlugin("meeting-bot", [
+      { ...ROUTES[0]!, path: "ours", signer: "vellum" },
+      { ...ROUTES[0]!, path: "theirs" },
+    ]);
+
+    const body = (await (await list()).json()) as {
+      sources: { state: string; routes: { path: string; served: boolean }[] }[];
+    };
+
+    expect(body.sources[0]!.state).toBe("pending");
+    expect(body.sources[0]!.routes.map((r) => [r.path, r.served])).toEqual([
+      ["ours", true],
+      ["theirs", false],
+    ]);
+  });
+
+  it("reports every route of an approved declaration as served", async () => {
+    writePlugin("meeting-bot");
+    approvePluginIngress({
+      plugin: "meeting-bot",
+      digest: ingressDeclarationDigest(ROUTES),
+    });
+
+    const body = (await (await list()).json()) as {
+      sources: { routes: { served: boolean }[] }[];
+    };
+
+    expect(body.sources[0]!.routes[0]!.served).toBe(true);
   });
 });

--- a/gateway/src/http/routes/channel-ingress.ts
+++ b/gateway/src/http/routes/channel-ingress.ts
@@ -16,6 +16,7 @@
  */
 
 import {
+  findServableRoute,
   resolvePluginIngress,
   type PluginIngressResolution,
 } from "../../channels/plugin-ingress-approvals.js";
@@ -42,7 +43,7 @@ const log = getLogger("channel-ingress");
 const ApproveBodySchema = ApproveChannelIngressRequestSchema;
 
 // ---------------------------------------------------------------------------
-// GET /v1/channel-ingress — what has been declared, and what is being served
+// GET /v1/channel-ingress: what has been declared, and what is being served
 // ---------------------------------------------------------------------------
 
 /**
@@ -55,8 +56,18 @@ const ApproveBodySchema = ApproveChannelIngressRequestSchema;
  * same view. The verification descriptor is summarised rather than echoed
  * whole: the algorithm, the header a signature arrives in, and which credential
  * keys it are what a decision turns on.
+ *
+ * `served` is answered by asking `findServableRoute` the same question the
+ * request path asks, rather than by restating its rule. A `signer: "vellum"`
+ * route is served out of a pending declaration, so approval state alone does
+ * not say whether a route is live, and a listing that reimplemented the
+ * exception could come to disagree with the surface it describes.
  */
-function routeView(plugin: string, route: IngressRoute) {
+function routeView(
+  resolution: PluginIngressResolution,
+  plugin: string,
+  route: IngressRoute,
+) {
   return {
     path: route.path,
     publicPath: pluginWebhookPath(plugin, route.path),
@@ -64,6 +75,9 @@ function routeView(plugin: string, route: IngressRoute) {
     signer: route.signer,
     handshake: route.handshake,
     description: route.description,
+    served:
+      findServableRoute(resolution, plugin, route.path, route.kind) !==
+      undefined,
     credential: route.verification
       ? credentialKey(plugin, route.verification.secret.field)
       : credentialKey(
@@ -83,10 +97,16 @@ function routeView(plugin: string, route: IngressRoute) {
  * Every declaration the gateway can see, with its state.
  *
  * Without this a guardian has no way to learn that something is waiting, nor
- * the digest they would have to approve — the pending state is otherwise
+ * the digest they would have to approve. The pending state is otherwise
  * visible only in a gateway log line, and a route held back by it 404s exactly
  * like one nobody declared. That is right for the public surface, where the
  * caller is anyone on the internet, and wrong here.
+ *
+ * `state` is the approval state and nothing more, because approval and
+ * servability are not the same question: a `signer: "vellum"` route is served
+ * out of a pending declaration. Each route carries its own `served`, so a
+ * source can report accurately that it is waiting on a decision while some of
+ * what it declared is already live.
  *
  * `pending` covers two situations worth telling apart, so a source that holds a
  * grant for some earlier manifest reports the digest it was granted for under
@@ -102,10 +122,13 @@ export function createChannelIngressListHandler(
 ) {
   return async (): Promise<Response> => {
     try {
-      const { approved, pending, problems } = resolve();
+      const resolution = resolve();
+      const { approved, pending, problems } = resolution;
       const approvals = new Map(
         listPluginIngressApprovals().map((a) => [a.plugin, a]),
       );
+      const routes = (plugin: string, declared: readonly IngressRoute[]) =>
+        declared.map((r) => routeView(resolution, plugin, r));
 
       return Response.json({
         sources: [
@@ -114,14 +137,14 @@ export function createChannelIngressListHandler(
             state: "approved" as const,
             digest: d.digest,
             approvedAt: approvals.get(d.plugin)?.approvedAt,
-            routes: d.routes.map((r) => routeView(d.plugin, r)),
+            routes: routes(d.plugin, d.routes),
           })),
           ...pending.map((d) => ({
             source: d.plugin,
             state: "pending" as const,
             digest: d.digest,
             approvedDigest: approvals.get(d.plugin)?.digest,
-            routes: d.routes.map((r) => routeView(d.plugin, r)),
+            routes: routes(d.plugin, d.routes),
           })),
         ],
         problems: problems.map((p) => ({ source: p.plugin, reason: p.reason })),

--- a/gateway/src/http/routes/channel-ingress.ts
+++ b/gateway/src/http/routes/channel-ingress.ts
@@ -20,7 +20,13 @@ import {
   type PluginIngressResolution,
 } from "../../channels/plugin-ingress-approvals.js";
 import {
+  pluginWebhookPath,
+  type IngressRoute,
+} from "../../channels/plugin-ingress.js";
+import { credentialKey } from "../../credential-key.js";
+import {
   approvePluginIngress,
+  listPluginIngressApprovals,
   revokePluginIngressApproval,
 } from "../../db/plugin-ingress-approval-store.js";
 import { getLogger } from "../../logger.js";
@@ -34,6 +40,98 @@ const log = getLogger("channel-ingress");
 
 // Wire schema shared with the published OpenAPI spec (single source).
 const ApproveBodySchema = ApproveChannelIngressRequestSchema;
+
+// ---------------------------------------------------------------------------
+// GET /v1/channel-ingress — what has been declared, and what is being served
+// ---------------------------------------------------------------------------
+
+/**
+ * One route, as the guardian needs to read it.
+ *
+ * `publicPath` is what would open on the public surface, which is the reach
+ * being granted and is not otherwise derivable without knowing how the gateway
+ * composes it. `credential` names the secret the route verifies against, so a
+ * declaration approved but 409ing on a missing secret is diagnosable from the
+ * same view. The verification descriptor is summarised rather than echoed
+ * whole: the algorithm, the header a signature arrives in, and which credential
+ * keys it are what a decision turns on.
+ */
+function routeView(plugin: string, route: IngressRoute) {
+  return {
+    path: route.path,
+    publicPath: pluginWebhookPath(plugin, route.path),
+    kind: route.kind,
+    signer: route.signer,
+    handshake: route.handshake,
+    description: route.description,
+    credential: route.verification
+      ? credentialKey(plugin, route.verification.secret.field)
+      : credentialKey(
+          route.signer === "vellum" ? "vellum" : plugin,
+          "webhook_secret",
+        ),
+    verification: route.verification
+      ? {
+          algorithm: route.verification.algorithm,
+          signatureHeader: route.verification.signature.header,
+        }
+      : undefined,
+  };
+}
+
+/**
+ * Every declaration the gateway can see, with its state.
+ *
+ * Without this a guardian has no way to learn that something is waiting, nor
+ * the digest they would have to approve — the pending state is otherwise
+ * visible only in a gateway log line, and a route held back by it 404s exactly
+ * like one nobody declared. That is right for the public surface, where the
+ * caller is anyone on the internet, and wrong here.
+ *
+ * `pending` covers two situations worth telling apart, so a source that holds a
+ * grant for some earlier manifest reports the digest it was granted for under
+ * `approvedDigest`: an edited declaration reads as "approve the new one", not
+ * as "this was never approved".
+ *
+ * Declarations that failed validation are reported too. They are unservable
+ * regardless of approval, and a guardian looking for a route that is missing
+ * needs to see the reason rather than an absence.
+ */
+export function createChannelIngressListHandler(
+  resolve: () => PluginIngressResolution = resolvePluginIngress,
+) {
+  return async (): Promise<Response> => {
+    try {
+      const { approved, pending, problems } = resolve();
+      const approvals = new Map(
+        listPluginIngressApprovals().map((a) => [a.plugin, a]),
+      );
+
+      return Response.json({
+        sources: [
+          ...approved.map((d) => ({
+            source: d.plugin,
+            state: "approved" as const,
+            digest: d.digest,
+            approvedAt: approvals.get(d.plugin)?.approvedAt,
+            routes: d.routes.map((r) => routeView(d.plugin, r)),
+          })),
+          ...pending.map((d) => ({
+            source: d.plugin,
+            state: "pending" as const,
+            digest: d.digest,
+            approvedDigest: approvals.get(d.plugin)?.digest,
+            routes: d.routes.map((r) => routeView(d.plugin, r)),
+          })),
+        ],
+        problems: problems.map((p) => ({ source: p.plugin, reason: p.reason })),
+      });
+    } catch (err) {
+      log.error({ err }, "Failed to resolve channel ingress");
+      return Response.json({ error: "Internal server error" }, { status: 500 });
+    }
+  };
+}
 
 // ---------------------------------------------------------------------------
 // POST /v1/channel-ingress/:source/approve — record a decision

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -143,6 +143,7 @@ import {
 } from "./http/routes/channel-admission-policy.js";
 import {
   createChannelIngressApproveHandler,
+  createChannelIngressListHandler,
   createChannelIngressRevokeHandler,
 } from "./http/routes/channel-ingress.js";
 import { createPluginWebhookHandler } from "./http/routes/plugin-webhook.js";
@@ -617,6 +618,7 @@ async function main() {
     createChannelAdmissionPolicySetHandler();
   const handleChannelAdmissionPolicyDelete =
     createChannelAdmissionPolicyDeleteHandler();
+  const handleChannelIngressList = createChannelIngressListHandler();
   const handleChannelIngressApprove = createChannelIngressApproveHandler();
   const handleChannelIngressRevoke = createChannelIngressRevokeHandler();
   const handlePluginWebhook = createPluginWebhookHandler({
@@ -1594,8 +1596,16 @@ async function main() {
     // is the decision the assistant must not make for itself; and there are no
     // assistant-scoped variants, because the guardian reaches these directly
     // rather than through the platform proxy. Deliberately absent from the IPC
-    // surface for the same reason as the auth choice. POST verb paths — a
-    // grant has no id of its own until a guardian creates one.
+    // surface for the same reason as the auth choice. Approve and revoke are
+    // POST verb paths — a grant has no id of its own until a guardian creates
+    // one. The listing is guardian-only for a different reason: it says which
+    // declarations are waiting, which the public surface will not.
+    {
+      path: /^\/v1\/channel-ingress\/?$/,
+      method: "GET",
+      auth: "edge-guardian",
+      handler: () => handleChannelIngressList(),
+    },
     {
       path: /^\/v1\/channel-ingress\/([^/]+)\/approve\/?$/,
       method: "POST",

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1597,9 +1597,9 @@ async function main() {
     // assistant-scoped variants, because the guardian reaches these directly
     // rather than through the platform proxy. Deliberately absent from the IPC
     // surface for the same reason as the auth choice. Approve and revoke are
-    // POST verb paths — a grant has no id of its own until a guardian creates
-    // one. The listing is guardian-only for a different reason: it says which
-    // declarations are waiting, which the public surface will not.
+    // POST verb paths because a grant has no id of its own until a guardian
+    // creates one. The listing is guardian-only for a different reason: it says
+    // which declarations are waiting, which the public surface will not.
     {
       path: /^\/v1\/channel-ingress\/?$/,
       method: "GET",

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -3512,6 +3512,23 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
+      "/v1/channel-ingress": {
+        get: {
+          summary: "List ingress declarations and their approval state",
+          description:
+            "Guardian-only gateway endpoint listing every ingress declaration the gateway can see, each with the digest a guardian would approve, the public paths it would open, the credential its signatures are verified against, and whether each route is served right now. Servability is not implied by approval state: a vellum-signed route is served out of a pending declaration. This is the only way to learn that a declaration is waiting, because on the public surface a route held back by approval answers 404 exactly like one nobody declared. Declarations that failed validation are reported separately with their reason.",
+          operationId: "channelIngressList",
+          security: [{ BearerAuth: [] }],
+          responses: {
+            "200": { description: "Ingress declarations and approval state" },
+            "401": {
+              description: "Unauthorized: missing or invalid bearer token",
+            },
+            "403": { description: "Forbidden: caller is not the guardian" },
+            "500": { description: "Internal server error" },
+          },
+        },
+      },
       "/v1/channel-ingress/{source}/approve": {
         post: {
           summary: "Approve an ingress declaration",


### PR DESCRIPTION
## Why

A plugin route signed by anyone other than Vellum is served only once a guardian approves the declaration. Until then `findServableRoute` returns nothing and the gateway answers `{"error":"Not Found"}`, deliberately identical to a route nobody declared, because that path is reachable by anyone on the internet and the gate should give nothing away.

That silence is right on the public surface and wrong for the guardian. `approve` and `revoke` were the only endpoints, so there was nothing to list against: no way to learn a declaration was waiting, no way to obtain the digest you would have to approve, short of catching an info line in the gateway log. In practice a plugin with third-party-signed routes 404s every delivery with no reachable explanation, which is what iMessage's Comms webhook has been doing.

## What changed

`GET /v1/channel-ingress`, guardian-authed like its neighbours, returns every declaration the gateway can see:

```json
{
  "sources": [
    {
      "source": "imessage",
      "state": "pending",
      "digest": "ef028521b75eeb7c170368d814e9583e",
      "routes": [
        {
          "path": "events-comms",
          "publicPath": "/webhooks/plugins/imessage/events-comms",
          "kind": "http",
          "signer": "plugin",
          "handshake": "signed-headers",
          "description": "Inbound message webhooks from a Comms by Osis line (comms.message.received).",
          "credential": "credential/imessage/comms_webhook_secret",
          "verification": { "algorithm": "sha256", "signatureHeader": "X-Osis-Signature" },
          "served": false
        }
      ]
    }
  ],
  "problems": []
}
```

Design notes:

- **`state` is the approval state, `served` is per route.** They are different questions: a `signer: "vellum"` route is served out of a pending declaration, so a vellum-only source is waiting on nothing and a mixed declaration has one half open. `served` is answered by asking `findServableRoute` the same question the request path asks, rather than restating its rule, so the listing cannot drift from the surface it describes.
- **`publicPath`** is the reach being granted, and is not derivable without knowing how the gateway composes it.
- **`credential`** names the secret each route verifies against, so an approved route answering 409 on a missing secret is diagnosable from the same view rather than being a second mystery.
- **`approvedDigest`** appears on a pending source that holds a grant for some earlier manifest, so an edited declaration reads as "approve the new one" rather than "this was never approved".
- **`problems`** carries declarations that failed validation. They are unservable regardless of approval, and a guardian hunting a route that is missing needs the reason, not an absence.
- The verification descriptor is summarised rather than echoed whole. Credential **fields** are named, values never are.

Registered in both contracts: the codegen source (`channel-ingress-routes.ts`, feeding `openapi.json`) and the served `/schema` (`schema.ts`), which `route-schema-guard.test.ts` checks.

## Tests

Seven cases in `channel-ingress.test.ts`: pending with its digest and composed public path; a declared verification scheme reporting its credential and header; an approved source carrying `approvedAt` with its routes served; an edited declaration distinguished from a never-approved one; a malformed manifest surfacing under `problems`; and a mixed pending declaration reporting its vellum-signed route as served and its plugin-signed one as not.

`gateway/openapi.json` regenerated (`bun run generate:openapi`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013p1nTdvsuAtTJ7zyCSDLbx