### PR TITLE
fix(macos): allow Stripe.js through the renderer CSP so the payment-method modal can mount

### DIFF
--- a/clients/macos/src/main/csp.test.ts
+++ b/clients/macos/src/main/csp.test.ts
@@ -15,6 +15,7 @@ describe("CSP_POLICY", () => {
       "script-src",
       "style-src",
       "connect-src",
+      "frame-src",
       "img-src",
       "media-src",
       "worker-src",
@@ -74,6 +75,21 @@ describe("CSP_POLICY", () => {
     expect(connectSrc).toContain("wss://*.vellum.ai");
     expect(connectSrc).toContain("https://*.ingest.sentry.io");
     expect(connectSrc).not.toMatch(/\bhttps:\s/);
+  });
+
+  test("allows the Stripe.js hosts needed by the payment-method modal", () => {
+    const scriptSrc = directiveValue("script-src")!;
+    expect(scriptSrc).toContain("https://js.stripe.com");
+    expect(scriptSrc).toContain("https://*.js.stripe.com");
+
+    const frameSrc = directiveValue("frame-src")!;
+    expect(frameSrc).toContain("'self'");
+    expect(frameSrc).toContain("https://js.stripe.com");
+    expect(frameSrc).toContain("https://*.js.stripe.com");
+    expect(frameSrc).toContain("https://hooks.stripe.com");
+
+    const connectSrc = directiveValue("connect-src")!;
+    expect(connectSrc).toContain("https://api.stripe.com");
   });
 
   test("connect-src allows loopback gateway WebSockets but not broad ws:", () => {

--- a/clients/macos/src/main/csp.ts
+++ b/clients/macos/src/main/csp.ts
@@ -37,11 +37,26 @@ const WILDCARD_HOST = `*${ROOT_HOSTNAME}`;
 // transfer is CSP-blocked without an explicit allowlist. Both the path-style
 // (`storage.googleapis.com/<bucket>/...`) and virtual-hosted
 // (`<bucket>.storage.googleapis.com/...`) URL shapes are covered.
+//
+// Stripe hosts: the billing payment-method modal (auto-top-up) loads Stripe.js
+// via `loadStripe` (script-src js.stripe.com), which mounts the card and
+// address inputs inside iframes on js.stripe.com / *.js.stripe.com (frame-src)
+// and confirms SetupIntents against api.stripe.com (connect-src).
+// hooks.stripe.com hosts the 3D Secure challenge frame. This is Stripe's
+// documented CSP set for Stripe.js: https://docs.stripe.com/security/guide
+// (minus maps.googleapis.com, which only applies when supplying your own
+// Google Maps key to the Address Element).
+// frame-src is the only directive that names Stripe hosts alongside 'self';
+// without it frames fall back to `default-src 'self'`, which blocks the
+// Element iframes. The sandboxed srcdoc surfaces (dynamic-page-surface,
+// app-viewer) don't consult frame-src at all: srcdoc inherits the embedder's
+// CSP, so keeping this list to 'self' + Stripe hosts costs them nothing.
 export const CSP_POLICY = [
   "default-src 'self'",
-  `script-src 'self' 'unsafe-inline' https://${WILDCARD_HOST}`,
+  `script-src 'self' 'unsafe-inline' https://${WILDCARD_HOST} https://js.stripe.com https://*.js.stripe.com`,
   "style-src 'self' 'unsafe-inline'",
-  `connect-src 'self' blob: data: https://${WILDCARD_HOST} wss://${WILDCARD_HOST} https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://api.elevenlabs.io https://api.deepgram.com https://storage.googleapis.com https://*.storage.googleapis.com ws://localhost:* ws://127.0.0.1:*`,
+  `connect-src 'self' blob: data: https://${WILDCARD_HOST} wss://${WILDCARD_HOST} https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://api.elevenlabs.io https://api.deepgram.com https://storage.googleapis.com https://*.storage.googleapis.com https://api.stripe.com ws://localhost:* ws://127.0.0.1:*`,
+  "frame-src 'self' https://js.stripe.com https://*.js.stripe.com https://hooks.stripe.com",
   "img-src 'self' https: data: blob:",
   // Hosted voice-preview samples: ElevenLabs premades live in the
   // eleven-public-prod GCS bucket (path-scoped so the rest of GCS stays


### PR DESCRIPTION
## Summary
- Add Stripe's documented CSP hosts for Stripe.js to the Electron renderer policy: `https://js.stripe.com` + `https://*.js.stripe.com` in `script-src`, a new `frame-src` directive (`'self'` + Stripe hosts + `https://hooks.stripe.com` for 3DS), and `https://api.stripe.com` in `connect-src`.
- Without these, the auto-top-up payment-method modal's card input never renders in the desktop app: `loadStripe` cannot inject the js.stripe.com loader, and the PaymentElement/AddressElement iframes are blocked by the `default-src 'self'` fallback.
- Extend `csp.test.ts` to pin the new `frame-src` directive and the Stripe hosts in each directive.

## Original prompt
The Stripe publishable key was recently added to the Electron app build, but the credit-card input in the billing payment-method modal still does not render. Investigation showed the Stripe packages and key are fine (the Electron app bundles the built web SPA, and the release workflows inject `VITE_STRIPE_PUBLISHABLE_KEY`); the actual blocker is the static CSP injected on `app://` responses in `clients/macos/src/main/csp.ts`, which never allowlisted Stripe's hosts. The user asked to fix that.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->