### PR TITLE
refactor(web): migrate the usage tab's pickers off Dropdown (LUM-2959)

### DIFF
--- a/clients/web/src/domains/settings/billing/usage/usage-tab.tsx
+++ b/clients/web/src/domains/settings/billing/usage/usage-tab.tsx
@@ -1,9 +1,15 @@
 import { useQuery } from "@tanstack/react-query";
 import { AlertTriangle } from "lucide-react";
-import { useCallback, useMemo, useState, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
 import { Link, useNavigate, useSearchParams } from "react-router";
 
-import { Dropdown } from "@vellumai/design-library";
+import { Select } from "@vellumai/design-library/components/select";
 
 import { buildCallSiteMetadataMap } from "@/domains/settings/billing/usage/call-site-metadata";
 import {
@@ -199,6 +205,21 @@ export function UsageTab({ assistantId }: UsageTabProps) {
   });
 
   const effectiveGroupBy = breakdownQuery.data?.groupBy ?? groupBy;
+
+  // The breakdown query falls back to a supported grouping when this gateway
+  // rejects the requested one, so `effectiveGroupBy` is what the page is
+  // actually showing. Adopt it into the URL: leaving the two apart means the
+  // address bar keeps asking for a grouping this gateway cannot serve, and
+  // every load pays the rejected request again. Converges in one pass, since
+  // the fallback grouping is by definition one the gateway supports.
+  useEffect(() => {
+    if (effectiveGroupBy !== groupBy) {
+      updateUsageSearchParams({
+        groupBy: effectiveGroupBy,
+        scheduleId: effectiveGroupBy === "schedule" ? undefined : null,
+      });
+    }
+  }, [effectiveGroupBy, groupBy, updateUsageSearchParams]);
   const seriesGroupBy = shouldFetchUsageSeries(effectiveGroupBy)
     ? effectiveGroupBy
     : undefined;
@@ -357,10 +378,6 @@ export function UsageTab({ assistantId }: UsageTabProps) {
   }, [effectiveGroupBy, scheduleId, schedulesQuery.data]);
 
   const handleGroupByChange = (nextGroupBy: UsageGroupBy) => {
-    if (nextGroupBy === groupBy && effectiveGroupBy !== groupBy) {
-      void breakdownQuery.refetch();
-      void seriesQuery.refetch();
-    }
     updateUsageSearchParams({
       groupBy: nextGroupBy,
       scheduleId: nextGroupBy === "schedule" ? undefined : null,
@@ -497,7 +514,7 @@ function TimeRangeStrip({
 }) {
   return (
     <div className="flex items-center">
-      <Dropdown<UsageTimeRange>
+      <Select<UsageTimeRange>
         value={range}
         onChange={onChange}
         options={RANGE_OPTIONS.map((option) => ({
@@ -704,7 +721,7 @@ function GroupByPicker({
 }) {
   return (
     <div className="flex items-center">
-      <Dropdown<UsageGroupBy>
+      <Select<UsageGroupBy>
         value={value}
         onChange={onChange}
         menuAlign="end"


### PR DESCRIPTION
## TL;DR

Migrates the last two `Dropdown` call sites, in the billing Usage tab. One is a plain swap; the other needed a real divergence fixed first. `Dropdown` is unreferenced after this and gets deleted separately.

Closes out [LUM-2959](https://linear.app/vellum/issue/LUM-2959).

## Why these were missed

Earlier batches surveyed for `@vellumai/design-library/components/dropdown`, the component path `clients/web/docs/CONVENTIONS.md:517` prescribes. These two import `Dropdown` from the package barrel instead, so they never appeared. "8 of 8" was really 8 of 10.

## What changes for the user

| Before | After |
| --- | --- |
| Scroll anywhere with a picker open and the page ran a layout read plus a re-render per scroll event | Radix positions without that |
| Menus could not flip upward or shift to stay on screen | They do both |
| On a gateway that cannot group by Task or Profile, the URL kept requesting it forever; the only way to settle it was to click the option already shown, which looks like it does nothing | The page adopts the grouping it fell back to, so the control, the chart and the address bar agree |

## The group-by divergence

`usage-tab.tsx:179-195`: when the gateway rejects `task` or `profile` as unsupported, the query retries with `FALLBACK_USAGE_GROUP_BY` (`model`) and reports that back. So `effectiveGroupBy = breakdownQuery.data?.groupBy ?? groupBy` is what the page is really showing, and on an older gateway it differs from what the URL asked for.

`Dropdown` fired `onChange` on every click, so picking the row already displayed wrote the fallback into the URL. That was the only path that reconverged the two, and `Select` reports genuine changes only, so migrating without a fix would have left it dead and the URL permanently requesting a grouping the gateway cannot serve.

Rather than preserve a gesture whose entire purpose was invisible, the fallback is adopted when it happens. It converges in one pass, since the fallback grouping is by definition supported. The reconciliation branch in `handleGroupByChange` that existed to paper over the gap is deleted with it.

The other branch of that condition, picking the value the URL holds while something else is displayed, survives on its own: those two genuinely differ, so `Select` fires.

## Why the range picker is safe

`value` is URL state read by `readUsageUrlState`, with no second source to diverge from. No option in `RANGE_OPTIONS` or `USAGE_GROUP_BY_OPTIONS` carries an empty string, so the other failure shape of this migration (Radix discards `""` and the row silently never renders) does not apply.

## Verification

`tsc --noEmit`, `eslint` and `prettier` clean.

**Not verified by tests, and this one deserves a real pass.** Local test runs are blocked in my environment and Actions has been down (`qcvjkzcs7j74`). Unlike the pure deletions in this sequence, this changes behaviour on a version-gated backwards-compatibility path I have no way to exercise: the fallback only triggers against a gateway that rejects `task`/`profile` groupings. A reviewer who can reach an older gateway should confirm the adopt-on-fallback effect settles rather than oscillates.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40390" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->