### PR TITLE
fix(assistant): warm both guardian-delivery cache keys at every persona warm site

### DIFF
--- a/assistant/src/__tests__/conversation-initial-prompt.test.ts
+++ b/assistant/src/__tests__/conversation-initial-prompt.test.ts
@@ -16,10 +16,7 @@
  */
 import { describe, expect, test } from "bun:test";
 
-import {
-  resolveInitialSystemPrompt,
-  warmGuardianBindings,
-} from "../daemon/conversation-initial-prompt.js";
+import { resolveInitialSystemPrompt } from "../daemon/conversation-initial-prompt.js";
 import type { ConversationCreateOptions } from "../daemon/handlers/shared.js";
 import type { TrustContext } from "../daemon/trust-context-types.js";
 
@@ -64,19 +61,6 @@ const GUARDIAN_REQUESTER_TRUST = {
   trustClass: "guardian",
   requesterExternalUserId: "principal-123",
 } as unknown as TrustContext;
-
-describe("warmGuardianBindings", () => {
-  test("warms both the vellum-channel key and the unfiltered fallback key", async () => {
-    const keys: string[] = [];
-    await warmGuardianBindings(async (input) => {
-      keys.push(input?.channelTypes?.join(",") ?? "ALL");
-      return null;
-    });
-    // Both keys the persona resolver reads — peekGuardianForChannel("vellum")
-    // and its peekAnyGuardian() fallback — must be warmed.
-    expect(keys.sort()).toEqual(["ALL", "vellum"]);
-  });
-});
 
 describe("resolveInitialSystemPrompt", () => {
   test("no construction-time identity: warms the guardian binding, then builds with no trust context", async () => {

--- a/assistant/src/contacts/__tests__/guardian-delivery-reader.test.ts
+++ b/assistant/src/contacts/__tests__/guardian-delivery-reader.test.ts
@@ -44,6 +44,7 @@ import {
   getGuardianDeliveryFresh,
   guardianForChannel,
   invalidateGuardianDeliveryCache,
+  warmGuardianBindings,
 } from "../guardian-delivery-reader.js";
 
 const METHOD = "resolve_guardian_delivery";
@@ -297,5 +298,20 @@ describe("selectors", () => {
   test("anyGuardian returns the first overall", () => {
     expect(anyGuardian([emailGuardian, telegramGuardian])).toBe(emailGuardian);
     expect(anyGuardian([])).toBeUndefined();
+  });
+});
+
+describe("warmGuardianBindings", () => {
+  test("warms both the vellum-channel key and the unfiltered fallback key", async () => {
+    const keys: string[] = [];
+    await warmGuardianBindings(async (input) => {
+      keys.push(input?.channelTypes?.join(",") ?? "ALL");
+      return null;
+    });
+    // Both keys the sync persona resolvers read — peekGuardianForChannel
+    // ("vellum") and the peekAnyGuardian() fallback — must be warmed;
+    // warming only the channel key leaves the any-channel fallback cold for
+    // guardians bound on non-vellum channels.
+    expect(keys.sort()).toEqual(["ALL", "vellum"]);
   });
 });

--- a/assistant/src/contacts/guardian-delivery-reader.ts
+++ b/assistant/src/contacts/guardian-delivery-reader.ts
@@ -181,6 +181,33 @@ export async function getGuardianDeliveryFresh(input?: {
   });
 }
 
+type GuardianDeliveryFetch = (input?: {
+  channelTypes?: string[];
+}) => Promise<unknown>;
+
+/**
+ * Warm both guardian-binding cache keys the sync persona resolvers read: the
+ * `"vellum"`-channel key for `peekGuardianForChannel("vellum")` and the
+ * unfiltered key for the `peekAnyGuardian()` fallback. Warming only one key
+ * still resolves `users/default.md` when the guardian lives on a non-vellum
+ * channel (phone / Telegram).
+ *
+ * Uses the FRESH reader so warmup bypasses a stale/empty cached entry: a
+ * gateway-side binding write (onboarding, rebind) does not invalidate the
+ * daemon cache, so a non-fresh read could return an empty binding cached
+ * before the guardian existed and freeze `users/default.md` until the TTL
+ * expires. The fresh reads repopulate the cache the sync `peek*` resolvers
+ * then read. Best-effort: the reader swallows failures.
+ */
+export async function warmGuardianBindings(
+  fetchDelivery: GuardianDeliveryFetch = getGuardianDeliveryFresh,
+): Promise<void> {
+  await Promise.all([
+    fetchDelivery({ channelTypes: ["vellum"] }),
+    fetchDelivery(),
+  ]);
+}
+
 /**
  * Clear ALL cached guardian deliveries so contact mutations refetch on the next
  * read. Called by {@link notifyContactsChanged} after a contact write, and

--- a/assistant/src/daemon/conversation-initial-prompt.ts
+++ b/assistant/src/daemon/conversation-initial-prompt.ts
@@ -1,42 +1,15 @@
 /**
  * Construction-time system-prompt resolution for a new conversation.
  *
- * The dependency seams (`fetchDelivery`, `deps.warm`, `deps.build`) exist so the
- * warm-then-build sequencing can be unit-tested without mocking the
- * widely-imported guardian-delivery / system-prompt modules — global module
- * mocks of those leak across test files in the shared-process runner.
+ * The dependency seams (`deps.warm`, `deps.build`) exist so the warm-then-build
+ * sequencing can be unit-tested without mocking the widely-imported
+ * guardian-delivery / system-prompt modules — global module mocks of those leak
+ * across test files in the shared-process runner.
  */
-import { getGuardianDeliveryFresh } from "../contacts/guardian-delivery-reader.js";
+import { warmGuardianBindings } from "../contacts/guardian-delivery-reader.js";
 import { buildSystemPrompt } from "../prompts/system-prompt.js";
 import type { ConversationCreateOptions } from "./handlers/shared.js";
 import type { TrustContext } from "./trust-context-types.js";
-
-type GuardianDeliveryFetch = (input?: {
-  channelTypes?: string[];
-}) => Promise<unknown>;
-
-/**
- * Warm both guardian-binding cache keys the desktop/native persona resolver
- * reads: the `"vellum"`-channel key for `peekGuardianForChannel("vellum")` and
- * the unfiltered key for its `peekAnyGuardian()` fallback. Warming only one
- * would still freeze `users/default.md` when the guardian lives on a non-vellum
- * channel (phone / Telegram).
- *
- * Uses the FRESH reader so warmup bypasses a stale/empty cached entry: a
- * gateway-side binding write (onboarding, rebind) does not invalidate the daemon
- * cache, so a non-fresh read could return an empty binding cached before the
- * guardian existed and freeze `users/default.md` until the TTL expires. The
- * fresh read repopulates the cache the sync `peek*` resolvers then read.
- * Best-effort — the reader swallows failures.
- */
-export async function warmGuardianBindings(
-  fetchDelivery: GuardianDeliveryFetch = getGuardianDeliveryFresh,
-): Promise<void> {
-  await Promise.all([
-    fetchDelivery({ channelTypes: ["vellum"] }),
-    fetchDelivery(),
-  ]);
-}
 
 /**
  * Resolve the system prompt to freeze onto a newly constructed conversation.

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import type { HeartbeatAlertEvent } from "../api/events/heartbeat-alert.js";
 import { getConfig } from "../config/loader.js";
 import type { HeartbeatConfig } from "../config/schemas/heartbeat.js";
-import { getGuardianDelivery } from "../contacts/guardian-delivery-reader.js";
+import { warmGuardianBindings } from "../contacts/guardian-delivery-reader.js";
 import {
   checkDiskPressureBackgroundGate,
   diskPressureBackgroundSkipLogFields,
@@ -815,10 +815,11 @@ export class HeartbeatService {
 
     const checklist = this.readChecklist();
     const completedRunCount = countCompletedHeartbeatRuns();
-    // Warm the vellum guardian-delivery cache so buildPrompt's sync guardian
-    // persona read (isShallowProfile → resolveGuardianPersona) hits a fresh key
-    // instead of falling back to default.md on a cold/TTL-expired cache.
-    await getGuardianDelivery({ channelTypes: ["vellum"] });
+    // Warm both guardian-delivery cache keys (vellum + unfiltered) so
+    // buildPrompt's sync guardian persona read (isShallowProfile →
+    // resolveGuardianPersona), including its any-channel fallback, hits fresh
+    // keys instead of falling back to default.md on a cold/TTL-expired cache.
+    await warmGuardianBindings();
     const { prompt, includedReengagement } = this.buildPrompt(
       checklist,
       unhealthyProviders,

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
@@ -57,7 +57,7 @@ import {
 } from "../../../channels/types.js";
 import { isV3TierActive } from "../../../config/memory-v3-gate.js";
 import type { AssistantConfig } from "../../../config/types.js";
-import { getGuardianDelivery } from "../../../contacts/guardian-delivery-reader.js";
+import { warmGuardianBindings } from "../../../contacts/guardian-delivery-reader.js";
 import { extractTurnContextTimestamp } from "../../../context/compactor.js";
 import {
   formatLocalTimestamp,
@@ -479,10 +479,11 @@ export async function runForkBasedRetrospective(
   // parity — the fork always runs execution gate mode below, so the source's
   // full tool surface stays on the wire while the allowlist holds at
   // execution time.
-  // Warm the vellum guardian-delivery cache so the sync slug resolution inside
-  // resolveSourceParityPins (resolveUserSlug(undefined)) hits a fresh key
-  // instead of falling back to "default" on a cold/TTL-expired cache.
-  await getGuardianDelivery({ channelTypes: ["vellum"] });
+  // Warm both guardian-delivery cache keys (vellum + unfiltered) so the sync
+  // slug resolution inside resolveSourceParityPins (resolveUserSlug(undefined)),
+  // including its any-channel fallback, hits fresh keys instead of falling
+  // back to "default" on a cold/TTL-expired cache.
+  await warmGuardianBindings();
   const { personaOverride, toolContextPin } = resolveSourceParityPins(
     sourceConversation,
     newMessages,

--- a/assistant/src/plugins/defaults/memory/substrate/sweep-job.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/sweep-job.ts
@@ -36,7 +36,7 @@ import { z } from "zod";
 
 import { usesConceptPageMemory } from "../../../../config/memory-v3-gate.js";
 import type { AssistantConfig } from "../../../../config/types.js";
-import { getGuardianDelivery } from "../../../../contacts/guardian-delivery-reader.js";
+import { warmGuardianBindings } from "../../../../contacts/guardian-delivery-reader.js";
 import { emitNotificationSignal } from "../../../../notifications/emit-signal.js";
 import { getDb } from "../../../../persistence/db-connection.js";
 import type { MemoryJob } from "../../../../persistence/jobs-store.js";
@@ -156,10 +156,11 @@ export async function memoryV2SweepJob(
       return 0;
     }
 
-    // Warm the vellum guardian-delivery cache so resolveUserName's sync
-    // guardian-file resolution hits a fresh key instead of falling back to
+    // Warm both guardian-delivery cache keys (vellum + unfiltered) so
+    // resolveUserName's sync guardian-file resolution, including its
+    // any-channel fallback, hits fresh keys instead of falling back to
     // users/default.md on this worker process's cold cache.
-    await getGuardianDelivery({ channelTypes: ["vellum"] });
+    await warmGuardianBindings();
 
     const systemPrompt = renderSweepPrompt({
       assistantName: getAssistantName(),

--- a/assistant/src/plugins/defaults/memory/v2/router.ts
+++ b/assistant/src/plugins/defaults/memory/v2/router.ts
@@ -41,7 +41,7 @@ import {
 import { z } from "zod";
 
 import type { AssistantConfig } from "../../../../config/types.js";
-import { getGuardianDelivery } from "../../../../contacts/guardian-delivery-reader.js";
+import { warmGuardianBindings } from "../../../../contacts/guardian-delivery-reader.js";
 import {
   cachedTextBlock,
   extractToolUse,
@@ -394,11 +394,12 @@ async function runRouterBatch(
     provider,
   } = params;
 
-  // Warm the vellum guardian-delivery cache so resolveUserName's sync
-  // guardian-file resolution hits a fresh key instead of falling back to
-  // users/default.md on a cold/TTL-expired cache. Single-flight and
-  // TTL-cached, so per-batch calls collapse to at most one IPC read.
-  await getGuardianDelivery({ channelTypes: ["vellum"] });
+  // Warm both guardian-delivery cache keys (vellum + unfiltered) so
+  // resolveUserName's sync guardian-file resolution, including its
+  // any-channel fallback, hits fresh keys instead of falling back to
+  // users/default.md on a cold/TTL-expired cache. Two local-socket IPC
+  // reads per batch, dwarfed by the batch's provider call.
+  await warmGuardianBindings();
 
   const systemPrompt = resolveRouterPrompt(
     config.memory?.v2?.router?.router_prompt_path ?? null,


### PR DESCRIPTION
## Summary
- Moves warmGuardianBindings (fresh fetch of both the vellum-channel and unfiltered cache keys) from conversation-initial-prompt.ts into the guardian-delivery reader, next to the cache it warms; the construction path now imports it from there.
- Switches the four single-key warm sites to it: the memory sweep job, the v2 router, the heartbeat, and the retrospective job. Each feeds a sync resolution whose any-channel fallback (peekAnyGuardian) reads the unfiltered key, so warming only the vellum key left that fallback cold and a guardian bound only on a non-vellum channel (phone, Telegram) still resolved users/default.md.
- The warmGuardianBindings unit test moves to the reader's test file. No baseline changes: the plugin sites keep the same import specifiers, only the imported symbol changes.

Addresses the Codex P2 review comment on #40416 (sweep-job warm covers only the vellum key), and applies the same fix to the pre-existing single-key warms in heartbeat and the retrospective job.

## Original prompt
Follow-up requested to the guardian-persona fix in #40416: Codex flagged that the new call-site warms populate only the vellum guardian-delivery cache key while resolveUserName's any-channel fallback reads the unfiltered key, so guardians bound only on non-vellum channels would still get the default profile in sweep and router prompts. The user asked to address the comment in a follow-up; the shared warm helper Codex suggested already existed and now lives with the cache it warms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)