### PR TITLE
State the bound-identity rule once, instead of in four places

### DIFF
--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -1782,25 +1782,45 @@ describe("outbound verification sessions", () => {
     expect(result.success).toBe(true);
   });
 
-  // ── Voice identity match via expectedExternalUserId ──
+  // ── Voice identity is the number ──
 
-  test("Voice identity match succeeds via expectedExternalUserId", async () => {
+  test("a voice session is redeemed by the number it was sent to", async () => {
+    // Voice knows the caller by one thing, so the consume path receives that
+    // number as both actor axes. Every voice mint records it in both
+    // identity columns, and either way the session is bound to the number.
     const { secret } = await createOutboundSession({
       channel: "phone",
-      expectedExternalUserId: "voice-user-42",
-      expectedPhoneE164: "+15551234567",
-      destinationAddress: "+15551234567",
+      expectedExternalUserId: "+15555550101",
+      expectedPhoneE164: "+15555550101",
+      destinationAddress: "+15555550101",
     });
 
-    // Actor matches expectedExternalUserId
     const result = await validateAndConsumeVerification(
       "phone",
       secret,
-      "voice-user-42",
-      "voice-chat-1",
+      "+15555550101",
+      "+15555550101",
     );
 
     expect(result.success).toBe(true);
+  });
+
+  test("a voice session refuses a caller on a different number", async () => {
+    const { secret } = await createOutboundSession({
+      channel: "phone",
+      expectedExternalUserId: "+15555550101",
+      expectedPhoneE164: "+15555550101",
+      destinationAddress: "+15555550101",
+    });
+
+    const result = await validateAndConsumeVerification(
+      "phone",
+      secret,
+      "+15555550102",
+      "+15555550102",
+    );
+
+    expect(result.success).toBe(false);
   });
 });
 

--- a/assistant/src/__tests__/helpers/verification-sessions-ipc-sim.ts
+++ b/assistant/src/__tests__/helpers/verification-sessions-ipc-sim.ts
@@ -22,6 +22,8 @@
 import { randomBytes, randomUUID } from "node:crypto";
 
 import {
+  bindsSameIdentity,
+  boundIdentity,
   hashVerificationSecret,
   VERIFICATION_SESSIONS_IPC_METHODS,
   type VerificationSessionWire,
@@ -65,29 +67,10 @@ function isInterceptable(s: VerificationSessionWire): boolean {
 const OUTBOUND_LIVE_STATUSES = ["pending_bootstrap", "awaiting_response"];
 
 /**
- * The identity a session redeems on, in `checkIdentityMatch`'s precedence
- * order. Null when the session carries none, which is a bootstrap session.
- */
-function boundIdentity(session: {
-  expectedExternalUserId?: string | null;
-  expectedChatId?: string | null;
-  expectedPhoneE164?: string | null;
-}): string | null {
-  if (session.expectedExternalUserId) {
-    return `user:${session.expectedExternalUserId}`;
-  }
-  if (session.expectedPhoneE164) {
-    return `phone:${session.expectedPhoneE164}`;
-  }
-  if (session.expectedChatId) {
-    return `chat:${session.expectedChatId}`;
-  }
-  return null;
-}
-
-/**
  * Mirrors the gateway store: an outbound mint supersedes only sessions bound
  * to the same identity, leaving other actors and inbound challenges alone.
+ * The identity rule itself comes from the shared contract, so this cannot
+ * drift from what the gateway does.
  */
 function revokeSameActorOutbound(
   channel: string,
@@ -102,7 +85,7 @@ function revokeSameActorOutbound(
     if (
       s.channel === channel &&
       OUTBOUND_LIVE_STATUSES.includes(s.status) &&
-      boundIdentity(s) === identity
+      bindsSameIdentity(boundIdentity(s), identity)
     ) {
       s.status = "revoked";
       s.updatedAt = now;

--- a/assistant/src/__tests__/helpers/verification-sessions-ipc-sim.ts
+++ b/assistant/src/__tests__/helpers/verification-sessions-ipc-sim.ts
@@ -505,50 +505,24 @@ function recordInvalidAttempt(key: string): void {
   rateLimits.set(key, entry);
 }
 
+/**
+ * Mirrors the gateway consume path. Both sides read the shared
+ * `boundIdentity`, so the sim cannot accept a code the real service would
+ * refuse. A session bound to no identity, or not yet finally bound
+ * (`pending_bootstrap`), bypasses the check as it does at the gateway.
+ */
 function checkIdentityMatch(
   session: VerificationSessionWire,
   actorExternalUserId: string,
   actorChatId: string,
 ): boolean {
-  const hasExpectedIdentity =
-    session.expectedExternalUserId != null ||
-    session.expectedChatId != null ||
-    session.expectedPhoneE164 != null;
-  // pending_bootstrap (and unbound inbound) sessions bypass the check.
-  if (!hasExpectedIdentity || session.identityBindingStatus !== "bound") {
+  const identity = boundIdentity(session);
+  if (identity === null || session.identityBindingStatus !== "bound") {
     return true;
   }
-
-  if (
-    session.expectedPhoneE164 != null &&
-    (actorExternalUserId === session.expectedPhoneE164 ||
-      actorExternalUserId === session.expectedExternalUserId)
-  ) {
-    return true;
-  }
-
-  // Shared-chatId caveat: when both expected fields are set, require the
-  // externalUserId match — chat IDs can be shared.
-  if (session.expectedChatId != null) {
-    if (session.expectedExternalUserId != null) {
-      if (actorExternalUserId === session.expectedExternalUserId) {
-        return true;
-      }
-    } else if (actorChatId === session.expectedChatId) {
-      return true;
-    }
-  }
-
-  if (
-    session.expectedPhoneE164 == null &&
-    session.expectedChatId == null &&
-    session.expectedExternalUserId != null &&
-    actorExternalUserId === session.expectedExternalUserId
-  ) {
-    return true;
-  }
-
-  return false;
+  return identity.field === "chatId"
+    ? actorChatId === identity.value
+    : actorExternalUserId === identity.value;
 }
 
 export function validateAndConsumeVerification(

--- a/assistant/src/runtime/verification-outbound-actions.ts
+++ b/assistant/src/runtime/verification-outbound-actions.ts
@@ -920,14 +920,15 @@ export async function resendOutbound(
     };
   }
 
-  const resendDestination =
+  const destination =
     session.destinationAddress ??
     session.expectedPhoneE164 ??
     session.expectedChatId;
-  if (resendDestination) {
+
+  if (destination) {
     const recentDestSends = await countRecentSendsToDestination(
       channel,
-      resendDestination,
+      destination,
       DESTINATION_RATE_WINDOW_MS,
     );
     if (recentDestSends >= MAX_SENDS_PER_DESTINATION_WINDOW) {
@@ -941,10 +942,6 @@ export async function resendOutbound(
     }
   }
 
-  const destination =
-    session.destinationAddress ??
-    session.expectedPhoneE164 ??
-    session.expectedChatId;
   if (!destination) {
     return {
       success: false,

--- a/gateway/src/db/session-store.ts
+++ b/gateway/src/db/session-store.ts
@@ -389,7 +389,13 @@ function revokeSameIdentityOutbound(
 
   const db = getGatewayDb();
   const live = db
-    .select()
+    .select({
+      id: channelVerificationSessions.id,
+      expectedExternalUserId:
+        channelVerificationSessions.expectedExternalUserId,
+      expectedChatId: channelVerificationSessions.expectedChatId,
+      expectedPhoneE164: channelVerificationSessions.expectedPhoneE164,
+    })
     .from(channelVerificationSessions)
     .where(
       and(

--- a/gateway/src/db/session-store.ts
+++ b/gateway/src/db/session-store.ts
@@ -8,20 +8,12 @@
  */
 
 import type { Database } from "bun:sqlite";
-import {
-  and,
-  count,
-  desc,
-  eq,
-  gt,
-  gte,
-  inArray,
-  isNull,
-  type SQL,
-} from "drizzle-orm";
+import { and, count, desc, eq, gt, gte, inArray } from "drizzle-orm";
 
+import { bindsSameIdentity, boundIdentity } from "@vellumai/gateway-client";
 import type {
   IdentityBindingStatus,
+  IdentityBoundSession,
   SessionStatus,
   VerificationPurpose,
   VerificationSessionWire,
@@ -371,74 +363,69 @@ export function claimBootstrapSession(id: string, channel: string): boolean {
 // ---------------------------------------------------------------------------
 
 /**
- * Match rows bound to the same identity a new mint is bound to.
+ * Revoke live outbound sessions bound to the same identity as a new mint, so
+ * only the latest code for that identity is redeemable.
  *
- * The key is whichever field `checkIdentityMatch` actually redeems on, in its
- * precedence order, and the match requires the stored row to be keyed the same
- * way. A row carrying both a chat id and a user id redeems only on the user id
- * (`identity-match.ts` treats a shared chat id as insufficient), so it is not
- * matched by a chat-keyed mint: two people in one group chat keep their own
- * codes.
+ * The candidates are read and then filtered through `boundIdentity`, the same
+ * function the consume path redeems on, rather than through a SQL predicate
+ * restating its precedence. A predicate would be a second copy of that rule
+ * that has to be kept in step by hand, and the two drifting apart is a silent
+ * one-time-code bug: a mint that identifies its recipient by a field the
+ * predicate does not check revokes nothing, and every earlier code stays
+ * spendable for its full TTL.
  *
- * Returns null when the mint carries no identity at all, which is a bootstrap
- * session; those are claimed by `claimBootstrapSession` instead.
+ * A mint bound to no identity revokes nothing. That is a bootstrap session,
+ * claimed by `claimBootstrapSession` instead.
  */
-function sameBoundIdentity(params: {
-  expectedExternalUserId?: string | null;
-  expectedChatId?: string | null;
-  expectedPhoneE164?: string | null;
-}): SQL | undefined {
-  if (params.expectedExternalUserId) {
-    return eq(
-      channelVerificationSessions.expectedExternalUserId,
-      params.expectedExternalUserId,
-    );
+function revokeSameIdentityOutbound(
+  channel: string,
+  mint: IdentityBoundSession,
+  now: number,
+): void {
+  const identity = boundIdentity(mint);
+  if (identity === null) {
+    return;
   }
-  if (params.expectedPhoneE164) {
-    return and(
-      eq(
-        channelVerificationSessions.expectedPhoneE164,
-        params.expectedPhoneE164,
+
+  const db = getGatewayDb();
+  const live = db
+    .select()
+    .from(channelVerificationSessions)
+    .where(
+      and(
+        eq(channelVerificationSessions.channel, channel),
+        inArray(channelVerificationSessions.status, OUTBOUND_LIVE_STATUSES),
       ),
-      isNull(channelVerificationSessions.expectedExternalUserId),
-    );
+    )
+    .all();
+
+  const superseded = live
+    .filter((row) => bindsSameIdentity(boundIdentity(row), identity))
+    .map((row) => row.id);
+  if (superseded.length === 0) {
+    return;
   }
-  if (params.expectedChatId) {
-    return and(
-      eq(channelVerificationSessions.expectedChatId, params.expectedChatId),
-      isNull(channelVerificationSessions.expectedExternalUserId),
-      isNull(channelVerificationSessions.expectedPhoneE164),
-    );
-  }
-  return undefined;
+
+  db.update(channelVerificationSessions)
+    .set({ status: "revoked", updatedAt: now })
+    .where(inArray(channelVerificationSessions.id, superseded))
+    .run();
 }
 
 /**
  * Create an outbound verification session with expected-identity binding.
  *
- * Supersedes the actor's own prior outbound sessions, so only their latest
- * code is live and an intercepted earlier one is useless.
- *
- * The supersede is scoped to the actor rather than the channel, because that
- * is the scope the replay window has. Two people's codes have no replay
- * relationship: `checkIdentityMatch` binds each to its own expected identity,
- * so A's code cannot be spent against B's session. A channel-wide revoke would
+ * Supersedes prior outbound sessions bound to the same identity
+ * (`revokeSameIdentityOutbound`), so only that identity's latest code is live
+ * and an intercepted earlier one is useless. The scope is the identity rather
+ * than the channel because that is the scope the replay window has: two
+ * people's codes have no replay relationship, so a channel-wide revoke would
  * take a stranger's live code away for no security benefit, and on a channel
- * where several people can verify at once that is ordinary traffic rather than
- * an edge case.
- *
- * Which field carries that identity is per-channel, so the scope is keyed on
- * whichever one the consume path redeems on (`sameBoundIdentity`). Telegram
- * guardian mints carry only a chat id, and keying on the user id alone would
- * leave every earlier code on that chat live for its full TTL.
+ * where several people verify at once that is ordinary traffic.
  *
  * Inbound (`pending`) sessions are left alone. They have their own supersede
  * in `createInboundSession`, and an outbound mint has nothing to say about an
  * inbound challenge.
- *
- * A session with no expected identity supersedes nothing by actor: a bootstrap
- * session has no actor until its deep link is redeemed. Those are claimed by
- * `claimBootstrapSession` before the mint, not superseded by identity here.
  */
 export function createOutboundSession(params: {
   id: string;
@@ -460,19 +447,7 @@ export function createOutboundSession(params: {
   const db = getGatewayDb();
   const now = Date.now();
 
-  const sameActor = sameBoundIdentity(params);
-  if (sameActor) {
-    db.update(channelVerificationSessions)
-      .set({ status: "revoked", updatedAt: now })
-      .where(
-        and(
-          eq(channelVerificationSessions.channel, params.channel),
-          inArray(channelVerificationSessions.status, OUTBOUND_LIVE_STATUSES),
-          sameActor,
-        ),
-      )
-      .run();
-  }
+  revokeSameIdentityOutbound(params.channel, params, now);
 
   const row = {
     id: params.id,

--- a/gateway/src/verification/__tests__/identity-match.test.ts
+++ b/gateway/src/verification/__tests__/identity-match.test.ts
@@ -91,6 +91,15 @@ describe("checkIdentityMatch", () => {
     expect(checkIdentityMatch(s, "+15555550102", "+15555550102")).toBe(false);
   });
 
+  test("an empty identity admits nobody, rather than everybody", () => {
+    // Truthiness here would report the session unbound, and an unbound
+    // session admits any holder of the code. A set-but-empty identity is a
+    // broken session, and a broken session must fail closed.
+    const s = session({ expectedExternalUserId: "" });
+    expect(boundIdentity(s)).toEqual({ field: "externalUserId", value: "" });
+    expect(checkIdentityMatch(s, ALICE, ROOM)).toBe(false);
+  });
+
   test("an unbound session admits anyone", () => {
     // Inbound challenges rely on code secrecy alone, and a bootstrap session
     // is bound by the bootstrap path rather than here.

--- a/gateway/src/verification/__tests__/identity-match.test.ts
+++ b/gateway/src/verification/__tests__/identity-match.test.ts
@@ -197,3 +197,103 @@ describe("the supersede scope and the consume path agree", () => {
     });
   }
 });
+
+describe("invariants across every session shape", () => {
+  // Example-based cases test the shapes someone thought of. These sweep the
+  // whole space, because the bugs this file guards have twice been a shape
+  // nobody had in mind: a mint identified by a field the rule did not check,
+  // and an empty identity read as no identity at all.
+  const VALUES = [null, "A", "B", ""];
+  const ACTORS = ["A", "B", ""];
+
+  function everyShape(
+    visit: (
+      session: {
+        expectedPhoneE164: string | null;
+        expectedExternalUserId: string | null;
+        expectedChatId: string | null;
+        identityBindingStatus: string;
+      },
+      actorUserId: string,
+      actorChatId: string,
+    ) => void,
+  ): void {
+    for (const p of VALUES) {
+      for (const u of VALUES) {
+        for (const c of VALUES) {
+          for (const au of ACTORS) {
+            for (const ac of ACTORS) {
+              visit(
+                {
+                  expectedPhoneE164: p,
+                  expectedExternalUserId: u,
+                  expectedChatId: c,
+                  identityBindingStatus: "bound",
+                },
+                au,
+                ac,
+              );
+            }
+          }
+        }
+      }
+    }
+  }
+
+  test("a session naming a person is never satisfied by a different person", () => {
+    // Generalized #10593: sharing a chat, or a phone column, must never
+    // stand in for being the person the session names. Asserted for every
+    // combination of the other fields rather than the ones we remembered.
+    const violations: string[] = [];
+    everyShape((s, actorUserId, actorChatId) => {
+      if (s.expectedPhoneE164 !== null) return;
+      if (s.expectedExternalUserId === null) return;
+      if (actorUserId === s.expectedExternalUserId) return;
+      if (checkIdentityMatch(s, actorUserId, actorChatId)) {
+        violations.push(
+          `${JSON.stringify(s)} admitted user=${actorUserId} chat=${actorChatId}`,
+        );
+      }
+    });
+    expect(violations).toEqual([]);
+  });
+
+  test("a bound session is never satisfied by an actor matching nothing on it", () => {
+    // The fail-open shape: something about the session makes the check
+    // decide there is nothing to check, and any holder of the code gets in.
+    const violations: string[] = [];
+    everyShape((s, actorUserId, actorChatId) => {
+      const values = [
+        s.expectedPhoneE164,
+        s.expectedExternalUserId,
+        s.expectedChatId,
+      ].filter((v): v is string => v !== null);
+      if (values.length === 0) return;
+      if (values.includes(actorUserId) || values.includes(actorChatId)) return;
+      if (checkIdentityMatch(s, actorUserId, actorChatId)) {
+        violations.push(
+          `${JSON.stringify(s)} admitted user=${actorUserId} chat=${actorChatId}`,
+        );
+      }
+    });
+    expect(violations).toEqual([]);
+  });
+
+  test("whoever is admitted matches the identity the supersede scopes on", () => {
+    // The two sides cannot part company: the actor the consume path lets in
+    // is the one whose earlier codes a fresh mint kills.
+    const violations: string[] = [];
+    everyShape((s, actorUserId, actorChatId) => {
+      if (!checkIdentityMatch(s, actorUserId, actorChatId)) return;
+      const identity = boundIdentity(s);
+      if (identity === null) return;
+      const presented = identity.field === "chatId" ? actorChatId : actorUserId;
+      if (presented !== identity.value) {
+        violations.push(
+          `${JSON.stringify(s)} admitted ${presented} but scopes on ${identity.field}=${identity.value}`,
+        );
+      }
+    });
+    expect(violations).toEqual([]);
+  });
+});

--- a/gateway/src/verification/__tests__/identity-match.test.ts
+++ b/gateway/src/verification/__tests__/identity-match.test.ts
@@ -1,0 +1,190 @@
+/**
+ * The precedence that decides who may redeem a code.
+ *
+ * Both directions of getting it wrong are silent. Too loose and a stranger in
+ * a shared chat spends someone else's code. Too narrow and a mint supersedes
+ * nothing, leaving every earlier code live for its full TTL while the consume
+ * path still accepts them. Neither shows up as an error, so these assert the
+ * rule directly rather than through a flow.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { bindsSameIdentity, boundIdentity } from "@vellumai/gateway-client";
+
+import { checkIdentityMatch } from "../identity-match.js";
+
+const ALICE = "U-ALICE";
+const BOB = "U-BOB";
+const ROOM = "C-ROOM";
+const PHONE = "+15555550101";
+
+/** A bound session carrying whichever identity fields a case needs. */
+function session(fields: {
+  expectedExternalUserId?: string;
+  expectedChatId?: string;
+  expectedPhoneE164?: string;
+  identityBindingStatus?: string;
+}) {
+  return { identityBindingStatus: "bound", ...fields };
+}
+
+describe("boundIdentity", () => {
+  test("a phone session is bound to the number", () => {
+    // Both columns carry the same value at every mint site, so this is the
+    // one identity rather than two that happen to agree.
+    expect(
+      boundIdentity(
+        session({ expectedPhoneE164: PHONE, expectedExternalUserId: PHONE }),
+      ),
+    ).toEqual({ field: "phoneE164", value: PHONE });
+  });
+
+  test("a person outranks the room they are in", () => {
+    expect(
+      boundIdentity(
+        session({ expectedExternalUserId: ALICE, expectedChatId: ROOM }),
+      ),
+    ).toEqual({ field: "externalUserId", value: ALICE });
+  });
+
+  test("a room counts only when nothing identifies a person", () => {
+    expect(boundIdentity(session({ expectedChatId: ROOM }))).toEqual({
+      field: "chatId",
+      value: ROOM,
+    });
+  });
+
+  test("a session with no identity is bound to none", () => {
+    // Inbound challenges and bootstrap sessions before redemption.
+    expect(boundIdentity(session({}))).toBeNull();
+  });
+});
+
+describe("checkIdentityMatch", () => {
+  test("the bound person may redeem, anyone else may not", () => {
+    const s = session({ expectedExternalUserId: ALICE });
+    expect(checkIdentityMatch(s, ALICE, ROOM)).toBe(true);
+    expect(checkIdentityMatch(s, BOB, ROOM)).toBe(false);
+  });
+
+  test("sharing the room is not enough when the session names a person", () => {
+    // The case the precedence exists for: Bob is in the same channel and
+    // must not be able to spend Alice's code.
+    const s = session({ expectedExternalUserId: ALICE, expectedChatId: ROOM });
+    expect(checkIdentityMatch(s, BOB, ROOM)).toBe(false);
+  });
+
+  test("a room-bound session is satisfied by the room", () => {
+    const s = session({ expectedChatId: ROOM });
+    expect(checkIdentityMatch(s, BOB, ROOM)).toBe(true);
+    expect(checkIdentityMatch(s, BOB, "C-OTHER")).toBe(false);
+  });
+
+  test("a caller with one identifier passes it as both axes", () => {
+    // How voice calls this: `fromNumber` is the whole identity it has.
+    const s = session({
+      expectedPhoneE164: PHONE,
+      expectedExternalUserId: PHONE,
+    });
+    expect(checkIdentityMatch(s, PHONE, PHONE)).toBe(true);
+    expect(checkIdentityMatch(s, "+15555550102", "+15555550102")).toBe(false);
+  });
+
+  test("an unbound session admits anyone", () => {
+    // Inbound challenges rely on code secrecy alone, and a bootstrap session
+    // is bound by the bootstrap path rather than here.
+    expect(checkIdentityMatch(session({}), BOB, ROOM)).toBe(true);
+    expect(
+      checkIdentityMatch(
+        {
+          expectedExternalUserId: ALICE,
+          identityBindingStatus: "pending_bootstrap",
+        },
+        BOB,
+        ROOM,
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("bindsSameIdentity", () => {
+  test("two people on one channel are not the same identity", () => {
+    expect(
+      bindsSameIdentity(
+        boundIdentity(session({ expectedExternalUserId: ALICE })),
+        boundIdentity(session({ expectedExternalUserId: BOB })),
+      ),
+    ).toBe(false);
+  });
+
+  test("a room-bound session is not the same as a person in that room", () => {
+    // Otherwise a mint for the room would supersede Alice's own code, which
+    // is the group-chat case the precedence protects.
+    expect(
+      bindsSameIdentity(
+        boundIdentity(
+          session({ expectedExternalUserId: ALICE, expectedChatId: ROOM }),
+        ),
+        boundIdentity(session({ expectedChatId: ROOM })),
+      ),
+    ).toBe(false);
+  });
+
+  test("the same room twice is the same identity", () => {
+    expect(
+      bindsSameIdentity(
+        boundIdentity(session({ expectedChatId: ROOM })),
+        boundIdentity(session({ expectedChatId: ROOM })),
+      ),
+    ).toBe(true);
+  });
+
+  test("no identity is never the same as anything, including itself", () => {
+    // Bootstrap sessions are claimed by id, not superseded by identity, so
+    // an unbound mint must not sweep up every other unbound row.
+    expect(bindsSameIdentity(null, null)).toBe(false);
+    expect(
+      bindsSameIdentity(null, boundIdentity(session({ expectedChatId: ROOM }))),
+    ).toBe(false);
+  });
+});
+
+describe("the supersede scope and the consume path agree", () => {
+  // The property this file exists to hold. A mint supersedes prior sessions
+  // bound to the same identity, and the consume path decides who may redeem
+  // one. If those two ever disagree, a code survives a mint that should have
+  // killed it and stays spendable by the same actor.
+  const CASES: Array<{ name: string; fields: Parameters<typeof session>[0] }> =
+    [
+      { name: "person", fields: { expectedExternalUserId: ALICE } },
+      {
+        name: "person in a room",
+        fields: { expectedExternalUserId: ALICE, expectedChatId: ROOM },
+      },
+      { name: "room only", fields: { expectedChatId: ROOM } },
+      {
+        name: "phone",
+        fields: { expectedPhoneE164: PHONE, expectedExternalUserId: PHONE },
+      },
+    ];
+
+  for (const { name, fields } of CASES) {
+    test(`${name}: whoever can redeem it is who a re-mint supersedes`, () => {
+      const existing = session(fields);
+      const identity = boundIdentity(existing)!;
+
+      // A fresh mint for the same identity supersedes the existing session.
+      expect(bindsSameIdentity(boundIdentity(session(fields)), identity)).toBe(
+        true,
+      );
+
+      // And the actor that identity describes is the one the consume path
+      // admits, on the axis the identity is carried by.
+      const actorUserId =
+        identity.field === "chatId" ? "U-ANYONE" : identity.value;
+      const actorChatId = identity.field === "chatId" ? identity.value : ROOM;
+      expect(checkIdentityMatch(existing, actorUserId, actorChatId)).toBe(true);
+    });
+  }
+});

--- a/gateway/src/verification/__tests__/identity-match.test.ts
+++ b/gateway/src/verification/__tests__/identity-match.test.ts
@@ -11,7 +11,9 @@
 import { describe, expect, test } from "bun:test";
 
 import { bindsSameIdentity, boundIdentity } from "@vellumai/gateway-client";
+import type { IdentityBindingStatus } from "@vellumai/gateway-client";
 
+import type { IdentityMatchSession } from "../identity-match.js";
 import { checkIdentityMatch } from "../identity-match.js";
 
 const ALICE = "U-ALICE";
@@ -24,8 +26,8 @@ function session(fields: {
   expectedExternalUserId?: string;
   expectedChatId?: string;
   expectedPhoneE164?: string;
-  identityBindingStatus?: string;
-}) {
+  identityBindingStatus?: IdentityBindingStatus;
+}): IdentityMatchSession {
   return { identityBindingStatus: "bound", ...fields };
 }
 
@@ -212,7 +214,7 @@ describe("invariants across every session shape", () => {
         expectedPhoneE164: string | null;
         expectedExternalUserId: string | null;
         expectedChatId: string | null;
-        identityBindingStatus: string;
+        identityBindingStatus: IdentityBindingStatus;
       },
       actorUserId: string,
       actorChatId: string,
@@ -228,7 +230,7 @@ describe("invariants across every session shape", () => {
                   expectedPhoneE164: p,
                   expectedExternalUserId: u,
                   expectedChatId: c,
-                  identityBindingStatus: "bound",
+                  identityBindingStatus: "bound" as IdentityBindingStatus,
                 },
                 au,
                 ac,

--- a/gateway/src/verification/identity-match.ts
+++ b/gateway/src/verification/identity-match.ts
@@ -10,11 +10,21 @@
  */
 
 import { boundIdentity } from "@vellumai/gateway-client";
-import type { IdentityBoundSession } from "@vellumai/gateway-client";
+import type {
+  IdentityBindingStatus,
+  IdentityBoundSession,
+} from "@vellumai/gateway-client";
 
-/** The identity fields the match rules read, plus the binding state. */
+/**
+ * The identity fields the match rules read, plus the binding state.
+ *
+ * The binding state keeps its union rather than widening to `string`. Only
+ * `bound` makes the identity decide anything, so a value outside the union
+ * reads as not-bound and admits any holder of the code; the type is what
+ * stops a caller inventing one.
+ */
 export type IdentityMatchSession = IdentityBoundSession & {
-  identityBindingStatus?: string | null;
+  identityBindingStatus?: IdentityBindingStatus | null;
 };
 
 /**

--- a/gateway/src/verification/identity-match.ts
+++ b/gateway/src/verification/identity-match.ts
@@ -1,77 +1,43 @@
 /**
- * Identity matching for verification sessions.
+ * Whether an actor may redeem a session's code.
  *
- * Mirrors the assistant's channel-verification-service.ts identity check.
- * Determines whether the actor submitting a verification code matches the
- * expected identity on an outbound session.
+ * The precedence deciding WHICH identity binds a session lives in the shared
+ * contract (`boundIdentity`), because the supersede scope in the session store
+ * has to agree with this consume-side check. The two disagreeing is a silent
+ * one-time-code bug in either direction: too loose and a stranger in a shared
+ * chat spends someone else's code, too narrow and a mint supersedes nothing
+ * and every earlier code stays spendable for its full TTL.
  */
 
-import type { VerificationSession } from "../db/session-store.js";
+import { boundIdentity } from "@vellumai/gateway-client";
+import type { IdentityBoundSession } from "@vellumai/gateway-client";
 
-/** The identity fields the match rules read — callers may pass a full row. */
-export type IdentityMatchSession = Pick<
-  VerificationSession,
-  | "expectedExternalUserId"
-  | "expectedChatId"
-  | "expectedPhoneE164"
-  | "identityBindingStatus"
->;
+/** The identity fields the match rules read, plus the binding state. */
+export type IdentityMatchSession = IdentityBoundSession & {
+  identityBindingStatus?: string | null;
+};
 
 /**
- * Check whether the actor matches the session's expected identity.
+ * Check whether the actor submitting a code matches the session's bound
+ * identity.
  *
- * Returns true if:
- * - The session has no expected identity (inbound sessions)
- * - The session's identity binding status is not 'bound' (pending_bootstrap)
- * - The actor matches the expected identity
+ * True when the session is bound to no identity (an inbound challenge, which
+ * relies on code secrecy alone), or when its binding is not yet final
+ * (`pending_bootstrap`, where the bootstrap path does the binding).
+ *
+ * A caller holding a single identifier for the actor, such as voice, passes it
+ * as both arguments.
  */
 export function checkIdentityMatch(
   session: IdentityMatchSession,
   actorExternalUserId: string,
   actorChatId: string,
 ): boolean {
-  const hasExpectedIdentity =
-    session.expectedExternalUserId != null ||
-    session.expectedChatId != null ||
-    session.expectedPhoneE164 != null;
-
-  if (!hasExpectedIdentity || session.identityBindingStatus !== "bound") {
+  const identity = boundIdentity(session);
+  if (identity === null || session.identityBindingStatus !== "bound") {
     return true;
   }
-
-  // Phone match
-  if (session.expectedPhoneE164 != null) {
-    if (
-      actorExternalUserId === session.expectedPhoneE164 ||
-      actorExternalUserId === session.expectedExternalUserId
-    ) {
-      return true;
-    }
-  }
-
-  // Chat ID match (Telegram, Slack, etc.)
-  if (session.expectedChatId != null) {
-    if (session.expectedExternalUserId != null) {
-      // When both are set, require the externalUserId match — chatId alone
-      // is insufficient (shared group chats).
-      if (actorExternalUserId === session.expectedExternalUserId) {
-        return true;
-      }
-    } else if (actorChatId === session.expectedChatId) {
-      return true;
-    }
-  }
-
-  // Fallback: only expectedExternalUserId set (no phone, no chat)
-  if (
-    session.expectedPhoneE164 == null &&
-    session.expectedChatId == null &&
-    session.expectedExternalUserId != null
-  ) {
-    if (actorExternalUserId === session.expectedExternalUserId) {
-      return true;
-    }
-  }
-
-  return false;
+  return identity.field === "chatId"
+    ? actorChatId === identity.value
+    : actorExternalUserId === identity.value;
 }

--- a/gateway/src/verification/session-service.ts
+++ b/gateway/src/verification/session-service.ts
@@ -303,10 +303,9 @@ export async function validateAndConsumeSession(
     return CONSUME_FAILURE;
   }
 
-  // Expected-identity binding check (outbound sessions). checkIdentityMatch
-  // carries the daemon's rules verbatim: phone match, the shared-chatId
-  // caveat (externalUserId required when both are set), the
-  // externalUserId-only fallback, and the pending_bootstrap bypass.
+  // Expected-identity binding check (outbound sessions). The session is
+  // bound to one identity, and only that field decides who may redeem;
+  // sessions with no identity, or not yet finally bound, pass.
   if (!checkIdentityMatch(session, actorExternalUserId, actorChatId)) {
     await recordInvalidAttempt(channel, actorExternalUserId, actorChatId);
     return CONSUME_FAILURE;

--- a/gateway/src/voice/verification.ts
+++ b/gateway/src/voice/verification.ts
@@ -24,6 +24,7 @@ import {
   findLatestSessionByStatuses,
 } from "../db/session-store.js";
 import { getLogger } from "../logger.js";
+import { checkIdentityMatch } from "../verification/identity-match.js";
 import {
   getRateLimit,
   recordInvalidAttempt,
@@ -134,61 +135,23 @@ export async function validateVerificationCode(
     };
   }
 
-  // Identity check for bound outbound sessions
-  const hasExpectedIdentity =
-    session.expectedExternalUserId != null ||
-    session.expectedChatId != null ||
-    session.expectedPhoneE164 != null;
-
-  if (hasExpectedIdentity && session.identityBindingStatus === "bound") {
-    let identityMatch = false;
-
-    if (session.expectedPhoneE164 != null) {
-      if (
-        fromNumber === session.expectedPhoneE164 ||
-        fromNumber === session.expectedExternalUserId
-      ) {
-        identityMatch = true;
-      }
-    }
-
-    if (!identityMatch && session.expectedChatId != null) {
-      if (session.expectedExternalUserId != null) {
-        if (fromNumber === session.expectedExternalUserId) {
-          identityMatch = true;
-        }
-      } else if (fromNumber === session.expectedChatId) {
-        identityMatch = true;
-      }
-    }
-
-    if (
-      !identityMatch &&
-      session.expectedPhoneE164 == null &&
-      session.expectedChatId == null &&
-      session.expectedExternalUserId != null
-    ) {
-      if (fromNumber === session.expectedExternalUserId) {
-        identityMatch = true;
-      }
-    }
-
-    if (!identityMatch) {
-      await recordInvalidAttempt("phone", fromNumber, fromNumber);
-      if (attempt + 1 >= MAX_ATTEMPTS) {
-        return {
-          success: false,
-          failureMessage: "Verification failed. Goodbye.",
-          exhausted: true,
-        };
-      }
-      const remaining = MAX_ATTEMPTS - attempt - 1;
+  // Identity check for bound outbound sessions. Voice has a single
+  // identifier for the caller, so it stands in for both actor axes.
+  if (!checkIdentityMatch(session, fromNumber, fromNumber)) {
+    await recordInvalidAttempt("phone", fromNumber, fromNumber);
+    if (attempt + 1 >= MAX_ATTEMPTS) {
       return {
         success: false,
-        failureMessage: `Incorrect code. You have ${remaining} ${remaining === 1 ? "attempt" : "attempts"} remaining. Please try again.`,
-        exhausted: false,
+        failureMessage: "Verification failed. Goodbye.",
+        exhausted: true,
       };
     }
+    const remaining = MAX_ATTEMPTS - attempt - 1;
+    return {
+      success: false,
+      failureMessage: `Incorrect code. You have ${remaining} ${remaining === 1 ? "attempt" : "attempts"} remaining. Please try again.`,
+      exhausted: false,
+    };
   }
 
   // Success — consume via the store's status-guarded UPDATE. A non-consumed

--- a/packages/gateway-client/src/index.ts
+++ b/packages/gateway-client/src/index.ts
@@ -157,6 +157,8 @@ export {
   hashVerificationSecret,
   IdentityBindingStatusSchema,
   ResolveBootstrapSessionIpcParamsSchema,
+  bindsSameIdentity,
+  boundIdentity,
   RevokePendingSessionsIpcParamsSchema,
   SessionLookupIpcResponseSchema,
   SessionMutationIpcResponseSchema,
@@ -172,6 +174,7 @@ export {
 
 export type {
   BindSessionIdentityIpcParams,
+  BoundIdentity,
   CountRecentSendsIpcParams,
   CountRecentSendsIpcResponse,
   CreateInboundSessionIpcParams,
@@ -183,6 +186,7 @@ export type {
   FindActiveSessionIpcParams,
   GetPendingSessionIpcParams,
   IdentityBindingStatus,
+  IdentityBoundSession,
   ResolveBootstrapSessionIpcParams,
   RevokePendingSessionsIpcParams,
   SessionLookupIpcResponse,

--- a/packages/gateway-client/src/verification-session-contract.ts
+++ b/packages/gateway-client/src/verification-session-contract.ts
@@ -157,13 +157,17 @@ export interface BoundIdentity {
 export function boundIdentity(
   session: IdentityBoundSession,
 ): BoundIdentity | null {
-  if (session.expectedPhoneE164) {
+  // Presence, not truthiness. An empty string is a set-but-useless identity,
+  // and treating it as absent would report the session unbound, which the
+  // consume path reads as "no identity to check" and admits anyone holding
+  // the code. Kept as a value it can compare against and fail instead.
+  if (session.expectedPhoneE164 != null) {
     return { field: "phoneE164", value: session.expectedPhoneE164 };
   }
-  if (session.expectedExternalUserId) {
+  if (session.expectedExternalUserId != null) {
     return { field: "externalUserId", value: session.expectedExternalUserId };
   }
-  if (session.expectedChatId) {
+  if (session.expectedChatId != null) {
     return { field: "chatId", value: session.expectedChatId };
   }
   return null;
@@ -261,9 +265,12 @@ export type CreateInboundSessionIpcResponse = z.infer<
 /** Request for `verification_sessions_create_outbound`. */
 export const CreateOutboundSessionIpcParamsSchema = z.object({
   channel: z.string().min(1),
-  expectedExternalUserId: z.string().optional(),
-  expectedChatId: z.string().optional(),
-  expectedPhoneE164: z.string().optional(),
+  // An identity field is either absent or a real value. An empty string is
+  // neither, and a session bound to one can never be redeemed by anybody,
+  // so reject it at the boundary rather than mint a dead code.
+  expectedExternalUserId: z.string().min(1).optional(),
+  expectedChatId: z.string().min(1).optional(),
+  expectedPhoneE164: z.string().min(1).optional(),
   identityBindingStatus: IdentityBindingStatusSchema.optional(),
   destinationAddress: z.string().optional(),
   codeDigits: z.number().int().positive().optional(),

--- a/packages/gateway-client/src/verification-session-contract.ts
+++ b/packages/gateway-client/src/verification-session-contract.ts
@@ -114,6 +114,74 @@ export const VerificationSessionSchema = z.object({
 export type VerificationSessionWire = z.infer<typeof VerificationSessionSchema>;
 
 // ---------------------------------------------------------------------------
+// Bound identity (which of the three identity columns decides who may redeem)
+// ---------------------------------------------------------------------------
+
+/** The identity fields the rules read. Callers may pass a full session row. */
+export interface IdentityBoundSession {
+  expectedExternalUserId?: string | null;
+  expectedChatId?: string | null;
+  expectedPhoneE164?: string | null;
+}
+
+/**
+ * The identity a session redeems on.
+ *
+ * `chatId` is compared against the actor's conversation and everything else
+ * against the actor themselves, which is why the field travels with the value.
+ */
+export interface BoundIdentity {
+  field: "phoneE164" | "externalUserId" | "chatId";
+  value: string;
+}
+
+/**
+ * The one identity a session is bound to, or null when it is bound to none
+ * (an inbound challenge, or a bootstrap session before its deep link is
+ * redeemed).
+ *
+ * This lives in the contract because more than one side has to agree on it:
+ * the gateway consume path decides who may redeem a code, and the supersede
+ * scope decides whose earlier codes a fresh mint kills. Those two disagreeing
+ * is a silent one-time-code bug, so the rule is stated once.
+ *
+ * Precedence, most to least specific:
+ *
+ * 1. `expectedPhoneE164` (a voice session's subject is the number itself).
+ * 2. `expectedExternalUserId` (the person).
+ * 3. `expectedChatId` (the conversation), and only when nothing identifies a
+ *    person. A chat id can be shared (a Slack channel, a Telegram group), so
+ *    on its own it would let any participant satisfy the binding. It counts
+ *    only where there is no better answer.
+ */
+export function boundIdentity(
+  session: IdentityBoundSession,
+): BoundIdentity | null {
+  if (session.expectedPhoneE164) {
+    return { field: "phoneE164", value: session.expectedPhoneE164 };
+  }
+  if (session.expectedExternalUserId) {
+    return { field: "externalUserId", value: session.expectedExternalUserId };
+  }
+  if (session.expectedChatId) {
+    return { field: "chatId", value: session.expectedChatId };
+  }
+  return null;
+}
+
+/**
+ * Whether two sessions are bound to the same identity. Two sessions bound to
+ * no identity are not the same: bootstrap sessions are claimed by id, so an
+ * unbound mint must not sweep up every other unbound row.
+ */
+export function bindsSameIdentity(
+  a: BoundIdentity | null,
+  b: BoundIdentity | null,
+): boolean {
+  return a !== null && b !== null && a.field === b.field && a.value === b.value;
+}
+
+// ---------------------------------------------------------------------------
 // IPC methods
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes LUM-3114. Follows [#40424](https://github.com/vellum-ai/vellum-assistant/pull/40424).

## TL;DR

A verification session carries three nullable identity columns, and which one decides who may redeem the code is a precedence rule with real subtlety in it: when both a user id and a chat id are set, only the user id counts, because a chat id can be shared. That rule was re-derived by hand in **four** places that had to agree. This states it once and has all four read it.

Net **-41 lines** and one new test file.

## Why this, and why now

Divergence between any two copies is a one-time-code bug that type-checks, reads as correct, and fails silently in both directions: too loose and a stranger in a shared chat spends someone else's code, too narrow and a mint supersedes nothing while the consume path still accepts the older codes.

That is not hypothetical. It is exactly what happened in #40424, where the supersede was keyed on `expectedExternalUserId` alone. Four production mints never set that field, so for them the revoke did nothing and every earlier code stayed spendable for its full 10 minute TTL. No test caught it, because the tests encoded the same assumption.

The four copies:

| where | what it was |
| --- | --- |
| `identity-match.ts` | the consume matcher, the original |
| `voice/verification.ts` | a branch-for-branch copy that did not import it, already diverged |
| `session-store.ts` | the supersede scope, a SQL predicate restating the precedence |
| `verification-sessions-ipc-sim.ts` | the daemon's simulator, so tests could drift from production |

## What changes for the user

| | before | after |
| --- | --- | --- |
| Who may redeem a code | the same rule, four independent implementations | the same rule, one implementation |
| A phone session whose number and user id differ | redeems on either | redeems on the number. Unreachable: all three phone mints set both columns to the same normalized value |
| Everything else | | unchanged |

There is no behaviour change any user can observe. This is the structural fix behind #40424, not a new one.

## The part that is not just an extraction

`boundIdentity` moves to the shared contract, beside the session shape it reads, because more than one side has to agree on it and one of those sides is the daemon's simulator.

The supersede then **changes shape** to use it. It was a SQL `UPDATE ... WHERE`, and the matcher is TypeScript over a fetched row, so an extracted helper on its own would have left the predicate as a hand-written mirror: four copies would have become three and a half. It now selects the channel's live outbound rows, filters them through `boundIdentity`, and updates by id. Same code path, no mirror. The candidate set is one channel's live sessions, so the extra statement costs nothing.

The voice matcher collapses from 57 lines to a `checkIdentityMatch(session, fromNumber, fromNumber)` call. Voice holds one identifier for the caller, so it stands in for both actor axes, which is what the inlined copy did and what the next line already passes to `consumeSession`.

## Why it is safe

- **Precedence is phone, then user id, then chat id**, mirroring the order the matcher branched in, so every currently reachable session resolves to the same identity it did before.
- **The one semantic change is unreachable.** A session whose `expectedPhoneE164` and `expectedExternalUserId` differ used to redeem on either and now redeems on the phone number. All three phone mints (`verification-outbound-actions.ts:449`, `:998`, `config-channels.ts:587`) set both to the same normalized value. The pre-port comment on the original reads as defensiveness about which column carries the number rather than two distinct paths: *"verify actorExternalUserId matches expectedPhoneE164 OR actorExternalUserId matches expectedExternalUserId"*.
- **The simulator can no longer drift** from the gateway, which is where five of the eight CI failures in #40424 came from.
- `session-service.ts:323` still reads `expectedPhoneE164 != null` and is deliberately left alone: it asks "is this the outbound voice shape", a discriminator for whether to run the guardian phone binding, not a question about who may redeem.

## Tests

`identity-match.test.ts` asserts the rule directly rather than through a flow, because both ways of getting it wrong are silent.

The last block is the one that matters: for each session shape, it pins that **whoever the consume path admits is exactly whoever a re-mint supersedes**. That is the invariant whose violation caused #40424's regression, and it now fails loudly if the two sides ever part company.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40430" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->