### PR TITLE
fix(web): collapse composer access + profile pickers when narrow (LUM-3127)

### DIFF
--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -10,7 +10,7 @@
  *      send/stop button, disabled attribute).
  */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { createRef } from "react";
+import { createRef, type ReactNode } from "react";
 import { act, cleanup, fireEvent, render } from "@testing-library/react";
 
 import {
@@ -173,6 +173,16 @@ mock.module("@/domains/chat/voice/live-voice/live-voice-preflight-api", () => ({
 let mockSupportsLiveVoice = true;
 mock.module("@/lib/backwards-compat/use-supports-live-voice", () => ({
   useSupportsLiveVoice: () => mockSupportsLiveVoice,
+}));
+
+// Composer-card width measurement. happy-dom has no layout engine (every box
+// measures 0), so drive the compact signal directly instead of resizing.
+let mockCompactComposer = false;
+mock.module("@/domains/chat/components/chat-composer/composer-compact", () => ({
+  COMPOSER_COMPACT_WIDTH_PX: 520,
+  useIsCompactComposerWidth: () => mockCompactComposer,
+  useComposerCompact: () => mockCompactComposer,
+  ComposerCompactProvider: ({ children }: { children: ReactNode }) => children,
 }));
 
 // Avatar data feeding the voice bar's wave accent. Mocked so the composer
@@ -543,6 +553,7 @@ describe("computeGhostSuffix", () => {
 afterEach(cleanup);
 beforeEach(() => {
   resetLiveVoiceMocks();
+  mockCompactComposer = false;
   // The composer self-sources its draft + attachments from the store; reset
   // them between tests so seeded values can't leak across cases.
   useComposerStore.setState({
@@ -800,6 +811,23 @@ describe("ChatComposer — optional slots", () => {
     });
     expect(html).toContain(">THR<");
     expect(html).toContain(">CTX<");
+  });
+
+  test("modelPickerSlot renders beside the mic while the composer is wide", () => {
+    const html = renderComposer({ modelPickerSlot: <span>PROFILE</span> });
+    expect(html).toContain(">PROFILE<");
+  });
+
+  test("modelPickerSlot is dropped when the composer is compact", () => {
+    // Narrow card: the profile picker folds into the access slot's hamburger
+    // (see `ComposerSettingsMenu`), so mounting it here too would double it up.
+    mockCompactComposer = true;
+    const html = renderComposer({
+      thresholdPickerSlot: <span>THR</span>,
+      modelPickerSlot: <span>PROFILE</span>,
+    });
+    expect(html).toContain(">THR<");
+    expect(html).not.toContain(">PROFILE<");
   });
 
   test("voice button is omitted when voiceInputRef/onVoiceTranscript are not provided (app-editing variant)", () => {

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -27,6 +27,10 @@ import { useQuoteReplyStore } from "@/domains/chat/quote-reply-store";
 import { ComposerDraftNotices } from "@/domains/chat/components/composer-draft-notices";
 import { StreamingWaveform } from "@/domains/chat/components/chat-composer/streaming-waveform";
 import {
+  ComposerCompactProvider,
+  useIsCompactComposerWidth,
+} from "@/domains/chat/components/chat-composer/composer-compact";
+import {
   COMPOSER_RADIUS_CLASS,
   VoiceComposerBar,
 } from "@/domains/chat/components/chat-composer/voice-composer-bar";
@@ -153,7 +157,9 @@ export interface ChatComposerProps {
   contextWindowIndicatorSlot?: ReactNode;
   // Model-profile picker rendered on the row's right end, beside the mic
   // (Figma: New-App 7471-25234). The orchestrator passes a second
-  // `ComposerSettingsMenu` instance scoped to the profile segment.
+  // `ComposerSettingsMenu` instance scoped to the profile segment. Dropped
+  // below the compact card width, where `thresholdPickerSlot`'s menu absorbs
+  // the profile section rather than the two triggers colliding.
   modelPickerSlot?: ReactNode;
 
   // Slot rendered above the form (between the max-width wrapper and the form).
@@ -484,6 +490,15 @@ export function ChatComposer({
   const isNative = useIsNativePlatform();
   const isElectronHost = isElectron();
 
+  // Narrow-card collapse: below the compact width the labelled access and
+  // model-profile triggers collide, so the pair folds into one hamburger menu
+  // (mounted in the access slot, keeping the row's attach | settings | mic |
+  // voice order). Mobile is excluded — its triggers are already icon-only and
+  // open bottom sheets, which fit.
+  const composerCardRef = useRef<HTMLFormElement>(null);
+  const compactSettings =
+    useIsCompactComposerWidth(composerCardRef) && !isMobile;
+
   // Stable ref so handleSlashCommandSelect's autoSend path always calls the
   // latest onSubmit even after flushSync triggers a synchronous re-render.
   const onSubmitRef = useRef(onSubmit);
@@ -706,6 +721,7 @@ export function ChatComposer({
       <Popover.Root open={emoji.show || slash.show}>
         <Popover.Anchor asChild>
           <form
+            ref={composerCardRef}
             data-slot="chat-composer"
             onSubmit={onSubmit}
             className={`overflow-hidden bg-[var(--surface-lift)] shadow-[0px_2px_2px_rgba(0,0,0,0.05)] ${
@@ -967,110 +983,40 @@ export function ChatComposer({
                 session's own controls live in the bar above the card, and
                 everything here (attach, model picker, send) keeps working
                 alongside it. */}
-              <div className="flex items-center justify-between gap-1 px-2 pb-2">
-                <div className="flex min-w-0 items-center gap-2">
-                  {contextWindowIndicatorSlot}
-                  {!isAssistantBusy && (
-                    <AttachFileButton
-                      disabled={typingDisabled || !assistantId}
-                      onFilesSelected={onAddAttachmentFiles}
-                    />
-                  )}
-                  {!isAssistantBusy && thresholdPickerSlot ? (
-                    <div
-                      aria-hidden="true"
-                      className="h-4 w-px shrink-0 bg-[var(--border-hover)] touch-mobile:-mx-1"
-                    />
-                  ) : null}
-                  {thresholdPickerSlot}
-                </div>
-                <div className="flex shrink-0 items-center gap-2">
-                  {isAssistantBusy ? (
-                    <>
-                      {/* Desktop: always show stop. Mobile: show stop only when there is no sendable content. */}
-                      {(!isMobile || !canSendMessageContent) && (
-                        <Button
-                          variant="primary"
-                          iconOnly={
-                            <Square className="h-3 w-3" fill="currentColor" />
-                          }
-                          onClick={onStopGenerating}
-                          aria-label="Stop generating"
-                        />
-                      )}
-                      {/* Mobile: show send instead of stop when content can be queued. */}
-                      {isMobile && canSendMessageContent && (
-                        <Button
-                          variant="primary"
-                          iconOnly={
-                            <ArrowUp className="h-4 w-4" strokeWidth={2.5} />
-                          }
-                          type="submit"
-                          disabled={
-                            sendDisabled || attachmentsUploadingCount > 0
-                          }
-                          title={
-                            sendDisabled
-                              ? "Type a message to send"
-                              : attachmentsUploadingCount > 0
-                                ? "Uploading attachments…"
-                                : "Send message"
-                          }
-                          aria-label="Send message"
-                        />
-                      )}
-                    </>
-                  ) : (
-                    <>
-                      {modelPickerSlot}
-                      {modelPickerSlot && showDictationButton ? (
-                        <div
-                          aria-hidden="true"
-                          className="h-4 w-px shrink-0 bg-[var(--border-hover)] touch-mobile:-mx-1"
-                        />
-                      ) : null}
-                      {showDictationButton && (
-                        <VoiceInputButton
-                          ref={voiceInputRef}
-                          assistantId={assistantId}
-                          // Mutual exclusion: a live-voice session in another
-                          // thread must block dictation, or two mic capture
-                          // flows could run at once. (This composer's own
-                          // session takes the button away entirely — see
-                          // `showDictationButton`.)
-                          disabled={typingDisabled || isLiveVoiceSessionLive}
-                          onTranscript={onVoiceTranscript}
-                          onInterimTranscript={onVoiceInterimTranscript}
-                          onError={onVoiceError}
-                          onBeforeStart={onVoiceBeforeStart}
-                          onStreamReady={(stream: MediaStream | null) => {
-                            voiceStreamRef.current = stream;
-                            setVoiceStream(stream);
-                          }}
-                        />
-                      )}
-                      {/* macOS parity: the send button is hidden during recording
-                      and while transcription is being processed. Only the voice
-                      button (mic / stop / spinner) is shown. Otherwise the send
-                      slot holds voice mode until there is something to send, at
-                      which point the send arrow takes over. */}
-                      {!isVoiceActive &&
-                        (showVoiceModeInSendSlot ? (
-                          // Session entry point: once a session starts here the
-                          // slot gives way to the send arrow and the bar above
-                          // the card owns stopping. Disabled while dictation is
-                          // active or a live-voice session already runs
-                          // elsewhere, so a second mic/voice capture can't open
-                          // alongside it.
-                          <LiveVoiceButton
-                            onStart={handleLiveVoiceStart}
-                            disabled={
-                              typingDisabled ||
-                              isVoiceActive ||
-                              isLiveVoiceSessionLive
+              <ComposerCompactProvider compact={compactSettings}>
+                <div className="flex items-center justify-between gap-1 px-2 pb-2">
+                  <div className="flex min-w-0 items-center gap-2">
+                    {contextWindowIndicatorSlot}
+                    {!isAssistantBusy && (
+                      <AttachFileButton
+                        disabled={typingDisabled || !assistantId}
+                        onFilesSelected={onAddAttachmentFiles}
+                      />
+                    )}
+                    {!isAssistantBusy && thresholdPickerSlot ? (
+                      <div
+                        aria-hidden="true"
+                        className="h-4 w-px shrink-0 bg-[var(--border-hover)] touch-mobile:-mx-1"
+                      />
+                    ) : null}
+                    {thresholdPickerSlot}
+                  </div>
+                  <div className="flex shrink-0 items-center gap-2">
+                    {isAssistantBusy ? (
+                      <>
+                        {/* Desktop: always show stop. Mobile: show stop only when there is no sendable content. */}
+                        {(!isMobile || !canSendMessageContent) && (
+                          <Button
+                            variant="primary"
+                            iconOnly={
+                              <Square className="h-3 w-3" fill="currentColor" />
                             }
+                            onClick={onStopGenerating}
+                            aria-label="Stop generating"
                           />
-                        ) : (
+                        )}
+                        {/* Mobile: show send instead of stop when content can be queued. */}
+                        {isMobile && canSendMessageContent && (
                           <Button
                             variant="primary"
                             iconOnly={
@@ -1078,12 +1024,10 @@ export function ChatComposer({
                             }
                             type="submit"
                             disabled={
-                              sendDisabled ||
-                              attachmentsUploadingCount > 0 ||
-                              !canSendMessageContent
+                              sendDisabled || attachmentsUploadingCount > 0
                             }
                             title={
-                              sendDisabled || !canSendMessageContent
+                              sendDisabled
                                 ? "Type a message to send"
                                 : attachmentsUploadingCount > 0
                                   ? "Uploading attachments…"
@@ -1091,11 +1035,93 @@ export function ChatComposer({
                             }
                             aria-label="Send message"
                           />
-                        ))}
-                    </>
-                  )}
+                        )}
+                      </>
+                    ) : (
+                      <>
+                        {/* Compact: the model profile moves into the left
+                          slot's hamburger alongside access, so nothing is
+                          mounted here. */}
+                        {!compactSettings && modelPickerSlot}
+                        {!compactSettings &&
+                        modelPickerSlot &&
+                        showDictationButton ? (
+                          <div
+                            aria-hidden="true"
+                            className="h-4 w-px shrink-0 bg-[var(--border-hover)] touch-mobile:-mx-1"
+                          />
+                        ) : null}
+                        {showDictationButton && (
+                          <VoiceInputButton
+                            ref={voiceInputRef}
+                            assistantId={assistantId}
+                            // Mutual exclusion: a live-voice session in another
+                            // thread must block dictation, or two mic capture
+                            // flows could run at once. (This composer's own
+                            // session takes the button away entirely — see
+                            // `showDictationButton`.)
+                            disabled={typingDisabled || isLiveVoiceSessionLive}
+                            onTranscript={onVoiceTranscript}
+                            onInterimTranscript={onVoiceInterimTranscript}
+                            onError={onVoiceError}
+                            onBeforeStart={onVoiceBeforeStart}
+                            onStreamReady={(stream: MediaStream | null) => {
+                              voiceStreamRef.current = stream;
+                              setVoiceStream(stream);
+                            }}
+                          />
+                        )}
+                        {/* macOS parity: the send button is hidden during recording
+                      and while transcription is being processed. Only the voice
+                      button (mic / stop / spinner) is shown. Otherwise the send
+                      slot holds voice mode until there is something to send, at
+                      which point the send arrow takes over. */}
+                        {!isVoiceActive &&
+                          (showVoiceModeInSendSlot ? (
+                            // Session entry point: once a session starts here the
+                            // slot gives way to the send arrow and the bar above
+                            // the card owns stopping. Disabled while dictation is
+                            // active or a live-voice session already runs
+                            // elsewhere, so a second mic/voice capture can't open
+                            // alongside it.
+                            <LiveVoiceButton
+                              onStart={handleLiveVoiceStart}
+                              disabled={
+                                typingDisabled ||
+                                isVoiceActive ||
+                                isLiveVoiceSessionLive
+                              }
+                            />
+                          ) : (
+                            <Button
+                              variant="primary"
+                              iconOnly={
+                                <ArrowUp
+                                  className="h-4 w-4"
+                                  strokeWidth={2.5}
+                                />
+                              }
+                              type="submit"
+                              disabled={
+                                sendDisabled ||
+                                attachmentsUploadingCount > 0 ||
+                                !canSendMessageContent
+                              }
+                              title={
+                                sendDisabled || !canSendMessageContent
+                                  ? "Type a message to send"
+                                  : attachmentsUploadingCount > 0
+                                    ? "Uploading attachments…"
+                                    : "Send message"
+                              }
+                              aria-label="Send message"
+                            />
+                          ))}
+                      </>
+                    )}
+                  </div>
                 </div>
-              </div>
+              </ComposerCompactProvider>
             </div>
           </form>
         </Popover.Anchor>

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -493,7 +493,7 @@ export function ChatComposer({
   // Narrow-card collapse: below the compact width the labelled access and
   // model-profile triggers collide, so the pair folds into one hamburger menu
   // (mounted in the access slot, keeping the row's attach | settings | mic |
-  // voice order). Mobile is excluded — its triggers are already icon-only and
+  // voice order). Mobile is excluded: its triggers are already icon-only and
   // open bottom sheets, which fit.
   const composerCardRef = useRef<HTMLFormElement>(null);
   const compactSettings =

--- a/clients/web/src/domains/chat/components/chat-composer/composer-compact.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/composer-compact.tsx
@@ -9,7 +9,7 @@ import {
 
 /**
  * Composer card width (px) below which the action row can no longer hold the
- * labelled access + model-profile triggers side by side — they run into each
+ * labelled access + model-profile triggers side by side: they run into each
  * other and the two labels render on top of one another. Below this the pair
  * collapses into a single hamburger menu holding both sections.
  *

--- a/clients/web/src/domains/chat/components/chat-composer/composer-compact.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/composer-compact.tsx
@@ -1,0 +1,71 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+  type RefObject,
+} from "react";
+
+/**
+ * Composer card width (px) below which the action row can no longer hold the
+ * labelled access + model-profile triggers side by side — they run into each
+ * other and the two labels render on top of one another. Below this the pair
+ * collapses into a single hamburger menu holding both sections.
+ *
+ * Measured against the card, not the viewport: the composer also narrows when
+ * the sidebar opens or the window is split, and the collision follows the card.
+ */
+export const COMPOSER_COMPACT_WIDTH_PX = 520;
+
+const ComposerCompactContext = createContext(false);
+
+/**
+ * True while the composer this control sits in is too narrow for labelled
+ * triggers. Read by the controls themselves (they own how they shrink);
+ * `ChatComposer` owns the measurement and which slots stay mounted.
+ */
+export function useComposerCompact(): boolean {
+  return useContext(ComposerCompactContext);
+}
+
+export function ComposerCompactProvider({
+  compact,
+  children,
+}: {
+  compact: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <ComposerCompactContext.Provider value={compact}>
+      {children}
+    </ComposerCompactContext.Provider>
+  );
+}
+
+/**
+ * Track whether `ref`'s element is narrower than
+ * {@link COMPOSER_COMPACT_WIDTH_PX}, via `ResizeObserver` so it follows
+ * sidebar toggles and window resizes, not just the initial layout.
+ */
+export function useIsCompactComposerWidth(
+  ref: RefObject<HTMLElement | null>,
+): boolean {
+  const [compact, setCompact] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || typeof ResizeObserver === "undefined") {
+      return;
+    }
+    const measure = () => {
+      setCompact(el.getBoundingClientRect().width < COMPOSER_COMPACT_WIDTH_PX);
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [ref]);
+
+  return compact;
+}

--- a/clients/web/src/domains/chat/components/composer-settings-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.test.tsx
@@ -178,6 +178,7 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
   conversationsByIdInferenceprofilePut: inferenceprofilePut,
 }));
 
+import { ComposerCompactProvider } from "@/domains/chat/components/chat-composer/composer-compact";
 import { ComposerSettingsMenu } from "@/domains/chat/components/composer-settings-menu";
 // Real store (not mocked) — the component reads the draft conversation id and
 // the pending-profile stash from it.
@@ -625,5 +626,62 @@ describe("Profile activation rejected by the daemon", () => {
         "Failed to switch profile. Please try again.",
       );
     });
+  });
+});
+
+describe("compact composer collapse", () => {
+  function renderCompact(segments: "both" | "access" | "profile") {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    return render(
+      createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        createElement(ComposerCompactProvider, {
+          compact: true,
+          children: createElement(ComposerSettingsMenu, {
+            assistantId: "assistant-1",
+            conversationId: "conv-1",
+            segments,
+          }),
+        }),
+      ),
+    );
+  }
+
+  test("folds both segments into one hamburger trigger", async () => {
+    // The composer mounts only the access-segment instance when compact, so
+    // that instance has to carry the model profile too — otherwise the picker
+    // is unreachable on a narrow window.
+    renderCompact("access");
+
+    const trigger = await screen.findByLabelText(
+      "Assistant access and model profile",
+    );
+    expect(trigger).toBeTruthy();
+    // No labelled split triggers alongside it.
+    expect(screen.queryByLabelText("Model profile")).toBeNull();
+
+    await waitFor(() => {
+      expect(screen.getByText("Smart")).toBeTruthy();
+    });
+    // Access presets live in the same menu, under their own section label.
+    expect(screen.getByText("Assistant Access")).toBeTruthy();
+    expect(screen.getByText("Model Profile")).toBeTruthy();
+  });
+
+  test("stays split when the composer is wide", async () => {
+    renderMenu();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Model profile")).toBeTruthy();
+    });
+    expect(
+      screen.queryByLabelText("Assistant access and model profile"),
+    ).toBeNull();
   });
 });

--- a/clients/web/src/domains/chat/components/composer-settings-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.test.tsx
@@ -655,8 +655,8 @@ describe("compact composer collapse", () => {
 
   test("folds both segments into one hamburger trigger", async () => {
     // The composer mounts only the access-segment instance when compact, so
-    // that instance has to carry the model profile too — otherwise the picker
-    // is unreachable on a narrow window.
+    // that instance has to carry the model profile too, or the picker is
+    // unreachable on a narrow window.
     renderCompact("access");
 
     const trigger = await screen.findByLabelText(

--- a/clients/web/src/domains/chat/components/composer-settings-menu.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.tsx
@@ -1,5 +1,11 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Check, Plus, SlidersHorizontal, Sparkles } from "lucide-react";
+import {
+  Check,
+  Menu as HamburgerIcon,
+  Plus,
+  SlidersHorizontal,
+  Sparkles,
+} from "lucide-react";
 import {
   useCallback,
   useEffect,
@@ -25,6 +31,7 @@ import {
   conversationsByIdGetQueryKey,
 } from "@/generated/daemon/@tanstack/react-query.gen";
 import { conversationsByIdInferenceprofilePut } from "@/generated/daemon/sdk.gen";
+import { useComposerCompact } from "@/domains/chat/components/chat-composer/composer-compact";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import {
   deleteConversationOverride,
@@ -60,6 +67,9 @@ interface Props {
    * access on the left beside the attach button, model profile on the
    * right beside the mic), mounting one instance per side. Server state
    * is TanStack-Query-cached, so the two instances share fetches.
+   *
+   * Ignored when the surrounding composer is compact — the row then holds a
+   * single instance whose hamburger menu carries both sections.
    */
   segments?: "both" | "access" | "profile";
 }
@@ -70,12 +80,18 @@ export function ComposerSettingsMenu({
   segments = "both",
 }: Props) {
   const isMobile = useIsMobile();
+  // A composer too narrow for two labelled triggers folds both segments into
+  // one hamburger menu. The composer mounts a single instance in that mode
+  // (see `ChatComposer`'s action row), so `segments` is ignored here — the one
+  // menu holds both sections.
+  const compact = useComposerCompact() && !isMobile;
   const queryClient = useQueryClient();
   // Two independent menus/triggers — the access-level segment and the model-
   // profile segment each open their own popover so only the clicked segment
   // highlights and each surface shows a single, focused list.
   const [accessOpen, setAccessOpen] = useState(false);
   const [profileOpen, setProfileOpen] = useState(false);
+  const [compactOpen, setCompactOpen] = useState(false);
 
   // ---------------------------------------------------------------------------
   // Server-state queries — replace the old useEffect + async IIFE pattern.
@@ -499,6 +515,7 @@ export function ComposerSettingsMenu({
             return;
           }
           setProfileOpen(false);
+          setCompactOpen(false);
           openProfileQuickAdd({
             existingNames: existingProfileNames,
             onCreated: (name, _label) => {
@@ -527,9 +544,8 @@ export function ComposerSettingsMenu({
   // value loads. Only the icon is shown inline — the label lives in a tooltip
   // and the menu — to keep the composer's bottom bar compact.
   const AccessIcon = activePreset.icon;
-  const showAccess =
-    (globalThresholdsQuery.isSuccess || serverIsOverride) &&
-    segments !== "profile";
+  const accessSettled = globalThresholdsQuery.isSuccess || serverIsOverride;
+  const showAccess = accessSettled && segments !== "profile";
   const showProfile = segments !== "access";
 
   // Each trigger is the design library's ghost Button — same chrome and
@@ -606,6 +622,117 @@ export function ComposerSettingsMenu({
       serverGlobalInteractive !== null &&
       preset.riskThreshold === serverGlobalInteractive,
   }));
+
+  // Menu rows, shared by the split desktop menus and the compact hamburger so
+  // the two layouts can never drift apart.
+  const accessMenuItems = accessItems.map(({ preset, isActive, isDefault }) => {
+    const PresetIcon = preset.icon;
+    return (
+      <Menu.Item
+        key={preset.id}
+        onSelect={() => handleSelect(preset)}
+        leftIcon={<PresetIcon className="h-3.5 w-3.5" />}
+        className={
+          isActive
+            ? "bg-[var(--surface-active)] text-[var(--content-emphasised)]"
+            : ""
+        }
+        shortcut={
+          isActive ? (
+            <Check className="h-3.5 w-3.5 text-[var(--system-positive-strong)]" />
+          ) : undefined
+        }
+        title={preset.description}
+      >
+        {preset.label}
+        {isDefault && (
+          <span className="ml-1 text-[var(--content-tertiary)]">(default)</span>
+        )}
+      </Menu.Item>
+    );
+  });
+
+  const profileMenuItems = visibleProfileEntries.map((entry) => {
+    const isActive = entry.name === profileActiveKey;
+    return (
+      <Menu.Item
+        key={entry.name}
+        onSelect={() => handleProfileSelect(entry.name)}
+        leftIcon={<Sparkles className="h-3.5 w-3.5" />}
+        className={
+          isActive
+            ? "bg-[var(--surface-active)] text-[var(--content-emphasised)]"
+            : ""
+        }
+        shortcut={
+          isActive ? (
+            <Check className="h-3.5 w-3.5 text-[var(--system-positive-strong)]" />
+          ) : undefined
+        }
+      >
+        {profilePickerLabel(entry)}
+      </Menu.Item>
+    );
+  });
+
+  const menuLabelClass =
+    "mb-1 text-label-small-default normal-case tracking-normal";
+  const profileMenuLabel = (
+    <Menu.Label
+      className={`${menuLabelClass} flex items-center justify-between gap-2`}
+    >
+      <span>Model Profile</span>
+      {/* The compact quick-add button (h-6/24px) is taller than the label
+          text's own line box (10px); items-center would otherwise stretch the
+          row to fit it and nudge the text down relative to the icon-less
+          Assistant Access label. Cancel that out so both labels sit at the
+          same offset. */}
+      <span className="-my-[7px]">{quickAddButton}</span>
+    </Menu.Label>
+  );
+
+  if (compact) {
+    // One trigger, one menu, both sections — the row keeps its
+    // attach | settings | mic | voice order and nothing collides. The access
+    // section waits on a settled fetch (same gate as `showAccess`) so it never
+    // flashes the fallback preset, but the trigger itself is always mounted:
+    // the profile section below it is reachable either way.
+    const activeSummary = [
+      accessSettled ? activePreset.label : null,
+      activeProfileLabel,
+    ]
+      .filter(Boolean)
+      .join(" · ");
+    const compactLabel = "Assistant access and model profile";
+    return (
+      <Menu.Root open={compactOpen} onOpenChange={setCompactOpen}>
+        <Menu.Trigger asChild>
+          <Button
+            variant="ghost"
+            iconOnly={<HamburgerIcon />}
+            aria-label={compactLabel}
+            title={
+              activeSummary ? `${compactLabel}: ${activeSummary}` : compactLabel
+            }
+            className={triggerClass}
+          />
+        </Menu.Trigger>
+        <Menu.Content side="top" align="start">
+          {accessSettled && (
+            <>
+              <Menu.Label className={menuLabelClass}>
+                Assistant Access
+              </Menu.Label>
+              {accessMenuItems}
+              <Menu.Separator />
+            </>
+          )}
+          {profileMenuLabel}
+          {profileMenuItems}
+        </Menu.Content>
+      </Menu.Root>
+    );
+  }
 
   if (isMobile) {
     return (
@@ -694,37 +821,8 @@ export function ComposerSettingsMenu({
         <Menu.Root open={accessOpen} onOpenChange={setAccessOpen}>
           <Menu.Trigger asChild>{accessTrigger}</Menu.Trigger>
           <Menu.Content side="top" align="start">
-            <Menu.Label className="mb-1 text-label-small-default normal-case tracking-normal">
-              Assistant Access
-            </Menu.Label>
-            {accessItems.map(({ preset, isActive, isDefault }) => {
-              const PresetIcon = preset.icon;
-              return (
-                <Menu.Item
-                  key={preset.id}
-                  onSelect={() => handleSelect(preset)}
-                  leftIcon={<PresetIcon className="h-3.5 w-3.5" />}
-                  className={
-                    isActive
-                      ? "bg-[var(--surface-active)] text-[var(--content-emphasised)]"
-                      : ""
-                  }
-                  shortcut={
-                    isActive ? (
-                      <Check className="h-3.5 w-3.5 text-[var(--system-positive-strong)]" />
-                    ) : undefined
-                  }
-                  title={preset.description}
-                >
-                  {preset.label}
-                  {isDefault && (
-                    <span className="ml-1 text-[var(--content-tertiary)]">
-                      (default)
-                    </span>
-                  )}
-                </Menu.Item>
-              );
-            })}
+            <Menu.Label className={menuLabelClass}>Assistant Access</Menu.Label>
+            {accessMenuItems}
           </Menu.Content>
         </Menu.Root>
       )}
@@ -732,37 +830,8 @@ export function ComposerSettingsMenu({
         <Menu.Root open={profileOpen} onOpenChange={setProfileOpen}>
           <Menu.Trigger asChild>{profileTrigger}</Menu.Trigger>
           <Menu.Content side="top" align="start">
-            <Menu.Label className="mb-1 flex items-center justify-between gap-2 text-label-small-default normal-case tracking-normal">
-              <span>Model Profile</span>
-              {/* The compact quick-add button (h-6/24px) is taller than the
-                  label text's own line box (10px); items-center would
-                  otherwise stretch the row to fit it and nudge the text down
-                  relative to the icon-less Assistant Access label. Cancel
-                  that out so both labels sit at the same offset. */}
-              <span className="-my-[7px]">{quickAddButton}</span>
-            </Menu.Label>
-            {visibleProfileEntries.map((entry) => {
-              const isActive = entry.name === profileActiveKey;
-              return (
-                <Menu.Item
-                  key={entry.name}
-                  onSelect={() => handleProfileSelect(entry.name)}
-                  leftIcon={<Sparkles className="h-3.5 w-3.5" />}
-                  className={
-                    isActive
-                      ? "bg-[var(--surface-active)] text-[var(--content-emphasised)]"
-                      : ""
-                  }
-                  shortcut={
-                    isActive ? (
-                      <Check className="h-3.5 w-3.5 text-[var(--system-positive-strong)]" />
-                    ) : undefined
-                  }
-                >
-                  {profilePickerLabel(entry)}
-                </Menu.Item>
-              );
-            })}
+            {profileMenuLabel}
+            {profileMenuItems}
           </Menu.Content>
         </Menu.Root>
       )}

--- a/clients/web/src/domains/chat/components/composer-settings-menu.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.tsx
@@ -68,7 +68,7 @@ interface Props {
    * right beside the mic), mounting one instance per side. Server state
    * is TanStack-Query-cached, so the two instances share fetches.
    *
-   * Ignored when the surrounding composer is compact — the row then holds a
+   * Ignored when the surrounding composer is compact: the row then holds a
    * single instance whose hamburger menu carries both sections.
    */
   segments?: "both" | "access" | "profile";
@@ -82,7 +82,7 @@ export function ComposerSettingsMenu({
   const isMobile = useIsMobile();
   // A composer too narrow for two labelled triggers folds both segments into
   // one hamburger menu. The composer mounts a single instance in that mode
-  // (see `ChatComposer`'s action row), so `segments` is ignored here — the one
+  // (see `ChatComposer`'s action row), so `segments` is ignored here: the one
   // menu holds both sections.
   const compact = useComposerCompact() && !isMobile;
   const queryClient = useQueryClient();
@@ -692,7 +692,7 @@ export function ComposerSettingsMenu({
   );
 
   if (compact) {
-    // One trigger, one menu, both sections — the row keeps its
+    // One trigger, one menu, both sections, so the row keeps its
     // attach | settings | mic | voice order and nothing collides. The access
     // section waits on a settled fetch (same gate as `showAccess`) so it never
     // flashes the fallback preset, but the trigger itself is always mounted:


### PR DESCRIPTION
The labelled access-level and model-profile triggers collide on a narrow composer card — in the macOS app the two labels render on top of one another (the "Full access" and "Balanced" labels overlap into unreadable text).

Below a compact card width the pair now folds into a single hamburger menu holding both sections, so the action row reads **attach | settings | mic | voice**.

## How

- **`chat-composer/composer-compact.tsx`** (new) — `useIsCompactComposerWidth(ref)` measures the composer *card* via `ResizeObserver` against a 520px threshold, and `ComposerCompactProvider` publishes the result. Measuring the card rather than the viewport means it also follows sidebar toggles and split windows. Context rather than props because the pickers are mounted by `chat-route-content` but *rendered* inside the composer's tree, so they read the provider at their render position.
- **`chat-composer.tsx`** — measures the form, wraps the action row in the provider, and drops `modelPickerSlot` (and its divider) when compact. Mobile is excluded: its triggers are already icon-only and open bottom sheets, which fit.
- **`composer-settings-menu.tsx`** — when compact, ignores `segments` and renders one ghost hamburger trigger opening a single menu with `Assistant Access` / separator / `Model Profile` (quick-add "+" included). The access section still waits on a settled fetch so it can't flash the fallback preset, but the trigger always mounts so the profile list stays reachable either way. The menu rows were extracted into shared lists so the split and collapsed layouts can't drift apart.

Design-library primitives only (`Menu`, `Button` ghost) — no new custom surfaces.

## Testing

- `chat-composer.test.tsx` — model picker renders while wide; dropped when compact.
- `composer-settings-menu.test.tsx` — compact renders one hamburger carrying both sections and no split triggers; wide stays split.
- 97 tests pass across both files; typecheck and lint clean.

**Not verified in a live window** — the 520px threshold is a calculated estimate (worst case ≈ 465px: attach + both labelled triggers with a long profile name + context-window indicator + mic + send). If it collapses too eagerly or too late in practice, `COMPOSER_COMPACT_WIDTH_PX` is the single knob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
