### PR TITLE
feat(android): assistant switcher and paired-server parity with iOS

### DIFF
--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -108,19 +108,23 @@ production SSO.
 Android accepts environment-specific connect links in this form:
 
 ```text
-vellum-assistant-dev://connect?url=https%3A%2F%2Fassistant.example.com&code=device-code
+vellum-assistant-dev://connect?url=https%3A%2F%2Fassistant.example.com&code=device-code&name=Studio+Mac
 ```
 
 The production and staging builds use their matching auth schemes from the
 Build Variants table. Scanning a connect link switches the native shell to the
 validated server, opens `<server>/assistant/pair`, and keeps an existing server
-path prefix intact. Cold and warm app launches use the same route.
+path prefix intact. Cold and warm app launches use the same route. The optional
+`name` is the label the assistant chooser shows for that server; without one the
+chooser falls back to the hostname.
 
-Only the validated server base is saved after the pairing page loads. The
-one-time device code is kept out of app preferences and the generated
-Capacitor configuration. HTTPS is required except for `localhost`, `127.0.0.1`,
-and the Android emulator host alias `10.0.2.2`. Use `adb reverse` when a physical
-development device needs to reach a service through `localhost`.
+Only the validated server base is saved after the pairing page loads, and the
+remembered list is appended at the same moment, so a server that never loaded
+leaves no card behind. The one-time device code is kept out of app preferences
+and the generated Capacitor configuration. HTTPS is required except for
+`localhost`, `127.0.0.1`, and the Android emulator host alias `10.0.2.2`. Use
+`adb reverse` when a physical development device needs to reach a service
+through `localhost`.
 
 If Android terminates the app before the pairing page loads, scan the connect
 link again. The shell intentionally does not save the one-time code for process
@@ -129,6 +133,22 @@ restoration.
 If a saved or newly scanned server cannot load, the native recovery dialog can
 retry it or clear the saved server and return to Vellum Cloud. A failed new
 server is never promoted over the last server that loaded successfully.
+
+## Assistant Switcher
+
+The `SelfHostedServers` plugin backs the web assistant chooser, matching the iOS
+contract in [`clients/web/docs/CAPACITOR.md`](../web/docs/CAPACITOR.md). It lists
+every paired server alongside the active slot and the baked Vellum Cloud origin,
+adds and forgets entries, and switches between them without leaving the app.
+
+The server url is baked into the Capacitor config at `onCreate`, so switching
+writes the preference and recreates the activity rather than navigating the
+WebView. Forgetting the active server clears the slot and lands back on Vellum
+Cloud, which is also what the chooser's "Vellum Cloud" card does.
+
+The shell loads `<server>/assistant` rather than the bare base: the ingress
+redirects a bare `/` to an absolute `/assistant/`, which would drop a hosting
+path prefix on relaunch.
 
 ## Biometric Session Recovery
 
@@ -210,6 +230,7 @@ clients/
     │       │   ├── NativeLaunchScreenPlugin.java
     │       │   ├── BiometricTokenStore.java
     │       │   ├── SelfHostedServer.java
+    │       │   ├── SelfHostedServersPlugin.java
     │       │   ├── VoiceAudioSessionPlugin.java
     │       │   ├── VoiceDeepLink.java
     │       │   ├── VoiceLiveActivityPlugin.java

--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -143,8 +143,11 @@ adds and forgets entries, and switches between them without leaving the app.
 
 The server url is baked into the Capacitor config at `onCreate`, so switching
 writes the preference and recreates the activity rather than navigating the
-WebView. Forgetting the active server clears the slot and lands back on Vellum
-Cloud, which is also what the chooser's "Vellum Cloud" card does.
+WebView. `switchToPath` additionally lands on a route relative to the app entry,
+carrying it across the recreate; the pairing page's Cancel uses it so abandoning
+a pairing both leaves the origin and reaches the hub chooser in one step.
+Forgetting the active server clears the slot and lands back on Vellum Cloud,
+which is also what the chooser's "Vellum Cloud" card does.
 
 The shell loads `<server>/assistant` rather than the bare base: the ingress
 redirects a bare `/` to an absolute `/assistant/`, which would drop a hosting

--- a/clients/android/app/build.gradle
+++ b/clients/android/app/build.gradle
@@ -152,6 +152,9 @@ dependencies {
     implementation "com.google.firebase:firebase-messaging:$firebaseMessagingVersion"
     implementation project(':capacitor-android')
     testImplementation "junit:junit:$junitVersion"
+    // The mockable android.jar stubs org.json into throwing, so the remembered
+    // server list's codec needs a real implementation to be unit-testable.
+    testImplementation "org.json:json:$jsonVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
     implementation project(':capacitor-cordova-android-plugins')

--- a/clients/android/app/src/main/java/ai/vellum/assistant/ConnectDeepLink.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/ConnectDeepLink.java
@@ -14,10 +14,12 @@ final class ConnectDeepLink {
 
     private final URI server;
     private final URI pairPage;
+    private final String name;
 
-    private ConnectDeepLink(URI server, URI pairPage) {
+    private ConnectDeepLink(URI server, URI pairPage, String name) {
         this.server = server;
         this.pairPage = pairPage;
+        this.name = name;
     }
 
     static boolean handles(String raw, String expectedScheme) {
@@ -66,7 +68,7 @@ final class ConnectDeepLink {
         if (pairPage == null) {
             return null;
         }
-        return new ConnectDeepLink(server, pairPage);
+        return new ConnectDeepLink(server, pairPage, query.get("name"));
     }
 
     URI server() {
@@ -75,6 +77,15 @@ final class ConnectDeepLink {
 
     URI pairPage() {
         return pairPage;
+    }
+
+    /**
+     * The optional user-facing label for the remembered-server list. Absent on
+     * links from a sender that does not send one, which is not an error: the
+     * chooser falls back to the hostname.
+     */
+    String name() {
+        return name;
     }
 
     private static URI parseUri(String raw) {

--- a/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
@@ -124,6 +124,7 @@ public class MainActivity extends BridgeActivity {
         registerPlugin(VoiceAudioSessionPlugin.class);
         registerPlugin(VoiceLiveActivityPlugin.class);
         registerPlugin(SafePushNotificationsPlugin.class);
+        registerPlugin(SelfHostedServersPlugin.class);
         super.load();
     }
 
@@ -317,6 +318,11 @@ public class MainActivity extends BridgeActivity {
         bridge.getWebView().loadUrl(appLink.toASCIIString());
     }
 
+    /**
+     * Promote a scanned server once its pairing page loads. The list append
+     * waits for the load like the active-slot write does, so an unreachable
+     * origin leaves no card behind in the chooser.
+     */
     private void finishPendingConnect(String loadedUrl) {
         if (
             pendingConnect == null ||
@@ -325,6 +331,7 @@ public class MainActivity extends BridgeActivity {
             return;
         }
         SelfHostedServer.store(this, pendingConnect.server());
+        SelfHostedServer.append(this, pendingConnect.server(), pendingConnect.name());
         pendingConnect = null;
     }
 
@@ -354,20 +361,33 @@ public class MainActivity extends BridgeActivity {
             return;
         }
         String destination = pendingConnect == null
-            ? effectiveServer.toASCIIString()
+            ? SelfHostedServer.appEntry(effectiveServer).toASCIIString()
             : pendingConnect.pairPage().toASCIIString();
         bridge.getWebView().loadUrl(destination);
     }
 
-    private void useVellumCloud() {
+    /**
+     * Reload the shell against the stored server, or the baked Vellum Cloud
+     * origin when the slot is empty. The server url is baked into the Capacitor
+     * config at {@code onCreate}, so applying a new one means recreating the
+     * activity. Backs the {@code SelfHostedServers} plugin's {@code switchTo};
+     * must run on the UI thread.
+     */
+    void applyConfiguredOrigin() {
         VoiceLiveActivityPlugin.clearStatus(this);
-        SelfHostedServer.clear(this);
         pendingConnect = null;
         pendingNewChat = false;
         setRecreationConnect(null);
+        // Cleared before the recreate lands so a teardown failure on the origin
+        // being left cannot raise the unreachable dialog against it.
         effectiveServer = null;
         setIntent(withoutData(getIntent()));
         recreate();
+    }
+
+    private void useVellumCloud() {
+        SelfHostedServer.clear(this);
+        applyConfiguredOrigin();
     }
 
     private void prepareVoiceLaunch(Intent intent) {

--- a/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
@@ -32,11 +32,13 @@ public class MainActivity extends BridgeActivity {
     private static final long LAUNCH_SCREEN_LOAD_FALLBACK_MS = 2_000;
     private static final long LAUNCH_SCREEN_TIMEOUT_MS = 15_000;
     private static ConnectDeepLink recreationConnect;
+    private static String recreationRoute;
 
     private final Handler launchScreenHandler = new Handler(Looper.getMainLooper());
     private AlertDialog unreachableDialog;
     private URI effectiveServer;
     private URI pendingAppLink;
+    private String pendingRoute;
     private ConnectDeepLink pendingConnect;
     private boolean pendingNewChat;
     private Intent pendingVoiceLaunch;
@@ -77,6 +79,7 @@ public class MainActivity extends BridgeActivity {
             },
             null
         );
+        pendingRoute = takeRecreationRoute();
         URI selectedServer = pendingConnect == null
             ? NativeFailureGuard.get(
                 "Unable to read the saved self-hosted server",
@@ -99,6 +102,7 @@ public class MainActivity extends BridgeActivity {
             }
         });
         NativeFailureGuard.run("Unable to deliver the Android app link", this::deliverPendingAppLink);
+        NativeFailureGuard.run("Unable to deliver the Android switch route", this::deliverPendingRoute);
         NativeFailureGuard.run("Unable to deliver the Android connect launch", this::deliverPendingConnect);
         NativeFailureGuard.run("Unable to deliver the Android new chat launch", this::deliverPendingNewChat);
     }
@@ -319,6 +323,22 @@ public class MainActivity extends BridgeActivity {
     }
 
     /**
+     * Land on the route a {@code switchToPath} asked for. The configured server
+     * url is the app entry, so the route hangs off it directly, which keeps a
+     * hosting path prefix intact.
+     */
+    private void deliverPendingRoute() {
+        if (pendingRoute == null || bridge == null || bridge.getServerUrl() == null) {
+            return;
+        }
+        String route = pendingRoute;
+        pendingRoute = null;
+        bridge
+            .getWebView()
+            .loadUrl(SelfHostedServer.appRoute(URI.create(bridge.getServerUrl()), route).toASCIIString());
+    }
+
+    /**
      * Promote a scanned server once its pairing page loads. The list append
      * waits for the load like the active-slot write does, so an unreachable
      * origin leaves no card behind in the chooser.
@@ -368,16 +388,20 @@ public class MainActivity extends BridgeActivity {
 
     /**
      * Reload the shell against the stored server, or the baked Vellum Cloud
-     * origin when the slot is empty. The server url is baked into the Capacitor
+     * origin when the slot is empty, optionally landing on a {@code route}
+     * relative to the app entry. The server url is baked into the Capacitor
      * config at {@code onCreate}, so applying a new one means recreating the
-     * activity. Backs the {@code SelfHostedServers} plugin's {@code switchTo};
-     * must run on the UI thread.
+     * activity, and the route rides a static across that recreate the way a
+     * connect deep link already does. Backs the {@code SelfHostedServers}
+     * plugin's {@code switchTo} and {@code switchToPath}; must run on the UI
+     * thread.
      */
-    void applyConfiguredOrigin() {
+    void applyConfiguredOrigin(String route) {
         VoiceLiveActivityPlugin.clearStatus(this);
         pendingConnect = null;
         pendingNewChat = false;
         setRecreationConnect(null);
+        setRecreationRoute(route);
         // Cleared before the recreate lands so a teardown failure on the origin
         // being left cannot raise the unreachable dialog against it.
         effectiveServer = null;
@@ -387,7 +411,7 @@ public class MainActivity extends BridgeActivity {
 
     private void useVellumCloud() {
         SelfHostedServer.clear(this);
-        applyConfiguredOrigin();
+        applyConfiguredOrigin(null);
     }
 
     private void prepareVoiceLaunch(Intent intent) {
@@ -435,6 +459,16 @@ public class MainActivity extends BridgeActivity {
 
     private static synchronized void setRecreationConnect(ConnectDeepLink connect) {
         recreationConnect = connect;
+    }
+
+    private static synchronized String takeRecreationRoute() {
+        String route = recreationRoute;
+        recreationRoute = null;
+        return route;
+    }
+
+    private static synchronized void setRecreationRoute(String route) {
+        recreationRoute = route;
     }
 
     private static final class SelfHostedWebViewClient extends BridgeWebViewClient {

--- a/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
@@ -409,6 +409,11 @@ public class MainActivity extends BridgeActivity {
         recreate();
     }
 
+    /**
+     * A dropped clear needs no branch here, unlike on the bridge: reloading
+     * lands back on the origin that could not be reached and re-presents this
+     * dialog, so the failure is already visible and already retryable.
+     */
     private void useVellumCloud() {
         SelfHostedServer.clear(this);
         applyConfiguredOrigin(null);

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
@@ -12,7 +12,10 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -21,13 +24,31 @@ final class SelfHostedServer {
     private static final String CONFIG_FILE = "capacitor.config.json";
     private static final String PREFERENCES_NAME = "self_hosted_server";
     private static final String SERVER_URL_KEY = "server_url";
+    private static final String SERVERS_KEY = "servers";
+    private static final String APP_ENTRY_SEGMENT = "/assistant";
 
+    /** The active slot the shell serves, plus every server it has paired with. */
     interface Store {
         String read();
 
         boolean write(String value);
 
         void clear();
+
+        String readServers();
+
+        void writeServers(String value);
+    }
+
+    /** A canonical server base plus the optional label the chooser shows. */
+    static final class Entry {
+        final String name;
+        final String url;
+
+        Entry(String name, String url) {
+            this.name = name;
+            this.url = url;
+        }
     }
 
     private SelfHostedServer() {}
@@ -45,7 +66,7 @@ final class SelfHostedServer {
     }
 
     static boolean store(Store store, URI server) {
-        URI validated = validate(server == null ? null : server.toASCIIString());
+        URI validated = canonical(server);
         if (validated == null) {
             return false;
         }
@@ -58,6 +79,107 @@ final class SelfHostedServer {
 
     static void clear(Store store) {
         store.clear();
+    }
+
+    static List<Entry> servers(Context context) {
+        return servers(new PreferencesStore(context));
+    }
+
+    /**
+     * The remembered list. Urls re-canonicalize on read so pre-canonical
+     * duplicates collapse (first wins), and an active server missing from the
+     * list joins it unnamed, so a shell paired before the list existed still
+     * lists what it is serving.
+     */
+    static List<Entry> servers(Store store) {
+        List<Entry> entries = new ArrayList<>();
+        for (Entry item : decode(store.readServers())) {
+            URI url = validate(item.url);
+            if (url == null || indexOf(entries, url.toASCIIString()) >= 0) {
+                continue;
+            }
+            entries.add(new Entry(item.name, url.toASCIIString()));
+        }
+        URI active = configured(store);
+        if (active != null && indexOf(entries, active.toASCIIString()) < 0) {
+            entries.add(new Entry(null, active.toASCIIString()));
+        }
+        return entries;
+    }
+
+    static void append(Context context, URI server, String name) {
+        append(new PreferencesStore(context), server, name);
+    }
+
+    /**
+     * Remember a server, deduped by url. A named re-append renames; a nameless
+     * one keeps the stored label, so switching never wipes a name.
+     */
+    static void append(Store store, URI server, String name) {
+        URI validated = canonical(server);
+        if (validated == null) {
+            return;
+        }
+        List<Entry> entries = servers(store);
+        String url = validated.toASCIIString();
+        String label = normalizeName(name);
+        int index = indexOf(entries, url);
+        if (index < 0) {
+            entries.add(new Entry(label, url));
+        } else if (label != null) {
+            entries.set(index, new Entry(label, url));
+        }
+        store.writeServers(encode(entries));
+    }
+
+    static boolean remove(Context context, URI server) {
+        return remove(new PreferencesStore(context), server);
+    }
+
+    /**
+     * Forget a server, clearing the active slot when it was the active one and
+     * answering whether it was, so the caller knows to reload the shell.
+     */
+    static boolean remove(Store store, URI server) {
+        URI validated = canonical(server);
+        if (validated == null) {
+            return false;
+        }
+        List<Entry> entries = servers(store);
+        int index = indexOf(entries, validated.toASCIIString());
+        if (index >= 0) {
+            entries.remove(index);
+            store.writeServers(encode(entries));
+        }
+        boolean wasActive = validated.equals(configured(store));
+        if (wasActive) {
+            clear(store);
+        }
+        return wasActive;
+    }
+
+    /**
+     * The SPA entry point for a server base, {@code <base>/assistant}. The
+     * ingress redirects a bare {@code /} to an absolute {@code /assistant/},
+     * which drops a hosting prefix ({@code https://host/assistant-123} landing
+     * on {@code https://host/assistant/}), so the segment is appended here. The
+     * baked Vellum Cloud url already carries it and comes back unchanged.
+     */
+    static URI appEntry(URI server) {
+        String base = server.toASCIIString();
+        if (base.endsWith(APP_ENTRY_SEGMENT)) {
+            return server;
+        }
+        try {
+            return new URI(base + APP_ENTRY_SEGMENT);
+        } catch (URISyntaxException exception) {
+            return server;
+        }
+    }
+
+    /** {@link #validate} for an already-parsed url, which re-canonicalizes it. */
+    private static URI canonical(URI server) {
+        return validate(server == null ? null : server.toASCIIString());
     }
 
     static URI validate(String raw) {
@@ -97,7 +219,7 @@ final class SelfHostedServer {
         }
         String path = normalizePath(normalized.getRawPath());
         try {
-            return new URI(scheme + "://" + formatAuthority(host, parsed.getPort()) + path);
+            return new URI(scheme + "://" + formatAuthority(scheme, host, parsed.getPort()) + path);
         } catch (URISyntaxException exception) {
             return null;
         }
@@ -141,7 +263,7 @@ final class SelfHostedServer {
         String source = readAsset(context, CONFIG_FILE);
         JSONObject root = new JSONObject(source);
         JSONObject serverConfig = root.getJSONObject("server");
-        serverConfig.put("url", server.toASCIIString());
+        serverConfig.put("url", appEntry(server).toASCIIString());
 
         File directory = new File(context.getCacheDir(), CONFIG_DIRECTORY);
         if (!directory.exists() && !directory.mkdirs()) {
@@ -181,7 +303,7 @@ final class SelfHostedServer {
         if (uri.getPort() >= 0) {
             return uri.getPort();
         }
-        return "https".equalsIgnoreCase(uri.getScheme()) ? 443 : 80;
+        return defaultPort(uri.getScheme() == null ? "" : uri.getScheme().toLowerCase(Locale.US));
     }
 
     private static String normalizePath(String rawPath) {
@@ -244,13 +366,86 @@ final class SelfHostedServer {
         return false;
     }
 
-    private static String formatAuthority(String host, int port) {
+    /**
+     * The scheme's default port is dropped so the canonical form matches the web
+     * store's {@code normalizeOriginUrl}, which builds from {@code URL.origin}
+     * and collapses it. Both sides key the remembered list on this string.
+     */
+    private static String formatAuthority(String scheme, String host, int port) {
         String authorityHost = host.indexOf(':') >= 0 && !host.startsWith("[") ? "[" + host + "]" : host;
-        return port >= 0 ? authorityHost + ":" + port : authorityHost;
+        if (port < 0 || port == defaultPort(scheme)) {
+            return authorityHost;
+        }
+        return authorityHost + ":" + port;
+    }
+
+    private static int defaultPort(String scheme) {
+        return "https".equals(scheme) ? 443 : 80;
     }
 
     private static boolean isLocalDevelopmentHost(String host) {
         return "localhost".equals(host) || "127.0.0.1".equals(host) || "10.0.2.2".equals(host);
+    }
+
+    private static int indexOf(List<Entry> entries, String url) {
+        for (int index = 0; index < entries.size(); index++) {
+            if (entries.get(index).url.equals(url)) {
+                return index;
+            }
+        }
+        return -1;
+    }
+
+    /** Trim a label and collapse an empty one to null. */
+    private static String normalizeName(String name) {
+        if (name == null) {
+            return null;
+        }
+        String trimmed = name.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    /**
+     * Anything that is not a JSON array of url-carrying objects reads as empty
+     * rather than as an error, so a corrupt preference costs the list rather
+     * than the launch.
+     */
+    private static List<Entry> decode(String raw) {
+        List<Entry> entries = new ArrayList<>();
+        if (raw == null || raw.isEmpty()) {
+            return entries;
+        }
+        final JSONArray items;
+        try {
+            items = new JSONArray(raw);
+        } catch (JSONException exception) {
+            return entries;
+        }
+        for (int index = 0; index < items.length(); index++) {
+            JSONObject item = items.optJSONObject(index);
+            String url = item == null ? null : item.optString("url", null);
+            if (url != null) {
+                entries.add(new Entry(normalizeName(item.optString("name", null)), url));
+            }
+        }
+        return entries;
+    }
+
+    private static String encode(List<Entry> entries) {
+        JSONArray items = new JSONArray();
+        for (Entry entry : entries) {
+            JSONObject item = new JSONObject();
+            try {
+                item.put("url", entry.url);
+                if (entry.name != null) {
+                    item.put("name", entry.name);
+                }
+            } catch (JSONException exception) {
+                continue;
+            }
+            items.put(item);
+        }
+        return items.toString();
     }
 
     private static String readAsset(Context context, String path) throws IOException {
@@ -284,6 +479,16 @@ final class SelfHostedServer {
         @Override
         public void clear() {
             preferences.edit().remove(SERVER_URL_KEY).commit();
+        }
+
+        @Override
+        public String readServers() {
+            return preferences.getString(SERVERS_KEY, null);
+        }
+
+        @Override
+        public void writeServers(String value) {
+            preferences.edit().putString(SERVERS_KEY, value).commit();
         }
     }
 }

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
@@ -33,7 +33,7 @@ final class SelfHostedServer {
 
         boolean write(String value);
 
-        void clear();
+        boolean clear();
 
         String readServers();
 
@@ -73,12 +73,13 @@ final class SelfHostedServer {
         return store.write(validated.toASCIIString());
     }
 
-    static void clear(Context context) {
-        clear(new PreferencesStore(context));
+    static boolean clear(Context context) {
+        return clear(new PreferencesStore(context));
     }
 
-    static void clear(Store store) {
-        store.clear();
+    /** Return the shell to the baked origin, answering whether the slot took it. */
+    static boolean clear(Store store) {
+        return store.clear();
     }
 
     static List<Entry> servers(Context context) {
@@ -150,24 +151,27 @@ final class SelfHostedServer {
 
     /**
      * Forget a server, clearing the active slot when it was the active one.
-     * Answers whether the list is now without it, which a url that was never in
-     * it satisfies, so only a failed write reads as failure.
+     * Answers whether the server is gone from both, which a url that was never
+     * remembered satisfies, so only a dropped write reads as failure.
+     *
+     * The list commits before the active slot: the two keys cannot be written
+     * atomically, and a failure that has already cleared the slot would strand
+     * the shell on the baked origin while the caller is told the removal failed.
      */
     static boolean remove(Store store, URI server) {
         URI validated = canonical(server);
         if (validated == null) {
             return true;
         }
-        if (validated.equals(configured(store))) {
-            clear(store);
-        }
         List<Entry> entries = servers(store);
         int index = indexOf(entries, validated.toASCIIString());
-        if (index < 0) {
-            return true;
+        if (index >= 0) {
+            entries.remove(index);
+            if (!store.writeServers(encode(entries))) {
+                return false;
+            }
         }
-        entries.remove(index);
-        return store.writeServers(encode(entries));
+        return !validated.equals(configured(store)) || clear(store);
     }
 
     /**
@@ -533,8 +537,8 @@ final class SelfHostedServer {
         }
 
         @Override
-        public void clear() {
-            preferences.edit().remove(SERVER_URL_KEY).commit();
+        public boolean clear() {
+            return preferences.edit().remove(SERVER_URL_KEY).commit();
         }
 
         @Override

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
@@ -37,7 +37,7 @@ final class SelfHostedServer {
 
         String readServers();
 
-        void writeServers(String value);
+        boolean writeServers(String value);
     }
 
     /** A canonical server base plus the optional label the chooser shows. */
@@ -107,18 +107,20 @@ final class SelfHostedServer {
         return entries;
     }
 
-    static void append(Context context, URI server, String name) {
-        append(new PreferencesStore(context), server, name);
+    static boolean append(Context context, URI server, String name) {
+        return append(new PreferencesStore(context), server, name);
     }
 
     /**
      * Remember a server, deduped by url. A named re-append renames; a nameless
-     * one keeps the stored label, so switching never wipes a name.
+     * one keeps the stored label, so switching never wipes a name. Answers
+     * whether the list now holds it, so a caller does not publish an entry the
+     * shell failed to persist.
      */
-    static void append(Store store, URI server, String name) {
+    static boolean append(Store store, URI server, String name) {
         URI validated = canonical(server);
         if (validated == null) {
-            return;
+            return false;
         }
         List<Entry> entries = servers(store);
         String url = validated.toASCIIString();
@@ -129,7 +131,17 @@ final class SelfHostedServer {
         } else if (label != null) {
             entries.set(index, new Entry(label, url));
         }
-        store.writeServers(encode(entries));
+        return store.writeServers(encode(entries));
+    }
+
+    static boolean isActive(Context context, URI server) {
+        return isActive(new PreferencesStore(context), server);
+    }
+
+    /** Whether a server canonically matches the active slot. */
+    static boolean isActive(Store store, URI server) {
+        URI validated = canonical(server);
+        return validated != null && validated.equals(configured(store));
     }
 
     static boolean remove(Context context, URI server) {
@@ -137,41 +149,43 @@ final class SelfHostedServer {
     }
 
     /**
-     * Forget a server, clearing the active slot when it was the active one and
-     * answering whether it was, so the caller knows to reload the shell.
+     * Forget a server, clearing the active slot when it was the active one.
+     * Answers whether the list is now without it, which a url that was never in
+     * it satisfies, so only a failed write reads as failure.
      */
     static boolean remove(Store store, URI server) {
         URI validated = canonical(server);
         if (validated == null) {
-            return false;
+            return true;
+        }
+        if (validated.equals(configured(store))) {
+            clear(store);
         }
         List<Entry> entries = servers(store);
         int index = indexOf(entries, validated.toASCIIString());
-        if (index >= 0) {
-            entries.remove(index);
-            store.writeServers(encode(entries));
+        if (index < 0) {
+            return true;
         }
-        boolean wasActive = validated.equals(configured(store));
-        if (wasActive) {
-            clear(store);
-        }
-        return wasActive;
+        entries.remove(index);
+        return store.writeServers(encode(entries));
     }
 
     /**
-     * The SPA entry point for a server base, {@code <base>/assistant}. The
+     * The SPA entry point for a self-hosted base, {@code <base>/assistant}. The
      * ingress redirects a bare {@code /} to an absolute {@code /assistant/},
      * which drops a hosting prefix ({@code https://host/assistant-123} landing
-     * on {@code https://host/assistant/}), so the segment is appended here. The
-     * baked Vellum Cloud url already carries it and comes back unchanged.
+     * on {@code https://host/assistant/}), so the segment is appended here.
+     *
+     * Appended unconditionally, matching the pair page {@link ConnectDeepLink}
+     * builds: a base is never already an entry, because the only url that
+     * carries the segment natively is the baked Vellum Cloud one, which is
+     * configured whole and never passes through here. Testing the last segment
+     * instead would strand a deployment hosted at a {@code /assistant} prefix,
+     * whose entry is {@code /assistant/assistant}.
      */
     static URI appEntry(URI server) {
-        String base = server.toASCIIString();
-        if (base.endsWith(APP_ENTRY_SEGMENT)) {
-            return server;
-        }
         try {
-            return new URI(base + APP_ENTRY_SEGMENT);
+            return new URI(server.toASCIIString() + APP_ENTRY_SEGMENT);
         } catch (URISyntaxException exception) {
             return server;
         }
@@ -529,8 +543,8 @@ final class SelfHostedServer {
         }
 
         @Override
-        public void writeServers(String value) {
-            preferences.edit().putString(SERVERS_KEY, value).commit();
+        public boolean writeServers(String value) {
+            return preferences.edit().putString(SERVERS_KEY, value).commit();
         }
     }
 }

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
@@ -177,6 +177,48 @@ final class SelfHostedServer {
         }
     }
 
+    /**
+     * A route relative to the app entry, as {@code path[?query]}, or null when
+     * the candidate could steer the shell off the entry: an absolute or
+     * scheme-relative url, an empty or rooted path, a dot segment, or a
+     * fragment. Validated at the bridge boundary so an invalid route rejects
+     * before anything is stored.
+     */
+    static String routePath(String raw) {
+        if (raw == null) {
+            return null;
+        }
+        final URI relative;
+        try {
+            relative = new URI(raw.trim());
+        } catch (URISyntaxException exception) {
+            return null;
+        }
+        String path = relative.getRawPath();
+        if (
+            relative.isAbsolute() ||
+            relative.getHost() != null ||
+            relative.getRawFragment() != null ||
+            path == null ||
+            path.isEmpty() ||
+            path.startsWith("/") ||
+            containsDotSegment(path) ||
+            containsEncodedDotSegment(path)
+        ) {
+            return null;
+        }
+        return relative.getRawQuery() == null ? path : path + "?" + relative.getRawQuery();
+    }
+
+    /** Hang a {@link #routePath} off an app entry. */
+    static URI appRoute(URI entry, String routePath) {
+        try {
+            return new URI(entry.toASCIIString() + "/" + routePath);
+        } catch (URISyntaxException exception) {
+            return entry;
+        }
+    }
+
     /** {@link #validate} for an already-parsed url, which re-canonicalizes it. */
     private static URI canonical(URI server) {
         return validate(server == null ? null : server.toASCIIString());

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServersPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServersPlugin.java
@@ -1,0 +1,137 @@
+package ai.vellum.assistant;
+
+import android.app.Activity;
+import com.getcapacitor.CapConfig;
+import com.getcapacitor.JSArray;
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+import java.net.URI;
+import org.json.JSONObject;
+
+/**
+ * Capacitor plugin exposing the remembered self-hosted server list to the web
+ * layer, which installs it as the assistant chooser's storage provider. The
+ * active slot stays the one the connect deep link writes; this plugin
+ * generalizes it into a switchable {@code {name?, url}} list. Mirrors iOS's
+ * {@code SelfHostedServersPlugin.swift} method for method.
+ *
+ * Per the skew rule in {@code clients/web/docs/CAPACITOR.md}, one result shape
+ * encodes every state: empty state resolves with an empty list and nulls rather
+ * than rejecting, so only genuinely invalid caller input (an {@code add} or
+ * {@code switchTo} url failing {@link SelfHostedServer#validate}) rejects.
+ */
+@CapacitorPlugin(name = "SelfHostedServers")
+public class SelfHostedServersPlugin extends Plugin {
+
+    @PluginMethod
+    public void list(PluginCall call) {
+        JSArray servers = new JSArray();
+        for (SelfHostedServer.Entry entry : SelfHostedServer.servers(getContext())) {
+            JSObject item = new JSObject();
+            item.put("url", entry.url);
+            if (entry.name != null) {
+                item.put("name", entry.name);
+            }
+            servers.put(item);
+        }
+        URI active = SelfHostedServer.configured(getContext());
+        JSObject result = new JSObject();
+        result.put("servers", servers);
+        result.put("activeUrl", nullable(active == null ? null : active.toASCIIString()));
+        result.put("bakedUrl", nullable(bakedServerUrl()));
+        call.resolve(result);
+    }
+
+    @PluginMethod
+    public void add(PluginCall call) {
+        URI server = SelfHostedServer.validate(call.getString("url"));
+        if (server == null) {
+            call.reject("invalid url");
+            return;
+        }
+        SelfHostedServer.append(getContext(), server, call.getString("name"));
+        call.resolve(ok());
+    }
+
+    /**
+     * Forgetting a url that is not (or cannot be) in the list is a no-op, so this
+     * never rejects. Removing the active server clears the active slot, so the
+     * shell reloads back to the baked origin like {@code switchTo({})}.
+     */
+    @PluginMethod
+    public void remove(PluginCall call) {
+        boolean removedActive = SelfHostedServer.remove(
+            getContext(),
+            SelfHostedServer.validate(call.getString("url"))
+        );
+        // Resolve before scheduling the reload: it recreates the activity and
+        // tears the web context down, so a caller awaiting this call would
+        // otherwise never settle.
+        call.resolve(ok());
+        if (removedActive) {
+            reloadConfiguredOrigin();
+        }
+    }
+
+    /**
+     * Switching to a url implies remembering it, so the target joins the list
+     * alongside the active-slot write. An absent or empty url returns the shell
+     * to its baked Vellum Cloud origin.
+     */
+    @PluginMethod
+    public void switchTo(PluginCall call) {
+        String raw = call.getString("url");
+        String trimmed = raw == null ? "" : raw.trim();
+        if (trimmed.isEmpty()) {
+            SelfHostedServer.clear(getContext());
+        } else {
+            URI server = SelfHostedServer.validate(trimmed);
+            if (server == null) {
+                call.reject("invalid url");
+                return;
+            }
+            if (!SelfHostedServer.store(getContext(), server)) {
+                // The active slot did not take the write, so the reload below
+                // would land back on the current origin. Report the failure
+                // instead and let the caller navigate.
+                call.reject("unable to save the server");
+                return;
+            }
+            SelfHostedServer.append(getContext(), server, null);
+        }
+        call.resolve(ok());
+        reloadConfiguredOrigin();
+    }
+
+    /**
+     * The Vellum Cloud origin this build ships with, read from the packaged
+     * Capacitor config rather than the running one so an active self-hosted
+     * override cannot mask it.
+     */
+    private String bakedServerUrl() {
+        return NativeFailureGuard.get(
+            "Unable to read the baked Android server url",
+            () -> CapConfig.loadDefault(getContext()).getServerUrl(),
+            null
+        );
+    }
+
+    private void reloadConfiguredOrigin() {
+        Activity activity = getActivity();
+        if (!(activity instanceof MainActivity)) {
+            return;
+        }
+        activity.runOnUiThread(((MainActivity) activity)::applyConfiguredOrigin);
+    }
+
+    private static JSObject ok() {
+        return new JSObject().put("ok", true);
+    }
+
+    private static Object nullable(String value) {
+        return value == null ? JSONObject.NULL : value;
+    }
+}

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServersPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServersPlugin.java
@@ -52,26 +52,33 @@ public class SelfHostedServersPlugin extends Plugin {
             call.reject("invalid url");
             return;
         }
-        SelfHostedServer.append(getContext(), server, call.getString("name"));
+        // A dropped write must reject: the store treats a resolved add as a
+        // committed mutation and would publish a card the shell does not hold.
+        if (!SelfHostedServer.append(getContext(), server, call.getString("name"))) {
+            call.reject("unable to remember the server");
+            return;
+        }
         call.resolve(ok());
     }
 
     /**
-     * Forgetting a url that is not (or cannot be) in the list is a no-op, so this
-     * never rejects. Removing the active server clears the active slot, so the
-     * shell reloads back to the baked origin like {@code switchTo({})}.
+     * Forgetting a url that is not (or cannot be) in the list is a no-op, so only
+     * a dropped write rejects. Removing the active server clears the active slot,
+     * so the shell reloads back to the baked origin like {@code switchTo({})}.
      */
     @PluginMethod
     public void remove(PluginCall call) {
-        boolean removedActive = SelfHostedServer.remove(
-            getContext(),
-            SelfHostedServer.validate(call.getString("url"))
-        );
+        URI server = SelfHostedServer.validate(call.getString("url"));
+        boolean wasActive = server != null && SelfHostedServer.isActive(getContext(), server);
+        if (!SelfHostedServer.remove(getContext(), server)) {
+            call.reject("unable to forget the server");
+            return;
+        }
         // Resolve before scheduling the reload: it recreates the activity and
         // tears the web context down, so a caller awaiting this call would
         // otherwise never settle.
         call.resolve(ok());
-        if (removedActive) {
+        if (wasActive) {
             reloadConfiguredOrigin(null);
         }
     }
@@ -128,6 +135,9 @@ public class SelfHostedServersPlugin extends Plugin {
             call.reject("unable to save the server");
             return false;
         }
+        // Unlike `add`, a dropped list write is not worth failing the switch: the
+        // active slot took, so the origin is genuinely changing, and `list` reports
+        // the active url whether or not the stored list carries it.
         SelfHostedServer.append(getContext(), server, null);
         return true;
     }

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServersPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServersPlugin.java
@@ -72,7 +72,7 @@ public class SelfHostedServersPlugin extends Plugin {
         // otherwise never settle.
         call.resolve(ok());
         if (removedActive) {
-            reloadConfiguredOrigin();
+            reloadConfiguredOrigin(null);
         }
     }
 
@@ -83,27 +83,53 @@ public class SelfHostedServersPlugin extends Plugin {
      */
     @PluginMethod
     public void switchTo(PluginCall call) {
-        String raw = call.getString("url");
-        String trimmed = raw == null ? "" : raw.trim();
-        if (trimmed.isEmpty()) {
-            SelfHostedServer.clear(getContext());
-        } else {
-            URI server = SelfHostedServer.validate(trimmed);
-            if (server == null) {
-                call.reject("invalid url");
-                return;
-            }
-            if (!SelfHostedServer.store(getContext(), server)) {
-                // The active slot did not take the write, so the reload below
-                // would land back on the current origin. Report the failure
-                // instead and let the caller navigate.
-                call.reject("unable to save the server");
-                return;
-            }
-            SelfHostedServer.append(getContext(), server, null);
+        if (applyOrigin(call)) {
+            call.resolve(ok());
+            reloadConfiguredOrigin(null);
         }
-        call.resolve(ok());
-        reloadConfiguredOrigin();
+    }
+
+    /**
+     * {@link #switchTo} that also lands on a route relative to the assistant app
+     * entry, so abandoning a flow on one origin arrives somewhere specific on
+     * another rather than at the entry's own redirect.
+     */
+    @PluginMethod
+    public void switchToPath(PluginCall call) {
+        String route = SelfHostedServer.routePath(call.getString("path"));
+        if (route == null) {
+            call.reject("invalid path");
+            return;
+        }
+        if (applyOrigin(call)) {
+            call.resolve(ok());
+            reloadConfiguredOrigin(route);
+        }
+    }
+
+    /**
+     * Point the active slot at the call's url, or clear it when the url is
+     * absent or empty. Answers whether the caller should go on to reload;
+     * rejects the call itself when it should not, so the shell never recreates
+     * onto an origin it failed to record.
+     */
+    private boolean applyOrigin(PluginCall call) {
+        String raw = call.getString("url");
+        if (raw == null || raw.trim().isEmpty()) {
+            SelfHostedServer.clear(getContext());
+            return true;
+        }
+        URI server = SelfHostedServer.validate(raw.trim());
+        if (server == null) {
+            call.reject("invalid url");
+            return false;
+        }
+        if (!SelfHostedServer.store(getContext(), server)) {
+            call.reject("unable to save the server");
+            return false;
+        }
+        SelfHostedServer.append(getContext(), server, null);
+        return true;
     }
 
     /**
@@ -119,12 +145,12 @@ public class SelfHostedServersPlugin extends Plugin {
         );
     }
 
-    private void reloadConfiguredOrigin() {
+    private void reloadConfiguredOrigin(String route) {
         Activity activity = getActivity();
         if (!(activity instanceof MainActivity)) {
             return;
         }
-        activity.runOnUiThread(((MainActivity) activity)::applyConfiguredOrigin);
+        activity.runOnUiThread(() -> ((MainActivity) activity).applyConfiguredOrigin(route));
     }
 
     private static JSObject ok() {

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServersPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServersPlugin.java
@@ -123,7 +123,13 @@ public class SelfHostedServersPlugin extends Plugin {
     private boolean applyOrigin(PluginCall call) {
         String raw = call.getString("url");
         if (raw == null || raw.trim().isEmpty()) {
-            SelfHostedServer.clear(getContext());
+            // A dropped clear leaves the shell on the current self-hosted origin,
+            // so recreating would land right back on it while the caller believes
+            // it reached Vellum Cloud.
+            if (!SelfHostedServer.clear(getContext())) {
+                call.reject("unable to clear the server");
+                return false;
+            }
             return true;
         }
         URI server = SelfHostedServer.validate(raw.trim());

--- a/clients/android/app/src/test/java/ai/vellum/assistant/ConnectDeepLinkTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/ConnectDeepLinkTest.java
@@ -25,6 +25,21 @@ public class ConnectDeepLinkTest {
     }
 
     @Test
+    public void carriesTheOptionalLabelForTheRememberedServerList() {
+        ConnectDeepLink named = ConnectDeepLink.parse(
+            SCHEME + "://connect?url=https%3A%2F%2Fexample.com&code=device-code&name=Studio+Mac",
+            SCHEME
+        );
+        ConnectDeepLink unnamed = ConnectDeepLink.parse(
+            SCHEME + "://connect?url=https%3A%2F%2Fexample.com&code=device-code",
+            SCHEME
+        );
+
+        assertEquals("Studio Mac", named.name());
+        assertNull(unnamed.name());
+    }
+
+    @Test
     public void preservesEscapedSeparatorsInPairingPrefixes() {
         ConnectDeepLink connect = ConnectDeepLink.parse(
             SCHEME + "://connect?url=https%3A%2F%2Fexample.com%2Ftenant%252Fabc&code=device-code",

--- a/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.net.URI;
+import java.util.List;
 import org.junit.Test;
 
 public class SelfHostedServerTest {
@@ -102,8 +103,107 @@ public class SelfHostedServerTest {
         assertFalse(SelfHostedServer.samePage(pairPage, "https://example.com/other/assistant/pair"));
     }
 
+    @Test
+    public void collapsesTheDefaultPortSoCanonicalUrlsMatchTheWebStore() {
+        assertEquals("https://example.com/tenant", SelfHostedServer.validate("https://example.com:443/tenant").toASCIIString());
+        assertEquals("http://localhost", SelfHostedServer.validate("http://localhost:80").toASCIIString());
+    }
+
+    @Test
+    public void appendsTheAppEntrySegmentOnlyWhereItIsMissing() {
+        assertEquals("https://example.com/assistant", SelfHostedServer.appEntry(URI.create("https://example.com")).toASCIIString());
+        assertEquals(
+            "https://example.com/assistant-123/assistant",
+            SelfHostedServer.appEntry(URI.create("https://example.com/assistant-123")).toASCIIString()
+        );
+        assertEquals(
+            "https://example.com/assistant",
+            SelfHostedServer.appEntry(URI.create("https://example.com/assistant")).toASCIIString()
+        );
+    }
+
+    @Test
+    public void remembersServersDedupedByCanonicalUrl() {
+        FakeStore store = new FakeStore();
+
+        SelfHostedServer.append(store, SelfHostedServer.validate("https://example.com/assistant-123"), "Work");
+        SelfHostedServer.append(store, SelfHostedServer.validate("HTTPS://Example.com:443/assistant-123/"), null);
+        SelfHostedServer.append(store, SelfHostedServer.validate("https://other.example.com"), "  ");
+
+        List<SelfHostedServer.Entry> servers = SelfHostedServer.servers(store);
+        assertEquals(2, servers.size());
+        assertEquals("https://example.com/assistant-123", servers.get(0).url);
+        assertEquals("Work", servers.get(0).name);
+        assertEquals("https://other.example.com", servers.get(1).url);
+        assertNull(servers.get(1).name);
+    }
+
+    @Test
+    public void keepsTheStoredLabelOnANamelessReAppend() {
+        FakeStore store = new FakeStore();
+        URI server = SelfHostedServer.validate("https://example.com");
+
+        SelfHostedServer.append(store, server, "Kitchen");
+        SelfHostedServer.append(store, server, null);
+        assertEquals("Kitchen", SelfHostedServer.servers(store).get(0).name);
+
+        SelfHostedServer.append(store, server, "Studio");
+        assertEquals("Studio", SelfHostedServer.servers(store).get(0).name);
+    }
+
+    @Test
+    public void listsAnActiveServerThatPredatesTheRememberedList() {
+        FakeStore store = new FakeStore();
+        URI server = SelfHostedServer.validate("https://example.com/assistant-123");
+        SelfHostedServer.store(store, server);
+
+        List<SelfHostedServer.Entry> servers = SelfHostedServer.servers(store);
+        assertEquals(1, servers.size());
+        assertEquals("https://example.com/assistant-123", servers.get(0).url);
+    }
+
+    @Test
+    public void forgettingTheActiveServerReturnsTheShellToVellumCloud() {
+        FakeStore store = new FakeStore();
+        URI active = SelfHostedServer.validate("https://example.com");
+        URI other = SelfHostedServer.validate("https://other.example.com");
+        SelfHostedServer.append(store, active, null);
+        SelfHostedServer.append(store, other, null);
+        SelfHostedServer.store(store, active);
+
+        assertFalse(SelfHostedServer.remove(store, other));
+        assertEquals(1, SelfHostedServer.servers(store).size());
+        assertEquals(active, SelfHostedServer.configured(store));
+
+        assertTrue(SelfHostedServer.remove(store, active));
+        assertTrue(SelfHostedServer.servers(store).isEmpty());
+        assertNull(SelfHostedServer.configured(store));
+    }
+
+    @Test
+    public void aCorruptListCostsTheListRatherThanTheLaunch() {
+        FakeStore store = new FakeStore();
+        store.writeServers("not json");
+        SelfHostedServer.store(store, SelfHostedServer.validate("https://example.com"));
+
+        List<SelfHostedServer.Entry> servers = SelfHostedServer.servers(store);
+        assertEquals(1, servers.size());
+        assertEquals("https://example.com", servers.get(0).url);
+    }
+
+    @Test
+    public void entriesThatNoLongerValidateAreDropped() {
+        FakeStore store = new FakeStore();
+        store.writeServers("[{\"url\":\"http://example.com\"},{\"name\":\"Ok\",\"url\":\"https://example.com\"},{}]");
+
+        List<SelfHostedServer.Entry> servers = SelfHostedServer.servers(store);
+        assertEquals(1, servers.size());
+        assertEquals("Ok", servers.get(0).name);
+    }
+
     private static final class FakeStore implements SelfHostedServer.Store {
         private String value;
+        private String servers;
 
         @Override
         public String read() {
@@ -119,6 +219,16 @@ public class SelfHostedServerTest {
         @Override
         public void clear() {
             value = null;
+        }
+
+        @Override
+        public String readServers() {
+            return servers;
+        }
+
+        @Override
+        public void writeServers(String value) {
+            servers = value;
         }
     }
 }

--- a/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
@@ -123,6 +123,34 @@ public class SelfHostedServerTest {
     }
 
     @Test
+    public void acceptsOnlyRoutesThatStayUnderTheAppEntry() {
+        assertEquals("select-assistant?noAutoSkip=1", SelfHostedServer.routePath("select-assistant?noAutoSkip=1"));
+        assertEquals("settings/general", SelfHostedServer.routePath("  settings/general  "));
+
+        assertNull(SelfHostedServer.routePath(null));
+        assertNull(SelfHostedServer.routePath(""));
+        assertNull(SelfHostedServer.routePath("/select-assistant"));
+        assertNull(SelfHostedServer.routePath("//other.example.com/select-assistant"));
+        assertNull(SelfHostedServer.routePath("https://other.example.com/select-assistant"));
+        assertNull(SelfHostedServer.routePath("select-assistant#device_code=secret"));
+        assertNull(SelfHostedServer.routePath("../../escape"));
+        assertNull(SelfHostedServer.routePath("tenant/%2e%2e/escape"));
+    }
+
+    @Test
+    public void hangsRoutesOffTheAppEntrySoHostingPrefixesSurvive() {
+        assertEquals(
+            "https://example.com/assistant-123/assistant/select-assistant?noAutoSkip=1",
+            SelfHostedServer
+                .appRoute(
+                    SelfHostedServer.appEntry(SelfHostedServer.validate("https://example.com/assistant-123")),
+                    SelfHostedServer.routePath("select-assistant?noAutoSkip=1")
+                )
+                .toASCIIString()
+        );
+    }
+
+    @Test
     public void remembersServersDedupedByCanonicalUrl() {
         FakeStore store = new FakeStore();
 

--- a/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
@@ -110,16 +110,35 @@ public class SelfHostedServerTest {
     }
 
     @Test
-    public void appendsTheAppEntrySegmentOnlyWhereItIsMissing() {
+    public void appendsTheAppEntrySegmentToEverySelfHostedBase() {
         assertEquals("https://example.com/assistant", SelfHostedServer.appEntry(URI.create("https://example.com")).toASCIIString());
         assertEquals(
             "https://example.com/assistant-123/assistant",
             SelfHostedServer.appEntry(URI.create("https://example.com/assistant-123")).toASCIIString()
         );
+        // A base hosted at an /assistant prefix has its entry one level deeper,
+        // matching the pair page a connect link for it opens.
         assertEquals(
-            "https://example.com/assistant",
+            "https://example.com/assistant/assistant",
             SelfHostedServer.appEntry(URI.create("https://example.com/assistant")).toASCIIString()
         );
+    }
+
+    @Test
+    public void reportsADroppedListWriteRatherThanClaimingTheMutationLanded() {
+        FakeStore store = new FakeStore();
+        URI server = SelfHostedServer.validate("https://example.com");
+        store.serversWritable = false;
+
+        assertFalse(SelfHostedServer.append(store, server, null));
+
+        store.serversWritable = true;
+        assertTrue(SelfHostedServer.append(store, server, null));
+        // Forgetting a url the list never held needs no write, so it succeeds.
+        assertTrue(SelfHostedServer.remove(store, SelfHostedServer.validate("https://other.example.com")));
+
+        store.serversWritable = false;
+        assertFalse(SelfHostedServer.remove(store, server));
     }
 
     @Test
@@ -199,8 +218,9 @@ public class SelfHostedServerTest {
         SelfHostedServer.append(store, other, null);
         SelfHostedServer.store(store, active);
 
-        assertFalse(SelfHostedServer.remove(store, other));
+        assertTrue(SelfHostedServer.remove(store, other));
         assertEquals(1, SelfHostedServer.servers(store).size());
+        assertTrue(SelfHostedServer.isActive(store, active));
         assertEquals(active, SelfHostedServer.configured(store));
 
         assertTrue(SelfHostedServer.remove(store, active));
@@ -232,6 +252,7 @@ public class SelfHostedServerTest {
     private static final class FakeStore implements SelfHostedServer.Store {
         private String value;
         private String servers;
+        private boolean serversWritable = true;
 
         @Override
         public String read() {
@@ -255,8 +276,12 @@ public class SelfHostedServerTest {
         }
 
         @Override
-        public void writeServers(String value) {
+        public boolean writeServers(String value) {
+            if (!serversWritable) {
+                return false;
+            }
             servers = value;
+            return true;
         }
     }
 }

--- a/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
@@ -142,6 +142,32 @@ public class SelfHostedServerTest {
     }
 
     @Test
+    public void aFailedRemovalLeavesTheActiveServerServing() {
+        FakeStore store = new FakeStore();
+        URI server = SelfHostedServer.validate("https://example.com");
+        SelfHostedServer.append(store, server, null);
+        SelfHostedServer.store(store, server);
+        store.serversWritable = false;
+
+        assertFalse(SelfHostedServer.remove(store, server));
+        // The list write goes first precisely so this stays put: a cleared slot
+        // here would relaunch onto Vellum Cloud after a reported failure.
+        assertEquals(server, SelfHostedServer.configured(store));
+    }
+
+    @Test
+    public void reportsADroppedClearRatherThanClaimingTheShellLeftTheOrigin() {
+        FakeStore store = new FakeStore();
+        URI server = SelfHostedServer.validate("https://example.com");
+        SelfHostedServer.store(store, server);
+        store.activeWritable = false;
+
+        assertFalse(SelfHostedServer.clear(store));
+        assertFalse(SelfHostedServer.remove(store, server));
+        assertEquals(server, SelfHostedServer.configured(store));
+    }
+
+    @Test
     public void acceptsOnlyRoutesThatStayUnderTheAppEntry() {
         assertEquals("select-assistant?noAutoSkip=1", SelfHostedServer.routePath("select-assistant?noAutoSkip=1"));
         assertEquals("settings/general", SelfHostedServer.routePath("  settings/general  "));
@@ -253,6 +279,7 @@ public class SelfHostedServerTest {
         private String value;
         private String servers;
         private boolean serversWritable = true;
+        private boolean activeWritable = true;
 
         @Override
         public String read() {
@@ -261,13 +288,20 @@ public class SelfHostedServerTest {
 
         @Override
         public boolean write(String value) {
+            if (!activeWritable) {
+                return false;
+            }
             this.value = value;
             return true;
         }
 
         @Override
-        public void clear() {
+        public boolean clear() {
+            if (!activeWritable) {
+                return false;
+            }
             value = null;
+            return true;
         }
 
         @Override

--- a/clients/android/variables.gradle
+++ b/clients/android/variables.gradle
@@ -11,6 +11,7 @@ ext {
     coreSplashScreenVersion = '1.2.0'
     androidxWebkitVersion = '1.14.0'
     junitVersion = '4.13.2'
+    jsonVersion = '20240303'
     androidxJunitVersion = '1.3.0'
     androidxEspressoCoreVersion = '3.7.0'
     cordovaAndroidVersion = '14.0.1'

--- a/clients/web/docs/CAPACITOR.md
+++ b/clients/web/docs/CAPACITOR.md
@@ -235,6 +235,7 @@ The bridge contract:
 | `add({url, name?})` | `{ ok }` | Deduped by canonical url. A nameless re-add keeps the stored label |
 | `remove({url})` | `{ ok }` | Forgetting the active url also clears the active slot, so the shell returns to the baked origin |
 | `switchTo({url?})` | `{ ok }` | Swaps the active slot and reloads in place. An absent or empty `url` returns to the baked origin |
+| `switchToPath({url?, path})` | `{ ok }` | `switchTo` that also lands on `path`, relative to the assistant app entry. Rejects a `path` that could leave the entry (absolute, rooted, dot-segmented, or carrying a fragment) |
 
 Only genuinely invalid caller input rejects (an `add` or `switchTo` url that
 fails `SelfHostedServer.validate`). Empty state resolves with an empty list and
@@ -257,8 +258,15 @@ takes https only, so they are dropped on the way in and never reach the chooser.
 **Only the reload mechanism differs by shell.** iOS points the existing
 `WKWebView` at the new origin. Android bakes the origin into the Capacitor
 config at `onCreate`, so `switchTo` writes the preference and recreates the
-activity, whose fresh `onCreate` re-reads it. Both resolve the call before the
-reload tears the web context down, so an awaiting caller always settles.
+activity, whose fresh `onCreate` re-reads it; a `switchToPath` route rides a
+static across that recreate and loads once the bridge is up. Both resolve the
+call before the reload tears the web context down, so an awaiting caller always
+settles.
+
+`switchToPath` exists so abandoning a flow on one origin is atomic. The pairing
+page's Cancel is the caller: it has to both leave the origin and land on the
+hub's chooser, and doing that as a plain navigation would leave the half-paired
+origin in the active slot, so the next launch would return to it.
 
 **Switching is per surface, and every surface has a working answer.**
 

--- a/clients/web/docs/CAPACITOR.md
+++ b/clients/web/docs/CAPACITOR.md
@@ -216,13 +216,16 @@ References:
 
 The assistant chooser offers every origin this device knows about. On a native
 mobile shell those origins live natively, not in web storage, because the shell
-is the only thing that can point its `WKWebView` somewhere else without leaving
-the app, and because the same list is written by the native Settings pane and
-the `<scheme>://connect` deep link. The web side is
-[`src/runtime/self-hosted-servers.ts`](../src/runtime/self-hosted-servers.ts);
-the native side is
-[`SelfHostedServersPlugin.swift`](../../../clients/ios/App/App/SelfHostedServersPlugin.swift)
-over [`SelfHostedServer.swift`](../../../clients/ios/App/App/SelfHostedServer.swift).
+is the only thing that can point its web view somewhere else without leaving
+the app, and because the same list is written by the `<scheme>://connect` deep
+link (and, on iOS, the native Settings pane). The web side is
+[`src/runtime/self-hosted-servers.ts`](../src/runtime/self-hosted-servers.ts)
+and is shared; both shells implement the same bridge:
+
+| Shell | Plugin | Store |
+| --- | --- | --- |
+| iOS | [`SelfHostedServersPlugin.swift`](../../../clients/ios/App/App/SelfHostedServersPlugin.swift) | [`SelfHostedServer.swift`](../../../clients/ios/App/App/SelfHostedServer.swift) (`UserDefaults`) |
+| Android | [`SelfHostedServersPlugin.java`](../../../clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServersPlugin.java) | [`SelfHostedServer.java`](../../../clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java) (`SharedPreferences`) |
 
 The bridge contract:
 
@@ -237,11 +240,25 @@ Only genuinely invalid caller input rejects (an `add` or `switchTo` url that
 fails `SelfHostedServer.validate`). Empty state resolves with an empty list and
 nulls, so there is no "not configured" error branch to write.
 
-Urls cross the bridge in one canonical form: `SelfHostedServer.canonicalize` and
-the store's `normalizeOriginUrl` implement the same rules (lowercase scheme and
-host, userinfo dropped, trailing slashes stripped, query and fragment dropped,
-path and port preserved), so both sides agree on which strings mean the same
-server. Changing one means changing the other.
+Urls cross the bridge in one canonical form: iOS's
+`SelfHostedServer.canonicalize`, Android's `SelfHostedServer.validate`, and the
+store's `normalizeOriginUrl` produce the same string (lowercase scheme and host,
+userinfo stripped, trailing slashes stripped, no query or fragment, the scheme's
+default port collapsed, path preserved), so all three agree on which strings
+mean the same server. Changing one means changing the others.
+
+Two deliberate differences sit behind that shared form. Android *rejects* a
+candidate carrying userinfo, a query, or a fragment where iOS strips it, and
+Android additionally admits `http:` for `localhost`, `127.0.0.1`, and the
+emulator alias `10.0.2.2`. Those cleartext dev entries are the one case where
+the native list holds something the web store will not: `normalizeOriginUrl`
+takes https only, so they are dropped on the way in and never reach the chooser.
+
+**Only the reload mechanism differs by shell.** iOS points the existing
+`WKWebView` at the new origin. Android bakes the origin into the Capacitor
+config at `onCreate`, so `switchTo` writes the preference and recreates the
+activity, whose fresh `onCreate` re-reads it. Both resolve the call before the
+reload tears the web context down, so an awaiting caller always settles.
 
 **Switching is per surface, and every surface has a working answer.**
 


### PR DESCRIPTION
## Summary

- Adds `SelfHostedServersPlugin.java` and grows `SelfHostedServer.java` from a single active slot into an active slot plus a remembered `{name?, url}` list, implementing the same `SelfHostedServers` bridge contract as iOS (`list` / `add` / `remove` / `switchTo`). The web chooser is already platform-neutral (`isNativeMobile()`), so no web code changes: Android was simply missing the native side, which left it on the localStorage provider with no in-app origin switching and no "Vellum Cloud" card.
- Switching reloads in place. Android bakes `server.url` into the Capacitor config at `onCreate`, so `switchTo` writes the preference and recreates the activity (resolving the call first, since the recreate tears the web context down). Canonical urls now collapse the scheme's default port so they match the web store's `normalizeOriginUrl`, which keys the same list.
- Closes three pairing gaps against iOS: `<scheme>://connect` accepts an optional `name` label for the chooser card; a paired server joins the remembered list at the same moment its base is promoted (once the pair page loads, so an unreachable origin leaves no card behind); and the shell now loads `<base>/assistant` rather than the bare base, because the ingress redirects a bare `/` to an absolute `/assistant/` and would drop a hosting path prefix on relaunch.

## Original prompt

Bring the assistant switcher page to Android the way it already works on iOS, and reach feature parity for pairing to local assistants between the two shells, with iOS as the reference implementation. This follows the origin-model assistant chooser arc, which shipped iOS first and deliberately deferred Android shell work while designing the plugin contract to be cross-platform.

## Testing

No JDK or Android SDK on the dev machine and Android unit tests do not run in CI, so the suite was compiled and run against a temporary JDK 17 with stubbed `android.*` / Capacitor classes: **26/26 pass**, including 8 new cases (list dedupe and canonical identity, rename-vs-nameless-re-append, active-server-predating-the-list, forget-the-active-server, corrupt-preference tolerance, default-port collapse, app-entry segment, and the deep link's `name`). `SelfHostedServersPlugin.java` was compile-checked the same way against Capacitor-shaped stubs. Unit tests needed a real `org.json` on the test classpath, since the mockable `android.jar` stubs it into throwing.

**Not verified on a device.** The origin switch, the connect-deep-link append, and the `/assistant` boot path all want a real handset pass before the flag goes on for Android.