### PR TITLE
fix(web): stop the schedule model picker outweighing the panel

### DIFF
--- a/clients/web/src/domains/schedules/components/schedule-detail-panel.test.tsx
+++ b/clients/web/src/domains/schedules/components/schedule-detail-panel.test.tsx
@@ -174,6 +174,28 @@ describe("ScheduleDetailPanel model profile", () => {
     expect(optionLabels).toEqual(["Quality", "Thrifty"]);
   });
 
+  /**
+   * The picker is the one editable value in a list of read-only facts, so it
+   * has to occupy a row the same height as theirs and put its value on their
+   * right edge. That rests on the trigger claiming no fixed height and on the
+   * negative margins cancelling its own padding; drop either and the row
+   * silently grows taller than its neighbours again.
+   */
+  test("the picker takes no more room than the facts around it", async () => {
+    renderPanel(BASE_SCHEDULE);
+    await waitFor(() => {
+      expect(profileTrigger()).toBeDefined();
+    });
+
+    const trigger = profileTrigger()!;
+    expect(trigger.className).not.toContain("h-9");
+    expect(trigger.className).toContain("py-1");
+
+    const wrapper = trigger.closest('[data-slot="select"]');
+    expect(wrapper?.className).toContain("-my-1");
+    expect(wrapper?.className).toContain("-mr-2");
+  });
+
   test("picking a profile patches that schedule with the chosen key", async () => {
     renderPanel(BASE_SCHEDULE);
     await waitFor(() => {

--- a/clients/web/src/domains/schedules/components/schedule-detail-panel.tsx
+++ b/clients/web/src/domains/schedules/components/schedule-detail-panel.tsx
@@ -179,11 +179,15 @@ function ScheduleModelProfileField({
           placeholder={t("scheduleDetail.chooseModel")}
           isSaving={profileMutation.isPending}
           // The row sits among read-only facts, so the trigger stays
-          // borderless until aimed at. The negative margin cancels its
-          // horizontal padding so the label lines up with the values above
-          // and below it rather than sitting inset from them.
+          // borderless until aimed at. The negative margins cancel the
+          // trigger's own padding, so its value lines up with the values
+          // above and below it and its row stays their height.
           variant="ghost"
-          className="-mr-2"
+          // The trigger shrink-wraps at the right edge of the row, and its
+          // menu is wider than it is, so the menu hangs from that same edge
+          // rather than growing rightwards into the panel wall.
+          menuAlign="end"
+          className="-my-1 -mr-2"
         />
       }
     />

--- a/clients/web/src/domains/schedules/components/schedule-detail-panel.tsx
+++ b/clients/web/src/domains/schedules/components/schedule-detail-panel.tsx
@@ -178,7 +178,12 @@ function ScheduleModelProfileField({
           // asks for a choice instead of rendering blank.
           placeholder={t("scheduleDetail.chooseModel")}
           isSaving={profileMutation.isPending}
-          className="min-w-[11rem]"
+          // The row sits among read-only facts, so the trigger stays
+          // borderless until aimed at. The negative margin cancels its
+          // horizontal padding so the label lines up with the values above
+          // and below it rather than sitting inset from them.
+          variant="ghost"
+          className="-mr-2"
         />
       }
     />

--- a/clients/web/src/domains/settings/components/model-profile-select.tsx
+++ b/clients/web/src/domains/settings/components/model-profile-select.tsx
@@ -4,6 +4,8 @@ import { Select } from "@vellumai/design-library/components/select";
 
 import { useProfileOptions } from "@/domains/settings/hooks/use-profile-options";
 
+import type { SelectVariant } from "@vellumai/design-library/components/select";
+
 export interface ModelProfileSelectProps {
   assistantId: string;
   value: string | null;
@@ -26,6 +28,8 @@ export interface ModelProfileSelectProps {
    * pin names a profile that has since been deleted.
    */
   placeholder?: string;
+  /** Trigger chrome. `"ghost"` suits a run of otherwise read-only rows. */
+  variant?: SelectVariant;
 }
 
 export function ModelProfileSelect({
@@ -37,6 +41,7 @@ export function ModelProfileSelect({
   className,
   includeDefaultOption = true,
   placeholder,
+  variant,
 }: ModelProfileSelectProps) {
   const options = useProfileOptions(assistantId, value)
     .filter((option) => includeDefaultOption || option.value != null)
@@ -62,6 +67,7 @@ export function ModelProfileSelect({
       disabled={disabled || isSaving}
       placeholder={placeholder}
       className={className}
+      variant={variant}
       aria-label="Model profile"
     />
   );

--- a/clients/web/src/domains/settings/components/model-profile-select.tsx
+++ b/clients/web/src/domains/settings/components/model-profile-select.tsx
@@ -4,7 +4,10 @@ import { Select } from "@vellumai/design-library/components/select";
 
 import { useProfileOptions } from "@/domains/settings/hooks/use-profile-options";
 
-import type { SelectVariant } from "@vellumai/design-library/components/select";
+import type {
+  SelectMenuAlign,
+  SelectVariant,
+} from "@vellumai/design-library/components/select";
 
 export interface ModelProfileSelectProps {
   assistantId: string;
@@ -30,6 +33,12 @@ export interface ModelProfileSelectProps {
   placeholder?: string;
   /** Trigger chrome. `"ghost"` suits a run of otherwise read-only rows. */
   variant?: SelectVariant;
+  /**
+   * Which trigger edge the menu is anchored to. Pair `"end"` with a
+   * right-aligned trigger, whose menu is usually wider than it is and would
+   * otherwise grow rightwards into the surface edge.
+   */
+  menuAlign?: SelectMenuAlign;
 }
 
 export function ModelProfileSelect({
@@ -42,6 +51,7 @@ export function ModelProfileSelect({
   includeDefaultOption = true,
   placeholder,
   variant,
+  menuAlign,
 }: ModelProfileSelectProps) {
   const options = useProfileOptions(assistantId, value)
     .filter((option) => includeDefaultOption || option.value != null)
@@ -68,6 +78,7 @@ export function ModelProfileSelect({
       placeholder={placeholder}
       className={className}
       variant={variant}
+      menuAlign={menuAlign}
       aria-label="Model profile"
     />
   );

--- a/packages/design-library/src/components/select.stories.tsx
+++ b/packages/design-library/src/components/select.stories.tsx
@@ -224,6 +224,58 @@ export const Compact: Story = {
   },
 };
 
+/**
+ * The ghost trigger in the situation it exists for: one editable value in a
+ * run of read-only ones. Its row must stay the same height as its neighbours
+ * and its text must sit on their right edge, so the card reads as a list of
+ * facts until the picker is aimed at.
+ */
+export const Ghost: Story = {
+  args: { value: "apple", variant: "ghost", "aria-label": "Fruit" },
+  render: function GhostSelect(args) {
+    const [{ value }, updateArgs] = useArgs();
+    const row = "flex items-center justify-between gap-4 py-1";
+    return (
+      <div className="w-80 rounded-lg border border-[var(--border-base)] bg-[var(--surface-lift)] px-4 py-2">
+        <div className={row}>
+          <span className="text-body-medium-lighter text-[var(--content-secondary)]">
+            Cadence
+          </span>
+          <span className="text-body-medium-lighter text-[var(--content-default)]">
+            Every day at 4:00 PM
+          </span>
+        </div>
+        <div className={row}>
+          <span className="text-body-medium-lighter text-[var(--content-secondary)]">
+            Fruit
+          </span>
+          <span className="min-w-0 text-right text-body-medium-lighter text-[var(--content-default)]">
+            <Select
+              {...args}
+              value={value}
+              onChange={(next) => updateArgs({ value: next })}
+              onSelectNone={() => updateArgs({ value: null })}
+              menuAlign="end"
+              // Cancels the trigger's own padding so its text lands on the
+              // same right edge as the plain values, and its box does not
+              // make the row taller than they are.
+              className="-my-1 -mr-2"
+            />
+          </span>
+        </div>
+        <div className={row}>
+          <span className="text-body-medium-lighter text-[var(--content-secondary)]">
+            Status
+          </span>
+          <span className="text-body-medium-lighter text-[var(--content-default)]">
+            Enabled
+          </span>
+        </div>
+      </div>
+    );
+  },
+};
+
 export const InsideTransformedAncestor: Story = {
   args: { value: "apple", "aria-label": "Fruit" },
   render: function TransformedAncestorSelect(args) {

--- a/packages/design-library/src/components/select.stories.tsx
+++ b/packages/design-library/src/components/select.stories.tsx
@@ -73,6 +73,7 @@ const meta: Meta<typeof Select> = {
     placeholder: { control: "text" },
     disabled: { control: "boolean" },
     size: { control: "inline-radio", options: ["regular", "compact"] },
+    variant: { control: "inline-radio", options: ["default", "ghost"] },
     menuAlign: { control: "select", options: ["start", "end"] },
     menuMaxHeight: { control: "number" },
     menuMinWidth: { control: "number" },

--- a/packages/design-library/src/components/select.test.tsx
+++ b/packages/design-library/src/components/select.test.tsx
@@ -137,3 +137,65 @@ describe("nullable selection", () => {
     expect(attr(html, "span", "title")).toBe("Literally the token");
   });
 });
+
+describe("Select trigger chrome", () => {
+  function triggerClasses(markup: string): string {
+    return attr(markup, "button", "class") ?? "";
+  }
+
+  /**
+   * The default trigger is the path every pre-existing call site takes, and
+   * its chrome is now assembled by branching on `variant`. These are the
+   * pieces that branch, pinned so a future variant cannot quietly restyle the
+   * control that most of the app renders.
+   */
+  test("the default trigger keeps its border, fill, width and height", () => {
+    const classes = triggerClasses(
+      renderToStaticMarkup(
+        <Select
+          aria-label="Provider"
+          options={options}
+          value="anthropic"
+          onChange={() => {}}
+        />,
+      ),
+    );
+    expect(classes).toContain("w-full");
+    expect(classes).toContain("bg-[var(--field-bg)]");
+    expect(classes).toContain("border-[var(--field-border)]");
+    expect(classes).toContain("h-9");
+    expect(classes).toContain("focus:outline-none");
+    // Ghost-only chrome must not leak into the default.
+    expect(classes).not.toContain("bg-transparent");
+    expect(classes).not.toContain("outline-transparent");
+  });
+
+  /**
+   * Ghost exists to sit in a run of read-only values, which it can only do if
+   * it claims no fixed height and draws its ring outside layout. Both are load
+   * bearing: a bordered ring would keep 2px in layout and stand the row taller
+   * than its neighbours, and a fixed height would defeat the variant outright.
+   */
+  test("the ghost trigger claims no height and rings itself with an outline", () => {
+    const classes = triggerClasses(
+      renderToStaticMarkup(
+        <Select
+          aria-label="Provider"
+          variant="ghost"
+          options={options}
+          value="anthropic"
+          onChange={() => {}}
+        />,
+      ),
+    );
+    expect(classes).toContain("w-auto");
+    expect(classes).toContain("bg-transparent");
+    expect(classes).toContain("outline-transparent");
+    expect(classes).toContain("py-1");
+    expect(classes).not.toContain("h-9");
+    // A border would sit in layout and undo the height match.
+    expect(classes).not.toContain("border-[var(--field-border)]");
+    // The base rule that would erase the ghost's own focus ring.
+    expect(classes).not.toContain("focus:outline-none");
+  });
+});

--- a/packages/design-library/src/components/select.tsx
+++ b/packages/design-library/src/components/select.tsx
@@ -11,6 +11,17 @@ export type SelectMenuAlign = "start" | "end";
 
 export type SelectSize = "regular" | "compact";
 
+/**
+ * `"ghost"` shrink-wraps the trigger and drops its border and fill until the
+ * pointer or keyboard focus reaches it.
+ *
+ * Use it where the control sits in a run of read-only values (a detail panel's
+ * fact list, say) and a permanently drawn box would make the one editable row
+ * the heaviest thing on the surface. The chevron still marks it editable at
+ * rest, so the affordance survives the missing border.
+ */
+export type SelectVariant = "default" | "ghost";
+
 export interface SelectOption<T extends string> {
   /**
    * `null` marks the row meaning "no value chosen", where that is a real
@@ -48,6 +59,8 @@ export interface SelectProps<T extends string> {
   readonly disabled?: boolean;
   /** Trigger + option density. Defaults to `"regular"` (36px trigger). */
   readonly size?: SelectSize;
+  /** Trigger chrome. Defaults to `"default"` (border and fill always drawn). */
+  readonly variant?: SelectVariant;
   readonly className?: string;
   readonly style?: CSSProperties;
   readonly id?: string;
@@ -92,6 +105,17 @@ const CHEVRON_SIZE_CLASSES: Record<SelectSize, string> = {
 };
 
 /**
+ * Ghost triggers set padding but no height, so a row of them keeps whatever
+ * rhythm its container already has. A fixed height here would reintroduce the
+ * problem the variant exists to solve: one row standing taller than its
+ * read-only neighbours.
+ */
+const GHOST_TRIGGER_SIZE_CLASSES: Record<SelectSize, string> = {
+  regular: "px-2 py-1 text-body-medium-lighter",
+  compact: "px-1.5 py-0.5 text-body-small-default",
+};
+
+/**
  * Single-select control for choosing one value from a list.
  *
  * Use this when the user is picking a *value* that then shows in the trigger.
@@ -125,6 +149,7 @@ export function Select<T extends string>({
   placeholder,
   disabled = false,
   size = "regular",
+  variant = "default",
   className,
   style,
   id,
@@ -144,6 +169,7 @@ export function Select<T extends string>({
   wrapperClassName,
 }: SelectProps<T>) {
   const portalContainer = usePortalContainer();
+  const ghost = variant === "ghost";
   const reactId = useId();
   const triggerId = id ?? `select-${reactId}`;
   const invalid = Boolean(errorText);
@@ -231,7 +257,10 @@ export function Select<T extends string>({
     >
       <div
         data-slot="select"
-        className={cn("relative", className)}
+        // A ghost trigger sizes to its content, so the wrapper goes inline to
+        // shrink-wrap with it. Left block, it would stretch to the container
+        // and strand the trigger on the left of a right-aligned row.
+        className={cn("relative", ghost && "inline-flex", className)}
         style={style}
       >
         <RadixSelect.Trigger
@@ -248,11 +277,25 @@ export function Select<T extends string>({
           data-testid={dataTestId}
           data-slot="select-trigger"
           className={cn(
-            "flex w-full items-center gap-2 rounded-md border bg-[var(--field-bg)] text-left transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-60",
+            "flex items-center gap-2 rounded-md border text-left transition-colors disabled:cursor-not-allowed disabled:opacity-60",
+            // Ghost draws its own focus ring as an outline, so suppressing the
+            // UA outline here would erase it.
+            ghost || "focus:outline-none",
+            ghost
+              ? "w-auto bg-transparent hover:bg-[var(--field-bg)] data-[state=open]:bg-[var(--field-bg)]"
+              : "w-full bg-[var(--field-bg)]",
             invalid
               ? "border-[var(--system-negative-strong)] data-[state=open]:border-[var(--system-negative-strong)]"
-              : "border-[var(--field-border)] data-[state=open]:border-[var(--border-active)]",
-            TRIGGER_SIZE_CLASSES[size],
+              : ghost
+                ? // The ring is withheld until the control is aimed at, so at
+                  // rest the row reads as one of the values around it. Drawn
+                  // as an outline rather than a border because outlines sit
+                  // outside layout: the trigger keeps the height of a bare
+                  // line of text, so its row matches its read-only
+                  // neighbours and nothing shifts when the ring appears.
+                  "border-0 outline outline-1 -outline-offset-1 outline-transparent hover:outline-[var(--field-border)] focus-visible:outline-[var(--field-border)] data-[state=open]:outline-[var(--border-active)]"
+                : "border-[var(--field-border)] data-[state=open]:border-[var(--border-active)]",
+            ghost ? GHOST_TRIGGER_SIZE_CLASSES[size] : TRIGGER_SIZE_CLASSES[size],
           )}
           style={{
             color: selectedOption

--- a/packages/design-library/src/index.ts
+++ b/packages/design-library/src/index.ts
@@ -155,6 +155,7 @@ export {
   type SelectProps,
   type SelectMenuAlign,
   type SelectSize,
+  type SelectVariant,
 } from "./components/select";
 export {
   PanelItem,


### PR DESCRIPTION
## Problem

The schedule detail panel's DETAILS card is a list of read-only facts with one editable value sitting in the middle of it. That value was a full-chrome `Select`, and it showed:

- it was the **only bordered element on the panel**, so a form input outweighed the schedule's own title;
- its row stood **~9px taller** than its neighbours (35px vs 26px), breaking the label column's rhythm;
- its text was **left-aligned inside the box** while every other value is right-aligned, so the value column went ragged;
- `min-w-[11rem]` was hardcoded, leaving dead space for short profile names.

## Change

Add a `ghost` variant to the design-library `Select`. It shrink-wraps and withholds its ring until hover or keyboard focus, so at rest the row reads as one of the values around it while the chevron still marks it editable.

Two details worth review attention:

- **The ring is an `outline`, not a `border`.** Outlines sit outside layout, so the trigger keeps the height of a bare line of text. A transparent border would have kept 2px in layout and left the row taller than its neighbours; a border that appears on hover would have shifted the row on hover. This is the crux of the fix, not a style preference.
- **The wrapper goes `inline-flex` for ghost.** A block wrapper stretches to its container and strands the shrink-wrapped trigger on the left of a right-aligned row.

The schedules picker then points at the variant with `-my-1 -mr-2`, which cancels the trigger's own padding so its text lands on the same right edge as the plain values.

## Verification

Measured in Storybook rather than eyeballed:

- every row in the card is now **26px** (was 26/26/**35**/26/26);
- every value's text right edge is at the **same x** (403px), the ghost trigger included;
- hover, keyboard-focus, and open states all paint their ring with **no layout shift**;
- checked in **light and dark**; axe reports **0 violations**.

`bunx tsc --noEmit` clean in `clients/web` and `packages/design-library`; `schedule-detail-panel.test.tsx` 12 pass; `select.test.tsx` 7 pass; `select.stories.tsx` 18 story-tests pass (the new `Ghost` story is covered by the design library's storybook vitest project).

## Notes

- The `Ghost` story renders the variant in the situation it exists for (one editable value among read-only ones) so the row-height and alignment contract is visible and regression-testable.
- Not fixed here, spotted nearby: `schedule-detail-panel.tsx` renders `schedule.mode` raw, so it prints lowercase `notify` next to title-case `Enabled`. Separate change, needs i18n keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40515" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->