### PR TITLE
fix(security): pass turn trust at the processMessage and POST /messages entry points (Part of LUM-3135)

### DIFF
--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -648,6 +648,72 @@ describe("Conversation message queue", () => {
     await new Promise((r) => setTimeout(r, 10));
   });
 
+  test("a processMessage turn keeps its turn-start trust when the slot moves before the loop opens", async () => {
+    // processMessage is the third turn entry point, and the one a web turn
+    // takes on an idle conversation (the route only enqueues while
+    // isProcessing). It captures trust at turn start, then awaits several
+    // times before the agent loop opens. The conversation slot is writable
+    // throughout that window by paths that do not own this turn: live-voice
+    // hydration stamp-and-restore, pointer elevation, the voice bridge.
+    //
+    // Driving a real Conversation with only AgentLoop.run mocked is what makes
+    // this observable. A double that stubs runAgentLoop itself would skip the
+    // re-read entirely and pass either way.
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+
+    conversation.setTrustContext({
+      trustClass: "trusted_contact",
+      sourceChannel: "slack",
+      requesterExternalUserId: "U-contact",
+    });
+
+    // Land another actor's slot write inside the window, after the turn-start
+    // capture and before the loop opens. persistUserMessage is awaited there.
+    const originalPersist = conversation.persistUserMessage.bind(conversation);
+    let slotMoved = false;
+    (
+      conversation as unknown as {
+        persistUserMessage: typeof conversation.persistUserMessage;
+      }
+    ).persistUserMessage = async (opts) => {
+      const result = await originalPersist(opts);
+      conversation.setTrustContext({
+        trustClass: "guardian",
+        sourceChannel: "vellum",
+        requesterExternalUserId: "guardian-principal",
+      });
+      slotMoved = true;
+      return result;
+    };
+
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      onEvent: () => {},
+      requestId: "req-1",
+    });
+    await waitForPendingRun(1);
+
+    // Guard the test itself: if the injection stopped running, the assertions
+    // below would pass for the wrong reason.
+    expect(slotMoved).toBe(true);
+    expect(conversation.trustContext?.trustClass).toBe("guardian");
+
+    // Read mid-run: this is what tool setup and the guardian-request producers
+    // resolve against while the turn executes.
+    expect(conversation.currentTurnTrustContext?.trustClass).toBe(
+      "trusted_contact",
+    );
+    expect(conversation.currentTurnTrustContext?.requesterExternalUserId).toBe(
+      "U-contact",
+    );
+
+    await resolveRun(0);
+    await p1;
+    await new Promise((r) => setTimeout(r, 10));
+  });
+
   test("[experimental] queued passthrough siblings drain as a single batched run", async () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();

--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -683,6 +683,16 @@ describe("Conversation message queue", () => {
         sourceChannel: "vellum",
         requesterExternalUserId: "guardian-principal",
       });
+      // Also move the per-turn field, which is writable out-of-band: a wake
+      // that settles inside this window restores its prior value there
+      // (agent-wake stamps at :1470 and restores in a `finally` at :1554).
+      // Covers both writers, so a fix that reads either one back at the agent
+      // loop call still fails this test.
+      conversation.currentTurnTrustContext = {
+        trustClass: "guardian",
+        sourceChannel: "vellum",
+        requesterExternalUserId: "guardian-principal",
+      };
       slotMoved = true;
       return result;
     };

--- a/assistant/src/__tests__/conversation-routes-hidden-queue.test.ts
+++ b/assistant/src/__tests__/conversation-routes-hidden-queue.test.ts
@@ -164,7 +164,11 @@ function makeConversationWithPendingConfirmation(
       promoteToHead: (requestId: string) => ({ requestId }),
     },
     pendingSteerRepair: false,
-    setTrustContext: () => {},
+    // Stores rather than discarding, so a test can observe which trust the
+    // route resolved and move the slot afterwards.
+    setTrustContext(this: { trustContext: unknown }, ctx: unknown) {
+      this.trustContext = ctx;
+    },
     updateClient: () => {},
     emitConfirmationStateChanged: () => {},
     emitActivityState: () => {},
@@ -352,5 +356,64 @@ describe("hidden sends to an idle conversation with a pending confirmation", () 
     expect(res.status).toBe(202);
     expect(spies.denyAllCount()).toBe(1);
     expect(spies.agentLoopOptions()?.isHiddenPrompt).toBeUndefined();
+  });
+});
+
+describe("POST /messages turn trust", () => {
+  test("the idle send path runs its turn under the trust resolved for the request", async () => {
+    // The idle web path does not go through `processMessage`; it persists and
+    // calls `runAgentLoop` directly. Without the captured trust travelling
+    // with that call, the loop re-reads the conversation slot when it opens,
+    // and the slot is writable in between by paths that do not own this turn
+    // (channel ingress for another actor, live-voice hydration, pointer
+    // elevation, the voice bridge).
+    //
+    // The defect here is at the call site, not inside the loop, so observing
+    // the options the route passes is sufficient. The re-read *inside* the
+    // loop is covered separately against a real Conversation, since a stub
+    // like this one cannot see it.
+    const spies = makeConversationWithPendingConfirmation(false);
+    setConversation(CONV_ID, spies.conversation);
+
+    const conversation = spies.conversation as unknown as {
+      trustContext: unknown;
+      persistUserMessage: () => Promise<{ id: string; deduplicated: boolean }>;
+    };
+
+    // Another actor writes the slot inside the window, after the route
+    // resolves this request's trust and before the loop call.
+    let slotMoved = false;
+    conversation.persistUserMessage = async () => {
+      conversation.trustContext = {
+        trustClass: "trusted_contact",
+        sourceChannel: "slack",
+        requesterExternalUserId: "U-other-actor",
+      };
+      slotMoved = true;
+      return { id: "persisted-user-id", deduplicated: false };
+    };
+
+    const res = await callHandler(
+      (args) => handleSendMessage(args, makeDeps(spies.conversation)),
+      makeRequest({ content: "run a command" }),
+      undefined,
+      202,
+    );
+
+    expect(res.status).toBe(202);
+    // Guard the test itself: if the injection stopped running the assertion
+    // below would pass for the wrong reason.
+    expect(slotMoved).toBe(true);
+    expect(
+      (conversation.trustContext as { trustClass?: string } | undefined)
+        ?.trustClass,
+    ).toBe("trusted_contact");
+
+    // The turn carries the trust this request resolved, not the moved slot.
+    const turnTrust = spies.agentLoopOptions()?.turnTrustContext as
+      | { trustClass?: string }
+      | undefined;
+    expect(turnTrust).toBeDefined();
+    expect(turnTrust?.trustClass).toBe("guardian");
   });
 });

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -384,14 +384,19 @@ export async function runAgentLoopImpl(
   // without going through processMessage/drainQueue. This ensures the system
   // prompt callback always reads a valid snapshot rather than undefined.
   //
-  // Every turn entry point (`processMessage` and both queue drains) captures
-  // the acting trust at turn start and passes it here. Awaits sit between that
-  // capture and this line, and the conversation slot is writable throughout
-  // (live-voice hydration, pointer elevation, the voice bridge), so re-reading
-  // it would run the turn as whoever wrote last rather than as the actor the
-  // turn belongs to. The `?? ctx.trustContext` fallback serves only the direct
-  // callers that never capture a turn: subagent manager, voice bridge,
-  // regenerate.
+  // The invariant: a turn runs under the trust captured when that turn
+  // started, never under whatever the slot holds when the loop happens to
+  // open. Awaits sit between capture and this line, and the slot is writable
+  // throughout by paths that do not own the turn (channel ingress for another
+  // actor, live-voice hydration, pointer elevation, the voice bridge).
+  //
+  // Callers that own a turn are expected to capture at turn start and pass
+  // `turnTrustContext`. This has not been swept across all 13 call sites, so
+  // the fallback below is load-bearing for two different populations: callers
+  // that legitimately have no turn to capture (subagent manager, voice
+  // bridge, regenerate), and callers that should pass it and do not yet.
+  // Treat a caller reaching the fallback as unverified, not as correct.
+  // LUM-3148 removes the ambiguity by making trust ride the turn.
   ctx.currentTurnTrustContext = options?.turnTrustContext ?? ctx.trustContext;
   ctx.currentTurnChannelCapabilities = ctx.channelCapabilities;
 

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -384,10 +384,14 @@ export async function runAgentLoopImpl(
   // without going through processMessage/drainQueue. This ensures the system
   // prompt callback always reads a valid snapshot rather than undefined.
   //
-  // A queue drain runs a message whose sender may not be the conversation's
-  // most recent one, so it passes that sender's trust explicitly. Falling back
-  // to the slot here would undo the drain's stamp and hand the turn back to
-  // whoever sent last.
+  // Every turn entry point (`processMessage` and both queue drains) captures
+  // the acting trust at turn start and passes it here. Awaits sit between that
+  // capture and this line, and the conversation slot is writable throughout
+  // (live-voice hydration, pointer elevation, the voice bridge), so re-reading
+  // it would run the turn as whoever wrote last rather than as the actor the
+  // turn belongs to. The `?? ctx.trustContext` fallback serves only the direct
+  // callers that never capture a turn: subagent manager, voice bridge,
+  // regenerate.
   ctx.currentTurnTrustContext = options?.turnTrustContext ?? ctx.trustContext;
   ctx.currentTurnChannelCapabilities = ctx.channelCapabilities;
 

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -2345,7 +2345,15 @@ export async function processMessage(
     titleText?: string;
     callSite?: LLMCallSite;
     overrideProfile?: string;
-  } = { isUserMessage: true };
+    turnTrustContext?: TrustContext;
+  } = {
+    isUserMessage: true,
+    // Carry the trust captured at turn start into the run. Several awaits sit
+    // between that capture and the loop opening, and the conversation slot is
+    // writable throughout that window, so letting the loop re-read it would
+    // run this turn as whoever wrote last.
+    turnTrustContext: conversation.currentTurnTrustContext,
+  };
   if (isInteractive !== undefined) {
     loopOptions.isInteractive = isInteractive;
   }

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -1876,7 +1876,14 @@ export async function processMessage(
   await conversation.ensureActorScopedHistory();
   // Snapshot persona context at turn start so later tool turns can't pick up
   // a different actor's context if a concurrent request mutates the live fields.
-  conversation.currentTurnTrustContext = conversation.trustContext;
+  //
+  // Held in a local as well as on the conversation: the field is writable
+  // out-of-band while this turn is in flight (`agent-wake` stamps it and
+  // restores the prior value in a `finally`), so reading it back at the agent
+  // loop call below would reintroduce the late read this capture exists to
+  // avoid. The local is what the loop runs under.
+  const turnTrustContext = conversation.trustContext;
+  conversation.currentTurnTrustContext = turnTrustContext;
   conversation.currentTurnAuthContext = conversation.authContext;
   conversation.currentTurnSourceActorPrincipalId =
     sourceActorPrincipalId ?? conversation.authContext?.actorPrincipalId;
@@ -2349,10 +2356,11 @@ export async function processMessage(
   } = {
     isUserMessage: true,
     // Carry the trust captured at turn start into the run. Several awaits sit
-    // between that capture and the loop opening, and the conversation slot is
-    // writable throughout that window, so letting the loop re-read it would
-    // run this turn as whoever wrote last.
-    turnTrustContext: conversation.currentTurnTrustContext,
+    // between that capture and the loop opening, and both the conversation
+    // slot and the per-turn field are writable throughout that window, so
+    // reading either here would run this turn as whoever wrote last. The
+    // local captured at turn start is the only value no other writer can move.
+    turnTrustContext,
   };
   if (isInteractive !== undefined) {
     loopOptions.isInteractive = isInteractive;

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1915,6 +1915,15 @@ export async function handleSendMessage(
     conversation.setTrustContext({ trustClass: "guardian", sourceChannel });
   }
 
+  // The trust this request's turn runs under, captured here rather than read
+  // back at the agent loop below. Every branch above has just written it and
+  // nothing awaits in between, so this is the resolved sender. Between here
+  // and the loop the conversation slot is writable by paths that do not own
+  // this turn (channel ingress for another actor, live-voice hydration,
+  // pointer elevation, the voice bridge), and the loop would otherwise
+  // re-read it and run this turn as whoever wrote last.
+  const turnTrustContext = conversation.trustContext;
+
   const isInteractive = isInteractiveInterface(sourceInterface);
   // Translate the dev-bypass actor principal to the real guardian principal
   // before the same-actor host-proxy gate so web/iOS turns match the macOS
@@ -2691,6 +2700,7 @@ export async function handleSendMessage(
       onEvent: broadcastMessage,
       isInteractive,
       isUserMessage: true,
+      turnTrustContext,
       ...(body.hidden === true ? { isHiddenPrompt: true } : {}),
     })
     .catch((err) => {


### PR DESCRIPTION
## TL;DR

[#40458](https://github.com/vellum-ai/vellum-assistant/pull/40458) threaded `turnTrustContext` through both queue drains. **Two** further turn entry points still let the agent loop re-read the live slot: `processMessage`, and the `POST /messages` idle path — which is the path the reported symptom runs on.

13 non-test `.runAgentLoop(` call sites exist. Before this PR, two passed the option; now four do.

**Part of** [LUM-3135](https://linear.app/vellum/issue/LUM-3135) — the ticket has remaining work.

## What was broken

`processMessage` stamps the turn's trust at `conversation-process.ts:1879`, then calls `runAgentLoop` at `:2370` **without** `turnTrustContext`. So `runAgentLoopImpl` hits its `?? ctx.trustContext` fallback and re-reads the live slot when the loop opens, discarding the capture.

The two drains at `:1282` and `:1757` do pass it. This call site did not.

**This is the path a web turn takes.** The send route only enqueues while `isProcessing()`, so a turn on an idle conversation falls through to `processMessage` — and never got #40458's fix.

The window is real rather than theoretical. Several awaits sit between the capture and the loop opening (`persistUserMessage` at `:2286` among them), and the conversation slot is writable throughout by paths that don't own this turn:

- `live-voice-session.ts:6173` — stamp-and-restore around a hydration load, whose own comment notes the user's next foreground turn can start during that load
- `conversation.ts:2158` — pointer elevation
- `voice-session-bridge.ts:1027`

## Before / after

| | Before | After |
|---|---|---|
| Web turn on an idle conversation | Runs under whatever the slot holds when the loop opens | Runs under the trust captured at turn start |
| Slot written mid-window by live voice / pointer elevation | Turn silently adopts that actor | Turn keeps its own actor |
| Queue drains | Already correct via #40458 | Unchanged |

## Why this is safe

- **Same mechanism as the drains**, applied to the remaining entry point. No new machinery.
- **Fallback untouched**, so every direct caller that never captures a turn (subagent manager, voice bridge, regenerate) behaves exactly as before.
- **Narrower, never wider.** The change can only make a turn use the trust it captured; it cannot grant trust the turn didn't already hold.

## The comment that let this slip

The note above the fallback described only drains. That framing is why a third entry point could sit next to it and be missed. It now states the rule for every entry point and confines the fallback to direct callers.

## Testing

Regression test drives a **real `Conversation`** with only `AgentLoop.run` mocked, lands another actor's slot write inside the window via `persistUserMessage`, and asserts the turn's trust **mid-run**.

That shape is deliberate. A double that stubs `runAgentLoop` itself skips the re-read entirely and passes either way — which is exactly how round 1 of #40458 shipped inert with green tests. The test also asserts the injection actually ran and that the slot really moved, so it cannot pass for the wrong reason.

Against `main` without the fix, `:391` resolves `guardian` and the assertion fails.

Typecheck, lint, and prettier pass. Test suites run in CI, not locally, per the standing rule on this machine.

## Does this explain the reported symptom?

**Yes — this is now the leading explanation, ahead of the stored-options rebuild.**

The report is a guardian on `interface: web` whose every `bash` call escalated as a Slack contact's grant request, with `executionChannel: "slack"` and that contact's `requesterExternalUserId`.

`conversation-routes.ts:2699` is exactly that path. A guardian sending from web to an idle conversation resolves guardian trust at :1877, then awaits through persistence, attachment resolution, secret scanning and slash resolution before the loop opens. Channel ingress for another actor writes the same slot during that window, and the loop re-read it — so the whole turn ran under the contact's trust.

Three things that only this mechanism accounts for:

- **`executionChannel: "slack"` on a guardian who was on web.** The tool context derives `executionChannel` from `turnTrust.sourceChannel`. A guardian-resolved context is `vellum`; only adopting the contact's context yields `slack`.
- **`requesterExternalUserId` being the contact's, not the guardian's.** The route sets `requesterExternalUserId` to the vellum principal, so a merely mis-channelled guardian context would still carry her id.
- **"Every `bash` call in her turns."** Trust is resolved once at loop start, so a turn that opens under the wrong actor stays wrong for every tool call in it. A per-call race would produce intermittent failures, not uniform ones.

The stored-options rebuild is still a real bug and still needs its own PR, but it is now the weaker candidate for *this* report: it requires an eviction or restart, and because the rebuild also calls `ensureActorScopedHistory()` it would additionally truncate the guardian's transcript — a conspicuous symptom that was not reported.

The one thing still unverified is whether a message from that contact actually landed inside the window during her turns. That needs the log. Everything else in the chain is verified in source.

The PR stays `Part of LUM-3135` regardless: the stored-options bug is unfixed, and LUM-3148's architectural work is untouched.

## Scope

This entry point only, deliberately. `currentTurnTrustContext` is **not** cleared at turn end and the `?? ctx.trustContext` fallbacks stay. Eight readers depend on that chain:

`conversation-agent-loop.ts:1278`, `conversation-tool-setup.ts:393`, `conversation-runtime-assembly.ts:2383`, `confirmation-guardian-request.ts:69`, `question-guardian-request.ts:111`, `post-compact.ts:74`, `subagent/manager.ts:709`, `run-workflow.ts:59`

Dropping it before live voice stamps the per-turn field would fail legitimate flows closed to `FALLBACK_TURN_TRUST` (`{ sourceChannel: "vellum", trustClass: "unknown" }`). Tracked in [LUM-3148](https://linear.app/vellum/issue/LUM-3148).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40469" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
