### PR TITLE
fix(assistant): retry the SSE actor-principal heal instead of giving up after one lookup

### DIFF
--- a/assistant/src/__tests__/events-dev-bypass-actor.test.ts
+++ b/assistant/src/__tests__/events-dev-bypass-actor.test.ts
@@ -27,6 +27,10 @@ let fakeGuardianPrincipalId: string | undefined = undefined;
 // exactly when the SSE self-heal lookup completes.
 const pendingAsyncResolutions: Array<(value: string | undefined) => void> = [];
 
+/** Options each async resolution was called with, in the same order. */
+const asyncResolutionOptions: Array<{ forceRefresh?: boolean } | undefined> =
+  [];
+
 mock.module("../config/env.js", () => ({
   isHttpAuthDisabled: () => fakeHttpAuthDisabled,
   hasUngatedHttpAuthDisabled: () => false,
@@ -42,10 +46,14 @@ mock.module("../runtime/local-actor-identity.js", () => ({
     }
     return fakeGuardianPrincipalId;
   },
-  resolveActorPrincipalIdForLocalGuardian: (rawHeader: string | undefined) => {
+  resolveActorPrincipalIdForLocalGuardian: (
+    rawHeader: string | undefined,
+    options?: { forceRefresh?: boolean },
+  ) => {
     if (rawHeader !== "dev-bypass" || !fakeHttpAuthDisabled) {
       return Promise.resolve(rawHeader);
     }
+    asyncResolutionOptions.push(options);
     return new Promise<string | undefined>((resolve) => {
       pendingAsyncResolutions.push(resolve);
     });
@@ -86,6 +94,7 @@ afterAll(() => {
 describe("events SSE registration — dev-bypass actor translation", () => {
   beforeEach(() => {
     pendingAsyncResolutions.length = 0;
+    asyncResolutionOptions.length = 0;
   });
 
   test("translates 'dev-bypass' to the real guardian principalId when auth is disabled", () => {
@@ -280,9 +289,9 @@ describe("events SSE registration — dev-bypass actor translation", () => {
 
   test("retries the heal after a failed lookup instead of giving up for the connection's lifetime", async () => {
     // The gateway IPC returns null on any transport failure, so the first
-    // lookup can miss even when a guardian is bound. Before the retry, that
-    // one miss left the subscription principal-less until the user manually
-    // reconnected — every host-proxy result it submitted 403'd in between.
+    // lookup can miss even when a guardian is bound. A subscription left
+    // principal-less rejects every host-proxy result it submits, so the heal
+    // has to outlive one miss rather than stopping there.
     fakeHttpAuthDisabled = true;
     fakeGuardianPrincipalId = undefined; // cold cache: sync resolution misses
 
@@ -317,6 +326,15 @@ describe("events SSE registration — dev-bypass actor translation", () => {
     expect(hub.getActorPrincipalIdForClient("retry-client-001")).toBe(
       "guardian-real-id",
     );
+
+    // Every attempt must bypass the guardian-delivery cache. A successful read
+    // that finds no binding is cached for minutes, which outlives the retry
+    // schedule, so a cached read would spend all attempts on the same answer
+    // and never observe a binding created in between.
+    expect(asyncResolutionOptions).toEqual([
+      { forceRefresh: true },
+      { forceRefresh: true },
+    ]);
 
     ac.abort();
   });

--- a/assistant/src/__tests__/events-dev-bypass-actor.test.ts
+++ b/assistant/src/__tests__/events-dev-bypass-actor.test.ts
@@ -57,6 +57,23 @@ async function flushMicrotasks(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
+/**
+ * Poll until `predicate` holds, for assertions that depend on the heal's
+ * retry backoff timer rather than on promise settling alone.
+ */
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 3_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) {
+      throw new Error("waitFor timed out");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
 // ── Real imports (after mocks) ────────────────────────────────────────────
 
 import { AssistantEventHub } from "../runtime/assistant-event-hub.js";
@@ -259,6 +276,82 @@ describe("events SSE registration — dev-bypass actor translation", () => {
 
     ac1.abort();
     ac2.abort();
+  });
+
+  test("retries the heal after a failed lookup instead of giving up for the connection's lifetime", async () => {
+    // The gateway IPC returns null on any transport failure, so the first
+    // lookup can miss even when a guardian is bound. Before the retry, that
+    // one miss left the subscription principal-less until the user manually
+    // reconnected — every host-proxy result it submitted 403'd in between.
+    fakeHttpAuthDisabled = true;
+    fakeGuardianPrincipalId = undefined; // cold cache: sync resolution misses
+
+    const ac = new AbortController();
+    const hub = new AssistantEventHub();
+
+    handleSubscribeAssistantEvents(
+      {
+        headers: {
+          "x-vellum-client-id": "retry-client-001",
+          "x-vellum-interface-id": "chrome-extension",
+          "x-vellum-actor-principal-id": "dev-bypass",
+        },
+        abortSignal: ac.signal,
+      },
+      { hub },
+    );
+
+    // First attempt fails (gateway not reachable yet).
+    expect(pendingAsyncResolutions).toHaveLength(1);
+    pendingAsyncResolutions.shift()!(undefined);
+    await flushMicrotasks();
+    expect(
+      hub.getActorPrincipalIdForClient("retry-client-001"),
+    ).toBeUndefined();
+
+    // The retry fires on the backoff and succeeds this time.
+    await waitFor(() => pendingAsyncResolutions.length === 1);
+    pendingAsyncResolutions.shift()!("guardian-real-id");
+    await flushMicrotasks();
+
+    expect(hub.getActorPrincipalIdForClient("retry-client-001")).toBe(
+      "guardian-real-id",
+    );
+
+    ac.abort();
+  });
+
+  test("needsActorPrincipalHeal reports only live, principal-less client subscriptions", () => {
+    const hub = new AssistantEventHub();
+    const bare = hub.subscribe({
+      type: "client",
+      clientId: "needs-heal-001",
+      interfaceId: "chrome-extension",
+      capabilities: [],
+      callback: () => {},
+    });
+    const withPrincipal = hub.subscribe({
+      type: "client",
+      clientId: "needs-heal-002",
+      interfaceId: "macos",
+      capabilities: [],
+      actorPrincipalId: "guardian-real-id",
+      callback: () => {},
+    });
+    const process = hub.subscribe({ type: "process", callback: () => {} });
+
+    expect(hub.needsActorPrincipalHeal(bare.connectionId)).toBe(true);
+    expect(hub.needsActorPrincipalHeal(withPrincipal.connectionId)).toBe(false);
+    expect(hub.needsActorPrincipalHeal(process.connectionId)).toBe(false);
+    expect(hub.needsActorPrincipalHeal("conn-does-not-exist")).toBe(false);
+
+    // A disposed connection stops needing a heal, which is what ends the
+    // retry loop when a client disconnects mid-backoff.
+    bare.dispose();
+    expect(hub.needsActorPrincipalHeal(bare.connectionId)).toBe(false);
+
+    withPrincipal.dispose();
+    process.dispose();
   });
 
   test("fillClientActorPrincipalId never overwrites a present principal", () => {

--- a/assistant/src/runtime/__tests__/local-actor-identity-force-refresh.test.ts
+++ b/assistant/src/runtime/__tests__/local-actor-identity-force-refresh.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for the cache-bypass option on the local guardian principal lookup.
+ *
+ * The guardian-delivery reader caches a successful read that finds no binding,
+ * and gateway-side binding writes do not invalidate the daemon's cache. A
+ * caller polling for a binding it expects to appear (the SSE actor-principal
+ * heal) therefore has to force the read, or every attempt re-reads the same
+ * empty answer until the TTL lapses.
+ */
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { GuardianDelivery } from "@vellumai/gateway-client";
+
+let cachedResult: GuardianDelivery[] | null = null;
+let freshResult: GuardianDelivery[] | null = null;
+let cachedCalls = 0;
+let freshCalls = 0;
+
+mock.module("../../config/env.js", () => ({
+  isHttpAuthDisabled: () => true,
+  hasUngatedHttpAuthDisabled: () => false,
+}));
+
+mock.module("../../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: () => {
+    cachedCalls++;
+    return Promise.resolve(cachedResult);
+  },
+  getGuardianDeliveryFresh: () => {
+    freshCalls++;
+    return Promise.resolve(freshResult);
+  },
+  peekCachedGuardianDelivery: () => undefined,
+  guardianForChannel: (list: GuardianDelivery[]) => list[0],
+}));
+
+import {
+  findLocalGuardianPrincipalId,
+  resolveActorPrincipalIdForLocalGuardian,
+} from "../local-actor-identity.js";
+
+afterAll(() => {
+  mock.restore();
+});
+
+/** Minimal guardian row: only `principalId` is read here. */
+function guardian(principalId: string): GuardianDelivery {
+  return { principalId } as unknown as GuardianDelivery;
+}
+
+describe("local guardian principal lookup — cache bypass", () => {
+  beforeEach(() => {
+    cachedCalls = 0;
+    freshCalls = 0;
+    cachedResult = [];
+    freshResult = [];
+  });
+
+  test("reads the cache by default", async () => {
+    cachedResult = [guardian("guardian-cached")];
+    freshResult = [guardian("guardian-fresh")];
+
+    expect(await findLocalGuardianPrincipalId()).toBe("guardian-cached");
+    expect(cachedCalls).toBe(1);
+    expect(freshCalls).toBe(0);
+  });
+
+  test("forceRefresh bypasses the cache and sees a binding the cache would miss", async () => {
+    // Cached read holds the empty result from before the binding existed.
+    cachedResult = [];
+    freshResult = [guardian("guardian-fresh")];
+
+    expect(await findLocalGuardianPrincipalId()).toBeUndefined();
+    expect(await findLocalGuardianPrincipalId({ forceRefresh: true })).toBe(
+      "guardian-fresh",
+    );
+    expect(freshCalls).toBe(1);
+  });
+
+  test("resolveActorPrincipalIdForLocalGuardian threads forceRefresh through", async () => {
+    cachedResult = [];
+    freshResult = [guardian("guardian-fresh")];
+
+    expect(
+      await resolveActorPrincipalIdForLocalGuardian("dev-bypass"),
+    ).toBeUndefined();
+    expect(
+      await resolveActorPrincipalIdForLocalGuardian("dev-bypass", {
+        forceRefresh: true,
+      }),
+    ).toBe("guardian-fresh");
+    expect(freshCalls).toBe(1);
+  });
+
+  test("a non-dev-bypass principal is passed through without any lookup", async () => {
+    expect(
+      await resolveActorPrincipalIdForLocalGuardian("actor-123", {
+        forceRefresh: true,
+      }),
+    ).toBe("actor-123");
+    expect(cachedCalls).toBe(0);
+    expect(freshCalls).toBe(0);
+  });
+});

--- a/assistant/src/runtime/assistant-event-hub.ts
+++ b/assistant/src/runtime/assistant-event-hub.ts
@@ -466,6 +466,29 @@ export class AssistantEventHub {
   }
 
   /**
+   * Whether the connection identified by `connectionId` is still an active
+   * client subscription that carries no `actorPrincipalId`.
+   *
+   * Drives the retrying SSE self-heal (`sse-actor-principal-heal.ts`): the
+   * loop re-checks before each attempt so it stops as soon as the connection
+   * closes, is replaced by a reconnect, or gets a principal from any path.
+   * Returns `false` for an unknown, inactive, or process-type connection.
+   */
+  needsActorPrincipalHeal(connectionId: string): boolean {
+    for (const entry of this.subscribers) {
+      if (entry.connectionId !== connectionId) {
+        continue;
+      }
+      return (
+        entry.active &&
+        entry.type === "client" &&
+        entry.actorPrincipalId == null
+      );
+    }
+    return false;
+  }
+
+  /**
    * Fill a missing `actorPrincipalId` on a live client subscription.
    *
    * Used by the SSE dev-bypass self-heal: when the guardian-delivery cache is

--- a/assistant/src/runtime/assistant-event-hub.ts
+++ b/assistant/src/runtime/assistant-event-hub.ts
@@ -469,10 +469,10 @@ export class AssistantEventHub {
    * Whether the connection identified by `connectionId` is still an active
    * client subscription that carries no `actorPrincipalId`.
    *
-   * Drives the retrying SSE self-heal (`sse-actor-principal-heal.ts`): the
-   * loop re-checks before each attempt so it stops as soon as the connection
-   * closes, is replaced by a reconnect, or gets a principal from any path.
-   * Returns `false` for an unknown, inactive, or process-type connection.
+   * Drives the retrying SSE self-heal (`sse-actor-principal-heal.ts`): the loop
+   * re-checks before each attempt so it stops as soon as the connection closes,
+   * is replaced by a reconnect, or gets a principal from any path. Returns
+   * `false` for an unknown, inactive, or process-type connection.
    */
   needsActorPrincipalHeal(connectionId: string): boolean {
     for (const entry of this.subscribers) {

--- a/assistant/src/runtime/local-actor-identity.ts
+++ b/assistant/src/runtime/local-actor-identity.ts
@@ -11,6 +11,7 @@
 import { isHttpAuthDisabled } from "../config/env.js";
 import {
   getGuardianDelivery,
+  getGuardianDeliveryFresh,
   guardianForChannel,
   peekCachedGuardianDelivery,
 } from "../contacts/guardian-delivery-reader.js";
@@ -52,11 +53,19 @@ export function buildLocalAuthContext(conversationId: string): AuthContext {
  * Returns `undefined` when no vellum guardian binding exists (e.g. fresh
  * install before bootstrap, or the gateway is unreachable). Callers should
  * treat that case as "not yet available" and proceed without a principalId.
+ *
+ * `forceRefresh` bypasses the reader's TTL cache. A successful read that finds
+ * no binding is itself cached, and gateway-side binding writes do not
+ * invalidate the daemon's cache, so a caller that polls for a binding it
+ * expects to appear (the SSE actor-principal heal) must force the read or it
+ * re-reads the same empty answer until the TTL lapses.
  */
-export async function findLocalGuardianPrincipalId(): Promise<
-  string | undefined
-> {
-  const list = await getGuardianDelivery({ channelTypes: ["vellum"] });
+export async function findLocalGuardianPrincipalId(options?: {
+  forceRefresh?: boolean;
+}): Promise<string | undefined> {
+  const list = options?.forceRefresh
+    ? await getGuardianDeliveryFresh({ channelTypes: ["vellum"] })
+    : await getGuardianDelivery({ channelTypes: ["vellum"] });
   if (!list) {
     return undefined;
   }
@@ -136,15 +145,19 @@ export function findLocalGuardianPrincipalIdFromStore(): string | undefined {
  * `undefined` when dev-bypass is set but no guardian binding has been created
  * yet (e.g. fresh install before bootstrap); callers must treat this the
  * same as a missing principal.
+ *
+ * `forceRefresh` bypasses the guardian-delivery cache, for callers that poll
+ * for a binding they expect to appear. See {@link findLocalGuardianPrincipalId}.
  */
 export async function resolveActorPrincipalIdForLocalGuardian(
   rawHeader: string | undefined,
+  options?: { forceRefresh?: boolean },
 ): Promise<string | undefined> {
   if (rawHeader !== "dev-bypass" || !isHttpAuthDisabled()) {
     return rawHeader;
   }
 
-  const guardianPrincipalId = await findLocalGuardianPrincipalId();
+  const guardianPrincipalId = await findLocalGuardianPrincipalId(options);
   if (guardianPrincipalId) {
     return guardianPrincipalId;
   }

--- a/assistant/src/runtime/routes/__tests__/sse-actor-principal-heal.test.ts
+++ b/assistant/src/runtime/routes/__tests__/sse-actor-principal-heal.test.ts
@@ -1,12 +1,12 @@
 /**
- * Regression tests for the retrying SSE actor-principal self-heal.
+ * Tests for the retrying SSE actor-principal self-heal.
  *
- * The bug these pin: the heal used to be a single fire-and-forget lookup. The
- * guardian read goes over the gateway IPC and returns `null` on any transport
- * failure, so one unlucky attempt left the subscription principal-less for its
- * whole lifetime — every host-proxy result from that client then 403'd with
- * "Submitting actor does not match the target client's actor for this request"
- * until the user reconnected by hand.
+ * The invariant they pin: a single empty or failed guardian lookup must not
+ * strand the subscription without a principal. The read goes over the gateway
+ * IPC and comes back empty both when the transport fails and when no binding
+ * exists yet, and a subscription that stays principal-less rejects every
+ * host-proxy result its client submits with "Submitting actor does not match
+ * the target client's actor for this request" until it reconnects.
  */
 import { describe, expect, mock, test } from "bun:test";
 

--- a/assistant/src/runtime/routes/__tests__/sse-actor-principal-heal.test.ts
+++ b/assistant/src/runtime/routes/__tests__/sse-actor-principal-heal.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Regression tests for the retrying SSE actor-principal self-heal.
+ *
+ * The bug these pin: the heal used to be a single fire-and-forget lookup. The
+ * guardian read goes over the gateway IPC and returns `null` on any transport
+ * failure, so one unlucky attempt left the subscription principal-less for its
+ * whole lifetime — every host-proxy result from that client then 403'd with
+ * "Submitting actor does not match the target client's actor for this request"
+ * until the user reconnected by hand.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+import { startActorPrincipalHeal } from "../sse-actor-principal-heal.js";
+
+/** All-zero schedule so the retries run without real wall-clock delay. */
+const NO_DELAYS = [0, 0, 0];
+
+/** Minimal hub double: `needs` flips to false once a principal is filled. */
+function fakeHub(options?: { needs?: boolean }) {
+  let needs = options?.needs ?? true;
+  const filled: string[] = [];
+  return {
+    filled,
+    setNeeds(value: boolean) {
+      needs = value;
+    },
+    needsActorPrincipalHeal: mock(() => needs),
+    fillClientActorPrincipalId: mock((_connectionId: string, id: string) => {
+      filled.push(id);
+      needs = false;
+    }),
+  };
+}
+
+/** Let the heal's async loop run to completion. */
+async function settle(): Promise<void> {
+  for (let i = 0; i < 10; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+describe("startActorPrincipalHeal", () => {
+  test("fills the principal on the first successful attempt", async () => {
+    const hub = fakeHub();
+    startActorPrincipalHeal({
+      hub,
+      connectionId: "conn-1",
+      resolve: () => Promise.resolve("guardian-real-id"),
+      delaysMs: NO_DELAYS,
+    });
+    await settle();
+
+    expect(hub.filled).toEqual(["guardian-real-id"]);
+    expect(hub.needsActorPrincipalHeal).toHaveBeenCalledTimes(1);
+  });
+
+  test("retries after a lookup that resolves undefined (gateway unreachable)", async () => {
+    const hub = fakeHub();
+    let calls = 0;
+    startActorPrincipalHeal({
+      hub,
+      connectionId: "conn-1",
+      resolve: () => {
+        calls++;
+        // Two failed reads, then the gateway comes up.
+        return Promise.resolve(calls < 3 ? undefined : "guardian-real-id");
+      },
+      delaysMs: NO_DELAYS,
+    });
+    await settle();
+
+    expect(calls).toBe(3);
+    expect(hub.filled).toEqual(["guardian-real-id"]);
+  });
+
+  test("retries after a lookup that rejects", async () => {
+    const hub = fakeHub();
+    let calls = 0;
+    startActorPrincipalHeal({
+      hub,
+      connectionId: "conn-1",
+      resolve: () => {
+        calls++;
+        return calls === 1
+          ? Promise.reject(new Error("ipc timeout"))
+          : Promise.resolve("guardian-real-id");
+      },
+      delaysMs: NO_DELAYS,
+    });
+    await settle();
+
+    expect(calls).toBe(2);
+    expect(hub.filled).toEqual(["guardian-real-id"]);
+  });
+
+  test("stops retrying once the connection no longer needs healing", async () => {
+    // Models a disconnect (or a reconnect that replaced this subscription)
+    // between attempts: the loop must not keep polling the gateway for a
+    // connection that is gone.
+    const hub = fakeHub();
+    let calls = 0;
+    startActorPrincipalHeal({
+      hub,
+      connectionId: "conn-1",
+      resolve: () => {
+        calls++;
+        hub.setNeeds(false);
+        return Promise.resolve(undefined);
+      },
+      delaysMs: NO_DELAYS,
+    });
+    await settle();
+
+    expect(calls).toBe(1);
+    expect(hub.filled).toEqual([]);
+  });
+
+  test("never starts a lookup when the connection is already healed or gone", async () => {
+    const hub = fakeHub({ needs: false });
+    const resolve = mock(() => Promise.resolve("guardian-real-id"));
+    startActorPrincipalHeal({
+      hub,
+      connectionId: "conn-1",
+      resolve,
+      delaysMs: NO_DELAYS,
+    });
+    await settle();
+
+    expect(resolve).toHaveBeenCalledTimes(0);
+    expect(hub.filled).toEqual([]);
+  });
+
+  test("gives up after the schedule is exhausted without filling", async () => {
+    const hub = fakeHub();
+    let calls = 0;
+    startActorPrincipalHeal({
+      hub,
+      connectionId: "conn-1",
+      resolve: () => {
+        calls++;
+        return Promise.resolve(undefined);
+      },
+      delaysMs: NO_DELAYS,
+    });
+    await settle();
+
+    expect(calls).toBe(NO_DELAYS.length);
+    expect(hub.filled).toEqual([]);
+  });
+
+  test("dispatches the first attempt synchronously", () => {
+    const hub = fakeHub();
+    const resolve = mock(() => Promise.resolve("guardian-real-id"));
+    startActorPrincipalHeal({
+      hub,
+      connectionId: "conn-1",
+      resolve,
+      delaysMs: NO_DELAYS,
+    });
+
+    // No await: the leading zero delay must not cost a macrotask, so a
+    // warm-cache heal lands before the stream delivers its first event.
+    expect(resolve).toHaveBeenCalledTimes(1);
+  });
+});

--- a/assistant/src/runtime/routes/__tests__/surface-action-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/surface-action-routes.test.ts
@@ -59,6 +59,8 @@ let mockReResolve: { trustClass: string; sourceChannel: string } | null = null;
 mock.module("../../../contacts/guardian-delivery-reader.js", () => ({
   getGuardianDelivery: (_input?: { channelTypes?: string[] }) =>
     Promise.resolve(mockGuardianList),
+  getGuardianDeliveryFresh: (_input?: { channelTypes?: string[] }) =>
+    Promise.resolve(mockGuardianList),
   peekCachedGuardianDelivery: () => mockGuardianList ?? undefined,
   guardianForChannel: (
     list: Array<Record<string, unknown>>,

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -52,6 +52,7 @@ import {
   ServiceUnavailableError,
 } from "./errors.js";
 import { parseBody } from "./parse-body.js";
+import { startActorPrincipalHeal } from "./sse-actor-principal-heal.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 const log = getLogger("events-routes");
@@ -460,23 +461,21 @@ export function handleSubscribeAssistantEvents(
   // Without this, the subscription would carry no principal for its whole
   // lifetime and every host-proxy result would 403. Fire-and-forget so the
   // stream is not delayed; keyed by connectionId so a reconnect race cannot
-  // patch the subscription that replaced this one.
+  // patch the subscription that replaced this one. The lookup goes over the
+  // gateway IPC and can fail transiently, so it retries on a bounded backoff
+  // rather than leaving the subscription principal-less until the user
+  // manually reconnects — see `sse-actor-principal-heal.ts`.
   if (
     clientId &&
     interfaceId &&
     actorPrincipalId == null &&
     rawActorPrincipalId?.trim() === "dev-bypass"
   ) {
-    void resolveActorPrincipalIdForLocalGuardian("dev-bypass")
-      .then((resolved) => {
-        if (resolved) {
-          hub.fillClientActorPrincipalId(sub.connectionId, resolved);
-        }
-      })
-      .catch(() => {
-        // Best-effort: an unreachable gateway leaves the record unhealed;
-        // the next reconnect retries.
-      });
+    startActorPrincipalHeal({
+      hub,
+      connectionId: sub.connectionId,
+      resolve: () => resolveActorPrincipalIdForLocalGuardian("dev-bypass"),
+    });
   }
 
   const stream = new ReadableStream<Uint8Array>(

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -456,15 +456,14 @@ export function handleSubscribeAssistantEvents(
     throw err;
   }
 
-  // Self-heal for dev-bypass connections: the sync resolution above reads
-  // only the guardian-delivery cache, which can be cold at connect time.
-  // Without this, the subscription would carry no principal for its whole
-  // lifetime and every host-proxy result would 403. Fire-and-forget so the
-  // stream is not delayed; keyed by connectionId so a reconnect race cannot
-  // patch the subscription that replaced this one. The lookup goes over the
-  // gateway IPC and can fail transiently, so it retries on a bounded backoff
-  // rather than leaving the subscription principal-less until the user
-  // manually reconnects — see `sse-actor-principal-heal.ts`.
+  // Self-heal for dev-bypass connections: the sync resolution above reads only
+  // the guardian-delivery cache, which can be cold at connect time, and a
+  // subscription that carries no principal for its lifetime 403s every
+  // host-proxy result it submits. The heal retries on a bounded backoff
+  // (`sse-actor-principal-heal.ts`), fire-and-forget so the stream is not
+  // delayed, keyed by connectionId so a reconnect race cannot patch the
+  // subscription that replaced this one. The lookup forces a fresh gateway read
+  // because a cached empty result outlives the retry schedule.
   if (
     clientId &&
     interfaceId &&
@@ -474,7 +473,10 @@ export function handleSubscribeAssistantEvents(
     startActorPrincipalHeal({
       hub,
       connectionId: sub.connectionId,
-      resolve: () => resolveActorPrincipalIdForLocalGuardian("dev-bypass"),
+      resolve: () =>
+        resolveActorPrincipalIdForLocalGuardian("dev-bypass", {
+          forceRefresh: true,
+        }),
     });
   }
 

--- a/assistant/src/runtime/routes/sse-actor-principal-heal.ts
+++ b/assistant/src/runtime/routes/sse-actor-principal-heal.ts
@@ -1,37 +1,34 @@
 /**
- * Retrying self-heal for an SSE client subscription that registered without
- * an actor principal.
+ * Retrying self-heal for an SSE client subscription that registered without an
+ * actor principal.
  *
- * In `DISABLE_HTTP_AUTH` deployments the SSE subscribe path cannot await, so
- * it resolves the dev-bypass actor principal from an IO-free peek at the
- * guardian-delivery cache. On a cold cache the subscription registers with
- * `actorPrincipalId: undefined`, and every host-proxy result the client
- * submits then fails the same-actor gate with `missing_target` — a 403 the
- * client can only escape by reconnecting.
+ * In `DISABLE_HTTP_AUTH` deployments the SSE subscribe path cannot await, so it
+ * resolves the dev-bypass actor principal from an IO-free peek at the
+ * guardian-delivery cache. A cold cache registers the subscription with
+ * `actorPrincipalId: undefined`, and every host-proxy result that client
+ * submits then fails the same-actor gate with `missing_target`: a 403 that only
+ * a fresh registration clears.
  *
- * The route closes that window by resolving the guardian asynchronously after
- * the eager subscribe and patching the live hub record. A single attempt is
- * not enough: the guardian read goes over the gateway IPC, which returns
- * `null` on ANY transport failure (unreachable gateway, 2s timeout, a pod that
- * has not finished starting). One failed attempt left the subscription
- * principal-less for its whole lifetime, so the client 403'd every host-proxy
- * result until the user manually reconnected — and, for a Chrome extension
- * whose MV3 service worker suspends and reconnects on its own schedule, each
- * reconnect was a fresh coin flip on whether the read happened to succeed.
- * That is the "reconnect fixes it, then it breaks again" report.
+ * The heal resolves the guardian asynchronously and patches the live hub
+ * record. Each attempt can come back empty, since the lookup goes over the
+ * gateway IPC and yields nothing both when the transport fails (unreachable
+ * gateway, its 2s timeout, a pod still starting) and when no guardian binding
+ * exists yet, so attempts repeat on a bounded backoff. The loop stops on the
+ * first success, when the connection is gone or already carries a principal, or
+ * when the schedule is exhausted.
  *
- * So the heal retries on a bounded backoff, re-checking before each attempt
- * whether the subscription still needs healing. It stops on the first success,
- * when the connection is gone or already carries a principal, or when the
- * schedule is exhausted (a reconnect retries from scratch either way).
+ * Callers must pass a cache-bypassing lookup: the guardian-delivery reader
+ * caches a successful empty result for minutes, which outlives the whole
+ * schedule, so a cached read would spend every attempt on the same stale
+ * answer.
  */
 import { getLogger } from "../../util/logger.js";
 
 const log = getLogger("sse-actor-heal");
 
 /**
- * The hub surface this module needs: a liveness/need check and the fill.
- * Narrow by design so tests can drive the loop without a real hub.
+ * The hub surface this module needs: a liveness check and the fill. Narrow by
+ * design so tests can drive the loop without a real hub.
  */
 export interface ActorPrincipalHealHub {
   needsActorPrincipalHeal(connectionId: string): boolean;
@@ -42,22 +39,23 @@ export interface ActorPrincipalHealHub {
 }
 
 /**
- * Delay before each attempt, in milliseconds. The first attempt starts
- * immediately (no timer — the previous single-shot timing is preserved), then
- * the retries back off to cover a gateway that is slow to come up without
- * holding a timer for the life of a long-lived stream. Total span ≈ 44s.
+ * Delay before each attempt, in milliseconds. The leading zero dispatches the
+ * first attempt inline with the subscribe; the rest back off to cover a gateway
+ * that is slow to come up, without holding a timer for the life of a long-lived
+ * stream. Total span is about 44s.
  */
 export const ACTOR_PRINCIPAL_HEAL_DELAYS_MS: readonly number[] = [
   0, 1_000, 3_000, 10_000, 30_000,
 ];
 
 /**
- * Start the retrying heal for `connectionId`. Fire-and-forget: never awaited
- * by the route, never delays the stream.
+ * Start the retrying heal for `connectionId`. Fire-and-forget: never awaited by
+ * the route, never delays the stream.
  *
- * `resolve` performs the daemon's own server-side guardian lookup — the value
- * must never come from client input. It may resolve `undefined` (no binding
- * yet / gateway unreachable) or reject; both count as a failed attempt.
+ * `resolve` performs the daemon's own server-side guardian lookup, bypassing
+ * the guardian-delivery cache. The value must never come from client input. It
+ * may resolve `undefined` (no binding yet, or the gateway is unreachable) or
+ * reject; both count as a failed attempt.
  */
 export function startActorPrincipalHeal(args: {
   hub: ActorPrincipalHealHub;
@@ -71,15 +69,13 @@ export function startActorPrincipalHeal(args: {
 
   void (async () => {
     for (let attempt = 0; attempt < delays.length; attempt++) {
-      // A zero delay runs inline rather than costing a macrotask, so the
-      // first attempt is dispatched synchronously with the subscribe.
       const delayMs = delays[attempt] ?? 0;
       if (delayMs > 0) {
         await sleep(delayMs);
       }
 
-      // Re-check every time: the connection may have closed, been replaced by
-      // a reconnect, or been healed by a concurrent path since the last pass.
+      // Re-check every pass: the connection may have closed, been replaced by a
+      // reconnect, or been healed by another path since the last one.
       if (!hub.needsActorPrincipalHeal(connectionId)) {
         return;
       }
@@ -96,13 +92,13 @@ export function startActorPrincipalHeal(args: {
       }
     }
 
-    // Exhausted. Log once so a persistently principal-less subscription is
-    // greppable next to the same-actor rejections it will cause, rather than
-    // showing up only as unexplained 403s on the client.
+    // Log the give-up so a principal-less subscription is greppable next to the
+    // same-actor rejections it causes, rather than surfacing only as opaque
+    // 403s on the client.
     if (hub.needsActorPrincipalHeal(connectionId)) {
       log.warn(
         { connectionId, attempts: delays.length },
-        "gave up healing missing actorPrincipalId for client subscription; host-proxy results from this connection will be rejected until it reconnects",
+        "gave up healing missing actorPrincipalId for client subscription; host-proxy results from this connection are rejected until it reconnects",
       );
     }
   })();

--- a/assistant/src/runtime/routes/sse-actor-principal-heal.ts
+++ b/assistant/src/runtime/routes/sse-actor-principal-heal.ts
@@ -1,0 +1,117 @@
+/**
+ * Retrying self-heal for an SSE client subscription that registered without
+ * an actor principal.
+ *
+ * In `DISABLE_HTTP_AUTH` deployments the SSE subscribe path cannot await, so
+ * it resolves the dev-bypass actor principal from an IO-free peek at the
+ * guardian-delivery cache. On a cold cache the subscription registers with
+ * `actorPrincipalId: undefined`, and every host-proxy result the client
+ * submits then fails the same-actor gate with `missing_target` — a 403 the
+ * client can only escape by reconnecting.
+ *
+ * The route closes that window by resolving the guardian asynchronously after
+ * the eager subscribe and patching the live hub record. A single attempt is
+ * not enough: the guardian read goes over the gateway IPC, which returns
+ * `null` on ANY transport failure (unreachable gateway, 2s timeout, a pod that
+ * has not finished starting). One failed attempt left the subscription
+ * principal-less for its whole lifetime, so the client 403'd every host-proxy
+ * result until the user manually reconnected — and, for a Chrome extension
+ * whose MV3 service worker suspends and reconnects on its own schedule, each
+ * reconnect was a fresh coin flip on whether the read happened to succeed.
+ * That is the "reconnect fixes it, then it breaks again" report.
+ *
+ * So the heal retries on a bounded backoff, re-checking before each attempt
+ * whether the subscription still needs healing. It stops on the first success,
+ * when the connection is gone or already carries a principal, or when the
+ * schedule is exhausted (a reconnect retries from scratch either way).
+ */
+import { getLogger } from "../../util/logger.js";
+
+const log = getLogger("sse-actor-heal");
+
+/**
+ * The hub surface this module needs: a liveness/need check and the fill.
+ * Narrow by design so tests can drive the loop without a real hub.
+ */
+export interface ActorPrincipalHealHub {
+  needsActorPrincipalHeal(connectionId: string): boolean;
+  fillClientActorPrincipalId(
+    connectionId: string,
+    actorPrincipalId: string,
+  ): void;
+}
+
+/**
+ * Delay before each attempt, in milliseconds. The first attempt starts
+ * immediately (no timer — the previous single-shot timing is preserved), then
+ * the retries back off to cover a gateway that is slow to come up without
+ * holding a timer for the life of a long-lived stream. Total span ≈ 44s.
+ */
+export const ACTOR_PRINCIPAL_HEAL_DELAYS_MS: readonly number[] = [
+  0, 1_000, 3_000, 10_000, 30_000,
+];
+
+/**
+ * Start the retrying heal for `connectionId`. Fire-and-forget: never awaited
+ * by the route, never delays the stream.
+ *
+ * `resolve` performs the daemon's own server-side guardian lookup — the value
+ * must never come from client input. It may resolve `undefined` (no binding
+ * yet / gateway unreachable) or reject; both count as a failed attempt.
+ */
+export function startActorPrincipalHeal(args: {
+  hub: ActorPrincipalHealHub;
+  connectionId: string;
+  resolve: () => Promise<string | undefined>;
+  /** Override the backoff schedule. Tests pass all-zero delays. */
+  delaysMs?: readonly number[];
+}): void {
+  const { hub, connectionId, resolve } = args;
+  const delays = args.delaysMs ?? ACTOR_PRINCIPAL_HEAL_DELAYS_MS;
+
+  void (async () => {
+    for (let attempt = 0; attempt < delays.length; attempt++) {
+      // A zero delay runs inline rather than costing a macrotask, so the
+      // first attempt is dispatched synchronously with the subscribe.
+      const delayMs = delays[attempt] ?? 0;
+      if (delayMs > 0) {
+        await sleep(delayMs);
+      }
+
+      // Re-check every time: the connection may have closed, been replaced by
+      // a reconnect, or been healed by a concurrent path since the last pass.
+      if (!hub.needsActorPrincipalHeal(connectionId)) {
+        return;
+      }
+
+      let resolved: string | undefined;
+      try {
+        resolved = await resolve();
+      } catch {
+        resolved = undefined;
+      }
+      if (resolved) {
+        hub.fillClientActorPrincipalId(connectionId, resolved);
+        return;
+      }
+    }
+
+    // Exhausted. Log once so a persistently principal-less subscription is
+    // greppable next to the same-actor rejections it will cause, rather than
+    // showing up only as unexplained 403s on the client.
+    if (hub.needsActorPrincipalHeal(connectionId)) {
+      log.warn(
+        { connectionId, attempts: delays.length },
+        "gave up healing missing actorPrincipalId for client subscription; host-proxy results from this connection will be rejected until it reconnects",
+      );
+    }
+  })();
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    // Never hold the process (or a test runner) open on a pending backoff.
+    (timer as { unref?: () => void }).unref?.();
+  });
+}

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -489,19 +489,18 @@ async function dispatchHostBrowserResult(
  * applies its own cap as the second line of defense).
  */
 /**
- * The daemon's same-actor gate rejects a host-proxy result when the actor
- * that opened this client's SSE stream and the actor submitting the result
- * don't line up — most often because the stream registered before the
- * daemon could resolve its actor identity, so the binding is missing rather
- * than genuinely mismatched. That binding is established at subscribe time,
- * so the only thing that clears it from this side is a fresh registration:
- * exactly the "disconnect and reconnect and it works again" workaround.
+ * The daemon's same-actor gate rejects a host-proxy result when the actor that
+ * opened this client's SSE stream and the actor submitting the result don't
+ * line up, most often because the stream registered before the daemon could
+ * resolve its actor identity, leaving the binding missing rather than genuinely
+ * mismatched. The binding is established at subscribe time, so the only thing
+ * that clears it from this side is a fresh registration.
  *
- * Doing it automatically keeps a single unlucky subscribe from silently
- * breaking every browser action until the user notices and reconnects by
- * hand. A cooldown keeps a persistent rejection (e.g. the stream really is
- * bound to a different user) from turning into a reconnect loop — after the
- * one attempt, the failure is left to surface as it did before.
+ * Reconnecting on the rejection keeps one unlucky subscribe from silently
+ * breaking every browser action until the user reconnects by hand. The cooldown
+ * keeps a persistent rejection (e.g. the stream really is bound to a different
+ * user) from turning into a reconnect loop: past the one attempt, the failure
+ * surfaces to the event log and stops there.
  */
 const ACTOR_BINDING_RECONNECT_COOLDOWN_MS = 60_000;
 let lastActorBindingReconnectAt = 0;
@@ -514,8 +513,12 @@ function maybeReconnectOnActorBindingRejection(
   status: number,
   body: string,
 ): void {
-  if (!isActorBindingRejection(status, body)) return;
-  if (!shouldConnect) return;
+  if (!isActorBindingRejection(status, body)) {
+    return;
+  }
+  if (!shouldConnect) {
+    return;
+  }
 
   const now = Date.now();
   if (now - lastActorBindingReconnectAt < ACTOR_BINDING_RECONNECT_COOLDOWN_MS) {

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -424,6 +424,7 @@ async function dispatchHostBrowserResult(
           resp.status,
           body,
         );
+        maybeReconnectOnActorBindingRejection(resp.status, body);
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -487,6 +488,58 @@ async function dispatchHostBrowserResult(
  * operations ring buffer (the {@link recordCallbackFailure} helper
  * applies its own cap as the second line of defense).
  */
+/**
+ * The daemon's same-actor gate rejects a host-proxy result when the actor
+ * that opened this client's SSE stream and the actor submitting the result
+ * don't line up — most often because the stream registered before the
+ * daemon could resolve its actor identity, so the binding is missing rather
+ * than genuinely mismatched. That binding is established at subscribe time,
+ * so the only thing that clears it from this side is a fresh registration:
+ * exactly the "disconnect and reconnect and it works again" workaround.
+ *
+ * Doing it automatically keeps a single unlucky subscribe from silently
+ * breaking every browser action until the user notices and reconnects by
+ * hand. A cooldown keeps a persistent rejection (e.g. the stream really is
+ * bound to a different user) from turning into a reconnect loop — after the
+ * one attempt, the failure is left to surface as it did before.
+ */
+const ACTOR_BINDING_RECONNECT_COOLDOWN_MS = 60_000;
+let lastActorBindingReconnectAt = 0;
+
+function isActorBindingRejection(status: number, body: string): boolean {
+  return status === 403 && /Submitting actor does not match/i.test(body);
+}
+
+function maybeReconnectOnActorBindingRejection(
+  status: number,
+  body: string,
+): void {
+  if (!isActorBindingRejection(status, body)) return;
+  if (!shouldConnect) return;
+
+  const now = Date.now();
+  if (now - lastActorBindingReconnectAt < ACTOR_BINDING_RECONNECT_COOLDOWN_MS) {
+    return;
+  }
+  lastActorBindingReconnectAt = now;
+
+  console.warn(
+    "[vellum] host-browser-result rejected by the actor binding check; re-registering the SSE connection",
+  );
+  appendEvent("outbound", "actor_binding_reconnect", {
+    summary: "re-registering after a 403 from the actor binding check",
+    isError: true,
+  });
+
+  disconnect();
+  void connect({ interactive: false }).catch((err) => {
+    console.warn(
+      "[vellum] reconnect after actor-binding rejection failed",
+      err,
+    );
+  });
+}
+
 async function safeReadBody(resp: Response): Promise<string> {
   try {
     const text = await resp.text();


### PR DESCRIPTION
## Prompt / plan

User report: the Chrome extension keeps failing browser actions with

```
{"error":{"code":"FORBIDDEN","message":"Submitting actor does not match the target client's actor for this request. The targeted client's authenticated user must submit the result."}}
```

> "If I reconnect it works the first time but fails shortly after."

**Root cause.** The same-actor gate (`runtime/auth/same-actor.ts`) compares the actor that opened the target client's SSE stream against the actor submitting the host-proxy result. In `DISABLE_HTTP_AUTH` deployments the SSE subscribe path cannot await, so it resolves the dev-bypass principal from an IO-free peek at the guardian-delivery cache; on a cold cache the subscription registers with `actorPrincipalId: undefined`. #40169 added an async self-heal to patch the hub record after subscribe, which is the right shape, but it was a **single fire-and-forget lookup**.

That lookup goes over the gateway IPC, and `guardian-delivery-reader` returns `null` on *any* transport failure (unreachable gateway, its 2s timeout, a pod still starting) without caching the failure. So one unlucky attempt left the subscription principal-less for its entire lifetime, and every host-proxy result that client submitted failed the gate with `missing_target`: the 403 above. The existing code even notes the consequence: *"an unreachable gateway leaves the record unhealed; the next reconnect retries."*

That matches the reported symptom. A Chrome extension's MV3 service worker suspends and reconnects on its own schedule, so every reconnect was a fresh coin flip on whether that one read happened to succeed. Reconnect fixes it, and it breaks again on the next unlucky subscribe. The `hubForMissingTarget` fill-if-missing added alongside #40169 doesn't rescue it either, since it reads the same hub record the heal failed to fill.

**Fix, three parts:**

- **Retry the heal (the actual bug).** A new `runtime/routes/sse-actor-principal-heal.ts` retries on a bounded backoff (immediate, then 1s/3s/10s/30s), re-checking `AssistantEventHub.needsActorPrincipalHeal(connectionId)` before each attempt so it stops as soon as the connection closes, is replaced by a reconnect, or gets a principal from any path. Still fire-and-forget: the stream is never delayed, the first attempt is dispatched synchronously with subscribe as before, and timers are unref'd. Exhausting the schedule logs a warning so a persistently principal-less subscription is greppable next to the rejections it causes, instead of surfacing only as opaque client-side 403s.
- **Force a fresh guardian read on each attempt** (from Codex review). `readGuardianDelivery` caches on a truthy result, and an empty array is truthy, so a successful read that finds no binding is cached for the full 300s TTL. That outlives the ~44s schedule, so a cached lookup would spend every attempt on the same stale empty answer and never observe a binding created mid-schedule. `findLocalGuardianPrincipalId` and `resolveActorPrincipalIdForLocalGuardian` now take a `forceRefresh` option routing through `getGuardianDeliveryFresh`; the heal passes it on every attempt. Existing call sites are unchanged.
- **Chrome extension recovery.** A result POST rejected by the actor gate now re-registers the SSE connection once, with a 60s cooldown, automating the reconnect workaround the user found by hand and bounded so a genuine cross-user mismatch can't turn into a reconnect loop.

No change to the gate's semantics: the value filled always comes from the daemon's own server-side guardian lookup (never client input), `fillClientActorPrincipalId` remains fill-only and connection-id-keyed, and a present-but-mismatched principal still 403s.

## Test plan

New `src/runtime/routes/__tests__/sse-actor-principal-heal.test.ts` (7 tests): fills on first success; retries past a lookup that resolves `undefined`; retries past a lookup that rejects; stops as soon as the connection no longer needs healing; never starts a lookup for an already-healed or gone connection; gives up after the schedule is exhausted; dispatches the first attempt synchronously.

New `src/runtime/__tests__/local-actor-identity-force-refresh.test.ts` (4 tests): default reads stay cached; `forceRefresh` sees a binding the cached read misses; the option threads through `resolveActorPrincipalIdForLocalGuardian`; a non-dev-bypass principal passes through with no lookup at all.

Extended `src/__tests__/events-dev-bypass-actor.test.ts`: end-to-end through the route, a first lookup that fails is retried on the backoff and the second one heals the hub record (the regression that reproduces the report), and both attempts are asserted to request `forceRefresh: true`; plus `needsActorPrincipalHeal` semantics (live principal-less client is true; client with a principal, process subscriber, unknown id, and disposed connection are false).

All suites green run per-file: `events-dev-bypass-actor` (11), `local-actor-identity-force-refresh` (4), `sse-actor-principal-heal` (7), `local-actor-identity` (8), `sse-actor-principal-guardian-source` (3), `events-client-registration` (18), `host-browser-routes` (20), `host-app-control-routes` (30), `host-browser-proxy` (44), `host-bash-proxy` (34), `clients-list-ipc` (4), `http-user-message-parity` (25). Running several of these in one `bun test` process trips a pre-existing `mock.module` cross-file contamination (`Export named 'AssistantEventHub' not found`) that reproduces identically on the base commit. `tsc --noEmit` plus eslint and prettier clean for `assistant/` and `clients/chrome-extension/`.

Not verified end-to-end against a live cold-cache pod, since the failing lookup is a transient gateway-IPC condition. The retry path is covered by the tests above rather than by reproduction.

## CLI verb checklist

No new routes. `sse-actor-principal-heal.ts` is an internal helper for the existing `GET /v1/events` handler, not a route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUFybo5kLB4njFe5FPY4JC