### PR TITLE
Use natural text and hydrate live voice photos

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-photo.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-photo.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  createMockProvider,
+  textResponse,
+} from "../../__tests__/helpers/mock-provider.js";
+import { setConfig } from "../../__tests__/helpers/set-config.js";
+import { waitFor } from "../../__tests__/helpers/wait-for.js";
+
+setConfig("memory", { enabled: false });
+
+import type { AssistantEvent } from "../../api/index.js";
+import { Conversation } from "../../daemon/conversation.js";
+import {
+  deleteConversation,
+  setConversation,
+} from "../../daemon/conversation-registry.js";
+import {
+  getAttachmentsForMessage,
+  uploadAttachment,
+} from "../../persistence/attachments-store.js";
+import {
+  createConversation,
+  getMessages,
+} from "../../persistence/conversation-crud.js";
+import { initializeDb } from "../../persistence/db-init.js";
+import { assistantEventHub } from "../../runtime/assistant-event-hub.js";
+import { persistLiveVoicePhoto } from "../live-voice-photo.js";
+
+await initializeDb();
+
+const IMAGE_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk";
+
+describe("persistLiveVoicePhoto", () => {
+  test("persists and echoes the image without placeholder text", async () => {
+    const conversation = createConversation("Live voice photo");
+    const { provider } = createMockProvider([textResponse("")]);
+    const activeConversation = new Conversation(
+      conversation.id,
+      provider,
+      "system prompt",
+      () => {},
+      "/tmp",
+      { maxTokens: 4096 },
+    );
+    activeConversation.setTrustContext({
+      trustClass: "guardian",
+      sourceChannel: "vellum",
+    });
+    setConversation(conversation.id, activeConversation);
+    const attachment = await uploadAttachment(
+      "photo.png",
+      "image/png",
+      IMAGE_BASE64,
+    );
+    const published: AssistantEvent[] = [];
+    const subscription = assistantEventHub.subscribe({
+      type: "process",
+      filter: { conversationId: conversation.id },
+      callback: (event) => {
+        published.push(event.message);
+      },
+    });
+
+    try {
+      const result = await persistLiveVoicePhoto(
+        conversation.id,
+        attachment.id,
+      );
+      expect(result.ok).toBe(true);
+
+      await waitFor(
+        () => published.some((event) => event.type === "user_message_echo"),
+        { message: "Timed out waiting for live-voice photo echo" },
+      );
+
+      const [message] = getMessages(conversation.id);
+      if (!message) {
+        throw new Error("Live-voice photo message was not persisted");
+      }
+      expect(message.content.some((block) => block.type === "text")).toBe(
+        false,
+      );
+      expect(getAttachmentsForMessage(message.id)).toHaveLength(1);
+      expect(
+        published.find((event) => event.type === "user_message_echo"),
+      ).toMatchObject({
+        type: "user_message_echo",
+        text: "",
+        conversationId: conversation.id,
+        messageId: message.id,
+      });
+    } finally {
+      subscription.dispose();
+      deleteConversation(conversation.id);
+      activeConversation.dispose();
+    }
+  });
+});

--- a/assistant/src/live-voice/__tests__/live-voice-photo.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-photo.test.ts
@@ -33,7 +33,7 @@ const IMAGE_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk";
 
 describe("persistLiveVoicePhoto", () => {
-  test("persists and echoes the image without placeholder text", async () => {
+  test("persists and echoes the image with human-readable context", async () => {
     const conversation = createConversation("Live voice photo");
     const { provider } = createMockProvider([textResponse("")]);
     const activeConversation = new Conversation(
@@ -79,15 +79,15 @@ describe("persistLiveVoicePhoto", () => {
       if (!message) {
         throw new Error("Live-voice photo message was not persisted");
       }
-      expect(message.content.some((block) => block.type === "text")).toBe(
-        false,
-      );
+      expect(message.content.filter((block) => block.type === "text")).toEqual([
+        { type: "text", text: "here's a photo:" },
+      ]);
       expect(getAttachmentsForMessage(message.id)).toHaveLength(1);
       expect(
         published.find((event) => event.type === "user_message_echo"),
       ).toMatchObject({
         type: "user_message_echo",
-        text: "",
+        text: "here's a photo:",
         conversationId: conversation.id,
         messageId: message.id,
       });

--- a/assistant/src/live-voice/live-voice-photo.ts
+++ b/assistant/src/live-voice/live-voice-photo.ts
@@ -49,8 +49,8 @@ const log = getLogger("live-voice-photo");
 const PROCESSING_WAIT_MS = 30_000;
 const PROCESSING_POLL_MS = 100;
 
-/** What the user message says. The image blocks carry the actual content. */
-const PHOTO_MESSAGE_CONTENT = "[photo]";
+/** The image blocks are the complete user-visible message content. */
+const PHOTO_MESSAGE_CONTENT = "";
 
 export interface LiveVoicePhotoResult {
   readonly ok: boolean;

--- a/assistant/src/live-voice/live-voice-photo.ts
+++ b/assistant/src/live-voice/live-voice-photo.ts
@@ -49,8 +49,7 @@ const log = getLogger("live-voice-photo");
 const PROCESSING_WAIT_MS = 30_000;
 const PROCESSING_POLL_MS = 100;
 
-/** The image blocks are the complete user-visible message content. */
-const PHOTO_MESSAGE_CONTENT = "";
+const PHOTO_MESSAGE_CONTENT = "here's a photo:";
 
 export interface LiveVoicePhotoResult {
   readonly ok: boolean;

--- a/clients/web/src/domains/chat/utils/reconcile-detection.test.ts
+++ b/clients/web/src/domains/chat/utils/reconcile-detection.test.ts
@@ -13,6 +13,20 @@ function userRow(id: string, text: string): DisplayMessage {
 function assistantRow(id: string, text: string): DisplayMessage {
   return { id, role: "assistant", ...textBody(text) } as DisplayMessage;
 }
+function withPhoto(message: DisplayMessage, id: string): DisplayMessage {
+  return {
+    ...message,
+    attachments: [
+      {
+        id,
+        filename: "photo.png",
+        mimeType: "image/png",
+        sizeBytes: 42,
+        previewUrl: null,
+      },
+    ],
+  };
+}
 
 // ---------------------------------------------------------------------------
 // serverSnapshotHasNewContent — the structural "is there anything new?" half.
@@ -35,6 +49,24 @@ describe("serverSnapshotHasNewContent", () => {
         [assistantRow("a1", "par")],
       ),
     ).toBe(true);
+  });
+
+  test("true when a matched row gains a server attachment", () => {
+    expect(
+      serverSnapshotHasNewContent(
+        [withPhoto(userRow("u1", "here's a photo:"), "attachment-1")],
+        [userRow("u1", "here's a photo:")],
+      ),
+    ).toBe(true);
+  });
+
+  test("false when the local row already has the server attachment", () => {
+    expect(
+      serverSnapshotHasNewContent(
+        [withPhoto(userRow("u1", "here's a photo:"), "attachment-1")],
+        [withPhoto(userRow("u1", "here's a photo:"), "attachment-1")],
+      ),
+    ).toBe(false);
   });
 
   test("false when the server matches the local view", () => {

--- a/clients/web/src/domains/chat/utils/reconcile-detection.ts
+++ b/clients/web/src/domains/chat/utils/reconcile-detection.ts
@@ -18,9 +18,24 @@ import { messagePlainText } from "@/domains/chat/utils/message-plain-text";
 import { liveAssistantRowId } from "@/domains/chat/utils/stream-updaters/shared";
 import type { DisplayMessage } from "@/domains/chat/types/types";
 
+function serverHasNewAttachments(
+  serverMessage: DisplayMessage,
+  localMessage: DisplayMessage,
+): boolean {
+  if (!serverMessage.attachments?.length) {
+    return false;
+  }
+  const localAttachmentIds = new Set(
+    localMessage.attachments?.map((attachment) => attachment.id),
+  );
+  return serverMessage.attachments.some(
+    (attachment) => !localAttachmentIds.has(attachment.id),
+  );
+}
+
 /**
- * Whether the server snapshot carries content the local view does not yet have
- * — a row absent locally, or a matched row whose text has grown.
+ * Whether the server snapshot carries content the local view does not yet have:
+ * a row absent locally, changed text, or a newly hydrated attachment.
  */
 export function serverSnapshotHasNewContent(
   serverMessages: DisplayMessage[],
@@ -39,7 +54,10 @@ export function serverSnapshotHasNewContent(
     if (!match) {
       return true;
     }
-    if (messagePlainText(match) !== messagePlainText(sm)) {
+    if (
+      messagePlainText(match) !== messagePlainText(sm) ||
+      serverHasNewAttachments(sm, match)
+    ) {
       return true;
     }
   }


### PR DESCRIPTION
## Summary

- Replace the machine-style `[photo]` placeholder with natural `here's a photo:` context.
- Preserve the no-turn persistence behavior for photos taken during a voice session.
- Treat newly hydrated server attachments as changed content so active transcripts refresh without navigation or reload.
- Add regression coverage for persistence, attachment linkage, live echo text, and attachment-aware reconciliation.

## Original prompt

Replace `[photo]` shown alongside full-screen voice-room photos with reasonable human input such as `here's a photo:`, while ensuring the photo appears in the active transcript without a manual refresh.