### PR TITLE
Cap the injected memory Buffer section at the consolidation threshold

### DIFF
--- a/assistant/src/plugins/defaults/memory/substrate/__tests__/static-context.test.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/__tests__/static-context.test.ts
@@ -5,6 +5,7 @@
  *   - Reads the four files in canonical order and joins them under headings.
  *   - Skips empty / missing files.
  *   - Returns null when every file is empty or missing.
+ *   - Caps the Buffer section at `consolidation_max_buffer_lines`.
  */
 
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
@@ -33,12 +34,19 @@ mock.module("../../../../../util/logger.js", () => ({
 
 let configMemoryV2Enabled = true;
 let configMemoryEnabled = true;
+// Mirrors the `memory.v2.consolidation_max_buffer_lines` schema default; the
+// Buffer-cap tests move it.
+let configMaxBufferLines: number | null = 100;
 
-// static-context reads its gates through the plugin's own config accessor.
+// static-context reads its gates and the substrate tuning through the
+// plugin's own config accessor.
 mock.module("../../config.js", () => ({
   getMemoryConfig: () => ({
     enabled: configMemoryEnabled,
-    v2: { enabled: configMemoryV2Enabled },
+    v2: {
+      enabled: configMemoryV2Enabled,
+      consolidation_max_buffer_lines: configMaxBufferLines,
+    },
   }),
 }));
 
@@ -70,6 +78,7 @@ describe("readMemoryV2StaticContent", () => {
     mkdirSync(TEST_DIR, { recursive: true });
     configMemoryV2Enabled = true;
     configMemoryEnabled = true;
+    configMaxBufferLines = 100;
   });
 
   afterEach(() => {
@@ -162,6 +171,73 @@ describe("readMemoryV2StaticContent", () => {
   test("returns null when memory directory is missing entirely", () => {
     cleanupMemoryDir();
     expect(readMemoryV2StaticContent()).toBeNull();
+  });
+});
+
+describe("readMemoryV2StaticContent Buffer cap", () => {
+  /** `n` timestamped buffer entries, oldest first, in `remember()`'s shape. */
+  function bufferEntries(n: number): string {
+    return Array.from(
+      { length: n },
+      (_, i) => `- [Jan 1, 9:00 AM] entry-${i}`,
+    ).join("\n");
+  }
+
+  beforeEach(() => {
+    mkdirSync(TEST_DIR, { recursive: true });
+    configMemoryV2Enabled = true;
+    configMemoryEnabled = true;
+    configMaxBufferLines = 10;
+  });
+
+  afterEach(() => {
+    cleanupMemoryDir();
+  });
+
+  test("passes a buffer at or under the cap through byte-identically", () => {
+    const buffer = bufferEntries(10);
+    writeMemoryFile("buffer.md", buffer);
+
+    expect(readMemoryV2StaticContent()).toBe(`## Buffer\n\n${buffer}`);
+  });
+
+  test("keeps the newest entries and drops the oldest when over the cap", () => {
+    writeMemoryFile("buffer.md", bufferEntries(30));
+
+    const text = readMemoryV2StaticContent()!;
+    expect(text).toContain(
+      "(Older entries trimmed. Read memory/buffer.md for the full backlog.)",
+    );
+    // The cap counts non-empty lines, matching the scheduler's
+    // `countBufferLines`, so exactly the newest 10 entries survive.
+    const kept = text
+      .split("\n")
+      .filter((line) => line.startsWith("- ["))
+      .map((line) => line.slice(line.lastIndexOf(" ") + 1));
+    expect(kept).toEqual(
+      Array.from({ length: 10 }, (_, i) => `entry-${i + 20}`),
+    );
+  });
+
+  test("leaves the buffer unbounded when the size trigger is disabled", () => {
+    configMaxBufferLines = null;
+    const buffer = bufferEntries(30);
+    writeMemoryFile("buffer.md", buffer);
+
+    expect(readMemoryV2StaticContent()).toBe(`## Buffer\n\n${buffer}`);
+  });
+
+  test("caps only the Buffer section, never the curated views", () => {
+    const long = Array.from({ length: 30 }, (_, i) => `line-${i}`).join("\n");
+    writeMemoryFile("essentials.md", long);
+    writeMemoryFile("threads.md", long);
+    writeMemoryFile("recent.md", long);
+    writeMemoryFile("buffer.md", bufferEntries(30));
+
+    const lines = readMemoryV2StaticContent()!.split("\n");
+    expect(lines.filter((line) => line === "line-0")).toHaveLength(3);
+    expect(lines.filter((line) => line === "line-29")).toHaveLength(3);
+    expect(lines.some((line) => line.endsWith("entry-0"))).toBe(false);
   });
 });
 

--- a/assistant/src/plugins/defaults/memory/substrate/__tests__/static-context.test.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/__tests__/static-context.test.ts
@@ -219,6 +219,59 @@ describe("readMemoryV2StaticContent Buffer cap", () => {
     );
   });
 
+  test("never opens mid-entry when the cap lands inside a multiline fact", () => {
+    // The 5-line fact straddles the cap: counting back 10 non-empty lines
+    // lands on one of its continuation lines. Injecting from there would show
+    // orphan bullets with no timestamp and no opening clause.
+    const multiline = [
+      "- [Jan 1, 9:00 AM] the straddling fact",
+      "  - [ ] a checklist item inside the fact",
+      "  continuation prose",
+      "  - another bullet",
+      "  closing line",
+    ].join("\n");
+    writeMemoryFile(
+      "buffer.md",
+      `${bufferEntries(20)}\n${multiline}\n${bufferEntries(8)}`,
+    );
+
+    const text = readMemoryV2StaticContent()!;
+    const body = text.slice(text.indexOf("buffer.md for the full backlog.)\n"));
+    const firstLine = body.split("\n")[1]!;
+    expect(firstLine).toMatch(/^- \[Jan 1, 9:00 AM\]/);
+    // The partial entry is dropped whole: none of its continuation lines
+    // survive on their own.
+    expect(text).not.toContain("continuation prose");
+    expect(text).not.toContain("the straddling fact");
+  });
+
+  test("keeps a multiline entry intact when it sits fully inside the cap", () => {
+    const multiline = [
+      "- [Jan 1, 9:00 AM] a fact with a body",
+      "  second line of the same fact",
+    ].join("\n");
+    writeMemoryFile("buffer.md", `${bufferEntries(20)}\n${multiline}`);
+
+    const text = readMemoryV2StaticContent()!;
+    expect(text).toContain("a fact with a body");
+    expect(text).toContain("second line of the same fact");
+  });
+
+  test("falls back to the line cut for a buffer with no timestamped entries", () => {
+    // A hand-written buffer that never went through `remember()` has no entry
+    // structure to preserve, so the line-based cut stands rather than dropping
+    // everything.
+    const handWritten = Array.from(
+      { length: 30 },
+      (_, i) => `just a line ${i}`,
+    ).join("\n");
+    writeMemoryFile("buffer.md", handWritten);
+
+    const text = readMemoryV2StaticContent()!;
+    expect(text).toContain("just a line 29");
+    expect(text).not.toContain("just a line 0");
+  });
+
   test("leaves the buffer unbounded when the size trigger is disabled", () => {
     configMaxBufferLines = null;
     const buffer = bufferEntries(30);

--- a/assistant/src/plugins/defaults/memory/substrate/static-context.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/static-context.ts
@@ -91,7 +91,49 @@ function capBufferSection(content: string, maxLines: number | null): string {
   while (start < lines.length && lines[start]!.trim().length === 0) {
     start++;
   }
+  start = alignToEntryStart(lines, start);
   return `${BUFFER_INJECTION_NOTICE}\n${lines.slice(start).join("\n")}`;
+}
+
+/**
+ * Matches the first line of a buffer entry: `- [Mon D, h:mm AM/PM] fact`, the
+ * shape `formatRememberEntry` writes. The timestamp must be present and
+ * timestamp-shaped, so a bullet carrying other bracketed text (a `- [ ]`
+ * checklist item inside a multiline fact) reads as a continuation line.
+ *
+ * Duplicated from `BUFFER_ENTRY_REGEX` in `graph-topology/pending-buffer.ts`
+ * rather than imported: `substrate/` is the bottom layer and `graph-topology/`
+ * already imports it, so importing back would invert the layering. The two
+ * must stay in sync.
+ */
+const BUFFER_ENTRY_START_REGEX =
+  /^-\s+\[[A-Z][a-z]{2}\s+\d{1,2},\s+\d{1,2}:\d{2}\s+[AP]M\]/;
+
+/**
+ * Advance `start` to the next line that begins a buffer entry, so the injected
+ * Buffer never opens mid-entry.
+ *
+ * A multiline `remember()` stores its body verbatim after the timestamped
+ * first line, and consolidation reads non-timestamped lines as part of the
+ * preceding entry. Cutting purely on a line count can therefore land inside a
+ * fact and inject orphan continuation lines stripped of the timestamp and
+ * opening clause that give them meaning, which is worse than showing one fewer
+ * fact. Dropping the partial entry keeps every surviving fact whole and can
+ * only shrink the result, so the cap still holds.
+ *
+ * Returns `start` unchanged when no entry start exists at or after it, which
+ * is the hand-written buffer that never used `remember()`. There is no entry
+ * structure to preserve there, so the line-based cut stands.
+ */
+function alignToEntryStart(lines: string[], start: number): number {
+  let aligned = start;
+  while (
+    aligned < lines.length &&
+    !BUFFER_ENTRY_START_REGEX.test(lines[aligned]!)
+  ) {
+    aligned++;
+  }
+  return aligned === lines.length ? start : aligned;
 }
 
 /**

--- a/assistant/src/plugins/defaults/memory/substrate/static-context.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/static-context.ts
@@ -19,29 +19,86 @@
 // Refresh cadence is owned by the caller: the agent loop only passes the
 // content through when `mode === "full"` (first turn / post-compaction),
 // matching the existing PKB auto-inject pattern.
+//
+// Three of the four files are curated aggregate views that consolidation
+// keeps lean. `memory/buffer.md` is not: it is the raw append-only staging
+// log that `remember()` writes and consolidation drains, so its length is
+// bounded only by how far behind consolidation has fallen. The injected
+// Buffer section is therefore capped: see `capBufferSection`.
 
 import type { ChannelId } from "../../../../channels/types.js";
 import { usesConceptPageMemory } from "../../../../config/memory-v3-gate.js";
 import { readPromptFile } from "../../../../prompts/system-prompt.js";
 import { getMemoryConfig } from "../config.js";
 import { getWorkspacePromptPath } from "../paths.js";
+import { resolveSubstrateTuning } from "./tuning.js";
 
 interface MemoryV2StaticBlock {
   heading: string;
   file: string;
 }
 
+const BUFFER_FILE = "memory/buffer.md";
+
 const MEMORY_V2_STATIC_BLOCKS: readonly MemoryV2StaticBlock[] = [
   { heading: "## Essentials", file: "memory/essentials.md" },
   { heading: "## Threads", file: "memory/threads.md" },
   { heading: "## Recent", file: "memory/recent.md" },
-  { heading: "## Buffer", file: "memory/buffer.md" },
+  { heading: "## Buffer", file: BUFFER_FILE },
 ];
+
+/**
+ * Leader line on a Buffer section that was capped, so the model knows the
+ * section is a tail rather than the whole backlog and where the rest lives.
+ */
+const BUFFER_INJECTION_NOTICE =
+  "(Older entries trimmed. Read memory/buffer.md for the full backlog.)";
+
+/**
+ * Cap the Buffer section at its most recent `maxLines` non-empty lines,
+ * returning the content unchanged when it already fits or when `maxLines` is
+ * `null`.
+ *
+ * The bound is `consolidation_max_buffer_lines`, the same threshold at which
+ * the scheduler already considers the buffer overdue for consolidation (see
+ * `jobs-worker.ts`). Reusing it means the injected buffer never exceeds one
+ * consolidation's worth of backlog, and that a workspace whose consolidation
+ * keeps up sees byte-identical output. `null` disables the size trigger, so
+ * the operator has opted out of size-based buffer management and the
+ * injection is left unbounded to match.
+ *
+ * Non-empty lines are the unit because that is what the scheduler counts
+ * (`countBufferLines`), so the two readings of "how big is the buffer" agree.
+ * Retained lines keep their original spacing; the notice replaces everything
+ * before them.
+ */
+function capBufferSection(content: string, maxLines: number | null): string {
+  if (maxLines === null) {
+    return content;
+  }
+  const lines = content.split("\n");
+  let kept = 0;
+  let start = lines.length;
+  while (start > 0 && kept < maxLines) {
+    start--;
+    if (lines[start]!.trim().length > 0) {
+      kept++;
+    }
+  }
+  if (start === 0) {
+    return content;
+  }
+  while (start < lines.length && lines[start]!.trim().length === 0) {
+    start++;
+  }
+  return `${BUFFER_INJECTION_NOTICE}\n${lines.slice(start).join("\n")}`;
+}
 
 /**
  * Build the static memory block, gated on concept-page memory being active
  * ({@link usesConceptPageMemory}). Empty/missing files are skipped; returns
- * `null` when the gate is off or every file is empty.
+ * `null` when the gate is off or every file is empty. The Buffer section is
+ * capped by {@link capBufferSection}.
  *
  * `excludeBuffer` drops the `## Buffer` section. The consolidation run sets
  * it: the agent's contract there is the `memory/buffer.md` FILE — it reads,
@@ -57,17 +114,22 @@ export function readMemoryV2StaticContent(
   if (!usesConceptPageMemory(memoryConfig)) {
     return null;
   }
+  const maxBufferLines =
+    resolveSubstrateTuning(memoryConfig).consolidation_max_buffer_lines;
 
   const sections: string[] = [];
   for (const { heading, file } of MEMORY_V2_STATIC_BLOCKS) {
-    if (options.excludeBuffer === true && file === "memory/buffer.md") {
+    const isBuffer = file === BUFFER_FILE;
+    if (options.excludeBuffer === true && isBuffer) {
       continue;
     }
     const content = readPromptFile(getWorkspacePromptPath(file));
     if (!content) {
       continue;
     }
-    sections.push(`${heading}\n\n${content}`);
+    sections.push(
+      `${heading}\n\n${isBuffer ? capBufferSection(content, maxBufferLines) : content}`,
+    );
   }
   return sections.length > 0 ? sections.join("\n\n") : null;
 }


### PR DESCRIPTION
Caps the `## Buffer` section of the static `<info>` memory block at `consolidation_max_buffer_lines`. JARVIS-1493.

## What changed

`substrate/static-context.ts` builds the `<info>` block from four files. Three of them (essentials/threads/recent) are curated aggregate views that consolidation keeps lean. `memory/buffer.md` is not: it is the raw append-only staging log `remember()` writes and consolidation drains, so its injected size is bounded only by how far behind consolidation has fallen. The block is injected on the first turn of every session and on every post-compaction re-injection, so a backlogged buffer is paid at exactly the moment latency is most visible.

The cap reuses `consolidation_max_buffer_lines` (default 100), the threshold at which the scheduler already treats the buffer as overdue for consolidation, counted in the same non-empty-line unit as `countBufferLines`. Consequences:

- a workspace whose consolidation keeps up gets **byte-identical output** (no behavior change in the steady state),
- only a backlog is trimmed, keeping the newest entries and leading with `(Older entries trimmed. Read memory/buffer.md for the full backlog.)`,
- `null` (operator disabled the size trigger) leaves the injection unbounded to match,
- no new config key, no feature flag.

This restores a bound the predecessor path had. The v1 PKB context loader caps its own injected buffer at 50 lines for the same stated reason (`v1/pkb/context.ts`, `MAX_BUFFER_LINES`); the concept-page substrate dropped it.

## What I measured

**I could not measure first-token latency in this environment** (no live daemon, no provider, no real workspace corpus). The numbers below are byte and estimated-token counts of the injected Buffer section, using the repo's own `estimateTextTokens`, over synthetic backlogs of ~90-char `remember()` entries with the default 100-line cap:

| buffer lines | before (bytes) | before (tok) | after (bytes) | after (tok) | saved |
| --- | --- | --- | --- | --- | --- |
| 50 | 4,529 | 1,133 | 4,529 | 1,133 | 0 |
| 100 | 9,059 | 2,265 | 9,059 | 2,265 | 0 |
| 250 | 22,649 | 5,663 | 9,128 | 2,282 | 3,381 |
| 500 | 45,299 | 11,325 | 9,128 | 2,282 | 9,043 |
| 1000 | 90,599 | 22,650 | 9,128 | 2,282 | 20,368 |
| 2000 | 181,199 | 45,300 | 9,128 | 2,282 | 43,018 |

At or under the trigger the output is unchanged; past it the injected buffer plateaus at ~9.1 KB instead of growing without limit. Tests assert both halves of that (byte-identical pass-through, and the exact retained tail).

## Investigation notes: most of the ticket's premise does not hold on the live tier

Worth recording, because the ticket points at code that new assistants do not run.

- **`conversation-graph-memory.ts:638` (`runContextLoad`) is the memory-v2 engine path and is dead on v3-live assistants.** `shouldRunLegacyMemoryRetrieval` (`hooks/user-prompt-submit.ts:65`) is `isTrustedActor && !memoryV3Live`, so under `memory.v3.live` `prepareMemory` is never called at all. Workspace migration 105 sets `memory.v3.live` for every brand-new workspace, so the cited site does not run for new users.
- **`memory.v2.top_k = 25` is not the v3 budget, and is not even the v2 injection budget** when the v2 router is on (the default), where `router.max_page_ids` governs instead.
- **`SOUL.md` (10,861 bytes) is a system-prompt section**, not part of the first-turn user message. It is a cache-stable prefix paid on every turn, not a first-turn cost.
- **v3 already ships the two mitigations the ticket asks for.** `tuning-profile.ts` runs a lean profile under 10 concept pages (`denseK: 0`, `selectorEnabled: false`, no embedding and no selector LLM call), and `memory.v3.gate` (schema default **enabled: true**) hard-skips the selector call on a low-signal turn. A bare "hi" scores below `denseThreshold: 0.66` and its BM25F hits the zero-overlap hard floor, so the selector is already skipped for exactly the case the ticket names.
- **Greeting detection was ruled out on convention, not just on taste.** Root `AGENTS.md` "Assistant-Driven Judgement" forbids string matches that approximate a model decision.

## Deliberately left out

- **Skipping memory retrieval on the voice front-door leg.** The front-door leg (`calls/voice-triage-escalate.ts`) runs a full `runAgentLoop` and pays the whole `user-prompt-submit` chain before its first token, with only `toolsDisabledDepth` and `callSite: "voiceFrontDoor"` distinguishing it. Skipping memory there is the single biggest available win, but it is a product judgment I cannot measure: memory-answerable questions ("what is my dog's name") would stop being answerable at the front door and would escalate instead, trading one latency profile for another.
- **De-duplicating the memory load across legs of one utterance.** A single spoken utterance can pay the pipeline more than once: each hold-replay re-dispatches a fresh front-door leg, and escalation dispatches a second leg. The v3 per-turn memo is keyed `(conversationId, turnIndex)` and `turnIndex` increments per agent-loop run, so it never dedupes across legs. Related: the escalated leg's retrieval query is `ESCALATION_CONTINUATION_CONTENT`, a fixed internal instruction rather than the caller's utterance. Both deserve their own ticket.
- **Pre-warming the v3 lane build.** `getLanes` is lazy with no startup pre-warm, so the first turn after daemon start pays a full `initLanes` (every page read off disk, section index, BM25 needle, entity catalog, edge graph, learned-edge NPMI, pre-rendered prefix cards, plus a Qdrant collection ensure and two SQLite scans). I benchmarked the CPU/disk core of that at **17 ms / 25 pages, 19 ms / 100, 38 ms / 300, 80 ms / 800** (Qdrant and DB portions excluded), which is real but small enough that I did not want it competing with the change above for review attention.
- **Trimming essentials/threads/recent.** Those are model-curated by consolidation; capping them would fight the thing that maintains them.
- **Touching the v2 engine.** `memory/AGENTS.md` forbids new work in `v1/` and `v2/`, so adding a v2 equivalent of the v3 gate is not on the table.

## Tests

`assistant/src/plugins/defaults/memory/substrate/__tests__/static-context.test.ts` gains four cases: byte-identical pass-through at the cap, exact retained tail plus notice over the cap, `null` leaves it unbounded, and the cap never touches the other three sections.

```
bun test src/plugins/defaults/memory/substrate/__tests__/static-context.test.ts
 16 pass  0 fail  45 expect() calls
```

All 22 `substrate/__tests__/*.test.ts` files pass individually, as do `conversation-runtime-assembly.test.ts` (204), `memory-v2-static-injector.test.ts` (10), `injector-chain.test.ts` (9), `injector-registry-order-guard.test.ts` (5), `conversation-lifecycle.test.ts` (23), `config-schema-memory-substrate.test.ts` (18), `memory-config-file-parity.test.ts` (13), `jobs-worker-v2-schedule.test.ts` (38), `memory-tier-boundary-guard.test.ts` (20), `plugin-import-boundary-guard.test.ts`.

`bunx tsc --noEmit` clean; eslint and prettier clean.

**One pre-existing flake to ignore:** running `memory-v2-static-injector.test.ts` and `injector-chain.test.ts` in the *same* `bun test` invocation produces 6 failures from `mock.module` leakage between the files. Verified identical on the base commit (`f90146cf5f`) with the change stashed. Both files pass when run individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
