### PR TITLE
Companion surface: the mascot is the status channel, and it is alive

### DIFF
--- a/clients/macos/src/main/avatar.test.ts
+++ b/clients/macos/src/main/avatar.test.ts
@@ -72,11 +72,28 @@ describe("avatar cache", () => {
 });
 
 describe("installAvatarIpc", () => {
-  test("registers the avatar channel once, even across repeated calls", () => {
+  test("registers both channels once, even across repeated calls", () => {
     installAvatarIpc();
     installAvatarIpc();
-    expect(registrations).toHaveLength(1);
-    expect(registrations[0]?.channel).toBe("vellum:icon:setAvatar");
+    expect(registrations.map((r) => r.channel)).toEqual([
+      "vellum:icon:setAvatar",
+      "vellum:icon:setCharacter",
+    ]);
+  });
+
+  test("the character schema takes the three trait ids, or null", () => {
+    installAvatarIpc();
+    const schema = registrations[1]!.schema;
+    expect(
+      schema.safeParse([
+        { bodyShape: "burst", eyeStyle: "curious", color: "teal" },
+      ]).success,
+    ).toBe(true);
+    expect(schema.safeParse([null]).success).toBe(true);
+    // A partial character would compose into nothing, so it is refused at the
+    // boundary rather than halfway through a render.
+    expect(schema.safeParse([{ bodyShape: "burst" }]).success).toBe(false);
+    expect(schema.safeParse(["burst"]).success).toBe(false);
   });
 
   test("the schema accepts a Uint8Array or null and rejects anything else", () => {

--- a/clients/macos/src/main/avatar.ts
+++ b/clients/macos/src/main/avatar.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import type { CompanionCharacter } from "@vellumai/ipc-contract";
+
 import { on } from "./ipc";
 
 /**
@@ -25,6 +27,7 @@ import { on } from "./ipc";
 type AvatarListener = () => void;
 
 let currentAvatarPng: Buffer | null = null;
+let currentCharacter: CompanionCharacter | null = null;
 const listeners = new Set<AvatarListener>();
 
 /**
@@ -33,6 +36,16 @@ const listeners = new Set<AvatarListener>();
  * fallback mark.
  */
 export const getAvatarPng = (): Buffer | null => currentAvatarPng;
+
+/**
+ * The traits the assistant's character is composed from, or `null` when there
+ * are none: a custom uploaded image, or no avatar at all.
+ *
+ * The still in {@link getAvatarPng} is what the Dock and Tray need, because
+ * neither can run an animation. The companion surface can, so it takes these
+ * and composes the character itself, which is the only way its eyes blink.
+ */
+export const getCharacter = (): CompanionCharacter | null => currentCharacter;
 
 /**
  * Subscribe to avatar changes. Returns an unsubscribe function. The listener
@@ -56,10 +69,33 @@ export const setAvatar = (png: Buffer | null): void => {
   for (const listener of listeners) listener();
 };
 
+/**
+ * Cache the character's traits (or `null` to clear) and notify subscribers.
+ * Same listener set as the PNG: they describe one assistant, and a surface
+ * that re-renders for one wants to re-render for the other.
+ */
+export const setCharacter = (character: CompanionCharacter | null): void => {
+  currentCharacter = character;
+  for (const listener of listeners) listener();
+};
+
 // The renderer ships raw PNG bytes as a `Uint8Array`, or `null` to clear.
 // Electron's structured clone delivers it as a `Uint8Array` (a `Buffer` is a
 // subclass), normalized to `Buffer` here so consumers have one type.
 const avatarPayloadSchema = z.tuple([z.instanceof(Uint8Array).nullable()]);
+
+// The three trait ids the character is composed from. Validated rather than
+// trusted because they are interpolated into a lookup the renderer performs;
+// unknown ids resolve to no character rather than throwing.
+const characterPayloadSchema = z.tuple([
+  z
+    .object({
+      bodyShape: z.string(),
+      eyeStyle: z.string(),
+      color: z.string(),
+    })
+    .nullable(),
+]);
 
 /**
  * Register the `vellum:icon:setAvatar` renderer→main channel. Fire-and-forget
@@ -77,6 +113,10 @@ export const installAvatarIpc = (): void => {
   on("vellum:icon:setAvatar", avatarPayloadSchema, ([png]) => {
     setAvatar(png === null ? null : Buffer.from(png));
   });
+
+  on("vellum:icon:setCharacter", characterPayloadSchema, ([character]) => {
+    setCharacter(character);
+  });
 };
 
 // Test seam — exported only for unit-test setup so each test starts from a
@@ -84,5 +124,6 @@ export const installAvatarIpc = (): void => {
 export const __resetForTesting = (): void => {
   installed = false;
   currentAvatarPng = null;
+  currentCharacter = null;
   listeners.clear();
 };

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -10,7 +10,7 @@ import {
   type VoiceActivityState,
 } from "@vellumai/ipc-contract";
 
-import { getAvatarPng, onAvatarChange } from "./avatar";
+import { getAvatarPng, getCharacter, onAvatarChange } from "./avatar";
 import { createFloatingWindow, getFloatingWindow } from "./floating-window";
 import { handle, on } from "./ipc";
 import {
@@ -105,8 +105,10 @@ let call: VoiceActivityState | null = null;
  */
 const currentState = (): CompanionSurfaceState => {
   const png = getAvatarPng();
+  const character = getCharacter();
   return {
     growth,
+    character: character === null ? undefined : character,
     avatarBase64: png === null ? undefined : png.toString("base64"),
     call,
   };

--- a/clients/macos/src/preload/index.ts
+++ b/clients/macos/src/preload/index.ts
@@ -285,6 +285,9 @@ const bridge: VellumBridge = {
     setAvatar: (png: Uint8Array | null): void => {
       ipcRenderer.send("vellum:icon:setAvatar", png);
     },
+    setCharacter: (character): void => {
+      ipcRenderer.send("vellum:icon:setCharacter", character);
+    },
   },
   dock: {
     setBadge: (count: number): void => {

--- a/clients/web/src/components/avatar/animated-avatar.tsx
+++ b/clients/web/src/components/avatar/animated-avatar.tsx
@@ -17,6 +17,16 @@ interface AnimatedAvatarProps {
   size: number;
   isAssistantBusy?: boolean;
   /**
+   * Widen the eyes: the creature has noticed something.
+   *
+   * A surface with a pointer over it uses this so the mascot answers the hand
+   * reaching for it. Deliberately the eyes alone and not the body, because
+   * "noticing" is what eyes do and a body that grew on hover would read as a
+   * button rather than a creature. Composes with the blink, which wins for its
+   * 150ms.
+   */
+  attentive?: boolean;
+  /**
    * Continuous idle "breathing" scale pulse. On by default; pass `false` to
    * keep the avatar still while leaving blink/twitch (and streaming morph)
    * intact — e.g. the scattered onboarding edge characters.
@@ -124,6 +134,7 @@ export function AnimatedAvatar({
   traits,
   size,
   isAssistantBusy = false,
+  attentive = false,
   breathe = true,
 }: AnimatedAvatarProps) {
   const reduce = useReducedMotion();
@@ -375,7 +386,13 @@ export function AnimatedAvatar({
 
       <g
         style={{
-          transform: effectiveBlinking ? "scaleY(0.1)" : "scaleY(1)",
+          // Blink first: a squish that a widening cancelled would read as the
+          // creature failing to blink rather than as it paying attention.
+          transform: effectiveBlinking
+            ? "scaleY(0.1)"
+            : attentive
+              ? "scale(1.12, 1.22)"
+              : "scaleY(1)",
           transformOrigin: `${eyeCenterOutputX}px ${eyeCenterOutputY}px`,
           transition: "transform 0.15s ease-in-out",
         }}

--- a/clients/web/src/components/companion-surface-page.tsx
+++ b/clients/web/src/components/companion-surface-page.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/runtime/companion-surface";
 import { sendVoiceActivityControl } from "@/runtime/desktop-voice-activity";
 import type {
+  CompanionCharacter,
   CompanionGrowth,
   CompanionSurfaceState,
   VoiceActivityState,
@@ -52,6 +53,7 @@ const DRAG_SLOP = 3;
 export function CompanionSurfacePage() {
   const [growth, setGrowth] = useState<CompanionGrowth>("right");
   const [avatarSrc, setAvatarSrc] = useState<string | undefined>();
+  const [character, setCharacter] = useState<CompanionCharacter | undefined>();
   const [call, setCall] = useState<VoiceActivityState | null>(null);
   const [hovered, setHovered] = useState(false);
   // Mirrors what main was last told, so a pointer crossing the pill does not
@@ -77,6 +79,7 @@ export function CompanionSurfacePage() {
           ? undefined
           : `data:image/png;base64,${state.avatarBase64}`,
       );
+      setCharacter(state.character);
       setCall(state.call);
     };
     const unsubscribe = subscribeCompanionState(apply);
@@ -187,6 +190,9 @@ export function CompanionSurfacePage() {
         phase={phase}
         growth={growth}
         avatarSrc={avatarSrc}
+        character={character}
+        // The creature notices the hand, in every state including mid-call.
+        hovered={hovered}
         accentHex={accentHex}
         call={call ?? undefined}
         rootRef={pillRef}

--- a/clients/web/src/components/companion-surface.stories.tsx
+++ b/clients/web/src/components/companion-surface.stories.tsx
@@ -39,6 +39,20 @@ const EXAMPLE_AVATAR = `data:image/svg+xml;utf8,${encodeURIComponent(
 )}`;
 
 /**
+ * The same creature as traits rather than pixels, which is how the real
+ * surface receives it: composed live so it blinks, twitches and breathes, and
+ * holds a focused pose while the turn is the assistant's.
+ *
+ * Clear `character` in the controls to see the custom-image fallback, which is
+ * a still and does none of that.
+ */
+const EXAMPLE_CHARACTER = {
+  bodyShape: "burst",
+  eyeStyle: "curious",
+  color: "teal",
+};
+
+/**
  * The surface floats over other applications, so every story sits on a
  * stand-in desktop rather than the Storybook canvas. What is behind it is the
  * variable that decides whether the pill is readable, which is why it is a
@@ -83,6 +97,7 @@ const meta: Meta<StoryArgs> = {
     glow: true,
     backdrop: "dark",
     avatarSrc: EXAMPLE_AVATAR,
+    character: EXAMPLE_CHARACTER,
   },
   decorators: [
     (Story, context) => {
@@ -117,9 +132,16 @@ export const Resting: Story = {
   args: { phase: "resting" },
 };
 
-/** Expanded with the app idle: the two ways in. */
+/**
+ * Expanded with the app idle: the two ways in.
+ *
+ * `hovered` is what the creature answers: the eyes widen while the hand is
+ * over the surface. It is a separate arg from `phase` because a call holds the
+ * pill open regardless of the pointer, and the mascot should still notice a
+ * hand arriving mid-call.
+ */
 export const Hover: Story = {
-  args: { phase: "hover" },
+  args: { phase: "hover", hovered: true },
 };
 
 /** Expanded mid-call: the session's own controls, at pill scale. */
@@ -149,6 +171,25 @@ export const PendingApproval: Story = {
       detail: "Read package.json",
       approvalRequestId: "req-1",
       startedAt: Date.now() - 14_000,
+    },
+  },
+};
+
+/**
+ * The assistant's turn, which is what the mascot expresses.
+ *
+ * Compare with `InCall` above: same row, but the creature stops blinking and
+ * holds the focused, morphing pose it uses in chat while a reply streams. The
+ * words name the finer phase; the mascot says whose turn it is.
+ */
+export const InCallAssistantTurn: Story = {
+  args: {
+    phase: "call",
+    call: {
+      ...DEMO_CALL,
+      phase: "thinking",
+      label: "Thinking\u2026",
+      startedAt: Date.now() - 9_000,
     },
   },
 };
@@ -287,6 +328,7 @@ function HoverDrivenSurface(args: StoryArgs) {
       <CompanionSurface
         {...args}
         phase={phase}
+        hovered={hovered}
         avatarSrc={uploaded ?? args.avatarSrc}
         onHoverStart={() => {
           setHovered(true);

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -1,14 +1,10 @@
 import {
   ArrowUp,
   AudioLines,
-  Brain,
   Check,
   Keyboard,
-  MessageSquareText,
   Mic,
   MicOff,
-  PhoneOff,
-  RadioTower,
   Volume2,
   VolumeX,
   X,
@@ -22,10 +18,13 @@ import type {
 } from "react";
 
 import type {
+  CompanionCharacter,
   VoiceActivityControlAction,
-  VoiceActivityPhase,
   VoiceActivityState,
 } from "@vellumai/ipc-contract";
+
+import { AnimatedAvatar } from "@/components/avatar/animated-avatar";
+import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
 
 /**
  * The macOS companion surface (LUM-3086): the assistant's avatar floating from
@@ -66,10 +65,7 @@ import type {
  *
  * Open, and reproducible from the stories:
  *
- * 1. **The microphone glyph means two things in a call**, "listening" and
- *    "mute", forty pixels apart. The shipped voice panel has the same
- *    collision, so it is worth solving once rather than twice.
- * 2. **Nothing marks a live call while resting.** The circle looks identical
+ * 1. **Nothing marks a live call while resting.** The circle looks identical
  *    whether or not the microphone is open, which is the state this surface
  *    exists to make visible.
  */
@@ -98,11 +94,30 @@ export type CompanionSurfaceGrowth = "right" | "left";
 /** Fallback accent, used until the assistant's own avatar colour is known. */
 const DEFAULT_ACCENT = "#5eead4";
 
+/**
+ * The phases that are the assistant's turn rather than the user's.
+ *
+ * What the mascot expresses is whose turn it is, which is the distinction a
+ * glance actually needs: the creature is either waiting on you or working. The
+ * finer phase is in the words beside it, where the reading is deliberate.
+ *
+ * `connecting` and `ending` are neither turn, and read better as the ordinary
+ * idle creature than as one straining.
+ */
+const ASSISTANT_TURN_PHASES = new Set(["transcribing", "thinking", "speaking"]);
+
 // The avatar is a fixed 44px disc in every state; only the body around it
 // changes. That is what makes this one surface expanding rather than three
 // surfaces that happen to share a colour, and it is the property to protect as
 // the states gain content.
 const AVATAR_BOX = 44;
+
+/**
+ * The avatar artwork inside that box, which is inset by {@link INNER_GAP} on
+ * every side. Both the still and the composed creature draw at this size, so
+ * nothing moves when one replaces the other.
+ */
+const AVATAR_IMAGE = 28;
 
 /**
  * The clearance every round thing inside the pill keeps from its edge.
@@ -184,8 +199,33 @@ export interface CompanionSurfaceProps {
    * The assistant's avatar. Any image source: the Electron payload carries it
    * as base64, which the caller turns into a data URL. Falls back to a disc in
    * the accent colour while it is still resolving.
+   *
+   * Only used when there is no {@link character} to compose, since a still
+   * cannot blink.
    */
   avatarSrc?: string;
+  /**
+   * The traits to compose the live creature from.
+   *
+   * **This is the surface's status channel.** The mascot is the one thing on
+   * the pill present in every state, so it is what carries how the assistant
+   * *is*: it blinks and breathes at rest, and holds a focused, morphing pose
+   * while the turn is the assistant's. That is also what frees the mic and
+   * speaker glyphs to mean nothing but their controls.
+   *
+   * Absent for an assistant whose avatar is a custom uploaded image, which
+   * falls back to {@link avatarSrc} and does not animate.
+   */
+  character?: CompanionCharacter;
+  /**
+   * Whether the pointer is on the surface, which the creature answers by
+   * widening its eyes.
+   *
+   * Passed rather than derived from `phase`, because a call holds the pill open
+   * regardless of the pointer and the mascot should still notice a hand
+   * arriving over it mid-call.
+   */
+  hovered?: boolean;
   /**
    * Expand. Wired to the avatar alone, never to the surface: at rest the two
    * are the same box, but arming from anything larger than what is drawn would
@@ -269,6 +309,8 @@ export function CompanionSurface({
   glow = true,
   accentHex = DEFAULT_ACCENT,
   avatarSrc,
+  character,
+  hovered = false,
   onHoverStart,
   onHoverEnd,
   growth = "right",
@@ -389,6 +431,13 @@ export function CompanionSurface({
           glow={glow && !expanded}
           accentHex={accentHex}
           avatarSrc={avatarSrc}
+          character={character}
+          attentive={hovered}
+          // The assistant's own turn. The creature stops blinking and holds a
+          // focused, morphing pose, which is the same treatment the chat avatar
+          // uses while a reply is streaming: one vocabulary for "it is working"
+          // wherever the user meets it.
+          busy={call !== undefined && ASSISTANT_TURN_PHASES.has(call.phase)}
           onMouseEnter={onHoverStart}
           onClick={onAvatarClick}
         />
@@ -518,12 +567,18 @@ function Avatar({
   glow,
   accentHex,
   avatarSrc,
+  character,
+  busy = false,
+  attentive = false,
   onMouseEnter,
   onClick,
 }: {
   glow: boolean;
   accentHex: string;
   avatarSrc?: string;
+  character?: CompanionCharacter;
+  busy?: boolean;
+  attentive?: boolean;
   onMouseEnter?: () => void;
   onClick?: () => void;
 }) {
@@ -543,8 +598,21 @@ function Avatar({
           aria-hidden
         />
       )}
-      {avatarSrc === undefined ? (
-        // Until the avatar resolves, a disc in its colour. Same 28px, so
+      {character !== undefined ? (
+        // The live creature, composed here rather than shipped as pixels. It
+        // blinks, twitches and breathes on its own, which is the whole reason
+        // the traits cross the bridge instead of a still.
+        <div className="relative drop-shadow-[0_1px_3px_rgba(0,0,0,0.55)]">
+          <AnimatedAvatar
+            components={BUNDLED_COMPONENTS}
+            traits={character}
+            size={AVATAR_IMAGE}
+            isAssistantBusy={busy}
+            attentive={attentive}
+          />
+        </div>
+      ) : avatarSrc === undefined ? (
+        // Until the avatar resolves, a disc in its colour. Same size, so
         // nothing about the geometry moves when the image lands.
         <span
           className="relative size-7 rounded-full drop-shadow-[0_1px_3px_rgba(0,0,0,0.55)]"
@@ -552,6 +620,8 @@ function Avatar({
           aria-hidden
         />
       ) : (
+        // A custom uploaded image, which has no traits to compose and so no
+        // eyes to animate.
         <img
           src={avatarSrc}
           alt=""
@@ -608,8 +678,14 @@ function IdleBody({
  * through from the session's store, because the phase wording deploys
  * continuously with the web bundle while this surface's shell ships on release
  * cadence. A surface that re-words its own phases is how the two come to
- * disagree. The glyph is the exception, and is not copy: the phase vocabulary
- * is the contract, so a new phase makes its switch a compile error.
+ * disagree.
+ *
+ * **And no phase glyph.** One belonged here until it collided: a microphone
+ * meaning "listening" sat forty pixels from a microphone meaning "mute", and a
+ * speaker meaning "speaking" from a speaker meaning "mute the assistant".
+ * Adjacent identical glyphs meaning different things is a coin flip, so status
+ * moved to the mascot, which is the one element on the pill that is not a
+ * control and cannot be mistaken for one.
  */
 function CallBody({
   call,
@@ -632,11 +708,10 @@ function CallBody({
     );
   }
 
-  const phase = call?.phase ?? "listening";
   // The activity line when the turn has one, the phase otherwise. `detail` is
   // the more specific of the two ("Reading a file" against "Thinking…") and is
   // empty for most of a call, so this reads as the surface saying more exactly
-  // when there is more to say. The glyph carries the phase either way.
+  // when there is more to say. The mascot carries the state either way.
   const line = call === undefined ? "Listening" : call.detail || call.label;
   const muted = call?.muted ?? false;
   const outputMuted = call?.outputMuted ?? false;
@@ -648,11 +723,8 @@ function CallBody({
           measure its own collapsed self: the width and the truncation would
           chase each other down. The cap is what keeps a pathological label from
           growing the pill without bound. */}
-      <span className="ml-1 flex shrink-0 items-center gap-1.5">
-        <PhaseGlyph phase={phase} />
-        <span className="max-w-[120px] truncate text-[12px] text-white/85">
-          {line}
-        </span>
+      <span className="ml-1 max-w-[120px] shrink-0 truncate text-[12px] text-white/85">
+        {line}
       </span>
       <span className="ml-1 shrink-0 font-mono text-[11px] tabular-nums text-white/60">
         <Elapsed startedAt={call?.startedAt} />
@@ -745,45 +817,11 @@ function ApprovalBody({
 }
 
 /**
- * The phase as a glyph, matching `phaseSymbol` in
- * `VoiceSessionIslandViews.swift` one-for-one.
- *
- * It earns its place by being legible at a glance from across a desk, which a
- * 12px caption is not: someone whose assistant sits in a screen corner reads
- * its state peripherally, and the glyph is what survives that. It is also what
- * keeps the phase visible on the frames where the line above shows the turn's
- * activity instead.
- *
- * Known corner, shared with the island: a `speaking` phase gone silent
- * mid-turn relabels to "Thinking…" through `liveVoiceSurfaceLabel` while
- * `phase` stays `speaking`, so the glyph reads as a speaker beside that word.
- * It is not fixable on one surface alone, because the daemon's push path
- * composes the island's content from the raw phase.
- */
-function PhaseGlyph({ phase }: { phase: VoiceActivityPhase }) {
-  const className = "size-3.5 shrink-0 text-[var(--accent)]";
-  switch (phase) {
-    case "connecting":
-      return <RadioTower className={className} aria-hidden />;
-    case "listening":
-      return <Mic className={className} aria-hidden />;
-    case "transcribing":
-      return <MessageSquareText className={className} aria-hidden />;
-    case "thinking":
-      return <Brain className={className} aria-hidden />;
-    case "speaking":
-      return <Volume2 className={className} aria-hidden />;
-    case "ending":
-      return <PhoneOff className={className} aria-hidden />;
-  }
-}
-
-/**
  * Elapsed call time.
  *
  * Ticks from a timestamp the caller owns rather than one of its own, because
  * the session started before this component mounted and will outlive it: the
- * panel that renders this can reload mid-call. With no timestamp it holds a
+ * surface that renders this can reload mid-call. With no timestamp it holds a
  * fixed sample, which is what a static story wants.
  */
 function Elapsed({ startedAt }: { startedAt?: number }) {

--- a/clients/web/src/hooks/use-electron-icon-sync.ts
+++ b/clients/web/src/hooks/use-electron-icon-sync.ts
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 
 import { isElectron } from "@/runtime/is-electron";
-import { setAssistantIcon } from "@/runtime/icon";
+import { setAssistantCharacter, setAssistantIcon } from "@/runtime/icon";
 import { rasterizeAvatar } from "@/utils/avatar-raster";
 import { resolveAvatarRender } from "@/utils/avatar-render";
 import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
@@ -26,6 +26,10 @@ const ICON_SIZE = 512;
  * the bundled-Vellum-mark fallback. Publishing `null` (no avatar, or a
  * rasterization failure) tells main to restore that fallback.
  *
+ * It also publishes the character's *traits*, for surfaces that compose the
+ * creature themselves and animate it (the companion surface). Pixels are all
+ * the Dock and the Tray can use; a surface that can blink wants the source.
+ *
  * Everything no-ops off Electron — `rasterizeAvatar` is gated behind
  * `isElectron()` so web/iOS hosts never do the canvas work. Mounted in
  * `RootLayout` next to the favicon sync so both consume the same avatar data.
@@ -45,6 +49,19 @@ export function useElectronIconSync(
       components,
       traits,
       ICON_SIZE,
+    );
+    // The traits themselves, for the surfaces that render the character live
+    // rather than as pixels. Published off the same resolution as the still, so
+    // the two can never describe different assistants: only a `character`
+    // render has traits to send, and every other outcome clears them.
+    setAssistantCharacter(
+      render.kind === "character" && traits !== null
+        ? {
+            bodyShape: traits.bodyShape,
+            eyeStyle: traits.eyeStyle,
+            color: traits.color,
+          }
+        : null,
     );
     if (render.kind === "none") {
       setAssistantIcon(null);

--- a/clients/web/src/runtime/icon.ts
+++ b/clients/web/src/runtime/icon.ts
@@ -1,4 +1,5 @@
 import { isElectron } from "@/runtime/is-electron";
+import type { CompanionCharacter } from "@vellumai/ipc-contract";
 
 /**
  * Per-capability wrapper for the Electron host's app-icon surfaces (the macOS
@@ -19,4 +20,26 @@ export function setAssistantIcon(png: Uint8Array | null): void {
     return;
   }
   window.vellum?.icon?.setAvatar(png);
+}
+
+/**
+ * Publish the traits the assistant's character is composed from, for surfaces
+ * that render it live rather than showing the still {@link setAssistantIcon}
+ * ships.
+ *
+ * The Dock and the Tray cannot animate, so pixels are all they can use. The
+ * companion surface is a web renderer and can, so it composes the character
+ * itself and the creature blinks and breathes there. Pass `null` for a custom
+ * uploaded image or no avatar, which have no traits to compose from.
+ *
+ * Safe to call from any host: no-op off Electron and on a shell that predates
+ * the channel.
+ */
+export function setAssistantCharacter(
+  character: CompanionCharacter | null,
+): void {
+  if (!isElectron()) {
+    return;
+  }
+  window.vellum?.icon?.setCharacter?.(character);
 }

--- a/clients/web/src/runtime/is-electron.ts
+++ b/clients/web/src/runtime/is-electron.ts
@@ -20,6 +20,7 @@ import type {
   AppVersionInfo,
   AssistantStatus,
   BundleScanData,
+  CompanionCharacter,
   CompanionGrowth,
   CompanionSurfaceState,
   ConnectivityState,
@@ -190,6 +191,7 @@ declare global {
       };
       icon?: {
         setAvatar(png: Uint8Array | null): void;
+        setCharacter?(character: CompanionCharacter | null): void;
       };
       dock: {
         setBadge(count: number): void;

--- a/packages/ipc-contract/src/bridge.ts
+++ b/packages/ipc-contract/src/bridge.ts
@@ -18,6 +18,7 @@ import type {
   AppVersionInfo,
   AssistantStatus,
   BundleScanData,
+  CompanionCharacter,
   CompanionSurfaceState,
   ConnectivityState,
   DeepLink,
@@ -167,6 +168,12 @@ export interface VellumBridge {
   };
   icon: {
     setAvatar(png: Uint8Array | null): void;
+    /**
+     * Publish the traits the assistant's character is composed from, so
+     * surfaces that can render it live do, rather than showing the still that
+     * `setAvatar` ships. `null` when the avatar is a custom image or absent.
+     */
+    setCharacter(character: CompanionCharacter | null): void;
   };
   dock: {
     setBadge(count: number): void;

--- a/packages/ipc-contract/src/channels.ts
+++ b/packages/ipc-contract/src/channels.ts
@@ -56,6 +56,7 @@ export const IDENTITY_NAME = "vellum:identity:name";
 
 // Icon / avatar
 export const ICON_SET_AVATAR = "vellum:icon:setAvatar";
+export const ICON_SET_CHARACTER = "vellum:icon:setCharacter";
 
 // Dock
 export const DOCK_SET_BADGE = "vellum:dock:setBadge";

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -567,9 +567,33 @@ export const COMPANION_GROWTHS = ["right", "left"] as const;
 
 export type CompanionGrowth = (typeof COMPANION_GROWTHS)[number];
 
+/**
+ * The assistant's character, as the three trait ids it is composed from.
+ *
+ * Structurally the fields of the web layer's `CharacterTraits` that
+ * `composeSvg` actually consumes, restated here rather than imported: that type
+ * is generated from the daemon's OpenAPI schema, and the contract package must
+ * not depend on it.
+ *
+ * Traits rather than pixels, because the surface renders the *live* character
+ * from them: an avatar that blinks and breathes cannot be shipped as a still.
+ * Absent for an assistant whose avatar is a custom uploaded image, which has no
+ * traits to compose from and stays a still.
+ */
+export interface CompanionCharacter {
+  bodyShape: string;
+  eyeStyle: string;
+  color: string;
+}
+
 /** What main tells the companion renderer. */
 export interface CompanionSurfaceState {
   growth: CompanionGrowth;
+  /**
+   * The character to render live, or `undefined` when there is none to
+   * compose. See {@link CompanionCharacter}; `avatarBase64` is the fallback.
+   */
+  character?: CompanionCharacter;
   /**
    * The live-voice session the surface is showing, or `null` when none is
    * running.


### PR DESCRIPTION
The remaining two points of the review: the duplicate glyph, and the eyes. They are one change, because what replaces the glyph is the mascot.

Stacked on #40395.

## The glyph goes

Two mic glyphs sat forty pixels apart in a call, one meaning "listening" and one meaning "mute". Two speakers likewise. Adjacent identical glyphs meaning different things is a coin flip, so the status glyph is gone entirely and the mic and speaker now mean nothing but their controls.

```
before:  (o) [mic] Listening 0:14 [mic] [spk] [x]
after:   (@) Listening 0:14 [mic] [spk] [x]
```

## The mascot carries status, so it has to be alive

The surface now receives the assistant's **traits** and composes the creature itself, instead of showing the still the Dock and Tray use. Traits rather than pixels because an avatar that blinks cannot be shipped as a still, and three ids are smaller than the PNG they replace.

What the creature does:

| | |
| --- | --- |
| resting | blinks, twitches, breathes |
| pointer on the surface | eyes widen |
| the assistant's turn | focused morphing pose, no blink |

The last is the same treatment the chat avatar uses while a reply streams, so "it is working" is one vocabulary wherever the user meets it. The words beside it still name the finer phase; the mascot says whose turn it is.

`attentive` is new on `AnimatedAvatar` and drives the eyes alone, not the body: noticing is what eyes do, and a body that grew on hover would read as a button rather than a creature.

## Two limits worth knowing

- **Custom uploaded images have no eyes.** They have no traits to compose from, so they keep the still. Character avatars are the common case.
- **Amplitude is deliberately not wired.** The eyes do not track the user's voice, because the session payload carries no per-frame fields on purpose: this surface costs one IPC message per state change, and voice-tracking eyes would need one per frame. The voice room is where amplitude-reactive eyes live, and it has the amplitude in-process.

## Testing

Typecheck and lint clean across `clients/macos`, `clients/web` and `packages/ipc-contract`. `avatar` tests cover the new channel and its schema, including that a partial character is refused at the boundary rather than halfway through a render; `companion-window` and `animated-avatar` tests green.

Rendered states verified in Storybook. The animation itself (blink, widen, morph) is not visible in a screenshot, so that part wants a look in the running app.

Part of LUM-3086.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
