### PR TITLE
refactor(persistence): add message-reads accessors and migrate internal callers

### DIFF
--- a/assistant/src/__tests__/conversation-attention-store.test.ts
+++ b/assistant/src/__tests__/conversation-attention-store.test.ts
@@ -832,3 +832,39 @@ describe("conversation-attention-store", () => {
     });
   });
 });
+
+describe("attention watermarks and streaming rows", () => {
+  test("state init from an upgraded database anchors on the latest finalized reply", () => {
+    clearTables();
+    ensureConversation("conv-1");
+    insertAssistantMessage("conv-1", "msg-done", 1_000);
+    getDb()
+      .insert(messages)
+      .values({
+        id: "msg-streaming",
+        conversationId: "conv-1",
+        role: "assistant",
+        content: "still being written",
+        createdAt: 2_000,
+        metadata: null,
+        finalized: 0,
+      })
+      .run();
+
+    // No attention row exists, so the seen signal initializes state from the
+    // messages table. The streaming row is newest but is not a reply yet;
+    // anchoring the watermark on it would classify the finished reply as
+    // already seen the moment it completes.
+    recordConversationSeenSignal({
+      conversationId: "conv-1",
+      sourceChannel: "vellum",
+      signalType: "macos_conversation_opened",
+      confidence: "explicit",
+      source: "desktop-client",
+    });
+
+    const state = getAttentionStateByConversationIds(["conv-1"]).get("conv-1")!;
+    expect(state.latestAssistantMessageId).toBe("msg-done");
+    expect(state.lastSeenAssistantMessageId).toBe("msg-done");
+  });
+});

--- a/assistant/src/__tests__/conversation-attention-store.test.ts
+++ b/assistant/src/__tests__/conversation-attention-store.test.ts
@@ -868,3 +868,30 @@ describe("attention watermarks and streaming rows", () => {
     expect(state.lastSeenAssistantMessageId).toBe("msg-done");
   });
 });
+
+describe("markConversationUnread with only a streaming reply", () => {
+  test("reports no assistant message rather than rewinding onto the streaming row", () => {
+    clearTables();
+    ensureConversation("conv-1");
+    getDb()
+      .insert(messages)
+      .values({
+        id: "msg-streaming-only",
+        conversationId: "conv-1",
+        role: "assistant",
+        content: "still being written",
+        createdAt: 1_000,
+        metadata: null,
+        finalized: 0,
+      })
+      .run();
+
+    // The write-path projection anchors at the finalize seam
+    // (`reserveMessage` deliberately skips it), so attention state for this
+    // conversation says "no reply yet". The rewind fallback must agree with
+    // the projection rather than anchoring on the streaming row.
+    expect(() => markConversationUnread("conv-1")).toThrow(
+      /no assistant message/i,
+    );
+  });
+});

--- a/assistant/src/persistence/attachments-store.ts
+++ b/assistant/src/persistence/attachments-store.ts
@@ -137,6 +137,9 @@ function getAttachmentRow(attachmentId: string): AttachmentRow | null {
 function getMessageConversationContext(
   messageId: string,
 ): { conversationId: string; conversationCreatedAt: number } | null {
+  // Any-state read, deliberately: the id names a message the caller is
+  // already linking an attachment to, and a rendered row may still be
+  // streaming. Existence and ownership are the question, not completeness.
   return (
     rawGet<{ conversationId: string; conversationCreatedAt: number }>(
       "attachments:getMessageConversationContext",

--- a/assistant/src/persistence/bookmark-crud.ts
+++ b/assistant/src/persistence/bookmark-crud.ts
@@ -3,6 +3,7 @@ import { v4 as uuid } from "uuid";
 
 import type { DrizzleDb } from "./db-connection.js";
 import { stringifyMessageContent } from "./message-content.js";
+import { messageConversationId } from "./message-reads.js";
 import { conversations, messageBookmarks, messages } from "./schema.js";
 
 /**
@@ -138,15 +139,10 @@ export function createBookmark(
   params: { messageId: string },
 ): CreateBookmarkResult {
   const { messageId } = params;
-  const message = db
-    .select({ conversationId: messages.conversationId })
-    .from(messages)
-    .where(eq(messages.id, messageId))
-    .get();
-  if (!message) {
+  const conversationId = messageConversationId(messageId);
+  if (conversationId === null) {
     throw new Error(`Message ${messageId} not found`);
   }
-  const conversationId = message.conversationId;
 
   const existing = db
     .select({ id: messageBookmarks.id })

--- a/assistant/src/persistence/bookmark-crud.ts
+++ b/assistant/src/persistence/bookmark-crud.ts
@@ -139,7 +139,7 @@ export function createBookmark(
   params: { messageId: string },
 ): CreateBookmarkResult {
   const { messageId } = params;
-  const conversationId = messageConversationId(messageId);
+  const conversationId = messageConversationId(messageId, { db });
   if (conversationId === null) {
     throw new Error(`Message ${messageId} not found`);
   }

--- a/assistant/src/persistence/conversation-attention-store.ts
+++ b/assistant/src/persistence/conversation-attention-store.ts
@@ -22,10 +22,13 @@ import { v4 as uuid } from "uuid";
 import { UserError } from "../util/errors.js";
 import { getDb } from "./db-connection.js";
 import {
+  latestAssistantMessage,
+  latestAssistantMessageBefore,
+} from "./message-reads.js";
+import {
   conversationAssistantAttentionState,
   conversationAttentionEvents,
   conversations,
-  messages,
 } from "./schema/index.js";
 
 // ── Types ────────────────────────────────────────────────────────────
@@ -361,19 +364,11 @@ export function recordConversationSeenSignal(params: {
     if (!state) {
       // No state row yet — look up the conversation's latest assistant message so
       // upgraded databases (with existing messages but no attention row) correctly
-      // initialize the full state on the first seen signal.
-      const latestMsg = tx
-        .select({ id: messages.id, createdAt: messages.createdAt })
-        .from(messages)
-        .where(
-          and(
-            eq(messages.conversationId, conversationId),
-            eq(messages.role, "assistant"),
-          ),
-        )
-        .orderBy(desc(messages.createdAt))
-        .limit(1)
-        .get();
+      // initialize the full state on the first seen signal. Finalized-only via
+      // the accessor: a still-streaming reply is not a reply the user has seen,
+      // and anchoring the watermark on it would classify the finished reply as
+      // seen the moment it completes.
+      const latestMsg = latestAssistantMessage(conversationId, { db: tx });
 
       const latestMsgId = latestMsg?.id ?? null;
       const latestMsgAt = latestMsg?.createdAt ?? null;
@@ -461,26 +456,11 @@ function resolveAssistantCursor(params: {
     latestAssistantMessageAt,
   } = params;
 
-  // Unread classification compares timestamps strictly, so rewinding to a
-  // same-timestamp sibling would leave the latest reply classified as seen.
-  const previousAssistantMessageBefore = (before: number) =>
-    db
-      .select({ id: messages.id, createdAt: messages.createdAt })
-      .from(messages)
-      .where(
-        and(
-          eq(messages.conversationId, conversationId),
-          eq(messages.role, "assistant"),
-          lt(messages.createdAt, before),
-        ),
-      )
-      .orderBy(desc(messages.createdAt), desc(messages.id))
-      .limit(1)
-      .get();
-
   if (latestAssistantMessageId && latestAssistantMessageAt != null) {
-    const previousMessage = previousAssistantMessageBefore(
+    const previousMessage = latestAssistantMessageBefore(
+      conversationId,
       latestAssistantMessageAt,
+      { db },
     );
 
     return {
@@ -491,25 +471,16 @@ function resolveAssistantCursor(params: {
     };
   }
 
-  const latestMessage = db
-    .select({ id: messages.id, createdAt: messages.createdAt })
-    .from(messages)
-    .where(
-      and(
-        eq(messages.conversationId, conversationId),
-        eq(messages.role, "assistant"),
-      ),
-    )
-    .orderBy(desc(messages.createdAt), desc(messages.id))
-    .limit(1)
-    .get();
+  const latestMessage = latestAssistantMessage(conversationId, { db });
 
   if (!latestMessage) {
     return null;
   }
 
-  const previousMessage = previousAssistantMessageBefore(
+  const previousMessage = latestAssistantMessageBefore(
+    conversationId,
     latestMessage.createdAt,
+    { db },
   );
   return {
     latestAssistantMessageId: latestMessage.id,

--- a/assistant/src/persistence/conversation-queries.ts
+++ b/assistant/src/persistence/conversation-queries.ts
@@ -1,4 +1,4 @@
-import { and, count, desc, eq, inArray, isNull, lt, sql } from "drizzle-orm";
+import { and, count, desc, eq, isNull, lt, sql } from "drizzle-orm";
 
 import {
   parseExternalContentEnvelope,
@@ -26,11 +26,14 @@ import {
   parseContentRef,
   resolveMessageContentBlocks,
 } from "./message-content-file.js";
+import {
+  countMessagesByRoleForConversations,
+  latestUserMessageRawContent,
+} from "./message-reads.js";
 import { rawAll } from "./raw-query.js";
 import {
   conversationAssistantAttentionState,
   conversations,
-  messages,
 } from "./schema/index.js";
 
 const log = getLogger("conversation-store");
@@ -438,31 +441,7 @@ export function getMessageRoleStatsByConversation(
   conversationIds: string[],
   role: string = "assistant",
 ): Map<string, { count: number; lastAt: number }> {
-  if (conversationIds.length === 0) {
-    return new Map();
-  }
-  const db = getDb();
-  const rows = db
-    .select({
-      conversationId: messages.conversationId,
-      count: sql<number>`COUNT(*)`.as("count"),
-      lastAt: sql<number>`MAX(${messages.createdAt})`.as("last_at"),
-    })
-    .from(messages)
-    .where(
-      and(
-        inArray(messages.conversationId, conversationIds),
-        eq(messages.role, role),
-      ),
-    )
-    .groupBy(messages.conversationId)
-    .all();
-  return new Map(
-    rows.map((r) => [
-      r.conversationId,
-      { count: Number(r.count), lastAt: Number(r.lastAt) },
-    ]),
-  );
+  return countMessagesByRoleForConversations(conversationIds, role);
 }
 
 export function listPinnedConversations(
@@ -535,6 +514,8 @@ export function listConversationsByTitlePrefix(
   const rows = rawAll<Row>(
     "conversation:listByTitlePrefix",
     `SELECT c.id, c.title,
+            -- Any-state count (streaming rows included): a list-surface size
+            -- hint where a transient +1 during a live turn is immaterial.
             (SELECT COUNT(*) FROM messages WHERE conversation_id = c.id) AS message_count,
             c.created_at
      FROM conversations c
@@ -623,26 +604,14 @@ export function countUnreadConversations(): number {
  * determine if additional exchanges need to be deleted from the DB.
  */
 export function isLastUserMessageToolResult(conversationId: string): boolean {
-  const db = getDb();
-  const lastUserMsg = db
-    .select({ content: messages.content })
-    .from(messages)
-    .where(
-      and(
-        eq(messages.conversationId, conversationId),
-        eq(messages.role, "user"),
-      ),
-    )
-    .orderBy(sql`rowid DESC`)
-    .limit(1)
-    .get();
+  const lastUserContent = latestUserMessageRawContent(conversationId);
 
-  if (!lastUserMsg) {
+  if (lastUserContent === null) {
     return false;
   }
 
   try {
-    const parsed = JSON.parse(lastUserMsg.content);
+    const parsed = JSON.parse(lastUserContent);
     if (
       Array.isArray(parsed) &&
       parsed.length > 0 &&
@@ -816,6 +785,10 @@ export async function searchConversations(
       if (!opts?.includeArchived) {
         whereClauses.push(`c.archived_at IS NULL`);
       }
+      // No completeness predicate: candidate ids come from the lexical
+      // index, which filters finalized = 1 at index time, so an unfinalized
+      // row cannot be a candidate. Do not copy this shape for id sets with
+      // different provenance.
       const visibleRows = rawAll<CandidateRow>(
         "conversation:searchConversations:visibleCandidates",
         `

--- a/assistant/src/persistence/llm-request-log-store.ts
+++ b/assistant/src/persistence/llm-request-log-store.ts
@@ -28,13 +28,14 @@ import {
   getTurnTimeBounds,
   messageMetadataSchema,
 } from "./conversation-crud.js";
-import { type DrizzleDb, getDb, getLogsDb } from "./db-connection.js";
+import { type DrizzleDb, getLogsDb } from "./db-connection.js";
 import { getClickHouseLlmRequestLogSink } from "./llm-request-log-sink-clickhouse.js";
 import type {
   LlmRequestLogWriter,
   LlmRequestLogWriteRow,
 } from "./llm-request-log-writer-types.js";
-import { llmRequestLogs, messages } from "./schema/index.js";
+import { existingMessageIds } from "./message-reads.js";
+import { llmRequestLogs } from "./schema/index.js";
 import { timeSyncSection } from "./slow-sync-log.js";
 
 /**
@@ -593,14 +594,7 @@ function selectOrphanedLogsInRange(
   const candidateMessageIds = [
     ...new Set(candidates.map((c) => c.messageId as string)),
   ];
-  const existing = new Set(
-    getDb()
-      .select({ id: messages.id })
-      .from(messages)
-      .where(inArray(messages.id, candidateMessageIds))
-      .all()
-      .map((r) => r.id),
-  );
+  const existing = existingMessageIds(candidateMessageIds);
 
   // Orphaned = the referenced message no longer exists.
   return candidates.filter((c) => !existing.has(c.messageId as string));

--- a/assistant/src/persistence/llm-usage-store.ts
+++ b/assistant/src/persistence/llm-usage-store.ts
@@ -300,6 +300,9 @@ export function queryUnreportedUsageEvents(
   // branch from a turn far earlier than the fork's creation time, so
   // they anchor on the fork boundary message instead; child creation is
   // the fallback when the boundary message is absent.
+  // The turn-index subqueries below count user-role rows only. User rows are
+  // always written finalized (only assistant turns stream), so no completeness
+  // predicate is needed; do not copy this shape for assistant-row counts.
   const parentTurnCutoffSql = sql<number>`CASE
     WHEN ${conversations.parentConversationId} IS NOT NULL THEN ${conversations.createdAt}
     ELSE COALESCE(

--- a/assistant/src/persistence/message-reads.test.ts
+++ b/assistant/src/persistence/message-reads.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { eq } from "drizzle-orm";
+
+import { createConversation } from "./conversation-crud.js";
+import { getDb } from "./db-connection.js";
+import { initializeDb } from "./db-init.js";
+import {
+  countMessagesByRoleForConversations,
+  existingMessageIds,
+  latestAssistantMessage,
+  latestAssistantMessageBefore,
+  latestUserMessageRawContent,
+  messageConversationId,
+} from "./message-reads.js";
+import { messages } from "./schema/index.js";
+
+await initializeDb();
+
+let seq = 0;
+function insertRow(opts: {
+  conversationId: string;
+  role: string;
+  createdAt: number;
+  content?: string;
+  finalized?: 0 | 1;
+}): string {
+  const id = `msg-${String(++seq).padStart(4, "0")}`;
+  getDb()
+    .insert(messages)
+    .values({
+      id,
+      conversationId: opts.conversationId,
+      role: opts.role,
+      content: opts.content ?? JSON.stringify([{ type: "text", text: "hi" }]),
+      createdAt: opts.createdAt,
+      metadata: null,
+      finalized: opts.finalized ?? 1,
+    })
+    .run();
+  return id;
+}
+
+function seedConversation(): string {
+  return createConversation("Message reads test").id;
+}
+
+describe("message-reads", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run("DELETE FROM messages");
+    db.run("DELETE FROM conversations");
+  });
+
+  test("latestAssistantMessage returns the newest finalized assistant row", () => {
+    const conv = seedConversation();
+    insertRow({ conversationId: conv, role: "user", createdAt: 1_000 });
+    const older = insertRow({
+      conversationId: conv,
+      role: "assistant",
+      createdAt: 2_000,
+    });
+    const newer = insertRow({
+      conversationId: conv,
+      role: "assistant",
+      createdAt: 3_000,
+    });
+
+    expect(latestAssistantMessage(conv)?.id).toBe(newer);
+    expect(latestAssistantMessage(conv)?.id).not.toBe(older);
+    expect(latestAssistantMessage("missing-conv")).toBeNull();
+  });
+
+  test("latestAssistantMessage never anchors on a streaming row", () => {
+    const conv = seedConversation();
+    const finalizedReply = insertRow({
+      conversationId: conv,
+      role: "assistant",
+      createdAt: 1_000,
+    });
+    insertRow({
+      conversationId: conv,
+      role: "assistant",
+      createdAt: 2_000,
+      finalized: 0,
+    });
+
+    // The streaming row is newest but is not a reply yet; the watermark must
+    // sit on the completed one until the turn finishes.
+    expect(latestAssistantMessage(conv)?.id).toBe(finalizedReply);
+  });
+
+  test("a streaming row qualifies on its own once finalized", () => {
+    const conv = seedConversation();
+    insertRow({ conversationId: conv, role: "assistant", createdAt: 1_000 });
+    const streaming = insertRow({
+      conversationId: conv,
+      role: "assistant",
+      createdAt: 2_000,
+      finalized: 0,
+    });
+
+    getDb()
+      .update(messages)
+      .set({ finalized: 1 })
+      .where(eq(messages.id, streaming))
+      .run();
+
+    expect(latestAssistantMessage(conv)?.id).toBe(streaming);
+  });
+
+  test("latestAssistantMessageBefore is strict and skips streaming rows", () => {
+    const conv = seedConversation();
+    const first = insertRow({
+      conversationId: conv,
+      role: "assistant",
+      createdAt: 1_000,
+    });
+    insertRow({
+      conversationId: conv,
+      role: "assistant",
+      createdAt: 2_000,
+      finalized: 0,
+    });
+    insertRow({ conversationId: conv, role: "assistant", createdAt: 3_000 });
+
+    // Strictly before 3000: the streaming row at 2000 is passed over in
+    // favour of the completed row at 1000.
+    expect(latestAssistantMessageBefore(conv, 3_000)?.id).toBe(first);
+    // Strictly before 1000: nothing.
+    expect(latestAssistantMessageBefore(conv, 1_000)).toBeNull();
+  });
+
+  test("latestUserMessageRawContent resolves same-timestamp rows by insertion order", () => {
+    const conv = seedConversation();
+    insertRow({
+      conversationId: conv,
+      role: "user",
+      createdAt: 1_000,
+      content: "first",
+    });
+    insertRow({
+      conversationId: conv,
+      role: "user",
+      createdAt: 1_000,
+      content: "second",
+    });
+    insertRow({ conversationId: conv, role: "assistant", createdAt: 2_000 });
+
+    expect(latestUserMessageRawContent(conv)).toBe("second");
+    expect(latestUserMessageRawContent("missing-conv")).toBeNull();
+  });
+
+  test("countMessagesByRoleForConversations aggregates per conversation", () => {
+    const convA = seedConversation();
+    const convB = seedConversation();
+    insertRow({ conversationId: convA, role: "assistant", createdAt: 1_000 });
+    insertRow({ conversationId: convA, role: "assistant", createdAt: 2_000 });
+    insertRow({ conversationId: convA, role: "user", createdAt: 3_000 });
+    insertRow({ conversationId: convB, role: "assistant", createdAt: 4_000 });
+
+    const stats = countMessagesByRoleForConversations(
+      [convA, convB],
+      "assistant",
+    );
+    expect(stats.get(convA)).toEqual({ count: 2, lastAt: 2_000 });
+    expect(stats.get(convB)).toEqual({ count: 1, lastAt: 4_000 });
+    expect(countMessagesByRoleForConversations([], "assistant").size).toBe(0);
+  });
+
+  test("existingMessageIds returns only ids that exist", () => {
+    const conv = seedConversation();
+    const present = insertRow({
+      conversationId: conv,
+      role: "user",
+      createdAt: 1_000,
+    });
+
+    const existing = existingMessageIds([present, "msg-not-there"]);
+    expect(existing.has(present)).toBe(true);
+    expect(existing.has("msg-not-there")).toBe(false);
+    expect(existingMessageIds([]).size).toBe(0);
+  });
+
+  test("messageConversationId resolves ownership in any state", () => {
+    const conv = seedConversation();
+    const streaming = insertRow({
+      conversationId: conv,
+      role: "assistant",
+      createdAt: 1_000,
+      finalized: 0,
+    });
+
+    expect(messageConversationId(streaming)).toBe(conv);
+    expect(messageConversationId("msg-not-there")).toBeNull();
+  });
+});

--- a/assistant/src/persistence/message-reads.ts
+++ b/assistant/src/persistence/message-reads.ts
@@ -1,0 +1,203 @@
+/**
+ * Named read accessors for the `messages` table.
+ *
+ * Every row in `messages` is conversation content in some state of
+ * completeness: `finalized = 1` rows are immutable history, `finalized = 0`
+ * rows are still being written and their `content` may be a `{ ref }` into an
+ * in-flight delta file that disappears when the turn completes. Ad-hoc queries
+ * tend to encode a visibility decision without stating it; each accessor here
+ * states its decision in its name and contract, so a caller (and a reviewer)
+ * chooses between "completed history" and "any row" deliberately.
+ *
+ * Conversation-history reads (transcripts, lineage, pagination) stay with
+ * `getMessages` / `getMessagesAfter` / `getMessagesPaginated` in
+ * `conversation-crud.ts`, which also own fork-lineage resolution. This module
+ * is for the narrower point lookups and aggregates that other persistence
+ * modules need.
+ *
+ * Correlated subqueries embedded inside larger SQL (usage accounting's
+ * turn-index arithmetic, search candidate joins, `message_count` projections)
+ * are out of scope: extracting them would restructure their host queries. They
+ * carry their visibility decision as a comment at the site instead.
+ */
+
+import { and, desc, eq, inArray, lt, sql } from "drizzle-orm";
+
+import { type DrizzleDb, getDb } from "./db-connection.js";
+import { messages } from "./schema/index.js";
+
+/** `(id, createdAt)` of a message, the shape cursor and watermark logic needs. */
+export interface MessageRef {
+  id: string;
+  createdAt: number;
+}
+
+/**
+ * Structural read handle: anything that can `select` like the shared
+ * connection, which includes the connection itself and an open transaction.
+ * Accessors take this rather than `DrizzleDb` so a caller inside
+ * `db.transaction(...)` reads through its own handle.
+ */
+export type MessageReadHandle = Pick<DrizzleDb, "select">;
+
+/**
+ * The newest completed assistant message in a conversation, or null when it
+ * has none.
+ *
+ * Finalized-only: an assistant row that is still streaming is not a reply yet,
+ * so consumers tracking "the latest reply" (read/unread watermarks, previews)
+ * must not anchor on it. The row qualifies on its own once the turn completes.
+ *
+ * `db` lets a caller inside a transaction read through its own handle.
+ */
+export function latestAssistantMessage(
+  conversationId: string,
+  opts?: { db?: MessageReadHandle },
+): MessageRef | null {
+  const db = opts?.db ?? getDb();
+  const row = db
+    .select({ id: messages.id, createdAt: messages.createdAt })
+    .from(messages)
+    .where(
+      and(
+        eq(messages.conversationId, conversationId),
+        eq(messages.role, "assistant"),
+        eq(messages.finalized, 1),
+      ),
+    )
+    .orderBy(desc(messages.createdAt), desc(messages.id))
+    .limit(1)
+    .get();
+  return row ?? null;
+}
+
+/**
+ * The newest completed assistant message strictly before `createdAt`, or null.
+ * Strict comparison: rewind logic that landed on a same-timestamp sibling
+ * would classify the latest reply as already seen.
+ */
+export function latestAssistantMessageBefore(
+  conversationId: string,
+  createdAt: number,
+  opts?: { db?: MessageReadHandle },
+): MessageRef | null {
+  const db = opts?.db ?? getDb();
+  const row = db
+    .select({ id: messages.id, createdAt: messages.createdAt })
+    .from(messages)
+    .where(
+      and(
+        eq(messages.conversationId, conversationId),
+        eq(messages.role, "assistant"),
+        eq(messages.finalized, 1),
+        lt(messages.createdAt, createdAt),
+      ),
+    )
+    .orderBy(desc(messages.createdAt), desc(messages.id))
+    .limit(1)
+    .get();
+  return row ?? null;
+}
+
+/**
+ * Raw `content` of the last user-role row in a conversation, in insertion
+ * order (`rowid DESC`, not `createdAt`), or null when there is none.
+ *
+ * Insertion order is load-bearing for the undo path this serves: same-
+ * millisecond rows must resolve to the one written last. User rows are always
+ * written finalized, so no completeness predicate applies; only assistant
+ * turns stream.
+ */
+export function latestUserMessageRawContent(
+  conversationId: string,
+): string | null {
+  const row = getDb()
+    .select({ content: messages.content })
+    .from(messages)
+    .where(
+      and(
+        eq(messages.conversationId, conversationId),
+        eq(messages.role, "user"),
+      ),
+    )
+    .orderBy(sql`rowid DESC`)
+    .limit(1)
+    .get();
+  return row?.content ?? null;
+}
+
+/**
+ * Per-conversation count and latest timestamp of rows with `role`, for the
+ * given conversations.
+ *
+ * Any-state deliberately: these aggregates feed list ordering and previews,
+ * where a streaming reply still counts as activity. A caller needing
+ * completed-only aggregates should say so here rather than post-filtering.
+ */
+export function countMessagesByRoleForConversations(
+  conversationIds: string[],
+  role: string,
+): Map<string, { count: number; lastAt: number }> {
+  if (conversationIds.length === 0) {
+    return new Map();
+  }
+  const rows = getDb()
+    .select({
+      conversationId: messages.conversationId,
+      count: sql<number>`COUNT(*)`.as("count"),
+      lastAt: sql<number>`MAX(${messages.createdAt})`.as("last_at"),
+    })
+    .from(messages)
+    .where(
+      and(
+        inArray(messages.conversationId, conversationIds),
+        eq(messages.role, role),
+      ),
+    )
+    .groupBy(messages.conversationId)
+    .all();
+  return new Map(
+    rows.map((r) => [
+      r.conversationId,
+      { count: Number(r.count), lastAt: Number(r.lastAt) },
+    ]),
+  );
+}
+
+/**
+ * Which of `messageIds` exist as rows, in any state.
+ *
+ * Any-state deliberately: existence is the question (orphan detection for
+ * rows referencing messages), and a streaming row exists. An empty input
+ * returns an empty set without querying.
+ */
+export function existingMessageIds(messageIds: string[]): Set<string> {
+  if (messageIds.length === 0) {
+    return new Set();
+  }
+  return new Set(
+    getDb()
+      .select({ id: messages.id })
+      .from(messages)
+      .where(inArray(messages.id, messageIds))
+      .all()
+      .map((r) => r.id),
+  );
+}
+
+/**
+ * The conversation that owns `messageId`, in any state, or null when the
+ * message does not exist.
+ *
+ * Any-state deliberately: callers hold an id the user acted on (a bookmark on
+ * a rendered row, an attachment link), and a rendered row may still be
+ * streaming.
+ */
+export function messageConversationId(messageId: string): string | null {
+  const row = getDb()
+    .select({ conversationId: messages.conversationId })
+    .from(messages)
+    .where(eq(messages.id, messageId))
+    .get();
+  return row?.conversationId ?? null;
+}

--- a/assistant/src/persistence/message-reads.ts
+++ b/assistant/src/persistence/message-reads.ts
@@ -35,8 +35,9 @@ export interface MessageRef {
 /**
  * Structural read handle: anything that can `select` like the shared
  * connection, which includes the connection itself and an open transaction.
- * Accessors take this rather than `DrizzleDb` so a caller inside
- * `db.transaction(...)` reads through its own handle.
+ * Every accessor takes `opts.db` with this type and defaults to the shared
+ * connection, so a caller holding its own handle (a transaction, an injected
+ * or in-memory database) reads the same database it writes.
  */
 export type MessageReadHandle = Pick<DrizzleDb, "select">;
 
@@ -110,8 +111,9 @@ export function latestAssistantMessageBefore(
  */
 export function latestUserMessageRawContent(
   conversationId: string,
+  opts?: { db?: MessageReadHandle },
 ): string | null {
-  const row = getDb()
+  const row = (opts?.db ?? getDb())
     .select({ content: messages.content })
     .from(messages)
     .where(
@@ -137,11 +139,12 @@ export function latestUserMessageRawContent(
 export function countMessagesByRoleForConversations(
   conversationIds: string[],
   role: string,
+  opts?: { db?: MessageReadHandle },
 ): Map<string, { count: number; lastAt: number }> {
   if (conversationIds.length === 0) {
     return new Map();
   }
-  const rows = getDb()
+  const rows = (opts?.db ?? getDb())
     .select({
       conversationId: messages.conversationId,
       count: sql<number>`COUNT(*)`.as("count"),
@@ -171,12 +174,15 @@ export function countMessagesByRoleForConversations(
  * rows referencing messages), and a streaming row exists. An empty input
  * returns an empty set without querying.
  */
-export function existingMessageIds(messageIds: string[]): Set<string> {
+export function existingMessageIds(
+  messageIds: string[],
+  opts?: { db?: MessageReadHandle },
+): Set<string> {
   if (messageIds.length === 0) {
     return new Set();
   }
   return new Set(
-    getDb()
+    (opts?.db ?? getDb())
       .select({ id: messages.id })
       .from(messages)
       .where(inArray(messages.id, messageIds))
@@ -193,8 +199,11 @@ export function existingMessageIds(messageIds: string[]): Set<string> {
  * a rendered row, an attachment link), and a rendered row may still be
  * streaming.
  */
-export function messageConversationId(messageId: string): string | null {
-  const row = getDb()
+export function messageConversationId(
+  messageId: string,
+  opts?: { db?: MessageReadHandle },
+): string | null {
+  const row = (opts?.db ?? getDb())
     .select({ conversationId: messages.conversationId })
     .from(messages)
     .where(eq(messages.id, messageId))

--- a/assistant/src/persistence/message-reads.ts
+++ b/assistant/src/persistence/message-reads.ts
@@ -55,21 +55,7 @@ export function latestAssistantMessage(
   conversationId: string,
   opts?: { db?: MessageReadHandle },
 ): MessageRef | null {
-  const db = opts?.db ?? getDb();
-  const row = db
-    .select({ id: messages.id, createdAt: messages.createdAt })
-    .from(messages)
-    .where(
-      and(
-        eq(messages.conversationId, conversationId),
-        eq(messages.role, "assistant"),
-        eq(messages.finalized, 1),
-      ),
-    )
-    .orderBy(desc(messages.createdAt), desc(messages.id))
-    .limit(1)
-    .get();
-  return row ?? null;
+  return newestFinalizedAssistantRow(conversationId, opts?.db ?? getDb());
 }
 
 /**
@@ -82,7 +68,18 @@ export function latestAssistantMessageBefore(
   createdAt: number,
   opts?: { db?: MessageReadHandle },
 ): MessageRef | null {
-  const db = opts?.db ?? getDb();
+  return newestFinalizedAssistantRow(
+    conversationId,
+    opts?.db ?? getDb(),
+    createdAt,
+  );
+}
+
+function newestFinalizedAssistantRow(
+  conversationId: string,
+  db: MessageReadHandle,
+  strictlyBefore?: number,
+): MessageRef | null {
   const row = db
     .select({ id: messages.id, createdAt: messages.createdAt })
     .from(messages)
@@ -91,7 +88,9 @@ export function latestAssistantMessageBefore(
         eq(messages.conversationId, conversationId),
         eq(messages.role, "assistant"),
         eq(messages.finalized, 1),
-        lt(messages.createdAt, createdAt),
+        ...(strictlyBefore === undefined
+          ? []
+          : [lt(messages.createdAt, strictlyBefore)]),
       ),
     )
     .orderBy(desc(messages.createdAt), desc(messages.id))


### PR DESCRIPTION
## TL;DR

First PR of the messages-reader consolidation (Part of JARVIS-1478). Adds `persistence/message-reads.ts`, a small module of read accessors named by intent, and migrates the persistence-internal callers onto it. The point: every row in `messages` is content in some state of completeness, and the `finalized` column's filter-it-yourself contract has already failed once (the fork paths copied mid-stream rows for months, fixed in #40484). Accessors make the completed-history vs. any-row choice visible at the call site instead of implicit in a hand-rolled query.

## What changes for the user

| | Before | After |
|---|---|---|
| Unread badge during a live turn | Attention watermarks could anchor on a still-streaming reply, so the finished reply could be classified as already seen the moment it completed (state init on upgraded databases, and mark-unread's rewind) | Watermarks anchor only on completed replies; the streaming reply becomes the unseen-latest when it finishes |
| Everything else | — | No behavior change; same queries, now behind named accessors or explicit visibility comments |

## Why this is safe

- The accessor bodies are the migrated queries, moved verbatim except for the audited attention-store change above; `getMessageRoleStatsByConversation` and `isLastUserMessageToolResult` delegate with identical semantics (including the load-bearing `rowid DESC` insertion-order read for undo).
- Any-state accessors (`existingMessageIds`, `messageConversationId`) document why any-state is correct (existence/ownership questions; ids from user actions on rendered rows).
- Correlated subqueries embedded in larger SQL (usage-store turn indexes, search candidate joins, `message_count`) are deliberately not extracted; each now carries its visibility decision as a comment, including the id-provenance argument that makes the search reads safe without a `finalized` predicate. Forcing them into JS accessors would restructure analytics queries for pattern purity.
- History reads (`getMessages` family, fork lineage) stay in `conversation-crud.ts`, untouched.
- Net diff on the six migrated files is negative (-60 lines); the new module carries the documentation weight.

## Follow-ups (tracked on JARVIS-1478, not this PR)

Module-family migrations (memory plugins, telemetry, routes), then a lint/CI guard against new direct `messages` reads outside `persistence/`. The guard intentionally comes last so it lands against a migrated tree instead of a suppression wall.

## Tests

`message-reads.test.ts` covers each accessor including the streaming-row exclusions and insertion-order resolution; `conversation-attention-store.test.ts` gains the wiring regression pinning finalized-only watermark anchoring on the upgraded-database init path.

Local `bun test` is hook-blocked in this environment; typecheck and lint pass locally and CI runs the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40541" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->