### PR TITLE
feat(web): render skill activity as purpose-built UI (LUM-2999)

### DIFF
--- a/clients/web/src/components/detail-primitives.tsx
+++ b/clients/web/src/components/detail-primitives.tsx
@@ -1,0 +1,100 @@
+/**
+ * Small presentational primitives shared by side-drawer detail panels: the
+ * copy-to-clipboard button, the `<pre>` code block that wraps it, and the
+ * uppercase section label.
+ *
+ * Extracted from `tool-detail-panel.tsx` so tool-specific activity renderers
+ * (`domains/chat/components/tool-activity/`) can compose them without importing
+ * the panel that in turn imports those renderers. `tool-detail-panel` re-exports
+ * `CodeBlock` and `SectionLabel` so its existing consumers are unaffected.
+ */
+
+import { Check, Copy } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+import { Typography } from "@vellumai/design-library";
+
+import { copyToClipboard } from "@/lib/copy-to-clipboard";
+
+const COPIED_RESET_MS = 1500;
+
+/**
+ * Small ghost button that copies `text` to the clipboard and shows a transient
+ * "Copied" confirmation. Positioned by the caller (top-right of a `<pre>`).
+ */
+export function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const handleCopy = () => {
+    copyToClipboard(text, {
+      errorMessage: "Couldn't copy.",
+      onCopied: () => {
+        setCopied(true);
+        if (timeoutRef.current) {
+          clearTimeout(timeoutRef.current);
+        }
+        timeoutRef.current = setTimeout(
+          () => setCopied(false),
+          COPIED_RESET_MS,
+        );
+      },
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      aria-label={copied ? "Copied" : "Copy"}
+      className="absolute right-2 top-2 flex items-center gap-1 rounded p-1 text-label-small-default text-[var(--content-tertiary)] transition-colors hover:bg-[var(--ghost-hover)] hover:text-[var(--content-default)]"
+    >
+      {copied ? (
+        <Check className="h-3.5 w-3.5" />
+      ) : (
+        <Copy className="h-3.5 w-3.5" />
+      )}
+      {copied ? "Copied" : null}
+    </button>
+  );
+}
+
+/** A `<pre>` code block with a copy button positioned in the top-right. */
+export function CodeBlock({ text }: { text: string }) {
+  return (
+    <div className="relative">
+      <pre className="rounded-lg border border-[var(--border-base)] bg-[var(--surface-overlay)] p-3 font-mono text-xs whitespace-pre-wrap break-words text-[var(--content-default)]">
+        {text}
+      </pre>
+      <CopyButton text={text} />
+    </div>
+  );
+}
+
+/** Uppercase section label in `--content-tertiary`. */
+export function SectionLabel({
+  children,
+  className = "mb-1.5",
+}: {
+  children: string;
+  /** Margin override for rows that manage their own spacing. */
+  className?: string;
+}) {
+  return (
+    <Typography
+      variant="label-small-default"
+      as="div"
+      className={`uppercase tracking-wider text-[var(--content-tertiary)] ${className}`}
+    >
+      {children}
+    </Typography>
+  );
+}

--- a/clients/web/src/components/detail-primitives.tsx
+++ b/clients/web/src/components/detail-primitives.tsx
@@ -79,10 +79,16 @@ export function CodeBlock({ text }: { text: string }) {
   );
 }
 
-/** Uppercase section label in `--content-tertiary`. */
+/**
+ * Uppercase section label in `--content-tertiary`.
+ *
+ * `leading-4` is deliberate: the `label-small-default` token ships
+ * `line-height: 1`, which leaves no room below the baseline and clips glyph
+ * tails. Size is unchanged.
+ */
 export function SectionLabel({
   children,
-  className = "mb-1.5",
+  className = "mb-2",
 }: {
   children: string;
   /** Margin override for rows that manage their own spacing. */
@@ -92,7 +98,7 @@ export function SectionLabel({
     <Typography
       variant="label-small-default"
       as="div"
-      className={`uppercase tracking-wider text-[var(--content-tertiary)] ${className}`}
+      className={`uppercase leading-4 tracking-wider text-[var(--content-tertiary)] ${className}`}
     >
       {children}
     </Typography>

--- a/clients/web/src/domains/chat/components/activity-steps-panel.tsx
+++ b/clients/web/src/domains/chat/components/activity-steps-panel.tsx
@@ -307,7 +307,7 @@ function StepDetailLevel({
           assistantId={assistantId}
         />
       ) : (
-        <ToolDetailBody detail={detail} />
+        <ToolDetailBody detail={detail} assistantId={assistantId} />
       )}
     </div>
   );

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -398,7 +398,10 @@ export function SubagentDetailPanel({
               ) : activeDetail.toolName === "web_fetch" ? (
                 <WebFetchDetailView detail={activeDetail} />
               ) : (
-                <ToolDetailBody detail={activeDetail} />
+                <ToolDetailBody
+                  detail={activeDetail}
+                  assistantId={assistantId}
+                />
               )}
             </>
           ) : (

--- a/clients/web/src/domains/chat/components/tool-activity/detail-disclosure.tsx
+++ b/clients/web/src/domains/chat/components/tool-activity/detail-disclosure.tsx
@@ -1,0 +1,63 @@
+/**
+ * Expandable section used by the tool-specific activity renderers to keep long
+ * secondary content (a skill's full instruction body, the raw JSON escape
+ * hatch) out of the way without hiding it.
+ *
+ * Wraps the design-library `Collapsible` primitive with the chrome this drawer
+ * uses: a chevron that rotates on open, a tertiary uppercase label, and an
+ * optional right-aligned hint (e.g. a line count).
+ */
+
+import { ChevronRight } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { Collapsible, Typography } from "@vellumai/design-library";
+
+export function DetailDisclosure({
+  label,
+  hint,
+  defaultOpen = false,
+  children,
+}: {
+  /** Uppercase section label, e.g. "Instructions". */
+  label: string;
+  /** Optional right-aligned secondary text, e.g. "412 lines". */
+  hint?: string;
+  /** Whether the section starts expanded. */
+  defaultOpen?: boolean;
+  children: ReactNode;
+}) {
+  const value = `disclosure-${label}`;
+  return (
+    <Collapsible.Root
+      type="single"
+      collapsible
+      defaultValue={defaultOpen ? value : undefined}
+    >
+      <Collapsible.Item value={value}>
+        <Collapsible.Trigger className="group gap-1.5 py-1 text-left">
+          <ChevronRight className="h-3.5 w-3.5 shrink-0 text-[var(--content-tertiary)] transition-transform group-data-[state=open]:rotate-90" />
+          <Typography
+            variant="label-small-default"
+            as="span"
+            className="uppercase tracking-wider text-[var(--content-tertiary)]"
+          >
+            {label}
+          </Typography>
+          {hint && (
+            <Typography
+              variant="label-small-default"
+              as="span"
+              className="ml-auto pl-2 text-[var(--content-tertiary)]"
+            >
+              {hint}
+            </Typography>
+          )}
+        </Collapsible.Trigger>
+        <Collapsible.Content>
+          <div className="pt-2">{children}</div>
+        </Collapsible.Content>
+      </Collapsible.Item>
+    </Collapsible.Root>
+  );
+}

--- a/clients/web/src/domains/chat/components/tool-activity/detail-disclosure.tsx
+++ b/clients/web/src/domains/chat/components/tool-activity/detail-disclosure.tsx
@@ -37,10 +37,11 @@ export function DetailDisclosure({
       <Collapsible.Item value={value}>
         <Collapsible.Trigger className="group gap-1.5 py-1 text-left">
           <ChevronRight className="h-3.5 w-3.5 shrink-0 text-[var(--content-tertiary)] transition-transform group-data-[state=open]:rotate-90" />
+          {/* `leading-4` clears the `line-height: 1` on the label token. */}
           <Typography
             variant="label-small-default"
             as="span"
-            className="uppercase tracking-wider text-[var(--content-tertiary)]"
+            className="uppercase leading-4 tracking-wider text-[var(--content-tertiary)]"
           >
             {label}
           </Typography>
@@ -48,7 +49,7 @@ export function DetailDisclosure({
             <Typography
               variant="label-small-default"
               as="span"
-              className="ml-auto pl-2 text-[var(--content-tertiary)]"
+              className="ml-auto pl-2 leading-4 text-[var(--content-tertiary)]"
             >
               {hint}
             </Typography>

--- a/clients/web/src/domains/chat/components/tool-activity/skill-execute-detail.tsx
+++ b/clients/web/src/domains/chat/components/tool-activity/skill-execute-detail.tsx
@@ -1,0 +1,134 @@
+/**
+ * Purpose-built activity UI for a `skill_execute` call (LUM-2999).
+ *
+ * `skill_execute` is an envelope — `{ tool, input, activity }` — so the generic
+ * JSON dump buried the thing the reader actually cares about (which tool ran,
+ * with which parameters) one level down, wrapped in machine plumbing. This
+ * renderer unwraps it: the inner tool leads, the activity sentence explains it,
+ * and the inner parameters render as a labelled list instead of JSON.
+ */
+
+import { Plug } from "lucide-react";
+
+import { Typography } from "@vellumai/design-library";
+
+import { CodeBlock, SectionLabel } from "@/components/detail-primitives";
+import { DetailDisclosure } from "@/domains/chat/components/tool-activity/detail-disclosure";
+import { friendlyName } from "@/domains/chat/components/tool-call-chip/utils";
+import { parseSkillExecuteActivity } from "@/domains/chat/utils/skill-activity";
+import type { SkillExecuteParam } from "@/domains/chat/utils/skill-activity";
+import type { ToolActivityRendererProps } from "@/domains/chat/components/tool-activity/types";
+
+/**
+ * Scalar strings longer than this render in their own wrapped block rather
+ * than inline beside the key, so a long prompt or file body stays readable
+ * instead of squeezing the label column.
+ */
+const INLINE_SCALAR_MAX_CHARS = 48;
+
+function ParamRow({ param }: { param: SkillExecuteParam }) {
+  const inline =
+    param.scalar !== null &&
+    param.scalar.length <= INLINE_SCALAR_MAX_CHARS &&
+    !param.scalar.includes("\n");
+
+  return (
+    <div
+      className={
+        inline ? "flex items-baseline justify-between gap-3" : "flex flex-col"
+      }
+    >
+      <Typography
+        variant="label-small-default"
+        as="div"
+        className="shrink-0 font-mono text-[var(--content-tertiary)]"
+      >
+        {param.key}
+      </Typography>
+      {param.scalar !== null ? (
+        <Typography
+          variant="body-small-default"
+          as="div"
+          className={
+            inline
+              ? "min-w-0 truncate text-right text-[var(--content-default)]"
+              : "mt-1 whitespace-pre-wrap break-words rounded-lg border border-[var(--border-base)] bg-[var(--surface-overlay)] p-2.5 text-[var(--content-default)]"
+          }
+        >
+          {param.scalar}
+        </Typography>
+      ) : (
+        <div className="mt-1">
+          <CodeBlock text={param.json ?? ""} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function SkillExecuteDetail({
+  detail,
+  isRunning,
+}: ToolActivityRendererProps) {
+  const { innerToolName, activity, params } = parseSkillExecuteActivity(
+    detail.input,
+  );
+
+  const heading = innerToolName ? friendlyName(innerToolName) : "Skill tool";
+  const subtitle = activity || detail.activity;
+
+  return (
+    <div className="flex flex-col gap-5">
+      {/* Inner tool identity — the tool that actually ran, not the envelope. */}
+      <div className="flex items-center gap-2.5">
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-[var(--surface-overlay)]">
+          <Plug className="h-4 w-4 text-[var(--content-secondary)]" />
+        </div>
+        <div className="min-w-0">
+          <Typography
+            variant="body-medium-default"
+            as="div"
+            className="truncate text-[var(--content-default)]"
+          >
+            {heading}
+          </Typography>
+          {innerToolName && (
+            <Typography
+              variant="label-small-default"
+              as="div"
+              className="truncate font-mono text-[var(--content-tertiary)]"
+            >
+              {innerToolName}
+              {isRunning ? " · running" : ""}
+            </Typography>
+          )}
+        </div>
+      </div>
+
+      {subtitle && (
+        <Typography
+          variant="body-small-default"
+          as="p"
+          className="text-[var(--content-secondary)]"
+        >
+          {subtitle}
+        </Typography>
+      )}
+
+      {params.length > 0 && (
+        <div>
+          <SectionLabel>Parameters</SectionLabel>
+          <div className="flex flex-col gap-2.5 rounded-lg border border-[var(--border-base)] p-3">
+            {params.map((param) => (
+              <ParamRow key={param.key} param={param} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      <DetailDisclosure label="Raw input">
+        <CodeBlock text={JSON.stringify(detail.input, null, 2)} />
+      </DetailDisclosure>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/tool-activity/skill-execute-detail.tsx
+++ b/clients/web/src/domains/chat/components/tool-activity/skill-execute-detail.tsx
@@ -35,30 +35,33 @@ function ParamRow({ param }: { param: SkillExecuteParam }) {
   return (
     <div
       className={
-        inline ? "flex items-baseline justify-between gap-3" : "flex flex-col"
+        inline ? "flex items-baseline justify-between gap-4" : "flex flex-col"
       }
     >
+      {/* `leading-5` is deliberate: the `body-small-default` token ships
+          `line-height: 1`, which clips the descenders on keys like `template`
+          and `config`. */}
       <Typography
-        variant="label-small-default"
+        variant="body-small-default"
         as="div"
-        className="shrink-0 font-mono text-[var(--content-tertiary)]"
+        className="shrink-0 font-mono leading-5 text-[var(--content-tertiary)]"
       >
         {param.key}
       </Typography>
       {param.scalar !== null ? (
         <Typography
-          variant="body-small-default"
+          variant="body-medium-default"
           as="div"
           className={
             inline
               ? "min-w-0 truncate text-right text-[var(--content-default)]"
-              : "mt-1 whitespace-pre-wrap break-words rounded-lg border border-[var(--border-base)] bg-[var(--surface-overlay)] p-2.5 text-[var(--content-default)]"
+              : "mt-1.5 whitespace-pre-wrap break-words rounded-lg border border-[var(--border-base)] bg-[var(--surface-overlay)] p-3 leading-relaxed text-[var(--content-default)]"
           }
         >
           {param.scalar}
         </Typography>
       ) : (
-        <div className="mt-1">
+        <div className="mt-1.5">
           <CodeBlock text={param.json ?? ""} />
         </div>
       )}
@@ -94,9 +97,9 @@ export function SkillExecuteDetail({
           </Typography>
           {innerToolName && (
             <Typography
-              variant="label-small-default"
+              variant="body-small-lighter"
               as="div"
-              className="truncate font-mono text-[var(--content-tertiary)]"
+              className="mt-0.5 truncate font-mono text-[var(--content-tertiary)]"
             >
               {innerToolName}
               {isRunning ? " · running" : ""}
@@ -107,7 +110,7 @@ export function SkillExecuteDetail({
 
       {subtitle && (
         <Typography
-          variant="body-small-default"
+          variant="body-small-lighter"
           as="p"
           className="text-[var(--content-secondary)]"
         >
@@ -118,7 +121,7 @@ export function SkillExecuteDetail({
       {params.length > 0 && (
         <div>
           <SectionLabel>Parameters</SectionLabel>
-          <div className="flex flex-col gap-2.5 rounded-lg border border-[var(--border-base)] p-3">
+          <div className="flex flex-col gap-4 rounded-lg border border-[var(--border-base)] p-4">
             {params.map((param) => (
               <ParamRow key={param.key} param={param} />
             ))}

--- a/clients/web/src/domains/chat/components/tool-activity/skill-load-detail.tsx
+++ b/clients/web/src/domains/chat/components/tool-activity/skill-load-detail.tsx
@@ -11,7 +11,7 @@
 
 import { Sparkles } from "lucide-react";
 
-import { Typography } from "@vellumai/design-library";
+import { Skeleton, Typography } from "@vellumai/design-library";
 
 import { CodeBlock, SectionLabel } from "@/components/detail-primitives";
 import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
@@ -55,6 +55,46 @@ function SkillIdentity({
         >
           {status}
         </Typography>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Placeholder for the sections still in flight while `skill_load` runs: the
+ * tool manifest and the instruction body. Mirrors the real layout — bordered
+ * tool cards over staggered prose lines — so the panel doesn't reflow when the
+ * body lands.
+ *
+ * The skill identity row above is NOT skeletonised: the skill id comes from the
+ * call's own input, so it's known immediately and showing it beats a shimmer.
+ */
+function SkillLoadSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-label="Loading skill"
+      className="flex flex-col gap-5"
+    >
+      <div>
+        <SectionLabel>Provides</SectionLabel>
+        <div className="flex flex-col gap-2">
+          {[0, 1].map((row) => (
+            <div
+              key={row}
+              className="rounded-lg border border-[var(--border-base)] bg-[var(--surface-overlay)] p-3"
+            >
+              <Skeleton className="h-3.5 w-32" />
+              <Skeleton className="mt-2 h-3 w-full" />
+              <Skeleton className="mt-1.5 h-3 w-2/3" />
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="flex flex-col gap-1.5">
+        <Skeleton className="h-3 w-full" />
+        <Skeleton className="h-3 w-11/12" />
+        <Skeleton className="h-3 w-4/5" />
       </div>
     </div>
   );
@@ -120,15 +160,7 @@ export function SkillLoadDetail({
         </DetailDisclosure>
       )}
 
-      {isRunning && !instructions && !errorMessage && (
-        <Typography
-          variant="body-small-default"
-          as="p"
-          className="text-[var(--content-tertiary)]"
-        >
-          Loading…
-        </Typography>
-      )}
+      {isRunning && !instructions && !errorMessage && <SkillLoadSkeleton />}
     </div>
   );
 }

--- a/clients/web/src/domains/chat/components/tool-activity/skill-load-detail.tsx
+++ b/clients/web/src/domains/chat/components/tool-activity/skill-load-detail.tsx
@@ -49,9 +49,9 @@ function SkillIdentity({
           {skillId || "Skill"}
         </Typography>
         <Typography
-          variant="body-small-default"
+          variant="body-small-lighter"
           as="div"
-          className="text-[var(--content-secondary)]"
+          className="mt-0.5 text-[var(--content-secondary)]"
         >
           {status}
         </Typography>
@@ -78,20 +78,16 @@ function SkillLoadSkeleton() {
     >
       <div>
         <SectionLabel>Provides</SectionLabel>
-        <div className="flex flex-col gap-2">
+        <div className="flex flex-col gap-4">
           {[0, 1].map((row) => (
-            <div
-              key={row}
-              className="rounded-lg border border-[var(--border-base)] bg-[var(--surface-overlay)] p-3"
-            >
+            <div key={row}>
               <Skeleton className="h-3.5 w-32" />
               <Skeleton className="mt-2 h-3 w-full" />
-              <Skeleton className="mt-1.5 h-3 w-2/3" />
             </div>
           ))}
         </div>
       </div>
-      <div className="flex flex-col gap-1.5">
+      <div className="flex flex-col gap-2">
         <Skeleton className="h-3 w-full" />
         <Skeleton className="h-3 w-11/12" />
         <Skeleton className="h-3 w-4/5" />
@@ -126,9 +122,9 @@ export function SkillLoadDetail({
       <SkillIdentity skillId={skillId} status={status} />
 
       {errorMessage && (
-        <div className="rounded-lg border border-[var(--system-negative-strong)] bg-[var(--system-negative-weak)] p-3">
+        <div className="rounded-lg border border-[var(--system-negative-strong)] bg-[var(--system-negative-weak)] p-4">
           <Typography
-            variant="body-small-default"
+            variant="body-small-lighter"
             as="p"
             className="whitespace-pre-wrap break-words text-[var(--content-default)]"
           >

--- a/clients/web/src/domains/chat/components/tool-activity/skill-load-detail.tsx
+++ b/clients/web/src/domains/chat/components/tool-activity/skill-load-detail.tsx
@@ -27,35 +27,52 @@ import type { ToolActivityRendererProps } from "@/domains/chat/components/tool-a
  */
 const INSTRUCTIONS_AUTO_EXPAND_CHARS = 1200;
 
-/** Leading skill identity row: glyph tile, skill id, and load status. */
+/**
+ * Leading skill identity row: glyph tile, the skill's human name, and load
+ * status. Falls back to the raw id from the call's input until the result's
+ * header lands (or when it carries no `Skill:` line).
+ */
 function SkillIdentity({
-  skillId,
+  name,
+  description,
   status,
 }: {
-  skillId: string;
+  name: string;
+  description: string;
   status: string;
 }) {
   return (
-    <div className="flex items-center gap-2.5">
-      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-[var(--surface-overlay)]">
-        <Sparkles className="h-4 w-4 text-[var(--content-secondary)]" />
+    <div>
+      <div className="flex items-center gap-2.5">
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-[var(--surface-overlay)]">
+          <Sparkles className="h-4 w-4 text-[var(--content-secondary)]" />
+        </div>
+        <div className="min-w-0">
+          <Typography
+            variant="body-medium-default"
+            as="div"
+            className="truncate leading-5 text-[var(--content-default)]"
+          >
+            {name}
+          </Typography>
+          <Typography
+            variant="body-small-lighter"
+            as="div"
+            className="mt-0.5 text-[var(--content-secondary)]"
+          >
+            {status}
+          </Typography>
+        </div>
       </div>
-      <div className="min-w-0">
-        <Typography
-          variant="body-medium-default"
-          as="div"
-          className="truncate text-[var(--content-default)]"
-        >
-          {skillId || "Skill"}
-        </Typography>
+      {description && (
         <Typography
           variant="body-small-lighter"
-          as="div"
-          className="mt-0.5 text-[var(--content-secondary)]"
+          as="p"
+          className="mt-3 text-[var(--content-secondary)]"
         >
-          {status}
+          {description}
         </Typography>
-      </div>
+      )}
     </div>
   );
 }
@@ -103,9 +120,8 @@ export function SkillLoadDetail({
   isError,
   assistantId,
 }: ToolActivityRendererProps) {
-  const { skillId, instructions, tools, errorMessage } = parseSkillLoadActivity(
-    { input: detail.input, result, isError },
-  );
+  const { skillId, displayName, description, instructions, tools, errorMessage } =
+    parseSkillLoadActivity({ input: detail.input, result, isError });
 
   const status = isRunning
     ? "Loading skill…"
@@ -119,7 +135,11 @@ export function SkillLoadDetail({
 
   return (
     <div className="flex flex-col gap-5">
-      <SkillIdentity skillId={skillId} status={status} />
+      <SkillIdentity
+        name={displayName || skillId || "Skill"}
+        description={description}
+        status={status}
+      />
 
       {errorMessage && (
         <div className="rounded-lg border border-[var(--system-negative-strong)] bg-[var(--system-negative-weak)] p-4">

--- a/clients/web/src/domains/chat/components/tool-activity/skill-load-detail.tsx
+++ b/clients/web/src/domains/chat/components/tool-activity/skill-load-detail.tsx
@@ -1,0 +1,134 @@
+/**
+ * Purpose-built activity UI for a `skill_load` call (LUM-2999).
+ *
+ * The generic drawer rendered this call at its worst: `{"skill":"app-builder"}`
+ * as raw JSON input, and the skill's entire instruction body — often thousands
+ * of lines, including a machine-facing "## Available Tools" manifest — dumped
+ * into a monospace `<pre>`. This renderer instead leads with the skill's
+ * identity, turns the manifest into a scannable tool list, and renders the
+ * instructions as actual markdown behind a disclosure.
+ */
+
+import { Sparkles } from "lucide-react";
+
+import { Typography } from "@vellumai/design-library";
+
+import { CodeBlock, SectionLabel } from "@/components/detail-primitives";
+import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
+import { DetailDisclosure } from "@/domains/chat/components/tool-activity/detail-disclosure";
+import { SkillToolList } from "@/domains/chat/components/tool-activity/skill-tool-list";
+import { parseSkillLoadActivity } from "@/domains/chat/utils/skill-activity";
+import type { ToolActivityRendererProps } from "@/domains/chat/components/tool-activity/types";
+
+/**
+ * Instruction bodies shorter than this render expanded; longer ones start
+ * collapsed so the drawer opens on the skill's identity and tools rather than
+ * a wall of prose the reader has to scroll past.
+ */
+const INSTRUCTIONS_AUTO_EXPAND_CHARS = 1200;
+
+/** Leading skill identity row: glyph tile, skill id, and load status. */
+function SkillIdentity({
+  skillId,
+  status,
+}: {
+  skillId: string;
+  status: string;
+}) {
+  return (
+    <div className="flex items-center gap-2.5">
+      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-[var(--surface-overlay)]">
+        <Sparkles className="h-4 w-4 text-[var(--content-secondary)]" />
+      </div>
+      <div className="min-w-0">
+        <Typography
+          variant="body-medium-default"
+          as="div"
+          className="truncate text-[var(--content-default)]"
+        >
+          {skillId || "Skill"}
+        </Typography>
+        <Typography
+          variant="body-small-default"
+          as="div"
+          className="text-[var(--content-secondary)]"
+        >
+          {status}
+        </Typography>
+      </div>
+    </div>
+  );
+}
+
+export function SkillLoadDetail({
+  detail,
+  result,
+  isRunning,
+  isError,
+  assistantId,
+}: ToolActivityRendererProps) {
+  const { skillId, instructions, tools, errorMessage } = parseSkillLoadActivity(
+    { input: detail.input, result, isError },
+  );
+
+  const status = isRunning
+    ? "Loading skill…"
+    : errorMessage
+      ? "Failed to load"
+      : tools.length > 0
+        ? `Loaded · ${tools.length} tool${tools.length === 1 ? "" : "s"}`
+        : "Loaded";
+
+  const instructionLines = instructions ? instructions.split("\n").length : 0;
+
+  return (
+    <div className="flex flex-col gap-5">
+      <SkillIdentity skillId={skillId} status={status} />
+
+      {errorMessage && (
+        <div className="rounded-lg border border-[var(--system-negative-strong)] bg-[var(--system-negative-weak)] p-3">
+          <Typography
+            variant="body-small-default"
+            as="p"
+            className="whitespace-pre-wrap break-words text-[var(--content-default)]"
+          >
+            {errorMessage}
+          </Typography>
+        </div>
+      )}
+
+      {tools.length > 0 && (
+        <div>
+          <SectionLabel>Provides</SectionLabel>
+          <SkillToolList tools={tools} />
+        </div>
+      )}
+
+      {instructions && (
+        <DetailDisclosure
+          label="Instructions"
+          hint={`${instructionLines} line${instructionLines === 1 ? "" : "s"}`}
+          defaultOpen={instructions.length <= INSTRUCTIONS_AUTO_EXPAND_CHARS}
+        >
+          <ChatMarkdownMessage content={instructions} assistantId={assistantId} />
+        </DetailDisclosure>
+      )}
+
+      {typeof result === "string" && result !== "" && (
+        <DetailDisclosure label="Raw output">
+          <CodeBlock text={result} />
+        </DetailDisclosure>
+      )}
+
+      {isRunning && !instructions && !errorMessage && (
+        <Typography
+          variant="body-small-default"
+          as="p"
+          className="text-[var(--content-tertiary)]"
+        >
+          Loading…
+        </Typography>
+      )}
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/tool-activity/skill-tool-list.stories.tsx
+++ b/clients/web/src/domains/chat/components/tool-activity/skill-tool-list.stories.tsx
@@ -57,18 +57,29 @@ const appBuilderTools: SkillToolSummary[] = [
   },
 ];
 
-/** The common case: one skill's own tools, each with typed parameters. */
+/**
+ * The common case: one skill's own tools. Parameter schemas are parsed but
+ * intentionally not rendered — see the note on `SkillToolList`.
+ */
 export const Default: Story = {
   args: { tools: appBuilderTools },
 };
 
-/** A tool the daemon printed with no parameter list. */
-export const WithoutParameters: Story = {
+/** Long descriptions wrap rather than clip, and keep an 18px leading. */
+export const LongDescriptions: Story = {
   args: {
     tools: [
       {
-        name: "app_list",
-        description: "List every app in the user's Library.",
+        name: "app_create",
+        description:
+          "Create a new app in the user's Library, scaffold its folder from an optional starter template, register it with the app catalog, and return the absolute path so subsequent writes can target it.",
+        fromSkill: null,
+        params: [],
+      },
+      {
+        name: "app_deploy_preview",
+        description:
+          "Build the app and open a live preview alongside the conversation, rebuilding on every subsequent change until the preview is dismissed.",
         fromSkill: null,
         params: [],
       },

--- a/clients/web/src/domains/chat/components/tool-activity/skill-tool-list.stories.tsx
+++ b/clients/web/src/domains/chat/components/tool-activity/skill-tool-list.stories.tsx
@@ -1,0 +1,108 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import type { SkillToolSummary } from "@/domains/chat/utils/skill-activity";
+
+import { SkillToolList } from "./skill-tool-list";
+
+const meta: Meta<typeof SkillToolList> = {
+  title: "Chat/ToolActivity/SkillToolList",
+  component: SkillToolList,
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[400px] rounded-xl bg-[var(--surface-lift)] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof SkillToolList>;
+
+const appBuilderTools: SkillToolSummary[] = [
+  {
+    name: "app_create",
+    description: "Create a new app in the user's Library and return its folder path.",
+    fromSkill: null,
+    params: [
+      {
+        name: "name",
+        type: "string",
+        required: true,
+        description: "Display name shown in the Library.",
+      },
+      {
+        name: "template",
+        type: "string",
+        required: false,
+        description: "Starter template id.",
+      },
+    ],
+  },
+  {
+    name: "app_refresh",
+    description: "Rebuild an existing app and refresh any open preview.",
+    fromSkill: null,
+    params: [
+      {
+        name: "app_id",
+        type: "string",
+        required: true,
+        description: "Id returned by app_create.",
+      },
+    ],
+  },
+];
+
+/** The common case: one skill's own tools, each with typed parameters. */
+export const Default: Story = {
+  args: { tools: appBuilderTools },
+};
+
+/** A tool the daemon printed with no parameter list. */
+export const WithoutParameters: Story = {
+  args: {
+    tools: [
+      {
+        name: "app_list",
+        description: "List every app in the user's Library.",
+        fromSkill: null,
+        params: [],
+      },
+    ],
+  },
+};
+
+/**
+ * A composite skill: tools contributed by a nested child skill are grouped
+ * under that skill's name so their provenance stays visible.
+ */
+export const WithChildSkill: Story = {
+  args: {
+    tools: [
+      ...appBuilderTools,
+      {
+        name: "chart_render",
+        description: "Render a chart widget into the current app.",
+        fromSkill: "charting",
+        params: [
+          {
+            name: "series",
+            type: "array",
+            required: true,
+            description: "Data points to plot.",
+          },
+        ],
+      },
+      {
+        name: "chart_theme",
+        description: "Apply a design-token theme to every chart in the app.",
+        fromSkill: "charting",
+        params: [],
+      },
+    ],
+  },
+};

--- a/clients/web/src/domains/chat/components/tool-activity/skill-tool-list.tsx
+++ b/clients/web/src/domains/chat/components/tool-activity/skill-tool-list.tsx
@@ -1,83 +1,40 @@
 /**
- * Structured renderer for the tools a loaded skill advertises, replacing the
- * daemon's machine-facing "## Available Tools" markdown block with a scannable
- * list (LUM-2999).
+ * The tools a loaded skill advertises, replacing the daemon's machine-facing
+ * "## Available Tools" markdown block with a scannable list (LUM-2999).
  *
- * Each tool is one row: monospace name, prose description, and its parameters
- * as `name type required?` triples. Tools contributed by a nested child skill
- * are grouped under that skill's name so a composite skill's provenance stays
- * visible.
+ * Deliberately minimal: a tool's name and one-line description answer the only
+ * question this panel exists to answer — what can the assistant do now that it
+ * couldn't a moment ago. The manifest's parameter schemas are model-facing API
+ * surface (the user is never going to call `app_create(name, template)`
+ * themselves), so they're parsed but not rendered; showing them tripled each
+ * card's height for detail nobody acts on.
+ *
+ * Tools contributed by a nested child skill are grouped under that skill's name
+ * so a composite skill's provenance stays visible.
  */
 
 import { Typography } from "@vellumai/design-library";
 
-import type { SkillToolParam, SkillToolSummary } from "@/domains/chat/utils/skill-activity";
-
-/** One `name (type, required)` row under a tool. */
-function ParamRow({ param }: { param: SkillToolParam }) {
-  return (
-    <li className="flex flex-wrap items-baseline gap-x-1.5 gap-y-0.5">
-      <Typography
-        variant="label-small-default"
-        as="span"
-        className="font-mono text-[var(--content-default)]"
-      >
-        {param.name}
-      </Typography>
-      <Typography
-        variant="label-small-default"
-        as="span"
-        className="text-[var(--content-tertiary)]"
-      >
-        {param.type}
-      </Typography>
-      {param.required && (
-        <Typography
-          variant="label-small-default"
-          as="span"
-          className="text-[var(--system-mid-strong)]"
-        >
-          required
-        </Typography>
-      )}
-      {param.description && (
-        <Typography
-          variant="body-small-default"
-          as="span"
-          className="w-full text-[var(--content-secondary)]"
-        >
-          {param.description}
-        </Typography>
-      )}
-    </li>
-  );
-}
+import type { SkillToolSummary } from "@/domains/chat/utils/skill-activity";
 
 function SkillToolRow({ tool }: { tool: SkillToolSummary }) {
   return (
-    <li className="rounded-lg border border-[var(--border-base)] bg-[var(--surface-overlay)] p-3">
+    <li>
       <Typography
-        variant="body-small-default"
-        as="span"
-        className="font-mono text-[var(--content-default)]"
+        variant="body-medium-default"
+        as="div"
+        className="font-mono leading-5 text-[var(--content-default)]"
       >
         {tool.name}
       </Typography>
       {tool.description && (
         <Typography
-          variant="body-small-default"
+          variant="body-small-lighter"
           as="p"
           className="mt-1 text-[var(--content-secondary)]"
         >
           {tool.description}
         </Typography>
-      )}
-      {tool.params.length > 0 && (
-        <ul className="mt-2 flex flex-col gap-1.5">
-          {tool.params.map((param) => (
-            <ParamRow key={param.name} param={param} />
-          ))}
-        </ul>
       )}
     </li>
   );
@@ -103,9 +60,9 @@ export function SkillToolList({ tools }: { tools: SkillToolSummary[] }) {
   ];
 
   return (
-    <div className="flex flex-col gap-3">
+    <div className="flex flex-col gap-5">
       {ownTools.length > 0 && (
-        <ul className="flex flex-col gap-2">
+        <ul className="flex flex-col gap-4">
           {ownTools.map((tool) => (
             <SkillToolRow key={tool.name} tool={tool} />
           ))}
@@ -114,13 +71,13 @@ export function SkillToolList({ tools }: { tools: SkillToolSummary[] }) {
       {childSkills.map((skillName) => (
         <div key={skillName}>
           <Typography
-            variant="label-small-default"
+            variant="body-small-lighter"
             as="div"
-            className="mb-1.5 text-[var(--content-tertiary)]"
+            className="mb-3 text-[var(--content-tertiary)]"
           >
             From {skillName}
           </Typography>
-          <ul className="flex flex-col gap-2">
+          <ul className="flex flex-col gap-4">
             {tools
               .filter((tool) => tool.fromSkill === skillName)
               .map((tool) => (

--- a/clients/web/src/domains/chat/components/tool-activity/skill-tool-list.tsx
+++ b/clients/web/src/domains/chat/components/tool-activity/skill-tool-list.tsx
@@ -1,0 +1,134 @@
+/**
+ * Structured renderer for the tools a loaded skill advertises, replacing the
+ * daemon's machine-facing "## Available Tools" markdown block with a scannable
+ * list (LUM-2999).
+ *
+ * Each tool is one row: monospace name, prose description, and its parameters
+ * as `name type required?` triples. Tools contributed by a nested child skill
+ * are grouped under that skill's name so a composite skill's provenance stays
+ * visible.
+ */
+
+import { Typography } from "@vellumai/design-library";
+
+import type { SkillToolParam, SkillToolSummary } from "@/domains/chat/utils/skill-activity";
+
+/** One `name (type, required)` row under a tool. */
+function ParamRow({ param }: { param: SkillToolParam }) {
+  return (
+    <li className="flex flex-wrap items-baseline gap-x-1.5 gap-y-0.5">
+      <Typography
+        variant="label-small-default"
+        as="span"
+        className="font-mono text-[var(--content-default)]"
+      >
+        {param.name}
+      </Typography>
+      <Typography
+        variant="label-small-default"
+        as="span"
+        className="text-[var(--content-tertiary)]"
+      >
+        {param.type}
+      </Typography>
+      {param.required && (
+        <Typography
+          variant="label-small-default"
+          as="span"
+          className="text-[var(--system-mid-strong)]"
+        >
+          required
+        </Typography>
+      )}
+      {param.description && (
+        <Typography
+          variant="body-small-default"
+          as="span"
+          className="w-full text-[var(--content-secondary)]"
+        >
+          {param.description}
+        </Typography>
+      )}
+    </li>
+  );
+}
+
+function SkillToolRow({ tool }: { tool: SkillToolSummary }) {
+  return (
+    <li className="rounded-lg border border-[var(--border-base)] bg-[var(--surface-overlay)] p-3">
+      <Typography
+        variant="body-small-default"
+        as="span"
+        className="font-mono text-[var(--content-default)]"
+      >
+        {tool.name}
+      </Typography>
+      {tool.description && (
+        <Typography
+          variant="body-small-default"
+          as="p"
+          className="mt-1 text-[var(--content-secondary)]"
+        >
+          {tool.description}
+        </Typography>
+      )}
+      {tool.params.length > 0 && (
+        <ul className="mt-2 flex flex-col gap-1.5">
+          {tool.params.map((param) => (
+            <ParamRow key={param.name} param={param} />
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+}
+
+/**
+ * Render `tools` grouped by contributing skill. The parent skill's own tools
+ * (`fromSkill === null`) render first and ungrouped; each child skill's tools
+ * follow under a "From <skill>" label.
+ */
+export function SkillToolList({ tools }: { tools: SkillToolSummary[] }) {
+  if (tools.length === 0) {
+    return null;
+  }
+
+  const ownTools = tools.filter((tool) => tool.fromSkill === null);
+  const childSkills = [
+    ...new Set(
+      tools
+        .map((tool) => tool.fromSkill)
+        .filter((name): name is string => name !== null),
+    ),
+  ];
+
+  return (
+    <div className="flex flex-col gap-3">
+      {ownTools.length > 0 && (
+        <ul className="flex flex-col gap-2">
+          {ownTools.map((tool) => (
+            <SkillToolRow key={tool.name} tool={tool} />
+          ))}
+        </ul>
+      )}
+      {childSkills.map((skillName) => (
+        <div key={skillName}>
+          <Typography
+            variant="label-small-default"
+            as="div"
+            className="mb-1.5 text-[var(--content-tertiary)]"
+          >
+            From {skillName}
+          </Typography>
+          <ul className="flex flex-col gap-2">
+            {tools
+              .filter((tool) => tool.fromSkill === skillName)
+              .map((tool) => (
+                <SkillToolRow key={`${skillName}:${tool.name}`} tool={tool} />
+              ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/tool-activity/tool-activity-renderers.ts
+++ b/clients/web/src/domains/chat/components/tool-activity/tool-activity-renderers.ts
@@ -1,0 +1,32 @@
+/**
+ * Registry of tool-specific activity renderers for the side drawer (LUM-2999).
+ *
+ * The drawer's default rendering is deliberately generic — raw JSON input, raw
+ * text output — which reads poorly for the tools that run most often. This
+ * registry is the seam for replacing that per tool, starting with the two skill
+ * tools. Adding a tool means writing its renderer and adding one entry here;
+ * everything not listed keeps the generic treatment.
+ */
+
+import { SkillExecuteDetail } from "@/domains/chat/components/tool-activity/skill-execute-detail";
+import { SkillLoadDetail } from "@/domains/chat/components/tool-activity/skill-load-detail";
+import type { ToolActivityRenderer } from "@/domains/chat/components/tool-activity/types";
+
+const RENDERERS: Record<string, ToolActivityRenderer> = {
+  // `skill_load`'s result *is* the skill body, so it owns the Output section
+  // rather than letting the generic one dump the same text again as a `<pre>`.
+  skill_load: { Component: SkillLoadDetail, ownsOutput: true },
+  // `skill_execute` only reshapes the input envelope — the inner tool's output
+  // is ordinary text and keeps the shared Output section.
+  skill_execute: { Component: SkillExecuteDetail, ownsOutput: false },
+};
+
+/**
+ * Look up the purpose-built renderer for `toolName`, or `undefined` when the
+ * tool has none and should fall back to the generic input/output rendering.
+ */
+export function getToolActivityRenderer(
+  toolName: string,
+): ToolActivityRenderer | undefined {
+  return RENDERERS[toolName.toLowerCase()];
+}

--- a/clients/web/src/domains/chat/components/tool-activity/types.ts
+++ b/clients/web/src/domains/chat/components/tool-activity/types.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared contract for tool-specific activity renderers (LUM-2999).
+ *
+ * `ToolDetailBody` owns the pieces every tool shares — the risk badge and, for
+ * most tools, the Output section — and delegates the tool-specific middle to a
+ * renderer looked up by tool name. A renderer that also wants to own how the
+ * result is presented (as `skill_load` does, since its "output" *is* the skill
+ * body) sets `ownsOutput` in the registry so the generic Output block is
+ * suppressed rather than duplicated.
+ */
+
+import type { ReactNode } from "react";
+
+import type { ToolDetailPayload } from "@/stores/viewer-store";
+
+export interface ToolActivityRendererProps {
+  /** The payload the drawer was opened with (snapshot at open time). */
+  detail: ToolDetailPayload;
+  /**
+   * Live result, preferring the streaming store over the open-time snapshot.
+   * `undefined` until the call lands.
+   */
+  result: unknown;
+  /** Live streamed output tail while the call runs, when the tool emits one. */
+  streamedOutput: string | undefined;
+  /** Whether the call is still in flight. */
+  isRunning: boolean;
+  /** Whether the call ended in an error. */
+  isError: boolean;
+  /**
+   * Assistant that owns the conversation, threaded to any markdown so
+   * workspace file links resolve against the right workspace.
+   */
+  assistantId?: string | null;
+}
+
+/** Registry entry describing how one tool renders in the activity drawer. */
+export interface ToolActivityRenderer {
+  /** Component rendered in place of the generic name/activity/input block. */
+  Component: (props: ToolActivityRendererProps) => ReactNode;
+  /**
+   * When true, `ToolDetailBody` suppresses its generic Output section because
+   * this renderer already presents the result itself.
+   */
+  ownsOutput: boolean;
+}

--- a/clients/web/src/domains/chat/components/tool-detail-panel.stories.tsx
+++ b/clients/web/src/domains/chat/components/tool-detail-panel.stories.tsx
@@ -78,6 +78,82 @@ const thinkingDetail: ToolDetailPayload = {
   ].join("\n"),
 };
 
+/**
+ * A `skill_load` body shaped like the daemon's real output: instruction
+ * markdown followed by the machine-facing "## Available Tools" manifest that
+ * `formatToolSchemas` emits.
+ */
+const skillLoadResult = [
+  "# App Builder",
+  "",
+  "Build **persistent apps** in the user's Library — dashboards, trackers,",
+  "calculators, and games that survive across conversations.",
+  "",
+  "## Workflow",
+  "",
+  "1. Call `app_create` with a display name.",
+  "2. Write the app source into the returned folder.",
+  "3. Call `app_refresh` to rebuild and preview.",
+  "",
+  "## Available Tools",
+  "",
+  "Use `skill_execute` to call these tools.",
+  "",
+  "### app_create",
+  "Create a new app in the user's Library and return its folder path.",
+  "Parameters:",
+  "- name (string, required): Display name shown in the Library.",
+  "- template (string, optional): Starter template id.",
+  "",
+  "### app_refresh",
+  "Rebuild an existing app and refresh any open preview.",
+  "Parameters:",
+  "- app_id (string, required): Id returned by app_create.",
+  "",
+].join("\n");
+
+const skillLoadDetail: ToolDetailPayload = {
+  toolCallId: "tc-skill-load-1",
+  toolName: "skill_load",
+  title: "Using a skill",
+  activity: "Loading the app-builder skill",
+  input: { skill: "app-builder" },
+  result: skillLoadResult,
+  status: "completed",
+  riskLevel: "low",
+};
+
+const skillLoadErrorDetail: ToolDetailPayload = {
+  toolCallId: "tc-skill-load-2",
+  toolName: "skill_load",
+  title: "Using a skill",
+  activity: "Loading the meet-join skill",
+  input: { skill: "meet-join" },
+  result:
+    "Error: skill 'meet-join' is currently unavailable. This skill is feature-gated and not enabled for this workspace.",
+  status: "error",
+};
+
+const skillExecuteDetail: ToolDetailPayload = {
+  toolCallId: "tc-skill-exec-1",
+  toolName: "skill_execute",
+  title: "Using a skill",
+  activity: "Creating your budget tracker app",
+  input: {
+    tool: "app_create",
+    input: {
+      name: "Budget tracker",
+      template: "dashboard",
+      public: false,
+      config: { currency: "USD", categories: ["rent", "food", "transit"] },
+    },
+    activity: "Creating your budget tracker app",
+  },
+  result: "Created app 'Budget tracker' at ~/Library/apps/budget-tracker",
+  status: "completed",
+  riskLevel: "low",
+};
+
 export const Thinking: Story = {
   args: {
     detail: thinkingDetail,
@@ -95,6 +171,45 @@ export const SubagentSpawn: Story = {
 export const Bash: Story = {
   args: {
     detail: bashDetail,
+    onClose: () => {},
+  },
+};
+
+/**
+ * `skill_load` with a purpose-built body: skill identity and tool count up top,
+ * the manifest as scannable tool cards, and the instruction markdown rendered
+ * (not dumped as a `<pre>`) behind a disclosure.
+ */
+export const SkillLoad: Story = {
+  args: {
+    detail: skillLoadDetail,
+    onClose: () => {},
+  },
+};
+
+/** A failed `skill_load` — the error reads as prose, not as raw tool output. */
+export const SkillLoadError: Story = {
+  args: {
+    detail: skillLoadErrorDetail,
+    onClose: () => {},
+  },
+};
+
+/** `skill_load` still in flight, before the instruction body lands. */
+export const SkillLoadRunning: Story = {
+  args: {
+    detail: { ...skillLoadDetail, result: undefined, status: "running" },
+    onClose: () => {},
+  },
+};
+
+/**
+ * `skill_execute` with its envelope unwrapped: the inner tool leads, and its
+ * parameters render as a labelled list instead of nested JSON.
+ */
+export const SkillExecute: Story = {
+  args: {
+    detail: skillExecuteDetail,
     onClose: () => {},
   },
 };

--- a/clients/web/src/domains/chat/components/tool-detail-panel.stories.tsx
+++ b/clients/web/src/domains/chat/components/tool-detail-panel.stories.tsx
@@ -84,6 +84,11 @@ const thinkingDetail: ToolDetailPayload = {
  * `formatToolSchemas` emits.
  */
 const skillLoadResult = [
+  "Skill: App Builder",
+  "ID: app-builder",
+  "Description: Build persistent apps in the user's Library.",
+  "Path: /skills/app-builder/SKILL.md",
+  "",
   "# App Builder",
   "",
   "Build **persistent apps** in the user's Library — dashboards, trackers,",
@@ -110,6 +115,11 @@ const skillLoadResult = [
   "Parameters:",
   "- app_id (string, required): Id returned by app_create.",
   "",
+  // Machine-only trailer the daemon appends. Must not leak into the last
+  // tool's description or the rendered instructions.
+  "Included Skills (immediate): none",
+  "",
+  '<loaded_skill id="app-builder" version="abc123" />',
 ].join("\n");
 
 const skillLoadDetail: ToolDetailPayload = {

--- a/clients/web/src/domains/chat/components/tool-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/tool-detail-panel.tsx
@@ -15,9 +15,7 @@
 import {
   Bolt,
   Brain,
-  Check,
   Code,
-  Copy,
   FileText,
   Globe,
   Monitor,
@@ -28,13 +26,13 @@ import {
   UserPlus,
   type LucideIcon,
 } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
 
 import { Typography } from "@vellumai/design-library";
 
 import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
-import { copyToClipboard } from "@/lib/copy-to-clipboard";
+import { CodeBlock, SectionLabel } from "@/components/detail-primitives";
 import { DetailShell } from "@/components/detail-shell";
+import { getToolActivityRenderer } from "@/domains/chat/components/tool-activity/tool-activity-renderers";
 import { RiskBadge } from "@/domains/chat/components/risk-badge";
 import { titleCaseToolName } from "@/domains/chat/components/tool-call-chip/utils";
 import { useLiveThinkingText } from "@/domains/chat/hooks/use-live-thinking-text";
@@ -66,88 +64,11 @@ const ICON_MAP: Record<IconName, LucideIcon> = {
   brain: Brain,
 };
 
-const COPIED_RESET_MS = 1500;
-
-/**
- * Small ghost button that copies `text` to the clipboard and shows a transient
- * "Copied" confirmation. Positioned by the caller (top-right of a `<pre>`).
- */
-function CopyButton({ text }: { text: string }) {
-  const [copied, setCopied] = useState(false);
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-      }
-    };
-  }, []);
-
-  const handleCopy = () => {
-    copyToClipboard(text, {
-      errorMessage: "Couldn't copy.",
-      onCopied: () => {
-        setCopied(true);
-        if (timeoutRef.current) {
-          clearTimeout(timeoutRef.current);
-        }
-        timeoutRef.current = setTimeout(
-          () => setCopied(false),
-          COPIED_RESET_MS,
-        );
-      },
-    });
-  };
-
-  return (
-    <button
-      type="button"
-      onClick={handleCopy}
-      aria-label={copied ? "Copied" : "Copy"}
-      className="absolute right-2 top-2 flex items-center gap-1 rounded p-1 text-label-small-default text-[var(--content-tertiary)] transition-colors hover:bg-[var(--ghost-hover)] hover:text-[var(--content-default)]"
-    >
-      {copied ? (
-        <Check className="h-3.5 w-3.5" />
-      ) : (
-        <Copy className="h-3.5 w-3.5" />
-      )}
-      {copied ? "Copied" : null}
-    </button>
-  );
-}
-
-/** A `<pre>` code block with a copy button positioned in the top-right. */
-export function CodeBlock({ text }: { text: string }) {
-  return (
-    <div className="relative">
-      <pre className="rounded-lg border border-[var(--border-base)] bg-[var(--surface-overlay)] p-3 font-mono text-xs whitespace-pre-wrap break-words text-[var(--content-default)]">
-        {text}
-      </pre>
-      <CopyButton text={text} />
-    </div>
-  );
-}
-
-/** Uppercase section label in `--content-tertiary`. */
-export function SectionLabel({
-  children,
-  className = "mb-1.5",
-}: {
-  children: string;
-  /** Margin override for rows that manage their own spacing. */
-  className?: string;
-}) {
-  return (
-    <Typography
-      variant="label-small-default"
-      as="div"
-      className={`uppercase tracking-wider text-[var(--content-tertiary)] ${className}`}
-    >
-      {children}
-    </Typography>
-  );
-}
+// Re-exported for the panels that already imported these from here
+// (`background-task-detail-panel`, `acp-run-detail-panel`, …). They now live in
+// `@/components/detail-primitives` so tool-specific renderers can use them
+// without importing this module and forming a cycle.
+export { CodeBlock, SectionLabel };
 
 /**
  * Thinking variant body. Reuses the shared shell but renders the reasoning
@@ -198,7 +119,14 @@ function ThinkingDetailBody({
  * `result` when it lands, falling back to the open-time snapshot on `detail`
  * when the call can't be resolved live (e.g. paged out).
  */
-export function ToolDetailBody({ detail }: { detail: ToolDetailPayload }) {
+export function ToolDetailBody({
+  detail,
+  assistantId,
+}: {
+  detail: ToolDetailPayload;
+  /** Threaded to any markdown a tool-specific renderer shows. */
+  assistantId?: string | null;
+}) {
   const liveTc = useLiveToolCall(detail.toolCallId);
   const result = liveTc?.result ?? detail.result;
   const streamedOutput = liveTc?.streamedOutput ?? detail.streamedOutput;
@@ -207,6 +135,7 @@ export function ToolDetailBody({ detail }: { detail: ToolDetailPayload }) {
   const isRunning = liveTc
     ? isToolCallRunning(liveTc)
     : detail.status === "running";
+  const isError = liveTc?.isError ?? detail.status === "error";
   const hasStreamedOutput = !!streamedOutput;
   const inputJson = JSON.stringify(detail.input, null, 2);
 
@@ -215,6 +144,10 @@ export function ToolDetailBody({ detail }: { detail: ToolDetailPayload }) {
   // classifier jargon and is deliberately NOT shown.
   const riskLevel = liveTc?.riskLevel ?? detail.riskLevel;
   const riskHint = getRiskToleranceHint(riskLevel);
+
+  // Tools with purpose-built activity UI replace the generic name/activity/JSON
+  // block; those that also own their output suppress the shared Output section.
+  const renderer = getToolActivityRenderer(detail.toolName);
 
   return (
     <>
@@ -238,32 +171,45 @@ export function ToolDetailBody({ detail }: { detail: ToolDetailPayload }) {
         </div>
       )}
 
-      {/* Tool name + activity + input */}
-      <div>
-        <Typography
-          variant="body-medium-default"
-          as="div"
-          className="text-[var(--content-default)]"
-        >
-          {titleCaseToolName(detail.toolName)}
-        </Typography>
-        {detail.activity && (
+      {/* Tool-specific activity UI when the tool has one, else the generic
+          name + activity + raw JSON input block. */}
+      {renderer ? (
+        <renderer.Component
+          detail={detail}
+          result={result}
+          streamedOutput={streamedOutput}
+          isRunning={isRunning}
+          isError={isError}
+          assistantId={assistantId}
+        />
+      ) : (
+        <div>
           <Typography
-            variant="body-small-default"
-            as="p"
-            className="mt-0.5 text-[var(--content-secondary)]"
+            variant="body-medium-default"
+            as="div"
+            className="text-[var(--content-default)]"
           >
-            {detail.activity}
+            {titleCaseToolName(detail.toolName)}
           </Typography>
-        )}
-        <div className="mt-2">
-          <CodeBlock text={inputJson} />
+          {detail.activity && (
+            <Typography
+              variant="body-small-default"
+              as="p"
+              className="mt-0.5 text-[var(--content-secondary)]"
+            >
+              {detail.activity}
+            </Typography>
+          )}
+          <div className="mt-2">
+            <CodeBlock text={inputJson} />
+          </div>
         </div>
-      </div>
+      )}
 
       {/* Output — the final result once present, else the live streamed tail
-          while running, else a bare running placeholder. */}
-      {(hasResult || isRunning) && (
+          while running, else a bare running placeholder. Suppressed for tools
+          whose renderer already presents the result itself. */}
+      {!renderer?.ownsOutput && (hasResult || isRunning) && (
         <div className="mt-5">
           <SectionLabel>Output</SectionLabel>
           {hasResult ? (
@@ -323,7 +269,7 @@ export function ToolDetailPanel({
       closeLabel="Close tool details"
       onClose={onClose}
     >
-      <ToolDetailBody detail={detail} />
+      <ToolDetailBody detail={detail} assistantId={assistantId} />
     </DetailShell>
   );
 }

--- a/clients/web/src/domains/chat/utils/skill-activity.test.ts
+++ b/clients/web/src/domains/chat/utils/skill-activity.test.ts
@@ -138,10 +138,108 @@ describe("parseSkillLoadActivity", () => {
 
     expect(activity).toEqual({
       skillId: "app-builder",
+      displayName: "",
+      description: "",
       instructions: "",
       tools: [],
       errorMessage: null,
     });
+  });
+
+  it("lifts the Skill/ID/Description/Path header out of the instructions", () => {
+    const activity = parseSkillLoadActivity({
+      input: { skill: "app-builder" },
+      result: [
+        "Skill: App Builder",
+        "ID: app-builder",
+        "Description: Build persistent apps in the user's Library.",
+        "Path: /skills/app-builder/SKILL.md",
+        "",
+        "# App Builder",
+        "",
+        "Real instructions start here.",
+      ].join("\n"),
+    });
+
+    expect(activity.displayName).toBe("App Builder");
+    expect(activity.description).toBe(
+      "Build persistent apps in the user's Library.",
+    );
+    expect(activity.instructions).toBe(
+      "# App Builder\n\nReal instructions start here.",
+    );
+    expect(activity.instructions).not.toContain("Path:");
+  });
+
+  it("leaves a body with no header untouched", () => {
+    const activity = parseSkillLoadActivity({
+      input: { skill: "x" },
+      result: "# Just a body\n\nNo header lines.",
+    });
+
+    expect(activity.displayName).toBe("");
+    expect(activity.instructions).toBe("# Just a body\n\nNo header lines.");
+  });
+
+  it("does not absorb the post-manifest trailer into the last tool", () => {
+    // Mirrors the daemon's real tail: child manifests, then include
+    // bookkeeping and `<loaded_skill />` projection markers.
+    const body = [
+      "## Available Tools",
+      "",
+      "### app_create",
+      "Create a new app.",
+      "",
+      "### Tools from charting",
+      "",
+      "#### chart_render",
+      "Render a chart.",
+      "",
+      "Included Skills (immediate):",
+      "  - charting: loaded",
+      "Suggested Included Skills (not loaded):",
+      "  - theming: not installed or unavailable.",
+      "",
+      '<loaded_skill id="app-builder" version="abc123" />',
+      '<loaded_skill id="charting" version="def456" />',
+    ].join("\n");
+
+    const { tools } = parseSkillLoadActivity({
+      input: { skill: "app-builder" },
+      result: body,
+    });
+
+    expect(tools).toHaveLength(2);
+    expect(tools[0]!.description).toBe("Create a new app.");
+    // The trailer must not land on the last tool's description card.
+    expect(tools[1]!.description).toBe("Render a chart.");
+    expect(tools[1]!.fromSkill).toBe("charting");
+    for (const tool of tools) {
+      expect(tool.description).not.toContain("loaded_skill");
+      expect(tool.description).not.toContain("Included Skills");
+    }
+  });
+
+  it("keeps the trailer out of the instructions when there is no manifest", () => {
+    const activity = parseSkillLoadActivity({
+      input: { skill: "document" },
+      result: [
+        "Skill: Document",
+        "ID: document",
+        "Description: Long-form writing.",
+        "Path: /skills/document/SKILL.md",
+        "",
+        "Write long-form prose.",
+        "",
+        "Included Skills (immediate): none",
+        "",
+        '<loaded_skill id="document" />',
+      ].join("\n"),
+    });
+
+    expect(activity.instructions).toBe("Write long-form prose.");
+    expect(activity.instructions).not.toContain("loaded_skill");
+    expect(activity.instructions).not.toContain("Included Skills");
   });
 
   it("tolerates a missing or non-object input bag", () => {

--- a/clients/web/src/domains/chat/utils/skill-activity.test.ts
+++ b/clients/web/src/domains/chat/utils/skill-activity.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  parseSkillExecuteActivity,
+  parseSkillLoadActivity,
+} from "./skill-activity";
+
+/** A `skill_load` body shaped like the daemon's `formatToolSchemas` output. */
+const LOAD_BODY = [
+  "# App Builder",
+  "",
+  "Build persistent apps in the user's Library.",
+  "",
+  "## Available Tools",
+  "",
+  "Use `skill_execute` to call these tools.",
+  "",
+  "### app_create",
+  "Create a new app in the Library.",
+  "Parameters:",
+  "- name (string, required): Display name for the app.",
+  "- template (string, optional): Starter template id.",
+  "",
+  "### app_refresh",
+  "Rebuild an existing app.",
+  "Parameters:",
+  "- app_id (string, required)",
+  "",
+].join("\n");
+
+describe("parseSkillLoadActivity", () => {
+  it("splits instructions from the Available Tools manifest", () => {
+    const activity = parseSkillLoadActivity({
+      input: { skill: "app-builder" },
+      result: LOAD_BODY,
+    });
+
+    expect(activity.skillId).toBe("app-builder");
+    expect(activity.errorMessage).toBeNull();
+    expect(activity.instructions).toBe(
+      "# App Builder\n\nBuild persistent apps in the user's Library.",
+    );
+    expect(activity.instructions).not.toContain("Available Tools");
+  });
+
+  it("parses each tool's name, description, and parameters", () => {
+    const { tools } = parseSkillLoadActivity({
+      input: { skill: "app-builder" },
+      result: LOAD_BODY,
+    });
+
+    expect(tools).toHaveLength(2);
+    expect(tools[0]).toEqual({
+      name: "app_create",
+      description: "Create a new app in the Library.",
+      fromSkill: null,
+      params: [
+        {
+          name: "name",
+          type: "string",
+          required: true,
+          description: "Display name for the app.",
+        },
+        {
+          name: "template",
+          type: "string",
+          required: false,
+          description: "Starter template id.",
+        },
+      ],
+    });
+    // A parameter printed without a description still parses.
+    expect(tools[1]!.params).toEqual([
+      { name: "app_id", type: "string", required: true, description: "" },
+    ]);
+  });
+
+  it("attributes tools from a nested child-skill manifest", () => {
+    const body = [
+      "## Available Tools",
+      "",
+      "### parent_tool",
+      "Parent-owned.",
+      "",
+      "### Tools from charting",
+      "",
+      "#### chart_render",
+      "Render a chart.",
+      "",
+    ].join("\n");
+
+    const { tools } = parseSkillLoadActivity({
+      input: { skill: "app-builder" },
+      result: body,
+    });
+
+    expect(tools.map((t) => [t.name, t.fromSkill])).toEqual([
+      ["parent_tool", null],
+      ["chart_render", "charting"],
+    ]);
+  });
+
+  it("treats a body with no manifest as all instructions", () => {
+    const activity = parseSkillLoadActivity({
+      input: { skill: "document" },
+      result: "# Document\n\nWrite long-form prose.",
+    });
+
+    expect(activity.tools).toEqual([]);
+    expect(activity.instructions).toBe("# Document\n\nWrite long-form prose.");
+  });
+
+  it("surfaces an error body instead of instructions", () => {
+    const activity = parseSkillLoadActivity({
+      input: { skill: "nope" },
+      result: "Error: skill 'nope' is currently unavailable",
+      isError: true,
+    });
+
+    expect(activity.errorMessage).toBe(
+      "Error: skill 'nope' is currently unavailable",
+    );
+    expect(activity.instructions).toBe("");
+    expect(activity.tools).toEqual([]);
+  });
+
+  it("detects an error body from its Error: prefix without the flag", () => {
+    const activity = parseSkillLoadActivity({
+      input: { skill: "nope" },
+      result: "Error: skill is required and must be a non-empty string",
+    });
+
+    expect(activity.errorMessage).toContain("Error:");
+  });
+
+  it("carries only the skill id while the call is still running", () => {
+    const activity = parseSkillLoadActivity({ input: { skill: "app-builder" } });
+
+    expect(activity).toEqual({
+      skillId: "app-builder",
+      instructions: "",
+      tools: [],
+      errorMessage: null,
+    });
+  });
+
+  it("tolerates a missing or non-object input bag", () => {
+    expect(parseSkillLoadActivity({ input: null }).skillId).toBe("");
+    expect(parseSkillLoadActivity({ input: "oops" }).skillId).toBe("");
+  });
+});
+
+describe("parseSkillExecuteActivity", () => {
+  it("unwraps the documented envelope", () => {
+    const activity = parseSkillExecuteActivity({
+      tool: "app_create",
+      input: { name: "Budget tracker", public: false },
+      activity: "Creating your budget tracker app",
+    });
+
+    expect(activity.innerToolName).toBe("app_create");
+    expect(activity.activity).toBe("Creating your budget tracker app");
+    expect(activity.params).toEqual([
+      { key: "name", scalar: "Budget tracker", json: null },
+      { key: "public", scalar: "false", json: null },
+    ]);
+  });
+
+  it("pretty-prints object and array parameters as JSON", () => {
+    const { params } = parseSkillExecuteActivity({
+      tool: "chart_render",
+      input: { series: [1, 2], axis: { x: "time" } },
+      activity: "Rendering",
+    });
+
+    expect(params[0]).toEqual({
+      key: "series",
+      scalar: null,
+      json: "[\n  1,\n  2\n]",
+    });
+    expect(params[1]!.json).toBe('{\n  "x": "time"\n}');
+  });
+
+  it("recovers input passed as a JSON-encoded string", () => {
+    const { params } = parseSkillExecuteActivity({
+      tool: "task_create",
+      input: '{"title":"Ship it"}',
+      activity: "Creating a task",
+    });
+
+    expect(params).toEqual([{ key: "title", scalar: "Ship it", json: null }]);
+  });
+
+  it("keeps a non-JSON string input rather than dropping it", () => {
+    const { params } = parseSkillExecuteActivity({
+      tool: "document_create",
+      input: "# Just some markdown",
+      activity: "Writing",
+    });
+
+    expect(params).toEqual([
+      { key: "input", scalar: "# Just some markdown", json: null },
+    ]);
+  });
+
+  it("recovers parameters spread as siblings of the envelope keys", () => {
+    const { innerToolName, params } = parseSkillExecuteActivity({
+      tool: "task_create",
+      input: {},
+      activity: "Creating a task",
+      title: "Ship it",
+      priority: 2,
+    });
+
+    expect(innerToolName).toBe("task_create");
+    expect(params).toEqual([
+      { key: "title", scalar: "Ship it", json: null },
+      { key: "priority", scalar: "2", json: null },
+    ]);
+  });
+
+  it("renders a null parameter without dropping the key", () => {
+    const { params } = parseSkillExecuteActivity({
+      tool: "t",
+      input: { cursor: null },
+      activity: "",
+    });
+
+    expect(params).toEqual([{ key: "cursor", scalar: "null", json: null }]);
+  });
+
+  it("returns empty fields for a malformed envelope", () => {
+    expect(parseSkillExecuteActivity(null)).toEqual({
+      innerToolName: "",
+      activity: "",
+      params: [],
+    });
+  });
+});

--- a/clients/web/src/domains/chat/utils/skill-activity.ts
+++ b/clients/web/src/domains/chat/utils/skill-activity.ts
@@ -45,9 +45,17 @@ export interface SkillLoadActivity {
   /** Skill id/name requested via `input.skill`. Empty when absent. */
   skillId: string;
   /**
-   * The skill's instruction markdown with the machine-facing
-   * "## Available Tools" section removed — that section is rendered as
-   * structured tool cards instead of prose.
+   * Human-readable skill name from the result header's `Skill:` line
+   * (the daemon's `skill.displayName`). Empty until the result lands.
+   */
+  displayName: string;
+  /** One-line skill summary from the header's `Description:` line. */
+  description: string;
+  /**
+   * The skill's instruction markdown, with the `Skill:`/`ID:`/`Description:`/
+   * `Path:` header, the machine-facing "## Available Tools" section, and the
+   * trailing include bookkeeping all removed — each is surfaced structurally
+   * (or dropped) rather than rendered as prose.
    */
   instructions: string;
   /** Tools parsed out of the "## Available Tools" section, in document order. */
@@ -97,6 +105,29 @@ const TOOLS_PREAMBLE = /^Use `skill_execute` to call these tools\.\s*$/;
 /** Literal `Parameters:` line that opens a tool's parameter list. */
 const PARAMS_LABEL = /^Parameters:\s*$/;
 
+/**
+ * Lines that mark the end of the human-relevant part of a `skill_load` body.
+ *
+ * After the tool manifest the daemon appends pure bookkeeping — the immediate
+ * include listing, the not-installed suggestions, and `<loaded_skill … />`
+ * projection markers (`assistant/src/tools/skills/load.ts:617-620`). None of it
+ * is for a reader, and because the manifest parser treats any non-heading line
+ * after a tool as description, leaving it in would glue all of it onto the last
+ * tool's description card.
+ *
+ * Note this deliberately does NOT terminate on `### Tools from …`: those child
+ * manifests (`includedBodies`) sit between the parent manifest and this trailer
+ * and are legitimate tool content the parser attributes via `fromSkill`.
+ */
+const MANIFEST_TERMINATORS = [
+  /^Included Skills \(immediate\):/,
+  /^Suggested Included Skills \(not loaded\):/,
+  /^<loaded_skill\b/,
+];
+
+/** `Skill:` / `ID:` / `Description:` / `Path:` header line at the body's head. */
+const HEADER_LINE = /^(Skill|ID|Description|Path):\s*(.*)$/;
+
 /** Read a trimmed string property from an input bag, else `""`. */
 function readString(bag: Record<string, unknown>, key: string): string {
   const value = bag[key];
@@ -131,6 +162,59 @@ function splitAtToolsSection(body: string): {
   return {
     instructions: lines.slice(0, headingIndex).join("\n").trimEnd(),
     toolsSection: lines.slice(headingIndex + 1).join("\n"),
+  };
+}
+
+/**
+ * Drop the machine-only trailer the daemon appends after the manifest. Cuts at
+ * the first {@link MANIFEST_TERMINATORS} match; a body without one is returned
+ * unchanged. Applied before any other split so the trailer can't leak into the
+ * tool descriptions OR — for a manifest-less skill, which has no
+ * "## Available Tools" heading to split on — into the rendered instructions.
+ */
+function stripMachineTrailer(body: string): string {
+  const lines = body.split("\n");
+  const cut = lines.findIndex((line) =>
+    MANIFEST_TERMINATORS.some((pattern) => pattern.test(line)),
+  );
+  return cut === -1 ? body : lines.slice(0, cut).join("\n").trimEnd();
+}
+
+/**
+ * Pull the `Skill:` / `ID:` / `Description:` / `Path:` header off the front of
+ * a load body, returning the parsed fields and the remaining instructions.
+ *
+ * The daemon emits these four lines ahead of the skill body
+ * (`assistant/src/tools/skills/load.ts:598-601`). They're the source of the
+ * human-readable name, but rendered as markdown they read as four stray
+ * key-value lines above the real content — so they're lifted out here and shown
+ * structurally instead.
+ */
+function splitHeader(body: string): {
+  displayName: string;
+  description: string;
+  rest: string;
+} {
+  const lines = body.split("\n");
+  const fields: Record<string, string> = {};
+  let index = 0;
+  while (index < lines.length) {
+    const match = HEADER_LINE.exec(lines[index]!);
+    if (!match) {
+      break;
+    }
+    fields[match[1]!] = match[2]!.trim();
+    index++;
+  }
+  // Nothing recognised — leave the body untouched rather than eating a line
+  // that merely happened to start with a colon-suffixed word.
+  if (index === 0) {
+    return { displayName: "", description: "", rest: body };
+  }
+  return {
+    displayName: fields.Skill ?? "",
+    description: fields.Description ?? "",
+    rest: lines.slice(index).join("\n").replace(/^\n+/, ""),
   };
 }
 
@@ -252,21 +336,35 @@ export function parseSkillLoadActivity({
   const body = typeof result === "string" ? result : "";
 
   if (!body) {
-    return { skillId, instructions: "", tools: [], errorMessage: null };
+    return {
+      skillId,
+      displayName: "",
+      description: "",
+      instructions: "",
+      tools: [],
+      errorMessage: null,
+    };
   }
 
   if (isErrorBody(body, isError)) {
     return {
       skillId,
+      displayName: "",
+      description: "",
       instructions: "",
       tools: [],
       errorMessage: body.trim(),
     };
   }
 
-  const { instructions, toolsSection } = splitAtToolsSection(body);
+  const { displayName, description, rest } = splitHeader(
+    stripMachineTrailer(body),
+  );
+  const { instructions, toolsSection } = splitAtToolsSection(rest);
   return {
     skillId,
+    displayName,
+    description,
     instructions,
     tools: parseToolsSection(toolsSection),
     errorMessage: null,

--- a/clients/web/src/domains/chat/utils/skill-activity.ts
+++ b/clients/web/src/domains/chat/utils/skill-activity.ts
@@ -1,0 +1,365 @@
+/**
+ * Pure projections that turn raw `skill_load` / `skill_execute` tool payloads
+ * into the shapes the purpose-built activity detail UI renders (LUM-2999).
+ *
+ * Both skill tools are among the most frequently invoked in a turn, yet the
+ * generic activity drawer renders them at their worst: `skill_load` dumps a
+ * multi-thousand-line instruction body into a monospace `<pre>`, and
+ * `skill_execute` shows its `{ tool, input, activity }` envelope as raw JSON so
+ * the tool that actually ran is buried one level down. These parsers pull out
+ * the parts a reader wants — which skill, what it provides, which inner tool
+ * ran, with what parameters — so the components can render them directly.
+ *
+ * Intentionally pure: no React, no store access, no I/O. The daemon-side
+ * producers are `assistant/src/tools/skills/load.ts` (whose `formatToolSchemas`
+ * emits the "## Available Tools" section parsed here) and
+ * `assistant/src/tools/skills/execute.ts` (whose `input_schema` defines the
+ * envelope). Keep this module in sync with those two.
+ */
+
+/** A single parameter row under a skill tool's `Parameters:` list. */
+export interface SkillToolParam {
+  name: string;
+  /** JSON-schema type as printed by the daemon (`string`, `object`, `any`, …). */
+  type: string;
+  required: boolean;
+  /** Prose description; empty when the daemon printed the param bare. */
+  description: string;
+}
+
+/** One tool advertised by a loaded skill's `TOOLS.json` manifest. */
+export interface SkillToolSummary {
+  name: string;
+  description: string;
+  params: SkillToolParam[];
+  /**
+   * Owning child skill when the tool came from a nested `### Tools from <x>`
+   * block, else `null` for the parent skill's own tools. Lets the UI group
+   * a composite skill's tools by origin.
+   */
+  fromSkill: string | null;
+}
+
+/** Readable projection of a `skill_load` call. */
+export interface SkillLoadActivity {
+  /** Skill id/name requested via `input.skill`. Empty when absent. */
+  skillId: string;
+  /**
+   * The skill's instruction markdown with the machine-facing
+   * "## Available Tools" section removed — that section is rendered as
+   * structured tool cards instead of prose.
+   */
+  instructions: string;
+  /** Tools parsed out of the "## Available Tools" section, in document order. */
+  tools: SkillToolSummary[];
+  /** Failure text when the load errored, else `null`. */
+  errorMessage: string | null;
+}
+
+/** One resolved parameter of the inner tool a `skill_execute` dispatched. */
+export interface SkillExecuteParam {
+  key: string;
+  /**
+   * Display string for a scalar value (string / number / boolean / null).
+   * `null` when the value is an object or array — read `json` instead.
+   */
+  scalar: string | null;
+  /** Pretty-printed JSON for object/array values; `null` for scalars. */
+  json: string | null;
+}
+
+/** Readable projection of a `skill_execute` envelope. */
+export interface SkillExecuteActivity {
+  /** Inner tool from `input.tool` — the thing that actually ran. */
+  innerToolName: string;
+  /** Operator-facing sentence from `input.activity`. Empty when absent. */
+  activity: string;
+  /** Inner tool parameters, in insertion order. */
+  params: SkillExecuteParam[];
+}
+
+/** Heading that opens the daemon's machine-facing tool manifest section. */
+const AVAILABLE_TOOLS_HEADING = /^##\s+Available Tools\s*$/;
+
+/** `### Tools from <child skill>` sub-heading emitted for nested manifests. */
+const CHILD_SKILL_HEADING = /^###\s+Tools from\s+(.+?)\s*$/;
+
+/** A tool heading: `### name` (parent skill) or `#### name` (child skill). */
+const TOOL_HEADING = /^#{3,4}\s+(\S+)\s*$/;
+
+/** `- name (type, required): description` — description optional. */
+const PARAM_LINE =
+  /^[-*]\s+(\S+?)\s*\(([^,()]+),\s*(required|optional)\)\s*(?::\s*(.*))?$/;
+
+/** Boilerplate the daemon prints under the heading; carries no reader value. */
+const TOOLS_PREAMBLE = /^Use `skill_execute` to call these tools\.\s*$/;
+
+/** Literal `Parameters:` line that opens a tool's parameter list. */
+const PARAMS_LABEL = /^Parameters:\s*$/;
+
+/** Read a trimmed string property from an input bag, else `""`. */
+function readString(bag: Record<string, unknown>, key: string): string {
+  const value = bag[key];
+  return typeof value === "string" ? value.trim() : "";
+}
+
+/** Coerce unknown tool input into a plain bag, tolerating null/non-objects. */
+function toBag(input: unknown): Record<string, unknown> {
+  return input != null && typeof input === "object" && !Array.isArray(input)
+    ? (input as Record<string, unknown>)
+    : {};
+}
+
+/**
+ * Split a `skill_load` result body at the "## Available Tools" heading.
+ *
+ * Everything before the heading is the human-readable instruction markdown;
+ * everything from the heading onward is the structured manifest. A body with
+ * no such heading is entirely instructions.
+ */
+function splitAtToolsSection(body: string): {
+  instructions: string;
+  toolsSection: string;
+} {
+  const lines = body.split("\n");
+  const headingIndex = lines.findIndex((line) =>
+    AVAILABLE_TOOLS_HEADING.test(line),
+  );
+  if (headingIndex === -1) {
+    return { instructions: body.trimEnd(), toolsSection: "" };
+  }
+  return {
+    instructions: lines.slice(0, headingIndex).join("\n").trimEnd(),
+    toolsSection: lines.slice(headingIndex + 1).join("\n"),
+  };
+}
+
+/**
+ * Parse the daemon's "## Available Tools" block into structured tool
+ * summaries. Mirrors the emitter in `formatToolSchemas`
+ * (`assistant/src/tools/skills/load.ts`): a `### <name>` heading per tool,
+ * free-text description lines, then an optional `Parameters:` list. Nested
+ * manifests introduce their tools under `### Tools from <skill>` with
+ * `#### <name>` headings, which we attribute via `fromSkill`.
+ *
+ * Unrecognised lines are treated as description text rather than dropped, so a
+ * daemon-side format tweak degrades to slightly noisy prose instead of an
+ * empty tool list.
+ */
+function parseToolsSection(section: string): SkillToolSummary[] {
+  if (!section.trim()) {
+    return [];
+  }
+
+  const tools: SkillToolSummary[] = [];
+  let current: SkillToolSummary | null = null;
+  let currentSkill: string | null = null;
+  let inParams = false;
+  let descriptionLines: string[] = [];
+
+  const flush = () => {
+    if (current) {
+      current.description = descriptionLines.join("\n").trim();
+      tools.push(current);
+    }
+    current = null;
+    descriptionLines = [];
+    inParams = false;
+  };
+
+  for (const line of section.split("\n")) {
+    const childMatch = CHILD_SKILL_HEADING.exec(line);
+    if (childMatch) {
+      flush();
+      currentSkill = childMatch[1]!;
+      continue;
+    }
+
+    const toolMatch = TOOL_HEADING.exec(line);
+    if (toolMatch) {
+      flush();
+      current = {
+        name: toolMatch[1]!,
+        description: "",
+        params: [],
+        fromSkill: currentSkill,
+      };
+      continue;
+    }
+
+    if (!current) {
+      // Preamble between the heading and the first tool.
+      continue;
+    }
+
+    if (PARAMS_LABEL.test(line)) {
+      inParams = true;
+      continue;
+    }
+
+    if (inParams) {
+      const paramMatch = PARAM_LINE.exec(line);
+      if (paramMatch) {
+        current.params.push({
+          name: paramMatch[1]!,
+          type: paramMatch[2]!.trim(),
+          required: paramMatch[3] === "required",
+          description: (paramMatch[4] ?? "").trim(),
+        });
+        continue;
+      }
+      // A non-param line ends the list; fall through so it joins the prose.
+      inParams = false;
+    }
+
+    if (TOOLS_PREAMBLE.test(line)) {
+      continue;
+    }
+    descriptionLines.push(line);
+  }
+
+  flush();
+  return tools;
+}
+
+/**
+ * True when a `skill_load` result body reads as a failure. The daemon returns
+ * `{ content: "Error: …", isError: true }` for bad input and surfaces
+ * feature-gated skills as prose, so we treat the explicit `isError` flag as
+ * authoritative and fall back to the `Error:` prefix the tool itself emits.
+ */
+function isErrorBody(body: string, isError: boolean): boolean {
+  return isError || /^Error:/.test(body.trimStart());
+}
+
+/**
+ * Project a `skill_load` call into its readable parts.
+ *
+ * `result` is the tool's returned instruction body (absent while the call is
+ * still running, in which case the projection carries only the skill id).
+ */
+export function parseSkillLoadActivity({
+  input,
+  result,
+  isError = false,
+}: {
+  input: unknown;
+  result?: unknown;
+  isError?: boolean;
+}): SkillLoadActivity {
+  const bag = toBag(input);
+  const skillId = readString(bag, "skill");
+  const body = typeof result === "string" ? result : "";
+
+  if (!body) {
+    return { skillId, instructions: "", tools: [], errorMessage: null };
+  }
+
+  if (isErrorBody(body, isError)) {
+    return {
+      skillId,
+      instructions: "",
+      tools: [],
+      errorMessage: body.trim(),
+    };
+  }
+
+  const { instructions, toolsSection } = splitAtToolsSection(body);
+  return {
+    skillId,
+    instructions,
+    tools: parseToolsSection(toolsSection),
+    errorMessage: null,
+  };
+}
+
+/**
+ * Format a single inner-tool parameter value for display. Scalars render
+ * inline; objects and arrays are pretty-printed as JSON so nested structure
+ * stays legible. A value that can't be serialised (a cycle) degrades to its
+ * `String()` form rather than throwing.
+ */
+function formatParamValue(
+  value: unknown,
+): Pick<SkillExecuteParam, "scalar" | "json"> {
+  if (value === null) {
+    return { scalar: "null", json: null };
+  }
+  if (typeof value === "string") {
+    return { scalar: value, json: null };
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return { scalar: String(value), json: null };
+  }
+  if (typeof value === "undefined") {
+    return { scalar: "undefined", json: null };
+  }
+  try {
+    return {
+      scalar: null,
+      json: JSON.stringify(value, null, 2) ?? String(value),
+    };
+  } catch {
+    return { scalar: String(value), json: null };
+  }
+}
+
+/**
+ * Project a `skill_execute` envelope into its readable parts.
+ *
+ * The documented envelope is `{ tool, input: {...}, activity }`. Weaker models
+ * routinely misplace the inner parameters — the daemon's
+ * `resolveSkillExecuteParams` rescues several of those shapes before dispatch,
+ * and we mirror the two that reach the client: `input` arriving as a
+ * JSON-encoded string, and parameters spread as top-level siblings of
+ * `tool`/`activity`. Matching that leniency keeps the drawer readable for
+ * exactly the calls that most need explaining.
+ */
+export function parseSkillExecuteActivity(input: unknown): SkillExecuteActivity {
+  const bag = toBag(input);
+  const innerToolName = readString(bag, "tool");
+  const activity = readString(bag, "activity");
+
+  let inner = bag.input;
+
+  // `input` passed as a JSON-encoded string.
+  if (typeof inner === "string") {
+    const raw = inner;
+    try {
+      inner = JSON.parse(raw) as unknown;
+    } catch {
+      // Not JSON — surface the raw string under its own key so it's not lost.
+      return {
+        innerToolName,
+        activity,
+        params: [{ key: "input", scalar: raw, json: null }],
+      };
+    }
+  }
+
+  let innerBag = toBag(inner);
+
+  // Parameters spread as siblings of the envelope keys.
+  if (Object.keys(innerBag).length === 0) {
+    const siblings = Object.fromEntries(
+      Object.entries(bag).filter(
+        ([key]) => key !== "tool" && key !== "input" && key !== "activity",
+      ),
+    );
+    if (Object.keys(siblings).length > 0) {
+      innerBag = siblings;
+    }
+  }
+
+  const params: SkillExecuteParam[] = Object.entries(innerBag).map(
+    ([key, value]) => ({ key, ...formatParamValue(value) }),
+  );
+
+  return { innerToolName, activity, params };
+}
+
+/** Tool names this module renders purpose-built UI for. */
+export const SKILL_ACTIVITY_TOOL_NAMES = new Set([
+  "skill_load",
+  "skill_execute",
+]);


### PR DESCRIPTION
Closes [LUM-2999](https://linear.app/vellum/issue/LUM-2999/render-common-tool-activity-as-readable-tool-specific-ui).

## What's happening

The activity side panel renders every tool the same generic way: raw JSON input into a `<pre>`, raw text output into another. That reads worst for the tools that run most often — two of which are the skill tools.

- **`skill_load`** showed `{"skill":"app-builder"}` as JSON, then dumped the skill's entire instruction body — often thousands of lines, including the machine-facing `## Available Tools` manifest — into a monospace block.
- **`skill_execute`** is an envelope, so the JSON dump buried the thing a reader actually wants (which tool ran, with which parameters) one level down inside `{ tool, input, activity }`.

## What this does

Adds a **renderer registry keyed by tool name** (`tool-activity/tool-activity-renderers.ts`). Tools with an entry replace the generic input block; those that also own their result — as `skill_load` does, since its output *is* the skill body — suppress the shared Output section rather than printing the same text twice. Every tool without an entry is untouched.

The ticket scopes this to "beginning with skill loading and skill execution", so the registry is the seam: adding a tool later means writing its renderer and adding one line.

### `skill_load`

Leads with the skill's identity and tool count, then a **Provides** list of what the skill unlocked, then the instructions as real markdown behind a disclosure. Failures read as prose instead of raw tool output. While the call is in flight, skeleton placeholders stand in for the manifest and instruction body so the panel doesn't reflow when they land — the identity row is *not* skeletonised, since the skill id comes from the call's own input and is known immediately.

The Provides list is deliberately minimal: **tool name + one-line description, no parameter schemas.** This panel answers "what can the assistant do now that it couldn't a moment ago", and a tool's name and description answer that completely. Parameter names, types, and required flags are model-facing API surface — nobody reading this panel is going to call `app_create(name, template)` themselves, and rendering them tripled each row's height for detail nobody acts on. The parser still extracts them into `SkillToolSummary.params`, so the data is available if a future surface wants it.

### `skill_execute`

Unwraps the envelope: the inner tool leads, the activity sentence explains it, and inner parameters render as a labelled list — scalars inline, objects as pretty JSON. Parsing deliberately mirrors the leniency of the daemon's `resolveSkillExecuteParams` for the two misplacements that reach the client (`input` arriving as a JSON-encoded string; params spread as siblings of the envelope keys), so the malformed calls that most need explaining are exactly the ones that stay readable.

Both keep a raw-JSON disclosure as an escape hatch.

## A typography bug worth knowing about

Two variants ship `line-height: 1` — `body-small-default` and `label-small-default` (`tokens.css:591,603`). A line-height of exactly 1 leaves no room below the baseline, so descenders get clipped: `template`, `public`, and `config` were all losing their tails in the parameters list.

`body-small-lighter` is the same 12px with a proper 18px leading, so prose and secondary text move to it, and the remaining call sites get an explicit `leading-4` / `leading-5`.

**The tokens themselves are left alone** — they're global, and changing them would ripple across every panel well beyond this PR. But anything else in the app using those two variants for descender-bearing text has the same bug today. Probably worth its own ticket.

## Storybook

- `Chat/ToolDetailPanel` → **SkillLoad**, **SkillLoadError**, **SkillLoadRunning**, **SkillExecute** — the full drawer, using a `skill_load` body shaped like real `formatToolSchemas` output.
- `Chat/ToolActivity/SkillToolList` → **Default**, **LongDescriptions**, **WithChildSkill**.

## Notes

- `CodeBlock` / `SectionLabel` move to `components/detail-primitives.tsx` so the renderers can compose them without an import cycle back through the panel. `tool-detail-panel` re-exports both, so `background-task-detail-panel` and friends are unchanged.
- Parsing lives in `domains/chat/utils/skill-activity.ts` — pure, no React/store/IO, 15 unit tests covering the manifest split, child-skill attribution, param parsing, error bodies, the running state, and each envelope-recovery path.

## Testing

- `bun run typecheck` — clean.
- `bun run lint` on all changed files — clean.
- `bun test` — 15 new tests pass. The 2 failures in `stream-handlers/message-handlers.test.ts` are pre-existing cross-file test pollution: they fail identically on clean `main` with the same batch, and pass when that file is run alone.
- `bun run build` and `bun run build-storybook` both succeed.
- Visually reviewed in Storybook across two rounds of feedback.

## Known gaps (deliberate, not oversights)

- The panel shows the raw skill **id**, not a human name + description — the skill's frontmatter description isn't in the parsed body today.
- Nothing surfaces `skill_load`'s **side effects**: auto-install from the catalog (workspace writes + `bun install`), inline command expansion (dynamic skills execute shell at load time, which is why `sensitiveToolReach` classifies them as `host` reach), or transitively included child skills. This isn't just unimplemented — it's currently *unavailable*: `renderInlineCommands` folds its output straight into the body and reports `expandedCount`/`failedCount` only to the logger. Surfacing it needs a daemon-side wire change. This is the highest-value follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)