### PR TITLE
refactor(web): give the live window size one owner

### DIFF
--- a/clients/web/docs/PLATFORM_ADAPTATION.md
+++ b/clients/web/docs/PLATFORM_ADAPTATION.md
@@ -39,6 +39,29 @@ matching Tailwind's `md` breakpoint. Use it for **layout**: how many columns, wh
 stacks, how many chips fit before truncating. Prefer plain `max-md:` classes when CSS can express it,
 and reach for the hook only when the difference is structural (different components, different props).
 
+#### Measured sizes: no new JavaScript `clamp()`
+
+The same preference, one level down. `useLayoutViewportSize()` and `useElementSize()`
+([`src/hooks/use-element-size.ts`](../src/hooks/use-element-size.ts)) hand you a live `{ w, h }`, and it
+is tempting to do the sizing arithmetic in JavaScript. If `clamp()`, `min()`, `vmin`, `vw`, `dvh` or `%`
+can express the rule, write it in CSS instead. Most of this app already does
+(`max-w-[min(520px,calc(100vw-8rem))]`, `w-[90vw] max-w-[800px]`).
+
+This is not a style preference. CSS units resolve against a defined box automatically, so they cannot
+disagree with the `%`-positioned content beside them. JavaScript has to *pick* a box, and there are
+three plausible answers here (the layout viewport, the visual viewport, and the container), which is
+how a decorative layer ends up half a safe-area inset out of register with the foreground it is pinned
+to. CSS also updates without a React render.
+
+Reach for a measured size only when CSS genuinely cannot: a number handed to an animation library, or
+one paired with a `getBoundingClientRect()`.
+
+**Direction of travel.** The onboarding and voice-room decorative layers predate this rule and compute
+`clamp()` in JavaScript today (`edgeSize` is literally `clamp(130px, 40vmin, 420px)`). That is tracked
+in LUM-3204 and is being unwound per surface, so treat those files as the pattern being retired rather
+than the example to copy. New consumers of the measured-size hooks should be able to say which of the
+two exceptions above they fall under.
+
 ### Input capability
 
 The pointer is the signal for **interaction**: which overlay a trigger opens, whether long-press is

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
@@ -48,7 +48,7 @@
  * Everything here is sized against the box it is given, not the window. The
  * room is an inset panel on desktop (see `voice-room.tsx`), so "the screen" the
  * avatar grows to BE is the panel; the room measures itself and passes that
- * box, and Storybook passes its frame. `useWindowSize` remains only as the
+ * box, and Storybook passes its frame. `useLayoutViewportSize` remains only as the
  * fallback for callers that render at full-viewport scale.
  */
 
@@ -60,7 +60,7 @@ import {
   useReducedMotion,
 } from "motion/react";
 
-import { useWindowSize } from "@/hooks/use-element-size";
+import { useLayoutViewportSize } from "@/hooks/use-element-size";
 import { pathBBox, unionBBox, type BBox } from "@/utils/eye-bbox";
 import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
 
@@ -357,7 +357,7 @@ export function VoiceRoomColorLook({
   viewport?: { w: number; h: number };
 }) {
   const reduce = useReducedMotion();
-  const measured = useWindowSize();
+  const measured = useLayoutViewportSize();
   const { w, h } = viewport ?? measured;
   const entrance = withReducedMotion(requestedEntrance, reduce === true);
 
@@ -958,7 +958,7 @@ export function VoiceRespondingRings({
   /** The room box to size against; omitted, falls back to the window. */
   viewport?: { w: number; h: number };
 }) {
-  const measured = useWindowSize();
+  const measured = useLayoutViewportSize();
   return (
     <VoiceRespondingTreatment
       style="rings"

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
@@ -48,7 +48,7 @@
  * Everything here is sized against the box it is given, not the window. The
  * room is an inset panel on desktop (see `voice-room.tsx`), so "the screen" the
  * avatar grows to BE is the panel; the room measures itself and passes that
- * box, and Storybook passes its frame. `useViewportSize` remains only as the
+ * box, and Storybook passes its frame. `useWindowSize` remains only as the
  * fallback for callers that render at full-viewport scale.
  */
 
@@ -60,6 +60,7 @@ import {
   useReducedMotion,
 } from "motion/react";
 
+import { useWindowSize } from "@/hooks/use-element-size";
 import { pathBBox, unionBBox, type BBox } from "@/utils/eye-bbox";
 import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
 
@@ -301,25 +302,6 @@ function eyeDisplayHeight(art: VoiceRoomEyeArt, w: number, h: number): number {
   );
 }
 
-function windowSize(): { w: number; h: number } {
-  return { w: window.innerWidth, h: window.innerHeight };
-}
-
-/**
- * The window box, kept live on resize. The fallback for callers that render at
- * full-viewport scale. The room itself measures its own panel and passes it in
- * as `viewport`; see `use-room-box.ts`.
- */
-function useViewportSize(): { w: number; h: number } {
-  const [size, setSize] = useState(windowSize);
-  useEffect(() => {
-    const onResize = () => setSize(windowSize());
-    window.addEventListener("resize", onResize);
-    return () => window.removeEventListener("resize", onResize);
-  }, []);
-  return size;
-}
-
 /**
  * The full color look: dark base, screen-covering body grow, color fade,
  * listening waves, peeking eyes. Mount = session start (the room only mounts
@@ -375,7 +357,7 @@ export function VoiceRoomColorLook({
   viewport?: { w: number; h: number };
 }) {
   const reduce = useReducedMotion();
-  const measured = useViewportSize();
+  const measured = useWindowSize();
   const { w, h } = viewport ?? measured;
   const entrance = withReducedMotion(requestedEntrance, reduce === true);
 
@@ -976,7 +958,7 @@ export function VoiceRespondingRings({
   /** The room box to size against; omitted, falls back to the window. */
   viewport?: { w: number; h: number };
 }) {
-  const measured = useViewportSize();
+  const measured = useWindowSize();
   return (
     <VoiceRespondingTreatment
       style="rings"

--- a/clients/web/src/domains/onboarding/components/onboarding-edge-characters.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-edge-characters.tsx
@@ -15,7 +15,7 @@
  * Decorative: `aria-hidden`, `pointer-events-none`, reduced-motion safe.
  */
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo } from "react";
 import { useReducedMotion } from "motion/react";
 
 import { AnimatedAvatar } from "@/components/avatar/animated-avatar";
@@ -28,28 +28,15 @@ import {
   SLOT_ROTATIONS,
 } from "@/domains/onboarding/components/onboarding-character-stage";
 import { useOnboardingAvatarPoolStore } from "@/domains/onboarding/onboarding-avatar-pool-store";
+import { useWindowSize } from "@/hooks/use-element-size";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
-
-function useViewport() {
-  const [size, setSize] = useState(() => ({
-    w: typeof window === "undefined" ? 1280 : window.innerWidth,
-    h: typeof window === "undefined" ? 800 : window.innerHeight,
-  }));
-  useEffect(() => {
-    const onResize = () =>
-      setSize({ w: window.innerWidth, h: window.innerHeight });
-    window.addEventListener("resize", onResize);
-    return () => window.removeEventListener("resize", onResize);
-  }, []);
-  return size;
-}
 
 export function OnboardingEdgeCharacters() {
   const components = useBundledAvatarComponents();
   const characters = useOnboardingAvatarPoolStore.use.characters();
   const ensureGenerated = useOnboardingAvatarPoolStore.use.ensureGenerated();
   const reduce = useReducedMotion();
-  const { w, h } = useViewport();
+  const { w, h } = useWindowSize();
 
   useEffect(() => {
     if (components) {

--- a/clients/web/src/domains/onboarding/components/onboarding-edge-characters.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-edge-characters.tsx
@@ -28,7 +28,7 @@ import {
   SLOT_ROTATIONS,
 } from "@/domains/onboarding/components/onboarding-character-stage";
 import { useOnboardingAvatarPoolStore } from "@/domains/onboarding/onboarding-avatar-pool-store";
-import { useWindowSize } from "@/hooks/use-element-size";
+import { useLayoutViewportSize } from "@/hooks/use-element-size";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 
 export function OnboardingEdgeCharacters() {
@@ -36,7 +36,7 @@ export function OnboardingEdgeCharacters() {
   const characters = useOnboardingAvatarPoolStore.use.characters();
   const ensureGenerated = useOnboardingAvatarPoolStore.use.ensureGenerated();
   const reduce = useReducedMotion();
-  const { w, h } = useWindowSize();
+  const { w, h } = useLayoutViewportSize();
 
   useEffect(() => {
     if (components) {

--- a/clients/web/src/domains/onboarding/hooks/use-onboarding-stage-size.tsx
+++ b/clients/web/src/domains/onboarding/hooks/use-onboarding-stage-size.tsx
@@ -17,7 +17,10 @@
 
 import { createContext, useContext, type ReactNode } from "react";
 
-import { useWindowSize, type StageSize } from "@/hooks/use-element-size";
+import {
+  useLayoutViewportSize,
+  type StageSize,
+} from "@/hooks/use-element-size";
 
 export { useElementSize } from "@/hooks/use-element-size";
 export type { ElementSize, StageSize } from "@/hooks/use-element-size";
@@ -45,6 +48,6 @@ export function OnboardingStageSizeProvider({
 export function useOnboardingStageSize(): StageSize {
   const ctx = useContext(OnboardingStageSizeContext);
   // A provider supplies the size; no need to track the window.
-  const fallback = useWindowSize(!ctx);
+  const fallback = useLayoutViewportSize(!ctx);
   return ctx ?? fallback;
 }

--- a/clients/web/src/domains/onboarding/hooks/use-onboarding-stage-size.tsx
+++ b/clients/web/src/domains/onboarding/hooks/use-onboarding-stage-size.tsx
@@ -15,15 +15,9 @@
  * falls back to the window size so standalone use never breaks.
  */
 
-import {
-  createContext,
-  useContext,
-  useEffect,
-  useState,
-  type ReactNode,
-} from "react";
+import { createContext, useContext, type ReactNode } from "react";
 
-import { windowSize, type StageSize } from "@/hooks/use-element-size";
+import { useWindowSize, type StageSize } from "@/hooks/use-element-size";
 
 export { useElementSize } from "@/hooks/use-element-size";
 export type { ElementSize, StageSize } from "@/hooks/use-element-size";
@@ -50,14 +44,7 @@ export function OnboardingStageSizeProvider({
  */
 export function useOnboardingStageSize(): StageSize {
   const ctx = useContext(OnboardingStageSizeContext);
-  const [fallback, setFallback] = useState<StageSize>(() => windowSize());
-  useEffect(() => {
-    if (ctx) {
-      return;
-    } // a provider supplies the size; no need to track the window
-    const onResize = () => setFallback(windowSize());
-    window.addEventListener("resize", onResize);
-    return () => window.removeEventListener("resize", onResize);
-  }, [ctx]);
+  // A provider supplies the size; no need to track the window.
+  const fallback = useWindowSize(!ctx);
   return ctx ?? fallback;
 }

--- a/clients/web/src/domains/onboarding/screens/create-personality-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/create-personality-step.tsx
@@ -22,7 +22,7 @@
  * phones) so the Continue button always sits above the eyes.
  */
 
-import { Fragment, useEffect, useMemo, useState } from "react";
+import { Fragment, useMemo } from "react";
 import { ArrowRight } from "lucide-react";
 import * as SliderPrimitive from "@radix-ui/react-slider";
 
@@ -31,6 +31,7 @@ import { OnboardingTopBar } from "@/domains/onboarding/components/onboarding-top
 import { useOnboardingStageSize } from "@/domains/onboarding/hooks/use-onboarding-stage-size";
 import { useOnboardingAvatarPoolStore } from "@/domains/onboarding/onboarding-avatar-pool-store";
 import { useOnboardingTone } from "@/domains/onboarding/onboarding-tone";
+import { useWindowSize } from "@/hooks/use-element-size";
 import {
   preloadBundledAvatarComponents,
   useBundledAvatarComponents,
@@ -188,19 +189,6 @@ function resolveSideColors(
     resolved.push(alt);
   }
   return resolved;
-}
-
-/** Track a live viewport width so the peeking avatars scale with the screen. */
-function useViewportWidth(): number {
-  const [width, setWidth] = useState(() =>
-    typeof window === "undefined" ? 1280 : window.innerWidth,
-  );
-  useEffect(() => {
-    const onResize = () => setWidth(window.innerWidth);
-    window.addEventListener("resize", onResize);
-    return () => window.removeEventListener("resize", onResize);
-  }, []);
-  return width;
 }
 
 /**
@@ -389,7 +377,7 @@ export function CreatePersonalityStep({
 }: CreatePersonalityStepProps) {
   const tone = useOnboardingTone();
   const components = useBundledAvatarComponents();
-  const viewportWidth = useViewportWidth();
+  const { w: viewportWidth } = useWindowSize();
   const { w: stageW, h: stageH } = useOnboardingStageSize();
   // Keep the Continue button clear of the backdrop eyes: reserve their visible
   // height (plus a little breathing room) at the bottom of the content column.

--- a/clients/web/src/domains/onboarding/screens/create-personality-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/create-personality-step.tsx
@@ -31,7 +31,7 @@ import { OnboardingTopBar } from "@/domains/onboarding/components/onboarding-top
 import { useOnboardingStageSize } from "@/domains/onboarding/hooks/use-onboarding-stage-size";
 import { useOnboardingAvatarPoolStore } from "@/domains/onboarding/onboarding-avatar-pool-store";
 import { useOnboardingTone } from "@/domains/onboarding/onboarding-tone";
-import { useWindowSize } from "@/hooks/use-element-size";
+import { useLayoutViewportSize } from "@/hooks/use-element-size";
 import {
   preloadBundledAvatarComponents,
   useBundledAvatarComponents,
@@ -377,7 +377,7 @@ export function CreatePersonalityStep({
 }: CreatePersonalityStepProps) {
   const tone = useOnboardingTone();
   const components = useBundledAvatarComponents();
-  const { w: viewportWidth } = useWindowSize();
+  const { w: viewportWidth } = useLayoutViewportSize();
   const { w: stageW, h: stageH } = useOnboardingStageSize();
   // Keep the Continue button clear of the backdrop eyes: reserve their visible
   // height (plus a little breathing room) at the bottom of the content column.

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -28,6 +28,7 @@ import {
   useOnboardingTone,
   type OnboardingTone,
 } from "@/domains/onboarding/onboarding-tone";
+import { useWindowSize } from "@/hooks/use-element-size";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 import {
   pluginDisplayName,
@@ -41,20 +42,6 @@ import {
 // yellow would otherwise render dark text, invisible on black). The avatar color
 // is still used where it's intentional (e.g. the plugin pills).
 const DARK_TONE = toneForBg("#17191C");
-
-function useViewportSize() {
-  const [size, setSize] = useState(() => ({
-    w: typeof window === "undefined" ? 1280 : window.innerWidth,
-    h: typeof window === "undefined" ? 800 : window.innerHeight,
-  }));
-  useEffect(() => {
-    const onResize = () =>
-      setSize({ w: window.innerWidth, h: window.innerHeight });
-    window.addEventListener("resize", onResize);
-    return () => window.removeEventListener("resize", onResize);
-  }, []);
-  return size;
-}
 
 /** The chosen avatar's components + traits. */
 function useChosenAvatar() {
@@ -134,7 +121,7 @@ export function MeetingCreatedStep({
 }) {
   const { components, chosen } = useChosenAvatar();
   const reduce = useReducedMotion();
-  const { w, h } = useViewportSize();
+  const { w, h } = useWindowSize();
 
   const title = scheduledTime
     ? `Check-in scheduled for tomorrow at ${scheduledTime}!`
@@ -965,7 +952,7 @@ export function LetsChatReadyStep({
   const reduce = useReducedMotion();
   const [starting, setStarting] = useState(false);
   const { components, chosen } = useChosenAvatar();
-  const { h: vh } = useViewportSize();
+  const { h: vh } = useWindowSize();
 
   // Each installed plugin as a card: its display name + (when known) the
   // catalog description. Names without a display label are dropped.

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -28,7 +28,7 @@ import {
   useOnboardingTone,
   type OnboardingTone,
 } from "@/domains/onboarding/onboarding-tone";
-import { useWindowSize } from "@/hooks/use-element-size";
+import { useLayoutViewportSize } from "@/hooks/use-element-size";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 import {
   pluginDisplayName,
@@ -121,7 +121,7 @@ export function MeetingCreatedStep({
 }) {
   const { components, chosen } = useChosenAvatar();
   const reduce = useReducedMotion();
-  const { w, h } = useWindowSize();
+  const { w, h } = useLayoutViewportSize();
 
   const title = scheduledTime
     ? `Check-in scheduled for tomorrow at ${scheduledTime}!`
@@ -952,7 +952,7 @@ export function LetsChatReadyStep({
   const reduce = useReducedMotion();
   const [starting, setStarting] = useState(false);
   const { components, chosen } = useChosenAvatar();
-  const { h: vh } = useWindowSize();
+  const { h: vh } = useLayoutViewportSize();
 
   // Each installed plugin as a card: its display name + (when known) the
   // catalog description. Names without a display label are dropped.

--- a/clients/web/src/hooks/use-element-size.test.ts
+++ b/clients/web/src/hooks/use-element-size.test.ts
@@ -2,10 +2,9 @@
  * Tests for `useLayoutViewportSize`, the live layout-viewport measurement the
  * onboarding and voice-room decorative layers read.
  *
- * The contract worth pinning is the part callers used to hand-roll: that the
- * size comes from `layoutViewportSize` (so the fallback dimensions have one owner
- * rather than being restated per call site), that it tracks `resize`, and
- * that `enabled: false` opts out for the caller that already has a size from
+ * The contract: the size comes from `layoutViewportSize`, so the fallback
+ * dimensions have one owner rather than one per call site; it tracks `resize`;
+ * and `enabled: false` opts out for a caller that already has a size from
  * context.
  *
  * The reference-stability test is load-bearing rather than cosmetic:

--- a/clients/web/src/hooks/use-element-size.test.ts
+++ b/clients/web/src/hooks/use-element-size.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for `useWindowSize`, the live window measurement four onboarding
+ * layers read.
+ *
+ * The contract worth pinning is the part callers used to hand-roll: that the
+ * size comes from `windowSize` (so the SSR guard and the FALLBACK dimensions
+ * have one owner rather than being restated per call site), that it tracks
+ * `resize`, that a `resize` reporting unchanged dimensions does not churn a
+ * render, and that `enabled: false` opts out of the listener entirely for the
+ * caller that already has a size from context.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+
+import { useWindowSize, windowSize } from "@/hooks/use-element-size";
+
+function setWindowSize(w: number, h: number): void {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: w,
+  });
+  Object.defineProperty(window, "innerHeight", {
+    configurable: true,
+    writable: true,
+    value: h,
+  });
+}
+
+/** Fire a `resize` the way the browser does, inside React's act scope. */
+function fireResize(): void {
+  act(() => {
+    window.dispatchEvent(new Event("resize"));
+  });
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useWindowSize", () => {
+  test("reports the current window size", () => {
+    setWindowSize(1024, 768);
+    const { result } = renderHook(() => useWindowSize());
+    expect(result.current).toEqual({ w: 1024, h: 768 });
+    // Same source of truth as every other layer on the screen.
+    expect(result.current).toEqual(windowSize());
+  });
+
+  test("tracks a resize", () => {
+    setWindowSize(1024, 768);
+    const { result } = renderHook(() => useWindowSize());
+
+    setWindowSize(390, 844);
+    fireResize();
+
+    expect(result.current).toEqual({ w: 390, h: 844 });
+  });
+
+  test("does not re-render when a resize leaves the dimensions alone", () => {
+    setWindowSize(1024, 768);
+    const { result } = renderHook(() => useWindowSize());
+    const first = result.current;
+
+    // `resize` also fires for zoom, the iOS keyboard, and orientation changes
+    // that settle back; none of those move the box.
+    fireResize();
+
+    expect(result.current).toBe(first);
+  });
+
+  test("ignores resizes while disabled", () => {
+    setWindowSize(1024, 768);
+    const { result } = renderHook(() => useWindowSize(false));
+
+    setWindowSize(390, 844);
+    fireResize();
+
+    expect(result.current).toEqual({ w: 1024, h: 768 });
+  });
+
+  test("starts tracking when it becomes enabled", () => {
+    setWindowSize(1024, 768);
+    const { result, rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) => useWindowSize(enabled),
+      { initialProps: { enabled: false } },
+    );
+
+    setWindowSize(390, 844);
+    rerender({ enabled: true });
+
+    // Enabling syncs immediately rather than waiting for the next resize:
+    // the window can move while a provider is supplying the size.
+    expect(result.current).toEqual({ w: 390, h: 844 });
+  });
+});

--- a/clients/web/src/hooks/use-element-size.test.ts
+++ b/clients/web/src/hooks/use-element-size.test.ts
@@ -1,9 +1,9 @@
 /**
- * Tests for `useWindowSize`, the live window measurement the onboarding and
- * voice-room decorative layers read.
+ * Tests for `useLayoutViewportSize`, the live layout-viewport measurement the
+ * onboarding and voice-room decorative layers read.
  *
  * The contract worth pinning is the part callers used to hand-roll: that the
- * size comes from `windowSize` (so the fallback dimensions have one owner
+ * size comes from `layoutViewportSize` (so the fallback dimensions have one owner
  * rather than being restated per call site), that it tracks `resize`, and
  * that `enabled: false` opts out for the caller that already has a size from
  * context.
@@ -17,7 +17,10 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { act, cleanup, renderHook } from "@testing-library/react";
 
-import { useWindowSize, windowSize } from "@/hooks/use-element-size";
+import {
+  useLayoutViewportSize,
+  layoutViewportSize,
+} from "@/hooks/use-element-size";
 
 function setWindowSize(w: number, h: number): void {
   Object.defineProperty(window, "innerWidth", {
@@ -43,18 +46,18 @@ afterEach(() => {
   cleanup();
 });
 
-describe("useWindowSize", () => {
+describe("useLayoutViewportSize", () => {
   test("reports the current window size", () => {
     setWindowSize(1024, 768);
-    const { result } = renderHook(() => useWindowSize());
+    const { result } = renderHook(() => useLayoutViewportSize());
     expect(result.current).toEqual({ w: 1024, h: 768 });
     // Same source of truth as every other layer on the screen.
-    expect(result.current).toEqual(windowSize());
+    expect(result.current).toEqual(layoutViewportSize());
   });
 
   test("tracks a resize", () => {
     setWindowSize(1024, 768);
-    const { result } = renderHook(() => useWindowSize());
+    const { result } = renderHook(() => useLayoutViewportSize());
 
     setWindowSize(390, 844);
     fireResize();
@@ -64,7 +67,7 @@ describe("useWindowSize", () => {
 
   test("keeps the same reference when a resize leaves the dimensions alone", () => {
     setWindowSize(1024, 768);
-    const { result, rerender } = renderHook(() => useWindowSize());
+    const { result, rerender } = renderHook(() => useLayoutViewportSize());
     const first = result.current;
 
     // `resize` also fires for zoom, the iOS keyboard, and orientation changes
@@ -77,8 +80,8 @@ describe("useWindowSize", () => {
 
   test("shares one snapshot across consumers", () => {
     setWindowSize(1024, 768);
-    const a = renderHook(() => useWindowSize());
-    const b = renderHook(() => useWindowSize());
+    const a = renderHook(() => useLayoutViewportSize());
+    const b = renderHook(() => useLayoutViewportSize());
 
     expect(a.result.current).toBe(b.result.current);
 
@@ -91,7 +94,7 @@ describe("useWindowSize", () => {
 
   test("does not re-subscribe while disabled, but still reports the size", () => {
     setWindowSize(1024, 768);
-    const { result } = renderHook(() => useWindowSize(false));
+    const { result } = renderHook(() => useLayoutViewportSize(false));
 
     expect(result.current).toEqual({ w: 1024, h: 768 });
 

--- a/clients/web/src/hooks/use-element-size.test.ts
+++ b/clients/web/src/hooks/use-element-size.test.ts
@@ -1,13 +1,17 @@
 /**
- * Tests for `useWindowSize`, the live window measurement four onboarding
- * layers read.
+ * Tests for `useWindowSize`, the live window measurement the onboarding and
+ * voice-room decorative layers read.
  *
  * The contract worth pinning is the part callers used to hand-roll: that the
- * size comes from `windowSize` (so the SSR guard and the FALLBACK dimensions
- * have one owner rather than being restated per call site), that it tracks
- * `resize`, that a `resize` reporting unchanged dimensions does not churn a
- * render, and that `enabled: false` opts out of the listener entirely for the
- * caller that already has a size from context.
+ * size comes from `windowSize` (so the fallback dimensions have one owner
+ * rather than being restated per call site), that it tracks `resize`, and
+ * that `enabled: false` opts out for the caller that already has a size from
+ * context.
+ *
+ * The reference-stability test is load-bearing rather than cosmetic:
+ * `useSyncExternalStore` bails out only on reference equality, so a
+ * `getSnapshot` returning a fresh `{ w, h }` each call would re-render
+ * forever. It fails loudly if that caching is ever dropped.
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
@@ -58,40 +62,45 @@ describe("useWindowSize", () => {
     expect(result.current).toEqual({ w: 390, h: 844 });
   });
 
-  test("does not re-render when a resize leaves the dimensions alone", () => {
+  test("keeps the same reference when a resize leaves the dimensions alone", () => {
     setWindowSize(1024, 768);
-    const { result } = renderHook(() => useWindowSize());
+    const { result, rerender } = renderHook(() => useWindowSize());
     const first = result.current;
 
     // `resize` also fires for zoom, the iOS keyboard, and orientation changes
     // that settle back; none of those move the box.
     fireResize();
+    rerender();
 
     expect(result.current).toBe(first);
   });
 
-  test("ignores resizes while disabled", () => {
+  test("shares one snapshot across consumers", () => {
     setWindowSize(1024, 768);
-    const { result } = renderHook(() => useWindowSize(false));
+    const a = renderHook(() => useWindowSize());
+    const b = renderHook(() => useWindowSize());
+
+    expect(a.result.current).toBe(b.result.current);
 
     setWindowSize(390, 844);
     fireResize();
 
-    expect(result.current).toEqual({ w: 1024, h: 768 });
+    expect(a.result.current).toEqual({ w: 390, h: 844 });
+    expect(a.result.current).toBe(b.result.current);
   });
 
-  test("starts tracking when it becomes enabled", () => {
+  test("does not re-subscribe while disabled, but still reports the size", () => {
     setWindowSize(1024, 768);
-    const { result, rerender } = renderHook(
-      ({ enabled }: { enabled: boolean }) => useWindowSize(enabled),
-      { initialProps: { enabled: false } },
-    );
+    const { result } = renderHook(() => useWindowSize(false));
 
+    expect(result.current).toEqual({ w: 1024, h: 768 });
+
+    // No subscription, so a resize does not notify this consumer. The value
+    // is read during render, so it is never stale when something else
+    // re-renders it.
     setWindowSize(390, 844);
-    rerender({ enabled: true });
+    fireResize();
 
-    // Enabling syncs immediately rather than waiting for the next resize:
-    // the window can move while a provider is supplying the size.
-    expect(result.current).toEqual({ w: 390, h: 844 });
+    expect(result.current).toEqual({ w: 1024, h: 768 });
   });
 });

--- a/clients/web/src/hooks/use-element-size.ts
+++ b/clients/web/src/hooks/use-element-size.ts
@@ -108,7 +108,7 @@ const noopSubscribe = () => () => {};
  *
  * This hook is for the cases CSS genuinely cannot reach: a number handed to
  * an animation library, or one paired with a `getBoundingClientRect()`. The
- * onboarding and voice decorative layers currently use it well beyond that,
+ * onboarding and voice decorative layers use it well beyond that,
  * computing `clamp()` in JavaScript, which is what LUM-3204 tracks. Adding a
  * consumer that CSS could have expressed makes that worse.
  *

--- a/clients/web/src/hooks/use-element-size.ts
+++ b/clients/web/src/hooks/use-element-size.ts
@@ -99,6 +99,19 @@ const noopSubscribe = () => () => {};
 /**
  * The layout viewport size, kept live on `resize`.
  *
+ * Reach for CSS first. If what you are writing is a size or a position that
+ * `clamp()`, `vmin`, `vw` or `%` can express, write it in CSS: it resolves
+ * against a defined box automatically, updates without a React render, and
+ * cannot disagree with the `%`-positioned foreground next to it. Most of this
+ * app already sizes that way (`max-w-[min(520px,calc(100vw-8rem))]`,
+ * `w-[90vw] max-w-[800px]`).
+ *
+ * This hook is for the cases CSS genuinely cannot reach: a number handed to
+ * an animation library, or one paired with a `getBoundingClientRect()`. The
+ * onboarding and voice decorative layers currently use it well beyond that,
+ * computing `clamp()` in JavaScript, which is what LUM-3204 tracks. Adding a
+ * consumer that CSS could have expressed makes that worse.
+ *
  * Lives here rather than at the call site so the SSR fallback and the
  * `FALLBACK` dimensions keep one owner: a caller re-deriving this from
  * `window.innerWidth` ends up restating those constants, and then they drift

--- a/clients/web/src/hooks/use-element-size.ts
+++ b/clients/web/src/hooks/use-element-size.ts
@@ -15,7 +15,7 @@
  * (viewport-relative) `getBoundingClientRect()`, want the window instead.
  */
 
-import { useEffect, useLayoutEffect, useState } from "react";
+import { useLayoutEffect, useState, useSyncExternalStore } from "react";
 
 export interface StageSize {
   w: number;
@@ -32,39 +32,72 @@ export function windowSize(): StageSize {
 }
 
 /**
+ * The window, as an external store: one `resize` listener and one snapshot
+ * shared by every consumer, however many mount.
+ *
+ * `getSnapshot` reads live but returns the *previous* object whenever both
+ * dimensions are unchanged. `useSyncExternalStore` calls it on every render
+ * and bails out only on reference equality, so a freshly built `{ w, h }`
+ * would re-render forever; this is the same caching contract
+ * `typed-storage.ts` implements for its non-primitive snapshots. It also
+ * means a `resize` that leaves the box alone (zoom, the iOS keyboard, an
+ * orientation change that settles back) costs nothing downstream.
+ */
+let windowSnapshot: StageSize = FALLBACK;
+const windowListeners = new Set<() => void>();
+
+function notifyWindowResize(): void {
+  for (const listener of windowListeners) {
+    listener();
+  }
+}
+
+function subscribeToWindow(onStoreChange: () => void): () => void {
+  if (windowListeners.size === 0) {
+    window.addEventListener("resize", notifyWindowResize);
+  }
+  windowListeners.add(onStoreChange);
+  return () => {
+    windowListeners.delete(onStoreChange);
+    if (windowListeners.size === 0) {
+      window.removeEventListener("resize", notifyWindowResize);
+    }
+  };
+}
+
+function getWindowSnapshot(): StageSize {
+  const next = windowSize();
+  if (next.w !== windowSnapshot.w || next.h !== windowSnapshot.h) {
+    windowSnapshot = next;
+  }
+  return windowSnapshot;
+}
+
+function getWindowServerSnapshot(): StageSize {
+  return FALLBACK;
+}
+
+/** Subscribe to nothing, for the opt-out below. */
+const noopSubscribe = () => () => {};
+
+/**
  * The window size, kept live on `resize`.
  *
- * Lives here rather than at the call site so the SSR guard and the `FALLBACK`
- * dimensions keep one owner: a caller re-deriving this from
+ * Lives here rather than at the call site so the SSR fallback and the
+ * `FALLBACK` dimensions keep one owner: a caller re-deriving this from
  * `window.innerWidth` ends up restating those constants, and then they drift
  * from the ones `windowSize` hands every other layer on the same screen.
  *
- * Re-renders only when a dimension actually changes. `resize` also fires for
- * things that leave the box alone (zoom, the iOS keyboard, an orientation
- * change that settles back), and a decorative layer has no reason to redraw
- * for those.
- *
  * Pass `enabled: false` when something else is supplying the size and the
- * window is only a fallback, to skip the listener entirely.
+ * window is only a fallback. The value stays correct; it just stops
+ * subscribing to changes.
  */
 export function useWindowSize(enabled = true): StageSize {
-  const [size, setSize] = useState<StageSize>(() => windowSize());
-
-  useEffect(() => {
-    if (!enabled) {
-      return;
-    }
-    const onResize = () => {
-      const next = windowSize();
-      setSize((prev) => (prev.w === next.w && prev.h === next.h ? prev : next));
-    };
-    // The window can have changed between the initial render and this effect.
-    onResize();
-    window.addEventListener("resize", onResize);
-    return () => window.removeEventListener("resize", onResize);
-  }, [enabled]);
-
-  return size;
+  return useSyncExternalStore(
+    enabled ? subscribeToWindow : noopSubscribe,
+    getWindowSnapshot,
+    getWindowServerSnapshot,
+  );
 }
 
 export interface ElementSize {

--- a/clients/web/src/hooks/use-element-size.ts
+++ b/clients/web/src/hooks/use-element-size.ts
@@ -1,15 +1,21 @@
 /**
- * Live element-box measurement via `ResizeObserver`.
+ * The size a decorative layer positions itself against, kept live.
  *
- * Decorative layers that anchor to a container's edges (the onboarding
- * stage, the About Assistant stage) read this size to position
- * `absolute` children against the same box the `%`-positioned foreground
- * uses — robust on iOS, where a `position: fixed` layer measured from
- * `window.innerHeight` resolves against the taller layout viewport
- * instead of the container.
+ * Two boxes qualify, so this module owns both and the fallback dimensions
+ * they share: `useElementSize` for a container (via `ResizeObserver`) and
+ * `useWindowSize` for the viewport (via `resize`).
+ *
+ * Which one a layer wants is the whole point of the split. Layers that anchor
+ * to a container's edges (the onboarding stage, the About Assistant stage)
+ * read the element box, so their `absolute` children resolve against the same
+ * box the `%`-positioned foreground uses. That is what holds up on iOS, where
+ * a `position: fixed` layer measured from `window.innerHeight` resolves
+ * against the taller layout viewport instead of the container. Layers that
+ * genuinely anchor to the screen edge, or that pair a size with a
+ * (viewport-relative) `getBoundingClientRect()`, want the window instead.
  */
 
-import { useLayoutEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useState } from "react";
 
 export interface StageSize {
   w: number;
@@ -23,6 +29,42 @@ export function windowSize(): StageSize {
     return FALLBACK;
   }
   return { w: window.innerWidth, h: window.innerHeight };
+}
+
+/**
+ * The window size, kept live on `resize`.
+ *
+ * Lives here rather than at the call site so the SSR guard and the `FALLBACK`
+ * dimensions keep one owner: a caller re-deriving this from
+ * `window.innerWidth` ends up restating those constants, and then they drift
+ * from the ones `windowSize` hands every other layer on the same screen.
+ *
+ * Re-renders only when a dimension actually changes. `resize` also fires for
+ * things that leave the box alone (zoom, the iOS keyboard, an orientation
+ * change that settles back), and a decorative layer has no reason to redraw
+ * for those.
+ *
+ * Pass `enabled: false` when something else is supplying the size and the
+ * window is only a fallback, to skip the listener entirely.
+ */
+export function useWindowSize(enabled = true): StageSize {
+  const [size, setSize] = useState<StageSize>(() => windowSize());
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    const onResize = () => {
+      const next = windowSize();
+      setSize((prev) => (prev.w === next.w && prev.h === next.h ? prev : next));
+    };
+    // The window can have changed between the initial render and this effect.
+    onResize();
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, [enabled]);
+
+  return size;
 }
 
 export interface ElementSize {

--- a/clients/web/src/hooks/use-element-size.ts
+++ b/clients/web/src/hooks/use-element-size.ts
@@ -3,7 +3,7 @@
  *
  * Two boxes qualify, so this module owns both and the fallback dimensions
  * they share: `useElementSize` for a container (via `ResizeObserver`) and
- * `useWindowSize` for the viewport (via `resize`).
+ * `useLayoutViewportSize` for the layout viewport (via `resize`).
  *
  * Which one a layer wants is the whole point of the split. Layers that anchor
  * to a container's edges (the onboarding stage, the About Assistant stage)
@@ -12,7 +12,20 @@
  * a `position: fixed` layer measured from `window.innerHeight` resolves
  * against the taller layout viewport instead of the container. Layers that
  * genuinely anchor to the screen edge, or that pair a size with a
- * (viewport-relative) `getBoundingClientRect()`, want the window instead.
+ * (viewport-relative) `getBoundingClientRect()`, want the layout viewport.
+ *
+ * "Layout viewport" is deliberate, and is not a third name for the two things
+ * that already carry one. It is `window.innerWidth` / `innerHeight`: the box
+ * CSS resolves `%` and `dvh` against, which does NOT shrink when the soft
+ * keyboard opens.
+ *
+ * - `useVisibleViewport` (`use-visible-viewport.ts`) is the *visual* viewport,
+ *   which does shrink with the keyboard and reports no width. Sizing artwork
+ *   from it would resize the artwork every time a field is focused.
+ * - `useOnboardingWindowSize` (`use-onboarding-window-size.ts`) is the Electron
+ *   OS window, driven over IPC. Nothing to do with either viewport.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Visual_Viewport_API#visual_viewport_vs._layout_viewport
  */
 
 import { useLayoutEffect, useState, useSyncExternalStore } from "react";
@@ -24,7 +37,7 @@ export interface StageSize {
 
 const FALLBACK: StageSize = { w: 1280, h: 800 };
 
-export function windowSize(): StageSize {
+export function layoutViewportSize(): StageSize {
   if (typeof window === "undefined") {
     return FALLBACK;
   }
@@ -32,8 +45,8 @@ export function windowSize(): StageSize {
 }
 
 /**
- * The window, as an external store: one `resize` listener and one snapshot
- * shared by every consumer, however many mount.
+ * The layout viewport, as an external store: one `resize` listener and one
+ * snapshot shared by every consumer, however many mount.
  *
  * `getSnapshot` reads live but returns the *previous* object whenever both
  * dimensions are unchanged. `useSyncExternalStore` calls it on every render
@@ -43,37 +56,40 @@ export function windowSize(): StageSize {
  * means a `resize` that leaves the box alone (zoom, the iOS keyboard, an
  * orientation change that settles back) costs nothing downstream.
  */
-let windowSnapshot: StageSize = FALLBACK;
-const windowListeners = new Set<() => void>();
+let layoutViewportSnapshot: StageSize = FALLBACK;
+const layoutViewportListeners = new Set<() => void>();
 
-function notifyWindowResize(): void {
-  for (const listener of windowListeners) {
+function notifyLayoutViewportResize(): void {
+  for (const listener of layoutViewportListeners) {
     listener();
   }
 }
 
-function subscribeToWindow(onStoreChange: () => void): () => void {
-  if (windowListeners.size === 0) {
-    window.addEventListener("resize", notifyWindowResize);
+function subscribeToLayoutViewport(onStoreChange: () => void): () => void {
+  if (layoutViewportListeners.size === 0) {
+    window.addEventListener("resize", notifyLayoutViewportResize);
   }
-  windowListeners.add(onStoreChange);
+  layoutViewportListeners.add(onStoreChange);
   return () => {
-    windowListeners.delete(onStoreChange);
-    if (windowListeners.size === 0) {
-      window.removeEventListener("resize", notifyWindowResize);
+    layoutViewportListeners.delete(onStoreChange);
+    if (layoutViewportListeners.size === 0) {
+      window.removeEventListener("resize", notifyLayoutViewportResize);
     }
   };
 }
 
-function getWindowSnapshot(): StageSize {
-  const next = windowSize();
-  if (next.w !== windowSnapshot.w || next.h !== windowSnapshot.h) {
-    windowSnapshot = next;
+function getLayoutViewportSnapshot(): StageSize {
+  const next = layoutViewportSize();
+  if (
+    next.w !== layoutViewportSnapshot.w ||
+    next.h !== layoutViewportSnapshot.h
+  ) {
+    layoutViewportSnapshot = next;
   }
-  return windowSnapshot;
+  return layoutViewportSnapshot;
 }
 
-function getWindowServerSnapshot(): StageSize {
+function getLayoutViewportServerSnapshot(): StageSize {
   return FALLBACK;
 }
 
@@ -81,22 +97,22 @@ function getWindowServerSnapshot(): StageSize {
 const noopSubscribe = () => () => {};
 
 /**
- * The window size, kept live on `resize`.
+ * The layout viewport size, kept live on `resize`.
  *
  * Lives here rather than at the call site so the SSR fallback and the
  * `FALLBACK` dimensions keep one owner: a caller re-deriving this from
  * `window.innerWidth` ends up restating those constants, and then they drift
- * from the ones `windowSize` hands every other layer on the same screen.
+ * from the ones `layoutViewportSize` hands every other layer on the same
+ * screen.
  *
- * Pass `enabled: false` when something else is supplying the size and the
- * window is only a fallback. The value stays correct; it just stops
- * subscribing to changes.
+ * Pass `enabled: false` when something else is supplying the size and this is
+ * only a fallback. The value stays correct; it just stops subscribing.
  */
-export function useWindowSize(enabled = true): StageSize {
+export function useLayoutViewportSize(enabled = true): StageSize {
   return useSyncExternalStore(
-    enabled ? subscribeToWindow : noopSubscribe,
-    getWindowSnapshot,
-    getWindowServerSnapshot,
+    enabled ? subscribeToLayoutViewport : noopSubscribe,
+    getLayoutViewportSnapshot,
+    getLayoutViewportServerSnapshot,
   );
 }
 
@@ -110,12 +126,12 @@ export interface ElementSize {
  * Measure an element's box, kept live via `ResizeObserver`. Uses a callback
  * ref (stored in state) so it re-measures whenever the element
  * mounts/unmounts — robust to containers that appear after the first render
- * (e.g. a step that's conditionally rendered). Returns the window size
- * until the element mounts.
+ * (e.g. a step that's conditionally rendered). Returns the layout viewport
+ * size until the element mounts.
  */
 export function useElementSize(): ElementSize {
   const [el, setEl] = useState<HTMLElement | null>(null);
-  const [size, setSize] = useState<StageSize>(() => windowSize());
+  const [size, setSize] = useState<StageSize>(() => layoutViewportSize());
 
   useLayoutEffect(() => {
     if (!el) {


### PR DESCRIPTION
## TL;DR

Five files each hand-rolled "the live layout-viewport size". `use-element-size.ts` already owned the snapshot of exactly that (`layoutViewportSize`, carrying the `FALLBACK = { w: 1280, h: 800 }` dimensions) but had no live version, so every caller wrote its own.

This adds `useLayoutViewportSize` next to it and deletes all five copies. No call site changes which box it reads.

Fixes LUM-3196.

## Why a new hook rather than an existing one

Nothing in the repo could serve these callers. They need a live width **and** height of the box CSS resolves `%` and `dvh` against:

| Existing | Measures | Fits? |
|---|---|---|
| `useVisibleViewport` | the **visual** viewport: height only, no width, shrinks with the soft keyboard | No — artwork would resize whenever a field is focused |
| `useViewportMinHeight` | a scroll container's `clientHeight` (chat transcript) | No |
| `useOnboardingWindowSize` | the Electron OS window, over IPC; returns `void` | No |
| `useElementSize` | an element's box | No |

Two of the deleted copies were *named* `useViewportSize` and `useViewport` while reading the layout viewport, which is the confusion the precise name is there to stop: mistaking these two measurements is a bug you would not catch on a desktop browser.

## Why this is safe

**Every call site keeps reading the same box it read before.** This is a dedup, not a re-pointing. Two of them want the layout viewport for a documented reason and keep it:

- `create-personality-step`'s peeking avatars anchor to the true screen edge via `calc(50% - 50vw)`.
- `research-result-steps` pairs its size with `getBoundingClientRect()` slots, which are viewport-relative.

Those two also sit inside `OnboardingStageSizeProvider` while their sibling layers read the stage box, so that screen genuinely has two coordinate spaces on it. That is a real bug and is **not** touched here, because fixing it means rebasing the rects onto the container, not swapping a size. It has its own ticket: LUM-3198.

**The hook uses this repo's idiom for browser-API subscriptions.** `use-media-query.ts`, `typed-storage.ts` and `platform-detection.ts` all use `useSyncExternalStore`; `typed-storage.ts` documents the cached-snapshot contract non-primitive snapshots need, and `platform-detection.ts` the noop subscribe for opting out. Building on it deletes three things the copies hand-rolled rather than re-homing them:

| Hand-rolled in the copies | Now |
|---|---|
| `typeof window === "undefined"` fallback | `getServerSnapshot` |
| Re-render on every `resize`, changed or not | Reference equality on the cached snapshot |
| One listener + one state cell per consumer | One `resize` listener and one snapshot, app-wide |

**`useOnboardingStageSize` keeps its documented optimization.** It skipped the window listener when a provider supplied the size; that survives as `useLayoutViewportSize(!ctx)`, which swaps in a noop subscribe.

Verified with typecheck, lint (0 errors; the 16 remaining warnings are the pre-existing baseline in untouched files) and CI. New tests cover the hook's contract, including the reference-stability property `useSyncExternalStore` requires. These onboarding screens have no Storybook stories and the research-onboarding flow needs a live hatched assistant, so this was not exercised in a browser; the behavior argument rests on the diff being a like-for-like lift.

## Before / after

| | Before | After |
|---|---|---|
| Live layout-viewport size | Re-implemented in 5 files | One `useLayoutViewportSize` |
| The `1280` / `800` fallback | Restated inline in 3 of them | Read from the module's `FALLBACK`, one owner |
| SSR guard in the voice-room copy | Missing | Handled by `getServerSnapshot` |
| `resize` listeners | One per mounted consumer | One, shared |
| Name of the measurement | `useViewportSize` / `useViewport` / `useViewportWidth` / inline | Says which of the three viewport-ish things it is |
| What each screen renders | | Unchanged |

## The regression this closes

Three copies restated `1280` / `800` inline. Change that constant and those files silently keep the old one, which does not fail loudly: it puts two coordinate systems on one screen. Same failure mode as `COLLAPSED_ASSISTANT_TILE = 30` in #40501.

The voice-room copy shows this is not hypothetical: it had already dropped the `typeof window === "undefined"` guard that the shared snapshot carries.

## This is a step away from the pattern, not an endorsement of it

Extracting a shared helper for something we want *less* of makes it easier to reach for, so both places a reader would look now say the opposite.

The hook's docstring leads with "reach for CSS first" and names the only two exceptions that need a measured number: a value handed to an animation library, or one paired with a `getBoundingClientRect()`. `docs/PLATFORM_ADAPTATION.md` gets the same rule as a sibling of its existing "prefer `max-md:` classes" guidance, plus the direction of travel, so the onboarding and voice-room files read as the pattern being unwound (LUM-3204) rather than the example to copy.

The root issue is that this family computes CSS sizing functions in JavaScript: `edgeSize` is literally `clamp(130px, 40vmin, 420px)`. That is not fixed here because the conversion is not decomposable, `edgeSize`'s output feeds `edgeSlots(w, h, size / 2)`, so a surface's whole slot system moves at once. It is a visual change to the onboarding flow that needs to be seen on a device. LUM-3204 carries it.

## Scope notes

- The fifth copy is in the voice domain rather than onboarding. It is here because lifting a helper and leaving one call site on its own copy is the step most often skipped, and the remaining copy is the entire drift vector.
- The module is still named `use-element-size.ts` while hosting a layout-viewport store, so a reader will not grep there. Renaming the file touches importers this diff does not otherwise touch, so it is deliberately left for its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
