### PR TITLE
Let the assistant say which sense of connected it found

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -22151,6 +22151,11 @@ paths:
                             anyOf:
                               - type: string
                               - type: "null"
+                          acts_as:
+                            type: string
+                            enum:
+                              - user
+                              - assistant
                         required:
                           - provider_key
                           - display_name
@@ -22162,6 +22167,7 @@ paths:
                           - supports_managed_mode
                           - managed_service_is_paid
                           - feature_flag
+                          - acts_as
                         additionalProperties: false
                       - type: "null"
                   apps:
@@ -22679,6 +22685,11 @@ paths:
                           anyOf:
                             - type: string
                             - type: "null"
+                        acts_as:
+                          type: string
+                          enum:
+                            - user
+                            - assistant
                       required:
                         - provider_key
                         - display_name
@@ -22690,6 +22701,7 @@ paths:
                         - supports_managed_mode
                         - managed_service_is_paid
                         - feature_flag
+                        - acts_as
                       additionalProperties: false
                 required:
                   - providers

--- a/assistant/src/__tests__/oauth-provider-serializer.test.ts
+++ b/assistant/src/__tests__/oauth-provider-serializer.test.ts
@@ -291,7 +291,24 @@ describe("serializeProviderSummary", () => {
       supports_managed_mode: true,
       managed_service_is_paid: false,
       feature_flag: null,
+      acts_as: "user",
     });
+  });
+
+  test("names which sense of connected a provider represents", () => {
+    // The provider key does not say, and the naming actively misleads:
+    // `slack` is the user integration while its bot is `slack_channel`, but
+    // `telegram` is itself the bot. A caller asking "is X connected?" needs
+    // this to answer which X it found.
+    const sense = (provider: string) =>
+      serializeProviderSummary(makeRow({ provider }))!.acts_as;
+
+    expect(sense("slack")).toBe("user");
+    expect(sense("slack_channel")).toBe("assistant");
+    expect(sense("discord")).toBe("user");
+    expect(sense("discord_channel")).toBe("assistant");
+    expect(sense("telegram")).toBe("assistant");
+    expect(sense("google")).toBe("user");
   });
 
   test("nullifies missing optional fields", () => {

--- a/assistant/src/__tests__/oauth-providers-routes.test.ts
+++ b/assistant/src/__tests__/oauth-providers-routes.test.ts
@@ -178,6 +178,7 @@ describe("GET /v1/oauth/providers", () => {
       "supports_managed_mode",
       "managed_service_is_paid",
       "feature_flag",
+      "acts_as",
     ];
 
     for (const provider of providers) {

--- a/assistant/src/cli/commands/oauth/providers.ts
+++ b/assistant/src/cli/commands/oauth/providers.ts
@@ -13,6 +13,8 @@ const log = getCliLogger("cli");
 
 interface SerializedProvider {
   providerKey: string;
+  /** Which sense of connected: a grant to act as the user, or a bot. */
+  actsAs?: "user" | "assistant";
   displayName?: string | null;
   description?: string | null;
   supportsManagedMode?: boolean;
@@ -301,6 +303,7 @@ export function registerProviderCommands(oauth: Command): void {
         dashboardUrl: p.dashboard_url as string | null,
         clientIdPlaceholder: p.client_id_placeholder as string | null,
         featureFlag: p.feature_flag as string | null,
+        actsAs: p.acts_as as "user" | "assistant" | undefined,
       }));
 
       if (opts.providerKey) {

--- a/assistant/src/oauth/credential-token-resolver.ts
+++ b/assistant/src/oauth/credential-token-resolver.ts
@@ -19,6 +19,7 @@ import {
   getSecureKeyResultAsync,
   type SecureKeyResult,
 } from "../security/secure-keys.js";
+import { manualTokenProvider } from "./manual-token-providers.js";
 
 // ── Types ─────────────────────────────────────────────────────────────
 
@@ -44,18 +45,8 @@ export interface ConnectionAccessTokenResult {
  * rather than assuming the OAuth access-token path.
  */
 function manualTokenAccessCredentialKey(provider: string): string | null {
-  switch (provider) {
-    case "slack_channel":
-      return credentialKey("slack_channel", "bot_token");
-    case "telegram":
-      return credentialKey("telegram", "bot_token");
-    case "discord_channel":
-      return credentialKey("discord_channel", "bot_token");
-    case "sanity":
-      return credentialKey("sanity", "api_token");
-    default:
-      return null;
-  }
+  const spec = manualTokenProvider(provider);
+  return spec ? credentialKey(provider, spec.accessField) : null;
 }
 
 /**

--- a/assistant/src/oauth/manual-token-connection.ts
+++ b/assistant/src/oauth/manual-token-connection.ts
@@ -145,7 +145,7 @@ export async function syncManualTokenConnection(
       );
       if (botTokenResult.unreachable || webhookSecretResult.unreachable) {
         log.warn(
-          "Skipping telegram manual-token reconciliation — credential backend unreachable",
+          "Skipping telegram manual-token reconciliation: credential backend unreachable",
         );
         return;
       }
@@ -166,7 +166,7 @@ export async function syncManualTokenConnection(
       );
       if (botTokenResult.unreachable || appTokenResult.unreachable) {
         log.warn(
-          "Skipping slack_channel manual-token reconciliation — credential backend unreachable",
+          "Skipping slack_channel manual-token reconciliation: credential backend unreachable",
         );
         return;
       }
@@ -184,7 +184,7 @@ export async function syncManualTokenConnection(
       );
       if (botTokenResult.unreachable) {
         log.warn(
-          "Skipping discord_channel manual-token reconciliation — credential backend unreachable",
+          "Skipping discord_channel manual-token reconciliation: credential backend unreachable",
         );
         return;
       }
@@ -202,7 +202,7 @@ export async function syncManualTokenConnection(
       );
       if (tokenResult.unreachable) {
         log.warn(
-          "Skipping sanity manual-token reconciliation — credential backend unreachable",
+          "Skipping sanity manual-token reconciliation: credential backend unreachable",
         );
         return;
       }

--- a/assistant/src/oauth/manual-token-connection.ts
+++ b/assistant/src/oauth/manual-token-connection.ts
@@ -13,6 +13,10 @@ import { getSecureKeyResultAsync } from "../security/secure-keys.js";
 import { getTelegramBotUsername } from "../telegram/bot-username.js";
 import { getLogger } from "../util/logger.js";
 import {
+  MANUAL_TOKEN_PROVIDERS,
+  manualTokenProvider,
+} from "./manual-token-providers.js";
+import {
   createConnection,
   deleteConnection,
   getConnectionByProvider,
@@ -135,87 +139,30 @@ export async function syncManualTokenConnection(
     resolvedAccountInfo,
   );
 
-  switch (provider) {
-    case "telegram": {
-      const botTokenResult = await getSecureKeyResultAsync(
-        credentialKey("telegram", "bot_token"),
-      );
-      const webhookSecretResult = await getSecureKeyResultAsync(
-        credentialKey("telegram", "webhook_secret"),
-      );
-      if (botTokenResult.unreachable || webhookSecretResult.unreachable) {
-        log.warn(
-          "Skipping telegram manual-token reconciliation: credential backend unreachable",
-        );
-        return;
-      }
-      if (botTokenResult.value && webhookSecretResult.value) {
-        await ensureManualTokenConnection(provider, accountInfoToStore);
-      } else {
-        removeManualTokenConnection(provider);
-      }
-      return;
-    }
+  const spec = manualTokenProvider(provider);
+  if (!spec) {
+    return;
+  }
 
-    case "slack_channel": {
-      const botTokenResult = await getSecureKeyResultAsync(
-        credentialKey("slack_channel", "bot_token"),
-      );
-      const appTokenResult = await getSecureKeyResultAsync(
-        credentialKey("slack_channel", "app_token"),
-      );
-      if (botTokenResult.unreachable || appTokenResult.unreachable) {
-        log.warn(
-          "Skipping slack_channel manual-token reconciliation: credential backend unreachable",
-        );
-        return;
-      }
-      if (botTokenResult.value && appTokenResult.value) {
-        await ensureManualTokenConnection(provider, accountInfoToStore);
-      } else {
-        removeManualTokenConnection(provider);
-      }
-      return;
-    }
+  // Every field must be present and readable. An unreachable backend is not
+  // evidence a credential was removed, so the row is left as it stands rather
+  // than being read as a disconnection.
+  const results = await Promise.all(
+    spec.fields.map((field) =>
+      getSecureKeyResultAsync(credentialKey(provider, field)),
+    ),
+  );
+  if (results.some((r) => r.unreachable)) {
+    log.warn(
+      `Skipping ${provider} manual-token reconciliation: credential backend unreachable`,
+    );
+    return;
+  }
 
-    case "discord_channel": {
-      const botTokenResult = await getSecureKeyResultAsync(
-        credentialKey("discord_channel", "bot_token"),
-      );
-      if (botTokenResult.unreachable) {
-        log.warn(
-          "Skipping discord_channel manual-token reconciliation: credential backend unreachable",
-        );
-        return;
-      }
-      if (botTokenResult.value) {
-        await ensureManualTokenConnection(provider, accountInfoToStore);
-      } else {
-        removeManualTokenConnection(provider);
-      }
-      return;
-    }
-
-    case "sanity": {
-      const tokenResult = await getSecureKeyResultAsync(
-        credentialKey("sanity", "api_token"),
-      );
-      if (tokenResult.unreachable) {
-        log.warn(
-          "Skipping sanity manual-token reconciliation: credential backend unreachable",
-        );
-        return;
-      }
-      if (tokenResult.value) {
-        await ensureManualTokenConnection(provider, accountInfoToStore);
-      } else {
-        removeManualTokenConnection(provider);
-      }
-      return;
-    }
-
-    default:
-      return;
+  if (results.every((r) => r.value)) {
+    await ensureManualTokenConnection(provider, accountInfoToStore);
+  } else {
+    removeManualTokenConnection(provider);
   }
 }
 
@@ -232,8 +179,7 @@ export async function syncManualTokenConnection(
  * connection row.
  */
 export async function backfillManualTokenConnections(): Promise<void> {
-  await syncManualTokenConnection("telegram");
-  await syncManualTokenConnection("slack_channel");
-  await syncManualTokenConnection("discord_channel");
-  await syncManualTokenConnection("sanity");
+  for (const provider of Object.keys(MANUAL_TOKEN_PROVIDERS)) {
+    await syncManualTokenConnection(provider);
+  }
 }

--- a/assistant/src/oauth/manual-token-providers.ts
+++ b/assistant/src/oauth/manual-token-providers.ts
@@ -1,0 +1,62 @@
+/**
+ * Providers whose credentials are pasted in rather than granted through a
+ * browser flow, and what each one stores.
+ *
+ * Two questions are answered together because they are the same fact seen from
+ * two sides, and answering them in separate tables lets them drift: which
+ * fields must be present for the provider to count as configured
+ * (reconciliation), and which single field an API request authenticates with
+ * (token resolution). Slack stores an app token and Telegram a webhook secret,
+ * and neither authenticates a request.
+ *
+ * `accessField` is named rather than taken as the first of `fields`, so
+ * reordering that list cannot silently change which secret gets sent.
+ *
+ * Channel bots are keyed off the shared channel contract, so adding a channel
+ * does not mean remembering this file exists. `sanity` is not in that contract
+ * because it is a user's own API token: manual to enter, but not a bot and not
+ * a channel.
+ *
+ * The gateway declares the same field sets for its own reading of these
+ * credentials (`gateway/src/credential-reader.ts`). One declaration serving
+ * both is worth doing and needs the specs hoisted into a shared package.
+ */
+
+import { CHANNEL_BOT_PROVIDER } from "@vellumai/service-contracts";
+
+export interface ManualTokenProviderSpec {
+  /** Every field that must be present for the provider to count as connected. */
+  fields: readonly string[];
+  /** The one field an API request authenticates with. */
+  accessField: string;
+}
+
+export const MANUAL_TOKEN_PROVIDERS: Record<string, ManualTokenProviderSpec> = {
+  [CHANNEL_BOT_PROVIDER.slack]: {
+    fields: ["bot_token", "app_token"],
+    accessField: "bot_token",
+  },
+  [CHANNEL_BOT_PROVIDER.discord]: {
+    fields: ["bot_token"],
+    accessField: "bot_token",
+  },
+  [CHANNEL_BOT_PROVIDER.telegram]: {
+    fields: ["bot_token", "webhook_secret"],
+    accessField: "bot_token",
+  },
+  sanity: { fields: ["api_token"], accessField: "api_token" },
+};
+
+/**
+ * The spec for a provider, or undefined when it is not a manual-token one.
+ *
+ * Own-property lookup so an inherited key (`constructor`, `__proto__`) reads
+ * as absent rather than returning a function.
+ */
+export function manualTokenProvider(
+  provider: string,
+): ManualTokenProviderSpec | undefined {
+  return Object.prototype.hasOwnProperty.call(MANUAL_TOKEN_PROVIDERS, provider)
+    ? MANUAL_TOKEN_PROVIDERS[provider]
+    : undefined;
+}

--- a/assistant/src/oauth/manual-token-providers.ts
+++ b/assistant/src/oauth/manual-token-providers.ts
@@ -22,7 +22,7 @@
  * both is worth doing and needs the specs hoisted into a shared package.
  */
 
-import { CHANNEL_BOT_PROVIDER } from "@vellumai/service-contracts";
+import { CHANNEL_BOT_PROVIDER } from "@vellumai/service-contracts/channels";
 
 export interface ManualTokenProviderSpec {
   /** Every field that must be present for the provider to count as connected. */

--- a/assistant/src/oauth/provider-serializer.ts
+++ b/assistant/src/oauth/provider-serializer.ts
@@ -18,7 +18,7 @@ import type { OAuthProviderRow } from "./oauth-store.js";
 export type SerializedProvider = ReturnType<typeof serializeProvider> &
   Record<string, unknown>;
 
-import { isChannelBotProvider } from "@vellumai/service-contracts";
+import { isChannelBotProvider } from "@vellumai/service-contracts/channels";
 
 /**
  * Lightweight summary projection of an OAuth provider, suitable for API

--- a/assistant/src/oauth/provider-serializer.ts
+++ b/assistant/src/oauth/provider-serializer.ts
@@ -18,6 +18,8 @@ import type { OAuthProviderRow } from "./oauth-store.js";
 export type SerializedProvider = ReturnType<typeof serializeProvider> &
   Record<string, unknown>;
 
+import { isChannelBotProvider } from "@vellumai/service-contracts";
+
 /**
  * Lightweight summary projection of an OAuth provider, suitable for API
  * list responses where full detail is not needed. All keys are snake_case
@@ -34,6 +36,16 @@ export interface SerializedProviderSummary {
   supports_managed_mode: boolean;
   managed_service_is_paid: boolean;
   feature_flag: string | null;
+  /**
+   * Which sense of "connected" this provider represents: `assistant` for a bot
+   * credential people reach the assistant through, `user` for a grant letting
+   * it act as the person who authorized it.
+   *
+   * Derived rather than stored, because the provider key does not say: `slack`
+   * and `discord` name the user integration while their bots take a `_channel`
+   * suffix, yet `telegram` is the bot.
+   */
+  acts_as: "user" | "assistant";
 }
 
 /**
@@ -152,5 +164,6 @@ export function serializeProviderSummary(
     supports_managed_mode: !!row.managedServiceConfigKey,
     managed_service_is_paid: !!row.managedServiceIsPaid,
     feature_flag: row.featureFlag ?? null,
+    acts_as: isChannelBotProvider(row.provider) ? "assistant" : "user",
   };
 }

--- a/assistant/src/runtime/routes/oauth-providers.ts
+++ b/assistant/src/runtime/routes/oauth-providers.ts
@@ -397,6 +397,7 @@ export const oauthProviderSummarySchema = z.object({
   supports_managed_mode: z.boolean(),
   managed_service_is_paid: z.boolean(),
   feature_flag: z.string().nullable(),
+  acts_as: z.enum(["user", "assistant"]),
 });
 
 /**

--- a/clients/web/src/domains/chat/components/surfaces/choice-copy-surfaces.stories.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/choice-copy-surfaces.stories.tsx
@@ -98,6 +98,7 @@ const storyOAuthClient: ManagedOAuthConnectClient = {
     supports_managed_mode: true,
     managed_service_is_paid: false,
     feature_flag: null,
+    acts_as: "user",
   }),
   connect: async () => {
     await new Promise((resolve) => setTimeout(resolve, 650));

--- a/gateway/AGENTS.md
+++ b/gateway/AGENTS.md
@@ -90,6 +90,18 @@ Trust/guardian decisions must be keyed on `actorExternalId` only — never fall 
 
 Physical DB column names (`externalUserId`, `externalChatId`) are unchanged; the rename is at the API/type layer only.
 
+**Provider words that are not our words.** A Discord **guild** is what Discord's
+own UI calls a **server**; the word survives only in its API (`guild_id`, the
+`guilds` OAuth scope). Use it when naming what the API returns, and use
+"server" in anything a person reads: UI copy, setup instructions, error
+messages, notification text. The same rule covers any provider term its own
+product does not show users.
+
+`guild_id` also carries meaning past naming. Discord ingress reads its absence
+as "this is a DM" (`discord/admit.ts`), so a parse that collapses a malformed
+value to `undefined` would admit a public channel through the DM branch. Read
+the comments there before changing how the field is parsed.
+
 ## Module Organization
 
 Organize gateway code **by concern, not by technical layer** — group by what code _does_, not what it _is_. This mirrors the web client's rule (`clients/web/docs/CONVENTIONS.md` → "Organize by domain, not technical layer"), which is the fuller treatment of the shared principles; the gateway-specific shape:

--- a/packages/service-contracts/src/channels.ts
+++ b/packages/service-contracts/src/channels.ts
@@ -40,3 +40,42 @@ export function isChannelId(value: unknown): value is ChannelId {
     (CHANNEL_IDS as readonly string[]).includes(value)
   );
 }
+
+/**
+ * The provider key holding each channel's bot credential.
+ *
+ * Two senses of "connected" share the provider registry: a provider the user
+ * authorized so the assistant can act **as them** (`slack`, `discord`,
+ * `google`), and a bot credential letting people reach the assistant **as
+ * itself**. Nothing in a provider key says which, and the naming actively
+ * misleads: `slack` and `discord` name the user integration while their bots
+ * take a `_channel` suffix, yet `telegram` *is* the bot, because Telegram has
+ * no user-identity integration.
+ *
+ * That irregularity is why this is stated rather than derived from the key,
+ * and it is stated here because this file already owns what a channel is.
+ *
+ * Deliberately only the key. What fields each credential requires is declared
+ * once already, per service, in the gateway's credential specs; restating it
+ * here would be a second copy of a different fact.
+ *
+ * Channels absent from this map reach the assistant without a bot credential
+ * of their own: `phone` through the voice provider, `vellum` and `platform`
+ * internally.
+ */
+export const CHANNEL_BOT_PROVIDER = {
+  slack: "slack_channel",
+  discord: "discord_channel",
+  telegram: "telegram",
+} as const satisfies Partial<Record<ChannelId, string>>;
+
+/**
+ * Whether a provider key names a bot the assistant is reached through, rather
+ * than a grant letting it act as the user. This is the "which sense of
+ * connected" question, for any provider key.
+ */
+export function isChannelBotProvider(providerKey: string): boolean {
+  return (Object.values(CHANNEL_BOT_PROVIDER) as readonly string[]).includes(
+    providerKey,
+  );
+}

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1172,7 +1172,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-07T06:07:41.000Z"
+      "updatedAt": "2026-08-07T06:47:06.000Z"
     },
     {
       "id": "vellum-skills-catalog",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1146,7 +1146,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-07T05:27:26.000Z"
+      "updatedAt": "2026-08-07T06:03:32.000Z"
     },
     {
       "id": "vellum-self-knowledge",
@@ -1162,6 +1162,7 @@
             "how Vellum works or its architecture",
             "its current configuration or settings",
             "what it can do, or what skills/tools are available",
+            "whether a service is connected, and in which sense",
             "how to self-host a Vellum assistant",
             "how to configure your own model API key"
           ],
@@ -1171,7 +1172,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-28T22:26:01.000Z"
+      "updatedAt": "2026-08-07T06:07:41.000Z"
     },
     {
       "id": "vellum-skills-catalog",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1172,7 +1172,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-07T06:47:06.000Z"
+      "updatedAt": "2026-08-07T06:54:09.000Z"
     },
     {
       "id": "vellum-skills-catalog",

--- a/skills/vellum-self-knowledge/SKILL.md
+++ b/skills/vellum-self-knowledge/SKILL.md
@@ -12,6 +12,7 @@ metadata:
       - "how Vellum works or its architecture"
       - "its current configuration or settings"
       - "what it can do, or what skills/tools are available"
+      - "whether a service is connected, and in which sense"
       - "how to self-host a Vellum assistant"
       - "how to configure your own model API key"
     avoid-when:
@@ -29,25 +30,32 @@ This skill contains zero static information — only pointers to where the truth
 
 The CLI is the single source of truth for anything about the running assistant's current state.
 
-| Question type                       | Command                                                                    |
-| ----------------------------------- | -------------------------------------------------------------------------- |
-| Current model, provider, config     | `assistant config get llm`                                                 |
-| Full config                         | `assistant config list`                                                    |
-| Config schema (what's configurable) | `assistant config schema [path]`                                           |
-| Available/installed skills          | `assistant skills list --json`                                             |
-| Platform connection                 | `assistant platform status --json`                                         |
-| Auth/identity                       | `assistant auth info --json`                                               |
-| Connected OAuth providers           | `assistant oauth status <provider>`                                        |
-| Connected clients                   | `assistant clients list --json`                                            |
-| Trust rules                         | `assistant trust list`                                                     |
-| Stored credentials                  | `assistant credentials list`                                               |
-| API keys                            | `assistant keys list`                                                      |
-| MCP servers                         | `assistant mcp list`                                                       |
-| Watchers                            | `assistant watchers list`                                                  |
-| Token usage/costs                   | `assistant usage totals` / `assistant usage breakdown --group-by provider` |
-| Version                             | `assistant --version`                                                      |
+| Question type                         | Command                                                                    |
+| ------------------------------------- | -------------------------------------------------------------------------- |
+| Current model, provider, config       | `assistant config get llm`                                                 |
+| Full config                           | `assistant config list`                                                    |
+| Config schema (what's configurable)   | `assistant config schema [path]`                                           |
+| Available/installed skills            | `assistant skills list --json`                                             |
+| Platform connection                   | `assistant platform status --json`                                         |
+| Auth/identity                         | `assistant auth info --json`                                               |
+| Connected as the user (integrations)  | `assistant oauth status <provider>`                                        |
+| Reachable as the assistant (channels) | `assistant channels list`                                                  |
+| Connected clients                     | `assistant clients list --json`                                            |
+| Trust rules                           | `assistant trust list`                                                     |
+| Stored credentials                    | `assistant credentials list`                                               |
+| API keys                              | `assistant keys list`                                                      |
+| MCP servers                           | `assistant mcp list`                                                       |
+| Watchers                              | `assistant watchers list`                                                  |
+| Token usage/costs                     | `assistant usage totals` / `assistant usage breakdown --group-by provider` |
+| Version                               | `assistant --version`                                                      |
 
 Run `assistant --help` or `assistant <command> --help` to discover more.
+
+A service can be connected in both senses at once, in neither, or in one
+without the other, and the two say nothing about each other. "Is X connected?"
+therefore takes both lookups, and an answer names which sense it found. Some
+services offer both from the same authorize URL, so having done one is not
+evidence of the other.
 
 ### 2. Vellum Docs Site — Conceptual Knowledge
 

--- a/skills/vellum-self-knowledge/SKILL.md
+++ b/skills/vellum-self-knowledge/SKILL.md
@@ -30,32 +30,37 @@ This skill contains zero static information — only pointers to where the truth
 
 The CLI is the single source of truth for anything about the running assistant's current state.
 
-| Question type                         | Command                                                                    |
-| ------------------------------------- | -------------------------------------------------------------------------- |
-| Current model, provider, config       | `assistant config get llm`                                                 |
-| Full config                           | `assistant config list`                                                    |
-| Config schema (what's configurable)   | `assistant config schema [path]`                                           |
-| Available/installed skills            | `assistant skills list --json`                                             |
-| Platform connection                   | `assistant platform status --json`                                         |
-| Auth/identity                         | `assistant auth info --json`                                               |
-| What is connected, and in which sense | `assistant oauth providers list --json`                                    |
-| One provider's connection state       | `assistant oauth status <provider>`                                        |
-| Channel delivery health               | `assistant channels list`                                                  |
-| Connected clients                     | `assistant clients list --json`                                            |
-| Trust rules                           | `assistant trust list`                                                     |
-| Stored credentials                    | `assistant credentials list`                                               |
-| API keys                              | `assistant keys list`                                                      |
-| MCP servers                           | `assistant mcp list`                                                       |
-| Watchers                              | `assistant watchers list`                                                  |
-| Token usage/costs                     | `assistant usage totals` / `assistant usage breakdown --group-by provider` |
-| Version                               | `assistant --version`                                                      |
+| Question type                             | Command                                                                    |
+| ----------------------------------------- | -------------------------------------------------------------------------- |
+| Current model, provider, config           | `assistant config get llm`                                                 |
+| Full config                               | `assistant config list`                                                    |
+| Config schema (what's configurable)       | `assistant config schema [path]`                                           |
+| Available/installed skills                | `assistant skills list --json`                                             |
+| Platform connection                       | `assistant platform status --json`                                         |
+| Auth/identity                             | `assistant auth info --json`                                               |
+| Which providers exist, and in which sense | `assistant oauth providers list --json`                                    |
+| Whether one is actually connected         | `assistant oauth status <provider>`                                        |
+| Channel delivery health                   | `assistant channels list`                                                  |
+| Connected clients                         | `assistant clients list --json`                                            |
+| Trust rules                               | `assistant trust list`                                                     |
+| Stored credentials                        | `assistant credentials list`                                               |
+| API keys                                  | `assistant keys list`                                                      |
+| MCP servers                               | `assistant mcp list`                                                       |
+| Watchers                                  | `assistant watchers list`                                                  |
+| Token usage/costs                         | `assistant usage totals` / `assistant usage breakdown --group-by provider` |
+| Version                                   | `assistant --version`                                                      |
 
 Run `assistant --help` or `assistant <command> --help` to discover more.
 
 "Is X connected?" has two answers and a service can have either, both, or
-neither. Each provider carries `acts_as`: `user` means the assistant can act as
-the person who authorized it, `assistant` means a bot people reach the
-assistant through. Report the sense found rather than a bare yes.
+neither. It takes both commands: the providers list is a catalog and says
+nothing about whether anything is connected, so use it to find which provider
+keys belong to X, then check each with `oauth status`.
+
+Each provider in that list carries its sense: `actsAs` in the CLI's JSON,
+`acts_as` over HTTP. `user` means the assistant can act as the person who
+authorized it, `assistant` means a bot people reach the assistant through.
+Report the sense found rather than a bare yes.
 
 Do not infer the sense from the provider key. `slack` and `discord` name the
 user integration while their bots are `slack_channel` and `discord_channel`,

--- a/skills/vellum-self-knowledge/SKILL.md
+++ b/skills/vellum-self-knowledge/SKILL.md
@@ -38,8 +38,9 @@ The CLI is the single source of truth for anything about the running assistant's
 | Available/installed skills            | `assistant skills list --json`                                             |
 | Platform connection                   | `assistant platform status --json`                                         |
 | Auth/identity                         | `assistant auth info --json`                                               |
-| Connected as the user (integrations)  | `assistant oauth status <provider>`                                        |
-| Reachable as the assistant (channels) | `assistant channels list`                                                  |
+| What is connected, and in which sense | `assistant oauth providers list --json`                                    |
+| One provider's connection state       | `assistant oauth status <provider>`                                        |
+| Channel delivery health               | `assistant channels list`                                                  |
 | Connected clients                     | `assistant clients list --json`                                            |
 | Trust rules                           | `assistant trust list`                                                     |
 | Stored credentials                    | `assistant credentials list`                                               |
@@ -51,11 +52,20 @@ The CLI is the single source of truth for anything about the running assistant's
 
 Run `assistant --help` or `assistant <command> --help` to discover more.
 
-A service can be connected in both senses at once, in neither, or in one
-without the other, and the two say nothing about each other. "Is X connected?"
-therefore takes both lookups, and an answer names which sense it found. Some
-services offer both from the same authorize URL, so having done one is not
-evidence of the other.
+"Is X connected?" has two answers and a service can have either, both, or
+neither. Each provider carries `acts_as`: `user` means the assistant can act as
+the person who authorized it, `assistant` means a bot people reach the
+assistant through. Report the sense found rather than a bare yes.
+
+Do not infer the sense from the provider key. `slack` and `discord` name the
+user integration while their bots are `slack_channel` and `discord_channel`,
+yet `telegram` is itself the bot. Some services offer both from one authorize
+URL, so having done one is not evidence of the other, and people often cannot
+recall which they did.
+
+`channels list` reports delivery health for channels that have a readiness
+probe, which is not all of them. It answers whether a channel is working, not
+whether something is connected.
 
 ### 2. Vellum Docs Site — Conceptual Knowledge
 


### PR DESCRIPTION
Fixes LUM-3092. Follows [#40432](https://github.com/vellum-ai/vellum-assistant/pull/40432).

## TL;DR

Asked "is Discord connected?", the assistant could not answer, because which sense of connected a provider represents existed nowhere as data. This makes it data, and has the assistant read it.

## The reported incident

A community user connected Discord **both** ways, was told neither was recognised, and was advised to go build a custom bridge.

[#40432](https://github.com/vellum-ai/vellum-assistant/pull/40432) made the two senses separately nameable in the provider registry. This makes them tellable apart.

## Why the obvious fix does not work

The first attempt here routed the two questions to two commands: OAuth status for "acting as you", `assistant channels list` for "reachable as the assistant". Both review bots showed that cannot work, and they were right.

`createReadinessService` registers probes for voice, telegram, email, whatsapp and slack (`channel-readiness-service.ts:621-628`), and `getReadiness` enumerates only registered probes (`:471`). **Discord has none, so it can never appear in that listing.** Meanwhile the Discord bot's connection is a synthetic `oauth_connection` under `discord_channel`, surfacing through the command the table called the acting-as-you sense.

So the routing produced a false negative on the exact case the issue is about, and the two rows asserted a partition the data does not follow.

## The sense is not derivable from the key

| key | what it is |
| --- | --- |
| `slack` | the user integration |
| `slack_channel` | the Slack bot |
| `discord` | the user integration |
| `discord_channel` | the Discord bot |
| `telegram` | **the bot** — no suffix, because Telegram has no user integration |

No string rule survives that last row. The irregularity now lives once, in `packages/service-contracts/src/channels.ts`, which already declares itself the source of truth for what a channel is and which both the daemon and gateway already depend on.

Providers carry a derived `acts_as` (`user` | `assistant`). Derived, not stored, so it cannot drift from the contract.

## What changes for the user

| | before | after |
| --- | --- | --- |
| "Is Discord connected?" with only the bot set up | "not connected" | connected as the assistant, named as such |
| "Is Slack connected?" with both | one sense reported, arbitrarily | both, distinctly |
| `oauth providers list --json` | no sense field | `acts_as` per provider |
| Field requirements per provider | unchanged | unchanged |

## The duplication behind it

Three places hand-maintained which providers are bot-identity: the reconciliation switch, the token-key resolver, and the backfill list. They now share one table (`manual-token-providers.ts`) of what each manual-token provider stores.

It holds both the fields a provider requires **and** the one field a request authenticates with, because separate tables for those two let them drift. That is not hypothetical: the first pass at this kept them apart and read the access token as `fields[0]`, so reordering a list would have silently changed which secret got sent. It is named per provider now.

## Why it is safe

- **Field requirements verified provider by provider** against the switch they replace: telegram `bot_token`+`webhook_secret`, slack_channel `bot_token`+`app_token`, discord_channel `bot_token`, sanity `api_token`. Unchanged.
- **The unreachable-backend guard is preserved.** An unreadable credential store is still not read as a disconnection, which is the case a naive rewrite gets wrong.
- **`acts_as` is carried through every projection.** The serializer, the HTTP response schema, the OpenAPI spec, and the CLI's camelCase remap each pick fields by hand, so the field had to be added to all four; adding it only at the source would have dropped it silently at every step.
- **Prototype-safe lookup** on the provider table, so an inherited key reads as absent.

## Deliberately not here

- **A cross-reference between the integrations and channels pages.** The two senses are already partitioned by page (`integrations-page.tsx` filters on `supports_managed_mode`; the channels page runs off `SETUP_CHANNEL_IDS`), and neither `slack_channel` nor `discord_channel` renders an integrations card at all. A cross-reference has nowhere to point for Discord until it has a channels surface, which is [LUM-3102](https://linear.app/vellum/issue/LUM-3102).
- **[LUM-3121](https://linear.app/vellum/issue/LUM-3121)** — the gateway declares the same credential field sets in `credential-reader.ts`. Real duplication, predates this, needs the specs hoisted into a shared package.
- **[LUM-3122](https://linear.app/vellum/issue/LUM-3122)** — renaming `telegram` to `telegram_channel` makes the split derivable and **deletes the map this PR adds**. It does not need a credential migration, which is why it is worth doing; it does need the `oauth_apps` row handled.

## Also here

The four manual-token reconciliation warnings carried em dashes, which AGENTS.md bans. One arrived in #40432 and three predate it; fixing only the new one would have left the file inconsistent as well as non-conforming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
