### PR TITLE
fix(web): hide the pair-device card when remote web access is off

### DIFF
--- a/clients/web/src/domains/settings/pair-device/pair-device-card.test.tsx
+++ b/clients/web/src/domains/settings/pair-device/pair-device-card.test.tsx
@@ -144,52 +144,24 @@ describe("PairDeviceCard", () => {
     expect(screen.queryByText("Pair a device")).toBeNull();
   });
 
-  test("holds the action in a loading state until feature flags hydrate", () => {
-    // Before hydration the store still reports registry defaults
-    // (webRemoteIngress false), so the precheck must not run against it yet.
+  test("renders nothing until feature flags hydrate", () => {
+    // Before hydration the store reports registry defaults, not this
+    // assistant's values, so the card waits rather than showing an action it
+    // may have to take away.
     flagsHydrated = false;
-    webRemoteIngressOn = false;
-    const fetchMock = installFetch(() => jsonResponse(challengeBody()));
-    render(<PairDeviceCard />);
-    typeUrl(PUBLIC_URL);
-
-    const button = screen.getByRole("button", {
-      name: "Loading…",
-    }) as HTMLButtonElement;
-    expect(button.disabled).toBe(true);
-
-    // Enter is a second mint path the disabled button doesn't cover, so it must
-    // also no-op until hydration — otherwise the default flag reaches the
-    // precheck and shows a spurious "disabled" error.
-    fireEvent.keyDown(screen.getByLabelText("Public URL"), { key: "Enter" });
-
-    expect(
-      screen.queryByText(
-        "Remote web access is disabled on this assistant, so a scanned code couldn't connect.",
-      ),
-    ).toBeNull();
-    expect(fetchMock).toHaveBeenCalledTimes(0);
+    webRemoteIngressOn = true;
+    const { container } = render(<PairDeviceCard />);
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByText("Pair a device")).toBeNull();
   });
 
-  test("reports the enable guidance without minting when web-remote-ingress is off", async () => {
+  test("renders nothing when web-remote-ingress is off", () => {
+    // A scanned code could not connect without the ingress, so the card is
+    // absent rather than present and failing on use.
     webRemoteIngressOn = false;
-    const fetchMock = installFetch(() => jsonResponse(challengeBody()));
-    render(<PairDeviceCard />);
-    typeUrl(PUBLIC_URL);
-    fireEvent.click(
-      screen.getByRole("button", { name: "Generate pairing QR" }),
-    );
-
-    await waitFor(() =>
-      expect(
-        screen.getByText(
-          "Remote web access is disabled on this assistant, so a scanned code couldn't connect.",
-        ),
-      ).toBeTruthy(),
-    );
-    expect(screen.getByText(/web-remote-ingress/)).toBeTruthy();
-    // Mirrors the CLI: the flag is checked before minting, so no network call.
-    expect(fetchMock).toHaveBeenCalledTimes(0);
+    const { container } = render(<PairDeviceCard />);
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByText("Pair a device")).toBeNull();
   });
 
   test("mints + approves, then shows the QR and pair URL", async () => {

--- a/clients/web/src/domains/settings/pair-device/pair-device-card.tsx
+++ b/clients/web/src/domains/settings/pair-device/pair-device-card.tsx
@@ -20,10 +20,11 @@ import { usePairDevice } from "./use-pair-device";
  *
  * Rendered only in desktop/local mode against an on-machine gateway (the gate
  * lives in {@link resolvePairDeviceTarget}) whose assistant version serves the
- * pairing routes ({@link useSupportsRemoteWebPairing}); a remote or platform
- * session, or an older assistant, sees nothing. Generating also requires the
- * `web-remote-ingress` flag — checked before minting, like the CLI, so a
- * rendered QR always represents a scannable pairing.
+ * pairing routes ({@link useSupportsRemoteWebPairing}) and whose
+ * `web-remote-ingress` flag is on, so a code minted here can always connect.
+ * The flag is read only once the store has hydrated, since before that it
+ * reports the registry default rather than this assistant's value: the card
+ * appears a beat late rather than appearing and then vanishing.
  */
 export function PairDeviceCard() {
   const target = resolvePairDeviceTarget();
@@ -40,7 +41,7 @@ export function PairDeviceCard() {
     errorMessage: "Could not copy the pairing address.",
   });
 
-  if (!target || !supported) {
+  if (!target || !supported || !flagsHydrated || !webRemoteIngressOn) {
     return null;
   }
 
@@ -52,25 +53,11 @@ export function PairDeviceCard() {
   // empty. Advanced users can still type an address into the field below.
   const showNoTunnelGuidance =
     pair.prefillSource === "none" && pair.publicBaseUrl.trim() === "";
-  // Until the feature-flag store hydrates, webRemoteIngressOn is the registry
-  // default (false), not this assistant's real value, so the mint precheck
-  // can't be trusted until hasHydrated is true.
-  const buttonLabel = !flagsHydrated
-    ? "Loading…"
-    : isMinting
-      ? "Generating…"
-      : isReady
-        ? "Generate new code"
-        : "Generate pairing QR";
-
-  // Both the button and the Enter key mint through here, so the flag precheck
-  // is never evaluated against the pre-hydration default.
-  const handleGenerate = () => {
-    if (!flagsHydrated) {
-      return;
-    }
-    pair.generate();
-  };
+  const buttonLabel = isMinting
+    ? "Generating…"
+    : isReady
+      ? "Generate new code"
+      : "Generate pairing QR";
 
   return (
     <DetailCard
@@ -104,17 +91,15 @@ export function PairDeviceCard() {
             onKeyDown={(event) => {
               if (event.key === "Enter") {
                 event.preventDefault();
-                handleGenerate();
+                pair.generate();
               }
             }}
           />
           <Button
             variant="primary"
             className="self-start"
-            disabled={
-              !flagsHydrated || isMinting || pair.publicBaseUrl.trim() === ""
-            }
-            onClick={handleGenerate}
+            disabled={isMinting || pair.publicBaseUrl.trim() === ""}
+            onClick={pair.generate}
           >
             {buttonLabel}
           </Button>


### PR DESCRIPTION
## Summary
- `PairDeviceCard` now renders only when the assistant's `web-remote-ingress` flag is on, instead of rendering always and failing at mint time with "Remote web access is disabled on this assistant". The flag defaults off at assistant scope, so the default local-desktop experience was a card that errored on use.
- The flag is read only after the flag store hydrates, since before that it reports the registry default rather than this assistant's value. The card appears a beat late rather than appearing and then vanishing, which also retires the pre-hydration "Loading…" button state and the `handleGenerate` wrapper that existed to keep the mint precheck away from that default.
- `usePairDevice` keeps its own precheck: it is the layer that actually mints, and the guarantee that a minted code can connect should not depend on which UI calls it.

## Original prompt
While QAing the origin-model chooser, Noa noticed the pairing UI in Settings → General is not behind a feature flag. That is correct and pre-dates the chooser arc: the card gated only on desktop/local mode plus assistant version, while `web-remote-ingress` was consulted at mint time and surfaced an error. Noa asked to hide it when we know it will not work, rather than show a control that always fails.