### PR TITLE
fix(voice): language-plumbing consolidation from plan review

### DIFF
--- a/assistant/src/calls/call-speech-output.ts
+++ b/assistant/src/calls/call-speech-output.ts
@@ -30,7 +30,6 @@ import {
   resolveCallTtsProvider,
   resolveSynthesisFormats,
 } from "./resolve-call-tts-provider.js";
-import { resolveTelephonySynthesisLanguage } from "./telephony-synthesis-language.js";
 
 const log = getLogger("call-speech-output");
 
@@ -129,15 +128,16 @@ async function synthesizeAndPlay(
       },
     });
 
-    // No STT session is reachable from the deterministic prompt path, so
-    // only the pin-based language resolves here.
-    const language = resolveTelephonySynthesisLanguage();
+    // No language hint: this path speaks fixed English copy (verification
+    // codes, guardian prompts), so a pin-based hint would tell an
+    // enforcing provider to render English text in the pinned language.
+    // Conversational synthesis (call-controller, media-stream-output)
+    // carries the hint instead.
     const result = await synthesizeAndEmit({
       provider,
       text,
       useCase: "phone-call",
       outputFormat,
-      ...(language !== undefined ? { language } : {}),
       signal,
       onChunk: sink.onChunk,
       onFirstAudio: sink.onFirstAudio,

--- a/assistant/src/calls/telephony-synthesis-language.ts
+++ b/assistant/src/calls/telephony-synthesis-language.ts
@@ -12,9 +12,8 @@
  */
 
 import { getConfig } from "../config/loader.js";
-import { getProviderEntry } from "../providers/speech-to-text/provider-catalog.js";
-import { normalizeLanguageTag } from "../stt/language-metadata.js";
-import type { SttProviderId } from "../stt/types.js";
+import { pinnedListeningLanguage } from "../providers/speech-to-text/provider-catalog.js";
+import { baseLanguageSubtag } from "../util/language-subtag.js";
 
 /**
  * Resolve the language hint for telephony synthesis as a lowercase base
@@ -27,11 +26,9 @@ import type { SttProviderId } from "../stt/types.js";
 export function resolveTelephonySynthesisLanguage(
   detectedLanguage?: string,
 ): string | undefined {
-  if (detectedLanguage !== undefined) {
-    const normalized = normalizeLanguageTag(detectedLanguage);
-    if (normalized) {
-      return normalized;
-    }
+  const detected = baseLanguageSubtag(detectedLanguage);
+  if (detected !== undefined) {
+    return detected;
   }
 
   let stt: { provider: string; language?: string };
@@ -42,18 +39,5 @@ export function resolveTelephonySynthesisLanguage(
     return undefined;
   }
 
-  // A persisted pin only counts when the configured provider honors manual
-  // language selection: auto-detecting providers (gemini, whisper) ignore
-  // the setting entirely, so treating it as the caller's language would
-  // force every call into a stale pin. Same gate as the pre-speech prompt
-  // rule (voice-session-bridge.ts) and live voice's turnLanguageFor.
-  const providerHonorsLanguagePin =
-    getProviderEntry(stt.provider as SttProviderId)?.languageSelection ===
-    "manual";
-  const configured = stt.language?.trim();
-  if (!providerHonorsLanguagePin || !configured || configured === "multi") {
-    return undefined;
-  }
-  const normalized = normalizeLanguageTag(configured);
-  return normalized || undefined;
+  return pinnedListeningLanguage(stt.provider, stt.language);
 }

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -34,14 +34,13 @@ import {
   recordConversationPersistedSeq,
   updateMessageContent,
 } from "../persistence/conversation-crud.js";
-import { getProviderEntry } from "../providers/speech-to-text/provider-catalog.js";
+import { pinnedListeningLanguage } from "../providers/speech-to-text/provider-catalog.js";
 import type { ContentBlock } from "../providers/types.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getCurrentSeq } from "../runtime/assistant-stream-state.js";
 import { publishConversationMessagesChanged } from "../runtime/sync/resource-sync-events.js";
 import { computeToolApprovalDigest } from "../security/tool-approval-digest.js";
-import type { SttProviderId } from "../stt/types.js";
 import { getAllTools } from "../tools/registry.js";
 import { sensitiveToolReach } from "../tools/tool-approval-handler.js";
 import { createAbortReason } from "../util/abort-reasons.js";
@@ -440,25 +439,19 @@ export const VOICE_NO_SETUP_FLOWS_RULE =
  * media-stream-stt-session.ts and providers/speech-to-text/resolve.ts), so it
  * outranks the English default; "multi" and unset mean auto-detect, where
  * English remains the fallback. The pin only counts when the active provider
- * honors manual language selection: auto-detecting providers (gemini,
- * whisper) ignore a persisted language entirely, so greeting in it would
- * contradict what the transcriber actually hears. Exported for tests: the
- * default test config exercises only the auto-detect branch.
+ * honors manual language selection (see pinnedListeningLanguage):
+ * auto-detecting providers (gemini, whisper) ignore a persisted language
+ * entirely, so greeting in it would contradict what the transcriber
+ * actually hears. Exported for tests: the default test config exercises
+ * only the auto-detect branch.
  */
 export function preSpeechLanguageRuleFragment(
   sttLanguage: string | undefined,
   sttProvider?: string,
 ): string {
-  const providerHonorsLanguagePin =
-    sttProvider !== undefined &&
-    getProviderEntry(sttProvider as SttProviderId)?.languageSelection ===
-      "manual";
   const configuredListeningLanguage =
-    providerHonorsLanguagePin &&
-    sttLanguage &&
-    sttLanguage.trim() !== "" &&
-    sttLanguage.trim() !== "multi"
-      ? sttLanguage.trim()
+    sttProvider !== undefined
+      ? pinnedListeningLanguage(sttProvider, sttLanguage)
       : undefined;
   return configuredListeningLanguage
     ? `use the language the Task context implies, if any; otherwise open in the assistant's configured listening language ("${configuredListeningLanguage}"), and default to English only when neither gives a language`

--- a/assistant/src/calls/voice-triage-escalate.ts
+++ b/assistant/src/calls/voice-triage-escalate.ts
@@ -26,7 +26,8 @@
  * cap/fallback policy. LiveVoiceSession drives the routing.
  */
 
-import { baseLanguageSubtag } from "../util/language-subtag.js";
+import { NON_LATIN_SENTENCE_ENDING_PUNCTUATION } from "../tts/speakable-segments.js";
+import { localizedOrDefault } from "../util/language-subtag.js";
 import {
   ESCALATE_VERDICT_TOKEN,
   HOLD_VERDICT_TOKEN,
@@ -86,11 +87,10 @@ export const FALLBACK_ESCALATION_BRIDGE_BY_LANGUAGE: Readonly<
  * {@link FALLBACK_ESCALATION_BRIDGE} for unknown or absent languages.
  */
 export function fallbackEscalationBridgeFor(language?: string): string {
-  const base = baseLanguageSubtag(language);
-  return (
-    (base !== undefined
-      ? FALLBACK_ESCALATION_BRIDGE_BY_LANGUAGE[base]
-      : undefined) ?? FALLBACK_ESCALATION_BRIDGE
+  return localizedOrDefault(
+    FALLBACK_ESCALATION_BRIDGE_BY_LANGUAGE,
+    language,
+    FALLBACK_ESCALATION_BRIDGE,
   );
 }
 
@@ -109,12 +109,16 @@ export const MIN_SPOKEN_BRIDGE_CHARS = 3;
 export const MAX_ESCALATION_BRIDGE_CHARS = 140;
 
 /**
- * Sentence terminators that end an escalation bridge, including the
- * non-Latin enders the localized bridges use (the set mirrors
- * tts/speakable-segments.ts). Without them a Japanese or Hindi bridge never
- * hits a terminator and buffers to the char cap before hand-off.
+ * Sentence terminators that end an escalation bridge: the segmenter's
+ * non-Latin ender roster (tts/speakable-segments.ts) plus the ASCII enders
+ * and the ellipsis. Built from the shared set so the rosters cannot
+ * diverge: without the non-Latin enders a Japanese or Hindi bridge never
+ * hits a terminator and buffers to the char cap before hand-off. Exported
+ * for tests that assert spoken phrases end in a recognized terminator.
  */
-const BRIDGE_SENTENCE_END_REGEX = /[.!?…。｡！？．।॥؟۔]/;
+export const BRIDGE_SENTENCE_END_REGEX = new RegExp(
+  `[.!?…${[...NON_LATIN_SENTENCE_ENDING_PUNCTUATION].join("")}]`,
+);
 
 /**
  * Normalize a raw post-`[1]` stream into the bridge that is actually

--- a/assistant/src/config/schemas/tts.ts
+++ b/assistant/src/config/schemas/tts.ts
@@ -44,7 +44,7 @@ function languageVoicesSchema(providerId: string, valuesDescription: string) {
     .transform((map) => {
       const normalized = new Map<string, string>();
       for (const [key, voice] of Object.entries(map)) {
-        const subtag = baseLanguageSubtag(key)?.trim();
+        const subtag = baseLanguageSubtag(key);
         if (!subtag || normalized.has(subtag)) {
           continue;
         }

--- a/assistant/src/live-voice/__tests__/progress-phrases.test.ts
+++ b/assistant/src/live-voice/__tests__/progress-phrases.test.ts
@@ -1,22 +1,33 @@
 /**
- * Tests for the static progress-phrase fallback tables: full coverage of the
- * Deepgram code-switching roster, the per-phrase invariants (persona-neutral
- * floor-holders, at most 8 words where word-counting makes sense), and the
- * language-aware selection in `pickProgressPhrase` with its English default.
+ * Tests for the static spoken-phrase tables (progress fallbacks and the
+ * approval-pending phrase): full coverage of the Deepgram code-switching
+ * roster, the per-phrase invariants (persona-neutral floor-holders, word
+ * or length budgets, a recognized sentence terminator), and the
+ * language-aware selection with its English default.
  */
 
 import { describe, expect, test } from "bun:test";
 
+import { BRIDGE_SENTENCE_END_REGEX } from "../../calls/voice-triage-escalate.js";
 import { DEEPGRAM_MULTI_LANGUAGE_CODES } from "../../providers/speech-to-text/deepgram.js";
 import {
+  APPROVAL_PENDING_PHRASE,
+  APPROVAL_PENDING_PHRASE_BY_LANGUAGE,
+  approvalPendingPhraseFor,
   pickProgressPhrase,
   PROGRESS_FALLBACK_PHRASES,
   PROGRESS_FALLBACK_PHRASES_BY_LANGUAGE,
 } from "../progress-phrases.js";
 
-// Scripts without space-delimited words, where an 8-word budget is
+// Scripts without space-delimited words, where a word budget is
 // meaningless and length is asserted instead.
 const NON_WORD_COUNTED_LANGUAGES = new Set(["ja"]);
+
+// Every table phrase is spoken audio, so it must end in a terminator the
+// speech pipeline recognizes (shared roster from voice-triage-escalate).
+function expectEndsInSentenceTerminator(phrase: string): void {
+  expect(BRIDGE_SENTENCE_END_REGEX.test(phrase.trim().slice(-1))).toBe(true);
+}
 
 describe("PROGRESS_FALLBACK_PHRASES_BY_LANGUAGE", () => {
   test("covers every Deepgram code-switching language with three phrases", () => {
@@ -41,6 +52,16 @@ describe("PROGRESS_FALLBACK_PHRASES_BY_LANGUAGE", () => {
         } else {
           expect(phrase.split(/\s+/).length).toBeLessThanOrEqual(8);
         }
+      }
+    }
+  });
+
+  test("every phrase ends in a recognized sentence terminator", () => {
+    for (const phrases of Object.values(
+      PROGRESS_FALLBACK_PHRASES_BY_LANGUAGE,
+    )) {
+      for (const phrase of phrases) {
+        expectEndsInSentenceTerminator(phrase);
       }
     }
   });
@@ -81,5 +102,66 @@ describe("pickProgressPhrase", () => {
   test("falls back to English for unknown or blank languages", () => {
     expect(pickProgressPhrase(0, "ko")).toBe(PROGRESS_FALLBACK_PHRASES[0]);
     expect(pickProgressPhrase(0, "")).toBe(PROGRESS_FALLBACK_PHRASES[0]);
+  });
+
+  test("never resolves prototype keys as phrase tables", () => {
+    expect(pickProgressPhrase(0, "constructor")).toBe(
+      PROGRESS_FALLBACK_PHRASES[0],
+    );
+  });
+});
+
+describe("APPROVAL_PENDING_PHRASE_BY_LANGUAGE", () => {
+  test("covers every Deepgram code-switching language", () => {
+    for (const code of DEEPGRAM_MULTI_LANGUAGE_CODES) {
+      const phrase = APPROVAL_PENDING_PHRASE_BY_LANGUAGE[code];
+      expect(phrase).toBeDefined();
+      expect(phrase!.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  test("every phrase stays short", () => {
+    for (const [code, phrase] of Object.entries(
+      APPROVAL_PENDING_PHRASE_BY_LANGUAGE,
+    )) {
+      if (NON_WORD_COUNTED_LANGUAGES.has(code)) {
+        // No spaces to count words by; assert a comparable spoken length.
+        expect(phrase.length).toBeLessThanOrEqual(30);
+      } else {
+        expect(phrase.split(/\s+/).length).toBeLessThanOrEqual(12);
+      }
+    }
+  });
+
+  test("every phrase ends in a recognized sentence terminator", () => {
+    for (const phrase of Object.values(APPROVAL_PENDING_PHRASE_BY_LANGUAGE)) {
+      expectEndsInSentenceTerminator(phrase);
+    }
+  });
+
+  test("the en entry is the exported English phrase", () => {
+    expect(APPROVAL_PENDING_PHRASE_BY_LANGUAGE.en).toBe(
+      APPROVAL_PENDING_PHRASE,
+    );
+  });
+});
+
+describe("approvalPendingPhraseFor", () => {
+  test("selects by the language's lowercased base subtag", () => {
+    expect(approvalPendingPhraseFor("es")).toBe(
+      APPROVAL_PENDING_PHRASE_BY_LANGUAGE.es!,
+    );
+    expect(approvalPendingPhraseFor("pt-BR")).toBe(
+      APPROVAL_PENDING_PHRASE_BY_LANGUAGE.pt!,
+    );
+  });
+
+  test("falls back to English for unknown, blank, or absent languages", () => {
+    expect(approvalPendingPhraseFor("ko")).toBe(APPROVAL_PENDING_PHRASE);
+    expect(approvalPendingPhraseFor("")).toBe(APPROVAL_PENDING_PHRASE);
+    expect(approvalPendingPhraseFor(undefined)).toBe(APPROVAL_PENDING_PHRASE);
+    expect(approvalPendingPhraseFor("constructor")).toBe(
+      APPROVAL_PENDING_PHRASE,
+    );
   });
 });

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -45,8 +45,8 @@ import {
 import { isInstalledStaticSkillLoad } from "../permissions/checker.js";
 import { ensureConversationExists } from "../persistence/conversation-crud.js";
 import {
-  getProviderEntry,
   listProviderIds,
+  pinnedListeningLanguage,
   supportsBoundary,
 } from "../providers/speech-to-text/provider-catalog.js";
 import type { ResolveStreamingTranscriberOptions } from "../providers/speech-to-text/resolve.js";
@@ -54,7 +54,6 @@ import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { publishConversationListAndMetadataChanged } from "../runtime/sync/resource-sync-events.js";
 import {
   dominantLanguageTag,
-  normalizeLanguageTag,
   voteDominantLanguage,
 } from "../stt/language-metadata.js";
 import { detectPcm16SpeechActivity } from "../stt/speech-energy.js";
@@ -108,7 +107,10 @@ import type {
   LiveVoiceTtsOptions,
   LiveVoiceTtsResult,
 } from "./live-voice-tts.js";
-import { pickProgressPhrase } from "./progress-phrases.js";
+import {
+  approvalPendingPhraseFor,
+  pickProgressPhrase,
+} from "./progress-phrases.js";
 import {
   type LiveVoiceClientAttachImageFrame,
   type LiveVoiceClientFrame,
@@ -376,7 +378,7 @@ interface UtteranceCycle {
   // text replays the boundary immediately — the hold was judged on stale
   // text, so waiting out the extension only adds silence.
   heldSpeculativeContent: string | null;
-  // Count per normalized detected-language tag (see normalizeLanguageTag)
+  // Count per detected-language base subtag (see voteDominantLanguage)
   // across this cycle's final transcript events. Resolves the turn's spoken
   // language (see turnLanguageFor); empty when the provider tags nothing.
   languageTally: Map<string, number>;
@@ -712,12 +714,6 @@ function createControlMarkerHoldback(
 // barge-in, the interruption merge note is appended to it (see
 // buildInterruptionMergeNote) so the model reconciles the interrupted request
 // with the new utterance.
-// Spoken once when a turn starts waiting on the user's decision. Fixed rather
-// than generated: this is a statement about the system's state, not about the
-// work, and it has to be true every time. Kept in the shape of the progress
-// phrases it displaces (short, neutral, no claim about tools).
-const APPROVAL_PENDING_PHRASE = "I need your okay for that one. Take a look.";
-
 const LIVE_VOICE_CONTROL_PROMPT_BASE =
   "You are speaking in a local live voice session. Keep replies brief and conversational. Speech is the main channel: say the answer, and do not narrate a surface instead of answering. You can also put something on screen when it genuinely helps (a form, a list to pick from, a progress card for long work); the call overlay minimizes by itself once you finish speaking, so the user sees it without doing anything. Never tell the user you cannot show them something. Reply in the language the caller is speaking; if they switch languages, switch with them. ";
 
@@ -2566,8 +2562,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // Spoken, because opening the room is only a cue for someone looking at
     // the screen, and the case this exists for is a phone the user has put
     // down. One line, not narration: the turn is not working, it is waiting,
-    // and it says which.
-    this.enqueueFillerPhrase(turn, APPROVAL_PENDING_PHRASE);
+    // and it says which — in the turn's spoken language, like every other
+    // filler phrase.
+    this.enqueueFillerPhrase(turn, approvalPendingPhraseFor(turn.language));
   }
 
   /** Clear the wait once a decision lands, so the turn narrates normally again. */
@@ -3464,10 +3461,12 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     await this.startAssistantTurnIfReady();
   }
 
-  // Record a partial event's detected languages (normalized, deduped,
-  // order preserved) so speculative dispatch has a detection before the
-  // first tagged final. Partials revise each other, so this overwrites
-  // rather than tallies, and a tag-less partial keeps the previous value.
+  // Record a partial event's detected languages so speculative dispatch
+  // has a detection before the first tagged final. The event contract
+  // (stt/types.ts) guarantees the tags arrive as normalized base subtags
+  // in dominance order, so they are stored as-is. Partials revise each
+  // other, so this overwrites rather than tallies, and a tag-less partial
+  // keeps the previous value.
   private capturePartialLanguages(
     utterance: UtteranceCycle,
     languages: readonly string[] | undefined,
@@ -3475,14 +3474,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (!languages || languages.length === 0) {
       return;
     }
-    const normalized = [
-      ...new Set(
-        languages.map(normalizeLanguageTag).filter((tag) => tag.length > 0),
-      ),
-    ];
-    if (normalized.length > 0) {
-      utterance.latestPartialLanguages = normalized;
-    }
+    utterance.latestPartialLanguages = languages;
   }
 
   /**
@@ -3507,29 +3499,19 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       return partialDominant;
     }
     // A persisted pin only counts when the provider that actually
-    // transcribed honors manual language selection: auto-detecting
-    // providers (gemini, whisper) ignore the setting entirely, so treating
-    // it as the caller's language would force every turn into a stale pin.
-    // The DIALED transcriber's providerId is authoritative, because the
-    // resolver silently falls back to managed vellum (which honors the pin)
-    // when a BYOK provider has no credential; the configured provider is
-    // only the last resort when no transcriber reference survives. Same
-    // gate as the telephony pre-speech rule (voice-session-bridge.ts).
+    // transcribed honors manual language selection (the shared
+    // pinnedListeningLanguage gate). The DIALED transcriber's providerId
+    // is authoritative, because the resolver silently falls back to
+    // managed vellum (which honors the pin) when a BYOK provider has no
+    // credential; the configured provider is only the last resort when no
+    // transcriber reference survives.
     const { language: configured, provider: sttProvider } =
       getConfig().services.stt;
     const dialedProvider =
       utterance.dialedSttProvider ??
       this.sharedTranscriber?.providerId ??
       (sttProvider as SttProviderId);
-    const providerHonorsLanguagePin =
-      getProviderEntry(dialedProvider)?.languageSelection === "manual";
-    if (providerHonorsLanguagePin && configured && configured !== "multi") {
-      const normalized = normalizeLanguageTag(configured);
-      if (normalized) {
-        return normalized;
-      }
-    }
-    return undefined;
+    return pinnedListeningLanguage(dialedProvider, configured);
   }
 
   // Providers emit `error` mid-stream and may keep streaming; `closed` /

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -2562,7 +2562,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // Spoken, because opening the room is only a cue for someone looking at
     // the screen, and the case this exists for is a phone the user has put
     // down. One line, not narration: the turn is not working, it is waiting,
-    // and it says which — in the turn's spoken language, like every other
+    // and it says which, in the turn's spoken language, like every other
     // filler phrase.
     this.enqueueFillerPhrase(turn, approvalPendingPhraseFor(turn.language));
   }

--- a/assistant/src/live-voice/progress-phrases.ts
+++ b/assistant/src/live-voice/progress-phrases.ts
@@ -1,4 +1,4 @@
-import { baseLanguageSubtag } from "../util/language-subtag.js";
+import { localizedOrDefault } from "../util/language-subtag.js";
 
 // Static fallbacks for an idle-triggered progress narration whose LLM
 // phrasing failed — the one case where prolonged silence is actively harmful.
@@ -73,10 +73,48 @@ export const PROGRESS_FALLBACK_PHRASES_BY_LANGUAGE: Readonly<
 // `language` selects the per-language list by its lowercased base subtag
 // (e.g. "pt-BR" -> "pt"); unknown or absent languages fall back to English.
 export function pickProgressPhrase(counter: number, language?: string): string {
-  const base = baseLanguageSubtag(language);
-  const phrases =
-    (base !== undefined
-      ? PROGRESS_FALLBACK_PHRASES_BY_LANGUAGE[base]
-      : undefined) ?? PROGRESS_FALLBACK_PHRASES;
+  const phrases = localizedOrDefault(
+    PROGRESS_FALLBACK_PHRASES_BY_LANGUAGE,
+    language,
+    PROGRESS_FALLBACK_PHRASES,
+  );
   return phrases[counter % phrases.length];
+}
+
+// Spoken once when a turn starts waiting on the user's approval decision.
+// Fixed rather than generated: this is a statement about the system's
+// state, not about the work, and it has to be true every time. Kept in the
+// shape of the progress phrases it displaces (short, neutral, no claim
+// about tools).
+export const APPROVAL_PENDING_PHRASE =
+  "I need your okay for that one. Take a look.";
+
+// Per-language spellings of the approval-pending phrase, keyed by lowercased
+// BCP 47 base subtag, covering the Deepgram code-switching roster
+// (DEEPGRAM_MULTI_LANGUAGE_CODES in providers/speech-to-text/deepgram.ts).
+// Same invariants as the progress phrases: persona-neutral, no claims about
+// running tools or tasks.
+export const APPROVAL_PENDING_PHRASE_BY_LANGUAGE: Readonly<
+  Record<string, string>
+> = {
+  en: APPROVAL_PENDING_PHRASE,
+  es: "Necesito tu visto bueno para eso. Échale un vistazo.",
+  fr: "J'ai besoin de ton accord pour ça. Jette un œil.",
+  de: "Dafür brauche ich dein Okay. Schau mal drauf.",
+  hi: "इसके लिए मुझे आपकी मंज़ूरी चाहिए। एक नज़र डाल लीजिए।",
+  ru: "Для этого мне нужно твоё согласие. Взгляни, пожалуйста.",
+  pt: "Preciso do seu ok para isso. Dê uma olhada.",
+  ja: "これには許可が必要です。ご確認ください。",
+  it: "Mi serve il tuo via libera per questo. Dai un'occhiata.",
+  nl: "Hiervoor heb ik je akkoord nodig. Kijk even mee.",
+};
+
+// The approval-pending phrase in the turn's spoken language, defaulting to
+// English for unknown or absent languages.
+export function approvalPendingPhraseFor(language?: string): string {
+  return localizedOrDefault(
+    APPROVAL_PENDING_PHRASE_BY_LANGUAGE,
+    language,
+    APPROVAL_PENDING_PHRASE,
+  );
 }

--- a/assistant/src/providers/speech-to-text/deepgram-realtime.test.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-realtime.test.ts
@@ -576,12 +576,11 @@ describe("DeepgramRealtimeTranscriber", () => {
         type: "final",
         text: "hello world hola",
         confidence: 0.95,
-        language: "en",
         languages: ["en", "es"],
       });
     });
 
-    test("omits both fields entirely when no language metadata is present", async () => {
+    test("omits the languages field entirely when no language metadata is present", async () => {
       const { events } = await startSession();
 
       mockWs.simulateMessage(
@@ -614,7 +613,6 @@ describe("DeepgramRealtimeTranscriber", () => {
         type: "final",
         text: "hello",
         confidence: 0.95,
-        language: "en",
         languages: ["en"],
       });
     });
@@ -638,7 +636,6 @@ describe("DeepgramRealtimeTranscriber", () => {
         type: "partial",
         text: "namaste hello",
         confidence: 0.95,
-        language: "en",
         languages: ["en", "hi"],
       });
     });
@@ -658,7 +655,6 @@ describe("DeepgramRealtimeTranscriber", () => {
         type: "final",
         text: "mixed speech",
         confidence: 0.95,
-        language: "es",
         languages: ["es", "en"],
       });
     });
@@ -677,7 +673,6 @@ describe("DeepgramRealtimeTranscriber", () => {
         type: "final",
         text: "bonjour",
         confidence: 0.95,
-        language: "fr",
         languages: ["fr", "en"],
       });
     });
@@ -700,7 +695,6 @@ describe("DeepgramRealtimeTranscriber", () => {
         type: "final",
         text: "hola amigo",
         confidence: 0.95,
-        language: "es",
         languages: ["es"],
       });
     });
@@ -863,7 +857,6 @@ describe("DeepgramRealtimeTranscriber", () => {
       expect(finals[0]).toEqual({
         type: "final",
         text: "hello hola amigo",
-        language: "es",
         languages: ["es", "en"],
       });
     });
@@ -890,7 +883,6 @@ describe("DeepgramRealtimeTranscriber", () => {
       expect(finals[0]).toEqual({
         type: "final",
         text: "bonjour hello there",
-        language: "fr",
         languages: ["fr", "en"],
       });
     });
@@ -931,7 +923,6 @@ describe("DeepgramRealtimeTranscriber", () => {
       expect(finals[0]).toEqual({
         type: "final",
         text: "hello",
-        language: "en",
         languages: ["en"],
       });
     });
@@ -959,7 +950,6 @@ describe("DeepgramRealtimeTranscriber", () => {
       expect(finals[1]).toEqual({
         type: "final",
         text: "hello",
-        language: "en",
         languages: ["en"],
       });
     });

--- a/assistant/src/providers/speech-to-text/deepgram-realtime.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-realtime.ts
@@ -29,14 +29,12 @@
  * - All timers and listeners are cleaned up on close to prevent leaks.
  */
 
-import {
-  normalizeLanguageTag,
-  rankLanguages,
-} from "../../stt/language-metadata.js";
+import { rankLanguages } from "../../stt/language-metadata.js";
 import type {
   StreamingTranscriber,
   SttStreamServerEvent,
 } from "../../stt/types.js";
+import { baseLanguageSubtag } from "../../util/language-subtag.js";
 import { getLogger } from "../../util/logger.js";
 
 const log = getLogger("deepgram-realtime");
@@ -366,7 +364,7 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
 
   /**
    * Raw detected-language tags for the withheld segments, accumulated
-   * alongside {@link pendingFinalSegments} and ranked into `language` /
+   * alongside {@link pendingFinalSegments} and ranked into the event's
    * `languages` when the utterance flushes. Cleared wherever the pending
    * segments are cleared. Only populated when
    * {@link utteranceBoundaryFinals} is enabled.
@@ -779,10 +777,10 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
    * the top alternative when present.
    *
    * Code-switching models (nova-3 with `language=multi`) tag detected
-   * languages per word and per container. When present, these become
-   * dominance-ranked `language` / `languages` fields on the emitted
-   * events (see {@link extractLanguages}). Both fields are omitted when
-   * the frame carries no language metadata.
+   * languages per word and per container. When present, these become the
+   * dominance-ranked `languages` field on the emitted events (see
+   * {@link extractLanguages}). The field is omitted when the frame
+   * carries no language metadata.
    *
    * We emit:
    * - `partial` for `is_final: false` frames (if interim results enabled).
@@ -825,7 +823,6 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
         ? alternative.confidence
         : undefined;
     const languages = extractLanguages(frame.channel, alternative);
-    const language = languages[0];
 
     if (frame.is_final) {
       if (this.utteranceBoundaryFinals) {
@@ -855,7 +852,7 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
           text,
           ...(speakerLabel !== undefined ? { speakerLabel } : {}),
           ...(confidence !== undefined ? { confidence } : {}),
-          ...(language !== undefined ? { language, languages } : {}),
+          ...(languages.length > 0 ? { languages } : {}),
           // Mark the finalize flush so consumers can attribute it to the
           // utterance that requested the flush rather than new speech.
           ...(fromFinalize ? { fromFinalize: true } : {}),
@@ -868,7 +865,7 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
         text,
         ...(speakerLabel !== undefined ? { speakerLabel } : {}),
         ...(confidence !== undefined ? { confidence } : {}),
-        ...(language !== undefined ? { language, languages } : {}),
+        ...(languages.length > 0 ? { languages } : {}),
       });
     }
 
@@ -968,7 +965,7 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
   /**
    * Emit a single aggregated `final` for the withheld `is_final` segments
    * of the current utterance, carrying the dominance-ranked detected
-   * languages accumulated alongside them (fields omitted when no segment
+   * languages accumulated alongside them (field omitted when no segment
    * carried language metadata). No-op when nothing is pending, so
    * boundary signals over silence emit nothing.
    */
@@ -986,7 +983,7 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
     this.emitEvent({
       type: "final",
       text,
-      ...(languages.length > 0 ? { language: languages[0], languages } : {}),
+      ...(languages.length > 0 ? { languages } : {}),
     });
   }
 
@@ -1316,8 +1313,10 @@ function extractLanguages(
   const deduped = new Set(
     container
       .filter((tag): tag is string => typeof tag === "string")
-      .map(normalizeLanguageTag)
-      .filter((tag) => tag !== ""),
+      .flatMap((tag) => {
+        const base = baseLanguageSubtag(tag);
+        return base !== undefined ? [base] : [];
+      }),
   );
   return [...deduped];
 }

--- a/assistant/src/providers/speech-to-text/provider-catalog.ts
+++ b/assistant/src/providers/speech-to-text/provider-catalog.ts
@@ -16,6 +16,7 @@ import type {
   SttProviderId,
   TelephonySttMode,
 } from "../../stt/types.js";
+import { baseLanguageSubtag } from "../../util/language-subtag.js";
 
 // ---------------------------------------------------------------------------
 // Client display metadata
@@ -280,6 +281,43 @@ export function getProviderEntry(
  */
 export function listProviderEntries(): readonly SttProviderEntry[] {
   return [...CATALOG.values()];
+}
+
+/**
+ * A base-subtag regex over the pinned listening language. The pin is
+ * free-form workspace config, and it flows into prompt interpolation and
+ * per-language table lookups, so only a plausible ISO 639 base subtag
+ * passes; anything else (junk strings, prototype keys like "constructor")
+ * resolves as no pin.
+ */
+const PINNED_LANGUAGE_SUBTAG_REGEX = /^[a-z]{2,3}$/;
+
+/**
+ * The configured `services.stt.language` pin as the caller's listening
+ * language, or undefined when the pin carries no signal.
+ *
+ * A persisted pin only counts when the provider honors manual language
+ * selection: auto-detecting providers (gemini, whisper) ignore the setting
+ * entirely, so treating it as the caller's language would force every
+ * turn into a stale pin. "multi" and blank mean auto-detect (no pin), and
+ * the value must normalize to a plausible base subtag. Shared by the
+ * telephony pre-speech prompt rule (voice-session-bridge.ts), live
+ * voice's turn language (live-voice-session.ts), and telephony synthesis
+ * (telephony-synthesis-language.ts) so the gate cannot drift.
+ */
+export function pinnedListeningLanguage(
+  provider: string,
+  configuredLanguage: string | undefined,
+): string | undefined {
+  const providerHonorsLanguagePin =
+    getProviderEntry(provider as SttProviderId)?.languageSelection === "manual";
+  if (!providerHonorsLanguagePin || configuredLanguage?.trim() === "multi") {
+    return undefined;
+  }
+  const base = baseLanguageSubtag(configuredLanguage);
+  return base !== undefined && PINNED_LANGUAGE_SUBTAG_REGEX.test(base)
+    ? base
+    : undefined;
 }
 
 /**

--- a/assistant/src/stt/__tests__/language-metadata.test.ts
+++ b/assistant/src/stt/__tests__/language-metadata.test.ts
@@ -1,27 +1,60 @@
 import { describe, expect, test } from "bun:test";
 
-import { normalizeLanguageTag, rankLanguages } from "../language-metadata.js";
+import {
+  dominantLanguageTag,
+  rankLanguages,
+  voteDominantLanguage,
+} from "../language-metadata.js";
 
-describe("normalizeLanguageTag", () => {
-  test("lowercases a bare base subtag", () => {
-    expect(normalizeLanguageTag("EN")).toBe("en");
+describe("voteDominantLanguage", () => {
+  test("only the dominance-ranked first entry votes", () => {
+    const tally = new Map<string, number>();
+    voteDominantLanguage(tally, ["en", "es"]);
+    expect(tally.get("en")).toBe(1);
+    expect(tally.has("es")).toBe(false);
   });
 
-  test("strips the region subtag", () => {
-    expect(normalizeLanguageTag("en-US")).toBe("en");
+  test("regional variants count toward their base subtag", () => {
+    const tally = new Map<string, number>();
+    voteDominantLanguage(tally, ["pt-BR"]);
+    voteDominantLanguage(tally, ["pt"]);
+    expect(tally.get("pt")).toBe(2);
   });
 
-  test("handles mixed-case regional tags", () => {
-    expect(normalizeLanguageTag("PT-br")).toBe("pt");
+  test("underscore-separated variants count toward their base subtag", () => {
+    const tally = new Map<string, number>();
+    voteDominantLanguage(tally, ["hi_IN"]);
+    expect(tally.get("hi")).toBe(1);
   });
 
-  test("trims surrounding whitespace", () => {
-    expect(normalizeLanguageTag("  hi ")).toBe("hi");
+  test("blank and absent tags cast no vote", () => {
+    const tally = new Map<string, number>();
+    voteDominantLanguage(tally, undefined);
+    voteDominantLanguage(tally, []);
+    voteDominantLanguage(tally, ["  "]);
+    expect(tally.size).toBe(0);
+  });
+});
+
+describe("dominantLanguageTag", () => {
+  test("most votes wins", () => {
+    const tally = new Map([
+      ["en", 1],
+      ["es", 3],
+    ]);
+    expect(dominantLanguageTag(tally)).toBe("es");
   });
 
-  test("returns empty string for blank input", () => {
-    expect(normalizeLanguageTag("")).toBe("");
-    expect(normalizeLanguageTag("   ")).toBe("");
+  test("ties break by first insertion", () => {
+    const tally = new Map([
+      ["hi", 2],
+      ["en", 2],
+    ]);
+    expect(dominantLanguageTag(tally)).toBe("hi");
+  });
+
+  test("undefined for an empty tally", () => {
+    expect(dominantLanguageTag(new Map())).toBeUndefined();
   });
 });
 

--- a/assistant/src/stt/language-metadata.ts
+++ b/assistant/src/stt/language-metadata.ts
@@ -1,18 +1,13 @@
 /**
- * Pure helpers for normalizing and ranking detected-language tags emitted
+ * Pure helpers for tallying and ranking detected-language tags emitted
  * by streaming STT providers (e.g. Deepgram nova-3 `multi` per-word tags).
  *
- * Dependency-free leaf so provider adapters and event consumers can share
- * one notion of a normalized language tag without coupling to each other.
+ * Tag normalization is `baseLanguageSubtag` (util/language-subtag.ts);
+ * these helpers layer vote-counting on top of it so provider adapters and
+ * event consumers share one notion of a dominant language.
  */
 
-/**
- * Normalize a BCP-47 language tag to its lowercase base subtag:
- * "en-US" -> "en", "PT-br" -> "pt". Returns "" for blank input.
- */
-export function normalizeLanguageTag(tag: string): string {
-  return tag.trim().toLowerCase().split("-")[0] ?? "";
-}
+import { baseLanguageSubtag } from "../util/language-subtag.js";
 
 /**
  * Cast one vote into a language tally for a transcript chunk's dominant
@@ -25,8 +20,8 @@ export function voteDominantLanguage(
   tally: Map<string, number>,
   languages: readonly string[] | undefined,
 ): void {
-  const dominant = normalizeLanguageTag(languages?.[0] ?? "");
-  if (dominant) {
+  const dominant = baseLanguageSubtag(languages?.[0]);
+  if (dominant !== undefined) {
     tally.set(dominant, (tally.get(dominant) ?? 0) + 1);
   }
 }
@@ -60,8 +55,8 @@ export function rankLanguages(tags: Iterable<string>): string[] {
   // leaves tied tags in first-appearance order.
   const counts = new Map<string, number>();
   for (const tag of tags) {
-    const normalized = normalizeLanguageTag(tag);
-    if (!normalized) {
+    const normalized = baseLanguageSubtag(tag);
+    if (normalized === undefined) {
       continue;
     }
     counts.set(normalized, (counts.get(normalized) ?? 0) + 1);

--- a/assistant/src/stt/types.ts
+++ b/assistant/src/stt/types.ts
@@ -264,16 +264,11 @@ export interface SttStreamServerPartialEvent {
    */
   readonly confidence?: number;
   /**
-   * Dominant detected language of this chunk as a lowercase base subtag
-   * (e.g. "en", "hi"). Only providers with code-switching metadata
-   * (currently Deepgram nova-3 `multi`) populate this. Consumers must
-   * treat absence as "unknown", never as English.
-   */
-  readonly language?: string;
-  /**
-   * All detected languages of this chunk in dominance order, normalized
-   * to lowercase base subtags. Populated under the same conditions as
-   * {@link language}; absence means "unknown", never English.
+   * All detected languages of this chunk in dominance order (first entry
+   * dominant), already normalized to lowercase base subtags (e.g. "en",
+   * "hi") by the emitting adapter; consumers must not re-normalize. Only
+   * providers with code-switching metadata (currently Deepgram nova-3
+   * `multi`) populate this. Absence means "unknown", never English.
    */
   readonly languages?: readonly string[];
 }
@@ -293,16 +288,11 @@ export interface SttStreamServerFinalEvent {
    */
   readonly confidence?: number;
   /**
-   * Dominant detected language of this chunk as a lowercase base subtag
-   * (e.g. "en", "hi"). Only providers with code-switching metadata
-   * (currently Deepgram nova-3 `multi`) populate this. Consumers must
-   * treat absence as "unknown", never as English.
-   */
-  readonly language?: string;
-  /**
-   * All detected languages of this chunk in dominance order, normalized
-   * to lowercase base subtags. Populated under the same conditions as
-   * {@link language}; absence means "unknown", never English.
+   * All detected languages of this chunk in dominance order (first entry
+   * dominant), already normalized to lowercase base subtags (e.g. "en",
+   * "hi") by the emitting adapter; consumers must not re-normalize. Only
+   * providers with code-switching metadata (currently Deepgram nova-3
+   * `multi`) populate this. Absence means "unknown", never English.
    */
   readonly languages?: readonly string[];
   /**

--- a/assistant/src/util/__tests__/language-subtag.test.ts
+++ b/assistant/src/util/__tests__/language-subtag.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+
+import { baseLanguageSubtag, localizedOrDefault } from "../language-subtag.js";
+
+describe("baseLanguageSubtag", () => {
+  test("lowercases a bare tag", () => {
+    expect(baseLanguageSubtag("EN")).toBe("en");
+  });
+
+  test("strips a hyphenated region", () => {
+    expect(baseLanguageSubtag("en-US")).toBe("en");
+    expect(baseLanguageSubtag("PT-br")).toBe("pt");
+  });
+
+  test("strips an underscore-separated region", () => {
+    expect(baseLanguageSubtag("hi_IN")).toBe("hi");
+    expect(baseLanguageSubtag("es_419")).toBe("es");
+  });
+
+  test("trims surrounding whitespace", () => {
+    expect(baseLanguageSubtag("  hi ")).toBe("hi");
+    expect(baseLanguageSubtag(" pt-BR ")).toBe("pt");
+  });
+
+  test("returns undefined for undefined and blank input", () => {
+    expect(baseLanguageSubtag(undefined)).toBeUndefined();
+    expect(baseLanguageSubtag("")).toBeUndefined();
+    expect(baseLanguageSubtag("   ")).toBeUndefined();
+  });
+});
+
+describe("localizedOrDefault", () => {
+  const table: Readonly<Record<string, string>> = { en: "hello", es: "hola" };
+
+  test("selects by the language's base subtag", () => {
+    expect(localizedOrDefault(table, "es", "hello")).toBe("hola");
+    expect(localizedOrDefault(table, "ES-mx", "hello")).toBe("hola");
+    expect(localizedOrDefault(table, "en_GB", "fallback")).toBe("hello");
+  });
+
+  test("falls back for unset, blank, and unknown languages", () => {
+    expect(localizedOrDefault(table, undefined, "fallback")).toBe("fallback");
+    expect(localizedOrDefault(table, "", "fallback")).toBe("fallback");
+    expect(localizedOrDefault(table, "ko", "fallback")).toBe("fallback");
+  });
+
+  test("never resolves prototype keys as entries", () => {
+    expect(localizedOrDefault(table, "constructor", "fallback")).toBe(
+      "fallback",
+    );
+    expect(localizedOrDefault(table, "toString", "fallback")).toBe("fallback");
+    expect(localizedOrDefault(table, "__proto__", "fallback")).toBe("fallback");
+  });
+});

--- a/assistant/src/util/language-subtag.ts
+++ b/assistant/src/util/language-subtag.ts
@@ -1,8 +1,29 @@
 /**
  * The lowercased primary subtag of a BCP 47 (or underscore-separated)
- * language tag: "pt-BR" -> "pt", "es_419" -> "es". Undefined in,
- * undefined out.
+ * language tag: "pt-BR" -> "pt", "es_419" -> "es", "  EN-us " -> "en".
+ * Undefined for undefined or blank input. The one language-tag
+ * normalizer in the daemon: every language comparison, table lookup, and
+ * prompt interpolation goes through this so a regional variant can never
+ * slip past a base-subtag consumer.
  */
 export function baseLanguageSubtag(language?: string): string | undefined {
-  return language?.toLowerCase().split(/[-_]/)[0];
+  const base = language?.trim().toLowerCase().split(/[-_]/)[0];
+  return base ? base : undefined;
+}
+
+/**
+ * Look up a per-language value in a plain-record table keyed by lowercase
+ * base subtags, falling back when the language is unset, unknown, or a
+ * prototype key ("constructor", "toString") rather than a table entry.
+ */
+export function localizedOrDefault<T>(
+  table: Readonly<Record<string, T>>,
+  language: string | undefined,
+  fallback: T,
+): T {
+  const base = baseLanguageSubtag(language);
+  if (base === undefined || !Object.hasOwn(table, base)) {
+    return fallback;
+  }
+  return table[base] as T;
 }


### PR DESCRIPTION
## Summary
Review remediation round 2: one canonical subtag helper, one provider-pin gate with subtag validation, prototype-safe localized lookups, shared terminator roster, dead singular language event field removed, single-place normalization, localized approval-pending phrase with invariant tests, and deterministic English telephony prompts exempted from the language hint.

Part of plan: voice-multilingual-pipeline.md (review remediation round 2)