### PR TITLE
fix(gateway): address review on the plugin inbound path

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4354,6 +4354,7 @@ paths:
                             - platform
                             - a2a
                             - discord
+                            - plugin
                         ready:
                           type: boolean
                         setupStatus:
@@ -4444,6 +4445,7 @@ paths:
                     - platform
                     - a2a
                     - discord
+                    - plugin
                 includeRemote:
                   description: Include remote checks (default true)
                   type: boolean
@@ -4474,6 +4476,7 @@ paths:
                             - platform
                             - a2a
                             - discord
+                            - plugin
                         ready:
                           type: boolean
                         setupStatus:
@@ -6578,6 +6581,7 @@ paths:
               - platform
               - a2a
               - discord
+              - plugin
           description:
             Filter by origin channel. When provided, only conversations with this exact origin_channel value are
             returned. Omit to include all channels.
@@ -6714,6 +6718,7 @@ paths:
                                 - platform
                                 - a2a
                                 - discord
+                                - plugin
                             - type: "null"
                         assistantAttention:
                           type: object
@@ -7077,6 +7082,7 @@ paths:
                               - platform
                               - a2a
                               - discord
+                              - plugin
                           - type: "null"
                       assistantAttention:
                         type: object
@@ -8290,6 +8296,7 @@ paths:
                               - platform
                               - a2a
                               - discord
+                              - plugin
                           - type: "null"
                       assistantAttention:
                         type: object
@@ -21958,6 +21965,7 @@ paths:
                     - platform
                     - a2a
                     - discord
+                    - plugin
                     - scheduler
                     - watcher
                 sourceContextId:

--- a/clients/web/src/domains/channels/components/assistant-channels-list.tsx
+++ b/clients/web/src/domains/channels/components/assistant-channels-list.tsx
@@ -226,6 +226,7 @@ export function AssistantChannelsList({
       key={selectedPlugin.key}
       channel={selectedPlugin}
       assistantId={assistantId}
+      assistantDisplayName={displayName}
     />
   ) : (
     <ChannelPanel

--- a/clients/web/src/domains/channels/components/plugin-channel-panel.test.tsx
+++ b/clients/web/src/domains/channels/components/plugin-channel-panel.test.tsx
@@ -59,7 +59,11 @@ function renderPanel(sources?: unknown[]) {
   return render(
     <MemoryRouter>
       <QueryClientProvider client={queryClient}>
-        <PluginChannelPanel channel={CHANNEL} assistantId={ASSISTANT_ID} />
+        <PluginChannelPanel
+          channel={CHANNEL}
+          assistantId={ASSISTANT_ID}
+          assistantDisplayName="Ada"
+        />
       </QueryClientProvider>
     </MemoryRouter>,
   );

--- a/clients/web/src/domains/channels/components/plugin-channel-panel.tsx
+++ b/clients/web/src/domains/channels/components/plugin-channel-panel.tsx
@@ -3,11 +3,13 @@ import { useNavigate } from "react-router";
 import { Button } from "@vellumai/design-library/components/button";
 import { Tag } from "@vellumai/design-library/components/tag";
 
+import { ChannelTrustFloorSection } from "@/domains/channels/components/channel-trust-floor-section";
 import {
   useChannelIngress,
   type ChannelIngress,
   type IngressPath,
 } from "@/domains/channels/hooks/use-channel-ingress";
+import { usePluginChannelTrustFloor } from "@/domains/channels/hooks/use-plugin-channel-trust-floor";
 import { useTranslation } from "@/i18n";
 import { PluginChannelIcon } from "@/utils/channel-presentation";
 import type { PluginChannelSummary } from "@/types/channel-types";
@@ -15,14 +17,19 @@ import type { PluginChannelSummary } from "@/types/channel-types";
 export interface PluginChannelPanelProps {
   channel: PluginChannelSummary;
   assistantId: string;
+  assistantDisplayName: string;
 }
 
 /**
  * Detail panel for a channel a plugin brings.
  *
- * Two things belong here. The ingress approval, because a plugin channel's
+ * Three things belong here. The ingress approval, because a plugin channel's
  * routes are refused until a guardian grants them and this is where someone
- * would look for that. And a way through to the plugin, because the built-in
+ * would look for that. Who may message the assistant once they are open,
+ * because a plugin channel's floor seeds stricter than any other inbound
+ * channel's — strict enough that a fresh install turns away its first message —
+ * and this is the only surface a plugin channel has to make that an explicit
+ * choice rather than a wall. And a way through to the plugin, because the built-in
  * adapters each render a credential form this client knows the shape of and a
  * plugin's does not exist here: guessing one would be worse than sending the
  * guardian to the plugin, which owns its own setup surface and its own idea of
@@ -36,10 +43,12 @@ export interface PluginChannelPanelProps {
 export function PluginChannelPanel({
   channel,
   assistantId,
+  assistantDisplayName,
 }: PluginChannelPanelProps) {
   const { t } = useTranslation("channels");
   const navigate = useNavigate();
   const ingress = useChannelIngress(assistantId, channel.plugin);
+  const trustFloor = usePluginChannelTrustFloor(assistantId);
 
   return (
     <div className="flex flex-col items-center gap-3 py-10 text-center">
@@ -65,6 +74,19 @@ export function PluginChannelPanel({
       ) : null}
 
       <IngressSection channel={channel} ingress={ingress} />
+
+      {trustFloor.onChange ? (
+        <div className="w-full max-w-[420px] text-left">
+          <ChannelTrustFloorSection
+            assistantDisplayName={assistantDisplayName}
+            policy={trustFloor.policy}
+            saving={trustFloor.isSaving}
+            loading={trustFloor.isLoading}
+            error={trustFloor.isError}
+            onChange={trustFloor.onChange}
+          />
+        </div>
+      ) : null}
 
       <Button
         onClick={() => navigate(`/assistant/plugins/${channel.plugin}`)}

--- a/clients/web/src/domains/channels/hooks/use-plugin-channel-trust-floor.ts
+++ b/clients/web/src/domains/channels/hooks/use-plugin-channel-trust-floor.ts
@@ -1,0 +1,113 @@
+/**
+ * The admission floor for plugin-brought channels.
+ *
+ * Separate from {@link import("./use-channel-trust-floors.js").useChannelTrustFloors}
+ * because that one is keyed by `SetupChannelId` — the built-in adapters, each
+ * with its own row and its own panel. Every plugin channel shares the single
+ * `plugin` row instead, since the gateway has one channel id covering them all
+ * (`packages/service-contracts/src/channels.ts`), so there is no per-plugin key
+ * to hang it off and the list hook drops the row rather than mis-key it.
+ *
+ * It reads through the same generated query as the list hook, so both share one
+ * cache entry and a floor changed here is reflected there without a refetch.
+ *
+ * This exists because the floor seeds at `guardian_only`, which is stricter
+ * than any other inbound channel and strict enough that a fresh install rejects
+ * its first message. Making that an explicit choice — the wording the panel
+ * uses — requires somewhere to make it, and the plugin panel is the only
+ * surface a plugin channel has.
+ */
+
+import { useCallback, useMemo } from "react";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import {
+  assistantChannelAdmissionPolicyListOptions,
+  assistantChannelAdmissionPolicyListQueryKey,
+} from "@/generated/gateway/@tanstack/react-query.gen";
+import {
+  setChannelPolicy,
+  toChannelPolicyViews,
+} from "@/lib/channel-admission-policy/api";
+import type { AdmissionPolicy } from "@/lib/channel-admission-policy/types";
+import { useSupportsChannelTrustFloors } from "@/lib/backwards-compat/channel-trust-floors";
+import { toastOnError } from "@/utils/mutation-error";
+
+/** The one channel id every plugin channel's inbound is admitted under. */
+const PLUGIN_CHANNEL_TYPE = "plugin";
+
+export interface PluginChannelTrustFloor {
+  /** The stored floor, or `undefined` while loading or when unsupported. */
+  policy?: AdmissionPolicy;
+  /** True until the floor has loaded at least once. */
+  isLoading: boolean;
+  /** True when the floor failed to load. */
+  isError: boolean;
+  /** True while a write is in flight. */
+  isSaving: boolean;
+  /**
+   * Persist a floor, or `undefined` when this gateway has no floors at all.
+   * Absent means the control renders nowhere rather than offering a setting
+   * the gateway would refuse.
+   */
+  onChange?: (policy: AdmissionPolicy) => void;
+}
+
+export function usePluginChannelTrustFloor(
+  assistantId: string,
+): PluginChannelTrustFloor {
+  const queryClient = useQueryClient();
+  const enabled = useSupportsChannelTrustFloors();
+
+  const pathOptions = useMemo(
+    () => ({ path: { assistant_id: assistantId } }),
+    [assistantId],
+  );
+  const queryKey = useMemo(
+    () => assistantChannelAdmissionPolicyListQueryKey(pathOptions),
+    [pathOptions],
+  );
+
+  const query = useQuery({
+    ...assistantChannelAdmissionPolicyListOptions(pathOptions),
+    enabled: enabled && Boolean(assistantId),
+    select: toChannelPolicyViews,
+  });
+
+  const mutation = useMutation({
+    mutationFn: (policy: AdmissionPolicy) =>
+      setChannelPolicy(assistantId, PLUGIN_CHANNEL_TYPE, policy),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey }),
+    onError: toastOnError("Failed to save channel policy"),
+  });
+
+  const onChange = useCallback(
+    (policy: AdmissionPolicy) => {
+      mutation.mutate(policy);
+    },
+    [mutation],
+  );
+
+  if (!enabled) {
+    return {
+      policy: undefined,
+      isLoading: false,
+      isError: false,
+      isSaving: false,
+      onChange: undefined,
+    };
+  }
+
+  return {
+    policy: query.data?.find((p) => p.channelType === PLUGIN_CHANNEL_TYPE)
+      ?.policy,
+    // `isPending` stays true until the first successful fetch, so the control
+    // can hold rather than flash the default over a stored non-default floor
+    // and let it be overwritten.
+    isLoading: query.isPending,
+    isError: query.isError,
+    isSaving: mutation.isPending,
+    onChange,
+  };
+}

--- a/gateway/src/channels/ingress-inbound.ts
+++ b/gateway/src/channels/ingress-inbound.ts
@@ -154,9 +154,12 @@ export function readInboundField(
 ): string | undefined {
   let cursor: unknown = body;
   for (const segment of path.split(".")) {
-    if (cursor === null || typeof cursor !== "object") return undefined;
-    if (!Object.prototype.hasOwnProperty.call(cursor, segment))
+    if (cursor === null || typeof cursor !== "object") {
       return undefined;
+    }
+    if (!Object.prototype.hasOwnProperty.call(cursor, segment)) {
+      return undefined;
+    }
     cursor = (cursor as Record<string, unknown>)[segment];
   }
   return typeof cursor === "string" ? cursor : undefined;

--- a/gateway/src/channels/plugin-inbound.test.ts
+++ b/gateway/src/channels/plugin-inbound.test.ts
@@ -192,14 +192,33 @@ describe("readPluginInbound", () => {
     expect(result.status).toBe("invalid");
   });
 
-  it("carries none of the plugin's reply forward as raw", () => {
-    // `raw` exists so a normalizer can hand the vendor payload to a later
-    // stage. Nothing does that here, and the reply is unvalidated input that
-    // would otherwise ride into the runtime unexamined.
-    const result = read(reply({ secrets: { token: "shh" } }));
+  it("carries the vendor payload the plugin kept", () => {
+    // The gateway understands only the declared fields, so anything the vendor
+    // sent beyond them survives on `raw` or nowhere.
+    const result = read(reply({ raw: { reactions: ["heart"] } }));
 
     expect(result.status).toBe("event");
-    if (result.status !== "event") return;
-    expect(result.event.raw).toEqual({});
+    if (result.status !== "event") {
+      return;
+    }
+    expect(result.event.raw).toEqual({ reactions: ["heart"] });
+  });
+
+  it("carries nothing as raw when the plugin kept nothing", () => {
+    // `raw` means the vendor's payload. Substituting the reply envelope when
+    // the plugin sent none would quietly redefine it.
+    for (const body of [
+      reply(),
+      reply({ raw: "not an object" }),
+      reply({ raw: ["not an object either"] }),
+      reply({ raw: null }),
+    ]) {
+      const result = read(body);
+      expect(result.status).toBe("event");
+      if (result.status !== "event") {
+        continue;
+      }
+      expect(result.event.raw).toEqual({});
+    }
   });
 });

--- a/gateway/src/channels/plugin-inbound.ts
+++ b/gateway/src/channels/plugin-inbound.ts
@@ -64,6 +64,35 @@ export function pluginScopedId(plugin: string, value: string): string {
   return `${plugin}:${value}`;
 }
 
+/**
+ * The vendor payload the plugin carried forward, if it carried one.
+ *
+ * `raw` is what every other channel's normalizer keeps for a later stage to
+ * re-read — a field the mapping did not cover, a debugging question, a
+ * capability added after the fact. A plugin channel has more reason to keep it
+ * than a built-in one, not less: the gateway understands only the declared
+ * fields, so anything the vendor sent beyond them survives here or nowhere.
+ *
+ * Read as a whole object rather than through the field map, because it is not
+ * a scalar and there is nothing to map. A reply that carries no object there
+ * yields `{}` rather than the reply itself: `raw` means the vendor's payload,
+ * and substituting the envelope would quietly redefine it.
+ */
+function readRaw(body: unknown): Record<string, unknown> {
+  if (body === null || typeof body !== "object") {
+    return {};
+  }
+  const carried = (body as Record<string, unknown>).raw;
+  if (
+    carried === null ||
+    typeof carried !== "object" ||
+    Array.isArray(carried)
+  ) {
+    return {};
+  }
+  return carried as Record<string, unknown>;
+}
+
 export type PluginInboundReading =
   | { status: "event"; event: PluginInboundEvent }
   | { status: "none" }
@@ -155,11 +184,7 @@ export function readPluginInbound(
         messageId: pluginScopedId(plugin, messageId!),
         ...(chatType ? { chatType } : {}),
       },
-      // Deliberately empty. `raw` exists so a channel's normalizer can carry
-      // the vendor payload forward for a later stage to re-read; nothing does
-      // that for plugin channels, and the plugin's reply is unvalidated input
-      // that would otherwise ride along into the runtime unexamined.
-      raw: {},
+      raw: readRaw(body),
     },
   };
 }

--- a/gateway/src/channels/plugin-ingress-approvals.test.ts
+++ b/gateway/src/channels/plugin-ingress-approvals.test.ts
@@ -16,7 +16,10 @@ import {
 } from "../db/plugin-ingress-approval-store.js";
 import { pluginIngressApprovals } from "../db/schema.js";
 import { IngressInboundSchema } from "./ingress-inbound.js";
-import { PLUGIN_INGRESS_MANIFEST_RELPATH } from "./plugin-ingress.js";
+import {
+  PLUGIN_INGRESS_MANIFEST_RELPATH,
+  type IngressRoute,
+} from "./plugin-ingress.js";
 import {
   findServableRoute,
   ingressDeclarationDigest,
@@ -74,83 +77,48 @@ function writePlugin(
   );
 }
 
+/**
+ * A declared route, defaulted so each case states only what it is about.
+ *
+ * The digest takes whole `IngressRoute`s — it is computed from real
+ * declarations, and a partial shape here would let a field be added to the
+ * declaration without any of these cases noticing it is now covered.
+ */
+function route(
+  overrides: Partial<IngressRoute> & { path: string },
+): IngressRoute {
+  return {
+    kind: "http",
+    signer: "plugin",
+    handshake: "signed-headers",
+    description: "events",
+    ...overrides,
+  };
+}
+
 describe("ingressDeclarationDigest", () => {
   it("is stable across route ordering", () => {
-    const a = ingressDeclarationDigest([
-      {
-        kind: "http",
-        signer: "plugin",
-        handshake: "signed-headers",
-        path: "a",
-      },
-      {
-        kind: "http",
-        signer: "plugin",
-        handshake: "signed-headers",
-        path: "b",
-      },
-    ]);
-    const b = ingressDeclarationDigest([
-      {
-        kind: "http",
-        signer: "plugin",
-        handshake: "signed-headers",
-        path: "b",
-      },
-      {
-        kind: "http",
-        signer: "plugin",
-        handshake: "signed-headers",
-        path: "a",
-      },
-    ]);
-    expect(a).toBe(b);
+    expect(
+      ingressDeclarationDigest([route({ path: "a" }), route({ path: "b" })]),
+    ).toBe(
+      ingressDeclarationDigest([route({ path: "b" }), route({ path: "a" })]),
+    );
   });
 
   it("ignores a description reword so an approval survives it", () => {
-    const before = ingressDeclarationDigest([
-      {
-        kind: "http",
-        signer: "plugin",
-        handshake: "signed-headers" as const,
-        path: "a",
-        description: "one",
-      } as never,
-    ]);
-    const after = ingressDeclarationDigest([
-      {
-        kind: "http",
-        signer: "plugin",
-        handshake: "signed-headers" as const,
-        path: "a",
-        description: "reworded",
-      } as never,
-    ]);
-    expect(after).toBe(before);
+    expect(
+      ingressDeclarationDigest([route({ path: "a", description: "reworded" })]),
+    ).toBe(
+      ingressDeclarationDigest([route({ path: "a", description: "one" })]),
+    );
   });
 
   it("changes when the signer changes", () => {
     // Switching signer changes whose key opens the route, so an approval for
     // one must not carry over to the other.
     expect(
-      ingressDeclarationDigest([
-        {
-          kind: "http",
-          signer: "vellum",
-          handshake: "signed-headers",
-          path: "a",
-        },
-      ]),
-    ).not.toBe(
-      ingressDeclarationDigest([
-        {
-          kind: "http",
-          signer: "plugin",
-          handshake: "signed-headers",
-          path: "a",
-        },
-      ]),
-    );
+      ingressDeclarationDigest([route({ path: "a", signer: "vellum" })]),
+    ).not.toBe(ingressDeclarationDigest([route({ path: "a" })]));
   });
 
   it("keeps the digest a default-scheme route had before handshake existed", () => {
@@ -160,23 +128,11 @@ describe("ingressDeclarationDigest", () => {
     // guardian approves it again. Adding a field must not do that.
     expect(
       ingressDeclarationDigest([
-        {
-          kind: "websocket",
-          signer: "plugin",
-          handshake: "signed-headers",
-          path: "realtime",
-        },
+        route({ path: "realtime", kind: "websocket" }),
       ]),
     ).toBe("a32e2511180b489c31e147ebb926e72b");
     expect(
-      ingressDeclarationDigest([
-        {
-          kind: "http",
-          signer: "vellum",
-          handshake: "signed-headers",
-          path: "hook",
-        },
-      ]),
+      ingressDeclarationDigest([route({ path: "hook", signer: "vellum" })]),
     ).toBe("db809d978434fd3804c8faad82851069");
   });
 
@@ -186,61 +142,36 @@ describe("ingressDeclarationDigest", () => {
     // approved plugin drops back to pending on upgrade.
     expect(
       ingressDeclarationDigest([
-        {
-          kind: "http",
-          signer: "plugin",
-          handshake: "signed-headers",
-          path: "hook",
-          verification: undefined,
-        },
+        route({ path: "hook", verification: undefined }),
       ]),
-    ).toBe(
-      ingressDeclarationDigest([
-        {
-          kind: "http",
-          signer: "plugin",
-          handshake: "signed-headers",
-          path: "hook",
-        },
-      ]),
-    );
+    ).toBe(ingressDeclarationDigest([route({ path: "hook" })]));
   });
 
   it("changes when a route gains a verification descriptor", () => {
     // The descriptor decides which secret and which bytes make a delivery
     // authentic. A guardian approved a route verified one way, not any way.
-    const base = {
-      kind: "http" as const,
-      signer: "plugin" as const,
-      handshake: "signed-headers" as const,
-      path: "events-comms",
-    };
-    const declared = {
-      ...base,
-      verification: {
-        kind: "hmac" as const,
-        algorithm: "sha256" as const,
-        secret: { field: "comms_webhook_secret" },
-        signature: {
-          header: "X-Osis-Signature",
-          encoding: "hex" as const,
-          prefix: "sha256=",
-        },
-        payload: ["body" as const],
+    const verification = {
+      kind: "hmac" as const,
+      algorithm: "sha256" as const,
+      secret: { field: "comms_webhook_secret" },
+      signature: {
+        header: "X-Osis-Signature",
+        encoding: "hex" as const,
+        prefix: "sha256=",
       },
+      payload: ["body" as const],
     };
+    const declared = route({ path: "events-comms", verification });
+
     expect(ingressDeclarationDigest([declared])).not.toBe(
-      ingressDeclarationDigest([base]),
+      ingressDeclarationDigest([route({ path: "events-comms" })]),
     );
     expect(
       ingressDeclarationDigest([
-        {
-          ...declared,
-          verification: {
-            ...declared.verification,
-            secret: { field: "other_secret" },
-          },
-        },
+        route({
+          path: "events-comms",
+          verification: { ...verification, secret: { field: "other_secret" } },
+        }),
       ]),
     ).not.toBe(ingressDeclarationDigest([declared]));
   });
@@ -250,59 +181,21 @@ describe("ingressDeclarationDigest", () => {
     // approved the header scheme has not approved that.
     expect(
       ingressDeclarationDigest([
-        {
-          kind: "websocket",
-          signer: "plugin",
-          handshake: "signed-headers",
-          path: "a",
-        },
+        route({ path: "a", kind: "websocket", handshake: "signed-query" }),
       ]),
     ).not.toBe(
-      ingressDeclarationDigest([
-        {
-          kind: "websocket",
-          signer: "plugin",
-          handshake: "signed-query",
-          path: "a",
-        },
-      ]),
+      ingressDeclarationDigest([route({ path: "a", kind: "websocket" })]),
     );
   });
 
   it("changes when reach widens or a transport changes", () => {
-    const base = ingressDeclarationDigest([
-      {
-        kind: "http",
-        signer: "plugin",
-        handshake: "signed-headers",
-        path: "a",
-      },
-    ]);
+    const base = ingressDeclarationDigest([route({ path: "a" })]);
+
     expect(
-      ingressDeclarationDigest([
-        {
-          kind: "http",
-          signer: "plugin",
-          handshake: "signed-headers",
-          path: "a",
-        },
-        {
-          kind: "http",
-          signer: "plugin",
-          handshake: "signed-headers",
-          path: "b",
-        },
-      ]),
+      ingressDeclarationDigest([route({ path: "a" }), route({ path: "b" })]),
     ).not.toBe(base);
     expect(
-      ingressDeclarationDigest([
-        {
-          kind: "websocket",
-          signer: "plugin",
-          handshake: "signed-headers",
-          path: "a",
-        },
-      ]),
+      ingressDeclarationDigest([route({ path: "a", kind: "websocket" })]),
     ).not.toBe(base);
   });
 
@@ -311,44 +204,26 @@ describe("ingressDeclarationDigest", () => {
     // same grant, so the second must not begin under an approval for the first.
     expect(
       ingressDeclarationDigest([
-        {
-          kind: "http",
-          signer: "plugin",
-          handshake: "signed-headers",
-          path: "a",
-          inbound: IngressInboundSchema.parse({}),
-        },
+        route({ path: "a", inbound: IngressInboundSchema.parse({}) }),
       ]),
-    ).not.toBe(
-      ingressDeclarationDigest([
-        {
-          kind: "http",
-          signer: "plugin",
-          handshake: "signed-headers",
-          path: "a",
-        },
-      ]),
-    );
+    ).not.toBe(ingressDeclarationDigest([route({ path: "a" })]));
   });
 
   it("changes when a delivering route starts reading a field elsewhere", () => {
     // Which key the sender is read from decides who the message is from.
-    const declared = {
-      kind: "http" as const,
-      signer: "plugin" as const,
-      handshake: "signed-headers" as const,
+    const declared = route({
       path: "a",
       inbound: IngressInboundSchema.parse({}),
-    };
+    });
 
     expect(
       ingressDeclarationDigest([
-        {
-          ...declared,
+        route({
+          path: "a",
           inbound: IngressInboundSchema.parse({
             fields: { actorExternalId: "from" },
           }),
-        },
+        }),
       ]),
     ).not.toBe(ingressDeclarationDigest([declared]));
   });
@@ -357,16 +232,9 @@ describe("ingressDeclarationDigest", () => {
     // Introducing the field must not silently re-digest every unchanged
     // manifest, drop each back to pending, and 404 routes a guardian already
     // approved. This is the digest as it stood before `inbound` existed.
-    expect(
-      ingressDeclarationDigest([
-        {
-          kind: "http",
-          signer: "plugin",
-          handshake: "signed-headers",
-          path: "a",
-        },
-      ]),
-    ).toBe("45e87741e530e330a663d4c0bb493c36");
+    expect(ingressDeclarationDigest([route({ path: "a" })])).toBe(
+      "45e87741e530e330a663d4c0bb493c36",
+    );
   });
 });
 

--- a/gateway/src/channels/plugin-ingress-approvals.ts
+++ b/gateway/src/channels/plugin-ingress-approvals.ts
@@ -44,10 +44,7 @@ const log = getLogger("plugin-ingress-approvals");
  * `JSON.stringify` escapes rather than emits.
  */
 export function ingressDeclarationDigest(
-  routes: readonly Pick<
-    IngressRoute,
-    "kind" | "path" | "signer" | "handshake" | "verification" | "inbound"
-  >[],
+  routes: readonly IngressRoute[],
 ): string {
   const canonical = routes
     .map((route) => {

--- a/gateway/src/http/routes/plugin-webhook.test.ts
+++ b/gateway/src/http/routes/plugin-webhook.test.ts
@@ -1091,7 +1091,10 @@ describe("inbound delivery", () => {
     expect(handled).toHaveLength(0);
   });
 
-  it("still acknowledges the vendor when the pipeline throws", async () => {
+  it("asks the vendor to retry when the pipeline throws", async () => {
+    // A message that never reached the runtime would land on the next attempt.
+    // Acknowledging it loses a real message for the length of an outage, so
+    // this answers retryably and lets the vendor's own retry carry it.
     const { deps } = replyingWith(MESSAGE);
     const handle = createPluginWebhookHandler({
       ...deps,
@@ -1106,7 +1109,67 @@ describe("inbound delivery", () => {
       "events",
     );
 
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("30");
+  });
+
+  it("asks the vendor to retry when the forward failed", async () => {
+    // `handleInbound` reports a runtime it could not reach as `forwarded:
+    // false` rather than by throwing, so the quiet case needs the same answer
+    // as the loud one.
+    const { deps } = replyingWith(MESSAGE);
+    const handle = createPluginWebhookHandler({
+      ...deps,
+      handleInboundImpl: async () => ({ forwarded: false, rejected: false }),
+    });
+
+    const res = await handle(
+      post("/webhooks/plugins/meeting-bot/events"),
+      "meeting-bot",
+      "events",
+    );
+
+    expect(res.status).toBe(503);
+  });
+
+  it("acknowledges a message the pipeline decided against", async () => {
+    // A rejection is a decision, not a failure: the message reached the
+    // pipeline and the pipeline said no. Sending it again changes nothing.
+    const { deps } = replyingWith(MESSAGE);
+    const handle = createPluginWebhookHandler({
+      ...deps,
+      handleInboundImpl: async () => ({
+        forwarded: false,
+        rejected: true,
+        rejectionReason: "admission_no_one",
+      }),
+    });
+
+    const res = await handle(
+      post("/webhooks/plugins/meeting-bot/events"),
+      "meeting-bot",
+      "events",
+    );
+
     expect(res.status).toBe(200);
+  });
+
+  it("carries the vendor payload the plugin kept", async () => {
+    // The gateway understands only the declared fields, so anything the vendor
+    // sent beyond them survives on `raw` or nowhere.
+    const { handled, deps } = replyingWith({
+      ...MESSAGE,
+      raw: { reactions: ["heart"] },
+    });
+    const handle = createPluginWebhookHandler(deps);
+
+    await handle(
+      post("/webhooks/plugins/meeting-bot/events"),
+      "meeting-bot",
+      "events",
+    );
+
+    expect(handled[0]!.raw).toEqual({ reactions: ["heart"] });
   });
 
   it("delivers nothing from a reply the plugin itself failed", async () => {

--- a/gateway/src/http/routes/plugin-webhook.ts
+++ b/gateway/src/http/routes/plugin-webhook.ts
@@ -34,7 +34,10 @@ import {
 import { readPluginInbound } from "../../channels/plugin-inbound.js";
 import type { IngressInbound } from "../../channels/ingress-inbound.js";
 import type { IngressSigner } from "../../channels/plugin-ingress.js";
-import { handleInbound } from "../../handlers/handle-inbound.js";
+import {
+  handleInbound,
+  type InboundResult,
+} from "../../handlers/handle-inbound.js";
 import { mintServiceToken } from "../../auth/token-exchange.js";
 import type { GatewayConfig } from "../../config.js";
 import type { CredentialCache } from "../../credential-cache.js";
@@ -331,11 +334,18 @@ export function createPluginWebhookHandler(deps: PluginWebhookHandlerDeps) {
  * delivery into an event should not thereby echo the sender's message back to
  * the vendor that sent it.
  *
- * Errors here are logged and swallowed. The delivery was authentic and the
- * plugin accepted it, so a failure to interpret the reply is ours; answering
- * the vendor with a 5xx would have them retry a delivery that will fail the
- * same way, which is the retry storm the 409 on unapproved routes exists to
- * avoid.
+ * Two kinds of failure, answered differently. A reply the gateway cannot make
+ * sense of — unreadable, not JSON, half a message — fails the same way on
+ * every retry, so the vendor is acknowledged and the reason goes to the log;
+ * that is the retry storm the 409 on unapproved routes exists to avoid.
+ *
+ * A failure to *forward* is the opposite: the runtime is down, the circuit
+ * breaker is open, the message is well-formed and would land on the next
+ * attempt. Acknowledging that would lose a real message for the length of an
+ * assistant outage, so it answers 503 and lets the vendor's own retry carry
+ * the delivery. This is what `processInboundResult` does for the built-in
+ * channels; the shape differs only because the plugin's reply, not the
+ * vendor's request, is what carries the message here.
  */
 async function deliverPluginInbound(opts: {
   config: GatewayConfig;
@@ -394,30 +404,66 @@ async function deliverPluginInbound(opts: {
     return ack;
   }
 
+  let result: InboundResult;
   try {
-    const result = await handleInboundImpl(config, reading.event, {
+    result = await handleInboundImpl(config, reading.event, {
       // Which plugin, for the runtime and for anyone reading a transcript. The
       // route too: a plugin can declare several, and knowing which one a turn
       // arrived on is the difference between a provider misconfiguration and a
       // plugin bug.
       sourceMetadata: { plugin, ingressRoute: routePath },
     });
-    log.info(
-      {
-        plugin,
-        path: routePath,
-        forwarded: result.forwarded,
-        rejected: result.rejected,
-        rejectionReason: result.rejectionReason,
-      },
-      "Plugin inbound message handled",
-    );
   } catch (err) {
+    // `CircuitBreakerOpenError` reaches here by design: `handleInbound` lets it
+    // through precisely so a caller can answer retryably instead of 500ing.
     log.error(
       { err, plugin, path: routePath },
-      "Failed to handle a plugin inbound message",
+      "Plugin inbound message could not be handled",
     );
+    return retryLater();
+  }
+
+  log.info(
+    {
+      plugin,
+      path: routePath,
+      forwarded: result.forwarded,
+      rejected: result.rejected,
+      rejectionReason: result.rejectionReason,
+    },
+    "Plugin inbound message handled",
+  );
+
+  // Rejected and intercepted are decisions, not failures: the message reached
+  // the pipeline and the pipeline said no, or consumed it. Only a message that
+  // never reached the runtime is worth sending again.
+  const reachedRuntime =
+    result.forwarded ||
+    result.rejected ||
+    result.verificationIntercepted === true ||
+    result.inviteIntercepted === true;
+  if (!reachedRuntime) {
+    log.error(
+      { plugin, path: routePath },
+      "Plugin inbound message was not forwarded to the runtime",
+    );
+    return retryLater();
   }
 
   return ack;
+}
+
+/**
+ * Ask the vendor to send this delivery again.
+ *
+ * 503 with `Retry-After` rather than 500, matching what the built-in webhook
+ * handlers answer when the runtime is unreachable: a vendor reading a 500
+ * often disables the endpoint, while 503 is the one status every retry policy
+ * treats as "later, not never".
+ */
+function retryLater(): Response {
+  return Response.json(
+    { error: "Service Unavailable" },
+    { status: 503, headers: { "Retry-After": "30" } },
+  );
 }

--- a/gateway/src/verification/identity.ts
+++ b/gateway/src/verification/identity.ts
@@ -68,8 +68,12 @@ export function canonicalizeInboundIdentity(
 export type IdentityKind = "phone" | "email" | "opaque";
 
 function identityKindFor(channel: string): IdentityKind {
-  if (PHONE_CHANNELS.has(channel)) return "phone";
-  if (EMAIL_CHANNELS.has(channel)) return "email";
+  if (PHONE_CHANNELS.has(channel)) {
+    return "phone";
+  }
+  if (EMAIL_CHANNELS.has(channel)) {
+    return "email";
+  }
   return "opaque";
 }
 
@@ -89,7 +93,9 @@ export function canonicalizeIdentityAs(
   rawId: string,
 ): string | null {
   const trimmed = rawId.trim();
-  if (trimmed.length === 0) return null;
+  if (trimmed.length === 0) {
+    return null;
+  }
 
   if (kind === "phone") {
     return normalizePhoneNumber(trimmed) ?? trimmed;


### PR DESCRIPTION
## Prompt / plan

Follow-up to #40503, which merged with a red OpenAPI check and open feedback.

**The failing check.** `assistant/openapi.yaml` was stale. Adding `plugin` to the canonical channel set widens an enum the assistant's spec publishes, and only the gateway's `openapi.json` had been regenerated. Regenerated; `generate:openapi -- --check` is clean.

### Your two notes

**Carry `raw` rather than discard it.** You're right, and for the reason `raw` exists: the gateway understands only the fields the manifest declares, so anything the vendor sent beyond them survives on `raw` or nowhere — and `raw` is precisely what a later stage would re-read to answer a question the plugin's normalizer did not anticipate. Read as a whole object rather than through the field map, since it is not a scalar and there is nothing to map. A reply carrying no object there yields `{}` rather than the reply envelope: `raw` means the vendor's payload, and substituting the envelope would quietly redefine it. Paired with vellum-ai/imessage#30, which stops stripping it.

**`ingressDeclarationDigest` takes `IngressRoute[]`.** The `Pick` was there only to let tests pass partial literals, and it was worse than silly — the digest is computed from real declarations, and the narrowed parameter meant a field could be added to a declaration without any digest case noticing it was now covered. The tests get a `route()` helper instead, so each case states only the field it is about. That block is a lot shorter for it.

### Codex P1s taken

**Answer retryably when the forward fails.** A reply the gateway cannot make sense of — unreadable, not JSON, half a message — fails the same way every time, so the vendor is still acknowledged. A failure to *forward* is the opposite: the runtime is down or the circuit breaker is open, the message is well-formed, and the next attempt would land. Acknowledging that lost a real message for the length of an assistant outage. Those now answer 503 with `Retry-After`, matching what `processInboundResult` does for the built-in channels. A rejection or an intercept is a decision rather than a failure and is still acknowledged.

**Expose the plugin admission floor.** The floor seeds at `guardian_only`, so on a fresh install every sender resolves as `unknown` and the first message is turned away — and `PluginChannelPanel` rendered no trust-floor control, so the "explicit widening choice" the copy describes had nowhere to be made. It renders one now, backed by `usePluginChannelTrustFloor`. Separate from `useChannelTrustFloors` because that one is keyed by `SetupChannelId` (one row per built-in adapter) while every plugin channel shares the single `plugin` row; it reads through the same generated query, so both share one cache entry and a floor changed in either is reflected in the other.

**Braces on single-statement guards** (AGENTS.md §Control-Flow Braces), on the lines this work added. `normalizePhoneNumber`'s pre-existing one is left alone per the same section's no-retroactive-sweep rule.

## Test plan

- Full gateway suite green: `bun run test` — all 249 test files passed.
- `gateway/src/channels/plugin-inbound.test.ts`: `raw` is carried through, and a reply carrying no object there yields `{}` rather than the envelope.
- `gateway/src/http/routes/plugin-webhook.test.ts`: a throwing pipeline and a `forwarded: false` return both answer 503 with `Retry-After`; a rejection is still acknowledged; the vendor payload reaches the pipeline.
- `gateway/src/channels/plugin-ingress-approvals.test.ts`: rewritten against whole `IngressRoute`s, with both pinned pre-change digests still holding.
- `clients/web`: typecheck clean, `plugin-channel-panel.test.tsx` green. The four pre-existing `useChannelPermissionOverrides` failures under `src/domains/channels` reproduce unchanged on `main`.
- `assistant/openapi.yaml` regenerated and verified with `--check`.

## Not addressed

The outbound reply path (Codex's other P1). It is a real gap and was called out in #40503's description: a plugin channel has no `replyCallbackUrl` and no entry in the direct-delivery transport registry, so assistant replies, verification prompts, and denial notices do not reach the sender. Closing it needs a plugin transport registration seam that does not exist in the host yet, which is more than a review follow-up. Worth noting the interaction with the floor above — a guardian cannot complete a verification handshake over a channel that cannot reply, so until outbound lands the practical path on a fresh install is lowering the floor in the control this PR adds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013p1nTdvsuAtTJ7zyCSDLbx

---
_Generated by [Claude Code](https://claude.ai/code/session_013p1nTdvsuAtTJ7zyCSDLbx)_