### PR TITLE
fix(web): queue notification intents behind a pending permission prompt

### DIFF
--- a/clients/web/src/runtime/notifications-permission.test.ts
+++ b/clients/web/src/runtime/notifications-permission.test.ts
@@ -1,0 +1,171 @@
+/**
+ * `ensureNotificationPermission` concurrency, on the desktop-browser branch.
+ *
+ * The prompt is answered by a human who is — by construction — in another
+ * app when the first notification intent lands, so intents keep arriving
+ * while it sits open. They must queue behind that one prompt and post once
+ * it resolves, rather than each resolving to `"prompt"` and dropping its
+ * banner.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Force the desktop-browser branch: both guards must report false or
+// `postLocalNotification` returns through Electron/Capacitor before it
+// reaches the permission path.
+
+mock.module("@/runtime/is-electron", () => ({
+  isElectron: () => false,
+}));
+mock.module("@/runtime/native-auth", () => ({
+  isNativePlatform: () => false,
+}));
+mock.module("@/runtime/platform-detection", () => ({
+  isNativeAndroid: () => false,
+}));
+mock.module("@/runtime/push-registration", () => ({
+  hasSessionConfirmedRemotePushRegistration: () => false,
+  extractPushConversationId: () => undefined,
+}));
+mock.module("@/runtime/android-notification-channels", () => ({
+  ANDROID_ALERTS_CHANNEL_ID: "vellum-alerts",
+  ensureAndroidAlertsChannel: async () => {},
+}));
+
+interface AckArg {
+  path: { assistant_id: string };
+  body: { deliveryId: string; success: boolean; errorMessage?: string };
+  throwOnError: boolean;
+}
+const ackArgs: AckArg[] = [];
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  notificationintentresultPost: async (arg: AckArg) => {
+    ackArgs.push(arg);
+    return { data: undefined, error: undefined };
+  },
+}));
+
+const { postLocalNotification, __resetNotificationsStateForTests } =
+  await import("@/runtime/notifications");
+
+// ── Notification stub ────────────────────────────────────────────────────────
+//
+// happy-dom ships no Notification constructor. The stub records each posted
+// banner and exposes a manually-settled `requestPermission` so a prompt can
+// be held open across several intents.
+
+const posted: string[] = [];
+let permission: NotificationPermission = "default";
+let settlePrompt: ((value: NotificationPermission) => void) | undefined;
+let promptCallCount = 0;
+
+class NotificationStub {
+  onclick: (() => void) | null = null;
+  constructor(title: string, _options?: NotificationOptions) {
+    posted.push(title);
+  }
+  close(): void {}
+  static get permission(): NotificationPermission {
+    return permission;
+  }
+  static requestPermission(): Promise<NotificationPermission> {
+    promptCallCount += 1;
+    return new Promise<NotificationPermission>((resolve) => {
+      settlePrompt = (value) => {
+        permission = value;
+        resolve(value);
+      };
+    });
+  }
+}
+
+beforeEach(() => {
+  posted.length = 0;
+  ackArgs.length = 0;
+  permission = "default";
+  settlePrompt = undefined;
+  promptCallCount = 0;
+  __resetNotificationsStateForTests();
+  (globalThis as { Notification?: unknown }).Notification = NotificationStub;
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => "hidden",
+  });
+});
+
+/**
+ * Let the in-flight calls reach the prompt. `requestPermission` is called
+ * several awaits deep, so `settlePrompt` is not assigned synchronously.
+ */
+const reachPrompt = (): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, 0));
+
+const intent = (deliveryId: string, title: string) => ({
+  title,
+  body: "This is a test notification",
+  sourceEventName: "assistant.share",
+  deliveryId,
+  assistantId: "assistant-1",
+});
+
+describe("ensureNotificationPermission single-flight", () => {
+  test("intents arriving during an unanswered prompt post once it is granted", async () => {
+    // Three intents land back-to-back while the user is in another app.
+    const inFlight = [
+      postLocalNotification(intent("d1", "Test 1")),
+      postLocalNotification(intent("d2", "Test 2")),
+      postLocalNotification(intent("d3", "Test 3")),
+    ];
+
+    await reachPrompt();
+
+    // Nothing can post yet — the prompt is still open.
+    expect(posted).toEqual([]);
+
+    // The user returns and clicks Allow.
+    settlePrompt?.("granted");
+    await Promise.all(inFlight);
+
+    expect(posted).toEqual(["Test 1", "Test 2", "Test 3"]);
+    // One prompt for all three, not one per intent.
+    expect(promptCallCount).toBe(1);
+    expect(ackArgs.map((a) => a.body)).toEqual([
+      { deliveryId: "d1", success: true },
+      { deliveryId: "d2", success: true },
+      { deliveryId: "d3", success: true },
+    ]);
+  });
+
+  test("a denial is reported as such and never re-prompts", async () => {
+    const first = postLocalNotification(intent("d1", "Test 1"));
+    await reachPrompt();
+    settlePrompt?.("denied");
+    await first;
+
+    await postLocalNotification(intent("d2", "Test 2"));
+
+    expect(posted).toEqual([]);
+    expect(promptCallCount).toBe(1);
+    expect(ackArgs.map((a) => a.body)).toEqual([
+      {
+        deliveryId: "d1",
+        success: false,
+        errorMessage: "Notification authorization denied",
+      },
+      {
+        deliveryId: "d2",
+        success: false,
+        errorMessage: "Notification authorization denied",
+      },
+    ]);
+  });
+
+  test("an already-granted permission posts without prompting", async () => {
+    permission = "granted";
+
+    await postLocalNotification(intent("d1", "Test 1"));
+
+    expect(posted).toEqual(["Test 1"]);
+    expect(promptCallCount).toBe(0);
+  });
+});

--- a/clients/web/src/runtime/notifications.ts
+++ b/clients/web/src/runtime/notifications.ts
@@ -58,7 +58,7 @@ export interface NotificationTapPayload {
 type PermissionState = "granted" | "denied" | "prompt" | "unsupported";
 
 let cachedPermission: PermissionState | null = null;
-let permissionPromptIssued = false;
+let pendingPermissionRequest: Promise<PermissionState> | null = null;
 let tapListenersRegistered = false;
 let tapHandler: ((payload: NotificationTapPayload) => void) | null = null;
 const recentNativeDeliveryIds = new Set<string>();
@@ -165,21 +165,43 @@ export async function refreshNotificationPermission(): Promise<PermissionState> 
  * notification-worthy event. Subsequent denials are cached — we never
  * re-prompt (both iOS and browsers ignore repeat prompts anyway, but the
  * cache avoids wasted round-trips).
+ *
+ * The prompt is memoized as an in-flight promise rather than latched behind
+ * a boolean, because the user can take arbitrarily long to answer it — they
+ * are, by construction, in another app when the first intent lands. Every
+ * intent that arrives during that window awaits the same prompt and posts
+ * once it resolves; a boolean latch would instead resolve them all to
+ * `"prompt"`, drop their banners, and ack the daemon with an authorization
+ * denial that never happened.
  */
 export async function ensureNotificationPermission(): Promise<PermissionState> {
   const current = await getNotificationPermission();
   if (current !== "prompt") {
     return current;
   }
-  if (permissionPromptIssued) {
-    return current;
+  pendingPermissionRequest ??= requestPermissionOnce();
+  return pendingPermissionRequest;
+}
+
+/**
+ * Issue the permission request and cache its outcome. Kept memoized for the
+ * life of the session (never cleared): a resolved grant or denial is served
+ * from `cachedPermission` on the next call, and an unanswered or throwing
+ * prompt resolves to `"prompt"` without re-prompting.
+ */
+async function requestPermissionOnce(): Promise<PermissionState> {
+  try {
+    const result = isNativePlatform()
+      ? await requestNativePermission()
+      : await requestBrowserPermission();
+    cachedPermission = result;
+    return result;
+  } catch {
+    // `Notification.requestPermission()` throws on older browsers and when
+    // the page lacks the activation some engines require. Treat it as
+    // unanswered rather than denied.
+    return "prompt";
   }
-  permissionPromptIssued = true;
-  const result = isNativePlatform()
-    ? await requestNativePermission()
-    : await requestBrowserPermission();
-  cachedPermission = result;
-  return result;
 }
 
 async function registerTapListeners(): Promise<void> {
@@ -572,7 +594,7 @@ export function postForegroundRemotePush(
 
 export function __resetNotificationsStateForTests(): void {
   cachedPermission = null;
-  permissionPromptIssued = false;
+  pendingPermissionRequest = null;
   tapListenersRegistered = false;
   tapHandler = null;
   recentNativeDeliveryIds.clear();


### PR DESCRIPTION
## Prompt / plan

Investigating a user report: they asked the assistant for 5 test notifications while working in another app, and only the last 2 arrived as macOS system banners. The first 3 appeared only in the Vellum activity tab. The user's theory was that Vellum suppresses system banners while the app is focused, and that clicking into the activity tab is what enabled them.

Both halves of that theory turned out to be wrong, and so did my own first diagnosis — worth recording, since the dead ends are the useful part:

1. **Not app focus.** Nothing in the pipeline consults window focus. `clients/macos/src/main/presence.ts` is explicit that presence is HID idle time and *deliberately not* focus, and `isDesktopAttended()` is consumed only by `assistant-reply-producer.ts` to suppress the mobile push. The Electron client already posts banners regardless of focus.

2. **Not the routing LLM.** My first read was that the decision engine declined the low-urgency signals (`assistant notifications send` defaults to `urgency: "low"`, and the prompt says to suppress low-urgency events). That is wrong: `decision-engine.ts:975` has an `assistant_tool` pass-through that skips the classifier entirely whenever `contextPayload.requestedMessage` is present, hard-selecting `["vellum"]`. `buildPassThroughDecision` then sets `shouldNotify: true` with a per-emit `dedupeKey`. All five signals selected vellum and dispatched. A server-side delivery floor — which is what I nearly built — would have been dead code sitting one layer below an existing one.

That leaves the client, where there is a real bug.

`ensureNotificationPermission` set `permissionPromptIssued = true` **synchronously, before awaiting the prompt**. The prompt is answered by a human who is by construction in another app when the first intent lands, so intents keep arriving while it sits open. Each one hit the latch, resolved to `"prompt"`, failed the `!== "granted"` check, and was dropped — then acked the daemon with `"Notification authorization denied"`, recording a denial in the delivery audit trail that never happened. Once the prompt was finally answered, `cachedPermission` flipped to `"granted"` and everything after worked, which reads as "notifications only work after I click into the app."

The fix memoizes the request as an in-flight promise instead of latching a boolean. Intents arriving during the window await the same prompt and post once it resolves. The prompt is still issued exactly once per session and a resolved grant/denial is still served from `cachedPermission`, so the never-re-prompt behavior is unchanged. Net effect is one fewer piece of module state and the removal of the "issued but unresolved" limbo that silently dropped banners.

Two notes on scope:

- This is the web/browser path. The Electron client bypasses it (`postLocalNotification` returns at the `isElectron()` branch before touching permission), and Electron cannot request authorization up front — its first `.show()` races the macOS prompt, which produces the same user-visible symptom from a different cause. If the reporter was on the desktop app, this fix does not cover them.
- Confirming which one applies to that specific user is a lookup, not a guess: `notification_deliveries.client_delivery_status` / `client_delivery_error` for those five deliveries. `'client_failed'` + `"Notification authorization denied"` is this bug exactly.

## Test plan

- New `clients/web/src/runtime/notifications-permission.test.ts` covers the desktop-browser branch, which had no coverage — the existing `notifications.test.ts` forces the Capacitor branch with permissions stubbed as always granted.
  - Three intents arriving during an unanswered prompt all post once it is granted, from a single prompt.
  - A denial is still reported as a denial and never re-prompts.
  - An already-granted permission posts without prompting.
- Verified the regression test actually catches the bug: stashed the source change, re-ran, and the first test fails with `"Test 2"` and `"Test 3"` missing while `"Test 1"` posts. Restored and re-ran green.
- `bun test src/runtime/notifications-permission.test.ts src/runtime/notifications.test.ts` — 15 pass, 0 fail.
- `bunx tsc --noEmit` — 0 errors repo-wide. `bunx eslint` clean on both files. Pre-commit lint + typecheck hooks passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SjRZmSArFEUKb659Fhvb4z)_