### PR TITLE
fix(web): one Chats tile and an uncropped Preferences on the collapsed rail (LUM-3130)

### DIFF
--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -934,6 +934,7 @@ export function ChatLayout({
           assistantVersion={assistantVersion}
           activeConversationId={activeConversationId}
           triggerVariant={args.variant === "overlay" ? "pill" : "item"}
+          collapsed={args.collapsed}
         />
       }
       // The overlay subtree mounts mid edge-swipe while still off-screen;

--- a/clients/web/src/domains/chat/components/assistant-side-menu.stories.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.stories.tsx
@@ -19,6 +19,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { AssistantSideMenu } from "@/domains/chat/components/assistant-side-menu";
 import { PreferencesMenu } from "@/domains/chat/components/preferences-menu";
 import { useSidebarLayoutStore } from "@/domains/chat/sidebar-layout-store";
+import { useAuthStore } from "@/stores/auth-store";
 import { usePinnedAppsStore } from "@/stores/pinned-apps-store";
 import {
   saveViewMode,
@@ -145,6 +146,11 @@ function seedViewMode(assistantId: string, mode: SidebarViewMode): void {
     pinnedApps: PINNED_APPS,
     pinnedAppIds: new Set(PINNED_APPS.map((app) => app.appId)),
   });
+  /* `PreferencesMenu` renders nothing for a signed-out user, and a story has
+     no session, so without this the footer these stories claim to show was
+     silently absent from every one of them - which is how a clipped collapsed
+     Preferences pill shipped (LUM-3130). */
+  useAuthStore.setState({ sessionStatus: "authenticated" });
 }
 
 const SHARED_ARGS = {
@@ -245,12 +251,30 @@ export const GroupedView: Story = {
    explaining why it does nothing stays reachable. It's muted rather than
    natively disabled for exactly that reason. */
 export const CollapsedRail: Story = {
-  name: "Collapsed rail",
+  name: "Collapsed rail · grouped view",
   beforeEach: () => seedViewMode("asst-collapsed", "grouped"),
   args: {
     ...SHARED_ARGS,
     assistantId: "asst-collapsed",
     collapsed: true,
+    footerAction: <PreferencesMenu assistantId="asst-story" collapsed />,
+  },
+};
+
+/* The same rail in the default view, which is the one users actually land on
+   and the one where the rail last drifted from the expanded sidebar: Chats
+   drew twice, once as a section and once as an extra icon left over from when
+   `all` view had no Chats section (LUM-3130). Grouped view hid it, so the
+   collapsed story above never showed it. Every view the rail supports gets a
+   collapsed surface here for that reason. */
+export const CollapsedRailAllView: Story = {
+  name: "Collapsed rail · all view",
+  beforeEach: () => seedViewMode("asst-collapsed-all", "all"),
+  args: {
+    ...SHARED_ARGS,
+    assistantId: "asst-collapsed-all",
+    collapsed: true,
+    footerAction: <PreferencesMenu assistantId="asst-story" collapsed />,
   },
 };
 

--- a/clients/web/src/domains/chat/components/assistant-side-menu.stories.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.stories.tsx
@@ -146,10 +146,9 @@ function seedViewMode(assistantId: string, mode: SidebarViewMode): void {
     pinnedApps: PINNED_APPS,
     pinnedAppIds: new Set(PINNED_APPS.map((app) => app.appId)),
   });
-  /* `PreferencesMenu` renders nothing for a signed-out user, and a story has
-     no session, so without this the footer these stories claim to show was
-     silently absent from every one of them - which is how a clipped collapsed
-     Preferences pill shipped (LUM-3130). */
+  /* `PreferencesMenu` renders nothing for a signed-out user and a story has no
+     session of its own, so the sidebar's footer entry only appears in these
+     stories once one is seeded. */
   useAuthStore.setState({ sessionStatus: "authenticated" });
 }
 
@@ -261,12 +260,10 @@ export const CollapsedRail: Story = {
   },
 };
 
-/* The same rail in the default view, which is the one users actually land on
-   and the one where the rail last drifted from the expanded sidebar: Chats
-   drew twice, once as a section and once as an extra icon left over from when
-   `all` view had no Chats section (LUM-3130). Grouped view hid it, so the
-   collapsed story above never showed it. Every view the rail supports gets a
-   collapsed surface here for that reason. */
+/* The same rail in the default view, which is the one most users see. The two
+   views put a different section set in the column, and the rail is where a
+   section list going wrong is hardest to spot, so each view gets its own
+   collapsed surface rather than sharing one. */
 export const CollapsedRailAllView: Story = {
   name: "Collapsed rail · all view",
   beforeEach: () => seedViewMode("asst-collapsed-all", "all"),

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -499,8 +499,6 @@ export function AssistantSideMenu({
             <CollapsedRailSections
               sections={sidebar.sections}
               assistantId={assistantId ?? null}
-              viewMode={sidebar.viewMode}
-              flatList={sidebar.flatList}
               processingConversationIds={processingConversationIds}
               attentionConversationIds={attentionConversationIds}
             />

--- a/clients/web/src/domains/chat/components/collapsed-rail-sections.test.tsx
+++ b/clients/web/src/domains/chat/components/collapsed-rail-sections.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * Tests for `CollapsedRailSections`.
+ *
+ * The rail's whole contract is that it is the expanded sidebar's section list
+ * with the labels taken off: same sections, same order, one tile each. It is
+ * not a second list that happens to agree, which is what it drifted into -
+ * an extra hardcoded Chats tile survived `all` view gaining a real Chats
+ * section, and the rail drew the same conversations twice (LUM-3130).
+ *
+ * So these assert the mapping itself - tile count against section count, and
+ * labels against section labels, in order - rather than that some particular
+ * section is present. A test for "Chats renders" passes with two of them.
+ *
+ * `CollapsedGroupIcon` is stubbed to surface its label, since what it draws
+ * (the circle, the dot, the flyout) is covered in its own file. The section
+ * query is stubbed too: which rows a section fetches is
+ * `use-section-conversations`'s contract, and mounting it here would make
+ * this file depend on the daemon capability gates.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import { createElement, type ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { Conversation } from "@/types/conversation-types";
+import type { SidebarSection } from "@/domains/chat/use-sidebar-state";
+
+/** Every section resolves to the same single row; identity is not what's under test. */
+const SECTION_ROWS: Conversation[] = [
+  { conversationId: "c1", title: "A conversation" } as Conversation,
+];
+
+mock.module("@/domains/chat/use-section-conversations", () => ({
+  useSectionConversations: () => SECTION_ROWS,
+}));
+
+mock.module("@/domains/chat/components/conversation-rail-flyout", () => ({
+  CollapsedGroupFlyout: () => null,
+}));
+
+mock.module("@/domains/chat/components/collapsed-group-icon", () => ({
+  getGroupIndicatorState: () => null,
+  GroupIndicatorDot: () => null,
+  CollapsedGroupIcon: ({ label }: { label: ReactNode }) =>
+    createElement("button", { "data-testid": "rail-tile" }, String(label)),
+}));
+
+const { CollapsedRailSections } = await import(
+  "@/domains/chat/components/collapsed-rail-sections"
+);
+
+function railLabels(sections: SidebarSection[]): string[] {
+  const html = renderToStaticMarkup(
+    <CollapsedRailSections sections={sections} assistantId="asst-1" />,
+  );
+  return [...html.matchAll(/data-testid="rail-tile">([^<]*)</g)].map(
+    (m) => m[1] ?? "",
+  );
+}
+
+const PINNED: SidebarSection = {
+  type: "pinned",
+  key: "pinned",
+  label: "Pinned",
+  all: SECTION_ROWS,
+};
+const CHATS: SidebarSection = {
+  type: "recents",
+  key: "recents",
+  label: "Chats",
+  all: SECTION_ROWS,
+  holdsChannels: true,
+};
+const SLACK: SidebarSection = {
+  type: "channel",
+  key: "channel:slack",
+  label: "Slack",
+  all: SECTION_ROWS,
+  channelId: "slack",
+};
+
+describe("CollapsedRailSections", () => {
+  /* `all` view: Chats holds the channel conversations itself, so the rail is
+     Pinned + Chats and nothing else. The regression drew a second Chats tile
+     here from a list published alongside `sections`, so this counts the tiles
+     rather than asking whether Chats is present - two of them satisfy that. */
+  test("draws one tile per section in all view, Chats included exactly once", () => {
+    const labels = railLabels([PINNED, CHATS]);
+
+    expect(labels).toEqual(["Pinned", "Chats"]);
+    expect(labels.filter((l) => l === "Chats")).toHaveLength(1);
+  });
+
+  /* Grouped view is the arrangement the bug hid in: with channel sections
+     present the extra tile was suppressed, so the rail looked correct here
+     while `all` view - the default - showed the duplicate. Both views are
+     asserted so a fix that only holds in one of them fails. */
+  test("draws one tile per section in grouped view", () => {
+    const labels = railLabels([
+      PINNED,
+      { ...CHATS, holdsChannels: false },
+      SLACK,
+    ]);
+
+    expect(labels).toEqual(["Pinned", "Chats", "Slack"]);
+  });
+
+  /* Order is the user's, stored per assistant, and the rail has no ordering
+     of its own to disagree with it. */
+  test("keeps the order it is handed", () => {
+    expect(railLabels([SLACK, CHATS, PINNED])).toEqual([
+      "Slack",
+      "Chats",
+      "Pinned",
+    ]);
+  });
+
+  /* No sections means no tiles - not a fallback tile standing in for a list
+     that isn't there, which is the shape the duplicate came in. */
+  test("draws nothing when there are no sections", () => {
+    expect(railLabels([])).toEqual([]);
+  });
+});

--- a/clients/web/src/domains/chat/components/collapsed-rail-sections.test.tsx
+++ b/clients/web/src/domains/chat/components/collapsed-rail-sections.test.tsx
@@ -3,9 +3,7 @@
  *
  * The rail's whole contract is that it is the expanded sidebar's section list
  * with the labels taken off: same sections, same order, one tile each. It is
- * not a second list that happens to agree, which is what it drifted into -
- * an extra hardcoded Chats tile survived `all` view gaining a real Chats
- * section, and the rail drew the same conversations twice (LUM-3130).
+ * not a second list that happens to agree with that one.
  *
  * So these assert the mapping itself - tile count against section count, and
  * labels against section labels, in order - rather than that some particular
@@ -81,9 +79,8 @@ const SLACK: SidebarSection = {
 
 describe("CollapsedRailSections", () => {
   /* `all` view: Chats holds the channel conversations itself, so the rail is
-     Pinned + Chats and nothing else. The regression drew a second Chats tile
-     here from a list published alongside `sections`, so this counts the tiles
-     rather than asking whether Chats is present - two of them satisfy that. */
+     Pinned + Chats and nothing else. Counts the tiles rather than asking
+     whether Chats is present, because two Chats tiles satisfy that. */
   test("draws one tile per section in all view, Chats included exactly once", () => {
     const labels = railLabels([PINNED, CHATS]);
 
@@ -91,10 +88,9 @@ describe("CollapsedRailSections", () => {
     expect(labels.filter((l) => l === "Chats")).toHaveLength(1);
   });
 
-  /* Grouped view is the arrangement the bug hid in: with channel sections
-     present the extra tile was suppressed, so the rail looked correct here
-     while `all` view - the default - showed the duplicate. Both views are
-     asserted so a fix that only holds in one of them fails. */
+  /* The two views hand the rail a different section set, and the mapping has
+     to hold for both: asserting only one leaves the other free to add or drop
+     a tile. */
   test("draws one tile per section in grouped view", () => {
     const labels = railLabels([
       PINNED,
@@ -115,8 +111,8 @@ describe("CollapsedRailSections", () => {
     ]);
   });
 
-  /* No sections means no tiles - not a fallback tile standing in for a list
-     that isn't there, which is the shape the duplicate came in. */
+  /* No sections means no tiles, rather than a fallback tile standing in for a
+     list the rail is not given. */
   test("draws nothing when there are no sections", () => {
     expect(railLabels([])).toEqual([]);
   });

--- a/clients/web/src/domains/chat/components/collapsed-rail-sections.tsx
+++ b/clients/web/src/domains/chat/components/collapsed-rail-sections.tsx
@@ -67,14 +67,10 @@ function CollapsedRailSectionIcon({
  * order and labels come straight from `sections`, so the rail can't drift
  * from the expanded list the way two hand-maintained orders would.
  *
- * That includes the flat list. It used to get an extra icon of its own here,
- * from when `useSidebarState` pushed the Chats section in `grouped` view only
- * and `all` view rendered the same conversations through a separate headerless
- * path. Chats is now a section in both views, so the extra icon drew a second
- * Chats tile - same label, same glyph, same conversations - beside the real
- * one in the rail's default view (LUM-3130). Anything the rail needs to show
- * has to be a section, which is the invariant that keeps the two lists from
- * drifting apart again.
+ * `sections` is the only source a tile may come from, in either view mode:
+ * every conversation the rail can reach belongs to some section, so a tile
+ * drawn from anywhere else stands beside the section that already holds those
+ * rows and draws them a second time.
  */
 export function CollapsedRailSections({
   sections,

--- a/clients/web/src/domains/chat/components/collapsed-rail-sections.tsx
+++ b/clients/web/src/domains/chat/components/collapsed-rail-sections.tsx
@@ -5,22 +5,12 @@ import {
 import { CollapsedGroupFlyout } from "@/domains/chat/components/conversation-rail-flyout";
 import type { SidebarSection } from "@/domains/chat/use-sidebar-state";
 import { useSectionConversations } from "@/domains/chat/use-section-conversations";
-import {
-  RECENTS_SECTION_ICON,
-  RECENTS_SECTION_LABEL,
-  sectionIcon,
-} from "@/domains/chat/utils/sidebar-section-icon";
-import type { SidebarViewMode } from "@/domains/chat/utils/sidebar-view-mode";
-import type { Conversation } from "@/types/conversation-types";
+import { sectionIcon } from "@/domains/chat/utils/sidebar-section-icon";
 
 export interface CollapsedRailSectionsProps {
   sections: SidebarSection[];
   /** Owns the section queries; `null` keeps them on the derived rows. */
   assistantId: string | null;
-  /** Sidebar view mode; the flat list gets its own rail icon in "all". */
-  viewMode: SidebarViewMode;
-  /** Every conversation neither pinned nor in a custom group. */
-  flatList: Conversation[];
   processingConversationIds?: Set<string>;
   attentionConversationIds?: Set<string>;
 }
@@ -76,12 +66,19 @@ function CollapsedRailSectionIcon({
  * as the expanded sidebar, as flyout icons. Nothing here is type-aware -
  * order and labels come straight from `sections`, so the rail can't drift
  * from the expanded list the way two hand-maintained orders would.
+ *
+ * That includes the flat list. It used to get an extra icon of its own here,
+ * from when `useSidebarState` pushed the Chats section in `grouped` view only
+ * and `all` view rendered the same conversations through a separate headerless
+ * path. Chats is now a section in both views, so the extra icon drew a second
+ * Chats tile - same label, same glyph, same conversations - beside the real
+ * one in the rail's default view (LUM-3130). Anything the rail needs to show
+ * has to be a section, which is the invariant that keeps the two lists from
+ * drifting apart again.
  */
 export function CollapsedRailSections({
   sections,
   assistantId,
-  viewMode,
-  flatList,
   processingConversationIds,
   attentionConversationIds,
 }: CollapsedRailSectionsProps) {
@@ -96,30 +93,6 @@ export function CollapsedRailSections({
           attentionConversationIds={attentionConversationIds}
         />
       ))}
-      {/* The flat list has no section of its own to draw, so the rail
-          gives it one icon - otherwise the All view's conversations
-          would be unreachable while collapsed. */}
-      {viewMode === "all" ? (
-        <CollapsedGroupIcon
-          icon={RECENTS_SECTION_ICON}
-          label={RECENTS_SECTION_LABEL}
-          disabled={flatList.length === 0}
-          indicatorState={getGroupIndicatorState(
-            flatList,
-            processingConversationIds,
-            attentionConversationIds,
-          )}
-        >
-          {(close, scrollParent) => (
-            <CollapsedGroupFlyout
-              title={RECENTS_SECTION_LABEL}
-              conversations={flatList}
-              onClosePopover={close}
-              scrollParent={scrollParent}
-            />
-          )}
-        </CollapsedGroupIcon>
-      ) : null}
     </div>
   );
 }

--- a/clients/web/src/domains/chat/components/preferences-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/preferences-menu.test.tsx
@@ -11,7 +11,15 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+
+import { SideMenu } from "@vellumai/design-library";
 
 import type { AuthUser } from "@/stores/auth-store";
 
@@ -197,6 +205,70 @@ describe("PreferencesMenu", () => {
     isMobileRef.value = true;
     const html = renderToStaticMarkup(createElement(PreferencesMenu));
     expect(html).toContain("Preferences");
+  });
+
+  /* The collapsed rail is 48px wide and the trigger is a pill sized by its
+     content, so an expanded trigger rendered there is clipped mid-word - what
+     shipped as a squashed "Pr…" at the foot of the rail (LUM-3130). The tile
+     is not a pill with `display:none` on its label: it is a fixed 30px square
+     that centres its glyph, the same affordance the pinned apps and section
+     tiles above it reduce to.
+
+     Mounted inside a collapsed `SideMenu` because `shape="tile"` reads the
+     rail's state from that context; outside one it is an ordinary row, so a
+     bare render would assert nothing about the rail. */
+  function collapsedRailMarkup(): string {
+    return renderToStaticMarkup(
+      <SideMenu ariaLabel="Assistant navigation" variant="rail" collapsed>
+        <SideMenu.Footer>
+          <PreferencesMenu collapsed />
+        </SideMenu.Footer>
+      </SideMenu>,
+    );
+  }
+
+  /** Text a sighted user would read, with every tag and attribute stripped. */
+  function visibleText(html: string): string {
+    return html.replace(/<[^>]*>/g, "").trim();
+  }
+
+  test("collapsed rail drops the label and centers the glyph in a fixed tile", () => {
+    const html = collapsedRailMarkup();
+
+    // Fixed square, centered in the rail column, fully rounded - not a
+    // content-width capsule that the 48px rail then crops.
+    expect(html).toContain("size-[30px]");
+    expect(html).toContain("mx-auto");
+    // Nothing to clip: the label is not rendered at all.
+    expect(visibleText(html)).toBe("");
+    // …and the control is still named, for assistive tech and the tooltip.
+    expect(html).toContain('aria-label="Preferences"');
+  });
+
+  test("collapsed trigger stays a keyboard-reachable menu control", () => {
+    const html = collapsedRailMarkup();
+
+    // A real tab stop that announces what it opens. The rail's own
+    // `aria-current` is for destinations; this opens a menu over the rail.
+    expect(html).toContain('aria-haspopup="dialog"');
+    expect(html).not.toContain('aria-current="page"');
+    expect(html).not.toContain('tabindex="-1"');
+  });
+
+  test("expanded rail keeps the labeled pill", () => {
+    const html = renderToStaticMarkup(
+      <SideMenu ariaLabel="Assistant navigation" variant="rail">
+        <SideMenu.Footer>
+          <PreferencesMenu />
+        </SideMenu.Footer>
+      </SideMenu>,
+    );
+
+    // The label is visible text here, not just an accessible name, and the
+    // trigger is the content-sized pill it shares with the pinned apps.
+    expect(visibleText(html)).toContain("Preferences");
+    expect(html).toContain("w-fit");
+    expect(html).not.toContain("size-[30px]");
   });
 
   test("native Android shows the balance without an add-credits action", async () => {

--- a/clients/web/src/domains/chat/components/preferences-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/preferences-menu.test.tsx
@@ -207,12 +207,11 @@ describe("PreferencesMenu", () => {
     expect(html).toContain("Preferences");
   });
 
-  /* The collapsed rail is 48px wide and the trigger is a pill sized by its
-     content, so an expanded trigger rendered there is clipped mid-word - what
-     shipped as a squashed "Pr…" at the foot of the rail (LUM-3130). The tile
-     is not a pill with `display:none` on its label: it is a fixed 30px square
-     that centres its glyph, the same affordance the pinned apps and section
-     tiles above it reduce to.
+  /* The collapsed rail is 48px wide and a pill is sized by its content, so a
+     labelled trigger rendered there is clipped mid-word. The tile is not that
+     pill with `display:none` on its label: it is a fixed 30px square centring
+     its glyph, the same affordance the pinned apps and section tiles reduce
+     to.
 
      Mounted inside a collapsed `SideMenu` because `shape="tile"` reads the
      rail's state from that context; outside one it is an ordinary row, so a

--- a/clients/web/src/domains/chat/components/preferences-menu.tsx
+++ b/clients/web/src/domains/chat/components/preferences-menu.tsx
@@ -14,6 +14,7 @@ import {
   Button,
   PanelItem,
   Popover,
+  SideMenu,
 } from "@vellumai/design-library";
 
 import { LazyBoundary } from "@/components/lazy-boundary";
@@ -54,6 +55,12 @@ export interface PreferencesMenuProps {
    * `pill` is a floating rounded button for the mobile overlay's action row.
    */
   triggerVariant?: "item" | "pill";
+  /**
+   * The rail is collapsed, so the `item` trigger reduces to the icon-only
+   * tile every other rail entry reduces to. Ignored by the `pill` variant,
+   * which only ever renders on the mobile overlay.
+   */
+  collapsed?: boolean;
 }
 
 export function PreferencesMenu({
@@ -61,6 +68,7 @@ export function PreferencesMenu({
   assistantVersion,
   activeConversationId,
   triggerVariant = "item",
+  collapsed = false,
 }: PreferencesMenuProps) {
   const isAuthenticated = useIsAuthenticated();
   const isMobile = useIsMobile();
@@ -87,6 +95,33 @@ export function PreferencesMenu({
             wide enough to overlap it at narrow viewports. */}
         <span className="min-w-0 truncate">{PREFERENCES_LABEL}</span>
       </Button>
+    ) : collapsed ? (
+      /* Collapsed, the pill becomes the same tile every other rail entry
+         becomes: a 30px circle with the glyph centred and no label, its
+         name carried by the hover tooltip instead. A pill is sized by its
+         content, so one keeping its label overflows the 48px rail and gets
+         clipped mid-word (LUM-3130); dropping only the label would still
+         leave a content-width capsule with the glyph pinned to its leading
+         edge. `SideMenu.Item` owns that whole treatment, which is what the
+         pinned apps above and the section tiles use, so the foot of the rail
+         is drawn by the same component as the rest of it.
+
+         No chevron: it says which way the popover will open, and a tile has
+         no room for it beside the glyph. */
+      <SideMenu.Item
+        icon={CircleUser}
+        label={PREFERENCES_LABEL}
+        showCollapsedTooltip
+        shape="tile"
+        active={isOpen}
+        /* `active` is the open-popover surface here, not a location: this
+           tile opens a menu over the rail rather than navigating, so it drops
+           the `aria-current="page"` a real destination row sets. Mirrors the
+           section tiles in `CollapsedGroupIcon`. */
+        aria-current={undefined}
+        aria-haspopup="dialog"
+        data-tour-id="settings"
+      />
     ) : (
       /* A pill, matching the identity and pinned-app entries it shares the
          rail with: these are destinations you keep, not rows in a list.

--- a/clients/web/src/domains/chat/components/preferences-menu.tsx
+++ b/clients/web/src/domains/chat/components/preferences-menu.tsx
@@ -96,15 +96,15 @@ export function PreferencesMenu({
         <span className="min-w-0 truncate">{PREFERENCES_LABEL}</span>
       </Button>
     ) : collapsed ? (
-      /* Collapsed, the pill becomes the same tile every other rail entry
-         becomes: a 30px circle with the glyph centred and no label, its
-         name carried by the hover tooltip instead. A pill is sized by its
-         content, so one keeping its label overflows the 48px rail and gets
-         clipped mid-word (LUM-3130); dropping only the label would still
-         leave a content-width capsule with the glyph pinned to its leading
-         edge. `SideMenu.Item` owns that whole treatment, which is what the
-         pinned apps above and the section tiles use, so the foot of the rail
-         is drawn by the same component as the rest of it.
+      /* Collapsed, the same tile every other rail entry reduces to: a 30px
+         circle with the glyph centred and no label, its name carried by the
+         hover tooltip. A pill is sized by its content, so one keeping its
+         label is wider than the 48px rail and gets clipped mid-word, and one
+         with only the label dropped is still a content-width capsule with the
+         glyph against its leading edge. `SideMenu.Item` owns that whole
+         treatment, and it is what the pinned apps above and the section tiles
+         use, so the foot of the rail is drawn by the same component as the
+         rest of it.
 
          No chevron: it says which way the popover will open, and a tile has
          no room for it beside the glyph. */

--- a/clients/web/src/domains/chat/use-section-conversations.ts
+++ b/clients/web/src/domains/chat/use-section-conversations.ts
@@ -61,8 +61,8 @@ const NO_FILTER: SectionConversationFilter = {};
  * would return a fraction of the section and look like a quiet account rather
  * than a broken filter. Chats stays on its derived rows there.
  *
- * Chats is a section only in Grouped view. The `all` view renders the same
- * conversations as `flatList`, which is not a section and is not wired here.
+ * Chats is a section in both views, and both are wired here: `holdsChannels`
+ * below is which of the two it is asking as.
  *
  * One asymmetry to know about, because it looks like a bug from either side.
  * `Conversation.originChannel` is binding-first on the client

--- a/clients/web/src/domains/chat/use-sidebar-state.test.tsx
+++ b/clients/web/src/domains/chat/use-sidebar-state.test.tsx
@@ -292,11 +292,10 @@ describe("useSidebarState all view", () => {
     expect(recentsIds(result)).not.toContain("g1");
   });
 
-  /* Regression (LUM-3130): the uncurated rows are reachable as the Chats
-     section and nowhere else. A second copy published beside `sections` is
-     what put a duplicate Chats tile on the collapsed rail, so this asserts
-     the count rather than merely that Chats holds them - one section holding
-     them and a parallel list holding them too would pass the tests above. */
+  /* The uncurated rows are reachable as the Chats section and nowhere else.
+     Asserts the count rather than merely that Chats holds them: one section
+     holding them and a parallel list holding them too passes the tests above,
+     and gives the collapsed rail two Chats tiles to draw. */
   test("publishes the uncurated rows once, as the Chats section", () => {
     const { result } = renderSidebar();
 

--- a/clients/web/src/domains/chat/use-sidebar-state.test.tsx
+++ b/clients/web/src/domains/chat/use-sidebar-state.test.tsx
@@ -4,6 +4,9 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 import type * as ConversationQueries from "@/hooks/conversation-queries";
 import type { Conversation } from "@/types/conversation-types";
 import { useSidebarLayoutStore } from "@/domains/chat/sidebar-layout-store";
+/* Type-only, so it is erased before the `mock.module` above takes effect and
+   the dynamic `import` below is still what supplies the implementation. */
+import type { SidebarState } from "@/domains/chat/use-sidebar-state";
 
 /* The Background/Scheduled sections own their lazy queries; stub both so the
    hook resolves without a QueryClient.
@@ -267,25 +270,41 @@ describe("useSidebarState all view", () => {
     expect(renderSidebar().result.current.viewMode).toBe("all");
   });
 
+  /** The Chats section, which is where this view's uncurated rows live. */
+  function recentsIds(result: { current: SidebarState }): string[] {
+    const recents = result.current.sections.find((s) => s.type === "recents");
+    return (recents?.all ?? []).map((c) => c.conversationId);
+  }
+
   test("merges the channel conversations into one recency-sorted list", () => {
     const { result } = renderSidebar();
 
     expect(
       result.current.sections.filter((section) => section.type === "channel"),
     ).toEqual([]);
-    expect(result.current.flatList.map((c) => c.conversationId)).toEqual([
-      "s1",
-      "r1",
-      "t1",
-    ]);
+    expect(recentsIds(result)).toEqual(["s1", "r1", "t1"]);
   });
 
   test("leaves pinned and grouped conversations out of the flat list", () => {
     const { result } = renderSidebar();
 
-    const flatIds = result.current.flatList.map((c) => c.conversationId);
-    expect(flatIds).not.toContain("p1");
-    expect(flatIds).not.toContain("g1");
+    expect(recentsIds(result)).not.toContain("p1");
+    expect(recentsIds(result)).not.toContain("g1");
+  });
+
+  /* Regression (LUM-3130): the uncurated rows are reachable as the Chats
+     section and nowhere else. A second copy published beside `sections` is
+     what put a duplicate Chats tile on the collapsed rail, so this asserts
+     the count rather than merely that Chats holds them - one section holding
+     them and a parallel list holding them too would pass the tests above. */
+  test("publishes the uncurated rows once, as the Chats section", () => {
+    const { result } = renderSidebar();
+
+    const holders = result.current.sections.filter((section) =>
+      section.all.some((c) => c.conversationId === "s1"),
+    );
+    expect(holders.map((s) => s.key)).toEqual(["recents"]);
+    expect(Object.keys(result.current)).not.toContain("flatList");
   });
 
   /* Chats is a section in this view too, not a bare list under the curated

--- a/clients/web/src/domains/chat/use-sidebar-state.ts
+++ b/clients/web/src/domains/chat/use-sidebar-state.ts
@@ -25,9 +25,7 @@
  * out. In `all` (the default) they are Pinned, the custom groups, and Chats,
  * which holds every conversation the others did not claim. In `grouped`, one
  * section per origin channel joins them and Chats keeps the remainder. Neither
- * view has a list outside the sections: `all` view used to render its
- * conversations through a second, headerless path, and every consumer that
- * forgot to special-case it drifted (LUM-3130).
+ * view has a list outside the sections.
  *
  * The headline output is {@link SidebarState.sections}: one flat, ordered
  * list of every renderable section (Pinned, Chats, each channel, each custom
@@ -137,11 +135,10 @@ export interface SidebarState {
    * - in `grouped` view - the channel sections), which is a starting
    * arrangement rather than a constraint.
    *
-   * The only list this hook publishes. The conversations that belong to no
-   * curated section reach the sidebar as the Chats section's own contents,
-   * never as a second collection beside `sections`: one was published here as
-   * `flatList` after Chats became a section in both views, and the rail went
-   * on drawing it as an extra Chats tile alongside the real one (LUM-3130).
+   * The only list this hook publishes. Conversations that belong to no curated
+   * section reach the sidebar as the Chats section's own contents, never as a
+   * second collection beside `sections`: a consumer handed both renders
+   * whichever one it is not told to skip, on top of the section itself.
    */
   sections: SidebarSection[];
   /**

--- a/clients/web/src/domains/chat/use-sidebar-state.ts
+++ b/clients/web/src/domains/chat/use-sidebar-state.ts
@@ -21,11 +21,13 @@
  * comment on `defaultSections` for why it cannot simply move down with the
  * contents, and for the point at which it has to go.
  *
- * Two views share all of that. In `all` (the default) the sections are Pinned
- * and the custom groups, and everything else renders as
- * {@link SidebarState.flatList}, one recency-sorted list the sidebar
- * virtualizes. In `grouped`, Chats and one section per origin channel join
- * them, and the flat list goes unused.
+ * Two views share all of that, and they differ only in how many sections come
+ * out. In `all` (the default) they are Pinned, the custom groups, and Chats,
+ * which holds every conversation the others did not claim. In `grouped`, one
+ * section per origin channel joins them and Chats keeps the remainder. Neither
+ * view has a list outside the sections: `all` view used to render its
+ * conversations through a second, headerless path, and every consumer that
+ * forgot to special-case it drifted (LUM-3130).
  *
  * The headline output is {@link SidebarState.sections}: one flat, ordered
  * list of every renderable section (Pinned, Chats, each channel, each custom
@@ -130,17 +132,16 @@ export interface SidebarState {
   onViewModeChange: (next: SidebarViewMode) => void;
 
   /**
-   * The `all` view's list: every conversation that is neither pinned nor in a
-   * custom group, newest first. Windowed at render, so it carries no page
-   * size or reveal state of its own.
-   */
-  flatList: Conversation[];
-
-  /**
    * Every section in the user's chosen order. Sections the user has never
-   * moved fall back to the default order (Pinned, custom groups, then - in
-   * `grouped` view - Chats and the channel sections), which is a starting
+   * moved fall back to the default order (Pinned, custom groups, Chats, then
+   * - in `grouped` view - the channel sections), which is a starting
    * arrangement rather than a constraint.
+   *
+   * The only list this hook publishes. The conversations that belong to no
+   * curated section reach the sidebar as the Chats section's own contents,
+   * never as a second collection beside `sections`: one was published here as
+   * `flatList` after Chats became a section in both views, and the rail went
+   * on drawing it as an extra Chats tile alongside the real one (LUM-3130).
    */
   sections: SidebarSection[];
   /**
@@ -463,7 +464,6 @@ export function useSidebarState({
   return {
     viewMode,
     onViewModeChange: setViewMode,
-    flatList: grouped.recents,
     sections,
     onReorderSections,
     onMoveSection,


### PR DESCRIPTION
## TL;DR

The collapsed left rail showed **two identical Chats tiles** and a **Preferences trigger cropped mid-word**. Both are fixed. The expanded sidebar is untouched.

Fixes [LUM-3130](https://linear.app/vellum/issue/LUM-3130/fix-duplicate-chats-sections-and-compressed-preferences-in-collapsed).

## What the user sees

| | Before | After |
|---|---|---|
| Collapsed rail, default (`all`) view | Two chat-bubble tiles, identical glyph, label, conversations and unread dot | One Chats tile |
| Collapsed rail, `grouped` view | One Chats tile (correct) | Unchanged |
| Preferences, collapsed rail | Full-width pill cropped by the 48px rail — a circle with `Pr` trailing off the edge | A 30px circle with the glyph centred, name on hover, like every other rail tile |
| Preferences, expanded rail | Labeled pill with chevron | Unchanged |
| Preferences, mobile drawer | Floating pill | Unchanged |

## Why Chats drew twice

`CollapsedRailSections` rendered one tile per section, then an **extra hardcoded Chats tile** gated on `viewMode === "all"`.

That tile was correct once. `useSidebarState` used to push the Chats section in `grouped` view only, leaving `all` view to render the same conversations through a separate headerless path — so on the rail, `all` view genuinely had no Chats section to draw and needed one supplied. Chats has since become a section in **both** views. The extra tile survived that change, and in `all` view — the default — it duplicated the real section exactly.

`SidebarState.flatList` was the same list published a second time, and after removing the tile it had no consumers left. It is deleted here too: the Chats section's own contents are now the only route those conversations take to the sidebar, so there is nothing left for a future consumer to render twice. Two doc comments that still described the old two-path arrangement are corrected.

## Why Preferences was cropped

`PreferencesMenu` rendered the same content-sized pill — icon, label, chevron — in both rail states. The collapsed rail is 48px wide, so it overflowed and clipped.

It now branches the way `PinnedAppNavItem` and the section tiles already do: `PanelItem shape="pill"` expanded, `SideMenu.Item shape="tile"` collapsed. `shape="tile"` is the design library's existing collapsed-rail affordance — fixed 30px square, centred glyph, `--surface-lift`, tooltip in place of the label — so the foot of the rail is now drawn by the same component as the rest of it rather than by a pill with its label hidden.

Keyboard and screen-reader access are preserved: still a real button and tab stop, `aria-label="Preferences"`, `aria-haspopup="dialog"`, and no `aria-current="page"` (it opens a menu over the rail, it doesn't navigate).

## Why this is safe

- Behaviour changes only where `collapsed && variant === "rail"`. Expanded rail and mobile overlay take the same code paths they did before.
- The removed rail tile and the removed `flatList` were provably unreferenced — no other consumer in the repo.
- No API, storage-format, or persisted-state changes. Section order, collapse state, and view mode are all untouched.
- Reverting the fix reproduces the duplicate on demand, which is how it was confirmed rather than inferred.

## Why Storybook missed both

Worth calling out, because it is the reason these shipped:

- The only collapsed story was seeded to `grouped` view, where the extra Chats tile is suppressed. There is now **a collapsed story per view**.
- `PreferencesMenu` returns `null` for a signed-out user, and a story has no session — so the footer these stories claim to document was silently absent from **every** one of them. They now seed an authenticated session, and the Preferences trigger renders in all of them.

## Tests

- `collapsed-rail-sections.test.tsx` (new) — asserts tile **count** against section count and labels in order, in both view modes. A test that merely asked "does Chats render" would have passed with two of them.
- `preferences-menu.test.tsx` — collapsed trigger has the fixed-tile geometry, renders no visible label while keeping its accessible name, and stays a keyboard-reachable menu control; expanded trigger still renders the labeled pill.
- `use-sidebar-state.test.tsx` — the uncurated conversations are published exactly once, as the Chats section.

## Verification

Typecheck, lint and Prettier are clean. Both fixes were verified in the real component in Storybook, and the duplicate was reproduced by reverting the fix and re-checking. `bun test` is blocked on this machine by a standing local rule, so the suites above run in CI.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40447" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->