### PR TITLE
fix(web): restore the Contacts and Channels cards on iOS and Android (LUM-3136)

### DIFF
--- a/clients/web/src/domains/intelligence/components/identity-overview.tsx
+++ b/clients/web/src/domains/intelligence/components/identity-overview.tsx
@@ -204,8 +204,8 @@ export function IdentityOverview({ assistantId }: IdentityOverviewProps) {
   } = useAssistantAvatar(assistantId);
   const identityQuery = useAssistantIdentityDetails(assistantId);
   const supportsPlugins = useSupportsPluginsSurface();
-  // The native mobile shells drop the Memory, Workspace, Contacts and
-  // Channels cards, so their measurements are dead reads there.
+  // The native mobile shells drop the Memory and Workspace cards, so those
+  // two measurements are dead reads there.
   const isNativeMobile = useIsNativeMobile();
   const stats = useIdentitySectionStats(assistantId, {
     supportsPlugins,

--- a/clients/web/src/domains/intelligence/components/identity-sections.test.ts
+++ b/clients/web/src/domains/intelligence/components/identity-sections.test.ts
@@ -3,8 +3,8 @@
  * on backend capability. Whatever the backend reports, the list is the same,
  * so an assistant that can't draw the memory concept graph still gets a
  * Memory card leading into the tab that explains it. The one subtraction is
- * the native mobile shell, which omits the sections whose UI is not ready
- * for a phone.
+ * the native mobile shell, which omits the two sections that are desk work
+ * (Memory and Workspace) and keeps everything a phone user needs to reach.
  */
 import { describe, expect, test } from "bun:test";
 
@@ -35,18 +35,27 @@ describe("buildIdentitySections", () => {
     expect(keys()).toContain("memory");
   });
 
-  test("always includes Channels off native mobile", () => {
-    expect(keys()).toContain("channels");
-  });
-
-  test("native mobile drops Memory, Workspace, Contacts and Channels", () => {
+  test("native mobile drops Memory and Workspace, and nothing else", () => {
     expect(keys(true)).toEqual([
       "personality",
       "schedules",
       "superpowers",
       "library",
+      "contacts",
+      "channels",
     ]);
   });
+
+  // LUM-3136: the phone shells briefly hid these two for having rough UI,
+  // which read as a broken home screen. Checking who the assistant knows and
+  // where it listens is mobile work, so the filter must never take them.
+  test.each(["contacts", "channels"])(
+    "keeps %s on every platform, phone included",
+    (key) => {
+      expect(keys(true)).toContain(key);
+      expect(keys(false)).toContain(key);
+    },
+  );
 
   test("native mobile keeps the remaining sections in their desktop order", () => {
     const nativeMobile = keys(true);

--- a/clients/web/src/domains/intelligence/components/identity-sections.test.ts
+++ b/clients/web/src/domains/intelligence/components/identity-sections.test.ts
@@ -46,9 +46,9 @@ describe("buildIdentitySections", () => {
     ]);
   });
 
-  // LUM-3136: the phone shells briefly hid these two for having rough UI,
-  // which read as a broken home screen. Checking who the assistant knows and
-  // where it listens is mobile work, so the filter must never take them.
+  // Checking who the assistant knows and where it listens is mobile work,
+  // so the native mobile filter must never drop Contacts or Channels
+  // (LUM-3136).
   test.each(["contacts", "channels"])(
     "keeps %s on every platform, phone included",
     (key) => {

--- a/clients/web/src/domains/intelligence/components/identity-sections.ts
+++ b/clients/web/src/domains/intelligence/components/identity-sections.ts
@@ -31,18 +31,22 @@ function section(
 }
 
 /**
- * Sections the native mobile shells leave off the overview. Their UI needs
- * more work before it earns a place on a phone, so on iOS and Android they
- * offer the user little. Only the overview cards go: the routes stay
- * registered and reachable by deep link, so putting a section back is a
- * single edit to this list once its mobile UI is ready.
+ * Sections the native mobile shells leave off the overview. The test is
+ * whether the task belongs on a phone, not how finished the surface looks:
+ * curating memories and browsing host files are desk work, so on iOS and
+ * Android those two are noise.
+ *
+ * Contacts and Channels are deliberately absent from this list. Who the
+ * assistant knows and where it listens are exactly what someone needs to
+ * check and change while away from their desk, so they earn a card even
+ * though their mobile UI is still rough. An unpolished way in beats no way
+ * in. Do not re-add them for looking unfinished; that is a reason to polish
+ * them, not to hide them.
+ *
+ * Only the overview cards go: the routes stay registered and reachable by
+ * deep link, so moving a section either way is a single edit to this list.
  */
-const NATIVE_MOBILE_HIDDEN_KEYS: readonly string[] = [
-  "memory",
-  "workspace",
-  "contacts",
-  "channels",
-];
+const NATIVE_MOBILE_HIDDEN_KEYS: readonly string[] = ["memory", "workspace"];
 
 export interface BuildIdentitySectionsOptions {
   /** True inside the iOS or Android Capacitor shell. */

--- a/clients/web/src/domains/intelligence/use-identity-section-stats.ts
+++ b/clients/web/src/domains/intelligence/use-identity-section-stats.ts
@@ -105,13 +105,11 @@ export function useIdentitySectionStats(
     ...contactsGetOptions({ path }),
     select: (data) => data.contacts.length,
     ...common,
-    enabled: !isNativeMobile,
   });
   const channels = useQuery({
     ...channelsReadinessGetOptions({ path }),
     select: (data) => data.snapshots.filter((s) => s.ready).length,
     ...common,
-    enabled: !isNativeMobile,
   });
   // Shares the schedules cache entry owned by `fetchSchedules` (Settings
   // and the Activity page key it identically with a `Schedule[]` payload)


### PR DESCRIPTION
## TL;DR

The iOS and Android home screen shows four cards and then half a screen of empty background. #40216 filtered Memory, Workspace, Contacts and Channels off the phone shells because their mobile UI was not finished. This restores **Contacts** and **Channels**, and keeps Memory and Workspace hidden.

Fixes LUM-3136.

## Why restore these two specifically

Not because their UI got better. It did not. They come back because **they are things a user actually wants and needs to do from their phone**, and polish is a separate question from access.

- **Contacts** is who the assistant knows. Checking or correcting that is exactly the kind of thing you do away from your desk.
- **Channels** is where the assistant listens. If it is posting in the wrong place, or you need to see whether a channel is connected, you need that on your phone, not when you next sit down at a laptop.

For both, a rough way in beats no way in. Hiding a card because the page behind it looks unfinished takes the capability away entirely; it does not make the page better. The comment on the hidden-keys list now says this outright, so the next person reading it does not "fix" the unpolished UI by hiding it again.

**Memory** and **Workspace** stay hidden, and that is deliberate rather than deferred triage. Curating memories and browsing files on the host machine are desk work. A phone loses little by leaving them out, and neither has the same "I need this right now, from here" character as the two above.

## What changes for the user

| | Before | After |
|---|---|---|
| Home screen on iOS / Android | Personality, Schedules, My Superpowers, Library, then a large empty gap | Those four plus Contacts and Channels, filling the grid as two rows of two |
| Reaching your contact list from a phone | No entry point on the home screen; deep link only | Tap the Contacts card |
| Reaching channel wiring from a phone | No entry point on the home screen; deep link only | Tap the Channels card |
| Contacts / Channels card stat line | Not shown (the reads were switched off on mobile) | Shows the count, same as desktop |
| Memory and Workspace on a phone | Hidden | Still hidden, unchanged |
| Desktop and desktop web | All eight cards | Unchanged |

Worth stating plainly for whoever reviews the report: Maggie's question on LUM-3136, "Are they intentionally hidden?", was literally yes. This was working as designed. The design was wrong for two of the four.

## Why this is safe

- **One-line data change at a single chokepoint.** `NATIVE_MOBILE_HIDDEN_KEYS` goes from four keys to two. Both layouts, the desktop bento strip and the mobile stacked grid, build from the same `buildIdentitySections()` array, so they follow from the one edit with no layout code touched.
- **No new rendering path.** These two cards already render on every desktop and mobile-web session today. The phone grid returns to the exact shape it had before #40216, four mini tiles in two columns, which had shipped and was fine.
- **The re-enabled reads are the same two queries the cards used before #40216**, restored by deleting the `enabled: !isNativeMobile` overrides added in that PR. They keep the shared `retry: false` and 60s stale time, and both stats already degrade to a card with no stat line on loading or error, so a failed read cannot break the home screen.
- **No route, permission, flag or backend change.** Both routes stayed registered and deep-link reachable throughout; only the cards were gone.
- **Test coverage is a named regression guard.** The mobile list is asserted with a full `toEqual`, so any future addition to the hidden list fails loudly, plus a `test.each` that pins Contacts and Channels as present on every platform and cites LUM-3136 for why.

Verified: `typecheck`, `eslint` and `prettier --check` all clean. The Bun suites are blocked from running locally on this machine by a standing rule, so `identity-sections.test.ts` runs in CI here.

## Deferred, with reasons

- **`useIsNativeMobile()` is shell detection, not size detection.** It requires `Capacitor.isNativePlatform()`, so the same phone in mobile Safari still gets all eight cards, including the two judged unfit for a phone. Same device, same viewport, two different home screens. That inconsistency predates this PR and is a separate fix (re-gate on viewport, or accept the split deliberately); folding it in here would turn a two-key data change into a behavior change for every mobile-web user. Filed as [LUM-3138](https://linear.app/vellum/issue/LUM-3138/home-screen-card-set-differs-between-the-phone-app-and-mobile-web).
- **Polish for the Contacts and Channels mobile UI.** Still genuinely rough, still worth doing. This PR restores access; it does not claim to have improved either page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
