### PR TITLE
Tell a verified caller that its route is waiting on approval

### DIFF
--- a/gateway/src/channels/plugin-ingress-approvals.ts
+++ b/gateway/src/channels/plugin-ingress-approvals.ts
@@ -186,6 +186,35 @@ export function findServableRoute(
   path: string,
   kind: IngressRouteKind,
 ): IngressRoute | undefined {
+  const match = findDeclaredRoute(resolution, plugin, path, kind);
+  return match?.servable ? match.route : undefined;
+}
+
+/** A declaration matching the request, and whether the gate opens it. */
+export interface DeclaredRouteMatch {
+  route: IngressRoute;
+  /** True where {@link findServableRoute} would return this route. */
+  servable: boolean;
+}
+
+/**
+ * The declared route at `plugin`/`path`, served or not.
+ *
+ * {@link findServableRoute} answers what the gateway may serve. This answers
+ * what was declared, which is a different question and the one a caller who
+ * can prove who they are is entitled to an answer about: a route awaiting
+ * approval exists, and telling its own signer that it is waiting reveals
+ * nothing they were not already told when they were handed the URL.
+ *
+ * Servability is reported rather than enforced, so nothing may act on a match
+ * without deciding what to do with a `servable: false` one.
+ */
+export function findDeclaredRoute(
+  resolution: PluginIngressResolution,
+  plugin: string,
+  path: string,
+  kind: IngressRouteKind,
+): DeclaredRouteMatch | undefined {
   const requested = path.endsWith("/") ? path.slice(0, -1) : path;
   const matches = (routes: readonly IngressRoute[]) =>
     routes.find((route) => route.kind === kind && route.path === requested);
@@ -193,10 +222,12 @@ export function findServableRoute(
   const approved = resolution.approved.find((d) => d.plugin === plugin);
   const fromApproved = approved && matches(approved.routes);
   if (fromApproved) {
-    return fromApproved;
+    return { route: fromApproved, servable: true };
   }
 
   const pending = resolution.pending.find((d) => d.plugin === plugin);
   const fromPending = pending && matches(pending.routes);
-  return fromPending?.signer === "vellum" ? fromPending : undefined;
+  return fromPending
+    ? { route: fromPending, servable: fromPending.signer === "vellum" }
+    : undefined;
 }

--- a/gateway/src/http/routes/plugin-webhook.test.ts
+++ b/gateway/src/http/routes/plugin-webhook.test.ts
@@ -163,18 +163,69 @@ describe("approved routes", () => {
 });
 
 describe("the gate", () => {
-  it("404s a route the plugin declares but nobody approved", async () => {
-    // The whole point of the gate: pending is not served.
+  /** An unapproved declaration of `routes` for `meeting-bot`. */
+  function pendingWith(routes: IngressRoute[]): PluginIngressResolution {
+    return resolution({
+      pending: [{ plugin: "meeting-bot", routes, digest: "d".repeat(32) }],
+    });
+  }
+
+  it("does not forward a route the plugin declares but nobody approved", async () => {
+    // The whole point of the gate: pending is not served, however well the
+    // delivery is signed.
     const { calls, fetchImpl } = recordingFetch();
     const handle = createPluginWebhookHandler({
       config: CONFIG,
       credentials: CREDENTIALS,
-      resolve: () =>
-        resolution({
-          pending: [
-            { plugin: "meeting-bot", routes: [ROUTE], digest: "d".repeat(32) },
-          ],
-        }),
+      resolve: () => pendingWith([ROUTE]),
+      fetchImpl,
+    });
+
+    const res = await handle(
+      post("/webhooks/plugins/meeting-bot/realtime"),
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({
+      error: "Ingress route awaiting approval",
+    });
+    expect(calls).toEqual([]);
+  });
+
+  it("tells only a verified caller that the route is waiting", async () => {
+    // A prober cannot sign, and the difference between 404 and 409 is exactly
+    // what would tell them a route is declared here. Every way of failing
+    // before the signature has to land on the same answer.
+    const { calls, fetchImpl } = recordingFetch();
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      credentials: CREDENTIALS,
+      resolve: () => pendingWith([ROUTE]),
+      fetchImpl,
+    });
+
+    for (const req of [
+      post("/webhooks/plugins/meeting-bot/realtime", "{}", ""),
+      post("/webhooks/plugins/meeting-bot/realtime", "{}", "wrong-secret"),
+      post("/webhooks/plugins/meeting-bot/realtime", "x".repeat(2048)),
+    ]) {
+      const res = await handle(req, "meeting-bot", "realtime");
+      expect(res.status).toBe(404);
+      expect(await res.json()).toEqual({ error: "Not Found" } as never);
+    }
+    expect(calls).toEqual([]);
+  });
+
+  it("hides a missing secret on an unapproved route", async () => {
+    // 409 "secret not configured" would name the plugin and the route to a
+    // caller who has proved nothing.
+    const { calls, fetchImpl } = recordingFetch();
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      credentials: credentialsFor({}),
+      resolve: () => pendingWith([ROUTE]),
       fetchImpl,
     });
 

--- a/gateway/src/http/routes/plugin-webhook.ts
+++ b/gateway/src/http/routes/plugin-webhook.ts
@@ -17,7 +17,7 @@
  */
 
 import {
-  findServableRoute,
+  findDeclaredRoute,
   type PluginIngressResolution,
 } from "../../channels/plugin-ingress-approvals.js";
 import {
@@ -73,6 +73,19 @@ function signingCredentialKey(
 const METHODS_WITHOUT_BODY = new Set(["GET", "HEAD"]);
 
 /**
+ * The answer for a caller who has not proved who they are.
+ *
+ * Every refusal on a route that is declared but not servable returns exactly
+ * this, whatever went wrong: an oversized body, an unreadable one, a missing
+ * secret, a bad signature. Otherwise the differences between those answers
+ * would tell an unauthenticated prober that a route is declared and waiting,
+ * which is the one thing withholding it is for.
+ */
+function notFound(): Response {
+  return Response.json({ error: "Not Found" }, { status: 404 });
+}
+
+/**
  * Upstream path for a plugin route.
  *
  * The `/v1` prefix is load-bearing: the runtime 404s anything outside it
@@ -98,33 +111,45 @@ export interface PluginWebhookHandlerDeps {
 /**
  * Handle `/webhooks/plugins/:plugin/:path`.
  *
- * The requested path must equal a servable route's declared path, up to one
- * trailing slash. Matching is exact rather than prefix-based: a declaration
- * covers the paths it listed, so serving `<declared>/anything` would hand out
- * reach nobody granted. Exact matching also disposes of traversal, since no
- * `..` segment equals a declared path, and of percent-encoded spellings,
- * which fail closed rather than being decoded into a match.
+ * The requested path must equal a declared route's path, up to one trailing
+ * slash. Matching is exact rather than prefix-based: a declaration covers the
+ * paths it listed, so serving `<declared>/anything` would hand out reach
+ * nobody granted. Exact matching also disposes of traversal, since no `..`
+ * segment equals a declared path, and of percent-encoded spellings, which
+ * fail closed rather than being decoded into a match.
+ *
+ * The approval gate is consulted after the signature, not before. Both orders
+ * refuse the same requests; they differ only in what the caller is told, and
+ * the reason to withhold that is the prober, who cannot sign. A caller who can
+ * sign with this plugin's own secret is the party the route was declared for,
+ * was handed the URL by us, and gets told the route is waiting on approval
+ * rather than being sent to look for a URL that is already correct. Everyone
+ * else gets {@link notFound}, identically, whatever they got wrong.
+ *
+ * The cost is one HMAC on requests to a route that cannot be served, bounded
+ * by the same body cap as everything else here.
  */
 export function createPluginWebhookHandler(deps: PluginWebhookHandlerDeps) {
   const { config, resolve, credentials, fetchImpl } = deps;
 
   return async (req: Request, plugin: string, path: string) => {
-    let route: ReturnType<typeof findServableRoute>;
+    let match: ReturnType<typeof findDeclaredRoute>;
     try {
       // WebSocket routes are declared here but upgraded elsewhere; serving one
       // over plain HTTP would be a different thing than was declared.
-      route = findServableRoute(resolve(), plugin, path, "http");
+      match = findDeclaredRoute(resolve(), plugin, path, "http");
     } catch (err) {
       log.error({ err, plugin }, "Failed to resolve plugin ingress");
       return Response.json({ error: "Internal server error" }, { status: 500 });
     }
 
-    if (!route) {
+    if (!match) {
       // Deliberately quiet: this path is reachable by anyone on the internet,
       // so logging every miss at info would hand out a log-flooding lever.
-      log.debug({ plugin, path }, "No servable HTTP ingress route");
-      return Response.json({ error: "Not Found" }, { status: 404 });
+      log.debug({ plugin, path }, "No declared HTTP ingress route");
+      return notFound();
     }
+    const route = match.route;
 
     // Cap the body on the streamed bytes before anything forwards it. The
     // caller is unauthenticated and Content-Length is attacker-controlled
@@ -133,10 +158,14 @@ export function createPluginWebhookHandler(deps: PluginWebhookHandlerDeps) {
     const body = await readLimitedBodyBytes(req, config.maxWebhookPayloadBytes);
     if (body.status === "too_large") {
       log.warn({ plugin, path }, "Plugin webhook payload too large");
-      return Response.json({ error: "Payload Too Large" }, { status: 413 });
+      return match.servable
+        ? Response.json({ error: "Payload Too Large" }, { status: 413 })
+        : notFound();
     }
     if (body.status === "unreadable") {
-      return Response.json({ error: "Bad Request" }, { status: 400 });
+      return match.servable
+        ? Response.json({ error: "Bad Request" }, { status: 400 })
+        : notFound();
     }
 
     // Signature check before the forward, and fail-closed when no secret is
@@ -148,12 +177,14 @@ export function createPluginWebhookHandler(deps: PluginWebhookHandlerDeps) {
     if (!secret) {
       log.warn(
         { plugin, path, signer: route.signer, secretKey },
-        "Plugin webhook secret is not configured — rejecting request",
+        "Plugin webhook secret is not configured, rejecting request",
       );
-      return Response.json(
-        { error: "Webhook secret not configured" },
-        { status: 409 },
-      );
+      return match.servable
+        ? Response.json(
+            { error: "Webhook secret not configured" },
+            { status: 409 },
+          )
+        : notFound();
     }
 
     // Kept for the log line only. The retry inside verifySecretWithRefresh can
@@ -190,7 +221,31 @@ export function createPluginWebhookHandler(deps: PluginWebhookHandlerDeps) {
         },
         "Plugin webhook signature verification failed",
       );
-      return Response.json({ error: "Forbidden" }, { status: 403 });
+      return match.servable
+        ? Response.json({ error: "Forbidden" }, { status: 403 })
+        : notFound();
+    }
+
+    // Verified, and only now does the gate speak. The caller signed with this
+    // plugin's own secret, so they are the party the route was declared for and
+    // already know it exists; 404ing them here is the answer written for a
+    // prober, and it reads as "wrong URL", which sends whoever is debugging to
+    // the one thing that is not wrong.
+    if (!match.servable) {
+      log.info(
+        { plugin, path, signer: route.signer },
+        "Verified delivery to an ingress route awaiting guardian approval",
+      );
+      return Response.json(
+        {
+          error: "Ingress route awaiting approval",
+          detail:
+            `The route "${path}" is declared by the "${plugin}" plugin but a ` +
+            "guardian has not approved its ingress declaration yet, so the " +
+            "gateway is not serving it. Deliveries are refused, not queued.",
+        },
+        { status: 409 },
+      );
     }
 
     // Forward under the declared path, not the requested spelling: matching


### PR DESCRIPTION
## Why

A plugin route awaiting a guardian answers `404 {"error":"Not Found"}`, chosen so an unauthenticated prober cannot tell a declared-but-pending route from one that was never declared.

RFC 9110 scopes that reasoning to exactly that caller. §15.5.4: a server *"can choose to hide whether the target resource exists"* because *"revealing the specific reason for refusing a request might aid an attacker."* A vendor holding the plugin's own signing secret is not an attacker: we handed them the URL, the plugin name and the route when we registered the webhook. 404 hides nothing from them, and it costs plenty, because it reads as "wrong URL" and sends whoever is debugging to the one thing that isn't wrong. It took five rounds of QA on the iMessage Comms webhook to get past it.

## What changed

**The gate runs after the signature instead of before.** Both orders refuse exactly the same requests and forward exactly the same ones. They differ only in what the caller is told, and the reason to withhold that is the prober, who cannot sign.

A verified delivery to an unapproved route now gets:

```
HTTP/1.1 409 Conflict

{
  "error": "Ingress route awaiting approval",
  "detail": "The route \"events-comms\" is declared by the \"imessage\" plugin but a guardian has not approved its ingress declaration yet, so the gateway is not serving it. Deliveries are refused, not queued."
}
```

**409 rather than 503, because we don't want retries.** 409 is also the closer semantic fit: RFC 9110 scopes 503 to *"temporary overload or scheduled maintenance,"* which this isn't, while 409 is *"the request conflicts with the current state of the target resource"* and pending-approval is a resource state. The delivery is not going to succeed without a human decision, so a retry loop buys nothing and risks the vendor disabling the endpoint over sustained failures (Stripe disables after ~3 days of any non-2xx; GitLab after 4 consecutive failures).

**Everything before the signature returns one indistinguishable 404.** On a declared-but-unservable route, an oversized body, an unreadable one, a missing secret and a bad signature all return the same `notFound()`. Otherwise the differences between those answers would leak precisely what the gate withholds.

**`findDeclaredRoute` reports servability rather than enforcing it**, so nothing can match a route without deciding what a `servable: false` match means. `findServableRoute` keeps its signature and becomes a wrapper, so the WebSocket half is untouched.

## Tradeoff worth knowing

Verifying before gating means an unapproved route now does HMAC work it previously skipped, and a failed verification triggers one forced credential refresh via `verifySecretWithRefresh`. That vector already exists on every approved route, and reaching it needs the exact plugin and path, so this widens an accepted cost rather than introducing a new one. Body size is capped by `maxWebhookPayloadBytes` as before.

## Tests

`plugin-webhook.test.ts`: a signed delivery to a pending route gets 409 and is not forwarded; unsigned, wrong-secret and oversized deliveries to the same route all get an identical 404 body; a missing secret on a pending route is hidden as 404 rather than surfacing the existing "secret not configured" 409.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013p1nTdvsuAtTJ7zyCSDLbx

---
_Generated by [Claude Code](https://claude.ai/code/session_013p1nTdvsuAtTJ7zyCSDLbx)_