### PR TITLE
fix(acp): renew the Claude OAuth token instead of dead-ending on expiry (LUM-3205)

### DIFF
--- a/assistant/src/acp/__tests__/acp-claude-oauth.test.ts
+++ b/assistant/src/acp/__tests__/acp-claude-oauth.test.ts
@@ -56,11 +56,13 @@ const {
   CLAUDE_MANUAL_REDIRECT_URI,
   buildClaudeAuthorizeUrl,
   parseManualClaudeCode,
-  storeAcpClaudeTokens,
+  storeConnectedAcpClaudeTokens,
+  persistRefreshedAcpClaudeTokens,
   hasAcpClaudeToken,
   isAcpClaudeTokenExpiring,
   readAcpClaudeRefreshToken,
-  clearAcpClaudeRefreshMaterial,
+  clearAcpClaudeRefreshToken,
+  forgetAcpClaudeRenewalStateOnForeignWrite,
 } = await import("../acp-claude-oauth.js");
 
 beforeEach(() => {
@@ -161,9 +163,9 @@ describe("parseManualClaudeCode", () => {
 // storeAcpClaudeTokens
 // ---------------------------------------------------------------------------
 
-describe("storeAcpClaudeTokens", () => {
+describe("storeConnectedAcpClaudeTokens", () => {
   test("writes the access token and force-grants the acp_spawn policy (repairs a denied policy)", async () => {
-    await storeAcpClaudeTokens({ accessToken: "sk-ant-oat-token" });
+    await storeConnectedAcpClaudeTokens({ accessToken: "sk-ant-oat-token" });
 
     expect(setSecureKeyAsync).toHaveBeenCalledWith(
       ACCESS_KEY,
@@ -177,7 +179,7 @@ describe("storeAcpClaudeTokens", () => {
 
   test("persists the refresh token and an absolute expiry alongside it", async () => {
     const before = Date.now();
-    await storeAcpClaudeTokens({
+    await storeConnectedAcpClaudeTokens({
       accessToken: "sk-ant-oat-token",
       refreshToken: "refresh-me",
       expiresIn: 3600,
@@ -194,7 +196,7 @@ describe("storeAcpClaudeTokens", () => {
     vault.set(REFRESH_KEY, "old-refresh");
     vault.set(EXPIRES_KEY, String(Date.now() + 60_000));
 
-    await storeAcpClaudeTokens({ accessToken: "sk-ant-oat-fresh" });
+    await storeConnectedAcpClaudeTokens({ accessToken: "sk-ant-oat-fresh" });
 
     // Leaving the old values would pair a NEW access token with the PREVIOUS
     // connect's refresh token, which renews into the wrong credential.
@@ -206,7 +208,7 @@ describe("storeAcpClaudeTokens", () => {
     storeReturn = false;
 
     await expect(
-      storeAcpClaudeTokens({ accessToken: "sk-ant-oat-token" }),
+      storeConnectedAcpClaudeTokens({ accessToken: "sk-ant-oat-token" }),
     ).rejects.toThrow(/Failed to store/);
     expect(grantAcpSpawnPolicy).not.toHaveBeenCalled();
   });
@@ -234,16 +236,87 @@ describe("refresh material accessors", () => {
     expect(await isAcpClaudeTokenExpiring()).toBe(false);
   });
 
-  test("clearAcpClaudeRefreshMaterial drops refresh + expiry but keeps the access token", async () => {
+  test("clearAcpClaudeRefreshToken leaves the account reading as NOT connected", async () => {
     vault.set(ACCESS_KEY, "sk-ant-oat-token");
     vault.set(REFRESH_KEY, "refresh-me");
     vault.set(EXPIRES_KEY, String(Date.now() - 1000));
 
-    await clearAcpClaudeRefreshMaterial();
+    await clearAcpClaudeRefreshToken();
+
+    // The invariant, not the mechanics: after a rejected refresh the account
+    // must stop vouching for itself, or the Connect card self-dismisses and
+    // the user is stuck. Asserting only that the expiry survives would pass
+    // just as well against a helper that cleared it and broke this.
+    expect(await hasAcpClaudeToken()).toBe(false);
+    expect(await readAcpClaudeRefreshToken()).toBeNull();
+    // The expiry is what makes that answer possible, so it must survive.
+    expect(vault.get(EXPIRES_KEY)).toBeDefined();
+    expect(vault.get(ACCESS_KEY)).toBe("sk-ant-oat-token");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Writes that bypass the Connect flow
+// ---------------------------------------------------------------------------
+
+describe("forgetAcpClaudeRenewalStateOnForeignWrite", () => {
+  test("a hand-provisioned token reads as connected instead of inheriting a stale expiry", async () => {
+    // `credentials set` and friends write only the access token. The previous
+    // token's expiry would otherwise condemn a brand-new working one.
+    vault.set(EXPIRES_KEY, String(Date.now() - 1000));
+    vault.set(ACCESS_KEY, "sk-ant-oat-pasted");
+
+    await forgetAcpClaudeRenewalStateOnForeignWrite(
+      "acp",
+      "claude_oauth_token",
+    );
+
+    expect(await hasAcpClaudeToken()).toBe(true);
+    expect(vault.has(EXPIRES_KEY)).toBe(false);
+  });
+
+  test("drops the previous refresh token so it cannot overwrite the new one", async () => {
+    // Left in place, the next expiring spawn would spend this and clobber the
+    // token the user just pasted.
+    vault.set(ACCESS_KEY, "sk-ant-oat-pasted");
+    vault.set(REFRESH_KEY, "refresh-from-previous-connect");
+    vault.set(EXPIRES_KEY, String(Date.now() - 1000));
+
+    await forgetAcpClaudeRenewalStateOnForeignWrite(
+      "acp",
+      "claude_oauth_token",
+    );
 
     expect(await readAcpClaudeRefreshToken()).toBeNull();
-    expect(vault.has(EXPIRES_KEY)).toBe(false);
-    expect(vault.get(ACCESS_KEY)).toBe("sk-ant-oat-token");
+  });
+
+  test("ignores other services and fields", async () => {
+    vault.set(REFRESH_KEY, "refresh-me");
+
+    await forgetAcpClaudeRenewalStateOnForeignWrite("acp", "openai_api_key");
+    await forgetAcpClaudeRenewalStateOnForeignWrite("github", "token");
+
+    expect(vault.get(REFRESH_KEY)).toBe("refresh-me");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// persistRefreshedAcpClaudeTokens
+// ---------------------------------------------------------------------------
+
+describe("persistRefreshedAcpClaudeTokens", () => {
+  test("writes the token set WITHOUT granting the acp_spawn policy", async () => {
+    await persistRefreshedAcpClaudeTokens({
+      accessToken: "sk-ant-oat-renewed",
+      refreshToken: "refresh-rotated",
+      expiresIn: 3600,
+    });
+
+    expect(vault.get(ACCESS_KEY)).toBe("sk-ant-oat-renewed");
+    expect(vault.get(REFRESH_KEY)).toBe("refresh-rotated");
+    // A background renewal carries no user consent, so it must not restore a
+    // permission an admin removed from allowedTools.
+    expect(grantAcpSpawnPolicy).not.toHaveBeenCalled();
   });
 });
 

--- a/assistant/src/acp/__tests__/acp-claude-oauth.test.ts
+++ b/assistant/src/acp/__tests__/acp-claude-oauth.test.ts
@@ -13,12 +13,28 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 // Mocks — wired BEFORE importing the module via dynamic import.
 // ---------------------------------------------------------------------------
 
+/**
+ * Key-addressed fake vault. The module now touches THREE keys (access token,
+ * refresh token, expiry), so a single shared return value would let a test
+ * pass for the wrong reason: an expiry read that accidentally returns the
+ * access token parses to NaN and silently reads as "no expiry recorded".
+ */
+const vault = new Map<string, string>();
+const ACCESS_KEY = "credential/acp/claude_oauth_token";
+const REFRESH_KEY = "credential/acp/claude_oauth_refresh_token";
+const EXPIRES_KEY = "credential/acp/claude_oauth_expires_at";
+
 let storeReturn = true;
-let getReturn: string | undefined = undefined;
-const setSecureKeyAsync = mock(
-  async (_account: string, _value: string) => storeReturn,
+const setSecureKeyAsync = mock(async (account: string, value: string) => {
+  if (storeReturn) {
+    vault.set(account, value);
+  }
+  return storeReturn;
+});
+const getSecureKeyAsync = mock(async (account: string) => vault.get(account));
+const deleteSecureKeyAsync = mock(async (account: string) =>
+  vault.delete(account),
 );
-const getSecureKeyAsync = mock(async (_account: string) => getReturn);
 const grantAcpSpawnPolicy = mock(
   (_field: string, _usageDescription: string) => {},
 );
@@ -28,8 +44,9 @@ const acpSpawnCanReadCredential = mock((_field: string) => spawnCanRead);
 mock.module("../../security/secure-keys.js", () => ({
   setSecureKeyAsync,
   getSecureKeyAsync,
+  deleteSecureKeyAsync,
 }));
-mock.module("../prepare-agent-env.js", () => ({
+mock.module("../acp-credential-policy.js", () => ({
   grantAcpSpawnPolicy,
   acpSpawnCanReadCredential,
 }));
@@ -39,16 +56,20 @@ const {
   CLAUDE_MANUAL_REDIRECT_URI,
   buildClaudeAuthorizeUrl,
   parseManualClaudeCode,
-  storeAcpClaudeToken,
+  storeAcpClaudeTokens,
   hasAcpClaudeToken,
+  isAcpClaudeTokenExpiring,
+  readAcpClaudeRefreshToken,
+  clearAcpClaudeRefreshMaterial,
 } = await import("../acp-claude-oauth.js");
 
 beforeEach(() => {
+  vault.clear();
   storeReturn = true;
-  getReturn = undefined;
   spawnCanRead = true;
   setSecureKeyAsync.mockClear();
   getSecureKeyAsync.mockClear();
+  deleteSecureKeyAsync.mockClear();
   grantAcpSpawnPolicy.mockClear();
   acpSpawnCanReadCredential.mockClear();
 });
@@ -137,31 +158,92 @@ describe("parseManualClaudeCode", () => {
 });
 
 // ---------------------------------------------------------------------------
-// storeAcpClaudeToken
+// storeAcpClaudeTokens
 // ---------------------------------------------------------------------------
 
-describe("storeAcpClaudeToken", () => {
-  test("writes the token and force-grants the acp_spawn policy (repairs a denied policy)", async () => {
-    await storeAcpClaudeToken("sk-ant-oat-token");
+describe("storeAcpClaudeTokens", () => {
+  test("writes the access token and force-grants the acp_spawn policy (repairs a denied policy)", async () => {
+    await storeAcpClaudeTokens({ accessToken: "sk-ant-oat-token" });
 
-    expect(setSecureKeyAsync).toHaveBeenCalledTimes(1);
     expect(setSecureKeyAsync).toHaveBeenCalledWith(
-      "credential/acp/claude_oauth_token",
+      ACCESS_KEY,
       "sk-ant-oat-token",
     );
-    // grant (union), not merely ensure (preserve) — so an explicit Connect
+    // grant (union), not merely ensure (preserve), so an explicit Connect
     // repairs a credential whose allowedTools omitted acp_spawn.
     expect(grantAcpSpawnPolicy).toHaveBeenCalledTimes(1);
     expect(grantAcpSpawnPolicy.mock.calls[0][0]).toBe("claude_oauth_token");
   });
 
+  test("persists the refresh token and an absolute expiry alongside it", async () => {
+    const before = Date.now();
+    await storeAcpClaudeTokens({
+      accessToken: "sk-ant-oat-token",
+      refreshToken: "refresh-me",
+      expiresIn: 3600,
+    });
+
+    expect(vault.get(REFRESH_KEY)).toBe("refresh-me");
+    const expiresAt = Number(vault.get(EXPIRES_KEY));
+    // Absolute epoch ms roughly one hour out, not the raw `expires_in`.
+    expect(expiresAt).toBeGreaterThanOrEqual(before + 3600 * 1000);
+    expect(expiresAt).toBeLessThan(before + 3600 * 1000 + 5000);
+  });
+
+  test("clears stale refresh material when a reconnect returns none", async () => {
+    vault.set(REFRESH_KEY, "old-refresh");
+    vault.set(EXPIRES_KEY, String(Date.now() + 60_000));
+
+    await storeAcpClaudeTokens({ accessToken: "sk-ant-oat-fresh" });
+
+    // Leaving the old values would pair a NEW access token with the PREVIOUS
+    // connect's refresh token, which renews into the wrong credential.
+    expect(vault.has(REFRESH_KEY)).toBe(false);
+    expect(vault.has(EXPIRES_KEY)).toBe(false);
+  });
+
   test("throws when the secure store rejects the write", async () => {
     storeReturn = false;
 
-    await expect(storeAcpClaudeToken("sk-ant-oat-token")).rejects.toThrow(
-      /Failed to store/,
-    );
+    await expect(
+      storeAcpClaudeTokens({ accessToken: "sk-ant-oat-token" }),
+    ).rejects.toThrow(/Failed to store/);
     expect(grantAcpSpawnPolicy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Refresh material accessors
+// ---------------------------------------------------------------------------
+
+describe("refresh material accessors", () => {
+  test("isAcpClaudeTokenExpiring is false when no expiry was recorded", async () => {
+    vault.set(ACCESS_KEY, "sk-ant-oat-token");
+    // Tokens connected before expiry tracking existed must not be treated as
+    // expired, or we would discard a working credential.
+    expect(await isAcpClaudeTokenExpiring()).toBe(false);
+  });
+
+  test("isAcpClaudeTokenExpiring is true once the recorded expiry has passed", async () => {
+    vault.set(EXPIRES_KEY, String(Date.now() - 1000));
+    expect(await isAcpClaudeTokenExpiring()).toBe(true);
+  });
+
+  test("isAcpClaudeTokenExpiring ignores an unparseable expiry", async () => {
+    vault.set(EXPIRES_KEY, "not-a-number");
+    expect(await isAcpClaudeTokenExpiring()).toBe(false);
+  });
+
+  test("clearAcpClaudeRefreshMaterial drops refresh + expiry but keeps the access token", async () => {
+    vault.set(ACCESS_KEY, "sk-ant-oat-token");
+    vault.set(REFRESH_KEY, "refresh-me");
+    vault.set(EXPIRES_KEY, String(Date.now() - 1000));
+
+    await clearAcpClaudeRefreshMaterial();
+
+    expect(await readAcpClaudeRefreshToken()).toBeNull();
+    expect(vault.has(EXPIRES_KEY)).toBe(false);
+    expect(vault.get(ACCESS_KEY)).toBe("sk-ant-oat-token");
   });
 });
 
@@ -171,26 +253,23 @@ describe("storeAcpClaudeToken", () => {
 
 describe("hasAcpClaudeToken", () => {
   test("reads credential/acp/claude_oauth_token and reports true when present", async () => {
-    getReturn = "sk-ant-oat-token";
+    vault.set(ACCESS_KEY, "sk-ant-oat-token");
 
     expect(await hasAcpClaudeToken()).toBe(true);
-    expect(getSecureKeyAsync).toHaveBeenCalledWith(
-      "credential/acp/claude_oauth_token",
-    );
+    expect(getSecureKeyAsync).toHaveBeenCalledWith(ACCESS_KEY);
   });
 
   test("reports false when the vault field is absent", async () => {
-    getReturn = undefined;
     expect(await hasAcpClaudeToken()).toBe(false);
   });
 
   test("reports false for an empty stored value", async () => {
-    getReturn = "";
+    vault.set(ACCESS_KEY, "");
     expect(await hasAcpClaudeToken()).toBe(false);
   });
 
   test("reports false for a legacy Anthropic API key so Connect stays offered", async () => {
-    getReturn = "sk-ant-api03-legacy-bad-entry";
+    vault.set(ACCESS_KEY, "sk-ant-api03-legacy-bad-entry");
     expect(await hasAcpClaudeToken()).toBe(false);
   });
 
@@ -199,8 +278,36 @@ describe("hasAcpClaudeToken", () => {
     // `acp_spawn` means the broker denies the spawn read. Reporting "connected"
     // would self-dismiss the card and trap the user in a missing-token loop, so
     // it stays not-connected to keep the repair CTA visible.
-    getReturn = "sk-ant-oat-token";
+    vault.set(ACCESS_KEY, "sk-ant-oat-token");
     spawnCanRead = false;
     expect(await hasAcpClaudeToken()).toBe(false);
+  });
+
+  test("reports FALSE for an expired token with no refresh token", async () => {
+    // The regression this guards: presence alone used to answer "connected",
+    // so an expired credential reported true and the inline Connect card
+    // self-dismissed on mount, leaving a failed run with no way to act on it.
+    vault.set(ACCESS_KEY, "sk-ant-oat-token");
+    vault.set(EXPIRES_KEY, String(Date.now() - 1000));
+
+    expect(await hasAcpClaudeToken()).toBe(false);
+  });
+
+  test("reports true for an expired token that still has a refresh token", async () => {
+    // Renewable on the next spawn, so there is nothing for the user to do and
+    // no card to show.
+    vault.set(ACCESS_KEY, "sk-ant-oat-token");
+    vault.set(EXPIRES_KEY, String(Date.now() - 1000));
+    vault.set(REFRESH_KEY, "refresh-me");
+
+    expect(await hasAcpClaudeToken()).toBe(true);
+  });
+
+  test("reports true for an unexpired token with no refresh token", async () => {
+    // No refresh token is not itself a problem while the access token is live.
+    vault.set(ACCESS_KEY, "sk-ant-oat-token");
+    vault.set(EXPIRES_KEY, String(Date.now() + 60 * 60 * 1000));
+
+    expect(await hasAcpClaudeToken()).toBe(true);
   });
 });

--- a/assistant/src/acp/__tests__/claude-token-refresh.test.ts
+++ b/assistant/src/acp/__tests__/claude-token-refresh.test.ts
@@ -25,10 +25,12 @@ let refreshImpl: () => Promise<OAuth2TokenResult> = async () => {
   throw new Error("refreshOAuth2Token not stubbed for this test");
 };
 
+let spawnCanRead = true;
 const isAcpClaudeTokenExpiring = mock(async () => expiring);
 const readAcpClaudeRefreshToken = mock(async () => storedRefreshToken);
-const storeAcpClaudeTokens = mock(async (_tokens: unknown) => {});
-const clearAcpClaudeRefreshMaterial = mock(async () => {});
+const persistRefreshedAcpClaudeTokens = mock(async (_tokens: unknown) => {});
+const clearAcpClaudeRefreshToken = mock(async () => {});
+const acpSpawnCanReadCredential = mock((_field: string) => spawnCanRead);
 const refreshOAuth2Token = mock(async (..._args: unknown[]) => refreshImpl());
 
 mock.module("../acp-claude-oauth.js", () => ({
@@ -39,8 +41,11 @@ mock.module("../acp-claude-oauth.js", () => ({
   },
   isAcpClaudeTokenExpiring,
   readAcpClaudeRefreshToken,
-  storeAcpClaudeTokens,
-  clearAcpClaudeRefreshMaterial,
+  persistRefreshedAcpClaudeTokens,
+  clearAcpClaudeRefreshToken,
+}));
+mock.module("../acp-credential-policy.js", () => ({
+  acpSpawnCanReadCredential,
 }));
 mock.module("../../security/oauth2.js", () => ({ refreshOAuth2Token }));
 
@@ -50,13 +55,15 @@ const { ensureFreshAcpClaudeToken } =
 beforeEach(() => {
   expiring = false;
   storedRefreshToken = null;
+  spawnCanRead = true;
   refreshImpl = async () => {
     throw new Error("refreshOAuth2Token not stubbed for this test");
   };
   isAcpClaudeTokenExpiring.mockClear();
   readAcpClaudeRefreshToken.mockClear();
-  storeAcpClaudeTokens.mockClear();
-  clearAcpClaudeRefreshMaterial.mockClear();
+  persistRefreshedAcpClaudeTokens.mockClear();
+  clearAcpClaudeRefreshToken.mockClear();
+  acpSpawnCanReadCredential.mockClear();
   refreshOAuth2Token.mockClear();
 });
 
@@ -72,7 +79,7 @@ describe("ensureFreshAcpClaudeToken: skip paths", () => {
     await ensureFreshAcpClaudeToken();
 
     expect(refreshOAuth2Token).not.toHaveBeenCalled();
-    expect(storeAcpClaudeTokens).not.toHaveBeenCalled();
+    expect(persistRefreshedAcpClaudeTokens).not.toHaveBeenCalled();
   });
 
   test("does nothing when expiring with no refresh token stored", async () => {
@@ -84,7 +91,7 @@ describe("ensureFreshAcpClaudeToken: skip paths", () => {
     await ensureFreshAcpClaudeToken();
 
     expect(refreshOAuth2Token).not.toHaveBeenCalled();
-    expect(clearAcpClaudeRefreshMaterial).not.toHaveBeenCalled();
+    expect(clearAcpClaudeRefreshToken).not.toHaveBeenCalled();
   });
 });
 
@@ -114,7 +121,7 @@ describe("ensureFreshAcpClaudeToken: renewal", () => {
     expect(args[5]).toBe("json");
 
     // The ROTATED refresh token must be persisted, not the one we spent.
-    expect(storeAcpClaudeTokens).toHaveBeenCalledWith({
+    expect(persistRefreshedAcpClaudeTokens).toHaveBeenCalledWith({
       accessToken: "sk-ant-oat-new",
       refreshToken: "refresh-rotated",
       expiresIn: 3600,
@@ -126,20 +133,52 @@ describe("ensureFreshAcpClaudeToken: renewal", () => {
     // exchange would spend an already-invalidated token.
     expiring = true;
     storedRefreshToken = "refresh-me";
-    let resolveRefresh: (v: OAuth2TokenResult) => void = () => {};
-    refreshImpl = () =>
-      new Promise<OAuth2TokenResult>((resolve) => {
-        resolveRefresh = resolve;
-      });
+
+    // The deferred is built UP FRONT so `resolve` exists before either call
+    // runs. Capturing it inside `refreshImpl` instead would leave it unassigned
+    // until the first refresh actually starts, several awaits in, and resolving
+    // a not-yet-created promise hangs the test rather than failing it.
+    let resolveRefresh!: (v: OAuth2TokenResult) => void;
+    const gate = new Promise<OAuth2TokenResult>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    refreshImpl = () => gate;
 
     const both = Promise.all([
       ensureFreshAcpClaudeToken(),
       ensureFreshAcpClaudeToken(),
     ]);
+    // Let both calls get past their awaited storage reads and reach the
+    // deduplicator before the refresh completes; otherwise the second could
+    // start a fresh one and the test would pass or fail on timing.
+    for (let i = 0; i < 20; i++) {
+      await Promise.resolve();
+    }
     resolveRefresh({ accessToken: "sk-ant-oat-new" });
     await both;
 
     expect(refreshOAuth2Token).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Policy
+// ---------------------------------------------------------------------------
+
+describe("ensureFreshAcpClaudeToken: policy", () => {
+  test("does not refresh when the spawn policy denies reading the credential", async () => {
+    // The broker would refuse the read this renewal feeds, so spending the
+    // refresh token buys nothing. It also keeps a passive spawn from touching
+    // a credential the workspace fenced off: the renewal write must never be
+    // able to hand `acp_spawn` back a permission an admin removed.
+    expiring = true;
+    storedRefreshToken = "refresh-me";
+    spawnCanRead = false;
+
+    await ensureFreshAcpClaudeToken();
+
+    expect(refreshOAuth2Token).not.toHaveBeenCalled();
+    expect(persistRefreshedAcpClaudeTokens).not.toHaveBeenCalled();
   });
 });
 
@@ -159,8 +198,8 @@ describe("ensureFreshAcpClaudeToken: failures", () => {
 
     // Clearing is what flips hasAcpClaudeToken() to "not connected", which is
     // what keeps the Connect card on screen instead of self-dismissing.
-    expect(clearAcpClaudeRefreshMaterial).toHaveBeenCalledTimes(1);
-    expect(storeAcpClaudeTokens).not.toHaveBeenCalled();
+    expect(clearAcpClaudeRefreshToken).toHaveBeenCalledTimes(1);
+    expect(persistRefreshedAcpClaudeTokens).not.toHaveBeenCalled();
   });
 
   test("keeps refresh material on a transient failure", async () => {
@@ -173,8 +212,8 @@ describe("ensureFreshAcpClaudeToken: failures", () => {
     await ensureFreshAcpClaudeToken();
 
     // A network blip must not cost the user their stored credential.
-    expect(clearAcpClaudeRefreshMaterial).not.toHaveBeenCalled();
-    expect(storeAcpClaudeTokens).not.toHaveBeenCalled();
+    expect(clearAcpClaudeRefreshToken).not.toHaveBeenCalled();
+    expect(persistRefreshedAcpClaudeTokens).not.toHaveBeenCalled();
   });
 
   test("never throws, so a refresh outage cannot fail the spawn", async () => {

--- a/assistant/src/acp/__tests__/claude-token-refresh.test.ts
+++ b/assistant/src/acp/__tests__/claude-token-refresh.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Tests for the Claude ACP OAuth renewal policy.
+ *
+ * Storage is mocked (it belongs to `acp-claude-oauth.ts`, tested separately) so
+ * these assert only the decisions this module owns: when to spend the refresh
+ * token, what to persist, and what to tear down when the provider rejects it.
+ *
+ * `isCredentialError` is deliberately NOT mocked. Whether a failure is
+ * permanent or transient is the hinge of the whole module, and asserting it
+ * against the real classifier is the only way these tests stay honest about
+ * which thrown errors clear a user's stored credential.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { OAuth2TokenResult } from "../../security/oauth2.js";
+
+// ---------------------------------------------------------------------------
+// Mocks: wired BEFORE importing the module via dynamic import.
+// ---------------------------------------------------------------------------
+
+let expiring = false;
+let storedRefreshToken: string | null = null;
+let refreshImpl: () => Promise<OAuth2TokenResult> = async () => {
+  throw new Error("refreshOAuth2Token not stubbed for this test");
+};
+
+const isAcpClaudeTokenExpiring = mock(async () => expiring);
+const readAcpClaudeRefreshToken = mock(async () => storedRefreshToken);
+const storeAcpClaudeTokens = mock(async (_tokens: unknown) => {});
+const clearAcpClaudeRefreshMaterial = mock(async () => {});
+const refreshOAuth2Token = mock(async (..._args: unknown[]) => refreshImpl());
+
+mock.module("../acp-claude-oauth.js", () => ({
+  CLAUDE_OAUTH_CONFIG: {
+    tokenExchangeUrl: "https://platform.claude.com/v1/oauth/token",
+    clientId: "9d1c250a-e61b-44d9-88ed-5944d1962f5e",
+    tokenExchangeBodyFormat: "json",
+  },
+  isAcpClaudeTokenExpiring,
+  readAcpClaudeRefreshToken,
+  storeAcpClaudeTokens,
+  clearAcpClaudeRefreshMaterial,
+}));
+mock.module("../../security/oauth2.js", () => ({ refreshOAuth2Token }));
+
+const { ensureFreshAcpClaudeToken } =
+  await import("../claude-token-refresh.js");
+
+beforeEach(() => {
+  expiring = false;
+  storedRefreshToken = null;
+  refreshImpl = async () => {
+    throw new Error("refreshOAuth2Token not stubbed for this test");
+  };
+  isAcpClaudeTokenExpiring.mockClear();
+  readAcpClaudeRefreshToken.mockClear();
+  storeAcpClaudeTokens.mockClear();
+  clearAcpClaudeRefreshMaterial.mockClear();
+  refreshOAuth2Token.mockClear();
+});
+
+// ---------------------------------------------------------------------------
+// When renewal is skipped
+// ---------------------------------------------------------------------------
+
+describe("ensureFreshAcpClaudeToken: skip paths", () => {
+  test("does nothing while the token is still fresh", async () => {
+    expiring = false;
+    storedRefreshToken = "refresh-me";
+
+    await ensureFreshAcpClaudeToken();
+
+    expect(refreshOAuth2Token).not.toHaveBeenCalled();
+    expect(storeAcpClaudeTokens).not.toHaveBeenCalled();
+  });
+
+  test("does nothing when expiring with no refresh token stored", async () => {
+    // The pre-refresh-token connect. Nothing to spend, so the spawn proceeds
+    // and fails at the adapter as auth_required, which raises the Connect card.
+    expiring = true;
+    storedRefreshToken = null;
+
+    await ensureFreshAcpClaudeToken();
+
+    expect(refreshOAuth2Token).not.toHaveBeenCalled();
+    expect(clearAcpClaudeRefreshMaterial).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Successful renewal
+// ---------------------------------------------------------------------------
+
+describe("ensureFreshAcpClaudeToken: renewal", () => {
+  test("refreshes against Claude's token endpoint and persists the rotated set", async () => {
+    expiring = true;
+    storedRefreshToken = "refresh-me";
+    refreshImpl = async () => ({
+      accessToken: "sk-ant-oat-new",
+      refreshToken: "refresh-rotated",
+      expiresIn: 3600,
+    });
+
+    await ensureFreshAcpClaudeToken();
+
+    expect(refreshOAuth2Token).toHaveBeenCalledTimes(1);
+    const args = refreshOAuth2Token.mock.calls[0];
+    expect(args[0]).toBe("https://platform.claude.com/v1/oauth/token");
+    expect(args[1]).toBe("9d1c250a-e61b-44d9-88ed-5944d1962f5e");
+    expect(args[2]).toBe("refresh-me");
+    // PKCE public client: no secret, and Anthropic's endpoint needs a JSON body.
+    expect(args[3]).toBeUndefined();
+    expect(args[5]).toBe("json");
+
+    // The ROTATED refresh token must be persisted, not the one we spent.
+    expect(storeAcpClaudeTokens).toHaveBeenCalledWith({
+      accessToken: "sk-ant-oat-new",
+      refreshToken: "refresh-rotated",
+      expiresIn: 3600,
+    });
+  });
+
+  test("runs one refresh for concurrent spawns", async () => {
+    // Anthropic rotates the refresh token on use, so a second concurrent
+    // exchange would spend an already-invalidated token.
+    expiring = true;
+    storedRefreshToken = "refresh-me";
+    let resolveRefresh: (v: OAuth2TokenResult) => void = () => {};
+    refreshImpl = () =>
+      new Promise<OAuth2TokenResult>((resolve) => {
+        resolveRefresh = resolve;
+      });
+
+    const both = Promise.all([
+      ensureFreshAcpClaudeToken(),
+      ensureFreshAcpClaudeToken(),
+    ]);
+    resolveRefresh({ accessToken: "sk-ant-oat-new" });
+    await both;
+
+    expect(refreshOAuth2Token).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Failure handling
+// ---------------------------------------------------------------------------
+
+describe("ensureFreshAcpClaudeToken: failures", () => {
+  test("clears refresh material when the provider rejects the refresh token", async () => {
+    expiring = true;
+    storedRefreshToken = "revoked";
+    refreshImpl = async () => {
+      throw new Error("OAuth2 token refresh failed (HTTP 400 invalid_grant)");
+    };
+
+    await ensureFreshAcpClaudeToken();
+
+    // Clearing is what flips hasAcpClaudeToken() to "not connected", which is
+    // what keeps the Connect card on screen instead of self-dismissing.
+    expect(clearAcpClaudeRefreshMaterial).toHaveBeenCalledTimes(1);
+    expect(storeAcpClaudeTokens).not.toHaveBeenCalled();
+  });
+
+  test("keeps refresh material on a transient failure", async () => {
+    expiring = true;
+    storedRefreshToken = "refresh-me";
+    refreshImpl = async () => {
+      throw new Error("fetch failed: ECONNREFUSED");
+    };
+
+    await ensureFreshAcpClaudeToken();
+
+    // A network blip must not cost the user their stored credential.
+    expect(clearAcpClaudeRefreshMaterial).not.toHaveBeenCalled();
+    expect(storeAcpClaudeTokens).not.toHaveBeenCalled();
+  });
+
+  test("never throws, so a refresh outage cannot fail the spawn", async () => {
+    expiring = true;
+    storedRefreshToken = "refresh-me";
+    refreshImpl = async () => {
+      throw new Error("HTTP 401 unauthorized");
+    };
+
+    // Resolves rather than rejects: the stored token may still work, and if it
+    // does not, the adapter's auth_required is the path the user recovers by.
+    await expect(ensureFreshAcpClaudeToken()).resolves.toBeUndefined();
+  });
+});

--- a/assistant/src/acp/__tests__/prepare-agent-env.test.ts
+++ b/assistant/src/acp/__tests__/prepare-agent-env.test.ts
@@ -104,6 +104,17 @@ mock.module("../../tools/credentials/broker.js", () => ({
   },
 }));
 
+/**
+ * Token renewal runs ahead of the broker read on the claude path. It is
+ * exercised in `claude-token-refresh.test.ts`; stubbed here so this file keeps
+ * testing env injection against mocked storage only, rather than reaching a
+ * real secure-keys backend (and its credential timeout) through the import.
+ */
+const ensureFreshAcpClaudeToken = mock(async () => {});
+mock.module("../claude-token-refresh.js", () => ({
+  ensureFreshAcpClaudeToken,
+}));
+
 const { prepareAgentEnv, ACP_CLAUDE_OAUTH_MISSING_CODE } =
   await import("../prepare-agent-env.js");
 const { grantAcpSpawnPolicy } = await import("../acp-credential-policy.js");

--- a/assistant/src/acp/__tests__/prepare-agent-env.test.ts
+++ b/assistant/src/acp/__tests__/prepare-agent-env.test.ts
@@ -104,8 +104,9 @@ mock.module("../../tools/credentials/broker.js", () => ({
   },
 }));
 
-const { prepareAgentEnv, ACP_CLAUDE_OAUTH_MISSING_CODE, grantAcpSpawnPolicy } =
+const { prepareAgentEnv, ACP_CLAUDE_OAUTH_MISSING_CODE } =
   await import("../prepare-agent-env.js");
+const { grantAcpSpawnPolicy } = await import("../acp-credential-policy.js");
 
 beforeEach(() => {
   metadataStore.clear();

--- a/assistant/src/acp/acp-claude-oauth.ts
+++ b/assistant/src/acp/acp-claude-oauth.ts
@@ -6,9 +6,10 @@
  * helpers the daemon connect routes call: the loopback path builds an
  * authorize URL against a localhost redirect, while the cloud paste path
  * builds one against the manual redirect page and parses the `code#state`
- * string the user copies back. Both converge on `storeAcpClaudeTokens`, which
- * writes the `acp/claude_oauth_token` vault field the ACP broker reads at
- * spawn time and provisions the `acp_spawn` read policy.
+ * string the user copies back. Both converge on
+ * `storeConnectedAcpClaudeTokens`, which writes the `acp/claude_oauth_token`
+ * vault field the ACP broker reads at spawn time and provisions the
+ * `acp_spawn` read policy.
  *
  * It also owns the two companion fields captured by the same exchange, the
  * refresh token and the access token's expiry, plus the accessors over them.
@@ -113,23 +114,22 @@ function key(field: string): string {
 }
 
 /**
- * Store a captured Claude OAuth token set in the `acp/claude_oauth_*` vault
- * fields and provision the `acp_spawn` read policy so the broker can inject the
- * access token at spawn time. Throws when the backing store rejects the write.
+ * Write a Claude OAuth token set to the `acp/claude_oauth_*` vault fields.
+ * Throws when the backing store rejects any of the three writes.
  *
  * The refresh token and expiry are written as a SET with the access token: when
  * the provider returns neither (which we cannot rule out for this client and
  * scope), any previously stored values are cleared rather than left behind. A
  * stale refresh token paired with a newly connected access token would
- * otherwise renew into the credential from a previous connect.
+ * otherwise renew into the credential from a previous connect. That invariant
+ * is only worth as much as the writes that enforce it, so a failed companion
+ * write or clear is fatal here rather than silently leaving a mismatched set.
  *
  * Only the access-token field gets credential metadata. `serverUse` refuses any
  * field without metadata, so the refresh token and expiry stay unreachable
  * through the broker and can never be injected into a spawned agent's env.
  */
-export async function storeAcpClaudeTokens(
-  tokens: AcpClaudeTokens,
-): Promise<void> {
+async function writeTokenSet(tokens: AcpClaudeTokens): Promise<void> {
   const stored = await setSecureKeyAsync(
     key(ACP_OAUTH_TOKEN_FIELD),
     tokens.accessToken,
@@ -144,14 +144,44 @@ export async function storeAcpClaudeTokens(
     ACP_OAUTH_EXPIRES_AT_FIELD,
     expiresAt == null ? undefined : String(expiresAt),
   );
-  // Force-grant acp_spawn (union) rather than merely ensure it: an explicit
-  // Connect is a deliberate opt-in to ACP, so this repairs a credential whose
-  // explicit allowedTools omitted acp_spawn — otherwise the broker keeps denying
-  // the spawn read and the Connect card dead-loops on every auto-continue.
+}
+
+/**
+ * Persist the token set captured by an explicit "Connect Claude" flow, and
+ * provision the `acp_spawn` read policy so the broker can inject the access
+ * token at spawn time.
+ *
+ * The policy grant belongs to THIS path only. Connecting is a deliberate user
+ * opt-in to ACP, which is what makes force-granting (union) defensible: it
+ * repairs a credential whose explicit `allowedTools` omitted `acp_spawn`,
+ * without which the broker keeps denying the spawn read and the Connect card
+ * dead-loops on every auto-continue. A background token renewal carries no such
+ * consent, so it must use {@link persistRefreshedAcpClaudeTokens} instead.
+ */
+export async function storeConnectedAcpClaudeTokens(
+  tokens: AcpClaudeTokens,
+): Promise<void> {
+  await writeTokenSet(tokens);
   grantAcpSpawnPolicy(
     ACP_OAUTH_TOKEN_FIELD,
     "Claude OAuth token for ACP agent authentication",
   );
+}
+
+/**
+ * Persist a token set obtained by renewing an existing credential, leaving the
+ * read policy exactly as it was.
+ *
+ * A renewal happens on a passive spawn with no user in the loop, so it must not
+ * widen what the credential is allowed to do. Granting `acp_spawn` here would
+ * let a background refresh silently restore a permission a user or admin had
+ * explicitly removed from `allowedTools`, turning a denied credential into a
+ * readable one without anyone asking.
+ */
+export async function persistRefreshedAcpClaudeTokens(
+  tokens: AcpClaudeTokens,
+): Promise<void> {
+  await writeTokenSet(tokens);
 }
 
 /**
@@ -173,11 +203,14 @@ export async function storeAcpClaudeTokens(
  * that denied-policy case too.
  *
  * An EXPIRED token with no way to renew it is the same shape of problem, and is
- * likewise NOT connected. Presence alone used to answer this question, which
- * meant a dead token reported "connected" and the inline Connect card
- * self-dismissed the moment it mounted, leaving the user with a failed run and
- * no way to act on it. An expired token that still has a refresh token IS
- * connected: `ensureFreshAcpClaudeToken` renews it on the next spawn.
+ * likewise NOT connected: the card has to stay up so the user can reconnect,
+ * because nothing else will repair the credential. An expired token that still
+ * has a refresh token IS connected, since `ensureFreshAcpClaudeToken` renews it
+ * on the next spawn and there is nothing for the user to do.
+ *
+ * The recorded expiry is therefore load-bearing for this answer, and the code
+ * that drops refresh material must leave it in place. See
+ * {@link clearAcpClaudeRefreshToken}.
  */
 export async function hasAcpClaudeToken(): Promise<boolean> {
   const token = await getSecureKeyAsync(key(ACP_OAUTH_TOKEN_FIELD));
@@ -202,15 +235,36 @@ export async function hasAcpClaudeToken(): Promise<boolean> {
 // Read/write helpers for the two companion fields, kept here with the rest of
 // the Claude ACP credential storage. `claude-token-refresh.ts` drives them.
 
+/**
+ * Write a companion field, or delete it when there is no value.
+ *
+ * Both outcomes are checked. The store signals failure by return value rather
+ * than by throwing (`setSecureKeyAsync` returns false, `deleteSecureKeyAsync`
+ * returns `"error"` on timeout), so ignoring them would let a backend hiccup
+ * report success while leaving the three fields out of sync: an access token
+ * with no way to renew it, or worse, a NEW access token still paired with a
+ * PREVIOUS connect's refresh token, which is the exact mismatch the set-write
+ * semantics exist to prevent.
+ */
 async function writeOrClear(
   field: string,
   value: string | undefined,
 ): Promise<void> {
   if (value) {
-    await setSecureKeyAsync(key(field), value);
+    const stored = await setSecureKeyAsync(key(field), value);
+    if (!stored) {
+      throw new Error(
+        `Failed to store Claude OAuth ${field} in secure storage.`,
+      );
+    }
     return;
   }
-  await deleteSecureKeyAsync(key(field));
+  const result = await deleteSecureKeyAsync(key(field));
+  if (result === "error") {
+    throw new Error(
+      `Failed to clear Claude OAuth ${field} from secure storage.`,
+    );
+  }
 }
 
 /**
@@ -249,11 +303,60 @@ export async function hasAcpClaudeRefreshToken(): Promise<boolean> {
 }
 
 /**
- * Drop the refresh token and expiry, leaving the access token in place. Called
- * when the provider rejects the refresh token, so the connected check stops
- * reporting a credential that can no longer be renewed.
+ * Drop the refresh token, KEEPING the recorded expiry and the access token.
+ * Called when the provider rejects the refresh token.
+ *
+ * The expiry has to survive. `hasAcpClaudeToken()` reads "not connected" from
+ * the combination of an expired token and no refresh token; clearing the expiry
+ * as well would make `readExpiresAt()` return null, which
+ * {@link isAcpClaudeTokenExpiring} treats as "assume usable", and the dead
+ * credential would report itself connected and dismiss the user's only repair
+ * CTA.
  */
-export async function clearAcpClaudeRefreshMaterial(): Promise<void> {
+export async function clearAcpClaudeRefreshToken(): Promise<void> {
+  await writeOrClear(ACP_OAUTH_REFRESH_TOKEN_FIELD, undefined);
+}
+
+/**
+ * Forget everything we know about renewing the stored access token: both the
+ * refresh token and the recorded expiry.
+ *
+ * For when the access token is replaced by a path that knows nothing about
+ * either, which is every write outside the Connect flow (`credentials set`, the
+ * secret-collection route, a prompted credential). The companion fields
+ * describe the PREVIOUS token, and keeping them against a new one is wrong
+ * twice over: a stale past expiry makes a valid token report as not connected,
+ * and a stale refresh token can be spent to overwrite the token that was just
+ * pasted. Clearing both lands on "no expiry recorded", which reads as assume
+ * usable, and no renewal material, which is the truth.
+ */
+export async function forgetAcpClaudeRenewalState(): Promise<void> {
   await writeOrClear(ACP_OAUTH_REFRESH_TOKEN_FIELD, undefined);
   await writeOrClear(ACP_OAUTH_EXPIRES_AT_FIELD, undefined);
+}
+
+/**
+ * Call after ANY successful credential write that did not come from the Connect
+ * flow, so a hand-provisioned Claude token does not inherit the previous one's
+ * renewal state. A no-op for every other service and field.
+ *
+ * `storeConnectedAcpClaudeTokens` is the only writer that keeps the three
+ * `acp/claude_oauth_*` fields consistent. The generic credential writers
+ * (`credentials set`, the secret-collection route, a prompted credential) reach
+ * the access-token field directly, and the headless instructions in
+ * `prepare-agent-env.ts` actively point users at one of them, so this is a
+ * supported route rather than an edge case.
+ *
+ * Best-effort by contract: the token itself is already stored, so a failure to
+ * tidy the companion fields must not fail the caller's write. Callers log and
+ * continue.
+ */
+export async function forgetAcpClaudeRenewalStateOnForeignWrite(
+  service: string,
+  field: string,
+): Promise<void> {
+  if (service !== ACP_SERVICE || field !== ACP_OAUTH_TOKEN_FIELD) {
+    return;
+  }
+  await forgetAcpClaudeRenewalState();
 }

--- a/assistant/src/acp/acp-claude-oauth.ts
+++ b/assistant/src/acp/acp-claude-oauth.ts
@@ -6,26 +6,36 @@
  * helpers the daemon connect routes call: the loopback path builds an
  * authorize URL against a localhost redirect, while the cloud paste path
  * builds one against the manual redirect page and parses the `code#state`
- * string the user copies back. Both converge on `storeAcpClaudeToken`, which
+ * string the user copies back. Both converge on `storeAcpClaudeTokens`, which
  * writes the `acp/claude_oauth_token` vault field the ACP broker reads at
  * spawn time and provisions the `acp_spawn` read policy.
+ *
+ * It also owns the two companion fields captured by the same exchange, the
+ * refresh token and the access token's expiry, plus the accessors over them.
+ * The policy for WHEN to spend that refresh token lives next door in
+ * `claude-token-refresh.ts`.
  */
+
+import { computeExpiresAt, isTokenExpired } from "@vellumai/credential-storage";
 
 import { credentialKey } from "../security/credential-key.js";
 import type { OAuth2Config } from "../security/oauth2.js";
 import {
+  deleteSecureKeyAsync,
   getSecureKeyAsync,
   setSecureKeyAsync,
 } from "../security/secure-keys.js";
 import {
+  acpSpawnCanReadCredential,
+  grantAcpSpawnPolicy,
+} from "./acp-credential-policy.js";
+import {
+  ACP_OAUTH_EXPIRES_AT_FIELD,
+  ACP_OAUTH_REFRESH_TOKEN_FIELD,
   ACP_OAUTH_TOKEN_FIELD,
   ACP_SERVICE,
   classifyAnthropicToken,
 } from "./acp-credentials.js";
-import {
-  acpSpawnCanReadCredential,
-  grantAcpSpawnPolicy,
-} from "./prepare-agent-env.js";
 
 /**
  * Verified Claude Code public OAuth client. PKCE-only (no client secret);
@@ -90,19 +100,50 @@ export function parseManualClaudeCode(input: string): {
   };
 }
 
+/** Tokens as returned by an authorization-code exchange or a refresh. */
+export interface AcpClaudeTokens {
+  accessToken: string;
+  refreshToken?: string;
+  /** Lifetime in seconds, as the provider reports it. */
+  expiresIn?: number;
+}
+
+function key(field: string): string {
+  return credentialKey(ACP_SERVICE, field);
+}
+
 /**
- * Store a captured Claude OAuth token in the `acp/claude_oauth_token` vault
- * field and provision the `acp_spawn` read policy so the broker can inject it
- * at spawn time. Throws when the backing store rejects the write.
+ * Store a captured Claude OAuth token set in the `acp/claude_oauth_*` vault
+ * fields and provision the `acp_spawn` read policy so the broker can inject the
+ * access token at spawn time. Throws when the backing store rejects the write.
+ *
+ * The refresh token and expiry are written as a SET with the access token: when
+ * the provider returns neither (which we cannot rule out for this client and
+ * scope), any previously stored values are cleared rather than left behind. A
+ * stale refresh token paired with a newly connected access token would
+ * otherwise renew into the credential from a previous connect.
+ *
+ * Only the access-token field gets credential metadata. `serverUse` refuses any
+ * field without metadata, so the refresh token and expiry stay unreachable
+ * through the broker and can never be injected into a spawned agent's env.
  */
-export async function storeAcpClaudeToken(token: string): Promise<void> {
+export async function storeAcpClaudeTokens(
+  tokens: AcpClaudeTokens,
+): Promise<void> {
   const stored = await setSecureKeyAsync(
-    credentialKey(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD),
-    token,
+    key(ACP_OAUTH_TOKEN_FIELD),
+    tokens.accessToken,
   );
   if (!stored) {
     throw new Error("Failed to store Claude OAuth token in secure storage.");
   }
+
+  await writeOrClear(ACP_OAUTH_REFRESH_TOKEN_FIELD, tokens.refreshToken);
+  const expiresAt = computeExpiresAt(tokens.expiresIn);
+  await writeOrClear(
+    ACP_OAUTH_EXPIRES_AT_FIELD,
+    expiresAt == null ? undefined : String(expiresAt),
+  );
   // Force-grant acp_spawn (union) rather than merely ensure it: an explicit
   // Connect is a deliberate opt-in to ACP, so this repairs a credential whose
   // explicit allowedTools omitted acp_spawn — otherwise the broker keeps denying
@@ -130,15 +171,89 @@ export async function storeAcpClaudeToken(token: string): Promise<void> {
  * value but the spawn's broker read is denied, so self-dismissing the card would
  * hide the only repair CTA while every spawn keeps failing. Keep the card up in
  * that denied-policy case too.
+ *
+ * An EXPIRED token with no way to renew it is the same shape of problem, and is
+ * likewise NOT connected. Presence alone used to answer this question, which
+ * meant a dead token reported "connected" and the inline Connect card
+ * self-dismissed the moment it mounted, leaving the user with a failed run and
+ * no way to act on it. An expired token that still has a refresh token IS
+ * connected: `ensureFreshAcpClaudeToken` renews it on the next spawn.
  */
 export async function hasAcpClaudeToken(): Promise<boolean> {
-  const token = await getSecureKeyAsync(
-    credentialKey(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD),
-  );
-  return (
-    token != null &&
-    token.length > 0 &&
-    classifyAnthropicToken(token) !== "api_key" &&
-    acpSpawnCanReadCredential(ACP_OAUTH_TOKEN_FIELD)
-  );
+  const token = await getSecureKeyAsync(key(ACP_OAUTH_TOKEN_FIELD));
+  if (
+    token == null ||
+    token.length === 0 ||
+    classifyAnthropicToken(token) === "api_key" ||
+    !acpSpawnCanReadCredential(ACP_OAUTH_TOKEN_FIELD)
+  ) {
+    return false;
+  }
+  if (!(await isAcpClaudeTokenExpiring())) {
+    return true;
+  }
+  return await hasAcpClaudeRefreshToken();
+}
+
+// ---------------------------------------------------------------------------
+// Refresh material accessors
+// ---------------------------------------------------------------------------
+//
+// Read/write helpers for the two companion fields, kept here with the rest of
+// the Claude ACP credential storage. `claude-token-refresh.ts` drives them.
+
+async function writeOrClear(
+  field: string,
+  value: string | undefined,
+): Promise<void> {
+  if (value) {
+    await setSecureKeyAsync(key(field), value);
+    return;
+  }
+  await deleteSecureKeyAsync(key(field));
+}
+
+/**
+ * The stored absolute expiry in epoch milliseconds, or null when unknown.
+ *
+ * Unknown is the norm for tokens connected before the expiry was recorded, and
+ * is treated as "assume usable": we cannot tell fresh from expired, and
+ * guessing expired would refresh (or worse, discard) a perfectly good token.
+ */
+async function readExpiresAt(): Promise<number | null> {
+  const raw = await getSecureKeyAsync(key(ACP_OAUTH_EXPIRES_AT_FIELD));
+  if (!raw) {
+    return null;
+  }
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+/**
+ * Whether the stored access token is past its recorded expiry, or close enough
+ * that it should be renewed before use. False when no expiry was recorded.
+ */
+export async function isAcpClaudeTokenExpiring(): Promise<boolean> {
+  return isTokenExpired(await readExpiresAt());
+}
+
+/** The stored refresh token, or null when none was captured. */
+export async function readAcpClaudeRefreshToken(): Promise<string | null> {
+  const token = await getSecureKeyAsync(key(ACP_OAUTH_REFRESH_TOKEN_FIELD));
+  return token != null && token.length > 0 ? token : null;
+}
+
+/** Whether renewal material is on hand, without revealing it. */
+export async function hasAcpClaudeRefreshToken(): Promise<boolean> {
+  return (await readAcpClaudeRefreshToken()) != null;
+}
+
+/**
+ * Drop the refresh token and expiry, leaving the access token in place. Called
+ * when the provider rejects the refresh token, so the connected check stops
+ * reporting a credential that can no longer be renewed.
+ */
+export async function clearAcpClaudeRefreshMaterial(): Promise<void> {
+  await writeOrClear(ACP_OAUTH_REFRESH_TOKEN_FIELD, undefined);
+  await writeOrClear(ACP_OAUTH_EXPIRES_AT_FIELD, undefined);
 }

--- a/assistant/src/acp/acp-credential-policy.ts
+++ b/assistant/src/acp/acp-credential-policy.ts
@@ -1,10 +1,10 @@
 /**
  * Read-policy helpers for the `acp/<field>` credentials the ACP spawn path
- * consumes.
+ * consumes: who may read them, and whether a given read would be permitted.
  *
- * Split out of `prepare-agent-env.ts` so modules that only need the policy
- * rules (the Connect Claude flow, the token-refresh path) do not have to
- * import the env-injection module, which imports them back.
+ * Kept separate from the env-injection module that applies them so the other
+ * callers (the Connect Claude flow, the token-refresh path) can depend on the
+ * policy rules alone, without a cycle through env injection.
  */
 
 import {

--- a/assistant/src/acp/acp-credential-policy.ts
+++ b/assistant/src/acp/acp-credential-policy.ts
@@ -1,0 +1,94 @@
+/**
+ * Read-policy helpers for the `acp/<field>` credentials the ACP spawn path
+ * consumes.
+ *
+ * Split out of `prepare-agent-env.ts` so modules that only need the policy
+ * rules (the Connect Claude flow, the token-refresh path) do not have to
+ * import the env-injection module, which imports them back.
+ */
+
+import {
+  getCredentialMetadata,
+  upsertCredentialMetadata,
+} from "../tools/credentials/metadata-store.js";
+import { ACP_SERVICE } from "./acp-credentials.js";
+
+/** The only tool permitted to read `acp/<field>` credentials at spawn time. */
+export const ACP_SPAWN_TOOL = "acp_spawn";
+
+/**
+ * Ensure an `acp/<field>` credential has metadata that allows the
+ * `acp_spawn` tool to read it, but only for legacy/unmanaged cases:
+ *
+ * - No metadata at all: create with `allowedTools: ["acp_spawn"]`.
+ * - Metadata exists with an empty `allowedTools`: default provisioning
+ *   path (user ran `credentials set` without `--allowed-tools`), add it.
+ * - Metadata exists with a non-empty `allowedTools`: explicit policy set
+ *   by the user/admin. Respect it even if `acp_spawn` is absent; the
+ *   broker will deny the read and the caller decides whether that's fatal.
+ */
+export function ensureAcpCredentialPolicy(
+  field: string,
+  usageDescription: string,
+): void {
+  const meta = getCredentialMetadata(ACP_SERVICE, field);
+  if (!meta) {
+    upsertCredentialMetadata(ACP_SERVICE, field, {
+      allowedTools: [ACP_SPAWN_TOOL],
+      usageDescription,
+    });
+    return;
+  }
+  const tools = meta.allowedTools ?? [];
+  if (tools.length === 0) {
+    upsertCredentialMetadata(ACP_SERVICE, field, {
+      allowedTools: [ACP_SPAWN_TOOL],
+    });
+  }
+}
+
+/**
+ * Force-grant the `acp_spawn` read policy on `acp/<field>`, unioning it into any
+ * existing `allowedTools`. Unlike {@link ensureAcpCredentialPolicy} (which
+ * PRESERVES an explicit non-empty policy so a passive spawn can't silently widen
+ * it), this is for the EXPLICIT Connect flow: a user connecting Claude is a
+ * deliberate opt-in to `acp_spawn`, so granting it makes the CTA actually repair
+ * a policy-denied credential instead of dead-looping the missing-token card.
+ */
+export function grantAcpSpawnPolicy(
+  field: string,
+  usageDescription: string,
+): void {
+  const meta = getCredentialMetadata(ACP_SERVICE, field);
+  if (!meta) {
+    upsertCredentialMetadata(ACP_SERVICE, field, {
+      allowedTools: [ACP_SPAWN_TOOL],
+      usageDescription,
+    });
+    return;
+  }
+  const tools = meta.allowedTools ?? [];
+  if (!tools.includes(ACP_SPAWN_TOOL)) {
+    upsertCredentialMetadata(ACP_SERVICE, field, {
+      allowedTools: [...tools, ACP_SPAWN_TOOL],
+    });
+  }
+}
+
+/**
+ * Whether the `acp_spawn` broker read for `acp/<field>` would actually be
+ * permitted, mirroring {@link ensureAcpCredentialPolicy}'s grant rules: a
+ * missing or empty `allowedTools` is auto-granted `acp_spawn` at spawn time, so
+ * it can read; a non-empty explicit policy is respected as-is, so it can read
+ * only when it lists `acp_spawn`. Lets a connected-status check avoid reporting
+ * "connected" for a token the spawn is policy-denied from reading (which would
+ * otherwise hide the repair CTA and trap the user in a missing-token loop).
+ */
+export function acpSpawnCanReadCredential(field: string): boolean {
+  const meta = getCredentialMetadata(ACP_SERVICE, field);
+  if (!meta) {
+    return true;
+  }
+  const tools = meta.allowedTools ?? [];
+  return tools.length === 0 || tools.includes(ACP_SPAWN_TOOL);
+}

--- a/assistant/src/acp/acp-credentials.ts
+++ b/assistant/src/acp/acp-credentials.ts
@@ -15,6 +15,21 @@ export const ACP_SERVICE = "acp";
 export const ACP_OAUTH_TOKEN_FIELD = "claude_oauth_token";
 
 /**
+ * Companion fields to {@link ACP_OAUTH_TOKEN_FIELD}, written by the same
+ * "Connect Claude" exchange: the refresh token that renews the access token and
+ * the absolute expiry (epoch MILLISECONDS, matching `computeExpiresAt` and
+ * `isTokenExpired` in `@vellumai/credential-storage`) that says when to bother.
+ *
+ * Deliberately given NO credential metadata. `credentialBroker.serverUse`
+ * refuses any field without metadata, so these are unreachable through the
+ * broker and can never be injected into a spawned agent's env. That is the
+ * point: only the access token crosses into the child process, while the
+ * refresh token stays daemon-side for `ensureFreshAcpClaudeToken` to use.
+ */
+export const ACP_OAUTH_REFRESH_TOKEN_FIELD = "claude_oauth_refresh_token";
+export const ACP_OAUTH_EXPIRES_AT_FIELD = "claude_oauth_expires_at";
+
+/**
  * True for the ACP vault field the "Connect Claude" flow owns
  * (`acp/claude_oauth_token`). Used to route this credential to the inline
  * Connect card instead of a redundant legacy secure-prompt.

--- a/assistant/src/acp/claude-token-refresh.ts
+++ b/assistant/src/acp/claude-token-refresh.ts
@@ -28,10 +28,11 @@
  * path, so it must never be the thing that fails a spawn.
  *
  * One case is not quiet: when the provider rejects the refresh token itself
- * (revoked, or rotated out from under us), the stored refresh material is
- * cleared. That flips `hasAcpClaudeToken()` to "not connected", which is what
- * keeps the inline Connect card on screen instead of letting it self-dismiss
- * against a credential that can never be renewed.
+ * (revoked, or rotated out from under us), the stored refresh token is dropped.
+ * The recorded EXPIRY is deliberately kept, because that pair (expired, no way
+ * to renew) is what makes `hasAcpClaudeToken()` answer "not connected" and keep
+ * the inline Connect card on screen. Dropping the expiry too would make the
+ * dead credential read as unexpired and vouch for itself.
  */
 
 import {
@@ -43,11 +44,13 @@ import { refreshOAuth2Token } from "../security/oauth2.js";
 import { getLogger } from "../util/logger.js";
 import {
   CLAUDE_OAUTH_CONFIG,
-  clearAcpClaudeRefreshMaterial,
+  clearAcpClaudeRefreshToken,
   isAcpClaudeTokenExpiring,
+  persistRefreshedAcpClaudeTokens,
   readAcpClaudeRefreshToken,
-  storeAcpClaudeTokens,
 } from "./acp-claude-oauth.js";
+import { acpSpawnCanReadCredential } from "./acp-credential-policy.js";
+import { ACP_OAUTH_TOKEN_FIELD } from "./acp-credentials.js";
 
 const log = getLogger("acp:claude-token-refresh");
 
@@ -66,6 +69,13 @@ const REFRESH_KEY = "acp:claude";
  * with the credential broker, so callers re-read through it as usual.
  */
 export async function ensureFreshAcpClaudeToken(): Promise<void> {
+  // An explicit `allowedTools` that omits `acp_spawn` means the broker will
+  // deny the read this renewal exists to feed, so there is nothing to gain by
+  // spending a refresh token here. Checking first also keeps a passive spawn
+  // from touching a credential the workspace has deliberately fenced off.
+  if (!acpSpawnCanReadCredential(ACP_OAUTH_TOKEN_FIELD)) {
+    return;
+  }
   if (!(await isAcpClaudeTokenExpiring())) {
     return;
   }
@@ -110,16 +120,16 @@ async function doRefresh(refreshToken: string): Promise<string> {
       // reconnect, rather than re-attempting a grant that cannot succeed.
       log.warn(
         { err },
-        "Claude OAuth refresh token was rejected; clearing stored refresh material",
+        "Claude OAuth refresh token was rejected; dropping it so the account reads as needing a reconnect",
       );
-      await clearAcpClaudeRefreshMaterial();
+      await clearAcpClaudeRefreshToken();
     } else {
       log.warn({ err }, "Claude OAuth token refresh failed transiently");
     }
     throw err;
   }
 
-  await storeAcpClaudeTokens({
+  await persistRefreshedAcpClaudeTokens({
     accessToken: result.accessToken,
     refreshToken: result.refreshToken,
     expiresIn: result.expiresIn,

--- a/assistant/src/acp/claude-token-refresh.ts
+++ b/assistant/src/acp/claude-token-refresh.ts
@@ -1,0 +1,129 @@
+/**
+ * Renewal policy for the Claude OAuth credential the ACP spawn path injects as
+ * `CLAUDE_CODE_OAUTH_TOKEN`. Storage lives in `acp-claude-oauth.ts`; this
+ * module owns only the decision to refresh and the handling of what comes back.
+ *
+ * WHY THE DAEMON REFRESHES THIS AT ALL
+ *
+ * Setting `CLAUDE_CODE_OAUTH_TOKEN` tells the Claude Agent SDK to treat the
+ * value as a static bearer token: its own credential store and refresh
+ * machinery are skipped entirely (the SDK's credentials-file/keychain lookup is
+ * guarded on that variable being unset). The SDK does expose a host-refresh
+ * hook, `getOAuthToken`, but it is unreachable from here: `claude-agent-acp`
+ * never passes it through, and it is absent from the SDK's public typings. So
+ * with the env-var contract the adapter gives us, the daemon is the only thing
+ * that CAN renew this token. Nothing downstream will do it for us.
+ *
+ * The renewal itself is ordinary OAuth2. The Connect Claude flow authorizes
+ * against Claude Code's own public OAuth client, which issues refresh tokens,
+ * and `refreshOAuth2Token` already implements the `refresh_token` grant with
+ * retry and credential-error classification.
+ *
+ * WHAT HAPPENS WHEN RENEWAL IS NOT POSSIBLE
+ *
+ * Every failure mode here is deliberately quiet: this returns without throwing
+ * and lets the spawn proceed with whatever token is stored. A dead token then
+ * fails at the adapter as a structured ACP `auth_required`, which is the signal
+ * the re-authentication UI is built on. Renewal is the fast path, not the error
+ * path, so it must never be the thing that fails a spawn.
+ *
+ * One case is not quiet: when the provider rejects the refresh token itself
+ * (revoked, or rotated out from under us), the stored refresh material is
+ * cleared. That flips `hasAcpClaudeToken()` to "not connected", which is what
+ * keeps the inline Connect card on screen instead of letting it self-dismiss
+ * against a credential that can never be renewed.
+ */
+
+import {
+  isCredentialError,
+  RefreshDeduplicator,
+} from "@vellumai/credential-storage";
+
+import { refreshOAuth2Token } from "../security/oauth2.js";
+import { getLogger } from "../util/logger.js";
+import {
+  CLAUDE_OAUTH_CONFIG,
+  clearAcpClaudeRefreshMaterial,
+  isAcpClaudeTokenExpiring,
+  readAcpClaudeRefreshToken,
+  storeAcpClaudeTokens,
+} from "./acp-claude-oauth.js";
+
+const log = getLogger("acp:claude-token-refresh");
+
+/**
+ * Single in-flight refresh across concurrent spawns. Anthropic rotates the
+ * refresh token on use, so two parallel refreshes would race and one would
+ * invalidate the other's token.
+ */
+const deduplicator = new RefreshDeduplicator();
+const REFRESH_KEY = "acp:claude";
+
+/**
+ * Renew the stored Claude access token if it is expiring and a refresh token is
+ * available. Returns without throwing in every failure mode; see the module
+ * comment for why. Never returns the token: the plaintext read boundary stays
+ * with the credential broker, so callers re-read through it as usual.
+ */
+export async function ensureFreshAcpClaudeToken(): Promise<void> {
+  if (!(await isAcpClaudeTokenExpiring())) {
+    return;
+  }
+
+  const refreshToken = await readAcpClaudeRefreshToken();
+  if (!refreshToken) {
+    log.info(
+      "Claude OAuth token is expiring and no refresh token is stored; " +
+        "the spawn will surface auth_required so the user can reconnect",
+    );
+    return;
+  }
+
+  try {
+    await deduplicator.deduplicate(REFRESH_KEY, () => doRefresh(refreshToken));
+  } catch (err) {
+    // Already classified and logged in doRefresh. Swallowed so a refresh
+    // outage cannot fail a spawn that might still succeed on the stored token.
+    log.debug({ err }, "Claude OAuth token refresh did not complete");
+  }
+}
+
+async function doRefresh(refreshToken: string): Promise<string> {
+  log.info("Refreshing the Claude OAuth token for ACP");
+
+  let result;
+  try {
+    result = await refreshOAuth2Token(
+      CLAUDE_OAUTH_CONFIG.tokenExchangeUrl,
+      CLAUDE_OAUTH_CONFIG.clientId,
+      refreshToken,
+      // PKCE public client, so no secret. Anthropic's token endpoint takes a
+      // JSON body, matching the authorization-code exchange.
+      undefined,
+      undefined,
+      CLAUDE_OAUTH_CONFIG.tokenExchangeBodyFormat,
+    );
+  } catch (err) {
+    if (isCredentialError(err)) {
+      // The refresh token is revoked or rotated out from under us. Clear it so
+      // the connected check reports "not connected" and the user is offered a
+      // reconnect, rather than re-attempting a grant that cannot succeed.
+      log.warn(
+        { err },
+        "Claude OAuth refresh token was rejected; clearing stored refresh material",
+      );
+      await clearAcpClaudeRefreshMaterial();
+    } else {
+      log.warn({ err }, "Claude OAuth token refresh failed transiently");
+    }
+    throw err;
+  }
+
+  await storeAcpClaudeTokens({
+    accessToken: result.accessToken,
+    refreshToken: result.refreshToken,
+    expiresIn: result.expiresIn,
+  });
+  log.info("Claude OAuth token refreshed");
+  return result.accessToken;
+}

--- a/assistant/src/acp/prepare-agent-env.ts
+++ b/assistant/src/acp/prepare-agent-env.ts
@@ -15,30 +15,36 @@
  * every caller route through it before calling `manager.spawn`.
  *
  * Credential reads go through the credential broker (`serverUse`) so they
- * are policy-gated (tool allowlist) and audit-logged. This keeps
- * `prepare-agent-env.ts` off the secure-keys import allowlist — the broker
- * owns the plaintext read boundary.
+ * are policy-gated (tool allowlist) and audit-logged. Every value this module
+ * injects into a spawned agent's env comes from the broker; it never reads
+ * secure-keys itself, so the broker keeps the plaintext read boundary.
+ *
+ * One call here does reach storage outside the broker, indirectly:
+ * `ensureFreshAcpClaudeToken` renews an expiring Claude token before the
+ * broker read. It reads the refresh token and rewrites the access token in
+ * place, and returns nothing, so no plaintext crosses back into this module
+ * and the injected value is still whatever the broker hands us. See
+ * `claude-token-refresh.ts` for why the daemon has to do that renewal at all.
  */
 
 import { basename } from "node:path";
 
 import { FailedDependencyError } from "../runtime/routes/errors.js";
 import { credentialBroker } from "../tools/credentials/broker.js";
-import {
-  getCredentialMetadata,
-  upsertCredentialMetadata,
-} from "../tools/credentials/metadata-store.js";
 import { getLogger } from "../util/logger.js";
+import {
+  ACP_SPAWN_TOOL,
+  ensureAcpCredentialPolicy,
+} from "./acp-credential-policy.js";
 import {
   ACP_OAUTH_TOKEN_FIELD,
   ACP_SERVICE,
   classifyAnthropicToken,
 } from "./acp-credentials.js";
+import { ensureFreshAcpClaudeToken } from "./claude-token-refresh.js";
 import type { AcpAgentConfig } from "./types.js";
 
 const log = getLogger("acp:prepare-agent-env");
-
-const ACP_SPAWN_TOOL = "acp_spawn";
 
 /**
  * Stable, machine-readable marker carried on the `FailedDependencyError.details`
@@ -49,83 +55,6 @@ const ACP_SPAWN_TOOL = "acp_spawn";
  * `clients/web/src/domains/chat/transcript/acp-connect-affordance.tsx`.
  */
 export const ACP_CLAUDE_OAUTH_MISSING_CODE = "acp_claude_oauth_missing";
-
-/**
- * Ensure an `acp/<field>` credential has metadata that allows the
- * `acp_spawn` tool to read it, but only for legacy/unmanaged cases:
- *
- * - No metadata at all: create with `allowedTools: ["acp_spawn"]`.
- * - Metadata exists with an empty `allowedTools`: default provisioning
- *   path (user ran `credentials set` without `--allowed-tools`), add it.
- * - Metadata exists with a non-empty `allowedTools`: explicit policy set
- *   by the user/admin. Respect it even if `acp_spawn` is absent; the
- *   broker will deny the read and the caller decides whether that's fatal.
- */
-export function ensureAcpCredentialPolicy(
-  field: string,
-  usageDescription: string,
-): void {
-  const meta = getCredentialMetadata(ACP_SERVICE, field);
-  if (!meta) {
-    upsertCredentialMetadata(ACP_SERVICE, field, {
-      allowedTools: [ACP_SPAWN_TOOL],
-      usageDescription,
-    });
-    return;
-  }
-  const tools = meta.allowedTools ?? [];
-  if (tools.length === 0) {
-    upsertCredentialMetadata(ACP_SERVICE, field, {
-      allowedTools: [ACP_SPAWN_TOOL],
-    });
-  }
-}
-
-/**
- * Force-grant the `acp_spawn` read policy on `acp/<field>`, unioning it into any
- * existing `allowedTools`. Unlike {@link ensureAcpCredentialPolicy} (which
- * PRESERVES an explicit non-empty policy so a passive spawn can't silently widen
- * it), this is for the EXPLICIT Connect flow: a user connecting Claude is a
- * deliberate opt-in to `acp_spawn`, so granting it makes the CTA actually repair
- * a policy-denied credential instead of dead-looping the missing-token card.
- */
-export function grantAcpSpawnPolicy(
-  field: string,
-  usageDescription: string,
-): void {
-  const meta = getCredentialMetadata(ACP_SERVICE, field);
-  if (!meta) {
-    upsertCredentialMetadata(ACP_SERVICE, field, {
-      allowedTools: [ACP_SPAWN_TOOL],
-      usageDescription,
-    });
-    return;
-  }
-  const tools = meta.allowedTools ?? [];
-  if (!tools.includes(ACP_SPAWN_TOOL)) {
-    upsertCredentialMetadata(ACP_SERVICE, field, {
-      allowedTools: [...tools, ACP_SPAWN_TOOL],
-    });
-  }
-}
-
-/**
- * Whether the `acp_spawn` broker read for `acp/<field>` would actually be
- * permitted, mirroring {@link ensureAcpCredentialPolicy}'s grant rules: a
- * missing or empty `allowedTools` is auto-granted `acp_spawn` at spawn time, so
- * it can read; a non-empty explicit policy is respected as-is, so it can read
- * only when it lists `acp_spawn`. Lets a connected-status check avoid reporting
- * "connected" for a token the spawn is policy-denied from reading (which would
- * otherwise hide the repair CTA and trap the user in a missing-token loop).
- */
-export function acpSpawnCanReadCredential(field: string): boolean {
-  const meta = getCredentialMetadata(ACP_SERVICE, field);
-  if (!meta) {
-    return true;
-  }
-  const tools = meta.allowedTools ?? [];
-  return tools.length === 0 || tools.includes(ACP_SPAWN_TOOL);
-}
 
 /**
  * Read an `acp/<field>` credential through the broker and inject it into
@@ -244,6 +173,12 @@ export async function prepareAgentEnv(
 
     dropApiKeyOauthToken();
     if (!env.CLAUDE_CODE_OAUTH_TOKEN) {
+      // Renew an expiring vault token BEFORE the broker read, so the value we
+      // inject is the fresh one. Skipped when a config.json override is in
+      // play: that token is the user's to manage, and we hold no refresh
+      // material for it. Never throws, so a refresh outage cannot fail a spawn
+      // that the stored token might still satisfy.
+      await ensureFreshAcpClaudeToken();
       await injectCredential(
         env,
         ACP_OAUTH_TOKEN_FIELD,

--- a/assistant/src/credential-execution/prompted-credential.ts
+++ b/assistant/src/credential-execution/prompted-credential.ts
@@ -12,6 +12,7 @@
  * collected through a secure prompt.
  */
 
+import { forgetAcpClaudeRenewalStateOnForeignWrite } from "../acp/acp-claude-oauth.js";
 import {
   ACP_SERVICE,
   AcpCredentialFormatError,
@@ -202,6 +203,19 @@ export async function persistPromptedCredential(args: {
     if (!ok) {
       return { outcome: "error", message: "failed to store credential" };
     }
+  }
+
+  // A token written outside the Connect flow knows nothing about the previous
+  // one's refresh token or expiry; leaving them would either report a valid new
+  // token as disconnected or spend a stale refresh token over it. Best-effort:
+  // the credential is already stored.
+  try {
+    await forgetAcpClaudeRenewalStateOnForeignWrite(service, field);
+  } catch (err) {
+    log.warn(
+      { service, field, err },
+      "Stored credential, but failed to clear stale Claude ACP renewal state",
+    );
   }
 
   // The prompt UI never puts the value in the transcript, but the flow is

--- a/assistant/src/runtime/routes/__tests__/acp-claude-auth-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/acp-claude-auth-routes.test.ts
@@ -48,13 +48,13 @@ mock.module("../../../security/oauth2.js", () => ({
 
 const actualClaudeOauth = await import("../../../acp/acp-claude-oauth.js");
 const { CLAUDE_MANUAL_REDIRECT_URI } = actualClaudeOauth;
-const storeAcpClaudeTokenMock = mock(async (_token: string) => {});
+const storeConnectedAcpClaudeTokensMock = mock(async (_tokens: unknown) => {});
 // The connect-status route reads token presence; mock it so the route test
 // doesn't reach real secure storage.
 const hasAcpClaudeTokenMock = mock(async () => false);
 mock.module("../../../acp/acp-claude-oauth.js", () => ({
   ...actualClaudeOauth,
-  storeAcpClaudeToken: storeAcpClaudeTokenMock,
+  storeConnectedAcpClaudeTokens: storeConnectedAcpClaudeTokensMock,
   hasAcpClaudeToken: hasAcpClaudeTokenMock,
 }));
 
@@ -135,7 +135,7 @@ function deferredFlow(state: string): {
 beforeEach(() => {
   prepareOAuth2FlowMock.mockClear();
   exchangeCodeForTokensMock.mockClear();
-  storeAcpClaudeTokenMock.mockClear();
+  storeConnectedAcpClaudeTokensMock.mockClear();
   // Reset host to its default (local/loopback); cloud tests flip it on.
   getIsContainerizedMock.mockReturnValue(false);
   hasAcpClaudeTokenMock.mockClear();
@@ -223,9 +223,16 @@ describe("loopback capture", () => {
     const status = await waitForStatus(state, "connected");
     expect(status).toEqual({ status: "connected" });
 
-    // Access token persisted via storeAcpClaudeToken.
-    expect(storeAcpClaudeTokenMock).toHaveBeenCalledTimes(1);
-    expect(storeAcpClaudeTokenMock).toHaveBeenCalledWith("sk-ant-oat-access");
+    // The WHOLE token set is persisted, not just the access token: without
+    // the refresh token and expiry the credential can never renew itself.
+    expect(storeConnectedAcpClaudeTokensMock).toHaveBeenCalledTimes(1);
+    expect(storeConnectedAcpClaudeTokensMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accessToken: "sk-ant-oat-access",
+        refreshToken: "refresh-xyz",
+        expiresIn: 3600,
+      }),
+    );
   });
 
   test("flips status to error when the exchange fails", async () => {
@@ -238,7 +245,7 @@ describe("loopback capture", () => {
     const status = await waitForStatus(state, "error");
     expect(status.status).toBe("error");
     expect(status.error).toContain("token exchange failed");
-    expect(storeAcpClaudeTokenMock).not.toHaveBeenCalled();
+    expect(storeConnectedAcpClaudeTokensMock).not.toHaveBeenCalled();
   });
 });
 
@@ -331,7 +338,9 @@ describe("acp_claude_auth_exchange", () => {
     expect(call[1]).toBe("auth-code-123");
     expect(call[2]).toBe(CLAUDE_MANUAL_REDIRECT_URI);
     expect(call[3]).toBeTruthy(); // PKCE verifier from the start call
-    expect(storeAcpClaudeTokenMock).toHaveBeenCalledWith("sk-ant-oat-manual");
+    expect(storeConnectedAcpClaudeTokensMock).toHaveBeenCalledWith(
+      expect.objectContaining({ accessToken: "sk-ant-oat-manual" }),
+    );
 
     // The pending entry is consumed — a second exchange fails.
     await expect(
@@ -352,7 +361,9 @@ describe("acp_claude_auth_exchange", () => {
       string,
     ];
     expect(call[1]).toBe("raw-code-xyz");
-    expect(storeAcpClaudeTokenMock).toHaveBeenCalledWith("sk-ant-oat-manual");
+    expect(storeConnectedAcpClaudeTokensMock).toHaveBeenCalledWith(
+      expect.objectContaining({ accessToken: "sk-ant-oat-manual" }),
+    );
   });
 
   test("malformed paste (no `#`, no state) is rejected", async () => {
@@ -403,6 +414,6 @@ describe("acp_claude_auth_exchange", () => {
 
     // The flow is marked errored (not left pending) and the token is not stored.
     expect(getStatus(state).status).toBe("error");
-    expect(storeAcpClaudeTokenMock).not.toHaveBeenCalled();
+    expect(storeConnectedAcpClaudeTokensMock).not.toHaveBeenCalled();
   });
 });

--- a/assistant/src/runtime/routes/acp-claude-auth-routes.ts
+++ b/assistant/src/runtime/routes/acp-claude-auth-routes.ts
@@ -33,7 +33,7 @@ import {
   CLAUDE_OAUTH_CONFIG,
   hasAcpClaudeToken,
   parseManualClaudeCode,
-  storeAcpClaudeToken,
+  storeAcpClaudeTokens,
 } from "../../acp/acp-claude-oauth.js";
 import { getIsContainerized } from "../../config/env-registry.js";
 import {
@@ -153,7 +153,10 @@ async function handleStartLocalAuth(): Promise<StartResponse> {
   // can react. Runs in the background — the web client opens `authorize_url`.
   void flow.completion
     .then(async (result) => {
-      await storeAcpClaudeToken(result.tokens.accessToken);
+      // Persist the whole token set, not just the access token: the refresh
+      // token is what lets a later spawn renew this credential instead of
+      // dead-ending on an expired-token 401.
+      await storeAcpClaudeTokens(result.tokens);
       markFlow(flow.state, "connected");
       log.info("ACP Claude local OAuth flow connected");
     })
@@ -245,7 +248,8 @@ async function handleExchange(args: RouteHandlerArgs): Promise<{ ok: true }> {
       pending.codeVerifier,
       state,
     );
-    await storeAcpClaudeToken(result.tokens.accessToken);
+    // Whole token set, for the same reason as the loopback path above.
+    await storeAcpClaudeTokens(result.tokens);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     markFlow(state, "error", message);

--- a/assistant/src/runtime/routes/acp-claude-auth-routes.ts
+++ b/assistant/src/runtime/routes/acp-claude-auth-routes.ts
@@ -33,7 +33,7 @@ import {
   CLAUDE_OAUTH_CONFIG,
   hasAcpClaudeToken,
   parseManualClaudeCode,
-  storeAcpClaudeTokens,
+  storeConnectedAcpClaudeTokens,
 } from "../../acp/acp-claude-oauth.js";
 import { getIsContainerized } from "../../config/env-registry.js";
 import {
@@ -156,7 +156,7 @@ async function handleStartLocalAuth(): Promise<StartResponse> {
       // Persist the whole token set, not just the access token: the refresh
       // token is what lets a later spawn renew this credential instead of
       // dead-ending on an expired-token 401.
-      await storeAcpClaudeTokens(result.tokens);
+      await storeConnectedAcpClaudeTokens(result.tokens);
       markFlow(flow.state, "connected");
       log.info("ACP Claude local OAuth flow connected");
     })
@@ -249,7 +249,7 @@ async function handleExchange(args: RouteHandlerArgs): Promise<{ ok: true }> {
       state,
     );
     // Whole token set, for the same reason as the loopback path above.
-    await storeAcpClaudeTokens(result.tokens);
+    await storeConnectedAcpClaudeTokens(result.tokens);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     markFlow(state, "error", message);

--- a/assistant/src/runtime/routes/credential-routes.ts
+++ b/assistant/src/runtime/routes/credential-routes.ts
@@ -16,6 +16,7 @@
 
 import { z } from "zod";
 
+import { forgetAcpClaudeRenewalStateOnForeignWrite } from "../../acp/acp-claude-oauth.js";
 import {
   ACP_SERVICE,
   AcpCredentialFormatError,
@@ -483,6 +484,19 @@ async function handleCredentialsSet({ body }: RouteHandlerArgs) {
   if (!stored) {
     throw new InternalError(
       `Failed to store credential in secure storage (backend: ${getActiveBackendName()})`,
+    );
+  }
+
+  // A token written outside the Connect flow knows nothing about the previous
+  // one's refresh token or expiry; leaving them would either report a valid new
+  // token as disconnected or spend a stale refresh token over it. Best-effort:
+  // the credential is already stored, so tidying must not fail this write.
+  try {
+    await forgetAcpClaudeRenewalStateOnForeignWrite(service, field);
+  } catch (err) {
+    log.warn(
+      { service, field, err },
+      "Stored credential, but failed to clear stale Claude ACP renewal state",
     );
   }
 

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -9,6 +9,7 @@
 
 import { z } from "zod";
 
+import { forgetAcpClaudeRenewalStateOnForeignWrite } from "../../acp/acp-claude-oauth.js";
 import {
   ACP_SERVICE,
   AcpCredentialFormatError,
@@ -375,6 +376,19 @@ async function handleAddSecret({ body }: RouteHandlerArgs) {
         if (!stored) {
           throw new InternalError(
             `Failed to store credential in secure storage (backend: ${getActiveBackendName()})`,
+          );
+        }
+
+        // A token written outside the Connect flow knows nothing about the
+        // previous one's refresh token or expiry; leaving them would either
+        // report a valid new token as disconnected or spend a stale refresh
+        // token over it. Best-effort: the credential is already stored.
+        try {
+          await forgetAcpClaudeRenewalStateOnForeignWrite(service, field);
+        } catch (err) {
+          log.warn(
+            { service, field, err },
+            "Stored credential, but failed to clear stale Claude ACP renewal state",
           );
         }
         if (!isNonSecretPlatformField(service, field)) {


### PR DESCRIPTION
## TL;DR

When a Claude Code delegation failed because the OAuth token had expired, there was no way to recover: the token could not be renewed, and the UI could not even offer a reconnect. This PR fixes the renewal half. The re-authentication UI is a follow-up that builds on the expiry tracking added here.

Part of [LUM-3205](https://linear.app/vellum/issue/LUM-3205/claude-acp-failures-do-not-expose-an-actionable-re-authentication-path).

## Why the token could never renew

Three findings, each verified against the code and the installed adapter:

1. **We threw away the refresh token.** `exchangeCodeForTokens` returns `refreshToken` and `expiresIn`. Both connect paths persisted only `result.tokens.accessToken`.
2. **The child process cannot renew it either.** Setting `CLAUDE_CODE_OAUTH_TOKEN` tells the Claude Agent SDK to treat the value as a static bearer token. Its own credentials-file/keychain lookup is guarded on that variable being *unset*, so injecting it opts the child out of the SDK's refresh machinery entirely.
3. **The SDK's host-refresh hook is unreachable.** The SDK does accept a `getOAuthToken` option (it sets `CLAUDE_CODE_SDK_HAS_OAUTH_REFRESH=1`), but `claude-agent-acp` never passes it through, and it is absent from the SDK's public typings.

So with the env-var contract the adapter gives us, the daemon is the only thing that *can* renew this token.

Renewal itself is ordinary OAuth2, and the existing `refreshOAuth2Token` already implements the `refresh_token` grant with retry and credential-error classification. Our flow authorizes against OAuth client `9d1c250a-...`, which is Claude Code's own public client, and that client demonstrably issues refresh tokens.

## Design

**Two writers, because consent differs.** `storeConnectedAcpClaudeTokens` persists the token set *and* force-unions `acp_spawn` into `allowedTools`. That grant is defensible only for an explicit Connect, which is a deliberate user opt-in, and it exists to repair a credential whose policy would otherwise dead-loop the card. `persistRefreshedAcpClaudeTokens` writes the same fields and touches no policy: a renewal happens on a passive spawn with nobody in the loop, so it must never restore a permission an admin removed. Renewal is also skipped outright when `acpSpawnCanReadCredential()` is false, so a fenced-off credential is never touched and no refresh token is spent feeding a read the broker will refuse.

**"Connected" means valid, not present.** `hasAcpClaudeToken()` reads not-connected for an expired token with no refresh token, and connected for an expired one that still has a refresh token (the next spawn renews it). This is what lets a re-authentication affordance stay on screen instead of self-dismissing.

**The recorded expiry is load-bearing.** When the provider rejects a refresh token, only the refresh token is dropped; the expiry stays. `isTokenExpired(null)` is false by design ("assume usable"), so clearing the expiry would make a dead credential read as unexpired and vouch for itself.

**Writes outside the Connect flow reset renewal state.** `credentials set`, the secret-collection route, and a prompted credential all reach `acp/claude_oauth_token` directly, and the headless instructions point users at one of them. The companion fields describe the *previous* token, so they are cleared after a successful write: otherwise a stale past expiry condemns a valid new token, and a stale refresh token can be spent to overwrite the one just pasted.

## Why this is safe

- **Renewal is the fast path, never the error path.** `ensureFreshAcpClaudeToken` returns without throwing in every failure mode. A refresh outage cannot fail a spawn that the stored token might still satisfy; the spawn proceeds and, if the token really is dead, fails at the adapter as a structured ACP `auth_required`.
- **No new plaintext boundary.** The refresh token and expiry are stored *without* credential metadata, and `serverUse` refuses any field without metadata. The broker can never hand them to a spawned agent. Only the access token crosses into the child process, still via the broker.
- **Concurrent spawns share one refresh.** Anthropic rotates the refresh token on use, so a second parallel exchange would spend an already-invalidated token. `RefreshDeduplicator` (the existing shared primitive) collapses them.
- **Tokens connected before this change keep working.** No recorded expiry reads as "assume usable", so an untracked-but-valid token is never refreshed or discarded.
- **A network blip never costs a credential.** Only a *credential* error (revoked/rotated refresh token, per the real `isCredentialError`) clears stored refresh material. Transient failures leave it intact.
- **Partial writes fail loud.** Companion writes and clears honor the store's failure signals rather than reporting success on a half-updated set. There is no transaction across the three keys, so throwing beats a rollback that has the same failure mode one level down.
- The policy-helper move is a pure relocation with no behavior change.

## What changes for the user

| Situation | Before | After |
|---|---|---|
| Access token expires mid-session | Delegation fails with a raw `401 ... Re-authenticate to continue`, unrecoverable without manual intervention | Renewed transparently on the next spawn; the user sees nothing |
| Connecting Claude Code | Only the access token is kept | Refresh token and expiry kept too, so the credential can renew itself |
| Expired token, nothing to renew with | Reported as "connected", so the inline Connect card self-dismissed on mount | Reported as not connected, so a re-auth affordance can stay on screen |
| Refresh token revoked | n/a | The refresh token is dropped and the account reads as needing a reconnect |
| Token pasted via `credentials set` | Presence alone made it connected | Still connected, and the previous token's renewal state no longer clobbers it |
| Workspace policy denies `acp_spawn` | n/a | Renewal is skipped entirely; policy is never widened behind the user's back |
| Token from a `config.json` override | Injected as-is | Unchanged: it is the user's to manage, and we hold no refresh material for it |

## Verification

`bunx tsc --noEmit`, `bun run lint`, and the pinned prettier all pass. Local test runs are blocked by a standing hook in this environment, so the suites run in CI.

Coverage: renewal skip paths (including the policy-denied gate), the rotated-token persist, concurrent-spawn deduplication, and the credential-vs-transient failure split, asserted against the *real* `isCredentialError` since which errors clear a user's credential is the hinge of the module. The connected check is pinned on all four expiry/refresh combinations, and the rejected-refresh test asserts the resulting invariant (`hasAcpClaudeToken()` is false) rather than that a helper was called. The fake vault in the ACP OAuth tests is key-addressed, since a single shared return value lets an expiry read pass for the wrong reason.

## Known gap, deliberately not papered over

Our authorize call requests only `user:inference`, while Claude Code itself requests five scopes. I could not confirm from the code alone that a single-scope authorize returns a refresh token, so nothing here *depends* on it: "no refresh token returned" is treated as a normal outcome that falls through to the re-authentication path. Worth confirming with one live connect, and widening the scope set if it turns out to matter.

## Deferred

- **ACP Claude auth lives in an ad-hoc vault field** rather than the real `oauth/` connection store, which already has refresh with a circuit breaker (`token-manager.ts`). That is the right long-term home, but migrating ripples through the credential broker, the Connect card, the CLI, and every already-stored token. Out of scope for a fix this size.
- **The `CLAUDE_CONFIG_DIR` + `.credentials.json` alternative** (hand the child a credentials file and let the CLI refresh itself) was rejected: it depends on undocumented internals of an auto-installed, floating-version package, and on macOS the CLI prefers the Keychain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)