### PR TITLE
refactor(web): stop overriding control heights in Credit Usage

### DIFF
--- a/clients/web/src/domains/settings/components/billing-usage/billing-usage-panel.tsx
+++ b/clients/web/src/domains/settings/components/billing-usage/billing-usage-panel.tsx
@@ -125,17 +125,7 @@ export function BillingUsagePanel() {
               Overview of your spending habits.
             </Typography>
           </div>
-          {/*
-           * Compact 32px controls per Figma. `SegmentControl` exposes no size
-           * prop, and neither of `Select`'s presets is 32px (regular is 36,
-           * compact 28), so we override the inner button heights with
-           * arbitrary descendant variants here rather than mutating the
-           * shared primitives.
-           * - Select's trigger is `<button role="combobox">` (h-9 → h-8).
-           * - SegmentControl's inner items are `<button role="radio">`
-           *   wrapped by a 2px-padded container, so h-7 inner = 32px outer.
-           */}
-          <div className="flex flex-wrap items-center justify-end gap-2 [&_[role=combobox]]:h-8 [&_[role=radio]]:h-7">
+          <div className="flex flex-wrap items-center justify-end gap-2">
             <DateRangeSelect value={presetDays} onChange={setPresetDays} />
             <div className="w-44">
               <SegmentControl


### PR DESCRIPTION
## TL;DR

Deletes the only control-height override in the web client. The Credit Usage controls render at the sizes their own components define.

## What changes for the user

The date picker gets 4px taller (32 → 36), its natural height. The metric toggle stays at 32. The two no longer match.

## The override, and why it was right when it was written

```
[&_[role=combobox]]:h-8 [&_[role=radio]]:h-7
```

It came in with `d195cc5099` (2026-05-20, LUM-1647), and its comment opens with "Compact 32px controls per Figma." So 32px was a deliberate design decision, and at that moment there was no other way to get it: `Dropdown` gained a size prop on 2026-07-24 and `SegmentControl` on 2026-07-31, both roughly two months later. "The shared primitives don't expose a size prop" was simply true when written.

What has changed is that both halves of the justification have since expired, in different ways.

## Why remove it now

**The radio half is dead.** `SegmentControl`'s `default` size renders `h-7` inner, 32px including the group's 2px padding, and the panel passes no `size`. The rule sets the value already in effect. That has been true since the size prop landed in July.

**The combobox half rests on one frame and one call site.** `Select` genuinely cannot do 32px, only 36 or 28, so this rule is load-bearing for matching the Figma. But the case for teaching `Select` a third size is thin:

- This is the only place in the web client where a `Select` and a `SegmentControl` sit side by side. The other two files containing both stack them vertically (`create-schedule-modal`, `flex flex-col gap-3`) or place them in unrelated sections 370 lines apart (`voice-page`), where a height difference never arises.
- It is the only control-height override anywhere in `clients/web/src`. Nothing else has wanted a size outside the presets.
- The Figma frame predates both size props, so it was drawn against primitives that could not express a choice. Nobody has re-confirmed 32 since.

Adding a size to a shared component to serve exactly one layout moves the arbitrary decision from a call site into the design system, where it is harder to remove and invites the next one-off to follow suit.

## The question this makes answerable

There is a real mismatch in that row, and this PR makes it visible rather than resolving it. If design confirms the row must align, the fix should be chosen with the rendered comparison in hand, and "add 32px to `Select`" is only one of the candidates. "Give `SegmentControl` a 36px size" and "use two controls of the same kind" are others, and the broader question of whether `Select` (36, matching `Input`) and `Button` (32) should share a scale at all sits underneath all of them.

## Verification

`tsc --noEmit`, `eslint` and `prettier` clean. No test touches this markup. Local test runs are blocked in my environment and Actions has been down (`qcvjkzcs7j74`), so a CI pass is worth having before merge.
