### PR TITLE
fix(web): decide the context-window ring on pointer, and use the real Tooltip (LUM-3197)

### DIFF
--- a/clients/web/src/domains/chat/components/context-window-indicator.stories.tsx
+++ b/clients/web/src/domains/chat/components/context-window-indicator.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { showContextWindowIndicator } from "@/utils/composer-settings";
+
+import { ContextWindowIndicator } from "./context-window-indicator";
+
+/**
+ * The composer's context-window fill ring. Opt-in via Settings → General →
+ * Preferences, so every story enables the preference first.
+ *
+ * The ring reveals its detail on hover under a mouse and opens a bottom sheet
+ * under a thumb: the input-capability axis, per `docs/PLATFORM_ADAPTATION.md`.
+ * Switch the emulated pointer (DevTools → Rendering → "Emulate CSS media
+ * feature pointer") and reload to compare the two presentations; the sheet is
+ * the only branch carrying "Clear Context".
+ */
+
+const meta = {
+  title: "Chat/ContextWindowIndicator",
+  component: ContextWindowIndicator,
+  parameters: { layout: "centered" },
+  loaders: [
+    () => {
+      showContextWindowIndicator.save(true);
+      return {};
+    },
+  ],
+  decorators: [
+    (Story) => (
+      <div className="flex items-center rounded-lg bg-[var(--surface-lift)] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    assistantName: "Vellum",
+    onClearContext: () => {},
+  },
+} satisfies Meta<typeof ContextWindowIndicator>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    usage: { tokens: 42_000, maxTokens: 200_000, fillRatio: 0.21 },
+  },
+};
+
+export const Warning: Story = {
+  args: {
+    usage: { tokens: 130_000, maxTokens: 200_000, fillRatio: 0.65 },
+  },
+};
+
+export const Critical: Story = {
+  args: {
+    usage: { tokens: 176_000, maxTokens: 200_000, fillRatio: 0.88 },
+  },
+};

--- a/clients/web/src/domains/chat/components/context-window-indicator.test.tsx
+++ b/clients/web/src/domains/chat/components/context-window-indicator.test.tsx
@@ -119,9 +119,8 @@ describe("ContextWindowIndicator presentation axis", () => {
 
   test("a roomy touch window still gets a tappable trigger", () => {
     // GIVEN a tablet in landscape: a coarse pointer with plenty of room.
-    // This is the regression. Forking on the narrow-AND-coarse compound left
-    // this combination on the hover-only branch, where the ring had no tap
-    // path and no way to reach Clear Context.
+    // Roomy and thumb-driven is the combination the two axes only disagree
+    // on, and the one a width check answers wrongly.
     setViewport({ narrow: false, coarsePointer: true });
 
     // WHEN the ring renders
@@ -162,10 +161,10 @@ describe("ContextWindowIndicator presentation axis", () => {
       <ContextWindowIndicator usage={USAGE} assistantName="Vellum" />,
     );
 
-    // THEN the control reveals a tooltip rather than opening a sheet
+    // THEN the control reveals a tooltip rather than opening a sheet, while
+    // remaining named and keyboard-reachable, which is how a desktop user
+    // without a mouse gets at it.
     expect(opensASheet()).toBe(false);
-    // ...but the ring is still named and still reachable by keyboard, which is
-    // the only way a mouse-less desktop user opens it.
     expectOneNamedTabStop(container);
   });
 });

--- a/clients/web/src/domains/chat/components/context-window-indicator.test.tsx
+++ b/clients/web/src/domains/chat/components/context-window-indicator.test.tsx
@@ -91,12 +91,16 @@ describe("ContextWindowIndicator presentation axis", () => {
   const RING_NAME = "Context window 45% full";
 
   /**
-   * The ring's detail is reachable by tap exactly when the pointer is coarse,
-   * because the alternative presentation is hover-only. A coarse pointer has
-   * no hover, so anything short of a real trigger leaves the ring inert.
+   * Both branches render a button, so element type cannot tell them apart.
+   * What distinguishes them is whether the control opens something on
+   * activation: the sheet trigger announces `aria-haspopup="dialog"`, the
+   * tooltip trigger announces nothing because a tooltip is revealed, not
+   * opened. That is also the contract a screen-reader user hears, so it is
+   * the right thing to assert.
    */
-  function ringTrigger(): HTMLElement | null {
-    return screen.queryByRole("button", { name: RING_NAME });
+  function opensASheet(): boolean {
+    const trigger = screen.getByRole("button", { name: RING_NAME });
+    return trigger.getAttribute("aria-haspopup") === "dialog";
   }
 
   /**
@@ -130,7 +134,7 @@ describe("ContextWindowIndicator presentation axis", () => {
     );
 
     // THEN the ring is a real trigger a thumb can hit, not a hover target
-    expect(ringTrigger()).not.toBeNull();
+    expect(opensASheet()).toBe(true);
     expectOneNamedTabStop(container);
   });
 
@@ -144,7 +148,7 @@ describe("ContextWindowIndicator presentation axis", () => {
     );
 
     // THEN it is the same presentation as the roomy touch case above
-    expect(ringTrigger()).not.toBeNull();
+    expect(opensASheet()).toBe(true);
     expectOneNamedTabStop(container);
   });
 
@@ -158,8 +162,8 @@ describe("ContextWindowIndicator presentation axis", () => {
       <ContextWindowIndicator usage={USAGE} assistantName="Vellum" />,
     );
 
-    // THEN there is no sheet trigger, because hover can still reveal the detail
-    expect(ringTrigger()).toBeNull();
+    // THEN the control reveals a tooltip rather than opening a sheet
+    expect(opensASheet()).toBe(false);
     // ...but the ring is still named and still reachable by keyboard, which is
     // the only way a mouse-less desktop user opens it.
     expectOneNamedTabStop(container);

--- a/clients/web/src/domains/chat/components/context-window-indicator.test.tsx
+++ b/clients/web/src/domains/chat/components/context-window-indicator.test.tsx
@@ -88,13 +88,25 @@ describe("ContextWindowIndicator", () => {
 });
 
 describe("ContextWindowIndicator presentation axis", () => {
+  const RING_NAME = "Context window 45% full";
+
   /**
    * The ring's detail is reachable by tap exactly when the pointer is coarse,
    * because the alternative presentation is hover-only. A coarse pointer has
    * no hover, so anything short of a real trigger leaves the ring inert.
    */
   function ringTrigger(): HTMLElement | null {
-    return screen.getByLabelText("Context window 45% full").closest("button");
+    return screen.queryByRole("button", { name: RING_NAME });
+  }
+
+  /**
+   * Whichever branch renders, exactly one element carries the ring's name and
+   * exactly one is focusable. A labelled, tabbable glyph nested inside a
+   * labelled, tabbable trigger announces twice and costs two tab stops.
+   */
+  function expectOneNamedTabStop(container: HTMLElement): void {
+    expect(screen.getAllByLabelText(RING_NAME)).toHaveLength(1);
+    expect(container.querySelectorAll("[tabindex], button")).toHaveLength(1);
   }
 
   beforeEach(() => {
@@ -109,7 +121,7 @@ describe("ContextWindowIndicator presentation axis", () => {
     setViewport({ narrow: false, coarsePointer: true });
 
     // WHEN the ring renders
-    render(
+    const { container } = render(
       <ContextWindowIndicator
         usage={USAGE}
         assistantName="Vellum"
@@ -119,6 +131,7 @@ describe("ContextWindowIndicator presentation axis", () => {
 
     // THEN the ring is a real trigger a thumb can hit, not a hover target
     expect(ringTrigger()).not.toBeNull();
+    expectOneNamedTabStop(container);
   });
 
   test("a phone-sized touch window gets the same tappable trigger", () => {
@@ -126,10 +139,13 @@ describe("ContextWindowIndicator presentation axis", () => {
     setViewport({ narrow: true, coarsePointer: true });
 
     // WHEN the ring renders
-    render(<ContextWindowIndicator usage={USAGE} assistantName="Vellum" />);
+    const { container } = render(
+      <ContextWindowIndicator usage={USAGE} assistantName="Vellum" />,
+    );
 
     // THEN it is the same presentation as the roomy touch case above
     expect(ringTrigger()).not.toBeNull();
+    expectOneNamedTabStop(container);
   });
 
   test("a narrow mouse window keeps the hover presentation", () => {
@@ -138,9 +154,14 @@ describe("ContextWindowIndicator presentation axis", () => {
     setViewport({ narrow: true, coarsePointer: false });
 
     // WHEN the ring renders
-    render(<ContextWindowIndicator usage={USAGE} assistantName="Vellum" />);
+    const { container } = render(
+      <ContextWindowIndicator usage={USAGE} assistantName="Vellum" />,
+    );
 
     // THEN there is no sheet trigger, because hover can still reveal the detail
     expect(ringTrigger()).toBeNull();
+    // ...but the ring is still named and still reachable by keyboard, which is
+    // the only way a mouse-less desktop user opens it.
+    expectOneNamedTabStop(container);
   });
 });

--- a/clients/web/src/domains/chat/components/context-window-indicator.test.tsx
+++ b/clients/web/src/domains/chat/components/context-window-indicator.test.tsx
@@ -1,16 +1,22 @@
 /**
- * Tests for `ContextWindowIndicator`'s opt-in gate.
+ * Tests for `ContextWindowIndicator`'s opt-in gate and its presentation axis.
  *
  * The ring is hidden unless the user turns it on in Settings → General →
  * Preferences: a gauge filling toward "full" reads as an impending failure
  * even though the assistant compacts its own context. These tests pin both
- * halves of that contract — silent by default, visible once opted in.
+ * halves of that contract, silent by default and visible once opted in.
+ *
+ * They also pin which axis chooses the presentation. The ring reveals its
+ * detail on hover under a mouse and opens a tappable sheet under a thumb,
+ * which is input capability, not window size: see `docs/PLATFORM_ADAPTATION.md`.
  * Uses happy-dom via the bun:test preload configured in `web/bunfig.toml`.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { cleanup, render, screen } from "@testing-library/react";
+
+import { stubViewportAxes } from "@/hooks/viewport-axes.test-helper";
 
 let indicatorEnabled = false;
 
@@ -21,20 +27,26 @@ mock.module("@/utils/composer-settings", () => ({
   },
 }));
 
-mock.module("@/hooks/use-touch-mobile", () => ({
-  useTouchMobile: () => false,
-}));
-
 import { ContextWindowIndicator } from "@/domains/chat/components/context-window-indicator";
 
 const USAGE = { tokens: 90_000, maxTokens: 200_000, fillRatio: 0.45 };
 
+let restoreViewport: () => void = () => {};
+
+function setViewport(axes: { narrow: boolean; coarsePointer: boolean }): void {
+  restoreViewport();
+  restoreViewport = stubViewportAxes(axes);
+}
+
 beforeEach(() => {
   indicatorEnabled = false;
+  setViewport({ narrow: false, coarsePointer: false });
 });
 
 afterEach(() => {
   cleanup();
+  restoreViewport();
+  restoreViewport = () => {};
 });
 
 describe("ContextWindowIndicator", () => {
@@ -72,5 +84,63 @@ describe("ContextWindowIndicator", () => {
 
     // THEN there is nothing to show
     expect(container.firstChild).toBeNull();
+  });
+});
+
+describe("ContextWindowIndicator presentation axis", () => {
+  /**
+   * The ring's detail is reachable by tap exactly when the pointer is coarse,
+   * because the alternative presentation is hover-only. A coarse pointer has
+   * no hover, so anything short of a real trigger leaves the ring inert.
+   */
+  function ringTrigger(): HTMLElement | null {
+    return screen.getByLabelText("Context window 45% full").closest("button");
+  }
+
+  beforeEach(() => {
+    indicatorEnabled = true;
+  });
+
+  test("a roomy touch window still gets a tappable trigger", () => {
+    // GIVEN a tablet in landscape: a coarse pointer with plenty of room.
+    // This is the regression. Forking on the narrow-AND-coarse compound left
+    // this combination on the hover-only branch, where the ring had no tap
+    // path and no way to reach Clear Context.
+    setViewport({ narrow: false, coarsePointer: true });
+
+    // WHEN the ring renders
+    render(
+      <ContextWindowIndicator
+        usage={USAGE}
+        assistantName="Vellum"
+        onClearContext={() => {}}
+      />,
+    );
+
+    // THEN the ring is a real trigger a thumb can hit, not a hover target
+    expect(ringTrigger()).not.toBeNull();
+  });
+
+  test("a phone-sized touch window gets the same tappable trigger", () => {
+    // GIVEN a phone in portrait: coarse and narrow
+    setViewport({ narrow: true, coarsePointer: true });
+
+    // WHEN the ring renders
+    render(<ContextWindowIndicator usage={USAGE} assistantName="Vellum" />);
+
+    // THEN it is the same presentation as the roomy touch case above
+    expect(ringTrigger()).not.toBeNull();
+  });
+
+  test("a narrow mouse window keeps the hover presentation", () => {
+    // GIVEN a desktop window dragged narrow, or an Electron shell: still a
+    // mouse. Width alone must not push a hover-capable pointer to the sheet.
+    setViewport({ narrow: true, coarsePointer: false });
+
+    // WHEN the ring renders
+    render(<ContextWindowIndicator usage={USAGE} assistantName="Vellum" />);
+
+    // THEN there is no sheet trigger, because hover can still reveal the detail
+    expect(ringTrigger()).toBeNull();
   });
 });

--- a/clients/web/src/domains/chat/components/context-window-indicator.tsx
+++ b/clients/web/src/domains/chat/components/context-window-indicator.tsx
@@ -44,24 +44,26 @@ function formatTokens(count: number): string {
   return `${count}`;
 }
 
+/**
+ * The ring glyph only. Deliberately carries no name, role, or tab stop: each
+ * branch below wraps it in exactly one focusable, labelled element, and a
+ * labelled ring nested inside a labelled trigger would announce twice and
+ * take two tab stops.
+ */
 function CircularRing({
   ringColor,
   dashOffset,
-  percentage,
 }: {
   ringColor: string;
   dashOffset: number;
-  percentage: number;
 }) {
   return (
     <svg
       width={RING_SIZE}
       height={RING_SIZE}
       viewBox={`0 0 ${RING_SIZE} ${RING_SIZE}`}
-      role="img"
-      aria-label={`Context window ${percentage}% full`}
-      tabIndex={0}
-      className="block outline-none focus-visible:ring-1 focus-visible:ring-[var(--primary-base)] rounded-full"
+      aria-hidden="true"
+      className="block"
     >
       <circle
         cx={RING_SIZE / 2}
@@ -301,11 +303,7 @@ export function ContextWindowIndicator({
             className="relative flex items-center px-1.5"
             aria-label={`Context window ${percentage}% full`}
           >
-            <CircularRing
-              ringColor={ringColor}
-              dashOffset={dashOffset}
-              percentage={percentage}
-            />
+            <CircularRing ringColor={ringColor} dashOffset={dashOffset} />
           </button>
         </BottomSheet.Trigger>
         <BottomSheet.Content
@@ -335,17 +333,16 @@ export function ContextWindowIndicator({
   return (
     <div
       ref={triggerRef}
-      className="relative flex items-center px-1.5"
+      role="img"
+      aria-label={`Context window ${percentage}% full`}
+      tabIndex={0}
+      className="relative flex items-center rounded-full px-1.5 outline-none focus-visible:ring-1 focus-visible:ring-[var(--primary-base)]"
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       onFocus={handleMouseEnter}
       onBlur={handleMouseLeave}
     >
-      <CircularRing
-        ringColor={ringColor}
-        dashOffset={dashOffset}
-        percentage={percentage}
-      />
+      <CircularRing ringColor={ringColor} dashOffset={dashOffset} />
       {isHovered &&
         createPortal(
           <div

--- a/clients/web/src/domains/chat/components/context-window-indicator.tsx
+++ b/clients/web/src/domains/chat/components/context-window-indicator.tsx
@@ -1,9 +1,9 @@
 import { Brain } from "lucide-react";
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
-import { useTouchMobile } from "@/hooks/use-touch-mobile";
 import { showContextWindowIndicator } from "@/utils/composer-settings";
+import { isPointerCoarse } from "@/utils/pointer";
 import { BottomSheet, Button } from "@vellumai/design-library";
 
 export interface ContextWindowUsage {
@@ -91,7 +91,7 @@ function CircularRing({
   );
 }
 
-function DesktopTooltipContent({
+function PointerTooltipContent({
   percentage,
   ringColor,
   tokens,
@@ -126,7 +126,7 @@ function DesktopTooltipContent({
   );
 }
 
-function MobileSheetContent({
+function TouchSheetContent({
   percentage,
   ringColor,
   ratio,
@@ -220,7 +220,13 @@ export function ContextWindowIndicator({
 }: ContextWindowIndicatorProps) {
   const assistantDisplayName = assistantName?.trim() || "Your assistant";
   const enabled = showContextWindowIndicator.useValue();
-  const isTouchMobile = useTouchMobile();
+  // Input capability, not window size: the other presentation is a
+  // hover-revealed tooltip, and a coarse pointer has no hover to reveal it
+  // with. The narrow-AND-coarse compound would strand every roomy touch
+  // device (a tablet either way up, a phone in landscape) on a branch it
+  // cannot operate. Read once so a streaming token count cannot flip the
+  // presentation mid-turn and remount the open sheet.
+  const isTouch = useMemo(() => isPointerCoarse(), []);
   const [sheetOpen, setSheetOpen] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
   const [tooltipPosition, setTooltipPosition] = useState<{
@@ -266,10 +272,9 @@ export function ContextWindowIndicator({
   const dashOffset = RING_CIRCUMFERENCE * (1 - ratio);
   const { tokens, maxTokens } = usage;
 
+  // Only ever wired up on the pointer branch below, which a coarse pointer
+  // never reaches.
   const handleMouseEnter = () => {
-    if (isTouchMobile) {
-      return;
-    }
     if (hoverTimerRef.current != null) {
       clearTimeout(hoverTimerRef.current);
     }
@@ -287,7 +292,7 @@ export function ContextWindowIndicator({
     setTooltipPosition(null);
   };
 
-  if (isTouchMobile) {
+  if (isTouch) {
     return (
       <BottomSheet.Root open={sheetOpen} onOpenChange={setSheetOpen}>
         <BottomSheet.Trigger asChild>
@@ -311,7 +316,7 @@ export function ContextWindowIndicator({
             <BottomSheet.Title>Context Window</BottomSheet.Title>
           </BottomSheet.Header>
           <BottomSheet.Body className="px-2 pt-8 pb-8">
-            <MobileSheetContent
+            <TouchSheetContent
               percentage={percentage}
               ringColor={ringColor}
               ratio={ratio}
@@ -353,7 +358,7 @@ export function ContextWindowIndicator({
               opacity: tooltipPosition ? 1 : 0,
             }}
           >
-            <DesktopTooltipContent
+            <PointerTooltipContent
               percentage={percentage}
               ringColor={ringColor}
               tokens={tokens}

--- a/clients/web/src/domains/chat/components/context-window-indicator.tsx
+++ b/clients/web/src/domains/chat/components/context-window-indicator.tsx
@@ -48,6 +48,14 @@ function formatTokens(count: number): string {
 }
 
 /**
+ * The ring's accessible name. Both presentations and the sheet's gauge share
+ * it, so a screen reader hears the same thing whichever one renders.
+ */
+function ringLabel(percentage: number): string {
+  return `Context window ${percentage}% full`;
+}
+
+/**
  * The ring glyph only. Deliberately carries no name, role, or tab stop: each
  * branch below wraps it in exactly one focusable, labelled element, and a
  * labelled ring nested inside a labelled trigger would announce twice and
@@ -170,7 +178,7 @@ function TouchSheetContent({
             height={16}
             fillColor={ringColor}
             className="bg-[color-mix(in_srgb,var(--content-tertiary)_20%,transparent)]"
-            aria-label={`Context window ${percentage}% full`}
+            aria-label={ringLabel(percentage)}
           />
         </div>
 
@@ -249,7 +257,7 @@ export function ContextWindowIndicator({
           <button
             type="button"
             className="relative flex items-center px-1.5"
-            aria-label={`Context window ${percentage}% full`}
+            aria-label={ringLabel(percentage)}
           >
             <CircularRing ringColor={ringColor} dashOffset={dashOffset} />
           </button>
@@ -280,15 +288,15 @@ export function ContextWindowIndicator({
 
   // Own the provider rather than relying on the app-level one in
   // `providers.tsx`, so the ring also works in isolation (tests, Storybook).
-  // The design library's own `Tooltip` convenience wrapper does the same and
+  // The design library's own `Tooltip` convenience wrapper does the same, and
   // documents that a nested provider scopes its subtree with matching
-  // defaults. The delays match the app-level values.
+  // defaults.
   return (
     <TooltipProvider delayDuration={200} skipDelayDuration={300}>
       <Tooltip.Root>
         <Tooltip.Trigger
           type="button"
-          aria-label={`Context window ${percentage}% full`}
+          aria-label={ringLabel(percentage)}
           className="relative flex items-center rounded-full px-1.5 outline-none focus-visible:ring-1 focus-visible:ring-[var(--primary-base)]"
         >
           <CircularRing ringColor={ringColor} dashOffset={dashOffset} />

--- a/clients/web/src/domains/chat/components/context-window-indicator.tsx
+++ b/clients/web/src/domains/chat/components/context-window-indicator.tsx
@@ -6,6 +6,7 @@ import { isPointerCoarse } from "@/utils/pointer";
 import {
   BottomSheet,
   Button,
+  ProgressBar,
   Tooltip,
   TooltipProvider,
 } from "@vellumai/design-library";
@@ -164,15 +165,13 @@ function TouchSheetContent({
         </BottomSheet.Title>
 
         <div className="w-full px-2">
-          <div className="relative h-4 w-full overflow-hidden rounded-full bg-[color-mix(in_srgb,var(--content-tertiary)_20%,transparent)]">
-            <div
-              className="h-full rounded-full transition-[width] duration-250 ease-out"
-              style={{
-                width: `${Math.round(ratio * 100)}%`,
-                backgroundColor: ringColor,
-              }}
-            />
-          </div>
+          <ProgressBar
+            value={ratio}
+            height={16}
+            fillColor={ringColor}
+            className="bg-[color-mix(in_srgb,var(--content-tertiary)_20%,transparent)]"
+            aria-label={`Context window ${percentage}% full`}
+          />
         </div>
 
         <div className="flex flex-col items-center gap-2">

--- a/clients/web/src/domains/chat/components/context-window-indicator.tsx
+++ b/clients/web/src/domains/chat/components/context-window-indicator.tsx
@@ -224,13 +224,12 @@ export function ContextWindowIndicator({
 }: ContextWindowIndicatorProps) {
   const assistantDisplayName = assistantName?.trim() || "Your assistant";
   const enabled = showContextWindowIndicator.useValue();
-  // Input capability, not window size: the other presentation is a
-  // hover-revealed tooltip, and a coarse pointer has no hover to reveal it
-  // with (Radix tooltips deliberately never open on touch). The
-  // narrow-AND-coarse compound would strand every roomy touch device (a
-  // tablet either way up, a phone in landscape) on a branch it cannot
-  // operate. Read once so a streaming token count cannot flip the
-  // presentation mid-turn and remount the open sheet.
+  // Input capability, not window size. The other presentation is a
+  // hover-revealed tooltip, and Radix tooltips never open on touch, so a
+  // coarse pointer needs the sheet at any width: a tablet and a phone in
+  // landscape are both roomy and both thumb-driven. Read once, so a
+  // streaming token count cannot flip the presentation mid-turn and remount
+  // an open sheet.
   const isTouch = useMemo(() => isPointerCoarse(), []);
   const [sheetOpen, setSheetOpen] = useState(false);
 

--- a/clients/web/src/domains/chat/components/context-window-indicator.tsx
+++ b/clients/web/src/domains/chat/components/context-window-indicator.tsx
@@ -1,10 +1,14 @@
 import { Brain } from "lucide-react";
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
 
 import { showContextWindowIndicator } from "@/utils/composer-settings";
 import { isPointerCoarse } from "@/utils/pointer";
-import { BottomSheet, Button } from "@vellumai/design-library";
+import {
+  BottomSheet,
+  Button,
+  Tooltip,
+  TooltipProvider,
+} from "@vellumai/design-library";
 
 export interface ContextWindowUsage {
   tokens: number;
@@ -22,8 +26,6 @@ const RING_SIZE = 16;
 const RING_STROKE = 2;
 const RING_RADIUS = (RING_SIZE - RING_STROKE) / 2;
 const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
-const HOVER_DELAY_MS = 200;
-const TOOLTIP_GAP_PX = 8;
 
 function resolveRingColor(ratio: number): string {
   if (ratio >= 0.8) {
@@ -224,45 +226,13 @@ export function ContextWindowIndicator({
   const enabled = showContextWindowIndicator.useValue();
   // Input capability, not window size: the other presentation is a
   // hover-revealed tooltip, and a coarse pointer has no hover to reveal it
-  // with. The narrow-AND-coarse compound would strand every roomy touch
-  // device (a tablet either way up, a phone in landscape) on a branch it
-  // cannot operate. Read once so a streaming token count cannot flip the
+  // with (Radix tooltips deliberately never open on touch). The
+  // narrow-AND-coarse compound would strand every roomy touch device (a
+  // tablet either way up, a phone in landscape) on a branch it cannot
+  // operate. Read once so a streaming token count cannot flip the
   // presentation mid-turn and remount the open sheet.
   const isTouch = useMemo(() => isPointerCoarse(), []);
   const [sheetOpen, setSheetOpen] = useState(false);
-  const [isHovered, setIsHovered] = useState(false);
-  const [tooltipPosition, setTooltipPosition] = useState<{
-    top: number;
-    left: number;
-  } | null>(null);
-  const triggerRef = useRef<HTMLDivElement | null>(null);
-  const tooltipRef = useRef<HTMLDivElement | null>(null);
-  const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (hoverTimerRef.current != null) {
-        clearTimeout(hoverTimerRef.current);
-      }
-    };
-  }, []);
-
-  useLayoutEffect(() => {
-    if (!isHovered || !triggerRef.current || !tooltipRef.current) {
-      return;
-    }
-    const triggerRect = triggerRef.current.getBoundingClientRect();
-    const tooltipRect = tooltipRef.current.getBoundingClientRect();
-    const viewportWidth = window.innerWidth;
-    const idealLeft =
-      triggerRect.left + triggerRect.width / 2 - tooltipRect.width / 2;
-    const clampedLeft = Math.max(
-      8,
-      Math.min(idealLeft, viewportWidth - tooltipRect.width - 8),
-    );
-    const top = triggerRect.top - tooltipRect.height - TOOLTIP_GAP_PX;
-    setTooltipPosition({ top, left: clampedLeft });
-  }, [isHovered, usage]);
 
   if (!enabled || !usage || usage.fillRatio == null) {
     return null;
@@ -273,26 +243,6 @@ export function ContextWindowIndicator({
   const ringColor = resolveRingColor(ratio);
   const dashOffset = RING_CIRCUMFERENCE * (1 - ratio);
   const { tokens, maxTokens } = usage;
-
-  // Only ever wired up on the pointer branch below, which a coarse pointer
-  // never reaches.
-  const handleMouseEnter = () => {
-    if (hoverTimerRef.current != null) {
-      clearTimeout(hoverTimerRef.current);
-    }
-    hoverTimerRef.current = setTimeout(() => {
-      setIsHovered(true);
-    }, HOVER_DELAY_MS);
-  };
-
-  const handleMouseLeave = () => {
-    if (hoverTimerRef.current != null) {
-      clearTimeout(hoverTimerRef.current);
-      hoverTimerRef.current = null;
-    }
-    setIsHovered(false);
-    setTooltipPosition(null);
-  };
 
   if (isTouch) {
     return (
@@ -330,41 +280,34 @@ export function ContextWindowIndicator({
     );
   }
 
+  // Own the provider rather than relying on the app-level one in
+  // `providers.tsx`, so the ring also works in isolation (tests, Storybook).
+  // The design library's own `Tooltip` convenience wrapper does the same and
+  // documents that a nested provider scopes its subtree with matching
+  // defaults. The delays match the app-level values.
   return (
-    <div
-      ref={triggerRef}
-      role="img"
-      aria-label={`Context window ${percentage}% full`}
-      tabIndex={0}
-      className="relative flex items-center rounded-full px-1.5 outline-none focus-visible:ring-1 focus-visible:ring-[var(--primary-base)]"
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
-      onFocus={handleMouseEnter}
-      onBlur={handleMouseLeave}
-    >
-      <CircularRing ringColor={ringColor} dashOffset={dashOffset} />
-      {isHovered &&
-        createPortal(
-          <div
-            ref={tooltipRef}
-            role="tooltip"
-            className="fixed z-[9999] flex flex-col gap-2 rounded-[10px] bg-[var(--surface-lift)] p-3 text-left whitespace-nowrap pointer-events-none shadow-[var(--shadow-popover)]"
-            style={{
-              top: tooltipPosition?.top ?? -9999,
-              left: tooltipPosition?.left ?? -9999,
-              opacity: tooltipPosition ? 1 : 0,
-            }}
-          >
-            <PointerTooltipContent
-              percentage={percentage}
-              ringColor={ringColor}
-              tokens={tokens}
-              maxTokens={maxTokens}
-              assistantDisplayName={assistantDisplayName}
-            />
-          </div>,
-          document.body,
-        )}
-    </div>
+    <TooltipProvider delayDuration={200} skipDelayDuration={300}>
+      <Tooltip.Root>
+        <Tooltip.Trigger
+          type="button"
+          aria-label={`Context window ${percentage}% full`}
+          className="relative flex items-center rounded-full px-1.5 outline-none focus-visible:ring-1 focus-visible:ring-[var(--primary-base)]"
+        >
+          <CircularRing ringColor={ringColor} dashOffset={dashOffset} />
+        </Tooltip.Trigger>
+        <Tooltip.Content
+          side="top"
+          className="flex flex-col gap-2 bg-[var(--surface-lift)] p-3 text-left"
+        >
+          <PointerTooltipContent
+            percentage={percentage}
+            ringColor={ringColor}
+            tokens={tokens}
+            maxTokens={maxTokens}
+            assistantDisplayName={assistantDisplayName}
+          />
+        </Tooltip.Content>
+      </Tooltip.Root>
+    </TooltipProvider>
   );
 }

--- a/clients/web/src/domains/intelligence/components/superpowers/superpowers-tab.test.tsx
+++ b/clients/web/src/domains/intelligence/components/superpowers/superpowers-tab.test.tsx
@@ -34,6 +34,7 @@ import type {
   PluginsSearchGetResponse,
   SkillsGetResponse,
 } from "@/generated/daemon/types.gen";
+import { stubViewportAxes } from "@/hooks/viewport-axes.test-helper";
 import { MIN_VERSION as PLUGINS_MIN_VERSION } from "@/lib/backwards-compat/plugins-surface";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 
@@ -303,40 +304,6 @@ function clickFilterOption(label: string): void {
     throw new Error(`expected a "${label}" filter option`);
   }
   fireEvent.click(option);
-}
-
-/**
- * Answers media queries for a given device shape: `narrow` drives the mobile
- * breakpoint (which decides whether the category rail renders at all), and
- * `coarsePointer` drives `useTouchMobile`, which picks the bottom sheet over
- * the popover. Returns a restore fn the caller invokes once done.
- */
-function stubViewport({
-  narrow,
-  coarsePointer,
-}: {
-  narrow: boolean;
-  coarsePointer: boolean;
-}): () => void {
-  const original = window.matchMedia;
-  window.matchMedia = ((query: string) => {
-    const widthOk = query.includes("min-width")
-      ? !narrow
-      : !query.includes("max-width") || narrow;
-    return {
-      matches: widthOk && (!query.includes("pointer: coarse") || coarsePointer),
-      media: query,
-      onchange: null,
-      addEventListener: () => {},
-      removeEventListener: () => {},
-      addListener: () => {},
-      removeListener: () => {},
-      dispatchEvent: () => false,
-    };
-  }) as unknown as typeof window.matchMedia;
-  return () => {
-    window.matchMedia = original;
-  };
 }
 
 beforeEach(() => {
@@ -896,7 +863,7 @@ describe("SuperpowersTab", () => {
     installedCategoryCounts = { email: 1 };
     catalogMatches = [catalog({ name: "sys-cat", category: "system" })];
 
-    const restoreMatchMedia = stubViewport({
+    const restoreMatchMedia = stubViewportAxes({
       narrow: true,
       coarsePointer: true,
     });
@@ -928,7 +895,7 @@ describe("SuperpowersTab", () => {
     // A mouse-driven window narrow enough to hide the category rail: the
     // popover is the only category surface, so it grows the section the sheet
     // carries on touch.
-    const restoreMatchMedia = stubViewport({
+    const restoreMatchMedia = stubViewportAxes({
       narrow: true,
       coarsePointer: false,
     });

--- a/clients/web/src/hooks/viewport-axes.test-helper.ts
+++ b/clients/web/src/hooks/viewport-axes.test-helper.ts
@@ -1,0 +1,44 @@
+/**
+ * Answers media queries for a given device shape, so a test can drive the two
+ * device-side platform-adaptation axes independently.
+ *
+ * `narrow` drives the window-size axis (`useIsMobile()`, `max-md:`), and
+ * `coarsePointer` drives the input-capability axis (`isPointerCoarse()`).
+ * The compound `useTouchMobile()` query falls out of both, which is the point:
+ * the combinations that come apart, a roomy touch tablet and a narrow window
+ * driven by a mouse, are the ones adaptation bugs hide in. See
+ * `docs/PLATFORM_ADAPTATION.md`.
+ *
+ * Stubbing `window.matchMedia` rather than mocking the hook modules keeps the
+ * test honest about which signal the component actually consults, and avoids
+ * bun's process-global module mocks leaking into sibling suites.
+ *
+ * Returns a restore fn the caller invokes once done.
+ */
+export function stubViewportAxes({
+  narrow,
+  coarsePointer,
+}: {
+  narrow: boolean;
+  coarsePointer: boolean;
+}): () => void {
+  const original = window.matchMedia;
+  window.matchMedia = ((query: string) => {
+    const widthOk = query.includes("min-width")
+      ? !narrow
+      : !query.includes("max-width") || narrow;
+    return {
+      matches: widthOk && (!query.includes("pointer: coarse") || coarsePointer),
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    };
+  }) as unknown as typeof window.matchMedia;
+  return () => {
+    window.matchMedia = original;
+  };
+}

--- a/packages/design-library/src/components/progress-bar.stories.tsx
+++ b/packages/design-library/src/components/progress-bar.stories.tsx
@@ -8,6 +8,7 @@ const meta: Meta<typeof ProgressBar> = {
   argTypes: {
     value: { control: { type: "range", min: 0, max: 1, step: 0.01 } },
     height: { control: { type: "number", min: 2, max: 24 } },
+    fillColor: { control: { type: "text" } },
   },
   decorators: [
     (Story) => (
@@ -36,6 +37,20 @@ export const Full: Story = {
 
 export const CustomHeight: Story = {
   args: { value: 0.45, height: 12, "aria-label": "Thick progress bar" },
+};
+
+/**
+ * A threshold gauge, where colour carries meaning that length alone does not.
+ * `fillColor` tints the fill; the track is styled with `className`.
+ */
+export const Tinted: Story = {
+  args: {
+    value: 0.88,
+    height: 16,
+    fillColor: "var(--system-negative-strong)",
+    className: "bg-[color-mix(in_srgb,var(--content-tertiary)_20%,transparent)]",
+    "aria-label": "Context window 88% full",
+  },
 };
 
 export const Increments: Story = {

--- a/packages/design-library/src/components/progress-bar.tsx
+++ b/packages/design-library/src/components/progress-bar.tsx
@@ -6,6 +6,13 @@ export interface ProgressBarProps {
   value: number;
   "aria-label"?: string;
   className?: string;
+  /**
+   * Fill colour, for bars whose meaning is carried by colour rather than
+   * length alone (a threshold gauge that shifts neutral to amber to red).
+   * Any CSS colour; prefer a token. Defaults to `--content-default`.
+   * Style the track with `className`.
+   */
+  fillColor?: string;
   height?: number;
   ref?: Ref<HTMLDivElement>;
 }
@@ -21,6 +28,7 @@ export function ProgressBar({
   value,
   "aria-label": ariaLabel,
   className,
+  fillColor,
   height = 6,
   ref,
 }: ProgressBarProps) {
@@ -44,9 +52,11 @@ export function ProgressBar({
       style={{ height }}
     >
       <div
+        data-slot="progress-bar-fill"
         className="h-full bg-[var(--content-default)] rounded-full"
         style={{
           width: `${percent}%`,
+          backgroundColor: fillColor,
           transition: "width 400ms cubic-bezier(0.22, 1, 0.36, 1)",
         }}
       />


### PR DESCRIPTION
## TL;DR

The composer's context-window ring is completely inert on any touch device wider than 767px: an iPad in either orientation, an iPhone in landscape, an Android tablet. It picked its presentation from `useTouchMobile()` (narrow **AND** coarse) and fell back to a hover-revealed tooltip, and a coarse pointer has no hover. The trigger on that branch was a plain `<div>` with no `onClick` and the tooltip was `pointer-events-none`, so a tap did nothing whatsoever.

Whether a hover-revealed affordance can exist at all is the **input-capability** axis, so the fork now reads `isPointerCoarse()` and drops the size half.

While in here, two hand-rolled reimplementations of design-library primitives in the same file are replaced with the primitives.

Fixes LUM-3197. Closes most of LUM-3199.

## Five commits, five separable things

1. **The bug.** `useTouchMobile()` to `isPointerCoarse()`. Restores a dead control on every tablet.
2. **An a11y defect CI surfaced.** The touch branch put the ring's `aria-label` on the `BottomSheet` trigger *and* on the `<svg role="img">` inside it, which also carried `tabIndex={0}`: a labelled, tabbable glyph inside a labelled, tabbable button, so it announced twice and cost two tab stops. Commit 1 would have shipped that to tablets. `CircularRing` is now presentational (`aria-hidden`, no role, no tab stop) and each branch owns exactly one focusable named element.
3. **The hand-rolled tooltip.** Replaced with the design library's Radix-backed `Tooltip`. Net **-53 lines**.
4. **Comments describing history rather than the present.** Root `AGENTS.md` rule, caught in review.
5. **A second hand-rolled reimplementation.** The sheet built its progress bar from a nested div with an inline width percentage, next to a `ProgressBar` in the design library. Swapped, which required extending the primitive.

## Why the primitive swaps are in this PR

`clients/web/AGENTS.md` says design-system-first, and a repo-wide grep for `role="tooltip"` returned **this file and nothing else**. Every other hover label in the client already goes through the primitive. `providers.tsx` already mounts a `TooltipProvider` with `delayDuration={200}`, the exact 200ms this component reimplemented with its own `setTimeout`.

Deleted with the tooltip swap: the `createPortal`, the `useLayoutEffect` measuring `getBoundingClientRect()`, the hand-clamped horizontal positioning, the hover timer, `isHovered`, `tooltipPosition`, all three refs, and the cleanup effect. Two things the hand-rolled version got wrong, fixed for free:

- **Collision handling.** It only ever opened above, with a single `Math.max/min` on the horizontal axis. Radix picks a side and sizes against `--radix-tooltip-content-available-width`.
- **It was invisible to screen readers.** Nothing associated the panel with its trigger. Radix wires `aria-describedby`; verified set in the browser.

The component owns its own `TooltipProvider` so it still works in tests and Storybook. The library's own convenience wrapper does the same and documents the nesting.

## Extending ProgressBar rather than keeping the hand-rolled copy

`ProgressBar` could not express this bar: its fill colour is fixed to `--content-default`, and this one is a threshold gauge whose colour carries the meaning (neutral, then amber, then red). The design library's rule 7 says customization goes through a prop, not a wrapper, so it takes an optional `fillColor`.

It is additive and the four existing consumers are untouched: with the prop absent, React omits the inline `backgroundColor` and the existing class still applies. Verified against the `Default` story, which still resolves to `--content-default` with no inline background. The track was already stylable through `className`, since `cn` runs tailwind-merge.

The swap also gives the bar semantics it never had. The hand-rolled markup was two anonymous divs, invisible to assistive tech; the primitive carries `role="progressbar"` with `aria-valuenow`, and the fill gains a `data-slot="progress-bar-fill"` per the library's slot rule. A `Tinted` story covers the new prop.

## What is deliberately still deferred

Unifying the two content bodies, tracked in LUM-3199. "Clear Context" ships only on the sheet. Radix forbids interactive tooltip content, so putting it on the pointer branch means moving desktop from hover-reveal to click-to-open: a UX decision that wants design sign-off. Note this is an affordance asymmetry, not a lost capability, since `onClearContext` maps to `sendMessage("/clean")`, which anyone can type.

Also deferred: this file's user-facing strings are hardcoded rather than going through `t()`. The chat domain is 2 of 305 files on `useTranslation`, and i18n is being migrated a domain at a time (see #40537), so converting one file here would start a migration at an arbitrary point rather than clean anything up.

## What changes for the user

| Device | Before | After |
| --- | --- | --- |
| Desktop or Electron, mouse, any width | Hover reveals a hand-positioned tooltip | Hover reveals the same content via the design-library tooltip, with proper collision handling |
| Desktop window dragged narrow, still a mouse | Hover reveals the tooltip | Unchanged. Width alone never pushes a hover-capable pointer to the sheet |
| Phone, portrait (under 768px) | Tap opens the bottom sheet, with Clear Context | Unchanged |
| **Phone, landscape (852px on a 15 Pro)** | **Ring is dead. No hover, no tap, no numbers** | Tap opens the bottom sheet, with Clear Context |
| **iPad, either orientation (768px and up)** | **Ring is dead. No hover, no tap, no numbers** | Tap opens the bottom sheet, with Clear Context |
| **Android tablet** | **Ring is dead** | Tap opens the bottom sheet, with Clear Context |
| Screen reader | Touch branch announced twice; the desktop tooltip was never announced; the progress bar was two anonymous divs | One name per branch, tooltip wired via `aria-describedby`, bar exposes `role="progressbar"` with `aria-valuenow` |
| Keyboard | Two tab stops on touch | One tab stop, both branches |

Axes touched: **input capability** is now the only one consulted; **window size** no longer participates (it was the half causing the bug); **platform** is untouched.

## Why it is safe

- `isPointerCoarse()` is false wherever `useTouchMobile()` was false *and* the pointer is fine, which is every mouse-driven window at every width. The only cell whose behaviour changes is coarse-pointer-and-roomy, which was broken.
- Read once via `useMemo` on mount, so a streaming token count cannot flip the presentation mid-turn and remount an open sheet. Matches the existing `isPointerCoarse()` call sites (`mobile-subagent-detail-overlay`, `queued-messages-drawer`).
- The `ProgressBar` change is additive, with the default path verified unchanged in Storybook.
- Presentation is still forked, because Radix tooltips deliberately never open on touch, so a coarse pointer genuinely still needs the sheet. This does not add a caller-side `Sheet : Popover` fork of the kind LUM-3177 is consolidating.

## Verification

- Reproduced and re-verified in the browser at both sides of both axes, driving viewport width and `(pointer: coarse)` / `(hover: none)` independently. Before: at 1024px with a coarse pointer the ring rendered a `DIV`, and a synthetic tap produced no tooltip, no dialog, and left `document.activeElement` on `BODY`. After: the same combination renders a `BUTTON` with `aria-haspopup="dialog"` whose tap opens the sheet with Clear Context present. At 1024px with a fine pointer the trigger has no `aria-haspopup`, hover and keyboard focus both reveal the tooltip (confirmed rendering through `data-slot="tooltip-content"`), and `aria-describedby` is set. One accessible name and one tab stop in every combination.
- Progress bar verified in both Storybooks: the tinted bar renders `role="progressbar"`, `aria-valuenow="65"`, a 16px track with the translucent override, and an amber fill at exactly 65% (624 of 960px). The `Default` story still resolves to `--content-default` with no inline background.
- Typecheck clean in both `clients/web` and `packages/design-library`; lint clean, warning count unchanged at 16 pre-existing.
- Local `bun test` is blocked by a standing hook here, so the axis tests run in CI. The first CI run failed on a bad test query, which is what surfaced the double-label defect in commit 2.

## Not verified without a real device

An emulated coarse pointer in a desktop browser is not a WKWebView. The iOS overlay-tap quirk in `docs/CAPACITOR.md` should not apply, because the touch trigger is a real `<button>` via `BottomSheet.Trigger asChild` rather than the plain `<div>` that quirk requires, but a confirmation pass on a physical iPad is worth doing. Called out in the ticket.

## Also in this PR

- A colocated Storybook story for the ring (three fill levels), which had none.
- `stubViewportAxes`, a shared test helper driving the size and pointer axes independently, extracted from an exact duplicate in `superpowers-tab.test.tsx` and now used by both. Two copies of the stub encoding the three-axis contract is the same drift this class of bug comes from.
- Tests discriminate the branches on `aria-haspopup="dialog"` rather than element type, since both triggers are now buttons. That is also the contract a screen-reader user hears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
