### PR TITLE
fix(web): scrim the voice room controls over the camera feed (LUM-3132)

### DIFF
--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-control.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-control.tsx
@@ -1,30 +1,25 @@
 /**
- * The room's circular icon controls: minimize, the two mutes, the camera
- * toggle, flip camera, end session.
+ * Every circular icon control in the room: the corner minimize, the two mutes,
+ * the camera toggle, flip camera, end session.
  *
- * One component rather than the class constants these used to be. The
- * treatment varies along three axes (neutral vs destructive, bordered vs bare,
- * and whether the viewfinder is open behind it), and every call site was
- * re-deriving its own combination through `cn()`. That is how the camera-open
- * scrim can reach four controls and quietly miss the fifth, which is exactly
- * the bug class this file exists to close.
+ * The treatment varies along three axes, so it lives in one place rather than
+ * being assembled per call site: neutral vs destructive toning, bordered vs
+ * bare, and whether the viewfinder is open behind the control. A scrim that
+ * every call site has to remember is one that reaches most of the row and
+ * misses a control.
  *
- * Not the design library's `Button`, and not for lack of trying: these are
- * 48px circles, and `Button`'s sizes stop at `h-8` with `rounded-md` baked
- * into every one of them (see its `size` variants and the `iconOnly` compound
- * variants), so adopting it would mean overriding size, radius, border and
- * every color at each call site while still inheriting `active:scale-[0.97]`
- * and a theme-token focus ring the room cannot use. The library also has no
- * treatment for chrome over live video. The room is not app chrome: it paints
- * itself an arbitrary avatar color, which is why it carries its own `--room-*`
- * contract at all.
+ * The element is a bare `<button>`, not the design library's `Button`. These
+ * are 48px circles; `Button`'s sizes stop at `h-8` with `rounded-md` on every
+ * one of them, and it carries `active:scale-[0.97]` plus a theme-token focus
+ * ring. The room paints itself an arbitrary avatar color, so theme tokens are
+ * as likely to be invisible on it as legible, which is what the `--room-*`
+ * contract exists to replace. The library also has no treatment for chrome
+ * over live video.
  *
- * The sibling voice surfaces (the composer bar, the header pill) DO use
- * `Button` plus `VOICE_SURFACE_CONTROL_CLASS` from `voice-surface-paint.ts`,
- * because at their size the library's shape is the right one. This component
- * deliberately reads the same `--room-*` vars that module publishes, so all
- * three surfaces stay one visual system even though two of them can share an
- * element and this one cannot.
+ * The sibling voice surfaces (the composer bar, the header pill) do use
+ * `Button` with `VOICE_SURFACE_CONTROL_CLASS` from `voice-surface-paint.ts`,
+ * where the library's shape suits their size. This reads the same `--room-*`
+ * vars that module publishes, so all three surfaces are one visual system.
  */
 
 import { Tooltip, cn } from "@vellumai/design-library";

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-control.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-control.tsx
@@ -1,0 +1,148 @@
+/**
+ * The room's circular icon controls: minimize, the two mutes, the camera
+ * toggle, flip camera, end session.
+ *
+ * One component rather than the class constants these used to be. The
+ * treatment varies along three axes (neutral vs destructive, bordered vs bare,
+ * and whether the viewfinder is open behind it), and every call site was
+ * re-deriving its own combination through `cn()`. That is how the camera-open
+ * scrim can reach four controls and quietly miss the fifth, which is exactly
+ * the bug class this file exists to close.
+ *
+ * Not the design library's `Button`, and not for lack of trying: these are
+ * 48px circles, and `Button`'s sizes stop at `h-8` with `rounded-md` baked
+ * into every one of them (see its `size` variants and the `iconOnly` compound
+ * variants), so adopting it would mean overriding size, radius, border and
+ * every color at each call site while still inheriting `active:scale-[0.97]`
+ * and a theme-token focus ring the room cannot use. The library also has no
+ * treatment for chrome over live video. The room is not app chrome: it paints
+ * itself an arbitrary avatar color, which is why it carries its own `--room-*`
+ * contract at all.
+ *
+ * The sibling voice surfaces (the composer bar, the header pill) DO use
+ * `Button` plus `VOICE_SURFACE_CONTROL_CLASS` from `voice-surface-paint.ts`,
+ * because at their size the library's shape is the right one. This component
+ * deliberately reads the same `--room-*` vars that module publishes, so all
+ * three surfaces stay one visual system even though two of them can share an
+ * element and this one cannot.
+ */
+
+import { Tooltip, cn } from "@vellumai/design-library";
+import type { ReactNode } from "react";
+
+/**
+ * The treatment for a control sitting over the open viewfinder.
+ *
+ * Every other treatment here is derived from the assistant's avatar tone,
+ * which is the correct reference right up until the camera opens: the feed
+ * then covers the look edge to edge, so the tone describes a background nobody
+ * can see, and a control whose entire resting appearance is a 15%-white
+ * hairline simply is not there over a dark shirt.
+ *
+ * Fixed colors rather than tone-derived ones, deliberately. What sits behind
+ * these is arbitrary camera video, not a color the room picked, so there is
+ * nothing to derive from. The blur is what keeps the scrim honest over a busy
+ * frame without having to push the fill toward opaque.
+ */
+const OVER_MEDIA_NEUTRAL_CLASS =
+  "border-white/25 bg-black/45 text-white backdrop-blur-sm hover:bg-black/60 hover:text-white focus-visible:outline-white";
+
+/**
+ * The red worn by a control that is doing something to the call: the two mutes
+ * while engaged, and end-session always.
+ *
+ * Three variants because the room's background is the assistant's avatar
+ * color, which can be a light one (yellow). A single red picked against the
+ * dark look washes out over that, so `isLight` swaps to the darker red the
+ * tone helper's foreground colors are chosen against. Over the viewfinder
+ * neither applies: the fill carries the same weight the neutral scrim does,
+ * keeping the red identity while staying readable on whatever is in frame, and
+ * the glyph goes white because a red-on-red icon is the first thing to
+ * disappear.
+ */
+function destructiveClass(overMedia: boolean, isLight: boolean): string {
+  if (overMedia) {
+    return "border-red-200/40 bg-red-600/55 text-white backdrop-blur-sm hover:bg-red-600/70 focus-visible:outline-white";
+  }
+  return isLight
+    ? "border-red-700/50 bg-red-600/15 text-red-800 hover:bg-red-600/25"
+    : "border-red-400/50 bg-red-500/20 text-red-300 hover:bg-red-500/30";
+}
+
+export interface VoiceRoomControlProps {
+  /** Accessible name, and the tooltip's text unless `tooltip` overrides it. */
+  label: string;
+  /**
+   * Tooltip text, when it needs to say more than the accessible name. The
+   * minimize control is the case: its name has to be the act ("Minimize voice
+   * room") while the tooltip answers the question the act raises ("session
+   * keeps going").
+   */
+  tooltip?: string;
+  onClick: () => void;
+  /** The glyph. Sized by the caller, since the shutter's siblings vary. */
+  children: ReactNode;
+  /**
+   * `destructive` for a control acting ON the call: a mute while engaged, and
+   * end-session always. Defaults to the neutral toning.
+   */
+  tone?: "neutral" | "destructive";
+  /** True while the viewfinder is open behind this control. */
+  overMedia?: boolean;
+  /** The room's look is a light avatar color, so reds need the darker pick. */
+  isLight?: boolean;
+  /**
+   * Corner chrome (the minimize control) wears no border: it sits alone
+   * against the look rather than in a row of peers that need to read as a set.
+   */
+  bare?: boolean;
+  /** Mirrors a toggle's state to assistive tech. */
+  pressed?: boolean;
+  disabled?: boolean;
+  className?: string;
+  "data-testid"?: string;
+}
+
+export function VoiceRoomControl({
+  label,
+  tooltip,
+  onClick,
+  children,
+  tone = "neutral",
+  overMedia = false,
+  isLight = false,
+  bare = false,
+  pressed,
+  disabled,
+  className,
+  "data-testid": testId,
+}: VoiceRoomControlProps) {
+  return (
+    <Tooltip content={tooltip ?? label}>
+      <button
+        type="button"
+        onClick={onClick}
+        aria-label={label}
+        aria-pressed={pressed}
+        disabled={disabled}
+        data-testid={testId}
+        className={cn(
+          "flex size-12 items-center justify-center rounded-full transition",
+          "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--room-fg-muted)]",
+          !bare && "border",
+          tone === "destructive"
+            ? destructiveClass(overMedia, isLight)
+            : cn(
+                bare
+                  ? "text-[var(--room-fg-muted)] hover:bg-[var(--room-wash)] hover:text-[var(--room-fg)]"
+                  : "border-[var(--room-border)] text-[var(--room-fg-muted)] hover:bg-[var(--room-wash)] hover:text-[var(--room-fg)]",
+                overMedia && OVER_MEDIA_NEUTRAL_CLASS,
+              ),
+          className,
+        )}
+      >
+        {children}
+      </button>
+    </Tooltip>
+  );
+}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -1568,6 +1568,39 @@ describe("VoiceRoom: camera", () => {
     expect(viewfinder()?.className).toContain("z-[2]");
   });
 
+  test("the controls take a scrim once they sit over the feed", async () => {
+    stubMediaDevices(async () => fakeStream());
+    seedCameraCapableAssistant();
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+
+    // Closed: the room's own flat color is behind them, and the controls wear
+    // the tone-derived hairline treatment.
+    expect(cameraToggle()!.className).not.toContain("bg-black");
+
+    await act(async () => {
+      fireEvent.click(cameraToggle()!);
+    });
+
+    // Open: the background is now arbitrary camera video, where a border-only
+    // control disappears against dark clothing. Every control on the surface
+    // has to carry its own fill, the end button included.
+    const scrimmed = [
+      "Close camera",
+      "Mute microphone",
+      "Mute assistant",
+      "Flip camera",
+      "Minimize voice room",
+    ];
+    for (const name of scrimmed) {
+      expect(screen.getByRole("button", { name }).className).toContain(
+        "bg-black/45",
+      );
+    }
+    const end = screen.getByRole("button", { name: "End voice session" });
+    expect(end.className).toContain("bg-red-600/55");
+  });
+
   test("a failed flip falls back to the camera the user already had", async () => {
     // A phone that cannot hold two captures at once: the first camera opens,
     // the flip's request fails, and reopening the original succeeds.

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -1599,6 +1599,14 @@ describe("VoiceRoom: camera", () => {
     }
     const end = screen.getByRole("button", { name: "End voice session" });
     expect(end.className).toContain("bg-red-600/55");
+
+    // The shutter is white so it reads on a dark frame, which leaves it
+    // invisible on a bright one unless it carries a dark backing of its own.
+    // It is the only control on the surface with no neutral scrim to fall
+    // back on, so it is asserted separately rather than in the loop above.
+    const shutter = screen.getByTestId("voice-room-shutter");
+    expect(shutter.className).toContain("bg-black/30");
+    expect(shutter.className).toContain("shadow-");
   });
 
   test("a failed flip falls back to the camera the user already had", async () => {

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -196,15 +196,48 @@ const SESSION_CONTROL_NEUTRAL_CLASS =
   "border-[var(--room-border)] text-[var(--room-fg-muted)] hover:bg-[var(--room-wash)] hover:text-[var(--room-fg)]";
 
 /**
+ * The same chrome, once the viewfinder is open behind it.
+ *
+ * Every treatment above is derived from the assistant's avatar tone, which is
+ * the correct reference right up until the camera opens: the feed then covers
+ * the look edge to edge, so the tone is describing a background nobody can
+ * see, and a control whose entire resting appearance is a 15%-white hairline
+ * simply is not there over a dark shirt. Over video each control carries its
+ * own scrim instead, and the glyphs go plain white.
+ *
+ * Fixed colors rather than tone-derived ones, deliberately: what sits behind
+ * these is arbitrary camera video, not a color the room picked, so there is
+ * nothing to derive from. The blur is what keeps the scrim honest over a busy
+ * frame without having to push the fill toward opaque.
+ *
+ * `null` for a closed camera, so callers read as "the neutral treatment, plus
+ * whatever the viewfinder demands".
+ */
+function overVideoControlClass(cameraOpen: boolean): string | null {
+  return cameraOpen
+    ? "border-white/25 bg-black/45 text-white backdrop-blur-sm hover:bg-black/60 hover:text-white focus-visible:outline-white"
+    : null;
+}
+
+/**
  * The red treatment worn by a control that is doing something to the call: the
  * two mutes while engaged, and the end control always.
  *
- * Two variants because the room's background is the assistant's avatar color,
+ * Three variants because the room's background is the assistant's avatar color,
  * which can be a light one (yellow). A single red picked against the dark look
  * washes out over that; `isLight` swaps to the darker red the tone helper's
- * foreground colors are chosen against.
+ * foreground colors are chosen against. Over the viewfinder neither applies:
+ * the fill carries the same weight the neutral scrim does, keeping the red
+ * identity while staying readable on whatever is in frame, and the glyph goes
+ * white because a red-on-red icon is the first thing to disappear.
  */
-function destructiveControlClass(isLight: boolean | undefined): string {
+function destructiveControlClass(
+  isLight: boolean | undefined,
+  cameraOpen: boolean,
+): string {
+  if (cameraOpen) {
+    return "border-red-200/40 bg-red-600/55 text-white backdrop-blur-sm hover:bg-red-600/70 focus-visible:outline-white";
+  }
   return isLight
     ? "border-red-700/50 bg-red-600/15 text-red-800 hover:bg-red-600/25"
     : "border-red-400/50 bg-red-500/20 text-red-300 hover:bg-red-500/30";
@@ -825,7 +858,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
             type="button"
             onClick={minimizeVoiceRoom}
             aria-label="Minimize voice room"
-            className={ROOM_CONTROL_CLASS}
+            className={cn(ROOM_CONTROL_CLASS, overVideoControlClass(cameraOpen))}
           >
             <ChevronDown className="size-5" />
           </button>
@@ -931,7 +964,16 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
           {errorMessage ? (
             <p
               role="status"
-              className="rounded-full bg-[var(--room-wash)] px-3 py-1 text-xs text-[var(--room-fg)]"
+              className={cn(
+                "rounded-full px-3 py-1 text-xs",
+                // Same reason the controls get a scrim: a failed send reported
+                // in tone-derived text over the feed is a message nobody can
+                // read. Camera-closed (a denied permission, the case where the
+                // viewfinder never came up) keeps the room's own treatment.
+                cameraOpen
+                  ? "bg-black/45 text-white backdrop-blur-sm"
+                  : "bg-[var(--room-wash)] text-[var(--room-fg)]",
+              )}
             >
               {errorMessage}
             </p>
@@ -999,16 +1041,22 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
                   data-testid="voice-room-shutter"
                   className={cn(
                     "flex size-16 items-center justify-center rounded-full border-4 transition",
-                    "border-[var(--room-fg)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--room-fg-muted)]",
+                    // White rather than the tone's foreground, and the one
+                    // control here that never needs a camera-open branch: the
+                    // shutter exists only while the viewfinder does, so video
+                    // is the only thing it is ever seen against. A light avatar
+                    // tone (yellow) resolves `--room-fg` to a dark color, which
+                    // put a dark ring over dark clothing.
+                    "border-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white",
                     // The inner disc shrinks while the photo uploads: the
                     // shutter's own press animation doubling as the progress
                     // signal, so nothing else has to appear over the viewfinder.
-                    sending ? "opacity-60" : "hover:bg-[var(--room-wash)]",
+                    sending ? "opacity-60" : "hover:bg-white/20",
                   )}
                 >
                   <span
                     className={cn(
-                      "rounded-full bg-[var(--room-fg)] transition-all",
+                      "rounded-full bg-white transition-all",
                       sending ? "size-6" : "size-11",
                     )}
                   />
@@ -1024,6 +1072,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
                     "absolute right-8",
                     SESSION_CONTROL_CLASS,
                     SESSION_CONTROL_NEUTRAL_CLASS,
+                    overVideoControlClass(cameraOpen),
                   )}
                 >
                   <SwitchCamera className="size-5" />
@@ -1050,8 +1099,11 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
             className={cn(
               SESSION_CONTROL_CLASS,
               muted
-                ? destructiveControlClass(tone?.isLight)
-                : SESSION_CONTROL_NEUTRAL_CLASS,
+                ? destructiveControlClass(tone?.isLight, cameraOpen)
+                : cn(
+                    SESSION_CONTROL_NEUTRAL_CLASS,
+                    overVideoControlClass(cameraOpen),
+                  ),
             )}
           >
             {muted ? <MicOff className="size-5" /> : <Mic className="size-5" />}
@@ -1067,8 +1119,11 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
             className={cn(
               SESSION_CONTROL_CLASS,
               outputMuted
-                ? destructiveControlClass(tone?.isLight)
-                : SESSION_CONTROL_NEUTRAL_CLASS,
+                ? destructiveControlClass(tone?.isLight, cameraOpen)
+                : cn(
+                    SESSION_CONTROL_NEUTRAL_CLASS,
+                    overVideoControlClass(cameraOpen),
+                  ),
             )}
           >
             {outputMuted ? (
@@ -1110,6 +1165,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
               className={cn(
                 SESSION_CONTROL_CLASS,
                 SESSION_CONTROL_NEUTRAL_CLASS,
+                overVideoControlClass(cameraOpen),
               )}
             >
               {cameraOpen ? (
@@ -1128,7 +1184,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
             aria-label="End voice session"
             className={cn(
               SESSION_CONTROL_CLASS,
-              destructiveControlClass(tone?.isLight),
+              destructiveControlClass(tone?.isLight, cameraOpen),
             )}
           >
             <X className="size-5" strokeWidth={2.5} />

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -983,17 +983,22 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
                   data-testid="voice-room-shutter"
                   className={cn(
                     "flex size-16 items-center justify-center rounded-full border-4 transition",
-                    // White rather than the tone's foreground, and the one
-                    // control here that never needs a camera-open branch: the
-                    // shutter exists only while the viewfinder does, so video
-                    // is the only thing it is ever seen against. A light avatar
-                    // tone (yellow) resolves `--room-fg` to a dark color, which
-                    // would put a dark ring over dark clothing.
-                    "border-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white",
+                    // The one control with no camera-open branch: the shutter
+                    // exists only while the viewfinder does, so video is the
+                    // only thing it is ever seen against, and a tone-derived
+                    // color describes a background the feed has covered.
+                    //
+                    // White alone is not enough either, because the frame can
+                    // be any brightness: a white ring on a white wall is as
+                    // invisible as a dark one on a dark shirt. The white sits
+                    // on a dark fill and a dark outer hairline, so one edge or
+                    // the other separates it from the video at both extremes.
+                    "border-white bg-black/30 shadow-[0_0_0_1.5px_rgba(0,0,0,0.4)]",
+                    "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white",
                     // The inner disc shrinks while the photo uploads: the
                     // shutter's own press animation doubling as the progress
                     // signal, so nothing else has to appear over the viewfinder.
-                    sending ? "opacity-60" : "hover:bg-white/20",
+                    sending ? "opacity-60" : "hover:bg-black/45",
                   )}
                 >
                   <span

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -988,7 +988,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
                     // shutter exists only while the viewfinder does, so video
                     // is the only thing it is ever seen against. A light avatar
                     // tone (yellow) resolves `--room-fg` to a dark color, which
-                    // put a dark ring over dark clothing.
+                    // would put a dark ring over dark clothing.
                     "border-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white",
                     // The inner disc shrinks while the photo uploads: the
                     // shutter's own press animation doubling as the progress

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -165,6 +165,11 @@ import { VoiceAmbientTranscript } from "./voice-ambient-transcript";
 import { VoiceAvatar } from "./voice-avatar";
 import { VoiceMeshWaves } from "./voice-mesh-waves";
 import { VoiceRoomAmbientBackground } from "./voice-room-ambient-background";
+// Every circular icon control in the room is one of these: the corner
+// minimize, the two mutes, the camera toggle, flip camera and end session. See
+// that module for the toning, and for why the design library's `Button` is not
+// the element here.
+import { VoiceRoomControl } from "./voice-room-control";
 import {
   VoiceRespondingRings,
   VoiceRoomColorLook,
@@ -180,68 +185,6 @@ const AVATAR_SIZE = 220;
  * top-right exit and the bottom control row sit on the same rhythm.
  */
 const CORNER_GAP = "1.25rem";
-
-/**
- * Shared treatment for the room's top icon controls, toned to the active look
- * via the `--room-*` vars set on the root (white-on-dark for the void look,
- * tone-derived over an avatar color).
- */
-const ROOM_CONTROL_CLASS =
-  "flex size-12 items-center justify-center rounded-full text-[var(--room-fg-muted)] transition hover:bg-[var(--room-wash)] hover:text-[var(--room-fg)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--room-fg-muted)]";
-
-/** The centred row's circular session controls, same toning. */
-const SESSION_CONTROL_CLASS =
-  "flex size-12 items-center justify-center rounded-full border transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--room-fg-muted)]";
-const SESSION_CONTROL_NEUTRAL_CLASS =
-  "border-[var(--room-border)] text-[var(--room-fg-muted)] hover:bg-[var(--room-wash)] hover:text-[var(--room-fg)]";
-
-/**
- * The same chrome, once the viewfinder is open behind it.
- *
- * Every treatment above is derived from the assistant's avatar tone, which is
- * the correct reference right up until the camera opens: the feed then covers
- * the look edge to edge, so the tone is describing a background nobody can
- * see, and a control whose entire resting appearance is a 15%-white hairline
- * simply is not there over a dark shirt. Over video each control carries its
- * own scrim instead, and the glyphs go plain white.
- *
- * Fixed colors rather than tone-derived ones, deliberately: what sits behind
- * these is arbitrary camera video, not a color the room picked, so there is
- * nothing to derive from. The blur is what keeps the scrim honest over a busy
- * frame without having to push the fill toward opaque.
- *
- * `null` for a closed camera, so callers read as "the neutral treatment, plus
- * whatever the viewfinder demands".
- */
-function overVideoControlClass(cameraOpen: boolean): string | null {
-  return cameraOpen
-    ? "border-white/25 bg-black/45 text-white backdrop-blur-sm hover:bg-black/60 hover:text-white focus-visible:outline-white"
-    : null;
-}
-
-/**
- * The red treatment worn by a control that is doing something to the call: the
- * two mutes while engaged, and the end control always.
- *
- * Three variants because the room's background is the assistant's avatar color,
- * which can be a light one (yellow). A single red picked against the dark look
- * washes out over that; `isLight` swaps to the darker red the tone helper's
- * foreground colors are chosen against. Over the viewfinder neither applies:
- * the fill carries the same weight the neutral scrim does, keeping the red
- * identity while staying readable on whatever is in frame, and the glyph goes
- * white because a red-on-red icon is the first thing to disappear.
- */
-function destructiveControlClass(
-  isLight: boolean | undefined,
-  cameraOpen: boolean,
-): string {
-  if (cameraOpen) {
-    return "border-red-200/40 bg-red-600/55 text-white backdrop-blur-sm hover:bg-red-600/70 focus-visible:outline-white";
-  }
-  return isLight
-    ? "border-red-700/50 bg-red-600/15 text-red-800 hover:bg-red-600/25"
-    : "border-red-400/50 bg-red-500/20 text-red-300 hover:bg-red-500/30";
-}
 
 /** Placement variant. See the module docstring. */
 export type VoiceRoomVariant = "fullscreen" | "content" | "sheet";
@@ -853,16 +796,15 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
         }}
         className="absolute z-10 flex items-center gap-1"
       >
-        <Tooltip content="Minimize (session keeps going)">
-          <button
-            type="button"
-            onClick={minimizeVoiceRoom}
-            aria-label="Minimize voice room"
-            className={cn(ROOM_CONTROL_CLASS, overVideoControlClass(cameraOpen))}
-          >
-            <ChevronDown className="size-5" />
-          </button>
-        </Tooltip>
+        <VoiceRoomControl
+          label="Minimize voice room"
+          tooltip="Minimize (session keeps going)"
+          onClick={minimizeVoiceRoom}
+          bare
+          overMedia={cameraOpen}
+        >
+          <ChevronDown className="size-5" />
+        </VoiceRoomControl>
       </div>
 
       {/* Void look: the avatar springs to center once on entry (the wrapper
@@ -1063,21 +1005,14 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
                 </button>
               </Tooltip>
 
-              <Tooltip content="Flip camera">
-                <button
-                  type="button"
-                  onClick={() => void camera.flipCamera()}
-                  aria-label="Flip camera"
-                  className={cn(
-                    "absolute right-8",
-                    SESSION_CONTROL_CLASS,
-                    SESSION_CONTROL_NEUTRAL_CLASS,
-                    overVideoControlClass(cameraOpen),
-                  )}
-                >
-                  <SwitchCamera className="size-5" />
-                </button>
-              </Tooltip>
+              <VoiceRoomControl
+                label="Flip camera"
+                onClick={() => void camera.flipCamera()}
+                overMedia={cameraOpen}
+                className="absolute right-8"
+              >
+                <SwitchCamera className="size-5" />
+              </VoiceRoomControl>
             </div>
           ) : null}
         </div>
@@ -1090,49 +1025,31 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
         // home-indicator inset is real here in a way the top inset was not.
         style={{ bottom: `max(${CORNER_GAP}, ${SAFE_AREA_BOTTOM})` }}
       >
-        <Tooltip content={muted ? "Unmute microphone" : "Mute microphone"}>
-          <button
-            type="button"
-            onClick={() => setLiveVoiceMuted(!muted)}
-            aria-label={muted ? "Unmute microphone" : "Mute microphone"}
-            aria-pressed={muted}
-            className={cn(
-              SESSION_CONTROL_CLASS,
-              muted
-                ? destructiveControlClass(tone?.isLight, cameraOpen)
-                : cn(
-                    SESSION_CONTROL_NEUTRAL_CLASS,
-                    overVideoControlClass(cameraOpen),
-                  ),
-            )}
-          >
-            {muted ? <MicOff className="size-5" /> : <Mic className="size-5" />}
-          </button>
-        </Tooltip>
+        <VoiceRoomControl
+          label={muted ? "Unmute microphone" : "Mute microphone"}
+          onClick={() => setLiveVoiceMuted(!muted)}
+          pressed={muted}
+          tone={muted ? "destructive" : "neutral"}
+          isLight={tone?.isLight}
+          overMedia={cameraOpen}
+        >
+          {muted ? <MicOff className="size-5" /> : <Mic className="size-5" />}
+        </VoiceRoomControl>
 
-        <Tooltip content={outputMuted ? "Unmute assistant" : "Mute assistant"}>
-          <button
-            type="button"
-            onClick={() => setLiveVoiceOutputMuted(!outputMuted)}
-            aria-label={outputMuted ? "Unmute assistant" : "Mute assistant"}
-            aria-pressed={outputMuted}
-            className={cn(
-              SESSION_CONTROL_CLASS,
-              outputMuted
-                ? destructiveControlClass(tone?.isLight, cameraOpen)
-                : cn(
-                    SESSION_CONTROL_NEUTRAL_CLASS,
-                    overVideoControlClass(cameraOpen),
-                  ),
-            )}
-          >
-            {outputMuted ? (
-              <VolumeX className="size-5" />
-            ) : (
-              <Volume2 className="size-5" />
-            )}
-          </button>
-        </Tooltip>
+        <VoiceRoomControl
+          label={outputMuted ? "Unmute assistant" : "Mute assistant"}
+          onClick={() => setLiveVoiceOutputMuted(!outputMuted)}
+          pressed={outputMuted}
+          tone={outputMuted ? "destructive" : "neutral"}
+          isLight={tone?.isLight}
+          overMedia={cameraOpen}
+        >
+          {outputMuted ? (
+            <VolumeX className="size-5" />
+          ) : (
+            <Volume2 className="size-5" />
+          )}
+        </VoiceRoomControl>
 
         {/* Show the assistant what you're looking at.
 
@@ -1155,41 +1072,31 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
             to be undismissable to stay compliant, which for a control this
             self-evident would be worse than nothing. */}
         {cameraSupported ? (
-          <Tooltip content={cameraOpen ? "Close camera" : "Show the camera"}>
-            <button
-              type="button"
-              onClick={() => (cameraOpen ? close() : void open())}
-              aria-label={cameraOpen ? "Close camera" : "Show the camera"}
-              aria-pressed={cameraOpen}
-              data-testid="voice-room-camera-toggle"
-              className={cn(
-                SESSION_CONTROL_CLASS,
-                SESSION_CONTROL_NEUTRAL_CLASS,
-                overVideoControlClass(cameraOpen),
-              )}
-            >
-              {cameraOpen ? (
-                <CameraOff className="size-5" />
-              ) : (
-                <Camera className="size-5" />
-              )}
-            </button>
-          </Tooltip>
+          <VoiceRoomControl
+            label={cameraOpen ? "Close camera" : "Show the camera"}
+            onClick={() => (cameraOpen ? close() : void open())}
+            pressed={cameraOpen}
+            overMedia={cameraOpen}
+            data-testid="voice-room-camera-toggle"
+          >
+            {cameraOpen ? (
+              <CameraOff className="size-5" />
+            ) : (
+              <Camera className="size-5" />
+            )}
+          </VoiceRoomControl>
         ) : null}
 
-        <Tooltip content="End session">
-          <button
-            type="button"
-            onClick={endLiveVoiceSession}
-            aria-label="End voice session"
-            className={cn(
-              SESSION_CONTROL_CLASS,
-              destructiveControlClass(tone?.isLight, cameraOpen),
-            )}
-          >
-            <X className="size-5" strokeWidth={2.5} />
-          </button>
-        </Tooltip>
+        <VoiceRoomControl
+          label="End voice session"
+          tooltip="End session"
+          onClick={endLiveVoiceSession}
+          tone="destructive"
+          isLight={tone?.isLight}
+          overMedia={cameraOpen}
+        >
+          <X className="size-5" strokeWidth={2.5} />
+        </VoiceRoomControl>
       </div>
 
       {/* Screen readers get session-state changes here; the avatar is the


### PR DESCRIPTION
## Problem

Reported by Marina: the controls shown during a live voice session with the camera on are very hard to spot against dark clothing.

The room's session controls are toned from the assistant's avatar color, which is the correct reference right up until the camera opens. The viewfinder then covers the look edge to edge, so the tone describes a background nobody can see, and a control whose entire resting appearance is a 1px `rgba(255,255,255,0.15)` hairline is not there at all over a dark shirt.

## Change

While the viewfinder is open, the room's chrome carries its own scrim instead of the tone-derived treatment:

- **Neutral controls** (mic, speaker, camera toggle, flip camera, minimize) get `bg-black/45` + `backdrop-blur-sm` + a plain white glyph, via a new `overVideoControlClass(cameraOpen)`. With the camera closed nothing changes.
- **The end button** gets a camera-open branch in `destructiveControlClass` (`bg-red-600/55`, white glyph). At `bg-red-500/20` with a `text-red-300` icon it was the second-least visible thing in the row, and a red glyph on a red wash is the first thing to go.
- **The shutter and its disc** go hard white rather than `var(--room-fg)`. This is the one control that needs no camera-open branch at all: it renders only while the viewfinder does, so video is the only background it is ever seen against, and a light avatar tone (yellow) resolved `--room-fg` to a dark color, putting a dark ring over dark clothing.
- **The camera error pill** takes the same scrim while the feed is up. A failed send reported in tone-derived text over video is a message nobody can read. The camera-closed case (a denied permission, where the viewfinder never came up) keeps the room's own treatment.

Fixed colors rather than tone-derived ones, deliberately: what sits behind these is arbitrary camera video, not a color the room picked, so there is nothing to derive from. The blur is what keeps the scrim honest over a busy frame without pushing the fill toward opaque.

## Verification

Rendered both treatments over the exact frame from the report. Left is current, right is the fix (the faint row baked into the photo is the original screenshot; compare the two overlaid rows):

Rendered side by side at the same scale, the border-only controls are legible only where they cross the light strap; every one that lands on the dark top disappears. With the scrim all five neutral controls and the end button read cleanly across the whole frame, light strap and dark top alike.

`voice-room.test.tsx`: 98 pass, including a new case asserting every control on the surface takes a fill once the viewfinder opens. `tsc --noEmit` and lint clean.

## Second commit: one control component

The first commit fixed this by editing six hand-rolled `<button>` elements, each re-deriving its treatment through `cn()` over three class constants and two helpers. That is precisely how a scrim reaches four controls and quietly misses the fifth, so the second commit collapses them into a single `VoiceRoomControl` (`voice-room-control.tsx`) owning the whole matrix: neutral vs destructive, bordered vs bare, viewfinder open or not. Call sites went from a `cn()` triplet each to props, and the accessible name and tooltip can no longer drift apart.

On reuse, for the record on why this is not the design library's `Button`: these are 48px circles, and `Button`'s sizes stop at `h-8` with `rounded-md` baked into every one of them, so adopting it would mean overriding size, radius, border and every color at each call site while still inheriting `active:scale-[0.97]` and a theme-token focus ring the room cannot use (the room paints itself an arbitrary avatar color, which is why it has the `--room-*` contract at all). The library also has no treatment for chrome over live video. The sibling voice surfaces — the composer bar and the header pill — *do* use `Button` plus `VOICE_SURFACE_CONTROL_CLASS`, because at their size the library's shape is the right one; `VoiceRoomControl` reads the same `--room-*` vars that module publishes, so all three surfaces stay one visual system.

The refactor is behavior-preserving: the tests assert the exact class strings on all six controls and pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

