### PR TITLE
feat(gateway): claim an inbound delivery before handing it to the assistant

### DIFF
--- a/assistant/src/persistence/delivery-crud.ts
+++ b/assistant/src/persistence/delivery-crud.ts
@@ -236,6 +236,13 @@ export function findInboundConversationId(
 /**
  * Record an inbound channel event. Returns `duplicate: true` if this
  * exact (channel, chat, message) combination was already seen.
+ *
+ * The dedup half of this is also implemented gateway-side, on the same
+ * triple, in `gateway/src/db/inbound-dedup-store.ts`. Deliberately, not by
+ * accident: the gateway claims a delivery before handing it over, so a
+ * vendor's retry costs no crossing, and this stays as the record that binds
+ * the conversation and tracks the reply. Both must key on the same three
+ * fields for either to mean anything.
  */
 export function recordInbound(
   sourceChannel: string,

--- a/gateway/src/db/inbound-dedup-store.test.ts
+++ b/gateway/src/db/inbound-dedup-store.test.ts
@@ -1,0 +1,130 @@
+/**
+ * The gateway's claim on an inbound delivery.
+ *
+ * What is being tested is a single question asked concurrently: two copies of
+ * the same delivery must not both be told to proceed. The rest follows from
+ * that: the release exists so a claim taken for a handoff that then failed
+ * does not answer the retry it just asked for, and the expiry exists so the
+ * table does not grow a row per message forever.
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "bun:test";
+
+import "../__tests__/test-preload.js";
+import { getGatewayDb, initGatewayDb, resetGatewayDb } from "./connection.js";
+import {
+  cleanupExpiredInboundEvents,
+  hasInboundEventClaim,
+  releaseInboundEvent,
+  reserveInboundEvent,
+} from "./inbound-dedup-store.js";
+import { inboundSeenEvents } from "./schema.js";
+
+const KEY = {
+  sourceChannel: "plugin",
+  externalChatId: "imessage:+12025550142",
+  externalMessageId: "imessage:msg-1",
+};
+
+beforeAll(async () => {
+  resetGatewayDb();
+  await initGatewayDb();
+});
+
+afterAll(() => {
+  resetGatewayDb();
+});
+
+beforeEach(() => {
+  getGatewayDb().delete(inboundSeenEvents).run();
+});
+
+describe("reserveInboundEvent", () => {
+  it("gives the claim to the first caller and no one else", () => {
+    expect(reserveInboundEvent(KEY)).toBe(true);
+    expect(reserveInboundEvent(KEY)).toBe(false);
+    expect(reserveInboundEvent(KEY)).toBe(false);
+  });
+
+  it("treats a different message in the same conversation as its own", () => {
+    // Otherwise a second message from the same sender would be swallowed as a
+    // retry of the first, which is the failure mode a dedup key that was too
+    // coarse would produce.
+    expect(reserveInboundEvent(KEY)).toBe(true);
+    expect(
+      reserveInboundEvent({ ...KEY, externalMessageId: "imessage:msg-2" }),
+    ).toBe(true);
+  });
+
+  it("keeps two plugins numbering from one out of each other's keyspace", () => {
+    // `pluginScopedId` is what makes this true upstream; the store's job is
+    // only to not collapse ids that arrive already distinct.
+    expect(
+      reserveInboundEvent({
+        ...KEY,
+        externalChatId: "imessage:room",
+        externalMessageId: "imessage:1",
+      }),
+    ).toBe(true);
+    expect(
+      reserveInboundEvent({
+        ...KEY,
+        externalChatId: "signal:room",
+        externalMessageId: "signal:1",
+      }),
+    ).toBe(true);
+  });
+
+  it("hands the claim on once it has expired", () => {
+    // A vendor still sending this an hour after the window closed is sending
+    // something new, and answering it as a duplicate would drop a real
+    // message. The reclaim happens in place, so no sweep has to have run.
+    expect(reserveInboundEvent(KEY, -1)).toBe(true);
+    expect(reserveInboundEvent(KEY)).toBe(true);
+    expect(reserveInboundEvent(KEY)).toBe(false);
+  });
+});
+
+describe("releaseInboundEvent", () => {
+  it("lets the delivery be claimed again", () => {
+    // The rollback for a handoff that failed after the claim was taken.
+    expect(reserveInboundEvent(KEY)).toBe(true);
+    releaseInboundEvent(KEY);
+    expect(reserveInboundEvent(KEY)).toBe(true);
+  });
+
+  it("is silent about a claim that was never held", () => {
+    expect(() => releaseInboundEvent(KEY)).not.toThrow();
+  });
+
+  it("releases only the claim it was given", () => {
+    reserveInboundEvent(KEY);
+    reserveInboundEvent({ ...KEY, externalMessageId: "imessage:msg-2" });
+
+    releaseInboundEvent(KEY);
+
+    expect(hasInboundEventClaim(KEY)).toBe(false);
+    expect(
+      hasInboundEventClaim({ ...KEY, externalMessageId: "imessage:msg-2" }),
+    ).toBe(true);
+  });
+});
+
+describe("cleanupExpiredInboundEvents", () => {
+  it("drops the expired and keeps the live", () => {
+    reserveInboundEvent(KEY, -1);
+    reserveInboundEvent({ ...KEY, externalMessageId: "imessage:msg-2" });
+
+    expect(cleanupExpiredInboundEvents()).toBe(1);
+    expect(
+      hasInboundEventClaim({ ...KEY, externalMessageId: "imessage:msg-2" }),
+    ).toBe(true);
+  });
+});

--- a/gateway/src/db/inbound-dedup-store.test.ts
+++ b/gateway/src/db/inbound-dedup-store.test.ts
@@ -4,8 +4,9 @@
  * What is being tested is a single question asked concurrently: two copies of
  * the same delivery must not both be told to proceed. The rest follows from
  * that: the release exists so a claim taken for a handoff that then failed
- * does not answer the retry it just asked for, and the expiry exists so the
- * table does not grow a row per message forever.
+ * does not answer the retry it just asked for, the lease exists so a claim
+ * abandoned by a crash frees itself, and the expiry exists so the table does
+ * not grow a row per message forever.
  */
 
 import {
@@ -21,9 +22,11 @@ import "../__tests__/test-preload.js";
 import { getGatewayDb, initGatewayDb, resetGatewayDb } from "./connection.js";
 import {
   cleanupExpiredInboundEvents,
-  hasInboundEventClaim,
+  commitInboundEvent,
+  readInboundEventClaim,
   releaseInboundEvent,
   reserveInboundEvent,
+  INBOUND_DEDUP_TTL_MS,
 } from "./inbound-dedup-store.js";
 import { inboundSeenEvents } from "./schema.js";
 
@@ -32,6 +35,8 @@ const KEY = {
   externalChatId: "imessage:+12025550142",
   externalMessageId: "imessage:msg-1",
 };
+
+const OTHER = { ...KEY, externalMessageId: "imessage:msg-2" };
 
 beforeAll(async () => {
   resetGatewayDb();
@@ -58,9 +63,7 @@ describe("reserveInboundEvent", () => {
     // retry of the first, which is the failure mode a dedup key that was too
     // coarse would produce.
     expect(reserveInboundEvent(KEY)).toBe(true);
-    expect(
-      reserveInboundEvent({ ...KEY, externalMessageId: "imessage:msg-2" }),
-    ).toBe(true);
+    expect(reserveInboundEvent(OTHER)).toBe(true);
   });
 
   it("keeps two plugins numbering from one out of each other's keyspace", () => {
@@ -82,13 +85,60 @@ describe("reserveInboundEvent", () => {
     ).toBe(true);
   });
 
-  it("hands the claim on once it has expired", () => {
-    // A vendor still sending this an hour after the window closed is sending
-    // something new, and answering it as a duplicate would drop a real
-    // message. The reclaim happens in place, so no sweep has to have run.
+  it("claims on a lease, not the full window", () => {
+    // The distinction the crash case rests on: until the delivery lands, the
+    // claim has to be short enough to outlive nothing.
+    expect(readInboundEventClaim(KEY)).toBeUndefined();
+
+    reserveInboundEvent(KEY);
+
+    const pending = readInboundEventClaim(KEY);
+    expect(pending?.state).toBe("pending");
+    expect(pending!.expiresAt - pending!.seenAt).toBeLessThan(
+      INBOUND_DEDUP_TTL_MS,
+    );
+  });
+
+  it("hands the claim on once the lease has lapsed", () => {
+    // A gateway that died between claiming a delivery and forwarding it runs
+    // nothing, so nothing releases. The lease is the only thing that makes the
+    // message deliverable again, and it has to work without a sweep.
     expect(reserveInboundEvent(KEY, -1)).toBe(true);
     expect(reserveInboundEvent(KEY)).toBe(true);
     expect(reserveInboundEvent(KEY)).toBe(false);
+  });
+});
+
+describe("commitInboundEvent", () => {
+  it("widens the claim to the full dedup window", () => {
+    reserveInboundEvent(KEY);
+    commitInboundEvent(KEY);
+
+    const claim = readInboundEventClaim(KEY);
+    expect(claim?.state).toBe("committed");
+    expect(claim!.expiresAt).toBeGreaterThan(
+      Date.now() + INBOUND_DEDUP_TTL_MS / 2,
+    );
+  });
+
+  it("keeps blocking redelivery after the lease would have lapsed", () => {
+    // The point of committing: a delivery that landed stays deduped for the
+    // whole window, not just for the lease it was claimed on.
+    reserveInboundEvent(KEY, 50);
+    commitInboundEvent(KEY);
+
+    expect(reserveInboundEvent(KEY)).toBe(false);
+  });
+
+  it("does not reach into a claim that replaced its own", () => {
+    // A commit whose lease lapsed mid-flight must not promote whatever took
+    // the key over; that row belongs to a delivery still in flight.
+    reserveInboundEvent(KEY, -1);
+    reserveInboundEvent(KEY);
+
+    commitInboundEvent(OTHER);
+
+    expect(readInboundEventClaim(KEY)?.state).toBe("pending");
   });
 });
 
@@ -106,25 +156,32 @@ describe("releaseInboundEvent", () => {
 
   it("releases only the claim it was given", () => {
     reserveInboundEvent(KEY);
-    reserveInboundEvent({ ...KEY, externalMessageId: "imessage:msg-2" });
+    reserveInboundEvent(OTHER);
 
     releaseInboundEvent(KEY);
 
-    expect(hasInboundEventClaim(KEY)).toBe(false);
-    expect(
-      hasInboundEventClaim({ ...KEY, externalMessageId: "imessage:msg-2" }),
-    ).toBe(true);
+    expect(readInboundEventClaim(KEY)).toBeUndefined();
+    expect(readInboundEventClaim(OTHER)).toBeDefined();
+  });
+
+  it("does not retract a delivery that already landed", () => {
+    // A release is a caller giving up its own in-flight claim, never a
+    // retraction of something the assistant already took.
+    reserveInboundEvent(KEY);
+    commitInboundEvent(KEY);
+
+    releaseInboundEvent(KEY);
+
+    expect(readInboundEventClaim(KEY)?.state).toBe("committed");
   });
 });
 
 describe("cleanupExpiredInboundEvents", () => {
   it("drops the expired and keeps the live", () => {
     reserveInboundEvent(KEY, -1);
-    reserveInboundEvent({ ...KEY, externalMessageId: "imessage:msg-2" });
+    reserveInboundEvent(OTHER);
 
     expect(cleanupExpiredInboundEvents()).toBe(1);
-    expect(
-      hasInboundEventClaim({ ...KEY, externalMessageId: "imessage:msg-2" }),
-    ).toBe(true);
+    expect(readInboundEventClaim(OTHER)).toBeDefined();
   });
 });

--- a/gateway/src/db/inbound-dedup-store.ts
+++ b/gateway/src/db/inbound-dedup-store.ts
@@ -1,0 +1,131 @@
+/**
+ * Gateway-side claim on an inbound delivery, so a vendor's retry does not
+ * become a second turn.
+ *
+ * This is the dedup half of the assistant's `recordInbound`, forked to run
+ * before the handoff rather than after it. The key is identical, deliberately:
+ * `(sourceChannel, externalChatId, externalMessageId)`, the triple every
+ * channel already dedups on. What is not forked is everything else that
+ * function does. `recordInbound` also binds the conversation, writes the
+ * permanent event row, and opens the delivery-status record the outbound
+ * reply is tracked on, and none of that is administrative in the way a
+ * duplicate check is. Those stay where the messages are.
+ *
+ * The claim is a reservation, not a receipt. It is taken before the delivery
+ * is handed off and released when the handoff fails, so a message lost to an
+ * assistant outage is one the vendor's next retry can still deliver. That is
+ * the rollback `deleteInbound` was written for on the assistant side and which
+ * nothing there ever calls.
+ *
+ * Rows expire. The assistant's are permanent because they carry more than
+ * dedup; these answer one question, and a vendor still retrying a day later is
+ * sending something new rather than the same thing again.
+ */
+
+import type { Database } from "bun:sqlite";
+
+import { getGatewayDb } from "./connection.js";
+
+/** Which delivery, in the terms every channel's dedup already uses. */
+export interface InboundEventKey {
+  sourceChannel: string;
+  externalChatId: string;
+  externalMessageId: string;
+}
+
+/**
+ * How long a claim blocks a redelivery of the same message.
+ *
+ * A day, matching the window every other webhook route in the gateway holds
+ * (`StringDedupCache` in telegram-webhook, email-webhook, whatsapp-webhook,
+ * mailgun-webhook) and the Slack socket dedup. Vendor retry schedules are
+ * measured in hours at the outside, so this covers the retries and little
+ * else.
+ */
+export const INBOUND_DEDUP_TTL_MS = 24 * 60 * 60 * 1_000;
+
+function rawDb(): Database {
+  return (getGatewayDb() as unknown as { $client: Database }).$client;
+}
+
+/**
+ * Claim `key` for processing. Returns false when it is already claimed.
+ *
+ * One statement, because two would be a race: between a `SELECT` that found
+ * nothing and the `INSERT` that followed it, a concurrent redelivery of the
+ * same message would pass the same check and both would proceed. The upsert
+ * takes the row only when there is none or the one there has expired, and
+ * SQLite reports that as a changed row, so the return value is the claim.
+ *
+ * Written as SQL rather than through Drizzle for the change count, which is
+ * the whole answer here and which the query builder does not surface.
+ */
+export function reserveInboundEvent(
+  key: InboundEventKey,
+  ttlMs: number = INBOUND_DEDUP_TTL_MS,
+): boolean {
+  const now = Date.now();
+  return (
+    rawDb()
+      .prepare(
+        `INSERT INTO inbound_seen_events
+           (source_channel, external_chat_id, external_message_id, seen_at, expires_at)
+         VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT (source_channel, external_chat_id, external_message_id)
+         DO UPDATE SET seen_at = excluded.seen_at, expires_at = excluded.expires_at
+         WHERE inbound_seen_events.expires_at <= ?`,
+      )
+      .run(
+        key.sourceChannel,
+        key.externalChatId,
+        key.externalMessageId,
+        now,
+        now + ttlMs,
+        now,
+      ).changes > 0
+  );
+}
+
+/**
+ * Give up a claim, so the vendor's retry is not answered as a duplicate.
+ *
+ * For the delivery that was claimed and then could not be handed off. Silent
+ * when there is nothing to release: releasing twice, or releasing a claim that
+ * has already expired, is the same outcome the caller wanted.
+ */
+export function releaseInboundEvent(key: InboundEventKey): void {
+  rawDb()
+    .prepare(
+      `DELETE FROM inbound_seen_events
+        WHERE source_channel = ?
+          AND external_chat_id = ?
+          AND external_message_id = ?`,
+    )
+    .run(key.sourceChannel, key.externalChatId, key.externalMessageId);
+}
+
+/** Whether `key` is currently claimed. Read-only, for tests and diagnostics. */
+export function hasInboundEventClaim(key: InboundEventKey): boolean {
+  const row = rawDb()
+    .prepare(
+      `SELECT 1 FROM inbound_seen_events
+        WHERE source_channel = ?
+          AND external_chat_id = ?
+          AND external_message_id = ?
+          AND expires_at > ?`,
+    )
+    .get(
+      key.sourceChannel,
+      key.externalChatId,
+      key.externalMessageId,
+      Date.now(),
+    );
+  return row !== undefined && row !== null;
+}
+
+/** Drop expired claims. Returns how many rows went. */
+export function cleanupExpiredInboundEvents(): number {
+  return rawDb()
+    .prepare("DELETE FROM inbound_seen_events WHERE expires_at <= ?")
+    .run(Date.now()).changes;
+}

--- a/gateway/src/db/inbound-dedup-store.ts
+++ b/gateway/src/db/inbound-dedup-store.ts
@@ -11,20 +11,42 @@
  * reply is tracked on, and none of that is administrative in the way a
  * duplicate check is. Those stay where the messages are.
  *
- * The claim is a reservation, not a receipt. It is taken before the delivery
- * is handed off and released when the handoff fails, so a message lost to an
- * assistant outage is one the vendor's next retry can still deliver. That is
- * the rollback `deleteInbound` was written for on the assistant side and which
- * nothing there ever calls.
+ * ## Reserve, then commit
+ *
+ * A claim is taken in two steps, for the same reason `StringDedupCache`
+ * (telegram-webhook, email-webhook, whatsapp-webhook, mailgun-webhook) takes
+ * one in two steps: a reservation and a delivery are not the same fact.
+ *
+ * {@link reserveInboundEvent} claims the key on a short lease, which is enough
+ * to keep a concurrent redelivery out while the first copy is in flight.
+ * {@link commitInboundEvent} converts it to the full window once the message
+ * actually reached the assistant. Between those, two things can go wrong and
+ * both have to end with the delivery still deliverable:
+ *
+ * - The handoff fails and the gateway answers 503. {@link releaseInboundEvent}
+ *   drops the claim, because asking the vendor to retry while holding the row
+ *   that answers the retry as a duplicate is how a message is lost with both
+ *   sides reporting success. That is the rollback `deleteInbound` was written
+ *   for on the assistant side and which nothing there ever calls.
+ * - The gateway dies outright: a deploy, an OOM, a host failure. Nothing runs,
+ *   so nothing can release. The lease is what covers this. A `pending` row is
+ *   reclaimable as soon as it expires, so the delivery is retryable minutes
+ *   later rather than being answered as already-delivered for a day, which
+ *   would outlive the vendor's retry schedule and lose the message for good.
+ *
+ * The bias is deliberate: re-delivering a message the assistant already took
+ * is recoverable, and the assistant's own `recordInbound` catches that case
+ * today. Dropping one is not recoverable by anything.
  *
  * Rows expire. The assistant's are permanent because they carry more than
  * dedup; these answer one question, and a vendor still retrying a day later is
  * sending something new rather than the same thing again.
  */
 
-import type { Database } from "bun:sqlite";
+import { and, eq, gt, lte } from "drizzle-orm";
 
 import { getGatewayDb } from "./connection.js";
+import { inboundSeenEvents } from "./schema.js";
 
 /** Which delivery, in the terms every channel's dedup already uses. */
 export interface InboundEventKey {
@@ -34,7 +56,7 @@ export interface InboundEventKey {
 }
 
 /**
- * How long a claim blocks a redelivery of the same message.
+ * How long a committed claim blocks a redelivery of the same message.
  *
  * A day, matching the window every other webhook route in the gateway holds
  * (`StringDedupCache` in telegram-webhook, email-webhook, whatsapp-webhook,
@@ -44,8 +66,30 @@ export interface InboundEventKey {
  */
 export const INBOUND_DEDUP_TTL_MS = 24 * 60 * 60 * 1_000;
 
-function rawDb(): Database {
-  return (getGatewayDb() as unknown as { $client: Database }).$client;
+/**
+ * How long an unfinished claim blocks one, before it is assumed abandoned.
+ *
+ * Bounded below by how long a handoff can legitimately take, so a slow
+ * assistant is not overtaken by the vendor's own retry: the forward is capped
+ * by `runtimeTimeoutMs`, 30s by default, and this is an order of magnitude
+ * above that. Bounded above by how long a message may sit undeliverable after
+ * a crash, which is why it is minutes rather than the full window.
+ */
+export const INBOUND_CLAIM_LEASE_MS = 5 * 60 * 1_000;
+
+/** The composite key's columns, for the upsert's conflict target. */
+const KEY_COLUMNS = [
+  inboundSeenEvents.sourceChannel,
+  inboundSeenEvents.externalChatId,
+  inboundSeenEvents.externalMessageId,
+];
+
+function keyMatches(key: InboundEventKey) {
+  return and(
+    eq(inboundSeenEvents.sourceChannel, key.sourceChannel),
+    eq(inboundSeenEvents.externalChatId, key.externalChatId),
+    eq(inboundSeenEvents.externalMessageId, key.externalMessageId),
+  );
 }
 
 /**
@@ -55,77 +99,88 @@ function rawDb(): Database {
  * nothing and the `INSERT` that followed it, a concurrent redelivery of the
  * same message would pass the same check and both would proceed. The upsert
  * takes the row only when there is none or the one there has expired, and
- * SQLite reports that as a changed row, so the return value is the claim.
+ * `RETURNING` reports which happened, so the returned rows are the claim.
  *
- * Written as SQL rather than through Drizzle for the change count, which is
- * the whole answer here and which the query builder does not surface.
+ * The claim is `pending` and short-lived until {@link commitInboundEvent}
+ * says otherwise.
  */
 export function reserveInboundEvent(
   key: InboundEventKey,
-  ttlMs: number = INBOUND_DEDUP_TTL_MS,
+  leaseMs: number = INBOUND_CLAIM_LEASE_MS,
 ): boolean {
   const now = Date.now();
-  return (
-    rawDb()
-      .prepare(
-        `INSERT INTO inbound_seen_events
-           (source_channel, external_chat_id, external_message_id, seen_at, expires_at)
-         VALUES (?, ?, ?, ?, ?)
-         ON CONFLICT (source_channel, external_chat_id, external_message_id)
-         DO UPDATE SET seen_at = excluded.seen_at, expires_at = excluded.expires_at
-         WHERE inbound_seen_events.expires_at <= ?`,
-      )
-      .run(
-        key.sourceChannel,
-        key.externalChatId,
-        key.externalMessageId,
-        now,
-        now + ttlMs,
-        now,
-      ).changes > 0
-  );
+  const claim = {
+    state: "pending" as const,
+    seenAt: now,
+    expiresAt: now + leaseMs,
+  };
+  const claimed = getGatewayDb()
+    .insert(inboundSeenEvents)
+    .values({ ...key, ...claim })
+    .onConflictDoUpdate({
+      target: KEY_COLUMNS,
+      set: claim,
+      // Only an expired row may be taken over. Without this the upsert would
+      // hand every redelivery a fresh claim, which is the opposite of dedup.
+      setWhere: lte(inboundSeenEvents.expiresAt, now),
+    })
+    .returning({ externalMessageId: inboundSeenEvents.externalMessageId })
+    .all();
+  return claimed.length > 0;
+}
+
+/**
+ * Promote a claim to the full dedup window, the delivery having landed.
+ *
+ * Scoped to a row still `pending`, so a commit arriving after its own lease
+ * expired and the key was reclaimed cannot reach into the claim that replaced
+ * it. A commit that matches nothing is not an error: the delivery succeeded,
+ * and the worst that follows is the vendor's next retry being forwarded again
+ * and deduped by the assistant.
+ */
+export function commitInboundEvent(
+  key: InboundEventKey,
+  ttlMs: number = INBOUND_DEDUP_TTL_MS,
+): void {
+  const now = Date.now();
+  getGatewayDb()
+    .update(inboundSeenEvents)
+    .set({ state: "committed", expiresAt: now + ttlMs })
+    .where(and(keyMatches(key), eq(inboundSeenEvents.state, "pending")))
+    .run();
 }
 
 /**
  * Give up a claim, so the vendor's retry is not answered as a duplicate.
  *
- * For the delivery that was claimed and then could not be handed off. Silent
- * when there is nothing to release: releasing twice, or releasing a claim that
- * has already expired, is the same outcome the caller wanted.
+ * For the delivery that was claimed and then could not be handed off. Scoped
+ * to `pending` for the same reason the commit is: a release is only ever the
+ * caller giving up its own in-flight claim, never a retraction of a delivery
+ * that already landed. Silent when there is nothing to release, since
+ * releasing twice and releasing an expired claim both leave what the caller
+ * wanted.
  */
 export function releaseInboundEvent(key: InboundEventKey): void {
-  rawDb()
-    .prepare(
-      `DELETE FROM inbound_seen_events
-        WHERE source_channel = ?
-          AND external_chat_id = ?
-          AND external_message_id = ?`,
-    )
-    .run(key.sourceChannel, key.externalChatId, key.externalMessageId);
+  getGatewayDb()
+    .delete(inboundSeenEvents)
+    .where(and(keyMatches(key), eq(inboundSeenEvents.state, "pending")))
+    .run();
 }
 
-/** Whether `key` is currently claimed. Read-only, for tests and diagnostics. */
-export function hasInboundEventClaim(key: InboundEventKey): boolean {
-  const row = rawDb()
-    .prepare(
-      `SELECT 1 FROM inbound_seen_events
-        WHERE source_channel = ?
-          AND external_chat_id = ?
-          AND external_message_id = ?
-          AND expires_at > ?`,
-    )
-    .get(
-      key.sourceChannel,
-      key.externalChatId,
-      key.externalMessageId,
-      Date.now(),
-    );
-  return row !== undefined && row !== null;
+/** The live claim on `key`, if there is one. For tests and diagnostics. */
+export function readInboundEventClaim(key: InboundEventKey) {
+  return getGatewayDb()
+    .select()
+    .from(inboundSeenEvents)
+    .where(and(keyMatches(key), gt(inboundSeenEvents.expiresAt, Date.now())))
+    .get();
 }
 
 /** Drop expired claims. Returns how many rows went. */
 export function cleanupExpiredInboundEvents(): number {
-  return rawDb()
-    .prepare("DELETE FROM inbound_seen_events WHERE expires_at <= ?")
-    .run(Date.now()).changes;
+  return getGatewayDb()
+    .delete(inboundSeenEvents)
+    .where(lte(inboundSeenEvents.expiresAt, Date.now()))
+    .returning({ externalMessageId: inboundSeenEvents.externalMessageId })
+    .all().length;
 }

--- a/gateway/src/db/schema.ts
+++ b/gateway/src/db/schema.ts
@@ -693,6 +693,14 @@ export const pluginIngressApprovals = sqliteTable(
  * one question, so its rows expire. A vendor that retries a day later is
  * sending a new message, not a retry, and holding the key forever would grow
  * a table nothing reads.
+ *
+ * A row means one of two different things, which is what `state` records. A
+ * `pending` row is a delivery in flight and carries a short lease; a
+ * `committed` one reached the assistant and carries the full window. The
+ * distinction is load-bearing rather than descriptive: without it, a gateway
+ * that died between claiming a delivery and forwarding it would leave a row
+ * that answers every retry with "already delivered" for a full day, outliving
+ * the vendor's retry schedule and losing the message for good.
  */
 export const inboundSeenEvents = sqliteTable(
   "inbound_seen_events",
@@ -705,7 +713,14 @@ export const inboundSeenEvents = sqliteTable(
     sourceChannel: text("source_channel").notNull(),
     externalChatId: text("external_chat_id").notNull(),
     externalMessageId: text("external_message_id").notNull(),
+    // `pending` while the delivery is in flight, `committed` once it reached
+    // the assistant. Nothing reclaims on this column (expiry does that on its
+    // own), but the two lifetimes are otherwise indistinguishable from a row,
+    // and an abandoned claim is the thing most worth being able to see.
+    state: text("state").$type<"pending" | "committed">().notNull(),
     seenAt: integer("seen_at").notNull(),
+    // When this row stops blocking a redelivery. Short for `pending`, so a
+    // claim abandoned by a crash frees itself; a full day for `committed`.
     expiresAt: integer("expires_at").notNull(),
   },
   (table) => [

--- a/gateway/src/db/schema.ts
+++ b/gateway/src/db/schema.ts
@@ -10,6 +10,7 @@ import { sql } from "drizzle-orm";
 import {
   index,
   integer,
+  primaryKey,
   sqliteTable,
   text,
   uniqueIndex,
@@ -669,4 +670,52 @@ export const pluginIngressApprovals = sqliteTable(
     approvedBy: text("approved_by"),
   },
   (table) => [index("idx_plugin_ingress_approvals_digest").on(table.digest)],
+);
+
+// ---------------------------------------------------------------------------
+// Inbound dedup (a vendor's retry must not become a second turn)
+// ---------------------------------------------------------------------------
+
+/**
+ * Inbound deliveries already claimed by the gateway.
+ *
+ * Every vendor retries: on a timeout, on a 5xx, on an ack it did not see. The
+ * assistant has always deduped these on the same three columns, in
+ * `channel_inbound_events` (`recordInbound`), but that is on the far side of
+ * the handoff, so a retry still costs a crossing and lands wherever the
+ * pipeline's side effects happen to be idempotent. Claiming it here is the
+ * same decision made earlier, on the gateway side, where the rest of the
+ * administrative work already lives.
+ *
+ * Only the claim lives here, not the record. The assistant's row is permanent
+ * because it carries more than dedup: the conversation it bound to, the
+ * message it produced, the delivery status of the reply. This table answers
+ * one question, so its rows expire. A vendor that retries a day later is
+ * sending a new message, not a retry, and holding the key forever would grow
+ * a table nothing reads.
+ */
+export const inboundSeenEvents = sqliteTable(
+  "inbound_seen_events",
+  {
+    // The same triple `recordInbound` dedups on, so a key claimed here means
+    // the same delivery it would mean there. For plugin channels this is
+    // always `plugin` with plugin-scoped ids (see `pluginScopedId`), which is
+    // what keeps two plugins whose vendors both number messages from 1 out of
+    // each other's keyspace.
+    sourceChannel: text("source_channel").notNull(),
+    externalChatId: text("external_chat_id").notNull(),
+    externalMessageId: text("external_message_id").notNull(),
+    seenAt: integer("seen_at").notNull(),
+    expiresAt: integer("expires_at").notNull(),
+  },
+  (table) => [
+    primaryKey({
+      columns: [
+        table.sourceChannel,
+        table.externalChatId,
+        table.externalMessageId,
+      ],
+    }),
+    index("idx_inbound_seen_events_expires_at").on(table.expiresAt),
+  ],
 );

--- a/gateway/src/http/routes/plugin-webhook.test.ts
+++ b/gateway/src/http/routes/plugin-webhook.test.ts
@@ -21,6 +21,10 @@ import {
   initGatewayDb,
   resetGatewayDb,
 } from "../../db/connection.js";
+import {
+  readInboundEventClaim,
+  INBOUND_CLAIM_LEASE_MS,
+} from "../../db/inbound-dedup-store.js";
 import { inboundSeenEvents } from "../../db/schema.js";
 import type { HandleInboundOptions } from "../../handlers/handle-inbound.js";
 import { createPluginWebhookHandler } from "./plugin-webhook.js";
@@ -1265,6 +1269,13 @@ describe("inbound dedup", () => {
     actor: { actorExternalId: "(202) 555-0142" },
   };
 
+  /** What MESSAGE is claimed under, once the plugin scoping is applied. */
+  const DEDUP_KEY = {
+    sourceChannel: "plugin",
+    externalChatId: "meeting-bot:chat-1",
+    externalMessageId: "meeting-bot:msg-1",
+  };
+
   /**
    * A handler over a fixed plugin reply, recording what reached the pipeline.
    *
@@ -1417,5 +1428,45 @@ describe("inbound dedup", () => {
         externalMessageId: "meeting-bot:msg-1",
       }),
     ] as never);
+  });
+
+  it("commits the claim once the message reached the runtime", async () => {
+    // Committing is what turns the in-flight lease into the dedup window. A
+    // delivery that landed and stayed `pending` would start admitting retries
+    // again the moment its lease lapsed.
+    const { impl } = accepting();
+    await deliver(handlerFor(impl));
+
+    expect(readInboundEventClaim(DEDUP_KEY)?.state).toBe("committed");
+  });
+
+  it("leaves a delivery reclaimable when the gateway dies mid-handoff", async () => {
+    // The failure nothing can roll back: a deploy, an OOM, a host crash
+    // between claiming the delivery and handing it over. Nothing runs, so
+    // nothing releases, and the row survives the restart. If it were the full
+    // window it would answer every retry as already-delivered for a day,
+    // outliving the vendor's retry schedule and losing the message for good.
+    // The lease is what makes that recoverable, so the claim must be short and
+    // uncommitted while the handoff is in flight.
+    // Freeze the handoff at the point the gateway would have died: entered,
+    // never returning. Waiting on `entered` rather than a tick keeps this
+    // deterministic, since the claim is taken just before the pipeline runs.
+    let enter!: () => void;
+    const entered = new Promise<void>((resolve) => {
+      enter = resolve;
+    });
+    void deliver(
+      handlerFor(() => {
+        enter();
+        return new Promise<never>(() => {});
+      }),
+    );
+    await entered;
+
+    const claim = readInboundEventClaim(DEDUP_KEY);
+    expect(claim?.state).toBe("pending");
+    expect(claim!.expiresAt - claim!.seenAt).toBeLessThanOrEqual(
+      INBOUND_CLAIM_LEASE_MS,
+    );
   });
 });

--- a/gateway/src/http/routes/plugin-webhook.test.ts
+++ b/gateway/src/http/routes/plugin-webhook.test.ts
@@ -1,6 +1,13 @@
 import { createHmac } from "node:crypto";
 
-import { describe, expect, it } from "bun:test";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "bun:test";
 
 import "../../__tests__/test-preload.js";
 import { initSigningKey } from "../../auth/token-service.js";
@@ -9,6 +16,12 @@ import type { GatewayInboundEvent } from "../../channels/inbound-event.js";
 import type { PluginIngressResolution } from "../../channels/plugin-ingress-approvals.js";
 import type { IngressRoute } from "../../channels/plugin-ingress.js";
 import type { GatewayConfig } from "../../config.js";
+import {
+  getGatewayDb,
+  initGatewayDb,
+  resetGatewayDb,
+} from "../../db/connection.js";
+import { inboundSeenEvents } from "../../db/schema.js";
 import type { HandleInboundOptions } from "../../handlers/handle-inbound.js";
 import { createPluginWebhookHandler } from "./plugin-webhook.js";
 
@@ -16,6 +29,25 @@ import { createPluginWebhookHandler } from "./plugin-webhook.js";
 // the key beats mocking token-exchange, which is process-wide in bun and
 // would leak into every other suite in the run.
 initSigningKey(Buffer.from("test-signing-key-at-least-32-bytes-long"));
+
+// Inbound delivery claims each message against redelivery, and that claim is
+// a real row. Standing up the gateway DB beats stubbing the store: the thing
+// under test here is that a second copy of a message does not become a second
+// turn, and a stub would be asserting on the stub.
+beforeAll(async () => {
+  resetGatewayDb();
+  await initGatewayDb();
+});
+
+afterAll(() => {
+  resetGatewayDb();
+});
+
+// Claims outlive a test by design, so the tests below would otherwise dedup
+// against each other rather than against a redelivery.
+beforeEach(() => {
+  getGatewayDb().delete(inboundSeenEvents).run();
+});
 
 const CONFIG = {
   assistantRuntimeBaseUrl: "http://runtime.test:7821",
@@ -1214,5 +1246,176 @@ describe("inbound delivery", () => {
 
     expect(res.status).toBe(409);
     expect(handled).toHaveLength(0);
+  });
+});
+
+describe("inbound dedup", () => {
+  const INBOUND_ROUTE: IngressRoute = {
+    ...ROUTE,
+    path: "events",
+    inbound: IngressInboundSchema.parse({ identity: "phone" }),
+  };
+
+  const MESSAGE = {
+    message: {
+      content: "hello",
+      conversationExternalId: "chat-1",
+      externalMessageId: "msg-1",
+    },
+    actor: { actorExternalId: "(202) 555-0142" },
+  };
+
+  /**
+   * A handler over a fixed plugin reply, recording what reached the pipeline.
+   *
+   * `handleInboundImpl` is a parameter rather than fixed because what the
+   * pipeline did is exactly what decides whether the claim is kept: a message
+   * it handled stays claimed, a message it could not take is released so the
+   * vendor's retry is not answered as a duplicate.
+   */
+  function handlerFor(
+    handleInboundImpl: NonNullable<
+      Parameters<typeof createPluginWebhookHandler>[0]["handleInboundImpl"]
+    >,
+    reply: unknown = MESSAGE,
+  ) {
+    return createPluginWebhookHandler({
+      config: CONFIG,
+      credentials: CREDENTIALS,
+      resolve: () => approvedWith([INBOUND_ROUTE]),
+      fetchImpl: async () => new Response(JSON.stringify(reply)),
+      handleInboundImpl,
+    });
+  }
+
+  function deliver(handle: ReturnType<typeof createPluginWebhookHandler>) {
+    return handle(
+      post("/webhooks/plugins/meeting-bot/events"),
+      "meeting-bot",
+      "events",
+    );
+  }
+
+  function accepting() {
+    const handled: GatewayInboundEvent[] = [];
+    return {
+      handled,
+      impl: async (_c: GatewayConfig, event: GatewayInboundEvent) => {
+        handled.push(event);
+        return { forwarded: true, rejected: false };
+      },
+    };
+  }
+
+  it("runs a redelivered message once, and acknowledges the second copy", async () => {
+    // Every vendor retries: on a timeout, on a 5xx, on an ack it did not see.
+    // The assistant deduped this already, but on the far side of the handoff,
+    // so without the claim a retry still costs a crossing and lands wherever
+    // the pipeline happens to be idempotent.
+    const { handled, impl } = accepting();
+    const handle = handlerFor(impl);
+
+    const first = await deliver(handle);
+    const second = await deliver(handle);
+
+    expect(handled).toHaveLength(1);
+    expect(first.status).toBe(200);
+    // 200, not an error: the delivery did land, and anything else asks the
+    // vendor to keep sending it.
+    expect(second.status).toBe(200);
+  });
+
+  it("does not treat the next message in a conversation as a retry", async () => {
+    const { handled, impl } = accepting();
+
+    await deliver(handlerFor(impl));
+    await deliver(
+      handlerFor(impl, {
+        ...MESSAGE,
+        message: { ...MESSAGE.message, externalMessageId: "msg-2" },
+      }),
+    );
+
+    expect(handled).toHaveLength(2);
+  });
+
+  it("lets the retry through after the pipeline threw", async () => {
+    // The 503 asked for this delivery again. Keeping the claim would answer
+    // the retry we requested as a duplicate, which is how a message is lost
+    // while both sides report having done the right thing.
+    const failing = await deliver(
+      handlerFor(async () => {
+        throw new Error("runtime is down");
+      }),
+    );
+    expect(failing.status).toBe(503);
+
+    const { handled, impl } = accepting();
+    const retried = await deliver(handlerFor(impl));
+
+    expect(retried.status).toBe(200);
+    expect(handled).toHaveLength(1);
+  });
+
+  it("lets the retry through after the forward quietly failed", async () => {
+    // `handleInbound` reports an unreachable runtime as `forwarded: false`
+    // rather than by throwing, so the quiet path needs the same release.
+    const failing = await deliver(
+      handlerFor(async () => ({ forwarded: false, rejected: false })),
+    );
+    expect(failing.status).toBe(503);
+
+    const { handled, impl } = accepting();
+    await deliver(handlerFor(impl));
+
+    expect(handled).toHaveLength(1);
+  });
+
+  it("holds the claim on a message the pipeline decided against", async () => {
+    // A rejection is a decision the pipeline already made. Re-running it on
+    // every vendor retry would re-run its side effects too, and the denial
+    // reply is one of them.
+    let calls = 0;
+    const handle = handlerFor(async () => {
+      calls += 1;
+      return {
+        forwarded: false,
+        rejected: true,
+        rejectionReason: "admission_no_one",
+      };
+    });
+
+    await deliver(handle);
+    const second = await deliver(handle);
+
+    expect(calls).toBe(1);
+    expect(second.status).toBe(200);
+  });
+
+  it("claims nothing for a reply that carried no message", async () => {
+    // A receipt or an echo is not a delivery to dedup, and claiming one would
+    // put a row in the table for every event a plugin ever declines.
+    const { handled, impl } = accepting();
+    await deliver(handlerFor(impl, { ok: true, ignored: "an echo" }));
+
+    expect(handled).toHaveLength(0);
+    expect(getGatewayDb().select().from(inboundSeenEvents).all()).toHaveLength(
+      0,
+    );
+  });
+
+  it("claims under the plugin-scoped id, not the vendor's", async () => {
+    // One channel id covers every installed plugin, so two vendors both
+    // numbering messages from 1 would otherwise be each other's duplicates.
+    const { impl } = accepting();
+    await deliver(handlerFor(impl));
+
+    expect(getGatewayDb().select().from(inboundSeenEvents).all()).toEqual([
+      expect.objectContaining({
+        sourceChannel: "plugin",
+        externalChatId: "meeting-bot:chat-1",
+        externalMessageId: "meeting-bot:msg-1",
+      }),
+    ] as never);
   });
 });

--- a/gateway/src/http/routes/plugin-webhook.ts
+++ b/gateway/src/http/routes/plugin-webhook.ts
@@ -44,6 +44,7 @@ import type { GatewayConfig } from "../../config.js";
 import type { CredentialCache } from "../../credential-cache.js";
 import { credentialKey } from "../../credential-key.js";
 import {
+  commitInboundEvent,
   releaseInboundEvent,
   reserveInboundEvent,
 } from "../../db/inbound-dedup-store.js";
@@ -355,7 +356,8 @@ export function createPluginWebhookHandler(deps: PluginWebhookHandlerDeps) {
  * Which makes the dedup claim part of the same decision. Asking for a retry
  * and keeping the claim that would answer it as a duplicate is how a message
  * is lost while both sides look correct, so every path that answers 503
- * releases first. See `reserveInboundEvent`.
+ * releases first, and the claim is only widened to the full dedup window once
+ * the message has actually landed. See `reserveInboundEvent`.
  */
 async function deliverPluginInbound(opts: {
   config: GatewayConfig;
@@ -494,6 +496,12 @@ async function deliverPluginInbound(opts: {
     releaseInboundEvent(dedupKey);
     return retryLater();
   }
+
+  // The delivery landed, so the claim stops being a lease and becomes the
+  // dedup window proper. Until this runs the claim is short-lived on purpose:
+  // a gateway that died mid-handoff must not leave a row that answers every
+  // retry as already-delivered.
+  commitInboundEvent(dedupKey);
 
   return ack;
 }

--- a/gateway/src/http/routes/plugin-webhook.ts
+++ b/gateway/src/http/routes/plugin-webhook.ts
@@ -18,9 +18,10 @@
  * A route may also declare that its replies carry messages
  * (`IngressRouteSchema.inbound`), which is how a plugin channel receives
  * anything at all. The plugin parses its vendor's delivery and answers with
- * the result; the gateway reads that answer and runs it through the same
- * `handleInbound` every built-in channel uses. See `plugin-inbound.ts` for
- * what of the reply the gateway believes.
+ * the result; the gateway reads that answer, claims it against redelivery,
+ * and runs it through the same `handleInbound` every built-in channel uses.
+ * See `plugin-inbound.ts` for what of the reply the gateway believes, and
+ * `db/inbound-dedup-store.ts` for the claim.
  */
 
 import {
@@ -42,6 +43,10 @@ import { mintServiceToken } from "../../auth/token-exchange.js";
 import type { GatewayConfig } from "../../config.js";
 import type { CredentialCache } from "../../credential-cache.js";
 import { credentialKey } from "../../credential-key.js";
+import {
+  releaseInboundEvent,
+  reserveInboundEvent,
+} from "../../db/inbound-dedup-store.js";
 import {
   resolveCredentialWithRefresh,
   verifySecretWithRefresh,
@@ -346,6 +351,11 @@ export function createPluginWebhookHandler(deps: PluginWebhookHandlerDeps) {
  * the delivery. This is what `processInboundResult` does for the built-in
  * channels; the shape differs only because the plugin's reply, not the
  * vendor's request, is what carries the message here.
+ *
+ * Which makes the dedup claim part of the same decision. Asking for a retry
+ * and keeping the claim that would answer it as a duplicate is how a message
+ * is lost while both sides look correct, so every path that answers 503
+ * releases first. See `reserveInboundEvent`.
  */
 async function deliverPluginInbound(opts: {
   config: GatewayConfig;
@@ -404,6 +414,35 @@ async function deliverPluginInbound(opts: {
     return ack;
   }
 
+  // Claimed before the handoff, not after it. The assistant dedups on this
+  // same triple in `recordInbound`, but that is on the far side of the
+  // crossing, so without this a vendor's retry still costs a forward and
+  // relies on everything upstream of that record being idempotent. See
+  // `reserveInboundEvent`.
+  //
+  // As early as it can currently be: the message only exists once the plugin
+  // has parsed the delivery, so a redelivery still reaches the plugin, which
+  // must keep its own parse free of side effects. That ends when the gateway
+  // parses the vendor payload itself and the claim can precede the forward.
+  const dedupKey = {
+    sourceChannel: reading.event.sourceChannel,
+    externalChatId: reading.event.message.conversationExternalId,
+    externalMessageId: reading.event.message.externalMessageId,
+  };
+  if (!reserveInboundEvent(dedupKey)) {
+    // Acknowledged, because the delivery did land: the first copy is already
+    // through. Anything else asks the vendor to keep sending it.
+    log.info(
+      {
+        plugin,
+        path: routePath,
+        externalMessageId: dedupKey.externalMessageId,
+      },
+      "Duplicate plugin inbound delivery, acknowledged without forwarding",
+    );
+    return ack;
+  }
+
   let result: InboundResult;
   try {
     result = await handleInboundImpl(config, reading.event, {
@@ -420,6 +459,11 @@ async function deliverPluginInbound(opts: {
       { err, plugin, path: routePath },
       "Plugin inbound message could not be handled",
     );
+    // Answering 503 asks for the delivery again, so the claim has to go with
+    // it. Keeping it would have the retry we just asked for answered as a
+    // duplicate, which is how a message disappears while both sides report
+    // having done the right thing.
+    releaseInboundEvent(dedupKey);
     return retryLater();
   }
 
@@ -447,6 +491,7 @@ async function deliverPluginInbound(opts: {
       { plugin, path: routePath },
       "Plugin inbound message was not forwarded to the runtime",
     );
+    releaseInboundEvent(dedupKey);
     return retryLater();
   }
 

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -230,6 +230,7 @@ import { AvatarChannelSyncer } from "./avatar-sync/avatar-channel-syncer.js";
 import { AvatarSyncWatcher } from "./avatar-sync/avatar-sync-watcher.js";
 import { SlackAvatarSyncer } from "./avatar-sync/slack-avatar-syncer.js";
 import { initGatewayDb } from "./db/connection.js";
+import { cleanupExpiredInboundEvents } from "./db/inbound-dedup-store.js";
 import { runPostAssistantReady } from "./post-assistant-ready.js";
 import {
   clearManagedPublicBaseUrl,
@@ -347,6 +348,15 @@ function getClientIp(
   const addr = server.requestIP(req);
   return addr?.address ?? "unknown";
 }
+
+/**
+ * How often expired inbound dedup claims are swept.
+ *
+ * Hourly, because nothing depends on the sweep being timely: an expired claim
+ * is already reclaimed in place by the next delivery on the same key, so this
+ * is a size bound, not a correctness one.
+ */
+const INBOUND_DEDUP_CLEANUP_INTERVAL_MS = 60 * 60 * 1_000;
 
 async function main() {
   const config = loadConfig();
@@ -2189,6 +2199,21 @@ async function main() {
   whatsappDedupCache.startCleanup();
   emailDedupCache.startCleanup();
 
+  // The persistent inbound claims sweep too, more slowly. Expired rows are
+  // already reclaimed in place by the next claim on the same key, so this only
+  // keeps the table from growing a row per message that nothing will read
+  // again.
+  const inboundDedupCleanup = setInterval(() => {
+    try {
+      const evicted = cleanupExpiredInboundEvents();
+      if (evicted > 0) {
+        log.debug({ evicted }, "Evicted expired inbound dedup claims");
+      }
+    } catch (err) {
+      log.warn({ err }, "Inbound dedup cleanup failed");
+    }
+  }, INBOUND_DEDUP_CLEANUP_INTERVAL_MS);
+
   const telegramCaches = {
     credentials: credentialCache,
     configFile: configFileCache,
@@ -2971,6 +2996,7 @@ async function main() {
     telegramDedupCache.stopCleanup();
     whatsappDedupCache.stopCleanup();
     emailDedupCache.stopCleanup();
+    clearInterval(inboundDedupCleanup);
     if (slackSocketClient) {
       slackSocketClient.stop();
       slackSocketClient = null;


### PR DESCRIPTION
## Prompt / plan

> ok so deduping event delivery I would expect the gateway to handle before it gets handed over to the assistant daemon. maybe even the other two - essentially anything that is administrative is on the gateway side

> ok let's try to reuse `recordInbound` but before the handoff to the assistant, forking the implementation if we need to

Every vendor retries: on a timeout, on a 5xx, on an ack it did not see. The assistant has always deduped these, on the `(sourceChannel, externalChatId, externalMessageId)` triple in `recordInbound`, but that is on the far side of the handoff. A retry therefore still cost a crossing and relied on everything upstream of that record being idempotent.

This forks the dedup half of `recordInbound` into the gateway and runs it before the forward, where the rest of the administrative work already sits.

### What moved, and what did not

The key is identical, deliberately: both sides must agree on the triple for either to mean anything.

What is **not** forked is the rest of what `recordInbound` does. Binding the conversation, writing the permanent event row, and opening the delivery-status record the outbound reply is tracked on are not administrative in the way a duplicate check is:

- **Conversation binding** stays, because edit correlation needs the assistant's own message row id (`linkMessage`), which does not exist gateway-side.
- **`deliveryStatus`** stays, because it tracks the *outbound* reply (`pending` → `delivered` | `failed` → `dead_letter`), not the inbound event.

`recordInbound` itself is untouched. It is live for Slack, Telegram, edits and reactions, so it remains the record that binds the conversation and tracks the reply. A doc note on it points at the fork so the duplication is deliberate on the record rather than discovered later.

### The claim is a reservation, not a receipt

It is taken before the handoff and released on every path that answers 503 (`handleInbound` throws; `forwarded: false`), so a message lost to an assistant outage is one the vendor's next retry can still deliver. Keeping the claim while asking for a retry is how a message disappears with both sides reporting they did the right thing. That is the rollback `deleteInbound` was written for on the assistant side and which nothing there ever calls.

### Details

- **`gateway/src/db/schema.ts`** adds `inbound_seen_events`, composite PK on the triple plus `seen_at` / `expires_at`. Created declaratively like every other gateway table, so no migration file.
- **`gateway/src/db/inbound-dedup-store.ts`** holds the claim in one SQL statement (`INSERT … ON CONFLICT DO UPDATE … WHERE expires_at <= ?`) rather than select-then-insert, because two statements would let two concurrent copies of the same delivery both pass the check. An expired row is reclaimed in place, so no sweep has to have run for a genuinely new message to get through.
- Rows expire after a day, matching the window every other webhook route in the gateway already holds in memory (`StringDedupCache` in telegram / email / whatsapp / mailgun, and the Slack socket dedup). The assistant's rows are permanent because they carry more than dedup; these answer one question.
- An hourly sweep in `index.ts` bounds table growth. It is a size bound, not a correctness one.

### Known limitation, noted in the code

The claim is as early as it *can* currently be rather than as early as it *should* be: the message only exists once the plugin has parsed the delivery, so a redelivery still reaches the plugin, which must keep its parse free of side effects. That ends when the gateway parses the vendor payload itself with the ingress declaration (#40536) and the claim can precede the forward.

## Test plan

- New `gateway/src/db/inbound-dedup-store.test.ts`: first caller wins and no one else; a different message in the same conversation is its own; ids that arrive distinct are not collapsed; an expired claim is handed on in place; release lets the delivery be claimed again and touches only the claim it was given; the sweep drops expired and keeps live.
- New `inbound dedup` suite in `gateway/src/http/routes/plugin-webhook.test.ts`, over the real store rather than a stub: a redelivery runs once and the second copy is acked 200; the next message in a conversation is not a retry; the retry goes through after the pipeline threw and after a quiet `forwarded: false`; a rejection holds its claim so its side effects do not re-run; a reply carrying no message claims nothing; the claim is stored under the plugin-scoped ids.
- Gateway suite green via the real runner (`bun run test`, 251 files). Gateway typecheck, lint and prettier clean; assistant typecheck clean.

No new IPC routes, so the CLI verb checklist does not apply. No OpenAPI change: this adds a table and a store, not an HTTP surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_013p1nTdvsuAtTJ7zyCSDLbx)_