### PR TITLE
fix(design-library): give the three splitters the keyboard pattern their role promises (LUM-3194)

### DIFF
--- a/clients/web/src/domains/chat/components/animated-right-drawer.tsx
+++ b/clients/web/src/domains/chat/components/animated-right-drawer.tsx
@@ -25,12 +25,13 @@
 import {
   useCallback,
   useEffect,
+  useId,
   useRef,
   useState,
-  type PointerEvent as ReactPointerEvent,
   type ReactNode,
 } from "react";
 import { motion, useReducedMotion } from "motion/react";
+import { SplitterHandle } from "@vellumai/design-library";
 
 import { cn } from "@/utils/misc";
 
@@ -95,8 +96,9 @@ export function AnimatedRightDrawer({
   const [width, setWidth] = useState<number>(
     () => readStoredWidth(storageKey, minWidth) ?? defaultWidth,
   );
-  const dragRef = useRef<{ startX: number; startWidth: number } | null>(null);
   const [isDragging, setIsDragging] = useState(false);
+  const drawerPaneId = useId();
+  const [containerWidth, setContainerWidth] = useState(0);
 
   // Keep the drawer pane (content + drag handle) mounted while open and through
   // the close animation. `mounted` flips on synchronously when opening, and off
@@ -139,46 +141,22 @@ export function AnimatedRightDrawer({
     [minWidth, minLeftWidth],
   );
 
-  const handlePointerDown = useCallback(
-    (e: ReactPointerEvent<HTMLDivElement>) => {
-      e.preventDefault();
-      (e.target as HTMLElement).setPointerCapture(e.pointerId);
-      dragRef.current = { startX: e.clientX, startWidth: width };
-      setIsDragging(true);
-    },
-    [width],
-  );
-
-  const handlePointerMove = useCallback(
-    (e: ReactPointerEvent<HTMLDivElement>) => {
-      if (!dragRef.current) {
-        return;
-      }
-      // Dragging the handle LEFT (clientX decreases) widens the drawer.
-      const delta = dragRef.current.startX - e.clientX;
-      setWidth(clamp(dragRef.current.startWidth + delta));
+  const handleValueChange = useCallback(
+    (next: number) => {
+      setWidth(clamp(next));
     },
     [clamp],
   );
 
-  const handlePointerUp = useCallback(
-    (e: ReactPointerEvent<HTMLDivElement>) => {
-      if (!dragRef.current) {
+  const handleValueCommit = useCallback(
+    (next: number) => {
+      if (!storageKey) {
         return;
       }
-      (e.target as HTMLElement).releasePointerCapture(e.pointerId);
-      const finalWidth = clamp(
-        dragRef.current.startWidth + (dragRef.current.startX - e.clientX),
-      );
-      dragRef.current = null;
-      setIsDragging(false);
-      setWidth(finalWidth);
-      if (storageKey) {
-        try {
-          localStorage.setItem(storageKey, String(finalWidth));
-        } catch {
-          // Storage quota or security error — ignore.
-        }
+      try {
+        localStorage.setItem(storageKey, String(clamp(next)));
+      } catch {
+        // Storage quota or security error, ignore.
       }
     },
     [clamp, storageKey],
@@ -193,6 +171,30 @@ export function AnimatedRightDrawer({
     window.addEventListener("resize", onResize);
     return () => window.removeEventListener("resize", onResize);
   }, [clamp]);
+
+  // Backs `aria-valuemax` only; `clamp` above still measures live on each
+  // change. Observed rather than read on window resize because this container
+  // changes width without one (the sidebar collapsing beside it, say), and a
+  // stale maximum would misreport how far the drawer can still travel.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+    setContainerWidth(container.offsetWidth);
+    const observer = new ResizeObserver(() => {
+      setContainerWidth(container.offsetWidth);
+    });
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, []);
+
+  // Before the first measurement the container width is unknown, so the only
+  // honest upper bound is the width already in use.
+  const maxWidth =
+    containerWidth > 0
+      ? Math.max(minWidth, containerWidth - minLeftWidth - SEPARATOR_WIDTH_PX)
+      : Math.max(minWidth, width);
 
   return (
     <div
@@ -213,27 +215,33 @@ export function AnimatedRightDrawer({
           present while the drawer is mounted so a closed drawer leaves no
           stray hit-area or grab handle over the full-width chat. */}
       {mounted && (
-        <div
-          role="separator"
-          aria-orientation="vertical"
+        <SplitterHandle
+          value={width}
+          min={minWidth}
+          max={maxWidth}
+          onValueChange={handleValueChange}
+          onValueCommit={handleValueCommit}
+          onResizeStart={() => setIsDragging(true)}
+          onResizeEnd={() => setIsDragging(false)}
+          // The handle sits to the LEFT of the drawer, so moving it right
+          // shrinks the pane it controls.
+          invert
+          label="Resize side panel"
+          controls={drawerPaneId}
           className={cn(
-            "group relative z-10 flex h-full w-2 shrink-0 cursor-col-resize items-center justify-center",
+            "group relative z-10 flex h-full w-2 shrink-0 items-center justify-center",
             isDragging && "select-none",
           )}
-          onPointerDown={handlePointerDown}
-          onPointerMove={handlePointerMove}
-          onPointerUp={handlePointerUp}
-          onPointerCancel={handlePointerUp}
         >
           <div className="h-full w-px bg-transparent" />
           <div
             className={cn(
               "absolute h-8 w-1 rounded-full bg-[var(--content-tertiary)] opacity-0 transition-opacity",
-              "group-hover:opacity-100",
+              "group-hover:opacity-100 group-focus-visible:opacity-100",
               isDragging && "opacity-100",
             )}
           />
-        </div>
+        </SplitterHandle>
       )}
 
       {/* Drawer — its width is the animated dimension, eased 0 ⇄ target by the
@@ -243,6 +251,7 @@ export function AnimatedRightDrawer({
           reflowing the content mid-animation. Reduced motion: snap instead of
           ease. Content unmounts only once a close animation reaches width 0. */}
       <motion.div
+        id={drawerPaneId}
         className="relative h-full shrink-0 overflow-hidden"
         initial={reduce ? false : { width: 0 }}
         animate={{ width: open ? width : 0 }}

--- a/packages/design-library/src/components/resizable-panel.tsx
+++ b/packages/design-library/src/components/resizable-panel.tsx
@@ -1,6 +1,7 @@
 import {
   useCallback,
   useEffect,
+  useId,
   useLayoutEffect,
   useRef,
   useState,
@@ -9,6 +10,7 @@ import {
 } from "react";
 
 import { cn } from "../utils/cn";
+import { SplitterHandle } from "./splitter-handle";
 
 /**
  * Width of the drag-handle column between the two panes. Must match the
@@ -39,7 +41,8 @@ function readStoredWidth(
   }
 }
 
-export interface ResizablePanelProps extends Omit<ComponentProps<"div">, "children"> {
+export interface ResizablePanelProps
+  extends Omit<ComponentProps<"div">, "children"> {
   /** Content for the left pane. */
   left: ReactNode;
   /** Content for the right pane. */
@@ -59,8 +62,13 @@ export interface ResizablePanelProps extends Omit<ComponentProps<"div">, "childr
   minLeftWidth?: number;
   /** Minimum right pane width in px (default 300). */
   minRightWidth?: number;
-  /** Callback fired when the left pane width changes during drag. */
+  /** Callback fired when the left pane width changes, by drag or by key. */
   onWidthChange?: (leftWidth: number) => void;
+  /**
+   * Accessible name for the drag separator (default "Resize panels"). Set it
+   * when a page has more than one split so the two are told apart.
+   */
+  separatorLabel?: string;
   /** Optional localStorage key for persisting the left pane width across reloads. */
   storageKey?: string;
   /**
@@ -87,19 +95,21 @@ export function ResizablePanel({
   minLeftWidth = 300,
   minRightWidth = 300,
   onWidthChange,
+  separatorLabel = "Resize panels",
   storageKey,
   hideDivider = false,
   className,
   ...rest
 }: ResizablePanelProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const leftPaneId = useId();
 
   const [leftWidth, setLeftWidth] = useState<number>(
     () => readStoredWidth(storageKey, minLeftWidth) ?? defaultLeftWidth,
   );
 
-  const dragRef = useRef<{ startX: number; startWidth: number } | null>(null);
   const [isDragging, setIsDragging] = useState(false);
+  const [containerWidth, setContainerWidth] = useState(0);
 
   const clamp = useCallback(
     (width: number) => {
@@ -113,43 +123,22 @@ export function ResizablePanel({
     [minLeftWidth, minRightWidth],
   );
 
-  const handlePointerDown = useCallback(
-    (e: React.PointerEvent<HTMLDivElement>) => {
-      e.preventDefault();
-      (e.target as HTMLElement).setPointerCapture(e.pointerId);
-      dragRef.current = { startX: e.clientX, startWidth: leftWidth };
-      setIsDragging(true);
-    },
-    [leftWidth],
-  );
-
-  const handlePointerMove = useCallback(
-    (e: React.PointerEvent<HTMLDivElement>) => {
-      if (!dragRef.current) return;
-      const delta = e.clientX - dragRef.current.startX;
-      const next = clamp(dragRef.current.startWidth + delta);
-      setLeftWidth(next);
-      onWidthChange?.(next);
+  const handleValueChange = useCallback(
+    (next: number) => {
+      const width = clamp(next);
+      setLeftWidth(width);
+      onWidthChange?.(width);
     },
     [clamp, onWidthChange],
   );
 
-  const handlePointerUp = useCallback(
-    (e: React.PointerEvent<HTMLDivElement>) => {
-      if (!dragRef.current) return;
-      (e.target as HTMLElement).releasePointerCapture(e.pointerId);
-      const finalWidth = clamp(
-        dragRef.current.startWidth + (e.clientX - dragRef.current.startX),
-      );
-      dragRef.current = null;
-      setIsDragging(false);
-
-      if (storageKey) {
-        try {
-          localStorage.setItem(storageKey, String(finalWidth));
-        } catch {
-          // Storage quota or security error — ignore.
-        }
+  const handleValueCommit = useCallback(
+    (next: number) => {
+      if (!storageKey) return;
+      try {
+        localStorage.setItem(storageKey, String(clamp(next)));
+      } catch {
+        // Storage quota or security error, ignore.
       }
     },
     [clamp, storageKey],
@@ -164,6 +153,21 @@ export function ResizablePanel({
     window.addEventListener("resize", onResize);
     return () => window.removeEventListener("resize", onResize);
   }, [clamp]);
+
+  // Backs `aria-valuemax` only; `clamp` above still measures live on each
+  // change. Observed rather than read on window resize because this container
+  // changes width without one (the sidebar collapsing beside it, say), and a
+  // stale maximum would misreport how far the pane can still travel.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    setContainerWidth(container.offsetWidth);
+    const observer = new ResizeObserver(() => {
+      setContainerWidth(container.offsetWidth);
+    });
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, []);
 
   // Resolve the on-mount width before paint when no valid persisted
   // preference exists. Runs in useLayoutEffect so the resolved width is
@@ -187,13 +191,14 @@ export function ResizablePanel({
     }
     if (target == null) return;
     setLeftWidth(clamp(target));
-  }, [
-    defaultLeftPercent,
-    defaultRightWidth,
-    storageKey,
-    minLeftWidth,
-    clamp,
-  ]);
+  }, [defaultLeftPercent, defaultRightWidth, storageKey, minLeftWidth, clamp]);
+
+  // Before the first measurement the container width is unknown, so the only
+  // honest upper bound is the width already in use.
+  const maxLeftWidth =
+    containerWidth > 0
+      ? Math.max(minLeftWidth, containerWidth - minRightWidth)
+      : Math.max(minLeftWidth, leftWidth);
 
   return (
     <div
@@ -203,23 +208,27 @@ export function ResizablePanel({
       className={cn("flex h-full w-full overflow-hidden", className)}
     >
       <div
+        id={leftPaneId}
         className="flex h-full shrink-0 flex-col overflow-hidden"
         style={{ width: leftWidth }}
       >
         {left}
       </div>
 
-      <div
-        role="separator"
-        aria-orientation="vertical"
+      <SplitterHandle
+        value={leftWidth}
+        min={minLeftWidth}
+        max={maxLeftWidth}
+        onValueChange={handleValueChange}
+        onValueCommit={handleValueCommit}
+        onResizeStart={() => setIsDragging(true)}
+        onResizeEnd={() => setIsDragging(false)}
+        label={separatorLabel}
+        controls={leftPaneId}
         className={cn(
-          "group relative z-10 flex h-full w-2 shrink-0 cursor-col-resize items-center justify-center",
+          "group relative z-10 flex h-full w-2 shrink-0 items-center justify-center",
           isDragging && "select-none",
         )}
-        onPointerDown={handlePointerDown}
-        onPointerMove={handlePointerMove}
-        onPointerUp={handlePointerUp}
-        onPointerCancel={handlePointerUp}
       >
         <div
           className={cn(
@@ -230,11 +239,11 @@ export function ResizablePanel({
         <div
           className={cn(
             "absolute h-8 w-1 rounded-full bg-[var(--content-tertiary)] opacity-0 transition-opacity",
-            "group-hover:opacity-100",
+            "group-hover:opacity-100 group-focus-visible:opacity-100",
             isDragging && "opacity-100",
           )}
         />
-      </div>
+      </SplitterHandle>
 
       <div className="h-full min-w-0 flex-1 overflow-auto">{right}</div>
     </div>

--- a/packages/design-library/src/components/side-menu/side-menu.tsx
+++ b/packages/design-library/src/components/side-menu/side-menu.tsx
@@ -4,18 +4,19 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useId,
   useRef,
   useState,
   type ComponentProps,
   type CSSProperties,
   type MouseEvent,
-  type PointerEvent,
   type ReactNode,
   type Ref,
 } from "react";
 
 import { Typography } from "../typography";
 import { Tooltip } from "../tooltip";
+import { SplitterHandle } from "../splitter-handle";
 import { cn } from "../../utils/cn";
 
 /**
@@ -272,7 +273,11 @@ function SideMenuRoot({
 }: SideMenuProps) {
   const effectiveCollapsed = variant === "overlay" ? false : collapsed;
   const resizable = variant === "rail" && onWidthChange != null;
-  const showResizeHandle = resizable && !effectiveCollapsed;
+  // `width` is required for the handle, not just for the inline style: the
+  // separator publishes it as `aria-valuenow`, and a handle that cannot say
+  // where it sits is the kind of half-kept ARIA promise this pattern exists
+  // to avoid. A rail sized purely by CSS gets no drag handle.
+  const showResizeHandle = resizable && !effectiveCollapsed && width != null;
 
   const [contentCollapsed, setContentCollapsed] = useState(effectiveCollapsed);
   if (!effectiveCollapsed && contentCollapsed) {
@@ -284,70 +289,62 @@ function SideMenuRoot({
     return () => clearTimeout(id);
   }, [effectiveCollapsed]);
 
-  const dragRef = useRef<{
-    nav: HTMLElement;
-    startX: number;
-    startWidth: number;
-  } | null>(null);
+  const generatedNavId = useId();
+  const navId = rest.id ?? generatedNavId;
 
-  const handleResizePointerDown = useCallback(
-    (e: PointerEvent<HTMLDivElement>) => {
-      if (!onWidthChange) return;
-      e.preventDefault();
-      e.currentTarget.setPointerCapture(e.pointerId);
-      const nav = e.currentTarget.closest(
-        '[data-slot="side-menu"]',
-      ) as HTMLElement | null;
-      if (!nav) return;
-      dragRef.current = {
-        nav,
-        startX: e.clientX,
-        startWidth: nav.getBoundingClientRect().width,
-      };
-      nav.style.transition = "none";
-      document.body.style.cursor = "col-resize";
-      document.body.style.userSelect = "none";
-    },
-    [onWidthChange],
-  );
+  const handleRef = useRef<HTMLDivElement>(null);
+  // The nav being dragged, held only for the duration of a pointer drag. Its
+  // presence is also what tells `handleResizeValueChange` a drag is in flight.
+  const dragNavRef = useRef<HTMLElement | null>(null);
 
-  const handleResizePointerMove = useCallback(
-    (e: PointerEvent<HTMLDivElement>) => {
-      const drag = dragRef.current;
-      if (!drag) return;
-      const delta = e.clientX - drag.startX;
-      const next = Math.min(
-        maxWidth,
-        Math.max(minWidth, drag.startWidth + delta),
-      );
-      drag.nav.style.width = `${next}px`;
-    },
+  const handleResizeDragStart = useCallback(() => {
+    const nav = handleRef.current?.closest(
+      '[data-slot="side-menu"]',
+    ) as HTMLElement | null;
+    if (!nav) return;
+    dragNavRef.current = nav;
+    nav.style.transition = "none";
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+  }, []);
+
+  const handleResizeDragEnd = useCallback(() => {
+    const nav = dragNavRef.current;
+    dragNavRef.current = null;
+    if (nav) nav.style.transition = "";
+    document.body.style.cursor = "";
+    document.body.style.userSelect = "";
+  }, []);
+
+  const clampWidth = useCallback(
+    (next: number) => Math.min(maxWidth, Math.max(minWidth, next)),
     [minWidth, maxWidth],
   );
 
-  const handleResizeEnd = useCallback(
-    (e: PointerEvent<HTMLDivElement>) => {
-      const drag = dragRef.current;
-      if (!drag) return;
-      e.currentTarget.releasePointerCapture(e.pointerId);
-      dragRef.current = null;
-      drag.nav.style.transition = "";
-      document.body.style.cursor = "";
-      document.body.style.userSelect = "";
-      const delta = e.clientX - drag.startX;
-      const finalWidth = Math.min(
-        maxWidth,
-        Math.max(minWidth, drag.startWidth + delta),
-      );
-      onWidthChange?.(finalWidth);
+  // During a pointer drag the width is written straight to the DOM so the
+  // rail tracks the cursor without a React commit per frame; `onWidthChange`
+  // fires once at the end. A keyboard nudge has no such frame budget problem
+  // and goes through the commit path alone, via `onValueCommit` below.
+  const handleResizeValueChange = useCallback(
+    (next: number) => {
+      const nav = dragNavRef.current;
+      if (!nav) return;
+      nav.style.width = `${clampWidth(next)}px`;
     },
-    [onWidthChange, minWidth, maxWidth],
+    [clampWidth],
+  );
+
+  const handleResizeValueCommit = useCallback(
+    (next: number) => {
+      onWidthChange?.(clampWidth(next));
+    },
+    [onWidthChange, clampWidth],
   );
 
   useEffect(() => {
     return () => {
-      if (dragRef.current) {
-        dragRef.current = null;
+      if (dragNavRef.current) {
+        dragNavRef.current = null;
         document.body.style.cursor = "";
         document.body.style.userSelect = "";
       }
@@ -376,20 +373,25 @@ function SideMenuRoot({
         )}
         style={widthStyle}
         {...rest}
+        id={navId}
       >
         {children}
         {showResizeHandle ? (
-          <div
-            role="separator"
-            aria-orientation="vertical"
-            className="absolute right-0 top-0 bottom-0 z-10 w-[6px] cursor-col-resize group/resize"
-            onPointerDown={handleResizePointerDown}
-            onPointerMove={handleResizePointerMove}
-            onPointerUp={handleResizeEnd}
-            onPointerCancel={handleResizeEnd}
+          <SplitterHandle
+            ref={handleRef}
+            value={width}
+            min={minWidth}
+            max={maxWidth}
+            onValueChange={handleResizeValueChange}
+            onValueCommit={handleResizeValueCommit}
+            onResizeStart={handleResizeDragStart}
+            onResizeEnd={handleResizeDragEnd}
+            label="Resize sidebar"
+            controls={navId}
+            className="absolute right-0 top-0 bottom-0 z-10 w-[6px] group/resize"
           >
-            <div className="pointer-events-none absolute right-0 top-2 bottom-2 w-[2px] rounded-full bg-[var(--content-tertiary)] opacity-0 transition-opacity group-hover/resize:opacity-100" />
-          </div>
+            <div className="pointer-events-none absolute right-0 top-2 bottom-2 w-[2px] rounded-full bg-[var(--content-tertiary)] opacity-0 transition-opacity group-hover/resize:opacity-100 group-focus-visible/resize:opacity-100" />
+          </SplitterHandle>
         ) : null}
       </nav>
     </SideMenuContext>

--- a/packages/design-library/src/components/splitter-handle.stories.tsx
+++ b/packages/design-library/src/components/splitter-handle.stories.tsx
@@ -1,0 +1,152 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { SplitterHandle } from "./splitter-handle";
+
+const MIN = 120;
+const MAX = 480;
+
+const meta: Meta<typeof SplitterHandle> = {
+  title: "Components/SplitterHandle",
+  component: SplitterHandle,
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "The interactive divider between two panes. Tab to it, then use " +
+          "Left/Right to nudge (hold Shift for a coarser step) and Home/End " +
+          "to jump to the minimum and maximum. Implements the APG window " +
+          "splitter pattern: https://www.w3.org/WAI/ARIA/apg/patterns/windowsplitter/",
+      },
+    },
+  },
+  args: {
+    min: MIN,
+    max: MAX,
+    label: "Resize panels",
+    invert: false,
+    step: 16,
+  },
+  argTypes: {
+    value: { control: false },
+    onValueChange: { control: false },
+    onValueCommit: { control: false },
+    onDragStart: { control: false },
+    onDragEnd: { control: false },
+    children: { control: false },
+    step: { control: { type: "number" } },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ height: "320px", width: "100%" }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof SplitterHandle>;
+
+function Pane({ label, bg }: { label: string; bg: string }) {
+  return (
+    <div
+      className="flex h-full items-center justify-center px-4 text-center"
+      style={{ backgroundColor: bg }}
+    >
+      <span className="text-sm font-medium text-[color:var(--content-default)]">
+        {label}
+      </span>
+    </div>
+  );
+}
+
+/**
+ * A left pane sized by the handle. Moving the handle right widens it, so
+ * `invert` stays false. The live `aria-valuenow` is echoed under the panes so
+ * a reviewer can watch it track the keyboard without a screen reader.
+ */
+export const Default: Story = {
+  render: function Render(args) {
+    const [width, setWidth] = useState(240);
+    const [committed, setCommitted] = useState(240);
+    // The handle reports what was asked for; clamping is the caller's job.
+    const clamp = (next: number) => Math.min(MAX, Math.max(MIN, next));
+    return (
+      <div className="flex h-full w-full flex-col">
+        <div className="flex min-h-0 flex-1 overflow-hidden">
+          <div
+            id="splitter-story-left"
+            className="h-full shrink-0"
+            style={{ width }}
+          >
+            <Pane label="Left pane" bg="var(--surface-base)" />
+          </div>
+          <SplitterHandle
+            {...args}
+            value={width}
+            controls="splitter-story-left"
+            onValueChange={(next) => setWidth(clamp(next))}
+            onValueCommit={(next) => setCommitted(clamp(next))}
+            className="group relative z-10 flex h-full w-2 shrink-0 items-center justify-center"
+          >
+            <div className="h-full w-px bg-[var(--border-base)]" />
+            <div className="absolute h-8 w-1 rounded-full bg-[var(--content-tertiary)] opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100" />
+          </SplitterHandle>
+          <div className="h-full min-w-0 flex-1">
+            <Pane label="Right pane" bg="var(--surface-lift)" />
+          </div>
+        </div>
+        <p className="p-2 text-xs text-[color:var(--content-tertiary)]">
+          Tab to the divider, then Left/Right (Shift for a coarse step) or
+          Home/End. aria-valuenow: {Math.round(width)} (min {args.min}, max{" "}
+          {args.max}). Last committed: {Math.round(committed)}.
+        </p>
+      </div>
+    );
+  },
+};
+
+/**
+ * The same handle sizing the pane on its *right*, as a side drawer does.
+ * `invert` keeps the arrow keys following the divider rather than the pane, so
+ * ArrowRight still moves the divider rightward and the drawer gets narrower.
+ */
+export const RightAnchoredPane: Story = {
+  args: { invert: true, label: "Resize side panel" },
+  render: function Render(args) {
+    const [width, setWidth] = useState(240);
+    const clamp = (next: number) => Math.min(MAX, Math.max(MIN, next));
+    return (
+      <div className="flex h-full w-full flex-col">
+        <div className="flex min-h-0 flex-1 overflow-hidden">
+          <div className="h-full min-w-0 flex-1">
+            <Pane label="Fills the rest" bg="var(--surface-lift)" />
+          </div>
+          <SplitterHandle
+            {...args}
+            value={width}
+            controls="splitter-story-drawer"
+            onValueChange={(next) => setWidth(clamp(next))}
+            className="group relative z-10 flex h-full w-2 shrink-0 items-center justify-center"
+          >
+            <div className="h-full w-px bg-[var(--border-base)]" />
+            <div className="absolute h-8 w-1 rounded-full bg-[var(--content-tertiary)] opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100" />
+          </SplitterHandle>
+          <div
+            id="splitter-story-drawer"
+            className="h-full shrink-0"
+            style={{ width }}
+          >
+            <Pane label="Drawer" bg="var(--surface-base)" />
+          </div>
+        </div>
+        <p className="p-2 text-xs text-[color:var(--content-tertiary)]">
+          ArrowRight moves the divider right, which narrows the drawer.
+          aria-valuenow: {Math.round(width)}.
+        </p>
+      </div>
+    );
+  },
+};

--- a/packages/design-library/src/components/splitter-handle.tsx
+++ b/packages/design-library/src/components/splitter-handle.tsx
@@ -1,0 +1,219 @@
+import {
+  useCallback,
+  useRef,
+  type ComponentProps,
+  type KeyboardEvent,
+  type PointerEvent,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../utils/cn";
+
+/**
+ * Default keyboard nudge in px for a single arrow press, and the coarse step
+ * used when Shift is held. A split pane's useful range is hundreds of pixels
+ * wide, so a 1px arrow step would be unusable; 16 matches the app's spacing
+ * scale and 64 crosses the range in a sensible number of presses.
+ */
+const DEFAULT_STEP_PX = 16;
+const COARSE_STEP_MULTIPLIER = 4;
+
+export interface SplitterHandleProps
+  extends Omit<
+    ComponentProps<"div">,
+    | "role"
+    | "tabIndex"
+    | "onKeyDown"
+    | "children"
+    | "aria-label"
+    // The handle owns the pointer sequence end to end, including capture. A
+    // caller-supplied handler would either be overwritten or silently split
+    // the drag across two owners, so the props are removed rather than merged.
+    | "onPointerDown"
+    | "onPointerMove"
+    | "onPointerUp"
+    | "onPointerCancel"
+  > {
+  /**
+   * Current size in px of the pane this handle controls, reported as
+   * `aria-valuenow`. The handle is controlled: it never holds the size
+   * itself, so each caller keeps its own clamping and persistence.
+   */
+  value: number;
+  /** Smallest size the controlled pane may take, in px. */
+  min: number;
+  /** Largest size the controlled pane may take, in px. */
+  max: number;
+  /**
+   * Called with the requested new size on every drag frame and every key
+   * press. The value is **not** clamped: `min`/`max` are what the handle
+   * announces, but the caller is the one that can measure its container at
+   * the moment of the change, so the caller owns clamping. A handle that
+   * clamped against its own props would freeze the pane whenever those props
+   * were computed from a stale measurement.
+   */
+  onValueChange: (next: number) => void;
+  /**
+   * Called once with the final size when a drag or key press finishes. This
+   * is the hook for persisting a width. Omit when there is nothing to commit.
+   */
+  onValueCommit?: (next: number) => void;
+  /** Accessible name, e.g. "Resize sidebar". Required: an unnamed splitter announces as a bare separator. */
+  label: string;
+  /** `id` of the pane this handle resizes, for `aria-controls`. */
+  controls?: string;
+  /**
+   * Set when moving the handle to the right *shrinks* the controlled pane.
+   * True for a right-hand drawer, whose size grows as the handle travels
+   * left. Arrow keys follow the handle, not the pane, so ArrowRight always
+   * moves the divider rightward on screen.
+   */
+  invert?: boolean;
+  /** Px moved per arrow press (default 16). Shift multiplies it by 4. */
+  step?: number;
+  /**
+   * Called when a pointer drag begins, for callers that suspend a transition
+   * or set a body cursor for its duration. Named `onResize*` rather than
+   * `onDrag*` so it does not shadow the native HTML drag events, which stay
+   * available on this element.
+   */
+  onResizeStart?: () => void;
+  /** Called when a pointer drag ends, after `onValueCommit`. */
+  onResizeEnd?: () => void;
+  /** Visual content: the divider line and grab affordance. */
+  children?: ReactNode;
+}
+
+/**
+ * The interactive divider between two panes, implementing the APG window
+ * splitter pattern: a focusable `role="separator"` that reports its position
+ * and moves with the arrow keys.
+ *
+ * Exists because three splitters in this codebase each hand-rolled a
+ * pointer-only divider (LUM-3194). `role="separator"` is a widget role only
+ * when the element is focusable ([ARIA 1.2][aria-separator]); a divider that
+ * declares the role without `tabindex` announces as decorative page furniture
+ * while being the only control over the pane's size.
+ *
+ * `Enter` (collapse/restore the primary pane) is deliberately absent. APG
+ * lists it as conditional on the implementation supporting collapse, and no
+ * caller here can collapse a pane: all three clamp to a non-zero minimum.
+ *
+ * Presentation belongs to the caller: pass the divider line and grab handle as
+ * `children` and size the hit area with `className`.
+ *
+ * [aria-separator]: https://www.w3.org/TR/wai-aria-1.2/#separator
+ * @see https://www.w3.org/WAI/ARIA/apg/patterns/windowsplitter/
+ */
+export function SplitterHandle({
+  value,
+  min,
+  max,
+  onValueChange,
+  onValueCommit,
+  label,
+  controls,
+  invert = false,
+  step = DEFAULT_STEP_PX,
+  onResizeStart,
+  onResizeEnd,
+  className,
+  children,
+  ...rest
+}: SplitterHandleProps) {
+  const dragRef = useRef<{ startX: number; startValue: number } | null>(null);
+
+  /** Signed px the controlled pane grows by when the handle travels `dx` right. */
+  const paneDelta = useCallback((dx: number) => (invert ? -dx : dx), [invert]);
+
+  const handlePointerDown = useCallback(
+    (e: PointerEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      e.currentTarget.setPointerCapture(e.pointerId);
+      dragRef.current = { startX: e.clientX, startValue: value };
+      onResizeStart?.();
+    },
+    [value, onResizeStart],
+  );
+
+  const handlePointerMove = useCallback(
+    (e: PointerEvent<HTMLDivElement>) => {
+      const drag = dragRef.current;
+      if (!drag) return;
+      onValueChange(drag.startValue + paneDelta(e.clientX - drag.startX));
+    },
+    [onValueChange, paneDelta],
+  );
+
+  const endDrag = useCallback(
+    (e: PointerEvent<HTMLDivElement>) => {
+      const drag = dragRef.current;
+      if (!drag) return;
+      e.currentTarget.releasePointerCapture(e.pointerId);
+      dragRef.current = null;
+      const final = drag.startValue + paneDelta(e.clientX - drag.startX);
+      onValueChange(final);
+      onValueCommit?.(final);
+      onResizeEnd?.();
+    },
+    [paneDelta, onValueChange, onValueCommit, onResizeEnd],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>) => {
+      const nudge = e.shiftKey ? step * COARSE_STEP_MULTIPLIER : step;
+      let next: number;
+      switch (e.key) {
+        case "ArrowLeft":
+          next = value + paneDelta(-nudge);
+          break;
+        case "ArrowRight":
+          next = value + paneDelta(nudge);
+          break;
+        case "Home":
+          next = min;
+          break;
+        case "End":
+          next = max;
+          break;
+        default:
+          return;
+      }
+      // Claim the key before the browser scrolls the pane behind the handle.
+      e.preventDefault();
+      onValueChange(next);
+      onValueCommit?.(next);
+    },
+    [step, value, paneDelta, min, max, onValueChange, onValueCommit],
+  );
+
+  return (
+    <div
+      {...rest}
+      role="separator"
+      aria-orientation="vertical"
+      aria-label={label}
+      aria-controls={controls}
+      aria-valuenow={Math.round(value)}
+      aria-valuemin={Math.round(min)}
+      aria-valuemax={Math.round(max)}
+      tabIndex={0}
+      data-slot="splitter-handle"
+      className={cn(
+        "cursor-col-resize",
+        // A newly focusable control needs a visible focus indicator (WCAG
+        // 2.4.7). The handle is a thin column, so a ring reads better than an
+        // inset outline at that width.
+        "focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]",
+        className,
+      )}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={endDrag}
+      onPointerCancel={endDrag}
+      onKeyDown={handleKeyDown}
+    >
+      {children}
+    </div>
+  );
+}

--- a/packages/design-library/src/index.ts
+++ b/packages/design-library/src/index.ts
@@ -25,6 +25,10 @@ export {
   type ScrollShadowOrientation,
 } from "./components/scroll-shadow";
 export {
+  SplitterHandle,
+  type SplitterHandleProps,
+} from "./components/splitter-handle";
+export {
   Tag,
   tagVariants,
   type TagProps,


### PR DESCRIPTION
## TL;DR

Every split view in the app is resizable with a mouse and immovable with a keyboard. Three files hand-roll the same drag handle, all three declare `role="separator"`, and none is focusable or implements a single key. This adds one `SplitterHandle` primitive that owns the pointer drag, the key handling, and the ARIA, and adopts it in all three.

Rendered pixels are unchanged everywhere.

Fixes LUM-3194.

## What was broken

`role="separator"` on a draggable divider invokes the [APG window splitter pattern](https://www.w3.org/WAI/ARIA/apg/patterns/windowsplitter/). Per [ARIA 1.2](https://www.w3.org/TR/wai-aria-1.2/#separator), a separator is a widget role **only when it is focusable**; a non-focusable one is a static structural divider. So each of these announced itself as decorative page furniture while actually being the sole control over how much of the window each pane gets.

Verified against the rendered DOM before changing anything, in Storybook on `Components/ResizablePanel → Default`:

1. Tab repeatedly from the canvas. Focus never lands on the divider, which has no `tabindex`.
2. Calling `.focus()` on the separator leaves `document.activeElement` as `<body>`.
3. Dispatching `ArrowRight`, `ArrowLeft`, `Home`, `End`, `Enter`, and `F6` leaves the left pane at exactly `width: 300px`.
4. The element carries only `role="separator"` and `aria-orientation="vertical"`. No `aria-valuenow`, no `aria-valuemin`/`aria-valuemax`, no `aria-controls`, no accessible name.

The same three-attribute markup and the same missing keyboard appeared in all three files, including the sidebar, so the most-used split in the product was also the keyboard-immovable one.

## Before and after, for the person using it

| | Before | After |
| -- | -- | -- |
| Reaching a divider with the keyboard | Impossible. It is not in the tab order at any split in the app. | Tab reaches it, and a focus ring shows where you are. |
| Resizing without a mouse | Impossible. Not degraded, absent. | Left/Right nudge it 16px, Shift makes that 64px, Home/End jump to the narrowest and widest allowed. |
| What a screen reader announces | An unnamed separator with no position. | "Resize sidebar" / "Resize panels" / "Resize side panel", with the pane's current, minimum, and maximum size, so you can hear that you are already at a limit. |
| Which pane it resizes | Not stated. | Stated, via `aria-controls` pointing at that pane. |
| Switch control and voice control | Cannot reach the divider at all. | Reach it like any other focusable control. |
| Dragging with a mouse or trackpad | Works. | Unchanged. |
| How anything looks | | Unchanged. |

## Why it is safe

- **No rendered pixels change.** The divider line and grab affordance are still drawn by each caller and passed to the primitive as children. The only visual addition is a focus ring, which appears only on keyboard focus.
- **Each caller keeps its own drag characteristics.** `side-menu` still writes the width straight to the DOM during a drag rather than paying a React commit per frame, and still suspends its width transition and sets the body cursor for the drag's duration. The drawer's width is still the dimension `motion/react` animates for the 0 ⇄ target wipe, and its render-phase state discipline from LUM-3062 (error 185) is untouched.
- **The handle deliberately does not clamp.** `min`/`max` are what it announces; the caller clamps, because the caller is the one that can measure its container at the moment of the change. A handle clamping against its own props would freeze the pane whenever those props came from a stale measurement. Each of the three callers already clamped and still does.
- **Verified in the browser, not just the source.** Real key presses on the live component: 240 → 320 across five ArrowRight presses, End → 480, Home → 120, two Shift+ArrowRight → 248. The inverted (drawer) case moves the divider right and narrows the pane, 240 → 176. Pointer drag re-verified on `ResizablePanel` (460 → 340 on a 120px leftward drag) and on `SideMenu` (280 → 360, with the transition suspended during the drag and restored after, and the body cursor set and restored).
- Typecheck and lint clean in both `packages/design-library` and `clients/web`. `bun test` is blocked locally by a hook, so CI is the gate for tests.

## Notes on the design

**`Enter` is deliberately not implemented.** APG lists collapse/restore as conditional on the implementation supporting collapse, and no caller here can collapse a pane, since all three clamp to a non-zero minimum. Claiming the key would be the same category of mistake this PR fixes.

**`SideMenu` now requires `width` to show its drag handle.** The separator publishes `width` as `aria-valuenow`, and a handle that cannot say where it sits is a half-kept promise. Previously the drag measured the nav at pointer-down instead. Every call site in the app already passes `width`; a rail sized purely by CSS now gets no drag handle rather than an unreportable one.

**`onResizeStart`/`onResizeEnd`, not `onDragStart`/`onDragEnd`,** so the props do not shadow the native HTML drag events, which stay available on the element.

## Deferred, with reasons

**Should we own a splitter at all?** Radix has no splitter primitive, and the obvious alternative is [`react-resizable-panels`](https://github.com/bvaughn/react-resizable-panels), which is what shadcn's `Resizable` is built on. It is the wrong primitive here, but not for the reason it first appears.

`react-resizable-panels` models a panel *group*: N panes sharing a space proportionally, with layout persisted as a percentage array. None of these four surfaces is that. On `main`, `defaultLeftPercent` has 7 references and all of them are inside `resizable-panel.tsx` itself; no caller sets it, and no caller sets `defaultLeftWidth` either. Every real usage passes `defaultRightWidth`:

| Surface | Shape |
| -- | -- |
| `chat-content-layout.tsx:348` (app editing) | right pane sized 400px, left takes the remainder |
| `detail-drawer.tsx:28` (Activity, Schedules) | right pane sized 480px, left takes the remainder |
| `animated-right-drawer.tsx` | right pane sized, left takes the remainder, animated |
| `side-menu.tsx` | left pane sized, right takes the remainder |

All four are one shape: one pane owns a pixel size, the other takes what is left. Expressing "the inspector is 480px" as a percentage of its container is not a neutral translation, it is worse, because that is exactly what makes a fixed-width inspector drift as the window resizes. The shared concept is "a pane with a size, plus a resizable edge", which is the sidebar/drawer recipe rather than the panel-group recipe, and that is what `SplitterHandle` serves.

The real follow-up is therefore not a library swap: `ResizablePanel` is misnamed for what every caller actually uses it as, and its dead proportional API is what makes a panel-group library look like the obvious upgrade. Tracked separately; out of scope here because renaming a design-library export and removing a prop is a different review than a change that alters no rendered pixels.

**A `ResizeObserver` is now duplicated in two files.** It exists only so `aria-valuemax` is truthful: the pane's maximum comes from a live container measurement neither component tracked, and an omitted `aria-valuemax` defaults to 100, which would be a lie against pixel values. `clients/web`'s `useElementSize` was not reused because it owns its own callback ref (both components need an object ref for the live clamp) and falls back to `windowSize()` before mount, which would publish a wrong maximum on first paint. This is the strongest argument for the library above, and it is noted on the ticket as such.

**LUM-2979 is now canceled.** It reported this same defect against `sidebar-section-resize-handle.tsx`, which was deleted outright in #39934 along with the Pinned section's height cap. The ticket was obsolete on its own terms; the defect it described survives in the three files this PR fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
