### PR TITLE
refactor(web): drop the unreachable custom range from Credit Usage

### DIFF
--- a/clients/web/src/domains/settings/components/billing-usage/billing-usage-panel.tsx
+++ b/clients/web/src/domains/settings/components/billing-usage/billing-usage-panel.tsx
@@ -28,7 +28,6 @@ import {
 } from "@/domains/settings/components/billing-usage/billing-usage-chart";
 import {
   type BillingUsageSourceFilter,
-  getDefaultDateRange,
   useBillingUsageData,
 } from "@/domains/settings/components/billing-usage/use-billing-usage-data";
 import { useEffectiveTimezone } from "@/utils/use-effective-timezone";
@@ -66,30 +65,18 @@ function formatEventCount(count: number | undefined): string {
 
 export function BillingUsagePanel() {
   const tz = useEffectiveTimezone();
-  // Track the SELECTED PRESET IDENTITY (days), not its computed bounds. The
-  // active range is derived from this identity + the live tz below, so a tz
+  // Track the SELECTED PRESET IDENTITY (days), not its computed bounds, so a tz
   // change (even one that crosses a calendar-day rollover after the range was
-  // first computed) always yields the correct bounds for the active preset.
-  // `null` means a custom range that isn't a preset (defensive; billing only
-  // exposes presets today) — in that case `customRange` holds the bounds.
-  const [presetDays, setPresetDays] = useState<number | null>(
-    DEFAULT_PRESET_DAYS,
-  );
-  const [customRange, setCustomRange] = useState<DateRange>(() =>
-    getDefaultDateRange(tz),
+  // first computed) yields the correct bounds for the active preset.
+  const [presetDays, setPresetDays] = useState<number>(DEFAULT_PRESET_DAYS);
+
+  const dateRange = useMemo(
+    () => computeRangeInTimezone(presetDays, tz),
+    [presetDays, tz],
   );
 
-  const dateRange = useMemo<DateRange>(
-    () =>
-      presetDays === null
-        ? customRange
-        : computeRangeInTimezone(presetDays, tz),
-    [presetDays, customRange, tz],
-  );
-
-  const handleRangeChange = (range: DateRange, nextPresetDays: number) => {
+  const handleRangeChange = (_range: DateRange, nextPresetDays: number) => {
     setPresetDays(nextPresetDays);
-    setCustomRange(range);
   };
 
   const [drilldown, setDrilldown] = useState<{
@@ -100,12 +87,6 @@ export function BillingUsagePanel() {
 
   const { series, totals, isLoading, isError } = useBillingUsageData({
     dateRange,
-    // Any imperative range set is treated as custom (not a preset). The data
-    // hook only reads `dateRange`, so this exists to satisfy UsageChartState.
-    setDateRange: (range) => {
-      setPresetDays(null);
-      setCustomRange(range);
-    },
     drilldown,
     setDrilldown,
   });

--- a/clients/web/src/domains/settings/components/billing-usage/use-billing-usage-data.test.ts
+++ b/clients/web/src/domains/settings/components/billing-usage/use-billing-usage-data.test.ts
@@ -8,7 +8,6 @@ import {
 import {
   buildBillingUsageSeriesQuery,
   buildBillingUsageTotalsQuery,
-  getDefaultDateRange,
   isBillingUsageDataEnabled,
   type UsageChartState,
 } from "./use-billing-usage-data";
@@ -23,7 +22,6 @@ function daysApart(from: string, to: string): number {
 function makeState(): UsageChartState {
   return {
     dateRange: { from: "2026-01-01", to: "2026-01-31" },
-    setDateRange: () => {},
     drilldown: null,
     setDrilldown: () => {},
   };
@@ -81,9 +79,9 @@ describe("isBillingUsageDataEnabled", () => {
   });
 });
 
-describe("getDefaultDateRange", () => {
+describe("computeRangeInTimezone", () => {
   test("computes a 30-day range as YYYY-MM-DD bounds in the given tz", () => {
-    const { from, to } = getDefaultDateRange("America/New_York");
+    const { from, to } = computeRangeInTimezone(30, "America/New_York");
     expect(from).toMatch(DATE_RE);
     expect(to).toMatch(DATE_RE);
     expect(daysApart(from, to)).toBe(30);
@@ -94,8 +92,8 @@ describe("getDefaultDateRange", () => {
     // each zone yields a self-consistent, well-formed 30-day range; at the
     // right instant Kiritimati (UTC+14) and Niue (UTC-11) sit on different
     // calendar days, so the computed bounds are independent per zone.
-    const east = getDefaultDateRange("Pacific/Kiritimati");
-    const west = getDefaultDateRange("Pacific/Niue");
+    const east = computeRangeInTimezone(30, "Pacific/Kiritimati");
+    const west = computeRangeInTimezone(30, "Pacific/Niue");
     for (const r of [east, west]) {
       expect(r.from).toMatch(DATE_RE);
       expect(r.to).toMatch(DATE_RE);

--- a/clients/web/src/domains/settings/components/billing-usage/use-billing-usage-data.ts
+++ b/clients/web/src/domains/settings/components/billing-usage/use-billing-usage-data.ts
@@ -1,10 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 
-import {
-  type DateRange,
-  DEFAULT_PRESET_DAYS,
-  computeRangeInTimezone,
-} from "@/components/charts/date-range-select";
+import { type DateRange } from "@/components/charts/date-range-select";
 import {
   organizationsBillingUsageSeriesRetrieveOptions,
   organizationsBillingUsageTotalsRetrieveOptions,
@@ -26,20 +22,8 @@ import {
 } from "@/utils/llm-dimension";
 import { useEffectiveTimezone } from "@/utils/use-effective-timezone";
 
-/**
- * Default date range (the `DEFAULT_PRESET_DAYS` preset), with calendar bounds
- * computed in the effective timezone so they stay aligned with the `tz` sent to
- * the billing backend.
- */
-export function getDefaultDateRange(
-  tz: string = getEffectiveTimezone(),
-): DateRange {
-  return computeRangeInTimezone(DEFAULT_PRESET_DAYS, tz);
-}
-
 export type UsageChartState = {
   dateRange: DateRange;
-  setDateRange: (range: DateRange) => void;
   drilldown: BillingUsageDrilldown | null;
   setDrilldown: (d: BillingUsageDrilldown | null) => void;
 };


### PR DESCRIPTION
## TL;DR

Removes the Credit Usage panel's custom-date-range plumbing, which has never been reachable. Three files, 49 lines out, 12 in.

Ordered before [#40378](https://github.com/vellum-ai/vellum-assistant/pull/40378) (the `Dropdown` migration), which gets smaller and simpler once this lands.

## What changes for the user

Nothing. There is no way to reach any of this from the UI.

## The evidence it is dead

`UsageChartState` requires a `setDateRange`, and `billing-usage-panel` keeps a `customRange` alongside the selected preset to hold whatever such a call would set.

```
git log --all -S "setDateRange(" --oneline
```

No matches, on any path, in the repository's entire history. It has never been called once.

It arrived on 2026-05-19 in `d83f06685b`, "feat(web): port all remaining platform web files", a bulk automated port. That port brought `DateRangeSelect.tsx`, the three-option preset picker, but nothing that sets arbitrary bounds. So what landed here is one half of a state machine whose other half was never ported, and it has sat that way since. This is not an abandoned feature, it is port residue.

Consequently:

- `presetDays === null` is unreachable, since the only assignment of `null` is inside the `setDateRange` implementation
- `customRange` is written and never read
- `getDefaultDateRange` exists solely to seed `customRange`

## What goes

| Removed | Because |
| --- | --- |
| `UsageChartState.setDateRange` | Never called; `useBillingUsageData` only reads `state.dateRange` |
| the panel's implementation of it | Existed to satisfy the type, and its own comment said so |
| `customRange` state and the `null` branch | Unreachable once the setter is gone |
| `getDefaultDateRange` | Its only caller was `customRange`'s initializer |

`presetDays` becomes a plain `number`.

## Tests

The two `getDefaultDateRange` cases now call `computeRangeInTimezone(30, tz)` directly, which is what they were exercising through a one-line wrapper. Same assertions, same zones. Nothing else in the suite touched the removed code beyond a `setDateRange: () => {}` stub in the state fixture.

I could not run the suite: local test runs are blocked in my environment, and Actions has not been running (GitHub incident `qcvjkzcs7j74`). `tsc --noEmit`, `eslint` and `prettier` are clean. Worth a CI pass before merge.

## If custom ranges are wanted later

Build them deliberately. That means a real date picker, and a library to build it on: Radix ships no calendar primitive, and this repository has no date-picker dependency of any kind. Keeping a non-functioning half of the state machine around does not make that work any easier when it comes.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40382" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->