### PR TITLE
feat(assistant): let the model show the voice picker inline

### DIFF
--- a/assistant/src/__tests__/ui-shape-teaching.test.ts
+++ b/assistant/src/__tests__/ui-shape-teaching.test.ts
@@ -5,6 +5,7 @@ import { uiShowTool } from "../tools/ui-surface/definitions.js";
 import {
   SURFACE_SHAPE_DOCS,
   SURFACE_TYPE_NAMES,
+  UI_SHOW_TYPE_DOCS,
   uiShowTeachingError,
 } from "../tools/ui-surface/surface-shape-docs.js";
 
@@ -290,6 +291,12 @@ describe("ui_show displayable payloads proxy through", () => {
         surfaceType: "channel_setup",
         input: { surface_type: "channel_setup", data: { channel: "telegram" } },
       },
+      {
+        // The picker reads its own voice and catalog, so an empty payload is
+        // the whole contract and there is no missing-content state to teach.
+        surfaceType: "voice_picker",
+        input: { surface_type: "voice_picker", data: {} },
+      },
     ];
 
   for (const { surfaceType, input } of cases) {
@@ -346,5 +353,15 @@ describe("uiShowTeachingError", () => {
     for (const name of SURFACE_TYPE_NAMES) {
       expect(uiShowTool.description).toContain(name);
     }
+  });
+
+  test("voice_picker is a cold type that accepts an empty payload", () => {
+    expect(
+      uiShowTeachingError({ surface_type: "voice_picker", data: {} }),
+    ).toBeNull();
+    expect(UI_SHOW_TYPE_DOCS).toContain(
+      `voice_picker (${SURFACE_SHAPE_DOCS.voice_picker!.purpose})`,
+    );
+    expect(UI_SHOW_TYPE_DOCS).not.toContain("- voice_picker:");
   });
 });

--- a/assistant/src/tools/ui-surface/surface-shape-docs.ts
+++ b/assistant/src/tools/ui-surface/surface-shape-docs.ts
@@ -211,6 +211,11 @@ export const SURFACE_SHAPE_DOCS: Record<string, SurfaceShapeDoc> = {
         ? null
         : '`data.channel` must be one of "slack", "telegram", "phone"',
   },
+  voice_picker: {
+    purpose: "inline picker for the voice the assistant speaks in",
+    shape:
+      "{}: no payload, the card reads the current voice and the catalog itself. Show it when the user asks to change, hear, or pick a voice, instead of describing voices in prose or sending them to Settings. Selecting a voice applies on the assistant's next spoken turn",
+  },
 };
 
 /** Model-facing surface_type enum, derived so docs and schema cannot drift. */


### PR DESCRIPTION
## Summary
- Add a `voice_picker` entry to `SURFACE_SHAPE_DOCS`, which is what puts the type in the model-facing `ui_show` `surface_type` enum (`SURFACE_TYPE_NAMES` is derived from this object and feeds `definitions.ts`).
- No `missingContent` guard and no `HOT_SURFACE_TYPES` membership: the payload is legitimately empty, so there is nothing to teach and no reason to spend hot-tier description tokens. It appears as a one-line cold index entry.
- Tests cover both halves: `ui_show { surface_type: "voice_picker", data: {} }` proxies through with no teaching error, and the type shows up in the cold index rather than the hot full-shape block. Slack is unaffected, its `ui_show` variant still hard-restricts `surface_type` to `["card"]`.

Part of plan: inline-voice-picker-surface.md (PR 4 of 5)