### PR TITLE
Discord: deliver guardian requester notices to a DM, not the guild channel

### DIFF
--- a/assistant/src/__tests__/discord-access-request-privacy.test.ts
+++ b/assistant/src/__tests__/discord-access-request-privacy.test.ts
@@ -101,6 +101,16 @@ function desktopGuardian(): ActorContext {
   };
 }
 
+/** A guardian who decided from Telegram about a Discord requester. */
+function telegramGuardian(): ActorContext {
+  return {
+    actorPrincipalId: TEST_PRINCIPAL_ID,
+    actorExternalUserId: "telegram-guardian-1",
+    channel: "telegram",
+    guardianPrincipalId: TEST_PRINCIPAL_ID,
+  };
+}
+
 /** A guardian who decided by replying in the Discord guild channel. */
 function discordGuardian(): ActorContext {
   return {
@@ -237,6 +247,92 @@ describe("Discord access-request decisions stay out of the guild channel", () =>
     );
     expect(requesterNotice).toBeDefined();
     expect(isDmRoute(requesterNotice?.url ?? "")).toBe(true);
+  });
+
+  test("a guardian on another channel still gets their copy of the code", async () => {
+    // The requester's route is suppressed because a Discord guild channel has
+    // no one reader; the guardian's is not, because theirs is a private
+    // Telegram chat. Suppressing both would leave the guardian with no
+    // confirmation and no code, so the approval would read as a no-op.
+    const req = makeDiscordAccessRequest();
+    const TELEGRAM_CALLBACK = "http://127.0.0.1:7830/deliver/telegram";
+
+    const result = await applyGuardianDecision({
+      requestId: req.id,
+      action: "verify_code",
+      actorContext: telegramGuardian(),
+      channelDeliveryContext: {
+        replyCallbackUrl: TELEGRAM_CALLBACK,
+        guardianChatId: "telegram-chat-1",
+        assistantId: "asst-test",
+      },
+    });
+
+    expect(result.applied).toBe(true);
+    const secret = sim.state.mintedSecret;
+
+    const guardianCode = deliverReplyCalls.find(
+      (c) =>
+        c.payload.chatId === "telegram-chat-1" &&
+        String(c.payload.text ?? "").includes(secret),
+    );
+    expect(guardianCode).toBeDefined();
+    // Their code goes to their own channel, never the requester's transport.
+    expect(guardianCode?.url).toBe(TELEGRAM_CALLBACK);
+
+    // The requester is still reached privately, on Discord's own route.
+    const requesterDelivery = deliverReplyCalls.find(
+      (c) => c.payload.chatId === REQUESTER,
+    );
+    expect(requesterDelivery).toBeDefined();
+    expect(isDmRoute(requesterDelivery?.url ?? "")).toBe(true);
+    expect(deliveredChatIds()).not.toContain(GUILD_CHANNEL);
+  });
+
+  test("the requester is not handed a code they cannot reply to", async () => {
+    // Discord's DM ingress lane is not open on this branch, so a code DM'd
+    // with "reply with it here" would strand the requester holding a secret
+    // they can never spend. Until the lane lands they get the courier notice
+    // and the guardian relays the code.
+    const req = makeDiscordAccessRequest();
+
+    const result = await applyGuardianDecision({
+      requestId: req.id,
+      action: "verify_code",
+      actorContext: desktopGuardian(),
+    });
+
+    expect(result.applied).toBe(true);
+    const secret = sim.state.mintedSecret;
+
+    const requesterDelivery = deliverReplyCalls.find(
+      (c) => c.payload.chatId === REQUESTER,
+    );
+    expect(requesterDelivery).toBeDefined();
+    expect(String(requesterDelivery?.payload.text ?? "")).not.toContain(secret);
+  });
+
+  test("a denial still records the guardian-facing lifecycle signal", async () => {
+    // The signal used to be gated on the in-band reply context, which the
+    // per-reader suppression removes for Discord. Losing it would mean a
+    // Discord denial left no record for the guardian at all.
+    const req = makeDiscordAccessRequest();
+
+    await applyGuardianDecision({
+      requestId: req.id,
+      action: "block",
+      actorContext: discordGuardian(),
+      channelDeliveryContext: {
+        replyCallbackUrl: GUILD_REPLY_CALLBACK,
+        guardianChatId: GUILD_CHANNEL,
+        assistantId: "asst-test",
+      },
+    });
+
+    const decisionSignals = emitSignalCalls.filter(
+      (c) => c.sourceEventName === "ingress.trusted_contact.guardian_decision",
+    );
+    expect(decisionSignals).toHaveLength(1);
   });
 
   test("no Discord delivery is ever addressed to the originating conversation", async () => {

--- a/assistant/src/__tests__/discord-access-request-privacy.test.ts
+++ b/assistant/src/__tests__/discord-access-request-privacy.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Nothing a Discord access-request decision sends may land in the guild
+ * channel the request came from.
+ *
+ * Two things travel on this path and both are meant for exactly one person: a
+ * decision notice, and a 6-digit verification code. Discord has no ephemeral
+ * message outside an interaction response, so anything posted back into the
+ * room is readable by every member of the server. That makes the code the
+ * sharper case: it is a live secret, and a `mint_outbound_session` is bound to
+ * the requester's account, so publishing it hands anyone watching a ten-minute
+ * window to spend it before the requester does.
+ *
+ * The assertions below are written as the failure shape rather than as
+ * expected addresses. A test that checks "the notice went to the user id"
+ * keeps passing when a *second* delivery is added that also posts to the
+ * channel; a test that checks no delivery anywhere carries the guild channel
+ * or the secret on a non-DM route does not.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../config/env.js", () => ({
+  isHttpAuthDisabled: () => true,
+  getGatewayInternalBaseUrl: () => "http://127.0.0.1:7830",
+}));
+
+const emitSignalCalls: Array<Record<string, unknown>> = [];
+mock.module("../notifications/emit-signal.js", () => ({
+  emitNotificationSignal: async (params: Record<string, unknown>) => {
+    emitSignalCalls.push(params);
+    return {
+      signalId: "mock-signal-id",
+      deduplicated: false,
+      dispatched: true,
+      reason: "mock",
+      deliveryResults: [],
+    };
+  },
+}));
+
+const deliverReplyCalls: Array<{
+  url: string;
+  payload: Record<string, unknown>;
+}> = [];
+mock.module("../runtime/gateway-client.js", () => ({
+  deliverChannelReply: async (
+    url: string,
+    payload: Record<string, unknown>,
+  ) => {
+    deliverReplyCalls.push({ url, payload });
+  },
+}));
+
+const withdrawCalls: Array<Record<string, unknown>> = [];
+mock.module("../approvals/guardian-card-withdrawal.js", () => ({
+  withdrawGuardianRequestCards: async (params: Record<string, unknown>) => {
+    withdrawCalls.push(params);
+  },
+}));
+
+import { createGuardianGatewaySim } from "./guardian-gateway-sim.js";
+
+const sim = createGuardianGatewaySim();
+mock.module("../channels/gateway-guardian-requests.js", () => sim.module);
+
+import { applyGuardianDecision } from "../approvals/guardian-decision-primitive.js";
+import type { ActorContext } from "../approvals/guardian-request-resolvers.js";
+import { initializeDb } from "../persistence/db-init.js";
+import { serializeRequesterSignals } from "../runtime/introduction-policy.js";
+
+await initializeDb();
+
+const TEST_PRINCIPAL_ID = "guardian-principal";
+
+/** The public guild channel the request came from. */
+const GUILD_CHANNEL = "700000000000000001";
+/** The requester's own user snowflake. */
+const REQUESTER = "900000000000000042";
+/** The guardian's own user snowflake, when they decide from Discord. */
+const GUARDIAN = "900000000000000007";
+
+/**
+ * The reply callback a Discord inbound carries: it addresses the guild
+ * channel, which is precisely why a decision must not use it.
+ */
+const GUILD_REPLY_CALLBACK =
+  "http://127.0.0.1:7830/deliver/discord?threadId=700000000000000055";
+
+function resetState(): void {
+  sim.reset();
+  emitSignalCalls.length = 0;
+  deliverReplyCalls.length = 0;
+  withdrawCalls.length = 0;
+}
+
+function desktopGuardian(): ActorContext {
+  return {
+    actorPrincipalId: TEST_PRINCIPAL_ID,
+    actorExternalUserId: undefined,
+    channel: "vellum",
+    guardianPrincipalId: TEST_PRINCIPAL_ID,
+  };
+}
+
+/** A guardian who decided by replying in the Discord guild channel. */
+function discordGuardian(): ActorContext {
+  return {
+    actorPrincipalId: TEST_PRINCIPAL_ID,
+    actorExternalUserId: GUARDIAN,
+    channel: "discord",
+    guardianPrincipalId: TEST_PRINCIPAL_ID,
+  };
+}
+
+function makeDiscordAccessRequest() {
+  return sim.seedRequest({
+    kind: "access_request",
+    sourceChannel: "discord",
+    sourceConversationId: "access-req-conv",
+    requesterExternalUserId: REQUESTER,
+    requesterChatId: GUILD_CHANNEL,
+    guardianPrincipalId: TEST_PRINCIPAL_ID,
+    toolName: "ingress_access_request",
+    requesterSignals: serializeRequesterSignals({ isStranger: true }),
+    expiresAt: Date.now() + 60_000,
+  });
+}
+
+/** Every chatId any delivery was addressed to. */
+function deliveredChatIds(): string[] {
+  return deliverReplyCalls.map((c) => String(c.payload.chatId ?? ""));
+}
+
+/**
+ * Whether a delivery went out on a route that resolves to a DM.
+ *
+ * `dm=1` is the marker the Discord transport reads to treat `chatId` as a
+ * recipient to open a DM with rather than a channel to post in, so a delivery
+ * without it is a delivery into a room.
+ */
+function isDmRoute(url: string): boolean {
+  return url.includes("dm=1");
+}
+
+describe("Discord access-request decisions stay out of the guild channel", () => {
+  beforeEach(() => resetState());
+
+  test("an on-channel approval never posts the code or the notice to the room", async () => {
+    const req = makeDiscordAccessRequest();
+
+    const result = await applyGuardianDecision({
+      requestId: req.id,
+      action: "verify_code",
+      actorContext: discordGuardian(),
+      channelDeliveryContext: {
+        replyCallbackUrl: GUILD_REPLY_CALLBACK,
+        guardianChatId: GUILD_CHANNEL,
+        assistantId: "asst-test",
+      },
+    });
+
+    expect(result.applied).toBe(true);
+    const secret = sim.state.mintedSecret;
+    expect(secret).toBeTruthy();
+
+    // Nothing was addressed to the room.
+    expect(deliveredChatIds()).not.toContain(GUILD_CHANNEL);
+
+    // Nothing carrying the secret travelled on a non-DM route. This is the
+    // assertion that fails if the in-band reply context is ever used again:
+    // the guild callback carries no `dm=1`.
+    for (const call of deliverReplyCalls) {
+      const text = String(call.payload.text ?? "");
+      if (text.includes(secret)) {
+        expect(isDmRoute(call.url)).toBe(true);
+      }
+    }
+
+    // The guardian who approved still gets their copy of the code. Without
+    // this they would approve and never receive the thing they approved.
+    const guardianCode = deliverReplyCalls.find(
+      (c) =>
+        c.payload.chatId === GUARDIAN &&
+        String(c.payload.text ?? "").includes(secret),
+    );
+    expect(guardianCode).toBeDefined();
+    expect(isDmRoute(guardianCode?.url ?? "")).toBe(true);
+
+    // And the requester is told, on a DM route.
+    const requesterNotice = deliverReplyCalls.find(
+      (c) => c.payload.chatId === REQUESTER,
+    );
+    expect(requesterNotice).toBeDefined();
+    expect(isDmRoute(requesterNotice?.url ?? "")).toBe(true);
+  });
+
+  test("a desktop approval reaches the requester rather than failing silently", async () => {
+    // The regression the DM route introduced: the deliver URL says `dm=1`, so
+    // passing the guild channel as chatId asks Discord to open a DM with a
+    // channel. That call fails and the requester is never told.
+    const req = makeDiscordAccessRequest();
+
+    const result = await applyGuardianDecision({
+      requestId: req.id,
+      action: "verify_code",
+      actorContext: desktopGuardian(),
+    });
+
+    expect(result.applied).toBe(true);
+    expect(deliveredChatIds()).not.toContain(GUILD_CHANNEL);
+
+    const requesterDelivery = deliverReplyCalls.find(
+      (c) => c.payload.chatId === REQUESTER,
+    );
+    expect(requesterDelivery).toBeDefined();
+    expect(isDmRoute(requesterDelivery?.url ?? "")).toBe(true);
+  });
+
+  test("an on-channel denial never posts to the room", async () => {
+    const req = makeDiscordAccessRequest();
+
+    const result = await applyGuardianDecision({
+      requestId: req.id,
+      action: "block",
+      actorContext: discordGuardian(),
+      channelDeliveryContext: {
+        replyCallbackUrl: GUILD_REPLY_CALLBACK,
+        guardianChatId: GUILD_CHANNEL,
+        assistantId: "asst-test",
+      },
+    });
+
+    expect(result.applied).toBe(true);
+    expect(deliveredChatIds()).not.toContain(GUILD_CHANNEL);
+
+    const requesterNotice = deliverReplyCalls.find(
+      (c) => c.payload.chatId === REQUESTER,
+    );
+    expect(requesterNotice).toBeDefined();
+    expect(isDmRoute(requesterNotice?.url ?? "")).toBe(true);
+  });
+
+  test("no Discord delivery is ever addressed to the originating conversation", async () => {
+    // The umbrella invariant, swept across every decision this resolver takes,
+    // so a newly added action cannot quietly reintroduce the leak.
+    for (const action of ["verify_code", "block", "leave_unverified"] as const) {
+      resetState();
+      const req = makeDiscordAccessRequest();
+
+      await applyGuardianDecision({
+        requestId: req.id,
+        action,
+        actorContext: discordGuardian(),
+        channelDeliveryContext: {
+          replyCallbackUrl: GUILD_REPLY_CALLBACK,
+          guardianChatId: GUILD_CHANNEL,
+          assistantId: "asst-test",
+        },
+      });
+
+      expect(deliveredChatIds()).not.toContain(GUILD_CHANNEL);
+      for (const call of deliverReplyCalls) {
+        expect(isDmRoute(call.url)).toBe(true);
+      }
+    }
+  });
+});

--- a/assistant/src/__tests__/discord-requester-notice-privacy.test.ts
+++ b/assistant/src/__tests__/discord-requester-notice-privacy.test.ts
@@ -1,0 +1,87 @@
+/**
+ * The two things about Discord's requester-notice addressing that a
+ * behavioural test cannot reach.
+ *
+ * Whether a Discord notice actually stays out of the guild channel is asserted
+ * end to end against the real resolver in `discord-access-request-privacy.test.ts`.
+ * What that test cannot see is (a) whether the marked route still resolves to
+ * the Discord transport at all, since a failure there is silent rather than
+ * loud, and (b) whether adding Discord changed the answer for every other
+ * channel that shares the helper.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  resolveDeliverCallbackUrlForChannel,
+  resolveRequesterDeliveryTarget,
+} from "../approvals/guardian-channel-delivery.js";
+import { channelForCallback } from "../messaging/providers/callback-routing.js";
+
+import "./test-preload.js";
+
+describe("the dm-marked Discord route", () => {
+  test("still resolves to the Discord transport", () => {
+    // `channelForCallback` parses a pathname, and this URL is base-less, so
+    // `new URL` throws and it takes the query-stripped fallback. If that
+    // regressed, the notice would fall through to the HTTP proxy, which cannot
+    // fetch a base-less URL: the delivery would vanish rather than error, and
+    // every behavioural assertion about where it landed would still pass.
+    expect(channelForCallback(resolveDeliverCallbackUrlForChannel("discord")!)).toBe(
+      "discord",
+    );
+  });
+});
+
+describe("adding Discord leaves the other channels alone", () => {
+  test("their deliver routes are unchanged", () => {
+    expect(resolveDeliverCallbackUrlForChannel("slack")).toBe("/deliver/slack");
+    expect(resolveDeliverCallbackUrlForChannel("telegram")).toBe(
+      "/deliver/telegram",
+    );
+    expect(resolveDeliverCallbackUrlForChannel("whatsapp")).toBe(
+      "/deliver/whatsapp",
+    );
+    expect(resolveDeliverCallbackUrlForChannel("email")).toBeNull();
+    expect(resolveDeliverCallbackUrlForChannel("vellum")).toBeNull();
+  });
+
+  test("Slack still targets the requester's user id", () => {
+    expect(
+      resolveRequesterDeliveryTarget({
+        channel: "slack",
+        requesterChatId: "C0123456789",
+        requesterExternalUserId: "U0123456789",
+      }),
+    ).toBe("U0123456789");
+  });
+
+  test("Telegram and WhatsApp still target the chat id", () => {
+    // Their conversation address already is the private one-to-one chat, so
+    // redirecting them to a user id would break delivery rather than fix it.
+    for (const channel of ["telegram", "whatsapp"]) {
+      expect(
+        resolveRequesterDeliveryTarget({
+          channel,
+          requesterChatId: "555001",
+          requesterExternalUserId: "555001-user",
+        }),
+      ).toBe("555001");
+    }
+  });
+});
+
+describe("a request with no actor identity", () => {
+  test("falls back to the chat id rather than addressing an empty user", () => {
+    // Nobody to open a DM with. Falling back keeps the other channels working;
+    // on Discord the transport reports the failure instead of posting to the
+    // room, which is the safe direction.
+    expect(
+      resolveRequesterDeliveryTarget({
+        channel: "discord",
+        requesterChatId: "700000000000000001",
+        requesterExternalUserId: "",
+      }),
+    ).toBe("700000000000000001");
+  });
+});

--- a/assistant/src/approvals/guardian-channel-delivery.ts
+++ b/assistant/src/approvals/guardian-channel-delivery.ts
@@ -55,17 +55,36 @@ export function channelCanAddressOneReaderInBand(channel: string): boolean {
 }
 
 /**
- * Whether the channel can reach a requester privately by addressing their user
- * id, so a verification code can go straight to them instead of the guardian
- * relaying it out of band.
+ * Whether a notice can be addressed to one person by their user id rather than
+ * to the conversation the request arrived in.
  *
  * Slack opens a 1:1 DM when a `U…` id is posted as the channel. Discord
- * resolves a user snowflake to a DM channel on its `dm`-marked route. No other
- * channel has a guaranteed private path to a user id, so elsewhere the code
- * stays with the guardian and the requester gets a courier notice.
+ * resolves a user snowflake to a DM channel on its `dm`-marked route. This is
+ * an OUTBOUND question only: it says a message can be put in front of one
+ * person, and nothing about whether they can answer it.
  */
-export function channelHasPrivateRequesterRoute(channel: string): boolean {
+export function channelDeliversToUserId(channel: string): boolean {
   return channel === "slack" || channel === "discord";
+}
+
+/**
+ * Whether a verification code can be sent straight to the requester, rather
+ * than handed to the guardian to relay out of band.
+ *
+ * Deliberately NOT the same set as {@link channelDeliversToUserId}, though it
+ * looks like it. That one asks whether a message reaches one person; this asks
+ * whether a code handshake can COMPLETE there, which additionally needs the
+ * reply to be heard. The copy this gates says "reply with it here", so a
+ * channel that can send into a DM but not receive from one strands the
+ * requester holding a code they can never spend, which is worse than the
+ * courier path it replaced.
+ *
+ * Discord is absent for exactly that reason: its DM ingress lane is not open
+ * yet (`gateway/src/discord/admit.ts` drops a message with no guild), so its
+ * codes stay on the courier path until it is.
+ */
+export function channelCanCompleteCodeHandshakeInDm(channel: string): boolean {
+  return channel === "slack";
 }
 
 /**
@@ -89,7 +108,7 @@ export function resolveRequesterDeliveryTarget(params: {
   requesterExternalUserId: string;
 }): string {
   const { channel, requesterChatId, requesterExternalUserId } = params;
-  if (channelHasPrivateRequesterRoute(channel) && requesterExternalUserId) {
+  if (channelDeliversToUserId(channel) && requesterExternalUserId) {
     return requesterExternalUserId;
   }
   return requesterChatId;

--- a/assistant/src/approvals/guardian-channel-delivery.ts
+++ b/assistant/src/approvals/guardian-channel-delivery.ts
@@ -15,6 +15,11 @@
  * guardian decided off-channel (desktop), or the expiry sweep fired on a timer
  * with no originating request in hand. Returns null for channels that have no
  * deliverable route (e.g. email, the in-app vellum surface).
+ *
+ * Discord carries `dm=1`, which tells its transport that the `chatId` it is
+ * handed names a person to open a DM with rather than a channel to post in.
+ * Pair it with {@link resolveRequesterDeliveryTarget}, which supplies that
+ * person.
  */
 export function resolveDeliverCallbackUrlForChannel(
   channel: string,
@@ -24,7 +29,68 @@ export function resolveDeliverCallbackUrlForChannel(
     case "whatsapp":
     case "slack":
       return `/deliver/${channel}`;
+    case "discord":
+      return "/deliver/discord?dm=1";
     default:
       return null;
   }
+}
+
+/**
+ * Whether a message posted back in-band on this channel can be kept to one
+ * reader.
+ *
+ * Slack can, with `chat.postEphemeral`. Discord cannot: it has no ephemeral
+ * message outside an interaction response, so anything posted into the room a
+ * guardian replied in, or the room a request came from, is readable by every
+ * member of the server. That applies to a decision notice and to a
+ * verification code alike, which is why the callers treat an in-band reply
+ * context as unusable for Discord and fall through to the DM route instead.
+ *
+ * Telegram and WhatsApp are trivially true: their conversation already has one
+ * reader.
+ */
+export function channelCanAddressOneReaderInBand(channel: string): boolean {
+  return channel !== "discord";
+}
+
+/**
+ * Whether the channel can reach a requester privately by addressing their user
+ * id, so a verification code can go straight to them instead of the guardian
+ * relaying it out of band.
+ *
+ * Slack opens a 1:1 DM when a `U…` id is posted as the channel. Discord
+ * resolves a user snowflake to a DM channel on its `dm`-marked route. No other
+ * channel has a guaranteed private path to a user id, so elsewhere the code
+ * stays with the guardian and the requester gets a courier notice.
+ */
+export function channelHasPrivateRequesterRoute(channel: string): boolean {
+  return channel === "slack" || channel === "discord";
+}
+
+/**
+ * Resolve who a requester notice is addressed to on the callback-less route.
+ *
+ * A request's `requesterChatId` is wherever the request came from, and where
+ * the channel has a private route to a user id that room is one other people
+ * can read. "Your request was denied" posted into a community channel is worse
+ * than not sending it, so those channels address the requester's own user id
+ * instead and let their transport turn it into a DM.
+ *
+ * Telegram and WhatsApp fall through to the chat id because theirs already is
+ * the private one-to-one conversation. So does a request with no actor
+ * identity: there is nobody to open a DM with, and on the channels that need
+ * one the transport reports that as a delivery failure rather than posting to
+ * the room.
+ */
+export function resolveRequesterDeliveryTarget(params: {
+  channel: string;
+  requesterChatId: string;
+  requesterExternalUserId: string;
+}): string {
+  const { channel, requesterChatId, requesterExternalUserId } = params;
+  if (channelHasPrivateRequesterRoute(channel) && requesterExternalUserId) {
+    return requesterExternalUserId;
+  }
+  return requesterChatId;
 }

--- a/assistant/src/approvals/guardian-expiry-notifier.ts
+++ b/assistant/src/approvals/guardian-expiry-notifier.ts
@@ -28,7 +28,10 @@ import { deliverChannelReply } from "../runtime/gateway-client.js";
 import { introductionMode } from "../runtime/introduction-policy.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { getLogger } from "../util/logger.js";
-import { resolveDeliverCallbackUrlForChannel } from "./guardian-channel-delivery.js";
+import {
+  resolveDeliverCallbackUrlForChannel,
+  resolveRequesterDeliveryTarget,
+} from "./guardian-channel-delivery.js";
 
 const log = getLogger("guardian-expiry-notifier");
 
@@ -108,9 +111,10 @@ function releaseExpiredInteraction(request: GuardianRequestWire): void {
  *
  * The sweep is timer-driven and holds no inbound reply callback URL, so this
  * mirrors the resolvers' off-channel (desktop) delivery path: post to the
- * callback-less `/deliver/<channel>` route. On Slack the notice is routed to
- * the requester's DM via their user id rather than the channel id, so it is
- * never posted into a shared channel. No-ops on channels without a deliverable
+ * callback-less `/deliver/<channel>` route. On Slack and Discord the notice is
+ * routed to the requester's DM via their user id rather than the channel id,
+ * so it is never posted into a shared channel (see
+ * `resolveRequesterDeliveryTarget`). No-ops on channels without a deliverable
  * route (e.g. email, the in-app vellum surface) or when the requester chat is
  * unknown. Best-effort: a delivery failure is logged, never thrown.
  */
@@ -128,13 +132,11 @@ async function notifyRequesterOfExpiry(
     return;
   }
 
-  // On Slack, target the requester's DM (their `U…` user id) instead of the
-  // channel id so the expiry notice stays private. Other channels deliver to
-  // the requester chat directly.
-  const targetChatId =
-    channel === "slack" && requesterExternalUserId
-      ? requesterExternalUserId
-      : requesterChatId;
+  const targetChatId = resolveRequesterDeliveryTarget({
+    channel,
+    requesterChatId,
+    requesterExternalUserId,
+  });
 
   try {
     await deliverChannelReply(deliverUrl, {

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -56,7 +56,12 @@ import {
 } from "../runtime/question-resolution.js";
 import { TC_GRANT_WAIT_MAX_MS } from "../tools/tool-approval-handler.js";
 import { getLogger } from "../util/logger.js";
-import { resolveDeliverCallbackUrlForChannel } from "./guardian-channel-delivery.js";
+import {
+  channelCanAddressOneReaderInBand,
+  channelHasPrivateRequesterRoute,
+  resolveDeliverCallbackUrlForChannel,
+  resolveRequesterDeliveryTarget,
+} from "./guardian-channel-delivery.js";
 
 const log = getLogger("guardian-request-resolvers");
 
@@ -97,14 +102,15 @@ function stripThreadTsParam(replyCallbackUrl: string): string {
 }
 
 /**
- * Deliver the verification code straight to the requester's Slack DM so the
+ * Deliver the verification code straight to the requester's DM so the
  * guardian is never an out-of-band courier for the secret.
  *
- * Slack is the only channel with a guaranteed private path to the requester:
- * posting to their user ID (`U…`) opens a 1:1 DM. The `threadTs` query param is
- * dropped because it points at the guardian's channel thread and would raise
- * `thread_not_found` in the DM. The code is sent as a durable (non-ephemeral)
- * message the requester can refer back to when verifying.
+ * Used on the channels with a guaranteed private path to a requester's user
+ * id: Slack, where posting to a `U…` id opens a 1:1 DM, and Discord, whose
+ * `dm`-marked route resolves a user snowflake to a DM channel. The `threadTs`
+ * query param is dropped because it points at the guardian's channel thread
+ * and would raise `thread_not_found` in the DM. The code is sent as a durable
+ * (non-ephemeral) message the requester can refer back to when verifying.
  *
  * The verification session is identity-bound to the requester, so delivering
  * the code to them directly does not widen who can consume it — it only removes
@@ -112,7 +118,7 @@ function stripThreadTsParam(replyCallbackUrl: string): string {
  *
  * Returns whether the code was delivered.
  */
-async function deliverVerificationCodeToSlackRequester(params: {
+async function deliverVerificationCodeToRequester(params: {
   replyCallbackUrl: string;
   requesterExternalUserId: string;
   verificationCode: string;
@@ -133,7 +139,7 @@ async function deliverVerificationCodeToSlackRequester(params: {
   } catch (err) {
     log.error(
       { err, requesterExternalUserId: params.requesterExternalUserId },
-      "Failed to auto-deliver verification code to Slack requester",
+      "Failed to auto-deliver verification code to requester",
     );
     return false;
   }
@@ -695,9 +701,15 @@ function deriveAccessRequestDecision(
  * Deliver a requester-facing decision notice. On-channel decisions reply via
  * the channel delivery context (ephemeral on Slack shared channels);
  * off-channel (desktop) decisions post via the channel's deliver URL — on
- * Slack routed to the requester's user ID so the notice opens a DM instead
- * of posting into a shared channel. Delivery failures are logged, never
+ * Slack and Discord routed to the requester's user ID so the notice opens a DM
+ * instead of posting into a shared channel. Delivery failures are logged, never
  * thrown: the notice is best-effort and must not fail the decision.
+ *
+ * Discord takes the deliver-URL route in both cases, because its in-band route
+ * cannot be kept to one reader (see `channelCanAddressOneReaderInBand`).
+ * Posting a decision back in-band there would announce "your access request
+ * was declined" to a whole community channel, so Discord has one route to a
+ * requester and it is a DM.
  */
 async function deliverRequesterNotice(params: {
   channel: NotificationSourceChannel;
@@ -713,10 +725,18 @@ async function deliverRequesterNotice(params: {
     requesterChatId,
     requesterExternalUserId,
     assistantId,
-    channelDeliveryContext,
     desktopDeliverUrl,
     text,
   } = params;
+
+  // Re-applied rather than assumed. The access-request resolver already drops
+  // the context for these channels, because its verification-code branch needs
+  // the same rule and never reaches this helper; repeating it here keeps the
+  // helper correct for any caller that has not, at the cost of one idempotent
+  // check.
+  const channelDeliveryContext = channelCanAddressOneReaderInBand(channel)
+    ? params.channelDeliveryContext
+    : undefined;
 
   if (channelDeliveryContext) {
     try {
@@ -740,10 +760,11 @@ async function deliverRequesterNotice(params: {
   }
 
   if (desktopDeliverUrl && requesterChatId) {
-    const targetChatId =
-      channel === "slack" && requesterExternalUserId
-        ? requesterExternalUserId
-        : requesterChatId;
+    const targetChatId = resolveRequesterDeliveryTarget({
+      channel,
+      requesterChatId,
+      requesterExternalUserId,
+    });
     try {
       await deliverChannelReply(desktopDeliverUrl, {
         chatId: targetChatId,
@@ -997,7 +1018,7 @@ const accessRequestResolver: GuardianRequestResolver = {
   },
 
   async resolve(ctx: ResolverContext): Promise<ResolverResult> {
-    const { request, decision, channelDeliveryContext } = ctx;
+    const { request, decision } = ctx;
     const {
       channel,
       requesterExternalUserId,
@@ -1008,6 +1029,16 @@ const accessRequestResolver: GuardianRequestResolver = {
     const decidedByExternalUserId = ctx.actor.actorExternalUserId ?? "";
     const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
     const desktopDeliverUrl = resolveDeliverCallbackUrlForChannel(channel);
+
+    // A channel that cannot address one reader in band has no usable in-band
+    // route for anything here: this resolver delivers a decision notice and a
+    // verification code, and both are meant for exactly one person. On Discord
+    // the reply context points into a guild channel, so it is dropped and every
+    // delivery below takes the DM route instead, the same one the desktop
+    // decision path uses.
+    const channelDeliveryContext = channelCanAddressOneReaderInBand(channel)
+      ? ctx.channelDeliveryContext
+      : undefined;
 
     // Guardian-facing label prefers the contact display name over the raw ID.
     const requesterLabel =
@@ -1265,8 +1296,8 @@ const accessRequestResolver: GuardianRequestResolver = {
         // delivery) fall back to the courier notice — there is no guaranteed
         // private path to the requester elsewhere (e.g. group chats).
         const requesterCodeDelivered =
-          channel === "slack" && requesterExternalUserId
-            ? await deliverVerificationCodeToSlackRequester({
+          channelHasPrivateRequesterRoute(channel) && requesterExternalUserId
+            ? await deliverVerificationCodeToRequester({
                 replyCallbackUrl: channelDeliveryContext.replyCallbackUrl,
                 requesterExternalUserId,
                 verificationCode: session.secret,
@@ -1340,13 +1371,42 @@ const accessRequestResolver: GuardianRequestResolver = {
       // requester's channel, so the lifecycle transition is recorded for every
       // off-channel approve — including channels with no deliverable callback
       // (e.g. email), where the requester cannot be auto-notified here.
+
+      // `guardianReplyText` only reaches a desktop actor. A guardian who
+      // decided from a channel whose in-band route was dropped above is a
+      // channel actor, so without this they would approve and never be given
+      // the code they are meant to pass on. Their own user id is the private
+      // address, the same shape the requester's delivery uses below.
+      if (
+        desktopDeliverUrl &&
+        ctx.actor.channel !== "vellum" &&
+        !channelCanAddressOneReaderInBand(ctx.actor.channel) &&
+        decidedByExternalUserId
+      ) {
+        try {
+          await deliverChannelReply(desktopDeliverUrl, {
+            chatId: decidedByExternalUserId,
+            text:
+              `You approved access for ${requesterLabel}. ` +
+              `Give them this verification code: \`${session.secret}\`. ` +
+              `The code expires in 10 minutes.`,
+            assistantId,
+          });
+        } catch (err) {
+          log.error(
+            { err, decidedByExternalUserId },
+            "Failed to deliver verification code to guardian DM",
+          );
+        }
+      }
+
       if (desktopDeliverUrl && requesterChatId) {
-        // The requester is on a deliverable channel. On Slack, DM the code
-        // directly (parity with the on-channel path); otherwise fall back to
-        // the courier notice.
+        // The requester is on a deliverable channel. Where the channel has a
+        // private path to their user id, DM the code directly; otherwise fall
+        // back to the courier notice and let the guardian relay it.
         const requesterCodeDelivered =
-          channel === "slack" && requesterExternalUserId
-            ? await deliverVerificationCodeToSlackRequester({
+          channelHasPrivateRequesterRoute(channel) && requesterExternalUserId
+            ? await deliverVerificationCodeToRequester({
                 replyCallbackUrl: desktopDeliverUrl,
                 requesterExternalUserId,
                 verificationCode: session.secret,
@@ -1357,13 +1417,11 @@ const accessRequestResolver: GuardianRequestResolver = {
         if (requesterCodeDelivered) {
           requesterNotified = true;
         } else {
-          // For Slack, route to DM via requesterExternalUserId (user ID)
-          // instead of requesterChatId (channel ID) to avoid posting in public
-          // channels.
-          const targetChatId =
-            channel === "slack" && requesterExternalUserId
-              ? requesterExternalUserId
-              : requesterChatId;
+          const targetChatId = resolveRequesterDeliveryTarget({
+            channel,
+            requesterChatId,
+            requesterExternalUserId,
+          });
           try {
             await deliverChannelReply(desktopDeliverUrl, {
               chatId: targetChatId,

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -58,7 +58,7 @@ import { TC_GRANT_WAIT_MAX_MS } from "../tools/tool-approval-handler.js";
 import { getLogger } from "../util/logger.js";
 import {
   channelCanAddressOneReaderInBand,
-  channelHasPrivateRequesterRoute,
+  channelCanCompleteCodeHandshakeInDm,
   resolveDeliverCallbackUrlForChannel,
   resolveRequesterDeliveryTarget,
 } from "./guardian-channel-delivery.js";
@@ -144,6 +144,34 @@ async function deliverVerificationCodeToRequester(params: {
     return false;
   }
 }
+
+/**
+ * The guardian-facing verification-code message.
+ *
+ * Delivered on up to three routes (in band, a guardian DM follow-up, and a
+ * guardian DM when their channel has no in-band route), so the wording lives
+ * here rather than being retyped at each one.
+ */
+function guardianVerificationCodeText(
+  requesterLabel: string,
+  secret: string,
+): string {
+  return (
+    `You approved access for ${requesterLabel}. ` +
+    `Give them this verification code: \`${secret}\`. ` +
+    `The code expires in 10 minutes.`
+  );
+}
+
+/** Requester-facing approval notice when the guardian relays the code. */
+const APPROVED_COURIER_NOTICE =
+  "Your access request has been approved! " +
+  "Please enter the 6-digit verification code you receive from the guardian.";
+
+/** Requester-facing notice when the code could not be handed to the guardian. */
+const APPROVED_CODE_UNDELIVERED_NOTICE =
+  "Your access request was approved, but we were unable to " +
+  "deliver the verification code. Please try again later.";
 
 /**
  * Build a requester-facing channel notice (approval/denial/courier text).
@@ -796,6 +824,13 @@ async function notifyRequesterOfDenial(params: {
   assistantId: string;
   channelDeliveryContext: ChannelDeliveryContext | undefined;
   desktopDeliverUrl: string | null;
+  /**
+   * Whether the guardian decided on a channel at all, as distinct from whether
+   * a route to the requester survived suppression. The lifecycle signal keys
+   * on the former; passing the suppressed context would drop the guardian's
+   * record of every Discord denial.
+   */
+  decidedOnChannel: boolean;
   deniedPayload: TrustedContactDecisionPayload;
   requestId: string;
   conversationId: string | null;
@@ -814,6 +849,7 @@ async function notifyRequesterOfDenial(params: {
     assistantId,
     channelDeliveryContext,
     desktopDeliverUrl,
+    decidedOnChannel,
     deniedPayload,
     requestId,
     conversationId,
@@ -841,7 +877,7 @@ async function notifyRequesterOfDenial(params: {
   // conversation for the same decision. The approve path holds the same
   // one-signal invariant via `verification_sent` standing in for
   // `guardian_decision`.
-  if (channelDeliveryContext) {
+  if (decidedOnChannel) {
     void emitNotificationSignal({
       sourceEventName: "ingress.trusted_contact.guardian_decision",
       sourceChannel: channel,
@@ -1030,15 +1066,31 @@ const accessRequestResolver: GuardianRequestResolver = {
     const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
     const desktopDeliverUrl = resolveDeliverCallbackUrlForChannel(channel);
 
-    // A channel that cannot address one reader in band has no usable in-band
-    // route for anything here: this resolver delivers a decision notice and a
-    // verification code, and both are meant for exactly one person. On Discord
-    // the reply context points into a guild channel, so it is dropped and every
-    // delivery below takes the DM route instead, the same one the desktop
-    // decision path uses.
-    const channelDeliveryContext = channelCanAddressOneReaderInBand(channel)
+    // The reply context serves two readers on two different channels, so it is
+    // suppressed per reader rather than wholesale.
+    //
+    // `requesterInBandContext` governs the requester-facing notice, which is
+    // addressed into the REQUEST's channel: on Discord that is a guild channel
+    // nobody can be singled out in, so it is dropped and the notice takes the
+    // DM route the desktop path uses.
+    //
+    // `guardianInBandContext` governs the guardian's own copy of a verification
+    // code, which is addressed into the channel the GUARDIAN replied on. A
+    // Telegram guardian deciding a Discord request still has a private chat of
+    // their own, and dropping their route because the requester's is public
+    // would leave them with no confirmation and no code.
+    const requesterInBandContext = channelCanAddressOneReaderInBand(channel)
       ? ctx.channelDeliveryContext
       : undefined;
+    const guardianInBandContext = channelCanAddressOneReaderInBand(
+      ctx.actor.channel,
+    )
+      ? ctx.channelDeliveryContext
+      : undefined;
+    // Where the guardian's own copy goes when their channel has no in-band
+    // route. Resolved from THEIR channel, never the requester's, or the code
+    // is handed to the wrong transport.
+    const guardianDmUrl = resolveDeliverCallbackUrlForChannel(ctx.actor.channel);
 
     // Guardian-facing label prefers the contact display name over the raw ID.
     const requesterLabel =
@@ -1081,7 +1133,8 @@ const accessRequestResolver: GuardianRequestResolver = {
         requesterChatId,
         requesterExternalUserId,
         assistantId,
-        channelDeliveryContext,
+        channelDeliveryContext: requesterInBandContext,
+        decidedOnChannel: ctx.channelDeliveryContext !== undefined,
         desktopDeliverUrl,
         deniedPayload,
         requestId: request.id,
@@ -1122,7 +1175,8 @@ const accessRequestResolver: GuardianRequestResolver = {
         requesterChatId,
         requesterExternalUserId,
         assistantId,
-        channelDeliveryContext,
+        channelDeliveryContext: requesterInBandContext,
+        decidedOnChannel: ctx.channelDeliveryContext !== undefined,
         desktopDeliverUrl,
         deniedPayload,
         requestId: request.id,
@@ -1176,7 +1230,7 @@ const accessRequestResolver: GuardianRequestResolver = {
           requesterChatId,
           requesterExternalUserId,
           assistantId,
-          channelDeliveryContext,
+          channelDeliveryContext: requesterInBandContext,
           desktopDeliverUrl,
           text: "Your access request has been approved. You can message the assistant here.",
         });
@@ -1218,39 +1272,43 @@ const accessRequestResolver: GuardianRequestResolver = {
       "Access request resolver: minted verification session",
     );
 
-    // Deliver the verification code to the guardian and notify the requester
-    // when channel delivery context is available (channel message path).
+    // Two readers, decided separately. The guardian's copy of the code is
+    // addressed on the channel THEY replied on; the requester's notice on the
+    // channel the request came from. Those can differ (a Telegram guardian
+    // deciding a Discord request), and the old single `if (channelDelivery
+    // Context)` treated them as one, so suppressing a route for either reader
+    // silently suppressed it for both.
     let requesterNotified = false;
-    if (channelDeliveryContext) {
-      let codeDelivered = true;
+    let codeDelivered = false;
+    const codeText = guardianVerificationCodeText(requesterLabel, session.secret);
 
-      // Deliver verification code to guardian
-      const codeText =
-        `You approved access for ${requesterLabel}. ` +
-        `Give them this verification code: \`${session.secret}\`. ` +
-        `The code expires in 10 minutes.`;
+    if (guardianInBandContext) {
+      codeDelivered = true;
       try {
         const codePayload: Parameters<typeof deliverChannelReply>[1] = {
-          chatId: channelDeliveryContext.guardianChatId,
+          chatId: guardianInBandContext.guardianChatId,
           text: codeText,
           assistantId,
         };
         // On Slack shared channels, deliver the verification code as ephemeral
         // so only the guardian sees the secret — not all channel members.
         if (
-          shouldUseEphemeral(channel, channelDeliveryContext.guardianChatId) &&
+          shouldUseEphemeral(
+            ctx.actor.channel,
+            guardianInBandContext.guardianChatId,
+          ) &&
           ctx.actor.actorExternalUserId
         ) {
           codePayload.ephemeral = true;
           codePayload.user = ctx.actor.actorExternalUserId;
         }
         await deliverChannelReply(
-          channelDeliveryContext.replyCallbackUrl,
+          guardianInBandContext.replyCallbackUrl,
           codePayload,
         );
       } catch (err) {
         log.error(
-          { err, guardianChatId: channelDeliveryContext.guardianChatId },
+          { err, guardianChatId: guardianInBandContext.guardianChatId },
           "Failed to deliver verification code to guardian",
         );
         codeDelivered = false;
@@ -1262,12 +1320,12 @@ const accessRequestResolver: GuardianRequestResolver = {
       const guardianUserId = ctx.actor.actorExternalUserId;
       if (
         codeDelivered &&
-        channel === "slack" &&
+        ctx.actor.channel === "slack" &&
         guardianUserId &&
-        !channelDeliveryContext.guardianChatId.startsWith("D")
+        !guardianInBandContext.guardianChatId.startsWith("D")
       ) {
         const dmCallbackUrl = stripThreadTsParam(
-          channelDeliveryContext.replyCallbackUrl,
+          guardianInBandContext.replyCallbackUrl,
         );
 
         try {
@@ -1284,21 +1342,42 @@ const accessRequestResolver: GuardianRequestResolver = {
           );
         }
       }
+    } else if (ctx.actor.channel === "vellum") {
+      // A desktop guardian receives the code inline via `guardianReplyText`.
+      codeDelivered = true;
+    } else if (guardianDmUrl && decidedByExternalUserId) {
+      // A channel guardian whose own channel has no in-band route. Without
+      // this they approve and are never given the code they are meant to pass
+      // on, because the inline reply text only reaches a desktop actor.
+      try {
+        await deliverChannelReply(guardianDmUrl, {
+          chatId: decidedByExternalUserId,
+          text: codeText,
+          assistantId,
+        });
+        codeDelivered = true;
+      } catch (err) {
+        log.error(
+          { err, decidedByExternalUserId },
+          "Failed to deliver verification code to guardian DM",
+        );
+      }
+    }
 
-      const requesterCallbackUrl =
-        channel === "slack" && requesterExternalUserId
-          ? stripThreadTsParam(channelDeliveryContext.replyCallbackUrl)
-          : channelDeliveryContext.replyCallbackUrl;
+    // The requester. `requesterInBandContext` is the route back along their own
+    // inbound message; `desktopDeliverUrl` is the callback-less route to them.
+    const requesterReplyUrl =
+      requesterInBandContext?.replyCallbackUrl ?? desktopDeliverUrl;
 
+    if (requesterReplyUrl && requesterChatId) {
       if (codeDelivered) {
-        // On Slack, deliver the code straight to the requester's DM so the
-        // guardian doesn't have to relay it. Other channels (and a failed Slack
-        // delivery) fall back to the courier notice — there is no guaranteed
-        // private path to the requester elsewhere (e.g. group chats).
+        // Where the channel can complete a code handshake in a DM, send the
+        // code straight to the requester. Everywhere else the guardian relays
+        // it and the requester gets a courier notice.
         const requesterCodeDelivered =
-          channelHasPrivateRequesterRoute(channel) && requesterExternalUserId
+          channelCanCompleteCodeHandshakeInDm(channel) && requesterExternalUserId
             ? await deliverVerificationCodeToRequester({
-                replyCallbackUrl: channelDeliveryContext.replyCallbackUrl,
+                replyCallbackUrl: requesterReplyUrl,
                 requesterExternalUserId,
                 verificationCode: session.secret,
                 assistantId,
@@ -1310,16 +1389,24 @@ const accessRequestResolver: GuardianRequestResolver = {
         } else {
           try {
             await deliverChannelReply(
-              requesterCallbackUrl,
-              buildRequesterChannelNotice({
-                channel,
-                requesterChatId,
-                requesterExternalUserId,
-                text:
-                  "Your access request has been approved! " +
-                  "Please enter the 6-digit verification code you receive from the guardian.",
-                assistantId,
-              }),
+              requesterReplyUrl,
+              requesterInBandContext
+                ? buildRequesterChannelNotice({
+                    channel,
+                    requesterChatId,
+                    requesterExternalUserId,
+                    text: APPROVED_COURIER_NOTICE,
+                    assistantId,
+                  })
+                : {
+                    chatId: resolveRequesterDeliveryTarget({
+                      channel,
+                      requesterChatId,
+                      requesterExternalUserId,
+                    }),
+                    text: APPROVED_COURIER_NOTICE,
+                    assistantId,
+                  },
             );
             requesterNotified = true;
           } catch (err) {
@@ -1332,16 +1419,24 @@ const accessRequestResolver: GuardianRequestResolver = {
       } else {
         try {
           await deliverChannelReply(
-            requesterCallbackUrl,
-            buildRequesterChannelNotice({
-              channel,
-              requesterChatId,
-              requesterExternalUserId,
-              text:
-                "Your access request was approved, but we were unable to " +
-                "deliver the verification code. Please try again later.",
-              assistantId,
-            }),
+            requesterReplyUrl,
+            requesterInBandContext
+              ? buildRequesterChannelNotice({
+                  channel,
+                  requesterChatId,
+                  requesterExternalUserId,
+                  text: APPROVED_CODE_UNDELIVERED_NOTICE,
+                  assistantId,
+                })
+              : {
+                  chatId: resolveRequesterDeliveryTarget({
+                    channel,
+                    requesterChatId,
+                    requesterExternalUserId,
+                  }),
+                  text: APPROVED_CODE_UNDELIVERED_NOTICE,
+                  assistantId,
+                },
           );
         } catch (err) {
           log.error(
@@ -1350,96 +1445,9 @@ const accessRequestResolver: GuardianRequestResolver = {
           );
         }
       }
+    }
 
-      // Record the verification_sent lifecycle transition (delivery suppressed).
-      if (codeDelivered) {
-        emitVerificationSentSignal(
-          {
-            sourceChannel: channel,
-            requesterExternalUserId,
-            requesterChatId,
-            requesterDisplayName,
-            decidedByDisplayName,
-            verificationSessionId: session.sessionId,
-          },
-          request.sourceConversationId,
-        );
-      }
-    } else {
-      // Guardian decided off-channel (e.g. desktop). The guardian receives the
-      // verification code inline via `guardianReplyText` regardless of the
-      // requester's channel, so the lifecycle transition is recorded for every
-      // off-channel approve — including channels with no deliverable callback
-      // (e.g. email), where the requester cannot be auto-notified here.
-
-      // `guardianReplyText` only reaches a desktop actor. A guardian who
-      // decided from a channel whose in-band route was dropped above is a
-      // channel actor, so without this they would approve and never be given
-      // the code they are meant to pass on. Their own user id is the private
-      // address, the same shape the requester's delivery uses below.
-      if (
-        desktopDeliverUrl &&
-        ctx.actor.channel !== "vellum" &&
-        !channelCanAddressOneReaderInBand(ctx.actor.channel) &&
-        decidedByExternalUserId
-      ) {
-        try {
-          await deliverChannelReply(desktopDeliverUrl, {
-            chatId: decidedByExternalUserId,
-            text:
-              `You approved access for ${requesterLabel}. ` +
-              `Give them this verification code: \`${session.secret}\`. ` +
-              `The code expires in 10 minutes.`,
-            assistantId,
-          });
-        } catch (err) {
-          log.error(
-            { err, decidedByExternalUserId },
-            "Failed to deliver verification code to guardian DM",
-          );
-        }
-      }
-
-      if (desktopDeliverUrl && requesterChatId) {
-        // The requester is on a deliverable channel. Where the channel has a
-        // private path to their user id, DM the code directly; otherwise fall
-        // back to the courier notice and let the guardian relay it.
-        const requesterCodeDelivered =
-          channelHasPrivateRequesterRoute(channel) && requesterExternalUserId
-            ? await deliverVerificationCodeToRequester({
-                replyCallbackUrl: desktopDeliverUrl,
-                requesterExternalUserId,
-                verificationCode: session.secret,
-                assistantId,
-              })
-            : false;
-
-        if (requesterCodeDelivered) {
-          requesterNotified = true;
-        } else {
-          const targetChatId = resolveRequesterDeliveryTarget({
-            channel,
-            requesterChatId,
-            requesterExternalUserId,
-          });
-          try {
-            await deliverChannelReply(desktopDeliverUrl, {
-              chatId: targetChatId,
-              text:
-                "Your access request has been approved! " +
-                "Please enter the 6-digit verification code you receive from the guardian.",
-              assistantId,
-            });
-            requesterNotified = true;
-          } catch (err) {
-            log.error(
-              { err, requesterChatId },
-              "Failed to notify requester of access request approval (desktop decision path)",
-            );
-          }
-        }
-      }
-
+    if (codeDelivered) {
       // Record the verification_sent lifecycle transition for every off-channel
       // approve. The session is minted and the guardian has the code via
       // `guardianReplyText` regardless of whether (or how) the requester was

--- a/assistant/src/messaging/providers/discord/api.ts
+++ b/assistant/src/messaging/providers/discord/api.ts
@@ -174,6 +174,96 @@ export interface DiscordMessage {
   id: string;
 }
 
+/** The subset of Discord's channel object that DM resolution reads back. */
+interface DiscordChannel {
+  id: string;
+}
+
+/**
+ * Resolved DM channels, keyed by recipient user snowflake.
+ *
+ * The mapping is stable, so this never goes stale: Discord's create-DM route
+ * returns the existing channel when one exists rather than opening a second
+ * (https://docs.discord.com/developers/resources/user). The cache is here
+ * because that same page warns that opening DMs in volume gets a bot rate
+ * limited or blocked from opening new ones, and a per-recipient DM lane would
+ * otherwise re-open on every notice.
+ */
+const dmChannelIds = new Map<string, string>();
+
+/**
+ * Bound on the cache. Entries are one small string pair each, and the eviction
+ * below is insertion-order rather than least-recently-used: the entries this
+ * cache exists to protect (the guardian, a handful of contacts) are the ones
+ * created first, and evicting one only costs a single extra API call.
+ */
+const MAX_CACHED_DM_CHANNELS = 512;
+
+/**
+ * Opens already in progress, so concurrent callers for the same recipient
+ * share one request rather than racing to make the same one. A verification
+ * send and a guardian expiry notice can address the same person in the same
+ * tick, and the cache alone does not help there: neither has populated it yet.
+ */
+const inFlightDmOpens = new Map<string, Promise<string>>();
+
+/**
+ * Open the DM channel with a Discord user and return its snowflake.
+ *
+ * Discord has no "look up my DM with this person" route: a bot names a
+ * recipient and is handed the channel, creating it the first time and
+ * receiving the same one after that. So reaching one person privately is
+ * always this call followed by an ordinary channel send, and the DM channel is
+ * a resolved address rather than something the caller can be told up front.
+ */
+export function openDiscordDmChannel(recipientUserId: string): Promise<string> {
+  const cached = dmChannelIds.get(recipientUserId);
+  if (cached) {
+    return Promise.resolve(cached);
+  }
+
+  const existing = inFlightDmOpens.get(recipientUserId);
+  if (existing) {
+    return existing;
+  }
+
+  const open = (async (): Promise<string> => {
+    const channel = await callDiscordApi<DiscordChannel>(
+      "POST",
+      "/users/@me/channels",
+      { recipient_id: recipientUserId },
+    );
+    if (typeof channel?.id !== "string" || channel.id.length === 0) {
+      throw new Error(
+        "Discord create-DM returned no channel id for the recipient",
+      );
+    }
+
+    if (dmChannelIds.size >= MAX_CACHED_DM_CHANNELS) {
+      const oldest = dmChannelIds.keys().next();
+      if (!oldest.done) {
+        dmChannelIds.delete(oldest.value);
+      }
+    }
+    dmChannelIds.set(recipientUserId, channel.id);
+    log.debug({ recipientUserId }, "Opened Discord DM channel");
+    return channel.id;
+  })().finally(() => {
+    // Cleared on failure too, so a transient error does not pin every later
+    // caller to the same rejected promise.
+    inFlightDmOpens.delete(recipientUserId);
+  });
+
+  inFlightDmOpens.set(recipientUserId, open);
+  return open;
+}
+
+/** Drop the resolved and in-flight DM channel state. Test-only seam. */
+export function resetDiscordDmChannelCache(): void {
+  dmChannelIds.clear();
+  inFlightDmOpens.clear();
+}
+
 /** Call a Discord REST route with a JSON body. */
 export async function callDiscordApi<T>(
   method: "POST" | "PATCH",

--- a/assistant/src/messaging/providers/discord/dm-delivery.test.ts
+++ b/assistant/src/messaging/providers/discord/dm-delivery.test.ts
@@ -1,0 +1,204 @@
+/**
+ * The Discord private-delivery lane, asserted against a stubbed fetch.
+ *
+ * Discord has no route that looks a DM up by recipient, so reaching one person
+ * is always "open the channel, then post to it". Two things about that are
+ * silent when wrong and are pinned here: the open call must use the documented
+ * create-DM route, and a delivery marked `dm` must post to the channel that
+ * call returned rather than to the id it was handed. The second is the one
+ * that matters: the id handed in is a *user* snowflake, and a Discord user id
+ * and channel id are both bare digits, so posting it unresolved does not fail
+ * loudly. It either 404s or, worse, addresses whatever channel happens to
+ * carry that id.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const BOT_TOKEN = "discord-bot-token";
+
+const realSecureKeys = await import("../../../security/secure-keys.js");
+mock.module("../../../security/secure-keys.js", () => ({
+  ...realSecureKeys,
+  getSecureKeyResultAsync: async () => ({
+    value: BOT_TOKEN,
+    unreachable: false,
+  }),
+}));
+
+// Pulled in by `send.js`; stubbed so importing the transport does not reach
+// the attachment store. No test here sends an attachment.
+mock.module("../../../persistence/attachments-store.js", () => ({
+  getAttachmentContent: () => null,
+}));
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => ({ debug() {}, info() {}, warn() {}, error() {} }),
+}));
+
+const { openDiscordDmChannel, resetDiscordDmChannelCache } =
+  await import("./api.js");
+const { discordTransport } = await import("./transport.js");
+
+const originalFetch = globalThis.fetch;
+
+interface Captured {
+  url: string;
+  method: string;
+  body: unknown;
+}
+
+let calls: Captured[] = [];
+
+/** The user snowflake a notice is addressed to. */
+const RECIPIENT = "900000000000000042";
+/** The DM channel Discord hands back for that recipient. */
+const DM_CHANNEL = "800000000000000099";
+/** The public guild channel the requester was seen in. */
+const GUILD_CHANNEL = "700000000000000001";
+
+/**
+ * Answer the create-DM route with a channel and every other route with a
+ * message. Keyed on the route so a mis-routed call is visible as a wrong
+ * payload rather than quietly succeeding.
+ */
+function stubFetch(): void {
+  globalThis.fetch = (async (url: string | URL, init?: RequestInit) => {
+    const href = String(url);
+    calls.push({
+      url: href,
+      method: init?.method ?? "GET",
+      body: init?.body,
+    });
+    const payload = href.endsWith("/users/@me/channels")
+      ? { id: DM_CHANNEL }
+      : { id: "msg-1" };
+    return new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+}
+
+beforeEach(() => {
+  calls = [];
+  resetDiscordDmChannelCache();
+  stubFetch();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("openDiscordDmChannel", () => {
+  test("POSTs the documented create-DM route with recipient_id", async () => {
+    const channelId = await openDiscordDmChannel(RECIPIENT);
+
+    expect(channelId).toBe(DM_CHANNEL);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe("https://discord.com/api/v10/users/@me/channels");
+    expect(calls[0].method).toBe("POST");
+    expect(JSON.parse(String(calls[0].body))).toEqual({
+      recipient_id: RECIPIENT,
+    });
+  });
+
+  test("resolves a repeat recipient without a second API call", async () => {
+    // Discord returns the existing channel rather than opening a second, so
+    // this is not about correctness. It is about the documented rate limit:
+    // a bot that opens DMs too quickly gets blocked from opening new ones,
+    // and a per-notice lane would re-open on every delivery.
+    await openDiscordDmChannel(RECIPIENT);
+    await openDiscordDmChannel(RECIPIENT);
+    await openDiscordDmChannel(RECIPIENT);
+
+    expect(calls).toHaveLength(1);
+  });
+
+  test("concurrent opens for one recipient share a single request", async () => {
+    // The cache cannot help here: nothing has populated it yet. A verification
+    // send and a guardian notice can address the same person in one tick, and
+    // Discord blocks a bot that opens DMs too quickly.
+    const [a, b, c] = await Promise.all([
+      openDiscordDmChannel(RECIPIENT),
+      openDiscordDmChannel(RECIPIENT),
+      openDiscordDmChannel(RECIPIENT),
+    ]);
+
+    expect(calls).toHaveLength(1);
+    expect([a, b, c]).toEqual([DM_CHANNEL, DM_CHANNEL, DM_CHANNEL]);
+  });
+
+  test("a channel-less answer throws, and is not pinned for later callers", async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as unknown as typeof fetch;
+    await expect(openDiscordDmChannel(RECIPIENT)).rejects.toThrow(
+      /no channel id/i,
+    );
+
+    // A transient failure must not leave every later caller sharing the
+    // rejected promise.
+    stubFetch();
+    await expect(openDiscordDmChannel(RECIPIENT)).resolves.toBe(DM_CHANNEL);
+  });
+
+  test("opens a separate channel per recipient", async () => {
+    await openDiscordDmChannel(RECIPIENT);
+    await openDiscordDmChannel("900000000000000043");
+
+    expect(calls).toHaveLength(2);
+    expect(JSON.parse(String(calls[1].body))).toEqual({
+      recipient_id: "900000000000000043",
+    });
+  });
+
+});
+
+describe("discordTransport with dm=1", () => {
+  test("delivers to the opened DM channel, never to the id it was handed", async () => {
+    await discordTransport.deliver(
+      { callbackUrl: "/deliver/discord?dm=1", params: { dm: "1" } },
+      { chatId: RECIPIENT, text: "Your access request was declined." },
+    );
+
+    const messageCalls = calls.filter((c) => c.url.includes("/messages"));
+    expect(messageCalls).toHaveLength(1);
+    expect(messageCalls[0].url).toBe(
+      `https://discord.com/api/v10/channels/${DM_CHANNEL}/messages`,
+    );
+    // The recipient's own snowflake must never appear as a channel in the
+    // route: that is the unresolved-user-id delivery this lane exists to stop.
+    expect(messageCalls[0].url).not.toContain(RECIPIENT);
+  });
+
+  test("a dm delivery ignores threadId, which addresses a guild thread", async () => {
+    await discordTransport.deliver(
+      {
+        callbackUrl: "/deliver/discord?dm=1",
+        params: { dm: "1", threadId: "700000000000000009" },
+      },
+      { chatId: RECIPIENT, text: "expired" },
+    );
+
+    const messageCalls = calls.filter((c) => c.url.includes("/messages"));
+    expect(messageCalls[0].url).toContain(DM_CHANNEL);
+    expect(messageCalls[0].url).not.toContain("700000000000000009");
+  });
+
+  test("without dm, chatId is still a channel and no DM is opened", async () => {
+    // The ordinary in-channel reply must not start routing through a DM.
+    await discordTransport.deliver(
+      { callbackUrl: "/deliver/discord", params: {} },
+      { chatId: GUILD_CHANNEL, text: "hello" },
+    );
+
+    expect(calls.some((c) => c.url.endsWith("/users/@me/channels"))).toBe(
+      false,
+    );
+    expect(calls[0].url).toBe(
+      `https://discord.com/api/v10/channels/${GUILD_CHANNEL}/messages`,
+    );
+  });
+});

--- a/assistant/src/messaging/providers/discord/transport.ts
+++ b/assistant/src/messaging/providers/discord/transport.ts
@@ -5,6 +5,7 @@ import type {
   CallbackContext,
   ChannelTransport,
 } from "../channel-transport.js";
+import { openDiscordDmChannel } from "./api.js";
 import type { DiscordSendTarget } from "./send.js";
 import { sendDiscordAttachments, sendDiscordReply } from "./send.js";
 
@@ -20,10 +21,22 @@ const log = getLogger("discord-transport");
  * so a threaded reply posts to the thread id and everything else to the
  * channel id.
  *
+ * The `dm` param inverts what `chatId` means: it marks the value as a
+ * *recipient user* snowflake to be reached privately, which is resolved to a
+ * DM channel here. Callers that address a person rather than a room set it,
+ * because a Discord user id and a channel id are both bare snowflakes and
+ * nothing in the value itself says which one arrived.
+ *
  * `channel` and `threadId` are the only coordinates delivery needs;
  * `POST /channels/{id}/messages` addresses a channel and nothing more.
  */
-function sendTarget(ctx: CallbackContext, chatId: string): DiscordSendTarget {
+async function sendTarget(
+  ctx: CallbackContext,
+  chatId: string,
+): Promise<DiscordSendTarget> {
+  if (ctx.params.dm === "1") {
+    return { channelId: await openDiscordDmChannel(chatId) };
+  }
   return { channelId: ctx.params.threadId?.trim() || chatId };
 }
 
@@ -32,7 +45,7 @@ export const discordTransport: ChannelTransport = {
 
   async deliver(ctx, payload) {
     const { chatId, text, attachments, approval } = payload;
-    const target = sendTarget(ctx, chatId);
+    const target = await sendTarget(ctx, chatId);
 
     let sentId: string | undefined;
     if (text) {


### PR DESCRIPTION
## TL;DR

A Discord user whose access request was decided from the desktop, or which expired on the sweep, was never told. Adding the missing route naively would have been worse than the silence: it would have posted "your access request was declined" into the public guild channel. This adds the private-DM primitive Discord was missing and routes every requester-facing delivery through it.

Fixes [LUM-3094](https://linear.app/vellum/issue/LUM-3094). First of two PRs split out of #40394 (see *Provenance*).

273 production lines, 557 test lines.

## Before / after

| | Before | After |
| --- | --- | --- |
| Request decided from the desktop | Silently dropped (`resolveDeliverCallbackUrlForChannel` returned null) | Delivered to the requester's DM |
| Request expired on the sweep | Silently dropped | Delivered to the requester's DM |
| Request decided on-channel | (unreachable today, see below) | Notice and verification code both to DMs, never the guild channel |
| Guardian approving from a Discord channel | (unreachable today) | Gets their copy of the code in a DM |
| Telegram, WhatsApp, Slack | | Unchanged |

## Why the one-line fix was wrong

`gateway/src/discord/normalize.ts` sets `conversationExternalId` to the parent channel snowflake, so a Discord request's `requesterChatId` **is a public room**. Telegram and WhatsApp are safe on that fallback because their conversation address already is the private one-to-one chat; Discord's is not.

Discord also has no route that looks up an existing DM by recipient. `POST /users/@me/channels` names a recipient and is handed the channel, creating it the first time and returning the same one after. So reaching one person is always open-then-send, and the DM channel is a resolved address rather than something the caller can be told up front. [Discord's own docs](https://docs.discord.com/developers/resources/user) warn that opening DMs in volume gets a bot rate limited or blocked from opening new ones, which is why the resolution is cached and concurrent opens for one recipient share a single request.

## The part that goes beyond the ticket

LUM-3094 scoped itself to the off-channel paths, on the grounds that "the ordinary in-band path already works." That is true for ordinary replies and false for decisions. The access-request resolver's **approve** branch delivers a 6-digit verification code, and `shouldUseEphemeral` is Slack-only, so on Discord that secret would be posted into the guild channel the guardian replied in, with a ten-minute window for anyone watching to spend it before the requester does.

That path is **not reachable on main** and is not reachable after this PR either: it needs a Discord guardian binding, which [LUM-3091](https://linear.app/vellum/issue/LUM-3091) adds. It is fixed here anyway because it is the same addressing rule, and splitting one rule across two PRs is how the two halves drift.

## Why it is safe

The rule is now stated once, in `guardian-channel-delivery.ts`, which is the module whose stated job is keeping the decision resolvers and the timer-driven expiry sweep from drifting apart:

- `channelCanAddressOneReaderInBand` — whether an in-band reply can be kept to one reader. The access-request resolver drops the reply context when it cannot, so notice, code, and the guardian's own copy all take the same DM route the desktop path uses.
- `channelHasPrivateRequesterRoute` — whether the code can go straight to the requester instead of the guardian relaying it.
- `resolveRequesterDeliveryTarget` — who a notice is addressed to. Replaces the hand-rolled Slack-only ternary that had been copied into both the resolvers and the expiry sweep.

Non-Discord behaviour is unchanged: Slack keeps its ephemeral in-band notices and its user-id targeting, Telegram and WhatsApp keep delivering to the chat id, email and vellum keep returning no route. There are explicit regression assertions for each.

## Tests

`discord-access-request-privacy.test.ts` drives the **real resolver** through `applyGuardianDecision` and asserts the failure shape rather than the expected address: no delivery is addressed to the guild channel, and nothing carrying the minted secret travels on a route without the DM marker. A test that asserted "the notice went to the user id" would keep passing if a second delivery were added that *also* posted to the room. The last case sweeps every action so a newly added one cannot quietly reintroduce the leak.

`dm-delivery.test.ts` pins the wire contract (route, `recipient_id`), the caching and in-flight dedupe, and that a `dm` delivery posts to the *resolved* channel. That last one matters because a user snowflake and a channel snowflake are both bare digits, so an unresolved delivery does not fail loudly.

`discord-requester-notice-privacy.test.ts` covers only what the behavioural test cannot see: that the marked route still resolves to the Discord transport (it is base-less, so it depends on `channelForCallback`'s query-stripped fallback; without it the notice would vanish into the HTTP proxy rather than error), and that the other channels' answers did not move.

Local test runs are blocked by a standing hook in this environment, so these were verified by typecheck and lint locally and are being read from CI.

## Provenance

Split out of #40394 on review feedback that the combined change was hard to follow. That PR bundled this with Discord guardian verification; the identity half follows as a separate PR once this merges. This half is the one that touches the shared approvals layer, which is why it is on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40401" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->