### PR TITLE
fix(web): collapse the onboarding funnel to one history entry

### DIFF
--- a/clients/web/src/components/onboarding-checkin-overlay.tsx
+++ b/clients/web/src/components/onboarding-checkin-overlay.tsx
@@ -20,6 +20,7 @@ import { useNavigate } from "react-router";
 import { fetchAssistantIdentity } from "@/assistant/identity";
 import { scheduleCheckin } from "@/domains/onboarding/checkin-scheduler";
 import { OnboardingBackButton } from "@/components/onboarding-back-button";
+import { SETUP_NAVIGATE } from "@/domains/onboarding/onboarding-navigation";
 import { CheckinConnectScreen } from "@/domains/onboarding/screens/checkin-connect-screen";
 import { useOnboardingFocusStore } from "@/stores/onboarding-focus-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
@@ -62,7 +63,9 @@ export function OnboardingCheckinOverlay() {
   // the form renders with its normal chrome.
   const handleBack = () => {
     exitFocus();
-    void navigate(routes.onboarding.research);
+    // Still inside setup, so it replaces like every other step — the funnel
+    // stays a single history entry (see `SETUP_NAVIGATE`).
+    void navigate(routes.onboarding.research, SETUP_NAVIGATE);
   };
 
   // Above the research overlay (z-50) so it fully covers the streaming results.

--- a/clients/web/src/domains/onboarding/onboarding-navigation.test.tsx
+++ b/clients/web/src/domains/onboarding/onboarding-navigation.test.tsx
@@ -1,0 +1,196 @@
+/**
+ * The funnel's history contract: every move between setup screens REPLACES the
+ * current entry.
+ *
+ * This is what makes Back inert once setup finishes. The handoff to chat has
+ * always replaced, but that drops one entry — so before this contract, each
+ * screen the funnel pushed on the way in survived, and a single Back press
+ * landed a finished user back inside setup (`onboarding/start` on platform,
+ * `onboarding/hatching` in local mode). A pushed navigation anywhere in the
+ * funnel puts that entry back on the stack, which is exactly the regression
+ * these assertions catch — so they check the options argument, not just the
+ * destination.
+ *
+ * Self-contained mocks (run this file solo — `mock.module` leaks across a shared
+ * `bun test` run).
+ */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { ReactNode } from "react";
+
+import { routes } from "@/utils/routes";
+
+const navigateMock = mock((_to: string, _opts?: unknown) => {});
+let searchParamsValue = new URLSearchParams();
+
+mock.module("react-router", () => ({
+  useNavigate: () => navigateMock,
+  useSearchParams: () => [searchParamsValue, mock(() => {})],
+}));
+
+let localAssistants = false;
+mock.module("@/lib/local-mode", () => ({
+  hasAssistants: () => localAssistants,
+  isLocalClient: () => true,
+}));
+
+mock.module("@/hooks/use-onboarding-login", () => ({
+  useOnboardingLogin: () => ({
+    loading: false,
+    error: null,
+    login: mock(() => {}),
+    cancel: mock(() => {}),
+  }),
+}));
+
+mock.module("@/runtime/is-electron", () => ({ isElectron: () => false }));
+
+mock.module("@/lib/auth/gateway-session", () => ({
+  clearGatewayToken: mock(() => {}),
+}));
+mock.module("@/lib/self-hosted/connection", () => ({
+  setSelfHostedConnection: mock(() => {}),
+}));
+mock.module("@/domains/onboarding/provider-key", () => ({
+  setPendingProviderKey: mock(() => {}),
+  // A staged key so the api-key screen's Continue is enabled without the test
+  // having to drive the (mocked-out) provider inputs.
+  peekPendingProviderKey: () => ({ provider: "anthropic", key: "sk-test" }),
+}));
+
+mock.module("@/stores/auth-store", () => ({
+  useHasPlatformSession: () => true,
+}));
+mock.module("@/stores/client-feature-flag-store", () => ({
+  useClientFeatureFlagStore: {
+    use: { multiPlatformAssistant: () => true },
+  },
+}));
+mock.module("@/stores/resolved-assistants-store", () => ({
+  useResolvedAssistantsStore: { use: { assistants: () => [] } },
+}));
+
+mock.module("@/domains/onboarding/components/onboarding-layout", () => ({
+  OnboardingLayout: ({ children }: { children: ReactNode }) => children,
+}));
+
+mock.module("@vellumai/design-library/components/button", () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children?: ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}));
+mock.module("@vellumai/design-library/components/select", () => ({
+  Select: () => null,
+}));
+mock.module("@vellumai/design-library/components/input", () => ({
+  Input: () => null,
+}));
+
+const { StartScreen } = await import(
+  "@/domains/onboarding/pages/start-screen"
+);
+const { WelcomeScreen } = await import(
+  "@/domains/onboarding/pages/welcome-screen"
+);
+const { HostingScreen } = await import(
+  "@/domains/onboarding/pages/hosting-screen"
+);
+const { ApiKeyScreen } = await import(
+  "@/domains/onboarding/pages/api-key-screen"
+);
+
+/** The options argument of the single `navigate()` this click produced. */
+function navigatedWith(): { to: string; opts: unknown } {
+  expect(navigateMock).toHaveBeenCalledTimes(1);
+  const [to, opts] = navigateMock.mock.calls[0] as [string, unknown];
+  return { to, opts };
+}
+
+function click(label: string): void {
+  fireEvent.click(screen.getByText(label));
+}
+
+describe("onboarding funnel history contract", () => {
+  beforeEach(() => {
+    navigateMock.mockClear();
+    searchParamsValue = new URLSearchParams();
+    localAssistants = false;
+  });
+  afterEach(cleanup);
+
+  test("StartScreen's CTA replaces on the way to consent", () => {
+    render(<StartScreen />);
+    click("Create your assistant");
+
+    const { to, opts } = navigatedWith();
+    expect(to).toBe(routes.onboarding.privacy);
+    expect(opts).toEqual({ replace: true });
+  });
+
+  test("WelcomeScreen replaces on the way into the funnel", () => {
+    render(<WelcomeScreen />);
+    click("Continue without account");
+
+    const { to, opts } = navigatedWith();
+    expect(to).toBe(routes.onboarding.hosting);
+    expect(opts).toEqual({ replace: true });
+  });
+
+  test("WelcomeScreen replaces on the way to the chooser too", () => {
+    localAssistants = true;
+    render(<WelcomeScreen />);
+    click("Continue without account");
+
+    const { to, opts } = navigatedWith();
+    expect(to).toBe(routes.selectAssistant);
+    expect(opts).toEqual({ replace: true });
+  });
+
+  test("HostingScreen replaces going forward", () => {
+    render(<HostingScreen />);
+    click("Continue");
+
+    const { to, opts } = navigatedWith();
+    expect(to).toBe(routes.onboarding.privacy);
+    expect(opts).toEqual({ replace: true });
+  });
+
+  // The in-screen Back affordances have to replace too: a pushed back-step is
+  // an entry the user can then Back INTO after finishing.
+  test("HostingScreen replaces going back", () => {
+    render(<HostingScreen />);
+    click("Back");
+
+    const { to, opts } = navigatedWith();
+    expect(to).toBe(routes.welcome);
+    expect(opts).toEqual({ replace: true });
+  });
+
+  test("ApiKeyScreen replaces in both directions", () => {
+    searchParamsValue = new URLSearchParams("hosting=local");
+    render(<ApiKeyScreen />);
+
+    click("Back");
+    expect(navigatedWith()).toEqual({
+      to: routes.onboarding.hosting,
+      opts: { replace: true },
+    });
+
+    navigateMock.mockClear();
+    click("Continue");
+    const { to, opts } = navigatedWith();
+    expect(to.startsWith(routes.onboarding.privacy)).toBe(true);
+    expect(opts).toEqual({ replace: true });
+  });
+});

--- a/clients/web/src/domains/onboarding/onboarding-navigation.test.tsx
+++ b/clients/web/src/domains/onboarding/onboarding-navigation.test.tsx
@@ -11,6 +11,10 @@
  * these assertions catch — so they check the options argument, not just the
  * destination.
  *
+ * Covers the screens with no test file of their own; `StartScreen` asserts the
+ * same contract in `pages/start-screen.test.tsx`, and `PrivacyScreen` /
+ * `HatchingScreen` in theirs.
+ *
  * Self-contained mocks (run this file solo — `mock.module` leaks across a shared
  * `bun test` run).
  */
@@ -97,9 +101,6 @@ mock.module("@vellumai/design-library/components/input", () => ({
   Input: () => null,
 }));
 
-const { StartScreen } = await import(
-  "@/domains/onboarding/pages/start-screen"
-);
 const { WelcomeScreen } = await import(
   "@/domains/onboarding/pages/welcome-screen"
 );
@@ -128,15 +129,6 @@ describe("onboarding funnel history contract", () => {
     localAssistants = false;
   });
   afterEach(cleanup);
-
-  test("StartScreen's CTA replaces on the way to consent", () => {
-    render(<StartScreen />);
-    click("Create your assistant");
-
-    const { to, opts } = navigatedWith();
-    expect(to).toBe(routes.onboarding.privacy);
-    expect(opts).toEqual({ replace: true });
-  });
 
   test("WelcomeScreen replaces on the way into the funnel", () => {
     render(<WelcomeScreen />);

--- a/clients/web/src/domains/onboarding/onboarding-navigation.ts
+++ b/clients/web/src/domains/onboarding/onboarding-navigation.ts
@@ -1,0 +1,34 @@
+/**
+ * How the onboarding funnel moves between its own screens.
+ *
+ * The funnel is a wizard, and a wizard belongs in ONE history entry. Every step
+ * — forward and back — replaces the current entry instead of pushing a new one,
+ * so the whole journey (welcome → hosting → api-key → privacy → hatching →
+ * research → chat) leaves exactly one entry behind, which the final handoff to
+ * `/assistant` then replaces in turn.
+ *
+ * That is what makes Back inert after setup finishes. `replace: true` on the
+ * handoff alone only ever dropped the LAST entry, so every earlier step stayed
+ * on the stack and a single Back press landed a finished user back inside the
+ * funnel — on `onboarding/start` in platform mode, `onboarding/hatching` in
+ * local mode. Both are full-viewport takeovers whose only forward control
+ * re-enters setup, so the user was stuck. Collapsing the funnel removes the
+ * entries rather than guarding them: there is nothing behind chat to go back
+ * to, so the browser's Back button is genuinely inert rather than bouncing
+ * through a redirect.
+ *
+ * Nothing in the funnel reads the history stack — every in-screen "Back"
+ * affordance navigates to a NAMED predecessor rather than `navigate(-1)` (a
+ * deliberate choice: on a Capacitor staging shell a history-relative back could
+ * leave the SPA for the marketing host and switch the app off its own
+ * environment). So replacing costs the funnel nothing.
+ *
+ * The entry INTO the funnel is deliberately not covered here: the post-auth
+ * landing already replaces, and the chooser's "Create a new assistant" pushes on
+ * purpose so an onboarded user adding a second assistant can Back out to the
+ * chooser they came from.
+ */
+
+import type { NavigateOptions } from "react-router";
+
+export const SETUP_NAVIGATE: NavigateOptions = { replace: true };

--- a/clients/web/src/domains/onboarding/pages/api-key-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/api-key-screen.tsx
@@ -9,6 +9,7 @@ import {
   onboardingProvider,
   type OnboardingProviderId,
 } from "@/domains/onboarding/provider-catalog";
+import { SETUP_NAVIGATE } from "@/domains/onboarding/onboarding-navigation";
 import {
   peekPendingProviderKey,
   setPendingProviderKey,
@@ -80,11 +81,12 @@ export function ApiKeyScreen() {
       hosting
         ? `${routes.onboarding.privacy}?hosting=${hosting}`
         : routes.onboarding.privacy,
+      SETUP_NAVIGATE,
     );
   };
 
   const onBack = () => {
-    void navigate(routes.onboarding.hosting);
+    void navigate(routes.onboarding.hosting, SETUP_NAVIGATE);
   };
 
   return (

--- a/clients/web/src/domains/onboarding/pages/hosting-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hosting-screen.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useSearchParams } from "react-router";
 
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
 import { handleRadioCardArrowNav } from "@/domains/onboarding/components/radio-card-nav";
+import { SETUP_NAVIGATE } from "@/domains/onboarding/onboarding-navigation";
 import { setPendingProviderKey } from "@/domains/onboarding/provider-key";
 import { useOnboardingLogin } from "@/hooks/use-onboarding-login";
 import { clearGatewayToken } from "@/lib/auth/gateway-session";
@@ -100,15 +101,19 @@ export function HostingScreen() {
       // Cloud is managed: drop any provider key staged from a prior
       // Local/Docker visit so it can't leak into a later local hatch.
       setPendingProviderKey(null);
-      void navigate(routes.onboarding.privacy);
+      void navigate(routes.onboarding.privacy, SETUP_NAVIGATE);
     } else {
-      void navigate(`${routes.onboarding.apiKey}?hosting=${selected}`);
+      void navigate(
+        `${routes.onboarding.apiKey}?hosting=${selected}`,
+        SETUP_NAVIGATE,
+      );
     }
   };
 
   const onBack = () => {
     void navigate(
       fromSelectAssistant ? routes.selectAssistant : routes.welcome,
+      SETUP_NAVIGATE,
     );
   };
 

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
@@ -210,7 +210,20 @@ describe("PrivacyScreen — Start navigation", () => {
     expect(emitFunnelStepCompletedMock).toHaveBeenCalledWith(PRIVACY_TOS_STEP, {
       userId: "user-1",
     });
-    expect(navigateMock).toHaveBeenCalledWith(routes.onboarding.research);
+    expect(navigateMock).toHaveBeenCalledWith(routes.onboarding.research, {
+      replace: true,
+    });
+  });
+
+  // The funnel is one history entry, so Back can never re-enter it after setup
+  // finishes — a pushed step here would put consent back on the stack.
+  test("advances by replacing the current history entry, never pushing", () => {
+    searchParamsValue = new URLSearchParams("hosting=managed");
+    render(<PrivacyScreen />);
+
+    clickStart();
+
+    expect(navigateMock.mock.calls[0]?.[1]).toEqual({ replace: true });
   });
 
   test("resumes checkout when a pending signup-marked package intent is present", () => {
@@ -465,7 +478,7 @@ describe("PrivacyScreen — Start navigation", () => {
     // Consent is recorded first — the resume never skips it.
     expect(saveConsentMock).toHaveBeenCalledTimes(1);
     expect(navigateMock).toHaveBeenCalledTimes(1);
-    expect(navigateMock).toHaveBeenCalledWith(PAID_HATCH);
+    expect(navigateMock).toHaveBeenCalledWith(PAID_HATCH, { replace: true });
   });
 
   test("the paid hatch wins over a pending signup-marked package intent", () => {
@@ -482,7 +495,7 @@ describe("PrivacyScreen — Start navigation", () => {
 
     clickStart();
 
-    expect(navigateMock).toHaveBeenCalledWith(PAID_HATCH);
+    expect(navigateMock).toHaveBeenCalledWith(PAID_HATCH, { replace: true });
   });
 
   test("ignores a returnTo that is not a paid hatch", () => {
@@ -552,7 +565,9 @@ describe("PrivacyScreen — Back navigation", () => {
 
     fireEvent.click(screen.getByText("Back"));
 
-    expect(navigateMock).toHaveBeenCalledWith(routes.onboarding.hosting);
+    expect(navigateMock).toHaveBeenCalledWith(routes.onboarding.hosting, {
+      replace: true,
+    });
     expect(assignMock).not.toHaveBeenCalled();
   });
 
@@ -562,7 +577,9 @@ describe("PrivacyScreen — Back navigation", () => {
 
     fireEvent.click(screen.getByText("Back"));
 
-    expect(navigateMock).toHaveBeenCalledWith(routes.onboarding.start);
+    expect(navigateMock).toHaveBeenCalledWith(routes.onboarding.start, {
+      replace: true,
+    });
     // Must not leave the SPA for the marketing host — that would switch a
     // Capacitor staging/dev shell onto production.
     expect(assignMock).not.toHaveBeenCalled();
@@ -578,7 +595,9 @@ describe("PrivacyScreen — Back navigation", () => {
 
     fireEvent.click(screen.getByText("Back"));
 
-    expect(navigateMock).toHaveBeenCalledWith(routes.onboarding.start);
+    expect(navigateMock).toHaveBeenCalledWith(routes.onboarding.start, {
+      replace: true,
+    });
     expect(assignMock).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -13,6 +13,7 @@ import {
   ONBOARDING_FUNNEL_STEPS,
 } from "@/domains/onboarding/funnel-events";
 import { onboardingDestinationAfterConsent } from "@/domains/onboarding/onboarding-destination";
+import { SETUP_NAVIGATE } from "@/domains/onboarding/onboarding-navigation";
 import { ATTRIBUTED_PLUGIN_PARAM } from "@/domains/onboarding/plugin-attribution";
 import { useMarketingPricingTakeover } from "@/hooks/use-marketing-pricing-takeover";
 import { CHECKOUT_CONTINUE_PARAM } from "@/lib/billing/checkout-continuation";
@@ -89,7 +90,7 @@ export function PrivacyScreen() {
       searchParams.get("returnTo"),
     );
     if (paidHatchReturnTo) {
-      void navigate(paidHatchReturnTo);
+      void navigate(paidHatchReturnTo, SETUP_NAVIGATE);
       return;
     }
 
@@ -140,13 +141,16 @@ export function PrivacyScreen() {
         const checkoutParams = checkoutResumeSearch(checkoutIntent);
         if (checkoutParams) {
           checkoutParams.set(CHECKOUT_CONTINUE_PARAM, onboardingNext);
-          void navigate(`${routes.checkout}?${checkoutParams.toString()}`);
+          void navigate(
+            `${routes.checkout}?${checkoutParams.toString()}`,
+            SETUP_NAVIGATE,
+          );
           return;
         }
       }
     }
 
-    void navigate(onboardingNext);
+    void navigate(onboardingNext, SETUP_NAVIGATE);
   }, [
     privacyConsent,
     hasPlatformSession,
@@ -248,6 +252,7 @@ export function PrivacyScreen() {
                 isLocalClient()
                   ? routes.onboarding.hosting
                   : routes.onboarding.start,
+                SETUP_NAVIGATE,
               )
             }
             className={electron ? undefined : "h-11 text-base"}

--- a/clients/web/src/domains/onboarding/pages/start-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/start-screen.test.tsx
@@ -28,11 +28,17 @@ describe("StartScreen", () => {
   beforeEach(() => navigateMock.mockClear());
   afterEach(cleanup);
 
+  // It REPLACES: the funnel is one history entry, so Back can never re-enter
+  // it once setup finishes (see `onboarding-navigation.ts`). This screen is
+  // reached only via Back in the first place, so a push here would put it
+  // straight back on the stack.
   test("the single CTA re-enters the funnel at the privacy screen", () => {
     render(<StartScreen />);
 
     fireEvent.click(screen.getByText("Create your assistant"));
 
-    expect(navigateMock).toHaveBeenCalledWith(routes.onboarding.privacy);
+    expect(navigateMock).toHaveBeenCalledWith(routes.onboarding.privacy, {
+      replace: true,
+    });
   });
 });

--- a/clients/web/src/domains/onboarding/pages/start-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/start-screen.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from "react-router";
 
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
+import { SETUP_NAVIGATE } from "@/domains/onboarding/onboarding-navigation";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
 
@@ -48,7 +49,9 @@ export function StartScreen() {
               size="regular"
               fullWidth
               className="h-11 text-base"
-              onClick={() => void navigate(routes.onboarding.privacy)}
+              onClick={() =>
+                void navigate(routes.onboarding.privacy, SETUP_NAVIGATE)
+              }
             >
               Create your assistant
             </Button>

--- a/clients/web/src/domains/onboarding/pages/welcome-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/welcome-screen.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from "react-router";
 
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
+import { SETUP_NAVIGATE } from "@/domains/onboarding/onboarding-navigation";
 import { useOnboardingLogin } from "@/hooks/use-onboarding-login";
 import { hasAssistants } from "@/lib/local-mode";
 import { routes } from "@/utils/routes";
@@ -14,10 +15,13 @@ export function WelcomeScreen() {
     if (loading) {
       cancel();
     }
+    // `replace`, like every other step of the setup flow: the funnel occupies a
+    // single history entry so a Back press can never re-enter it (see
+    // `SETUP_NAVIGATE` in `onboarding-navigation.ts`).
     if (hasAssistants()) {
-      void navigate(routes.selectAssistant);
+      void navigate(routes.selectAssistant, SETUP_NAVIGATE);
     } else {
-      void navigate(routes.onboarding.hosting);
+      void navigate(routes.onboarding.hosting, SETUP_NAVIGATE);
     }
   };
 


### PR DESCRIPTION
## What's happening

After finishing onboarding, a user can press Back and return to the completed onboarding flow, where they can become stuck.

The handoff to chat navigates with `replace: true` — but that drops exactly **one** history entry, the terminal step. Every screen the funnel pushed on the way in is still on the stack:

| mode | history at the handoff | Back lands on |
| --- | --- | --- |
| platform | `… → privacy → start → /assistant` | `/assistant/onboarding/start` |
| local | `… → hosting → api-key → privacy → hatching → /assistant` | `/assistant/onboarding/hatching` |

Both are full-viewport takeovers with no route into the app. `StartScreen`'s only control is "Create your assistant", which re-enters the funnel at consent. That's the dead end.

## What should happen

After onboarding, Back should be inert — not bounced somewhere, just nothing to go back to.

## The fix

The funnel is a wizard, and a wizard belongs in **one** history entry. Every move between setup screens now replaces instead of pushing:

- `welcome → hosting`, `welcome → select-assistant`
- `hosting → privacy` / `hosting → api-key`, and hosting's own Back
- `api-key → privacy`, and api-key's own Back
- `privacy → research` / `privacy → hatching` / `privacy → checkout` / paid-hatch resume, and privacy's own Back
- `start → privacy`
- the check-in overlay's return into research

`hatching → research`, hatching's error Back, and the research handoff already replaced, as does the post-auth landing on privacy. So a fresh signup's entire journey — OAuth callback through chat — now occupies a **single** entry.

Back is then genuinely inert: there's no onboarding entry left to return to, so nothing redirects and nothing flashes. In a fresh tab `history.length === 1` and the browser's Back button is greyed out outright. It also fixes Android hardware-back and iOS swipe-back for free, since both pop the same stack.

## Why replacing is safe here

Nothing in the funnel reads the history stack. Every in-screen "Back" navigates to a **named** predecessor rather than `navigate(-1)` — a deliberate existing choice, documented in `privacy-screen.tsx`: on a Capacitor staging/dev shell a history-relative back could leave the SPA for the marketing host and switch the native app off its own environment. So the screens already don't depend on what's behind them.

The one navigation left as a **push** is the chooser's "Create a new assistant" (`select-assistant → hosting?from=select-assistant`). An onboarded user adding a second assistant should be able to Back out to the chooser they came from — and with the funnel's internals collapsed, that Back now goes to the chooser instead of into the middle of setup.

## Note on the earlier revision

The first version of this PR took a different approach: a persisted completion marker plus a route-guard step that **redirected** a finished user out of the setup screens. That worked, but it bounced rather than disabled — and it needed a re-entry query param threaded through four screens to keep the local add-another-assistant flow alive. Collapsing the history removes the entries instead of guarding them, which is both the smaller change and the behavior actually wanted. That revision is gone; this is a clean rewrite.

## Testing

- `bunx tsc --noEmit` — clean
- `bun run lint` — 0 errors (16 pre-existing warnings, unchanged)
- `bun run build` — clean
- New `onboarding-navigation.test.tsx` — 6 cases pinning the contract on `StartScreen`, `WelcomeScreen`, `HostingScreen`, and `ApiKeyScreen`, asserting the **options argument** (not just the destination), since a pushed navigation is exactly the regression.
- `privacy-screen.test.tsx` — added a forward-replace case and updated the existing Back / paid-hatch assertions to the new call shape.
- Re-ran individually: `hatching-screen`, `research-onboarding-route`, `select-assistant-screen`, `navigation-resolver`, `onboarding-middleware`, `routes`, `retire-service` — all green.

Run files individually — `mock.module` leaks across a shared `bun test` run in this area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)