### PR TITLE
feat(web): translate the copy that reaches the screen from outside JSX

### DIFF
--- a/clients/web/src/domains/account/components/signup-screen.tsx
+++ b/clients/web/src/domains/account/components/signup-screen.tsx
@@ -53,7 +53,7 @@ export function SignupScreen({ returnTo }: SignupScreenProps) {
       intent: "signup",
     }).catch((err) => {
       console.error("[signup] auth flow failed:", err);
-      setError("Something went wrong. Please try again.");
+      setError(t("authErrors.genericFailure"));
     });
   };
 
@@ -65,7 +65,7 @@ export function SignupScreen({ returnTo }: SignupScreenProps) {
       returnTo,
     }).catch((err) => {
       console.error("[signup] sign-in flow failed:", err);
-      setError("Something went wrong. Please try again.");
+      setError(t("authErrors.genericFailure"));
     });
   };
 

--- a/clients/web/src/domains/account/native-auth-error.test.ts
+++ b/clients/web/src/domains/account/native-auth-error.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
 import {
-  GENERIC_AUTH_ERROR_MESSAGE,
+  GENERIC_AUTH_ERROR_KEY,
   isUserCancelledAuthError,
   nativeAuthErrorCode,
   nativeAuthErrorDetail,
-  nativeAuthErrorMessage,
+  nativeAuthErrorKey,
 } from "./native-auth-error";
 
 /**
@@ -15,7 +15,10 @@ import {
  * the Error). These helpers build that exact shape.
  */
 function nativeRejection(code: string, data?: Record<string, unknown>): Error {
-  return Object.assign(new Error("rejected"), { code, ...(data ? { data } : {}) });
+  return Object.assign(new Error("rejected"), {
+    code,
+    ...(data ? { data } : {}),
+  });
 }
 
 function authErrorRejection(authError: string): Error {
@@ -78,7 +81,9 @@ describe("nativeAuthErrorDetail", () => {
   });
 
   test("is undefined when AUTH_ERROR carries no usable cause", () => {
-    expect(nativeAuthErrorDetail(nativeRejection("AUTH_ERROR"))).toBeUndefined();
+    expect(
+      nativeAuthErrorDetail(nativeRejection("AUTH_ERROR")),
+    ).toBeUndefined();
     expect(
       nativeAuthErrorDetail(nativeRejection("AUTH_ERROR", {})),
     ).toBeUndefined();
@@ -91,37 +96,38 @@ describe("nativeAuthErrorDetail", () => {
   });
 });
 
-describe("nativeAuthErrorMessage", () => {
-  test("explains a closed signup instead of asking the user to retry", () => {
-    const message = nativeAuthErrorMessage(authErrorRejection("signup_closed"));
-
-    expect(message).not.toBe(GENERIC_AUTH_ERROR_MESSAGE);
-    expect(message).toContain("vellum.ai/community");
+describe("nativeAuthErrorKey", () => {
+  test("names the closed-signup message instead of the retry one", () => {
+    // The copy itself now lives in the account catalog, so what this module
+    // owns is the mapping: a known cause must not collapse to the generic key.
+    expect(nativeAuthErrorKey(authErrorRejection("signup_closed"))).toBe(
+      "authErrors.signupClosed",
+    );
   });
 
   test("explains a provider account that is not linked to an account yet", () => {
-    expect(nativeAuthErrorMessage(authErrorRejection("provider_signup"))).toBe(
-      "No Vellum account is linked to that login yet. Sign up first, then sign in.",
+    expect(nativeAuthErrorKey(authErrorRejection("provider_signup"))).toBe(
+      "authErrors.providerSignup",
     );
   });
 
   test("explains a sign-in that needs a step this shell cannot run", () => {
-    expect(nativeAuthErrorMessage(authErrorRejection("login_incomplete"))).toBe(
-      "Your account needs another step to finish signing in. Please sign in on the web, then try again.",
+    expect(nativeAuthErrorKey(authErrorRejection("login_incomplete"))).toBe(
+      "authErrors.loginIncomplete",
     );
   });
 
   test("falls back to the generic message for an unmapped cause", () => {
     // allauth names its own code in a 400, so unmapped values reach here.
-    expect(nativeAuthErrorMessage(authErrorRejection("some_new_code"))).toBe(
-      GENERIC_AUTH_ERROR_MESSAGE,
+    expect(nativeAuthErrorKey(authErrorRejection("some_new_code"))).toBe(
+      GENERIC_AUTH_ERROR_KEY,
     );
   });
 
   test("falls back to the generic message for an unclassified failure", () => {
-    expect(nativeAuthErrorMessage(new Error("Failed to fetch"))).toBe(
-      GENERIC_AUTH_ERROR_MESSAGE,
+    expect(nativeAuthErrorKey(new Error("Failed to fetch"))).toBe(
+      GENERIC_AUTH_ERROR_KEY,
     );
-    expect(nativeAuthErrorMessage(undefined)).toBe(GENERIC_AUTH_ERROR_MESSAGE);
+    expect(nativeAuthErrorKey(undefined)).toBe(GENERIC_AUTH_ERROR_KEY);
   });
 });

--- a/clients/web/src/domains/account/native-auth-error.ts
+++ b/clients/web/src/domains/account/native-auth-error.ts
@@ -19,9 +19,24 @@ import { VELLUM_COMMUNITY_URL } from "@/utils/external-urls";
  * those causes into copy, so the three entry points cannot drift apart.
  */
 
-/** Shown when nothing more specific is known — a transport failure, a bug. */
-export const GENERIC_AUTH_ERROR_MESSAGE =
-  "Something went wrong. Please try again.";
+/** Catalog keys this module can name, all under the `account` namespace. */
+export type AuthErrorKey =
+  | "authErrors.genericFailure"
+  | "authErrors.signupClosed"
+  | "authErrors.providerSignup"
+  | "authErrors.loginIncomplete";
+
+/**
+ * The community link as prose, displayed bare without its scheme. Passed as
+ * the `community` value of `authErrors.signupClosed`.
+ */
+export const AUTH_ERROR_COMMUNITY_LINK = VELLUM_COMMUNITY_URL.replace(
+  /^https?:\/\//,
+  "",
+);
+
+/** Shown when nothing more specific is known: a transport failure, a bug. */
+export const GENERIC_AUTH_ERROR_KEY = "authErrors.genericFailure" as const;
 
 /**
  * Copy per `data.authError`. Keys are the codes the native shells emit:
@@ -30,15 +45,10 @@ export const GENERIC_AUTH_ERROR_MESSAGE =
  * falls back to {@link GENERIC_AUTH_ERROR_MESSAGE} — an unmapped code is a
  * missing entry here, never a crash.
  */
-/** The community link as prose — displayed bare, without its scheme. */
-const COMMUNITY_LINK_TEXT = VELLUM_COMMUNITY_URL.replace(/^https?:\/\//, "");
-
-const AUTH_ERROR_MESSAGES: Record<string, string> = {
-  signup_closed: `Sign-ups are currently closed. Visit ${COMMUNITY_LINK_TEXT} to request access.`,
-  provider_signup:
-    "No Vellum account is linked to that login yet. Sign up first, then sign in.",
-  login_incomplete:
-    "Your account needs another step to finish signing in. Please sign in on the web, then try again.",
+const AUTH_ERROR_KEYS: Record<string, AuthErrorKey> = {
+  signup_closed: "authErrors.signupClosed",
+  provider_signup: "authErrors.providerSignup",
+  login_incomplete: "authErrors.loginIncomplete",
 };
 
 function errorProperty(err: unknown, key: string): unknown {
@@ -81,11 +91,18 @@ export function nativeAuthErrorDetail(err: unknown): string | undefined {
   return typeof detail === "string" && detail !== "" ? detail : undefined;
 }
 
-/** User-facing copy for a rejected auth flow. */
-export function nativeAuthErrorMessage(err: unknown): string {
+/**
+ * Catalog key for a rejected auth flow, not the copy itself.
+ *
+ * A plain module cannot call `useTranslation()`, so returning a key keeps the
+ * mapping here and leaves the rendering to a component that knows the active
+ * locale. `authErrors.signupClosed` interpolates `community`, which callers
+ * supply from {@link AUTH_ERROR_COMMUNITY_LINK}.
+ */
+export function nativeAuthErrorKey(err: unknown): AuthErrorKey {
   const detail = nativeAuthErrorDetail(err);
   if (detail === undefined) {
-    return GENERIC_AUTH_ERROR_MESSAGE;
+    return GENERIC_AUTH_ERROR_KEY;
   }
-  return AUTH_ERROR_MESSAGES[detail] ?? GENERIC_AUTH_ERROR_MESSAGE;
+  return AUTH_ERROR_KEYS[detail] ?? GENERIC_AUTH_ERROR_KEY;
 }

--- a/clients/web/src/domains/account/pages/account-page.tsx
+++ b/clients/web/src/domains/account/pages/account-page.tsx
@@ -37,7 +37,7 @@ export function AccountPage() {
       await startAuthFlow(PROVIDER_ID, PROVIDER_CALLBACK_URL);
     } catch (err) {
       console.error("[account] auth flow failed:", err);
-      setErrorMessage("Something went wrong. Please try again.");
+      setErrorMessage(t("authErrors.genericFailure"));
       setSigningIn(false);
     }
   };

--- a/clients/web/src/domains/account/pages/login-page.tsx
+++ b/clients/web/src/domains/account/pages/login-page.tsx
@@ -18,7 +18,8 @@ import {
 import {
   isUserCancelledAuthError,
   nativeAuthErrorDetail,
-  nativeAuthErrorMessage,
+  AUTH_ERROR_COMMUNITY_LINK,
+  nativeAuthErrorKey,
 } from "@/domains/account/native-auth-error";
 import { withPreservedAttribution } from "@/domains/account/social-auth";
 import { captureError } from "@/lib/sentry/capture-error";
@@ -58,7 +59,9 @@ function NativeLoginForm({ returnTo }: { returnTo: string | null }) {
         context: "native_login",
         tags: { authError: nativeAuthErrorDetail(err) ?? "unclassified" },
       });
-      setErrorMessage(nativeAuthErrorMessage(err));
+      setErrorMessage(
+        t(nativeAuthErrorKey(err), { community: AUTH_ERROR_COMMUNITY_LINK }),
+      );
       setLoading(false);
     }
   };
@@ -119,7 +122,9 @@ function WebLoginForm({ returnTo }: { returnTo: string | null }) {
         context: "web_login",
         tags: { authError: nativeAuthErrorDetail(err) ?? "unclassified" },
       });
-      setErrorMessage(nativeAuthErrorMessage(err));
+      setErrorMessage(
+        t(nativeAuthErrorKey(err), { community: AUTH_ERROR_COMMUNITY_LINK }),
+      );
       setLoading(false);
     }
   };

--- a/clients/web/src/domains/account/pages/platform-loopback-page.tsx
+++ b/clients/web/src/domains/account/pages/platform-loopback-page.tsx
@@ -44,17 +44,17 @@ export function PlatformLoopbackPage() {
     sessionStorage.removeItem(LOOPBACK_RETURN_TO_KEY);
 
     if (!state || state !== expectedState) {
-      setError("Login failed: state mismatch. Please try again.");
+      setError(t("authErrors.loopbackStateMismatch"));
       return;
     }
 
     if (!sessionToken) {
-      setError("Login failed: no session token received. Please try again.");
+      setError(t("authErrors.loopbackNoToken"));
       return;
     }
 
     if (!/^[a-zA-Z0-9]+$/.test(sessionToken)) {
-      setError("Login failed: invalid session token.");
+      setError(t("authErrors.loopbackInvalidToken"));
       return;
     }
 
@@ -92,7 +92,7 @@ export function PlatformLoopbackPage() {
       }
       void navigate(returnTo, { replace: true });
     })();
-  }, [searchParams, navigate]);
+  }, [searchParams, navigate, t]);
 
   if (error) {
     return (

--- a/clients/web/src/domains/account/pages/provider-signup-page.tsx
+++ b/clients/web/src/domains/account/pages/provider-signup-page.tsx
@@ -119,7 +119,7 @@ export function ProviderSignupPage() {
     try {
       await completeSignup();
     } catch {
-      setError("Something went wrong. Please try again.");
+      setError(t("authErrors.genericFailure"));
     } finally {
       setIsSubmitting(false);
     }
@@ -138,7 +138,7 @@ export function ProviderSignupPage() {
       // `account` domain may not import `onboarding` directly). Deferred.
       await completeSignup();
     } catch {
-      setError("Something went wrong. Please try again.");
+      setError(t("authErrors.genericFailure"));
     } finally {
       setIsSubmitting(false);
     }

--- a/clients/web/src/domains/account/social-auth.ts
+++ b/clients/web/src/domains/account/social-auth.ts
@@ -88,10 +88,7 @@ export function readAttributionParams(search: string): Record<string, string> {
  * attribution was decorated deliberately upstream, so re-applying is safe
  * (idempotent). Returns `href` unchanged when nothing new is collected.
  */
-export function withPreservedAttribution(
-  href: string,
-  search: string,
-): string {
+export function withPreservedAttribution(href: string, search: string): string {
   const queryStart = href.indexOf("?");
   const existing = new URLSearchParams(
     queryStart === -1 ? "" : href.slice(queryStart + 1),

--- a/clients/web/src/domains/channels/channel-meta.ts
+++ b/clients/web/src/domains/channels/channel-meta.ts
@@ -1,47 +1,59 @@
 import type { SetupChannelId } from "@/types/channel-types";
 
+/**
+ * Per-adapter presentation metadata for the Channels tab.
+ *
+ * The copy itself lives in the `channels` catalog; this module holds the keys
+ * that reach it. A data module cannot call `useTranslation()`, and a plain
+ * string here would render English whatever the active locale is, which is how
+ * the disconnect dialog and the disconnected empty state stayed English after
+ * the domain was otherwise converted.
+ *
+ * Shared by `AssistantChannelsList` (disconnect dialog) and `ChannelPanel`
+ * (trust floor + empty state), so it lives in its own module rather than
+ * having one component import it from the other.
+ */
 interface ChannelMeta {
-  /** The disconnect-dialog subject ("Disconnect {label}?"). */
-  label: string;
-  disconnectMessage: string;
+  /** Catalog key for the disconnect-dialog subject ("Disconnect {label}?"). */
+  labelKey:
+    | "channelMeta.slack.label"
+    | "channelMeta.telegram.label"
+    | "channelMeta.phone.label";
+  disconnectMessageKey:
+    | "channelMeta.slack.disconnectMessage"
+    | "channelMeta.telegram.disconnectMessage"
+    | "channelMeta.phone.disconnectMessage";
   /**
    * Whether a connected channel surfaces the "Who can message" trust-floor
    * dropdown. Slack has none: its admission floors are managed per
    * conversation type (DMs vs. channels), with no channel-wide knob.
    */
   hasTrustFloorControl: boolean;
-  /** One-line pitch for the disconnected empty state. Slack has none — its disconnected state is the setup wizard. */
-  disconnectedPitch?: (displayName: string) => string;
+  /**
+   * Catalog key for the disconnected empty state's pitch, which interpolates
+   * `assistant`. Slack has none: its disconnected state is the setup wizard.
+   */
+  disconnectedPitchKey?:
+    | "channelMeta.telegram.disconnectedPitch"
+    | "channelMeta.phone.disconnectedPitch";
 }
 
-/**
- * Per-adapter presentation metadata for the Channels tab: disconnect-dialog
- * copy, whether the connected panel shows the trust-floor control, and the
- * disconnected-state pitch. Shared by `AssistantChannelsList` (disconnect
- * dialog) and `ChannelPanel` (trust floor + empty state), so it lives in its
- * own module rather than having one component import it from the other.
- */
 export const CHANNEL_META: Record<SetupChannelId, ChannelMeta> = {
   slack: {
-    label: "Slack",
-    disconnectMessage:
-      "This clears the stored Slack bot and app tokens for this assistant. You can reconnect later.",
+    labelKey: "channelMeta.slack.label",
+    disconnectMessageKey: "channelMeta.slack.disconnectMessage",
     hasTrustFloorControl: false,
   },
   telegram: {
-    label: "Telegram",
-    disconnectMessage:
-      "This clears the stored Telegram bot token for this assistant. You can reconnect later.",
+    labelKey: "channelMeta.telegram.label",
+    disconnectMessageKey: "channelMeta.telegram.disconnectMessage",
     hasTrustFloorControl: true,
-    disconnectedPitch: (displayName) =>
-      `Connect a Telegram bot so ${displayName} can send and receive messages on Telegram.`,
+    disconnectedPitchKey: "channelMeta.telegram.disconnectedPitch",
   },
   phone: {
-    label: "Phone Calling",
-    disconnectMessage:
-      "This clears the stored Twilio credentials for this assistant. You can reconnect later.",
+    labelKey: "channelMeta.phone.label",
+    disconnectMessageKey: "channelMeta.phone.disconnectMessage",
     hasTrustFloorControl: true,
-    disconnectedPitch: (displayName) =>
-      `Connect your Twilio account so ${displayName} can make and answer phone calls.`,
+    disconnectedPitchKey: "channelMeta.phone.disconnectedPitch",
   },
 };

--- a/clients/web/src/domains/channels/components/assistant-channels-list.tsx
+++ b/clients/web/src/domains/channels/components/assistant-channels-list.tsx
@@ -307,9 +307,9 @@ export function AssistantChannelsList({
       <ConfirmDialog
         open={pendingDisconnect !== null}
         title={t("assistantChannelsList.disconnectTitle", {
-          channel: disconnectMeta?.label ?? "",
+          channel: disconnectMeta ? t(disconnectMeta.labelKey) : "",
         })}
-        message={disconnectMeta?.disconnectMessage ?? ""}
+        message={disconnectMeta ? t(disconnectMeta.disconnectMessageKey) : ""}
         confirmLabel={t("assistantChannelsList.disconnectConfirm")}
         destructive
         onConfirm={() => {

--- a/clients/web/src/domains/channels/components/channel-panel.tsx
+++ b/clients/web/src/domains/channels/components/channel-panel.tsx
@@ -200,7 +200,11 @@ export function ChannelPanel({
                 t("channelPanel.incompleteDescription", {
                   channel: getChannelLabel(channel.key),
                 }))
-              : meta.disconnectedPitch?.(assistantDisplayName)
+              : meta.disconnectedPitchKey
+                ? t(meta.disconnectedPitchKey, {
+                    assistant: assistantDisplayName,
+                  })
+                : undefined
           }
           action={
             <div className="flex flex-col items-center gap-1">

--- a/clients/web/src/domains/schedules/components/system-task-detail-panel.tsx
+++ b/clients/web/src/domains/schedules/components/system-task-detail-panel.tsx
@@ -92,7 +92,7 @@ export function SystemTaskDetailPanel({
   let onRunNow: (() => void) | undefined;
 
   if (kind === "heartbeat") {
-    name = "Heartbeat";
+    name = t("systemTaskDetail.nameHeartbeat");
     subtitle = heartbeatConfig ? heartbeatSubtitle(heartbeatConfig) : "";
     enabled = heartbeatConfig?.enabled ?? false;
     nextRunAt = heartbeatConfig?.nextRunAt ?? null;
@@ -100,7 +100,7 @@ export function SystemTaskDetailPanel({
     isRunning = systemTasks.isHeartbeatRunning;
     onRunNow = systemTasks.runHeartbeatNow;
   } else if (kind === "consolidation") {
-    name = "Consolidation";
+    name = t("systemTaskDetail.nameConsolidation");
     subtitle = consolidationConfig
       ? consolidationSubtitle(consolidationConfig)
       : "";
@@ -110,7 +110,7 @@ export function SystemTaskDetailPanel({
     isRunning = systemTasks.isConsolidationRunning;
     onRunNow = systemTasks.runConsolidationNow;
   } else {
-    name = "Memory retrospective";
+    name = t("systemTaskDetail.nameRetrospective");
     subtitle = RETROSPECTIVE_SUBTITLE;
     enabled = retrospectiveConfig?.enabled ?? false;
     // Event-driven: no global "next run".
@@ -132,18 +132,18 @@ export function SystemTaskDetailPanel({
   const runNowDisabled = isRunning || isMemoryPaused;
   const statusValue = isMemoryManaged
     ? enabled
-      ? "On · Managed by Memory"
-      : "Paused"
+      ? t("systemTaskDetail.statusManagedOn")
+      : t("systemTaskDetail.statusPaused")
     : enabled
-      ? "Enabled"
-      : "Disabled";
+      ? t("scheduleDetail.enabled")
+      : t("scheduleDetail.disabled");
   const isRetrospectiveSwitchedOff =
     isRetrospective && retrospectiveConfig?.available === true;
   const pausedNotice = isRetrospectiveSwitchedOff
-    ? "Retrospectives are turned off. Turn them back on under Memory in settings."
+    ? t("systemTaskDetail.pausedRetrospectiveSwitchedOff")
     : isRetrospective
-      ? "Memory is off, so retrospectives are paused. Turn Memory back on to resume them."
-      : "Memory is off, so consolidation is paused. Turn Memory back on to resume consolidation.";
+      ? t("systemTaskDetail.pausedRetrospective")
+      : t("systemTaskDetail.pausedConsolidation");
   const showMemorySettings =
     isMemoryManaged && enabled && canOpenMemorySettings;
 

--- a/clients/web/src/hooks/use-onboarding-login.ts
+++ b/clients/web/src/hooks/use-onboarding-login.ts
@@ -1,10 +1,12 @@
 import { useRef, useState } from "react";
 import { useLocation } from "react-router";
 
+import { t } from "@/i18n";
 import { PROVIDER_ID } from "@/domains/account/login-flow";
 import {
   nativeAuthErrorDetail,
-  nativeAuthErrorMessage,
+  AUTH_ERROR_COMMUNITY_LINK,
+  nativeAuthErrorKey,
 } from "@/domains/account/native-auth-error";
 import { buildNavigationState } from "@/lib/navigation/build-state";
 import { captureError } from "@/lib/sentry/capture-error";
@@ -41,7 +43,11 @@ export function useOnboardingLogin(returnToOverride?: string) {
         context: "onboarding_login",
         tags: { authError: nativeAuthErrorDetail(err) ?? "unclassified" },
       });
-      setError(nativeAuthErrorMessage(err));
+      setError(
+        t(`account:${nativeAuthErrorKey(err)}`, {
+          community: AUTH_ERROR_COMMUNITY_LINK,
+        }),
+      );
       setLoading(false);
     }
   };

--- a/clients/web/src/i18n/locales/en/account.json
+++ b/clients/web/src/i18n/locales/en/account.json
@@ -75,5 +75,14 @@
     "usernamePlaceholder": "Username",
     "completeSignup": "Complete signup",
     "completingSignup": "Completing..."
+  },
+  "authErrors": {
+    "genericFailure": "Something went wrong. Please try again.",
+    "signupClosed": "Sign-ups are currently closed. Visit {community} to request access.",
+    "providerSignup": "No Vellum account is linked to that login yet. Sign up first, then sign in.",
+    "loginIncomplete": "Your account needs another step to finish signing in. Please sign in on the web, then try again.",
+    "loopbackStateMismatch": "Login failed: state mismatch. Please try again.",
+    "loopbackNoToken": "Login failed: no session token received. Please try again.",
+    "loopbackInvalidToken": "Login failed: invalid session token."
   }
 }

--- a/clients/web/src/i18n/locales/en/channels.json
+++ b/clients/web/src/i18n/locales/en/channels.json
@@ -91,5 +91,21 @@
     "authTokenPlaceholder": "Twilio auth token",
     "saving": "Saving…",
     "save": "Save"
+  },
+  "channelMeta": {
+    "slack": {
+      "label": "Slack",
+      "disconnectMessage": "This clears the stored Slack bot and app tokens for this assistant. You can reconnect later."
+    },
+    "telegram": {
+      "label": "Telegram",
+      "disconnectMessage": "This clears the stored Telegram bot token for this assistant. You can reconnect later.",
+      "disconnectedPitch": "Connect a Telegram bot so {assistant} can send and receive messages on Telegram."
+    },
+    "phone": {
+      "label": "Phone Calling",
+      "disconnectMessage": "This clears the stored Twilio credentials for this assistant. You can reconnect later.",
+      "disconnectedPitch": "Connect your Twilio account so {assistant} can make and answer phone calls."
+    }
   }
 }

--- a/clients/web/src/i18n/locales/en/schedules.json
+++ b/clients/web/src/i18n/locales/en/schedules.json
@@ -63,7 +63,15 @@
     "openMemorySettings": "Open Memory settings",
     "turnOnMemory": "Turn on Memory",
     "memorySettings": "Memory settings",
-    "fallbackModelProfile": "Default (system task model)"
+    "fallbackModelProfile": "Default (system task model)",
+    "nameHeartbeat": "Heartbeat",
+    "nameConsolidation": "Consolidation",
+    "nameRetrospective": "Memory retrospective",
+    "statusManagedOn": "On · Managed by Memory",
+    "statusPaused": "Paused",
+    "pausedRetrospectiveSwitchedOff": "Retrospectives are turned off. Turn them back on under Memory in settings.",
+    "pausedRetrospective": "Memory is off, so retrospectives are paused. Turn Memory back on to resume them.",
+    "pausedConsolidation": "Memory is off, so consolidation is paused. Turn Memory back on to resume consolidation."
   },
   "scheduleRow": {
     "toggleAria": "Toggle {name}"

--- a/clients/web/src/i18n/locales/es/account.json
+++ b/clients/web/src/i18n/locales/es/account.json
@@ -75,5 +75,14 @@
     "usernamePlaceholder": "Nombre de usuario",
     "completeSignup": "Completar el registro",
     "completingSignup": "Completando..."
+  },
+  "authErrors": {
+    "genericFailure": "Algo ha ido mal. Inténtalo de nuevo.",
+    "signupClosed": "Los registros están cerrados por ahora. Visita {community} para solicitar acceso.",
+    "providerSignup": "Todavía no hay ninguna cuenta de Vellum vinculada a ese inicio de sesión. Regístrate primero y luego inicia sesión.",
+    "loginIncomplete": "Tu cuenta necesita un paso más para terminar de iniciar sesión. Inicia sesión en la web y vuelve a intentarlo.",
+    "loopbackStateMismatch": "No se pudo iniciar sesión: el estado no coincide. Inténtalo de nuevo.",
+    "loopbackNoToken": "No se pudo iniciar sesión: no se recibió ningún token de sesión. Inténtalo de nuevo.",
+    "loopbackInvalidToken": "No se pudo iniciar sesión: el token de sesión no es válido."
   }
 }

--- a/clients/web/src/i18n/locales/es/channels.json
+++ b/clients/web/src/i18n/locales/es/channels.json
@@ -91,5 +91,21 @@
     "authTokenPlaceholder": "Token de autenticación de Twilio",
     "saving": "Guardando…",
     "save": "Guardar"
+  },
+  "channelMeta": {
+    "slack": {
+      "label": "Slack",
+      "disconnectMessage": "Esto borra los tokens de bot y de aplicación de Slack guardados para este asistente. Puedes volver a conectarlo más tarde."
+    },
+    "telegram": {
+      "label": "Telegram",
+      "disconnectMessage": "Esto borra el token de bot de Telegram guardado para este asistente. Puedes volver a conectarlo más tarde.",
+      "disconnectedPitch": "Conecta un bot de Telegram para que {assistant} pueda enviar y recibir mensajes en Telegram."
+    },
+    "phone": {
+      "label": "Llamadas telefónicas",
+      "disconnectMessage": "Esto borra las credenciales de Twilio guardadas para este asistente. Puedes volver a conectarlo más tarde.",
+      "disconnectedPitch": "Conecta tu cuenta de Twilio para que {assistant} pueda hacer y contestar llamadas."
+    }
   }
 }

--- a/clients/web/src/i18n/locales/es/schedules.json
+++ b/clients/web/src/i18n/locales/es/schedules.json
@@ -63,7 +63,15 @@
     "openMemorySettings": "Abrir la configuración de Memoria",
     "turnOnMemory": "Activar Memoria",
     "memorySettings": "Configuración de Memoria",
-    "fallbackModelProfile": "Predeterminado (modelo de tareas del sistema)"
+    "fallbackModelProfile": "Predeterminado (modelo de tareas del sistema)",
+    "nameHeartbeat": "Latido",
+    "nameConsolidation": "Consolidación",
+    "nameRetrospective": "Retrospectiva de memoria",
+    "statusManagedOn": "Activo · Gestionado por Memoria",
+    "statusPaused": "En pausa",
+    "pausedRetrospectiveSwitchedOff": "Las retrospectivas están desactivadas. Vuelve a activarlas en Memoria, dentro de los ajustes.",
+    "pausedRetrospective": "Memoria está desactivada, así que las retrospectivas están en pausa. Vuelve a activar Memoria para reanudarlas.",
+    "pausedConsolidation": "Memoria está desactivada, así que la consolidación está en pausa. Vuelve a activar Memoria para reanudarla."
   },
   "scheduleRow": {
     "toggleAria": "Alternar {name}"


### PR DESCRIPTION
## Prompt / plan

The remaining Codex findings from #40454, #40465 and #40479, and the follow-up #40487 promised.

#40487 made the lint rule honest about what it covers; this closes the gap it documented. None of this copy is visible to a JSX-reading rule, which is exactly why it survived three domains being marked converted. It is what Spanish users actually still saw in English.

## Data modules now hold keys, not copy

`CHANNEL_META` carried the disconnect-dialog message and the disconnected-state pitch as plain strings. A plain module cannot call `useTranslation()`, so those rendered English whatever the locale — the disconnect confirmation and the empty state on every channel.

It now carries `labelKey`, `disconnectMessageKey` and `disconnectedPitchKey`, typed as **the exact unions the catalog defines**. My first attempt used a `channelMeta.${SetupChannelId}.*` template type and `tsc` rejected it, because that names a `channelMeta.slack.disconnectedPitch` which does not exist (Slack's disconnected state is the setup wizard). Worth the extra lines: the narrower type is the one that is true.

`native-auth-error.ts` had the same shape and the same fix. `nativeAuthErrorMessage()` returned copy from a `Record<string, string>` table; it is now `nativeAuthErrorKey()` returning a typed `AuthErrorKey` that its two call sites translate. The community link moved out to `AUTH_ERROR_COMMUNITY_LINK` and is passed as the `community` value of `authErrors.signupClosed`.

Its test asserted the English sentences verbatim. It now asserts the **mapping** — that `signup_closed` reaches `authErrors.signupClosed` rather than collapsing to the generic key — which is the thing this module actually owns now that the copy lives in the catalog.

## Computed-in-TypeScript copy

Everything below reached JSX already-English, so no JSX rule could ever have seen it:

- every `setError` / `setErrorMessage` literal across signup, account, platform-loopback and provider-signup
- the system-task panel's `name` (`"Heartbeat"`, `"Consolidation"`, `"Memory retrospective"`), `statusValue` (`"On · Managed by Memory"`, `"Paused"`) and all three `pausedNotice` variants

## One thing the hooks rule caught

Adding `t` inside the loopback page's `useEffect` needed it declared in the dependency array. Fixed rather than left as a new warning — the count is back to the 16 pre-existing ones.

## Test plan

- `bun scripts/run-tests.ts`: **922 test files pass, 0 fail**
- `bun run lint`: 0 errors, 16 warnings — verified against a stashed baseline that the set is unchanged from main
- `bunx tsc --noEmit` clean; pre-commit hook passed without bypass
- `bun run build` clean

## Where the cutover stands

Four namespaces (`schedules`, `account`, `channels`, `chat` partial) are now converted in both their JSX **and** their non-JSX copy. That is the first time that claim has been true.

Remaining by survey count, expect 25–45% more in practice: settings 1275, chat 750, components 369, onboarding 151, intelligence 141, contacts 69, home 40, library 33, workspace 30, credential-requests 21, logs 19, terminal 11, remote-web 5.

I'd still put the **pseudolocale** before `settings` and `chat`. Five of the six Codex findings across three PRs were "you missed a shape", and each cost a round trip. A pseudolocale catches copy by what reaches the screen rather than by what a rule can parse, which is the only way to stop finding shape number six the hard way.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CD12TRfmDF3UiXjdbiWn3i)_