### PR TITLE
fix(assistant): make the voice picker steering reachable and its no-action invariant enforced

### DIFF
--- a/assistant/src/__tests__/ui-shape-teaching.test.ts
+++ b/assistant/src/__tests__/ui-shape-teaching.test.ts
@@ -364,4 +364,20 @@ describe("uiShowTeachingError", () => {
     );
     expect(UI_SHOW_TYPE_DOCS).not.toContain("- voice_picker:");
   });
+
+  test("voice_picker steering reaches the model through the cold index", () => {
+    // Asserted on the built description rather than the doc entry: a cold
+    // type's `shape` reaches the model only through a teaching error, and an
+    // empty payload has no missing-content state to raise one, so steering
+    // parked there would be dead.
+    for (const directive of [
+      "change, hear, or pick a voice",
+      "rather than describing voices in prose",
+      "attach no actions and never set await_action",
+      "during a live voice call answer in speech",
+    ]) {
+      expect(UI_SHOW_TYPE_DOCS).toContain(directive);
+      expect(uiShowTool.description).toContain(directive);
+    }
+  });
 });

--- a/assistant/src/__tests__/ui-voice-picker-surface.test.ts
+++ b/assistant/src/__tests__/ui-voice-picker-surface.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests for the `voice_picker` ui_show surface's "never blocks a turn"
+ * invariant.
+ *
+ * The card has no terminal action: it settles when the user picks a voice,
+ * with no button to click. `actions` and `await_action` are generic ui_show
+ * params though, so the model can attach them to any surface, and the web
+ * client latches `awaiting_user_input` on the presence of actions alone with
+ * nothing to clear it. The daemon resolver therefore strips both, and a
+ * pending picker never holds the one-interactive-surface lock.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { UISurfaceShowEventSchema } from "../api/events/ui-surface-show.js";
+import type { AssistantEvent } from "../api/index.js";
+import type { Conversation } from "../daemon/conversation.js";
+import {
+  createSurfaceMutex,
+  surfaceProxyResolver,
+} from "../daemon/conversation-surfaces.js";
+import type { SurfaceType } from "../daemon/message-protocol.js";
+import { INTERACTIVE_SURFACE_TYPES } from "../daemon/message-protocol.js";
+import { asConversation } from "./helpers/mock-conversation.js";
+
+function makeContext(sent: AssistantEvent[] = []): Conversation {
+  return asConversation({
+    conversationId: "session-1",
+    sendToClient: (msg) => sent.push(msg),
+    pendingSurfaceActions: new Map<string, { surfaceType: SurfaceType }>(),
+    lastSurfaceAction: new Map<
+      string,
+      { actionId: string; data?: Record<string, unknown> }
+    >(),
+    surfaceState: new Map(),
+    surfaceUndoStacks: new Map<string, string[]>(),
+    accumulatedSurfaceState: new Map<string, Record<string, unknown>>(),
+    surfaceActionRequestIds: new Set<string>(),
+    currentTurnSurfaces: [],
+    isProcessing: () => false,
+    enqueueMessage: () => ({ queued: false, requestId: "req-1" }),
+    getQueueDepth: () => 0,
+    processMessage: async () => "ok",
+    withSurface: createSurfaceMutex(),
+  });
+}
+
+function showEvent(sent: AssistantEvent[]) {
+  return UISurfaceShowEventSchema.parse(
+    sent.find((msg) => msg.type === "ui_surface_show"),
+  );
+}
+
+describe("voice_picker never blocks a turn", () => {
+  test("shows with an empty payload and awaits nothing", async () => {
+    const sent: AssistantEvent[] = [];
+    const ctx = makeContext(sent);
+
+    const result = await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "voice_picker",
+      data: {},
+    });
+
+    expect(result.isError).toBe(false);
+    expect(result.yieldToUser).toBeUndefined();
+
+    const parsed = showEvent(sent);
+    expect(parsed.surfaceType).toBe("voice_picker");
+    expect(parsed.actions).toBeUndefined();
+    expect(ctx.pendingSurfaceActions.has(parsed.surfaceId)).toBe(false);
+  });
+
+  test("strips actions the model attached", async () => {
+    const sent: AssistantEvent[] = [];
+    const ctx = makeContext(sent);
+
+    const result = await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "voice_picker",
+      data: {},
+      actions: [{ id: "done", label: "Done", style: "primary" }],
+    });
+
+    expect(result.isError).toBe(false);
+    expect(result.yieldToUser).toBeUndefined();
+
+    const parsed = showEvent(sent);
+    expect(parsed.actions).toBeUndefined();
+    // The persisted copy must match the emitted one, or a history reseed would
+    // resurrect the button the client blocks on.
+    expect(ctx.currentTurnSurfaces[0]?.actions).toBeUndefined();
+    expect(ctx.pendingSurfaceActions.has(parsed.surfaceId)).toBe(false);
+  });
+
+  test("ignores an explicit await_action", async () => {
+    const sent: AssistantEvent[] = [];
+    const ctx = makeContext(sent);
+
+    const result = await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "voice_picker",
+      data: {},
+      await_action: true,
+    });
+
+    expect(result.isError).toBe(false);
+    expect(result.yieldToUser).toBeUndefined();
+    expect(result.content).not.toContain("awaiting_user_action");
+    expect(ctx.pendingSurfaceActions.size).toBe(0);
+  });
+
+  test("a pending picker does not hold the one-interactive-surface lock", async () => {
+    const ctx = makeContext();
+    ctx.pendingSurfaceActions.set("surface-picker", {
+      surfaceType: "voice_picker",
+    });
+
+    const result = await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "choice",
+      data: { options: [{ id: "a", title: "Option A" }] },
+    });
+
+    expect(result.isError).toBe(false);
+    expect(result.content).not.toContain("already awaiting user input");
+  });
+
+  test("voice_picker is not an interactive surface type", () => {
+    expect(INTERACTIVE_SURFACE_TYPES).not.toContain("voice_picker");
+  });
+});

--- a/assistant/src/__tests__/voice-config-update.test.ts
+++ b/assistant/src/__tests__/voice-config-update.test.ts
@@ -276,6 +276,46 @@ describe("voice_config_update — tts_voice_id (managed/vellum active)", () => {
     expect(result.content).not.toContain("broadcast");
   });
 
+  test("hints the inline picker for the next managed voice change", async () => {
+    makeVellumActive();
+
+    const result = await run(
+      { setting: "tts_voice_id", value: "aura-2-zeus-en" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toStartWith("Vellum managed voice updated to");
+    expect(result.content).toContain(
+      'ui_show { surface_type: "voice_picker", data: {} }',
+    );
+  });
+
+  test("does not hint the picker when the voice is not managed", async () => {
+    writeConfig({ services: { tts: { provider: "elevenlabs" } } });
+    invalidateConfigCache();
+
+    const result = await run(
+      { setting: "tts_voice_id", value: "abc123" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).not.toContain("voice_picker");
+  });
+
+  test("does not hint the picker for a non-voice setting", async () => {
+    makeVellumActive();
+
+    const result = await run(
+      { setting: "conversation_timeout", value: 30 },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).not.toContain("voice_picker");
+  });
+
   test("rejects a value with characters invalid for any voice id", async () => {
     makeVellumActive();
 

--- a/assistant/src/config/bundled-skills/settings/tools/navigate-settings-tab.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/navigate-settings-tab.ts
@@ -2,6 +2,7 @@ import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { voicePickerHint } from "./shared.js";
 
 const SETTINGS_TABS = [
   "General",
@@ -23,8 +24,9 @@ const LEGACY_TAB_ALIASES: Record<string, SettingsTab> = {
   "Archived Conversations": "Archive",
 };
 
-const VOICE_TAB_PICKER_HINT =
-  'Next time the user wants to change or hear a voice, prefer `ui_show { surface_type: "voice_picker", data: {} }`, which puts the picker in the conversation without navigating away. Navigating here is right only when the user explicitly asked to open Settings.';
+const VOICE_TAB_PICKER_HINT = voicePickerHint(
+  "which puts the picker in the conversation without navigating away. Navigating here is right only when the user explicitly asked to open Settings.",
+);
 
 export async function run(
   input: Record<string, unknown>,

--- a/assistant/src/config/bundled-skills/settings/tools/shared.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/shared.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared helpers for the settings skill's tool executors.
+ */
+
+/**
+ * Steer the model back to the inline voice picker.
+ *
+ * Both settings tools a "change my voice" request can land on (the Voice tab
+ * navigation and a managed `tts_voice_id` write) end by naming the picker, so
+ * the invocation itself lives here: if the surface type or its payload ever
+ * changes, one edit keeps both tools correct instead of leaving one teaching a
+ * call that no longer exists. Each caller supplies its own tail, because the
+ * reason the picker is better differs by the tool the model just reached for.
+ */
+export function voicePickerHint(tail: string): string {
+  return `Next time the user wants to change or hear a voice, prefer \`ui_show { surface_type: "voice_picker", data: {} }\`, ${tail}`;
+}

--- a/assistant/src/config/bundled-skills/settings/tools/shared.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/shared.ts
@@ -7,10 +7,9 @@
  *
  * Both settings tools a "change my voice" request can land on (the Voice tab
  * navigation and a managed `tts_voice_id` write) end by naming the picker, so
- * the invocation itself lives here: if the surface type or its payload ever
- * changes, one edit keeps both tools correct instead of leaving one teaching a
- * call that no longer exists. Each caller supplies its own tail, because the
- * reason the picker is better differs by the tool the model just reached for.
+ * the invocation itself lives here: one edit keeps both tools teaching the same
+ * call. Each caller supplies its own tail, because the reason the picker is
+ * better differs by the tool the model just reached for.
  */
 export function voicePickerHint(tail: string): string {
   return `Next time the user wants to change or hear a voice, prefer \`ui_show { surface_type: "voice_picker", data: {} }\`, ${tail}`;

--- a/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
@@ -19,6 +19,7 @@ import {
 } from "../../../loader.js";
 import { VALID_CONVERSATION_TIMEOUTS } from "../../../schemas/elevenlabs.js";
 import { VALID_STT_PROVIDERS } from "../../../schemas/stt.js";
+import { voicePickerHint } from "./shared.js";
 
 /**
  * Valid voice config settings and their UserDefaults key mappings.
@@ -196,8 +197,9 @@ const STT_LANGUAGE_ALIASES: Record<
  * write still happens and the result stays non-error; this only redirects the
  * next request.
  */
-const MANAGED_VOICE_PICKER_HINT =
-  'Next time the user wants to change or hear a voice, prefer `ui_show { surface_type: "voice_picker", data: {} }`, which lets them hear and pick from the managed catalog in the conversation. Set the id here only when the user named a specific voice.';
+const MANAGED_VOICE_PICKER_HINT = voicePickerHint(
+  "which lets them hear and pick from the managed catalog in the conversation. Set the id here only when the user named a specific voice.",
+);
 
 function validateSetting(
   setting: string,

--- a/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
@@ -187,6 +187,18 @@ const STT_LANGUAGE_ALIASES: Record<
   "code-switching": "multi",
 };
 
+/**
+ * Same steer `navigate_settings_tab` puts on the Voice tab, applied to the
+ * strongest competing affordance: this tool's description coaches the model to
+ * read the managed catalog and set `tts_voice_id` itself, which is exactly the
+ * "assistant names voices in prose" outcome the inline picker exists to
+ * replace. Managed only, because that is the catalog the picker renders. The
+ * write still happens and the result stays non-error; this only redirects the
+ * next request.
+ */
+const MANAGED_VOICE_PICKER_HINT =
+  'Next time the user wants to change or hear a voice, prefer `ui_show { surface_type: "voice_picker", data: {} }`, which lets them hear and pick from the managed catalog in the conversation. Set the id here only when the user named a specific voice.';
+
 function validateSetting(
   setting: string,
   value: unknown,
@@ -530,10 +542,14 @@ export async function run(
     AUTO_DETECT_STT_PROVIDERS.has(activeSttProviderId)
       ? ` Note: the configured STT provider (${activeSttProviderId}) auto-detects the spoken language natively and ignores this setting.`
       : "";
+  const pickerNote =
+    setting === "tts_voice_id" && activeTtsProviderId === "vellum"
+      ? ` ${MANAGED_VOICE_PICKER_HINT}`
+      : "";
   return {
     content: `${friendlyName} updated to ${JSON.stringify(
       validation.coerced,
-    )}.${broadcastNote}${autoDetectNote}`,
+    )}.${broadcastNote}${autoDetectNote}${pickerNote}`,
     isError: false,
   };
 }

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -140,13 +140,27 @@ const MAX_UNDO_DEPTH = 10;
 
 /**
  * Pending surface types that do not hold the one-interactive-surface-at-a-time
- * lock. Both render content the user reads rather than a question they must
- * answer, so a live one must not block the next surface.
+ * lock. Each renders content the user reads (or settles on its own) rather
+ * than a question they must answer, so a live one must not block the next
+ * surface.
  */
 const NON_BLOCKING_PENDING_SURFACE_TYPES = new Set<SurfaceType>([
   "dynamic_page",
   "visual",
+  "voice_picker",
 ]);
+
+/**
+ * Surface types that carry no terminal action: the card settles when the user
+ * interacts with it, so no click could ever satisfy an attached `actions`
+ * entry or an explicit `await_action`. Both are generic ui_show params though,
+ * so nothing stops the model attaching them here, and doing so wedges the
+ * turn: the client latches `awaiting_user_input` on the presence of actions
+ * alone and no action ever arrives to clear it, leaving the composer disabled
+ * and Stop hidden while the daemon is still streaming. Stripping them makes
+ * the "never blocks a turn" contract structural rather than advisory.
+ */
+const ACTIONLESS_SURFACE_TYPES = new Set<SurfaceType>(["voice_picker"]);
 
 /**
  * Debounce window for persisting `ui_surface_update` data back to the
@@ -3279,8 +3293,12 @@ export async function surfaceProxyResolver(
       }
       inputActions = valid.length > 0 ? valid : undefined;
     }
-    const actions =
-      choiceData !== undefined ? buildChoiceActions(choiceData) : inputActions;
+    const isActionless = ACTIONLESS_SURFACE_TYPES.has(surfaceType);
+    const actions = isActionless
+      ? undefined
+      : choiceData !== undefined
+        ? buildChoiceActions(choiceData)
+        : inputActions;
     const hasActions = Array.isArray(actions) && actions.length > 0;
     if (surfaceType === "choice" && !hasActions) {
       return {
@@ -3332,7 +3350,11 @@ export async function surfaceProxyResolver(
           : surfaceType === "table"
             ? hasActions
             : INTERACTIVE_SURFACE_TYPES.includes(surfaceType);
-    const awaitAction = (input.await_action as boolean) ?? isInteractive;
+    // An explicit `await_action: true` is honored for every other type; an
+    // actionless surface has nothing to await, so it is forced false.
+    const awaitAction = isActionless
+      ? false
+      : ((input.await_action as boolean) ?? isInteractive);
 
     // Only one non-persistent interactive surface at a time. If another
     // surface is already awaiting user input, reject this one so the LLM

--- a/assistant/src/tools/ui-surface/surface-shape-docs.ts
+++ b/assistant/src/tools/ui-surface/surface-shape-docs.ts
@@ -212,9 +212,15 @@ export const SURFACE_SHAPE_DOCS: Record<string, SurfaceShapeDoc> = {
         : '`data.channel` must be one of "slack", "telegram", "phone"',
   },
   voice_picker: {
-    purpose: "inline picker for the voice the assistant speaks in",
+    // The steering lives in `purpose` because that is the only part of a cold
+    // type the model ever sees: `shape` ships solely inside a teaching error,
+    // and an empty payload has no missing-content state to raise one. The
+    // surface exists to replace prose voice tours, so losing the directive
+    // would leave nothing but a renderer nobody invokes.
+    purpose:
+      "inline picker for the voice the assistant speaks in; show it when the user asks to change, hear, or pick a voice rather than describing voices in prose or sending them to Settings; attach no actions and never set await_action; during a live voice call answer in speech instead, the room already carries its own picker",
     shape:
-      "{}: no payload, the card reads the current voice and the catalog itself. Show it when the user asks to change, hear, or pick a voice, instead of describing voices in prose or sending them to Settings. Selecting a voice applies on the assistant's next spoken turn",
+      "{}: no payload, the card reads the current voice and the catalog itself. Selecting a voice applies on the assistant's next spoken turn",
   },
 };
 


### PR DESCRIPTION
## Summary

- **The steering now reaches the model.** `voice_picker`'s directive lived in `shape`, which is dead for a cold type: `UI_SHOW_TYPE_DOCS` interpolates a cold type's `shape` nowhere, and `uiShowTeachingError` returns early when a type has no `missingContent` (an empty payload has none), so the only thing the model ever saw was `voice_picker (inline picker for the voice the assistant speaks in)`. Moved the directive into `purpose`, which the cold index does ship. `shape` keeps the payload contract. Not promoted to `HOT_SURFACE_TYPES`: an empty-payload surface does not merit a whole shape block.
- **Mid-call it now steers to speech.** `supportsDynamicUi` is TRUE for live-voice on web, and the live-voice session latches `minimizeRequested` on any non-error `ui_show`, so "change your voice" said during a call dropped the user out of the room to reach a picker the room already exposes. Added a clause telling the model to answer in speech during a live call. `revealsUiSurface` is untouched: suppressing the minimize would render the card behind the room modal.
- **The "never blocks a turn" invariant is now structural.** `actions` and `await_action` are generic `ui_show` params and nothing stopped the model attaching them. The daemon left `awaitAction` false while the client latched `awaiting_user_input` on `hasActions` alone, and nothing cleared it (composer stuck, Stop hidden mid-stream). The resolver now strips `actions` and forces `awaitAction` false for actionless types, and `voice_picker` joined `NON_BLOCKING_PENDING_SURFACE_TYPES`. The guidance says so too.
- **The competing affordance is steered.** `voice_config_update`'s description coaches the model to read the managed catalog and set `tts_voice_id` itself, which is the prose-tour outcome the picker exists to replace, and its activation hint fires on the same request. Its success `content` now carries the same one-line picker preference when the setting is `tts_voice_id` and the active TTS provider is managed. Result stays `isError: false`; no behavior change.

Verified the first bullet by asserting each directive on the built `UI_SHOW_TYPE_DOCS` and on `uiShowTool.description`, not on the doc entry.

Fixes gaps found in self-review of plan inline-voice-picker-surface.md