### PR TITLE
docs(web): describe the avatar stories in the present tense

### DIFF
--- a/clients/web/src/domains/chat/components/assistant-side-menu.stories.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.stories.tsx
@@ -157,16 +157,17 @@ function seedViewMode(assistantId: string, mode: SidebarViewMode): void {
 }
 
 /**
- * The identity row reads its avatar through React Query rather than through a
- * prop, so a story that seeds nothing gets the row's no-avatar fallback: a
- * Brain glyph on a plain pill. That is the row behaving correctly on the data
- * it has, and it is why the eyes, the avatar tint and the uploaded-image
- * treatment were all unreviewable here.
+ * Seeds the cache the identity row's avatar hook reads.
  *
- * Seeding the cache the hook reads is enough to fix that. The story owns its
- * own client so the seed cannot leak between stories, and both spellings of
- * the key carry it: the hook appends its manifest-support flag, and a story
- * cannot know which way that resolves.
+ * That row takes an assistant id and fetches its own avatar rather than being
+ * handed one, so a story seeding nothing renders the row's no-avatar fallback:
+ * a Brain glyph on a plain pill. The row is correct on the data it has, which
+ * puts the eyes, the avatar tint and the uploaded-image treatment out of reach
+ * of any story that does not seed.
+ *
+ * Each story owns its client, so a seed cannot leak into its neighbours, and
+ * both spellings of the key carry it: the hook appends its manifest-support
+ * flag and a story cannot know which way that resolves.
  */
 function seededAvatarClient(
   assistantId: string,
@@ -383,9 +384,9 @@ export const UploadedImageAvatarCollapsed: Story = {
 };
 
 /**
- * The character-avatar treatment, which no story reached before: the eyes in
- * the leading slot, the pill painted in the avatar's colour, and the name
- * flipped for contrast against it. The eyes blink where they sit.
+ * The character-avatar treatment: the eyes in the leading slot, the pill
+ * painted in the avatar's colour, and the name flipped for contrast against
+ * it. The eyes blink where they sit.
  */
 export const CharacterAvatar: Story = {
   name: "Identity row · character avatar",


### PR DESCRIPTION
## TL;DR

Two JSDoc blocks I added in #40461 describe how the stories came to exist rather than what they document. AGENTS.md:129-134 asks the other way round: comments describe the present, PR descriptions carry the history. Flagged as non-blocking on that PR's approval, and it is the same rule two bots caught on #40448, so it is worth closing rather than leaving.

Same wording, present tense. No behaviour, no story output, no test touched.

| Was | Is |
| --- | --- |
| "...and it is why the eyes, the avatar tint and the uploaded-image treatment **were all unreviewable here**" | "...**which puts** the eyes, the avatar tint and the uploaded-image treatment **out of reach of any story that does not seed**" |
| "The character-avatar treatment, **which no story reached before**: the eyes in the leading slot..." | "The character-avatar treatment: the eyes in the leading slot..." |

## Why it is safe

Comment text in a stories file. Prettier and lint clean, and a sweep of everything the two avatar PRs added (`assistant-side-menu.stories.tsx`, `assistant-nav-item.tsx`, `assistant-nav-item.test.tsx`) for the rule's named forms comes back empty.

No `cherry-pick-to-release` label, deliberately: this is internal prose with no user-visible or behavioural effect, and cherry-picking a comment edit into a release branch under QA is churn for nothing. The release branch keeps the wording from #40461 until the next release picks this up with everything else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40467" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->