### PR TITLE
feat(billing): abandoned-checkout $5 bonus claim modal

### DIFF
--- a/clients/web/eslint.config.mjs
+++ b/clients/web/eslint.config.mjs
@@ -194,6 +194,7 @@ const i18nEnforcedPaths = [
   "src/domains/chat/components/conversation-assets-pill.tsx",
   "src/domains/chat/components/pinned-app-color-swatches.tsx",
   "src/domains/schedules/**/*.{ts,tsx}",
+  "src/domains/settings/billing/checkout-bonus-modal.tsx",
   "src/domains/account/**/*.{ts,tsx}",
   "src/domains/channels/**/*.{ts,tsx}",
 ];

--- a/clients/web/src/domains/settings/billing/checkout-bonus-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-bonus-modal.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * Tests for `CheckoutBonusModal`:
+ *  - the offer copy and claim button render the amount from props, never a
+ *    hardcoded figure
+ *  - a granted claim toasts success with the server-returned amount,
+ *    invalidates the billing summary, and closes
+ *  - `already_claimed` / `ineligible` claims toast info and close without
+ *    touching the billing summary
+ *  - a failed claim toasts an error and keeps the modal open with the button
+ *    re-enabled
+ *  - both actions are disabled while the claim is in flight
+ *
+ * The claim call is mocked at the SDK boundary so the real generated mutation
+ * factory (and its cache-invalidation contract) stays in the loop. Radix
+ * portals the dialog, so queries go through `screen` (document.body).
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+
+import * as sdkGen from "@/generated/api/sdk.gen";
+import type { CheckoutBonusClaimResponse } from "@/generated/api/types.gen";
+import * as toastModule from "@vellumai/design-library/components/toast";
+
+const GRANTED: CheckoutBonusClaimResponse = {
+  status: "granted",
+  amount_usd: "5.00",
+  balance_usd: "5.00",
+};
+
+let claimCalls = 0;
+// Lazy so a per-test rejection is only created once a handler will attach.
+let claimImpl: () => Promise<{ data: CheckoutBonusClaimResponse }> = () =>
+  Promise.resolve({ data: GRANTED });
+let successToasts: string[] = [];
+let infoToasts: string[] = [];
+let errorToasts: string[] = [];
+
+mock.module("@/generated/api/sdk.gen", () => ({
+  ...sdkGen,
+  organizationsBillingCheckoutBonusCreate: () => {
+    claimCalls += 1;
+    return claimImpl();
+  },
+}));
+
+mock.module("@vellumai/design-library/components/toast", () => ({
+  ...toastModule,
+  toast: {
+    success: (message: string) => successToasts.push(message),
+    info: (message: string) => infoToasts.push(message),
+    error: (message: string) => errorToasts.push(message),
+    warning: () => {},
+  },
+}));
+
+const { organizationsBillingSummaryRetrieveQueryKey } =
+  await import("@/generated/api/@tanstack/react-query.gen");
+const { CheckoutBonusModal } = await import("./checkout-bonus-modal");
+
+const SUMMARY_KEY = organizationsBillingSummaryRetrieveQueryKey();
+
+function renderModal({
+  amountUsd = "5.00",
+  onOpenChange = () => {},
+}: {
+  amountUsd?: string;
+  onOpenChange?: (open: boolean) => void;
+} = {}) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  // Seed the billing summary entry so invalidation is observable without the
+  // query ever fetching.
+  queryClient.setQueryData(SUMMARY_KEY, { settled_balance_usd: "0.00" });
+  render(
+    <QueryClientProvider client={queryClient}>
+      <CheckoutBonusModal
+        open
+        onOpenChange={onOpenChange}
+        amountUsd={amountUsd}
+      />
+    </QueryClientProvider>,
+  );
+  return queryClient;
+}
+
+function claimButton(): HTMLButtonElement {
+  return screen.getByTestId("claim-checkout-bonus-button") as HTMLButtonElement;
+}
+
+afterEach(() => {
+  cleanup();
+  claimCalls = 0;
+  claimImpl = () => Promise.resolve({ data: GRANTED });
+  successToasts = [];
+  infoToasts = [];
+  errorToasts = [];
+});
+
+describe("CheckoutBonusModal", () => {
+  test("renders the offered amount from props, not a hardcoded figure", () => {
+    renderModal({ amountUsd: "7.50" });
+
+    screen.getByRole("heading", { name: "Here's $7.50 on us" });
+    expect(claimButton().textContent).toBe("Claim $7.50 in credits");
+    screen.getByRole("button", { name: "No thanks" });
+  });
+
+  test("a granted claim toasts, invalidates the billing summary, and closes", async () => {
+    claimImpl = () =>
+      Promise.resolve({
+        data: { ...GRANTED, amount_usd: "10.00", balance_usd: "12.00" },
+      });
+    const onOpenChange = mock((_open: boolean) => {});
+    const queryClient = renderModal({ onOpenChange });
+
+    fireEvent.click(claimButton());
+
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+    expect(claimCalls).toBe(1);
+    expect(successToasts).toEqual(["$10 in credits added to your account."]);
+    expect(infoToasts).toEqual([]);
+    expect(queryClient.getQueryState(SUMMARY_KEY)?.isInvalidated).toBe(true);
+  });
+
+  for (const status of ["already_claimed", "ineligible"] as const) {
+    test(`an ${status} claim toasts info and closes without granting`, async () => {
+      claimImpl = () => Promise.resolve({ data: { ...GRANTED, status } });
+      const onOpenChange = mock((_open: boolean) => {});
+      const queryClient = renderModal({ onOpenChange });
+
+      fireEvent.click(claimButton());
+
+      await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+      expect(infoToasts).toEqual(["This offer is no longer available."]);
+      expect(successToasts).toEqual([]);
+      expect(queryClient.getQueryState(SUMMARY_KEY)?.isInvalidated).toBe(false);
+    });
+  }
+
+  test("a failed claim toasts an error and keeps the modal open", async () => {
+    claimImpl = () => Promise.reject(new Error("network down"));
+    const onOpenChange = mock((_open: boolean) => {});
+    renderModal({ onOpenChange });
+
+    fireEvent.click(claimButton());
+
+    await waitFor(() =>
+      expect(errorToasts).toEqual([
+        "Could not add the credits. Please try again.",
+      ]),
+    );
+    expect(onOpenChange).not.toHaveBeenCalled();
+    screen.getByTestId("checkout-bonus-modal");
+    await waitFor(() => expect(claimButton().disabled).toBe(false));
+  });
+
+  test("both actions are disabled while the claim is in flight", async () => {
+    let resolveClaim: (value: { data: CheckoutBonusClaimResponse }) => void;
+    claimImpl = () =>
+      new Promise((resolve) => {
+        resolveClaim = resolve;
+      });
+    const onOpenChange = mock((_open: boolean) => {});
+    renderModal({ onOpenChange });
+
+    fireEvent.click(claimButton());
+
+    await waitFor(() => expect(claimButton().disabled).toBe(true));
+    expect(
+      (screen.getByRole("button", { name: "No thanks" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+
+    resolveClaim!({ data: GRANTED });
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+  });
+});

--- a/clients/web/src/domains/settings/billing/checkout-bonus-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-bonus-modal.test.tsx
@@ -3,9 +3,10 @@
  *  - the offer copy and claim button render the amount from props, never a
  *    hardcoded figure
  *  - a granted claim toasts success with the server-returned amount,
- *    invalidates the billing summary, and closes
- *  - `already_claimed` / `ineligible` claims toast info and close without
- *    touching the billing summary
+ *    invalidates the billing summary and the eligibility query, and closes
+ *  - `already_claimed` / `ineligible` claims toast info, invalidate the
+ *    eligibility query so a cached `eligible: true` cannot re-show the offer,
+ *    and close without touching the billing summary
  *  - a failed claim toasts an error and keeps the modal open with the button
  *    re-enabled
  *  - both actions are disabled while the claim is in flight
@@ -61,11 +62,14 @@ mock.module("@vellumai/design-library/components/toast", () => ({
   },
 }));
 
-const { organizationsBillingSummaryRetrieveQueryKey } =
-  await import("@/generated/api/@tanstack/react-query.gen");
+const {
+  organizationsBillingCheckoutBonusRetrieveQueryKey,
+  organizationsBillingSummaryRetrieveQueryKey,
+} = await import("@/generated/api/@tanstack/react-query.gen");
 const { CheckoutBonusModal } = await import("./checkout-bonus-modal");
 
 const SUMMARY_KEY = organizationsBillingSummaryRetrieveQueryKey();
+const ELIGIBILITY_KEY = organizationsBillingCheckoutBonusRetrieveQueryKey();
 
 function renderModal({
   amountUsd = "5.00",
@@ -77,9 +81,13 @@ function renderModal({
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
-  // Seed the billing summary entry so invalidation is observable without the
-  // query ever fetching.
+  // Seed the billing summary and eligibility entries so invalidation is
+  // observable without either query ever fetching.
   queryClient.setQueryData(SUMMARY_KEY, { settled_balance_usd: "0.00" });
+  queryClient.setQueryData(ELIGIBILITY_KEY, {
+    eligible: true,
+    amount_usd: "5.00",
+  });
   render(
     <QueryClientProvider client={queryClient}>
       <CheckoutBonusModal
@@ -114,7 +122,7 @@ describe("CheckoutBonusModal", () => {
     screen.getByRole("button", { name: "No thanks" });
   });
 
-  test("a granted claim toasts, invalidates the billing summary, and closes", async () => {
+  test("a granted claim toasts, invalidates the summary and eligibility, and closes", async () => {
     claimImpl = () =>
       Promise.resolve({
         data: { ...GRANTED, amount_usd: "10.00", balance_usd: "12.00" },
@@ -129,6 +137,9 @@ describe("CheckoutBonusModal", () => {
     expect(successToasts).toEqual(["$10 in credits added to your account."]);
     expect(infoToasts).toEqual([]);
     expect(queryClient.getQueryState(SUMMARY_KEY)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(ELIGIBILITY_KEY)?.isInvalidated).toBe(
+      true,
+    );
   });
 
   for (const status of ["already_claimed", "ineligible"] as const) {
@@ -143,6 +154,11 @@ describe("CheckoutBonusModal", () => {
       expect(infoToasts).toEqual(["This offer is no longer available."]);
       expect(successToasts).toEqual([]);
       expect(queryClient.getQueryState(SUMMARY_KEY)?.isInvalidated).toBe(false);
+      // The stale `eligible: true` must be dropped so the offer cannot
+      // re-show from cache.
+      expect(queryClient.getQueryState(ELIGIBILITY_KEY)?.isInvalidated).toBe(
+        true,
+      );
     });
   }
 

--- a/clients/web/src/domains/settings/billing/checkout-bonus-modal.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-bonus-modal.tsx
@@ -4,22 +4,16 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import {
   organizationsBillingCheckoutBonusCreateMutation,
+  organizationsBillingCheckoutBonusRetrieveOptions,
   organizationsBillingSummaryRetrieveOptions,
 } from "@/generated/api/@tanstack/react-query.gen";
+import { useTranslation } from "@/i18n";
 import { Button } from "@vellumai/design-library/components/button";
 import { Modal } from "@vellumai/design-library/components/modal";
 import { toast } from "@vellumai/design-library/components/toast";
 import { Typography } from "@vellumai/design-library/components/typography";
 
-/** Format a USD decimal string ("5.00") as "$5", keeping non-zero cents ("$7.50"). */
-function formatUsdShort(value: string): string {
-  const n = parseFloat(value);
-  if (!Number.isFinite(n)) {
-    return `$${value}`;
-  }
-  const formatted = n.toFixed(2);
-  return `$${formatted.endsWith(".00") ? formatted.slice(0, -3) : formatted}`;
-}
+import { formatUsdShort } from "@/domains/settings/billing/format-usd";
 
 export interface CheckoutBonusModalProps {
   open: boolean;
@@ -44,6 +38,7 @@ export function CheckoutBonusModal({
   onOpenChange,
   amountUsd,
 }: CheckoutBonusModalProps) {
+  const { t } = useTranslation("settings");
   const queryClient = useQueryClient();
   const claimMutation = useMutation(
     organizationsBillingCheckoutBonusCreateMutation(),
@@ -61,18 +56,27 @@ export function CheckoutBonusModal({
         onSuccess: (data) => {
           if (data.status === "granted") {
             toast.success(
-              `${formatUsdShort(data.amount_usd)} in credits added to your account.`,
+              t("checkoutBonusModal.grantedToast", {
+                amount: formatUsdShort(data.amount_usd),
+              }),
             );
             void queryClient.invalidateQueries(
               organizationsBillingSummaryRetrieveOptions(),
             );
           } else {
-            toast.info("This offer is no longer available.");
+            toast.info(t("checkoutBonusModal.unavailableToast"));
           }
+          // Every non-error result means the offer is spent (granted or
+          // already claimed) or was never claimable (ineligible), so drop the
+          // cached eligibility answer before closing: a stale `eligible: true`
+          // would let the parent re-show the offer.
+          void queryClient.invalidateQueries(
+            organizationsBillingCheckoutBonusRetrieveOptions(),
+          );
           onOpenChange(false);
         },
         onError: () => {
-          toast.error("Could not add the credits. Please try again.");
+          toast.error(t("checkoutBonusModal.errorToast"));
         },
       },
     );
@@ -90,7 +94,9 @@ export function CheckoutBonusModal({
     >
       <Modal.Content size="sm" data-testid="checkout-bonus-modal">
         <Modal.Header>
-          <Modal.Title icon={Gift}>Here&apos;s {amount} on us</Modal.Title>
+          <Modal.Title icon={Gift}>
+            {t("checkoutBonusModal.title", { amount })}
+          </Modal.Title>
         </Modal.Header>
         <Modal.Body>
           <Typography
@@ -98,14 +104,13 @@ export function CheckoutBonusModal({
             variant="body-medium-default"
             className="text-(--content-secondary)"
           >
-            Claim a one-time {amount} credit and we&apos;ll add it straight to
-            your account balance. No payment required.
+            {t("checkoutBonusModal.body", { amount })}
           </Typography>
         </Modal.Body>
         <Modal.Footer>
           <Modal.Close asChild>
             <Button variant="outlined" disabled={pending}>
-              No thanks
+              {t("checkoutBonusModal.decline")}
             </Button>
           </Modal.Close>
           <Button
@@ -117,7 +122,7 @@ export function CheckoutBonusModal({
             disabled={pending}
             data-testid="claim-checkout-bonus-button"
           >
-            Claim {amount} in credits
+            {t("checkoutBonusModal.claim", { amount })}
           </Button>
         </Modal.Footer>
       </Modal.Content>

--- a/clients/web/src/domains/settings/billing/checkout-bonus-modal.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-bonus-modal.tsx
@@ -1,0 +1,126 @@
+import { Gift, Loader2 } from "lucide-react";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import {
+  organizationsBillingCheckoutBonusCreateMutation,
+  organizationsBillingSummaryRetrieveOptions,
+} from "@/generated/api/@tanstack/react-query.gen";
+import { Button } from "@vellumai/design-library/components/button";
+import { Modal } from "@vellumai/design-library/components/modal";
+import { toast } from "@vellumai/design-library/components/toast";
+import { Typography } from "@vellumai/design-library/components/typography";
+
+/** Format a USD decimal string ("5.00") as "$5", keeping non-zero cents ("$7.50"). */
+function formatUsdShort(value: string): string {
+  const n = parseFloat(value);
+  if (!Number.isFinite(n)) {
+    return `$${value}`;
+  }
+  const formatted = n.toFixed(2);
+  return `$${formatted.endsWith(".00") ? formatted.slice(0, -3) : formatted}`;
+}
+
+export interface CheckoutBonusModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /**
+   * Bonus amount as a USD decimal string (e.g. "5.00"), taken from the
+   * eligibility response. The server owns the amount; nothing here assumes a
+   * specific value.
+   */
+  amountUsd: string;
+}
+
+/**
+ * Offer dialog for the one-time abandoned-checkout credit bonus. The parent
+ * decides when to show it (server-verified eligibility); this component owns
+ * the claim call. The server re-verifies on claim, so a stale offer resolves
+ * to `already_claimed` / `ineligible` and the dialog bows out with an info
+ * toast instead of granting.
+ */
+export function CheckoutBonusModal({
+  open,
+  onOpenChange,
+  amountUsd,
+}: CheckoutBonusModalProps) {
+  const queryClient = useQueryClient();
+  const claimMutation = useMutation(
+    organizationsBillingCheckoutBonusCreateMutation(),
+  );
+  const pending = claimMutation.isPending;
+  const amount = formatUsdShort(amountUsd);
+
+  const handleClaim = () => {
+    if (pending) {
+      return;
+    }
+    claimMutation.mutate(
+      {},
+      {
+        onSuccess: (data) => {
+          if (data.status === "granted") {
+            toast.success(
+              `${formatUsdShort(data.amount_usd)} in credits added to your account.`,
+            );
+            void queryClient.invalidateQueries(
+              organizationsBillingSummaryRetrieveOptions(),
+            );
+          } else {
+            toast.info("This offer is no longer available.");
+          }
+          onOpenChange(false);
+        },
+        onError: () => {
+          toast.error("Could not add the credits. Please try again.");
+        },
+      },
+    );
+  };
+
+  return (
+    <Modal.Root
+      open={open}
+      onOpenChange={(next) => {
+        if (!next && pending) {
+          return;
+        }
+        onOpenChange(next);
+      }}
+    >
+      <Modal.Content size="sm" data-testid="checkout-bonus-modal">
+        <Modal.Header>
+          <Modal.Title icon={Gift}>Here&apos;s {amount} on us</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <Typography
+            as="p"
+            variant="body-medium-default"
+            className="text-(--content-secondary)"
+          >
+            Claim a one-time {amount} credit and we&apos;ll add it straight to
+            your account balance. No payment required.
+          </Typography>
+        </Modal.Body>
+        <Modal.Footer>
+          <Modal.Close asChild>
+            <Button variant="outlined" disabled={pending}>
+              No thanks
+            </Button>
+          </Modal.Close>
+          <Button
+            variant="primary"
+            leftIcon={
+              pending ? <Loader2 className="animate-spin" /> : undefined
+            }
+            onClick={handleClaim}
+            disabled={pending}
+            data-testid="claim-checkout-bonus-button"
+          >
+            Claim {amount} in credits
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal.Root>
+  );
+}

--- a/clients/web/src/domains/settings/billing/format-usd.test.ts
+++ b/clients/web/src/domains/settings/billing/format-usd.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Tests for the shared short-dollar formatter: whole dollars drop cents,
+ * non-zero cents are kept, thousands get locale separators, negatives keep
+ * the sign outside the dollar sign, and nullish or unparseable input renders
+ * "$0" rather than leaking the raw string.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { formatUsdShort } from "./format-usd";
+
+describe("formatUsdShort", () => {
+  test.each([
+    ["5.00", "$5"],
+    ["7.50", "$7.50"],
+    ["1000.00", "$1,000"],
+    ["1234.56", "$1,234.56"],
+    ["0.00", "$0"],
+    ["-5.00", "-$5"],
+    ["-7.25", "-$7.25"],
+  ])("formats %p as %p", (input, expected) => {
+    expect(formatUsdShort(input)).toBe(expected);
+  });
+
+  test.each([null, undefined, "", "not-a-number"])(
+    "renders $0 for %p",
+    (input) => {
+      expect(formatUsdShort(input)).toBe("$0");
+    },
+  );
+});

--- a/clients/web/src/domains/settings/billing/format-usd.ts
+++ b/clients/web/src/domains/settings/billing/format-usd.ts
@@ -1,0 +1,27 @@
+/**
+ * Format a USD decimal string like "25.00" as "$25" (or "$25.50" if non-zero
+ * cents, "$1,250" with locale separators). Nullish or unparseable input
+ * renders "$0"; negatives render "-$5".
+ *
+ * Single source of truth for short dollar amounts on billing surfaces (the
+ * auto-top-up summary, the checkout bonus offer). Import this rather than
+ * writing a private copy so the display rule cannot drift between surfaces.
+ */
+export function formatUsdShort(value: string | null | undefined): string {
+  if (!value) {
+    return "$0";
+  }
+  const n = parseFloat(value);
+  if (!Number.isFinite(n)) {
+    return "$0";
+  }
+  const abs = Math.abs(n);
+  const formatted = abs.toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+  const stripped = formatted.endsWith(".00")
+    ? formatted.slice(0, -3)
+    : formatted;
+  return n < 0 ? `-$${stripped}` : `$${stripped}`;
+}

--- a/clients/web/src/domains/settings/components/auto-top-up-card.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-card.tsx
@@ -21,6 +21,7 @@ import { Notice } from "@vellumai/design-library/components/notice";
 import { Toggle } from "@vellumai/design-library/components/toggle";
 import { Typography } from "@vellumai/design-library/components/typography";
 
+import { formatUsdShort } from "@/domains/settings/billing/format-usd";
 import { AutoTopUpDisableConfirm } from "@/domains/settings/components/auto-top-up-disable-confirm";
 import {
   AutoTopUpForm,
@@ -39,30 +40,6 @@ function apiToIntStr(v: string | null | undefined): string {
   }
   const n = parseFloat(v);
   return Number.isFinite(n) ? String(Math.trunc(n)) : "";
-}
-
-/**
- * Format a USD decimal string like "25.00" as "$25" (or "$25.50" if non-zero
- * cents). Used for the inline summary in the enabled-not-configuring view
- * ("Add $200 when the balance falls under $50").
- */
-function formatUsdShort(value: string | null | undefined): string {
-  if (!value) {
-    return "$0";
-  }
-  const n = parseFloat(value);
-  if (!Number.isFinite(n)) {
-    return "$0";
-  }
-  const abs = Math.abs(n);
-  const formatted = abs.toLocaleString("en-US", {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  });
-  const stripped = formatted.endsWith(".00")
-    ? formatted.slice(0, -3)
-    : formatted;
-  return n < 0 ? `-$${stripped}` : `$${stripped}`;
 }
 
 /**

--- a/clients/web/src/i18n/catalogs.ts
+++ b/clients/web/src/i18n/catalogs.ts
@@ -38,6 +38,7 @@ import enChannels from "@/i18n/locales/en/channels.json";
 import enChat from "@/i18n/locales/en/chat.json";
 import enCommon from "@/i18n/locales/en/common.json";
 import enSchedules from "@/i18n/locales/en/schedules.json";
+import enSettings from "@/i18n/locales/en/settings.json";
 import { NAMESPACES, type Namespace } from "@/i18n/namespaces";
 import { DEFAULT_LOCALE, type SupportedLocale } from "@/i18n/supported-locales";
 
@@ -63,6 +64,7 @@ export const FALLBACK_CATALOGS: LocaleCatalogs = {
   schedules: enSchedules,
   account: enAccount,
   channels: enChannels,
+  settings: enSettings,
 };
 
 /** Loaders for the locales that are not bundled into the entry chunk. */
@@ -76,6 +78,7 @@ const CATALOG_LOADERS: Record<
     schedules: () => import("@/i18n/locales/es/schedules.json"),
     account: () => import("@/i18n/locales/es/account.json"),
     channels: () => import("@/i18n/locales/es/channels.json"),
+    settings: () => import("@/i18n/locales/es/settings.json"),
   },
 };
 

--- a/clients/web/src/i18n/i18next.d.ts
+++ b/clients/web/src/i18n/i18next.d.ts
@@ -17,6 +17,7 @@ import type channels from "@/i18n/locales/en/channels.json";
 import type chat from "@/i18n/locales/en/chat.json";
 import type common from "@/i18n/locales/en/common.json";
 import type schedules from "@/i18n/locales/en/schedules.json";
+import type settings from "@/i18n/locales/en/settings.json";
 
 declare module "i18next" {
   interface CustomTypeOptions {
@@ -27,6 +28,7 @@ declare module "i18next" {
       schedules: typeof schedules;
       account: typeof account;
       channels: typeof channels;
+      settings: typeof settings;
     };
     returnNull: false;
   }

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -1,0 +1,11 @@
+{
+  "checkoutBonusModal": {
+    "title": "Here's {amount} on us",
+    "body": "Claim a one-time {amount} credit and we'll add it straight to your account balance. No payment required.",
+    "decline": "No thanks",
+    "claim": "Claim {amount} in credits",
+    "grantedToast": "{amount} in credits added to your account.",
+    "unavailableToast": "This offer is no longer available.",
+    "errorToast": "Could not add the credits. Please try again."
+  }
+}

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -1,0 +1,11 @@
+{
+  "checkoutBonusModal": {
+    "title": "Aquí tienes {amount} de nuestra parte",
+    "body": "Reclama un crédito único de {amount} y lo añadiremos directamente al saldo de tu cuenta. No se requiere ningún pago.",
+    "decline": "No, gracias",
+    "claim": "Reclamar {amount} en créditos",
+    "grantedToast": "Se añadieron {amount} en créditos a tu cuenta.",
+    "unavailableToast": "Esta oferta ya no está disponible.",
+    "errorToast": "No se pudieron añadir los créditos. Inténtalo de nuevo."
+  }
+}

--- a/clients/web/src/i18n/namespaces.ts
+++ b/clients/web/src/i18n/namespaces.ts
@@ -40,6 +40,7 @@ export const NAMESPACES = [
   "schedules",
   "account",
   "channels",
+  "settings",
 ] as const;
 
 export type Namespace = (typeof NAMESPACES)[number];


### PR DESCRIPTION
## Summary
- Adds the inert CheckoutBonusModal component (claim mutation, toasts, billing summary invalidation)
- Not mounted anywhere yet; PR 3 wires the cancel-path triggers

Part of plan: abandoned-checkout-bonus-ui.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40495" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->