### PR TITLE
refactor(web): migrate four more Dropdown call sites off it (LUM-2959)

### DIFF
--- a/clients/web/src/components/add-credits-modal.tsx
+++ b/clients/web/src/components/add-credits-modal.tsx
@@ -13,7 +13,7 @@ import { openUrl, openUrlFinishedListener } from "@/runtime/browser";
 import { useIsNativeAndroid } from "@/runtime/platform-detection";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
-import { Dropdown } from "@vellumai/design-library/components/dropdown";
+import { Select } from "@vellumai/design-library/components/select";
 import { Modal } from "@vellumai/design-library/components/modal";
 
 const DEFAULT_TOP_UP_AMOUNTS: [string, ...string[]] = [
@@ -60,10 +60,7 @@ interface AddCreditsModalProps {
   onOpenChange: (open: boolean) => void;
 }
 
-function AddCreditsModalContent({
-  open,
-  onOpenChange,
-}: AddCreditsModalProps) {
+function AddCreditsModalContent({ open, onOpenChange }: AddCreditsModalProps) {
   const queryClient = useQueryClient();
   const { pathname } = useLocation();
   const [searchParams] = useSearchParams();
@@ -144,7 +141,7 @@ function AddCreditsModalContent({
               >
                 Amount
               </label>
-              <Dropdown
+              <Select
                 id="add-credits-amount"
                 value={amount}
                 onChange={(value) => {

--- a/clients/web/src/components/charts/date-range-select.tsx
+++ b/clients/web/src/components/charts/date-range-select.tsx
@@ -1,9 +1,9 @@
 import { useMemo } from "react";
 
 import {
-  Select,
-  type SelectOption,
-} from "@vellumai/design-library/components/select";
+  Dropdown,
+  type DropdownOption,
+} from "@vellumai/design-library/components/dropdown";
 
 import { getEffectiveTimezone } from "@/utils/effective-timezone";
 import { resolveLastTimezoneCalendarDays } from "@/utils/usage-window";
@@ -36,9 +36,8 @@ export const DEFAULT_PRESET_DAYS = 30;
 
 type PresetDays = `${(typeof PRESET_DAYS)[number]}`;
 
-const PRESET_OPTIONS: ReadonlyArray<SelectOption<PresetDays>> = PRESET_DAYS.map(
-  (days) => ({ value: `${days}`, label: `Last ${days} days` }),
-);
+const PRESET_OPTIONS: ReadonlyArray<DropdownOption<PresetDays>> =
+  PRESET_DAYS.map((days) => ({ value: `${days}`, label: `Last ${days} days` }));
 
 /**
  * Compute a "last N days" range whose calendar bounds are expressed in the
@@ -94,7 +93,7 @@ export function DateRangeSelect({ value, onChange }: DateRangeSelectProps) {
   };
 
   return (
-    <Select<PresetDays>
+    <Dropdown<PresetDays>
       options={PRESET_OPTIONS}
       value={selectedPreset}
       onChange={handleChange}

--- a/clients/web/src/components/charts/date-range-select.tsx
+++ b/clients/web/src/components/charts/date-range-select.tsx
@@ -1,9 +1,9 @@
 import { useMemo } from "react";
 
 import {
-  Dropdown,
-  type DropdownOption,
-} from "@vellumai/design-library/components/dropdown";
+  Select,
+  type SelectOption,
+} from "@vellumai/design-library/components/select";
 
 import { getEffectiveTimezone } from "@/utils/effective-timezone";
 import { resolveLastTimezoneCalendarDays } from "@/utils/usage-window";
@@ -36,8 +36,9 @@ export const DEFAULT_PRESET_DAYS = 30;
 
 type PresetDays = `${(typeof PRESET_DAYS)[number]}`;
 
-const PRESET_OPTIONS: ReadonlyArray<DropdownOption<PresetDays>> =
-  PRESET_DAYS.map((days) => ({ value: `${days}`, label: `Last ${days} days` }));
+const PRESET_OPTIONS: ReadonlyArray<SelectOption<PresetDays>> = PRESET_DAYS.map(
+  (days) => ({ value: `${days}`, label: `Last ${days} days` }),
+);
 
 /**
  * Compute a "last N days" range whose calendar bounds are expressed in the
@@ -93,7 +94,7 @@ export function DateRangeSelect({ value, onChange }: DateRangeSelectProps) {
   };
 
   return (
-    <Dropdown<PresetDays>
+    <Select<PresetDays>
       options={PRESET_OPTIONS}
       value={selectedPreset}
       onChange={handleChange}

--- a/clients/web/src/components/share-feedback-modal.tsx
+++ b/clients/web/src/components/share-feedback-modal.tsx
@@ -30,10 +30,7 @@ import { createPortal } from "react-dom";
 import type { ChatDebugEventsApi } from "@/domains/chat/api/debug-api";
 import type { ChatDebugApi } from "@/domains/chat/utils/debug-api";
 import { feedbackCreateMutation } from "@/generated/api/@tanstack/react-query.gen";
-import type {
-  ClassificationEnum,
-  ClientEnum,
-} from "@/generated/api/types.gen";
+import type { ClassificationEnum, ClientEnum } from "@/generated/api/types.gen";
 import { logsExportPost } from "@/generated/daemon/sdk.gen";
 import type { LogsExportPostData } from "@/generated/daemon/types.gen";
 import { buildDiagnosticsSnapshot } from "@/lib/diagnostics";
@@ -43,9 +40,9 @@ import { useAuthStore } from "@/stores/auth-store";
 import { VELLUM_COMMUNITY_URL } from "@/utils/external-urls";
 import { Button } from "@vellumai/design-library/components/button";
 import {
-  Dropdown,
-  type DropdownOption,
-} from "@vellumai/design-library/components/dropdown";
+  Select,
+  type SelectOption,
+} from "@vellumai/design-library/components/select";
 import { Input, Textarea } from "@vellumai/design-library/components/input";
 import { Notice } from "@vellumai/design-library/components/notice";
 import { Toggle } from "@vellumai/design-library/components/toggle";
@@ -96,12 +93,10 @@ const TIME_RANGES: {
   { value: "all_time", label: "All time", cutoffMs: null },
 ];
 
-const TIME_RANGE_OPTIONS: DropdownOption<TimeRange>[] = TIME_RANGES.map(
-  (r) => ({
-    value: r.value,
-    label: r.label,
-  }),
-);
+const TIME_RANGE_OPTIONS: SelectOption<TimeRange>[] = TIME_RANGES.map((r) => ({
+  value: r.value,
+  label: r.label,
+}));
 
 const ALLOWED_MIME_TYPES = new Set([
   "image/png",
@@ -1056,7 +1051,7 @@ export function ShareFeedbackModal({
               <span className="text-body-medium-lighter text-[var(--content-default)]">
                 Time range
               </span>
-              <Dropdown
+              <Select
                 options={TIME_RANGE_OPTIONS}
                 value={logTimeRange}
                 onChange={setLogTimeRange}
@@ -1172,7 +1167,7 @@ export function ShareFeedbackModal({
                     </Tooltip>
                   </div>
                   {includeLogs && (
-                    <Dropdown
+                    <Select
                       options={TIME_RANGE_OPTIONS}
                       value={logTimeRange}
                       onChange={setLogTimeRange}

--- a/clients/web/src/domains/channels/components/channel-trust-floor-section.tsx
+++ b/clients/web/src/domains/channels/components/channel-trust-floor-section.tsx
@@ -1,4 +1,4 @@
-import { Dropdown } from "@vellumai/design-library/components/dropdown";
+import { Select } from "@vellumai/design-library/components/select";
 import { Notice } from "@vellumai/design-library/components/notice";
 import { Typography } from "@vellumai/design-library/components/typography";
 
@@ -73,7 +73,7 @@ export function ChannelTrustFloorSection({
       ) : (
         <>
           <div style={{ maxWidth: 280 }}>
-            <Dropdown<AdmissionPolicy>
+            <Select<AdmissionPolicy>
               value={value}
               onChange={onChange}
               options={options}

--- a/clients/web/src/domains/onboarding/pages/api-key-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/api-key-screen.tsx
@@ -16,7 +16,7 @@ import {
 import { isElectron } from "@/runtime/is-electron";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
-import { Dropdown } from "@vellumai/design-library/components/dropdown";
+import { Select } from "@vellumai/design-library/components/select";
 import { Input } from "@vellumai/design-library/components/input";
 
 import { MOBILE_INPUT_NO_ZOOM } from "@/domains/onboarding/onboarding-step-layout";
@@ -117,7 +117,7 @@ export function ApiKeyScreen() {
             <label className="text-body-small-default text-[var(--content-tertiary)]">
               Provider
             </label>
-            <Dropdown
+            <Select
               aria-label="Provider"
               value={provider}
               onChange={(v) => {
@@ -140,7 +140,7 @@ export function ApiKeyScreen() {
               <label className="text-body-small-default text-[var(--content-tertiary)]">
                 Model
               </label>
-              <Dropdown
+              <Select
                 aria-label="Model"
                 value={model}
                 onChange={setModel}


### PR DESCRIPTION
## TL;DR

Moves four `Dropdown` call sites onto `Select`: `add-credits-modal`, `share-feedback-modal`, `channel-trust-floor-section` and `onboarding/api-key-screen`. Import swap only.

`charts/date-range-select` started in this batch and was pulled back out — it needs a behaviour fix first, and gets its own change. `Dropdown` becomes unreferenced once that lands alongside this and [#40356](https://github.com/vellum-ai/vellum-assistant/pull/40356); the deletion is separate.

Part of [LUM-2959](https://linear.app/vellum/issue/LUM-2959).

## What changes for the user

| Before | After |
| --- | --- |
| While a menu was open, every scroll anywhere in the document ran a layout read and a re-render | Radix positions without that |
| Menus could not flip upward, so a picker low in the page opened below the fold | Menu flips and shifts to stay on screen |
| Menus mispositioned inside a transformed ancestor (the LUM-2955 class) | Positioned correctly |
| With a menu open, a screen reader could arrow into covered page content | The page leaves the accessibility tree while the menu is open |

Visually identical otherwise.

## The one behaviour difference, and where it lands

`Dropdown` called `onChange` on every option click. `Select` forwards Radix's `onValueChange`, which fires only on a genuine value change. So a call site whose *displayed* value is derived through a fallback rather than held as state loses something real: the user re-picks what the trigger already shows, and nothing happens.

The first draft of this PR claimed no call site here had that shape. That was wrong — three did, and this is what changed in response:

- **`charts/date-range-select`** — the one where it bites. Removed from this batch; covered below.
- **`channel-trust-floor-section`** (`policy ?? ADMISSION_POLICY_DEFAULT`) — inert. A channel with no stored row falls back to the default *on the read side too*: `gateway/src/db/admission-policy-store.ts:36-40` documents the absent-row default as the same `trusted_contacts`. So the write that no longer fires would have stored a value identical to the one already in effect. The trigger shows the truth either way.
- **`add-credits-modal`** (`selectedAmount ?? topUpAmounts[0]`) — the `onChange` body also calls `checkoutMutation.reset()`, so after a failed checkout, re-picking the already-shown amount used to clear the error banner and now does not. The banner still clears on the next attempt, since `mutate` moves the mutation out of its error state. Accepted rather than fixed: re-picking the value you already have is not an interaction users perform, and the alternative is to keep a submit error's lifecycle tied to a value-change event, which is the thing worth removing rather than preserving.

## Why the rest is safe

**Nothing styling-related changes.** None of the four passes `className`, `size`, `menuAlign`, `menuMaxHeight` or `style`, so all render the default `Select`. Computed styles compared in Storybook rather than assumed:

| | Dropdown | Select |
| --- | --- | --- |
| trigger | 36×256, 14px/400 DM Sans, padding `0 12px`, border `1px rgb(207,204,201)`, radius 8px | identical |
| option | height 34, padding `8px/8px`, 14px/500 | identical |
| menu box | 180px | 180px |
| first option top / last bottom | 387 / 557 | 387 / 557 |

The menu's 4px vertical padding moves from the `<ul>` onto Radix's `Viewport`, so per-node padding reads differently, but the rendered geometry is identical to the pixel.

**No empty-string option values.** The other shape this migration keeps producing: Radix treats `""` as "no selection" and discards such an item, so the row silently never renders. Grepped across the four, literal and via named constants — none.

## Coverage

`add-credits-modal` and `share-feedback-modal` have test files, but neither opens its picker, so those suites do not exercise this change. `channel-trust-floor-section` is covered indirectly through `slack-channel-section`. The code-level checks above are what this rests on; none of these had picker coverage before, and adding some purely to cover an import swap did not seem worth the noise.
