### PR TITLE
feat(tts): optional per-language voice overrides for live voice

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -1409,6 +1409,65 @@ describe("AssistantConfigSchema", () => {
     expect(result.services.tts.providers.deepgram.format).toBe("opus");
   });
 
+  test("accepts services.tts.providers languageVoices maps", () => {
+    const result = AssistantConfigSchema.parse({
+      services: {
+        tts: {
+          providers: {
+            elevenlabs: {
+              languageVoices: { hi: "voice-hindi", ja: "voice-japanese" },
+            },
+            deepgram: { languageVoices: { hi: "aura-2-hi-voice" } },
+            vellum: { languageVoices: { hi: "aura-2-hi-voice" } },
+          },
+        },
+      },
+    });
+    expect(result.services.tts.providers.elevenlabs.languageVoices).toEqual({
+      hi: "voice-hindi",
+      ja: "voice-japanese",
+    });
+    expect(result.services.tts.providers.deepgram.languageVoices).toEqual({
+      hi: "aura-2-hi-voice",
+    });
+    expect(result.services.tts.providers.vellum.languageVoices).toEqual({
+      hi: "aura-2-hi-voice",
+    });
+  });
+
+  test("languageVoices defaults to unset", () => {
+    const result = AssistantConfigSchema.parse({});
+    expect(
+      result.services.tts.providers.elevenlabs.languageVoices,
+    ).toBeUndefined();
+    expect(
+      result.services.tts.providers.deepgram.languageVoices,
+    ).toBeUndefined();
+    expect(result.services.tts.providers.vellum.languageVoices).toBeUndefined();
+  });
+
+  test("rejects non-string services.tts.providers languageVoices values", () => {
+    for (const provider of ["elevenlabs", "deepgram", "vellum"]) {
+      const result = AssistantConfigSchema.safeParse({
+        services: {
+          tts: {
+            providers: {
+              [provider]: { languageVoices: { hi: 42 } },
+            },
+          },
+        },
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(
+          result.error.issues.some((issue) =>
+            issue.path.join(".").includes("languageVoices"),
+          ),
+        ).toBe(true);
+      }
+    }
+  });
+
   // Legacy config objects on disk may carry a `mode` key. Parsing must strip
   // it rather than reject the config — and must not treat it as a managed
   // selection, which is what migration 130 rewrites to `provider: "vellum"`.

--- a/assistant/src/config/schemas/tts.ts
+++ b/assistant/src/config/schemas/tts.ts
@@ -14,6 +14,35 @@ import {
  * legacy top-level schemas (`elevenlabs.*`, `fishAudio.*`) so that
  * migration can copy values 1:1.
  */
+
+/**
+ * Optional per-language voice override map for a TTS provider block.
+ * Keys are lowercase base language subtags (e.g. "hi", "ja"); values are
+ * provider voice identifiers. Live voice consults the map when a turn's
+ * spoken language is known and no explicit voice was requested.
+ */
+function languageVoicesSchema(providerId: string, valuesDescription: string) {
+  return z
+    .record(
+      z.string({
+        error: `services.tts.providers.${providerId}.languageVoices keys must be strings`,
+      }),
+      z.string({
+        error: `services.tts.providers.${providerId}.languageVoices values must be strings`,
+      }),
+      {
+        error: `services.tts.providers.${providerId}.languageVoices must be an object mapping language subtags to voice identifiers`,
+      },
+    )
+    .optional()
+    .describe(
+      "Per-language voice overrides for live voice. Keys are lowercase base " +
+        `language subtags (e.g. "hi", "ja"); ${valuesDescription} ` +
+        "Applied when the turn's spoken language matches an entry and no " +
+        "explicit voice is requested.",
+    );
+}
+
 export const TtsElevenLabsProviderConfigSchema = z
   .object({
     voiceId: z
@@ -79,6 +108,10 @@ export const TtsElevenLabsProviderConfigSchema = z
       )
       .default(30)
       .describe("Seconds of silence before voice conversation auto-ends"),
+    languageVoices: languageVoicesSchema(
+      "elevenlabs",
+      "values are ElevenLabs voice IDs.",
+    ),
   })
   .describe("ElevenLabs provider configuration under services.tts");
 
@@ -150,6 +183,10 @@ export const TtsDeepgramProviderConfigSchema = z
       })
       .default("mp3")
       .describe("Output audio format for call/runtime playback"),
+    languageVoices: languageVoicesSchema(
+      "deepgram",
+      "values are Deepgram TTS model identifiers (e.g. an aura-2 voice).",
+    ),
   })
   .describe("Deepgram provider configuration under services.tts");
 
@@ -221,6 +258,13 @@ const TtsVellumProviderConfigSchema = z
       .describe(
         "Managed TTS voice model (e.g. aura-2-thalia-en). Unset means the platform's default voice. The platform rejects voices it does not offer.",
       ),
+    languageVoices: languageVoicesSchema(
+      "vellum",
+      "values are managed TTS voice models (e.g. aura-2-thalia-en) and must " +
+        "be voices offered by the platform rate card: an unpriced model is " +
+        "rejected by the relay (missing_price), the same contract as " +
+        "services.tts.providers.vellum.model.",
+    ),
   })
   .describe("Vellum managed provider configuration under services.tts");
 

--- a/assistant/src/live-voice/__tests__/live-voice-tts.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-tts.test.ts
@@ -589,6 +589,26 @@ describe("resolveLanguageVoiceOverride", () => {
     expect(resolveLanguageVoiceOverride(map, "HI")).toBe("voice-hindi");
   });
 
+  test("normalizes user-entered regional or uppercase MAP KEYS too", () => {
+    // The schema accepts any string key, so "hi-IN" or "HI" in config must
+    // still match a spoken "hi" instead of silently never applying.
+    expect(resolveLanguageVoiceOverride({ "hi-IN": "voice-hindi" }, "hi")).toBe(
+      "voice-hindi",
+    );
+    expect(resolveLanguageVoiceOverride({ HI: "voice-hindi" }, "hi-IN")).toBe(
+      "voice-hindi",
+    );
+  });
+
+  test("an exact base-subtag key outranks a normalized regional key", () => {
+    expect(
+      resolveLanguageVoiceOverride(
+        { "hi-IN": "voice-regional", hi: "voice-base" },
+        "hi",
+      ),
+    ).toBe("voice-base");
+  });
+
   test("returns undefined without a language", () => {
     expect(
       resolveLanguageVoiceOverride({ hi: "voice-hindi" }, undefined),

--- a/assistant/src/live-voice/__tests__/live-voice-tts.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-tts.test.ts
@@ -24,8 +24,11 @@ mock.module("../../security/secure-keys.js", () => ({
   getProviderKeyAsync: async () => "test-api-key",
 }));
 
-const { LiveVoiceTtsError, streamLiveVoiceTtsAudio } =
-  await import("../live-voice-tts.js");
+const {
+  LiveVoiceTtsError,
+  resolveLanguageVoiceOverride,
+  streamLiveVoiceTtsAudio,
+} = await import("../live-voice-tts.js");
 
 beforeEach(() => {
   config = makeConfig();
@@ -494,6 +497,76 @@ describe("streamLiveVoiceTtsAudio", () => {
     }
   });
 
+  test("applies the configured per-language voice for a language-known turn", async () => {
+    config = makeConfig({
+      provider: "elevenlabs",
+      elevenlabsLanguageVoices: { hi: "voice-hindi", ja: "voice-japanese" },
+    });
+    const { requests, probeRequests } = installCapturingElevenLabsStub();
+
+    await streamLiveVoiceTtsAudio({
+      config,
+      text: "namaste",
+      language: "hi",
+      onAudioChunk: () => {},
+    });
+
+    expect(requests[0]?.voiceId).toBe("voice-hindi");
+    expect(probeRequests[0]?.voiceId).toBe("voice-hindi");
+  });
+
+  test("skips the override when the map has no entry for the turn language", async () => {
+    config = makeConfig({
+      provider: "elevenlabs",
+      elevenlabsLanguageVoices: { hi: "voice-hindi" },
+    });
+    const { requests } = installCapturingElevenLabsStub();
+
+    await streamLiveVoiceTtsAudio({
+      config,
+      text: "hola",
+      language: "es",
+      onAudioChunk: () => {},
+    });
+
+    expect(requests[0]?.voiceId).toBeUndefined();
+  });
+
+  test("an explicit request voiceId outranks the per-language map", async () => {
+    config = makeConfig({
+      provider: "elevenlabs",
+      elevenlabsLanguageVoices: { hi: "voice-hindi" },
+    });
+    const { requests, probeRequests } = installCapturingElevenLabsStub();
+
+    await streamLiveVoiceTtsAudio({
+      config,
+      text: "namaste",
+      language: "hi",
+      voiceId: "voice-explicit",
+      onAudioChunk: () => {},
+    });
+
+    expect(requests[0]?.voiceId).toBe("voice-explicit");
+    expect(probeRequests[0]?.voiceId).toBe("voice-explicit");
+  });
+
+  test("performs no lookup when the turn has no language", async () => {
+    config = makeConfig({
+      provider: "elevenlabs",
+      elevenlabsLanguageVoices: { hi: "voice-hindi" },
+    });
+    const { requests } = installCapturingElevenLabsStub();
+
+    await streamLiveVoiceTtsAudio({
+      config,
+      text: "hello",
+      onAudioChunk: () => {},
+    });
+
+    expect(requests[0]?.voiceId).toBeUndefined();
+  });
+
   test("keeps live voice TTS behind the registry instead of direct provider SDKs", () => {
     const source = readFileSync(
       new URL("../live-voice-tts.ts", import.meta.url),
@@ -508,11 +581,84 @@ describe("streamLiveVoiceTtsAudio", () => {
   });
 });
 
+describe("resolveLanguageVoiceOverride", () => {
+  test("keys the lookup by the language's lowercase base subtag", () => {
+    const map = { hi: "voice-hindi" };
+    expect(resolveLanguageVoiceOverride(map, "hi")).toBe("voice-hindi");
+    expect(resolveLanguageVoiceOverride(map, "hi-IN")).toBe("voice-hindi");
+    expect(resolveLanguageVoiceOverride(map, "HI")).toBe("voice-hindi");
+  });
+
+  test("returns undefined without a language", () => {
+    expect(
+      resolveLanguageVoiceOverride({ hi: "voice-hindi" }, undefined),
+    ).toBeUndefined();
+    expect(
+      resolveLanguageVoiceOverride({ hi: "voice-hindi" }, ""),
+    ).toBeUndefined();
+  });
+
+  test("rejects malformed maps and non-string or empty entries", () => {
+    expect(resolveLanguageVoiceOverride(undefined, "hi")).toBeUndefined();
+    expect(resolveLanguageVoiceOverride(null, "hi")).toBeUndefined();
+    expect(resolveLanguageVoiceOverride("voice-hindi", "hi")).toBeUndefined();
+    expect(resolveLanguageVoiceOverride(["voice-hindi"], "hi")).toBeUndefined();
+    expect(resolveLanguageVoiceOverride({ hi: 42 }, "hi")).toBeUndefined();
+    expect(resolveLanguageVoiceOverride({ hi: "  " }, "hi")).toBeUndefined();
+    expect(resolveLanguageVoiceOverride({}, "constructor")).toBeUndefined();
+  });
+
+  test("trims the resolved voice identifier", () => {
+    expect(resolveLanguageVoiceOverride({ hi: " voice-hindi " }, "hi")).toBe(
+      "voice-hindi",
+    );
+  });
+});
+
+/**
+ * Install an ElevenLabs-id streaming stub that records the sample-rate probe
+ * and synthesis requests.
+ */
+function installCapturingElevenLabsStub(): {
+  requests: TtsSynthesisRequest[];
+  probeRequests: TtsSynthesisRequest[];
+} {
+  const requests: TtsSynthesisRequest[] = [];
+  const probeRequests: TtsSynthesisRequest[] = [];
+  _setTtsProviderForTests({
+    id: "elevenlabs",
+    capabilities: {
+      supportsStreaming: true,
+      supportedFormats: ["mp3", "pcm"],
+    },
+    resolveOutputSampleRateHz: (request) => {
+      probeRequests.push(request);
+      return 24_000;
+    },
+    async synthesize(): Promise<TtsSynthesisResult> {
+      throw new Error("buffered synthesis should not be used");
+    },
+    async synthesizeStream(
+      request: TtsSynthesisRequest,
+      onChunk: (chunk: Uint8Array) => void,
+    ): Promise<TtsSynthesisResult> {
+      requests.push(request);
+      onChunk(Buffer.from("pcm-one!"));
+      return {
+        audio: Buffer.from("pcm-one!"),
+        contentType: "audio/pcm",
+      };
+    },
+  });
+  return { requests, probeRequests };
+}
+
 function makeConfig(
   overrides: {
     provider?: string;
     format?: "mp3" | "wav" | "opus";
     sampleRate?: number;
+    elevenlabsLanguageVoices?: Record<string, string>;
   } = {},
 ): LiveVoiceTtsConfig {
   return {
@@ -535,6 +681,7 @@ function makeConfig(
             stability: 0.5,
             similarityBoost: 0.75,
             conversationTimeoutSeconds: 30,
+            languageVoices: overrides.elevenlabsLanguageVoices,
           },
           deepgram: {
             model: "aura-asteria-en",

--- a/assistant/src/live-voice/live-voice-tts.ts
+++ b/assistant/src/live-voice/live-voice-tts.ts
@@ -76,9 +76,13 @@ interface ResolvedStreamingTtsProvider {
 
 /**
  * Look up a per-language voice override in a provider config's
- * `languageVoices` map. Returns the voice for the language's lowercase
- * base subtag, or undefined when the language is unset, the map is not a
- * record, or its entry for the language is not a non-empty string.
+ * `languageVoices` map. Map KEYS are normalized to their lowercase base
+ * subtag before matching, so a user-entered "hi-IN" or "HI" key still
+ * matches a spoken "hi" (the schema accepts any string key). An exact
+ * base-subtag key wins over a normalized regional one; otherwise the
+ * first matching entry in insertion order applies. Returns undefined when
+ * the language is unset, the map is not a record, or the matching entry
+ * is not a non-empty string.
  */
 export function resolveLanguageVoiceOverride(
   languageVoices: unknown,
@@ -89,16 +93,28 @@ export function resolveLanguageVoiceOverride(
     !base ||
     typeof languageVoices !== "object" ||
     languageVoices === null ||
-    Array.isArray(languageVoices) ||
-    !Object.hasOwn(languageVoices, base)
+    Array.isArray(languageVoices)
   ) {
     return undefined;
   }
-  const voice = (languageVoices as Record<string, unknown>)[base];
-  if (typeof voice !== "string") {
-    return undefined;
+  const asVoice = (value: unknown): string | undefined =>
+    typeof value === "string" ? value.trim() || undefined : undefined;
+  const record = languageVoices as Record<string, unknown>;
+  if (Object.hasOwn(record, base)) {
+    const exact = asVoice(record[base]);
+    if (exact !== undefined) {
+      return exact;
+    }
   }
-  return voice.trim() || undefined;
+  for (const [key, value] of Object.entries(record)) {
+    if (baseLanguageSubtag(key) === base) {
+      const voice = asVoice(value);
+      if (voice !== undefined) {
+        return voice;
+      }
+    }
+  }
+  return undefined;
 }
 
 export async function streamLiveVoiceTtsAudio(

--- a/assistant/src/live-voice/live-voice-tts.ts
+++ b/assistant/src/live-voice/live-voice-tts.ts
@@ -8,6 +8,7 @@ import type {
   TtsSynthesisRequest,
   TtsUseCase,
 } from "../tts/types.js";
+import { baseLanguageSubtag } from "../util/language-subtag.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("live-voice-tts");
@@ -73,11 +74,46 @@ interface ResolvedStreamingTtsProvider {
   providerConfig: Record<string, unknown>;
 }
 
+/**
+ * Look up a per-language voice override in a provider config's
+ * `languageVoices` map. Returns the voice for the language's lowercase
+ * base subtag, or undefined when the language is unset, the map is not a
+ * record, or its entry for the language is not a non-empty string.
+ */
+export function resolveLanguageVoiceOverride(
+  languageVoices: unknown,
+  language: string | undefined,
+): string | undefined {
+  const base = baseLanguageSubtag(language);
+  if (
+    !base ||
+    typeof languageVoices !== "object" ||
+    languageVoices === null ||
+    Array.isArray(languageVoices) ||
+    !Object.hasOwn(languageVoices, base)
+  ) {
+    return undefined;
+  }
+  const voice = (languageVoices as Record<string, unknown>)[base];
+  if (typeof voice !== "string") {
+    return undefined;
+  }
+  return voice.trim() || undefined;
+}
+
 export async function streamLiveVoiceTtsAudio(
   options: LiveVoiceTtsOptions,
 ): Promise<LiveVoiceTtsResult> {
   const { provider, providerId, providerConfig } =
     await resolveLiveVoiceStreamingTtsProvider(options.config);
+  // An explicit request voice wins outright; otherwise a language-known
+  // turn may select the provider's configured per-language voice.
+  const voiceId =
+    options.voiceId ??
+    resolveLanguageVoiceOverride(
+      providerConfig.languageVoices,
+      options.language,
+    );
   const useCase = options.useCase ?? "phone-call";
   const requestedSampleRate = resolveSampleRate(
     options.sampleRate,
@@ -90,7 +126,7 @@ export async function streamLiveVoiceTtsAudio(
   const providerSampleRate = provider.resolveOutputSampleRateHz?.({
     text: options.text,
     useCase,
-    voiceId: options.voiceId,
+    voiceId,
     outputFormat: options.outputFormat,
     sampleRateHz: requestedSampleRate,
     language: options.language,
@@ -140,7 +176,7 @@ export async function streamLiveVoiceTtsAudio(
       provider,
       text: options.text,
       useCase,
-      voiceId: options.voiceId,
+      voiceId,
       outputFormat: options.outputFormat,
       sampleRateHz: requestedSampleRate,
       language: options.language,

--- a/assistant/src/tts/__tests__/provider-adapters.test.ts
+++ b/assistant/src/tts/__tests__/provider-adapters.test.ts
@@ -1218,6 +1218,22 @@ describe("Deepgram TTS provider adapter", () => {
     expect(body.text).toBe("Hello world");
   });
 
+  test("request voiceId overrides the configured Deepgram model", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      capturedUrl = typeof input === "string" ? input : input.toString();
+      return new Response(new Uint8Array([0x49, 0x44, 0x33]), { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    const provider = createDeepgramProvider();
+    await provider.synthesize(makeRequest({ voiceId: "aura-2-thalia-en" }));
+    expect(capturedUrl).toContain("model=aura-2-thalia-en");
+
+    // A blank request voiceId falls back to the configured model.
+    await provider.synthesize(makeRequest({ voiceId: "  " }));
+    expect(capturedUrl).toContain("model=aura-asteria-en");
+  });
+
   test("uses linear16 encoding with container=none and sample_rate=16000 when outputFormat is pcm", async () => {
     const audioPayload = new Uint8Array([0x00, 0x01, 0x02]);
     let capturedUrl = "";

--- a/assistant/src/tts/providers/deepgram-provider.ts
+++ b/assistant/src/tts/providers/deepgram-provider.ts
@@ -165,7 +165,9 @@ async function performTtsRequest(
 
   const config = getConfig().services.tts.providers.deepgram;
   const outputParams = resolveOutputParams(request, config);
-  const model = config.model;
+  // A request-level voiceId is the per-request Aura model override and wins
+  // over the configured model.
+  const model = request.voiceId?.trim() || config.model;
 
   const params = new URLSearchParams({
     model,


### PR DESCRIPTION
## Summary
- Adds an optional languageVoices map (language subtag to voice id) to the elevenlabs, vellum, and deepgram TTS provider configs
- Live voice resolves the turn language against the map when no explicit voiceId is given; explicit voiceId always wins
- Managed-path values must be rate-card-priced voices (missing_price surfaces otherwise, documented in the schema)

Part of plan: voice-multilingual-pipeline.md (PR 6 of 6)