### PR TITLE
fix(tts): gate forwarded TTS language hints on provider-supported codes

### DIFF
--- a/assistant/src/tts/__tests__/provider-adapters.test.ts
+++ b/assistant/src/tts/__tests__/provider-adapters.test.ts
@@ -570,6 +570,24 @@ describe("ElevenLabs TTS provider adapter", () => {
     expect(body.language_code).toBe("hi");
   });
 
+  test("omits language_code for a language the v2.5 models do not support", async () => {
+    let capturedBody = "";
+
+    globalThis.fetch = mock(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        capturedBody = init?.body as string;
+        return new Response(streamOf(new Uint8Array([0x01])), { status: 200 });
+      },
+    ) as unknown as typeof globalThis.fetch;
+
+    const provider = createElevenLabsProvider();
+    await provider.synthesizeStream!(makeRequest({ language: "he" }), () => {});
+
+    const body = JSON.parse(capturedBody);
+    expect(body.model_id).toBe("eleven_flash_v2_5");
+    expect("language_code" in body).toBe(false);
+  });
+
   test("omits language_code when the configured model does not support enforcement", async () => {
     mockElevenLabsConfig.voiceModelId = "eleven_multilingual_v2";
     seedTtsConfig();
@@ -1752,10 +1770,28 @@ describe("xAI TTS provider adapter", () => {
     ) as unknown as typeof globalThis.fetch;
 
     const provider = createXaiProvider();
-    await provider.synthesize(makeRequest({ language: "es" }));
+    await provider.synthesize(makeRequest({ language: "hi" }));
 
     const body = JSON.parse(capturedBody);
-    expect(body.language).toBe("es");
+    expect(body.language).toBe("hi");
+  });
+
+  test("keeps configured language for a request code outside the code-switching roster", async () => {
+    const audioPayload = new Uint8Array([0x49, 0x44, 0x33]);
+    let capturedBody = "";
+
+    globalThis.fetch = mock(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        capturedBody = init?.body as string;
+        return new Response(audioPayload, { status: 200 });
+      },
+    ) as unknown as typeof globalThis.fetch;
+
+    const provider = createXaiProvider();
+    await provider.synthesize(makeRequest({ language: "th" }));
+
+    const body = JSON.parse(capturedBody);
+    expect(body.language).toBe("auto");
   });
 
   test("wav config format produces codec=wav without bit_rate", async () => {
@@ -1983,6 +2019,16 @@ describe("xAI TTS provider adapter", () => {
       );
 
       expect(capturedSocketOptions().url).toContain("language=es");
+    });
+
+    test("keeps configured language in the stream URL for an out-of-roster request code", async () => {
+      const provider = createXaiProvider();
+      await provider.synthesizeStream!(
+        makeRequest({ language: "th" }),
+        () => {},
+      );
+
+      expect(capturedSocketOptions().url).toContain("language=auto");
     });
 
     test("mp3 requests carry codec=mp3 and bit_rate and resolve audio/mpeg", async () => {

--- a/assistant/src/tts/providers/elevenlabs-provider.ts
+++ b/assistant/src/tts/providers/elevenlabs-provider.ts
@@ -180,6 +180,50 @@ const LANGUAGE_ENFORCEMENT_MODEL_IDS = new Set([
   "eleven_turbo_v2_5",
 ]);
 
+/**
+ * ISO 639-1 codes for the 32 languages the v2.5 flash/turbo models accept in
+ * `language_code` (per the ElevenLabs models documentation: the Multilingual
+ * v2 roster plus Hungarian, Norwegian, and Vietnamese; Filipino uses the
+ * ISO 639-2 code `fil` since 639-1 has none). The request-level language is
+ * a hint sourced from the wider STT roster, so codes outside this set are
+ * dropped rather than forwarded: ElevenLabs rejects unknown codes with a 400,
+ * which would fail every synthesis segment in a session.
+ */
+const ELEVENLABS_V2_5_LANGUAGE_CODES = new Set([
+  "en",
+  "ja",
+  "zh",
+  "de",
+  "hi",
+  "fr",
+  "ko",
+  "pt",
+  "it",
+  "es",
+  "id",
+  "nl",
+  "tr",
+  "fil",
+  "pl",
+  "sv",
+  "bg",
+  "ro",
+  "ar",
+  "cs",
+  "el",
+  "fi",
+  "hr",
+  "ms",
+  "sk",
+  "da",
+  "ta",
+  "uk",
+  "ru",
+  "hu",
+  "no",
+  "vi",
+]);
+
 /** ElevenLabs `pcm_*` rates available on every subscription tier. */
 const UNRESTRICTED_PCM_SAMPLE_RATES_HZ = [16_000, 22_050, 24_000] as const;
 
@@ -273,7 +317,11 @@ async function performTtsRequest(
       speed: config.speed,
     },
   };
-  if (request.language && LANGUAGE_ENFORCEMENT_MODEL_IDS.has(modelId)) {
+  if (
+    request.language &&
+    LANGUAGE_ENFORCEMENT_MODEL_IDS.has(modelId) &&
+    ELEVENLABS_V2_5_LANGUAGE_CODES.has(request.language)
+  ) {
     body.language_code = request.language;
   }
 

--- a/assistant/src/tts/providers/xai-provider.ts
+++ b/assistant/src/tts/providers/xai-provider.ts
@@ -11,6 +11,7 @@
 
 import { getConfig } from "../../config/loader.js";
 import type { TtsXaiProviderConfig } from "../../config/schemas/tts.js";
+import { DEEPGRAM_MULTI_LANGUAGE_CODES } from "../../providers/speech-to-text/deepgram.js";
 import { credentialKey } from "../../security/credential-key.js";
 import { getSecureKeyAsync } from "../../security/secure-keys.js";
 import { getLogger } from "../../util/logger.js";
@@ -149,12 +150,29 @@ function resolveVoiceId(
   return request.voiceId?.trim() || config.voiceId || "eve";
 }
 
-/** Resolve the synthesis language: request override > configured default. */
+/**
+ * Language codes a request-level hint may carry into the xAI API. xAI does
+ * not document a supported-language roster, so the hint is bounded by the
+ * Deepgram code-switching set: languages the STT layer detects are always in
+ * it, and only an out-of-roster `services.stt.language` pin can exceed it.
+ */
+const REQUEST_LANGUAGE_CODES: ReadonlySet<string> = new Set(
+  DEEPGRAM_MULTI_LANGUAGE_CODES,
+);
+
+/**
+ * Resolve the synthesis language: request override > configured default.
+ * A request language outside {@link REQUEST_LANGUAGE_CODES} is dropped in
+ * favor of the configured value (default "auto", which self-detects).
+ */
 function resolveLanguage(
   request: TtsSynthesisRequest,
   config: TtsXaiProviderConfig,
 ): string {
-  return request.language ?? config.language;
+  if (request.language && REQUEST_LANGUAGE_CODES.has(request.language)) {
+    return request.language;
+  }
+  return config.language;
 }
 
 /** Resolve the xAI API key, throwing `XAI_TTS_NO_API_KEY` when unset. */


### PR DESCRIPTION
## Summary
Fixes a review finding: an out-of-roster language pin could 400 every ElevenLabs synthesis (language_code had a model gate but no code gate) and override xAI auto-detection with unsupported codes. Hints are now allowlisted per provider.

Part of plan: voice-multilingual-pipeline.md (review remediation round 1)