### PR TITLE
feat(web): give the onboarding flow a live avatar wave

### DIFF
--- a/clients/web/src/domains/onboarding/avatar-wave-ribbon.test.ts
+++ b/clients/web/src/domains/onboarding/avatar-wave-ribbon.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  buildRibbonWave,
+  mulberry32,
+  type RibbonPoint,
+} from "@/domains/onboarding/avatar-wave-ribbon";
+
+const RIBBON: RibbonPoint[] = [
+  { x: 0, y: 0, w: 100, s: 40 },
+  { x: 100, y: 200, w: 160, s: 80 },
+  { x: 40, y: 400, w: 200, s: 120 },
+];
+
+describe("mulberry32", () => {
+  it("is deterministic for a seed", () => {
+    const a = mulberry32(42);
+    const b = mulberry32(42);
+    const runA = [a(), a(), a(), a()];
+    const runB = [b(), b(), b(), b()];
+    expect(runA).toEqual(runB);
+  });
+
+  it("produces values in [0, 1)", () => {
+    const rng = mulberry32(7);
+    for (let i = 0; i < 500; i++) {
+      const v = rng();
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThan(1);
+    }
+  });
+
+  it("does not return the same value every call", () => {
+    const rng = mulberry32(1);
+    const seen = new Set(Array.from({ length: 50 }, () => rng()));
+    expect(seen.size).toBeGreaterThan(40);
+  });
+});
+
+describe("buildRibbonWave", () => {
+  it("reproduces the same composition for the same seed", () => {
+    expect(buildRibbonWave(RIBBON, 99)).toEqual(buildRibbonWave(RIBBON, 99));
+  });
+
+  it("produces a different composition for a different seed", () => {
+    expect(buildRibbonWave(RIBBON, 99)).not.toEqual(
+      buildRibbonWave(RIBBON, 100),
+    );
+  });
+
+  it("lays several rows along the ribbon rather than a single one", () => {
+    const items = buildRibbonWave(RIBBON, 1);
+    expect(items.length).toBeGreaterThan(10);
+  });
+
+  it("caps avatar size at maxSize", () => {
+    const capped = buildRibbonWave(RIBBON, 1, 50);
+    expect(capped.length).toBeGreaterThan(0);
+    for (const item of capped) {
+      expect(item.size).toBeLessThanOrEqual(50);
+    }
+  });
+
+  it("grows avatars from the head of the ribbon toward its tail", () => {
+    const items = buildRibbonWave(RIBBON, 3);
+    const head = items.slice(0, 10);
+    const tail = items.slice(-10);
+    const mean = (xs: typeof items) =>
+      xs.reduce((sum, i) => sum + i.size, 0) / xs.length;
+    expect(mean(tail)).toBeGreaterThan(mean(head));
+  });
+
+  it("keeps every avatar within a sane distance of the centerline", () => {
+    // Nothing should land far outside the widest band (200) plus jitter.
+    const items = buildRibbonWave(RIBBON, 5);
+    for (const item of items) {
+      expect(Math.abs(item.x)).toBeLessThan(400);
+      expect(item.y).toBeGreaterThan(-200);
+      expect(item.y).toBeLessThan(600);
+    }
+  });
+
+  it("returns nothing for a ribbon that cannot form a segment", () => {
+    expect(buildRibbonWave([], 1)).toEqual([]);
+    expect(buildRibbonWave([{ x: 0, y: 0, w: 10, s: 10 }], 1)).toEqual([]);
+  });
+
+  it("skips zero-length segments instead of looping forever", () => {
+    const degenerate: RibbonPoint[] = [
+      { x: 10, y: 10, w: 50, s: 20 },
+      { x: 10, y: 10, w: 50, s: 20 },
+      { x: 10, y: 90, w: 50, s: 20 },
+    ];
+    const items = buildRibbonWave(degenerate, 2);
+    expect(items.length).toBeGreaterThan(0);
+  });
+});

--- a/clients/web/src/domains/onboarding/avatar-wave-ribbon.ts
+++ b/clients/web/src/domains/onboarding/avatar-wave-ribbon.ts
@@ -1,0 +1,103 @@
+/**
+ * Layout generator for the welcome screen's avatar wave.
+ *
+ * A ribbon is a centerline of control points, each carrying the ribbon's
+ * width and the avatar size at that point. Walking it with arc-length steps
+ * and laying a row of avatars across the perpendicular at each step packs a
+ * crowd that flows along the path and grows toward its tail.
+ *
+ * Everything is deterministic for a given seed so a re-layout (resize,
+ * orientation change) reproduces the same composition instead of reshuffling
+ * the crowd under the user.
+ */
+
+/** Centerline control point: position, ribbon width, and avatar size here. */
+export interface RibbonPoint {
+  x: number;
+  y: number;
+  w: number;
+  s: number;
+}
+
+/** One placed avatar in design coordinates (center point). */
+export interface WaveItem {
+  x: number;
+  y: number;
+  size: number;
+  rotate: number;
+}
+
+/** mulberry32 — small deterministic PRNG for layout jitter. */
+export function mulberry32(seed: number): () => number {
+  let state = seed;
+  return () => {
+    state |= 0;
+    state = (state + 0x6d2b79f5) | 0;
+    let t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Pack avatars along `ribbon`. Push order follows the path, so callers can
+ * use the index as the reveal order and get a head-to-tail pour.
+ *
+ * `maxSize` caps the post-jitter avatar size so a ribbon can keep widening
+ * toward its tail without any single avatar outgrowing its container.
+ */
+export function buildRibbonWave(
+  ribbon: RibbonPoint[],
+  seed: number,
+  maxSize = Infinity,
+): WaveItem[] {
+  const rng = mulberry32(seed);
+  const jitter = (amount: number) => (rng() * 2 - 1) * amount;
+  const items: WaveItem[] = [];
+
+  for (let seg = 0; seg < ribbon.length - 1; seg++) {
+    const a = ribbon[seg];
+    const b = ribbon[seg + 1];
+    if (!a || !b) {
+      continue;
+    }
+    const dx = b.x - a.x;
+    const dy = b.y - a.y;
+    const len = Math.hypot(dx, dy);
+    if (len === 0) {
+      continue;
+    }
+    const perpX = dy / len;
+    const perpY = -dx / len;
+
+    let dist = 0;
+    let row = 0;
+    while (dist < len) {
+      const t = dist / len;
+      const cx = a.x + dx * t;
+      const cy = a.y + dy * t;
+      const width = a.w + (b.w - a.w) * t;
+      const size = a.s + (b.s - a.s) * t;
+
+      const count = Math.max(1, Math.round(width / (size * 0.95)));
+      const spacing = width / count;
+      // Alternate rows shift half a slot across the ribbon so the packing
+      // nests organically instead of forming parallel strands.
+      const rowShift = row % 2 === 0 ? 0 : spacing * 0.5;
+      for (let k = 0; k < count; k++) {
+        const offset =
+          (k - (count - 1) / 2) * spacing + rowShift + jitter(size * 0.12);
+        items.push({
+          x: cx + perpX * offset + jitter(size * 0.08),
+          y: cy + perpY * offset + jitter(size * 0.08),
+          size: Math.min(maxSize, size * (0.85 + rng() * 0.3)),
+          rotate: jitter(10),
+        });
+      }
+      dist += size * 0.85 + 4;
+      row++;
+    }
+  }
+
+  return items;
+}

--- a/clients/web/src/domains/onboarding/components/avatar-wave.tsx
+++ b/clients/web/src/domains/onboarding/components/avatar-wave.tsx
@@ -1,0 +1,526 @@
+import { useEffect, useRef } from "react";
+
+import {
+  buildRibbonWave,
+  mulberry32,
+  type RibbonPoint,
+} from "@/domains/onboarding/avatar-wave-ribbon";
+import type { CharacterComponents } from "@/types/avatar";
+import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
+
+/**
+ * A crowd of characters flowing down a ribbon, drawn on one canvas and
+ * simulated per frame: they lean away from the cursor, a quick swipe knocks
+ * nearby ones loose to sail off and bounce around, and everything springs
+ * back home once it settles.
+ *
+ * Purely decorative. The canvas never takes pointer events, and the cursor
+ * is tracked on `window` so the characters still react while the pointer is
+ * over the content sitting beside them.
+ */
+
+/**
+ * Design-space box the ribbon is authored in. The canvas scales this to
+ * cover its container, so the crowd keeps its shape at any panel size.
+ */
+const DESIGN_W = 620;
+const DESIGN_H = 900;
+
+const SEED = 20260807;
+
+/** Keeps the widening tail from producing one absurdly large character. */
+const MAX_AVATAR_SIZE = 190;
+
+/**
+ * The ribbon enters cut off by the top edge, bulges toward the outer side,
+ * and pours back out through the bottom, growing the whole way.
+ */
+const RIBBON: RibbonPoint[] = [
+  { x: 140, y: -60, w: 100, s: 40 },
+  { x: 270, y: 80, w: 130, s: 54 },
+  { x: 400, y: 230, w: 160, s: 70 },
+  { x: 460, y: 400, w: 190, s: 88 },
+  { x: 420, y: 570, w: 220, s: 108 },
+  { x: 310, y: 720, w: 250, s: 128 },
+  { x: 200, y: 860, w: 275, s: 148 },
+  { x: 150, y: 990, w: 300, s: 168 },
+];
+
+const REPEL_RADIUS = 170;
+const REPEL_PUSH = 70;
+/** Kick impulse per frame per unit of cursor velocity. */
+const FLING = 2;
+/** Speed at which a character detaches and sails off, immune from there on. */
+const BALLISTIC_ON = 5;
+const MAX_SPEED = 17;
+const FLIGHT_FRICTION = 0.972;
+const BOUNCE = 0.84;
+/** Displacement past which a merely-nudged character also goes immune. */
+const DISTURB_DIST = 70;
+const STIFF_BACK = 0.06;
+const DAMP_BACK = 0.85;
+const STIFF_HOVER = 0.12;
+const DAMP_HOVER = 0.74;
+/** Cursor speed is clamped before it becomes an impulse. */
+const MAX_CURSOR_SPEED = 8;
+
+const REVEAL_MS = 550;
+/**
+ * Gap between one character's entrance and the next. Derived from size so
+ * the small characters at the head of the ribbon pour in quickly and the
+ * large ones at the tail arrive with a beat between them.
+ */
+const POUR_GAP_MIN_MS = 12;
+const POUR_GAP_MAX_MS = 55;
+const POUR_GAP_NUMERATOR = 1900;
+
+/**
+ * The simulation is tuned in 60fps frames, so every integration step scales
+ * by how long the real frame took. Without this the wave springs and flies
+ * at double speed on a 120Hz display. Capped so returning to a backgrounded
+ * tab resumes rather than teleporting everything.
+ */
+const FRAME_MS = 1000 / 60;
+const MAX_FRAME_SCALE = 3;
+
+/** Idle decay so a stationary cursor stops flinging on its last reading. */
+const CURSOR_VELOCITY_DECAY = 0.9;
+
+/** Sprites are rasterized per size bucket so a resize reuses most of them. */
+const SPRITE_SIZE_BUCKET = 8;
+
+interface LiveItem {
+  /** Home position and drawn size, in canvas pixels. */
+  hx: number;
+  hy: number;
+  px: number;
+  rotate: number;
+  phase: number;
+  pourDelay: number;
+  /** Offset from home, velocity, and disturbance mode. */
+  dx: number;
+  dy: number;
+  vx: number;
+  vy: number;
+  disturbed: boolean;
+  flying: boolean;
+  fade: number;
+  sprite: HTMLCanvasElement | null;
+}
+
+/**
+ * Draw one character to an offscreen canvas at its final size. Rasterizing
+ * once per character keeps the per-frame cost to a `drawImage` each, which
+ * is what lets the whole crowd run at frame rate.
+ */
+function renderSprite(
+  components: CharacterComponents,
+  bodyIdx: number,
+  eyeIdx: number,
+  colorIdx: number,
+  px: number,
+): HTMLCanvasElement | null {
+  const body = components.bodyShapes[bodyIdx];
+  const eye = components.eyeStyles[eyeIdx];
+  const color = components.colors[colorIdx];
+  if (!body || !eye || !color) {
+    return null;
+  }
+
+  const dpr = Math.min(2, window.devicePixelRatio || 1);
+  const sprite = document.createElement("canvas");
+  sprite.width = Math.max(2, Math.ceil(px * dpr));
+  sprite.height = sprite.width;
+  const ctx = sprite.getContext("2d");
+  if (!ctx) {
+    return null;
+  }
+  ctx.scale(dpr, dpr);
+
+  const bodyBox = body.viewBox;
+  const bodyScale = Math.min(px / bodyBox.width, px / bodyBox.height);
+  const bodyTx = (px - bodyBox.width * bodyScale) / 2;
+  const bodyTy = (px - bodyBox.height * bodyScale) / 2;
+  ctx.save();
+  ctx.translate(bodyTx, bodyTy);
+  ctx.scale(bodyScale, bodyScale);
+  ctx.fillStyle = color.hex;
+  ctx.fill(new Path2D(body.svgPath));
+  ctx.restore();
+
+  const override = components.faceCenterOverrides.find(
+    (o) => o.bodyShape === body.id && o.eyeStyle === eye.id,
+  );
+  const faceCenter = override ? override.faceCenter : body.faceCenter;
+  const eyeBox = eye.sourceViewBox;
+  const remapScale = Math.min(
+    bodyBox.width / eyeBox.width,
+    bodyBox.height / eyeBox.height,
+  );
+  ctx.save();
+  ctx.translate(
+    bodyScale * (faceCenter.x - eye.eyeCenter.x * remapScale) + bodyTx,
+    bodyScale * (faceCenter.y - eye.eyeCenter.y * remapScale) + bodyTy,
+  );
+  ctx.scale(bodyScale * remapScale, bodyScale * remapScale);
+  for (const path of eye.paths) {
+    ctx.fillStyle = path.color;
+    ctx.fill(new Path2D(path.svgPath));
+  }
+  ctx.restore();
+
+  return sprite;
+}
+
+interface AvatarWaveProps {
+  className?: string;
+}
+
+export function AvatarWave({ className = "" }: AvatarWaveProps) {
+  const components = useBundledAvatarComponents();
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || !components) {
+      return;
+    }
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+      return;
+    }
+    const reduce = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
+
+    let width = 0;
+    let height = 0;
+    let items: LiveItem[] = [];
+    let pourStart = 0;
+    let lastFrame = 0;
+    const cursor = { x: 0, y: 0, vx: 0, vy: 0, active: false };
+    let lastMove: { x: number; y: number; t: number } | null = null;
+    const spriteCache = new Map<string, HTMLCanvasElement | null>();
+
+    const spriteFor = (
+      bodyIdx: number,
+      eyeIdx: number,
+      colorIdx: number,
+      px: number,
+    ): HTMLCanvasElement | null => {
+      const bucket =
+        Math.max(1, Math.round(px / SPRITE_SIZE_BUCKET)) * SPRITE_SIZE_BUCKET;
+      const key = `${bodyIdx}-${eyeIdx}-${colorIdx}-${bucket}`;
+      const hit = spriteCache.get(key);
+      if (hit !== undefined) {
+        return hit;
+      }
+      const made = renderSprite(components, bodyIdx, eyeIdx, colorIdx, bucket);
+      spriteCache.set(key, made);
+      return made;
+    };
+
+    const layout = () => {
+      const rect = canvas.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) {
+        return;
+      }
+      if (
+        Math.abs(rect.width - width) < 1 &&
+        Math.abs(rect.height - height) < 1
+      ) {
+        return;
+      }
+      width = rect.width;
+      height = rect.height;
+
+      const dpr = Math.min(2, window.devicePixelRatio || 1);
+      canvas.width = Math.round(width * dpr);
+      canvas.height = Math.round(height * dpr);
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+      // Cover the panel so the ribbon always reaches both edges.
+      const scale = Math.max(width / DESIGN_W, height / DESIGN_H);
+      const offsetX = (width - DESIGN_W * scale) / 2;
+      const offsetY = (height - DESIGN_H * scale) / 2;
+
+      const rng = mulberry32(SEED + 1);
+      let lastColor = -1;
+      let pourDelay = 0;
+      items = buildRibbonWave(RIBBON, SEED, MAX_AVATAR_SIZE).map(
+        (placed): LiveItem => {
+          let colorIdx = Math.floor(rng() * components.colors.length);
+          if (colorIdx === lastColor) {
+            colorIdx = (colorIdx + 1) % components.colors.length;
+          }
+          lastColor = colorIdx;
+          const bodyIdx = Math.floor(rng() * components.bodyShapes.length);
+          const eyeIdx = Math.floor(rng() * components.eyeStyles.length);
+          const px = placed.size * scale;
+          const item: LiveItem = {
+            hx: offsetX + placed.x * scale,
+            hy: offsetY + placed.y * scale,
+            px,
+            rotate: (placed.rotate * Math.PI) / 180,
+            phase: rng() * Math.PI * 2,
+            pourDelay,
+            dx: 0,
+            dy: 0,
+            vx: 0,
+            vy: 0,
+            disturbed: false,
+            flying: false,
+            fade: 1,
+            sprite: spriteFor(bodyIdx, eyeIdx, colorIdx, px),
+          };
+          pourDelay += Math.min(
+            POUR_GAP_MAX_MS,
+            Math.max(POUR_GAP_MIN_MS, POUR_GAP_NUMERATOR / placed.size),
+          );
+          return item;
+        },
+      );
+      if (pourStart === 0) {
+        pourStart = performance.now();
+      }
+    };
+
+    const step = (item: LiveItem, frames: number) => {
+      const posX = item.hx + item.dx;
+      const posY = item.hy + item.dy;
+
+      if (item.flying) {
+        const friction = Math.pow(FLIGHT_FRICTION, frames);
+        item.vx *= friction;
+        item.vy *= friction;
+        item.dx += item.vx * frames;
+        item.dy += item.vy * frames;
+
+        const half = item.px / 2;
+        const minX = half;
+        const maxX = width - half;
+        const minY = half;
+        const maxY = height - half;
+        const cx = item.hx + item.dx;
+        const cy = item.hy + item.dy;
+        if (maxX > minX) {
+          if (cx < minX) {
+            item.dx = minX - item.hx;
+            item.vx = Math.abs(item.vx) * BOUNCE;
+          } else if (cx > maxX) {
+            item.dx = maxX - item.hx;
+            item.vx = -Math.abs(item.vx) * BOUNCE;
+          }
+        }
+        if (maxY > minY) {
+          if (cy < minY) {
+            item.dy = minY - item.hy;
+            item.vy = Math.abs(item.vy) * BOUNCE;
+          } else if (cy > maxY) {
+            item.dy = maxY - item.hy;
+            item.vy = -Math.abs(item.vy) * BOUNCE;
+          }
+        }
+        if (Math.hypot(item.vx, item.vy) < 0.7) {
+          item.flying = false;
+        }
+        return;
+      }
+
+      if (item.disturbed) {
+        // Immune to the cursor until it has settled back home.
+        const damp = Math.pow(DAMP_BACK, frames);
+        item.vx = (item.vx - item.dx * STIFF_BACK * frames) * damp;
+        item.dx += item.vx * frames;
+        item.vy = (item.vy - item.dy * STIFF_BACK * frames) * damp;
+        item.dy += item.vy * frames;
+        if (
+          Math.hypot(item.dx, item.dy) < 2 &&
+          Math.hypot(item.vx, item.vy) < 0.25
+        ) {
+          item.disturbed = false;
+        }
+        return;
+      }
+
+      let targetX = 0;
+      let targetY = 0;
+      if (cursor.active) {
+        const awayX = posX - cursor.x;
+        const awayY = posY - cursor.y;
+        const dist = Math.hypot(awayX, awayY) || 1;
+        if (dist < REPEL_RADIUS) {
+          const falloff = 1 - dist / REPEL_RADIUS;
+          targetX = (awayX / dist) * Math.pow(falloff, 1.4) * REPEL_PUSH;
+          targetY = (awayY / dist) * Math.pow(falloff, 1.4) * REPEL_PUSH;
+          item.vx += cursor.vx * falloff * FLING * frames;
+          item.vy += cursor.vy * falloff * FLING * frames;
+          const speed = Math.hypot(item.vx, item.vy);
+          if (speed > MAX_SPEED) {
+            item.vx = (item.vx / speed) * MAX_SPEED;
+            item.vy = (item.vy / speed) * MAX_SPEED;
+          }
+          if (speed > BALLISTIC_ON) {
+            item.flying = true;
+            item.disturbed = true;
+            return;
+          }
+        }
+      }
+
+      const displacing = targetX !== 0 || targetY !== 0;
+      const stiff = (displacing ? STIFF_HOVER : STIFF_BACK) * frames;
+      const damp = Math.pow(displacing ? DAMP_HOVER : DAMP_BACK, frames);
+      item.vx = (item.vx + (targetX - item.dx) * stiff) * damp;
+      item.dx += item.vx * frames;
+      item.vy = (item.vy + (targetY - item.dy) * stiff) * damp;
+      item.dy += item.vy * frames;
+      if (Math.hypot(item.dx, item.dy) > DISTURB_DIST) {
+        item.disturbed = true;
+      }
+    };
+
+    const draw = (now: number) => {
+      const frames = lastFrame
+        ? Math.min(MAX_FRAME_SCALE, (now - lastFrame) / FRAME_MS)
+        : 1;
+      lastFrame = now;
+      if (!reduce) {
+        // The cursor's velocity only updates on movement, so bleed it off
+        // here; otherwise a pointer that stops inside the field keeps
+        // flinging characters with its last reading forever.
+        const decay = Math.pow(CURSOR_VELOCITY_DECAY, frames);
+        cursor.vx *= decay;
+        cursor.vy *= decay;
+      }
+
+      ctx.clearRect(0, 0, width, height);
+      for (const item of items) {
+        const sprite = item.sprite;
+        if (!sprite) {
+          continue;
+        }
+
+        let revealScale = 1;
+        let revealAlpha = 1;
+        let revealDrop = 0;
+        if (!reduce) {
+          const elapsed = now - pourStart - item.pourDelay;
+          if (elapsed < 0) {
+            continue;
+          }
+          const p = Math.min(1, elapsed / REVEAL_MS);
+          if (p < 1) {
+            const eased =
+              1 + 2.2 * Math.pow(p - 1, 3) + 1.2 * Math.pow(p - 1, 2);
+            revealScale =
+              0.3 + 0.7 * Math.min(1.04, eased + 0.04 * Math.sin(p * Math.PI));
+            revealAlpha = Math.min(1, p * 2.2);
+            revealDrop = (1 - p) * -60;
+          }
+          step(item, frames);
+          const away = Math.hypot(item.dx, item.dy);
+          const targetFade = item.flying ? 0.88 : away > 20 ? 0.92 : 1;
+          item.fade += (targetFade - item.fade) * Math.min(1, 0.08 * frames);
+        }
+
+        const bob = reduce ? 0 : Math.sin(now * 0.001 + item.phase) * 1.4;
+        const wobble = reduce
+          ? 0
+          : Math.sin(now * 0.0008 + item.phase * 2) * 0.025;
+        const size = item.px * revealScale;
+
+        ctx.save();
+        ctx.translate(
+          item.hx + item.dx,
+          item.hy + item.dy + bob + revealDrop,
+        );
+        ctx.rotate(item.rotate + wobble);
+        ctx.globalAlpha = item.fade * revealAlpha;
+        ctx.drawImage(sprite, -size / 2, -size / 2, size, size);
+        ctx.restore();
+      }
+    };
+
+    layout();
+
+    const resizeObserver = new ResizeObserver(() => {
+      layout();
+      if (reduce) {
+        draw(performance.now());
+      }
+    });
+    resizeObserver.observe(canvas);
+
+    let raf = 0;
+    if (reduce) {
+      draw(performance.now());
+    } else {
+      const tick = (now: number) => {
+        draw(now);
+        raf = requestAnimationFrame(tick);
+      };
+      raf = requestAnimationFrame(tick);
+    }
+
+    const setCursor = (clientX: number, clientY: number) => {
+      const now = performance.now();
+      if (lastMove) {
+        const dt = Math.max(1, now - lastMove.t);
+        let vx = cursor.vx * 0.5 + ((clientX - lastMove.x) / dt) * 0.5;
+        let vy = cursor.vy * 0.5 + ((clientY - lastMove.y) / dt) * 0.5;
+        const speed = Math.hypot(vx, vy);
+        if (speed > MAX_CURSOR_SPEED) {
+          vx = (vx / speed) * MAX_CURSOR_SPEED;
+          vy = (vy / speed) * MAX_CURSOR_SPEED;
+        }
+        cursor.vx = vx;
+        cursor.vy = vy;
+      }
+      lastMove = { x: clientX, y: clientY, t: now };
+      const rect = canvas.getBoundingClientRect();
+      cursor.x = clientX - rect.left;
+      cursor.y = clientY - rect.top;
+      cursor.active = true;
+    };
+    const onMove = (e: MouseEvent) => setCursor(e.clientX, e.clientY);
+    const onTouchMove = (e: TouchEvent) => {
+      const touch = e.touches[0];
+      if (touch) {
+        setCursor(touch.clientX, touch.clientY);
+      }
+    };
+    const onLeave = () => {
+      cursor.active = false;
+      cursor.vx = 0;
+      cursor.vy = 0;
+      lastMove = null;
+    };
+
+    if (!reduce) {
+      window.addEventListener("mousemove", onMove, { passive: true });
+      window.addEventListener("mouseout", onLeave);
+      window.addEventListener("touchmove", onTouchMove, { passive: true });
+      window.addEventListener("touchend", onLeave);
+      window.addEventListener("touchcancel", onLeave);
+    }
+
+    return () => {
+      cancelAnimationFrame(raf);
+      resizeObserver.disconnect();
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseout", onLeave);
+      window.removeEventListener("touchmove", onTouchMove);
+      window.removeEventListener("touchend", onLeave);
+      window.removeEventListener("touchcancel", onLeave);
+    };
+  }, [components]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      aria-hidden="true"
+      className={`pointer-events-none block h-full w-full ${className}`}
+    />
+  );
+}

--- a/clients/web/src/domains/onboarding/components/avatar-wave.tsx
+++ b/clients/web/src/domains/onboarding/components/avatar-wave.tsx
@@ -193,11 +193,27 @@ function renderSprite(
   return sprite;
 }
 
+/**
+ * Whether the entrance has already played somewhere in this session. The
+ * wave sits behind a run of screens that each mount their own copy, and
+ * replaying the pour on every step reads as the page restarting rather than
+ * as the same wave carrying through. One pour per visit, then it is simply
+ * there.
+ */
+let hasPlayedEntrance = false;
+
 interface AvatarWaveProps {
   className?: string;
+  /**
+   * Ask for the staggered entrance. Honored only on the first wave to mount
+   * in a session; later ones render settled however they are configured, so
+   * a screen that requests it does not have to know whether the user has
+   * already come past one.
+   */
+  entrance?: boolean;
 }
 
-export function AvatarWave({ className = "" }: AvatarWaveProps) {
+export function AvatarWave({ className = "", entrance = false }: AvatarWaveProps) {
   const components = useBundledAvatarComponents();
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
 
@@ -213,6 +229,10 @@ export function AvatarWave({ className = "" }: AvatarWaveProps) {
     const reduce = window.matchMedia(
       "(prefers-reduced-motion: reduce)",
     ).matches;
+    const pour = entrance && !reduce && !hasPlayedEntrance;
+    if (pour) {
+      hasPlayedEntrance = true;
+    }
 
     let width = 0;
     let height = 0;
@@ -442,18 +462,21 @@ export function AvatarWave({ className = "" }: AvatarWaveProps) {
         let revealAlpha = 1;
         let revealDrop = 0;
         if (!reduce) {
-          const elapsed = now - pourStart - item.pourDelay;
-          if (elapsed < 0) {
-            continue;
-          }
-          const p = Math.min(1, elapsed / REVEAL_MS);
-          if (p < 1) {
-            const eased =
-              1 + 2.2 * Math.pow(p - 1, 3) + 1.2 * Math.pow(p - 1, 2);
-            revealScale =
-              0.3 + 0.7 * Math.min(1.04, eased + 0.04 * Math.sin(p * Math.PI));
-            revealAlpha = Math.min(1, p * 2.2);
-            revealDrop = (1 - p) * -60;
+          if (pour) {
+            const elapsed = now - pourStart - item.pourDelay;
+            if (elapsed < 0) {
+              continue;
+            }
+            const p = Math.min(1, elapsed / REVEAL_MS);
+            if (p < 1) {
+              const eased =
+                1 + 2.2 * Math.pow(p - 1, 3) + 1.2 * Math.pow(p - 1, 2);
+              revealScale =
+                0.3 +
+                0.7 * Math.min(1.04, eased + 0.04 * Math.sin(p * Math.PI));
+              revealAlpha = Math.min(1, p * 2.2);
+              revealDrop = (1 - p) * -60;
+            }
           }
           step(item, frames);
           const away = Math.hypot(item.dx, item.dy);
@@ -551,7 +574,7 @@ export function AvatarWave({ className = "" }: AvatarWaveProps) {
       window.removeEventListener("touchend", onLeave);
       window.removeEventListener("touchcancel", onLeave);
     };
-  }, [components]);
+  }, [components, entrance]);
 
   return (
     <canvas

--- a/clients/web/src/domains/onboarding/components/avatar-wave.tsx
+++ b/clients/web/src/domains/onboarding/components/avatar-wave.tsx
@@ -29,21 +29,38 @@ const DESIGN_H = 900;
 const SEED = 20260807;
 
 /** Keeps the widening tail from producing one absurdly large character. */
-const MAX_AVATAR_SIZE = 190;
+const MAX_AVATAR_SIZE = 165;
 
 /**
- * The ribbon enters cut off by the top edge, bulges toward the outer side,
- * and pours back out through the bottom, growing the whole way.
+ * The ribbon enters cut off by the top edge as a thin thread of small
+ * characters, switches back across the panel three times, and broadens into
+ * a full crowd that pours off the bottom.
+ *
+ * Two ramps do the work, and they are deliberately different. `s` grows
+ * about tenfold from head to tail, which reads as depth. `w` grows about
+ * thirtyfold, and since a row holds `w / s` characters, that difference is
+ * what turns a two-wide thread at the top into a six-wide crowd at the
+ * bottom. Widening the two together would keep the row count flat however
+ * large the characters got.
+ *
+ * The centerline drifts back toward the middle as `w` overtakes the panel,
+ * so the broad rows bleed off the outer edge rather than being sliced by
+ * the inner one.
  */
 const RIBBON: RibbonPoint[] = [
-  { x: 140, y: -60, w: 100, s: 40 },
-  { x: 270, y: 80, w: 130, s: 54 },
-  { x: 400, y: 230, w: 160, s: 70 },
-  { x: 460, y: 400, w: 190, s: 88 },
-  { x: 420, y: 570, w: 220, s: 108 },
-  { x: 310, y: 720, w: 250, s: 128 },
-  { x: 200, y: 860, w: 275, s: 148 },
-  { x: 150, y: 990, w: 300, s: 168 },
+  { x: 330, y: -70, w: 26, s: 13 },
+  { x: 420, y: 20, w: 40, s: 18 },
+  { x: 482, y: 115, w: 62, s: 25 },
+  { x: 458, y: 215, w: 96, s: 34 },
+  { x: 368, y: 298, w: 140, s: 45 },
+  { x: 258, y: 372, w: 196, s: 57 },
+  { x: 208, y: 462, w: 262, s: 70 },
+  { x: 262, y: 556, w: 340, s: 84 },
+  { x: 352, y: 642, w: 430, s: 98 },
+  { x: 372, y: 730, w: 530, s: 112 },
+  { x: 340, y: 822, w: 620, s: 124 },
+  { x: 360, y: 912, w: 700, s: 132 },
+  { x: 380, y: 1002, w: 760, s: 140 },
 ];
 
 const REPEL_RADIUS = 170;
@@ -66,13 +83,17 @@ const MAX_CURSOR_SPEED = 8;
 
 const REVEAL_MS = 550;
 /**
- * Gap between one character's entrance and the next. Derived from size so
- * the small characters at the head of the ribbon pour in quickly and the
- * large ones at the tail arrive with a beat between them.
+ * Relative gap between one character's entrance and the next: small ones at
+ * the head of the ribbon follow each other quickly, large ones at the tail
+ * arrive with a beat between them. These are weights, not milliseconds —
+ * they are normalized to {@link POUR_TOTAL_MS} so that reshaping the ribbon
+ * changes the wave's look without changing how long it takes to arrive.
  */
-const POUR_GAP_MIN_MS = 12;
-const POUR_GAP_MAX_MS = 55;
+const POUR_GAP_MIN = 12;
+const POUR_GAP_MAX = 55;
 const POUR_GAP_NUMERATOR = 1900;
+/** How long the whole crowd takes to finish pouring in. */
+const POUR_TOTAL_MS = 1600;
 
 /**
  * The simulation is tuned in 60fps frames, so every integration step scales
@@ -239,15 +260,34 @@ export function AvatarWave({ className = "" }: AvatarWaveProps) {
       canvas.height = Math.round(height * dpr);
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
 
-      // Cover the panel so the ribbon always reaches both edges.
+      // Cover the panel so the ribbon always reaches every edge. Covering
+      // means the design is at least as wide as the panel, so there is
+      // always horizontal overflow to place. Pin it to the inner edge and
+      // let all of that overflow run off the outer one: this panel sits
+      // flush against the side of the window, so overflow there leaves the
+      // screen, while overflow at the inner edge would slice the crowd in
+      // half along the boundary with the content beside it.
+      const offsetX = 0;
       const scale = Math.max(width / DESIGN_W, height / DESIGN_H);
-      const offsetX = (width - DESIGN_W * scale) / 2;
       const offsetY = (height - DESIGN_H * scale) / 2;
+
+      const placements = buildRibbonWave(RIBBON, SEED, MAX_AVATAR_SIZE);
+
+      // Normalize the size-weighted stagger to a fixed total so the crowd
+      // always finishes arriving at the same moment, however many characters
+      // the ribbon happens to pack.
+      const gapWeight = (size: number) =>
+        Math.min(POUR_GAP_MAX, Math.max(POUR_GAP_MIN, POUR_GAP_NUMERATOR / size));
+      const weightTotal = placements.reduce(
+        (sum, placed) => sum + gapWeight(placed.size),
+        0,
+      );
+      const pourRate = weightTotal > 0 ? POUR_TOTAL_MS / weightTotal : 0;
 
       const rng = mulberry32(SEED + 1);
       let lastColor = -1;
       let pourDelay = 0;
-      items = buildRibbonWave(RIBBON, SEED, MAX_AVATAR_SIZE).map(
+      items = placements.map(
         (placed): LiveItem => {
           let colorIdx = Math.floor(rng() * components.colors.length);
           if (colorIdx === lastColor) {
@@ -273,10 +313,7 @@ export function AvatarWave({ className = "" }: AvatarWaveProps) {
             fade: 1,
             sprite: spriteFor(bodyIdx, eyeIdx, colorIdx, px),
           };
-          pourDelay += Math.min(
-            POUR_GAP_MAX_MS,
-            Math.max(POUR_GAP_MIN_MS, POUR_GAP_NUMERATOR / placed.size),
-          );
+          pourDelay += gapWeight(placed.size) * pourRate;
           return item;
         },
       );

--- a/clients/web/src/domains/onboarding/components/onboarding-layout.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-layout.tsx
@@ -2,6 +2,7 @@ import { useState, type ReactNode } from "react";
 
 import { PortalContainerProvider } from "@vellumai/design-library/utils/portal-container";
 import { useIsMobile } from "@/hooks/use-is-mobile";
+import { isElectron } from "@/runtime/is-electron";
 import { AvatarWave } from "./avatar-wave";
 import { CreatureFooter } from "./creature-footer";
 
@@ -49,7 +50,10 @@ export function OnboardingLayout({
   // `hidden md:block` class) keeps the wave's canvas and its animation loop
   // from mounting at all on the layout that would not show them.
   const isMobile = useIsMobile();
-  const withWave = showAvatarWave && !isMobile;
+  // The desktop shell runs its own compact, top-aligned onboarding flow in a
+  // window narrow enough that surrendering half of it to decoration would
+  // crowd the step content.
+  const withWave = showAvatarWave && !isMobile && !isElectron();
 
   const content = (
     <div className="flex-1 overflow-y-auto">

--- a/clients/web/src/domains/onboarding/components/onboarding-layout.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-layout.tsx
@@ -27,6 +27,7 @@ export function OnboardingLayout({
   children,
   showCreatureFooter = true,
   showAvatarWave = false,
+  animateAvatarWaveIn = false,
 }: {
   children: ReactNode;
   /**
@@ -42,6 +43,14 @@ export function OnboardingLayout({
    * rather than surrendering half the screen to decoration.
    */
   showAvatarWave?: boolean;
+  /**
+   * Ask the wave to play its entrance rather than appear settled. Reserved
+   * for the screen a visit starts on: the wave spans a run of screens that
+   * each mount their own copy, and pouring it in again at every step reads
+   * as the page restarting. Ignored without `showAvatarWave`, and the wave
+   * itself plays the entrance at most once per session.
+   */
+  animateAvatarWaveIn?: boolean;
 }) {
   const [portalContainer, setPortalContainer] = useState<HTMLElement | null>(
     null,
@@ -69,7 +78,7 @@ export function OnboardingLayout({
         <div className="flex min-h-0 flex-1">
           {content}
           <div className="relative w-[46%] lg:w-1/2">
-            <AvatarWave className="absolute inset-0" />
+            <AvatarWave className="absolute inset-0" entrance={animateAvatarWaveIn} />
           </div>
         </div>
       ) : (

--- a/clients/web/src/domains/onboarding/components/onboarding-layout.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-layout.tsx
@@ -1,6 +1,8 @@
 import { useState, type ReactNode } from "react";
 
 import { PortalContainerProvider } from "@vellumai/design-library/utils/portal-container";
+import { useIsMobile } from "@/hooks/use-is-mobile";
+import { AvatarWave } from "./avatar-wave";
 import { CreatureFooter } from "./creature-footer";
 
 /**
@@ -23,6 +25,7 @@ import { CreatureFooter } from "./creature-footer";
 export function OnboardingLayout({
   children,
   showCreatureFooter = true,
+  showAvatarWave = false,
 }: {
   children: ReactNode;
   /**
@@ -31,19 +34,44 @@ export function OnboardingLayout({
    * steps pass `false` for a cleaner, footer-free layout.
    */
   showCreatureFooter?: boolean;
+  /**
+   * Whether to seat the content beside the live avatar wave. The wave needs
+   * a column of its own, so it is only offered from the `md` breakpoint up;
+   * narrower viewports keep the single-column layout and the creature footer
+   * rather than surrendering half the screen to decoration.
+   */
+  showAvatarWave?: boolean;
 }) {
   const [portalContainer, setPortalContainer] = useState<HTMLElement | null>(
     null,
   );
+  // Matches the `md` breakpoint. Gating in render (rather than with a
+  // `hidden md:block` class) keeps the wave's canvas and its animation loop
+  // from mounting at all on the layout that would not show them.
+  const isMobile = useIsMobile();
+  const withWave = showAvatarWave && !isMobile;
+
+  const content = (
+    <div className="flex-1 overflow-y-auto">
+      <PortalContainerProvider container={portalContainer}>
+        {children}
+      </PortalContainerProvider>
+    </div>
+  );
 
   return (
     <div className="relative flex h-full flex-col bg-[var(--surface-base)]">
-      <div className="flex-1 overflow-y-auto">
-        <PortalContainerProvider container={portalContainer}>
-          {children}
-        </PortalContainerProvider>
-      </div>
-      {showCreatureFooter && <CreatureFooter />}
+      {withWave ? (
+        <div className="flex min-h-0 flex-1">
+          {content}
+          <div className="relative w-[46%] lg:w-1/2">
+            <AvatarWave className="absolute inset-0" />
+          </div>
+        </div>
+      ) : (
+        content
+      )}
+      {showCreatureFooter && !withWave && <CreatureFooter />}
       <div ref={setPortalContainer} />
     </div>
   );

--- a/clients/web/src/domains/onboarding/pages/api-key-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/api-key-screen.tsx
@@ -88,7 +88,7 @@ export function ApiKeyScreen() {
   };
 
   return (
-    <OnboardingLayout>
+    <OnboardingLayout showAvatarWave>
       <div
         className={`mx-auto flex w-full max-w-xl flex-col items-center ${electron ? "min-h-full px-8 pt-21 pb-4 electron-prechat-type" : "px-6 py-16"} text-[var(--content-default)]`}
       >

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -760,10 +760,10 @@ export function HatchingScreen() {
 
   if (error) {
     return (
-      <OnboardingLayout>
+      <OnboardingLayout showAvatarWave>
         <div
           role="alert"
-          className={`mx-auto flex w-full max-w-xl flex-col items-center ${electron ? "min-h-full px-8 pt-21 pb-28 electron-prechat-type" : "min-h-screen justify-center px-6 pb-40"} text-center text-[var(--content-default)]`}
+          className={`mx-auto flex w-full max-w-xl flex-col items-center ${electron ? "min-h-full px-8 pt-21 pb-28 electron-prechat-type" : "min-h-screen justify-center px-6 pb-40 md:min-h-full md:pb-6"} text-center text-[var(--content-default)]`}
         >
           <h1
             className={
@@ -869,7 +869,7 @@ export function HatchingScreen() {
   }
 
   return (
-    <OnboardingLayout>
+    <OnboardingLayout showAvatarWave>
       {/* Electron layout: title pinned 84px from the window top (the shared
           step-title position), the creature centered in the leftover space via
           auto margins, and the progress section near the bottom — pb-28 keeps
@@ -877,7 +877,7 @@ export function HatchingScreen() {
           bar caps at 200px with a 10px label. Web/iOS keep the centered
           layout. */}
       <div
-        className={`mx-auto flex w-full max-w-xl flex-col items-center ${electron ? "min-h-full px-8 pt-21 pb-28 electron-prechat-type" : "min-h-screen justify-center px-6 pb-40"} text-center text-[var(--content-default)]`}
+        className={`mx-auto flex w-full max-w-xl flex-col items-center ${electron ? "min-h-full px-8 pt-21 pb-28 electron-prechat-type" : "min-h-screen justify-center px-6 pb-40 md:min-h-full md:pb-6"} text-center text-[var(--content-default)]`}
       >
         <h1
           className={

--- a/clients/web/src/domains/onboarding/pages/hosting-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hosting-screen.tsx
@@ -113,9 +113,9 @@ export function HostingScreen() {
   };
 
   return (
-    <OnboardingLayout>
+    <OnboardingLayout showAvatarWave>
       <div
-        className={`mx-auto flex w-full max-w-xl flex-col items-center ${electron ? "min-h-full px-8 pt-21 pb-4 electron-prechat-type" : "min-h-screen px-6 pb-40 pt-6"} text-[var(--content-default)]`}
+        className={`mx-auto flex w-full max-w-xl flex-col items-center ${electron ? "min-h-full px-8 pt-21 pb-4 electron-prechat-type" : "min-h-screen px-6 pb-40 pt-6 md:min-h-full md:pb-6"} text-[var(--content-default)]`}
       >
         {/* The main block floats in the space above the creature footer;
             electron keeps its compact top-aligned flow. */}

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -160,7 +160,7 @@ export function PrivacyScreen() {
   ]);
 
   return (
-    <OnboardingLayout>
+    <OnboardingLayout showAvatarWave>
       <div
         className={`mx-auto flex w-full max-w-xl flex-col items-center ${electron ? "min-h-full px-8 pt-21 pb-4 electron-prechat-type" : "px-6 py-16"} text-[var(--content-default)]`}
       >

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -904,7 +904,7 @@ export function SelectAssistantScreen() {
 /** Full-screen "Connecting…" hold shown while a decision or connect lands. */
 function ConnectingHold() {
   return (
-    <OnboardingLayout>
+    <OnboardingLayout showAvatarWave>
       <div className="mx-auto flex min-h-screen w-full max-w-xl flex-col items-center justify-center px-6 text-[var(--content-default)]">
         <p className="text-body-medium-lighter text-[var(--content-tertiary)]">
           Connecting to your assistant…

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -672,9 +672,9 @@ export function SelectAssistantScreen() {
   }
 
   return (
-    <OnboardingLayout>
+    <OnboardingLayout showAvatarWave>
       <div
-        className={`mx-auto flex w-full max-w-xl flex-col items-center ${electron ? "min-h-full px-8 pt-21 pb-4 electron-prechat-type" : "min-h-screen px-6 pb-40 pt-6"} text-[var(--content-default)]`}
+        className={`mx-auto flex w-full max-w-xl flex-col items-center ${electron ? "min-h-full px-8 pt-21 pb-4 electron-prechat-type" : "min-h-screen px-6 pb-40 pt-6 md:min-h-full md:pb-6"} text-[var(--content-default)]`}
       >
         {/* The main block floats in the space above the creature footer;
             electron keeps its compact top-aligned flow. */}
@@ -682,7 +682,7 @@ export function SelectAssistantScreen() {
           className={`flex w-full flex-col items-center ${electron ? "" : "flex-1 justify-center"}`}
         >
         <h1
-          className="text-center text-5xl font-normal tracking-tight"
+          className="text-center text-5xl font-normal tracking-tight md:text-4xl lg:text-5xl"
           style={{
             fontFamily: "var(--font-serif)",
             animation: "fadeInUp 0.5s ease-out 0.1s both",

--- a/clients/web/src/domains/onboarding/pages/start-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/start-screen.tsx
@@ -23,8 +23,8 @@ export function StartScreen() {
   const navigate = useNavigate();
 
   return (
-    <OnboardingLayout>
-      <div className="mx-auto flex min-h-screen w-full max-w-xl flex-col items-center px-6 pb-40 text-[var(--content-default)]">
+    <OnboardingLayout showAvatarWave>
+      <div className="mx-auto flex min-h-screen w-full max-w-xl flex-col items-center px-6 pb-40 md:min-h-full md:pb-6 text-[var(--content-default)]">
         <div className="flex flex-1 flex-col items-center justify-center">
           <h1
             className="text-3xl font-semibold tracking-tight"

--- a/clients/web/src/domains/onboarding/pages/welcome-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/welcome-screen.tsx
@@ -1,6 +1,9 @@
 import { useNavigate } from "react-router";
 
+import { AvatarWave } from "@/domains/onboarding/components/avatar-wave";
+import { CreatureFooter } from "@/domains/onboarding/components/creature-footer";
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useOnboardingLogin } from "@/hooks/use-onboarding-login";
 import { hasAssistants } from "@/lib/local-mode";
 import { routes } from "@/utils/routes";
@@ -9,6 +12,10 @@ import { Button } from "@vellumai/design-library/components/button";
 export function WelcomeScreen() {
   const navigate = useNavigate();
   const { loading, error, login, cancel } = useOnboardingLogin();
+  // `useIsMobile` tracks the same 768px boundary as the `md:` variants below,
+  // so the wave's canvas and its animation loop never mount on the narrow
+  // layout that hides it.
+  const isMobile = useIsMobile();
 
   const handleContinueWithoutAccount = () => {
     if (loading) {
@@ -22,11 +29,16 @@ export function WelcomeScreen() {
   };
 
   return (
-    <OnboardingLayout>
-      <div className="mx-auto flex min-h-screen w-full max-w-xl flex-col items-center px-6 pb-40 text-[var(--content-default)]">
-        <div className="flex flex-1 flex-col items-center justify-center">
+    <OnboardingLayout showCreatureFooter={false}>
+      <div className="flex min-h-full w-full flex-col md:flex-row">
+        <div className="flex min-h-screen w-full flex-col items-center justify-center px-6 pb-40 text-[var(--content-default)] md:min-h-full md:flex-1 md:pb-0">
+          {/*
+            Only the tablet split is tight enough to wrap the heading: the
+            column is widest on the single-column layout, and wide again once
+            the wave settles at half width.
+          */}
           <h1
-            className="text-5xl font-normal tracking-tight"
+            className="text-5xl font-normal tracking-tight md:text-4xl lg:text-5xl"
             style={{
               fontFamily: "var(--font-serif)",
               animation: "fadeInUp 0.5s ease-out 0.1s both",
@@ -71,7 +83,19 @@ export function WelcomeScreen() {
             </Button>
           </div>
         </div>
+
+        {!isMobile && (
+          <div className="relative hidden md:block md:w-[46%] lg:w-1/2">
+            <AvatarWave className="absolute inset-0" />
+          </div>
+        )}
       </div>
+
+      {/*
+        The wave is the decoration on the wide layout, so the static creature
+        art is kept for the narrow one only, where the wave never mounts.
+      */}
+      <CreatureFooter className="md:hidden" />
     </OnboardingLayout>
   );
 }

--- a/clients/web/src/domains/onboarding/pages/welcome-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/welcome-screen.tsx
@@ -22,7 +22,7 @@ export function WelcomeScreen() {
   };
 
   return (
-    <OnboardingLayout showAvatarWave>
+    <OnboardingLayout showAvatarWave animateAvatarWaveIn>
       <div className="mx-auto flex min-h-full w-full max-w-xl flex-col items-center px-6 pb-40 text-[var(--content-default)] md:pb-0">
         <div className="flex flex-1 flex-col items-center justify-center">
           {/*

--- a/clients/web/src/domains/onboarding/pages/welcome-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/welcome-screen.tsx
@@ -1,9 +1,6 @@
 import { useNavigate } from "react-router";
 
-import { AvatarWave } from "@/domains/onboarding/components/avatar-wave";
-import { CreatureFooter } from "@/domains/onboarding/components/creature-footer";
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
-import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useOnboardingLogin } from "@/hooks/use-onboarding-login";
 import { hasAssistants } from "@/lib/local-mode";
 import { routes } from "@/utils/routes";
@@ -12,10 +9,6 @@ import { Button } from "@vellumai/design-library/components/button";
 export function WelcomeScreen() {
   const navigate = useNavigate();
   const { loading, error, login, cancel } = useOnboardingLogin();
-  // `useIsMobile` tracks the same 768px boundary as the `md:` variants below,
-  // so the wave's canvas and its animation loop never mount on the narrow
-  // layout that hides it.
-  const isMobile = useIsMobile();
 
   const handleContinueWithoutAccount = () => {
     if (loading) {
@@ -29,9 +22,9 @@ export function WelcomeScreen() {
   };
 
   return (
-    <OnboardingLayout showCreatureFooter={false}>
-      <div className="flex min-h-full w-full flex-col md:flex-row">
-        <div className="flex min-h-screen w-full flex-col items-center justify-center px-6 pb-40 text-[var(--content-default)] md:min-h-full md:flex-1 md:pb-0">
+    <OnboardingLayout showAvatarWave>
+      <div className="mx-auto flex min-h-full w-full max-w-xl flex-col items-center px-6 pb-40 text-[var(--content-default)] md:pb-0">
+        <div className="flex flex-1 flex-col items-center justify-center">
           {/*
             Only the tablet split is tight enough to wrap the heading: the
             column is widest on the single-column layout, and wide again once
@@ -83,19 +76,7 @@ export function WelcomeScreen() {
             </Button>
           </div>
         </div>
-
-        {!isMobile && (
-          <div className="relative hidden md:block md:w-[46%] lg:w-1/2">
-            <AvatarWave className="absolute inset-0" />
-          </div>
-        )}
       </div>
-
-      {/*
-        The wave is the decoration on the wide layout, so the static creature
-        art is kept for the narrow one only, where the wave never mounts.
-      */}
-      <CreatureFooter className="md:hidden" />
     </OnboardingLayout>
   );
 }

--- a/clients/web/src/domains/onboarding/pages/welcome-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/welcome-screen.tsx
@@ -31,7 +31,7 @@ export function WelcomeScreen() {
             the wave settles at half width.
           */}
           <h1
-            className="text-5xl font-normal tracking-tight md:text-4xl lg:text-5xl"
+            className="text-5xl font-normal tracking-tight md:text-4xl lg:text-5xl xl:text-6xl"
             style={{
               fontFamily: "var(--font-serif)",
               animation: "fadeInUp 0.5s ease-out 0.1s both",
@@ -40,7 +40,7 @@ export function WelcomeScreen() {
             Welcome to Vellum
           </h1>
           <p
-            className="mt-3 text-body-medium-lighter text-[var(--content-tertiary)]"
+            className="mt-3 text-body-large-lighter text-[var(--content-tertiary)]"
             style={{ animation: "fadeInUp 0.5s ease-out 0.3s both" }}
           >
             Your own personal intelligence is just a step away.


### PR DESCRIPTION
The sign-in screen was an empty field with a heading and two buttons. This puts the marketing homepage's avatar wave beside it and carries it through the whole create-assistant flow.

A crowd of characters flows down a ribbon on one canvas, simulated per frame: they lean away from the cursor, a quick swipe knocks nearby ones loose to sail off and bounce around, and everything springs back home once it settles. The step content sits in the column to its left.

## What is new

- `domains/onboarding/avatar-wave-ribbon.ts` — the ribbon layout walker and its seeded PRNG. Pure, deterministic, unit-tested.
- `domains/onboarding/components/avatar-wave.tsx` — the canvas, the simulation, and the entrance pour.
- `OnboardingLayout` grows `showAvatarWave` and `animateAvatarWaveIn`. Screens that do not opt in render exactly the DOM they did before, since the extra flex row only appears on the wave path.

## Which screens

Every branded onboarding screen: welcome, the assistant picker, start, privacy, hosting, api-key, hatching, and the connecting hold. The rule is the one the layout already implied, since the wave stands in for the creature art — screens that show the creature footer show the wave instead. The three prechat steps that deliberately run footer-free are untouched.

The entrance plays **once per visit**, not once per screen. Only the welcome screen asks for it, and the wave refuses to replay it once it has run anywhere in the session, so re-entering the flow or landing on a later screen never re-pours.

## Porting notes

The wave comes from the v2 homepage variation in `vellum-assistant-platform`, reduced to a single fixed-size container: no scroll story, no `data-wave-region` system, no page coordinates. It reads `BUNDLED_COMPONENTS`, the character catalog this app already ships, so it adds no new data and no new dependency.

Three things were fixed on the way over, all of which are live bugs in the marketing original and worth backporting:

1. **Frame-rate dependence.** The integrator advanced by `v` per frame with no delta, so springs and flights ran at double speed on a 120Hz display. Every step now scales by real frame time, capped so a backgrounded tab resumes instead of teleporting.
2. **Sprite churn.** Every character was re-rasterized from its SVG paths on each resize. Sprites are now cached by trait and size bucket.
3. **Sticky cursor velocity.** Cursor velocity only updated on `mousemove` and was never decayed, so a pointer that stopped inside the field kept flinging characters with its last reading forever. It now bleeds off per frame.

## The ribbon

Two ramps drive the shape and they deliberately diverge: avatar size grows about tenfold head to tail (reads as depth), while the band width grows about thirtyfold. Since a row holds `w / s` characters, that difference turns a two-wide thread at the top into a six-wide crowd at the bottom. Growing them together — the obvious thing — keeps the row count flat however large the characters get.

The design is pinned to the panel's inner edge rather than centered. Covering always leaves horizontal overflow; the panel sits flush against the window edge, so overflow there leaves the screen, whereas centering sliced the crowd along the boundary with the content beside it.

## Design system

No new primitive. Buttons, tokens, and typography are unchanged — this adds a decorative canvas beside existing content, which the design library has no equivalent for. Per `clients/web/AGENTS.md` that choice is called out here.

## Where the wave does not render

- **Below 768px** the canvas and its animation loop never mount (gated on `useIsMobile()`, which tracks the same boundary as the `md:` variants) and the existing static creature footer stands as it does today.
- **In the Electron shell**, whose onboarding runs a compact top-aligned flow in a window narrow enough that giving up half of it would crowd the step content.
- **Under reduced motion** it paints one settled frame and starts no loop.

## Verification

Typecheck and lint clean. `bun test src/domains/onboarding/` shows the same 29 pre-existing failures as `main` (a `loadLockfile` export error unrelated to this change); the new ribbon tests and the existing suites pass.

Checked in headless Chromium against the dev server. All six routable screens at 390 / 768 / 1440 px: wave present and footer hidden at the two wider sizes, no canvas mounted and footer shown at 390. Every heading fits on one line except "Connect a Model Provider" at 390px, which wraps to two — pre-existing, mobile is untouched.

Entrance behavior, measured as painted-canvas coverage:

| | first paint | +500ms | settled |
|---|---|---|---|
| welcome, fresh session | 0.001 | 0.041 | 0.410 |
| next screen, same session | 0.410 | 0.410 | 0.410 |
| hosting, fresh session | 0.410 | 0.410 | 0.410 |

Also confirmed a cursor sweep visibly disturbs the field and that it settles back afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)