### PR TITLE
fix(assistant): resolve the guardian persona for scheduled tasks and memory consolidation

### DIFF
--- a/assistant/src/__tests__/conversation-initial-prompt.test.ts
+++ b/assistant/src/__tests__/conversation-initial-prompt.test.ts
@@ -3,11 +3,12 @@
  *
  * A conversation's system prompt is built once at construction and frozen for
  * every turn (the agent loop never re-resolves it), so the persona slot must
- * resolve correctly here. With no construction-time identity the default-build
- * path must warm the gateway guardian binding BEFORE building (else a cold cache
- * pins `users/default.md`); a channel-routed conversation that already carries
- * the requester's trust context must build with it so the requester's profile
- * resolves instead of the guardian/default one.
+ * resolve correctly here. With no construction-time identity OR a
+ * guardian-class trust context (background/scheduled turns, memory
+ * consolidation, managed desktop) the guardian binding must be warmed BEFORE
+ * building (else a cold cache pins `users/default.md`); a channel-routed
+ * conversation carrying a non-guardian requester trust context must build with
+ * it directly so the requester's profile resolves via the DB contact lookup.
  *
  * Dependency seams are injected so this exercises the sequencing without mocking
  * the widely-imported guardian-delivery / system-prompt modules (those global
@@ -47,6 +48,23 @@ const REQUESTER_TRUST = {
   requesterExternalUserId: "user-123",
 } as unknown as TrustContext;
 
+// The shape scheduler execute/reuse runs, memory consolidation, and other
+// runBackgroundJob callers pass at construction: guardian class, no
+// per-actor identity.
+const GUARDIAN_BACKGROUND_TRUST = {
+  sourceChannel: "vellum",
+  trustClass: "guardian",
+} as unknown as TrustContext;
+
+// Managed desktop: guardian class WITH a requester principal id. The persona
+// resolution may still need the guardian-delivery cache (contact lookup miss
+// or null userFile falls through to the guardian file).
+const GUARDIAN_REQUESTER_TRUST = {
+  sourceChannel: "vellum",
+  trustClass: "guardian",
+  requesterExternalUserId: "principal-123",
+} as unknown as TrustContext;
+
 describe("warmGuardianBindings", () => {
   test("warms both the vellum-channel key and the unfiltered fallback key", async () => {
     const keys: string[] = [];
@@ -72,7 +90,7 @@ describe("resolveInitialSystemPrompt", () => {
     expect(builtWith).toEqual([undefined]);
   });
 
-  test("channel-routed: threads the requester trust context and skips the guardian warm", async () => {
+  test("non-guardian channel-routed: threads the requester trust context and skips the guardian warm", async () => {
     const { calls, builtWith, deps } = spyDeps();
     const result = await resolveInitialSystemPrompt(
       { trustContext: REQUESTER_TRUST } as ConversationCreateOptions,
@@ -84,6 +102,33 @@ describe("resolveInitialSystemPrompt", () => {
     // guardian-cache warm is needed and the trust context must reach the build.
     expect(calls).toEqual(["build"]);
     expect(builtWith).toEqual([REQUESTER_TRUST]);
+  });
+
+  test("guardian-class background shape: warms the guardian binding, then builds with the trust context", async () => {
+    const { calls, builtWith, deps } = spyDeps();
+    const result = await resolveInitialSystemPrompt(
+      { trustContext: GUARDIAN_BACKGROUND_TRUST } as ConversationCreateOptions,
+      deps,
+    );
+
+    expect(result).toBe("BUILD");
+    // Scheduled tasks and memory consolidation construct conversations in
+    // worker processes whose guardian-delivery cache starts cold; the warm
+    // MUST precede the build or the persona slot pins users/default.md.
+    expect(calls).toEqual(["warm", "build"]);
+    expect(builtWith).toEqual([GUARDIAN_BACKGROUND_TRUST]);
+  });
+
+  test("guardian-class with requester identity (managed desktop): still warms before building", async () => {
+    const { calls, builtWith, deps } = spyDeps();
+    const result = await resolveInitialSystemPrompt(
+      { trustContext: GUARDIAN_REQUESTER_TRUST } as ConversationCreateOptions,
+      deps,
+    );
+
+    expect(result).toBe("BUILD");
+    expect(calls).toEqual(["warm", "build"]);
+    expect(builtWith).toEqual([GUARDIAN_REQUESTER_TRUST]);
   });
 
   test("an explicit override is used verbatim and skips the warm and build", async () => {

--- a/assistant/src/__tests__/persona-resolver.test.ts
+++ b/assistant/src/__tests__/persona-resolver.test.ts
@@ -63,6 +63,8 @@ function seedVellumGuardian(userFile: string | null): void {
 
 mock.module("../util/platform.js", () => ({
   getWorkspaceDir: () => mockWorkspaceDir,
+  getWorkspacePromptPath: (filename: string) =>
+    join(mockWorkspaceDir, "prompts", filename),
 }));
 
 mock.module("../contacts/contact-store.js", () => ({
@@ -96,6 +98,7 @@ mock.module("../contacts/guardian-delivery-reader.js", () => ({
 // Import AFTER mocks so the module under test binds to the stubbed
 // implementations.
 import { getGuardianDelivery } from "../contacts/guardian-delivery-reader.js";
+import { resolveUserName } from "../daemon/identity-helpers.js";
 import type { TrustContext } from "../daemon/trust-context-types.js";
 import {
   ensureGuardianPersonaFile,
@@ -406,5 +409,156 @@ describe("resolveUserSlug (guardian trust WITH requester identity)", () => {
     } as TrustContext;
 
     expect(resolveUserSlug(trustContext)).toBeNull();
+  });
+});
+
+// ── resolveUserSlug — guardian bound on a non-vellum channel ───────
+//
+// warmGuardianBindings warms both the channel-filtered and unfiltered cache
+// keys, but a guardian may be bound only on a non-vellum channel (phone,
+// Telegram). A guardian-class turn sourced elsewhere must still resolve that
+// guardian instead of silently landing on users/default.md.
+
+describe("resolveUserSlug (guardian bound on a non-vellum channel)", () => {
+  test("falls back to the any-channel guardian when the source channel has none", () => {
+    mockGuardianDeliveries = [
+      { channelType: "telegram", address: "guardian-tg", status: "active" },
+    ];
+    mockContactsByAddress["telegram:guardian-tg"] = { userFile: "alice.md" };
+
+    const trustContext = {
+      sourceChannel: "vellum",
+      trustClass: "guardian",
+    } as TrustContext;
+
+    expect(resolveUserSlug(trustContext)).toBe("alice");
+  });
+
+  test("any-channel guardian with no userFile resolves the guardian.md fallback", () => {
+    mockGuardianDeliveries = [
+      { channelType: "telegram", address: "guardian-tg", status: "active" },
+    ];
+    mockContactsByAddress["telegram:guardian-tg"] = { userFile: null };
+
+    const trustContext = {
+      sourceChannel: "vellum",
+      trustClass: "guardian",
+    } as TrustContext;
+
+    expect(resolveUserSlug(trustContext)).toBe("guardian");
+  });
+});
+
+// ── resolveUserSlug — cold cache then construction-time warm ───────
+//
+// The exact shape scheduled tasks and memory consolidation pass through
+// resolveInitialSystemPrompt: guardian class, no requester identity, built in
+// a worker process whose guardian-delivery cache starts cold.
+
+describe("resolveUserSlug (cold cache, background shape)", () => {
+  test("misses on a cold cache, resolves the guardian after the construction-time warm", async () => {
+    pendingWarmDeliveries = [
+      { channelType: "vellum", address: "vellum:self", status: "active" },
+    ];
+    mockContactsByAddress["vellum:vellum:self"] = { userFile: "alice.md" };
+
+    const trustContext = {
+      sourceChannel: "vellum",
+      trustClass: "guardian",
+    } as TrustContext;
+
+    // Cold: the sync peek finds nothing and the slug falls back to default.
+    expect(resolveUserSlug(trustContext)).toBeNull();
+
+    // resolveInitialSystemPrompt warms guardian bindings for guardian-class
+    // contexts before building; afterwards the same resolution succeeds.
+    await getGuardianDelivery({ channelTypes: ["vellum"] });
+
+    expect(resolveUserSlug(trustContext)).toBe("alice");
+  });
+});
+
+// ── resolveUserName — guardian-preferred display name ──────────────
+//
+// The sweep job and v2 router address the user by name in their prompts. The
+// name must come from the guardian's own persona file when one is resolvable,
+// falling back to users/default.md.
+
+describe("resolveUserName", () => {
+  test("prefers the Name label from the guardian's own persona file over default.md", () => {
+    seedVellumGuardian("alice.md");
+    const usersDir = join(mockWorkspaceDir, "users");
+    mkdirSync(usersDir, { recursive: true });
+    writeFileSync(join(usersDir, "alice.md"), "**Name:** Alice\n", "utf-8");
+    writeFileSync(
+      join(usersDir, "default.md"),
+      "**Name:** Default User\n",
+      "utf-8",
+    );
+
+    expect(resolveUserName(mockWorkspaceDir)).toBe("Alice");
+  });
+
+  test("reads the onboarding-written Preferred name bullet", () => {
+    seedVellumGuardian("alice.md");
+    const usersDir = join(mockWorkspaceDir, "users");
+    mkdirSync(usersDir, { recursive: true });
+    writeFileSync(
+      join(usersDir, "alice.md"),
+      "# User Profile\n\n## Onboarding Context\n\n- **Preferred name:** Ali\n",
+      "utf-8",
+    );
+
+    expect(resolveUserName(mockWorkspaceDir)).toBe("Ali");
+  });
+
+  test("reads the scaffold's filled Preferred name/reference line", () => {
+    seedVellumGuardian("alice.md");
+    const usersDir = join(mockWorkspaceDir, "users");
+    mkdirSync(usersDir, { recursive: true });
+    writeFileSync(
+      join(usersDir, "alice.md"),
+      "- Preferred name/reference: Alice\n- Pronouns: she/her\n",
+      "utf-8",
+    );
+
+    expect(resolveUserName(mockWorkspaceDir)).toBe("Alice");
+  });
+
+  test("an unfilled scaffold does not swallow the next line and falls back to default.md", () => {
+    seedVellumGuardian("alice.md");
+    const usersDir = join(mockWorkspaceDir, "users");
+    mkdirSync(usersDir, { recursive: true });
+    // The bare scaffold: every label present, every value unfilled.
+    ensureGuardianPersonaFile("alice.md");
+    writeFileSync(join(usersDir, "default.md"), "**Name:** Bob\n", "utf-8");
+
+    expect(resolveUserName(mockWorkspaceDir)).toBe("Bob");
+  });
+
+  test("a declined_by_user sentinel is not used as a name", () => {
+    seedVellumGuardian("alice.md");
+    const usersDir = join(mockWorkspaceDir, "users");
+    mkdirSync(usersDir, { recursive: true });
+    writeFileSync(
+      join(usersDir, "alice.md"),
+      "- Preferred name/reference: declined_by_user\n",
+      "utf-8",
+    );
+    writeFileSync(join(usersDir, "default.md"), "**Name:** Bob\n", "utf-8");
+
+    expect(resolveUserName(mockWorkspaceDir)).toBe("Bob");
+  });
+
+  test("falls back to default.md when no guardian resolves", () => {
+    const usersDir = join(mockWorkspaceDir, "users");
+    mkdirSync(usersDir, { recursive: true });
+    writeFileSync(join(usersDir, "default.md"), "**Name:** Bob\n", "utf-8");
+
+    expect(resolveUserName(mockWorkspaceDir)).toBe("Bob");
+  });
+
+  test("returns null when neither file yields a name", () => {
+    expect(resolveUserName(mockWorkspaceDir)).toBeNull();
   });
 });

--- a/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
+++ b/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
@@ -115,6 +115,12 @@ const BASELINE: Record<string, readonly string[]> = {
     "../../../../config/skill-state.js",
     "../../../../config/skills.js",
     "../../../../config/types.js",
+    // Same host module the retrospective job couples to (the `../../../`
+    // entry below): the sweep job and v2 router warm the guardian-delivery
+    // cache before their sync `resolveUserName` reads so worker-process
+    // prompts address the guardian instead of the default profile. No
+    // plugin-api equivalent.
+    "../../../../contacts/guardian-delivery-reader.js",
     "../../../../context/token-estimator.js",
     "../../../../daemon/conversation-error.js",
     "../../../../daemon/conversation-notices.js",

--- a/assistant/src/daemon/conversation-initial-prompt.ts
+++ b/assistant/src/daemon/conversation-initial-prompt.ts
@@ -47,11 +47,16 @@ export async function warmGuardianBindings(
  *
  * - An explicit `systemPromptOverride` (including an empty string) is used
  *   verbatim.
- * - A channel-routed conversation that already carries the requester's
- *   `trustContext` (e.g. Slack / Telegram inbound) builds with it, so the
- *   persona resolves the *requester's* `users/<slug>.md` (a DB contact lookup)
- *   rather than the guardian/default profile.
- * - Otherwise (no construction-time identity — the local vellum app sets trust
+ * - A channel-routed conversation carrying a non-guardian requester
+ *   `trustContext` (e.g. Slack / Telegram inbound) builds with it directly:
+ *   the requester's persona (`users/<slug>.md`) resolves via a DB contact
+ *   lookup that needs no guardian binding.
+ * - A guardian-class `trustContext` (background and scheduled turns, memory
+ *   consolidation, managed desktop) warms the guardian binding first: its
+ *   persona resolution reads the sync guardian-delivery cache, which is cold
+ *   in worker processes (schedule worker, memory worker) and after TTL expiry
+ *   in the daemon.
+ * - Otherwise (no construction-time identity: the local vellum app sets trust
  *   after creation) the guardian binding is warmed first so the persona slot
  *   resolves the guardian's `users/<slug>.md` instead of `users/default.md` on
  *   a cold cache.
@@ -67,7 +72,7 @@ export async function resolveInitialSystemPrompt(
     return storedOptions.systemPromptOverride;
   }
   const trustContext = storedOptions?.trustContext;
-  if (trustContext === undefined) {
+  if (trustContext === undefined || trustContext.trustClass === "guardian") {
     await (deps.warm ?? warmGuardianBindings)();
   }
   const build =

--- a/assistant/src/daemon/identity-helpers.ts
+++ b/assistant/src/daemon/identity-helpers.ts
@@ -1,6 +1,8 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { resolveGuardianPersonaStrict } from "../prompts/persona-resolver.js";
+import { DECLINED_BY_USER_SENTINEL } from "../prompts/user-reference.js";
 import { getWorkspacePromptPath } from "../util/platform.js";
 
 /** Read the assistant's name from IDENTITY.md for personalized responses. */
@@ -19,19 +21,45 @@ export function getAssistantName(): string | null {
 }
 
 /**
- * Read the guardian's display name from `users/default.md`. We look for the
- * markdown-bold "Name" label (matching the IDENTITY.md convention) and fall
- * back to `null` on any miss; callers substitute a generic label.
+ * Extract a display name from persona-file content. Tries the markdown-bold
+ * "Name" label (the IDENTITY.md convention), then the onboarding-written
+ * "Preferred name" bullet, then the scaffold's "Preferred name/reference"
+ * line. Matches only horizontal whitespace after the label so an unfilled
+ * scaffold line does not swallow the next line.
  */
-export function resolveUserName(workspaceDir: string): string | null {
+function extractPersonaName(content: string): string | null {
+  const match =
+    content.match(/\*\*Name:\*\*[ \t]*(.+)/) ??
+    content.match(/\*\*Preferred name:\*\*[ \t]*(.+)/) ??
+    content.match(/Preferred name\/reference:[ \t]*(.+)/);
+  return match?.[1]?.trim() || null;
+}
+
+function readPersonaName(filePath: string): string | null {
   try {
-    const content = readFileSync(
-      join(workspaceDir, "users", "default.md"),
-      "utf-8",
-    );
-    const match = content.match(/\*\*Name:\*\*\s*(.+)/);
-    return match?.[1]?.trim() || null;
+    return extractPersonaName(readFileSync(filePath, "utf-8"));
   } catch {
     return null;
   }
+}
+
+/**
+ * Read the user's display name from the guardian's persona file
+ * (`users/<slug>.md`, resolved via the guardian-delivery binding), falling
+ * back to `users/default.md`. Returns `null` on any miss; callers substitute
+ * a generic label.
+ *
+ * The guardian resolution reads the sync in-process guardian-delivery cache;
+ * callers in processes that do not otherwise warm it (memory worker) await
+ * `getGuardianDelivery` first.
+ */
+export function resolveUserName(workspaceDir: string): string | null {
+  const guardianContent = resolveGuardianPersonaStrict();
+  if (guardianContent) {
+    const name = extractPersonaName(guardianContent);
+    if (name && name !== DECLINED_BY_USER_SENTINEL) {
+      return name;
+    }
+  }
+  return readPersonaName(join(workspaceDir, "users", "default.md"));
 }

--- a/assistant/src/plugins/defaults/memory/substrate/sweep-job.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/sweep-job.ts
@@ -36,6 +36,7 @@ import { z } from "zod";
 
 import { usesConceptPageMemory } from "../../../../config/memory-v3-gate.js";
 import type { AssistantConfig } from "../../../../config/types.js";
+import { getGuardianDelivery } from "../../../../contacts/guardian-delivery-reader.js";
 import { emitNotificationSignal } from "../../../../notifications/emit-signal.js";
 import { getDb } from "../../../../persistence/db-connection.js";
 import type { MemoryJob } from "../../../../persistence/jobs-store.js";
@@ -154,6 +155,11 @@ export async function memoryV2SweepJob(
       log.warn("memoryV2Sweep provider unavailable; sweep skipped");
       return 0;
     }
+
+    // Warm the vellum guardian-delivery cache so resolveUserName's sync
+    // guardian-file resolution hits a fresh key instead of falling back to
+    // users/default.md on this worker process's cold cache.
+    await getGuardianDelivery({ channelTypes: ["vellum"] });
 
     const systemPrompt = renderSweepPrompt({
       assistantName: getAssistantName(),

--- a/assistant/src/plugins/defaults/memory/v2/router.ts
+++ b/assistant/src/plugins/defaults/memory/v2/router.ts
@@ -41,6 +41,7 @@ import {
 import { z } from "zod";
 
 import type { AssistantConfig } from "../../../../config/types.js";
+import { getGuardianDelivery } from "../../../../contacts/guardian-delivery-reader.js";
 import {
   cachedTextBlock,
   extractToolUse,
@@ -392,6 +393,12 @@ async function runRouterBatch(
     batchIndex,
     provider,
   } = params;
+
+  // Warm the vellum guardian-delivery cache so resolveUserName's sync
+  // guardian-file resolution hits a fresh key instead of falling back to
+  // users/default.md on a cold/TTL-expired cache. Single-flight and
+  // TTL-cached, so per-batch calls collapse to at most one IPC read.
+  await getGuardianDelivery({ channelTypes: ["vellum"] });
 
   const systemPrompt = resolveRouterPrompt(
     config.memory?.v2?.router?.router_prompt_path ?? null,

--- a/assistant/src/prompts/persona-resolver.ts
+++ b/assistant/src/prompts/persona-resolver.ts
@@ -82,7 +82,10 @@ function readPersonaFile(filePath: string): string | null {
  * (`guardianExternalUserId`): the info read is keyed on that address so it
  * matches the gateway's guardian binding. When the context carries no guardian
  * address (desktop / native turns), fall back to the channel's guardian
- * contact. Returns `"guardian.md"` when the resolved guardian has no userFile.
+ * contact, then any guardian: the guardian may be bound on a channel other
+ * than the turn's source, and the construction-time warm populates both the
+ * channel-filtered and unfiltered cache keys. Returns `"guardian.md"` when the
+ * resolved guardian has no userFile.
  */
 function resolveGuardianUserFile(trustContext: TrustContext): string | null {
   if (trustContext.guardianExternalUserId) {
@@ -94,7 +97,8 @@ function resolveGuardianUserFile(trustContext: TrustContext): string | null {
       return guardianContact.userFile ?? "guardian.md";
     }
   }
-  const guardian = peekGuardianForChannel(trustContext.sourceChannel);
+  const guardian =
+    peekGuardianForChannel(trustContext.sourceChannel) ?? peekAnyGuardian();
   return guardian
     ? (guardianDeliveryUserFile(guardian) ?? "guardian.md")
     : null;


### PR DESCRIPTION
## Summary
- resolveInitialSystemPrompt now warms the guardian-delivery binding for guardian-class trust contexts (previously only when trust was absent), so conversations created by the scheduler, memory consolidation, and other background guardian paths resolve the guardian's users/<slug>.md instead of users/default.md. Those paths run in standalone worker processes whose per-process cache is never otherwise populated, and the construction-time build is the only shot (the prompt freezes for the conversation's life).
- resolveGuardianUserFile falls back to the any-channel guardian, matching the no-trust-context branch, so a guardian bound on a non-vellum channel still resolves.
- resolveUserName (used by the memory sweep job and v2 router prompts) prefers the guardian's persona file via resolveGuardianPersonaStrict, honors the declined_by_user sentinel, and both call sites warm the guardian-delivery cache before the sync read. The plugin import baseline gains the contacts/guardian-delivery-reader entry at the substrate/v2 depth (same module the retrospective job already couples to).

## Original prompt
Scheduled tasks and memory consolidation passes were observed running with the "Default User" profile (workspace users/default.md) injected into the system prompt instead of the guardian's profile, and the user asked for these background runs to carry the guardian context. Root cause: these paths pass a guardian-class trust context, which skipped the construction-time guardian-binding warm, and they execute in worker processes whose guardian-delivery cache stays cold, so the synchronous persona peek silently fell back to the default profile. The user confirmed also fixing the resolveUserName leak (sweep job and v2 router) in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)