### PR TITLE
refactor(web): migrate the speech pickers off the deprecated Dropdown (LUM-2959)

### DIFF
--- a/clients/web/src/components/speech/stt-provider-form.tsx
+++ b/clients/web/src/components/speech/stt-provider-form.tsx
@@ -14,7 +14,7 @@ import { useDraftOverride } from "@/hooks/use-draft-override";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { isNativeDictationSupported } from "@/runtime/native-dictation-partials";
 import { getLocalSetting, setLocalSetting } from "@/utils/local-settings";
-import { Dropdown } from "@vellumai/design-library/components/dropdown";
+import { Select } from "@vellumai/design-library/components/select";
 import { Input } from "@vellumai/design-library/components/input";
 import { toast } from "@vellumai/design-library/components/toast";
 
@@ -372,7 +372,7 @@ export function SttProviderForm({
         <label className="block text-body-small-default text-[var(--content-tertiary)]">
           Provider
         </label>
-        <Dropdown
+        <Select
           value={draftProvider}
           onChange={setDraftProvider}
           options={providers.map((p) => ({
@@ -389,7 +389,7 @@ export function SttProviderForm({
             Spoken language
           </label>
           {/* A trigger row (current value + chevron) opening the shared
-              search-first picker: mirrors the Dropdown trigger's field
+              search-first picker: mirrors the Select trigger's field
               styling so the form reads uniformly, but opens a dialog. */}
           <SelectTriggerRow
             aria-label="Spoken language"

--- a/clients/web/src/components/speech/tts-provider-form.tsx
+++ b/clients/web/src/components/speech/tts-provider-form.tsx
@@ -17,7 +17,7 @@ import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { synthesizeTTS } from "@/lib/tts-synthesize";
 import { getLocalSetting, setLocalSetting } from "@/utils/local-settings";
 import { Button } from "@vellumai/design-library/components/button";
-import { Dropdown } from "@vellumai/design-library/components/dropdown";
+import { Select } from "@vellumai/design-library/components/select";
 import { Input } from "@vellumai/design-library/components/input";
 import { toast } from "@vellumai/design-library/components/toast";
 
@@ -464,7 +464,7 @@ export function TtsProviderForm({
         <label className="block text-body-small-default text-[var(--content-tertiary)]">
           Provider
         </label>
-        <Dropdown
+        <Select
           value={draftProvider}
           onChange={setDraftProvider}
           options={providers.map((p) => ({

--- a/clients/web/src/components/speech/voice-list.tsx
+++ b/clients/web/src/components/speech/voice-list.tsx
@@ -26,7 +26,7 @@ import { Check, Square, Volume2 } from "lucide-react";
 
 import { cn } from "@vellumai/design-library";
 import { Button } from "@vellumai/design-library/components/button";
-import { Dropdown } from "@vellumai/design-library/components/dropdown";
+import { Select } from "@vellumai/design-library/components/select";
 
 import { useManagedVoiceSelection } from "@/components/speech/use-managed-voice-selection";
 import { useVoiceSamplePreview } from "@/components/speech/use-voice-sample-preview";
@@ -198,7 +198,7 @@ export function VoiceList({
       )}
       {showSourceFilter && (
         <div className="px-1 pb-1">
-          <Dropdown
+          <Select
             value={selectedSource ?? ""}
             onChange={setSourceOverride}
             options={sources.map((s) => ({


### PR DESCRIPTION
## TL;DR

Moves the three speech pickers off the deprecated `Dropdown`. Import swap only.

Part of [LUM-2959](https://linear.app/vellum/issue/LUM-2959). First of two batches covering the last eight call sites.

## What changes for the user

| Before | After |
| --- | --- |
| While a menu was open, every scroll anywhere in the document ran a layout read and a re-render | Radix positions without that |
| Menus could not flip upward, so a picker low in the page opened below the fold | Menu flips and shifts to stay on screen |
| Menus mispositioned inside a transformed ancestor | Positioned correctly |
| With a menu open, a screen reader could arrow into covered page content | The page leaves the accessibility tree while the menu is open |

Visually identical otherwise, see below.

## Why the scroll behaviour is worth calling out

`Dropdown` positions itself by hand:

```ts
window.addEventListener("scroll", updatePosition, true);
window.addEventListener("resize", updatePosition);
```

Capture phase, so it fires for scrolling in **any** container, and each call does a `getBoundingClientRect()` and a `setState`. While a menu is open, a scroll gesture drives a layout read and a re-render per event. The cost only exists while a menu is open, so this is not an app-wide win, but it is a real one during the window it applies to.

## Why this is safe

**Nothing styling-related changes.** None of the three passes `className`, `size`, `menuAlign`, `menuMaxHeight` or `style`, so all three render the default `Select`. I compared the two components' computed styles in Storybook rather than assuming:

| | Dropdown | Select |
| --- | --- | --- |
| trigger | 36×256, 14px/400 DM Sans, padding `0 12px`, border `1px rgb(207,204,201)`, radius 8px | identical |
| option | height 34, padding `8px/8px`, 14px/500 | identical |
| menu box | 180px | 180px |
| first option top / last bottom | 387 / 557 | 387 / 557 |

The menu's 4px vertical padding moves from the `<ul>` onto Radix's `Viewport`, which is why the padding reads differently per node, but the rendered geometry is the same to the pixel.

**Both failure shapes this migration keeps producing were checked.** No option carries an empty-string value, directly or through a named constant. `voice-list` derives its displayed source from a fallback chain (`sourceOverride ?? activeVoiceSource ?? sources[0]`), so re-picking the shown provider reports nothing — but that state is modal-local rather than persisted, and the visible filter is the same either way. The only difference is whether the filter keeps tracking the active voice, which is the documented default behaviour.

## Coverage gap, stated rather than papered over

`voice-list` has a test file, but it never opens the picker: zero `role="option"` queries. `speech-to-text-card` and `text-to-speech-card` pass and exercise their own surfaces. So the suites here do not prove this change; the code-level checks above are what it rests on. Adding tests purely to cover an import swap did not seem worth it, and these components never had picker coverage before this PR either.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40356" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->