### PR TITLE
fix(cli): stop the remote-web edge blanking on a cold load

### DIFF
--- a/cli/src/__tests__/nginx-ingress.test.ts
+++ b/cli/src/__tests__/nginx-ingress.test.ts
@@ -80,6 +80,7 @@ afterAll(() => {
 
 import {
   buildIngressNginxConfig,
+  hasIpv6Loopback,
   buildRemoteWebIndexHtml,
   cloudWebHubUrl,
   ensureTunnelEdge,
@@ -165,16 +166,28 @@ describe("buildIngressNginxConfig", () => {
     },
   });
 
-  test("listens on both loopback families, and nothing else", () => {
-    // A tunnel agent pointed at "localhost" reaches ::1 first on macOS, so an
-    // IPv4-only bind refuses whichever share of a burst resolves that way.
+  test("listens on loopback only", () => {
     expect(conf).toContain("listen 127.0.0.1:7840;");
-    expect(conf).toContain("listen [::1]:7840;");
     const listens = conf.match(/listen [^;]+;/g) ?? [];
     expect(listens.length).toBeGreaterThan(0);
     for (const directive of listens) {
       expect(directive).toMatch(/127\.0\.0\.1|\[::1\]/);
     }
+  });
+
+  test("adds the IPv6 loopback listener only where ::1 exists", () => {
+    // A tunnel agent pointed at "localhost" reaches ::1 first on macOS, so an
+    // IPv4-only bind refuses whichever share of a burst resolves that way.
+    // Emitting it unconditionally would make nginx exit on an IPv6-less host.
+    const withIpv6 = buildIngressNginxConfig({
+      gatewayPort: 7830,
+      listenPort: 7840,
+      ipv6Loopback: true,
+    });
+    expect(withIpv6).toContain("listen 127.0.0.1:7840;");
+    expect(withIpv6).toContain("listen [::1]:7840;");
+
+    expect(conf).not.toContain("[::1]");
   });
 
   test("emits relative redirects so a fronting proxy keeps scheme and port", () => {
@@ -693,19 +706,24 @@ const PRODUCTION_HUB_URL = "https://www.vellum.ai/assistant";
 
 /**
  * Mirror of the SPA config fingerprint the edge records in its ingress state
- * (sha256 over the injected config JSON). Pins both the injected config
- * shape and the hash format; assumes the production-pinned environment.
+ * (sha256 over the edge template version and the injected config JSON). Pins
+ * both the injected config shape and the hash format; assumes the
+ * production-pinned environment. Bump `template` alongside
+ * `EDGE_TEMPLATE_VERSION` so an upgraded CLI restarts a stale detached edge.
  */
 function spaConfigHash(assistantName?: string): string {
   return createHash("sha256")
     .update(
       JSON.stringify({
-        mode: "remote-gateway",
-        apiBaseUrl: "/v1",
-        platformDisabled: true,
-        disablePlatform: true,
-        ...(assistantName ? { assistantName } : {}),
-        hubUrl: PRODUCTION_HUB_URL,
+        template: 2,
+        config: {
+          mode: "remote-gateway",
+          apiBaseUrl: "/v1",
+          platformDisabled: true,
+          disablePlatform: true,
+          ...(assistantName ? { assistantName } : {}),
+          hubUrl: PRODUCTION_HUB_URL,
+        },
       }),
     )
     .digest("hex");
@@ -765,7 +783,11 @@ describe("startRemoteWebIngress", () => {
 
     const conf = realFs.readFileSync(ingressConfPath(ws), "utf-8");
     expect(conf).toBe(
-      buildIngressNginxConfig({ gatewayPort: 7830, listenPort: 7845 }),
+      buildIngressNginxConfig({
+        gatewayPort: 7830,
+        listenPort: 7845,
+        ipv6Loopback: hasIpv6Loopback(),
+      }),
     );
     expect(conf).toContain("location = /auth/token { return 404; }");
     expect(conf).toContain("location = /v1/pair { return 404; }");
@@ -805,6 +827,7 @@ describe("startRemoteWebIngress", () => {
       buildIngressNginxConfig({
         gatewayPort: 7830,
         listenPort: 7845,
+        ipv6Loopback: hasIpv6Loopback(),
         remoteWebIngress: {
           webDistDir,
           indexHtmlPath: join(ws, "data", "ingress", "assistant-index.html"),
@@ -987,7 +1010,11 @@ describe("startRemoteWebIngress", () => {
     expect(spawnMock).toHaveBeenCalledTimes(1);
     const conf = realFs.readFileSync(ingressConfPath(ws), "utf-8");
     expect(conf).toBe(
-      buildIngressNginxConfig({ gatewayPort: 7830, listenPort: 7845 }),
+      buildIngressNginxConfig({
+        gatewayPort: 7830,
+        listenPort: 7845,
+        ipv6Loopback: hasIpv6Loopback(),
+      }),
     );
     expect(conf).toContain("proxy_pass http://127.0.0.1:7830;");
     expect((readConfig(ws).ingress as Record<string, unknown>).nginx).toEqual({
@@ -1021,7 +1048,11 @@ describe("startRemoteWebIngress", () => {
     expect(edge.killed()).toBe(true);
     expect(spawnMock).toHaveBeenCalledTimes(1);
     expect(realFs.readFileSync(ingressConfPath(ws), "utf-8")).toBe(
-      buildIngressNginxConfig({ gatewayPort: 7900, listenPort: 7845 }),
+      buildIngressNginxConfig({
+        gatewayPort: 7900,
+        listenPort: 7845,
+        ipv6Loopback: hasIpv6Loopback(),
+      }),
     );
     expect((readConfig(ws).ingress as Record<string, unknown>).nginx).toEqual({
       listenPort: 7845,
@@ -1206,7 +1237,11 @@ describe("startRemoteWebIngress", () => {
     expect(spawnMock).toHaveBeenCalledTimes(1);
     const conf = realFs.readFileSync(ingressConfPath(ws), "utf-8");
     expect(conf).toBe(
-      buildIngressNginxConfig({ gatewayPort: 7830, listenPort: 7845 }),
+      buildIngressNginxConfig({
+        gatewayPort: 7830,
+        listenPort: 7845,
+        ipv6Loopback: hasIpv6Loopback(),
+      }),
     );
     expect((readConfig(ws).ingress as Record<string, unknown>).nginx).toEqual({
       listenPort: 7845,
@@ -1246,7 +1281,11 @@ describe("startRemoteWebIngress", () => {
     expect(spawnMock).toHaveBeenCalledTimes(1);
     const conf = realFs.readFileSync(ingressConfPath(ws), "utf-8");
     expect(conf).toBe(
-      buildIngressNginxConfig({ gatewayPort: 7830, listenPort: 7845 }),
+      buildIngressNginxConfig({
+        gatewayPort: 7830,
+        listenPort: 7845,
+        ipv6Loopback: hasIpv6Loopback(),
+      }),
     );
     expect((readConfig(ws).ingress as Record<string, unknown>).nginx).toEqual({
       listenPort: 7845,
@@ -1742,6 +1781,7 @@ describe("ensureTunnelEdge", () => {
       buildIngressNginxConfig({
         gatewayPort: 7830,
         listenPort: REQUESTED_PORT,
+        ipv6Loopback: hasIpv6Loopback(),
       }),
     );
   });
@@ -1772,6 +1812,7 @@ describe("ensureTunnelEdge", () => {
       buildIngressNginxConfig({
         gatewayPort: 7830,
         listenPort: REQUESTED_PORT,
+        ipv6Loopback: hasIpv6Loopback(),
       }),
     );
   });

--- a/cli/src/__tests__/nginx-ingress.test.ts
+++ b/cli/src/__tests__/nginx-ingress.test.ts
@@ -165,12 +165,15 @@ describe("buildIngressNginxConfig", () => {
     },
   });
 
-  test("listens on loopback only", () => {
+  test("listens on both loopback families, and nothing else", () => {
+    // A tunnel agent pointed at "localhost" reaches ::1 first on macOS, so an
+    // IPv4-only bind refuses whichever share of a burst resolves that way.
     expect(conf).toContain("listen 127.0.0.1:7840;");
+    expect(conf).toContain("listen [::1]:7840;");
     const listens = conf.match(/listen [^;]+;/g) ?? [];
     expect(listens.length).toBeGreaterThan(0);
     for (const directive of listens) {
-      expect(directive).toContain("127.0.0.1");
+      expect(directive).toMatch(/127\.0\.0\.1|\[::1\]/);
     }
   });
 
@@ -361,6 +364,24 @@ describe("buildRemoteWebIndexHtml", () => {
 
     expect(result).not.toContain("</script><script>alert(1)</script>");
     expect(result).toContain("\\u003c/script\\u003e");
+  });
+
+  test("drops modulepreload hints but keeps the entry script and stylesheet", () => {
+    const html = [
+      "<html><head>",
+      '<link rel="modulepreload" crossorigin href="/assistant/assets/a-1.js">',
+      '<link rel="modulepreload" crossorigin href="/assistant/assets/b-2.js">',
+      '<link rel="stylesheet" crossorigin href="/assistant/assets/main-3.css">',
+      '<script type="module" crossorigin src="/assistant/assets/index-4.js"></script>',
+      "</head><body></body></html>",
+    ].join("\n");
+
+    const result = buildRemoteWebIndexHtml(html, { mode: "remote-gateway" });
+
+    expect(result).not.toContain("modulepreload");
+    expect(result).not.toContain("/assistant/assets/a-1.js");
+    expect(result).toContain('href="/assistant/assets/main-3.css"');
+    expect(result).toContain('src="/assistant/assets/index-4.js"');
   });
 });
 

--- a/cli/src/__tests__/nginx-ingress.test.ts
+++ b/cli/src/__tests__/nginx-ingress.test.ts
@@ -708,8 +708,7 @@ const PRODUCTION_HUB_URL = "https://www.vellum.ai/assistant";
  * Mirror of the SPA config fingerprint the edge records in its ingress state
  * (sha256 over the edge template version and the injected config JSON). Pins
  * both the injected config shape and the hash format; assumes the
- * production-pinned environment. Bump `template` alongside
- * `EDGE_TEMPLATE_VERSION` so an upgraded CLI restarts a stale detached edge.
+ * production-pinned environment. `template` tracks `EDGE_TEMPLATE_VERSION`.
  */
 function spaConfigHash(assistantName?: string): string {
   return createHash("sha256")
@@ -1151,6 +1150,51 @@ describe("startRemoteWebIngress", () => {
       includeWebApp: true,
       gatewayPort: 7830,
       remoteWebConfigHash: spaConfigHash("New Name"),
+    });
+  });
+
+  test("restarts an SPA edge recorded against an older template version", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockNginxSpawn();
+    mockWebDistPresent();
+    // Same injected config, earlier template: the detached edge serves an
+    // index this build renders differently, so identity must not match.
+    const priorTemplateHash = createHash("sha256")
+      .update(
+        JSON.stringify({
+          template: 1,
+          config: {
+            mode: "remote-gateway",
+            apiBaseUrl: "/v1",
+            platformDisabled: true,
+            disablePlatform: true,
+            hubUrl: PRODUCTION_HUB_URL,
+          },
+        }),
+      )
+      .digest("hex");
+    const pid = mockRunningEdge(ws, {
+      listenPort: 7845,
+      includeWebApp: true,
+      gatewayPort: 7830,
+      remoteWebConfigHash: priorTemplateHash,
+    });
+    const edge = mockKillableNginx(pid);
+
+    const result = await startRemoteWebIngress({
+      workspaceDir: ws,
+      gatewayPort: 7830,
+      listenPort: 7845,
+    });
+
+    expect(result.status).toBe("started");
+    expect(edge.killed()).toBe(true);
+    expect((readConfig(ws).ingress as Record<string, unknown>).nginx).toEqual({
+      listenPort: 7845,
+      includeWebApp: true,
+      gatewayPort: 7830,
+      remoteWebConfigHash: spaConfigHash(),
     });
   });
 

--- a/cli/src/__tests__/tunnel.test.ts
+++ b/cli/src/__tests__/tunnel.test.ts
@@ -964,7 +964,7 @@ describe("ngrok --domain spawn args", () => {
     expect(cmd).toBe("ngrok");
     expect(args).toEqual([
       "http",
-      "7831",
+      "127.0.0.1:7831",
       "--log=stdout",
       "--domain=foo.ngrok.app",
     ]);
@@ -1209,7 +1209,7 @@ describe("ngrok --domain spawn args", () => {
     expect(cmd).toBe("ngrok");
     expect(args).toEqual([
       "http",
-      "7830",
+      "127.0.0.1:7830",
       "--log=stdout",
       "--domain=foo.ngrok.app",
     ]);
@@ -1248,7 +1248,7 @@ describe("ngrok --domain spawn args", () => {
     const [, args] = spawnMock.mock.calls[0] as unknown as [string, string[]];
     expect(args).toEqual([
       "http",
-      "7831",
+      "127.0.0.1:7831",
       "--log=stdout",
       "--domain=foo.ngrok.app",
     ]);

--- a/cli/src/lib/nginx-ingress.ts
+++ b/cli/src/lib/nginx-ingress.ts
@@ -189,10 +189,9 @@ function remoteWebIngressConfig(
 }
 
 /**
- * Bump whenever the generated index or nginx template changes. A detached edge
- * survives a CLI upgrade, and the reuse check only compares the injected
- * config, so without this an upgraded CLI would keep an old edge alive and
- * never re-render the index it now builds differently.
+ * Part of edge identity: a detached edge is reused only while its recorded
+ * fingerprint matches, so this must change whenever the generated index or
+ * nginx template does.
  */
 const EDGE_TEMPLATE_VERSION = 2;
 

--- a/cli/src/lib/nginx-ingress.ts
+++ b/cli/src/lib/nginx-ingress.ts
@@ -15,6 +15,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { createRequire } from "node:module";
+import { networkInterfaces } from "node:os";
 import { dirname, join } from "node:path";
 
 import { cloudAssistantHubUrl } from "@vellumai/environments";
@@ -188,13 +189,23 @@ function remoteWebIngressConfig(
 }
 
 /**
+ * Bump whenever the generated index or nginx template changes. A detached edge
+ * survives a CLI upgrade, and the reuse check only compares the injected
+ * config, so without this an upgraded CLI would keep an old edge alive and
+ * never re-render the index it now builds differently.
+ */
+const EDGE_TEMPLATE_VERSION = 2;
+
+/**
  * Stable fingerprint of the SPA config injected into the served index and
- * `/assistant/__config`. Recorded alongside the edge state so a reuse
- * decision can tell whether a running edge already serves the requested
- * config (see `IngressState.remoteWebConfigHash`).
+ * `/assistant/__config`, plus the template that renders them. Recorded
+ * alongside the edge state so a reuse decision can tell whether a running edge
+ * already serves the requested config (see `IngressState.remoteWebConfigHash`).
  */
 function remoteWebConfigFingerprint(config: Record<string, unknown>): string {
-  return createHash("sha256").update(JSON.stringify(config)).digest("hex");
+  return createHash("sha256")
+    .update(JSON.stringify({ template: EDGE_TEMPLATE_VERSION, config }))
+    .digest("hex");
 }
 
 function safeScriptJson(value: unknown): string {
@@ -225,14 +236,33 @@ export function buildRemoteWebIndexHtml(
 }
 
 /**
+ * Whether the host has an IPv6 loopback to bind. False on Linux installs with
+ * IPv6 disabled, where emitting the listener would make nginx exit at startup
+ * rather than fall back to IPv4.
+ */
+export function hasIpv6Loopback(): boolean {
+  return Object.values(networkInterfaces())
+    .flatMap((addrs) => addrs ?? [])
+    .some((addr) => addr.address === "::1");
+}
+
+/**
  * Build the nginx config that forwards tunnel web traffic to the gateway.
  */
 export function buildIngressNginxConfig(opts: {
   gatewayPort: number;
   listenPort: number;
   remoteWebIngress?: RemoteWebIngressOptions;
+  /** Emit the `[::1]` listener. Off where the host has no IPv6 loopback,
+   *  since nginx exits at startup when it cannot bind a listen address. */
+  ipv6Loopback?: boolean;
 }): string {
   const proxyBlock = gatewayProxyBlock(opts.gatewayPort);
+  // A tunnel agent pointed at "localhost" reaches ::1 first on macOS, so an
+  // IPv4-only bind refuses whichever share of a burst resolves that way.
+  const ipv6Listen = opts.ipv6Loopback
+    ? `    listen [::1]:${opts.listenPort};\n`
+    : "";
   const remoteWebIngress = opts.remoteWebIngress;
   const serverLocations = remoteWebIngress
     ? buildRemoteWebIngressLocations({
@@ -282,10 +312,7 @@ http {
 
   server {
     listen 127.0.0.1:${opts.listenPort};
-    # A tunnel agent pointed at "localhost" reaches ::1 first on macOS, so an
-    # IPv4-only bind refuses whichever share of a burst resolves that way.
-    listen [::1]:${opts.listenPort};
-    client_max_body_size 512m;
+${ipv6Listen}    client_max_body_size 512m;
 
     # This edge sits behind a TLS-terminating front (tunnel or tailscale serve),
     # so redirects must be relative: emit "Location: /assistant/" and let the
@@ -566,6 +593,7 @@ export function startIngressNginx(opts: {
       gatewayPort: opts.gatewayPort,
       listenPort: opts.listenPort,
       remoteWebIngress,
+      ipv6Loopback: hasIpv6Loopback(),
     }),
   );
 

--- a/cli/src/lib/nginx-ingress.ts
+++ b/cli/src/lib/nginx-ingress.ts
@@ -203,15 +203,25 @@ function safeScriptJson(value: unknown): string {
     .replace(/>/g, "\\u003e");
 }
 
+/**
+ * Preloading the whole chunk graph opens ~290 tunnel connections on a cold
+ * load, and one dropped request blanks the app before React can report it.
+ * These are hints only; the entry module still pulls what it needs.
+ */
+function stripModulePreloads(html: string): string {
+  return html.replace(/<link[^>]+rel="modulepreload"[^>]*>\s*/g, "");
+}
+
 export function buildRemoteWebIndexHtml(
   rawHtml: string,
   config: Record<string, unknown>,
 ): string {
+  const html = stripModulePreloads(rawHtml);
   const script = `<script>window.__VELLUM_CONFIG__=${safeScriptJson(config)}</script>`;
-  if (rawHtml.includes("</head>")) {
-    return rawHtml.replace("</head>", `${script}</head>`);
+  if (html.includes("</head>")) {
+    return html.replace("</head>", `${script}</head>`);
   }
-  return `${script}${rawHtml}`;
+  return `${script}${html}`;
 }
 
 /**
@@ -272,6 +282,9 @@ http {
 
   server {
     listen 127.0.0.1:${opts.listenPort};
+    # A tunnel agent pointed at "localhost" reaches ::1 first on macOS, so an
+    # IPv4-only bind refuses whichever share of a burst resolves that way.
+    listen [::1]:${opts.listenPort};
     client_max_body_size 512m;
 
     # This edge sits behind a TLS-terminating front (tunnel or tailscale serve),

--- a/cli/src/lib/ngrok.ts
+++ b/cli/src/lib/ngrok.ts
@@ -142,7 +142,7 @@ export function startNgrokProcess(
     stdio = ["ignore", fd, fd];
   }
 
-  // Explicit over a bare port, which ngrok expands to `localhost` — whose ::1
+  // Explicit over a bare port, which ngrok expands to `localhost`, whose ::1
   // answer resolves first on macOS and races the edge's IPv4 bind.
   const args = ["http", `127.0.0.1:${targetPort}`, "--log=stdout"];
   if (domain) {

--- a/cli/src/lib/ngrok.ts
+++ b/cli/src/lib/ngrok.ts
@@ -142,7 +142,9 @@ export function startNgrokProcess(
     stdio = ["ignore", fd, fd];
   }
 
-  const args = ["http", String(targetPort), "--log=stdout"];
+  // Explicit over a bare port, which ngrok expands to `localhost` — whose ::1
+  // answer resolves first on macOS and races the edge's IPv4 bind.
+  const args = ["http", `127.0.0.1:${targetPort}`, "--log=stdout"];
   if (domain) {
     args.push(`--domain=${domain}`);
   }


### PR DESCRIPTION
## Summary

- **Bind the ingress on `[::1]` as well as `127.0.0.1`.** A tunnel agent pointed at `localhost` resolves `::1` first on macOS, so an IPv4-only bind refuses whichever share of a connection burst takes the IPv6 answer. ngrok reports those as `ERR_NGROK_3004` / 503.
- **Launch ngrok against `127.0.0.1:<port>` instead of a bare port**, which ngrok expands to `localhost`. `tunnelTargetsPort` already accepts this spelling, so tunnel reuse is unaffected.
- **Strip `modulepreload` hints from the tunnel-served index.** The build preloads its entire chunk graph — 286 links — so a cold load opens ~290 connections at once. They are hints only; the entry module still pulls what it needs.

## Why

A cold load of any remote-web page (pair screen, app) came up **blank**, with nothing in any log. A refresh always fixed it, which made it look intermittent.

The chain: ~290 simultaneous requests → some connections land on `::1` where nothing listens → those chunks 503 → the ES module graph breaks → the app never mounts. Because it fails before React, there is no error boundary, no retry, and no console trace beyond aborted fetches. Refresh works because the assets are `immutable` and come from cache.

Measured on a live ngrok tunnel:

| state | failed chunks per cold load |
|---|---|
| before | ~11 |
| dual-bind only | ~1 |
| dual-bind + no preloads | 0 |

nginx itself was never the constraint — it served 290/290 at concurrency 150 over loopback. The residual single drop after the bind fix came from inside ngrok's edge↔agent path (the failed request never appeared in ngrok's own request log), so cutting the request volume is what closes it.

## Notes

- Worker/connection tuning was tried and deliberately left out: it appeared to help, but the loopback burst showed capacity was never the issue.
- The remaining fragility is upstream of this fix — **one failed chunk still blanks the app**, with no retry and no error UI. Worth addressing separately; over a home tunnel on a phone, occasional drops are a certainty.

## Original prompt

While QAing the origin-model assistant chooser over a home ngrok tunnel, scanning a pairing QR from a phone (and any fresh browser context) landed on a blank page, while a refresh loaded fine. The ask was to root-cause it and ship the valid code fixes.