### PR TITLE
feat(web): translate the account domain

### DIFF
--- a/clients/web/eslint.config.mjs
+++ b/clients/web/eslint.config.mjs
@@ -193,6 +193,7 @@ const i18nEnforcedPaths = [
   "src/components/not-found.tsx",
   "src/domains/chat/components/conversation-assets-pill.tsx",
   "src/domains/schedules/**/*.{ts,tsx}",
+  "src/domains/account/**/*.{ts,tsx}",
 ];
 
 const eslintConfig = defineConfig([

--- a/clients/web/src/domains/account/components/auth-wait-spinner.tsx
+++ b/clients/web/src/domains/account/components/auth-wait-spinner.tsx
@@ -1,14 +1,17 @@
 import { Loader2 } from "lucide-react";
 
+import { useTranslation } from "@/i18n";
+
 /**
  * Held by `/account/login` and `/account/signup` while the session behind the
  * short-circuit decision settles, so the branded shell is never empty.
  */
 export function AuthWaitSpinner() {
+  const { t } = useTranslation("account");
   return (
     <Loader2
       className="h-6 w-6 animate-spin text-[var(--content-tertiary)]"
-      aria-label="Loading"
+      aria-label={t("authWaitSpinner.loading")}
     />
   );
 }

--- a/clients/web/src/domains/account/components/signup-screen.tsx
+++ b/clients/web/src/domains/account/components/signup-screen.tsx
@@ -1,6 +1,7 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import { AppleLogo } from "@/components/icons/apple-logo";
+import { Trans, useTranslation } from "@/i18n";
 import { SignupShell } from "@/domains/account/components/signup-shell";
 import { RotatingWord } from "@/domains/account/components/rotating-word";
 import {
@@ -9,14 +10,18 @@ import {
 } from "@/domains/account/login-flow";
 import { startAuthFlow } from "@/runtime/native-auth";
 
-const HEADLINE_WORDS = [
-  "Personal Intelligence",
-  "Software Engineer",
-  "Finance Ops",
-  "Household Manager",
-  "GTM Engineer",
-  "Product Lead",
-];
+/**
+ * Catalog keys for the rotating headline roles. The copy lives in the catalog;
+ * this list only fixes the order they cycle in.
+ */
+const HEADLINE_ROLE_KEYS = [
+  "signupScreen.headlineRoles.personalIntelligence",
+  "signupScreen.headlineRoles.softwareEngineer",
+  "signupScreen.headlineRoles.financeOps",
+  "signupScreen.headlineRoles.householdManager",
+  "signupScreen.headlineRoles.gtmEngineer",
+  "signupScreen.headlineRoles.productLead",
+] as const;
 
 interface SignupScreenProps {
   returnTo: string | null;
@@ -29,6 +34,13 @@ interface SignupScreenProps {
  * lives in `ProviderSignupPage`.
  */
 export function SignupScreen({ returnTo }: SignupScreenProps) {
+  const { t } = useTranslation("account");
+  // Whole keys, not a built suffix: `t()` is typed against the English
+  // catalog, so only a literal key is checked at compile time.
+  const headlineWords = useMemo(
+    () => HEADLINE_ROLE_KEYS.map((key) => t(key)),
+    [t],
+  );
   const [error, setError] = useState<string | null>(null);
   const callbackUrl = buildProviderCallbackUrl(returnTo, {
     authIntent: "signup",
@@ -60,33 +72,35 @@ export function SignupScreen({ returnTo }: SignupScreenProps) {
   return (
     <SignupShell>
       <h1 className="signup__title">
-        Meet your new
+        {t("signupScreen.headlineLead")}
         <br />
-        <RotatingWord words={HEADLINE_WORDS} />
+        <RotatingWord words={headlineWords} />
       </h1>
-      <p className="signup__subtitle">
-        The most powerful assistant that can handle your work and life admin
-        tasks.
-      </p>
+      <p className="signup__subtitle">{t("signupScreen.subtitle")}</p>
 
       <div className="signup__buttons">
         <button type="button" className="signup__btn" onClick={start}>
-          Continue
+          {t("signupScreen.continue")}
         </button>
       </div>
 
       {error && <p className="signup__error">{error}</p>}
 
       <p className="signup__footer">
-        Already have an account?{" "}
-        <button type="button" className="signup__link" onClick={signIn}>
-          Sign in
-        </button>
+        <Trans
+          i18nKey="signupScreen.haveAccountPrompt"
+          ns="account"
+          components={{
+            signIn: (
+              <button type="button" className="signup__link" onClick={signIn} />
+            ),
+          }}
+        />
       </p>
 
       <a className="signup__download" href="/downloads">
         <AppleLogo size={16} />
-        Download for macOS
+        {t("signupScreen.downloadMac")}
       </a>
     </SignupShell>
   );

--- a/clients/web/src/domains/account/components/signup-shell.tsx
+++ b/clients/web/src/domains/account/components/signup-shell.tsx
@@ -28,6 +28,7 @@ export function SignupShell({ children }: { children?: ReactNode }) {
         <div className="signup__logo">
           <img
             src={publicAsset("/vellum-logo-white.svg")}
+            // eslint-disable-next-line local/no-untranslated-strings -- brand name
             alt="Vellum"
             width={82}
             height={25}

--- a/clients/web/src/domains/account/login-background.tsx
+++ b/clients/web/src/domains/account/login-background.tsx
@@ -13,6 +13,7 @@ export function LoginBackground() {
       <div className="pointer-events-none absolute top-[120px] left-1/2 z-0 -translate-x-1/2">
         <img
           src={publicAsset("/vellum-logo-white.svg")}
+          // eslint-disable-next-line local/no-untranslated-strings -- brand name
           alt="Vellum"
           width={92}
           height={28}

--- a/clients/web/src/domains/account/pages/account-page.tsx
+++ b/clients/web/src/domains/account/pages/account-page.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Link } from "react-router";
 
+import { useTranslation } from "@/i18n";
 import { AccountHeading } from "@/components/account/account-form";
 import { AccountShell } from "@/components/account/account-shell";
 import {
@@ -21,6 +22,7 @@ import { routes } from "@/utils/routes";
  * or a "Go to your assistant" link + sign-out button when logged in.
  */
 export function AccountPage() {
+  const { t } = useTranslation("account");
   const isAuthenticated = useIsAuthenticated();
   const isSessionInitializing = useIsSessionInitializing();
   const user = useAuthStore.use.user();
@@ -43,7 +45,7 @@ export function AccountPage() {
   if (isSessionInitializing) {
     return (
       <AccountShell>
-        <AccountHeading title="Loading..." />
+        <AccountHeading title={t("accountPage.loading")} />
       </AccountShell>
     );
   }
@@ -52,8 +54,8 @@ export function AccountPage() {
     return (
       <AccountShell>
         <AccountHeading
-          title="Welcome to Vellum"
-          subtitle="Sign in to get started."
+          title={t("accountPage.welcomeTitle")}
+          subtitle={t("accountPage.welcomeSubtitle")}
         />
         {errorMessage && (
           <p className="text-center text-sm text-[var(--system-negative-strong)]">
@@ -67,7 +69,7 @@ export function AccountPage() {
             disabled={signingIn}
             className="inline-flex w-full cursor-pointer items-center justify-center gap-2 rounded-lg bg-[var(--primary-base)] px-6 py-3 text-sm font-medium text-[var(--content-inset)] transition-colors hover:bg-[var(--primary-hover)] disabled:opacity-50"
           >
-            Sign in
+            {t("accountPage.signIn")}
           </button>
         </div>
       </AccountShell>
@@ -77,15 +79,19 @@ export function AccountPage() {
   return (
     <AccountShell>
       <AccountHeading
-        title={`Welcome${user?.username ? `, ${user.username}` : ""}!`}
-        subtitle="You are signed in."
+        title={
+          user?.username
+            ? t("accountPage.signedInTitleNamed", { name: user.username })
+            : t("accountPage.signedInTitle")
+        }
+        subtitle={t("accountPage.signedInSubtitle")}
       />
       <div className="flex flex-col items-center gap-4">
         <Link
           to={routes.assistant}
           className="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-[var(--primary-base)] px-6 py-3 text-sm font-medium text-[var(--content-inset)] no-underline transition-colors hover:bg-[var(--primary-hover)]"
         >
-          Go to your assistant
+          {t("accountPage.goToAssistant")}
         </Link>
         <button
           type="button"
@@ -95,7 +101,7 @@ export function AccountPage() {
           }}
           className="cursor-pointer bg-transparent text-sm font-normal text-[var(--content-secondary)] transition-colors hover:text-[var(--content-default)]"
         >
-          Sign out
+          {t("accountPage.signOut")}
         </button>
       </div>
     </AccountShell>

--- a/clients/web/src/domains/account/pages/login-page.tsx
+++ b/clients/web/src/domains/account/pages/login-page.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Link, useLocation } from "react-router";
 
+import { useTranslation } from "@/i18n";
 import { NativeSplash } from "@/components/native-splash";
 import { AuthWaitSpinner } from "@/domains/account/components/auth-wait-spinner";
 import {
@@ -35,6 +36,7 @@ import { Button } from "@vellumai/design-library";
  * AuthKit handles Apple / Google / email selection.
  */
 function NativeLoginForm({ returnTo }: { returnTo: string | null }) {
+  const { t } = useTranslation("account");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
@@ -81,7 +83,7 @@ function NativeLoginForm({ returnTo }: { returnTo: string | null }) {
           disabled={loading}
           className="max-w-[300px]"
         >
-          Sign in
+          {t("loginPage.signIn")}
         </Button>
       </div>
     </NativeSplash>
@@ -94,6 +96,7 @@ function NativeLoginForm({ returnTo }: { returnTo: string | null }) {
  * theme context (the web login screen is always dark per Figma).
  */
 function WebLoginForm({ returnTo }: { returnTo: string | null }) {
+  const { t } = useTranslation("account");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const callbackUrl = buildProviderCallbackUrl(returnTo);
@@ -124,7 +127,7 @@ function WebLoginForm({ returnTo }: { returnTo: string | null }) {
   return (
     <DarkLoginShell>
       <LoginCard>
-        <LoginHeading>Sign in to Vellum</LoginHeading>
+        <LoginHeading>{t("loginPage.heading")}</LoginHeading>
         {errorMessage && <LoginErrorText>{errorMessage}</LoginErrorText>}
         <div className="flex flex-col items-center gap-3">
           <Button
@@ -135,18 +138,18 @@ function WebLoginForm({ returnTo }: { returnTo: string | null }) {
             disabled={loading}
             className="max-w-[300px]"
           >
-            Continue
+            {t("loginPage.continue")}
           </Button>
         </div>
         <p className="text-body-small-default flex justify-center gap-1">
           <span className="text-[var(--content-secondary)]">
-            Don&apos;t have an account?
+            {t("loginPage.noAccount")}
           </span>
           <Link
             to={signUpHref}
             className="font-medium text-[var(--content-emphasised)] hover:underline"
           >
-            Sign up
+            {t("loginPage.signUp")}
           </Link>
         </p>
       </LoginCard>

--- a/clients/web/src/domains/account/pages/logout-page.tsx
+++ b/clients/web/src/domains/account/pages/logout-page.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import { useSearchParams } from "react-router";
 
+import { useTranslation } from "@/i18n";
 import { AccountHeading } from "@/components/account/account-form";
 import { AccountShell } from "@/components/account/account-shell";
 import { sanitizeReturnTo } from "@/domains/account/return-to";
@@ -9,6 +10,7 @@ import { useAuthStore } from "@/stores/auth-store";
 import { routes } from "@/utils/routes";
 
 export function LogoutPage() {
+  const { t } = useTranslation("account");
   const [searchParams] = useSearchParams();
   const logout = useAuthStore.use.logout();
   const logoutInitiated = useRef(false);
@@ -51,7 +53,7 @@ export function LogoutPage() {
 
   return (
     <AccountShell>
-      <AccountHeading title="Signing out..." />
+      <AccountHeading title={t("logoutPage.title")} />
     </AccountShell>
   );
 }

--- a/clients/web/src/domains/account/pages/oauth-complete-page.tsx
+++ b/clients/web/src/domains/account/pages/oauth-complete-page.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useRef } from "react";
+
+import { useTranslation } from "@/i18n";
 import { useSearchParams } from "react-router";
 
 import {
@@ -208,6 +210,7 @@ export function completeOAuthPopup(
 // ── Page ─────────────────────────────────────────────────────────────────────
 
 export function OAuthCompletePage() {
+  const { t } = useTranslation("account");
   const [searchParams] = useSearchParams();
   const requestId = searchParams.get("requestId");
   const oauthStatus = searchParams.get("oauth_status");
@@ -270,7 +273,7 @@ export function OAuthCompletePage() {
               opacity: 0.7,
             }}
           >
-            Error: {oauthCode}
+            {t("oauthComplete.errorCode", { code: oauthCode })}
           </p>
         )}
       </div>

--- a/clients/web/src/domains/account/pages/oauth-popup-complete-page.tsx
+++ b/clients/web/src/domains/account/pages/oauth-popup-complete-page.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { useSearchParams } from "react-router";
 
+import { useTranslation } from "@/i18n";
 import { oauthCompletionStorageKey } from "@/lib/auth/oauth-popup";
 import {
   buildOAuthCompleteDeepLink,
@@ -193,6 +194,7 @@ function formatProviderName(provider: string): string {
 // ── Page ─────────────────────────────────────────────────────────────────────
 
 export function OAuthPopupCompletePage() {
+  const { t } = useTranslation("account");
   const [searchParams] = useSearchParams();
   const requestId = searchParams.get("requestId");
   const oauthStatus = searchParams.get("oauth_status");
@@ -272,7 +274,7 @@ export function OAuthPopupCompletePage() {
               opacity: 0.7,
             }}
           >
-            Error: {oauthCode}
+            {t("oauthComplete.errorCode", { code: oauthCode })}
           </p>
         )}
       </div>

--- a/clients/web/src/domains/account/pages/platform-loopback-page.tsx
+++ b/clients/web/src/domains/account/pages/platform-loopback-page.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useSearchParams, useNavigate } from "react-router";
 
+import { useTranslation } from "@/i18n";
 import { listAssistants } from "@/assistant/api";
 import { syncPlatformAssistantsToLockfile } from "@/lib/local-mode";
 import { registerLocalPlatformSession } from "@/runtime/local-mode-host";
@@ -27,6 +28,7 @@ const LOOPBACK_RETURN_TO_KEY = "vellum:loopback:returnTo";
  *      cookie), checks for existing assistants, and navigates accordingly
  */
 export function PlatformLoopbackPage() {
+  const { t } = useTranslation("account");
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const [error, setError] = useState<string | null>(null);
@@ -102,7 +104,7 @@ export function PlatformLoopbackPage() {
             className="mt-4 rounded-lg border border-[var(--border-disabled)] px-4 py-2 text-sm hover:bg-[var(--surface-lift)]"
             onClick={() => void navigate(routes.welcome)}
           >
-            Back to Welcome
+            {t("platformLoopbackPage.backToWelcome")}
           </button>
         </div>
       </div>
@@ -111,7 +113,9 @@ export function PlatformLoopbackPage() {
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-[var(--surface-base)] text-[var(--content-default)]">
-      <p className="text-body-medium-default">Completing login...</p>
+      <p className="text-body-medium-default">
+        {t("platformLoopbackPage.completing")}
+      </p>
     </div>
   );
 }

--- a/clients/web/src/domains/account/pages/provider-callback-page.tsx
+++ b/clients/web/src/domains/account/pages/provider-callback-page.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router";
+import { useTranslation } from "@/i18n";
 import { captureError } from "@/lib/sentry/capture-error";
 
 import { AccountHeading } from "@/components/account/account-form";
@@ -34,6 +35,7 @@ import { routes } from "@/utils/routes";
  * callback to `/accounts/native/callback` without loading any SPA.
  */
 export function ProviderCallbackPage() {
+  const { t } = useTranslation("account");
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const refreshSession = useAuthStore.use.refreshSession();
@@ -117,8 +119,8 @@ export function ProviderCallbackPage() {
     return (
       <AccountShell>
         <AccountHeading
-          title="Signups are currently closed"
-          subtitle="Join the community to request access or learn when signups reopen."
+          title={t("providerCallbackPage.signupClosedTitle")}
+          subtitle={t("providerCallbackPage.signupClosedSubtitle")}
         />
         <div className="flex flex-col items-center gap-4">
           <a
@@ -127,13 +129,13 @@ export function ProviderCallbackPage() {
             rel="noopener noreferrer"
             className="inline-flex items-center justify-center gap-2 rounded-lg bg-[var(--primary-base)] px-6 py-3 text-sm font-medium text-[var(--content-inset)] no-underline transition-colors hover:bg-[var(--primary-hover)]"
           >
-            Join the community
+            {t("providerCallbackPage.joinCommunity")}
           </a>
           <Link
             to={routes.account.login}
             className="text-sm font-medium text-[var(--content-emphasised)] hover:underline"
           >
-            Back to sign in
+            {t("providerCallbackPage.backToSignIn")}
           </Link>
         </div>
       </AccountShell>
@@ -144,18 +146,15 @@ export function ProviderCallbackPage() {
     return (
       <AccountShell>
         <AccountHeading
-          title="Authentication failed"
-          subtitle={
-            fallbackError ??
-            "Something went wrong during social sign-in. Please try again or use a different method."
-          }
+          title={t("providerCallbackPage.failedTitle")}
+          subtitle={fallbackError ?? t("providerCallbackPage.failedSubtitle")}
         />
         <div className="flex flex-col items-center gap-4">
           <Link
             to={routes.account.login}
             className="inline-flex items-center justify-center gap-2 rounded-lg bg-[var(--primary-base)] px-6 py-3 text-sm font-medium text-[var(--content-inset)] no-underline transition-colors hover:bg-[var(--primary-hover)]"
           >
-            Back to sign in
+            {t("providerCallbackPage.backToSignIn")}
           </Link>
         </div>
       </AccountShell>
@@ -165,8 +164,8 @@ export function ProviderCallbackPage() {
   return (
     <AccountShell>
       <AccountHeading
-        title="Completing sign-in..."
-        subtitle="Please wait while we finish authenticating you."
+        title={t("providerCallbackPage.completingTitle")}
+        subtitle={t("providerCallbackPage.completingSubtitle")}
       />
     </AccountShell>
   );

--- a/clients/web/src/domains/account/pages/provider-signup-page.tsx
+++ b/clients/web/src/domains/account/pages/provider-signup-page.tsx
@@ -6,6 +6,7 @@ import {
   AccountHeading,
   AccountInput,
 } from "@/components/account/account-form";
+import { useTranslation } from "@/i18n";
 import { AccountShell } from "@/components/account/account-shell";
 import { SignupShell } from "@/domains/account/components/signup-shell";
 import {
@@ -32,6 +33,7 @@ import { routes } from "@/utils/routes";
  * still complete signup.
  */
 export function ProviderSignupPage() {
+  const { t } = useTranslation("account");
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const refreshSession = useAuthStore.use.refreshSession();
@@ -146,8 +148,8 @@ export function ProviderSignupPage() {
     return (
       <AccountShell>
         <AccountHeading
-          title="Completing signup..."
-          subtitle="Please wait while we load your information."
+          title={t("providerSignupPage.completingTitle")}
+          subtitle={t("providerSignupPage.completingSubtitle")}
         />
       </AccountShell>
     );
@@ -167,22 +169,22 @@ export function ProviderSignupPage() {
           className="signup-details__thread"
         >
           <h2 className="signup-details__heading">
-            Almost there,
+            {t("providerSignupPage.headingLine1")}
             <br />
-            one more detail
+            {t("providerSignupPage.headingLine2")}
           </h2>
 
           {error && <p className="signup-details__error">{error}</p>}
 
           <div className="signup-details__step">
             <span className="signup-details__label">
-              What should I call you?{" "}
+              {t("providerSignupPage.firstNameQuestion")}{" "}
               <span className="signup-details__req">*</span>
             </span>
             <input
               className="signup-details__input"
               type="text"
-              placeholder="First name"
+              placeholder={t("providerSignupPage.firstNamePlaceholder")}
               value={firstName}
               readOnly
               disabled
@@ -191,12 +193,13 @@ export function ProviderSignupPage() {
 
           <div className="signup-details__step">
             <span className="signup-details__label">
-              And your last name? <span className="signup-details__req">*</span>
+              {t("providerSignupPage.lastNameQuestion")}{" "}
+              <span className="signup-details__req">*</span>
             </span>
             <input
               className="signup-details__input"
               type="text"
-              placeholder="Last name"
+              placeholder={t("providerSignupPage.lastNamePlaceholder")}
               value={lastName}
               readOnly
               disabled
@@ -205,13 +208,14 @@ export function ProviderSignupPage() {
 
           <div className="signup-details__step">
             <span className="signup-details__label">
-              Your role <span className="signup-details__req">*</span>
+              {t("providerSignupPage.roleQuestion")}{" "}
+              <span className="signup-details__req">*</span>
             </span>
             <input
               className="signup-details__input"
               type="text"
               autoComplete="organization-title"
-              placeholder="e.g. Software Engineer"
+              placeholder={t("providerSignupPage.rolePlaceholder")}
               value={occupation}
               onChange={(e) => setOccupation(e.target.value)}
               autoFocus
@@ -224,7 +228,9 @@ export function ProviderSignupPage() {
               className="signup-details__continue"
               disabled={!canSubmit}
             >
-              {isSubmitting ? "Setting up…" : "Continue →"}
+              {isSubmitting
+                ? t("providerSignupPage.submitting")
+                : t("providerSignupPage.submit")}
             </button>
           </div>
         </form>
@@ -235,8 +241,8 @@ export function ProviderSignupPage() {
   return (
     <AccountShell>
       <AccountHeading
-        title="Complete your account"
-        subtitle="We need a few more details to finish setting up your account."
+        title={t("providerSignupPage.completeAccountTitle")}
+        subtitle={t("providerSignupPage.completeAccountSubtitle")}
       />
 
       <AccountForm
@@ -250,7 +256,7 @@ export function ProviderSignupPage() {
             to={routes.account.login}
             className="text-sm text-[var(--content-secondary)] hover:text-[var(--content-default)]"
           >
-            &larr; Back to sign in
+            {t("providerSignupPage.backToSignIn")}
           </Link>
         }
       >
@@ -258,7 +264,7 @@ export function ProviderSignupPage() {
           id="email"
           type="email"
           autoComplete="email"
-          placeholder="Email"
+          placeholder={t("providerSignupPage.emailPlaceholder")}
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           required
@@ -267,7 +273,7 @@ export function ProviderSignupPage() {
           id="username"
           type="text"
           autoComplete="username"
-          placeholder="Username"
+          placeholder={t("providerSignupPage.usernamePlaceholder")}
           value={username}
           onChange={(e) => setUsername(e.target.value)}
           required

--- a/clients/web/src/i18n/catalogs.ts
+++ b/clients/web/src/i18n/catalogs.ts
@@ -33,6 +33,7 @@
  *
  * Reference: https://vite.dev/guide/features#dynamic-import
  */
+import enAccount from "@/i18n/locales/en/account.json";
 import enChat from "@/i18n/locales/en/chat.json";
 import enCommon from "@/i18n/locales/en/common.json";
 import enSchedules from "@/i18n/locales/en/schedules.json";
@@ -59,6 +60,7 @@ export const FALLBACK_CATALOGS: LocaleCatalogs = {
   common: enCommon,
   chat: enChat,
   schedules: enSchedules,
+  account: enAccount,
 };
 
 /** Loaders for the locales that are not bundled into the entry chunk. */
@@ -70,6 +72,7 @@ const CATALOG_LOADERS: Record<
     common: () => import("@/i18n/locales/es/common.json"),
     chat: () => import("@/i18n/locales/es/chat.json"),
     schedules: () => import("@/i18n/locales/es/schedules.json"),
+    account: () => import("@/i18n/locales/es/account.json"),
   },
 };
 

--- a/clients/web/src/i18n/i18next.d.ts
+++ b/clients/web/src/i18n/i18next.d.ts
@@ -12,6 +12,7 @@
  *
  * Reference: https://www.i18next.com/overview/typescript
  */
+import type account from "@/i18n/locales/en/account.json";
 import type chat from "@/i18n/locales/en/chat.json";
 import type common from "@/i18n/locales/en/common.json";
 import type schedules from "@/i18n/locales/en/schedules.json";
@@ -23,6 +24,7 @@ declare module "i18next" {
       common: typeof common;
       chat: typeof chat;
       schedules: typeof schedules;
+      account: typeof account;
     };
     returnNull: false;
   }

--- a/clients/web/src/i18n/locales/en/account.json
+++ b/clients/web/src/i18n/locales/en/account.json
@@ -1,0 +1,77 @@
+{
+  "authWaitSpinner": {
+    "loading": "Loading"
+  },
+  "signupScreen": {
+    "headlineLead": "Meet your new",
+    "headlineRoles": {
+      "personalIntelligence": "Personal Intelligence",
+      "softwareEngineer": "Software Engineer",
+      "financeOps": "Finance Ops",
+      "householdManager": "Household Manager",
+      "gtmEngineer": "GTM Engineer",
+      "productLead": "Product Lead"
+    },
+    "subtitle": "The most powerful assistant that can handle your work and life admin tasks.",
+    "continue": "Continue",
+    "downloadMac": "Download for macOS",
+    "haveAccountPrompt": "Already have an account? <signIn>Sign in</signIn>"
+  },
+  "accountPage": {
+    "loading": "Loading...",
+    "welcomeTitle": "Welcome to Vellum",
+    "welcomeSubtitle": "Sign in to get started.",
+    "signIn": "Sign in",
+    "signedInTitle": "Welcome!",
+    "signedInTitleNamed": "Welcome, {name}!",
+    "signedInSubtitle": "You are signed in.",
+    "goToAssistant": "Go to your assistant",
+    "signOut": "Sign out"
+  },
+  "loginPage": {
+    "heading": "Sign in to Vellum",
+    "continue": "Continue",
+    "noAccount": "Don't have an account?",
+    "signUp": "Sign up",
+    "signIn": "Sign in"
+  },
+  "logoutPage": {
+    "title": "Signing out..."
+  },
+  "platformLoopbackPage": {
+    "backToWelcome": "Back to Welcome",
+    "completing": "Completing login..."
+  },
+  "oauthComplete": {
+    "errorCode": "Error: {code}"
+  },
+  "providerCallbackPage": {
+    "signupClosedTitle": "Signups are currently closed",
+    "signupClosedSubtitle": "Join the community to request access or learn when signups reopen.",
+    "joinCommunity": "Join the community",
+    "backToSignIn": "Back to sign in",
+    "failedTitle": "Authentication failed",
+    "failedSubtitle": "Something went wrong during social sign-in. Please try again or use a different method.",
+    "completingTitle": "Completing sign-in...",
+    "completingSubtitle": "Please wait while we finish authenticating you."
+  },
+  "providerSignupPage": {
+    "completingTitle": "Completing signup...",
+    "completingSubtitle": "Please wait while we load your information.",
+    "headingLine1": "Almost there,",
+    "headingLine2": "one more detail",
+    "firstNameQuestion": "What should I call you?",
+    "firstNamePlaceholder": "First name",
+    "lastNameQuestion": "And your last name?",
+    "lastNamePlaceholder": "Last name",
+    "roleQuestion": "Your role",
+    "rolePlaceholder": "e.g. Software Engineer",
+    "submitting": "Setting up…",
+    "submit": "Continue →",
+    "completeAccountTitle": "Complete your account",
+    "completeAccountSubtitle": "We need a few more details to finish setting up your account.",
+    "backToSignIn": "← Back to sign in",
+    "emailPlaceholder": "Email",
+    "usernamePlaceholder": "Username"
+  }
+}

--- a/clients/web/src/i18n/locales/es/account.json
+++ b/clients/web/src/i18n/locales/es/account.json
@@ -1,0 +1,77 @@
+{
+  "authWaitSpinner": {
+    "loading": "Cargando"
+  },
+  "signupScreen": {
+    "headlineLead": "Conoce a tu nuevo",
+    "headlineRoles": {
+      "personalIntelligence": "Inteligencia personal",
+      "softwareEngineer": "Ingeniero de software",
+      "financeOps": "Operaciones financieras",
+      "householdManager": "Gestor del hogar",
+      "gtmEngineer": "Ingeniero de GTM",
+      "productLead": "Responsable de producto"
+    },
+    "subtitle": "El asistente más potente, capaz de encargarse de tus tareas del trabajo y de la vida diaria.",
+    "continue": "Continuar",
+    "downloadMac": "Descargar para macOS",
+    "haveAccountPrompt": "¿Ya tienes una cuenta? <signIn>Inicia sesión</signIn>"
+  },
+  "accountPage": {
+    "loading": "Cargando...",
+    "welcomeTitle": "Te damos la bienvenida a Vellum",
+    "welcomeSubtitle": "Inicia sesión para empezar.",
+    "signIn": "Iniciar sesión",
+    "signedInTitle": "¡Hola!",
+    "signedInTitleNamed": "¡Hola, {name}!",
+    "signedInSubtitle": "Has iniciado sesión.",
+    "goToAssistant": "Ir a tu asistente",
+    "signOut": "Cerrar sesión"
+  },
+  "loginPage": {
+    "heading": "Inicia sesión en Vellum",
+    "continue": "Continuar",
+    "noAccount": "¿No tienes una cuenta?",
+    "signUp": "Regístrate",
+    "signIn": "Iniciar sesión"
+  },
+  "logoutPage": {
+    "title": "Cerrando sesión..."
+  },
+  "platformLoopbackPage": {
+    "backToWelcome": "Volver al inicio",
+    "completing": "Completando el inicio de sesión..."
+  },
+  "oauthComplete": {
+    "errorCode": "Error: {code}"
+  },
+  "providerCallbackPage": {
+    "signupClosedTitle": "Los registros están cerrados por ahora",
+    "signupClosedSubtitle": "Únete a la comunidad para solicitar acceso o enterarte de cuándo se reabren los registros.",
+    "joinCommunity": "Unirse a la comunidad",
+    "backToSignIn": "Volver al inicio de sesión",
+    "failedTitle": "No se pudo autenticar",
+    "failedSubtitle": "Algo ha ido mal durante el inicio de sesión con redes sociales. Inténtalo de nuevo o usa otro método.",
+    "completingTitle": "Completando el inicio de sesión...",
+    "completingSubtitle": "Espera mientras terminamos de autenticarte."
+  },
+  "providerSignupPage": {
+    "completingTitle": "Completando el registro...",
+    "completingSubtitle": "Espera mientras cargamos tu información.",
+    "headingLine1": "Ya casi está,",
+    "headingLine2": "un detalle más",
+    "firstNameQuestion": "¿Cómo quieres que te llame?",
+    "firstNamePlaceholder": "Nombre",
+    "lastNameQuestion": "¿Y tu apellido?",
+    "lastNamePlaceholder": "Apellido",
+    "roleQuestion": "Tu puesto",
+    "rolePlaceholder": "p. ej. Ingeniero de software",
+    "submitting": "Configurando…",
+    "submit": "Continuar →",
+    "completeAccountTitle": "Completa tu cuenta",
+    "completeAccountSubtitle": "Necesitamos algunos datos más para terminar de configurar tu cuenta.",
+    "backToSignIn": "← Volver al inicio de sesión",
+    "emailPlaceholder": "Correo electrónico",
+    "usernamePlaceholder": "Nombre de usuario"
+  }
+}

--- a/clients/web/src/i18n/namespaces.ts
+++ b/clients/web/src/i18n/namespaces.ts
@@ -34,7 +34,7 @@
  * checked at compile time, so a half-finished addition fails `tsc` rather than
  * rendering raw key paths at runtime.
  */
-export const NAMESPACES = ["common", "chat", "schedules"] as const;
+export const NAMESPACES = ["common", "chat", "schedules", "account"] as const;
 
 export type Namespace = (typeof NAMESPACES)[number];
 


### PR DESCRIPTION
## Prompt / plan

Second domain cutover, following #40454. 53 strings across 12 files, in a new `account` namespace.

`account` next because it is the **pre-login surface**, which is where the `device:locale` design actually has to hold. The preference is device-scoped rather than account-scoped precisely so the login screen stays in the language the user picked after they sign out. Until this domain was converted, that design was untested against real copy.

## Notable conversions

**A greeting built two ways in one template.**

```tsx
title={`Welcome${user?.username ? `, ${user.username}` : ""}!`}
```

Now two keys, so a translator sees two whole sentences instead of a fragment and a comma. The named form is `"Welcome, {name}!"`, which a translator can reorder however their language wants.

**First `<Trans>` in the codebase.** The signup footer was a sentence split around a button:

```tsx
Already have an account?{" "}
<button onClick={signIn}>Sign in</button>
```

No translator can reorder that, and several languages need to. It's now a `<Trans>` with the button as a component slot, which is the pattern `docs/I18N.md` prescribes for inline markup. It also exercises the rule's `<Trans>` exemption against real code rather than a fixture.

**A module-level array of user-facing copy.** `HEADLINE_WORDS` held the rotating job titles on the signup screen ("Personal Intelligence", "Software Engineer", …). The lint rule cannot see an array literal, so this is a shape only reading the code catches, and worth flagging as a known blind spot alongside the destructuring defaults from the last PR.

Now catalog keys. The array holds **whole key paths** rather than a built suffix:

```ts
const HEADLINE_ROLE_KEYS = [
  "signupScreen.headlineRoles.personalIntelligence",
  ...
] as const;
```

The first attempt built the key with a template (`t(\`signupScreen.headlineRoles.${key}\`)`) and `tsc` rejected it, because `t()` is typed against the English catalog and only a literal key type-checks. That's the typed-keys guard doing exactly what it should.

**Punctuation and arrows folded into the message.** `Error: {code}`, `← Back to sign in`, `Continue →` are now whole messages, so a translator can move or drop the arrow rather than having it welded outside the string.

## Escape hatch

The two `alt="Vellum"` attributes take the documented escape hatch with a reason, being a brand name:

```tsx
// eslint-disable-next-line local/no-untranslated-strings -- brand name
alt="Vellum"
```

## Test plan

- `bun scripts/run-tests.ts`: **918 test files pass, 0 fail**
- `bun run lint` clean with `src/domains/account/**/*.{ts,tsx}` on the ratchet: 0 errors, 16 pre-existing warnings
- `bunx tsc --noEmit` clean; pre-commit hook passed without bypass
- `bun run build` clean; Spanish `account` emits as its own 2,749 B lazily-imported chunk

## Cutover progress

| Done | Remaining (largest first) |
| --- | --- |
| schedules 63, account 53, chat (partial) | settings 1275, chat 750, components 369, onboarding 151, intelligence 141, contacts 69, channels 51, home 40, library 33, workspace 30, credential-requests 21, logs 19, terminal 11, remote-web 5 |

Counts are from the pre-rule-fix survey, so expect roughly 25% more in practice, the way `schedules` went from 50 to 63.

`channels` (51) or `contacts` (69) are the natural next slices at this size. `settings` and `chat` will want splitting across several PRs each.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CD12TRfmDF3UiXjdbiWn3i)_