### PR TITLE
fix(web): keep the pinned-app menu on the collapsed rail (LUM-3146)

### DIFF
--- a/clients/web/src/domains/chat/components/pinned-app-nav-item.test.tsx
+++ b/clients/web/src/domains/chat/components/pinned-app-nav-item.test.tsx
@@ -365,12 +365,6 @@ describe("PinnedAppNavItem", () => {
     expect(screen.queryByRole("menuitemradio", { name: "teal" })).toBeNull();
   });
 
-  test("collapsed rail: the colour row is omitted with the rest of the menu", () => {
-    render(<PinnedAppNavItem app={TEAL_APP} active={false} collapsed />);
-
-    expect(screen.queryByRole("menuitemradio", { name: "Teal" })).toBeNull();
-  });
-
   /* `aria-current="page"` rather than a `data-active` attribute: the pill's
      active state is the one assistive tech reads, and it is what the pill's
      own active styling is keyed off (`aria-[current=page]:` classes), so

--- a/clients/web/src/domains/chat/components/pinned-app-nav-item.test.tsx
+++ b/clients/web/src/domains/chat/components/pinned-app-nav-item.test.tsx
@@ -3,7 +3,7 @@
  *
  * The design-library `SideMenu.Item` and `ContextMenu` primitives are mocked
  * with lightweight elements so these tests exercise the component's
- * composition and store wiring (open, unpin, collapsed omission) rather than
+ * composition and store wiring (open, unpin, the menu on both shapes) rather than
  * Radix ContextMenu internals. `onSelect` is surfaced as an `onClick` so
  * happy-dom can drive it.
  *
@@ -180,12 +180,43 @@ describe("PinnedAppNavItem", () => {
     expect(button.className).toContain("pointer-coarse:pointer-events-none");
   });
 
-  test("collapsed rail: renders the row without the context-menu wrapper", () => {
+  /* The tile is the shape with the most riding on the menu: no hover button,
+     nothing to swipe, so this is its only route to an unpin. Collapsing the
+     rail changes what a pinned app looks like, not what can be done to it. */
+  test("collapsed rail: keeps the context menu", () => {
     render(<PinnedAppNavItem app={APP} active={false} collapsed />);
 
     expect(screen.getByTestId("app-row").textContent).toBe("My App");
-    expect(screen.queryByTestId("ctx-root")).toBeNull();
-    expect(screen.queryByRole("button", { name: "Unpin" })).toBeNull();
+    expect(screen.getByTestId("ctx-root")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Unpin" })).toBeTruthy();
+  });
+
+  test("collapsed rail: Unpin clears the pin", () => {
+    seedPin(APP);
+    expect(usePinnedAppsStore.getState().isPinned("app-1")).toBe(true);
+
+    render(<PinnedAppNavItem app={APP} active={false} collapsed />);
+    fireEvent.click(screen.getByRole("button", { name: "Unpin" }));
+
+    expect(usePinnedAppsStore.getState().isPinned("app-1")).toBe(false);
+  });
+
+  test("collapsed rail: the colour row rides along with the menu", () => {
+    render(<PinnedAppNavItem app={TEAL_APP} active={false} collapsed />);
+
+    expect(
+      screen
+        .getByRole("menuitemradio", { name: "Teal" })
+        .getAttribute("aria-checked"),
+    ).toBe("true");
+  });
+
+  /* The hover button is expanded-only on purpose: `SideMenu.Item` has no
+     trailing slot, and a 20px button inside a 30px tile would sit on the glyph
+     it is meant to sit beside. */
+  test("collapsed rail: omits the hover unpin button", () => {
+    render(<PinnedAppNavItem app={APP} active={false} collapsed />);
+
     expect(screen.queryByRole("button", { name: "Unpin My App" })).toBeNull();
   });
 

--- a/clients/web/src/domains/chat/components/pinned-app-nav-item.tsx
+++ b/clients/web/src/domains/chat/components/pinned-app-nav-item.tsx
@@ -32,10 +32,14 @@ export interface PinnedAppNavItemProps {
  * cleared: a deleted app never appears in the Library, so its card-level
  * unpin is unreachable, leaving the sidebar entry orphaned.
  *
- * On touch devices, swiping left reveals an Unpin action button —
- * complementing the long-press context menu. In the collapsed rail the
- * swipe is omitted (the tooltip provider would interfere, same as the
- * context menu).
+ * Both shapes carry the menu, because the rail changes what a pinned app
+ * looks like and not what can be done to it. The collapsed tile depends on it
+ * most: it has no hover button and nothing to swipe, so the menu is its only
+ * route to an unpin, reached by right click or by long press.
+ *
+ * On touch, the expanded row additionally reveals an Unpin button on a left
+ * swipe. The tile omits that: it has nowhere to swipe to, and the actions a
+ * swipe reveals are sized for a full-width row.
  *
  * On desktop, a third path: a hover-revealed unpin button on the row's
  * trailing edge. `SideMenu.Item` has no `trailingAction` slot (unlike
@@ -81,8 +85,36 @@ export function PinnedAppNavItem({
     />
   );
 
+  /* One definition for both shapes. The rail changes what a pinned app looks
+     like, not what can be done to it, and the collapsed tile is the shape with
+     the most riding on this: it has no hover button and nothing to swipe, so
+     the menu is its only route to an unpin. */
+  const menu = (
+    <ContextMenu.Content onClick={(event) => event.stopPropagation()}>
+      <PinnedAppColorSwatches
+        value={app.color}
+        onChange={(color) => setColor(app.appId, color)}
+      />
+      <ContextMenu.Separator />
+      <ContextMenu.Item
+        leftIcon={<PinOff size={14} />}
+        onSelect={() => unpin(app.appId)}
+      >
+        Unpin
+      </ContextMenu.Item>
+    </ContextMenu.Content>
+  );
+
   if (collapsed) {
-    return sideMenuItem;
+    /* No `SwipeActionReveal`: a 30px tile has nowhere to swipe to, and the
+       actions it reveals are sized for a full-width row. Touch reaches the
+       same menu by long press, which is what the trigger already does. */
+    return (
+      <ContextMenu.Root>
+        <ContextMenu.Trigger>{sideMenuItem}</ContextMenu.Trigger>
+        {menu}
+      </ContextMenu.Root>
+    );
   }
 
   /* A pill, so a pinned app reads as its own object rather than as a row in
@@ -153,19 +185,7 @@ export function PinnedAppNavItem({
           {item}
         </SwipeActionReveal>
       </ContextMenu.Trigger>
-      <ContextMenu.Content onClick={(event) => event.stopPropagation()}>
-        <PinnedAppColorSwatches
-          value={app.color}
-          onChange={(color) => setColor(app.appId, color)}
-        />
-        <ContextMenu.Separator />
-        <ContextMenu.Item
-          leftIcon={<PinOff size={14} />}
-          onSelect={() => unpin(app.appId)}
-        >
-          Unpin
-        </ContextMenu.Item>
-      </ContextMenu.Content>
+      {menu}
     </ContextMenu.Root>
   );
 }

--- a/packages/design-library/src/components/tooltip.test.tsx
+++ b/packages/design-library/src/components/tooltip.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * Tests for the `Tooltip` convenience wrapper.
+ *
+ * Rendered to static markup: the tooltip content itself only mounts on hover,
+ * so what is assertable here is the trigger, which is the part other
+ * primitives compose with.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { Tooltip } from "./tooltip";
+
+describe("Tooltip", () => {
+  test("renders its child as the trigger, with no wrapper element", () => {
+    const html = renderToStaticMarkup(
+      <Tooltip content="Preferences">
+        <button type="button">Open</button>
+      </Tooltip>,
+    );
+
+    expect(html).toContain("<button");
+    expect(html).toContain("Open");
+  });
+
+  /* The reason this wrapper forwards anything at all. An outer primitive that
+     composes through `asChild` (`ContextMenu.Trigger`, `Popover.Trigger`)
+     clones its child with handlers and data attributes; a tooltip that kept
+     them would leave the element with a tooltip and none of the behaviour
+     wrapped around it. The sidebar's collapsed rail depends on this: its tiles
+     carry a tooltip and a right-click menu at once. */
+  test("forwards props to the trigger so an outer asChild primitive composes", () => {
+    const html = renderToStaticMarkup(
+      <Tooltip content="Vex Ops" data-slot="context-menu-trigger" id="probe">
+        <button type="button">Open</button>
+      </Tooltip>,
+    );
+
+    expect(html).toContain('data-slot="context-menu-trigger"');
+    expect(html).toContain('id="probe"');
+  });
+});

--- a/packages/design-library/src/components/tooltip.tsx
+++ b/packages/design-library/src/components/tooltip.tsx
@@ -88,7 +88,8 @@ function Content({
   );
 }
 
-export interface TooltipProps {
+export interface TooltipProps
+  extends Omit<TriggerProps, "content" | "children" | "asChild"> {
   content: ReactNode;
   children: ReactNode;
   side?: TooltipContentProps["side"];
@@ -105,6 +106,13 @@ export interface TooltipProps {
  * storybooks) without requiring a provider ancestor. When an app-level
  * `TooltipProvider` exists, the inner provider scopes its own subtree
  * with matching defaults so behaviour is consistent.
+ *
+ * Anything else passed in reaches the trigger, so an outer primitive that
+ * composes through `asChild` (a `ContextMenu.Trigger`, a `Popover.Trigger`)
+ * can still reach the element underneath. Without that, a tooltipped child
+ * silently swallows the handlers such a primitive clones onto it, and the
+ * element ends up with a tooltip and none of the behaviour that was wrapped
+ * around it.
  */
 function Tooltip({
   content,
@@ -112,11 +120,14 @@ function Tooltip({
   side,
   align,
   delayDuration,
+  ...triggerProps
 }: TooltipProps) {
   return (
     <RadixTooltip.Provider delayDuration={200} skipDelayDuration={300}>
       <Root delayDuration={delayDuration}>
-        <Trigger asChild>{children}</Trigger>
+        <Trigger asChild {...triggerProps}>
+          {children}
+        </Trigger>
         <Content side={side} align={align}>
           {content}
         </Content>


### PR DESCRIPTION
## TL;DR

A pinned app could not be unpinned from the collapsed rail. The context menu now survives the collapse, so right-click (or long press) reaches the colour row and Unpin on the tile exactly as it does on the expanded pill.

Fixes LUM-3146.

## Before / after

| Affordance | Expanded pill | Collapsed tile (before) | Collapsed tile (after) |
|---|---|---|---|
| Right-click / long-press menu | yes | **none** | **yes** |
| Hover unpin button | yes | none | none, deliberately |
| Swipe to unpin (touch) | yes | none | none, deliberately |

Before, the only route was to expand the rail first.

## The cause, and the real blocker underneath it

The early return that swaps the pill for a tile sat *above* the `ContextMenu` wrapper, so the tile was a bare `SideMenu.Item`. Moving the return below it is the obvious fix, and on its own it would not have worked.

`Tooltip` accepted five props and dropped everything else. The collapsed tile carries `showCollapsedTooltip`, so `SideMenu.Item` returns a `Tooltip`-wrapped element; `ContextMenu.Trigger` composes through `asChild`, cloning its child with `onContextMenu`. Those handlers went into `Tooltip` and were never forwarded, so the tile could carry a tooltip **or** a menu, never both. That is what the old code recorded as "the tooltip provider would interfere".

`Tooltip` now forwards the rest of its props to its trigger, which is already `asChild`. That is the general fix: any element that needs a tooltip and an outer composing primitive at once now works, not just this tile.

## Why the tile keeps no swipe or hover button

Not an oversight, and worth stating so nobody "completes" it later:

- **No swipe.** A 30px tile has nowhere to swipe to, and `SwipeActionReveal`'s action buttons are sized for a full-width row. Touch gets the same menu by long press, which the trigger already handles.
- **No hover button.** `SideMenu.Item` has no trailing slot, and a 20px button inside a 30px tile would sit on the glyph it is meant to sit beside.

The menu content is now one definition used by both shapes, so the tile cannot drift from the row.

## Not the same as the conversation sections

Worth noting, because a sweep of the rail suggests nothing on it has a menu. Collapsed section tiles wrap in `Popover.Root` and render the section's list inside, so their popover **is** the interaction and their bulk actions live on the expanded header. A pinned app's tile has no popover: it opens the app on click and offered nothing else, so the early return removed its only management path rather than one of several.

## Verified in Storybook

Right-clicked the collapsed tile with a real pointer: the menu opens with the swatch row (teal checked, matching the tile's own tint) and Unpin. Clicking Unpin removed `Vex Ops`, left `Inbox Triage` in place, and storage updated to match. The tile itself now carries `data-slot="context-menu-trigger"`.

## Testing

Typecheck and lint clean in both packages. The collapsed-rail test that asserted the old behaviour ("renders the row without the context-menu wrapper") is replaced by four: the menu is present, Unpin clears the pin, the colour row rides along with its selection intact, and the hover button stays absent. A new `tooltip.test.tsx` covers the forwarding directly, including why it exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40543" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->