### PR TITLE
fix(web): stop revoking an avatar url the cache still hands out (LUM-3157)

### DIFF
--- a/clients/web/src/hooks/use-assistant-avatar.test.tsx
+++ b/clients/web/src/hooks/use-assistant-avatar.test.tsx
@@ -106,6 +106,44 @@ afterEach(() => {
 });
 
 describe("useAssistantAvatar", () => {
+  /* Asserted as "never", not "at the right time", because there is no right
+     time: this cache hands the same url to every avatar on screen and one
+     assistant can hold two entries while the manifest flag resolves, so any
+     revoke here can land on a url another surface is still rendering.
+
+     Driven through a real refetch that changes the image, which is the case
+     that used to revoke. Spying on the global is the only way to see it: a
+     revoked url still reads as a string, so the returned value cannot tell you
+     whether it is alive. */
+  test("never revokes an object url the cache still hands out", async () => {
+    const revoke = mock(() => {});
+    const original = URL.revokeObjectURL;
+    URL.revokeObjectURL = revoke as unknown as typeof URL.revokeObjectURL;
+    try {
+      fetchAvatarState.mockResolvedValue(imageState);
+      fetchAvatarImageUrl.mockResolvedValue("blob:first");
+      const wrapper = createWrapper();
+      const { result } = renderHook(() => useAssistantAvatar("test-asst"), {
+        wrapper,
+      });
+      await waitFor(() => {
+        expect(result.current.customImageUrl).toBe("blob:first");
+      });
+
+      // The avatar changes, so the next fetch produces a different url for the
+      // same assistant: the replacement that used to trigger a revoke.
+      fetchAvatarImageUrl.mockResolvedValue("blob:second");
+      result.current.invalidate();
+      await waitFor(() => {
+        expect(result.current.customImageUrl).toBe("blob:second");
+      });
+
+      expect(revoke).not.toHaveBeenCalled();
+    } finally {
+      URL.revokeObjectURL = original;
+    }
+  });
+
   test("character kind exposes manifest traits and skips the image fetch", async () => {
     fetchAvatarState.mockResolvedValueOnce(characterState);
 

--- a/clients/web/src/hooks/use-assistant-avatar.ts
+++ b/clients/web/src/hooks/use-assistant-avatar.ts
@@ -23,8 +23,6 @@ export interface AvatarData {
   customImageUrl: string | null;
 }
 
-const activeBlobUrls = new Map<string, string>();
-
 /**
  * Resolve the avatar render mode from the authoritative `/avatar/state`
  * manifest (assistants on `MIN_VERSION`+). Throws on a null state so React
@@ -113,16 +111,22 @@ export function useAssistantAvatar(assistantId: string | null) {
         throw new Error("Failed to fetch character components");
       }
 
-      const prev = activeBlobUrls.get(id);
-      if (prev && prev !== imageUrl) {
-        URL.revokeObjectURL(prev);
-      }
-      if (imageUrl) {
-        activeBlobUrls.set(id, imageUrl);
-      } else {
-        activeBlobUrls.delete(id);
-      }
+      /* An uploaded avatar arrives as bytes from an authenticated endpoint, so
+         `fetchAvatarImageUrl` hands it over as an object url. That url is
+         deliberately never revoked.
 
+         This cache is what gives the same string to every avatar on screen: the
+         sidebar's identity row, the chat avatars, the voice room, the identity
+         page. Nothing here can know when the last of them has stopped
+         rendering it, and the entry is keyed by assistant *and* by the
+         manifest-support flag, which resolves asynchronously, so one assistant
+         can hold two entries carrying the same url. Revoking on behalf of one
+         of them paints a broken image in every surface still showing it.
+
+         The cost of keeping them is bounded. `staleTime: Infinity` means one
+         url per image-avatar assistant per page load, plus one more if the
+         manifest flag flips, and the browser reclaims them all on unload.
+         Revisit if anything ever refetches this query on a timer. */
       return { components, traits, customImageUrl: imageUrl };
     },
     enabled: Boolean(assistantId),


### PR DESCRIPTION
## TL;DR

An uploaded avatar arrives as bytes from an authenticated endpoint, so it reaches `<img src>` as an object url. The query function revoked the previous url for an assistant whenever it produced a new one, and that is not a safe place to do it: the cache is what gives the same string to every avatar on screen, and the query function runs *before* React Query commits the new data, so mounted images are still carrying the old url at the moment it dies.

The urls are no longer revoked. Fixes LUM-3157.

## The path that needs no user action

The tracking map was keyed by assistant id. The cache entry is keyed by assistant id **and** the manifest-support flag:

```
queryKey: [...avatarQueryKey(assistantId), supportsManifest]
```

That flag resolves asynchronously through a version gate, so on an ordinary page load one assistant briefly holds two cache entries carrying the same url, and the second fetch revoked the url the first entry was still handing out. Anything mounting from the stale entry during that window paints a broken image. No avatar change required, which is why this is worth more than the "narrow race" I first filed it as.

## What changes for the user

| | Before | After |
| --- | --- | --- |
| Avatar after the manifest flag resolves | Can paint broken in whichever surfaces read the stale entry | Renders |
| Avatar right after it is changed | Can paint broken in surfaces that re-fetch the url | Renders |
| Object urls held | Revoked on replacement, leaked in every other case | Kept for the page's life |

## Why not `onError`

The review that surfaced this suggested a fallback on the `<img>`, and that is the symptom. Every avatar surface renders this same url the same way, so a fallback in one of them diverges that surface from the rest, and it leaves the cache still handing out a dead string. Fixing the lifetime fixes all of them at once and needs no product decision about what a broken avatar should show.

## Why not reference-count or revoke later

Both are real options and both are more machinery than the problem justifies. Nothing at this layer can know when the last surface has stopped rendering a url, and the honest bound is small: `staleTime: Infinity` means one url per image-avatar assistant per page load, plus one more if the manifest flag flips. The browser reclaims them on unload. The code comment says to revisit if anything ever refetches this query on a timer; today exactly one place invalidates it, `seedHatchAvatar` during onboarding.

Worth noting what the old code actually achieved: it only revoked on *replacement*, which is precisely the harmful case, and leaked in every other case anyway. So this gives up almost no cleanup and removes the whole failure class.

## Why it is safe

A deletion plus a comment in the query function. No call-site changes, no signature change, nothing else reads the map that is gone.

The invariant is now a test, driven through a real refetch that changes the image: the case that used to revoke. Asserted as "never revoked" rather than "revoked at the right time", because from inside a shared cache there is no right time. Spying on the global is the only way to observe it, since a revoked url still reads as an ordinary string.

`bun test` is blocked locally by a standing hook, so it runs in CI alongside the nine tests already in that file, none of which asserted anything about revocation.

## Cherry-pick

Labelled. It is a shared hook that every avatar surface reads, so whoever merges the v0.11.3 batch PR should weigh that rather than take it as routine. The change itself is a deletion and its blast radius is "object urls live longer".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40470" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->