### PR TITLE
Deduplicate <channel_capabilities> in the outbound history

### DIFF
--- a/assistant/src/__tests__/channel-capabilities-dedupe.test.ts
+++ b/assistant/src/__tests__/channel-capabilities-dedupe.test.ts
@@ -1,0 +1,214 @@
+/**
+ * `<channel_capabilities>` must not accumulate one copy per turn — and
+ * deduplicating it must not disturb the cross-turn byte-identity that prompt
+ * caching depends on (see `prompt-cache-cross-turn-stability.test.ts`, which
+ * owns that invariant end to end).
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+  dedupeChannelCapabilityBlocks,
+  preModelCallSanitize,
+} from "../context/outbound-sanitize.js";
+import type { Message } from "../providers/types.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures — shaped like what runtime injection actually produces: the block is
+// its OWN text content block, prepended to the turn-starting user message by
+// `injectChannelCapabilityContext`, and then frozen into history.
+// ---------------------------------------------------------------------------
+
+const slackCapabilities = (dynamicUi = false): string =>
+  [
+    "<channel_capabilities>",
+    "channel: slack",
+    "dashboard_capable: false",
+    `supports_dynamic_ui: ${dynamicUi}`,
+    "supports_voice_input: false",
+    "",
+    "CHANNEL CONSTRAINTS:",
+    "- Do NOT reference the dashboard UI, settings panels, or visual preference pickers.",
+    '- Do NOT use app_create. Only use ui_show/ui_update for card surfaces with template: "task_progress"; present all other information as text.',
+    "- Present information as well-formatted text instead of dynamic UI.",
+    "</channel_capabilities>",
+  ].join("\n");
+
+const CAPS = slackCapabilities();
+
+const turnContextBlock = (turn: number): string =>
+  [
+    "<turn_context>",
+    `current_time: 2026-05-21 (Thursday) 10:${String(turn).padStart(2, "0")}:00 -05:00 (America/Chicago)`,
+    "interface: slack",
+    "trust_class: guardian",
+    "</turn_context>",
+  ].join("\n");
+
+const userTurn = (turn: number, caps: string = CAPS): Message => ({
+  role: "user",
+  content: [
+    { type: "text", text: turnContextBlock(turn) },
+    { type: "text", text: caps },
+    { type: "text", text: `User message ${turn}.` },
+  ],
+});
+
+const assistantTurn = (turn: number): Message => ({
+  role: "assistant",
+  content: [{ type: "text", text: `Reply ${turn}.` }],
+});
+
+/** An N-turn conversation, every user row carrying its own injected copy. */
+const conversation = (turns: number): Message[] => {
+  const messages: Message[] = [];
+  for (let turn = 1; turn <= turns; turn++) {
+    messages.push(userTurn(turn));
+    if (turn < turns) {
+      messages.push(assistantTurn(turn));
+    }
+  }
+  return messages;
+};
+
+const allText = (messages: Message[]): string =>
+  messages
+    .flatMap((m) =>
+      m.content.filter((b) => b.type === "text").map((b) => b.text),
+    )
+    .join("\n");
+
+const countOccurrences = (haystack: string, needle: string): number =>
+  haystack.split(needle).length - 1;
+
+// ---------------------------------------------------------------------------
+
+describe("<channel_capabilities> does not accumulate across a conversation", () => {
+  test("a 50-turn conversation carries exactly one copy", () => {
+    const raw = conversation(50);
+    expect(countOccurrences(allText(raw), "<channel_capabilities>")).toBe(50);
+
+    const text = allText(preModelCallSanitize(raw));
+    expect(countOccurrences(text, "<channel_capabilities>")).toBe(1);
+    expect(countOccurrences(text, "CHANNEL CONSTRAINTS:")).toBe(1);
+  });
+
+  test("the surviving copy is the first one, unmodified", () => {
+    const sanitized = preModelCallSanitize(conversation(6));
+    expect(sanitized[0].content).toEqual(conversation(6)[0].content);
+    expect(allText([sanitized[2]])).not.toContain("<channel_capabilities>");
+  });
+
+  test("outbound size stops growing with the repeated block", () => {
+    const rawGrowth =
+      allText(conversation(45)).length - allText(conversation(5)).length;
+    const sanitizedGrowth =
+      allText(preModelCallSanitize(conversation(45))).length -
+      allText(preModelCallSanitize(conversation(5))).length;
+
+    // Every extra raw turn pays for a full copy of the block; the deduplicated
+    // projection pays nothing for it.
+    expect((rawGrowth - sanitizedGrowth) / 40).toBeGreaterThanOrEqual(
+      CAPS.length,
+    );
+  });
+
+  test("everything else on the row is untouched", () => {
+    const sanitized = preModelCallSanitize(conversation(4));
+    // `<turn_context>` is deliberately left alone — it carries a fresh
+    // timestamp each turn and historical copies are read back by the
+    // compactor's tail resolution.
+    expect(countOccurrences(allText(sanitized), "<turn_context>")).toBe(4);
+    // The dropped block is the only thing that goes: the row keeps its
+    // `<turn_context>` and the user's own text, in order.
+    expect(sanitized[6].content).toEqual([
+      { type: "text", text: turnContextBlock(4) },
+      { type: "text", text: "User message 4." },
+    ]);
+  });
+});
+
+describe("cross-turn byte stability", () => {
+  test("a message renders identically no matter how many turns follow it", () => {
+    // The prompt cache is only readable when turn N's messages recur
+    // byte-identically at the same index in turn N+1. Deduplication must
+    // therefore depend only on what sits ABOVE a message, never on how far it
+    // is from the end.
+    const turn2 = preModelCallSanitize(conversation(2));
+    const turn20 = preModelCallSanitize(conversation(20));
+
+    turn2.forEach((message, index) => {
+      expect(JSON.stringify(turn20[index])).toBe(JSON.stringify(message));
+    });
+  });
+
+  test("the turn-starting message is not treated specially", () => {
+    const sanitized = preModelCallSanitize(conversation(3));
+    const turnStart = sanitized[sanitized.length - 1];
+    // Turn 3 opened this turn and still drops its duplicate copy, which is
+    // exactly what keeps it stable once turn 4 arrives.
+    expect(allText([turnStart])).not.toContain("<channel_capabilities>");
+  });
+
+  test("is idempotent", () => {
+    const once = preModelCallSanitize(conversation(6));
+    expect(preModelCallSanitize(once)).toEqual(once);
+  });
+});
+
+describe("changes and safety", () => {
+  test("capabilities that actually change mid-conversation are kept", () => {
+    const changed = slackCapabilities(true);
+    const history: Message[] = [
+      userTurn(1),
+      assistantTurn(1),
+      userTurn(2),
+      assistantTurn(2),
+      userTurn(3, changed),
+      assistantTurn(3),
+      userTurn(4, changed),
+    ];
+
+    const sanitized = dedupeChannelCapabilityBlocks(history);
+    const text = allText(sanitized);
+    expect(countOccurrences(text, "<channel_capabilities>")).toBe(2);
+    expect(text).toContain("supports_dynamic_ui: false");
+    expect(text).toContain("supports_dynamic_ui: true");
+    // Turn 2 and turn 4 are the repeats and are the ones that go.
+    expect(allText([sanitized[2]])).not.toContain("<channel_capabilities>");
+    expect(allText([sanitized[6]])).not.toContain("<channel_capabilities>");
+  });
+
+  test("a conversation with a single copy is returned untouched", () => {
+    const history = conversation(1);
+    expect(dedupeChannelCapabilityBlocks(history)).toBe(history);
+  });
+
+  test("user-authored text that merely mentions the tag is left alone", () => {
+    const authored =
+      "why does <channel_capabilities> say dashboard_capable: false?";
+    const history: Message[] = [
+      { role: "user", content: [{ type: "text", text: authored }] },
+      assistantTurn(1),
+      { role: "user", content: [{ type: "text", text: authored }] },
+    ];
+
+    expect(dedupeChannelCapabilityBlocks(history)).toBe(history);
+  });
+
+  test("a user row made only of the block is never emptied or dropped", () => {
+    const history: Message[] = [
+      userTurn(1),
+      assistantTurn(1),
+      { role: "user", content: [{ type: "text", text: CAPS }] },
+      assistantTurn(2),
+      userTurn(3),
+    ];
+
+    const sanitized = dedupeChannelCapabilityBlocks(history);
+    expect(sanitized).toHaveLength(5);
+    expect(sanitized[2].content).toEqual(history[2].content);
+    // The all-block row is retained, so it becomes the baseline the later
+    // duplicate is measured against and turn 3 still drops.
+    expect(allText([sanitized[4]])).not.toContain("<channel_capabilities>");
+  });
+});

--- a/assistant/src/__tests__/channel-capabilities-dedupe.test.ts
+++ b/assistant/src/__tests__/channel-capabilities-dedupe.test.ts
@@ -1,5 +1,5 @@
 /**
- * `<channel_capabilities>` must not accumulate one copy per turn — and
+ * `<channel_capabilities>` must not accumulate one copy per turn, and
  * deduplicating it must not disturb the cross-turn byte-identity that prompt
  * caching depends on (see `prompt-cache-cross-turn-stability.test.ts`, which
  * owns that invariant end to end).
@@ -13,7 +13,7 @@ import {
 import type { Message } from "../providers/types.js";
 
 // ---------------------------------------------------------------------------
-// Fixtures — shaped like what runtime injection actually produces: the block is
+// Fixtures, shaped like what runtime injection actually produces: the block is
 // its OWN text content block, prepended to the turn-starting user message by
 // `injectChannelCapabilityContext`, and then frozen into history.
 // ---------------------------------------------------------------------------
@@ -114,7 +114,7 @@ describe("<channel_capabilities> does not accumulate across a conversation", () 
 
   test("everything else on the row is untouched", () => {
     const sanitized = preModelCallSanitize(conversation(4));
-    // `<turn_context>` is deliberately left alone — it carries a fresh
+    // `<turn_context>` is deliberately left alone: it carries a fresh
     // timestamp each turn and historical copies are read back by the
     // compactor's tail resolution.
     expect(countOccurrences(allText(sanitized), "<turn_context>")).toBe(4);

--- a/assistant/src/context/outbound-sanitize.ts
+++ b/assistant/src/context/outbound-sanitize.ts
@@ -105,7 +105,7 @@ export function compactAxTreeHistory(messages: Message[]): Message[] {
 /**
  * Full-wrapper matcher for the `<channel_capabilities>` block. Both ends are
  * required so a user message that merely opens with the tag (someone pasting
- * prompt markup into chat) is never mistaken for an injected block — the same
+ * prompt markup into chat) is never mistaken for an injected block, the same
  * discipline `stripUserTextBlocksByPrefix` uses in `strip-injections.ts`.
  */
 const CHANNEL_CAPABILITIES_OPEN = "<channel_capabilities>\n";
@@ -125,7 +125,7 @@ function isChannelCapabilitiesBlock(text: string): boolean {
  * of one per turn.
  *
  * Runtime injection prepends this block to the turn-starting user message and
- * then freezes it into history — live, because injection splices into the
+ * then freezes it into history: live, because injection splices into the
  * conversation's own message array, and across restarts, because `loadFromDb`
  * rehydrates it from message metadata. Nothing ever removes it, so an N-turn
  * channel conversation ships N copies. Unlike `<turn_context>`, which at least
@@ -136,7 +136,7 @@ function isChannelCapabilitiesBlock(text: string): boolean {
  * ## Why "same as the last retained copy" and not "not the current turn"
  *
  * Prompt caching only pays off when the bytes a provider marked in turn N are
- * still at the same position in turn N+1 — an invariant this repo enforces end
+ * still at the same position in turn N+1, an invariant this repo enforces end
  * to end in `prompt-cache-cross-turn-stability.test.ts`. Any rule of the form
  * "keep it on the current turn, collapse it above" necessarily re-renders one
  * message every turn (the turn that just ended), which is a full cache miss on

--- a/assistant/src/context/outbound-sanitize.ts
+++ b/assistant/src/context/outbound-sanitize.ts
@@ -103,6 +103,96 @@ export function compactAxTreeHistory(messages: Message[]): Message[] {
 }
 
 /**
+ * Full-wrapper matcher for the `<channel_capabilities>` block. Both ends are
+ * required so a user message that merely opens with the tag (someone pasting
+ * prompt markup into chat) is never mistaken for an injected block — the same
+ * discipline `stripUserTextBlocksByPrefix` uses in `strip-injections.ts`.
+ */
+const CHANNEL_CAPABILITIES_OPEN = "<channel_capabilities>\n";
+const CHANNEL_CAPABILITIES_CLOSE = "\n</channel_capabilities>";
+
+/** Whether a text block is a complete `<channel_capabilities>…` block. */
+function isChannelCapabilitiesBlock(text: string): boolean {
+  return (
+    text.startsWith(CHANNEL_CAPABILITIES_OPEN) &&
+    text.endsWith(CHANNEL_CAPABILITIES_CLOSE)
+  );
+}
+
+/**
+ * Drop `<channel_capabilities>` blocks that repeat the last one still standing,
+ * so a conversation carries one copy per distinct set of capabilities instead
+ * of one per turn.
+ *
+ * Runtime injection prepends this block to the turn-starting user message and
+ * then freezes it into history — live, because injection splices into the
+ * conversation's own message array, and across restarts, because `loadFromDb`
+ * rehydrates it from message metadata. Nothing ever removes it, so an N-turn
+ * channel conversation ships N copies. Unlike `<turn_context>`, which at least
+ * carries a fresh timestamp, this block is a pure function of the channel
+ * (`buildChannelCapabilityBlock`): every copy after the first is byte-identical
+ * to the one above it and tells the model nothing it has not already read.
+ *
+ * ## Why "same as the last retained copy" and not "not the current turn"
+ *
+ * Prompt caching only pays off when the bytes a provider marked in turn N are
+ * still at the same position in turn N+1 — an invariant this repo enforces end
+ * to end in `prompt-cache-cross-turn-stability.test.ts`. Any rule of the form
+ * "keep it on the current turn, collapse it above" necessarily re-renders one
+ * message every turn (the turn that just ended), which is a full cache miss on
+ * the whole message prefix, every turn, for every conversation.
+ *
+ * Comparing against the last RETAINED copy avoids that entirely: whether a
+ * given occurrence survives depends only on the messages above it, never on
+ * how many turns come later. A message's rendering is therefore fixed the
+ * moment it is written, and the prefix stays byte-stable as the conversation
+ * grows. Capabilities that genuinely change mid-conversation (the same
+ * conversation resumed from a different client) still differ from the retained
+ * copy, so the new block is kept and the model sees the change.
+ *
+ * The cost is placement: the surviving copy sits at the top of the conversation
+ * rather than next to the newest message. It is the same bytes either way.
+ *
+ * Idempotent, like every other transform in this module: re-running it over an
+ * already-deduplicated history retains exactly the same occurrences.
+ */
+export function dedupeChannelCapabilityBlocks(history: Message[]): Message[] {
+  let lastRetained: string | null = null;
+  let changed = false;
+
+  const next = history.map((message) => {
+    if (message.role !== "user") {
+      return message;
+    }
+
+    let messageChanged = false;
+    const content = message.content.filter((block) => {
+      if (block.type !== "text" || !isChannelCapabilitiesBlock(block.text)) {
+        return true;
+      }
+      if (block.text === lastRetained) {
+        messageChanged = true;
+        return false;
+      }
+      lastRetained = block.text;
+      return true;
+    });
+
+    // A user row is never only injections in practice, but guard anyway: an
+    // empty content array is not a message any provider will accept, and
+    // dropping the row would break tool_use/tool_result pairing and the
+    // row-to-history index mapping `summarizeUpToMessage` relies on.
+    if (!messageChanged || content.length === 0) {
+      return message;
+    }
+    changed = true;
+    return { ...message, content };
+  });
+
+  return changed ? next : history;
+}
+
+/**
  * Index of the last user message carrying `tool_result` blocks — the
  * "current turn" boundary {@link stripOldMediaBlocks} keeps intact while
  * stripping media from older tool results. Returns -1 when no user message
@@ -194,6 +284,9 @@ function stripOldMediaBlocks(history: Message[]): Message[] {
  *   `web_search_tool_result` blocks to text summaries; Anthropic's opaque
  *   `encrypted_content` tokens expire / are route-scoped, and replaying a stale
  *   one is rejected with `Invalid encrypted_content in search_result block`.
+ * - {@link dedupeChannelCapabilityBlocks} keeps one `<channel_capabilities>`
+ *   block per distinct set of capabilities instead of the one-per-turn history
+ *   accumulates; every repeat is byte-identical to the copy above it.
  *
  * Transforms the outbound copy only — the durable history keeps the rich
  * originals and each send re-derives the sanitized projection (every transform
@@ -206,5 +299,7 @@ function stripOldMediaBlocks(history: Message[]): Message[] {
 export function preModelCallSanitize(history: Message[]): Message[] {
   const mediaStripped = stripOldMediaBlocks(history);
   const axCompacted = compactAxTreeHistory(mediaStripped);
-  return stripHistoricalWebSearchResults(axCompacted).messages;
+  const webSearchStripped =
+    stripHistoricalWebSearchResults(axCompacted).messages;
+  return dedupeChannelCapabilityBlocks(webSearchStripped);
 }


### PR DESCRIPTION
## Summary

`<turn_context>` and `<channel_capabilities>` are injected onto the turn-starting user message and then frozen into history, so a 50-turn conversation ships ~50 copies of each. This PR removes the accumulation for `<channel_capabilities>` and explains why `<turn_context>` is deliberately left alone.

`dedupeChannelCapabilityBlocks` is added to `preModelCallSanitize` — the outbound projection that both the agent loop's model calls and the compactor's summary call already funnel through. An occurrence is kept only when it differs from the last retained one, so a conversation carries one copy per *distinct* set of capabilities rather than one per turn. Capabilities that genuinely change mid-conversation (same conversation resumed from a different client) still differ from the retained copy and are kept, so the model still sees the change.

`<channel_capabilities>` is a pure function of the channel (`buildChannelCapabilityBlock`), so every copy after the first is byte-identical to the one above it. Deduplicating loses no information at all — only placement: the surviving copy sits at the top of the conversation instead of next to the newest message.

## Strip on assembly, not "never persist"

Deliberately scoped to the outbound projection rather than to what gets written:

- **Persisted metadata has a second reader.** The memory retrospective anchors its review window on `metadata.turnContextBlock` (`memory-retrospective-job.ts:1014`), reading it off DB rows rather than the message array. Persistence is load-bearing beyond rehydration.
- **Stored-conversation replay keeps the full record.** A conversation replayed later still shows the exact per-turn capabilities each turn ran under. Not persisting would throw that away permanently; the outbound strip is a projection, so the durable rows keep the originals — matching the module's existing contract ("durable history keeps the rich originals, every transform is idempotent").
- **Not persisting would only be a half fix.** The copies get into history by *injection* (`ctx.latestMessages = injection.messages`), not only by rehydration, so a long-lived in-memory conversation would keep accumulating even if nothing were ever written to metadata.

## Consumers checked

Every path that could read these blocks back out of history:

| Path | Finding |
|---|---|
| `Conversation.loadFromDb` rehydration (`conversation.ts:1265`) | The only reader of `metadata.channelCapabilitiesBlock`. Untouched — it still rehydrates, the outbound layer dedupes. |
| Compaction (`compactor.ts`) | `extractTurnContextTimestamp` / `buildTimestampIndex` / `resolveTailStartIndex` read `current_time` out of **`<turn_context>`** on historical rows; an unresolved `tail_start` **aborts the compaction pass**. Nothing reads `<channel_capabilities>`. This is the main reason `<turn_context>` is not touched. |
| `strip-injections.ts` | `<channel_capabilities>` is already in `RUNTIME_INJECTION_PREFIXES`, i.e. compaction already discards it. Nothing counts occurrences or branches on the strip being a no-op. |
| Memory retrospective | Anchors on `metadata.turnContextBlock` from DB rows, not the message array. Its cache-parity note holds: the dedupe applies symmetrically to source and fork, both going through `preModelCallSanitize`. |
| Live-voice / calls | `voice-triage-escalate.ts:290` is a comment only. The voice legs reload via `loadFromDb`, which is unchanged. |
| Resume / replay / forks | All funnel through `loadFromDb`; unchanged. Subagents receive post-load `parentMessages`; the dedupe is applied at send time on both sides. |
| `btw-routes.ts` | Hand-builds a literal `<turn_context>` on an ephemeral, never-persisted conversation. Unaffected. |

## Reduction

Measured against the real `buildChannelCapabilityBlock` output:

| Channel | Per-turn block | Saved at 20 turns | Saved at 50 turns |
|---|---|---|---|
| Slack group | 1086 chars (~272 tok) | ~5.2K tok | ~13.3K tok |
| WhatsApp | 513 chars (~128 tok) | ~2.4K tok | ~6.3K tok |
| Slack DM | 473 chars (~118 tok) | ~2.2K tok | ~5.8K tok |
| macOS desktop | 363 chars (~91 tok) | ~1.7K tok | ~4.5K tok |
| Web desktop | no block injected | — | — |

Growth from this block is now flat instead of linear in turn count.

## Left out deliberately

**`<turn_context>` is unchanged.** Both shapes the ticket proposed break something real, and I could not find a third that doesn't:

- *Tail-only regeneration / strip historical copies.* Any rule that renders the block one way on the current turn and another way in history necessarily re-renders exactly one message per turn — the turn that just ended, which is precisely where the Anthropic client places its previous-turn cache anchor. That is a cache miss on the whole message prefix, every turn, for every conversation. `prompt-cache-cross-turn-stability.test.ts` enforces this across three layers ("turn 2 resends every turn-1 message byte-identically, at the same index"); I implemented the strip first and it failed 4 of that suite's tests. In the common web-guardian case the block is 4 lines, so the trade was ~50 bytes for the entire cached prefix.
- *Deduplication, as applied here.* Doesn't work: the block carries a fresh `current_time` every turn, so no two copies are equal. Reducing it to only the changed lines would be prefix-stable, but it would also strip the trust-defense and response-discretion guidance from the current turn on every turn after the first, which is a security-relevant behavior change, not a size optimization.
- Its historical copies are also load-bearing in a way `<channel_capabilities>`'s are not: the compactor resolves the summarizer's `<tail_start timestamp=…>` against them, and losing them degrades tail resolution to a preview-text fallback that can abort compaction outright.

The real fix for `<turn_context>` is to stop putting per-turn *guidance* into a per-turn *message* block at all — move the static trust/discretion prose into the system prompt, leaving only the per-turn facts on the message. That preserves byte-identity because the block is smaller for everyone, not smaller only in history. It is a larger change than this ticket and worth its own ticket.

Also not done: no change to what is persisted, no change to `loadFromDb` rehydration, no feature flag.

## Testing

- New `assistant/src/__tests__/channel-capabilities-dedupe.test.ts` (11 tests). The bug-catching one asserts a 50-turn conversation carries exactly one copy where raw history carries 50. It also asserts the cache invariant directly — a message renders identically whether 2 or 20 turns follow it — plus idempotency, mid-conversation capability changes, user-authored text that merely mentions the tag, and never emptying a row.
- 20 potentially affected suites re-run, all green, including `prompt-cache-cross-turn-stability` (12 pass), `conversation-runtime-assembly` (204), `conversation-agent-loop` (83), `memory-retrospective-job` (83), `conversation-lifecycle` (23), and the 9 compactor suites.
- `bun run typecheck` clean; eslint and prettier clean.

Closes JARVIS-1494.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
