### PR TITLE
feat(web): give the onboarding decorative layers a stage they can be seen in

### DIFF
--- a/clients/web/src/domains/onboarding/components/onboarding-character-stage.stories.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-character-stage.stories.tsx
@@ -1,0 +1,110 @@
+/**
+ * The picker's avatar ring: one character centered, the rest cut off around the
+ * edges.
+ *
+ * These stories exist for the geometry. `edgeSize` and `edgeSlots` compute every
+ * avatar's size and position from the measured stage box, so the arrangement is
+ * only correct relative to a container, and it is different at every container
+ * size. Nothing in the running app lets you see it at more than one size at a
+ * time, which is how a slot arrangement drifts unnoticed.
+ *
+ * The stage box is deliberately not a prop. These mount inside the real
+ * `OnboardingStage`, the same component the three onboarding screens use, so it
+ * measures itself exactly as it does in production. A story that passed a size
+ * by hand would be validating its own arithmetic (see LUM-3164).
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { OnboardingCharacterStage } from "./onboarding-character-stage";
+import { OnboardingStage } from "./onboarding-stage";
+import { SeededAvatarPool, StageHost } from "./onboarding-story-fixtures";
+import { useOnboardingAvatarPoolStore } from "@/domains/onboarding/onboarding-avatar-pool-store";
+import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
+
+/**
+ * The ring as `GiveMeAFaceScreen` arranges it: the stored selection centered,
+ * everyone else in an edge slot, at rest (no swap in flight).
+ *
+ * Renders inside `SeededAvatarPool`, so the pool is guaranteed non-empty here.
+ */
+function CharacterRing({ centerChar = 0 }: { centerChar?: number }) {
+  const components = useBundledAvatarComponents();
+  const characters = useOnboardingAvatarPoolStore.use.characters();
+  if (!components) {
+    return null;
+  }
+
+  return (
+    <OnboardingCharacterStage
+      components={components}
+      characters={characters}
+      centerChar={centerChar}
+      edgeOrder={characters.map((_, i) => i).filter((i) => i !== centerChar)}
+      entering={null}
+      exiting={null}
+      onEnterComplete={() => {}}
+      onSelectChar={() => {}}
+    />
+  );
+}
+
+const meta: Meta<typeof OnboardingCharacterStage> = {
+  title: "Onboarding/OnboardingCharacterStage",
+  parameters: {
+    layout: "fullscreen",
+    // The ring's inputs are the pool and the measured box, neither of which is
+    // a meaningful control; the stories differ by viewport instead.
+    controls: { disable: true },
+  },
+  render: () => (
+    <StageHost>
+      <OnboardingStage className="bg-[var(--surface-base)] text-[var(--content-default)]">
+        <SeededAvatarPool>
+          <CharacterRing />
+        </SeededAvatarPool>
+      </OnboardingStage>
+    </StageHost>
+  ),
+};
+
+export default meta;
+type Story = StoryObj<typeof OnboardingCharacterStage>;
+
+/** Desktop: the widest arrangement, where the edge slots spread furthest. */
+export const Desktop: Story = {
+  globals: { viewport: { value: "sbDesktop" } },
+};
+
+/**
+ * Phone width, where `edgeSize`'s 130px floor starts to dominate its 40% term
+ * and the cast crowds the centered avatar. The arrangement the app ships on
+ * mobile, and the case the desktop story cannot show.
+ */
+export const Mobile: Story = {
+  globals: { viewport: { value: "sbMobile" } },
+};
+
+/**
+ * The stage inset by a notched device's safe area (`root-layout.tsx` is `100dvh`
+ * minus `env(safe-area-inset-*)`), measured here as a 390x751 stage inside a
+ * 390x844 viewport.
+ *
+ * The ring reads the stage box, so it stays whole and centered inside the inset
+ * frame, clipping at the stage's edges rather than the window's. A layer reading
+ * the layout viewport instead would be 93px out, which is the defect LUM-3198
+ * describes.
+ */
+export const InsetByASafeArea: Story = {
+  globals: { viewport: { value: "sbMobile" } },
+  render: () => (
+    // iPhone 15 Pro insets: 59pt status/Dynamic Island, 34pt home indicator.
+    <StageHost insetTop={59} insetBottom={34}>
+      <OnboardingStage className="bg-[var(--surface-base)] text-[var(--content-default)]">
+        <SeededAvatarPool>
+          <CharacterRing />
+        </SeededAvatarPool>
+      </OnboardingStage>
+    </StageHost>
+  ),
+};

--- a/clients/web/src/domains/onboarding/components/onboarding-peeking-eyes.stories.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-peeking-eyes.stories.tsx
@@ -1,0 +1,78 @@
+/**
+ * The eyes that peek up from the bottom of an onboarding screen.
+ *
+ * These exist for one measurement. The eyes size and place themselves from
+ * `useOnboardingStageSize()`, so they are anchored to the bottom of the *stage*,
+ * not the bottom of the window. On a notched device those are 93px apart
+ * (`InsetByASafeArea` below), and nothing in the running app shows both cases
+ * side by side.
+ *
+ * The same component also reads `window.innerWidth` / `innerHeight` directly for
+ * its cursor parallax, ten lines from where it reads the stage box. That mixture
+ * is the subject of LUM-3198; these stories are what make the difference between
+ * the two boxes visible rather than argued about.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { OnboardingPeekingEyes } from "./onboarding-peeking-eyes";
+import { OnboardingStage } from "./onboarding-stage";
+import { SeededAvatarPool, StageHost } from "./onboarding-story-fixtures";
+
+const meta: Meta<typeof OnboardingPeekingEyes> = {
+  title: "Onboarding/OnboardingPeekingEyes",
+  parameters: { layout: "fullscreen" },
+  argTypes: {
+    entrance: { control: "boolean" },
+    settleBlink: { control: "boolean" },
+    entranceDelay: { control: { type: "number", step: 0.1 } },
+  },
+  args: { entrance: false, settleBlink: false },
+  render: (args) => (
+    <StageHost>
+      <OnboardingStage className="bg-[var(--surface-base)]">
+        <SeededAvatarPool>
+          <OnboardingPeekingEyes {...args} />
+        </SeededAvatarPool>
+      </OnboardingStage>
+    </StageHost>
+  ),
+};
+
+export default meta;
+type Story = StoryObj<typeof OnboardingPeekingEyes>;
+
+/** At rest, cut off by the stage's bottom edge. */
+export const Resting: Story = {};
+
+/** The Introduction step's grow-in, delayed behind the body cover. */
+export const Entrance: Story = {
+  args: { entrance: true, entranceDelay: 0.3, settleBlink: true },
+};
+
+/** Phone width, where the eyes are sized from the smaller stage dimension. */
+export const Mobile: Story = {
+  globals: { viewport: { value: "sbMobile" } },
+};
+
+/**
+ * The stage inset by a notched device's safe area, so the stage is 93px shorter
+ * than the window (measured: a 390x844 viewport gives a 390x751 stage).
+ *
+ * The eyes should sit on the stage's bottom edge, above the home-indicator band,
+ * not behind it. If they ever anchor to the window instead, this is the story
+ * where that shows up as the eyes sliding under the bottom band.
+ */
+export const InsetByASafeArea: Story = {
+  globals: { viewport: { value: "sbMobile" } },
+  render: (args) => (
+    // iPhone 15 Pro insets: 59pt status/Dynamic Island, 34pt home indicator.
+    <StageHost insetTop={59} insetBottom={34}>
+      <OnboardingStage className="bg-[var(--surface-base)]">
+        <SeededAvatarPool>
+          <OnboardingPeekingEyes {...args} />
+        </SeededAvatarPool>
+      </OnboardingStage>
+    </StageHost>
+  ),
+};

--- a/clients/web/src/domains/onboarding/components/onboarding-stage.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-stage.tsx
@@ -1,0 +1,48 @@
+/**
+ * The box the onboarding decorative layers position themselves against.
+ *
+ * Every onboarding screen puts its content inside one of these. It measures
+ * itself and publishes that size through `OnboardingStageSizeProvider`, so the
+ * decorative layers (the character stage, the peeking crowd, the bottom eyes,
+ * the coin arc) resolve their `absolute` positions against the same box the
+ * `%`-positioned foreground uses.
+ *
+ * Measuring the container rather than the layout viewport is the point. The app
+ * shell is `100dvh` minus the safe-area insets, and shorter still while the iOS
+ * keyboard is up, so a layer sized from `window.innerHeight` sits in a taller
+ * coordinate space than the content it is supposed to be pinned to. See
+ * `use-element-size.ts` for the same hazard stated from the other side.
+ *
+ * This exists as a component rather than a snippet each screen repeats because
+ * a story that mirrors the wrapper proves nothing about the real one: the two
+ * drift, and the story keeps passing. Screens differ only in the surface they
+ * paint, so that is the only prop.
+ */
+
+import { type ReactNode } from "react";
+
+import { OnboardingStageSizeProvider } from "@/domains/onboarding/hooks/use-onboarding-stage-size";
+import { useElementSize } from "@/hooks/use-element-size";
+import { cn } from "@/utils/misc";
+
+interface OnboardingStageProps {
+  /** Surface classes for this screen (background, text colour). */
+  className?: string;
+  children: ReactNode;
+}
+
+export function OnboardingStage({ className, children }: OnboardingStageProps) {
+  const { ref, size } = useElementSize();
+
+  return (
+    <div
+      ref={ref}
+      data-theme="dark"
+      className={cn("relative h-full overflow-hidden", className)}
+    >
+      <OnboardingStageSizeProvider size={size}>
+        {children}
+      </OnboardingStageSizeProvider>
+    </div>
+  );
+}

--- a/clients/web/src/domains/onboarding/components/onboarding-story-fixtures.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-story-fixtures.tsx
@@ -23,8 +23,7 @@ import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-component
  * (minus the safe-area padding) whose route slot is `flex: 1 1 0%` with
  * `min-height: 0`. Mounted without that chain the stage measures zero tall,
  * every layer resolves against a zero-height box, and the whole arrangement
- * collapses to the origin without erroring. That is what these stories did the
- * first time they ran, which is the argument for having them.
+ * collapses to the origin without erroring.
  *
  * `insetTop` / `insetBottom` stand in for `env(safe-area-inset-*)`, which the
  * shell applies and Storybook cannot produce. That is the one thing here

--- a/clients/web/src/domains/onboarding/components/onboarding-story-fixtures.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-story-fixtures.tsx
@@ -1,0 +1,90 @@
+/**
+ * Shared setup for the onboarding decorative-layer stories.
+ *
+ * Both pieces here exist because getting them wrong produces a story that
+ * renders nothing, or renders against the wrong box, without erroring:
+ *
+ * - `StageHost` supplies the height contract `OnboardingStage` depends on.
+ * - `SeededAvatarPool` fills the character pool the layers draw from.
+ *
+ * Not a `.stories.tsx` file, so Storybook does not index it.
+ */
+
+import { useEffect, type ReactNode } from "react";
+
+import { useOnboardingAvatarPoolStore } from "@/domains/onboarding/onboarding-avatar-pool-store";
+import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
+
+/**
+ * The height contract `OnboardingStage` relies on.
+ *
+ * `OnboardingStage` is `h-full`, so it is however tall its parent makes it. In
+ * the app that parent is the shell in `root-layout.tsx`: a `100dvh` flex column
+ * (minus the safe-area padding) whose route slot is `flex: 1 1 0%` with
+ * `min-height: 0`. Mounted without that chain the stage measures zero tall,
+ * every layer resolves against a zero-height box, and the whole arrangement
+ * collapses to the origin without erroring. That is what these stories did the
+ * first time they ran, which is the argument for having them.
+ *
+ * `insetTop` / `insetBottom` stand in for `env(safe-area-inset-*)`, which the
+ * shell applies and Storybook cannot produce. That is the one thing here
+ * standing in for the app rather than reproducing it, and it is the point of
+ * the inset stories: on a 390x844 viewport with the iPhone 15 Pro's insets the
+ * stage measures 390x751, so a layer reading the window is 93px out.
+ *
+ * Mirrored rather than imported because the contract lives inline in the app
+ * shell around `<Outlet />`, tangled with its keyboard and safe-area handling.
+ * If it is ever extracted, this should import it instead.
+ */
+export function StageHost({
+  children,
+  insetTop = 0,
+  insetBottom = 0,
+}: {
+  children: ReactNode;
+  insetTop?: number;
+  insetBottom?: number;
+}) {
+  return (
+    <div
+      className="flex w-screen flex-col bg-[var(--surface-sunken)]"
+      style={{
+        height: "100dvh",
+        paddingTop: insetTop,
+        paddingBottom: insetBottom,
+      }}
+    >
+      <div
+        className="flex w-full min-w-0 flex-col overflow-hidden"
+        style={{ flex: "1 1 0%", minHeight: 0 }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Fills the avatar pool the way the app does, then renders `children`.
+ *
+ * The decorative layers draw the *chosen* character's art and return `null`
+ * until the pool has one, so a story that skips this renders an empty stage and
+ * still passes. Seeding goes through `ensureGenerated`, the same write path
+ * `GiveMeAFaceScreen` uses, rather than pushing state in behind it.
+ */
+export function SeededAvatarPool({ children }: { children: ReactNode }) {
+  const components = useBundledAvatarComponents();
+  const characters = useOnboardingAvatarPoolStore.use.characters();
+  const ensureGenerated = useOnboardingAvatarPoolStore.use.ensureGenerated();
+
+  useEffect(() => {
+    if (components) {
+      ensureGenerated(components);
+    }
+  }, [components, ensureGenerated]);
+
+  if (!components || characters.length === 0) {
+    return null;
+  }
+  return <>{children}</>;
+}

--- a/clients/web/src/domains/onboarding/hooks/use-onboarding-stage-size.tsx
+++ b/clients/web/src/domains/onboarding/hooks/use-onboarding-stage-size.tsx
@@ -25,9 +25,6 @@ import {
 
 import { windowSize, type StageSize } from "@/hooks/use-element-size";
 
-export { useElementSize } from "@/hooks/use-element-size";
-export type { ElementSize, StageSize } from "@/hooks/use-element-size";
-
 const OnboardingStageSizeContext = createContext<StageSize | null>(null);
 
 export function OnboardingStageSizeProvider({

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
@@ -381,14 +381,11 @@ mock.module("@/domains/onboarding/hooks/use-onboarding-stage-size", () => ({
   OnboardingStageSizeProvider: ({ children }: { children: ReactNode }) => (
     <>{children}</>
   ),
-  useElementSize: () => ({
-    ref: { current: null },
-    size: { width: 0, height: 0 },
-  }),
 }));
 
-const { ResearchOnboardingRoute } =
-  await import("@/domains/onboarding/pages/research-onboarding-route");
+const { ResearchOnboardingRoute } = await import(
+  "@/domains/onboarding/pages/research-onboarding-route"
+);
 
 function postFormSnapshot(
   overrides: Partial<ResearchOnboardingSnapshot> = {},
@@ -1054,7 +1051,9 @@ describe("ResearchOnboardingRoute claim-credits skip", () => {
 
     // Straight to the research reveal: the calendar steps are skipped for
     // self-hosted too, so nothing renders between.
-    await waitFor(() => expect(screen.getByTestId("looking-step")).toBeTruthy());
+    await waitFor(() =>
+      expect(screen.getByTestId("looking-step")).toBeTruthy(),
+    );
     expect(screen.queryByTestId("integration-step")).toBeNull();
   });
 
@@ -1101,7 +1100,9 @@ describe("ResearchOnboardingRoute claim-credits skip", () => {
     platformSessionSettled = true;
     rerender(<ResearchOnboardingRoute />);
 
-    await waitFor(() => expect(screen.getByTestId("looking-step")).toBeTruthy());
+    await waitFor(() =>
+      expect(screen.getByTestId("looking-step")).toBeTruthy(),
+    );
   });
 
   test("a snapshot resuming onto the skipped claim-credits step remaps to the research reveal", async () => {
@@ -1111,7 +1112,9 @@ describe("ResearchOnboardingRoute claim-credits skip", () => {
 
     render(<ResearchOnboardingRoute />);
 
-    await waitFor(() => expect(screen.getByTestId("looking-step")).toBeTruthy());
+    await waitFor(() =>
+      expect(screen.getByTestId("looking-step")).toBeTruthy(),
+    );
     expect(screen.queryByTestId("integration-step")).toBeNull();
   });
 });

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -93,10 +93,7 @@ import {
 } from "@/domains/onboarding/screens/research-result-steps";
 import { OnboardingTonedBackdrop } from "@/domains/onboarding/components/onboarding-toned-backdrop";
 import { HatchErrorOverlay } from "@/domains/onboarding/components/hatch-error-overlay";
-import {
-  OnboardingStageSizeProvider,
-  useElementSize,
-} from "@/domains/onboarding/hooks/use-onboarding-stage-size";
+import { OnboardingStage } from "@/domains/onboarding/components/onboarding-stage";
 import { getBrowserTimezone } from "@/utils/browser-timezone";
 import {
   checkEstablishedAssistant,
@@ -158,10 +155,6 @@ export function ResearchOnboardingRoute() {
   // persistent backdrop so the avatars/eyes stay put. The handoff fires from
   // the "let's chat tomorrow" step (or the picker's skip).
   const [step, setStep] = useState<ResearchStep>("form");
-  // Measure the shared toned-step container so the persistent backdrop, eyes,
-  // peekers, and coin all position against the same box as the foreground
-  // content (see use-onboarding-stage-size).
-  const { ref: tonedStageRef, size: tonedStageSize } = useElementSize();
   // Forward-history (redo) stack: pushed when the user steps back, popped when
   // they step forward via the header's forward chevron. The chevron only shows
   // while this is non-empty — i.e. only after a back. A deliberate forward move
@@ -1025,277 +1018,271 @@ export function ResearchOnboardingRoute() {
       ? edgeAvatars
       : 0;
     return withHatchError(
-      <div
-        ref={tonedStageRef}
-        data-theme="dark"
-        className="relative h-full overflow-hidden"
-      >
-        <OnboardingStageSizeProvider size={tonedStageSize}>
-          <OnboardingTonedBackdrop
-            eyesBumpNonce={eyesBump}
-            peekLevel={peekLevel}
-            darkBg={postCalendar}
-            // The pitch step ("different") choreographs its own eyes (rising to
-            // speak the lines in), so hide the backdrop's resting pair there to
-            // avoid doubling. Every other toned step uses the backdrop's resting
-            // eyes. The top-right team isn't persistent — the pitch step peeks
-            // its own transient team in and out (see PitchStep).
-            showBottomEyes={!postCalendar && step !== "different"}
-            // The eyes are hidden on "different" (PitchStep owns its own) and
-            // first mount here on "personality" — play the grow-in entrance
-            // only for that handoff so they don't re-animate on later steps.
-            eyesEntrance={step === "personality"}
+      <OnboardingStage>
+        <OnboardingTonedBackdrop
+          eyesBumpNonce={eyesBump}
+          peekLevel={peekLevel}
+          darkBg={postCalendar}
+          // The pitch step ("different") choreographs its own eyes (rising to
+          // speak the lines in), so hide the backdrop's resting pair there to
+          // avoid doubling. Every other toned step uses the backdrop's resting
+          // eyes. The top-right team isn't persistent — the pitch step peeks
+          // its own transient team in and out (see PitchStep).
+          showBottomEyes={!postCalendar && step !== "different"}
+          // The eyes are hidden on "different" (PitchStep owns its own) and
+          // first mount here on "personality" — play the grow-in entrance
+          // only for that handoff so they don't re-animate on later steps.
+          eyesEntrance={step === "personality"}
+        />
+        {step === "different" && (
+          <PitchStep
+            onContinue={() =>
+              goForwardTo(
+                personalityEnabled ? "personality" : stepAfterPersonality,
+              )
+            }
+            onBack={() => goBackTo("intro")}
+            onForward={onForward}
           />
-          {step === "different" && (
-            <PitchStep
-              onContinue={() =>
-                goForwardTo(
-                  personalityEnabled ? "personality" : stepAfterPersonality,
-                )
+        )}
+        {step === "personality" && (
+          <CreatePersonalityStep
+            values={personalityValues}
+            onValueChange={(axisId, value) =>
+              setPersonalityValues((prev) => ({ ...prev, [axisId]: value }))
+            }
+            locked={personalityLocked}
+            onContinue={() => {
+              // First continue applies the sliders and locks them — the prompt
+              // has been sent, so a later step-back can't silently diverge. A
+              // continue while already locked just advances.
+              if (!personalityLocked) {
+                startPersonalityApply();
+                setPersonalityLocked(true);
               }
-              onBack={() => goBackTo("intro")}
-              onForward={onForward}
-            />
-          )}
-          {step === "personality" && (
-            <CreatePersonalityStep
-              values={personalityValues}
-              onValueChange={(axisId, value) =>
-                setPersonalityValues((prev) => ({ ...prev, [axisId]: value }))
-              }
-              locked={personalityLocked}
-              onContinue={() => {
-                // First continue applies the sliders and locks them — the prompt
-                // has been sent, so a later step-back can't silently diverge. A
-                // continue while already locked just advances.
-                if (!personalityLocked) {
-                  startPersonalityApply();
-                  setPersonalityLocked(true);
-                }
-                goForwardTo(stepAfterPersonality);
-              }}
-              onBack={() => goBackTo("different")}
-              onForward={onForward}
-            />
-          )}
-          {step === "integration" && (
-            <IntegrationStep
-              onClaim={() =>
-                goForwardTo(skipCheckinSteps ? "looking" : "letschat")
-              }
-              onBumpEyes={() => setEyesBump((n) => n + 1)}
-              onBack={() =>
-                goBackTo(personalityEnabled ? "personality" : "different")
-              }
-              onForward={onForward}
-            />
-          )}
-          {step === "letschat" && (
-            <LetsChatTomorrowStep
-              assistantId={hatchedAssistantId}
-              assistantReady={hatchReady}
-              hatchError={hatchError}
-              onConnected={handleCheckinConnected}
-              missingCalendarScope={missingCalendarScope}
-              onRetry={() => setMissingCalendarScope(false)}
-              onSkip={() => {
-                setMissingCalendarScope(false);
-                goForwardTo("looking", "skipped");
-              }}
-              onBack={() => goBackTo("integration")}
-              onForward={onForward}
-            />
-          )}
-          {step === "meeting" && (
-            <MeetingCreatedStep
-              scheduledTime={checkinTime ?? undefined}
-              awaitingTime={checkinPending}
-              onDone={() => goForwardTo("looking")}
-              onBack={() => goBackTo("letschat")}
-              onForward={onForward}
-            />
-          )}
-          {step === "looking" && (
-            <LookingYouUpStep
-              onDone={() => goForwardTo(noClaims ? "suggestions" : "results")}
-              onBack={() =>
-                goBackTo(
-                  skipClaimCreditsStep
-                    ? "personality"
-                    : skipCheckinSteps
-                      ? "integration"
-                      : "letschat",
-                )
-              }
-              onAdvance={(i) => setEdgeAvatars(Math.min(i + 1, 4))}
-              onForward={onForward}
-              // Gate only on the web-search turn — the personality rewrite runs
-              // decoupled in the background and is finished off in its own step
-              // right before the chat handoff (see the "finishing" step), so this
-              // quick loading state isn't held hostage to the persona turn.
-              // A hatch failure holds the carousel too: the turn settles "error"
-              // the moment the hatch dies, and advancing would walk the user past
-              // the result steps into a handoff behind the failure banner, out
-              // from under its retry.
-              ready={!researchLoading && hatchError === null}
-            />
-          )}
-          {step === "results" && (
-            <ResearchResultsStep
-              claims={research.claims}
-              loading={researchLoading}
-              onContinue={(removed) => {
-                const removedSet = new Set(removed);
-                setKeptFindings(
-                  research.claims
-                    .filter((c) => !removedSet.has(c.claim))
-                    .map((c) => c.claim),
-                );
-                // Pruned claims are wrong — tell the assistant to disregard them so
-                // they don't leak into the real chat (the research turn taught its
-                // memory these facts). Fold in the aggregator-only claims the card
-                // hid: they live in the same memory but were never shown, so the
-                // user couldn't prune them. Skip that fold if a resume already
-                // scrubbed them, so stepping back to this card can't re-send them.
-                // The chat handoff awaits this promise, so the correction is
-                // persisted before the first conversation is minted.
-                const dropsToFold = droppedClaimsScrubbedRef.current
-                  ? []
-                  : research.droppedClaims;
-                const toDisregard = [...removed, ...dropsToFold];
-                if (
-                  researchConversationId &&
-                  hatchedAssistantId &&
-                  toDisregard.length > 0
-                ) {
-                  if (dropsToFold.length > 0) {
-                    syncDroppedClaimsScrubbed(true);
-                  }
-                  researchCorrectionRef.current = sendResearchCorrection({
-                    assistantId: hatchedAssistantId,
-                    conversationId: researchConversationId,
-                    removedClaims: toDisregard,
-                    rejectedAll: false,
-                  });
-                }
-                goForwardTo("suggestions");
-              }}
-              onRejectAll={() => {
-                setKeptFindings([]);
-                // "This is not me" — the search matched someone else. Disown the
-                // whole result so none of it carries into the assistant's context;
-                // that covers the hidden drops too, so mark them scrubbed.
-                if (researchConversationId && hatchedAssistantId) {
+              goForwardTo(stepAfterPersonality);
+            }}
+            onBack={() => goBackTo("different")}
+            onForward={onForward}
+          />
+        )}
+        {step === "integration" && (
+          <IntegrationStep
+            onClaim={() =>
+              goForwardTo(skipCheckinSteps ? "looking" : "letschat")
+            }
+            onBumpEyes={() => setEyesBump((n) => n + 1)}
+            onBack={() =>
+              goBackTo(personalityEnabled ? "personality" : "different")
+            }
+            onForward={onForward}
+          />
+        )}
+        {step === "letschat" && (
+          <LetsChatTomorrowStep
+            assistantId={hatchedAssistantId}
+            assistantReady={hatchReady}
+            hatchError={hatchError}
+            onConnected={handleCheckinConnected}
+            missingCalendarScope={missingCalendarScope}
+            onRetry={() => setMissingCalendarScope(false)}
+            onSkip={() => {
+              setMissingCalendarScope(false);
+              goForwardTo("looking", "skipped");
+            }}
+            onBack={() => goBackTo("integration")}
+            onForward={onForward}
+          />
+        )}
+        {step === "meeting" && (
+          <MeetingCreatedStep
+            scheduledTime={checkinTime ?? undefined}
+            awaitingTime={checkinPending}
+            onDone={() => goForwardTo("looking")}
+            onBack={() => goBackTo("letschat")}
+            onForward={onForward}
+          />
+        )}
+        {step === "looking" && (
+          <LookingYouUpStep
+            onDone={() => goForwardTo(noClaims ? "suggestions" : "results")}
+            onBack={() =>
+              goBackTo(
+                skipClaimCreditsStep
+                  ? "personality"
+                  : skipCheckinSteps
+                    ? "integration"
+                    : "letschat",
+              )
+            }
+            onAdvance={(i) => setEdgeAvatars(Math.min(i + 1, 4))}
+            onForward={onForward}
+            // Gate only on the web-search turn — the personality rewrite runs
+            // decoupled in the background and is finished off in its own step
+            // right before the chat handoff (see the "finishing" step), so this
+            // quick loading state isn't held hostage to the persona turn.
+            // A hatch failure holds the carousel too: the turn settles "error"
+            // the moment the hatch dies, and advancing would walk the user past
+            // the result steps into a handoff behind the failure banner, out
+            // from under its retry.
+            ready={!researchLoading && hatchError === null}
+          />
+        )}
+        {step === "results" && (
+          <ResearchResultsStep
+            claims={research.claims}
+            loading={researchLoading}
+            onContinue={(removed) => {
+              const removedSet = new Set(removed);
+              setKeptFindings(
+                research.claims
+                  .filter((c) => !removedSet.has(c.claim))
+                  .map((c) => c.claim),
+              );
+              // Pruned claims are wrong — tell the assistant to disregard them so
+              // they don't leak into the real chat (the research turn taught its
+              // memory these facts). Fold in the aggregator-only claims the card
+              // hid: they live in the same memory but were never shown, so the
+              // user couldn't prune them. Skip that fold if a resume already
+              // scrubbed them, so stepping back to this card can't re-send them.
+              // The chat handoff awaits this promise, so the correction is
+              // persisted before the first conversation is minted.
+              const dropsToFold = droppedClaimsScrubbedRef.current
+                ? []
+                : research.droppedClaims;
+              const toDisregard = [...removed, ...dropsToFold];
+              if (
+                researchConversationId &&
+                hatchedAssistantId &&
+                toDisregard.length > 0
+              ) {
+                if (dropsToFold.length > 0) {
                   syncDroppedClaimsScrubbed(true);
-                  researchCorrectionRef.current = sendResearchCorrection({
-                    assistantId: hatchedAssistantId,
-                    conversationId: researchConversationId,
-                    removedClaims: research.claims.map((c) => c.claim),
-                    rejectedAll: true,
-                  });
                 }
-                goForwardTo("suggestions", "skipped");
-              }}
-              onBack={() => goBackTo("looking")}
-              onForward={onForward}
-            />
-          )}
-          {step === "suggestions" && personalityEnabled && (
-            <LetsChatReadyStep
-              installedPlugins={research.installedPlugins}
-              pluginCatalog={research.pluginCatalog}
-              // Hold the handoff until a resumed done journey's guard settles, so
-              // it can't fire against an established assistant before the verdict
-              // — and until the hatch has a live assistant to hand off to, since a
-              // resumed COMPLETED snapshot lands straight here (past the gated
-              // carousel) and the handoff would clear the snapshot and navigate to
-              // a null assistant. Readiness is its own condition: a retry clears
-              // the error while the fresh attempt is still provisioning.
-              disabled={
-                resumeGuardPending ||
-                hatchError !== null ||
-                !hatchReady ||
-                hatchedAssistantId === null
-              }
-              onStart={async () => {
-                // Terminal step: the handoff leaves via enterAssistant, not
-                // goForwardTo, so emit the completion here (mirrors SuggestionsStep).
-                emitResearchOnboardingStepCompleted(
-                  RESEARCH_ONBOARDING_FUNNEL_STEPS.suggestions,
-                  { userId, outcome: "completed" },
-                );
-                // If the personality rewrite is still running, show the dedicated
-                // "finishing" carousel that holds until it settles, then enters
-                // chat — so the persona is fully written first without the invisible
-                // "Starting…" button stalling on a long turn. If it's already done,
-                // drop straight into chat.
-                if (personalityPending) {
-                  setForwardStack([]);
-                  setStep("finishing");
-                  return;
-                }
-                await finishAndEnterChat();
-              }}
-              onBack={() => goBackTo(noClaims ? "looking" : "results")}
-              onForward={onForward}
-            />
-          )}
-          {step === "suggestions" && !personalityEnabled && (
-            <SuggestionsStep
-              suggestions={research.suggestions}
-              loading={researchLoading}
-              installedPlugins={research.installedPlugins}
-              onSuggestionClick={async (suggestion) => {
-                // Terminal step: the handoff leaves via enterAssistant, not
-                // goForwardTo, so emit the suggestions completion here (mirrors the
-                // pre-chat funnel emitting on its final step before completeFlow).
-                emitResearchOnboardingStepCompleted(
-                  RESEARCH_ONBOARDING_FUNNEL_STEPS.suggestions,
-                  { userId, outcome: "completed" },
-                );
-                // Wait out any background capability installs so the new chat can
-                // discover their skills (else it silently degrades to a generic
-                // prompt). Usually instant — installs kicked off while the user
-                // reviewed the results. Also wait for any removal correction to
-                // persist so rejected claims can't leak into this first chat.
-                await Promise.all([
-                  research.awaitPluginInstalls(),
-                  researchCorrectionRef.current,
-                ]);
-                enterAssistant(formValues, faceValues, suggestion.prompt);
-              }}
-              onSkip={async () => {
-                // "Skip to Chat" — record the suggestions step as skipped.
-                emitResearchOnboardingStepCompleted(
-                  RESEARCH_ONBOARDING_FUNNEL_STEPS.suggestions,
-                  { userId, outcome: "skipped" },
-                );
-                await Promise.all([
-                  research.awaitPluginInstalls(),
-                  researchCorrectionRef.current,
-                ]);
-                enterAssistant(formValues, faceValues, undefined, {
-                  skip: true,
+                researchCorrectionRef.current = sendResearchCorrection({
+                  assistantId: hatchedAssistantId,
+                  conversationId: researchConversationId,
+                  removedClaims: toDisregard,
+                  rejectedAll: false,
                 });
-              }}
-              onBack={() => goBackTo(noClaims ? "looking" : "results")}
-              onForward={onForward}
-            />
-          )}
-          {step === "finishing" && (
-            <FinishingUpStep
-              // Hold the carousel until the personality rewrite settles, then hand
-              // off. `finishAndEnterChat` also awaits the (usually already-resolved)
-              // plugin installs + correction before dropping into chat. A hatch
-              // failure holds it too: the rewrite settles the moment the hatch
-              // rejects, and handing off would clear the snapshot and navigate away
-              // behind the failure overlay, out from under its retry.
-              ready={!personalityPending && hatchError === null}
-              onDone={() => void finishAndEnterChat()}
-            />
-          )}
-        </OnboardingStageSizeProvider>
-      </div>,
+              }
+              goForwardTo("suggestions");
+            }}
+            onRejectAll={() => {
+              setKeptFindings([]);
+              // "This is not me" — the search matched someone else. Disown the
+              // whole result so none of it carries into the assistant's context;
+              // that covers the hidden drops too, so mark them scrubbed.
+              if (researchConversationId && hatchedAssistantId) {
+                syncDroppedClaimsScrubbed(true);
+                researchCorrectionRef.current = sendResearchCorrection({
+                  assistantId: hatchedAssistantId,
+                  conversationId: researchConversationId,
+                  removedClaims: research.claims.map((c) => c.claim),
+                  rejectedAll: true,
+                });
+              }
+              goForwardTo("suggestions", "skipped");
+            }}
+            onBack={() => goBackTo("looking")}
+            onForward={onForward}
+          />
+        )}
+        {step === "suggestions" && personalityEnabled && (
+          <LetsChatReadyStep
+            installedPlugins={research.installedPlugins}
+            pluginCatalog={research.pluginCatalog}
+            // Hold the handoff until a resumed done journey's guard settles, so
+            // it can't fire against an established assistant before the verdict
+            // — and until the hatch has a live assistant to hand off to, since a
+            // resumed COMPLETED snapshot lands straight here (past the gated
+            // carousel) and the handoff would clear the snapshot and navigate to
+            // a null assistant. Readiness is its own condition: a retry clears
+            // the error while the fresh attempt is still provisioning.
+            disabled={
+              resumeGuardPending ||
+              hatchError !== null ||
+              !hatchReady ||
+              hatchedAssistantId === null
+            }
+            onStart={async () => {
+              // Terminal step: the handoff leaves via enterAssistant, not
+              // goForwardTo, so emit the completion here (mirrors SuggestionsStep).
+              emitResearchOnboardingStepCompleted(
+                RESEARCH_ONBOARDING_FUNNEL_STEPS.suggestions,
+                { userId, outcome: "completed" },
+              );
+              // If the personality rewrite is still running, show the dedicated
+              // "finishing" carousel that holds until it settles, then enters
+              // chat — so the persona is fully written first without the invisible
+              // "Starting…" button stalling on a long turn. If it's already done,
+              // drop straight into chat.
+              if (personalityPending) {
+                setForwardStack([]);
+                setStep("finishing");
+                return;
+              }
+              await finishAndEnterChat();
+            }}
+            onBack={() => goBackTo(noClaims ? "looking" : "results")}
+            onForward={onForward}
+          />
+        )}
+        {step === "suggestions" && !personalityEnabled && (
+          <SuggestionsStep
+            suggestions={research.suggestions}
+            loading={researchLoading}
+            installedPlugins={research.installedPlugins}
+            onSuggestionClick={async (suggestion) => {
+              // Terminal step: the handoff leaves via enterAssistant, not
+              // goForwardTo, so emit the suggestions completion here (mirrors the
+              // pre-chat funnel emitting on its final step before completeFlow).
+              emitResearchOnboardingStepCompleted(
+                RESEARCH_ONBOARDING_FUNNEL_STEPS.suggestions,
+                { userId, outcome: "completed" },
+              );
+              // Wait out any background capability installs so the new chat can
+              // discover their skills (else it silently degrades to a generic
+              // prompt). Usually instant — installs kicked off while the user
+              // reviewed the results. Also wait for any removal correction to
+              // persist so rejected claims can't leak into this first chat.
+              await Promise.all([
+                research.awaitPluginInstalls(),
+                researchCorrectionRef.current,
+              ]);
+              enterAssistant(formValues, faceValues, suggestion.prompt);
+            }}
+            onSkip={async () => {
+              // "Skip to Chat" — record the suggestions step as skipped.
+              emitResearchOnboardingStepCompleted(
+                RESEARCH_ONBOARDING_FUNNEL_STEPS.suggestions,
+                { userId, outcome: "skipped" },
+              );
+              await Promise.all([
+                research.awaitPluginInstalls(),
+                researchCorrectionRef.current,
+              ]);
+              enterAssistant(formValues, faceValues, undefined, {
+                skip: true,
+              });
+            }}
+            onBack={() => goBackTo(noClaims ? "looking" : "results")}
+            onForward={onForward}
+          />
+        )}
+        {step === "finishing" && (
+          <FinishingUpStep
+            // Hold the carousel until the personality rewrite settles, then hand
+            // off. `finishAndEnterChat` also awaits the (usually already-resolved)
+            // plugin installs + correction before dropping into chat. A hatch
+            // failure holds it too: the rewrite settles the moment the hatch
+            // rejects, and handing off would clear the snapshot and navigate away
+            // behind the failure overlay, out from under its retry.
+            ready={!personalityPending && hatchError === null}
+            onDone={() => void finishAndEnterChat()}
+          />
+        )}
+      </OnboardingStage>,
     );
   }
 

--- a/clients/web/src/domains/onboarding/screens/give-me-a-face-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/give-me-a-face-screen.tsx
@@ -27,11 +27,8 @@ import {
 
 import { useVoiceSamplePreview } from "@/components/speech/use-voice-sample-preview";
 import { OnboardingCharacterStage } from "@/domains/onboarding/components/onboarding-character-stage";
+import { OnboardingStage } from "@/domains/onboarding/components/onboarding-stage";
 import { OnboardingTopBar } from "@/domains/onboarding/components/onboarding-top-bar";
-import {
-  OnboardingStageSizeProvider,
-  useElementSize,
-} from "@/domains/onboarding/hooks/use-onboarding-stage-size";
 import { useOnboardingAvatarPoolStore } from "@/domains/onboarding/onboarding-avatar-pool-store";
 import { resolveAvatarVoice } from "@/domains/onboarding/onboarding-avatar-voices";
 import { useUnscopedManagedVoices } from "@/lib/tts/use-managed-voices";
@@ -111,10 +108,6 @@ export function GiveMeAFaceScreen({
   // so their custom name survives cycling through avatars.
   const nameCustomized = useRef(false);
   const nameInputRef = useRef<HTMLInputElement>(null);
-  // Measure this screen's container so the decorative stage shares the exact
-  // coordinate space as the foreground arrows/title/buttons (see
-  // use-onboarding-stage-size).
-  const { ref: stageRef, size: stageSize } = useElementSize();
   // The current swap: the newly selected char + the slot it came from
   // (entering), and the old center + the slot it's heading to (exiting).
   const [swap, setSwap] = useState<{
@@ -264,157 +257,151 @@ export function GiveMeAFaceScreen({
     "transition-colors duration-150 hover:bg-[color-mix(in_srgb,var(--content-default)_18%,transparent)]";
 
   return (
-    <div
-      ref={stageRef}
-      data-theme="dark"
-      className="relative h-full overflow-hidden bg-[var(--surface-base)] text-[var(--content-default)]"
-    >
-      <OnboardingStageSizeProvider size={stageSize}>
-        {ready && (
-          <OnboardingCharacterStage
-            components={components}
-            characters={characters}
-            centerChar={arrangement.centerChar}
-            edgeOrder={arrangement.edgeOrder}
-            entering={swap?.entering ?? null}
-            exiting={swap?.exiting ?? null}
-            onEnterComplete={(char) =>
-              setSwap((curr) => (curr?.entering.char === char ? null : curr))
-            }
-            onSelectChar={moveTo}
-          />
-        )}
+    <OnboardingStage className="bg-[var(--surface-base)] text-[var(--content-default)]">
+      {ready && (
+        <OnboardingCharacterStage
+          components={components}
+          characters={characters}
+          centerChar={arrangement.centerChar}
+          edgeOrder={arrangement.edgeOrder}
+          entering={swap?.entering ?? null}
+          exiting={swap?.exiting ?? null}
+          onEnterComplete={(char) =>
+            setSwap((curr) => (curr?.entering.char === char ? null : curr))
+          }
+          onSelectChar={moveTo}
+        />
+      )}
 
-        {/* Redo routes through Continue (not the generic step redo) so any avatar
+      {/* Redo routes through Continue (not the generic step redo) so any avatar
           or name edits made after stepping back are captured before advancing —
           otherwise the redo would re-stage the previous selection. */}
-        <OnboardingTopBar
-          tone="light"
-          onBack={onBack}
-          onNext={onForward ? handleContinue : undefined}
-        />
+      <OnboardingTopBar
+        tone="light"
+        onBack={onBack}
+        onNext={onForward ? handleContinue : undefined}
+      />
 
-        {/* Title */}
-        <h1
-          className="absolute left-1/2 top-[22%] z-10 -translate-x-1/2 whitespace-nowrap text-center text-[2.6rem] leading-none max-md:w-[90vw] max-md:whitespace-normal max-md:text-[2.08rem]"
-          style={{
-            fontFamily: "var(--font-serif)",
-            animation: "fadeInUp 0.4s ease-out both",
-          }}
-        >
-          Give me a face and a name
-        </h1>
+      {/* Title */}
+      <h1
+        className="absolute left-1/2 top-[22%] z-10 -translate-x-1/2 whitespace-nowrap text-center text-[2.6rem] leading-none max-md:w-[90vw] max-md:whitespace-normal max-md:text-[2.08rem]"
+        style={{
+          fontFamily: "var(--font-serif)",
+          animation: "fadeInUp 0.4s ease-out both",
+        }}
+      >
+        Give me a face and a name
+      </h1>
 
-        {/* Cycle arrows, flanking the centered avatar */}
-        <button
-          type="button"
-          aria-label="Previous character"
-          onClick={goPrev}
-          className={`absolute left-[calc(50%-170px)] top-[43%] -translate-y-1/2 ${arrowClass}`}
-        >
-          <ArrowLeft className="h-4 w-4" />
-        </button>
-        <button
-          type="button"
-          aria-label="Next character"
-          onClick={goNext}
-          className={`absolute right-[calc(50%-170px)] top-[43%] -translate-y-1/2 ${arrowClass}`}
-        >
-          <ArrowRight className="h-4 w-4" />
-        </button>
+      {/* Cycle arrows, flanking the centered avatar */}
+      <button
+        type="button"
+        aria-label="Previous character"
+        onClick={goPrev}
+        className={`absolute left-[calc(50%-170px)] top-[43%] -translate-y-1/2 ${arrowClass}`}
+      >
+        <ArrowLeft className="h-4 w-4" />
+      </button>
+      <button
+        type="button"
+        aria-label="Next character"
+        onClick={goNext}
+        className={`absolute right-[calc(50%-170px)] top-[43%] -translate-y-1/2 ${arrowClass}`}
+      >
+        <ArrowRight className="h-4 w-4" />
+      </button>
 
-        {/* Name (view ↔ edit) + Continue, grouped with room between them. */}
-        <div className="absolute left-1/2 top-[58%] z-10 flex -translate-x-1/2 flex-col items-center gap-10 max-md:top-[54%]">
-          <div className="flex flex-col items-center gap-4">
-            {editingName ? (
-              <input
-                ref={nameInputRef}
-                value={name}
-                onChange={(e) => {
-                  nameCustomized.current = true;
-                  setName(e.target.value);
-                }}
-                onBlur={() => setEditingName(false)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.preventDefault();
-                    setEditingName(false);
-                  }
-                }}
-                placeholder="Name your assistant"
-                aria-label="Assistant name"
-                className="w-[234px] rounded-2xl border border-[var(--border-element)] bg-transparent px-4 py-2.5 text-center text-lg text-[var(--content-default)] placeholder:text-[var(--content-tertiary)] outline-none transition-colors duration-150 focus:border-[var(--border-active)]"
-              />
-            ) : (
-              <div className="flex items-center gap-2.5">
-                <button
-                  type="button"
-                  onClick={() => setEditingName(true)}
-                  aria-label="Edit name"
-                  className="flex cursor-pointer items-center gap-2.5"
+      {/* Name (view ↔ edit) + Continue, grouped with room between them. */}
+      <div className="absolute left-1/2 top-[58%] z-10 flex -translate-x-1/2 flex-col items-center gap-10 max-md:top-[54%]">
+        <div className="flex flex-col items-center gap-4">
+          {editingName ? (
+            <input
+              ref={nameInputRef}
+              value={name}
+              onChange={(e) => {
+                nameCustomized.current = true;
+                setName(e.target.value);
+              }}
+              onBlur={() => setEditingName(false)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  setEditingName(false);
+                }
+              }}
+              placeholder="Name your assistant"
+              aria-label="Assistant name"
+              className="w-[234px] rounded-2xl border border-[var(--border-element)] bg-transparent px-4 py-2.5 text-center text-lg text-[var(--content-default)] placeholder:text-[var(--content-tertiary)] outline-none transition-colors duration-150 focus:border-[var(--border-active)]"
+            />
+          ) : (
+            <div className="flex items-center gap-2.5">
+              <button
+                type="button"
+                onClick={() => setEditingName(true)}
+                aria-label="Edit name"
+                className="flex cursor-pointer items-center gap-2.5"
+              >
+                <span
+                  className={`text-2xl font-medium ${name ? "text-[var(--content-default)]" : "text-[var(--content-tertiary)]"}`}
                 >
-                  <span
-                    className={`text-2xl font-medium ${name ? "text-[var(--content-default)]" : "text-[var(--content-tertiary)]"}`}
-                  >
-                    {name || "Name your assistant"}
-                  </span>
-                  <Pencil className="h-5 w-5 text-[var(--content-tertiary)]" />
-                </button>
-                <button
-                  type="button"
-                  onClick={randomizeCharacter}
-                  aria-label="Shuffle name and appearance"
-                  title="Shuffle name and appearance"
-                  className="cursor-pointer text-[var(--content-tertiary)] transition-[transform,color] duration-300 hover:rotate-180 hover:text-[var(--content-default)]"
-                >
-                  <Dices className="h-5 w-5" />
-                </button>
-              </div>
-            )}
+                  {name || "Name your assistant"}
+                </span>
+                <Pencil className="h-5 w-5 text-[var(--content-tertiary)]" />
+              </button>
+              <button
+                type="button"
+                onClick={randomizeCharacter}
+                aria-label="Shuffle name and appearance"
+                title="Shuffle name and appearance"
+                className="cursor-pointer text-[var(--content-tertiary)] transition-[transform,color] duration-300 hover:rotate-180 hover:text-[var(--content-default)]"
+              >
+                <Dices className="h-5 w-5" />
+              </button>
+            </div>
+          )}
 
-            {/* The only place voice is surfaced in onboarding. It auditions the
+          {/* The only place voice is surfaced in onboarding. It auditions the
                 CENTERED avatar's own voice, so cycling the carousel is also how
                 you shop for a voice. While the catalog is in flight the button
                 spins rather than sitting dead: a slow fetch has to read as
                 "coming", not "broken". Absent entirely where the catalog is out
                 of reach, rather than offered and permanently inert. */}
-            {canAuditionVoice && (
-              <button
-                type="button"
-                onClick={toggleVoice}
-                disabled={!centeredVoice}
-                title="Hear my voice"
-                aria-label={
-                  auditioning ? "Stop the voice sample" : "Hear my voice"
-                }
-                aria-busy={voicePending}
-                className={`flex cursor-pointer items-center gap-2 rounded-full border border-[color-mix(in_srgb,var(--content-default)_22%,transparent)] px-4 py-2 text-sm text-[var(--content-default)] transition-colors duration-150 hover:bg-[color-mix(in_srgb,var(--content-default)_10%,transparent)] disabled:cursor-default ${voicePending ? "disabled:opacity-70" : "disabled:opacity-40"}`}
-              >
-                {voicePending ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : auditioning ? (
-                  <Square className="h-4 w-4" />
-                ) : (
-                  <Volume2 className="h-4 w-4" />
-                )}
-                Hear my voice
-              </button>
-            )}
-          </div>
-
-          <Button
-            type="button"
-            variant="primary"
-            size="regular"
-            rightIcon={<ArrowRight size={16} />}
-            disabled={!ready}
-            onClick={handleContinue}
-            className="h-11 w-[234px] text-base"
-          >
-            Continue
-          </Button>
+          {canAuditionVoice && (
+            <button
+              type="button"
+              onClick={toggleVoice}
+              disabled={!centeredVoice}
+              title="Hear my voice"
+              aria-label={
+                auditioning ? "Stop the voice sample" : "Hear my voice"
+              }
+              aria-busy={voicePending}
+              className={`flex cursor-pointer items-center gap-2 rounded-full border border-[color-mix(in_srgb,var(--content-default)_22%,transparent)] px-4 py-2 text-sm text-[var(--content-default)] transition-colors duration-150 hover:bg-[color-mix(in_srgb,var(--content-default)_10%,transparent)] disabled:cursor-default ${voicePending ? "disabled:opacity-70" : "disabled:opacity-40"}`}
+            >
+              {voicePending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : auditioning ? (
+                <Square className="h-4 w-4" />
+              ) : (
+                <Volume2 className="h-4 w-4" />
+              )}
+              Hear my voice
+            </button>
+          )}
         </div>
-      </OnboardingStageSizeProvider>
-    </div>
+
+        <Button
+          type="button"
+          variant="primary"
+          size="regular"
+          rightIcon={<ArrowRight size={16} />}
+          disabled={!ready}
+          onClick={handleContinue}
+          className="h-11 w-[234px] text-base"
+        >
+          Continue
+        </Button>
+      </div>
+    </OnboardingStage>
   );
 }

--- a/clients/web/src/domains/onboarding/screens/introduction-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/introduction-screen.tsx
@@ -18,11 +18,9 @@ import { Button } from "@vellumai/design-library/components/button";
 
 import { ONBOARDING_STEP_CONTENT } from "@/domains/onboarding/onboarding-step-layout";
 import { OnboardingPeekingEyes } from "@/domains/onboarding/components/onboarding-peeking-eyes";
+import { OnboardingStage } from "@/domains/onboarding/components/onboarding-stage";
 import { OnboardingTopBar } from "@/domains/onboarding/components/onboarding-top-bar";
-import {
-  OnboardingStageSizeProvider,
-  useElementSize,
-} from "@/domains/onboarding/hooks/use-onboarding-stage-size";
+import { useOnboardingStageSize } from "@/domains/onboarding/hooks/use-onboarding-stage-size";
 import { useOnboardingTone } from "@/domains/onboarding/onboarding-tone";
 import { useOnboardingAvatarPoolStore } from "@/domains/onboarding/onboarding-avatar-pool-store";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
@@ -41,6 +39,54 @@ interface IntroductionScreenProps {
 const PICKER_SIZE = 200;
 const PICKER_CENTER_VH = 40;
 
+interface IntroductionArt {
+  body: { viewBox: { width: number; height: number }; svgPath: string };
+  color: string;
+}
+
+/**
+ * The chosen avatar's body, growing from the picker's size to cover the stage.
+ *
+ * Reads the stage box rather than taking it as a prop so it lands in the same
+ * coordinate space as the peeking eyes and the greeting beside it.
+ */
+function IntroductionBodyGrow({
+  art,
+  reduce,
+}: {
+  art: IntroductionArt;
+  reduce: boolean;
+}) {
+  const { w, h } = useOnboardingStageSize();
+  const coverSize = 1.25 * Math.max(w, h);
+  const coverH = (coverSize * art.body.viewBox.height) / art.body.viewBox.width;
+  const bodyLeft = (w - coverSize) / 2;
+  const bodyTop = (h - coverH) / 2;
+  const bodyStartScale = PICKER_SIZE / coverSize;
+  // Start near the picker's centre.
+  const bodyStartY = (PICKER_CENTER_VH / 100 - 0.5) * h;
+
+  return (
+    <motion.svg
+      aria-hidden="true"
+      className="pointer-events-none absolute z-[1]"
+      viewBox={`0 0 ${art.body.viewBox.width} ${art.body.viewBox.height}`}
+      width={coverSize}
+      height={coverH}
+      style={{ left: bodyLeft, top: bodyTop, transformOrigin: "center" }}
+      initial={reduce ? false : { scale: bodyStartScale, y: bodyStartY }}
+      animate={{ scale: 1, y: 0 }}
+      transition={
+        reduce
+          ? { duration: 0 }
+          : { type: "spring", stiffness: 78, damping: 18, mass: 1 }
+      }
+    >
+      <path d={art.body.svgPath} fill={art.color} />
+    </motion.svg>
+  );
+}
+
 export function IntroductionScreen({
   firstName,
   assistantName,
@@ -52,12 +98,6 @@ export function IntroductionScreen({
   const characters = useOnboardingAvatarPoolStore.use.characters();
   const selectedIndex = useOnboardingAvatarPoolStore.use.selectedIndex();
   const reduce = useReducedMotion();
-  // Measure this screen's container so the body grow and the peeking eyes share
-  // one coordinate space (see use-onboarding-stage-size).
-  const {
-    ref: stageRef,
-    size: { w, h },
-  } = useElementSize();
   const tone = useOnboardingTone();
 
   const chosen = characters.length > 0 ? characters[selectedIndex] : undefined;
@@ -89,111 +129,78 @@ export function IntroductionScreen({
     );
   }
 
-  // Body grows to cover the screen end to end, starting from the picker size.
-  const coverSize = 1.25 * Math.max(w, h);
-  const coverH = (coverSize * art.body.viewBox.height) / art.body.viewBox.width;
-  const bodyLeft = (w - coverSize) / 2;
-  const bodyTop = (h - coverH) / 2;
-  const bodyStartScale = PICKER_SIZE / coverSize;
-  const bodyStartY = (PICKER_CENTER_VH / 100 - 0.5) * h; // start near picker center
-
   return (
     // Starts on the picker's dark surface; the color layer below fades in.
-    <div
-      ref={stageRef}
-      data-theme="dark"
-      className="relative h-full overflow-hidden"
-      style={{ backgroundColor: "var(--surface-base)" }}
-    >
-      <OnboardingStageSizeProvider size={{ w, h }}>
-        {/* The avatar color fills in so coverage is end-to-end even where the
+    <OnboardingStage className="bg-[var(--surface-base)]">
+      {/* The avatar color fills in so coverage is end-to-end even where the
           body shape has gaps/spikes. */}
-        <motion.div
-          className="absolute inset-0 z-0"
-          style={{ backgroundColor: art.color }}
-          initial={reduce ? false : { opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={reduce ? { duration: 0 } : { duration: 0.6, delay: 0.35 }}
-        />
+      <motion.div
+        className="absolute inset-0 z-0"
+        style={{ backgroundColor: art.color }}
+        initial={reduce ? false : { opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={reduce ? { duration: 0 } : { duration: 0.6, delay: 0.35 }}
+      />
 
-        {/* Body — grows from the picker size to cover the screen. */}
-        <motion.svg
-          aria-hidden="true"
-          className="pointer-events-none absolute z-[1]"
-          viewBox={`0 0 ${art.body.viewBox.width} ${art.body.viewBox.height}`}
-          width={coverSize}
-          height={coverH}
-          style={{ left: bodyLeft, top: bodyTop, transformOrigin: "center" }}
-          initial={reduce ? false : { scale: bodyStartScale, y: bodyStartY }}
-          animate={{ scale: 1, y: 0 }}
+      {/* Body: grows from the picker size to cover the screen. */}
+      <IntroductionBodyGrow art={art} reduce={reduce === true} />
+
+      {/* Eyes peek up from the bottom, growing in alongside the body. */}
+      <OnboardingPeekingEyes entrance />
+
+      {/* Progress + back, fading in after the grow. */}
+      <motion.div
+        initial={reduce ? false : { opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={reduce ? { duration: 0 } : { duration: 0.4, delay: 1 }}
+      >
+        <OnboardingTopBar onBack={onBack} onNext={onForward} />
+      </motion.div>
+
+      {/* Greeting + Continue, grouped so the button sits just under the text. */}
+      <div className={ONBOARDING_STEP_CONTENT}>
+        <motion.h1
+          className="text-center leading-[1.15] max-md:leading-[1.25]"
+          style={{ fontFamily: "var(--font-serif)" }}
+          initial={reduce ? false : { scale: 0.9, opacity: 0 }}
+          animate={{ scale: 1, opacity: 1 }}
           transition={
             reduce
               ? { duration: 0 }
-              : { type: "spring", stiffness: 78, damping: 18, mass: 1 }
+              : { type: "spring", stiffness: 260, damping: 11, delay: 1 }
           }
         >
-          <path d={art.body.svgPath} fill={art.color} />
-        </motion.svg>
+          <span
+            className="block text-[clamp(2.5rem,6vw,5rem)]"
+            style={{ color: tone.fgDeep }}
+          >
+            {greeting}
+          </span>
+          <span
+            className="block text-[clamp(2.5rem,6vw,5rem)]"
+            style={{ color: tone.fg }}
+          >
+            {intro}
+          </span>
+        </motion.h1>
 
-        {/* Eyes peek up from the bottom, growing in alongside the body. */}
-        <OnboardingPeekingEyes entrance />
-
-        {/* Progress + back — fade in after the grow. */}
         <motion.div
-          initial={reduce ? false : { opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={reduce ? { duration: 0 } : { duration: 0.4, delay: 1 }}
+          initial={reduce ? false : { opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={reduce ? { duration: 0 } : { duration: 0.4, delay: 1.15 }}
         >
-          <OnboardingTopBar onBack={onBack} onNext={onForward} />
+          <Button
+            type="button"
+            variant="primary"
+            size="regular"
+            rightIcon={<ArrowRight size={16} />}
+            onClick={onContinue}
+            className="h-11 w-[234px] text-base"
+          >
+            Continue
+          </Button>
         </motion.div>
-
-        {/* Greeting + Continue, grouped so the button sits just under the text. */}
-        <div className={ONBOARDING_STEP_CONTENT}>
-          <motion.h1
-            className="text-center leading-[1.15] max-md:leading-[1.25]"
-            style={{ fontFamily: "var(--font-serif)" }}
-            initial={reduce ? false : { scale: 0.9, opacity: 0 }}
-            animate={{ scale: 1, opacity: 1 }}
-            transition={
-              reduce
-                ? { duration: 0 }
-                : { type: "spring", stiffness: 260, damping: 11, delay: 1 }
-            }
-          >
-            <span
-              className="block text-[clamp(2.5rem,6vw,5rem)]"
-              style={{ color: tone.fgDeep }}
-            >
-              {greeting}
-            </span>
-            <span
-              className="block text-[clamp(2.5rem,6vw,5rem)]"
-              style={{ color: tone.fg }}
-            >
-              {intro}
-            </span>
-          </motion.h1>
-
-          <motion.div
-            initial={reduce ? false : { opacity: 0, y: 8 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={
-              reduce ? { duration: 0 } : { duration: 0.4, delay: 1.15 }
-            }
-          >
-            <Button
-              type="button"
-              variant="primary"
-              size="regular"
-              rightIcon={<ArrowRight size={16} />}
-              onClick={onContinue}
-              className="h-11 w-[234px] text-base"
-            >
-              Continue
-            </Button>
-          </motion.div>
-        </div>
-      </OnboardingStageSizeProvider>
-    </div>
+      </div>
+    </OnboardingStage>
   );
 }


### PR DESCRIPTION
## TL;DR

The onboarding decorative layers size and position themselves from a measured container, so their arrangement is only correct *relative to a box* and is different at every box size. None of them had a story, and the app shows one size at a time, so no arrangement was reviewable.

This extracts the container the three onboarding screens were each repeating, and adds stories that mount the real one at several sizes.

**Review tip:** diff with whitespace ignored. Removing a wrapper level re-indented whole subtrees; the real change is 19/19/105 lines in the three screens, not 533/279/215.

## Why the extraction is part of a story PR

A story that mirrors its production wrapper proves nothing about the real one, because the two drift and the story keeps passing (LUM-3164). Three screens each carried the same container inline: a `relative h-full overflow-hidden` div, `data-theme="dark"`, `useElementSize`, an `OnboardingStageSizeProvider`, and three copies of the comment explaining why. Now they share `OnboardingStage` and the stories import it.

Same precedent as #40539, which extracted `ChatColumn` so the staged-quotes story could import rather than mirror it.

## What the stories found immediately

**The stage has an unstated height contract.** `OnboardingStage` is `h-full`, so its height comes from `root-layout.tsx`'s `100dvh` flex chain. Mounted without it, the stage measures **zero tall**, every layer resolves against a zero-height box, and the whole arrangement collapses to the origin without erroring. The first render of these stories did exactly that. The fixture now reproduces that contract explicitly and says why.

**LUM-3198 is now a number.** On a 390x844 viewport with a notched device's insets, the stage measures **390x751**. A layer reading the window instead of the stage is **93px out** (measured, not argued). That is what `InsetByASafeArea` shows.

## Why this is safe

Behaviour is unchanged. The extraction moves the same markup, the same `useElementSize` call, and the same provider into one component; `introduction-screen` keeps its body-grow geometry in a sub-component that reads the stage from context instead of local state, which is the same value by a shorter path.

Verified in Storybook on an isolated port, asserting the story ids against `/index.json` before trusting any reading (a stale instance on the default port answers with old bundles). The eyes were checked **differentially** rather than by eye, since a backgrounded preview freezes `motion/react` mid-animation:

| Story | stage bottom | eyes bottom | overhang past stage |
|---|---|---|---|
| Mobile, no inset | 844 | 915 | 71 |
| Inset by safe area | 810 | 877 | 67 |

Shrinking the stage by 34px moves the eyes up with it. A window-anchored layer would instead have gained 34px of overhang, so this story would catch that regression.

## Before / after

| | Before | After |
|---|---|---|
| The stage container | Inline in 3 screens, 3 copies of the comment | One `OnboardingStage` |
| Stories for these layers | None | Ring and eyes, at desktop, phone, and safe-area-inset |
| The height contract | Implicit; silently zero if absent | Reproduced and documented in the fixture |
| Seeding the avatar pool | | Through `ensureGenerated`, the app's own write path, not `.setState` |
| Rendered output | | Unchanged |

## Follow-ups, not done here

- The app shell's height contract is mirrored in the story fixture rather than imported, because it lives inline around `<Outlet />` tangled with keyboard and safe-area handling. If it is ever extracted, the fixture should import it.
- These stories make LUM-3204 (CSS-expressed sizing) verifiable; that work is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40554" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->