### PR TITLE
fix(web): make remembered-origins compile

### DIFF
--- a/clients/web/src/stores/remembered-origins-store.test.ts
+++ b/clients/web/src/stores/remembered-origins-store.test.ts
@@ -517,7 +517,7 @@ describe("providers and hydration", () => {
 
   it("a watch event after a failed hydration retries hydration", async () => {
     let failLoads = true;
-    let watchCallback: (() => void) | null = null;
+    const watchRef: { fn: (() => void) | null } = { fn: null };
     const provider: RememberedOriginsProvider = {
       load: async () => {
         if (failLoads) {
@@ -532,7 +532,7 @@ describe("providers and hydration", () => {
       },
       save: async () => {},
       watch: (onChange) => {
-        watchCallback = onChange;
+        watchRef.fn = onChange;
         return () => {};
       },
     };
@@ -543,7 +543,7 @@ describe("providers and hydration", () => {
     // The provider recovers and announces a change; no caller invokes
     // hydrate() manually.
     failLoads = false;
-    watchCallback?.();
+    watchRef.fn?.();
     await new Promise((resolve) => setTimeout(resolve, 5));
 
     expect(store().hydrated).toBe(true);
@@ -556,7 +556,7 @@ describe("providers and hydration", () => {
     let entries: RememberedOrigin[] = [
       { url: "https://example.com/new", addedAt: "2026-01-02T00:00:00Z" },
     ];
-    let watchCallback: (() => void) | null = null;
+    const watchRef: { fn: (() => void) | null } = { fn: null };
     let releaseHydrateLoad = () => {};
     const hydrateGate = new Promise<void>((resolve) => {
       releaseHydrateLoad = resolve;
@@ -579,14 +579,14 @@ describe("providers and hydration", () => {
         entries = next;
       },
       watch: (onChange) => {
-        watchCallback = onChange;
+        watchRef.fn = onChange;
         return () => {};
       },
     };
     setRememberedOriginsProvider(provider);
 
     // The provider's value changes while hydration is still loading.
-    watchCallback?.();
+    watchRef.fn?.();
     await new Promise((resolve) => setTimeout(resolve, 1));
     releaseHydrateLoad();
     await store().hydrate();
@@ -601,7 +601,7 @@ describe("providers and hydration", () => {
     let entries: RememberedOrigin[] = [
       { url: "https://example.com/a", addedAt: "2026-01-01T00:00:00Z" },
     ];
-    let watchCallback: (() => void) | null = null;
+    const watchRef: { fn: (() => void) | null } = { fn: null };
     let gate: Promise<void> | null = null;
     let releaseGate = () => {};
     const provider: RememberedOriginsProvider = {
@@ -617,7 +617,7 @@ describe("providers and hydration", () => {
         entries = next;
       },
       watch: (onChange) => {
-        watchCallback = onChange;
+        watchRef.fn = onChange;
         return () => {};
       },
     };
@@ -628,7 +628,7 @@ describe("providers and hydration", () => {
     gate = new Promise((resolve) => {
       releaseGate = resolve;
     });
-    watchCallback?.();
+    watchRef.fn?.();
     const add = store().addOrigin({ url: "https://example.com/b" });
     releaseGate();
     await add;

--- a/clients/web/src/stores/remembered-origins-store.test.ts
+++ b/clients/web/src/stores/remembered-origins-store.test.ts
@@ -1,13 +1,11 @@
 import { describe, it, expect, beforeEach } from "bun:test";
 
 /**
- * Holds a callback the provider hands us from inside its own `watch` call.
+ * Holds a callback the provider hands back from inside its own `watch` call.
  *
- * A plain `let` initialized to `null` narrows to `null`, and the compiler
- * cannot prove the provider ever invokes the assignment, so a later
- * `callback?.()` types as `never` and the assertion it guards is treated as
- * unreachable. Reading through a property sidesteps the narrowing without a
- * cast.
+ * A `let` initialized to `null` narrows to `null` for the rest of the scope,
+ * since the compiler cannot prove the provider ever runs the assignment. A
+ * property read carries the full union, so calling it stays type-checked.
  */
 type WatchRef = { fn: (() => void) | null };
 

--- a/clients/web/src/stores/remembered-origins-store.test.ts
+++ b/clients/web/src/stores/remembered-origins-store.test.ts
@@ -1,5 +1,21 @@
 import { describe, it, expect, beforeEach } from "bun:test";
 
+/**
+ * Holds a callback the provider hands us from inside its own `watch` call.
+ *
+ * A plain `let` initialized to `null` narrows to `null`, and the compiler
+ * cannot prove the provider ever invokes the assignment, so a later
+ * `callback?.()` types as `never` and the assertion it guards is treated as
+ * unreachable. Reading through a property sidesteps the narrowing without a
+ * cast.
+ */
+type WatchRef = { fn: (() => void) | null };
+
+function watchRef(): WatchRef {
+  return { fn: null };
+}
+
+
 import {
   REMEMBERED_ORIGINS_STORAGE_KEY,
   localStorageProvider,
@@ -517,7 +533,7 @@ describe("providers and hydration", () => {
 
   it("a watch event after a failed hydration retries hydration", async () => {
     let failLoads = true;
-    const watchRef: { fn: (() => void) | null } = { fn: null };
+    const watch = watchRef();
     const provider: RememberedOriginsProvider = {
       load: async () => {
         if (failLoads) {
@@ -532,7 +548,7 @@ describe("providers and hydration", () => {
       },
       save: async () => {},
       watch: (onChange) => {
-        watchRef.fn = onChange;
+        watch.fn = onChange;
         return () => {};
       },
     };
@@ -543,7 +559,7 @@ describe("providers and hydration", () => {
     // The provider recovers and announces a change; no caller invokes
     // hydrate() manually.
     failLoads = false;
-    watchRef.fn?.();
+    watch.fn?.();
     await new Promise((resolve) => setTimeout(resolve, 5));
 
     expect(store().hydrated).toBe(true);
@@ -556,7 +572,7 @@ describe("providers and hydration", () => {
     let entries: RememberedOrigin[] = [
       { url: "https://example.com/new", addedAt: "2026-01-02T00:00:00Z" },
     ];
-    const watchRef: { fn: (() => void) | null } = { fn: null };
+    const watch = watchRef();
     let releaseHydrateLoad = () => {};
     const hydrateGate = new Promise<void>((resolve) => {
       releaseHydrateLoad = resolve;
@@ -579,14 +595,14 @@ describe("providers and hydration", () => {
         entries = next;
       },
       watch: (onChange) => {
-        watchRef.fn = onChange;
+        watch.fn = onChange;
         return () => {};
       },
     };
     setRememberedOriginsProvider(provider);
 
     // The provider's value changes while hydration is still loading.
-    watchRef.fn?.();
+    watch.fn?.();
     await new Promise((resolve) => setTimeout(resolve, 1));
     releaseHydrateLoad();
     await store().hydrate();
@@ -601,7 +617,7 @@ describe("providers and hydration", () => {
     let entries: RememberedOrigin[] = [
       { url: "https://example.com/a", addedAt: "2026-01-01T00:00:00Z" },
     ];
-    const watchRef: { fn: (() => void) | null } = { fn: null };
+    const watch = watchRef();
     let gate: Promise<void> | null = null;
     let releaseGate = () => {};
     const provider: RememberedOriginsProvider = {
@@ -617,7 +633,7 @@ describe("providers and hydration", () => {
         entries = next;
       },
       watch: (onChange) => {
-        watchRef.fn = onChange;
+        watch.fn = onChange;
         return () => {};
       },
     };
@@ -628,7 +644,7 @@ describe("providers and hydration", () => {
     gate = new Promise((resolve) => {
       releaseGate = resolve;
     });
-    watchRef.fn?.();
+    watch.fn?.();
     const add = store().addOrigin({ url: "https://example.com/b" });
     releaseGate();
     await add;

--- a/clients/web/src/stores/remembered-origins-store.ts
+++ b/clients/web/src/stores/remembered-origins-store.ts
@@ -148,12 +148,18 @@ const MUTATION_LOCK_NAME = "vellum:remembered-origins:mutate";
  * API. Without it (non-browser test envs, very old engines) the in-tab
  * queue still applies and concurrent-tab writes fall back to last-writer.
  */
-function withCrossTabLock<T>(mutation: () => Promise<T>): Promise<T> {
+async function withCrossTabLock<T>(mutation: () => Promise<T>): Promise<T> {
   const locks = typeof navigator === "undefined" ? undefined : navigator.locks;
   if (!locks) {
     return mutation();
   }
-  return locks.request(MUTATION_LOCK_NAME, mutation);
+  // Awaited rather than returned directly. `LockManager.request` infers its
+  // type parameter from what the callback returns, and this callback returns
+  // `Promise<T>`, so the call itself is typed `Promise<Promise<T>>`. Awaiting
+  // collapses that to `T`, which is what the signature promises and what
+  // every caller already receives at runtime. A cast would hide the nesting
+  // rather than resolve it.
+  return await locks.request(MUTATION_LOCK_NAME, mutation);
 }
 
 function enqueueMutation<T>(mutation: () => Promise<T>): Promise<T> {

--- a/clients/web/src/stores/remembered-origins-store.ts
+++ b/clients/web/src/stores/remembered-origins-store.ts
@@ -153,12 +153,8 @@ async function withCrossTabLock<T>(mutation: () => Promise<T>): Promise<T> {
   if (!locks) {
     return mutation();
   }
-  // Awaited rather than returned directly. `LockManager.request` infers its
-  // type parameter from what the callback returns, and this callback returns
-  // `Promise<T>`, so the call itself is typed `Promise<Promise<T>>`. Awaiting
-  // collapses that to `T`, which is what the signature promises and what
-  // every caller already receives at runtime. A cast would hide the nesting
-  // rather than resolve it.
+  // `LockManager.request` infers its type parameter from the callback's
+  // return, so the call is typed `Promise<Promise<T>>`; awaiting collapses it.
   return await locks.request(MUTATION_LOCK_NAME, mutation);
 }
 


### PR DESCRIPTION
TL;DR
------

`bun run typecheck` fails on `origin/main` right now, four errors in one file and its test. This fixes them. No behavior change.

Why it is on main
-----------------

[#40315](https://github.com/vellum-ai/vellum-assistant/pull/40315) merged at 18:14 on Aug 6, during the GitHub Actions outage that afternoon. Only the two Socket Security checks reported, because those run on Socket infrastructure rather than a GitHub runner. Type Check never ran, and the merge gate read "no blocking checks" as "clear.

Not a criticism of that PR. It is the same failure shape we were fixing in [#40286](https://github.com/vellum-ai/vellum-assistant/pull/40286) the same afternoon: absence of evidence read as success.

What changed
------------

**`withCrossTabLock` returned the lock call directly.** `LockManager.request` infers its type parameter from what the callback returns. This callback returns `Promise<T>`, so the call is typed `Promise<Promise<T>>` against a declared `Promise<T>`. Awaiting collapses it to what every caller already receives at runtime. A cast would have hidden the nesting rather than resolved it.

**Three test errors were the same defect in another form.** `let watchCallback: (() => void) | null = null` narrows to `null`; the assignment happens inside a provider callback the compiler cannot prove runs, so `watchCallback?.()` typed as `never`. Holding it on an object avoids the narrowing, again without a cast.

That second one was load-bearing rather than cosmetic. Those calls drive the watcher re-hydration assertions, and as written the compiler considered them unreachable.

Before / after
--------------

| | Before | After |
| -- | -- | -- |
| `clients/web` typecheck | 4 errors | 0 |
| `remembered-origins-store.test.ts` | 34/34 pass, 3 calls typed `never` | 34/34 pass, all typed |
| Runtime behavior | unchanged | unchanged |

Why it is safe
--------------

`await` on a promise that was already being awaited one level up by the caller is a no-op at runtime, and the object holder is a local test variable. Verified by running the suite, not by inspection: 34/34 in the file, `clients/web` typecheck clean.

Deferred
--------

Nothing. This is scoped to making main compile.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40342" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->