### PR TITLE
fix(web): stop the inline voice picker rendering an empty card and fix its scroll containment

### DIFF
--- a/clients/web/src/components/speech/use-managed-voice-selection.ts
+++ b/clients/web/src/components/speech/use-managed-voice-selection.ts
@@ -25,7 +25,7 @@ import {
   configGetOptions,
   ttsProvidersGetOptions,
 } from "@/generated/daemon/@tanstack/react-query.gen";
-import { useIsOrgReady } from "@/hooks/use-is-org-ready";
+import { useOrgHeaderReadiness } from "@/hooks/use-is-org-ready";
 import {
   useManagedVoices,
   type ManagedVoiceOption,
@@ -50,6 +50,14 @@ export interface UseManagedVoiceSelection {
    * a "set it in Settings" state without flashing it during the fetch.
    */
   isByok: boolean;
+  /**
+   * Every fetch that decides `available` has concluded (or was never going to
+   * run: no assistant, or an organization that resolved to nothing). Until then
+   * `available` and `isByok` are both false and say nothing about each other,
+   * so a surface with no picker to show can hold its chrome back rather than
+   * draw an empty box that never fills.
+   */
+  settled: boolean;
   voices: readonly ManagedVoiceOption[];
   /**
    * The currently-selected model: the pick a write is still carrying, else the
@@ -70,16 +78,16 @@ export interface UseManagedVoiceSelection {
 export function useManagedVoiceSelection(
   assistantId: string | null,
 ): UseManagedVoiceSelection {
-  const isOrgReady = useIsOrgReady();
-  const enabled = isOrgReady && !!assistantId;
+  const orgReadiness = useOrgHeaderReadiness();
+  const enabled = orgReadiness === "ready" && !!assistantId;
 
-  const { data: providerCatalog } = useQuery({
+  const { data: providerCatalog, isLoading: catalogLoading } = useQuery({
     ...ttsProvidersGetOptions({ path: { assistant_id: assistantId ?? "" } }),
     enabled,
     staleTime: Infinity,
     retry: false,
   });
-  const { data: daemonConfig } = useQuery({
+  const { data: daemonConfig, isLoading: configLoading } = useQuery({
     ...configGetOptions({ path: { assistant_id: assistantId ?? "" } }),
     enabled,
     staleTime: 30_000,
@@ -104,7 +112,11 @@ export function useManagedVoiceSelection(
     providerCatalog?.providers?.find((p) => p.id === "vellum")
       ?.supportsVoiceSelection === true;
 
-  const { voices, defaultModel } = useManagedVoices(assistantId, {
+  const {
+    voices,
+    defaultModel,
+    loading: voicesLoading,
+  } = useManagedVoices(assistantId, {
     enabled: enabled && isManaged,
   });
 
@@ -113,6 +125,17 @@ export function useManagedVoiceSelection(
   // Gated on config having actually arrived — an unfetched config reads as
   // "not managed", which would flash the BYO state on every mount.
   const isByok = enabled && !!daemonConfig && !isManaged;
+  // "Nothing is in flight, and nothing is waiting to start." Each `isLoading`
+  // is false for a query that is disabled or has failed, so the states that
+  // never produce a picker (no assistant, an org that resolved to nothing, an
+  // old daemon, a catalog that failed or came back empty) settle rather than
+  // read as perpetually loading. `"resolving"` is the one wait not expressed as
+  // a query: it disables all three, and they'd otherwise look settled.
+  const settled =
+    orgReadiness !== "resolving" &&
+    !catalogLoading &&
+    !configLoading &&
+    !voicesLoading;
 
   const configuredModel =
     daemonTts?.providers?.vellum?.model ??
@@ -134,6 +157,7 @@ export function useManagedVoiceSelection(
   return {
     available,
     isByok,
+    settled,
     voices,
     currentModel,
     defaultModel: defaultModel ?? "",

--- a/clients/web/src/components/speech/voice-list.test.tsx
+++ b/clients/web/src/components/speech/voice-list.test.tsx
@@ -35,6 +35,7 @@ const ASSISTANT_ID = "asst_1";
 let orgReady = true;
 mock.module("@/hooks/use-is-org-ready", () => ({
   useIsOrgReady: () => orgReady,
+  useOrgHeaderReadiness: () => (orgReady ? "ready" : "resolving"),
 }));
 mock.module("@vellumai/design-library/components/toast", () => ({
   toast: { success: () => {}, error: () => {} },

--- a/clients/web/src/components/speech/voice-list.tsx
+++ b/clients/web/src/components/speech/voice-list.tsx
@@ -67,6 +67,13 @@ export interface VoiceListProps {
   /** Optional section heading (shown above the list, with a top divider). */
   heading?: string;
   className?: string;
+  /**
+   * Extra classes for the scrolling listbox, merged after its own `max-h-*` so
+   * a cap passed here wins. Where a height belongs: `className` lands on the
+   * outer wrapper, which also holds the provider dropdown, and capping that
+   * scrolls the dropdown out of view instead of the voices.
+   */
+  listClassName?: string;
   /** Called after a voice is chosen — e.g. to close the picker modal. */
   onSelect?: () => void;
   /**
@@ -92,17 +99,28 @@ export interface VoiceListProps {
    * height. The dropdown hides itself when the catalog has a single provider.
    */
   filterBySource?: boolean;
+  /**
+   * Bring the current voice into view on mount. Grouping means it may sit in a
+   * lower section rather than at the top, so hosts whose nearest scrollport is
+   * the list itself want this on: the picker modal, the first-run card, the
+   * Models & Services popover. Off by default because `scrollIntoView` scrolls
+   * *every* scrollable ancestor, so a list rendered inline in the chat
+   * transcript would drag the transcript to itself on each load.
+   */
+  autoScrollToSelected?: boolean;
 }
 
 export function VoiceList({
   assistantId,
   heading,
   className,
+  listClassName,
   onSelect,
   value,
   onChange,
   showSource = false,
   filterBySource = false,
+  autoScrollToSelected = false,
 }: VoiceListProps) {
   const {
     available,
@@ -164,13 +182,14 @@ export function VoiceList({
   );
   const { previewingModel, play, stop } = useVoiceSamplePreview();
 
-  // Bring the current voice into view on open — grouping means it may sit in a
-  // lower section rather than at the top.
   const selectedRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
+    if (!autoScrollToSelected) {
+      return;
+    }
     // `?.` on the method too — not every environment implements scrollIntoView.
     selectedRef.current?.scrollIntoView?.({ block: "nearest" });
-  }, []);
+  }, [autoScrollToSelected]);
 
   // Render nothing when there's no catalog, so the surrounding chrome collapses
   // with it. Uncontrolled surfaces also require the assistant to be managed
@@ -216,6 +235,7 @@ export function VoiceList({
           "flex flex-col overflow-y-auto",
           filterBySource ? "max-h-[60vh]" : "max-h-80",
           selecting && "pointer-events-none opacity-70",
+          listClassName,
         )}
       >
         {groups.map((group) => (

--- a/clients/web/src/components/speech/voice-picker-field.tsx
+++ b/clients/web/src/components/speech/voice-picker-field.tsx
@@ -69,6 +69,9 @@ export function VoicePickerField({
           onChange={onChange}
           onSelect={() => setOpen(false)}
           showSource
+          // The popover is the nearest scrollport, so opening on the current
+          // voice scrolls nothing but this list.
+          autoScrollToSelected
         />
       </Popover.Content>
     </Popover.Root>

--- a/clients/web/src/components/speech/voice-picker-modal.tsx
+++ b/clients/web/src/components/speech/voice-picker-modal.tsx
@@ -78,6 +78,9 @@ function VoicePickerContent({
           filterBySource
           value={currentModel}
           onChange={selectModel}
+          // The dialog body is the nearest scrollport, so opening on the
+          // current voice scrolls nothing but this list.
+          autoScrollToSelected
         />
       </Modal.Body>
       <Modal.Footer className="items-center justify-between gap-3">

--- a/clients/web/src/domains/chat/components/surfaces/surface-router.test.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/surface-router.test.tsx
@@ -71,7 +71,7 @@ describe("SurfaceRouter error boundary", () => {
   });
 });
 
-describe("SurfaceRouter — voice picker", () => {
+describe("SurfaceRouter: voice picker", () => {
   test("routes surfaceType \"voice_picker\" to the inline picker", () => {
     const { getByTestId, container } = render(
       <SurfaceRouter

--- a/clients/web/src/domains/chat/components/surfaces/surface-router.test.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/surface-router.test.tsx
@@ -11,6 +11,15 @@ mock.module("@/domains/chat/components/surfaces/card-surface", () => ({
   },
 }));
 
+// Stands in for the real picker, which would pull the daemon config, TTS
+// provider, and managed-voice queries into a routing test. What matters here is
+// which component the router picks.
+mock.module("@/domains/chat/components/surfaces/voice-picker-surface", () => ({
+  VoicePickerSurface: ({ assistantId }: { assistantId: string | null }) => (
+    <div data-testid="voice-picker-surface">{assistantId ?? "no-assistant"}</div>
+  ),
+}));
+
 import { SurfaceRouter } from "@/domains/chat/components/surfaces/surface-router";
 import type { Surface } from "@/domains/chat/types/types";
 
@@ -59,6 +68,27 @@ describe("SurfaceRouter error boundary", () => {
     expect(getByRole("alert").textContent).toContain("My App");
     // …while the sibling copy_block surface renders normally.
     expect(getByText("still here")).toBeTruthy();
+  });
+});
+
+describe("SurfaceRouter — voice picker", () => {
+  test("routes surfaceType \"voice_picker\" to the inline picker", () => {
+    const { getByTestId, container } = render(
+      <SurfaceRouter
+        surface={makeSurface({
+          surfaceId: "surface-voice",
+          surfaceType: "voice_picker",
+          title: "Pick a voice",
+        })}
+        onAction={() => {}}
+        assistantId="asst_1"
+      />,
+    );
+
+    // The acceptance criterion for registering the type: not the fallback card.
+    expect(container.textContent).not.toContain("Unsupported surface type");
+    // The owning assistant is threaded through, not read from global state.
+    expect(getByTestId("voice-picker-surface").textContent).toBe("asst_1");
   });
 });
 

--- a/clients/web/src/domains/chat/components/surfaces/surface-router.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/surface-router.tsx
@@ -181,7 +181,7 @@ function SurfaceRouterInner({
         <VoicePickerSurface
           surface={surface}
           onAction={onAction}
-          assistantId={assistantId}
+          assistantId={assistantId ?? null}
         />
       );
 

--- a/clients/web/src/domains/chat/components/surfaces/voice-picker-surface.test.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/voice-picker-surface.test.tsx
@@ -4,12 +4,17 @@
  *
  * Load-bearing behavior:
  *   - a managed assistant gets the fetched voice rows inside the surface card,
- *   - picking a voice PATCHes `services.tts.providers.vellum.model`,
+ *     scoped by the provider dropdown,
  *   - picking a voice submits no surface action, so auditioning several voices
  *     never fires an assistant turn,
- *   - a BYO assistant gets the Models & Services pointer, not an empty card.
+ *   - the height cap lands on the scrolling list, not on the wrapper that also
+ *     holds the provider dropdown,
+ *   - every settled state without a picker gets a pointer instead, and the
+ *     unsettled state gets no card at all: a bordered box with nothing in it is
+ *     the one outcome this surface must never produce.
  *
- * The daemon queries, the config PATCH, and audio playback are mocked.
+ * The daemon queries, the config PATCH, and audio playback are mocked; the
+ * design-library Dropdown is real, driven via its combobox trigger.
  */
 
 import {
@@ -32,12 +37,14 @@ import {
 import { MemoryRouter } from "react-router";
 
 import type { Surface } from "@/domains/chat/types/types";
+import type { OrgHeaderReadiness } from "@/hooks/use-is-org-ready";
 
 const ASSISTANT_ID = "asst_1";
 
-let orgReady = true;
+let orgReadiness: OrgHeaderReadiness = "ready";
 mock.module("@/hooks/use-is-org-ready", () => ({
-  useIsOrgReady: () => orgReady,
+  useIsOrgReady: () => orgReadiness === "ready",
+  useOrgHeaderReadiness: () => orgReadiness,
 }));
 mock.module("@vellumai/design-library/components/toast", () => ({
   toast: { success: () => {}, error: () => {} },
@@ -48,6 +55,8 @@ mock.module("@vellumai/design-library/components/toast", () => ({
 let daemonConfigData: { services: Record<string, unknown> } = {
   services: { tts: { provider: "vellum" } },
 };
+// Holds the config query in flight, for the "still loading" state.
+let configPending = false;
 let providersData: { providers: unknown[] } = {
   providers: [
     { id: "vellum", displayName: "Vellum", supportsVoiceSelection: true },
@@ -63,11 +72,17 @@ mock.module("@/generated/daemon/@tanstack/react-query.gen", () => ({
     queryFn: () => Promise.resolve(providersData),
     initialData: providersData,
   }),
-  configGetOptions: () => ({
-    queryKey: ["config-get-test"],
-    queryFn: () => Promise.resolve(daemonConfigData),
-    initialData: daemonConfigData,
-  }),
+  configGetOptions: () =>
+    configPending
+      ? {
+          queryKey: ["config-get-test"],
+          queryFn: () => new Promise(() => {}),
+        }
+      : {
+          queryKey: ["config-get-test"],
+          queryFn: () => Promise.resolve(daemonConfigData),
+          initialData: daemonConfigData,
+        },
   configGetQueryKey: () => ["config-get-test"],
   ttsManagedvoicesGetOptions: () => ({
     queryKey: ["tts-managed-voices-test"],
@@ -84,8 +99,9 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
   },
 }));
 
-const { VoicePickerSurface } =
-  await import("@/domains/chat/components/surfaces/voice-picker-surface");
+const { VoicePickerSurface } = await import(
+  "@/domains/chat/components/surfaces/voice-picker-surface"
+);
 
 const SURFACE: Surface = {
   surfaceId: "surface-voice-1",
@@ -126,10 +142,34 @@ function renderSurface(assistantId: string | null = ASSISTANT_ID) {
   );
 }
 
+/** Voice rows only; the provider dropdown's own options live in a portal. */
+function voiceRows(): HTMLElement[] {
+  const list = screen.getByRole("listbox", { name: "Assistant voice" });
+  return Array.from(list.querySelectorAll<HTMLElement>('[role="option"]'));
+}
+
+/** The list opens on the current voice's provider; Zeus lives under the other. */
+function selectDeepgram() {
+  const trigger = document.querySelector<HTMLElement>(
+    'button[role="combobox"][aria-label="Voice provider"]',
+  );
+  if (!trigger) {
+    throw new Error("expected the voice provider dropdown trigger");
+  }
+  fireEvent.click(trigger);
+  const option = Array.from(
+    document.querySelectorAll<HTMLElement>('[role="option"]'),
+  ).find((o) => o.textContent?.trim() === "Deepgram");
+  if (!option) {
+    throw new Error("expected a Deepgram option");
+  }
+  fireEvent.click(option);
+}
+
 function pickZeus() {
-  const zeus = screen
-    .getAllByRole("option")
-    .find((o) => o.textContent?.includes("Deep, trustworthy"));
+  const zeus = voiceRows().find((o) =>
+    o.textContent?.includes("Deep, trustworthy"),
+  );
   if (!zeus) {
     throw new Error("expected the Zeus option");
   }
@@ -137,7 +177,8 @@ function pickZeus() {
 }
 
 beforeEach(() => {
-  orgReady = true;
+  orgReadiness = "ready";
+  configPending = false;
   configPatchCalls.length = 0;
   onActionCalls.length = 0;
   daemonConfigData = { services: { tts: { provider: "vellum" } } };
@@ -160,7 +201,7 @@ beforeEach(() => {
         label: "Zeus",
         description: "American · deep, trustworthy, smooth",
         sampleUrl: "https://example.test/zeus.wav",
-        source: "elevenlabs",
+        source: "deepgram",
       },
     ],
     defaultModel: "EXAVITQu4vr4xnSDxMaL",
@@ -173,26 +214,43 @@ describe("VoicePickerSurface", () => {
     renderSurface();
 
     expect(screen.getByText("Pick a voice")).toBeTruthy();
-    const rows = screen.getAllByRole("option");
-    expect(rows.length).toBe(2);
-    expect(rows.map((r) => r.textContent ?? "").join(" ")).toContain(
-      "Deep, trustworthy, smooth",
-    );
+    // Scoped to the current voice's provider, with the dropdown to leave it.
+    expect(
+      document.querySelector('button[role="combobox"][aria-label="Voice provider"]'),
+    ).toBeTruthy();
+    const rows = voiceRows();
+    expect(rows.length).toBe(1);
+    expect(rows[0]!.textContent).toContain("Professional, reassuring");
+    // Managed voices bill credits, so the card says so.
+    expect(screen.getByText(/Uses Vellum credits/)).toBeTruthy();
   });
 
-  test("picking a voice PATCHes services.tts.providers.vellum.model", async () => {
+  test("the provider dropdown scopes the list to the chosen provider", () => {
     renderSurface();
-    pickZeus();
+    selectDeepgram();
 
-    await waitFor(() => expect(configPatchCalls.length).toBe(1));
-    expect(configPatchCalls[0]!.path).toEqual({ assistant_id: ASSISTANT_ID });
-    expect(configPatchCalls[0]!.body).toEqual({
-      services: { tts: { providers: { vellum: { model: "aura-2-zeus-en" } } } },
-    });
+    const rows = voiceRows();
+    expect(rows.length).toBe(1);
+    expect(rows[0]!.textContent).toContain("Deep, trustworthy");
+  });
+
+  test("the height cap lands on the scrolling list, not on the wrapper", () => {
+    renderSurface();
+
+    const list = screen.getByRole("listbox", { name: "Assistant voice" });
+    expect(list.className).toContain("max-h-[22rem]");
+    // The cap replaces the list's own default rather than nesting inside it.
+    expect(list.className).not.toContain("max-h-[60vh]");
+    // The wrapper holding the provider dropdown stays unconstrained, so the
+    // dropdown can't be scrolled out of the card.
+    const wrapper = list.parentElement!;
+    expect(wrapper.className).not.toContain("max-h-");
+    expect(wrapper.className).not.toContain("overflow-y-auto");
   });
 
   test("picking a voice submits no surface action", async () => {
     renderSurface();
+    selectDeepgram();
     pickZeus();
 
     // The write is what the card does instead of an action. Waiting for it
@@ -211,5 +269,44 @@ describe("VoicePickerSurface", () => {
     expect(link.getAttribute("href")).toBe(
       "/assistant/settings/ai#text-to-speech",
     );
+  });
+
+  test("a daemon too old to select voices gets a pointer, not an empty card", () => {
+    providersData = {
+      providers: [
+        { id: "vellum", displayName: "Vellum", supportsVoiceSelection: false },
+      ],
+    };
+    renderSurface();
+
+    expect(screen.queryByRole("listbox")).toBeNull();
+    // Managed, so the BYO pointer would be a lie: it gets the plain line.
+    expect(screen.queryByRole("link")).toBeNull();
+    expect(screen.getByText(/available for this assistant/)).toBeTruthy();
+  });
+
+  test("an empty voice catalog gets a pointer, not an empty card", () => {
+    managedVoicesData = { voices: [], defaultModel: null };
+    renderSurface();
+
+    expect(screen.queryByRole("listbox")).toBeNull();
+    expect(screen.getByText(/available for this assistant/)).toBeTruthy();
+  });
+
+  test("no assistant gets a pointer, not an empty card", () => {
+    renderSurface(null);
+
+    expect(screen.queryByRole("listbox")).toBeNull();
+    expect(screen.getByText(/available for this assistant/)).toBeTruthy();
+  });
+
+  test("renders no card at all while daemon config is still in flight", () => {
+    configPending = true;
+    const { container } = renderSurface();
+
+    // Not even the title: the card's own chrome would be an empty box until
+    // the queries land.
+    expect(container.textContent).toBe("");
+    expect(screen.queryByText("Pick a voice")).toBeNull();
   });
 });

--- a/clients/web/src/domains/chat/components/surfaces/voice-picker-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/voice-picker-surface.tsx
@@ -70,8 +70,9 @@ export function VoicePickerSurface({
             // out of the card instead of scrolling the voices.
             listClassName="max-h-[22rem]"
           />
-          {/* Every other managed-voice surface discloses the cost; this one is
-              now the path users are steered toward. */}
+          {/* Managed voices bill credits, and every surface that offers them
+              says so. This one is reached without opening Settings, so it
+              carries the disclosure too. */}
           <p className={NOTE_CLASS}>{MANAGED_VOICE_CREDITS_NOTE}</p>
         </div>
       ) : isByok ? (

--- a/clients/web/src/domains/chat/components/surfaces/voice-picker-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/voice-picker-surface.tsx
@@ -4,17 +4,22 @@
  * pointer to Settings. Same {@link VoiceList} the Voice settings page and the
  * voice room render, so a voice is chosen the same way everywhere.
  *
- * **Fires no surface action.** `handleSurfaceAction` requests a send on every
+ * **Carries no surface action.** `handleSurfaceAction` requests a send on every
  * non-guardian action, so a per-selection action would cost an assistant turn
  * on every audition click. It needs none: `VoiceList` writes
  * `services.tts.providers.vellum.model` to daemon config itself, and that
- * hot-applies on the assistant's next spoken turn. `onAction` is accepted only
- * to satisfy {@link SurfaceContainer}'s required prop and to keep the router's
- * call shape uniform across surfaces. This component never invokes it.
+ * hot-applies on the assistant's next spoken turn. `onAction` is accepted to
+ * satisfy {@link SurfaceContainer}'s required prop and to keep the router's
+ * call shape uniform; `SurfaceContainer` only invokes it for actions the
+ * surface declares, and no voice picker is given any.
  *
- * The assistant arrives as a prop rather than from `useActiveAssistantId()`,
- * which throws when nothing is resolved and answers with the globally-active
- * assistant, not necessarily the one that owns this surface's stream.
+ * Three states, not two, because most of the ways a picker fails to appear are
+ * permanent rather than transient: no chrome at all while the daemon queries
+ * are in flight, the picker once managed voice selection is available, and a
+ * pointer to where the voice actually lives for every settled state in between
+ * (a daemon too old to select voices, a catalog that failed or came back empty,
+ * no assistant). An empty bordered box is the one unacceptable outcome, since
+ * the model has just told the user the picker is here.
  */
 
 import { ByoVoiceNote } from "@/components/speech/byo-voice-note";
@@ -22,6 +27,9 @@ import { useManagedVoiceSelection } from "@/components/speech/use-managed-voice-
 import { VoiceList } from "@/components/speech/voice-list";
 import { SurfaceContainer } from "@/domains/chat/components/surfaces/surface-container";
 import type { Surface } from "@/domains/chat/types/types";
+import { MANAGED_VOICE_CREDITS_NOTE } from "@/lib/tts/managed-voice-catalog";
+
+const NOTE_CLASS = "text-body-small-default text-[var(--content-tertiary)]";
 
 interface VoicePickerSurfaceProps {
   surface: Surface;
@@ -30,7 +38,7 @@ interface VoicePickerSurfaceProps {
     actionId: string,
     data?: Record<string, unknown>,
   ) => void | Promise<void>;
-  assistantId?: string | null;
+  assistantId: string | null;
 }
 
 export function VoicePickerSurface({
@@ -38,25 +46,43 @@ export function VoicePickerSurface({
   onAction,
   assistantId,
 }: VoicePickerSurfaceProps) {
-  const { available, isByok } = useManagedVoiceSelection(assistantId ?? null);
+  // Only the three flags that pick the state. `VoiceList` runs the same hook for
+  // the data it renders; both calls share one set of React Query subscriptions.
+  const { available, isByok, settled } = useManagedVoiceSelection(assistantId);
+
+  if (!settled) {
+    return null;
+  }
 
   return (
     <SurfaceContainer surface={surface} onAction={onAction}>
-      {available && (
-        // Uncontrolled (no `value`/`onChange`) so the list commits the pick
-        // itself and it hot-applies, the mode the Settings picker and the voice
-        // room use. `showSource` stays off because `filterBySource` already
-        // labels the whole list with the chosen provider and drops the per-row
-        // badge. Capped so a long catalog can't take over the transcript.
-        <VoiceList
-          assistantId={assistantId ?? null}
-          filterBySource
-          className="max-h-[22rem] overflow-y-auto"
-        />
+      {available ? (
+        <div className="flex flex-col gap-3">
+          {/* Uncontrolled (no `value`/`onChange`): the list commits each pick
+              itself and it hot-applies. Every other host is controlled, because
+              each owns a Done or Start button that has to wait out an in-flight
+              write; this card has no button, so there is nothing to gate. */}
+          <VoiceList
+            assistantId={assistantId}
+            filterBySource
+            // Capped on the listbox rather than the wrapper, which also holds
+            // the provider dropdown: capping the wrapper scrolls the dropdown
+            // out of the card instead of scrolling the voices.
+            listClassName="max-h-[22rem]"
+          />
+          {/* Every other managed-voice surface discloses the cost; this one is
+              now the path users are steered toward. */}
+          <p className={NOTE_CLASS}>{MANAGED_VOICE_CREDITS_NOTE}</p>
+        </div>
+      ) : isByok ? (
+        <ByoVoiceNote />
+      ) : (
+        // Managed, but with nothing to choose from: an old daemon, or a catalog
+        // that failed or is empty. The BYO note would be a lie here.
+        <p className={NOTE_CLASS}>
+          Choosing a voice isn’t available for this assistant right now.
+        </p>
       )}
-      {/* Gated on `isByok` rather than `!available` so the BYO pointer never
-          flashes while config is still loading. */}
-      {isByok && <ByoVoiceNote />}
     </SurfaceContainer>
   );
 }

--- a/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
@@ -493,6 +493,9 @@ function VoiceSettingsView({
           filterBySource
           value={currentModel}
           onChange={selectModel}
+          // The dialog body is the nearest scrollport, so opening on the
+          // current voice scrolls nothing but this list.
+          autoScrollToSelected
         />
       </Modal.Body>
       {/* Mirrors the intro footer (fine print left, primary right) and is always

--- a/clients/web/src/domains/settings/ai/text-to-speech-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/text-to-speech-card.test.tsx
@@ -32,6 +32,7 @@ mock.module("@vellumai/design-library/components/toast", () => ({
 let orgReady = false;
 mock.module("@/hooks/use-is-org-ready", () => ({
   useIsOrgReady: () => orgReady,
+  useOrgHeaderReadiness: () => (orgReady ? "ready" : "resolving"),
 }));
 // Controllable daemon config the config-get query resolves to. `initialData`
 // makes it available even though the query is `enabled: isOrgReady` (false),


### PR DESCRIPTION
## Summary

- **Three-way state instead of two.** No chrome while daemon queries are in flight, the picker when managed voice selection is available, and a pointer for every settled state in between (a daemon too old to select voices, a catalog that failed or came back empty, no assistant). Those states are permanent, not transient, and previously rendered an empty bordered box right after the assistant said the picker was here. Backed by a new `settled` flag on `useManagedVoiceSelection`.
- **Height cap moved onto the scrolling listbox** via a new `listClassName` prop. It was landing on the outer wrapper, which also holds the provider dropdown, so scrolling dragged the dropdown out of the card instead of scrolling the voices.
- **`VoiceList`'s mount-time `scrollIntoView` is now opt-in** (`autoScrollToSelected`, default off, re-enabled for the modal, field, and first-run hosts). Inline in a non-virtualized transcript it scrolled every ancestor, yanking the transcript whenever history contained a picker.
- **Added the managed-voice credits disclosure.** Every other voice surface carries it; this one lacked it, and it is now the path users are steered toward.
- **Corrected two inaccurate comments** (the controlled/uncontrolled claim was inverted, and `onAction` is not 'never invoked', it is never given an action) and narrowed `assistantId` to a required prop.
- **Tests:** the router now asserts `voice_picker` renders the picker rather than the unsupported fallback (PR 2's stated acceptance criterion, previously untested); the surface fixture restores a second provider so the dropdown is actually exercised; dropped a test that duplicated `voice-list.test.tsx`; added the old-daemon and empty-catalog states.

Verified: 31 tests pass across `voice-picker-surface`, `surface-router`, `voice-list`, and `voice-page` (the shared hosts stay green). `tsc --noEmit` and eslint clean.

Fixes gaps found in self-review of plan inline-voice-picker-surface.md