### PR TITLE
feat(billing): show checkout-bonus offer on abandoned-checkout return

### DIFF
--- a/clients/web/src/domains/settings/billing/billing-page.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.tsx
@@ -67,12 +67,9 @@ function BillingStatusHandler({
     }
 
     if (billingStatus === "success") {
-      toast.success(
-        "Payment received! Your credit balance will update shortly.",
-        {
-          id: "billing-status",
-        },
-      );
+      toast.success(t("billingStatusHandler.successToast"), {
+        id: "billing-status",
+      });
       queryClient.invalidateQueries({
         queryKey: organizationsBillingSummaryRetrieveOptions().queryKey,
       });
@@ -80,7 +77,7 @@ function BillingStatusHandler({
       toast.info(
         searchParams.get("billing_context") === "upgrade"
           ? t("billingStatusHandler.upgradeCancelToast")
-          : "Checkout was cancelled. No credits were added.",
+          : t("billingStatusHandler.topUpCancelToast"),
         { id: "billing-status" },
       );
       onCheckoutCancelled();

--- a/clients/web/src/domains/settings/billing/billing-page.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.tsx
@@ -10,6 +10,8 @@ import { PlatformLoginNotice } from "@/components/platform-login-notice";
 import { AndroidBillingGate } from "@/domains/settings/billing/android-billing-gate";
 import { BillingOnboardingModal } from "@/domains/settings/billing/pro-onboarding/billing-onboarding-modal";
 import { shouldShowBillingTab } from "@/domains/settings/billing/billing-tab-visibility";
+import { CheckoutBonusModal } from "@/domains/settings/billing/checkout-bonus-modal";
+import { useCheckoutBonusOffer } from "@/domains/settings/billing/use-checkout-bonus-offer";
 import { proPackageDisplayName } from "@/domains/settings/billing/package-types";
 import { UsageTab } from "@/domains/settings/billing/usage/usage-tab";
 import { AdjustPlanModal } from "@/domains/settings/components/adjust-plan-modal";
@@ -26,6 +28,7 @@ import {
   organizationsBillingSummaryRetrieveOptions,
 } from "@/generated/api/@tanstack/react-query.gen";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
+import { useTranslation } from "@/i18n";
 import {
   useActiveAssistantIsPlatformHosted,
   useActiveAssistantLifecycleIsLoading,
@@ -40,12 +43,22 @@ import { toast } from "@vellumai/design-library/components/toast";
 
 /**
  * Handles the `billing_status` query parameter that Stripe redirects back with
- * after checkout completes (success) or is cancelled.
+ * after checkout completes (success) or is cancelled. The upgrade-cancel page
+ * funnels into the cancel branch too, tagged `billing_context=upgrade` so the
+ * toast keeps its copy. A cancel is also lifted into parent state via
+ * `onCheckoutCancelled` before the navigate below wipes the query string, so
+ * the abandoned-checkout bonus offer can run its server-side eligibility
+ * check.
  */
-function BillingStatusHandler() {
+function BillingStatusHandler({
+  onCheckoutCancelled,
+}: {
+  onCheckoutCancelled: () => void;
+}) {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const { t } = useTranslation("settings");
 
   useEffect(() => {
     const billingStatus = searchParams.get("billing_status");
@@ -64,13 +77,17 @@ function BillingStatusHandler() {
         queryKey: organizationsBillingSummaryRetrieveOptions().queryKey,
       });
     } else if (billingStatus === "cancel") {
-      toast.info("Checkout was cancelled. No credits were added.", {
-        id: "billing-status",
-      });
+      toast.info(
+        searchParams.get("billing_context") === "upgrade"
+          ? t("billingStatusHandler.upgradeCancelToast")
+          : "Checkout was cancelled. No credits were added.",
+        { id: "billing-status" },
+      );
+      onCheckoutCancelled();
     }
 
     navigate(routes.settings.usageBilling, { replace: true });
-  }, [searchParams, navigate, queryClient]);
+  }, [searchParams, navigate, queryClient, onCheckoutCancelled, t]);
 
   return null;
 }
@@ -146,6 +163,22 @@ function BillingTabContent() {
   const [resizeModalOpen, setResizeModalOpen] = useState(false);
   const onTierUpgraded = useCallback(() => setResizeModalOpen(true), []);
   const [proOnboardingOpen, setProOnboardingOpen] = useState(false);
+
+  // Abandoned-checkout bonus: the cancel signal lives in state (not the URL)
+  // because BillingStatusHandler immediately navigate-replaces the query
+  // string away. The hook only queries once a cancel actually happened, and
+  // the server's answer alone decides whether the offer shows. Local
+  // dismissal keeps a declined offer closed while the eligibility answer is
+  // still cached.
+  const [checkoutCancelled, setCheckoutCancelled] = useState(false);
+  const onCheckoutCancelled = useCallback(() => setCheckoutCancelled(true), []);
+  const [bonusDismissed, setBonusDismissed] = useState(false);
+  const { showOffer, amountUsd } = useCheckoutBonusOffer(checkoutCancelled);
+  const onBonusOpenChange = useCallback((open: boolean) => {
+    if (!open) {
+      setBonusDismissed(true);
+    }
+  }, []);
 
   useEffect(() => {
     // Only consume the modal-opening params once billing is usable (signed
@@ -248,7 +281,7 @@ function BillingTabContent() {
   return (
     <div className="space-y-4">
       <Suspense fallback={null}>
-        <BillingStatusHandler />
+        <BillingStatusHandler onCheckoutCancelled={onCheckoutCancelled} />
         <BillingPortalReturnHandler />
       </Suspense>
       {showPlanManagement && <GracePeriodBanner />}
@@ -265,6 +298,11 @@ function BillingTabContent() {
           onTierUpgraded={onTierUpgraded}
         />
       )}
+      <CheckoutBonusModal
+        open={showOffer && !bonusDismissed}
+        onOpenChange={onBonusOpenChange}
+        amountUsd={amountUsd}
+      />
       <Suspense fallback={null}>
         <BillingPanel />
       </Suspense>

--- a/clients/web/src/domains/settings/billing/billing-tab-visibility.test.ts
+++ b/clients/web/src/domains/settings/billing/billing-tab-visibility.test.ts
@@ -13,6 +13,11 @@ describe("hasBillingIntent", () => {
     expect(hasBillingIntent(params("adjust_plan=1"))).toBe(true);
     expect(hasBillingIntent(params("pro_onboarding"))).toBe(true);
     expect(hasBillingIntent(params("billing_status=success"))).toBe(true);
+    // The upgrade-cancel redirect always pairs billing_context with
+    // billing_status, so the existing billing_status check covers it.
+    expect(
+      hasBillingIntent(params("billing_status=cancel&billing_context=upgrade")),
+    ).toBe(true);
     expect(hasBillingIntent(params("session_id=cs_test_123"))).toBe(true);
   });
 

--- a/clients/web/src/domains/settings/billing/upgrade-cancel-page.tsx
+++ b/clients/web/src/domains/settings/billing/upgrade-cancel-page.tsx
@@ -12,7 +12,6 @@ import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
 import { Card } from "@vellumai/design-library/components/card";
 import { Notice } from "@vellumai/design-library/components/notice";
-import { toast } from "@vellumai/design-library/components/toast";
 import { Typography } from "@vellumai/design-library/components/typography";
 
 /**
@@ -20,9 +19,12 @@ import { Typography } from "@vellumai/design-library/components/typography";
  *
  * When a user bails out of the Stripe-hosted upgrade flow, Stripe redirects
  * them here. Stripe does not create a subscription on cancellation, so there
- * is no backend state to clean up — we just surface a non-blocking toast and
- * bounce the user back to the billing settings page via `router.replace` so
- * the cancel route does not pollute browser history.
+ * is no backend state to clean up. This page bounces the user back to the
+ * billing settings page via `router.replace` (so the cancel route does not
+ * pollute browser history), carrying `billing_status=cancel` so the billing
+ * page's `BillingStatusHandler` owns the cancel UX in one place: the toast
+ * (`billing_context=upgrade` picks the upgrade copy) and the
+ * abandoned-checkout bonus offer.
  */
 export function UpgradeCancelPage() {
   // Defense in depth: this page is only reachable from a Stripe Checkout
@@ -34,9 +36,10 @@ export function UpgradeCancelPage() {
   // Strict hosting predicate for the side effect below. `platformGate ===
   // "full"` is the *Render*-tier predicate — it's intentionally permissive
   // during the lifecycle-loading window so the page chrome stays mounted.
-  // The toast + navigate side effect is a *Fetch/Interact*-tier action and
+  // The cancel-redirect side effect is a *Fetch/Interact*-tier action and
   // must wait for positive hosted resolution; otherwise a self-hosted
-  // deep-link user sees the stray toast before `<Navigate />` flips below.
+  // deep-link user gets the stray cancel redirect (and its toast on the
+  // billing page) before `<Navigate />` flips below.
   const isPlatformHosted = useActiveAssistantIsPlatformHosted();
   // Distinguish the genuine *resolving* window from terminal-non-hosted
   // states. The resolving window lets the existing "Returning you to
@@ -48,20 +51,24 @@ export function UpgradeCancelPage() {
   const navigate = useNavigate();
 
   useEffect(() => {
-    // Wait for positive hosted resolution before firing the toast +
-    // redirect. During the lifecycle-loading window `platformGate ===
-    // "full"` AND `isPlatformHosted === false` — running the effect here
-    // would defeat the gate on a self-hosted deep-link. Once lifecycle
-    // resolves, either `isPlatformHosted` flips true (run the effect) or
-    // `platformGate` flips to `"gated"` (body's `<Navigate />` takes
-    // over, this effect never runs).
+    // Wait for positive hosted resolution before firing the redirect.
+    // During the lifecycle-loading window `platformGate === "full"` AND
+    // `isPlatformHosted === false`; running the effect here would defeat
+    // the gate on a self-hosted deep-link. Once lifecycle resolves, either
+    // `isPlatformHosted` flips true (run the effect) or `platformGate`
+    // flips to `"gated"` (body's `<Navigate />` takes over, this effect
+    // never runs).
     if (!isPlatformHosted) {
       return;
     }
-    toast.info("Upgrade canceled. No changes to your plan.", {
-      id: "pro-upgrade-cancel",
-    });
-    navigate(routes.settings.usageBilling, { replace: true });
+    // `usageBilling` already carries `?tab=billing`, hence the `&`. The
+    // billing page's BillingStatusHandler consumes these params: it shows
+    // the upgrade-cancel toast and runs the server-side check for the
+    // abandoned-checkout bonus offer.
+    navigate(
+      `${routes.settings.usageBilling}&billing_status=cancel&billing_context=upgrade`,
+      { replace: true },
+    );
   }, [navigate, isPlatformHosted]);
 
   if (platformGate === "gated") {

--- a/clients/web/src/domains/settings/billing/use-checkout-bonus-offer.test.ts
+++ b/clients/web/src/domains/settings/billing/use-checkout-bonus-offer.test.ts
@@ -8,6 +8,9 @@
  *    so hand-typed cancel URLs stay quiet
  *  - triggered + server says eligible: the offer shows with the
  *    server-returned amount
+ *  - a second trigger behind the app's 10s default staleTime: the cached
+ *    ineligible answer from a previous probe is not reused; each trigger
+ *    re-asks the server
  *
  * The GET is mocked at the SDK boundary so the real generated query factory
  * stays in the loop, mirroring checkout-bonus-modal.test.tsx.
@@ -42,12 +45,14 @@ mock.module("@/hooks/use-is-org-ready", () => ({
 
 const { useCheckoutBonusOffer } = await import("./use-checkout-bonus-offer");
 
-function setup(triggered: boolean) {
-  const client = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
+function setup(triggered: boolean, client?: QueryClient) {
+  const queryClient =
+    client ??
+    new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
   const wrapper = ({ children }: { children: ReactNode }) =>
-    createElement(QueryClientProvider, { client }, children);
+    createElement(QueryClientProvider, { client: queryClient }, children);
   return renderHook((props) => useCheckoutBonusOffer(props.triggered), {
     initialProps: { triggered },
     wrapper,
@@ -107,5 +112,28 @@ describe("useCheckoutBonusOffer", () => {
     await waitFor(() => expect(result.current.showOffer).toBe(true));
     expect(result.current.amountUsd).toBe("7.50");
     expect(retrieveCalls).toBe(1);
+  });
+
+  test("repeat trigger: refetches past the app's 10s default staleTime", async () => {
+    // Mirror the app QueryClient (providers.tsx): a 10s default staleTime
+    // would otherwise let a cached ineligible probe answer a real cancel.
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: 10_000 } },
+    });
+
+    eligibilityResponse = { eligible: false, amount_usd: "0.00" };
+    const first = setup(true, client);
+    await waitFor(() => expect(retrieveCalls).toBe(1));
+    await flush();
+    expect(first.result.current.showOffer).toBe(false);
+    first.unmount();
+
+    // A real abandoned checkout lands within the staleness window.
+    eligibilityResponse = { eligible: true, amount_usd: "5.00" };
+    const second = setup(true, client);
+
+    await waitFor(() => expect(second.result.current.showOffer).toBe(true));
+    expect(second.result.current.amountUsd).toBe("5.00");
+    expect(retrieveCalls).toBe(2);
   });
 });

--- a/clients/web/src/domains/settings/billing/use-checkout-bonus-offer.test.ts
+++ b/clients/web/src/domains/settings/billing/use-checkout-bonus-offer.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for `useCheckoutBonusOffer` gating:
+ *  - no cancel signal: the eligibility endpoint is never queried and no offer
+ *    shows, whatever the server would say
+ *  - triggered before the org store settles: the query waits for org
+ *    readiness (a header-less request would be rejected), then fires once
+ *  - triggered + server says ineligible: exactly one request and no offer,
+ *    so hand-typed cancel URLs stay quiet
+ *  - triggered + server says eligible: the offer shows with the
+ *    server-returned amount
+ *
+ * The GET is mocked at the SDK boundary so the real generated query factory
+ * stays in the loop, mirroring checkout-bonus-modal.test.tsx.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+
+import * as sdkGen from "@/generated/api/sdk.gen";
+import type { CheckoutBonusEligibilityResponse } from "@/generated/api/types.gen";
+
+let retrieveCalls = 0;
+let eligibilityResponse: CheckoutBonusEligibilityResponse;
+let orgReady = true;
+
+mock.module("@/generated/api/sdk.gen", () => ({
+  ...sdkGen,
+  organizationsBillingCheckoutBonusRetrieve: () => {
+    retrieveCalls += 1;
+    return Promise.resolve({
+      data: eligibilityResponse,
+      response: { ok: true },
+    });
+  },
+}));
+
+mock.module("@/hooks/use-is-org-ready", () => ({
+  useIsOrgReady: () => orgReady,
+}));
+
+const { useCheckoutBonusOffer } = await import("./use-checkout-bonus-offer");
+
+function setup(triggered: boolean) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client }, children);
+  return renderHook((props) => useCheckoutBonusOffer(props.triggered), {
+    initialProps: { triggered },
+    wrapper,
+  });
+}
+
+// Lets any wrongly-enabled fetch land before asserting a call count of zero.
+const flush = () => new Promise((resolve) => setTimeout(resolve, 10));
+
+beforeEach(() => {
+  retrieveCalls = 0;
+  eligibilityResponse = { eligible: true, amount_usd: "5.00" };
+  orgReady = true;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useCheckoutBonusOffer", () => {
+  test("no cancel signal: never queries, never offers", async () => {
+    const { result } = setup(false);
+
+    await flush();
+    expect(retrieveCalls).toBe(0);
+    expect(result.current.showOffer).toBe(false);
+  });
+
+  test("triggered before the org settles: waits, then fires once", async () => {
+    orgReady = false;
+    const { result, rerender } = setup(true);
+
+    await flush();
+    expect(retrieveCalls).toBe(0);
+    expect(result.current.showOffer).toBe(false);
+
+    orgReady = true;
+    rerender({ triggered: true });
+
+    await waitFor(() => expect(result.current.showOffer).toBe(true));
+    expect(retrieveCalls).toBe(1);
+  });
+
+  test("triggered + ineligible: one request, no offer", async () => {
+    eligibilityResponse = { eligible: false, amount_usd: "0.00" };
+    const { result } = setup(true);
+
+    await waitFor(() => expect(retrieveCalls).toBe(1));
+    await flush();
+    expect(result.current.showOffer).toBe(false);
+  });
+
+  test("triggered + eligible: offers the server-returned amount", async () => {
+    eligibilityResponse = { eligible: true, amount_usd: "7.50" };
+    const { result } = setup(true);
+
+    await waitFor(() => expect(result.current.showOffer).toBe(true));
+    expect(result.current.amountUsd).toBe("7.50");
+    expect(retrieveCalls).toBe(1);
+  });
+});

--- a/clients/web/src/domains/settings/billing/use-checkout-bonus-offer.ts
+++ b/clients/web/src/domains/settings/billing/use-checkout-bonus-offer.ts
@@ -25,12 +25,21 @@ export interface CheckoutBonusOffer {
  * Gated on org readiness exactly like the other billing queries: a request
  * fired before the org store settles omits `Vellum-Organization-Id` and the
  * platform rejects it.
+ *
+ * `staleTime: 0` overrides the app QueryClient's 10s default so every cancel
+ * trigger asks the server again: without it, an `eligible: false` answer
+ * cached by a recent probe (an upgrade cancel, a hand-typed URL) would be
+ * reused when a real abandoned checkout lands moments later, and the offer
+ * would never show. Focus refetches are disabled so each trigger still costs
+ * exactly one request.
  */
 export function useCheckoutBonusOffer(triggered: boolean): CheckoutBonusOffer {
   const orgReady = useIsOrgReady();
   const { data } = useQuery({
     ...organizationsBillingCheckoutBonusRetrieveOptions(),
     enabled: triggered && orgReady,
+    staleTime: 0,
+    refetchOnWindowFocus: false,
   });
   return {
     showOffer: triggered && data?.eligible === true,

--- a/clients/web/src/domains/settings/billing/use-checkout-bonus-offer.ts
+++ b/clients/web/src/domains/settings/billing/use-checkout-bonus-offer.ts
@@ -1,0 +1,39 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { organizationsBillingCheckoutBonusRetrieveOptions } from "@/generated/api/@tanstack/react-query.gen";
+import { useIsOrgReady } from "@/hooks/use-is-org-ready";
+
+export interface CheckoutBonusOffer {
+  /** True once the server has verified the offer is claimable. */
+  showOffer: boolean;
+  /**
+   * Offer amount as a USD decimal string (e.g. "5.00") from the eligibility
+   * response. Meaningful only while `showOffer` is true.
+   */
+  amountUsd: string;
+}
+
+/**
+ * Server-verified eligibility for the abandoned-checkout credit bonus.
+ *
+ * `triggered` is the client-side cancel signal (`?billing_status=cancel`,
+ * which the Pro upgrade-cancel page also funnels into). The GET is the
+ * authority on eligibility (the client never decides it), so a hand-typed
+ * cancel URL with no real abandoned checkout behind it resolves to
+ * `eligible: false` and shows nothing.
+ *
+ * Gated on org readiness exactly like the other billing queries: a request
+ * fired before the org store settles omits `Vellum-Organization-Id` and the
+ * platform rejects it.
+ */
+export function useCheckoutBonusOffer(triggered: boolean): CheckoutBonusOffer {
+  const orgReady = useIsOrgReady();
+  const { data } = useQuery({
+    ...organizationsBillingCheckoutBonusRetrieveOptions(),
+    enabled: triggered && orgReady,
+  });
+  return {
+    showOffer: triggered && data?.eligible === true,
+    amountUsd: data?.amount_usd ?? "0.00",
+  };
+}

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -1,4 +1,7 @@
 {
+  "billingStatusHandler": {
+    "upgradeCancelToast": "Upgrade canceled. No changes to your plan."
+  },
   "checkoutBonusModal": {
     "title": "Here's {amount} on us",
     "body": "Claim a one-time {amount} credit and we'll add it straight to your account balance. No payment required.",

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -1,6 +1,8 @@
 {
   "billingStatusHandler": {
-    "upgradeCancelToast": "Upgrade canceled. No changes to your plan."
+    "successToast": "Payment received! Your credit balance will update shortly.",
+    "upgradeCancelToast": "Upgrade canceled. No changes to your plan.",
+    "topUpCancelToast": "Checkout was cancelled. No credits were added."
   },
   "checkoutBonusModal": {
     "title": "Here's {amount} on us",

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -1,6 +1,8 @@
 {
   "billingStatusHandler": {
-    "upgradeCancelToast": "Mejora cancelada. No hay cambios en tu plan."
+    "successToast": "¡Pago recibido! Tu saldo de créditos se actualizará en breve.",
+    "upgradeCancelToast": "Mejora cancelada. No hay cambios en tu plan.",
+    "topUpCancelToast": "Se canceló el pago. No se añadieron créditos."
   },
   "checkoutBonusModal": {
     "title": "Aquí tienes {amount} de nuestra parte",

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -1,4 +1,7 @@
 {
+  "billingStatusHandler": {
+    "upgradeCancelToast": "Mejora cancelada. No hay cambios en tu plan."
+  },
   "checkoutBonusModal": {
     "title": "Aquí tienes {amount} de nuestra parte",
     "body": "Reclama un crédito único de {amount} y lo añadiremos directamente al saldo de tu cuenta. No se requiere ningún pago.",


### PR DESCRIPTION
## Summary
- Adds useCheckoutBonusOffer hook (server-verified eligibility GET, org-ready gated)
- Wires both web cancel paths (billing_status=cancel and Pro upgrade-cancel redirect) into the single modal owner on the billing page
- Moves the upgrade-cancel toast into BillingStatusHandler via billing_context param

## Notes
- The cancel signal is lifted into React state via an onCheckoutCancelled prop before BillingStatusHandler's unconditional navigate-replace wipes the query string; the navigate itself is unchanged.
- The upgrade-cancel redirect appends with '&' because routes.settings.usageBilling already embeds '?tab=billing' (the plan's literal '?' would produce a malformed URL).
- Gating check requested by the plan: BillingStatusHandler mounts only inside the gated BillingTabContent body, after the billingGate 'disabled' and lifecycle-loading early returns, the same placement the '?adjust_plan' consumer relies on. No extra gating was needed; a signed-out viewer keeps billing_status in the URL through the login notice and the handler consumes it after sign-in.
- The moved toast copy is preserved verbatim ('Upgrade canceled. No changes to your plan.') and now lives in the settings i18n namespace (billingStatusHandler.upgradeCancelToast, en + es); the toast fires in all cancel cases and never waits on the eligibility request.
- billing-tab-visibility needed no change: the redirect always pairs billing_context with billing_status, which hasBillingIntent already treats as billing intent. Added a test case for the combined params.

## Manual verification remaining (not possible in this environment)
- Flag on + never-paid low-balance org with a real abandoned checkout: modal appears on both cancel paths (top-up billing_status=cancel return and Pro upgrade/cancel), claim adds the credit, balance updates, and the modal does not reappear.
- Same org visiting the billing page with a hand-typed ?billing_status=cancel but no actual abandoned checkout: server returns eligible: false, no modal, cancel toast only.
- Org with a paid top-up: toast only.
- Flag off: behavior indistinguishable from today aside from the eligibility GET returning eligible: false.

Part of plan: abandoned-checkout-bonus-ui.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40502" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->