### PR TITLE
fix(web): mount the staged-quotes strip story on the real composer, and give the chat footer column one owner (LUM-3193)

### DIFF
--- a/clients/web/src/domains/chat/components/chat-body.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.tsx
@@ -4,6 +4,7 @@ import { Paperclip } from "lucide-react";
 
 import { useKeyboardOpen } from "@/hooks/use-keyboard-open";
 import { useBannerVisibilityStore } from "@/stores/banner-visibility-store";
+import { ChatColumn } from "@/domains/chat/components/chat-column";
 import { QuestionPromptSlot } from "@/domains/chat/components/question-prompt-slot";
 import { StagedQuotesStrip } from "@/domains/chat/components/staged-quotes-strip";
 import {
@@ -322,41 +323,43 @@ export function ChatBody({
         </div>
       )}
       {bannerRendered && bannerSlot}
-      <div className="relative px-3 pt-1 pb-2 sm:px-6 sm:pb-0">
-        {refreshFeedback && (
-          <div className="pointer-events-none absolute inset-x-0 bottom-full z-10 flex justify-center pb-2">
-            <RefreshFeedbackPill
-              feedback={refreshFeedback}
-              onDismiss={onDismissRefreshFeedback}
-              onRetry={onRetryRefresh}
-            />
+      <ChatColumn
+        className="relative pt-1 pb-2 sm:pb-0"
+        overlay={
+          refreshFeedback && (
+            <div className="pointer-events-none absolute inset-x-0 bottom-full z-10 flex justify-center pb-2">
+              <RefreshFeedbackPill
+                feedback={refreshFeedback}
+                onDismiss={onDismissRefreshFeedback}
+                onRetry={onRetryRefresh}
+              />
+            </div>
+          )
+        }
+      >
+        {genericChatError && (
+          <div className="mb-2">
+            <Notice
+              tone={genericChatError.tone ?? "error"}
+              onDismiss={onDismissChatError}
+              actions={genericChatError.actions}
+            >
+              {genericChatError.message}
+            </Notice>
           </div>
         )}
-        <div className="mx-auto max-w-[var(--chat-max-width)]">
-          {genericChatError && (
-            <div className="mb-2">
-              <Notice
-                tone={genericChatError.tone ?? "error"}
-                onDismiss={onDismissChatError}
-                actions={genericChatError.actions}
-              >
-                {genericChatError.message}
-              </Notice>
-            </div>
+        {queuedDrawerSlot}
+        <QuestionPromptSlot />
+        {channelFooterSlot}
+        <StagedQuotesStrip />
+        {composerSlot}
+        {pluginPillsSlot &&
+          renderKeyboardCollapse(
+            "new-chat-plugins",
+            <div className="mt-4">{pluginPillsSlot}</div>,
           )}
-          {queuedDrawerSlot}
-          <QuestionPromptSlot />
-          {channelFooterSlot}
-          <StagedQuotesStrip />
-          {composerSlot}
-          {pluginPillsSlot &&
-            renderKeyboardCollapse(
-              "new-chat-plugins",
-              <div className="mt-4">{pluginPillsSlot}</div>,
-            )}
-          {trailingStarters}
-        </div>
-      </div>
+        {trailingStarters}
+      </ChatColumn>
     </div>
   );
 
@@ -398,19 +401,11 @@ export function ChatBody({
           {startersSlot &&
             renderKeyboardCollapse(
               "docked-starters",
-              <div className="px-3 pb-3 sm:px-6">
-                <div className="mx-auto max-w-[var(--chat-max-width)]">
-                  {startersSlot}
-                </div>
-              </div>,
+              <ChatColumn className="pb-3">{startersSlot}</ChatColumn>,
             )}
         </div>
         {belowFoldSlot && (
-          <div className="px-3 pt-2 pb-8 sm:px-6">
-            <div className="mx-auto max-w-[var(--chat-max-width)]">
-              {belowFoldSlot}
-            </div>
-          </div>
+          <ChatColumn className="pt-2 pb-8">{belowFoldSlot}</ChatColumn>
         )}
         {dragOverlay}
       </div>

--- a/clients/web/src/domains/chat/components/chat-column.tsx
+++ b/clients/web/src/domains/chat/components/chat-column.tsx
@@ -1,0 +1,45 @@
+/**
+ * The chat body's centered column: everything stacked below the transcript
+ * (the composer and its notices, the docked starters, the below-fold block)
+ * shares one width and one set of horizontal insets, so they line up with
+ * each other down the whole footer.
+ *
+ * The horizontal padding sits on the outer element and the `--chat-max-width`
+ * cap on an inner one, so the cap measures the content rather than the
+ * content plus its gutters: at a wide viewport the column is exactly
+ * `--chat-max-width`, and the padding only bites once the viewport is
+ * narrower than that. The transcript column deliberately does the opposite
+ * (`transcript.tsx` puts `px-4 sm:px-6` inside the capped box, insetting rows
+ * from the composer's edge), which is why these are two components and not
+ * one.
+ *
+ * Vertical padding is the caller's, through `className`: it is the only thing
+ * that legitimately differs between the three stacks.
+ */
+
+import type { ReactNode } from "react";
+
+interface ChatColumnProps {
+  /** Vertical padding and any other per-stack framing. */
+  className?: string;
+  /**
+   * Rendered inside the padded wrapper but outside the capped column, for
+   * chrome that positions against the column's full padded width rather than
+   * flowing in it (the refresh pill hangs above the composer this way). A
+   * caller passing this must also pass `relative` in `className`: the
+   * positioning context is not applied here, because adding one changes the
+   * containing block for any absolutely-positioned descendant of `children`,
+   * and `children` is a slot the column does not control.
+   */
+  overlay?: ReactNode;
+  children: ReactNode;
+}
+
+export function ChatColumn({ className, overlay, children }: ChatColumnProps) {
+  return (
+    <div className={`px-3 sm:px-6${className ? ` ${className}` : ""}`}>
+      {overlay}
+      <div className="mx-auto max-w-[var(--chat-max-width)]">{children}</div>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/staged-quotes-strip.stories.tsx
+++ b/clients/web/src/domains/chat/components/staged-quotes-strip.stories.tsx
@@ -4,10 +4,11 @@
  * quote is added the strip scrolls to reveal the newest chip.
  *
  * The strip's whole job is to sit between the transcript and the composer, so
- * these stories mount it where `chat-body` mounts it: inside the footer
- * column, with the real `ChatComposer` as its next sibling. Its own `mb-2` is
- * the gap to that composer, and its width comes from the column rather than
- * from itself, so neither is reviewable with the strip standing alone.
+ * these stories mount it where `chat-body` mounts it: inside the real
+ * `ChatColumn`, with the real `ChatComposer` as its next sibling. Its own
+ * `mb-2` is the gap to that composer, and its width comes from the column
+ * rather than from itself, so neither is reviewable with the strip standing
+ * alone.
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
@@ -15,6 +16,7 @@ import { useEffect, useRef } from "react";
 import { Button } from "@vellumai/design-library";
 
 import { StagedQuotesStrip } from "./staged-quotes-strip";
+import { ChatColumn } from "@/domains/chat/components/chat-column";
 import { ChatComposer } from "@/domains/chat/components/chat-composer/chat-composer";
 import { useQuoteReplyStore } from "@/domains/chat/quote-reply-store";
 
@@ -87,19 +89,17 @@ const meta: Meta<typeof StagedQuotesStrip> = {
   title: "Chat/StagedQuotesStrip",
   parameters: { layout: "fullscreen", controls: { disable: true } },
   decorators: [
-    /* `chat-body`'s footer column, class for class: the bottom-anchored body,
-       the `px-3 pt-1 pb-2 sm:px-6 sm:pb-0` wrapper, and the
-       `mx-auto max-w-[var(--chat-max-width)]` child the strip shares with the
-       composer. Keep in sync with `chat-body.tsx`. */
+    /* The real `ChatColumn` with the composer stack's own vertical padding,
+       inside a bottom-anchored body: the same arrangement `chat-body` builds
+       around the strip. Imported rather than mirrored, so a change to the
+       column reaches this story on its own. */
     (Story) => (
       <div className="flex h-screen flex-col justify-end">
-        <div className="px-3 pt-1 pb-2 sm:px-6 sm:pb-0">
-          <div className="mx-auto max-w-[var(--chat-max-width)]">
-            <Story />
-            <StoryComposer />
-          </div>
-        </div>
-        {/* Harness control, deliberately outside the mirrored app column. */}
+        <ChatColumn className="pt-1 pb-2 sm:pb-0">
+          <Story />
+          <StoryComposer />
+        </ChatColumn>
+        {/* Harness control, deliberately outside the app column. */}
         <div className="px-3 py-3 sm:px-6">
           <Button variant="outlined" size="compact" onClick={stageAnotherQuote}>
             Stage another quote

--- a/clients/web/src/domains/chat/components/staged-quotes-strip.stories.tsx
+++ b/clients/web/src/domains/chat/components/staged-quotes-strip.stories.tsx
@@ -1,15 +1,22 @@
-import type { Meta, StoryObj } from "@storybook/react-vite";
-import { useEffect } from "react";
-import { Button } from "@vellumai/design-library";
-
-import { StagedQuotesStrip } from "./staged-quotes-strip";
-import { useQuoteReplyStore } from "@/domains/chat/quote-reply-store";
-
 /**
  * The staged-quotes strip: the quotes the user has pulled from assistant
  * messages, each with an editable reply, rendered above the composer. When a
  * quote is added the strip scrolls to reveal the newest chip.
+ *
+ * The strip's whole job is to sit between the transcript and the composer, so
+ * these stories mount it where `chat-body` mounts it: inside the footer
+ * column, with the real `ChatComposer` as its next sibling. Its own `mb-2` is
+ * the gap to that composer, and its width comes from the column rather than
+ * from itself, so neither is reviewable with the strip standing alone.
  */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useEffect, useRef } from "react";
+import { Button } from "@vellumai/design-library";
+
+import { StagedQuotesStrip } from "./staged-quotes-strip";
+import { ChatComposer } from "@/domains/chat/components/chat-composer/chat-composer";
+import { useQuoteReplyStore } from "@/domains/chat/quote-reply-store";
 
 const SAMPLE_QUOTES = [
   {
@@ -30,46 +37,77 @@ const SAMPLE_QUOTES = [
   },
 ];
 
-/** Renders the strip plus a button that stages another quote (to test scroll). */
-function StripHarness({ initialCount }: { initialCount: number }) {
+/** Stages the next sample quote, cycling once the samples run out. */
+function stageAnotherQuote() {
+  const n = useQuoteReplyStore.getState().stagedQuotes.length;
+  const quote = SAMPLE_QUOTES[n % SAMPLE_QUOTES.length]!;
+  useQuoteReplyStore
+    .getState()
+    .addStagedQuote({ ...quote, sourceMessageId: `msg-${n}` });
+}
+
+/** Seeds the store with `count` staged quotes, then renders the real strip. */
+function SeededStrip({ count }: { count: number }) {
   useEffect(() => {
     useQuoteReplyStore.setState({ stagedQuotes: [] });
-    for (const q of SAMPLE_QUOTES.slice(0, initialCount)) {
+    for (const quote of SAMPLE_QUOTES.slice(0, count)) {
       useQuoteReplyStore
         .getState()
-        .addStagedQuote({ ...q, sourceMessageId: "msg-1" });
+        .addStagedQuote({ ...quote, sourceMessageId: "msg-1" });
     }
     return () => useQuoteReplyStore.setState({ stagedQuotes: [] });
-  }, [initialCount]);
+  }, [count]);
 
-  const stageAnother = () => {
-    const n = useQuoteReplyStore.getState().stagedQuotes.length;
-    const q = SAMPLE_QUOTES[n % SAMPLE_QUOTES.length]!;
-    useQuoteReplyStore
-      .getState()
-      .addStagedQuote({ ...q, sourceMessageId: `msg-${n}` });
-  };
+  return <StagedQuotesStrip />;
+}
 
+/**
+ * The composer the strip actually sits on. Every required prop is an input the
+ * orchestrator hands down, so the real component mounts on story-supplied
+ * callbacks; nothing here stands in for a value the app derives.
+ */
+function StoryComposer() {
+  const inputRef = useRef<HTMLTextAreaElement | null>(null);
   return (
-    <div className="mx-auto max-w-[720px]">
-      <div className="rounded-[10px] bg-[var(--surface-base)] p-2">
-        <StagedQuotesStrip />
-        <div className="px-4 pt-3 pb-2 text-chat text-[var(--content-disabled)]">
-          What would you like to do?
-        </div>
-      </div>
-      <div className="mt-3">
-        <Button variant="outlined" size="compact" onClick={stageAnother}>
-          Stage another quote
-        </Button>
-      </div>
-    </div>
+    <ChatComposer
+      placeholder="What would you like to do?"
+      onSubmit={(event) => event.preventDefault()}
+      inputRef={inputRef}
+      typingDisabled={false}
+      sendDisabled={false}
+      onAddAttachmentFiles={() => {}}
+      onStopGenerating={() => {}}
+      isAssistantBusy={false}
+      assistantId={null}
+    />
   );
 }
 
 const meta: Meta<typeof StagedQuotesStrip> = {
   title: "Chat/StagedQuotesStrip",
-  parameters: { layout: "padded", controls: { disable: true } },
+  parameters: { layout: "fullscreen", controls: { disable: true } },
+  decorators: [
+    /* `chat-body`'s footer column, class for class: the bottom-anchored body,
+       the `px-3 pt-1 pb-2 sm:px-6 sm:pb-0` wrapper, and the
+       `mx-auto max-w-[var(--chat-max-width)]` child the strip shares with the
+       composer. Keep in sync with `chat-body.tsx`. */
+    (Story) => (
+      <div className="flex h-screen flex-col justify-end">
+        <div className="px-3 pt-1 pb-2 sm:px-6 sm:pb-0">
+          <div className="mx-auto max-w-[var(--chat-max-width)]">
+            <Story />
+            <StoryComposer />
+          </div>
+        </div>
+        {/* Harness control, deliberately outside the mirrored app column. */}
+        <div className="px-3 py-3 sm:px-6">
+          <Button variant="outlined" size="compact" onClick={stageAnotherQuote}>
+            Stage another quote
+          </Button>
+        </div>
+      </div>
+    ),
+  ],
 };
 
 export default meta;
@@ -77,15 +115,15 @@ type Story = StoryObj<typeof StagedQuotesStrip>;
 
 /** A few staged quotes; click "Stage another" to confirm it scrolls to the newest. */
 export const Overflowing: Story = {
-  render: () => <StripHarness initialCount={3} />,
+  render: () => <SeededStrip count={3} />,
 };
 
 /** Single staged quote with an editable reply. */
 export const Single: Story = {
-  render: () => <StripHarness initialCount={1} />,
+  render: () => <SeededStrip count={1} />,
 };
 
 /** Starts empty; click "Stage another" to confirm the very first chip animates in. */
 export const Empty: Story = {
-  render: () => <StripHarness initialCount={0} />,
+  render: () => <SeededStrip count={0} />,
 };


### PR DESCRIPTION
## TL;DR

The `StagedQuotesStrip` story mounted the strip inside a white panel and a line of grey text pretending to be the composer. The strip's only real geometry (its `mb-2` gap to the composer, and its alignment with the composer's edges) comes from its container, so against a fake container the story proved neither.

Two commits: mount it on the real `ChatComposer`, then extract the column it lives in as `ChatColumn` so the story imports the production wrapper instead of mirroring it.

Fixes LUM-3193.

## Why this is safe

**The story change** touches no production code. The real `ChatComposer` now mounts in Storybook; every required prop is an input the orchestrator hands down (`onSubmit`, `inputRef`, `typingDisabled`, `sendDisabled`, `onAddAttachmentFiles`, `onStopGenerating`, `isAssistantBusy`, `assistantId`), so it runs on story-supplied callbacks and nothing stands in for a value the app derives.

**The extraction** is structural only. The class strings at all three `chat-body` sites are unchanged — only utility order differs, which Tailwind does not depend on:

| Site | Before | After (composed) |
|---|---|---|
| Composer stack | `relative px-3 pt-1 pb-2 sm:px-6 sm:pb-0` | `px-3 sm:px-6 relative pt-1 pb-2 sm:pb-0` |
| Docked starters | `px-3 pb-3 sm:px-6` | `px-3 sm:px-6 pb-3` |
| Below fold | `px-3 pt-2 pb-8 sm:px-6` | `px-3 sm:px-6 pt-2 pb-8` |

The positioning context deliberately stayed at the call site instead of moving into the component. `children` is a slot `ChatColumn` does not control, and adding a containing block would silently re-anchor any absolutely-positioned descendant of it — at the composer-stack site the parent is itself `relative`, so the change would have been invisible in review and real at runtime.

Verified in a real browser at 1280px: the strip renders at 800px / x=240 both before and after the extraction, identical to production geometry. `tsc --noEmit` and eslint clean. `chat-body.test.tsx` (38 cases) queries by `data-testid` / `data-slot` and asserts `.closest(".absolute")` / `.closest(".pointer-events-none")` on the scroll-to-latest pill, which sits outside `ChatColumn` and is untouched; `renderKeyboardCollapse` sets its own `data-slot` wrapper, so the docked-starters queries are unaffected. Local test runs are blocked by a hook here, so CI is the gate.

## Before / after for a reviewer

| | Before | After |
|---|---|---|
| What sits below the strip | A grey text line copying the composer's placeholder string | The real `ChatComposer`, with its attach button and send control |
| Backdrop | A `--surface-base` panel with `p-2` that the app never renders | The chat body background, as in the app |
| Column width (1280px canvas) | 704px, from a hardcoded `max-w-[720px]` | 800px, from the real `ChatColumn` |
| The `mb-2` gap to the composer | Measured against a text node with its own `pt-3`; deleting `mb-2` changed nothing visible | The real gap between the last chip and the composer card |
| A change to the footer column | Invisible; the story never used that column | Reaches the story automatically; it imports the same component |
| Footer column definition | Written out three times in `chat-body` | One `ChatColumn`, used by all three sites and the story |

## Regression it would now catch

The class the strip belongs to: a defect that is a property of the component **and its container** — dropping the strip's `mb-2`, or the footer column changing width or padding out from under it. That is the shape of the sidebar drawer inset regression in #40490, which the old story's structure could not have caught either. Because the story now imports `ChatColumn` rather than mirroring it, the second of those can no longer diverge silently.

## Deliberately not done

**The transcript column.** `transcript.tsx` (×2) and `chat-skeleton.tsx` also center on `--chat-max-width`, but they put `px-4 sm:px-6` *inside* the capped box rather than outside it, so their rows are inset from the composer's edge by the padding. That is a different geometry, not a duplicate of this one — folding them into `ChatColumn` would move layout rather than restructure it. `chat-empty-state.tsx` and the two tour overlays are the same story. `ChatColumn`'s docblock records why the two shapes are separate so the next reader does not "unify" them by mistake.

## Note on verification

An earlier measurement pass of mine was wrong twice, both times from the harness rather than the code, so it is worth stating how these numbers were taken: Storybook was read through headless Chromium, not the in-app browser pane. That pane reports `document.visibilityState === "hidden"`, which throttles rAF and freezes `motion/react` entrance animations mid-flight — chips read back at `opacity: 0` and textareas at absurd heights, none of it real. And a stale Storybook holding port 6007 from a previous checkout served pre-change bundles that looked like a regression in this one. LUM-3164's rubric has been updated with the first trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)