### PR TITLE
refactor(web): size the settings AI buttons regular, not compact

### DIFF
--- a/clients/web/src/domains/settings/ai/bulk-override-swap-modal.tsx
+++ b/clients/web/src/domains/settings/ai/bulk-override-swap-modal.tsx
@@ -273,7 +273,6 @@ export function BulkOverrideSwapModal({
               </div>
               <Button
                 variant="ghost"
-                size="compact"
                 onClick={() =>
                   setDeselectedIds(
                     allSelected
@@ -318,17 +317,11 @@ export function BulkOverrideSwapModal({
           >
             {actionCount(selectedIds.length)} will change
           </Typography>
-          <Button
-            variant="ghost"
-            size="compact"
-            onClick={onClose}
-            disabled={applying}
-          >
+          <Button variant="ghost" onClick={onClose} disabled={applying}>
             Cancel
           </Button>
           <Button
             variant="primary"
-            size="compact"
             disabled={
               !source || !target || selectedIds.length === 0 || applying
             }

--- a/clients/web/src/domains/settings/ai/language-model-card.tsx
+++ b/clients/web/src/domains/settings/ai/language-model-card.tsx
@@ -136,7 +136,6 @@ export function LanguageModelCard({
             action={
               <Button
                 variant="outlined"
-                size="compact"
                 onClick={() => onOpenPanel({ kind: "overrides" })}
               >
                 Manage

--- a/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
@@ -374,7 +374,6 @@ export function OverridesDetailPanel({
       {hasAnyPersistedOverride && (
         <Button
           variant="outlined"
-          size="compact"
           onClick={() => setShowResetConfirmation(true)}
           disabled={saving || !isSeeded}
           tintColor="var(--system-negative-strong)"
@@ -385,7 +384,6 @@ export function OverridesDetailPanel({
       )}
       <Button
         variant="primary"
-        size="compact"
         onClick={() => void handleSave()}
         disabled={!hasUnsavedDrafts || hasValidationError || saving}
       >
@@ -424,7 +422,6 @@ export function OverridesDetailPanel({
           </div>
           <Button
             variant="outlined"
-            size="compact"
             onClick={() => setShowBulkSwap(true)}
             disabled={
               !isSeeded || saving || hasUnsavedDrafts || !hasBulkSwapCandidates
@@ -475,11 +472,7 @@ export function OverridesDetailPanel({
             <p className="text-body-medium-lighter text-[var(--content-tertiary)]">
               Make sure your assistant is running
             </p>
-            <Button
-              variant="outlined"
-              size="compact"
-              onClick={() => void refetch()}
-            >
+            <Button variant="outlined" onClick={() => void refetch()}>
               Retry
             </Button>
           </div>

--- a/clients/web/src/domains/settings/ai/profiles-section.tsx
+++ b/clients/web/src/domains/settings/ai/profiles-section.tsx
@@ -67,7 +67,6 @@ export function ProfilesSection({
         action={
           <Button
             variant="primary"
-            size="compact"
             onClick={onCreateProfile}
             leftIcon={<Plus />}
             // The create panel needs config for duplicate-key validation

--- a/clients/web/src/domains/settings/ai/providers-section.tsx
+++ b/clients/web/src/domains/settings/ai/providers-section.tsx
@@ -85,7 +85,6 @@ export function ProvidersSection({
       action={
         <Button
           variant="outlined"
-          size="compact"
           onClick={onAddProvider}
           leftIcon={<Plus />}
         >


### PR DESCRIPTION
## TL;DR

Ten buttons in the Language Model card and the Action Overrides panel move from `compact` (24px) to the default `regular` (32px). Five files, ten lines removed.

## What changes for the user

| Button | Where |
| --- | --- |
| Create Profile | Profiles card header |
| Add Provider | Providers card header |
| Manage | Overrides card header |
| Bulk change | beside the search field in the Overrides panel |
| Reset to Defaults, Save | Overrides panel footer |
| Retry | Overrides panel error state |
| Select all / Clear all | Bulk swap modal header |
| Cancel, Apply | Bulk swap modal footer |

Each goes from 24px to 32px, and the ones with a leading `+` get a 14px icon instead of 10px.

## Why

`compact` is the smaller of the two sizes `Button` offers: a third shorter than the default, with a smaller type token and a 10px icon. It is for dense inline affordances.

None of these is that. They are card header actions and panel or modal footer actions, which is the ordinary case the default exists for. The wider codebase agrees: across `domains/settings` there are 136 buttons on the default against 74 explicit `compact`, and the three card headers were the only users of `LanguageModelSection`'s `action` slot, so no local pattern held them at compact either.

**"Bulk change" is the clearest case.** It sits immediately beside a 36px search field at 24px, so the entry point to the panel's only bulk operation reads as an afterthought. At 32 it still does not match the field exactly, for the reason [LUM-3107](https://linear.app/vellum/issue/LUM-3107) covers, but it stops looking accidental.

## Judgement call worth a second opinion

**Select all / Clear all** in the bulk swap modal (`bulk-override-swap-modal.tsx:274`) is a `ghost` button acting as an inline text toggle next to a heading, not a real button. It is the one of the ten where `compact` may have been deliberate, and 32px could read heavy against the heading beside it. Included for consistency; happy to put it back if it looks wrong in the running app.

## Details

The prop is dropped rather than set to `size="regular"`. `regular` is the default, and the codebase spells it explicitly only twice against 136 omissions.

`language-model-card.tsx` and `providers-section.tsx` do not satisfy `prettier` on `main`. They are left as found rather than reformatted: running the formatter over them turned a one-line removal into a 125-line diff, which was reverted. Checked against the unmodified files rather than assumed.

## Verification

`tsc --noEmit` and `eslint` clean. No test asserts on button size. This is visual, so it is worth a look in the running app rather than only on the diff, particularly the ghost toggle noted above.
