### PR TITLE
Use native camera preview in voice rooms

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -185,6 +185,7 @@
       "name": "@vellumai/web",
       "version": "0.11.2",
       "dependencies": {
+        "@capacitor-community/camera-preview": "8.0.1",
         "@capacitor/android": "8.3.4",
         "@capacitor/app": "8.1.0",
         "@capacitor/browser": "8.0.3",
@@ -607,6 +608,7 @@
     "@playwright/browser-chromium",
   ],
   "patchedDependencies": {
+    "@capacitor-community/camera-preview@8.0.1": "patches/@capacitor-community%2Fcamera-preview@8.0.1.patch",
     "storybook@10.4.0": "patches/storybook@10.4.0.patch",
   },
   "overrides": {
@@ -672,6 +674,8 @@
     "@blazediff/core": ["@blazediff/core@1.9.1", "", {}, "sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA=="],
 
     "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
+
+    "@capacitor-community/camera-preview": ["@capacitor-community/camera-preview@8.0.1", "", { "peerDependencies": { "@capacitor/core": ">=8.0.2" } }, "sha512-pEBB+FKXoISMiorn9nKvyd9DPkalopckYxKlHuRBhC6cBLOxgLPnjj9nQO9TYOnWI5nuh973QRZtgN4sOe5Pyw=="],
 
     "@capacitor/android": ["@capacitor/android@8.3.4", "", { "peerDependencies": { "@capacitor/core": "^8.3.0" } }, "sha512-7gJjrG3X32Am1QMLqgMztWTYMLMVNE+VZwhekNxhvYizH4mOV05vH+rC9B+f17bCkYZfyu/qXQX6hoY7kLeVZw=="],
 

--- a/clients/android/app/capacitor.build.gradle
+++ b/clients/android/app/capacitor.build.gradle
@@ -9,6 +9,7 @@ android {
 
 apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
+    implementation project(':capacitor-community-camera-preview')
     implementation project(':capacitor-app')
     implementation project(':capacitor-browser')
     implementation project(':capacitor-file-viewer')

--- a/clients/android/app/src/main/AndroidManifest.xml
+++ b/clients/android/app/src/main/AndroidManifest.xml
@@ -185,8 +185,13 @@
     <!-- Permissions -->
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.POST_PROMOTED_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
 </manifest>

--- a/clients/android/capacitor.settings.gradle
+++ b/clients/android/capacitor.settings.gradle
@@ -2,6 +2,9 @@
 include ':capacitor-android'
 project(':capacitor-android').projectDir = new File('../../node_modules/.bun/@capacitor+android@8.3.4+33da1c2fb16abc29/node_modules/@capacitor/android/capacitor')
 
+include ':capacitor-community-camera-preview'
+project(':capacitor-community-camera-preview').projectDir = new File('../../node_modules/.bun/@capacitor-community+camera-preview@8.0.1+33da1c2fb16abc29/node_modules/@capacitor-community/camera-preview/android')
+
 include ':capacitor-app'
 project(':capacitor-app').projectDir = new File('../../node_modules/.bun/@capacitor+app@8.1.0+33da1c2fb16abc29/node_modules/@capacitor/app/android')
 

--- a/clients/ios/App/App/MyViewController.swift
+++ b/clients/ios/App/App/MyViewController.swift
@@ -426,6 +426,7 @@ extension MyViewController: WKScriptMessageHandler {
                   let hex = body["color"] as? String,
                   let color = UIColor(cssHex: hex)
             else { return }
+            webView?.isOpaque = false
             view.backgroundColor = color
             webView?.backgroundColor = color
             webView?.scrollView.backgroundColor = color

--- a/clients/ios/App/CapApp-SPM/Package.swift
+++ b/clients/ios/App/CapApp-SPM/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 // DO NOT MODIFY THIS FILE - managed by Capacitor CLI commands
 let package = Package(
     name: "CapApp-SPM",
-    platforms: [.iOS(.v15)],
+    platforms: [.iOS(.v17)],
     products: [
         .library(
             name: "CapApp-SPM",
@@ -12,18 +12,19 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.3.4"),
-        .package(name: "CapacitorApp", path: "../../../web/node_modules/@capacitor/app"),
-        .package(name: "CapacitorBrowser", path: "../../../web/node_modules/@capacitor/browser"),
-        .package(name: "CapacitorFileViewer", path: "../../../web/node_modules/@capacitor/file-viewer"),
-        .package(name: "CapacitorFilesystem", path: "../../../web/node_modules/@capacitor/filesystem"),
-        .package(name: "CapacitorHaptics", path: "../../../web/node_modules/@capacitor/haptics"),
-        .package(name: "CapacitorKeyboard", path: "../../../web/node_modules/@capacitor/keyboard"),
-        .package(name: "CapacitorLocalNotifications", path: "../../../web/node_modules/@capacitor/local-notifications"),
-        .package(name: "CapacitorNetwork", path: "../../../web/node_modules/@capacitor/network"),
-        .package(name: "CapacitorPushNotifications", path: "../../../web/node_modules/@capacitor/push-notifications"),
-        .package(name: "CapacitorShare", path: "../../../web/node_modules/@capacitor/share"),
-        .package(name: "SentryCapacitor", path: "../../../web/node_modules/@sentry/capacitor"),
-        .package(name: "CapacitorPluginSafeArea", path: "../../../web/node_modules/capacitor-plugin-safe-area")
+        .package(name: "CapacitorCommunityCameraPreview", path: "../../../../node_modules/.bun/@capacitor-community+camera-preview@8.0.1+33da1c2fb16abc29/node_modules/@capacitor-community/camera-preview"),
+        .package(name: "CapacitorApp", path: "../../../../node_modules/.bun/@capacitor+app@8.1.0+33da1c2fb16abc29/node_modules/@capacitor/app"),
+        .package(name: "CapacitorBrowser", path: "../../../../node_modules/.bun/@capacitor+browser@8.0.3+33da1c2fb16abc29/node_modules/@capacitor/browser"),
+        .package(name: "CapacitorFileViewer", path: "../../../../node_modules/.bun/@capacitor+file-viewer@2.0.1+33da1c2fb16abc29/node_modules/@capacitor/file-viewer"),
+        .package(name: "CapacitorFilesystem", path: "../../../../node_modules/.bun/@capacitor+filesystem@8.1.2+33da1c2fb16abc29/node_modules/@capacitor/filesystem"),
+        .package(name: "CapacitorHaptics", path: "../../../../node_modules/.bun/@capacitor+haptics@8.0.0+33da1c2fb16abc29/node_modules/@capacitor/haptics"),
+        .package(name: "CapacitorKeyboard", path: "../../../../node_modules/.bun/@capacitor+keyboard@8.0.5+33da1c2fb16abc29/node_modules/@capacitor/keyboard"),
+        .package(name: "CapacitorLocalNotifications", path: "../../../../node_modules/.bun/@capacitor+local-notifications@8.2.0+33da1c2fb16abc29/node_modules/@capacitor/local-notifications"),
+        .package(name: "CapacitorNetwork", path: "../../../../node_modules/.bun/@capacitor+network@8.0.0+33da1c2fb16abc29/node_modules/@capacitor/network"),
+        .package(name: "CapacitorPushNotifications", path: "../../../../node_modules/.bun/@capacitor+push-notifications@8.0.3+33da1c2fb16abc29/node_modules/@capacitor/push-notifications"),
+        .package(name: "CapacitorShare", path: "../../../../node_modules/.bun/@capacitor+share@8.0.1+33da1c2fb16abc29/node_modules/@capacitor/share"),
+        .package(name: "SentryCapacitor", path: "../../../../node_modules/.bun/@sentry+capacitor@4.1.0+1184c339b098859f/node_modules/@sentry/capacitor"),
+        .package(name: "CapacitorPluginSafeArea", path: "../../../../node_modules/.bun/capacitor-plugin-safe-area@5.0.0+33da1c2fb16abc29/node_modules/capacitor-plugin-safe-area")
     ],
     targets: [
         .target(
@@ -31,6 +32,7 @@ let package = Package(
             dependencies: [
                 .product(name: "Capacitor", package: "capacitor-swift-pm"),
                 .product(name: "Cordova", package: "capacitor-swift-pm"),
+                .product(name: "CapacitorCommunityCameraPreview", package: "CapacitorCommunityCameraPreview"),
                 .product(name: "CapacitorApp", package: "CapacitorApp"),
                 .product(name: "CapacitorBrowser", package: "CapacitorBrowser"),
                 .product(name: "CapacitorFileViewer", package: "CapacitorFileViewer"),

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -42,14 +42,15 @@ which URL is baked into the build.
   to days. Bundling web assets would gate every web change behind that
   process. With `server.url`, only native shell changes (Swift code,
   entitlements, Capacitor plugin updates) require a store submission.
-- **Thin native surface** — the IPC bridge between the WKWebView and
-  native code is minimal (six plugins: `NativeAuthPlugin`,
+- **Thin native surface** - the IPC bridge between the WKWebView and
+  native code is minimal (six app-local plugins: `NativeAuthPlugin`,
   `NativeBiometricPlugin`, `VoiceAudioSessionPlugin`,
   `VoiceLiveActivityPlugin`, `ApnsEnvironmentPlugin`, and
-  `SelfHostedServersPlugin`), so version
-  skew risk between the web app and native shell is low. Every plugin
-  call from the web side must still be capability-probed, because a new
-  web bundle always ships ahead of the shell that hosts it. Contrast
+  `SelfHostedServersPlugin`, plus the auto-discovered community camera
+  preview dependency), so version skew risk between the web app and native
+  shell is low. Every plugin call from the web side must still have a
+  working missing-plugin fallback because a new web bundle always ships
+  ahead of the shell that hosts it. Contrast
   with the Electron app, where the
   `window.vellum.*` IPC surface is broad and tightly coupled.
 - **WKWebView security model** — unlike Electron's renderer, `WKWebView`
@@ -149,9 +150,10 @@ Apple's reference for the toolbar controls:
 
 ## Debugging
 
-The app has two layers — the **WKWebView contents** (the React app loaded
+The app has two layers: the **WKWebView contents** (the React app loaded
 from the configured server URL) and the **native Swift shell** (Capacitor
-bridge, `MyViewController`, the six native plugins). Each has its own
+bridge, `MyViewController`, the six app-local plugins, and linked package
+plugins such as `CameraPreview`). Each has its own
 debugger.
 
 ### Safari Web Inspector — for the web side (JS / CSS / network / `console.log`)
@@ -227,6 +229,12 @@ a breakpoint.
   hits, the JS-side `Capacitor.Plugins.NativeAuth` lookup is wrong (check
   `src/runtime/native-auth.ts` / `native-biometric.ts`). If it hits but
   doesn't return, step through and check `call.resolve` / `call.reject`.
+- **The voice-room camera preview is blank or covered**: open the
+  `CameraPreview` package under Xcode's Package Dependencies and breakpoint
+  its `start` method. In Safari Web Inspector, confirm `<html>` carries
+  `native-voice-camera-active` while the preview is open. The camera is a
+  native layer behind the non-opaque web view, so an opaque page background
+  will cover a correctly running capture session.
 - **A streaming/SSE bug only reproduces in the iOS shell**: open Safari
   Web Inspector → Network → filter for `text/event-stream`. You should
   see the connection stay open with `data:` frames arriving. If you see
@@ -379,7 +387,7 @@ who clones fresh. ([Capacitor SPM docs](https://capacitorjs.com/docs/ios/spm))
 
 ```bash
 cd clients/web
-bun add @capacitor/<plugin-name>   # adds to package.json + bun.lock
+bun add --exact @capacitor/<plugin-name>   # adds to package.json + bun.lock
 bun run ios:setup                   # cap sync regenerates Package.swift; xcodegen wires it into the project
 ```
 
@@ -417,6 +425,8 @@ On first build after pulling:
       arrive in one big blob, CapacitorHttp got turned on somewhere)
 - [ ] Photo / file attachments work (exercises the WKWebView file-picker
       bridge)
+- [ ] Voice-room camera opens a sharp native preview on a physical device,
+      flips cameras, captures a photo, and leaves live-voice audio running
 - [ ] Xcode → App target → General → Bundle Identifier reads
       `ai.vocify-inc.vellum-assistant-ios`
 

--- a/clients/web/docs/CAPACITOR.md
+++ b/clients/web/docs/CAPACITOR.md
@@ -144,9 +144,9 @@ References:
 
 ## Native voice bridge
 
-Live voice is a web feature with native accessories. The session, including mic capture, the velay socket, TTS playback, and every user-facing string, lives entirely under `src/domains/chat/voice/live-voice/`. iOS adds interruption reporting, a Dynamic Island and Lock Screen presence, and App Intents. Android adds foreground audio focus and an ongoing status notification.
+Live voice is a web feature with native accessories. The session, including mic capture, the velay socket, TTS playback, and every user-facing string, lives under `src/domains/chat/voice/live-voice/`. iOS adds interruption reporting, a Dynamic Island and Lock Screen presence, and App Intents. Android adds foreground audio focus and an ongoing status notification. The voice-room camera is the capture exception: native mobile shells use `@capacitor-community/camera-preview`, while browsers and older shells use a web `MediaStream` fallback.
 
-The shell registers **six** Capacitor plugins in [`MyViewController.capacitorDidLoad()`](../../../clients/ios/App/App/MyViewController.swift) (count them there, not from prose):
+The shell registers **six app-local** Capacitor plugins in [`MyViewController.capacitorDidLoad()`](../../../clients/ios/App/App/MyViewController.swift) (count them there, not from prose). `CameraPreview` is an external SPM/Gradle dependency that Capacitor discovers automatically, so it is not registered in that method.
 
 | Plugin | Web module | What it does |
 | --- | --- | --- |
@@ -174,6 +174,18 @@ Three things follow from the rule:
 - **Destructure the plugin inline inside `invoke`.** The lazy-import rule at the top of this document applies verbatim: only the *result* may cross the `async` boundary, never the plugin Proxy.
 
 **No capability probes.** Neither voice plugin exposes an `isAvailable`, and neither web module wants one: `startVoiceLiveActivity()` resolving `false` already covers every reason there is no native side: outside a native mobile shell, an older shell, or a disabled platform status surface. A probe that can itself be absent just moves the problem, and it is the only answer a caller could act on anyway.
+
+### Native voice-room camera
+
+[`native-voice-camera.ts`](../src/runtime/native-voice-camera.ts) is the only web module that calls `CameraPreview`. The mobile preview is a native camera layer behind the Capacitor web view, not an HTML media element. Opening it makes the web canvas transparent and keeps the voice-room controls visible in front; closing it restores the active theme through the iOS `--surface-overlay` bridge. The dependency is patched so its cleanup does not force an opaque or white web view over the app's own theme.
+
+The camera call has one hard audio rule: `disableAudio: true` is mandatory. Live voice already owns microphone capture, and the viewfinder must not add an audio input or reconfigure the session underneath it. `enableHighResolution: true` requests the iOS high-resolution photo path, `toBack: true` keeps the HTML controls above the preview, and `storeToFile: false` returns captured JPEG bytes directly to the existing attachment pipeline.
+
+Camera permission is declared in both shells: `NSCameraUsageDescription` on iOS and `android.permission.CAMERA` on Android. Android marks camera hardware optional so devices without a camera remain installable and fail through the existing no-device path.
+
+The skew rule applies to every camera call through `callNativeVoice`. `startNativeVoiceCamera()` resolving `false` is the availability result. Do not add a separate probe. When the plugin is missing from an older installed shell, `voice-camera.ts` falls through to video-only `getUserMedia` with ideal 1920 by 1080 constraints and logs the negotiated non-identifying track settings. Desktop web and Electron use that same fallback. The native path renders no `<video>`, so it has no browser playback state or media-element play affordance.
+
+The iOS Simulator does not provide a real camera feed. A native build verifies linking and compilation, but preview sharpness, camera switching, tap focus, audio continuity, and the permission path require a physical handset.
 
 ### The background-audio contract
 

--- a/clients/web/package.json
+++ b/clients/web/package.json
@@ -31,6 +31,7 @@
     "test:ci": "bun scripts/run-tests.ts"
   },
   "dependencies": {
+    "@capacitor-community/camera-preview": "8.0.1",
     "@capacitor/android": "8.3.4",
     "@capacitor/app": "8.1.0",
     "@capacitor/browser": "8.0.3",

--- a/clients/web/src/domains/chat/components/chat-attachments/utils.ts
+++ b/clients/web/src/domains/chat/components/chat-attachments/utils.ts
@@ -138,7 +138,9 @@ export function estimateBase64Bytes(base64: string): number {
  * Decode a base64 data URI into a Uint8Array. Returns null if the URI does
  * not contain a recognizable `;base64,` segment.
  */
-export function dataUriToUint8Array(dataUri: string): Uint8Array | null {
+export function dataUriToUint8Array(
+  dataUri: string,
+): Uint8Array<ArrayBuffer> | null {
   const match = dataUri.match(/;base64,(.*)$/);
   if (!match?.[1]) {
     return null;

--- a/clients/web/src/domains/chat/voice/voice-room/voice-camera.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-camera.ts
@@ -2,15 +2,15 @@
  * The voice room's camera: a live viewfinder the user can leave open for the
  * whole call, and a shutter that turns the current frame into a `File`.
  *
- * ## Why this is not the system camera
+ * ## Why this is not the system camera UI
  *
  * On iOS the obvious move (`<input type="file" capture="environment">`, which
  * raises Apple's own camera) is wrong for this feature in three ways: it is
  * modal and one-shot, so every photo costs a full open/aim/expose cycle; it
  * covers the room, so the call it belongs to disappears while you use it; and
  * it puts the OS in charge of an audio session that a call is currently
- * holding. A viewfinder the room owns is a `<video>` element, which does none
- * of that and stays open across as many photos as the user wants to take.
+ * holding. The room therefore owns a persistent preview: a native Capacitor
+ * camera layer on mobile and a `<video>` stream as the browser fallback.
  *
  * ## The one hard rule: never renegotiate the call's audio
  *
@@ -25,13 +25,22 @@
  *
  * ## Permissions
  *
- * `open()` calls `getUserMedia` directly so the tap that opens the camera is
- * the thing that raises the OS alert, per docs/CAPACITOR.md § OS permission
- * requests on iOS. Nothing dismissible may sit between the two, so the room
- * offers a plain camera button rather than an explanatory sheet.
+ * `open()` calls the native camera bridge, or `getUserMedia` on the fallback
+ * path, directly so the tap that opens the camera is the thing that raises the
+ * OS alert. Nothing dismissible may sit between the two, so the room offers a
+ * plain camera button rather than an explanatory sheet.
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
+
+import { dataUriToUint8Array } from "@/domains/chat/components/chat-attachments/utils";
+import { isNativeMobile } from "@/runtime/platform-detection";
+import {
+  captureNativeVoiceCameraFrame,
+  flipNativeVoiceCamera,
+  startNativeVoiceCamera,
+  stopNativeVoiceCamera,
+} from "@/runtime/native-voice-camera";
 
 /** Which way the camera points. `environment` is the rear/world-facing one. */
 export type VoiceCameraFacing = "environment" | "user";
@@ -48,24 +57,29 @@ export type VoiceCameraError =
   | "unknown";
 
 /**
- * JPEG quality for a captured frame. A viewfinder frame is already only as big
- * as the negotiated video track (typically 1280×720), so this lands well under
- * the attachment pipeline's 3.5 MB auto-resize threshold and
- * `prepareImageAttachmentForUpload` passes it through untouched. Quality is
- * chosen for a model reading the image, not for a photo library.
+ * JPEG quality for a captured frame. The attachment pipeline resizes an
+ * encoded frame when it exceeds its upload budget, so this value favors a
+ * model-readable image without depending on the camera's negotiated size.
  */
 const CAPTURE_JPEG_QUALITY = 0.85;
+
+// Ideals keep lower-resolution cameras usable while asking capable devices for
+// enough detail to fill a phone-sized viewfinder without visible upscaling.
+const VIEWFINDER_IDEAL_WIDTH = 1920;
+const VIEWFINDER_IDEAL_HEIGHT = 1080;
 
 /**
  * Whether a viewfinder can run in this environment.
  *
- * Pure feature detection per docs/CAPACITOR.md § Platform short-circuits.
- * Capacitor iOS is a WKWebView that ships `getUserMedia` for video, so there
- * is no platform branch here.
+ * Native mobile shells can provide the Capacitor preview even when the web
+ * media API is unavailable. The actual bridge call remains skew-safe and
+ * falls through to `getUserMedia` when an older shell lacks the plugin.
  */
 export function isVoiceCameraSupported(): boolean {
   return (
-    typeof navigator !== "undefined" && !!navigator.mediaDevices?.getUserMedia
+    isNativeMobile() ||
+    (typeof navigator !== "undefined" &&
+      !!navigator.mediaDevices?.getUserMedia)
   );
 }
 
@@ -133,8 +147,10 @@ export async function captureVideoFrame(
 }
 
 export interface VoiceCamera {
-  /** True once a stream is live and attached. */
+  /** True once a camera preview is live. */
   readonly open: boolean;
+  /** True when the preview is a native layer behind the Capacitor web view. */
+  readonly native: boolean;
   /** Which way the camera currently points. */
   readonly facing: VoiceCameraFacing;
   /** Why the last `openCamera()` failed, or null. Cleared on the next attempt. */
@@ -150,8 +166,8 @@ export interface VoiceCamera {
 }
 
 /**
- * Owns the viewfinder's `MediaStream` for as long as the component holding it
- * is mounted. Unmounting releases the camera, which is what makes the room's
+ * Owns the viewfinder capture for as long as the component holding it is
+ * mounted. Unmounting releases the camera, which is what makes the room's
  * minimize (and the end of the call) turn the camera hardware off without
  * anything having to remember to.
  *
@@ -166,18 +182,25 @@ export function useVoiceCamera(
   videoRef: React.RefObject<HTMLVideoElement | null>,
 ): VoiceCamera {
   const streamRef = useRef<MediaStream | null>(null);
+  const sourceRef = useRef<"native-pending" | "native" | "web" | null>(null);
   const captureCountRef = useRef(0);
   // Bumped by every acquire and every release, so a `getUserMedia` that
   // resolves after it was superseded can tell and stop its own stream.
   const acquireEpochRef = useRef(0);
   const [open, setOpen] = useState(false);
+  const [native, setNative] = useState(false);
   const [facing, setFacing] = useState<VoiceCameraFacing>("environment");
   const [error, setError] = useState<VoiceCameraError | null>(null);
 
-  const stopStream = useCallback(() => {
+  const stopCapture = useCallback(() => {
     // Cancels any acquire still in flight, so its stream is stopped on arrival
     // rather than installed behind this release.
     acquireEpochRef.current++;
+    const source = sourceRef.current;
+    sourceRef.current = null;
+    if (source === "native-pending" || source === "native") {
+      void stopNativeVoiceCamera();
+    }
     const stream = streamRef.current;
     streamRef.current = null;
     if (stream) {
@@ -204,7 +227,7 @@ export function useVoiceCamera(
    */
   const acquire = useCallback(
     async (nextFacing: VoiceCameraFacing): Promise<VoiceCameraError | null> => {
-      stopStream();
+      stopCapture();
       // Snapshot the epoch across the await. Anything that releases the camera
       // while this request is in flight (unmount, close, a second tap, a flip)
       // bumps it, and the stream that eventually arrives belongs to nobody:
@@ -213,6 +236,31 @@ export function useVoiceCamera(
       // with no owner, which is the camera staying on after the room closes.
       // Same guard, and the same reason, as `pcm-capture.ts`'s cancel epoch.
       const epoch = ++acquireEpochRef.current;
+
+      if (isNativeMobile()) {
+        sourceRef.current = "native-pending";
+        const started = await startNativeVoiceCamera(nextFacing);
+        if (epoch !== acquireEpochRef.current) {
+          if (started) {
+            await stopNativeVoiceCamera();
+          }
+          return "aborted";
+        }
+        if (started) {
+          sourceRef.current = "native";
+          setNative(true);
+          setFacing(nextFacing);
+          return null;
+        }
+        sourceRef.current = null;
+      }
+
+      if (
+        typeof navigator === "undefined" ||
+        !navigator.mediaDevices?.getUserMedia
+      ) {
+        return "unsupported";
+      }
 
       let stream: MediaStream;
       try {
@@ -223,7 +271,11 @@ export function useVoiceCamera(
         // one camera (most laptops) still opens it instead of failing with
         // OverconstrainedError.
         stream = await navigator.mediaDevices.getUserMedia({
-          video: { facingMode: nextFacing },
+          video: {
+            facingMode: nextFacing,
+            width: { ideal: VIEWFINDER_IDEAL_WIDTH },
+            height: { ideal: VIEWFINDER_IDEAL_HEIGHT },
+          },
         });
       } catch (cause) {
         return classifyError(cause);
@@ -236,14 +288,31 @@ export function useVoiceCamera(
         return "aborted";
       }
 
+      const videoTrack = stream.getVideoTracks()[0];
+      if (videoTrack) {
+        const { width, height, aspectRatio, frameRate, facingMode } =
+          videoTrack.getSettings();
+        // Keep deviceId and groupId out of the console: the dimensions are
+        // enough to verify what the browser negotiated.
+        console.debug("[voice-camera] negotiated video track", {
+          width,
+          height,
+          aspectRatio,
+          frameRate,
+          facingMode,
+        });
+      }
+
       streamRef.current = stream;
+      sourceRef.current = "web";
+      setNative(false);
       if (videoRef.current) {
         videoRef.current.srcObject = stream;
       }
       setFacing(nextFacing);
       return null;
     },
-    [stopStream, videoRef],
+    [stopCapture, videoRef],
   );
 
   const start = useCallback(
@@ -278,10 +347,11 @@ export function useVoiceCamera(
   }, [facing, start]);
 
   const closeCamera = useCallback(() => {
-    stopStream();
+    stopCapture();
     setOpen(false);
+    setNative(false);
     setError(null);
-  }, [stopStream]);
+  }, [stopCapture]);
 
   /**
    * Switch cameras, keeping the viewfinder up.
@@ -292,11 +362,18 @@ export function useVoiceCamera(
    * mid-conversation and make them find the button again.
    */
   const flipCamera = useCallback(async () => {
-    if (!isVoiceCameraSupported() || !streamRef.current) {
+    if (!sourceRef.current) {
       return;
     }
     const previous = facing;
     const next = previous === "environment" ? "user" : "environment";
+
+    if (sourceRef.current === "native") {
+      if (await flipNativeVoiceCamera()) {
+        setFacing(next);
+      }
+      return;
+    }
 
     const failure = await acquire(next);
     if (!failure || failure === "aborted") {
@@ -312,28 +389,50 @@ export function useVoiceCamera(
   }, [acquire, facing]);
 
   const captureFrame = useCallback(async () => {
-    const video = videoRef.current;
-    if (!video || !streamRef.current) {
-      return null;
+    const filename = `photo-${captureCountRef.current + 1}.jpg`;
+    let file: File | null = null;
+
+    if (sourceRef.current === "native") {
+      const encoded = await captureNativeVoiceCameraFrame(
+        Math.round(CAPTURE_JPEG_QUALITY * 100),
+      );
+      if (encoded) {
+        try {
+          const dataUri = encoded.startsWith("data:")
+            ? encoded
+            : `data:image/jpeg;base64,${encoded}`;
+          const bytes = dataUriToUint8Array(dataUri);
+          if (bytes) {
+            file = new File([bytes], filename, {
+              type: "image/jpeg",
+            });
+          }
+        } catch {
+          return null;
+        }
+      }
+    } else {
+      const video = videoRef.current;
+      if (!video || !streamRef.current) {
+        return null;
+      }
+      file = await captureVideoFrame(video, filename);
     }
+
     // Numbered per session rather than timestamped: the name is what the
     // transcript labels the photo with, and "Photo 2" reads as the second one
     // taken, which is exactly what the user is looking for when they scroll
     // back. Incremented only on a frame that actually encoded.
-    const file = await captureVideoFrame(
-      video,
-      `photo-${captureCountRef.current + 1}.jpg`,
-    );
     if (file) {
       captureCountRef.current += 1;
     }
     return file;
   }, [videoRef]);
 
-  // The stream outlives React's own teardown of the element, so releasing the
-  // hardware has to be explicit. Without this the camera light stays on after
-  // the room closes.
-  useEffect(() => stopStream, [stopStream]);
+  // The capture outlives React's own teardown of the element, so releasing
+  // the hardware has to be explicit. Without this the camera light stays on
+  // after the room closes.
+  useEffect(() => stopCapture, [stopCapture]);
 
   // The `<video>` renders on the same commit that flips `open`, so a stream
   // acquired in `start()` has no element to attach to yet. This runs after
@@ -346,6 +445,7 @@ export function useVoiceCamera(
 
   return {
     open,
+    native,
     facing,
     error,
     openCamera,

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -18,7 +18,15 @@
 
 import { type ReactNode } from "react";
 
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
 
 import {
   act,
@@ -1401,9 +1409,14 @@ describe("VoiceRoom: camera", () => {
   // stand-in throws where a real camera would not, but happy-dom's
   // implementation has no `getTracks()`, which release needs, so that one
   // method is filled in.
-  function fakeStream() {
+  function fakeStream(getSettings?: () => MediaTrackSettings) {
     const stream = new MediaStream();
-    Object.defineProperty(stream, "getTracks", { value: () => [] });
+    Object.defineProperties(stream, {
+      getTracks: { value: () => [] },
+      getVideoTracks: {
+        value: () => (getSettings ? [{ getSettings }] : []),
+      },
+    });
     return stream;
   }
 
@@ -1508,29 +1521,64 @@ describe("VoiceRoom: camera", () => {
   });
 
   test("tapping the camera opens the viewfinder and the shutter, and the call keeps running", async () => {
-    const getUserMedia = mock(async (_constraints?: MediaStreamConstraints) =>
-      fakeStream(),
+    const getSettings = mock(() => ({
+      width: 1920,
+      height: 1080,
+      aspectRatio: 16 / 9,
+      frameRate: 30,
+      facingMode: "environment",
+      deviceId: "camera-device-id",
+      groupId: "camera-group-id",
+    }));
+    const getUserMedia = mock(
+      async (_constraints?: MediaStreamConstraints) =>
+        fakeStream(getSettings),
     );
+    const consoleDebug = spyOn(console, "debug").mockImplementation(() => {});
     stubMediaDevices(getUserMedia);
     seedCameraCapableAssistant();
     startOwnedSession("listening");
-    render(<VoiceRoom />);
+    try {
+      render(<VoiceRoom />);
 
-    await act(async () => {
-      fireEvent.click(cameraToggle()!);
-    });
+      await act(async () => {
+        fireEvent.click(cameraToggle()!);
+      });
 
-    expect(viewfinder()).not.toBeNull();
-    expect(screen.queryByTestId("voice-room-shutter")).not.toBeNull();
-    // Video only. Requesting audio here would renegotiate the microphone the
-    // live-voice session is streaming from. See `voice-camera.ts`.
-    expect(getUserMedia).toHaveBeenCalledTimes(1);
-    expect(getUserMedia.mock.calls[0]?.[0]).toEqual({
-      video: { facingMode: "environment" },
-    });
-    // Opening a camera is not an act on the session itself.
-    expect(controls.stop).not.toHaveBeenCalled();
-    expect(controls.interrupt).not.toHaveBeenCalled();
+      const video = viewfinder() as HTMLVideoElement | null;
+      expect(video).not.toBeNull();
+      expect(video?.autoplay).toBe(true);
+      expect(video?.muted).toBe(true);
+      expect(video?.hasAttribute("playsinline")).toBe(true);
+      expect(video?.controls).toBe(false);
+      expect(screen.queryByTestId("voice-room-shutter")).not.toBeNull();
+      // Video only. Requesting audio here would renegotiate the microphone the
+      // live-voice session is streaming from. See `voice-camera.ts`.
+      expect(getUserMedia).toHaveBeenCalledTimes(1);
+      expect(getUserMedia.mock.calls[0]?.[0]).toEqual({
+        video: {
+          facingMode: "environment",
+          width: { ideal: 1920 },
+          height: { ideal: 1080 },
+        },
+      });
+      expect(getSettings).toHaveBeenCalledTimes(1);
+      expect(consoleDebug).toHaveBeenCalledWith(
+        "[voice-camera] negotiated video track",
+        {
+          width: 1920,
+          height: 1080,
+          aspectRatio: 16 / 9,
+          frameRate: 30,
+          facingMode: "environment",
+        },
+      );
+      // Opening a camera is not an act on the session itself.
+      expect(controls.stop).not.toHaveBeenCalled();
+      expect(controls.interrupt).not.toHaveBeenCalled();
+    } finally {
+      consoleDebug.mockRestore();
+    }
   });
 
   test("closing the camera leaves the session alone", async () => {

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -76,7 +76,8 @@
  * moment it is taken and runs no turn, so shutter-then-speak and
  * speak-then-shutter behave the same and nothing races the sentence in
  * progress. See `voice-camera.ts` for the capture rules (video-only
- * `getUserMedia`, so the call's audio is never renegotiated) and
+ * native Capacitor preview with a browser-stream fallback, both video-only so
+ * the call's audio is never renegotiated) and
  * `use-voice-room-camera.ts` for the send path, which is the composer's own
  * attachment upload.
  *
@@ -558,6 +559,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
   const body = (
     <motion.div
       ref={roomRef}
+      data-native-voice-camera-chrome
       className={cn(
         "z-50 flex items-center justify-center overflow-hidden",
         // z-50 orders the room's own box against the chat layout for the
@@ -621,7 +623,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
           the room reads identically for a custom avatar bar the full-screen
           color + eyes. Both draw the waves only while `listening`, from live mic
           amplitude. */}
-      {look ? (
+      {!camera.native && look ? (
         // Held back until the box is measured. That is one pre-paint commit, so the
         // entrance still plays from the room's first painted frame, but it
         // grows inside a real rectangle rather than a zero-sized one.
@@ -642,7 +644,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
             viewport={box}
           />
         ) : null
-      ) : (
+      ) : !camera.native ? (
         <>
           <VoiceRoomAmbientBackground />
           {visual === "listening" ? (
@@ -672,15 +674,13 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
             <VoiceStateCaption visual={visual} />
           ) : null}
         </>
-      )}
+      ) : null}
 
-      {/* The viewfinder, when the camera is open.
+      {/* The browser-fallback viewfinder, when the camera is open.
 
-          Full-bleed over the look rather than beside it: the room is one
-          surface at a time, and a camera squeezed into a corner of the avatar
-          would be too small to aim. The look keeps rendering underneath, so
-          closing the camera reveals it already in the right state rather than
-          replaying its entrance.
+          Capacitor mobile shells render their native camera preview behind the
+          transparent web view and need no media element. Browsers and older
+          shells render this full-bleed `<video>` over the look instead.
 
           `z-[2]` puts it above every layer of both looks (the color field and
           the void avatar sit at `z-0`, the giant eyes and the state caption at
@@ -695,11 +695,10 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
           selfie viewfinder on the platform; the rear one is not, because it
           shows the world and a mirrored world is unusable for aiming.
 
-          Muted + playsInline + autoPlay is the combination WebKit requires to
-          play an inline stream without a user gesture per frame; `aria-hidden`
-          because a live camera feed has nothing to announce and the controls
-          below carry the accessible names. */}
-      {cameraOpen ? (
+          Muted + playsInline + autoPlay lets the fallback stream start inline;
+          `aria-hidden` because a live camera feed has nothing to announce and
+          the controls below carry the accessible names. */}
+      {cameraOpen && !camera.native ? (
         <video
           ref={viewfinderRef}
           data-testid="voice-room-viewfinder"
@@ -811,7 +810,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
           owns the one-time entry spring); per-state expression is the avatar's
           own CSS loop, which cross-fades in place without re-popping. The
           color look has no centered figure — the bottom eyes are the cast. */}
-      {!look ? (
+      {!camera.native && !look ? (
         <motion.div
           className="relative z-0"
           {...voidAvatarMotion(choreography.entrance)}

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -22,6 +22,28 @@ body {
   background: var(--surface-base);
 }
 
+/* The Capacitor camera preview is a native layer behind the web view. While it
+ * is active, hide the surrounding app canvas and keep only the voice room's
+ * controls visible over the transparent web view. The eight-digit token also
+ * tells the iOS backdrop bridge to clear safe-area paint around the web view. */
+:root.native-voice-camera-active {
+  --surface-overlay: #00000000;
+  background: transparent;
+}
+
+:root.native-voice-camera-active body,
+:root.native-voice-camera-active #root {
+  background: transparent;
+}
+
+:root.native-voice-camera-active #root {
+  visibility: hidden;
+}
+
+:root.native-voice-camera-active [data-native-voice-camera-chrome] {
+  visibility: visible;
+}
+
 /* Electron prechat onboarding typography — mirror the lighter DM Sans (Swift
  * VFont) weights/sizes so the macOS Electron funnel matches the native Swift
  * client. Scoped via `.electron-prechat-type` (applied ONLY on Electron) so the

--- a/clients/web/src/runtime/native-voice-camera.test.ts
+++ b/clients/web/src/runtime/native-voice-camera.test.ts
@@ -1,0 +1,163 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
+import { Capacitor } from "@capacitor/core";
+import { act, renderHook } from "@testing-library/react";
+
+let nativeMobile = false;
+
+spyOn(Capacitor, "isNativePlatform").mockImplementation(() => nativeMobile);
+spyOn(Capacitor, "getPlatform").mockImplementation(() =>
+  nativeMobile ? "ios" : "web",
+);
+
+const startSpy = mock(async () => {});
+const stopSpy = mock(async () => {});
+const captureSpy = mock(async () => ({ value: "jpeg-base64" }));
+const flipSpy = mock(async () => {});
+
+mock.module("@capacitor-community/camera-preview", () => ({
+  CameraPreview: {
+    start: startSpy,
+    stop: stopSpy,
+    capture: captureSpy,
+    flip: flipSpy,
+  },
+}));
+
+const {
+  NATIVE_VOICE_CAMERA_ACTIVE_CLASS,
+  captureNativeVoiceCameraFrame,
+  flipNativeVoiceCamera,
+  startNativeVoiceCamera,
+  stopNativeVoiceCamera,
+} = await import("@/runtime/native-voice-camera");
+const { useVoiceCamera } =
+  await import("@/domains/chat/voice/voice-room/voice-camera");
+
+beforeEach(() => {
+  nativeMobile = false;
+  startSpy.mockClear();
+  stopSpy.mockClear();
+  captureSpy.mockClear();
+  flipSpy.mockClear();
+  startSpy.mockImplementation(async () => {});
+  stopSpy.mockImplementation(async () => {});
+  captureSpy.mockImplementation(async () => ({ value: "jpeg-base64" }));
+  flipSpy.mockImplementation(async () => {});
+  document.documentElement.classList.remove(
+    NATIVE_VOICE_CAMERA_ACTIVE_CLASS,
+  );
+});
+
+afterEach(() => {
+  nativeMobile = false;
+  document.documentElement.classList.remove(
+    NATIVE_VOICE_CAMERA_ACTIVE_CLASS,
+  );
+});
+
+describe("native voice camera", () => {
+  test("does not call the plugin outside a native mobile shell", async () => {
+    expect(await startNativeVoiceCamera("environment")).toBe(false);
+    expect(startSpy).not.toHaveBeenCalled();
+    expect(
+      document.documentElement.classList.contains(
+        NATIVE_VOICE_CAMERA_ACTIVE_CLASS,
+      ),
+    ).toBe(false);
+  });
+
+  test("starts a video-only native high-resolution preview", async () => {
+    nativeMobile = true;
+
+    expect(await startNativeVoiceCamera("environment")).toBe(true);
+    expect(startSpy).toHaveBeenCalledWith({
+      position: "rear",
+      toBack: true,
+      storeToFile: false,
+      enableHighResolution: true,
+      disableAudio: true,
+      enableZoom: true,
+    });
+    expect(
+      document.documentElement.classList.contains(
+        NATIVE_VOICE_CAMERA_ACTIVE_CLASS,
+      ),
+    ).toBe(true);
+  });
+
+  test("clears the native layer marker when an older shell rejects start", async () => {
+    nativeMobile = true;
+    const debugSpy = spyOn(console, "debug").mockImplementation(() => {});
+    startSpy.mockImplementation(async () => {
+      throw new Error("plugin unavailable");
+    });
+
+    expect(await startNativeVoiceCamera("user")).toBe(false);
+    expect(startSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ position: "front", disableAudio: true }),
+    );
+    expect(
+      document.documentElement.classList.contains(
+        NATIVE_VOICE_CAMERA_ACTIVE_CLASS,
+      ),
+    ).toBe(false);
+    debugSpy.mockRestore();
+  });
+
+  test("captures, flips, and stops through the native bridge", async () => {
+    nativeMobile = true;
+    document.documentElement.classList.add(
+      NATIVE_VOICE_CAMERA_ACTIVE_CLASS,
+    );
+
+    expect(await captureNativeVoiceCameraFrame(85)).toBe("jpeg-base64");
+    expect(captureSpy).toHaveBeenCalledWith({ quality: 85 });
+    expect(await flipNativeVoiceCamera()).toBe(true);
+    expect(flipSpy).toHaveBeenCalledTimes(1);
+
+    await stopNativeVoiceCamera();
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+    expect(
+      document.documentElement.classList.contains(
+        NATIVE_VOICE_CAMERA_ACTIVE_CLASS,
+      ),
+    ).toBe(false);
+  });
+
+  test("drives the voice camera hook without an HTML video stream", async () => {
+    nativeMobile = true;
+    captureSpy.mockImplementation(async () => ({ value: "AQID" }));
+    const videoRef: { current: HTMLVideoElement | null } = { current: null };
+    const { result, unmount } = renderHook(() => useVoiceCamera(videoRef));
+
+    await act(async () => {
+      await result.current.openCamera();
+    });
+    expect(result.current.open).toBe(true);
+    expect(result.current.native).toBe(true);
+    expect(startSpy).toHaveBeenCalledTimes(1);
+
+    const photo = await result.current.captureFrame();
+    expect(photo?.name).toBe("photo-1.jpg");
+    expect(photo?.size).toBe(3);
+
+    await act(async () => {
+      await result.current.flipCamera();
+    });
+    expect(result.current.facing).toBe("user");
+
+    act(() => result.current.closeCamera());
+    expect(result.current.open).toBe(false);
+    expect(result.current.native).toBe(false);
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+});

--- a/clients/web/src/runtime/native-voice-camera.ts
+++ b/clients/web/src/runtime/native-voice-camera.ts
@@ -1,0 +1,80 @@
+/**
+ * Native camera preview bridge for the voice room.
+ *
+ * The native preview is inserted behind the Capacitor web view. The root class
+ * makes the web canvas transparent while the voice room keeps its controls in
+ * front. Calls are intentionally failure-tolerant because a newly deployed web
+ * bundle can run inside an older installed shell that does not have this plugin.
+ */
+
+import { CameraPreview } from "@capacitor-community/camera-preview";
+
+import { callNativeVoice } from "@/runtime/native-voice";
+import { isNativeMobile } from "@/runtime/platform-detection";
+
+export type NativeVoiceCameraFacing = "environment" | "user";
+
+export const NATIVE_VOICE_CAMERA_ACTIVE_CLASS =
+  "native-voice-camera-active";
+
+function setPreviewVisible(visible: boolean): void {
+  if (typeof document === "undefined") {
+    return;
+  }
+  document.documentElement.classList.toggle(
+    NATIVE_VOICE_CAMERA_ACTIVE_CLASS,
+    visible,
+  );
+}
+
+/** Start the native preview, or return false when this shell cannot provide it. */
+export async function startNativeVoiceCamera(
+  facing: NativeVoiceCameraFacing,
+): Promise<boolean> {
+  if (!isNativeMobile()) {
+    return false;
+  }
+
+  setPreviewVisible(true);
+  const started = await callNativeVoice(async () => {
+    await CameraPreview.start({
+      position: facing === "environment" ? "rear" : "front",
+      toBack: true,
+      storeToFile: false,
+      enableHighResolution: true,
+      disableAudio: true,
+      enableZoom: true,
+    });
+    return true;
+  }, false);
+  if (!started) {
+    setPreviewVisible(false);
+  }
+  return started;
+}
+
+/** Stop the native preview. Safe when the plugin is absent or already stopped. */
+export async function stopNativeVoiceCamera(): Promise<void> {
+  setPreviewVisible(false);
+  await callNativeVoice(async () => {
+    await CameraPreview.stop();
+  }, undefined);
+}
+
+/** Capture a native JPEG as base64, or null when capture fails. */
+export async function captureNativeVoiceCameraFrame(
+  quality: number,
+): Promise<string | null> {
+  return callNativeVoice(async () => {
+    const { value } = await CameraPreview.capture({ quality });
+    return value || null;
+  }, null);
+}
+
+/** Flip the active native camera, returning whether the switch succeeded. */
+export async function flipNativeVoiceCamera(): Promise<boolean> {
+  return callNativeVoice(async () => {
+    await CameraPreview.flip();
+    return true;
+  }, false);
+}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "path-to-regexp": "8.4.2"
   },
   "patchedDependencies": {
-    "storybook@10.4.0": "patches/storybook@10.4.0.patch"
+    "storybook@10.4.0": "patches/storybook@10.4.0.patch",
+    "@capacitor-community/camera-preview@8.0.1": "patches/@capacitor-community%2Fcamera-preview@8.0.1.patch"
   }
 }

--- a/patches/@capacitor-community%2Fcamera-preview@8.0.1.patch
+++ b/patches/@capacitor-community%2Fcamera-preview@8.0.1.patch
@@ -1,0 +1,45 @@
+diff --git a/Package.swift b/Package.swift
+index 50e325e84c01305ac5b7a909856b56662eeb6ea7..a7a049147a7d182d60c1e84f291c036b32e05cf2 100644
+--- a/Package.swift
++++ b/Package.swift
+@@ -10,7 +10,7 @@ let package = Package(
+             targets: ["CameraPreviewPlugin"])
+     ],
+     dependencies: [
+-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.2")
++        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.3.4")
+     ],
+     targets: [
+         .target(
+diff --git a/android/src/main/java/com/ahm/capacitor/camera/preview/CameraPreview.java b/android/src/main/java/com/ahm/capacitor/camera/preview/CameraPreview.java
+index 854aeee57dc88c115e6e294af1a5a8866d10d30c..cf23806dec64d1023d3d06e8f87a94ad859e44f2 100644
+--- a/android/src/main/java/com/ahm/capacitor/camera/preview/CameraPreview.java
++++ b/android/src/main/java/com/ahm/capacitor/camera/preview/CameraPreview.java
+@@ -126,7 +126,10 @@ public class CameraPreview extends Plugin implements CameraActivity.CameraPrevie
+ 
+                         if (containerView != null) {
+                             ((ViewGroup) getBridge().getWebView().getParent()).removeView(containerView);
+-                            getBridge().getWebView().setBackgroundColor(Color.WHITE);
++                            // The web app paints its own theme. Keeping the
++                            // WebView transparent avoids a white flash when a
++                            // dark room closes the native preview.
++                            getBridge().getWebView().setBackgroundColor(Color.TRANSPARENT);
+                             FragmentManager fragmentManager = getActivity().getFragmentManager();
+                             FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
+                             if (fragment != null) {
+diff --git a/ios/Sources/CameraPreviewPlugin/CameraPreviewPlugin.swift b/ios/Sources/CameraPreviewPlugin/CameraPreviewPlugin.swift
+index aa18ca78d0d73ceceeae4eee2d23a83a802bab03..42eb0bd7f8619da07f32d12ab9c5989c389d4ac7 100644
+--- a/ios/Sources/CameraPreviewPlugin/CameraPreviewPlugin.swift
++++ b/ios/Sources/CameraPreviewPlugin/CameraPreviewPlugin.swift
+@@ -171,7 +171,10 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin {
+                     previewView.removeFromSuperview()
+                     self.previewView = nil
+                 }
+-                self.webView?.isOpaque = true
++                // Vellum's WKWebView stays non-opaque so its native safe-area
++                // backdrop can track the active web theme after the preview is
++                // removed.
++                self.webView?.isOpaque = false
+                 call.resolve()
+             } else {
+                 call.reject("camera already stopped")

--- a/patches/@capacitor-community%2Fcamera-preview@8.0.1.patch
+++ b/patches/@capacitor-community%2Fcamera-preview@8.0.1.patch
@@ -43,3 +43,16 @@ index aa18ca78d0d73ceceeae4eee2d23a83a802bab03..42eb0bd7f8619da07f32d12ab9c5989c
                  call.resolve()
              } else {
                  call.reject("camera already stopped")
+@@ -207,9 +210,10 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin {
+                     return
+                 }
+                 let imageData: Data?
++                let compression = CGFloat(quality ?? 85) / 100.0
+                 if self.cameraController.currentCameraPosition == .front {
+                     let flippedImage = image.withHorizontallyFlippedOrientation()
+-                    imageData = flippedImage.jpegData(compressionQuality: CGFloat(quality!/100))
++                    imageData = flippedImage.jpegData(compressionQuality: compression)
+                 } else {
+-                    imageData = image.jpegData(compressionQuality: CGFloat(quality!/100))
++                    imageData = image.jpegData(compressionQuality: compression)
+                 }


### PR DESCRIPTION
## Summary

- use `@capacitor-community/camera-preview` for the voice-room camera on Capacitor iOS and Android
- keep desktop web, Electron, and older native shells on a video-only `getUserMedia` fallback with ideal 1920 by 1080 constraints and negotiated-track diagnostics
- render the native preview behind a transparent web view while preserving the voice-room controls, camera flip, and JPEG attachment flow
- add native permissions, synced Capacitor dependencies, and a dependency patch that preserves the app theme when the preview stops

## Why

The voice-room viewfinder used an HTML `<video>` backed by `getUserMedia` on every surface. On iOS this produced a softer preview and exposed WebKit media playback behavior, including a centered play/pause affordance. Native mobile shells should use the platform capture session directly while leaving the existing live-voice microphone session untouched.

The native path requests video only with `disableAudio: true`. Browsers and installed shells that predate the plugin continue to work through the existing web fallback.

## User impact

On physical iOS and Android devices, the voice-room camera opens as a native preview without an HTML media element or playback state. Browser and Electron behavior remains compatible and requests a sharper stream where supported.

## Validation

- `clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx`: 98 tests passed
- `clients/web/src/runtime/native-voice-camera.test.ts`: 5 tests passed
- scoped web ESLint passed
- full web TypeScript check passed
- web production build passed
- iOS App Dev simulator build passed and the native preview rendered with the Simulator's synthetic camera source
- Android Capacitor sync passed

Physical-device camera quality and permission behavior still need a final iPhone smoke test. An Android Gradle build was not run locally because this machine does not have a JDK installed.