### PR TITLE
Scope a verification session to its actor, not to the channel

### DIFF
--- a/assistant/src/__tests__/call-start-guardian-guard.test.ts
+++ b/assistant/src/__tests__/call-start-guardian-guard.test.ts
@@ -40,10 +40,24 @@ const realGatewaySessionsModule = {
 };
 mock.module("../channels/gateway-verification-sessions.js", () => ({
   ...realGatewaySessionsModule,
-  findActiveSession: async (channel: string) =>
-    findActiveSessionMockActive
-      ? activeVoiceSession
-      : realGatewaySessionsModule.findActiveSession(channel),
+  // Honours the caller's filter: the guard asks for the number it is about
+  // to dial, so a session for a different number must read as absent.
+  findActiveSession: async (
+    channel: string,
+    filter?: { expectedExternalUserId?: string },
+  ) => {
+    if (!findActiveSessionMockActive) {
+      return realGatewaySessionsModule.findActiveSession(channel, filter);
+    }
+    const wanted = filter?.expectedExternalUserId;
+    if (
+      wanted !== undefined &&
+      activeVoiceSession?.expectedPhoneE164 !== wanted
+    ) {
+      return null;
+    }
+    return activeVoiceSession;
+  },
 }));
 
 const { executeCallStart } = await import("../tools/calls/call-start.js");

--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -1640,32 +1640,42 @@ describe("outbound verification sessions", () => {
 
   // ── Auto-revoke of prior sessions ──
 
-  test("creating a new outbound session auto-revokes prior pending/awaiting sessions", async () => {
+  test("a second code for the same number revokes the first", async () => {
     const { sessionId: firstId } = await createOutboundSession({
       channel: "phone",
-      expectedPhoneE164: "+15551234567",
-      destinationAddress: "+15551234567",
+      expectedPhoneE164: "+15555550101",
+      destinationAddress: "+15555550101",
     });
-
-    const first = await serviceFindActiveSession("phone");
-    expect(first).not.toBeNull();
-    expect(first!.id).toBe(firstId);
-
-    // Create a second session — first should be revoked
     const { sessionId: secondId } = await createOutboundSession({
       channel: "phone",
-      expectedPhoneE164: "+15559876543",
-      destinationAddress: "+15559876543",
+      expectedPhoneE164: "+15555550101",
+      destinationAddress: "+15555550101",
     });
 
-    const second = await serviceFindActiveSession("phone");
-    expect(second).not.toBeNull();
-    expect(second!.id).toBe(secondId);
+    // Read by id rather than through the unfiltered lookup: two live
+    // sessions minted in the same millisecond have no defined order, and
+    // what matters here is each row's status, not which one is "latest".
+    expect(getSessionById(firstId)!.status).toBe("revoked");
+    expect(getSessionById(secondId)!.status).toBe("awaiting_response");
+  });
 
-    // First session should no longer be findable as active
-    const firstRow = getSessionById(firstId);
-    expect(firstRow).not.toBeNull();
-    expect(firstRow!.status).toBe("revoked");
+  test("a code for a different number leaves the first alone", async () => {
+    // Two numbers are two people. Verifying one must not silently kill the
+    // other's code, which they would learn about only by trying to use it
+    // and being told it is "invalid or has expired".
+    const { sessionId: firstId } = await createOutboundSession({
+      channel: "phone",
+      expectedPhoneE164: "+15555550101",
+      destinationAddress: "+15555550101",
+    });
+    const { sessionId: secondId } = await createOutboundSession({
+      channel: "phone",
+      expectedPhoneE164: "+15555550102",
+      destinationAddress: "+15555550102",
+    });
+
+    expect(getSessionById(firstId)!.status).toBe("awaiting_response");
+    expect(getSessionById(secondId)!.status).toBe("awaiting_response");
   });
 
   // ── findActiveSession returns correct session ──

--- a/assistant/src/__tests__/helpers/gateway-verification-sessions-stub.ts
+++ b/assistant/src/__tests__/helpers/gateway-verification-sessions-stub.ts
@@ -139,9 +139,22 @@ export function createGatewayVerificationSessionsStub(options: {
       throwIfUnreachable("updateSessionDelivery");
       calls.updateSessionDelivery.push(args);
     },
-    findActiveSession: async () => {
+    // Honours the caller's `expectedExternalUserId` filter the way the
+    // gateway does. Returning the session for every filter would make a
+    // "someone else is verifying" test pass against a lookup that, against
+    // the real gateway, would have found nothing.
+    findActiveSession: async (...args: unknown[]) => {
       calls.sessionReads.push("findActiveSession");
       throwIfUnreachable("findActiveSession");
+      const wantedActor = (
+        args[1] as { expectedExternalUserId?: string } | undefined
+      )?.expectedExternalUserId;
+      if (
+        wantedActor !== undefined &&
+        state.activeSession?.expectedExternalUserId !== wantedActor
+      ) {
+        return null;
+      }
       return state.activeSession;
     },
     getPendingSession: async () => {

--- a/assistant/src/__tests__/helpers/verification-sessions-ipc-sim.ts
+++ b/assistant/src/__tests__/helpers/verification-sessions-ipc-sim.ts
@@ -62,10 +62,48 @@ function isInterceptable(s: VerificationSessionWire): boolean {
   return (INTERCEPTABLE_STATUSES as readonly string[]).includes(s.status);
 }
 
-function revokeInterceptable(channel: string): void {
+const OUTBOUND_LIVE_STATUSES = ["pending_bootstrap", "awaiting_response"];
+
+/**
+ * The identity a session redeems on, in `checkIdentityMatch`'s precedence
+ * order. Null when the session carries none, which is a bootstrap session.
+ */
+function boundIdentity(session: {
+  expectedExternalUserId?: string | null;
+  expectedChatId?: string | null;
+  expectedPhoneE164?: string | null;
+}): string | null {
+  if (session.expectedExternalUserId) {
+    return `user:${session.expectedExternalUserId}`;
+  }
+  if (session.expectedPhoneE164) {
+    return `phone:${session.expectedPhoneE164}`;
+  }
+  if (session.expectedChatId) {
+    return `chat:${session.expectedChatId}`;
+  }
+  return null;
+}
+
+/**
+ * Mirrors the gateway store: an outbound mint supersedes only sessions bound
+ * to the same identity, leaving other actors and inbound challenges alone.
+ */
+function revokeSameActorOutbound(
+  channel: string,
+  params: SimCreateOutboundParams,
+): void {
+  const identity = boundIdentity(params);
+  if (identity === null) {
+    return;
+  }
   const now = Date.now();
   for (const s of sessions.values()) {
-    if (s.channel === channel && isInterceptable(s)) {
+    if (
+      s.channel === channel &&
+      OUTBOUND_LIVE_STATUSES.includes(s.status) &&
+      boundIdentity(s) === identity
+    ) {
       s.status = "revoked";
       s.updatedAt = now;
     }
@@ -164,7 +202,7 @@ export interface SimCreateOutboundResult {
 export function createOutboundSession(
   params: SimCreateOutboundParams,
 ): SimCreateOutboundResult {
-  revokeInterceptable(params.channel);
+  revokeSameActorOutbound(params.channel, params);
 
   const isUnbound = params.identityBindingStatus === "pending_bootstrap";
   const secret = isUnbound
@@ -229,25 +267,35 @@ export function createOutboundSessionGuarded(
     ...createParams
   } = params;
 
+  let sourceSession: VerificationSessionWire | undefined;
   if (requireSourceSessionPending !== undefined) {
-    const source = sessions.get(requireSourceSessionPending);
+    sourceSession = sessions.get(requireSourceSessionPending);
     if (
-      !source ||
-      source.channel !== params.channel ||
-      source.status !== "pending_bootstrap"
+      !sourceSession ||
+      sourceSession.channel !== params.channel ||
+      sourceSession.status !== "pending_bootstrap"
     ) {
       return { conflict: true, reason: "source_session_not_pending" };
     }
   }
 
   if (ifNoneActiveForExternalUserId !== undefined) {
-    const active = findActiveSession(params.channel);
-    if (
-      active !== null &&
-      active.expectedExternalUserId === ifNoneActiveForExternalUserId
-    ) {
+    // Scoped, like the gateway. Reading the channel's latest and comparing
+    // misses this sender's session whenever somebody else started later.
+    const active = findActiveSession(params.channel, {
+      expectedExternalUserId: ifNoneActiveForExternalUserId,
+    });
+    if (active !== null) {
       return { conflict: true, reason: "active_session_exists" };
     }
+  }
+
+  // Claim the named source row, so a second claim of the same deep-link
+  // token conflicts. The identity-scoped revoke cannot do this: a bootstrap
+  // row carries whichever identity was bound onto it last.
+  if (sourceSession) {
+    sourceSession.status = "revoked";
+    sourceSession.updatedAt = Date.now();
   }
 
   return createOutboundSession(createParams);

--- a/assistant/src/__tests__/helpers/verification-sessions-ipc-sim.ts
+++ b/assistant/src/__tests__/helpers/verification-sessions-ipc-sim.ts
@@ -267,18 +267,6 @@ export function createOutboundSessionGuarded(
     ...createParams
   } = params;
 
-  let sourceSession: VerificationSessionWire | undefined;
-  if (requireSourceSessionPending !== undefined) {
-    sourceSession = sessions.get(requireSourceSessionPending);
-    if (
-      !sourceSession ||
-      sourceSession.channel !== params.channel ||
-      sourceSession.status !== "pending_bootstrap"
-    ) {
-      return { conflict: true, reason: "source_session_not_pending" };
-    }
-  }
-
   if (ifNoneActiveForExternalUserId !== undefined) {
     // Scoped, like the gateway. Reading the channel's latest and comparing
     // misses this sender's session whenever somebody else started later.
@@ -290,12 +278,21 @@ export function createOutboundSessionGuarded(
     }
   }
 
-  // Claim the named source row, so a second claim of the same deep-link
-  // token conflicts. The identity-scoped revoke cannot do this: a bootstrap
-  // row carries whichever identity was bound onto it last.
-  if (sourceSession) {
-    sourceSession.status = "revoked";
-    sourceSession.updatedAt = Date.now();
+  // Claim the named source row. Winning the claim IS the guard, so a second
+  // claim of the same deep-link token conflicts. The identity-scoped revoke
+  // cannot do this: a bootstrap row carries whichever identity was bound onto
+  // it last.
+  if (requireSourceSessionPending !== undefined) {
+    const source = sessions.get(requireSourceSessionPending);
+    if (
+      !source ||
+      source.channel !== params.channel ||
+      source.status !== "pending_bootstrap"
+    ) {
+      return { conflict: true, reason: "source_session_not_pending" };
+    }
+    source.status = "revoked";
+    source.updatedAt = Date.now();
   }
 
   return createOutboundSession(createParams);

--- a/assistant/src/__tests__/helpers/verification-sessions-ipc-sim.ts
+++ b/assistant/src/__tests__/helpers/verification-sessions-ipc-sim.ts
@@ -220,13 +220,11 @@ export type SimGuardedCreateOutboundResult =
 export function createOutboundSessionGuarded(
   params: SimCreateOutboundParams & {
     requireSourceSessionPending?: string;
-    ifNoneActive?: boolean;
     ifNoneActiveForExternalUserId?: string;
   },
 ): SimGuardedCreateOutboundResult {
   const {
     requireSourceSessionPending,
-    ifNoneActive,
     ifNoneActiveForExternalUserId,
     ...createParams
   } = params;
@@ -240,10 +238,6 @@ export function createOutboundSessionGuarded(
     ) {
       return { conflict: true, reason: "source_session_not_pending" };
     }
-  }
-
-  if (ifNoneActive && findActiveSession(params.channel) !== null) {
-    return { conflict: true, reason: "active_session_exists" };
   }
 
   if (ifNoneActiveForExternalUserId !== undefined) {
@@ -309,6 +303,10 @@ export function getPendingSession(
 
 export function findActiveSession(
   channel: string,
+  filter: {
+    expectedExternalUserId?: string;
+    verificationPurpose?: "guardian" | "trusted_contact";
+  } = {},
 ): VerificationSessionWire | null {
   const now = Date.now();
   return (
@@ -318,7 +316,11 @@ export function findActiveSession(
           s.channel === channel &&
           (s.status === "pending_bootstrap" ||
             s.status === "awaiting_response") &&
-          s.expiresAt > now,
+          s.expiresAt > now &&
+          (!filter.expectedExternalUserId ||
+            s.expectedExternalUserId === filter.expectedExternalUserId) &&
+          (!filter.verificationPurpose ||
+            s.verificationPurpose === filter.verificationPurpose),
       )
       .sort(newestFirst)[0] ?? null
   );

--- a/assistant/src/__tests__/introduction-card-resolver.test.ts
+++ b/assistant/src/__tests__/introduction-card-resolver.test.ts
@@ -182,7 +182,12 @@ describe("introduction card decisions", () => {
       expectedExternalUserId: "U-REQUESTER",
       expectedChatId: "C-CHAT",
       identityBindingStatus: "bound",
-      destinationAddress: "C-CHAT",
+      // The person, not the room. Slack delivers to a user id, and the room
+      // may hold an audience the code was never meant for. `expectedChatId`
+      // still carries the room because that is where the conversation is;
+      // with both identity fields set the consume path requires the user
+      // match, so the room is not a credential.
+      destinationAddress: "U-REQUESTER",
       verificationPurpose: "trusted_contact",
     });
     expect(outcomesOfType("activate_member")).toHaveLength(0);

--- a/assistant/src/__tests__/slack-inbound-verification.test.ts
+++ b/assistant/src/__tests__/slack-inbound-verification.test.ts
@@ -104,7 +104,10 @@ mock.module("../channels/gateway-verification-sessions.js", () => ({
     params: Parameters<typeof createOutboundSessionGuarded>[0],
   ) => createOutboundSessionGuarded(params),
   getPendingSession: async (channel: string) => getPendingSession(channel),
-  findActiveSession: async (channel: string) => findActiveSession(channel),
+  findActiveSession: async (
+    channel: string,
+    filter?: Parameters<typeof findActiveSession>[1],
+  ) => findActiveSession(channel, filter),
 }));
 
 await initializeDb();

--- a/assistant/src/__tests__/trusted-contact-multichannel.test.ts
+++ b/assistant/src/__tests__/trusted-contact-multichannel.test.ts
@@ -92,7 +92,10 @@ mock.module("../channels/gateway-verification-sessions.js", () => ({
     params: Parameters<typeof createOutboundSessionGuarded>[0],
   ) => createOutboundSessionGuarded(params),
   getPendingSession: async (channel: string) => getPendingSession(channel),
-  findActiveSession: async (channel: string) => findActiveSession(channel),
+  findActiveSession: async (
+    channel: string,
+    filter?: Parameters<typeof findActiveSession>[1],
+  ) => findActiveSession(channel, filter),
 }));
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
 import {

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -59,6 +59,7 @@ import { getLogger } from "../util/logger.js";
 import {
   channelCanAddressOneReaderInBand,
   channelCanCompleteCodeHandshakeInDm,
+  channelDeliversToUserId,
   resolveDeliverCallbackUrlForChannel,
   resolveRequesterDeliveryTarget,
 } from "./guardian-channel-delivery.js";
@@ -1038,6 +1039,17 @@ const accessRequestResolver: GuardianRequestResolver = {
     // Non-voice approvals: mint an identity-bound verification session so the
     // requester can verify their identity. The raw secret transits back on
     // the decide response for daemon-owned delivery.
+    //
+    // The session is addressed to the requester, not to the room the request
+    // arrived in. On the channels that reach a person by user id, that room is
+    // one other people can read, so recording it as the destination describes
+    // somewhere the code is never sent. `expectedChatId` keeps the room, which
+    // is where the conversation is, and it is not a credential: whenever both
+    // identity fields are set, `checkIdentityMatch` requires the user match.
+    const destinationAddress = channelDeliversToUserId(channel)
+      ? requesterExternalUserId || requesterChatId
+      : requesterChatId;
+
     return {
       ok: true,
       aclOutcome: {
@@ -1046,7 +1058,7 @@ const accessRequestResolver: GuardianRequestResolver = {
         expectedExternalUserId: requesterExternalUserId,
         expectedChatId: requesterChatId,
         identityBindingStatus: "bound",
-        destinationAddress: requesterChatId,
+        destinationAddress,
         verificationPurpose: "trusted_contact",
       },
       persistFailureReason: "verification_session_mint_failed",
@@ -1090,7 +1102,9 @@ const accessRequestResolver: GuardianRequestResolver = {
     // Where the guardian's own copy goes when their channel has no in-band
     // route. Resolved from THEIR channel, never the requester's, or the code
     // is handed to the wrong transport.
-    const guardianDmUrl = resolveDeliverCallbackUrlForChannel(ctx.actor.channel);
+    const guardianDmUrl = resolveDeliverCallbackUrlForChannel(
+      ctx.actor.channel,
+    );
 
     // Guardian-facing label prefers the contact display name over the raw ID.
     const requesterLabel =
@@ -1280,7 +1294,10 @@ const accessRequestResolver: GuardianRequestResolver = {
     // silently suppressed it for both.
     let requesterNotified = false;
     let codeDelivered = false;
-    const codeText = guardianVerificationCodeText(requesterLabel, session.secret);
+    const codeText = guardianVerificationCodeText(
+      requesterLabel,
+      session.secret,
+    );
 
     if (guardianInBandContext) {
       codeDelivered = true;
@@ -1375,7 +1392,8 @@ const accessRequestResolver: GuardianRequestResolver = {
         // code straight to the requester. Everywhere else the guardian relays
         // it and the requester gets a courier notice.
         const requesterCodeDelivered =
-          channelCanCompleteCodeHandshakeInDm(channel) && requesterExternalUserId
+          channelCanCompleteCodeHandshakeInDm(channel) &&
+          requesterExternalUserId
             ? await deliverVerificationCodeToRequester({
                 replyCallbackUrl: requesterReplyUrl,
                 requesterExternalUserId,

--- a/assistant/src/channels/__tests__/gateway-verification-sessions.test.ts
+++ b/assistant/src/channels/__tests__/gateway-verification-sessions.test.ts
@@ -192,14 +192,14 @@ describe("createOutboundSessionConditional", () => {
     const result = await client.createOutboundSessionConditional({
       channel: "telegram",
       requireSourceSessionPending: "bootstrap-1",
-      ifNoneActive: true,
+      ifNoneActiveForExternalUserId: "user-1",
     });
 
     expect(ipcCalls[0]?.method).toBe("verification_sessions_create_outbound");
     expect(ipcCalls[0]?.params).toEqual({
       channel: "telegram",
       requireSourceSessionPending: "bootstrap-1",
-      ifNoneActive: true,
+      ifNoneActiveForExternalUserId: "user-1",
     });
     expect(result).toEqual(created);
   });
@@ -209,7 +209,7 @@ describe("createOutboundSessionConditional", () => {
 
     const result = await client.createOutboundSessionConditional({
       channel: "telegram",
-      ifNoneActive: true,
+      ifNoneActiveForExternalUserId: "user-1",
     });
 
     expect(result).toEqual({

--- a/assistant/src/channels/gateway-verification-sessions.ts
+++ b/assistant/src/channels/gateway-verification-sessions.ts
@@ -122,7 +122,8 @@ export async function createOutboundSession(
 
 /**
  * Guarded variant of `createOutboundSession` for callers passing an atomic
- * claim guard (`requireSourceSessionPending` / `ifNoneActive`). The gateway
+ * claim guard (`requireSourceSessionPending` /
+ * `ifNoneActiveForExternalUserId`). The gateway
  * evaluates the guard in the same synchronous section as the mint; a failed
  * guard returns a conflict marker instead of revoking the concurrent
  * winner's session. Throws when the gateway is unreachable (fail-closed).
@@ -160,10 +161,14 @@ export async function getPendingSession(
  */
 export async function findActiveSession(
   channel: string,
+  filter: {
+    expectedExternalUserId?: string;
+    verificationPurpose?: "guardian" | "trusted_contact";
+  } = {},
 ): Promise<VerificationSessionWire | null> {
   return callGateway(
     VERIFICATION_SESSIONS_IPC_METHODS.findActive,
-    { channel },
+    { channel, ...filter },
     SessionLookupIpcResponseSchema,
   );
 }

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -209,7 +209,10 @@ export async function getVerificationStatus(
   // restart and detect bootstrap completion.
   const [pendingSession, activeOutboundSession] = await Promise.all([
     getPendingSession(resolvedChannel),
-    findActiveSession(resolvedChannel),
+    // The guardian's own session. A channel can carry one per person
+    // verifying, so an unscoped read would report a requester's session as
+    // the guardian's pending verification.
+    findActiveSession(resolvedChannel, { verificationPurpose: "guardian" }),
   ]);
   const hasPendingChallenge = pendingSession != null;
   const outboundFields: Record<string, unknown> = {};

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -980,7 +980,12 @@ async function initiateVerificationChallenge(params: {
     try {
       [existingChallenge, existingSession] = await Promise.all([
         getPendingSession(sourceChannel),
-        findActiveSession(sourceChannel),
+        // Scoped to this sender. Reading the channel's latest and comparing
+        // its `expectedExternalUserId` misses their session whenever somebody
+        // else started more recently.
+        findActiveSession(sourceChannel, {
+          expectedExternalUserId: senderUserId,
+        }),
       ]);
     } catch (err) {
       log.warn(
@@ -992,8 +997,7 @@ async function initiateVerificationChallenge(params: {
     const senderHasPending =
       (existingChallenge &&
         existingChallenge.expectedExternalUserId === senderUserId) ||
-      (existingSession &&
-        existingSession.expectedExternalUserId === senderUserId);
+      existingSession != null;
     if (senderHasPending) {
       log.debug(
         {

--- a/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.test.ts
@@ -122,8 +122,9 @@ describe("handleGuardianActivationIntercept", () => {
       identityBindingStatus: "bound",
       destinationAddress: "chat-123",
       verificationPurpose: "guardian",
-      // No session was read: the create is a gateway-side create-if-absent.
-      ifNoneActive: true,
+      // No session was read for this sender, so the create is a
+      // sender-scoped create-if-absent.
+      ifNoneActiveForExternalUserId: "user-42",
     });
 
     // Verify deliverChannelReply was called with the welcome/verify message
@@ -259,10 +260,11 @@ describe("handleGuardianActivationIntercept", () => {
     const body = result!;
     expect(body).toEqual({ accepted: true, guardianActivation: true });
     expect(gatewaySessions.calls.create).toHaveLength(1);
-    // Deliberate supersede: the create-if-absent guard is omitted so the
-    // stale session gets revoked.
+    // Deliberate supersede of this sender's own stale session: the
+    // create-if-absent guard is omitted so it gets revoked.
     expect(
-      (gatewaySessions.calls.create[0] as Record<string, unknown>).ifNoneActive,
+      (gatewaySessions.calls.create[0] as Record<string, unknown>)
+        .ifNoneActiveForExternalUserId,
     ).toBeUndefined();
     expect(emitNotificationSignalCalls).toHaveLength(1);
   });

--- a/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.test.ts
@@ -244,7 +244,11 @@ describe("handleGuardianActivationIntercept", () => {
     expect(emitNotificationSignalCalls).toHaveLength(0);
   });
 
-  test("existing active session from different sender allows superseding", async () => {
+  test("someone else verifying does not turn this sender away", async () => {
+    // The read is scoped to the sender, so another person's live session is
+    // invisible here and this activation proceeds as a first one. Without the
+    // scope it would return the stranger's session and this sender would be
+    // told a verification is "already in progress" that is not theirs.
     gatewaySessions.state.activeSession = {
       id: "existing-sess",
       channel: "telegram",
@@ -255,17 +259,14 @@ describe("handleGuardianActivationIntercept", () => {
 
     const result = await handleGuardianActivationIntercept(makeParams());
 
-    // Should proceed and create a new session (superseding the stale one)
-    expect(result).not.toBeNull();
-    const body = result!;
-    expect(body).toEqual({ accepted: true, guardianActivation: true });
+    expect(result).toEqual({ accepted: true, guardianActivation: true });
     expect(gatewaySessions.calls.create).toHaveLength(1);
-    // Deliberate supersede of this sender's own stale session: the
-    // create-if-absent guard is omitted so it gets revoked.
+    // Carrying the guard is what keeps the stranger's code alive: the mint
+    // supersedes by bound identity, and this sender is not that identity.
     expect(
       (gatewaySessions.calls.create[0] as Record<string, unknown>)
         .ifNoneActiveForExternalUserId,
-    ).toBeUndefined();
+    ).toBe("user-42");
     expect(emitNotificationSignalCalls).toHaveLength(1);
   });
 

--- a/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.ts
@@ -133,7 +133,11 @@ export async function handleGuardianActivationIntercept(
   // normal pipeline handle the message.
   let existingSession: VerificationSessionWire | null;
   try {
-    existingSession = await findActiveSession(sourceChannel);
+    // This sender's own session. The channel may carry others, and what the
+    // guard below needs to know is whether THIS activation is a duplicate.
+    existingSession = await findActiveSession(sourceChannel, {
+      expectedExternalUserId: rawSenderId,
+    });
   } catch (err) {
     log.warn(
       { err, sourceChannel },
@@ -173,10 +177,12 @@ export async function handleGuardianActivationIntercept(
   }
 
   // ── Create verification session ──
-  // When the read above saw no active session, ifNoneActive makes the create
-  // a gateway-side create-if-absent: a concurrent activation that minted in
-  // between conflicts here instead of revoking that first code. A supersede
-  // (stale session from a different sender) deliberately omits the guard.
+  // When the read above saw no session for this sender, the sender-scoped
+  // create-if-absent makes the mint atomic: a concurrent activation from the
+  // same sender that minted in between conflicts here instead of revoking that
+  // first code. Scoped to the sender rather than the channel, because another
+  // person verifying at the same time is ordinary and must not block this.
+  // Superseding this sender's own stale session deliberately omits the guard.
   let sessionResult: Awaited<
     ReturnType<typeof createOutboundSessionConditional>
   >;
@@ -188,7 +194,9 @@ export async function handleGuardianActivationIntercept(
       identityBindingStatus: "bound",
       destinationAddress: conversationExternalId,
       verificationPurpose: "guardian",
-      ...(existingSession ? {} : { ifNoneActive: true }),
+      ...(existingSession
+        ? {}
+        : { ifNoneActiveForExternalUserId: rawSenderId }),
     });
   } catch (err) {
     log.warn(

--- a/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.ts
@@ -162,27 +162,18 @@ export async function handleGuardianActivationIntercept(
     return { accepted: true, guardianActivationPending: true };
   };
 
+  // The read is scoped to this sender, so anything it returned is this
+  // sender's own activation already in flight.
   if (existingSession) {
-    // Only block if the session belongs to the same sender. If a different
-    // user triggered the session, let this sender proceed (they'll supersede
-    // the stale session via createOutboundSession's revocation logic).
-    const sessionOwner =
-      existingSession.expectedExternalUserId ?? existingSession.expectedChatId;
-    if (
-      sessionOwner === rawSenderId ||
-      sessionOwner === conversationExternalId
-    ) {
-      return respondActivationPending();
-    }
+    return respondActivationPending();
   }
 
   // ── Create verification session ──
-  // When the read above saw no session for this sender, the sender-scoped
+  // The read above saw no session for this sender, so the sender-scoped
   // create-if-absent makes the mint atomic: a concurrent activation from the
   // same sender that minted in between conflicts here instead of revoking that
   // first code. Scoped to the sender rather than the channel, because another
   // person verifying at the same time is ordinary and must not block this.
-  // Superseding this sender's own stale session deliberately omits the guard.
   let sessionResult: Awaited<
     ReturnType<typeof createOutboundSessionConditional>
   >;
@@ -194,9 +185,7 @@ export async function handleGuardianActivationIntercept(
       identityBindingStatus: "bound",
       destinationAddress: conversationExternalId,
       verificationPurpose: "guardian",
-      ...(existingSession
-        ? {}
-        : { ifNoneActiveForExternalUserId: rawSenderId }),
+      ifNoneActiveForExternalUserId: rawSenderId,
     });
   } catch (err) {
     log.warn(

--- a/assistant/src/runtime/verification-outbound-actions.ts
+++ b/assistant/src/runtime/verification-outbound-actions.ts
@@ -875,7 +875,13 @@ export async function resendOutbound(
   const channel = params.channel;
   const originConversationId = params.originConversationId;
 
-  const session = await findActiveSession(channel);
+  // Scoped to the guardian's own flow. A channel can carry a live session per
+  // person verifying, so an unscoped lookup returns whoever started most
+  // recently, which on a busy channel is a requester rather than the guardian
+  // this resend is for.
+  const session = await findActiveSession(channel, {
+    verificationPurpose: "guardian",
+  });
   if (!session) {
     return {
       success: false,
@@ -1064,7 +1070,11 @@ export async function cancelOutbound(
 ): Promise<OutboundActionResult> {
   const channel = params.channel;
 
-  const session = await findActiveSession(channel);
+  // Scoped the same way as resend: cancelling the guardian's verification must
+  // not revoke a requester's live session.
+  const session = await findActiveSession(channel, {
+    verificationPurpose: "guardian",
+  });
   if (!session) {
     return {
       success: false,

--- a/assistant/src/tools/calls/call-start.ts
+++ b/assistant/src/tools/calls/call-start.ts
@@ -48,11 +48,14 @@ export async function executeCallStart(
 
   const requestedPhone = normalizePhoneNumber(parsed.phone_number);
   if (requestedPhone) {
-    const activeVoiceVerification = await findActiveSession("phone");
-    const verificationDestination =
-      activeVoiceVerification?.destinationAddress ??
-      activeVoiceVerification?.expectedPhoneE164;
-    if (verificationDestination === requestedPhone) {
+    // Scoped to the number being called. Voice sessions bind
+    // `expectedExternalUserId` to the E.164 number, and several can be live
+    // at once, so reading the latest and comparing would miss a verification
+    // for this number whenever another one started more recently.
+    const activeVoiceVerification = await findActiveSession("phone", {
+      expectedExternalUserId: requestedPhone,
+    });
+    if (activeVoiceVerification) {
       return {
         content: [
           "Error: A guardian voice verification call is already active for this number.",

--- a/gateway/src/__tests__/guardian-request-decide.test.ts
+++ b/gateway/src/__tests__/guardian-request-decide.test.ts
@@ -454,11 +454,11 @@ describe("decide — ATL-463 crash-window closure", () => {
   });
 
   test("a conflicted outbound-session mint rolls the approval back", async () => {
-    // A guarded mint against a channel that already has an
-    // active session conflicts — the approval must not commit codeless.
+    // A guarded mint for a requester who already has a live session
+    // conflicts. The approval must not commit codeless.
     const existing = createOutboundSession({
       channel: CHANNEL,
-      expectedExternalUserId: "someone-else",
+      expectedExternalUserId: SENDER,
       verificationPurpose: "trusted_contact",
     });
     const request = seedRequest();
@@ -473,6 +473,7 @@ describe("decide — ATL-463 crash-window closure", () => {
           channel: CHANNEL,
           expectedExternalUserId: SENDER,
           verificationPurpose: "trusted_contact",
+          ifNoneActiveForExternalUserId: SENDER,
         },
       }),
     ).rejects.toThrow("outbound session mint conflicted");

--- a/gateway/src/__tests__/guardian-request-decide.test.ts
+++ b/gateway/src/__tests__/guardian-request-decide.test.ts
@@ -69,13 +69,12 @@ const {
   guardianRequestDeliveries,
   guardianRequests,
 } = await import("../db/schema.js");
-const { createGuardianRequest } = await import("../db/guardian-request-store.js");
-const { decideGuardianRequest } = await import(
-  "../approvals/guardian-request-service.js"
-);
-const { createOutboundSession } = await import(
-  "../verification/session-service.js"
-);
+const { createGuardianRequest } =
+  await import("../db/guardian-request-store.js");
+const { decideGuardianRequest } =
+  await import("../approvals/guardian-request-service.js");
+const { createOutboundSession } =
+  await import("../verification/session-service.js");
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -254,7 +253,10 @@ describe("decide — per-outcome success", () => {
 
     const channels = channelRows();
     expect(channels).toHaveLength(1);
-    expect(channels[0]).toMatchObject({ status: "unverified", policy: "allow" });
+    expect(channels[0]).toMatchObject({
+      status: "unverified",
+      policy: "allow",
+    });
 
     const contact = getGatewayDb()
       .select()
@@ -452,7 +454,7 @@ describe("decide — ATL-463 crash-window closure", () => {
   });
 
   test("a conflicted outbound-session mint rolls the approval back", async () => {
-    // A guarded mint (ifNoneActive) against a channel that already has an
+    // A guarded mint against a channel that already has an
     // active session conflicts — the approval must not commit codeless.
     const existing = createOutboundSession({
       channel: CHANNEL,
@@ -471,7 +473,6 @@ describe("decide — ATL-463 crash-window closure", () => {
           channel: CHANNEL,
           expectedExternalUserId: SENDER,
           verificationPurpose: "trusted_contact",
-          ifNoneActive: true,
         },
       }),
     ).rejects.toThrow("outbound session mint conflicted");

--- a/gateway/src/__tests__/verification-session-actor-scope.test.ts
+++ b/gateway/src/__tests__/verification-session-actor-scope.test.ts
@@ -133,6 +133,66 @@ describe("an outbound mint supersedes only its own actor", () => {
   });
 });
 
+describe("channels that identify the actor by chat id", () => {
+  // Telegram guardian mints carry only `expectedChatId`, and
+  // `checkIdentityMatch` redeems those on a chat-id match. Keying the
+  // supersede on the user id alone would leave every earlier code on the
+  // chat live for its full TTL.
+  function mintChatKeyed(chatId: string) {
+    seq += 1;
+    return createOutboundSession({
+      id: `session-${seq}`,
+      channel: "telegram",
+      challengeHash: `hash-${seq}`,
+      expiresAt: Date.now() + TEN_MINUTES,
+      status: "awaiting_response",
+      expectedChatId: chatId,
+      identityBindingStatus: "bound",
+      destinationAddress: chatId,
+      verificationPurpose: "guardian",
+    });
+  }
+
+  test("a resend to the same chat supersedes the earlier code", () => {
+    const first = mintChatKeyed("123456789");
+    const second = mintChatKeyed("123456789");
+
+    expect(statusOf(first.id)).toBe("revoked");
+    expect(statusOf(second.id)).toBe("awaiting_response");
+    expect(
+      findPendingSessionByHash("telegram", first.challengeHash),
+    ).toBeNull();
+  });
+
+  test("a mint to another chat leaves the first alone", () => {
+    const first = mintChatKeyed("123456789");
+    mintChatKeyed("987654321");
+
+    expect(statusOf(first.id)).toBe("awaiting_response");
+  });
+
+  test("two people in one group chat keep their own codes", () => {
+    // A row carrying both fields redeems only on the user id, so a
+    // chat-keyed match must not reach it.
+    seq += 1;
+    const alice = createOutboundSession({
+      id: `session-${seq}`,
+      channel: "telegram",
+      challengeHash: `hash-${seq}`,
+      expiresAt: Date.now() + TEN_MINUTES,
+      status: "awaiting_response",
+      expectedExternalUserId: ALICE,
+      expectedChatId: "group-1",
+      identityBindingStatus: "bound",
+      verificationPurpose: "guardian",
+    });
+
+    mintChatKeyed("group-1");
+
+    expect(statusOf(alice.id)).toBe("awaiting_response");
+  });
+});
+
 describe("an outbound mint leaves inbound challenges alone", () => {
   test("an inbound challenge survives an unrelated outbound mint", () => {
     // Inbound sessions have their own supersede in `createInboundSession`, and
@@ -167,8 +227,12 @@ describe("findActiveSession", () => {
     const alice = mintOutboundFor(ALICE);
     const bob = mintOutboundFor(BOB);
 
-    expect(findActiveSession(CHANNEL, { expectedExternalUserId: ALICE })?.id).toBe(alice.id);
-    expect(findActiveSession(CHANNEL, { expectedExternalUserId: BOB })?.id).toBe(bob.id);
+    expect(
+      findActiveSession(CHANNEL, { expectedExternalUserId: ALICE })?.id,
+    ).toBe(alice.id);
+    expect(
+      findActiveSession(CHANNEL, { expectedExternalUserId: BOB })?.id,
+    ).toBe(bob.id);
   });
 
   test("unfiltered, returns the most recent regardless of actor", () => {
@@ -182,7 +246,9 @@ describe("findActiveSession", () => {
   test("returns null for an actor with nothing in flight", () => {
     mintOutboundFor(ALICE);
 
-    expect(findActiveSession(CHANNEL, { expectedExternalUserId: BOB })).toBeNull();
+    expect(
+      findActiveSession(CHANNEL, { expectedExternalUserId: BOB }),
+    ).toBeNull();
   });
 });
 

--- a/gateway/src/__tests__/verification-session-actor-scope.test.ts
+++ b/gateway/src/__tests__/verification-session-actor-scope.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Two people can be verifying on one channel at the same time.
+ *
+ * A fresh outbound session supersedes the same actor's prior one, so only
+ * their latest code is live and an intercepted earlier one is useless. It must
+ * not supersede anyone else's: two people's codes have no replay relationship,
+ * because `checkIdentityMatch` binds each to its own `expectedExternalUserId`,
+ * so A's code cannot be spent against B's session.
+ *
+ * The failure this guards is silent from both ends. The revoked holder is told
+ * only that their code is "invalid or has expired", which is the anti-oracle
+ * reply and deliberately says nothing, and the guardian who caused it by
+ * approving someone else sees no sign at all. So these assert what survives a
+ * mint rather than what the mint returned.
+ *
+ * The DB is real and file-backed, so a session's status after a mint is read
+ * back from the row rather than inferred.
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { eq } from "drizzle-orm";
+
+import "./test-preload.js";
+
+import {
+  createInboundSession,
+  createOutboundSession,
+  findActiveSession,
+  findPendingSessionByHash,
+  hasInterceptableSession,
+} from "../db/session-store.js";
+import {
+  getGatewayDb,
+  initGatewayDb,
+  resetGatewayDb,
+} from "../db/connection.js";
+import { channelVerificationSessions } from "../db/schema.js";
+
+const CHANNEL = "discord";
+/** Two requesters on the same community server. */
+const ALICE = "900000000000000001";
+const BOB = "900000000000000002";
+
+const TEN_MINUTES = 10 * 60 * 1000;
+
+let seq = 0;
+
+/** Mint an outbound session the way an approved access request does. */
+function mintOutboundFor(
+  actor: string | null,
+  overrides: {
+    channel?: string;
+    status?: "awaiting_response" | "pending_bootstrap";
+  } = {},
+) {
+  seq += 1;
+  return createOutboundSession({
+    id: `session-${seq}`,
+    channel: overrides.channel ?? CHANNEL,
+    challengeHash: `hash-${seq}`,
+    expiresAt: Date.now() + TEN_MINUTES,
+    status: overrides.status ?? "awaiting_response",
+    expectedExternalUserId: actor,
+    identityBindingStatus: "bound",
+    destinationAddress: actor,
+    verificationPurpose: "trusted_contact",
+  });
+}
+
+function statusOf(id: string): string | undefined {
+  return getGatewayDb()
+    .select({ status: channelVerificationSessions.status })
+    .from(channelVerificationSessions)
+    .where(eq(channelVerificationSessions.id, id))
+    .get()?.status;
+}
+
+beforeAll(async () => {
+  await initGatewayDb();
+});
+
+beforeEach(() => {
+  getGatewayDb().delete(channelVerificationSessions).run();
+});
+
+afterAll(() => {
+  resetGatewayDb();
+});
+
+describe("an outbound mint supersedes only its own actor", () => {
+  test("Bob's approval leaves Alice's code live", () => {
+    const alice = mintOutboundFor(ALICE);
+    const bob = mintOutboundFor(BOB);
+
+    expect(statusOf(alice.id)).toBe("awaiting_response");
+    expect(statusOf(bob.id)).toBe("awaiting_response");
+  });
+
+  test("Alice's code is still redeemable after Bob is approved", () => {
+    // The count above could pass while the consume path still refused the
+    // code, so this asserts the thing the requester actually experiences.
+    const alice = mintOutboundFor(ALICE);
+    mintOutboundFor(BOB);
+
+    const found = findPendingSessionByHash(CHANNEL, alice.challengeHash);
+    expect(found).not.toBeNull();
+    expect(found?.id).toBe(alice.id);
+  });
+
+  test("Alice re-requesting does supersede her own earlier code", () => {
+    // The replay window this exists to close. Two live codes for one identity
+    // means an intercepted first one is still spendable.
+    const first = mintOutboundFor(ALICE);
+    const second = mintOutboundFor(ALICE);
+
+    expect(statusOf(first.id)).toBe("revoked");
+    expect(statusOf(second.id)).toBe("awaiting_response");
+    expect(findPendingSessionByHash(CHANNEL, first.challengeHash)).toBeNull();
+  });
+
+  test("a mint on one channel leaves another channel alone", () => {
+    const onDiscord = mintOutboundFor(ALICE);
+    mintOutboundFor(ALICE, { channel: "slack" });
+
+    expect(statusOf(onDiscord.id)).toBe("awaiting_response");
+  });
+});
+
+describe("an outbound mint leaves inbound challenges alone", () => {
+  test("an inbound challenge survives an unrelated outbound mint", () => {
+    // Inbound sessions have their own supersede in `createInboundSession`, and
+    // an outbound mint has nothing to say about one.
+    seq += 1;
+    const inbound = createInboundSession({
+      id: `inbound-${seq}`,
+      channel: CHANNEL,
+      challengeHash: `inbound-hash-${seq}`,
+      expiresAt: Date.now() + TEN_MINUTES,
+    });
+
+    mintOutboundFor(ALICE);
+
+    expect(statusOf(inbound.id)).toBe("pending");
+  });
+});
+
+describe("a session with no actor supersedes nothing", () => {
+  test("a bootstrap mint does not revoke a bound session", () => {
+    // Bootstrap sessions carry no identity until the deep link is redeemed,
+    // and are claimed atomically by `requireSourceSessionPending` instead.
+    const bound = mintOutboundFor(ALICE);
+    mintOutboundFor(null, { status: "pending_bootstrap" });
+
+    expect(statusOf(bound.id)).toBe("awaiting_response");
+  });
+});
+
+describe("findActiveSession", () => {
+  test("returns one actor's session when asked for whose", () => {
+    const alice = mintOutboundFor(ALICE);
+    const bob = mintOutboundFor(BOB);
+
+    expect(findActiveSession(CHANNEL, { expectedExternalUserId: ALICE })?.id).toBe(alice.id);
+    expect(findActiveSession(CHANNEL, { expectedExternalUserId: BOB })?.id).toBe(bob.id);
+  });
+
+  test("unfiltered, returns the most recent regardless of actor", () => {
+    // The shape a caller gets when it does not say whose session it means.
+    mintOutboundFor(ALICE);
+    const bob = mintOutboundFor(BOB);
+
+    expect(findActiveSession(CHANNEL)?.id).toBe(bob.id);
+  });
+
+  test("returns null for an actor with nothing in flight", () => {
+    mintOutboundFor(ALICE);
+
+    expect(findActiveSession(CHANNEL, { expectedExternalUserId: BOB })).toBeNull();
+  });
+});
+
+describe("hasInterceptableSession", () => {
+  test("stays an any-match across several actors", () => {
+    // It gates the text-verification intercept, so it has to answer "could any
+    // message here be a code", not "is one particular person verifying".
+    mintOutboundFor(ALICE);
+    mintOutboundFor(BOB);
+
+    expect(hasInterceptableSession(CHANNEL)).toBe(true);
+  });
+});

--- a/gateway/src/db/__tests__/session-store.test.ts
+++ b/gateway/src/db/__tests__/session-store.test.ts
@@ -6,6 +6,7 @@ import { getGatewayDb, initGatewayDb, resetGatewayDb } from "../connection.js";
 import { channelVerificationSessions } from "../schema.js";
 import {
   bindSessionIdentity,
+  claimBootstrapSession,
   consumeSession,
   countRecentSendsToDestination,
   createInboundSession,
@@ -228,19 +229,55 @@ describe("createOutboundSession", () => {
 
     expect(getRow("bound")?.status).toBe("awaiting_response");
   });
+});
 
-  test("supersedeSessionId revokes the named session regardless of actor", () => {
-    // The bootstrap claim. Without this a redeemed deep-link token stays
-    // pending_bootstrap and is claimable a second time, because the claim
-    // guard passes on exactly that status.
-    insertRaw({ id: "bootstrap", status: "pending_bootstrap" });
+// ---------------------------------------------------------------------------
+// claimBootstrapSession
+// ---------------------------------------------------------------------------
 
-    createOutbound({
-      expectedExternalUserId: "u-1",
-      supersedeSessionId: "bootstrap",
+describe("claimBootstrapSession", () => {
+  test("the first claim wins and the row is revoked", () => {
+    insertRaw({
+      id: "bootstrap",
+      channel: "telegram",
+      status: "pending_bootstrap",
     });
 
+    expect(claimBootstrapSession("bootstrap", "telegram")).toBe(true);
     expect(getRow("bootstrap")?.status).toBe("revoked");
+  });
+
+  test("a second claim loses, so one deep link mints once", () => {
+    // The property the bootstrap handoff rests on. A blind revoke would
+    // report success here and let both claimants mint.
+    insertRaw({
+      id: "bootstrap",
+      channel: "telegram",
+      status: "pending_bootstrap",
+    });
+    claimBootstrapSession("bootstrap", "telegram");
+
+    expect(claimBootstrapSession("bootstrap", "telegram")).toBe(false);
+  });
+
+  test("a claim on another channel's row loses and leaves it alone", () => {
+    insertRaw({
+      id: "bootstrap",
+      channel: "telegram",
+      status: "pending_bootstrap",
+    });
+
+    expect(claimBootstrapSession("bootstrap", "slack")).toBe(false);
+    expect(getRow("bootstrap")?.status).toBe("pending_bootstrap");
+  });
+
+  test("a row that is not pending_bootstrap cannot be claimed", () => {
+    // Guards the reverse mistake: an unguarded claim would revoke a live
+    // awaiting_response code belonging to someone mid-verification.
+    insertRaw({ id: "live", channel: "telegram", status: "awaiting_response" });
+
+    expect(claimBootstrapSession("live", "telegram")).toBe(false);
+    expect(getRow("live")?.status).toBe("awaiting_response");
   });
 });
 

--- a/gateway/src/db/__tests__/session-store.test.ts
+++ b/gateway/src/db/__tests__/session-store.test.ts
@@ -175,23 +175,72 @@ describe("createOutboundSession", () => {
     expect(row?.bootstrapTokenHash).toBe("boot-hash");
   });
 
-  test("revokes prior interceptable sessions on the same channel", () => {
+  test("supersedes the same actor's prior outbound sessions", () => {
     for (const status of [
-      "pending",
       "pending_bootstrap",
       "awaiting_response",
     ] as SessionStatus[]) {
-      insertRaw({ id: `prior-${status}`, status });
+      insertRaw({
+        id: `mine-${status}`,
+        status,
+        expectedExternalUserId: "u-1",
+      });
     }
-    insertRaw({ id: "prior-consumed", status: "consumed" });
+    insertRaw({
+      id: "mine-consumed",
+      status: "consumed",
+      expectedExternalUserId: "u-1",
+    });
 
-    const session = createOutbound();
+    const session = createOutbound({ expectedExternalUserId: "u-1" });
 
-    expect(getRow("prior-pending")?.status).toBe("revoked");
-    expect(getRow("prior-pending_bootstrap")?.status).toBe("revoked");
-    expect(getRow("prior-awaiting_response")?.status).toBe("revoked");
-    expect(getRow("prior-consumed")?.status).toBe("consumed");
+    expect(getRow("mine-pending_bootstrap")?.status).toBe("revoked");
+    expect(getRow("mine-awaiting_response")?.status).toBe("revoked");
+    expect(getRow("mine-consumed")?.status).toBe("consumed");
     expect(getRow(session.id)?.status).toBe("awaiting_response");
+  });
+
+  test("leaves another actor's session and any inbound challenge alone", () => {
+    // The replay window is per identity, so a stranger's live code is not this
+    // mint's to take. Inbound challenges have their own supersede in
+    // createInboundSession and are not this function's business.
+    insertRaw({
+      id: "theirs",
+      status: "awaiting_response",
+      expectedExternalUserId: "u-2",
+    });
+    insertRaw({ id: "inbound", status: "pending" });
+
+    createOutbound({ expectedExternalUserId: "u-1" });
+
+    expect(getRow("theirs")?.status).toBe("awaiting_response");
+    expect(getRow("inbound")?.status).toBe("pending");
+  });
+
+  test("a mint with no actor supersedes nothing by actor", () => {
+    insertRaw({
+      id: "bound",
+      status: "awaiting_response",
+      expectedExternalUserId: "u-1",
+    });
+
+    createOutbound({ status: "pending_bootstrap" });
+
+    expect(getRow("bound")?.status).toBe("awaiting_response");
+  });
+
+  test("supersedeSessionId revokes the named session regardless of actor", () => {
+    // The bootstrap claim. Without this a redeemed deep-link token stays
+    // pending_bootstrap and is claimable a second time, because the claim
+    // guard passes on exactly that status.
+    insertRaw({ id: "bootstrap", status: "pending_bootstrap" });
+
+    createOutbound({
+      expectedExternalUserId: "u-1",
+      supersedeSessionId: "bootstrap",
+    });
+
+    expect(getRow("bootstrap")?.status).toBe("revoked");
   });
 });
 

--- a/gateway/src/db/session-store.ts
+++ b/gateway/src/db/session-store.ts
@@ -339,6 +339,33 @@ export function consumeSession(
   return changes > 0 ? { consumed: true, consumedAt } : { consumed: false };
 }
 
+/**
+ * Claim a `pending_bootstrap` session for the mint that redeemed its deep
+ * link, revoking it so the token cannot be spent twice. Status-guarded like
+ * {@link consumeSession}: only the first claimant wins, and a later attempt
+ * on an already-claimed row reports `false` instead of quietly succeeding.
+ *
+ * The claim has to name the row rather than match it by identity. A bootstrap
+ * row carries whichever identity was bound onto it last, so two people
+ * redeeming the same link leave it bound to the second one, and an
+ * identity-matched revoke would miss it for the first.
+ */
+export function claimBootstrapSession(id: string, channel: string): boolean {
+  const raw = (getGatewayDb() as unknown as { $client: Database }).$client;
+  return (
+    raw
+      .prepare(
+        `UPDATE channel_verification_sessions
+       SET status = 'revoked',
+           updated_at = ?
+       WHERE id = ?
+         AND channel = ?
+         AND status = 'pending_bootstrap'`,
+      )
+      .run(Date.now(), id, channel).changes > 0
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Outbound verification sessions (identity-bound)
 // ---------------------------------------------------------------------------
@@ -354,7 +381,7 @@ export function consumeSession(
  * codes.
  *
  * Returns null when the mint carries no identity at all, which is a bootstrap
- * session; those supersede by `supersedeSessionId` instead.
+ * session; those are claimed by `claimBootstrapSession` instead.
  */
 function sameBoundIdentity(params: {
   expectedExternalUserId?: string | null;
@@ -410,13 +437,8 @@ function sameBoundIdentity(params: {
  * inbound challenge.
  *
  * A session with no expected identity supersedes nothing by actor: a bootstrap
- * session has no actor until its deep link is redeemed.
- *
- * `supersedeSessionId` covers that last case: a mint claiming a bootstrap
- * session names it, and it is revoked here so the claim happens in the same
- * synchronous section as the insert. Without it a redeemed deep-link token
- * would stay `pending_bootstrap` and be claimable a second time, because the
- * claim guard passes on exactly that status.
+ * session has no actor until its deep link is redeemed. Those are claimed by
+ * `claimBootstrapSession` before the mint, not superseded by identity here.
  */
 export function createOutboundSession(params: {
   id: string;
@@ -434,18 +456,9 @@ export function createOutboundSession(params: {
   maxAttempts?: number;
   verificationPurpose?: VerificationPurpose;
   bootstrapTokenHash?: string | null;
-  /** A specific session this mint claims and therefore supersedes. */
-  supersedeSessionId?: string;
 }): VerificationSession {
   const db = getGatewayDb();
   const now = Date.now();
-
-  if (params.supersedeSessionId) {
-    db.update(channelVerificationSessions)
-      .set({ status: "revoked", updatedAt: now })
-      .where(eq(channelVerificationSessions.id, params.supersedeSessionId))
-      .run();
-  }
 
   const sameActor = sameBoundIdentity(params);
   if (sameActor) {

--- a/gateway/src/db/session-store.ts
+++ b/gateway/src/db/session-store.ts
@@ -43,6 +43,28 @@ const INTERCEPTABLE_STATUSES: SessionStatus[] = [
   "awaiting_response",
 ];
 
+/**
+ * Outbound statuses a fresh outbound session for the same actor supersedes.
+ *
+ * Deliberately excludes `pending`: that is an inbound challenge, superseded by
+ * `createInboundSession` and no business of an outbound mint.
+ */
+const OUTBOUND_LIVE_STATUSES: SessionStatus[] = [
+  "pending_bootstrap",
+  "awaiting_response",
+];
+
+/**
+ * Narrows a session lookup to the one the caller means.
+ *
+ * Both axes exist because a channel can carry several live sessions at once:
+ * one per person verifying, plus the guardian's own flow.
+ */
+export interface SessionFilter {
+  expectedExternalUserId?: string;
+  verificationPurpose?: VerificationPurpose;
+}
+
 const INTERCEPTABLE_STATUSES_SQL = INTERCEPTABLE_STATUSES.map(
   (s) => `'${s}'`,
 ).join(", ");
@@ -205,10 +227,15 @@ export function findPendingSessionForChannel(
 
 /**
  * Latest non-expired session for a channel in one of the given statuses.
+ *
+ * Several people can be verifying on a channel at once, and a guardian's own
+ * flow runs alongside theirs, so a caller that means "the session I am working
+ * on" has to say which. Unfiltered, it gets whoever started most recently.
  */
 export function findLatestSessionByStatuses(
   channel: string,
   statuses: SessionStatus[],
+  filter: SessionFilter = {},
 ): VerificationSession | null {
   const db = getGatewayDb();
 
@@ -220,6 +247,22 @@ export function findLatestSessionByStatuses(
         eq(channelVerificationSessions.channel, channel),
         inArray(channelVerificationSessions.status, statuses),
         gt(channelVerificationSessions.expiresAt, Date.now()),
+        ...(filter.expectedExternalUserId
+          ? [
+              eq(
+                channelVerificationSessions.expectedExternalUserId,
+                filter.expectedExternalUserId,
+              ),
+            ]
+          : []),
+        ...(filter.verificationPurpose
+          ? [
+              eq(
+                channelVerificationSessions.verificationPurpose,
+                filter.verificationPurpose,
+              ),
+            ]
+          : []),
       ),
     )
     .orderBy(desc(channelVerificationSessions.createdAt))
@@ -292,8 +335,26 @@ export function consumeSession(
 
 /**
  * Create an outbound verification session with expected-identity binding.
- * Auto-revokes prior pending/pending_bootstrap/awaiting_response sessions
- * for the same channel to close the replay window.
+ *
+ * Supersedes the actor's own prior outbound sessions, so only their latest
+ * code is live and an intercepted earlier one is useless.
+ *
+ * The supersede is scoped to the actor rather than the channel, because that
+ * is the scope the replay window has. Two people's codes have no replay
+ * relationship: `checkIdentityMatch` binds each to its own
+ * `expectedExternalUserId`, so A's code cannot be spent against B's session. A
+ * channel-wide revoke would take a stranger's live code away for no security
+ * benefit, and on a channel where several people can verify at once that is
+ * ordinary traffic rather than an edge case.
+ *
+ * Inbound (`pending`) sessions are left alone. They have their own supersede
+ * in `createInboundSession`, and an outbound mint has nothing to say about an
+ * inbound challenge.
+ *
+ * A session with no `expectedExternalUserId` supersedes nothing. Bootstrap
+ * sessions have no actor until the deep link is redeemed and are claimed
+ * atomically by `requireSourceSessionPending` instead; inbound sessions are
+ * not this function's business.
  */
 export function createOutboundSession(params: {
   id: string;
@@ -315,15 +376,21 @@ export function createOutboundSession(params: {
   const db = getGatewayDb();
   const now = Date.now();
 
-  db.update(channelVerificationSessions)
-    .set({ status: "revoked", updatedAt: now })
-    .where(
-      and(
-        eq(channelVerificationSessions.channel, params.channel),
-        inArray(channelVerificationSessions.status, INTERCEPTABLE_STATUSES),
-      ),
-    )
-    .run();
+  if (params.expectedExternalUserId) {
+    db.update(channelVerificationSessions)
+      .set({ status: "revoked", updatedAt: now })
+      .where(
+        and(
+          eq(channelVerificationSessions.channel, params.channel),
+          inArray(channelVerificationSessions.status, OUTBOUND_LIVE_STATUSES),
+          eq(
+            channelVerificationSessions.expectedExternalUserId,
+            params.expectedExternalUserId,
+          ),
+        ),
+      )
+      .run();
+  }
 
   const row = {
     id: params.id,
@@ -370,12 +437,18 @@ export function getSessionById(id: string): VerificationSession | null {
 /**
  * Find the most recent pending_bootstrap or awaiting_response session
  * for a given channel.
+ *
+ * Pass a filter when the caller means a particular session: an actor for one
+ * person's, a purpose to tell a guardian's own flow apart from a requester's.
+ * Unfiltered this returns whoever started most recently, which is right for a
+ * caller asking "is anything in flight here" and wrong for one about to
+ * resend, cancel, or report state back.
  */
-export function findActiveSession(channel: string): VerificationSession | null {
-  return findLatestSessionByStatuses(channel, [
-    "pending_bootstrap",
-    "awaiting_response",
-  ]);
+export function findActiveSession(
+  channel: string,
+  filter: SessionFilter = {},
+): VerificationSession | null {
+  return findLatestSessionByStatuses(channel, OUTBOUND_LIVE_STATUSES, filter);
 }
 
 /**

--- a/gateway/src/db/session-store.ts
+++ b/gateway/src/db/session-store.ts
@@ -8,7 +8,17 @@
  */
 
 import type { Database } from "bun:sqlite";
-import { and, count, desc, eq, gt, gte, inArray } from "drizzle-orm";
+import {
+  and,
+  count,
+  desc,
+  eq,
+  gt,
+  gte,
+  inArray,
+  isNull,
+  type SQL,
+} from "drizzle-orm";
 
 import type {
   IdentityBindingStatus,
@@ -334,6 +344,49 @@ export function consumeSession(
 // ---------------------------------------------------------------------------
 
 /**
+ * Match rows bound to the same identity a new mint is bound to.
+ *
+ * The key is whichever field `checkIdentityMatch` actually redeems on, in its
+ * precedence order, and the match requires the stored row to be keyed the same
+ * way. A row carrying both a chat id and a user id redeems only on the user id
+ * (`identity-match.ts` treats a shared chat id as insufficient), so it is not
+ * matched by a chat-keyed mint: two people in one group chat keep their own
+ * codes.
+ *
+ * Returns null when the mint carries no identity at all, which is a bootstrap
+ * session; those supersede by `supersedeSessionId` instead.
+ */
+function sameBoundIdentity(params: {
+  expectedExternalUserId?: string | null;
+  expectedChatId?: string | null;
+  expectedPhoneE164?: string | null;
+}): SQL | undefined {
+  if (params.expectedExternalUserId) {
+    return eq(
+      channelVerificationSessions.expectedExternalUserId,
+      params.expectedExternalUserId,
+    );
+  }
+  if (params.expectedPhoneE164) {
+    return and(
+      eq(
+        channelVerificationSessions.expectedPhoneE164,
+        params.expectedPhoneE164,
+      ),
+      isNull(channelVerificationSessions.expectedExternalUserId),
+    );
+  }
+  if (params.expectedChatId) {
+    return and(
+      eq(channelVerificationSessions.expectedChatId, params.expectedChatId),
+      isNull(channelVerificationSessions.expectedExternalUserId),
+      isNull(channelVerificationSessions.expectedPhoneE164),
+    );
+  }
+  return undefined;
+}
+
+/**
  * Create an outbound verification session with expected-identity binding.
  *
  * Supersedes the actor's own prior outbound sessions, so only their latest
@@ -341,20 +394,29 @@ export function consumeSession(
  *
  * The supersede is scoped to the actor rather than the channel, because that
  * is the scope the replay window has. Two people's codes have no replay
- * relationship: `checkIdentityMatch` binds each to its own
- * `expectedExternalUserId`, so A's code cannot be spent against B's session. A
- * channel-wide revoke would take a stranger's live code away for no security
- * benefit, and on a channel where several people can verify at once that is
- * ordinary traffic rather than an edge case.
+ * relationship: `checkIdentityMatch` binds each to its own expected identity,
+ * so A's code cannot be spent against B's session. A channel-wide revoke would
+ * take a stranger's live code away for no security benefit, and on a channel
+ * where several people can verify at once that is ordinary traffic rather than
+ * an edge case.
+ *
+ * Which field carries that identity is per-channel, so the scope is keyed on
+ * whichever one the consume path redeems on (`sameBoundIdentity`). Telegram
+ * guardian mints carry only a chat id, and keying on the user id alone would
+ * leave every earlier code on that chat live for its full TTL.
  *
  * Inbound (`pending`) sessions are left alone. They have their own supersede
  * in `createInboundSession`, and an outbound mint has nothing to say about an
  * inbound challenge.
  *
- * A session with no `expectedExternalUserId` supersedes nothing. Bootstrap
- * sessions have no actor until the deep link is redeemed and are claimed
- * atomically by `requireSourceSessionPending` instead; inbound sessions are
- * not this function's business.
+ * A session with no expected identity supersedes nothing by actor: a bootstrap
+ * session has no actor until its deep link is redeemed.
+ *
+ * `supersedeSessionId` covers that last case: a mint claiming a bootstrap
+ * session names it, and it is revoked here so the claim happens in the same
+ * synchronous section as the insert. Without it a redeemed deep-link token
+ * would stay `pending_bootstrap` and be claimable a second time, because the
+ * claim guard passes on exactly that status.
  */
 export function createOutboundSession(params: {
   id: string;
@@ -372,21 +434,28 @@ export function createOutboundSession(params: {
   maxAttempts?: number;
   verificationPurpose?: VerificationPurpose;
   bootstrapTokenHash?: string | null;
+  /** A specific session this mint claims and therefore supersedes. */
+  supersedeSessionId?: string;
 }): VerificationSession {
   const db = getGatewayDb();
   const now = Date.now();
 
-  if (params.expectedExternalUserId) {
+  if (params.supersedeSessionId) {
+    db.update(channelVerificationSessions)
+      .set({ status: "revoked", updatedAt: now })
+      .where(eq(channelVerificationSessions.id, params.supersedeSessionId))
+      .run();
+  }
+
+  const sameActor = sameBoundIdentity(params);
+  if (sameActor) {
     db.update(channelVerificationSessions)
       .set({ status: "revoked", updatedAt: now })
       .where(
         and(
           eq(channelVerificationSessions.channel, params.channel),
           inArray(channelVerificationSessions.status, OUTBOUND_LIVE_STATUSES),
-          eq(
-            channelVerificationSessions.expectedExternalUserId,
-            params.expectedExternalUserId,
-          ),
+          sameActor,
         ),
       )
       .run();

--- a/gateway/src/ipc/__tests__/verification-session-routes.test.ts
+++ b/gateway/src/ipc/__tests__/verification-session-routes.test.ts
@@ -256,45 +256,7 @@ describe("verification_sessions_create_outbound", () => {
     ).toEqual({ conflict: true, reason: "source_session_not_pending" });
   });
 
-  test("ifNoneActive: conflicts when an active session exists, without minting or revoking it", async () => {
-    const first = CreateOutboundSessionIpcResponseSchema.parse(
-      await call(METHODS.createOutbound, {
-        channel: "telegram",
-        expectedExternalUserId: "tg-user-1",
-        expectedChatId: "tg-chat-1",
-      }),
-    );
-
-    const second = await call(METHODS.createOutbound, {
-      channel: "telegram",
-      expectedExternalUserId: "tg-user-2",
-      expectedChatId: "tg-chat-2",
-      ifNoneActive: true,
-    });
-    expect(second).toEqual({
-      conflict: true,
-      reason: "active_session_exists",
-    });
-
-    // The first activation's code is still redeemable.
-    expect(getRow(first.sessionId)?.status).toBe("awaiting_response");
-    expect(
-      getGatewayDb().select().from(channelVerificationSessions).all(),
-    ).toHaveLength(1);
-  });
-
-  test("ifNoneActive: mints normally when the channel has no active session", async () => {
-    const result = CreateOutboundSessionIpcResponseSchema.parse(
-      await call(METHODS.createOutbound, {
-        channel: "telegram",
-        expectedChatId: "tg-chat-1",
-        ifNoneActive: true,
-      }),
-    );
-    expect(getRow(result.sessionId)?.status).toBe("awaiting_response");
-  });
-
-  test("ifNoneActiveForExternalUserId: conflicts on same sender, supersedes a different sender", async () => {
+  test("ifNoneActiveForExternalUserId: conflicts on same sender, leaves a different sender alone", async () => {
     const first = CreateOutboundSessionIpcResponseSchema.parse(
       await call(METHODS.createOutbound, {
         channel: "slack",
@@ -314,7 +276,8 @@ describe("verification_sessions_create_outbound", () => {
     ).toEqual({ conflict: true, reason: "active_session_exists" });
     expect(getRow(first.sessionId)?.status).toBe("awaiting_response");
 
-    // Different sender: supersedes (revoke-prior semantics apply).
+    // Different sender: mints alongside. Two people's codes have no replay
+    // relationship, so the first one's stays live and both are redeemable.
     const second = CreateOutboundSessionIpcResponseSchema.parse(
       await call(METHODS.createOutbound, {
         channel: "slack",
@@ -324,7 +287,7 @@ describe("verification_sessions_create_outbound", () => {
       }),
     );
     expect(getRow(second.sessionId)?.status).toBe("awaiting_response");
-    expect(getRow(first.sessionId)?.status).toBe("revoked");
+    expect(getRow(first.sessionId)?.status).toBe("awaiting_response");
   });
 });
 

--- a/gateway/src/ipc/__tests__/verification-session-routes.test.ts
+++ b/gateway/src/ipc/__tests__/verification-session-routes.test.ts
@@ -234,6 +234,55 @@ describe("verification_sessions_create_outbound", () => {
     ).toHaveLength(rowsBefore);
   });
 
+  test("requireSourceSessionPending: two senders redeeming one deep link, only the first mints", async () => {
+    // Both open the same `gv_` link and their identity binds interleave, so
+    // by the time the first one mints the source row carries the second
+    // one's identity. The claim is single-use because the mint revokes the
+    // row it named, not because that row happens to match the minter.
+    const bootstrap = CreateOutboundSessionIpcResponseSchema.parse(
+      await call(METHODS.createOutbound, {
+        channel: "telegram",
+        identityBindingStatus: "pending_bootstrap",
+        bootstrapTokenHash: hashVerificationSecret("shared-deep-link"),
+      }),
+    );
+
+    await call(METHODS.bindIdentity, {
+      sessionId: bootstrap.sessionId,
+      externalUserId: "tg-user-A",
+      chatId: "tg-chat-A",
+    });
+    await call(METHODS.bindIdentity, {
+      sessionId: bootstrap.sessionId,
+      externalUserId: "tg-user-B",
+      chatId: "tg-chat-B",
+    });
+
+    const first = CreateOutboundSessionIpcResponseSchema.parse(
+      await call(METHODS.createOutbound, {
+        channel: "telegram",
+        expectedExternalUserId: "tg-user-A",
+        expectedChatId: "tg-chat-A",
+        identityBindingStatus: "bound",
+        requireSourceSessionPending: bootstrap.sessionId,
+      }),
+    );
+    expect(getRow(bootstrap.sessionId)?.status).toBe("revoked");
+
+    const second = await call(METHODS.createOutbound, {
+      channel: "telegram",
+      expectedExternalUserId: "tg-user-B",
+      expectedChatId: "tg-chat-B",
+      identityBindingStatus: "bound",
+      requireSourceSessionPending: bootstrap.sessionId,
+    });
+    expect(second).toEqual({
+      conflict: true,
+      reason: "source_session_not_pending",
+    });
+    expect(getRow(first.sessionId)?.status).toBe("awaiting_response");
+  });
+
   test("requireSourceSessionPending: unknown or cross-channel source conflicts", async () => {
     expect(
       await call(METHODS.createOutbound, {

--- a/gateway/src/ipc/verification-session-handlers.ts
+++ b/gateway/src/ipc/verification-session-handlers.ts
@@ -67,7 +67,8 @@ export const verificationSessionRoutes: IpcRoute[] = [
   {
     // Mint an outbound session (numeric code when identity is bound,
     // 32-byte hex for pending_bootstrap); secret transits for delivery.
-    // Optional claim guards (requireSourceSessionPending / ifNoneActive)
+    // Optional claim guards (requireSourceSessionPending /
+    // ifNoneActiveForExternalUserId)
     // run atomically with the mint; a failed guard returns a conflict
     // marker instead of revoking the winner's session.
     method: VERIFICATION_SESSIONS_IPC_METHODS.createOutbound,
@@ -88,12 +89,16 @@ export const verificationSessionRoutes: IpcRoute[] = [
   },
   {
     // Most recent active outbound session (pending_bootstrap /
-    // awaiting_response).
+    // awaiting_response), narrowed by the caller's filter when it named one.
     method: VERIFICATION_SESSIONS_IPC_METHODS.findActive,
     schema: FindActiveSessionIpcParamsSchema,
     handler: (params?: Record<string, unknown>) => {
-      const { channel } = FindActiveSessionIpcParamsSchema.parse(params);
-      return findActiveSession(channel);
+      const { channel, expectedExternalUserId, verificationPurpose } =
+        FindActiveSessionIpcParamsSchema.parse(params);
+      return findActiveSession(channel, {
+        ...(expectedExternalUserId ? { expectedExternalUserId } : {}),
+        ...(verificationPurpose ? { verificationPurpose } : {}),
+      });
     },
   },
   {

--- a/gateway/src/verification/session-service.ts
+++ b/gateway/src/verification/session-service.ts
@@ -140,6 +140,8 @@ export function createOutboundSession(params: {
   verificationPurpose?: VerificationPurpose;
   bootstrapTokenHash?: string;
   sessionId?: string;
+  /** A specific session this mint claims and therefore supersedes. */
+  supersedeSessionId?: string;
 }): CreateOutboundSessionResult {
   const isUnbound = params.identityBindingStatus === "pending_bootstrap";
   const secret = isUnbound
@@ -164,6 +166,7 @@ export function createOutboundSession(params: {
     maxAttempts: params.maxAttempts,
     verificationPurpose: params.verificationPurpose,
     bootstrapTokenHash: params.bootstrapTokenHash,
+    supersedeSessionId: params.supersedeSessionId,
   });
 
   return {
@@ -192,12 +195,15 @@ export type GuardedCreateOutboundSessionResult =
  * winner's freshly minted code.
  *
  * - `requireSourceSessionPending`: the bootstrap handoff claim. The source
- *   session must still be `pending_bootstrap` (a prior mint revokes it, so a
- *   second claim of the same deep-link token conflicts).
+ *   session must still be `pending_bootstrap`, and the mint revokes it by id
+ *   in the same section, so a second claim of the same deep-link token
+ *   conflicts. Naming the row is what makes the claim single-use: the
+ *   supersede-by-identity below cannot do it, because a bootstrap row carries
+ *   whichever identity was bound onto it last.
  * - `ifNoneActiveForExternalUserId`: sender-scoped create-if-absent.
  *   Conflicts only when the channel's active session is bound to the same
- *   expectedExternalUserId — a different sender's session may be superseded
- *   (the unguarded revoke-prior semantics apply).
+ *   expectedExternalUserId. A different sender's session is neither a
+ *   conflict nor superseded: it is not this sender's to take.
  */
 export function createOutboundSessionGuarded(
   params: Parameters<typeof createOutboundSession>[0] & {
@@ -229,7 +235,11 @@ export function createOutboundSessionGuarded(
     }
   }
 
-  return createOutboundSession(params);
+  return createOutboundSession(
+    params.requireSourceSessionPending
+      ? { ...params, supersedeSessionId: params.requireSourceSessionPending }
+      : params,
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/gateway/src/verification/session-service.ts
+++ b/gateway/src/verification/session-service.ts
@@ -194,8 +194,6 @@ export type GuardedCreateOutboundSessionResult =
  * - `requireSourceSessionPending`: the bootstrap handoff claim. The source
  *   session must still be `pending_bootstrap` (a prior mint revokes it, so a
  *   second claim of the same deep-link token conflicts).
- * - `ifNoneActive`: create-if-absent. Conflicts when the channel already has
- *   an active (pending_bootstrap / awaiting_response, non-expired) session.
  * - `ifNoneActiveForExternalUserId`: sender-scoped create-if-absent.
  *   Conflicts only when the channel's active session is bound to the same
  *   expectedExternalUserId — a different sender's session may be superseded
@@ -204,7 +202,6 @@ export type GuardedCreateOutboundSessionResult =
 export function createOutboundSessionGuarded(
   params: Parameters<typeof createOutboundSession>[0] & {
     requireSourceSessionPending?: string;
-    ifNoneActive?: boolean;
     ifNoneActiveForExternalUserId?: string;
   },
 ): GuardedCreateOutboundSessionResult {
@@ -219,16 +216,15 @@ export function createOutboundSessionGuarded(
     }
   }
 
-  if (params.ifNoneActive && findActiveSession(params.channel) !== null) {
-    return { conflict: true, reason: "active_session_exists" };
-  }
-
   if (params.ifNoneActiveForExternalUserId !== undefined) {
-    const active = findActiveSession(params.channel);
-    if (
-      active !== null &&
-      active.expectedExternalUserId === params.ifNoneActiveForExternalUserId
-    ) {
+    // Scoped to the actor rather than reading the channel's latest and
+    // comparing: a channel can carry several live sessions, so the latest is
+    // often somebody else's, and this guard would then miss the very session
+    // it exists to find.
+    const active = findActiveSession(params.channel, {
+      expectedExternalUserId: params.ifNoneActiveForExternalUserId,
+    });
+    if (active !== null) {
       return { conflict: true, reason: "active_session_exists" };
     }
   }

--- a/gateway/src/verification/session-service.ts
+++ b/gateway/src/verification/session-service.ts
@@ -41,12 +41,12 @@ import type {
   VerificationPurpose,
 } from "../db/session-store.js";
 import {
+  claimBootstrapSession,
   consumeSession,
   createInboundSession,
   createOutboundSession as storeCreateOutboundSession,
   findActiveSession,
   findPendingSessionByHash,
-  getSessionById,
   updateSessionStatus,
 } from "../db/session-store.js";
 import { getLogger } from "../logger.js";
@@ -140,8 +140,6 @@ export function createOutboundSession(params: {
   verificationPurpose?: VerificationPurpose;
   bootstrapTokenHash?: string;
   sessionId?: string;
-  /** A specific session this mint claims and therefore supersedes. */
-  supersedeSessionId?: string;
 }): CreateOutboundSessionResult {
   const isUnbound = params.identityBindingStatus === "pending_bootstrap";
   const secret = isUnbound
@@ -166,7 +164,6 @@ export function createOutboundSession(params: {
     maxAttempts: params.maxAttempts,
     verificationPurpose: params.verificationPurpose,
     bootstrapTokenHash: params.bootstrapTokenHash,
-    supersedeSessionId: params.supersedeSessionId,
   });
 
   return {
@@ -194,12 +191,12 @@ export type GuardedCreateOutboundSessionResult =
  * mints; the rest get a machine-readable conflict instead of revoking the
  * winner's freshly minted code.
  *
- * - `requireSourceSessionPending`: the bootstrap handoff claim. The source
- *   session must still be `pending_bootstrap`, and the mint revokes it by id
- *   in the same section, so a second claim of the same deep-link token
- *   conflicts. Naming the row is what makes the claim single-use: the
- *   supersede-by-identity below cannot do it, because a bootstrap row carries
- *   whichever identity was bound onto it last.
+ * - `requireSourceSessionPending`: the bootstrap handoff claim, a single
+ *   status-guarded UPDATE (`claimBootstrapSession`) rather than a read
+ *   followed by a write. Winning the UPDATE is the guard, so a second claim
+ *   of the same deep-link token conflicts. The claim names the row: an
+ *   identity-matched revoke cannot make it single-use, because a bootstrap
+ *   row carries whichever identity was bound onto it last.
  * - `ifNoneActiveForExternalUserId`: sender-scoped create-if-absent.
  *   Conflicts only when the channel's active session is bound to the same
  *   expectedExternalUserId. A different sender's session is neither a
@@ -211,17 +208,6 @@ export function createOutboundSessionGuarded(
     ifNoneActiveForExternalUserId?: string;
   },
 ): GuardedCreateOutboundSessionResult {
-  if (params.requireSourceSessionPending !== undefined) {
-    const source = getSessionById(params.requireSourceSessionPending);
-    if (
-      !source ||
-      source.channel !== params.channel ||
-      source.status !== "pending_bootstrap"
-    ) {
-      return { conflict: true, reason: "source_session_not_pending" };
-    }
-  }
-
   if (params.ifNoneActiveForExternalUserId !== undefined) {
     // Scoped to the actor rather than reading the channel's latest and
     // comparing: a channel can carry several live sessions, so the latest is
@@ -235,11 +221,16 @@ export function createOutboundSessionGuarded(
     }
   }
 
-  return createOutboundSession(
-    params.requireSourceSessionPending
-      ? { ...params, supersedeSessionId: params.requireSourceSessionPending }
-      : params,
-  );
+  // Claimed after the other guard, so a mint that is going to conflict
+  // anyway does not burn a bootstrap token on its way out.
+  if (
+    params.requireSourceSessionPending !== undefined &&
+    !claimBootstrapSession(params.requireSourceSessionPending, params.channel)
+  ) {
+    return { conflict: true, reason: "source_session_not_pending" };
+  }
+
+  return createOutboundSession(params);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway-client/src/verification-session-contract.ts
+++ b/packages/gateway-client/src/verification-session-contract.ts
@@ -211,7 +211,6 @@ export const CreateOutboundSessionIpcParamsSchema = z.object({
   requireSourceSessionPending: z.string().min(1).optional(),
   // Mint only if the channel has no active (pending_bootstrap /
   // awaiting_response, non-expired) session.
-  ifNoneActive: z.boolean().optional(),
   // Sender-scoped variant: mint unless the channel's active session is bound
   // to this expectedExternalUserId (a different sender may supersede).
   ifNoneActiveForExternalUserId: z.string().min(1).optional(),
@@ -240,7 +239,8 @@ export type CreateOutboundSessionIpcResponse = z.infer<
 
 /**
  * Conflict marker returned by `verification_sessions_create_outbound` when a
- * claim guard (`requireSourceSessionPending` / `ifNoneActive`) fails. Only
+ * claim guard (`requireSourceSessionPending` /
+ * `ifNoneActiveForExternalUserId`) fails. Only
  * reachable when a guard was passed — legacy callers never see this shape.
  */
 export const CreateOutboundSessionConflictSchema = z.object({
@@ -277,7 +277,17 @@ export type GetPendingSessionIpcParams = z.infer<
  * Request for `verification_sessions_find_active` (statuses
  * `pending_bootstrap`/`awaiting_response`, newest first).
  */
-export const FindActiveSessionIpcParamsSchema = ChannelOnlyIpcParamsSchema;
+export const FindActiveSessionIpcParamsSchema =
+  ChannelOnlyIpcParamsSchema.extend({
+    /**
+     * Narrows the lookup to one session. A channel can carry several live
+     * sessions at once, one per person verifying plus the guardian's own flow,
+     * so a caller that means a particular one has to say which. Omitted, the
+     * lookup returns whoever started most recently.
+     */
+    expectedExternalUserId: z.string().min(1).optional(),
+    verificationPurpose: VerificationPurposeSchema.optional(),
+  });
 
 export type FindActiveSessionIpcParams = z.infer<
   typeof FindActiveSessionIpcParamsSchema


### PR DESCRIPTION
## TL;DR

A channel held one live verification session **for everybody**. Approving a second person revoked the first person's code, and they were told only that it was "invalid or has expired" — the anti-oracle reply, which by design tells them nothing.

Fixes [LUM-3111](https://linear.app/vellum/issue/LUM-3111). Fixes [LUM-3110](https://linear.app/vellum/issue/LUM-3110) (folded in: same mint, same class of problem).

## Before / after

| | Before | After |
| --- | --- | --- |
| Two requesters approved within 10 min | The first one's code silently dies | Both work |
| An outbound mint vs. an in-flight inbound challenge | Challenge killed as collateral | Untouched |
| Guardian resend / cancel | Acts on whoever started most recently | Acts on the guardian's own session |
| Guardian verification status | Can report a requester's session as the guardian's | Reports the guardian's |
| `call_start` vs. a number being verified | Reads the latest and compares | Asks about that number |
| Same person re-requesting a code | Supersedes their own | Unchanged |

## Why this is safe to narrow

The revoke's stated job, in both session creators, is that only the latest session stays valid so an intercepted earlier code is useless. **That reasoning is entirely within one identity.** Two people's codes have no replay relationship: `checkIdentityMatch` binds each to its own `expectedExternalUserId`, so A's code cannot be spent against B's session. Scoping the revoke to the actor preserves the guarantee rather than trading it away.

The inbound path already worked this way. `createInboundSession` supersedes only `status = "pending"` — its own kind, nothing else. `createOutboundSession` was the outlier, revoking all three interceptable statuses for anyone, which is also why it was killing inbound challenges that had nothing to do with it.

## The part that made this bigger than the revoke

Making concurrent sessions possible turns every unscoped lookup into a coin flip, where before there was only ever one session and "the active session" was unambiguous. **Scoping the revoke alone would have traded one bug for a wider one.** So `findActiveSession` takes a filter (actor, purpose), threaded through the IPC contract, and each caller says what it means:

- **resend / cancel** → the guardian flow. That is the only thing their route *can* mean: its body is `{channel, originConversationId}`, with no way to name a contact, and it is listed among the guardian-only control-plane endpoints in `verification-control-plane-policy.ts`.
- **guardian status read** → the guardian flow, so it stops reporting a requester's session.
- **`call_start`** → the number being called. Voice sessions bind `expectedExternalUserId` to the E.164 number, so this is a direct question instead of read-latest-and-compare.
- **self-verify challenge** and **guardian activation** → their own sender. Both previously read the channel's latest and compared its `expectedExternalUserId`, which misses the session they are looking for whenever somebody else started more recently.

The `ifNoneActiveForExternalUserId` guard in `session-service.ts` had the same read-then-compare shape and would have silently stopped matching.

## One removal

`ifNoneActive` (channel-wide create-if-absent) is gone. Under per-actor sessions it would conflict on a stranger's session and block a legitimate mint, so it is not merely unused but actively wrong; its single caller is now the sender-scoped guard. Leaving it would be the same trap as the dead hook removed in #40415: an option that reads as available and is incorrect to reach for.

Two tests that pinned its behaviour are removed, and one that asserted a different sender **is** superseded now asserts the opposite, which is the behaviour change this PR is.

## Behaviour change worth naming

Today an unfiltered resend after a *contact* verification resends that contact's code, because theirs is the active session. That now returns `no_active_session`.

This is a purpose-conversion hazard the scoping closes, not a convenience being dropped. The resend path hardcodes `verificationPurpose: "guardian"`, and the consume path branches on that purpose: a code minted for a contact, resent through the guardian route, would consume as a guardian activation and run `createGuardianBinding` for that contact unless another guardian already held the channel. It is not remotely exploitable, since the route is guardian-gated, but "resend" quietly promoting a contact's verification into a guardian one is a real footgun.

No client offers a contact resend, so nothing breaks. If contact resend becomes real, the fix is a `contactChannelId` on the route rather than an ambiguous lookup.

## What the supersede is keyed on

An outbound mint supersedes only sessions bound to the same identity, and the identity is whichever field the consume path redeems on, in `checkIdentityMatch`'s precedence order:

| New mint carries | Supersedes rows where |
| --- | --- |
| `expectedExternalUserId` | same user id |
| phone only | same phone, and no user id |
| chat id only | same chat id, and no user id or phone |
| nothing (bootstrap) | nothing, claimed by id instead |

Keying on `expectedExternalUserId` alone is wrong: guardian Telegram start and resend, and the trusted-contact Telegram and Slack paths whose contact address is the chat id, all identify the recipient by chat id. Skipping the revoke for them would leave every earlier code on that chat redeemable for its full TTL.

Requiring the stored row to be keyed the same way is what keeps the group-chat case correct: a row carrying both a chat id and a user id redeems only on the user id, so a chat-keyed mint does not reach it and two people in one group chat keep their own codes.

Bootstrap sessions carry no identity until their deep link is redeemed, so they are claimed by id (`supersedeSessionId`) rather than matched. That is not an optimisation: a bootstrap row carries whichever identity was bound onto it last, so an identity-matched revoke cannot make a one-time deep link single-use when two people redeem it concurrently.

## Tests

`verification-session-actor-scope.test.ts` runs against a real file-backed gateway DB, so a session's status after a mint is read back from the row. It asserts what *survives* a mint rather than what the mint returned, because this failure is silent from both ends: the revoked holder gets the anti-oracle message, and the guardian who caused it sees nothing at all.

Cases: Bob's approval leaves Alice's code live **and still redeemable through the consume lookup**; Alice re-requesting still supersedes her own; a resend to the same chat supersedes on a chat-addressed channel, while a mint to a different chat does not; two people in one group chat keep their own codes; an inbound challenge survives an outbound mint; an actor-less bootstrap mint supersedes nothing; `findActiveSession` filtered and unfiltered; `hasInterceptableSession` stays an any-match, because it gates the text intercept and must ask "could any message here be a code".

`verification-session-routes.test.ts` adds the concurrent deep-link case: two senders whose identity binds interleave, only the first mints.

The test doubles now honour the caller's filter (the shared stub plus three suite-local forwarders). Before, sender-scoped assertions passed against a lookup that could not have found anything, which is how a scope regression typechecked and read as covered.

Local test runs are blocked by a standing hook in this environment, so this was verified by typecheck, lint, `/simplify` and format across all three packages, and is being read from CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40424" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
