### PR TITLE
fix(documents): stop a document append from writing the opening twice

### DIFF
--- a/assistant/src/__tests__/document-append-idempotency.test.ts
+++ b/assistant/src/__tests__/document-append-idempotency.test.ts
@@ -1,0 +1,233 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { getDocumentById } from "../documents/document-store.js";
+import { getSqlite } from "../persistence/db-connection.js";
+import {
+  executeDocumentCreate,
+  executeDocumentUpdate,
+} from "../tools/document/document-tool.js";
+import type { ToolContext, ToolExecutionResult } from "../tools/types.js";
+import { resetDbForTesting } from "./db-test-helpers.js";
+
+const CONVERSATION_ID = "conv-current";
+
+/** Long enough to clear the store's minimum-duplicate-length floor. */
+const OPENING =
+  "Remote work reshaped the office long before anyone had a name for it.";
+
+function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    workingDir: "/tmp/project",
+    conversationId: CONVERSATION_ID,
+    trustClass: "trusted_contact",
+    executionChannel: "slack",
+    sendToClient: () => {},
+    ...overrides,
+  };
+}
+
+function parseResult<T>(result: ToolExecutionResult): T {
+  return JSON.parse(result.content) as T;
+}
+
+function bootstrapDocumentTables(): void {
+  resetDbForTesting();
+  const raw = getSqlite();
+  raw.exec(/*sql*/ `
+    DROP TABLE IF EXISTS document_conversations;
+    DROP TABLE IF EXISTS documents;
+    DROP TABLE IF EXISTS conversations;
+
+    CREATE TABLE conversations (
+      id TEXT PRIMARY KEY,
+      created_at INTEGER NOT NULL DEFAULT (strftime('%s','now') * 1000)
+    );
+
+    CREATE TABLE documents (
+      surface_id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+      title TEXT NOT NULL,
+      content TEXT NOT NULL,
+      word_count INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      workspace_path TEXT
+    );
+
+    CREATE TABLE document_conversations (
+      surface_id TEXT NOT NULL,
+      conversation_id TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      PRIMARY KEY (surface_id, conversation_id),
+      FOREIGN KEY (surface_id) REFERENCES documents(surface_id) ON DELETE CASCADE
+    );
+  `);
+  raw
+    .query(`INSERT OR IGNORE INTO conversations (id, created_at) VALUES (?, ?)`)
+    .run(CONVERSATION_ID, Date.now());
+}
+
+function seedDocument(surfaceId: string, content: string): void {
+  const now = Date.now();
+  const raw = getSqlite();
+  raw
+    .query(
+      `INSERT INTO documents (surface_id, conversation_id, title, content, word_count, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      surfaceId,
+      CONVERSATION_ID,
+      "Draft",
+      content,
+      content.split(/\s+/).filter(Boolean).length,
+      now,
+      now,
+    );
+  raw
+    .query(
+      `INSERT OR IGNORE INTO document_conversations (surface_id, conversation_id, created_at) VALUES (?, ?, ?)`,
+    )
+    .run(surfaceId, CONVERSATION_ID, now);
+}
+
+describe("document append idempotency", () => {
+  beforeEach(() => {
+    bootstrapDocumentTables();
+  });
+
+  test("an opening passed to both document_create and the first append lands once", () => {
+    const created = executeDocumentCreate(
+      { title: "Draft", initial_content: `# Draft\n\n${OPENING}` },
+      makeContext(),
+    );
+    const surfaceId = parseResult<{ surface_id: string }>(created).surface_id;
+
+    const result = executeDocumentUpdate(
+      {
+        surface_id: surfaceId,
+        content: `# Draft\n\n${OPENING}\n\nThe second paragraph carries the argument forward.`,
+        mode: "append",
+      },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(getDocumentById(surfaceId)?.content).toBe(
+      `# Draft\n\n${OPENING}\n\nThe second paragraph carries the argument forward.`,
+    );
+  });
+
+  test("an append that only restates the tail writes nothing", () => {
+    seedDocument("doc-restate", `# Draft\n\n${OPENING}`);
+
+    const result = executeDocumentUpdate(
+      { surface_id: "doc-restate", content: OPENING, mode: "append" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    const body = parseResult<{ success: boolean; message: string }>(result);
+    expect(body.success).toBe(true);
+    expect(body.message).toBe(
+      "Nothing appended: the content is already at the end of the document",
+    );
+    expect(getDocumentById("doc-restate")?.content).toBe(
+      `# Draft\n\n${OPENING}`,
+    );
+  });
+
+  test("the client is told what landed, not what was submitted", () => {
+    seedDocument("doc-client", OPENING);
+    const sent: { markdown: unknown; mode: unknown }[] = [];
+
+    executeDocumentUpdate(
+      {
+        surface_id: "doc-client",
+        content: `${OPENING}\n\nAnd then the rest.`,
+        mode: "append",
+      },
+      makeContext({
+        sendToClient: (message) => {
+          if (message.type === "document_editor_update") {
+            sent.push({ markdown: message.markdown, mode: message.mode });
+          }
+        },
+      }),
+    );
+
+    expect(sent).toEqual([{ markdown: "And then the rest.", mode: "append" }]);
+  });
+
+  // ── Legitimate repetition the guard must not eat ──────────────────
+
+  test("keeps a short repeated line, even back to back", () => {
+    seedDocument("doc-refrain", "## Checklist\n\nTODO");
+
+    executeDocumentUpdate(
+      { surface_id: "doc-refrain", content: "TODO\n\nTODO", mode: "append" },
+      makeContext(),
+    );
+
+    expect(getDocumentById("doc-refrain")?.content).toBe(
+      "## Checklist\n\nTODO\n\nTODO\n\nTODO",
+    );
+  });
+
+  test("keeps a repeated heading followed by new prose", () => {
+    seedDocument("doc-heading", "# Weekly Notes\n\n## Monday");
+
+    executeDocumentUpdate(
+      {
+        surface_id: "doc-heading",
+        content: "## Monday\n\nShipped the importer.",
+        mode: "append",
+      },
+      makeContext(),
+    );
+
+    expect(getDocumentById("doc-heading")?.content).toBe(
+      "# Weekly Notes\n\n## Monday\n\n## Monday\n\nShipped the importer.",
+    );
+  });
+
+  test("keeps a long paragraph that repeats something other than the tail", () => {
+    seedDocument("doc-midway", `${OPENING}\n\nA later paragraph ends the doc.`);
+
+    executeDocumentUpdate(
+      { surface_id: "doc-midway", content: OPENING, mode: "append" },
+      makeContext(),
+    );
+
+    expect(getDocumentById("doc-midway")?.content).toBe(
+      `${OPENING}\n\nA later paragraph ends the doc.\n\n${OPENING}`,
+    );
+  });
+
+  test("keeps content whose repetition starts partway into the append", () => {
+    seedDocument("doc-partway", `# Draft\n\n${OPENING}`);
+
+    executeDocumentUpdate(
+      {
+        surface_id: "doc-partway",
+        content: `A fresh lead-in.\n\n${OPENING}`,
+        mode: "append",
+      },
+      makeContext(),
+    );
+
+    expect(getDocumentById("doc-partway")?.content).toBe(
+      `# Draft\n\n${OPENING}\n\nA fresh lead-in.\n\n${OPENING}`,
+    );
+  });
+
+  test("replace mode is never deduplicated", () => {
+    seedDocument("doc-replace", OPENING);
+
+    executeDocumentUpdate(
+      { surface_id: "doc-replace", content: OPENING, mode: "replace" },
+      makeContext(),
+    );
+
+    expect(getDocumentById("doc-replace")?.content).toBe(OPENING);
+  });
+});

--- a/assistant/src/config/bundled-skills/document-editor/SKILL.md
+++ b/assistant/src/config/bundled-skills/document-editor/SKILL.md
@@ -33,9 +33,9 @@ Write and edit long-form documents using the built-in rich text editor. Document
 
 This is the default path when the user asks you to write something.
 
-1. **Create the document**: Call `document_create` with a title (inferred from the request). Call the tool immediately, not after conversational preamble.
+1. **Create the document**: Call `document_create` with a title (inferred from the request). Call the tool immediately, not after conversational preamble. Anything you pass as `initial_content` is saved right then, so the first `document_update` must start with the next chunk rather than repeating it.
 2. **Write content in Markdown**: Use proper structure (`#` for titles, `##` for sections), **bold**, _italic_, code blocks, tables, lists, blockquotes as appropriate.
-3. **CRITICAL - Stream content in chunks**: Call `document_update` MULTIPLE times, not just once. Break content into logical chunks (paragraphs, sections, or every 200-300 words). Call `document_update` with `mode: "append"` for EACH chunk separately. When you are streaming into the document you just created, `surface_id` is optional — omit it and pass only `content`, and the update targets that document. The user experiences real-time content appearing as you write.
+3. **CRITICAL - Stream content in chunks**: Call `document_update` MULTIPLE times, not just once. Break content into logical chunks (paragraphs, sections, or every 200-300 words). Call `document_update` with `mode: "append"` for EACH chunk separately. Each append carries ONLY that chunk: content already in the document is committed, and resending it would print it twice. When you are streaming into the document you just created, `surface_id` is optional: omit it and pass only `content`, and the update targets that document. The user experiences real-time content appearing as you write.
 
 ### Recovering from a failed update
 

--- a/assistant/src/config/bundled-skills/document-editor/TOOLS.json
+++ b/assistant/src/config/bundled-skills/document-editor/TOOLS.json
@@ -33,7 +33,7 @@
           },
           "initial_content": {
             "type": "string",
-            "description": "Initial Markdown content to populate the editor (optional)"
+            "description": "Initial Markdown content to populate the editor (optional). It is saved as soon as the document is created, so the first document_update append must start with the NEXT chunk, never with this text again."
           }
         }
       },
@@ -54,7 +54,7 @@
           },
           "content": {
             "type": "string",
-            "description": "Markdown content to set or append"
+            "description": "Markdown content to set or append. In append mode, send only the new chunk: whatever is already in the document, including document_create's initial_content, is committed and must not be resent."
           },
           "mode": {
             "type": "string",

--- a/assistant/src/documents/document-store.ts
+++ b/assistant/src/documents/document-store.ts
@@ -798,12 +798,125 @@ export function replaceInDocument(
   }
 }
 
+// ---------------------------------------------------------------------------
+// Append idempotency
+// ---------------------------------------------------------------------------
+
+/** A blank-line-delimited block of markdown, located in its source string. */
+interface MarkdownBlock {
+  /** Whitespace-trimmed block text, the unit duplicate detection compares. */
+  text: string;
+  /** Offset of the block's first character in the source string. */
+  start: number;
+}
+
+/**
+ * Split markdown into blank-line-delimited blocks, dropping empty ones but
+ * keeping each surviving block's offset so a suffix of the source can be
+ * recovered verbatim.
+ */
+function splitIntoBlocks(content: string): MarkdownBlock[] {
+  const blocks: MarkdownBlock[] = [];
+  const separator = /\n[^\S\n]*\n/g;
+  let cursor = 0;
+  let match: RegExpExecArray | null;
+  const push = (start: number, end: number): void => {
+    const text = content.slice(start, end).trim();
+    if (text.length > 0) {
+      blocks.push({ text, start });
+    }
+  };
+  while ((match = separator.exec(content)) !== null) {
+    push(cursor, match.index);
+    cursor = match.index + match[0].length;
+  }
+  push(cursor, content.length);
+  return blocks;
+}
+
+/**
+ * An append has to repeat at least this many characters of the document's tail
+ * before the repetition is treated as an accident.
+ *
+ * The floor is what keeps legitimate repetition intact. A document can honestly
+ * repeat a heading, a refrain, a table row, or a bare "TODO" back to back, and
+ * those are all short. Only a substantial restatement (an opening paragraph
+ * passed to both `document_create` and the first append) clears the bar.
+ */
+const MIN_DUPLICATE_APPEND_CHARS = 40;
+
+/**
+ * Drop a leading run of blocks from `markdown` that exactly repeats the tail of
+ * `existing`, so an append that restates content already committed does not
+ * write it a second time.
+ *
+ * The guard is deliberately narrow: the repeated run must be an exact,
+ * block-aligned match, it must sit at the very start of the append and the very
+ * end of the document, and it must be at least
+ * {@link MIN_DUPLICATE_APPEND_CHARS} long. Anything else, including the same
+ * text reappearing further down the append, is passed through untouched.
+ */
+function stripDuplicateLeadingBlocks(
+  existing: string,
+  markdown: string,
+): string {
+  const existingBlocks = splitIntoBlocks(existing);
+  const incomingBlocks = splitIntoBlocks(markdown);
+  const maxOverlap = Math.min(existingBlocks.length, incomingBlocks.length);
+
+  let overlap = 0;
+  for (let candidate = maxOverlap; candidate >= 1; candidate--) {
+    const offset = existingBlocks.length - candidate;
+    let matches = true;
+    for (let i = 0; i < candidate; i++) {
+      if (existingBlocks[offset + i].text !== incomingBlocks[i].text) {
+        matches = false;
+        break;
+      }
+    }
+    if (matches) {
+      overlap = candidate;
+      break;
+    }
+  }
+  if (overlap === 0) {
+    return markdown;
+  }
+
+  const duplicatedChars = incomingBlocks
+    .slice(0, overlap)
+    .reduce((total, block) => total + block.text.length, 0);
+  if (duplicatedChars < MIN_DUPLICATE_APPEND_CHARS) {
+    return markdown;
+  }
+
+  if (overlap === incomingBlocks.length) {
+    return "";
+  }
+  return markdown
+    .slice(incomingBlocks[overlap].start)
+    .replace(/^(?:[^\S\n]*\n)+/, "");
+}
+
+/** Outcome of a successful {@link updateDocumentContent} call. */
+export interface DocumentContentUpdated {
+  success: true;
+  /**
+   * The markdown that actually landed. Equals the submitted markdown except
+   * when an append's leading blocks duplicated the document's tail, in which
+   * case it is the remainder. Clients render this so their view matches the row.
+   */
+  appliedMarkdown: string;
+  /** True when a duplicated leading run was dropped from an append. */
+  duplicateLeadingContentSkipped: boolean;
+}
+
 /** Update persisted document content (append or replace). */
 export function updateDocumentContent(
   surfaceId: string,
   markdown: string,
   mode: string,
-): { success: true } | { success: false; error: string } {
+): DocumentContentUpdated | { success: false; error: string } {
   try {
     const existing = rawGet<{ content: string }>(
       "documents:updateDocumentContent:get",
@@ -814,9 +927,19 @@ export function updateDocumentContent(
       log.info({ surfaceId }, "No persisted document to update");
       return { success: false, error: "Document not found" };
     }
-    const sep = mode === "append" && existing.content.length > 0 ? "\n\n" : "";
-    const newContent =
-      mode === "append" ? existing.content + sep + markdown : markdown;
+    const appending = mode === "append";
+    const appliedMarkdown = appending
+      ? stripDuplicateLeadingBlocks(existing.content, markdown)
+      : markdown;
+    const duplicateLeadingContentSkipped =
+      appending && appliedMarkdown !== markdown;
+    const sep =
+      appending && existing.content.length > 0 && appliedMarkdown.length > 0
+        ? "\n\n"
+        : "";
+    const newContent = appending
+      ? existing.content + sep + appliedMarkdown
+      : appliedMarkdown;
     writeThroughToWorkspaceFile(surfaceId, newContent);
     const wordCount = countWords(newContent);
     rawRun(
@@ -827,8 +950,18 @@ export function updateDocumentContent(
       Date.now(),
       surfaceId,
     );
+    if (duplicateLeadingContentSkipped) {
+      log.info(
+        { surfaceId, skippedChars: markdown.length - appliedMarkdown.length },
+        "Skipped append content duplicating the document tail",
+      );
+    }
     log.info({ surfaceId, mode }, "Updated document content");
-    return { success: true };
+    return {
+      success: true,
+      appliedMarkdown,
+      duplicateLeadingContentSkipped,
+    };
   } catch (error) {
     log.error({ err: error, surfaceId }, "Document content update error");
     return {

--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -426,13 +426,22 @@ export function executeDocumentUpdate(
     };
   }
 
+  // The store drops append content that merely restates the document's tail,
+  // so the client renders what actually landed rather than the submission.
+  const applied = result.appliedMarkdown;
+  const message = result.duplicateLeadingContentSkipped
+    ? applied.length === 0
+      ? "Nothing appended: the content is already at the end of the document"
+      : "Document content updated (leading content already at the end of the document was skipped)"
+    : "Document content updated";
+
   // Send document_editor_update message to update the built-in RTE
   if (context.sendToClient) {
     context.sendToClient({
       type: "document_editor_update",
       conversationId: context.conversationId,
       surfaceId,
-      markdown: content,
+      markdown: applied,
       mode,
     });
 
@@ -441,7 +450,7 @@ export function executeDocumentUpdate(
         success: true,
         surface_id: surfaceId,
         mode,
-        message: "Document content updated",
+        message,
       }),
       isError: false,
     };
@@ -458,7 +467,7 @@ export function executeDocumentUpdate(
       success: true,
       surface_id: surfaceId,
       mode,
-      message: "Document content updated (no client connected to render it)",
+      message: `${message} (no client connected to render it)`,
     }),
     isError: false,
   };

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -19,7 +19,7 @@
     },
     "document-editor": {
       "docsSlug": "document",
-      "sha256": "95f34b03900851215b2bc153d5e6c92e382476fa361147f31b28d4757ed6c4d3"
+      "sha256": "2932aab14bc1050e9901f1771351ca0c6539edca2acec61ac49e2c3ac6f7b76c"
     },
     "followups": {
       "docsSlug": "followups",


### PR DESCRIPTION
## Summary

`document_create` persists `initial_content` immediately, and `updateDocumentContent` concatenates appends unconditionally. A model that passes the opening paragraph to both the create and the first `document_update` (an easy mistake, and one the document-editor skill's "stream in chunks" instruction invites) leaves the reader seeing it twice.

This adds a narrow store-level guard plus a clearer tool/skill contract.

**Store guard** (`assistant/src/documents/document-store.ts`): on `append`, `updateDocumentContent` drops a leading run of blank-line-delimited blocks from the incoming markdown when that run exactly repeats the document's current tail. `updateDocumentContent` now returns `appliedMarkdown` (what actually landed) and `duplicateLeadingContentSkipped`, and `executeDocumentUpdate` sends `appliedMarkdown` to the client so the editor and the row stay in sync rather than the client re-appending the text the store just dropped.

**Contract** (`TOOLS.json` + `SKILL.md`): `document_create.initial_content` and `document_update.content` now state that committed content must not be resent, and the skill's streaming step says each append carries only its own chunk.

## What the guard catches

An append is trimmed only when **all** of these hold:

- the mode is `append` (`replace` is never touched),
- the repeated run is **block-aligned** (blank-line-delimited) and matches **exactly** after trimming,
- the run sits at the **very start** of the append and the **very end** of the document,
- the repeated text is at least **40 characters**.

When the whole append is a restatement of the tail, nothing is written and the tool reports success with `"Nothing appended: the content is already at the end of the document"`.

## What it deliberately does not catch (content is preserved)

- **Short repetition**, back to back or otherwise: a repeated heading, a refrain, a table row, a bare `TODO`. This is the 40-character floor, and it is the main reason the guard cannot silently eat meaningful user content: the things a document honestly repeats adjacently are short.
- **Repetition anywhere other than the boundary**: the same long paragraph appearing earlier in the document, or starting partway into the append rather than at its first block.
- **Near-duplicates**: reworded, re-punctuated, or partially overlapping text passes through untouched. The match must be exact.
- **Mid-block overlap**: a duplicate that does not begin and end on a blank line is not trimmed.

The bias is deliberate. Dropping content the user wanted is worse than the duplication being fixed, so the guard is scoped to the exact failure mode and errs toward writing too much rather than too little. A duplicated *short* opening (a repeated `## Section` heading and nothing else) still slips through; the tool-description change is what covers that case.

## Deliberately left out

- No feature flag.
- No fuzzy or normalized matching (no case folding, whitespace collapsing, or similarity scoring). Every one of those widens the blast radius onto legitimate content.
- No dedupe for `replace` mode or for `document_replace_text`.
- No client-side guard. The web store's append (`prev.content + content`) also omits the `\n\n` separator the server inserts; that pre-existing divergence is untouched here.
- The five sibling document test files each carry their own near-identical `bootstrapDocumentTables` / `seedDocument` copy and the new test file follows that local convention rather than extracting a shared helper. The copies have already diverged (`document-workspace-file.test.ts` builds a different schema), so consolidating them is its own change, not a rider on a bug fix.

## Tests

`assistant/src/__tests__/document-append-idempotency.test.ts` (8 tests): the create+append duplication repro, a whole-append restatement, the client receiving the deduped markdown, plus four preservation tests (short repeated line back to back, repeated heading, long paragraph repeating something other than the tail, repetition starting partway into the append) and a `replace`-mode passthrough.

Verified the repro tests fail without the fix: reverting only the two source files turns 3 of the 8 red (the 5 preservation tests pass either way, as they should).

```
$ bun test src/__tests__/document-append-idempotency.test.ts src/__tests__/document-create-dedupe.test.ts \
    src/__tests__/document-update-default-surface.test.ts src/__tests__/document-find-replace.test.ts \
    src/__tests__/document-tool-security.test.ts src/__tests__/document-workspace-file.test.ts \
    src/__tests__/document-conversations.test.ts src/__tests__/tool-side-effects-documents.test.ts \
    src/tools/__tests__/document-tool-input-schemas.test.ts
 107 pass
 0 fail
Ran 107 tests across 9 files.

$ bunx tsc --noEmit     # clean
$ bunx eslint <changed files>   # clean
$ bunx prettier --check <changed files>   # clean
```

One unrelated pre-existing failure: `skills.test.ts > plugin-resident skills > warns when a plugin directory is missing package.json` fails when `skills.test.ts`, `checker.test.ts`, and `conversation-skill-tools.test.ts` run in one `bun test` invocation, and passes when `skills.test.ts` runs alone. Confirmed identical on the base commit (`f90146cf5f`) with the change stashed, so it is cross-file test isolation, not this branch.

Closes JARVIS-1495

🤖 Generated with [Claude Code](https://claude.com/claude-code)
