### PR TITLE
refactor(memory): state each messages-read's visibility decision

### DIFF
--- a/assistant/src/persistence/message-reads.ts
+++ b/assistant/src/persistence/message-reads.ts
@@ -191,6 +191,25 @@ export function existingMessageIds(
 }
 
 /**
+ * Whether `messageId` exists as a row, in any state.
+ *
+ * Any-state deliberately: callers bracket work with this check to avoid
+ * leaving derived artifacts for a deleted message, and a streaming row
+ * exists. The single-id twin of {@link existingMessageIds}.
+ */
+export function messageExists(
+  messageId: string,
+  opts?: { db?: MessageReadHandle },
+): boolean {
+  const row = (opts?.db ?? getDb())
+    .select({ id: messages.id })
+    .from(messages)
+    .where(eq(messages.id, messageId))
+    .get();
+  return row !== undefined;
+}
+
+/**
  * The conversation that owns `messageId`, in any state, or null when the
  * message does not exist.
  *

--- a/assistant/src/persistence/message-reads.ts
+++ b/assistant/src/persistence/message-reads.ts
@@ -191,25 +191,6 @@ export function existingMessageIds(
 }
 
 /**
- * Whether `messageId` exists as a row, in any state.
- *
- * Any-state deliberately: callers bracket work with this check to avoid
- * leaving derived artifacts for a deleted message, and a streaming row
- * exists. The single-id twin of {@link existingMessageIds}.
- */
-export function messageExists(
-  messageId: string,
-  opts?: { db?: MessageReadHandle },
-): boolean {
-  const row = (opts?.db ?? getDb())
-    .select({ id: messages.id })
-    .from(messages)
-    .where(eq(messages.id, messageId))
-    .get();
-  return row !== undefined;
-}
-
-/**
  * The conversation that owns `messageId`, in any state, or null when the
  * message does not exist.
  *

--- a/assistant/src/plugins/defaults/memory/graph/image-ref-utils.ts
+++ b/assistant/src/plugins/defaults/memory/graph/image-ref-utils.ts
@@ -17,6 +17,9 @@ export async function loadImageRefData(
   const msg = db
     .select({ content: messages.content })
     .from(messages)
+    // No completeness predicate: refs come from the extracted memory graph,
+    // and extraction reads finalized rows only, so an unfinalized id cannot
+    // reach here. Do not copy this shape for ids with other provenance.
     .where(eq(messages.id, ref.messageId))
     .get();
   if (!msg) {

--- a/assistant/src/plugins/defaults/memory/indexer.ts
+++ b/assistant/src/plugins/defaults/memory/indexer.ts
@@ -16,13 +16,13 @@ import {
   getMemoryCheckpoint,
   setMemoryCheckpoint,
 } from "../../../persistence/checkpoints.js";
-import { getDb } from "../../../persistence/db-connection.js";
 import {
   enqueueMemoryJob,
   isMemoryEnabled,
   upsertDebouncedJob,
 } from "../../../persistence/jobs-store.js";
-import { memorySegments, messages } from "../../../persistence/schema/index.js";
+import { messageExists } from "../../../persistence/message-reads.js";
+import { memorySegments } from "../../../persistence/schema/index.js";
 import type { TrustClass } from "../../../runtime/actor-trust-resolver.js";
 import { isAutoAnalysisConversation } from "../../../runtime/services/auto-analysis-guard.js";
 import { getLogger } from "./logging.js";
@@ -125,12 +125,7 @@ export async function indexMessageNow(
   // row is already gone, the common case of a backfill job running after the
   // message was deleted. A post-write re-check below closes the narrower window
   // where the delete lands mid-transaction.
-  const sourceMessage = getDb()
-    .select({ id: messages.id })
-    .from(messages)
-    .where(eq(messages.id, input.messageId))
-    .get();
-  if (!sourceMessage) {
+  if (!messageExists(input.messageId)) {
     return { indexedSegments: 0, enqueuedJobs: 0 };
   }
 
@@ -198,12 +193,7 @@ export async function indexMessageNow(
   // drop the pieces this call just wrote and skip the embedding jobs, so a
   // delete racing a backfill leaves nothing searchable behind. No embeddings
   // exist yet. The skipped jobs are what would have created them.
-  const stillExists = getDb()
-    .select({ id: messages.id })
-    .from(messages)
-    .where(eq(messages.id, input.messageId))
-    .get();
-  if (!stillExists) {
+  if (!messageExists(input.messageId)) {
     mem
       .delete(memorySegments)
       .where(eq(memorySegments.messageId, input.messageId))

--- a/assistant/src/plugins/defaults/memory/indexer.ts
+++ b/assistant/src/plugins/defaults/memory/indexer.ts
@@ -16,13 +16,13 @@ import {
   getMemoryCheckpoint,
   setMemoryCheckpoint,
 } from "../../../persistence/checkpoints.js";
+import { getDb } from "../../../persistence/db-connection.js";
 import {
   enqueueMemoryJob,
   isMemoryEnabled,
   upsertDebouncedJob,
 } from "../../../persistence/jobs-store.js";
-import { messageExists } from "../../../persistence/message-reads.js";
-import { memorySegments } from "../../../persistence/schema/index.js";
+import { memorySegments, messages } from "../../../persistence/schema/index.js";
 import type { TrustClass } from "../../../runtime/actor-trust-resolver.js";
 import { isAutoAnalysisConversation } from "../../../runtime/services/auto-analysis-guard.js";
 import { getLogger } from "./logging.js";
@@ -123,9 +123,16 @@ export async function indexMessageNow(
   // memory_segments has no cross-file FK to messages, so this call must not
   // leave pieces for a message with no row. Skip early when the source
   // row is already gone, the common case of a backfill job running after the
-  // message was deleted. A post-write re-check below closes the narrower window
+  // message was deleted. Any-state existence check, deliberately: a
+  // streaming row exists, and orphan prevention is about deletion, not
+  // completeness. A post-write re-check below closes the narrower window
   // where the delete lands mid-transaction.
-  if (!messageExists(input.messageId)) {
+  const sourceMessage = getDb()
+    .select({ id: messages.id })
+    .from(messages)
+    .where(eq(messages.id, input.messageId))
+    .get();
+  if (!sourceMessage) {
     return { indexedSegments: 0, enqueuedJobs: 0 };
   }
 
@@ -193,7 +200,12 @@ export async function indexMessageNow(
   // drop the pieces this call just wrote and skip the embedding jobs, so a
   // delete racing a backfill leaves nothing searchable behind. No embeddings
   // exist yet. The skipped jobs are what would have created them.
-  if (!messageExists(input.messageId)) {
+  const stillExists = getDb()
+    .select({ id: messages.id })
+    .from(messages)
+    .where(eq(messages.id, input.messageId))
+    .get();
+  if (!stillExists) {
     mem
       .delete(memorySegments)
       .where(eq(memorySegments.messageId, input.messageId))

--- a/assistant/src/plugins/defaults/memory/v1/graph/extraction.ts
+++ b/assistant/src/plugins/defaults/memory/v1/graph/extraction.ts
@@ -1365,7 +1365,9 @@ function resolveConversationTimestamp(conversationId: string): number | null {
   const db = getDb();
   // Use the last message timestamp, not the conversation creation time.
   // A conversation can span hours/days — memories should be timestamped
-  // to when the relevant content was actually discussed.
+  // to when the relevant content was actually discussed. Any-state read,
+  // deliberately: only `createdAt` is consumed, and a streaming last row
+  // still marks when discussion happened.
   const lastMsg = db
     .select({ createdAt: messages.createdAt })
     .from(messages)

--- a/assistant/src/plugins/defaults/memory/v3/prune.ts
+++ b/assistant/src/plugins/defaults/memory/v3/prune.ts
@@ -293,6 +293,8 @@ export function collectPersistedV3Cards(conversationId: string): Set<string> {
   const rows = getSqliteFrom(getDb())
     .query(
       /*sql*/ `
+      -- Any-state scan: only metadata markers are read, and the marker is
+      -- written by the injection path on rows it owns regardless of state.
       SELECT metadata FROM messages
       WHERE conversation_id = ? AND metadata LIKE '%' || ? || '%'
     `,

--- a/assistant/src/plugins/defaults/memory/v3/selection-log-store.ts
+++ b/assistant/src/plugins/defaults/memory/v3/selection-log-store.ts
@@ -97,6 +97,8 @@ function forkSourceIdsOf(messageIds: string[]): string[] {
     .query(
       /*sql*/ `
       SELECT json_extract(metadata, '$.forkSourceMessageId') AS src
+      -- No completeness predicate: ids come from this store's own selection
+      -- log, written for rows the injection pipeline already processed.
       FROM messages
       WHERE id IN (${placeholders})
     `,


### PR DESCRIPTION
## TL;DR

Second PR of the messages-reader consolidation (Part of JARVIS-1478), covering the memory plugin family. Annotation-only by design, and smaller than planned for a principled reason: the walkthrough found most of this family already correct (the lexical/embedding/sweep batch jobs filter `finalized = 1` in SQL), and the plugin import-boundary ratchet correctly rejected the one accessor swap attempted here — a plugin importing `persistence/message-reads.js` would grow plugin-to-host coupling, so plugin reads stay on their existing baselined couplings until an accessor surface exists at the `@vellumai/plugin-api` level.

Every remaining direct `messages` read in the family now states its visibility decision at the site:

- The indexer's orphan-prevention existence checks: any-state deliberately (a streaming row exists; the checks guard against deletion races around cross-database writes).
- The graph timestamp resolver: any-state deliberately (consumes only `createdAt`; a streaming last row still marks when discussion happened).
- Image-ref and selection-log id lookups: finalized by provenance (extraction and the injection pipeline filter at write time); each annotation warns against copying the shape for ids with different provenance.
- The v3 prune scan: reads only injection markers this store's own pipeline wrote.

The census's suspected live bug at `extraction.ts:1371` was audited and downgraded: it reads timestamps, never content, so a streaming last row skews a memory date by seconds at most.

## What changes for the user

Nothing. This PR is comments; no query changes.

## Why this is safe

- Zero behavioral diff: every annotation asserts only what the walkthrough verified by tracing the provenance claim to the writing code.
- `memory-retrospective-accounting.ts` and `context-search/conversations.ts` are deliberately untouched: both have pending changes on #40484 and get their treatment when it lands, avoiding a manufactured conflict.

## Remaining in the arc

Telemetry + routes family, then the lint/CI guard against new direct `messages` reads outside `persistence/` (guard last, against a migrated tree). A plugin-api read surface for plugin message access is noted on JARVIS-1478 as the eventual path for the plugin family's baselined raw reads.

Local `bun test` is hook-blocked for broad runs in this environment; typecheck, lint, and the plugin-boundary guard pass locally and CI runs the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)