### PR TITLE
fix(web): keep consent and assistant guards binding on the chooser route

### DIFF
--- a/clients/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.test.ts
@@ -245,21 +245,74 @@ describe("resolveNavigation", () => {
       ).toEqual({ action: "redirect", to: "/assistant" });
     });
 
-    // The platform build hosts the hub chooser: the route admits an
+    // The platform build hosts the hub chooser: the route admits a settled
     // authenticated user in every mode. The assistant-switcher flag gate for
     // platform-mode access lives in the screen, which can wait on flag
     // hydration; the resolver has no hydration signal to gate on.
-    test("allows an authenticated non-local user on select-assistant", () => {
+    test("allows a consented authenticated non-local user on select-assistant", () => {
       expect(
         guard(s({ isLocalClient: false }), "/assistant/select-assistant"),
       ).toEqual(ALLOW);
-      // The hub shows the chooser even with nothing resolved for this org.
+    });
+
+    // Opening the chooser to non-local clients does not lift the gates that run
+    // after the mode boundary: the route falls through to them like every other
+    // platform surface.
+    test("sends a stale-consent platform user off select-assistant to review-terms", () => {
+      expect(
+        guard(
+          s({ isLocalClient: false, analyticsConsentCurrent: false }),
+          "/assistant/select-assistant",
+        ),
+      ).toEqual({
+        action: "redirect",
+        to: "/assistant/review-terms?returnTo=%2Fassistant%2Fselect-assistant",
+      });
+      expect(
+        guard(
+          s({ isLocalClient: false, tosAccepted: false, privacyConsent: false }),
+          "/assistant/select-assistant",
+        ),
+      ).toEqual({
+        action: "redirect",
+        to: "/assistant/review-terms?returnTo=%2Fassistant%2Fselect-assistant",
+      });
+    });
+
+    test("funnels a zero-assistant platform user off select-assistant", () => {
+      const chooser = "/assistant/select-assistant";
+      const noAssistants = {
+        isLocalClient: false,
+        hasAssistants: false,
+        hasPlatformHostedAssistant: false,
+      };
+      // The platform list loads asynchronously, so an unhydrated read waits
+      // instead of funneling an established user out of the chooser.
+      expect(
+        guard(s({ ...noAssistants, assistantsHydrated: false }), chooser),
+      ).toEqual(WAIT);
+      expect(guard(s(noAssistants), chooser)).toEqual({
+        action: "redirect",
+        to: "/assistant/onboarding/hatching",
+      });
+      expect(
+        guard(
+          s({ ...noAssistants, tosAccepted: false, privacyConsent: false }),
+          chooser,
+        ),
+      ).toEqual({ action: "redirect", to: "/assistant/onboarding/privacy" });
+    });
+
+    // The local chooser is a pre-existing onboarding surface reachable before
+    // there is a session to gate on, so it keeps its short-circuit ahead of the
+    // assistant and consent gates that now bind on the platform hub.
+    test("keeps the local chooser open ahead of the consent gate", () => {
       expect(
         guard(
           s({
-            isLocalClient: false,
-            hasAssistants: false,
-            hasPlatformHostedAssistant: false,
+            isLocalClient: true,
+            platformSession: "present",
+            analyticsConsentCurrent: false,
           }),
           "/assistant/select-assistant",
         ),
@@ -276,6 +329,31 @@ describe("resolveNavigation", () => {
         action: "redirect",
         to: "/account/login?returnTo=%2Fassistant%2Fselect-assistant",
       });
+    });
+
+    test("sends an unpaired remote-gateway chooser visit to pairing", () => {
+      expect(
+        guard(
+          s({
+            isLocalClient: true,
+            isRemoteGateway: true,
+            isAuthenticated: false,
+          }),
+          "/assistant/select-assistant",
+        ),
+      ).toEqual({
+        action: "redirect",
+        to: "/assistant/pair?returnTo=%2Fassistant%2Fselect-assistant",
+      });
+    });
+
+    test("allows a gateway-auth remote-gateway chooser visit", () => {
+      expect(
+        guard(
+          s({ isLocalClient: true, isRemoteGateway: true, isGatewayAuth: true }),
+          "/assistant/select-assistant",
+        ),
+      ).toEqual(ALLOW);
     });
 
     test("allows non-local user on onboarding screens regardless of assistant count", () => {

--- a/clients/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.test.ts
@@ -58,6 +58,14 @@ const RESEARCH_FUNNEL_URL =
 const HATCHING_FUNNEL_URL =
   "/assistant/onboarding/hatching?hosting=vellum-cloud&post_checkout=1";
 
+const CHOOSER = "/assistant/select-assistant";
+/** A platform account with nothing resolved: the chooser's empty state. */
+const NO_ASSISTANTS: Partial<NavigationState> = {
+  isLocalClient: false,
+  hasAssistants: false,
+  hasPlatformHostedAssistant: false,
+};
+
 const ALLOW: NavigationDecision = { action: "allow" };
 const WAIT: NavigationDecision = { action: "wait" };
 // The auth middleware awaits the probe only for a wait that names it, so the
@@ -250,19 +258,17 @@ describe("resolveNavigation", () => {
     // platform-mode access lives in the screen, which can wait on flag
     // hydration; the resolver has no hydration signal to gate on.
     test("allows a consented authenticated non-local user on select-assistant", () => {
-      expect(
-        guard(s({ isLocalClient: false }), "/assistant/select-assistant"),
-      ).toEqual(ALLOW);
+      expect(guard(s({ isLocalClient: false }), CHOOSER)).toEqual(ALLOW);
     });
 
-    // Opening the chooser to non-local clients does not lift the gates that run
-    // after the mode boundary: the route falls through to them like every other
-    // platform surface.
+    // Opening the chooser to non-local clients does not lift the consent gate
+    // that runs after the mode boundary: the route falls through to it like
+    // every other platform surface.
     test("sends a stale-consent platform user off select-assistant to review-terms", () => {
       expect(
         guard(
           s({ isLocalClient: false, analyticsConsentCurrent: false }),
-          "/assistant/select-assistant",
+          CHOOSER,
         ),
       ).toEqual({
         action: "redirect",
@@ -270,8 +276,12 @@ describe("resolveNavigation", () => {
       });
       expect(
         guard(
-          s({ isLocalClient: false, tosAccepted: false, privacyConsent: false }),
-          "/assistant/select-assistant",
+          s({
+            isLocalClient: false,
+            tosAccepted: false,
+            privacyConsent: false,
+          }),
+          CHOOSER,
         ),
       ).toEqual({
         action: "redirect",
@@ -279,28 +289,49 @@ describe("resolveNavigation", () => {
       });
     });
 
-    test("funnels a zero-assistant platform user off select-assistant", () => {
-      const chooser = "/assistant/select-assistant";
-      const noAssistants = {
-        isLocalClient: false,
-        hasAssistants: false,
-        hasPlatformHostedAssistant: false,
-      };
-      // The platform list loads asynchronously, so an unhydrated read waits
-      // instead of funneling an established user out of the chooser.
+    // The chooser is exempt from the no-assistant funnel: an account whose
+    // assistants are all self-hosted has none in `hasAssistants` (remembered
+    // origins are client-local), and the funnel would also drop a `?register=`
+    // handoff before the chooser could record it.
+    test("keeps a zero-assistant platform user on select-assistant", () => {
+      expect(guard(s(NO_ASSISTANTS), CHOOSER)).toEqual(ALLOW);
+      // Nothing is held for the assistants list here: with no funnel to decide,
+      // an unhydrated read has nothing to get wrong.
       expect(
-        guard(s({ ...noAssistants, assistantsHydrated: false }), chooser),
-      ).toEqual(WAIT);
-      expect(guard(s(noAssistants), chooser)).toEqual({
+        guard(s({ ...NO_ASSISTANTS, assistantsHydrated: false }), CHOOSER),
+      ).toEqual(ALLOW);
+    });
+
+    // The exemption lifts the funnel only. Consent runs after it, so terms
+    // still gate the chooser for a zero-assistant user.
+    test("keeps consent binding on select-assistant with no assistants", () => {
+      expect(
+        guard(s({ ...NO_ASSISTANTS, analyticsConsentCurrent: false }), CHOOSER),
+      ).toEqual({
         action: "redirect",
-        to: "/assistant/onboarding/hatching",
+        to: "/assistant/review-terms?returnTo=%2Fassistant%2Fselect-assistant",
       });
       expect(
         guard(
-          s({ ...noAssistants, tosAccepted: false, privacyConsent: false }),
-          chooser,
+          s({ ...NO_ASSISTANTS, tosAccepted: false, privacyConsent: false }),
+          CHOOSER,
         ),
-      ).toEqual({ action: "redirect", to: "/assistant/onboarding/privacy" });
+      ).toEqual({
+        action: "redirect",
+        to: "/assistant/review-terms?returnTo=%2Fassistant%2Fselect-assistant",
+      });
+      // Stale-looking flags that have not hydrated still wait rather than
+      // bouncing a consented user off the chooser.
+      expect(
+        guard(
+          s({
+            ...NO_ASSISTANTS,
+            analyticsConsentCurrent: false,
+            consentHydrated: false,
+          }),
+          CHOOSER,
+        ),
+      ).toEqual(WAIT);
     });
 
     // The local chooser is a pre-existing onboarding surface reachable before
@@ -314,17 +345,14 @@ describe("resolveNavigation", () => {
             platformSession: "present",
             analyticsConsentCurrent: false,
           }),
-          "/assistant/select-assistant",
+          CHOOSER,
         ),
       ).toEqual(ALLOW);
     });
 
     test("sends an unauthenticated non-local select-assistant visit to login with returnTo", () => {
       expect(
-        guard(
-          s({ isLocalClient: false, isAuthenticated: false }),
-          "/assistant/select-assistant",
-        ),
+        guard(s({ isLocalClient: false, isAuthenticated: false }), CHOOSER),
       ).toEqual({
         action: "redirect",
         to: "/account/login?returnTo=%2Fassistant%2Fselect-assistant",
@@ -339,7 +367,7 @@ describe("resolveNavigation", () => {
             isRemoteGateway: true,
             isAuthenticated: false,
           }),
-          "/assistant/select-assistant",
+          CHOOSER,
         ),
       ).toEqual({
         action: "redirect",
@@ -350,8 +378,12 @@ describe("resolveNavigation", () => {
     test("allows a gateway-auth remote-gateway chooser visit", () => {
       expect(
         guard(
-          s({ isLocalClient: true, isRemoteGateway: true, isGatewayAuth: true }),
-          "/assistant/select-assistant",
+          s({
+            isLocalClient: true,
+            isRemoteGateway: true,
+            isGatewayAuth: true,
+          }),
+          CHOOSER,
         ),
       ).toEqual(ALLOW);
     });
@@ -478,7 +510,11 @@ describe("resolveNavigation", () => {
     test("redirects platform-mode user without consent to review-terms with returnTo", () => {
       expect(
         guard(
-          s({ isLocalClient: false, tosAccepted: false, privacyConsent: false }),
+          s({
+            isLocalClient: false,
+            tosAccepted: false,
+            privacyConsent: false,
+          }),
         ),
       ).toEqual({
         action: "redirect",
@@ -1381,7 +1417,10 @@ describe("resolveNavigation", () => {
 
     test("allows local mode with assistants", () => {
       expect(
-        intercept(s({ isLocalClient: true, hasAssistants: true }), "/assistant"),
+        intercept(
+          s({ isLocalClient: true, hasAssistants: true }),
+          "/assistant",
+        ),
       ).toEqual(ALLOW);
     });
 
@@ -1572,12 +1611,12 @@ describe("resolveNavigation", () => {
       resolveNavigation(state, { kind: "post-retire" });
 
     test("redirects to select-assistant in local mode when other assistants remain", () => {
-      expect(postRetire(s({ hasAssistants: true, isLocalClient: true }))).toEqual(
-        {
-          action: "redirect",
-          to: "/assistant/select-assistant",
-        },
-      );
+      expect(
+        postRetire(s({ hasAssistants: true, isLocalClient: true })),
+      ).toEqual({
+        action: "redirect",
+        to: "/assistant/select-assistant",
+      });
     });
 
     test("redirects to /assistant in platform mode when other assistants remain", () => {

--- a/clients/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.test.ts
@@ -334,9 +334,9 @@ describe("resolveNavigation", () => {
       ).toEqual(WAIT);
     });
 
-    // The local chooser is a pre-existing onboarding surface reachable before
-    // there is a session to gate on, so it keeps its short-circuit ahead of the
-    // assistant and consent gates that now bind on the platform hub.
+    // The local chooser is an onboarding surface reachable before there is a
+    // session to gate on, so it short-circuits ahead of the assistant and
+    // consent gates that bind on the platform hub.
     test("keeps the local chooser open ahead of the consent gate", () => {
       expect(
         guard(

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -554,10 +554,11 @@ function enforceModeBoundary(
 ): NavigationDecision | null {
   // The chooser is reachable in every mode: local clients keep their
   // lockfile-driven picker, and the platform build hosts the hub chooser. The
-  // non-local case falls through rather than allowing, so `requireAssistant`
-  // and `requireConsent` below still bind on this route. The screen owns the
-  // assistant-switcher flag gate for platform-mode access, because the flag
-  // hydrates asynchronously and this resolver has no hydration signal.
+  // non-local case falls through rather than allowing, so `requireConsent`
+  // below still binds on this route; `requireAssistant` exempts it on purpose
+  // (see NO_ASSISTANT_EXEMPT_PATHS). The screen owns the assistant-switcher
+  // flag gate for platform-mode access, because the flag hydrates
+  // asynchronously and this resolver has no hydration signal.
   if (path === routes.selectAssistant) {
     return state.isLocalClient ? localChooserDecision(state) : null;
   }
@@ -691,6 +692,26 @@ function enforceFunnelConsent(
   return { action: "allow" };
 }
 
+/**
+ * The routes a no-assistant user reaches without being funneled into
+ * provisioning first.
+ *
+ * `checkout` is where the marketing pricing CTAs deep-link a brand-new user to
+ * start Stripe checkout for a chosen package; every other billing surface still
+ * provisions first. `selectAssistant` is the hub chooser, the one screen that
+ * answers the empty state for an account whose assistants are all self-hosted:
+ * remembered origins are client-local, so they never reach `hasAssistants`, and
+ * a `?register=` handoff arriving from a self-hosted origin would be lost on the
+ * funnel bounce before the chooser could record it.
+ *
+ * Only the funnel is lifted. `requireConsent` runs after this step, so neither
+ * route can be reached on unaccepted or stale terms.
+ */
+const NO_ASSISTANT_EXEMPT_PATHS: ReadonlySet<string> = new Set([
+  routes.checkout,
+  routes.selectAssistant,
+]);
+
 function requireAssistant(
   state: NavigationState,
   path: string,
@@ -700,13 +721,7 @@ function requireAssistant(
     return null;
   }
 
-  // The marketing pricing CTAs deep-link a brand-new user (no assistant yet)
-  // straight into Stripe checkout for a chosen package. Exempt that route from
-  // the no-assistant funnel redirect only here — `requireConsent` runs after
-  // this step, so consent is still enforced before any paid checkout starts.
-  // Every other billing surface still funnels a no-assistant user into
-  // provisioning first.
-  if (path === routes.checkout) {
+  if (NO_ASSISTANT_EXEMPT_PATHS.has(path)) {
     return null;
   }
 

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -500,6 +500,22 @@ function requireRemoteGatewayPairing(
   };
 }
 
+/**
+ * The local-mode chooser, decided the same way for an unauthenticated visit
+ * (`requireAuth`) and an authenticated one (`enforceModeBoundary`): an empty
+ * lockfile has nothing to choose from, so the visit funnels to hosting.
+ *
+ * Deciding either way is what keeps the local chooser short-circuiting ahead of
+ * the assistant and consent gates: it is itself an onboarding surface,
+ * reachable before there is a platform session to gate on.
+ */
+function localChooserDecision(state: NavigationState): NavigationDecision {
+  if (!state.hasAssistants) {
+    return { action: "redirect", to: routes.onboarding.hosting };
+  }
+  return { action: "allow" };
+}
+
 function requireAuth(
   state: NavigationState,
   path: string,
@@ -515,8 +531,8 @@ function requireAuth(
       LOCAL_ONLY_STANDALONE_PATHS.has(path) ||
       path === routes.selectAssistant)
   ) {
-    if (path === routes.selectAssistant && !state.hasAssistants) {
-      return { action: "redirect", to: routes.onboarding.hosting };
+    if (path === routes.selectAssistant) {
+      return localChooserDecision(state);
     }
     return { action: "allow" };
   }
@@ -537,15 +553,13 @@ function enforceModeBoundary(
   path: string,
 ): NavigationDecision | null {
   // The chooser is reachable in every mode: local clients keep their
-  // lockfile-driven picker (a no-assistant local visit still funnels to
-  // hosting), and the platform build hosts the hub chooser. The screen owns
-  // the assistant-switcher flag gate for platform-mode access, because the
-  // flag hydrates asynchronously and this resolver has no hydration signal.
+  // lockfile-driven picker, and the platform build hosts the hub chooser. The
+  // non-local case falls through rather than allowing, so `requireAssistant`
+  // and `requireConsent` below still bind on this route. The screen owns the
+  // assistant-switcher flag gate for platform-mode access, because the flag
+  // hydrates asynchronously and this resolver has no hydration signal.
   if (path === routes.selectAssistant) {
-    if (state.isLocalClient && !state.hasAssistants) {
-      return { action: "redirect", to: routes.onboarding.hosting };
-    }
-    return { action: "allow" };
+    return state.isLocalClient ? localChooserDecision(state) : null;
   }
 
   if (LOCAL_ONLY_STANDALONE_PATHS.has(path)) {


### PR DESCRIPTION
## Summary
- Opening select-assistant to non-local clients short-circuited the guard pipeline before requireAssistant and requireConsent; the route now falls through so the consent gate still applies (stale or unaccepted terms bounce to review-terms with returnTo)
- The chooser is exempted from the no-assistant funnel alongside /assistant/checkout: remembered origins are client-local, so an account whose assistants are all self-hosted reads as zero-assistant and would be funneled off the one screen that answers that empty state, taking a ?register= handoff with it. The exemption lifts the funnel only, consent still binds
- Local-mode chooser behavior is unchanged, and unauthenticated non-local visitors still get the login redirect with returnTo
- Adds resolver cases pinning stale consent on the chooser, consent winning over the exemption, and the local chooser's pre-existing short-circuit

Part of plan: origin-model-chooser.md (self-review remediation)
