### PR TITLE
fix(web): read the Preferences trigger's collapsed state from the rail (LUM-3061)

### DIFF
--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -934,7 +934,6 @@ export function ChatLayout({
           assistantVersion={assistantVersion}
           activeConversationId={activeConversationId}
           triggerVariant={args.variant === "overlay" ? "pill" : "item"}
-          collapsed={args.collapsed}
         />
       }
       // The overlay subtree mounts mid edge-swipe while still off-screen;

--- a/clients/web/src/domains/chat/components/assistant-nav-item.tsx
+++ b/clients/web/src/domains/chat/components/assistant-nav-item.tsx
@@ -47,6 +47,20 @@ import { eyeStyleBaseWidth } from "@/utils/assistant-eyes";
 import { contrastForeground } from "@/utils/avatar-tone";
 import { pathBBox, unionBBox } from "@/utils/eye-bbox";
 
+/**
+ * The identity pill's own geometry, taller than the pills below it.
+ *
+ * This row is the assistant rather than an entry in a list, and on the tinted
+ * path it is the only row carrying the avatar's colour: at the shared 32px it
+ * reads as the first of several chips instead of the thing they hang off. The
+ * label keeps its position, so this row and New Chat still start on one axis
+ * and only the surface around it grows.
+ *
+ * Shared by both branches below, because an assistant with no character avatar
+ * is still the assistant: the colour is the only thing that should differ.
+ */
+const IDENTITY_PILL_CLASSES = "h-10";
+
 /** Collapsed-rail assistant tile height (Figma 7257:135820). */
 /* Matches the circle `SideMenu.Item` and the section triggers render on the
    rail: every tile there is the same 30px circle, so one step runs the whole
@@ -334,10 +348,12 @@ export function AssistantNavItem({
           </button>
         ) : (
           /* No character avatar, so nothing declares the tint properties and
-             the pill wears its plain surface. Same component as the tinted
-             one below: the colour is the only difference between them. */
+             the pill wears its plain surface. Same component and same
+             geometry as the tinted one below: the colour is the only
+             difference between them. */
           <PanelItem
             shape="pill"
+            className={IDENTITY_PILL_CLASSES}
             icon={Brain}
             leadingSlot={avatarImage ?? undefined}
             label={label}
@@ -475,6 +491,7 @@ export function AssistantNavItem({
     <span style={tintStyle}>
       <PanelItem
         shape="pill"
+        className={IDENTITY_PILL_CLASSES}
         leadingSlot={eyesSlot}
         label={label}
         active={active}

--- a/clients/web/src/domains/chat/components/assistant-nav-item.tsx
+++ b/clients/web/src/domains/chat/components/assistant-nav-item.tsx
@@ -48,16 +48,13 @@ import { contrastForeground } from "@/utils/avatar-tone";
 import { pathBBox, unionBBox } from "@/utils/eye-bbox";
 
 /**
- * The identity pill's own geometry, taller than the pills below it.
+ * Taller than the pills below it: this row is the assistant, not an entry in a
+ * list, and at their shared height it reads as the first of several chips
+ * rather than the thing they hang off. Height only, so the label stays on the
+ * axis it shares with New Chat.
  *
- * This row is the assistant rather than an entry in a list, and on the tinted
- * path it is the only row carrying the avatar's colour: at the shared 32px it
- * reads as the first of several chips instead of the thing they hang off. The
- * label keeps its position, so this row and New Chat still start on one axis
- * and only the surface around it grows.
- *
- * Shared by both branches below, because an assistant with no character avatar
- * is still the assistant: the colour is the only thing that should differ.
+ * One constant for both branches below, because an assistant with no character
+ * avatar is still the assistant: colour is the only thing that differs.
  */
 const IDENTITY_PILL_CLASSES = "h-10";
 

--- a/clients/web/src/domains/chat/components/assistant-side-menu.stories.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.stories.tsx
@@ -328,7 +328,7 @@ export const CollapsedRail: Story = {
     ...SHARED_ARGS,
     assistantId: "asst-collapsed",
     collapsed: true,
-    footerAction: <PreferencesMenu assistantId="asst-story" collapsed />,
+    footerAction: <PreferencesMenu assistantId="asst-story" />,
   },
 };
 
@@ -343,7 +343,7 @@ export const CollapsedRailAllView: Story = {
     ...SHARED_ARGS,
     assistantId: "asst-collapsed-all",
     collapsed: true,
-    footerAction: <PreferencesMenu assistantId="asst-story" collapsed />,
+    footerAction: <PreferencesMenu assistantId="asst-story" />,
   },
 };
 
@@ -391,7 +391,7 @@ export const UploadedImageAvatarCollapsed: Story = {
     assistantId: "asst-image",
     assistantName: "Haze II",
     collapsed: true,
-    footerAction: <PreferencesMenu assistantId="asst-story" collapsed />,
+    footerAction: <PreferencesMenu assistantId="asst-story" />,
   },
 };
 

--- a/clients/web/src/domains/chat/components/preferences-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/preferences-menu.test.tsx
@@ -213,14 +213,16 @@ describe("PreferencesMenu", () => {
      its glyph, the same affordance the pinned apps and section tiles reduce
      to.
 
-     Mounted inside a collapsed `SideMenu` because `shape="tile"` reads the
-     rail's state from that context; outside one it is an ordinary row, so a
-     bare render would assert nothing about the rail. */
+     The collapsed `SideMenu` is the whole input: the trigger reads the rail's
+     state from that context and takes no prop for it, so this renders the
+     component the way the sidebar does and cannot pass a value the menu
+     disagrees with. Outside a rail it is an ordinary row, so a bare render
+     would assert nothing. */
   function collapsedRailMarkup(): string {
     return renderToStaticMarkup(
       <SideMenu ariaLabel="Assistant navigation" variant="rail" collapsed>
         <SideMenu.Footer>
-          <PreferencesMenu collapsed />
+          <PreferencesMenu />
         </SideMenu.Footer>
       </SideMenu>,
     );

--- a/clients/web/src/domains/chat/components/preferences-menu.tsx
+++ b/clients/web/src/domains/chat/components/preferences-menu.tsx
@@ -15,6 +15,7 @@ import {
   PanelItem,
   Popover,
   SideMenu,
+  useSideMenuCollapsed,
 } from "@vellumai/design-library";
 
 import { LazyBoundary } from "@/components/lazy-boundary";
@@ -55,12 +56,6 @@ export interface PreferencesMenuProps {
    * `pill` is a floating rounded button for the mobile overlay's action row.
    */
   triggerVariant?: "item" | "pill";
-  /**
-   * The rail is collapsed, so the `item` trigger reduces to the icon-only
-   * tile every other rail entry reduces to. Ignored by the `pill` variant,
-   * which only ever renders on the mobile overlay.
-   */
-  collapsed?: boolean;
 }
 
 export function PreferencesMenu({
@@ -68,8 +63,15 @@ export function PreferencesMenu({
   assistantVersion,
   activeConversationId,
   triggerVariant = "item",
-  collapsed = false,
 }: PreferencesMenuProps) {
+  /* Read from the menu this sits in rather than taken as a prop. The trigger
+     has to reduce to a tile at the same moment every other rail entry does,
+     and a prop is a second derivation of that one fact: the caller threading
+     it can hold a different value from the menu rendering around it, and the
+     footer then draws a labelled pill into a 48px column. Ignored by the
+     `pill` variant, which only ever renders on the mobile overlay, where the
+     hook reports false anyway. */
+  const collapsed = useSideMenuCollapsed();
   const isAuthenticated = useIsAuthenticated();
   const isMobile = useIsMobile();
   const [isOpen, setIsOpen] = useState(false);

--- a/clients/web/src/domains/chat/components/preferences-menu.tsx
+++ b/clients/web/src/domains/chat/components/preferences-menu.tsx
@@ -64,13 +64,11 @@ export function PreferencesMenu({
   activeConversationId,
   triggerVariant = "item",
 }: PreferencesMenuProps) {
-  /* Read from the menu this sits in rather than taken as a prop. The trigger
-     has to reduce to a tile at the same moment every other rail entry does,
-     and a prop is a second derivation of that one fact: the caller threading
-     it can hold a different value from the menu rendering around it, and the
-     footer then draws a labelled pill into a 48px column. Ignored by the
-     `pill` variant, which only ever renders on the mobile overlay, where the
-     hook reports false anyway. */
+  /* From the menu rather than a prop: this trigger has to reduce to a tile at
+     the same moment every other rail entry does, and a threaded prop is that
+     one fact derived twice, free to disagree with the menu rendering around
+     it. The `pill` variant ignores it, and only renders on the overlay, where
+     it reads false regardless. */
   const collapsed = useSideMenuCollapsed();
   const isAuthenticated = useIsAuthenticated();
   const isMobile = useIsMobile();

--- a/packages/design-library/src/components/side-menu/side-menu.test.tsx
+++ b/packages/design-library/src/components/side-menu/side-menu.test.tsx
@@ -10,7 +10,7 @@ import { Globe } from "lucide-react";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
-import { SideMenu } from "./side-menu";
+import { SideMenu, useSideMenuCollapsed } from "./side-menu";
 
 describe("SideMenu root", () => {
   test("renders a <nav> with the provided aria-label and data-slot", () => {
@@ -675,5 +675,52 @@ describe("SideMenu.Item collapsed accessible name", () => {
     );
     expect(html).not.toContain('aria-label="Pinned"');
     expect(html).toContain(">Pinned<");
+  });
+});
+
+describe("useSideMenuCollapsed", () => {
+  /* Reports what a slot's own trigger has to render as. Exercised through a
+     real `SideMenu` rather than a stubbed context, because the value a caller
+     needs is the one the menu actually publishes. */
+  function Probe() {
+    return createElement("span", null, String(useSideMenuCollapsed()));
+  }
+
+  function probeInside(props: {
+    variant?: "rail" | "overlay";
+    collapsed?: boolean;
+  }): string {
+    return renderToStaticMarkup(
+      createElement(
+        SideMenu,
+        { ariaLabel: "Navigation", ...props },
+        createElement(SideMenu.Footer, null, createElement(Probe, null)),
+      ),
+    );
+  }
+
+  test("true inside a collapsed rail", () => {
+    expect(probeInside({ variant: "rail", collapsed: true })).toContain("true");
+  });
+
+  test("false inside an expanded rail", () => {
+    expect(probeInside({ variant: "rail", collapsed: false })).toContain(
+      "false",
+    );
+  });
+
+  /* The overlay ignores `collapsed` and always shows labels, so a slot must
+     not reduce its trigger to a tile there even when the flag is set. */
+  test("false on the overlay even when collapsed is set", () => {
+    expect(probeInside({ variant: "overlay", collapsed: true })).toContain(
+      "false",
+    );
+  });
+
+  /* Rendered outside any `SideMenu`, which is what a consumer mounted in
+     isolation (a test, a story of the trigger alone) does. The default context
+     answers rather than throwing, so such a caller gets the expanded form. */
+  test("false with no SideMenu above it", () => {
+    expect(renderToStaticMarkup(createElement(Probe, null))).toContain("false");
   });
 });

--- a/packages/design-library/src/components/side-menu/side-menu.tsx
+++ b/packages/design-library/src/components/side-menu/side-menu.tsx
@@ -90,6 +90,21 @@ function isCollapsingRail(ctx: SideMenuContextValue): boolean {
   return ctx.variant === "rail" && ctx.collapsed;
 }
 
+/**
+ * Whether a rail entry should render in its collapsed form, for the entries
+ * this package does not draw itself.
+ *
+ * A caller supplying its own trigger through a slot needs the same answer
+ * `SideMenu.Item` gets, and it has to be the delayed one: the lag is what
+ * keeps a label from painting into a rail that is still narrowing around it.
+ * Reading it here rather than accepting it as a prop is what keeps the slot's
+ * content from disagreeing with the menu it sits in, since the two cannot then
+ * be derived from different sources.
+ */
+function useSideMenuCollapsed(): boolean {
+  return isCollapsedRail(useSideMenuContext());
+}
+
 // ---------------------------------------------------------------------------
 // Root
 // ---------------------------------------------------------------------------
@@ -908,4 +923,5 @@ export {
   SideMenuSection,
   SideMenuSeparator,
   SideMenuSubList,
+  useSideMenuCollapsed,
 };

--- a/packages/design-library/src/index.ts
+++ b/packages/design-library/src/index.ts
@@ -191,6 +191,7 @@ export {
   SideMenuSection,
   SideMenuSeparator,
   SideMenuSubList,
+  useSideMenuCollapsed,
   SIDE_MENU_DEFAULT_WIDTH,
   SIDE_MENU_COLLAPSED_WIDTH,
   SIDE_MENU_MIN_WIDTH,


### PR DESCRIPTION
## TL;DR

The Preferences footer trigger derived `collapsed` from a prop while every other rail entry reads it from the `SideMenu` context. Removes the prop so there is one source of truth, and makes the story and unit test exercise production's path instead of their own.

Also gives the assistant identity pill its own height (32px to 40px).

## Before / after

| | Before | After |
|---|---|---|
| Preferences collapse state | `collapsed` prop threaded from `chat-layout` | read from the `SideMenu` context, same as every sibling |
| Story wiring | passed `collapsed` by hand | passes nothing; derives it like the app |
| Unit test | passed `collapsed` **and** mounted a collapsed rail | mounts the rail only, so the context path is what is asserted |
| Identity pill | 32px, same as the pills below it | 40px, label still on the shared x-axis |

## The actual defect

One fact derived twice. `SideMenu` already publishes the answer through context, and `SideMenu.Item` reads it; the footer slot's content took it as a prop instead. Anything that can be derived in two places can disagree in two places, and the failure mode is a labelled pill rendered into a 48px column.

`SideMenu` now exports `useSideMenuCollapsed()`, returning the same delayed `contentCollapsed` answer `isCollapsedRail` gives its own items. Delayed on purpose: the lag is what stops a label painting into a rail that is still narrowing.

**Why this is the fix rather than correcting the prop's value:** with the prop deleted there is nothing left to pass wrongly. Correcting a value leaves the second derivation in place.

## Why the story could not have caught this

The collapsed stories did this:

```tsx
footerAction: <PreferencesMenu assistantId="asst-story" collapsed />
```

The story was playing `chat-layout`'s role, hardcoding the value production has to derive. So it validated its own wiring, and the sidebar could look right in Storybook while the app was wrong. The unit test had the same shape: it mounted a collapsed `SideMenu` **and** passed the prop, so it never proved the context path worked.

Both now pass nothing. The test's input is the collapsed rail alone.

## Verified in Storybook

Measured in the DOM rather than eyeballed, with no `collapsed` prop anywhere in the tree:

- **Collapsed rail:** the trigger is a **30x30 tile**, `size-[30px] mx-auto rounded-full`, no label. It can only reach that shape through the context.
- **Expanded:** identity pill **40px**, the pills below it **32px**, and every label still starts at **x=16** so the cluster's shared axis is intact. An earlier `px-3` broke that alignment by 4px and was dropped.

## Known gap this surfaced, not fixed here

Storybook has no avatar, so the identity row always renders its **plain fallback**, never the avatar-tinted pill with the eyes. The sidebar's most distinctive element has never been reviewable there, which is why the height change had to be applied to both branches to be visible at all. Filing separately.

## Testing

Typecheck and lint clean across `clients/web` and `packages/design-library`. The existing collapsed-rail assertions in `preferences-menu.test.tsx` now cover the context path, since that is the only path left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40482" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->