### PR TITLE
feat(macos): companion surface snaps to the cursor and hosts dictation (LUM-3170)

### DIFF
--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -17,8 +17,14 @@ mock.module("electron-store", () => ({
 
 // Dynamic, so the mock above is installed before the module graph loads:
 // static imports hoist above it.
-const { growthFor, callOnStart, callOnUpdate, shouldShowCompanionSurface } =
-  await import("./companion-window");
+const {
+  growthFor,
+  callOnStart,
+  callOnUpdate,
+  shouldShowCompanionSurface,
+  canvasOriginForAvatarCentre,
+  parkedOriginForSnap,
+} = await import("./companion-window");
 
 /** A session as the mirror publishes one, before main stamps its clock. */
 const START = {
@@ -147,5 +153,118 @@ describe("shouldShowCompanionSurface", () => {
   // wrote last time, and a fresh install has none.
   test("stays away when nothing is known yet", () => {
     expect(shouldShowCompanionSurface(false, false)).toBe(false);
+  });
+});
+
+/**
+ * Where the window goes when a dictation session calls the surface to the
+ * cursor.
+ *
+ * The canvas is far larger than the circle drawn in it, so every position is
+ * stated as the avatar's centre and backed out by half the canvas. That
+ * arithmetic is the whole of the bug surface here: off by the wrong half and
+ * the avatar lands a third of a screen from the pointer that summoned it.
+ */
+describe("canvasOriginForAvatarCentre", () => {
+  // Half of `CANVAS_WIDTH` (724) and `CANVAS_HEIGHT` (584): what the avatar's
+  // centre is offset by to become the window's own origin.
+  const HALF_W = 362;
+  const HALF_H = 292;
+  // Half the avatar's 44pt box, which is how close its centre may get to an
+  // edge before the circle would start leaving the display.
+  const HALF_AVATAR = 22;
+  const WORK_AREA = { x: 0, y: 0, width: 1440, height: 900 };
+
+  test("centres the avatar on the point", () => {
+    expect(canvasOriginForAvatarCentre({ x: 720, y: 450 }, WORK_AREA)).toEqual({
+      x: 720 - HALF_W,
+      y: 450 - HALF_H,
+    });
+  });
+
+  test("holds the avatar inside the top-left corner", () => {
+    expect(canvasOriginForAvatarCentre({ x: 0, y: 0 }, WORK_AREA)).toEqual({
+      x: HALF_AVATAR - HALF_W,
+      y: HALF_AVATAR - HALF_H,
+    });
+  });
+
+  test("holds the avatar inside the bottom-right corner", () => {
+    expect(canvasOriginForAvatarCentre({ x: 1440, y: 900 }, WORK_AREA)).toEqual(
+      {
+        x: 1440 - HALF_AVATAR - HALF_W,
+        y: 900 - HALF_AVATAR - HALF_H,
+      },
+    );
+  });
+
+  test("the canvas is allowed off the display, the avatar is not", () => {
+    // The origin lands well outside the work area at every edge, which is the
+    // point: clamping the canvas instead would keep the circle 362pt from the
+    // left of every display and 292pt from the top.
+    const origin = canvasOriginForAvatarCentre({ x: 0, y: 0 }, WORK_AREA);
+    expect(origin.x).toBeLessThan(WORK_AREA.x);
+    expect(origin.y).toBeLessThan(WORK_AREA.y);
+  });
+
+  test("clamps against the display's own origin, not the screen's", () => {
+    // A second display to the right of the primary. A cursor on its left edge
+    // is at x=1440 in screen coordinates, which is inside this display and must
+    // not be pulled to the primary's bounds.
+    const secondary = { x: 1440, y: 0, width: 1440, height: 900 };
+    expect(canvasOriginForAvatarCentre({ x: 1440, y: 450 }, secondary)).toEqual(
+      {
+        x: 1440 + HALF_AVATAR - HALF_W,
+        y: 450 - HALF_H,
+      },
+    );
+  });
+
+  test("rounds to whole points", () => {
+    // Electron takes integers, and a fractional position is silently truncated
+    // somewhere further down rather than rejected.
+    const origin = canvasOriginForAvatarCentre(
+      { x: 720.6, y: 450.4 },
+      WORK_AREA,
+    );
+    expect(Number.isInteger(origin.x)).toBe(true);
+    expect(Number.isInteger(origin.y)).toBe(true);
+  });
+
+  test("a work area narrower than the avatar resolves to its near edge", () => {
+    // The bounds cross over here, so the two clamps disagree. Answering with
+    // the near edge keeps the arithmetic total rather than returning something
+    // outside the display on the far side.
+    const sliver = { x: 0, y: 0, width: 30, height: 30 };
+    expect(canvasOriginForAvatarCentre({ x: 15, y: 15 }, sliver)).toEqual({
+      x: HALF_AVATAR - HALF_W,
+      y: HALF_AVATAR - HALF_H,
+    });
+  });
+});
+
+/**
+ * The spot the surface goes back to when the session that moved it ends.
+ *
+ * The rule is one line and the bug it prevents is not obvious: a session pushes
+ * many states, and re-reading the window's position on any of them would record
+ * the cursor the session had already moved it to.
+ */
+describe("parkedOriginForSnap", () => {
+  test("records where the surface was parked on the first snap", () => {
+    expect(parkedOriginForSnap(null, { x: 100, y: 200 })).toEqual({
+      x: 100,
+      y: 200,
+    });
+  });
+
+  test("a later snap in the same session does not overwrite it", () => {
+    const parked = parkedOriginForSnap(null, { x: 100, y: 200 });
+    // The surface has since been moved to the cursor. Recording that would put
+    // the return at the cursor rather than at the spot the user chose.
+    expect(parkedOriginForSnap(parked, { x: 900, y: 40 })).toEqual({
+      x: 100,
+      y: 200,
+    });
   });
 });

--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -24,6 +24,7 @@ const {
   shouldShowCompanionSurface,
   canvasOriginForAvatarCentre,
   parkedOriginForSnap,
+  canHostDictation,
 } = await import("./companion-window");
 
 /** A session as the mirror publishes one, before main stamps its clock. */
@@ -153,6 +154,30 @@ describe("shouldShowCompanionSurface", () => {
   // wrote last time, and a fresh install has none.
   test("stays away when nothing is known yet", () => {
     expect(shouldShowCompanionSurface(false, false)).toBe(false);
+  });
+});
+
+/**
+ * Whether the surface takes a dictation session or leaves it to the overlay.
+ *
+ * Taking one suppresses the top-center overlay, so declining has to be the
+ * answer whenever the surface could not actually draw the session: the user
+ * would otherwise dictate with no transcription and no stop control anywhere.
+ */
+describe("canHostDictation", () => {
+  test("takes the session while on screen and idle", () => {
+    expect(canHostDictation(true, false)).toBe(true);
+  });
+
+  test("declines while off screen, which is what the overlay is for", () => {
+    expect(canHostDictation(false, false)).toBe(false);
+  });
+
+  // The composer holds a half-typed message that closing would throw away, and
+  // the pill draws one thing at a time. Hosting here would suppress the overlay
+  // and then render the card over the session it just took.
+  test("declines while the composer is open, draft intact", () => {
+    expect(canHostDictation(true, true)).toBe(false);
   });
 });
 

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -9,6 +9,7 @@ import {
   type CompanionGrowth,
   type CompanionContext,
   type CompanionSurfaceState,
+  type DictationOverlayState,
   type VellumCommand,
   type VoiceActivityState,
 } from "@vellumai/ipc-contract";
@@ -154,6 +155,8 @@ const CANVAS_HEIGHT = (MAX_RISE + CANVAS_PAD) * 2;
 /** Gap from the work area's bottom-right on the first ever launch. */
 const DEFAULT_MARGIN = 24;
 
+/** A canvas origin, which is what `BrowserWindow.getPosition` deals in. */
+type Origin = { x: number; y: number };
 
 let growth: CompanionGrowth = "right";
 
@@ -178,6 +181,26 @@ let call: VoiceActivityState | null = null;
 let context: CompanionContext = { assistantName: "", turns: [] };
 
 /**
+ * The dictation session the surface is standing in for, or `null` when none is.
+ *
+ * Held here for the same reason the call is: the states arrive from the
+ * renderer that owns the recording, and this surface's own renderer can reload
+ * mid-session.
+ */
+let dictation: DictationOverlayState | null = null;
+
+/**
+ * Where the surface sat before a dictation session moved it, or `null` when it
+ * is at rest where the user left it.
+ *
+ * A session snaps the avatar to the cursor and the end of that session puts it
+ * back. Remembering the spot is what makes the move a loan rather than a
+ * relocation: the surface is dragged where the user wants it, and dictating
+ * must not be a way to quietly lose that.
+ */
+let parkedOrigin: Origin | null = null;
+
+/**
  * The state the renderer sees, rebuilt on demand.
  *
  * The avatar is read from the cache main already keeps for the Dock and Tray
@@ -192,6 +215,7 @@ const currentState = (): CompanionSurfaceState => {
     character: character === null ? undefined : character,
     avatarBase64: png === null ? undefined : png.toString("base64"),
     call,
+    dictation,
     assistantName: context.assistantName,
     turns: context.turns,
   };
@@ -257,6 +281,63 @@ export const growthFor = (
 };
 
 /**
+ * The canvas origin that puts the avatar's centre on a point, kept on screen.
+ *
+ * The canvas is many times the size of the visible circle and the avatar is
+ * pinned to its centre, so a point the caller cares about is always a statement
+ * about the avatar and always has to be backed out by half the canvas to become
+ * a window position. Getting that backwards puts the circle half a screen from
+ * where it was meant to be, which is why this is one function both callers go
+ * through rather than the arithmetic written out twice.
+ *
+ * **The clamp is on the avatar, not the canvas.** Holding the whole canvas
+ * inside the work area would keep the circle hundreds of points away from every
+ * edge, which is most of the screen ruled out; the thing that has to stay
+ * reachable is the part the user can see. So the avatar is held inside the work
+ * area by its own half-width and the canvas hangs off the display either side,
+ * which costs nothing: it is transparent and click-through.
+ */
+export const canvasOriginForAvatarCentre = (
+  centre: Origin,
+  workArea: { x: number; y: number; width: number; height: number },
+): Origin => {
+  const half = AVATAR_BOX / 2;
+  const clamp = (value: number, min: number, max: number): number =>
+    // `min` last, so a work area narrower than the avatar resolves to its near
+    // edge rather than inverting the bounds.
+    Math.max(Math.min(value, max), min);
+  const x = clamp(
+    centre.x,
+    workArea.x + half,
+    workArea.x + workArea.width - half,
+  );
+  const y = clamp(
+    centre.y,
+    workArea.y + half,
+    workArea.y + workArea.height - half,
+  );
+  return {
+    x: Math.round(x - CANVAS_WIDTH / 2),
+    y: Math.round(y - CANVAS_HEIGHT / 2),
+  };
+};
+
+/**
+ * The spot to put the surface back to, given where it is now.
+ *
+ * **The first snap of a session wins.** A session pushes several states through
+ * and the surface can be snapped again while one is running, so taking the
+ * current position each time would record a spot the session itself had already
+ * moved the surface to, and the return would put it back to the cursor rather
+ * than to where the user parked it. Once a session ends the caller drops this
+ * and the next one records afresh.
+ */
+export const parkedOriginForSnap = (
+  parked: Origin | null,
+  current: Origin,
+): Origin => parked ?? current;
+
+/**
  * Where the surface opens with no remembered position: the bottom-right of the
  * display under the cursor, near where the Dock usually is and clear of the
  * window the user is working in.
@@ -265,17 +346,16 @@ export const growthFor = (
  * computed for the avatar and then backed out to the canvas origin. Getting
  * that backwards puts the circle half a screen from where it was meant to be.
  */
-const defaultCanvasOrigin = (): { x: number; y: number } => {
+const defaultCanvasOrigin = (): Origin => {
   const cursor = screen.getCursorScreenPoint();
   const { workArea } = screen.getDisplayNearestPoint(cursor);
-  const avatarCentreX =
-    workArea.x + workArea.width - DEFAULT_MARGIN - AVATAR_BOX / 2;
-  const avatarCentreY =
-    workArea.y + workArea.height - DEFAULT_MARGIN - AVATAR_BOX / 2;
-  return {
-    x: Math.round(avatarCentreX - CANVAS_WIDTH / 2),
-    y: Math.round(avatarCentreY - CANVAS_HEIGHT / 2),
-  };
+  return canvasOriginForAvatarCentre(
+    {
+      x: workArea.x + workArea.width - DEFAULT_MARGIN - AVATAR_BOX / 2,
+      y: workArea.y + workArea.height - DEFAULT_MARGIN - AVATAR_BOX / 2,
+    },
+    workArea,
+  );
 };
 
 const pushState = (): void => {
@@ -303,6 +383,85 @@ const refreshGrowth = (): void => {
   }
   growth = next;
   pushState();
+};
+
+/**
+ * Put the window somewhere.
+ *
+ * The growth direction takes care of itself: moving fires `move`, which
+ * recomputes it, the same way dragging the surface does.
+ */
+const moveCanvasTo = (origin: Origin): void => {
+  const win = getFloatingWindow(COMPANION_KIND);
+  if (!win || win.isDestroyed()) {
+    return;
+  }
+  win.setPosition(origin.x, origin.y);
+};
+
+/**
+ * The surface as a host for a dictation session, which it is whenever it is on
+ * screen.
+ *
+ * Handed to `installDictationOverlay` from `index.ts` rather than imported
+ * there, for the reason its sibling `onRecordingLifecycle` is injected: this
+ * module reaches `main-window.ts`, and importing it into the overlay would drag
+ * that whole graph into the overlay's unit tests.
+ *
+ * **The surface is the dictation HUD for as long as it exists.** The top-center
+ * overlay is what the app falls back to when the surface is flag-off or hidden
+ * from the tray, so the two are never both on screen describing the same
+ * session. That is the rule the running call already follows: one assistant,
+ * one place on screen.
+ */
+export const companionDictationHost = {
+  /** Whether the surface is on screen to be handed a session at all. */
+  canHost: (): boolean => getFloatingWindow(COMPANION_KIND) !== null,
+
+  /**
+   * Begin: come to the cursor, and hold the spot to go back to.
+   *
+   * The mouse cursor rather than the text caret. The caret is arguably the
+   * better answer while dictating into another app's field, but reading it
+   * means the accessibility API, which returns nothing at all in Electron apps
+   * and Terminal, so the surface would sit still exactly where a user is most
+   * likely to be typing.
+   */
+  begin: (): void => {
+    const win = getFloatingWindow(COMPANION_KIND);
+    if (!win || win.isDestroyed()) {
+      return;
+    }
+    const [x, y] = win.getPosition();
+    parkedOrigin = parkedOriginForSnap(parkedOrigin, { x, y });
+    const cursor = screen.getCursorScreenPoint();
+    const { workArea } = screen.getDisplayNearestPoint(cursor);
+    moveCanvasTo(canvasOriginForAvatarCentre(cursor, workArea));
+  },
+
+  /** Draw a state. */
+  forward: (state: DictationOverlayState): void => {
+    dictation = state;
+    pushState();
+  },
+
+  /**
+   * End: drop the session and go back to where the user parked the surface.
+   *
+   * The return happens even when the surface was closed and reopened
+   * mid-session, in which case there is no window to move and the reopened one
+   * has already computed a position of its own. See `closeCompanionWindow`,
+   * which drops the remembered spot for exactly that reason.
+   */
+  end: (): void => {
+    dictation = null;
+    const parked = parkedOrigin;
+    parkedOrigin = null;
+    if (parked !== null) {
+      moveCanvasTo(parked);
+    }
+    pushState();
+  },
 };
 
 /**
@@ -624,6 +783,12 @@ export const openCompanionWindow = (): void => {
 
 const closeCompanionWindow = (): void => {
   getFloatingWindow(COMPANION_KIND)?.close();
+  // The remembered spot belongs to the window that is going away. A session
+  // running through a close and reopen would otherwise end by moving the new
+  // window to where the old one happened to sit, undoing the position it just
+  // computed for the display the cursor is actually on.
+  parkedOrigin = null;
+  dictation = null;
 };
 
 /**

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -54,6 +54,27 @@ export const shouldShowCompanionSurface = (
 ): boolean => enabled && !hidden;
 
 /**
+ * Whether the surface may take a dictation session, rather than leaving it to
+ * the top-center overlay.
+ *
+ * **An open composer declines the session.** Taking one suppresses the overlay,
+ * and this surface can only draw one thing at a time: the composer holds a
+ * half-typed message of the user's that closing would throw away, so a hosted
+ * session would have nowhere to appear and the user would dictate with no
+ * transcription and no stop control anywhere on screen. Declining leaves the
+ * draft alone and puts the session on the overlay, which is exactly the
+ * fallback it exists to be.
+ *
+ * A session cannot be overtaken by a composer opened later: while one is
+ * running the pill draws the dictation body, so the Type control that opens the
+ * composer is not on screen to press.
+ */
+export const canHostDictation = (
+  onScreen: boolean,
+  composing: boolean,
+): boolean => onScreen && !composing;
+
+/**
  * The companion surface (LUM-3086): the assistant's avatar floating from app
  * launch, expanding on hover into a pill with the voice and type-chat options,
  * and holding that expansion for as long as a call runs. It stays on screen
@@ -199,6 +220,15 @@ let dictation: DictationOverlayState | null = null;
  * must not be a way to quietly lose that.
  */
 let parkedOrigin: Origin | null = null;
+
+/**
+ * Whether the surface's composer is open, as its renderer last reported.
+ *
+ * Tracked because it decides more than the keyboard: a surface with a draft in
+ * it declines a dictation session rather than covering the draft or swallowing
+ * the session. See {@link canHostDictation}.
+ */
+let composing = false;
 
 /**
  * The state the renderer sees, rebuilt on demand.
@@ -415,8 +445,9 @@ const moveCanvasTo = (origin: Origin): void => {
  * one place on screen.
  */
 export const companionDictationHost = {
-  /** Whether the surface is on screen to be handed a session at all. */
-  canHost: (): boolean => getFloatingWindow(COMPANION_KIND) !== null,
+  /** Whether the surface will take a session. See {@link canHostDictation}. */
+  canHost: (): boolean =>
+    canHostDictation(getFloatingWindow(COMPANION_KIND) !== null, composing),
 
   /**
    * Begin: come to the cursor, and hold the spot to go back to.
@@ -609,12 +640,15 @@ export const installCompanionWindow = (): void => {
    * the instant the composer closes rather than the next time the user clicks
    * into the app they are working in.
    */
-  on("vellum:companion:setComposing", z.tuple([z.boolean()]), ([composing]) => {
+  on("vellum:companion:setComposing", z.tuple([z.boolean()]), ([next]) => {
+    // Recorded before the window check, because whether the surface will take a
+    // dictation session is a fact about the draft rather than about the window.
+    composing = next;
     const win = getFloatingWindow(COMPANION_KIND);
     if (!win || win.isDestroyed()) {
       return;
     }
-    if (composing) {
+    if (next) {
       win.setFocusable(true);
       win.focus();
       return;
@@ -789,6 +823,9 @@ const closeCompanionWindow = (): void => {
   // computed for the display the cursor is actually on.
   parkedOrigin = null;
   dictation = null;
+  // A window that is gone has no composer open in it. The renderer reports this
+  // on unmount too, but a destroyed window may never get to.
+  composing = false;
 };
 
 /**

--- a/clients/macos/src/main/dictation-overlay-window.test.ts
+++ b/clients/macos/src/main/dictation-overlay-window.test.ts
@@ -320,7 +320,7 @@ describe("createRoutedDictationDeps", () => {
     deps.showOverlay();
     deps.forwardState(RECORDING);
 
-    // Two begins, one per session — not a third from the stale `done`.
+    // Two begins, one per session, not a third from the stale `done`.
     expect(host.begin).toHaveBeenCalledTimes(2);
   });
 

--- a/clients/macos/src/main/dictation-overlay-window.test.ts
+++ b/clients/macos/src/main/dictation-overlay-window.test.ts
@@ -5,7 +5,9 @@ import {
   DONE_HIDE_MS,
   ERROR_HIDE_MS,
   createDictationOverlayController,
+  createRoutedDictationDeps,
   positionDictationOverlayInWorkArea,
+  type DictationOverlayDeps,
   type DictationOverlayState,
 } from "./dictation-overlay-window";
 
@@ -162,6 +164,129 @@ describe("createDictationOverlayController", () => {
 
     h.controller.handleMessage({ kind: "recording", transcription: "" });
     expect(h.showOverlay).toHaveBeenCalledTimes(2);
+  });
+});
+
+/**
+ * Which surface draws the session.
+ *
+ * The companion surface is the dictation HUD whenever it is on screen, and the
+ * top-center overlay is the fallback for a user who is not targeted by the flag
+ * or has hidden the surface from the tray. Both are never up at once describing
+ * the same session, which is the whole reason this routes rather than fanning
+ * out.
+ */
+describe("createRoutedDictationDeps", () => {
+  const createRouted = (canHost: () => boolean) => {
+    const base = {
+      showOverlay: mock(() => undefined),
+      hideOverlay: mock(() => undefined),
+      forwardState: mock(() => undefined),
+      setTimeout: (callback: () => void) => callback as unknown,
+      clearTimeout: () => undefined,
+    } satisfies DictationOverlayDeps;
+    const host = {
+      canHost,
+      begin: mock(() => undefined),
+      forward: mock(() => undefined),
+      end: mock(() => undefined),
+    };
+    return { base, host, deps: createRoutedDictationDeps(base, host) };
+  };
+
+  const RECORDING: DictationOverlayState = {
+    kind: "recording",
+    transcription: "hi",
+  };
+
+  test("draws on the host while it is on screen", () => {
+    const { base, host, deps } = createRouted(() => true);
+
+    deps.showOverlay();
+    deps.forwardState(RECORDING);
+    deps.hideOverlay();
+
+    expect(host.begin).toHaveBeenCalledTimes(1);
+    expect(host.forward).toHaveBeenCalledWith(RECORDING);
+    expect(host.end).toHaveBeenCalledTimes(1);
+    expect(base.showOverlay).not.toHaveBeenCalled();
+    expect(base.forwardState).not.toHaveBeenCalled();
+    expect(base.hideOverlay).not.toHaveBeenCalled();
+  });
+
+  test("falls back to the overlay when the host is not on screen", () => {
+    const { base, host, deps } = createRouted(() => false);
+
+    deps.showOverlay();
+    deps.forwardState(RECORDING);
+    deps.hideOverlay();
+
+    expect(base.showOverlay).toHaveBeenCalledTimes(1);
+    expect(base.forwardState).toHaveBeenCalledWith(RECORDING);
+    expect(base.hideOverlay).toHaveBeenCalledTimes(1);
+    expect(host.begin).not.toHaveBeenCalled();
+  });
+
+  test("with no host at all, everything goes to the overlay", () => {
+    const base = {
+      showOverlay: mock(() => undefined),
+      hideOverlay: mock(() => undefined),
+      forwardState: mock(() => undefined),
+      setTimeout: (callback: () => void) => callback as unknown,
+      clearTimeout: () => undefined,
+    } satisfies DictationOverlayDeps;
+    const deps = createRoutedDictationDeps(base, undefined);
+
+    deps.showOverlay();
+    deps.hideOverlay();
+
+    expect(base.showOverlay).toHaveBeenCalledTimes(1);
+    expect(base.hideOverlay).toHaveBeenCalledTimes(1);
+  });
+
+  // The two cases the latch exists for. A surface that appears or disappears
+  // mid-session must not split it across both windows, which would leave
+  // whichever one never got its end sitting there for good.
+  test("a host that disappears mid-session still finishes the session", () => {
+    let onScreen = true;
+    const { base, host, deps } = createRouted(() => onScreen);
+
+    deps.showOverlay();
+    onScreen = false;
+    deps.forwardState(RECORDING);
+    deps.hideOverlay();
+
+    expect(host.forward).toHaveBeenCalledWith(RECORDING);
+    expect(host.end).toHaveBeenCalledTimes(1);
+    expect(base.hideOverlay).not.toHaveBeenCalled();
+  });
+
+  test("a host that appears mid-session does not steal the running one", () => {
+    let onScreen = false;
+    const { base, host, deps } = createRouted(() => onScreen);
+
+    deps.showOverlay();
+    onScreen = true;
+    deps.forwardState(RECORDING);
+    deps.hideOverlay();
+
+    expect(base.forwardState).toHaveBeenCalledWith(RECORDING);
+    expect(base.hideOverlay).toHaveBeenCalledTimes(1);
+    expect(host.begin).not.toHaveBeenCalled();
+    expect(host.end).not.toHaveBeenCalled();
+  });
+
+  test("the next session re-decides", () => {
+    let onScreen = false;
+    const { base, host, deps } = createRouted(() => onScreen);
+
+    deps.showOverlay();
+    deps.hideOverlay();
+    onScreen = true;
+    deps.showOverlay();
+
+    expect(base.showOverlay).toHaveBeenCalledTimes(1);
+    expect(host.begin).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/clients/macos/src/main/dictation-overlay-window.test.ts
+++ b/clients/macos/src/main/dictation-overlay-window.test.ts
@@ -276,6 +276,54 @@ describe("createRoutedDictationDeps", () => {
     expect(host.end).not.toHaveBeenCalled();
   });
 
+  // The controller keeps a session visible while a terminal state lingers and
+  // folds a new recording into it, so `showOverlay` never fires a second time.
+  // A window pinned top-center does not care; one that comes to the cursor
+  // would otherwise draw the second dictation wherever the first one happened.
+  test("a recording during the done linger snaps again", () => {
+    const { host, deps } = createRouted(() => true);
+
+    deps.showOverlay();
+    deps.forwardState({ kind: "done" });
+    deps.forwardState(RECORDING);
+
+    expect(host.begin).toHaveBeenCalledTimes(2);
+  });
+
+  test("a recording during the error linger snaps again", () => {
+    const { host, deps } = createRouted(() => true);
+
+    deps.showOverlay();
+    deps.forwardState({ kind: "error", message: "Microphone unavailable" });
+    deps.forwardState(RECORDING);
+
+    expect(host.begin).toHaveBeenCalledTimes(2);
+  });
+
+  test("states within one dictation do not snap again", () => {
+    const { host, deps } = createRouted(() => true);
+
+    deps.showOverlay();
+    deps.forwardState(RECORDING);
+    deps.forwardState({ kind: "recording", transcription: "more words" });
+    deps.forwardState({ kind: "processing" });
+
+    expect(host.begin).toHaveBeenCalledTimes(1);
+  });
+
+  test("the terminal marker does not survive into the next session", () => {
+    const { host, deps } = createRouted(() => true);
+
+    deps.showOverlay();
+    deps.forwardState({ kind: "done" });
+    deps.hideOverlay();
+    deps.showOverlay();
+    deps.forwardState(RECORDING);
+
+    // Two begins, one per session — not a third from the stale `done`.
+    expect(host.begin).toHaveBeenCalledTimes(2);
+  });
+
   test("the next session re-decides", () => {
     let onScreen = false;
     const { base, host, deps } = createRouted(() => onScreen);

--- a/clients/macos/src/main/dictation-overlay-window.ts
+++ b/clients/macos/src/main/dictation-overlay-window.ts
@@ -171,11 +171,16 @@ export const createRoutedDictationDeps = (
   host: DictationHost | undefined,
 ): DictationOverlayDeps => {
   let routedToHost = false;
+  // Whether the last state drawn ended a dictation, which is what makes the
+  // next `recording` a new one rather than a continuation. See the re-begin
+  // below.
+  let settled = false;
 
   return {
     ...base,
     showOverlay: () => {
       routedToHost = host?.canHost() === true;
+      settled = false;
       if (routedToHost) {
         host?.begin();
         return;
@@ -184,12 +189,28 @@ export const createRoutedDictationDeps = (
     },
     forwardState: (state) => {
       if (routedToHost) {
+        // **A recording that interrupts a terminal state is a fresh begin.**
+        // The controller keeps a session visible while `done` or `error`
+        // lingers and folds a new recording into it, so `showOverlay` is not
+        // called a second time. For a window that only has to stay put that is
+        // exactly right; for one that comes to the cursor it means the second
+        // dictation is drawn wherever the first one was. The error linger is
+        // three seconds, which is precisely when a user retries somewhere else.
+        //
+        // `begin` is safe to call again: it keeps the parked spot it already
+        // recorded (see `parkedOriginForSnap`), so the surface still returns to
+        // where the user left it rather than to the previous cursor.
+        if (settled && state.kind === "recording") {
+          host?.begin();
+        }
+        settled = state.kind === "done" || state.kind === "error";
         host?.forward(state);
         return;
       }
       base.forwardState(state);
     },
     hideOverlay: () => {
+      settled = false;
       if (routedToHost) {
         routedToHost = false;
         host?.end();

--- a/clients/macos/src/main/dictation-overlay-window.ts
+++ b/clients/macos/src/main/dictation-overlay-window.ts
@@ -134,6 +134,72 @@ export const createDictationOverlayController = (
   return { handleMessage };
 };
 
+/**
+ * A surface that can draw a dictation session in the overlay's place.
+ *
+ * Structural rather than an import of the companion surface's own module: this
+ * one is loaded by the overlay's unit tests, and the companion window reaches
+ * `main-window.ts`, which cannot resolve off-Electron. The real implementation
+ * is `companionDictationHost`, injected from `index.ts`.
+ */
+export interface DictationHost {
+  /** Whether this surface is on screen to take a session right now. */
+  canHost: () => boolean;
+  /** A session is beginning. */
+  begin: () => void;
+  /** Draw a state. */
+  forward: (state: DictationOverlayState) => void;
+  /** The session is over. */
+  end: () => void;
+}
+
+/**
+ * The overlay's deps, routed to whichever surface should draw the session.
+ *
+ * A decorator over the deps rather than a branch inside the state machine: the
+ * rules about when a session begins, how long a terminal state lingers and what
+ * a `dismiss` may cut short are the same wherever it is drawn, and a second
+ * copy of them is how the two surfaces would come to disagree.
+ *
+ * **The target is latched when the session begins.** Deciding per call would
+ * let a surface appearing or disappearing mid-session split it across both:
+ * shown on one and hidden on the other, which strands whichever surface never
+ * got its end. The window that took the session is the window that finishes it.
+ */
+export const createRoutedDictationDeps = (
+  base: DictationOverlayDeps,
+  host: DictationHost | undefined,
+): DictationOverlayDeps => {
+  let routedToHost = false;
+
+  return {
+    ...base,
+    showOverlay: () => {
+      routedToHost = host?.canHost() === true;
+      if (routedToHost) {
+        host?.begin();
+        return;
+      }
+      base.showOverlay();
+    },
+    forwardState: (state) => {
+      if (routedToHost) {
+        host?.forward(state);
+        return;
+      }
+      base.forwardState(state);
+    },
+    hideOverlay: () => {
+      if (routedToHost) {
+        routedToHost = false;
+        host?.end();
+        return;
+      }
+      base.hideOverlay();
+    },
+  };
+};
+
 // ---------------------------------------------------------------------------
 // Window plumbing
 // ---------------------------------------------------------------------------
@@ -236,19 +302,30 @@ export const installDictationOverlay = (
      * recording even when the overlay itself is suppressed.
      */
     onRecordingLifecycle?: (recording: boolean) => void;
+    /**
+     * A surface that draws the session in this overlay's place while it is on
+     * screen, which is what the companion surface does. Injected rather than
+     * imported: see {@link DictationHost}.
+     */
+    host?: DictationHost;
   } = {},
 ): void => {
   if (installed) return;
   installed = true;
 
-  const controller = createDictationOverlayController({
-    showOverlay,
-    hideOverlay,
-    forwardState: sendState,
-    setTimeout,
-    clearTimeout: (handle) =>
-      clearTimeout(handle as ReturnType<typeof setTimeout>),
-  });
+  const controller = createDictationOverlayController(
+    createRoutedDictationDeps(
+      {
+        showOverlay,
+        hideOverlay,
+        forwardState: sendState,
+        setTimeout,
+        clearTimeout: (handle) =>
+          clearTimeout(handle as ReturnType<typeof setTimeout>),
+      },
+      options.host,
+    ),
+  );
 
   on(
     "vellum:dictationOverlay:setState",

--- a/clients/macos/src/main/index.ts
+++ b/clients/macos/src/main/index.ts
@@ -95,6 +95,7 @@ import { installPermissionsService } from "./permissions-service";
 import { installPowerEvents } from "./power-events";
 import { installIdentityIpc } from "./identity";
 import {
+  companionDictationHost,
   installCompanionWindow,
   syncCompanionSurface,
 } from "./companion-window";
@@ -481,7 +482,13 @@ app
     installCommandPaletteWindow();
     installApplicationMenu();
     installQuickInput();
-    installDictationOverlay({ onRecordingLifecycle: setDictationRecording });
+    // The companion surface draws the session instead whenever it is on
+    // screen, which leaves the top-center overlay as the fallback for a user
+    // who is not targeted by the flag or has hidden the surface from the tray.
+    installDictationOverlay({
+      onRecordingLifecycle: setDictationRecording,
+      host: companionDictationHost,
+    });
     installCompanionWindow();
     installPopoutWindows();
     installGlobalShortcuts();

--- a/clients/web/src/components/companion-surface-page.tsx
+++ b/clients/web/src/components/companion-surface-page.tsx
@@ -107,7 +107,13 @@ export function CompanionSurfacePage() {
       );
       setCharacter(state.character);
       setCall(state.call);
-      setDictation(state.dictation);
+      // `?? null` despite the contract naming this field required: a shell that
+      // predates it sends a payload without it, and the phase below asks
+      // `!== null`, so an absent field would read as a running session and park
+      // a recording pill on the surface that nothing can clear. The same skew
+      // contract the runtime wrapper describes, at the one read that can be
+      // wrong about it.
+      setDictation(state.dictation ?? null);
       setTurns(state.turns);
       setAssistantName(state.assistantName);
     };

--- a/clients/web/src/components/companion-surface-page.tsx
+++ b/clients/web/src/components/companion-surface-page.tsx
@@ -235,6 +235,13 @@ export function CompanionSurfacePage() {
   // by itself in seconds, and the surface came to the cursor to show it: an
   // avatar that moved across the screen and then drew something else entirely
   // would be the wrong half of what just happened.
+  //
+  // **The composer still outranks dictation, and cannot hide one.** A session
+  // is never handed to this surface while the composer is open
+  // (`canHostDictation` in `companion-window.ts`) — it goes to the top-center
+  // overlay instead, so the draft survives and the recording is still visible
+  // somewhere. And once a session is running the pill draws the dictation body,
+  // so there is no Type control on screen to open a composer over it.
   const phase: CompanionSurfacePhase = typing
     ? "typing"
     : dictation !== null

--- a/clients/web/src/components/companion-surface-page.tsx
+++ b/clients/web/src/components/companion-surface-page.tsx
@@ -238,7 +238,7 @@ export function CompanionSurfacePage() {
   //
   // **The composer still outranks dictation, and cannot hide one.** A session
   // is never handed to this surface while the composer is open
-  // (`canHostDictation` in `companion-window.ts`) — it goes to the top-center
+  // (`canHostDictation` in `companion-window.ts`). It goes to the top-center
   // overlay instead, so the draft survives and the recording is still visible
   // somewhere. And once a session is running the pill draws the dictation body,
   // so there is no Type control on screen to open a composer over it.

--- a/clients/web/src/components/companion-surface-page.tsx
+++ b/clients/web/src/components/companion-surface-page.tsx
@@ -15,11 +15,13 @@ import {
   subscribeCompanionState,
 } from "@/runtime/companion-surface";
 import { sendVoiceActivityControl } from "@/runtime/desktop-voice-activity";
+import { requestDictationOverlayStop } from "@/runtime/dictation-overlay";
 import type {
   CompanionCharacter,
   CompanionGrowth,
   CompanionSurfaceState,
   CompanionTurn,
+  DictationOverlayState,
   VoiceActivityState,
 } from "@vellumai/ipc-contract";
 
@@ -58,6 +60,13 @@ export function CompanionSurfacePage() {
   const [avatarSrc, setAvatarSrc] = useState<string | undefined>();
   const [character, setCharacter] = useState<CompanionCharacter | undefined>();
   const [call, setCall] = useState<VoiceActivityState | null>(null);
+  // The dictation session this surface is hosting in the top-center overlay's
+  // place, or null when none is. Pushed from main with the rest of the state,
+  // for the same reason the call is: the session is owned by the renderer doing
+  // the recording, not by this window.
+  const [dictation, setDictation] = useState<DictationOverlayState | null>(
+    null,
+  );
   const [turns, setTurns] = useState<CompanionTurn[]>([]);
   // Empty until the app's window publishes one, which the surface covers with
   // the component's own fallback wording rather than drawing a blank name.
@@ -98,6 +107,7 @@ export function CompanionSurfacePage() {
       );
       setCharacter(state.character);
       setCall(state.call);
+      setDictation(state.dictation);
       setTurns(state.turns);
       setAssistantName(state.assistantName);
     };
@@ -209,23 +219,31 @@ export function CompanionSurfacePage() {
     setInteractive(inside);
   };
 
-  // **An open composer outranks everything, and a running call outranks the
+  // **An open composer outranks everything, and a live microphone outranks the
   // pointer.** The surface is otherwise a circle that only becomes a pill while
   // it is being pointed at, and a live microphone that hides itself the moment
-  // the pointer leaves is a live microphone the user cannot see. So the call
+  // the pointer leaves is a live microphone the user cannot see. So a session
   // holds the pill open, and hovering it changes nothing: the controls it wants
   // are already there.
   //
   // The composer sits above even that, because it is the one state holding
   // something of the user's. A call starting from the app while a sentence is
   // half-typed must not collapse the card and take the sentence with it.
+  //
+  // **Dictation outranks a call**, on the rare occasion both are somehow live.
+  // It is the one the user started a moment ago by holding a key down, it ends
+  // by itself in seconds, and the surface came to the cursor to show it: an
+  // avatar that moved across the screen and then drew something else entirely
+  // would be the wrong half of what just happened.
   const phase: CompanionSurfacePhase = typing
     ? "typing"
-    : call !== null
-      ? "call"
-      : hovered
-        ? "hover"
-        : "resting";
+    : dictation !== null
+      ? "dictating"
+      : call !== null
+        ? "call"
+        : hovered
+          ? "hover"
+          : "resting";
 
   // The avatar's own colour, which arrives with the session. It is `""` until
   // the avatar resolves and the contract makes no promise it parses, so
@@ -274,6 +292,12 @@ export function CompanionSurfacePage() {
         // before the app's window has published one.
         assistantName={assistantName === "" ? undefined : assistantName}
         call={call ?? undefined}
+        dictation={dictation ?? undefined}
+        // Out to main and broadcast, which is how the overlay's own stop
+        // control asks: this page does not know which renderer is holding the
+        // recording, and the one that is has a listener up for exactly as long
+        // as it does.
+        onStopDictation={requestDictationOverlayStop}
         rootRef={pillRef}
         onSurfaceMouseDown={(event) => {
           dragRef.current = { x: event.screenX, y: event.screenY };

--- a/clients/web/src/components/companion-surface.stories.tsx
+++ b/clients/web/src/components/companion-surface.stories.tsx
@@ -79,7 +79,7 @@ const meta: Meta<StoryArgs> = {
   argTypes: {
     phase: {
       control: "inline-radio",
-      options: ["resting", "hover", "call", "typing"],
+      options: ["resting", "hover", "call", "dictating", "typing"],
     },
     backdrop: {
       control: "inline-radio",
@@ -214,6 +214,55 @@ export const InCallMuted: Story = {
  */
 export const OnALightDesktop: Story = {
   args: { phase: "call", backdrop: "light" },
+};
+
+/**
+ * Dictating: the surface standing in for the top-center dictation overlay,
+ * having come to the cursor to do it.
+ *
+ * The words run past the room the pill gives them here on purpose. The line is
+ * anchored to its end, so what falls off is the beginning: a speaker checking
+ * the surface mid-sentence is checking that the words just said arrived, not
+ * re-reading the ones from ten seconds ago.
+ */
+export const Dictating: Story = {
+  args: {
+    phase: "dictating",
+    dictation: {
+      kind: "recording",
+      transcription:
+        "let's move the review to thursday afternoon if that still works for everyone",
+    },
+  },
+};
+
+/** The first moment of a session, before any words have been heard. */
+export const DictatingSilent: Story = {
+  args: {
+    phase: "dictating",
+    dictation: { kind: "recording", transcription: "" },
+  },
+};
+
+/**
+ * The key released: the stop control goes with it, because there is no longer
+ * anything to stop, and the mascot takes over as the thing showing work.
+ */
+export const DictatingProcessing: Story = {
+  args: { phase: "dictating", dictation: { kind: "processing" } },
+};
+
+/**
+ * A session that failed, carrying the reason.
+ *
+ * The message is the overlay's own wording passed straight through, so the two
+ * surfaces never explain the same failure differently.
+ */
+export const DictatingError: Story = {
+  args: {
+    phase: "dictating",
+    dictation: { kind: "error", message: "Microphone unavailable" },
+  },
 };
 
 /**

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -5,6 +5,7 @@ import {
   Keyboard,
   Mic,
   MicOff,
+  StopCircle,
   Volume2,
   VolumeX,
   X,
@@ -20,6 +21,7 @@ import type {
 import type {
   CompanionCharacter,
   CompanionTurn,
+  DictationOverlayState,
   VoiceActivityControlAction,
   VoiceActivityState,
 } from "@vellumai/ipc-contract";
@@ -75,6 +77,13 @@ export type CompanionSurfacePhase =
   | "resting"
   | "hover"
   | "call"
+  /**
+   * Dictating: the surface is standing in for the top-center dictation
+   * overlay, having come to the cursor to do it. The pill holds open for the
+   * session the way it does for a call, and for the same reason: a live
+   * microphone that only shows itself on hover is one the user cannot see.
+   */
+  | "dictating"
   /**
    * Typing: the pill becomes a card carrying a condensed read of the
    * conversation and somewhere to answer it. The only phase that grows
@@ -154,8 +163,21 @@ const FALLBACK_WIDTHS: Record<CompanionSurfacePhase, number> = {
   resting: AVATAR_BOX,
   hover: 188,
   call: 296,
+  dictating: 296,
   typing: 360,
 };
+
+/**
+ * How much room the live transcription may take before it starts scrolling
+ * itself.
+ *
+ * The pill measures its own body, so an uncapped line would widen the surface
+ * with every word until it ran off the display. Past this the newest words push
+ * the older ones out of view instead, which is the same bargain the overlay's
+ * two-line box makes and the right one: what a speaker needs to see is that the
+ * words arriving are the words they said.
+ */
+const TRANSCRIPTION_MAX_WIDTH = 180;
 
 /**
  * The card is a fixed width, unlike the pills.
@@ -320,6 +342,22 @@ export interface CompanionSurfaceProps {
    * no-op the next push corrects.
    */
   onControl?: (action: VoiceActivityControlAction, requestId?: string) => void;
+  /**
+   * The dictation session, when `phase` is `dictating`.
+   *
+   * The overlay's own state rather than a restatement of it: this surface and
+   * the top-center overlay draw the same session, and only one of them is on
+   * screen at a time.
+   */
+  dictation?: DictationOverlayState;
+  /**
+   * Stop the recording, which is what the pill's stop control asks for.
+   *
+   * The control the top-center overlay carries, kept here because this surface
+   * replaces it: a user who reaches for the mouse to stop dictating must not
+   * find that the button moved out from under them when the HUD did.
+   */
+  onStopDictation?: () => void;
 }
 
 export function CompanionSurface({
@@ -344,6 +382,8 @@ export function CompanionSurface({
   onAvatarClick,
   call,
   onControl,
+  dictation,
+  onStopDictation,
 }: CompanionSurfaceProps) {
   const expanded = phase !== "resting";
   const typing = phase === "typing";
@@ -459,8 +499,14 @@ export function CompanionSurface({
           // The assistant's own turn. The creature stops blinking and holds a
           // focused, morphing pose, which is the same treatment the chat avatar
           // uses while a reply is streaming: one vocabulary for "it is working"
-          // wherever the user meets it.
-          busy={call !== undefined && ASSISTANT_TURN_PHASES.has(call.phase)}
+          // wherever the user meets it. Dictation has the same shape: the
+          // speaker's turn ends at the key, and what follows is the assistant
+          // working on what it heard.
+          busy={
+            dictation !== undefined
+              ? dictation.kind === "processing"
+              : call !== undefined && ASSISTANT_TURN_PHASES.has(call.phase)
+          }
           onMouseEnter={onHoverStart}
           onClick={onAvatarClick}
         />
@@ -489,6 +535,11 @@ export function CompanionSurface({
           >
             {phase === "call" ? (
               <CallBody call={call} onControl={onControl} />
+            ) : phase === "dictating" ? (
+              <DictationBody
+                dictation={dictation}
+                onStopDictation={onStopDictation}
+              />
             ) : (
               <IdleBody spotlight={spotlight} onTalk={onTalk} onType={onType} />
             )}
@@ -876,6 +927,99 @@ function CallBody({
       />
     </>
   );
+}
+
+/**
+ * Expanded, mid-dictation: the words as they arrive, and the way to stop.
+ *
+ * **This is the top-center overlay's content on the surface that replaced it**,
+ * so it carries the same three things that pill did: whether the session is
+ * recording, processing or finished, what has been heard so far, and a stop
+ * control. It has one line where that pill had two, which is what the
+ * transcription's treatment below is about.
+ *
+ * **The status is the mascot's job, not a glyph's.** The same choice `CallBody`
+ * makes and for the same reason: a recording dot next to a stop button is two
+ * red circles forty pixels apart meaning different things. The creature holds
+ * the state instead, and the words carry the rest.
+ */
+function DictationBody({
+  dictation,
+  onStopDictation,
+}: {
+  dictation?: DictationOverlayState;
+  onStopDictation?: () => void;
+}) {
+  // No session yet is the first frame of one, which reads better as the state
+  // the surface is about to be in than as an empty pill.
+  const state: DictationOverlayState = dictation ?? {
+    kind: "recording",
+    transcription: "",
+  };
+  const transcription =
+    state.kind === "recording" ? state.transcription.trim() : "";
+
+  return (
+    <>
+      {/* **Anchored to its end, so the newest words win.** The line grows as
+          the speaker talks and the interesting end is the one still being
+          written, so overflow is pushed off the left rather than ellipsed on
+          the right: truncating forward would freeze the pill on the opening
+          words and hide everything said since. */}
+      {transcription === "" ? (
+        <span className="ml-1 shrink-0 text-[12px] text-white/85">
+          {stateLabel(state)}
+        </span>
+      ) : (
+        <span
+          className="ml-1 flex min-w-0 justify-end overflow-hidden"
+          style={{ maxWidth: TRANSCRIPTION_MAX_WIDTH }}
+        >
+          <span className="whitespace-nowrap text-[12px] text-white/85">
+            {transcription}
+          </span>
+        </span>
+      )}
+      {/* Only while there is something to stop. A terminal state lingers a
+          beat before the surface goes back to rest, and a stop button on a
+          session that already ended is a control that does nothing. */}
+      {state.kind === "recording" && (
+        <PillButton
+          icon={<StopCircle className="size-4" strokeWidth={2} />}
+          label="Stop recording"
+          tone="negative"
+          onClick={onStopDictation}
+        />
+      )}
+    </>
+  );
+}
+
+/**
+ * What the session is doing, for the moments it has no words to show instead.
+ *
+ * Only ever drawn when there is no transcription yet: once words are arriving
+ * they say the same thing better, and the mascot is already carrying the state.
+ *
+ * **"Listening" where the overlay says "Recording…"**, which is the one place
+ * the two HUDs deliberately part. That pill is a system recording indicator and
+ * names the machine's activity; this one is an assistant with a face on it, and
+ * a creature that says it is recording you reads as surveillance where the same
+ * creature saying it is listening reads as attention. Everything else here is
+ * the overlay's wording verbatim, `error` included, so a failure is never
+ * explained two different ways.
+ */
+function stateLabel(state: DictationOverlayState): string {
+  switch (state.kind) {
+    case "recording":
+      return "Listening";
+    case "processing":
+      return "Processing…";
+    case "done":
+      return "Done";
+    case "error":
+      return state.message;
+  }
 }
 
 /**

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -390,6 +390,23 @@ export function CompanionSurface({
   const contentRef = useRef<HTMLDivElement | null>(null);
   const [contentWidth, setContentWidth] = useState<number | null>(null);
 
+  /**
+   * What the dictation body currently says, as one value to re-measure on.
+   *
+   * A dictation is the only body whose content grows while its phase holds
+   * still: the words arrive one interim at a time. The observer below catches a
+   * box that changes size, but the pill's width is derived from the measurement
+   * it produces, so a measurement that does not re-run leaves the line clipped
+   * at whatever the first frame needed. Keying on the text closes that loop
+   * without depending on which of the two mechanisms notices first.
+   */
+  const dictationBody =
+    dictation === undefined
+      ? ""
+      : dictation.kind === "recording"
+        ? dictation.transcription
+        : dictation.kind;
+
   // The body is measured while it is still clipped, so the pill knows how wide
   // to grow before it starts growing. `scrollWidth` reports the content's own
   // width regardless of how little the collapsed pill is giving it.
@@ -407,7 +424,7 @@ export function CompanionSurface({
     return () => {
       observer.disconnect();
     };
-  }, [phase]);
+  }, [phase, dictationBody]);
 
   // The avatar's 44pt box sits flush, because its image is already inset by
   // `INNER_GAP` inside it. Only the trailing end needs the gap added, since the

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -675,6 +675,17 @@ export interface CompanionSurfaceState {
    */
   call: VoiceActivityState | null;
   /**
+   * The dictation session the surface is hosting, or `null` when none is.
+   *
+   * Set while the surface is standing in for the top-center dictation overlay,
+   * which it does for as long as it is on screen: one assistant, one place, the
+   * same rule the running call follows. The states are the overlay's own
+   * ({@link DictationOverlayState}) rather than a restatement of them, because
+   * both surfaces draw the same session and a second vocabulary is how the two
+   * come to disagree about what a session is doing.
+   */
+  dictation: DictationOverlayState | null;
+  /**
    * The assistant's avatar as a base64 PNG, or `undefined` when there is none.
    *
    * Reuses the cache main already keeps for the Dock and Tray icons, which the


### PR DESCRIPTION
## Summary

- **Push-to-talk snaps the avatar to the mouse cursor** and returns it to its parked spot when the session ends. `canvasOriginForAvatarCentre` converts a cursor point to a canvas origin, clamping the *avatar* to the work area rather than the canvas, so the circle can still be summoned to a screen edge; `parkedOriginForSnap` records the spot on the first snap of a session so later states cannot overwrite it with a position the session itself caused.
- **The surface becomes the dictation HUD while it is on screen.** `CompanionSurfaceState` carries the overlay's own `DictationOverlayState` rather than a parallel type, and a new `dictating` phase renders live partials in the pill, anchored to the end of the line so the newest words win. The stop control comes across too, so a user who reaches for the mouse does not find it moved with the HUD.
- **One assistant, one place on screen.** `createRoutedDictationDeps` decorates the overlay's injected deps and latches which surface owns the session when it begins. The state machine is untouched. The top-center overlay stays as the fallback whenever the surface is flag-off or hidden from the tray.
- **No Swift, no new permissions.** The helper already pushes `hotkey.event`, `hotkey-helper.ts` already forwards it, and the overlay already emits every state a listening avatar needs. All behind the existing `companion-surface` flag.

## Original prompt

Alex wanted a Vellum-owned plugin for the new macOS companion surface: something that makes it easy to act on context from the screen, in the shape of a Wispr Flow style dictation flow but with an agent loop behind it for summarize / rewrite / etc. The concrete first slice was to jump the avatar to the cursor, initially on drag-and-release, then on copy, and finally settled on reusing the existing push-to-talk trigger so the same gesture snaps the avatar and starts voice input. Decisions taken along the way: return the surface to its home spot rather than leaving it where it landed, and use the mouse cursor rather than the text caret.

Two findings reshaped the scope. First, this slice cannot be a plugin: plugins load in the assistant daemon, which in Docker mode has no macOS access at all, while window positioning lives in Electron main. The plugin belongs to the follow-on agent loop, which is separable and does not block this. Second, `context.selectedText` already exists in the daemon dictation contract and drives a "command mode" branch in `assistant/src/runtime/routes/diagnostics-routes.ts` that no client has ever populated, so that rewrite pipeline has never actually been reachable.

## Notes for review

- **The trigger is the dictation session's lifecycle, not the raw push-to-talk keypress.** Same gesture in practice, but it pairs the snap with the return: snapping on the keypress would strand the avatar at the cursor whenever recording failed to start, since nothing would ever fire the end of a session that never began.
- **`stateLabel` deliberately says "Listening" where the overlay says "Recording…"**, and is not shared with it for that reason. Everything else, `error` included, is the overlay's wording verbatim. Documented at the function.
- **Pre-existing, not introduced here:** `pushState()` ships the whole surface state including the avatar PNG, and it now fires once per partial transcription. This is the same thing `voiceActivity:update` already does, but dictation partials are more frequent than call updates. Trimming it needs a partial-state channel, which is a larger change than this ticket.
- Unit tests cover the point→origin conversion and its clamping (including multi-display origins and a work area narrower than the avatar), the park/restore rule, and the routing latch in both directions across a mid-session surface change.