### PR TITLE
polish: borderless Notice, larger compact Button text, Figma-matched …

### DIFF
--- a/clients/web/src/components/add-credential-modal.tsx
+++ b/clients/web/src/components/add-credential-modal.tsx
@@ -162,8 +162,8 @@ export function AddCredentialModal({
     >
       <Modal.Content size="sm">
         <form onSubmit={handleSave}>
-          <Modal.Header>
-            <Modal.Title icon={KeyRound}>Add credential</Modal.Title>
+          <Modal.Header icon={KeyRound}>
+            <Modal.Title>Add credential</Modal.Title>
             <Modal.Description>
               Add an API key or token to let tools and integrations use it.
             </Modal.Description>

--- a/clients/web/src/components/disk-pressure-banner.tsx
+++ b/clients/web/src/components/disk-pressure-banner.tsx
@@ -218,10 +218,8 @@ export function DiskPressureBanner(props: DiskPressureBannerProps) {
         }}
       >
         <Modal.Content size="sm">
-          <Modal.Header>
-            <Modal.Title icon={AlertTriangle}>
-              Storage is critically low
-            </Modal.Title>
+          <Modal.Header icon={AlertTriangle}>
+            <Modal.Title>Storage is critically low</Modal.Title>
           </Modal.Header>
           <Modal.Body>
             <Modal.Description>

--- a/clients/web/src/domains/chat/components/mic-permission-primer.tsx
+++ b/clients/web/src/domains/chat/components/mic-permission-primer.tsx
@@ -58,8 +58,8 @@ export function MicPermissionPrimer({
       }}
     >
       <Modal.Content size="sm">
-        <Modal.Header>
-          <Modal.Title icon={Mic}>Microphone Access</Modal.Title>
+        <Modal.Header icon={Mic}>
+          <Modal.Title>Microphone Access</Modal.Title>
         </Modal.Header>
         <Modal.Body>
           <Modal.Description>

--- a/clients/web/src/domains/chat/components/vellum-file-action-modal.tsx
+++ b/clients/web/src/domains/chat/components/vellum-file-action-modal.tsx
@@ -79,10 +79,8 @@ export function VellumFileActionModal({
       }}
     >
       <Modal.Content size="sm">
-        <Modal.Header>
-          <Modal.Title icon={iconForFilename(target.filename)}>
-            {target.filename}
-          </Modal.Title>
+        <Modal.Header icon={iconForFilename(target.filename)}>
+          <Modal.Title>{target.filename}</Modal.Title>
           {target.workspacePath ? (
             <Modal.Description className="truncate font-mono">
               {target.workspacePath}

--- a/clients/web/src/domains/chat/inspector/components/export-progress-modal.tsx
+++ b/clients/web/src/domains/chat/inspector/components/export-progress-modal.tsx
@@ -67,16 +67,16 @@ export function ExportProgressModal({
           }
         }}
       >
-        <Modal.Header>
-          <Modal.Title
-            icon={
-              phase === "error"
-                ? AlertCircle
-                : phase === "done"
-                  ? CheckCircle2
-                  : Download
-            }
-          >
+        <Modal.Header
+          icon={
+            phase === "error"
+              ? AlertCircle
+              : phase === "done"
+                ? CheckCircle2
+                : Download
+          }
+        >
+          <Modal.Title>
             {phase === "error"
               ? "Export failed"
               : phase === "done"

--- a/clients/web/src/domains/contacts/components/contact-merge-dialog.tsx
+++ b/clients/web/src/domains/contacts/components/contact-merge-dialog.tsx
@@ -70,8 +70,8 @@ function ContactMergeDialogInner({
       }}
     >
       <Modal.Content size="md">
-        <Modal.Header>
-          <Modal.Title icon={GitMerge}>
+        <Modal.Header icon={GitMerge}>
+          <Modal.Title>
             {donor
               ? `Merge "${donor.displayName}" into ${survivorLabel}?`
               : `Merge another contact into ${survivorLabel}`}

--- a/clients/web/src/domains/onboarding/components/add-remote-origin-dialog.tsx
+++ b/clients/web/src/domains/onboarding/components/add-remote-origin-dialog.tsx
@@ -114,8 +114,8 @@ function AddRemoteOriginDialog({
       }}
     >
       <Modal.Content size="md">
-        <Modal.Header>
-          <Modal.Title icon={Globe}>Add a Remote Assistant</Modal.Title>
+        <Modal.Header icon={Globe}>
+          <Modal.Title>Add a Remote Assistant</Modal.Title>
           <Modal.Description>
             Paste the https link your assistant&rsquo;s pairing page gave you.
           </Modal.Description>

--- a/clients/web/src/domains/onboarding/components/connect-assistant-dialog.tsx
+++ b/clients/web/src/domains/onboarding/components/connect-assistant-dialog.tsx
@@ -105,8 +105,8 @@ function ConnectAssistantDialog({
         }}
       >
         <Modal.Content size="sm">
-          <Modal.Header>
-            <Modal.Title icon={Link2}>Pairing Imported</Modal.Title>
+          <Modal.Header icon={Link2}>
+            <Modal.Title>Pairing Imported</Modal.Title>
           </Modal.Header>
           <Modal.Body>
             <Notice tone="warning">
@@ -138,8 +138,8 @@ function ConnectAssistantDialog({
       }}
     >
       <Modal.Content size="md">
-        <Modal.Header>
-          <Modal.Title icon={Link2}>Connect a Remote Assistant</Modal.Title>
+        <Modal.Header icon={Link2}>
+          <Modal.Title>Connect a Remote Assistant</Modal.Title>
           <Modal.Description>
             On the assistant&rsquo;s machine, run{" "}
             <code>vellum pair --url https://...</code> and paste the bundle

--- a/clients/web/src/domains/settings/billing/plans/free-downgrade-confirm-modal.tsx
+++ b/clients/web/src/domains/settings/billing/plans/free-downgrade-confirm-modal.tsx
@@ -43,8 +43,8 @@ export function FreeDowngradeConfirmModal({
       }}
     >
       <Modal.Content size="md" hideCloseButton>
-        <Modal.Header>
-          <Modal.Title icon={AlertTriangle}>Downgrade to Base?</Modal.Title>
+        <Modal.Header icon={AlertTriangle}>
+          <Modal.Title>Downgrade to Base?</Modal.Title>
         </Modal.Header>
         <Modal.Body>
           <Typography

--- a/clients/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/clients/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -541,10 +541,8 @@ export function AdjustPlanModal({
         <Modal.Content size={view === "plans" ? "lg" : "md"}>
           {view === "downgrade-confirm" ? (
             <>
-              <Modal.Header>
-                <Modal.Title icon={AlertTriangle}>
-                  Downgrade to Base?
-                </Modal.Title>
+              <Modal.Header icon={AlertTriangle}>
+                <Modal.Title>Downgrade to Base?</Modal.Title>
               </Modal.Header>
               <Modal.Body>
                 <Typography

--- a/clients/web/src/domains/settings/components/downgrade-reconfirm-modal.tsx
+++ b/clients/web/src/domains/settings/components/downgrade-reconfirm-modal.tsx
@@ -29,8 +29,8 @@ export function DowngradeReconfirmModal({
       }}
     >
       <Modal.Content size="md" hideCloseButton>
-        <Modal.Header>
-          <Modal.Title icon={AlertTriangle}>Downgrade to Base?</Modal.Title>
+        <Modal.Header icon={AlertTriangle}>
+          <Modal.Title>Downgrade to Base?</Modal.Title>
         </Modal.Header>
         <Modal.Body>
           <Typography

--- a/clients/web/src/domains/settings/components/preview-release-channel.tsx
+++ b/clients/web/src/domains/settings/components/preview-release-channel.tsx
@@ -411,8 +411,8 @@ function OptInModal({
   return (
     <Modal.Root open={open} onOpenChange={(next) => !next && onCancel()}>
       <Modal.Content size="md" hideCloseButton={isPending}>
-        <Modal.Header>
-          <Modal.Title icon={AlertTriangle}>Opt in to Preview</Modal.Title>
+        <Modal.Header icon={AlertTriangle}>
+          <Modal.Title>Opt in to Preview</Modal.Title>
           <Modal.Description>
             Preview releases may be unstable. A 90-day safety backup is taken
             before the image changes.
@@ -483,8 +483,8 @@ function OptOutModal({
   return (
     <Modal.Root open={open} onOpenChange={(next) => !next && onCancel()}>
       <Modal.Content size="md" hideCloseButton={isPending}>
-        <Modal.Header>
-          <Modal.Title icon={AlertTriangle}>Switch back to Stable</Modal.Title>
+        <Modal.Header icon={AlertTriangle}>
+          <Modal.Title>Switch back to Stable</Modal.Title>
           <Modal.Description>
             Choose how this assistant should leave the Preview channel.
           </Modal.Description>

--- a/clients/web/src/domains/settings/components/resize-card.tsx
+++ b/clients/web/src/domains/settings/components/resize-card.tsx
@@ -426,8 +426,8 @@ export function ResizeCard({
         }}
       >
         <Modal.Content size="sm">
-          <Modal.Header>
-            <Modal.Title icon={Server}>Resize Assistant</Modal.Title>
+          <Modal.Header icon={Server}>
+            <Modal.Title>Resize Assistant</Modal.Title>
             <Modal.Description>
               Resize your assistant's compute and storage. Your assistant will
               briefly restart.

--- a/clients/web/src/domains/settings/credentials/credentials-page.tsx
+++ b/clients/web/src/domains/settings/credentials/credentials-page.tsx
@@ -423,8 +423,8 @@ function CredentialsPageInner() {
         }}
       >
         <Modal.Content size="sm">
-          <Modal.Header>
-            <Modal.Title icon={Link2}>One-time credential link</Modal.Title>
+          <Modal.Header icon={Link2}>
+            <Modal.Title>One-time credential link</Modal.Title>
             <Modal.Description>
               {generatedLink
                 ? `Send this link to whoever should provide ${generatedLink.name}. It works exactly once${

--- a/clients/web/src/domains/settings/mcp/mcp-add-server-modal.tsx
+++ b/clients/web/src/domains/settings/mcp/mcp-add-server-modal.tsx
@@ -144,8 +144,8 @@ export function McpAddServerModal({
       }}
     >
       <Modal.Content size="md">
-        <Modal.Header>
-          <Modal.Title icon={Cable}>Add MCP Server</Modal.Title>
+        <Modal.Header icon={Cable}>
+          <Modal.Title>Add MCP Server</Modal.Title>
           <Modal.Description>
             Connect to a Model Context Protocol server to extend available
             tools.

--- a/clients/web/src/domains/settings/mcp/mcp-server-detail-modal.tsx
+++ b/clients/web/src/domains/settings/mcp/mcp-server-detail-modal.tsx
@@ -124,8 +124,8 @@ export function McpServerDetailModal({
       }}
     >
       <Modal.Content size="lg">
-        <Modal.Header>
-          <Modal.Title icon={Cable}>{server.id}</Modal.Title>
+        <Modal.Header icon={Cable}>
+          <Modal.Title>{server.id}</Modal.Title>
           <Modal.Description>
             {server.transport.type} transport &middot; {server.status}
           </Modal.Description>

--- a/packages/design-library/src/components/button.test.tsx
+++ b/packages/design-library/src/components/button.test.tsx
@@ -258,9 +258,9 @@ describe("Button class output", () => {
     expect(html).toContain("text-body-medium-default");
   });
 
-  test("compact size applies text-label-medium-default typography class", () => {
+  test("compact size applies text-body-small-default typography class", () => {
     const html = renderToStaticMarkup(<Button size="compact">C</Button>);
-    expect(html).toContain("text-label-medium-default");
+    expect(html).toContain("text-body-small-default");
   });
 
   test("ghost icon-only button expands to a circular mobile tap target by default", () => {

--- a/packages/design-library/src/components/button.tsx
+++ b/packages/design-library/src/components/button.tsx
@@ -112,7 +112,7 @@ const buttonVariants = cva(
       },
       size: {
         regular: "h-8 px-2.5 text-body-medium-default rounded-md",
-        compact: "h-6 px-2 text-label-medium-default rounded-md",
+        compact: "h-6 px-2 text-body-small-default rounded-[6px]",
       },
       iconOnly: {
         true: "p-0",

--- a/packages/design-library/src/components/confirm-dialog.tsx
+++ b/packages/design-library/src/components/confirm-dialog.tsx
@@ -69,10 +69,8 @@ function ConfirmDialog({
           if (!isPending) onCancel();
         }}
       >
-        <Modal.Header>
-          <Modal.Title icon={destructive ? AlertTriangle : undefined}>
-            {title}
-          </Modal.Title>
+        <Modal.Header icon={destructive ? AlertTriangle : undefined}>
+          <Modal.Title>{title}</Modal.Title>
         </Modal.Header>
         <Modal.Body>
           <Modal.Description>{message}</Modal.Description>

--- a/packages/design-library/src/components/modal.stories.tsx
+++ b/packages/design-library/src/components/modal.stories.tsx
@@ -47,10 +47,8 @@ export const Default: Story = {
         <Button>Open Modal</Button>
       </Modal.Trigger>
       <Modal.Content size={size} hideCloseButton={hideCloseButton}>
-        <Modal.Header>
-          <Modal.Title icon={showIcon ? Settings : undefined}>
-            {title}
-          </Modal.Title>
+        <Modal.Header icon={showIcon ? Settings : undefined}>
+          <Modal.Title>{title}</Modal.Title>
           {description ? (
             <Modal.Description>{description}</Modal.Description>
           ) : null}
@@ -97,10 +95,8 @@ export const NoCloseButton: Story = {
         <Button>Open (no close button)</Button>
       </Modal.Trigger>
       <Modal.Content size={size} hideCloseButton={hideCloseButton}>
-        <Modal.Header>
-          <Modal.Title icon={showIcon ? Settings : undefined}>
-            {title}
-          </Modal.Title>
+        <Modal.Header icon={showIcon ? Settings : undefined}>
+          <Modal.Title>{title}</Modal.Title>
         </Modal.Header>
         <Modal.Body>
           {description ? (
@@ -151,10 +147,8 @@ export const Sizes: Story = {
         ))}
         <Modal.Root open={open} onOpenChange={setOpen}>
           <Modal.Content size={activeSize} hideCloseButton={hideCloseButton}>
-            <Modal.Header>
-              <Modal.Title icon={showIcon ? Settings : undefined}>
-                Size: {activeSize}
-              </Modal.Title>
+            <Modal.Header icon={showIcon ? Settings : undefined}>
+              <Modal.Title>Size: {activeSize}</Modal.Title>
             </Modal.Header>
             <Modal.Body>
               <p className="text-body-medium-default">{body}</p>

--- a/packages/design-library/src/components/modal.tsx
+++ b/packages/design-library/src/components/modal.tsx
@@ -140,17 +140,19 @@ function Title({
       ref={ref}
       data-slot="modal-title"
       className={cn(
-        // `text-title-*` set line-height: 1, leaving no room under the
-        // baseline, so `truncate`'s `overflow: hidden` shears glyph
-        // descenders (the tail of a g/p/y in a title like "Upgrade to
-        // Super?"). `leading-snug` grows the line box to contain them;
-        // single-line ellipsis still works.
-        "min-w-0 truncate text-title-medium leading-snug text-[var(--content-emphasised)]",
+        "text-title-medium text-[var(--content-emphasised)]",
         className,
       )}
       {...props}
     >
-      {children}
+      {/* `text-title-*` set line-height: 1, leaving no room under the
+          baseline, so `truncate`'s `overflow: hidden` shears glyph
+          descenders (the tail of a g/p/y in a title like "Upgrade to
+          Super?"). `leading-snug` grows the line box to contain them;
+          single-line ellipsis still works. Kept as a child span (rather
+          than truncating the root) so callers can opt a long title back
+          into wrapping via `[&>span]:whitespace-normal`. */}
+      <span className="min-w-0 truncate leading-snug">{children}</span>
     </Dialog.Title>
   );
 }
@@ -183,7 +185,7 @@ function Close(props: ComponentProps<typeof Dialog.Close>) {
 interface ModalHeaderProps extends ComponentProps<"div"> {
   /**
    * Leading glyph shown beside the title/description column, sized and
-   * centered against the whole column rather than just the title line —
+   * centered against the whole column rather than just the title line:
    * matches Figma's icon+title+subtitle header layout.
    */
   icon?: LucideIcon;

--- a/packages/design-library/src/components/modal.tsx
+++ b/packages/design-library/src/components/modal.tsx
@@ -127,12 +127,9 @@ function Content({
   );
 }
 
-interface ModalTitleProps extends ComponentProps<typeof Dialog.Title> {
-  icon?: LucideIcon;
-}
+type ModalTitleProps = ComponentProps<typeof Dialog.Title>;
 
 function Title({
-  icon: Icon,
   className,
   children,
   ref,
@@ -143,28 +140,17 @@ function Title({
       ref={ref}
       data-slot="modal-title"
       className={cn(
-        "flex items-center gap-3 text-title-medium text-[var(--content-default)]",
+        // `text-title-*` set line-height: 1, leaving no room under the
+        // baseline, so `truncate`'s `overflow: hidden` shears glyph
+        // descenders (the tail of a g/p/y in a title like "Upgrade to
+        // Super?"). `leading-snug` grows the line box to contain them;
+        // single-line ellipsis still works.
+        "min-w-0 truncate text-title-medium leading-snug text-[var(--content-emphasised)]",
         className,
       )}
       {...props}
     >
-      {Icon ? (
-        <span
-          aria-hidden="true"
-          className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full"
-          style={{
-            backgroundColor:
-              "color-mix(in oklab, var(--primary-base) 16%, transparent)",
-          }}
-        >
-          <Icon className="h-5 w-5 text-[var(--primary-base)]" />
-        </span>
-      ) : null}
-      {/* `text-title-*` set line-height: 1, leaving no room under the baseline,
-          so `truncate`'s `overflow: hidden` shears glyph descenders (the tail
-          of a g/p/y in a title like "Upgrade to Super?"). `leading-snug` grows
-          the line box to contain them; single-line ellipsis still works. */}
-      <span className="min-w-0 truncate leading-snug">{children}</span>
+      {children}
     </Dialog.Title>
   );
 }
@@ -180,7 +166,7 @@ function Description({
       ref={ref}
       data-slot="modal-description"
       className={cn(
-        "mt-1 whitespace-pre-line text-body-medium-lighter text-[var(--content-secondary)]",
+        "mt-0.5 whitespace-pre-line text-body-small-default text-[var(--content-tertiary)]",
         className,
       )}
       {...props}
@@ -194,18 +180,36 @@ function Close(props: ComponentProps<typeof Dialog.Close>) {
   return <Dialog.Close data-slot="modal-close" {...props} />;
 }
 
+interface ModalHeaderProps extends ComponentProps<"div"> {
+  /**
+   * Leading glyph shown beside the title/description column, sized and
+   * centered against the whole column rather than just the title line —
+   * matches Figma's icon+title+subtitle header layout.
+   */
+  icon?: LucideIcon;
+}
+
 function Header({
+  icon: Icon,
   className,
   children,
   ...props
-}: ComponentProps<"div">) {
+}: ModalHeaderProps) {
   return (
     <div
       data-slot="modal-header"
-      className={cn("flex flex-col gap-1 p-4 pr-10", className)}
+      className={cn("flex items-center gap-3 p-4 pr-10", className)}
       {...props}
     >
-      {children}
+      {Icon ? (
+        <span
+          aria-hidden="true"
+          className="flex h-11 w-11 shrink-0 items-center justify-center rounded-md bg-[var(--surface-base)]"
+        >
+          <Icon className="h-5 w-5 text-[var(--primary-base)]" />
+        </span>
+      ) : null}
+      <div className="flex min-w-0 flex-1 flex-col">{children}</div>
     </div>
   );
 }
@@ -258,4 +262,4 @@ const Modal = {
 };
 
 export { Modal };
-export type { ModalSize, ModalContentProps, ModalTitleProps };
+export type { ModalSize, ModalContentProps, ModalTitleProps, ModalHeaderProps };

--- a/packages/design-library/src/components/modal.tsx
+++ b/packages/design-library/src/components/modal.tsx
@@ -204,14 +204,18 @@ function Header({
       {...props}
     >
       {Icon ? (
-        <span
-          aria-hidden="true"
-          className="flex h-11 w-11 shrink-0 items-center justify-center rounded-md bg-[var(--surface-base)]"
-        >
-          <Icon className="h-5 w-5 text-[var(--primary-base)]" />
-        </span>
-      ) : null}
-      <div className="flex min-w-0 flex-1 flex-col">{children}</div>
+        <>
+          <span
+            aria-hidden="true"
+            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-md bg-[var(--surface-base)]"
+          >
+            <Icon className="h-5 w-5 text-[var(--primary-base)]" />
+          </span>
+          <div className="flex min-w-0 flex-1 flex-col">{children}</div>
+        </>
+      ) : (
+        children
+      )}
     </div>
   );
 }

--- a/packages/design-library/src/components/notice.stories.tsx
+++ b/packages/design-library/src/components/notice.stories.tsx
@@ -81,10 +81,14 @@ export const WithActions: Story = {
     title: "Action Required",
     children: "Your session is about to expire.",
     actions: (
-      <div style={{ display: "flex", gap: "0.5rem" }}>
-        <button type="button">Renew</button>
-        <button type="button">Sign out</button>
-      </div>
+      <>
+        <Button variant="primary" size="compact">
+          Renew
+        </Button>
+        <Button variant="ghost" size="compact">
+          Sign out
+        </Button>
+      </>
     ),
   },
 };

--- a/packages/design-library/src/components/notice.tsx
+++ b/packages/design-library/src/components/notice.tsx
@@ -31,31 +31,27 @@ interface ToneClasses {
 
 const TONE_CLASSES: Record<NoticeTone, ToneClasses> = {
   info: {
-    container:
-      "bg-[var(--surface-overlay)] border-[var(--border-element)]",
+    container: "bg-[var(--surface-overlay)]",
     icon: "text-[color:var(--content-secondary)]",
     DefaultIcon: Info,
   },
   success: {
-    container:
-      "bg-[var(--system-positive-weak)] border-[color-mix(in_srgb,var(--system-positive-strong)_25%,transparent)]",
+    container: "bg-[var(--system-positive-weak)]",
     icon: "text-[color:var(--system-positive-strong)]",
     DefaultIcon: CircleCheck,
   },
   warning: {
-    container:
-      "bg-[var(--system-mid-weak)] border-[color-mix(in_srgb,var(--system-mid-strong)_30%,transparent)]",
+    container: "bg-[var(--system-mid-weak)]",
     icon: "text-[color:var(--system-mid-strong)]",
     DefaultIcon: CircleAlert,
   },
   error: {
-    container:
-      "bg-[var(--system-negative-weak)] border-[color-mix(in_srgb,var(--system-negative-strong)_25%,transparent)]",
+    container: "bg-[var(--system-negative-weak)]",
     icon: "text-[color:var(--system-negative-strong)]",
     DefaultIcon: TriangleAlert,
   },
   neutral: {
-    container: "bg-[var(--surface-overlay)] border-[var(--border-base)]",
+    container: "bg-[var(--surface-overlay)]",
     icon: "text-[color:var(--content-secondary)]",
     DefaultIcon: null,
   },
@@ -94,7 +90,7 @@ export function Notice({
       role={role}
       data-slot="notice"
       className={cn(
-        "relative flex w-full gap-3 rounded-lg border p-3",
+        "relative flex w-full gap-3 rounded-lg p-3",
         alignTop ? "items-start" : "items-center",
         "text-[color:var(--content-default)]",
         toneClasses.container,

--- a/packages/design-library/src/index.ts
+++ b/packages/design-library/src/index.ts
@@ -106,6 +106,7 @@ export {
   type ModalSize,
   type ModalContentProps,
   type ModalTitleProps,
+  type ModalHeaderProps,
 } from "./components/modal";
 export {
   BottomSheet,


### PR DESCRIPTION
…Modal header

Notice drops its border entirely. Button's compact size moves from the 11px label scale to the 12px body scale for readability, with a matching 6px radius. Modal's icon moves from Title to Header so it centers against the whole title+subtitle column instead of just the title line, with typography, color, spacing, and icon-tile styling brought in line with the Figma reference (title bumped one step to text-title-medium, subtitle color/weight matched to --content-tertiary, icon tile at 44px/8px radius/ --surface-base, 12px icon-to-text gap, 2px title-to-subtitle gap).

<!-- PR title format: type(scope): description -->
<!-- Examples: feat(slack): add user token support, fix(cli): handle missing config, docs(architecture): update API table -->

## Prompt / plan
<!-- What prompt or plan was used to generate this code? Link to a plan file, paste the prompt, or describe the approach. -->

## Test plan
<!-- How was this change verified? e.g. unit tests, manual testing, CI checks -->

## CLI verb checklist
<!-- For PRs that add a new IPC route under assistant/src/runtime/routes/: -->
<!-- - [ ] Does this route need an `assistant` CLI verb? If yes, add a thin -->
<!--       wrapper in assistant/src/cli/commands/ via registerCommand (same -->
<!--       PR or a follow-up). -->
<!-- - [ ] If no, leave a one-line note explaining why (e.g. internal-only, -->
<!--       composed by another command). -->
<!-- Delete this section if your PR does not add any new routes. -->
