### PR TITLE
fix(web,ios): typecheck repair, prefix-safe native switch, and gate documentation

### DIFF
--- a/clients/ios/App/App/MyViewController.swift
+++ b/clients/ios/App/App/MyViewController.swift
@@ -235,7 +235,20 @@ class MyViewController: CAPBridgeViewController {
         guard let destination = appliedServerURL else {
             return
         }
-        webView?.load(URLRequest(url: destination))
+        webView?.load(URLRequest(url: Self.appEntryURL(forBase: destination)))
+    }
+
+    /// The SPA entry point for a server base, `<base>/assistant`. The ingress
+    /// redirects a bare `/` to a prefix-less `/assistant/`, which would drop a
+    /// hosting prefix (base `https://host/assistant-123` → `https://host/assistant/`),
+    /// so the segment is appended here instead. Mirrors `AppDelegate`'s
+    /// pair-page URL; the baked cloud URL already carries the segment, so it is
+    /// returned unchanged. Tracking state keeps the bare base.
+    private static func appEntryURL(forBase base: URL) -> URL {
+        guard base.lastPathComponent != "assistant" else {
+            return base
+        }
+        return base.appendingPathComponent("assistant")
     }
 
     // MARK: - Quote-and-reply edit menu
@@ -462,13 +475,13 @@ extension MyViewController: WebViewNavigationFailureObserver {
             )
             alert.addAction(UIAlertAction(title: "Retry", style: .default) { [weak self] _ in
                 self?.appliedServerURL = origin
-                self?.webView?.load(URLRequest(url: origin))
+                self?.webView?.load(URLRequest(url: Self.appEntryURL(forBase: origin)))
             })
             alert.addAction(UIAlertAction(title: "Use Vellum Cloud", style: .default) { [weak self] _ in
                 SelfHostedServer.clear()
                 if let baked = self?.bakedServerURL {
                     self?.appliedServerURL = baked
-                    self?.webView?.load(URLRequest(url: baked))
+                    self?.webView?.load(URLRequest(url: Self.appEntryURL(forBase: baked)))
                 }
             })
             self.present(alert, animated: true)

--- a/clients/ios/App/App/SelfHostedServersPlugin.swift
+++ b/clients/ios/App/App/SelfHostedServersPlugin.swift
@@ -66,13 +66,14 @@ public class SelfHostedServersPlugin: CAPPlugin, CAPBridgedPlugin {
             removedActive = SelfHostedServer.isActive(url)
             SelfHostedServer.remove(url: url)
         }
+        // Resolve before scheduling the reload: it tears the web context down,
+        // so a caller awaiting this call would otherwise never settle.
+        call.resolve(["ok": true])
         guard removedActive else {
-            call.resolve(["ok": true])
             return
         }
         DispatchQueue.main.async { [weak self] in
             (self?.bridge?.viewController as? MyViewController)?.applyConfiguredOrigin()
-            call.resolve(["ok": true])
         }
     }
 

--- a/clients/web/src/domains/settings/pages/general-page.tsx
+++ b/clients/web/src/domains/settings/pages/general-page.tsx
@@ -47,8 +47,8 @@ import {
 } from "@/lib/local-mode";
 import { isElectron } from "@/runtime/is-electron";
 import {
-  isNativeMobile,
   useIsNativeAndroid,
+  useIsNativeMobile,
 } from "@/runtime/platform-detection";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { useIsAuthenticated } from "@/stores/auth-store";
@@ -72,17 +72,22 @@ export function GeneralPage() {
   const settingsSleepPolicy =
     useAssistantFeatureFlagStore.use.settingsSleepPolicy();
   const isAuthenticated = useIsAuthenticated();
+  const isNativeMobile = useIsNativeMobile();
   // The assistant-switcher flag gates every chooser surface; the card
   // supersedes the in-page picker so the two never render together. On
   // remote-gateway origins and native shells the client flag store settles to
   // registry defaults (no LD fetch), so the registry default / env /
   // localStorage override governs there, not per-user LD targeting.
+  //
+  // Deliberately wider than `useGatedSelectedAssistantId` in
+  // `assistant/selection.ts`: that gate closes under `isGatewayAuthMode()`,
+  // which is exactly where this card hands off to the hub chooser.
   const showAssistantSwitcherCard =
     assistantSwitcher &&
     (isLocalClient() ||
       isAuthenticated ||
       isRemoteGatewayMode() ||
-      isNativeMobile());
+      isNativeMobile);
   const navigate = useNavigate();
   const platformGate = usePlatformGate();
   const infraGate = usePlatformGate({ platformHostedOnly: true });
@@ -143,17 +148,22 @@ export function GeneralPage() {
 
   const openAssistantChooser = () => {
     const hubUrl = getRemoteGatewayHubUrl();
-    if (isRemoteGatewayMode() && !isNativeMobile() && hubUrl) {
+    if (isRemoteGatewayMode() && !isNativeMobile && hubUrl) {
       // Self-registration handoff: landing on the hub chooser records this
       // origin in the hub's remembered list. `hubUrl` is the hub SPA's
-      // assistant root (`<origin>/assistant`), so the chooser's sub-path is
-      // appended onto it rather than the absolute route.
-      const chooserPath = routes.selectAssistant.slice(routes.assistant.length);
+      // assistant root (`<origin>/assistant`), so the absolute chooser route
+      // hangs off its origin.
+      const params = new URLSearchParams({
+        register: remoteGatewayPublicBaseUrl(),
+      });
       const assistantName = getRemoteGatewayAssistantName();
-      const params =
-        `register=${encodeURIComponent(remoteGatewayPublicBaseUrl())}` +
-        (assistantName ? `&name=${encodeURIComponent(assistantName)}` : "");
-      window.location.assign(`${hubUrl}${chooserPath}?${params}`);
+      if (assistantName) {
+        params.set("name", assistantName);
+      }
+      const hubOrigin = new URL(hubUrl).origin;
+      window.location.assign(
+        `${hubOrigin}${routes.selectAssistant}?${params.toString()}`,
+      );
       return;
     }
     void navigate(`${routes.selectAssistant}?noAutoSkip=1`);

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -330,7 +330,7 @@
       "scope": "client",
       "key": "assistant-switcher",
       "label": "Assistant Switcher",
-      "description": "Show the Switch Assistant section in General settings, linking to the assistant chooser. Covers local clients, signed-in cloud-hub users, remote-gateway origins, and native mobile shells; remote-gateway desktop browsers hand off to the hub chooser with a self-registration param.",
+      "description": "Show the Switch Assistant section in General settings, linking to the assistant chooser. Covers local clients, signed-in cloud-hub users, remote-gateway origins, and native mobile shells; remote-gateway desktop browsers hand off to the hub chooser with a self-registration param. Also makes the chooser's selection authoritative for the app's active assistant on every surface including the platform hub, a job that previously belonged to multi-platform-assistant alone.",
       "defaultEnabled": false
     },
     {

--- a/clients/web/src/stores/remembered-origins-store.test.ts
+++ b/clients/web/src/stores/remembered-origins-store.test.ts
@@ -517,7 +517,8 @@ describe("providers and hydration", () => {
 
   it("a watch event after a failed hydration retries hydration", async () => {
     let failLoads = true;
-    let watchCallback: (() => void) | null = null;
+    // Boxed: a bare `let` assigned in the callback narrows to `null`.
+    const watchRef: { current: (() => void) | null } = { current: null };
     const provider: RememberedOriginsProvider = {
       load: async () => {
         if (failLoads) {
@@ -532,7 +533,7 @@ describe("providers and hydration", () => {
       },
       save: async () => {},
       watch: (onChange) => {
-        watchCallback = onChange;
+        watchRef.current = onChange;
         return () => {};
       },
     };
@@ -543,7 +544,7 @@ describe("providers and hydration", () => {
     // The provider recovers and announces a change; no caller invokes
     // hydrate() manually.
     failLoads = false;
-    watchCallback?.();
+    watchRef.current?.();
     await new Promise((resolve) => setTimeout(resolve, 5));
 
     expect(store().hydrated).toBe(true);
@@ -556,7 +557,8 @@ describe("providers and hydration", () => {
     let entries: RememberedOrigin[] = [
       { url: "https://example.com/new", addedAt: "2026-01-02T00:00:00Z" },
     ];
-    let watchCallback: (() => void) | null = null;
+    // Boxed: a bare `let` assigned in the callback narrows to `null`.
+    const watchRef: { current: (() => void) | null } = { current: null };
     let releaseHydrateLoad = () => {};
     const hydrateGate = new Promise<void>((resolve) => {
       releaseHydrateLoad = resolve;
@@ -579,14 +581,14 @@ describe("providers and hydration", () => {
         entries = next;
       },
       watch: (onChange) => {
-        watchCallback = onChange;
+        watchRef.current = onChange;
         return () => {};
       },
     };
     setRememberedOriginsProvider(provider);
 
     // The provider's value changes while hydration is still loading.
-    watchCallback?.();
+    watchRef.current?.();
     await new Promise((resolve) => setTimeout(resolve, 1));
     releaseHydrateLoad();
     await store().hydrate();
@@ -601,7 +603,8 @@ describe("providers and hydration", () => {
     let entries: RememberedOrigin[] = [
       { url: "https://example.com/a", addedAt: "2026-01-01T00:00:00Z" },
     ];
-    let watchCallback: (() => void) | null = null;
+    // Boxed: a bare `let` assigned in the callback narrows to `null`.
+    const watchRef: { current: (() => void) | null } = { current: null };
     let gate: Promise<void> | null = null;
     let releaseGate = () => {};
     const provider: RememberedOriginsProvider = {
@@ -617,7 +620,7 @@ describe("providers and hydration", () => {
         entries = next;
       },
       watch: (onChange) => {
-        watchCallback = onChange;
+        watchRef.current = onChange;
         return () => {};
       },
     };
@@ -628,7 +631,7 @@ describe("providers and hydration", () => {
     gate = new Promise((resolve) => {
       releaseGate = resolve;
     });
-    watchCallback?.();
+    watchRef.current?.();
     const add = store().addOrigin({ url: "https://example.com/b" });
     releaseGate();
     await add;

--- a/clients/web/src/stores/remembered-origins-store.ts
+++ b/clients/web/src/stores/remembered-origins-store.ts
@@ -165,7 +165,9 @@ function withCrossTabLock<T>(mutation: () => Promise<T>): Promise<T> {
   if (!locks) {
     return mutation();
   }
-  return locks.request(MUTATION_LOCK_NAME, mutation);
+  // TS infers the lock's generic as `Promise<T>`, typing the result
+  // `Promise<Promise<T>>`; the runtime promise is already flattened.
+  return locks.request(MUTATION_LOCK_NAME, mutation) as Promise<T>;
 }
 
 function enqueueMutation<T>(mutation: () => Promise<T>): Promise<T> {

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -330,7 +330,7 @@
       "scope": "client",
       "key": "assistant-switcher",
       "label": "Assistant Switcher",
-      "description": "Show the Switch Assistant section in General settings, linking to the assistant chooser. Covers local clients, signed-in cloud-hub users, remote-gateway origins, and native mobile shells; remote-gateway desktop browsers hand off to the hub chooser with a self-registration param.",
+      "description": "Show the Switch Assistant section in General settings, linking to the assistant chooser. Covers local clients, signed-in cloud-hub users, remote-gateway origins, and native mobile shells; remote-gateway desktop browsers hand off to the hub chooser with a self-registration param. Also makes the chooser's selection authoritative for the app's active assistant on every surface including the platform hub, a job that previously belonged to multi-platform-assistant alone.",
       "defaultEnabled": false
     },
     {


### PR DESCRIPTION
## Summary
- Fixes four TypeScript errors introduced with the remembered-origins store (Web Locks generic inference and a narrowed test callback), which are currently red on main
- The iOS shell now loads the assistant path when switching, so a path-prefixed origin is not dropped by the ingress redirect; removing the active server resolves its bridge call before reloading
- Settings gate uses the hook form and a robust hub URL construction; the assistant-switcher description now records that the flag makes the chooser selection authoritative

Part of plan: origin-model-chooser.md (self-review remediation)