### PR TITLE
feat(mcp): present a logo on the OAuth consent screen

### DIFF
--- a/assistant/src/mcp/__tests__/mcp-oauth-client-registration.test.ts
+++ b/assistant/src/mcp/__tests__/mcp-oauth-client-registration.test.ts
@@ -183,9 +183,13 @@ describe("McpOAuthProvider client metadata", () => {
     );
   });
 
-  test("omits logo_uri, which has no anonymously fetchable URL", async () => {
+  test("presents an anonymously fetchable logo", async () => {
+    // The consent screen loads this without credentials, so it cannot be
+    // the assistant's own avatar, which is served behind authentication.
     const provider = newProvider();
-    expect(provider.clientMetadata.logo_uri).toBeUndefined();
+    expect(provider.clientMetadata.logo_uri).toEqual(
+      "https://www.vellum.ai/favicon.svg",
+    );
   });
 
   test("registers the resolved callback URL as the redirect URI", async () => {

--- a/assistant/src/mcp/mcp-oauth-provider.ts
+++ b/assistant/src/mcp/mcp-oauth-provider.ts
@@ -56,6 +56,15 @@ function clientBindingKey(serverId: string): string {
 }
 
 /**
+ * Logo shown on an authorization server's consent screen.
+ *
+ * Anonymously fetchable, which is the requirement: the server loads it
+ * without credentials. It identifies Vellum rather than the individual
+ * assistant, so every assistant a person runs presents the same mark.
+ */
+const CLIENT_LOGO_URI = "https://www.vellum.ai/favicon.svg";
+
+/**
  * What a stored client registration was made against.
  *
  * A client identifier belongs to the authorization server that issued it and
@@ -133,18 +142,19 @@ export class McpOAuthProvider implements OAuthClientProvider {
    * assistant id so a server can correlate an assistant's registrations
    * across servers without treating every assistant as the same client.
    *
-   * `logo_uri` is absent deliberately. The assistant's avatar is served
-   * only behind authentication, and an authorization server fetching a logo
-   * is anonymous, so there is no URL to give it. A stable public identity
-   * per assistant is what would supply one, and the same prerequisite would
-   * let this move to Client ID Metadata Documents and drop registration
-   * altogether.
+   * `logo_uri` is the Vellum mark rather than the assistant's own avatar.
+   * An authorization server fetching a logo is anonymous, and the avatar is
+   * served only behind authentication, so there is no per-assistant URL to
+   * give it. A stable public identity per assistant is what would supply
+   * one, and the same prerequisite would let this move to Client ID
+   * Metadata Documents and drop registration altogether.
    */
   get clientMetadata(): OAuthClientMetadata {
     const assistantName = getAssistantName();
     const assistantId = getPlatformAssistantId().trim();
     return {
       client_name: assistantName ?? "Vellum Assistant",
+      logo_uri: CLIENT_LOGO_URI,
       redirect_uris: this._redirectUrl ? [this._redirectUrl] : [],
       token_endpoint_auth_method: "none",
       grant_types: ["authorization_code", "refresh_token"],


### PR DESCRIPTION
## Prompt / plan

Follow-up to the review comment on #40497: *"default this to https://www.vellum.ai/favicon.svg for now"*.

`logo_uri` was omitted because the assistant's own avatar has no anonymously fetchable URL. This registers the Vellum mark instead, so the consent screen has something to show next to the assistant's name.

## Notes

The comment on `clientMetadata` now says why it's the Vellum mark rather than the assistant's avatar: the authorization server fetching the logo is anonymous, and every route in `avatar-routes.ts` requires an authenticated principal. So every assistant a person runs presents the same image, distinguished by `client_name`. The pointer to what would change that (a stable public identity per assistant, which is also what unblocks CIMD) stays where it was.

**Verified the URL resolves:** `200`, `image/svg+xml`, 1685 bytes.

One thing worth knowing rather than guessing at: it's an SVG. Consent screens that render logos with a plain `<img>` will be fine, but some providers only accept raster formats for a client logo. If Unabyss's screen comes back blank, a PNG at a stable URL is the fix, not a code change here.

## Test plan

- Updated the metadata test from asserting `logo_uri` is absent to asserting the registered value, with a comment on why it can't be the avatar.
- `mcp-oauth-client-registration` 11 passing, plus every `src/mcp/__tests__` file and all eight `*mcp*` suites, each run individually.
- `bunx tsc --noEmit` — 0 errors repo-wide. `eslint` clean. Pre-commit hook green.

## CLI verb checklist

No new route. This changes one field in the metadata sent at dynamic registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XhVk8rfYUZHQQ9UPFPEBKU

---
_Generated by [Claude Code](https://claude.ai/code/session_01XhVk8rfYUZHQQ9UPFPEBKU)_