### PR TITLE
Companion surface: Talk starts a live-voice session

### DIFF
--- a/clients/macos/src/main/commands.ts
+++ b/clients/macos/src/main/commands.ts
@@ -46,6 +46,7 @@ export const DEFAULT_ACCELERATORS: Record<VellumCommandKind, string> = {
   retireAssistant: "",
   removePairedAssistant: "",
   quickInputSubmit: "",
+  startVoice: "",
   cancelDictation: "",
   replayOnboarding: "",
   replayHatchFailure: "",

--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -1,6 +1,23 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 
-import { anchorFor } from "./companion-window";
+// The module under test reaches `main-window.ts` to hand Talk to the renderer
+// that owns the live-voice session, and that chain loads `electron-store`, a
+// real module that imports the Electron binary's default export and cannot
+// resolve off-Electron. Only the import chain needs satisfying here: these
+// cases exercise the anchor, which touches no store. Same shape as
+// `voice-activity-window.test.ts`, which mocks it for the same reason.
+mock.module("electron-store", () => ({
+  default: class {
+    get(_key: string, fallback?: unknown) {
+      return fallback;
+    }
+    set() {}
+  },
+}));
+
+// Dynamic, so the mock above is installed before the module graph loads:
+// static imports hoist above it.
+const { anchorFor } = await import("./companion-window");
 
 /**
  * The anchor is the only rule in the companion window worth testing without a

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -6,7 +6,11 @@ import type { CompanionAnchor, CompanionSurfaceState } from "@vellumai/ipc-contr
 import { getAvatarPng, onAvatarChange } from "./avatar";
 import { createFloatingWindow, getFloatingWindow } from "./floating-window";
 import { handle, on } from "./ipc";
-import { dispatchToMain } from "./main-window";
+import {
+  current as currentMainWindow,
+  dispatchToMain,
+  ensureVisible as ensureMainWindowVisible,
+} from "./main-window";
 
 /**
  * The always-present companion surface (LUM-3086): the assistant's avatar
@@ -210,12 +214,25 @@ export const installCompanionWindow = (): void => {
    * window and no other, and the press arrives while the user is working in
    * some other app entirely, so "focused" would name the wrong target.
    *
-   * The window is not raised. A user reaching for a floating avatar has chosen
-   * not to go back to Vellum, and the session gets its own on-screen readout
-   * from the voice-activity panel.
+   * **A window that exists is not raised, and one that does not is created.**
+   * A user reaching for a floating avatar has chosen not to go back to Vellum,
+   * and the session gets its own on-screen readout from the voice-activity
+   * panel, so an existing window is left exactly where it was. But closing the
+   * main window destroys it while this surface stays on screen, and a command
+   * dispatched into that gap lands nowhere: Talk would read as broken. There is
+   * no way to host a session without a renderer to host it in, so that case
+   * builds one, which necessarily shows it.
    */
   on("vellum:companion:startVoice", z.tuple([]), () => {
-    dispatchToMain({ kind: "startVoice" });
+    if (currentMainWindow() !== null) {
+      dispatchToMain({ kind: "startVoice" });
+      return;
+    }
+    // Resolves once the renderer has loaded and the window has shown, so the
+    // command arrives at a page that can receive it.
+    void ensureMainWindowVisible().then(() => {
+      dispatchToMain({ kind: "startVoice" });
+    });
   });
 
   // One avatar feeds every surface, so a change to the Dock icon is a change

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -6,6 +6,7 @@ import type { CompanionAnchor, CompanionSurfaceState } from "@vellumai/ipc-contr
 import { getAvatarPng, onAvatarChange } from "./avatar";
 import { createFloatingWindow, getFloatingWindow } from "./floating-window";
 import { handle, on } from "./ipc";
+import { dispatchToMain } from "./main-window";
 
 /**
  * The always-present companion surface (LUM-3086): the assistant's avatar
@@ -198,6 +199,24 @@ export const installCompanionWindow = (): void => {
       win.setPosition(Math.round(x + dx), Math.round(y + dy));
     },
   );
+
+  /**
+   * Talk, delivered to the renderer that can act on it.
+   *
+   * The surface is its own renderer and holds no live-voice session, so the
+   * press travels through main the way the voice panel's controls do. It goes
+   * to the main window rather than the focused one, and rather than to every
+   * window: the session lives where `ChatLayout` is mounted, which is that
+   * window and no other, and the press arrives while the user is working in
+   * some other app entirely, so "focused" would name the wrong target.
+   *
+   * The window is not raised. A user reaching for a floating avatar has chosen
+   * not to go back to Vellum, and the session gets its own on-screen readout
+   * from the voice-activity panel.
+   */
+  on("vellum:companion:startVoice", z.tuple([]), () => {
+    dispatchToMain({ kind: "startVoice" });
+  });
 
   // One avatar feeds every surface, so a change to the Dock icon is a change
   // here too.

--- a/clients/macos/src/preload/index.ts
+++ b/clients/macos/src/preload/index.ts
@@ -639,6 +639,9 @@ const bridge: VellumBridge = {
     moveBy: (dx: number, dy: number): void => {
       ipcRenderer.send("vellum:companion:moveBy", dx, dy);
     },
+    startVoice: (): void => {
+      ipcRenderer.send("vellum:companion:startVoice");
+    },
   },
   popout: {
     open: (conversationId: string): Promise<void> =>

--- a/clients/web/src/components/companion-surface-page.tsx
+++ b/clients/web/src/components/companion-surface-page.tsx
@@ -8,6 +8,7 @@ import {
   getCompanionState,
   moveCompanionBy,
   setCompanionInteractive,
+  startCompanionVoice,
   subscribeCompanionState,
 } from "@/runtime/companion-surface";
 import type { CompanionAnchor } from "@vellumai/ipc-contract";
@@ -140,6 +141,11 @@ export function CompanionSurfacePage() {
         onSurfaceMouseDown={(event) => {
           dragRef.current = { x: event.screenX, y: event.screenY };
         }}
+        // The press leaves this window immediately: the session lives in the
+        // renderer holding the chat layout, and this page only asks for one.
+        // Nothing here changes as a result, which is what makes the
+        // voice-activity panel the visible answer for now.
+        onTalk={startCompanionVoice}
       />
     </div>
   );

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -216,6 +216,11 @@ export interface CompanionSurfaceProps {
    */
   spotlight?: "talk" | "type";
   /**
+   * Start a live-voice session. Absent leaves Talk inert, which is what
+   * Storybook wants: there is no session to start there.
+   */
+  onTalk?: () => void;
+  /**
    * When the call started, for the elapsed clock. Absent leaves the clock at a
    * fixed sample, which is what the static stories want.
    */
@@ -235,6 +240,7 @@ export function CompanionSurface({
   rootRef,
   onSurfaceMouseDown,
   spotlight,
+  onTalk,
   callStartedAt,
 }: CompanionSurfaceProps) {
   const expanded = phase !== "resting";
@@ -372,7 +378,7 @@ export function CompanionSurface({
             {phase === "call" ? (
               <CallBody startedAt={callStartedAt} />
             ) : (
-              <IdleBody spotlight={spotlight} />
+              <IdleBody spotlight={spotlight} onTalk={onTalk} />
             )}
           </div>
         )}
@@ -521,7 +527,13 @@ function Avatar({
  * of one choice about how to say something, and a verb pair reads as that where
  * a verb and a question word do not.
  */
-function IdleBody({ spotlight }: { spotlight?: "talk" | "type" }) {
+function IdleBody({
+  spotlight,
+  onTalk,
+}: {
+  spotlight?: "talk" | "type";
+  onTalk?: () => void;
+}) {
   return (
     <>
       <PillButton
@@ -529,6 +541,7 @@ function IdleBody({ spotlight }: { spotlight?: "talk" | "type" }) {
         label="Talk"
         showLabel
         active={spotlight === "talk"}
+        onClick={onTalk}
       />
       <PillButton
         icon={<Keyboard className="size-4" />}
@@ -614,6 +627,7 @@ function PillButton({
   tone,
   showLabel = false,
   active = false,
+  onClick,
 }: {
   icon: ReactNode;
   label: string;
@@ -621,12 +635,14 @@ function PillButton({
   showLabel?: boolean;
   /** Held down, for a control whose surface is currently open. */
   active?: boolean;
+  onClick?: () => void;
 }) {
   return (
     <button
       type="button"
       aria-label={label}
       title={label}
+      onClick={onClick}
       // A press on a control is not the start of a drag. Without this the
       // surface would move under a click meant to activate something on it.
       onMouseDown={(event) => {

--- a/clients/web/src/domains/chat/voice/live-voice/start-voice-request.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/start-voice-request.test.ts
@@ -28,9 +28,9 @@ mock.module("@/lib/backwards-compat/utils", () => ({
 
 const {
   PENDING_VOICE_START_TTL_MS,
-  drainPendingVoiceStartDeepLink,
-  requestVoiceStartFromDeepLink,
-} = await import("@/domains/chat/voice/live-voice/start-voice-deep-link");
+  drainPendingVoiceStart,
+  requestVoiceStart,
+} = await import("@/domains/chat/voice/live-voice/start-voice-request");
 const { useLiveVoiceStore } = await import(
   "@/domains/chat/voice/live-voice/live-voice-store"
 );
@@ -100,7 +100,7 @@ describe("starting a session", () => {
     identityHydrated();
     registerStarter();
 
-    requestVoiceStartFromDeepLink();
+    requestVoiceStart();
     await Promise.resolve();
     await Promise.resolve();
 
@@ -114,14 +114,14 @@ describe("starting a session", () => {
     identityHydrated();
 
     // No `ChatLayout` yet: the drain no-ops and the request stays parked.
-    requestVoiceStartFromDeepLink();
+    requestVoiceStart();
     await Promise.resolve();
     expect(starter).not.toHaveBeenCalled();
     expect(isParked()).toBe(true);
 
     // The controller mounts and drains, exactly as it does on registration.
     registerStarter();
-    await drainPendingVoiceStartDeepLink();
+    await drainPendingVoiceStart();
 
     expect(starter).toHaveBeenCalledWith("assistant-1", null);
     expect(isParked()).toBe(false);
@@ -131,7 +131,7 @@ describe("starting a session", () => {
     identityHydrated();
     registerStarter();
 
-    await drainPendingVoiceStartDeepLink();
+    await drainPendingVoiceStart();
 
     expect(whenAssistantVersionKnown).not.toHaveBeenCalled();
     expect(starter).not.toHaveBeenCalled();
@@ -151,15 +151,15 @@ describe("a request that cannot be served yet stays parked", () => {
     useResolvedAssistantsStore.setState({ activeAssistantId: "assistant-1" });
     registerStarter();
 
-    requestVoiceStartFromDeepLink();
-    await drainPendingVoiceStartDeepLink();
+    requestVoiceStart();
+    await drainPendingVoiceStart();
 
     expect(starter).not.toHaveBeenCalled();
     expect(isParked()).toBe(true);
 
     // The identity lands and the next drain runs it.
     identityHydrated();
-    await drainPendingVoiceStartDeepLink();
+    await drainPendingVoiceStart();
     expect(starter).toHaveBeenCalledWith("assistant-1", null);
   });
 
@@ -173,7 +173,7 @@ describe("a request that cannot be served yet stays parked", () => {
     });
 
     usePendingDeepLinkStore.getState().setPendingVoiceStart();
-    const drained = drainPendingVoiceStartDeepLink();
+    const drained = drainPendingVoiceStart();
     // Navigating off the chat layout mid-await: there is no starter left to
     // hand this to.
     useLiveVoiceStore.getState().setStarter(null);
@@ -186,7 +186,7 @@ describe("a request that cannot be served yet stays parked", () => {
     // The next `ChatLayout` mount picks it up.
     versionResolution = Promise.resolve();
     registerStarter();
-    await drainPendingVoiceStartDeepLink();
+    await drainPendingVoiceStart();
     expect(starter).toHaveBeenCalledWith("assistant-1", null);
   });
 });
@@ -203,8 +203,8 @@ describe("a request that will never be served is discarded", () => {
     identityHydrated("0.10.11");
     registerStarter();
 
-    requestVoiceStartFromDeepLink();
-    await drainPendingVoiceStartDeepLink();
+    requestVoiceStart();
+    await drainPendingVoiceStart();
 
     expect(starter).not.toHaveBeenCalled();
     expect(isParked()).toBe(false);
@@ -220,7 +220,7 @@ describe("a request that will never be served is discarded", () => {
     usePendingDeepLinkStore.setState({
       pendingVoiceStartAt: Date.now() - PENDING_VOICE_START_TTL_MS - 1,
     });
-    await drainPendingVoiceStartDeepLink();
+    await drainPendingVoiceStart();
 
     expect(starter).not.toHaveBeenCalled();
     expect(isParked()).toBe(false);
@@ -233,7 +233,7 @@ describe("a request that will never be served is discarded", () => {
     usePendingDeepLinkStore.setState({
       pendingVoiceStartAt: Date.now() - PENDING_VOICE_START_TTL_MS + 5_000,
     });
-    await drainPendingVoiceStartDeepLink();
+    await drainPendingVoiceStart();
 
     expect(starter).toHaveBeenCalledWith("assistant-1", null);
   });
@@ -248,10 +248,10 @@ describe("one-shot delivery", () => {
     identityHydrated();
     registerStarter();
 
-    requestVoiceStartFromDeepLink();
-    await drainPendingVoiceStartDeepLink();
-    await drainPendingVoiceStartDeepLink();
-    await drainPendingVoiceStartDeepLink();
+    requestVoiceStart();
+    await drainPendingVoiceStart();
+    await drainPendingVoiceStart();
+    await drainPendingVoiceStart();
 
     expect(starter).toHaveBeenCalledTimes(1);
   });
@@ -259,12 +259,12 @@ describe("one-shot delivery", () => {
   test("two links before a drain are one request", async () => {
     identityHydrated();
 
-    requestVoiceStartFromDeepLink();
-    requestVoiceStartFromDeepLink();
+    requestVoiceStart();
+    requestVoiceStart();
     await Promise.resolve();
 
     registerStarter();
-    await drainPendingVoiceStartDeepLink();
+    await drainPendingVoiceStart();
 
     expect(starter).toHaveBeenCalledTimes(1);
   });

--- a/clients/web/src/domains/chat/voice/live-voice/start-voice-request.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/start-voice-request.ts
@@ -1,18 +1,21 @@
 /**
- * Start-voice deep link → live-voice session.
+ * "The user asked to talk" → live-voice session.
  *
- * The seam between the host-agnostic deep-link consumer
- * (`useGlobalDeepLinkConsumer`, mounted at `RootLayout`) and the live-voice
- * domain. The consumer knows only "the user asked to talk"; everything about
- * *how* a session starts lives here.
+ * The seam between the surfaces that can ask for a session from outside the
+ * chat layout and the live-voice domain. Two ask today: the host-agnostic
+ * deep-link consumer (`useGlobalDeepLinkConsumer`, mounted at `RootLayout`) and
+ * the macOS companion surface's Talk, which arrives as a `startVoice` command
+ * from the Electron host. Neither knows anything about sessions; everything
+ * about *how* one starts lives here, so the two cannot drift into two ideas of
+ * what talking means.
  *
  * Why a parked request instead of a direct call: the session `starter` is
  * registered by `useLiveVoiceSessionController`, which is mounted at
  * `ChatLayout` scope. On a cold launch (Siri, the Action Button, a Live
  * Activity tap) the deep link fires before that layout mounts, and on
  * settings / logs / account routes the controller does not exist at all. So the
- * request is parked in `usePendingDeepLinkStore` — the same one-shot inbox
- * `deeplink.send` uses for exactly this race — and the controller drains it
+ * request is parked in `usePendingDeepLinkStore` (the one-shot inbox
+ * `deeplink.send` uses for exactly this race) and the controller drains it
  * when it registers a starter. No polling, no retry timer.
  */
 
@@ -37,21 +40,21 @@ import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 export const PENDING_VOICE_START_TTL_MS = 60_000;
 
 /**
- * Ask for a live-voice session on behalf of a start-voice deep link.
+ * Ask for a live-voice session.
  *
- * Always parks first, then drains — one code path for both the warm case (a
+ * Always parks first, then drains: one code path for both the warm case (a
  * controller is already mounted, so the drain starts immediately) and the
  * cold-launch case (the drain no-ops and the controller picks the request up).
  */
-export function requestVoiceStartFromDeepLink(): void {
+export function requestVoiceStart(): void {
   usePendingDeepLinkStore.getState().setPendingVoiceStart();
-  void drainPendingVoiceStartDeepLink();
+  void drainPendingVoiceStart();
 }
 
 /**
- * Start a parked start-voice deep link, if there is one and a starter exists.
+ * Start a parked start-voice request, if there is one and a starter exists.
  * Called by {@link useLiveVoiceSessionController} right after it registers its
- * starter, and by {@link requestVoiceStartFromDeepLink} for the warm path.
+ * starter, and by {@link requestVoiceStart} for the warm path.
  * A no-op when nothing is parked, so the repeat calls are free.
  *
  * **The park is consumed last.** Everything before the consume is a *precondition
@@ -63,7 +66,7 @@ export function requestVoiceStartFromDeepLink(): void {
  * launch against a hibernating assistant, where the version resolution can hit
  * its timeout with `version` still `null`.
  */
-export async function drainPendingVoiceStartDeepLink(): Promise<void> {
+export async function drainPendingVoiceStart(): Promise<void> {
   if (usePendingDeepLinkStore.getState().pendingVoiceStartAt === null) {
     return;
   }

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.ts
@@ -20,7 +20,7 @@
  * - `starter` — registered here for the lifetime of the mount; the composer's
  *   entry-point mic calls it to start a session. Registering it also drains any
  *   start-voice deep link parked before this mount (see
- *   `start-voice-deep-link.ts`).
+ *   `start-voice-request.ts`).
  * - `controls` (stop/release/interrupt) — registered per-session by
  *   {@link useLiveVoice} itself.
  * - `state`/`error`/transcripts/amplitude — observable session state.
@@ -43,7 +43,7 @@ import {
   subscribeSettledLiveVoiceState,
   useLiveVoiceStore,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
-import { drainPendingVoiceStartDeepLink } from "@/domains/chat/voice/live-voice/start-voice-deep-link";
+import { drainPendingVoiceStart } from "@/domains/chat/voice/live-voice/start-voice-request";
 import { useLiveActivityControls } from "@/domains/chat/voice/live-voice/use-live-activity-controls";
 import { useLiveActivityMirror } from "@/domains/chat/voice/live-voice/use-live-activity-mirror";
 import {
@@ -185,7 +185,7 @@ export function useLiveVoiceSessionController(
     // A start-voice deep link that arrived before this mount (cold launch from
     // Siri / the Action Button / a Live Activity tap) is parked; now that a
     // starter exists, run it. One-shot, so the re-runs of this effect are free.
-    void drainPendingVoiceStartDeepLink();
+    void drainPendingVoiceStart();
     return () => {
       useLiveVoiceStore.getState().setStarter(null);
     };

--- a/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
@@ -53,8 +53,8 @@ mock.module("@sentry/react", () => ({
 
 const { useGlobalDeepLinkConsumer } =
   await import("./use-global-deep-link-consumer");
-const { drainPendingVoiceStartDeepLink } =
-  await import("@/domains/chat/voice/live-voice/start-voice-deep-link");
+const { drainPendingVoiceStart } =
+  await import("@/domains/chat/voice/live-voice/start-voice-request");
 const { useIsVoiceRoomVisible } = await import(
   "@/domains/chat/voice/voice-room/use-is-voice-room-visible"
 );
@@ -280,7 +280,7 @@ describe("deeplink.startVoice", () => {
     const starter = mock((_a: string, _c: string | null) => undefined);
     useLiveVoiceStore.getState().setStarter(asStarter(starter));
     await act(async () => {
-      await drainPendingVoiceStartDeepLink();
+      await drainPendingVoiceStart();
     });
 
     expect(starter).toHaveBeenCalledWith("assistant-1", null);

--- a/clients/web/src/hooks/use-global-deep-link-consumer.ts
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.ts
@@ -8,7 +8,7 @@ import {
   restoreVoiceRoom,
   useLiveVoiceStore,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
-import { requestVoiceStartFromDeepLink } from "@/domains/chat/voice/live-voice/start-voice-deep-link";
+import { requestVoiceStart } from "@/domains/chat/voice/live-voice/start-voice-request";
 import { ensureMainWindowVisible } from "@/runtime/main-window";
 import { useConnectDialogStore } from "@/stores/connect-dialog-store";
 import { useConversationStore } from "@/stores/conversation-store";
@@ -36,7 +36,7 @@ import { routes } from "@/utils/routes";
  *   on `status: "cancel"` — the same landing the web flow uses.
  * - `deeplink.startVoice` → `ensureMainWindowVisible()` + navigate,
  *   then hand the request to the live-voice starter (parked for the
- *   cold-launch case — see `start-voice-deep-link.ts`). `mode: "resume"`
+ *   cold-launch case, see `start-voice-request.ts`). `mode: "resume"`
  *   just navigates back to a running session's conversation. A `prompt`
  *   (Siri's "Ask …" intent, which collects the question before the app is
  *   up) is parked in the composer inbox — see below.
@@ -190,7 +190,7 @@ export function useGlobalDeepLinkConsumer(): void {
     // The draft composer (no conversation): the session starts without one and
     // the server assigns it on `ready`.
     navigateRef.current(routes.assistant);
-    requestVoiceStartFromDeepLink();
+    requestVoiceStart();
   });
 
   useBusSubscription(

--- a/clients/web/src/lib/backwards-compat/use-supports-live-voice.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-live-voice.ts
@@ -66,7 +66,7 @@ export function useSupportsLiveVoice(
  * Callers must have a *resolved* version in hand: the snapshot collapses
  * "unknown" and "known-old" into `false`, so a caller running before the
  * identity fetch lands has to await `whenAssistantVersionKnown()` first (see
- * `start-voice-deep-link.ts`).
+ * `start-voice-request.ts`).
  */
 export function supportsLiveVoice(
   ownerAssistantId: string | null | undefined,

--- a/clients/web/src/root-layout.tsx
+++ b/clients/web/src/root-layout.tsx
@@ -12,6 +12,11 @@ import { useAssistantLifecycle } from "@/assistant/use-lifecycle";
 import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
 import { useChannelSetupCloseNotify } from "@/domains/chat/hooks/use-channel-setup-close-notify";
 import {
+  isLiveVoiceSessionActive,
+  useLiveVoiceStore,
+} from "@/domains/chat/voice/live-voice/live-voice-store";
+import { requestVoiceStart } from "@/domains/chat/voice/live-voice/start-voice-request";
+import {
   useAuthStore,
   useIsSessionInitializing,
   useHasPlatformSession,
@@ -289,6 +294,25 @@ export function RootLayout() {
       void navigate(
         `${routes.conversation(draftId)}?prompt=${encodeURIComponent(command.message)}`,
       );
+    },
+    startVoice: () => {
+      // A session already running is the session the user is in, so the press
+      // is spent: the starter refuses a second one anyway, and navigating
+      // would only walk the app away from the composer that owns it.
+      if (isLiveVoiceSessionActive(useLiveVoiceStore.getState().state)) {
+        return;
+      }
+      // The draft composer, because the session starts with no conversation
+      // and the server assigns one on `ready`. Navigating is also what mounts
+      // `ChatLayout` and therefore the starter this request is waiting for;
+      // until then it stays parked.
+      //
+      // The window is deliberately not raised. This command comes from the
+      // companion surface, which the user reached for precisely because they
+      // are working somewhere else, and the call gets its own floating readout
+      // from the voice-activity panel.
+      void navigate(routes.assistant);
+      requestVoiceStart();
     },
     replayOnboarding: () => {
       void navigate(`${routes.onboarding.privacy}?preview=true`);

--- a/clients/web/src/runtime/companion-surface.ts
+++ b/clients/web/src/runtime/companion-surface.ts
@@ -60,3 +60,16 @@ export function setCompanionInteractive(interactive: boolean): void {
 export function moveCompanionBy(dx: number, dy: number): void {
   bridge()?.moveBy?.(dx, dy);
 }
+
+/**
+ * Ask for a live-voice session, which is what Talk does.
+ *
+ * The surface is a renderer of its own with no session in it, so the press is
+ * handed to main and dispatched to the window that owns one. Nothing is
+ * returned and nothing is awaited: whether a session actually starts is the
+ * receiving window's decision, and the panel that surface opens is the answer
+ * the user sees.
+ */
+export function startCompanionVoice(): void {
+  bridge()?.startVoice?.();
+}

--- a/clients/web/src/runtime/is-electron.ts
+++ b/clients/web/src/runtime/is-electron.ts
@@ -335,6 +335,7 @@ declare global {
         onState(callback: (state: CompanionSurfaceState) => void): () => void;
         setInteractive?(interactive: boolean): void;
         moveBy?(dx: number, dy: number): void;
+        startVoice?(): void;
       };
     };
   }

--- a/clients/web/src/stores/pending-deep-link-store.ts
+++ b/clients/web/src/stores/pending-deep-link-store.ts
@@ -60,7 +60,7 @@ export interface PendingDeepLinkActions {
    * was parked, and when the parked one is older than `maxAgeMs` — a park that
    * was never drained (its navigation bounced off a route guard, say) must not
    * open a full-screen voice session minutes later. Either way the park is
-   * cleared. Used by `drainPendingVoiceStartDeepLink` in the live-voice domain,
+   * cleared. Used by `drainPendingVoiceStart` in the live-voice domain,
    * which owns the age bound.
    */
   consumePendingVoiceStart: (maxAgeMs: number) => boolean;

--- a/packages/ipc-contract/src/bridge.ts
+++ b/packages/ipc-contract/src/bridge.ts
@@ -326,6 +326,14 @@ export interface VellumBridge {
     setInteractive(interactive: boolean): void;
     /** Nudge the window, for dragging the surface around the desktop. */
     moveBy(dx: number, dy: number): void;
+    /**
+     * Ask for a live-voice session, which is what Talk does.
+     *
+     * The surface is its own renderer and holds no session, so the press is
+     * handed to main and dispatched to the window that does. Nothing comes
+     * back: the session's readout is the voice-activity panel.
+     */
+    startVoice(): void;
   };
   popout: {
     open(conversationId: string): Promise<void>;

--- a/packages/ipc-contract/src/channels.ts
+++ b/packages/ipc-contract/src/channels.ts
@@ -151,6 +151,7 @@ export const COMPANION_GET_STATE = "vellum:companion:getState";
 export const COMPANION_STATE_EVENT = "vellum:companion:state";
 export const COMPANION_SET_INTERACTIVE = "vellum:companion:setInteractive";
 export const COMPANION_MOVE_BY = "vellum:companion:moveBy";
+export const COMPANION_START_VOICE = "vellum:companion:startVoice";
 
 // Popout
 export const POPOUT_OPEN = "vellum:popout:open";

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -56,6 +56,16 @@ export type VellumCommand =
   | { kind: "retireAssistant"; assistantId: string }
   | { kind: "removePairedAssistant"; assistantId: string }
   | { kind: "quickInputSubmit"; message: string }
+  /**
+   * Start a live-voice session, the way the companion surface's Talk asks for
+   * one.
+   *
+   * Carries no conversation: the session starts against a draft and the server
+   * assigns the conversation on its `ready` frame, which is the same shape the
+   * `startVoice` deep link uses. A press that lands while a session is already
+   * running is a no-op, because the running session is the one the user is in.
+   */
+  | { kind: "startVoice" }
   | { kind: "cancelDictation" }
   | { kind: "replayOnboarding" }
   | { kind: "replayHatchFailure" }


### PR DESCRIPTION
Talk on the companion pill was inert: it rendered, it took a click, and nothing was attached to it. This gives it the session it names.

Stacked on #40362, because the `onTalk` prop lands directly on that PR's hunks in `companion-surface.tsx` (`spotlight`, `IdleBody`, `PillButton`). GitHub retargets this to `main` when that one merges.

## The path a press takes

```
companion renderer      startCompanionVoice()               runtime/companion-surface.ts
  -> preload            vellum:companion:startVoice          preload/index.ts
  -> main               dispatchToMain({kind:"startVoice"})   companion-window.ts
  -> main window        useVellumCommands.startVoice          root-layout.tsx
  -> live-voice         requestVoiceStart()                   start-voice-request.ts
```

The press cannot start the call where it happens: the companion surface is its own renderer with no live-voice session in it. So it travels the way the voice panel's controls travel under LUM-3073, out to main and back down into the renderer that holds the session.

## Two decisions

**`dispatchToMain`, not `dispatchToFocused` and not a broadcast.** The session lives where `ChatLayout` is mounted, which is the main window and no other. The press arrives while the user is working in some other app entirely, so "focused" would name the wrong window, and a broadcast would hand a command against a live call to renderers that have no business acting on one.

**The app is not raised.** Someone reaching for a floating avatar has chosen not to go back to Vellum, and the call already gets an on-screen readout from the voice-activity panel LUM-3073 shipped. The renderer still navigates to the draft composer, because that is what mounts the starter, and it returns early when a session is already running rather than walking the app away from the composer that owns it.

## The rename

`start-voice-deep-link.ts` becomes `start-voice-request.ts` (`requestVoiceStartFromDeepLink` -> `requestVoiceStart`, `drainPendingVoiceStartDeepLink` -> `drainPendingVoiceStart`). Its park-then-drain machinery now serves two callers, the start-voice deep link and this command, and sharing the one entry point is what keeps them from drifting into two ideas of what talking means. The park also covers the case where the app sits on a route with no starter mounted, so the request waits rather than being dropped.

## Testing

Typecheck and lint clean across `clients/macos`, `clients/web` and `packages/ipc-contract`. Green: `companion-window` (8), `start-voice-request` (10), `use-global-deep-link-consumer` (30), `use-live-voice-session-controller` (22). `companion-window.test.ts` picks up the `electron-store` shim `voice-activity-window.test.ts` already uses, since the new `main-window` import pulls it into the graph.

Exercised in the dev app: hovering the avatar and pressing Talk starts a session and raises the voice-activity panel, without bringing Vellum forward.

## Not in this change

The pill still shows its idle state while a call runs. Feeding session state back to the surface is the next step, as is Type, which needs main to grow the canvas first.

Part of LUM-3086.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
