### PR TITLE
feat(web): cancel a pending pairing back to the hub chooser

### DIFF
--- a/clients/ios/App/App/MyViewController.swift
+++ b/clients/ios/App/App/MyViewController.swift
@@ -230,12 +230,14 @@ class MyViewController: CAPBridgeViewController {
     /// Load the effective server URL (the configured self-hosted origin or the
     /// baked default) and re-arm foreground change detection against it. Backs
     /// the `SelfHostedServers` plugin's `switchTo`; must run on the main queue.
-    func applyConfiguredOrigin() {
+    func applyConfiguredOrigin(path: String? = nil) {
         bindServerTrackingToConfiguredOrigin()
         guard let destination = appliedServerURL else {
             return
         }
-        webView?.load(URLRequest(url: Self.appEntryURL(forBase: destination)))
+        let entryURL = Self.appEntryURL(forBase: destination)
+        let destinationURL = path.flatMap { Self.appRouteURL(forEntry: entryURL, path: $0) } ?? entryURL
+        webView?.load(URLRequest(url: destinationURL))
     }
 
     /// The SPA entry point for a server base, `<base>/assistant`. The ingress
@@ -249,6 +251,25 @@ class MyViewController: CAPBridgeViewController {
             return base
         }
         return base.appendingPathComponent("assistant")
+    }
+
+    private static func appRouteURL(forEntry entry: URL, path: String) -> URL? {
+        guard let components = URLComponents(string: path),
+              components.scheme == nil,
+              components.host == nil,
+              !components.path.isEmpty,
+              !components.path.split(separator: "/").contains(".."),
+              components.fragment == nil
+        else {
+            return nil
+        }
+        var route = entry.appendingPathComponent(components.path)
+        guard var routeComponents = URLComponents(url: route, resolvingAgainstBaseURL: false) else {
+            return nil
+        }
+        routeComponents.percentEncodedQuery = components.percentEncodedQuery
+        route = routeComponents.url ?? route
+        return route
     }
 
     // MARK: - Quote-and-reply edit menu

--- a/clients/ios/App/App/SelfHostedServersPlugin.swift
+++ b/clients/ios/App/App/SelfHostedServersPlugin.swift
@@ -26,6 +26,7 @@ public class SelfHostedServersPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "add", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "remove", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "switchTo", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "switchToPath", returnType: CAPPluginReturnPromise),
     ]
 
     @objc public func list(_ call: CAPPluginCall) {
@@ -95,6 +96,29 @@ public class SelfHostedServersPlugin: CAPPlugin, CAPBridgedPlugin {
         }
         DispatchQueue.main.async { [weak self] in
             (self?.bridge?.viewController as? MyViewController)?.applyConfiguredOrigin()
+            call.resolve(["ok": true])
+        }
+    }
+
+    @objc public func switchToPath(_ call: CAPPluginCall) {
+        let path = call.getString("path")?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !path.isEmpty, !path.hasPrefix("/"), !path.contains("://"), !path.contains("#") else {
+            call.reject("invalid path")
+            return
+        }
+
+        let raw = call.getString("url")?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if raw.isEmpty {
+            SelfHostedServer.clear()
+        } else if let url = SelfHostedServer.validate(raw) {
+            SelfHostedServer.store(url)
+            SelfHostedServer.append(url: url, name: nil)
+        } else {
+            call.reject("invalid url")
+            return
+        }
+        DispatchQueue.main.async { [weak self] in
+            (self?.bridge?.viewController as? MyViewController)?.applyConfiguredOrigin(path: path)
             call.resolve(["ok": true])
         }
     }

--- a/clients/web/src/domains/remote-web/pairing-page.test.tsx
+++ b/clients/web/src/domains/remote-web/pairing-page.test.tsx
@@ -15,6 +15,7 @@ let injectedAssistantName: string | undefined;
 let injectedHubUrl: string | undefined;
 let nativePlatform = false;
 let nativePlatformName: "ios" | "android" = "ios";
+const nativeSwitchToOriginMock = mock(async (_url: string | null) => false);
 
 mock.module("@/lib/local-mode", () => ({
   isRemoteGatewayMode: () => remoteGatewayMode,
@@ -24,6 +25,10 @@ mock.module("@/lib/local-mode", () => ({
 
 mock.module("@/runtime/native-auth", () => ({
   isNativePlatform: () => nativePlatform,
+}));
+
+mock.module("@/runtime/self-hosted-servers", () => ({
+  nativeSwitchToOrigin: nativeSwitchToOriginMock,
 }));
 
 mock.module("@capacitor/core", () => ({
@@ -137,6 +142,8 @@ afterEach(() => {
   exchangeRemoteWebPairingTokenMock.mockClear();
   createRemoteWebPairingChallengeMock.mockClear();
   activateRemoteGatewaySessionMock.mockClear();
+  nativeSwitchToOriginMock.mockReset();
+  nativeSwitchToOriginMock.mockImplementation(async () => false);
 });
 
 describe("RemoteWebPairingPage", () => {
@@ -199,9 +206,47 @@ describe("RemoteWebPairingPage", () => {
 
       // An in-app navigate would be bounced back here by the remote-gateway
       // pairing guard, so cancelling must cross to the hub's own origin.
-      expect(assignMock.mock.calls[0]?.[0]).toBe(
-        "https://hub.example.com/assistant/select-assistant?noAutoSkip=1",
+      await waitFor(() => {
+        expect(assignMock.mock.calls[0]?.[0]).toBe(
+          "https://hub.example.com/assistant/select-assistant?noAutoSkip=1",
+        );
+      });
+    } finally {
+      Object.defineProperty(window.location, "assign", {
+        value: originalAssign,
+        configurable: true,
+      });
+    }
+  });
+
+  test("cancel uses the native origin switch when available", async () => {
+    remoteGatewayMode = true;
+    injectedHubUrl = "https://hub.example.com/assistant";
+    nativePlatform = true;
+    nativeSwitchToOriginMock.mockResolvedValueOnce(true);
+    const assignMock = mock((_url: string) => {});
+    const originalAssign = window.location.assign;
+    Object.defineProperty(window.location, "assign", {
+      value: assignMock,
+      configurable: true,
+    });
+
+    try {
+      render(
+        <MemoryRouter
+          initialEntries={["/assistant/pair?deviceCode=device-1&userCode=ABCD"]}
+        >
+          <RemoteWebPairingPage />
+        </MemoryRouter>,
       );
+
+      expect(await screen.findByText("Waiting for approval")).not.toBeNull();
+      fireEvent.click(screen.getByText("Cancel"));
+
+      await waitFor(() => {
+        expect(nativeSwitchToOriginMock).toHaveBeenCalledWith(null);
+      });
+      expect(assignMock).not.toHaveBeenCalled();
     } finally {
       Object.defineProperty(window.location, "assign", {
         value: originalAssign,

--- a/clients/web/src/domains/remote-web/pairing-page.test.tsx
+++ b/clients/web/src/domains/remote-web/pairing-page.test.tsx
@@ -15,7 +15,9 @@ let injectedAssistantName: string | undefined;
 let injectedHubUrl: string | undefined;
 let nativePlatform = false;
 let nativePlatformName: "ios" | "android" = "ios";
-const nativeSwitchToOriginMock = mock(async (_url: string | null) => false);
+const nativeSwitchToOriginPathMock = mock(
+  async (_url: string | null, _path: string) => false,
+);
 
 mock.module("@/lib/local-mode", () => ({
   isRemoteGatewayMode: () => remoteGatewayMode,
@@ -28,7 +30,7 @@ mock.module("@/runtime/native-auth", () => ({
 }));
 
 mock.module("@/runtime/self-hosted-servers", () => ({
-  nativeSwitchToOrigin: nativeSwitchToOriginMock,
+  nativeSwitchToOriginPath: nativeSwitchToOriginPathMock,
 }));
 
 mock.module("@capacitor/core", () => ({
@@ -142,8 +144,8 @@ afterEach(() => {
   exchangeRemoteWebPairingTokenMock.mockClear();
   createRemoteWebPairingChallengeMock.mockClear();
   activateRemoteGatewaySessionMock.mockClear();
-  nativeSwitchToOriginMock.mockReset();
-  nativeSwitchToOriginMock.mockImplementation(async () => false);
+  nativeSwitchToOriginPathMock.mockReset();
+  nativeSwitchToOriginPathMock.mockImplementation(async () => false);
 });
 
 describe("RemoteWebPairingPage", () => {
@@ -223,7 +225,7 @@ describe("RemoteWebPairingPage", () => {
     remoteGatewayMode = true;
     injectedHubUrl = "https://hub.example.com/assistant";
     nativePlatform = true;
-    nativeSwitchToOriginMock.mockResolvedValueOnce(true);
+    nativeSwitchToOriginPathMock.mockResolvedValueOnce(true);
     const assignMock = mock((_url: string) => {});
     const originalAssign = window.location.assign;
     Object.defineProperty(window.location, "assign", {
@@ -244,9 +246,52 @@ describe("RemoteWebPairingPage", () => {
       fireEvent.click(screen.getByText("Cancel"));
 
       await waitFor(() => {
-        expect(nativeSwitchToOriginMock).toHaveBeenCalledWith(null);
+        expect(nativeSwitchToOriginPathMock).toHaveBeenCalledWith(
+          null,
+          "select-assistant?noAutoSkip=1",
+        );
       });
       expect(assignMock).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(window.location, "assign", {
+        value: originalAssign,
+        configurable: true,
+      });
+    }
+  });
+
+  test("cancel falls back when the native shell lacks path switching", async () => {
+    remoteGatewayMode = true;
+    injectedHubUrl = "https://hub.example.com/assistant";
+    nativePlatform = true;
+    const assignMock = mock((_url: string) => {});
+    const originalAssign = window.location.assign;
+    Object.defineProperty(window.location, "assign", {
+      value: assignMock,
+      configurable: true,
+    });
+
+    try {
+      render(
+        <MemoryRouter
+          initialEntries={["/assistant/pair?deviceCode=device-1&userCode=ABCD"]}
+        >
+          <RemoteWebPairingPage />
+        </MemoryRouter>,
+      );
+
+      expect(await screen.findByText("Waiting for approval")).not.toBeNull();
+      fireEvent.click(screen.getByText("Cancel"));
+
+      await waitFor(() => {
+        expect(nativeSwitchToOriginPathMock).toHaveBeenCalledWith(
+          null,
+          "select-assistant?noAutoSkip=1",
+        );
+        expect(assignMock.mock.calls[0]?.[0]).toBe(
+          "https://hub.example.com/assistant/select-assistant?noAutoSkip=1",
+        );
+      });
     } finally {
       Object.defineProperty(window.location, "assign", {
         value: originalAssign,

--- a/clients/web/src/domains/remote-web/pairing-page.test.tsx
+++ b/clients/web/src/domains/remote-web/pairing-page.test.tsx
@@ -12,12 +12,14 @@ import type { RemoteWebPairingTokenResult } from "@/lib/auth/remote-gateway-sess
 
 let remoteGatewayMode = false;
 let injectedAssistantName: string | undefined;
+let injectedHubUrl: string | undefined;
 let nativePlatform = false;
 let nativePlatformName: "ios" | "android" = "ios";
 
 mock.module("@/lib/local-mode", () => ({
   isRemoteGatewayMode: () => remoteGatewayMode,
   getRemoteGatewayAssistantName: () => injectedAssistantName,
+  getRemoteGatewayHubUrl: () => injectedHubUrl,
 }));
 
 mock.module("@/runtime/native-auth", () => ({
@@ -128,6 +130,7 @@ afterEach(() => {
   cleanup();
   remoteGatewayMode = false;
   injectedAssistantName = undefined;
+  injectedHubUrl = undefined;
   nativePlatform = false;
   nativePlatformName = "ios";
   setUserAgent(ORIGINAL_USER_AGENT);
@@ -170,6 +173,57 @@ describe("RemoteWebPairingPage", () => {
       AbortSignal,
     );
     expect(createRemoteWebPairingChallengeMock).not.toHaveBeenCalled();
+  });
+
+  test("cancel leaves the origin for the hub chooser", async () => {
+    remoteGatewayMode = true;
+    injectedHubUrl = "https://hub.example.com/assistant";
+    const assignMock = mock((_url: string) => {});
+    const originalAssign = window.location.assign;
+    Object.defineProperty(window.location, "assign", {
+      value: assignMock,
+      configurable: true,
+    });
+
+    try {
+      render(
+        <MemoryRouter
+          initialEntries={["/assistant/pair?deviceCode=device-1&userCode=ABCD"]}
+        >
+          <RemoteWebPairingPage />
+        </MemoryRouter>,
+      );
+
+      expect(await screen.findByText("Waiting for approval")).not.toBeNull();
+      fireEvent.click(screen.getByText("Cancel"));
+
+      // An in-app navigate would be bounced back here by the remote-gateway
+      // pairing guard, so cancelling must cross to the hub's own origin.
+      expect(assignMock.mock.calls[0]?.[0]).toBe(
+        "https://hub.example.com/assistant/select-assistant?noAutoSkip=1",
+      );
+    } finally {
+      Object.defineProperty(window.location, "assign", {
+        value: originalAssign,
+        configurable: true,
+      });
+    }
+  });
+
+  test("cancel is hidden when the served config names no hub", async () => {
+    remoteGatewayMode = true;
+    injectedHubUrl = undefined;
+
+    render(
+      <MemoryRouter
+        initialEntries={["/assistant/pair?deviceCode=device-1&userCode=ABCD"]}
+      >
+        <RemoteWebPairingPage />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Waiting for approval")).not.toBeNull();
+    expect(screen.queryByText("Cancel")).toBeNull();
   });
 
   test("shows progress state while creating a challenge", () => {

--- a/clients/web/src/domains/remote-web/pairing-page.tsx
+++ b/clients/web/src/domains/remote-web/pairing-page.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/lib/auth/remote-gateway-session";
 import {
   getRemoteGatewayAssistantName,
+  getRemoteGatewayHubUrl,
   isRemoteGatewayMode,
 } from "@/lib/local-mode";
 import { isNativePlatform } from "@/runtime/native-auth";
@@ -180,6 +181,25 @@ function buildAppHandoffUrl(
     `package=${VELLUM_ANDROID_PACKAGE};` +
     `S.browser_fallback_url=${fallbackUrl};end`
   );
+}
+
+/**
+ * The hub's chooser on its own origin, or `null` when the served config names
+ * no hub. Abandoning a pairing has to leave this origin: the chooser sits
+ * behind `requireRemoteGatewayPairing`, which bounces an unauthenticated visit
+ * straight back here and mints a fresh code. `noAutoSkip` keeps the hub on the
+ * chooser instead of skipping through a lone assistant.
+ */
+function hubChooserUrl(): string | null {
+  const hubUrl = getRemoteGatewayHubUrl();
+  if (!hubUrl) {
+    return null;
+  }
+  try {
+    return `${new URL(hubUrl).origin}${routes.selectAssistant}?noAutoSkip=1`;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -391,6 +411,8 @@ export function RemoteWebPairingPage() {
     setState({ kind: "verifying" });
   }, []);
 
+  const cancelUrl = useMemo(() => hubChooserUrl(), []);
+
   if (!enabled) {
     return <NotFound />;
   }
@@ -434,6 +456,17 @@ export function RemoteWebPairingPage() {
           <p className="text-body-small-lighter mt-4 text-[var(--content-tertiary)]">
             Expires {new Date(state.expiresAt).toLocaleTimeString()}.
           </p>
+        ) : null}
+
+        {state.kind === "polling" && cancelUrl ? (
+          <Button
+            variant="outlined"
+            fullWidth
+            className="mt-6"
+            onClick={() => window.location.assign(cancelUrl)}
+          >
+            Cancel
+          </Button>
         ) : null}
       </section>
     </main>

--- a/clients/web/src/domains/remote-web/pairing-page.tsx
+++ b/clients/web/src/domains/remote-web/pairing-page.tsx
@@ -25,7 +25,7 @@ import {
 } from "@/lib/local-mode";
 import { isNativePlatform } from "@/runtime/native-auth";
 import { isAndroidBrowser, isIOSBrowser } from "@/runtime/platform-detection";
-import { nativeSwitchToOrigin } from "@/runtime/self-hosted-servers";
+import { nativeSwitchToOriginPath } from "@/runtime/self-hosted-servers";
 import { sanitizeReturnTo } from "@/utils/return-to";
 import { routes } from "@/utils/routes";
 
@@ -414,7 +414,10 @@ export function RemoteWebPairingPage() {
 
   const cancelUrl = useMemo(() => hubChooserUrl(), []);
   const handleCancel = useCallback(() => {
-    void nativeSwitchToOrigin(null).then((switched) => {
+    void nativeSwitchToOriginPath(
+      null,
+      `select-assistant?noAutoSkip=1`,
+    ).then((switched) => {
       if (!switched && cancelUrl) {
         window.location.assign(cancelUrl);
       }

--- a/clients/web/src/domains/remote-web/pairing-page.tsx
+++ b/clients/web/src/domains/remote-web/pairing-page.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/lib/local-mode";
 import { isNativePlatform } from "@/runtime/native-auth";
 import { isAndroidBrowser, isIOSBrowser } from "@/runtime/platform-detection";
+import { nativeSwitchToOrigin } from "@/runtime/self-hosted-servers";
 import { sanitizeReturnTo } from "@/utils/return-to";
 import { routes } from "@/utils/routes";
 
@@ -412,6 +413,13 @@ export function RemoteWebPairingPage() {
   }, []);
 
   const cancelUrl = useMemo(() => hubChooserUrl(), []);
+  const handleCancel = useCallback(() => {
+    void nativeSwitchToOrigin(null).then((switched) => {
+      if (!switched && cancelUrl) {
+        window.location.assign(cancelUrl);
+      }
+    });
+  }, [cancelUrl]);
 
   if (!enabled) {
     return <NotFound />;
@@ -463,7 +471,7 @@ export function RemoteWebPairingPage() {
             variant="outlined"
             fullWidth
             className="mt-6"
-            onClick={() => window.location.assign(cancelUrl)}
+            onClick={handleCancel}
           >
             Cancel
           </Button>

--- a/clients/web/src/runtime/self-hosted-servers.test.ts
+++ b/clients/web/src/runtime/self-hosted-servers.test.ts
@@ -66,6 +66,14 @@ const switchToMock = mock(async (_options: { url?: string }) => {
   }
   return { ok: true };
 });
+const switchToPathMock = mock(
+  async (_options: { url?: string; path: string }) => {
+    if (bridgeRejects) {
+      throw bridgeFailure("switchToPath");
+    }
+    return { ok: true };
+  },
+);
 
 mock.module("@capacitor/core", () => ({
   registerPlugin: (name: string) =>
@@ -75,6 +83,7 @@ mock.module("@capacitor/core", () => ({
           add: addMock,
           remove: removeMock,
           switchTo: switchToMock,
+          switchToPath: switchToPathMock,
         }
       : {},
 }));
@@ -83,6 +92,7 @@ const {
   installNativeRememberedOrigins,
   nativeRememberedOriginsProvider,
   nativeSwitchToOrigin,
+  nativeSwitchToOriginPath,
   nativeVellumCloudOrigin,
 } = await import("@/runtime/self-hosted-servers");
 
@@ -107,6 +117,7 @@ beforeEach(() => {
   addMock.mockClear();
   removeMock.mockClear();
   switchToMock.mockClear();
+  switchToPathMock.mockClear();
   consoleDebugSpy.mockClear();
   window.localStorage.clear();
 });
@@ -325,6 +336,24 @@ describe("nativeSwitchToOrigin", () => {
   test("a null url asks for the baked origin", async () => {
     expect(await nativeSwitchToOrigin(null)).toBe(true);
     expect(switchToMock).toHaveBeenCalledWith({});
+  });
+
+  test("switches to a relative path atomically", async () => {
+    expect(
+      await nativeSwitchToOriginPath(null, "select-assistant?noAutoSkip=1"),
+    ).toBe(true);
+    expect(switchToPathMock).toHaveBeenCalledWith({
+      path: "select-assistant?noAutoSkip=1",
+    });
+  });
+
+  test("path switching resolves false on an older shell", async () => {
+    bridgeRejects = true;
+
+    expect(
+      await nativeSwitchToOriginPath(null, "select-assistant?noAutoSkip=1"),
+    ).toBe(false);
+    expect(consoleDebugSpy).toHaveBeenCalled();
   });
 
   test("resolves false on an older shell so the caller can fall back", async () => {

--- a/clients/web/src/runtime/self-hosted-servers.ts
+++ b/clients/web/src/runtime/self-hosted-servers.ts
@@ -53,6 +53,11 @@ interface SelfHostedServersPlugin {
   remove(options: { url: string }): Promise<{ ok: boolean }>;
   /** An absent `url` returns the shell to its baked Vellum Cloud origin. */
   switchTo(options: { url?: string }): Promise<{ ok: boolean }>;
+  /** Switches origin and loads a route relative to the assistant app entry. */
+  switchToPath(options: {
+    url?: string;
+    path: string;
+  }): Promise<{ ok: boolean }>;
 }
 
 /**
@@ -242,6 +247,29 @@ export async function nativeSwitchToOrigin(
     return true;
   } catch (err) {
     console.debug("[self-hosted-servers] switchTo unavailable:", err);
+    return false;
+  }
+}
+
+/**
+ * Switch the shell to an origin and load a route atomically. A separate bridge
+ * method preserves the skew fallback when an older shell lacks path support.
+ */
+export async function nativeSwitchToOriginPath(
+  url: string | null,
+  path: string,
+): Promise<boolean> {
+  if (!isNativeMobile()) {
+    return false;
+  }
+  try {
+    await SelfHostedServers.switchToPath({
+      ...(url === null ? {} : { url }),
+      path,
+    });
+    return true;
+  } catch (err) {
+    console.debug("[self-hosted-servers] switchToPath unavailable:", err);
     return false;
   }
 }


### PR DESCRIPTION
## Summary

- Adds a **Cancel** button to the pair page's `polling` ("Waiting for approval") state that navigates to the hub's assistant chooser.
- The target is built from `getRemoteGatewayHubUrl()` — the `hubUrl` #40317 threaded into the remote-web config — as `${hubOrigin}/assistant/select-assistant?noAutoSkip=1`.
- The button is **hidden** when the served config names no hub, since there is then nowhere real to send the visitor.

## Why the navigation crosses origins

The obvious implementation — `navigate(routes.selectAssistant)` — would silently fail. `select-assistant` is a child of `/assistant`, which carries `authMiddleware`, and `requireRemoteGatewayPairing` sits at position 4 of the guard pipeline, *ahead* of `requireAuth`. Anyone waiting for approval is unauthenticated by definition, so the guard would redirect them straight back to `/assistant/pair` — which mints a fresh code. Cancel would read as "restart pairing".

Crossing to the hub's own origin is the only way out, mirroring `openAssistantChooser` in `domains/settings/pages/general-page.tsx`. This also stays in-app inside the iOS shell: `MyViewController.instanceDescriptor()` puts the baked cloud host in `allowedNavigationHostnames`, so it is not ejected to the system browser.

## Decisions worth a look

- **No `register=` param.** `openAssistantChooser` includes it to self-register the origin in the hub's remembered list, but someone cancelling is not opting in — and they almost certainly arrived *from* that chooser, so the entry already exists.
- **`noAutoSkip=1`** so the hub lands on the chooser rather than skipping through a lone assistant.
- **Hidden without a hub** rather than falling back to an in-app navigate, which would restart pairing — worse than no button.
- Cancelling stops the client-side poll by unmounting. There is no revoke endpoint, so the pending challenge stays live until its TTL lapses.

## Original prompt

Asked for a Cancel button on the "Waiting for approval" page that returns the user to the assistant picker, found while QAing the origin-model assistant chooser over a tunnel.