### PR TITLE
feat(mcp): reuse the dynamic client registration across OAuth attempts

### DIFF
--- a/assistant/src/mcp/__tests__/mcp-oauth-client-registration.test.ts
+++ b/assistant/src/mcp/__tests__/mcp-oauth-client-registration.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Reuse and invalidation of the stored dynamic client registration.
+ *
+ * Dynamic registration writes a record on the authorization server, so
+ * registering per attempt leaves records behind that nobody cleans up. The
+ * stored registration is therefore reused, and only withheld when it
+ * provably no longer applies. Both halves matter: reusing one bound to a
+ * stale redirect URI produces authorization requests the server rejects,
+ * and re-registering unnecessarily is the accumulation this exists to stop.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const CALLBACK_URL =
+  "https://platform.example/v1/gateway/callbacks/abc/webhooks/oauth/callback/";
+
+let resolvedCallbackUrl = CALLBACK_URL;
+
+mock.module("../../inbound/platform-callback-registration.js", () => ({
+  resolveCallbackUrl: async () => resolvedCallbackUrl,
+}));
+
+mock.module("../../inbound/public-ingress-urls.js", () => ({
+  getOAuthCallbackUrl: () => resolvedCallbackUrl,
+}));
+
+mock.module("../../config/loader.js", () => ({
+  loadConfig: () => ({}),
+}));
+
+/** In-memory stand-in for the credential store. */
+const store = new Map<string, string>();
+
+mock.module("../../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async (k: string) => store.get(k) ?? null,
+  setSecureKeyAsync: async (k: string, v: string) => {
+    store.set(k, v);
+    return true;
+  },
+  deleteSecureKeyAsync: async (k: string) =>
+    store.delete(k) ? "deleted" : "not-found",
+}));
+
+mock.module("../../daemon/identity-helpers.js", () => ({
+  getAssistantName: () => "Jarvis",
+}));
+
+mock.module("../../config/env.js", () => ({
+  getPlatformAssistantId: () => "019d6d4f-6dbd-779f-91d3-cb273b9429a5",
+}));
+
+const { McpOAuthProvider } = await import("../mcp-oauth-provider.js");
+
+const REGISTRATION = { client_id: "generated-client-id" };
+
+function newProvider() {
+  return new McpOAuthProvider(
+    "unabyss",
+    "https://mcp.unabyss.com",
+    /* interactive */ false,
+  );
+}
+
+/** Seed discovery state the way the SDK would after running discovery. */
+async function seedDiscovery(
+  provider: InstanceType<typeof McpOAuthProvider>,
+  issuer: string,
+): Promise<void> {
+  await provider.saveDiscoveryState({
+    authorizationServerUrl: issuer,
+    authorizationServerMetadata: { issuer },
+  } as never);
+}
+
+/** Run one registration the way a completed flow would. */
+async function register(issuer = "https://mcp.unabyss.com"): Promise<void> {
+  const provider = newProvider();
+  await provider.startCallbackServer();
+  await seedDiscovery(provider, issuer);
+  await provider.saveClientInformation(REGISTRATION as never);
+  provider.stopCallbackServer();
+}
+
+beforeEach(() => {
+  store.clear();
+  resolvedCallbackUrl = CALLBACK_URL;
+});
+
+describe("McpOAuthProvider client registration reuse", () => {
+  test("a stored registration is reused on the next flow", async () => {
+    await register();
+
+    const next = newProvider();
+    await next.startCallbackServer();
+    await seedDiscovery(next, "https://mcp.unabyss.com");
+
+    // Returning the stored value is what keeps the server from accruing a
+    // fresh client record on every `assistant mcp auth`.
+    expect(await next.clientInformation()).toEqual(REGISTRATION as never);
+  });
+
+  test("no stored registration means the SDK registers", async () => {
+    const provider = newProvider();
+    await provider.startCallbackServer();
+    expect(await provider.clientInformation()).toBeUndefined();
+  });
+
+  test("a changed redirect URI withholds the registration", async () => {
+    await register();
+
+    // The assistant moved, so its callback URL moved with it. The stored
+    // client is registered for the old one and the server would reject it.
+    resolvedCallbackUrl = "https://other.example/webhooks/oauth/callback";
+    const next = newProvider();
+    await next.startCallbackServer();
+    await seedDiscovery(next, "https://mcp.unabyss.com");
+
+    expect(await next.clientInformation()).toBeUndefined();
+  });
+
+  test("a changed authorization server withholds the registration", async () => {
+    await register("https://auth.unabyss.com");
+
+    const next = newProvider();
+    await next.startCallbackServer();
+    await seedDiscovery(next, "https://different-auth.example");
+
+    expect(await next.clientInformation()).toBeUndefined();
+  });
+
+  test("a silent reconnect reuses the registration without a redirect URI", async () => {
+    await register();
+
+    // `McpClient.connect` never prepares a callback, so `_redirectUrl` is
+    // unset. Treating that as a mismatch would turn every background
+    // reconnect into a registration.
+    const silent = newProvider();
+    await seedDiscovery(silent, "https://mcp.unabyss.com");
+
+    expect(await silent.clientInformation()).toEqual(REGISTRATION as never);
+  });
+
+  test("a registration stored before bindings existed is kept", async () => {
+    // Upgrading must not invalidate every existing registration at once.
+    store.set(
+      "mcp:unabyss:client_info",
+      JSON.stringify({ client_id: "legacy" }),
+    );
+
+    const provider = newProvider();
+    await provider.startCallbackServer();
+    await seedDiscovery(provider, "https://mcp.unabyss.com");
+
+    expect(await provider.clientInformation()).toEqual({
+      client_id: "legacy",
+    } as never);
+  });
+
+  test("invalidating the client drops its binding too", async () => {
+    await register();
+    expect(store.has("mcp:unabyss:client_binding")).toBe(true);
+
+    const provider = newProvider();
+    await provider.invalidateCredentials("client");
+
+    expect(store.has("mcp:unabyss:client_info")).toBe(false);
+    // A surviving binding would let the next registration inherit the
+    // previous one's issuer and redirect URI.
+    expect(store.has("mcp:unabyss:client_binding")).toBe(false);
+  });
+});
+
+describe("McpOAuthProvider client metadata", () => {
+  test("registers under the assistant's own name", async () => {
+    const provider = newProvider();
+    expect(provider.clientMetadata.client_name).toEqual("Jarvis");
+  });
+
+  test("carries the assistant id as software_id", async () => {
+    const provider = newProvider();
+    expect(provider.clientMetadata.software_id).toEqual(
+      "019d6d4f-6dbd-779f-91d3-cb273b9429a5",
+    );
+  });
+
+  test("omits logo_uri, which has no anonymously fetchable URL", async () => {
+    const provider = newProvider();
+    expect(provider.clientMetadata.logo_uri).toBeUndefined();
+  });
+
+  test("registers the resolved callback URL as the redirect URI", async () => {
+    const provider = newProvider();
+    await provider.startCallbackServer();
+    expect(provider.clientMetadata.redirect_uris).toEqual([CALLBACK_URL]);
+  });
+});

--- a/assistant/src/mcp/__tests__/mcp-oauth-provider.test.ts
+++ b/assistant/src/mcp/__tests__/mcp-oauth-provider.test.ts
@@ -16,6 +16,9 @@ mock.module("../../inbound/public-ingress-urls.js", () => ({
 
 mock.module("../../config/loader.js", () => ({
   loadConfig: () => ({}),
+  // `clientMetadata` reads the assistant's name, which pulls the persona
+  // resolver into the provider's import graph, and that reads config.
+  getConfig: () => ({}),
 }));
 
 // ── Import SUT after mocks ────────────────────────────────────────────────────

--- a/assistant/src/mcp/mcp-auth-orchestrator.ts
+++ b/assistant/src/mcp/mcp-auth-orchestrator.ts
@@ -61,8 +61,11 @@ export async function orchestrateMcpOAuthConnect(args: {
     },
   );
 
-  // Clear stale credentials so the flow starts fresh
-  await provider.invalidateCredentials("client");
+  // Re-discover, but keep the client registration. Discovery is a read and
+  // costs a request; registration is a write on the authorization server,
+  // and remaking it per attempt leaves a record behind every time. The
+  // provider drops a stored registration on its own when the redirect URI
+  // or the authorization server it was made against has changed.
   await provider.invalidateCredentials("discovery");
 
   // Register the pending callback in the daemon heap

--- a/assistant/src/mcp/mcp-oauth-provider.ts
+++ b/assistant/src/mcp/mcp-oauth-provider.ts
@@ -28,6 +28,8 @@ import type {
   OAuthTokens,
 } from "@modelcontextprotocol/sdk/shared/auth.js";
 
+import { getPlatformAssistantId } from "../config/env.js";
+import { getAssistantName } from "../daemon/identity-helpers.js";
 import {
   deleteSecureKeyAsync,
   getSecureKeyAsync,
@@ -35,6 +37,7 @@ import {
 } from "../security/secure-keys.js";
 import { openInHostBrowser } from "../util/browser.js";
 import { getLogger } from "../util/logger.js";
+import { APP_VERSION } from "../version.js";
 
 const log = getLogger("mcp-oauth");
 
@@ -47,6 +50,23 @@ function clientInfoKey(serverId: string): string {
 }
 function discoveryKey(serverId: string): string {
   return `mcp:${serverId}:discovery`;
+}
+function clientBindingKey(serverId: string): string {
+  return `mcp:${serverId}:client_binding`;
+}
+
+/**
+ * What a stored client registration was made against.
+ *
+ * A client identifier belongs to the authorization server that issued it and
+ * is registered for one set of redirect URIs, so reusing a registration after
+ * either changes is invalid. Recording both is what lets a registration be
+ * reused when they still hold, which is the difference between registering
+ * once per assistant and registering once per attempt.
+ */
+interface ClientRegistrationBinding {
+  issuer: string | null;
+  redirectUri: string;
 }
 
 export interface McpOAuthCallbackResult {
@@ -102,13 +122,35 @@ export class McpOAuthProvider implements OAuthClientProvider {
 
   // --- clientMetadata ---
 
+  /**
+   * Identity presented at dynamic registration, and on the consent screen
+   * the user reads before approving.
+   *
+   * The client is this assistant, not the Vellum product and not the plugin
+   * that declared the server: each assistant registers separately, with its
+   * own redirect URI, so its own name is what makes the consent screen
+   * meaningful when a person runs several. `software_id` carries the
+   * assistant id so a server can correlate an assistant's registrations
+   * across servers without treating every assistant as the same client.
+   *
+   * `logo_uri` is absent deliberately. The assistant's avatar is served
+   * only behind authentication, and an authorization server fetching a logo
+   * is anonymous, so there is no URL to give it. A stable public identity
+   * per assistant is what would supply one, and the same prerequisite would
+   * let this move to Client ID Metadata Documents and drop registration
+   * altogether.
+   */
   get clientMetadata(): OAuthClientMetadata {
+    const assistantName = getAssistantName();
+    const assistantId = getPlatformAssistantId().trim();
     return {
-      client_name: "Vellum Assistant",
+      client_name: assistantName ?? "Vellum Assistant",
       redirect_uris: this._redirectUrl ? [this._redirectUrl] : [],
       token_endpoint_auth_method: "none",
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],
+      ...(assistantId.length > 0 && { software_id: assistantId }),
+      software_version: APP_VERSION,
     };
   }
 
@@ -199,13 +241,26 @@ export class McpOAuthProvider implements OAuthClientProvider {
 
   // --- Client Information ---
 
+  /**
+   * The stored registration, or `undefined` to make the SDK register a new
+   * one.
+   *
+   * Returning the stored value is the normal case: dynamic registration
+   * writes a record on the authorization server, so re-registering per
+   * attempt accumulates records nobody cleans up. It is withheld only when
+   * the registration provably no longer applies, because the redirect URI
+   * it was made for changed or because a different authorization server now
+   * fronts the resource.
+   */
   async clientInformation(): Promise<OAuthClientInformationMixed | undefined> {
     const raw = await getSecureKeyAsync(clientInfoKey(this.serverId));
     if (!raw) {
       return undefined;
     }
+
+    let info: OAuthClientInformationMixed;
     try {
-      return JSON.parse(raw) as OAuthClientInformationMixed;
+      info = JSON.parse(raw) as OAuthClientInformationMixed;
     } catch {
       log.warn(
         { serverId: this.serverId },
@@ -213,6 +268,16 @@ export class McpOAuthProvider implements OAuthClientProvider {
       );
       return undefined;
     }
+
+    const stale = await this.describeStaleBinding();
+    if (stale) {
+      log.info(
+        { serverId: this.serverId, reason: stale },
+        "Stored client registration no longer applies; registering again",
+      );
+      return undefined;
+    }
+    return info;
   }
 
   async saveClientInformation(
@@ -229,7 +294,74 @@ export class McpOAuthProvider implements OAuthClientProvider {
       );
       return;
     }
+
+    // Record what the registration was made against, so a later run can tell
+    // whether reusing it is still valid.
+    if (this._redirectUrl) {
+      const binding: ClientRegistrationBinding = {
+        issuer: await this.currentIssuer(),
+        redirectUri: this._redirectUrl,
+      };
+      const boundOk = await setSecureKeyAsync(
+        clientBindingKey(this.serverId),
+        JSON.stringify(binding),
+      );
+      if (!boundOk) {
+        log.warn(
+          { serverId: this.serverId },
+          "Failed to persist OAuth client binding; the registration will be remade on the next flow",
+        );
+      }
+    }
+
     log.info({ serverId: this.serverId }, "OAuth client information saved");
+  }
+
+  /** Issuer of the authorization server currently in play, when known. */
+  private async currentIssuer(): Promise<string | null> {
+    const state = await this.discoveryState();
+    return (
+      state?.authorizationServerMetadata?.issuer ??
+      state?.authorizationServerUrl ??
+      null
+    );
+  }
+
+  /**
+   * Why the stored registration cannot be reused, or null when it can.
+   *
+   * The redirect URI is only checked while a flow is being prepared:
+   * outside one there is no redirect URI to compare against, and a silent
+   * reconnect must not be turned into a registration.
+   *
+   * The issuer is only checked when discovery has run. An unverifiable
+   * issuer keeps the registration rather than discarding it, since the
+   * redirect check already covers the case this plugin actually changes.
+   */
+  private async describeStaleBinding(): Promise<string | null> {
+    const raw = await getSecureKeyAsync(clientBindingKey(this.serverId));
+    if (!raw) {
+      // Registered before the binding was recorded. Keep it: discarding
+      // every pre-existing registration would remake all of them at once.
+      return null;
+    }
+
+    let binding: ClientRegistrationBinding;
+    try {
+      binding = JSON.parse(raw) as ClientRegistrationBinding;
+    } catch {
+      return "stored binding is unreadable";
+    }
+
+    if (this._redirectUrl && binding.redirectUri !== this._redirectUrl) {
+      return "redirect URI changed";
+    }
+
+    const issuer = await this.currentIssuer();
+    if (issuer && binding.issuer && binding.issuer !== issuer) {
+      return "authorization server changed";
+    }
+    return null;
   }
 
   // --- Code Verifier (in-memory, ephemeral) ---
@@ -382,6 +514,10 @@ export class McpOAuthProvider implements OAuthClientProvider {
           "OAuth client information key not found in secure storage (already removed)",
         );
       }
+      // The binding describes the registration being dropped, so it goes
+      // with it. Leaving it would let a later registration inherit the
+      // previous one's issuer and redirect URI.
+      await deleteSecureKeyAsync(clientBindingKey(this.serverId));
     }
     if (scope === "all" || scope === "verifier") {
       this._codeVerifier = undefined;
@@ -483,14 +619,17 @@ export async function hasMcpOAuthTokens(serverId: string): Promise<boolean> {
 export async function deleteMcpOAuthCredentials(
   serverId: string,
 ): Promise<{ ok: boolean; failedKeys: string[] }> {
-  const [tokensResult, clientResult, discoveryResult] = await Promise.all([
-    deleteSecureKeyAsync(tokensKey(serverId)),
-    deleteSecureKeyAsync(clientInfoKey(serverId)),
-    deleteSecureKeyAsync(discoveryKey(serverId)),
-  ]);
+  const [tokensResult, clientResult, bindingResult, discoveryResult] =
+    await Promise.all([
+      deleteSecureKeyAsync(tokensKey(serverId)),
+      deleteSecureKeyAsync(clientInfoKey(serverId)),
+      deleteSecureKeyAsync(clientBindingKey(serverId)),
+      deleteSecureKeyAsync(discoveryKey(serverId)),
+    ]);
   const results = [
     { key: "tokens", result: tokensResult },
     { key: "client_info", result: clientResult },
+    { key: "client_binding", result: bindingResult },
     { key: "discovery", result: discoveryResult },
   ];
   const failedKeys = results


### PR DESCRIPTION
## Prompt / plan

Committing to Dynamic Client Registration for MCP OAuth, with Client ID Metadata Documents as the eventual destination once `*.vellum.me` / velay give each assistant a stable public identity.

Three decisions from review, implemented here:

1. **Reuse the stored registration** rather than remaking it per attempt.
2. **Invalidate on issuer change, redirect-URI change, or server rejection.**
3. **Register under the assistant's own name and id.**

## The bug this fixes

`orchestrateMcpOAuthConnect` invalidated the client registration before every flow:

```ts
await provider.invalidateCredentials("client");   // ← removed
await provider.invalidateCredentials("discovery");
```

That was harmless while the redirect URI moved per attempt — the old registration was junk regardless. After #40452 made the URI stable, it became exactly the accumulation that fix existed to end: **one abandoned client record on the authorization server per retry**, on servers with no way to reap them.

Discovery is still re-fetched. It's a read that costs a request; registration is a write that leaves a record.

## Invalidation

`saveClientInformation` now records the issuer and redirect URI the registration was made against, under `mcp:<server>:client_binding`. `clientInformation` returns `undefined` — which is how the SDK is told to register — when either has changed. Both records drop together on invalidation and on `mcp remove`.

Two cases are deliberately *kept* rather than discarded, and each is a test:

- **A silent reconnect has no redirect URI to compare.** `McpClient.connect` prepares no callback, so `_redirectUrl` is unset. Treating that as a mismatch would turn every background reconnect into a registration — the opposite of the goal.
- **A registration stored before bindings existed has nothing to compare.** Discarding those would remake every existing registration at once on upgrade.

## Client identity

`client_name` is now the assistant's own name (`IDENTITY.md`), with `software_id` set to the assistant id and `software_version` to the app version.

The client is the *assistant*: each registers separately with its own redirect URI, so its own name is what makes a consent screen meaningful to someone running several. `software_id` lets a server correlate one assistant's registrations across servers without collapsing every assistant into one client — and it's the closest DCR gets to the stable identity CIMD would provide.

**`logo_uri` is omitted, and I want to flag this since you asked for the avatar.** Every route in `avatar-routes.ts` requires an authenticated principal (`ACTOR_PRINCIPALS` / `LOCAL_PRINCIPALS`), and an authorization server fetching a logo is anonymous. There is no URL to give it. Same root cause as CIMD being unavailable, and the same prerequisite unblocks both — which is what the comment at `clientMetadata` says, so the next reader finds the reason at the decision.

## Test plan

- **New** — `mcp-oauth-client-registration.test.ts` (11): reuse across flows, register when nothing is stored, withhold on changed redirect URI, withhold on changed issuer, reuse on silent reconnect, keep pre-binding registrations, binding dropped with the client, plus the four metadata assertions.
- **Mutation-tested:** deleting the redirect-URI check makes `a changed redirect URI withholds the registration` fail, so the guard is real.
- **Existing, all passing individually:** every `src/mcp/__tests__` file (7/11/2), all eight `*mcp*` suites, and all sixteen `*oauth*` / `inbound` suites including `oauth-store` 116, `oauth-commands-routes` 46, `oauth2-gateway-transport` 29.
- `bunx tsc --noEmit` — 0 errors repo-wide. `eslint` clean. Pre-commit hook green.

One incidental fix: `mcp-oauth-provider.test.ts` mocked `config/loader` with only `loadConfig`, and reading the assistant name pulls the persona resolver into the provider's import graph, which also needs `getConfig`. Mock widened, with a comment saying why.

## CLI verb checklist

No new route. `assistant mcp auth` and the `internal_mcp_auth_*` routes are unchanged; this changes what the flow does with a stored registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XhVk8rfYUZHQQ9UPFPEBKU

---
_Generated by [Claude Code](https://claude.ai/code/session_01XhVk8rfYUZHQQ9UPFPEBKU)_