### PR TITLE
refactor(assistant): stop writing display_order, and name the function for its job (LUM-3108)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -9293,8 +9293,10 @@ paths:
   /v1/conversations/reorder:
     post:
       operationId: conversations_reorder_post
-      summary: Reorder conversations
-      description: Batch-update display order and pin state for conversations.
+      summary: Move conversations between sections
+      description:
+        Batch-update which group holds each conversation, and its pin state. Lists are ordered by recency, so this
+        sets placement, not order.
       tags:
         - conversations
       requestBody:
@@ -9311,8 +9313,6 @@ paths:
                     properties:
                       conversationId:
                         type: string
-                      displayOrder:
-                        type: number
                       isPinned:
                         type: boolean
                       groupId:

--- a/assistant/src/__tests__/background-workers-disk-pressure.test.ts
+++ b/assistant/src/__tests__/background-workers-disk-pressure.test.ts
@@ -61,7 +61,7 @@ mock.module("../persistence/conversation-crud.js", () => ({
   getConversationPersistedSeq: () => null,
   addMessage: mock(() => ({ id: "msg-1" })),
   archiveConversation: mock(() => true),
-  batchSetDisplayOrders: mock(() => {}),
+  batchSetConversationPlacement: mock(() => {}),
   createConversation: (opts: { conversationType: string }) => {
     createdConversations.push(opts);
     return { id: "conv-1", ...opts };

--- a/assistant/src/__tests__/conversation-placement-promotion.test.ts
+++ b/assistant/src/__tests__/conversation-placement-promotion.test.ts
@@ -17,7 +17,7 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
 import {
-  batchSetDisplayOrders,
+  batchSetConversationPlacement,
   createConversation,
 } from "../persistence/conversation-crud.js";
 import { listConversations } from "../persistence/conversation-queries.js";
@@ -58,22 +58,16 @@ describe("pinning a background conversation", () => {
     const conv = seedRoutedBackground("bg-job", "background");
     expect(visibleTitles()).toEqual([]);
 
-    batchSetDisplayOrders([
-      { id: conv.id, displayOrder: 0, groupId: "system:pinned" },
-    ]);
+    batchSetConversationPlacement([{ id: conv.id, groupId: "system:pinned" }]);
 
     expect(titlesInGroup("system:pinned")).toEqual(["bg-job"]);
   });
 
   test("unpinning lands it in Recents rather than hiding it again", () => {
     const conv = seedRoutedBackground("bg-job", "background");
-    batchSetDisplayOrders([
-      { id: conv.id, displayOrder: 0, groupId: "system:pinned" },
-    ]);
+    batchSetConversationPlacement([{ id: conv.id, groupId: "system:pinned" }]);
 
-    batchSetDisplayOrders([
-      { id: conv.id, displayOrder: null, groupId: "system:all" },
-    ]);
+    batchSetConversationPlacement([{ id: conv.id, groupId: "system:all" }]);
 
     expect(titlesInGroup("system:all")).toEqual(["bg-job"]);
   });
@@ -84,9 +78,7 @@ describe("filing a background conversation into a custom group", () => {
     const group = createGroup("Car Chat");
     const conv = seedRoutedBackground("bg-job", "background");
 
-    batchSetDisplayOrders([
-      { id: conv.id, displayOrder: 0, groupId: group.id },
-    ]);
+    batchSetConversationPlacement([{ id: conv.id, groupId: group.id }]);
 
     expect(titlesInGroup(group.id)).toEqual(["bg-job"]);
   });
@@ -94,13 +86,9 @@ describe("filing a background conversation into a custom group", () => {
   test("removing it from the group lands it in Recents rather than losing it", () => {
     const group = createGroup("Car Chat");
     const conv = seedRoutedBackground("bg-job", "background");
-    batchSetDisplayOrders([
-      { id: conv.id, displayOrder: 0, groupId: group.id },
-    ]);
+    batchSetConversationPlacement([{ id: conv.id, groupId: group.id }]);
 
-    batchSetDisplayOrders([
-      { id: conv.id, displayOrder: null, groupId: "system:all" },
-    ]);
+    batchSetConversationPlacement([{ id: conv.id, groupId: "system:all" }]);
 
     expect(titlesInGroup("system:all")).toEqual(["bg-job"]);
     expect(visibleTitles()).toEqual(["bg-job"]);
@@ -110,12 +98,8 @@ describe("filing a background conversation into a custom group", () => {
     const group = createGroup("Morning Briefs");
     const conv = seedRoutedBackground("sched-job", "scheduled");
 
-    batchSetDisplayOrders([
-      { id: conv.id, displayOrder: 0, groupId: group.id },
-    ]);
-    batchSetDisplayOrders([
-      { id: conv.id, displayOrder: null, groupId: "system:all" },
-    ]);
+    batchSetConversationPlacement([{ id: conv.id, groupId: group.id }]);
+    batchSetConversationPlacement([{ id: conv.id, groupId: "system:all" }]);
 
     expect(titlesInGroup("system:all")).toEqual(["sched-job"]);
   });
@@ -125,13 +109,11 @@ describe("what promotion must not do", () => {
   test("filing into system:background still demotes", () => {
     const conv = seedRoutedBackground("bg-job", "background");
     // Promote first, so the demotion has something to undo.
-    batchSetDisplayOrders([
-      { id: conv.id, displayOrder: 0, groupId: "system:pinned" },
-    ]);
+    batchSetConversationPlacement([{ id: conv.id, groupId: "system:pinned" }]);
     expect(titlesInGroup("system:pinned")).toEqual(["bg-job"]);
 
-    batchSetDisplayOrders([
-      { id: conv.id, displayOrder: null, groupId: "system:background" },
+    batchSetConversationPlacement([
+      { id: conv.id, groupId: "system:background" },
     ]);
 
     expect(visibleTitles()).toEqual([]);
@@ -149,9 +131,7 @@ describe("what promotion must not do", () => {
     // system bucket.
     const conv = seedRoutedBackground("bg-job", "background");
 
-    batchSetDisplayOrders([
-      { id: conv.id, displayOrder: null, groupId: "system:all" },
-    ]);
+    batchSetConversationPlacement([{ id: conv.id, groupId: "system:all" }]);
 
     expect(visibleTitles()).toEqual([]);
   });
@@ -168,13 +148,9 @@ describe("what promotion must not do", () => {
     // came from, `surfaced_at` records that the user promoted it, and only
     // an explicit demotion clears the latter.
     const conv = seedRoutedBackground("bg-job", "background");
-    batchSetDisplayOrders([
-      { id: conv.id, displayOrder: 0, groupId: "system:pinned" },
-    ]);
+    batchSetConversationPlacement([{ id: conv.id, groupId: "system:pinned" }]);
 
-    batchSetDisplayOrders([
-      { id: conv.id, displayOrder: null, isPinned: false },
-    ]);
+    batchSetConversationPlacement([{ id: conv.id, isPinned: false }]);
 
     expect(visibleTitles()).toEqual(["bg-job"]);
     expect(titlesInGroup("system:all")).toEqual(["bg-job"]);
@@ -186,9 +162,7 @@ describe("what promotion must not do", () => {
     const group = createGroup("Car Chat");
     const conv = createConversation("plain-chat");
 
-    batchSetDisplayOrders([
-      { id: conv.id, displayOrder: 0, groupId: group.id },
-    ]);
+    batchSetConversationPlacement([{ id: conv.id, groupId: group.id }]);
 
     const row = getDb()
       .all(`SELECT surfaced_at FROM conversations WHERE id = '${conv.id}'`)

--- a/assistant/src/__tests__/conversation-retry-route.test.ts
+++ b/assistant/src/__tests__/conversation-retry-route.test.ts
@@ -74,7 +74,7 @@ const getConversationMock = mock((id: string) =>
 mock.module("../persistence/conversation-crud.js", () => ({
   addMessage: async () => ({ id: "unused", deduplicated: false }),
   archiveConversation: () => true,
-  batchSetDisplayOrders: () => {},
+  batchSetConversationPlacement: () => {},
   countConversationsByScheduleJobId: () => 0,
   deleteConversation: () => ({ segmentIds: [], deletedSummaryIds: [] }),
   extractImageSourcePaths: () => undefined,

--- a/assistant/src/__tests__/conversation-summarize-route.test.ts
+++ b/assistant/src/__tests__/conversation-summarize-route.test.ts
@@ -53,7 +53,7 @@ const getConversationMock = mock((id: string) =>
 mock.module("../persistence/conversation-crud.js", () => ({
   addMessage: addMessageMock,
   archiveConversation: () => true,
-  batchSetDisplayOrders: () => {},
+  batchSetConversationPlacement: () => {},
   countConversationsByScheduleJobId: () => 0,
   deleteConversation: () => ({ segmentIds: [], deletedSummaryIds: [] }),
   extractImageSourcePaths: () => undefined,

--- a/assistant/src/__tests__/http-conversation-lineage.test.ts
+++ b/assistant/src/__tests__/http-conversation-lineage.test.ts
@@ -13,7 +13,7 @@ mock.module("../config/env.js", () => ({
 }));
 
 import {
-  batchSetDisplayOrders,
+  batchSetConversationPlacement,
   createConversation,
   updateConversationTitle,
 } from "../persistence/conversation-crud.js";
@@ -100,9 +100,7 @@ describe("conversation lineage in HTTP reads", () => {
 
   test("GET /v1/conversations/:id includes pin metadata when present", async () => {
     const conversation = createConversation("Pinned conversation");
-    batchSetDisplayOrders([
-      { id: conversation.id, displayOrder: 7, isPinned: true },
-    ]);
+    batchSetConversationPlacement([{ id: conversation.id, isPinned: true }]);
     await startServer();
 
     const response = await fetch(url(`/conversations/${conversation.id}`));
@@ -115,7 +113,6 @@ describe("conversation lineage in HTTP reads", () => {
     expect(body.conversation).toMatchObject({
       id: conversation.id,
       title: conversation.title ?? "Untitled",
-      displayOrder: 7,
       isPinned: true,
     });
   });

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -4209,13 +4209,19 @@ export function getConversationRecentProvenanceTrustClass(
 }
 
 // ---------------------------------------------------------------------------
-// CRUD functions for display_order and is_pinned
+// Conversation placement (group + pin) and display metadata
 // ---------------------------------------------------------------------------
 
-export function batchSetDisplayOrders(
+/**
+ * Move conversations between sections: set the group, and the pin state
+ * derived from it.
+ *
+ * Writes no ordering. Every list is ordered by recency, so a conversation's
+ * placement is which section holds it, not where it sits inside one.
+ */
+export function batchSetConversationPlacement(
   updates: Array<{
     id: string;
-    displayOrder: number | null;
     isPinned?: boolean;
     groupId?: string | null;
   }>,
@@ -4236,7 +4242,7 @@ export function batchSetDisplayOrders(
           safeGroupId = UNGROUPED_GROUP_ID;
         } else if (
           !rawGet<{ id: string }>(
-            "conversation:batchSetDisplayOrders:groupCheck",
+            "conversation:batchSetConversationPlacement:groupCheck",
             "SELECT id FROM conversation_groups WHERE id = ?",
             safeGroupId,
           )
@@ -4270,13 +4276,8 @@ export function batchSetDisplayOrders(
           safeGroupId !== UNGROUPED_GROUP_ID &&
           (safeGroupId === PINNED_GROUP_ID ||
             !safeGroupId.startsWith("system:"));
-        const setClauses = [
-          "display_order = ?",
-          "is_pinned = ?",
-          "group_id = ?",
-        ];
+        const setClauses = ["is_pinned = ?", "group_id = ?"];
         const params: Array<string | number | null> = [
-          update.displayOrder,
           safeGroupId === PINNED_GROUP_ID ? 1 : 0,
           safeGroupId,
         ];
@@ -4291,31 +4292,22 @@ export function batchSetDisplayOrders(
         }
         params.push(update.id);
         rawRun(
-          "conversation:batchSetDisplayOrders:group",
+          "conversation:batchSetConversationPlacement:group",
           `UPDATE conversations SET ${setClauses.join(", ")} WHERE id = ?`,
           ...params,
         );
-      } else if (update.isPinned === undefined) {
-        // Only displayOrder provided — preserve existing pin state and group.
+      } else if (update.isPinned === true) {
         rawRun(
-          "conversation:batchSetDisplayOrders:orderOnly",
-          "UPDATE conversations SET display_order = ? WHERE id = ?",
-          update.displayOrder,
+          "conversation:batchSetConversationPlacement:pin",
+          "UPDATE conversations SET is_pinned = 1, group_id = 'system:pinned' WHERE id = ?",
           update.id,
         );
-      } else if (update.isPinned) {
-        rawRun(
-          "conversation:batchSetDisplayOrders:pin",
-          "UPDATE conversations SET display_order = ?, is_pinned = 1, group_id = 'system:pinned' WHERE id = ?",
-          update.displayOrder,
-          update.id,
-        );
-      } else {
+      } else if (update.isPinned === false) {
         // Restore system group from source/conversationType when unpinning,
         // instead of clearing to NULL (which would lose provenance).
         rawRun(
-          "conversation:batchSetDisplayOrders:unpin",
-          `UPDATE conversations SET display_order = ?, is_pinned = 0,
+          "conversation:batchSetConversationPlacement:unpin",
+          `UPDATE conversations SET is_pinned = 0,
            group_id = CASE WHEN group_id = 'system:pinned' THEN
              CASE
                WHEN source IN ('schedule', 'reminder') THEN 'system:scheduled'
@@ -4325,7 +4317,6 @@ export function batchSetDisplayOrders(
              END
            ELSE group_id END
            WHERE id = ?`,
-          update.displayOrder,
           update.id,
         );
       }

--- a/assistant/src/persistence/conversation-group-migration.ts
+++ b/assistant/src/persistence/conversation-group-migration.ts
@@ -36,7 +36,7 @@ export function _resetGroupMigrationForTests(): void {
  * for the first time inside a Drizzle db.transaction() block — SQLite
  * does not support nested transactions. In practice this is safe because
  * the migration is triggered by early startup queries (listConversations,
- * batchSetDisplayOrders) before any transaction-wrapped paths run, and
+ * batchSetConversationPlacement) before any transaction-wrapped paths run, and
  * the `migrated` flag makes subsequent calls no-ops.
  */
 export function ensureGroupMigration(): void {

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -46,7 +46,7 @@ import { normalizeConversationType } from "../../daemon/message-types/shared.js"
 import { stripConversationIds } from "../../home/feed-writer.js";
 import {
   archiveConversation,
-  batchSetDisplayOrders,
+  batchSetConversationPlacement,
   countConversationsByScheduleJobId,
   deleteConversation,
   forkConversation as forkConversationInStore,
@@ -845,7 +845,6 @@ function handleReorderConversations({ body = {}, headers }: RouteHandlerArgs) {
   const updates = body.updates as
     | Array<{
         conversationId: string;
-        displayOrder?: number;
         isPinned?: boolean;
         groupId?: string | null;
       }>
@@ -853,10 +852,9 @@ function handleReorderConversations({ body = {}, headers }: RouteHandlerArgs) {
   if (!Array.isArray(updates)) {
     throw new BadRequestError("Missing updates array");
   }
-  batchSetDisplayOrders(
+  batchSetConversationPlacement(
     updates.map((u) => ({
       id: u.conversationId,
-      displayOrder: u.displayOrder ?? null,
       isPinned: u.isPinned,
       groupId: u.groupId,
     })),
@@ -1304,14 +1302,15 @@ export const ROUTES: RouteDefinition[] = [
       requiredScopes: ["chat.write"],
       allowedPrincipalTypes: ACTOR_PRINCIPALS,
     },
-    summary: "Reorder conversations",
-    description: "Batch-update display order and pin state for conversations.",
+    summary: "Move conversations between sections",
+    description:
+      "Batch-update which group holds each conversation, and its pin state. " +
+      "Lists are ordered by recency, so this sets placement, not order.",
     tags: ["conversations"],
     requestBody: z.object({
       updates: z.array(
         z.object({
           conversationId: z.string(),
-          displayOrder: z.number().optional(),
           isPinned: z.boolean().optional(),
           groupId: z.string().nullable().optional(),
         }),

--- a/assistant/src/tools/conversation-groups/move_to_group.ts
+++ b/assistant/src/tools/conversation-groups/move_to_group.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 import {
-  batchSetDisplayOrders,
+  batchSetConversationPlacement,
   getConversation,
   getDisplayMetaForConversations,
 } from "../../persistence/conversation-crud.js";
@@ -73,15 +73,7 @@ export async function executeConversationMoveToGroup(
     };
   }
 
-  // Preserve the conversation's manual sort slot across the move; only the
-  // group assignment changes.
-  batchSetDisplayOrders([
-    {
-      id: conversationId,
-      displayOrder: meta?.displayOrder ?? null,
-      groupId: group.id,
-    },
-  ]);
+  batchSetConversationPlacement([{ id: conversationId, groupId: group.id }]);
   publishConversationListAndMetadataChanged("reordered", [conversationId]);
 
   const notes: string[] = [];


### PR DESCRIPTION
## TL;DR

Nothing reads `display_order` after #40428, but the daemon still wrote it on every group move and every pin — under a comment claiming it preserved a manual sort slot that no longer exists. Writes removed, and `batchSetDisplayOrders` becomes `batchSetConversationPlacement`, which is what it actually does.

No behavior change. Finishes LUM-3108.

## The misleading part, which is the point

`move_to_group.ts` read the current value and passed it back through:

```ts
// Preserve the conversation's manual sort slot across the move; only the
// group assignment changes.
batchSetDisplayOrders([{ id, displayOrder: meta?.displayOrder ?? null, groupId: group.id }]);
```

There is no manual sort slot. That comment was a false statement in a live assistant tool, sitting above code maintaining a column no query consults — the worst combination, because the next person to read it learns a system that isn't there.

The function name had the same problem: it was named for ordering while doing placement.

## What changed

- **`batchSetDisplayOrders` → `batchSetConversationPlacement`.** Placement is *which section holds a conversation*. Lists are recency-ordered, so there is no position within one to set. `conversation-placement-promotion.test.ts` already used "placement" as the domain word.
- **`displayOrder` dropped from the update shape** and from all three write branches.
- **The `orderOnly` branch is gone.** It fired only when a caller supplied `displayOrder` and nothing else, which was only ever the web reorder mutation deleted in #40408. With the column gone it could not do anything.
- **Route body drops `displayOrder`;** summary and description now describe placement. `openapi.yaml` regenerated.

## Why it is safe

- **Nothing reads the column**, so removing the writes changes no query result.
- **The route keeps its path and `operationId`.** It is live — its other job, moving conversations between groups, is untouched. Only the body field goes.
- **A caller still sending `displayOrder` is ignored, not rejected.** `http-adapter.ts` performs no schema validation: it parses the JSON body into `Record<string, unknown>` and the handler reads the keys it wants. `requestBody` drives `openapi.yaml` generation only, so an extra key is simply never read. No client sends it anyway: web's mutation is deleted, and macOS/iOS have no `displayOrder` reference.
- **Kept:** the `display_order` column, the runtime migration that adds it (which also adds `is_pinned`, still read by the group backfill), the `displayOrder` wire field on `ConversationSummary`, and `getDisplayMetaForConversations` which serves it.
- Typecheck, lint, format clean on both packages; web types regenerated against the new spec.

## Before / after

| | Before | After |
| --- | --- | --- |
| Moving a conversation to a group | Wrote `group_id`, `is_pinned`, and `display_order` | Writes `group_id` and `is_pinned` |
| Pin / unpin | Same, plus `display_order` | Without it |
| Sending `displayOrder` to the route | Accepted and written | Accepted and ignored |
| `display_order` column value | Maintained, never read | Untouched, never read |
| Function name | Named for ordering | Named for placement |
| Reading `displayOrder` off the wire | Works | Works |

Part of LUM-3108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
