### PR TITLE
feat(web): translate the channels domain

### DIFF
--- a/clients/web/eslint.config.mjs
+++ b/clients/web/eslint.config.mjs
@@ -195,6 +195,7 @@ const i18nEnforcedPaths = [
   "src/domains/chat/components/pinned-app-color-swatches.tsx",
   "src/domains/schedules/**/*.{ts,tsx}",
   "src/domains/account/**/*.{ts,tsx}",
+  "src/domains/channels/**/*.{ts,tsx}",
 ];
 
 const eslintConfig = defineConfig([

--- a/clients/web/src/domains/channels/components/assistant-channels-list.tsx
+++ b/clients/web/src/domains/channels/components/assistant-channels-list.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 
 import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 
+import { useTranslation } from "@/i18n";
 import { DetailCard } from "@/components/detail-card";
 import {
   MobileSidebarDrawer,
@@ -146,6 +147,7 @@ export function AssistantChannelsList({
   onSaveTwilioCredentials,
   initialChannel = null,
 }: AssistantChannelsListProps) {
+  const { t } = useTranslation("channels");
   const { selected: selectedAdapter, select: selectAdapter } =
     useChannelRouteSelection();
 
@@ -274,7 +276,7 @@ export function AssistantChannelsList({
         <MobileSidebarDrawer
           open={drawerOpen}
           onClose={() => setDrawerOpen(false)}
-          title="Channels"
+          title={t("assistantChannelsList.drawerTitle")}
         >
           <ChannelAdapterList
             channels={channels}
@@ -304,9 +306,11 @@ export function AssistantChannelsList({
 
       <ConfirmDialog
         open={pendingDisconnect !== null}
-        title={`Disconnect ${disconnectMeta?.label ?? ""}?`}
+        title={t("assistantChannelsList.disconnectTitle", {
+          channel: disconnectMeta?.label ?? "",
+        })}
         message={disconnectMeta?.disconnectMessage ?? ""}
-        confirmLabel="Disconnect"
+        confirmLabel={t("assistantChannelsList.disconnectConfirm")}
         destructive
         onConfirm={() => {
           if (pendingDisconnect && onDisconnect) {

--- a/clients/web/src/domains/channels/components/channel-adapter-list.tsx
+++ b/clients/web/src/domains/channels/components/channel-adapter-list.tsx
@@ -1,5 +1,7 @@
 import { Plug } from "lucide-react";
 
+import { useTranslation } from "@/i18n";
+
 import { Card } from "@vellumai/design-library/components/card";
 import { PanelItem } from "@vellumai/design-library/components/panel-item";
 import { Tag } from "@vellumai/design-library/components/tag";
@@ -129,6 +131,7 @@ interface PluginRowProps {
  * the one thing this client does know, which is where the channel came from.
  */
 function PluginRow({ channel, selected, onClick }: PluginRowProps) {
+  const { t } = useTranslation("channels");
   return (
     // The plug is decorative, so the aria-label carries the same fact in
     // words. Without it a screen reader announces a plugin channel and a
@@ -136,7 +139,9 @@ function PluginRow({ channel, selected, onClick }: PluginRowProps) {
     <PanelItem
       asChild
       active={selected}
-      label={`${channel.label}, from a plugin`}
+      label={t("channelAdapterList.pluginChannelAria", {
+        channel: channel.label,
+      })}
     >
       <button
         type="button"

--- a/clients/web/src/domains/channels/components/channel-panel.tsx
+++ b/clients/web/src/domains/channels/components/channel-panel.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 
 import { Button } from "@vellumai/design-library/components/button";
 
+import { useTranslation } from "@/i18n";
 import type { MutationStatus } from "@/components/channel-setup-wizard";
 import { EmptyState } from "@/components/empty-state";
 import { SlackSetupWizard } from "@/components/slack-setup-wizard";
@@ -89,6 +90,7 @@ export function ChannelPanel({
   policyError = false,
   onPolicyChange,
 }: ChannelPanelProps) {
+  const { t } = useTranslation("channels");
   const connected = channel.status === "ready";
   // Manual credential entry is a connect-time affordance, so it only applies
   // while disconnected — seeded from a `?setup=<channel>` deep link. Declared
@@ -185,13 +187,19 @@ export function ChannelPanel({
           icon={<ChannelIcon channelId={channel.key} className="h-6 w-6" />}
           title={
             incomplete
-              ? `${getChannelLabel(channel.key)} isn't working yet`
-              : `${getChannelLabel(channel.key)} isn't connected`
+              ? t("channelPanel.incompleteTitle", {
+                  channel: getChannelLabel(channel.key),
+                })
+              : t("channelPanel.disconnectedTitle", {
+                  channel: getChannelLabel(channel.key),
+                })
           }
           description={
             incomplete
               ? (channel.warning ??
-                `${getChannelLabel(channel.key)} is set up but not delivering messages yet. Your assistant can pick up where setup left off and tell you what is wrong.`)
+                t("channelPanel.incompleteDescription", {
+                  channel: getChannelLabel(channel.key),
+                }))
               : meta.disconnectedPitch?.(assistantDisplayName)
           }
           action={
@@ -203,17 +211,17 @@ export function ChannelPanel({
                 disabled={!onSetup || pending}
               >
                 {pending
-                  ? "Opening…"
+                  ? t("channelPanel.opening")
                   : incomplete
-                    ? "Finish setup with your assistant"
-                    : "Set up"}
+                    ? t("channelPanel.finishSetup")
+                    : t("channelPanel.setUp")}
               </Button>
               <Button
                 type="button"
                 variant="link"
                 onClick={() => setManualEntry(true)}
               >
-                or connect manually
+                {t("channelPanel.connectManually")}
               </Button>
             </div>
           }

--- a/clients/web/src/domains/channels/components/channel-trust-floor-section.tsx
+++ b/clients/web/src/domains/channels/components/channel-trust-floor-section.tsx
@@ -1,4 +1,6 @@
 import { Select } from "@vellumai/design-library/components/select";
+
+import { useTranslation } from "@/i18n";
 import { Notice } from "@vellumai/design-library/components/notice";
 import { Typography } from "@vellumai/design-library/components/typography";
 
@@ -34,6 +36,7 @@ export function ChannelTrustFloorSection({
   error = false,
   onChange,
 }: ChannelTrustFloorSectionProps) {
+  const { t } = useTranslation("channels");
   const value = policy ?? ADMISSION_POLICY_DEFAULT;
   const descriptions = getPolicyDescriptions(assistantDisplayName);
   const options = ADMISSION_POLICY_VALUES.map((floor) => ({
@@ -49,7 +52,7 @@ export function ChannelTrustFloorSection({
         variant="body-small-emphasised"
         className="text-[color:var(--content-secondary)]"
       >
-        Who can message {assistantDisplayName}
+        {t("channelTrustFloor.heading", { assistant: assistantDisplayName })}
       </Typography>
       {loading ? (
         // Hold off on rendering a concrete floor until the GET succeeds — the
@@ -60,7 +63,7 @@ export function ChannelTrustFloorSection({
           variant="body-small-lighter"
           className="text-[color:var(--content-tertiary)]"
         >
-          Loading…
+          {t("channelTrustFloor.loading")}
         </Typography>
       ) : error ? (
         <Typography
@@ -68,7 +71,7 @@ export function ChannelTrustFloorSection({
           variant="body-small-lighter"
           className="text-[color:var(--content-negative)]"
         >
-          Couldn’t load this setting. Try reopening this page.
+          {t("channelTrustFloor.loadFailed")}
         </Typography>
       ) : (
         <>
@@ -78,7 +81,9 @@ export function ChannelTrustFloorSection({
               onChange={onChange}
               options={options}
               disabled={saving}
-              aria-label={`Who can message ${assistantDisplayName}`}
+              aria-label={t("channelTrustFloor.selectAria", {
+                assistant: assistantDisplayName,
+              })}
             />
           </div>
           <Typography
@@ -90,10 +95,9 @@ export function ChannelTrustFloorSection({
           </Typography>
           {value === "trusted_contacts" ? (
             <Notice tone="info" className="max-w-lg">
-              People you haven’t verified yet (even teammates in the same
-              channel) can’t get through: {assistantDisplayName} lets them know
-              they need to be verified and notifies you. You can verify people
-              ahead of time in Contacts.
+              {t("channelTrustFloor.trustedContactsNotice", {
+                assistant: assistantDisplayName,
+              })}
             </Notice>
           ) : null}
         </>

--- a/clients/web/src/domains/channels/components/connected-channel-header.tsx
+++ b/clients/web/src/domains/channels/components/connected-channel-header.tsx
@@ -1,5 +1,7 @@
 import { CheckCircle } from "lucide-react";
 
+import { useTranslation } from "@/i18n";
+
 import { Button } from "@vellumai/design-library/components/button";
 import { Tag } from "@vellumai/design-library/components/tag";
 
@@ -22,10 +24,11 @@ export function ConnectedChannelHeader({
   pending,
   onDisconnect,
 }: ConnectedChannelHeaderProps) {
+  const { t } = useTranslation("channels");
   return (
     <div className="flex items-center gap-3">
       <Tag tone="positive" leftIcon={<CheckCircle />}>
-        Connected
+        {t("connectionCard.connected")}
       </Tag>
       {address ? (
         <span
@@ -42,7 +45,9 @@ export function ConnectedChannelHeader({
           onClick={onDisconnect}
           disabled={!onDisconnect || pending}
         >
-          {pending ? "Disconnecting…" : "Disconnect"}
+          {pending
+            ? t("connectionCard.disconnecting")
+            : t("connectionCard.disconnect")}
         </Button>
       </div>
     </div>

--- a/clients/web/src/domains/channels/components/plugin-channel-panel.tsx
+++ b/clients/web/src/domains/channels/components/plugin-channel-panel.tsx
@@ -8,6 +8,7 @@ import {
   type ChannelIngress,
   type IngressPath,
 } from "@/domains/channels/hooks/use-channel-ingress";
+import { useTranslation } from "@/i18n";
 import { PluginChannelIcon } from "@/utils/channel-presentation";
 import type { PluginChannelSummary } from "@/types/channel-types";
 
@@ -36,6 +37,7 @@ export function PluginChannelPanel({
   channel,
   assistantId,
 }: PluginChannelPanelProps) {
+  const { t } = useTranslation("channels");
   const navigate = useNavigate();
   const ingress = useChannelIngress(assistantId, channel.plugin);
 
@@ -68,7 +70,7 @@ export function PluginChannelPanel({
         onClick={() => navigate(`/assistant/plugins/${channel.plugin}`)}
         variant="outlined"
       >
-        Open plugin page
+        {t("pluginChannelPanel.openPluginPage")}
       </Button>
     </div>
   );
@@ -92,34 +94,31 @@ interface IngressSectionProps {
  * that reads like one.
  */
 function IngressSection({ channel, ingress }: IngressSectionProps) {
+  const { t } = useTranslation("channels");
   switch (ingress.status) {
     case "loading":
-      return <Note>Checking who can reach {channel.label}…</Note>;
+      return (
+        <Note>
+          {t("pluginChannelPanel.ingressLoading", { channel: channel.label })}
+        </Note>
+      );
 
     case "unsupported":
       // Says nothing about who is viewing: this gateway has no such endpoint,
       // which is equally true for the guardian.
-      return (
-        <Note>
-          This assistant&apos;s gateway does not report ingress approvals, so
-          there is nothing to decide here.
-        </Note>
-      );
+      return <Note>{t("pluginChannelPanel.ingressUnsupported")}</Note>;
 
     case "forbidden":
-      return (
-        <Note>
-          Only this assistant&apos;s guardian can see or change ingress
-          approvals.
-        </Note>
-      );
+      return <Note>{t("pluginChannelPanel.ingressForbidden")}</Note>;
 
     case "unreadable":
       // Transient, and the query is retrying. Reporting it beats presenting a
       // failed read as a settled answer about what the gateway declares.
       return (
         <Note>
-          Could not read the ingress approval for {channel.label}.
+          {t("pluginChannelPanel.ingressUnreadable", {
+            channel: channel.label,
+          })}
           {ingress.error ? ` ${ingress.error}` : ""}
         </Note>
       );
@@ -130,8 +129,7 @@ function IngressSection({ channel, ingress }: IngressSectionProps) {
       // scanned, or a manifest it rejected.
       return (
         <Note>
-          The gateway sees no ingress declaration for {channel.label}, so there
-          is nothing to approve yet.
+          {t("pluginChannelPanel.ingressNone", { channel: channel.label })}
         </Note>
       );
 
@@ -155,6 +153,7 @@ function IngressSection({ channel, ingress }: IngressSectionProps) {
  * close them either.
  */
 function IngressDecision({ channel, ingress }: IngressSectionProps) {
+  const { t } = useTranslation("channels");
   const approved = ingress.status === "approved";
   const governed = ingress.paths.filter((entry) => entry.approvalGoverned);
   const ungoverned = ingress.paths.filter((entry) => !entry.approvalGoverned);
@@ -162,15 +161,21 @@ function IngressDecision({ channel, ingress }: IngressSectionProps) {
   return (
     <div className="flex flex-col items-center gap-3">
       <Tag tone={approved ? "positive" : "neutral"}>
-        {approved ? "Ingress approved" : "Ingress awaiting approval"}
+        {approved
+          ? t("pluginChannelPanel.ingressApprovedTag")
+          : t("pluginChannelPanel.ingressPendingTag")}
       </Tag>
 
       {governed.length > 0 ? (
         <>
           <Note>
             {approved
-              ? `${channel.label} receives messages at these addresses:`
-              : `${channel.label} asks to receive messages at these addresses. Until you approve, deliveries to them are refused:`}
+              ? t("pluginChannelPanel.approvedAddresses", {
+                  channel: channel.label,
+                })
+              : t("pluginChannelPanel.pendingAddresses", {
+                  channel: channel.label,
+                })}
           </Note>
           <PathList paths={governed} />
         </>
@@ -178,10 +183,7 @@ function IngressDecision({ channel, ingress }: IngressSectionProps) {
 
       {ungoverned.length > 0 ? (
         <>
-          <Note>
-            These addresses are open whatever you decide, because only Vellum
-            can reach them:
-          </Note>
+          <Note>{t("pluginChannelPanel.ungovernedAddresses")}</Note>
           <PathList paths={ungoverned} />
         </>
       ) : null}
@@ -191,7 +193,9 @@ function IngressDecision({ channel, ingress }: IngressSectionProps) {
         disabled={ingress.deciding}
         variant={approved ? "outlined" : "primary"}
       >
-        {approved ? "Revoke ingress" : "Approve ingress"}
+        {approved
+          ? t("pluginChannelPanel.revokeIngress")
+          : t("pluginChannelPanel.approveIngress")}
       </Button>
 
       {ingress.error ? (

--- a/clients/web/src/domains/channels/components/slack-channel-card.tsx
+++ b/clients/web/src/domains/channels/components/slack-channel-card.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { Card } from "@vellumai/design-library/components/card";
 import { Typography } from "@vellumai/design-library/components/typography";
 
+import { useTranslation } from "@/i18n";
 import { publicAsset } from "@/utils/public-asset";
 
 interface SlackChannelCardProps {
@@ -10,10 +11,11 @@ interface SlackChannelCardProps {
 }
 
 /**
- * The "Slack setup" card wrapping the setup wizard for a disconnected
+ * The "{t("slackChannelCard.setupHeading")}" card wrapping the setup wizard for a disconnected
  * Slack. A connected Slack renders `SlackConnectionCard` instead.
  */
 export function SlackChannelCard({ children }: SlackChannelCardProps) {
+  const { t } = useTranslation("channels");
   return (
     <Card.Root>
       <Card.Header>
@@ -24,7 +26,7 @@ export function SlackChannelCard({ children }: SlackChannelCardProps) {
             className="size-8 rounded-lg bg-[var(--surface-sunken)] p-1"
           />
           <Typography as="span" variant="body-medium-default">
-            Slack setup
+            {t("slackChannelCard.setupHeading")}
           </Typography>
         </div>
       </Card.Header>

--- a/clients/web/src/domains/channels/components/slack-channel-list.tsx
+++ b/clients/web/src/domains/channels/components/slack-channel-list.tsx
@@ -7,6 +7,7 @@ import { ListRow } from "@vellumai/design-library/components/list-row";
 import { Typography } from "@vellumai/design-library/components/typography";
 import { VirtualList } from "@vellumai/design-library/components/virtual-list";
 
+import { Trans, useTranslation } from "@/i18n";
 import { EmptyState } from "@/components/empty-state";
 import { TierPicker } from "@/domains/channels/components/tier-picker";
 import type { RiskThreshold } from "@/utils/threshold-presets";
@@ -90,11 +91,14 @@ export function slackChannelMetaLabel(channel: SlackChannel): string | null {
 
 const CHANNEL_KIND_FILTERS: {
   value: SlackRoomKind | null;
-  label: string;
+  labelKey:
+    | "slackChannelList.filterAll"
+    | "slackChannelList.filterPublic"
+    | "slackChannelList.filterPrivate";
 }[] = [
-  { value: null, label: "All" },
-  { value: "public", label: "Public" },
-  { value: "private", label: "Private" },
+  { value: null, labelKey: "slackChannelList.filterAll" },
+  { value: "public", labelKey: "slackChannelList.filterPublic" },
+  { value: "private", labelKey: "slackChannelList.filterPrivate" },
 ];
 
 const CHANNEL_KIND_ICONS: Record<SlackRoomKind, typeof Hash> = {
@@ -185,6 +189,7 @@ export function SlackChannelList({
   onTierChange,
   onTierReset,
 }: SlackChannelListProps) {
+  const { t } = useTranslation("channels");
   const [search, setSearch] = useState("");
   const [kindFilter, setKindFilter] = useState<SlackRoomKind | null>(null);
 
@@ -200,18 +205,15 @@ export function SlackChannelList({
 
   const handle = slackHandle ?? `@${assistantDisplayName}`;
   const presenceHint = (
-    <>
-      Add with{" "}
-      <code className="text-[color:var(--content-secondary)]">
-        /invite {handle}
-      </code>{" "}
-      or remove with{" "}
-      <code className="text-[color:var(--content-secondary)]">
-        /remove {handle}
-      </code>{" "}
-      in that Slack channel. Only channels {assistantDisplayName} is in appear
-      here.
-    </>
+    <Trans
+      i18nKey="slackChannelList.presenceHint"
+      ns="channels"
+      values={{ handle, assistant: assistantDisplayName }}
+      components={{
+        invite: <code className="text-[color:var(--content-secondary)]" />,
+        remove: <code className="text-[color:var(--content-secondary)]" />,
+      }}
+    />
   );
 
   return (
@@ -229,7 +231,7 @@ export function SlackChannelList({
           variant="body-small-lighter"
           className="text-[color:var(--content-tertiary)]"
         >
-          Loading…
+          {t("slackChannelList.loading")}
         </Typography>
       ) : error ? (
         <Typography
@@ -237,12 +239,12 @@ export function SlackChannelList({
           variant="body-small-lighter"
           className="text-[color:var(--content-negative)]"
         >
-          Couldn’t load channels. Try reopening this page.
+          {t("slackChannelList.loadFailed")}
         </Typography>
       ) : allChannels.length === 0 ? (
         <EmptyState
           icon={<Hash className="h-6 w-6" />}
-          title="No channels yet"
+          title={t("slackChannelList.emptyTitle")}
         />
       ) : (
         <>
@@ -252,8 +254,8 @@ export function SlackChannelList({
                 type="search"
                 value={search}
                 onChange={(event) => setSearch(event.target.value)}
-                placeholder="Search channels"
-                aria-label="Search channels"
+                placeholder={t("slackChannelList.searchPlaceholder")}
+                aria-label={t("slackChannelList.searchAria")}
                 leftIcon={<Search className="h-4 w-4" />}
                 fullWidth
               />
@@ -261,9 +263,9 @@ export function SlackChannelList({
             <div
               className="flex items-center gap-2"
               role="group"
-              aria-label="Filter channels by type"
+              aria-label={t("slackChannelList.filterGroupAria")}
             >
-              {CHANNEL_KIND_FILTERS.map(({ value, label }) => {
+              {CHANNEL_KIND_FILTERS.map(({ value, labelKey }) => {
                 const active = kindFilter === value;
                 const count =
                   value === null ? allChannels.length : kindCounts[value];
@@ -280,7 +282,7 @@ export function SlackChannelList({
                         : "bg-[var(--tag-bg-neutral)] text-[color:var(--content-secondary)] hover:text-[color:var(--content-default)]",
                     )}
                   >
-                    {label} {count}
+                    {t(labelKey)} {count}
                   </button>
                 );
               })}
@@ -292,7 +294,7 @@ export function SlackChannelList({
               variant="body-small-lighter"
               className="py-4 text-center text-[color:var(--content-tertiary)]"
             >
-              No channels match.
+              {t("slackChannelList.noMatches")}
             </Typography>
           ) : visibleChannels.length > VIRTUALIZE_THRESHOLD ? (
             // Virtuoso sizes its scroller to 100% of the wrapper, so the wrapper
@@ -365,6 +367,7 @@ function SlackChannelRow({
   onTierChange: (tier: RiskThreshold) => void;
   onReset: () => void;
 }) {
+  const { t } = useTranslation("channels");
   const kind = classifySlackChannelKind(channel);
   // Rows are rooms only ({@link roomsOnly}); a 1:1 DM row is unreachable.
   if (kind === "dm") {
@@ -411,7 +414,9 @@ function SlackChannelRow({
             disabled={pending || overridesLoading || overridesError}
             onTierChange={onTierChange}
             onReset={onReset}
-            aria-label={`Assistant Access in ${channel.name}`}
+            aria-label={t("slackChannelList.accessAria", {
+              channel: channel.name,
+            })}
           />
         </div>
       }

--- a/clients/web/src/domains/channels/components/slack-channel-section.test.tsx
+++ b/clients/web/src/domains/channels/components/slack-channel-section.test.tsx
@@ -35,9 +35,12 @@ const CHANNELS: SlackChannel[] = [
 /** The controller the mocked hook returns; each test seeds it. */
 let controller: ChannelPermissionOverridesController;
 
-mock.module("@/domains/channels/hooks/use-channel-permission-overrides", () => ({
-  useChannelPermissionOverrides: () => controller,
-}));
+mock.module(
+  "@/domains/channels/hooks/use-channel-permission-overrides",
+  () => ({
+    useChannelPermissionOverrides: () => controller,
+  }),
+);
 
 mock.module("@/domains/channels/slack-channels-query", () => ({
   memberSlackChannelsOptions: () => ({
@@ -50,9 +53,8 @@ mock.module("@/lib/threshold-api", () => ({
   getGlobalThresholds: async () => ({ interactive: "low" }),
 }));
 
-const { SlackChannelSection } = await import(
-  "@/domains/channels/components/slack-channel-section"
-);
+const { SlackChannelSection } =
+  await import("@/domains/channels/components/slack-channel-section");
 
 /** A healthy controller: cells loaded, every handler wired. */
 function healthyController(

--- a/clients/web/src/domains/channels/components/slack-channel-section.tsx
+++ b/clients/web/src/domains/channels/components/slack-channel-section.tsx
@@ -6,6 +6,7 @@ import { Collapsible } from "@vellumai/design-library/components/collapsible";
 import { Notice } from "@vellumai/design-library/components/notice";
 import { Typography } from "@vellumai/design-library/components/typography";
 
+import { useTranslation } from "@/i18n";
 import { SlackChannelList } from "@/domains/channels/components/slack-channel-list";
 import { SlackChannelTypeDefaults } from "@/domains/channels/components/slack-channel-type-defaults";
 import { useChannelPermissionOverrides } from "@/domains/channels/hooks/use-channel-permission-overrides";
@@ -38,6 +39,7 @@ export function SlackChannelSection({
   assistantDisplayName,
   slackHandle,
 }: SlackChannelSectionProps) {
+  const { t } = useTranslation("channels");
   const channelsQuery = useQuery({
     ...memberSlackChannelsOptions(assistantId),
     enabled: Boolean(assistantId),
@@ -108,8 +110,7 @@ export function SlackChannelSection({
           clobber them, so there's nothing to offer here but a reload. */}
       {overrides.isError ? (
         <Notice tone="error">
-          Couldn’t load access settings. These controls stay disabled until they
-          load. Try reopening this page.
+          {t("slackChannelSection.overridesLoadFailed")}
         </Notice>
       ) : null}
       <SlackChannelTypeDefaults
@@ -129,7 +130,7 @@ export function SlackChannelSection({
           <Collapsible.Item value="per-channel-overrides">
             <Collapsible.Trigger className="group justify-between gap-2 px-4 py-3">
               <Typography as="span" variant="body-small-emphasised">
-                Per-channel overrides
+                {t("slackChannelSection.perChannelOverrides")}
               </Typography>
               <ChevronDown
                 aria-hidden="true"

--- a/clients/web/src/domains/channels/components/slack-channel-tier-legend.tsx
+++ b/clients/web/src/domains/channels/components/slack-channel-tier-legend.tsx
@@ -5,6 +5,7 @@ import {
   CHANNEL_TIER_VALUES,
   channelTierBehavesAs,
 } from "@/domains/channels/slack-channel-overrides";
+import { useTranslation } from "@/i18n";
 import { TierDot } from "@/domains/channels/components/tier-picker";
 import type { RiskThreshold } from "@/utils/threshold-presets";
 
@@ -62,7 +63,10 @@ export interface SlackChannelTierLegendProps {
  * the usual default reads first; the picker menu keeps preset order, which is
  * fine because each key entry names its level.
  */
-export function SlackChannelTierLegend({ defaultTier }: SlackChannelTierLegendProps) {
+export function SlackChannelTierLegend({
+  defaultTier,
+}: SlackChannelTierLegendProps) {
+  const { t } = useTranslation("channels");
   const shownDefault = channelTierBehavesAs(defaultTier ?? undefined) ?? null;
   const legendTiers = [...CHANNEL_TIER_VALUES].reverse();
   return (
@@ -83,7 +87,7 @@ export function SlackChannelTierLegend({ defaultTier }: SlackChannelTierLegendPr
                     variant="body-small-default"
                     className="text-[color:var(--content-tertiary)]"
                   >
-                    · default
+                    {t("slackChannelTierLegend.defaultMarker")}
                   </Typography>
                 ) : null}
               </span>

--- a/clients/web/src/domains/channels/components/slack-channel-type-defaults.tsx
+++ b/clients/web/src/domains/channels/components/slack-channel-type-defaults.tsx
@@ -5,6 +5,7 @@ import { Card } from "@vellumai/design-library/components/card";
 import { ListRow } from "@vellumai/design-library/components/list-row";
 import { Typography } from "@vellumai/design-library/components/typography";
 
+import { Trans, useTranslation } from "@/i18n";
 import { SlackChannelTierLegend } from "@/domains/channels/components/slack-channel-tier-legend";
 import { TierPicker } from "@/domains/channels/components/tier-picker";
 import type { ChannelDefaultBucket } from "@/domains/channels/slack-channel-overrides";
@@ -75,11 +76,12 @@ export function SlackChannelTypeDefaults({
   onBucketChange,
   onBucketReset,
 }: SlackChannelTypeDefaultsProps) {
+  const { t } = useTranslation("channels");
   return (
     <Card.Root>
       <Card.Header>
         <div className="flex flex-col gap-1">
-          Default access
+          {t("slackChannelTypeDefaults.heading")}
           {/* body-small-lighter: this subtitle wraps to two lines, and
               body-small-default is a line-height-1 single-line label style. */}
           <Typography
@@ -87,15 +89,19 @@ export function SlackChannelTypeDefaults({
             variant="body-small-lighter"
             className="text-[color:var(--content-tertiary)]"
           >
-            How much {assistantName} does on its own, by conversation type.
-            Individual channels can override this below, and{" "}
-            <Link
-              to={routes.settings.privacy}
-              className="text-[var(--content-link)] underline hover:text-[var(--content-link-hover)]"
-            >
-              Trust Rules
-            </Link>{" "}
-            fine-tune when it asks.
+            <Trans
+              i18nKey="slackChannelTypeDefaults.subtitle"
+              ns="channels"
+              values={{ assistant: assistantName }}
+              components={{
+                trustRules: (
+                  <Link
+                    to={routes.settings.privacy}
+                    className="text-[var(--content-link)] underline hover:text-[var(--content-link-hover)]"
+                  />
+                ),
+              }}
+            />
           </Typography>
         </div>
       </Card.Header>
@@ -126,7 +132,9 @@ export function SlackChannelTypeDefaults({
                     disabled={loading || error || pendingBuckets.has(bucket)}
                     onTierChange={(tier) => onBucketChange(bucket, tier)}
                     onReset={() => onBucketReset(bucket)}
-                    aria-label={`Default Assistant Access for ${title}`}
+                    aria-label={t("slackChannelTypeDefaults.bucketAria", {
+                      bucket: title,
+                    })}
                   />
                 </div>
               }

--- a/clients/web/src/domains/channels/components/slack-connection-card.tsx
+++ b/clients/web/src/domains/channels/components/slack-connection-card.tsx
@@ -6,6 +6,7 @@ import { Card } from "@vellumai/design-library/components/card";
 import { Tag } from "@vellumai/design-library/components/tag";
 import { Typography } from "@vellumai/design-library/components/typography";
 
+import { useTranslation } from "@/i18n";
 import { publicAsset } from "@/utils/public-asset";
 
 interface SlackConnectionCardProps {
@@ -31,6 +32,7 @@ export function SlackConnectionCard({
   onDisconnect,
   children,
 }: SlackConnectionCardProps) {
+  const { t } = useTranslation("channels");
   return (
     <Card.Root>
       <Card.Header>
@@ -46,7 +48,7 @@ export function SlackConnectionCard({
             </Typography>
           ) : null}
           <Tag tone="positive" leftIcon={<CheckCircle />}>
-            Connected
+            {t("connectionCard.connected")}
           </Tag>
           <div className="ml-auto">
             <Button
@@ -55,7 +57,9 @@ export function SlackConnectionCard({
               onClick={onDisconnect}
               disabled={!onDisconnect || disconnectPending}
             >
-              {disconnectPending ? "Disconnecting…" : "Disconnect"}
+              {disconnectPending
+                ? t("connectionCard.disconnecting")
+                : t("connectionCard.disconnect")}
             </Button>
           </div>
         </div>

--- a/clients/web/src/domains/channels/components/slack-thread-behavior.tsx
+++ b/clients/web/src/domains/channels/components/slack-thread-behavior.tsx
@@ -1,6 +1,7 @@
 import { Radio, RadioGroup } from "@vellumai/design-library/components/radio";
 import { Typography } from "@vellumai/design-library/components/typography";
 
+import { useTranslation } from "@/i18n";
 import type { IntegrationsSlackChannelConfigGetResponse } from "@/generated/daemon/types.gen";
 
 export type SlackThreadMode =
@@ -13,7 +14,7 @@ interface SlackThreadBehaviorProps {
 }
 
 /**
- * Thread Behavior setting for a connected Slack channel: whether the
+ * {t("slackThreadBehavior.heading")} setting for a connected Slack channel: whether the
  * assistant only answers @mentions or follows a thread after its first
  * mention. Rendered inside the connected Slack card on the Channels tab;
  * setup for a disconnected Slack lives in `SlackSetupWizard`.
@@ -23,6 +24,7 @@ export function SlackThreadBehavior({
   threadModePending = false,
   onThreadModeChange,
 }: SlackThreadBehaviorProps) {
+  const { t } = useTranslation("channels");
   return (
     <div className="flex flex-col gap-3">
       <Typography
@@ -30,23 +32,23 @@ export function SlackThreadBehavior({
         variant="body-small-emphasised"
         className="text-[color:var(--content-secondary)]"
       >
-        Thread Behavior
+        {t("slackThreadBehavior.heading")}
       </Typography>
       <RadioGroup<SlackThreadMode>
         value={threadMode ?? "mention_then_thread"}
         onValueChange={(next) => onThreadModeChange?.(next)}
         disabled={threadModePending || !onThreadModeChange}
-        aria-label="Slack thread behavior"
+        aria-label={t("slackThreadBehavior.selectAria")}
       >
         <Radio<SlackThreadMode>
           value="mention_only"
-          label="Mentions only"
-          helperText="Bot only responds when @mentioned."
+          label={t("slackThreadBehavior.mentionsOnly")}
+          helperText={t("slackThreadBehavior.mentionsOnlyHelp")}
         />
         <Radio<SlackThreadMode>
           value="mention_then_thread"
-          label="Follow threads after first mention"
-          helperText="After an @mention in a thread, bot listens to all subsequent replies."
+          label={t("slackThreadBehavior.followThreads")}
+          helperText={t("slackThreadBehavior.followThreadsHelp")}
         />
       </RadioGroup>
     </div>

--- a/clients/web/src/domains/channels/components/tier-picker.tsx
+++ b/clients/web/src/domains/channels/components/tier-picker.tsx
@@ -8,6 +8,7 @@ import {
   CHANNEL_TIER_VALUES,
   channelTierBehavesAs,
 } from "@/domains/channels/slack-channel-overrides";
+import { useTranslation } from "@/i18n";
 import type { RiskThreshold } from "@/utils/threshold-presets";
 
 /**
@@ -78,6 +79,7 @@ export function TierPicker({
   onReset,
   "aria-label": ariaLabel,
 }: TierPickerProps) {
+  const { t } = useTranslation("channels");
   const effectiveTier = channelTierBehavesAs(tier ?? defaultTier ?? undefined);
   const shownDefault = channelTierBehavesAs(defaultTier ?? undefined) ?? null;
   const options: SelectOption<TierOptionValue>[] = CHANNEL_TIER_VALUES.map(
@@ -87,7 +89,9 @@ export function TierPicker({
       icon: <TierDot color={CAPABILITY_TIER_META[value].dotColor} />,
       suffix:
         value === shownDefault ? (
-          <span className="text-[color:var(--content-tertiary)]">default</span>
+          <span className="text-[color:var(--content-tertiary)]">
+            {t("tierPicker.defaultSuffix")}
+          </span>
         ) : undefined,
       tooltip: CAPABILITY_TIER_META[value].sublabel,
     }),
@@ -123,7 +127,7 @@ export function TierPicker({
       value={effectiveTier ?? ""}
       onChange={handleChange}
       options={options}
-      placeholder="Default"
+      placeholder={t("tierPicker.defaultPlaceholder")}
       disabled={disabled}
       size="compact"
       menuAlign="end"

--- a/clients/web/src/domains/channels/components/twilio-credential-entry.tsx
+++ b/clients/web/src/domains/channels/components/twilio-credential-entry.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
 
+import { useTranslation } from "@/i18n";
+
 import { Button } from "@vellumai/design-library/components/button";
 import { Input } from "@vellumai/design-library/components/input";
 
@@ -13,6 +15,7 @@ interface TwilioCredentialEntryProps {
  * and surfaces a save error. Rendered only while disconnected.
  */
 export function TwilioCredentialEntry({ onSave }: TwilioCredentialEntryProps) {
+  const { t } = useTranslation("channels");
   const [accountSid, setAccountSid] = useState("");
   const [authToken, setAuthToken] = useState("");
   const [saving, setSaving] = useState(false);
@@ -41,20 +44,21 @@ export function TwilioCredentialEntry({ onSave }: TwilioCredentialEntryProps) {
   return (
     <div className="flex flex-col gap-3">
       <Input
-        label="Account SID"
+        label={t("twilioCredentialEntry.accountSid")}
         type="text"
         value={accountSid}
         onChange={(e) => setAccountSid(e.target.value)}
+        // eslint-disable-next-line local/no-untranslated-strings -- Twilio SID format, identical in every language
         placeholder="ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
         disabled={saving}
         fullWidth
       />
       <Input
-        label="Auth Token"
+        label={t("twilioCredentialEntry.authToken")}
         type="password"
         value={authToken}
         onChange={(e) => setAuthToken(e.target.value)}
-        placeholder="Twilio auth token"
+        placeholder={t("twilioCredentialEntry.authTokenPlaceholder")}
         disabled={saving}
         fullWidth
       />
@@ -68,7 +72,9 @@ export function TwilioCredentialEntry({ onSave }: TwilioCredentialEntryProps) {
       ) : null}
       <div>
         <Button type="button" onClick={handleSave} disabled={!canSave}>
-          {saving ? "Saving…" : "Save"}
+          {saving
+            ? t("twilioCredentialEntry.saving")
+            : t("twilioCredentialEntry.save")}
         </Button>
       </div>
     </div>

--- a/clients/web/src/domains/channels/hooks/use-channel-permission-overrides.test.tsx
+++ b/clients/web/src/domains/channels/hooks/use-channel-permission-overrides.test.tsx
@@ -44,9 +44,8 @@ mock.module("@/lib/backwards-compat/channel-access-controls", () => ({
   useSupportsChannelAccessControls: () => supportsAccessControls,
 }));
 
-const { useChannelPermissionOverrides } = await import(
-  "./use-channel-permission-overrides"
-);
+const { useChannelPermissionOverrides } =
+  await import("./use-channel-permission-overrides");
 
 /**
  * An HTTP failure carrying `status` directly, the shape `ApiError` and the

--- a/clients/web/src/i18n/catalogs.ts
+++ b/clients/web/src/i18n/catalogs.ts
@@ -34,6 +34,7 @@
  * Reference: https://vite.dev/guide/features#dynamic-import
  */
 import enAccount from "@/i18n/locales/en/account.json";
+import enChannels from "@/i18n/locales/en/channels.json";
 import enChat from "@/i18n/locales/en/chat.json";
 import enCommon from "@/i18n/locales/en/common.json";
 import enSchedules from "@/i18n/locales/en/schedules.json";
@@ -61,6 +62,7 @@ export const FALLBACK_CATALOGS: LocaleCatalogs = {
   chat: enChat,
   schedules: enSchedules,
   account: enAccount,
+  channels: enChannels,
 };
 
 /** Loaders for the locales that are not bundled into the entry chunk. */
@@ -73,6 +75,7 @@ const CATALOG_LOADERS: Record<
     chat: () => import("@/i18n/locales/es/chat.json"),
     schedules: () => import("@/i18n/locales/es/schedules.json"),
     account: () => import("@/i18n/locales/es/account.json"),
+    channels: () => import("@/i18n/locales/es/channels.json"),
   },
 };
 

--- a/clients/web/src/i18n/i18next.d.ts
+++ b/clients/web/src/i18n/i18next.d.ts
@@ -13,6 +13,7 @@
  * Reference: https://www.i18next.com/overview/typescript
  */
 import type account from "@/i18n/locales/en/account.json";
+import type channels from "@/i18n/locales/en/channels.json";
 import type chat from "@/i18n/locales/en/chat.json";
 import type common from "@/i18n/locales/en/common.json";
 import type schedules from "@/i18n/locales/en/schedules.json";
@@ -25,6 +26,7 @@ declare module "i18next" {
       chat: typeof chat;
       schedules: typeof schedules;
       account: typeof account;
+      channels: typeof channels;
     };
     returnNull: false;
   }

--- a/clients/web/src/i18n/locales/en/channels.json
+++ b/clients/web/src/i18n/locales/en/channels.json
@@ -1,0 +1,94 @@
+{
+  "assistantChannelsList": {
+    "drawerTitle": "Channels",
+    "disconnectTitle": "Disconnect {channel}?",
+    "disconnectConfirm": "Disconnect"
+  },
+  "channelAdapterList": {
+    "pluginChannelAria": "{channel}, from a plugin"
+  },
+  "connectionCard": {
+    "connected": "Connected",
+    "disconnecting": "Disconnecting…",
+    "disconnect": "Disconnect"
+  },
+  "slackChannelCard": {
+    "setupHeading": "Slack setup"
+  },
+  "channelPanel": {
+    "incompleteTitle": "{channel} isn't working yet",
+    "disconnectedTitle": "{channel} isn't connected",
+    "incompleteDescription": "{channel} is set up but not delivering messages yet. Your assistant can pick up where setup left off and tell you what is wrong.",
+    "opening": "Opening…",
+    "finishSetup": "Finish setup with your assistant",
+    "setUp": "Set up",
+    "connectManually": "or connect manually"
+  },
+  "pluginChannelPanel": {
+    "openPluginPage": "Open plugin page",
+    "ingressLoading": "Checking who can reach {channel}…",
+    "ingressUnsupported": "This assistant's gateway does not report ingress approvals, so there is nothing to decide here.",
+    "ingressForbidden": "Only this assistant's guardian can see or change ingress approvals.",
+    "ingressUnreadable": "Could not read the ingress approval for {channel}.",
+    "ingressNone": "The gateway sees no ingress declaration for {channel}, so there is nothing to approve yet.",
+    "ingressApprovedTag": "Ingress approved",
+    "ingressPendingTag": "Ingress awaiting approval",
+    "approvedAddresses": "{channel} receives messages at these addresses:",
+    "pendingAddresses": "{channel} asks to receive messages at these addresses. Until you approve, deliveries to them are refused:",
+    "ungovernedAddresses": "These addresses are open whatever you decide, because only Vellum can reach them:",
+    "revokeIngress": "Revoke ingress",
+    "approveIngress": "Approve ingress"
+  },
+  "channelTrustFloor": {
+    "heading": "Who can message {assistant}",
+    "loading": "Loading…",
+    "loadFailed": "Couldn’t load this setting. Try reopening this page.",
+    "selectAria": "Who can message {assistant}",
+    "trustedContactsNotice": "People you haven’t verified yet (even teammates in the same channel) can’t get through: {assistant} lets them know they need to be verified and notifies you. You can verify people ahead of time in Contacts."
+  },
+  "slackChannelTypeDefaults": {
+    "heading": "Default access",
+    "subtitle": "How much {assistant} does on its own, by conversation type. Individual channels can override this below, and <trustRules>Trust Rules</trustRules> fine-tune when it asks.",
+    "bucketAria": "Default Assistant Access for {bucket}"
+  },
+  "tierPicker": {
+    "defaultSuffix": "default",
+    "defaultPlaceholder": "Default"
+  },
+  "slackChannelTierLegend": {
+    "defaultMarker": "· default"
+  },
+  "slackChannelSection": {
+    "overridesLoadFailed": "Couldn’t load access settings. These controls stay disabled until they load. Try reopening this page.",
+    "perChannelOverrides": "Per-channel overrides"
+  },
+  "slackThreadBehavior": {
+    "heading": "Thread Behavior",
+    "selectAria": "Slack thread behavior",
+    "mentionsOnly": "Mentions only",
+    "mentionsOnlyHelp": "Bot only responds when @mentioned.",
+    "followThreads": "Follow threads after first mention",
+    "followThreadsHelp": "After an @mention in a thread, bot listens to the rest of that thread."
+  },
+  "slackChannelList": {
+    "presenceHint": "Add with <invite>/invite {handle}</invite> or remove with <remove>/remove {handle}</remove> in that Slack channel. Only channels {assistant} is in appear here.",
+    "loading": "Loading…",
+    "loadFailed": "Couldn’t load channels. Try reopening this page.",
+    "emptyTitle": "No channels yet",
+    "searchPlaceholder": "Search channels",
+    "searchAria": "Search channels",
+    "filterGroupAria": "Filter channels by type",
+    "noMatches": "No channels match.",
+    "accessAria": "Assistant Access in {channel}",
+    "filterAll": "All",
+    "filterPublic": "Public",
+    "filterPrivate": "Private"
+  },
+  "twilioCredentialEntry": {
+    "accountSid": "Account SID",
+    "authToken": "Auth Token",
+    "authTokenPlaceholder": "Twilio auth token",
+    "saving": "Saving…",
+    "save": "Save"
+  }
+}

--- a/clients/web/src/i18n/locales/es/channels.json
+++ b/clients/web/src/i18n/locales/es/channels.json
@@ -1,0 +1,94 @@
+{
+  "assistantChannelsList": {
+    "drawerTitle": "Canales",
+    "disconnectTitle": "¿Desconectar {channel}?",
+    "disconnectConfirm": "Desconectar"
+  },
+  "channelAdapterList": {
+    "pluginChannelAria": "{channel}, de un plugin"
+  },
+  "connectionCard": {
+    "connected": "Conectado",
+    "disconnecting": "Desconectando…",
+    "disconnect": "Desconectar"
+  },
+  "slackChannelCard": {
+    "setupHeading": "Configuración de Slack"
+  },
+  "channelPanel": {
+    "incompleteTitle": "{channel} aún no funciona",
+    "disconnectedTitle": "{channel} no está conectado",
+    "incompleteDescription": "{channel} está configurado pero todavía no entrega mensajes. Tu asistente puede retomar donde se quedó la configuración y decirte qué falla.",
+    "opening": "Abriendo…",
+    "finishSetup": "Terminar la configuración con tu asistente",
+    "setUp": "Configurar",
+    "connectManually": "o conectar manualmente"
+  },
+  "pluginChannelPanel": {
+    "openPluginPage": "Abrir la página del plugin",
+    "ingressLoading": "Comprobando quién puede contactar con {channel}…",
+    "ingressUnsupported": "La puerta de enlace de este asistente no informa de las aprobaciones de entrada, así que aquí no hay nada que decidir.",
+    "ingressForbidden": "Solo el guardián de este asistente puede ver o cambiar las aprobaciones de entrada.",
+    "ingressUnreadable": "No se pudo leer la aprobación de entrada de {channel}.",
+    "ingressNone": "La puerta de enlace no ve ninguna declaración de entrada para {channel}, así que todavía no hay nada que aprobar.",
+    "ingressApprovedTag": "Entrada aprobada",
+    "ingressPendingTag": "Entrada pendiente de aprobación",
+    "approvedAddresses": "{channel} recibe mensajes en estas direcciones:",
+    "pendingAddresses": "{channel} pide recibir mensajes en estas direcciones. Hasta que lo apruebes, se rechazan las entregas:",
+    "ungovernedAddresses": "Estas direcciones están abiertas decidas lo que decidas, porque solo Vellum puede alcanzarlas:",
+    "revokeIngress": "Revocar la entrada",
+    "approveIngress": "Aprobar la entrada"
+  },
+  "channelTrustFloor": {
+    "heading": "Quién puede escribir a {assistant}",
+    "loading": "Cargando…",
+    "loadFailed": "No se pudo cargar este ajuste. Prueba a volver a abrir esta página.",
+    "selectAria": "Quién puede escribir a {assistant}",
+    "trustedContactsNotice": "Las personas que aún no has verificado (incluso compañeros del mismo canal) no pueden pasar: {assistant} les avisa de que necesitan verificarse y te lo notifica. Puedes verificar personas por adelantado en Contactos."
+  },
+  "slackChannelTypeDefaults": {
+    "heading": "Acceso predeterminado",
+    "subtitle": "Cuánto hace {assistant} por su cuenta, según el tipo de conversación. Cada canal puede anular esto más abajo, y las <trustRules>Reglas de confianza</trustRules> afinan cuándo pregunta.",
+    "bucketAria": "Acceso predeterminado del asistente para {bucket}"
+  },
+  "tierPicker": {
+    "defaultSuffix": "predeterminado",
+    "defaultPlaceholder": "Predeterminado"
+  },
+  "slackChannelTierLegend": {
+    "defaultMarker": "· predeterminado"
+  },
+  "slackChannelSection": {
+    "overridesLoadFailed": "No se pudieron cargar los ajustes de acceso. Estos controles seguirán desactivados hasta que se carguen. Prueba a volver a abrir esta página.",
+    "perChannelOverrides": "Anulaciones por canal"
+  },
+  "slackThreadBehavior": {
+    "heading": "Comportamiento en hilos",
+    "selectAria": "Comportamiento de Slack en hilos",
+    "mentionsOnly": "Solo menciones",
+    "mentionsOnlyHelp": "El bot solo responde cuando se le menciona con @.",
+    "followThreads": "Seguir el hilo tras la primera mención",
+    "followThreadsHelp": "Tras una mención con @ en un hilo, el bot escucha el resto de ese hilo."
+  },
+  "slackChannelList": {
+    "presenceHint": "Añádelo con <invite>/invite {handle}</invite> o quítalo con <remove>/remove {handle}</remove> en ese canal de Slack. Aquí solo aparecen los canales en los que está {assistant}.",
+    "loading": "Cargando…",
+    "loadFailed": "No se pudieron cargar los canales. Prueba a volver a abrir esta página.",
+    "emptyTitle": "Aún no hay canales",
+    "searchPlaceholder": "Buscar canales",
+    "searchAria": "Buscar canales",
+    "filterGroupAria": "Filtrar canales por tipo",
+    "noMatches": "Ningún canal coincide.",
+    "accessAria": "Acceso del asistente en {channel}",
+    "filterAll": "Todos",
+    "filterPublic": "Públicos",
+    "filterPrivate": "Privados"
+  },
+  "twilioCredentialEntry": {
+    "accountSid": "SID de la cuenta",
+    "authToken": "Token de autenticación",
+    "authTokenPlaceholder": "Token de autenticación de Twilio",
+    "saving": "Guardando…",
+    "save": "Guardar"
+  }
+}

--- a/clients/web/src/i18n/namespaces.ts
+++ b/clients/web/src/i18n/namespaces.ts
@@ -34,7 +34,13 @@
  * checked at compile time, so a half-finished addition fails `tsc` rather than
  * rendering raw key paths at runtime.
  */
-export const NAMESPACES = ["common", "chat", "schedules", "account"] as const;
+export const NAMESPACES = [
+  "common",
+  "chat",
+  "schedules",
+  "account",
+  "channels",
+] as const;
 
 export type Namespace = (typeof NAMESPACES)[number];
 


### PR DESCRIPTION
## Prompt / plan

Third domain cutover, following #40465. **74 strings across 16 files**, in a new `channels` namespace.

The pre-rule survey said 51, so this domain was **45% larger than it looked** — the same undercount `schedules` had (50 → 63). Almost all of the extra is one shape: sentences broken into fragments around an expression or an element. They read fine in English and cannot be translated at all.

## What was fragmented

**Text spliced around a value.** All now placeholders:

- `Who can message {name}`
- `Checking who can reach {name}…`
- `Could not read the ingress approval for {name}.`
- `The gateway sees no ingress declaration for {name}, so there is nothing to approve yet.`
- `Disconnect {name}?`

**Subjects welded to the front by a template literal in a ternary.** `${label} isn't working yet` / `isn't connected`, plus both ingress address sentences. Now whole messages, so a translator can put the subject where their language wants it.

**Two `<Trans>` conversions,** where prose interleaved with elements:

```tsx
Add with <code>/invite @assistant</code> or remove with <code>/remove @assistant</code> in that Slack channel.
```

That's one sentence with two `<code>` slots, now a single message. The default-access subtitle similarly wrapped a `Trust Rules` router link mid-sentence.

**Another array-of-literals.** `CHANNEL_KIND_FILTERS` held `label: "All" | "Public" | "Private"` as data. Same blind spot as the account signup headline — the rule can't see array literals. Now catalog keys.

## Escape hatches

One, with a reason: the Twilio Account SID format hint (`ACxxxx…`), which is the same string in every language.

## Two guards earned their place

**The orphan check caught a dead key.** `slackChannelTypeDefaults.trustRulesLink` was written before the subtitle became a `<Trans>`; the `<Trans>` absorbed the link text, so nothing read the key any more. Exactly the "translator gets paid for copy nobody shows" case that check exists for.

**An existing component test caught a copy change.** `slack-channel-section.test.tsx` asserts on `Couldn’t load access settings` with a typographic apostrophe, and my catalog had flattened it to a straight `'`. Restored — and worth keeping deliberately, because ICU treats a straight `'` as an escape character while `’` is an ordinary one. The curly form is both the original design and the safer character.

## Test plan

- `bun scripts/run-tests.ts`: **920 test files pass, 0 fail**
- `bun run lint` clean with `src/domains/channels/**/*.{ts,tsx}` on the ratchet: 0 errors, 16 pre-existing warnings
- `bunx tsc --noEmit` clean; pre-commit hook passed without bypass
- `bun run build` clean; Spanish `channels` emits as its own 4,538 B lazily-imported chunk

## Cutover progress

Four domains done (schedules 63, account 53, channels 74, chat partial) — roughly **190 strings**.

Remaining, by pre-rule survey count (expect ~25–45% more in practice):

| Domain | Survey | Domain | Survey |
| --- | ---: | --- | ---: |
| settings | 1275 | library | 33 |
| chat | 750 | workspace | 30 |
| components | 369 | credential-requests | 21 |
| onboarding | 151 | logs | 19 |
| intelligence | 141 | terminal | 11 |
| contacts | 69 | remote-web | 5 |
| home | 40 | | |

---
_Generated by [Claude Code](https://claude.ai/code/session_01CD12TRfmDF3UiXjdbiWn3i)_