### PR TITLE
fix(persistence): skip unfinalized rows when forking a conversation

### DIFF
--- a/assistant/src/__tests__/conversation-fork-crud.test.ts
+++ b/assistant/src/__tests__/conversation-fork-crud.test.ts
@@ -1794,3 +1794,72 @@ describe("forkConversation + memory_retrospective_state", () => {
     expect(fork.slackContextCompactionWatermarkAt).toBe(compactedAt);
   });
 });
+
+describe("forkConversation with unfinalized rows", () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test("skips unfinalized rows and anchors the fork at the last finalized message", async () => {
+    const source = createConversation("Mid-turn fork");
+    await addMessage(source.id, "user", "question", { skipIndexing: true });
+    const lastFinalized = await addMessage(
+      source.id,
+      "assistant",
+      "completed reply",
+      { skipIndexing: true },
+    );
+    const streaming = await addMessage(
+      source.id,
+      "assistant",
+      "partial reply still being written",
+      { skipIndexing: true },
+    );
+    rawRun(
+      "test:markUnfinalized",
+      "UPDATE messages SET finalized = 0 WHERE id = ?",
+      streaming.id,
+    );
+
+    const fork = forkConversation({ conversationId: source.id });
+    const forkMessages = getMessages(fork.id);
+
+    // The invariant, not mere presence: exactly the finalized rows were
+    // copied, every copy reads as finalized, no copy descends from the
+    // unfinalized source row, and the lineage anchor is a row the fork
+    // actually holds.
+    expect(forkMessages).toHaveLength(2);
+    expect(forkMessages.every((row) => row.finalized === 1)).toBe(true);
+    const forkedFromIds = forkMessages.map(
+      (row) =>
+        (parseMetadata(row.metadata) as { forkSourceMessageId?: string })
+          ?.forkSourceMessageId,
+    );
+    expect(forkedFromIds).not.toContain(streaming.id);
+    expect(fork.forkParentMessageId).toBe(lastFinalized.id);
+    // The source still owns its in-flight row untouched.
+    expect(getMessages(source.id)).toHaveLength(3);
+  });
+
+  test("a stale mid-history unfinalized row is skipped without shifting the anchor", async () => {
+    const source = createConversation("Stale row fork");
+    await addMessage(source.id, "user", "first", { skipIndexing: true });
+    const stale = await addMessage(source.id, "assistant", "orphaned partial", {
+      skipIndexing: true,
+    });
+    const tail = await addMessage(source.id, "user", "latest", {
+      skipIndexing: true,
+    });
+    rawRun(
+      "test:markUnfinalized",
+      "UPDATE messages SET finalized = 0 WHERE id = ?",
+      stale.id,
+    );
+
+    const fork = forkConversation({ conversationId: source.id });
+    const forkMessages = getMessages(fork.id);
+
+    expect(forkMessages).toHaveLength(2);
+    expect(fork.forkParentMessageId).toBe(tail.id);
+  });
+});

--- a/assistant/src/__tests__/conversation-fork-referential.test.ts
+++ b/assistant/src/__tests__/conversation-fork-referential.test.ts
@@ -350,3 +350,70 @@ describe("referential forking", () => {
     expect(textOf(getMessages(source.id))).toHaveLength(4);
   });
 });
+
+describe("referential forking with unfinalized rows", () => {
+  beforeEach(() => {
+    resetTables();
+    clearConfig();
+  });
+
+  test("ancestor rows are hidden while unfinalized and appear once finalized", async () => {
+    const source = await seedSource("Launch");
+    const midRow = getMessages(source.id)[1]!;
+    getDb()
+      .update(messages)
+      .set({ finalized: 0 })
+      .where(eq(messages.id, midRow.id))
+      .run();
+
+    setForkStrategy("reference");
+    const fork = await forkConversationForRetrospective({
+      conversationId: source.id,
+    });
+
+    // The fork's lineage read excludes the ancestor's in-flight row; the
+    // source's own read keeps it.
+    expect(textOf(getMessages(fork.id))).toEqual([
+      "draft a launch plan",
+      "tweak the timeline",
+      "updated",
+    ]);
+    expect(getMessages(source.id)).toHaveLength(4);
+
+    getDb()
+      .update(messages)
+      .set({ finalized: 1 })
+      .where(eq(messages.id, midRow.id))
+      .run();
+
+    // Once the row finalizes it enters the inherited window on its own.
+    expect(textOf(getMessages(fork.id))).toEqual([
+      "draft a launch plan",
+      "here is a first pass",
+      "tweak the timeline",
+      "updated",
+    ]);
+  });
+
+  test("an unfinalized tail is not the fork anchor", async () => {
+    const source = await seedSource("Launch");
+    const tail = getMessages(source.id).at(-1)!;
+    getDb()
+      .update(messages)
+      .set({ finalized: 0 })
+      .where(eq(messages.id, tail.id))
+      .run();
+
+    setForkStrategy("reference");
+    const fork = await forkConversationForRetrospective({
+      conversationId: source.id,
+    });
+
+    expect(fork.forkParentMessageId).not.toBe(tail.id);
+    expect(textOf(getMessages(fork.id))).toEqual([
+      "draft a launch plan",
+      "here is a first pass",
+      "tweak the timeline",
+    ]);
+  });
+});

--- a/assistant/src/__tests__/conversation-fork-retrospective.test.ts
+++ b/assistant/src/__tests__/conversation-fork-retrospective.test.ts
@@ -723,3 +723,27 @@ describe("forkConversationForRetrospective — compacted source", () => {
     });
   });
 });
+
+describe("forkConversationForRetrospective with unfinalized rows", () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test("skips the unfinalized tail and anchors at the last finalized message", async () => {
+    const source = await seedSource("Mid-turn retro");
+    const tail = getMessages(source.id).at(-1)!;
+    const db = getDb();
+    db.run(`UPDATE messages SET finalized = 0 WHERE id = '${tail.id}'`);
+
+    const fork = await forkConversationForRetrospective({
+      conversationId: source.id,
+    });
+    const forkMessages = getMessages(fork.id);
+
+    // Invariant: only finalized rows are copied, and the lineage anchor is a
+    // row the fork actually holds.
+    expect(forkMessages).toHaveLength(3);
+    expect(forkMessages.every((row) => row.finalized === 1)).toBe(true);
+    expect(fork.forkParentMessageId).not.toBe(tail.id);
+  });
+});

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -498,6 +498,25 @@ export function parseMessageMetadata(
   }
 }
 
+/**
+ * Rows a fork may copy: finalized ones. A `finalized = 0` row is mid-write,
+ * its content a `{ ref }` into the source turn's in-flight delta file, which
+ * the source deletes when the turn completes. A copied row would point at a
+ * file another conversation is about to delete, leaving a permanently empty
+ * message that reads as final and is invisible to crash recovery (which scans
+ * `finalized = 0` only). Unfinalized is not "unsent": the message was sent
+ * and is still being written, so there is no completed content to copy. A
+ * fork reflects the conversation at a completed point.
+ *
+ * Callers apply this to `messagesToCopy` itself, upstream of the boundary
+ * timestamp, compaction inheritance, `forkParentMessageId`, and the id map,
+ * so every derivation describes the rows actually copied and the lineage
+ * anchor can never reference a row the fork does not hold.
+ */
+function dropUnfinalizedRows(rows: MessageRow[]): MessageRow[] {
+  return rows.filter((message) => message.finalized === 1);
+}
+
 function cloneForkMessageMetadata(
   metadata: string | null,
   sourceMessageId: string,
@@ -1336,7 +1355,7 @@ export function forkConversation(params: {
 
   const messagesToCopy =
     copyBoundaryIndex >= 0
-      ? sourceMessages.slice(0, copyBoundaryIndex + 1)
+      ? dropUnfinalizedRows(sourceMessages.slice(0, copyBoundaryIndex + 1))
       : ([] as MessageRow[]);
 
   // Inherit the history-strip marker only when the fork boundary is at-or-
@@ -1461,7 +1480,13 @@ export function forkConversation(params: {
       messagesToCopy,
       forkedMessageIds,
       latestForkedAssistant,
-      isFullHistoryFork: copyBoundaryIndex === sourceMessages.length - 1,
+      // The wholesale memory-state carry requires the fork's window to equal
+      // the source's rendered window; a boundary at the tip no longer
+      // guarantees that when the unfinalized filter dropped rows from the
+      // slice, so both conditions gate it.
+      isFullHistoryFork:
+        copyBoundaryIndex === sourceMessages.length - 1 &&
+        messagesToCopy.length === copyBoundaryIndex + 1,
       inheritedCompactedMessageCount:
         inheritedCompaction?.compactedMessageCount ?? 0,
       diskSyncQueue,
@@ -1772,7 +1797,7 @@ export async function forkConversationForRetrospective(params: {
   );
   const messagesToCopy =
     copyBoundaryIndex >= 0
-      ? sourceMessages.slice(0, copyBoundaryIndex + 1)
+      ? dropUnfinalizedRows(sourceMessages.slice(0, copyBoundaryIndex + 1))
       : ([] as MessageRow[]);
 
   const sourceHistoryStrippedAt = sourceConversation.historyStrippedAt ?? null;
@@ -1936,8 +1961,12 @@ export async function forkConversationForRetrospective(params: {
               messagesToCopy: rowsToCopy,
               forkedMessageIds,
               latestForkedAssistant,
+              // Both conditions, for the same reason as `forkConversation`:
+              // a tip boundary no longer implies an equal window once the
+              // unfinalized filter dropped rows from the slice.
               isFullHistoryFork:
-                copyBoundaryIndex === sourceMessages.length - 1,
+                copyBoundaryIndex === sourceMessages.length - 1 &&
+                messagesToCopy.length === copyBoundaryIndex + 1,
               // The copied range already starts at the visible window.
               inheritedCompactedMessageCount: forkCompactedMessageCount,
               skipCompactionLedgerCopy: inheritedCompaction != null,

--- a/assistant/src/persistence/conversation-lineage.ts
+++ b/assistant/src/persistence/conversation-lineage.ts
@@ -184,6 +184,14 @@ export function isSingleSegmentLineage(segments: LineageSegment[]): boolean {
  * strictly-earlier `createdAt`, or an equal `createdAt` with an id that does
  * not sort after the bound. The fork message itself is included, because a
  * fork is taken THROUGH that message.
+ *
+ * Ancestor segments additionally exclude unfinalized rows. An ancestor's
+ * `finalized = 0` row is a message its own live turn is still writing; a
+ * descendant reading it would see partial content that the ancestor rewrites
+ * inline when the turn completes. The row enters the window on its own once
+ * it finalizes. A segment with no bound is the conversation's own tail and
+ * keeps its unfinalized rows: a conversation always sees its own in-flight
+ * message.
  */
 export function lineageMessageFilter(segments: LineageSegment[]): SQL {
   const clauses = segments.map((segment) => {
@@ -194,6 +202,7 @@ export function lineageMessageFilter(segments: LineageSegment[]): SQL {
     const { createdAt, id } = segment.through;
     return and(
       owner,
+      eq(messages.finalized, 1),
       or(
         lt(messages.createdAt, createdAt),
         and(

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-accounting.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-accounting.test.ts
@@ -209,6 +209,38 @@ describe("getRetrospectiveMessagesAfter", () => {
     createConversation({ id: CONV });
   });
 
+  test("truncates at a stale mid-slice unfinalized row so the cursor never passes it", () => {
+    const first = insertRaw({ role: "user", content: TEXT, createdAt: 1_000 });
+    const stale = insertRaw({
+      role: "assistant",
+      content: TEXT,
+      createdAt: 2_000,
+    });
+    insertRaw({ role: "user", content: TEXT, createdAt: 3_000 });
+    insertRaw({ role: "assistant", content: TEXT, createdAt: 4_000 });
+    getDb()
+      .update(messages)
+      .set({ finalized: 0 })
+      .where(eq(messages.id, stale))
+      .run();
+
+    const slice = getRetrospectiveMessagesAfter(CONV, null);
+
+    // The slice stops BEFORE the stale row: taking the later finalized rows
+    // as the cutoff would advance the cursor past the stale row, and once it
+    // finalizes it would sit behind the cursor, unreviewed forever.
+    expect(slice.map((row) => row.id)).toEqual([first]);
+
+    getDb()
+      .update(messages)
+      .set({ finalized: 1 })
+      .where(eq(messages.id, stale))
+      .run();
+
+    // Once the row resolves, the slice continues past it.
+    expect(getRetrospectiveMessagesAfter(CONV, null)).toHaveLength(4);
+  });
+
   test("excludes unfinalized rows so the cutoff stays on rows a fork holds", () => {
     insertRaw({ role: "user", content: TEXT, createdAt: 1_000 });
     const lastFinalized = insertRaw({

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-accounting.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-accounting.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
+import { eq } from "drizzle-orm";
+
 import {
   createConversation,
   type MessageRow,
@@ -8,6 +10,7 @@ import { getDb } from "../../../../persistence/db-connection.js";
 import { initializeDb } from "../../../../persistence/db-init.js";
 import { messages } from "../../../../persistence/schema/index.js";
 import {
+  getRetrospectiveMessagesAfter,
   hasQualifyingUserMessageAfter,
   messagesHaveUserActivity,
 } from "../memory-retrospective-accounting.js";
@@ -195,5 +198,42 @@ describe("messagesHaveUserActivity", () => {
       ]),
     ).toBe(false);
     expect(messagesHaveUserActivity([])).toBe(false);
+  });
+});
+
+describe("getRetrospectiveMessagesAfter", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run(`DELETE FROM messages`);
+    db.run(`DELETE FROM conversations`);
+    createConversation({ id: CONV });
+  });
+
+  test("excludes unfinalized rows so the cutoff stays on rows a fork holds", () => {
+    insertRaw({ role: "user", content: TEXT, createdAt: 1_000 });
+    const lastFinalized = insertRaw({
+      role: "assistant",
+      content: TEXT,
+      createdAt: 2_000,
+    });
+    const streaming = insertRaw({
+      role: "assistant",
+      content: TEXT,
+      createdAt: 3_000,
+    });
+    getDb()
+      .update(messages)
+      .set({ finalized: 0 })
+      .where(eq(messages.id, streaming))
+      .run();
+
+    const slice = getRetrospectiveMessagesAfter(CONV, null);
+
+    // The invariant: no slice member is unfinalized, and the cutoff the job
+    // would take (the last slice row) is a row the retrospective fork
+    // actually contains.
+    expect(slice.some((row) => row.finalized === 0)).toBe(false);
+    expect(slice.at(-1)?.id).toBe(lastFinalized);
+    expect(slice.map((row) => row.id)).not.toContain(streaming);
   });
 });

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
@@ -168,7 +168,10 @@ mock.module("../find-most-recent-retrospective-for.js", () => ({
 mock.module("../../../../persistence/conversation-crud.js", () => ({
   getMessagesAfter: (id: string, afterId: string | null) => {
     messagesAfterCalls.push({ conversationId: id, afterId });
-    return newMessages;
+    // Real rows always carry `finalized` (NOT NULL, default 1); the slice
+    // filter drops unfinalized rows, so mock rows default to finalized
+    // unless a test explicitly stages a streaming row.
+    return newMessages.map((row) => ({ finalized: 1, ...row }));
   },
   getMessages: (id: string) => {
     if (messagesByConversationId[id]) {

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-provider-path.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-provider-path.test.ts
@@ -96,7 +96,10 @@ mock.module("../find-most-recent-retrospective-for.js", () => ({
 }));
 
 mock.module("../../../../persistence/conversation-crud.js", () => ({
-  getMessagesAfter: (_id: string, _afterId: string | null) => newMessages,
+  // Real rows always carry `finalized` (NOT NULL, default 1); the slice
+  // filter drops unfinalized rows, so mock rows default to finalized.
+  getMessagesAfter: (_id: string, _afterId: string | null) =>
+    newMessages.map((row) => ({ finalized: 1, ...row })),
   getMessages: (id: string) => messageStores[id] ?? [],
   // `defaultResolveTarget` in the REAL wake reads the FORK id's row for the
   // archived check, so both rows carry archivedAt/createdAt. The fork's

--- a/assistant/src/plugins/defaults/memory/context-search/sources/conversations.ts
+++ b/assistant/src/plugins/defaults/memory/context-search/sources/conversations.ts
@@ -224,6 +224,12 @@ async function gatherCandidateRowsFromQdrant(
  * the source/type/excluded-conversation predicates in SQL (Qdrant has no
  * visibility filtering). The app-side scorer determines final ordering, so
  * the SQL tie-break falls back to recency.
+ *
+ * No `finalized = 1` predicate, deliberately: every id in `messageIds` comes
+ * from the lexical or vector index, and indexing filters `finalized = 1` at
+ * index time (`message-lexical.ts`), so an unfinalized row can never be a
+ * candidate here. Do not copy this query shape to a reader whose id set has a
+ * different provenance; those need the filter themselves.
  */
 function searchByIds(
   messageIds: readonly string[],

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-accounting.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-accounting.ts
@@ -52,17 +52,26 @@ export function isSkillCardMessage(row: { metadata: string | null }): boolean {
 }
 
 /**
- * `getMessagesAfter` minus skill-card rows. The retrospective job's
- * new-message slice: a card-only tail yields an empty slice (the job's
- * `no_new_messages` early return), and a mixed tail's cutoff lands on the
- * last real message rather than the card.
+ * `getMessagesAfter` minus skill-card rows and unfinalized rows. The
+ * retrospective job's new-message slice: a card-only tail yields an empty
+ * slice (the job's `no_new_messages` early return), and a mixed tail's
+ * cutoff lands on the last real message rather than the card.
+ *
+ * Unfinalized rows are excluded because the job's cutoff (and therefore
+ * `lastProcessedMessageId` on success) is chosen from this slice, while the
+ * fork the job reviews skips unfinalized rows. A cutoff on an unfinalized
+ * row would advance the cursor past content the fork never contained, and
+ * that content would never be reviewed once it finalizes. Keeping the slice
+ * to finalized rows pins the cursor to the last row the fork actually holds;
+ * the row left out is reviewed by the retrospective that runs after it
+ * finalizes.
  */
 export function getRetrospectiveMessagesAfter(
   conversationId: string,
   afterMessageId: string | null,
 ): MessageRow[] {
   return getMessagesAfter(conversationId, afterMessageId).filter(
-    (row) => !isSkillCardMessage(row),
+    (row) => row.finalized === 1 && !isSkillCardMessage(row),
   );
 }
 

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-accounting.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-accounting.ts
@@ -52,27 +52,30 @@ export function isSkillCardMessage(row: { metadata: string | null }): boolean {
 }
 
 /**
- * `getMessagesAfter` minus skill-card rows and unfinalized rows. The
- * retrospective job's new-message slice: a card-only tail yields an empty
- * slice (the job's `no_new_messages` early return), and a mixed tail's
+ * `getMessagesAfter` truncated at the first unfinalized row, minus skill-card
+ * rows. The retrospective job's new-message slice: a card-only tail yields an
+ * empty slice (the job's `no_new_messages` early return), and a mixed tail's
  * cutoff lands on the last real message rather than the card.
  *
- * Unfinalized rows are excluded because the job's cutoff (and therefore
- * `lastProcessedMessageId` on success) is chosen from this slice, while the
- * fork the job reviews skips unfinalized rows. A cutoff on an unfinalized
- * row would advance the cursor past content the fork never contained, and
- * that content would never be reviewed once it finalizes. Keeping the slice
- * to finalized rows pins the cursor to the last row the fork actually holds;
- * the row left out is reviewed by the retrospective that runs after it
- * finalizes.
+ * The slice STOPS BEFORE the first unfinalized row rather than filtering it
+ * out. The job's cutoff (and therefore `lastProcessedMessageId` on success)
+ * is chosen from this slice, while the fork the job reviews skips unfinalized
+ * rows, so the cursor must never move past one: filtering through a stale
+ * mid-slice `finalized = 0` row would advance the cursor beyond it, and once
+ * the row later finalizes its `(createdAt, id)` sits behind the cursor,
+ * unreviewed forever. Truncating parks the cursor before the unfinalized row;
+ * the rows behind it are reviewed by the retrospective that runs after the
+ * row resolves (finalizes, or is repaired away by crash recovery).
  */
 export function getRetrospectiveMessagesAfter(
   conversationId: string,
   afterMessageId: string | null,
 ): MessageRow[] {
-  return getMessagesAfter(conversationId, afterMessageId).filter(
-    (row) => row.finalized === 1 && !isSkillCardMessage(row),
-  );
+  const rows = getMessagesAfter(conversationId, afterMessageId);
+  const firstUnfinalized = rows.findIndex((row) => row.finalized !== 1);
+  const bounded =
+    firstUnfinalized === -1 ? rows : rows.slice(0, firstUnfinalized);
+  return bounded.filter((row) => !isSkillCardMessage(row));
 }
 
 /**


### PR DESCRIPTION
Part of JARVIS-1478 (the messages-visibility contract family this bug motivated).

## TL;DR

A fork taken while the source conversation is mid-turn copied the streaming (`finalized = 0`) row. The copy's content is a `{ ref }` into the source turn's in-flight delta file, which the source deletes when its turn completes, so the fork ends up with a permanently empty message that reads as final and that crash recovery (which scans `finalized = 0` only) can never repair. Forks now skip unfinalized rows entirely, in both fork paths, referential forks exclude them on the read side, and the retrospective's cursor accounting only advances over rows a fork can hold.

`finalized = 0` is not an unsent message. It is a message that was sent and is still being written, so there is no completed content to copy: a fork reflects the conversation at a completed point.

## What changes for the user

| | Before | After |
|---|---|---|
| Fork while the assistant is replying | The in-progress reply appears in the fork as a message that renders empty, forever | The fork contains everything up to the last completed message; the in-progress reply simply is not part of it |
| Fork anchor (`forkParentMessageId`) | Could point at the in-flight row, including one the fork never copied | Always the last completed message the fork actually holds |
| Referential (retrospective) fork reading its parent mid-turn | Could read the parent's partial, in-flight content | Sees the parent's completed messages; the in-flight one appears on its own once it completes |
| Memory retrospective running while a reply streams | Could advance its cursor past the in-flight message, so that content was never reviewed once it completed | The cursor stops at the last completed message; the next retrospective reviews the finished reply |

## Why this is safe

- The filter sits on `messagesToCopy` in both fork functions, upstream of every derivation (boundary timestamp, compaction inheritance, `forkParentMessageId`, the id map), so all of them describe the rows actually copied. Filtering only the copy statement would have left id-map entries pointing at rows that were never copied.
- `isFullHistoryFork` (which gates the wholesale memory-state carry) now also requires that the filter dropped nothing, so a tip-anchored fork that skipped the streaming row degrades to the conservative carry path instead of claiming an equal window.
- The lineage read-side change applies only to bounded ancestor segments, which exist only for referential forks. A conversation's own unbounded segment is untouched, so every conversation still sees its own in-flight row, and no non-fork read changes at all.
- An ancestor row excluded while unfinalized enters the fork's window automatically once it finalizes (the bound already covers it); the regression test pins this.
- The retrospective's slice (`getRetrospectiveMessagesAfter`) truncates at the first unfinalized row: the job's cutoff, and therefore `lastProcessedMessageId` on success, is chosen from this slice, and the cursor must never move past a row the reviewed fork did not hold — including a stale mid-slice row that finalizes later, which would otherwise sit behind the cursor unreviewed forever. Rows behind a stale row are reviewed by the retrospective that runs after it resolves.
- `searchByIds` in memory context-search intentionally has no `finalized` predicate because its candidate ids come from indexes that filter `finalized = 1` at index time; that reasoning is now a comment on the query so the shape is not blind-copied to readers without that provenance.

## Tests

- `forkConversation`: mid-turn fork copies only finalized rows, anchors at the last finalized message, and no copied row descends from the unfinalized source row; a stale mid-history unfinalized row is skipped without shifting the anchor.
- `forkConversationForRetrospective` (cloning): unfinalized tail skipped, anchor correctness.
- Referential: unfinalized ancestor row hidden from the fork while the source still sees it, appears after finalization; unfinalized tail is never the fork anchor.
- Retrospective accounting: the slice never contains an unfinalized row; a stale mid-slice row truncates it (and the slice resumes past the row once it finalizes); the last element (the job's cutoff) is always a row the fork holds.

Local `bun test` is hook-blocked in this environment; typecheck and lint pass locally and CI runs the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40484" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
