### PR TITLE
feat(macos): add a tray toggle to show or hide the floating companion surface

### DIFF
--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -18,11 +18,15 @@ import {
   dispatchToMain,
   ensureVisible as ensureMainWindowVisible,
 } from "./main-window";
+import { writeCompanionHidden } from "./window-state";
 
 /**
- * The always-present companion surface (LUM-3086): the assistant's avatar
- * floating from app launch, expanding on hover into a pill with the voice and
- * type-chat options, and holding that expansion for as long as a call runs.
+ * The companion surface (LUM-3086): the assistant's avatar floating from app
+ * launch, expanding on hover into a pill with the voice and type-chat options,
+ * and holding that expansion for as long as a call runs. It stays on screen
+ * for the app's whole run unless the user hides it via the tray's "Show
+ * Floating Companion" item, a choice that persists across launches
+ * (`readCompanionHidden` in `window-state.ts`).
  *
  * **It is also the desktop's live-voice session surface**, the counterpart to
  * the iOS Dynamic Island and Lock Screen activity. Main holds the session
@@ -399,9 +403,22 @@ export const installCompanionWindow = (): void => {
   // The route loads lazily after the window is created, so a state pushed
   // before its subscription registers is dropped. It pulls this once mounted.
   handle("vellum:companion:getState", z.tuple([]), () => currentState());
+
+  // Registered once here rather than per window: `refreshGrowth` no-ops
+  // while no surface exists, and the surface can be closed and reopened from
+  // the tray, which must not stack duplicate listeners. A display added,
+  // removed or rearranged moves the edges the direction is measured against
+  // without the window itself moving at all.
+  screen.on("display-metrics-changed", refreshGrowth);
+  screen.on("display-added", refreshGrowth);
+  screen.on("display-removed", refreshGrowth);
 };
 
 export const openCompanionWindow = (): void => {
+  if (getFloatingWindow(COMPANION_KIND) !== null) {
+    return;
+  }
+
   const win = createFloatingWindow({
     kind: COMPANION_KIND,
     route: COMPANION_ROUTE,
@@ -439,9 +456,28 @@ export const openCompanionWindow = (): void => {
 
   refreshGrowth();
   win.on("move", refreshGrowth);
-  // A display added, removed or rearranged moves the edges the direction is
-  // measured against without the window itself moving at all.
-  screen.on("display-metrics-changed", refreshGrowth);
-  screen.on("display-added", refreshGrowth);
-  screen.on("display-removed", refreshGrowth);
+};
+
+const closeCompanionWindow = (): void => {
+  getFloatingWindow(COMPANION_KIND)?.close();
+};
+
+/**
+ * Show or hide the surface, persisting the choice so a hidden surface stays
+ * hidden on the next launch.
+ *
+ * Hiding closes the window outright rather than making it invisible: the
+ * canvas is a click-through mouse-event forwarder, and a hidden-but-alive
+ * window would keep that machinery running for nothing. The live-voice
+ * session state is unaffected either way, since main holds it (see `call`),
+ * so a call running while the surface is hidden appears mid-call, clock
+ * intact, when the surface is shown again.
+ */
+export const setCompanionSurfaceVisible = (visible: boolean): void => {
+  writeCompanionHidden(!visible);
+  if (visible) {
+    openCompanionWindow();
+  } else {
+    closeCompanionWindow();
+  }
 };

--- a/clients/macos/src/main/index.ts
+++ b/clients/macos/src/main/index.ts
@@ -101,6 +101,7 @@ import {
 import { installConnectivityIpc, installStatusIpc } from "./status";
 import { installTextInsertionIpc } from "./textInsertion";
 import { installTray } from "./tray";
+import { readCompanionHidden } from "./window-state";
 import { installWebContentsSecurity } from "./windows";
 
 // Dev-only: override the workspace `name` (`@vellumai/macos`) so the
@@ -519,9 +520,12 @@ app
     installMainWindow();
 
     // After the main window, so the surface opens over a running app rather
-    // than being the first thing on screen at launch. It is always present
-    // from here on: the app being frontmost is not one of its states.
-    openCompanionWindow();
+    // than being the first thing on screen at launch. Present from here on,
+    // unless the user has hidden it from the tray: the app being frontmost is
+    // not one of its states.
+    if (!readCompanionHidden()) {
+      openCompanionWindow();
+    }
 
     // Runs after the main window so the recovery dialog has a window to sit in
     // front of, and so a user who declines lands on a working app rather than

--- a/clients/macos/src/main/tray.test.ts
+++ b/clients/macos/src/main/tray.test.ts
@@ -125,8 +125,20 @@ mock.module("./settings", () => ({
   onSettingChange: () => () => {},
 }));
 
+// Full `./window-state` surface, for the same leak-safety reason as
+// `./settings` above. The companion flag is controllable so the checkbox
+// state can be exercised.
+let companionHidden = false;
 mock.module("./window-state", () => ({
   readOnboardingActive: () => false,
+  readCompanionHidden: () => companionHidden,
+  writeCompanionHidden: () => {},
+  writeOnboardingActive: () => {},
+}));
+
+const setCompanionSurfaceVisibleMock = mock((_visible: boolean) => undefined);
+mock.module("./companion-window", () => ({
+  setCompanionSurfaceVisible: setCompanionSurfaceVisibleMock,
 }));
 
 const dispatchToMainMock = mock((_command: unknown) => undefined);
@@ -213,6 +225,8 @@ beforeEach(() => {
   avatarListeners.clear();
   watchedLockfile = { assistants: [], activeAssistant: null };
   featureFlags = null;
+  companionHidden = false;
+  setCompanionSurfaceVisibleMock.mockClear();
   dispatchToMainMock.mockClear();
   buildFromTemplateMock.mockClear();
   statusFramesMock.mockClear();
@@ -293,6 +307,7 @@ describe("installTray", () => {
     expect(labels).toContain("Current Conversation");
     expect(labels).toContain("Mark All as Read");
     expect(labels).toContain("Show / Hide Main Window");
+    expect(labels).toContain("Show Floating Companion");
     expect(labels).toContain("Restart");
     expect(labels).toContain("About Vellum Electron");
     expect(labels).toContain("Quit Vellum Electron");
@@ -531,6 +546,44 @@ describe("assistant switcher", () => {
     );
     expect(empty).toBeDefined();
     expect(empty?.enabled).toBe(false);
+  });
+});
+
+describe("floating companion toggle", () => {
+  type MenuItem = {
+    label?: string;
+    type?: string;
+    checked?: boolean;
+    click?: (item: { checked: boolean }) => void;
+  };
+
+  const popCompanionItem = (): MenuItem | undefined => {
+    installTray(handlers);
+    handlerFor(trays[0], "right-click")?.();
+    const calls = buildFromTemplateMock.mock.calls;
+    const template = calls[calls.length - 1]?.[0] as MenuItem[];
+    return template.find((i) => i.label === "Show Floating Companion");
+  };
+
+  test("renders as a checked checkbox while the surface is shown", () => {
+    const item = popCompanionItem();
+    expect(item?.type).toBe("checkbox");
+    expect(item?.checked).toBe(true);
+  });
+
+  test("renders unchecked once the surface has been hidden", () => {
+    companionHidden = true;
+    expect(popCompanionItem()?.checked).toBe(false);
+  });
+
+  test("applies the item's toggled state to the surface", () => {
+    const item = popCompanionItem();
+    // Electron flips `checked` on the item before `click` runs, so the item
+    // carries the state being asked for.
+    item?.click?.({ checked: false });
+    expect(setCompanionSurfaceVisibleMock).toHaveBeenLastCalledWith(false);
+    item?.click?.({ checked: true });
+    expect(setCompanionSurfaceVisibleMock).toHaveBeenLastCalledWith(true);
   });
 });
 

--- a/clients/macos/src/main/tray.ts
+++ b/clients/macos/src/main/tray.ts
@@ -16,6 +16,7 @@ import {
 } from "./assets/menu-icons";
 import { onAvatarChange } from "./avatar";
 import { acceleratorOption } from "./commands.client";
+import { setCompanionSurfaceVisible } from "./companion-window";
 import { getName, onNameChange } from "./identity";
 import { getWatchedLockfile } from "./lockfile-watcher";
 import { dispatchToMain } from "./main-window";
@@ -30,7 +31,7 @@ import {
   type AssistantStatus,
 } from "./status";
 import { invalidateIconCache, statusFrames } from "./status-icon";
-import { readOnboardingActive } from "./window-state";
+import { readCompanionHidden, readOnboardingActive } from "./window-state";
 
 /**
  * macOS menu-bar (Tray) status item.
@@ -306,6 +307,19 @@ const buildTrayMenu = (
     {
       label: "Show / Hide Main Window",
       click: handlers.toggleMainWindow,
+    },
+    {
+      // The floating avatar pill (`companion-window.ts`). A checkbox rather
+      // than a toggle-action item: once the surface is hidden, this menu is
+      // the only place left to bring it back from, so the item has to show
+      // which state it is in. Electron flips `checked` before `click` runs,
+      // so the item carries the state being asked for.
+      label: "Show Floating Companion",
+      type: "checkbox",
+      checked: !readCompanionHidden(),
+      click: (item) => {
+        setCompanionSurfaceVisible(item.checked);
+      },
     },
     { type: "separator" },
     {

--- a/clients/macos/src/main/window-state.test.ts
+++ b/clients/macos/src/main/window-state.test.ts
@@ -10,6 +10,7 @@ type SavedState = {
 
 let savedWindows: Record<string, SavedState> = {};
 let savedOnboardingActive: boolean | undefined = undefined;
+let savedCompanionHidden: boolean | undefined = undefined;
 let workArea = { x: 0, y: 0, width: 1920, height: 1080 };
 const storeSetMock = mock((_key: string, _value: unknown) => {});
 
@@ -23,6 +24,7 @@ mock.module("electron-store", () => ({
       // Mirror electron-store: return the stored value, or the fallback
       // when the key is absent.
       if (key === "onboardingActive") return savedOnboardingActive ?? fallback;
+      if (key === "companionHidden") return savedCompanionHidden ?? fallback;
       if (key === "windows") return savedWindows;
       return fallback;
     }
@@ -42,8 +44,14 @@ mock.module("electron", () => ({
   },
 }));
 
-const { restoreBounds, track, readOnboardingActive, writeOnboardingActive } =
-  await import("./window-state");
+const {
+  restoreBounds,
+  track,
+  readCompanionHidden,
+  readOnboardingActive,
+  writeCompanionHidden,
+  writeOnboardingActive,
+} = await import("./window-state");
 
 const DEFAULTS = { width: 800, height: 600 };
 
@@ -68,6 +76,7 @@ function makeTrackableWindow() {
 beforeEach(() => {
   savedWindows = {};
   savedOnboardingActive = undefined;
+  savedCompanionHidden = undefined;
   workArea = { x: 0, y: 0, width: 1920, height: 1080 };
   storeSetMock.mockClear();
 });
@@ -280,5 +289,27 @@ describe("readOnboardingActive default", () => {
 
     writeOnboardingActive(true);
     expect(storeSetMock).toHaveBeenCalledWith("onboardingActive", true);
+  });
+});
+
+describe("companion surface visibility flag", () => {
+  test("absent flag defaults to shown", () => {
+    expect(readCompanionHidden()).toBe(false);
+  });
+
+  test("an explicit persisted flag wins over the default", () => {
+    savedCompanionHidden = true;
+    expect(readCompanionHidden()).toBe(true);
+
+    savedCompanionHidden = false;
+    expect(readCompanionHidden()).toBe(false);
+  });
+
+  test("writeCompanionHidden skips persisting when the effective value is unchanged", () => {
+    writeCompanionHidden(false);
+    expect(storeSetMock).not.toHaveBeenCalled();
+
+    writeCompanionHidden(true);
+    expect(storeSetMock).toHaveBeenCalledWith("companionHidden", true);
   });
 });

--- a/clients/macos/src/main/window-state.ts
+++ b/clients/macos/src/main/window-state.ts
@@ -27,6 +27,11 @@ interface StoreSchema {
   // launch is built at the right size before the renderer loads. Optional:
   // absent means "not yet decided" (see `readOnboardingActive`).
   onboardingActive?: boolean;
+  // Whether the user has hidden the companion surface from the tray. A
+  // main-process concern like the rest of this store: launch consults it
+  // before any renderer loads. Optional: absent means shown, so the flag
+  // records only the opt-out (see `readCompanionHidden`).
+  companionHidden?: boolean;
 }
 
 let instance: Store<StoreSchema> | null = null;
@@ -65,6 +70,25 @@ export const readOnboardingActive = (): boolean =>
 export const writeOnboardingActive = (active: boolean): void => {
   if (readOnboardingActive() === active) return;
   store().set("onboardingActive", active);
+};
+
+/**
+ * Whether the user has hidden the companion surface from the tray's
+ * "Show Floating Companion" item. Absent defaults to `false`: the surface
+ * is a standing presence, and this flag records only the opt-out.
+ */
+export const readCompanionHidden = (): boolean =>
+  store().get("companionHidden", false);
+
+/**
+ * Persist the companion-surface opt-out. No-op when the effective value is
+ * unchanged so re-asserting the current state doesn't churn the store file.
+ */
+export const writeCompanionHidden = (hidden: boolean): void => {
+  if (readCompanionHidden() === hidden) {
+    return;
+  }
+  store().set("companionHidden", hidden);
 };
 
 /**


### PR DESCRIPTION
## Summary
- Adds a "Show Floating Companion" checkbox to the tray menu (next to "Show / Hide Main Window"): unchecking closes the floating avatar pill immediately, checking reopens it in place.
- Persists the choice as `companionHidden` in the main-process `window-state.json` store (default: shown), and launch skips opening the surface when hidden, so the pill stays gone across restarts.
- Moves the display-growth `screen` listeners from `openCompanionWindow` to install scope: they no-op with no surface, and hide/show cycles must not stack duplicate listeners. Live-voice session state is held in main and unaffected; a call running while hidden appears mid-call, clock intact, if the surface is shown again.

## Original prompt
The companion surface (LUM-3086) opens unconditionally at app launch and had no setting, menu item, or shortcut to hide it. The user wants it hidden (they run their own floating avatar overlay), so the ask was a tray-menu checkbox in the same group as "Show / Hide Main Window" that closes the pill immediately and persists across restarts, defaulting to shown.