### PR TITLE
fix(web): reduce a pasted pairing link to the assistant's public base

### DIFF
--- a/clients/web/src/domains/onboarding/components/add-remote-origin-dialog.test.tsx
+++ b/clients/web/src/domains/onboarding/components/add-remote-origin-dialog.test.tsx
@@ -160,6 +160,9 @@ describe("AddRemoteOriginDialog", () => {
       "https://host.example/assistant-1",
     ],
     ["https://host.example/assistant-1", "https://host.example/assistant-1"],
+    // Only the full app route reduces: a prefix that merely ends in /pair
+    // is somebody's deployment path, not our pairing page.
+    ["https://host.example/tenant/pair", "https://host.example/tenant/pair"],
   ])("reduces %s to the public base", async (typed, expected) => {
     renderDialog();
 

--- a/clients/web/src/domains/onboarding/components/add-remote-origin-dialog.test.tsx
+++ b/clients/web/src/domains/onboarding/components/add-remote-origin-dialog.test.tsx
@@ -145,6 +145,32 @@ describe("AddRemoteOriginDialog", () => {
     );
   });
 
+  // The dialog tells users to paste the link their pairing page gave them,
+  // so the app-route tail has to reduce to the public base; otherwise
+  // switching would append /assistant to it and land on NotFound.
+  test.each([
+    ["https://host.example/assistant/pair", "https://host.example"],
+    [
+      "https://host.example/assistant/pair#device_code=ABCD-1234",
+      "https://host.example",
+    ],
+    ["https://host.example/assistant", "https://host.example"],
+    [
+      "https://host.example/assistant-1/assistant/pair",
+      "https://host.example/assistant-1",
+    ],
+    ["https://host.example/assistant-1", "https://host.example/assistant-1"],
+  ])("reduces %s to the public base", async (typed, expected) => {
+    renderDialog();
+
+    fillAddress(typed);
+    fireEvent.click(screen.getByText("Add"));
+
+    await waitFor(() =>
+      expect(addOriginMock).toHaveBeenCalledWith({ url: expected }),
+    );
+  });
+
   test.each([
     "http://host.example/assistant-1",
     "javascript:alert(1)",

--- a/clients/web/src/domains/onboarding/components/add-remote-origin-dialog.tsx
+++ b/clients/web/src/domains/onboarding/components/add-remote-origin-dialog.tsx
@@ -22,10 +22,12 @@ const ADD_FAILED_COPY = "Failed to add the assistant. Please try again.";
  * `https://host/assistant-123`.
  */
 function stripAppRouteSuffix(base: string): string {
-  const withoutPair = base.endsWith("/pair") ? base.slice(0, -5) : base;
-  return withoutPair.endsWith("/assistant")
-    ? withoutPair.slice(0, -"/assistant".length)
-    : withoutPair;
+  for (const route of ["/assistant/pair", "/assistant"]) {
+    if (base.endsWith(route)) {
+      return base.slice(0, -route.length);
+    }
+  }
+  return base;
 }
 
 interface AddRemoteOriginDialogProps {

--- a/clients/web/src/domains/onboarding/components/add-remote-origin-dialog.tsx
+++ b/clients/web/src/domains/onboarding/components/add-remote-origin-dialog.tsx
@@ -13,6 +13,21 @@ import {
 
 const ADD_FAILED_COPY = "Failed to add the assistant. Please try again.";
 
+/**
+ * Drop the app-route tail from an address a user is likely to have copied
+ * out of their browser, so both `<base>/assistant/pair` (what the pairing
+ * page shows) and `<base>/assistant` reduce to the public base the store
+ * remembers. A Velay path prefix survives because it is a different
+ * segment: `https://host/assistant-123/assistant/pair` yields
+ * `https://host/assistant-123`.
+ */
+function stripAppRouteSuffix(base: string): string {
+  const withoutPair = base.endsWith("/pair") ? base.slice(0, -5) : base;
+  return withoutPair.endsWith("/assistant")
+    ? withoutPair.slice(0, -"/assistant".length)
+    : withoutPair;
+}
+
 interface AddRemoteOriginDialogProps {
   open: boolean;
   onClose: () => void;
@@ -59,7 +74,10 @@ function AddRemoteOriginDialog({
     if (!url.trim() || pending) {
       return;
     }
-    const normalized = normalizeOriginUrl(url);
+    const parsed = normalizeOriginUrl(url);
+    // Re-normalize: stripping the route tail can leave a bare origin.
+    const normalized =
+      parsed === null ? null : normalizeOriginUrl(stripAppRouteSuffix(parsed));
     if (normalized === null) {
       setError(
         "Enter the full https address, like https://example.com/assistant-1.",


### PR DESCRIPTION
## Summary
- The add-remote-assistant dialog tells users to paste the link their pairing page gave them, but `https://host/assistant/pair#device_code=...` was stored verbatim, so switching appended `/assistant` and landed on NotFound
- Submitting now drops a trailing `/assistant/pair` or `/assistant` before remembering the entry; a Velay path prefix survives because it is a different segment
- Adds cases pinning the pair page, the fragment form, the assistant root, a prefixed origin, and the untouched bare prefix

Part of plan: origin-model-chooser.md (self-review remediation)