### PR TITLE
refactor: consolidate the billing checkout flow type and align the deep-link contract

### DIFF
--- a/clients/macos/src/main/deep-links.ts
+++ b/clients/macos/src/main/deep-links.ts
@@ -154,8 +154,6 @@ export const parseVellumUrl = (input: string): DeepLink => {
     if (segment !== "checkout-complete") {
       return { kind: "unknown", url: withoutQuery };
     }
-    // `flow=top_up` marks a credit top-up checkout; anything else (including
-    // links without the param) is a subscription checkout.
     const flow: "subscription" | "top_up" =
       url.searchParams.get("flow") === "top_up" ? "top_up" : "subscription";
     const status = url.searchParams.get("status");

--- a/clients/web/src/lib/event-bus.ts
+++ b/clients/web/src/lib/event-bus.ts
@@ -46,6 +46,14 @@ export type AppResumeSignal = "visibility" | "app_state" | "online";
 export type AppHiddenSignal = "visibility" | "app_state";
 
 /**
+ * Which checkout a completed Stripe session belongs to: a Pro
+ * subscription upgrade or a credit top-up. Carried on
+ * `deeplink.billingCheckoutComplete`; the deep-link parsers in
+ * `runtime/` share this alias.
+ */
+export type BillingCheckoutFlow = "subscription" | "top_up";
+
+/**
  * Map of bus event name → payload type. New event names are added
  * here so subscribers get exact handler types via the `keyof` lookup.
  */
@@ -158,8 +166,8 @@ export interface BusEventMap {
    * clients and current Pro links).
    */
   "deeplink.billingCheckoutComplete":
-    | { status: "success"; sessionId: string; flow: "subscription" | "top_up" }
-    | { status: "cancel"; sessionId: null; flow: "subscription" | "top_up" };
+    | { status: "success"; sessionId: string; flow: BillingCheckoutFlow }
+    | { status: "cancel"; sessionId: null; flow: BillingCheckoutFlow };
   /**
    * The user asked to talk, from outside the SPA:
    * `<scheme>://voice?mode=new|resume&prompt=…`. The single native→SPA

--- a/clients/web/src/runtime/deep-links.ts
+++ b/clients/web/src/runtime/deep-links.ts
@@ -1,3 +1,4 @@
+import type { BillingCheckoutFlow } from "@/lib/event-bus";
 import { isElectron } from "@/runtime/is-electron";
 
 /**
@@ -31,13 +32,13 @@ export type DeepLink =
       kind: "billingCheckoutComplete";
       status: "success";
       sessionId: string;
-      flow?: "subscription" | "top_up";
+      flow?: BillingCheckoutFlow;
     }
   | {
       kind: "billingCheckoutComplete";
       status: "cancel";
       sessionId: null;
-      flow?: "subscription" | "top_up";
+      flow?: BillingCheckoutFlow;
     }
   /** `<scheme>://connect` pairing hand-off. `bundle` is secret material:
    *  never log or breadcrumb it. */

--- a/clients/web/src/runtime/event-sources/electron-deep-links.test.ts
+++ b/clients/web/src/runtime/event-sources/electron-deep-links.test.ts
@@ -1,22 +1,7 @@
 import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 
-type DeepLink =
-  | { kind: "send"; message: string }
-  | { kind: "openThread"; threadId: string }
-  | {
-      kind: "billingCheckoutComplete";
-      status: "success";
-      sessionId: string;
-      flow: "subscription" | "top_up";
-    }
-  | {
-      kind: "billingCheckoutComplete";
-      status: "cancel";
-      sessionId: null;
-      flow: "subscription" | "top_up";
-    }
-  | { kind: "connect"; url?: string; bundle?: string }
-  | { kind: "unknown"; url: string };
+// Type-only, so it is erased before `mock.module` replaces the module.
+import type { DeepLink } from "@/runtime/deep-links";
 
 let activeCallback: ((link: DeepLink) => void) | null = null;
 let pendingFixture: DeepLink[] = [];

--- a/clients/web/src/runtime/native-deep-link.ts
+++ b/clients/web/src/runtime/native-deep-link.ts
@@ -12,6 +12,8 @@
  * Reference: https://capacitorjs.com/docs/apis/app#addlistenerappurlopen-
  */
 
+import type { BillingCheckoutFlow } from "@/lib/event-bus";
+
 export const OAUTH_COMPLETE_DEEP_LINK_EVENT = "vellum:oauth-complete-deeplink";
 export const OAUTH_COMPLETE_DEEP_LINK_HOST = "oauth-complete";
 
@@ -58,13 +60,6 @@ const BILLING_CHECKOUT_COMPLETE_PATH_SEGMENT = "checkout-complete";
  */
 const CHECKOUT_SESSION_ID_RE = /^cs_[A-Za-z0-9_]{1,255}$/;
 
-/**
- * Which checkout the completed Stripe session belongs to: a Pro subscription
- * upgrade or a credit top-up. Carried as the deep link's optional `flow`
- * query param; links that omit it (all Pro-upgrade links) are `subscription`.
- */
-export type BillingCheckoutFlow = "subscription" | "top_up";
-
 export type BillingCheckoutCompleteDeepLinkPayload =
   | { status: "success"; sessionId: string; flow: BillingCheckoutFlow }
   | { status: "cancel"; sessionId: null; flow: BillingCheckoutFlow };
@@ -100,8 +95,6 @@ export function parseBillingCheckoutCompleteDeepLink(
     return null;
   }
 
-  // Only `top_up` is meaningful; a missing or unrecognized value degrades to
-  // `subscription`, which is what every link without the param means.
   const flow: BillingCheckoutFlow =
     url.searchParams.get("flow") === "top_up" ? "top_up" : "subscription";
 

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -225,20 +225,24 @@ export type DeepLink =
   | { kind: "openThread"; threadId: string }
   /**
    * `flow` distinguishes a Pro subscription checkout from a credit top-up
-   * checkout. The main-process parser defaults it to `subscription` when
-   * the link omits the `flow` query param (all current Pro links).
+   * checkout. The main-process parser always sets it, defaulting to
+   * `subscription` when the link omits the `flow` query param (all current
+   * Pro links). Optional at this seam because a newer renderer can pair
+   * with a main process that predates the field (dev serves the SPA from
+   * Vite or the edge proxy, not the app bundle); the renderer defaults an
+   * absent value to `subscription`.
    */
   | {
       kind: "billingCheckoutComplete";
       status: "success";
       sessionId: string;
-      flow: "subscription" | "top_up";
+      flow?: "subscription" | "top_up";
     }
   | {
       kind: "billingCheckoutComplete";
       status: "cancel";
       sessionId: null;
-      flow: "subscription" | "top_up";
+      flow?: "subscription" | "top_up";
     }
   /**
    * `<scheme>://connect`: the pair-page "Open in the Vellum app" hand-off


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for abandoned-checkout-bonus-ui.md.

**Gap A:** BillingCheckoutFlow was exported but unused while the union was retyped inline across the web files; web declarations now share one alias
**Gap B:** the ipc-contract and renderer DeepLink types disagreed on flow optionality; aligned with a single version-skew story
**Gap C:** removed within-file restatements of the flow-defaulting rule
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40530" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->