### PR TITLE
Fail closed on an inherited channel key, and two smaller follow-ups

### DIFF
--- a/assistant/src/__tests__/tool-side-effects-documents.test.ts
+++ b/assistant/src/__tests__/tool-side-effects-documents.test.ts
@@ -26,12 +26,6 @@ mock.module("../util/logger.js", () => createMockLoggerModule());
 
 // Stub the transitive imports so the module graph under test stops at
 // tool-side-effects.ts and never reaches the real sync publisher.
-mock.module("../channels/gateway-verification-sessions.js", () => ({
-  findActiveSession: mock(() => Promise.resolve(null)),
-}));
-mock.module("../runtime/verification-outbound-actions.js", () => ({
-  deliverVerificationSlack: mock(() => {}),
-}));
 mock.module("../media/app-icon-generator.js", () => ({
   generateAppIcon: mock(() => Promise.resolve()),
 }));

--- a/assistant/src/__tests__/tool-side-effects-hook-failures.test.ts
+++ b/assistant/src/__tests__/tool-side-effects-hook-failures.test.ts
@@ -10,7 +10,7 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 // ---------------------------------------------------------------------------
-// Mocks — must be set up before importing the module under test
+// Mocks: must be set up before importing the module under test
 // ---------------------------------------------------------------------------
 
 // Stub out transitive dependencies to prevent import errors
@@ -76,7 +76,7 @@ mock.module("../util/logger.js", () => ({
 }));
 
 // ---------------------------------------------------------------------------
-// Import after mocks — dynamic import ensures mock.module() calls above
+// Import after mocks: dynamic import ensures mock.module() calls above
 // are registered before tool-side-effects.ts evaluates its top-level
 // `const log = getLogger(...)`.
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/verification-outbound-delivery.test.ts
+++ b/assistant/src/__tests__/verification-outbound-delivery.test.ts
@@ -78,7 +78,7 @@ mock.module("../runtime/channel-verification-service.js", () => ({
   getGuardianBinding: async () => null,
 }));
 
-const { startOutbound } =
+const { startOutbound, resendOutbound } =
   await import("../runtime/verification-outbound-actions.js");
 
 /**
@@ -113,6 +113,21 @@ describe("startOutbound delivers from inside the action", () => {
       expect(sent[0].text.length).toBeGreaterThan(0);
     });
   }
+
+  test("resend delivers too, on every channel that starts", async () => {
+    // Start and resend run the same mint-and-send, so this is coverage of that
+    // shared path from its second entry point rather than of resend as a
+    // feature.
+    for (const { channel, destination } of DESTINATIONS) {
+      deliveries.length = 0;
+      await startOutbound({ channel: channel as never, destination });
+      deliveries.length = 0;
+
+      const result = await resendOutbound({ channel: channel as never });
+      expect(result.success).toBe(true);
+      expect(deliveries.filter((d) => d.transport === channel)).toHaveLength(1);
+    }
+  });
 
   test("no channel returns a payload for the caller to send instead", async () => {
     // A `_pending*` field means some channel is minting a session whose

--- a/assistant/src/__tests__/verification-outbound-delivery.test.ts
+++ b/assistant/src/__tests__/verification-outbound-delivery.test.ts
@@ -97,6 +97,10 @@ const DESTINATIONS: Array<{ channel: string; destination: string }> = [
 
 beforeEach(() => {
   deliveries.length = 0;
+  // Sessions persist in the sim, and `findActiveSession` returns the latest
+  // for a channel, so without this a test would resend against the previous
+  // test's session.
+  sessions.resetVerificationSessionsSim();
 });
 
 describe("startOutbound delivers from inside the action", () => {
@@ -119,8 +123,21 @@ describe("startOutbound delivers from inside the action", () => {
     // shared path from its second entry point rather than of resend as a
     // feature.
     for (const { channel, destination } of DESTINATIONS) {
-      deliveries.length = 0;
-      await startOutbound({ channel: channel as never, destination });
+      sessions.resetVerificationSessionsSim();
+      const start = await startOutbound({
+        channel: channel as never,
+        destination,
+      });
+      expect(start.verificationSessionId).toBeDefined();
+
+      // A start stamps a 15-second resend cooldown. That cooldown is its own
+      // behaviour; clearing it here is what lets this reach the delivery.
+      sessions.updateSessionDelivery(
+        start.verificationSessionId!,
+        Date.now(),
+        1,
+        null,
+      );
       deliveries.length = 0;
 
       const result = await resendOutbound({ channel: channel as never });

--- a/assistant/src/runtime/verification-outbound-actions.ts
+++ b/assistant/src/runtime/verification-outbound-actions.ts
@@ -235,7 +235,7 @@ export async function startOutbound(
     );
   }
 
-  const spec = TEXT_CHANNEL_VERIFICATION[channel];
+  const spec = textChannelSpec(channel);
   if (spec) {
     return await startOutboundTextChannel(
       spec,
@@ -725,6 +725,26 @@ const TEXT_CHANNEL_VERIFICATION: Partial<
 };
 
 /**
+ * The spec for a channel, or undefined when it has none.
+ *
+ * An own-property check rather than a bare index read: `channel` reaches here
+ * as a plain string, so `"constructor"`, `"toString"` and `"__proto__"` would
+ * otherwise resolve to inherited values, pass a truthy guard, and throw on the
+ * first spec field instead of falling through to `unsupported_channel`. Same
+ * fail-closed shape as `resolveCapabilities`.
+ */
+function textChannelSpec(
+  channel: ChannelId,
+): TextChannelVerificationSpec | undefined {
+  return Object.prototype.hasOwnProperty.call(
+    TEXT_CHANNEL_VERIFICATION,
+    channel,
+  )
+    ? TEXT_CHANNEL_VERIFICATION[channel]
+    : undefined;
+}
+
+/**
  * Mint a session, compose the message, stamp the delivery, and send it.
  *
  * Shared by the start and resend paths, which differ only in the template and
@@ -1004,7 +1024,7 @@ export async function resendOutbound(
     };
   }
 
-  const spec = TEXT_CHANNEL_VERIFICATION[channel];
+  const spec = textChannelSpec(channel);
   if (spec) {
     const newSendCount = currentSendCount + 1;
     const sent = await mintAndSend({


### PR DESCRIPTION
## TL;DR

Three non-blocking findings from the review of #40415, cleaned up now that it has merged.

## The one that matters

`TEXT_CHANNEL_VERIFICATION[channel]` was a bare index read. `channel` arrives as `z.string()` and is narrowed by a cast, never parsed against the union, so `"constructor"`, `"toString"`, `"valueOf"` and `"__proto__"` all resolve to inherited values, pass the truthy `if (spec)` guard, and throw a TypeError on the first spec field.

The `if/else` chain this replaced fell through to a clean `unsupported_channel` 400. So it is an error-shape regression rather than a bypass: no session is minted, nothing is sent, and it takes an authenticated `settings.write` actor. Still worth closing, and there is an in-repo pattern for exactly this: `resolveCapabilities` uses an own-property check so inherited keys fail closed. Same shape here.

## The other two

**Two em dashes** reached `tool-side-effects-hook-failures.test.ts`, which `AGENTS.md` forbids. They got in because that file was assembled programmatically rather than through an editor, so the hook that normally catches them never saw the lines.

**`tool-side-effects-documents.test.ts` kept mocks** for `gateway-verification-sessions.js` and `verification-outbound-actions.js`, neither of which is in `tool-side-effects.ts`'s import graph any more. Harmless no-ops, but they assert a shape of the graph that is no longer true. (This also corrects a reply I left on the review: I said those two mocks "went with" the deleted file. They went from the deleted file; the documents test had its own copies.)

## Coverage

The delivery test now exercises `resendOutbound` as well as `startOutbound`. Both run the same `mintAndSend`, so this is coverage of that shared path from its second entry point rather than coverage of resend as a feature.

Email delivery is still unasserted. It reaches delivery through the same shared path, and covering it needs an email-specific platform-client harness, so it is filed rather than built here.

## Why it is safe

`textChannelSpec` returns the same value as the index read for every real channel id, and `undefined` instead of an inherited member for everything else, which restores the `unsupported_channel` fall-through. No spec content, template key, session field, or delivery changed.

Local test runs are blocked by a standing hook in this environment, so this was verified by typecheck, lint and format locally, and is being read from CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->