### PR TITLE
fix(voice): gate front-door verdict deltas out of the shared hub stream

### DIFF
--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -73,7 +73,11 @@ mock.module("../../persistence/conversation-crud.js", () => ({
 import { setConfig } from "../../__tests__/helpers/set-config.js";
 import { ABORT_WATCHDOG_MS } from "../../daemon/abort-watchdog.js";
 import { assistantEventHub } from "../../runtime/assistant-event-hub.js";
-import { CALL_OPENING_MARKER } from "../voice-control-protocol.js";
+import {
+  CALL_OPENING_MARKER,
+  ESCALATE_VERDICT_TOKEN,
+  HOLD_VERDICT_TOKEN,
+} from "../voice-control-protocol.js";
 import {
   cutFrontDoorContentAtVerdict,
   preSpeechLanguageRuleFragment,
@@ -1698,6 +1702,174 @@ describe("cutFrontDoorContentAtVerdict", () => {
       { type: "text", text: "It is Tuesday  indeed." },
     ]);
     expect(cut?.spokenText).toBe("It is Tuesday  indeed.");
+  });
+});
+
+/**
+ * The front-door leg's raw stream is a control plane: its leading tokens are
+ * the routing verdict, not speech. The hub broadcast (web / passive devices)
+ * must never carry those tokens, and must still carry every word of real
+ * assistant content: an over-broad filter would leave the shared transcript
+ * silent or truncated, which is worse than the leak it fixes.
+ */
+describe("front-door hub stream gate", () => {
+  beforeEach(resetCrudLog);
+
+  /**
+   * Conversation whose scripted agent loop announces a reserved row, streams
+   * `deltas` in order, then ends the leg with `finalEvent`.
+   */
+  function makeStreamingConversation(
+    deltas: string[],
+    finalEvent:
+      | "message_complete"
+      | "generation_cancelled" = "message_complete",
+  ): void {
+    const fake = makeFakeConversation({ processing: false });
+    fake.conversation.runAgentLoop = async (...args: unknown[]) => {
+      const { onEvent } = args[2] as { onEvent: (msg: unknown) => void };
+      onEvent({
+        type: "assistant_turn_start",
+        messageId: "assistant-row-1",
+        conversationId: "conv-voice-bridge-test",
+      });
+      for (const text of deltas) {
+        onEvent({
+          type: "assistant_text_delta",
+          text,
+          messageId: "assistant-row-1",
+          conversationId: "conv-voice-bridge-test",
+        });
+      }
+      onEvent({
+        type: finalEvent,
+        ...(finalEvent === "message_complete"
+          ? { messageId: "assistant-row-1" }
+          : {}),
+        conversationId: "conv-voice-bridge-test",
+      });
+    };
+    fakeConversation = fake.conversation;
+  }
+
+  /** The text of every `assistant_text_delta` `turn` publishes to the hub. */
+  async function collectBroadcastText(
+    turn: () => Promise<unknown>,
+  ): Promise<string[]> {
+    const texts: string[] = [];
+    const subscription = assistantEventHub.subscribe({
+      type: "process",
+      filter: { conversationId: "conv-voice-bridge-test" },
+      callback: (event) => {
+        const msg = event.message as { type: string; text?: string };
+        if (msg.type === "assistant_text_delta") {
+          texts.push(msg.text ?? "");
+        }
+      },
+    });
+    try {
+      await turn();
+      // The hub publishes off a promise chain, so every broadcast costs a
+      // few microtask hops before it reaches a subscriber.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await flushMicrotasks();
+    } finally {
+      subscription.dispose();
+    }
+    return texts;
+  }
+
+  test("an escalating leg broadcasts only the capped bridge, never the verdict token", async () => {
+    makeStreamingConversation([
+      "[1]",
+      " Let me check your calendar.",
+      " weak answer past the cap",
+    ]);
+
+    const texts = await collectBroadcastText(() =>
+      startVoiceTurn({ ...makeTurnOptions(), routingLeg: "front-door" }),
+    );
+
+    expect(texts).toEqual(["Let me check your calendar."]);
+    expect(texts.join("")).not.toContain(ESCALATE_VERDICT_TOKEN);
+  });
+
+  test("a front-door answer reaches the hub in full", async () => {
+    makeStreamingConversation(["It is ", "Tuesday", ", and it is sunny."]);
+
+    const texts = await collectBroadcastText(() =>
+      startVoiceTurn({ ...makeTurnOptions(), routingLeg: "front-door" }),
+    );
+
+    expect(texts.join("")).toBe("It is Tuesday, and it is sunny.");
+  });
+
+  test("an answer that merely opens with a bracket is released in full", async () => {
+    // "[" alone could still become the escalate token, so the gate holds it;
+    // the next delta disproves the token and the whole prefix must come out.
+    makeStreamingConversation(["[", "A] is the option to pick."]);
+
+    const texts = await collectBroadcastText(() =>
+      startVoiceTurn({ ...makeTurnOptions(), routingLeg: "front-door" }),
+    );
+
+    expect(texts.join("")).toBe("[A] is the option to pick.");
+  });
+
+  test("a hold verdict broadcasts nothing", async () => {
+    makeStreamingConversation([HOLD_VERDICT_TOKEN]);
+
+    const texts = await collectBroadcastText(() =>
+      startVoiceTurn({
+        ...makeTurnOptions(),
+        routingLeg: "front-door",
+        unifiedVerdict: true,
+      }),
+    );
+
+    expect(texts).toEqual([]);
+  });
+
+  test("a leg that completes mid-bridge broadcasts what it handed off with", async () => {
+    makeStreamingConversation(["[1] Let me check"]);
+
+    const texts = await collectBroadcastText(() =>
+      startVoiceTurn({ ...makeTurnOptions(), routingLeg: "front-door" }),
+    );
+
+    expect(texts).toEqual(["Let me check"]);
+  });
+
+  test("a leg cancelled mid-bridge never hands off, so it broadcasts nothing", async () => {
+    makeStreamingConversation(["[1] Let me check"], "generation_cancelled");
+
+    const texts = await collectBroadcastText(() =>
+      startVoiceTurn({ ...makeTurnOptions(), routingLeg: "front-door" }),
+    );
+
+    expect(texts).toEqual([]);
+  });
+
+  test("the escalated continuation streams to the hub untouched", async () => {
+    // The leg that produces the real answer is never gated: its deltas are
+    // assistant speech from the first token.
+    makeStreamingConversation(["Your next meeting ", "is at four."]);
+
+    const texts = await collectBroadcastText(() =>
+      startVoiceTurn({ ...makeTurnOptions(), routingLeg: "escalated" }),
+    );
+
+    expect(texts).toEqual(["Your next meeting ", "is at four."]);
+  });
+
+  test("an un-routed voice leg streams to the hub untouched", async () => {
+    makeStreamingConversation(["[1] not a verdict here"]);
+
+    const texts = await collectBroadcastText(() =>
+      startVoiceTurn(makeTurnOptions()),
+    );
+
+    expect(texts).toEqual(["[1] not a verdict here"]);
   });
 });
 

--- a/assistant/src/calls/__tests__/voice-triage-escalate.test.ts
+++ b/assistant/src/calls/__tests__/voice-triage-escalate.test.ts
@@ -4,6 +4,7 @@ import { DEEPGRAM_MULTI_LANGUAGE_CODES } from "../../providers/speech-to-text/de
 import {
   capEscalationBridge,
   classifyFrontDoorLeading,
+  createFrontDoorStreamGate,
   ESCALATE_VERDICT_TOKEN,
   escalatedContinuationRule,
   ESCALATION_CONTINUATION_CONTENT,
@@ -438,4 +439,77 @@ describe("live-voice escalation orchestration (end-to-end — TODO)", () => {
     "the escalated answer's TTS follows the bridge audio with no listening window between them",
     () => {},
   );
+});
+
+describe("createFrontDoorStreamGate", () => {
+  /** Feed `deltas` through a gate and return what it released, in order. */
+  function release(
+    deltas: string[],
+    opts?: { holdEnabled?: boolean; finish?: boolean },
+  ): string[] {
+    const gate = createFrontDoorStreamGate(opts?.holdEnabled === true);
+    const out = deltas
+      .map((delta) => gate.push(delta))
+      .filter((chunk) => chunk.length > 0);
+    if (opts?.finish !== false) {
+      const trailing = gate.finish();
+      if (trailing.length > 0) {
+        out.push(trailing);
+      }
+    }
+    return out;
+  }
+
+  test("an answer passes through delta by delta", () => {
+    expect(release(["It is ", "Tuesday."])).toEqual(["It is ", "Tuesday."]);
+  });
+
+  test("leading text held while the verdict was pending is not lost", () => {
+    expect(release(["[", "A] is the option."])).toEqual(["[A] is the option."]);
+  });
+
+  test("an escalation releases the capped bridge and nothing else", () => {
+    expect(
+      release([
+        ESCALATE_VERDICT_TOKEN,
+        " Let me check your calendar.",
+        " rambling past the cap",
+      ]),
+    ).toEqual(["Let me check your calendar."]);
+  });
+
+  test("a verdict token split across deltas still never escapes", () => {
+    expect(release(["[", "1", "] One moment.", " more"])).toEqual([
+      "One moment.",
+    ]);
+  });
+
+  test("a bridge with no terminator is released by finish", () => {
+    const gate = createFrontDoorStreamGate(false);
+    expect(gate.push("[1] Let me check")).toBe("");
+    expect(gate.finish()).toBe("Let me check");
+  });
+
+  test("a bridge is dropped when the leg never finishes (cancellation)", () => {
+    expect(release(["[1] Let me check"], { finish: false })).toEqual([]);
+  });
+
+  test("a hold verdict releases nothing", () => {
+    expect(release([HOLD_VERDICT_TOKEN], { holdEnabled: true })).toEqual([]);
+  });
+
+  test("the hold token is ordinary text on a leg that was never taught it", () => {
+    // A non-speculative leg's prompt has no hold branch, so its output must
+    // not be swallowed by a token it could only have parroted.
+    expect(release([`${HOLD_VERDICT_TOKEN} is the index.`])).toEqual([
+      `${HOLD_VERDICT_TOKEN} is the index.`,
+    ]);
+  });
+
+  test("nothing more escapes after the bridge is released", () => {
+    const gate = createFrontDoorStreamGate(false);
+    expect(gate.push("[1] One moment.")).toBe("One moment.");
+    expect(gate.push(" and a leaked continuation")).toBe("");
+    expect(gate.finish()).toBe("");
+  });
 });

--- a/assistant/src/calls/__tests__/voice-triage-escalate.test.ts
+++ b/assistant/src/calls/__tests__/voice-triage-escalate.test.ts
@@ -484,6 +484,26 @@ describe("createFrontDoorStreamGate", () => {
     ]);
   });
 
+  test("a too-short bridge releases nothing, matching the audio-only fallback", () => {
+    // Under MIN_SPOKEN_BRIDGE_CHARS the session discards the model's bridge
+    // and plays a canned fallback with no caption and no persisted row, so
+    // releasing the capped text would show words the caller never heard.
+    expect(release([ESCALATE_VERDICT_TOKEN, " ok"])).toEqual([]);
+    expect(release([ESCALATE_VERDICT_TOKEN, " ."])).toEqual([]);
+  });
+
+  test("a too-short bridge releases nothing via finish either", () => {
+    const gate = createFrontDoorStreamGate(false);
+    expect(gate.push(`${ESCALATE_VERDICT_TOKEN} ok`)).toBe("");
+    expect(gate.finish()).toBe("");
+  });
+
+  test("a bridge at the spoken threshold is still released", () => {
+    // The boundary belongs to the spoken side: the session speaks anything
+    // that is not BELOW the threshold, so the gate must release it too.
+    expect(release([ESCALATE_VERDICT_TOKEN, " Sure."])).toEqual(["Sure."]);
+  });
+
   test("a bridge with no terminator is released by finish", () => {
     const gate = createFrontDoorStreamGate(false);
     expect(gate.push("[1] Let me check")).toBe("");

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -55,6 +55,7 @@ import {
   stripInternalSpeechMarkers,
 } from "./voice-control-protocol.js";
 import {
+  createFrontDoorStreamGate,
   escalatedContinuationRule,
   ESCALATION_CONTINUATION_CONTENT,
   frontDoorCapabilityDigest,
@@ -1450,6 +1451,34 @@ export async function startVoiceTurn(
   // Set by the handle's discard(): the whole leg must leave no trace.
   let discarded = false;
 
+  // Verdict-first gate on the hub broadcast. A front-door leg's raw stream
+  // carries its routing verdict, so hub subscribers (web, passive devices)
+  // read it through the gate and see only the text the caller heard. Every
+  // other leg, including the escalated continuation that answers for real,
+  // broadcasts its deltas untouched.
+  const frontDoorStreamGate =
+    opts.routingLeg === "front-door"
+      ? createFrontDoorStreamGate(opts.unifiedVerdict === true)
+      : null;
+
+  /**
+   * Broadcast one agent-loop event to hub subscribers, holding a front-door
+   * leg's control-plane text back at the boundary rather than emitting it and
+   * repairing the transcript afterwards. Text released by the gate travels as
+   * an ordinary delta on the leg's own reserved row, so a client that renders
+   * the stream lands on the same text the teardown hygiene pass persists.
+   */
+  const broadcastLegEvent = (msg: AssistantEvent): void => {
+    if (frontDoorStreamGate === null || msg.type !== "assistant_text_delta") {
+      broadcastMessage(msg);
+      return;
+    }
+    const released = frontDoorStreamGate.push(msg.text);
+    if (released.length > 0) {
+      broadcastMessage({ ...msg, text: released });
+    }
+  };
+
   /**
    * Teardown transcript hygiene. Runs after the agent loop has fully
    * settled — including the stranded-content fold that finalizes an aborted
@@ -1477,6 +1506,12 @@ export async function startVoiceTurn(
    * the escalated leg — blocked on this turn's teardown — snapshots it, so
    * the quality model never sees the marker text either. Best-effort: a
    * hiccup here must not escalate into a turn-level failure.
+   *
+   * This pass owns the PERSISTED row, which the agent loop writes from the
+   * model's raw output regardless of what was broadcast. The live hub stream
+   * is gated separately by `broadcastLegEvent`, so the refetch this pass
+   * publishes confirms text a subscriber already holds instead of correcting
+   * it.
    */
   const finalizeVoiceLegTranscript = async (): Promise<void> => {
     if (reservedAssistantRowId == null) {
@@ -1620,7 +1655,24 @@ export async function startVoiceTurn(
           } else if (msg.type === "conversation_error") {
             lastError = msg.userMessage;
           }
-          broadcastMessage(msg);
+          if (frontDoorStreamGate !== null && msg.type === "message_complete") {
+            // A leg that completed mid-bridge (a holding phrase with no
+            // sentence terminator) still hands off and speaks what arrived,
+            // so release it ahead of the completion frame. A cancelled leg
+            // never hands off, and correspondingly never flushes.
+            const trailing = frontDoorStreamGate.finish();
+            if (trailing.length > 0) {
+              broadcastMessage({
+                type: "assistant_text_delta",
+                text: trailing,
+                ...(reservedAssistantRowId !== null
+                  ? { messageId: reservedAssistantRowId }
+                  : {}),
+                conversationId: opts.conversationId,
+              });
+            }
+          }
+          broadcastLegEvent(msg);
 
           // Forward voice-relevant events to the real-time event sink
           if (msg.type === "assistant_text_delta") {

--- a/assistant/src/calls/voice-triage-escalate.ts
+++ b/assistant/src/calls/voice-triage-escalate.ts
@@ -222,6 +222,97 @@ export function classifyFrontDoorLeading(
 }
 
 /**
+ * Verdict-first gate over a front-door leg's delta stream: given the leg's
+ * raw deltas in order, it releases only the text the caller actually hears.
+ * A front-door leg's raw stream is a control plane, not assistant speech,
+ * until its leading tokens classify, so anything downstream of the model
+ * that shows text to a person reads the stream through this gate.
+ *
+ * `push` returns the text released by that delta (empty while the gate is
+ * holding). `finish` is called when the leg completes normally and releases
+ * a bridge that stopped short of a sentence terminator. A leg that is
+ * cancelled instead spoke nothing past what `push` already released, so it
+ * simply never calls `finish`.
+ */
+export interface FrontDoorStreamGate {
+  push(deltaText: string): string;
+  finish(): string;
+}
+
+/**
+ * Build a {@link FrontDoorStreamGate}. `holdEnabled` mirrors
+ * {@link classifyFrontDoorLeading}: true only for speculative (unified
+ * front-door) legs, whose decision rule is the only one that teaches the
+ * hold token.
+ *
+ * The three verdicts release differently, matching what the caller hears:
+ *
+ * - `hold`: the leg is discarded and its row deleted, so nothing is ever
+ *   released.
+ * - `escalate`: the only spoken text is the capped holding phrase, released
+ *   in one piece once the bridge is complete (exactly what
+ *   {@link capEscalationBridge} yields, so the released text, the audio, and
+ *   the persisted row agree). The verdict token and anything streamed past
+ *   the cap are dropped.
+ * - `answer`: the leg's output IS the reply, so every delta passes through,
+ *   including the leading text held back while the verdict was pending.
+ */
+export function createFrontDoorStreamGate(
+  holdEnabled: boolean,
+): FrontDoorStreamGate {
+  let raw = "";
+  let stage: "deciding" | "answer" | "bridging" | "done" = "deciding";
+  let bridgeRaw = "";
+  let releasedChars = 0;
+
+  const releaseBridge = (): string => {
+    stage = "done";
+    return capEscalationBridge(bridgeRaw);
+  };
+
+  return {
+    push(deltaText: string): string {
+      raw += deltaText;
+      if (stage === "done") {
+        return "";
+      }
+      if (stage === "bridging") {
+        bridgeRaw += deltaText;
+        return isEscalationBridgeComplete(bridgeRaw) ? releaseBridge() : "";
+      }
+      if (stage === "deciding") {
+        const verdict = classifyFrontDoorLeading(raw.trimStart(), holdEnabled);
+        if (verdict === "pending") {
+          return "";
+        }
+        if (verdict === "hold") {
+          stage = "done";
+          return "";
+        }
+        if (verdict === "escalate") {
+          stage = "bridging";
+          bridgeRaw = raw.trimStart().slice(ESCALATE_VERDICT_TOKEN.length);
+          return isEscalationBridgeComplete(bridgeRaw) ? releaseBridge() : "";
+        }
+        stage = "answer";
+      }
+      // Answer stage: release everything not yet released, which on the
+      // transition includes the leading text the pending verdict held.
+      const chunk = raw.slice(releasedChars);
+      releasedChars = raw.length;
+      return chunk;
+    },
+    finish(): string {
+      if (stage === "bridging") {
+        return releaseBridge();
+      }
+      stage = "done";
+      return "";
+    },
+  };
+}
+
+/**
  * The escalated leg runs as its own voice turn. Rather than re-persist the
  * caller's utterance (it is already in history from the front-door leg), the
  * escalated leg is driven by this synthetic, echo-suppressed continuation

--- a/assistant/src/calls/voice-triage-escalate.ts
+++ b/assistant/src/calls/voice-triage-escalate.ts
@@ -253,7 +253,10 @@ export interface FrontDoorStreamGate {
  *   in one piece once the bridge is complete (exactly what
  *   {@link capEscalationBridge} yields, so the released text, the audio, and
  *   the persisted row agree). The verdict token and anything streamed past
- *   the cap are dropped.
+ *   the cap are dropped. A bridge shorter than
+ *   {@link MIN_SPOKEN_BRIDGE_CHARS} releases nothing at all: the session
+ *   substitutes an audio-only canned fallback for it, so there is no
+ *   displayed text for the gate to agree with.
  * - `answer`: the leg's output IS the reply, so every delta passes through,
  *   including the leading text held back while the verdict was pending.
  */
@@ -267,7 +270,15 @@ export function createFrontDoorStreamGate(
 
   const releaseBridge = (): string => {
     stage = "done";
-    return capEscalationBridge(bridgeRaw);
+    const capped = capEscalationBridge(bridgeRaw);
+    // Below the spoken threshold the session throws the model's bridge away
+    // and plays a canned fallback that is audio-only, deleting the row rather
+    // than persisting a phrase the model never really produced (see
+    // `usesFallbackBridge` in `live-voice-session.ts`). Releasing the capped
+    // text here would put words on a subscriber's screen that the caller never
+    // heard, which is the same spoken/displayed divergence this gate exists to
+    // prevent.
+    return capped.length < MIN_SPOKEN_BRIDGE_CHARS ? "" : capped;
   };
 
   return {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -4593,9 +4593,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
    * escalate verdict the post-verdict stream buffers into the capped bridge
    * and `escalateTurn` starts a second "escalated" leg that shares this same
    * ActiveAssistantTurn. The persisted assistant row is reduced to the capped
-   * bridge by the bridge's teardown transcript-hygiene pass; the shared
-   * conversation-hub broadcast still streams the raw verdict deltas mid-turn
-   * until the turn-end resync (the remaining scope of issue #37850).
+   * bridge by the bridge's teardown transcript-hygiene pass, and the shared
+   * conversation-hub broadcast releases the same capped bridge through the
+   * bridge's front-door stream gate, so no verdict token reaches a hub
+   * subscriber mid-turn.
    */
   private async startAssistantLeg(
     activeTurn: ActiveAssistantTurn,


### PR DESCRIPTION
## Summary

Front-door routing verdict deltas were reaching the shared conversation-hub stream (web and passive devices) verbatim, so subscribers briefly saw control-plane fragments in the live transcript until the turn-end transcript-hygiene pass rewrote the persisted row. This suppresses them at the stream boundary instead of repairing them afterwards.

`createFrontDoorStreamGate` (in the routing-policy module, `assistant/src/calls/voice-triage-escalate.ts`) turns a front-door leg's delta stream into just the text the caller heard. `startVoiceTurn` broadcasts a front-door leg's `assistant_text_delta` events through it; every other event type and every other leg broadcasts exactly as before.

## How control-plane and real content are distinguished at the boundary

The verdict-first protocol already makes this decidable, and the gate reuses the existing shared primitives (`classifyFrontDoorLeading`, `ESCALATE_VERDICT_TOKEN`, `capEscalationBridge`, `isEscalationBridgeComplete`) rather than adding a second policy:

- **Only the front-door leg is gated.** `routingLeg === "front-door"` is the one leg whose leading tokens are a routing verdict rather than speech. The escalated continuation, which produces the real answer, and every un-routed voice leg pass through untouched.
- **`answer` verdict → everything is real content.** Once the leading tokens disprove a verdict token, the leg's output *is* the reply, so every delta is released, including the leading text held back while the verdict was still pending (a bare `[` is held for one delta, then released in full if it turns out to be ordinary text).
- **`escalate` verdict → only the capped holding phrase is real.** It is released in one piece once the bridge is complete, using the same `capEscalationBridge` the session speaks and the hygiene pass persists, so the three cannot drift. The verdict token and anything streamed past the cap never leave.
- **`hold` verdict → nothing is real.** The leg is discarded and its row deleted, so nothing is released. `holdEnabled` is passed from `unifiedVerdict`, matching the session, so a leg that was never taught the hold token cannot have real text swallowed by a parroted one.
- **Leg end.** A leg that completes mid-bridge still hands off and speaks what arrived, so the gate flushes on `message_complete`. A cancelled leg never hands off and correspondingly never flushes.

## Turn-end resync

Kept, and not dead. The hygiene pass owns the *persisted* row, which the agent loop writes from raw model output regardless of what was broadcast, so it is still the only thing that keeps the verdict token out of the stored transcript and out of the escalated leg's history snapshot. What changes is its relationship to the stream: the `publishConversationMessagesChanged` refetch it publishes now confirms text a subscriber already holds instead of correcting it. Both docstrings that described the old "emit then repair" arrangement are updated.

## Tests

New coverage in `assistant/src/calls/__tests__/voice-session-bridge.test.ts` asserts against real hub subscriptions, at the actual boundary, that an escalating leg broadcasts only the capped bridge and never the verdict token, a hold verdict broadcasts nothing, and a leg cancelled mid-bridge broadcasts nothing. The over-suppression half is asserted just as explicitly: a front-door answer reaches the hub in full, an answer that merely opens with a bracket is released in full, the escalated continuation streams untouched, and an un-routed leg streams untouched. Unit tests for the gate itself live in `assistant/src/calls/__tests__/voice-triage-escalate.test.ts`, including a verdict token split across deltas and a hold token on a leg that was never taught it.

Verified the tests fail on the unfixed path: with the gate disabled, exactly the four suppression tests fail and the four pass-through tests still pass.

```
bun test src/calls/__tests__/voice-session-bridge.test.ts \
         src/calls/__tests__/voice-triage-escalate.test.ts \
         src/live-voice/__tests__/live-voice-triage-escalate.test.ts \
         src/live-voice/__tests__/live-voice-agent-turn.test.ts \
         src/live-voice/__tests__/live-voice-flux-turn-end.test.ts
 192 pass / 2 todo / 0 fail

bun test src/live-voice/__tests__/live-voice-vad.test.ts \
         src/live-voice/__tests__/live-voice-integration.test.ts \
         src/live-voice/__tests__/live-voice-events.test.ts
 126 pass / 0 fail

bunx tsc --noEmit   # clean
eslint              # clean
```

No flakes hit on this branch, so nothing needed a base-commit comparison.

## Deliberately left out

- **The front-door prompt selection is untouched.** An audit of current main checked the "front-door instructions leak into the escalated model" hypothesis and it did not hold up: the routing prompt picks either the front-door rule or the escalated continuation rule, the front-door tool surface is empty, and the control prompt is cleared during teardown. The prompt plumbing is fine and was not rewritten.
- **The gate is scoped to the verdict protocol only.** It does not filter `[-1]` or other internal speech markers out of the hub stream. Those are a separate concern with their own live holdback and their own teardown handling, and widening the filter here is exactly the over-suppression risk this change is trying to avoid.
- **No feature flag.** The behavior is verifiable by test, so a flag would only defer the decision.
- **`assistant_turn_start` on a hold-verdict leg still broadcasts.** A hub subscriber may briefly see an empty assistant row anchor for a leg that is then discarded. That is pre-existing, carries no text, and is out of scope here.

Related to JARVIS-1496.

🤖 Generated with [Claude Code](https://claude.com/claude-code)