### PR TITLE
fix(approvals): spend the configured approval budget on inline grant waits (LUM-3135)

### DIFF
--- a/assistant/src/__tests__/tool-grant-request-escalation.test.ts
+++ b/assistant/src/__tests__/tool-grant-request-escalation.test.ts
@@ -101,17 +101,20 @@ import {
   getRegisteredKinds,
   getResolver,
 } from "../approvals/guardian-request-resolvers.js";
+import { getConfig } from "../config/loader.js";
 import { getDb } from "../persistence/db-connection.js";
 import { getSqlite } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { scopedApprovalGrants } from "../persistence/schema/index.js";
 import {
+  TC_GRANT_WAIT_MAX_MS,
   ToolApprovalHandler,
   waitForInlineGrant,
 } from "../tools/tool-approval-handler.js";
 import type { ToolContext } from "../tools/types.js";
+import { setConfig } from "./helpers/set-config.js";
 
-/** Short wait config for tests — avoids blocking test suite on the 60s default. */
+/** Short wait config for tests: keeps escalation cases off the real budget. */
 const TEST_INLINE_WAIT_CONFIG = { maxWaitMs: 100, intervalMs: 20 };
 
 await initializeDb();
@@ -489,6 +492,42 @@ describe("inline wait-and-resume", () => {
     expect(elapsed).toBeGreaterThanOrEqual(80);
     expect(elapsed).toBeLessThan(500);
   });
+
+  test("waitForInlineGrant spends timeouts.permissionTimeoutSec when no explicit budget is given", async () => {
+    // The guardian's escalation window must track the configured approval
+    // budget rather than a compiled-in constant, so an operator raising
+    // permissionTimeoutSec actually widens the window a guardian has to
+    // answer in. Omitting maxWaitMs is what production does.
+    const priorTimeouts = getConfig().timeouts;
+    setConfig("timeouts", {
+      ...priorTimeouts,
+      permissionTimeoutSec: 0.15,
+    });
+    try {
+      const req = seedGrantRequest("sha256:configbudget");
+
+      const start = Date.now();
+      const result = await waitForInlineGrant(
+        req.id,
+        {
+          toolName: "bash",
+          inputDigest: "sha256:configbudget",
+          consumingRequestId: "consume-config-budget",
+        },
+        { intervalMs: 20 },
+      );
+      const elapsed = Date.now() - start;
+
+      expect(result.outcome).toBe("timeout");
+      // Bounded well under TC_GRANT_WAIT_MAX_MS: a regression that ignores
+      // config and falls back to the constant blows this ceiling by ~400x.
+      expect(elapsed).toBeGreaterThanOrEqual(120);
+      expect(elapsed).toBeLessThan(3_000);
+      expect(elapsed).toBeLessThan(TC_GRANT_WAIT_MAX_MS);
+    } finally {
+      setConfig("timeouts", priorTimeouts);
+    }
+  }, 10_000);
 
   test("waitForInlineGrant returns aborted when signal fires during wait", async () => {
     const req = seedGrantRequest("sha256:abortwait");

--- a/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
+++ b/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
@@ -170,6 +170,7 @@ mock.module("../channels/gateway-guardian-requests.js", () => sim.module);
 import { applyGuardianDecision } from "../approvals/guardian-decision-primitive.js";
 import type { ActorContext } from "../approvals/guardian-request-resolvers.js";
 import { getResolver } from "../approvals/guardian-request-resolvers.js";
+import { getConfig } from "../config/loader.js";
 import type { TrustContext } from "../daemon/trust-context-types.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
@@ -177,12 +178,14 @@ import { scopedApprovalGrants } from "../persistence/schema/index.js";
 import { bridgeConfirmationRequestToGuardian } from "../runtime/confirmation-request-guardian-bridge.js";
 import { resolveRoutingState } from "../runtime/trust-context-resolver.js";
 import {
+  resolveInlineGrantWaitMs,
   TC_GRANT_WAIT_MAX_MS,
   ToolApprovalHandler,
   waitForInlineGrant,
 } from "../tools/tool-approval-handler.js";
 import type { ToolContext } from "../tools/types.js";
 import { seedContactChannel } from "./helpers/seed-contact-channel.js";
+import { setConfig } from "./helpers/set-config.js";
 
 await initializeDb();
 
@@ -754,7 +757,10 @@ describe("(f) timeout/stale flow: stale guardian decision after inline wait time
   test("inline_wait_active staleness guard: expired marker allows retry notification", async () => {
     // Create a guardian request with a stale inline_wait_active marker
     // that simulates a daemon crash during the wait.
-    const staleTimestamp = Date.now() - TC_GRANT_WAIT_MAX_MS - 60_000;
+    // Age the marker past the real wait budget, which the resolver's
+    // staleness threshold tracks. Deriving it from the same helper the
+    // waiter uses keeps this case meaningful if the budget changes.
+    const staleTimestamp = Date.now() - resolveInlineGrantWaitMs() - 60_000;
     const req = sim.seedRequest({
       id: `req-stale-${Date.now()}`,
       kind: "tool_grant_request",
@@ -800,6 +806,67 @@ describe("(f) timeout/stale flow: stale guardian decision after inline wait time
         (r.payload.text as string).includes("approved"),
     );
     expect(retryNotifications.length).toBeGreaterThan(0);
+  });
+
+  test("inline_wait_active marker older than the fallback constant but inside the real budget still suppresses retry", async () => {
+    // The staleness threshold must track the wait budget, not the fallback
+    // constant. A marker aged past TC_GRANT_WAIT_MAX_MS + buffer but still
+    // well inside the configured budget belongs to a waiter that is very
+    // much alive: telling the requester to retry would race a call that is
+    // about to resume, and the retry then fails against the one-time grant
+    // the live waiter consumes.
+    const priorTimeouts = getConfig().timeouts;
+    // Seed the budget rather than leaning on the ambient default, so the
+    // window this case probes exists no matter what the suite's config holds.
+    setConfig("timeouts", { ...priorTimeouts, permissionTimeoutSec: 300 });
+    try {
+      const budgetMs = resolveInlineGrantWaitMs();
+      // Comfortably past the old 90s threshold, comfortably short of the budget.
+      const markerAgeMs = TC_GRANT_WAIT_MAX_MS + 45_000;
+      const liveTimestamp = Date.now() - markerAgeMs;
+      expect(markerAgeMs).toBeLessThan(budgetMs);
+
+      const req = sim.seedRequest({
+        id: `req-live-${Date.now()}`,
+        kind: "tool_grant_request",
+        sourceType: "channel",
+        sourceChannel: "telegram",
+        sourceConversationId: "conv-live-1",
+        requesterExternalUserId: "requester-1",
+        requesterChatId: "requester-chat-1",
+        guardianExternalUserId: "guardian-1",
+        guardianPrincipalId: "test-principal-id",
+        toolName: "bash",
+        inputDigest: "sha256:livewait",
+        expiresAt: Date.now() + 60_000,
+      });
+
+      await sim.module.updateGuardianRequest(req.id, {
+        followupState: `inline_wait_active:${liveTimestamp}`,
+      });
+
+      deliveredReplies.length = 0;
+      const approvalResult = await applyGuardianDecision({
+        requestId: req.id,
+        action: "approve_once",
+        actorContext: guardianActor(),
+        channelDeliveryContext: {
+          replyCallbackUrl: "http://localhost:3000/reply",
+          guardianChatId: "guardian-chat-1",
+          assistantId: "self",
+        },
+      });
+      expect(approvalResult.applied).toBe(true);
+
+      const retryNotifications = deliveredReplies.filter(
+        (r) =>
+          typeof r.payload.text === "string" &&
+          (r.payload.text as string).includes("Please retry"),
+      );
+      expect(retryNotifications.length).toBe(0);
+    } finally {
+      setConfig("timeouts", priorTimeouts);
+    }
   });
 
   test("fresh inline_wait_active marker suppresses retry notification", async () => {

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -54,7 +54,7 @@ import {
   readBatchMetadata,
   resolvePendingQuestion,
 } from "../runtime/question-resolution.js";
-import { TC_GRANT_WAIT_MAX_MS } from "../tools/tool-approval-handler.js";
+import { resolveInlineGrantWaitMs } from "../tools/tool-approval-handler.js";
 import { getLogger } from "../util/logger.js";
 import {
   channelCanAddressOneReaderInBand,
@@ -1587,7 +1587,10 @@ const toolGrantRequestResolver: GuardianRequestResolver = {
     // outlive the actual waiter if the daemon crashes or restarts during
     // the wait. To avoid permanently suppressing the retry notification, we
     // treat the marker as stale if the encoded start timestamp is older than
-    // the maximum wait budget plus a 30s buffer.
+    // the maximum wait budget plus a 30s buffer. The budget is read from the
+    // same resolver the waiter itself uses, so a config change moves both
+    // together; sizing this off a constant would let it fall below the real
+    // wait and declare a live waiter dead.
     const INLINE_WAIT_STALENESS_BUFFER_MS = 30_000;
     const freshRequest = await getGuardianRequestOrNull(request.id);
     const followupState = freshRequest?.followupState ?? "";
@@ -1604,7 +1607,7 @@ const toolGrantRequestResolver: GuardianRequestResolver = {
         ? Date.now() - waitStartMs
         : Infinity; // Treat unparseable timestamps as stale for safety.
       const stalenessThresholdMs =
-        TC_GRANT_WAIT_MAX_MS + INLINE_WAIT_STALENESS_BUFFER_MS;
+        resolveInlineGrantWaitMs() + INLINE_WAIT_STALENESS_BUFFER_MS;
       if (markerAgeMs > stalenessThresholdMs) {
         log.warn(
           {

--- a/assistant/src/config/schemas/timeouts.ts
+++ b/assistant/src/config/schemas/timeouts.ts
@@ -26,7 +26,7 @@ export const TimeoutConfigSchema = z
       .positive("timeouts.permissionTimeoutSec must be a positive number")
       .default(300)
       .describe(
-        "How long to wait for user permission approval before timing out (seconds)",
+        "How long to wait for a human to approve a tool call before timing out (seconds). Spent by both approval paths: the interactive permission prompt, and the inline wait when a contact's sensitive tool call is escalated to the guardian.",
       ),
     questionResponseTimeoutSec: z
       .number({ error: "timeouts.questionResponseTimeoutSec must be a number" })

--- a/assistant/src/tools/execution-timeout.ts
+++ b/assistant/src/tools/execution-timeout.ts
@@ -6,11 +6,18 @@ const TIMEOUT_SENTINEL = Symbol("tool-timeout");
 /**
  * Convert a config-provided seconds value to a safe milliseconds value,
  * falling back to the default if the input is NaN, non-finite, zero, or negative.
+ *
+ * `fallbackMs` lets callers governed by a different budget (e.g. the inline
+ * grant wait) keep their own floor instead of inheriting the tool-execution
+ * default.
  */
-export function safeTimeoutMs(sec: unknown): number {
+export function safeTimeoutMs(
+  sec: unknown,
+  fallbackMs: number = DEFAULT_TOOL_EXECUTION_TIMEOUT_SEC * 1000,
+): number {
   const n = Number(sec);
   if (!Number.isFinite(n) || n <= 0) {
-    return DEFAULT_TOOL_EXECUTION_TIMEOUT_SEC * 1000;
+    return fallbackMs;
   }
   return n * 1000;
 }

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -127,8 +127,38 @@ export function buildInactiveToolMessage(args: {
 
 /** Default polling interval for inline grant wait (ms). */
 const TC_GRANT_WAIT_INTERVAL_MS = 500;
-/** Default maximum wait time for inline grant wait (ms). */
+/**
+ * Fallback maximum wait for the inline grant wait (ms), used only when the
+ * deployed config cannot be read. The governing budget is
+ * `timeouts.permissionTimeoutSec` (see {@link resolveInlineGrantWaitMs}).
+ */
 export const TC_GRANT_WAIT_MAX_MS = 60_000;
+
+/**
+ * Resolve the wait budget for an escalated tool grant.
+ *
+ * A guardian answering an escalated tool call is making the same decision as a
+ * local user answering a permission prompt, so both paths spend the same
+ * budget: `timeouts.permissionTimeoutSec` (read by `permissions/prompter.ts`).
+ * If anything, this path needs the larger share of it: the prompter's user
+ * already has the prompt on screen, while the guardian is notified
+ * out-of-band and has to context-switch before deciding.
+ *
+ * Falls back to {@link TC_GRANT_WAIT_MAX_MS} when the config is unreadable or
+ * carries a non-positive value, so a bad read can never collapse the window to
+ * zero and auto-deny every escalation.
+ */
+function resolveInlineGrantWaitMs(): number {
+  try {
+    const seconds = getConfig().timeouts.permissionTimeoutSec;
+    if (Number.isFinite(seconds) && seconds > 0) {
+      return seconds * 1000;
+    }
+  } catch {
+    // Unreadable config falls through to the compiled-in default.
+  }
+  return TC_GRANT_WAIT_MAX_MS;
+}
 
 /**
  * Inline wait result for trusted-contact grant polling.
@@ -152,13 +182,16 @@ export type InlineGrantWaitOutcome =
  * and atomically consume the grant).
  *
  * Only called for trusted_contact actors with valid guardian bindings.
+ *
+ * `options.maxWaitMs` overrides the wait budget; omitting it spends the
+ * configured one from {@link resolveInlineGrantWaitMs}.
  */
 export async function waitForInlineGrant(
   escalationRequestId: string,
   consumeParams: Parameters<typeof consumeGrantForInvocation>[0],
   options?: { maxWaitMs?: number; intervalMs?: number; signal?: AbortSignal },
 ): Promise<InlineGrantWaitOutcome> {
-  const maxWait = options?.maxWaitMs ?? TC_GRANT_WAIT_MAX_MS;
+  const maxWait = options?.maxWaitMs ?? resolveInlineGrantWaitMs();
   const interval = options?.intervalMs ?? TC_GRANT_WAIT_INTERVAL_MS;
   const signal = options?.signal;
   const deadline = Date.now() + maxWait;
@@ -592,9 +625,16 @@ export type PreExecutionGateResult =
     }
   | { allowed: false; result: ToolExecutionResult };
 
-/** Configuration for the inline grant wait behavior. */
+/**
+ * Overrides for the inline grant wait behavior. Production leaves this empty
+ * so the wait spends the configured budget; tests inject short waits to keep
+ * escalation cases fast.
+ */
 export interface InlineGrantWaitConfig {
-  /** Maximum time to wait for guardian approval (ms). Defaults to TC_GRANT_WAIT_MAX_MS. */
+  /**
+   * Maximum time to wait for guardian approval (ms). Defaults to the budget
+   * from {@link resolveInlineGrantWaitMs}.
+   */
   maxWaitMs?: number;
   /** Polling interval during the wait (ms). Defaults to TC_GRANT_WAIT_INTERVAL_MS. */
   intervalMs?: number;

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -147,8 +147,13 @@ export const TC_GRANT_WAIT_MAX_MS = 60_000;
  * Falls back to {@link TC_GRANT_WAIT_MAX_MS} when the config is unreadable or
  * carries a non-positive value, so a bad read can never collapse the window to
  * zero and auto-deny every escalation.
+ *
+ * Exported because the grant resolver sizes its `inline_wait_active` staleness
+ * threshold off this same budget: if the two drift, an approval arriving while
+ * a waiter is still live gets misread as a dead waiter and the requester is
+ * told to retry a call that is about to resume on its own.
  */
-function resolveInlineGrantWaitMs(): number {
+export function resolveInlineGrantWaitMs(): number {
   try {
     const seconds = getConfig().timeouts.permissionTimeoutSec;
     if (Number.isFinite(seconds) && seconds > 0) {

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -39,6 +39,7 @@ import { computeToolApprovalDigest } from "../security/tool-approval-digest.js";
 import { recordToolDenied, recordToolError } from "../telemetry/tool-audit.js";
 import { getLogger } from "../util/logger.js";
 import { resolveExecutionTarget } from "./execution-target.js";
+import { safeTimeoutMs } from "./execution-timeout.js";
 import { channelCoordinatesFromToolContext } from "./policy-context.js";
 import { getAllTools, getTool, getToolOwner } from "./registry.js";
 import { isSideEffectTool } from "./side-effects.js";
@@ -144,9 +145,9 @@ export const TC_GRANT_WAIT_MAX_MS = 60_000;
  * already has the prompt on screen, while the guardian is notified
  * out-of-band and has to context-switch before deciding.
  *
- * Falls back to {@link TC_GRANT_WAIT_MAX_MS} when the config is unreadable or
- * carries a non-positive value, so a bad read can never collapse the window to
- * zero and auto-deny every escalation.
+ * Falls back to {@link TC_GRANT_WAIT_MAX_MS} rather than the tool-execution
+ * default on a non-positive value, so a bad config can never collapse the
+ * window to zero and auto-deny every escalation.
  *
  * Exported because the grant resolver sizes its `inline_wait_active` staleness
  * threshold off this same budget: if the two drift, an approval arriving while
@@ -154,15 +155,10 @@ export const TC_GRANT_WAIT_MAX_MS = 60_000;
  * told to retry a call that is about to resume on its own.
  */
 export function resolveInlineGrantWaitMs(): number {
-  try {
-    const seconds = getConfig().timeouts.permissionTimeoutSec;
-    if (Number.isFinite(seconds) && seconds > 0) {
-      return seconds * 1000;
-    }
-  } catch {
-    // Unreadable config falls through to the compiled-in default.
-  }
-  return TC_GRANT_WAIT_MAX_MS;
+  return safeTimeoutMs(
+    getConfig().timeouts.permissionTimeoutSec,
+    TC_GRANT_WAIT_MAX_MS,
+  );
 }
 
 /**


### PR DESCRIPTION
## TL;DR

The inline wait for a guardian to approve an escalated tool call was hardcoded to 60s, while the interactive permission prompt honours `timeouts.permissionTimeoutSec` (default 300). Both paths ask the same question and now spend the same budget.

This is **defect B** of [LUM-3135](https://linear.app/vellum/issue/LUM-3135). Defect A (the stale trusted-contact attribution that routed a guardian's own tool calls into this path at all) is a separate change.

## What was broken

`waitForInlineGrant` read `options.maxWaitMs ?? TC_GRANT_WAIT_MAX_MS`. The only production construction of `ToolApprovalHandler` is `new ToolApprovalHandler()` in `tools/executor.ts`, with no config, so `inlineGrantWaitConfig` was `{}` and `maxWaitMs` was always `undefined`. The 60s constant always won. Only tests ever passed a value.

`permissions/prompter.ts` reads `timeouts.permissionTimeoutSec` for the same decision. So two approval paths silently spent budgets differing by 5x, and the escalation path had the *smaller* one, despite being the one that notifies a remote guardian who has to context-switch before answering.

## Before / after

| | Before | After |
|---|---|---|
| Guardian's window to approve an escalated tool call | 60s, fixed | `permissionTimeoutSec` (300s by default) |
| Raising `permissionTimeoutSec` | No effect on this path | Widens the window, as documented |
| Lowering it below 60s | No effect | Narrows the window, as documented |
| Config unreadable or non-positive | n/a | Falls back to 60s rather than 0 |

For a guardian on the current default config, an escalated tool call now waits 5 minutes instead of 1 before auto-denying.

## Why this is safe

- **Not clipped by an outer timeout.** `checkPreExecutionGates` runs at `executor.ts:91`, before `executeWithTimeout` at `:248`, so the approval wait sits outside `toolExecutionTimeoutSec` (default 120). Verified before choosing this approach; a 300s wait is genuinely honoured.
- **Cannot collapse to zero.** A non-finite, non-positive, or unreadable config falls back to the constant. A bad config can't turn every escalation into an instant auto-deny.
- **Fail-closed semantics unchanged.** Only the size of the window moved. Timeout still denies, explicit guardian rejection still exits early, abort still cancels.
- **Test injection preserved.** `InlineGrantWaitConfig` still overrides the budget, so escalation suites keep their short waits.
- **Blast radius is one call site.** `waitForInlineGrant` is the only consumer of the constant as a default.

## Why not a separate knob

The ticket floated giving this path its own documented timeout. That keeps two budgets and makes the operator responsible for syncing them, which is the defect renamed rather than fixed. If the remote path is later shown to need its own budget, the right shape is an `inlineGrantWaitSec` that *defaults to* `permissionTimeoutSec`, not a second independent default.

## A second consumer of the same constant

`TC_GRANT_WAIT_MAX_MS` was load-bearing in a second place, caught in review. `approvals/guardian-request-resolvers.ts:1607` sized its `inline_wait_active` staleness threshold as `TC_GRANT_WAIT_MAX_MS + 30s` (90s) to decide whether a waiter was still alive. Correct while the wait was that same constant; wrong once the wait reads `permissionTimeoutSec`. An approval arriving 90s-300s into a live wait would be read as a crashed daemon, so the requester got "Please retry" for a call that was still blocked and about to resume, and the retry would then fail against the one-time grant the live waiter consumes.

`resolveInlineGrantWaitMs` is now exported and the resolver derives its threshold from it, so the two move together.

## Testing

Three tests. One asserting the invariant: with no explicit `maxWaitMs`, the wait honours a configured `permissionTimeoutSec` (seeded to 0.15s via the real config path, not a mock) and returns `timeout` in ~150ms. Against the previous code this waits the full 60s and fails on the ceiling, so the test is sensitive to the regression rather than merely passing.

The staleness pair moved too: the existing `expired marker allows retry notification` test seeded its marker at `TC_GRANT_WAIT_MAX_MS + 60s`, an age now inside the budget and no longer stale, so it derives from the same helper; and a new case covers the regressed window, a marker older than the fallback constant plus buffer but still inside the configured budget, which must suppress the retry.

Also broadened the `permissionTimeoutSec` schema description to name both paths it governs, since the discoverability gap is what let them drift.

Typecheck, lint, and prettier pass. Test suites were not run locally per the standing rule on this machine; CI covers them.

## Deferred

- **Defect A (stale attribution)** stays open in LUM-3135. Worth flagging that the ticket's stated mechanism is wrong: it claims attribution is "resolved once per conversation rather than per turn", but `handleSendMessage` re-stamps trust on every web POST and all three drain entry points re-stamp the per-turn snapshot. The real seam is that trust lives in a single mutable conversation-level slot and queued messages don't snapshot it. `EnqueueMessageOptions` captures `sourceActorPrincipalId` for host-proxy routing but no trust context, so a drained turn reads whichever actor POSTed most recently. I'll correct the ticket separately.
- **`riskLevel` inconsistency** on byte-identical commands: untouched, and the ticket does not claim it as a defect.
- **`guardian_requests_sweep_expired` IPC timeouts**: flagged in the ticket as possibly unrelated; not investigated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
