### PR TITLE
docs(web): name the case where the compound touch signal is wrong, not just imprecise

### DIFF
--- a/clients/web/docs/PLATFORM_ADAPTATION.md
+++ b/clients/web/docs/PLATFORM_ADAPTATION.md
@@ -230,7 +230,21 @@ it too, per [`clients/AGENTS.md`](../../AGENTS.md).
 
 - **Which overlay a trigger opens** is the input axis. `ConversationActionsMenu` opens a
   `BottomSheet` under a thumb and a `Menu` under a mouse, so it reads `useTouchMobile()`. A narrow
-  desktop window keeps the dropdown, because a mouse can hit it.
+  desktop window keeps the dropdown, because a mouse can hit it. Note this is the compound, not the
+  input axis by itself, which is the known gap described [above](#input-capability): a landscape
+  tablet is coarse but roomy, so it gets the mouse-oriented branch.
+- **Whether a detail is hover-revealed or tap-opened** is the input axis *by itself*, and the case
+  where the compound is not merely imprecise but wrong. `ContextWindowIndicator` reads
+  `isPointerCoarse()`, because its alternative presentation is a hover-revealed tooltip and a coarse
+  pointer has no hover to reveal it with. The size half cannot matter when the other branch is
+  unusable at every width.
+
+  The distinction to draw when choosing between `isPointerCoarse()` and `useTouchMobile()`: ask what
+  the *other* branch does under a thumb. A bottom sheet whose alternative is an anchored popover can
+  use the compound, because a popover still works under a thumb, just less comfortably on a small
+  screen. A bottom sheet whose alternative is hover-only cannot, because there is no degraded
+  experience to fall back to, only a dead control. Reading the compound there strands every roomy
+  touch device: a tablet in either orientation, and a phone in landscape.
 - **Whether a detail pane docks beside the chat or floats over it** is the size axis. A side-by-side
   split cannot fit at 767px whatever the pointer is, so `ChatRouteContent` reads `useIsMobile()`.
 - **Safe-area padding under a full-screen sheet** is the platform axis, resolved in CSS off


### PR DESCRIPTION
## TL;DR

`PLATFORM_ADAPTATION.md` already warns that `useTouchMobile()` is a compound of size and pointer, and that a landscape tablet falls through the gap. What it did not give was a test for **when that gap is a comfort problem and when it is a dead control**. This adds one, using a case where the compound was not merely imprecise but wrong.

Docs only. No code changes.

## Why

The doc's first worked example is `ConversationActionsMenu` reading `useTouchMobile()`, introduced with "**Which overlay a trigger opens** is the input axis." Read on its own, that reads as "the input axis means `useTouchMobile()`", and the surrounding prose says the opposite: `useTouchMobile()` is the compound, `isPointerCoarse()` is the input axis.

That ambiguity has a real cost. `ContextWindowIndicator` forked on the compound, and because its alternative presentation was a hover-revealed tooltip, every touch device wider than 767px got a control it could not operate at all: no hover, no tap path, nothing. An iPad in either orientation, a phone in landscape, an Android tablet. Fixed in LUM-3197 / #40545; this is the doc change so the next surface does not repeat it.

## The test this adds

> Ask what the *other* branch does under a thumb.

- Alternative is an **anchored popover** → the compound is defensible. A popover still works under a thumb, just less comfortably on a small screen. There is a degraded experience to fall back to.
- Alternative is **hover-only** → the compound is wrong. There is no degraded experience, only a dead control, so the size half cannot matter and the surface must read `isPointerCoarse()`.

## Before / after

| | Before | After |
| --- | --- | --- |
| `ConversationActionsMenu` example | Presented as "the input axis" | Marked as the compound, with a pointer to the gap the doc already describes in *Input capability* |
| Choosing `isPointerCoarse()` vs `useTouchMobile()` | Stated as "use the compound only when both halves genuinely matter", with no test for when they do | Concrete discriminator, plus a worked example of a surface where they do not |
| The hover-only failure mode | Not covered | Named, with the devices it strands |

## Why it is safe

Documentation only. No behavioural claim is added that the code does not already implement: `ContextWindowIndicator` reads `isPointerCoarse()` on `main` as of `b9c095c1fa`. The internal anchor resolves to the existing `### Input capability` heading, and no em dashes were introduced, per the root `AGENTS.md` rule.

Related: LUM-3197 (the bug this generalises), LUM-3177 (overlay presentation moving into the design library, which is where the compound's remaining call sites are tracked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40558" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->