### PR TITLE
Break the latest-session tie on insert order

### DIFF
--- a/gateway/src/__tests__/verification-session-actor-scope.test.ts
+++ b/gateway/src/__tests__/verification-session-actor-scope.test.ts
@@ -238,10 +238,8 @@ describe("findActiveSession", () => {
   test("unfiltered, returns the most recent regardless of actor", () => {
     // The shape a caller gets when it does not say whose session it means.
     //
-    // Both mints land in the same millisecond, so `created_at` ties and only
-    // the insert-order tiebreak decides this. Without it the answer is
-    // whichever row SQLite reaches first, which is stable enough to pass
-    // locally and flake on CI.
+    // Both mints land in the same millisecond, so `created_at` ties and the
+    // insert-order tiebreak is the only thing deciding this.
     mintOutboundFor(ALICE);
     const bob = mintOutboundFor(BOB);
 

--- a/gateway/src/__tests__/verification-session-actor-scope.test.ts
+++ b/gateway/src/__tests__/verification-session-actor-scope.test.ts
@@ -237,10 +237,26 @@ describe("findActiveSession", () => {
 
   test("unfiltered, returns the most recent regardless of actor", () => {
     // The shape a caller gets when it does not say whose session it means.
+    //
+    // Both mints land in the same millisecond, so `created_at` ties and only
+    // the insert-order tiebreak decides this. Without it the answer is
+    // whichever row SQLite reaches first, which is stable enough to pass
+    // locally and flake on CI.
     mintOutboundFor(ALICE);
     const bob = mintOutboundFor(BOB);
 
     expect(findActiveSession(CHANNEL)?.id).toBe(bob.id);
+  });
+
+  test("the latest is the one written last, not the one stamped last", () => {
+    // Ten same-millisecond mints. Any tie-break that is not insert order
+    // picks the wrong one here well before ten.
+    let last = mintOutboundFor(ALICE);
+    for (let i = 0; i < 9; i += 1) {
+      last = mintOutboundFor(`actor-${i}`);
+    }
+
+    expect(findActiveSession(CHANNEL)?.id).toBe(last.id);
   });
 
   test("returns null for an actor with nothing in flight", () => {

--- a/gateway/src/db/session-store.ts
+++ b/gateway/src/db/session-store.ts
@@ -268,10 +268,10 @@ export function findLatestSessionByStatuses(
       ),
     )
     // `created_at` is a millisecond stamp, so two sessions minted in the same
-    // tick tie on it and SQLite is free to return either. Several people
-    // verifying at once is the normal case now, so break the tie on insert
-    // order: rowid rises with every insert, making "latest" mean the one
-    // actually written last rather than whichever the planner reached first.
+    // tick tie on it and SQLite is free to return either. Several people can
+    // be verifying at once, so the tie breaks on insert order: rowid rises
+    // with every insert, making "latest" mean the row written last rather
+    // than whichever the planner reached first.
     .orderBy(desc(channelVerificationSessions.createdAt), desc(sql`rowid`))
     .get();
 

--- a/gateway/src/db/session-store.ts
+++ b/gateway/src/db/session-store.ts
@@ -8,7 +8,7 @@
  */
 
 import type { Database } from "bun:sqlite";
-import { and, count, desc, eq, gt, gte, inArray } from "drizzle-orm";
+import { and, count, desc, eq, gt, gte, inArray, sql } from "drizzle-orm";
 
 import { bindsSameIdentity, boundIdentity } from "@vellumai/gateway-client";
 import type {
@@ -267,7 +267,12 @@ export function findLatestSessionByStatuses(
           : []),
       ),
     )
-    .orderBy(desc(channelVerificationSessions.createdAt))
+    // `created_at` is a millisecond stamp, so two sessions minted in the same
+    // tick tie on it and SQLite is free to return either. Several people
+    // verifying at once is the normal case now, so break the tie on insert
+    // order: rowid rises with every insert, making "latest" mean the one
+    // actually written last rather than whichever the planner reached first.
+    .orderBy(desc(channelVerificationSessions.createdAt), desc(sql`rowid`))
     .get();
 
   return row ? rowToSession(row) : null;

--- a/gateway/src/db/session-store.ts
+++ b/gateway/src/db/session-store.ts
@@ -272,6 +272,13 @@ export function findLatestSessionByStatuses(
     // be verifying at once, so the tie breaks on insert order: rowid rises
     // with every insert, making "latest" mean the row written last rather
     // than whichever the planner reached first.
+    //
+    // SQLite qualifies rowid monotonicity in two ways, neither of which
+    // reaches this ordering. A rowid may be reused after the highest-numbered
+    // row is deleted, but reuse only ever hands back the largest value, so a
+    // reused row still sorts newest. `VACUUM` may renumber a table whose
+    // primary key is not INTEGER, which this one is not, but it renumbers in
+    // existing rowid order, so relative order survives.
     .orderBy(desc(channelVerificationSessions.createdAt), desc(sql`rowid`))
     .get();
 


### PR DESCRIPTION
Fixes a flake on `main` introduced by #40424.

## TL;DR

`findActiveSession` ordered by `created_at` alone, which is a millisecond stamp. Two sessions minted in the same tick tie, and SQLite returns whichever row it reaches first, so "latest" was undefined exactly when several people were verifying at once. Ordering by `rowid` after `created_at` makes it mean the row written last.

## How it showed up

Run [31156970909](https://github.com/vellum-ai/vellum-assistant/actions/runs/31156970909) on `main`, at the #40433 merge commit:

```
verification-session-actor-scope.test.ts:243
Expected: "session-22"
Received: "session-21"
```

The test mints Alice then Bob back to back and asserts the unfiltered lookup returns Bob. Both land in the same millisecond, so the assertion rests entirely on tie-break behaviour that was never defined. It passed on the PR and failed on `main`, which is the signature of a flake rather than a regression: #40433 does not touch the session store.

## Why it is a product fix and not just a test fix

The lookup documents itself as returning the latest session, and callers read it that way (`config-channels.ts:215` for a status read, resend and cancel narrowed by purpose). Before per-actor sessions, one live session per channel meant ties could not arise. #40424 made several live sessions the normal case and did not give the ordering a tiebreak, so the contract quietly became unenforceable.

I flagged this in the #40424 thread and chose to note it rather than fix it, on the grounds that no production caller was affected. That was the wrong call: the exposure it created was a flaky assertion on `main` that will red-flag unrelated PRs until someone chases it.

## Why rowid

`rowid` increases with every insert, so it is insert order, which is what "latest" means when the clock cannot separate two rows. The table is not `WITHOUT ROWID`, so it exists. This is the only `orderBy` in the store, so there is no second site to keep in step.

Alternatives considered and rejected: ordering by `id` would be deterministic but arbitrary, since ids are UUIDs, so the test would still fail about half the time and "latest" would still be wrong. A monotonic column would mean a schema change for something rowid already provides.

## Tests

The existing case keeps its assertion, with a comment recording that the tiebreak is what makes it deterministic rather than merely usually right.

A second case mints ten sessions inside one millisecond and asserts the last one wins. That is deliberately not a rewrite of the first: any tiebreak other than insert order (id, hash, no tiebreak) gets it wrong well before the tenth, so it fails loudly if someone swaps the ordering for something that merely looks stable.

## Risk

Ordering only. No schema change, no behaviour change to who may redeem a code or which sessions a mint supersedes. The worst case before this was a status read showing one of two same-millisecond guardian sessions arbitrarily.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40435" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->