### PR TITLE
fix(android): declare camera permission

### DIFF
--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -340,7 +340,7 @@ Complete the following setup before enabling internal-track uploads:
    **Release apps to testing tracks**. Do not grant production publishing.
 6. Configure the repository and environment secrets above.
 7. Complete each Play listing, privacy policy, Data Safety form, content rating,
-   and the declarations required for microphone permissions.
+   and the declarations required for microphone and camera permissions.
 
 Before wider rollout, test the internal-track AAB on a physical device and
 verify its identity, web origin, authentication, keyboard, and file sharing.

--- a/clients/android/app/src/main/AndroidManifest.xml
+++ b/clients/android/app/src/main/AndroidManifest.xml
@@ -182,8 +182,19 @@
         </provider>
     </application>
 
+    <uses-feature
+        android:name="android.hardware.camera.any"
+        android:required="false" />
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
+    <uses-feature
+        android:name="android.hardware.camera.autofocus"
+        android:required="false" />
+
     <!-- Permissions -->
 
+    <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />


### PR DESCRIPTION
## Summary

- declare Android camera access so Capacitor WebView video capture can obtain runtime permission
- keep camera and autofocus hardware optional to avoid unnecessary Google Play device filtering

## Original prompt

Camera access does not work in the Android app. Fix the native Android permission path and ship the change in an isolated worktree as a focused pull request.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40471" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->