### PR TITLE
feat(mcp): connect plugin-declared MCP servers, default them to low risk

### DIFF
--- a/assistant/src/__tests__/mcp-list-plugin-servers.test.ts
+++ b/assistant/src/__tests__/mcp-list-plugin-servers.test.ts
@@ -204,12 +204,12 @@ describe("internal_mcp_list, plugin-declared servers", () => {
     expect(workspace.hasStaticAuth).toBe(true);
   });
 
-  test("plugin servers default to high risk", async () => {
+  test("plugin servers default to low risk", async () => {
     writePlugin("unabyss", unabyssManifest());
 
     const servers = await listServers();
     expect(servers.find((s) => s.id === "unabyss")!.defaultRiskLevel).toEqual(
-      "high",
+      "low",
     );
   });
 

--- a/assistant/src/config/schemas/mcp.ts
+++ b/assistant/src/config/schemas/mcp.ts
@@ -109,3 +109,26 @@ export const McpConfigSchema = z
 export type McpTransport = z.infer<typeof McpTransportSchema>;
 export type McpServerConfig = z.infer<typeof McpServerConfigSchema>;
 export type McpConfig = z.infer<typeof McpConfigSchema>;
+
+/**
+ * Who declared a server: the workspace `config.json`, which the user owns,
+ * or a plugin's `mcp.json`, which its author owns.
+ *
+ * Deliberately not a schema field. It is resolved from where the entry was
+ * read, never parsed from a file, so nothing on disk can claim to be
+ * workspace-owned. What it gates is credential access: only a workspace
+ * server resolves `mcp:<serverId>:*` from the credential store, because a
+ * plugin controls both its server key and its URL and would otherwise
+ * receive a workspace credential at an endpoint it chose.
+ */
+export type McpServerSource = "workspace" | "plugin";
+
+/** A server config with its origin resolved. */
+export interface ResolvedMcpServerConfig extends McpServerConfig {
+  readonly source: McpServerSource;
+}
+
+/** The MCP config the daemon runs: both origins, every server attributed. */
+export interface ResolvedMcpConfig extends Omit<McpConfig, "servers"> {
+  readonly servers: Record<string, ResolvedMcpServerConfig>;
+}

--- a/assistant/src/daemon/__tests__/plugin-mcp-reconcile.test.ts
+++ b/assistant/src/daemon/__tests__/plugin-mcp-reconcile.test.ts
@@ -1,0 +1,82 @@
+/**
+ * The plugin source reconcile drives MCP reload.
+ *
+ * Without this, installing a plugin leaves its `mcp.json` servers
+ * unconnected and its tools unregistered until an explicit MCP reload, a
+ * config edit, or a restart — and, worse in the other direction, an
+ * uninstalled or disabled plugin's connected client and registered tools
+ * stay callable. The reconcile is the seam every install / uninstall /
+ * upgrade / enable / disable already funnels through.
+ *
+ * The guard is equally load-bearing: a reconcile also fires for plugin
+ * edits that touch no `mcp.json`, and reloading on those would tear down
+ * every healthy workspace connection to rebuild it for nothing.
+ */
+
+import { beforeEach, describe, expect, jest, mock, test } from "bun:test";
+
+let pluginServersChanged = true;
+
+const managerStop = jest.fn(async () => {});
+const managerStart = jest.fn(async () => []);
+
+mock.module("../../mcp/effective-config.js", () => ({
+  buildEffectiveMcpConfig: () => ({
+    servers: {
+      unabyss: {
+        transport: { type: "streamable-http", url: "https://mcp.example/x" },
+        enabled: true,
+        defaultRiskLevel: "low",
+        maxTools: 20,
+        source: "plugin",
+      },
+    },
+    globalMaxTools: 50,
+  }),
+  pluginMcpServersChangedSinceLastBuild: () => pluginServersChanged,
+}));
+
+mock.module("../../mcp/manager.js", () => ({
+  getMcpServerManager: () => ({ stop: managerStop, start: managerStart }),
+}));
+
+mock.module("../../mcp/mcp-header-store.js", () => ({
+  migrateLegacyMcpHeaders: async () => {},
+}));
+
+mock.module("../../config/loader.js", () => ({
+  getConfig: () => ({ mcp: { servers: {}, globalMaxTools: 50 } }),
+  invalidateConfigCache: () => {},
+}));
+
+mock.module("../../tools/registry.js", () => ({
+  registerMcpTools: () => [],
+  unregisterAllMcpTools: () => {},
+}));
+
+const { reconcilePluginMcpServers } = await import("../mcp-reload-service.js");
+
+describe("reconcilePluginMcpServers", () => {
+  beforeEach(() => {
+    managerStop.mockClear();
+    managerStart.mockClear();
+  });
+
+  test("reloads when the plugin-declared set changed", async () => {
+    pluginServersChanged = true;
+
+    await reconcilePluginMcpServers();
+
+    expect(managerStop).toHaveBeenCalledTimes(1);
+    expect(managerStart).toHaveBeenCalledTimes(1);
+  });
+
+  test("does nothing when no plugin changed the set", async () => {
+    pluginServersChanged = false;
+
+    await reconcilePluginMcpServers();
+
+    expect(managerStop).not.toHaveBeenCalled();
+    expect(managerStart).not.toHaveBeenCalled();
+  });
+});

--- a/assistant/src/daemon/mcp-reload-service.ts
+++ b/assistant/src/daemon/mcp-reload-service.ts
@@ -6,7 +6,10 @@
  */
 
 import { getConfig, invalidateConfigCache } from "../config/loader.js";
-import { buildEffectiveMcpConfig } from "../mcp/effective-config.js";
+import {
+  buildEffectiveMcpConfig,
+  pluginMcpServersChangedSinceLastBuild,
+} from "../mcp/effective-config.js";
 import { getMcpServerManager } from "../mcp/manager.js";
 import { migrateLegacyMcpHeaders } from "../mcp/mcp-header-store.js";
 import { createMcpToolsFromServer } from "../tools/mcp/mcp-tool-factory.js";
@@ -53,6 +56,29 @@ export function reloadMcpServers(): Promise<McpReloadResult> {
   return reloadInProgress;
 }
 
+/**
+ * Reload MCP servers if — and only if — the plugin-declared set moved.
+ *
+ * Called by the plugin source reconcile, which every install / uninstall /
+ * upgrade / enable / disable already funnels through, so a plugin's MCP
+ * tools come up and go down with the plugin instead of lingering until an
+ * explicit reload, a config edit, or a restart.
+ *
+ * The guard matters: a reconcile also fires for plugin edits that touch no
+ * `mcp.json` at all, and an unconditional reload would tear down every
+ * healthy workspace connection to re-establish it for nothing.
+ *
+ * Never throws — the reconcile is best-effort and must not fail an install
+ * whose files already landed on disk.
+ */
+export async function reconcilePluginMcpServers(): Promise<void> {
+  if (!pluginMcpServersChangedSinceLastBuild()) {
+    return;
+  }
+  log.info("Plugin-declared MCP servers changed; reloading");
+  await reloadMcpServers();
+}
+
 async function doReload(): Promise<McpReloadResult> {
   try {
     const manager = getMcpServerManager();
@@ -79,9 +105,7 @@ async function doReload(): Promise<McpReloadResult> {
     // Plugins are re-read here too: installing or removing one changes the
     // server set exactly like editing config.json does, and both arrive
     // through this same reload.
-    const { config: mcpConfig, pluginServerIds } = buildEffectiveMcpConfig(
-      config.mcp,
-    );
+    const mcpConfig = buildEffectiveMcpConfig(config.mcp);
     const serverIds = Object.keys(mcpConfig.servers);
 
     // 3. Restart MCP servers
@@ -90,9 +114,7 @@ async function doReload(): Promise<McpReloadResult> {
     const servers: McpReloadServerResult[] = [];
 
     if (serverIds.length > 0) {
-      const serverToolInfos = await manager.start(mcpConfig, {
-        credentialIsolatedServerIds: pluginServerIds,
-      });
+      const serverToolInfos = await manager.start(mcpConfig);
       for (const { serverId, serverConfig, tools } of serverToolInfos) {
         const mcpTools = createMcpToolsFromServer(
           tools,

--- a/assistant/src/daemon/mcp-reload-service.ts
+++ b/assistant/src/daemon/mcp-reload-service.ts
@@ -6,6 +6,7 @@
  */
 
 import { getConfig, invalidateConfigCache } from "../config/loader.js";
+import { buildEffectiveMcpConfig } from "../mcp/effective-config.js";
 import { getMcpServerManager } from "../mcp/manager.js";
 import { migrateLegacyMcpHeaders } from "../mcp/mcp-header-store.js";
 import { createMcpToolsFromServer } from "../tools/mcp/mcp-tool-factory.js";
@@ -74,17 +75,24 @@ async function doReload(): Promise<McpReloadResult> {
     // 2. Stop existing MCP servers + unregister their tools
     await manager.stop();
     unregisterAllMcpTools();
-    const serverIds = config.mcp?.servers
-      ? Object.keys(config.mcp.servers)
-      : [];
+
+    // Plugins are re-read here too: installing or removing one changes the
+    // server set exactly like editing config.json does, and both arrive
+    // through this same reload.
+    const { config: mcpConfig, pluginServerIds } = buildEffectiveMcpConfig(
+      config.mcp,
+    );
+    const serverIds = Object.keys(mcpConfig.servers);
 
     // 3. Restart MCP servers
     let serverCount = 0;
     let toolCount = 0;
     const servers: McpReloadServerResult[] = [];
 
-    if (config.mcp?.servers && Object.keys(config.mcp.servers).length > 0) {
-      const serverToolInfos = await manager.start(config.mcp);
+    if (serverIds.length > 0) {
+      const serverToolInfos = await manager.start(mcpConfig, {
+        credentialIsolatedServerIds: pluginServerIds,
+      });
       for (const { serverId, serverConfig, tools } of serverToolInfos) {
         const mcpTools = createMcpToolsFromServer(
           tools,
@@ -105,7 +113,7 @@ async function doReload(): Promise<McpReloadResult> {
       // Include servers that were configured but failed to connect or are disabled
       for (const id of serverIds) {
         if (!servers.some((s) => s.id === id)) {
-          const serverConfig = config.mcp!.servers![id];
+          const serverConfig = mcpConfig.servers[id];
           const isDisabled = serverConfig?.enabled === false;
           servers.push({
             id,

--- a/assistant/src/daemon/providers-setup.ts
+++ b/assistant/src/daemon/providers-setup.ts
@@ -64,15 +64,11 @@ export async function initializeProvidersAndTools(
 
   // Start MCP servers — workspace-configured and plugin-declared alike —
   // and register their tools.
-  const { config: mcpConfig, pluginServerIds } = buildEffectiveMcpConfig(
-    config.mcp,
-  );
+  const mcpConfig = buildEffectiveMcpConfig(config.mcp);
   if (Object.keys(mcpConfig.servers).length > 0) {
     const manager = getMcpServerManager();
     try {
-      const serverToolInfos = await manager.start(mcpConfig, {
-        credentialIsolatedServerIds: pluginServerIds,
-      });
+      const serverToolInfos = await manager.start(mcpConfig);
       for (const { serverId, serverConfig, tools } of serverToolInfos) {
         const mcpTools = createMcpToolsFromServer(
           tools,

--- a/assistant/src/daemon/providers-setup.ts
+++ b/assistant/src/daemon/providers-setup.ts
@@ -1,6 +1,7 @@
 import { maybeDefaultSpeechToManaged } from "../config/managed-speech-defaults.js";
 import { rehydratePlatformCredentials } from "../config/platform-rehydration.js";
 import type { AssistantConfig } from "../config/types.js";
+import { buildEffectiveMcpConfig } from "../mcp/effective-config.js";
 import { getMcpServerManager } from "../mcp/manager.js";
 import { gmailMessagingProvider } from "../messaging/providers/gmail/adapter.js";
 import { outlookMessagingProvider } from "../messaging/providers/outlook/adapter.js";
@@ -61,11 +62,17 @@ export async function initializeProvidersAndTools(
     );
   }
 
-  // Start MCP servers and register their tools
-  if (config.mcp?.servers && Object.keys(config.mcp.servers).length > 0) {
+  // Start MCP servers — workspace-configured and plugin-declared alike —
+  // and register their tools.
+  const { config: mcpConfig, pluginServerIds } = buildEffectiveMcpConfig(
+    config.mcp,
+  );
+  if (Object.keys(mcpConfig.servers).length > 0) {
     const manager = getMcpServerManager();
     try {
-      const serverToolInfos = await manager.start(config.mcp);
+      const serverToolInfos = await manager.start(mcpConfig, {
+        credentialIsolatedServerIds: pluginServerIds,
+      });
       for (const { serverId, serverConfig, tools } of serverToolInfos) {
         const mcpTools = createMcpToolsFromServer(
           tools,

--- a/assistant/src/mcp/__tests__/effective-config.test.ts
+++ b/assistant/src/mcp/__tests__/effective-config.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Coverage for the config the MCP manager is actually started with.
+ *
+ * The properties worth pinning are the ones a refactor could quietly
+ * break, each of which fails silently rather than loudly:
+ *
+ * 1. Plugin servers reach the manager at all. Reading only `config.mcp`
+ *    leaves a plugin's tools missing with nothing logged.
+ * 2. A workspace entry of the same id wins, so a plugin cannot redirect a
+ *    server the user configured by hand.
+ * 3. Plugin ids come back separately, because they are what the caller
+ *    passes as `credentialIsolatedServerIds` — dropping them would send
+ *    `mcp:<id>:*` credentials to a plugin-chosen URL.
+ */
+
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import type { McpConfig } from "../../config/schemas/mcp.js";
+import { getWorkspacePluginsDir } from "../../util/platform.js";
+import { buildEffectiveMcpConfig } from "../effective-config.js";
+
+function writePlugin(name: string, mcpServers: Record<string, unknown>): void {
+  const dir = join(getWorkspacePluginsDir(), name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, "package.json"),
+    JSON.stringify({ name, version: "1.0.0" }),
+  );
+  writeFileSync(join(dir, "mcp.json"), JSON.stringify({ mcpServers }));
+}
+
+function workspaceConfig(servers: McpConfig["servers"]): McpConfig {
+  return { servers, globalMaxTools: 50 };
+}
+
+const UNABYSS = {
+  unabyss: { type: "streamable-http", url: "https://mcp.unabyss.com" },
+};
+
+describe("buildEffectiveMcpConfig", () => {
+  beforeEach(() => {
+    rmSync(getWorkspacePluginsDir(), { recursive: true, force: true });
+    mkdirSync(getWorkspacePluginsDir(), { recursive: true });
+  });
+
+  test("a plugin's server joins the set the manager starts", () => {
+    writePlugin("unabyss", UNABYSS);
+
+    const { config, pluginServerIds } = buildEffectiveMcpConfig(
+      workspaceConfig({
+        "from-workspace": {
+          transport: {
+            type: "streamable-http",
+            url: "https://config.example/mcp",
+          },
+          enabled: true,
+          defaultRiskLevel: "high",
+          maxTools: 20,
+        },
+      }),
+    );
+
+    expect(Object.keys(config.servers).sort()).toEqual([
+      "from-workspace",
+      "unabyss",
+    ]);
+    expect(config.servers.unabyss.transport).toEqual({
+      type: "streamable-http",
+      url: "https://mcp.unabyss.com",
+    });
+    expect([...pluginServerIds]).toEqual(["unabyss"]);
+  });
+
+  test("plugin servers arrive at low risk", () => {
+    writePlugin("unabyss", UNABYSS);
+
+    const { config } = buildEffectiveMcpConfig(workspaceConfig({}));
+    expect(config.servers.unabyss.defaultRiskLevel).toEqual("low");
+  });
+
+  test("a workspace server of the same id wins, and is not credential-isolated", () => {
+    writePlugin("shadowed", {
+      shadowed: { type: "streamable-http", url: "https://loses.example/mcp" },
+    });
+
+    const { config, pluginServerIds } = buildEffectiveMcpConfig(
+      workspaceConfig({
+        shadowed: {
+          transport: {
+            type: "streamable-http",
+            url: "https://wins.example/mcp",
+          },
+          enabled: true,
+          defaultRiskLevel: "high",
+          maxTools: 20,
+        },
+      }),
+    );
+
+    expect(config.servers.shadowed.transport).toEqual({
+      type: "streamable-http",
+      url: "https://wins.example/mcp",
+    });
+    // The surviving entry is the user's own, so it keeps its credentials.
+    expect(pluginServerIds.has("shadowed")).toBe(false);
+  });
+
+  test("plugin servers still load when the workspace has no mcp config", () => {
+    writePlugin("unabyss", UNABYSS);
+
+    const { config, pluginServerIds } = buildEffectiveMcpConfig(undefined);
+
+    expect(Object.keys(config.servers)).toEqual(["unabyss"]);
+    expect([...pluginServerIds]).toEqual(["unabyss"]);
+    // The schema's own default, which the manager needs to cap tool count.
+    expect(config.globalMaxTools).toEqual(50);
+  });
+
+  test("no plugins installed leaves the workspace config alone", () => {
+    const workspace = workspaceConfig({
+      "from-workspace": {
+        transport: {
+          type: "streamable-http",
+          url: "https://config.example/mcp",
+        },
+        enabled: true,
+        defaultRiskLevel: "high",
+        maxTools: 20,
+      },
+    });
+
+    const { config, pluginServerIds } = buildEffectiveMcpConfig(workspace);
+
+    expect(config.servers).toEqual(workspace.servers);
+    expect(pluginServerIds.size).toEqual(0);
+  });
+
+  test("a malformed plugin manifest does not remove workspace servers", () => {
+    const dir = join(getWorkspacePluginsDir(), "broken");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({ name: "broken", version: "1.0.0" }),
+    );
+    writeFileSync(join(dir, "mcp.json"), "{ not json");
+
+    const { config } = buildEffectiveMcpConfig(
+      workspaceConfig({
+        "from-workspace": {
+          transport: {
+            type: "streamable-http",
+            url: "https://config.example/mcp",
+          },
+          enabled: true,
+          defaultRiskLevel: "high",
+          maxTools: 20,
+        },
+      }),
+    );
+
+    expect(Object.keys(config.servers)).toEqual(["from-workspace"]);
+  });
+});

--- a/assistant/src/mcp/__tests__/effective-config.test.ts
+++ b/assistant/src/mcp/__tests__/effective-config.test.ts
@@ -8,9 +8,11 @@
  *    leaves a plugin's tools missing with nothing logged.
  * 2. A workspace entry of the same id wins, so a plugin cannot redirect a
  *    server the user configured by hand.
- * 3. Plugin ids come back separately, because they are what the caller
- *    passes as `credentialIsolatedServerIds` — dropping them would send
- *    `mcp:<id>:*` credentials to a plugin-chosen URL.
+ * 3. Every server is attributed. `source` is what `McpClient` reads to
+ *    decide whether it may resolve `mcp:<id>:*`, so a plugin server that
+ *    came out unattributed would be handed workspace credentials.
+ * 4. Change detection tracks the plugin set, since it decides whether a
+ *    plugin reconcile reloads MCP at all.
  */
 
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
@@ -19,7 +21,11 @@ import { beforeEach, describe, expect, test } from "bun:test";
 
 import type { McpConfig } from "../../config/schemas/mcp.js";
 import { getWorkspacePluginsDir } from "../../util/platform.js";
-import { buildEffectiveMcpConfig } from "../effective-config.js";
+import {
+  buildEffectiveMcpConfig,
+  pluginMcpServersChangedSinceLastBuild,
+  resetEffectiveMcpConfigForTests,
+} from "../effective-config.js";
 
 function writePlugin(name: string, mcpServers: Record<string, unknown>): void {
   const dir = join(getWorkspacePluginsDir(), name);
@@ -31,8 +37,24 @@ function writePlugin(name: string, mcpServers: Record<string, unknown>): void {
   writeFileSync(join(dir, "mcp.json"), JSON.stringify({ mcpServers }));
 }
 
+function removePlugin(name: string): void {
+  rmSync(join(getWorkspacePluginsDir(), name), {
+    recursive: true,
+    force: true,
+  });
+}
+
 function workspaceConfig(servers: McpConfig["servers"]): McpConfig {
   return { servers, globalMaxTools: 50 };
+}
+
+function workspaceServer(url: string): McpConfig["servers"][string] {
+  return {
+    transport: { type: "streamable-http", url },
+    enabled: true,
+    defaultRiskLevel: "high",
+    maxTools: 20,
+  };
 }
 
 const UNABYSS = {
@@ -43,22 +65,15 @@ describe("buildEffectiveMcpConfig", () => {
   beforeEach(() => {
     rmSync(getWorkspacePluginsDir(), { recursive: true, force: true });
     mkdirSync(getWorkspacePluginsDir(), { recursive: true });
+    resetEffectiveMcpConfigForTests();
   });
 
   test("a plugin's server joins the set the manager starts", () => {
     writePlugin("unabyss", UNABYSS);
 
-    const { config, pluginServerIds } = buildEffectiveMcpConfig(
+    const config = buildEffectiveMcpConfig(
       workspaceConfig({
-        "from-workspace": {
-          transport: {
-            type: "streamable-http",
-            url: "https://config.example/mcp",
-          },
-          enabled: true,
-          defaultRiskLevel: "high",
-          maxTools: 20,
-        },
+        "from-workspace": workspaceServer("https://config.example/mcp"),
       }),
     );
 
@@ -70,32 +85,36 @@ describe("buildEffectiveMcpConfig", () => {
       type: "streamable-http",
       url: "https://mcp.unabyss.com",
     });
-    expect([...pluginServerIds]).toEqual(["unabyss"]);
+  });
+
+  test("every server is attributed to its origin", () => {
+    writePlugin("unabyss", UNABYSS);
+
+    const config = buildEffectiveMcpConfig(
+      workspaceConfig({
+        "from-workspace": workspaceServer("https://config.example/mcp"),
+      }),
+    );
+
+    expect(config.servers.unabyss.source).toEqual("plugin");
+    expect(config.servers["from-workspace"].source).toEqual("workspace");
   });
 
   test("plugin servers arrive at low risk", () => {
     writePlugin("unabyss", UNABYSS);
 
-    const { config } = buildEffectiveMcpConfig(workspaceConfig({}));
+    const config = buildEffectiveMcpConfig(workspaceConfig({}));
     expect(config.servers.unabyss.defaultRiskLevel).toEqual("low");
   });
 
-  test("a workspace server of the same id wins, and is not credential-isolated", () => {
+  test("a workspace server of the same id wins, and stays workspace-attributed", () => {
     writePlugin("shadowed", {
       shadowed: { type: "streamable-http", url: "https://loses.example/mcp" },
     });
 
-    const { config, pluginServerIds } = buildEffectiveMcpConfig(
+    const config = buildEffectiveMcpConfig(
       workspaceConfig({
-        shadowed: {
-          transport: {
-            type: "streamable-http",
-            url: "https://wins.example/mcp",
-          },
-          enabled: true,
-          defaultRiskLevel: "high",
-          maxTools: 20,
-        },
+        shadowed: workspaceServer("https://wins.example/mcp"),
       }),
     );
 
@@ -104,37 +123,31 @@ describe("buildEffectiveMcpConfig", () => {
       url: "https://wins.example/mcp",
     });
     // The surviving entry is the user's own, so it keeps its credentials.
-    expect(pluginServerIds.has("shadowed")).toBe(false);
+    expect(config.servers.shadowed.source).toEqual("workspace");
   });
 
   test("plugin servers still load when the workspace has no mcp config", () => {
     writePlugin("unabyss", UNABYSS);
 
-    const { config, pluginServerIds } = buildEffectiveMcpConfig(undefined);
+    const config = buildEffectiveMcpConfig(undefined);
 
     expect(Object.keys(config.servers)).toEqual(["unabyss"]);
-    expect([...pluginServerIds]).toEqual(["unabyss"]);
+    expect(config.servers.unabyss.source).toEqual("plugin");
     // The schema's own default, which the manager needs to cap tool count.
     expect(config.globalMaxTools).toEqual(50);
   });
 
   test("no plugins installed leaves the workspace config alone", () => {
     const workspace = workspaceConfig({
-      "from-workspace": {
-        transport: {
-          type: "streamable-http",
-          url: "https://config.example/mcp",
-        },
-        enabled: true,
-        defaultRiskLevel: "high",
-        maxTools: 20,
-      },
+      "from-workspace": workspaceServer("https://config.example/mcp"),
     });
 
-    const { config, pluginServerIds } = buildEffectiveMcpConfig(workspace);
+    const config = buildEffectiveMcpConfig(workspace);
 
-    expect(config.servers).toEqual(workspace.servers);
-    expect(pluginServerIds.size).toEqual(0);
+    expect(Object.keys(config.servers)).toEqual(["from-workspace"]);
+    expect(config.servers["from-workspace"].transport).toEqual(
+      workspace.servers["from-workspace"].transport,
+    );
   });
 
   test("a malformed plugin manifest does not remove workspace servers", () => {
@@ -146,20 +159,80 @@ describe("buildEffectiveMcpConfig", () => {
     );
     writeFileSync(join(dir, "mcp.json"), "{ not json");
 
-    const { config } = buildEffectiveMcpConfig(
+    const config = buildEffectiveMcpConfig(
       workspaceConfig({
-        "from-workspace": {
-          transport: {
-            type: "streamable-http",
-            url: "https://config.example/mcp",
-          },
-          enabled: true,
-          defaultRiskLevel: "high",
-          maxTools: 20,
-        },
+        "from-workspace": workspaceServer("https://config.example/mcp"),
       }),
     );
 
     expect(Object.keys(config.servers)).toEqual(["from-workspace"]);
+  });
+});
+
+describe("pluginMcpServersChangedSinceLastBuild", () => {
+  beforeEach(() => {
+    rmSync(getWorkspacePluginsDir(), { recursive: true, force: true });
+    mkdirSync(getWorkspacePluginsDir(), { recursive: true });
+    resetEffectiveMcpConfigForTests();
+  });
+
+  test("true before anything has been built", () => {
+    expect(pluginMcpServersChangedSinceLastBuild()).toBe(true);
+  });
+
+  test("false right after a build", () => {
+    writePlugin("unabyss", UNABYSS);
+    buildEffectiveMcpConfig(workspaceConfig({}));
+
+    expect(pluginMcpServersChangedSinceLastBuild()).toBe(false);
+  });
+
+  test("true once a plugin is installed", () => {
+    buildEffectiveMcpConfig(workspaceConfig({}));
+    writePlugin("unabyss", UNABYSS);
+
+    expect(pluginMcpServersChangedSinceLastBuild()).toBe(true);
+  });
+
+  test("true once a plugin is uninstalled", () => {
+    writePlugin("unabyss", UNABYSS);
+    buildEffectiveMcpConfig(workspaceConfig({}));
+    removePlugin("unabyss");
+
+    expect(pluginMcpServersChangedSinceLastBuild()).toBe(true);
+  });
+
+  test("true once a plugin is disabled", () => {
+    writePlugin("unabyss", UNABYSS);
+    buildEffectiveMcpConfig(workspaceConfig({}));
+    writeFileSync(join(getWorkspacePluginsDir(), "unabyss", ".disabled"), "");
+
+    expect(pluginMcpServersChangedSinceLastBuild()).toBe(true);
+  });
+
+  test("true once a declared server's URL moves", () => {
+    writePlugin("unabyss", UNABYSS);
+    buildEffectiveMcpConfig(workspaceConfig({}));
+    writePlugin("unabyss", {
+      unabyss: {
+        type: "streamable-http",
+        url: "https://elsewhere.example/mcp",
+      },
+    });
+
+    expect(pluginMcpServersChangedSinceLastBuild()).toBe(true);
+  });
+
+  test("false for a plugin edit that touches no mcp.json", () => {
+    // The guard that keeps an unrelated plugin edit from tearing down every
+    // healthy workspace MCP connection.
+    writePlugin("unabyss", UNABYSS);
+    buildEffectiveMcpConfig(workspaceConfig({}));
+    writeFileSync(
+      join(getWorkspacePluginsDir(), "unabyss", "package.json"),
+      JSON.stringify({ name: "unabyss", version: "2.0.0" }),
+    );
+
+    expect(pluginMcpServersChangedSinceLastBuild()).toBe(false);
   });
 });

--- a/assistant/src/mcp/__tests__/plugin-server-credential-isolation.test.ts
+++ b/assistant/src/mcp/__tests__/plugin-server-credential-isolation.test.ts
@@ -5,8 +5,9 @@
  * A plugin controls both its server key and its URL, so a stored
  * credential whose id happens to match would otherwise be sent to an
  * endpoint the plugin chose. The listing route avoids this by never
- * probing a plugin server; the connect path avoids it here, by starting
- * those ids with credential resolution switched off.
+ * probing a plugin server; the connect path avoids it by reading the
+ * server's own `source`, so the rule cannot be lost by a caller that
+ * forgets to pass something.
  */
 
 import { beforeEach, describe, expect, jest, mock, test } from "bun:test";
@@ -35,12 +36,13 @@ const { McpServerManager } = await import("../manager.js");
 /** Refused immediately, so `connect` fails after the credential lookups. */
 const UNREACHABLE = "http://127.0.0.1:1/mcp";
 
-function httpServer(url: string) {
+function httpServer(source: "workspace" | "plugin") {
   return {
-    transport: { type: "streamable-http" as const, url },
+    transport: { type: "streamable-http" as const, url: UNREACHABLE },
     enabled: true,
     defaultRiskLevel: "low" as const,
     maxTools: 20,
+    source,
   };
 }
 
@@ -53,13 +55,10 @@ describe("plugin-declared MCP servers", () => {
   test("connect without resolving workspace credentials", async () => {
     const manager = new McpServerManager();
 
-    await manager.start(
-      {
-        servers: { unabyss: httpServer(UNREACHABLE) },
-        globalMaxTools: 50,
-      },
-      { credentialIsolatedServerIds: new Set(["unabyss"]) },
-    );
+    await manager.start({
+      servers: { unabyss: httpServer("plugin") },
+      globalMaxTools: 50,
+    });
 
     expect(getMcpHeaders).not.toHaveBeenCalled();
     expect(getSecureKeyAsync).not.toHaveBeenCalled();
@@ -68,13 +67,10 @@ describe("plugin-declared MCP servers", () => {
   test("workspace servers keep resolving theirs", async () => {
     const manager = new McpServerManager();
 
-    await manager.start(
-      {
-        servers: { "from-workspace": httpServer(UNREACHABLE) },
-        globalMaxTools: 50,
-      },
-      { credentialIsolatedServerIds: new Set(["unabyss"]) },
-    );
+    await manager.start({
+      servers: { "from-workspace": httpServer("workspace") },
+      globalMaxTools: 50,
+    });
 
     expect(getMcpHeaders).toHaveBeenCalledWith("from-workspace");
     expect(getSecureKeyAsync).toHaveBeenCalledWith("mcp:from-workspace:tokens");
@@ -85,16 +81,13 @@ describe("plugin-declared MCP servers", () => {
     // widen credential access for the workspace one, or vice versa.
     const manager = new McpServerManager();
 
-    await manager.start(
-      {
-        servers: {
-          unabyss: httpServer(UNREACHABLE),
-          "from-workspace": httpServer(UNREACHABLE),
-        },
-        globalMaxTools: 50,
+    await manager.start({
+      servers: {
+        unabyss: httpServer("plugin"),
+        "from-workspace": httpServer("workspace"),
       },
-      { credentialIsolatedServerIds: new Set(["unabyss"]) },
-    );
+      globalMaxTools: 50,
+    });
 
     const lookedUpIds = getMcpHeaders.mock.calls.map(([id]) => id);
     expect(lookedUpIds).toEqual(["from-workspace"]);

--- a/assistant/src/mcp/__tests__/plugin-server-credential-isolation.test.ts
+++ b/assistant/src/mcp/__tests__/plugin-server-credential-isolation.test.ts
@@ -1,0 +1,102 @@
+/**
+ * A plugin-declared server must connect without resolving
+ * `mcp:<serverId>:*` from the workspace credential store.
+ *
+ * A plugin controls both its server key and its URL, so a stored
+ * credential whose id happens to match would otherwise be sent to an
+ * endpoint the plugin chose. The listing route avoids this by never
+ * probing a plugin server; the connect path avoids it here, by starting
+ * those ids with credential resolution switched off.
+ */
+
+import { beforeEach, describe, expect, jest, mock, test } from "bun:test";
+
+const getSecureKeyAsync = jest.fn(async (_key: string) => "stored-oauth-token");
+const getMcpHeaders = jest.fn(async (_serverId: string) => ({
+  Authorization: "Bearer workspace-secret",
+}));
+
+mock.module("../../security/secure-keys.js", () => ({
+  getSecureKeyAsync,
+  setSecureKeyAsync: jest.fn(async () => true),
+  deleteSecureKeyAsync: jest.fn(async () => "deleted"),
+}));
+
+mock.module("../mcp-header-store.js", () => ({
+  getMcpHeaders,
+  setMcpHeaders: jest.fn(async () => {}),
+  deleteMcpHeaders: jest.fn(async () => true),
+}));
+
+// `McpOAuthProvider` is left real: its constructor only assigns fields, and
+// mocking the module here would bleed into the sibling provider tests.
+const { McpServerManager } = await import("../manager.js");
+
+/** Refused immediately, so `connect` fails after the credential lookups. */
+const UNREACHABLE = "http://127.0.0.1:1/mcp";
+
+function httpServer(url: string) {
+  return {
+    transport: { type: "streamable-http" as const, url },
+    enabled: true,
+    defaultRiskLevel: "low" as const,
+    maxTools: 20,
+  };
+}
+
+describe("plugin-declared MCP servers", () => {
+  beforeEach(() => {
+    getSecureKeyAsync.mockClear();
+    getMcpHeaders.mockClear();
+  });
+
+  test("connect without resolving workspace credentials", async () => {
+    const manager = new McpServerManager();
+
+    await manager.start(
+      {
+        servers: { unabyss: httpServer(UNREACHABLE) },
+        globalMaxTools: 50,
+      },
+      { credentialIsolatedServerIds: new Set(["unabyss"]) },
+    );
+
+    expect(getMcpHeaders).not.toHaveBeenCalled();
+    expect(getSecureKeyAsync).not.toHaveBeenCalled();
+  });
+
+  test("workspace servers keep resolving theirs", async () => {
+    const manager = new McpServerManager();
+
+    await manager.start(
+      {
+        servers: { "from-workspace": httpServer(UNREACHABLE) },
+        globalMaxTools: 50,
+      },
+      { credentialIsolatedServerIds: new Set(["unabyss"]) },
+    );
+
+    expect(getMcpHeaders).toHaveBeenCalledWith("from-workspace");
+    expect(getSecureKeyAsync).toHaveBeenCalledWith("mcp:from-workspace:tokens");
+  });
+
+  test("isolation is per-server, not per-start", async () => {
+    // Both kinds start together in one call — the plugin one must not
+    // widen credential access for the workspace one, or vice versa.
+    const manager = new McpServerManager();
+
+    await manager.start(
+      {
+        servers: {
+          unabyss: httpServer(UNREACHABLE),
+          "from-workspace": httpServer(UNREACHABLE),
+        },
+        globalMaxTools: 50,
+      },
+      { credentialIsolatedServerIds: new Set(["unabyss"]) },
+    );
+
+    const lookedUpIds = getMcpHeaders.mock.calls.map(([id]) => id);
+    expect(lookedUpIds).toEqual(["from-workspace"]);
+  });
+});

--- a/assistant/src/mcp/client.ts
+++ b/assistant/src/mcp/client.ts
@@ -52,8 +52,23 @@ export interface McpCallResult {
   isError: boolean;
 }
 
+export interface McpClientOptions {
+  /**
+   * Whether to resolve this server's credentials — `mcp:<serverId>:tokens`
+   * and `mcp:<serverId>:headers` — from the workspace credential store.
+   *
+   * True for workspace-configured servers, whose id and URL the user owns.
+   * False for plugin-declared servers: a plugin controls both its server
+   * key and its URL, so resolving them would send a workspace-owned
+   * credential to an endpoint the plugin chose whenever an id happens to
+   * match a stored key.
+   */
+  useStoredCredentials?: boolean;
+}
+
 export class McpClient {
   readonly serverId: string;
+  private readonly useStoredCredentials: boolean;
   private client: Client;
   private transport:
     | StdioClientTransport
@@ -73,8 +88,9 @@ export class McpClient {
     return this.connected;
   }
 
-  constructor(serverId: string) {
+  constructor(serverId: string, options: McpClientOptions = {}) {
     this.serverId = serverId;
+    this.useStoredCredentials = options.useStoredCredentials ?? true;
     this.client = new Client({
       name: "vellum-assistant",
       version: "1.0.0",
@@ -104,7 +120,7 @@ export class McpClient {
     // exist. This avoids triggering client registration during daemon
     // startup. If no tokens, try without auth: if the server requires it,
     // skip silently.
-    if (isHttpTransport) {
+    if (isHttpTransport && this.useStoredCredentials) {
       const cachedTokens = await getSecureKeyAsync(
         `mcp:${this.serverId}:tokens`,
       );
@@ -120,7 +136,7 @@ export class McpClient {
     // Resolve static auth headers from credential store, falling back to
     // any legacy headers in the transport config for backward compatibility.
     let effectiveConfig = transportConfig;
-    if (isHttpTransport) {
+    if (isHttpTransport && this.useStoredCredentials) {
       const storedHeaders = await getMcpHeaders(this.serverId);
       if (storedHeaders) {
         effectiveConfig = {

--- a/assistant/src/mcp/client.ts
+++ b/assistant/src/mcp/client.ts
@@ -5,7 +5,7 @@ import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 
-import type { McpTransport } from "../config/schemas/mcp.js";
+import type { McpServerSource, McpTransport } from "../config/schemas/mcp.js";
 import { getSecureKeyAsync } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
 import { getMcpHeaders } from "./mcp-header-store.js";
@@ -52,23 +52,14 @@ export interface McpCallResult {
   isError: boolean;
 }
 
-export interface McpClientOptions {
-  /**
-   * Whether to resolve this server's credentials — `mcp:<serverId>:tokens`
-   * and `mcp:<serverId>:headers` — from the workspace credential store.
-   *
-   * True for workspace-configured servers, whose id and URL the user owns.
-   * False for plugin-declared servers: a plugin controls both its server
-   * key and its URL, so resolving them would send a workspace-owned
-   * credential to an endpoint the plugin chose whenever an id happens to
-   * match a stored key.
-   */
-  useStoredCredentials?: boolean;
-}
-
 export class McpClient {
   readonly serverId: string;
-  private readonly useStoredCredentials: boolean;
+  /**
+   * Where this server was declared. Only a `workspace` server resolves
+   * `mcp:<serverId>:tokens` / `mcp:<serverId>:headers` from the credential
+   * store — see {@link McpServerSource} for why a plugin server must not.
+   */
+  readonly source: McpServerSource;
   private client: Client;
   private transport:
     | StdioClientTransport
@@ -88,9 +79,9 @@ export class McpClient {
     return this.connected;
   }
 
-  constructor(serverId: string, options: McpClientOptions = {}) {
+  constructor(serverId: string, source: McpServerSource = "workspace") {
     this.serverId = serverId;
-    this.useStoredCredentials = options.useStoredCredentials ?? true;
+    this.source = source;
     this.client = new Client({
       name: "vellum-assistant",
       version: "1.0.0",
@@ -115,12 +106,13 @@ export class McpClient {
     const isHttpTransport =
       transportConfig.type === "sse" ||
       transportConfig.type === "streamable-http";
+    const usesStoredCredentials = this.source === "workspace";
 
     // For HTTP transports, only attach an OAuth provider if cached tokens
     // exist. This avoids triggering client registration during daemon
     // startup. If no tokens, try without auth: if the server requires it,
     // skip silently.
-    if (isHttpTransport && this.useStoredCredentials) {
+    if (isHttpTransport && usesStoredCredentials) {
       const cachedTokens = await getSecureKeyAsync(
         `mcp:${this.serverId}:tokens`,
       );
@@ -136,7 +128,7 @@ export class McpClient {
     // Resolve static auth headers from credential store, falling back to
     // any legacy headers in the transport config for backward compatibility.
     let effectiveConfig = transportConfig;
-    if (isHttpTransport && this.useStoredCredentials) {
+    if (isHttpTransport && usesStoredCredentials) {
       const storedHeaders = await getMcpHeaders(this.serverId);
       if (storedHeaders) {
         effectiveConfig = {

--- a/assistant/src/mcp/effective-config.ts
+++ b/assistant/src/mcp/effective-config.ts
@@ -1,0 +1,78 @@
+/**
+ * The MCP configuration the daemon actually runs.
+ *
+ * Two sources contribute servers: the workspace `config.json`, which the
+ * user owns, and each installed plugin's `mcp.json`, which its author
+ * owns. Both must reach the MCP manager, so every consumer that starts
+ * servers builds its config through here rather than reading
+ * `config.mcp` directly — a path that only reads the workspace half
+ * leaves a plugin's tools silently missing.
+ *
+ * Plugin servers are projected onto the same `McpServerConfig` shape by
+ * `readPluginMcpServers`, so past this point nothing downstream needs to
+ * know where a server came from, with one exception: credentials. A
+ * plugin controls both its server key and its URL, so a plugin server
+ * must never resolve `mcp:<serverId>:*` from the credential store. That
+ * is why the plugin ids are returned alongside the merged config rather
+ * than folded into it — callers pass them to
+ * `McpServerManager.start` as `credentialIsolatedServerIds`.
+ */
+
+import { type McpConfig, McpConfigSchema } from "../config/schemas/mcp.js";
+import { readPluginMcpServers } from "../plugins/mcp-servers.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("mcp-effective-config");
+
+export interface EffectiveMcpConfig {
+  /** Workspace servers merged with every plugin-declared server. */
+  readonly config: McpConfig;
+  /** Ids within `config.servers` that came from a plugin's `mcp.json`. */
+  readonly pluginServerIds: ReadonlySet<string>;
+}
+
+/**
+ * Merge the workspace MCP config with the servers plugins declare.
+ *
+ * A workspace entry outranks a plugin's declaration of the same id: the
+ * user's own configuration is the more specific statement, and it is the
+ * one they can edit. `internal_mcp_list` applies the same precedence, so
+ * what the listing shows is what the daemon runs.
+ */
+export function buildEffectiveMcpConfig(
+  workspaceConfig?: McpConfig,
+): EffectiveMcpConfig {
+  // An absent `mcp` key still has to yield the schema's own defaults
+  // (`globalMaxTools`), since plugin servers alone are enough to need them.
+  const base = workspaceConfig ?? McpConfigSchema.parse({});
+  const servers: McpConfig["servers"] = { ...base.servers };
+  const pluginServerIds = new Set<string>();
+
+  const { servers: pluginServers, issues } = readPluginMcpServers();
+  for (const issue of issues) {
+    log.warn(
+      {
+        plugin: issue.pluginName,
+        ...(issue.serverKey && { serverKey: issue.serverKey }),
+      },
+      `Plugin MCP declaration problem: ${issue.message}`,
+    );
+  }
+
+  for (const server of pluginServers) {
+    if (Object.hasOwn(servers, server.id)) {
+      log.warn(
+        { plugin: server.pluginName, serverId: server.id },
+        "Plugin MCP server shadowed by a workspace server of the same id; skipping",
+      );
+      continue;
+    }
+    servers[server.id] = server.config;
+    pluginServerIds.add(server.id);
+  }
+
+  return {
+    config: { ...base, servers },
+    pluginServerIds,
+  };
+}

--- a/assistant/src/mcp/effective-config.ts
+++ b/assistant/src/mcp/effective-config.ts
@@ -8,28 +8,28 @@
  * `config.mcp` directly — a path that only reads the workspace half
  * leaves a plugin's tools silently missing.
  *
- * Plugin servers are projected onto the same `McpServerConfig` shape by
- * `readPluginMcpServers`, so past this point nothing downstream needs to
- * know where a server came from, with one exception: credentials. A
- * plugin controls both its server key and its URL, so a plugin server
- * must never resolve `mcp:<serverId>:*` from the credential store. That
- * is why the plugin ids are returned alongside the merged config rather
- * than folded into it — callers pass them to
- * `McpServerManager.start` as `credentialIsolatedServerIds`.
+ * Every server comes out attributed with its {@link McpServerSource}, so
+ * the one place origin still matters downstream — a plugin server must
+ * never resolve `mcp:<serverId>:*` from the credential store — reads it
+ * off the server rather than from a caller-supplied list.
  */
 
-import { type McpConfig, McpConfigSchema } from "../config/schemas/mcp.js";
+import {
+  type McpConfig,
+  McpConfigSchema,
+  type ResolvedMcpConfig,
+  type ResolvedMcpServerConfig,
+} from "../config/schemas/mcp.js";
 import { readPluginMcpServers } from "../plugins/mcp-servers.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("mcp-effective-config");
 
-export interface EffectiveMcpConfig {
-  /** Workspace servers merged with every plugin-declared server. */
-  readonly config: McpConfig;
-  /** Ids within `config.servers` that came from a plugin's `mcp.json`. */
-  readonly pluginServerIds: ReadonlySet<string>;
-}
+/**
+ * Fingerprint of the plugin-declared servers in the config last built here.
+ * Null until the first build, which happens during daemon startup.
+ */
+let lastBuiltPluginFingerprint: string | null = null;
 
 /**
  * Merge the workspace MCP config with the servers plugins declare.
@@ -41,12 +41,14 @@ export interface EffectiveMcpConfig {
  */
 export function buildEffectiveMcpConfig(
   workspaceConfig?: McpConfig,
-): EffectiveMcpConfig {
+): ResolvedMcpConfig {
   // An absent `mcp` key still has to yield the schema's own defaults
   // (`globalMaxTools`), since plugin servers alone are enough to need them.
   const base = workspaceConfig ?? McpConfigSchema.parse({});
-  const servers: McpConfig["servers"] = { ...base.servers };
-  const pluginServerIds = new Set<string>();
+  const servers: Record<string, ResolvedMcpServerConfig> = {};
+  for (const [id, config] of Object.entries(base.servers)) {
+    servers[id] = { ...config, source: "workspace" };
+  }
 
   const { servers: pluginServers, issues } = readPluginMcpServers();
   for (const issue of issues) {
@@ -68,11 +70,44 @@ export function buildEffectiveMcpConfig(
       continue;
     }
     servers[server.id] = server.config;
-    pluginServerIds.add(server.id);
   }
 
-  return {
-    config: { ...base, servers },
-    pluginServerIds,
-  };
+  lastBuiltPluginFingerprint = fingerprintPluginServers();
+
+  return { ...base, servers };
+}
+
+/**
+ * Whether the plugin-declared servers on disk differ from the ones in the
+ * config last built by {@link buildEffectiveMcpConfig}.
+ *
+ * The plugin source reconcile asks this after an install / uninstall /
+ * upgrade / enable / disable, so an MCP reload happens exactly when a
+ * plugin actually changed the server set — not on every unrelated plugin
+ * edit, which would tear down healthy workspace connections for nothing.
+ *
+ * True before the first build, since nothing has been applied yet.
+ */
+export function pluginMcpServersChangedSinceLastBuild(): boolean {
+  return fingerprintPluginServers() !== lastBuiltPluginFingerprint;
+}
+
+/**
+ * Stable digest of every plugin-declared server: its id and the config it
+ * resolves to. Covers a server appearing, disappearing, or changing its
+ * transport — a disabled or uninstalled plugin contributes nothing, so it
+ * drops out of the digest the same way a deleted `mcp.json` entry does.
+ */
+function fingerprintPluginServers(): string {
+  const { servers } = readPluginMcpServers();
+  return JSON.stringify(
+    [...servers]
+      .sort((a, b) => a.id.localeCompare(b.id))
+      .map((s) => [s.id, s.config]),
+  );
+}
+
+/** Test seam: forget the last built config, as on a fresh daemon. */
+export function resetEffectiveMcpConfigForTests(): void {
+  lastBuiltPluginFingerprint = null;
 }

--- a/assistant/src/mcp/manager.ts
+++ b/assistant/src/mcp/manager.ts
@@ -1,4 +1,7 @@
-import type { McpConfig, McpServerConfig } from "../config/schemas/mcp.js";
+import type {
+  ResolvedMcpConfig,
+  ResolvedMcpServerConfig,
+} from "../config/schemas/mcp.js";
 import { getLogger } from "../util/logger.js";
 import { McpClient, type McpToolInfo } from "./client.js";
 
@@ -6,28 +9,15 @@ const log = getLogger("mcp-manager");
 
 export interface McpServerToolInfo {
   serverId: string;
-  serverConfig: McpServerConfig;
+  serverConfig: ResolvedMcpServerConfig;
   tools: McpToolInfo[];
-}
-
-export interface McpStartOptions {
-  /**
-   * Servers that must connect without resolving `mcp:<serverId>:*` from the
-   * workspace credential store. Plugin-declared servers belong here: a
-   * plugin controls both its server key and its URL, so honoring a stored
-   * credential for one would send it to an endpoint the plugin chose.
-   */
-  credentialIsolatedServerIds?: ReadonlySet<string>;
 }
 
 export class McpServerManager {
   private clients = new Map<string, McpClient>();
-  private serverConfigs = new Map<string, McpServerConfig>();
+  private serverConfigs = new Map<string, ResolvedMcpServerConfig>();
 
-  async start(
-    config: McpConfig,
-    options: McpStartOptions = {},
-  ): Promise<McpServerToolInfo[]> {
+  async start(config: ResolvedMcpConfig): Promise<McpServerToolInfo[]> {
     const results: McpServerToolInfo[] = [];
 
     console.log(
@@ -53,10 +43,9 @@ export class McpServerManager {
             "HTTP transport — OAuth provider will be available if server requires authentication",
           );
         }
-        const client = new McpClient(serverId, {
-          useStoredCredentials:
-            !options.credentialIsolatedServerIds?.has(serverId),
-        });
+        // The server's own origin decides whether it may resolve
+        // `mcp:<serverId>:*` from the credential store.
+        const client = new McpClient(serverId, serverConfig.source);
         await client.connect(serverConfig.transport);
 
         if (!client.isConnected) {
@@ -158,7 +147,7 @@ export class McpServerManager {
 
   private filterTools(
     tools: McpToolInfo[],
-    config: McpServerConfig,
+    config: ResolvedMcpServerConfig,
   ): McpToolInfo[] {
     let filtered = tools;
 

--- a/assistant/src/mcp/manager.ts
+++ b/assistant/src/mcp/manager.ts
@@ -10,11 +10,24 @@ export interface McpServerToolInfo {
   tools: McpToolInfo[];
 }
 
+export interface McpStartOptions {
+  /**
+   * Servers that must connect without resolving `mcp:<serverId>:*` from the
+   * workspace credential store. Plugin-declared servers belong here: a
+   * plugin controls both its server key and its URL, so honoring a stored
+   * credential for one would send it to an endpoint the plugin chose.
+   */
+  credentialIsolatedServerIds?: ReadonlySet<string>;
+}
+
 export class McpServerManager {
   private clients = new Map<string, McpClient>();
   private serverConfigs = new Map<string, McpServerConfig>();
 
-  async start(config: McpConfig): Promise<McpServerToolInfo[]> {
+  async start(
+    config: McpConfig,
+    options: McpStartOptions = {},
+  ): Promise<McpServerToolInfo[]> {
     const results: McpServerToolInfo[] = [];
 
     console.log(
@@ -40,7 +53,10 @@ export class McpServerManager {
             "HTTP transport — OAuth provider will be available if server requires authentication",
           );
         }
-        const client = new McpClient(serverId);
+        const client = new McpClient(serverId, {
+          useStoredCredentials:
+            !options.credentialIsolatedServerIds?.has(serverId),
+        });
         await client.connect(serverConfig.transport);
 
         if (!client.isConnected) {

--- a/assistant/src/plugins/__tests__/mcp-servers.test.ts
+++ b/assistant/src/plugins/__tests__/mcp-servers.test.ts
@@ -137,12 +137,13 @@ describe("readPluginMcpServers", () => {
     });
   });
 
-  test("defaults plugin servers to high risk", () => {
-    // mcp.json has no risk field, and a plugin must not be able to lower
-    // the approval bar for the tools it introduces.
+  test("defaults plugin servers to low risk", () => {
+    // mcp.json has no risk field, so a host default applies. It is `low`
+    // because the review happens at install time — curated marketplace,
+    // SHA-pinned — rather than on every call.
     const dir = makePluginsDir({ unabyss: { mcpJson: VALID_MANIFEST } });
     const { servers } = readPluginMcpServers({ workspacePluginsDir: dir });
-    expect(servers[0].config.defaultRiskLevel).toEqual("high");
+    expect(servers[0].config.defaultRiskLevel).toEqual("low");
   });
 
   test("ignores a directory whose package.json is missing", () => {

--- a/assistant/src/plugins/mcp-servers.ts
+++ b/assistant/src/plugins/mcp-servers.ts
@@ -31,7 +31,10 @@
  * `mcp:<serverId>:*` credential namespace. Those keys belong to
  * workspace-configured servers, and a plugin controls both its server key
  * and its URL, so honoring them for a plugin-declared server would send a
- * workspace credential to an endpoint the plugin chose.
+ * workspace credential to an endpoint the plugin chose. On the connect
+ * path this is enforced by `McpServerManager.start`'s
+ * `credentialIsolatedServerIds`, which `buildEffectiveMcpConfig` populates
+ * with exactly the ids read here.
  */
 
 import { existsSync, readFileSync } from "node:fs";
@@ -54,12 +57,24 @@ export const PLUGIN_MCP_MANIFEST = "mcp.json";
 
 /**
  * Risk level assigned to a plugin-declared server. `mcp.json` has no risk
- * field, since the spec defines none, so the assistant's own default
- * applies. `high` matches `McpServerConfigSchema` and is the safe
- * direction: a plugin cannot lower the approval bar for the tools it
- * introduces.
+ * field, since the spec defines none, so a host default applies.
+ *
+ * `low` — so a plugin's tools run without prompting under the default
+ * auto-approve threshold — because the review happens earlier: the
+ * marketplace catalog (`plugins/marketplace.json`) is a curated whitelist
+ * of SHA-pinned entries, and installing a plugin is itself the user's
+ * decision to run the code it ships. Gating every call afterwards prompts
+ * on the tools the user installed the plugin to get.
+ *
+ * The gap this leaves is deliberate and known: a plugin installed
+ * off-marketplace straight from a GitHub URL gets the same default, and
+ * nothing recorded at install time distinguishes the two afterwards. A
+ * provenance signal is what would let this default be curation-gated
+ * rather than blanket. The user can still override per server — see the
+ * `defaultRiskLevel` field on a workspace `config.json` entry, which
+ * outranks a plugin's declaration of the same id.
  */
-const PLUGIN_SERVER_DEFAULT_RISK = "high" as const;
+const PLUGIN_SERVER_DEFAULT_RISK = "low" as const;
 
 /** Matches the `maxTools` default in `McpServerConfigSchema`. */
 const PLUGIN_SERVER_DEFAULT_MAX_TOOLS = 20;

--- a/assistant/src/plugins/mcp-servers.ts
+++ b/assistant/src/plugins/mcp-servers.ts
@@ -31,10 +31,9 @@
  * `mcp:<serverId>:*` credential namespace. Those keys belong to
  * workspace-configured servers, and a plugin controls both its server key
  * and its URL, so honoring them for a plugin-declared server would send a
- * workspace credential to an endpoint the plugin chose. On the connect
- * path this is enforced by `McpServerManager.start`'s
- * `credentialIsolatedServerIds`, which `buildEffectiveMcpConfig` populates
- * with exactly the ids read here.
+ * workspace credential to an endpoint the plugin chose. Every config built
+ * here carries `source: "plugin"`, which is what `McpClient` reads to
+ * decide, so the rule travels with the server rather than with the caller.
  */
 
 import { existsSync, readFileSync } from "node:fs";
@@ -47,7 +46,10 @@ import {
   listAllPlugins,
   type ListInstalledPluginsOptions,
 } from "../cli/lib/list-installed-plugins.js";
-import type { McpServerConfig, McpTransport } from "../config/schemas/mcp.js";
+import type {
+  McpTransport,
+  ResolvedMcpServerConfig,
+} from "../config/schemas/mcp.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("plugin-mcp-servers");
@@ -119,7 +121,7 @@ export interface PluginMcpServer {
   /** Key this server appears under in the plugin's `mcp.json`. */
   readonly serverKey: string;
   /** Projected onto the assistant's own server-config shape. */
-  readonly config: McpServerConfig;
+  readonly config: ResolvedMcpServerConfig;
 }
 
 /** A plugin's `mcp.json` that could not be used, in whole or in part. */
@@ -288,6 +290,7 @@ export function readPluginMcpServers(
           enabled: true,
           defaultRiskLevel: PLUGIN_SERVER_DEFAULT_RISK,
           maxTools: PLUGIN_SERVER_DEFAULT_MAX_TOOLS,
+          source: "plugin",
         },
       });
     }

--- a/assistant/src/plugins/mtime-cache.ts
+++ b/assistant/src/plugins/mtime-cache.ts
@@ -300,6 +300,18 @@ export async function reconcilePluginSourcesNow(): Promise<void> {
     } catch (err) {
       log.error({ err }, "plugin schedule reconcile failed");
     }
+    // Converge plugin-declared MCP servers the same way, so an install
+    // brings its `mcp.json` servers up and an uninstall/disable takes their
+    // connected clients and registered tools back down. Reloads only when
+    // the declared set actually moved. Lazily imported for the same reason
+    // as the schedule reconciler, and equally self-contained.
+    try {
+      const { reconcilePluginMcpServers } =
+        await import("../daemon/mcp-reload-service.js");
+      await reconcilePluginMcpServers();
+    } catch (err) {
+      log.error({ err }, "plugin MCP reconcile failed");
+    }
   })().finally(() => {
     reconcileInFlight = null;
   });

--- a/assistant/src/runtime/routes/mcp-auth-routes.ts
+++ b/assistant/src/runtime/routes/mcp-auth-routes.ts
@@ -19,6 +19,7 @@ import type { McpConfig, McpServerConfig } from "../../config/schemas/mcp.js";
 import { estimateToolDefinitionTokens } from "../../context/token-estimator.js";
 import { reloadMcpServers } from "../../daemon/mcp-reload-service.js";
 import { McpClient } from "../../mcp/client.js";
+import { getMcpServerManager } from "../../mcp/manager.js";
 import { orchestrateMcpOAuthConnect } from "../../mcp/mcp-auth-orchestrator.js";
 import { getMcpAuthState } from "../../mcp/mcp-auth-state.js";
 import {
@@ -237,17 +238,18 @@ interface McpServerEntry {
 }
 
 /**
- * Status reported for a plugin-declared server.
+ * Status reported for a plugin-declared server the MCP manager holds no
+ * live client for — it has not been started yet, or its connection failed.
  *
- * Plugin servers are listed but not managed: the MCP manager does not
- * connect them, so none of the health states describe them accurately.
- * They are also deliberately not health-checked. `McpClient.connect`
+ * A plugin server is never health-checked the way a workspace server is.
+ * `checkMachineReadableHealth` constructs its own `McpClient`, which
  * resolves `mcp:<serverId>:headers` and `mcp:<serverId>:tokens` from the
  * credential store, and a plugin controls both its server key and its URL,
  * so probing one would send workspace-owned credentials to an endpoint the
  * plugin chose whenever an id happens to match a stored key. Skipping the
  * probe also avoids spawning a plugin's declared stdio command as a side
- * effect of listing.
+ * effect of listing. The manager's own client — started with credentials
+ * isolated — is the only thing consulted instead.
  */
 const PLUGIN_SERVER_STATUS = "declared";
 
@@ -331,8 +333,9 @@ async function handleMcpList(_args: {
  * Project plugin-declared servers onto listing entries.
  *
  * Nothing here touches the credential store or the network: a plugin
- * server carries no auth state the assistant owns, and its status is fixed
- * (see {@link PLUGIN_SERVER_STATUS}).
+ * server carries no auth state the assistant owns, and its status comes
+ * from the manager's in-memory client rather than a probe (see
+ * {@link PLUGIN_SERVER_STATUS}).
  */
 function listPluginServerEntries(
   configEntries: [string, McpServerConfig][],
@@ -350,8 +353,10 @@ function listPluginServerEntries(
 
   // A workspace entry outranks a plugin's declaration of the same id: the
   // user's own configuration is the more specific statement, and it is the
-  // one they can edit.
+  // one they can edit. `buildEffectiveMcpConfig` applies the same
+  // precedence, so this listing describes the set the daemon actually runs.
   const workspaceIds = new Set(configEntries.map(([id]) => id));
+  const manager = getMcpServerManager();
 
   return servers
     .filter((server) => {
@@ -369,7 +374,9 @@ function listPluginServerEntries(
         .transport as Record<string, unknown>;
       return {
         id: server.id,
-        status: PLUGIN_SERVER_STATUS,
+        status: manager.getClient(server.id)?.isConnected
+          ? "connected"
+          : PLUGIN_SERVER_STATUS,
         transport: safeTransport as McpServerEntry["transport"],
         enabled: true,
         defaultRiskLevel: server.config.defaultRiskLevel,

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -18,6 +18,7 @@ wired surface.
 - [Hooks](#hooks)
 - [Tools](#tools)
 - [Schedules](#schedules)
+- [MCP servers](#mcp-servers)
 - [Marketplace — whitelisting external plugins](#marketplace--whitelisting-external-plugins)
 - [Conventions](#conventions)
 
@@ -37,13 +38,14 @@ wired surface.
 
 The external plugin loader extends the assistant by wiring these contribution surfaces.
 
-| Surface             | Directory                | Discovery                                                                      |
-| ------------------- | ------------------------ | ------------------------------------------------------------------------------ |
-| Lifecycle hooks     | `hooks/<name>.ts`        | filename → `plugin.hooks[<name>]`                                              |
-| Model-visible tools | `tools/<name>.ts`        | each file's default export → `plugin.tools[]`                                  |
-| Skills              | `skills/<id>/SKILL.md`   | picked up on disk by the skill catalog loader                                  |
-| Skill-scoped tools  | `skills/<id>/TOOLS.json` | registered only while the skill is active (see [Tools](#tools))                |
-| Schedules           | `schedules/<name>/`      | reconciled into schedule rows on install/upgrade (see [Schedules](#schedules)) |
+| Surface             | Directory                | Discovery                                                                                      |
+| ------------------- | ------------------------ | ---------------------------------------------------------------------------------------------- |
+| Lifecycle hooks     | `hooks/<name>.ts`        | filename → `plugin.hooks[<name>]`                                                              |
+| Model-visible tools | `tools/<name>.ts`        | each file's default export → `plugin.tools[]`                                                  |
+| Skills              | `skills/<id>/SKILL.md`   | picked up on disk by the skill catalog loader                                                  |
+| Skill-scoped tools  | `skills/<id>/TOOLS.json` | registered only while the skill is active (see [Tools](#tools))                                |
+| Schedules           | `schedules/<name>/`      | reconciled into schedule rows on install/upgrade (see [Schedules](#schedules))                 |
+| MCP servers         | `mcp.json`               | connected on daemon start; tools land as `mcp__<id>__<tool>` (see [MCP servers](#mcp-servers)) |
 
 ---
 
@@ -53,6 +55,7 @@ The external plugin loader extends the assistant by wiring these contribution su
 my-plugin/
 ├── package.json               # Manifest (required)
 ├── README.md                  # Optional plugin docs
+├── mcp.json                   # Optional MCP server declarations
 ├── hooks/
 │   ├── init.ts                # Bootstrap
 │   ├── shutdown.ts            # Teardown
@@ -625,6 +628,58 @@ re-links them. Users can enable/disable a declared schedule from the
 schedules UI; that override survives plugin upgrades. Rows are managed by
 the reconciler, so declared schedules cannot be edited or deleted
 imperatively: change the declaration instead.
+
+---
+
+## MCP servers
+
+A plugin declares MCP servers in a root `mcp.json`, per the [Agent Plugins
+1.0.0](https://agent-plugins.org) specification:
+
+```json
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "unabyss": { "type": "streamable-http", "url": "https://mcp.unabyss.com" }
+  }
+}
+```
+
+`stdio`, `sse`, and `streamable-http` transports are supported. In a `stdio`
+entry, `${PLUGIN_ROOT}` and `${PLUGIN_DATA}` interpolate in `args`, `env`
+values, and `cwd` — never in `command`, a URL, or a header, so a manifest
+cannot use them to build the executable path itself. `cwd` is accepted by the
+spec but has no host equivalent: it is ignored, with a warning, and the server
+runs in the daemon's working directory.
+
+The daemon connects these servers on start and registers their tools as
+`mcp__<serverId>__<tool>`, alongside workspace-configured ones. The server id
+is `<pluginName>__<serverKey>`, collapsed to just the name when the two match
+(the `unabyss` plugin above yields `mcp__unabyss__<tool>`, not
+`mcp__unabyss__unabyss__<tool>`). Installing or removing a plugin reconnects
+the set, exactly like editing `config.json` does.
+
+Three host behaviours worth knowing when authoring one:
+
+- **Risk defaults to `low`,** so the tools run without prompting under the
+  default auto-approve threshold. `mcp.json` has no risk field — the spec
+  defines none — and the review is the marketplace whitelist plus the user's
+  decision to install. A user who wants a different bar sets `defaultRiskLevel`
+  on a workspace `config.json` entry of the same id, which outranks the
+  plugin's declaration (and replaces it wholesale, transport included).
+- **A plugin cannot ship a credential.** The spec defines no portable OAuth or
+  credential-reference fields, and any `headers` in the file are literal
+  package data. A plugin server also never resolves the assistant's stored
+  `mcp:<serverId>:*` credentials: a plugin controls both its server key and its
+  URL, so honoring them would send a workspace credential to an endpoint the
+  plugin chose.
+- **Failures are isolated.** An invalid `mcp.json` disables MCP for that plugin
+  alone; an invalid individual entry disables only that entry; and an id
+  already claimed by another plugin is skipped rather than shadowing it. Each
+  case is logged, and none removes another plugin's servers.
+
+`assistant mcp list` shows plugin servers with their originating plugin, and
+`status: declared` for one the daemon holds no live connection to.
 
 ---
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -656,8 +656,10 @@ The daemon connects these servers on start and registers their tools as
 `mcp__<serverId>__<tool>`, alongside workspace-configured ones. The server id
 is `<pluginName>__<serverKey>`, collapsed to just the name when the two match
 (the `unabyss` plugin above yields `mcp__unabyss__<tool>`, not
-`mcp__unabyss__unabyss__<tool>`). Installing or removing a plugin reconnects
-the set, exactly like editing `config.json` does.
+`mcp__unabyss__unabyss__<tool>`). Installing, removing, upgrading, enabling, or
+disabling a plugin reconnects the set as part of that operation — its servers
+come up and go down with the plugin, no restart involved — exactly like editing
+`config.json` does.
 
 Three host behaviours worth knowing when authoring one:
 


### PR DESCRIPTION
## Prompt / plan

The unabyss team asked whether their plugin's MCP server could default to low risk. Investigating turned up a second, larger problem: `readPluginMcpServers()` had exactly one consumer, `internal_mcp_list`. Neither `initializeProvidersAndTools` nor `mcp-reload-service` looked past `config.mcp.servers`, so a plugin-declared server was **listed but never connected** and contributed no tools. The risk question was moot until that was wired up, so this PR does both.

### Connect them

Both start paths now build their config through a new `buildEffectiveMcpConfig` (`assistant/src/mcp/effective-config.ts`), which merges workspace servers with every plugin-declared one. A workspace entry still outranks a plugin's declaration of the same id — the same precedence the listing already applied — so what `assistant mcp list` shows is what the daemon runs. Installing or removing a plugin reconnects the set, since that arrives through the same reload as a `config.json` edit.

Connecting them must not undo the credential boundary the listing route protects. A plugin controls both its server key and its URL, so resolving `mcp:<serverId>:*` for one would send a workspace credential to an endpoint the plugin chose. `McpClient` takes a `useStoredCredentials` option, and `McpServerManager.start` switches it off for the ids that came from a plugin. The listing route now reports a plugin server's status from the manager's live client instead of a fixed `"declared"`, which keeps it honest without reintroducing the probe that would leak the credential.

### Default them to low

Plugin servers now default to `low` rather than `high`, so their tools run without prompting under the default auto-approve threshold. MCP-owned tools already fall through to the plain risk-based path in `DefaultApprovalPolicy`, so this is the difference between silent and prompt-on-every-call at default settings. The rationale is that review happens at install time — the marketplace catalog is a curated whitelist of SHA-pinned entries — rather than on every call, and `mcp.json` has no risk field to declare with (the spec defines none).

**Known gap, recorded next to the constant:** a plugin installed off-marketplace straight from a GitHub URL gets the same default, and nothing recorded at install time distinguishes the two afterwards. A provenance signal is what would let this default be curation-gated rather than blanket. A user who wants a different bar can set `defaultRiskLevel` on a workspace entry of the same id, which outranks the plugin's declaration.

Also documents the MCP surface in `plugins/README.md` — it was undocumented, and it now actually runs.

## Test plan

- New `assistant/src/mcp/__tests__/effective-config.test.ts` (6 tests): plugin servers reach the manager, workspace ids win and stay non-isolated, plugin ids come back for credential isolation, the no-`mcp`-config case still yields plugin servers plus schema defaults, and a malformed manifest doesn't remove workspace servers.
- New `assistant/src/mcp/__tests__/plugin-server-credential-isolation.test.ts` (3 tests): a plugin server connects without calling `getMcpHeaders`/`getSecureKeyAsync`, a workspace server still resolves its own, and isolation is per-server when both start in one call.
- Updated the two risk-default assertions (`plugins/__tests__/mcp-servers.test.ts`, `__tests__/mcp-list-plugin-servers.test.ts`) from `high` to `low`.
- Every affected test file passes in isolation, which is how `scripts/test.ts` runs them (one process per file, because `mock.module` is process-global). Cross-file failures visible from an ad-hoc `bun test <dir>` are pre-existing mock bleed — verified identical on `main`.
- `typecheck`, `eslint`, and `prettier` clean; pre-commit hooks passed.

## CLI verb checklist

No new routes — `internal/mcp/list` already existed and its shape is unchanged apart from the `status` value for plugin servers.

---
_Generated by [Claude Code](https://claude.ai/code/session_016DpUibHyfia8WfnPL4vCS5)_