### PR TITLE
feat(web): remove conversation drag-reorder, sort every section by recency (LUM-3108)

### DIFF
--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -592,7 +592,6 @@ export function ChatLayout({
     handleMoveToGroup,
     handleRemoveFromGroup,
     handleRenameConversation,
-    handleReorderConversations,
     handleMarkAllReadInGroup,
     handleArchiveAllInGroup,
   } = useConversationActions({
@@ -914,7 +913,6 @@ export function ChatLayout({
       activeAppId={activeAppId ?? undefined}
       onOpenApp={handleOpenAppFromSidebar}
       onPinConversation={handleTogglePinConversation}
-      onReorderConversations={handleReorderConversations}
       onRenameConversation={handleRenameConversation}
       onArchiveConversation={handleArchiveConversation}
       onUnarchiveConversation={handleUnarchiveConversation}

--- a/clients/web/src/domains/chat/components/assistant-side-menu.stories.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.stories.tsx
@@ -126,7 +126,6 @@ const SHARED_ARGS = {
   onStartNewConversation: () => {},
   onRenameGroup: () => {},
   onDeleteGroup: () => {},
-  onReorderConversations: () => {},
   // Wires the list's right-click "New group…". Omitting it drops the
   // affordance entirely, so the story has to pass it to show the menu.
   onCreateGroup: () => {},

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -33,7 +33,6 @@ import { SideMenuOverlayBottomColumn } from "@/domains/chat/components/side-menu
 import { SidebarViewModeSelect } from "@/domains/chat/components/sidebar-view-mode-select";
 import { SidebarBackToTop } from "@/domains/chat/components/sidebar-back-to-top";
 import { SidebarConversationSkeleton } from "@/domains/chat/components/sidebar-conversation-skeleton";
-import { useDragReorder } from "@/domains/chat/hooks/use-drag-reorder";
 import { useSectionDragReorder } from "@/domains/chat/hooks/use-section-drag-reorder";
 import { useScrolledPast } from "@/domains/chat/hooks/use-scrolled-past";
 import {
@@ -76,13 +75,6 @@ export interface AssistantSideMenuProps extends UseSidebarStateParams {
   onClose?: () => void;
 
   onPinConversation?: (conversation: Conversation) => void;
-  /**
-   * Persist a drag-reorder within a section. Receives the section's full
-   * conversation list in its new order. When omitted, rows aren't draggable.
-   * Only sections that honor `displayOrder` (Pinned, custom groups) offer
-   * drag-reordering — Recents and channel sections stay recency-sorted.
-   */
-  onReorderConversations?: (conversations: Conversation[]) => void;
   onRenameConversation?: (conversation: Conversation) => void;
   onArchiveConversation?: (conversation: Conversation) => void;
   onUnarchiveConversation?: (conversation: Conversation) => void;
@@ -207,7 +199,6 @@ export function AssistantSideMenu({
   footerAction,
   tipCard,
   onPinConversation,
-  onReorderConversations,
   onRenameConversation,
   onArchiveConversation,
   onUnarchiveConversation,
@@ -263,14 +254,8 @@ export function AssistantSideMenu({
   // variant is up, so a stale value from a dismissed overlay is inert.
   const [overlayBottomColumnHeight, setOverlayBottomColumnHeight] = useState(0);
 
-  // --- Drag-reorder (Pinned + custom groups; sections sorted by displayOrder) ---
-
-  const dragReorder = useDragReorder<Conversation>({
-    getId: (c) => c.conversationId,
-    onReorder: (_section, ordered) => onReorderConversations?.(ordered),
-  });
-
-  // Whole-section reordering, separate from the row-level controller above.
+  // Whole-section reordering. Rows themselves do not reorder: every section
+  // is recency-sorted (LUM-3108).
   const sectionDragFor = useSectionDragReorder({
     sections: sidebar.sections,
     onReorder: sidebar.onReorderSections,
@@ -350,8 +335,6 @@ export function AssistantSideMenu({
     onMoveToGroup,
     onCreateGroupInto,
     onRemoveFromGroup,
-    dragReorder,
-    canReorder: !!onReorderConversations,
   };
 
   // Header actions for one section: the bulk actions every section shares,

--- a/clients/web/src/domains/chat/components/conversation-list-context.tsx
+++ b/clients/web/src/domains/chat/components/conversation-list-context.tsx
@@ -3,15 +3,13 @@
  *
  * Every conversation row (in Pinned, Recents, a channel section, a custom
  * group, or the collapsed-rail flyout) needs the same ~12 action callbacks
- * plus the active/processing/attention state and the drag-reorder
- * controller. Providing them through context lets {@link ConversationRow}
- * read what it needs directly, so the row, list, and section components
- * don't each take a dozen props.
+ * plus the active/processing/attention state. Providing them through context
+ * lets {@link ConversationRow} read what it needs directly, so the row, list,
+ * and section components don't each take a dozen props.
  */
 
 import { createContext, useContext } from "react";
 
-import type { UseDragReorderResult } from "@/domains/chat/hooks/use-drag-reorder";
 import type {
   Conversation,
   ConversationGroup,
@@ -47,11 +45,6 @@ export interface ConversationListContextValue {
   onCreateGroupInto?: (conversation: Conversation) => void;
   /** Remove a conversation from its current custom group (back to Recents). */
   onRemoveFromGroup?: (conversation: Conversation) => void;
-
-  /** Drag-reorder controller; rows derive their own drag props from it. */
-  dragReorder: UseDragReorderResult<Conversation>;
-  /** True when reordering is wired (an `onReorder` handler exists). */
-  canReorder: boolean;
 }
 
 const ConversationListContext =

--- a/clients/web/src/domains/chat/components/conversation-nav-section.tsx
+++ b/clients/web/src/domains/chat/components/conversation-nav-section.tsx
@@ -55,13 +55,6 @@ export const CONVERSATION_LIST_VIRTUALIZE_THRESHOLD = 30;
 
 export interface ConversationRowListProps {
   items: Conversation[];
-  /** Drag-reorder section key; omit for non-reorderable lists. */
-  dragSection?: string;
-  /**
-   * Full ordered list for drag math. Defaults to `items` — pass explicitly
-   * only when the visible `items` are a subset.
-   */
-  dragSiblings?: Conversation[];
   /**
    * Scroll against this ancestor rather than bounding the list. Only the flat
    * list passes it: it already fills the sidebar body, so opening a scroller
@@ -81,8 +74,6 @@ export interface ConversationRowListProps {
 
 export function ConversationRowList({
   items,
-  dragSection,
-  dragSiblings,
   scrollParent,
   unbounded,
 }: ConversationRowListProps) {
@@ -90,22 +81,13 @@ export function ConversationRowList({
     <ConversationRow
       key={conversation.conversationId}
       conversation={conversation}
-      dragSection={dragSection}
-      dragSiblings={dragSiblings ?? items}
     />
   );
 
   const rows = <SideMenu.SubList>{items.map(renderRow)}</SideMenu.SubList>;
 
-  // Reorderable sections (Pinned, custom groups) always mount every row: the
-  // drag controller resolves a drop target from the rows themselves, so a
-  // windowed list would have nothing to drop onto past the viewport. They
-  // stay bounded and scrollable either way (unless `unbounded`), and they
-  // are the curated sections, so they are the least likely to run long.
   const windows =
-    !unbounded &&
-    !dragSection &&
-    items.length > CONVERSATION_LIST_VIRTUALIZE_THRESHOLD;
+    !unbounded && items.length > CONVERSATION_LIST_VIRTUALIZE_THRESHOLD;
 
   if (!windows) {
     if (unbounded) {

--- a/clients/web/src/domains/chat/components/conversation-row-long-press.test.tsx
+++ b/clients/web/src/domains/chat/components/conversation-row-long-press.test.tsx
@@ -94,28 +94,10 @@ mock.module("@/domains/chat/components/thread-status-indicator", () => ({
 import { ConversationRow } from "@/domains/chat/components/conversation-row";
 import { ConversationListProvider } from "@/domains/chat/components/conversation-list-context";
 import type { ConversationListContextValue } from "@/domains/chat/components/conversation-list-context";
-import type { UseDragReorderResult } from "@/domains/chat/hooks/use-drag-reorder";
 import type { Conversation } from "@/types/conversation-types";
 
-const stubDragReorder: UseDragReorderResult<Conversation> = {
-  getItemProps: () => ({
-    draggable: true,
-    onDragStart: () => {},
-    onDragOver: () => {},
-    onDragLeave: () => {},
-    onDrop: () => {},
-    onDragEnd: () => {},
-  }),
-  draggingId: null,
-  dropIndicator: null,
-};
-
 function renderRow(onSelect: (id: string) => void) {
-  const ctx: ConversationListContextValue = {
-    onSelect,
-    dragReorder: stubDragReorder,
-    canReorder: false,
-  };
+  const ctx: ConversationListContextValue = { onSelect };
   return render(
     createElement(
       ConversationListProvider,

--- a/clients/web/src/domains/chat/components/conversation-row.test.tsx
+++ b/clients/web/src/domains/chat/components/conversation-row.test.tsx
@@ -1,33 +1,14 @@
 import { describe, expect, test } from "bun:test";
 
-import {
-  buildDragProps,
-  buildMenuProps,
-} from "@/domains/chat/components/conversation-row";
+import { buildMenuProps } from "@/domains/chat/components/conversation-row";
 import type { ConversationListContextValue } from "@/domains/chat/components/conversation-list-context";
-import type { UseDragReorderResult } from "@/domains/chat/hooks/use-drag-reorder";
 import type { Conversation } from "@/types/conversation-types";
-
-const stubDragReorder: UseDragReorderResult<Conversation> = {
-  getItemProps: () => ({
-    draggable: true,
-    onDragStart: () => {},
-    onDragOver: () => {},
-    onDragLeave: () => {},
-    onDrop: () => {},
-    onDragEnd: () => {},
-  }),
-  draggingId: null,
-  dropIndicator: null,
-};
 
 function makeCtx(
   overrides: Partial<ConversationListContextValue> = {},
 ): ConversationListContextValue {
   return {
     onSelect: () => {},
-    dragReorder: stubDragReorder,
-    canReorder: false,
     ...overrides,
   };
 }
@@ -77,58 +58,5 @@ describe("buildMenuProps", () => {
     );
     expect(read.onMarkRead).toBeUndefined();
     expect(typeof read.onMarkUnread).toBe("function");
-  });
-});
-
-describe("buildDragProps", () => {
-  const a = conv({ conversationId: "a" });
-  const b = conv({ conversationId: "b" });
-
-  test("returns nothing when reordering is disabled", () => {
-    expect(
-      buildDragProps(makeCtx({ canReorder: false }), a, "pinned", [a, b]),
-    ).toEqual({});
-  });
-
-  test("returns nothing without a section or with fewer than two siblings", () => {
-    const ctx = makeCtx({ canReorder: true });
-    expect(buildDragProps(ctx, a, undefined, [a, b])).toEqual({});
-    expect(buildDragProps(ctx, a, "pinned", [a])).toEqual({});
-  });
-
-  test("dims the row currently being dragged", () => {
-    const ctx = makeCtx({
-      canReorder: true,
-      dragReorder: { ...stubDragReorder, draggingId: "a" },
-    });
-    const props = buildDragProps(ctx, a, "pinned", [a, b]);
-    expect(props.draggable).toBe(true);
-    expect(props.className).toContain("opacity-50");
-  });
-
-  test("draws the drop line on the hovered edge within the same section", () => {
-    const ctx = makeCtx({
-      canReorder: true,
-      dragReorder: {
-        ...stubDragReorder,
-        dropIndicator: { section: "pinned", itemId: "b", edge: "before" },
-      },
-    });
-    const props = buildDragProps(ctx, b, "pinned", [a, b]);
-    expect(props.className).toContain(
-      "shadow-[inset_0_2px_0_0_var(--primary-base)]",
-    );
-  });
-
-  test("ignores a drop indicator from another section", () => {
-    const ctx = makeCtx({
-      canReorder: true,
-      dragReorder: {
-        ...stubDragReorder,
-        dropIndicator: { section: "group:x", itemId: "b", edge: "after" },
-      },
-    });
-    const props = buildDragProps(ctx, b, "pinned", [a, b]);
-    expect(props.className).not.toContain("shadow-");
   });
 });

--- a/clients/web/src/domains/chat/components/conversation-row.tsx
+++ b/clients/web/src/domains/chat/components/conversation-row.tsx
@@ -29,7 +29,6 @@ import {
   hasThreadStatus,
   ThreadStatusIndicator,
 } from "@/domains/chat/components/thread-status-indicator";
-import type { DragReorderItemProps } from "@/domains/chat/hooks/use-drag-reorder";
 import { isChannelConversation } from "@/domains/chat/utils/conversation-channel";
 import { copyIdToClipboard } from "@/domains/chat/utils/copy-id-to-clipboard";
 import {
@@ -49,13 +48,6 @@ import {
 
 export interface ConversationRowProps {
   conversation: Conversation;
-  /**
-   * Drag-reorder section key. Omit for non-reorderable lists (Recents,
-   * channel sections) — only Pinned and custom groups reorder.
-   */
-  dragSection?: string;
-  /** The section's full ordered list, for drag math. Defaults to nothing. */
-  dragSiblings?: Conversation[];
   /** Wrap in a right-click context menu. Default true; false in the rail flyout. */
   withContextMenu?: boolean;
   /** Marquee the title on hover. Default true; false in the rail flyout. */
@@ -114,36 +106,6 @@ export function buildMenuProps(
     onCopyConversationId: hasId
       ? () => copyIdToClipboard(conversation.conversationId!, "Conversation ID")
       : undefined,
-  };
-}
-
-export function buildDragProps(
-  ctx: ConversationListContextValue,
-  conversation: Conversation,
-  dragSection: string | undefined,
-  dragSiblings: Conversation[] | undefined,
-): Partial<DragReorderItemProps> & { className?: string } {
-  if (
-    !dragSection ||
-    !ctx.canReorder ||
-    !dragSiblings ||
-    dragSiblings.length < 2
-  ) {
-    return {};
-  }
-  const { draggingId, dropIndicator } = ctx.dragReorder;
-  const edge =
-    dropIndicator?.section === dragSection &&
-    dropIndicator.itemId === conversation.conversationId
-      ? dropIndicator.edge
-      : null;
-  return {
-    ...ctx.dragReorder.getItemProps(dragSection, dragSiblings, conversation),
-    className: cn(
-      draggingId === conversation.conversationId && "opacity-50",
-      edge === "before" && "shadow-[inset_0_2px_0_0_var(--primary-base)]",
-      edge === "after" && "shadow-[inset_0_-2px_0_0_var(--primary-base)]",
-    ),
   };
 }
 
@@ -216,8 +178,6 @@ export function buildSwipeActions(
 
 export function ConversationRow({
   conversation,
-  dragSection,
-  dragSiblings,
   withContextMenu = true,
   marquee = true,
   onSelect,
@@ -246,12 +206,6 @@ export function ConversationRow({
     needsAttention,
     hasUnread: conversation.hasUnseenLatestAssistantMessage === true,
   };
-  const dragProps = buildDragProps(
-    ctx,
-    conversation,
-    dragSection,
-    dragSiblings,
-  );
   const { leadingActions, trailingActions } = buildSwipeActions(
     ctx,
     conversation,
@@ -297,13 +251,11 @@ export function ConversationRow({
             <ConversationActionsMenu {...menuProps} />
           )
         }
-        {...dragProps}
         className={cn(
           // `!` forces this over PanelItem's own max-md:py-3: cross-package
           // Tailwind generation order doesn't reliably favor a plain
           // (unmarked) override here.
           "h-[30px] p-[6px] max-md:p-2! text-[var(--content-default)]",
-          dragProps.className,
         )}
       />
     </SwipeActionReveal>

--- a/clients/web/src/domains/chat/components/sidebar-section-card.stories.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-section-card.stories.tsx
@@ -57,21 +57,14 @@ const CHATS: Conversation[] = [
 
 /**
  * Rows read their callbacks and active/processing state from context, so
- * every story provides one. Drag-reorder is off, which is what a
- * non-reorderable section passes in the app.
+ * every story provides one.
  */
-const LIST_CONTEXT = {
+const LIST_CONTEXT: React.ComponentProps<
+  typeof ConversationListProvider
+>["value"] = {
   activeConversationId: "c1",
   onSelect: () => {},
-  canReorder: false,
-  dragReorder: {
-    draggingId: null,
-    dropIndicator: null,
-    getItemProps: () => ({}),
-  },
-} as unknown as React.ComponentProps<
-  typeof ConversationListProvider
->["value"];
+};
 
 /**
  * A section's own actions, as the sidebar wires them. Deliberately the real
@@ -230,7 +223,11 @@ export const SectionMenuVersusRowMenu: Story = {
     items: CHATS.slice(0, 4),
     groupMenu: GROUP_MENU,
     trailing: (
-      <GroupActionsMenu label="Chats" footer={GROUP_BY_FOOTER} {...GROUP_MENU} />
+      <GroupActionsMenu
+        label="Chats"
+        footer={GROUP_BY_FOOTER}
+        {...GROUP_MENU}
+      />
     ),
   },
   render: (args) => (

--- a/clients/web/src/domains/chat/components/sidebar-section-item.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-section-item.tsx
@@ -4,11 +4,8 @@
  * This is the single render path for Pinned, Chats, every origin-channel
  * section, and every custom group - which is what keeps their spacing and
  * header treatment identical and lets the user interleave them freely
- * (LUM-2909). Only three things vary by type, and they're all here:
+ * (LUM-2909). Only two things vary by type, and they're both here:
  *
- * - **Whether rows drag.** Only the sections that honor `displayOrder`
- *   (Pinned, custom groups) offer row-level reordering - the rest stay
- *   recency-sorted, so dragging a row in them would have nothing to persist.
  * - **Whether the header carries a "…" button.** The curated sections (Pinned
  *   and the custom groups) get one, so their actions are reachable without
  *   knowing to right-click. It reveals on hover; the derived sections (Chats,
@@ -44,21 +41,6 @@ export interface SidebarSectionItemProps {
   collapsedIndicator?: ReactNode;
 }
 
-/**
- * Row-list props for a section. Both branches carry the same keys so the
- * spread below stays a single object type rather than a union.
- */
-function rowListPropsFor(section: SidebarSection) {
-  if (section.type === "recents" || section.type === "channel") {
-    return { items: section.all, dragSection: undefined };
-  }
-  return {
-    items: section.all,
-    dragSection:
-      section.type === "pinned" ? "pinned" : `group:${section.key}`,
-  };
-}
-
 export function SidebarSectionItem({
   section,
   groupMenu,
@@ -85,7 +67,7 @@ export function SidebarSectionItem({
       // rest). It is the one section that never caps/scrolls internally:
       // it grows to fit its own rows instead.
       unbounded={section.type === "pinned"}
-      {...rowListPropsFor(section)}
+      items={section.all}
     />
   );
 }

--- a/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
@@ -8,7 +8,6 @@ import {
   patchConversation,
   restoreConversationCaches,
   snapshotConversationCaches,
-  updateAllConversationCaches,
   type ConversationCacheSnapshot,
 } from "@/utils/conversation-cache";
 import { adjustUnreadCountCache } from "@/utils/conversation-cache-mutations";
@@ -49,7 +48,6 @@ type MoveToGroupVars = {
   previousIsPinned: boolean;
   previousGroupId: string | undefined;
 };
-type ReorderVars = { assistantId: string; orderedIds: string[] };
 
 type MutationContext = { snapshot: ConversationCacheSnapshot };
 
@@ -286,49 +284,6 @@ export function useConversationActions({
     },
   });
 
-  const reorderMutation = useMutation<
-    void,
-    Error,
-    ReorderVars,
-    MutationContext
-  >({
-    mutationFn: async ({ assistantId: aid, orderedIds }) => {
-      await conversationsReorderPost({
-        path: { assistant_id: aid },
-        body: {
-          // displayOrder-only updates — the daemon preserves each
-          // conversation's pin state and group assignment.
-          updates: orderedIds.map((conversationId, index) => ({
-            conversationId,
-            displayOrder: index,
-          })),
-        },
-        throwOnError: true,
-      });
-    },
-    onMutate: async ({ assistantId: aid, orderedIds }) => {
-      await cancelConversationQueries(queryClient, aid);
-      const snapshot = snapshotConversationCaches(queryClient, aid);
-      const orderById = new Map(orderedIds.map((id, index) => [id, index]));
-      updateAllConversationCaches(queryClient, aid, (conversations) =>
-        conversations.map((c) => {
-          const displayOrder = orderById.get(c.conversationId);
-          return displayOrder === undefined ? c : { ...c, displayOrder };
-        }),
-      );
-      return { snapshot };
-    },
-    onError: (err, _vars, context) => {
-      if (context?.snapshot) {
-        restoreConversationCaches(queryClient, context.snapshot);
-      }
-      captureError(err, { context: "reorderConversations" });
-    },
-    onSettled: (_data, _err, { assistantId: aid }) => {
-      void invalidateConversationQueries(queryClient, aid);
-    },
-  });
-
   // -------------------------------------------------------------------------
   // Handlers — thin wrappers that compute UI side effects, then fire mutate
   // -------------------------------------------------------------------------
@@ -467,25 +422,6 @@ export function useConversationActions({
       handleMoveToGroup(conversation, targetGroupId);
     },
     [handleMoveToGroup, prePinGroupIdsRef],
-  );
-
-  /**
-   * Persist a user drag-reorder. `ordered` is a sidebar section's full
-   * conversation list (pinned or one custom group) in its new order;
-   * each row's `displayOrder` becomes its index.
-   */
-  const handleReorderConversations = useCallback(
-    (ordered: Conversation[]) => {
-      if (!assistantId || ordered.length < 2) {
-        return;
-      }
-      haptic.light();
-      reorderMutation.mutate({
-        assistantId,
-        orderedIds: ordered.map((c) => c.conversationId),
-      });
-    },
-    [assistantId, reorderMutation],
   );
 
   const handleRenameConversation = useCallback(
@@ -641,7 +577,6 @@ export function useConversationActions({
     handleMoveToGroup,
     handleRemoveFromGroup,
     handleRenameConversation,
-    handleReorderConversations,
     handleMarkAllReadInGroup,
     handleArchiveAllInGroup,
   };

--- a/clients/web/src/domains/chat/use-sidebar-state.test.tsx
+++ b/clients/web/src/domains/chat/use-sidebar-state.test.tsx
@@ -487,27 +487,30 @@ describe("Pinned section, gate open", () => {
       .setIdentity("test-asst", "0.12.0", "asst-1");
   }
 
-  /* Regression: the daemon orders user-ordered groups by
-     `COALESCE(display_order, 999999) ASC` then by recency, and pinning writes
-     no `displayOrder`. So the server hands back activity order, while pinned
-     rows are supposed to hold their place regardless of activity. Asserting
-     the order flips, not merely that rows arrive: with the client sort
-     removed this returns the server's order and fails. */
-  test("holds creation order when the server answers in activity order", () => {
+  /* The server's order is the rendered order. Pinned used to re-sort the
+     response client side so a drag-reordered arrangement held regardless of
+     activity; LUM-3108 removed drag-reorder, so there is one order and the
+     client no longer second-guesses it.
+
+     `createdAt` and `displayOrder` both contradict the server's order here, so
+     re-introducing either comparator flips the result and fails this. */
+  test("renders the server's order as-is", () => {
     openGate();
-    const stale = makeConversation(1, {
-      conversationId: "pin-newest-created",
-      isPinned: true,
-      groupId: "system:pinned",
-      createdAt: 3_000,
-      lastMessageAt: 10,
-    });
-    const busy = makeConversation(2, {
-      conversationId: "pin-oldest-created",
+    const busy = makeConversation(1, {
+      conversationId: "pin-busy",
       isPinned: true,
       groupId: "system:pinned",
       createdAt: 1_000,
+      displayOrder: 1,
       lastMessageAt: 9_999,
+    });
+    const stale = makeConversation(2, {
+      conversationId: "pin-stale",
+      isPinned: true,
+      groupId: "system:pinned",
+      createdAt: 3_000,
+      displayOrder: 0,
+      lastMessageAt: 10,
     });
     // Server order: most recent activity first.
     sectionRows = [busy, stale];
@@ -518,37 +521,8 @@ describe("Pinned section, gate open", () => {
 
     const pinned = result.current.sections.find((s) => s.type === "pinned");
     expect(pinned?.all.map((c) => c.conversationId)).toEqual([
-      "pin-newest-created",
-      "pin-oldest-created",
-    ]);
-  });
-
-  test("honours an explicit displayOrder ahead of creation order", () => {
-    openGate();
-    const first = makeConversation(3, {
-      conversationId: "pin-dragged-first",
-      isPinned: true,
-      groupId: "system:pinned",
-      displayOrder: 0,
-      createdAt: 1_000,
-    });
-    const second = makeConversation(4, {
-      conversationId: "pin-dragged-second",
-      isPinned: true,
-      groupId: "system:pinned",
-      displayOrder: 1,
-      createdAt: 9_000,
-    });
-    sectionRows = [second, first];
-
-    const { result } = renderHook(() =>
-      useSidebarState({ assistantId: "asst-1", conversations: [] }),
-    );
-
-    const pinned = result.current.sections.find((s) => s.type === "pinned");
-    expect(pinned?.all.map((c) => c.conversationId)).toEqual([
-      "pin-dragged-first",
-      "pin-dragged-second",
+      "pin-busy",
+      "pin-stale",
     ]);
   });
 

--- a/clients/web/src/domains/chat/use-sidebar-state.ts
+++ b/clients/web/src/domains/chat/use-sidebar-state.ts
@@ -34,7 +34,6 @@ import type {
   ConversationGroup,
 } from "@/types/conversation-types";
 import {
-  compareByDisplayOrder,
   groupConversations,
   type CustomGroup,
 } from "@/domains/chat/utils/group-conversations";
@@ -302,30 +301,18 @@ export function useSidebarState({
     [allConversations, conversationGroups, viewMode],
   );
 
-  /* Re-apply the pinned comparator to the server's rows. The daemon orders
-     user-ordered groups by `COALESCE(display_order, 999999) ASC` then by
-     recency, and pinning writes no `displayOrder`, so for anyone who has
-     never drag-reordered every row ties at the sentinel and falls through to
-     activity order. Left alone, a pinned conversation would jump to the top
-     of Pinned whenever a message landed in it, which is exactly what
-     `compareByCreatedAt` exists to prevent. Copy before sorting: this array
-     is the query cache's own. */
-  const pinnedFromQuerySorted = useMemo(
-    () => [...pinnedFromQuery].sort(compareByDisplayOrder),
-    [pinnedFromQuery],
-  );
-
   /* Keep painting the derived rows until the section query has answered once.
      `pinnedFromQuery` is empty while pending, and an empty Pinned section is
      dropped entirely below, so switching on the gate alone would hide Pinned
      on every cold load until a multi-page drain finished. The derived list is
      a subset (the pinned rows that happen to be in the foreground page), so
      this paints immediately and fills in. `isPending` is false once data has
-     landed, so a later refetch never falls back. */
+     landed, so a later refetch never falls back.
+
+     The server's order is rendered as-is. Every section, this one included,
+     is ordered by recency now that nothing writes `display_order`. */
   const pinnedConversations =
-    supportsGroupFilter && !pinnedPending
-      ? pinnedFromQuerySorted
-      : grouped.pinned;
+    supportsGroupFilter && !pinnedPending ? pinnedFromQuery : grouped.pinned;
 
   // --- Section order ---
 

--- a/clients/web/src/domains/chat/use-sidebar-state.ts
+++ b/clients/web/src/domains/chat/use-sidebar-state.ts
@@ -423,7 +423,7 @@ export function useSidebarState({
         return null;
       }
       const settled = enforceCuratedLead(moved, classifySectionKey);
-      return settled.join(" ") === current.join(" ") ? null : settled;
+      return settled.join("\0") === current.join("\0") ? null : settled;
     },
     [sections],
   );

--- a/clients/web/src/domains/chat/utils/group-conversations.test.ts
+++ b/clients/web/src/domains/chat/utils/group-conversations.test.ts
@@ -443,70 +443,55 @@ describe("groupConversations · custom group routing", () => {
   });
 });
 
-describe("groupConversations · displayOrder for pinned and custom groups", () => {
-  test("pinned bucket sorts by displayOrder ascending (user-set order)", () => {
-    // Note: input is provided newest-first by lastMessageAt to confirm the
-    // pinned sort overrides recency, matching the bug described in LUM-1619.
+describe("groupConversations · recency order for pinned and custom groups", () => {
+  /* Pinned and the custom groups used to sort by `displayOrder`, falling back
+     to creation time, so that a drag-reordered arrangement held regardless of
+     activity. LUM-3108 removed drag-reorder, and every section sorts by
+     recency now. Each test below sets `displayOrder` to the REVERSE of the
+     expected result, so re-introducing the old comparator fails them rather
+     than leaving them coincidentally passing. */
+
+  test("pinned sorts by recency, ignoring displayOrder", () => {
     const result = groupConversations([
       makeConversation({
-        conversationId: "b",
+        conversationId: "oldest",
         isPinned: true,
-        displayOrder: 1,
+        displayOrder: 0,
+        lastMessageAt: 1704067200000,
+      }),
+      makeConversation({
+        conversationId: "newest",
+        isPinned: true,
+        displayOrder: 2,
         lastMessageAt: 1704240000000,
       }),
       makeConversation({
-        conversationId: "a",
+        conversationId: "middle",
         isPinned: true,
-        displayOrder: 0,
+        displayOrder: 1,
         lastMessageAt: 1704153600000,
-      }),
-      makeConversation({
-        conversationId: "c",
-        isPinned: true,
-        displayOrder: 2,
-        lastMessageAt: 1704067200000,
-      }),
-    ]);
-    expect(result.pinned.map((c) => c.conversationId)).toEqual(["a", "b", "c"]);
-  });
-
-  test("pinned conversations without displayOrder fall back to createdAt desc, ignoring activity", () => {
-    // lastMessageAt is the REVERSE of createdAt to prove the fallback keys on
-    // immutable creation time, not recency — pinned rows must not reorder
-    // themselves based on activity.
-    const result = groupConversations([
-      makeConversation({
-        conversationId: "older",
-        isPinned: true,
-        createdAt: 1704067200000,
-        lastMessageAt: 1704412800000, // most recent activity
-      }),
-      makeConversation({
-        conversationId: "newer",
-        isPinned: true,
-        createdAt: 1704412800000,
-        lastMessageAt: 1704067200000, // least recent activity
       }),
     ]);
     expect(result.pinned.map((c) => c.conversationId)).toEqual([
-      "newer",
-      "older",
+      "newest",
+      "middle",
+      "oldest",
     ]);
   });
 
-  test("pinned order is stable when a pinned conversation receives new activity", () => {
+  test("a pinned conversation moves to the top when new activity arrives", () => {
     const base = [
       makeConversation({
         conversationId: "a",
         isPinned: true,
         createdAt: 3000,
-        lastMessageAt: 100,
+        lastMessageAt: 300,
       }),
       makeConversation({
         conversationId: "b",
         isPinned: true,
         createdAt: 2000,
-        lastMessageAt: 100,
+        lastMessageAt: 200,
       }),
       makeConversation({
         conversationId: "c",
@@ -515,20 +500,21 @@ describe("groupConversations · displayOrder for pinned and custom groups", () =
         lastMessageAt: 100,
       }),
     ];
-    const before = groupConversations(base).pinned.map((c) => c.conversationId);
-    expect(before).toEqual(["a", "b", "c"]);
+    expect(
+      groupConversations(base).pinned.map((c) => c.conversationId),
+    ).toEqual(["a", "b", "c"]);
 
-    // "c" gets a brand-new message — its lastMessageAt jumps far ahead. The
-    // pinned order must not change.
+    // "c" receives a brand-new message, so it leads. Under the old comparator
+    // the order was pinned to creation time and would not have changed.
     const after = groupConversations(
       base.map((c) =>
         c.conversationId === "c" ? { ...c, lastMessageAt: 9_999_999 } : c,
       ),
     ).pinned.map((c) => c.conversationId);
-    expect(after).toEqual(before);
+    expect(after).toEqual(["c", "a", "b"]);
   });
 
-  test("displayOrder rows come before rows without displayOrder", () => {
+  test("a row carrying displayOrder gets no precedence over one without", () => {
     const result = groupConversations([
       makeConversation({
         conversationId: "no-order-newer",
@@ -543,12 +529,12 @@ describe("groupConversations · displayOrder for pinned and custom groups", () =
       }),
     ]);
     expect(result.pinned.map((c) => c.conversationId)).toEqual([
-      "ordered-0",
       "no-order-newer",
+      "ordered-0",
     ]);
   });
 
-  test("custom group conversations sort by displayOrder", () => {
+  test("custom group conversations sort by recency, ignoring displayOrder", () => {
     const groups: ConversationGroup[] = [
       {
         id: "grp-work",
@@ -560,16 +546,16 @@ describe("groupConversations · displayOrder for pinned and custom groups", () =
     const result = groupConversations(
       [
         makeConversation({
-          conversationId: "z",
-          groupId: "grp-work",
-          displayOrder: 2,
-          lastMessageAt: 1704240000000,
-        }),
-        makeConversation({
           conversationId: "x",
           groupId: "grp-work",
           displayOrder: 0,
           lastMessageAt: 1704067200000,
+        }),
+        makeConversation({
+          conversationId: "z",
+          groupId: "grp-work",
+          displayOrder: 2,
+          lastMessageAt: 1704240000000,
         }),
         makeConversation({
           conversationId: "y",
@@ -582,9 +568,9 @@ describe("groupConversations · displayOrder for pinned and custom groups", () =
     );
     const work = result.customGroups.find((g) => g.id === "grp-work");
     expect(work?.conversations.map((c) => c.conversationId)).toEqual([
-      "x",
-      "y",
       "z",
+      "y",
+      "x",
     ]);
   });
 });

--- a/clients/web/src/domains/chat/utils/group-conversations.ts
+++ b/clients/web/src/domains/chat/utils/group-conversations.ts
@@ -108,15 +108,12 @@ function parseLastMessageAt(conversation: Conversation): number {
 /**
  * Recency order, newest first: the one order every section uses.
  *
- * `conversationId` breaks ties so the result stays deterministic when two
- * rows share a `lastMessageAt` (or both lack one).
+ * No tiebreak. `Array.prototype.sort` is stable, so rows sharing a
+ * `lastMessageAt` (or both missing one) keep the order they arrived in, which
+ * is the server's. Adding an id tiebreak here would reorder them against it.
  */
 function compareByRecency(a: Conversation, b: Conversation): number {
-  const byRecency = parseLastMessageAt(b) - parseLastMessageAt(a);
-  if (byRecency !== 0) {
-    return byRecency;
-  }
-  return a.conversationId.localeCompare(b.conversationId);
+  return parseLastMessageAt(b) - parseLastMessageAt(a);
 }
 
 /**

--- a/clients/web/src/domains/chat/utils/group-conversations.ts
+++ b/clients/web/src/domains/chat/utils/group-conversations.ts
@@ -106,60 +106,17 @@ function parseLastMessageAt(conversation: Conversation): number {
 }
 
 /**
- * Stable fallback order for pinned / custom-group rows that have no
- * server-assigned `displayOrder`, and the tie-breaker when two rows share a
- * `displayOrder`.
+ * Recency order, newest first: the one order every section uses.
  *
- * Keyed on the immutable `createdAt` (newest-created first) — deliberately NOT
- * `lastMessageAt`. Pinning sends no `displayOrder` (the daemon stores it as
- * NULL until the user drag-reorders), so without this every pinned row would
- * sort by recency and jump to the top whenever a new message landed in it.
- * Pinned rows should hold their position regardless of activity, so we sort by
- * creation time, which never changes. `conversationId` is the final
- * tie-breaker so the order stays fully deterministic when `createdAt` is equal
- * or missing.
+ * `conversationId` breaks ties so the result stays deterministic when two
+ * rows share a `lastMessageAt` (or both lack one).
  */
-function compareByCreatedAt(a: Conversation, b: Conversation): number {
-  const byCreated = (b.createdAt ?? 0) - (a.createdAt ?? 0);
-  if (byCreated !== 0) {
-    return byCreated;
+function compareByRecency(a: Conversation, b: Conversation): number {
+  const byRecency = parseLastMessageAt(b) - parseLastMessageAt(a);
+  if (byRecency !== 0) {
+    return byRecency;
   }
   return a.conversationId.localeCompare(b.conversationId);
-}
-
-/**
- * Comparator for buckets where the user can manually drag-reorder rows
- * (pinned, custom groups). Conversations with a server-provided
- * `displayOrder` come first in ascending order; ties and rows without
- * `displayOrder` fall back to a stable creation-time order so pinned rows
- * never reshuffle when activity arrives (see {@link compareByCreatedAt}).
- *
- * Exported because a server-filtered section has to re-apply it. The daemon
- * orders user-ordered groups by `COALESCE(display_order, 999999) ASC` and
- * then by recency, so rows that were never dragged all tie at the sentinel
- * and fall through to activity order, which is the opposite of the invariant
- * above. Sorting the section's own response with this comparator keeps the
- * two paths agreeing.
- */
-export function compareByDisplayOrder(
-  a: Conversation,
-  b: Conversation,
-): number {
-  const aOrder = a.displayOrder;
-  const bOrder = b.displayOrder;
-  if (aOrder != null && bOrder != null) {
-    if (aOrder !== bOrder) {
-      return aOrder - bOrder;
-    }
-    return compareByCreatedAt(a, b);
-  }
-  if (aOrder != null) {
-    return -1;
-  }
-  if (bOrder != null) {
-    return 1;
-  }
-  return compareByCreatedAt(a, b);
 }
 
 /**
@@ -310,25 +267,21 @@ export function groupConversations(
   // Copy before sort so we never mutate the caller's array. Sorting in-place
   // on a shared reference is a subtle source of downstream re-render churn
   // in React.
-  const sortedRecents = recents.slice().sort((a, b) => {
-    return parseLastMessageAt(b) - parseLastMessageAt(a);
-  });
+  const sortedRecents = recents.slice().sort(compareByRecency);
   // One section per channel that has conversations, each recency-sorted,
   // with the sections themselves ordered by channel id for a stable layout.
   const channelSections: ChannelSection[] = [...channelBuckets.entries()]
     .map(([channelId, convs]) => ({
       channelId,
-      conversations: convs
-        .slice()
-        .sort((a, b) => parseLastMessageAt(b) - parseLastMessageAt(a)),
+      conversations: convs.slice().sort(compareByRecency),
     }))
     .sort((a, b) => a.channelId.localeCompare(b.channelId));
-  // Pinned + custom groups honor `displayOrder` (set when the user
-  // drag-reorders). Any global resort by recency at this level would
-  // override the user's custom order — see LUM-1619.
-  const sortedPinned = pinned.slice().sort(compareByDisplayOrder);
+  // Pinned and the custom groups sort by recency like every other section.
+  // They used to honor `displayOrder` instead, which only ever held a value
+  // for someone who had drag-reordered (LUM-3108 removed that affordance).
+  const sortedPinned = pinned.slice().sort(compareByRecency);
   for (const bucket of customGroupsList) {
-    bucket.conversations.sort(compareByDisplayOrder);
+    bucket.conversations.sort(compareByRecency);
   }
 
   return {


### PR DESCRIPTION
## TL;DR

Deletes conversation drag-reorder. Every sidebar section now sorts by recency, and the client stops sorting server-filtered sections at all. Nobody loses an arrangement they made, because for almost everyone there wasn't one.

Stacked on #40406 (one-character NUL fix) so this PR's changes to `use-sidebar-state.ts` render as a readable diff instead of "Binary files differ". Retarget to `main` once that merges.

## Why

Drag-reorder was the only reason a second ordering path existed, and it was already broken in a way nobody could see.

Pinning posts no `displayOrder` (`use-conversation-actions.ts` sent `{ conversationId, isPinned, groupId }`) and nothing backfills it. So for anyone who never dragged, every row was NULL — and the two sides then disagreed about what NULL meant:

- **Server:** `COALESCE(display_order, 999999) ASC, recency DESC, id DESC` → all rows tie at the sentinel, fall through to **activity order**.
- **Client:** `compareByCreatedAt` → **creation order**, with a docstring insisting pinned rows must "hold their position regardless of activity."

The order a user saw was neither an arrangement they made nor a consistent rule. #40375 had to patch over exactly this with a client-side re-sort; that patch goes here.

It is also the wrong seam. `isUserOrderedGroup` covers pinned **and every custom group**, so under per-section queries (LUM-2443) each newly wired section would have to re-apply the client comparator. This lands first so that patch is never written per section.

## Three things the ticket got wrong

LUM-3108 listed ~312 lines as "deletable outright." Verified against the code, two of those must stay:

| Ticket said | Actually |
| --- | --- |
| `use-drag-reorder.ts` (187 lines) deletable | **Stays.** `useDragReorder` has two consumers; `use-section-drag-reorder.ts:43` is the other |
| `use-section-drag-reorder.ts` (67 lines) deletable | **Stays entirely.** Section drag-reorder is a *different feature* — it reorders whole sidebar sections, persists to localStorage `sectionOrder`, not `display_order`, and is the drag counterpart of the header menu's move up/down that LUM-3061 keeps |
| "the reorder mutation and its route are gone" | **Route stays.** `moveToGroupMutation` posts pin/group changes through `conversationsReorderPost`. Only the displayOrder-writing mutation goes |

I've added a Corrected section to the ticket.

## Why it is safe

- **Almost nobody had an arrangement.** `display_order` is NULL unless the user explicitly dragged, so for everyone else the feature did nothing today.
- **For those who did drag:** they lose manual order in Pinned and custom groups and fall back to recency — bounded, small sections (curated membership is roughly 1% of conversations), and recency is the rule every other section already follows.
- **Nothing is dropped from the wire.** The `displayOrder` field and the `display_order` column stay, unread and unwritten. Web is the only consumer; no `displayOrder` reference exists in `clients/macos` or `clients/ios`.
- **Server untouched.** This PR is web-only. The daemon still orders by `COALESCE(display_order, ...)`; the client just renders whatever order it receives, which is coherent either way. PR 0b removes the server path separately.
- Typecheck, eslint (0 errors) and prettier pass.

## Before / after

| | Before | After |
| --- | --- | --- |
| Order in Pinned / custom groups | Neither manual nor consistent: server said activity order, client said creation order | Recency, same as every other section |
| A pinned chat gets a new message | Stayed put (client) / jumped (server) — depending on which list you were looking at | Moves to the top of Pinned |
| Dragging a conversation row | Possible, usually with no visible effect | Not offered |
| Dragging a whole section | Works | Works, unchanged |
| A manual arrangement you made by dragging | Honored inconsistently | Replaced by recency |
| Custom group with 30+ chats | Mounted every row | Windows, like other sections |

## Tests

The tests asserting the old ordering are **replaced, not deleted**. Each replacement sets `displayOrder` to contradict the expected result, so re-introducing either comparator fails them rather than leaving them coincidentally passing:

- `group-conversations.test.ts` — pinned and custom groups sort by recency and ignore `displayOrder`; a pinned row with new activity moves to the top.
- `use-sidebar-state.test.tsx` — Pinned renders the server's order as-is, with both `createdAt` and `displayOrder` contradicting it.
- `conversation-transforms-list.test.ts` is untouched: it tests parsing the wire field, which stays.

## Follow-up

PR 0b (assistant): `isUserOrderedGroup`, both `COALESCE(display_order, 999999)` branches, and `conversation-display-order-migration.ts`.

Part of LUM-3108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40408" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->