### PR TITLE
fix(providers): serve current Codex-subscription models from the openai defaults

### DIFF
--- a/assistant/src/__tests__/byok-default-profile-ensure.test.ts
+++ b/assistant/src/__tests__/byok-default-profile-ensure.test.ts
@@ -278,6 +278,8 @@ describe("ensureByokDefaultProfiles", () => {
     ["openrouter", "quality-optimized", "anthropic/claude-opus-4.8"],
     ["gemini", "cost-optimized", "gemini-3.1-flash-lite-preview"],
     ["openai", "cost-optimized", "gpt-5.4-nano"],
+    ["openai", "balanced", "gpt-5.4-mini"],
+    ["openai", "quality-optimized", "gpt-5.4"],
     ["fireworks", "balanced", "accounts/fireworks/models/kimi-k2p5"],
     ["fireworks", "balanced", "accounts/fireworks/models/kimi-k2p6"],
     [

--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -877,13 +877,13 @@ describe("loadConfig startup behavior", () => {
       raw.llm.defaultProvider,
     );
     expect(effective.balanced?.provider).toBe("openai");
-    expect(effective.balanced?.model).toBe("gpt-5.4-mini");
+    expect(effective.balanced?.model).toBe("gpt-5.6-luna");
     expect(effective.balanced?.provider_connection).toBe("openai-personal");
     expect(effective.balanced?.source).toBe("managed");
     expect(effective["quality-optimized"]?.provider).toBe("openai");
-    expect(effective["quality-optimized"]?.model).toBe("gpt-5.4");
+    expect(effective["quality-optimized"]?.model).toBe("gpt-5.6-sol");
     expect(effective["cost-optimized"]?.provider).toBe("openai");
-    expect(effective["cost-optimized"]?.model).toBe("gpt-5.4-nano");
+    expect(effective["cost-optimized"]?.model).toBe("gpt-5.6-luna");
   });
 
   test("off-platform hatch with a provider outside the named matrix columns resolves through the shared BYOK templates", () => {

--- a/assistant/src/__tests__/workspace-migration-142-consolidate-voice-front-door.test.ts
+++ b/assistant/src/__tests__/workspace-migration-142-consolidate-voice-front-door.test.ts
@@ -45,13 +45,21 @@ function readConfig(): Record<string, unknown> {
 }
 
 describe("142-consolidate-voice-front-door migration", () => {
-  test("is registered last", () => {
+  test("is registered in order", () => {
     expect(consolidateVoiceFrontDoorMigration.id).toBe(
       "142-consolidate-voice-front-door",
     );
-    expect(WORKSPACE_MIGRATIONS.at(-1)?.id).toBe(
-      consolidateVoiceFrontDoorMigration.id,
+    // getLastWorkspaceMigrationId() reports the final entry as the registry
+    // ceiling, so ordering matters: this must be registered, and everything
+    // after it must carry a higher id. Asserting it stays literally last
+    // would break on every migration appended after it.
+    const index = WORKSPACE_MIGRATIONS.findIndex(
+      (migration) => migration.id === "142-consolidate-voice-front-door",
     );
+    expect(index).toBeGreaterThan(-1);
+    for (const later of WORKSPACE_MIGRATIONS.slice(index + 1)) {
+      expect(later.id > "142").toBe(true);
+    }
   });
 
   test("moves progress overrides and removes generated-ack tuning", () => {

--- a/assistant/src/__tests__/workspace-migration-143-repair-deprecated-codex-model-id.test.ts
+++ b/assistant/src/__tests__/workspace-migration-143-repair-deprecated-codex-model-id.test.ts
@@ -64,6 +64,10 @@ describe("143-repair-deprecated-codex-model-id migration", () => {
         default: { provider: "chatgpt", model: DEPRECATED },
         callSites: {
           recall: { provider: "chatgpt", model: DEPRECATED, maxTokens: 4096 },
+          // A providerless call-site pin inherits the winning profile's
+          // provider and connection at resolve time, so it is repaired too.
+          heartbeatAgent: { model: DEPRECATED },
+          vision: { provider: "openai-compatible", model: DEPRECATED },
           malformed: DEPRECATED,
         },
         profiles: {
@@ -78,6 +82,8 @@ describe("143-repair-deprecated-codex-model-id migration", () => {
     expect(llm.default.model).toBe(REPLACEMENT);
     expect(llm.callSites.recall.model).toBe(REPLACEMENT);
     expect(llm.callSites.recall.maxTokens).toBe(4096);
+    expect(llm.callSites.heartbeatAgent.model).toBe(REPLACEMENT);
+    expect(llm.callSites.vision.model).toBe(DEPRECATED);
     expect(llm.profiles.codex.model).toBe(REPLACEMENT);
     expect(llm.profiles.codex.source).toBe("user");
   });
@@ -87,7 +93,9 @@ describe("143-repair-deprecated-codex-model-id migration", () => {
       llm: {
         profiles: {
           // The allowlist only gates the "chatgpt" routing identity; an
-          // openai-compatible endpoint may legitimately serve this id.
+          // openai-compatible endpoint may legitimately serve this id. A
+          // providerless profile completes against the code-owned base, not
+          // the subscription, so it stays untouched too.
           byok: { provider: "openai-compatible", model: DEPRECATED },
           inherited: { model: DEPRECATED },
           current: { provider: "chatgpt", model: "gpt-5.6-luna" },

--- a/assistant/src/__tests__/workspace-migration-143-repair-deprecated-codex-model-id.test.ts
+++ b/assistant/src/__tests__/workspace-migration-143-repair-deprecated-codex-model-id.test.ts
@@ -1,0 +1,125 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { repairDeprecatedCodexModelIdMigration } from "../workspace/migrations/143-repair-deprecated-codex-model-id.js";
+import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
+
+const DEPRECATED = "gpt-5.3-codex";
+const REPLACEMENT = "gpt-5.6-terra";
+
+let workspaceDir: string;
+
+function freshWorkspace(): void {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-143-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+}
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+beforeEach(() => {
+  freshWorkspace();
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+describe("143-repair-deprecated-codex-model-id migration", () => {
+  test("has correct migration id and is registered", () => {
+    expect(repairDeprecatedCodexModelIdMigration.id).toBe(
+      "143-repair-deprecated-codex-model-id",
+    );
+    expect(
+      WORKSPACE_MIGRATIONS.some(
+        (m) => m.id === "143-repair-deprecated-codex-model-id",
+      ),
+    ).toBe(true);
+  });
+
+  test("repairs chatgpt fragments in default, call sites, and profiles", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "chatgpt", model: DEPRECATED },
+        callSites: {
+          recall: { provider: "chatgpt", model: DEPRECATED, maxTokens: 4096 },
+          malformed: DEPRECATED,
+        },
+        profiles: {
+          codex: { provider: "chatgpt", model: DEPRECATED, source: "user" },
+        },
+      },
+    });
+
+    repairDeprecatedCodexModelIdMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as Record<string, any>;
+    expect(llm.default.model).toBe(REPLACEMENT);
+    expect(llm.callSites.recall.model).toBe(REPLACEMENT);
+    expect(llm.callSites.recall.maxTokens).toBe(4096);
+    expect(llm.profiles.codex.model).toBe(REPLACEMENT);
+    expect(llm.profiles.codex.source).toBe("user");
+  });
+
+  test("leaves other providers and other models untouched", () => {
+    const config = {
+      llm: {
+        profiles: {
+          // The allowlist only gates the "chatgpt" routing identity; an
+          // openai-compatible endpoint may legitimately serve this id.
+          byok: { provider: "openai-compatible", model: DEPRECATED },
+          inherited: { model: DEPRECATED },
+          current: { provider: "chatgpt", model: "gpt-5.6-luna" },
+        },
+      },
+    };
+    writeConfig(config);
+    const before = readFileSync(join(workspaceDir, "config.json"), "utf-8");
+
+    repairDeprecatedCodexModelIdMigration.run(workspaceDir);
+
+    expect(readFileSync(join(workspaceDir, "config.json"), "utf-8")).toBe(
+      before,
+    );
+  });
+
+  test("is idempotent and tolerates missing or malformed config", () => {
+    expect(() =>
+      repairDeprecatedCodexModelIdMigration.run(workspaceDir),
+    ).not.toThrow();
+
+    writeFileSync(join(workspaceDir, "config.json"), "not json {{{");
+    expect(() =>
+      repairDeprecatedCodexModelIdMigration.run(workspaceDir),
+    ).not.toThrow();
+
+    writeConfig({
+      llm: { profiles: { codex: { provider: "chatgpt", model: DEPRECATED } } },
+    });
+    repairDeprecatedCodexModelIdMigration.run(workspaceDir);
+    const once = readFileSync(join(workspaceDir, "config.json"), "utf-8");
+    repairDeprecatedCodexModelIdMigration.run(workspaceDir);
+    expect(readFileSync(join(workspaceDir, "config.json"), "utf-8")).toBe(once);
+  });
+});

--- a/assistant/src/providers/__tests__/connection-model-compat.test.ts
+++ b/assistant/src/providers/__tests__/connection-model-compat.test.ts
@@ -49,6 +49,7 @@ describe("isConnectionCompatibleWithModel", () => {
     expect(isConnectionCompatibleWithModel(conn, "gpt-5")).toBe(false);
     expect(isConnectionCompatibleWithModel(conn, "gpt-5.4-nano")).toBe(false);
     expect(isConnectionCompatibleWithModel(conn, "gpt-5.5-pro")).toBe(false);
+    expect(isConnectionCompatibleWithModel(conn, "gpt-5.3-codex")).toBe(false);
   });
 
   test("oauth_subscription connection is compatible with a Codex model", () => {
@@ -59,7 +60,6 @@ describe("isConnectionCompatibleWithModel", () => {
     expect(isConnectionCompatibleWithModel(conn, "gpt-5.5")).toBe(true);
     expect(isConnectionCompatibleWithModel(conn, "gpt-5.4")).toBe(true);
     expect(isConnectionCompatibleWithModel(conn, "gpt-5.4-mini")).toBe(true);
-    expect(isConnectionCompatibleWithModel(conn, "gpt-5.3-codex")).toBe(true);
   });
 
   test("undefined model applies no gating (compatible)", () => {

--- a/assistant/src/providers/model-intents.ts
+++ b/assistant/src/providers/model-intents.ts
@@ -93,10 +93,12 @@ for (const [provider, intents] of Object.entries(PROVIDER_MODEL_INTENTS)) {
 }
 
 // The openai column must additionally stay inside the ChatGPT Codex
-// subscription set: when `llm.defaultProvider` is the subscription, the
-// materialized default profiles pin the chatgpt-subscription connection —
-// which bypasses the auto-resolution compat gate and hard-routes to the
-// Codex endpoint, where a non-Codex model 400s on every request.
+// subscription set: the subscription default provider is stored as
+// `llm.defaultProvider = { provider: "openai", connectionName:
+// "chatgpt-subscription" }`, so the materialized default profiles resolve
+// through this column while pinning the subscription connection — which
+// bypasses the auto-resolution compat gate and hard-routes to the Codex
+// endpoint, where a non-Codex model 400s on every request.
 for (const [intent, modelId] of Object.entries(PROVIDER_MODEL_INTENTS.openai)) {
   if (!isCodexSubscriptionModel(modelId)) {
     throw new Error(

--- a/assistant/src/providers/model-intents.ts
+++ b/assistant/src/providers/model-intents.ts
@@ -13,7 +13,7 @@ const PROVIDER_DEFAULT_MODELS: Record<string, string> = Object.fromEntries(
 // `cost-optimized` is the cheapest model a provider serves, `latency-optimized`
 // the fastest to first token. On anthropic, ollama, fireworks and openai the
 // same model is both, so those columns repeat by construction rather than by
-// oversight (openai's balanced repeats it too — the default-profile templates
+// oversight (openai's balanced repeats it too: the default-profile templates
 // split those tiers by reasoning effort, not model).
 const PROVIDER_MODEL_INTENTS: Record<string, Record<ModelIntent, string>> = {
   anthropic: {
@@ -96,7 +96,7 @@ for (const [provider, intents] of Object.entries(PROVIDER_MODEL_INTENTS)) {
 // subscription set: the subscription default provider is stored as
 // `llm.defaultProvider = { provider: "openai", connectionName:
 // "chatgpt-subscription" }`, so the materialized default profiles resolve
-// through this column while pinning the subscription connection — which
+// through this column while pinning the subscription connection, which
 // bypasses the auto-resolution compat gate and hard-routes to the Codex
 // endpoint, where a non-Codex model 400s on every request.
 for (const [intent, modelId] of Object.entries(PROVIDER_MODEL_INTENTS.openai)) {

--- a/assistant/src/providers/model-intents.ts
+++ b/assistant/src/providers/model-intents.ts
@@ -1,4 +1,5 @@
 import { isModelInCatalog, PROVIDER_CATALOG } from "./model-catalog.js";
+import { isCodexSubscriptionModel } from "./openai/codex-models.js";
 import type { ModelIntent } from "./types.js";
 
 /**
@@ -10,8 +11,10 @@ const PROVIDER_DEFAULT_MODELS: Record<string, string> = Object.fromEntries(
 );
 
 // `cost-optimized` is the cheapest model a provider serves, `latency-optimized`
-// the fastest to first token. On anthropic, ollama and fireworks the same model
-// is both, so those columns repeat by construction rather than by oversight.
+// the fastest to first token. On anthropic, ollama, fireworks and openai the
+// same model is both, so those columns repeat by construction rather than by
+// oversight (openai's balanced repeats it too — the default-profile templates
+// split those tiers by reasoning effort, not model).
 const PROVIDER_MODEL_INTENTS: Record<string, Record<ModelIntent, string>> = {
   anthropic: {
     balanced: "claude-sonnet-4-6",
@@ -21,11 +24,11 @@ const PROVIDER_MODEL_INTENTS: Record<string, Record<ModelIntent, string>> = {
     "vision-optimized": "claude-opus-4-6",
   },
   openai: {
-    balanced: "gpt-5.4-mini",
-    "cost-optimized": "gpt-5.4-nano",
+    balanced: "gpt-5.6-luna",
+    "cost-optimized": "gpt-5.6-luna",
     "latency-optimized": "gpt-5.6-luna",
-    "quality-optimized": "gpt-5.4",
-    "vision-optimized": "gpt-5.4",
+    "quality-optimized": "gpt-5.6-sol",
+    "vision-optimized": "gpt-5.6-terra",
   },
   gemini: {
     balanced: "gemini-3-flash-preview",
@@ -86,6 +89,21 @@ for (const [provider, intents] of Object.entries(PROVIDER_MODEL_INTENTS)) {
           `which is not in PROVIDER_CATALOG. Update model-catalog.ts or model-intents.ts.`,
       );
     }
+  }
+}
+
+// The openai column must additionally stay inside the ChatGPT Codex
+// subscription set: when `llm.defaultProvider` is the subscription, the
+// materialized default profiles pin the chatgpt-subscription connection —
+// which bypasses the auto-resolution compat gate and hard-routes to the
+// Codex endpoint, where a non-Codex model 400s on every request.
+for (const [intent, modelId] of Object.entries(PROVIDER_MODEL_INTENTS.openai)) {
+  if (!isCodexSubscriptionModel(modelId)) {
+    throw new Error(
+      `PROVIDER_MODEL_INTENTS[openai][${intent}] references model "${modelId}" ` +
+        `which the ChatGPT subscription cannot serve. Pick a model from ` +
+        `CODEX_SUBSCRIPTION_MODEL_IDS in openai/codex-models.ts.`,
+    );
   }
 }
 

--- a/assistant/src/providers/openai/codex-models.ts
+++ b/assistant/src/providers/openai/codex-models.ts
@@ -13,9 +13,11 @@ export const CODEX_SUBSCRIPTION_MODEL_IDS: ReadonlySet<string> = new Set([
   "gpt-5.6-terra",
   "gpt-5.6-luna",
   "gpt-5.5",
+  // Retire from ChatGPT sign-in on 2026-08-31 (API-key auth is unaffected):
+  // remove both then, and migrate stored `provider: "chatgpt"` profiles that
+  // pin them, or those configs fail schema validation.
   "gpt-5.4",
   "gpt-5.4-mini",
-  "gpt-5.3-codex",
 ]);
 
 /** True when `model` is allowlisted for Codex subscription routing. */

--- a/assistant/src/providers/openai/codex-models.ts
+++ b/assistant/src/providers/openai/codex-models.ts
@@ -13,9 +13,8 @@ export const CODEX_SUBSCRIPTION_MODEL_IDS: ReadonlySet<string> = new Set([
   "gpt-5.6-terra",
   "gpt-5.6-luna",
   "gpt-5.5",
-  // Retire from ChatGPT sign-in on 2026-08-31 (API-key auth is unaffected):
-  // remove both then, and migrate stored `provider: "chatgpt"` profiles that
-  // pin them, or those configs fail schema validation.
+  // OpenAI retires these two from ChatGPT sign-in on 2026-08-31; API-key
+  // auth is unaffected.
   "gpt-5.4",
   "gpt-5.4-mini",
 ]);

--- a/assistant/src/workspace/byok-default-profile-ensure.ts
+++ b/assistant/src/workspace/byok-default-profile-ensure.ts
@@ -156,6 +156,10 @@ const HISTORICAL_INTENT_MODELS: Record<
   Partial<Record<string, readonly string[]>>
 > = {
   balanced: {
+    openai: [
+      // balanced intent 2026-05-05 (#29755) to the 2026-08-10 gpt-5.6 repoint.
+      "gpt-5.4-mini",
+    ],
     fireworks: [
       // balanced intent 2026-05-05 (#29755) to 2026-05-19 (#31068).
       "accounts/fireworks/models/kimi-k2p5",
@@ -166,6 +170,10 @@ const HISTORICAL_INTENT_MODELS: Record<
     ],
   },
   "quality-optimized": {
+    openai: [
+      // quality intent 2026-05-05 (#29755) to the 2026-08-10 gpt-5.6 repoint.
+      "gpt-5.4",
+    ],
     anthropic: [
       // quality intent 2026-05-05 (#29755) to 2026-06-11 (#34498).
       "claude-opus-4-7",

--- a/assistant/src/workspace/migrations/143-repair-deprecated-codex-model-id.ts
+++ b/assistant/src/workspace/migrations/143-repair-deprecated-codex-model-id.ts
@@ -1,0 +1,122 @@
+import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+/**
+ * Repair the deprecated `gpt-5.3-codex` model ID on ChatGPT-subscription
+ * config fragments.
+ *
+ * OpenAI deprecated `gpt-5.3-codex` under ChatGPT sign-in (the Codex
+ * endpoint rejects it with HTTP 400), so it is being removed from
+ * `CODEX_SUBSCRIPTION_MODEL_IDS`. A workspace can still pin it on
+ * `provider: "chatgpt"` fragments — migration 133 wrote exactly that shape
+ * for `chatgpt-subscription` entries — and once the ID leaves the allowlist,
+ * `LLMSchema.superRefine` rejects such a fragment. The loader's leaf
+ * recovery then deletes the fragment's `model`, which still fails ("chatgpt"
+ * requires an explicit model), and per-section salvage resets the whole
+ * `llm` section — discarding the user's other LLM settings.
+ *
+ * Repair rewrites the model to `gpt-5.6-terra` (OpenAI's recommended
+ * everyday Codex model) on an exact `provider: "chatgpt"` + model match in
+ * `llm.default`, `llm.callSites.*`, and `llm.profiles.*`. Fragments with any
+ * other provider are left untouched: the allowlist only gates the "chatgpt"
+ * routing identity, so they cannot trip the salvage path.
+ */
+export const repairDeprecatedCodexModelIdMigration: WorkspaceMigration = {
+  id: "143-repair-deprecated-codex-model-id",
+  description:
+    'Repair deprecated gpt-5.3-codex model ID on provider "chatgpt" fragments in workspace LLM config',
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) {
+      return;
+    }
+
+    // Read outside the parse catch: a transient filesystem error (EIO,
+    // EACCES) must reach the runner so the migration retries, while
+    // malformed JSON is a permanent state this migration cannot repair.
+    const rawText = readFileSync(configPath, "utf-8");
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(rawText);
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+        return;
+      }
+      config = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    const llm = readObject(config.llm);
+    if (llm === null) {
+      return;
+    }
+
+    let changed = false;
+
+    changed = repairFragment(readObject(llm.default)) || changed;
+
+    const callSites = readObject(llm.callSites);
+    if (callSites !== null) {
+      for (const rawConfig of Object.values(callSites)) {
+        changed = repairFragment(readObject(rawConfig)) || changed;
+      }
+    }
+
+    const profiles = readObject(llm.profiles);
+    if (profiles !== null) {
+      for (const rawProfile of Object.values(profiles)) {
+        changed = repairFragment(readObject(rawProfile)) || changed;
+      }
+    }
+
+    if (!changed) {
+      return;
+    }
+
+    // Write-then-rename so an interrupted write cannot leave config.json
+    // truncated: a torn in-place write would parse as invalid JSON on the
+    // retry, which the catch above treats as "nothing to do", letting the
+    // runner checkpoint the migration as completed against a corrupt file.
+    const tmpPath = `${configPath}.migration-143.tmp`;
+    writeFileSync(tmpPath, JSON.stringify(config, null, 2) + "\n");
+    renameSync(tmpPath, configPath);
+  },
+  // The exact-match rewrite is idempotent, so a transient failure (full
+  // disk, I/O error) is safe to retry on later startups.
+  retryFailedCheckpoint: true,
+  down(_workspaceDir: string): void {
+    // Forward-only: reintroducing the deprecated model ID would fail schema
+    // validation once the allowlist no longer carries it.
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers: self-contained per workspace migrations AGENTS.md
+// ---------------------------------------------------------------------------
+
+const DEPRECATED_MODEL_ID = "gpt-5.3-codex";
+const REPLACEMENT_MODEL_ID = "gpt-5.6-terra";
+
+function repairFragment(fragment: Record<string, unknown> | null): boolean {
+  if (fragment === null) {
+    return false;
+  }
+  if (
+    fragment.provider !== "chatgpt" ||
+    fragment.model !== DEPRECATED_MODEL_ID
+  ) {
+    return false;
+  }
+  fragment.model = REPLACEMENT_MODEL_ID;
+  return true;
+}
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}

--- a/assistant/src/workspace/migrations/143-repair-deprecated-codex-model-id.ts
+++ b/assistant/src/workspace/migrations/143-repair-deprecated-codex-model-id.ts
@@ -19,9 +19,14 @@ import type { WorkspaceMigration } from "./types.js";
  *
  * Repair rewrites the model to `gpt-5.6-terra` (OpenAI's recommended
  * everyday Codex model) on an exact `provider: "chatgpt"` + model match in
- * `llm.default`, `llm.callSites.*`, and `llm.profiles.*`. Fragments with any
- * other provider are left untouched: the allowlist only gates the "chatgpt"
- * routing identity, so they cannot trip the salvage path.
+ * `llm.default`, `llm.callSites.*`, and `llm.profiles.*`. A call-site
+ * fragment is also repaired when it pins the model with no provider of its
+ * own: at resolve time such a fragment overlays the winning profile, so the
+ * stale pin rides whatever provider and connection the winner supplies
+ * (including the subscription connection, which routes it to the Codex
+ * endpoint). Fragments with any other explicit provider are left untouched:
+ * the allowlist only gates the "chatgpt" routing identity, and a provider
+ * like `openai-compatible` may legitimately serve this id.
  */
 export const repairDeprecatedCodexModelIdMigration: WorkspaceMigration = {
   id: "143-repair-deprecated-codex-model-id",
@@ -61,7 +66,10 @@ export const repairDeprecatedCodexModelIdMigration: WorkspaceMigration = {
     const callSites = readObject(llm.callSites);
     if (callSites !== null) {
       for (const rawConfig of Object.values(callSites)) {
-        changed = repairFragment(readObject(rawConfig)) || changed;
+        changed =
+          repairFragment(readObject(rawConfig), {
+            repairMissingProvider: true,
+          }) || changed;
       }
     }
 
@@ -100,14 +108,18 @@ export const repairDeprecatedCodexModelIdMigration: WorkspaceMigration = {
 const DEPRECATED_MODEL_ID = "gpt-5.3-codex";
 const REPLACEMENT_MODEL_ID = "gpt-5.6-terra";
 
-function repairFragment(fragment: Record<string, unknown> | null): boolean {
-  if (fragment === null) {
+function repairFragment(
+  fragment: Record<string, unknown> | null,
+  options?: { repairMissingProvider?: boolean },
+): boolean {
+  if (fragment === null || fragment.model !== DEPRECATED_MODEL_ID) {
     return false;
   }
-  if (
-    fragment.provider !== "chatgpt" ||
-    fragment.model !== DEPRECATED_MODEL_ID
-  ) {
+  const providerRepairable =
+    fragment.provider === "chatgpt" ||
+    (options?.repairMissingProvider === true &&
+      fragment.provider === undefined);
+  if (!providerRepairable) {
     return false;
   }
   fragment.model = REPLACEMENT_MODEL_ID;

--- a/assistant/src/workspace/migrations/143-repair-deprecated-codex-model-id.ts
+++ b/assistant/src/workspace/migrations/143-repair-deprecated-codex-model-id.ts
@@ -10,12 +10,12 @@ import type { WorkspaceMigration } from "./types.js";
  * OpenAI deprecated `gpt-5.3-codex` under ChatGPT sign-in (the Codex
  * endpoint rejects it with HTTP 400), so it is being removed from
  * `CODEX_SUBSCRIPTION_MODEL_IDS`. A workspace can still pin it on
- * `provider: "chatgpt"` fragments — migration 133 wrote exactly that shape
- * for `chatgpt-subscription` entries — and once the ID leaves the allowlist,
+ * `provider: "chatgpt"` fragments (migration 133 wrote exactly that shape
+ * for `chatgpt-subscription` entries), and once the ID leaves the allowlist,
  * `LLMSchema.superRefine` rejects such a fragment. The loader's leaf
  * recovery then deletes the fragment's `model`, which still fails ("chatgpt"
  * requires an explicit model), and per-section salvage resets the whole
- * `llm` section — discarding the user's other LLM settings.
+ * `llm` section, discarding the user's other LLM settings.
  *
  * Repair rewrites the model to `gpt-5.6-terra` (OpenAI's recommended
  * everyday Codex model) on an exact `provider: "chatgpt"` + model match in

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -140,6 +140,7 @@ import { clearRenamedCostProfileLabelMigration } from "./139-clear-renamed-cost-
 import { repairSeedPinnedMemoryV3LiveMigration } from "./140-repair-seed-pinned-memory-v3-live.js";
 import { sttEnglishDefaultToMultilingualMigration } from "./141-stt-english-default-to-multilingual.js";
 import { consolidateVoiceFrontDoorMigration } from "./142-consolidate-voice-front-door.js";
+import { repairDeprecatedCodexModelIdMigration } from "./143-repair-deprecated-codex-model-id.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -295,4 +296,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   repairSeedPinnedMemoryV3LiveMigration,
   sttEnglishDefaultToMultilingualMigration,
   consolidateVoiceFrontDoorMigration,
+  repairDeprecatedCodexModelIdMigration,
 ];

--- a/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
@@ -32,7 +32,8 @@ const CODEX_SUBSCRIPTION_MODEL_IDS = new Set([
   "gpt-5.6-terra",
   "gpt-5.6-luna",
   "gpt-5.5",
-  // Retire from ChatGPT sign-in on 2026-08-31 (API-key auth is unaffected).
+  // OpenAI retires these two from ChatGPT sign-in on 2026-08-31; API-key
+  // auth is unaffected.
   "gpt-5.4",
   "gpt-5.4-mini",
 ]);

--- a/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
@@ -25,14 +25,16 @@ import type {
   ProviderConnection,
 } from "@/generated/daemon/types.gen";
 
+// Keep in sync with CODEX_SUBSCRIPTION_MODEL_IDS in
+// assistant/src/providers/openai/codex-models.ts.
 const CODEX_SUBSCRIPTION_MODEL_IDS = new Set([
   "gpt-5.6-sol",
   "gpt-5.6-terra",
   "gpt-5.6-luna",
   "gpt-5.5",
+  // Retire from ChatGPT sign-in on 2026-08-31 (API-key auth is unaffected).
   "gpt-5.4",
   "gpt-5.4-mini",
-  "gpt-5.3-codex",
 ]);
 
 function connectionModelsToCatalog(


### PR DESCRIPTION
## Summary
- Drop `gpt-5.3-codex` from `CODEX_SUBSCRIPTION_MODEL_IDS` (already deprecated upstream — the Codex endpoint 400s it) and from the web client's copy of the set; date-comment the 2026-08-31 retirement of `gpt-5.4`/`gpt-5.4-mini` from ChatGPT sign-in.
- Repoint the openai intent column to the gpt-5.6 family: balanced and cost-optimized → `gpt-5.6-luna` (tiers split by reasoning effort, matching the managed profiles), quality-optimized → `gpt-5.6-sol`, vision-optimized → `gpt-5.6-terra`. Outgoing pins are recorded in `HISTORICAL_INTENT_MODELS` so unedited hatch-era `custom-*` copies keep converting.
- Add a module-load guard that every openai intent model is Codex-subscription-servable: the subscription default-provider path pins the `chatgpt-subscription` connection, which bypasses the auto-resolution compat gate and hard-routes to the Codex endpoint — a non-Codex pin there (previously `gpt-5.4-nano` on Cost) 400s on every request.

## Original prompt
Per OpenAI's docs (learn.chatgpt.com/docs/models), `gpt-5.3-codex` is already deprecated under ChatGPT sign-in and `gpt-5.4`/`gpt-5.4-mini` retire on 2026-08-31 (API-key auth unaffected). The Cost default profile also resolved `gpt-5.4-nano`, which the subscription never served — the pinned connection bypasses the compat gate, so it 400d at request time. The user asked to align the openai defaults with the managed profiles (balanced on luna with thinking on, cost on luna with thinking off, quality on sol) and clean the deprecated ids out of the allowlist. A follow-up PR after the Aug 31 retirement will shrink the allowlist to the 5.6 family + 5.5 and migrate stored `provider: "chatgpt"` profiles off the retired models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uts2hxMb2vf6DfuNoK6B4X
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40544" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->