### PR TITLE
fix(web): chooser selection, cloud fallback, and native provider corrections

### DIFF
--- a/clients/web/docs/CAPACITOR.md
+++ b/clients/web/docs/CAPACITOR.md
@@ -245,9 +245,13 @@ server. Changing one means changing the other.
 
 **Switching is per surface, and every surface has a working answer.**
 
-- Browser and Electron: `switchToOrigin` navigates to the origin's SPA root. A
-  remembered origin is a separate deployment, so this is a full navigation, not
-  a route change.
+- Browser: `switchToOrigin` navigates to the origin's SPA root. A remembered
+  origin is a separate deployment, so this is a full navigation, not a route
+  change.
+- Electron: the same navigation, but it does not land in the app window. The
+  main window's `will-navigate` guard
+  ([`main-window.ts`](../../macos/src/main/main-window.ts)) sends any
+  cross-origin https target to the system browser, so the origin opens there.
 - Native mobile with the plugin: `nativeSwitchToOrigin` hands the url to the
   shell, which reloads the web view in place. The user never leaves the app,
   and a "Vellum Cloud" card sourced from `list().bakedUrl` is the way back.
@@ -278,12 +282,13 @@ make is the same answer one turn earlier. `nativeSwitchToOrigin` resolving
 `false` and `nativeVellumCloudOrigin` resolving `null` already cover every
 reason there is no native side.
 
-The plugin module is reached lazily. `switch-origin.ts` imports it with a
-dynamic `import()` inside the native branch so a browser surface never pulls it
-into its graph, and `registerPlugin` itself only builds the bridge Proxy, so
-nothing reaches the shell before the flag-gated install. The inline-destructure
-rule at the top of this document applies to every call: only results cross an
-`async` boundary, never the plugin Proxy.
+The module is a plain static import from both the chooser and
+`switch-origin.ts`: the chooser needs it on mount to install the provider, and
+`registerPlugin` only builds the bridge Proxy, so importing it reaches nothing
+on any surface. Every method call sits behind `isNativeMobile()` or the
+flag-gated install. The inline-destructure rule at the top of this document
+applies to every call: only results cross an `async` boundary, never the plugin
+Proxy.
 
 ---
 

--- a/clients/web/src/assistant/switch-origin.test.ts
+++ b/clients/web/src/assistant/switch-origin.test.ts
@@ -29,8 +29,9 @@ mock.module("@/lib/local-mode", () => ({
   isRemoteGatewayMode: () => remoteGatewayMode,
 }));
 
+let publicBaseUrl = "https://gateway.example/assistant-1";
 mock.module("@/lib/auth/remote-gateway-session", () => ({
-  remoteGatewayPublicBaseUrl: () => "https://gateway.example/assistant-1",
+  remoteGatewayPublicBaseUrl: () => publicBaseUrl,
 }));
 
 const assignMock = mock((_url: string) => {});
@@ -43,9 +44,8 @@ Object.defineProperty(window.location, "assign", {
 // remembered origin can carry; the harness default is http.
 window.location.href = "https://app.example/select-assistant";
 
-const { isCurrentOrigin, switchToOrigin, switchToVellumCloud } = await import(
-  "@/assistant/switch-origin"
-);
+const { isCurrentOrigin, switchToOrigin } =
+  await import("@/assistant/switch-origin");
 
 function origin(url: string): RememberedOrigin {
   return { url, addedAt: "2026-01-01T00:00:00.000Z" };
@@ -55,6 +55,7 @@ beforeEach(() => {
   isNativeMobileValue = false;
   nativeSwitchAccepts = true;
   remoteGatewayMode = false;
+  publicBaseUrl = "https://gateway.example/assistant-1";
   assignMock.mockClear();
   nativeSwitchToOriginMock.mockClear();
 });
@@ -96,15 +97,6 @@ describe("switchToOrigin", () => {
   });
 });
 
-describe("switchToVellumCloud", () => {
-  test("asks the shell for its baked origin", async () => {
-    isNativeMobileValue = true;
-
-    expect(await switchToVellumCloud()).toBe(true);
-    expect(nativeSwitchToOriginMock).toHaveBeenCalledWith(null);
-  });
-});
-
 describe("isCurrentOrigin", () => {
   test("compares against the running deployment's base", () => {
     expect(isCurrentOrigin(origin("https://app.example"))).toBe(true);
@@ -118,5 +110,14 @@ describe("isCurrentOrigin", () => {
       true,
     );
     expect(isCurrentOrigin(origin("https://gateway.example"))).toBe(false);
+  });
+
+  test("normalizes the running base, since stored urls are already canonical", () => {
+    remoteGatewayMode = true;
+    publicBaseUrl = "https://Gateway.Example/assistant-1/";
+
+    expect(isCurrentOrigin(origin("https://gateway.example/assistant-1"))).toBe(
+      true,
+    );
   });
 });

--- a/clients/web/src/assistant/switch-origin.ts
+++ b/clients/web/src/assistant/switch-origin.ts
@@ -3,15 +3,12 @@
  * separate SPA deployment, so selecting one is a full navigation to that
  * base, not an in-app route change. Native mobile shells swap the WKWebView's
  * configured origin instead, which keeps the switch inside the app.
- *
- * Kept dependency-light on the web path: the native seam is reached through a
- * dynamic import, so a browser surface never pulls the Capacitor plugin module
- * into its graph.
  */
 
 import { remoteGatewayPublicBaseUrl } from "@/lib/auth/remote-gateway-session";
 import { isRemoteGatewayMode } from "@/lib/local-mode";
 import { isNativeMobile } from "@/runtime/platform-detection";
+import { nativeSwitchToOrigin } from "@/runtime/self-hosted-servers";
 import {
   normalizeOriginUrl,
   type RememberedOrigin,
@@ -28,6 +25,10 @@ import { routes } from "@/utils/routes";
  * falls back to the same navigation the web takes: leaving the app for the
  * system browser is degraded, but it is what the pair-page path already does
  * there.
+ *
+ * In Electron the navigation does not land in the app window either: the
+ * main process's same-origin guard (`clients/macos/src/main/main-window.ts`)
+ * ejects a cross-origin https target to the system browser.
  */
 export async function switchToOrigin(origin: RememberedOrigin): Promise<void> {
   const navigate = () =>
@@ -36,34 +37,20 @@ export async function switchToOrigin(origin: RememberedOrigin): Promise<void> {
     navigate();
     return;
   }
-  const { nativeSwitchToOrigin } = await import(
-    "@/runtime/self-hosted-servers"
-  );
   if (!(await nativeSwitchToOrigin(origin.url))) {
     navigate();
   }
 }
 
 /**
- * Return a native mobile shell to its baked Vellum Cloud origin, resolving
- * whether the shell took the switch. Offered only where the baked origin is
- * known, which is a shell that carries the plugin.
- */
-export async function switchToVellumCloud(): Promise<boolean> {
-  const { nativeSwitchToOrigin } = await import(
-    "@/runtime/self-hosted-servers"
-  );
-  return nativeSwitchToOrigin(null);
-}
-
-/**
- * Whether `origin` is the deployment serving the running app. In
- * remote-gateway mode the app's base carries the public path prefix, so the
+ * Whether `origin` is the deployment serving the running app. Stored urls are
+ * already canonical, so the running base is the side that needs normalizing.
+ * In remote-gateway mode that base carries the public path prefix, so the
  * comparison includes it.
  */
 export function isCurrentOrigin(origin: RememberedOrigin): boolean {
   const currentBase = isRemoteGatewayMode()
     ? remoteGatewayPublicBaseUrl()
     : window.location.origin;
-  return normalizeOriginUrl(origin.url) === currentBase;
+  return normalizeOriginUrl(currentBase) === origin.url;
 }

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
@@ -27,6 +27,12 @@ import type { ResolvedAssistant } from "@/stores/resolved-assistants-store";
 
 const navigateMock = mock((_to: string, _opts?: unknown) => {});
 let searchParams = new URLSearchParams();
+const setSearchParamsMock = mock(
+  (
+    _next: (prev: URLSearchParams) => URLSearchParams,
+    _opts?: { replace?: boolean },
+  ) => {},
+);
 let hasPlatformSessionValue = false;
 let assistantsValue: ResolvedAssistant[] = [];
 let localModeHostAvailableValue = false;
@@ -78,7 +84,7 @@ const addOriginMock = mock(
   }),
 );
 const switchToOriginMock = mock(async (_origin: RememberedOrigin) => {});
-const switchToVellumCloudMock = mock(async () => true);
+const nativeSwitchToOriginMock = mock(async (_url: string | null) => true);
 let isNativeMobileValue = false;
 const installNativeRememberedOriginsMock = mock(() => {});
 /** What the native shell reports as its baked Vellum Cloud origin, if any. */
@@ -100,7 +106,7 @@ class MockGuardianTokenError extends Error {
 
 mock.module("react-router", () => ({
   useNavigate: () => navigateMock,
-  useSearchParams: () => [searchParams],
+  useSearchParams: () => [searchParams, setSearchParamsMock],
 }));
 
 mock.module("@/assistant/selection", () => ({
@@ -169,7 +175,6 @@ mock.module("@/stores/remembered-origins-store", () => ({
 
 mock.module("@/assistant/switch-origin", () => ({
   switchToOrigin: switchToOriginMock,
-  switchToVellumCloud: switchToVellumCloudMock,
   isCurrentOrigin: (origin: RememberedOrigin) =>
     origin.url === currentOriginUrl,
 }));
@@ -180,6 +185,7 @@ mock.module("@/runtime/platform-detection", () => ({
 
 mock.module("@/runtime/self-hosted-servers", () => ({
   installNativeRememberedOrigins: installNativeRememberedOriginsMock,
+  nativeSwitchToOrigin: nativeSwitchToOriginMock,
   nativeVellumCloudOrigin: async () => nativeCloudOriginValue,
 }));
 
@@ -416,6 +422,12 @@ function makePlatformAssistant(
 const REPAIR_COPY =
   "This pairing has expired. Run vellum pair on the assistant's machine and import it again with vellum connect import.";
 
+/**
+ * What a shell reports as its baked Vellum Cloud origin. It is the Capacitor
+ * `server.url`, which is the hub's `/assistant` root rather than a bare base.
+ */
+const BAKED_CLOUD_URL = "https://www.vellum.ai/assistant";
+
 function makeOrigin(
   overrides: Partial<RememberedOrigin> = {},
 ): RememberedOrigin {
@@ -436,6 +448,7 @@ beforeEach(() => {
   connectLocalAssistantMock.mockClear();
   connectPlatformAssistantMock.mockClear();
   searchParams = new URLSearchParams();
+  setSearchParamsMock.mockClear();
   hasPlatformSessionValue = false;
   assistantsValue = [];
   localModeHostAvailableValue = false;
@@ -461,7 +474,8 @@ beforeEach(() => {
     },
   }));
   switchToOriginMock.mockClear();
-  switchToVellumCloudMock.mockClear();
+  nativeSwitchToOriginMock.mockClear();
+  nativeSwitchToOriginMock.mockImplementation(async () => true);
   isNativeMobileValue = false;
   nativeCloudOriginValue = null;
   installNativeRememberedOriginsMock.mockClear();
@@ -1001,6 +1015,19 @@ describe("SelectAssistantScreen remembered origins", () => {
     expect(switchToOriginMock).not.toHaveBeenCalled();
   });
 
+  test("the current-origin card offers no remove menu", () => {
+    // A native shell always lists the origin it serves, and forgetting that
+    // one relocates the app, which the removal copy promises it will not do.
+    assistantSwitcherValue = true;
+    currentOriginUrl = "https://assistant.example.com";
+    originsValue = [makeOrigin()];
+    assistantsValue = [makePairedAssistant(), makePlatformAssistant()];
+
+    render(<SelectAssistantScreen />);
+
+    expect(screen.queryByLabelText("Actions for Home Server")).toBeNull();
+  });
+
   test("removing an origin shows the origin copy and forgets the entry", async () => {
     assistantSwitcherValue = true;
     originsValue = [makeOrigin()];
@@ -1083,6 +1110,29 @@ describe("SelectAssistantScreen remembered origins", () => {
     );
     expect(connectPairedAssistantMock).not.toHaveBeenCalled();
   });
+
+  test("auto-skip holds until the feature flags hydrate", async () => {
+    // The flag store boots to the registry default (off), so a targeted `on`
+    // lands after mount; skipping before then would strand this device's
+    // remembered origins behind an auto-connect.
+    flagsHydratedValue = false;
+    assistantsValue = [makePairedAssistant()];
+
+    const { rerender } = render(<SelectAssistantScreen />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Choose an Assistant")).toBeTruthy(),
+    );
+    expect(connectPairedAssistantMock).not.toHaveBeenCalled();
+
+    flagsHydratedValue = true;
+    assistantSwitcherValue = true;
+    originsValue = [makeOrigin()];
+    rerender(<SelectAssistantScreen />);
+
+    await waitFor(() => expect(screen.getByText("Home Server")).toBeTruthy());
+    expect(connectPairedAssistantMock).not.toHaveBeenCalled();
+  });
 });
 
 describe("SelectAssistantScreen native mobile", () => {
@@ -1106,7 +1156,7 @@ describe("SelectAssistantScreen native mobile", () => {
   test("a shell serving a self-hosted origin offers a Vellum Cloud card", async () => {
     assistantSwitcherValue = true;
     isNativeMobileValue = true;
-    nativeCloudOriginValue = "https://app.vellum.ai";
+    nativeCloudOriginValue = BAKED_CLOUD_URL;
     assistantsValue = [];
 
     render(<SelectAssistantScreen />);
@@ -1118,16 +1168,20 @@ describe("SelectAssistantScreen native mobile", () => {
     fireEvent.click(screen.getByText("Vellum Cloud"));
     fireEvent.click(screen.getByText("Continue"));
 
-    await waitFor(() => expect(switchToVellumCloudMock).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(nativeSwitchToOriginMock).toHaveBeenCalledWith(null),
+    );
     expect(switchToOriginMock).not.toHaveBeenCalled();
   });
 
-  test("a rejected cloud switch falls back to a plain navigation", async () => {
+  test("a rejected cloud switch navigates to the baked url as-is", async () => {
     assistantSwitcherValue = true;
     isNativeMobileValue = true;
-    nativeCloudOriginValue = "https://app.vellum.ai";
+    // The shell's baked `server.url` already carries the hub's `/assistant`
+    // root, so the fallback must not append the route a second time.
+    nativeCloudOriginValue = BAKED_CLOUD_URL;
     assistantsValue = [];
-    switchToVellumCloudMock.mockImplementation(async () => false);
+    nativeSwitchToOriginMock.mockImplementation(async () => false);
     const assignSpy = mock((_url: string) => {});
     const originalLocation = window.location;
     Object.defineProperty(window, "location", {
@@ -1145,18 +1199,57 @@ describe("SelectAssistantScreen native mobile", () => {
       fireEvent.click(screen.getByText("Continue"));
 
       await waitFor(() =>
-        expect(assignSpy).toHaveBeenCalledWith(
-          "https://app.vellum.ai/assistant",
-        ),
+        expect(assignSpy).toHaveBeenCalledWith(BAKED_CLOUD_URL),
       );
     } finally {
       Object.defineProperty(window, "location", {
         configurable: true,
         value: originalLocation,
       });
-      // mockClear keeps the implementation, so restore the default here.
-      switchToVellumCloudMock.mockImplementation(async () => true);
     }
+  });
+
+  test("an origins-only chooser defaults its selection so Continue can act", async () => {
+    assistantSwitcherValue = true;
+    isNativeMobileValue = true;
+    nativeCloudOriginValue = BAKED_CLOUD_URL;
+    originsValue = [makeOrigin()];
+    assistantsValue = [];
+
+    render(<SelectAssistantScreen />);
+
+    // The first origin card wins the default, ahead of the cloud card.
+    await waitFor(() =>
+      expect(
+        screen
+          .getAllByRole("radio")
+          .find((r) => r.textContent?.includes("Home Server"))
+          ?.getAttribute("aria-checked"),
+      ).toBe("true"),
+    );
+    expect(
+      (screen.getByText("Continue") as HTMLButtonElement).disabled,
+    ).toBe(false);
+
+    fireEvent.click(screen.getByText("Continue"));
+
+    await waitFor(() => expect(switchToOriginMock).toHaveBeenCalled());
+  });
+
+  test("with only the cloud card the selection defaults to it", async () => {
+    assistantSwitcherValue = true;
+    isNativeMobileValue = true;
+    nativeCloudOriginValue = BAKED_CLOUD_URL;
+    assistantsValue = [];
+
+    render(<SelectAssistantScreen />);
+
+    await waitFor(() => expect(screen.getByText("Vellum Cloud")).toBeTruthy());
+    fireEvent.click(screen.getByText("Continue"));
+
+    await waitFor(() =>
+      expect(nativeSwitchToOriginMock).toHaveBeenCalledWith(null),
+    );
   });
 
   test("no Vellum Cloud card when the shell already serves the baked origin", async () => {
@@ -1174,7 +1267,7 @@ describe("SelectAssistantScreen native mobile", () => {
 
   test("no Vellum Cloud card on a browser surface", async () => {
     assistantSwitcherValue = true;
-    nativeCloudOriginValue = "https://app.vellum.ai";
+    nativeCloudOriginValue = BAKED_CLOUD_URL;
     assistantsValue = [makePairedAssistant(), makePlatformAssistant()];
 
     render(<SelectAssistantScreen />);
@@ -1264,32 +1357,17 @@ describe("SelectAssistantScreen add-remote-assistant affordance", () => {
 });
 
 describe("SelectAssistantScreen register handoff", () => {
-  const replaceStateSpy = mock(
-    (_data: unknown, _unused: string, _url?: string | URL | null) => {},
-  );
-  let originalReplaceState: typeof window.history.replaceState;
+  /** The query string the screen's updater produces from the current one. */
+  function strippedQuery(): string {
+    const [update] = setSearchParamsMock.mock.calls[0];
+    return update(searchParams).toString();
+  }
 
-  beforeEach(() => {
-    replaceStateSpy.mockClear();
-    originalReplaceState = window.history.replaceState;
-    Object.defineProperty(window.history, "replaceState", {
-      configurable: true,
-      value: replaceStateSpy,
-    });
-  });
-
-  afterEach(() => {
-    Object.defineProperty(window.history, "replaceState", {
-      configurable: true,
-      value: originalReplaceState,
-    });
-  });
-
-  test("a valid register param records the origin with its label and cleans the address bar", async () => {
+  test("a valid register param records the origin with its label and strips the params through the router", async () => {
     assistantSwitcherValue = true;
     assistantsValue = [makePairedAssistant(), makePlatformAssistant()];
     searchParams = new URLSearchParams(
-      "register=https%3A%2F%2Fhost.example%2Fassistant-1&name=Homelab",
+      "register=https%3A%2F%2Fhost.example%2Fassistant-1&name=Homelab&keep=1",
     );
 
     render(<SelectAssistantScreen />);
@@ -1302,7 +1380,11 @@ describe("SelectAssistantScreen register handoff", () => {
         name: "Homelab",
       }),
     );
-    expect(replaceStateSpy).toHaveBeenCalled();
+    await waitFor(() => expect(setSearchParamsMock).toHaveBeenCalled());
+    // Only the consumed params go; the rest of the query survives, and the
+    // strip replaces the entry rather than pushing a new one.
+    expect(strippedQuery()).toBe("keep=1");
+    expect(setSearchParamsMock.mock.calls[0][1]).toEqual({ replace: true });
     // Records only; the user stays on the chooser to see the updated list.
     expect(switchToOriginMock).not.toHaveBeenCalled();
     expect(navigateMock).not.toHaveBeenCalled();
@@ -1321,7 +1403,7 @@ describe("SelectAssistantScreen register handoff", () => {
     await waitFor(() => expect(addOriginMock).toHaveBeenCalled());
     // The handoff params are the only copy of the registration; a failed
     // persistence keeps them so a reload retries.
-    expect(replaceStateSpy).not.toHaveBeenCalled();
+    expect(setSearchParamsMock).not.toHaveBeenCalled();
   });
 
   test("a name-less register param records the origin without a label", async () => {
@@ -1360,7 +1442,8 @@ describe("SelectAssistantScreen register handoff", () => {
       expect(addOriginMock).not.toHaveBeenCalled();
       expect(screen.queryByText(/Failed|Please try again/)).toBeNull();
       // The consumed params still leave the address bar.
-      expect(replaceStateSpy).toHaveBeenCalled();
+      expect(setSearchParamsMock).toHaveBeenCalled();
+      expect(strippedQuery()).toBe("");
     },
   );
 
@@ -1376,7 +1459,7 @@ describe("SelectAssistantScreen register handoff", () => {
       expect(screen.getByText("Choose an Assistant")).toBeTruthy(),
     );
     expect(addOriginMock).not.toHaveBeenCalled();
-    expect(replaceStateSpy).not.toHaveBeenCalled();
+    expect(setSearchParamsMock).not.toHaveBeenCalled();
   });
 });
 

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
@@ -1015,10 +1015,11 @@ describe("SelectAssistantScreen remembered origins", () => {
     expect(switchToOriginMock).not.toHaveBeenCalled();
   });
 
-  test("the current-origin card offers no remove menu", () => {
+  test("the current-origin card offers no remove menu on a native shell", () => {
     // A native shell always lists the origin it serves, and forgetting that
     // one relocates the app, which the removal copy promises it will not do.
     assistantSwitcherValue = true;
+    isNativeMobileValue = true;
     currentOriginUrl = "https://assistant.example.com";
     originsValue = [makeOrigin()];
     assistantsValue = [makePairedAssistant(), makePlatformAssistant()];
@@ -1026,6 +1027,19 @@ describe("SelectAssistantScreen remembered origins", () => {
     render(<SelectAssistantScreen />);
 
     expect(screen.queryByLabelText("Actions for Home Server")).toBeNull();
+  });
+
+  test("the current-origin card keeps its remove menu in a browser", () => {
+    // The browser list is local and inert: forgetting the entry cannot move
+    // the page, so the user keeps the affordance.
+    assistantSwitcherValue = true;
+    currentOriginUrl = "https://assistant.example.com";
+    originsValue = [makeOrigin()];
+    assistantsValue = [makePairedAssistant(), makePlatformAssistant()];
+
+    render(<SelectAssistantScreen />);
+
+    expect(screen.getByLabelText("Actions for Home Server")).toBeTruthy();
   });
 
   test("removing an origin shows the origin copy and forgets the entry", async () => {

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -759,7 +759,12 @@ export function SelectAssistantScreen() {
                 }
                 onSelect={() => setSelected(key)}
                 onRemove={
-                  current ? undefined : () => setRemoveOriginTarget(origin)
+                  // Forgetting the current entry on a native shell relocates
+                  // the app to the baked origin, which the dialog copy does
+                  // not promise. Elsewhere the list is local and inert.
+                  current && nativeMobile
+                    ? undefined
+                    : () => setRemoveOriginTarget(origin)
                 }
               />
             );

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -12,11 +12,7 @@ import { useNavigate, useSearchParams } from "react-router";
 
 import { resolveSelectedAssistantId } from "@/assistant/selection";
 import { retireAssistant } from "@/assistant/retire-service";
-import {
-  isCurrentOrigin,
-  switchToOrigin,
-  switchToVellumCloud,
-} from "@/assistant/switch-origin";
+import { isCurrentOrigin, switchToOrigin } from "@/assistant/switch-origin";
 import { removePairedAssistant } from "@/assistant/switch-service";
 import { RemoveFromDeviceDialog } from "@/components/remove-from-device-dialog";
 import {
@@ -45,6 +41,7 @@ import {
 import { useIsNativeMobile } from "@/runtime/platform-detection";
 import {
   installNativeRememberedOrigins,
+  nativeSwitchToOrigin,
   nativeVellumCloudOrigin,
 } from "@/runtime/self-hosted-servers";
 import { useAuthStore, useHasPlatformSession } from "@/stores/auth-store";
@@ -94,8 +91,12 @@ function assistantSubtitle(a: ResolvedAssistant): string {
  */
 type OriginCardEntry = Pick<RememberedOrigin, "name" | "url">;
 
+function originHostname(origin: OriginCardEntry): string {
+  return new URL(origin.url).hostname;
+}
+
 function originLabel(origin: OriginCardEntry): string {
-  return origin.name ?? new URL(origin.url).hostname;
+  return origin.name ?? originHostname(origin);
 }
 
 /**
@@ -114,29 +115,19 @@ const CLOUD_SELECTION_KEY = "origin:vellum-cloud";
 const NO_ORIGINS: RememberedOrigin[] = [];
 
 /**
- * Strip the consumed `register`/`name` handoff params from the address bar,
+ * The consumed `register`/`name` handoff params dropped from `params`,
  * preserving everything else, so a reload does not re-run the registration.
- * Mirrors `clearDeviceCodeFromUrl` on the pairing page: a plain
- * `history.replaceState`, never a navigation.
  */
-function clearRegisterParamsFromUrl(): void {
-  try {
-    const url = new URL(window.location.href);
-    url.searchParams.delete("register");
-    url.searchParams.delete("name");
-    window.history.replaceState(
-      null,
-      "",
-      `${url.pathname}${url.search}${url.hash}`,
-    );
-  } catch {
-    // history.replaceState unavailable; the leftover params are inert.
-  }
+function withoutRegisterParams(params: URLSearchParams): URLSearchParams {
+  const next = new URLSearchParams(params);
+  next.delete("register");
+  next.delete("name");
+  return next;
 }
 
 export function SelectAssistantScreen() {
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const fromLogin = searchParams.get("fromLogin") === "1";
   const noAutoSkip = searchParams.get("noAutoSkip") === "1";
   const electron = isElectron();
@@ -169,6 +160,9 @@ export function SelectAssistantScreen() {
     assistantSwitcher && cloudOriginUrl !== null
       ? { url: cloudOriginUrl, name: "Vellum Cloud" }
       : null;
+  // Stable dep for the selection effect: `cloudOrigin` is a fresh object each
+  // render.
+  const cloudOriginOffered = cloudOrigin !== null;
 
   const isAccessible = (a: ResolvedAssistant): boolean =>
     a.isLocal || a.isPaired || hasPlatformSession;
@@ -273,10 +267,11 @@ export function SelectAssistantScreen() {
 
   // `?register=<url>&name=<label>` handoff: another origin's Switch
   // Assistant action self-registers here so the hub lists it. Records the
-  // entry (renaming an existing one) and cleans the address bar; it never
-  // navigates, so the user sees the updated list. Consumed at most once,
-  // and only once the flag is known on: with the flag off the params are
-  // ignored and left untouched. Only a name and an https URL ride the
+  // entry (renaming an existing one) and strips the params through the
+  // router, so router state and the address bar stay in step; it never
+  // navigates away, so the user sees the updated list. Consumed at most
+  // once, and only once the flag is known on: with the flag off the params
+  // are ignored and left untouched. Only a name and an https URL ride the
   // params; anything failing `normalizeOriginUrl` is dropped silently
   // (and stripped, since retrying cannot fix it). A failed add keeps the
   // params and releases the ref so a reload can retry the registration.
@@ -290,9 +285,11 @@ export function SelectAssistantScreen() {
     if (register === null) {
       return;
     }
+    const clearParams = () =>
+      setSearchParams(withoutRegisterParams, { replace: true });
     const normalized = normalizeOriginUrl(register);
     if (normalized === null) {
-      clearRegisterParamsFromUrl();
+      clearParams();
       return;
     }
     void useRememberedOriginsStore
@@ -303,7 +300,7 @@ export function SelectAssistantScreen() {
       })
       .then((result) => {
         if (result.ok) {
-          clearRegisterParamsFromUrl();
+          clearParams();
         } else {
           registerHandledRef.current = false;
         }
@@ -311,15 +308,16 @@ export function SelectAssistantScreen() {
       .catch(() => {
         registerHandledRef.current = false;
       });
-  }, [assistantSwitcher, searchParams]);
+  }, [assistantSwitcher, searchParams, setSearchParams]);
 
   // Default selection: the app's known selected assistant when accessible,
-  // else the first accessible assistant. Also reconciles an existing
-  // selection that stops being accessible (an in-place logout locks the
-  // platform cards), so Continue can never target a locked assistant. A
-  // selected remembered origin needs no session, so it stands.
+  // else the first accessible assistant, else the first origin card. Also
+  // reconciles an existing selection that stops being accessible (an
+  // in-place logout locks the platform cards), so Continue can never target
+  // a locked assistant. A selected remembered origin needs no session, so it
+  // stands.
   useEffect(() => {
-    if (selected === CLOUD_SELECTION_KEY && cloudOriginUrl !== null) {
+    if (selected === CLOUD_SELECTION_KEY && cloudOriginOffered) {
       return;
     }
     if (
@@ -329,8 +327,16 @@ export function SelectAssistantScreen() {
       return;
     }
     if (accessibleAssistants.length === 0) {
-      if (selected != null) {
-        setSelected(null);
+      // Without this an origins-only chooser has no default and Continue
+      // renders permanently disabled.
+      const firstOrigin = originEntries[0];
+      const fallback = firstOrigin
+        ? originSelectionKey(firstOrigin)
+        : cloudOriginOffered
+          ? CLOUD_SELECTION_KEY
+          : null;
+      if (selected !== fallback) {
+        setSelected(fallback);
       }
       return;
     }
@@ -348,7 +354,7 @@ export function SelectAssistantScreen() {
     accessibleAssistants,
     currentOrganizationId,
     originEntries,
-    cloudOriginUrl,
+    cloudOriginOffered,
   ]);
 
   const handleConnect = async (assistant: ResolvedAssistant) => {
@@ -575,8 +581,12 @@ export function SelectAssistantScreen() {
       return;
     }
     // Remembered origins are alternatives a sole assistant does not account
-    // for, so the chooser stays up whenever any exist. Persisted entries
-    // publish only after hydration, so hold the skip until then.
+    // for, so the chooser stays up whenever any exist. Both the flag and the
+    // entries land after mount, and the flag store boots to its registry
+    // default, so the origin hold below is inert until this one clears.
+    if (!flagsHydrated) {
+      return;
+    }
     if (assistantSwitcher && !originsHydrated) {
       return;
     }
@@ -607,16 +617,19 @@ export function SelectAssistantScreen() {
     localClient,
     originEntries.length,
     assistantSwitcher,
+    flagsHydrated,
     originsHydrated,
   ]);
 
   const onContinue = () => {
     if (selected === CLOUD_SELECTION_KEY) {
       // A rejected bridge switch leaves the shell where it is, so fall back
-      // to the plain navigation the card's url already gives us.
-      void switchToVellumCloud().then((switched) => {
+      // to a plain navigation. The baked url is the hub's assistant root
+      // already (the shell's `server.url`), unlike a remembered origin's
+      // bare base.
+      void nativeSwitchToOrigin(null).then((switched) => {
         if (!switched && cloudOriginUrl !== null) {
-          window.location.assign(`${cloudOriginUrl}/assistant`);
+          window.location.assign(cloudOriginUrl);
         }
       });
       return;
@@ -729,19 +742,25 @@ export function SelectAssistantScreen() {
           })}
           {originEntries.map((origin, index) => {
             const key = originSelectionKey(origin);
+            // Forgetting the origin a native shell is serving clears its
+            // active slot and relocates the app, which the removal copy
+            // promises it will not do, so the current card has no menu.
+            const current = isCurrentOrigin(origin);
             return (
               <RemoteOriginCard
                 key={origin.url}
                 origin={origin}
                 selected={selected === key}
-                current={isCurrentOrigin(origin)}
+                current={current}
                 tabStop={
                   selected == null
                     ? accessibleAssistants.length === 0 && index === 0
                     : selected === key
                 }
                 onSelect={() => setSelected(key)}
-                onRemove={() => setRemoveOriginTarget(origin)}
+                onRemove={
+                  current ? undefined : () => setRemoveOriginTarget(origin)
+                }
               />
             );
           })}
@@ -760,7 +779,7 @@ export function SelectAssistantScreen() {
               onSelect={() => setSelected(CLOUD_SELECTION_KEY)}
             />
           )}
-          {isLocalClient() && (
+          {localClient && (
             <DashedActionButton
               icon={<Plus className="h-4 w-4" />}
               label="Create a new assistant"
@@ -928,38 +947,15 @@ function DashedActionButton({
   );
 }
 
-function AssistantCard({
-  assistant,
-  selected,
-  locked,
-  tabStop,
-  onSelect,
-  loginLabel,
-  loginDisabled,
-  onLogin,
+/** Overflow menu opening the remove-from-this-device confirmation. */
+function RemoveCardMenu({
+  label,
   onRemove,
 }: {
-  assistant: ResolvedAssistant;
-  selected: boolean;
-  /** Not selectable in this session (platform-hosted without a login). */
-  locked: boolean;
-  /** The radiogroup's single roving tab stop lands on this card. */
-  tabStop: boolean;
-  onSelect: () => void;
-  loginLabel: string;
-  loginDisabled: boolean;
-  /** Present only on locked platform cards: log in to unlock this assistant. */
-  onLogin?: () => void;
-  /** Present when the entry can be forgotten on this device: opens the confirm. */
-  onRemove?: () => void;
+  label: string;
+  onRemove: () => void;
 }) {
-  const subtitle = assistantSubtitle(assistant);
-  // Electron compacts the card to the Swift client's onboarding-card metrics
-  // (12px padding, 12px radius, 12px icon→text gap, 11px secondary text) so
-  // the picker reads at the same density as the native windows.
-  const electron = isElectron();
-
-  const removeMenu = onRemove && (
+  return (
     <Menu.Root>
       <Menu.Trigger asChild>
         <Button
@@ -967,7 +963,7 @@ function AssistantCard({
           size="regular"
           className="text-[var(--content-tertiary)]"
           iconOnly={<EllipsisVertical />}
-          aria-label={`Actions for ${assistantLabel(assistant)}`}
+          aria-label={`Actions for ${label}`}
         />
       </Menu.Trigger>
       <Menu.Content align="end" sideOffset={4}>
@@ -980,6 +976,43 @@ function AssistantCard({
       </Menu.Content>
     </Menu.Root>
   );
+}
+
+/**
+ * Radio-card shell every chooser entry renders through: icon, title,
+ * subtitle, the roving tab stop, and the right-hand affordance cluster. A
+ * locked card (a platform assistant with no session) drops the radio
+ * semantics and the selected dot, keeping only its actions.
+ */
+function ChooserCard({
+  icon,
+  title,
+  subtitle,
+  selected,
+  locked = false,
+  tabStop,
+  onSelect,
+  action,
+  removeMenu,
+}: {
+  icon: ReactNode;
+  title: string;
+  subtitle: string;
+  selected: boolean;
+  /** Not selectable in this session (platform-hosted without a login). */
+  locked?: boolean;
+  /** The radiogroup's single roving tab stop lands on this card. */
+  tabStop: boolean;
+  onSelect: () => void;
+  /** Leading right-hand affordance, e.g. a locked card's log-in button. */
+  action?: ReactNode;
+  /** Present when the entry can be forgotten on this device. */
+  removeMenu?: ReactNode;
+}) {
+  // Electron compacts the card to the Swift client's onboarding-card metrics
+  // (12px padding, 12px radius, 12px icon→text gap, 11px secondary text) so
+  // the picker reads at the same density as the native windows.
+  const electron = isElectron();
 
   return (
     <div
@@ -1022,18 +1055,12 @@ function AssistantCard({
             : "bg-[var(--surface-active)]/40 text-[var(--content-secondary)]",
         ].join(" ")}
       >
-        {assistant.isPaired ? (
-          <Link2 className="h-5 w-5" />
-        ) : assistant.isLocal ? (
-          <Laptop className="h-5 w-5" />
-        ) : (
-          <Cloud className="h-5 w-5" />
-        )}
+        {icon}
       </div>
 
       <div className="min-w-0 flex-1">
         <span className="block text-body-medium-default text-[var(--content-default)]">
-          {assistantLabel(assistant)}
+          {title}
         </span>
         <span
           className={`mt-1 block text-[var(--content-tertiary)] ${electron ? "text-label-medium-default font-normal" : "text-body-small-lighter"}`}
@@ -1042,23 +1069,12 @@ function AssistantCard({
         </span>
       </div>
 
-      {locked ? (
-        <div className="flex shrink-0 items-center gap-2">
-          {onLogin && (
-            <Button
-              variant="primary"
-              size="regular"
-              onClick={onLogin}
-              disabled={loginDisabled}
-            >
-              {loginLabel}
-            </Button>
-          )}
-          {removeMenu}
-        </div>
-      ) : (
-        <div className="flex shrink-0 items-center gap-2">
-          {removeMenu && (
+      <div className="flex shrink-0 items-center gap-2">
+        {action}
+        {removeMenu &&
+          (locked ? (
+            removeMenu
+          ) : (
             /* The trigger sits inside the radio card: stop clicks and keys
                from bubbling so opening the menu never selects the card and
                the radio's Enter/Space handler never swallows the trigger. */
@@ -1068,7 +1084,8 @@ function AssistantCard({
             >
               {removeMenu}
             </div>
-          )}
+          ))}
+        {!locked && (
           <div
             className={[
               "flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 transition-all duration-200",
@@ -1084,18 +1101,80 @@ function AssistantCard({
               />
             )}
           </div>
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 }
 
+function AssistantCard({
+  assistant,
+  selected,
+  locked,
+  tabStop,
+  onSelect,
+  loginLabel,
+  loginDisabled,
+  onLogin,
+  onRemove,
+}: {
+  assistant: ResolvedAssistant;
+  selected: boolean;
+  /** Not selectable in this session (platform-hosted without a login). */
+  locked: boolean;
+  /** The radiogroup's single roving tab stop lands on this card. */
+  tabStop: boolean;
+  onSelect: () => void;
+  loginLabel: string;
+  loginDisabled: boolean;
+  /** Present only on locked platform cards: log in to unlock this assistant. */
+  onLogin?: () => void;
+  /** Present when the entry can be forgotten on this device: opens the confirm. */
+  onRemove?: () => void;
+}) {
+  const label = assistantLabel(assistant);
+  return (
+    <ChooserCard
+      icon={
+        assistant.isPaired ? (
+          <Link2 className="h-5 w-5" />
+        ) : assistant.isLocal ? (
+          <Laptop className="h-5 w-5" />
+        ) : (
+          <Cloud className="h-5 w-5" />
+        )
+      }
+      title={label}
+      subtitle={assistantSubtitle(assistant)}
+      selected={selected}
+      locked={locked}
+      tabStop={tabStop}
+      onSelect={onSelect}
+      action={
+        locked && onLogin ? (
+          <Button
+            variant="primary"
+            size="regular"
+            onClick={onLogin}
+            disabled={loginDisabled}
+          >
+            {loginLabel}
+          </Button>
+        ) : undefined
+      }
+      removeMenu={
+        onRemove && <RemoveCardMenu label={label} onRemove={onRemove} />
+      }
+    />
+  );
+}
+
 /**
- * Chooser card for a remote origin, in the `AssistantCard` visual language. An
- * origin is only an address: it is always selectable (no session is needed to
- * navigate away), and its menu removal only forgets the entry on this device.
- * The native shell's baked Vellum Cloud origin reuses the card without a menu,
- * since there is no device-local entry to forget.
+ * Chooser card for a remote origin. An origin is only an address: it is
+ * always selectable (no session is needed to navigate away), and its menu
+ * removal only forgets the entry on this device. The native shell's baked
+ * Vellum Cloud origin reuses the card without a menu, since there is no
+ * device-local entry to forget.
  */
 function RemoteOriginCard({
   origin,
@@ -1118,102 +1197,18 @@ function RemoteOriginCard({
   /** Opens the remove-from-this-device confirmation, when there is one. */
   onRemove?: () => void;
 }) {
-  const electron = isElectron();
-  const hostname = new URL(origin.url).hostname;
-
+  const label = originLabel(origin);
   return (
-    <div
-      role="radio"
-      aria-checked={selected}
-      tabIndex={tabStop ? 0 : -1}
-      onClick={onSelect}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          onSelect();
-        }
-      }}
-      className={[
-        "group flex w-full items-center border text-left",
-        electron
-          ? "gap-3 rounded-lg px-[10px] py-3"
-          : "gap-4 rounded-2xl px-[18px] py-4",
-        "transition-all duration-200 ease-out",
-        "cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--primary-base)]",
-        selected
-          ? "border-[var(--primary-base)] bg-[var(--surface-lift)]"
-          : "border-[var(--border-base)] bg-[var(--surface-lift)]/60 hover:border-[var(--border-element)] hover:bg-[var(--surface-lift)]",
-      ].join(" ")}
-    >
-      <div
-        className={[
-          "flex shrink-0 items-center justify-center transition-colors duration-200",
-          "h-12 w-12 rounded-[10px]",
-          selected
-            ? "bg-[var(--primary-base)] text-[var(--surface-base)]"
-            : "bg-[var(--surface-active)]/40 text-[var(--content-secondary)]",
-        ].join(" ")}
-      >
-        {icon ?? <Globe className="h-5 w-5" />}
-      </div>
-
-      <div className="min-w-0 flex-1">
-        <span className="block text-body-medium-default text-[var(--content-default)]">
-          {originLabel(origin)}
-        </span>
-        <span
-          className={`mt-1 block text-[var(--content-tertiary)] ${electron ? "text-label-medium-default font-normal" : "text-body-small-lighter"}`}
-        >
-          {`${current ? "Current" : "Remote"} · ${hostname}`}
-        </span>
-      </div>
-
-      <div className="flex shrink-0 items-center gap-2">
-        {onRemove && (
-          /* The trigger sits inside the radio card: stop clicks and keys from
-             bubbling so opening the menu never selects the card and the
-             radio's Enter/Space handler never swallows the trigger. */
-          <div
-            onClick={(e) => e.stopPropagation()}
-            onKeyDown={(e) => e.stopPropagation()}
-          >
-            <Menu.Root>
-              <Menu.Trigger asChild>
-                <Button
-                  variant="ghost"
-                  size="regular"
-                  className="text-[var(--content-tertiary)]"
-                  iconOnly={<EllipsisVertical />}
-                  aria-label={`Actions for ${originLabel(origin)}`}
-                />
-              </Menu.Trigger>
-              <Menu.Content align="end" sideOffset={4}>
-                <Menu.Item
-                  onSelect={onRemove}
-                  className="text-[var(--system-negative-strong)] data-[highlighted]:text-[var(--system-negative-strong)]"
-                >
-                  Remove from this device…
-                </Menu.Item>
-              </Menu.Content>
-            </Menu.Root>
-          </div>
-        )}
-        <div
-          className={[
-            "flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 transition-all duration-200",
-            selected
-              ? "border-[var(--primary-base)] bg-[var(--primary-base)]"
-              : "border-[var(--border-element)] group-hover:border-[var(--content-tertiary)]",
-          ].join(" ")}
-        >
-          {selected && (
-            <Check
-              className="h-3 w-3 text-[var(--surface-base)]"
-              strokeWidth={3}
-            />
-          )}
-        </div>
-      </div>
-    </div>
+    <ChooserCard
+      icon={icon ?? <Globe className="h-5 w-5" />}
+      title={label}
+      subtitle={`${current ? "Current" : "Remote"} · ${originHostname(origin)}`}
+      selected={selected}
+      tabStop={tabStop}
+      onSelect={onSelect}
+      removeMenu={
+        onRemove && <RemoveCardMenu label={label} onRemove={onRemove} />
+      }
+    />
   );
 }

--- a/clients/web/src/runtime/self-hosted-servers.test.ts
+++ b/clients/web/src/runtime/self-hosted-servers.test.ts
@@ -35,6 +35,8 @@ let listResult: NativeList = { servers: [], activeUrl: null, bakedUrl: null };
 /** Simulates a shell whose build predates the plugin: every call rejects. */
 let bridgeRejects = false;
 let addRejects = false;
+/** Rejects `add` for one url only, so a partial write can be exercised. */
+let addRejectsUrl: string | null = null;
 
 function bridgeFailure(method: string): Error {
   return new Error(`SelfHostedServers.${method}() is not implemented on ios`);
@@ -46,8 +48,8 @@ const listMock = mock(async (): Promise<NativeList> => {
   }
   return listResult;
 });
-const addMock = mock(async (_options: { url: string; name?: string }) => {
-  if (bridgeRejects || addRejects) {
+const addMock = mock(async (options: { url: string; name?: string }) => {
+  if (bridgeRejects || addRejects || options.url === addRejectsUrl) {
     throw bridgeFailure("add");
   }
   return { ok: true };
@@ -100,6 +102,7 @@ beforeEach(() => {
   listResult = { servers: [], activeUrl: null, bakedUrl: null };
   bridgeRejects = false;
   addRejects = false;
+  addRejectsUrl = null;
   listMock.mockClear();
   addMock.mockClear();
   removeMock.mockClear();
@@ -206,15 +209,27 @@ describe("nativeRememberedOriginsProvider load", () => {
     addRejects = true;
 
     const provider = nativeRememberedOriginsProvider();
-    // The entry still shows up so the user does not see it vanish.
-    expect((await provider.load()).map((o) => o.url)).toEqual([
-      "https://legacy.example",
-    ]);
+    // The shell does not hold the entry, so no card is published for it.
+    expect((await provider.load()).map((o) => o.url)).toEqual([]);
 
     addRejects = false;
     addMock.mockClear();
-    await provider.load();
+    expect((await provider.load()).map((o) => o.url)).toEqual([
+      "https://legacy.example",
+    ]);
     expect(addMock).toHaveBeenCalledWith({ url: "https://legacy.example" });
+  });
+
+  test("a partial migration publishes only the entries the shell accepted", async () => {
+    await localStorageProvider.save([
+      { url: "https://first.example", addedAt: EPOCH },
+      { url: "https://second.example", addedAt: EPOCH },
+    ]);
+    addRejectsUrl = "https://second.example";
+
+    expect(
+      (await nativeRememberedOriginsProvider().load()).map((o) => o.url),
+    ).toEqual(["https://first.example"]);
   });
 });
 

--- a/clients/web/src/runtime/self-hosted-servers.ts
+++ b/clients/web/src/runtime/self-hosted-servers.ts
@@ -113,7 +113,9 @@ function markMigrationDone(): void {
 /**
  * Fold pre-plugin localStorage entries into the native list once, returning
  * the merged view. Native entries win on name conflicts, since the shell and
- * its deep links are the newer writer.
+ * its deep links are the newer writer. Only entries the shell accepted join
+ * the result, so a partial merge never publishes a card the shell would
+ * refuse to switch to; the marker stays unset so the next load retries.
  */
 async function migrateLocalOriginsIntoNative(
   native: RememberedOrigin[],
@@ -129,6 +131,7 @@ async function migrateLocalOriginsIntoNative(
   }
   const knownUrls = new Set(native.map((o) => o.url));
   const missing = local.filter((o) => !knownUrls.has(o.url));
+  const added: RememberedOrigin[] = [];
   for (const entry of missing) {
     try {
       await SelfHostedServers.add({
@@ -136,13 +139,13 @@ async function migrateLocalOriginsIntoNative(
         ...(entry.name ? { name: entry.name } : {}),
       });
     } catch (err) {
-      // Leave the marker unset so the next load retries the merge.
       console.debug("[self-hosted-servers] migration add failed:", err);
-      return [...native, ...missing];
+      return [...native, ...added];
     }
+    added.push(entry);
   }
   markMigrationDone();
-  return [...native, ...missing];
+  return [...native, ...added];
 }
 
 /**


### PR DESCRIPTION
## Summary
- The Vellum Cloud fallback no longer double-appends /assistant, and a partial native migration publishes only entries the shell actually holds
- An origins-only chooser gets a default selection, the auto-skip waits for flag hydration, and the current origin is no longer removable on a native shell
- The register handoff strips through the router, the plugin import story is consistent with the docs, and the shared card shell removes a large duplication

Part of plan: origin-model-chooser.md (self-review remediation)