### PR TITLE
fix(web): move a conversation between sections without waiting for a refetch (LUM-3195)

### DIFF
--- a/clients/web/src/domains/chat/components/conversation-row.tsx
+++ b/clients/web/src/domains/chat/components/conversation-row.tsx
@@ -33,11 +33,14 @@ import { isChannelConversation } from "@/domains/chat/utils/conversation-channel
 import { copyIdToClipboard } from "@/domains/chat/utils/copy-id-to-clipboard";
 import {
   buildMoveToGroupTargets,
-  isConversationPinned,
   isInCustomGroup,
 } from "@/domains/chat/utils/group-conversations";
 import type { Conversation } from "@/types/conversation-types";
-import { canMarkRead, canMarkUnread } from "@/utils/conversation-predicates";
+import {
+  canMarkRead,
+  canMarkUnread,
+  isConversationPinned,
+} from "@/utils/conversation-predicates";
 import { isPointerCoarse } from "@/utils/pointer";
 import type { SwipeAction } from "@/hooks/use-swipe-to-reveal";
 

--- a/clients/web/src/domains/chat/hooks/conversation-action-utils.test.ts
+++ b/clients/web/src/domains/chat/hooks/conversation-action-utils.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for the pure placement helpers.
+ *
+ * {@link resolvePlacementSurfacedAt} is a twin of the daemon's
+ * `batchSetConversationPlacement`, so the cases below are the branches that
+ * write actually takes: the promotion, the demotion, and the rows it leaves
+ * alone. A rule that drifts from the SQL shows up as a row that moves into a
+ * section optimistically and moves back out when the refetch lands.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { Conversation } from "@/types/conversation-types";
+import { resolvePlacementSurfacedAt } from "@/domains/chat/hooks/conversation-action-utils";
+
+const NOW = 1_700_000_000_000;
+
+function conversation(overrides: Partial<Conversation> = {}): Conversation {
+  return { conversationId: "c1", ...overrides };
+}
+
+describe("resolvePlacementSurfacedAt", () => {
+  test("pinning a background run stamps the promotion", () => {
+    // `system:pinned` fails the custom-group arm of the daemon's
+    // standard-listing visibility on its `system:` prefix, so the stamp is
+    // the only thing that puts a pinned background row in the sidebar.
+    expect(
+      resolvePlacementSurfacedAt(
+        conversation({ conversationType: "background" }),
+        "system:pinned",
+        NOW,
+      ),
+    ).toBe(NOW);
+  });
+
+  test("filing a scheduled run into a custom group stamps it too", () => {
+    expect(
+      resolvePlacementSurfacedAt(
+        conversation({ conversationType: "scheduled" }),
+        "group-uuid",
+        NOW,
+      ),
+    ).toBe(NOW);
+  });
+
+  test("an existing promotion time survives a re-file", () => {
+    // The daemon's COALESCE: re-filing keeps the original promotion time.
+    expect(
+      resolvePlacementSurfacedAt(
+        conversation({ conversationType: "background", surfacedAt: 5 }),
+        "group-uuid",
+        NOW,
+      ),
+    ).toBe(5);
+  });
+
+  test("moving into the background or scheduled bucket clears it", () => {
+    for (const groupId of ["system:background", "system:scheduled"]) {
+      expect(
+        resolvePlacementSurfacedAt(
+          conversation({ conversationType: "background", surfacedAt: 5 }),
+          groupId,
+          NOW,
+        ),
+      ).toBeUndefined();
+    }
+  });
+
+  test("a standard conversation is never stamped", () => {
+    // Everything outside the two automated types is already visible, so a
+    // stamp would leave `surfacedAt` meaning nothing.
+    expect(
+      resolvePlacementSurfacedAt(conversation(), "system:pinned", NOW),
+    ).toBeUndefined();
+    expect(
+      resolvePlacementSurfacedAt(conversation(), "group-uuid", NOW),
+    ).toBeUndefined();
+  });
+
+  test("returning to system:all neither stamps nor clears", () => {
+    expect(
+      resolvePlacementSurfacedAt(
+        conversation({ conversationType: "background", surfacedAt: 5 }),
+        "system:all",
+        NOW,
+      ),
+    ).toBe(5);
+    expect(
+      resolvePlacementSurfacedAt(
+        conversation({ conversationType: "background" }),
+        "system:all",
+        NOW,
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/clients/web/src/domains/chat/hooks/conversation-action-utils.ts
+++ b/clients/web/src/domains/chat/hooks/conversation-action-utils.ts
@@ -57,3 +57,46 @@ export function resolveUnpinGroupId(
   }
   return "system:all";
 }
+
+/**
+ * The `surfacedAt` a placement into `groupId` leaves on this conversation.
+ *
+ * Filing a background or scheduled run somewhere the user reads is a
+ * promotion, and the daemon stamps `surfaced_at` in the same write that sets
+ * the group (`batchSetConversationPlacement`). The stamp is what carries the
+ * visibility: `system:pinned` fails the custom-group arm of
+ * `standardListingVisibilitySql` on its `system:` prefix, so a pinned
+ * background row reaches the sidebar only because it is surfaced. Moving into
+ * `system:background` / `system:scheduled` is the demotion and clears it.
+ *
+ * The client twin of that write, so an optimistic placement leaves the row in
+ * the state the server is about to put it in. Without it, a section filter
+ * reading `surfacedAt` gets a different answer from the one the next refetch
+ * brings back, and the row visibly moves twice.
+ *
+ * Only background and scheduled rows are stamped: everything else is already
+ * visible, and the existing timestamp is kept so a re-filed row does not have
+ * its original promotion time overwritten.
+ */
+export function resolvePlacementSurfacedAt(
+  conversation: Conversation,
+  groupId: string,
+  now: number,
+): number | undefined {
+  if (groupId === "system:background" || groupId === "system:scheduled") {
+    return undefined;
+  }
+  const promotes =
+    groupId !== "system:all" &&
+    (groupId === "system:pinned" || !groupId.startsWith("system:"));
+  if (!promotes) {
+    return conversation.surfacedAt;
+  }
+  const isBackgroundOrScheduled =
+    conversation.conversationType === "background" ||
+    conversation.conversationType === "scheduled";
+  if (!isBackgroundOrScheduled) {
+    return conversation.surfacedAt;
+  }
+  return conversation.surfacedAt ?? now;
+}

--- a/clients/web/src/domains/chat/hooks/use-conversation-actions-placement.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-actions-placement.test.tsx
@@ -195,6 +195,56 @@ describe("pin/unpin placement", () => {
     expect(copies(client, "c1")).toBe(1);
   });
 
+  test("a failed move leaves a newer move of the same row alone", async () => {
+    /* Two moves of one conversation overlap whenever the second starts before
+       the first settles, and both write the same fields. A rollback that fires
+       regardless of what happened since would put the row back where it sat
+       before the *older* move, discarding a placement the user made later. */
+    const first = deferred<{ data: undefined; response: { ok: boolean } }>();
+    let call = 0;
+    reorderImpl = () => {
+      call += 1;
+      return call === 1
+        ? first.promise
+        : Promise.resolve({ data: undefined, response: { ok: true } });
+    };
+
+    const { result, client } = setup([
+      [SLACK, [SLACK_ROW]],
+      [PINNED, []],
+    ]);
+
+    // Move A: pin. Still in flight.
+    await act(async () => {
+      result.current.handleTogglePinConversation(SLACK_ROW);
+    });
+    expect(idsIn(client, PINNED)).toEqual(["c1"]);
+
+    // Move B: unpin the row A just placed, before A has settled.
+    const pinnedRow: Conversation = {
+      ...SLACK_ROW,
+      isPinned: true,
+      groupId: "system:pinned",
+    };
+    await act(async () => {
+      result.current.handleTogglePinConversation(pinnedRow);
+    });
+    expect(idsIn(client, SLACK)).toEqual(["c1"]);
+
+    // A now fails. Its rollback would restore the pre-A state, which is the
+    // placement B has already replaced.
+    await act(async () => {
+      first.reject(new Error("nope"));
+      await first.promise.catch(() => {});
+    });
+
+    await waitFor(() => {
+      expect(idsIn(client, SLACK)).toEqual(["c1"]);
+    });
+    expect(idsIn(client, PINNED)).toEqual([]);
+    expect(copies(client, "c1")).toBe(1);
+  });
+
   test("unpinning returns the row to its channel section", async () => {
     const pinnedRow: Conversation = {
       ...SLACK_ROW,

--- a/clients/web/src/domains/chat/hooks/use-conversation-actions-placement.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-actions-placement.test.tsx
@@ -1,0 +1,243 @@
+/**
+ * Tests for pin/unpin as a *placement*: the section caches, not the fields.
+ *
+ * **The bug these tests guard against.** Every sidebar section fetches its own
+ * rows through a server filter (LUM-2443), so a section's membership is the
+ * contents of its cache entry rather than something the client derives.
+ * Pinning used to rewrite `isPinned` / `groupId` on the row and stop there, so
+ * no cache moved it: the row appeared in Pinned only once Pinned's refetch
+ * landed, and stayed in the section it came from until *that* section's
+ * refetch landed. Those are separate requests of very different cost, which is
+ * why the row was visibly in two sections at once in between.
+ *
+ * The assertions count copies across every seeded section rather than checking
+ * the destination, because the old behavior satisfies "Pinned contains the
+ * row" perfectly well. What it violates is "a conversation appears in exactly
+ * one section, never twice".
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+
+import * as sdkGen from "@/generated/daemon/sdk.gen";
+import type { Conversation } from "@/types/conversation-types";
+import {
+  conversationsQueryKey,
+  sectionConversationsQueryKey,
+  type SectionConversationFilter,
+} from "@/utils/conversation-list-fetchers";
+
+type ReorderImpl = (opts: unknown) => Promise<{
+  data: undefined;
+  response: { ok: boolean };
+}>;
+
+let reorderImpl: ReorderImpl = async () => ({
+  data: undefined,
+  response: { ok: true },
+});
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...sdkGen,
+  conversationsReorderPost: (opts: unknown) => reorderImpl(opts),
+}));
+
+mock.module("@/utils/haptics", () => ({
+  haptic: { medium: () => {}, light: () => {} },
+}));
+
+mock.module("@sentry/react", () => ({
+  captureException: () => {},
+  captureMessage: () => {},
+  addBreadcrumb: () => {},
+}));
+
+const { useConversationActions } = await import(
+  "@/domains/chat/hooks/use-conversation-actions"
+);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ASSISTANT_ID = "asst-1";
+const PINNED: SectionConversationFilter = { groupId: "system:pinned" };
+const SLACK: SectionConversationFilter = {
+  groupId: "system:all",
+  originChannel: "slack",
+};
+
+const SLACK_ROW: Conversation = {
+  conversationId: "c1",
+  originChannel: "slack",
+  lastMessageAt: 1_000,
+};
+
+function setup(sections: Array<[SectionConversationFilter, Conversation[]]>) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  client.setQueryData<Conversation[]>(conversationsQueryKey(ASSISTANT_ID), [
+    SLACK_ROW,
+  ]);
+  for (const [filter, rows] of sections) {
+    client.setQueryData(
+      sectionConversationsQueryKey(ASSISTANT_ID, filter),
+      rows,
+    );
+  }
+
+  const { result } = renderHook(
+    () =>
+      useConversationActions({
+        assistantId: ASSISTANT_ID,
+        activeConversationId: null,
+        conversations: [SLACK_ROW],
+        switchConversation: () => {},
+        startNewConversation: () => {},
+        prePinGroupIdsRef: { current: new Map() },
+      }),
+    {
+      wrapper: ({ children }: { children: ReactNode }) =>
+        createElement(QueryClientProvider, { client }, children),
+    },
+  );
+
+  return { result, client };
+}
+
+function idsIn(
+  client: QueryClient,
+  filter: SectionConversationFilter,
+): string[] {
+  return (
+    client
+      .getQueryData<
+        Conversation[]
+      >(sectionConversationsQueryKey(ASSISTANT_ID, filter))
+      ?.map((c) => c.conversationId) ?? []
+  );
+}
+
+function copies(client: QueryClient, conversationId: string): number {
+  return [PINNED, SLACK].reduce(
+    (total, filter) =>
+      total +
+      idsIn(client, filter).filter((id) => id === conversationId).length,
+    0,
+  );
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (err: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+beforeEach(() => {
+  reorderImpl = async () => ({ data: undefined, response: { ok: true } });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("pin/unpin placement", () => {
+  test("pinning moves the row before the request resolves", async () => {
+    const pending = deferred<{ data: undefined; response: { ok: boolean } }>();
+    reorderImpl = () => pending.promise;
+    const { result, client } = setup([
+      [SLACK, [SLACK_ROW]],
+      [PINNED, []],
+    ]);
+
+    await act(async () => {
+      result.current.handleTogglePinConversation(SLACK_ROW);
+    });
+
+    // Still in flight: this is the whole point, the sidebar must already be
+    // correct rather than correct-once-two-refetches-land.
+    expect(idsIn(client, PINNED)).toEqual(["c1"]);
+    expect(idsIn(client, SLACK)).toEqual([]);
+    expect(copies(client, "c1")).toBe(1);
+
+    await act(async () => {
+      pending.resolve({ data: undefined, response: { ok: true } });
+    });
+  });
+
+  test("a failed pin puts the row back in the section it left", async () => {
+    reorderImpl = async () => {
+      throw new Error("nope");
+    };
+    const { result, client } = setup([
+      [SLACK, [SLACK_ROW]],
+      [PINNED, []],
+    ]);
+
+    await act(async () => {
+      result.current.handleTogglePinConversation(SLACK_ROW);
+    });
+
+    await waitFor(() => {
+      expect(idsIn(client, SLACK)).toEqual(["c1"]);
+    });
+    expect(idsIn(client, PINNED)).toEqual([]);
+    expect(copies(client, "c1")).toBe(1);
+  });
+
+  test("unpinning returns the row to its channel section", async () => {
+    const pinnedRow: Conversation = {
+      ...SLACK_ROW,
+      isPinned: true,
+      groupId: "system:pinned",
+    };
+    const { result, client } = setup([
+      [SLACK, []],
+      [PINNED, [pinnedRow]],
+    ]);
+
+    await act(async () => {
+      result.current.handleTogglePinConversation(pinnedRow);
+    });
+
+    expect(idsIn(client, SLACK)).toEqual(["c1"]);
+    expect(idsIn(client, PINNED)).toEqual([]);
+    expect(copies(client, "c1")).toBe(1);
+  });
+
+  test("settling does not invalidate the foreground list", async () => {
+    /* The foreground list drains every page serially, so invalidating it on
+       a pin re-reads the whole sidebar to learn one row's group. Nothing
+       about it is stale: the optimistic write already patched the row in
+       place, and the sidebar still reads it to decide which sections exist. */
+    const { result, client } = setup([
+      [SLACK, [SLACK_ROW]],
+      [PINNED, []],
+    ]);
+
+    await act(async () => {
+      result.current.handleTogglePinConversation(SLACK_ROW);
+    });
+
+    await waitFor(() => {
+      expect(
+        client.getQueryState(sectionConversationsQueryKey(ASSISTANT_ID, PINNED))
+          ?.isInvalidated,
+      ).toBe(true);
+    });
+    expect(
+      client.getQueryState(conversationsQueryKey(ASSISTANT_ID))?.isInvalidated,
+    ).toBe(false);
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-conversation-actions-placement.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-actions-placement.test.tsx
@@ -245,6 +245,109 @@ describe("pin/unpin placement", () => {
     expect(copies(client, "c1")).toBe(1);
   });
 
+  test("a settled move does not free its ownership claim for reuse", async () => {
+    /* A owns a token, B takes a newer one and settles first. If the next
+       token were derived from what the conversation currently holds rather
+       than from a counter that only increases, C would reissue A's token and
+       A's failure would then pass its ownership check against C's write. */
+    const a = deferred<{ data: undefined; response: { ok: boolean } }>();
+    let call = 0;
+    reorderImpl = () => {
+      call += 1;
+      return call === 1
+        ? a.promise
+        : Promise.resolve({ data: undefined, response: { ok: true } });
+    };
+
+    const { result, client } = setup([
+      [SLACK, [SLACK_ROW]],
+      [PINNED, []],
+    ]);
+
+    // A: pin, left in flight.
+    await act(async () => {
+      result.current.handleTogglePinConversation(SLACK_ROW);
+    });
+    const pinnedRow: Conversation = {
+      ...SLACK_ROW,
+      isPinned: true,
+      groupId: "system:pinned",
+    };
+
+    // B: unpin, settles immediately and releases the conversation's entry.
+    await act(async () => {
+      result.current.handleTogglePinConversation(pinnedRow);
+    });
+    await waitFor(() => {
+      expect(idsIn(client, SLACK)).toEqual(["c1"]);
+    });
+
+    // C: pin again, on a freshly empty entry.
+    await act(async () => {
+      result.current.handleTogglePinConversation(SLACK_ROW);
+    });
+    expect(idsIn(client, PINNED)).toEqual(["c1"]);
+
+    // A finally fails. It must not undo C.
+    await act(async () => {
+      a.reject(new Error("nope"));
+      await a.promise.catch(() => {});
+    });
+
+    await waitFor(() => {
+      expect(idsIn(client, PINNED)).toEqual(["c1"]);
+    });
+    expect(idsIn(client, SLACK)).toEqual([]);
+    expect(copies(client, "c1")).toBe(1);
+  });
+
+  test("an older move does not refetch while a newer one is in flight", async () => {
+    /* A refetch started by a superseded move brings back server state the
+       newer move has not been applied to yet, and it lands on top of the
+       newer optimistic write: the cancel that guards an optimistic write runs
+       when that write is made, so it cannot reach a request started later. */
+    const b = deferred<{ data: undefined; response: { ok: boolean } }>();
+    let call = 0;
+    reorderImpl = () => {
+      call += 1;
+      return call === 1
+        ? Promise.resolve({ data: undefined, response: { ok: true } })
+        : b.promise;
+    };
+
+    const { result, client } = setup([
+      [SLACK, [SLACK_ROW]],
+      [PINNED, []],
+    ]);
+    const pinnedKey = sectionConversationsQueryKey(ASSISTANT_ID, PINNED);
+
+    // A: pin. Its request resolves, but B starts before A settles.
+    await act(async () => {
+      result.current.handleTogglePinConversation(SLACK_ROW);
+      result.current.handleTogglePinConversation({
+        ...SLACK_ROW,
+        isPinned: true,
+        groupId: "system:pinned",
+      });
+    });
+
+    // A has settled and B is still pending: nothing is invalidated yet,
+    // because only the latest placement reconciles.
+    expect(client.getQueryState(pinnedKey)?.isInvalidated).toBe(false);
+
+    await act(async () => {
+      b.resolve({ data: undefined, response: { ok: true } });
+      await b.promise;
+    });
+
+    // Once B settles it reconciles, covering the sections A touched too.
+    await waitFor(() => {
+      expect(client.getQueryState(pinnedKey)?.isInvalidated).toBe(true);
+    });
+    expect(idsIn(client, SLACK)).toEqual(["c1"]);
+    expect(copies(client, "c1")).toBe(1);
+  });
+
   test("unpinning returns the row to its channel section", async () => {
     const pinnedRow: Conversation = {
       ...SLACK_ROW,

--- a/clients/web/src/domains/chat/hooks/use-conversation-actions-placement.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-actions-placement.test.tsx
@@ -1,19 +1,18 @@
 /**
  * Tests for pin/unpin as a *placement*: the section caches, not the fields.
  *
- * **The bug these tests guard against.** Every sidebar section fetches its own
- * rows through a server filter (LUM-2443), so a section's membership is the
- * contents of its cache entry rather than something the client derives.
- * Pinning used to rewrite `isPinned` / `groupId` on the row and stop there, so
- * no cache moved it: the row appeared in Pinned only once Pinned's refetch
- * landed, and stayed in the section it came from until *that* section's
- * refetch landed. Those are separate requests of very different cost, which is
- * why the row was visibly in two sections at once in between.
+ * Every sidebar section fetches its own rows through a server filter
+ * (LUM-2443), so a section's membership is the contents of its cache entry
+ * rather than something the client derives. Two invariants follow, and these
+ * are what the assertions are shaped around:
  *
- * The assertions count copies across every seeded section rather than checking
- * the destination, because the old behavior satisfies "Pinned contains the
- * row" perfectly well. What it violates is "a conversation appears in exactly
- * one section, never twice".
+ * 1. A conversation appears in exactly one section, never twice. Counting
+ *    copies across every seeded section is the only assertion that catches a
+ *    row which reaches its destination without leaving its origin; "Pinned
+ *    contains the row" holds either way.
+ * 2. The move lands before the request resolves. A placement that waits on the
+ *    network shows the row in two sections for the length of the round trip,
+ *    since each section corrects itself on its own refetch.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";

--- a/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
@@ -61,9 +61,9 @@ type MoveToGroupVars = {
 type MutationContext = { snapshot: ConversationCacheSnapshot };
 
 /**
- * Context for the mutations that move a row between sections. No snapshot:
- * they roll back by writing the previous field values, which re-derives
- * membership through the same path the optimistic write used.
+ * Context for a move between sections. No snapshot: it rolls back by writing
+ * the previous field values, which re-derives membership through the same
+ * path the optimistic write used.
  *
  * `sectionKeys` is what the optimistic write actually moved, so the settle
  * refetches those sections instead of the whole conversation-list prefix.
@@ -180,10 +180,6 @@ export function useConversationActions({
   // patch cannot reach.
   // -------------------------------------------------------------------------
 
-  /* Archive and unarchive are one shape twice: both write `archivedAt`, which
-     is a field every section filter reads, so both are placements. The row
-     leaves every section on archive and rejoins the one that claims it on
-     unarchive, without either path naming a section. */
   const archiveMutation = useMutation<void, Error, ArchiveVars>({
     mutationFn: async ({ assistantId: aid, conversationId }) => {
       await conversationsByIdArchivePost({
@@ -320,11 +316,6 @@ export function useConversationActions({
       isPinned,
     }) => {
       await cancelConversationQueries(queryClient, aid);
-      /* The whole move, in one write. `patchConversation` puts the row in
-         whichever sections the new `groupId` / `isPinned` place it and takes
-         it out of the ones they do not, so Pinned and the section the row
-         came from both repaint on this render rather than on their next
-         refetch. */
       const sectionKeys = patchConversation(queryClient, aid, conversationId, {
         isPinned,
         groupId,

--- a/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
@@ -1,5 +1,9 @@
 import { type MutableRefObject, useCallback } from "react";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQueryClient,
+  type QueryClient,
+} from "@tanstack/react-query";
 
 import {
   cancelConversationQueries,
@@ -11,6 +15,7 @@ import {
   type ConversationCacheSnapshot,
 } from "@/utils/conversation-cache";
 import { adjustUnreadCountCache } from "@/utils/conversation-cache-mutations";
+import { sectionListPrefix } from "@/utils/conversation-list-fetchers";
 import { contributesToUnreadCount } from "@/utils/conversation-predicates";
 import { executeBulkWithFallback } from "@/utils/bulk-with-fallback";
 import {
@@ -37,8 +42,12 @@ import { useMarkConversationSeenMutation } from "@/domains/chat/hooks/use-mark-c
 // Mutation variable types
 // ---------------------------------------------------------------------------
 
-type ArchiveVars = { assistantId: string; conversationId: string };
-type UnarchiveVars = { assistantId: string; conversationId: string };
+type ArchiveVars = {
+  assistantId: string;
+  conversationId: string;
+  previousArchivedAt: number | undefined;
+};
+type UnarchiveVars = ArchiveVars;
 type MarkUnreadVars = { assistantId: string; conversationId: string };
 type MoveToGroupVars = {
   assistantId: string;
@@ -50,6 +59,16 @@ type MoveToGroupVars = {
 };
 
 type MutationContext = { snapshot: ConversationCacheSnapshot };
+
+/**
+ * Context for the mutations that move a row between sections. No snapshot:
+ * they roll back by writing the previous field values, which re-derives
+ * membership through the same path the optimistic write used.
+ *
+ * `sectionKeys` is what the optimistic write actually moved, so the settle
+ * refetches those sections instead of the whole conversation-list prefix.
+ */
+type PlacementContext = { sectionKeys: readonly (readonly unknown[])[] };
 
 /**
  * Context for the mark-unread mutation, which additionally applies an
@@ -68,22 +87,64 @@ type MarkUnreadContext = MutationContext & { unreadCountDelta: number };
 // ---------------------------------------------------------------------------
 
 /**
+ * Reconcile the sections an optimistic placement moved a row between.
+ *
+ * Scoped to those sections rather than the conversation-list prefix. The
+ * prefix reaches every mounted section *and* the foreground list, and each of
+ * those refetches by draining its pages serially, so invalidating it made a
+ * pin cost a full re-read of the sidebar. Nothing else about the row changed:
+ * a move rewrites `groupId` / `isPinned` and the optimistic write already put
+ * the row where those values say it goes.
+ *
+ * Falls back to the whole section prefix when the write moved nothing, which
+ * is the case where the client's idea of the sections is least trustworthy.
+ *
+ * Returned, not fired and forgotten, so the mutation stays pending until the
+ * refetch finishes. TanStack is explicit about this, and it is what makes
+ * `isPending` mean "this action is still settling" for anything watching.
+ *
+ * @see {@link https://tanstack.com/query/latest/docs/framework/react/guides/optimistic-updates}
+ */
+function reconcilePlacement(
+  queryClient: QueryClient,
+  assistantId: string,
+  sectionKeys: readonly (readonly unknown[])[] | undefined,
+): Promise<unknown> {
+  if (!sectionKeys?.length) {
+    return queryClient.invalidateQueries({
+      queryKey: sectionListPrefix(assistantId),
+    });
+  }
+  return Promise.all(
+    sectionKeys.map((queryKey) => queryClient.invalidateQueries({ queryKey })),
+  );
+}
+
+/**
  * Conversation CRUD actions: archive, unarchive, rename, mark read/unread,
  * pin/unpin, and move between groups.
  *
  * Single-item mutations use `useMutation` with the TanStack-recommended
  * optimistic update lifecycle (`onMutate` → `onError` → `onSettled`):
  *   1. Cancel outgoing refetches
- *   2. Snapshot the cache
- *   3. Apply the optimistic update
- *   4. On error: restore the snapshot
- *   5. On settle: invalidate so TanStack refetches
+ *   2. Apply the optimistic update
+ *   3. On error: put the changed fields back
+ *   4. On settle: invalidate so TanStack refetches
+ *
+ * **Rollback is by field, never by snapshot, for anything that can run
+ * concurrently.** Restoring a whole-cache snapshot taken before mutation A
+ * also discards mutation B's successful optimistic write, and pinning two
+ * conversations in quick succession is exactly that case. Writing the previous
+ * field values back leaves every other row alone, and because section
+ * membership is derived from those fields inside `patchConversation`, undoing
+ * the fields undoes the move for free.
  *
  * Batch mutations (archive-all, mark-all-read) follow the same lifecycle
  * manually with per-item rollback.
  *
  * References:
  * - https://tanstack.com/query/latest/docs/framework/react/guides/optimistic-updates
+ * - https://tkdodo.eu/blog/concurrent-optimistic-updates-in-react-query
  *
  * @returns Stable callbacks for each conversation action.
  */
@@ -107,20 +168,23 @@ export function useConversationActions({
   const queryClient = useQueryClient();
 
   // -------------------------------------------------------------------------
-  // Mutations — TanStack-recommended onMutate / onError / onSettled lifecycle
+  // Mutations. TanStack-recommended onMutate / onError / onSettled lifecycle:
   //
-  // Each mutation:
-  //   onMutate  → cancelQueries, snapshot, optimistic setQueryData
-  //   onError   → restore snapshot, captureError
-  //   onSettled → invalidateQueries (refetch from server)
+  //   onMutate  -> cancelQueries, then the optimistic setQueryData
+  //   onError   -> put back what this mutation changed, captureError
+  //   onSettled -> invalidateQueries (refetch from server)
+  //
+  // "Put back what this mutation changed" is the field patch for a placement
+  // and the inverse delta for the unread count. Only mark-unread still keeps a
+  // whole-cache snapshot, because its optimistic write spans a cache the field
+  // patch cannot reach.
   // -------------------------------------------------------------------------
 
-  const archiveMutation = useMutation<
-    void,
-    Error,
-    ArchiveVars,
-    MutationContext
-  >({
+  /* Archive and unarchive are one shape twice: both write `archivedAt`, which
+     is a field every section filter reads, so both are placements. The row
+     leaves every section on archive and rejoins the one that claims it on
+     unarchive, without either path naming a section. */
+  const archiveMutation = useMutation<void, Error, ArchiveVars>({
     mutationFn: async ({ assistantId: aid, conversationId }) => {
       await conversationsByIdArchivePost({
         path: { assistant_id: aid, id: conversationId },
@@ -129,29 +193,27 @@ export function useConversationActions({
     },
     onMutate: async ({ assistantId: aid, conversationId }) => {
       await cancelConversationQueries(queryClient, aid);
-      const snapshot = snapshotConversationCaches(queryClient, aid);
       patchConversation(queryClient, aid, conversationId, {
         archivedAt: Date.now(),
       });
-      return { snapshot };
     },
-    onError: (err, _vars, context) => {
-      if (context?.snapshot) {
-        restoreConversationCaches(queryClient, context.snapshot);
-      }
+    onError: (
+      err,
+      { assistantId: aid, conversationId, previousArchivedAt },
+    ) => {
+      patchConversation(queryClient, aid, conversationId, {
+        archivedAt: previousArchivedAt,
+      });
       captureError(err, { context: "archiveConversation" });
     },
-    onSettled: (_data, _err, { assistantId: aid }) => {
-      void invalidateConversationQueries(queryClient, aid);
-    },
+    /* Still the full prefix, unlike a move: archiving takes the row out of the
+       foreground list and puts it in the archived one, so two caches outside
+       the sections change owners and the client does not write either. */
+    onSettled: (_data, _err, { assistantId: aid }) =>
+      invalidateConversationQueries(queryClient, aid),
   });
 
-  const unarchiveMutation = useMutation<
-    void,
-    Error,
-    UnarchiveVars,
-    MutationContext
-  >({
+  const unarchiveMutation = useMutation<void, Error, UnarchiveVars>({
     mutationFn: async ({ assistantId: aid, conversationId }) => {
       await conversationsByIdUnarchivePost({
         path: { assistant_id: aid, id: conversationId },
@@ -160,21 +222,21 @@ export function useConversationActions({
     },
     onMutate: async ({ assistantId: aid, conversationId }) => {
       await cancelConversationQueries(queryClient, aid);
-      const snapshot = snapshotConversationCaches(queryClient, aid);
       patchConversation(queryClient, aid, conversationId, {
         archivedAt: undefined,
       });
-      return { snapshot };
     },
-    onError: (err, _vars, context) => {
-      if (context?.snapshot) {
-        restoreConversationCaches(queryClient, context.snapshot);
-      }
+    onError: (
+      err,
+      { assistantId: aid, conversationId, previousArchivedAt },
+    ) => {
+      patchConversation(queryClient, aid, conversationId, {
+        archivedAt: previousArchivedAt,
+      });
       captureError(err, { context: "unarchiveConversation" });
     },
-    onSettled: (_data, _err, { assistantId: aid }) => {
-      void invalidateConversationQueries(queryClient, aid);
-    },
+    onSettled: (_data, _err, { assistantId: aid }) =>
+      invalidateConversationQueries(queryClient, aid),
   });
 
   // Shared with the mark-seen-on-open effect so both entry points produce
@@ -235,7 +297,7 @@ export function useConversationActions({
     void,
     Error,
     MoveToGroupVars,
-    MutationContext
+    PlacementContext
   >({
     mutationFn: async ({
       assistantId: aid,
@@ -258,30 +320,43 @@ export function useConversationActions({
       isPinned,
     }) => {
       await cancelConversationQueries(queryClient, aid);
-      const snapshot = snapshotConversationCaches(queryClient, aid);
-      patchConversation(queryClient, aid, conversationId, {
+      /* The whole move, in one write. `patchConversation` puts the row in
+         whichever sections the new `groupId` / `isPinned` place it and takes
+         it out of the ones they do not, so Pinned and the section the row
+         came from both repaint on this render rather than on their next
+         refetch. */
+      const sectionKeys = patchConversation(queryClient, aid, conversationId, {
         isPinned,
         groupId,
       });
-      return { snapshot };
+      return { sectionKeys };
     },
     onSuccess: (_data, { conversationId, isPinned }) => {
       if (!isPinned) {
         prePinGroupIdsRef.current.delete(conversationId);
       }
     },
-    onError: (err, { conversationId, isPinned }, context) => {
-      if (context?.snapshot) {
-        restoreConversationCaches(queryClient, context.snapshot);
-      }
+    onError: (
+      err,
+      {
+        assistantId: aid,
+        conversationId,
+        isPinned,
+        previousIsPinned,
+        previousGroupId,
+      },
+    ) => {
+      patchConversation(queryClient, aid, conversationId, {
+        isPinned: previousIsPinned,
+        groupId: previousGroupId,
+      });
       if (isPinned) {
         prePinGroupIdsRef.current.delete(conversationId);
       }
       captureError(err, { context: "moveToGroup" });
     },
-    onSettled: (_data, _err, { assistantId: aid }) => {
-      void invalidateConversationQueries(queryClient, aid);
-    },
+    onSettled: (_data, _err, { assistantId: aid }, context) =>
+      reconcilePlacement(queryClient, aid, context?.sectionKeys),
   });
 
   // -------------------------------------------------------------------------
@@ -311,6 +386,7 @@ export function useConversationActions({
       archiveMutation.mutate({
         assistantId,
         conversationId: conversation.conversationId,
+        previousArchivedAt: conversation.archivedAt,
       });
     },
     [
@@ -331,6 +407,7 @@ export function useConversationActions({
       unarchiveMutation.mutate({
         assistantId,
         conversationId: conversation.conversationId,
+        previousArchivedAt: conversation.archivedAt,
       });
     },
     [assistantId, unarchiveMutation],

--- a/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
@@ -34,6 +34,7 @@ import type { Conversation } from "@/types/conversation-types";
 import { useRenameRequestStore } from "@/domains/chat/rename-request-store";
 import {
   findNextConversationId,
+  resolvePlacementSurfacedAt,
   resolveUnpinGroupId,
 } from "@/domains/chat/hooks/conversation-action-utils";
 import { useMarkConversationSeenMutation } from "@/domains/chat/hooks/use-mark-conversation-seen-mutation";
@@ -54,8 +55,16 @@ type MoveToGroupVars = {
   conversationId: string;
   groupId: string;
   isPinned: boolean;
+  /**
+   * The promotion marker the placement leaves behind. Carried as a variable
+   * rather than derived in `onMutate` so the optimistic write and its rollback
+   * read the same value, and so the timestamp is stamped once instead of
+   * being re-taken on a retry.
+   */
+  surfacedAt: number | undefined;
   previousIsPinned: boolean;
   previousGroupId: string | undefined;
+  previousSurfacedAt: number | undefined;
 };
 
 type MutationContext = { snapshot: ConversationCacheSnapshot };
@@ -87,17 +96,17 @@ type MarkUnreadContext = MutationContext & { unreadCountDelta: number };
 // ---------------------------------------------------------------------------
 
 /**
- * Reconcile the sections an optimistic placement moved a row between.
+ * Refetch the sections an optimistic placement could not settle on its own.
  *
  * Scoped to those sections rather than the conversation-list prefix. The
- * prefix reaches every mounted section *and* the foreground list, and each of
- * those refetches by draining its pages serially, so invalidating it made a
- * pin cost a full re-read of the sidebar. Nothing else about the row changed:
- * a move rewrites `groupId` / `isPinned` and the optimistic write already put
- * the row where those values say it goes.
+ * prefix reaches every mounted section *and* the foreground list, each of
+ * which refetches by draining its pages serially, so invalidating it costs a
+ * full re-read of the sidebar to learn one row's group. A move rewrites
+ * `groupId` / `isPinned` / `surfacedAt` and nothing else, and the optimistic
+ * write has already put the row where those values say it goes.
  *
- * Falls back to the whole section prefix when the write moved nothing, which
- * is the case where the client's idea of the sections is least trustworthy.
+ * Falls back to the whole section prefix when the write reports nothing, the
+ * case where the client's idea of the sections is least trustworthy.
  *
  * Returned, not fired and forgotten, so the mutation stays pending until the
  * refetch finishes. TanStack is explicit about this, and it is what makes
@@ -314,11 +323,13 @@ export function useConversationActions({
       conversationId,
       groupId,
       isPinned,
+      surfacedAt,
     }) => {
       await cancelConversationQueries(queryClient, aid);
       const sectionKeys = patchConversation(queryClient, aid, conversationId, {
         isPinned,
         groupId,
+        surfacedAt,
       });
       return { sectionKeys };
     },
@@ -335,11 +346,13 @@ export function useConversationActions({
         isPinned,
         previousIsPinned,
         previousGroupId,
+        previousSurfacedAt,
       },
     ) => {
       patchConversation(queryClient, aid, conversationId, {
         isPinned: previousIsPinned,
         groupId: previousGroupId,
+        surfacedAt: previousSurfacedAt,
       });
       if (isPinned) {
         prePinGroupIdsRef.current.delete(conversationId);
@@ -448,6 +461,7 @@ export function useConversationActions({
 
       const previousIsPinned = conversation.isPinned ?? false;
       const previousGroupId = conversation.groupId;
+      const previousSurfacedAt = conversation.surfacedAt;
       const isPinned = groupId === "system:pinned";
 
       if (isPinned) {
@@ -462,8 +476,14 @@ export function useConversationActions({
         conversationId: conversation.conversationId,
         groupId,
         isPinned,
+        surfacedAt: resolvePlacementSurfacedAt(
+          conversation,
+          groupId,
+          Date.now(),
+        ),
         previousIsPinned,
         previousGroupId,
+        previousSurfacedAt,
       });
     },
     [assistantId, prePinGroupIdsRef, moveToGroupMutation],

--- a/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
@@ -1,4 +1,4 @@
-import { type MutableRefObject, useCallback } from "react";
+import { type MutableRefObject, useCallback, useRef } from "react";
 import {
   useMutation,
   useQueryClient,
@@ -76,8 +76,18 @@ type MutationContext = { snapshot: ConversationCacheSnapshot };
  *
  * `sectionKeys` is what the optimistic write actually moved, so the settle
  * refetches those sections instead of the whole conversation-list prefix.
+ *
+ * `token` identifies this mutation's optimistic write among the writes to the
+ * same conversation. Writing the previous values back is only correct while
+ * this write is still the one showing: two moves of one conversation overlap
+ * whenever the second is started before the first settles, and an
+ * unconditional rollback of the first would discard the second's placement and
+ * leave the row in a section the user has already moved it out of.
  */
-type PlacementContext = { sectionKeys: readonly (readonly unknown[])[] };
+type PlacementContext = {
+  sectionKeys: readonly (readonly unknown[])[];
+  token: number;
+};
 
 /**
  * Context for the mark-unread mutation, which additionally applies an
@@ -148,6 +158,12 @@ function reconcilePlacement(
  * membership is derived from those fields inside `patchConversation`, undoing
  * the fields undoes the move for free.
  *
+ * That covers overlapping moves of *different* conversations. Overlapping
+ * moves of the *same* conversation need one thing more, because both write the
+ * same fields: a failing move rolls back only while its own write is still the
+ * one showing (`PlacementContext.token`). Otherwise the user's newer placement
+ * would be replaced by whatever preceded the older, failed one.
+ *
  * Batch mutations (archive-all, mark-all-read) follow the same lifecycle
  * manually with per-item rollback.
  *
@@ -175,6 +191,12 @@ export function useConversationActions({
   prePinGroupIdsRef,
 }: UseConversationActionsParams) {
   const queryClient = useQueryClient();
+
+  /* Latest optimistic placement per conversation, so a failed move can tell
+     whether its own write is still the one showing before undoing it. A ref
+     rather than a store: nothing renders from it, and it is read and written
+     inside one mutation's lifecycle. */
+  const placementTokensRef = useRef(new Map<string, number>());
 
   // -------------------------------------------------------------------------
   // Mutations. TanStack-recommended onMutate / onError / onSettled lifecycle:
@@ -326,12 +348,18 @@ export function useConversationActions({
       surfacedAt,
     }) => {
       await cancelConversationQueries(queryClient, aid);
+      /* Claimed immediately before the write, not when `mutate` was called:
+         `onMutate` awaits, so two overlapping moves resume in whatever order
+         their cancellations settle, and the token has to order the writes as
+         they actually land. */
+      const token = (placementTokensRef.current.get(conversationId) ?? 0) + 1;
+      placementTokensRef.current.set(conversationId, token);
       const sectionKeys = patchConversation(queryClient, aid, conversationId, {
         isPinned,
         groupId,
         surfacedAt,
       });
-      return { sectionKeys };
+      return { sectionKeys, token };
     },
     onSuccess: (_data, { conversationId, isPinned }) => {
       if (!isPinned) {
@@ -348,19 +376,32 @@ export function useConversationActions({
         previousGroupId,
         previousSurfacedAt,
       },
+      context,
     ) => {
-      patchConversation(queryClient, aid, conversationId, {
-        isPinned: previousIsPinned,
-        groupId: previousGroupId,
-        surfacedAt: previousSurfacedAt,
-      });
+      /* Only the latest write may undo itself. A move superseded by another
+         move of the same conversation leaves the newer placement alone: the
+         user has already moved the row somewhere else, and restoring what came
+         before this failure would put it back in a section they left. The
+         newer mutation owns the correction from here, and its settle refetch
+         is the backstop if it fails too. */
+      if (placementTokensRef.current.get(conversationId) === context?.token) {
+        patchConversation(queryClient, aid, conversationId, {
+          isPinned: previousIsPinned,
+          groupId: previousGroupId,
+          surfacedAt: previousSurfacedAt,
+        });
+      }
       if (isPinned) {
         prePinGroupIdsRef.current.delete(conversationId);
       }
       captureError(err, { context: "moveToGroup" });
     },
-    onSettled: (_data, _err, { assistantId: aid }, context) =>
-      reconcilePlacement(queryClient, aid, context?.sectionKeys),
+    onSettled: (_data, _err, { assistantId: aid, conversationId }, context) => {
+      if (placementTokensRef.current.get(conversationId) === context?.token) {
+        placementTokensRef.current.delete(conversationId);
+      }
+      return reconcilePlacement(queryClient, aid, context?.sectionKeys);
+    },
   });
 
   // -------------------------------------------------------------------------

--- a/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
@@ -74,20 +74,19 @@ type MutationContext = { snapshot: ConversationCacheSnapshot };
  * the previous field values, which re-derives membership through the same
  * path the optimistic write used.
  *
- * `sectionKeys` is what the optimistic write actually moved, so the settle
- * refetches those sections instead of the whole conversation-list prefix.
- *
  * `token` identifies this mutation's optimistic write among the writes to the
- * same conversation. Writing the previous values back is only correct while
- * this write is still the one showing: two moves of one conversation overlap
- * whenever the second is started before the first settles, and an
- * unconditional rollback of the first would discard the second's placement and
- * leave the row in a section the user has already moved it out of.
+ * same conversation, and both the rollback and the settle refetch are gated on
+ * it still being the current one. Two moves of one conversation overlap
+ * whenever the second starts before the first settles, and either action taken
+ * by the older move lands on top of the newer placement: a rollback restores
+ * what preceded the older move, and a refetch brings back server state the
+ * newer move has not reached yet.
+ *
+ * The section keys live in the hook's placement record rather than here,
+ * because the move that ends up reconciling has to refetch what its
+ * predecessors touched as well as its own.
  */
-type PlacementContext = {
-  sectionKeys: readonly (readonly unknown[])[];
-  token: number;
-};
+type PlacementContext = { token: number };
 
 /**
  * Context for the mark-unread mutation, which additionally applies an
@@ -192,11 +191,27 @@ export function useConversationActions({
 }: UseConversationActionsParams) {
   const queryClient = useQueryClient();
 
-  /* Latest optimistic placement per conversation, so a failed move can tell
-     whether its own write is still the one showing before undoing it. A ref
+  /* The latest optimistic placement of each conversation, so a move that
+     settles can tell whether its own write is still the one showing. A ref
      rather than a store: nothing renders from it, and it is read and written
-     inside one mutation's lifecycle. */
-  const placementTokensRef = useRef(new Map<string, number>());
+     inside the mutation lifecycle.
+
+     Tokens come from one counter that only ever increases, and never from the
+     map's current value. Deriving the next token from the entry would let a
+     conversation whose entry was cleaned up reissue a token an older in-flight
+     move still holds, and that move's ownership check would then pass against
+     someone else's write.
+
+     Each entry also carries the section keys of every placement folded into
+     it, so the move that ends up owning the reconciliation refetches the
+     sections its predecessors touched as well as its own. */
+  const placementTokenRef = useRef(0);
+  const placementsRef = useRef(
+    new Map<
+      string,
+      { token: number; sectionKeys: Map<string, readonly unknown[]> }
+    >(),
+  );
 
   // -------------------------------------------------------------------------
   // Mutations. TanStack-recommended onMutate / onError / onSettled lifecycle:
@@ -352,14 +367,23 @@ export function useConversationActions({
          `onMutate` awaits, so two overlapping moves resume in whatever order
          their cancellations settle, and the token has to order the writes as
          they actually land. */
-      const token = (placementTokensRef.current.get(conversationId) ?? 0) + 1;
-      placementTokensRef.current.set(conversationId, token);
+      const token = ++placementTokenRef.current;
       const sectionKeys = patchConversation(queryClient, aid, conversationId, {
         isPinned,
         groupId,
         surfacedAt,
       });
-      return { sectionKeys, token };
+      const inherited =
+        placementsRef.current.get(conversationId)?.sectionKeys ??
+        new Map<string, readonly unknown[]>();
+      for (const queryKey of sectionKeys) {
+        inherited.set(JSON.stringify(queryKey), queryKey);
+      }
+      placementsRef.current.set(conversationId, {
+        token,
+        sectionKeys: inherited,
+      });
+      return { token };
     },
     onSuccess: (_data, { conversationId, isPinned }) => {
       if (!isPinned) {
@@ -384,7 +408,7 @@ export function useConversationActions({
          before this failure would put it back in a section they left. The
          newer mutation owns the correction from here, and its settle refetch
          is the backstop if it fails too. */
-      if (placementTokensRef.current.get(conversationId) === context?.token) {
+      if (placementsRef.current.get(conversationId)?.token === context?.token) {
         patchConversation(queryClient, aid, conversationId, {
           isPinned: previousIsPinned,
           groupId: previousGroupId,
@@ -396,11 +420,30 @@ export function useConversationActions({
       }
       captureError(err, { context: "moveToGroup" });
     },
+    /* Refetching is the latest placement's job too, for the same reason the
+       rollback is. A superseded move that invalidated its own sections would
+       refetch state the server has not applied the newer move to yet, and that
+       response would land on top of the newer optimistic write: the cancel
+       that protects an optimistic write runs when that write is made, so it
+       cannot reach a refetch an older move starts afterwards. The owner
+       refetches the accumulated sections, so nothing a superseded move touched
+       goes unreconciled. */
     onSettled: (_data, _err, { assistantId: aid, conversationId }, context) => {
-      if (placementTokensRef.current.get(conversationId) === context?.token) {
-        placementTokensRef.current.delete(conversationId);
+      if (!context) {
+        /* `onMutate` did not finish, so there is no optimistic write to own
+           and nothing accumulated to refetch. The request may still have
+           reached the server, so reconcile broadly rather than not at all. */
+        return reconcilePlacement(queryClient, aid, undefined);
       }
-      return reconcilePlacement(queryClient, aid, context?.sectionKeys);
+      const placement = placementsRef.current.get(conversationId);
+      if (placement?.token !== context.token) {
+        /* Superseded, or the owner has already settled and reconciled. */
+        return;
+      }
+      placementsRef.current.delete(conversationId);
+      return reconcilePlacement(queryClient, aid, [
+        ...placement.sectionKeys.values(),
+      ]);
     },
   });
 

--- a/clients/web/src/domains/chat/utils/group-conversations.ts
+++ b/clients/web/src/domains/chat/utils/group-conversations.ts
@@ -2,7 +2,12 @@ import type {
   Conversation,
   ConversationGroup,
 } from "@/types/conversation-types";
-import { isScheduledConversation } from "@/utils/conversation-predicates";
+import { compareByRecency } from "@/utils/conversation-order";
+import {
+  isConversationPinned,
+  isCustomGroupId,
+  isScheduledConversation,
+} from "@/utils/conversation-predicates";
 import { isChannelConversation } from "@/domains/chat/utils/conversation-channel";
 /**
  * Pure helper for splitting the sidebar's conversation list into system
@@ -69,17 +74,6 @@ export interface GroupedConversations {
   customGroups: CustomGroup[];
 }
 
-/**
- * True when a conversation is pinned, via either the modern `isPinned`
- * boolean or the legacy `groupId === "system:pinned"` marker. Some
- * conversations (especially older ones) only carry the legacy marker,
- * so checking `isPinned` alone misses them and shows the wrong
- * Pin/Unpin label in the actions menu.
- */
-export function isConversationPinned(c: Conversation): boolean {
-  return c.isPinned === true || c.groupId === "system:pinned";
-}
-
 function isBackground(c: Conversation): boolean {
   return (
     c.conversationType === "background" || c.groupId === "system:background"
@@ -100,35 +94,6 @@ function channelSectionBucketId(c: Conversation): string | null {
     return null;
   }
   return c.originChannel ?? null;
-}
-
-/**
- * Read the `lastMessageAt` epoch-ms timestamp for numeric comparison.
- * Missing values fall back to `0` so the caller's sort is stable.
- */
-function parseLastMessageAt(conversation: Conversation): number {
-  return conversation.lastMessageAt ?? 0;
-}
-
-/**
- * Recency order, newest first: the one order every section uses.
- *
- * No tiebreak. `Array.prototype.sort` is stable, so rows sharing a
- * `lastMessageAt` (or both missing one) keep the order they arrived in, which
- * is the server's. Adding an id tiebreak here would reorder them against it.
- */
-function compareByRecency(a: Conversation, b: Conversation): number {
-  return parseLastMessageAt(b) - parseLastMessageAt(a);
-}
-
-/**
- * True when a `groupId` refers to a non-system (custom) group.
- * System groups use a `"system:"` prefix (e.g. `"system:pinned"`).
- */
-export function isCustomGroupId(
-  groupId: string | undefined,
-): groupId is string {
-  return !!groupId && !groupId.startsWith("system:");
 }
 
 // ---------------------------------------------------------------------------

--- a/clients/web/src/utils/conversation-cache.ts
+++ b/clients/web/src/utils/conversation-cache.ts
@@ -329,11 +329,10 @@ export function getConversations(
  * is why the move happens here rather than in a companion helper the callers
  * are expected to also call. A section's contents are a server filter over
  * `groupId` / `isPinned` / `archivedAt` (LUM-2443), so a patch to one of those
- * fields *is* a membership change; leaving the two as separate steps is what
- * produced the bug this replaced, where pinning rewrote the row's fields and
- * no cache moved it, so the sidebar could only correct itself by refetching
- * every section. A caller that patches a field cannot forget the other half,
- * because there is no other half to call.
+ * fields *is* a membership change. Keeping them one operation means a caller
+ * that patches a field cannot forget the other half, because there is no other
+ * half to call; split apart, the row keeps its old section until a refetch
+ * removes it.
  *
  * Patches that touch no membership field (seen state, titles, processing
  * flags, and every bulk path built on them) skip the pass entirely.

--- a/clients/web/src/utils/conversation-cache.ts
+++ b/clients/web/src/utils/conversation-cache.ts
@@ -13,8 +13,12 @@
  *   when the user reveals the Scheduled sidebar section.
  * - **Archived** (`"archived"`) — archived conversations. Fetched
  *   lazily when the user opens the archive view.
- * - **Channel** (`"channel", channelId`) — origin-channel conversations
- *   (Slack, Telegram, etc.). Each channel section mounts its own cache.
+ * - **Section** (`"section", groupId, originChannel`): one sidebar section's
+ *   rows, fetched through the server filter that defines the section. Pinned,
+ *   each custom group, each channel, and Chats each key their own entry.
+ *   Membership here is the server's answer, not a client-side filter, so a
+ *   local change to the fields that filter reads has to move the row between
+ *   these caches. See `utils/section-membership.ts`.
  *
  * A conversation lives in exactly one cache, so the cross-cache helpers
  * (`findConversation`, `getConversations`, `patchConversation`,
@@ -38,6 +42,10 @@ import {
   scheduledConversationsQueryKey,
   unreadConversationCountQueryKey,
 } from "@/utils/conversation-list-fetchers";
+import {
+  patchAffectsMembership,
+  reconcileSectionMembership,
+} from "@/utils/section-membership";
 import type { Conversation } from "@/types/conversation-types";
 
 // ---------------------------------------------------------------------------
@@ -314,14 +322,32 @@ export function getConversations(
 
 /**
  * Immutably patch the conversation matching `key` in whichever cache holds
- * it, leaving all others untouched. No-op when no cache holds the key.
+ * it, and move it between section caches if the patch changed where it
+ * belongs. No-op when no cache holds the key.
+ *
+ * **Membership is not separable from the fields it is computed from**, which
+ * is why the move happens here rather than in a companion helper the callers
+ * are expected to also call. A section's contents are a server filter over
+ * `groupId` / `isPinned` / `archivedAt` (LUM-2443), so a patch to one of those
+ * fields *is* a membership change; leaving the two as separate steps is what
+ * produced the bug this replaced, where pinning rewrote the row's fields and
+ * no cache moved it, so the sidebar could only correct itself by refetching
+ * every section. A caller that patches a field cannot forget the other half,
+ * because there is no other half to call.
+ *
+ * Patches that touch no membership field (seen state, titles, processing
+ * flags, and every bulk path built on them) skip the pass entirely.
+ *
+ * Returns the section cache keys whose membership actually changed, so a
+ * mutation can reconcile exactly those rather than the whole list prefix.
+ * Empty for the overwhelmingly common case of a field-only patch.
  */
 export function patchConversation(
   queryClient: QueryClient,
   assistantId: string | null,
   key: string,
   patch: Partial<Conversation>,
-): void {
+): readonly (readonly unknown[])[] {
   updateAllConversationCaches(queryClient, assistantId, (conversations) => {
     let changed = false;
     const next = conversations.map((c) => {
@@ -333,4 +359,13 @@ export function patchConversation(
     });
     return changed ? next : conversations;
   });
+
+  if (!patchAffectsMembership(patch)) {
+    return [];
+  }
+  const patched = findConversation(queryClient, assistantId, key);
+  if (!patched) {
+    return [];
+  }
+  return reconcileSectionMembership(queryClient, assistantId, patched);
 }

--- a/clients/web/src/utils/conversation-cache.ts
+++ b/clients/web/src/utils/conversation-cache.ts
@@ -348,6 +348,12 @@ export function patchConversation(
   key: string,
   patch: Partial<Conversation>,
 ): readonly (readonly unknown[])[] {
+  // Built once and shared by every cache that holds the key, rather than
+  // looked up again afterwards. Sharing the instance is what lets the
+  // membership pass tell a cache that already agrees from one that needs
+  // rewriting, so sections the patch did not move are not re-rendered.
+  let patched: Conversation | undefined;
+
   updateAllConversationCaches(queryClient, assistantId, (conversations) => {
     let changed = false;
     const next = conversations.map((c) => {
@@ -355,16 +361,13 @@ export function patchConversation(
         return c;
       }
       changed = true;
-      return { ...c, ...patch };
+      patched ??= { ...c, ...patch };
+      return patched;
     });
     return changed ? next : conversations;
   });
 
-  if (!patchAffectsMembership(patch)) {
-    return [];
-  }
-  const patched = findConversation(queryClient, assistantId, key);
-  if (!patched) {
+  if (!patched || !patchAffectsMembership(patch)) {
     return [];
   }
   return reconcileSectionMembership(queryClient, assistantId, patched);

--- a/clients/web/src/utils/conversation-list-fetchers.ts
+++ b/clients/web/src/utils/conversation-list-fetchers.ts
@@ -31,6 +31,7 @@ import { recordDiagnostic } from "@/lib/diagnostics";
 import { emitClientPerfEvent } from "@/lib/telemetry/client-perf";
 import type { Conversation } from "@/types/conversation-types";
 import { readContentLength } from "@/utils/content-length";
+import { byTimestampDesc } from "@/utils/conversation-order";
 import { isScheduledConversation } from "@/utils/conversation-predicates";
 import { toConversation } from "@/utils/conversation-transforms";
 
@@ -95,6 +96,41 @@ export function sectionConversationsQueryKey(
 }
 
 /**
+ * Recover the filter a section cache was keyed by, or `null` when the key
+ * is not a section key.
+ *
+ * The decoder to {@link sectionConversationsQueryKey}'s encoder, and it lives
+ * beside it so the two cannot drift. It exists because a local write has to
+ * answer "does this row belong in *this* cache", and the only statement of
+ * what a cache holds is its own key: TanStack's `setQueriesData` hands its
+ * updater the data alone, never the key it came from, so a membership-aware
+ * write has to walk `getQueriesData` and decode each key itself.
+ *
+ * @see {@link https://tanstack.com/query/latest/docs/reference/QueryClient#queryclientsetqueriesdata}
+ */
+export function parseSectionConversationsQueryKey(
+  queryKey: readonly unknown[],
+): SectionConversationFilter | null {
+  const [prefix, , discriminator, groupId, originChannel] = queryKey;
+  if (
+    prefix !== CONVERSATION_LIST_PREFIX ||
+    discriminator !== "section" ||
+    typeof groupId !== "string" ||
+    typeof originChannel !== "string"
+  ) {
+    return null;
+  }
+  /* The encoder writes "" for an absent axis, so "" decodes back to absent
+     rather than to a filter on the empty string. */
+  return {
+    ...(groupId === "" ? {} : { groupId: groupId as ConversationGroupId }),
+    ...(originChannel === ""
+      ? {}
+      : { originChannel: originChannel as OriginChannel }),
+  };
+}
+
+/**
  * Key for the server-side unread conversation count
  * (`GET /v1/conversations/unread-count`). The cache holds `number | null`
  * (see {@link fetchUnreadConversationCount}).
@@ -108,17 +144,6 @@ export function unreadConversationCountQueryKey(assistantId: string | null) {
   return conversationsUnreadcountGetQueryKey({
     path: { assistant_id: assistantId ?? "" },
   });
-}
-
-// ---------------------------------------------------------------------------
-// Shared sort comparator
-// ---------------------------------------------------------------------------
-
-/** Sort conversations descending by a timestamp field (newest first). */
-function byTimestampDesc(
-  key: "lastMessageAt" | "archivedAt",
-): (a: Conversation, b: Conversation) => number {
-  return (a, b) => (b[key] ?? 0) - (a[key] ?? 0);
 }
 
 // ---------------------------------------------------------------------------

--- a/clients/web/src/utils/conversation-order.ts
+++ b/clients/web/src/utils/conversation-order.ts
@@ -1,14 +1,14 @@
 /**
  * The one order every conversation list is in, and how to place a row into it.
  *
- * Recency, newest first. Nothing writes `display_order` any more (LUM-3108),
- * so every section (Pinned, the custom groups, the channels, Chats) is
- * sorted by `lastMessageAt` descending, on the server and here.
+ * Recency, newest first: every section (Pinned, the custom groups, the
+ * channels, Chats) is sorted by `lastMessageAt` descending, on the server and
+ * here. Nothing consults `display_order` (LUM-3108).
  *
- * Extracted because the comparator had grown three copies (the list fetchers'
- * sort, the sidebar's derived bucketing, and now local placement) and they
- * have to agree: a locally inserted row that sorts differently from the way
- * the server would return it jumps position the moment the list refetches.
+ * One comparator, shared by the list fetchers, the sidebar's derived
+ * bucketing, and local placement, because the three have to agree. A locally
+ * inserted row that sorts differently from the way the server returns it jumps
+ * position the moment the list refetches.
  */
 
 import type { Conversation } from "@/types/conversation-types";

--- a/clients/web/src/utils/conversation-order.ts
+++ b/clients/web/src/utils/conversation-order.ts
@@ -1,0 +1,57 @@
+/**
+ * The one order every conversation list is in, and how to place a row into it.
+ *
+ * Recency, newest first. Nothing writes `display_order` any more (LUM-3108),
+ * so every section (Pinned, the custom groups, the channels, Chats) is
+ * sorted by `lastMessageAt` descending, on the server and here.
+ *
+ * Extracted because the comparator had grown three copies (the list fetchers'
+ * sort, the sidebar's derived bucketing, and now local placement) and they
+ * have to agree: a locally inserted row that sorts differently from the way
+ * the server would return it jumps position the moment the list refetches.
+ */
+
+import type { Conversation } from "@/types/conversation-types";
+
+/** Sort conversations descending by a timestamp field (newest first). */
+export function byTimestampDesc(
+  key: "lastMessageAt" | "archivedAt",
+): (a: Conversation, b: Conversation) => number {
+  return (a, b) => (b[key] ?? 0) - (a[key] ?? 0);
+}
+
+/**
+ * Recency order, newest first.
+ *
+ * No tiebreak. `Array.prototype.sort` is stable, so rows sharing a
+ * `lastMessageAt` (or both missing one) keep the order they arrived in, which
+ * is the server's. Adding an id tiebreak here would reorder them against it.
+ */
+export const compareByRecency = byTimestampDesc("lastMessageAt");
+
+/**
+ * `conversations` with `conversation` inserted at its recency position.
+ *
+ * Insertion rather than append-and-sort: the list is already ordered, and
+ * re-sorting would re-seat rows the server had deliberately placed (equal
+ * timestamps hold the server's arrival order, which a full sort of a
+ * partially-rebuilt array does not preserve).
+ *
+ * Ties place the new row *first*, matching what the server does with a row
+ * whose timestamp did not change: a just-touched conversation leads the rows
+ * it ties with.
+ */
+export function insertByRecency(
+  conversations: readonly Conversation[],
+  conversation: Conversation,
+): Conversation[] {
+  const at = conversations.findIndex(
+    (c) => compareByRecency(conversation, c) <= 0,
+  );
+  const index = at === -1 ? conversations.length : at;
+  return [
+    ...conversations.slice(0, index),
+    conversation,
+    ...conversations.slice(index),
+  ];
+}

--- a/clients/web/src/utils/conversation-predicates.ts
+++ b/clients/web/src/utils/conversation-predicates.ts
@@ -7,6 +7,29 @@
 
 import type { Conversation } from "@/types/conversation-types";
 
+/**
+ * True when a `groupId` refers to a non-system (custom) group.
+ * System groups use a `"system:"` prefix (e.g. `"system:pinned"`).
+ */
+export function isCustomGroupId(
+  groupId: string | undefined,
+): groupId is string {
+  return !!groupId && !groupId.startsWith("system:");
+}
+
+/**
+ * True when a conversation is pinned, via either the modern `isPinned`
+ * boolean or the legacy `groupId === "system:pinned"` marker. Some
+ * conversations (especially older ones) only carry the legacy marker,
+ * so checking `isPinned` alone misses them and shows the wrong
+ * Pin/Unpin label in the actions menu.
+ */
+export function isConversationPinned(conversation: Conversation): boolean {
+  return (
+    conversation.isPinned === true || conversation.groupId === "system:pinned"
+  );
+}
+
 export function isBackgroundConversation(conversation: Conversation): boolean {
   // Surfaced conversations (`surfacedAt != null`) are explicitly promoted
   // into the Recents grouping, so they get full foreground treatment —

--- a/clients/web/src/utils/section-membership.test.ts
+++ b/clients/web/src/utils/section-membership.test.ts
@@ -12,9 +12,9 @@
  * {@link reconcileSectionMembership} is the write, and the invariant it has to
  * hold is "a conversation appears in exactly one section, never twice"
  * (LUM-2443). Its tests count copies across every seeded section rather than
- * asserting the destination contains the row, because the bug being guarded
- * against (a row that arrives in Pinned while still sitting in the section it
- * left) passes every presence-only assertion.
+ * asserting the destination contains the row: a row that arrives in Pinned
+ * while still sitting in the section it left satisfies every presence-only
+ * assertion.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -247,8 +247,8 @@ describe("reconcileSectionMembership", () => {
       groupId: "system:pinned",
     });
 
-    // The invariant, not the destination: before this write existed, the row
-    // arrived in Pinned and *stayed* in Slack until a refetch removed it.
+    // The invariant, not the destination: arriving in Pinned while still
+    // sitting in Slack would satisfy the two assertions below on its own.
     expect(copiesAcrossSections(client, [SLACK, PINNED], "c1")).toBe(1);
     expect(rowsIn(client, PINNED).map((c) => c.conversationId)).toEqual(["c1"]);
     expect(rowsIn(client, SLACK)).toEqual([]);
@@ -276,6 +276,54 @@ describe("reconcileSectionMembership", () => {
     expect(copiesAcrossSections(client, [SLACK, PINNED], "c1")).toBe(1);
     expect(rowsIn(client, SLACK).map((c) => c.conversationId)).toEqual(["c1"]);
     expect(rowsIn(client, PINNED)).toEqual([]);
+  });
+
+  test("pinning a background run places it once its promotion is stamped", () => {
+    /* A background row reaches the sidebar only by being surfaced, and the
+       daemon stamps `surfaced_at` in the same write that pins it. The patch
+       has to carry that stamp or the row belongs to no section and the move
+       waits for the refetch. */
+    const row = conversation({
+      conversationId: "c1",
+      conversationType: "background",
+    });
+    const client = seed([[PINNED, []]]);
+
+    reconcileSectionMembership(client, ASSISTANT_ID, {
+      ...row,
+      isPinned: true,
+      groupId: "system:pinned",
+      surfacedAt: 42,
+    });
+
+    expect(rowsIn(client, PINNED).map((c) => c.conversationId)).toEqual(["c1"]);
+  });
+
+  test("demoting a surfaced background run keeps it out of Chats", () => {
+    /* Moving into `system:background` clears the promotion, so the row leaves
+       the sidebar. Without the cleared stamp it reads as an ordinary
+       ungrouped row and lands in Chats, which is a worse failure than the lag
+       it replaces: the refetch takes it straight back out. */
+    const row = conversation({
+      conversationId: "c1",
+      conversationType: "background",
+      surfacedAt: 42,
+      isPinned: true,
+      groupId: "system:pinned",
+    });
+    const client = seed([
+      [CHATS, []],
+      [PINNED, [row]],
+    ]);
+
+    reconcileSectionMembership(client, ASSISTANT_ID, {
+      ...row,
+      isPinned: false,
+      groupId: "system:background",
+      surfacedAt: undefined,
+    });
+
+    expect(copiesAcrossSections(client, [CHATS, PINNED], "c1")).toBe(0);
   });
 
   test("archiving takes the row out of every section", () => {
@@ -334,6 +382,38 @@ describe("reconcileSectionMembership", () => {
       client.getQueryData(sectionConversationsQueryKey(ASSISTANT_ID, PINNED)),
     ).toBeUndefined();
     expect(rowsIn(client, CHATS)).toEqual([]);
+  });
+
+  test("a section whose first fetch was cancelled is reported for refetch", async () => {
+    /* Optimistic writes cancel the list prefix so an in-flight response
+       cannot land on top of them, which leaves a first fetch abandoned with
+       no data and no pending request. Nothing can be written into that cache,
+       so the settle has to re-drive it or the section never loads. */
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    client.setQueryData(sectionConversationsQueryKey(ASSISTANT_ID, CHATS), [
+      conversation({ conversationId: "c1" }),
+    ]);
+    const pinnedKey = sectionConversationsQueryKey(ASSISTANT_ID, PINNED);
+    void client
+      .prefetchQuery({
+        queryKey: pinnedKey,
+        queryFn: () => new Promise<Conversation[]>(() => {}),
+      })
+      .catch(() => {});
+    await client.cancelQueries({ queryKey: pinnedKey });
+
+    expect(client.getQueryData(pinnedKey)).toBeUndefined();
+
+    const keys = reconcileSectionMembership(client, ASSISTANT_ID, {
+      conversationId: "c1",
+      isPinned: true,
+      groupId: "system:pinned",
+    });
+
+    const serialized = keys.map((k) => JSON.stringify(k));
+    expect(serialized).toContain(JSON.stringify(pinnedKey));
   });
 
   test("a member is replaced in place and reports no membership change", () => {

--- a/clients/web/src/utils/section-membership.test.ts
+++ b/clients/web/src/utils/section-membership.test.ts
@@ -1,0 +1,375 @@
+/**
+ * Tests for local section membership.
+ *
+ * Two things are under test and they fail in different ways.
+ *
+ * {@link matchesSectionFilter} is a twin of the daemon's SQL, so its tests are
+ * written as the same scenario matrix the server clauses cover: a rule that
+ * drifts from `groupIdClause` / `originChannelClause` puts a row in a section
+ * the next refetch takes it back out of, which looks like a flicker rather
+ * than a wrong answer.
+ *
+ * {@link reconcileSectionMembership} is the write, and the invariant it has to
+ * hold is "a conversation appears in exactly one section, never twice"
+ * (LUM-2443). Its tests count copies across every seeded section rather than
+ * asserting the destination contains the row, because the bug being guarded
+ * against (a row that arrives in Pinned while still sitting in the section it
+ * left) passes every presence-only assertion.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { QueryClient } from "@tanstack/react-query";
+
+import type { Conversation } from "@/types/conversation-types";
+import {
+  conversationsQueryKey,
+  sectionConversationsQueryKey,
+  type SectionConversationFilter,
+} from "@/utils/conversation-list-fetchers";
+import {
+  matchesSectionFilter,
+  patchAffectsMembership,
+  reconcileSectionMembership,
+} from "@/utils/section-membership";
+
+const ASSISTANT_ID = "asst-1";
+
+const PINNED: SectionConversationFilter = { groupId: "system:pinned" };
+const CHATS: SectionConversationFilter = { groupId: "system:all" };
+const SLACK: SectionConversationFilter = {
+  groupId: "system:all",
+  originChannel: "slack",
+};
+const NATIVE_CHATS: SectionConversationFilter = {
+  groupId: "system:all",
+  originChannel: "vellum",
+};
+const CUSTOM: SectionConversationFilter = { groupId: "group-uuid" };
+
+function conversation(overrides: Partial<Conversation> = {}): Conversation {
+  return { conversationId: "conv-1", lastMessageAt: 1_000, ...overrides };
+}
+
+// ---------------------------------------------------------------------------
+// matchesSectionFilter
+// ---------------------------------------------------------------------------
+
+describe("matchesSectionFilter", () => {
+  test("Pinned takes a row pinned by either representation", () => {
+    expect(matchesSectionFilter(conversation({ isPinned: true }), PINNED)).toBe(
+      true,
+    );
+    expect(
+      matchesSectionFilter(conversation({ groupId: "system:pinned" }), PINNED),
+    ).toBe(true);
+    expect(matchesSectionFilter(conversation(), PINNED)).toBe(false);
+  });
+
+  test("system:all means unclaimed, so it admits a row with no group", () => {
+    // The overwhelming majority of rows carry no `group_id` at all, and the
+    // server's clause is `group_id IS NULL OR ...` for exactly this reason.
+    expect(matchesSectionFilter(conversation(), CHATS)).toBe(true);
+  });
+
+  test("system:all admits the non-pinned system buckets", () => {
+    // Mirrors `group_id LIKE 'system:%' AND group_id != 'system:pinned'`. A
+    // surfaced background row keeps `system:background` and still renders in
+    // Chats.
+    expect(
+      matchesSectionFilter(
+        conversation({ groupId: "system:background", surfacedAt: 5 }),
+        CHATS,
+      ),
+    ).toBe(true);
+  });
+
+  test("system:all excludes pinned and custom-group rows", () => {
+    expect(matchesSectionFilter(conversation({ isPinned: true }), CHATS)).toBe(
+      false,
+    );
+    expect(
+      matchesSectionFilter(conversation({ groupId: "group-uuid" }), CHATS),
+    ).toBe(false);
+  });
+
+  test("a custom group matches its id exactly", () => {
+    expect(
+      matchesSectionFilter(conversation({ groupId: "group-uuid" }), CUSTOM),
+    ).toBe(true);
+    expect(
+      matchesSectionFilter(conversation({ groupId: "other-uuid" }), CUSTOM),
+    ).toBe(false);
+  });
+
+  test("both axes are ANDed", () => {
+    const slackRow = conversation({ originChannel: "slack" });
+    expect(matchesSectionFilter(slackRow, SLACK)).toBe(true);
+    // Filed into a custom group, it leaves the Slack card rather than
+    // rendering in both.
+    expect(
+      matchesSectionFilter(
+        conversation({ originChannel: "slack", groupId: "group-uuid" }),
+        SLACK,
+      ),
+    ).toBe(false);
+    expect(matchesSectionFilter(conversation(), SLACK)).toBe(false);
+  });
+
+  test("vellum admits an unattributed row, every other channel is exact", () => {
+    // `origin_channel` is left unset so an inbound message can still claim
+    // the conversation; reading unset as native is the self-correcting error.
+    expect(matchesSectionFilter(conversation(), NATIVE_CHATS)).toBe(true);
+    expect(
+      matchesSectionFilter(
+        conversation({ originChannel: "vellum" }),
+        NATIVE_CHATS,
+      ),
+    ).toBe(true);
+    expect(
+      matchesSectionFilter(
+        conversation({ originChannel: "slack" }),
+        NATIVE_CHATS,
+      ),
+    ).toBe(false);
+  });
+
+  test("an archived row belongs to no section", () => {
+    for (const filter of [PINNED, CHATS, SLACK, CUSTOM]) {
+      expect(
+        matchesSectionFilter(
+          conversation({
+            archivedAt: 10,
+            isPinned: true,
+            groupId: "system:pinned",
+          }),
+          filter,
+        ),
+      ).toBe(false);
+    }
+  });
+
+  test("a background run reaches a section only when surfaced or filed", () => {
+    const background = conversation({ conversationType: "background" });
+    expect(matchesSectionFilter(background, CHATS)).toBe(false);
+    expect(matchesSectionFilter({ ...background, surfacedAt: 5 }, CHATS)).toBe(
+      true,
+    );
+    expect(
+      matchesSectionFilter({ ...background, groupId: "group-uuid" }, CUSTOM),
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// patchAffectsMembership
+// ---------------------------------------------------------------------------
+
+describe("patchAffectsMembership", () => {
+  test("true for every field a section filter reads", () => {
+    expect(patchAffectsMembership({ groupId: "system:pinned" })).toBe(true);
+    expect(patchAffectsMembership({ isPinned: true })).toBe(true);
+    expect(patchAffectsMembership({ archivedAt: 1 })).toBe(true);
+    expect(patchAffectsMembership({ surfacedAt: 1 })).toBe(true);
+  });
+
+  test("false for the patches that only change how a row renders", () => {
+    // Mark-seen and rename run constantly, including per row in the bulk
+    // paths; they must not pay for a membership pass.
+    expect(
+      patchAffectsMembership({ hasUnseenLatestAssistantMessage: false }),
+    ).toBe(false);
+    expect(patchAffectsMembership({ title: "renamed" })).toBe(false);
+  });
+
+  test("an explicit undefined still counts", () => {
+    // Unarchive patches `archivedAt: undefined`, which is a membership change
+    // even though the value is absent. Presence of the key is the test.
+    expect(patchAffectsMembership({ archivedAt: undefined })).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reconcileSectionMembership
+// ---------------------------------------------------------------------------
+
+function seed(
+  sections: Array<[SectionConversationFilter, Conversation[]]>,
+): QueryClient {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  for (const [filter, rows] of sections) {
+    client.setQueryData(
+      sectionConversationsQueryKey(ASSISTANT_ID, filter),
+      rows,
+    );
+  }
+  return client;
+}
+
+function rowsIn(
+  client: QueryClient,
+  filter: SectionConversationFilter,
+): Conversation[] {
+  return (
+    client.getQueryData<Conversation[]>(
+      sectionConversationsQueryKey(ASSISTANT_ID, filter),
+    ) ?? []
+  );
+}
+
+/** How many sections hold `conversationId`, counting duplicates within one. */
+function copiesAcrossSections(
+  client: QueryClient,
+  filters: SectionConversationFilter[],
+  conversationId: string,
+): number {
+  return filters.reduce(
+    (total, filter) =>
+      total +
+      rowsIn(client, filter).filter((c) => c.conversationId === conversationId)
+        .length,
+    0,
+  );
+}
+
+describe("reconcileSectionMembership", () => {
+  test("pinning moves the row out of its section and into Pinned", () => {
+    const row = conversation({ conversationId: "c1", originChannel: "slack" });
+    const client = seed([
+      [SLACK, [row]],
+      [PINNED, []],
+    ]);
+
+    const changed = reconcileSectionMembership(client, ASSISTANT_ID, {
+      ...row,
+      isPinned: true,
+      groupId: "system:pinned",
+    });
+
+    // The invariant, not the destination: before this write existed, the row
+    // arrived in Pinned and *stayed* in Slack until a refetch removed it.
+    expect(copiesAcrossSections(client, [SLACK, PINNED], "c1")).toBe(1);
+    expect(rowsIn(client, PINNED).map((c) => c.conversationId)).toEqual(["c1"]);
+    expect(rowsIn(client, SLACK)).toEqual([]);
+    expect(changed).toHaveLength(2);
+  });
+
+  test("unpinning returns the row to the section that claims it", () => {
+    const row = conversation({
+      conversationId: "c1",
+      originChannel: "slack",
+      isPinned: true,
+      groupId: "system:pinned",
+    });
+    const client = seed([
+      [SLACK, []],
+      [PINNED, [row]],
+    ]);
+
+    reconcileSectionMembership(client, ASSISTANT_ID, {
+      ...row,
+      isPinned: false,
+      groupId: "system:all",
+    });
+
+    expect(copiesAcrossSections(client, [SLACK, PINNED], "c1")).toBe(1);
+    expect(rowsIn(client, SLACK).map((c) => c.conversationId)).toEqual(["c1"]);
+    expect(rowsIn(client, PINNED)).toEqual([]);
+  });
+
+  test("archiving takes the row out of every section", () => {
+    const row = conversation({ conversationId: "c1" });
+    const client = seed([
+      [CHATS, [row]],
+      [PINNED, []],
+    ]);
+
+    reconcileSectionMembership(client, ASSISTANT_ID, {
+      ...row,
+      archivedAt: 99,
+    });
+
+    expect(copiesAcrossSections(client, [CHATS, PINNED], "c1")).toBe(0);
+  });
+
+  test("the row lands at its recency position, not at either end", () => {
+    const client = seed([
+      [
+        PINNED,
+        [
+          conversation({ conversationId: "newer", lastMessageAt: 3_000 }),
+          conversation({ conversationId: "older", lastMessageAt: 1_000 }),
+        ],
+      ],
+    ]);
+
+    reconcileSectionMembership(client, ASSISTANT_ID, {
+      conversationId: "middle",
+      lastMessageAt: 2_000,
+      isPinned: true,
+      groupId: "system:pinned",
+    });
+
+    expect(rowsIn(client, PINNED).map((c) => c.conversationId)).toEqual([
+      "newer",
+      "middle",
+      "older",
+    ]);
+  });
+
+  test("a section that has never fetched is not created", () => {
+    // `useSectionConversations` reads "has data" as permission to stop
+    // painting its derived fallback, so minting a cache here would hand that
+    // section a single row and present it as the whole section.
+    const client = seed([[CHATS, [conversation({ conversationId: "c1" })]]]);
+
+    reconcileSectionMembership(client, ASSISTANT_ID, {
+      conversationId: "c1",
+      isPinned: true,
+      groupId: "system:pinned",
+    });
+
+    expect(
+      client.getQueryData(sectionConversationsQueryKey(ASSISTANT_ID, PINNED)),
+    ).toBeUndefined();
+    expect(rowsIn(client, CHATS)).toEqual([]);
+  });
+
+  test("a member is replaced in place and reports no membership change", () => {
+    const row = conversation({ conversationId: "c1", title: "before" });
+    const client = seed([[CHATS, [row]]]);
+
+    const changed = reconcileSectionMembership(client, ASSISTANT_ID, {
+      ...row,
+      title: "after",
+    });
+
+    expect(rowsIn(client, CHATS)[0]?.title).toBe("after");
+    expect(changed).toEqual([]);
+  });
+
+  test("the foreground list is left alone", () => {
+    /* It shares the `conversation-list` prefix but is not a section, so the
+       key decoder rejects it. It has to survive: the sidebar still reads it
+       to decide which sections exist at all, and a pinned row has to stay in
+       it for Pinned to appear in the first place. */
+    const row = conversation({ conversationId: "c1" });
+    const client = seed([[CHATS, [row]]]);
+    client.setQueryData<Conversation[]>(conversationsQueryKey(ASSISTANT_ID), [
+      row,
+    ]);
+
+    reconcileSectionMembership(client, ASSISTANT_ID, {
+      ...row,
+      isPinned: true,
+      groupId: "system:pinned",
+    });
+
+    expect(
+      client
+        .getQueryData<Conversation[]>(conversationsQueryKey(ASSISTANT_ID))
+        ?.map((c) => c.conversationId),
+    ).toEqual(["c1"]);
+  });
+});

--- a/clients/web/src/utils/section-membership.test.ts
+++ b/clients/web/src/utils/section-membership.test.ts
@@ -148,6 +148,43 @@ describe("matchesSectionFilter", () => {
     }
   });
 
+  test("a private conversation belongs to no section", () => {
+    // Excluded by all three arms of the daemon's visibility predicate.
+    for (const filter of [PINNED, CHATS, CUSTOM]) {
+      expect(
+        matchesSectionFilter(
+          conversation({
+            conversationType: "private",
+            surfacedAt: 5,
+            groupId: filter === CUSTOM ? "group-uuid" : undefined,
+          }),
+          filter,
+        ),
+      ).toBe(false);
+    }
+  });
+
+  test("a subagent run is excluded from the surfaced and filed arms only", () => {
+    /* The foreground arm does not test `source`, so a standard subagent row
+       stays visible; the surfaced and custom-group arms exclude it. Mirrors
+       `surfacedVisibilitySql` / `customGroupVisibilitySql`. */
+    const subagentBackground = conversation({
+      source: "subagent",
+      conversationType: "background",
+      surfacedAt: 5,
+    });
+    expect(matchesSectionFilter(subagentBackground, CHATS)).toBe(false);
+    expect(
+      matchesSectionFilter(
+        { ...subagentBackground, surfacedAt: undefined, groupId: "group-uuid" },
+        CUSTOM,
+      ),
+    ).toBe(false);
+    expect(
+      matchesSectionFilter(conversation({ source: "subagent" }), CHATS),
+    ).toBe(true);
+  });
+
   test("a background run reaches a section only when surfaced or filed", () => {
     const background = conversation({ conversationType: "background" });
     expect(matchesSectionFilter(background, CHATS)).toBe(false);

--- a/clients/web/src/utils/section-membership.ts
+++ b/clients/web/src/utils/section-membership.ts
@@ -1,0 +1,229 @@
+/**
+ * Which sidebar section a conversation belongs to, decided locally.
+ *
+ * Every section fetches its own rows through a server filter (LUM-2443), so a
+ * section's membership is no longer something the client derives: it is the
+ * contents of that section's cache entry. That is what makes this module
+ * necessary. A conversation's `groupId` / `isPinned` / `archivedAt` are the
+ * server's inputs to that filter, so the moment a mutation changes one of
+ * them locally, the caches disagree with the fields until a refetch lands.
+ * Without a local answer, moving a row between sections costs a network round
+ * trip per section and each one lands at a different time, which is visible as
+ * the row sitting in its old section after it has already appeared in its new
+ * one.
+ *
+ * {@link matchesSectionFilter} is the client twin of the daemon's
+ * `groupIdClause` / `originChannelClause` in
+ * `assistant/src/persistence/conversation-queries.ts`. **Changing the rules
+ * here means changing them there too**, or a locally placed row lands in a
+ * section the next refetch takes it out of. The same twin relationship, and
+ * the same warning, already governs `contributesToUnreadCount`.
+ */
+
+import type { QueryClient } from "@tanstack/react-query";
+
+import type { Conversation } from "@/types/conversation-types";
+import {
+  NATIVE_ORIGIN_CHANNEL,
+  SYSTEM_ALL_GROUP_ID,
+  SYSTEM_PINNED_GROUP_ID,
+  parseSectionConversationsQueryKey,
+  sectionListPrefix,
+  type SectionConversationFilter,
+} from "@/utils/conversation-list-fetchers";
+import { insertByRecency } from "@/utils/conversation-order";
+import {
+  isBackgroundConversation,
+  isConversationPinned,
+  isCustomGroupId,
+} from "@/utils/conversation-predicates";
+
+/**
+ * The fields a section filter reads. A patch touching none of them cannot
+ * change any section's membership, which is what lets the membership pass be
+ * skipped for the common patches (seen state, title, processing flags).
+ *
+ * Derived from what {@link matchesSectionFilter} and
+ * {@link isSidebarVisible} actually consult, so a rule that starts reading a
+ * new field has to be added here in the same edit or the skip goes stale.
+ */
+const MEMBERSHIP_FIELDS = [
+  "groupId",
+  "isPinned",
+  "archivedAt",
+  "surfacedAt",
+  "conversationType",
+  "originChannel",
+] as const satisfies readonly (keyof Conversation)[];
+
+/**
+ * Whether applying `patch` could move a conversation between sections.
+ *
+ * Presence, not value: a patch that sets `groupId` to what it already was
+ * still runs the pass, which is a no-op that costs one comparison per cached
+ * row. Comparing values here would mean reading the current row first, which
+ * is the more expensive of the two.
+ */
+export function patchAffectsMembership(patch: Partial<Conversation>): boolean {
+  return MEMBERSHIP_FIELDS.some((field) => field in patch);
+}
+
+/**
+ * Whether any sidebar section can hold this conversation at all.
+ *
+ * The daemon's `standardListingVisibilitySql` answers the same question for
+ * the same rows: archived conversations live in their own view, and background
+ * or scheduled runs are excluded unless they were surfaced or filed into a
+ * custom group. Rows failing this belong to no section, so a local placement
+ * must not invent one for them.
+ *
+ * This deliberately stays a *gate on insertion* rather than a rule the
+ * mutations consult. Pinning a background conversation is a real open question
+ * (LUM-3074 / LUM-3075) about what the daemon should do; answering it here by
+ * showing a row the next refetch removes would be this module inventing
+ * product behavior instead of mirroring it.
+ */
+function isSidebarVisible(conversation: Conversation): boolean {
+  if (conversation.archivedAt != null) {
+    return false;
+  }
+  return (
+    !isBackgroundConversation(conversation) ||
+    isCustomGroupId(conversation.groupId)
+  );
+}
+
+/**
+ * Whether the section identified by `filter` holds this conversation.
+ *
+ * Both axes are ANDed, exactly as the daemon ANDs the two query parameters,
+ * and an absent axis constrains nothing.
+ *
+ * Two of the server's clauses are tolerant, and both are reproduced here
+ * rather than tightened:
+ *
+ * - `system:all` means "nothing else claimed it", so it matches a NULL group
+ *   and the non-pinned system buckets, not the literal string. Most rows
+ *   carry no `group_id` at all.
+ * - `vellum` matches an unattributed row as well as an explicitly native one,
+ *   because `origin_channel` is left unset at insert so an inbound message can
+ *   still claim the conversation for its channel.
+ *
+ * The known asymmetry is on the channel axis and it predates this module:
+ * `Conversation.originChannel` is binding-first on the client
+ * (`channelBinding.sourceChannel ?? conversationOriginChannel`) while the
+ * server matches the column alone, so a row whose binding names a channel its
+ * column has not yet recorded reads as that channel here and as native there.
+ * Self-correcting when the first inbound message stamps the column, and in the
+ * safe direction: the row is in exactly one section throughout.
+ */
+export function matchesSectionFilter(
+  conversation: Conversation,
+  filter: SectionConversationFilter,
+): boolean {
+  if (!isSidebarVisible(conversation)) {
+    return false;
+  }
+  const { groupId, originChannel } = filter;
+
+  if (groupId === SYSTEM_PINNED_GROUP_ID) {
+    if (!isConversationPinned(conversation)) {
+      return false;
+    }
+  } else if (groupId === SYSTEM_ALL_GROUP_ID) {
+    if (
+      isConversationPinned(conversation) ||
+      isCustomGroupId(conversation.groupId)
+    ) {
+      return false;
+    }
+  } else if (groupId !== undefined && conversation.groupId !== groupId) {
+    return false;
+  }
+
+  if (originChannel === undefined) {
+    return true;
+  }
+  if (originChannel === NATIVE_ORIGIN_CHANNEL) {
+    return (
+      conversation.originChannel == null ||
+      conversation.originChannel === NATIVE_ORIGIN_CHANNEL
+    );
+  }
+  return conversation.originChannel === originChannel;
+}
+
+/**
+ * Bring every cached section into agreement with `conversation`, and report
+ * the caches that actually changed.
+ *
+ * Walks `getQueriesData` rather than writing through `setQueriesData` because
+ * the decision needs the query *key*: a section states what it holds only
+ * through the filter it was keyed by, and TanStack hands a `setQueriesData`
+ * updater the data alone.
+ *
+ * Only caches that already exist are touched. A section whose query has never
+ * run must stay unfetched: `useSectionConversations` treats "has data" as its
+ * signal to stop painting the derived fallback, so minting a cache here would
+ * hand that section a single row and call it the whole section.
+ *
+ * The returned keys are what a caller needs to reconcile narrowly. A move
+ * touches at most the section a row left and the one it joined, so
+ * invalidating those two beats invalidating the list prefix, which refetches
+ * every mounted section and the foreground list on every pin.
+ *
+ * @see {@link https://tanstack.com/query/latest/docs/reference/QueryClient#queryclientgetqueriesdata}
+ */
+export function reconcileSectionMembership(
+  queryClient: QueryClient,
+  assistantId: string | null,
+  conversation: Conversation,
+): readonly (readonly unknown[])[] {
+  if (!assistantId) {
+    return [];
+  }
+  const changed: (readonly unknown[])[] = [];
+  const entries = queryClient.getQueriesData<Conversation[]>({
+    queryKey: sectionListPrefix(assistantId),
+  });
+
+  for (const [queryKey, rows] of entries) {
+    if (!rows) {
+      continue;
+    }
+    const filter = parseSectionConversationsQueryKey(queryKey);
+    if (!filter) {
+      continue;
+    }
+
+    const index = rows.findIndex(
+      (c) => c.conversationId === conversation.conversationId,
+    );
+    const belongs = matchesSectionFilter(conversation, filter);
+
+    if (belongs === (index !== -1)) {
+      /* Membership agrees. The row is still replaced in place when it is a
+         member, so a patch that changed a rendered field reaches this cache
+         too. Skipped when the cache already holds this exact object, which is
+         the usual case: the field patch that preceded this call put it there,
+         and writing an equal array again would re-render the section for
+         nothing. */
+      if (belongs && rows[index] !== conversation) {
+        const next = [...rows];
+        next[index] = conversation;
+        queryClient.setQueryData<Conversation[]>(queryKey, next);
+      }
+      continue;
+    }
+
+    queryClient.setQueryData<Conversation[]>(
+      queryKey,
+      belongs
+        ? insertByRecency(rows, conversation)
+        : rows.filter((c) => c.conversationId !== conversation.conversationId),
+    );
+    changed.push(queryKey);
+  }
+
+  return changed;
+}

--- a/clients/web/src/utils/section-membership.ts
+++ b/clients/web/src/utils/section-membership.ts
@@ -2,15 +2,13 @@
  * Which sidebar section a conversation belongs to, decided locally.
  *
  * Every section fetches its own rows through a server filter (LUM-2443), so a
- * section's membership is no longer something the client derives: it is the
- * contents of that section's cache entry. That is what makes this module
- * necessary. A conversation's `groupId` / `isPinned` / `archivedAt` are the
- * server's inputs to that filter, so the moment a mutation changes one of
- * them locally, the caches disagree with the fields until a refetch lands.
- * Without a local answer, moving a row between sections costs a network round
- * trip per section and each one lands at a different time, which is visible as
- * the row sitting in its old section after it has already appeared in its new
- * one.
+ * section's membership is the contents of that section's cache entry rather
+ * than something the client derives. A conversation's `groupId` / `isPinned` /
+ * `archivedAt` are the server's inputs to that filter, so the moment a
+ * mutation changes one of them locally, the caches disagree with the fields
+ * until a refetch lands. Answering locally is what keeps a move off the
+ * network: without it, each section corrects itself on its own round trip, and
+ * a row is visible in two sections until the slower one returns.
  *
  * {@link matchesSectionFilter} is the client twin of the daemon's
  * `groupIdClause` / `originChannelClause` in
@@ -155,22 +153,31 @@ export function matchesSectionFilter(
 
 /**
  * Bring every cached section into agreement with `conversation`, and report
- * the caches that actually changed.
+ * the sections a settle still has to ask the server about.
  *
  * Walks `getQueriesData` rather than writing through `setQueriesData` because
  * the decision needs the query *key*: a section states what it holds only
  * through the filter it was keyed by, and TanStack hands a `setQueriesData`
  * updater the data alone.
  *
- * Only caches that already exist are touched. A section whose query has never
- * run must stay unfetched: `useSectionConversations` treats "has data" as its
- * signal to stop painting the derived fallback, so minting a cache here would
- * hand that section a single row and call it the whole section.
+ * Only caches that already hold rows are written. A section whose query has
+ * not resolved must stay unfetched: `useSectionConversations` treats "has
+ * data" as its signal to stop painting the derived fallback, so minting a
+ * cache here would hand that section a single row and call it the whole
+ * section.
  *
- * The returned keys are what a caller needs to reconcile narrowly. A move
- * touches at most the section a row left and the one it joined, so
- * invalidating those two beats invalidating the list prefix, which refetches
- * every mounted section and the foreground list on every pin.
+ * The returned keys are what a caller needs to reconcile narrowly, and they
+ * are of two kinds:
+ *
+ * 1. Sections this write moved the row between. A move touches at most the
+ *    one it left and the one it joined, so invalidating those beats
+ *    invalidating the list prefix, which refetches every mounted section and
+ *    the foreground list.
+ * 2. Sections holding no data, which this write could not place the row in.
+ *    A first fetch that was cancelled on the way in (optimistic writes cancel
+ *    the prefix so an in-flight response cannot land on top of them) leaves an
+ *    observer with nothing and no pending request, and a settle scoped to the
+ *    sections that changed would never re-drive it.
  *
  * @see {@link https://tanstack.com/query/latest/docs/reference/QueryClient#queryclientgetqueriesdata}
  */
@@ -182,17 +189,18 @@ export function reconcileSectionMembership(
   if (!assistantId) {
     return [];
   }
-  const changed: (readonly unknown[])[] = [];
+  const needsRefetch: (readonly unknown[])[] = [];
   const entries = queryClient.getQueriesData<Conversation[]>({
     queryKey: sectionListPrefix(assistantId),
   });
 
   for (const [queryKey, rows] of entries) {
-    if (!rows) {
-      continue;
-    }
     const filter = parseSectionConversationsQueryKey(queryKey);
     if (!filter) {
+      continue;
+    }
+    if (!rows) {
+      needsRefetch.push(queryKey);
       continue;
     }
 
@@ -222,8 +230,8 @@ export function reconcileSectionMembership(
         ? insertByRecency(rows, conversation)
         : rows.filter((c) => c.conversationId !== conversation.conversationId),
     );
-    changed.push(queryKey);
+    needsRefetch.push(queryKey);
   }
 
-  return changed;
+  return needsRefetch;
 }

--- a/clients/web/src/utils/section-membership.ts
+++ b/clients/web/src/utils/section-membership.ts
@@ -31,7 +31,6 @@ import {
 } from "@/utils/conversation-list-fetchers";
 import { insertByRecency } from "@/utils/conversation-order";
 import {
-  isBackgroundConversation,
   isConversationPinned,
   isCustomGroupId,
 } from "@/utils/conversation-predicates";
@@ -69,25 +68,42 @@ export function patchAffectsMembership(patch: Partial<Conversation>): boolean {
 /**
  * Whether any sidebar section can hold this conversation at all.
  *
- * The daemon's `standardListingVisibilitySql` answers the same question for
- * the same rows: archived conversations live in their own view, and background
- * or scheduled runs are excluded unless they were surfaced or filed into a
- * custom group. Rows failing this belong to no section, so a local placement
- * must not invent one for them.
+ * The three arms of the daemon's `standardListingVisibilitySql`, plus the
+ * archive filter every section query carries. Rows failing all three belong to
+ * no section, so a local placement must not invent one for them.
  *
- * This deliberately stays a *gate on insertion* rather than a rule the
- * mutations consult. Pinning a background conversation is a real open question
- * (LUM-3074 / LUM-3075) about what the daemon should do; answering it here by
- * showing a row the next refetch removes would be this module inventing
- * product behavior instead of mirroring it.
+ * 1. **Foreground**: not a background, scheduled, or private run by type, and
+ *    not routed to the `system:background` / `system:scheduled` groups.
+ * 2. **Surfaced**: promoted through the surface API, or by a placement that
+ *    stamps `surfaced_at` (see `resolvePlacementSurfacedAt`).
+ * 3. **Custom group**: filed into a user-created group, whatever its type,
+ *    because filing is an explicit organizational action.
+ *
+ * Private rows are excluded by all three. Subagent runs are excluded from the
+ * surfaced and custom-group arms only, matching the SQL exactly: the
+ * foreground arm does not test `source`.
  */
 function isSidebarVisible(conversation: Conversation): boolean {
   if (conversation.archivedAt != null) {
     return false;
   }
+  if (conversation.conversationType === "private") {
+    return false;
+  }
+  const isForeground =
+    conversation.conversationType !== "background" &&
+    conversation.conversationType !== "scheduled" &&
+    conversation.groupId !== "system:background" &&
+    conversation.groupId !== "system:scheduled";
+  if (isForeground) {
+    return true;
+  }
+  const isSubagentRun = conversation.source === "subagent";
+  if (isSubagentRun) {
+    return false;
+  }
   return (
-    !isBackgroundConversation(conversation) ||
-    isCustomGroupId(conversation.groupId)
+    conversation.surfacedAt != null || isCustomGroupId(conversation.groupId)
   );
 }
 


### PR DESCRIPTION
## TL;DR

Pinning a conversation put it in Pinned but left it in the section it came from until several refetches landed, so for a moment it was visibly in two sections at once. Membership is now computed locally from the fields it is derived from, so the move happens on the same render. Archive and unarchive had the same bug and are fixed by the same seam.

Fixes LUM-3195. Part of LUM-2443.

## What was actually wrong

Every sidebar section fetches its own rows through a server filter now (LUM-2443), so a section's membership is **the contents of its cache entry**, not something the client derives from one list. `useSectionConversations` hands its rows to `SidebarSectionItem`, which renders them verbatim.

The optimistic writes never caught up with that. `patchConversation` rewrote `groupId` / `isPinned` / `archivedAt` on the row inside whichever caches already held it, and never added or removed it from any of them. So on pin:

- the source section's cache still contained the row, and kept rendering it;
- Pinned's cache still did not, and nothing put it there.

The only thing that corrected membership was `onSettled -> invalidateConversationQueries`, which invalidates the whole `conversation-list` prefix: every mounted section plus the always-mounted foreground list, each refetching by draining its pages serially at 50 rows a page. Pinned's drain is one small GET and reads as instant; the source section's is queued behind the foreground drain. Two requests of very different cost, arriving at different times, is the tearing.

## The fix, and why it is at this seam

Membership is derived from the fields it is computed from, **inside `patchConversation`**. A caller that patches one of those fields cannot forget the other half, because there is no other half to call. A companion helper that call sites had to remember to also invoke would have recreated this bug at the next mutation that touches `groupId`.

- `matchesSectionFilter` (new `utils/section-membership.ts`) is the client twin of the daemon's `groupIdClause` / `originChannelClause`, reproducing both tolerant clauses rather than tightening them: `system:all` matches a NULL group and the non-pinned system buckets, `vellum` matches an unattributed row. It carries the same "change it here means change it there" warning `contributesToUnreadCount` already carries.
- Patches touching no membership field skip the pass entirely. Every other `patchConversation` caller in the app patches only `isProcessing` or `title`, so nothing outside the placement mutations changes behavior or cost.
- Section caches that have never fetched are never created, since `useSectionConversations` reads "has data" as permission to stop painting its derived fallback.

## Following the library rather than the surrounding code

Three things here contradict what the file did before, each checked against the docs rather than the codebase:

- **Rollback by field, not by whole-cache snapshot.** Restoring a snapshot taken before pin A also discards pin B's successful optimistic write, and pinning two conversations quickly is exactly that case. Both `clients/web/docs/STATE_MANAGEMENT.md` and [TkDodo](https://tkdodo.eu/blog/concurrent-optimistic-updates-in-react-query) call for field-level rollback. `previousIsPinned` / `previousGroupId` were already plumbed through `MoveToGroupVars` and unused, which is a good sign this was the intent.
- **`onSettled` returns its invalidation promise.** [TanStack is explicit](https://tanstack.com/query/latest/docs/framework/react/guides/optimistic-updates) that it must be, so the mutation stays pending until the refetch finishes. It was `void`-ed.
- **Cache-writing, not `useMutationState` derivation.** TanStack's rule is that the cache approach wins when multiple unrelated places need the update, which is this: the source card, Pinned, both collapsed rail icons, and section bulk-action scope.

`setQueriesData` cannot be used here: its updater receives the data alone, never the key, and the key is what states which filter a cache holds. Hence walking `getQueriesData`.

## Before / after

| Doing this | Before | After |
| --- | --- | --- |
| Pin a conversation | Appears in Pinned, stays in its old section for a moment, then leaves | Moves on the same render, before the request is sent |
| Unpin | Same lag in reverse | Returns to its channel or group immediately |
| Move to a group | Same lag | Immediate |
| Archive | Row keeps rendering in its section until the refetch | Leaves every section immediately |
| Unarchive | Row does not come back until the refetch | Returns to the section that claims it immediately |
| A pin that fails | Whole sidebar cache reverts, discarding any other pin in flight | Only that row goes back |
| Cost of one pin | Refetch every mounted section and drain the whole foreground list | Refetch the two sections that changed |

## Why this is safe

- The membership rules are a twin of SQL that already exists, tested against the same scenario matrix, so a locally placed row lands where the next refetch would have put it.
- Rows that no section can hold (archived, or a background run that is neither surfaced nor filed) are never inserted.
- Placement mirrors the daemon's `surfaced_at` side effect. `batchSetConversationPlacement` stamps the promotion when a background or scheduled run is filed into Pinned or a custom group, and clears it on a move into `system:background` / `system:scheduled`. `resolvePlacementSurfacedAt` is the client twin, so a pinned background run enters Pinned immediately and a demoted one leaves the sidebar immediately, both matching what the refetch brings back.
- Archive and unarchive keep the full-prefix invalidation, because they move the row between the foreground and archived caches, which the client does not write.
- Reconciliation still happens on every path; it is narrower, not absent. When a write moves nothing, it falls back to the whole section prefix.

## Also in here

- The recency comparator had grown three copies and they have to agree, or a locally inserted row jumps position on the next refetch. Consolidated into `utils/conversation-order.ts`.
- `isConversationPinned` / `isCustomGroupId` moved to `utils/conversation-predicates.ts` (their stated home) so `utils/` does not have to import from `domains/`.

## Review

Both bots found real problems and the code changed for all six comments.

Codex caught the one that mattered: the optimistic patch did not mirror `surfaced_at`, so demoting a surfaced background run inserted it into Chats before the refetch removed it. A wrong-direction flash, strictly worse than the lag this PR set out to fix. That finding also invalidated a claim I had made here about deferring background rows to LUM-3074 / LUM-3075, since the daemon's promotion logic already answers it. Corrected above.

Devin caught that a section whose first fetch is cancelled by the optimistic write was no longer covered by the narrowed settle, and four comments narrating history in violation of AGENTS.md "Code Comments". I had inferred the opposite convention from the surrounding files rather than reading the rule.

## Testing

Local test runs are blocked by a standing rule on this machine, so **CI is the verifier for these** and I have not been able to sensitivity-check them by hand. Typecheck, lint and format are clean.

- `section-membership.test.ts` covers each server clause branch and the write. The write's assertions **count copies across every seeded section** rather than checking the destination, because the old behavior satisfies "Pinned contains the row" perfectly well; what it violated is "a conversation appears in exactly one section, never twice".
- `use-conversation-actions-placement.test.tsx` asserts the move lands while the request is still in flight, that a failed pin returns the row, and that settling does not invalidate the foreground list.

## Deferred

- **New conversations and explicit surfacing still do not enter section caches.** `prependConversation` and `surfaceConversationInCaches` write the foreground cache directly instead of going through `patchConversation`, so a brand-new conversation waits for a refetch to appear in Chats. Same bug class, and a mechanical change now that the seam exists; kept out to hold this PR to the placement mutations.
- **`handleArchiveAllInGroup` is quadratic**, looping `patchConversation` per row where each call walks every cached row. Pre-existing shape; this change adds a constant factor, not an order. Wants a single batched write.
- **No `isMutating`-gated reconcile.** TkDodo's concurrent-updates pattern needs a key accumulator to avoid dropping a sibling's sections, and `cancelQueries` already covers the flicker it targets. Not paid for by two small refetches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40542" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
