### PR TITLE
feat(voice): show the voice picker inline in chat (JARVIS-1470)

### DIFF
--- a/assistant/src/__tests__/ui-shape-teaching.test.ts
+++ b/assistant/src/__tests__/ui-shape-teaching.test.ts
@@ -5,6 +5,7 @@ import { uiShowTool } from "../tools/ui-surface/definitions.js";
 import {
   SURFACE_SHAPE_DOCS,
   SURFACE_TYPE_NAMES,
+  UI_SHOW_TYPE_DOCS,
   uiShowTeachingError,
 } from "../tools/ui-surface/surface-shape-docs.js";
 
@@ -290,6 +291,12 @@ describe("ui_show displayable payloads proxy through", () => {
         surfaceType: "channel_setup",
         input: { surface_type: "channel_setup", data: { channel: "telegram" } },
       },
+      {
+        // The picker reads its own voice and catalog, so an empty payload is
+        // the whole contract and there is no missing-content state to teach.
+        surfaceType: "voice_picker",
+        input: { surface_type: "voice_picker", data: {} },
+      },
     ];
 
   for (const { surfaceType, input } of cases) {
@@ -346,5 +353,15 @@ describe("uiShowTeachingError", () => {
     for (const name of SURFACE_TYPE_NAMES) {
       expect(uiShowTool.description).toContain(name);
     }
+  });
+
+  test("voice_picker is a cold type that accepts an empty payload", () => {
+    expect(
+      uiShowTeachingError({ surface_type: "voice_picker", data: {} }),
+    ).toBeNull();
+    expect(UI_SHOW_TYPE_DOCS).toContain(
+      `voice_picker (${SURFACE_SHAPE_DOCS.voice_picker!.purpose})`,
+    );
+    expect(UI_SHOW_TYPE_DOCS).not.toContain("- voice_picker:");
   });
 });

--- a/assistant/src/__tests__/ui-shape-teaching.test.ts
+++ b/assistant/src/__tests__/ui-shape-teaching.test.ts
@@ -364,4 +364,20 @@ describe("uiShowTeachingError", () => {
     );
     expect(UI_SHOW_TYPE_DOCS).not.toContain("- voice_picker:");
   });
+
+  test("voice_picker steering reaches the model through the cold index", () => {
+    // Asserted on the built description rather than the doc entry: a cold
+    // type's `shape` reaches the model only through a teaching error, and an
+    // empty payload has no missing-content state to raise one, so steering
+    // parked there would be dead.
+    for (const directive of [
+      "change, hear, or pick a voice",
+      "rather than describing voices in prose",
+      "attach no actions and never set await_action",
+      "during a live voice call answer in speech",
+    ]) {
+      expect(UI_SHOW_TYPE_DOCS).toContain(directive);
+      expect(uiShowTool.description).toContain(directive);
+    }
+  });
 });

--- a/assistant/src/__tests__/ui-voice-picker-surface.test.ts
+++ b/assistant/src/__tests__/ui-voice-picker-surface.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests for the `voice_picker` ui_show surface's "never blocks a turn"
+ * invariant.
+ *
+ * The card has no terminal action: it settles when the user picks a voice,
+ * with no button to click. `actions` and `await_action` are generic ui_show
+ * params though, so the model can attach them to any surface, and the web
+ * client latches `awaiting_user_input` on the presence of actions alone with
+ * nothing to clear it. The daemon resolver therefore strips both, and a
+ * pending picker never holds the one-interactive-surface lock.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { UISurfaceShowEventSchema } from "../api/events/ui-surface-show.js";
+import type { AssistantEvent } from "../api/index.js";
+import type { Conversation } from "../daemon/conversation.js";
+import {
+  createSurfaceMutex,
+  surfaceProxyResolver,
+} from "../daemon/conversation-surfaces.js";
+import type { SurfaceType } from "../daemon/message-protocol.js";
+import { INTERACTIVE_SURFACE_TYPES } from "../daemon/message-protocol.js";
+import { asConversation } from "./helpers/mock-conversation.js";
+
+function makeContext(sent: AssistantEvent[] = []): Conversation {
+  return asConversation({
+    conversationId: "session-1",
+    sendToClient: (msg) => sent.push(msg),
+    pendingSurfaceActions: new Map<string, { surfaceType: SurfaceType }>(),
+    lastSurfaceAction: new Map<
+      string,
+      { actionId: string; data?: Record<string, unknown> }
+    >(),
+    surfaceState: new Map(),
+    surfaceUndoStacks: new Map<string, string[]>(),
+    accumulatedSurfaceState: new Map<string, Record<string, unknown>>(),
+    surfaceActionRequestIds: new Set<string>(),
+    currentTurnSurfaces: [],
+    isProcessing: () => false,
+    enqueueMessage: () => ({ queued: false, requestId: "req-1" }),
+    getQueueDepth: () => 0,
+    processMessage: async () => "ok",
+    withSurface: createSurfaceMutex(),
+  });
+}
+
+function showEvent(sent: AssistantEvent[]) {
+  return UISurfaceShowEventSchema.parse(
+    sent.find((msg) => msg.type === "ui_surface_show"),
+  );
+}
+
+describe("voice_picker never blocks a turn", () => {
+  test("shows with an empty payload and awaits nothing", async () => {
+    const sent: AssistantEvent[] = [];
+    const ctx = makeContext(sent);
+
+    const result = await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "voice_picker",
+      data: {},
+    });
+
+    expect(result.isError).toBe(false);
+    expect(result.yieldToUser).toBeUndefined();
+
+    const parsed = showEvent(sent);
+    expect(parsed.surfaceType).toBe("voice_picker");
+    expect(parsed.actions).toBeUndefined();
+    expect(ctx.pendingSurfaceActions.has(parsed.surfaceId)).toBe(false);
+  });
+
+  test("strips actions the model attached", async () => {
+    const sent: AssistantEvent[] = [];
+    const ctx = makeContext(sent);
+
+    const result = await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "voice_picker",
+      data: {},
+      actions: [{ id: "done", label: "Done", style: "primary" }],
+    });
+
+    expect(result.isError).toBe(false);
+    expect(result.yieldToUser).toBeUndefined();
+
+    const parsed = showEvent(sent);
+    expect(parsed.actions).toBeUndefined();
+    // The persisted copy must match the emitted one, or a history reseed would
+    // resurrect the button the client blocks on.
+    expect(ctx.currentTurnSurfaces[0]?.actions).toBeUndefined();
+    expect(ctx.pendingSurfaceActions.has(parsed.surfaceId)).toBe(false);
+  });
+
+  test("ignores an explicit await_action", async () => {
+    const sent: AssistantEvent[] = [];
+    const ctx = makeContext(sent);
+
+    const result = await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "voice_picker",
+      data: {},
+      await_action: true,
+    });
+
+    expect(result.isError).toBe(false);
+    expect(result.yieldToUser).toBeUndefined();
+    expect(result.content).not.toContain("awaiting_user_action");
+    expect(ctx.pendingSurfaceActions.size).toBe(0);
+  });
+
+  test("a pending picker does not hold the one-interactive-surface lock", async () => {
+    const ctx = makeContext();
+    ctx.pendingSurfaceActions.set("surface-picker", {
+      surfaceType: "voice_picker",
+    });
+
+    const result = await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "choice",
+      data: { options: [{ id: "a", title: "Option A" }] },
+    });
+
+    expect(result.isError).toBe(false);
+    expect(result.content).not.toContain("already awaiting user input");
+  });
+
+  test("voice_picker is not an interactive surface type", () => {
+    expect(INTERACTIVE_SURFACE_TYPES).not.toContain("voice_picker");
+  });
+});

--- a/assistant/src/__tests__/voice-config-update.test.ts
+++ b/assistant/src/__tests__/voice-config-update.test.ts
@@ -276,6 +276,46 @@ describe("voice_config_update — tts_voice_id (managed/vellum active)", () => {
     expect(result.content).not.toContain("broadcast");
   });
 
+  test("hints the inline picker for the next managed voice change", async () => {
+    makeVellumActive();
+
+    const result = await run(
+      { setting: "tts_voice_id", value: "aura-2-zeus-en" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toStartWith("Vellum managed voice updated to");
+    expect(result.content).toContain(
+      'ui_show { surface_type: "voice_picker", data: {} }',
+    );
+  });
+
+  test("does not hint the picker when the voice is not managed", async () => {
+    writeConfig({ services: { tts: { provider: "elevenlabs" } } });
+    invalidateConfigCache();
+
+    const result = await run(
+      { setting: "tts_voice_id", value: "abc123" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).not.toContain("voice_picker");
+  });
+
+  test("does not hint the picker for a non-voice setting", async () => {
+    makeVellumActive();
+
+    const result = await run(
+      { setting: "conversation_timeout", value: 30 },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).not.toContain("voice_picker");
+  });
+
   test("rejects a value with characters invalid for any voice id", async () => {
     makeVellumActive();
 

--- a/assistant/src/api/surfaces.ts
+++ b/assistant/src/api/surfaces.ts
@@ -591,6 +591,7 @@ export const SURFACE_TYPES = [
   "skill_card",
   "call_summary",
   "visual",
+  "voice_picker",
 ] as const;
 
 export const SurfaceTypeSchema = z.enum(SURFACE_TYPES);
@@ -662,9 +663,10 @@ export type SurfaceData =
  * and serves verbatim but whose shape it does not model, which is why they
  * are absent from the renderable `SurfaceData` union: `channel_setup` (a
  * side-effect command forwarded to the setup panel), `task_preferences` (a
- * fixed grid that reads no data), and `skill_card` / `call_summary` (cards
- * the daemon appends to history directly — the memory retrospective and a
- * call summary — and whose data shape is owned by their client renderers).
+ * fixed grid that reads no data), `voice_picker` (a settings card that reads
+ * its own config), and `skill_card` / `call_summary` (cards the daemon appends
+ * to history directly, the memory retrospective and a call summary, whose
+ * data shape is owned by their client renderers).
  */
 export interface SurfaceDataByType {
   card: CardSurfaceData;
@@ -684,6 +686,7 @@ export interface SurfaceDataByType {
   skill_card: Record<string, unknown>;
   call_summary: Record<string, unknown>;
   visual: VisualSurfaceData;
+  voice_picker: Record<string, unknown>;
 }
 
 /** Any surface `data` payload, including the opaque (non-renderable) types. */
@@ -717,6 +720,7 @@ export const SURFACE_DATA_SCHEMAS: {
   skill_card: z.record(z.string(), z.unknown()),
   call_summary: z.record(z.string(), z.unknown()),
   visual: VisualSurfaceDataSchema,
+  voice_picker: z.record(z.string(), z.unknown()),
 };
 
 /**

--- a/assistant/src/config/bundled-skills/settings/tools/navigate-settings-tab.test.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/navigate-settings-tab.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import type { ToolContext } from "../../../../tools/types.js";
+import { run } from "./navigate-settings-tab.js";
+
+let sentMessages: Array<{ type: string; [key: string]: unknown }> = [];
+
+function makeContext(overrides?: Partial<ToolContext>): ToolContext {
+  return {
+    workingDir: "/tmp",
+    conversationId: "conv-xyz",
+    trustClass: "guardian",
+    sendToClient: (msg) => {
+      sentMessages.push(msg);
+    },
+    ...overrides,
+  };
+}
+
+describe("navigate_settings_tab tool", () => {
+  beforeEach(() => {
+    sentMessages = [];
+  });
+
+  test("navigates to the Voice tab and hints the inline picker", async () => {
+    const result = await run({ tab: "Voice" }, makeContext());
+
+    expect(result.isError).toBe(false);
+    expect(sentMessages).toEqual([{ type: "navigate_settings", tab: "Voice" }]);
+    expect(result.content).toStartWith("Opened settings to the Voice tab.");
+    expect(result.content).toContain(
+      'ui_show { surface_type: "voice_picker", data: {} }',
+    );
+  });
+
+  test("leaves a non-Voice tab's result unchanged", async () => {
+    const result = await run({ tab: "Billing" }, makeContext());
+
+    expect(result.isError).toBe(false);
+    expect(sentMessages).toEqual([
+      { type: "navigate_settings", tab: "Billing" },
+    ]);
+    expect(result.content).toBe("Opened settings to the Billing tab.");
+    expect(result.content).not.toContain("voice_picker");
+  });
+
+  test("resolves legacy tab aliases without hinting", async () => {
+    const result = await run({ tab: "Archived Conversations" }, makeContext());
+
+    expect(result.isError).toBe(false);
+    expect(sentMessages).toEqual([
+      { type: "navigate_settings", tab: "Archive" },
+    ]);
+    expect(result.content).toBe("Opened settings to the Archive tab.");
+    expect(result.content).not.toContain("voice_picker");
+  });
+
+  test("rejects an unknown tab without navigating", async () => {
+    const result = await run({ tab: "Telepathy" }, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('unknown tab "Telepathy"');
+    expect(sentMessages).toEqual([]);
+  });
+});

--- a/assistant/src/config/bundled-skills/settings/tools/navigate-settings-tab.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/navigate-settings-tab.ts
@@ -23,6 +23,9 @@ const LEGACY_TAB_ALIASES: Record<string, SettingsTab> = {
   "Archived Conversations": "Archive",
 };
 
+const VOICE_TAB_PICKER_HINT =
+  'Next time the user wants to change or hear a voice, prefer `ui_show { surface_type: "voice_picker", data: {} }`, which puts the picker in the conversation without navigating away. Navigating here is right only when the user explicitly asked to open Settings.';
+
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
@@ -45,8 +48,9 @@ export async function run(
     });
   }
 
+  const opened = `Opened settings to the ${tab} tab.`;
   return {
-    content: `Opened settings to the ${tab} tab.`,
+    content: tab === "Voice" ? `${opened} ${VOICE_TAB_PICKER_HINT}` : opened,
     isError: false,
   };
 }

--- a/assistant/src/config/bundled-skills/settings/tools/navigate-settings-tab.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/navigate-settings-tab.ts
@@ -2,6 +2,7 @@ import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { voicePickerHint } from "./shared.js";
 
 const SETTINGS_TABS = [
   "General",
@@ -23,8 +24,9 @@ const LEGACY_TAB_ALIASES: Record<string, SettingsTab> = {
   "Archived Conversations": "Archive",
 };
 
-const VOICE_TAB_PICKER_HINT =
-  'Next time the user wants to change or hear a voice, prefer `ui_show { surface_type: "voice_picker", data: {} }`, which puts the picker in the conversation without navigating away. Navigating here is right only when the user explicitly asked to open Settings.';
+const VOICE_TAB_PICKER_HINT = voicePickerHint(
+  "which puts the picker in the conversation without navigating away. Navigating here is right only when the user explicitly asked to open Settings.",
+);
 
 export async function run(
   input: Record<string, unknown>,

--- a/assistant/src/config/bundled-skills/settings/tools/shared.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/shared.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared helpers for the settings skill's tool executors.
+ */
+
+/**
+ * Steer the model back to the inline voice picker.
+ *
+ * Both settings tools a "change my voice" request can land on (the Voice tab
+ * navigation and a managed `tts_voice_id` write) end by naming the picker, so
+ * the invocation itself lives here: one edit keeps both tools teaching the same
+ * call. Each caller supplies its own tail, because the reason the picker is
+ * better differs by the tool the model just reached for.
+ */
+export function voicePickerHint(tail: string): string {
+  return `Next time the user wants to change or hear a voice, prefer \`ui_show { surface_type: "voice_picker", data: {} }\`, ${tail}`;
+}

--- a/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
@@ -19,6 +19,7 @@ import {
 } from "../../../loader.js";
 import { VALID_CONVERSATION_TIMEOUTS } from "../../../schemas/elevenlabs.js";
 import { VALID_STT_PROVIDERS } from "../../../schemas/stt.js";
+import { voicePickerHint } from "./shared.js";
 
 /**
  * Valid voice config settings and their UserDefaults key mappings.
@@ -186,6 +187,19 @@ const STT_LANGUAGE_ALIASES: Record<
   mixed: "multi",
   "code-switching": "multi",
 };
+
+/**
+ * Same steer `navigate_settings_tab` puts on the Voice tab, applied to the
+ * strongest competing affordance: this tool's description coaches the model to
+ * read the managed catalog and set `tts_voice_id` itself, which is exactly the
+ * "assistant names voices in prose" outcome the inline picker exists to
+ * replace. Managed only, because that is the catalog the picker renders. The
+ * write still happens and the result stays non-error; this only redirects the
+ * next request.
+ */
+const MANAGED_VOICE_PICKER_HINT = voicePickerHint(
+  "which lets them hear and pick from the managed catalog in the conversation. Set the id here only when the user named a specific voice.",
+);
 
 function validateSetting(
   setting: string,
@@ -530,10 +544,14 @@ export async function run(
     AUTO_DETECT_STT_PROVIDERS.has(activeSttProviderId)
       ? ` Note: the configured STT provider (${activeSttProviderId}) auto-detects the spoken language natively and ignores this setting.`
       : "";
+  const pickerNote =
+    setting === "tts_voice_id" && activeTtsProviderId === "vellum"
+      ? ` ${MANAGED_VOICE_PICKER_HINT}`
+      : "";
   return {
     content: `${friendlyName} updated to ${JSON.stringify(
       validation.coerced,
-    )}.${broadcastNote}${autoDetectNote}`,
+    )}.${broadcastNote}${autoDetectNote}${pickerNote}`,
     isError: false,
   };
 }

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -140,13 +140,27 @@ const MAX_UNDO_DEPTH = 10;
 
 /**
  * Pending surface types that do not hold the one-interactive-surface-at-a-time
- * lock. Both render content the user reads rather than a question they must
- * answer, so a live one must not block the next surface.
+ * lock. Each renders content the user reads (or settles on its own) rather
+ * than a question they must answer, so a live one must not block the next
+ * surface.
  */
 const NON_BLOCKING_PENDING_SURFACE_TYPES = new Set<SurfaceType>([
   "dynamic_page",
   "visual",
+  "voice_picker",
 ]);
+
+/**
+ * Surface types that carry no terminal action: the card settles when the user
+ * interacts with it, so no click could ever satisfy an attached `actions`
+ * entry or an explicit `await_action`. Both are generic ui_show params though,
+ * so nothing stops the model attaching them here, and doing so wedges the
+ * turn: the client latches `awaiting_user_input` on the presence of actions
+ * alone and no action ever arrives to clear it, leaving the composer disabled
+ * and Stop hidden while the daemon is still streaming. Stripping them makes
+ * the "never blocks a turn" contract structural rather than advisory.
+ */
+const ACTIONLESS_SURFACE_TYPES = new Set<SurfaceType>(["voice_picker"]);
 
 /**
  * Debounce window for persisting `ui_surface_update` data back to the
@@ -3279,8 +3293,12 @@ export async function surfaceProxyResolver(
       }
       inputActions = valid.length > 0 ? valid : undefined;
     }
-    const actions =
-      choiceData !== undefined ? buildChoiceActions(choiceData) : inputActions;
+    const isActionless = ACTIONLESS_SURFACE_TYPES.has(surfaceType);
+    const actions = isActionless
+      ? undefined
+      : choiceData !== undefined
+        ? buildChoiceActions(choiceData)
+        : inputActions;
     const hasActions = Array.isArray(actions) && actions.length > 0;
     if (surfaceType === "choice" && !hasActions) {
       return {
@@ -3332,7 +3350,11 @@ export async function surfaceProxyResolver(
           : surfaceType === "table"
             ? hasActions
             : INTERACTIVE_SURFACE_TYPES.includes(surfaceType);
-    const awaitAction = (input.await_action as boolean) ?? isInteractive;
+    // An explicit `await_action: true` is honored for every other type; an
+    // actionless surface has nothing to await, so it is forced false.
+    const awaitAction = isActionless
+      ? false
+      : ((input.await_action as boolean) ?? isInteractive);
 
     // Only one non-persistent interactive surface at a time. If another
     // surface is already awaiting user input, reject this one so the LLM

--- a/assistant/src/tools/ui-surface/surface-shape-docs.ts
+++ b/assistant/src/tools/ui-surface/surface-shape-docs.ts
@@ -212,9 +212,15 @@ export const SURFACE_SHAPE_DOCS: Record<string, SurfaceShapeDoc> = {
         : '`data.channel` must be one of "slack", "telegram", "phone"',
   },
   voice_picker: {
-    purpose: "inline picker for the voice the assistant speaks in",
+    // The steering lives in `purpose` because that is the only part of a cold
+    // type the model ever sees: `shape` ships solely inside a teaching error,
+    // and an empty payload has no missing-content state to raise one. The
+    // surface exists to replace prose voice tours, so losing the directive
+    // would leave nothing but a renderer nobody invokes.
+    purpose:
+      "inline picker for the voice the assistant speaks in; show it when the user asks to change, hear, or pick a voice rather than describing voices in prose or sending them to Settings; attach no actions and never set await_action; during a live voice call answer in speech instead, the room already carries its own picker",
     shape:
-      "{}: no payload, the card reads the current voice and the catalog itself. Show it when the user asks to change, hear, or pick a voice, instead of describing voices in prose or sending them to Settings. Selecting a voice applies on the assistant's next spoken turn",
+      "{}: no payload, the card reads the current voice and the catalog itself. Selecting a voice applies on the assistant's next spoken turn",
   },
 };
 

--- a/assistant/src/tools/ui-surface/surface-shape-docs.ts
+++ b/assistant/src/tools/ui-surface/surface-shape-docs.ts
@@ -211,6 +211,11 @@ export const SURFACE_SHAPE_DOCS: Record<string, SurfaceShapeDoc> = {
         ? null
         : '`data.channel` must be one of "slack", "telegram", "phone"',
   },
+  voice_picker: {
+    purpose: "inline picker for the voice the assistant speaks in",
+    shape:
+      "{}: no payload, the card reads the current voice and the catalog itself. Show it when the user asks to change, hear, or pick a voice, instead of describing voices in prose or sending them to Settings. Selecting a voice applies on the assistant's next spoken turn",
+  },
 };
 
 /** Model-facing surface_type enum, derived so docs and schema cannot drift. */

--- a/clients/web/src/components/speech/byo-voice-note.tsx
+++ b/clients/web/src/components/speech/byo-voice-note.tsx
@@ -1,0 +1,30 @@
+/**
+ * Where a bring-your-own provider's voice is set. BYO assistants get no managed
+ * catalog to pick from: their voice is a field on the provider form, which
+ * lives with every other provider on Models & Services. Rendered by each
+ * surface that would otherwise offer the picker, so none of them leaves an
+ * empty box.
+ *
+ * Lives under `components/speech/` alongside the picker it stands in for, since
+ * both the `chat` and `settings` domains render it.
+ */
+
+import { Link } from "react-router";
+
+import { routes } from "@/utils/routes";
+
+export function ByoVoiceNote() {
+  return (
+    <p className="text-body-small-default text-[var(--content-tertiary)]">
+      Your assistant speaks through a provider you configured yourself. Set its
+      voice on{" "}
+      <Link
+        to={`${routes.settings.ai}#text-to-speech`}
+        className="text-[var(--primary-base)] hover:underline"
+      >
+        Models &amp; Services
+      </Link>
+      .
+    </p>
+  );
+}

--- a/clients/web/src/components/speech/use-managed-voice-selection.ts
+++ b/clients/web/src/components/speech/use-managed-voice-selection.ts
@@ -25,7 +25,7 @@ import {
   configGetOptions,
   ttsProvidersGetOptions,
 } from "@/generated/daemon/@tanstack/react-query.gen";
-import { useIsOrgReady } from "@/hooks/use-is-org-ready";
+import { useOrgHeaderReadiness } from "@/hooks/use-is-org-ready";
 import {
   useManagedVoices,
   type ManagedVoiceOption,
@@ -50,6 +50,14 @@ export interface UseManagedVoiceSelection {
    * a "set it in Settings" state without flashing it during the fetch.
    */
   isByok: boolean;
+  /**
+   * Every fetch that decides `available` has concluded (or was never going to
+   * run: no assistant, or an organization that resolved to nothing). Until then
+   * `available` and `isByok` are both false and say nothing about each other,
+   * so a surface with no picker to show can hold its chrome back rather than
+   * draw an empty box that never fills.
+   */
+  settled: boolean;
   voices: readonly ManagedVoiceOption[];
   /**
    * The currently-selected model: the pick a write is still carrying, else the
@@ -70,16 +78,16 @@ export interface UseManagedVoiceSelection {
 export function useManagedVoiceSelection(
   assistantId: string | null,
 ): UseManagedVoiceSelection {
-  const isOrgReady = useIsOrgReady();
-  const enabled = isOrgReady && !!assistantId;
+  const orgReadiness = useOrgHeaderReadiness();
+  const enabled = orgReadiness === "ready" && !!assistantId;
 
-  const { data: providerCatalog } = useQuery({
+  const { data: providerCatalog, isLoading: catalogLoading } = useQuery({
     ...ttsProvidersGetOptions({ path: { assistant_id: assistantId ?? "" } }),
     enabled,
     staleTime: Infinity,
     retry: false,
   });
-  const { data: daemonConfig } = useQuery({
+  const { data: daemonConfig, isLoading: configLoading } = useQuery({
     ...configGetOptions({ path: { assistant_id: assistantId ?? "" } }),
     enabled,
     staleTime: 30_000,
@@ -104,7 +112,11 @@ export function useManagedVoiceSelection(
     providerCatalog?.providers?.find((p) => p.id === "vellum")
       ?.supportsVoiceSelection === true;
 
-  const { voices, defaultModel } = useManagedVoices(assistantId, {
+  const {
+    voices,
+    defaultModel,
+    loading: voicesLoading,
+  } = useManagedVoices(assistantId, {
     enabled: enabled && isManaged,
   });
 
@@ -113,6 +125,17 @@ export function useManagedVoiceSelection(
   // Gated on config having actually arrived — an unfetched config reads as
   // "not managed", which would flash the BYO state on every mount.
   const isByok = enabled && !!daemonConfig && !isManaged;
+  // "Nothing is in flight, and nothing is waiting to start." Each `isLoading`
+  // is false for a query that is disabled or has failed, so the states that
+  // never produce a picker (no assistant, an org that resolved to nothing, an
+  // old daemon, a catalog that failed or came back empty) settle rather than
+  // read as perpetually loading. `"resolving"` is the one wait not expressed as
+  // a query: it disables all three, and they'd otherwise look settled.
+  const settled =
+    orgReadiness !== "resolving" &&
+    !catalogLoading &&
+    !configLoading &&
+    !voicesLoading;
 
   const configuredModel =
     daemonTts?.providers?.vellum?.model ??
@@ -134,6 +157,7 @@ export function useManagedVoiceSelection(
   return {
     available,
     isByok,
+    settled,
     voices,
     currentModel,
     defaultModel: defaultModel ?? "",

--- a/clients/web/src/components/speech/voice-list.test.tsx
+++ b/clients/web/src/components/speech/voice-list.test.tsx
@@ -35,6 +35,7 @@ const ASSISTANT_ID = "asst_1";
 let orgReady = true;
 mock.module("@/hooks/use-is-org-ready", () => ({
   useIsOrgReady: () => orgReady,
+  useOrgHeaderReadiness: () => (orgReady ? "ready" : "resolving"),
 }));
 mock.module("@vellumai/design-library/components/toast", () => ({
   toast: { success: () => {}, error: () => {} },

--- a/clients/web/src/components/speech/voice-list.tsx
+++ b/clients/web/src/components/speech/voice-list.tsx
@@ -71,6 +71,13 @@ export interface VoiceListProps {
   /** Optional section heading (shown above the list, with a top divider). */
   heading?: string;
   className?: string;
+  /**
+   * Extra classes for the scrolling listbox, merged after its own `max-h-*` so
+   * a cap passed here wins. Where a height belongs: `className` lands on the
+   * outer wrapper, which also holds the provider dropdown, and capping that
+   * scrolls the dropdown out of view instead of the voices.
+   */
+  listClassName?: string;
   /** Called after a voice is chosen — e.g. to close the picker modal. */
   onSelect?: () => void;
   /**
@@ -96,17 +103,28 @@ export interface VoiceListProps {
    * height. The dropdown hides itself when the catalog has a single provider.
    */
   filterBySource?: boolean;
+  /**
+   * Bring the current voice into view on mount. Grouping means it may sit in a
+   * lower section rather than at the top, so hosts whose nearest scrollport is
+   * the list itself want this on: the picker modal, the first-run card, the
+   * Models & Services popover. Off by default because `scrollIntoView` scrolls
+   * *every* scrollable ancestor, so a list rendered inline in the chat
+   * transcript would drag the transcript to itself on each load.
+   */
+  autoScrollToSelected?: boolean;
 }
 
 export function VoiceList({
   assistantId,
   heading,
   className,
+  listClassName,
   onSelect,
   value,
   onChange,
   showSource = false,
   filterBySource = false,
+  autoScrollToSelected = false,
 }: VoiceListProps) {
   const {
     available,
@@ -168,13 +186,14 @@ export function VoiceList({
   );
   const { previewingModel, play, stop } = useVoiceSamplePreview();
 
-  // Bring the current voice into view on open — grouping means it may sit in a
-  // lower section rather than at the top.
   const selectedRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
+    if (!autoScrollToSelected) {
+      return;
+    }
     // `?.` on the method too — not every environment implements scrollIntoView.
     selectedRef.current?.scrollIntoView?.({ block: "nearest" });
-  }, []);
+  }, [autoScrollToSelected]);
 
   // Render nothing when there's no catalog, so the surrounding chrome collapses
   // with it. Uncontrolled surfaces also require the assistant to be managed
@@ -220,6 +239,7 @@ export function VoiceList({
           "flex flex-col overflow-y-auto",
           filterBySource ? "max-h-[60vh]" : "max-h-80",
           selecting && "pointer-events-none opacity-70",
+          listClassName,
         )}
       >
         {groups.map((group) => (

--- a/clients/web/src/components/speech/voice-picker-field.tsx
+++ b/clients/web/src/components/speech/voice-picker-field.tsx
@@ -69,6 +69,9 @@ export function VoicePickerField({
           onChange={onChange}
           onSelect={() => setOpen(false)}
           showSource
+          // The popover is the nearest scrollport, so opening on the current
+          // voice scrolls nothing but this list.
+          autoScrollToSelected
         />
       </Popover.Content>
     </Popover.Root>

--- a/clients/web/src/components/speech/voice-picker-modal.tsx
+++ b/clients/web/src/components/speech/voice-picker-modal.tsx
@@ -78,6 +78,9 @@ function VoicePickerContent({
           filterBySource
           value={currentModel}
           onChange={selectModel}
+          // The dialog body is the nearest scrollport, so opening on the
+          // current voice scrolls nothing but this list.
+          autoScrollToSelected
         />
       </Modal.Body>
       <Modal.Footer className="items-center justify-between gap-3">

--- a/clients/web/src/domains/chat/components/surfaces/surface-router.test.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/surface-router.test.tsx
@@ -41,6 +41,15 @@ mock.module(CARD_SURFACE_MODULE, () => ({
   },
 }));
 
+// Stands in for the real picker, which would pull the daemon config, TTS
+// provider, and managed-voice queries into a routing test. What matters here is
+// which component the router picks.
+mock.module("@/domains/chat/components/surfaces/voice-picker-surface", () => ({
+  VoicePickerSurface: ({ assistantId }: { assistantId: string | null }) => (
+    <div data-testid="voice-picker-surface">{assistantId ?? "no-assistant"}</div>
+  ),
+}));
+
 import { SurfaceRouter } from "@/domains/chat/components/surfaces/surface-router";
 import type { Surface } from "@/domains/chat/types/types";
 
@@ -101,6 +110,27 @@ describe("SurfaceRouter error boundary", () => {
     expect(getByRole("alert").textContent).toContain("My App");
     // …while the sibling copy_block surface renders normally.
     expect(getByText("still here")).toBeTruthy();
+  });
+});
+
+describe("SurfaceRouter: voice picker", () => {
+  test("routes surfaceType \"voice_picker\" to the inline picker", () => {
+    const { getByTestId, container } = render(
+      <SurfaceRouter
+        surface={makeSurface({
+          surfaceId: "surface-voice",
+          surfaceType: "voice_picker",
+          title: "Pick a voice",
+        })}
+        onAction={() => {}}
+        assistantId="asst_1"
+      />,
+    );
+
+    // The acceptance criterion for registering the type: not the fallback card.
+    expect(container.textContent).not.toContain("Unsupported surface type");
+    // The owning assistant is threaded through, not read from global state.
+    expect(getByTestId("voice-picker-surface").textContent).toBe("asst_1");
   });
 });
 

--- a/clients/web/src/domains/chat/components/surfaces/surface-router.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/surface-router.tsx
@@ -22,6 +22,7 @@ import { SurfaceContainer } from "@/domains/chat/components/surfaces/surface-con
 import { TableSurface } from "@/domains/chat/components/surfaces/table-surface";
 import { TaskPreferencesSurface } from "@/domains/chat/components/surfaces/task-preferences-surface";
 import { VisualSurface } from "@/domains/chat/components/surfaces/visual-surface";
+import { VoicePickerSurface } from "@/domains/chat/components/surfaces/voice-picker-surface";
 import { WorkResultSurface } from "@/domains/chat/components/surfaces/work-result-surface";
 
 export interface SurfaceRouterProps {
@@ -169,6 +170,20 @@ function SurfaceRouterInner({
 
     case "task_preferences":
       return <TaskPreferencesSurface surface={surface} onAction={onAction} />;
+
+    // Deliberately absent from `INHERENTLY_INTERACTIVE_SURFACE_TYPES` and
+    // `OPTIMISTIC_COMPLETION_SURFACE_TYPES`. A settings card has no terminal
+    // action and so never completes: listing it in the first would block the
+    // composer indefinitely, and in the second would collapse the card into a
+    // "Done" chip on the first pick.
+    case "voice_picker":
+      return (
+        <VoicePickerSurface
+          surface={surface}
+          onAction={onAction}
+          assistantId={assistantId}
+        />
+      );
 
     case "work_result":
       return <WorkResultSurface surface={surface} onAction={onAction} />;

--- a/clients/web/src/domains/chat/components/surfaces/surface-router.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/surface-router.tsx
@@ -181,7 +181,7 @@ function SurfaceRouterInner({
         <VoicePickerSurface
           surface={surface}
           onAction={onAction}
-          assistantId={assistantId}
+          assistantId={assistantId ?? null}
         />
       );
 

--- a/clients/web/src/domains/chat/components/surfaces/voice-picker-surface.test.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/voice-picker-surface.test.tsx
@@ -4,12 +4,17 @@
  *
  * Load-bearing behavior:
  *   - a managed assistant gets the fetched voice rows inside the surface card,
- *   - picking a voice PATCHes `services.tts.providers.vellum.model`,
+ *     scoped by the provider dropdown,
  *   - picking a voice submits no surface action, so auditioning several voices
  *     never fires an assistant turn,
- *   - a BYO assistant gets the Models & Services pointer, not an empty card.
+ *   - the height cap lands on the scrolling list, not on the wrapper that also
+ *     holds the provider dropdown,
+ *   - every settled state without a picker gets a pointer instead, and the
+ *     unsettled state gets no card at all: a bordered box with nothing in it is
+ *     the one outcome this surface must never produce.
  *
- * The daemon queries, the config PATCH, and audio playback are mocked.
+ * The daemon queries, the config PATCH, and audio playback are mocked; the
+ * design-library Dropdown is real, driven via its combobox trigger.
  */
 
 import {
@@ -32,12 +37,14 @@ import {
 import { MemoryRouter } from "react-router";
 
 import type { Surface } from "@/domains/chat/types/types";
+import type { OrgHeaderReadiness } from "@/hooks/use-is-org-ready";
 
 const ASSISTANT_ID = "asst_1";
 
-let orgReady = true;
+let orgReadiness: OrgHeaderReadiness = "ready";
 mock.module("@/hooks/use-is-org-ready", () => ({
-  useIsOrgReady: () => orgReady,
+  useIsOrgReady: () => orgReadiness === "ready",
+  useOrgHeaderReadiness: () => orgReadiness,
 }));
 mock.module("@vellumai/design-library/components/toast", () => ({
   toast: { success: () => {}, error: () => {} },
@@ -48,6 +55,8 @@ mock.module("@vellumai/design-library/components/toast", () => ({
 let daemonConfigData: { services: Record<string, unknown> } = {
   services: { tts: { provider: "vellum" } },
 };
+// Holds the config query in flight, for the "still loading" state.
+let configPending = false;
 let providersData: { providers: unknown[] } = {
   providers: [
     { id: "vellum", displayName: "Vellum", supportsVoiceSelection: true },
@@ -63,11 +72,17 @@ mock.module("@/generated/daemon/@tanstack/react-query.gen", () => ({
     queryFn: () => Promise.resolve(providersData),
     initialData: providersData,
   }),
-  configGetOptions: () => ({
-    queryKey: ["config-get-test"],
-    queryFn: () => Promise.resolve(daemonConfigData),
-    initialData: daemonConfigData,
-  }),
+  configGetOptions: () =>
+    configPending
+      ? {
+          queryKey: ["config-get-test"],
+          queryFn: () => new Promise(() => {}),
+        }
+      : {
+          queryKey: ["config-get-test"],
+          queryFn: () => Promise.resolve(daemonConfigData),
+          initialData: daemonConfigData,
+        },
   configGetQueryKey: () => ["config-get-test"],
   ttsManagedvoicesGetOptions: () => ({
     queryKey: ["tts-managed-voices-test"],
@@ -84,8 +99,9 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
   },
 }));
 
-const { VoicePickerSurface } =
-  await import("@/domains/chat/components/surfaces/voice-picker-surface");
+const { VoicePickerSurface } = await import(
+  "@/domains/chat/components/surfaces/voice-picker-surface"
+);
 
 const SURFACE: Surface = {
   surfaceId: "surface-voice-1",
@@ -126,10 +142,34 @@ function renderSurface(assistantId: string | null = ASSISTANT_ID) {
   );
 }
 
+/** Voice rows only; the provider dropdown's own options live in a portal. */
+function voiceRows(): HTMLElement[] {
+  const list = screen.getByRole("listbox", { name: "Assistant voice" });
+  return Array.from(list.querySelectorAll<HTMLElement>('[role="option"]'));
+}
+
+/** The list opens on the current voice's provider; Zeus lives under the other. */
+function selectDeepgram() {
+  const trigger = document.querySelector<HTMLElement>(
+    'button[role="combobox"][aria-label="Voice provider"]',
+  );
+  if (!trigger) {
+    throw new Error("expected the voice provider dropdown trigger");
+  }
+  fireEvent.click(trigger);
+  const option = Array.from(
+    document.querySelectorAll<HTMLElement>('[role="option"]'),
+  ).find((o) => o.textContent?.trim() === "Deepgram");
+  if (!option) {
+    throw new Error("expected a Deepgram option");
+  }
+  fireEvent.click(option);
+}
+
 function pickZeus() {
-  const zeus = screen
-    .getAllByRole("option")
-    .find((o) => o.textContent?.includes("Deep, trustworthy"));
+  const zeus = voiceRows().find((o) =>
+    o.textContent?.includes("Deep, trustworthy"),
+  );
   if (!zeus) {
     throw new Error("expected the Zeus option");
   }
@@ -137,7 +177,8 @@ function pickZeus() {
 }
 
 beforeEach(() => {
-  orgReady = true;
+  orgReadiness = "ready";
+  configPending = false;
   configPatchCalls.length = 0;
   onActionCalls.length = 0;
   daemonConfigData = { services: { tts: { provider: "vellum" } } };
@@ -160,7 +201,7 @@ beforeEach(() => {
         label: "Zeus",
         description: "American · deep, trustworthy, smooth",
         sampleUrl: "https://example.test/zeus.wav",
-        source: "elevenlabs",
+        source: "deepgram",
       },
     ],
     defaultModel: "EXAVITQu4vr4xnSDxMaL",
@@ -173,26 +214,43 @@ describe("VoicePickerSurface", () => {
     renderSurface();
 
     expect(screen.getByText("Pick a voice")).toBeTruthy();
-    const rows = screen.getAllByRole("option");
-    expect(rows.length).toBe(2);
-    expect(rows.map((r) => r.textContent ?? "").join(" ")).toContain(
-      "Deep, trustworthy, smooth",
-    );
+    // Scoped to the current voice's provider, with the dropdown to leave it.
+    expect(
+      document.querySelector('button[role="combobox"][aria-label="Voice provider"]'),
+    ).toBeTruthy();
+    const rows = voiceRows();
+    expect(rows.length).toBe(1);
+    expect(rows[0]!.textContent).toContain("Professional, reassuring");
+    // Managed voices bill credits, so the card says so.
+    expect(screen.getByText(/Uses Vellum credits/)).toBeTruthy();
   });
 
-  test("picking a voice PATCHes services.tts.providers.vellum.model", async () => {
+  test("the provider dropdown scopes the list to the chosen provider", () => {
     renderSurface();
-    pickZeus();
+    selectDeepgram();
 
-    await waitFor(() => expect(configPatchCalls.length).toBe(1));
-    expect(configPatchCalls[0]!.path).toEqual({ assistant_id: ASSISTANT_ID });
-    expect(configPatchCalls[0]!.body).toEqual({
-      services: { tts: { providers: { vellum: { model: "aura-2-zeus-en" } } } },
-    });
+    const rows = voiceRows();
+    expect(rows.length).toBe(1);
+    expect(rows[0]!.textContent).toContain("Deep, trustworthy");
+  });
+
+  test("the height cap lands on the scrolling list, not on the wrapper", () => {
+    renderSurface();
+
+    const list = screen.getByRole("listbox", { name: "Assistant voice" });
+    expect(list.className).toContain("max-h-[22rem]");
+    // The cap replaces the list's own default rather than nesting inside it.
+    expect(list.className).not.toContain("max-h-[60vh]");
+    // The wrapper holding the provider dropdown stays unconstrained, so the
+    // dropdown can't be scrolled out of the card.
+    const wrapper = list.parentElement!;
+    expect(wrapper.className).not.toContain("max-h-");
+    expect(wrapper.className).not.toContain("overflow-y-auto");
   });
 
   test("picking a voice submits no surface action", async () => {
     renderSurface();
+    selectDeepgram();
     pickZeus();
 
     // The write is what the card does instead of an action. Waiting for it
@@ -211,5 +269,44 @@ describe("VoicePickerSurface", () => {
     expect(link.getAttribute("href")).toBe(
       "/assistant/settings/ai#text-to-speech",
     );
+  });
+
+  test("a daemon too old to select voices gets a pointer, not an empty card", () => {
+    providersData = {
+      providers: [
+        { id: "vellum", displayName: "Vellum", supportsVoiceSelection: false },
+      ],
+    };
+    renderSurface();
+
+    expect(screen.queryByRole("listbox")).toBeNull();
+    // Managed, so the BYO pointer would be a lie: it gets the plain line.
+    expect(screen.queryByRole("link")).toBeNull();
+    expect(screen.getByText(/available for this assistant/)).toBeTruthy();
+  });
+
+  test("an empty voice catalog gets a pointer, not an empty card", () => {
+    managedVoicesData = { voices: [], defaultModel: null };
+    renderSurface();
+
+    expect(screen.queryByRole("listbox")).toBeNull();
+    expect(screen.getByText(/available for this assistant/)).toBeTruthy();
+  });
+
+  test("no assistant gets a pointer, not an empty card", () => {
+    renderSurface(null);
+
+    expect(screen.queryByRole("listbox")).toBeNull();
+    expect(screen.getByText(/available for this assistant/)).toBeTruthy();
+  });
+
+  test("renders no card at all while daemon config is still in flight", () => {
+    configPending = true;
+    const { container } = renderSurface();
+
+    // Not even the title: the card's own chrome would be an empty box until
+    // the queries land.
+    expect(container.textContent).toBe("");
+    expect(screen.queryByText("Pick a voice")).toBeNull();
   });
 });

--- a/clients/web/src/domains/chat/components/surfaces/voice-picker-surface.test.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/voice-picker-surface.test.tsx
@@ -1,0 +1,215 @@
+/**
+ * Tests for `VoicePickerSurface`, the inline chat card that hosts the shared
+ * managed-voice picker.
+ *
+ * Load-bearing behavior:
+ *   - a managed assistant gets the fetched voice rows inside the surface card,
+ *   - picking a voice PATCHes `services.tts.providers.vellum.model`,
+ *   - picking a voice submits no surface action, so auditioning several voices
+ *     never fires an assistant turn,
+ *   - a BYO assistant gets the Models & Services pointer, not an empty card.
+ *
+ * The daemon queries, the config PATCH, and audio playback are mocked.
+ */
+
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+
+import type { Surface } from "@/domains/chat/types/types";
+
+const ASSISTANT_ID = "asst_1";
+
+let orgReady = true;
+mock.module("@/hooks/use-is-org-ready", () => ({
+  useIsOrgReady: () => orgReady,
+}));
+mock.module("@vellumai/design-library/components/toast", () => ({
+  toast: { success: () => {}, error: () => {} },
+  Toaster: () => null,
+  ToastContent: () => null,
+}));
+
+let daemonConfigData: { services: Record<string, unknown> } = {
+  services: { tts: { provider: "vellum" } },
+};
+let providersData: { providers: unknown[] } = {
+  providers: [
+    { id: "vellum", displayName: "Vellum", supportsVoiceSelection: true },
+  ],
+};
+let managedVoicesData: { voices: unknown[]; defaultModel: string | null } = {
+  voices: [],
+  defaultModel: null,
+};
+mock.module("@/generated/daemon/@tanstack/react-query.gen", () => ({
+  ttsProvidersGetOptions: () => ({
+    queryKey: ["tts-providers-test"],
+    queryFn: () => Promise.resolve(providersData),
+    initialData: providersData,
+  }),
+  configGetOptions: () => ({
+    queryKey: ["config-get-test"],
+    queryFn: () => Promise.resolve(daemonConfigData),
+    initialData: daemonConfigData,
+  }),
+  configGetQueryKey: () => ["config-get-test"],
+  ttsManagedvoicesGetOptions: () => ({
+    queryKey: ["tts-managed-voices-test"],
+    queryFn: () => Promise.resolve(managedVoicesData),
+    initialData: managedVoicesData,
+  }),
+}));
+
+const configPatchCalls: { path?: unknown; body?: unknown }[] = [];
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  configPatch: async (opts: { path?: unknown; body?: unknown }) => {
+    configPatchCalls.push(opts);
+    return { response: { ok: true, status: 200 } };
+  },
+}));
+
+const { VoicePickerSurface } =
+  await import("@/domains/chat/components/surfaces/voice-picker-surface");
+
+const SURFACE: Surface = {
+  surfaceId: "surface-voice-1",
+  surfaceType: "voice_picker",
+  title: "Pick a voice",
+  data: {},
+};
+
+beforeAll(() => {
+  (
+    window.HTMLMediaElement.prototype as unknown as {
+      play: () => Promise<void>;
+    }
+  ).play = () => Promise.resolve();
+  (
+    window.HTMLMediaElement.prototype as unknown as { pause: () => void }
+  ).pause = () => {};
+});
+
+const onActionCalls: unknown[][] = [];
+
+function renderSurface(assistantId: string | null = ASSISTANT_ID) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <VoicePickerSurface
+          surface={SURFACE}
+          onAction={(...args) => {
+            onActionCalls.push(args);
+          }}
+          assistantId={assistantId}
+        />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+function pickZeus() {
+  const zeus = screen
+    .getAllByRole("option")
+    .find((o) => o.textContent?.includes("Deep, trustworthy"));
+  if (!zeus) {
+    throw new Error("expected the Zeus option");
+  }
+  fireEvent.click(zeus);
+}
+
+beforeEach(() => {
+  orgReady = true;
+  configPatchCalls.length = 0;
+  onActionCalls.length = 0;
+  daemonConfigData = { services: { tts: { provider: "vellum" } } };
+  providersData = {
+    providers: [
+      { id: "vellum", displayName: "Vellum", supportsVoiceSelection: true },
+    ],
+  };
+  managedVoicesData = {
+    voices: [
+      {
+        model: "EXAVITQu4vr4xnSDxMaL",
+        label: "Sarah",
+        description: "American · professional, reassuring, confident",
+        sampleUrl: "https://example.test/sarah.mp3",
+        source: "elevenlabs",
+      },
+      {
+        model: "aura-2-zeus-en",
+        label: "Zeus",
+        description: "American · deep, trustworthy, smooth",
+        sampleUrl: "https://example.test/zeus.wav",
+        source: "elevenlabs",
+      },
+    ],
+    defaultModel: "EXAVITQu4vr4xnSDxMaL",
+  };
+});
+afterEach(cleanup);
+
+describe("VoicePickerSurface", () => {
+  test("renders the fetched voices inside the surface card", () => {
+    renderSurface();
+
+    expect(screen.getByText("Pick a voice")).toBeTruthy();
+    const rows = screen.getAllByRole("option");
+    expect(rows.length).toBe(2);
+    expect(rows.map((r) => r.textContent ?? "").join(" ")).toContain(
+      "Deep, trustworthy, smooth",
+    );
+  });
+
+  test("picking a voice PATCHes services.tts.providers.vellum.model", async () => {
+    renderSurface();
+    pickZeus();
+
+    await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    expect(configPatchCalls[0]!.path).toEqual({ assistant_id: ASSISTANT_ID });
+    expect(configPatchCalls[0]!.body).toEqual({
+      services: { tts: { providers: { vellum: { model: "aura-2-zeus-en" } } } },
+    });
+  });
+
+  test("picking a voice submits no surface action", async () => {
+    renderSurface();
+    pickZeus();
+
+    // The write is what the card does instead of an action. Waiting for it
+    // means the action would have been submitted by now if the card submitted
+    // one, and every audition click would cost an assistant turn.
+    await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    expect(onActionCalls.length).toBe(0);
+  });
+
+  test("a BYO assistant gets the Models & Services pointer, not an empty card", () => {
+    daemonConfigData = { services: { tts: { provider: "elevenlabs" } } };
+    renderSurface();
+
+    expect(screen.queryByRole("listbox")).toBeNull();
+    const link = screen.getByRole("link", { name: "Models & Services" });
+    expect(link.getAttribute("href")).toBe(
+      "/assistant/settings/ai#text-to-speech",
+    );
+  });
+});

--- a/clients/web/src/domains/chat/components/surfaces/voice-picker-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/voice-picker-surface.tsx
@@ -1,0 +1,62 @@
+/**
+ * The voice picker, rendered inline in the transcript: a user who asks to hear
+ * or change a voice gets the working picker in the conversation instead of a
+ * pointer to Settings. Same {@link VoiceList} the Voice settings page and the
+ * voice room render, so a voice is chosen the same way everywhere.
+ *
+ * **Fires no surface action.** `handleSurfaceAction` requests a send on every
+ * non-guardian action, so a per-selection action would cost an assistant turn
+ * on every audition click. It needs none: `VoiceList` writes
+ * `services.tts.providers.vellum.model` to daemon config itself, and that
+ * hot-applies on the assistant's next spoken turn. `onAction` is accepted only
+ * to satisfy {@link SurfaceContainer}'s required prop and to keep the router's
+ * call shape uniform across surfaces. This component never invokes it.
+ *
+ * The assistant arrives as a prop rather than from `useActiveAssistantId()`,
+ * which throws when nothing is resolved and answers with the globally-active
+ * assistant, not necessarily the one that owns this surface's stream.
+ */
+
+import { ByoVoiceNote } from "@/components/speech/byo-voice-note";
+import { useManagedVoiceSelection } from "@/components/speech/use-managed-voice-selection";
+import { VoiceList } from "@/components/speech/voice-list";
+import { SurfaceContainer } from "@/domains/chat/components/surfaces/surface-container";
+import type { Surface } from "@/domains/chat/types/types";
+
+interface VoicePickerSurfaceProps {
+  surface: Surface;
+  onAction: (
+    surfaceId: string,
+    actionId: string,
+    data?: Record<string, unknown>,
+  ) => void | Promise<void>;
+  assistantId?: string | null;
+}
+
+export function VoicePickerSurface({
+  surface,
+  onAction,
+  assistantId,
+}: VoicePickerSurfaceProps) {
+  const { available, isByok } = useManagedVoiceSelection(assistantId ?? null);
+
+  return (
+    <SurfaceContainer surface={surface} onAction={onAction}>
+      {available && (
+        // Uncontrolled (no `value`/`onChange`) so the list commits the pick
+        // itself and it hot-applies, the mode the Settings picker and the voice
+        // room use. `showSource` stays off because `filterBySource` already
+        // labels the whole list with the chosen provider and drops the per-row
+        // badge. Capped so a long catalog can't take over the transcript.
+        <VoiceList
+          assistantId={assistantId ?? null}
+          filterBySource
+          className="max-h-[22rem] overflow-y-auto"
+        />
+      )}
+      {/* Gated on `isByok` rather than `!available` so the BYO pointer never
+          flashes while config is still loading. */}
+      {isByok && <ByoVoiceNote />}
+    </SurfaceContainer>
+  );
+}

--- a/clients/web/src/domains/chat/components/surfaces/voice-picker-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/voice-picker-surface.tsx
@@ -4,17 +4,22 @@
  * pointer to Settings. Same {@link VoiceList} the Voice settings page and the
  * voice room render, so a voice is chosen the same way everywhere.
  *
- * **Fires no surface action.** `handleSurfaceAction` requests a send on every
+ * **Carries no surface action.** `handleSurfaceAction` requests a send on every
  * non-guardian action, so a per-selection action would cost an assistant turn
  * on every audition click. It needs none: `VoiceList` writes
  * `services.tts.providers.vellum.model` to daemon config itself, and that
- * hot-applies on the assistant's next spoken turn. `onAction` is accepted only
- * to satisfy {@link SurfaceContainer}'s required prop and to keep the router's
- * call shape uniform across surfaces. This component never invokes it.
+ * hot-applies on the assistant's next spoken turn. `onAction` is accepted to
+ * satisfy {@link SurfaceContainer}'s required prop and to keep the router's
+ * call shape uniform; `SurfaceContainer` only invokes it for actions the
+ * surface declares, and no voice picker is given any.
  *
- * The assistant arrives as a prop rather than from `useActiveAssistantId()`,
- * which throws when nothing is resolved and answers with the globally-active
- * assistant, not necessarily the one that owns this surface's stream.
+ * Three states, not two, because most of the ways a picker fails to appear are
+ * permanent rather than transient: no chrome at all while the daemon queries
+ * are in flight, the picker once managed voice selection is available, and a
+ * pointer to where the voice actually lives for every settled state in between
+ * (a daemon too old to select voices, a catalog that failed or came back empty,
+ * no assistant). An empty bordered box is the one unacceptable outcome, since
+ * the model has just told the user the picker is here.
  */
 
 import { ByoVoiceNote } from "@/components/speech/byo-voice-note";
@@ -22,6 +27,9 @@ import { useManagedVoiceSelection } from "@/components/speech/use-managed-voice-
 import { VoiceList } from "@/components/speech/voice-list";
 import { SurfaceContainer } from "@/domains/chat/components/surfaces/surface-container";
 import type { Surface } from "@/domains/chat/types/types";
+import { MANAGED_VOICE_CREDITS_NOTE } from "@/lib/tts/managed-voice-catalog";
+
+const NOTE_CLASS = "text-body-small-default text-[var(--content-tertiary)]";
 
 interface VoicePickerSurfaceProps {
   surface: Surface;
@@ -30,7 +38,7 @@ interface VoicePickerSurfaceProps {
     actionId: string,
     data?: Record<string, unknown>,
   ) => void | Promise<void>;
-  assistantId?: string | null;
+  assistantId: string | null;
 }
 
 export function VoicePickerSurface({
@@ -38,25 +46,44 @@ export function VoicePickerSurface({
   onAction,
   assistantId,
 }: VoicePickerSurfaceProps) {
-  const { available, isByok } = useManagedVoiceSelection(assistantId ?? null);
+  // Only the three flags that pick the state. `VoiceList` runs the same hook for
+  // the data it renders; both calls share one set of React Query subscriptions.
+  const { available, isByok, settled } = useManagedVoiceSelection(assistantId);
+
+  if (!settled) {
+    return null;
+  }
 
   return (
     <SurfaceContainer surface={surface} onAction={onAction}>
-      {available && (
-        // Uncontrolled (no `value`/`onChange`) so the list commits the pick
-        // itself and it hot-applies, the mode the Settings picker and the voice
-        // room use. `showSource` stays off because `filterBySource` already
-        // labels the whole list with the chosen provider and drops the per-row
-        // badge. Capped so a long catalog can't take over the transcript.
-        <VoiceList
-          assistantId={assistantId ?? null}
-          filterBySource
-          className="max-h-[22rem] overflow-y-auto"
-        />
+      {available ? (
+        <div className="flex flex-col gap-3">
+          {/* Uncontrolled (no `value`/`onChange`): the list commits each pick
+              itself and it hot-applies. Every other host is controlled, because
+              each owns a Done or Start button that has to wait out an in-flight
+              write; this card has no button, so there is nothing to gate. */}
+          <VoiceList
+            assistantId={assistantId}
+            filterBySource
+            // Capped on the listbox rather than the wrapper, which also holds
+            // the provider dropdown: capping the wrapper scrolls the dropdown
+            // out of the card instead of scrolling the voices.
+            listClassName="max-h-[22rem]"
+          />
+          {/* Managed voices bill credits, and every surface that offers them
+              says so. This one is reached without opening Settings, so it
+              carries the disclosure too. */}
+          <p className={NOTE_CLASS}>{MANAGED_VOICE_CREDITS_NOTE}</p>
+        </div>
+      ) : isByok ? (
+        <ByoVoiceNote />
+      ) : (
+        // Managed, but with nothing to choose from: an old daemon, or a catalog
+        // that failed or is empty. The BYO note would be a lie here.
+        <p className={NOTE_CLASS}>
+          Choosing a voice isn’t available for this assistant right now.
+        </p>
       )}
-      {/* Gated on `isByok` rather than `!available` so the BYO pointer never
-          flashes while config is still loading. */}
-      {isByok && <ByoVoiceNote />}
     </SurfaceContainer>
   );
 }

--- a/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
@@ -493,6 +493,9 @@ function VoiceSettingsView({
           filterBySource
           value={currentModel}
           onChange={selectModel}
+          // The dialog body is the nearest scrollport, so opening on the
+          // current voice scrolls nothing but this list.
+          autoScrollToSelected
         />
       </Modal.Body>
       {/* Mirrors the intro footer (fine print left, primary right) and is always

--- a/clients/web/src/domains/settings/ai/text-to-speech-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/text-to-speech-card.test.tsx
@@ -32,6 +32,7 @@ mock.module("@vellumai/design-library/components/toast", () => ({
 let orgReady = false;
 mock.module("@/hooks/use-is-org-ready", () => ({
   useIsOrgReady: () => orgReady,
+  useOrgHeaderReadiness: () => (orgReady ? "ready" : "resolving"),
 }));
 // Controllable daemon config the config-get query resolves to. `initialData`
 // makes it available even though the query is `enabled: isOrgReady` (false),

--- a/clients/web/src/domains/settings/pages/voice-picker-card.tsx
+++ b/clients/web/src/domains/settings/pages/voice-picker-card.tsx
@@ -15,18 +15,16 @@
 
 import { useState } from "react";
 
-import { Link } from "react-router";
-
 import { Button } from "@vellumai/design-library/components/button";
 
 import { DetailCard } from "@/components/detail-card";
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
+import { ByoVoiceNote } from "@/components/speech/byo-voice-note";
 import { useManagedVoiceSelection } from "@/components/speech/use-managed-voice-selection";
 import { MANAGED_VOICE_CREDITS_NOTE } from "@/lib/tts/managed-voice-catalog";
 import { VoiceLabel } from "@/components/speech/voice-list";
 import { VoicePickerModal } from "@/components/speech/voice-picker-modal";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
-import { routes } from "@/utils/routes";
 
 export function VoicePickerCard() {
   const assistantId = useActiveAssistantId();
@@ -72,17 +70,7 @@ export function VoicePickerCard() {
 
   return (
     <DetailCard title={voiceTitle}>
-      <p className="text-body-small-default text-[var(--content-tertiary)]">
-        Your assistant speaks through a provider you configured yourself. Set
-        its voice on{" "}
-        <Link
-          to={`${routes.settings.ai}#text-to-speech`}
-          className="text-[var(--primary-base)] hover:underline"
-        >
-          Models &amp; Services
-        </Link>
-        .
-      </p>
+      <ByoVoiceNote />
     </DetailCard>
   );
 }


### PR DESCRIPTION
Closes JARVIS-1470.

## Summary

When someone asks to change or hear a different voice, the assistant now renders the voice picker **in the conversation** instead of describing voices in prose or sending them to Settings.

Implemented as a new `voice_picker` member of the existing `ui_show` surface system, rendered by the same router that already handles `oauth_connect`. It reuses the shared `VoiceList` that Settings and the voice room already render, so a voice is chosen the same way everywhere, and selecting one writes `services.tts.providers.vellum.model` and hot-applies on the next spoken turn.

## Design decisions

- **Scoped to the picker**, not the whole Settings > Voice page. Mic, push-to-talk, captions, and tuning have no conversational trigger.
- **The card carries no surface action.** `handleSurfaceAction` requests a send on every non-guardian action, so a per-selection action would cost an assistant turn on every audition click. The list commits to daemon config directly, so none is needed. The daemon now strips `actions` and forces `awaitAction` false for this type, making the invariant structural rather than advisory.
- **Web only**, matching every other surface type. The native shells do not implement the surface registry; text-only channels never see it.

## PRs

| PR | Scope |
| --- | --- |
| #40303 | register the surface type |
| #40304 | the inline component |
| #40403 | router case |
| #40404 | make it invokable from `ui_show` |
| #40407 | steer the Voice settings tab toward it |
| #40412 | self-review fixes (daemon) |
| #40419 | self-review fixes (web) |

## Self-review

Four independent passes over the full diff produced 24 raw findings, deduplicated to 11 fixed across #40412 and #40419. The ones worth knowing:

- **The steering never reached the model.** Cold surface types contribute only `name (purpose)` to the tool description, and `uiShowTeachingError` returns early for a type with no `missingContent` (this one's payload is legitimately empty). The behavioral guidance sat in `shape`, which was unreachable by both routes. Moved into `purpose`; a test now asserts the directives against the *built* description so parking them in a dead field fails.
- **An empty bordered card in three permanent states** (a daemon predating `supportsVoiceSelection`, an empty or failed catalog, no assistant) while the assistant had just said the picker was here. Now a genuine three-way with a `settled` flag.
- **Mid-call the surface collapsed the voice room** to reach a picker the room already exposes. The model is now told to answer in speech during a live call.
- **`voice_config_update` actively coached the model to enumerate voices in prose**, the exact outcome this feature exists to prevent, and was unsteered.
- Scroll cap moved onto the listbox (it was scrolling the provider dropdown out of view), `scrollIntoView` made opt-in (it yanked the non-virtualized transcript on history load), and the managed-voice credits disclosure added.

## Not verified

**The end-to-end check has not been run.** Worktree agents cannot drive a live daemon plus web client, so everything here is unit-test level. Worth doing before merge: ask a running assistant "can you use a different voice?", confirm the picker renders, that auditioning several voices fires no extra turns, and that the pick applies on the next spoken turn.

## Follow-ups (not in scope)

- `ByoVoiceNote` and `VoiceProvidersNote` are near-twins in the same directory and want one component.
- `VoicePickerCard` and `VoicePickerSurface` hand-roll the same managed/BYO/loading branch.
- The voice room could open its own picker mid-call instead of the model answering in speech.