### PR TITLE
fix(skills): make calendar skills retrievable for day-planning turns

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -354,7 +354,7 @@
     {
       "id": "google-calendar",
       "name": "google-calendar",
-      "description": "View, create, and manage Google Calendar events and check availability",
+      "description": "View Google Calendar events for any day, create and manage events, and check availability",
       "metadata": {
         "icon": "assets/icon.svg",
         "emoji": "📅",
@@ -363,14 +363,14 @@
           "display-name": "Google Calendar",
           "user-invocable": "true",
           "activation-hints": [
-            "check my availability this week",
-            "find open time slots / when am I free",
-            "cross-calendar free/busy across my connected accounts"
+            "plan my day or my week",
+            "what does my day look like",
+            "check my availability, find open time slots, when am I free"
           ]
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-07T04:41:13.000Z"
+      "updatedAt": "2026-08-07T20:42:41.000Z"
     },
     {
       "id": "guardian-verify-setup",
@@ -716,7 +716,7 @@
     {
       "id": "outlook-calendar",
       "name": "outlook-calendar",
-      "description": "View, create, and manage Outlook Calendar events and check availability",
+      "description": "View Outlook Calendar events for any day, create and manage events, and check availability",
       "metadata": {
         "icon": "assets/icon.svg",
         "emoji": "📅",
@@ -725,14 +725,14 @@
           "display-name": "Outlook Calendar",
           "user-invocable": "true",
           "activation-hints": [
-            "check my availability this week",
-            "find open time slots / when am I free",
-            "cross-calendar free/busy across my connected accounts"
+            "plan my day or my week",
+            "what does my day look like",
+            "check my availability, find open time slots, when am I free"
           ]
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-07T04:41:13.000Z"
+      "updatedAt": "2026-08-07T20:42:41.000Z"
     },
     {
       "id": "plugin-builder",
@@ -759,7 +759,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-07T17:52:56.000Z"
+      "updatedAt": "2026-08-07T19:19:58.000Z"
     },
     {
       "id": "public-ingress",

--- a/skills/google-calendar/SKILL.md
+++ b/skills/google-calendar/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: google-calendar
-description: View, create, and manage Google Calendar events and check availability
+description: View Google Calendar events for any day, create and manage events, and check availability
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   icon: assets/icon.svg
@@ -10,9 +10,9 @@ metadata:
     display-name: "Google Calendar"
     user-invocable: true
     activation-hints:
-      - "check my availability this week"
-      - "find open time slots / when am I free"
-      - "cross-calendar free/busy across my connected accounts"
+      - "plan my day or my week"
+      - "what does my day look like"
+      - "check my availability, find open time slots, when am I free"
 ---
 
 ## Script Reference

--- a/skills/outlook-calendar/SKILL.md
+++ b/skills/outlook-calendar/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: outlook-calendar
-description: View, create, and manage Outlook Calendar events and check availability
+description: View Outlook Calendar events for any day, create and manage events, and check availability
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   icon: assets/icon.svg
@@ -10,9 +10,9 @@ metadata:
     display-name: "Outlook Calendar"
     user-invocable: true
     activation-hints:
-      - "check my availability this week"
-      - "find open time slots / when am I free"
-      - "cross-calendar free/busy across my connected accounts"
+      - "plan my day or my week"
+      - "what does my day look like"
+      - "check my availability, find open time slots, when am I free"
 ---
 
 ## Script Reference


### PR DESCRIPTION
## Prompt / plan

From a user feedback bundle: the assistant planned the user's day and missed a 1:00 PM meeting that was already on their calendar.

Tracing the raw LLM payloads, the planning turn made **zero tool calls** (`agentLoopExitReason: "no_tool_calls"`) and had **no calendar skill card in context**. One turn later, after the user said "appointment with BSCU around 1", both calendar cards appeared and the model immediately loaded them, queried all four accounts, and got the right answer. The model did not skip the calendar. Selection never surfaced it, so there was nothing to skip.

Skill selection matches a turn against the per-skill capability statement `buildSkillContent` renders from `description` + `activation-hints`. Both calendar skills described only scheduling **into** the calendar:

```
check my availability this week
find open time slots / when am I free
cross-calendar free/busy across my connected accounts
```

Nothing covered planning a day around what is already on it. The failing message ("it's Friday morning and I want to use today well... turn them into a realistic plan") carries no availability or free/busy vocabulary, so it had nothing to match on.

Same shape as #40437, which fixed `acp` for the same reason: a statement describing only one of the skill's modes.

## What changed

Both calendar skills (`outlook-calendar`, `google-calendar`), kept identical:

```yaml
activation-hints:
  - "plan my day or my week"
  - "what does my day look like"
  - "check my availability, find open time slots, when am I free"
```

Descriptions widen from "View, create, and manage ... events and check availability" to "View ... events **for any day**, create and manage events, and check availability", putting the read-the-agenda sense in the highest-weighted part of the statement.

`skills/catalog.json` regenerated via `scripts/skills/generate-catalog.mjs`.

Three files total: two `SKILL.md` and the catalog.

## Test plan

- Rendered both statements through the real `buildSkillContent` against the committed `catalog.json`: **276 (Outlook) and 273 (Google) of 500 chars**, so nothing is truncated.
- `node scripts/skills/check-catalog.mjs` -> up to date.
- `node scripts/skills/lint-skill-spec.mjs` -> 73 skills conform.
- `node scripts/skills/lint-skill-imports.mjs` -> no violations.
- `prettier@3.9.6 --check` clean on both skill directories (3.9.6 is what this workflow's `npx prettier` resolves to; the repo's pinned 3.8.1 formats union types differently, which is worth knowing before running prettier against `skills/` locally).

Rebased onto `main` so the catalog's git-derived `updatedAt` values match what CI computes on the merge.

## What this does not do

This makes these two skills match this class of turn. It does not change how selection works, and I have not verified end-to-end that the reported case now retrieves, which needs a live embedding backend and a seeded corpus.

Two things I looked at and deliberately left alone, both worth their own change if they matter:

- Skills are indexed on the same 500-char card they inject, while the v3 section lane embeds one vector per `## ` section. Every skill therefore collapses to a single blended vector averaging all its modes. CLI commands already avoid this by indexing full `--help` and injecting a one-liner.
- Capability rows carry no mtime, and the maintain job's reconcile stage only embeds slugs *missing* from the section store, so an edited skill description or hint never re-embeds. **This applies to this PR:** on an existing install the new hints reach the page-grain Qdrant point on the next skill seed, but the v3 section points keep the old text until something forces a rebuild.

The second one is worth confirming against a real workspace before assuming this lands for the user who reported it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017HvBLer92Ynhdy6yLHypKi