### PR TITLE
feat(web): translate the home domain

### DIFF
--- a/clients/web/eslint.config.mjs
+++ b/clients/web/eslint.config.mjs
@@ -203,6 +203,7 @@ const i18nEnforcedPaths = [
   "src/domains/credential-requests/**/*.{ts,tsx}",
   "src/domains/logs/**/*.{ts,tsx}",
   "src/domains/library/**/*.{ts,tsx}",
+  "src/domains/home/**/*.{ts,tsx}",
 ];
 
 const eslintConfig = defineConfig([

--- a/clients/web/src/domains/home/components/notifications-bell-detail.tsx
+++ b/clients/web/src/domains/home/components/notifications-bell-detail.tsx
@@ -7,6 +7,7 @@ import {
   Trash2,
 } from "lucide-react";
 
+import { useTranslation } from "@/i18n";
 import {
   formatCompactLocalDate,
   formatFullLocalDate,
@@ -91,9 +92,13 @@ export function NotificationsBellDetail({
   onDismiss,
   onTriggerAction,
 }: NotificationsBellDetailProps) {
+  const { t } = useTranslation("home");
   const conversationId = item.conversationId ?? null;
   const scheduleId = getFeedItemScheduleId(item);
   const isUnread = item.status === "new";
+  const readToggleLabel = isUnread
+    ? t("actions.markAsRead")
+    : t("actions.markAsUnread");
   const isDismissed = item.status === "dismissed";
   const actions = item.actions ?? [];
 
@@ -136,7 +141,7 @@ export function NotificationsBellDetail({
           variant="ghost"
           iconOnly={<ChevronLeft />}
           onClick={onBack}
-          aria-label="Back to notifications"
+          aria-label={t("notificationsBellDetail.back")}
         />
         <Typography
           variant="body-medium-default"
@@ -158,24 +163,24 @@ export function NotificationsBellDetail({
             variant="ghost"
             iconOnly={isUnread ? <MailOpen /> : <Mail />}
             onClick={() => onUpdateStatus(item.id, isUnread ? "seen" : "new")}
-            aria-label={isUnread ? "Mark as read" : "Mark as unread"}
-            tooltip={isUnread ? "Mark as read" : "Mark as unread"}
+            aria-label={readToggleLabel}
+            tooltip={readToggleLabel}
           />
           {isDismissed ? (
             <Button
               variant="ghost"
               iconOnly={<RotateCcw />}
               onClick={() => onUpdateStatus(item.id, "seen")}
-              aria-label="Restore"
-              tooltip="Restore"
+              aria-label={t("actions.restore")}
+              tooltip={t("actions.restore")}
             />
           ) : (
             <Button
               variant="ghost"
               iconOnly={<Trash2 />}
               onClick={() => onDismiss(item.id)}
-              aria-label="Dismiss"
-              tooltip="Dismiss"
+              aria-label={t("actions.dismiss")}
+              tooltip={t("actions.dismiss")}
             />
           )}
         </div>
@@ -264,7 +269,7 @@ export function NotificationsBellDetail({
               }
               {...pendingLinkProps}
             >
-              View schedule
+              {t("actions.viewSchedule")}
             </Button>
           ) : null}
           {linkedConversationId ? (
@@ -277,7 +282,7 @@ export function NotificationsBellDetail({
               }
               {...pendingLinkProps}
             >
-              Go to Conversation
+              {t("actions.goToConversation")}
             </Button>
           ) : null}
         </div>

--- a/clients/web/src/domains/home/components/notifications-bell.tsx
+++ b/clients/web/src/domains/home/components/notifications-bell.tsx
@@ -10,6 +10,7 @@ import {
   useScheduledConversationListQuery,
 } from "@/hooks/conversation-queries";
 import { useTouchMobile } from "@/hooks/use-touch-mobile";
+import { useTranslation } from "@/i18n";
 import { useSupportsBulkFeedStatus } from "@/lib/backwards-compat/bulk-feed-status";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { mergeConversationLists } from "@/utils/conversation-cache";
@@ -101,6 +102,7 @@ export function NotificationsBell() {
   const [isOpen, setIsOpen] = useState(false);
   const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
   const isTouchMobile = useTouchMobile();
+  const { t } = useTranslation("home");
   const navigate = useNavigate();
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
   const feedQuery = useHomeFeedQuery(assistantId);
@@ -266,7 +268,7 @@ export function NotificationsBell() {
           navigateToConversation(navigate, data.conversationId);
         },
         onError: () => {
-          toast.error("Couldn't start that conversation. Try again.");
+          toast.error(t("notificationsBell.actionFailed"));
         },
         onSettled: () => {
           isTriggeringActionRef.current = false;
@@ -309,7 +311,11 @@ export function NotificationsBell() {
           ) : null}
         </span>
       }
-      aria-label={hasUnread ? "Notifications (unread)" : "Notifications"}
+      aria-label={
+        hasUnread
+          ? t("notificationsBell.ariaLabelUnread")
+          : t("notificationsBell.ariaLabel")
+      }
     />
   );
 
@@ -330,8 +336,8 @@ export function NotificationsBell() {
         className="px-[var(--app-spacing-lg)] py-[var(--app-spacing-xl)] text-center text-[var(--content-tertiary)]"
       >
         {feedQuery.isError
-          ? "Couldn't load notifications."
-          : "No notifications yet."}
+          ? t("notificationsBell.loadFailed")
+          : t("notificationsBell.empty")}
       </Typography>
     ) : (
       <div
@@ -396,7 +402,7 @@ export function NotificationsBell() {
               as="h2"
               className="text-[var(--content-default)]"
             >
-              Notifications
+              {t("notificationsBell.heading")}
             </Typography>
           </div>
 
@@ -411,7 +417,7 @@ export function NotificationsBell() {
                   onClick={handleMarkAllRead}
                   disabled={feedQuery.markAll.isPending}
                 >
-                  Mark all as read
+                  {t("actions.markAllAsRead")}
                 </Button>
               ) : null}
               <Button
@@ -420,7 +426,7 @@ export function NotificationsBell() {
                 onClick={handleClearAll}
                 disabled={feedQuery.markAll.isPending}
               >
-                Clear all
+                {t("actions.clearAll")}
               </Button>
             </div>
           ) : null}
@@ -438,7 +444,7 @@ export function NotificationsBell() {
             <BottomSheet.Title>
               {selectedItem
                 ? resolveFeedItemTitle(selectedItem)
-                : "Notifications"}
+                : t("notificationsBell.heading")}
             </BottomSheet.Title>
           </BottomSheet.Header>
           <BottomSheet.Body className="pt-0">{panel}</BottomSheet.Body>
@@ -449,7 +455,7 @@ export function NotificationsBell() {
 
   return (
     <Popover.Root open={isOpen} onOpenChange={handleOpenChange}>
-      <Tooltip content="Notifications">
+      <Tooltip content={t("notificationsBell.ariaLabel")}>
         <Popover.Trigger asChild>{trigger}</Popover.Trigger>
       </Tooltip>
       <Popover.Content

--- a/clients/web/src/domains/home/detail-panel/home-detail-panel.tsx
+++ b/clients/web/src/domains/home/detail-panel/home-detail-panel.tsx
@@ -8,25 +8,13 @@ import {
   X,
 } from "lucide-react";
 
+import { useTranslation } from "@/i18n";
 import { formatFullLocalDate, formatRelativeDate } from "@/utils/format-date";
 import type { FeedItem, FeedItemStatus } from "@vellumai/assistant-api";
 import { Button, Tag, Typography } from "@vellumai/design-library";
 import { resolveCategoryStyle } from "../home-feed-filter-bar";
 import { HomeGenericDetail } from "./home-generic-detail";
 import { HomeToolPermissionCard } from "./home-tool-permission-card";
-
-// The header shows the item's own title when it has one. Many feed items omit
-// a distinct title — for those, falling back to `summary` (which is also the
-// body) duplicates the same text, so we surface the category label instead.
-function resolveHeaderTitle(item: FeedItem): string {
-  if (item.title) {
-    return item.title;
-  }
-  if (item.category) {
-    return item.category.charAt(0).toUpperCase() + item.category.slice(1);
-  }
-  return "Notification";
-}
 
 export interface HomeDetailPanelProps {
   item: FeedItem | null;
@@ -53,15 +41,27 @@ export function HomeDetailPanel({
   onDismiss,
   onViewSchedule,
 }: HomeDetailPanelProps) {
+  const { t } = useTranslation("home");
+
   if (!item) {
     return null;
   }
 
   const panelKind = item.detailPanel?.kind;
-  const headerTitle = resolveHeaderTitle(item);
   const categoryStyle = resolveCategoryStyle(item.category);
+  // The header shows the item's own title when it has one. Many feed items
+  // omit a distinct title, and falling back to `summary` (which is also the
+  // body) duplicates the same text, so the category label stands in instead.
+  const headerTitle = item.title
+    ? item.title
+    : item.category
+      ? t(categoryStyle.labelKey)
+      : t("homeDetailPanel.untitled");
   const CategoryIcon = categoryStyle.icon;
   const isUnread = item.status === "new";
+  const readToggleLabel = isUnread
+    ? t("actions.markAsRead")
+    : t("actions.markAsUnread");
   const isDismissed = item.status === "dismissed";
   const hasValidConversation =
     !!item.conversationId && validConversationIds.has(item.conversationId);
@@ -75,15 +75,15 @@ export function HomeDetailPanel({
             variant="ghost"
             iconOnly={<ArrowLeft />}
             onClick={onClose}
-            aria-label="Back"
-            tooltip="Back"
+            aria-label={t("homeDetailPanel.back")}
+            tooltip={t("homeDetailPanel.back")}
           />
 
           <Typography
             variant="body-medium-default"
             className="pointer-events-none absolute inset-x-0 text-center text-[var(--content-secondary)]"
           >
-            Details
+            {t("homeDetailPanel.heading")}
           </Typography>
 
           <div className="ml-auto flex items-center gap-2">
@@ -91,24 +91,24 @@ export function HomeDetailPanel({
               variant="ghost"
               iconOnly={isUnread ? <MailOpen /> : <Mail />}
               onClick={() => onUpdateStatus(item.id, isUnread ? "seen" : "new")}
-              aria-label={isUnread ? "Mark as read" : "Mark as unread"}
-              tooltip={isUnread ? "Mark as read" : "Mark as unread"}
+              aria-label={readToggleLabel}
+              tooltip={readToggleLabel}
             />
             {isDismissed ? (
               <Button
                 variant="ghost"
                 iconOnly={<RotateCcw />}
                 onClick={() => onUpdateStatus(item.id, "seen")}
-                aria-label="Restore"
-                tooltip="Restore"
+                aria-label={t("actions.restore")}
+                tooltip={t("actions.restore")}
               />
             ) : (
               <Button
                 variant="ghost"
                 iconOnly={<Trash2 />}
                 onClick={() => onDismiss(item.id)}
-                aria-label="Dismiss"
-                tooltip="Dismiss"
+                aria-label={t("actions.dismiss")}
+                tooltip={t("actions.dismiss")}
               />
             )}
           </div>
@@ -168,7 +168,7 @@ export function HomeDetailPanel({
                 leftIcon={<Calendar className="size-4" />}
                 onClick={onViewSchedule}
               >
-                View schedule
+                {t("actions.viewSchedule")}
               </Button>
             ) : null}
             {hasValidConversation ? (
@@ -177,7 +177,7 @@ export function HomeDetailPanel({
                 fullWidth
                 onClick={() => onGoToThread(item.conversationId!)}
               >
-                Go to Conversation
+                {t("actions.goToConversation")}
               </Button>
             ) : null}
           </div>
@@ -218,7 +218,7 @@ export function HomeDetailPanel({
             variant="outlined"
             onClick={() => onGoToThread(item.conversationId!)}
           >
-            Go to Convo
+            {t("actions.goToConvo")}
           </Button>
         ) : null}
 
@@ -226,8 +226,8 @@ export function HomeDetailPanel({
           variant="outlined"
           iconOnly={<X />}
           onClick={onClose}
-          aria-label="Close detail panel"
-          tooltip="Close"
+          aria-label={t("homeDetailPanel.closeAriaLabel")}
+          tooltip={t("homeDetailPanel.close")}
         />
       </div>
 
@@ -254,7 +254,7 @@ export function HomeDetailPanel({
               leftIcon={<Calendar className="size-4" />}
               onClick={onViewSchedule}
             >
-              View schedule
+              {t("actions.viewSchedule")}
             </Button>
           ) : null}
         </div>
@@ -264,7 +264,7 @@ export function HomeDetailPanel({
               variant="primary"
               onClick={() => onUpdateStatus(item.id, "seen")}
             >
-              Restore
+              {t("actions.restore")}
             </Button>
           ) : (
             <>
@@ -274,10 +274,10 @@ export function HomeDetailPanel({
                   onUpdateStatus(item.id, isUnread ? "seen" : "new")
                 }
               >
-                {isUnread ? "Mark as read" : "Mark as unread"}
+                {readToggleLabel}
               </Button>
               <Button variant="primary" onClick={() => onDismiss(item.id)}>
-                Dismiss
+                {t("actions.dismiss")}
               </Button>
             </>
           )}

--- a/clients/web/src/domains/home/detail-panel/home-tool-permission-card.tsx
+++ b/clients/web/src/domains/home/detail-panel/home-tool-permission-card.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "@/i18n";
 import type { FeedItem } from "@vellumai/assistant-api";
 import { Typography } from "@vellumai/design-library";
 
@@ -24,6 +25,37 @@ function statusDotColor(status: string): string {
   }
 }
 
+/**
+ * Catalog key naming a credential status, in the same shape as
+ * `statusDotColor`. Written out per status rather than composed from the wire
+ * value so the catalog can keep its camelCase key naming, and so every key
+ * stays greppable for the orphan check in `catalogs.test.ts`. Null for a
+ * status this build has no copy for.
+ */
+function statusLabelKey(status: string) {
+  switch (status as CredentialStatus) {
+    case "revoked":
+      return "homeToolPermissionCard.status.revoked";
+    case "expired":
+      return "homeToolPermissionCard.status.expired";
+    case "missing_scopes":
+      return "homeToolPermissionCard.status.missingScopes";
+    case "missing_token":
+      return "homeToolPermissionCard.status.missingToken";
+    case "ping_failed":
+      return "homeToolPermissionCard.status.pingFailed";
+    case "unreachable":
+      return "homeToolPermissionCard.status.unreachable";
+    default:
+      return null;
+  }
+}
+
+/**
+ * Last resort for a status this build has no copy for. The daemon is free to
+ * add statuses, and naming the one it actually reported tells the user more
+ * than any of the six known labels would.
+ */
 function capitalizeStatus(status: string): string {
   return status
     .split("_")
@@ -36,6 +68,7 @@ export interface HomeToolPermissionCardProps {
 }
 
 export function HomeToolPermissionCard({ item }: HomeToolPermissionCardProps) {
+  const { t } = useTranslation("home");
   const metadata = item.metadata;
   const provider = metadata?.provider as string | undefined;
 
@@ -54,6 +87,7 @@ export function HomeToolPermissionCard({ item }: HomeToolPermissionCardProps) {
 
   const accountInfo = (metadata?.accountInfo as string) ?? null;
   const status = (metadata?.status as string) ?? "unreachable";
+  const statusKey = statusLabelKey(status);
   const details = (metadata?.details as string) ?? "";
   const missingScopes = Array.isArray(metadata?.missingScopes)
     ? (metadata.missingScopes as string[])
@@ -88,7 +122,7 @@ export function HomeToolPermissionCard({ item }: HomeToolPermissionCardProps) {
           variant="body-medium-default"
           className="text-[var(--content-default)]"
         >
-          {capitalizeStatus(status)}
+          {statusKey ? t(statusKey) : capitalizeStatus(status)}
         </Typography>
       </div>
 
@@ -107,7 +141,7 @@ export function HomeToolPermissionCard({ item }: HomeToolPermissionCardProps) {
             variant="body-small-emphasised"
             className="text-[var(--content-secondary)]"
           >
-            Missing scopes
+            {t("homeToolPermissionCard.missingScopes")}
           </Typography>
           <ul className="m-0 flex list-disc flex-col gap-[var(--app-spacing-xxs)] pl-[var(--app-spacing-lg)]">
             {missingScopes.map((scope) => (

--- a/clients/web/src/domains/home/feed-category-chip.tsx
+++ b/clients/web/src/domains/home/feed-category-chip.tsx
@@ -1,11 +1,10 @@
 import { type CSSProperties } from "react";
 
+import { useTranslation } from "@/i18n";
 import type { FeedItemCategory } from "@vellumai/assistant-api";
 import { Tag } from "@vellumai/design-library";
 
 import { resolveCategoryStyle } from "./home-feed-filter-bar";
-
-const FALLBACK_CATEGORY: FeedItemCategory = "system";
 
 export interface FeedCategoryChipProps {
   category?: FeedItemCategory;
@@ -22,15 +21,15 @@ export interface FeedCategoryChipProps {
  * every category background at this 12px/600 size.
  */
 export function FeedCategoryChip({ category }: FeedCategoryChipProps) {
+  const { t } = useTranslation("home");
   const style = resolveCategoryStyle(category);
-  const label = category ?? FALLBACK_CATEGORY;
 
   return (
     <Tag
       className="bg-[var(--feed-chip-weak)] uppercase tracking-wide leading-none"
       style={{ "--feed-chip-weak": style.weak } as CSSProperties}
     >
-      {label.charAt(0).toUpperCase() + label.slice(1)}
+      {t(style.labelKey)}
     </Tag>
   );
 }

--- a/clients/web/src/domains/home/home-feed-filter-bar.tsx
+++ b/clients/web/src/domains/home/home-feed-filter-bar.tsx
@@ -1,6 +1,7 @@
 import { Bell, Clock, List, Mail, Settings, ShieldCheck } from "lucide-react";
 import { type ComponentType, type SVGProps } from "react";
 
+import { useTranslation } from "@/i18n";
 import type { FeedItemCategory } from "@vellumai/assistant-api";
 import {
   SegmentControl,
@@ -13,6 +14,12 @@ interface CategoryStyle {
   icon: LucideIcon;
   strong: string;
   weak: string;
+  /**
+   * Written out per category rather than built from the wire value, so a
+   * category added without its copy fails to compile and the key stays
+   * greppable for the orphan check in `catalogs.test.ts`.
+   */
+  labelKey: `category.${FeedItemCategory}`;
 }
 
 export const CATEGORY_STYLES: Record<FeedItemCategory, CategoryStyle> = {
@@ -20,26 +27,31 @@ export const CATEGORY_STYLES: Record<FeedItemCategory, CategoryStyle> = {
     icon: ShieldCheck,
     strong: "var(--feed-nudge-strong)",
     weak: "var(--feed-nudge-weak)",
+    labelKey: "category.security",
   },
   email: {
     icon: Mail,
     strong: "var(--feed-digest-strong)",
     weak: "var(--feed-digest-weak)",
+    labelKey: "category.email",
   },
   scheduling: {
     icon: Clock,
     strong: "var(--feed-thread-strong)",
     weak: "var(--feed-thread-weak)",
+    labelKey: "category.scheduling",
   },
   background: {
     icon: Settings,
     strong: "var(--system-info-strong)",
     weak: "var(--system-info-weak)",
+    labelKey: "category.background",
   },
   system: {
     icon: Bell,
     strong: "var(--feed-digest-strong)",
     weak: "var(--feed-digest-weak)",
+    labelKey: "category.system",
   },
 };
 
@@ -75,6 +87,7 @@ export function HomeFeedFilterBar({
   activeFilter,
   onFilterChange,
 }: HomeFeedFilterBarProps) {
+  const { t } = useTranslation("home");
   const presentCategories = CATEGORY_ORDER.filter((c) =>
     categories.includes(c),
   );
@@ -84,12 +97,16 @@ export function HomeFeedFilterBar({
   }
 
   const items: SegmentControlItem<FilterValue>[] = [
-    { value: ALL_FILTER, label: "All", icon: <List className="h-4 w-4" /> },
+    {
+      value: ALL_FILTER,
+      label: t("category.all"),
+      icon: <List className="h-4 w-4" />,
+    },
     ...presentCategories.map((category) => {
-      const Icon = CATEGORY_STYLES[category].icon;
+      const { icon: Icon, labelKey } = CATEGORY_STYLES[category];
       return {
         value: category,
-        label: category.charAt(0).toUpperCase() + category.slice(1),
+        label: t(labelKey),
         icon: <Icon className="h-4 w-4" />,
       };
     }),
@@ -97,7 +114,7 @@ export function HomeFeedFilterBar({
 
   return (
     <SegmentControl<FilterValue>
-      ariaLabel="Filter notifications"
+      ariaLabel={t("homeFeedFilterBar.ariaLabel")}
       value={activeFilter ?? ALL_FILTER}
       onChange={(next) => onFilterChange(next === ALL_FILTER ? null : next)}
       items={items}

--- a/clients/web/src/domains/home/home-feed-list.tsx
+++ b/clients/web/src/domains/home/home-feed-list.tsx
@@ -2,6 +2,7 @@ import { Bell, ChevronRight } from "lucide-react";
 import { useState } from "react";
 
 import { PageEmptyState } from "@/components/page-empty-state";
+import { useTranslation } from "@/i18n";
 
 import type {
   FeedItem,
@@ -20,10 +21,10 @@ import {
   sortFeedItems,
 } from "./utils";
 
-const TIME_GROUP_LABELS: Record<FeedTimeGroup, string> = {
-  today: "Today",
-  yesterday: "Yesterday",
-  older: "Older",
+const TIME_GROUP_KEYS: Record<FeedTimeGroup, `homeFeedList.${FeedTimeGroup}`> = {
+  today: "homeFeedList.today",
+  yesterday: "homeFeedList.yesterday",
+  older: "homeFeedList.older",
 };
 
 const READ_ARCHIVE_AGE_MS = 7 * 24 * 60 * 60 * 1000;
@@ -71,6 +72,7 @@ export function HomeFeedList({
   dismissedOpen,
   onDismissedOpenChange,
 }: HomeFeedListProps) {
+  const { t } = useTranslation("home");
   const [activeFilter, setActiveFilter] = useState<FeedItemCategory | null>(
     null,
   );
@@ -130,13 +132,13 @@ export function HomeFeedList({
             variant="body-medium-lighter"
             className="py-[var(--app-spacing-xl)] text-center text-[var(--content-disabled)]"
           >
-            No items match the selected filter.
+            {t("homeFeedList.noMatches")}
           </Typography>
         ) : (
           <PageEmptyState
             icon={Bell}
-            title="No notifications yet"
-            description="Updates and activity from your assistant will appear here."
+            title={t("homeFeedList.emptyTitle")}
+            description={t("homeFeedList.emptyBody")}
           />
         )
       ) : (
@@ -150,7 +152,7 @@ export function HomeFeedList({
               as="h3"
               className="text-[var(--content-tertiary)]"
             >
-              {TIME_GROUP_LABELS[group]}
+              {t(TIME_GROUP_KEYS[group])}
             </Typography>
 
             <div className="flex flex-col gap-[var(--app-spacing-sm)]">
@@ -185,7 +187,9 @@ export function HomeFeedList({
                 aria-hidden
                 className="shrink-0 transition-transform group-data-[state=open]:rotate-90"
               />
-              <span>Earlier ({archivedRead.length})</span>
+              <span>
+                {t("homeFeedList.earlier", { count: archivedRead.length })}
+              </span>
             </Collapsible.Trigger>
             <Collapsible.Content>
               <div className="flex flex-col gap-[var(--app-spacing-sm)] pt-[var(--app-spacing-sm)]">
@@ -221,7 +225,9 @@ export function HomeFeedList({
                 aria-hidden
                 className="shrink-0 transition-transform group-data-[state=open]:rotate-90"
               />
-              <span>Dismissed ({dismissed.length})</span>
+              <span>
+                {t("homeFeedList.dismissed", { count: dismissed.length })}
+              </span>
             </Collapsible.Trigger>
             <Collapsible.Content>
               <div className="flex flex-col gap-[var(--app-spacing-sm)] pt-[var(--app-spacing-sm)]">

--- a/clients/web/src/domains/home/home-page.tsx
+++ b/clients/web/src/domains/home/home-page.tsx
@@ -5,6 +5,7 @@ import { DetailDrawer, MobileDetailOverlay } from "@/components/detail-drawer";
 import { PageShell } from "@/components/page-shell";
 import { schedulesListQueryOptions } from "@/domains/settings/api/schedules";
 import { useIsMobile } from "@/hooks/use-is-mobile";
+import { useTranslation } from "@/i18n";
 import { useSupportsBulkFeedStatus } from "@/lib/backwards-compat/bulk-feed-status";
 import type { FeedItem, FeedItemStatus } from "@vellumai/assistant-api";
 import { Button, Skeleton } from "@vellumai/design-library";
@@ -63,6 +64,7 @@ export function HomePage({
   navigationKey,
   onInitialFeedItemConsumed,
 }: HomePageProps) {
+  const { t } = useTranslation("home");
   const isMobile = useIsMobile();
   const feedQuery = useHomeFeedQuery(assistantId);
   useHomeStateQuery(assistantId);
@@ -215,10 +217,11 @@ export function HomePage({
           role="alert"
           className="rounded-md border border-[var(--system-negative-weak)] bg-[var(--system-negative-weak)] px-[var(--app-spacing-lg)] py-[var(--app-spacing-md)] text-[var(--system-negative-strong)]"
         >
-          Couldn't load home feed
           {feedQuery.error instanceof Error
-            ? `: ${feedQuery.error.message}`
-            : "."}
+            ? t("homePage.loadFailedDetail", {
+                message: feedQuery.error.message,
+              })
+            : t("homePage.loadFailed")}
         </div>
       ) : null}
       {supportsBulkStatus && (newCount > 0 || activeCount > 0) && (
@@ -230,7 +233,7 @@ export function HomePage({
               onClick={handleMarkAllRead}
               disabled={feedQuery.markAll.isPending}
             >
-              Mark all as read
+              {t("actions.markAllAsRead")}
             </Button>
           )}
           {activeCount > 0 && (
@@ -240,7 +243,7 @@ export function HomePage({
               onClick={handleClearAll}
               disabled={feedQuery.markAll.isPending}
             >
-              Clear all
+              {t("actions.clearAll")}
             </Button>
           )}
         </div>

--- a/clients/web/src/domains/home/home-recap-row.tsx
+++ b/clients/web/src/domains/home/home-recap-row.tsx
@@ -1,6 +1,7 @@
 import { Mail, MailOpen, MessageSquare, RotateCcw, Trash2 } from "lucide-react";
 import { useMemo, type ReactNode } from "react";
 
+import { useTranslation } from "@/i18n";
 import { formatRelativeDate } from "@/utils/format-date";
 import type { FeedItem, FeedItemStatus } from "@vellumai/assistant-api";
 import {
@@ -109,6 +110,7 @@ export function HomeRecapRow({
   trailingAction = "dismiss",
   density = "comfortable",
 }: HomeRecapRowProps) {
+  const { t } = useTranslation("home");
   const isUnread = item.status === "new";
   const isRestore = trailingAction === "restore";
   const densityStyle = DENSITY_STYLES[density];
@@ -237,18 +239,24 @@ export function HomeRecapRow({
             >
               {isRestore ? (
                 <HoverIconButton
-                  label="Restore"
+                  label={t("actions.restore")}
                   onClick={() => onDismiss(item.id)}
                   className="w-auto gap-[var(--app-spacing-xs)] px-2"
                 >
                   <RotateCcw width={16} height={16} aria-hidden="true" />
-                  <span className="text-body-small-default">Restore</span>
+                  <span className="text-body-small-default">
+                    {t("actions.restore")}
+                  </span>
                 </HoverIconButton>
               ) : (
                 <>
                   {onToggleRead && (
                     <HoverIconButton
-                      label={isUnread ? "Mark as read" : "Mark as unread"}
+                      label={
+                        isUnread
+                          ? t("actions.markAsRead")
+                          : t("actions.markAsUnread")
+                      }
                       onClick={() =>
                         onToggleRead(item.id, isUnread ? "seen" : "new")
                       }
@@ -265,7 +273,7 @@ export function HomeRecapRow({
                     (!validConversationIds ||
                       validConversationIds.has(item.conversationId)) && (
                       <HoverIconButton
-                        label="Go to thread"
+                        label={t("actions.goToThread")}
                         onClick={() => {
                           if (isUnread && onToggleRead) {
                             onToggleRead(item.id, "seen");
@@ -277,7 +285,7 @@ export function HomeRecapRow({
                       </HoverIconButton>
                     )}
                   <HoverIconButton
-                    label="Dismiss"
+                    label={t("actions.dismiss")}
                     onClick={() => onDismiss(item.id)}
                   >
                     <Trash2 width={16} height={16} />

--- a/clients/web/src/domains/home/home-top-header.tsx
+++ b/clients/web/src/domains/home/home-top-header.tsx
@@ -1,11 +1,15 @@
+import { useTranslation } from "@/i18n";
+
 /**
  * Top-level page header for the home dashboard: the "Activity" title. Sits
  * above the notifications feed. Mirrors the Library page header styling.
  */
 export function HomeTopHeader() {
+  const { t } = useTranslation("home");
+
   return (
     <h1 className="shrink-0 text-title-large text-[var(--content-default)]">
-      Activity
+      {t("homeTopHeader.title")}
     </h1>
   );
 }

--- a/clients/web/src/i18n/catalogs.ts
+++ b/clients/web/src/i18n/catalogs.ts
@@ -36,6 +36,7 @@
 import enAccount from "@/i18n/locales/en/account.json";
 import enChannels from "@/i18n/locales/en/channels.json";
 import enCredentialRequests from "@/i18n/locales/en/credential-requests.json";
+import enHome from "@/i18n/locales/en/home.json";
 import enLibrary from "@/i18n/locales/en/library.json";
 import enLogs from "@/i18n/locales/en/logs.json";
 import enRemoteWeb from "@/i18n/locales/en/remote-web.json";
@@ -77,6 +78,7 @@ export const FALLBACK_CATALOGS: LocaleCatalogs = {
   "credential-requests": enCredentialRequests,
   logs: enLogs,
   library: enLibrary,
+  home: enHome,
 };
 
 /** Loaders for the locales that are not bundled into the entry chunk. */
@@ -98,6 +100,7 @@ const CATALOG_LOADERS: Record<
       import("@/i18n/locales/es/credential-requests.json"),
     logs: () => import("@/i18n/locales/es/logs.json"),
     library: () => import("@/i18n/locales/es/library.json"),
+    home: () => import("@/i18n/locales/es/home.json"),
   },
 };
 

--- a/clients/web/src/i18n/i18next.d.ts
+++ b/clients/web/src/i18n/i18next.d.ts
@@ -15,6 +15,7 @@
 import type account from "@/i18n/locales/en/account.json";
 import type channels from "@/i18n/locales/en/channels.json";
 import type credentialRequests from "@/i18n/locales/en/credential-requests.json";
+import type home from "@/i18n/locales/en/home.json";
 import type library from "@/i18n/locales/en/library.json";
 import type logs from "@/i18n/locales/en/logs.json";
 import type remoteWeb from "@/i18n/locales/en/remote-web.json";
@@ -41,6 +42,7 @@ declare module "i18next" {
       "credential-requests": typeof credentialRequests;
       logs: typeof logs;
       library: typeof library;
+      home: typeof home;
     };
     returnNull: false;
   }

--- a/clients/web/src/i18n/locales/en/home.json
+++ b/clients/web/src/i18n/locales/en/home.json
@@ -1,0 +1,65 @@
+{
+  "actions": {
+    "markAsRead": "Mark as read",
+    "markAsUnread": "Mark as unread",
+    "restore": "Restore",
+    "dismiss": "Dismiss",
+    "goToThread": "Go to thread",
+    "goToConversation": "Go to Conversation",
+    "goToConvo": "Go to Convo",
+    "viewSchedule": "View schedule",
+    "markAllAsRead": "Mark all as read",
+    "clearAll": "Clear all"
+  },
+  "category": {
+    "all": "All",
+    "security": "Security",
+    "email": "Email",
+    "scheduling": "Scheduling",
+    "background": "Background",
+    "system": "System"
+  },
+  "homeTopHeader": { "title": "Activity" },
+  "homeFeedFilterBar": { "ariaLabel": "Filter notifications" },
+  "homeFeedList": {
+    "today": "Today",
+    "yesterday": "Yesterday",
+    "older": "Older",
+    "noMatches": "No items match the selected filter.",
+    "emptyTitle": "No notifications yet",
+    "emptyBody": "Updates and activity from your assistant will appear here.",
+    "earlier": "Earlier ({count, number})",
+    "dismissed": "Dismissed ({count, number})"
+  },
+  "homePage": {
+    "loadFailed": "Couldn't load home feed.",
+    "loadFailedDetail": "Couldn't load home feed: {message}"
+  },
+  "homeDetailPanel": {
+    "back": "Back",
+    "heading": "Details",
+    "close": "Close",
+    "closeAriaLabel": "Close detail panel",
+    "untitled": "Notification"
+  },
+  "homeToolPermissionCard": {
+    "missingScopes": "Missing scopes",
+    "status": {
+      "revoked": "Revoked",
+      "expired": "Expired",
+      "missingScopes": "Missing scopes",
+      "missingToken": "Missing token",
+      "pingFailed": "Ping failed",
+      "unreachable": "Unreachable"
+    }
+  },
+  "notificationsBell": {
+    "ariaLabel": "Notifications",
+    "ariaLabelUnread": "Notifications (unread)",
+    "heading": "Notifications",
+    "loadFailed": "Couldn't load notifications.",
+    "empty": "No notifications yet.",
+    "actionFailed": "Couldn't start that conversation. Try again."
+  },
+  "notificationsBellDetail": { "back": "Back to notifications" }
+}

--- a/clients/web/src/i18n/locales/es/home.json
+++ b/clients/web/src/i18n/locales/es/home.json
@@ -1,0 +1,65 @@
+{
+  "actions": {
+    "markAsRead": "Marcar como leída",
+    "markAsUnread": "Marcar como no leída",
+    "restore": "Restaurar",
+    "dismiss": "Descartar",
+    "goToThread": "Ir al hilo",
+    "goToConversation": "Ir a la conversación",
+    "goToConvo": "Ir a la conversación",
+    "viewSchedule": "Ver programación",
+    "markAllAsRead": "Marcar todas como leídas",
+    "clearAll": "Borrar todas"
+  },
+  "category": {
+    "all": "Todas",
+    "security": "Seguridad",
+    "email": "Correo",
+    "scheduling": "Programación",
+    "background": "Segundo plano",
+    "system": "Sistema"
+  },
+  "homeTopHeader": { "title": "Actividad" },
+  "homeFeedFilterBar": { "ariaLabel": "Filtrar notificaciones" },
+  "homeFeedList": {
+    "today": "Hoy",
+    "yesterday": "Ayer",
+    "older": "Anteriores",
+    "noMatches": "Ningún elemento coincide con el filtro seleccionado.",
+    "emptyTitle": "Todavía no hay notificaciones",
+    "emptyBody": "Las novedades y la actividad de tu asistente aparecerán aquí.",
+    "earlier": "Anteriores ({count, number})",
+    "dismissed": "Descartadas ({count, number})"
+  },
+  "homePage": {
+    "loadFailed": "No se pudo cargar la actividad.",
+    "loadFailedDetail": "No se pudo cargar la actividad: {message}"
+  },
+  "homeDetailPanel": {
+    "back": "Atrás",
+    "heading": "Detalles",
+    "close": "Cerrar",
+    "closeAriaLabel": "Cerrar el panel de detalles",
+    "untitled": "Notificación"
+  },
+  "homeToolPermissionCard": {
+    "missingScopes": "Permisos faltantes",
+    "status": {
+      "revoked": "Revocado",
+      "expired": "Caducado",
+      "missingScopes": "Permisos faltantes",
+      "missingToken": "Falta el token",
+      "pingFailed": "Error de conexión",
+      "unreachable": "Inaccesible"
+    }
+  },
+  "notificationsBell": {
+    "ariaLabel": "Notificaciones",
+    "ariaLabelUnread": "Notificaciones (sin leer)",
+    "heading": "Notificaciones",
+    "loadFailed": "No se pudieron cargar las notificaciones.",
+    "empty": "Todavía no hay notificaciones.",
+    "actionFailed": "No se pudo iniciar esa conversación. Vuelve a intentarlo."
+  },
+  "notificationsBellDetail": { "back": "Volver a las notificaciones" }
+}

--- a/clients/web/src/i18n/namespaces.ts
+++ b/clients/web/src/i18n/namespaces.ts
@@ -47,6 +47,7 @@ export const NAMESPACES = [
   "credential-requests",
   "logs",
   "library",
+  "home",
 ] as const;
 
 export type Namespace = (typeof NAMESPACES)[number];


### PR DESCRIPTION
Adds a `home` namespace and moves the Activity page, its detail panel, and the notifications bell onto it, then turns the ratchet on for `src/domains/home/**`. 59 strings across 9 files.

## Why

`home` is the last of the mid-sized domains. It is also the one that was reverted from #40504 when a bulk replacement corrupted an import statement, so this pass converts it file by file with the survey re-run after each.

## Enum-driven labels

Three places were building user-visible copy by capitalizing a wire value, which no language other than English survives:

- feed categories (`security` to `Security`), in the filter bar, the category chip, and the detail panel's title fallback
- time-group headings (`today` to `Today`) in the feed list
- credential statuses (`missing_scopes` to `Missing scopes`) in the tool-permission card

Each now carries an explicit catalog key. Categories hang a `labelKey` off `CATEGORY_STYLES`, so all three call sites read it through the `resolveCategoryStyle` they already call and an unknown category falls back to `system` exactly as its icon and color already do. Time groups get `TIME_GROUP_KEYS`, typed as a total map over `FeedTimeGroup`. Statuses get `statusLabelKey`, a switch in the same shape as the `statusDotColor` beside it.

All three are written out per member rather than composed from the wire value. That keeps the catalog on camelCase key naming while the wire stays snake_case, and keeps every key a greppable literal for the orphan check in `catalogs.test.ts`, which reads source text and cannot see a key built from a template.

The credential card keeps its generic capitalization for a status this build has no copy for. The daemon is free to add statuses, and naming the one it actually reported tells the user more than any of the six known labels would.

## Shared actions

Read/unread, restore, dismiss, view schedule, and go-to-conversation appear in four files (the recap row, both detail panels, and the bell). They live in one `actions.*` section rather than repeating per component, and the read/unread ternary is lifted to a `readToggleLabel` const in the two panels that used it four times over.

## Verification

- survey of `src/domains/home/**` reports 0 remaining strings
- `tsc --noEmit` clean
- `bun run lint` 0 errors, 16 warnings, unchanged from the baseline on main
- 930 test files pass, including the existing home suites that assert on the English copy
- `bun run build` emits the Spanish `home` chunk

## What is left

`settings` (1585), `chat` (1066), `components` (463), `onboarding` (194), `intelligence` (177), `contacts` (115), and a tail of 23 in `hooks`/`utils`/`lib`. `contacts` is the next natural slice; after that only the four large areas remain.

Standing recommendation, still open: build a pseudolocale before starting `settings` or `chat`. Five of the six Codex findings across this series have been "you missed a shape the rule cannot parse", and a pseudolocale catches copy by what reaches the screen rather than by what a lint rule can see. The Spanish also has no native-speaker review yet, which matters more with every namespace added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CD12TRfmDF3UiXjdbiWn3i

---
_Generated by [Claude Code](https://claude.ai/code/session_01CD12TRfmDF3UiXjdbiWn3i)_