### PR TITLE
Cherry-pick the pinned-app colour work into release/v0.11.3 (LUM-3139, LUM-3140)

### DIFF
--- a/clients/web/src/domains/chat/components/assistant-side-menu.stories.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.stories.tsx
@@ -25,6 +25,7 @@ import { PreferencesMenu } from "@/domains/chat/components/preferences-menu";
 import { useSidebarLayoutStore } from "@/domains/chat/sidebar-layout-store";
 import { useAuthStore } from "@/stores/auth-store";
 import { usePinnedAppsStore } from "@/stores/pinned-apps-store";
+import { savePinnedApps } from "@/utils/app-pin-storage";
 import {
   saveViewMode,
   type SidebarViewMode,
@@ -97,9 +98,14 @@ const LONG_CONVERSATIONS: Conversation[] = [
 ];
 
 /* Two, because one pinned app cannot show whether the cluster spaces its
-   entries the way the sections below it do. */
+   entries the way the sections below it do.
+
+   One coloured and one not, because the pair is what shows the wash reading as
+   a tint of the pill it sits on rather than as a different component, and what
+   shows the two of them still reading as quieter than the assistant identity
+   pill above them. */
 const PINNED_APPS = [
-  { appId: "app-ops", pinnedOrder: 0, name: "Vex Ops" },
+  { appId: "app-ops", pinnedOrder: 0, name: "Vex Ops", color: "teal" },
   { appId: "app-inbox", pinnedOrder: 1, name: "Inbox Triage" },
 ];
 
@@ -146,6 +152,12 @@ const GROUPS: ConversationGroup[] = [
 function seedViewMode(assistantId: string, mode: SidebarViewMode): void {
   saveViewMode(assistantId, mode);
   useSidebarLayoutStore.setState({ assistantId: null });
+  /* Persisted as well as set, because the store mirrors storage rather than
+     owning the pins: every pin action writes through and then re-reads. Seeded
+     in memory alone, the list is a state the app cannot actually be in, and
+     the first Unpin or colour pick re-reads an empty key and clears both
+     entries in front of whoever is reviewing the story. */
+  savePinnedApps(PINNED_APPS);
   usePinnedAppsStore.setState({
     pinnedApps: PINNED_APPS,
     pinnedAppIds: new Set(PINNED_APPS.map((app) => app.appId)),

--- a/clients/web/src/domains/chat/components/pinned-app-color-swatches.tsx
+++ b/clients/web/src/domains/chat/components/pinned-app-color-swatches.tsx
@@ -1,0 +1,113 @@
+import { Ban, Check } from "lucide-react";
+
+import { cn, ContextMenu } from "@vellumai/design-library";
+
+import {
+  getPinColorHex,
+  PIN_COLORS,
+  pinColorNameKey,
+  type PinColorId,
+} from "@/domains/chat/utils/pin-color-registry";
+import { useTranslation } from "@/i18n";
+import { contrastForeground } from "@/utils/avatar-tone";
+
+/**
+ * The colour row inside a pinned app's context menu: a "no colour" tile
+ * followed by one swatch per registry colour, laid out as a single wrapping
+ * row above the menu's ordinary items.
+ *
+ * A row rather than the dialog the group icon picker opens, because there is
+ * no name field for it to sit beside. One press sets the colour, and the same
+ * row is what a long press reaches on touch, so the interaction needs no
+ * second path.
+ *
+ * The swatches are a single-choice set, so they carry `menuitemradio` and
+ * announce their selection through `aria-checked`. That is what a screen
+ * reader reads out in the user's own language, rather than this component
+ * gluing a word onto a colour's name and leaving it in English. They are also
+ * real `ContextMenu.Item`s because Radix's roving focus only reaches items:
+ * plain buttons here would be unreachable by keyboard, while as items the
+ * arrow keys walk the swatches in DOM order, along the row and then on to the
+ * items below it.
+ *
+ * The colour rides on an inner dot rather than on the item itself, so the
+ * item's own highlight surface stays visible behind it. The current colour is
+ * marked with a glyph inside its own dot rather than a ring around it: an item
+ * lays its children inside a clipping box, so a ring drawn outside the dot
+ * loses its top and bottom to the overflow. The glyph carries the foreground
+ * {@link contrastForeground} pairs with that colour, which keeps it legible on
+ * the light swatches as well as the dark ones.
+ */
+export interface PinnedAppColorSwatchesProps {
+  /**
+   * The pin's current colour id, or `undefined` when it has none. Widened to
+   * `string` because it arrives from storage, which can hold an id this
+   * registry no longer carries.
+   */
+  value: string | undefined;
+  /** `null` clears the colour. Only ever an id this registry knows. */
+  onChange: (color: PinColorId | null) => void;
+}
+
+/** A square tile with no label to make room for, at the menu's item rhythm. */
+const SWATCH_ITEM_CLASSES = "h-7 w-7 shrink-0 justify-center p-0";
+
+const DOT_CLASSES =
+  "mx-auto flex h-4 w-4 items-center justify-center rounded-full";
+
+export function PinnedAppColorSwatches({
+  value,
+  onChange,
+}: PinnedAppColorSwatchesProps) {
+  /* The default namespace: this release line carries a single `common`
+     catalog, the namespace split having landed on main after it was cut. */
+  const { t } = useTranslation();
+
+  /* A colour the registry no longer knows resolves to no tint, so the row
+     shows "no colour" as the selection, matching what the pill is painting. */
+  const selected = getPinColorHex(value) ? value : undefined;
+
+  return (
+    <div className="flex flex-wrap items-center gap-1 px-1 pb-1">
+      <ContextMenu.Item
+        role="menuitemradio"
+        aria-checked={selected === undefined}
+        aria-label={t("pinnedAppColorSwatches.noColor")}
+        className={SWATCH_ITEM_CLASSES}
+        onSelect={() => onChange(null)}
+      >
+        <span className={cn(DOT_CLASSES, "border border-[var(--border-base)]")}>
+          {selected === undefined ? (
+            <Check size={10} aria-hidden />
+          ) : (
+            <Ban
+              size={10}
+              aria-hidden
+              className="text-[var(--content-tertiary)]"
+            />
+          )}
+        </span>
+      </ContextMenu.Item>
+      {PIN_COLORS.map((color) => (
+        <ContextMenu.Item
+          key={color.id}
+          role="menuitemradio"
+          aria-checked={selected === color.id}
+          aria-label={t(pinColorNameKey(color.id))}
+          className={SWATCH_ITEM_CLASSES}
+          onSelect={() => onChange(color.id)}
+        >
+          <span className={DOT_CLASSES} style={{ backgroundColor: color.hex }}>
+            {selected === color.id ? (
+              <Check
+                size={10}
+                aria-hidden
+                style={{ color: contrastForeground(color.hex) }}
+              />
+            ) : null}
+          </span>
+        </ContextMenu.Item>
+      ))}
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/pinned-app-nav-item.test.tsx
+++ b/clients/web/src/domains/chat/components/pinned-app-nav-item.test.tsx
@@ -16,7 +16,7 @@
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { createElement, type ReactNode } from "react";
+import { createElement, type CSSProperties, type ReactNode } from "react";
 
 mock.module("@vellumai/design-library", () => {
   const SideMenu = {
@@ -24,10 +24,12 @@ mock.module("@vellumai/design-library", () => {
       label,
       onSelect,
       active,
+      style,
     }: {
       label: string;
       onSelect?: () => void;
       active?: boolean;
+      style?: CSSProperties;
     }) =>
       createElement(
         "button",
@@ -36,6 +38,10 @@ mock.module("@vellumai/design-library", () => {
           "data-testid": "app-row",
           "data-active": active ? "true" : "false",
           onClick: onSelect,
+          // Forwarded, not dropped: the tile's tint is declared through
+          // `style`, so a stand-in that swallowed it would report every
+          // collapsed pin as uncoloured.
+          style,
         },
         label,
       ),
@@ -47,19 +53,26 @@ mock.module("@vellumai/design-library", () => {
       createElement("div", { "data-testid": "ctx-trigger" }, children),
     Content: ({ children }: { children?: ReactNode }) =>
       createElement("div", { "data-testid": "ctx-content" }, children),
+    Separator: () => createElement("hr"),
     Item: ({
       children,
       onSelect,
+      ...rest
     }: {
       children?: ReactNode;
       onSelect?: () => void;
     }) =>
-      createElement("button", { type: "button", onClick: onSelect }, children),
+      createElement(
+        "button",
+        { type: "button", onClick: onSelect, ...rest },
+        children,
+      ),
   };
   return { SideMenu, ContextMenu };
 });
 
 import { PinnedAppNavItem } from "@/domains/chat/components/pinned-app-nav-item";
+import { getPinColorHex } from "@/domains/chat/utils/pin-color-registry";
 import { usePinnedAppsStore } from "@/stores/pinned-apps-store";
 import type { PinnableApp, PinnedAppEntry } from "@/utils/app-pin-storage";
 
@@ -69,6 +82,30 @@ const APP: PinnedAppEntry = {
   name: "My App",
   icon: "🚀",
 };
+
+const TEAL_APP: PinnedAppEntry = { ...APP, color: "teal" };
+
+/* Read from the registry rather than restated, so the palette stays the one
+   place a colour's hex is written down and a repalette does not fail tests
+   that are not about the palette. */
+const TEAL_HEX = getPinColorHex("teal")!;
+
+/**
+ * The three tint custom properties as the row actually declares them. Read
+ * through `getPropertyValue` because a custom property is not a typed style
+ * field, and an undeclared one reads as the empty string.
+ */
+function tintOf(element: HTMLElement): {
+  bg: string;
+  hover: string;
+  active: string;
+} {
+  return {
+    bg: element.style.getPropertyValue("--panel-item-bg"),
+    hover: element.style.getPropertyValue("--panel-item-hover"),
+    active: element.style.getPropertyValue("--panel-item-active"),
+  };
+}
 
 function seedPin(entry: PinnedAppEntry): void {
   const app: PinnableApp = {
@@ -152,15 +189,162 @@ describe("PinnedAppNavItem", () => {
     expect(screen.queryByRole("button", { name: "Unpin My App" })).toBeNull();
   });
 
+  /* `onOpen` is supplied throughout the tint cases below because the pill only
+     takes button semantics when it has a handler, and the sidebar always gives
+     it one. Without it these would read the tint off a shape the sidebar never
+     renders. */
+  test("an uncoloured pin declares no tint, so the pill keeps its plain surface", () => {
+    render(
+      <PinnedAppNavItem
+        app={APP}
+        active={false}
+        collapsed={false}
+        onOpen={() => {}}
+      />,
+    );
+
+    expect(tintOf(screen.getByRole("button", { name: "My App" }))).toEqual({
+      bg: "",
+      hover: "",
+      active: "",
+    });
+  });
+
+  test("a coloured pin declares all three tint properties on the pill", () => {
+    render(
+      <PinnedAppNavItem
+        app={TEAL_APP}
+        active={false}
+        collapsed={false}
+        onOpen={() => {}}
+      />,
+    );
+
+    const tint = tintOf(screen.getByRole("button", { name: "My App" }));
+    expect(tint.bg).toContain(TEAL_HEX);
+    expect(tint.hover).toContain(TEAL_HEX);
+    /* All three, not just the resting one. Each of the other two states has
+       its own declaration in the pill, so a tint that set only `--panel-item-bg`
+       would drop back to an untinted surface token the moment the row was
+       hovered or became the current page. */
+    expect(tint.active).toContain(TEAL_HEX);
+  });
+
+  /* The invariant from the collapsed-rail decision: the rail changes a pin's
+     shape and nothing else, so the tile declares exactly what the pill does.
+     Compared property by property rather than merely asserted non-empty, so a
+     tile that tinted only its resting surface would fail. */
+  test("the colour rides onto the collapsed rail tile unchanged", () => {
+    render(
+      <PinnedAppNavItem
+        app={TEAL_APP}
+        active={false}
+        collapsed={false}
+        onOpen={() => {}}
+      />,
+    );
+    const expanded = tintOf(screen.getByRole("button", { name: "My App" }));
+
+    cleanup();
+    render(<PinnedAppNavItem app={TEAL_APP} active={false} collapsed />);
+
+    expect(tintOf(screen.getByTestId("app-row"))).toEqual(expanded);
+  });
+
+  /* Stored ids outlive the palette. An id the registry no longer carries has
+     to paint nothing rather than resolve to a broken colour value. */
+  test("a colour id the registry does not know paints no tint", () => {
+    render(
+      <PinnedAppNavItem
+        app={{ ...APP, color: "not-a-real-color" }}
+        active={false}
+        collapsed={false}
+        onOpen={() => {}}
+      />,
+    );
+
+    expect(tintOf(screen.getByRole("button", { name: "My App" })).bg).toBe("");
+  });
+
+  test("picking a swatch stores the colour on the pin", () => {
+    seedPin(APP);
+
+    render(<PinnedAppNavItem app={APP} active={false} collapsed={false} />);
+    fireEvent.click(screen.getByRole("menuitemradio", { name: "Teal" }));
+
+    expect(usePinnedAppsStore.getState().pinnedApps[0]!.color).toBe("teal");
+  });
+
+  test("picking No color clears a colour the pin already had", () => {
+    seedPin(APP);
+    usePinnedAppsStore.getState().setColor(APP.appId, "teal");
+
+    render(
+      <PinnedAppNavItem app={TEAL_APP} active={false} collapsed={false} />,
+    );
+    fireEvent.click(screen.getByRole("menuitemradio", { name: "No color" }));
+
+    expect(usePinnedAppsStore.getState().pinnedApps[0]!.color).toBeUndefined();
+  });
+
+  /* Selection is carried by `aria-checked` on a radio, so a screen reader
+     announces it in the user's own language instead of this component gluing
+     a word onto the colour's name. Both states asserted, because a swatch that
+     is always checked marks every colour as the current one. */
+  test("marks the pin's current colour as the checked swatch", () => {
+    render(
+      <PinnedAppNavItem app={TEAL_APP} active={false} collapsed={false} />,
+    );
+
+    expect(
+      screen
+        .getByRole("menuitemradio", { name: "Teal" })
+        .getAttribute("aria-checked"),
+    ).toBe("true");
+    expect(
+      screen
+        .getByRole("menuitemradio", { name: "Green" })
+        .getAttribute("aria-checked"),
+    ).toBe("false");
+    expect(
+      screen
+        .getByRole("menuitemradio", { name: "No color" })
+        .getAttribute("aria-checked"),
+    ).toBe("false");
+  });
+
+  test("an uncoloured pin checks the No color swatch", () => {
+    render(<PinnedAppNavItem app={APP} active={false} collapsed={false} />);
+
+    expect(
+      screen
+        .getByRole("menuitemradio", { name: "No color" })
+        .getAttribute("aria-checked"),
+    ).toBe("true");
+  });
+
+  /* Named from the catalog, not from the stored id. Asserting the English
+     copy is what fails if the label ever falls back to announcing `teal`. */
+  test("announces a translated colour name rather than the stored id", () => {
+    render(
+      <PinnedAppNavItem app={TEAL_APP} active={false} collapsed={false} />,
+    );
+
+    expect(screen.getByRole("menuitemradio", { name: "Teal" })).toBeTruthy();
+    expect(screen.queryByRole("menuitemradio", { name: "teal" })).toBeNull();
+  });
+
+  test("collapsed rail: the colour row is omitted with the rest of the menu", () => {
+    render(<PinnedAppNavItem app={TEAL_APP} active={false} collapsed />);
+
+    expect(screen.queryByRole("menuitemradio", { name: "Teal" })).toBeNull();
+  });
+
   /* `aria-current="page"` rather than a `data-active` attribute: the pill's
      active state is the one assistive tech reads, and it is what the pill's
      own active styling is keyed off (`aria-[current=page]:` classes), so
      asserting it covers both. Both states, because an attribute that is always
-     set marks every row as the current one.
-
-     `onOpen` is supplied because the pill only takes button semantics when it
-     has a handler, and the sidebar always gives it one. Without it this would
-     assert the marker on a shape the sidebar never renders. */
+     set marks every row as the current one. */
   test("marks the row as the current page only while active", () => {
     const props = { app: APP, collapsed: false, onOpen: () => {} };
 

--- a/clients/web/src/domains/chat/components/pinned-app-nav-item.tsx
+++ b/clients/web/src/domains/chat/components/pinned-app-nav-item.tsx
@@ -1,6 +1,8 @@
 import { PinOff, Rocket } from "lucide-react";
 
 import { SwipeActionReveal } from "@/components/swipe-action-reveal";
+import { PinnedAppColorSwatches } from "@/domains/chat/components/pinned-app-color-swatches";
+import { pinTintStyle } from "@/domains/chat/utils/pin-color-registry";
 import { usePinnedAppsStore } from "@/stores/pinned-apps-store";
 import type { PinnedAppEntry } from "@/utils/app-pin-storage";
 import { isPointerCoarse } from "@/utils/pointer";
@@ -17,7 +19,13 @@ export interface PinnedAppNavItemProps {
 /**
  * A pinned-app row in the assistant sidebar. Renders the app as a
  * {@link SideMenu.Item} and, when expanded, wraps it in a right-click /
- * long-press {@link ContextMenu} whose sole action removes the pin.
+ * long-press {@link ContextMenu} offering a colour for the pin and an unpin.
+ *
+ * A pin the user has given a colour wears it as a wash rather than the solid
+ * fill the assistant identity pill above it wears, so that pill stays the
+ * sidebar's one saturated surface. The colour rides onto the collapsed rail
+ * with the row, because collapsing changes the shape of a thing and not what
+ * colour it is.
  *
  * The unpin lives here because it is the only place a stale pin can be
  * cleared: a deleted app never appears in the Library, so its card-level
@@ -42,9 +50,22 @@ export function PinnedAppNavItem({
   onOpen,
 }: PinnedAppNavItemProps) {
   const unpin = usePinnedAppsStore.use.unpin();
+  const setColor = usePinnedAppsStore.use.setColor();
+
+  /* The pin's colour, as the three custom properties both shapes read, and
+     `undefined` on an uncoloured pin so neither shape sees a declaration and
+     both wear their plain surface.
+
+     Declared on the row element itself rather than on a wrapper, which the
+     rail tile rules out: the tile centres itself with `mx-auto` against the
+     rail column, and a wrapper would become the thing it centres in. A custom
+     property resolves on the element that declares it, so one mechanism
+     covers both shapes. */
+  const tintStyle = pinTintStyle(app.color);
 
   const sideMenuItem = (
     <SideMenu.Item
+      style={tintStyle}
       // Apps source their icon as an emoji string on the manifest
       // (`app.icon`). Fall back to the Rocket lucide glyph so unmojified
       // apps still get a leading icon in the rail.
@@ -70,6 +91,7 @@ export function PinnedAppNavItem({
      absolutely positioned over the row's right edge. */
   const item = (
     <PanelItem
+      style={tintStyle}
       shape="pill"
       /* An app's icon is an emoji string on its manifest, so it goes in
          `leadingSlot`; `icon` takes a Lucide component, which is the fallback
@@ -130,6 +152,11 @@ export function PinnedAppNavItem({
         </SwipeActionReveal>
       </ContextMenu.Trigger>
       <ContextMenu.Content onClick={(event) => event.stopPropagation()}>
+        <PinnedAppColorSwatches
+          value={app.color}
+          onChange={(color) => setColor(app.appId, color)}
+        />
+        <ContextMenu.Separator />
         <ContextMenu.Item
           leftIcon={<PinOff size={14} />}
           onSelect={() => unpin(app.appId)}

--- a/clients/web/src/domains/chat/utils/pin-color-registry.ts
+++ b/clients/web/src/domains/chat/utils/pin-color-registry.ts
@@ -1,0 +1,116 @@
+/**
+ * Pinned-app colour registry: the single source of truth for the colours a
+ * user can assign to a pinned app in the sidebar, keyed by the stable id
+ * stored on the pin.
+ *
+ * Mirrors the group-icon registry (`./group-icon-registry`): map a stored id
+ * to a value once, and every surface (expanded pill, collapsed rail tile, the
+ * picker) resolves through it. Ids are the assistant avatar palette's, so a
+ * pin and an assistant identity that share an id are the same hue; an unknown
+ * or absent id resolves to no tint, which is also what an uncoloured pin
+ * stores.
+ *
+ * Sourced from the bundled copy of the character components rather than
+ * `useAssistantAvatar`, because a sidebar row paints on first render and the
+ * picker opens inside a context menu. Neither can wait on a fetch.
+ */
+
+import type { CSSProperties } from "react";
+
+import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
+
+/**
+ * The name each colour is announced by, as a catalog key rather than the
+ * stored id: a user hears a colour name, and "teal" is an internal identifier
+ * that happens to be an English word.
+ *
+ * This map, not the palette, decides which colours the picker offers:
+ * {@link PinColorId} is derived from it and {@link PIN_COLORS} is the palette
+ * narrowed to it. So every swatch has a name by construction and none can fall
+ * back to announcing its own id. A palette colour with no entry here is left
+ * out rather than caught by the compiler, which is the trade {@link PIN_COLORS}
+ * describes.
+ */
+const COLOR_NAME_KEYS = {
+  green: "pinnedAppColorSwatches.colors.green",
+  orange: "pinnedAppColorSwatches.colors.orange",
+  pink: "pinnedAppColorSwatches.colors.pink",
+  purple: "pinnedAppColorSwatches.colors.purple",
+  teal: "pinnedAppColorSwatches.colors.teal",
+  yellow: "pinnedAppColorSwatches.colors.yellow",
+} as const;
+
+export type PinColorId = keyof typeof COLOR_NAME_KEYS;
+
+export interface PinColor {
+  id: PinColorId;
+  hex: string;
+}
+
+/** Catalog key for a colour's name. */
+export function pinColorNameKey(
+  id: PinColorId,
+): (typeof COLOR_NAME_KEYS)[PinColorId] {
+  return COLOR_NAME_KEYS[id];
+}
+
+/**
+ * Picker choices, in the palette's own order.
+ *
+ * A palette colour this client has no name for is left out rather than shown
+ * under its id: a swatch nobody can hear the name of is worse than one fewer
+ * choice, and the omission is loud enough to fix because the colour simply
+ * does not appear.
+ */
+export const PIN_COLORS: readonly PinColor[] = BUNDLED_COMPONENTS.colors.filter(
+  (color): color is PinColor => color.id in COLOR_NAME_KEYS,
+);
+
+const HEX_BY_ID: ReadonlyMap<string, string> = new Map(
+  PIN_COLORS.map((color) => [color.id, color.hex]),
+);
+
+/**
+ * How much of the colour reaches the pill. A wash rather than a solid fill,
+ * because the assistant identity pill sits directly above the pinned apps and
+ * is the sidebar's only saturated surface: solid pills under it read as its
+ * peers rather than as entries below it.
+ *
+ * Two steps, the tinted analogue of what an untinted pill already does
+ * (`--surface-lift` at rest, `--surface-active` for hover and current page),
+ * so a coloured pill keeps that ladder instead of inventing a third state.
+ */
+const WASH_REST = "15%";
+const WASH_RAISED = "24%";
+
+/** Hex for a stored colour id, or `undefined` when the registry has no such colour. */
+export function getPinColorHex(
+  id: string | null | undefined,
+): string | undefined {
+  return id ? HEX_BY_ID.get(id) : undefined;
+}
+
+/**
+ * The three tint custom properties `PanelItem`'s pill and `SideMenu.Item`'s
+ * tile both read, or `undefined` when the pin has no (or an unrecognised)
+ * colour. In that case neither shape sees a declaration and both fall back to
+ * their plain surface.
+ *
+ * `--panel-item-fg` is deliberately left undeclared: a 15% wash moves the
+ * surface too little to need a paired foreground, so the label keeps the same
+ * content token every other row uses and stays legible in all three themes.
+ */
+export function pinTintStyle(
+  id: string | null | undefined,
+): CSSProperties | undefined {
+  const hex = getPinColorHex(id);
+  if (!hex) {
+    return undefined;
+  }
+  const raised = `color-mix(in srgb, ${hex} ${WASH_RAISED}, var(--surface-lift))`;
+  return {
+    "--panel-item-bg": `color-mix(in srgb, ${hex} ${WASH_REST}, var(--surface-lift))`,
+    "--panel-item-hover": raised,
+    "--panel-item-active": raised,
+  } as CSSProperties;
+}

--- a/clients/web/src/i18n/locales/en/common.json
+++ b/clients/web/src/i18n/locales/en/common.json
@@ -10,5 +10,16 @@
     "label": "{count, plural, one {# asset} other {# assets}}",
     "ariaLabel": "Conversation assets, {count, plural, one {# item} other {# items}}",
     "ariaLabelUnseen": "Conversation assets, {count, plural, one {# item} other {# items}} (unseen changes)"
+  },
+  "pinnedAppColorSwatches": {
+    "noColor": "No color",
+    "colors": {
+      "green": "Green",
+      "orange": "Orange",
+      "pink": "Pink",
+      "purple": "Purple",
+      "teal": "Teal",
+      "yellow": "Yellow"
+    }
   }
 }

--- a/clients/web/src/i18n/locales/es/common.json
+++ b/clients/web/src/i18n/locales/es/common.json
@@ -10,5 +10,16 @@
     "label": "{count, plural, one {# recurso} other {# recursos}}",
     "ariaLabel": "Recursos de la conversación, {count, plural, one {# elemento} other {# elementos}}",
     "ariaLabelUnseen": "Recursos de la conversación, {count, plural, one {# elemento} other {# elementos}} (cambios sin ver)"
+  },
+  "pinnedAppColorSwatches": {
+    "noColor": "Sin color",
+    "colors": {
+      "green": "Verde",
+      "orange": "Naranja",
+      "pink": "Rosa",
+      "purple": "Morado",
+      "teal": "Turquesa",
+      "yellow": "Amarillo"
+    }
   }
 }

--- a/clients/web/src/stores/pinned-apps-store.test.ts
+++ b/clients/web/src/stores/pinned-apps-store.test.ts
@@ -1,23 +1,25 @@
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  test,
-} from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 
-import { loadPinnedApps, type PinnableApp } from "@/utils/app-pin-storage";
-import { installMemoryStorage } from "@/utils/memory-storage.test-helper";
+import {
+  loadPinnedApps,
+  savePinnedApps,
+  type PinnableApp,
+  type PinnedAppEntry,
+} from "@/utils/app-pin-storage";
 import { usePinnedAppsStore } from "@/stores/pinned-apps-store";
 
-installMemoryStorage({ beforeAll, afterAll, beforeEach, afterEach });
-
-// The store is a module singleton whose in-memory slice survives across
-// tests; reset it (and the backing storage, cleared by installMemoryStorage)
-// before each case so pin state starts empty.
+/*
+ * The environment's own `localStorage`, rather than `installMemoryStorage`.
+ * That helper swaps `globalThis.window` for an object carrying nothing but a
+ * storage instance, which leaves the window with no `dispatchEvent`. The store
+ * follows its key by listening on the window, and a save announcing itself
+ * there would be swallowed, so a test file using the helper cannot observe the
+ * thing this store does.
+ */
 beforeEach(() => {
+  localStorage.clear();
+  // The store is a module singleton whose in-memory slice survives across
+  // tests, so reset it alongside storage and start each case empty.
   usePinnedAppsStore.setState({ pinnedApps: [], pinnedAppIds: new Set() });
 });
 
@@ -32,6 +34,17 @@ function makeApp(
 
 function pin(app: PinnableApp): void {
   usePinnedAppsStore.getState().togglePin(app);
+}
+
+/**
+ * Write the key without announcing it on the same-tab channel, leaving the
+ * cross-tab `StorageEvent` as the only signal a test then fires. Writing
+ * through `savePinnedApps` would announce it too, and the store would update
+ * before the event was dispatched, so the assertion would hold whether or not
+ * the cross-tab listener exists.
+ */
+function savePinnedAppsSilently(entries: PinnedAppEntry[]): void {
+  localStorage.setItem("vellum:pinnedApps", JSON.stringify(entries));
 }
 
 describe("togglePin", () => {
@@ -167,6 +180,119 @@ describe("setColor", () => {
       usePinnedAppsStore.getState().pinnedApps.map((a) => a.appId),
     ).toEqual(["a1"]);
     expect(loadPinnedApps().map((a) => a.appId)).toEqual(["a1"]);
+  });
+});
+
+/**
+ * The store follows `vellum:pinnedApps` rather than only its own writes, so a
+ * change made anywhere reaches it.
+ *
+ * `savePinnedApps` stands in for the other tab: it is the same write the other
+ * tab's store would perform, and it announces the key the same way. The final
+ * case drives a real `StorageEvent` instead, which is the specific listener
+ * only a genuinely different tab exercises.
+ */
+describe("storage subscription", () => {
+  test("picks up a pin added outside the store", () => {
+    savePinnedApps([{ appId: "a1", pinnedOrder: 1, name: "Elsewhere" }]);
+
+    const state = usePinnedAppsStore.getState();
+    expect(state.pinnedApps.map((a) => a.appId)).toEqual(["a1"]);
+    expect(state.pinnedAppIds.has("a1")).toBe(true);
+  });
+
+  test("picks up a colour changed outside the store", () => {
+    pin(makeApp({ id: "a1", name: "First" }));
+
+    savePinnedApps([
+      { appId: "a1", pinnedOrder: 1, name: "First", color: "teal" },
+    ]);
+
+    expect(usePinnedAppsStore.getState().pinnedApps[0]!.color).toBe("teal");
+  });
+
+  test("notifies onUnpin listeners for a pin removed outside the store", () => {
+    pin(makeApp({ id: "a1" }));
+    pin(makeApp({ id: "a2" }));
+    const seen: string[] = [];
+    const off = usePinnedAppsStore.getState().onUnpin((id) => seen.push(id));
+
+    savePinnedApps([{ appId: "a2", pinnedOrder: 1, name: "App a2" }]);
+
+    expect(seen).toEqual(["a1"]);
+    expect(usePinnedAppsStore.getState().pinnedAppIds.has("a1")).toBe(false);
+    off();
+  });
+
+  /* A local unpin writes storage, which notifies the subscription, which is
+     also what announces the removal. Counted rather than merely observed: the
+     action announcing it as well would still leave `seen` containing the id,
+     and would fire every listener twice. */
+  test("a local unpin notifies its listeners exactly once", () => {
+    pin(makeApp({ id: "a1" }));
+    const seen: string[] = [];
+    const off = usePinnedAppsStore.getState().onUnpin((id) => seen.push(id));
+
+    usePinnedAppsStore.getState().unpin("a1");
+
+    expect(seen).toEqual(["a1"]);
+    off();
+  });
+
+  test("a pin added outside the store notifies no unpin listener", () => {
+    const seen: string[] = [];
+    const off = usePinnedAppsStore.getState().onUnpin((id) => seen.push(id));
+
+    savePinnedApps([{ appId: "a1", pinnedOrder: 1, name: "Elsewhere" }]);
+
+    expect(seen).toEqual([]);
+    off();
+  });
+
+  test("follows a cross-tab StorageEvent for its own key", () => {
+    pin(makeApp({ id: "a1" }));
+
+    /* A real cross-tab write: another document mutated the key, so this one
+       gets the event with storage already carrying the new value. */
+    savePinnedAppsSilently([
+      { appId: "a1", pinnedOrder: 1, name: "App a1" },
+      { appId: "a2", pinnedOrder: 2, name: "From another tab" },
+    ]);
+    window.dispatchEvent(
+      new StorageEvent("storage", { key: "vellum:pinnedApps" }),
+    );
+
+    expect(
+      usePinnedAppsStore.getState().pinnedApps.map((a) => a.appId),
+    ).toEqual(["a1", "a2"]);
+  });
+
+  /* Six consumers select `pinnedAppIds` to ask whether one app is pinned, and
+     a fresh Set on every notification re-renders all of them against a set
+     holding exactly what it held before. Asserted by reference rather than by
+     contents, which would be equal either way. */
+  test("a notification carrying no change publishes no new state", () => {
+    pin(makeApp({ id: "a1" }));
+    const before = usePinnedAppsStore.getState();
+
+    savePinnedApps(loadPinnedApps());
+
+    const after = usePinnedAppsStore.getState();
+    expect(after.pinnedApps).toBe(before.pinnedApps);
+    expect(after.pinnedAppIds).toBe(before.pinnedAppIds);
+  });
+
+  test("ignores a StorageEvent for an unrelated key", () => {
+    pin(makeApp({ id: "a1" }));
+
+    savePinnedAppsSilently([]);
+    window.dispatchEvent(
+      new StorageEvent("storage", { key: "vellum:somethingElse" }),
+    );
+
+    expect(
+      usePinnedAppsStore.getState().pinnedApps.map((a) => a.appId),
+    ).toEqual(["a1"]);
   });
 });
 

--- a/clients/web/src/stores/pinned-apps-store.test.ts
+++ b/clients/web/src/stores/pinned-apps-store.test.ts
@@ -126,6 +126,50 @@ describe("togglePin unpin branch", () => {
   });
 });
 
+describe("setColor", () => {
+  test("reflects the colour in state and storage", () => {
+    pin(makeApp({ id: "a1", name: "First" }));
+
+    usePinnedAppsStore.getState().setColor("a1", "teal");
+
+    expect(usePinnedAppsStore.getState().pinnedApps[0]!.color).toBe("teal");
+    expect(loadPinnedApps()[0]!.color).toBe("teal");
+  });
+
+  test("clearing drops the colour in state and storage", () => {
+    pin(makeApp({ id: "a1", name: "First" }));
+    usePinnedAppsStore.getState().setColor("a1", "teal");
+
+    usePinnedAppsStore.getState().setColor("a1", null);
+
+    expect(usePinnedAppsStore.getState().pinnedApps[0]!.color).toBeUndefined();
+    expect(loadPinnedApps()[0]!.color).toBeUndefined();
+  });
+
+  /* A store slice the sidebar renders from: a colour change has to produce a
+     new array, or subscribers keep the reference they already have and the
+     pill never repaints. */
+  test("publishes a new pinnedApps reference so subscribers re-render", () => {
+    pin(makeApp({ id: "a1", name: "First" }));
+    const before = usePinnedAppsStore.getState().pinnedApps;
+
+    usePinnedAppsStore.getState().setColor("a1", "teal");
+
+    expect(usePinnedAppsStore.getState().pinnedApps).not.toBe(before);
+  });
+
+  test("is a no-op for an id that is not pinned", () => {
+    pin(makeApp({ id: "a1", name: "First" }));
+
+    usePinnedAppsStore.getState().setColor("ghost", "teal");
+
+    expect(
+      usePinnedAppsStore.getState().pinnedApps.map((a) => a.appId),
+    ).toEqual(["a1"]);
+    expect(loadPinnedApps().map((a) => a.appId)).toEqual(["a1"]);
+  });
+});
+
 describe("isPinned", () => {
   test("tracks pin/unpin transitions", () => {
     expect(usePinnedAppsStore.getState().isPinned("a1")).toBe(false);

--- a/clients/web/src/stores/pinned-apps-store.ts
+++ b/clients/web/src/stores/pinned-apps-store.ts
@@ -1,7 +1,12 @@
 /**
  * Zustand store for pinned-app state.
  *
- * Pin state is persisted to localStorage via {@link appPinStorage}.
+ * Pin state is persisted to localStorage via {@link appPinStorage}, which owns
+ * it: actions write there first and the store follows, both for its own writes
+ * and for changes arriving from another tab. It is a mirror rather than a
+ * plain read-through because it also derives `pinnedAppIds` for the callers
+ * that only ask whether one app is pinned, and hosts the unpin listeners.
+ *
  * No provider required — the store is a module-level singleton
  * accessible anywhere via `usePinnedAppsStore.use.*()` (React) or
  * `usePinnedAppsStore.getState()` (non-React).
@@ -16,6 +21,7 @@ import {
   loadPinnedApps,
   pinApp,
   setAppColor,
+  subscribePinnedApps,
   unpinApp,
   type PinnableApp,
   type PinnedAppEntry,
@@ -62,27 +68,65 @@ export type PinnedAppsStore = PinnedAppsState & PinnedAppsActions;
 // Helpers
 // ---------------------------------------------------------------------------
 
-function loadState(): PinnedAppsState {
-  const pinnedApps = loadPinnedApps();
+function deriveState(pinnedApps: PinnedAppEntry[]): PinnedAppsState {
   return {
     pinnedApps,
     pinnedAppIds: new Set(pinnedApps.map((a) => a.appId)),
   };
 }
 
+/**
+ * Bring the store up to what storage holds, announcing any pin that went away.
+ *
+ * The one way state advances, whether the write came from this tab or another,
+ * so a removed pin is announced once by whoever notices it first. That is what
+ * lets an action call it directly and the subscription call it as well,
+ * without either depending on the other having run.
+ */
+function syncFromStorage(): void {
+  const previous = usePinnedAppsStoreBase.getState();
+  const pinnedApps = loadPinnedApps();
+
+  /* An unchanged key reads back as the same array, because the accessor caches
+     its parse against the raw string. Stopping here is what makes a redundant
+     call free: publishing anyway would hand every consumer a fresh
+     `pinnedAppIds` Set, and the six that only ask whether one app is pinned
+     would re-render against a set holding exactly what it held before. */
+  if (pinnedApps === previous.pinnedApps) {
+    return;
+  }
+
+  const next = deriveState(pinnedApps);
+  usePinnedAppsStoreBase.setState(next);
+
+  /* An app open in this tab has to close when its pin is cleared, which is
+     what `use-active-app-pin-sync` listens for. Driving that from the diff
+     rather than from `unpin` means a pin cleared in another tab closes the
+     panel too, instead of leaving it open against a pin that is gone. */
+  for (const appId of previous.pinnedAppIds) {
+    if (!next.pinnedAppIds.has(appId)) {
+      for (const listener of unpinListeners) {
+        listener(appId);
+      }
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Store
 // ---------------------------------------------------------------------------
 
-const usePinnedAppsStoreBase = create<PinnedAppsStore>()((set, get) => ({
-  ...loadState(),
+/* `set` goes unused: `syncFromStorage` is the only writer, and it reaches the
+   store directly because the subscription calls it from out here as well. */
+const usePinnedAppsStoreBase = create<PinnedAppsStore>()((_set, get) => ({
+  ...deriveState(loadPinnedApps()),
 
   togglePin: (app: PinnableApp) => {
     if (get().pinnedAppIds.has(app.id)) {
       get().unpin(app.id);
     } else {
       pinApp(app);
-      set(loadState());
+      syncFromStorage();
     }
   },
 
@@ -91,10 +135,7 @@ const usePinnedAppsStoreBase = create<PinnedAppsStore>()((set, get) => ({
       return;
     }
     unpinApp(appId);
-    set(loadState());
-    for (const listener of unpinListeners) {
-      listener(appId);
-    }
+    syncFromStorage();
   },
 
   setColor: (appId: string, color: string | null) => {
@@ -102,7 +143,7 @@ const usePinnedAppsStoreBase = create<PinnedAppsStore>()((set, get) => ({
       return;
     }
     setAppColor(appId, color);
-    set(loadState());
+    syncFromStorage();
   },
 
   isPinned: (appId: string) => get().pinnedAppIds.has(appId),
@@ -114,5 +155,20 @@ const usePinnedAppsStoreBase = create<PinnedAppsStore>()((set, get) => ({
     };
   },
 }));
+
+/**
+ * A pin list changed under us, by another tab or by anything else writing the
+ * key, so catch up to it.
+ *
+ * Our own writes arrive here too, since a save announces itself on the same
+ * channel. That costs nothing and is not relied upon: {@link syncFromStorage}
+ * settles against live state, so whichever of the action and this subscription
+ * reaches it first does the work and the other finds nothing to do.
+ *
+ * Never unsubscribed. The store is a module-level singleton that lives as long
+ * as the document, so there is no later moment at which following the pins is
+ * the wrong thing to do.
+ */
+subscribePinnedApps(syncFromStorage);
 
 export const usePinnedAppsStore = createSelectors(usePinnedAppsStoreBase);

--- a/clients/web/src/stores/pinned-apps-store.ts
+++ b/clients/web/src/stores/pinned-apps-store.ts
@@ -15,6 +15,7 @@ import { createSelectors } from "@/utils/create-selectors";
 import {
   loadPinnedApps,
   pinApp,
+  setAppColor,
   unpinApp,
   type PinnableApp,
   type PinnedAppEntry,
@@ -45,6 +46,12 @@ export interface PinnedAppsActions {
    * unpin is unreachable. A no-op when the id isn't pinned.
    */
   unpin: (appId: string) => void;
+  /**
+   * Set or clear the colour the sidebar tints this pin with, as an id from the
+   * pinned-app colour registry. `null` clears it. A no-op when the id is not
+   * pinned, matching {@link PinnedAppsActions.unpin}.
+   */
+  setColor: (appId: string, color: string | null) => void;
   isPinned: (appId: string) => boolean;
   onUnpin: (listener: UnpinListener) => () => void;
 }
@@ -88,6 +95,14 @@ const usePinnedAppsStoreBase = create<PinnedAppsStore>()((set, get) => ({
     for (const listener of unpinListeners) {
       listener(appId);
     }
+  },
+
+  setColor: (appId: string, color: string | null) => {
+    if (!get().pinnedAppIds.has(appId)) {
+      return;
+    }
+    setAppColor(appId, color);
+    set(loadState());
   },
 
   isPinned: (appId: string) => get().pinnedAppIds.has(appId),

--- a/clients/web/src/utils/app-pin-storage.test.ts
+++ b/clients/web/src/utils/app-pin-storage.test.ts
@@ -13,6 +13,7 @@ import {
   loadPinnedApps,
   pinApp,
   savePinnedApps,
+  setAppColor,
   unpinApp,
   type PinnableApp,
 } from "@/utils/app-pin-storage";
@@ -146,6 +147,116 @@ describe("isAppPinned", () => {
     pinApp(makeApp({ id: "a1", name: "First" }));
     unpinApp("a1");
     expect(isAppPinned("a1")).toBe(false);
+  });
+});
+
+describe("setAppColor", () => {
+  test("sets the colour on the addressed pin only", () => {
+    pinApp(makeApp({ id: "a1", name: "First" }));
+    pinApp(makeApp({ id: "a2", name: "Second" }));
+
+    setAppColor("a1", "teal");
+
+    const result = loadPinnedApps();
+    expect(result[0]).toEqual({
+      appId: "a1",
+      pinnedOrder: 1,
+      name: "First",
+      color: "teal",
+    });
+    expect(result[1]!.color).toBeUndefined();
+  });
+
+  test("replaces an existing colour rather than accumulating", () => {
+    pinApp(makeApp({ id: "a1", name: "First" }));
+    setAppColor("a1", "teal");
+    setAppColor("a1", "pink");
+
+    expect(loadPinnedApps()[0]!.color).toBe("pink");
+  });
+
+  /* Cleared means absent, not present-and-undefined. Asserted against the
+     serialised text because that is where the two differ: an entry holding
+     `undefined` reads back as an entry holding nothing, so comparing parsed
+     objects would pass either way. */
+  test("clearing removes the key instead of storing undefined", () => {
+    pinApp(makeApp({ id: "a1", name: "First" }));
+    setAppColor("a1", "teal");
+    setAppColor("a1", null);
+
+    expect(memoryStorage.getItem(STORAGE_KEY)).not.toContain("color");
+    expect(loadPinnedApps()[0]!.color).toBeUndefined();
+  });
+
+  test("leaves the rest of the entry untouched", () => {
+    pinApp(makeApp({ id: "a1", name: "First", icon: "🚀" }));
+    setAppColor("a1", "green");
+
+    expect(loadPinnedApps()).toEqual([
+      {
+        appId: "a1",
+        pinnedOrder: 1,
+        name: "First",
+        icon: "🚀",
+        color: "green",
+      },
+    ]);
+  });
+
+  test("is a no-op for an app that is not pinned", () => {
+    setAppColor("ghost", "teal");
+    expect(loadPinnedApps()).toEqual([]);
+  });
+
+  test("colouring an unpinned app does not resurrect it", () => {
+    pinApp(makeApp({ id: "a1", name: "First" }));
+    unpinApp("a1");
+
+    setAppColor("a1", "teal");
+
+    expect(loadPinnedApps()).toEqual([]);
+    expect(isAppPinned("a1")).toBe(false);
+  });
+});
+
+describe("colour compatibility", () => {
+  /* The load path has no version stamp, so a pin written before `color`
+     existed has to stay valid on its own merits. This is the case that costs a
+     user their pins if the field is ever validated as required. */
+  test("keeps pins written without a colour", () => {
+    memoryStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify([
+        { appId: "a1", pinnedOrder: 1, name: "No colour" },
+        { appId: "a2", pinnedOrder: 2, name: "With colour", color: "teal" },
+      ]),
+    );
+
+    expect(loadPinnedApps().map((e) => e.appId)).toEqual(["a1", "a2"]);
+    expect(loadPinnedApps()[0]!.color).toBeUndefined();
+  });
+
+  test("keeps pins carrying keys the reader does not know", () => {
+    memoryStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify([
+        { appId: "a1", pinnedOrder: 1, name: "Future", somethingNew: 7 },
+      ]),
+    );
+
+    expect(loadPinnedApps().map((e) => e.appId)).toEqual(["a1"]);
+  });
+
+  test("rejects an entry whose colour is not a string", () => {
+    memoryStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify([
+        { appId: "a1", pinnedOrder: 1, name: "Bad colour", color: 42 },
+        { appId: "a2", pinnedOrder: 2, name: "Good" },
+      ]),
+    );
+
+    expect(loadPinnedApps().map((e) => e.appId)).toEqual(["a2"]);
   });
 });
 

--- a/clients/web/src/utils/app-pin-storage.ts
+++ b/clients/web/src/utils/app-pin-storage.ts
@@ -10,6 +10,17 @@ export interface PinnedAppEntry {
   pinnedOrder: number;
   name: string;
   icon?: string;
+  /**
+   * A colour the user picked for this pin, as an id from the pinned-app colour
+   * registry. Absent on a pin with no colour, which is every pin until one is
+   * chosen.
+   *
+   * Unlike {@link PinnedAppEntry.name} and {@link PinnedAppEntry.icon}, this
+   * has no counterpart on the app: those two are copied off {@link AppSummary}
+   * at pin time and mirror it, while this belongs to the pin alone and is not
+   * reflected anywhere else the app appears.
+   */
+  color?: string;
 }
 
 /**
@@ -19,6 +30,14 @@ export interface PinnedAppEntry {
  */
 export type PinnableApp = Pick<AppSummary, "id" | "name" | "icon">;
 
+/**
+ * Per-entry validation is the whole compatibility story for this key: there is
+ * no version stamp, and {@link parsePinnedApps} simply drops what fails. So
+ * every optional field must be optional here in both directions. A pin written
+ * before that field existed stays valid because `undefined` passes, and a pin
+ * carrying a field a reader does not know about stays valid because unknown
+ * keys are never rejected.
+ */
 function isValidEntry(value: unknown): value is PinnedAppEntry {
   if (!value || typeof value !== "object") {
     return false;
@@ -29,7 +48,8 @@ function isValidEntry(value: unknown): value is PinnedAppEntry {
     typeof record.pinnedOrder === "number" &&
     Number.isFinite(record.pinnedOrder) &&
     typeof record.name === "string" &&
-    (record.icon === undefined || typeof record.icon === "string")
+    (record.icon === undefined || typeof record.icon === "string") &&
+    (record.color === undefined || typeof record.color === "string")
   );
 }
 
@@ -75,6 +95,29 @@ export function unpinApp(appId: string): void {
     .sort((a, b) => a.pinnedOrder - b.pinnedOrder)
     .map((e, i) => ({ ...e, pinnedOrder: i + 1 }));
   storage.save(entries);
+}
+
+/**
+ * Set or clear a pin's colour. `null` clears it. A no-op for an app that is
+ * not pinned, so a colour can never conjure a pin that unpinning just removed.
+ */
+export function setAppColor(appId: string, color: string | null): void {
+  const entries = storage.load();
+  if (!entries.some((e) => e.appId === appId)) {
+    return;
+  }
+  storage.save(
+    entries.map((entry) => {
+      if (entry.appId !== appId) {
+        return entry;
+      }
+      /* Drop the key rather than storing `undefined`: `JSON.stringify` omits
+         it either way, so keeping it would leave the in-memory entry and the
+         entry read back from storage unequal. */
+      const { color: _cleared, ...rest } = entry;
+      return color === null ? rest : { ...rest, color };
+    }),
+  );
 }
 
 export function isAppPinned(appId: string): boolean {

--- a/clients/web/src/utils/app-pin-storage.ts
+++ b/clients/web/src/utils/app-pin-storage.ts
@@ -71,6 +71,7 @@ const storage = createStorageAccessor<PinnedAppEntry[]>({
 
 export const loadPinnedApps = storage.load;
 export const savePinnedApps = storage.save;
+export const subscribePinnedApps = storage.subscribe;
 
 export function pinApp(app: PinnableApp): void {
   const entries = storage.load();

--- a/clients/web/src/utils/typed-storage.test.ts
+++ b/clients/web/src/utils/typed-storage.test.ts
@@ -47,6 +47,64 @@ describe("createStorageAccessor", () => {
     expect(localStorage.getItem("vellum:test-items")).toBe('["a","b"]');
   });
 
+  /* The imperative counterpart to `useValue`, for the readers that are not
+     components. Both directions are covered: a write from this tab announces
+     itself on the same-tab channel, and a write from another tab arrives as a
+     `StorageEvent`, which is the one a module-level mirror depends on. */
+  describe("subscribe", () => {
+    test("fires on a write through the accessor", () => {
+      let calls = 0;
+      const off = accessor.subscribe(() => {
+        calls += 1;
+      });
+
+      accessor.save(["a"]);
+
+      expect(calls).toBe(1);
+      off();
+    });
+
+    test("fires on a cross-tab StorageEvent for its key", () => {
+      let calls = 0;
+      const off = accessor.subscribe(() => {
+        calls += 1;
+      });
+
+      window.dispatchEvent(
+        new StorageEvent("storage", { key: "vellum:test-items" }),
+      );
+
+      expect(calls).toBe(1);
+      off();
+    });
+
+    test("ignores changes to another key", () => {
+      let calls = 0;
+      const off = accessor.subscribe(() => {
+        calls += 1;
+      });
+
+      window.dispatchEvent(
+        new StorageEvent("storage", { key: "vellum:something-else" }),
+      );
+
+      expect(calls).toBe(0);
+      off();
+    });
+
+    test("stops firing once unsubscribed", () => {
+      let calls = 0;
+      const off = accessor.subscribe(() => {
+        calls += 1;
+      });
+      off();
+
+      accessor.save(["a"]);
+
+      expect(calls).toBe(0);
+    });
+  });
+
   test("remove deletes the key", () => {
     accessor.save(["a"]);
     accessor.remove();

--- a/clients/web/src/utils/typed-storage.ts
+++ b/clients/web/src/utils/typed-storage.ts
@@ -55,6 +55,16 @@ export interface StorageAccessor<T> {
   /** The declared scope. */
   scope: StorageScope;
   /**
+   * Call `onChange` whenever this key changes, in this tab or another, and
+   * return an unsubscribe. The imperative form of {@link StorageAccessor.useValue},
+   * for the readers that are not components: a module-level store that mirrors
+   * a key has to follow it, or it only ever learns about its own writes.
+   *
+   * Prefer this to reaching for `watchSetting` with {@link StorageAccessor.key},
+   * which spreads the key to callers that would then have to keep it in step.
+   */
+  subscribe: (onChange: () => void) => () => void;
+  /**
    * React hook that subscribes to storage changes via `useSyncExternalStore`.
    * Concurrent-rendering-safe, no initial null→value flicker.
    */
@@ -327,7 +337,7 @@ export function createStorageAccessor<T>(
     return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
   }
 
-  return { load, save, remove, key, scope, useValue };
+  return { load, save, remove, key, scope, subscribe, useValue };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/design-library/src/components/side-menu/side-menu.tsx
+++ b/packages/design-library/src/components/side-menu/side-menu.tsx
@@ -509,6 +509,12 @@ export interface SideMenuItemProps {
    * colour as well as form. A caller reaching for a round row somewhere other
    * than the rail wants neither.
    *
+   * Its surface reads the same `--panel-item-bg` / `--panel-item-hover` /
+   * `--panel-item-active` properties `PanelItem`'s pill does, each falling
+   * back to the untinted token. So a caller that tints the expanded pill tints
+   * the collapsed tile with the same one declaration, and a caller that tints
+   * nothing sees no difference.
+   *
    * Ignored when expanded, where the row spans the rail's full width and a
    * full round would draw a pill rather than a circle.
    *
@@ -669,8 +675,13 @@ function SideMenuItem({
   const geometryClasses = isTile
     ? /* The tile carries the same resting surface as the card or pill it
          stands in for when the rail is expanded, so collapsing changes the
-         shape of a thing and not whether it has a surface at all. */
-      "size-[30px] mx-auto rounded-full bg-[var(--surface-lift)]"
+         shape of a thing and not whether it has a surface at all.
+
+         Which is why it reads the same tint properties `PanelItem`'s pill
+         does, through the same fallback: a caller that tints the expanded pill
+         tints this with one declaration, and one that tints nothing reaches
+         `--surface-lift`. */
+      "size-[30px] mx-auto rounded-full bg-[var(--panel-item-bg,var(--surface-lift))]"
     : // `w-full` matters for the `<button>` render path: buttons keep
       // fit-content sizing even as flex containers, so without it a
       // button-backed item shrink-wraps while anchor-backed items fill the rail.
@@ -686,7 +697,18 @@ function SideMenuItem({
   const stateClasses = disabled
     ? "cursor-default text-[color:var(--content-disabled)]"
     : active
-      ? "cursor-pointer bg-[var(--surface-active)] text-[color:var(--content-emphasised)]"
+      ? cn(
+          "cursor-pointer text-[color:var(--content-emphasised)]",
+          /* A tinted tile stays tinted while it is the current page. Without
+             reading the tint here, this rule and the resting one are different
+             declarations of the same property, the active one wins, and the
+             tile drops its colour at exactly the moment it is selected. Only
+             the tile, because it is the only shape carrying a surface to
+             tint. Untinted callers reach `--surface-active`. */
+          isTile
+            ? "bg-[var(--panel-item-active,var(--panel-item-bg,var(--surface-active)))]"
+            : "bg-[var(--surface-active)]",
+        )
       : cn(
           "cursor-pointer",
           /* Which hover surface is right depends on what the shape rests on.
@@ -697,7 +719,7 @@ function SideMenuItem({
              step up from lifted. A row rests transparent, where the overlay
              is exactly what it was built for. */
           isTile
-            ? "hover:bg-[var(--surface-active)]"
+            ? "hover:bg-[var(--panel-item-hover,var(--surface-active))]"
             : "hover:bg-[var(--surface-hover)]",
           emphasized
             ? "text-[color:var(--content-emphasised)]"


### PR DESCRIPTION
## TL;DR

The two pinned-app changes the automation could not cherry-pick, applied by hand. Targets `cherry-pick/release/v0.11.3` so they join the rolling batch (#40441) and ship with this release line.

- `f8e87bc0a7` — #40457, colour on pinned apps (LUM-3139), **adapted**
- `b59b5cf779` — #40459, store follows its storage key (LUM-3140), **applied clean**

Opened as a PR into the cherry-pick branch rather than pushed straight to it, because one of the two is hand-adapted and that deserves a review surface plus CI on the release-line code.

## Why the automation failed

Both failures trace to one cause: **`release/v0.11.3` was cut before the i18n namespace split (#40445) merged to main.** On this line there is a single `common` catalog, no `chat` namespace, no `namespaces.ts`, and no `no-untranslated-strings` ratchet.

So #40457 hit two conflicts, neither of them a content clash:
- `chat.json` (en and es) came through as **modify/delete** — the file does not exist here
- `eslint.config.mjs` appends to `i18nEnforcedPaths`, an array this branch does not have

#40459's failure was **purely a cascade**: it edits `setColor`'s body and the `color` field, code that #40457 introduces. With #40457 missing there was nothing to patch. Once the adapted #40457 landed, #40459 applied with zero conflicts.

## What differs from main, exactly

Three points, all in service of the same constraint, and nothing else:

| | main | here |
|---|---|---|
| Picker strings | `chat.json` | `common.json` |
| Lookup | `useTranslation("chat")` | `useTranslation()` |
| `eslint.config.mjs` | appends to `i18nEnforcedPaths` | unchanged (no ratchet here) |

Both locales are carried over, so the feature is translated on this line too.

**Verified by diffing every touched file against `main`.** Nine of the ten are **byte-identical**: `pin-color-registry.ts`, `pinned-app-nav-item.tsx` and its test, `pinned-apps-store.ts` and its test, `app-pin-storage.ts` and its test, `typed-storage.ts`, and `side-menu.tsx`. The only file that differs is `pinned-app-color-swatches.tsx`, by exactly the three lines above.

That check matters here because a release branch gets no CI of its own on main's behalf, so byte-identity against the reviewed original is the strongest available evidence that this is a faithful port.

## The alternative, and why not

Cherry-picking the namespace split itself (#40445) would have kept everything byte-identical. It is 22 files and 874 insertions of i18n infrastructure — a new lint rule, the catalogs restructure, i18n core, test-setup and Storybook wiring — carried into a release branch to deliver one sidebar feature. Adapting three lines is the smaller risk.

Worth noting the conflict exists *because* the review was addressed: #40457 would have picked cleanly with its original raw `aria-label` strings. The i18n conversion came from Devin and Codex both flagging them, and it is still the right change on main.

## Testing

Typecheck and lint clean against this branch's code. The behaviour is unchanged from the versions already reviewed and merged to main, and the byte-identity table above is the evidence for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40476" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->