### PR TITLE
feat(gateway): let a plugin channel receive messages by answering its webhook

### DIFF
--- a/assistant/src/channels/config.ts
+++ b/assistant/src/channels/config.ts
@@ -86,6 +86,19 @@ const CHANNEL_POLICIES = {
       conversationStrategy: "continue_existing_conversation",
     },
   },
+  plugin: {
+    notification: {
+      // Every plugin-brought channel shares this row, so the answer has to
+      // hold for all of them. A reply to an inbound plugin message routes by
+      // `replyCallbackUrl` and does not read this flag; proactive notification
+      // does, and it needs a guardian binding plus a destination resolver to
+      // reach. Neither exists per-plugin, and `NotificationChannel` is derived
+      // from this flag, so enabling it would let the decision engine pick a
+      // channel that resolves to nothing for whichever plugin it landed on.
+      deliveryEnabled: false,
+      conversationStrategy: "continue_existing_conversation",
+    },
+  },
 } as const satisfies Record<ChannelId, ChannelNotificationPolicy>;
 
 export type ChannelPolicies = typeof CHANNEL_POLICIES;

--- a/assistant/src/channels/types.ts
+++ b/assistant/src/channels/types.ts
@@ -181,6 +181,10 @@ export const INTERFACE_IDS = [
   // device/service callbacks). Non-interactive — permission prompts route
   // through the guardian system, not an interactive client — and non-host-proxy.
   "route",
+  // Turns a plugin-brought channel delivered through the gateway. One id for
+  // every plugin, matching the `plugin` channel; which plugin it was is in
+  // `sourceMetadata.plugin`.
+  "plugin",
 ] as const;
 
 export type InterfaceId = (typeof INTERFACE_IDS)[number];

--- a/assistant/src/notifications/signal.ts
+++ b/assistant/src/notifications/signal.ts
@@ -26,6 +26,7 @@ export const NOTIFICATION_SOURCE_CHANNELS = [
   { id: "platform", description: "Platform-managed channel" },
   { id: "a2a", description: "Agent-to-agent protocol channel" },
   { id: "discord", description: "Discord channel" },
+  { id: "plugin", description: "Channel brought by an installed plugin" },
   { id: "scheduler", description: "Scheduled task runner (reminders, cron)" },
   { id: "watcher", description: "File/event watcher subsystem" },
 ] as const;

--- a/clients/web/src/domains/channels/components/plugin-channel-panel.tsx
+++ b/clients/web/src/domains/channels/components/plugin-channel-panel.tsx
@@ -151,12 +151,18 @@ function IngressSection({ channel, ingress }: IngressSectionProps) {
  * apart, because folding them into the refusal would tell a guardian that
  * public ingress is closed while it is open, and because revoking will not
  * close them either.
+ *
+ * Whether any of them starts conversations is said outright. Opening an
+ * address a plugin receives callbacks on and letting that address put messages
+ * in front of the assistant are different decisions, and this is the only
+ * place the second one is ever made.
  */
 function IngressDecision({ channel, ingress }: IngressSectionProps) {
   const { t } = useTranslation("channels");
   const approved = ingress.status === "approved";
   const governed = ingress.paths.filter((entry) => entry.approvalGoverned);
   const ungoverned = ingress.paths.filter((entry) => !entry.approvalGoverned);
+  const delivers = governed.some((entry) => entry.deliversInbound);
 
   return (
     <div className="flex flex-col items-center gap-3">
@@ -178,6 +184,13 @@ function IngressDecision({ channel, ingress }: IngressSectionProps) {
                 })}
           </Note>
           <PathList paths={governed} />
+          {delivers ? (
+            <Note>
+              {t("pluginChannelPanel.deliversInbound", {
+                channel: channel.label,
+              })}
+            </Note>
+          ) : null}
         </>
       ) : null}
 

--- a/clients/web/src/domains/channels/hooks/use-channel-ingress.ts
+++ b/clients/web/src/domains/channels/hooks/use-channel-ingress.ts
@@ -56,6 +56,13 @@ export interface IngressPath {
    * a guardian that public ingress is closed when it is open.
    */
   approvalGoverned: boolean;
+  /**
+   * True when what arrives here becomes a message to the assistant, rather
+   * than a callback the plugin merely receives. Opening an address and letting
+   * something start a conversation are different decisions, and only the
+   * gateway knows which one a route is asking for.
+   */
+  deliversInbound: boolean;
 }
 
 export interface ChannelIngress {
@@ -176,6 +183,7 @@ export function useChannelIngress(
       entry?.routes?.map((route) => ({
         path: route.publicPath,
         approvalGoverned: route.signer !== "vellum",
+        deliversInbound: route.deliversInbound === true,
       })) ?? [],
     deciding: approval.isPending || revocation.isPending,
     approve: () => {

--- a/clients/web/src/i18n/locales/en/channels.json
+++ b/clients/web/src/i18n/locales/en/channels.json
@@ -37,6 +37,7 @@
     "approvedAddresses": "{channel} receives messages at these addresses:",
     "pendingAddresses": "{channel} asks to receive messages at these addresses. Until you approve, deliveries to them are refused:",
     "ungovernedAddresses": "These addresses are open whatever you decide, because only Vellum can reach them:",
+    "deliversInbound": "What arrives here becomes a message to your assistant, not just a callback {channel} receives. Who gets through is still decided by who you allow to message it.",
     "revokeIngress": "Revoke ingress",
     "approveIngress": "Approve ingress"
   },

--- a/clients/web/src/i18n/locales/es/channels.json
+++ b/clients/web/src/i18n/locales/es/channels.json
@@ -37,6 +37,7 @@
     "approvedAddresses": "{channel} recibe mensajes en estas direcciones:",
     "pendingAddresses": "{channel} pide recibir mensajes en estas direcciones. Hasta que lo apruebes, se rechazan las entregas:",
     "ungovernedAddresses": "Estas direcciones están abiertas decidas lo que decidas, porque solo Vellum puede alcanzarlas:",
+    "deliversInbound": "Lo que llegue aquí se convierte en un mensaje para tu asistente, no solo en una llamada de vuelta que {channel} recibe. Quién consigue pasar lo sigue decidiendo a quién permites escribirle.",
     "revokeIngress": "Revocar la entrada",
     "approveIngress": "Aprobar la entrada"
   },

--- a/gateway/openapi.json
+++ b/gateway/openapi.json
@@ -388,6 +388,7 @@
                                 "description": { "type": "string" },
                                 "credential": { "type": "string" },
                                 "served": { "type": "boolean" },
+                                "deliversInbound": { "type": "boolean" },
                                 "verification": {
                                   "type": "object",
                                   "properties": {
@@ -406,7 +407,8 @@
                                 "handshake",
                                 "description",
                                 "credential",
-                                "served"
+                                "served",
+                                "deliversInbound"
                               ],
                               "additionalProperties": false
                             }

--- a/gateway/src/channels/inbound-event.ts
+++ b/gateway/src/channels/inbound-event.ts
@@ -10,7 +10,7 @@ import type { ChannelId } from "./types.js";
 
 export type InboundChannelId = Extract<
   ChannelId,
-  "telegram" | "whatsapp" | "slack" | "email" | "a2a" | "discord"
+  "telegram" | "whatsapp" | "slack" | "email" | "a2a" | "discord" | "plugin"
 >;
 
 interface InboundEventBase<C extends InboundChannelId> {
@@ -93,6 +93,14 @@ export type A2aInboundEvent = InboundEventBase<"a2a">;
  * `conversationExternalId` a private address.
  */
 export type DiscordInboundEvent = InboundEventBase<"discord">;
+/**
+ * Constructed by `plugin-inbound.ts` from a plugin's reply to a verified
+ * webhook delivery. One channel covers every plugin, so `conversationExternalId`
+ * and `actorExternalId` are both prefixed with the plugin's directory name and
+ * `source.chatType` carries whatever the plugin reported. Which plugin it was
+ * reaches the runtime on `sourceMetadata`, not here.
+ */
+export type PluginInboundEvent = InboundEventBase<"plugin">;
 
 export type GatewayInboundEvent =
   | TelegramInboundEvent
@@ -100,4 +108,5 @@ export type GatewayInboundEvent =
   | SlackInboundEvent
   | EmailInboundEvent
   | A2aInboundEvent
-  | DiscordInboundEvent;
+  | DiscordInboundEvent
+  | PluginInboundEvent;

--- a/gateway/src/channels/ingress-inbound.test.ts
+++ b/gateway/src/channels/ingress-inbound.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  INBOUND_FIELD_DEFAULTS,
+  IngressInboundSchema,
+  canonicalInbound,
+  inboundFieldPath,
+  readInboundField,
+} from "./ingress-inbound.js";
+
+/** Parse a declaration the way the manifest reader would. */
+function declare(raw: unknown) {
+  return IngressInboundSchema.parse(raw);
+}
+
+describe("IngressInboundSchema", () => {
+  it("takes an empty declaration for a plugin already replying in shape", () => {
+    // The whole point of the defaults: a plugin returning what the SDK's
+    // contract says it returns should not have to restate the contract.
+    const inbound = declare({});
+
+    expect(inbound.identity).toBe("opaque");
+    expect(inboundFieldPath(inbound, "content")).toBe("message.content");
+    expect(inboundFieldPath(inbound, "actorExternalId")).toBe(
+      "actor.actorExternalId",
+    );
+  });
+
+  it("keeps the defaults for fields an override did not name", () => {
+    const inbound = declare({ fields: { content: "text" } });
+
+    expect(inboundFieldPath(inbound, "content")).toBe("text");
+    expect(inboundFieldPath(inbound, "conversationExternalId")).toBe(
+      INBOUND_FIELD_DEFAULTS.conversationExternalId,
+    );
+  });
+
+  it("rejects a field name it does not know", () => {
+    // Silently ignoring one would present a typo as a plugin that stopped
+    // sending the field.
+    expect(() => declare({ fields: { contnet: "text" } })).toThrow();
+  });
+
+  it("rejects a path that is not dotted identifiers", () => {
+    // The manifest is untrusted input read against an attacker-authored
+    // document, so anything resembling an expression language is refused.
+    for (const path of [
+      "message[0].content",
+      "message.*.content",
+      "$.message.content",
+      "message..content",
+      ".content",
+      "content.",
+      "message/content",
+    ]) {
+      expect(() => declare({ fields: { content: path } })).toThrow();
+    }
+  });
+
+  it("refuses a path through __proto__", () => {
+    expect(() =>
+      declare({ fields: { content: "__proto__.content" } }),
+    ).toThrow();
+  });
+
+  it("rejects an identity kind it cannot canonicalize", () => {
+    expect(() => declare({ identity: "snowflake" })).toThrow();
+  });
+});
+
+describe("canonicalInbound", () => {
+  it("encodes a spelled-out default the same as an omitted one", () => {
+    // Two manifests that read the same fields the same way are the same
+    // grant. Without this, spelling out a default would revoke an approval.
+    const implicit = declare({});
+    const explicit = declare({
+      identity: "opaque",
+      fields: { ...INBOUND_FIELD_DEFAULTS },
+    });
+
+    expect(canonicalInbound(explicit)).toBe(canonicalInbound(implicit));
+  });
+
+  it("changes when a field is read from somewhere else", () => {
+    // Reading the sender from a different key is a different message, which
+    // is a change to what the guardian approved.
+    expect(
+      canonicalInbound(declare({ fields: { actorExternalId: "from" } })),
+    ).not.toBe(canonicalInbound(declare({})));
+  });
+
+  it("changes when the identity kind changes", () => {
+    // `phone` decides that two spellings of a number are one person, so it
+    // decides which stored contact a sender matches.
+    expect(canonicalInbound(declare({ identity: "phone" }))).not.toBe(
+      canonicalInbound(declare({})),
+    );
+  });
+});
+
+describe("readInboundField", () => {
+  const body = {
+    message: { content: "hi", conversationExternalId: "chat-1", count: 3 },
+    actor: { actorExternalId: "+12025550142", displayName: null },
+    empty: {},
+  };
+
+  it("reads a nested string", () => {
+    expect(readInboundField(body, "message.content")).toBe("hi");
+  });
+
+  it("returns undefined for anything that is not a string", () => {
+    // "absent" and "present but the wrong type" have to be one answer, so a
+    // malformed reply cannot half-build an event.
+    expect(readInboundField(body, "message.count")).toBeUndefined();
+    expect(readInboundField(body, "actor.displayName")).toBeUndefined();
+    expect(readInboundField(body, "message")).toBeUndefined();
+  });
+
+  it("returns undefined for a path that does not exist", () => {
+    expect(readInboundField(body, "message.missing")).toBeUndefined();
+    expect(readInboundField(body, "missing.content")).toBeUndefined();
+    expect(readInboundField(body, "empty.a.b")).toBeUndefined();
+  });
+
+  it("reads nothing off a non-object body", () => {
+    expect(readInboundField(null, "message.content")).toBeUndefined();
+    expect(readInboundField("hi", "message.content")).toBeUndefined();
+    expect(readInboundField(undefined, "message.content")).toBeUndefined();
+  });
+
+  it("does not walk into inherited properties", () => {
+    // A reply is a parsed JSON document, but the reader is what stands between
+    // a declared path and the prototype chain, so it checks ownership itself.
+    expect(readInboundField({}, "constructor.name")).toBeUndefined();
+    expect(readInboundField({}, "toString")).toBeUndefined();
+  });
+});

--- a/gateway/src/channels/ingress-inbound.ts
+++ b/gateway/src/channels/ingress-inbound.ts
@@ -1,0 +1,163 @@
+/**
+ * How a plugin's reply to a webhook delivery becomes an inbound message.
+ *
+ * The gateway already forwards every verified delivery to the plugin route
+ * that declared it and reads the reply. A route declaring `inbound` says that
+ * reply is not just an acknowledgement: it carries the message, normalized by
+ * the plugin, for the gateway to run through admission, trust resolution, the
+ * verification and invite intercepts, and on to the runtime. Nothing new is
+ * opened to do it — no plugin-to-gateway callback, no second authentication —
+ * because the delivery the gateway already authenticated is the only thing
+ * that can produce one.
+ *
+ * The plugin does the parsing, which is the whole reason it exists: only it
+ * knows what its vendor sends. What it cannot decide for itself is anything
+ * that would be a claim about the assistant rather than about the message, and
+ * that is what this declaration covers:
+ *
+ * - **Which channel it speaks as** is not declarable at all. The gateway
+ *   stamps `plugin` and prefixes the plugin's own directory name onto every
+ *   external id, so no reply can attribute a message to Slack, to another
+ *   plugin, or to a contact record it does not own.
+ * - **What kind of address the sender's id is** is declared here, because the
+ *   answer decides whether `+1 (202) 555-0142` and `+12025550142` are the same
+ *   person and the gateway cannot tell by looking.
+ * - **Where each field lives in the reply** is declared here when the reply is
+ *   not already in the canonical shape, so a plugin that would rather hand
+ *   back its own structure can, without the gateway learning a vendor format.
+ *
+ * The whole declaration is part of `ingressDeclarationDigest`, so a route
+ * cannot start delivering messages — or start reading them differently — under
+ * an approval a guardian granted for something else.
+ */
+
+import { z } from "zod";
+
+/**
+ * A field's location in the plugin's reply, as dotted object keys.
+ *
+ * Deliberately not JSONPath or JSON Pointer. This reads one scalar out of one
+ * object, the manifest is untrusted input, and every expression syntax that
+ * does more than that has to be evaluated against an attacker-authored
+ * document. Segments are identifier-shaped, so a path can never index an
+ * array, never reach a prototype (`__proto__` is a legal identifier but the
+ * reader refuses it explicitly), and never carry a wildcard.
+ */
+const InboundFieldPathSchema = z
+  .string()
+  .regex(
+    /^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$/,
+    'field path must be dotted identifiers, e.g. "message.content"',
+  )
+  .refine((p) => !p.split(".").includes("__proto__"), {
+    message: "field path must not traverse __proto__",
+  });
+
+/**
+ * Per-field overrides of {@link INBOUND_FIELD_DEFAULTS}.
+ *
+ * Only the fields whose location differs need naming; anything absent keeps
+ * its default path. Strict, so a misspelled field name is rejected with the
+ * rest of the manifest rather than silently read as "no override" — which
+ * would present a typo as a plugin that stopped sending display names.
+ */
+const InboundFieldsSchema = z
+  .object({
+    content: InboundFieldPathSchema.optional(),
+    conversationExternalId: InboundFieldPathSchema.optional(),
+    externalMessageId: InboundFieldPathSchema.optional(),
+    actorExternalId: InboundFieldPathSchema.optional(),
+    actorDisplayName: InboundFieldPathSchema.optional(),
+    actorUsername: InboundFieldPathSchema.optional(),
+    chatType: InboundFieldPathSchema.optional(),
+  })
+  .strict();
+
+export type InboundFieldName = keyof z.infer<typeof InboundFieldsSchema>;
+
+/**
+ * Where each normalized field is read from when the manifest does not say
+ * otherwise.
+ *
+ * The defaults are the shape of `PluginInboundEvent` — the contract the plugin
+ * SDK already exports — so a plugin that returns what it was built to return
+ * declares `"inbound": {}` and nothing more. The `satisfies` clause ties this
+ * to the schema above, so a field can never be declarable without a default or
+ * carry one nothing reads.
+ */
+export const INBOUND_FIELD_DEFAULTS = {
+  content: "message.content",
+  conversationExternalId: "message.conversationExternalId",
+  externalMessageId: "message.externalMessageId",
+  actorExternalId: "actor.actorExternalId",
+  actorDisplayName: "actor.displayName",
+  actorUsername: "actor.username",
+  chatType: "source.chatType",
+} as const satisfies Record<InboundFieldName, string>;
+
+const INBOUND_FIELD_NAMES = Object.keys(
+  INBOUND_FIELD_DEFAULTS,
+) as InboundFieldName[];
+
+/**
+ * What the sender's id is, so it can be compared with the ones already stored.
+ *
+ * `opaque` (the default) is right for a platform-stable id and is the only
+ * safe guess, because rewriting an id that was already canonical is how a
+ * returning sender stops matching their own contact record.
+ */
+export const InboundIdentitySchema = z.enum(["opaque", "phone", "email"]);
+export type InboundIdentity = z.infer<typeof InboundIdentitySchema>;
+
+export const IngressInboundSchema = z.object({
+  identity: InboundIdentitySchema.default("opaque"),
+  fields: InboundFieldsSchema.default({}),
+});
+export type IngressInbound = z.infer<typeof IngressInboundSchema>;
+
+/** The path a field is read from, after the manifest's overrides. */
+export function inboundFieldPath(
+  inbound: IngressInbound,
+  field: InboundFieldName,
+): string {
+  return inbound.fields[field] ?? INBOUND_FIELD_DEFAULTS[field];
+}
+
+/**
+ * Stable encoding of an inbound declaration, for the approval digest.
+ *
+ * Resolved rather than as-written: two manifests that read the same fields the
+ * same way are the same grant, whether one spelled a default out or not. That
+ * also means introducing a field with a default does not re-digest every
+ * manifest that predates it, provided the default matches what those manifests
+ * were already getting.
+ */
+export function canonicalInbound(inbound: IngressInbound): string {
+  const fields = INBOUND_FIELD_NAMES.map(
+    (name) => `${name}=${inboundFieldPath(inbound, name)}`,
+  ).sort();
+  return [inbound.identity, ...fields].join(" ");
+}
+
+/**
+ * Read one field out of a plugin's reply.
+ *
+ * Returns undefined for anything that is not a string sitting at exactly that
+ * path — a missing key, a null, an object, a number. A caller deciding whether
+ * a reply carries a message at all depends on that: "absent" and "present but
+ * the wrong type" are the same answer, so a malformed reply cannot half-build
+ * an event.
+ */
+export function readInboundField(
+  body: unknown,
+  path: string,
+): string | undefined {
+  let cursor: unknown = body;
+  for (const segment of path.split(".")) {
+    if (cursor === null || typeof cursor !== "object") return undefined;
+    if (!Object.prototype.hasOwnProperty.call(cursor, segment))
+      return undefined;
+    cursor = (cursor as Record<string, unknown>)[segment];
+  }
+  return typeof cursor === "string" ? cursor : undefined;
+}

--- a/gateway/src/channels/plugin-inbound.test.ts
+++ b/gateway/src/channels/plugin-inbound.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "bun:test";
+
+import { IngressInboundSchema } from "./ingress-inbound.js";
+import { readPluginInbound } from "./plugin-inbound.js";
+
+const RECEIVED_AT = "2026-02-01T00:00:00.000Z";
+
+function declare(raw: unknown = {}) {
+  return IngressInboundSchema.parse(raw);
+}
+
+/** A reply in the shape the plugin SDK's contract produces. */
+function reply(overrides: Record<string, unknown> = {}) {
+  return {
+    version: "v1",
+    sourceChannel: "imessage",
+    message: {
+      content: "hello",
+      conversationExternalId: "chat-1",
+      externalMessageId: "msg-1",
+    },
+    actor: { actorExternalId: "+12025550142", displayName: "Ada" },
+    source: { updateId: "msg-1", chatType: "dm" },
+    ...overrides,
+  };
+}
+
+function read(body: unknown, inbound = declare()) {
+  return readPluginInbound({
+    plugin: "imessage",
+    inbound,
+    body,
+    receivedAt: RECEIVED_AT,
+  });
+}
+
+describe("readPluginInbound", () => {
+  it("reads a canonical reply into an event", () => {
+    const result = read(reply());
+
+    expect(result.status).toBe("event");
+    if (result.status !== "event") return;
+    expect(result.event.message.content).toBe("hello");
+    expect(result.event.receivedAt).toBe(RECEIVED_AT);
+    expect(result.event.source.chatType).toBe("dm");
+    expect(result.event.actor.displayName).toBe("Ada");
+  });
+
+  it("stamps the channel rather than reading the one the reply claims", () => {
+    // A plugin that could name its own channel could claim `slack` and inherit
+    // Slack's admission floor, its contact records, and trust the guardian
+    // granted a different surface entirely.
+    const result = read(reply({ sourceChannel: "slack" }));
+
+    expect(result.status).toBe("event");
+    if (result.status !== "event") return;
+    expect(result.event.sourceChannel).toBe("plugin");
+  });
+
+  it("scopes every external id to the plugin that produced it", () => {
+    // One channel id covers every installed plugin. Without the prefix, two
+    // plugins whose vendors both address by phone number would share
+    // conversations and contact records, and either could address the other's.
+    const result = read(reply());
+
+    expect(result.status).toBe("event");
+    if (result.status !== "event") return;
+    expect(result.event.message.conversationExternalId).toBe("imessage:chat-1");
+    expect(result.event.actor.actorExternalId).toBe("imessage:+12025550142");
+    expect(result.event.message.externalMessageId).toBe("imessage:msg-1");
+  });
+
+  it("takes the plugin name from the caller, not the reply", () => {
+    // The caller has it from the request path, which is the only place it can
+    // come from without letting a manifest spell another plugin's namespace.
+    const result = readPluginInbound({
+      plugin: "signal",
+      inbound: declare(),
+      body: reply({ plugin: "imessage" }),
+      receivedAt: RECEIVED_AT,
+    });
+
+    expect(result.status).toBe("event");
+    if (result.status !== "event") return;
+    expect(result.event.actor.actorExternalId).toBe("signal:+12025550142");
+  });
+
+  it("canonicalizes a declared phone identity before scoping it", () => {
+    // Two spellings of a number are one person only if the declaration says
+    // the addresses are phone numbers, and the prefix has to land on the form
+    // everything downstream compares on.
+    const result = read(
+      reply({
+        actor: { actorExternalId: "(202) 555-0142" },
+      }),
+      declare({ identity: "phone" }),
+    );
+
+    expect(result.status).toBe("event");
+    if (result.status !== "event") return;
+    expect(result.event.actor.actorExternalId).toBe("imessage:+12025550142");
+  });
+
+  it("leaves an opaque identity alone", () => {
+    // Rewriting an id that was already canonical is how a returning sender
+    // stops matching their own contact record.
+    const result = read(reply({ actor: { actorExternalId: "U012ABC" } }));
+
+    expect(result.status).toBe("event");
+    if (result.status !== "event") return;
+    expect(result.event.actor.actorExternalId).toBe("imessage:U012ABC");
+  });
+
+  it("reads a reply through the manifest's field mapping", () => {
+    // A plugin that would rather hand back its own structure can, without the
+    // gateway learning a vendor format.
+    const result = read(
+      {
+        chat: { guid: "iMessage;-;+12025550188" },
+        text: "hi there",
+        id: "p_9",
+        sender: { handle: "+12025550188", name: "Grace" },
+      },
+      declare({
+        identity: "phone",
+        fields: {
+          content: "text",
+          conversationExternalId: "chat.guid",
+          externalMessageId: "id",
+          actorExternalId: "sender.handle",
+          actorDisplayName: "sender.name",
+        },
+      }),
+    );
+
+    expect(result.status).toBe("event");
+    if (result.status !== "event") return;
+    expect(result.event.message.content).toBe("hi there");
+    expect(result.event.message.conversationExternalId).toBe(
+      "imessage:iMessage;-;+12025550188",
+    );
+    expect(result.event.actor.displayName).toBe("Grace");
+  });
+
+  it("treats an acknowledgement as no message at all", () => {
+    // The ordinary case. Delivery receipts, outbound echoes, and events the
+    // plugin does not handle all reply like this.
+    expect(read({ ok: true }).status).toBe("none");
+    expect(read({ ok: true, ignored: "not an inbound message" }).status).toBe(
+      "none",
+    );
+    expect(read(undefined).status).toBe("none");
+    expect(read("").status).toBe("none");
+  });
+
+  it("reports a reply that carries some of a message but not enough", () => {
+    // Dropping this quietly would present a plugin bug as a vendor that
+    // stopped delivering.
+    const result = read({
+      message: { content: "hello", conversationExternalId: "chat-1" },
+    });
+
+    expect(result.status).toBe("invalid");
+    if (result.status !== "invalid") return;
+    expect(result.reason).toContain("actorExternalId");
+    expect(result.reason).toContain("externalMessageId");
+  });
+
+  it("accepts a message with no text", () => {
+    // An attachment-only message is a real message. Content is the one
+    // required-looking field that is not required.
+    const result = read(
+      reply({
+        message: {
+          content: "",
+          conversationExternalId: "chat-1",
+          externalMessageId: "msg-1",
+        },
+      }),
+    );
+
+    expect(result.status).toBe("event");
+    if (result.status !== "event") return;
+    expect(result.event.message.content).toBe("");
+  });
+
+  it("treats a whitespace-only identity as absent", () => {
+    // It canonicalizes to nothing, so admitting it would build an event whose
+    // sender is the plugin prefix and nobody else.
+    const result = read(reply({ actor: { actorExternalId: "   " } }));
+
+    expect(result.status).toBe("invalid");
+  });
+
+  it("carries none of the plugin's reply forward as raw", () => {
+    // `raw` exists so a normalizer can hand the vendor payload to a later
+    // stage. Nothing does that here, and the reply is unvalidated input that
+    // would otherwise ride into the runtime unexamined.
+    const result = read(reply({ secrets: { token: "shh" } }));
+
+    expect(result.status).toBe("event");
+    if (result.status !== "event") return;
+    expect(result.event.raw).toEqual({});
+  });
+});

--- a/gateway/src/channels/plugin-inbound.ts
+++ b/gateway/src/channels/plugin-inbound.ts
@@ -1,0 +1,165 @@
+/**
+ * A plugin's reply to a verified webhook delivery, read as an inbound message.
+ *
+ * This is the normalize step for plugin channels, and it sits where every
+ * other channel's does — `telegram/normalize.ts`, `discord/normalize.ts`,
+ * `email/normalize.ts` — feeding the same `handleInbound`. The difference is
+ * where the parsing happened: a built-in channel's normalizer knows the
+ * vendor's payload, and a plugin's does not exist here, so the plugin parses
+ * its own delivery and hands back the result. What this file does is decide
+ * what of that result the gateway is willing to believe.
+ *
+ * ## What the plugin says, and what it does not get to
+ *
+ * The plugin supplies the message: who sent it, where, what it said. It does
+ * not supply anything that would place that message inside the assistant.
+ *
+ * `sourceChannel` is stamped `plugin` here and is not readable from the reply.
+ * A plugin that could name its own channel could claim `slack`, and inherit
+ * Slack's admission floor, Slack's contact records, and the trust the guardian
+ * granted a different surface entirely.
+ *
+ * The external ids are prefixed with the plugin's directory name, which the
+ * gateway takes from the request path and never from the reply — the same rule
+ * `signingCredentialKey` follows for secrets, for the same reason. One channel
+ * id covers every installed plugin, so without the prefix two plugins whose
+ * vendors both address by phone number would share conversations and contact
+ * records, and either could address the other's. With it, `imessage:+1202…`
+ * and `signal:+1202…` are different people to every store downstream, and
+ * neither plugin can spell the other's namespace.
+ *
+ * The cost is real and worth stating: those same prefixes mean a plugin
+ * channel's contacts are disjoint from the built-in channels' too, so a
+ * guardian already verified on `phone` is a stranger on `imessage` until they
+ * verify again. That is the correct default — a plugin asserting an address is
+ * not the same evidence as an SMS arriving at a number Twilio owns — but it is
+ * a default, not a law, and cross-channel identity linking is where it would
+ * be revisited.
+ *
+ * ## What a reply that is not a message looks like
+ *
+ * Most deliveries are not turns. Delivery receipts, outbound echoes, and
+ * events the plugin does not handle all get acknowledged and dropped, and the
+ * plugin says so by replying without the fields. `none` is therefore the
+ * ordinary case and is silent; `invalid` means the reply carried some of a
+ * message but not enough of one, which is a plugin bug and says so in the log.
+ */
+
+import {
+  inboundFieldPath,
+  readInboundField,
+  type IngressInbound,
+} from "./ingress-inbound.js";
+import type { PluginInboundEvent } from "./inbound-event.js";
+import { canonicalizeIdentityAs } from "../verification/identity.js";
+
+/**
+ * Namespace an external id to the plugin that produced it.
+ *
+ * The separator is `:` and the plugin name is a safe URL path segment
+ * (`SAFE_PLUGIN_NAME` in `plugin-ingress.ts`), which excludes `:`, so the
+ * prefix is unambiguous: a scoped id splits back into exactly one plugin name.
+ */
+export function pluginScopedId(plugin: string, value: string): string {
+  return `${plugin}:${value}`;
+}
+
+export type PluginInboundReading =
+  | { status: "event"; event: PluginInboundEvent }
+  | { status: "none" }
+  | { status: "invalid"; reason: string };
+
+export interface ReadPluginInboundOptions {
+  /** Plugin directory name, from the request path. Never from the reply. */
+  plugin: string;
+  /** The route's declaration, which decides how the reply is read. */
+  inbound: IngressInbound;
+  /** The plugin's parsed reply body. */
+  body: unknown;
+  /** Gateway wall clock at receipt, never a plugin-supplied timestamp. */
+  receivedAt: string;
+}
+
+/**
+ * Read a plugin's reply into an inbound event, or say why there isn't one.
+ *
+ * A reply is a message when it carries a conversation, a sender, and a message
+ * id: the three the pipeline cannot proceed without. Conversation and sender
+ * are what the message is routed and admitted on, and the message id is the
+ * dedup key that keeps a vendor's retry from starting a second turn. Content
+ * is not among them — an attachment-only message is a real message with no
+ * text — so an empty string is accepted and a missing field reads as one.
+ *
+ * All three absent is a plain acknowledgement. Some present and some missing
+ * is a reply that meant to be a message and is not one, which is reported
+ * rather than quietly dropped: dropping it would present a plugin bug as a
+ * vendor that stopped delivering.
+ */
+export function readPluginInbound(
+  opts: ReadPluginInboundOptions,
+): PluginInboundReading {
+  const { plugin, inbound, body, receivedAt } = opts;
+  const read = (field: Parameters<typeof inboundFieldPath>[1]) =>
+    readInboundField(body, inboundFieldPath(inbound, field));
+
+  const conversation = read("conversationExternalId")?.trim();
+  const actor = read("actorExternalId")?.trim();
+  const messageId = read("externalMessageId")?.trim();
+
+  const present = [conversation, actor, messageId].filter(Boolean).length;
+  if (present === 0) {
+    return { status: "none" };
+  }
+  if (present < 3) {
+    const missing = [
+      conversation ? null : "conversationExternalId",
+      actor ? null : "actorExternalId",
+      messageId ? null : "externalMessageId",
+    ].filter((name): name is string => name !== null);
+    return {
+      status: "invalid",
+      reason: `reply is missing ${missing.join(", ")}`,
+    };
+  }
+
+  // Canonicalized before the prefix, so the prefix is applied to the form
+  // everything downstream compares on rather than to whatever spelling the
+  // vendor happened to send. `actor` is non-empty here, so this cannot be null.
+  const canonicalActor = canonicalizeIdentityAs(inbound.identity, actor!)!;
+
+  const displayName = read("actorDisplayName")?.trim();
+  const username = read("actorUsername")?.trim();
+  const chatType = read("chatType")?.trim();
+
+  return {
+    status: "event",
+    event: {
+      version: "v1",
+      sourceChannel: "plugin",
+      receivedAt,
+      message: {
+        content: read("content") ?? "",
+        conversationExternalId: pluginScopedId(plugin, conversation!),
+        externalMessageId: pluginScopedId(plugin, messageId!),
+      },
+      actor: {
+        actorExternalId: pluginScopedId(plugin, canonicalActor),
+        ...(displayName ? { displayName } : {}),
+        ...(username ? { username } : {}),
+      },
+      source: {
+        // The dedup key doubles as the update id: a plugin channel has no
+        // separate provider-assigned envelope id, and the message id is
+        // already unique per delivery.
+        updateId: pluginScopedId(plugin, messageId!),
+        messageId: pluginScopedId(plugin, messageId!),
+        ...(chatType ? { chatType } : {}),
+      },
+      // Deliberately empty. `raw` exists so a channel's normalizer can carry
+      // the vendor payload forward for a later stage to re-read; nothing does
+      // that for plugin channels, and the plugin's reply is unvalidated input
+      // that would otherwise ride along into the runtime unexamined.
+      raw: {},
+    },
+  };
+}

--- a/gateway/src/channels/plugin-ingress-approvals.test.ts
+++ b/gateway/src/channels/plugin-ingress-approvals.test.ts
@@ -15,6 +15,7 @@ import {
   revokePluginIngressApproval,
 } from "../db/plugin-ingress-approval-store.js";
 import { pluginIngressApprovals } from "../db/schema.js";
+import { IngressInboundSchema } from "./ingress-inbound.js";
 import { PLUGIN_INGRESS_MANIFEST_RELPATH } from "./plugin-ingress.js";
 import {
   findServableRoute,
@@ -303,6 +304,69 @@ describe("ingressDeclarationDigest", () => {
         },
       ]),
     ).not.toBe(base);
+  });
+
+  it("changes when a route starts delivering messages", () => {
+    // Receiving a callback and being able to start a conversation are not the
+    // same grant, so the second must not begin under an approval for the first.
+    expect(
+      ingressDeclarationDigest([
+        {
+          kind: "http",
+          signer: "plugin",
+          handshake: "signed-headers",
+          path: "a",
+          inbound: IngressInboundSchema.parse({}),
+        },
+      ]),
+    ).not.toBe(
+      ingressDeclarationDigest([
+        {
+          kind: "http",
+          signer: "plugin",
+          handshake: "signed-headers",
+          path: "a",
+        },
+      ]),
+    );
+  });
+
+  it("changes when a delivering route starts reading a field elsewhere", () => {
+    // Which key the sender is read from decides who the message is from.
+    const declared = {
+      kind: "http" as const,
+      signer: "plugin" as const,
+      handshake: "signed-headers" as const,
+      path: "a",
+      inbound: IngressInboundSchema.parse({}),
+    };
+
+    expect(
+      ingressDeclarationDigest([
+        {
+          ...declared,
+          inbound: IngressInboundSchema.parse({
+            fields: { actorExternalId: "from" },
+          }),
+        },
+      ]),
+    ).not.toBe(ingressDeclarationDigest([declared]));
+  });
+
+  it("leaves a route declaring no delivery encoded as it always was", () => {
+    // Introducing the field must not silently re-digest every unchanged
+    // manifest, drop each back to pending, and 404 routes a guardian already
+    // approved. This is the digest as it stood before `inbound` existed.
+    expect(
+      ingressDeclarationDigest([
+        {
+          kind: "http",
+          signer: "plugin",
+          handshake: "signed-headers",
+          path: "a",
+        },
+      ]),
+    ).toBe("45e87741e530e330a663d4c0bb493c36");
   });
 });
 

--- a/gateway/src/channels/plugin-ingress-approvals.ts
+++ b/gateway/src/channels/plugin-ingress-approvals.ts
@@ -4,6 +4,7 @@ import { createHash } from "node:crypto";
 
 import { listPluginIngressApprovals } from "../db/plugin-ingress-approval-store.js";
 import { getLogger } from "../logger.js";
+import { canonicalInbound } from "./ingress-inbound.js";
 import { canonicalVerification } from "./ingress-verification.js";
 import {
   discoverPluginIngress,
@@ -22,27 +23,30 @@ const log = getLogger("plugin-ingress-approvals");
  * Digest of what a declaration asks for.
  *
  * Covers reach only — each route's transport, signer, handshake scheme, path,
- * and how it is verified, order-independent. A `description` reword leaves the
- * digest alone, so it does not revoke an approval, while adding a route,
- * changing one's transport, changing whose signature opens it, moving it to a
- * scheme that exposes it differently, or changing which secret and which bytes
- * decide a delivery is authentic all do.
+ * how it is verified, and whether its replies deliver messages into the
+ * assistant, order-independent. A `description` reword leaves the digest
+ * alone, so it does not revoke an approval, while adding a route, changing
+ * one's transport, changing whose signature opens it, moving it to a scheme
+ * that exposes it differently, changing which secret and which bytes decide a
+ * delivery is authentic, or turning a webhook into a way to start a
+ * conversation all do.
  *
- * A route on the default `signed-headers` scheme, or with no declared
- * verification, is encoded without that field, exactly as it was before the
- * field existed. The alternative is that introducing a field silently
- * re-digests every unchanged manifest, drops each one back to `pending`, and
- * 404s routes a guardian already approved until someone approves them again.
- * Omitting the defaults is unambiguous because a path may not contain
- * whitespace (see `IngressRouteSchema`), so a three-token line can never be
- * read as a four-token one, and a verification descriptor is appended behind a
- * tab, which no path may carry and which `JSON.stringify` escapes rather than
- * emits.
+ * A route on the default `signed-headers` scheme, with no declared
+ * verification and no inbound delivery, is encoded without those fields,
+ * exactly as it was before each existed. The alternative is that introducing a
+ * field silently re-digests every unchanged manifest, drops each one back to
+ * `pending`, and 404s routes a guardian already approved until someone
+ * approves them again. Omitting the defaults is unambiguous because a path may
+ * not contain whitespace (see `IngressRouteSchema`), so a three-token line can
+ * never be read as a four-token one, and the two optional encodings are each
+ * appended behind their own separator — a tab for verification, a form feed
+ * for inbound — neither of which a path may carry and both of which
+ * `JSON.stringify` escapes rather than emits.
  */
 export function ingressDeclarationDigest(
   routes: readonly Pick<
     IngressRoute,
-    "kind" | "path" | "signer" | "handshake" | "verification"
+    "kind" | "path" | "signer" | "handshake" | "verification" | "inbound"
   >[],
 ): string {
   const canonical = routes
@@ -51,9 +55,12 @@ export function ingressDeclarationDigest(
         route.handshake === "signed-headers"
           ? `${route.kind} ${route.signer} ${route.path}`
           : `${route.kind} ${route.signer} ${route.handshake} ${route.path}`;
-      return route.verification
+      const verified = route.verification
         ? `${base}\t${canonicalVerification(route.verification)}`
         : base;
+      return route.inbound
+        ? `${verified}\f${canonicalInbound(route.inbound)}`
+        : verified;
     })
     .sort()
     .join("\n");

--- a/gateway/src/channels/plugin-ingress.test.ts
+++ b/gateway/src/channels/plugin-ingress.test.ts
@@ -216,6 +216,55 @@ describe("parsePluginIngressManifest", () => {
     ).toThrow(/only valid for http routes/);
   });
 
+  it("leaves a route that declares no inbound delivery a plain webhook", () => {
+    // The default. A route receives a callback and the message goes no
+    // further, which is what every declaration written before this meant.
+    const manifest = parsePluginIngressManifest(JSON.parse(VALID));
+    expect(manifest.routes[0]!.inbound).toBeUndefined();
+  });
+
+  it("accepts an empty inbound declaration and fills in the contract's shape", () => {
+    const manifest = parsePluginIngressManifest({
+      routes: [{ path: "hook", kind: "http", description: "d", inbound: {} }],
+    });
+    expect(manifest.routes[0]!.inbound?.identity).toBe("opaque");
+  });
+
+  it("rejects inbound delivery combined with signer vellum", () => {
+    // A `vellum` route is served without a guardian approval. Delivering
+    // messages is how a conversation starts, so a route that both skipped
+    // approval and injected turns would be reach a plugin grants itself.
+    expect(() =>
+      parsePluginIngressManifest({
+        routes: [
+          {
+            path: "hook",
+            kind: "http",
+            signer: "vellum",
+            inbound: {},
+            description: "d",
+          },
+        ],
+      }),
+    ).toThrow(/inbound delivery cannot be combined with signer "vellum"/);
+  });
+
+  it("rejects inbound delivery on a websocket route", () => {
+    // A socket upgrade is bridged elsewhere and has no reply to read.
+    expect(() =>
+      parsePluginIngressManifest({
+        routes: [
+          {
+            path: "realtime",
+            kind: "websocket",
+            inbound: {},
+            description: "d",
+          },
+        ],
+      }),
+    ).toThrow(/inbound delivery is only valid for http routes/);
+  });
+
   it("rejects a verification descriptor the gateway cannot run", () => {
     // Fail the manifest rather than falling back to the platform scheme: a
     // route verified differently than declared is worse than no route.

--- a/gateway/src/channels/plugin-ingress.ts
+++ b/gateway/src/channels/plugin-ingress.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 
 import { getLogger } from "../logger.js";
 import { getWorkspaceDir } from "../paths.js";
+import { IngressInboundSchema } from "./ingress-inbound.js";
 import { IngressVerificationSchema } from "./ingress-verification.js";
 
 const log = getLogger("plugin-ingress");
@@ -159,6 +160,30 @@ export const IngressRouteSchema = z.object({
    * approval granted for something else.
    */
   verification: IngressVerificationSchema.optional(),
+  /**
+   * That this route's replies carry inbound messages, and how to read them.
+   *
+   * Absent (the default) means the route is a webhook and nothing more: the
+   * gateway forwards the delivery, returns whatever the plugin answered, and
+   * the message goes no further. Present, the plugin's reply is normalized and
+   * run through the gateway's inbound pipeline — admission floor, trust
+   * verdict, the verification and invite intercepts — exactly as a built-in
+   * channel's would be. See `ingress-inbound.ts` for the declaration and
+   * `plugin-inbound.ts` for what the gateway supplies rather than reads.
+   *
+   * Rejected alongside `signer: "vellum"`. A `vellum`-signed route is served
+   * without a guardian approval (see `findServableRoute`), which is defensible
+   * for a path only Vellum can drive and carrying no authority over the
+   * assistant. Delivering messages *is* such authority — it is how a
+   * conversation starts — so a route that both skips approval and injects
+   * turns would be reach a plugin grants itself. HTTP only, for the same
+   * reason `verification` is: a socket upgrade is bridged elsewhere and has no
+   * reply to read.
+   *
+   * Part of the digest, so a route cannot begin delivering messages, or begin
+   * reading them differently, under an approval granted for something else.
+   */
+  inbound: IngressInboundSchema.optional(),
   /** Human-readable purpose, surfaced in gateway logs and admin UI. */
   description: z.string().min(1),
 });
@@ -244,6 +269,18 @@ export function parsePluginIngressManifest(
       if (route.kind !== "http") {
         throw new Error(
           `route ${route.path}: declared verification is only valid for http routes`,
+        );
+      }
+    }
+    if (route.inbound) {
+      if (route.signer === "vellum") {
+        throw new Error(
+          `route ${route.path}: inbound delivery cannot be combined with signer "vellum"`,
+        );
+      }
+      if (route.kind !== "http") {
+        throw new Error(
+          `route ${route.path}: inbound delivery is only valid for http routes`,
         );
       }
     }

--- a/gateway/src/channels/types.ts
+++ b/gateway/src/channels/types.ts
@@ -17,6 +17,7 @@ export const CHANNEL_IDS = [
   "email",
   "a2a",
   "discord",
+  "plugin",
 ] as const satisfies readonly CanonicalChannelId[];
 
 export type ChannelId = (typeof CHANNEL_IDS)[number];
@@ -39,6 +40,7 @@ export const INTERFACE_IDS = [
   "slack",
   "email",
   "a2a",
+  "plugin",
 ] as const;
 
 export type InterfaceId = (typeof INTERFACE_IDS)[number];

--- a/gateway/src/db/seed-admission-policy.ts
+++ b/gateway/src/db/seed-admission-policy.ts
@@ -15,7 +15,10 @@ import {
   type AdmissionPolicy,
 } from "@vellumai/gateway-client";
 import { CHANNEL_IDS, type ChannelId } from "../channels/types.js";
-import { AdmissionPolicyStore, isExemptChannelType } from "./admission-policy-store.js";
+import {
+  AdmissionPolicyStore,
+  isExemptChannelType,
+} from "./admission-policy-store.js";
 
 /**
  * Per-channel default floors. Channels absent from this map default to
@@ -28,9 +31,19 @@ import { AdmissionPolicyStore, isExemptChannelType } from "./admission-policy-st
  * `phone` is intentionally absent — it now seeds with the universal
  * `ADMISSION_POLICY_DEFAULT` (`trusted_contacts`), default-denying unknown /
  * unverified inbound callers.
+ *
+ * `plugin` defaults to `guardian_only`, a floor above every other inbound
+ * channel. A plugin channel reaches the assistant through code the guardian
+ * installed rather than through an integration this codebase implements, and
+ * the single row covers every installed plugin at once, so the default admits
+ * the narrowest set that still leaves the channel usable and makes widening it
+ * an explicit choice in the Channel Trust Floors UI.
  */
-export const CHANNEL_ADMISSION_DEFAULTS: Partial<Record<ChannelId, AdmissionPolicy>> = {
+export const CHANNEL_ADMISSION_DEFAULTS: Partial<
+  Record<ChannelId, AdmissionPolicy>
+> = {
   vellum: "guardian_only",
+  plugin: "guardian_only",
 };
 
 /**

--- a/gateway/src/http/read-limited-body.ts
+++ b/gateway/src/http/read-limited-body.ts
@@ -9,14 +9,26 @@ export type ReadLimitedBodyBytesResult =
   | { status: "unreadable" };
 
 /**
- * Read a request body into memory while enforcing a hard byte cap as the
- * stream arrives. Unlike a Content-Length header check, this bounds the bytes
- * actually buffered even when the header is absent, spoofed, or the request
+ * Anything with a body to read under a cap.
+ *
+ * Structural rather than `Request` so a `Response` can be read the same way. A
+ * reply the gateway is about to interpret — a plugin's, say — deserves the same
+ * bound as a request it accepts, and the reading is identical either way.
+ */
+export interface BodyCarrier {
+  headers: Headers;
+  body: ReadableStream<Uint8Array> | null;
+}
+
+/**
+ * Read a body into memory while enforcing a hard byte cap as the stream
+ * arrives. Unlike a Content-Length header check, this bounds the bytes
+ * actually buffered even when the header is absent, spoofed, or the message
  * uses chunked transfer-encoding — so it is safe to call on unauthenticated
  * ingress before any signature check.
  */
 export async function readLimitedBodyBytes(
-  req: Request,
+  req: BodyCarrier,
   maxBytes: number,
 ): Promise<ReadLimitedBodyBytesResult> {
   const contentLength = req.headers.get("content-length");
@@ -62,7 +74,7 @@ export async function readLimitedBodyBytes(
 }
 
 export async function readLimitedBody(
-  req: Request,
+  req: BodyCarrier,
   maxBytes: number,
 ): Promise<ReadLimitedBodyResult> {
   const result = await readLimitedBodyBytes(req, maxBytes);

--- a/gateway/src/http/routes/channel-ingress-routes.ts
+++ b/gateway/src/http/routes/channel-ingress-routes.ts
@@ -57,6 +57,13 @@ const IngressRouteViewSchema = z.object({
    * source's state: a `vellum`-signed route is served without approval.
    */
   served: z.boolean(),
+  /**
+   * Whether this route's replies deliver messages into the assistant, rather
+   * than the route being a callback the plugin merely receives. Approving one
+   * of these grants the plugin a way to start conversations, which is a
+   * different decision than opening an address.
+   */
+  deliversInbound: z.boolean(),
   /** Present when the route declares its own verification scheme. */
   verification: z
     .object({ algorithm: z.string(), signatureHeader: z.string() })

--- a/gateway/src/http/routes/channel-ingress.test.ts
+++ b/gateway/src/http/routes/channel-ingress.test.ts
@@ -229,6 +229,7 @@ describe("list", () => {
             description: "events",
             credential: "credential/meeting-bot/webhook_secret",
             served: false,
+            deliversInbound: false,
           },
         ],
       },

--- a/gateway/src/http/routes/channel-ingress.ts
+++ b/gateway/src/http/routes/channel-ingress.ts
@@ -62,6 +62,11 @@ const ApproveBodySchema = ApproveChannelIngressRequestSchema;
  * route is served out of a pending declaration, so approval state alone does
  * not say whether a route is live, and a listing that reimplemented the
  * exception could come to disagree with the surface it describes.
+ *
+ * `deliversInbound` is the difference between a route that receives a callback
+ * and one that starts conversations. They are not the same grant and a guardian
+ * deciding about the second should be told so, so it is reported rather than
+ * left to be inferred from a `description` the plugin wrote.
  */
 function routeView(
   resolution: PluginIngressResolution,
@@ -78,6 +83,7 @@ function routeView(
     served:
       findServableRoute(resolution, plugin, route.path, route.kind) !==
       undefined,
+    deliversInbound: route.inbound !== undefined,
     credential: route.verification
       ? credentialKey(plugin, route.verification.secret.field)
       : credentialKey(

--- a/gateway/src/http/routes/plugin-webhook.test.ts
+++ b/gateway/src/http/routes/plugin-webhook.test.ts
@@ -4,9 +4,12 @@ import { describe, expect, it } from "bun:test";
 
 import "../../__tests__/test-preload.js";
 import { initSigningKey } from "../../auth/token-service.js";
+import { IngressInboundSchema } from "../../channels/ingress-inbound.js";
+import type { GatewayInboundEvent } from "../../channels/inbound-event.js";
 import type { PluginIngressResolution } from "../../channels/plugin-ingress-approvals.js";
 import type { IngressRoute } from "../../channels/plugin-ingress.js";
 import type { GatewayConfig } from "../../config.js";
+import type { HandleInboundOptions } from "../../handlers/handle-inbound.js";
 import { createPluginWebhookHandler } from "./plugin-webhook.js";
 
 // The handler mints a real service token for the upstream hop. Initialising
@@ -937,5 +940,216 @@ describe("upstream failures", () => {
 
     expect(res.status).toBe(404);
     expect(await res.text()).toBe("no such route");
+  });
+});
+
+describe("inbound delivery", () => {
+  const INBOUND_ROUTE: IngressRoute = {
+    ...ROUTE,
+    path: "events",
+    inbound: IngressInboundSchema.parse({ identity: "phone" }),
+  };
+
+  /** A plugin reply, and a recorder for what reached the inbound pipeline. */
+  function replyingWith(body: unknown, status = 200) {
+    const handled: GatewayInboundEvent[] = [];
+    const options: (HandleInboundOptions | undefined)[] = [];
+    return {
+      handled,
+      options,
+      deps: {
+        config: CONFIG,
+        credentials: CREDENTIALS,
+        resolve: () => approvedWith([INBOUND_ROUTE]),
+        fetchImpl: async () =>
+          new Response(typeof body === "string" ? body : JSON.stringify(body), {
+            status,
+          }),
+        handleInboundImpl: async (
+          _config: GatewayConfig,
+          event: GatewayInboundEvent,
+          opts?: HandleInboundOptions,
+        ) => {
+          handled.push(event);
+          options.push(opts);
+          return { forwarded: true, rejected: false };
+        },
+      },
+    };
+  }
+
+  const MESSAGE = {
+    message: {
+      content: "hello",
+      conversationExternalId: "chat-1",
+      externalMessageId: "msg-1",
+    },
+    actor: { actorExternalId: "(202) 555-0142", displayName: "Ada" },
+  };
+
+  it("runs the plugin's reply through the inbound pipeline", async () => {
+    // The whole point: the delivery the gateway already authenticated is what
+    // produces the message, so nothing new has to be opened to receive one.
+    const { handled, deps } = replyingWith(MESSAGE);
+    const handle = createPluginWebhookHandler(deps);
+
+    const res = await handle(
+      post("/webhooks/plugins/meeting-bot/events"),
+      "meeting-bot",
+      "events",
+    );
+
+    expect(res.status).toBe(200);
+    expect(handled).toHaveLength(1);
+    expect(handled[0]!.sourceChannel).toBe("plugin");
+    expect(handled[0]!.message.content).toBe("hello");
+    expect(handled[0]!.actor.actorExternalId).toBe("meeting-bot:+12025550142");
+  });
+
+  it("tells the pipeline which plugin and which route it came from", async () => {
+    // A plugin can declare several routes, and knowing which one a turn
+    // arrived on separates a provider misconfiguration from a plugin bug.
+    const { options, deps } = replyingWith(MESSAGE);
+    const handle = createPluginWebhookHandler(deps);
+
+    await handle(
+      post("/webhooks/plugins/meeting-bot/events"),
+      "meeting-bot",
+      "events",
+    );
+
+    expect(options[0]?.sourceMetadata).toEqual({
+      plugin: "meeting-bot",
+      ingressRoute: "events",
+    });
+  });
+
+  it("does not echo the plugin's reply back to the vendor", async () => {
+    // The reply was addressed to us. A plugin normalizing a delivery into an
+    // event should not thereby send the sender's message back to the vendor.
+    const { deps } = replyingWith(MESSAGE);
+    const handle = createPluginWebhookHandler(deps);
+
+    const res = await handle(
+      post("/webhooks/plugins/meeting-bot/events"),
+      "meeting-bot",
+      "events",
+    );
+
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("leaves a route that declares no delivery a plain proxy", async () => {
+    // Every declaration written before `inbound` existed means this, so the
+    // reply has to reach the vendor untouched and nothing may be delivered.
+    const { handled, deps } = replyingWith(MESSAGE);
+    const handle = createPluginWebhookHandler({
+      ...deps,
+      resolve: () => approvedWith([{ ...INBOUND_ROUTE, inbound: undefined }]),
+    });
+
+    const res = await handle(
+      post("/webhooks/plugins/meeting-bot/events"),
+      "meeting-bot",
+      "events",
+    );
+
+    expect(handled).toHaveLength(0);
+    expect(await res.json()).toEqual(MESSAGE as never);
+  });
+
+  it("delivers nothing when the plugin only acknowledged", async () => {
+    // The ordinary case. Receipts, echoes, and events the plugin does not
+    // handle all reply like this, and none of them is a turn.
+    const { handled, deps } = replyingWith({ ok: true, ignored: "an echo" });
+    const handle = createPluginWebhookHandler(deps);
+
+    const res = await handle(
+      post("/webhooks/plugins/meeting-bot/events"),
+      "meeting-bot",
+      "events",
+    );
+
+    expect(res.status).toBe(200);
+    expect(handled).toHaveLength(0);
+  });
+
+  it("still acknowledges the vendor when the reply cannot be read", async () => {
+    // The delivery was authentic and the plugin accepted it, so a failure to
+    // interpret its answer is ours. A 5xx here would have the vendor retry a
+    // delivery that fails the same way every time.
+    const { handled, deps } = replyingWith("not json at all");
+    const handle = createPluginWebhookHandler(deps);
+
+    const res = await handle(
+      post("/webhooks/plugins/meeting-bot/events"),
+      "meeting-bot",
+      "events",
+    );
+
+    expect(res.status).toBe(200);
+    expect(handled).toHaveLength(0);
+  });
+
+  it("still acknowledges the vendor when the pipeline throws", async () => {
+    const { deps } = replyingWith(MESSAGE);
+    const handle = createPluginWebhookHandler({
+      ...deps,
+      handleInboundImpl: async () => {
+        throw new Error("runtime is down");
+      },
+    });
+
+    const res = await handle(
+      post("/webhooks/plugins/meeting-bot/events"),
+      "meeting-bot",
+      "events",
+    );
+
+    expect(res.status).toBe(200);
+  });
+
+  it("delivers nothing from a reply the plugin itself failed", async () => {
+    // A plugin reporting a failure is not reporting a message, and the vendor
+    // gets that status back so its own retry logic can act on it.
+    const { handled, deps } = replyingWith(MESSAGE, 500);
+    const handle = createPluginWebhookHandler(deps);
+
+    const res = await handle(
+      post("/webhooks/plugins/meeting-bot/events"),
+      "meeting-bot",
+      "events",
+    );
+
+    expect(res.status).toBe(500);
+    expect(handled).toHaveLength(0);
+  });
+
+  it("delivers nothing from a route awaiting approval", async () => {
+    // The gate stands in front of this like everything else: a declaration
+    // that can start conversations must be one a guardian decided about.
+    const { handled, deps } = replyingWith(MESSAGE);
+    const handle = createPluginWebhookHandler({
+      ...deps,
+      resolve: () =>
+        resolution({
+          pending: [
+            {
+              plugin: "meeting-bot",
+              routes: [INBOUND_ROUTE],
+              digest: "d".repeat(32),
+            },
+          ],
+        }),
+    });
+
+    const res = await handle(
+      post("/webhooks/plugins/meeting-bot/events"),
+      "meeting-bot",
+      "events",
+    );
+
+    expect(res.status).toBe(409);
+    expect(handled).toHaveLength(0);
   });
 });

--- a/gateway/src/http/routes/plugin-webhook.ts
+++ b/gateway/src/http/routes/plugin-webhook.ts
@@ -14,6 +14,13 @@
  * The declaration picks whose secret that is — see `IngressRouteSchema.signer`
  * — and, for a route a third party calls, how the signature is formed at all
  * (`IngressRouteSchema.verification`).
+ *
+ * A route may also declare that its replies carry messages
+ * (`IngressRouteSchema.inbound`), which is how a plugin channel receives
+ * anything at all. The plugin parses its vendor's delivery and answers with
+ * the result; the gateway reads that answer and runs it through the same
+ * `handleInbound` every built-in channel uses. See `plugin-inbound.ts` for
+ * what of the reply the gateway believes.
  */
 
 import {
@@ -24,7 +31,10 @@ import {
   verifyDeclaredSignature,
   type VerificationRejection,
 } from "../../channels/ingress-verification.js";
+import { readPluginInbound } from "../../channels/plugin-inbound.js";
+import type { IngressInbound } from "../../channels/ingress-inbound.js";
 import type { IngressSigner } from "../../channels/plugin-ingress.js";
+import { handleInbound } from "../../handlers/handle-inbound.js";
 import { mintServiceToken } from "../../auth/token-exchange.js";
 import type { GatewayConfig } from "../../config.js";
 import type { CredentialCache } from "../../credential-cache.js";
@@ -34,7 +44,7 @@ import {
   verifySecretWithRefresh,
 } from "../../credential-refresh.js";
 import { getLogger } from "../../logger.js";
-import { readLimitedBodyBytes } from "../read-limited-body.js";
+import { readLimitedBody, readLimitedBodyBytes } from "../read-limited-body.js";
 import { verifyVellumSignature } from "../vellum-signature.js";
 import { proxyForwardToResponse } from "@vellumai/assistant-client";
 
@@ -106,6 +116,12 @@ export interface PluginWebhookHandlerDeps {
     input: string | URL | Request,
     init?: RequestInit,
   ) => Promise<Response>;
+  /**
+   * The inbound pipeline, injected for the same reason `fetchImpl` is: it
+   * reaches the ACL database, the trust resolver, and the runtime, none of
+   * which a test of this route's decisions should have to stand up.
+   */
+  handleInboundImpl?: typeof handleInbound;
 }
 
 /**
@@ -130,7 +146,13 @@ export interface PluginWebhookHandlerDeps {
  * by the same body cap as everything else here.
  */
 export function createPluginWebhookHandler(deps: PluginWebhookHandlerDeps) {
-  const { config, resolve, credentials, fetchImpl } = deps;
+  const {
+    config,
+    resolve,
+    credentials,
+    fetchImpl,
+    handleInboundImpl = handleInbound,
+  } = deps;
 
   return async (req: Request, plugin: string, path: string) => {
     let match: ReturnType<typeof findDeclaredRoute>;
@@ -275,13 +297,127 @@ export function createPluginWebhookHandler(deps: PluginWebhookHandlerDeps) {
         { plugin, path, status: response.status, duration },
         "Plugin webhook upstream error",
       );
-    } else if (response.status >= 400) {
+      return response;
+    }
+    if (response.status >= 400) {
       log.warn(
         { plugin, path, status: response.status, duration },
         "Plugin webhook upstream error",
       );
+      return response;
     }
 
-    return response;
+    const inbound = route.inbound;
+    if (!inbound) {
+      return response;
+    }
+    return deliverPluginInbound({
+      config,
+      plugin,
+      routePath: route.path,
+      inbound,
+      response,
+      handleInboundImpl,
+    });
   };
+}
+
+/**
+ * Run a plugin's reply through the inbound pipeline and answer the vendor.
+ *
+ * Only reached for a 2xx, because a reply the plugin itself is reporting a
+ * failure on is not a message. The vendor gets the plugin's status back but
+ * not its body: the body was addressed to us, and a plugin that normalizes a
+ * delivery into an event should not thereby echo the sender's message back to
+ * the vendor that sent it.
+ *
+ * Errors here are logged and swallowed. The delivery was authentic and the
+ * plugin accepted it, so a failure to interpret the reply is ours; answering
+ * the vendor with a 5xx would have them retry a delivery that will fail the
+ * same way, which is the retry storm the 409 on unapproved routes exists to
+ * avoid.
+ */
+async function deliverPluginInbound(opts: {
+  config: GatewayConfig;
+  plugin: string;
+  /** The declared path, for logs. Not the requested spelling. */
+  routePath: string;
+  inbound: IngressInbound;
+  response: Response;
+  handleInboundImpl: typeof handleInbound;
+}): Promise<Response> {
+  const { config, plugin, routePath, inbound, response, handleInboundImpl } =
+    opts;
+  const ack = Response.json({ ok: true }, { status: response.status });
+
+  const body = await readLimitedBody(response, config.maxWebhookPayloadBytes);
+  if (body.status !== "ok") {
+    log.warn(
+      { plugin, path: routePath, reason: body.status },
+      "Could not read the plugin's reply for inbound delivery",
+    );
+    return ack;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = body.text.trim() === "" ? undefined : JSON.parse(body.text);
+  } catch {
+    log.warn(
+      { plugin, path: routePath },
+      "Plugin reply on an inbound route is not JSON",
+    );
+    return ack;
+  }
+
+  const reading = readPluginInbound({
+    plugin,
+    inbound,
+    body: parsed,
+    receivedAt: new Date().toISOString(),
+  });
+
+  if (reading.status === "none") {
+    // The ordinary case: a receipt, an echo, an event the plugin does not
+    // handle. Debug rather than info — every delivery would log otherwise.
+    log.debug(
+      { plugin, path: routePath },
+      "Plugin reply carried no inbound message",
+    );
+    return ack;
+  }
+  if (reading.status === "invalid") {
+    log.warn(
+      { plugin, path: routePath, reason: reading.reason },
+      "Plugin reply on an inbound route is not a usable message",
+    );
+    return ack;
+  }
+
+  try {
+    const result = await handleInboundImpl(config, reading.event, {
+      // Which plugin, for the runtime and for anyone reading a transcript. The
+      // route too: a plugin can declare several, and knowing which one a turn
+      // arrived on is the difference between a provider misconfiguration and a
+      // plugin bug.
+      sourceMetadata: { plugin, ingressRoute: routePath },
+    });
+    log.info(
+      {
+        plugin,
+        path: routePath,
+        forwarded: result.forwarded,
+        rejected: result.rejected,
+        rejectionReason: result.rejectionReason,
+      },
+      "Plugin inbound message handled",
+    );
+  } catch (err) {
+    log.error(
+      { err, plugin, path: routePath },
+      "Failed to handle a plugin inbound message",
+    );
+  }
+
+  return ack;
 }

--- a/gateway/src/verification/identity.ts
+++ b/gateway/src/verification/identity.ts
@@ -53,18 +53,50 @@ export function canonicalizeInboundIdentity(
   channel: string,
   rawId: string,
 ): string | null {
+  return canonicalizeIdentityAs(identityKindFor(channel), rawId);
+}
+
+/**
+ * What an address on a channel *is*, independent of which channel carries it.
+ *
+ * A built-in channel's answer follows from its name, which is why the sets
+ * above suffice for them. A plugin channel's does not: `plugin` is one id
+ * covering every plugin, and whether its addresses are phone numbers, email
+ * addresses, or opaque handles is the plugin's business. Its ingress manifest
+ * declares the answer, and it arrives here as one of these.
+ */
+export type IdentityKind = "phone" | "email" | "opaque";
+
+function identityKindFor(channel: string): IdentityKind {
+  if (PHONE_CHANNELS.has(channel)) return "phone";
+  if (EMAIL_CHANNELS.has(channel)) return "email";
+  return "opaque";
+}
+
+/**
+ * Canonicalize an address of a known kind.
+ *
+ * Phone-like: E.164 where the input parses as one, the trimmed input where it
+ * does not — a raw id that is not a phone number after all still has to
+ * compare equal to itself. Email: lowercased. Opaque: trimmed, because a
+ * platform-stable id is already canonical and rewriting it would only make it
+ * stop matching what is stored.
+ *
+ * Returns null only for an empty or whitespace-only input.
+ */
+export function canonicalizeIdentityAs(
+  kind: IdentityKind,
+  rawId: string,
+): string | null {
   const trimmed = rawId.trim();
   if (trimmed.length === 0) return null;
 
-  if (PHONE_CHANNELS.has(channel)) {
-    const e164 = normalizePhoneNumber(trimmed);
-    return e164 ?? trimmed;
+  if (kind === "phone") {
+    return normalizePhoneNumber(trimmed) ?? trimmed;
   }
-
-  if (EMAIL_CHANNELS.has(channel)) {
+  if (kind === "email") {
     return trimmed.toLowerCase();
   }
-
   return trimmed;
 }
 

--- a/packages/service-contracts/src/channels.ts
+++ b/packages/service-contracts/src/channels.ts
@@ -6,6 +6,16 @@
  * assistant through (Slack, Telegram, WhatsApp, phone, …) plus a couple of
  * internal ids (`vellum` for native app conversations, `platform` for the
  * internal control plane). This is the single source of truth for that set:
+ *
+ * One id, `plugin`, does not name a surface: it names *every* surface a plugin
+ * brings. A plugin channel's real identity is the plugin, which is workspace
+ * state and cannot be a compile-time union member, so the plugin name travels
+ * in `sourceMetadata.plugin` and is prefixed onto every external id the gateway
+ * forwards (`imessage:+15551234567`). Two plugins therefore share a channel
+ * row — one admission floor, one set of channel-wide defaults — while their
+ * conversations, contacts, and trust records stay disjoint. See
+ * `gateway/src/channels/plugin-inbound.ts` for what that concedes.
+ *
  * the assistant adopts it wholesale as its `ChannelId`, and the gateway
  * asserts its own (narrower) inbound list is a subset of it so the two sides
  * cannot silently drift.
@@ -30,6 +40,7 @@ export const CHANNEL_IDS = [
   "platform",
   "a2a",
   "discord",
+  "plugin",
 ] as const;
 
 export type ChannelId = (typeof CHANNEL_IDS)[number];


### PR DESCRIPTION
## Prompt / plan

> "we need to do a version of C, where any ambiguity can be answered by the `channels/ingress.json` on how to map fields if need be"

A plugin channel had no inbound path. The gateway forwarded a verified delivery to the plugin's route, the plugin normalized it, and the event stopped there at a `TODO`. Everything that decides whether a message may reach the assistant — the admission floor, the trust verdict, identity canonicalization, the verification and invite intercepts — lives in `handleInbound`, which is *upstream* of where a plugin webhook lands. So there was nowhere for the plugin to put the result that was not around all of it.

Three options were on the table:

- **A — plugin POSTs back to the gateway.** Needs a new authenticated plugin→gateway path and a widened `InboundChannelId`.
- **B — gateway parses vendor payloads.** Rejected: the verification descriptor deliberately tells the gateway how to *authenticate* a delivery, not how to parse one, which is the plugin's entire reason to exist.
- **C — plugin answers with a normalized event.** The gateway already forwards each verified delivery and reads the reply, so the reply is the way in. No new path, no second authentication, policy stays where it is.

This is C.

### What the declaration decides

A route declaring `inbound` in `channels/ingress.json` is one whose reply carries the message. The declaration answers exactly what the plugin cannot decide for itself:

- **Which channel it speaks as** is not declarable. The gateway stamps `plugin` and prefixes the plugin's own directory name, taken from the request path and never from the reply, onto every external id. A reply cannot attribute a message to Slack, to another plugin, or to a contact record it does not own.
- **What kind of address the sender's id is** (`identity`: `opaque` | `phone` | `email`), because that decides whether `(202) 555-0142` and `+12025550142` are one person, and the gateway cannot tell by looking.
- **Where each field lives in the reply** (`fields`), for a plugin that would rather hand back its own structure than the contract's. Paths are dotted identifiers — this reads one scalar out of one object, and the manifest is untrusted input evaluated against an attacker-authored document, so anything resembling an expression language is refused.

`inbound` is part of `ingressDeclarationDigest`, so a route cannot start delivering messages, or start reading them differently, under an approval granted for something else. It is rejected alongside `signer: "vellum"`, which is served without a guardian decision — starting conversations is not reach a plugin may grant itself. **A declaration that omits `inbound` digests exactly as it did before the field existed**, so no approved manifest is dropped back to pending by this change.

### The `plugin` channel

`plugin` joins the canonical channel set as one id covering every installed plugin, because the real identity is the plugin and workspace state cannot be a compile-time union member. The prefixed external ids keep two plugins' conversations, contacts, and trust records disjoint even though they share the channel row.

That row seeds at `guardian_only`, a floor above every other inbound channel: a plugin channel arrives through code the guardian installed rather than through an integration this codebase implements, and one row covers every plugin at once. It stays configurable in the Channel Trust Floors UI.

Stated cost: those same prefixes mean a guardian already verified on `phone` is a stranger on a plugin channel until they verify again. That is the right default — a plugin asserting an address is not the same evidence as an SMS arriving at a number Twilio owns — but it is a default, and cross-channel identity linking is where it would be revisited.

### UI

The ingress listing and the plugin channel panel now report `deliversInbound` per route. Opening an address a plugin receives callbacks on and letting that address put messages in front of the assistant are different decisions, and this is the only place the second one is ever made.

## Test plan

- New unit suites: `gateway/src/channels/ingress-inbound.test.ts` (declaration parsing, digest canonicalization, the field reader's refusal to walk prototypes or non-strings) and `gateway/src/channels/plugin-inbound.test.ts` (channel stamping, id scoping, identity canonicalization, field mapping, and the ack / invalid / event split).
- `gateway/src/http/routes/plugin-webhook.test.ts` grew an `inbound delivery` block covering the pipeline hand-off, the metadata stamped on it, the ack that does not echo the plugin's reply, a route declaring no delivery staying a plain proxy, and delivery being refused from a route awaiting approval.
- `ingressDeclarationDigest` has a pinned-constant test asserting a route without `inbound` still digests to its pre-change value.
- Full gateway suite green (`bun run test` — all 249 test files passed).
- `assistant` and `clients/web` typecheck; `assistant/src/channels` and `src/__tests__/channel-policy.test.ts` green. Four pre-existing failures in `clients/web/src/domains/channels` and 111 in `assistant/src/notifications` reproduce unchanged on `main` (cross-file `mock.module` interference when a directory is run in one process).

## Known gap

Outbound is not closed by this. A plugin channel has no `replyCallbackUrl` and no entry in the direct-delivery transport registry, so the assistant's reply does not get back to the plugin's vendor yet. That needs the plugin transport registration seam, which does not exist in the host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013p1nTdvsuAtTJ7zyCSDLbx

---
_Generated by [Claude Code](https://claude.ai/code/session_013p1nTdvsuAtTJ7zyCSDLbx)_