### PR TITLE
fix(web): drop the rule above the sidebar footer (LUM-3061)

### DIFF
--- a/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -478,22 +478,35 @@ describe("AssistantSideMenu · tipCard slot", () => {
     makeConversation({ conversationId: "a", title: "Alpha" }),
   ];
 
-  test("renders the rail footer as tip card, then divider, then footer action", () => {
+  test("renders the rail footer as tip card, then footer action", () => {
     const html = renderMenu({ conversations, includeTipCard: true });
 
     const footerIndex = html.indexOf('data-slot="side-menu-footer"');
     const tipIndex = html.indexOf("TipSentinel");
-    const separatorIndex = html.indexOf(
-      'data-slot="side-menu-separator"',
-      tipIndex,
-    );
     const actionIndex = html.indexOf("Preferences");
     expect(footerIndex).toBeGreaterThanOrEqual(0);
     expect(tipIndex).toBeGreaterThan(footerIndex);
-    // The divider sits BETWEEN the tip card and the footer action, never
-    // above the tip.
-    expect(separatorIndex).toBeGreaterThan(tipIndex);
-    expect(actionIndex).toBeGreaterThan(separatorIndex);
+    expect(actionIndex).toBeGreaterThan(tipIndex);
+  });
+
+  /* The footer carries no rule, in either direction: not over the tip card
+     and not between it and the action. Scoped to the footer rather than the
+     whole tree so a separator elsewhere in the sidebar cannot mask a rule
+     reappearing here. */
+  test("the rail footer carries no separator", () => {
+    const container = parse(
+      renderMenu({ conversations, includeTipCard: true }),
+    );
+
+    const footer = container.querySelector<HTMLElement>(
+      '[data-slot="side-menu-footer"]',
+    );
+    if (!footer) {
+      throw new Error("expected the rail footer");
+    }
+    expect(
+      footer.querySelectorAll('[data-slot="side-menu-separator"]'),
+    ).toHaveLength(0);
   });
 
   test("hides the tip card on the collapsed rail", () => {

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -552,14 +552,12 @@ export function AssistantSideMenu({
             onHeightChange={setOverlayBottomColumnHeight}
           />
         ) : footerAction || tipCard ? (
-          /* No rule over the footer. Every entry in this sidebar is a pill on
-             the page background, and a shape like that is already delimited:
-             a line above the last one divides a group that reads as grouped
-             without it. The footer's own top padding is the whole separation.
-
-             It still sticks to the bottom on `mt-auto` and the list above it
-             still scrolls in `SideMenu.Body`, both unchanged: what goes is the
-             rule, not the footer's place in the column. */
+          /* Every entry in this sidebar is a pill on the page background, and
+             a shape like that is already delimited: a line above the last one
+             would divide a column that reads as grouped without it. The
+             footer's own top padding is the whole separation, and `mt-auto`
+             on `SideMenu.Footer` is what holds it at the bottom while the
+             list scrolls in `SideMenu.Body` above it. */
           <SideMenu.Footer>
             {/* The collapsed rail drops the tip card (per design). */}
             {isCollapsedRail ? null : tipCard}

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -140,7 +140,6 @@ function SearchButton() {
  *
  *   Header
  *     • Your Assistant → Intelligence view, with New Chat beneath it
- *     • ───────────────
  *   Body · one section list, in the user's own order (default shown)
  *     • Pinned ▾       - when non-empty
  *     • Group ▾        - one collapsible section per custom group
@@ -152,8 +151,7 @@ function SearchButton() {
  *       in Chats instead, so which section a conversation appears in changes
  *       but whether it appears does not
  *   Footer
- *     • caller-provided tip card (SidebarTipCard) — hidden on the collapsed rail
- *     • ───────────────
+ *     • caller-provided tip card (SidebarTipCard), hidden on the collapsed rail
  *     • caller-provided action (PreferencesMenu)
  *
  * This component does **not** know that order. `useSidebarState` hands it one

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -552,13 +552,17 @@ export function AssistantSideMenu({
             onHeightChange={setOverlayBottomColumnHeight}
           />
         ) : footerAction || tipCard ? (
-          // `pt-0`, and a flush separator, so the conversation list runs right
-          // up to the rule instead of trailing off into dead space.
-          <SideMenu.Footer className="pt-0">
-            {/* Tip card first, divider between it and the footer action. The
-               collapsed rail drops both (per design). */}
+          /* No rule over the footer. Every entry in this sidebar is a pill on
+             the page background, and a shape like that is already delimited:
+             a line above the last one divides a group that reads as grouped
+             without it. The footer's own top padding is the whole separation.
+
+             It still sticks to the bottom on `mt-auto` and the list above it
+             still scrolls in `SideMenu.Body`, both unchanged: what goes is the
+             rule, not the footer's place in the column. */
+          <SideMenu.Footer>
+            {/* The collapsed rail drops the tip card (per design). */}
             {isCollapsedRail ? null : tipCard}
-            {isCollapsedRail ? null : <SideMenu.Separator className="my-0" />}
             {footerAction}
           </SideMenu.Footer>
         ) : null}


### PR DESCRIPTION
## TL;DR

Removes the horizontal rule between the conversation list and the Preferences footer. Nothing else about the footer changes.

Part of LUM-3061.

## Before / after

| | Before | After |
|---|---|---|
| Above Preferences | A full-width rule | Nothing |
| Preferences position | Stuck to the bottom | Stuck to the bottom, unchanged |
| Conversation list | Scrolls in `SideMenu.Body` | Scrolls in `SideMenu.Body`, unchanged |
| Collapsed rail | No rule (already dropped there) | No rule |

## Why

Every entry in this sidebar is now a pill on the page background, and a shape like that is already delimited. A line above the last one divides a group that reads as grouped without it, which is the same reasoning `side-menu-built-in-nav.tsx` already records for carrying neither a heading nor a rule around the pinned apps.

The `pt-0` on the footer goes with it. It existed so the list ran flush into the rule instead of trailing off into dead space; with no rule to run into, the footer's own `pt-2` is the separation.

## Why it is safe

The footer's stickiness is `mt-auto` on `SideMenu.Footer` and the scroll is `SideMenu.Body`. Neither is touched. Verified in Storybook at a viewport short enough to force a scroll: the body scrolls 622px while the footer stays at exactly the same viewport position and remains visible, with zero `side-menu-separator` elements in the DOM.

`SideMenu.Separator` is left exported from the design library. This was its only consumer, but it is a reasonable general primitive and pruning the library's public surface is a separate decision from this one.

## Testing

Typecheck, lint and format clean. Verified by hand in Storybook in the long-list story, which is the one where the scroll and the sticky footer actually interact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40463" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->