### PR TITLE
fix(security): run a queued turn under its sender's trust (LUM-3135)

### DIFF
--- a/assistant/src/__tests__/conversation-process-app-control-preactivation.test.ts
+++ b/assistant/src/__tests__/conversation-process-app-control-preactivation.test.ts
@@ -86,6 +86,7 @@ import {
   MessageQueue,
   type QueuedMessage,
 } from "../daemon/conversation-queue-manager.js";
+import type { TrustContext } from "../daemon/trust-context-types.js";
 
 // ---------------------------------------------------------------------------
 // Fake context — captures preactivation calls, satisfies the bare minimum
@@ -172,6 +173,7 @@ function makeQueuedMessage(opts: {
   content?: string;
   turnInterfaceContext?: TurnInterfaceContext;
   sourceActorPrincipalId?: string;
+  trustContext?: TrustContext;
 }): QueuedMessage {
   return {
     content: opts.content ?? "follow up",
@@ -185,6 +187,7 @@ function makeQueuedMessage(opts: {
     authContext: opts.sourceActorPrincipalId
       ? ({ actorPrincipalId: opts.sourceActorPrincipalId } as never)
       : undefined,
+    trustContext: opts.trustContext,
   };
 }
 
@@ -369,6 +372,126 @@ describe("drainQueue preactivation re-add for host-proxy interfaces", () => {
       "trusted-contact-user",
     );
     expect(ctx.currentTurnSourceActorPrincipalId).toBe("trusted-contact-user");
+  });
+
+  test("drainSingleMessage runs the turn under the queued sender's trust, not the live slot", async () => {
+    // The conversation-level slot holds whichever actor sent most recently.
+    // A message that waited while someone else sent must still run as its own
+    // sender: trust decides `trustClass`, `executionChannel`, and
+    // `requesterExternalUserId`, so reading the slot hands the whole
+    // tool-approval path the wrong identity in both directions -- a contact
+    // inheriting guardian self-approval, or a guardian's own call escalating
+    // back to her as a contact's grant request.
+    const contactTrust: TrustContext = {
+      trustClass: "trusted_contact",
+      sourceChannel: "slack",
+      requesterExternalUserId: "U-contact",
+    };
+    const queue = new MessageQueue();
+    queue.push(
+      makeQueuedMessage({
+        requestId: "req-contact",
+        trustContext: contactTrust,
+      }),
+    );
+    const ctx = makeFakeContext({ queue });
+    // Someone else sent after this message was queued, moving the slot.
+    ctx.trustContext = {
+      trustClass: "guardian",
+      sourceChannel: "vellum",
+      requesterExternalUserId: "guardian-principal",
+    };
+
+    await drainQueue(ctx);
+
+    expect(ctx.currentTurnTrustContext?.trustClass).toBe("trusted_contact");
+    expect(ctx.currentTurnTrustContext?.requesterExternalUserId).toBe(
+      "U-contact",
+    );
+    expect(ctx.currentTurnTrustContext?.sourceChannel).toBe("slack");
+    // The slot itself is left alone; only the turn's view is corrected.
+    expect(ctx.trustContext?.trustClass).toBe("guardian");
+  });
+
+  test("buildPassthroughBatch refuses to coalesce two channel senders", async () => {
+    // Channel senders carry no principal, so the `sourceActorPrincipalId`
+    // boundary sees `undefined === undefined` and would batch two different
+    // Slack contacts into one turn running under the head's trust. The batch
+    // must split on the sender's trust identity instead.
+    const ifCtx: TurnInterfaceContext = {
+      userMessageInterface: "web",
+      assistantMessageInterface: "web",
+    };
+    const queue = new MessageQueue();
+    queue.push(
+      makeQueuedMessage({
+        requestId: "req-contact-a",
+        content: "from A",
+        turnInterfaceContext: ifCtx,
+        trustContext: {
+          trustClass: "trusted_contact",
+          sourceChannel: "slack",
+          requesterExternalUserId: "U-alex",
+        },
+      }),
+    );
+    queue.push(
+      makeQueuedMessage({
+        requestId: "req-contact-b",
+        content: "from B",
+        turnInterfaceContext: ifCtx,
+        trustContext: {
+          trustClass: "trusted_contact",
+          sourceChannel: "slack",
+          requesterExternalUserId: "U-blake",
+        },
+      }),
+    );
+    const ctx = makeFakeContext({ queue, turnInterfaceContext: ifCtx });
+
+    await drainQueue(ctx);
+
+    // B stays queued: it gets its own turn under its own trust.
+    expect(queue.length).toBe(1);
+    expect(queue.peek(0)?.requestId).toBe("req-contact-b");
+    expect(ctx.currentTurnTrustContext?.requesterExternalUserId).toBe("U-alex");
+  });
+
+  test("buildPassthroughBatch still coalesces two messages from the same sender", async () => {
+    // Sensitivity check on the split above: identical trust must still batch,
+    // otherwise the boundary would be splitting on something incidental and
+    // the test above would pass for the wrong reason.
+    const ifCtx: TurnInterfaceContext = {
+      userMessageInterface: "web",
+      assistantMessageInterface: "web",
+    };
+    const sameTrust: TrustContext = {
+      trustClass: "trusted_contact",
+      sourceChannel: "slack",
+      requesterExternalUserId: "U-alex",
+    };
+    const queue = new MessageQueue();
+    queue.push(
+      makeQueuedMessage({
+        requestId: "req-a1",
+        content: "first",
+        turnInterfaceContext: ifCtx,
+        trustContext: { ...sameTrust },
+      }),
+    );
+    queue.push(
+      makeQueuedMessage({
+        requestId: "req-a2",
+        content: "second",
+        turnInterfaceContext: ifCtx,
+        trustContext: { ...sameTrust },
+      }),
+    );
+    const ctx = makeFakeContext({ queue, turnInterfaceContext: ifCtx });
+
+    await drainQueue(ctx);
+
+    expect(queue.length).toBe(0);
   });
 
   test("drainSingleMessage does NOT re-add 'app-control' for web-sourced message when no capable client is connected", async () => {

--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -597,6 +597,57 @@ describe("Conversation message queue", () => {
     await new Promise((r) => setTimeout(r, 10));
   });
 
+  test("a drained turn keeps its sender's trust once the agent loop is running", async () => {
+    // Exercises the real drain -> runAgentLoop ordering against a live
+    // Conversation. The loop re-initializes the per-turn trust snapshot on
+    // entry, so a drain that only stamped the field before calling it would
+    // have that stamp silently undone and the turn would execute as whoever
+    // sent most recently. Asserting inside the run is the point: checking
+    // before the loop starts passes either way.
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+
+    conversation.setTrustContext({
+      trustClass: "trusted_contact",
+      sourceChannel: "slack",
+      requesterExternalUserId: "U-contact",
+    });
+
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      onEvent: () => {},
+      requestId: "req-1",
+    });
+    await waitForPendingRun(1);
+
+    conversation.enqueueMessage({ content: "msg-2", requestId: "req-2" });
+
+    // The guardian sends while the contact's message waits, moving the slot.
+    conversation.setTrustContext({
+      trustClass: "guardian",
+      sourceChannel: "vellum",
+      requesterExternalUserId: "guardian-principal",
+    });
+
+    // Finish the first turn so the queue drains into a second run.
+    await resolveRun(0);
+    await p1;
+    await waitForPendingRun(2);
+
+    // Read while run 2 is in flight: this is what tool setup and the
+    // guardian-request producers resolve against.
+    expect(conversation.currentTurnTrustContext?.trustClass).toBe(
+      "trusted_contact",
+    );
+    expect(conversation.currentTurnTrustContext?.requesterExternalUserId).toBe(
+      "U-contact",
+    );
+
+    await resolveRun(1);
+    await new Promise((r) => setTimeout(r, 10));
+  });
+
   test("[experimental] queued passthrough siblings drain as a single batched run", async () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();

--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -556,6 +556,47 @@ describe("Conversation message queue", () => {
     await new Promise((r) => setTimeout(r, 10));
   });
 
+  test("enqueueMessage captures the sender's trust, immune to a later slot change", async () => {
+    // Trust must ride with the queued message. The conversation-level slot is
+    // rewritten by whoever sends next, so a message that reads it at drain time
+    // would run as the wrong actor. Capturing at enqueue is what makes the
+    // drain's identity independent of who sent afterwards.
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+
+    conversation.setTrustContext({
+      trustClass: "trusted_contact",
+      sourceChannel: "slack",
+      requesterExternalUserId: "U-contact",
+    });
+
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      onEvent: () => {},
+      requestId: "req-1",
+    });
+    await waitForPendingRun(1);
+
+    conversation.enqueueMessage({ content: "msg-2", requestId: "req-2" });
+
+    // A different actor sends while the message waits, moving the slot.
+    conversation.setTrustContext({
+      trustClass: "guardian",
+      sourceChannel: "vellum",
+      requesterExternalUserId: "guardian-principal",
+    });
+
+    const queued = conversation.queue.peek(0);
+    expect(queued?.requestId).toBe("req-2");
+    expect(queued?.trustContext?.trustClass).toBe("trusted_contact");
+    expect(queued?.trustContext?.requesterExternalUserId).toBe("U-contact");
+
+    await resolveRun(0);
+    await p1;
+    await new Promise((r) => setTimeout(r, 10));
+  });
+
   test("[experimental] queued passthrough siblings drain as a single batched run", async () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -366,6 +366,13 @@ export async function runAgentLoopImpl(
      * scheduled execute turn attributes its LLM spend to that firing.
      */
     cronRunId?: string | null;
+    /**
+     * Trust this turn runs under. Queue drains pass the trust captured from
+     * the sender at enqueue; without it the initialization below would reset
+     * the turn to the conversation slot, which holds whichever actor sent
+     * most recently rather than the one this turn belongs to.
+     */
+    turnTrustContext?: TrustContext;
   },
 ): Promise<void> {
   if (!ctx.abortController) {
@@ -376,9 +383,12 @@ export async function runAgentLoopImpl(
   // voice-session-bridge, regenerate, etc.) that invoke runAgentLoop directly
   // without going through processMessage/drainQueue. This ensures the system
   // prompt callback always reads a valid snapshot rather than undefined.
-  // processMessage/drainQueue set these fields before calling runAgentLoop;
-  // those existing assignments remain correct and are merely redundant here.
-  ctx.currentTurnTrustContext = ctx.trustContext;
+  //
+  // A queue drain runs a message whose sender may not be the conversation's
+  // most recent one, so it passes that sender's trust explicitly. Falling back
+  // to the slot here would undo the drain's stamp and hand the turn back to
+  // whoever sent last.
+  ctx.currentTurnTrustContext = options?.turnTrustContext ?? ctx.trustContext;
   ctx.currentTurnChannelCapabilities = ctx.channelCapabilities;
 
   // Re-resolve the system prompt under the snapshots just set and push it into

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -565,6 +565,12 @@ export interface EnqueueMessageOptions {
   sourceActorPrincipalId?: string;
   /** Auth context snapshot captured for queued turn-scoped authorization. */
   authContext?: AuthContext;
+  /**
+   * Sender's trust, for the drain to run this message under. Defaults to the
+   * conversation's trust at enqueue time, which the sending route has just
+   * set to this sender.
+   */
+  trustContext?: TrustContext;
 }
 
 // ── enqueueMessage ───────────────────────────────────────────────────
@@ -593,6 +599,9 @@ export function enqueueMessage(
     options.sourceActorPrincipalId ??
     ctx.currentTurnSourceActorPrincipalId ??
     queuedAuthContext?.actorPrincipalId;
+  // Deliberately not falling back to `currentTurnTrustContext`: that is the
+  // in-flight turn's actor, which is precisely who this message is not from.
+  const queuedTrustContext = options.trustContext ?? ctx.trustContext;
 
   if (!ctx.isProcessing()) {
     return { queued: false, requestId };
@@ -619,6 +628,7 @@ export function enqueueMessage(
     isInteractive,
     sourceActorPrincipalId,
     authContext: queuedAuthContext,
+    trustContext: queuedTrustContext,
     transport,
     displayContent,
     sentAt: Date.now(),

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -679,6 +679,14 @@ export interface PersistMessageOptions {
   displayContent?: string;
   clientMessageId?: string;
   /**
+   * Trust to attribute the stored row to. Queue drains pass the sender's
+   * captured trust so persisted provenance names the same actor the turn
+   * executes as; the conversation slot may by then hold someone else.
+   * Defaults to the conversation's trust, which is correct for callers
+   * persisting a message the current actor just sent.
+   */
+  trustContext?: TrustContext;
+  /**
    * Persist the row without indexing it (no memory segments, embeddings, or
    * lexical-index entry). For machine-authored prompts that must not enter
    * memory or search; see `ProcessMessageOptions.skipUserMessageIndexing`.
@@ -854,7 +862,9 @@ export async function persistQueuedMessageBody(
       extractTurnChannelContext(metadata) ?? ctx.getTurnChannelContext();
     const turnIfCtx =
       extractTurnInterfaceContext(metadata) ?? ctx.getTurnInterfaceContext();
-    const provenance = provenanceFromTrustContext(ctx.trustContext);
+    const provenance = provenanceFromTrustContext(
+      options.trustContext ?? ctx.trustContext,
+    );
     const imageSourcePaths = extractImageSourcePaths(attachments);
 
     // Strip the transient `slackInbound` carrier key from the persisted

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -62,7 +62,7 @@ import { getModelInfo } from "./handlers/config-model.js";
 import { preactivateHostProxySkills } from "./host-proxy-preactivation.js";
 import type { UserMessageAttachment } from "./message-protocol.js";
 import { buildTransportHints } from "./transport-hints.js";
-import { sameTrustIdentity } from "./trust-context-types.js";
+import { sameTrustIdentity, type TrustContext } from "./trust-context-types.js";
 import { resolveVerificationSessionIntent } from "./verification-session-intent.js";
 
 const log = getLogger("conversation-process");
@@ -1147,6 +1147,9 @@ async function drainSingleMessage(
       metadata: { ...next.metadata, sentAt: next.sentAt },
       displayContent: next.displayContent,
       clientMessageId: next.clientMessageId,
+      // Attribute the stored row to the sender this turn runs as, not to
+      // whoever happens to occupy the conversation slot at drain time.
+      trustContext: next.trustContext,
       ...(next.transport?.clientOs
         ? { requestClientOs: next.transport.clientOs }
         : {}),
@@ -1270,7 +1273,14 @@ async function drainSingleMessage(
     isUserMessage?: boolean;
     titleText?: string;
     isHiddenPrompt?: boolean;
-  } = { isUserMessage: true };
+    turnTrustContext?: TrustContext;
+  } = {
+    isUserMessage: true,
+    // Carry the sender's trust into the run. The loop re-initializes the
+    // per-turn snapshot on entry, so without this the stamp above is undone
+    // and the turn reverts to the conversation's most recent actor.
+    turnTrustContext: conversation.currentTurnTrustContext,
+  };
   if (next.isInteractive !== undefined) {
     drainLoopOptions.isInteractive = next.isInteractive;
   }
@@ -1505,6 +1515,9 @@ async function drainBatch(
         metadata: { ...qm.metadata, sentAt: qm.sentAt },
         displayContent: qm.displayContent,
         clientMessageId: qm.clientMessageId,
+        // Same attribution rule as the single-message drain. Batch members
+        // share one sender, so every row here names that sender.
+        trustContext: qm.trustContext,
         ...(qm.transport?.clientOs
           ? { requestClientOs: qm.transport.clientOs }
           : {}),
@@ -1736,8 +1749,12 @@ async function drainBatch(
     titleText?: string;
     isHiddenPrompt?: boolean;
     notifyUserMessageId?: string;
+    turnTrustContext?: TrustContext;
   } = {
     isUserMessage: true,
+    // Same reason as the single-message drain: the loop re-initializes the
+    // per-turn snapshot, so the head's trust has to travel with the call.
+    turnTrustContext: conversation.currentTurnTrustContext,
   };
   if (lastPushEligibleUserMessageId !== undefined) {
     drainLoopOptions.notifyUserMessageId = lastPushEligibleUserMessageId;

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -62,6 +62,7 @@ import { getModelInfo } from "./handlers/config-model.js";
 import { preactivateHostProxySkills } from "./host-proxy-preactivation.js";
 import type { UserMessageAttachment } from "./message-protocol.js";
 import { buildTransportHints } from "./transport-hints.js";
+import { sameTrustIdentity } from "./trust-context-types.js";
 import { resolveVerificationSessionIntent } from "./verification-session-intent.js";
 
 const log = getLogger("conversation-process");
@@ -299,6 +300,13 @@ async function buildPassthroughBatch(
       break;
     }
     if (candidate.sourceActorPrincipalId !== head.sourceActorPrincipalId) {
+      break;
+    }
+    // Channel senders carry no principal, so the check above leaves two
+    // different Slack contacts looking identical (`undefined === undefined`).
+    // The batch runs under a single trust context, so split on the sender's
+    // trust identity too or a tail executes with the head's privileges.
+    if (!sameTrustIdentity(candidate.trustContext, head.trustContext)) {
       break;
     }
     if (classifySlash(candidate.content) !== "passthrough") {
@@ -795,7 +803,11 @@ async function drainSingleMessage(
 
   // Snapshot persona context at turn start so later tool turns can't pick up
   // a different actor's context if a concurrent request mutates the live fields.
-  conversation.currentTurnTrustContext = conversation.trustContext;
+  // Trust comes from the queued message, not the live slot: the slot holds
+  // whichever actor sent most recently, which is this sender only when nobody
+  // else sent while this message waited.
+  conversation.currentTurnTrustContext =
+    next.trustContext ?? conversation.trustContext;
   conversation.currentTurnChannelCapabilities =
     conversation.channelCapabilities;
 
@@ -1383,7 +1395,12 @@ async function drainBatch(
 
   // Snapshot persona context at turn start so later tool turns can't pick up
   // a different actor's context if a concurrent request mutates the live fields.
-  conversation.currentTurnTrustContext = conversation.trustContext;
+  // The head's trust governs the batch, which is sound only because
+  // `buildPassthroughBatch` refuses to coalesce messages from different
+  // actors; without that boundary this would run a tail under the head's
+  // trust.
+  conversation.currentTurnTrustContext =
+    head.trustContext ?? conversation.trustContext;
   conversation.currentTurnChannelCapabilities =
     conversation.channelCapabilities;
 

--- a/assistant/src/daemon/conversation-queue-manager.ts
+++ b/assistant/src/daemon/conversation-queue-manager.ts
@@ -14,6 +14,7 @@ import type { AuthContext } from "../runtime/auth/types.js";
 import { getLogger } from "../util/logger.js";
 import type { UserMessageAttachment } from "./message-protocol.js";
 import type { ConversationTransportMetadata } from "./message-types/conversations.js";
+import type { TrustContext } from "./trust-context-types.js";
 
 const log = getLogger("conversation-queue");
 
@@ -33,6 +34,15 @@ export interface QueuedMessage {
   sourceActorPrincipalId?: string;
   /** Full auth snapshot captured at enqueue time for turn-scoped authorization decisions. */
   authContext?: AuthContext;
+  /**
+   * Sender's trust captured at enqueue time. The conversation-level
+   * `trustContext` is a single mutable slot holding whichever actor last sent
+   * a message, so a drain that read it would run this message under a
+   * different actor's trust whenever another actor sent in between. Trust
+   * governs `trustClass`, `executionChannel`, and `requesterExternalUserId`,
+   * so reading the wrong one misroutes the whole tool-approval path.
+   */
+  trustContext?: TrustContext;
   /** Transport metadata snapshot captured at enqueue time, applied when this message becomes active. */
   transport?: ConversationTransportMetadata;
   /** Original user message text to persist to DB when recording intent stripping produced a different `content`. */

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -2661,6 +2661,12 @@ export class Conversation {
        * forwarded into {@link runAgentLoopImpl} and threaded to `recordUsage`.
        */
       cronRunId?: string | null;
+      /**
+       * See {@link runAgentLoopImpl}: trust this turn runs under. Queue
+       * drains pass the sender's trust captured at enqueue so the run is not
+       * reset to the conversation's most recent actor.
+       */
+      turnTrustContext?: TrustContext;
     },
   ): Promise<void> {
     const { onEvent, ...rest } = options ?? {};

--- a/assistant/src/daemon/trust-context-types.ts
+++ b/assistant/src/daemon/trust-context-types.ts
@@ -73,13 +73,17 @@ export interface TrustContext {
  * privilege, for callers that may only run work under one of them (batched
  * turns being the case that matters).
  *
- * Compares the fields the tool-approval path keys on: the privilege
- * (`trustClass`), the channel a grant is scoped to (`sourceChannel`), and who
- * the actor is (`requesterExternalUserId`, `requesterChatId`). Deliberately
- * conservative: an absent field never matches a present one, so unknown
- * identities are treated as distinct. Answering "different" when they match
- * only costs a batching opportunity; answering "same" when they differ runs
- * one actor's work under another's privileges.
+ * Compares the privilege (`trustClass`), the channel a grant is scoped to
+ * (`sourceChannel`), and every field that can carry who the actor is. The
+ * identity fields are covered exhaustively rather than by picking the usual
+ * ones: an ingress that populates only `requesterIdentifier` or
+ * `requesterContactId` would otherwise leave two distinct senders comparing
+ * equal on a pair of undefineds, which is the exact case this guards.
+ *
+ * Deliberately conservative: an absent field never matches a present one, so
+ * unknown identities are treated as distinct. Answering "different" when they
+ * match only costs a batching opportunity; answering "same" when they differ
+ * runs one actor's work under another's privileges.
  */
 export function sameTrustIdentity(
   a: TrustContext | undefined,
@@ -95,6 +99,10 @@ export function sameTrustIdentity(
     a.trustClass === b.trustClass &&
     a.sourceChannel === b.sourceChannel &&
     a.requesterExternalUserId === b.requesterExternalUserId &&
-    a.requesterChatId === b.requesterChatId
+    a.requesterChatId === b.requesterChatId &&
+    a.requesterIdentifier === b.requesterIdentifier &&
+    a.requesterContactId === b.requesterContactId &&
+    a.guardianExternalUserId === b.guardianExternalUserId &&
+    a.guardianPrincipalId === b.guardianPrincipalId
   );
 }

--- a/assistant/src/daemon/trust-context-types.ts
+++ b/assistant/src/daemon/trust-context-types.ts
@@ -67,3 +67,34 @@ export interface TrustContext {
    */
   requesterInteractionCount?: number;
 }
+
+/**
+ * Whether two trust contexts describe the same acting identity at the same
+ * privilege, for callers that may only run work under one of them (batched
+ * turns being the case that matters).
+ *
+ * Compares the fields the tool-approval path keys on: the privilege
+ * (`trustClass`), the channel a grant is scoped to (`sourceChannel`), and who
+ * the actor is (`requesterExternalUserId`, `requesterChatId`). Deliberately
+ * conservative: an absent field never matches a present one, so unknown
+ * identities are treated as distinct. Answering "different" when they match
+ * only costs a batching opportunity; answering "same" when they differ runs
+ * one actor's work under another's privileges.
+ */
+export function sameTrustIdentity(
+  a: TrustContext | undefined,
+  b: TrustContext | undefined,
+): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (!a || !b) {
+    return false;
+  }
+  return (
+    a.trustClass === b.trustClass &&
+    a.sourceChannel === b.sourceChannel &&
+    a.requesterExternalUserId === b.requesterExternalUserId &&
+    a.requesterChatId === b.requesterChatId
+  );
+}

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -701,10 +701,17 @@ export class SubagentManager {
     // wins over parent inheritance: a parent that stamps trust per-turn (the
     // live-voice bridge) has already cleared it by the time a detached spawn
     // reads it, so its spawner resolves trust itself.
+    //
+    // Inherit the parent's *turn* trust ahead of its conversation-level slot:
+    // the slot holds whichever actor sent most recently, so a spawn during one
+    // actor's turn would otherwise run under another's privileges.
+    const parentTurnTrust =
+      parentConversation?.currentTurnTrustContext ??
+      parentConversation?.trustContext;
     if (config.trustContext) {
       conversation.setTrustContext({ ...config.trustContext });
-    } else if (parentConversation?.trustContext) {
-      conversation.setTrustContext({ ...parentConversation.trustContext });
+    } else if (parentTurnTrust) {
+      conversation.setTrustContext({ ...parentTurnTrust });
     }
     const parentAuthContext = parentConversation?.getAuthContext();
     if (parentAuthContext) {


### PR DESCRIPTION
## TL;DR

A queued turn ran under whichever actor sent to the conversation most recently, not under the actor who sent the queued message. Trust decides `trustClass`, `executionChannel`, and `requesterExternalUserId`, so the whole tool-approval path followed the wrong identity.

**Part of** [LUM-3135](https://linear.app/vellum/issue/LUM-3135), not a close. See "What this does not explain" below.

## What was broken

`conversation.trustContext` is a single mutable slot holding whichever actor sent last. The queue drain stamped the turn's trust from that slot, so a message that waited while somebody else sent ran as the wrong person.

This is the same gap [#33959](https://github.com/vellum-ai/vellum-assistant/pull/33959) closed for host-proxy dispatch — "the queued drain, batch drain, process-message, and tool dispatch paths used guardianPrincipalId (the workspace owner). This allowed a trusted contact to trigger host_cu and host_app_control actions on the owner's macOS client." That fix captured `sourceActorPrincipalId` and `authContext` at enqueue and read them back at drain. Trust was left reading the slot, two lines away in the same function:

```ts
conversation.currentTurnAuthContext = next.authContext;                       // queued message
conversation.currentTurnSourceActorPrincipalId = next.sourceActorPrincipalId; // queued message
...
conversation.currentTurnTrustContext = conversation.trustContext;             // mutable slot
```

## Before / after

| | Before | After |
|---|---|---|
| Queued turn's trust | Whoever sent most recently | The actor who sent that message |
| Contact's turn draining after a guardian sent | Could run with `canSelfApproveTools` | Runs as the contact |
| Guardian's turn draining after a contact sent | Escalates her own call to her as the contact's grant request | Runs as the guardian, no escalation |
| Two different Slack contacts queued together | Coalesced into one turn under the head's trust | Separate turns, each under its own trust |
| Subagent spawned mid-turn | Inherits the slot's actor | Inherits the spawning turn's actor |

## Why this is safe

- **Carries identity the way the codebase already does.** `trustContext` rides on `QueuedMessage` beside `sourceActorPrincipalId` and `authContext`, captured at the same point by the same mechanism.
- **Deliberately not falling back to `currentTurnTrustContext` at enqueue.** That is the in-flight turn's actor — precisely who this message is not from. Only `options.trustContext ?? ctx.trustContext` is used, and at enqueue the slot is what the sending route just set for this sender.
- **Batch boundary tightened, not loosened.** `buildPassthroughBatch` already split on `sourceActorPrincipalId`; channel senders carry none, so two Slack contacts compared equal as `undefined`. Splitting on trust identity only ever produces *more* boundaries.
- **`sameTrustIdentity` fails safe.** An absent field never matches a present one. A false "different" costs a batching opportunity; a false "same" runs one actor's work under another's privileges.
- **Drains keep a fallback.** `next.trustContext ?? conversation.trustContext` preserves today's behavior for any queue entry predating this change, so nothing regresses to `unknown` mid-flight.

## Testing

Four regression tests, one per link, each sensitive to the pre-fix code:

- `enqueueMessage` captures the sender's trust; a later slot change leaves the queued message alone.
- `drainSingleMessage` runs under the queued sender's trust while the slot holds someone else, and does not mutate the slot.
- `buildPassthroughBatch` refuses to coalesce two channel senders.
- The same batch still coalesces two messages from one sender — a sensitivity check, so the split above cannot pass for the wrong reason.

The drain and batch cases sit beside the #33959 tests asserting the same property for `sourceActorPrincipalId`.

Typecheck, lint, and prettier pass. Test suites run in CI, not locally, per the standing rule on this machine.

## What this does not explain

The reported symptom is a guardian on web having *every* `bash` call escalate as a Slack contact's grant request. This fix is necessary but I have not traced it to that symptom end to end: on the web path, `handleSendMessage` sets the slot to guardian before enqueuing, so I cannot yet show what left the contact's trust in the slot while she was driving. Remaining candidates are conversation re-hydration restoring a persisted `trustContext`, and a daemon restart mid-session.

Filed as `Part of` rather than `Fixes` for that reason. The defects here are real and provable on their own terms; whether they close LUM-3135 is a separate question.

## Deferred

- **Removing the `?? ctx.trustContext` fallbacks** at the eight consumers that read `currentTurnTrustContext ?? trustContext`. That is the hardening that would make stale ambient trust structurally impossible, and it is the real end state. It needs every turn entry point proven to stamp unconditionally first — anything missed falls to `FALLBACK_TURN_TRUST` and hard-denies a legitimate flow. Worth its own change where a regression can be attributed cleanly.
- **`live-voice-session.ts`** also reads `parentConversation.trustContext` directly. It stamps and restores per turn, so it is not obviously wrong, but it belongs in the same sweep as the fallback removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40458" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->