### PR TITLE
Companion surface: the typing card

### DIFF
--- a/clients/web/src/components/companion-surface.stories.tsx
+++ b/clients/web/src/components/companion-surface.stories.tsx
@@ -45,7 +45,7 @@ const meta: Meta<StoryArgs> = {
   argTypes: {
     phase: {
       control: "inline-radio",
-      options: ["resting", "hover", "call"],
+      options: ["resting", "hover", "call", "typing"],
     },
     backdrop: {
       control: "inline-radio",
@@ -67,7 +67,7 @@ const meta: Meta<StoryArgs> = {
   decorators: [
     (Story, context) => (
       <div
-        className="relative h-[180px] w-[520px] overflow-hidden rounded-xl"
+        className="relative h-[340px] w-[560px] overflow-hidden rounded-xl"
         style={{
           background: BACKDROPS[(context.args as StoryArgs).backdrop ?? "dark"],
         }}
@@ -104,6 +104,33 @@ export const InCall: Story = {
  */
 export const OnALightDesktop: Story = {
   args: { phase: "call", backdrop: "light" },
+};
+
+/**
+ * Typing: the pill becomes a card with the tail of the conversation and
+ * somewhere to answer it.
+ *
+ * Two turns at most, clamped to a few lines each, because this is a glance at
+ * where the conversation got to rather than the conversation. The second turn
+ * here overruns its clamp on purpose, so the cut is visible.
+ */
+export const Typing: Story = {
+  args: {
+    phase: "typing",
+    assistantName: "Ziggy",
+    turns: [
+      { role: "user", text: "can you pull the deploy logs from this morning" },
+      {
+        role: "assistant",
+        text: "Found them. The 09:14 deploy rolled back on its own after the health check failed twice, and the second attempt at 09:31 went through clean. The failing check was the one that talks to the queue, which was still draining from the migration you ran the night before, so nothing was actually wrong with the build itself. Want me to pull the queue depth over that window?",
+      },
+    ],
+  },
+};
+
+/** The card before anything has been said. */
+export const TypingEmpty: Story = {
+  args: { phase: "typing", assistantName: "Ziggy", turns: [] },
 };
 
 /**

--- a/clients/web/src/components/companion-surface.stories.tsx
+++ b/clients/web/src/components/companion-surface.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { useState, type ChangeEvent } from "react";
+import { useEffect, useMemo, useState, type ChangeEvent } from "react";
 
 import {
   CompanionSurface,
@@ -65,16 +65,25 @@ const meta: Meta<StoryArgs> = {
     avatarSrc: EXAMPLE_AVATAR,
   },
   decorators: [
-    (Story, context) => (
-      <div
-        className="relative h-[340px] w-[560px] overflow-hidden rounded-xl"
-        style={{
-          background: BACKDROPS[(context.args as StoryArgs).backdrop ?? "dark"],
-        }}
-      >
-        <Story />
-      </div>
-    ),
+    (Story, context) => {
+      // The stand-in desktop is for the design stories. A story that brings its
+      // own full-bleed backdrop (the demo reel) opts out, since decorators
+      // compose rather than replace and it would otherwise render inside a
+      // 560pt box with its own screen-sized content overflowing it.
+      if (context.parameters.layout === "fullscreen") {
+        return <Story />;
+      }
+      return (
+        <div
+          className="relative h-[340px] w-[560px] overflow-hidden rounded-xl"
+          style={{
+            background: BACKDROPS[(context.args as StoryArgs).backdrop ?? "dark"],
+          }}
+        >
+          <Story />
+        </div>
+      );
+    },
   ],
 };
 
@@ -243,5 +252,189 @@ function HoverDrivenSurface(args: StoryArgs) {
         </button>
       )}
     </>
+  );
+}
+
+/**
+ * A recording rig, not a design story.
+ *
+ * Drop in screenshots of a few apps and press play: each one holds for a couple
+ * of seconds carrying exactly one beat of the surface, then the finale flips
+ * them rapidly while the surface cycles. The point being made is that the
+ * companion persists while the rest of the computer changes, so the apps have
+ * to move faster than it does.
+ *
+ * One beat per app on purpose. Showing every state over every backdrop reads as
+ * a feature tour; showing one state each reads as a thing that is simply there
+ * while you work.
+ *
+ * The controls hide themselves while it plays, so a screen recording of this
+ * window is the finished clip.
+ */
+export const DemoReel: Story = {
+  args: {
+    phase: "call",
+  },
+
+  parameters: { layout: "fullscreen" },
+  render: (args) => <DemoReelPlayer {...args} />,
+};
+
+/** One app's moment: a backdrop, a state, and how long it holds. */
+const DEMO_BEATS: {
+  phase: CompanionSurfacePhase;
+  hold: number;
+  app: string;
+}[] = [
+  { phase: "resting", hold: 2000, app: "Browser: it is just there" },
+  { phase: "hover", hold: 2000, app: "Notes: Talk or Type" },
+  { phase: "call", hold: 2000, app: "Slack: listening" },
+  { phase: "typing", hold: 2200, app: "Editor: say something" },
+];
+
+/** The payoff: the same states again, faster than the apps behind them. */
+const DEMO_FINALE: CompanionSurfacePhase[] = [
+  "resting",
+  "hover",
+  "call",
+  "typing",
+  "hover",
+  "call",
+  "resting",
+];
+const FINALE_HOLD = 480;
+
+const DEMO_TURNS = [
+  {
+    role: "user" as const,
+    text: "can you pull the deploy logs from this morning",
+  },
+  {
+    role: "assistant" as const,
+    text: "Found them. The 09:14 deploy rolled back on its own after the health check failed twice, and the second attempt at 09:31 went through clean.",
+  },
+];
+
+function DemoReelPlayer(args: StoryArgs) {
+  const [shots, setShots] = useState<string[]>([]);
+  const [step, setStep] = useState<number | null>(null);
+
+  // The whole timeline up front, so playback is one timer walking an array
+  // rather than two phases with their own bookkeeping. Built once: it is a
+  // function of module constants, and rebuilding it every render would restart
+  // the timer that depends on it.
+  const timeline = useMemo(
+    () => [
+      ...DEMO_BEATS.map((beat, index) => ({
+        phase: beat.phase,
+        hold: beat.hold,
+        shot: index,
+      })),
+      ...DEMO_FINALE.map((phase, index) => ({
+        phase,
+        hold: FINALE_HOLD,
+        shot: index,
+      })),
+    ],
+    [],
+  );
+
+  useEffect(() => {
+    if (step === null) {
+      return;
+    }
+    if (step >= timeline.length) {
+      setStep(null);
+      return;
+    }
+    const timer = setTimeout(() => {
+      setStep(step + 1);
+    }, timeline[step].hold);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [step, timeline]);
+
+  const onFiles = (event: ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(event.target.files ?? []);
+    Promise.all(
+      files.map(
+        (file) =>
+          new Promise<string>((resolve) => {
+            const reader = new FileReader();
+            reader.onload = () => {
+              resolve(typeof reader.result === "string" ? reader.result : "");
+            };
+            reader.readAsDataURL(file);
+          }),
+      ),
+    ).then((urls) => {
+      setShots(urls.filter(Boolean));
+    });
+  };
+
+  const playing = step !== null && step < timeline.length;
+  const current = playing ? timeline[step] : null;
+  const phase = current?.phase ?? "resting";
+  // Screenshots cycle rather than run out, so three apps still carry four beats.
+  const shotIndex =
+    shots.length === 0 ? -1 : (current?.shot ?? 0) % shots.length;
+
+  return (
+    <div className="relative h-screen w-screen overflow-hidden bg-[#0f1113]">
+      {shots.map((shot, index) => (
+        <img
+          key={index}
+          src={shot}
+          alt=""
+          className="absolute inset-0 size-full object-cover transition-opacity duration-300"
+          style={{ opacity: index === shotIndex ? 1 : 0 }}
+        />
+      ))}
+      {shots.length === 0 && (
+        <div className="absolute inset-0 grid place-items-center text-[13px] text-white/40">
+          Add screenshots below, then play.
+        </div>
+      )}
+
+      {/* Parked where the real one parks: near the Dock, bottom right. */}
+      <div className="absolute right-[12%] bottom-[14%] size-11">
+        <CompanionSurface
+          {...args}
+          phase={phase}
+          turns={DEMO_TURNS}
+          assistantName={args.assistantName ?? "Ziggy"}
+        />
+      </div>
+
+      {!playing && (
+        <div className="absolute inset-x-0 bottom-0 flex items-center gap-3 bg-black/60 px-4 py-3 text-[12px] text-white/80">
+          <label className="cursor-pointer rounded-md bg-white/10 px-2 py-1">
+            Add screenshots
+            <input
+              type="file"
+              accept="image/*"
+              multiple
+              className="hidden"
+              onChange={onFiles}
+            />
+          </label>
+          <button
+            type="button"
+            className="rounded-md bg-white/10 px-2 py-1 disabled:opacity-40"
+            disabled={shots.length === 0}
+            onClick={() => {
+              setStep(0);
+            }}
+          >
+            Play
+          </button>
+          <span className="text-white/40">
+            {shots.length} loaded, {DEMO_BEATS.map((b) => b.app).join(" / ")},
+            then the fast pass
+          </span>
+        </div>
+      )}
+    </div>
   );
 }

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -276,10 +276,14 @@ export function CompanionSurface({
   const style: CSSProperties = {
     width,
     ...placement,
-    // The card grows downward from the row the pill occupied rather than around
-    // its own middle, so the avatar stays on the line the user last saw it on
-    // instead of jumping half a card's height the moment they press Type.
-    transform: typing ? "translateY(-22px)" : "translateY(-50%)",
+    // The composer row holds the line the pill occupied and the conversation
+    // stacks upward off it, so the avatar never moves when Type is pressed and
+    // never moves again as turns arrive. It is also the only direction that
+    // works where this surface lives: parked by the Dock, a card growing down
+    // grows off the bottom of the screen.
+    transform: typing
+      ? `translateY(calc(-100% + ${AVATAR_BOX / 2}px))`
+      : "translateY(-50%)",
     // Settles rather than overshoots. A surface on screen all day should not
     // bounce every time the pointer crosses it.
     transitionTimingFunction: "cubic-bezier(.2,.8,.2,1)",
@@ -323,6 +327,7 @@ export function CompanionSurface({
         style={{ opacity: expanded ? 1 : 0 }}
         aria-hidden
       />
+      {typing && turns.length > 0 && <RecentTurns turns={turns} />}
       <div className="relative flex h-11 shrink-0 items-center">
         <Avatar
           glow={glow && !expanded}
@@ -330,95 +335,112 @@ export function CompanionSurface({
           avatarSrc={avatarSrc}
           onMouseEnter={onHoverStart}
         />
-        <div
-          className="relative flex min-w-0 items-center gap-1 overflow-hidden transition-opacity duration-200"
-          ref={contentRef}
-          // Faded out is not gone: the body stays mounted while collapsed so
-          // it can be measured, which would otherwise leave its controls
-          // focusable and announced while nothing is drawn. `inert` takes them
-          // out of the tab order and the accessibility tree without taking them
-          // out of the DOM, so the measurement still works.
-          inert={!expanded}
-          style={{
-            opacity: expanded ? 1 : 0,
-            // Contents fade after the body has somewhere to put them, so
-            // nothing is ever drawn wider than the pill carrying it.
-            transitionDelay: expanded ? "120ms" : "0ms",
-          }}
-        >
-          {phase === "call" ? <CallBody /> : <IdleBody active={typing} />}
-        </div>
+        {typing ? (
+          <Composer assistantName={assistantName} />
+        ) : (
+          <div
+            className="relative flex min-w-0 items-center gap-1 overflow-hidden transition-opacity duration-200"
+            ref={contentRef}
+            // Faded out is not gone: the body stays mounted while collapsed so
+            // it can be measured, which would otherwise leave its controls
+            // focusable and announced while nothing is drawn. `inert` takes
+            // them out of the tab order and the accessibility tree without
+            // taking them out of the DOM, so the measurement still works.
+            inert={!expanded}
+            style={{
+              opacity: expanded ? 1 : 0,
+              // Contents fade after the body has somewhere to put them, so
+              // nothing is ever drawn wider than the pill carrying it.
+              transitionDelay: expanded ? "120ms" : "0ms",
+            }}
+          >
+            {phase === "call" ? <CallBody /> : <IdleBody />}
+          </div>
+        )}
       </div>
-      {typing && <ConversationCard turns={turns} assistantName={assistantName} />}
     </div>
   );
 }
 
 /**
- * The condensed conversation, and somewhere to answer it.
+ * The tail of the conversation, stacked above the composer.
  *
  * Deliberately not a transcript. Two turns at most and a few lines each,
  * because a surface floating over someone else's work is a glance at where the
  * conversation got to, and the app is where the thread actually lives. Anything
  * longer would be a chat window that happens to be always on top.
  */
-function ConversationCard({
-  turns,
-  assistantName,
-}: {
-  turns: CompanionTurn[];
-  assistantName: string;
-}) {
-  // The tail, oldest first, so the newest sits nearest the composer the way it
-  // does in the app.
+function RecentTurns({ turns }: { turns: CompanionTurn[] }) {
+  // Oldest first, so the newest sits nearest the composer as it does in the app.
   const recent = turns.slice(-2);
   return (
-    <div className="relative flex flex-col gap-2 px-2 pb-2">
-      {recent.length > 0 && (
-        <div className="flex flex-col gap-1.5 px-1">
-          {recent.map((turn, index) => (
+    <div className="relative flex flex-col gap-1.5 px-3 pt-3 pb-1">
+      {/* Sides, as the transcript does it: the user's turn is a bubble pushed
+          right and capped at 80%, the assistant's is plain text filling the
+          width. Matching `transcript-message-body.tsx` matters more than it
+          looks, because this is a condensed read of the same conversation and a
+          reader should not have to work out who said what a second time in a
+          second idiom. */}
+      {recent.map((turn, index) => {
+        const isUser = turn.role === "user";
+        return (
+          <div
+            key={`${turn.role}-${index}`}
+            className={`flex ${isUser ? "justify-end" : "justify-start"}`}
+          >
             <p
-              key={`${turn.role}-${index}`}
               className={`text-[12px] leading-[1.45] ${
-                turn.role === "user"
-                  ? "text-white/55"
+                isUser
+                  ? "max-w-[80%] rounded-lg bg-white/[0.08] px-2.5 py-1.5 text-white/75"
                   : "text-white/85"
               }`}
               style={{
                 display: "-webkit-box",
                 WebkitBoxOrient: "vertical",
-                WebkitLineClamp:
-                  turn.role === "user" ? USER_LINE_CLAMP : ASSISTANT_LINE_CLAMP,
+                WebkitLineClamp: isUser ? USER_LINE_CLAMP : ASSISTANT_LINE_CLAMP,
                 overflow: "hidden",
               }}
             >
               {turn.text}
             </p>
-          ))}
-        </div>
-      )}
-      <div className="flex items-center gap-1 rounded-full border border-white/10 bg-white/[0.04] py-1 pr-1 pl-3">
-        <input
-          type="text"
-          placeholder={`Message ${assistantName}`}
-          // A press in the field is not a drag, and the field wants the caret
-          // the press would otherwise be stolen from.
-          onMouseDown={(event) => {
-            event.stopPropagation();
-          }}
-          className="min-w-0 flex-1 bg-transparent text-[12px] text-white/85 placeholder:text-white/35 focus:outline-none"
-        />
-        <button
-          type="button"
-          aria-label="Send"
-          onMouseDown={(event) => {
-            event.stopPropagation();
-          }}
-          className="grid size-7 shrink-0 place-items-center rounded-full bg-white/10 text-white/85 transition-colors hover:bg-white/20"
-        >
-          <ArrowUp className="size-3.5" aria-hidden />
-        </button>
-      </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * Where you type, on the row the avatar is already on.
+ *
+ * It takes the place of Talk and Type rather than sitting under them, so
+ * pressing Type changes what the pill contains without changing what the pill
+ * is: empty, focused, or full of text, it is the same elongated single line as
+ * the voice states. Growth happens above it, never to it.
+ */
+function Composer({ assistantName }: { assistantName: string }) {
+  return (
+    <div className="relative flex min-w-0 flex-1 items-center gap-1 pr-2">
+      <input
+        type="text"
+        placeholder={`Message ${assistantName}`}
+        // A press in the field is not a drag, and the field wants the caret
+        // that press would otherwise be stolen from.
+        onMouseDown={(event) => {
+          event.stopPropagation();
+        }}
+        className="min-w-0 flex-1 bg-transparent text-[12px] text-white/85 placeholder:text-white/40 focus:outline-none"
+      />
+      <button
+        type="button"
+        aria-label="Send"
+        onMouseDown={(event) => {
+          event.stopPropagation();
+        }}
+        className="grid size-7 shrink-0 place-items-center rounded-full bg-white/10 text-white/85 transition-colors hover:bg-white/20"
+      >
+        <ArrowUp className="size-3.5" aria-hidden />
+      </button>
     </div>
   );
 }
@@ -480,7 +502,7 @@ function Avatar({
  * of one choice about how to say something, and a verb pair reads as that where
  * a verb and a question word do not.
  */
-function IdleBody({ active }: { active?: boolean }) {
+function IdleBody() {
   return (
     <>
       <PillButton icon={<AudioLines className="size-4" />} label="Talk" showLabel />
@@ -488,7 +510,6 @@ function IdleBody({ active }: { active?: boolean }) {
         icon={<Keyboard className="size-4" />}
         label="Type"
         showLabel
-        active={active}
       />
     </>
   );

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -1,4 +1,11 @@
-import { AudioLines, Mic, MessageSquareText, Volume2, X } from "lucide-react";
+import {
+  ArrowUp,
+  AudioLines,
+  Keyboard,
+  Mic,
+  Volume2,
+  X,
+} from "lucide-react";
 import { useLayoutEffect, useRef, useState } from "react";
 import type {
   CSSProperties,
@@ -56,7 +63,16 @@ import type {
  *    exists to make visible.
  */
 
-export type CompanionSurfacePhase = "resting" | "hover" | "call";
+export type CompanionSurfacePhase =
+  | "resting"
+  | "hover"
+  | "call"
+  /**
+   * Typing: the pill becomes a card carrying a condensed read of the
+   * conversation and somewhere to answer it. The only phase that grows
+   * vertically, which is why it is the only one that stops being a pill.
+   */
+  | "typing";
 
 /**
  * Which way the pill is allowed to grow, positioned against the avatar's
@@ -112,10 +128,44 @@ const FALLBACK_WIDTHS: Record<CompanionSurfacePhase, number> = {
   resting: AVATAR_BOX,
   hover: 188,
   call: 296,
+  typing: 360,
 };
+
+/**
+ * The card is a fixed width, unlike the pills.
+ *
+ * A pill is as wide as its controls and nothing more, so measuring is the only
+ * honest answer. A card holds wrapped prose, and prose has no natural width:
+ * measuring it would size the card to whatever the last turn happened to say
+ * and reflow the whole surface on every message.
+ */
+const CARD_WIDTH = 360;
+
+/**
+ * Lines each turn gets before it is cut off.
+ *
+ * The card is a glance at the conversation, not the conversation. The assistant
+ * gets one more line than the user because the user already knows what they
+ * said.
+ */
+const USER_LINE_CLAMP = 2;
+const ASSISTANT_LINE_CLAMP = 4;
+
+/** One side of one exchange, condensed for the card. */
+export interface CompanionTurn {
+  role: "user" | "assistant";
+  text: string;
+}
 
 export interface CompanionSurfaceProps {
   phase: CompanionSurfacePhase;
+  /**
+   * The tail of the conversation, most recent last. Only the last couple are
+   * drawn; the card is a glance, and the app is where the thread lives.
+   */
+  turns?: CompanionTurn[];
+  /** The assistant's name, for the composer's placeholder. */
+  assistantName?: string;
   /** The resting circle's ambient halo, in the avatar's own colour. */
   glow?: boolean;
   /** The assistant's avatar colour. Fills shapes; never carries text. */
@@ -161,6 +211,8 @@ export interface CompanionSurfaceProps {
 
 export function CompanionSurface({
   phase,
+  turns = [],
+  assistantName = "your assistant",
   glow = true,
   accentHex = DEFAULT_ACCENT,
   avatarSrc,
@@ -171,6 +223,7 @@ export function CompanionSurface({
   onSurfaceMouseDown,
 }: CompanionSurfaceProps) {
   const expanded = phase !== "resting";
+  const typing = phase === "typing";
   const contentRef = useRef<HTMLDivElement | null>(null);
   const [contentWidth, setContentWidth] = useState<number | null>(null);
 
@@ -196,11 +249,12 @@ export function CompanionSurface({
   // The avatar's 44pt box sits flush, because its image is already inset by
   // `INNER_GAP` inside it. Only the trailing end needs the gap added, since the
   // last control's own box ends where the body does.
-  const width =
-    AVATAR_BOX +
-    (!expanded
-      ? 0
-      : (contentWidth ?? FALLBACK_WIDTHS[phase] - AVATAR_BOX) + INNER_GAP);
+  const width = typing
+    ? CARD_WIDTH
+    : AVATAR_BOX +
+      (!expanded
+        ? 0
+        : (contentWidth ?? FALLBACK_WIDTHS[phase] - AVATAR_BOX) + INNER_GAP);
 
   // **Every anchor keeps the avatar on the same spot.** The host positions this
   // window around the avatar, not around the pill, so the avatar's resting box
@@ -222,7 +276,10 @@ export function CompanionSurface({
   const style: CSSProperties = {
     width,
     ...placement,
-    transform: "translateY(-50%)",
+    // The card grows downward from the row the pill occupied rather than around
+    // its own middle, so the avatar stays on the line the user last saw it on
+    // instead of jumping half a card's height the moment they press Type.
+    transform: typing ? "translateY(-22px)" : "translateY(-50%)",
     // Settles rather than overshoots. A surface on screen all day should not
     // bounce every time the pointer crosses it.
     transitionTimingFunction: "cubic-bezier(.2,.8,.2,1)",
@@ -234,10 +291,15 @@ export function CompanionSurface({
     // press, so everything that is not a button can be grabbed, which at rest
     // means the avatar and when expanded means the pill around the controls.
     <div
-      className={`absolute top-1/2 flex h-11 cursor-grab items-center rounded-full transition-[width,margin-left,margin-right] duration-300 will-change-[width,margin-left,margin-right] active:cursor-grabbing ${
+      className={`absolute top-1/2 cursor-grab transition-[width,margin-left,margin-right] duration-300 will-change-[width,margin-left,margin-right] active:cursor-grabbing ${
+        typing
+          ? "flex flex-col rounded-[22px]"
+          : "flex h-11 items-center rounded-full"
+      } ${
         // The avatar is the row's first child, so growing leftward means
-        // reversing the row rather than repositioning it.
-        anchor === "right" ? "flex-row-reverse" : ""
+        // reversing the row rather than repositioning it. The card is a column
+        // and grows upward instead, so it never wants this.
+        anchor === "right" && !typing ? "flex-row-reverse" : ""
       }`}
       style={style}
       onMouseLeave={onHoverEnd}
@@ -251,33 +313,111 @@ export function CompanionSurface({
           body in with the expansion also gives the avatar something to grow
           out of. */}
       <span
-        className="absolute inset-0 rounded-full border border-white/10 bg-[#17181b]/95 shadow-lg shadow-black/40 transition-opacity duration-200"
+        className={`absolute inset-0 border border-white/10 bg-[#17181b]/95 shadow-lg shadow-black/40 transition-opacity duration-200 ${
+          // Radius follows the same rule as the gap: the controls are 28pt so
+          // their radius is 14, and 8pt of clearance puts the outer radius at
+          // 22. A pill happens to reach that by being 44 tall; the card has to
+          // say it.
+          typing ? "rounded-[22px]" : "rounded-full"
+        }`}
         style={{ opacity: expanded ? 1 : 0 }}
         aria-hidden
       />
-      <Avatar
-        glow={glow && !expanded}
-        accentHex={accentHex}
-        avatarSrc={avatarSrc}
-        onMouseEnter={onHoverStart}
-      />
-      <div
-        className="relative flex min-w-0 items-center gap-1 overflow-hidden transition-opacity duration-200"
-        ref={contentRef}
-        // Faded out is not gone: the body stays mounted while collapsed so it
-        // can be measured, which would otherwise leave its controls focusable
-        // and announced while nothing is drawn. `inert` takes them out of the
-        // tab order and the accessibility tree without taking them out of the
-        // DOM, so the measurement still works.
-        inert={!expanded}
-        style={{
-          opacity: expanded ? 1 : 0,
-          // Contents fade after the body has somewhere to put them, so nothing
-          // is ever drawn wider than the pill carrying it.
-          transitionDelay: expanded ? "120ms" : "0ms",
-        }}
-      >
-        {phase === "call" ? <CallBody /> : <IdleBody />}
+      <div className="relative flex h-11 shrink-0 items-center">
+        <Avatar
+          glow={glow && !expanded}
+          accentHex={accentHex}
+          avatarSrc={avatarSrc}
+          onMouseEnter={onHoverStart}
+        />
+        <div
+          className="relative flex min-w-0 items-center gap-1 overflow-hidden transition-opacity duration-200"
+          ref={contentRef}
+          // Faded out is not gone: the body stays mounted while collapsed so
+          // it can be measured, which would otherwise leave its controls
+          // focusable and announced while nothing is drawn. `inert` takes them
+          // out of the tab order and the accessibility tree without taking them
+          // out of the DOM, so the measurement still works.
+          inert={!expanded}
+          style={{
+            opacity: expanded ? 1 : 0,
+            // Contents fade after the body has somewhere to put them, so
+            // nothing is ever drawn wider than the pill carrying it.
+            transitionDelay: expanded ? "120ms" : "0ms",
+          }}
+        >
+          {phase === "call" ? <CallBody /> : <IdleBody active={typing} />}
+        </div>
+      </div>
+      {typing && <ConversationCard turns={turns} assistantName={assistantName} />}
+    </div>
+  );
+}
+
+/**
+ * The condensed conversation, and somewhere to answer it.
+ *
+ * Deliberately not a transcript. Two turns at most and a few lines each,
+ * because a surface floating over someone else's work is a glance at where the
+ * conversation got to, and the app is where the thread actually lives. Anything
+ * longer would be a chat window that happens to be always on top.
+ */
+function ConversationCard({
+  turns,
+  assistantName,
+}: {
+  turns: CompanionTurn[];
+  assistantName: string;
+}) {
+  // The tail, oldest first, so the newest sits nearest the composer the way it
+  // does in the app.
+  const recent = turns.slice(-2);
+  return (
+    <div className="relative flex flex-col gap-2 px-2 pb-2">
+      {recent.length > 0 && (
+        <div className="flex flex-col gap-1.5 px-1">
+          {recent.map((turn, index) => (
+            <p
+              key={`${turn.role}-${index}`}
+              className={`text-[12px] leading-[1.45] ${
+                turn.role === "user"
+                  ? "text-white/55"
+                  : "text-white/85"
+              }`}
+              style={{
+                display: "-webkit-box",
+                WebkitBoxOrient: "vertical",
+                WebkitLineClamp:
+                  turn.role === "user" ? USER_LINE_CLAMP : ASSISTANT_LINE_CLAMP,
+                overflow: "hidden",
+              }}
+            >
+              {turn.text}
+            </p>
+          ))}
+        </div>
+      )}
+      <div className="flex items-center gap-1 rounded-full border border-white/10 bg-white/[0.04] py-1 pr-1 pl-3">
+        <input
+          type="text"
+          placeholder={`Message ${assistantName}`}
+          // A press in the field is not a drag, and the field wants the caret
+          // the press would otherwise be stolen from.
+          onMouseDown={(event) => {
+            event.stopPropagation();
+          }}
+          className="min-w-0 flex-1 bg-transparent text-[12px] text-white/85 placeholder:text-white/35 focus:outline-none"
+        />
+        <button
+          type="button"
+          aria-label="Send"
+          onMouseDown={(event) => {
+            event.stopPropagation();
+          }}
+          className="grid size-7 shrink-0 place-items-center rounded-full bg-white/10 text-white/85 transition-colors hover:bg-white/20"
+        >
+          <ArrowUp className="size-3.5" aria-hidden />
+        </button>
       </div>
     </div>
   );
@@ -333,15 +473,22 @@ function Avatar({
   );
 }
 
-/** Expanded, with the app idle: the two ways in. */
-function IdleBody() {
+/**
+ * Expanded, with the app idle: the two ways in.
+ *
+ * "Talk" and "Type" rather than "Talk" and "Ask", because they are two halves
+ * of one choice about how to say something, and a verb pair reads as that where
+ * a verb and a question word do not.
+ */
+function IdleBody({ active }: { active?: boolean }) {
   return (
     <>
       <PillButton icon={<AudioLines className="size-4" />} label="Talk" showLabel />
       <PillButton
-        icon={<MessageSquareText className="size-4" />}
-        label="Ask"
+        icon={<Keyboard className="size-4" />}
+        label="Type"
         showLabel
+        active={active}
       />
     </>
   );
@@ -388,11 +535,14 @@ function PillButton({
   label,
   tone,
   showLabel = false,
+  active = false,
 }: {
   icon: ReactNode;
   label: string;
   tone?: "negative";
   showLabel?: boolean;
+  /** Held down, for a control whose surface is currently open. */
+  active?: boolean;
 }) {
   return (
     <button
@@ -405,8 +555,8 @@ function PillButton({
         event.stopPropagation();
       }}
       className={`flex h-7 shrink-0 items-center gap-1.5 rounded-full px-2 text-[12px] transition-colors hover:bg-white/15 ${
-        tone === "negative" ? "text-[#ff6b6b]" : "text-white/85"
-      }`}
+        active ? "bg-white/10" : ""
+      } ${tone === "negative" ? "text-[#ff6b6b]" : "text-white/85"}`}
     >
       {icon}
       {showLabel && <span>{label}</span>}


### PR DESCRIPTION
Stacked on #40330. Pressing Type turns the pill into a card carrying the tail of the conversation and somewhere to answer it.

**Storybook only.** Nothing presses Type yet, and the Electron canvas is 92pt tall against a card of roughly 160, so this is not reachable in the app. It is split out for exactly that reason: #40330 is the surface that works, this is the surface that is designed.

## Talk and Type

"Ask" becomes "Type". They are two halves of one choice about how to say something, and a verb pair reads as that where a verb and a question word do not. The icon follows: a keyboard against the waveform.

## The card

**The composer sits on the row the avatar is already on**, taking the place of Talk and Type rather than sitting under them. So pressing Type changes what the pill contains without changing what the pill is: empty, focused, or full of text, it is the same elongated single line as the voice states.

**So the surface grows upward.** The composer holds the line the pill occupied and turns stack above it, which means the avatar does not move when Type is pressed and does not move again as turns arrive. It is also the only direction that works where this thing lives: parked by the Dock, a card growing downward grows off the bottom of the screen. The vertical edge case that would otherwise need solving in main mostly solves itself.

**Two turns, clamped.** Four lines for the assistant, two for the user, who already knows what they said. A surface floating over someone else's work is a glance at where the conversation got to; the app is where the thread lives. Anything longer is a chat window that happens to be always on top.

**Sides, as the transcript does them.** The user's turn is a bubble pushed right and capped at 80%, the assistant's is plain text filling the width, matching `transcript-message-body.tsx`. This is a condensed read of the same conversation, so a reader should not have to work out who said what a second time in a second idiom.

**Fixed width, unlike the pills.** Measuring is right for controls, which have a natural width. Prose does not: measuring it would size the card to whatever the last turn happened to say and reflow the surface on every message.

**Its radius is stated rather than inherited.** A pill reaches 22 by being 44 tall; a card has to say 22 to keep the same 8pt clearance around 28pt controls.

## Open

Talk is not visible while typing, so there is currently no way back to voice without leaving the surface. Either Talk persists as an icon-only control in the composer row, or dismissing the card is the way back.

## Testing

Lint and typecheck clean. `Typing` and `TypingEmpty` stories rendered and captured; the assistant turn in `Typing` overruns its clamp on purpose so the cut is visible.