### PR TITLE
fix(gateway): prefer the managed callback route over the Velay URL on platform pods

### DIFF
--- a/gateway/src/__tests__/telegram-webhook-manager.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-manager.test.ts
@@ -481,6 +481,72 @@ describe("reconcileTelegramWebhook", () => {
     ]);
   });
 
+  test("prefers the managed callback route over the Velay ingress URL on platform pods", async () => {
+    const calls: string[] = [];
+    let registeredUrl: string | undefined;
+    process.env.IS_PLATFORM = "true";
+    // A platform pod always has an `ingress.publicBaseUrl`: the Velay tunnel
+    // client publishes one at boot. It must not win over the managed callback
+    // route — the Velay address dies with the tunnel, and the daemon's
+    // `hasWebhookRoutingConfigured` reports this pod as managed-callback mode.
+    const caches = makeCaches({
+      ingressUrl:
+        "https://velay.vellum.ai/11111111-2222-4333-8444-555555555555",
+      platformBaseUrl: "https://platform.example.com",
+      assistantApiKey: "ast-managed-key",
+      platformAssistantId: "11111111-2222-4333-8444-555555555555",
+    });
+
+    fetchMock = mock(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        if (url.includes("/callback-routes/register/")) {
+          calls.push("registerCallbackRoute");
+          return new Response(
+            JSON.stringify({
+              callback_url:
+                "https://platform.example.com/v1/gateway/callbacks/11111111-2222-4333-8444-555555555555/webhooks/telegram/",
+            }),
+            { status: 201, headers: { "content-type": "application/json" } },
+          );
+        }
+        if (url.includes("/getWebhookInfo")) {
+          calls.push("getWebhookInfo");
+          return makeTelegramResponse({
+            url: "",
+            has_custom_certificate: false,
+            pending_update_count: 0,
+          });
+        }
+        if (url.includes("/setWebhook")) {
+          calls.push("setWebhook");
+          const body = init?.body
+            ? (JSON.parse(init.body as string) as { url?: string })
+            : undefined;
+          registeredUrl = body?.url;
+          return makeTelegramResponse(true);
+        }
+        return new Response("Not found", { status: 404 });
+      },
+    );
+
+    await reconcileTelegramWebhook(caches);
+
+    expect(calls).toEqual([
+      "registerCallbackRoute",
+      "getWebhookInfo",
+      "setWebhook",
+    ]);
+    expect(registeredUrl).toBe(
+      "https://platform.example.com/v1/gateway/callbacks/11111111-2222-4333-8444-555555555555/webhooks/telegram/",
+    );
+  });
+
   test("does not call Telegram when ingress is disabled but credentials are absent", async () => {
     fetchMock = mock(async () => new Response("", { status: 200 }));
 

--- a/gateway/src/telegram/webhook-manager.ts
+++ b/gateway/src/telegram/webhook-manager.ts
@@ -146,17 +146,30 @@ async function resolveExpectedTelegramWebhookUrl(
   // resolver declines makes setup report success while setWebhook never runs
   // (LUM-2899).
   //
-  //   1. An explicit `ingress.enabled: false` is a decision not to accept
+  //   1. Platform pods (`IS_PLATFORM`) always use the managed callback route
+  //      and never consult ingress at all — a pod has no self-owned ingress to
+  //      advertise. Its `ingress.publicBaseUrl` is written by the Velay tunnel
+  //      client, not by a user, and that address is only live while the tunnel
+  //      is: `clearManagedPublicBaseUrl` wipes the key when the tunnel drops,
+  //      but Telegram keeps delivering to whatever was last registered, so a
+  //      pod that resolved through this tier would be pointed at a dead
+  //      address until something triggered another reconciliation. The
+  //      platform callback route is the pod's stable inbound address.
+  //   2. An explicit `ingress.enabled: false` is a decision not to accept
   //      inbound webhooks at all; it precedes both tiers below and actively
   //      deregisters, so `reconcileTelegramWebhook` handles it before calling
   //      this resolver. Platform pods are exempt (see the comment there).
-  //   2. A configured public ingress URL wins (a self-hosted tunnel, or the
+  //   3. A configured public ingress URL wins (a self-hosted tunnel, or the
   //      Velay-published URL while the tunnel is registered).
-  //   3. Platform-connected assistants (platform pods and local assistants
-  //      holding vellum credentials) fall back to a managed platform callback
-  //      route. `registerManagedTelegramCallbackRoute` self-gates on platform
+  //   4. Platform-connected local assistants holding vellum credentials fall
+  //      back to a managed platform callback route.
+  //      `registerManagedTelegramCallbackRoute` self-gates on platform
   //      features and credential presence, so a gateway with no platform
   //      context resolves to undefined and reconciliation skips.
+  if (isPlatformMode()) {
+    return registerManagedTelegramCallbackRoute(caches);
+  }
+
   let ingressUrl: string | undefined;
   if (caches?.configFile) {
     ingressUrl = caches.configFile.getString("ingress", "publicBaseUrl");


### PR DESCRIPTION
## Prompt / plan

Reported from a platform assistant's logs:

```
[webhook-manager] Telegram webhook registered
  → https://velay.vellum.ai/019f68eb.../webhooks/telegram
```

The expected address for a platform assistant is its managed callback route,
`https://platform.vellum.ai/v1/gateway/callbacks/<assistantId>/webhooks/telegram/`.
Asked to confirm whether this was a regression and identify the PR that caused it, then fix it.

### What's wrong

`resolveExpectedTelegramWebhookUrl` (`gateway/src/telegram/webhook-manager.ts`) read `ingress.publicBaseUrl` before anything else, with no `IS_PLATFORM` tier:

```ts
const ingressUrl = caches.configFile.getString("ingress", "publicBaseUrl");
if (ingressUrl) {
  return `${ingressUrl}/${TELEGRAM_CALLBACK_PATH}`;   // ← always wins
}
return registerManagedTelegramCallbackRoute(caches);
```

The daemon derivation it claims to mirror does have that tier. `hasWebhookRoutingConfigured` (`assistant/src/config/webhook-routing.ts`) and `handleWebhooksRegister` (`assistant/src/runtime/routes/webhook-routes.ts`) both resolve `IS_PLATFORM` → managed callbacks *before* consulting ingress, because a pod has no self-owned ingress to advertise. So on a pod the daemon reported `usesManagedCallbacks: true` while the gateway registered the Velay URL — the same class of gateway/daemon divergence LUM-2899 fixed, in mirror image.

`reconcileTelegramWebhook` already knew about this rule; it calls `isPlatformMode()` for the `ingress.enabled: false` exemption. The URL resolution just never got the same treatment.

### Why it's a regression, and where from

Two commits, neither wrong on its own:

- **Latent from #29104** (`4dbb776786`, May 1) — "delete `ingress.twilioPublicBaseUrl` in favor of `publicBaseUrl` + `publicBaseUrlManagedBy`". Velay used to publish its URL to `ingress.twilioPublicBaseUrl`, a key the Telegram resolver never read. After this it writes the generic `ingress.publicBaseUrl` (`gateway/src/velay/client.ts:808`) — exactly the key this resolver reads. Harmless at the time, because the tunnel almost never ran.

- **Fires from #39222** (`ff78929883`, Jul 27) — "refactor(voice): drop the voice-mode flag and the canned spoken acks (JARVIS-1351)". It replaced flag-gated `maybeStartVelayTunnelForLiveVoice` with unconditional `startVelayTunnelForLiveVoice` (`gateway/src/index.ts:421`, called at `:2789`):

  ```ts
  -  if (!isLiveVoiceEnabled()) return false;   // voice-mode flag gate
  ```

  Its own comment states the intent: *"Live voice is available to every assistant, so this runs unconditionally at startup."* Every platform pod now brings the tunnel up at boot and publishes an ingress URL where previously almost none did.

Timing also explains the intermittency: `startAsync()` calls `clearManagedPublicBaseUrl` before connecting, so a reconciliation landing before tunnel registration still resolves to the platform URL.

### Why it matters beyond looking wrong

Velay does forward `^/webhooks/` (`gateway/src/velay/allowed-paths.ts:39`), so delivery works while the tunnel is up. But tunnels cycle (#40167), and on tunnel loss `clearManagedPublicBaseUrl` wipes `ingress.publicBaseUrl` while Telegram keeps delivering to the last address it was given — leaving the channel pointed at a dead URL until something triggers another reconciliation. The platform callback route is the pod's stable inbound address, which is why the daemon ranks it first.

### The fix

Resolve `IS_PLATFORM` to the managed callback route first and never consult ingress on a pod — the tier order the daemon already documents. Nine lines of comment, three lines of code.

Deliberately strict: a pod whose platform credentials aren't cached yet now resolves to `undefined` and skips, rather than falling back to the Velay URL. That matches the daemon's unconditional tier 1, and it self-heals — the credential watcher added in #39450 reconciles on vellum credential changes.

Considered and rejected: gating on `ingress.publicBaseUrlManagedBy === "velay"` instead, which would preserve a user-set custom ingress on a pod. Pods have no self-owned ingress to configure, so the `IS_PLATFORM` check is both correct and simpler.

## Test plan

- New test: `prefers the managed callback route over the Velay ingress URL on platform pods` — `IS_PLATFORM=true` with a Velay-shaped `ingress.publicBaseUrl` present, asserting `setWebhook` receives the platform callback URL. Verified it **fails** on the pre-fix resolver and passes after.
- This was the uncovered cell: the existing platform test (`ignores ingress.enabled false on platform pods`) pins `ingressUrl: undefined`, and the ingress-wins test is a non-platform ngrok case. Platform-pod-*with*-an-ingress-URL had no coverage.
- `bun test src/__tests__/telegram-webhook-manager.test.ts` — 17 pass, 0 fail.
- `bunx tsc --noEmit` clean; `bun run lint` 0 errors (5 pre-existing warnings in unrelated files).
- Note: running `src/telegram src/velay src/__tests__/config-file-watcher.test.ts` together shows 4 failures, but they reproduce identically on the unmodified tree — a pre-existing cross-file isolation issue, not from this change. Each file passes alone.

## Follow-up not included here

`gateway/src/email/register-callback.ts` has the same shape — it unconditionally sends `callback_base_url: ingressUrl` whenever `ingress.publicBaseUrl` is set, so a platform pod likely registers a Velay-based email callback for the same reason. Left out to keep this diff to the reported bug; worth a look.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGdKrEKGvwRsguuxxgq82g)_