### PR TITLE
feat(assistant): hint the inline picker when navigating to the Voice tab

### DIFF
--- a/assistant/src/config/bundled-skills/settings/tools/navigate-settings-tab.test.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/navigate-settings-tab.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import type { ToolContext } from "../../../../tools/types.js";
+import { run } from "./navigate-settings-tab.js";
+
+let sentMessages: Array<{ type: string; [key: string]: unknown }> = [];
+
+function makeContext(overrides?: Partial<ToolContext>): ToolContext {
+  return {
+    workingDir: "/tmp",
+    conversationId: "conv-xyz",
+    trustClass: "guardian",
+    sendToClient: (msg) => {
+      sentMessages.push(msg);
+    },
+    ...overrides,
+  };
+}
+
+describe("navigate_settings_tab tool", () => {
+  beforeEach(() => {
+    sentMessages = [];
+  });
+
+  test("navigates to the Voice tab and hints the inline picker", async () => {
+    const result = await run({ tab: "Voice" }, makeContext());
+
+    expect(result.isError).toBe(false);
+    expect(sentMessages).toEqual([{ type: "navigate_settings", tab: "Voice" }]);
+    expect(result.content).toStartWith("Opened settings to the Voice tab.");
+    expect(result.content).toContain(
+      'ui_show { surface_type: "voice_picker", data: {} }',
+    );
+  });
+
+  test("leaves a non-Voice tab's result unchanged", async () => {
+    const result = await run({ tab: "Billing" }, makeContext());
+
+    expect(result.isError).toBe(false);
+    expect(sentMessages).toEqual([
+      { type: "navigate_settings", tab: "Billing" },
+    ]);
+    expect(result.content).toBe("Opened settings to the Billing tab.");
+    expect(result.content).not.toContain("voice_picker");
+  });
+
+  test("resolves legacy tab aliases without hinting", async () => {
+    const result = await run({ tab: "Archived Conversations" }, makeContext());
+
+    expect(result.isError).toBe(false);
+    expect(sentMessages).toEqual([
+      { type: "navigate_settings", tab: "Archive" },
+    ]);
+    expect(result.content).toBe("Opened settings to the Archive tab.");
+    expect(result.content).not.toContain("voice_picker");
+  });
+
+  test("rejects an unknown tab without navigating", async () => {
+    const result = await run({ tab: "Telepathy" }, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('unknown tab "Telepathy"');
+    expect(sentMessages).toEqual([]);
+  });
+});

--- a/assistant/src/config/bundled-skills/settings/tools/navigate-settings-tab.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/navigate-settings-tab.ts
@@ -23,6 +23,9 @@ const LEGACY_TAB_ALIASES: Record<string, SettingsTab> = {
   "Archived Conversations": "Archive",
 };
 
+const VOICE_TAB_PICKER_HINT =
+  'Next time the user wants to change or hear a voice, prefer `ui_show { surface_type: "voice_picker", data: {} }`, which puts the picker in the conversation without navigating away. Navigating here is right only when the user explicitly asked to open Settings.';
+
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
@@ -45,8 +48,9 @@ export async function run(
     });
   }
 
+  const opened = `Opened settings to the ${tab} tab.`;
   return {
-    content: `Opened settings to the ${tab} tab.`,
+    content: tab === "Voice" ? `${opened} ${VOICE_TAB_PICKER_HINT}` : opened,
     isError: false,
   };
 }


### PR DESCRIPTION
## Summary

- `navigate_settings_tab { tab: "Voice" }` still navigates and still returns `isError: false`, but its result content now names `ui_show { surface_type: "voice_picker", data: {} }` as the preferred affordance for a voice change, so the model reaches for the inline card instead of pushing the app to Settings.
- Deliberately a hint, not an error or a redirect envelope: navigating to Voice settings works and is the right answer to "open voice settings", unlike the shell-OAuth case that hard-redirects. Tab validation, the legacy alias lookup, and the `navigate_settings` emission are untouched, and other tabs' results are byte-identical.
- Adds `navigate-settings-tab.test.ts` covering the Voice hint, an unchanged non-Voice tab, the legacy alias path, and the unknown-tab error.

Part of plan: inline-voice-picker-surface.md (PR 5 of 5)