### PR TITLE
feat(web): translate the terminal, remote-web and credential-requests domains

### DIFF
--- a/clients/web/eslint.config.mjs
+++ b/clients/web/eslint.config.mjs
@@ -197,6 +197,9 @@ const i18nEnforcedPaths = [
   "src/domains/account/**/*.{ts,tsx}",
   "src/domains/channels/**/*.{ts,tsx}",
   "src/domains/workspace/**/*.{ts,tsx}",
+  "src/domains/terminal/**/*.{ts,tsx}",
+  "src/domains/remote-web/**/*.{ts,tsx}",
+  "src/domains/credential-requests/**/*.{ts,tsx}",
 ];
 
 const eslintConfig = defineConfig([

--- a/clients/web/src/domains/credential-requests/credential-entry-page.tsx
+++ b/clients/web/src/domains/credential-requests/credential-entry-page.tsx
@@ -17,6 +17,8 @@ import {
   type CredentialRequestDetails,
 } from "./credential-entry-api";
 
+import { useTranslation } from "@/i18n";
+
 /**
  * Public one-time credential entry page (`/assistant/credentials/enter`).
  *
@@ -87,6 +89,7 @@ function StatusCard({
 }
 
 export function CredentialEntryPage() {
+  const { t } = useTranslation("credential-requests");
   // The token is captured once, before it is stripped from the URL below.
   // Minted links carry it in the fragment (never sent over HTTP); the query
   // param remains as a fallback.
@@ -213,29 +216,27 @@ export function CredentialEntryPage() {
             aria-hidden
           />
         }
-        title="Checking link"
+        title={t("credentialEntry.checkingTitle")}
       >
-        Looking up this credential request.
+        {t("credentialEntry.checkingBody")}
       </StatusCard>
     );
   } else if (phase.kind === "success") {
     content = (
       <StatusCard
         icon={<CheckCircle2 className="h-5 w-5 text-green-600" aria-hidden />}
-        title="Credential saved"
+        title={t("credentialEntry.savedTitle")}
       >
-        You can close this tab and return to your conversation — the assistant
-        can use the credential right away. The value can't be viewed again.
+        {t("credentialEntry.savedBody")}
       </StatusCard>
     );
   } else if (phase.kind === "invalid") {
     content = (
       <StatusCard
         icon={<AlertCircle className="h-5 w-5 text-red-600" aria-hidden />}
-        title="Link not valid"
+        title={t("credentialEntry.invalidTitle")}
       >
-        This credential link isn't valid. Check that the full link was copied,
-        or ask for a new one.
+        {t("credentialEntry.invalidBody")}
       </StatusCard>
     );
   } else if (
@@ -245,40 +246,36 @@ export function CredentialEntryPage() {
     content = (
       <StatusCard
         icon={<AlertCircle className="h-5 w-5 text-red-600" aria-hidden />}
-        title="Link expired"
+        title={t("credentialEntry.expiredTitle")}
       >
-        This credential link has expired. Links only work for a short time — ask
-        for a new one and enter the value again.
+        {t("credentialEntry.expiredBody")}
       </StatusCard>
     );
   } else if (phase.kind === "used") {
     content = (
       <StatusCard
         icon={<AlertCircle className="h-5 w-5 text-red-600" aria-hidden />}
-        title="Link already used"
+        title={t("credentialEntry.usedTitle")}
       >
-        This credential link has already been used. Each link works exactly once
-        — ask for a new one if the value still needs to be provided.
+        {t("credentialEntry.usedBody")}
       </StatusCard>
     );
   } else if (phase.kind === "store-failed") {
     content = (
       <StatusCard
         icon={<AlertCircle className="h-5 w-5 text-red-600" aria-hidden />}
-        title="Link no longer valid"
+        title={t("credentialEntry.storeFailedTitle")}
       >
-        The assistant could not store the credential, and for safety this
-        one-time link cannot be reused. Ask for a new link and try again there.
+        {t("credentialEntry.storeFailedBody")}
       </StatusCard>
     );
   } else if (phase.kind === "error") {
     content = (
       <StatusCard
         icon={<AlertCircle className="h-5 w-5 text-red-600" aria-hidden />}
-        title="Something went wrong"
+        title={t("credentialEntry.errorTitle")}
       >
-        The credential request couldn't be loaded. Refresh the page to try
-        again.
+        {t("credentialEntry.errorBody")}
       </StatusCard>
     );
   } else {
@@ -289,7 +286,9 @@ export function CredentialEntryPage() {
       <>
         <div className="flex items-center gap-3">
           <KeyRound className="h-5 w-5 text-blue-600" aria-hidden />
-          <h1 className="text-xl font-semibold">Provide a credential</h1>
+          <h1 className="text-xl font-semibold">
+            {t("credentialEntry.heading")}
+          </h1>
         </div>
 
         <div className="rounded-md border border-[var(--border-subtle)] bg-[var(--background-muted)] p-4">
@@ -297,14 +296,13 @@ export function CredentialEntryPage() {
             {request.label || name}
           </p>
           <p className="mt-1 font-mono text-body-small-default text-[var(--content-tertiary)]">
-            {request.label ? `${name} · ` : ""}one-time entry
+            {request.label ? `${name} · ` : ""}
+            {t("credentialEntry.oneTimeEntry")}
           </p>
         </div>
 
         <p className="text-sm leading-6 text-[var(--content-secondary)]">
-          Enter the secret value below. It is stored encrypted on the assistant,
-          is never shown again, and this link stops working as soon as it's
-          used.
+          {t("credentialEntry.instructions")}
         </p>
 
         <form
@@ -312,11 +310,11 @@ export function CredentialEntryPage() {
           onSubmit={(event) => void handleSubmit(event)}
         >
           <Input
-            label="Secret value"
+            label={t("credentialEntry.valueLabel")}
             type="password"
             value={value}
             onChange={(event) => setValue(event.target.value)}
-            placeholder="Enter the secret value"
+            placeholder={t("credentialEntry.valuePlaceholder")}
             autoComplete="off"
             autoFocus
             fullWidth
@@ -331,13 +329,15 @@ export function CredentialEntryPage() {
               ) : undefined
             }
           >
-            Submit
+            {t("credentialEntry.submit")}
           </Button>
         </form>
 
         <p className="text-xs text-[var(--content-tertiary)]">
-          Expires in {formatRemaining(remainingMs)} (
-          {new Date(expiresAtMs ?? 0).toLocaleTimeString()}).
+          {t("credentialEntry.expiresIn", {
+            remaining: formatRemaining(remainingMs),
+            time: new Date(expiresAtMs ?? 0).toLocaleTimeString(),
+          })}
         </p>
       </>
     );

--- a/clients/web/src/domains/remote-web/pairing-page.test.tsx
+++ b/clients/web/src/domains/remote-web/pairing-page.test.tsx
@@ -673,9 +673,7 @@ describe("RemoteWebPairingPage", () => {
     try {
       render(
         <MemoryRouter
-          initialEntries={[
-            "/assistant/pair?deviceCode=device-1&userCode=ABCD",
-          ]}
+          initialEntries={["/assistant/pair?deviceCode=device-1&userCode=ABCD"]}
         >
           <RemoteWebPairingPage />
         </MemoryRouter>,

--- a/clients/web/src/domains/remote-web/pairing-page.tsx
+++ b/clients/web/src/domains/remote-web/pairing-page.tsx
@@ -29,6 +29,8 @@ import { nativeSwitchToOriginPath } from "@/runtime/self-hosted-servers";
 import { sanitizeReturnTo } from "@/utils/return-to";
 import { routes } from "@/utils/routes";
 
+import { useTranslation } from "@/i18n";
+
 type PairingDetails = {
   deviceCode: string;
   userCode: string | null;
@@ -218,6 +220,7 @@ function PairingHandoffActions({
   platform: AppHandoffPlatform;
   onContinueInBrowser: () => void;
 }) {
+  const { t } = useTranslation("remote-web");
   const appLink = useMemo(
     () => buildAppHandoffUrl(deviceCode, platform),
     [deviceCode, platform],
@@ -226,16 +229,17 @@ function PairingHandoffActions({
   return (
     <div className="mt-6 flex flex-col gap-3">
       <Button variant="primary" fullWidth asChild>
-        <a href={appLink}>Open in the Vellum app</a>
+        <a href={appLink}>{t("pairingPage.openInApp")}</a>
       </Button>
       <Button variant="outlined" fullWidth onClick={onContinueInBrowser}>
-        Continue in this browser
+        {t("pairingPage.continueInBrowser")}
       </Button>
     </div>
   );
 }
 
 export function RemoteWebPairingPage() {
+  const { t } = useTranslation("remote-web");
   const location = useLocation();
   const navigate = useNavigate();
   const enabled = isRemoteGatewayMode();
@@ -414,14 +418,13 @@ export function RemoteWebPairingPage() {
 
   const cancelUrl = useMemo(() => hubChooserUrl(), []);
   const handleCancel = useCallback(() => {
-    void nativeSwitchToOriginPath(
-      null,
-      `select-assistant?noAutoSkip=1`,
-    ).then((switched) => {
-      if (!switched && cancelUrl) {
-        window.location.assign(cancelUrl);
-      }
-    });
+    void nativeSwitchToOriginPath(null, `select-assistant?noAutoSkip=1`).then(
+      (switched) => {
+        if (!switched && cancelUrl) {
+          window.location.assign(cancelUrl);
+        }
+      },
+    );
   }, [cancelUrl]);
 
   if (!enabled) {
@@ -443,7 +446,7 @@ export function RemoteWebPairingPage() {
         {state.kind === "polling" && pairing?.userCode ? (
           <div className="mb-5 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-sunken)] p-4 text-center">
             <div className="text-label-small-default uppercase tracking-wide text-[var(--content-tertiary)]">
-              Pairing code
+              {t("pairingPage.pairingCode")}
             </div>
             <div className="mt-2 font-mono text-3xl font-semibold tracking-[0.18em] text-[var(--content-emphasised)]">
               {pairing.userCode}
@@ -465,7 +468,9 @@ export function RemoteWebPairingPage() {
 
         {state.kind === "polling" && state.expiresAt ? (
           <p className="text-body-small-lighter mt-4 text-[var(--content-tertiary)]">
-            Expires {new Date(state.expiresAt).toLocaleTimeString()}.
+            {t("pairingPage.expiresAt", {
+              time: new Date(state.expiresAt).toLocaleTimeString(),
+            })}
           </p>
         ) : null}
 
@@ -476,7 +481,7 @@ export function RemoteWebPairingPage() {
             className="mt-6"
             onClick={handleCancel}
           >
-            Cancel
+            {t("pairingPage.cancel")}
           </Button>
         ) : null}
       </section>

--- a/clients/web/src/domains/terminal/components/terminal-console.tsx
+++ b/clients/web/src/domains/terminal/components/terminal-console.tsx
@@ -7,6 +7,8 @@ import {
 import type { Terminal as TerminalType, IDisposable } from "xterm";
 import "xterm/css/xterm.css";
 
+import { useTranslation } from "@/i18n";
+
 export interface TerminalDimensions {
   cols: number;
   rows: number;
@@ -27,6 +29,7 @@ export function TerminalConsole({
   readOnly = false,
   writeRef,
 }: TerminalConsoleProps) {
+  const { t } = useTranslation("terminal");
   const containerRef = useRef<HTMLDivElement | null>(null);
   const terminalRef = useRef<TerminalType | null>(null);
   const onDataRef = useRef(onData);
@@ -179,7 +182,7 @@ export function TerminalConsole({
       className={className}
       style={{ width: "100%", height: "100%", overflow: "hidden" }}
       role="region"
-      aria-label="Terminal console"
+      aria-label={t("terminalConsole.consoleAria")}
     />
   );
 }

--- a/clients/web/src/domains/terminal/components/terminal-toolbar.tsx
+++ b/clients/web/src/domains/terminal/components/terminal-toolbar.tsx
@@ -1,5 +1,6 @@
 import { Loader2, PlugZap, Terminal, Unplug, Wrench, X } from "lucide-react";
 
+import { useTranslation } from "@/i18n";
 import type { TerminalStatus } from "@/domains/terminal/types";
 import { Button } from "@vellumai/design-library/components/button";
 import { Tag, type TagTone } from "@vellumai/design-library/components/tag";
@@ -21,6 +22,7 @@ export function TerminalToolbar({
   className,
   maintenanceModeActive,
 }: TerminalToolbarProps) {
+  const { t } = useTranslation("terminal");
   const isConnecting = status === "connecting" || status === "reconnecting";
   const isConnected = status === "connected";
   const canConnect =
@@ -48,16 +50,16 @@ export function TerminalToolbar({
           className="truncate text-body-medium-default"
           style={{ color: "var(--content-secondary)" }}
         >
-          Terminal
+          {t("terminalToolbar.heading")}
         </span>
         <StatusBadge status={status} />
         {maintenanceModeActive && (
           <Tag
             tone="warning"
             leftIcon={<Wrench />}
-            title="Recovery Mode active — session connected to the debug terminal"
+            title={t("terminalToolbar.recoveryTitle")}
           >
-            Recovery
+            {t("terminalToolbar.recoveryTag")}
           </Tag>
         )}
       </div>
@@ -68,9 +70,9 @@ export function TerminalToolbar({
           size="compact"
           leftIcon={<X />}
           onClick={onClear}
-          title="Clear terminal output"
+          title={t("terminalToolbar.clearTitle")}
         >
-          Clear
+          {t("terminalToolbar.clear")}
         </Button>
 
         {isConnected || isConnecting ? (
@@ -82,9 +84,9 @@ export function TerminalToolbar({
             }
             onClick={onDisconnect}
             disabled={isConnecting}
-            title="Disconnect terminal session"
+            title={t("terminalToolbar.disconnectTitle")}
           >
-            Disconnect
+            {t("terminalToolbar.disconnect")}
           </Button>
         ) : (
           <Button
@@ -93,9 +95,9 @@ export function TerminalToolbar({
             leftIcon={<PlugZap />}
             onClick={onConnect}
             disabled={!canConnect}
-            title="Connect terminal session"
+            title={t("terminalToolbar.connectTitle")}
           >
-            Connect
+            {t("terminalToolbar.connect")}
           </Button>
         )}
       </div>
@@ -104,7 +106,9 @@ export function TerminalToolbar({
 }
 
 function StatusBadge({ status }: { status: TerminalStatus }) {
+  const { t } = useTranslation("terminal");
   const config = STATUS_CONFIG[status];
+  const label = t(config.labelKey);
   return (
     <Tag
       tone={config.tone}
@@ -118,21 +122,38 @@ function StatusBadge({ status }: { status: TerminalStatus }) {
             .join(" ")}
         />
       }
-      aria-label={`Terminal status: ${config.label}`}
+      aria-label={t("terminalToolbar.statusAria", { status: label })}
     >
-      {config.label}
+      {label}
     </Tag>
   );
 }
 
+/**
+ * Tone and pulse per status. The label is a catalog key rather than copy: a
+ * module-scope table cannot call `useTranslation()`, so a plain string here
+ * would render English whatever the active locale is.
+ */
 const STATUS_CONFIG: Record<
   TerminalStatus,
-  { label: string; tone: TagTone; pulse?: boolean }
+  {
+    labelKey: `terminalStatus.${TerminalStatus}`;
+    tone: TagTone;
+    pulse?: boolean;
+  }
 > = {
-  idle: { label: "Idle", tone: "neutral" },
-  connecting: { label: "Connecting", tone: "warning", pulse: true },
-  connected: { label: "Connected", tone: "positive" },
-  reconnecting: { label: "Reconnecting", tone: "warning", pulse: true },
-  error: { label: "Error", tone: "negative" },
-  closed: { label: "Closed", tone: "neutral" },
+  idle: { labelKey: "terminalStatus.idle", tone: "neutral" },
+  connecting: {
+    labelKey: "terminalStatus.connecting",
+    tone: "warning",
+    pulse: true,
+  },
+  connected: { labelKey: "terminalStatus.connected", tone: "positive" },
+  reconnecting: {
+    labelKey: "terminalStatus.reconnecting",
+    tone: "warning",
+    pulse: true,
+  },
+  error: { labelKey: "terminalStatus.error", tone: "negative" },
+  closed: { labelKey: "terminalStatus.closed", tone: "neutral" },
 };

--- a/clients/web/src/i18n/catalogs.ts
+++ b/clients/web/src/i18n/catalogs.ts
@@ -35,6 +35,9 @@
  */
 import enAccount from "@/i18n/locales/en/account.json";
 import enChannels from "@/i18n/locales/en/channels.json";
+import enCredentialRequests from "@/i18n/locales/en/credential-requests.json";
+import enRemoteWeb from "@/i18n/locales/en/remote-web.json";
+import enTerminal from "@/i18n/locales/en/terminal.json";
 import enWorkspace from "@/i18n/locales/en/workspace.json";
 import enChat from "@/i18n/locales/en/chat.json";
 import enCommon from "@/i18n/locales/en/common.json";
@@ -65,6 +68,9 @@ export const FALLBACK_CATALOGS: LocaleCatalogs = {
   account: enAccount,
   channels: enChannels,
   workspace: enWorkspace,
+  terminal: enTerminal,
+  "remote-web": enRemoteWeb,
+  "credential-requests": enCredentialRequests,
 };
 
 /** Loaders for the locales that are not bundled into the entry chunk. */
@@ -79,6 +85,10 @@ const CATALOG_LOADERS: Record<
     account: () => import("@/i18n/locales/es/account.json"),
     channels: () => import("@/i18n/locales/es/channels.json"),
     workspace: () => import("@/i18n/locales/es/workspace.json"),
+    terminal: () => import("@/i18n/locales/es/terminal.json"),
+    "remote-web": () => import("@/i18n/locales/es/remote-web.json"),
+    "credential-requests": () =>
+      import("@/i18n/locales/es/credential-requests.json"),
   },
 };
 

--- a/clients/web/src/i18n/i18next.d.ts
+++ b/clients/web/src/i18n/i18next.d.ts
@@ -14,6 +14,9 @@
  */
 import type account from "@/i18n/locales/en/account.json";
 import type channels from "@/i18n/locales/en/channels.json";
+import type credentialRequests from "@/i18n/locales/en/credential-requests.json";
+import type remoteWeb from "@/i18n/locales/en/remote-web.json";
+import type terminal from "@/i18n/locales/en/terminal.json";
 import type workspace from "@/i18n/locales/en/workspace.json";
 import type chat from "@/i18n/locales/en/chat.json";
 import type common from "@/i18n/locales/en/common.json";
@@ -29,6 +32,9 @@ declare module "i18next" {
       account: typeof account;
       channels: typeof channels;
       workspace: typeof workspace;
+      terminal: typeof terminal;
+      "remote-web": typeof remoteWeb;
+      "credential-requests": typeof credentialRequests;
     };
     returnNull: false;
   }

--- a/clients/web/src/i18n/locales/en/credential-requests.json
+++ b/clients/web/src/i18n/locales/en/credential-requests.json
@@ -1,0 +1,25 @@
+{
+  "credentialEntry": {
+    "checkingTitle": "Checking link",
+    "checkingBody": "Looking up this credential request.",
+    "savedTitle": "Credential saved",
+    "savedBody": "You can close this tab and return to your conversation, and the assistant can use the credential right away. The value can't be viewed again.",
+    "invalidTitle": "Link not valid",
+    "invalidBody": "This credential link isn't valid. Check that the full link was copied, or ask for a new one.",
+    "expiredTitle": "Link expired",
+    "expiredBody": "This credential link has expired. Links only work for a short time, so ask for a new one and enter the value again.",
+    "usedTitle": "Link already used",
+    "usedBody": "This credential link has already been used. Each link works exactly once, so ask for a new one if the value still needs to be provided.",
+    "storeFailedTitle": "Link no longer valid",
+    "storeFailedBody": "The assistant could not store the credential, and for safety this one-time link cannot be reused. Ask for a new link and try again there.",
+    "errorTitle": "Something went wrong",
+    "errorBody": "The credential request couldn't be loaded. Refresh the page to try again.",
+    "heading": "Provide a credential",
+    "oneTimeEntry": "one-time entry",
+    "instructions": "Enter the secret value below. It is stored encrypted on the assistant, is never shown again, and this link stops working as soon as it's used.",
+    "submit": "Submit",
+    "expiresIn": "Expires in {remaining} ({time}).",
+    "valueLabel": "Secret value",
+    "valuePlaceholder": "Enter the secret value"
+  }
+}

--- a/clients/web/src/i18n/locales/en/remote-web.json
+++ b/clients/web/src/i18n/locales/en/remote-web.json
@@ -1,0 +1,9 @@
+{
+  "pairingPage": {
+    "openInApp": "Open in the Vellum app",
+    "continueInBrowser": "Continue in this browser",
+    "pairingCode": "Pairing code",
+    "expiresAt": "Expires {time}.",
+    "cancel": "Cancel"
+  }
+}

--- a/clients/web/src/i18n/locales/en/terminal.json
+++ b/clients/web/src/i18n/locales/en/terminal.json
@@ -1,0 +1,23 @@
+{
+  "terminalToolbar": {
+    "heading": "Terminal",
+    "recoveryTitle": "Recovery Mode active, session connected to the debug terminal",
+    "recoveryTag": "Recovery",
+    "clearTitle": "Clear terminal output",
+    "clear": "Clear",
+    "disconnectTitle": "Disconnect terminal session",
+    "disconnect": "Disconnect",
+    "connectTitle": "Connect terminal session",
+    "connect": "Connect",
+    "statusAria": "Terminal status: {status}"
+  },
+  "terminalStatus": {
+    "idle": "Idle",
+    "connecting": "Connecting",
+    "connected": "Connected",
+    "reconnecting": "Reconnecting",
+    "error": "Error",
+    "closed": "Closed"
+  },
+  "terminalConsole": { "consoleAria": "Terminal console" }
+}

--- a/clients/web/src/i18n/locales/es/credential-requests.json
+++ b/clients/web/src/i18n/locales/es/credential-requests.json
@@ -1,0 +1,25 @@
+{
+  "credentialEntry": {
+    "checkingTitle": "Comprobando el enlace",
+    "checkingBody": "Buscando esta solicitud de credencial.",
+    "savedTitle": "Credencial guardada",
+    "savedBody": "Puedes cerrar esta pestaña y volver a tu conversación: el asistente ya puede usar la credencial. El valor no se puede volver a ver.",
+    "invalidTitle": "El enlace no es válido",
+    "invalidBody": "Este enlace de credencial no es válido. Comprueba que se copió el enlace completo o pide uno nuevo.",
+    "expiredTitle": "El enlace ha caducado",
+    "expiredBody": "Este enlace de credencial ha caducado. Los enlaces solo funcionan durante poco tiempo, así que pide uno nuevo e introduce el valor otra vez.",
+    "usedTitle": "El enlace ya se ha usado",
+    "usedBody": "Este enlace de credencial ya se ha usado. Cada enlace funciona exactamente una vez, así que pide uno nuevo si todavía hay que proporcionar el valor.",
+    "storeFailedTitle": "El enlace ya no es válido",
+    "storeFailedBody": "El asistente no pudo guardar la credencial y, por seguridad, este enlace de un solo uso no se puede reutilizar. Pide un enlace nuevo e inténtalo ahí.",
+    "errorTitle": "Algo ha ido mal",
+    "errorBody": "No se pudo cargar la solicitud de credencial. Actualiza la página para volver a intentarlo.",
+    "heading": "Proporciona una credencial",
+    "oneTimeEntry": "entrada de un solo uso",
+    "instructions": "Introduce el valor secreto abajo. Se guarda cifrado en el asistente, no se muestra nunca más y este enlace deja de funcionar en cuanto se usa.",
+    "submit": "Enviar",
+    "expiresIn": "Caduca en {remaining} ({time}).",
+    "valueLabel": "Valor secreto",
+    "valuePlaceholder": "Introduce el valor secreto"
+  }
+}

--- a/clients/web/src/i18n/locales/es/remote-web.json
+++ b/clients/web/src/i18n/locales/es/remote-web.json
@@ -1,0 +1,9 @@
+{
+  "pairingPage": {
+    "openInApp": "Abrir en la aplicación de Vellum",
+    "continueInBrowser": "Continuar en este navegador",
+    "pairingCode": "Código de vinculación",
+    "expiresAt": "Caduca a las {time}.",
+    "cancel": "Cancelar"
+  }
+}

--- a/clients/web/src/i18n/locales/es/terminal.json
+++ b/clients/web/src/i18n/locales/es/terminal.json
@@ -1,0 +1,23 @@
+{
+  "terminalToolbar": {
+    "heading": "Terminal",
+    "recoveryTitle": "Modo de recuperación activo, sesión conectada al terminal de depuración",
+    "recoveryTag": "Recuperación",
+    "clearTitle": "Borrar la salida del terminal",
+    "clear": "Borrar",
+    "disconnectTitle": "Desconectar la sesión del terminal",
+    "disconnect": "Desconectar",
+    "connectTitle": "Conectar la sesión del terminal",
+    "connect": "Conectar",
+    "statusAria": "Estado del terminal: {status}"
+  },
+  "terminalStatus": {
+    "idle": "Inactivo",
+    "connecting": "Conectando",
+    "connected": "Conectado",
+    "reconnecting": "Reconectando",
+    "error": "Error",
+    "closed": "Cerrado"
+  },
+  "terminalConsole": { "consoleAria": "Consola del terminal" }
+}

--- a/clients/web/src/i18n/namespaces.ts
+++ b/clients/web/src/i18n/namespaces.ts
@@ -41,6 +41,9 @@ export const NAMESPACES = [
   "account",
   "channels",
   "workspace",
+  "terminal",
+  "remote-web",
+  "credential-requests",
 ] as const;
 
 export type Namespace = (typeof NAMESPACES)[number];


### PR DESCRIPTION
## Prompt / plan

37 strings across 4 files, in three new namespaces. Three small domains batched into one PR rather than three, since each is a handful of files.

## Notable conversions

**`STATUS_CONFIG` was a module-scope table of copy.** It maps each terminal connection state to a label, a tone and a pulse flag. The labels were English strings, and a module-scope table cannot call `useTranslation()`, so they rendered English whatever the locale — the same shape as the channel metadata in #40494.

It now holds `terminalStatus.*` keys, typed as a template over `TerminalStatus`:

```ts
labelKey: `terminalStatus.${TerminalStatus}`;
```

so adding a connection state without its message fails `tsc`. (The template works here, unlike the channel-metadata case, because every status genuinely has a message — there is no missing member for the template to invent.)

**The credential entry page is seven mutually exclusive status cards**, each a title plus a paragraph. All fourteen messages are whole sentences now. Three of them ran a clause on after an em dash (`"Links only work for a short time — ask for a new one"`); those are commas now, so the sentence survives a translator reordering it rather than depending on English's dash-clause habit.

**`Expires {time}`, `Expires in {remaining} ({time})`** and the terminal's **`Terminal status: {status}`** were text spliced around values; now placeholders.

## One thing worth knowing for future catalogs

The repo's pre-commit secret scanner rejected the first commit. Its generic pattern matches a lowercase `secret` in a **key** position followed by a string of 8+ characters:

```
['"]?[a-z0-9_]*secret[a-z0-9_]*['"]?[[:space:]]*[:=][[:space:]]*['"][^'"]{8,}['"]
```

My keys were `secretLabel` and `secretPlaceholder`. In TSX those were prop names and never matched; as JSON catalog entries they look exactly like a secrets config. The values are field labels (`"Secret value"`), so the key name was the thing to change: they are now `valueLabel` and `valuePlaceholder`, copy unchanged.

Flagging it because **any catalog key containing `secret`, `apiKey`, `clientSecret` and friends will hit this**, and the fix is always to rename the key rather than bypass the hook.

## Test plan

- `bun scripts/run-tests.ts`: **925 test files pass, 0 fail**
- `bun run lint` clean with all three domains on the ratchet: 0 errors, 16 pre-existing warnings
- `bunx tsc --noEmit` clean; pre-commit hook passed without bypass
- `bun run build` clean

## Cutover progress

Eight namespaces converted: `schedules`, `account`, `channels`, `workspace`, `terminal`, `remote-web`, `credential-requests`, `chat` (partial).

Remaining by current-rule count: settings 1585, chat 1066, components 463, onboarding 194, intelligence 177, contacts 115, home 59, library 39, logs 30, hooks/utils/lib 23.

`library` (39) and `logs` (30) are the natural next batch, then `home` (59) and `contacts` (115).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CD12TRfmDF3UiXjdbiWn3i)_