### PR TITLE
fix(web): limit ChatGPT-subscription surfaces to Codex-servable models

### DIFF
--- a/clients/web/src/domains/settings/ai/call-site-overrides-row.test.tsx
+++ b/clients/web/src/domains/settings/ai/call-site-overrides-row.test.tsx
@@ -19,13 +19,15 @@ mock.module("@/hooks/use-platform-gate", () => ({
   useActiveAssistantIsSelfHosted: () => selfHosted,
 }));
 
-const { CallSiteOverrideRow } = await import(
-  "@/domains/settings/ai/call-site-overrides-row"
-);
+const { CallSiteOverrideRow } =
+  await import("@/domains/settings/ai/call-site-overrides-row");
 
 const drafts: unknown[] = [];
 
-function renderRow(draft: Record<string, unknown> | null) {
+function renderRow(
+  draft: Record<string, unknown> | null,
+  connections?: Record<string, unknown>[],
+) {
   return render(
     <CallSiteOverrideRow
       id="workflowLeaf"
@@ -33,6 +35,7 @@ function renderRow(draft: Record<string, unknown> | null) {
       defaultProfileLabel="Balanced"
       draft={draft as never}
       profileOptions={[{ value: "balanced", label: "Balanced" }] as never}
+      connections={connections as never}
       onDraftChange={(_id, next) => {
         drafts.push(next);
       }}
@@ -128,5 +131,66 @@ describe("CallSiteOverrideRow provider picker", () => {
 
     expect(optionLabels().some((l) => l.includes("(unavailable)"))).toBe(false);
     expect(optionLabels().some((l) => l.includes("Ollama"))).toBe(true);
+  });
+});
+
+/** The row renders three pickers in order: profile, provider, model. */
+function modelTrigger(): HTMLElement {
+  const triggers = document.querySelectorAll<HTMLElement>(
+    'button[role="combobox"]',
+  );
+  const el = triggers[2];
+  if (!el) {
+    throw new Error(
+      `expected a model trigger, saw ${triggers.length} comboboxes`,
+    );
+  }
+  return el;
+}
+
+const SUBSCRIPTION_CONNECTION = {
+  name: "chatgpt-subscription",
+  provider: "openai",
+  auth: { type: "oauth_subscription", credential: "credential/chatgpt" },
+};
+
+const API_KEY_CONNECTION = {
+  name: "openai-personal",
+  provider: "openai",
+  auth: { type: "api_key", credential: "credential/openai" },
+};
+
+describe("CallSiteOverrideRow model picker under a ChatGPT subscription", () => {
+  test("only Codex-servable models are offered when every openai connection is a subscription", () => {
+    renderRow({ provider: "openai", model: "gpt-5.6-luna" }, [
+      SUBSCRIPTION_CONNECTION,
+    ]);
+
+    fireEvent.click(modelTrigger());
+
+    const labels = optionLabels();
+    expect(labels.some((l) => l.includes("GPT-5.6 Luna"))).toBe(true);
+    // The Codex endpoint rejects gpt-5.4-nano; offering it saves a pin that
+    // fails on every request.
+    expect(labels.some((l) => l.includes("Nano"))).toBe(false);
+  });
+
+  test("an api-key connection restores the full catalog", () => {
+    renderRow({ provider: "openai", model: "gpt-5.6-luna" }, [
+      SUBSCRIPTION_CONNECTION,
+      API_KEY_CONNECTION,
+    ]);
+
+    fireEvent.click(modelTrigger());
+
+    expect(optionLabels().some((l) => l.includes("Nano"))).toBe(true);
+  });
+
+  test("absent connection data leaves the catalog unfiltered", () => {
+    renderRow({ provider: "openai", model: "gpt-5.6-luna" });
+
+    fireEvent.click(modelTrigger());
+
+    expect(optionLabels().some((l) => l.includes("Nano"))).toBe(true);
   });
 });

--- a/clients/web/src/domains/settings/ai/call-site-overrides-row.test.tsx
+++ b/clients/web/src/domains/settings/ai/call-site-overrides-row.test.tsx
@@ -193,4 +193,21 @@ describe("CallSiteOverrideRow model picker under a ChatGPT subscription", () => 
 
     expect(optionLabels().some((l) => l.includes("Nano"))).toBe(true);
   });
+
+  test("a stored pin outside the filtered set stays visible as unavailable", () => {
+    renderRow({ provider: "openai", model: "gpt-5.4-nano" }, [
+      SUBSCRIPTION_CONNECTION,
+    ]);
+
+    // The trigger shows the stored pin instead of rendering blank while the
+    // incompatible value is still saved.
+    expect(
+      triggerLabels().some((l) => l.includes("GPT-5.4 Nano (unavailable)")),
+    ).toBe(true);
+
+    fireEvent.click(modelTrigger());
+    expect(
+      optionLabels().some((l) => l.includes("GPT-5.4 Nano (unavailable)")),
+    ).toBe(true);
+  });
 });

--- a/clients/web/src/domains/settings/ai/call-site-overrides-row.test.tsx
+++ b/clients/web/src/domains/settings/ai/call-site-overrides-row.test.tsx
@@ -160,6 +160,19 @@ const API_KEY_CONNECTION = {
   auth: { type: "api_key", credential: "credential/openai" },
 };
 
+// The row identity daemon migration 366 stamps on the subscription row.
+const SUBSCRIPTION_CONNECTION_366 = {
+  name: "chatgpt-subscription",
+  provider: "chatgpt",
+  auth: { type: "oauth_subscription", credential: "credential/chatgpt" },
+};
+
+const VELLUM_CONNECTION = {
+  name: "vellum",
+  provider: "vellum",
+  auth: { type: "platform" },
+};
+
 describe("CallSiteOverrideRow model picker under a ChatGPT subscription", () => {
   test("only Codex-servable models are offered when every openai connection is a subscription", () => {
     renderRow({ provider: "openai", model: "gpt-5.6-luna" }, [
@@ -173,6 +186,29 @@ describe("CallSiteOverrideRow model picker under a ChatGPT subscription", () => 
     // The Codex endpoint rejects gpt-5.4-nano; offering it saves a pin that
     // fails on every request.
     expect(labels.some((l) => l.includes("Nano"))).toBe(false);
+  });
+
+  test("a migrated subscription row (provider chatgpt) filters the openai picker too", () => {
+    renderRow({ provider: "openai", model: "gpt-5.6-luna" }, [
+      SUBSCRIPTION_CONNECTION_366,
+    ]);
+
+    fireEvent.click(modelTrigger());
+
+    const labels = optionLabels();
+    expect(labels.some((l) => l.includes("GPT-5.6 Luna"))).toBe(true);
+    expect(labels.some((l) => l.includes("Nano"))).toBe(false);
+  });
+
+  test("a vellum-managed connection lifts the restriction (openai routes through the managed proxy)", () => {
+    renderRow({ provider: "openai", model: "gpt-5.6-luna" }, [
+      SUBSCRIPTION_CONNECTION_366,
+      VELLUM_CONNECTION,
+    ]);
+
+    fireEvent.click(modelTrigger());
+
+    expect(optionLabels().some((l) => l.includes("Nano"))).toBe(true);
   });
 
   test("an api-key connection restores the full catalog", () => {

--- a/clients/web/src/domains/settings/ai/call-site-overrides-row.tsx
+++ b/clients/web/src/domains/settings/ai/call-site-overrides-row.tsx
@@ -118,6 +118,19 @@ export function CallSiteOverrideRow({
     value: m.id,
     label: m.displayName,
   }));
+  // A stored pin outside the offered set stays visible as itself, marked
+  // unavailable: hiding it would render a blank trigger while the pin is
+  // still saved (mirrors the provider picker's unavailable-pin handling).
+  const storedModel = typeof draft?.model === "string" ? draft.model : "";
+  if (storedModel && !availableModels.some((m) => m.id === storedModel)) {
+    const displayName =
+      getModelsForProvider(currentProvider).find((m) => m.id === storedModel)
+        ?.displayName ?? storedModel;
+    modelOptions.push({
+      value: storedModel,
+      label: `${displayName} (unavailable)`,
+    });
+  }
   const hasModelError = !!draft?.provider && !draft?.model;
 
   function handleProfilePickerChange(val: string) {

--- a/clients/web/src/domains/settings/ai/call-site-overrides-row.tsx
+++ b/clients/web/src/domains/settings/ai/call-site-overrides-row.tsx
@@ -23,7 +23,10 @@ import {
   codexServableModels,
   restrictsToSubscriptionModels,
 } from "@/domains/settings/ai/codex-subscription-models";
-import { useSelectableInferenceProviders } from "@/domains/settings/ai/provider-availability";
+import {
+  connectionServesProvider,
+  useSelectableInferenceProviders,
+} from "@/domains/settings/ai/provider-availability";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -101,11 +104,12 @@ export function CallSiteOverrideRow({
     selectableInferenceProviders.some((p) => p === storedProvider);
   const currentProvider = storedProvider ?? defaultProvider;
   // A call-site override pins no connection, so dispatch auto-resolves one.
-  // When every connection for the provider is a ChatGPT subscription, only
-  // Codex models can resolve; offering the rest would save a pin that fails
-  // on every request.
-  const connectionsForProvider = (connections ?? []).filter(
-    (c) => c.provider === currentProvider,
+  // When every connection that can serve the provider is a ChatGPT
+  // subscription (stored as provider "chatgpt" once daemon migration 366 has
+  // run), only Codex models can resolve; offering the rest would save a pin
+  // that fails on every request.
+  const connectionsForProvider = (connections ?? []).filter((c) =>
+    connectionServesProvider(c.provider, currentProvider),
   );
   const availableModels = restrictsToSubscriptionModels(
     currentProvider,

--- a/clients/web/src/domains/settings/ai/call-site-overrides-row.tsx
+++ b/clients/web/src/domains/settings/ai/call-site-overrides-row.tsx
@@ -6,7 +6,10 @@ import {
   getModelsForProvider,
   PROVIDER_DISPLAY_NAMES,
 } from "@/assistant/llm-model-catalog";
-import type { CallSiteOverrideDraft } from "@/generated/daemon/types.gen";
+import type {
+  CallSiteOverrideDraft,
+  ProviderConnection,
+} from "@/generated/daemon/types.gen";
 
 import {
   INFERENCE_PROVIDERS,
@@ -16,6 +19,10 @@ import {
   CUSTOM_SENTINEL,
   isDraftActive,
 } from "@/domains/settings/ai/call-site-helpers";
+import {
+  codexServableModels,
+  restrictsToSubscriptionModels,
+} from "@/domains/settings/ai/codex-subscription-models";
 import { useSelectableInferenceProviders } from "@/domains/settings/ai/provider-availability";
 
 // ---------------------------------------------------------------------------
@@ -34,6 +41,13 @@ export interface CallSiteOverrideRowProps {
   defaultProfileLabel: string | null;
   draft: CallSiteOverrideDraft | null;
   profileOptions: ProfileOption[];
+  /**
+   * All provider connections, used to limit the model picker to what the
+   * matching connections can dispatch (a ChatGPT subscription serves only
+   * the Codex model set). Absent when the caller has no connection data;
+   * the picker then offers the full catalog.
+   */
+  connections?: ProviderConnection[];
   onDraftChange: (id: string, draft: CallSiteOverrideDraft | null) => void;
   onToggle: (id: string, on: boolean) => void;
 }
@@ -49,6 +63,7 @@ export function CallSiteOverrideRow({
   defaultProfileLabel,
   draft,
   profileOptions,
+  connections,
   onDraftChange,
   onToggle,
 }: CallSiteOverrideRowProps) {
@@ -85,7 +100,20 @@ export function CallSiteOverrideRow({
     storedProvider !== undefined &&
     selectableInferenceProviders.some((p) => p === storedProvider);
   const currentProvider = storedProvider ?? defaultProvider;
-  const availableModels = getModelsForProvider(currentProvider);
+  // A call-site override pins no connection, so dispatch auto-resolves one.
+  // When every connection for the provider is a ChatGPT subscription, only
+  // Codex models can resolve; offering the rest would save a pin that fails
+  // on every request.
+  const connectionsForProvider = (connections ?? []).filter(
+    (c) => c.provider === currentProvider,
+  );
+  const availableModels = restrictsToSubscriptionModels(
+    currentProvider,
+    "",
+    connectionsForProvider,
+  )
+    ? codexServableModels(currentProvider)
+    : getModelsForProvider(currentProvider);
   const modelOptions = availableModels.map((m) => ({
     value: m.id,
     label: m.displayName,

--- a/clients/web/src/domains/settings/ai/codex-subscription-models.test.ts
+++ b/clients/web/src/domains/settings/ai/codex-subscription-models.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+
+import { CODEX_SUBSCRIPTION_MODEL_IDS } from "@/domains/settings/ai/codex-subscription-models";
+// The daemon's allowlist is the source of truth for what the Codex endpoint
+// serves; the web copy exists because the client cannot import daemon source
+// at runtime. This parity check makes drift a test failure instead of a
+// silently wrong picker.
+import { CODEX_SUBSCRIPTION_MODEL_IDS as DAEMON_SET } from "../../../../../../assistant/src/providers/openai/codex-models";
+
+describe("codex subscription model set", () => {
+  test("matches the daemon allowlist exactly", () => {
+    expect([...CODEX_SUBSCRIPTION_MODEL_IDS].sort()).toEqual(
+      [...DAEMON_SET].sort(),
+    );
+  });
+});

--- a/clients/web/src/domains/settings/ai/codex-subscription-models.ts
+++ b/clients/web/src/domains/settings/ai/codex-subscription-models.ts
@@ -1,0 +1,57 @@
+import { getModelsForProvider } from "@/assistant/llm-model-catalog";
+import type {
+  ConnectionProvider,
+  ProviderConnection,
+} from "@/generated/daemon/types.gen";
+
+// Keep in sync with CODEX_SUBSCRIPTION_MODEL_IDS in
+// assistant/src/providers/openai/codex-models.ts.
+export const CODEX_SUBSCRIPTION_MODEL_IDS: ReadonlySet<string> = new Set([
+  "gpt-5.6-sol",
+  "gpt-5.6-terra",
+  "gpt-5.6-luna",
+  "gpt-5.5",
+  // OpenAI retires these two from ChatGPT sign-in on 2026-08-31; API-key
+  // auth is unaffected.
+  "gpt-5.4",
+  "gpt-5.4-mini",
+]);
+
+/** The provider's catalog models a ChatGPT subscription can dispatch. */
+export function codexServableModels(
+  provider: ConnectionProvider,
+): ReturnType<typeof getModelsForProvider> {
+  return getModelsForProvider(provider).filter((m) =>
+    CODEX_SUBSCRIPTION_MODEL_IDS.has(m.id),
+  );
+}
+
+/**
+ * Whether a connection restricts a catalog-backed provider to the
+ * Codex-compatible subscription model set. A ChatGPT `oauth_subscription`
+ * connection hard-routes to the Codex endpoint, which rejects any model
+ * outside the set with HTTP 400, so every surface that offers models for
+ * such a connection must respect the limit.
+ */
+export function restrictsToSubscriptionModels(
+  provider: ConnectionProvider | "",
+  providerConnection: string,
+  availableConnectionsForProvider: ProviderConnection[],
+): boolean {
+  if (!provider || getModelsForProvider(provider).length === 0) {
+    return false;
+  }
+  const selectedConn = providerConnection
+    ? availableConnectionsForProvider.find((c) => c.name === providerConnection)
+    : undefined;
+  if (selectedConn?.auth.type === "oauth_subscription") {
+    return true;
+  }
+  return (
+    !providerConnection &&
+    availableConnectionsForProvider.length > 0 &&
+    availableConnectionsForProvider.every(
+      (c) => c.auth.type === "oauth_subscription",
+    )
+  );
+}

--- a/clients/web/src/domains/settings/ai/constants.ts
+++ b/clients/web/src/domains/settings/ai/constants.ts
@@ -47,6 +47,14 @@ export function isInferenceProvider(
 export const VELLUM_CONNECTION_PROVIDER = "vellum";
 
 /**
+ * `provider` value stored on the canonical ChatGPT-subscription connection
+ * (daemon migration 366 stamps the row identity). Like `vellum`, a routing
+ * sentinel rather than a real LLM provider: the row dispatches OpenAI Codex
+ * models through the subscription endpoint.
+ */
+export const CHATGPT_CONNECTION_PROVIDER = "chatgpt";
+
+/**
  * Providers the single Vellum-managed (`vellum`) connection can serve. Mirrors
  * the daemon's managed-routable set. A managed profile keeps its real provider
  * (e.g. `fireworks`) while binding to the provider-agnostic `vellum`

--- a/clients/web/src/domains/settings/ai/overrides-call-site-list.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-call-site-list.tsx
@@ -7,6 +7,7 @@ import type { CallSiteDraftMap } from "@/domains/settings/ai/use-override-drafts
 import type {
   CallSiteOverrideDraft,
   ConfigLlmCallsitesGetResponse,
+  ProviderConnection,
 } from "@/generated/daemon/types.gen";
 
 // ---------------------------------------------------------------------------
@@ -36,6 +37,8 @@ export interface OverridesCallSiteListProps {
   ) => ProfileOption[];
   profileLabelFor: (name: string) => string;
   advisorMatchesSearch: boolean;
+  /** Passed through to each row's model picker; see CallSiteOverrideRowProps. */
+  connections?: ProviderConnection[];
   onDraftChange: (id: string, draft: CallSiteOverrideDraft | null) => void;
   onToggle: (id: string, on: boolean) => void;
 }
@@ -54,6 +57,7 @@ export function OverridesCallSiteList({
   buildProfileOptionsForRow,
   profileLabelFor,
   advisorMatchesSearch,
+  connections,
   onDraftChange,
   onToggle,
 }: OverridesCallSiteListProps) {
@@ -109,6 +113,7 @@ export function OverridesCallSiteList({
                         ? null
                         : profileVal,
                     )}
+                    connections={connections}
                     onDraftChange={onDraftChange}
                     onToggle={onToggle}
                   />

--- a/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
@@ -31,6 +31,7 @@ import {
 import {
   configGetOptions,
   configLlmCallsitesGetOptions,
+  inferenceProviderconnectionsGetOptions,
 } from "@/generated/daemon/@tanstack/react-query.gen";
 import { useLlmConfigPatch } from "@/domains/settings/ai/use-llm-config-patch";
 import { useSupportsCompleteProfileSnapshots } from "@/lib/backwards-compat/complete-profile-snapshots";
@@ -106,6 +107,16 @@ export function OverridesDetailPanel({
     enabled: !!assistantId,
     staleTime: 60_000,
     refetchOnWindowFocus: false,
+  });
+
+  // Custom-override rows limit their model picker to what the provider's
+  // connections can dispatch; shared TanStack cache with the sections and
+  // sidepanels.
+  const { data: connectionsData } = useQuery({
+    ...inferenceProviderconnectionsGetOptions({
+      path: { assistant_id: assistantId },
+    }),
+    enabled: !!assistantId,
   });
 
   const gatedCallSites = useMemo(
@@ -486,6 +497,7 @@ export function OverridesDetailPanel({
             buildProfileOptionsForRow={buildProfileOptionsForRow}
             profileLabelFor={profileLabelFor}
             advisorMatchesSearch={advisorMatchesSearch}
+            connections={connectionsData?.connections}
             onDraftChange={setDraft}
             onToggle={handleToggle}
           />

--- a/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
@@ -10,6 +10,10 @@ import {
   PROVIDER_DISPLAY_NAMES,
 } from "@/assistant/llm-model-catalog";
 
+import {
+  codexServableModels,
+  restrictsToSubscriptionModels,
+} from "@/domains/settings/ai/codex-subscription-models";
 import { OPENAI_COMPATIBLE_PROVIDER } from "@/domains/settings/ai/constants";
 import {
   endpointPickerValue,
@@ -25,19 +29,6 @@ import type {
   ProviderConnection,
 } from "@/generated/daemon/types.gen";
 
-// Keep in sync with CODEX_SUBSCRIPTION_MODEL_IDS in
-// assistant/src/providers/openai/codex-models.ts.
-const CODEX_SUBSCRIPTION_MODEL_IDS = new Set([
-  "gpt-5.6-sol",
-  "gpt-5.6-terra",
-  "gpt-5.6-luna",
-  "gpt-5.5",
-  // OpenAI retires these two from ChatGPT sign-in on 2026-08-31; API-key
-  // auth is unaffected.
-  "gpt-5.4",
-  "gpt-5.4-mini",
-]);
-
 function connectionModelsToCatalog(
   models: ConnectionModel[] | null | undefined,
 ) {
@@ -45,36 +36,6 @@ function connectionModelsToCatalog(
     id: m.id,
     displayName: m.displayName ?? m.id,
   }));
-}
-
-/**
- * Whether the current connection restricts a catalog-backed provider to the
- * Codex-compatible subscription model set. A ChatGPT `oauth_subscription`
- * connection is restricted to `CODEX_SUBSCRIPTION_MODEL_IDS`, so both the
- * model list and the free-text escape hatch must respect that limit — a typed
- * id the endpoint rejects would otherwise be saveable.
- */
-function restrictsToSubscriptionModels(
-  provider: ConnectionProvider | "",
-  providerConnection: string,
-  availableConnectionsForProvider: ProviderConnection[],
-): boolean {
-  if (!provider || getModelsForProvider(provider).length === 0) {
-    return false;
-  }
-  const selectedConn = providerConnection
-    ? availableConnectionsForProvider.find((c) => c.name === providerConnection)
-    : undefined;
-  if (selectedConn?.auth.type === "oauth_subscription") {
-    return true;
-  }
-  return (
-    !providerConnection &&
-    availableConnectionsForProvider.length > 0 &&
-    availableConnectionsForProvider.every(
-      (c) => c.auth.type === "oauth_subscription",
-    )
-  );
 }
 
 /**
@@ -259,9 +220,7 @@ export function ProfileEditorProviderSection({
             availableConnectionsForProvider,
           )
         ) {
-          return catalogModels.filter((m) =>
-            CODEX_SUBSCRIPTION_MODEL_IDS.has(m.id),
-          );
+          return codexServableModels(provider);
         }
         return catalogModels;
       }

--- a/clients/web/src/domains/settings/ai/provider-availability.ts
+++ b/clients/web/src/domains/settings/ai/provider-availability.ts
@@ -2,7 +2,9 @@ import { MODELS_BY_PROVIDER } from "@/assistant/llm-model-catalog";
 import { useActiveAssistantIsSelfHosted } from "@/hooks/use-platform-gate";
 
 import {
+  CHATGPT_CONNECTION_PROVIDER,
   INFERENCE_PROVIDERS,
+  MANAGED_ROUTABLE_PROVIDERS,
   OPENAI_COMPATIBLE_PROVIDER,
   VELLUM_CONNECTION_PROVIDER,
 } from "@/domains/settings/ai/constants";
@@ -14,6 +16,33 @@ import type {
 } from "@/generated/daemon/types.gen";
 
 const LOCAL_ONLY_PROVIDERS = new Set<string>(["ollama"]);
+
+/**
+ * Whether a connection (identified by its stored `provider`) can serve
+ * requests for `selectedProvider`. Two routing sentinels serve providers
+ * other than their own column value: the provider-agnostic `vellum`
+ * connection serves every managed-routable provider, and the `chatgpt`
+ * subscription connection serves OpenAI (Codex models only; callers gate
+ * the model set separately via `restrictsToSubscriptionModels`).
+ */
+export function connectionServesProvider(
+  connectionProvider: string,
+  selectedProvider: string,
+): boolean {
+  if (connectionProvider === selectedProvider) {
+    return true;
+  }
+  if (
+    connectionProvider === VELLUM_CONNECTION_PROVIDER &&
+    MANAGED_ROUTABLE_PROVIDERS.has(selectedProvider)
+  ) {
+    return true;
+  }
+  return (
+    connectionProvider === CHATGPT_CONNECTION_PROVIDER &&
+    selectedProvider === "openai"
+  );
+}
 
 export function isProviderSelectableForAssistant(
   provider: string,

--- a/clients/web/src/domains/settings/ai/provider-row-meta.test.ts
+++ b/clients/web/src/domains/settings/ai/provider-row-meta.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+
+import { getModelsForProvider } from "@/assistant/llm-model-catalog";
+import { CODEX_SUBSCRIPTION_MODEL_IDS } from "@/domains/settings/ai/codex-subscription-models";
+import { providerRowMeta } from "@/domains/settings/ai/provider-row-meta";
+import type { ProviderConnection } from "@/generated/daemon/types.gen";
+
+function connection(auth: ProviderConnection["auth"]): ProviderConnection {
+  return {
+    name: "openai-conn",
+    provider: "openai",
+    auth,
+  } as ProviderConnection;
+}
+
+describe("providerRowMeta model counts", () => {
+  test("an api-key openai row counts the full catalog", () => {
+    const total = getModelsForProvider("openai").length;
+    expect(
+      providerRowMeta(
+        connection({ type: "api_key", credential: "credential/openai" }),
+      ),
+    ).toBe(`${total} models  •  Own API key`);
+  });
+
+  test("a subscription openai row counts only Codex-servable models", () => {
+    const servable = getModelsForProvider("openai").filter((m) =>
+      CODEX_SUBSCRIPTION_MODEL_IDS.has(m.id),
+    ).length;
+    expect(servable).toBeGreaterThan(0);
+    expect(servable).toBeLessThan(getModelsForProvider("openai").length);
+    expect(
+      providerRowMeta(
+        connection({
+          type: "oauth_subscription",
+          credential: "credential/chatgpt",
+        }),
+      ),
+    ).toBe(`${servable} models  •  ChatGPT subscription`);
+  });
+});

--- a/clients/web/src/domains/settings/ai/provider-row-meta.test.ts
+++ b/clients/web/src/domains/settings/ai/provider-row-meta.test.ts
@@ -23,6 +23,22 @@ describe("providerRowMeta model counts", () => {
     ).toBe(`${total} models  •  Own API key`);
   });
 
+  test("a migrated subscription row (provider chatgpt) counts against the openai catalog", () => {
+    const servable = getModelsForProvider("openai").filter((m) =>
+      CODEX_SUBSCRIPTION_MODEL_IDS.has(m.id),
+    ).length;
+    expect(
+      providerRowMeta({
+        name: "chatgpt-subscription",
+        provider: "chatgpt",
+        auth: {
+          type: "oauth_subscription",
+          credential: "credential/chatgpt",
+        },
+      } as ProviderConnection),
+    ).toBe(`${servable} models  •  ChatGPT subscription`);
+  });
+
   test("a subscription openai row counts only Codex-servable models", () => {
     const servable = getModelsForProvider("openai").filter((m) =>
       CODEX_SUBSCRIPTION_MODEL_IDS.has(m.id),

--- a/clients/web/src/domains/settings/ai/provider-row-meta.ts
+++ b/clients/web/src/domains/settings/ai/provider-row-meta.ts
@@ -1,4 +1,5 @@
 import { getModelsForProvider } from "@/assistant/llm-model-catalog";
+import { codexServableModels } from "@/domains/settings/ai/codex-subscription-models";
 import { VELLUM_CONNECTION_PROVIDER } from "@/domains/settings/ai/constants";
 import type {
   DefaultProviderStatus,
@@ -85,8 +86,14 @@ export function providerRowMeta(conn: ProviderConnection): string {
     return customProviderMeta(conn);
   }
   const parts: string[] = [];
-  const modelCount =
-    conn.models?.length ?? getModelsForProvider(conn.provider).length;
+  // A subscription connection hard-routes to the Codex endpoint, which
+  // serves only the Codex model set; counting the full catalog would
+  // advertise models the connection cannot dispatch.
+  const catalogModels =
+    conn.auth.type === "oauth_subscription"
+      ? codexServableModels(conn.provider)
+      : getModelsForProvider(conn.provider);
+  const modelCount = conn.models?.length ?? catalogModels.length;
   if (modelCount > 0) {
     parts.push(`${modelCount} ${modelCount === 1 ? "model" : "models"}`);
   }

--- a/clients/web/src/domains/settings/ai/provider-row-meta.ts
+++ b/clients/web/src/domains/settings/ai/provider-row-meta.ts
@@ -1,6 +1,9 @@
 import { getModelsForProvider } from "@/assistant/llm-model-catalog";
 import { codexServableModels } from "@/domains/settings/ai/codex-subscription-models";
-import { VELLUM_CONNECTION_PROVIDER } from "@/domains/settings/ai/constants";
+import {
+  CHATGPT_CONNECTION_PROVIDER,
+  VELLUM_CONNECTION_PROVIDER,
+} from "@/domains/settings/ai/constants";
 import type {
   DefaultProviderStatus,
   ProviderConnection,
@@ -88,11 +91,15 @@ export function providerRowMeta(conn: ProviderConnection): string {
   const parts: string[] = [];
   // A subscription connection hard-routes to the Codex endpoint, which
   // serves only the Codex model set; counting the full catalog would
-  // advertise models the connection cannot dispatch.
+  // advertise models the connection cannot dispatch. The row's models come
+  // from the OpenAI catalog whether it stores provider "openai" or the
+  // "chatgpt" identity daemon migration 366 stamps.
+  const catalogProvider =
+    conn.provider === CHATGPT_CONNECTION_PROVIDER ? "openai" : conn.provider;
   const catalogModels =
     conn.auth.type === "oauth_subscription"
-      ? codexServableModels(conn.provider)
-      : getModelsForProvider(conn.provider);
+      ? codexServableModels(catalogProvider)
+      : getModelsForProvider(catalogProvider);
   const modelCount = conn.models?.length ?? catalogModels.length;
   if (modelCount > 0) {
     parts.push(`${modelCount} ${modelCount === 1 ? "model" : "models"}`);


### PR DESCRIPTION
## Summary
- Move the client-side Codex allowlist and `restrictsToSubscriptionModels` out of the profile editor into a shared `codex-subscription-models` module (with a `codexServableModels` helper), keeping the keep-in-sync pointer at `assistant/src/providers/openai/codex-models.ts`.
- Providers-list row for an `oauth_subscription` connection now counts only Codex-servable catalog models (previously "9 models" while only 6 serve).
- Call-site override rows limit their model picker to Codex-servable models when every connection for the picked provider is a ChatGPT subscription: an override pins no connection, so dispatch can only auto-resolve the subscription, and a non-Codex pin fails on every request. Connections reach the rows via the shared TanStack query threaded from the overrides panel; absent connection data leaves the catalog unfiltered.

## Original prompt
Follow-up to #40544: the Providers list advertised the full openai catalog ("9 models") on the ChatGPT subscription row even though the Codex endpoint serves only the subscription set, and the call-site override model picker offered non-Codex models that cannot dispatch when the subscription is the only openai connection. The user asked to centralize the client-side Codex set and filter both surfaces so the picker cannot offer a model that fails, reusing the existing `restrictsToSubscriptionModels` logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uts2hxMb2vf6DfuNoK6B4X
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40553" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->