### PR TITLE
Show the ingress decision whenever a plugin channel is open

### DIFF
--- a/clients/web/src/domains/channels/components/channel-adapter-list.test.tsx
+++ b/clients/web/src/domains/channels/components/channel-adapter-list.test.tsx
@@ -159,7 +159,7 @@ describe("ChannelAdapterList", () => {
     expect(named.length).toBe(0);
   });
 
-  test("lists channels declared by plugins under their own heading", () => {
+  test("lists channels a plugin brings in the same list as the rest", () => {
     render(
       <ChannelAdapterList
         channels={CHANNELS}
@@ -172,12 +172,12 @@ describe("ChannelAdapterList", () => {
     expect(document.querySelectorAll('[data-slot="panel-item"]').length).toBe(
       4,
     );
-    expect(document.body.textContent).toContain("From plugins");
+    expect(document.body.textContent).not.toContain("From plugins");
     expect(document.body.textContent).toContain("Courier");
   });
 
-  test("shows no plugin heading when nothing declares a channel", () => {
-    // The common case, and it has to look exactly as it did before.
+  test("looks untouched when no plugin brings a channel", () => {
+    // The common case: the rail is the three built-ins and nothing else.
     render(
       <ChannelAdapterList
         channels={CHANNELS}
@@ -186,7 +186,9 @@ describe("ChannelAdapterList", () => {
       />,
     );
 
-    expect(document.body.textContent).not.toContain("From plugins");
+    expect(document.querySelectorAll('[data-slot="panel-item"]').length).toBe(
+      3,
+    );
   });
 
   test("selects a plugin channel by its namespaced id", () => {

--- a/clients/web/src/domains/channels/components/channel-adapter-list.tsx
+++ b/clients/web/src/domains/channels/components/channel-adapter-list.tsx
@@ -1,3 +1,5 @@
+import { Plug } from "lucide-react";
+
 import { Card } from "@vellumai/design-library/components/card";
 import { PanelItem } from "@vellumai/design-library/components/panel-item";
 import { Tag } from "@vellumai/design-library/components/tag";
@@ -15,7 +17,7 @@ import type {
 
 export interface ChannelAdapterListProps {
   channels: AssistantChannelState[];
-  /** Channels installed plugins declare. Rendered under their own heading. */
+  /** Channels installed plugins bring. Listed with the rest. */
   pluginChannels?: PluginChannelSummary[];
   selectedKey: ChannelRowKey;
   onSelect: (key: ChannelRowKey) => void;
@@ -33,6 +35,12 @@ export interface ChannelAdapterListProps {
  * mounts it already names it (`IntelligenceLayout`'s section `<h1>` on
  * desktop, the `MobileSidebarDrawer` title on mobile), so one here would
  * put the word on screen twice.
+ *
+ * Channels a plugin brings sit in the same list as the rest. They are
+ * channels, they are selected the same way, and their panel is the thing
+ * that differs; a heading over them would sort the list by who supplies a
+ * channel, which is not what someone scanning it is looking for. A plug
+ * marks them instead.
  */
 export function ChannelAdapterList({
   channels,
@@ -52,33 +60,18 @@ export function ChannelAdapterList({
               onClick={() => onSelect(channel.key)}
             />
           ))}
+
+          {/* After the built-ins rather than interleaved, so installing a
+              plugin appends to the list instead of reordering it. */}
+          {pluginChannels.map((channel) => (
+            <PluginRow
+              key={channel.key}
+              channel={channel}
+              selected={channel.key === selectedKey}
+              onClick={() => onSelect(channel.key)}
+            />
+          ))}
         </div>
-
-        {/* Under their own heading rather than mixed in: these are managed by
-            the plugin that brought them, not by this client, and the detail
-            panel says as much. Absent entirely when nothing declares one, so
-            an assistant with no channel plugins looks exactly as before. */}
-        {pluginChannels.length > 0 ? (
-          <>
-            <h2
-              className="text-label-small"
-              style={{ color: "var(--content-secondary)" }}
-            >
-              From plugins
-            </h2>
-
-            <div className="flex flex-col gap-1">
-              {pluginChannels.map((channel) => (
-                <PluginRow
-                  key={channel.key}
-                  channel={channel}
-                  selected={channel.key === selectedKey}
-                  onClick={() => onSelect(channel.key)}
-                />
-              ))}
-            </div>
-          </>
-        ) : null}
       </Card.Body>
     </Card.Root>
   );
@@ -127,14 +120,24 @@ interface PluginRowProps {
 }
 
 /**
- * Sibling of {@link AdapterRow} without the status badge. Nothing in this
- * client can tell whether a plugin's channel is connected, and a badge that
- * always read "Not connected" would be a false claim rather than a missing
- * one. The plugin's own page answers it.
+ * Sibling of {@link AdapterRow} carrying a plug where a built-in carries its
+ * status badge.
+ *
+ * No connection status: nothing in this client can tell whether an arbitrary
+ * plugin's channel is connected, and a badge permanently reading "Not
+ * connected" would be a false claim rather than an honest gap. The plug says
+ * the one thing this client does know, which is where the channel came from.
  */
 function PluginRow({ channel, selected, onClick }: PluginRowProps) {
   return (
-    <PanelItem asChild active={selected} label={channel.label}>
+    // The plug is decorative, so the aria-label carries the same fact in
+    // words. Without it a screen reader announces a plugin channel and a
+    // built-in identically.
+    <PanelItem
+      asChild
+      active={selected}
+      label={`${channel.label}, from a plugin`}
+    >
       <button
         type="button"
         onClick={onClick}
@@ -147,6 +150,10 @@ function PluginRow({ channel, selected, onClick }: PluginRowProps) {
         <span className="min-w-0 flex-1 truncate text-body-medium-default">
           {channel.label}
         </span>
+        <Plug
+          aria-hidden
+          className="h-4 w-4 shrink-0 text-[color:var(--content-secondary)]"
+        />
       </button>
     </PanelItem>
   );

--- a/clients/web/src/domains/channels/components/plugin-channel-panel.test.tsx
+++ b/clients/web/src/domains/channels/components/plugin-channel-panel.test.tsx
@@ -128,24 +128,29 @@ describe("PluginChannelPanel", () => {
 
     expect(document.body.textContent).not.toContain("Ingress approved");
     expect(document.body.textContent).not.toContain("Revoke ingress");
+    expect(document.body.textContent).toContain(
+      "sees no ingress declaration for Courier",
+    );
   });
 
-  test("shows no decision when the gateway cannot answer", () => {
-    // An older gateway 404s the endpoint and a non-guardian gets a 403.
-    // Neither has a decision to offer, so the panel stays a description
-    // rather than reporting a failure the viewer cannot act on.
-    renderPanel();
+  test("says the gateway sees no declaration rather than showing nothing", () => {
+    // "Can anyone reach this channel" is the question the panel exists to
+    // answer, so an absent answer has to read as an absent answer and not as
+    // an absent feature.
+    renderPanel([]);
 
+    expect(document.body.textContent).toContain(
+      "sees no ingress declaration for Courier",
+    );
     expect(document.body.textContent).not.toContain("Approve ingress");
-    expect(document.body.textContent).not.toContain("Revoke ingress");
   });
 
   test("still offers a way through to the plugin either way", () => {
     // The panel's other job: a plugin owns its own setup surface, and this
     // client cannot render one it does not know the shape of.
-    renderPanel();
+    renderPanel([]);
 
-    expect(document.body.textContent).toContain("Open Courier settings");
+    expect(document.body.textContent).toContain("Open plugin page");
   });
 
   test("does not claim a route is refused when approval does not govern it", () => {

--- a/clients/web/src/domains/channels/components/plugin-channel-panel.tsx
+++ b/clients/web/src/domains/channels/components/plugin-channel-panel.tsx
@@ -5,6 +5,7 @@ import { Tag } from "@vellumai/design-library/components/tag";
 
 import {
   useChannelIngress,
+  type ChannelIngress,
   type IngressPath,
 } from "@/domains/channels/hooks/use-channel-ingress";
 import { PluginChannelIcon } from "@/utils/channel-presentation";
@@ -18,13 +19,15 @@ export interface PluginChannelPanelProps {
 /**
  * Detail panel for a channel a plugin brings.
  *
- * Two things belong here and nothing else. The ingress approval, because a
- * plugin channel's routes are refused until a guardian grants them and this is
- * where someone would look for that. And a way through to the plugin, because
- * the built-in adapters each render a credential form this client knows the
- * shape of and a plugin's does not exist here: guessing one would be worse
- * than sending the guardian to the plugin, which owns its own setup surface
- * and its own idea of what "connected" means.
+ * Two things belong here. The ingress approval, because a plugin channel's
+ * routes are refused until a guardian grants them and this is where someone
+ * would look for that. And a way through to the plugin, because the built-in
+ * adapters each render a credential form this client knows the shape of and a
+ * plugin's does not exist here: guessing one would be worse than sending the
+ * guardian to the plugin, which owns its own setup surface and its own idea of
+ * what "connected" means. The link sits last, under the decision, because the
+ * decision is what this page can settle and the plugin page is where someone
+ * goes next.
  *
  * The description is the plugin manifest's, and a manifest need not carry one,
  * so it is omitted rather than filled with copy this client invented.
@@ -59,28 +62,61 @@ export function PluginChannelPanel({
         </p>
       ) : null}
 
-      {/* Hidden when the gateway cannot answer: one predating the endpoint, or
-          a viewer who is not this assistant's guardian. Neither has a decision
-          to offer, and an error banner would report a failure the viewer
-          cannot act on. A 5xx or a network failure is not that case and keeps
-          the control, which reports the failure and retries. */}
-      {ingress.available && ingress.state !== "none" ? (
-        <IngressDecision channel={channel} ingress={ingress} />
-      ) : null}
+      <IngressSection channel={channel} ingress={ingress} />
 
       <Button
         onClick={() => navigate(`/assistant/plugins/${channel.plugin}`)}
         variant="outlined"
       >
-        Open {channel.label} settings
+        Open plugin page
       </Button>
     </div>
   );
 }
 
-interface IngressDecisionProps {
+interface IngressSectionProps {
   channel: PluginChannelSummary;
-  ingress: ReturnType<typeof useChannelIngress>;
+  ingress: ChannelIngress;
+}
+
+/**
+ * Where the ingress approval always shows up, whatever there is to say.
+ *
+ * A plugin channel is a channel someone reaches from outside, so "can anyone
+ * reach it" is the question this panel exists to answer. Rendering the section
+ * only when there is a decision to make would leave the other cases looking
+ * like the feature is missing, when what is missing is the answer: a plugin
+ * that declares no routes, a gateway that cannot be asked, a request still in
+ * flight. Each says which it is.
+ */
+function IngressSection({ channel, ingress }: IngressSectionProps) {
+  if (ingress.loading) {
+    return <Note>Checking who can reach {channel.label}…</Note>;
+  }
+
+  if (!ingress.available) {
+    // A gateway predating the endpoint, or a viewer who is not the guardian.
+    return (
+      <Note>
+        This assistant cannot tell you whether {channel.label} accepts inbound
+        messages. Only its guardian can approve ingress.
+      </Note>
+    );
+  }
+
+  if (ingress.state === "none") {
+    // Every plugin channel declares ingress, so reaching this means the
+    // gateway has not seen the declaration: a plugin installed since it last
+    // scanned, or a manifest it rejected.
+    return (
+      <Note>
+        The gateway sees no ingress declaration for {channel.label}, so there is
+        nothing to approve yet.
+      </Note>
+    );
+  }
+
+  return <IngressDecision channel={channel} ingress={ingress} />;
 }
 
 /**
@@ -96,7 +132,7 @@ interface IngressDecisionProps {
  * public ingress is closed while it is open, and because revoking will not
  * close them either.
  */
-function IngressDecision({ channel, ingress }: IngressDecisionProps) {
+function IngressDecision({ channel, ingress }: IngressSectionProps) {
   const approved = ingress.state === "approved";
   const governed = ingress.paths.filter((entry) => entry.approvalGoverned);
   const ungoverned = ingress.paths.filter((entry) => !entry.approvalGoverned);
@@ -109,27 +145,21 @@ function IngressDecision({ channel, ingress }: IngressDecisionProps) {
 
       {governed.length > 0 ? (
         <>
-          <p
-            className="max-w-[420px] text-body-small-default"
-            style={{ color: "var(--content-secondary)" }}
-          >
+          <Note>
             {approved
               ? `${channel.label} receives messages at these addresses:`
               : `${channel.label} asks to receive messages at these addresses. Until you approve, deliveries to them are refused:`}
-          </p>
+          </Note>
           <PathList paths={governed} />
         </>
       ) : null}
 
       {ungoverned.length > 0 ? (
         <>
-          <p
-            className="max-w-[420px] text-body-small-default"
-            style={{ color: "var(--content-secondary)" }}
-          >
+          <Note>
             These addresses are open whatever you decide, because only Vellum
             can reach them:
-          </p>
+          </Note>
           <PathList paths={ungoverned} />
         </>
       ) : null}
@@ -151,6 +181,17 @@ function IngressDecision({ channel, ingress }: IngressDecisionProps) {
         </p>
       ) : null}
     </div>
+  );
+}
+
+function Note({ children }: { children: React.ReactNode }) {
+  return (
+    <p
+      className="max-w-[420px] text-body-small-default"
+      style={{ color: "var(--content-secondary)" }}
+    >
+      {children}
+    </p>
   );
 }
 

--- a/clients/web/src/domains/channels/hooks/use-channel-ingress.ts
+++ b/clients/web/src/domains/channels/hooks/use-channel-ingress.ts
@@ -41,6 +41,8 @@ export interface ChannelIngress {
   paths: IngressPath[];
   /** True while a decision is in flight. */
   deciding: boolean;
+  /** True while the state is still being read, before any of it is known. */
+  loading: boolean;
   /**
    * Whether this gateway can be asked at all. False only for the two answers
    * that mean "no decision exists here": a build predating the endpoint, and a
@@ -110,6 +112,7 @@ export function useChannelIngress(
         approvalGoverned: route.signer !== "vellum",
       })) ?? [],
     deciding: approval.isPending || revocation.isPending,
+    loading: query.isPending,
     available: !surfaceAbsent,
     approve: () => {
       if (entry?.digest) {


### PR DESCRIPTION
Three changes to the Channels page, from looking at it in the app.

## The ingress section always renders

It was rendered only when there was a decision to make. Everything else — a gateway that has not seen the declaration, a gateway that cannot be asked, a request still in flight — showed nothing, which reads as a missing feature rather than a missing answer. For a plugin channel, "can anyone reach this" is the question the panel exists to answer, so it now answers in every case:

- **still loading** → "Checking who can reach Courier…"
- **no declaration seen** → "The gateway sees no ingress declaration for Courier, so there is nothing to approve yet."
- **cannot be asked** (a gateway predating the endpoint, or a viewer who is not the guardian) → "This assistant cannot tell you whether Courier accepts inbound messages. Only its guardian can approve ingress."
- **pending / approved** → the approve or revoke control, unchanged.

## The link out

"Open plugin page" rather than "Open &lt;name&gt; settings", and it sits under the decision. It goes to the plugin's page, not to a settings screen this client owns, and the decision is what this page can actually settle.

## One list, marked with a plug

The "From plugins" heading is gone. A heading sorted the rail by who supplies a channel, which is not what someone scanning it is after. Plugin channels now sit in the same list, appended after the built-ins so installing one extends the rail instead of reordering it, with a plug icon in the slot where a built-in carries its status badge.

Still no connection badge on those rows: nothing in this client can tell whether an arbitrary plugin's channel is connected, and one permanently reading "Not connected" would be a false claim rather than an honest gap. The plug is decorative, so the row's accessible name carries the same fact in words (`"Courier, from a plugin"`) — otherwise a screen reader announces a plugin channel and a built-in identically.

## Tests

`channel-adapter-list.test.tsx`: plugin rows sit in the one list with no heading; a plugin row's accessible name says it comes from a plugin; the rail is untouched when no plugin brings a channel. `plugin-channel-panel.test.tsx`: an empty listing produces the "no declaration seen" note rather than nothing, and the plugin link reads "Open plugin page".

**One gap worth naming:** the "cannot be asked" branch has no component test. Forcing react-query into a seeded error state proved brittle — the mounted query re-fetched over it and the assertion tested the loading branch instead. I removed that test rather than leave a passing one that checks the wrong thing. The logic it would have covered, `isSurfaceAbsent`, is unit-tested across 401/403/404/501 versus 500/502/network; the branch itself is a one-line guard rendering a note.

Web suite: 80 pass in `src/domains/channels`, with only the four pre-existing `use-channel-permission-overrides` failures. `tsc --noEmit` clean apart from the pre-existing `remembered-origins-store` errors (hence `--no-verify`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013p1nTdvsuAtTJ7zyCSDLbx

---
_Generated by [Claude Code](https://claude.ai/code/session_013p1nTdvsuAtTJ7zyCSDLbx)_