### PR TITLE
refactor(web): finish renaming the helpers that named Dropdown

### DIFF
--- a/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -147,7 +147,7 @@ function getSaveBtn(): HTMLButtonElement {
 }
 
 /** All Select triggers (custom comboboxes) in document order. */
-function dropdownTriggers(): HTMLButtonElement[] {
+function selectTriggers(): HTMLButtonElement[] {
   return Array.from(
     document.querySelectorAll<HTMLButtonElement>('button[role="combobox"]'),
   );
@@ -254,7 +254,7 @@ function selectModel(label: string): void {
   // listbox contains the target model label. Probing each candidate keeps the
   // helper robust to the optional Connection dropdown appearing alongside it.
   const provTrigger = providerTrigger();
-  for (const trigger of dropdownTriggers()) {
+  for (const trigger of selectTriggers()) {
     if (trigger === provTrigger) {
       continue;
     }
@@ -989,7 +989,7 @@ describe("ProfileEditorModal create mode — provider-first", () => {
 
     // The Model dropdown trigger explains the empty list instead of showing
     // a bare "Select a model" placeholder over zero options...
-    const triggerLabels = dropdownTriggers().map((t) => t.textContent?.trim());
+    const triggerLabels = selectTriggers().map((t) => t.textContent?.trim());
     expect(triggerLabels).toContain("No models available");
     expect(triggerLabels).not.toContain("Select a model");
 
@@ -1008,7 +1008,7 @@ describe("ProfileEditorModal create mode — provider-first", () => {
 
     selectProvider("Ollama");
 
-    const triggerLabels = dropdownTriggers().map((t) => t.textContent?.trim());
+    const triggerLabels = selectTriggers().map((t) => t.textContent?.trim());
     expect(triggerLabels).toContain("Select a model");
     expect(triggerLabels).not.toContain("No models available");
 
@@ -1376,7 +1376,7 @@ describe("ProfileEditorModal edit mode — catalog-absent bound model", () => {
     // The Model trigger surfaces the bound id (no catalog/connection name
     // available, so it falls back to the raw id) rather than the empty
     // placeholder...
-    const triggerLabels = dropdownTriggers().map((t) => t.textContent?.trim());
+    const triggerLabels = selectTriggers().map((t) => t.textContent?.trim());
     expect(triggerLabels).toContain("openrouter/fusion");
     expect(triggerLabels).not.toContain("Select a model");
 
@@ -1423,7 +1423,7 @@ describe("ProfileEditorModal edit mode — catalog-absent bound model", () => {
 
     // Open each combobox; the Model dropdown must list the bound id so it can
     // be re-selected manually (the second reported surface of JARVIS-1180).
-    const optionLabels = dropdownTriggers().flatMap((trigger) => {
+    const optionLabels = selectTriggers().flatMap((trigger) => {
       fireEvent.click(trigger);
       const labels = Array.from(
         document.querySelectorAll<HTMLElement>('[role="option"]'),
@@ -1465,15 +1465,15 @@ describe("ProfileEditorModal edit mode — catalog-absent bound model", () => {
     // The incompatible model is auto-cleared: the Model trigger falls back to the
     // placeholder and never surfaces "GPT-5.5 Pro".
     await waitFor(() => {
-      const labels = dropdownTriggers().map((t) => t.textContent?.trim());
+      const labels = selectTriggers().map((t) => t.textContent?.trim());
       expect(labels).toContain("Select a model");
     });
-    expect(dropdownTriggers().map((t) => t.textContent?.trim())).not.toContain(
+    expect(selectTriggers().map((t) => t.textContent?.trim())).not.toContain(
       "GPT-5.5 Pro",
     );
 
     // The dropdown offers the Codex-compatible models but not the filtered one.
-    const optionLabels = dropdownTriggers().flatMap((trigger) => {
+    const optionLabels = selectTriggers().flatMap((trigger) => {
       fireEvent.click(trigger);
       const labels = Array.from(
         document.querySelectorAll<HTMLElement>('[role="option"]'),
@@ -1526,7 +1526,7 @@ describe("ProfileEditorModal edit mode — catalog-absent bound model", () => {
     // WHEN the user picks the free-text option (the Model dropdown is the only
     // one offering it) and types an id absent from the catalog, then saves
     let pickedCustom = false;
-    for (const trigger of dropdownTriggers()) {
+    for (const trigger of selectTriggers()) {
       fireEvent.click(trigger);
       const customOption = Array.from(
         document.querySelectorAll<HTMLElement>('[role="option"]'),
@@ -1582,7 +1582,7 @@ describe("ProfileEditorModal edit mode — catalog-absent bound model", () => {
       subscriptionConnection,
     );
 
-    const optionLabels = dropdownTriggers().flatMap((trigger) => {
+    const optionLabels = selectTriggers().flatMap((trigger) => {
       fireEvent.click(trigger);
       const labels = Array.from(
         document.querySelectorAll<HTMLElement>('[role="option"]'),

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
@@ -339,7 +339,7 @@ function renderPage(
   );
 }
 
-function dropdownTrigger(ariaLabel: string): HTMLButtonElement {
+function selectTrigger(ariaLabel: string): HTMLButtonElement {
   const trigger = document.querySelector<HTMLButtonElement>(
     `button[role="combobox"][aria-label="${ariaLabel}"]`,
   );
@@ -350,7 +350,7 @@ function dropdownTrigger(ariaLabel: string): HTMLButtonElement {
 }
 
 function openSelect(ariaLabel: string): void {
-  fireEvent.click(dropdownTrigger(ariaLabel));
+  fireEvent.click(selectTrigger(ariaLabel));
 }
 
 function optionLabels(): string[] {
@@ -1030,7 +1030,7 @@ describe("CustomPlanModal — Pro plan holding a deprecated (legacy) credit bund
 
     // Seeded to the held tier (a no-op), so Continue starts disabled.
     expect(continueButton().disabled).toBe(true);
-    expect(dropdownTrigger("Storage").textContent).toContain("250 GB");
+    expect(selectTrigger("Storage").textContent).toContain("250 GB");
     expect(recapRows()).toEqual([
       "Platform fee: $20/mo",
       "Medium machine (2.5 vCPU, 5 GiB)",

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -95,7 +95,7 @@ body {
 }
 
 /* Home Activity detail drawer (schedule / heartbeat / notification) sliding
-   in from the right. The panel hosts fixed Dropdown/tooltip layers, so the
+   in from the right. The panel hosts fixed Select/tooltip layers, so the
    fill mode below matters: see the note on the rule. */
 @keyframes drawer-slide-in {
   0% { transform: translateX(16px); opacity: 0; }


### PR DESCRIPTION
## TL;DR

Three `Dropdown` references the sweep in [#40399](https://github.com/vellum-ai/vellum-assistant/pull/40399) missed. Renames and a comment; no behaviour, no queries, no assertions.

Caught by Vex's review on that PR, after Devin caught a fourth of the same kind.

## What was missed, and why

Each one sat past the edge of the grep that found the rest, in a different direction:

| Reference | Why the search missed it |
| --- | --- |
| `dropdownTriggers()` in `profile-editor-modal.test.tsx` | starts lowercase; the pass searched the component's name |
| `dropdownTrigger()` in `custom-plan-modal.test.tsx` | same |
| `index.css:98` "fixed Dropdown/tooltip layers" | the pass was scoped to `.ts` and `.tsx` |

`profile-editor-modal` is the worst of the three: #40399 rewrote its JSDoc to "All Select triggers" and left the function underneath named `dropdownTriggers`. That is precisely the inconsistency the rename pass existed to remove, introduced by the pass itself.

That is four misses now from three different too-narrow patterns: the component path but not the package barrel, capital-D but not lowercase, `.ts`/`.tsx` but not `.css`. The final check was a single `grep -rn "Dropdown"` across both packages with no extension filter, which is what should have run first. It now returns one hit, `// Radix DropdownMenu opens on pointerdown` in `profiles-section.test.tsx`, which is `Menu` and correct.

## Not a rename

`index.css` documents a real constraint: the Home Activity drawer hosts fixed-position layers, so the animation's fill mode matters. `select.tsx:108-113` describes the same containing-block trap. Only the component's name changes.

## Formatting

`index.css` is left as found. It does not satisfy `prettier` on `main` either, so reflowing it here would bury a one-word change in unrelated churn. Verified against the unmodified file rather than assumed.

## Verification

`tsc --noEmit` clean, which is complete verification for these renames: both helpers are module-local, so a missed reference is a type error rather than a silent failure. `eslint` clean on both test files.

Actions has recovered since earlier tonight (#40399 merged with 20 green check-runs), so this should get a real CI pass rather than Socket alone.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40405" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->