### PR TITLE
fix(web): stop the Channels rail from repeating the section heading

### DIFF
--- a/clients/web/src/domains/channels/channels-page.tsx
+++ b/clients/web/src/domains/channels/channels-page.tsx
@@ -19,10 +19,10 @@ export interface ChannelsPageProps {
  * the guardian manages how and where the assistant can be reached. Rendered
  * as its own tab in the About Assistant nav (`/assistant/channels`): the
  * adapter list beside the selected adapter's detail panel, with no page
- * heading or subtitle (the nav's tab already reads "Channels", matching the
- * sibling Contacts tab). The Contacts page's assistant detail
- * (`AssistantChannelsDetail`) shows only a connect/disconnect summary of the
- * same channels; management stays here.
+ * heading or subtitle of its own (`IntelligenceLayout` supplies the section
+ * heading, matching the sibling Contacts tab). The Contacts page's assistant
+ * detail (`AssistantChannelsDetail`) shows only a connect/disconnect summary
+ * of the same channels; management stays here.
  */
 export function ChannelsPage({
   assistantId,

--- a/clients/web/src/domains/channels/components/channel-adapter-list.test.tsx
+++ b/clients/web/src/domains/channels/components/channel-adapter-list.test.tsx
@@ -132,6 +132,33 @@ describe("ChannelAdapterList", () => {
     expect(document.activeElement).toBe(phone);
   });
 
+  /**
+   * Naming the section belongs to whatever mounts the rail (the chrome's
+   * `<h1>` on desktop, the drawer title on mobile), so the card must not
+   * say "Channels" itself. Counting headings by that name is what catches
+   * a second copy; `IntelligenceLayout`'s test holds up the first.
+   */
+  test("leaves naming the section to the surface that mounts it", () => {
+    render(
+      <ChannelAdapterList
+        channels={CHANNELS}
+        pluginChannels={PLUGIN_CHANNELS}
+        selectedKey="slack"
+        onSelect={() => {}}
+      />,
+    );
+
+    // Rows rendered, so the count below is not vacuously zero.
+    expect(document.querySelectorAll('[data-slot="panel-item"]').length).toBe(
+      4,
+    );
+
+    const named = Array.from(
+      document.querySelectorAll("h1, h2, h3, h4, h5, h6"),
+    ).filter((el) => el.textContent?.trim() === "Channels");
+    expect(named.length).toBe(0);
+  });
+
   test("lists channels declared by plugins under their own heading", () => {
     render(
       <ChannelAdapterList

--- a/clients/web/src/domains/channels/components/channel-adapter-list.tsx
+++ b/clients/web/src/domains/channels/components/channel-adapter-list.tsx
@@ -28,6 +28,11 @@ export interface ChannelAdapterListProps {
  * panel beside it. Mirrors the Contacts tab's `ContactsList` — same `Card`
  * shell, same `PanelItem` selection treatment — so the two About Assistant
  * tabs read as siblings.
+ *
+ * The card carries no "Channels" heading of its own: every surface that
+ * mounts it already names it (`IntelligenceLayout`'s section `<h1>` on
+ * desktop, the `MobileSidebarDrawer` title on mobile), so one here would
+ * put the word on screen twice.
  */
 export function ChannelAdapterList({
   channels,
@@ -38,13 +43,6 @@ export function ChannelAdapterList({
   return (
     <Card.Root className="flex h-full flex-col overflow-hidden">
       <Card.Body className="flex min-h-0 min-w-0 flex-1 flex-col gap-4">
-        <h2
-          className="text-title-medium"
-          style={{ color: "var(--content-default)" }}
-        >
-          Channels
-        </h2>
-
         <div className="flex flex-col gap-1">
           {channels.map((channel) => (
             <AdapterRow
@@ -62,12 +60,12 @@ export function ChannelAdapterList({
             an assistant with no channel plugins looks exactly as before. */}
         {pluginChannels.length > 0 ? (
           <>
-            <h3
+            <h2
               className="text-label-small"
               style={{ color: "var(--content-secondary)" }}
             >
               From plugins
-            </h3>
+            </h2>
 
             <div className="flex flex-col gap-1">
               {pluginChannels.map((channel) => (

--- a/clients/web/src/domains/intelligence/intelligence-layout.test.tsx
+++ b/clients/web/src/domains/intelligence/intelligence-layout.test.tsx
@@ -122,6 +122,20 @@ describe("IntelligenceLayout — section pages", () => {
     renderLayoutAt("/assistant/contacts");
     expect(setTopBarCenterMock).toHaveBeenLastCalledWith(null);
   });
+
+  /**
+   * The chrome is the only thing that says "Channels". The other half of
+   * that split lives in
+   * `domains/channels/components/channel-adapter-list.test.tsx`, which
+   * pins the page's own rail at zero headings by that name.
+   */
+  test("the channels page renders as a section with the back chevron", () => {
+    const { container } = renderLayoutAt("/assistant/channels");
+    expect(container.querySelector("h1")?.textContent).toBe("Channels");
+    expect(container.querySelector("a")?.getAttribute("href")).toBe(
+      "/assistant/identity",
+    );
+  });
 });
 
 describe("IntelligenceLayout — bare pages (overview, personality)", () => {


### PR DESCRIPTION
## TL;DR

The Channels page said "Channels" twice: once in the About Assistant section chrome, once at the top of the adapter rail card. This drops the card's copy and leaves naming the section to the chrome, matching the sibling Contacts rail.

Reported by Vargas in [#eng-fyi](https://vellumai.slack.com/archives/C08GM4RCPTR/p1786112655755669).

Fixes LUM-3133

## What changes for the user

| Surface | Before | After |
| --- | --- | --- |
| Channels page, desktop | Section heading "Channels", then a card headed "Channels" above the adapter list | Section heading "Channels", adapter list starts at the top of the card |
| Channels page, mobile | Top bar reads "Channels", card underneath reads "Channels" | Top bar reads "Channels", card underneath is just the list |
| Channels adapter drawer, mobile | Drawer titled "Channels" over a card headed "Channels" | Drawer titled "Channels" over just the list |
| Every other About Assistant page | No duplicate | Unchanged |

Nothing moves, nothing is renamed, and no row, badge, or detail panel changes.

## Why this is the right half to remove

`IntelligenceLayout` gives every About Assistant section its heading, so any section page that also names itself will duplicate. The rail card predates that chrome, which is how the two ended up stacked. Removing the chrome's heading instead would make Channels the only section without one.

The sibling Contacts rail settles which convention to follow: its card heads the list "Entries", not "Contacts", precisely so it does not repeat the section name.

## Why it is safe

`ChannelAdapterList` renders only inside the Channels page (the desktop aside and the mobile drawer), and both of those surfaces already print "Channels" themselves, so nothing loses its label. The change is one deleted heading plus a heading-level bump.

Accessibility: with the `<h2>` gone, the plugin sub-heading "From plugins" moves from `<h3>` to `<h2>` so the outline does not jump `<h1>` to `<h3>`. The detail panel's `<h3>` still follows an `<h2>` in document order, because a plugin channel can only be selected when the "From plugins" heading is on screen.

## Tests

The invariant is "the section names itself exactly once", asserted from both sides, since a single test could not span both without a cross-domain import:

- `channel-adapter-list.test.tsx` counts headings reading "Channels" in the rail and expects zero, after asserting the rows rendered so the count is not vacuously zero.
- `intelligence-layout.test.tsx` asserts the chrome renders "Channels" as the `<h1>` on `/assistant/channels`. It reads the first `<h1>`, so the rail test is what forbids a second copy of the word.

Re-adding a heading on either side fails one of them.

## Verification

Typecheck and lint pass. Test suites are left to CI. The rail was checked visually in Storybook (`Channels/AssistantChannelsList`) at desktop and mobile widths.

## Audit for other duplicates

The ask covered any Assistant Identity page with a duplicate heading, so all of them were swept, not just Channels: for each entry in `ABOUT_ASSISTANT_SECTIONS` (Schedules, My Superpowers, Memory, Library, Workspace, Contacts, Channels), the page's component tree was searched for a heading or card title matching its section label. Channels was the only hit. Contacts is the near miss, and it is already correct ("Entries").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40446" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
