### PR TITLE
feat(web): render the voice_picker surface inline in chat

### DIFF
--- a/clients/web/src/domains/chat/components/surfaces/surface-router.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/surface-router.tsx
@@ -22,6 +22,7 @@ import { SurfaceContainer } from "@/domains/chat/components/surfaces/surface-con
 import { TableSurface } from "@/domains/chat/components/surfaces/table-surface";
 import { TaskPreferencesSurface } from "@/domains/chat/components/surfaces/task-preferences-surface";
 import { VisualSurface } from "@/domains/chat/components/surfaces/visual-surface";
+import { VoicePickerSurface } from "@/domains/chat/components/surfaces/voice-picker-surface";
 import { WorkResultSurface } from "@/domains/chat/components/surfaces/work-result-surface";
 
 export interface SurfaceRouterProps {
@@ -169,6 +170,20 @@ function SurfaceRouterInner({
 
     case "task_preferences":
       return <TaskPreferencesSurface surface={surface} onAction={onAction} />;
+
+    // Deliberately absent from `INHERENTLY_INTERACTIVE_SURFACE_TYPES` and
+    // `OPTIMISTIC_COMPLETION_SURFACE_TYPES`. A settings card has no terminal
+    // action and so never completes: listing it in the first would block the
+    // composer indefinitely, and in the second would collapse the card into a
+    // "Done" chip on the first pick.
+    case "voice_picker":
+      return (
+        <VoicePickerSurface
+          surface={surface}
+          onAction={onAction}
+          assistantId={assistantId}
+        />
+      );
 
     case "work_result":
       return <WorkResultSurface surface={surface} onAction={onAction} />;


### PR DESCRIPTION
## Summary
- Route `surfaceType: "voice_picker"` to `VoicePickerSurface` (added in #40304) so the picker renders inline in the transcript instead of the "Unsupported surface type" fallback.
- Thread `assistantId` through so the card reads the voice config of the assistant that owns the stream, not the globally-active one.
- Leave `INHERENTLY_INTERACTIVE_SURFACE_TYPES` and `OPTIMISTIC_COMPLETION_SURFACE_TYPES` untouched, with a comment at the new case saying why: a settings card never completes, so listing it would block the composer indefinitely or collapse the card into a "Done" chip on the first pick.

Part of plan: inline-voice-picker-surface.md (PR 2 of 5)