### PR TITLE
refactor(web): drop the two grouping buckets nothing renders (LUM-2443)

### DIFF
--- a/clients/web/src/domains/chat/utils/group-conversations.test.ts
+++ b/clients/web/src/domains/chat/utils/group-conversations.test.ts
@@ -4,10 +4,28 @@ import type {
   Conversation,
   ConversationGroup,
 } from "@/types/conversation-types";
+import type { GroupedConversations } from "@/domains/chat/utils/group-conversations";
 import {
   buildMoveToGroupTargets,
   groupConversations,
 } from "@/domains/chat/utils/group-conversations";
+
+/**
+ * Every conversation id the sidebar would render from a grouping result.
+ *
+ * Scheduled and background threads have no section, so the invariant worth
+ * asserting is that they appear in NONE of these, not that they landed in a
+ * bucket of their own. Checking `recents` alone would miss a leak into a
+ * channel section or a custom group.
+ */
+function renderedIds(result: GroupedConversations): string[] {
+  return [
+    ...result.pinned,
+    ...result.recents,
+    ...result.customGroups.flatMap((g) => g.conversations),
+    ...result.channelSections.flatMap((s) => s.conversations),
+  ].map((c) => c.conversationId);
+}
 
 function makeConversation(overrides: Partial<Conversation>): Conversation {
   return {
@@ -32,8 +50,6 @@ describe("groupConversations · bucket routing", () => {
   test("returns empty buckets for an empty input", () => {
     const result = groupConversations([]);
     expect(result.pinned).toEqual([]);
-    expect(result.scheduled).toEqual([]);
-    expect(result.background).toEqual([]);
     expect(result.channelSections).toEqual([]);
     expect(result.recents).toEqual([]);
   });
@@ -46,12 +62,10 @@ describe("groupConversations · bucket routing", () => {
     ]);
     expect(result.pinned.map((c) => c.conversationId)).toEqual(["a", "b", "c"]);
     expect(result.recents).toEqual([]);
-    expect(result.scheduled).toEqual([]);
-    expect(result.background).toEqual([]);
     expect(result.channelSections).toEqual([]);
   });
 
-  test("routes conversationType=scheduled into scheduled bucket", () => {
+  test("excludes conversationType=scheduled from every rendered bucket", () => {
     const result = groupConversations([
       makeConversation({
         conversationId: "s1",
@@ -62,14 +76,14 @@ describe("groupConversations · bucket routing", () => {
         groupId: "system:scheduled",
       }),
     ]);
-    expect(result.scheduled.map((c) => c.conversationId).sort()).toEqual([
-      "s1",
-      "s2",
-    ]);
+    // No section renders these.
+    for (const id of ["s1", "s2"]) {
+      expect(renderedIds(result)).not.toContain(id);
+    }
     expect(result.recents).toEqual([]);
   });
 
-  test("routes conversationType=background into background bucket", () => {
+  test("excludes conversationType=background from every rendered bucket", () => {
     const result = groupConversations([
       makeConversation({
         conversationId: "b1",
@@ -81,10 +95,10 @@ describe("groupConversations · bucket routing", () => {
         groupId: "system:background",
       }),
     ]);
-    expect(result.background.map((c) => c.conversationId).sort()).toEqual([
-      "b1",
-      "b2",
-    ]);
+    // No section renders these.
+    for (const id of ["b1", "b2"]) {
+      expect(renderedIds(result)).not.toContain(id);
+    }
   });
 
   test("routes Slack-origin conversations into the Slack bucket", () => {
@@ -120,8 +134,6 @@ describe("groupConversations · bucket routing", () => {
       "slack-background",
     ]);
     expect(result.recents.map((c) => c.conversationId)).toEqual(["regular"]);
-    expect(result.scheduled).toEqual([]);
-    expect(result.background).toEqual([]);
   });
 
   test("keeps pinned and custom-group Slack conversations in their explicit buckets", () => {
@@ -160,7 +172,7 @@ describe("groupConversations · bucket routing", () => {
     ).toEqual(["custom-slack"]);
   });
 
-  test("keeps explicitly assigned scheduled and background Slack conversations in their system buckets", () => {
+  test("excludes scheduled and background Slack conversations, channel or not", () => {
     const result = groupConversations([
       makeConversation({
         conversationId: "scheduled-slack",
@@ -175,18 +187,16 @@ describe("groupConversations · bucket routing", () => {
     ]);
 
     expect(result.channelSections).toEqual([]);
-    expect(result.scheduled.map((c) => c.conversationId)).toEqual([
-      "scheduled-slack",
-    ]);
-    expect(result.background.map((c) => c.conversationId)).toEqual([
-      "background-slack",
-    ]);
+    // An explicit system group takes them out of channel routing, so they
+    // fall through to the exclusion rather than into the Slack section.
+    for (const id of ["scheduled-slack", "background-slack"]) {
+      expect(renderedIds(result)).not.toContain(id);
+    }
   });
 
-  test("routes background conversations with source=auto-analysis into background bucket", () => {
-    // Auto-analysis (reflections) are a flavor of background — they land
-    // in the background bucket and are sub-grouped downstream by
-    // backgroundSubGroups.ts.
+  test("excludes auto-analysis reflections like any other background thread", () => {
+    // Auto-analysis (reflections) are a flavor of background, so they are
+    // excluded on the same branch rather than treated as their own kind.
     const result = groupConversations([
       makeConversation({
         conversationId: "r1",
@@ -199,10 +209,10 @@ describe("groupConversations · bucket routing", () => {
         source: "auto-analysis",
       }),
     ]);
-    expect(result.background.map((c) => c.conversationId).sort()).toEqual([
-      "r1",
-      "r2",
-    ]);
+    // No section renders these.
+    for (const id of ["r1", "r2"]) {
+      expect(renderedIds(result)).not.toContain(id);
+    }
   });
 
   test("does not reroute a foreground thread with source=auto-analysis", () => {
@@ -210,7 +220,6 @@ describe("groupConversations · bucket routing", () => {
     const result = groupConversations([
       makeConversation({ conversationId: "a", source: "auto-analysis" }),
     ]);
-    expect(result.background).toEqual([]);
     expect(result.recents.map((c) => c.conversationId)).toEqual(["a"]);
   });
 
@@ -240,7 +249,6 @@ describe("groupConversations · bucket routing", () => {
     expect(result.pinned.map((c) => c.conversationId)).toEqual([
       "pinned-reflection",
     ]);
-    expect(result.background).toEqual([]);
   });
 
   test("excludes archived conversations from every bucket", () => {
@@ -409,7 +417,10 @@ describe("groupConversations · custom group routing", () => {
     const result = groupConversations(conversations, { groups });
 
     expect(result.pinned.map((c) => c.conversationId)).toEqual(["s1"]);
-    expect(result.scheduled.map((c) => c.conversationId)).toEqual(["s2"]);
+    // No section renders these.
+    for (const id of ["s2"]) {
+      expect(renderedIds(result)).not.toContain(id);
+    }
     expect(result.customGroups.every((g) => g.conversations.length === 0)).toBe(
       true,
     );
@@ -576,7 +587,7 @@ describe("groupConversations · recency order for pinned and custom groups", () 
 });
 
 describe("groupConversations · surfaced promotion to recents", () => {
-  test("a surfaced scheduled conversation lands in recents, not scheduled", () => {
+  test("a surfaced scheduled conversation reaches recents instead of being excluded", () => {
     const result = groupConversations([
       makeConversation({
         conversationId: "sched-surfaced",
@@ -591,12 +602,13 @@ describe("groupConversations · surfaced promotion to recents", () => {
     expect(result.recents.map((c) => c.conversationId)).toEqual([
       "sched-surfaced",
     ]);
-    expect(result.scheduled.map((c) => c.conversationId)).toEqual([
-      "sched-plain",
-    ]);
+    // No section renders these.
+    for (const id of ["sched-plain"]) {
+      expect(renderedIds(result)).not.toContain(id);
+    }
   });
 
-  test("a surfaced background conversation lands in recents, not background", () => {
+  test("a surfaced background conversation reaches recents instead of being excluded", () => {
     const result = groupConversations([
       makeConversation({
         conversationId: "bg-surfaced",
@@ -617,9 +629,10 @@ describe("groupConversations · surfaced promotion to recents", () => {
       "bg-legacy-surfaced",
       "bg-surfaced",
     ]);
-    expect(result.background.map((c) => c.conversationId)).toEqual([
-      "bg-plain",
-    ]);
+    // No section renders these.
+    for (const id of ["bg-plain"]) {
+      expect(renderedIds(result)).not.toContain(id);
+    }
   });
 
   test("surfaced conversations sort into recents by lastMessageAt desc", () => {
@@ -723,7 +736,6 @@ describe("groupConversations · surfaced promotion to recents", () => {
       }),
     ]);
     expect(result.recents).toEqual([]);
-    expect(result.background).toEqual([]);
   });
 
   test("duplicate pinned conversations in input produce duplicate pinned entries", () => {
@@ -793,10 +805,8 @@ describe("groupConversations · groupByChannel: false", () => {
     const grouped = groupConversations(conversations);
 
     expect(flat.recents.map((c) => c.conversationId)).toEqual(["s1"]);
-    expect(flat.background).toEqual([]);
     // Same membership in the grouped view, just a different bucket.
     expect(channelSectionIds(grouped, "slack")).toEqual(["s1"]);
-    expect(grouped.background).toEqual([]);
   });
 
   test("pinned and custom-group precedence is unchanged", () => {

--- a/clients/web/src/domains/chat/utils/group-conversations.test.ts
+++ b/clients/web/src/domains/chat/utils/group-conversations.test.ts
@@ -455,12 +455,11 @@ describe("groupConversations · custom group routing", () => {
 });
 
 describe("groupConversations · recency order for pinned and custom groups", () => {
-  /* Pinned and the custom groups used to sort by `displayOrder`, falling back
-     to creation time, so that a drag-reordered arrangement held regardless of
-     activity. LUM-3108 removed drag-reorder, and every section sorts by
-     recency now. Each test below sets `displayOrder` to the REVERSE of the
-     expected result, so re-introducing the old comparator fails them rather
-     than leaving them coincidentally passing. */
+  /* Recency is the only order, for these sections as much as any other.
+     `displayOrder` still exists on the wire and still carries values for
+     anyone who arranged rows by hand before that affordance went away, so
+     each test sets it to the REVERSE of the expected result: a comparator
+     that consults it again fails here rather than passing by coincidence. */
 
   test("pinned sorts by recency, ignoring displayOrder", () => {
     const result = groupConversations([

--- a/clients/web/src/domains/chat/utils/group-conversations.ts
+++ b/clients/web/src/domains/chat/utils/group-conversations.ts
@@ -275,8 +275,7 @@ export function groupConversations(
     }))
     .sort((a, b) => a.channelId.localeCompare(b.channelId));
   // Pinned and the custom groups sort by recency like every other section.
-  // They used to honor `displayOrder` instead, which only ever held a value
-  // for someone who had drag-reordered (LUM-3108 removed that affordance).
+  // `displayOrder` is not consulted anywhere: recency is the one order.
   const sortedPinned = pinned.slice().sort(compareByRecency);
   for (const bucket of customGroupsList) {
     bucket.conversations.sort(compareByRecency);

--- a/clients/web/src/domains/chat/utils/group-conversations.ts
+++ b/clients/web/src/domains/chat/utils/group-conversations.ts
@@ -6,8 +6,13 @@ import { isScheduledConversation } from "@/utils/conversation-predicates";
 import { isChannelConversation } from "@/domains/chat/utils/conversation-channel";
 /**
  * Pure helper for splitting the sidebar's conversation list into system
- * category buckets (`pinned`, `channelSections`, `scheduled`, `background`,
- * `recents`) and optional user-defined custom groups.
+ * category buckets (`pinned`, `channelSections`, `recents`) and optional
+ * user-defined custom groups.
+ *
+ * These buckets are the derived fallback, not the sidebar's contents: each
+ * section fetches its own rows (`useSectionConversations`) and falls back to
+ * what is here while a section's query is gated off, pending, or failed.
+ * Which sections exist is still read from these buckets.
  *
  * Categorization (mirrors backend conventions in `web/src/lib/chat/api.ts`):
  *
@@ -21,18 +26,20 @@ import { isChannelConversation } from "@/domains/chat/utils/conversation-channel
  *   produced at all and those conversations go to `recents` instead, at the
  *   same point in the precedence chain, so which bucket a conversation is
  *   visible in changes but whether it is visible does not.
- * - `scheduled` — `conversationType === "scheduled"` OR legacy
- *   `groupId === "system:scheduled"`.
- * - `background` — all background threads
- *   (`conversationType === "background"` or `groupId === "system:background"`),
- *   including auto-analysis (reflections).
  * - `recents` — everything else (foreground, non-pinned), sorted by
- *   `lastMessageAt` descending. Background/scheduled conversations with a
- *   non-null `surfacedAt` (explicitly promoted via the daemon's surface API)
- *   land here instead of their system buckets.
+ *   `lastMessageAt` descending.
  *
- * Archived conversations (`archivedAt != null`) are excluded from every
- * bucket.
+ * Excluded from every bucket, because no section renders them:
+ *
+ * - archived conversations (`archivedAt != null`), which live in their own view
+ * - scheduled threads (`conversationType === "scheduled"` or legacy
+ *   `groupId === "system:scheduled"`)
+ * - background threads (`conversationType === "background"` or legacy
+ *   `groupId === "system:background"`), including auto-analysis reflections
+ *
+ * A scheduled or background conversation with a non-null `surfacedAt` has
+ * been explicitly promoted through the daemon's surface API, and reaches
+ * `recents` like any foreground thread.
  *
  * Kept deliberately in its own file (no React, no icons) so it can be unit
  * tested without a DOM and reused by other surfaces if a compact recent-list
@@ -57,8 +64,6 @@ export interface ChannelSection {
 
 export interface GroupedConversations {
   pinned: Conversation[];
-  scheduled: Conversation[];
-  background: Conversation[];
   channelSections: ChannelSection[];
   recents: Conversation[];
   customGroups: CustomGroup[];
@@ -171,8 +176,6 @@ export function groupConversations(
 ): GroupedConversations {
   const groupByChannel = options?.groupByChannel ?? true;
   const pinned: Conversation[] = [];
-  const scheduled: Conversation[] = [];
-  const background: Conversation[] = [];
   const channelBuckets = new Map<string, Conversation[]>();
   const recents: Conversation[] = [];
 
@@ -248,13 +251,11 @@ export function groupConversations(
       continue;
     }
 
-    if (isScheduledConversation(c)) {
-      scheduled.push(c);
-      continue;
-    }
-
-    if (isBackground(c)) {
-      background.push(c);
+    /* Excluded rather than bucketed. Scheduled and background rows have no
+       section of their own, so what matters is that they do not fall through
+       into Chats. They reach the sidebar only by being surfaced, which the
+       branch above already promoted. */
+    if (isScheduledConversation(c) || isBackground(c)) {
       continue;
     }
 
@@ -283,8 +284,6 @@ export function groupConversations(
 
   return {
     pinned: sortedPinned,
-    scheduled,
-    background,
     channelSections,
     recents: sortedRecents,
     customGroups: customGroupsList,


### PR DESCRIPTION
## TL;DR

`groupConversations` returned `scheduled` and `background` buckets that nothing renders. They're gone. The branch that *populated* them stays, because that branch is what keeps those conversations out of Chats.

No behavior change. First of the LUM-2443 deletions, and deliberately the small one — see the bottom for why the rest can't follow yet.

## What was dead, and what wasn't

`grouped.scheduled` had **zero consumers** anywhere in the app. `grouped.background` had **one**, in a test assertion. `defaultSections` has never built sections for either.

But they were not inert. Pushing a conversation into one of those arrays is what stopped it falling through into `recents`:

```ts
if (isScheduledConversation(c)) { scheduled.push(c); continue; }
if (isBackground(c))            { background.push(c); continue; }
recents.push(c);
```

Deleting the arrays without keeping the branch would have leaked every scheduled and background thread into Chats. The branch now just excludes.

## Why it is safe

- **Nothing read the removed fields**, so nothing renders differently.
- **Surfaced conversations are unaffected.** The `surfacedAt` check runs *before* this branch, so an explicitly promoted background or scheduled conversation still reaches `recents`.
- **Channel routing is unaffected.** It also precedes this branch, so a scheduled Slack conversation with no explicit group still lands in the Slack section — as an existing test asserts, and still does.
- **The lazy queries are untouched.** `useBackgroundConversationListQuery` and `useScheduledConversationListQuery` are activated by persisted `openCategories` and by attention reconciliation, neither of which reads these buckets. This PR does not make them dead, and does not try to.
- Typecheck and eslint clean.

## Tests

Assertions now describe the surviving invariant instead of the removed shape. A `renderedIds` helper flattens **every** bucket the sidebar draws from — pinned, recents, custom groups, channel sections — so a leak into any of them fails. Asserting on `recents` alone would have missed a leak into a channel section.

Test names changed with them: `routes conversationType=scheduled into scheduled bucket` now reads `excludes conversationType=scheduled from every rendered bucket`, because naming a bucket that no longer exists is how a test stops describing the code.

## Before / after

| | Before | After |
| --- | --- | --- |
| What the sidebar shows | Unchanged | Unchanged |
| Scheduled / background threads | Collected into buckets nothing rendered | Excluded, same visible result |
| A surfaced background thread | In Recents | In Recents |
| A scheduled Slack thread with no explicit group | In the Slack section | In the Slack section |
| `GroupedConversations` shape | 6 fields, 2 unread | 4 fields, all read |

## Why the rest of the deletions cannot follow yet

LUM-2443 lists `groupConversations`, `mergeConversationLists`, and the `conversations` prop for removal. Checked rather than assumed, and only this piece is removable today:

- `groupConversations` still produces the **derived fallback** every section paints while its query is gated off, pending, or failed, and it is still where **section existence** is decided. Both survive until the compat gates retire and existence gets a server-side source.
- `mergeConversationLists` has consumers outside the sidebar (`notifications-bell`, `home-page-route`), so it is not the sidebar's to delete.
- The `conversations` prop feeds that same fallback.

Part of LUM-2443.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->