### PR TITLE
Companion surface: press the avatar to go back to the conversation

### DIFF
--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -304,6 +304,27 @@ export const installCompanionWindow = (): void => {
     });
   });
 
+  /**
+   * The avatar, pressed: come forward on the conversation the user was last in.
+   *
+   * `currentConversation` is the command the app already has for exactly this,
+   * so the surface asks for it rather than growing a path of its own, and the
+   * two degrade the same way. The renderer navigates when it has a conversation
+   * to navigate to and does nothing when it does not, which leaves the window
+   * simply coming forward. The same is true when the app is somewhere with no
+   * chat layout mounted, such as Settings: the command lands nowhere and the
+   * window is still raised, which is the smaller half of what was asked and
+   * never the wrong thing to do.
+   *
+   * This *does* raise the app, unlike Talk. It is the one press on the surface
+   * whose entire purpose is to go back to Vellum.
+   */
+  on("vellum:companion:activate", z.tuple([]), () => {
+    void ensureMainWindowVisible().then(() => {
+      dispatchToMain({ kind: "currentConversation" });
+    });
+  });
+
   // -------------------------------------------------------------------------
   // The running session
   //

--- a/clients/macos/src/preload/index.ts
+++ b/clients/macos/src/preload/index.ts
@@ -616,6 +616,9 @@ const bridge: VellumBridge = {
     startVoice: (): void => {
       ipcRenderer.send("vellum:companion:startVoice");
     },
+    activate: (): void => {
+      ipcRenderer.send("vellum:companion:activate");
+    },
   },
   popout: {
     open: (conversationId: string): Promise<void> =>

--- a/clients/web/src/components/companion-surface-page.tsx
+++ b/clients/web/src/components/companion-surface-page.tsx
@@ -5,6 +5,7 @@ import {
   type CompanionSurfacePhase,
 } from "@/components/companion-surface";
 import {
+  activateCompanionApp,
   getCompanionState,
   moveCompanionBy,
   setCompanionInteractive,
@@ -17,6 +18,15 @@ import type {
   CompanionSurfaceState,
   VoiceActivityState,
 } from "@vellumai/ipc-contract";
+
+/**
+ * How far a press may travel and still count as a click.
+ *
+ * The surface is its own drag handle, so every press is a potential grab. A few
+ * pixels of hand tremor between pressing the avatar and letting go must not
+ * turn "take me back to Vellum" into a one-pixel nudge that does nothing.
+ */
+const DRAG_SLOP = 3;
 
 /**
  * The companion surface inside its Electron canvas
@@ -52,6 +62,12 @@ export function CompanionSurfacePage() {
   // Screen rather than client: the window moves under the cursor, so client
   // coordinates barely change while screen ones track the hand exactly.
   const dragRef = useRef<{ x: number; y: number } | null>(null);
+  // Where the current press started, and whether it has travelled far enough to
+  // be a drag rather than a click. Every press starts as both: the surface is
+  // its own drag handle, so a press on the avatar is a grab until the hand
+  // moves, and a click once it lifts without having moved.
+  const pressOriginRef = useRef<{ x: number; y: number } | null>(null);
+  const draggedRef = useRef(false);
 
   useEffect(() => {
     const apply = (state: CompanionSurfaceState) => {
@@ -109,6 +125,15 @@ export function CompanionSurfacePage() {
       const { x, y } = dragRef.current;
       moveCompanionBy(event.screenX - x, event.screenY - y);
       dragRef.current = { x: event.screenX, y: event.screenY };
+      const origin = pressOriginRef.current;
+      if (
+        origin !== null &&
+        Math.abs(event.screenX - origin.x) +
+          Math.abs(event.screenY - origin.y) >
+          DRAG_SLOP
+      ) {
+        draggedRef.current = true;
+      }
       return;
     }
     const pill = pillRef.current;
@@ -167,6 +192,16 @@ export function CompanionSurfacePage() {
         rootRef={pillRef}
         onSurfaceMouseDown={(event) => {
           dragRef.current = { x: event.screenX, y: event.screenY };
+          pressOriginRef.current = { x: event.screenX, y: event.screenY };
+          draggedRef.current = false;
+        }}
+        // A press that never became a drag. The window comes forward on the
+        // conversation this surface belongs to; main decides what that means.
+        onAvatarClick={() => {
+          if (draggedRef.current) {
+            return;
+          }
+          activateCompanionApp();
         }}
         // The press leaves this window immediately: the session lives in the
         // renderer holding the chat layout, and this page only asks for one.

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -234,6 +234,17 @@ export interface CompanionSurfaceProps {
    */
   onTalk?: () => void;
   /**
+   * Press the avatar: go back to Vellum, on the conversation the surface
+   * belongs to.
+   *
+   * Wired to the avatar rather than the pill because the pill's body is
+   * controls, and to a press that did not turn into a drag: the whole surface
+   * is a drag handle, and the avatar is the part of it a user is most likely to
+   * grab. The caller owns that distinction, since it is the side holding the
+   * pointer.
+   */
+  onAvatarClick?: () => void;
+  /**
    * The running session, when `phase` is `call`.
    *
    * Absent renders the call state from fixed sample values, which is what the
@@ -268,6 +279,7 @@ export function CompanionSurface({
   onSurfaceMouseDown,
   spotlight,
   onTalk,
+  onAvatarClick,
   call,
   onControl,
 }: CompanionSurfaceProps) {
@@ -383,6 +395,7 @@ export function CompanionSurface({
           accentHex={accentHex}
           avatarSrc={avatarSrc}
           onMouseEnter={onHoverStart}
+          onClick={onAvatarClick}
         />
         {typing ? (
           <Composer assistantName={assistantName} />
@@ -511,17 +524,23 @@ function Avatar({
   accentHex,
   avatarSrc,
   onMouseEnter,
+  onClick,
 }: {
   glow: boolean;
   accentHex: string;
   avatarSrc?: string;
   onMouseEnter?: () => void;
+  onClick?: () => void;
 }) {
   return (
+    // A div rather than a button even when it is pressable: it is the drag
+    // handle for the whole surface, and the press that starts a drag must not
+    // read as activating a control. `onClick` fires only for presses the caller
+    // decided were not drags.
     <div
       className="relative grid size-11 shrink-0 place-items-center"
       onMouseEnter={onMouseEnter}
-    >
+      onClick={onClick}>
       {glow && (
         <span
           className="absolute size-10 animate-pulse rounded-full blur-lg"

--- a/clients/web/src/runtime/companion-surface.ts
+++ b/clients/web/src/runtime/companion-surface.ts
@@ -73,3 +73,14 @@ export function moveCompanionBy(dx: number, dy: number): void {
 export function startCompanionVoice(): void {
   bridge()?.startVoice?.();
 }
+
+/**
+ * Bring Vellum forward on the conversation the user was last in, which is what
+ * pressing the avatar asks for.
+ *
+ * The one call here that deliberately raises the app. Everything else on the
+ * surface exists so the user does not have to.
+ */
+export function activateCompanionApp(): void {
+  bridge()?.activate?.();
+}

--- a/clients/web/src/runtime/is-electron.ts
+++ b/clients/web/src/runtime/is-electron.ts
@@ -329,6 +329,7 @@ declare global {
         setInteractive?(interactive: boolean): void;
         moveBy?(dx: number, dy: number): void;
         startVoice?(): void;
+        activate?(): void;
       };
     };
   }

--- a/packages/ipc-contract/src/bridge.ts
+++ b/packages/ipc-contract/src/bridge.ts
@@ -326,6 +326,11 @@ export interface VellumBridge {
      * the session itself, on `onState`.
      */
     startVoice(): void;
+    /**
+     * Bring Vellum forward on the conversation the user was last in, which is
+     * what pressing the avatar asks for.
+     */
+    activate(): void;
   };
   popout: {
     open(conversationId: string): Promise<void>;

--- a/packages/ipc-contract/src/channels.ts
+++ b/packages/ipc-contract/src/channels.ts
@@ -147,6 +147,7 @@ export const COMPANION_STATE_EVENT = "vellum:companion:state";
 export const COMPANION_SET_INTERACTIVE = "vellum:companion:setInteractive";
 export const COMPANION_MOVE_BY = "vellum:companion:moveBy";
 export const COMPANION_START_VOICE = "vellum:companion:startVoice";
+export const COMPANION_ACTIVATE = "vellum:companion:activate";
 
 // Popout
 export const POPOUT_OPEN = "vellum:popout:open";


### PR DESCRIPTION
The surface could start a call and act on one, but had no way back to the app. The voice panel used to carry that as a return button; #40386 deleted it and left the gap open deliberately, on the grounds that the avatar is the better home for it. This closes it.

## It asks for a command the app already has

`currentConversation` is exactly "go to the conversation the user was last in", so the surface grows no path of its own, and every degradation comes for free:

- **A conversation to return to** goes there.
- **No active conversation** and the renderer's handler returns early, so the window simply comes forward.
- **A route with no chat layout** (Settings, Logs) and the command lands nowhere, so the window simply comes forward.

Unlike Talk, this deliberately raises the app. It is the one press on the surface whose entire purpose is to go back to Vellum.

## Click versus drag

The whole surface is its own drag handle, and the avatar is the part of it a user is most likely to grab, so a press is a grab until the hand moves and a click once it lifts without having moved. `DRAG_SLOP` is 3px of travel: hand tremor between pressing and releasing must not turn "take me back" into a one-pixel nudge that does nothing, and a real drag must not end by teleporting the user into the app.

## Testing

Typecheck and lint clean across `clients/macos`, `clients/web` and `packages/ipc-contract`; `companion-window` tests green.

Not yet exercised with a real mouse: click-versus-drag is precisely the kind of thing that only shows up under a hand, so this wants a manual pass (press the avatar, then drag it and confirm the drag does not also navigate).

Part of LUM-3098.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
