### PR TITLE
feat(gateway): make an ingress declaration expressive enough to parse a vendor payload

### DIFF
--- a/gateway/src/channels/ingress-inbound-vendors.test.ts
+++ b/gateway/src/channels/ingress-inbound-vendors.test.ts
@@ -1,0 +1,229 @@
+/**
+ * The declaration language against real vendor payloads.
+ *
+ * The question this answers is whether a manifest can express what a plugin's
+ * webhook normalizer expresses in code. If it cannot, the gateway has to take
+ * the plugin's word for what a delivery says, which means crossing into the
+ * assistant to ask before the gate can run — and the gate is the thing that
+ * must not move.
+ *
+ * So these are not schema tests. They are the two shipping vendors' actual
+ * webhook envelopes, read by a declaration written the way a plugin author
+ * would write one, checked against what `imessage`'s normalizers produce.
+ */
+
+import { describe, expect, it } from "bun:test";
+
+import { IngressInboundSchema } from "./ingress-inbound.js";
+import { readPluginInbound } from "./plugin-inbound.js";
+
+const AT = "2026-02-01T00:00:00.000Z";
+
+function read(plugin: string, raw: unknown, declaration: unknown) {
+  return readPluginInbound({
+    plugin,
+    inbound: IngressInboundSchema.parse(declaration),
+    body: raw,
+    receivedAt: AT,
+  });
+}
+
+/* ------------------------------------------------------------------ *
+ * Comms
+ * ------------------------------------------------------------------ */
+
+/** `{ event, message }`, the envelope Comms delivers. */
+const COMMS = {
+  identity: "phone",
+  when: [
+    { path: "event", in: ["comms.message.received", "message.received"] },
+    { path: "message.direction", equals: "inbound" },
+  ],
+  probe: [{ path: "event", in: ["comms.ping", "ping"] }],
+  fields: {
+    content: "message.body",
+    conversationExternalId: ["message.conversation_id", "message.from"],
+    externalMessageId: "message.id",
+    actorExternalId: "message.from",
+    chatType: {
+      from: "message.channel",
+      map: { imessage: "imessage" },
+      default: "sms",
+    },
+  },
+};
+
+function commsDelivery(overrides: Record<string, unknown> = {}) {
+  return {
+    event: "comms.message.received",
+    message: {
+      id: "msg_01",
+      direction: "inbound",
+      body: "hello",
+      channel: "imessage",
+      conversation_id: "conv_abc",
+      from: "+12025550142",
+      ...overrides,
+    },
+  };
+}
+
+describe("a Comms declaration", () => {
+  it("reads an inbound message the way the plugin's normalizer does", () => {
+    const result = read("imessage", commsDelivery(), COMMS);
+
+    expect(result.status).toBe("event");
+    if (result.status !== "event") return;
+    expect(result.event.message.content).toBe("hello");
+    expect(result.event.message.conversationExternalId).toBe(
+      "imessage:conv_abc",
+    );
+    expect(result.event.actor.actorExternalId).toBe("imessage:+12025550142");
+    expect(result.event.source.chatType).toBe("imessage");
+  });
+
+  it("falls back to the sender when there is no conversation id", () => {
+    // A 1:1 thread that Comms has not assigned a conversation to still has to
+    // bind somewhere, and the sender is the only stable address available.
+    const raw = commsDelivery();
+    delete (raw.message as Record<string, unknown>).conversation_id;
+
+    const result = read("imessage", raw, COMMS);
+    expect(result.status).toBe("event");
+    if (result.status !== "event") return;
+    expect(result.event.message.conversationExternalId).toBe(
+      "imessage:+12025550142",
+    );
+  });
+
+  it("reads an SMS as sms and anything unrecognized as sms too", () => {
+    // Not cosmetic. SMS sender ids are spoofable and iMessage identities are
+    // not, so an unknown value has to land on the conservative side.
+    for (const channel of ["sms", "rcs", undefined]) {
+      const raw = commsDelivery({ channel });
+      const result = read("imessage", raw, COMMS);
+      expect(result.status).toBe("event");
+      if (result.status !== "event") continue;
+      expect(result.event.source.chatType).toBe("sms");
+    }
+  });
+
+  it("calls the delivery test a probe rather than a broken message", () => {
+    const result = read("imessage", { event: "comms.ping" }, COMMS);
+    expect(result.status).toBe("probe");
+  });
+
+  it("does not treat our own echo as a turn", () => {
+    const result = read(
+      "imessage",
+      commsDelivery({ direction: "outbound" }),
+      COMMS,
+    );
+    expect(result.status).toBe("none");
+  });
+});
+
+/* ------------------------------------------------------------------ *
+ * Photon
+ * ------------------------------------------------------------------ */
+
+/**
+ * `{ event, space, message: { sender, space, content } }`.
+ *
+ * The two things a single path could not express are both here: the
+ * conversation falls back from `message.space.id` to `space.id` (in code,
+ * `message.space ?? event.space`), and the platform is mapped to the two
+ * values admission acts on.
+ */
+const PHOTON = {
+  identity: "phone",
+  when: [{ path: "event", equals: "messages" }],
+  fields: {
+    content: "message.content.text",
+    conversationExternalId: ["message.space.id", "space.id"],
+    externalMessageId: "message.id",
+    actorExternalId: "message.sender.id",
+    chatType: {
+      from: ["message.platform", "space.platform"],
+      map: { imessage: "imessage" },
+      default: "sms",
+    },
+  },
+};
+
+function photonDelivery(overrides: Record<string, unknown> = {}) {
+  return {
+    event: "messages",
+    space: { id: "any;-;+12025550142", platform: "iMessage", type: "dm" },
+    message: {
+      id: "p_9",
+      platform: "iMessage",
+      direction: "inbound",
+      sender: { id: "+12025550142" },
+      content: { type: "text", text: "hey, what time is dinner?" },
+      ...overrides,
+    },
+  };
+}
+
+describe("a Photon declaration", () => {
+  it("reads the documented webhook delivery", () => {
+    const result = read("imessage", photonDelivery(), PHOTON);
+
+    expect(result.status).toBe("event");
+    if (result.status !== "event") return;
+    expect(result.event.message.content).toBe("hey, what time is dinner?");
+    // The space id is the chat guid a reply is addressed to, so binding on it
+    // is what lets a reply skip chat resolution.
+    expect(result.event.message.conversationExternalId).toBe(
+      "imessage:any;-;+12025550142",
+    );
+    expect(result.event.actor.actorExternalId).toBe("imessage:+12025550142");
+    expect(result.event.source.chatType).toBe("imessage");
+  });
+
+  it("prefers the message's own space over the envelope's", () => {
+    // `message.space ?? event.space` in code. A group delivery carries the
+    // room on the message, and binding to the envelope would put every room's
+    // messages in one conversation.
+    const raw = photonDelivery({
+      space: { id: "any;-;group-7", platform: "iMessage" },
+    });
+
+    const result = read("imessage", raw, PHOTON);
+    expect(result.status).toBe("event");
+    if (result.status !== "event") return;
+    expect(result.event.message.conversationExternalId).toBe(
+      "imessage:any;-;group-7",
+    );
+  });
+
+  it("maps the platform case-insensitively", () => {
+    // Photon spells it `iMessage`. A map that missed on capitalisation would
+    // silently downgrade every blue bubble to the spoofable-sender treatment.
+    const result = read("imessage", photonDelivery(), PHOTON);
+    expect(result.status).toBe("event");
+    if (result.status !== "event") return;
+    expect(result.event.source.chatType).toBe("imessage");
+  });
+
+  it("reads an unrecognized platform as sms", () => {
+    const raw = photonDelivery({ platform: "RCS" });
+    (raw.space as Record<string, unknown>).platform = "RCS";
+
+    const result = read("imessage", raw, PHOTON);
+    expect(result.status).toBe("event");
+    if (result.status !== "event") return;
+    expect(result.event.source.chatType).toBe("sms");
+  });
+
+  it("ignores an event that is not a message", () => {
+    const raw = { ...photonDelivery(), event: "spaces" };
+    expect(read("imessage", raw, PHOTON).status).toBe("none");
+  });
+
+  it("reports a delivery with no sender rather than inventing one", () => {
+    const raw = photonDelivery({ sender: {} });
+    expect(read("imessage", raw, PHOTON).status).toBe("invalid");
+  });
+});

--- a/gateway/src/channels/ingress-inbound-vendors.test.ts
+++ b/gateway/src/channels/ingress-inbound-vendors.test.ts
@@ -4,8 +4,8 @@
  * The question this answers is whether a manifest can express what a plugin's
  * webhook normalizer expresses in code. If it cannot, the gateway has to take
  * the plugin's word for what a delivery says, which means crossing into the
- * assistant to ask before the gate can run — and the gate is the thing that
- * must not move.
+ * assistant to ask before the gate can run, and the gate is the thing that must
+ * not move.
  *
  * So these are not schema tests. They are the two shipping vendors' actual
  * webhook envelopes, read by a declaration written the way a plugin author
@@ -35,11 +35,6 @@ function read(plugin: string, raw: unknown, declaration: unknown) {
 /** `{ event, message }`, the envelope Comms delivers. */
 const COMMS = {
   identity: "phone",
-  when: [
-    { path: "event", in: ["comms.message.received", "message.received"] },
-    { path: "message.direction", equals: "inbound" },
-  ],
-  probe: [{ path: "event", in: ["comms.ping", "ping"] }],
   fields: {
     content: "message.body",
     conversationExternalId: ["message.conversation_id", "message.from"],
@@ -108,17 +103,11 @@ describe("a Comms declaration", () => {
     }
   });
 
-  it("calls the delivery test a probe rather than a broken message", () => {
+  it("finds no message in a delivery test, leaving it for the plugin", () => {
+    // A ping carries no sender and no content. The gateway has nobody to gate
+    // and nothing to admit, so it reads as absent rather than as broken, and
+    // what the event means stays the plugin\'s business.
     const result = read("imessage", { event: "comms.ping" }, COMMS);
-    expect(result.status).toBe("probe");
-  });
-
-  it("does not treat our own echo as a turn", () => {
-    const result = read(
-      "imessage",
-      commsDelivery({ direction: "outbound" }),
-      COMMS,
-    );
     expect(result.status).toBe("none");
   });
 });
@@ -130,14 +119,14 @@ describe("a Comms declaration", () => {
 /**
  * `{ event, space, message: { sender, space, content } }`.
  *
- * The two things a single path could not express are both here: the
- * conversation falls back from `message.space.id` to `space.id` (in code,
- * `message.space ?? event.space`), and the platform is mapped to the two
- * values admission acts on.
+ * The two things a single path could not express are both here. The
+ * conversation falls back from `message.space.id` to `space.id`, which in code
+ * is `message.space ?? event.space`, and the platform is mapped to the two
+ * values admission acts on. The vendor\'s own casing is used for the map key,
+ * because a declaration should be able to quote what the wire says.
  */
 const PHOTON = {
   identity: "phone",
-  when: [{ path: "event", equals: "messages" }],
   fields: {
     content: "message.content.text",
     conversationExternalId: ["message.space.id", "space.id"],
@@ -145,7 +134,7 @@ const PHOTON = {
     actorExternalId: "message.sender.id",
     chatType: {
       from: ["message.platform", "space.platform"],
-      map: { imessage: "imessage" },
+      map: { iMessage: "imessage" },
       default: "sms",
     },
   },
@@ -215,11 +204,6 @@ describe("a Photon declaration", () => {
     expect(result.status).toBe("event");
     if (result.status !== "event") return;
     expect(result.event.source.chatType).toBe("sms");
-  });
-
-  it("ignores an event that is not a message", () => {
-    const raw = { ...photonDelivery(), event: "spaces" };
-    expect(read("imessage", raw, PHOTON).status).toBe("none");
   });
 
   it("reports a delivery with no sender rather than inventing one", () => {

--- a/gateway/src/channels/ingress-inbound.test.ts
+++ b/gateway/src/channels/ingress-inbound.test.ts
@@ -5,6 +5,7 @@ import {
   IngressInboundSchema,
   canonicalInbound,
   inboundFieldSource,
+  readFieldSource,
   readInboundField,
 } from "./ingress-inbound.js";
 
@@ -89,12 +90,93 @@ describe("canonicalInbound", () => {
     ).not.toBe(canonicalInbound(declare({})));
   });
 
+  it("ignores the order keys were typed in, however deep", () => {
+    // A declaration that reads every field from the same place is the same
+    // grant. Digesting it differently drops an approved declaration back to
+    // pending and stops serving it until a guardian approves the identical
+    // thing again.
+    const a = declare({
+      fields: {
+        chatType: { from: "p", map: { a: "1", b: "2" }, default: "d" },
+      },
+    });
+    const b = declare({
+      fields: {
+        chatType: { default: "d", map: { b: "2", a: "1" }, from: "p" },
+      },
+    });
+
+    expect(canonicalInbound(a)).toBe(canonicalInbound(b));
+  });
+
   it("changes when the identity kind changes", () => {
     // `phone` decides that two spellings of a number are one person, so it
     // decides which stored contact a sender matches.
     expect(canonicalInbound(declare({ identity: "phone" }))).not.toBe(
       canonicalInbound(declare({})),
     );
+  });
+});
+
+describe("value maps", () => {
+  it("matches a key spelled the vendor\'s way", () => {
+    // A declaration should be able to quote what the wire says. Photon sends
+    // `iMessage`, and a lookup that folded only the payload would miss the key
+    // and fall through to the conservative default, silently treating every
+    // blue bubble as the spoofable-sender case.
+    const inbound = declare({
+      fields: {
+        chatType: {
+          from: "platform",
+          map: { iMessage: "imessage" },
+          default: "sms",
+        },
+      },
+    });
+
+    expect(
+      readFieldSource(
+        { platform: "iMessage" },
+        inboundFieldSource(inbound, "chatType"),
+      ),
+    ).toBe("imessage");
+  });
+
+  it("takes the default for a value no key matches", () => {
+    const inbound = declare({
+      fields: {
+        chatType: {
+          from: "platform",
+          map: { imessage: "imessage" },
+          default: "sms",
+        },
+      },
+    });
+
+    expect(
+      readFieldSource(
+        { platform: "RCS" },
+        inboundFieldSource(inbound, "chatType"),
+      ),
+    ).toBe("sms");
+    expect(readFieldSource({}, inboundFieldSource(inbound, "chatType"))).toBe(
+      "sms",
+    );
+  });
+
+  it("tries each path in turn and takes the first with a value", () => {
+    const inbound = declare({
+      fields: { conversationExternalId: ["message.space.id", "space.id"] },
+    });
+    const source = inboundFieldSource(inbound, "conversationExternalId");
+
+    expect(readFieldSource({ space: { id: "outer" } }, source)).toBe("outer");
+    expect(
+      readFieldSource(
+        { message: { space: { id: "inner" } }, space: { id: "outer" } },
+        source,
+      ),
+    ).toBe("inner");
   });
 });
 

--- a/gateway/src/channels/ingress-inbound.test.ts
+++ b/gateway/src/channels/ingress-inbound.test.ts
@@ -4,7 +4,7 @@ import {
   INBOUND_FIELD_DEFAULTS,
   IngressInboundSchema,
   canonicalInbound,
-  inboundFieldPath,
+  inboundFieldSource,
   readInboundField,
 } from "./ingress-inbound.js";
 
@@ -20,8 +20,8 @@ describe("IngressInboundSchema", () => {
     const inbound = declare({});
 
     expect(inbound.identity).toBe("opaque");
-    expect(inboundFieldPath(inbound, "content")).toBe("message.content");
-    expect(inboundFieldPath(inbound, "actorExternalId")).toBe(
+    expect(inboundFieldSource(inbound, "content")).toBe("message.content");
+    expect(inboundFieldSource(inbound, "actorExternalId")).toBe(
       "actor.actorExternalId",
     );
   });
@@ -29,8 +29,8 @@ describe("IngressInboundSchema", () => {
   it("keeps the defaults for fields an override did not name", () => {
     const inbound = declare({ fields: { content: "text" } });
 
-    expect(inboundFieldPath(inbound, "content")).toBe("text");
-    expect(inboundFieldPath(inbound, "conversationExternalId")).toBe(
+    expect(inboundFieldSource(inbound, "content")).toBe("text");
+    expect(inboundFieldSource(inbound, "conversationExternalId")).toBe(
       INBOUND_FIELD_DEFAULTS.conversationExternalId,
     );
   });

--- a/gateway/src/channels/ingress-inbound.ts
+++ b/gateway/src/channels/ingress-inbound.ts
@@ -22,9 +22,15 @@
  * - **What kind of address the sender's id is** is declared here, because the
  *   answer decides whether `+1 (202) 555-0142` and `+12025550142` are the same
  *   person and the gateway cannot tell by looking.
- * - **Where each field lives in the reply** is declared here when the reply is
- *   not already in the canonical shape, so a plugin that would rather hand
- *   back its own structure can, without the gateway learning a vendor format.
+ * - **Where each field lives** is declared here, so the gateway can find the
+ *   sender and the conversation in a payload whose shape it does not know.
+ *   That is what lets the gate run before anything is forwarded.
+ *
+ * Nothing here classifies a delivery. Which events mean what is the plugin's
+ * business, and every event reaches it; the gateway reads only what it needs
+ * to decide whether the sender may reach the assistant at all. A delivery with
+ * no sender to find, a vendor's delivery probe among them, is not a message
+ * the gateway can gate and is left for the plugin to interpret.
  *
  * The whole declaration is part of `ingressDeclarationDigest`, so a route
  * cannot start delivering messages — or start reading them differently — under
@@ -53,76 +59,6 @@ const InboundFieldPathSchema = z
     message: "field path must not traverse __proto__",
   });
 
-/* ------------------------------------------------------------------ *
- * Conditions — deciding what a delivery is
- * ------------------------------------------------------------------ */
-
-/**
- * One test against the delivery, as data.
- *
- * Deliberately a closed vocabulary rather than an expression language. The
- * manifest is untrusted input evaluated against an attacker-authored document,
- * so the set of things a condition can do is fixed here and a plugin composes
- * from it — no operators to escape, nothing to evaluate, no way to reach a
- * prototype or spend unbounded time.
- *
- * Exactly one operator per condition, which keeps "what does this mean" a
- * question with one answer. `equals` and `in` compare strings and nothing
- * else: a wire value that is not a string fails rather than being coerced,
- * because coercion is how `"false"` comes to mean `false`.
- */
-const IngressConditionSchema = z
-  .object({
-    path: InboundFieldPathSchema,
-    equals: z.string().optional(),
-    in: z.array(z.string()).min(1).optional(),
-    /**
-     * True: the path must resolve to a non-empty string. False: it must not.
-     * "Absent" and "present but empty" are one answer, because a vendor that
-     * sends `""` for a field it has nothing to say about is the common case
-     * and treating that as present strands the delivery.
-     */
-    present: z.boolean().optional(),
-  })
-  .strict()
-  .refine(
-    (c) =>
-      [c.equals, c.in, c.present].filter((v) => v !== undefined).length === 1,
-    { message: "a condition must use exactly one of equals, in, or present" },
-  );
-export type IngressCondition = z.infer<typeof IngressConditionSchema>;
-
-/**
- * Whether a delivery satisfies one condition.
- *
- * A path that resolves to a non-string reads as absent, matching
- * {@link readInboundField}: "not there" and "there but not a string" are the
- * same answer everywhere in this file, so a malformed payload cannot satisfy
- * a test by accident.
- */
-export function conditionHolds(
-  body: unknown,
-  condition: IngressCondition,
-): boolean {
-  const value = readInboundField(body, condition.path)?.trim();
-
-  if (condition.present !== undefined) {
-    return condition.present ? Boolean(value) : !value;
-  }
-  if (condition.equals !== undefined) {
-    return value === condition.equals;
-  }
-  return value !== undefined && condition.in!.includes(value);
-}
-
-/** Whether every condition holds. An empty list holds vacuously. */
-export function allConditionsHold(
-  body: unknown,
-  conditions: readonly IngressCondition[],
-): boolean {
-  return conditions.every((condition) => conditionHolds(body, condition));
-}
-
 /**
  * Where one field comes from.
  *
@@ -131,13 +67,15 @@ export function allConditionsHold(
  *
  * `from` may list several paths, tried in order, first non-empty wins. Photon
  * puts the conversation on `message.space.id` and falls back to `space.id`
- * depending on the delivery, which in code is `message.space ?? event.space` —
+ * depending on the delivery. In code that is `message.space ?? event.space`:
  * a fallback chain, not a second field.
  *
  * `map` and `default` turn a vendor's vocabulary into ours. Photon reports a
  * platform per message and the plugin collapses it to `imessage` or `sms`,
- * because SMS sender ids are spoofable and iMessage identities are not — a
- * distinction admission acts on, so it has to survive normalization. Matching
+ * because SMS sender ids are spoofable and iMessage identities are not. That
+ * is a distinction admission acts on, so it has to survive normalization.
+ * Keys are matched case-insensitively and folded at parse time, so a
+ * declaration may spell one the way the wire does. Matching
  * is case-insensitive and `default` is what an unmatched or absent value
  * becomes, which is how "anything that is not explicitly iMessage reads as
  * sms" stays the conservative answer rather than a guess.
@@ -151,7 +89,17 @@ const InboundFieldSourceSchema = z.union([
         InboundFieldPathSchema,
         z.array(InboundFieldPathSchema).min(1),
       ]),
-      map: z.record(z.string(), z.string()).optional(),
+      map: z
+        .record(z.string(), z.string())
+        .transform((entries) =>
+          Object.fromEntries(
+            Object.entries(entries).map(([key, value]) => [
+              key.toLowerCase(),
+              value,
+            ]),
+          ),
+        )
+        .optional(),
       default: z.string().optional(),
     })
     .strict(),
@@ -160,8 +108,12 @@ export type InboundFieldSource = z.infer<typeof InboundFieldSourceSchema>;
 
 /** The paths a source tries, in order. */
 export function fieldSourcePaths(source: InboundFieldSource): string[] {
-  if (typeof source === "string") return [source];
-  if (Array.isArray(source)) return source;
+  if (typeof source === "string") {
+    return [source];
+  }
+  if (Array.isArray(source)) {
+    return source;
+  }
   return typeof source.from === "string" ? [source.from] : source.from;
 }
 
@@ -180,8 +132,12 @@ export function readFieldSource(
 
   for (const path of fieldSourcePaths(source)) {
     const value = readInboundField(body, path)?.trim();
-    if (!value) continue;
-    if (!mapping) return value;
+    if (!value) {
+      continue;
+    }
+    if (!mapping) {
+      return value;
+    }
     // Case-insensitive because a vendor spelling it `iMessage` and `imessage`
     // across two endpoints is the ordinary case, and a mapping that missed on
     // capitalisation would silently fall through to the conservative default.
@@ -249,25 +205,6 @@ export type InboundIdentity = z.infer<typeof InboundIdentitySchema>;
 
 export const IngressInboundSchema = z.object({
   identity: InboundIdentitySchema.default("opaque"),
-  /**
-   * What must hold for a delivery to be a message at all.
-   *
-   * Empty by default, which reads as "every delivery is a message" — right for
-   * a vendor with one event type and wrong for every vendor that also sends
-   * receipts and echoes. Photon declares `event === "messages"` and
-   * `direction` inbound; Comms declares its own two names.
-   */
-  when: z.array(IngressConditionSchema).default([]),
-  /**
-   * What identifies the vendor's own delivery test.
-   *
-   * A probe carries no sender and no content, so it can never be a message and
-   * every required-field check would report it as a broken one. It is named
-   * separately because reaching us proves registration, the signing secret and
-   * routing all work — the only confirmation of inbound available without
-   * waiting for a human to send something.
-   */
-  probe: z.array(IngressConditionSchema).default([]),
   fields: InboundFieldsSchema.default({}),
 });
 export type IngressInbound = z.infer<typeof IngressInboundSchema>;
@@ -292,23 +229,36 @@ export function inboundFieldSource(
 export function canonicalInbound(inbound: IngressInbound): string {
   const fields = INBOUND_FIELD_NAMES.map((name) => {
     const source = inboundFieldSource(inbound, name);
-    return `${name}=${typeof source === "string" ? source : JSON.stringify(sortKeys(source))}`;
+    return `${name}=${
+      typeof source === "string"
+        ? source
+        : JSON.stringify(canonicalJson(source))
+    }`;
   }).sort();
-  const conditions = (label: string, list: readonly IngressCondition[]) =>
-    list.map((c) => `${label}:${JSON.stringify(sortKeys(c))}`).sort();
 
-  return [
-    inbound.identity,
-    ...conditions("when", inbound.when),
-    ...conditions("probe", inbound.probe),
-    ...fields,
-  ].join(" ");
+  return [inbound.identity, ...fields].join(" ");
 }
 
-/** Key-sorted shallow copy, so an encoding does not depend on author order. */
-function sortKeys(value: object): Record<string, unknown> {
+/**
+ * Key-sorted all the way down, so an encoding depends on what a declaration
+ * means rather than on the order its author typed.
+ *
+ * Shallow sorting is not enough: a plugin that only reorders the keys inside a
+ * field's `map` reads every field from the same place and yet would digest
+ * differently, which drops an approved declaration back to pending and stops
+ * serving it until a guardian approves the identical thing again.
+ */
+function canonicalJson(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalJson);
+  }
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
   return Object.fromEntries(
-    Object.entries(value).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)),
+    Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+      .map(([key, nested]) => [key, canonicalJson(nested)]),
   );
 }
 

--- a/gateway/src/channels/ingress-inbound.ts
+++ b/gateway/src/channels/ingress-inbound.ts
@@ -53,6 +53,144 @@ const InboundFieldPathSchema = z
     message: "field path must not traverse __proto__",
   });
 
+/* ------------------------------------------------------------------ *
+ * Conditions — deciding what a delivery is
+ * ------------------------------------------------------------------ */
+
+/**
+ * One test against the delivery, as data.
+ *
+ * Deliberately a closed vocabulary rather than an expression language. The
+ * manifest is untrusted input evaluated against an attacker-authored document,
+ * so the set of things a condition can do is fixed here and a plugin composes
+ * from it — no operators to escape, nothing to evaluate, no way to reach a
+ * prototype or spend unbounded time.
+ *
+ * Exactly one operator per condition, which keeps "what does this mean" a
+ * question with one answer. `equals` and `in` compare strings and nothing
+ * else: a wire value that is not a string fails rather than being coerced,
+ * because coercion is how `"false"` comes to mean `false`.
+ */
+const IngressConditionSchema = z
+  .object({
+    path: InboundFieldPathSchema,
+    equals: z.string().optional(),
+    in: z.array(z.string()).min(1).optional(),
+    /**
+     * True: the path must resolve to a non-empty string. False: it must not.
+     * "Absent" and "present but empty" are one answer, because a vendor that
+     * sends `""` for a field it has nothing to say about is the common case
+     * and treating that as present strands the delivery.
+     */
+    present: z.boolean().optional(),
+  })
+  .strict()
+  .refine(
+    (c) =>
+      [c.equals, c.in, c.present].filter((v) => v !== undefined).length === 1,
+    { message: "a condition must use exactly one of equals, in, or present" },
+  );
+export type IngressCondition = z.infer<typeof IngressConditionSchema>;
+
+/**
+ * Whether a delivery satisfies one condition.
+ *
+ * A path that resolves to a non-string reads as absent, matching
+ * {@link readInboundField}: "not there" and "there but not a string" are the
+ * same answer everywhere in this file, so a malformed payload cannot satisfy
+ * a test by accident.
+ */
+export function conditionHolds(
+  body: unknown,
+  condition: IngressCondition,
+): boolean {
+  const value = readInboundField(body, condition.path)?.trim();
+
+  if (condition.present !== undefined) {
+    return condition.present ? Boolean(value) : !value;
+  }
+  if (condition.equals !== undefined) {
+    return value === condition.equals;
+  }
+  return value !== undefined && condition.in!.includes(value);
+}
+
+/** Whether every condition holds. An empty list holds vacuously. */
+export function allConditionsHold(
+  body: unknown,
+  conditions: readonly IngressCondition[],
+): boolean {
+  return conditions.every((condition) => conditionHolds(body, condition));
+}
+
+/**
+ * Where one field comes from.
+ *
+ * A bare path is the shorthand. The object form adds the two things a real
+ * vendor payload needs and a single path cannot express:
+ *
+ * `from` may list several paths, tried in order, first non-empty wins. Photon
+ * puts the conversation on `message.space.id` and falls back to `space.id`
+ * depending on the delivery, which in code is `message.space ?? event.space` —
+ * a fallback chain, not a second field.
+ *
+ * `map` and `default` turn a vendor's vocabulary into ours. Photon reports a
+ * platform per message and the plugin collapses it to `imessage` or `sms`,
+ * because SMS sender ids are spoofable and iMessage identities are not — a
+ * distinction admission acts on, so it has to survive normalization. Matching
+ * is case-insensitive and `default` is what an unmatched or absent value
+ * becomes, which is how "anything that is not explicitly iMessage reads as
+ * sms" stays the conservative answer rather than a guess.
+ */
+const InboundFieldSourceSchema = z.union([
+  InboundFieldPathSchema,
+  z.array(InboundFieldPathSchema).min(1),
+  z
+    .object({
+      from: z.union([
+        InboundFieldPathSchema,
+        z.array(InboundFieldPathSchema).min(1),
+      ]),
+      map: z.record(z.string(), z.string()).optional(),
+      default: z.string().optional(),
+    })
+    .strict(),
+]);
+export type InboundFieldSource = z.infer<typeof InboundFieldSourceSchema>;
+
+/** The paths a source tries, in order. */
+export function fieldSourcePaths(source: InboundFieldSource): string[] {
+  if (typeof source === "string") return [source];
+  if (Array.isArray(source)) return source;
+  return typeof source.from === "string" ? [source.from] : source.from;
+}
+
+/**
+ * Read one field, following the fallback chain and applying any mapping.
+ *
+ * Returns undefined when nothing resolved and no default was declared, which
+ * is what a caller checking a required field tests.
+ */
+export function readFieldSource(
+  body: unknown,
+  source: InboundFieldSource,
+): string | undefined {
+  const mapping =
+    typeof source === "string" || Array.isArray(source) ? undefined : source;
+
+  for (const path of fieldSourcePaths(source)) {
+    const value = readInboundField(body, path)?.trim();
+    if (!value) continue;
+    if (!mapping) return value;
+    // Case-insensitive because a vendor spelling it `iMessage` and `imessage`
+    // across two endpoints is the ordinary case, and a mapping that missed on
+    // capitalisation would silently fall through to the conservative default.
+    const mapped = mapping.map?.[value.toLowerCase()];
+    return mapped ?? mapping.default ?? value;
+  }
+  return mapping?.default;
+}
+
 /**
  * Per-field overrides of {@link INBOUND_FIELD_DEFAULTS}.
  *
@@ -63,13 +201,13 @@ const InboundFieldPathSchema = z
  */
 const InboundFieldsSchema = z
   .object({
-    content: InboundFieldPathSchema.optional(),
-    conversationExternalId: InboundFieldPathSchema.optional(),
-    externalMessageId: InboundFieldPathSchema.optional(),
-    actorExternalId: InboundFieldPathSchema.optional(),
-    actorDisplayName: InboundFieldPathSchema.optional(),
-    actorUsername: InboundFieldPathSchema.optional(),
-    chatType: InboundFieldPathSchema.optional(),
+    content: InboundFieldSourceSchema.optional(),
+    conversationExternalId: InboundFieldSourceSchema.optional(),
+    externalMessageId: InboundFieldSourceSchema.optional(),
+    actorExternalId: InboundFieldSourceSchema.optional(),
+    actorDisplayName: InboundFieldSourceSchema.optional(),
+    actorUsername: InboundFieldSourceSchema.optional(),
+    chatType: InboundFieldSourceSchema.optional(),
   })
   .strict();
 
@@ -111,15 +249,34 @@ export type InboundIdentity = z.infer<typeof InboundIdentitySchema>;
 
 export const IngressInboundSchema = z.object({
   identity: InboundIdentitySchema.default("opaque"),
+  /**
+   * What must hold for a delivery to be a message at all.
+   *
+   * Empty by default, which reads as "every delivery is a message" — right for
+   * a vendor with one event type and wrong for every vendor that also sends
+   * receipts and echoes. Photon declares `event === "messages"` and
+   * `direction` inbound; Comms declares its own two names.
+   */
+  when: z.array(IngressConditionSchema).default([]),
+  /**
+   * What identifies the vendor's own delivery test.
+   *
+   * A probe carries no sender and no content, so it can never be a message and
+   * every required-field check would report it as a broken one. It is named
+   * separately because reaching us proves registration, the signing secret and
+   * routing all work — the only confirmation of inbound available without
+   * waiting for a human to send something.
+   */
+  probe: z.array(IngressConditionSchema).default([]),
   fields: InboundFieldsSchema.default({}),
 });
 export type IngressInbound = z.infer<typeof IngressInboundSchema>;
 
-/** The path a field is read from, after the manifest's overrides. */
-export function inboundFieldPath(
+/** Where a field is read from, after the manifest's overrides. */
+export function inboundFieldSource(
   inbound: IngressInbound,
   field: InboundFieldName,
-): string {
+): InboundFieldSource {
   return inbound.fields[field] ?? INBOUND_FIELD_DEFAULTS[field];
 }
 
@@ -133,10 +290,26 @@ export function inboundFieldPath(
  * were already getting.
  */
 export function canonicalInbound(inbound: IngressInbound): string {
-  const fields = INBOUND_FIELD_NAMES.map(
-    (name) => `${name}=${inboundFieldPath(inbound, name)}`,
-  ).sort();
-  return [inbound.identity, ...fields].join(" ");
+  const fields = INBOUND_FIELD_NAMES.map((name) => {
+    const source = inboundFieldSource(inbound, name);
+    return `${name}=${typeof source === "string" ? source : JSON.stringify(sortKeys(source))}`;
+  }).sort();
+  const conditions = (label: string, list: readonly IngressCondition[]) =>
+    list.map((c) => `${label}:${JSON.stringify(sortKeys(c))}`).sort();
+
+  return [
+    inbound.identity,
+    ...conditions("when", inbound.when),
+    ...conditions("probe", inbound.probe),
+    ...fields,
+  ].join(" ");
+}
+
+/** Key-sorted shallow copy, so an encoding does not depend on author order. */
+function sortKeys(value: object): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(value).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)),
+  );
 }
 
 /**

--- a/gateway/src/channels/plugin-inbound.ts
+++ b/gateway/src/channels/plugin-inbound.ts
@@ -46,7 +46,6 @@
  */
 
 import {
-  allConditionsHold,
   inboundFieldSource,
   readFieldSource,
   type IngressInbound,
@@ -97,8 +96,6 @@ function readRaw(body: unknown): Record<string, unknown> {
 
 export type PluginInboundReading =
   | { status: "event"; event: PluginInboundEvent }
-  /** The vendor's own delivery test. Proof the path works, never a turn. */
-  | { status: "probe" }
   | { status: "none" }
   | { status: "invalid"; reason: string };
 
@@ -134,19 +131,6 @@ export function readPluginInbound(
   const { plugin, inbound, body, receivedAt } = opts;
   const read = (field: InboundFieldName) =>
     readFieldSource(body, inboundFieldSource(inbound, field));
-
-  // Probe first: it carries no sender and no content, so every check below
-  // would report the vendor confirming it can reach us as a broken message.
-  if (inbound.probe.length > 0 && allConditionsHold(body, inbound.probe)) {
-    return { status: "probe" };
-  }
-
-  // Then whether this is a message at all. A receipt or an outbound echo is
-  // routine, and reporting it as a half-formed message would make the ordinary
-  // case look like a bug.
-  if (!allConditionsHold(body, inbound.when)) {
-    return { status: "none" };
-  }
 
   const conversation = read("conversationExternalId")?.trim();
   const actor = read("actorExternalId")?.trim();

--- a/gateway/src/channels/plugin-inbound.ts
+++ b/gateway/src/channels/plugin-inbound.ts
@@ -46,9 +46,11 @@
  */
 
 import {
-  inboundFieldPath,
-  readInboundField,
+  allConditionsHold,
+  inboundFieldSource,
+  readFieldSource,
   type IngressInbound,
+  type InboundFieldName,
 } from "./ingress-inbound.js";
 import type { PluginInboundEvent } from "./inbound-event.js";
 import { canonicalizeIdentityAs } from "../verification/identity.js";
@@ -95,6 +97,8 @@ function readRaw(body: unknown): Record<string, unknown> {
 
 export type PluginInboundReading =
   | { status: "event"; event: PluginInboundEvent }
+  /** The vendor's own delivery test. Proof the path works, never a turn. */
+  | { status: "probe" }
   | { status: "none" }
   | { status: "invalid"; reason: string };
 
@@ -128,8 +132,21 @@ export function readPluginInbound(
   opts: ReadPluginInboundOptions,
 ): PluginInboundReading {
   const { plugin, inbound, body, receivedAt } = opts;
-  const read = (field: Parameters<typeof inboundFieldPath>[1]) =>
-    readInboundField(body, inboundFieldPath(inbound, field));
+  const read = (field: InboundFieldName) =>
+    readFieldSource(body, inboundFieldSource(inbound, field));
+
+  // Probe first: it carries no sender and no content, so every check below
+  // would report the vendor confirming it can reach us as a broken message.
+  if (inbound.probe.length > 0 && allConditionsHold(body, inbound.probe)) {
+    return { status: "probe" };
+  }
+
+  // Then whether this is a message at all. A receipt or an outbound echo is
+  // routine, and reporting it as a half-formed message would make the ordinary
+  // case look like a bug.
+  if (!allConditionsHold(body, inbound.when)) {
+    return { status: "none" };
+  }
 
   const conversation = read("conversationExternalId")?.trim();
   const actor = read("actorExternalId")?.trim();

--- a/gateway/src/http/routes/plugin-webhook.ts
+++ b/gateway/src/http/routes/plugin-webhook.ts
@@ -396,6 +396,17 @@ async function deliverPluginInbound(opts: {
     );
     return ack;
   }
+  if (reading.status === "probe") {
+    // The vendor confirming it can reach us. It travelled the real path —
+    // signature, approval gate, forward — so one arriving is proof the whole
+    // surface works, and it is worth an info line rather than the silence a
+    // receipt gets. It is never a turn: it carries no sender and no content.
+    log.info(
+      { plugin, path: routePath },
+      "Plugin ingress delivery probe verified end to end",
+    );
+    return ack;
+  }
   if (reading.status === "invalid") {
     log.warn(
       { plugin, path: routePath, reason: reading.reason },

--- a/gateway/src/http/routes/plugin-webhook.ts
+++ b/gateway/src/http/routes/plugin-webhook.ts
@@ -396,17 +396,6 @@ async function deliverPluginInbound(opts: {
     );
     return ack;
   }
-  if (reading.status === "probe") {
-    // The vendor confirming it can reach us. It travelled the real path —
-    // signature, approval gate, forward — so one arriving is proof the whole
-    // surface works, and it is worth an info line rather than the silence a
-    // receipt gets. It is never a turn: it carries no sender and no content.
-    log.info(
-      { plugin, path: routePath },
-      "Plugin ingress delivery probe verified end to end",
-    );
-    return ack;
-  }
   if (reading.status === "invalid") {
     log.warn(
       { plugin, path: routePath, reason: reading.reason },


### PR DESCRIPTION
## Prompt / plan

> "if you can declare it in code, we can declare it in json. I'm confident you can figure it out. do NOT make gating advisory by moving it into the plugin"

The gate must stay in the gateway and must stay enforced, which means the gateway has to know who sent a delivery and where it landed **before** it forwards anything. Today it does not: it forwards to the plugin, reads the reply, and gates on that. Two crossings into the assistant, with the first one made before any admission decision has been taken.

Closing that needs the gateway to read the vendor's payload itself, and the declaration could not describe one. This makes it able to.

### What the declaration gains

Data only, no expression evaluation. The manifest is untrusted input read against an attacker-authored document, so the vocabulary is closed and a plugin composes from it.

- **Fallback chains.** A field may list paths, tried in order, first non-empty wins. This is Photon's `message.space ?? event.space`: a group delivery carries the room on the message, and binding to the envelope would put every room in one conversation.
- **Value maps** (`map` + `default`). This is `chatTypeFor`. Keys are folded at parse time, so a declaration can quote the vendor's own casing (`iMessage`). An unmatched or absent value takes the default, which keeps "anything not explicitly iMessage reads as sms" the conservative answer rather than a guess. Not cosmetic: SMS sender ids are spoofable, and admission acts on the difference.

Photon's whole webhook normaliser, as a declaration:

```json
{
  "identity": "phone",
  "fields": {
    "content": "message.content.text",
    "conversationExternalId": ["message.space.id", "space.id"],
    "externalMessageId": "message.id",
    "actorExternalId": "message.sender.id",
    "chatType": {
      "from": ["message.platform", "space.platform"],
      "map": { "iMessage": "imessage" },
      "default": "sms"
    }
  }
}
```

### The gateway classifies nothing

Per review: every event type reaches the plugin, and the gateway does only the standard gating and verification. So there is no condition vocabulary, no `when`, no `probe`. The gateway reads exactly what it needs to decide whether a sender may reach the assistant: sender, conversation, message id, content. A delivery with no sender to find, a vendor's delivery probe among them, is not something the gateway can gate. It reads as absent and reaches the plugin to be interpreted there, which is where the event vocabulary belongs.

### A correction

An earlier claim in this thread that Photon was not expressible was **wrong**. It cited `normalizePhotonMessage`, the poll path that decodes protobuf off the message plane, where `isFromMe`, `reactionTargetGuid` and `chatGuids[0]` live. The webhook path is `normalizeWebhookEvent`, and it needs a fallback chain and a value map. There was no case for making the gate advisory.

### Two bugs found in review

Both real, both fixed with tests:

- **Map keys were never folded.** The lookup lowercased the payload value but compared it against keys as written, so `{ iMessage: "imessage" }` never matched and fell through to the default. For `chatType` that silently treats every iMessage as the spoofable-sender case.
- **Digest canonicalization was shallow.** Reordering keys inside a field's `map` produced a different digest for a declaration that reads every field from the same place, dropping an approved declaration back to pending until a guardian re-approves the identical thing.

## Test plan

- Full gateway suite green: `bun run test`, all 250 test files passed.
- `gateway/src/channels/ingress-inbound-vendors.test.ts` (new) is the argument that the vocabulary is sufficient. It runs **both shipping vendors' real webhook envelopes** through declarations written the way a plugin author would write them, and checks the result against what the imessage plugin's own normalisers produce: the space fallback, the conservative `sms` default for an unrecognised platform, a sender-less delivery reported rather than invented, and a `comms.ping` finding no message for the gateway to gate.
- `ingress-inbound.test.ts` pins both review bugs: a vendor-cased map key resolves, and two declarations differing only in key order digest identically.
- Everything a declaration adds is in the approval digest. A declaration using none of it digests exactly as before, so no approved manifest is dropped back to pending.
- Em dashes cleared and braces added on changed lines (AGENTS.md "Em Dashes", "Control-Flow Braces").

## Scope

Parsing engine only. Nothing is rewired, and the current flow still works unchanged. What follows:

1. Gateway parses the vendor payload with the declaration instead of the plugin's reply.
2. Gate runs there, enforced, unchanged.
3. **One** crossing into the plugin route, carrying every event type.
4. Plugin runs the turn via `runConversationTurn` and replies over its own transport, retiring `POST /v1/channels/inbound` for plugin channels and closing the outbound gap.

Landing the vocabulary separately so it can be reviewed before everything moves onto it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013p1nTdvsuAtTJ7zyCSDLbx