### PR TITLE
docs(security): record that risk classification is gateway-owned

### DIFF
--- a/assistant/docs/architecture/security.md
+++ b/assistant/docs/architecture/security.md
@@ -67,12 +67,9 @@ Missing optional fields act as wildcards. A rule with no `executionTarget` match
 
 Risk classification is **gateway-owned**. The classifiers live in `gateway/src/risk/`, and the gateway is the sole entry point for classification: the assistant has no local classifier to fall back on.
 
-`classifyRisk()` in `assistant/src/permissions/checker.ts` is the assistant-side entry point. It is asynchronous and delegates to the gateway over IPC (`classify_risk`), returning the risk level plus the metadata the permission check needs: command candidates, action keys, sandbox auto-approve verdict, and allowlist options.
+`classifyRisk()` in `assistant/src/permissions/checker.ts` is the assistant-side entry point. It is asynchronous and delegates to the gateway over IPC (`classify_risk`), returning the risk level plus the metadata the permission check needs: command candidates, action keys, sandbox auto-approve verdict, and allowlist options. It caches results locally.
 
-Two properties of that call matter when reading the flow above:
-
-- **No local fallback.** If the gateway is unreachable or returns an invalid response, `classifyRisk()` throws. There is no local classifier to fall back on, so the tool does not execute. Note that this is an error, not a deny decision: it is recorded through the tool-error path rather than as a permission denial, so it does not appear in the audit trail as a blocked invocation.
-- **Cached per resolved invocation.** Results are cached on the tool name, a hash of the input, the working directory, the manifest override, and, for file tools, the symlink-resolved target paths. Folding resolved paths into the key is deliberate: file risk depends on filesystem state, so a retargeted symlink yields a different key rather than a stale hit. On a hit carrying sandbox path arguments the symlink escape check is re-run as well.
+This section describes **ownership**: which side of the daemon/gateway boundary decides a risk level. It deliberately does not specify what happens when classification fails or when a cached result goes stale. Both are open questions in the code rather than settled design, so pinning them here would turn current behaviour into contract before anyone has decided it should be.
 
 The risk level assigned to each tool invocation:
 

--- a/assistant/docs/architecture/security.md
+++ b/assistant/docs/architecture/security.md
@@ -10,7 +10,7 @@ The permission system controls which tool actions the agent can execute without 
 
 ```mermaid
 graph TB
-    TOOL_CALL["Tool invocation<br/>(toolName, input, policyContext)"] --> CLASSIFY["classifyRisk()<br/>→ Low / Medium / High"]
+    TOOL_CALL["Tool invocation<br/>(toolName, input, policyContext)"] --> CLASSIFY["classifyRisk()<br/>delegates to gateway over IPC<br/>→ Low / Medium / High"]
     CLASSIFY --> CANDIDATES["buildCommandCandidates()<br/>tool:target strings +<br/>canonical path variants"]
     CANDIDATES --> FIND_RULE["findHighestPriorityRule()<br/>iterate sorted rules:<br/>tool, scope, pattern (minimatch),<br/>executionTarget"]
 
@@ -65,7 +65,16 @@ Missing optional fields act as wildcards. A rule with no `executionTarget` match
 
 ### Risk Classification and Escalation
 
-The `classifyRisk()` function determines the risk level for each tool invocation:
+Risk classification is **gateway-owned**. The classifiers live in `gateway/src/risk/`, and the gateway is the sole entry point for classification: the assistant has no local classifier to fall back on.
+
+`classifyRisk()` in `assistant/src/permissions/checker.ts` is the assistant-side entry point. It is asynchronous and delegates to the gateway over IPC (`classify_risk`), returning the risk level plus the metadata the permission check needs: command candidates, action keys, sandbox auto-approve verdict, and allowlist options.
+
+Two properties of that call matter when reading the flow above:
+
+- **Fail-closed.** If the gateway is unreachable or returns an invalid response, `classifyRisk()` throws rather than assuming a risk level. There is no local fallback classification, matching the fail-closed posture used for thresholds.
+- **Cached, with a symlink re-check.** Results are cached on `(toolName, inputHash, workingDir, manifestOverride)`. On a cache hit for a classification carrying sandbox path arguments, the symlink escape check is re-run before the cached entry is reused, because a symlink target can change between invocations and a path that was safe when cached may now escape.
+
+The risk level assigned to each tool invocation:
 
 | Tool                                                             | Risk level                  | Notes                                                                                        |
 | ---------------------------------------------------------------- | --------------------------- | -------------------------------------------------------------------------------------------- |
@@ -184,7 +193,7 @@ File tool candidates include canonical (symlink-resolved) absolute paths via `no
 | File                                          | Role                                                                                                                                                                                |
 | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `assistant/src/permissions/types.ts`          | `TrustRule`, `PolicyContext`, `RiskLevel`, `UserDecision` types                                                                                                                     |
-| `assistant/src/permissions/checker.ts`        | `classifyRisk()`, `check()`, `buildCommandCandidates()`, allowlist/scope generation                                                                                                 |
+| `assistant/src/permissions/checker.ts`        | `classifyRisk()` (assistant-side entry point; delegates to the gateway over IPC and caches the result), `check()`, allowlist/scope generation                                       |
 | `assistant/src/permissions/shell-identity.ts` | `analyzeShellCommand()`, `deriveShellActionKeys()`, `buildShellCommandCandidates()`, `buildShellAllowlistOptions()` — parser-based shell command identity and action key derivation |
 | `assistant/src/permissions/trust-store.ts`    | Rule persistence, `findHighestPriorityRule()`, execution-target matching, starter bundle                                                                                            |
 | `assistant/src/permissions/prompter.ts`       | HTTP prompt flow: `confirmation_request` → `confirmation_response`                                                                                                                  |
@@ -193,6 +202,19 @@ File tool candidates include canonical (symlink-resolved) absolute paths via `no
 | `assistant/src/skills/path-classifier.ts`     | `isSkillSourcePath()`, `normalizeFilePath()`, skill root detection                                                                                                                  |
 | `assistant/src/tools/executor.ts`             | `ToolExecutor` — orchestrates risk classification, permission check, and execution                                                                                                  |
 | `assistant/src/daemon/handlers/config.ts`     | `handleToolPermissionSimulate()` — dry-run simulation handler                                                                                                                       |
+
+Risk classification itself lives in the gateway:
+
+| File                                              | Role                                                                                     |
+| ------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `gateway/src/ipc/risk-classification-handlers.ts` | `classify_risk` IPC handler, the entry point the assistant calls                         |
+| `gateway/src/risk/bash-risk-classifier.ts`        | Shell command risk, via the tree-sitter parse in `shell-parser.ts` / `shell-identity.ts` |
+| `gateway/src/risk/file-risk-classifier.ts`        | File tool risk, including skill-source-path escalation                                   |
+| `gateway/src/risk/web-risk-classifier.ts`         | Web tool risk                                                                            |
+| `gateway/src/risk/skill-risk-classifier.ts`       | Skill lifecycle tool risk                                                                |
+| `gateway/src/risk/schedule-risk-classifier.ts`    | Scheduled task risk                                                                      |
+| `gateway/src/risk/command-registry/`              | Known-program risk registry backing the bash classifier                                  |
+| `gateway/src/risk/risk-types.ts`                  | `Risk`, `RiskLevel`, and the conversions between them                                    |
 
 ### Permission Simulation (Tool Permission Tester)
 

--- a/assistant/docs/architecture/security.md
+++ b/assistant/docs/architecture/security.md
@@ -71,8 +71,8 @@ Risk classification is **gateway-owned**. The classifiers live in `gateway/src/r
 
 Two properties of that call matter when reading the flow above:
 
-- **Fail-closed.** If the gateway is unreachable or returns an invalid response, `classifyRisk()` throws rather than assuming a risk level. There is no local fallback classification, matching the fail-closed posture used for thresholds.
-- **Cached, with a symlink re-check.** Results are cached on `(toolName, inputHash, workingDir, manifestOverride)`. On a cache hit for a classification carrying sandbox path arguments, the symlink escape check is re-run before the cached entry is reused, because a symlink target can change between invocations and a path that was safe when cached may now escape.
+- **No local fallback.** If the gateway is unreachable or returns an invalid response, `classifyRisk()` throws. There is no local classifier to fall back on, so the tool does not execute. Note that this is an error, not a deny decision: it is recorded through the tool-error path rather than as a permission denial, so it does not appear in the audit trail as a blocked invocation.
+- **Cached per resolved invocation.** Results are cached on the tool name, a hash of the input, the working directory, the manifest override, and, for file tools, the symlink-resolved target paths. Folding resolved paths into the key is deliberate: file risk depends on filesystem state, so a retargeted symlink yields a different key rather than a stale hit. On a hit carrying sandbox path arguments the symlink escape check is re-run as well.
 
 The risk level assigned to each tool invocation:
 


### PR DESCRIPTION
## TL;DR

The security architecture doc says risk classification is daemon-local. It moved to the gateway in #27824 and the doc was never updated, so anyone onboarding off this page reaches the wrong conclusion about who owns it.

Scoped to **ownership only**. Docs, no code.

## What was stale

At current main the page has one gateway mention (the thresholds paragraph), and:

- the flow diagram shows `classifyRisk()` as a local step
- the Risk Classification section introduces it as "the `classifyRisk()` function"
- the source-file table lists only daemon-side files, with no `gateway/src/risk/` rows

## What changed

| | Before | After |
|---|---|---|
| Diagram node | `classifyRisk()` | notes it delegates to the gateway over IPC |
| Risk Classification section | "the `classifyRisk()` function determines..." | states classification is gateway-owned, with the daemon-side function as the entry point |
| Source-file table | daemon files only | adds a table for `gateway/src/risk/` and the `classify_risk` IPC handler |

Every file named in the new table was confirmed to exist.

## What this deliberately does not document

Earlier revisions of this branch also described what happens when classification fails, and how the result cache behaves. Both were removed, and the section now says so explicitly.

Neither is settled design:

- A classification failure surfaces as an unexpected tool error rather than a denial. Nobody chose that; it is what falls out of a throw reaching a generic catch, and it is probably wrong. Tracked on LUM-3159.
- The cache's invalidation function documents itself as called when trust rules change, and has no production caller. Tracked as LUM-3165.

Stating either in neutral prose in an architecture doc would convert current behaviour into contract before anyone decided it should be. The point of this PR is to align the doc with a decision that was actually made, not to ratify behaviour that happens to exist.

## Scope

The risk-level table, rule-matching sections, simulation section, and all permission code are untouched. Pre-existing formatting in unrelated rows left alone.

## Context

Found while investigating LUM-3135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
