### PR TITLE
fix(skills): route Claude Code setup and auth to the ACP skill

### DIFF
--- a/assistant/src/__tests__/credential-prompt-route.test.ts
+++ b/assistant/src/__tests__/credential-prompt-route.test.ts
@@ -209,8 +209,8 @@ describe("credentials/prompt route", () => {
   test("stores a non-slack credential to secure storage and reports the value as received", async () => {
     /**
      * The default delivery persists the value to secure storage and runs the
-     * manual-token connection sync. The message must name the outcome — the
-     * value is in hand — so a bare `ok: true` cannot be misread as "the prompt
+     * manual-token connection sync. The message must name the outcome (the
+     * value is in hand) so a bare `ok: true` cannot be misread as "the prompt
      * opened".
      */
     // GIVEN a standard store-delivery prompt for a non-slack credential
@@ -236,15 +236,12 @@ describe("credentials/prompt route", () => {
 
   test("every successful outcome states that the prompt has closed", async () => {
     /**
-     * The prompt blocks until answered, so a caller reads the result only after
-     * the secure input is gone. Without an explicit close signal a model
-     * follows up with "the prompt is open, paste it there" and the user
-     * re-submits into a surface that never reappears — the loop reported in
-     * the Aug 2026 Claude Code auth feedback. Every success path must say so,
-     * not just the plain vault write.
+     * The prompt blocks until answered, so a caller reads the result only once
+     * the secure input is gone. Every success path states the close, not just
+     * the plain vault write, so the result cannot be read as "the prompt is
+     * open, paste it there".
      */
-    const closed =
-      "The secure prompt has closed — do not ask the user to enter this value again.";
+    const closed = "The secure prompt has closed.";
 
     // GIVEN a plain vault write
     const stored = (await promptRoute!.handler({

--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -825,6 +825,38 @@ describe("always-candidate frontmatter parsing", () => {
       .map(({ id, chars }) => `${id}: ${chars}`);
     expect(overrun).toEqual([]);
   });
+
+  test("the bundled acp skill's card fits the default budget", async () => {
+    // `acp` owns Claude Code and Codex setup, sign-in, and delegation, and the
+    // terms that route those turns to it live in this card. The card is
+    // hard-truncated at the default budget, so an overrun drops the trailing
+    // hints and the whole avoid-when list from what the selector sees.
+    const { DEFAULT_CARD_CHARS, buildSkillContent } =
+      await import("../plugins/defaults/memory/substrate/skill-content.js");
+    const acp = loadSkillCatalog().find((skill) => skill.id === "acp");
+    expect(acp).toBeDefined();
+
+    // A card that overran is cut to exactly the budget, so staying under it is
+    // what proves nothing was dropped. `avoid-when` is appended last and is
+    // therefore the first content a truncation eats.
+    const card = buildSkillContent(acp!);
+    expect(card.length).toBeLessThan(DEFAULT_CARD_CHARS);
+    expect(card).toContain("Avoid when:");
+  });
+
+  test("the bundled acp card carries its setup and sign-in vocabulary", async () => {
+    // A "configure Claude Code" or "let's do the auth" turn only reaches this
+    // skill if the card actually says it covers setup and authentication;
+    // delegation-only wording routes those turns to a terminal skill instead.
+    const { buildSkillContent } =
+      await import("../plugins/defaults/memory/substrate/skill-content.js");
+    const acp = loadSkillCatalog().find((skill) => skill.id === "acp");
+    const card = buildSkillContent(acp!).toLowerCase();
+
+    for (const term of ["set up", "install", "authenticate", "connect"]) {
+      expect(card).toContain(term);
+    }
+  });
 });
 
 describe("bundled skill categories", () => {

--- a/assistant/src/cli/commands/credentials.help.ts
+++ b/assistant/src/cli/commands/credentials.help.ts
@@ -293,8 +293,8 @@ encrypted vault with the specified metadata.
 Requires the assistant to be running with at least one connected client.
 
 This command BLOCKS until the user answers the prompt, so it returns only once
-the prompt has already closed. Tell the user what to paste BEFORE running it —
-anything said afterwards reaches them after the input is gone, and pointing
+the prompt has already closed. Tell the user what to paste BEFORE running it.
+Anything said afterwards reaches them after the input is gone, and pointing
 them at a closed prompt makes them re-submit a value that was already received.
 The --label and --description text renders inside the prompt itself, so put the
 instructions there rather than in a follow-up message.

--- a/assistant/src/config/bundled-skills/acp/SKILL.md
+++ b/assistant/src/config/bundled-skills/acp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: acp
-description: Spawn external coding agents via the Agent Client Protocol (ACP)
+description: Set up, authenticate, and run external coding agents (Claude Code, Codex) via the Agent Client Protocol
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🔗"
@@ -8,13 +8,12 @@ metadata:
     display-name: "ACP"
     category: "development"
     activation-hints:
-      - "User asks to use Claude Code or Codex to do something"
-      - "User wants to delegate a coding task to Claude Code, Codex, or another ACP agent"
-      - "User wants to hand a coding task to another agent and check on it later"
-      - "User wants to spawn an external coding agent that runs autonomously and streams results back"
-      - "User mentions ACP, claude-agent-acp, codex-acp, or running multiple coding agents in parallel"
+      - "User wants to set up, install, configure, authenticate, or connect Claude Code or Codex"
+      - "User asks to use Claude Code or Codex, or delegate a coding task to an ACP agent"
+      - "User wants an agent to work autonomously and report back later"
+      - "User mentions ACP, claude-agent-acp, or codex-acp"
     avoid-when:
-      - "Task is small enough to do inline with the assistant's own tools - no need for an external agent"
+      - "The task is small enough to do inline"
 ---
 
 ACP agent orchestration - spawn external coding agents (Claude Code, Codex) to work on tasks via the Agent Client Protocol. Each agent runs as its own subprocess speaking ACP over stdio and streams results back into the conversation.

--- a/assistant/src/plugins/defaults/memory/substrate/skill-content.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/skill-content.ts
@@ -23,6 +23,13 @@ export interface SkillCapabilityInput {
 export const ALWAYS_CANDIDATE_CARD_CHARS = 900;
 
 /**
+ * Character budget for an ordinary skill's capability statement. A statement
+ * that overruns is hard-truncated, dropping its trailing activation hints and
+ * its entire avoid-when list from what the selector sees.
+ */
+export const DEFAULT_CARD_CHARS = 500;
+
+/**
  * Render the prose-style capability statement embedded into the unified
  * `memory_v2_concept_pages` Qdrant collection (under the `skills/<id>` slug
  * prefix) and rendered in `### Skills You Can Use` / the memory-v3 selector
@@ -32,7 +39,7 @@ export const ALWAYS_CANDIDATE_CARD_CHARS = 900;
  */
 export function buildSkillContent(
   input: SkillCapabilityInput,
-  maxChars = 500,
+  maxChars: number = DEFAULT_CARD_CHARS,
 ): string {
   const list = maxChars > 500;
   let content = `The "${input.displayName}" skill (${input.id}) is available. ${input.description}.`;

--- a/assistant/src/runtime/routes/credential-prompt-routes.ts
+++ b/assistant/src/runtime/routes/credential-prompt-routes.ts
@@ -55,14 +55,11 @@ const CredentialPromptParams = z.object({
  *
  * The prompt blocks until the user answers, so by the time a caller reads the
  * result the secure input is already gone from the UI. A bare `ok: true` reads
- * as "the prompt opened successfully", which leads a model to follow up with
- * "the prompt is open, paste your value there" — pointing the user at a surface
- * that has already closed. The user, having just submitted, re-answers a prompt
- * that never reappears, and the flow loops. State the close explicitly so the
- * only available reading is the correct one.
+ * as "the prompt opened successfully", which invites a follow-up telling the
+ * user to paste into a surface that has already closed. Stating the close
+ * leaves only the correct reading.
  */
-const PROMPT_CLOSED_NOTICE =
-  "The secure prompt has closed — do not ask the user to enter this value again.";
+const PROMPT_CLOSED_NOTICE = "The secure prompt has closed.";
 
 export type CredentialPromptResult = {
   ok: boolean;

--- a/clients/docs/src/app/docs/_components/skills-reference-acp-content.tsx
+++ b/clients/docs/src/app/docs/_components/skills-reference-acp-content.tsx
@@ -22,8 +22,9 @@ export function SkillsReferenceACPContent() {
             What it does
           </SectionHeading>
           <p className="mb-0 text-zinc-600">
-            Lets your assistant delegate development tasks to external tools such as Claude Code,
-            Codex, and Gemini CLI through the Agent Client Protocol.
+            Sets up, authenticates, and runs external coding tools such as Claude Code, Codex, and
+            Gemini CLI through the Agent Client Protocol, so your assistant can hand development
+            tasks to them.
           </p>
         </section>
 
@@ -32,8 +33,11 @@ export function SkillsReferenceACPContent() {
             Setup required
           </SectionHeading>
           <p className="mb-0 text-zinc-600">
-            Requires the external agent to be installed (e.g., Claude Code CLI). Say &ldquo;Set up
-            ACP&rdquo; for first-time configuration.
+            The protocol adapter is installed automatically the first time you use an agent. For
+            Claude Code that is everything: sign-in runs through an in-app Connect card, so there is
+            nothing to install yourself. Codex additionally needs the Codex CLI (version 0.111 or
+            higher) already on your PATH, since its adapter calls that CLI and inherits its
+            sign-in. Say &ldquo;Set up ACP&rdquo; to walk through it.
           </p>
         </section>
 

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -3,7 +3,7 @@
   "skills": {
     "acp": {
       "docsSlug": "acp",
-      "sha256": "ed643e026dc52be08d42cc1b1c41073240009078e5558474e9e44325640bdf8c"
+      "sha256": "721a130b51cc08112b057387fe43a6427d2987c8a36631ed84c6ee2131ea64e9"
     },
     "app-builder": {
       "docsSlug": "app-builder",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -397,16 +397,19 @@
     {
       "id": "headless-claude-code",
       "name": "headless-claude-code",
-      "description": "Reference guide for running Claude Code in headless, container, and CI environments — covers auth strategies, interactive mode pitfalls, tmux orchestration, root user workarounds, and git auth without SSH agents or keychains",
+      "description": "Reference guide for running Claude Code in third-party headless, container, and CI environments. Covers auth strategies, interactive mode pitfalls, tmux orchestration, root user workarounds, and git auth without SSH agents or keychains",
       "metadata": {
         "emoji": "🖥️",
         "vellum": {
           "category": "development",
-          "display-name": "Headless Claude Code"
+          "display-name": "Headless Claude Code",
+          "avoid-when": [
+            "Setting up or authenticating Claude Code inside a Vellum assistant: the ACP skill owns that path"
+          ]
         }
       },
       "compatibility": "Any environment running Claude Code headlessly",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "updatedAt": "2026-08-07T12:58:27.000Z"
     },
     {
       "id": "inbox-cleanup",
@@ -756,7 +759,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-06T13:51:52.000Z"
+      "updatedAt": "2026-08-07T12:35:44.000Z"
     },
     {
       "id": "public-ingress",
@@ -1172,7 +1175,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-07T06:54:09.000Z"
+      "updatedAt": "2026-08-07T07:15:43.000Z"
     },
     {
       "id": "vellum-skills-catalog",
@@ -1216,7 +1219,7 @@
     {
       "id": "vellum-terminal-sessions",
       "name": "vellum-terminal-sessions",
-      "description": "Manage persistent terminal sessions via tmux. Create, read, write to, list, and close named shell sessions. Use when the user asks about running terminal processes, wants help orchestrating CLI tasks, or asks you to monitor or interact with long-running commands. Also use when the user mentions tmux sessions.",
+      "description": "Manage persistent tmux terminal sessions: create, read, write to, list, and close named shell sessions. For Claude Code or Codex, use the ACP skill instead.",
       "metadata": {
         "emoji": "🖥️",
         "author": "vellum-ai",
@@ -1226,19 +1229,19 @@
           "display-name": "Terminal Sessions",
           "activation-hints": [
             "User asks about their running terminal sessions or processes",
-            "User wants to monitor a long-running command",
-            "User wants the assistant to run something in a persistent shell",
+            "User wants to monitor a long-running command or run something in a persistent shell",
             "User mentions tmux or terminal management",
-            "User wants to orchestrate multiple CLI agents (e.g. Claude Code sessions)"
+            "User wants to orchestrate multiple CLI processes in parallel"
           ],
           "avoid-when": [
+            "Setting up, authenticating, or running Claude Code or Codex: the ACP skill owns those agents",
             "A simple one-shot command that host_bash handles fine",
             "The user is asking about shell scripting in general, not session management"
           ]
         }
       },
       "compatibility": "Sandbox mode works without any host dependencies. Host mode requires tmux installed on the user's machine. Works on macOS and Linux.",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "updatedAt": "2026-08-07T12:58:27.000Z"
     },
     {
       "id": "vellum-workspace-theme",

--- a/skills/headless-claude-code/SKILL.md
+++ b/skills/headless-claude-code/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: headless-claude-code
-description: Reference guide for running Claude Code in headless, container, and CI environments — covers auth strategies, interactive mode pitfalls, tmux orchestration, root user workarounds, and git auth without SSH agents or keychains
+description: Reference guide for running Claude Code in third-party headless, container, and CI environments. Covers auth strategies, interactive mode pitfalls, tmux orchestration, root user workarounds, and git auth without SSH agents or keychains
 compatibility: "Any environment running Claude Code headlessly"
 metadata:
   emoji: "🖥️"
   vellum:
     category: "development"
     display-name: "Headless Claude Code"
+    avoid-when:
+      - "Setting up or authenticating Claude Code inside a Vellum assistant: the ACP skill owns that path"
 ---
 
 # Headless Claude Code

--- a/skills/vellum-terminal-sessions/SKILL.md
+++ b/skills/vellum-terminal-sessions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vellum-terminal-sessions
-description: Manage persistent terminal sessions via tmux. Create, read, write to, list, and close named shell sessions. Use when the user asks about running terminal processes, wants help orchestrating CLI tasks, or asks you to monitor or interact with long-running commands. Also use when the user mentions tmux sessions.
+description: "Manage persistent tmux terminal sessions: create, read, write to, list, and close named shell sessions. For Claude Code or Codex, use the ACP skill instead."
 compatibility: "Sandbox mode works without any host dependencies. Host mode requires tmux installed on the user's machine. Works on macOS and Linux."
 metadata:
   emoji: "🖥️"
@@ -11,11 +11,11 @@ metadata:
     display-name: "Terminal Sessions"
     activation-hints:
       - "User asks about their running terminal sessions or processes"
-      - "User wants to monitor a long-running command"
-      - "User wants the assistant to run something in a persistent shell"
+      - "User wants to monitor a long-running command or run something in a persistent shell"
       - "User mentions tmux or terminal management"
-      - "User wants to orchestrate multiple CLI agents (e.g. Claude Code sessions)"
+      - "User wants to orchestrate multiple CLI processes in parallel"
     avoid-when:
+      - "Setting up, authenticating, or running Claude Code or Codex: the ACP skill owns those agents"
       - "A simple one-shot command that host_bash handles fine"
       - "The user is asking about shell scripting in general, not session management"
 ---
@@ -24,12 +24,12 @@ metadata:
 
 This skill manages **persistent terminal sessions** via tmux. Two modes:
 
-|                       | Sandbox Mode                               | Host Mode                                                           |
-| --------------------- | ------------------------------------------ | ------------------------------------------------------------------- |
-| **Where tmux runs**   | In the assistant's sandbox                 | On the user's host machine                                          |
-| **How user connects** | `vellum terminal attach <session-name>`    | User opens their own terminal                                       |
-| **Assistant access**  | Direct (`bash` tool)                       | Via `host_bash`                                                     |
-| **Best for**          | Claude Code orchestration, always-on tasks | Work needing host access (e.g. SwiftUI builds, host-local services) |
+|                       | Sandbox Mode                                  | Host Mode                                                           |
+| --------------------- | --------------------------------------------- | ------------------------------------------------------------------- |
+| **Where tmux runs**   | In the assistant's sandbox                    | On the user's host machine                                          |
+| **How user connects** | `vellum terminal attach <session-name>`       | User opens their own terminal                                       |
+| **Assistant access**  | Direct (`bash` tool)                          | Via `host_bash`                                                     |
+| **Best for**          | Long-running builds, servers, always-on tasks | Work needing host access (e.g. SwiftUI builds, host-local services) |
 
 **Default:** Use **Sandbox Mode** unless the task specifically requires host access. Details: [sandbox-sessions.md](references/sandbox-sessions.md) · [host-sessions.md](references/host-sessions.md) · [tmux-best-practices.md](references/tmux-best-practices.md)
 

--- a/skills/vellum-terminal-sessions/references/sandbox-sessions.md
+++ b/skills/vellum-terminal-sessions/references/sandbox-sessions.md
@@ -6,7 +6,7 @@ title: Sandbox Mode
 
 In **Sandbox Mode**, the assistant runs tmux sessions inside its own sandbox environment. The user can attach to any of these sessions live via the Vellum terminal UI.
 
-This is the **default mode** for Claude Code orchestration tasks and any work that doesn't require access to the user's host machine. For tmux operational details (quoting, scrollback, naming, etc.) see [tmux-best-practices.md](tmux-best-practices.md).
+This is the **default mode** for any work that doesn't require access to the user's host machine. Claude Code and Codex are the exception: they run through the ACP skill, not through a tmux session. For tmux operational details (quoting, scrollback, naming, etc.) see [tmux-best-practices.md](tmux-best-practices.md).
 
 ## How It Works
 
@@ -45,6 +45,6 @@ tmux capture-pane -t frontend -p -S -50
 
 ## When to Use Sandbox Mode
 
-- Claude Code orchestration (running builds, tests, dev servers while the conversation continues)
+- Long-running processes (builds, tests, dev servers) that continue while the conversation moves on
 - Tasks where the assistant needs to start a process and poll it over multiple turns
 - Any work that doesn't need access to files, tools, or services that only exist on the user's host


### PR DESCRIPTION
## Prompt / plan

Follow-up to #40285. In the reported session the user asked to "configure Claude skill" and then "do the auth". The turn loaded `vellum-terminal-sessions`, and the agent hand-rolled a native install, a tmux `claude setup-token` session, and a screen-scraped OAuth token. It should have loaded `acp`, which owns that path natively: sandboxed adapter install, in-app Connect Claude Code card for OAuth, and the agent driven over a JSON-RPC subprocess with the token injected from the vault at spawn.

### Why the wrong skill won

Skill selection runs over a per-skill capability statement from `buildSkillContent`: description, then `Use when` hints, then `Avoid when`. It is hard-truncated at 500 chars for an ordinary skill, and `avoid-when` is appended last, so it is the first thing a truncation eats.

Measuring the statements the selector actually sees:

| skill | statement | budget | result |
|---|---|---|---|
| `acp` | 620 chars | 500 | truncated, avoid-when never visible |
| `vellum-terminal-sessions` | 834 chars | 500 | truncated mid-hints, avoid-when never visible |

Two things followed. First, the `acp` statement described delegation only ("Spawn external coding agents"), with every hint phrased as handing off a task. It carried no setup, install, authenticate, or connect vocabulary, even though the skill body owns all of it and explicitly says *"do NOT tell them to run `claude setup-token`"*. A setup or auth turn had nothing to match on.

Second, both skills silently lost their trailing hints and their entire avoid-when list before the selector saw them, so avoid-when was not available as a lever at all.

Worth noting for a reviewer: `vellum-terminal-sessions` does have a `User wants to orchestrate multiple CLI agents (e.g. Claude Code sessions)` hint, and I initially read that as the magnet. It is not. It sits past the truncation point and never reaches the selector. It is still removed here, but the load-bearing fix is elsewhere.

### Changes

- **`acp`** leads with "Set up, authenticate, and run", and its hints cover install, configure, authenticate, and connect. Rewritten to **487 chars** so the whole statement, avoid-when included, survives.
- **`vellum-terminal-sessions`** carries the redirect in its **description**, which is never truncated, because at 735 chars its avoid-when still cannot fit no matter how the hints are trimmed. Its description also stopped restating its own activation hints verbatim. The Claude Code hint is gone and an avoid-when names ACP as the owner.
- **`headless-claude-code`** is scoped to third-party environments and gains an avoid-when pointing at ACP. At 416 chars it fits, so both land.
- Skill and reference bodies no longer present tmux as the default for Claude Code work (`Best for: Claude Code orchestration`, `default mode for Claude Code orchestration tasks`).
- `DEFAULT_CARD_CHARS` is named next to the existing `ALWAYS_CANDIDATE_CARD_CHARS`, and two tests pin the `acp` card inside its budget and assert it keeps the setup vocabulary. This mirrors the existing always-candidate budget test, which already documents this exact failure mode but only guards pinned skills.

Also folds in review feedback from #40285: the prompt-closed notice is trimmed to a plain statement per @dvargasfuertes' suggestion, em dashes are removed from the lines that PR added (`AGENTS.md:138`), and the test comment drops the incident history (`AGENTS.md:127`).

### Known gap, not addressed here

25 of 95 skills overrun their budget; 17 declare an `avoid-when` that is truncated away entirely and does nothing. Fixing that means rewriting frontmatter across a lot of skills, so it is left for a separate change. Only the three skills on this routing path are corrected here.

## Test plan

- `bun test src/__tests__/skills.test.ts src/__tests__/credential-prompt-route.test.ts src/plugins/defaults/memory/substrate/__tests__/skill-content.test.ts src/__tests__/skill-docs-sync-guard.test.ts` — 87 pass.
- `node scripts/skills/check-catalog.mjs` and `node scripts/skills/lint-skill-spec.mjs` — clean. `skills/catalog.json` regenerated against full git history; the `vellum-oauth-integrations` `updatedAt` line is pre-existing drift the regen corrects.
- `bun run scripts/check-skill-docs-sync.ts --write` after updating the ACP docs page, whose "What it does" mirrored the old delegation-only wording and whose "Setup required" claimed the agent must be installed first, which auto-install has since made untrue.
- `bun run typecheck:fast` and `bun run lint` across `assistant/` and `clients/docs/` — clean.
- Pre-existing and unrelated: running all of `src/plugins/defaults/memory/substrate/__tests__/` in one process yields ~150 failures from cross-file pollution, identically on a clean tree (177 pass / 151 fail). The skill files pass 45/45 in isolation.

<!-- No new routes added. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EyxaUrBnc99tvQYsPyFrTD

---
_Generated by [Claude Code](https://claude.ai/code/session_01EyxaUrBnc99tvQYsPyFrTD)_