### PR TITLE
fix: re-arm the checkout-bonus trigger on every cancel signal

### DIFF
--- a/clients/web/src/domains/settings/billing/billing-page.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.tsx
@@ -161,14 +161,20 @@ function BillingTabContent() {
 
   // Abandoned-checkout bonus: the cancel signal lives in state (not the URL)
   // because BillingStatusHandler immediately navigate-replaces the query
-  // string away. The hook only queries once a cancel actually happened, and
-  // the server's answer alone decides whether the offer shows. Local
-  // dismissal keeps a declined offer closed while the eligibility answer is
-  // still cached.
-  const [checkoutCancelled, setCheckoutCancelled] = useState(false);
-  const onCheckoutCancelled = useCallback(() => setCheckoutCancelled(true), []);
+  // string away. It's a timestamp, not a boolean: this tab is a persistent
+  // mount on Electron/iOS, so a second cancel must read as a fresh trigger
+  // (the hook re-asks the server) instead of latching after the first. The
+  // server's answer alone decides whether the offer shows. Local dismissal
+  // keeps a declined offer closed until the next cancel re-arms it.
+  const [checkoutCancelledAt, setCheckoutCancelledAt] = useState<number | null>(
+    null,
+  );
   const [bonusDismissed, setBonusDismissed] = useState(false);
-  const { showOffer, amountUsd } = useCheckoutBonusOffer(checkoutCancelled);
+  const onCheckoutCancelled = useCallback(() => {
+    setCheckoutCancelledAt(Date.now());
+    setBonusDismissed(false);
+  }, []);
+  const { showOffer, amountUsd } = useCheckoutBonusOffer(checkoutCancelledAt);
   const onBonusOpenChange = useCallback((open: boolean) => {
     if (!open) {
       setBonusDismissed(true);

--- a/clients/web/src/domains/settings/billing/use-checkout-bonus-offer.test.ts
+++ b/clients/web/src/domains/settings/billing/use-checkout-bonus-offer.test.ts
@@ -8,9 +8,15 @@
  *    so hand-typed cancel URLs stay quiet
  *  - triggered + server says eligible: the offer shows with the
  *    server-returned amount
- *  - a second trigger behind the app's 10s default staleTime: the cached
- *    ineligible answer from a previous probe is not reused; each trigger
- *    re-asks the server
+ *  - a first cancel arriving on an already-mounted tab: exactly one request
+ *    (the enabled transition fetches; the repeat-trigger invalidation must
+ *    not double up)
+ *  - a repeat cancel on the same persistent mount (the Electron/iOS case:
+ *    no document reload, no remount): re-asks the server once per trigger,
+ *    and a stale `eligible: true` from the previous cancel is not re-shown
+ *    while the fresh verification is in flight
+ *  - a repeat cancel across a remount (the web case): the cached ineligible
+ *    answer behind the app's 10s default staleTime is not reused
  *
  * The GET is mocked at the SDK boundary so the real generated query factory
  * stays in the loop, mirroring checkout-bonus-modal.test.tsx.
@@ -27,15 +33,23 @@ import type { CheckoutBonusEligibilityResponse } from "@/generated/api/types.gen
 let retrieveCalls = 0;
 let eligibilityResponse: CheckoutBonusEligibilityResponse;
 let orgReady = true;
+// When set, in-flight responses wait until the test releases them.
+let releaseResponse: (() => void) | null = null;
+let holdResponses = false;
 
 mock.module("@/generated/api/sdk.gen", () => ({
   ...sdkGen,
-  organizationsBillingCheckoutBonusRetrieve: () => {
+  organizationsBillingCheckoutBonusRetrieve: async () => {
     retrieveCalls += 1;
-    return Promise.resolve({
+    if (holdResponses) {
+      await new Promise<void>((resolve) => {
+        releaseResponse = resolve;
+      });
+    }
+    return {
       data: eligibilityResponse,
       response: { ok: true },
-    });
+    };
   },
 }));
 
@@ -45,7 +59,7 @@ mock.module("@/hooks/use-is-org-ready", () => ({
 
 const { useCheckoutBonusOffer } = await import("./use-checkout-bonus-offer");
 
-function setup(triggered: boolean, client?: QueryClient) {
+function setup(cancelledAt: number | null, client?: QueryClient) {
   const queryClient =
     client ??
     new QueryClient({
@@ -53,19 +67,23 @@ function setup(triggered: boolean, client?: QueryClient) {
     });
   const wrapper = ({ children }: { children: ReactNode }) =>
     createElement(QueryClientProvider, { client: queryClient }, children);
-  return renderHook((props) => useCheckoutBonusOffer(props.triggered), {
-    initialProps: { triggered },
+  return renderHook((props) => useCheckoutBonusOffer(props.cancelledAt), {
+    initialProps: { cancelledAt },
     wrapper,
   });
 }
 
 // Lets any wrongly-enabled fetch land before asserting a call count of zero.
+// Also long enough that a `Date.now()` taken after it postdates any response
+// that already resolved, so successive triggers get distinct timestamps.
 const flush = () => new Promise((resolve) => setTimeout(resolve, 10));
 
 beforeEach(() => {
   retrieveCalls = 0;
   eligibilityResponse = { eligible: true, amount_usd: "5.00" };
   orgReady = true;
+  releaseResponse = null;
+  holdResponses = false;
 });
 
 afterEach(() => {
@@ -74,7 +92,7 @@ afterEach(() => {
 
 describe("useCheckoutBonusOffer", () => {
   test("no cancel signal: never queries, never offers", async () => {
-    const { result } = setup(false);
+    const { result } = setup(null);
 
     await flush();
     expect(retrieveCalls).toBe(0);
@@ -83,14 +101,15 @@ describe("useCheckoutBonusOffer", () => {
 
   test("triggered before the org settles: waits, then fires once", async () => {
     orgReady = false;
-    const { result, rerender } = setup(true);
+    const cancelledAt = Date.now();
+    const { result, rerender } = setup(cancelledAt);
 
     await flush();
     expect(retrieveCalls).toBe(0);
     expect(result.current.showOffer).toBe(false);
 
     orgReady = true;
-    rerender({ triggered: true });
+    rerender({ cancelledAt });
 
     await waitFor(() => expect(result.current.showOffer).toBe(true));
     expect(retrieveCalls).toBe(1);
@@ -98,7 +117,7 @@ describe("useCheckoutBonusOffer", () => {
 
   test("triggered + ineligible: one request, no offer", async () => {
     eligibilityResponse = { eligible: false, amount_usd: "0.00" };
-    const { result } = setup(true);
+    const { result } = setup(Date.now());
 
     await waitFor(() => expect(retrieveCalls).toBe(1));
     await flush();
@@ -107,22 +126,76 @@ describe("useCheckoutBonusOffer", () => {
 
   test("triggered + eligible: offers the server-returned amount", async () => {
     eligibilityResponse = { eligible: true, amount_usd: "7.50" };
-    const { result } = setup(true);
+    const { result } = setup(Date.now());
 
     await waitFor(() => expect(result.current.showOffer).toBe(true));
     expect(result.current.amountUsd).toBe("7.50");
     expect(retrieveCalls).toBe(1);
   });
 
-  test("repeat trigger: refetches past the app's 10s default staleTime", async () => {
-    // Mirror the app QueryClient (providers.tsx): a 10s default staleTime
-    // would otherwise let a cached ineligible probe answer a real cancel.
+  test("first cancel on an already-mounted tab: exactly one request", async () => {
+    const { result, rerender } = setup(null);
+
+    await flush();
+    expect(retrieveCalls).toBe(0);
+
+    rerender({ cancelledAt: Date.now() });
+
+    await waitFor(() => expect(result.current.showOffer).toBe(true));
+    await flush();
+    expect(retrieveCalls).toBe(1);
+  });
+
+  test("repeat cancel on a persistent mount: re-asks the server", async () => {
+    // Mirror the app QueryClient (providers.tsx): a 10s default staleTime.
+    // The mount never cycles, so `enabled` never re-transitions; the hook
+    // must refetch off the trigger itself.
     const client = new QueryClient({
       defaultOptions: { queries: { retry: false, staleTime: 10_000 } },
     });
 
     eligibilityResponse = { eligible: false, amount_usd: "0.00" };
-    const first = setup(true, client);
+    const { result, rerender } = setup(Date.now(), client);
+    await waitFor(() => expect(retrieveCalls).toBe(1));
+    await flush();
+    expect(result.current.showOffer).toBe(false);
+
+    // A real abandoned checkout lands moments later, on the same mount.
+    eligibilityResponse = { eligible: true, amount_usd: "5.00" };
+    rerender({ cancelledAt: Date.now() });
+
+    await waitFor(() => expect(result.current.showOffer).toBe(true));
+    expect(result.current.amountUsd).toBe("5.00");
+    expect(retrieveCalls).toBe(2);
+  });
+
+  test("repeat cancel: stale eligible answer stays hidden until re-verified", async () => {
+    const { result, rerender } = setup(Date.now());
+    await waitFor(() => expect(result.current.showOffer).toBe(true));
+    await flush();
+
+    // Second cancel on the same mount; hold the fresh answer in flight.
+    holdResponses = true;
+    rerender({ cancelledAt: Date.now() });
+
+    await waitFor(() => expect(retrieveCalls).toBe(2));
+    // The previous `eligible: true` predates this trigger, so no offer yet.
+    expect(result.current.showOffer).toBe(false);
+
+    eligibilityResponse = { eligible: true, amount_usd: "5.00" };
+    releaseResponse?.();
+
+    await waitFor(() => expect(result.current.showOffer).toBe(true));
+    expect(retrieveCalls).toBe(2);
+  });
+
+  test("repeat trigger across a remount: refetches past the app's 10s default staleTime", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: 10_000 } },
+    });
+
+    eligibilityResponse = { eligible: false, amount_usd: "0.00" };
+    const first = setup(Date.now(), client);
     await waitFor(() => expect(retrieveCalls).toBe(1));
     await flush();
     expect(first.result.current.showOffer).toBe(false);
@@ -130,7 +203,7 @@ describe("useCheckoutBonusOffer", () => {
 
     // A real abandoned checkout lands within the staleness window.
     eligibilityResponse = { eligible: true, amount_usd: "5.00" };
-    const second = setup(true, client);
+    const second = setup(Date.now(), client);
 
     await waitFor(() => expect(second.result.current.showOffer).toBe(true));
     expect(second.result.current.amountUsd).toBe("5.00");

--- a/clients/web/src/domains/settings/billing/use-checkout-bonus-offer.ts
+++ b/clients/web/src/domains/settings/billing/use-checkout-bonus-offer.ts
@@ -1,10 +1,15 @@
-import { useQuery } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
+
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { organizationsBillingCheckoutBonusRetrieveOptions } from "@/generated/api/@tanstack/react-query.gen";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 
 export interface CheckoutBonusOffer {
-  /** True once the server has verified the offer is claimable. */
+  /**
+   * True once the server has verified, for the most recent cancel trigger,
+   * that the offer is claimable.
+   */
   showOffer: boolean;
   /**
    * Offer amount as a USD decimal string (e.g. "5.00") from the eligibility
@@ -16,9 +21,13 @@ export interface CheckoutBonusOffer {
 /**
  * Server-verified eligibility for the abandoned-checkout credit bonus.
  *
- * `triggered` is the client-side cancel signal (`?billing_status=cancel`,
- * which the Pro upgrade-cancel page also funnels into). The GET is the
- * authority on eligibility (the client never decides it), so a hand-typed
+ * `cancelledAt` is the client-side cancel signal: the `Date.now()` of the most
+ * recent definitive cancel (`?billing_status=cancel`, which the upgrade-cancel
+ * page and the native `flow=top_up&status=cancel` deep link also funnel into),
+ * or `null` before any cancel. A timestamp rather than a boolean so repeat
+ * cancels on a persistent SPA mount (Electron/iOS never reload the document)
+ * each read as a fresh trigger instead of latching after the first. The GET is
+ * the authority on eligibility (the client never decides it), so a hand-typed
  * cancel URL with no real abandoned checkout behind it resolves to
  * `eligible: false` and shows nothing.
  *
@@ -26,23 +35,50 @@ export interface CheckoutBonusOffer {
  * fired before the org store settles omits `Vellum-Organization-Id` and the
  * platform rejects it.
  *
- * `staleTime: 0` overrides the app QueryClient's 10s default so every cancel
- * trigger asks the server again: without it, an `eligible: false` answer
- * cached by a recent probe (an upgrade cancel, a hand-typed URL) would be
- * reused when a real abandoned checkout lands moments later, and the offer
- * would never show. Focus refetches are disabled so each trigger still costs
- * exactly one request.
+ * Every trigger asks the server again, at a cost of exactly one request:
+ * - The first trigger flips `enabled`, and `staleTime: 0` (overriding the app
+ *   QueryClient's 10s default) makes that transition fetch even when a recent
+ *   probe (an upgrade cancel, a hand-typed URL) left an `eligible: false`
+ *   answer in the cache.
+ * - A repeat trigger never toggles `enabled`, so the effect below invalidates
+ *   the query instead. The first arming is excluded there because the enabled
+ *   transition already fetches, and focus refetches are disabled.
+ *
+ * `showOffer` additionally requires the answer to postdate the trigger
+ * (`dataUpdatedAt >= cancelledAt`), so a stale `eligible: true` from an
+ * earlier cancel cannot re-open the offer in the window before the fresh
+ * verification lands.
  */
-export function useCheckoutBonusOffer(triggered: boolean): CheckoutBonusOffer {
+export function useCheckoutBonusOffer(
+  cancelledAt: number | null,
+): CheckoutBonusOffer {
   const orgReady = useIsOrgReady();
-  const { data } = useQuery({
+  const queryClient = useQueryClient();
+  const triggered = cancelledAt !== null;
+  const { data, dataUpdatedAt } = useQuery({
     ...organizationsBillingCheckoutBonusRetrieveOptions(),
     enabled: triggered && orgReady,
     staleTime: 0,
     refetchOnWindowFocus: false,
   });
+
+  const armedAtRef = useRef(cancelledAt);
+  useEffect(() => {
+    const previous = armedAtRef.current;
+    armedAtRef.current = cancelledAt;
+    if (cancelledAt === null || cancelledAt === previous || previous === null) {
+      return;
+    }
+    // Refetches when the query is enabled; while it's still org-gated this
+    // only marks the cache stale and the enabled transition fetches later.
+    void queryClient.invalidateQueries(
+      organizationsBillingCheckoutBonusRetrieveOptions(),
+    );
+  }, [cancelledAt, queryClient]);
+
   return {
-    showOffer: triggered && data?.eligible === true,
+    showOffer:
+      triggered && data?.eligible === true && dataUpdatedAt >= cancelledAt,
     amountUsd: data?.amount_usd ?? "0.00",
   };
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for abandoned-checkout-bonus-ui.md.

**Gap:** repeat cancels in a persistent SPA mount never re-ran the eligibility check, and a dismissal latched forever
**What was expected:** every definitive cancel triggers a fresh server-verified eligibility GET and can re-offer
**What was found:** boolean latches in BillingTabContent made second cancels state no-ops on the native funnel's persistent mount
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40531" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->