### PR TITLE
feat(design-library): give Input regular and compact sizes

### DIFF
--- a/packages/design-library/src/components/input.stories.tsx
+++ b/packages/design-library/src/components/input.stories.tsx
@@ -16,6 +16,7 @@ const meta: Meta<typeof Input> = {
     disabled: false,
   },
   argTypes: {
+    size: { control: "inline-radio", options: ["regular", "compact"] },
     // Slots/handlers aren't editable text; hide them from Controls.
     leftIcon: { control: false },
     rightIcon: { control: false },
@@ -42,6 +43,14 @@ type Story = StoryObj<typeof Input>;
 
 /** Arg-driven: type in the field or edit label/placeholder/helper in Controls. */
 export const Default: Story = {};
+
+/**
+ * 28px instead of 36px, for dense surfaces. Matches `Select`'s `compact`, so
+ * the two line up when a form mixes them.
+ */
+export const Compact: Story = {
+  args: { size: "compact" },
+};
 
 /** Helper text below the field. */
 export const WithHelperText: Story = {

--- a/packages/design-library/src/components/input.tsx
+++ b/packages/design-library/src/components/input.tsx
@@ -36,19 +36,39 @@ const fieldVariants = cva(
         ].join(" "),
       },
       density: {
-        input: "h-9 px-3 py-1.5",
+        input: "",
         textarea: "min-h-[72px] px-3 py-2 resize-y",
+      },
+      /**
+       * Matches `Select`'s scale rather than `Button`'s: a field lines up with
+       * the fields around it, and `Select` is the control most often beside
+       * one. `regular` is 36px, `compact` 28px. Ignored by `Textarea`, whose
+       * height follows its content.
+       */
+      size: {
+        regular: "",
+        compact: "",
       },
       hasLeftIcon: { true: "", false: "" },
       hasRightIcon: { true: "", false: "" },
     },
     compoundVariants: [
-      { density: "input", hasLeftIcon: true, class: "pl-9" },
-      { density: "input", hasRightIcon: true, class: "pr-9" },
+      { density: "input", size: "regular", class: "h-9 px-3 py-1.5" },
+      {
+        density: "input",
+        size: "compact",
+        class: "h-7 px-2.5 py-1 text-body-small-default",
+      },
+      // Icon insets track the horizontal padding of the size they sit in.
+      { density: "input", size: "regular", hasLeftIcon: true, class: "pl-9" },
+      { density: "input", size: "regular", hasRightIcon: true, class: "pr-9" },
+      { density: "input", size: "compact", hasLeftIcon: true, class: "pl-8" },
+      { density: "input", size: "compact", hasRightIcon: true, class: "pr-8" },
     ],
     defaultVariants: {
       invalid: false,
       density: "input",
+      size: "regular",
       hasLeftIcon: false,
       hasRightIcon: false,
     },
@@ -57,11 +77,16 @@ const fieldVariants = cva(
 
 type FieldVariantProps = VariantProps<typeof fieldVariants>;
 
+/** Field heights: `regular` is 36px, `compact` 28px. Mirrors `SelectSize`. */
+export type InputSize = "regular" | "compact";
+
 // ---------------------------------------------------------------------------
 // Input (single-line)
 // ---------------------------------------------------------------------------
 
 export interface InputProps extends Omit<ComponentProps<"input">, "size"> {
+  /** Field height. Defaults to `regular` (36px); `compact` is 28px. */
+  size?: InputSize;
   label?: ReactNode;
   helperText?: ReactNode;
   errorText?: ReactNode;
@@ -72,6 +97,7 @@ export interface InputProps extends Omit<ComponentProps<"input">, "size"> {
 }
 
 function Input({
+  size = "regular",
   label,
   helperText,
   errorText,
@@ -111,7 +137,10 @@ function Input({
           <span
             aria-hidden
             data-testid="input-left-icon"
-            className="pointer-events-none absolute left-3 flex items-center text-[var(--content-tertiary)]"
+            className={cn(
+              "pointer-events-none absolute flex items-center text-[var(--content-tertiary)]",
+              size === "compact" ? "left-2.5" : "left-3",
+            )}
           >
             {leftIcon}
           </span>
@@ -128,6 +157,7 @@ function Input({
             fieldVariants({
               invalid: isInvalid,
               density: "input",
+              size,
               hasLeftIcon: leftIcon != null,
               hasRightIcon: rightIcon != null,
             }),
@@ -138,7 +168,10 @@ function Input({
           <span
             aria-hidden
             data-testid="input-right-icon"
-            className="pointer-events-none absolute right-3 flex items-center text-[var(--content-tertiary)]"
+            className={cn(
+              "pointer-events-none absolute flex items-center text-[var(--content-tertiary)]",
+              size === "compact" ? "right-2.5" : "right-3",
+            )}
           >
             {rightIcon}
           </span>

--- a/packages/design-library/src/index.ts
+++ b/packages/design-library/src/index.ts
@@ -42,6 +42,7 @@ export {
   Textarea,
   fieldVariants,
   type InputProps,
+  type InputSize,
   type TextareaProps,
   type FieldVariantProps,
 } from "./components/input";


### PR DESCRIPTION
## TL;DR

`Input` gains `regular` (36px, the default) and `compact` (28px). No call site changes: all 102 existing `Input`s render exactly as before.

## Why

`Input` was the only field primitive with a fixed height. `Button`, `Select` and `SegmentControl` all take a size; a dense surface that wanted a shorter field had no way to ask through the API, which is the shape that produces wrapper overrides.

## Which scale, and why that one

`compact` is 28px, matching `Select`'s compact rather than `Button`'s 24px.

A field lines up with the fields around it, and `Select` is the control most often standing next to one. `Input` and `Select` already agree at `regular` (both 36px), so agreeing at `compact` keeps a mixed form aligned at either density. Following `Button` instead would have made a compact `Input` 4px shorter than a compact `Select` in the same row.

| | Input | Select | Button |
| --- | --- | --- | --- |
| regular | 36 | 36 | 32 |
| compact | **28** | 28 | 24 |

## Details

Horizontal padding drops from `px-3` to `px-2.5` at compact, as `Select` does, and the icon insets follow (`pl-9`/`pr-9` → `pl-8`/`pr-8`, with the absolutely-positioned icon spans moving from `left-3`/`right-3` to `left-2.5`/`right-2.5`). A leading or trailing icon keeps the same gap from the edge at either size.

`Textarea` shares the underlying `fieldVariants` but ignores `size`: its height follows its content, so a height preset has nothing to apply to. Worth revisiting if a dense multi-line field is ever wanted, since that would want padding and type-scale changes rather than a height.

`InputProps` already did `Omit<ComponentProps<"input">, "size">`, so the DOM `size` attribute was never exposed and there is no collision.

## Verification

`tsc --noEmit` clean in both `packages/design-library` and `clients/web`, which is what proves the 102 call sites are unaffected: `size` is optional and defaults to `regular`. `prettier` clean. The design library has no ESLint config, so there is no lint step for it.

A `Compact` story is added alongside the existing ones, and `size` is wired into Controls as an inline radio, matching how `Select`'s stories present the same prop.

Local test runs are blocked in my environment and Actions has been down (`qcvjkzcs7j74`), so a CI pass is worth having before merge.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40396" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->