### PR TITLE
fix(calls): pass detected or pinned language to telephony TTS

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -377,6 +377,8 @@ function setupController(
     requiresPcmAudio?: boolean;
     /** Simulate a transport that gates teardown on playback drain. */
     awaitPlaybackDrained?: () => Promise<void>;
+    /** Synthesis-language resolver, as the media-stream server wires it. */
+    resolveSynthesisLanguage?: () => string | undefined;
   },
 ) {
   ensureConversation("conv-ctrl-test");
@@ -400,6 +402,7 @@ function setupController(
   const controller = new CallController(session.id, transport, task ?? null, {
     assistantId: opts?.assistantId,
     trustContext: opts?.trustContext,
+    resolveSynthesisLanguage: opts?.resolveSynthesisLanguage,
   });
   return { session, relay: transport, controller };
 }
@@ -3466,6 +3469,47 @@ describe("call-controller", () => {
     // End-of-turn signal fires only after the synthesis chain drains.
     const lastToken = relay.sentTokens[relay.sentTokens.length - 1];
     expect(lastToken).toEqual({ token: "", last: true });
+
+    controller.destroy();
+  });
+
+  test("synthesized provider: the resolved language rides every segment's synthesis request", async () => {
+    const requestLanguages: Array<string | undefined> = [];
+    registerFishAudioSegmentRecorder({
+      onSynthesizeStream: async (_text, request) => {
+        requestLanguages.push(request.language);
+      },
+    });
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["Hola desde aqui. ", "Segunda frase."]),
+    );
+    const { controller } = setupController(undefined, {
+      resolveSynthesisLanguage: () => "es",
+    });
+
+    await controller.handleCallerUtterance("Hola");
+
+    expect(requestLanguages).toEqual(["es", "es"]);
+
+    controller.destroy();
+  });
+
+  test("synthesized provider: no language on the request when nothing resolves", async () => {
+    const requestLanguages: Array<string | undefined> = [];
+    registerFishAudioSegmentRecorder({
+      onSynthesizeStream: async (_text, request) => {
+        requestLanguages.push(request.language);
+      },
+    });
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["Hello from here."]),
+    );
+    // Default resolver + default config (multilingual STT pin): no hint.
+    const { controller } = setupController();
+
+    await controller.handleCallerUtterance("Hi");
+
+    expect(requestLanguages).toEqual([undefined]);
 
     controller.destroy();
   });

--- a/assistant/src/__tests__/media-stream-output.test.ts
+++ b/assistant/src/__tests__/media-stream-output.test.ts
@@ -26,6 +26,7 @@ import {
 } from "../calls/media-stream-audio-transcode.js";
 import { MediaStreamOutput } from "../calls/media-stream-output.js";
 import { resolveCallTtsProvider } from "../calls/resolve-call-tts-provider.js";
+import { setConfig } from "./helpers/set-config.js";
 
 const mockResolveCallTtsProvider = resolveCallTtsProvider as ReturnType<
   typeof jest.fn
@@ -1210,6 +1211,76 @@ describe("MediaStreamOutput", () => {
         "Let me take a look at that,",
         "Here is the second answer,",
       ]);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Synthesis language hint
+  // ---------------------------------------------------------------------------
+
+  describe("synthesis language hint", () => {
+    /** Synthesize one turn and return the provider request it produced. */
+    async function synthesizeOneTurn(
+      output: MediaStreamOutput,
+    ): Promise<{ language?: string }> {
+      mockSynthesize.mockResolvedValue({
+        audio: makeWavBuffer([1000, 2000, 3000, 4000]),
+        contentType: "audio/wav",
+      });
+      output.sendTextToken("Hello caller.", true);
+      await drain(() => mockSynthesize.mock.calls.length > 0);
+      return mockSynthesize.mock.calls[0][0] as { language?: string };
+    }
+
+    test("the resolver's language rides the provider request", async () => {
+      const { ws } = createMockWs();
+      const output = makeOutput(ws, "stream-lang");
+      output.setSynthesisLanguageResolver(() => "es");
+
+      const request = await synthesizeOneTurn(output);
+
+      expect(request.language).toBe("es");
+    });
+
+    test("no language when nothing resolves (default multilingual pin)", async () => {
+      const { ws } = createMockWs();
+      const output = makeOutput(ws, "stream-lang");
+
+      const request = await synthesizeOneTurn(output);
+
+      expect(request.language).toBeUndefined();
+    });
+
+    test("a monolingual pin on a manual-selection provider resolves as the hint", async () => {
+      setConfig("services", {
+        stt: { provider: "deepgram", language: "es-ES" },
+      });
+      try {
+        const { ws } = createMockWs();
+        const output = makeOutput(ws, "stream-lang");
+
+        const request = await synthesizeOneTurn(output);
+
+        expect(request.language).toBe("es");
+      } finally {
+        setConfig("services", {});
+      }
+    });
+
+    test("the pin is ignored for auto-detecting providers", async () => {
+      setConfig("services", {
+        stt: { provider: "openai-whisper", language: "es" },
+      });
+      try {
+        const { ws } = createMockWs();
+        const output = makeOutput(ws, "stream-lang");
+
+        const request = await synthesizeOneTurn(output);
+
+        expect(request.language).toBeUndefined();
+      } finally {
+        setConfig("services", {});
+      }
     });
   });
 

--- a/assistant/src/__tests__/media-stream-stt-session.test.ts
+++ b/assistant/src/__tests__/media-stream-stt-session.test.ts
@@ -897,6 +897,49 @@ describe("MediaStreamSttSession", () => {
       session.dispose();
     });
 
+    // ── Detected-language tally ─────────────────────────────────────
+
+    test("tallies committed finals' dominant language and reports the session dominant", async () => {
+      const { session, fake } = await startStreamingSession();
+
+      expect(session.dominantLanguage()).toBeUndefined();
+
+      fake.emit({ type: "final", text: "hola", languages: ["es", "en"] });
+      fake.emit({ type: "final", text: "hello", languages: ["en"] });
+      fake.emit({ type: "final", text: "buenos dias", languages: ["es"] });
+
+      // Two dominant-tag votes for "es" beat one for "en"; the secondary
+      // "en" tag on the first final casts no vote.
+      expect(session.dominantLanguage()).toBe("es");
+
+      session.dispose();
+    });
+
+    test("regional variants tally toward their base subtag", async () => {
+      const { session, fake } = await startStreamingSession();
+
+      fake.emit({ type: "final", text: "tudo bem", languages: ["pt-BR"] });
+
+      expect(session.dominantLanguage()).toBe("pt");
+
+      session.dispose();
+    });
+
+    test("empty and untagged finals never vote", async () => {
+      const { session, fake } = await startStreamingSession();
+
+      // A silence final can carry container-level tags describing no
+      // emitted words; it must not vote.
+      fake.emit({ type: "final", text: "   ", languages: ["fr"] });
+      expect(session.dominantLanguage()).toBeUndefined();
+
+      // A committed final without tags casts no vote either.
+      fake.emit({ type: "final", text: "hello" });
+      expect(session.dominantLanguage()).toBeUndefined();
+
+      session.dispose();
+    });
+
     test("local VAD turn end never triggers batch transcription in streaming mode", async () => {
       const onTranscriptFinal = jest.fn();
       const { session } = await startStreamingSession(

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -65,6 +65,7 @@ import {
   resolveSynthesisFormats,
 } from "./resolve-call-tts-provider.js";
 import type { PromptSpeakerContext } from "./speaker-identification.js";
+import { resolveTelephonySynthesisLanguage } from "./telephony-synthesis-language.js";
 import { sanitizeForTts } from "./tts-text-sanitizer.js";
 import {
   ASK_GUARDIAN_CAPTURE_REGEX,
@@ -189,6 +190,13 @@ export class CallController {
   private guardianUnavailableForCall = false;
   /** Active synthesized-TTS session — tracked so interrupt handling can close it. */
   private activeSynthesisAbort: AbortController | null = null;
+  /**
+   * Resolves the language hint for synthesized speech. The media-stream
+   * server supplies a resolver backed by the STT session's detected
+   * dominant language; the default falls back to the pin-based
+   * resolution only.
+   */
+  private resolveSynthesisLanguage: () => string | undefined;
 
   constructor(
     callSessionId: string,
@@ -198,6 +206,7 @@ export class CallController {
       broadcast?: (msg: AssistantEvent) => void;
       assistantId?: string;
       trustContext?: TrustContext;
+      resolveSynthesisLanguage?: () => string | undefined;
     },
   ) {
     this.callSessionId = callSessionId;
@@ -207,6 +216,9 @@ export class CallController {
     this.broadcast = opts?.broadcast;
     this.assistantId = opts?.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID;
     this.trustContext = opts?.trustContext ?? null;
+    this.resolveSynthesisLanguage =
+      opts?.resolveSynthesisLanguage ??
+      (() => resolveTelephonySynthesisLanguage());
 
     // Resolve the conversation ID and skipDisclosure from the call session
     const session = getCallSession(callSessionId);
@@ -1080,11 +1092,13 @@ export class CallController {
 
       this.activeSynthesisAbort = abortController;
 
+      const language = this.resolveSynthesisLanguage();
       await synthesizeAndEmit({
         provider,
         text,
         useCase: "phone-call",
         outputFormat,
+        ...(language !== undefined ? { language } : {}),
         signal: abortController.signal,
         isCurrent: () => this.isCurrentRun(runVersion),
         onChunk: sink.onChunk,

--- a/assistant/src/calls/call-speech-output.ts
+++ b/assistant/src/calls/call-speech-output.ts
@@ -30,6 +30,7 @@ import {
   resolveCallTtsProvider,
   resolveSynthesisFormats,
 } from "./resolve-call-tts-provider.js";
+import { resolveTelephonySynthesisLanguage } from "./telephony-synthesis-language.js";
 
 const log = getLogger("call-speech-output");
 
@@ -128,11 +129,15 @@ async function synthesizeAndPlay(
       },
     });
 
+    // No STT session is reachable from the deterministic prompt path, so
+    // only the pin-based language resolves here.
+    const language = resolveTelephonySynthesisLanguage();
     const result = await synthesizeAndEmit({
       provider,
       text,
       useCase: "phone-call",
       outputFormat,
+      ...(language !== undefined ? { language } : {}),
       signal,
       onChunk: sink.onChunk,
       onFirstAudio: sink.onFirstAudio,

--- a/assistant/src/calls/media-stream-output.ts
+++ b/assistant/src/calls/media-stream-output.ts
@@ -54,6 +54,7 @@ import type {
   MediaStreamSendMediaCommand,
 } from "./media-stream-protocol.js";
 import { resolveCallTtsProvider } from "./resolve-call-tts-provider.js";
+import { resolveTelephonySynthesisLanguage } from "./telephony-synthesis-language.js";
 
 const log = getLogger("media-stream-output");
 
@@ -338,6 +339,15 @@ export class MediaStreamOutput implements CallTransport {
    */
   private audioStartCallback: (() => void) | null = null;
 
+  /**
+   * Resolves the language hint passed on synthesis requests. Defaults to
+   * the pin-based resolution; the media-stream server overrides it with
+   * a resolver that consults the STT session's detected dominant
+   * language.
+   */
+  private resolveSynthesisLanguage: () => string | undefined = () =>
+    resolveTelephonySynthesisLanguage();
+
   /** Incremented per end-of-turn mark enqueued. */
   private enqueuedEndOfTurnSeq = 0;
 
@@ -425,6 +435,14 @@ export class MediaStreamOutput implements CallTransport {
    */
   setAudioStartCallback(cb: (() => void) | null): void {
     this.audioStartCallback = cb;
+  }
+
+  /**
+   * Override the synthesis-language resolver (see
+   * {@link resolveSynthesisLanguage}).
+   */
+  setSynthesisLanguageResolver(resolver: () => string | undefined): void {
+    this.resolveSynthesisLanguage = resolver;
   }
 
   /**
@@ -876,12 +894,14 @@ export class MediaStreamOutput implements CallTransport {
       // Providers that support it (e.g. ElevenLabs pcm_16000) will
       // return raw PCM; others fall back to their default format and
       // the content-type sniffing below handles the mismatch.
+      const language = this.resolveSynthesisLanguage();
       const result = await synthesizeAndEmit({
         provider,
         text,
         useCase: "phone-call",
         outputFormat: "pcm",
         sampleRateHz: STREAMING_PCM_SAMPLE_RATE_HZ,
+        ...(language !== undefined ? { language } : {}),
         signal: abortController.signal,
         isCurrent,
         onChunk: (chunk) => {

--- a/assistant/src/calls/media-stream-server.ts
+++ b/assistant/src/calls/media-stream-server.ts
@@ -81,6 +81,7 @@ import {
   type MediaStreamSttSessionCallbacks,
   type MediaStreamSttSessionConfig,
 } from "./media-stream-stt-session.js";
+import { resolveTelephonySynthesisLanguage } from "./telephony-synthesis-language.js";
 import {
   TRUST_UNAVAILABLE_DENY_MESSAGE,
   unresolvedActorTrust,
@@ -215,6 +216,12 @@ export class MediaStreamCallSession {
     };
 
     this.sttSession = new MediaStreamSttSession(sttConfig ?? {}, callbacks);
+
+    // Synthesized speech follows the caller's detected language when the
+    // transcriber tags finals, falling back to the pin-based resolution.
+    this.output.setSynthesisLanguageResolver(() =>
+      resolveTelephonySynthesisLanguage(this.sttSession.dominantLanguage()),
+    );
 
     log.info({ callSessionId }, "Media stream call session created");
   }
@@ -681,6 +688,8 @@ export class MediaStreamCallSession {
       {
         assistantId: result.assistantId,
         trustContext: result.trustContext,
+        resolveSynthesisLanguage: () =>
+          resolveTelephonySynthesisLanguage(this.sttSession.dominantLanguage()),
       },
     );
     this.controller = controller;

--- a/assistant/src/calls/media-stream-stt-session.ts
+++ b/assistant/src/calls/media-stream-stt-session.ts
@@ -42,6 +42,10 @@ import {
   type TelephonySttCapability,
 } from "../providers/speech-to-text/resolve.js";
 import { normalizeSttError } from "../stt/daemon-batch-transcriber.js";
+import {
+  dominantLanguageTag,
+  voteDominantLanguage,
+} from "../stt/language-metadata.js";
 import { DEFAULT_SPEECH_ENERGY_THRESHOLD } from "../stt/speech-energy.js";
 import type {
   StreamingTranscriber,
@@ -220,6 +224,16 @@ export class MediaStreamSttSession {
   /** Speech-bearing audio milliseconds since the last streaming final. */
   private utteranceAudioMs = 0;
 
+  /**
+   * Count per normalized detected-language tag across the session's
+   * committed streaming finals. Only finals that carry transcript text
+   * vote, mirroring live voice's utterance tally: silence finals can
+   * carry container-level tags describing no emitted words, and counting
+   * those would let silence outvote real speech. Batch transcription
+   * reports no language tags, so the tally stays empty there.
+   */
+  private languageTally = new Map<string, number>();
+
   constructor(
     config: MediaStreamSttSessionConfig = {},
     callbacks: MediaStreamSttSessionCallbacks = {},
@@ -302,6 +316,16 @@ export class MediaStreamSttSession {
   /** Frames dropped from the bounded streaming startup buffer. */
   get streamingStartupFramesDropped(): number {
     return this.startupFramesDroppedCount;
+  }
+
+  /**
+   * The caller's dominant detected language across this session's
+   * committed streaming finals, as a lowercase base subtag. Undefined
+   * when no tagged final has committed (batch mode, non-tagging
+   * providers, silence).
+   */
+  dominantLanguage(): string | undefined {
+    return dominantLanguageTag(this.languageTally);
   }
 
   // ── Event handlers ─────────────────────────────────────────────────
@@ -515,6 +539,7 @@ export class MediaStreamSttSession {
         this.utteranceAudioMs = 0;
         const text = event.text.trim();
         if (text.length > 0) {
+          voteDominantLanguage(this.languageTally, event.languages);
           this.callbacks.onTranscriptFinal?.(text, durationMs);
         }
         return;

--- a/assistant/src/calls/telephony-synthesis-language.ts
+++ b/assistant/src/calls/telephony-synthesis-language.ts
@@ -1,0 +1,59 @@
+/**
+ * Synthesis-language resolution for telephony TTS.
+ *
+ * The telephony call-control prompt instructs the model to speak the
+ * caller's language; this resolver produces the matching TTS hint so
+ * providers that can enforce a language render the reply in it (the hint
+ * is a no-op for providers that cannot). Resolution mirrors live voice's
+ * turn language (live-voice-session.ts): the dominant STT-detected
+ * language when the transcriber tags finals, else a monolingual
+ * `services.stt.language` pin when the configured provider honors manual
+ * language selection, else undefined (no hint, provider default behavior).
+ */
+
+import { getConfig } from "../config/loader.js";
+import { getProviderEntry } from "../providers/speech-to-text/provider-catalog.js";
+import { normalizeLanguageTag } from "../stt/language-metadata.js";
+import type { SttProviderId } from "../stt/types.js";
+
+/**
+ * Resolve the language hint for telephony synthesis as a lowercase base
+ * subtag, or undefined when no signal resolves.
+ *
+ * @param detectedLanguage - The STT session's detected dominant caller
+ *   language, when a session is reachable from the call site. Wins over
+ *   the pin whenever it normalizes to a non-empty tag.
+ */
+export function resolveTelephonySynthesisLanguage(
+  detectedLanguage?: string,
+): string | undefined {
+  if (detectedLanguage !== undefined) {
+    const normalized = normalizeLanguageTag(detectedLanguage);
+    if (normalized) {
+      return normalized;
+    }
+  }
+
+  let stt: { provider: string; language?: string };
+  try {
+    stt = getConfig().services.stt;
+  } catch {
+    // Config unavailable (early startup, minimal test workspaces): no hint.
+    return undefined;
+  }
+
+  // A persisted pin only counts when the configured provider honors manual
+  // language selection: auto-detecting providers (gemini, whisper) ignore
+  // the setting entirely, so treating it as the caller's language would
+  // force every call into a stale pin. Same gate as the pre-speech prompt
+  // rule (voice-session-bridge.ts) and live voice's turnLanguageFor.
+  const providerHonorsLanguagePin =
+    getProviderEntry(stt.provider as SttProviderId)?.languageSelection ===
+    "manual";
+  const configured = stt.language?.trim();
+  if (!providerHonorsLanguagePin || !configured || configured === "multi") {
+    return undefined;
+  }
+  const normalized = normalizeLanguageTag(configured);
+  return normalized || undefined;
+}

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -52,7 +52,11 @@ import {
 import type { ResolveStreamingTranscriberOptions } from "../providers/speech-to-text/resolve.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { publishConversationListAndMetadataChanged } from "../runtime/sync/resource-sync-events.js";
-import { normalizeLanguageTag } from "../stt/language-metadata.js";
+import {
+  dominantLanguageTag,
+  normalizeLanguageTag,
+  voteDominantLanguage,
+} from "../stt/language-metadata.js";
 import { detectPcm16SpeechActivity } from "../stt/speech-energy.js";
 import type {
   StreamingTranscriber,
@@ -3420,17 +3424,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // Tally only finals that committed transcript: empty silence frames
       // can still carry container-level language tags describing no emitted
       // words, and counting those would let silence outvote real speech
-      // (same choice as the adapter's boundary-final aggregation). Each
-      // final casts one vote, for its dominant language only: `languages`
-      // is dominance-ranked, so giving secondary tags full votes would let
-      // a minority language outvote the utterance's dominant one.
-      const dominant = normalizeLanguageTag(languages?.[0] ?? "");
-      if (dominant) {
-        utterance.languageTally.set(
-          dominant,
-          (utterance.languageTally.get(dominant) ?? 0) + 1,
-        );
-      }
+      // (same choice as the adapter's boundary-final aggregation).
+      voteDominantLanguage(utterance.languageTally, languages);
     }
     // The final commits (and supersedes) whatever partial was trailing it.
     utterance.latestPartialText = null;
@@ -3500,14 +3495,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
    * non-tagging providers, silence).
    */
   private turnLanguageFor(utterance: UtteranceCycle): string | undefined {
-    let dominant: string | undefined;
-    let dominantCount = 0;
-    for (const [tag, count] of utterance.languageTally) {
-      if (count > dominantCount) {
-        dominant = tag;
-        dominantCount = count;
-      }
-    }
+    const dominant = dominantLanguageTag(utterance.languageTally);
     if (dominant !== undefined) {
       return dominant;
     }

--- a/assistant/src/stt/language-metadata.ts
+++ b/assistant/src/stt/language-metadata.ts
@@ -15,6 +15,42 @@ export function normalizeLanguageTag(tag: string): string {
 }
 
 /**
+ * Cast one vote into a language tally for a transcript chunk's dominant
+ * detected language. `languages` is dominance-ranked, so only the first
+ * entry votes: secondary tags at full weight would let a minority
+ * language outvote the dominant one. Blank and absent tags cast no vote;
+ * regional variants count toward their base subtag.
+ */
+export function voteDominantLanguage(
+  tally: Map<string, number>,
+  languages: readonly string[] | undefined,
+): void {
+  const dominant = normalizeLanguageTag(languages?.[0] ?? "");
+  if (dominant) {
+    tally.set(dominant, (tally.get(dominant) ?? 0) + 1);
+  }
+}
+
+/**
+ * The dominant tag in a language tally: most votes wins, ties break by
+ * first insertion (Map iteration is insertion order). Undefined for an
+ * empty tally.
+ */
+export function dominantLanguageTag(
+  tally: ReadonlyMap<string, number>,
+): string | undefined {
+  let dominant: string | undefined;
+  let dominantCount = 0;
+  for (const [tag, count] of tally) {
+    if (count > dominantCount) {
+      dominant = tag;
+      dominantCount = count;
+    }
+  }
+  return dominant;
+}
+
+/**
  * Tally normalized language tags and return them most-frequent-first.
  * Ties are broken by first appearance in the input. Blank tags are
  * skipped; regional variants count toward their base subtag.


### PR DESCRIPTION
## Summary
Review remediation: telephony prompts demand caller-language replies but synthesis carried no language hint. Media-stream STT now tallies detected languages (dominant-only voting like live voice) and telephony synthesis passes the detected or provider-gated pinned language, no-oping when unknown.

Part of plan: voice-multilingual-pipeline.md (review remediation round 1)