### PR TITLE
fix(web): escape the NUL separator so the sidebar hook stays greppable

### DIFF
--- a/clients/web/src/domains/chat/use-sidebar-state.ts
+++ b/clients/web/src/domains/chat/use-sidebar-state.ts
@@ -423,7 +423,7 @@ export function useSidebarState({
         return null;
       }
       const settled = enforceCuratedLead(moved, classifySectionKey);
-      return settled.join(" ") === current.join(" ") ? null : settled;
+      return settled.join("\0") === current.join("\0") ? null : settled;
     },
     [sections],
   );


### PR DESCRIPTION
## TL;DR

`use-sidebar-state.ts` contained a literal NUL byte (`0x00`) in its source. That made the whole file read as binary, so `git diff` printed "Binary files differ" and any grep that skips binary files skipped it **silently**. One character changes: the raw byte becomes the `\0` escape it should always have been.

## What was there

[`orderAfterMove`](https://github.com/vellum-ai/vellum-assistant/blob/main/clients/web/src/domains/chat/use-sidebar-state.ts#L426) compares two section orderings by joining each on a NUL separator — a sound choice, since no section key can contain one. The separator was just written as an actual NUL byte instead of `\0`.

Confirmed by hexdump — `22 00 22`, a NUL between two quotes:

```
00000010: 746c 6564 2e6a 6f69 6e28 2200 2229 203d  tled.join(".") =
```

It arrived in `c970a882dc0` (2026-07-31) and is the only such file in the repo.

## Why this is worth its own PR

It is a review-tooling hazard, not a style nit. The file is where LUM-3108's client-side pinned re-sort lives, and a grep for `compareByDisplayOrder` does not match it — the file is skipped with no warning, no match, and no indication anything was passed over. I hit exactly that while scoping LUM-3108 and initially concluded the re-sort did not exist.

It lands first so the PRs that edit this file next render as readable diffs.

## Why it is safe

`"\0"` denotes the same character the file already held, so the join, the comparison, and every caller behave identically. No logic touched. Typecheck, eslint and prettier pass.

## Before / after

| | Before | After |
| --- | --- | --- |
| What the code does | Unchanged | Unchanged |
| `file` reports | `data` | `UTF-8 text` |
| `git diff` on this file | "Binary files differ" | A normal diff |
| `grep` for a symbol in it | Skipped silently | Matches |

## Notes

The "before" side of the diff displays as `join(" ")` — the NUL renders as nothing. That invisibility is the point.

Part of LUM-3108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40406" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->