### PR TITLE
refactor(design-library): state SideMenu.Item's tile size instead of deriving it

### DIFF
--- a/clients/web/src/domains/chat/components/collapsed-rail-transition.test.tsx
+++ b/clients/web/src/domains/chat/components/collapsed-rail-transition.test.tsx
@@ -62,7 +62,7 @@ describe("collapsing an expanded rail", () => {
        in which the two flags disagree. */
     const [circle] = rows();
     expect(circle!.className).toContain("rounded-full");
-    expect(circle!.className).toContain("aspect-square");
+    expect(circle!.className).toContain("size-[30px]");
     expect(circle!.className).not.toContain("w-full");
     expect(circle!.querySelector('[data-slot="dot"]')).not.toBeNull();
     // The label is the tell: a visible one means it is still an expanded row.

--- a/clients/web/src/domains/chat/components/collapsed-rail-transition.test.tsx
+++ b/clients/web/src/domains/chat/components/collapsed-rail-transition.test.tsx
@@ -53,12 +53,13 @@ describe("collapsing an expanded rail", () => {
     const { rerender } = render(<Rail collapsed={false} />);
     rerender(<Rail collapsed />);
 
-    /* Regression: these all used to wait on the design library's delayed
-       `contentCollapsed`, so for the 150ms of the width transition the rail's
-       section tiles rendered as full-width labelled rows inside a 48px
-       column, with no activity dot and no tooltip. No timers are advanced
-       here on purpose: this asserts the state at the first collapsed paint,
-       which is exactly the window that regressed. */
+    /* A circle tile reads the rail's immediate collapsed flag, not the
+       delayed `contentCollapsed` that lets an ordinary row's label linger.
+       Keying it off the delayed one leaves the rail's section tiles as
+       full-width labelled rows inside a 48px column for the 150ms of the
+       width transition, with no activity dot and no tooltip. No timers are
+       advanced here on purpose: the first collapsed paint is the only window
+       in which the two flags disagree. */
     const [circle] = rows();
     expect(circle!.className).toContain("rounded-full");
     expect(circle!.className).toContain("aspect-square");

--- a/packages/design-library/src/components/side-menu/side-menu.test.tsx
+++ b/packages/design-library/src/components/side-menu/side-menu.test.tsx
@@ -491,11 +491,11 @@ describe("SideMenu.Item collapsed shape", () => {
 
   test('shape="circle" squares the tile, so it is round and not oval', () => {
     const html = renderCollapsedItem({ label: "Pinned", shape: "circle" });
-    /* Regression: a full radius on a `w-full` row drew a 32x30 ellipse,
-       because the rail column is a little wider than the row is tall. The
-       radius alone is not the shape, so assert the squaring too, and assert
-       it as `aspect-square` over the row height: a hard-coded width would be
-       a second copy of the row metric, free to drift from `h-[30px]`. */
+    /* A full radius on a `w-full` row is an ellipse, not a circle: the rail
+       column is a little wider than the row is tall. The radius alone is not
+       the shape, so assert the squaring too, and assert it as `aspect-square`
+       over the row height, since a hard-coded width is a second copy of the
+       row metric and free to drift from `h-[30px]`. */
     expect(html).toContain("h-[30px]");
     expect(html).toContain("aspect-square");
     expect(html).toContain("mx-auto");
@@ -504,11 +504,10 @@ describe("SideMenu.Item collapsed shape", () => {
   test("a tile is built as its own shape, not as a row with patches", () => {
     const html = renderCollapsedItem({ label: "Pinned", shape: "circle" });
     /* The row classes a tile does not want are absent, rather than present
-       and countered. Asserting absence is what keeps this honest: an earlier
-       attempt appended `w-auto` / `max-md:h-[30px]` / `max-md:py-[6px]` to
-       out-specify them, which renders the same but leaves the geometry
-       dependent on tailwind-merge order, one class list away from a 32x30
-       ellipse or a 38x38 tile overflowing the rail. */
+       and countered. Absence is the property worth asserting: countering them
+       with `w-auto` / `max-md:h-[30px]` / `max-md:py-[6px]` renders the same
+       while leaving the geometry dependent on tailwind-merge order, one class
+       list away from a 32x30 ellipse or a 38x38 tile overflowing the rail. */
     expect(html).not.toContain("w-full");
     expect(html).not.toContain("rounded-[6px]");
     expect(html).not.toContain("max-md:h-auto");

--- a/packages/design-library/src/components/side-menu/side-menu.test.tsx
+++ b/packages/design-library/src/components/side-menu/side-menu.test.tsx
@@ -493,12 +493,12 @@ describe("SideMenu.Item collapsed shape", () => {
     const html = renderCollapsedItem({ label: "Pinned", shape: "circle" });
     /* A full radius on a `w-full` row is an ellipse, not a circle: the rail
        column is a little wider than the row is tall. The radius alone is not
-       the shape, so assert the squaring too, and assert it as `aspect-square`
-       over the row height, since a hard-coded width is a second copy of the
-       row metric and free to drift from `h-[30px]`. */
-    expect(html).toContain("h-[30px]");
-    expect(html).toContain("aspect-square");
-    expect(html).toContain("mx-auto");
+       the shape, so assert the square too. A definite `size-*` is what makes
+       it one: a height plus `aspect-square` derives the width instead, and a
+       derived width is `auto`, which `align-items: stretch` then overrides
+       back to the container's. */
+    expect(html).toContain("size-[30px]");
+    expect(html).not.toContain("aspect-square");
   });
 
   test("a tile is built as its own shape, not as a row with patches", () => {
@@ -525,7 +525,7 @@ describe("SideMenu.Item collapsed shape", () => {
     expect(html).toContain("w-full");
     expect(html).toContain("max-md:h-auto");
     expect(html).toContain("max-md:py-3");
-    expect(html).not.toContain("aspect-square");
+    expect(html).not.toContain("size-[30px]");
   });
 
   test("default shape keeps the 6px row radius", () => {

--- a/packages/design-library/src/components/side-menu/side-menu.tsx
+++ b/packages/design-library/src/components/side-menu/side-menu.tsx
@@ -509,9 +509,6 @@ export interface SideMenuItemProps {
    * *why* the row does nothing would be the one thing a user could not
    * reach. The native attribute is omitted from this component's props for
    * the same reason.
-   *
-   * Wins over `active`: a row that cannot be activated does not draw the
-   * active fill. No caller passes both today.
    */
   disabled?: boolean;
   trailingIcon?: LucideIcon;

--- a/packages/design-library/src/components/side-menu/side-menu.tsx
+++ b/packages/design-library/src/components/side-menu/side-menu.tsx
@@ -509,6 +509,9 @@ export interface SideMenuItemProps {
    * *why* the row does nothing would be the one thing a user could not
    * reach. The native attribute is omitted from this component's props for
    * the same reason.
+   *
+   * Wins over `active`: a row that cannot be activated does not draw the
+   * active fill. No caller passes both today.
    */
   disabled?: boolean;
   trailingIcon?: LucideIcon;
@@ -643,13 +646,21 @@ function SideMenuItem({
      every width, having no label to make room for, and `aspect-square` takes
      its width from that height so the circle cannot drift from the row metric.
 
-     Writing this as a tile-shaped patch appended after the row classes is
-     what the first two attempts did, and each of `w-full`, `rounded-[6px]`,
-     `max-md:h-auto` and `max-md:py-3` then needed its own counter-class to
-     undo. Branching states each shape once instead. */
+     Appending a tile-shaped patch after the row classes renders the same,
+     but each of `w-full`, `rounded-[6px]`, `max-md:h-auto` and `max-md:py-3`
+     then needs its own counter-class, which leaves the geometry resting on
+     tailwind-merge order rather than on intent. Branching states each shape
+     once, so there is nothing to counter. */
   const isTile = collapsed && shape === "circle";
   const geometryClasses = isTile
-    ? "h-[30px] aspect-square mx-auto rounded-full"
+    ? /* `mx-auto` is load-bearing, not centering trim. With no `w-full` the
+         tile's width is auto and comes from `aspect-square`, and a flex child
+         with an auto cross size stretches to the container in the default
+         `align-items: stretch`, which makes the ratio inert (measured: 200px
+         wide in a 200px column). An auto cross-axis margin suppresses that
+         stretch, so it is what keeps the height authoritative anywhere the
+         parent is not already `items-center`. */
+      "h-[30px] aspect-square mx-auto rounded-full"
     : // `w-full` matters for the `<button>` render path: buttons keep
       // fit-content sizing even as flex containers, so without it a
       // button-backed item shrink-wraps while anchor-backed items fill the rail.

--- a/packages/design-library/src/components/side-menu/side-menu.tsx
+++ b/packages/design-library/src/components/side-menu/side-menu.tsx
@@ -638,10 +638,8 @@ function SideMenuItem({
   /* An item is drawn either as a row or as a tile, and the two want opposite
      things, so they are alternatives rather than one layered over the other.
      A row fills the rail and grows on narrow viewports, because it carries a
-     label and wants a comfortable touch target for it. A tile is a square of
-     the same row height, centered in the rail column: it holds that height at
-     every width, having no label to make room for, and `aspect-square` takes
-     its width from that height so the circle cannot drift from the row metric.
+     label and wants a comfortable touch target for it. A tile is a fixed
+     square at the row height, with no label to make room for.
 
      Appending a tile-shaped patch after the row classes renders the same,
      but each of `w-full`, `rounded-[6px]`, `max-md:h-auto` and `max-md:py-3`
@@ -650,14 +648,7 @@ function SideMenuItem({
      once, so there is nothing to counter. */
   const isTile = collapsed && shape === "circle";
   const geometryClasses = isTile
-    ? /* `mx-auto` is load-bearing, not centering trim. With no `w-full` the
-         tile's width is auto and comes from `aspect-square`, and a flex child
-         with an auto cross size stretches to the container in the default
-         `align-items: stretch`, which makes the ratio inert (measured: 200px
-         wide in a 200px column). An auto cross-axis margin suppresses that
-         stretch, so it is what keeps the height authoritative anywhere the
-         parent is not already `items-center`. */
-      "h-[30px] aspect-square mx-auto rounded-full"
+    ? "size-[30px] mx-auto rounded-full"
     : // `w-full` matters for the `<button>` render path: buttons keep
       // fit-content sizing even as flex containers, so without it a
       // button-backed item shrink-wraps while anchor-backed items fill the rail.


### PR DESCRIPTION
## TL;DR

Simplifies `SideMenu.Item`'s circle tile from a derived size plus a guard to a stated size, and makes the surrounding comments describe the code rather than the PR that produced it. Rendering is unchanged: 30x30 and round at both breakpoints.

## The tile geometry

Before, on `main`:

```
h-[30px] aspect-square mx-auto rounded-full
```

A height, a width derived from it, and an auto margin to stop `align-items: stretch` from overriding that derivation — because a derived width is `auto`, and auto cross sizes stretch. The guard needed a seven-line comment to survive review, since it reads as centering trim that the `justify-center` parent already provides.

After:

```
size-[30px] mx-auto rounded-full
```

A definite width is not subject to stretch, so there is no failure mode, no guard, and nothing to explain.

Measured in a 200px flex column:

| classes | rendered |
| -- | -- |
| `h-[30px] aspect-square` | **200x30** |
| `h-[30px] aspect-square mx-auto` | 30x30 |
| `size-[30px]`, no guard at all | **30x30** |

`mx-auto` stays, but now it is only centering, which is what it looks like.

### Why the derivation existed, and why it was wrong

It was meant to avoid restating the row metric — deriving the width from `h-[30px]` rather than writing `30` twice. It does not achieve that: `h-[30px]` is right there either way, so the literal never went away. It bought an indirection and two failure modes, one of which shipped: when `max-md:h-auto` made the height `auto` at narrow viewports, the derived width followed it into a 38x38 tile overflowing the rail's 30px content box. That needed `max-md:h-[30px]` and `max-md:py-[6px]` to patch. With a stated size, **none of those overrides are needed** — verified at 700px.

Genuinely sharing one source between the row and the tile is worth doing, but it cannot be expressed in class strings (`AGENTS.md` forbids interpolating Tailwind classes), so it belongs with the CVA conversion in [LUM-3103](https://linear.app/vellum/issue/LUM-3103/sidemenuitem-composes-classes-by-source-order-so-every-new-option).

## Comments

`AGENTS.md` — *"Comments describe the present; PRs describe the history"* — and four comments from #40383 broke it: "these all used to wait...", "drew a 32x30 ellipse", "an earlier attempt appended...", "what the first two attempts did". Each now states the contract and the failure mode it guards. The history stays in #40383's commit messages, where it belongs.

## What this deliberately does not document

An earlier revision of this branch added a note that `disabled` takes precedence over `active`. Removed, not reworded.

That precedence only needs stating because one interaction state is modelled as two independent booleans, making a meaningless fourth combination representable. Documenting which wins treats the symptom, and the note would go stale the moment the precedence changed — the same staleness that got it flagged. Folded into LUM-3103, where a single `state` axis makes the combination unrepresentable instead of explained.

## Why it's safe

One file. Rendering verified unchanged across a real collapse (driven through Storybook's args channel) at 1400px and 700px: all tiles 30x30, round, at the first collapsed paint and settled. Both packages typecheck; design-library and web test suites cover the geometry assertions, updated here to assert `size-[30px]` and the absence of `aspect-square`.

Follow-up to [LUM-3099](https://linear.app/vellum/issue/LUM-3099/retire-icontile-rail-to-sidemenuitem-picker-to-button).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
