### PR TITLE
feat(persistence): add conversation_queued_messages staging table and store

### DIFF
--- a/assistant/src/persistence/conversation-queue-store.test.ts
+++ b/assistant/src/persistence/conversation-queue-store.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { createConversation } from "./conversation-crud.js";
+import {
+  deleteRow,
+  deleteRowsForConversation,
+  insertQueuedRow,
+  listConversationIdsWithRows,
+  loadRows,
+  markDraining,
+  markQueued,
+  promoteRowToHead,
+} from "./conversation-queue-store.js";
+import { getDb } from "./db-connection.js";
+import { initializeDb } from "./db-init.js";
+
+await initializeDb();
+
+function resetTables() {
+  const db = getDb();
+  db.run("DELETE FROM conversation_queued_messages");
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+}
+
+function seedConversation(): string {
+  return createConversation("Queue store test").id;
+}
+
+function makeMessage(requestId: string, content = "queued text") {
+  return { requestId, content, sentAt: 1_000 };
+}
+
+describe("conversation-queue-store", () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test("inserts assign ascending FIFO sort keys per conversation", () => {
+    const convA = seedConversation();
+    const convB = seedConversation();
+    insertQueuedRow(convA, makeMessage("a-1"));
+    insertQueuedRow(convB, makeMessage("b-1"));
+    insertQueuedRow(convA, makeMessage("a-2"));
+
+    const backlogA = loadRows(convA);
+    expect(backlogA.map((row) => row.requestId)).toEqual(["a-1", "a-2"]);
+    expect(backlogA[0]!.sortKey).toBeLessThan(backlogA[1]!.sortKey);
+    expect(loadRows(convB).map((row) => row.requestId)).toEqual(["b-1"]);
+  });
+
+  test("round-trips the persistable projection through JSON columns", () => {
+    const conv = seedConversation();
+    insertQueuedRow(conv, {
+      requestId: "req-1",
+      content: "agent-facing text",
+      displayContent: "what the user typed",
+      clientMessageId: "nonce-1",
+      attachments: [{ filename: "a.txt", mimeType: "text/plain" }],
+      metadata: { hidden: true, nested: { keep: 1 } },
+      transport: { clientOs: "macos" },
+      sourceActorPrincipalId: "actor-1",
+      isInteractive: false,
+      sentAt: 42,
+    });
+
+    const [row] = loadRows(conv);
+    expect(row).toMatchObject({
+      requestId: "req-1",
+      content: "agent-facing text",
+      displayContent: "what the user typed",
+      clientMessageId: "nonce-1",
+      attachments: [{ filename: "a.txt", mimeType: "text/plain" }],
+      metadata: { hidden: true, nested: { keep: 1 } },
+      transport: { clientOs: "macos" },
+      sourceActorPrincipalId: "actor-1",
+      isInteractive: false,
+      sentAt: 42,
+      state: "queued",
+    });
+  });
+
+  test("promote moves one row to the head without renumbering siblings", () => {
+    const conv = seedConversation();
+    insertQueuedRow(conv, makeMessage("first"));
+    insertQueuedRow(conv, makeMessage("second"));
+    insertQueuedRow(conv, makeMessage("third"));
+
+    promoteRowToHead(conv, "third");
+
+    expect(loadRows(conv).map((row) => row.requestId)).toEqual([
+      "third",
+      "first",
+      "second",
+    ]);
+  });
+
+  test("draining rows survive and read back for recovery; markQueued restores them", () => {
+    const conv = seedConversation();
+    insertQueuedRow(conv, makeMessage("req-1"));
+    markDraining("req-1");
+
+    const [draining] = loadRows(conv);
+    expect(draining!.state).toBe("draining");
+
+    markQueued("req-1");
+    expect(loadRows(conv)[0]!.state).toBe("queued");
+  });
+
+  test("deleteRow and deleteRowsForConversation remove exactly their targets", () => {
+    const convA = seedConversation();
+    const convB = seedConversation();
+    insertQueuedRow(convA, makeMessage("a-1"));
+    insertQueuedRow(convA, makeMessage("a-2"));
+    insertQueuedRow(convB, makeMessage("b-1"));
+
+    deleteRow("a-1");
+    expect(loadRows(convA).map((row) => row.requestId)).toEqual(["a-2"]);
+
+    deleteRowsForConversation(convA);
+    expect(loadRows(convA)).toEqual([]);
+    expect(loadRows(convB)).toHaveLength(1);
+  });
+
+  test("listConversationIdsWithRows names each backlogged conversation once", () => {
+    const convA = seedConversation();
+    const convB = seedConversation();
+    seedConversation();
+    insertQueuedRow(convA, makeMessage("a-1"));
+    insertQueuedRow(convA, makeMessage("a-2"));
+    insertQueuedRow(convB, makeMessage("b-1"));
+
+    expect(listConversationIdsWithRows().sort()).toEqual([convA, convB].sort());
+  });
+
+  test("a failed write degrades silently instead of throwing", () => {
+    // FK violation: the conversation does not exist, so the insert fails
+    // inside the store. The helper must swallow it (the queue accepted the
+    // message; a storage failure must not reject the send) and reads must
+    // answer with an empty backlog.
+    expect(() =>
+      insertQueuedRow("missing-conversation", makeMessage("req-1")),
+    ).not.toThrow();
+    expect(loadRows("missing-conversation")).toEqual([]);
+  });
+});

--- a/assistant/src/persistence/conversation-queue-store.ts
+++ b/assistant/src/persistence/conversation-queue-store.ts
@@ -1,0 +1,261 @@
+/**
+ * Row-level helpers for `conversation_queued_messages`, the durable backing of
+ * the in-memory message queue. `MessageQueue` calls these from inside its own
+ * mutation methods so the table and the array cannot drift; nothing else
+ * should write this table.
+ *
+ * ## Failure policy
+ *
+ * Every helper is best-effort: it catches, logs, and returns a degraded value
+ * instead of throwing. A queued message whose row fails to write is exactly as
+ * durable as every queued message was before this table existed, whereas
+ * letting the throw escape would reject a send the queue has already accepted
+ * and the sender has already been told about. Reads degrade to an empty
+ * backlog, which recovers nothing. This matches the daemon's rule that
+ * subsystem failures degrade rather than propagate.
+ */
+
+import { and, asc, eq, sql } from "drizzle-orm";
+
+import { getLogger } from "../util/logger.js";
+import { getDb } from "./db-connection.js";
+import { conversationQueuedMessages } from "./schema/index.js";
+
+const log = getLogger("conversation-queue-store");
+
+/**
+ * The persistable projection of a queued message. Deliberately narrower than
+ * the daemon's `QueuedMessage`: that type also carries the live `onEvent`
+ * sink and the sender's `authContext` / `trustContext`, none of which may be
+ * stored (see the schema module). Mapping down to this shape is the caller's
+ * visible step, not an accident of serialization. Attachments, metadata, and
+ * transport are opaque JSON here; the daemon owns their types.
+ */
+export interface PersistableQueuedMessage {
+  requestId: string;
+  content: string;
+  displayContent?: string;
+  clientMessageId?: string;
+  attachments?: unknown[];
+  metadata?: Record<string, unknown>;
+  transport?: unknown;
+  sourceActorPrincipalId?: string;
+  isInteractive?: boolean;
+  sentAt: number;
+}
+
+/** A backlog row read back for recovery, JSON columns parsed. */
+export interface RecoveredQueuedMessage extends PersistableQueuedMessage {
+  sortKey: number;
+  state: "queued" | "draining";
+}
+
+function toJson(value: unknown): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return null;
+  }
+}
+
+function fromJson<T>(raw: string | null): T | undefined {
+  if (raw === null) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Write the row that stands behind a freshly accepted queued message. Called
+ * after the byte-budget accept, so a rejected message never leaves a row.
+ *
+ * `sort_key` is assigned by the insert itself (max + 1 for the conversation)
+ * rather than by an in-process counter: a counter would be one more piece of
+ * queue state to keep in agreement, and it would not survive the restart this
+ * table exists to survive.
+ */
+export function insertQueuedRow(
+  conversationId: string,
+  message: PersistableQueuedMessage,
+): void {
+  try {
+    getDb()
+      .insert(conversationQueuedMessages)
+      .values({
+        requestId: message.requestId,
+        conversationId,
+        clientMessageId: message.clientMessageId ?? null,
+        content: message.content,
+        displayContent: message.displayContent ?? null,
+        attachments: toJson(message.attachments),
+        metadata: toJson(message.metadata),
+        transport: toJson(message.transport),
+        sourceActorPrincipalId: message.sourceActorPrincipalId ?? null,
+        isInteractive:
+          message.isInteractive === undefined
+            ? null
+            : message.isInteractive
+              ? 1
+              : 0,
+        sortKey: sql`(SELECT COALESCE(MAX(sort_key), 0) + 1
+          FROM conversation_queued_messages WHERE conversation_id = ${conversationId})`,
+        state: "queued",
+        sentAt: message.sentAt,
+        enqueuedAt: Date.now(),
+      })
+      .run();
+  } catch (err) {
+    log.error(
+      { err, conversationId, requestId: message.requestId },
+      "Failed to persist queued message row; it remains in memory only",
+    );
+  }
+}
+
+/**
+ * Mark a row taken by a drain that has not yet persisted its message. The row
+ * stays until the drain confirms the persist, so the message is never absent
+ * from storage: it is a backlog row or a `messages` row, and briefly both.
+ */
+export function markDraining(requestId: string): void {
+  setRowState(requestId, "draining");
+}
+
+/** Return a row to `queued`: a drain gave the message back to the queue. */
+export function markQueued(requestId: string): void {
+  setRowState(requestId, "queued");
+}
+
+function setRowState(requestId: string, state: "queued" | "draining"): void {
+  try {
+    getDb()
+      .update(conversationQueuedMessages)
+      .set({ state })
+      .where(eq(conversationQueuedMessages.requestId, requestId))
+      .run();
+  } catch (err) {
+    log.error({ err, requestId, state }, "Failed to set queued row state");
+  }
+}
+
+/**
+ * Drop the row for a message that left the queue for good: persisted by a
+ * successful drain, cancelled by its sender, or discarded with the
+ * conversation.
+ */
+export function deleteRow(requestId: string): void {
+  try {
+    getDb()
+      .delete(conversationQueuedMessages)
+      .where(eq(conversationQueuedMessages.requestId, requestId))
+      .run();
+  } catch (err) {
+    log.error({ err, requestId }, "Failed to delete queued message row");
+  }
+}
+
+/** Drop every row for a conversation whose queue was cleared wholesale. */
+export function deleteRowsForConversation(conversationId: string): void {
+  try {
+    getDb()
+      .delete(conversationQueuedMessages)
+      .where(eq(conversationQueuedMessages.conversationId, conversationId))
+      .run();
+  } catch (err) {
+    log.error(
+      { err, conversationId },
+      "Failed to clear queued message rows for conversation",
+    );
+  }
+}
+
+/**
+ * Move a row to the head of its conversation's backlog (steer). One row's
+ * sort key moves; siblings keep theirs, so recovery order matches the
+ * in-memory order `promoteToHead` produced.
+ */
+export function promoteRowToHead(
+  conversationId: string,
+  requestId: string,
+): void {
+  try {
+    getDb()
+      .update(conversationQueuedMessages)
+      .set({
+        sortKey: sql`(SELECT COALESCE(MIN(sort_key), 0) - 1
+          FROM conversation_queued_messages WHERE conversation_id = ${conversationId})`,
+      })
+      .where(
+        and(
+          eq(conversationQueuedMessages.requestId, requestId),
+          eq(conversationQueuedMessages.conversationId, conversationId),
+        ),
+      )
+      .run();
+  } catch (err) {
+    log.error(
+      { err, conversationId, requestId },
+      "Failed to promote queued message row",
+    );
+  }
+}
+
+/**
+ * The surviving backlog for a conversation, FIFO. `draining` rows are
+ * returned alongside `queued` ones: a drain that did not live to confirm its
+ * persist never really took the message.
+ */
+export function loadRows(conversationId: string): RecoveredQueuedMessage[] {
+  try {
+    const rows = getDb()
+      .select()
+      .from(conversationQueuedMessages)
+      .where(eq(conversationQueuedMessages.conversationId, conversationId))
+      .orderBy(asc(conversationQueuedMessages.sortKey))
+      .all();
+    return rows.map((row) => ({
+      requestId: row.requestId,
+      content: row.content,
+      displayContent: row.displayContent ?? undefined,
+      clientMessageId: row.clientMessageId ?? undefined,
+      attachments: fromJson<unknown[]>(row.attachments) ?? [],
+      metadata: fromJson<Record<string, unknown>>(row.metadata),
+      transport: fromJson<unknown>(row.transport),
+      sourceActorPrincipalId: row.sourceActorPrincipalId ?? undefined,
+      isInteractive:
+        row.isInteractive === null ? undefined : row.isInteractive === 1,
+      sentAt: row.sentAt,
+      sortKey: row.sortKey,
+      state: row.state === "draining" ? "draining" : "queued",
+    }));
+  } catch (err) {
+    log.error(
+      { err, conversationId },
+      "Failed to read queued message backlog; recovering nothing",
+    );
+    return [];
+  }
+}
+
+/** Conversations with a surviving backlog, for the startup recovery sweep. */
+export function listConversationIdsWithRows(): string[] {
+  try {
+    return getDb()
+      .selectDistinct({
+        conversationId: conversationQueuedMessages.conversationId,
+      })
+      .from(conversationQueuedMessages)
+      .all()
+      .map((row) => row.conversationId);
+  } catch (err) {
+    log.error({ err }, "Failed to list conversations with queued backlogs");
+    return [];
+  }
+}

--- a/assistant/src/persistence/migrations/366-create-conversation-queued-messages.test.ts
+++ b/assistant/src/persistence/migrations/366-create-conversation-queued-messages.test.ts
@@ -1,0 +1,97 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import * as schema from "../schema.js";
+import { migrateCreateConversationQueuedMessages } from "./366-create-conversation-queued-messages.js";
+
+/** Pre-366 shape: conversations exists, the queue table does not. */
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA foreign_keys = ON");
+  sqlite.exec(/*sql*/ `
+    CREATE TABLE conversations (
+      id TEXT PRIMARY KEY,
+      created_at INTEGER NOT NULL
+    );
+    INSERT INTO conversations (id, created_at) VALUES ('conv-1', 1000);
+  `);
+  return { sqlite, db: drizzle(sqlite, { schema }) };
+}
+
+function tableNames(sqlite: Database): string[] {
+  return (
+    sqlite
+      .query("SELECT name FROM sqlite_master WHERE type = 'table'")
+      .all() as Array<{ name: string }>
+  ).map((row) => row.name);
+}
+
+function insertQueuedRow(sqlite: Database, requestId: string): void {
+  sqlite
+    .query(
+      /*sql*/ `INSERT INTO conversation_queued_messages
+        (request_id, conversation_id, content, sort_key, sent_at, enqueued_at)
+        VALUES (?, 'conv-1', 'queued text', 1, 1000, 1000)`,
+    )
+    .run(requestId);
+}
+
+describe("migration 366: conversation_queued_messages", () => {
+  test("creates the table and index on a database without them", () => {
+    const { sqlite, db } = createTestDb();
+    expect(tableNames(sqlite)).not.toContain("conversation_queued_messages");
+
+    migrateCreateConversationQueuedMessages(db);
+
+    expect(tableNames(sqlite)).toContain("conversation_queued_messages");
+    const indexes = (
+      sqlite
+        .query(
+          "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'conversation_queued_messages'",
+        )
+        .all() as Array<{ name: string }>
+    ).map((row) => row.name);
+    expect(indexes).toContain("idx_conversation_queued_messages_conv_sort");
+  });
+
+  test("re-running is a no-op that preserves existing rows", () => {
+    const { sqlite, db } = createTestDb();
+    migrateCreateConversationQueuedMessages(db);
+    insertQueuedRow(sqlite, "req-1");
+
+    migrateCreateConversationQueuedMessages(db);
+
+    const count = sqlite
+      .query("SELECT COUNT(*) AS n FROM conversation_queued_messages")
+      .get() as { n: number };
+    expect(count.n).toBe(1);
+  });
+
+  test("deleting a conversation cascades its queued rows", () => {
+    const { sqlite, db } = createTestDb();
+    migrateCreateConversationQueuedMessages(db);
+    insertQueuedRow(sqlite, "req-1");
+
+    sqlite.query("DELETE FROM conversations WHERE id = 'conv-1'").run();
+
+    const count = sqlite
+      .query("SELECT COUNT(*) AS n FROM conversation_queued_messages")
+      .get() as { n: number };
+    expect(count.n).toBe(0);
+  });
+
+  test("state defaults to queued", () => {
+    const { sqlite, db } = createTestDb();
+    migrateCreateConversationQueuedMessages(db);
+    insertQueuedRow(sqlite, "req-1");
+
+    const row = sqlite
+      .query(
+        "SELECT state FROM conversation_queued_messages WHERE request_id = 'req-1'",
+      )
+      .get() as { state: string };
+    expect(row.state).toBe("queued");
+  });
+});

--- a/assistant/src/persistence/migrations/366-create-conversation-queued-messages.ts
+++ b/assistant/src/persistence/migrations/366-create-conversation-queued-messages.ts
@@ -1,0 +1,42 @@
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+
+/**
+ * Creates `conversation_queued_messages`: the durable backing for each
+ * conversation's in-memory message queue (see the schema module for the
+ * design and for what is deliberately not stored).
+ *
+ * A message enqueued while the agent is mid-turn is otherwise held only in
+ * process memory until the drain persists it, so a restart or crash inside
+ * that window destroys input the daemon acknowledged with
+ * `202 { queued: true }`, with no event and no error.
+ *
+ * Idempotent (`IF NOT EXISTS`). No backfill: whatever sits in a live queue
+ * when this first runs predates the table and exists only in memory, and
+ * inventing rows for messages the daemon may already have drained would
+ * double-insert them.
+ */
+export function migrateCreateConversationQueuedMessages(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS conversation_queued_messages (
+      request_id                TEXT PRIMARY KEY,
+      conversation_id           TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+      client_message_id         TEXT,
+      content                   TEXT NOT NULL,
+      display_content           TEXT,
+      attachments               TEXT,
+      metadata                  TEXT,
+      transport                 TEXT,
+      source_actor_principal_id TEXT,
+      is_interactive            INTEGER,
+      sort_key                  INTEGER NOT NULL,
+      state                     TEXT NOT NULL DEFAULT 'queued',
+      sent_at                   INTEGER NOT NULL,
+      enqueued_at               INTEGER NOT NULL
+    )
+  `);
+  raw.exec(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_conversation_queued_messages_conv_sort
+      ON conversation_queued_messages(conversation_id, sort_key)`);
+}

--- a/assistant/src/persistence/schema/conversation-queue.ts
+++ b/assistant/src/persistence/schema/conversation-queue.ts
@@ -1,0 +1,75 @@
+import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+import { conversations } from "./conversations.js";
+
+/**
+ * Durable backing for a conversation's in-memory message queue.
+ *
+ * A message enqueued while the agent is mid-turn lives in `MessageQueue`'s
+ * array until the drain persists it as a real `messages` row. The sender was
+ * told `202 { queued: true }`, and this table is what stands behind that
+ * acknowledgement: a row lands here when the queue accepts a message and is
+ * deleted when the message leaves the queue for good (drained and persisted,
+ * cancelled, or discarded with the conversation). The table holds exactly the
+ * messages still waiting and is empty whenever no conversation is mid-turn.
+ *
+ * A separate table rather than rows in `messages`: a waiting message must be
+ * invisible to every reader of conversation history until it drains, and
+ * `messages` is read directly by dozens of modules (memory indexing, lexical
+ * jobs, usage accounting, telemetry). Keeping waiting messages out of that
+ * table makes a leak unrepresentable instead of relying on every reader to
+ * filter.
+ *
+ * ## What is deliberately not stored
+ *
+ * `QueuedMessage` also carries the sender's `authContext` / `trustContext`
+ * snapshots and the live `onEvent` sink. None of them persist. The trust and
+ * auth snapshots are authorization decisions captured at enqueue; replayed
+ * after a restart they would re-grant capabilities their bearer may no longer
+ * hold, so recovery stores only `source_actor_principal_id` (who sent it,
+ * durable and verifiable) and the drain re-derives what that principal may
+ * currently do. The sink cannot survive the restart that makes recovery
+ * necessary; recovered messages fall back to conversation-scoped broadcast.
+ */
+export const conversationQueuedMessages = sqliteTable(
+  "conversation_queued_messages",
+  {
+    /** Server-minted `requestId` (uuidv7), the queue's identity for the message. */
+    requestId: text("request_id").primaryKey(),
+    conversationId: text("conversation_id")
+      .notNull()
+      .references(() => conversations.id, { onDelete: "cascade" }),
+    /** Client correlation nonce, echoed back so a sender can match its optimistic row. */
+    clientMessageId: text("client_message_id"),
+    /** Content as the agent will receive it, recording-intent stripping applied. */
+    content: text("content").notNull(),
+    /** Original user text when `content` was rewritten; null when they match. */
+    displayContent: text("display_content"),
+    /** JSON attachment array, bounded by the queue's 50 MB byte budget. */
+    attachments: text("attachments"),
+    /** JSON metadata bag; carries the suppression markers and turn channel/interface context. */
+    metadata: text("metadata"),
+    /** JSON transport snapshot taken at enqueue. */
+    transport: text("transport"),
+    /** Verified requester principal. Identity only; see the note above on trust. */
+    sourceActorPrincipalId: text("source_actor_principal_id"),
+    /** 0/1: false marks a turn with no interactive user, which skips clarification prompts. */
+    isInteractive: integer("is_interactive"),
+    /** Per-conversation FIFO ordinal. Steer rewrites it to move a row to the head. */
+    sortKey: integer("sort_key").notNull(),
+    /** `queued` while waiting; `draining` once a drain took it but has not yet persisted it. */
+    state: text("state").notNull().default("queued"),
+    /** Wall-clock send time, used as the message's display timestamp. */
+    sentAt: integer("sent_at").notNull(),
+    /** When this row was written. Distinct from `sentAt` for channel-relayed messages. */
+    enqueuedAt: integer("enqueued_at").notNull(),
+  },
+  (table) => [
+    // Recovery reads one conversation's backlog in FIFO order; both columns
+    // together so the ordering comes off the index rather than a sort.
+    index("idx_conversation_queued_messages_conv_sort").on(
+      table.conversationId,
+      table.sortKey,
+    ),
+  ],
+);

--- a/assistant/src/persistence/schema/index.ts
+++ b/assistant/src/persistence/schema/index.ts
@@ -4,6 +4,7 @@ export * from "./bookmarks.js";
 export * from "./calls.js";
 export * from "./contacts.js";
 export * from "./conversation-groups.js";
+export * from "./conversation-queue.js";
 export * from "./conversation-starters.js";
 export * from "./conversations.js";
 export * from "./documents.js";

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -473,6 +473,7 @@ import { migrateAddConversationSubagentKind } from "./migrations/362-add-convers
 import { migrateBackfillScheduleInferenceProfile } from "./migrations/363-backfill-schedule-inference-profile.js";
 import { migrateAddScheduleSourceKey } from "./migrations/364-add-schedule-source-key.js";
 import { migrateAddConversationForkStrategy } from "./migrations/365-add-conversation-fork-strategy.js";
+import { migrateCreateConversationQueuedMessages } from "./migrations/366-create-conversation-queued-messages.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1573,4 +1574,11 @@ export const migrationSteps: MigrationStep[] = [
   },
   migrateAddScheduleSourceKey,
   migrateAddConversationForkStrategy,
+  {
+    name: "migrateCreateConversationQueuedMessages",
+    run: migrateCreateConversationQueuedMessages,
+    // The table declares `REFERENCES conversations(id) ON DELETE CASCADE`, so
+    // `conversations` must exist and be checkpointed before it is created.
+    dependsOn: ["migrateCoreTables"],
+  },
 ];


### PR DESCRIPTION
## TL;DR

First of two PRs closing the queued-message durability gap (Part of LUM-2850, continuing the LUM-2849 arc). Adds the `conversation_queued_messages` staging table (migration 366) and a synchronous store module with the full row lifecycle the in-memory queue needs: insert with per-conversation FIFO sort keys, `queued`/`draining` state flips, promote-to-head for steer, per-row and per-conversation deletes, FIFO backlog reads, and the startup-sweep listing. The companion durability PR makes `MessageQueue` write through this store from inside its own mutation methods and adds restart recovery; both land in the same release train, so no release ships a table with no reader.

Full design and the PR arc: working plan attached below in the review thread on request; decisions of record are on LUM-2849 (comment of 2026-08-07).

## What changes for the user

| | Before | After |
|---|---|---|
| This PR alone | Queued messages exist only in daemon memory | No behavior change; schema and store only, nothing writes the table yet |
| After the companion PR | A daemon restart silently destroys queued messages the user was told were accepted | Queued messages survive restarts and drain normally |

## Why this is safe

- The migration is `CREATE TABLE IF NOT EXISTS` plus one index; no backfill, no `ALTER`, no data rewrite. It depends on `migrateCoreTables` (the FK references `conversations` with `ON DELETE CASCADE`).
- No production code outside the new store module touches the table, and nothing calls the store yet; the diff is additive.
- Store helpers are best-effort by policy: a failed durable write logs and degrades (the queue accepted the message; a storage failure must not reject a send the sender was already told about), and failed reads recover nothing. This matches the daemon's subsystem-degradation rule.
- Auth/trust snapshots are deliberately not persistable: the row stores `source_actor_principal_id` only, and the drain re-derives current trust at processing time, so a restart can never replay a stale authorization decision.

## Tests

- Migration: fresh create, idempotent re-run preserving rows, FK cascade on conversation delete, `state` default.
- Store: per-conversation FIFO sort keys, JSON projection round-trip, promote-to-head ordering, draining/queued flips, targeted deletes, distinct backlog listing, and the swallow-on-failure policy (FK-violating insert does not throw).

Local `bun test` is hook-blocked in this environment; typecheck and lint pass locally and CI runs the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40486" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->