### PR TITLE
Name Discord's two senses of connected, and stop advertising a scope that grants nothing

### DIFF
--- a/assistant/src/__tests__/manual-token-reconciliation.test.ts
+++ b/assistant/src/__tests__/manual-token-reconciliation.test.ts
@@ -139,6 +139,51 @@ describe("syncManualTokenConnection", () => {
     warnings.length = 0;
   });
 
+  // ---- Discord server bot: one required field ----
+
+  test("connects discord_channel once the bot token is stored", async () => {
+    // Seeding the provider without this reconciliation leaves it listed and
+    // permanently disconnected, which is worse than not listing it: the
+    // setup skill stores the token and nothing ever reflects that.
+    setCredentialResult("discord_channel", "bot_token", {
+      value: "bot-token-value",
+      unreachable: false,
+    });
+
+    await syncManualTokenConnection("discord_channel");
+
+    expect(createdConnections.map((c) => c.provider)).toContain(
+      "discord_channel",
+    );
+  });
+
+  test("removes the discord_channel connection when the bot token is gone", async () => {
+    seedConnection("discord_channel");
+    setCredentialResult("discord_channel", "bot_token", {
+      value: undefined,
+      unreachable: false,
+    });
+
+    await syncManualTokenConnection("discord_channel");
+
+    expect(deletedConnectionIds).toContain("conn-discord_channel");
+  });
+
+  test("leaves the discord_channel row alone when the backend is unreachable", async () => {
+    // An unreachable credential store is not evidence the token is gone, so
+    // reconciliation must not read it as a disconnection.
+    seedConnection("discord_channel");
+    setCredentialResult("discord_channel", "bot_token", {
+      value: undefined,
+      unreachable: true,
+    });
+
+    await syncManualTokenConnection("discord_channel");
+
+    expect(deletedConnectionIds).not.toContain("conn-discord_channel");
+    expect(connectionStore["discord_channel"]).toBeDefined();
+  });
+
   // ---- Slack: reachable backend, missing tokens -> removes row ----
 
   test("removes slack_channel connection when bot token is missing and backend is reachable", async () => {

--- a/assistant/src/oauth/byo-connection.ts
+++ b/assistant/src/oauth/byo-connection.ts
@@ -47,6 +47,11 @@ export class BYOOAuthConnection implements OAuthConnection {
       async (token) => {
         const effectiveBaseUrl = req.baseUrl ?? this.baseUrl;
         const isTelegram = this.provider === "telegram";
+        // Discord bot tokens authenticate with the `Bot ` scheme, not
+        // `Bearer`. Sending Bearer here reaches Discord as an unusable
+        // credential and comes back 401, which reads as a revoked token.
+        const authScheme =
+          this.provider === "discord_channel" ? "Bot" : "Bearer";
         const requestPath = isTelegram
           ? buildTelegramBotApiPath(req.path, token)
           : req.path;
@@ -87,7 +92,7 @@ export class BYOOAuthConnection implements OAuthConnection {
           }
         }
         if (!isTelegram) {
-          headers.set("Authorization", `Bearer ${token}`);
+          headers.set("Authorization", `${authScheme} ${token}`);
         }
 
         const resp = await fetch(fullUrl, {

--- a/assistant/src/oauth/credential-token-resolver.ts
+++ b/assistant/src/oauth/credential-token-resolver.ts
@@ -49,6 +49,8 @@ function manualTokenAccessCredentialKey(provider: string): string | null {
       return credentialKey("slack_channel", "bot_token");
     case "telegram":
       return credentialKey("telegram", "bot_token");
+    case "discord_channel":
+      return credentialKey("discord_channel", "bot_token");
     case "sanity":
       return credentialKey("sanity", "api_token");
     default:

--- a/assistant/src/oauth/manual-token-connection.ts
+++ b/assistant/src/oauth/manual-token-connection.ts
@@ -178,6 +178,24 @@ export async function syncManualTokenConnection(
       return;
     }
 
+    case "discord_channel": {
+      const botTokenResult = await getSecureKeyResultAsync(
+        credentialKey("discord_channel", "bot_token"),
+      );
+      if (botTokenResult.unreachable) {
+        log.warn(
+          "Skipping discord_channel manual-token reconciliation — credential backend unreachable",
+        );
+        return;
+      }
+      if (botTokenResult.value) {
+        await ensureManualTokenConnection(provider, accountInfoToStore);
+      } else {
+        removeManualTokenConnection(provider);
+      }
+      return;
+    }
+
     case "sanity": {
       const tokenResult = await getSecureKeyResultAsync(
         credentialKey("sanity", "api_token"),
@@ -216,5 +234,6 @@ export async function syncManualTokenConnection(
 export async function backfillManualTokenConnections(): Promise<void> {
   await syncManualTokenConnection("telegram");
   await syncManualTokenConnection("slack_channel");
+  await syncManualTokenConnection("discord_channel");
   await syncManualTokenConnection("sanity");
 }

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -454,16 +454,15 @@ export const PROVIDER_SEED_DATA: Record<
     pingUrl: "https://discord.com/api/v10/users/@me",
     baseUrl: "https://discord.com/api/v10",
     displayLabel: "Discord",
-    description: "Servers and messages",
+    // Your servers, not their contents. These scopes reach the guild list and
+    // your membership in one; reading messages is not among them. Discord
+    // documents `messages.read` as local RPC only, so requesting it would put
+    // a permission on the consent screen that grants nothing here.
+    description: "Your servers and profile",
     dashboardUrl: "https://discord.com/developers/applications",
     clientIdPlaceholder: null,
     logoUrl: "https://cdn.simpleicons.org/discord",
-    defaultScopes: [
-      "identify",
-      "guilds",
-      "guilds.members.read",
-      "messages.read",
-    ],
+    defaultScopes: ["identify", "guilds", "guilds.members.read"],
     availableScopes:
       "https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes",
     loopbackPort: 17326,
@@ -773,6 +772,35 @@ export const PROVIDER_SEED_DATA: Record<
         injectionType: "header",
         headerName: "Authorization",
         valuePrefix: "Bearer ",
+      },
+    ],
+  },
+
+  // The bot that sits in a server and talks to people there, which is a
+  // different thing from the `discord` integration above and starts at the
+  // same Discord authorize URL. Both are reasonably called "connecting
+  // Discord", so each has to be nameable on its own. The bot token is already
+  // stored under this key by `skills/discord-app-setup`; seeding the provider
+  // is what lets the product tell the two apart.
+  discord_channel: {
+    provider: "discord_channel",
+    authorizeUrl: "urn:manual-token",
+    tokenExchangeUrl: "urn:manual-token",
+    pingUrl: "https://discord.com/api/v10/users/@me",
+    baseUrl: "https://discord.com/api/v10",
+    displayLabel: "Discord Server",
+    description: "A bot in your server",
+    dashboardUrl: "https://discord.com/developers/applications",
+    clientIdPlaceholder: null,
+    requiresClientSecret: false,
+    logoUrl: "https://cdn.simpleicons.org/discord",
+    defaultScopes: [],
+    injectionTemplates: [
+      {
+        hostPattern: "discord.com",
+        injectionType: "header",
+        headerName: "Authorization",
+        valuePrefix: "Bot ",
       },
     ],
   },

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -184,7 +184,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-07T00:19:46.000Z"
+      "updatedAt": "2026-08-07T01:16:55.000Z"
     },
     {
       "id": "doordash",
@@ -1146,7 +1146,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-05T01:40:48.000Z"
+      "updatedAt": "2026-08-07T05:17:02.000Z"
     },
     {
       "id": "vellum-self-knowledge",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1146,7 +1146,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-07T05:17:02.000Z"
+      "updatedAt": "2026-08-07T05:27:26.000Z"
     },
     {
       "id": "vellum-self-knowledge",

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/discord-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/discord-path-b.md
@@ -97,4 +97,6 @@ Send the returned auth URL to the user. Tell them to click **Authorize** on the 
 
 After authorization:
 
-> **Discord is connected!** You can now ask me to check your Discord servers, read messages, and look up server members.
+> **Discord is connected!** You can now ask me to check which Discord servers you are in and look up server members.
+>
+> This does not let me read your messages, and it is separate from putting a bot in a server so people can talk to me there.

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/discord-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/discord-path-b.md
@@ -86,7 +86,12 @@ Note: Discord app secrets don't have a known prefix that triggers channel scanne
 
 Follow the `vellum-oauth-integrations` workflow to register the OAuth app, connect, and verify.
 
-Scopes to request: `identify guilds guilds.members.read messages.read`
+Scopes to request: `identify guilds guilds.members.read`
+
+This reaches the user's server list and their profile, not the contents of any
+channel. Discord's `messages.read` grants nothing to a server-side app (its
+docs scope it to a local RPC client), so asking for it only adds a permission
+to the consent screen.
 
 Send the returned auth URL to the user. Tell them to click **Authorize** on the Discord consent page.
 

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/discord.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/discord.md
@@ -96,7 +96,12 @@ Wait for the user to provide the Client ID.
 
 Follow the `vellum-oauth-integrations` workflow to collect credentials, register the OAuth app, connect, and verify.
 
-Scopes to request: `identify guilds guilds.members.read messages.read`
+Scopes to request: `identify guilds guilds.members.read`
+
+This reaches the user's server list and their profile, not the contents of any
+channel. Discord's `messages.read` grants nothing to a server-side app (its
+docs scope it to a local RPC client), so asking for it only adds a permission
+to the consent screen.
 
 > I'll start the Discord authorization flow now. You should see a Discord consent page asking you to authorize **Vellum Assistant** to access your account.
 >

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/discord.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/discord.md
@@ -107,7 +107,7 @@ to the consent screen.
 >
 > Review the permissions and click **Authorize**.
 
-**On success:** "Discord is connected! You can now ask me to check your Discord servers, read messages, and look up server members."
+**On success:** "Discord is connected! You can now ask me to check which Discord servers you are in and look up server members. This does not let me read your messages, and it is separate from putting a bot in a server so people can talk to me there."
 
 ---
 


### PR DESCRIPTION
Part of LUM-3092.

## TL;DR

Two capabilities are both reasonably called "connecting Discord" and both start at the same authorize URL: one lets the assistant act **as you**, the other puts a **bot in a server**. Only the first existed as a provider, so nothing could say which one was in place. And the one that existed advertised a capability it does not have.

## What changes for the user

| | before | after |
| --- | --- | --- |
| Discord integration card | "Servers and messages" | "Your servers and profile" |
| Consent screen | asks for `messages.read` | does not |
| What the integration can read | server list, profile. **Not messages** | unchanged, now described accurately |
| The bot-in-a-server path | not a provider, unnameable | seeded as `discord_channel`, "Discord Server" / "A bot in your server" |
| Anything newly visible in the UI | | **nothing** |

## The capability claim was false, checked against Discord's docs

The integration seeded `["identify", "guilds", "guilds.members.read", "messages.read"]` and called itself "Servers and messages". Discord documents `messages.read` verbatim as:

> "for local rpc server api access, this allows you to read messages from all client channels (otherwise restricted to channels/guilds your app creates)"

It is RPC-only and grants a server-side app nothing. So the integration reaches the user's guild list (`guilds`), their membership in one (`guilds.members.read`), and their account (`identify`), and **cannot read messages at all**.

The scope is dropped rather than kept. Requesting it put a permission on the consent screen in exchange for nothing, which is a real ask of the user. Existing grants are unaffected; `defaultScopes` governs new authorizations.

Worth being explicit: fixing only the wording would have made a false claim *more legible*, not less. The label and the scope had to move together.

## The structural half

`skills/discord-app-setup` already stores the bot token under `discord_channel:bot_token`, and five files read that namespace, but no provider row was ever seeded for it. Slack seeds both `slack` and `slack_channel`; Discord seeded only the integration. That absence is *why* the two senses of connected cannot be told apart: one of them does not exist in the registry.

Seeded now, mirroring the shape `slack_channel` and `telegram` already use.

## Why it is safe

- **Nothing new surfaces in the UI.** `discord_channel` is a `urn:manual-token` provider, and `oauth-connect-routes.ts:64` rejects those with a `BadRequestError` pointing at the credential-prompt CLI surface. It cannot start an OAuth browser flow, exactly like the two manual-token providers already seeded. Checked deliberately, because Discord must not appear in the product until the LUM-3102 gates pass.
- **The `Bot ` auth prefix in the injection template matches the runtime**, which sends `Authorization: Bot ${botToken}` (`discord/api.ts:278`, `:303`).
- Dropping a default scope changes what new authorizations request; it does not revoke or alter existing connections.

## Deferred, and why

- **The assistant still cannot answer "is Discord connected?" with *which sense*.** Seeding the provider is the precondition for that, but wiring it into the assistant's own context is prompt-and-context work rather than provider data, and belongs in its own change.
- **Slack's labels are weak in the opposite direction.** "Channel bot token" names a credential rather than a capability. LUM-3092 says the vocabulary gets written once, so both channels' labels should be settled together, and that is a wording decision worth its own review rather than riding along with a scope correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40432" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->