### PR TITLE
feat(plugin-api): expose resolveOauthCallbackUrl to plugins

### DIFF
--- a/assistant/src/plugin-api/__tests__/oauth-callback-url-export.test.ts
+++ b/assistant/src/plugin-api/__tests__/oauth-callback-url-export.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Guards that `resolveOauthCallbackUrl` reaches plugins.
+ *
+ * The shim written into `<workspaceDir>/node_modules/@vellumai/plugin-api`
+ * re-binds whatever `Object.keys()` finds on the plugin-api namespace, so an
+ * export missing from `index.ts` is missing from every installed plugin with
+ * no other signal than a plugin failing to import it.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { PLUGIN_API_EXPORTS } from "../../embedded/plugin-api.js";
+import * as pluginApi from "../index.js";
+
+describe("plugin-api OAuth callback export", () => {
+  test("is exported from the plugin-api surface", () => {
+    expect(typeof pluginApi.resolveOauthCallbackUrl).toEqual("function");
+  });
+
+  test("is carried into the generated shim's binding list", () => {
+    expect(PLUGIN_API_EXPORTS).toContain("resolveOauthCallbackUrl");
+  });
+
+  test("takes no arguments, so a plugin cannot vary the URI", () => {
+    // The value a Client ID Metadata Document publishes and the value the
+    // host later authorizes with have to be the same string.
+    expect(pluginApi.resolveOauthCallbackUrl.length).toEqual(0);
+  });
+});

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -180,6 +180,16 @@ export {
 // the same resolution as `webhooks register`, and registers the callback route
 // on the managed branches. The plugin defaults to the one in context.
 export { resolveWebhookUrl, type WebhookUrlOptions } from "./webhook-url.js";
+// Resolve the redirect URI an authorization server should send a user back
+// to after consent. One shared route serves every OAuth flow in the
+// assistant, demultiplexed by OAuth `state`, so this takes no arguments and
+// returns the same URL for every caller and every attempt. A plugin needs it
+// when it publishes something that has to name the redirect URI ahead of the
+// flow, such as a Client ID Metadata Document, whose `redirect_uris` an
+// authorization server matches exactly. Throws when no public ingress is
+// configured and the assistant is not connected to the platform, which is the
+// case where no URL would work.
+export { resolveOauthCallbackUrl } from "../inbound/oauth-callback-url.js";
 // Resolve a provider for a call site (optionally overriding the profile) so a
 // plugin can run inference through the workspace's configured profiles and
 // credentials — managed-proxy or BYOK — without supplying its own API key.

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -409,7 +409,7 @@
         }
       },
       "compatibility": "Any environment running Claude Code headlessly",
-      "updatedAt": "2026-08-07T12:58:27.000Z"
+      "updatedAt": "2026-08-07T13:48:02.000Z"
     },
     {
       "id": "inbox-cleanup",
@@ -759,7 +759,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-07T12:35:44.000Z"
+      "updatedAt": "2026-08-07T17:52:56.000Z"
     },
     {
       "id": "public-ingress",
@@ -1241,7 +1241,7 @@
         }
       },
       "compatibility": "Sandbox mode works without any host dependencies. Host mode requires tmux installed on the user's machine. Works on macOS and Linux.",
-      "updatedAt": "2026-08-07T12:58:27.000Z"
+      "updatedAt": "2026-08-07T13:48:02.000Z"
     },
     {
       "id": "vellum-workspace-theme",

--- a/skills/plugin-builder/references/plugins.md
+++ b/skills/plugin-builder/references/plugins.md
@@ -133,6 +133,19 @@ Values, not just types, that a plugin consumes at module-load or init time. A bo
 | `resolveCredential`         | value | Resolve a stored credential to its plaintext value (the same value `assistant credentials reveal` prints) from a UUID or a `service/field` reference. When a plugin is in context, resolution is scoped to credentials whose `field` matches the plugin's manifest name; outside any plugin it is unscoped. Throws `CredentialResolutionError` on failure. |
 | `CredentialResolutionError` | class | Thrown when the credential ref does not resolve, the store is unreachable, or the credential is out of the plugin's scope. Catch it to degrade gracefully rather than crashing the hook.                                                                                                                                                                   |
 
+#### Public URLs
+
+Both resolve through the same host logic, which decides between a managed
+platform callback route and a configured public ingress. Both throw when the
+assistant has neither, since no URL would work in that case and a plausible
+one produces a registration that silently receives nothing.
+
+| Export                    | Kind  | Purpose                                                                                                                                                                                                                                                                                                                                                                |
+| ------------------------- | ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `resolveWebhookUrl`       | value | Resolve the public URL a third party should deliver to for one of the plugin's own ingress routes, in the plugin's reserved namespace. Takes the route `path`, and the `plugin` (defaulting to the one in context) plus an optional `sourceIdentifier` for admin display.                                                                                              |
+| `resolveOauthCallbackUrl` | value | Resolve the redirect URI an authorization server should send a user back to after consent. One shared route serves every OAuth flow, demultiplexed by OAuth `state`, so it takes no arguments and returns the same URL for every caller and every attempt. Use it where something must name the redirect URI ahead of the flow, such as a Client ID Metadata Document. |
+| `WebhookUrlOptions`       | type  | Options for `resolveWebhookUrl`.                                                                                                                                                                                                                                                                                                                                       |
+
 #### Inference helpers
 
 | Export                   | Kind  | Purpose                                                                                                                                                                                                                                                                                                               |


### PR DESCRIPTION
## Prompt / plan

"We need to now expose this on the plugin api so that the unabyss plugin can use it."

Follow-up to #40452, which added `resolveOauthCallbackUrl` in `inbound/` for host-internal callers. This re-exports it from `@vellumai/plugin-api` so plugins can read the same value.

A plugin needs it when it publishes something that has to name the redirect URI *ahead of* the flow. The concrete case is a Client ID Metadata Document: `mcp.unabyss.com` advertises `client_id_metadata_document_supported: true`, a CIMD document must list `redirect_uris`, and the authorization server matches that value exactly against what the host later authorizes with. Reading the host's resolver is the only way those two agree; reconstructing the URL plugin-side reintroduces exactly the drift #40452 removed.

## Notes

**No plugin scoping, deliberately.** `resolveWebhookUrl` resolves into the calling plugin's reserved namespace, so it takes a `plugin` and defaults to the one in context. This is one shared route for the whole assistant and takes no arguments, so there is nothing to scope and no way for one plugin to reach another's anything. It returns a public redirect URI, not a credential.

**No export-list entry needed.** The shim written into `<workspaceDir>/node_modules/@vellumai/plugin-api` re-binds whatever `Object.keys()` finds on the namespace (`PLUGIN_API_EXPORTS` in `embedded/plugin-api.ts` is derived, not hand-maintained), so adding to `index.ts` is sufficient. A test pins that it lands in that list anyway, because a missing binding otherwise surfaces only as a plugin failing to import it at load time.

**Docs.** The plugin-builder reference documented neither public-URL resolver. Added a section covering both, since a reader reaching for one needs to know which of the two applies.

## Test plan

- **New** — `src/plugin-api/__tests__/oauth-callback-url-export.test.ts` (3): the export exists on the plugin-api surface, it reaches `PLUGIN_API_EXPORTS` (what the generated shim binds from), and it takes no arguments, so a plugin cannot vary the URI it publishes.
- **Existing, passing individually:** `src/plugin-api/__tests__` 8, `plugin-api-shim` 8, `plugin-api-resolve-credential` 8, `plugin-api-model-profiles` 8, `external-plugin-loader` 30, plus the resolver's own suites (`oauth-callback-url` 5, `mcp-oauth-provider` 2, `mcp-auth-orchestrator` 7).
- `bunx tsc --noEmit` — 0 errors repo-wide. `eslint` clean. Pre-commit hook green.

Rebased onto `main` after #40452 merged, so this branch carries only the one new commit.

## CLI verb checklist

Not applicable, no new routes. This re-exports an existing internal function on the plugin API surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XhVk8rfYUZHQQ9UPFPEBKU

---
_Generated by [Claude Code](https://claude.ai/code/session_01XhVk8rfYUZHQQ9UPFPEBKU)_