### PR TITLE
fix(web): show an uploaded avatar in the sidebar's identity row

### DIFF
--- a/clients/web/src/domains/chat/components/assistant-nav-item.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-nav-item.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * Tests for `AssistantNavItem`'s leading slot: which avatar the sidebar's
+ * identity row wears.
+ *
+ * Rendered with `renderToStaticMarkup`, so no effects run and the blink loop
+ * stays out of it. What is under test is the branch that picks the slot's
+ * contents, which is pure.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
+import { AssistantNavItem } from "@/domains/chat/components/assistant-nav-item";
+import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
+
+/* The hook reads through React Query, which static rendering has no client
+   for. Mocked through a mutable value rather than a fixed one: a module mock
+   is per-file, and these cases differ only by what the hook resolves. */
+interface AvatarState {
+  components: CharacterComponents | null;
+  traits: CharacterTraits | null;
+  customImageUrl: string | null;
+}
+
+let avatar: AvatarState = {
+  components: null,
+  traits: null,
+  customImageUrl: null,
+};
+
+mock.module("@/hooks/use-assistant-avatar", () => ({
+  useAssistantAvatar: () => ({
+    ...avatar,
+    isLoading: false,
+    invalidate: () => {},
+  }),
+}));
+
+const IMAGE = "blob:http://localhost/abc-123";
+
+function renderRow(collapsed = false): string {
+  return renderToStaticMarkup(
+    createElement(AssistantNavItem, {
+      assistantId: "a1",
+      label: "Haze II",
+      active: false,
+      collapsed,
+      onSelect: () => {},
+    }),
+  );
+}
+
+/** How many times the uploaded image is painted in the row. */
+function imageCount(html: string): number {
+  return html.split(`src="${IMAGE}"`).length - 1;
+}
+
+describe("AssistantNavItem leading slot", () => {
+  beforeEach(() => {
+    avatar = { components: null, traits: null, customImageUrl: null };
+  });
+
+  test("an uploaded image takes the slot instead of the Brain", () => {
+    avatar = { components: null, traits: null, customImageUrl: IMAGE };
+    const html = renderRow();
+    /* Exactly one: the row draws one avatar, and a slot that renders both the
+       image and the glyph it stands in for is the failure this guards. */
+    expect(imageCount(html)).toBe(1);
+    expect(html).not.toContain("lucide-brain");
+  });
+
+  test("the collapsed tile wears the image too", () => {
+    avatar = { components: null, traits: null, customImageUrl: IMAGE };
+    const html = renderRow(true);
+    expect(imageCount(html)).toBe(1);
+    expect(html).not.toContain("lucide-brain");
+  });
+
+  test("no avatar at all still falls back to the Brain", () => {
+    const html = renderRow();
+    expect(html).toContain("lucide-brain");
+    expect(imageCount(html)).toBe(0);
+  });
+
+  test("the collapsed tile falls back to the Brain too", () => {
+    const html = renderRow(true);
+    expect(html).toContain("lucide-brain");
+    expect(imageCount(html)).toBe(0);
+  });
+
+  /* A character avatar owns the slot with its eyes, and an assistant can hold
+     both a character and a stale image blob. The character wins, and the image
+     must not be painted underneath or beside it. */
+  test("a character avatar keeps its eyes, even with an image present", () => {
+    avatar = {
+      components: BUNDLED_COMPONENTS,
+      traits: { bodyShape: "blob", eyeStyle: "curious", color: "purple" },
+      customImageUrl: IMAGE,
+    };
+    const html = renderRow();
+    expect(imageCount(html)).toBe(0);
+    expect(html).not.toContain("lucide-brain");
+    // The eyes render as inline SVG paths in the slot.
+    expect(html).toContain("<svg");
+  });
+});

--- a/clients/web/src/domains/chat/components/assistant-nav-item.tsx
+++ b/clients/web/src/domains/chat/components/assistant-nav-item.tsx
@@ -257,15 +257,20 @@ export function AssistantNavItem({
 
      Suppressed while the tour owns the nav, matching the way the character
      avatar's colour drains and the Brain stands in for its eyes. */
+  /* One answer to "is there an uploaded image to wear", read by both the
+     expanded slot and the collapsed tile so the two cannot disagree. A url
+     rather than a boolean, so each render site has the value it needs. */
+  const uploadedAvatarUrl = navTourActive ? null : customImageUrl;
+
   const avatarImage =
-    !navTourActive && customImageUrl ? (
+    uploadedAvatarUrl !== null ? (
       <span
         aria-hidden="true"
         className="pointer-events-none flex shrink-0 items-center justify-center"
         style={{ width: CHIP_SIZE, height: CHIP_SIZE }}
       >
         <img
-          src={customImageUrl}
+          src={uploadedAvatarUrl}
           alt=""
           width={CHIP_SIZE}
           height={CHIP_SIZE}
@@ -307,9 +312,9 @@ export function AssistantNavItem({
             {/* The uploaded image fills the tile, as an avatar rather than a
                 glyph sitting on a surface. The tile is already round and
                 clipping, so it needs no rounding of its own. */}
-            {customImageUrl && !navTourActive ? (
+            {uploadedAvatarUrl !== null ? (
               <img
-                src={customImageUrl}
+                src={uploadedAvatarUrl}
                 alt=""
                 aria-hidden="true"
                 width={COLLAPSED_ASSISTANT_TILE}

--- a/clients/web/src/domains/chat/components/assistant-nav-item.tsx
+++ b/clients/web/src/domains/chat/components/assistant-nav-item.tsx
@@ -18,9 +18,14 @@
  * avatar-colored row — except on light avatar colors (yellow), where it
  * flips dark for contrast.
  *
- * Falls back to a plain-toned row (a Brain icon in the same leading slot,
- * so both labels stay aligned) when there's no character avatar to dress
- * as (custom image / not loaded).
+ * The leading slot holds whichever avatar the assistant has: the character's
+ * eyes, or an uploaded image in their place, both at the slot's full width so
+ * the row's geometry does not change between them. An uploaded image wears the
+ * plain pill rather than a tinted one, since a colour is read from a
+ * character's palette and nothing derives one from an image.
+ *
+ * With neither, the row falls back to a plain-toned one with a Brain icon in
+ * that slot, so the cluster's labels stay aligned.
  */
 
 import { SIDEBAR_STACK_GAP } from "@/components/sidebar-nav-geometry";
@@ -80,7 +85,8 @@ export function AssistantNavItem({
   onSelect,
   onNewConversation,
 }: AssistantNavItemProps) {
-  const { components, traits } = useAssistantAvatar(assistantId);
+  const { components, traits, customImageUrl } =
+    useAssistantAvatar(assistantId);
   const reduce = useReducedMotion();
   // While the onboarding tour owns the nav rows (flooding them with its own
   // eyes treatment), this component's eyes and its loop stay completely
@@ -239,6 +245,36 @@ export function AssistantNavItem({
     />
   );
 
+  /* An uploaded image stands in for the character avatar this row otherwise
+     dresses as. It fills the same CHIP_SIZE slot the eyes occupy, so the row
+     reads the same whichever kind of avatar the assistant has, and it is
+     `rounded-full object-cover` as every other surface renders it.
+
+     Not `ChatAvatar`: that would also replace the Brain for assistants with no
+     avatar at all, since it falls back to a generated default character and
+     then to a "V", and it brings a mount spring and the poke sound into a nav
+     row. Only the uploaded-image case wants changing here.
+
+     Suppressed while the tour owns the nav, matching the way the character
+     avatar's colour drains and the Brain stands in for its eyes. */
+  const avatarImage =
+    !navTourActive && customImageUrl ? (
+      <span
+        aria-hidden="true"
+        className="pointer-events-none flex shrink-0 items-center justify-center"
+        style={{ width: CHIP_SIZE, height: CHIP_SIZE }}
+      >
+        <img
+          src={customImageUrl}
+          alt=""
+          width={CHIP_SIZE}
+          height={CHIP_SIZE}
+          className="rounded-full object-cover"
+          style={{ width: CHIP_SIZE, height: CHIP_SIZE }}
+        />
+      </span>
+    ) : null;
+
   if (!hex) {
     // No character avatar (custom image / not loaded): a plain-toned row
     // that keeps the New Chat row's geometry — the Brain icon centers in
@@ -268,14 +304,28 @@ export function AssistantNavItem({
               height: COLLAPSED_ASSISTANT_TILE,
             }}
           >
-            <Brain
-              className="h-3.5 w-3.5"
-              style={{
-                color: active
-                  ? "var(--content-default)"
-                  : "var(--content-tertiary)",
-              }}
-            />
+            {/* The uploaded image fills the tile, as an avatar rather than a
+                glyph sitting on a surface. The tile is already round and
+                clipping, so it needs no rounding of its own. */}
+            {customImageUrl && !navTourActive ? (
+              <img
+                src={customImageUrl}
+                alt=""
+                aria-hidden="true"
+                width={COLLAPSED_ASSISTANT_TILE}
+                height={COLLAPSED_ASSISTANT_TILE}
+                className="h-full w-full object-cover"
+              />
+            ) : (
+              <Brain
+                className="h-3.5 w-3.5"
+                style={{
+                  color: active
+                    ? "var(--content-default)"
+                    : "var(--content-tertiary)",
+                }}
+              />
+            )}
           </button>
         ) : (
           /* No character avatar, so nothing declares the tint properties and
@@ -284,6 +334,7 @@ export function AssistantNavItem({
           <PanelItem
             shape="pill"
             icon={Brain}
+            leadingSlot={avatarImage ?? undefined}
             label={label}
             active={active}
             onSelect={onSelect}

--- a/clients/web/src/domains/chat/components/assistant-side-menu.stories.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.stories.tsx
@@ -14,9 +14,13 @@
  * that does not seed it renders the rail without its pinned-app cluster.
  */
 
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { AssistantSideMenu } from "@/domains/chat/components/assistant-side-menu";
+import { avatarQueryKey } from "@/hooks/use-assistant-avatar";
+import type { AvatarData } from "@/hooks/use-assistant-avatar";
+import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
 import { PreferencesMenu } from "@/domains/chat/components/preferences-menu";
 import { useSidebarLayoutStore } from "@/domains/chat/sidebar-layout-store";
 import { useAuthStore } from "@/stores/auth-store";
@@ -150,6 +154,61 @@ function seedViewMode(assistantId: string, mode: SidebarViewMode): void {
      session of its own, so the sidebar's footer entry only appears in these
      stories once one is seeded. */
   useAuthStore.setState({ sessionStatus: "authenticated" });
+}
+
+/**
+ * The identity row reads its avatar through React Query rather than through a
+ * prop, so a story that seeds nothing gets the row's no-avatar fallback: a
+ * Brain glyph on a plain pill. That is the row behaving correctly on the data
+ * it has, and it is why the eyes, the avatar tint and the uploaded-image
+ * treatment were all unreviewable here.
+ *
+ * Seeding the cache the hook reads is enough to fix that. The story owns its
+ * own client so the seed cannot leak between stories, and both spellings of
+ * the key carry it: the hook appends its manifest-support flag, and a story
+ * cannot know which way that resolves.
+ */
+function seededAvatarClient(
+  assistantId: string,
+  data: AvatarData,
+): QueryClient {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  for (const supportsManifest of [true, false]) {
+    client.setQueryData(
+      [...avatarQueryKey(assistantId), supportsManifest],
+      data,
+    );
+  }
+  return client;
+}
+
+/* A stand-in for an uploaded photo, inline so the story needs no network and
+   works offline. Any image URL the daemon serves renders the same way. */
+const UPLOADED_IMAGE =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='64' height='64'%3E%3Crect width='64' height='64' fill='%23d9713f'/%3E%3Ccircle cx='22' cy='24' r='11' fill='%236b2f1f' opacity='0.6'/%3E%3Cpath d='M2 62c9-17 24-23 37-16 8 4 17 10 25 16z' fill='%232c1710' opacity='0.45'/%3E%3C/svg%3E";
+
+const IMAGE_AVATAR_CLIENT = seededAvatarClient("asst-image", {
+  components: null,
+  traits: null,
+  customImageUrl: UPLOADED_IMAGE,
+});
+
+const CHARACTER_AVATAR_CLIENT = seededAvatarClient("asst-character", {
+  components: BUNDLED_COMPONENTS,
+  traits: { bodyShape: "blob", eyeStyle: "curious", color: "purple" },
+  customImageUrl: null,
+});
+
+function withAvatar(client: QueryClient) {
+  return function AvatarDecorator(Story: () => React.ReactElement) {
+    return (
+      <QueryClientProvider client={client}>
+        <Story />
+      </QueryClientProvider>
+    );
+  };
 }
 
 const SHARED_ARGS = {
@@ -287,5 +346,54 @@ export const LoadingConversations: Story = {
     assistantId: "asst-loading",
     conversations: [],
     isLoadingConversations: true,
+  },
+};
+
+/**
+ * The identity row wearing an uploaded image. One slot, and whichever avatar
+ * the assistant has occupies it: this is the same slot the story below fills
+ * with a character's eyes.
+ *
+ * The pill stays plain rather than tinted. A colour is read from a character's
+ * palette and nothing derives one from an image.
+ */
+export const UploadedImageAvatar: Story = {
+  name: "Identity row · uploaded image avatar",
+  beforeEach: () => seedViewMode("asst-image", "all"),
+  decorators: [withAvatar(IMAGE_AVATAR_CLIENT)],
+  args: {
+    ...SHARED_ARGS,
+    assistantId: "asst-image",
+    assistantName: "Haze II",
+  },
+};
+
+/** The same row on the collapsed rail, where the image fills the tile. */
+export const UploadedImageAvatarCollapsed: Story = {
+  name: "Identity row · uploaded image avatar, collapsed",
+  beforeEach: () => seedViewMode("asst-image", "all"),
+  decorators: [withAvatar(IMAGE_AVATAR_CLIENT)],
+  args: {
+    ...SHARED_ARGS,
+    assistantId: "asst-image",
+    assistantName: "Haze II",
+    collapsed: true,
+    footerAction: <PreferencesMenu assistantId="asst-story" collapsed />,
+  },
+};
+
+/**
+ * The character-avatar treatment, which no story reached before: the eyes in
+ * the leading slot, the pill painted in the avatar's colour, and the name
+ * flipped for contrast against it. The eyes blink where they sit.
+ */
+export const CharacterAvatar: Story = {
+  name: "Identity row · character avatar",
+  beforeEach: () => seedViewMode("asst-character", "all"),
+  decorators: [withAvatar(CHARACTER_AVATAR_CLIENT)],
+  args: {
+    ...SHARED_ARGS,
+    assistantId: "asst-character",
+    assistantName: "Haze II",
   },
 };


### PR DESCRIPTION
## TL;DR

An assistant whose avatar is an uploaded image gets a Brain glyph in the sidebar's identity row. That row dresses as the assistant, and for these users it was the one place that did not: a character avatar puts its eyes in the leading slot, an image put a generic icon.

The image now takes that slot. One slot, and whichever avatar the assistant has occupies it.

## What changes for the user

| Assistant's avatar | Before | After |
| --- | --- | --- |
| Character | Its eyes in the slot | Unchanged |
| Uploaded image | Brain glyph | The image, round, at the slot's full width |
| Uploaded image, collapsed rail | Brain glyph on a plain tile | The image filling the tile |
| Neither, or not loaded yet | Brain glyph | Unchanged |
| During the onboarding tour | Brain glyph | Unchanged, the tour owns the nav |

The image is sized to the same 20px slot the eyes use, so the row's geometry and its label position do not change between the two kinds of avatar.

An uploaded image still wears the **plain** pill rather than a tinted one. A colour is read from a character's palette and nothing derives one from an image, which is tracked separately in LUM-3123.

## Why it is safe

The change is reachable only when `customImageUrl` is set. A character avatar returns before it (that path is keyed on `hex`, which only a character resolves), and an assistant with no avatar at all keeps the Brain, so neither of the two cases that ship today can be touched by this.

Deliberately not `ChatAvatar`, though it is the component that renders this image elsewhere. Its fallback chain would also replace the Brain for assistants with **no** avatar, generating a default character and then a "V" from the same call, and it brings a mount entrance spring and the poke sound into a nav row. Only the uploaded-image case wants changing here, so this renders the image the way `ChatAvatar` renders its own: `rounded-full object-cover`, same wrapper geometry.

Tests are new (`assistant-nav-item.test.tsx`, the component had none). They assert which occupant the slot gets rather than that an image is present anywhere: the image is counted, so a slot that painted both the image and the glyph it replaces fails, and the character case asserts the eyes win even when an assistant holds both a character and a stale image blob. Expanded and collapsed both covered. `bun test` is blocked locally by a standing hook, so they run in CI.

## Verification

Typecheck, lint and Prettier clean. Not verified visually, and it cannot be in Storybook: no story seeds an avatar into the sidebar, so every sidebar story renders this row's no-avatar fallback. That gap is the second item in LUM-3123, and it is why the tests here assert on markup rather than a screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40461" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->