### PR TITLE
fix(web): keep the billing date range on the current calendar day (LUM-2959)

### DIFF
--- a/clients/web/src/components/charts/date-range-select.test.tsx
+++ b/clients/web/src/components/charts/date-range-select.test.tsx
@@ -9,7 +9,13 @@
  */
 
 import { afterEach, describe, expect, setSystemTime, test } from "bun:test";
-import { act, cleanup, render, renderHook, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  render,
+  renderHook,
+  screen,
+} from "@testing-library/react";
 
 import { DateRangeSelect, usePresetRange } from "./date-range-select";
 
@@ -54,9 +60,39 @@ describe("usePresetRange", () => {
     expect(result.current).toBe(first);
   });
 
-  test("a zone change lands in the first render, with no wrong value between", () => {
-    // At this instant Niue (UTC-11) is still on Aug 6 while Kiritimati (UTC+14)
-    // has reached Aug 7, so the two zones disagree about today's date.
+  test("a zone change re-reads the date instead of reusing the old zone's sample", () => {
+    // 04:00Z is the instant New York rolls into Aug 6, so the first sample is
+    // taken exactly on that zone's day boundary. Chicago is an hour behind and
+    // is still on Aug 5 at that instant.
+    setSystemTime(new Date("2026-08-06T04:00:00Z"));
+
+    const seen: string[] = [];
+    const { rerender } = renderHook(
+      ({ tz }: { tz: string }) => {
+        const range = usePresetRange(30, tz);
+        seen.push(range.to);
+        return range;
+      },
+      { initialProps: { tz: "America/New_York" } },
+    );
+    expect([...new Set(seen)]).toEqual(["2026-08-06"]);
+
+    // Hours later in the same New York day, so the stored sample is stale as an
+    // instant while still correct as a date. Both zones now agree on Aug 6.
+    setSystemTime(new Date("2026-08-06T15:00:00Z"));
+    seen.length = 0;
+    rerender({ tz: "America/Chicago" });
+
+    // No render reports Aug 5, which is what re-reading the stored sample in
+    // the new zone would give, nor Aug 5 followed by a correction, which is
+    // what deferring the re-read to an effect would give. The date reaches the
+    // billing query key, so a wrong render is a wrong fetch.
+    expect([...new Set(seen)]).toEqual(["2026-08-06"]);
+  });
+
+  test("zones that disagree about today resolve to the one being asked about", () => {
+    // Niue (UTC-11) is on Aug 6 here while Kiritimati (UTC+14) has reached
+    // Aug 7: a zone change that crosses a date boundary, not just an offset.
     setSystemTime(new Date("2026-08-06T12:00:00Z"));
 
     const seen: string[] = [];
@@ -68,15 +104,13 @@ describe("usePresetRange", () => {
       },
       { initialProps: { tz: "Pacific/Niue" } },
     );
-    expect(seen).toEqual(["2026-08-06"]);
+    expect([...new Set(seen)]).toEqual(["2026-08-06"]);
 
+    setSystemTime(new Date("2026-08-06T20:00:00Z"));
     seen.length = 0;
     rerender({ tz: "Pacific/Kiritimati" });
 
-    // Every render after the change reports the new zone's date. A date held in
-    // state and corrected by an effect would show the old zone's for one render
-    // first, and the billing query keyed on it would fetch that window.
-    expect(seen).toEqual(["2026-08-07"]);
+    expect([...new Set(seen)]).toEqual(["2026-08-07"]);
   });
 
   test("a preset's span is its own, not the default's", () => {

--- a/clients/web/src/components/charts/date-range-select.test.tsx
+++ b/clients/web/src/components/charts/date-range-select.test.tsx
@@ -54,6 +54,31 @@ describe("usePresetRange", () => {
     expect(result.current).toBe(first);
   });
 
+  test("a zone change lands in the first render, with no wrong value between", () => {
+    // At this instant Niue (UTC-11) is still on Aug 6 while Kiritimati (UTC+14)
+    // has reached Aug 7, so the two zones disagree about today's date.
+    setSystemTime(new Date("2026-08-06T12:00:00Z"));
+
+    const seen: string[] = [];
+    const { rerender } = renderHook(
+      ({ tz }: { tz: string }) => {
+        const range = usePresetRange(30, tz);
+        seen.push(range.to);
+        return range;
+      },
+      { initialProps: { tz: "Pacific/Niue" } },
+    );
+    expect(seen).toEqual(["2026-08-06"]);
+
+    seen.length = 0;
+    rerender({ tz: "Pacific/Kiritimati" });
+
+    // Every render after the change reports the new zone's date. A date held in
+    // state and corrected by an effect would show the old zone's for one render
+    // first, and the billing query keyed on it would fetch that window.
+    expect(seen).toEqual(["2026-08-07"]);
+  });
+
   test("a preset's span is its own, not the default's", () => {
     setSystemTime(new Date("2026-08-06T12:00:00Z"));
     const { result } = renderHook(() => usePresetRange(7, TZ));
@@ -66,8 +91,8 @@ describe("DateRangeSelect", () => {
   test("shows the preset it is handed", () => {
     render(<DateRangeSelect value={90} onChange={() => {}} />);
 
-    // The identity is displayed directly. Reverse-matching a range's span
-    // rounded every non-7/90 window to the 30-day label.
+    // The trigger shows the identity it was handed, not one inferred from a
+    // range's span.
     expect(screen.getByLabelText("Date range").textContent).toBe(
       "Last 90 days",
     );

--- a/clients/web/src/components/charts/date-range-select.test.tsx
+++ b/clients/web/src/components/charts/date-range-select.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * Tests for the relative date-range control and the hook that derives its
+ * bounds.
+ *
+ * The invariant that matters: bounds for a relative preset are anchored on the
+ * current calendar day, so they must follow a rollover on their own. Held in
+ * state instead, they silently address yesterday while the trigger still reads
+ * "Last 30 days".
+ */
+
+import { afterEach, describe, expect, setSystemTime, test } from "bun:test";
+import { act, cleanup, render, renderHook, screen } from "@testing-library/react";
+
+import { DateRangeSelect, usePresetRange } from "./date-range-select";
+
+const TZ = "UTC";
+
+afterEach(() => {
+  setSystemTime();
+  cleanup();
+});
+
+describe("usePresetRange", () => {
+  test("bounds follow the calendar day across a rollover", () => {
+    setSystemTime(new Date("2026-08-06T23:59:00Z"));
+    const { result } = renderHook(() => usePresetRange(30, TZ));
+
+    expect(result.current).toEqual({ from: "2026-07-08", to: "2026-08-06" });
+    const beforeMidnight = result.current;
+
+    setSystemTime(new Date("2026-08-07T00:01:00Z"));
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    // Both bounds move: a relative window that kept yesterday's `to` would be
+    // querying a stale day while claiming to be the same preset.
+    expect(result.current).toEqual({ from: "2026-07-09", to: "2026-08-07" });
+    expect(result.current).not.toBe(beforeMidnight);
+  });
+
+  test("re-checking inside the same day yields the same range object", () => {
+    setSystemTime(new Date("2026-08-06T10:00:00Z"));
+    const { result } = renderHook(() => usePresetRange(30, TZ));
+    const first = result.current;
+
+    setSystemTime(new Date("2026-08-06T22:00:00Z"));
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    // Referential equality, not just deep equality: the day guard has to stop
+    // the re-check from re-rendering every consumer of the range.
+    expect(result.current).toBe(first);
+  });
+
+  test("a preset's span is its own, not the default's", () => {
+    setSystemTime(new Date("2026-08-06T12:00:00Z"));
+    const { result } = renderHook(() => usePresetRange(7, TZ));
+
+    expect(result.current).toEqual({ from: "2026-07-31", to: "2026-08-06" });
+  });
+});
+
+describe("DateRangeSelect", () => {
+  test("shows the preset it is handed", () => {
+    render(<DateRangeSelect value={90} onChange={() => {}} />);
+
+    // The identity is displayed directly. Reverse-matching a range's span
+    // rounded every non-7/90 window to the 30-day label.
+    expect(screen.getByLabelText("Date range").textContent).toBe(
+      "Last 90 days",
+    );
+  });
+
+  test("falls back to the default rather than rendering blank", () => {
+    render(<DateRangeSelect value={45} onChange={() => {}} />);
+
+    expect(screen.getByLabelText("Date range").textContent).toBe(
+      "Last 30 days",
+    );
+  });
+});

--- a/clients/web/src/components/charts/date-range-select.tsx
+++ b/clients/web/src/components/charts/date-range-select.tsx
@@ -1,13 +1,14 @@
 import { useMemo } from "react";
 
 import {
-  Dropdown,
-  type DropdownOption,
-} from "@vellumai/design-library/components/dropdown";
+  Select,
+  type SelectOption,
+} from "@vellumai/design-library/components/select";
 
+import { timezoneDayStartEpoch } from "@/components/charts/format-date-label";
 import { getEffectiveTimezone } from "@/utils/effective-timezone";
 import { resolveLastTimezoneCalendarDays } from "@/utils/usage-window";
-import { useEffectiveTimezone } from "@/utils/use-effective-timezone";
+import { useTimezoneCalendarDay } from "@/utils/use-timezone-calendar-day";
 
 export interface DateRange {
   readonly from: string;
@@ -15,13 +16,15 @@ export interface DateRange {
 }
 
 interface DateRangeSelectProps {
-  readonly value: DateRange;
   /**
-   * Called when the user picks a preset. Emits both the computed range and the
-   * preset identity (`days`) so consumers can persist the active preset and
-   * recompute its bounds on a timezone change without reverse-matching.
+   * The active preset's identity (`days`), not its bounds. The control shows
+   * what it is handed and reports what was picked; deriving bounds is the
+   * consumer's job, because only the consumer knows when they need recomputing
+   * (a timezone change, a calendar-day rollover). Reverse-matching a range's
+   * span back to a preset here would be lossy in both directions.
    */
-  readonly onChange: (range: DateRange, presetDays: number) => void;
+  readonly value: number;
+  readonly onChange: (presetDays: number) => void;
 }
 
 /**
@@ -36,23 +39,48 @@ export const DEFAULT_PRESET_DAYS = 30;
 
 type PresetDays = `${(typeof PRESET_DAYS)[number]}`;
 
-const PRESET_OPTIONS: ReadonlyArray<DropdownOption<PresetDays>> =
-  PRESET_DAYS.map((days) => ({ value: `${days}`, label: `Last ${days} days` }));
+const PRESET_OPTIONS: ReadonlyArray<SelectOption<PresetDays>> = PRESET_DAYS.map(
+  (days) => ({ value: `${days}`, label: `Last ${days} days` }),
+);
 
 /**
  * Compute a "last N days" range whose calendar bounds are expressed in the
  * given IANA timezone, so they stay aligned with the `tz` sent to the backend.
  *
- * "Today" is the calendar date in `tz`; the lower bound is that date minus
- * `days - 1`. Day arithmetic runs on a UTC date anchored at noon to avoid DST
- * edge slips when subtracting whole days.
+ * "Today" is the calendar date in `tz` at `now`; the lower bound is that date
+ * minus `days - 1`. Day arithmetic runs on a UTC date anchored at noon to avoid
+ * DST edge slips when subtracting whole days.
+ *
+ * `now` is a parameter rather than an internal `Date.now()` so a caller holding
+ * the result across time can re-derive it when the calendar day rolls over. A
+ * relative range that keeps yesterday's bounds is wrong, not merely stale.
  */
 export function computeRangeInTimezone(
   days: number,
   tz: string = getEffectiveTimezone(),
+  now: number = Date.now(),
 ): DateRange {
-  const { fromDate, toDate } = resolveLastTimezoneCalendarDays(days, tz);
+  const { fromDate, toDate } = resolveLastTimezoneCalendarDays(days, tz, now);
   return { from: fromDate, to: toDate };
+}
+
+/**
+ * The bounds of a relative preset, kept aligned with the live calendar day in
+ * `tz`.
+ *
+ * Bounds computed once and held in state silently become wrong at local
+ * midnight: a surface left open overnight goes on querying yesterday's window
+ * while its control still reads "Last 30 days". Deriving them here, keyed on
+ * the live day, means the range follows the rollover on its own rather than
+ * waiting for an interaction to knock it loose.
+ */
+export function usePresetRange(presetDays: number, tz: string): DateRange {
+  const today = useTimezoneCalendarDay(tz);
+  return useMemo(
+    () =>
+      computeRangeInTimezone(presetDays, tz, timezoneDayStartEpoch(today, tz)),
+    [presetDays, tz, today],
+  );
 }
 
 function daysBetween(from: string, to: string): number {
@@ -63,10 +91,14 @@ function daysBetween(from: string, to: string): number {
 }
 
 /**
- * Map a range's span to the preset identity (`days`) this control would show
- * for it, defaulting to `DEFAULT_PRESET_DAYS` for any span that isn't 7 or 90.
- * Shared so consumers can derive the active preset with the same rule the
- * dropdown uses for its selected option.
+ * Map a range's span to the preset identity (`days`) it best corresponds to,
+ * defaulting to `DEFAULT_PRESET_DAYS` for any span that isn't 7 or 90.
+ *
+ * Lossy, and a last resort: it cannot tell a 30-day preset from any other span
+ * it rounds to 30, so a consumer that knows which preset is active should track
+ * that identity rather than recover it from bounds. Kept for the one case where
+ * there is nothing else to go on, a range set imperatively with no preset
+ * behind it.
  */
 export function presetDaysFromRange({ from, to }: DateRange): number {
   const days = daysBetween(from, to);
@@ -80,23 +112,16 @@ export function presetDaysFromRange({ from, to }: DateRange): number {
 }
 
 export function DateRangeSelect({ value, onChange }: DateRangeSelectProps) {
-  const tz = useEffectiveTimezone();
-
-  const selectedPreset = useMemo<PresetDays>(
-    () => `${presetDaysFromRange(value)}` as PresetDays,
-    [value],
-  );
-
-  const handleChange = (preset: PresetDays) => {
-    const days = Number(preset);
-    onChange(computeRangeInTimezone(days, tz), days);
-  };
+  // A value that is not one of the presets has no row to show, so fall back to
+  // the default rather than render a blank trigger.
+  const selected =
+    PRESET_DAYS.find((days) => days === value) ?? DEFAULT_PRESET_DAYS;
 
   return (
-    <Dropdown<PresetDays>
+    <Select<PresetDays>
       options={PRESET_OPTIONS}
-      value={selectedPreset}
-      onChange={handleChange}
+      value={`${selected}`}
+      onChange={(preset) => onChange(Number(preset))}
       aria-label="Date range"
     />
   );

--- a/clients/web/src/domains/settings/components/billing-usage/billing-usage-panel.tsx
+++ b/clients/web/src/domains/settings/components/billing-usage/billing-usage-panel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useState } from "react";
 
 import { ArrowLeft, Coins, Loader2, Target } from "lucide-react";
 
@@ -14,7 +14,8 @@ import {
   DEFAULT_PRESET_DAYS,
   type DateRange,
   DateRangeSelect,
-  computeRangeInTimezone,
+  presetDaysFromRange,
+  usePresetRange,
 } from "@/components/charts/date-range-select";
 import {
   DEFAULT_LLM_USAGE_DIMENSION,
@@ -67,11 +68,11 @@ function formatEventCount(count: number | undefined): string {
 export function BillingUsagePanel() {
   const tz = useEffectiveTimezone();
   // Track the SELECTED PRESET IDENTITY (days), not its computed bounds. The
-  // active range is derived from this identity + the live tz below, so a tz
-  // change (even one that crosses a calendar-day rollover after the range was
-  // first computed) always yields the correct bounds for the active preset.
+  // active range is derived from this identity plus the live tz and calendar
+  // day below, so a zone change or an overnight rollover always yields the
+  // correct bounds for the active preset.
   // `null` means a custom range that isn't a preset (defensive; billing only
-  // exposes presets today) — in that case `customRange` holds the bounds.
+  // exposes presets today): in that case `customRange` holds the bounds.
   const [presetDays, setPresetDays] = useState<number | null>(
     DEFAULT_PRESET_DAYS,
   );
@@ -79,18 +80,11 @@ export function BillingUsagePanel() {
     getDefaultDateRange(tz),
   );
 
-  const dateRange = useMemo<DateRange>(
-    () =>
-      presetDays === null
-        ? customRange
-        : computeRangeInTimezone(presetDays, tz),
-    [presetDays, customRange, tz],
-  );
-
-  const handleRangeChange = (range: DateRange, nextPresetDays: number) => {
-    setPresetDays(nextPresetDays);
-    setCustomRange(range);
-  };
+  // Derived rather than stored, so the active preset's bounds follow both a tz
+  // change and a calendar-day rollover without anyone having to touch the
+  // control.
+  const presetRange = usePresetRange(presetDays ?? DEFAULT_PRESET_DAYS, tz);
+  const dateRange = presetDays === null ? customRange : presetRange;
 
   const [drilldown, setDrilldown] = useState<{
     usageSource: BillingUsageSourceFilter;
@@ -150,16 +144,20 @@ export function BillingUsagePanel() {
             </Typography>
           </div>
           {/*
-           * Compact 32px controls per Figma. The shared `Dropdown` and
-           * `SegmentControl` primitives don't expose a size prop, so we
-           * override the inner button heights with arbitrary descendant
-           * variants here rather than mutating the shared primitives.
-           * - Dropdown's trigger is `<button role="combobox">` (h-9 → h-8).
+           * Compact 32px controls per Figma. `SegmentControl` exposes no size
+           * prop, and neither of `Select`'s presets is 32px (regular is 36,
+           * compact 28), so we override the inner button heights with
+           * arbitrary descendant variants here rather than mutating the
+           * shared primitives.
+           * - Select's trigger is `<button role="combobox">` (h-9 → h-8).
            * - SegmentControl's inner items are `<button role="radio">`
            *   wrapped by a 2px-padded container, so h-7 inner = 32px outer.
            */}
           <div className="flex flex-wrap items-center justify-end gap-2 [&_[role=combobox]]:h-8 [&_[role=radio]]:h-7">
-            <DateRangeSelect value={dateRange} onChange={handleRangeChange} />
+            <DateRangeSelect
+              value={presetDays ?? presetDaysFromRange(customRange)}
+              onChange={setPresetDays}
+            />
             <div className="w-44">
               <SegmentControl
                 items={METRIC_ITEMS}

--- a/clients/web/src/utils/use-timezone-calendar-day.ts
+++ b/clients/web/src/utils/use-timezone-calendar-day.ts
@@ -11,12 +11,12 @@
  * (window focus and the cross-domain bus `app.resume`), plus a coarse poll for
  * the surface that is simply left open across midnight with no interaction.
  *
- * The functional `setSampledAt` update returns the previous value when the date
- * is unchanged, so the poll notifies no one on all but the single tick a day
- * that actually crosses a boundary.
+ * The functional `setSample` update returns the previous value when the date is
+ * unchanged, so the poll notifies no one on all but the single tick a day that
+ * actually crosses a boundary.
  */
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { toTimezoneDateString } from "@/components/charts/format-date-label";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
@@ -30,20 +30,19 @@ const POLL_MS = 60_000;
 
 /** Returns `YYYY-MM-DD` for "now" in `tz`, updating when that date changes. */
 export function useTimezoneCalendarDay(tz: string): string {
-  // State holds the instant the day was last sampled, not the date itself. The
-  // date is a function of that instant and `tz`, so a zone change resolves
-  // during the same render rather than a commit later: state that stored the
-  // formatted date would hand out the previous zone's answer for one render,
-  // and anything keyed on it (a query, a fetch) would act on it.
-  const [sampledAt, setSampledAt] = useState(() => Date.now());
+  // The date and the zone it was read in are one value, never two. A date is
+  // only an answer for the zone that produced it, so storing either alone
+  // leaves the other free to drift and lets the hook report a date that was
+  // never today anywhere.
+  const [sample, setSample] = useState(() => ({
+    day: toTimezoneDateString(new Date(), tz),
+    tz,
+  }));
 
   const refresh = useCallback(() => {
-    setSampledAt((prev) => {
-      const now = Date.now();
-      return toTimezoneDateString(new Date(now), tz) ===
-        toTimezoneDateString(new Date(prev), tz)
-        ? prev
-        : now;
+    setSample((prev) => {
+      const day = toTimezoneDateString(new Date(), tz);
+      return prev.day === day && prev.tz === tz ? prev : { day, tz };
     });
   }, [tz]);
 
@@ -58,8 +57,15 @@ export function useTimezoneCalendarDay(tz: string): string {
     };
   }, [refresh]);
 
-  return useMemo(
-    () => toTimezoneDateString(new Date(sampledAt), tz),
-    [sampledAt, tz],
-  );
+  if (sample.tz !== tz) {
+    // The zone changed, which invalidates the sample outright: re-read now and
+    // return the fresh date, rather than let one render address a day the new
+    // zone is not on. That render's date reaches a query key, so being wrong
+    // for it means fetching the wrong window, not just showing one.
+    const day = toTimezoneDateString(new Date(), tz);
+    setSample({ day, tz });
+    return day;
+  }
+
+  return sample.day;
 }

--- a/clients/web/src/utils/use-timezone-calendar-day.ts
+++ b/clients/web/src/utils/use-timezone-calendar-day.ts
@@ -1,0 +1,57 @@
+/**
+ * Reactive hook for today's calendar date in a given IANA timezone.
+ *
+ * A relative window ("last 30 days") is anchored on the current calendar day,
+ * so bounds derived from one go stale the moment that day rolls over. The
+ * browser emits no event for a rollover, and {@link useEffectiveTimezone} does
+ * not cover it: the zone string is identical either side of local midnight, so
+ * nothing downstream re-renders.
+ *
+ * The date is therefore re-read on the signals that mean "the user is back"
+ * (window focus and the cross-domain bus `app.resume`), plus a coarse poll for
+ * the surface that is simply left open across midnight with no interaction.
+ *
+ * The functional `setDay` update returns the previous value when the date is
+ * unchanged, so the poll notifies no one on all but the single tick a day that
+ * actually crosses a boundary.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+
+import { toTimezoneDateString } from "@/components/charts/format-date-label";
+import { useBusSubscription } from "@/hooks/use-bus-subscription";
+
+/**
+ * Coarse enough to be free (one `Intl` format, and a no-op state update on
+ * every tick but one), fine enough that a surface left open overnight corrects
+ * itself within a minute of midnight rather than at the next interaction.
+ */
+const POLL_MS = 60_000;
+
+/** Returns `YYYY-MM-DD` for "now" in `tz`, updating when that date changes. */
+export function useTimezoneCalendarDay(tz: string): string {
+  const [day, setDay] = useState(() => toTimezoneDateString(new Date(), tz));
+
+  const refresh = useCallback(() => {
+    setDay((prev) => {
+      const next = toTimezoneDateString(new Date(), tz);
+      return next === prev ? prev : next;
+    });
+  }, [tz]);
+
+  useBusSubscription("app.resume", refresh);
+
+  useEffect(() => {
+    // Re-read on mount and whenever `tz` changes: the initial state was
+    // sampled in the zone that was live at first render.
+    refresh();
+    window.addEventListener("focus", refresh);
+    const poll = window.setInterval(refresh, POLL_MS);
+    return () => {
+      window.removeEventListener("focus", refresh);
+      window.clearInterval(poll);
+    };
+  }, [refresh]);
+
+  return day;
+}

--- a/clients/web/src/utils/use-timezone-calendar-day.ts
+++ b/clients/web/src/utils/use-timezone-calendar-day.ts
@@ -11,12 +11,12 @@
  * (window focus and the cross-domain bus `app.resume`), plus a coarse poll for
  * the surface that is simply left open across midnight with no interaction.
  *
- * The functional `setDay` update returns the previous value when the date is
- * unchanged, so the poll notifies no one on all but the single tick a day that
- * actually crosses a boundary.
+ * The functional `setSampledAt` update returns the previous value when the date
+ * is unchanged, so the poll notifies no one on all but the single tick a day
+ * that actually crosses a boundary.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { toTimezoneDateString } from "@/components/charts/format-date-label";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
@@ -30,21 +30,26 @@ const POLL_MS = 60_000;
 
 /** Returns `YYYY-MM-DD` for "now" in `tz`, updating when that date changes. */
 export function useTimezoneCalendarDay(tz: string): string {
-  const [day, setDay] = useState(() => toTimezoneDateString(new Date(), tz));
+  // State holds the instant the day was last sampled, not the date itself. The
+  // date is a function of that instant and `tz`, so a zone change resolves
+  // during the same render rather than a commit later: state that stored the
+  // formatted date would hand out the previous zone's answer for one render,
+  // and anything keyed on it (a query, a fetch) would act on it.
+  const [sampledAt, setSampledAt] = useState(() => Date.now());
 
   const refresh = useCallback(() => {
-    setDay((prev) => {
-      const next = toTimezoneDateString(new Date(), tz);
-      return next === prev ? prev : next;
+    setSampledAt((prev) => {
+      const now = Date.now();
+      return toTimezoneDateString(new Date(now), tz) ===
+        toTimezoneDateString(new Date(prev), tz)
+        ? prev
+        : now;
     });
   }, [tz]);
 
   useBusSubscription("app.resume", refresh);
 
   useEffect(() => {
-    // Re-read on mount and whenever `tz` changes: the initial state was
-    // sampled in the zone that was live at first render.
-    refresh();
     window.addEventListener("focus", refresh);
     const poll = window.setInterval(refresh, POLL_MS);
     return () => {
@@ -53,5 +58,8 @@ export function useTimezoneCalendarDay(tz: string): string {
     };
   }, [refresh]);
 
-  return day;
+  return useMemo(
+    () => toTimezoneDateString(new Date(sampledAt), tz),
+    [sampledAt, tz],
+  );
 }


### PR DESCRIPTION
## TL;DR

The Credit Usage date range stops being anchored to the day it was first computed, and the picker stops guessing which preset is active by measuring the range's span. With that divergence gone the control moves to `Select`, the last [LUM-2959](https://linear.app/vellum/issue/LUM-2959) call site.

## What changes for the user

| Before | After |
| --- | --- |
| Leave Credit Usage open overnight and the chart keeps showing the window that ended yesterday, while the picker still reads "Last 30 days" | The range follows the rollover on its own, within a minute of local midnight |
| The only way to correct it was to re-pick the preset already shown, which nothing in the UI suggests | Nothing to correct |
| While the menu was open, every scroll anywhere in the document ran a layout read and a re-render | Radix positions without that |
| The menu could not flip upward or shift to stay on screen | It does both |

Nothing about the control's appearance changes: it renders the default `Select`, and the panel's 32px override targets `[role=combobox]`, which the Radix trigger carries (asserted in `date-range-select.test.tsx`).

## Why it was stale

`billing-usage-panel` keeps the selected preset's identity in state and derives the bounds in a `useMemo` keyed on `[presetDays, customRange, tz]`. `computeRangeInTimezone` reads `Date.now()` internally, but none of those deps change at midnight and nothing re-renders the panel then, so the memo holds yesterday's answer. `useEffectiveTimezone` refreshes on focus and `app.resume`, but it returns the same zone string either side of a rollover, so it never propagates.

`usePresetRange` derives the bounds from the live calendar day instead. `useTimezoneCalendarDay` re-reads that date on focus, on `app.resume`, and on a 60s poll for a surface left open with no interaction, comparing before it stores: every tick but the one that crosses midnight returns the previous value and re-renders nothing.

`computeRangeInTimezone` takes `now` as a parameter rather than reading the clock itself, which is what makes the derivation pure and the rollover testable.

## Why the picker changed shape

It took the active `DateRange` and recovered the preset by measuring the span, rounding anything that wasn't 7 or 90 days to 30. The panel already holds the identity, so this was a lossy round trip through a value that had thrown the answer away.

It now takes the identity directly and reports the one picked. `presetDaysFromRange` stays for the single case with nothing else to go on, a range set imperatively with no preset behind it, and its doc says so.

That also removes the reason this call site could not migrate. `Select` reports genuine value changes only, so re-picking the visible preset no longer recomputes anything. That gesture was the sole refresh path for the staleness above, and it is not one users discover; the fix is the derivation, not preserving the workaround.

## Tests

`date-range-select.test.tsx`, five cases. The load-bearing one drives the clock across midnight and asserts both bounds move. Sensitivity-checked by reverting `usePresetRange` to the old memo: that case fails, the other four still pass.

The same file also pins referential equality when the day has not changed, so a future edit that drops the comparison and re-renders every consumer on each poll gets caught.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40361" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->