### PR TITLE
fix(web): restore OpenAPI sync cursor clobbered by #39887

### DIFF
--- a/clients/web/openapi-schemas/platform-source.json
+++ b/clients/web/openapi-schemas/platform-source.json
@@ -1,4 +1,4 @@
 {
   "sourceRepo": "vellum-ai/vellum-assistant-platform",
-  "sourceSha": "71c5c29d09c776be1ef799797eed500dde04d8e0"
+  "sourceSha": "971fa01b044a5a8e2c5e1fd09c92798eb883b5ad"
 }


### PR DESCRIPTION
## Summary
One-line root-cause fix for the dead spec-sync automation.

`platform-source.json` pointed at platform SHA `71c5c29d09c7`, which **does not exist in the platform repo** — an orphaned pre-squash branch SHA committed as a side effect of #39887 (Aug 3). The `sync-openapi-to-oss` workflow's "don't move specs backwards" guard treats an unknown SHA as non-ancestor, so every run since Jul 31 has silently skipped (workflow still reports success; see the warning annotation on platform run 31204548497).

This restores the cursor to the last legitimately synced platform main commit — `971fa01b044a5a8e2c5e1fd09c92798eb883b5ad`, the source of the Jul 31 automated sync (#39716). No spec content changes here.

## After merging
Re-dispatch **Sync OpenAPI specs to OSS repo** in the platform repo (`gh workflow run sync-openapi-to-oss.yaml --repo vellum-ai/vellum-assistant-platform`). It will open a fresh automated sync PR carrying the five merges of accumulated spec drift (checkout-bonus endpoint, top-up `return_target`, grant-expiry fields on `BillingSummaryResponse`).

**Heads-up on that sync PR**: it will fail typecheck as opened — the new required `BillingSummaryResponse` fields (`credits_expiring_soon_usd`, `next_credit_expiry_at`) need two test fixtures updated (`daily-credit-limit-card.test.tsx`, `use-billing-balance-status.test.ts`). The fixture fix is ready and will be pushed onto the automated sync branch once it opens (it can't land ahead of the spec — excess-property checks reject the fields until the type has them).

Suggested follow-up (separate): make the sync workflow fail or alert when the cursor guard trips — five weeks of silent skips is how this drift accumulated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014NwUzAHTToiXxfS1t4k8HA