### PR TITLE
feat(design-library): give PanelItem a circle shape

### DIFF
--- a/clients/web/src/domains/chat/components/icon-tile.tsx
+++ b/clients/web/src/domains/chat/components/icon-tile.tsx
@@ -26,7 +26,10 @@ import { cn } from "@vellumai/design-library/utils/cn";
  */
 const SHAPE_CLASSES = {
   square: "rounded-[6px]",
-  round: "rounded-full",
+  /* The resting surface matches `PanelItem`'s pill and circle, so every
+     collapsed thing in the sidebar reads as the same kind of object whether
+     it came from a section or a nav entry. */
+  round: "rounded-full bg-[var(--surface-lift)]",
 } as const;
 
 export interface IconTileProps

--- a/packages/design-library/src/components/panel-item/panel-item.test.tsx
+++ b/packages/design-library/src/components/panel-item/panel-item.test.tsx
@@ -11,9 +11,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import { PanelItem } from "./panel-item";
 
-function renderRow(
-  trailingAction = createElement("button", {}, "⋯"),
-): string {
+function renderRow(trailingAction = createElement("button", {}, "⋯")): string {
   return renderToStaticMarkup(
     createElement(PanelItem, {
       label: "Row",
@@ -95,10 +93,7 @@ describe("PanelItem badge", () => {
 });
 
 describe("PanelItem shape", () => {
-  function renderShaped(
-    shape?: "row" | "pill",
-    className?: string,
-  ): string {
+  function renderShaped(shape?: "row" | "pill", className?: string): string {
     return renderToStaticMarkup(
       createElement(PanelItem, {
         label: "Row",
@@ -138,7 +133,9 @@ describe("PanelItem shape", () => {
 
   test("pill keeps the row's interaction treatment", () => {
     const html = renderShaped("pill");
-    expect(html).toContain("[@media(hover:hover)]:hover:bg-[var(--surface-hover)]");
+    expect(html).toContain(
+      "[@media(hover:hover)]:hover:bg-[var(--surface-hover)]",
+    );
     expect(html).toContain("aria-[current=page]:bg-[var(--surface-active)]");
   });
 
@@ -150,4 +147,3 @@ describe("PanelItem shape", () => {
     expect(html).not.toContain("bg-[var(--surface-lift)]");
   });
 });
-

--- a/packages/design-library/src/components/panel-item/panel-item.tsx
+++ b/packages/design-library/src/components/panel-item/panel-item.tsx
@@ -54,9 +54,14 @@ import { MarqueeText } from "./marquee-text";
  * - `"row"` (default): a full-width 6px-radius row, for lists and nav trees.
  * - `"pill"`: a capsule that hugs its content and carries a resting
  *   `--surface-lift` surface, for navigation chips that sit inline rather
- *   than filling a column. Everything else (hover, active, badge, trailing
- *   action, link/button semantics) is unchanged, which is the point: a pill
- *   is a differently-shaped row, not a different component.
+ *   than filling a column.
+ * - `"circle"`: that pill with its label dropped, for a collapsed rail. The
+ *   label stays the accessible name, so the control is the same one, just
+ *   without room to say so.
+ *
+ * Everything else (hover, active, badge, trailing action, link/button
+ * semantics) is unchanged at every shape, which is the point: these are
+ * differently-shaped rows, not different components.
  *
  * ### `activeVariant`
  *
@@ -116,9 +121,10 @@ interface PanelItemProps {
    * Row geometry.
    * - `"row"` fills its container at a 6px radius.
    * - `"pill"` hugs its content as a capsule on `--surface-lift`.
+   * - `"circle"` is that pill with its label dropped, for a collapsed rail.
    * @default "row"
    */
-  shape?: "row" | "pill";
+  shape?: "row" | "pill" | "circle";
   /** Selected state. Sets `aria-current="page"` automatically. */
   active?: boolean;
   /**
@@ -193,6 +199,17 @@ const INTERACTIVE_CLASSES = [
  */
 const PILL_SHAPE_CLASSES = [
   "w-fit rounded-full",
+  "bg-[var(--surface-lift)]",
+].join(" ");
+
+/**
+ * {@link PanelItemProps.shape} `"circle"`: the pill with its label dropped,
+ * so a collapsed sidebar is a column of circles rather than a different set
+ * of controls. Same surface, same states; only the label goes, and it stays
+ * the row's accessible name.
+ */
+const CIRCLE_SHAPE_CLASSES = [
+  "w-8 justify-center rounded-full",
   "bg-[var(--surface-lift)]",
 ].join(" ");
 
@@ -315,11 +332,12 @@ function PanelItem({
       />
     ) : null;
 
-  const labelNode = marqueeOnHover ? (
-    <MarqueeText>{label}</MarqueeText>
-  ) : (
-    <span className={LABEL_CLASSES}>{label}</span>
-  );
+  const labelNode =
+    shape === "circle" ? null : marqueeOnHover ? (
+      <MarqueeText>{label}</MarqueeText>
+    ) : (
+      <span className={LABEL_CLASSES}>{label}</span>
+    );
 
   const expandChevronNode = ExpandChevron ? (
     <ExpandChevron size={12} aria-hidden className={EXPAND_CHEVRON_CLASSES} />
@@ -373,6 +391,7 @@ function PanelItem({
     isInteractive && INTERACTIVE_CLASSES,
     activeClasses,
     shape === "pill" && PILL_SHAPE_CLASSES,
+    shape === "circle" && CIRCLE_SHAPE_CLASSES,
     className,
   );
 


### PR DESCRIPTION
## TL;DR

`PanelItem` is now **row / pill / circle**. A collapsed sidebar entry is the same control as an expanded one with no room for its label, so it is one component at a third shape rather than a second component.

Split out of #40359, which is being closed. This is the part of it worth keeping.

## What a circle is

The pill with its label dropped. The label stops rendering and becomes the accessible name, so assistive tech still hears "New Chat" on a bare circle. Surface, hover, active state, badge, trailing action, and link/button semantics are identical at all three shapes.

## Also

Round `IconTile` picks up the same resting surface. Collapsed-rail section tiles come from `CollapsedGroupIcon`, not `PanelItem`, so without this a collapsed sidebar mixes filled circles with transparent ones depending on which primitive drew them.

## What changes for the user

| | Before | After |
|---|---|---|
| Existing `PanelItem` call sites | Unchanged | Unchanged (`shape` defaults to `"row"`) |
| Collapsed rail tiles | Transparent until hover | Filled, matching pills and cards |
| Group-icon picker (square tiles) | Unchanged | Unchanged |

Additive: `shape` defaults to `"row"`, and the fill is scoped to `shape="round"` so the picker is untouched.

## Note on verification

Typecheck and lint are clean. Tests are **not** run locally under the current standing rule, so the added circle test is unverified by me — CI is the check.

Part of LUM-3061.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40366" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->