### PR TITLE
fix(acp): surface a re-authentication path when Claude rejects a run (LUM-3205)

### DIFF
--- a/assistant/src/acp/__tests__/auth-required.test.ts
+++ b/assistant/src/acp/__tests__/auth-required.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for the ACP auth-required signal.
+ *
+ * The point of this module is that the classification survives its trip from
+ * the agent's JSON-RPC rejection to the session manager, where it becomes an
+ * event the UI can act on. These pin both shapes it travels in, because losing
+ * either one silently degrades an actionable "reconnect Claude" failure back
+ * into an opaque one.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  ACP_CLAUDE_AUTH_REQUIRED_CODE,
+  AcpAuthRequiredError,
+  AUTH_REQUIRED_CODE,
+  CLAUDE_ACP_COMMAND,
+  isAcpAuthRequired,
+} from "../auth-required.js";
+
+describe("isAcpAuthRequired", () => {
+  test("recognizes the raw JSON-RPC rejection from the agent", () => {
+    // What the adapter actually sends: a plain object off the wire, not an
+    // instance of any class we control.
+    expect(isAcpAuthRequired({ code: AUTH_REQUIRED_CODE })).toBe(true);
+  });
+
+  test("recognizes our own error after the retry path gives up", () => {
+    expect(isAcpAuthRequired(new AcpAuthRequiredError("claude", "nope"))).toBe(
+      true,
+    );
+  });
+
+  test("does not fire on other failures", () => {
+    expect(isAcpAuthRequired(new Error("Internal error"))).toBe(false);
+    expect(isAcpAuthRequired({ code: -32601 })).toBe(false);
+    expect(isAcpAuthRequired(null)).toBe(false);
+    expect(isAcpAuthRequired(undefined)).toBe(false);
+    expect(isAcpAuthRequired("auth_required")).toBe(false);
+  });
+
+  test("uses the ACP-specified code", () => {
+    // Matches the SDK's RequestError.authRequired(); drifting from it would
+    // silently stop classifying every auth failure.
+    expect(AUTH_REQUIRED_CODE).toBe(-32000);
+  });
+});
+
+describe("AcpAuthRequiredError", () => {
+  test("is an Error that carries the agent id and its message", () => {
+    const err = new AcpAuthRequiredError("claude", "needs a reconnect");
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("AcpAuthRequiredError");
+    expect(err.agentId).toBe("claude");
+    expect(err.message).toBe("needs a reconnect");
+  });
+});
+
+describe("wire contract", () => {
+  test("the client marker matches the web literal", () => {
+    // Paired with ACP_CLAUDE_AUTH_REQUIRED_CODE in
+    // clients/web/src/domains/chat/utils/acp-connect.ts. A silent rename on
+    // either side turns the Connect card off with nothing failing.
+    expect(ACP_CLAUDE_AUTH_REQUIRED_CODE).toBe("acp_claude_auth_required");
+  });
+
+  test("the adapter gate matches the resolved command basename", () => {
+    // Compared against SessionEntry.command, which is already a basename.
+    expect(CLAUDE_ACP_COMMAND).toBe("claude-agent-acp");
+  });
+});

--- a/assistant/src/acp/__tests__/auth-required.test.ts
+++ b/assistant/src/acp/__tests__/auth-required.test.ts
@@ -10,6 +10,8 @@
 
 import { describe, expect, test } from "bun:test";
 
+import { AcpAuthRequiredEventSchema } from "../../api/events/acp-auth-required.js";
+import { AcpSessionErrorEventSchema } from "../../api/events/acp-session-error.js";
 import {
   ACP_CLAUDE_AUTH_REQUIRED_CODE,
   AcpAuthRequiredError,
@@ -53,6 +55,57 @@ describe("AcpAuthRequiredError", () => {
     expect(err.name).toBe("AcpAuthRequiredError");
     expect(err.agentId).toBe("claude");
     expect(err.message).toBe("needs a reconnect");
+  });
+});
+
+describe("event shape is additive-safe for older clients", () => {
+  test("acp_session_error rejects unknown keys, which is why the signal is not a field on it", () => {
+    // Clients parse with AssistantEventSchema.safeParse and fall back to an
+    // inert `unknown` event when it fails. A packaged client (iOS and macOS
+    // bundle the web app, so they can lag the daemon) carries whatever version
+    // of this schema it shipped with. Adding a field here would make such a
+    // client drop the whole event and leave the run rendering as still active,
+    // which is worse than the plain failure. This asserts the strictness that
+    // forces new signals into their own event type instead.
+    const result = AcpSessionErrorEventSchema.safeParse({
+      type: "acp_session_error",
+      acpSessionId: "acp-1",
+      error: "boom",
+      someFutureField: "x",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("acp_session_error still parses in its unchanged shape", () => {
+    expect(
+      AcpSessionErrorEventSchema.safeParse({
+        type: "acp_session_error",
+        acpSessionId: "acp-1",
+        error: "boom",
+      }).success,
+    ).toBe(true);
+  });
+
+  test("acp_auth_required carries the code and an optional anchor", () => {
+    const parsed = AcpAuthRequiredEventSchema.parse({
+      type: "acp_auth_required",
+      acpSessionId: "acp-1",
+      authCode: ACP_CLAUDE_AUTH_REQUIRED_CODE,
+      agent: "claude",
+      parentToolUseId: "tool-1",
+    });
+    expect(parsed.authCode).toBe(ACP_CLAUDE_AUTH_REQUIRED_CODE);
+    expect(parsed.parentToolUseId).toBe("tool-1");
+
+    // The anchor is optional: a run not started by a tool call has none.
+    expect(
+      AcpAuthRequiredEventSchema.safeParse({
+        type: "acp_auth_required",
+        acpSessionId: "acp-1",
+        authCode: ACP_CLAUDE_AUTH_REQUIRED_CODE,
+        agent: "claude",
+      }).success,
+    ).toBe(true);
   });
 });
 

--- a/assistant/src/acp/agent-process.ts
+++ b/assistant/src/acp/agent-process.ts
@@ -20,15 +20,10 @@ import type {
 import * as acp from "@agentclientprotocol/sdk";
 
 import { getLogger } from "../util/logger.js";
+import { AcpAuthRequiredError, isAcpAuthRequired } from "./auth-required.js";
 import type { AcpAgentConfig } from "./types.js";
 
 const log = getLogger("acp");
-
-/**
- * JSON-RPC error code agents use to signal that authentication is required
- * (matches the SDK's RequestError.authRequired()).
- */
-const AUTH_REQUIRED_CODE = -32000;
 
 /**
  * Rough byte cap for retained stderr. Oldest lines are evicted once the sum of
@@ -36,19 +31,6 @@ const AUTH_REQUIRED_CODE = -32000;
  * stays bounded.
  */
 const STDERR_RETENTION_BYTES = 4096;
-
-/**
- * Detects the ACP auth-required error. Checks the `code` property rather than
- * `instanceof acp.RequestError` so plain JSON-RPC error objects are also
- * recognized.
- */
-function isAuthRequiredError(err: unknown): boolean {
-  return (
-    typeof err === "object" &&
-    err !== null &&
-    (err as { code?: unknown }).code === AUTH_REQUIRED_CODE
-  );
-}
 
 function isEnvVarMethod(
   method: AuthMethod,
@@ -296,7 +278,7 @@ export class AcpAgentProcess {
     try {
       return await op();
     } catch (err) {
-      if (!isAuthRequiredError(err)) {
+      if (!isAcpAuthRequired(err)) {
         throw err;
       }
 
@@ -306,12 +288,28 @@ export class AcpAgentProcess {
 
       const method = this.selectEnvVarAuthMethod();
       if (!method) {
-        throw new Error(
-          `ACP agent "${this.agentId}" requires authentication. ` +
-            `Advertised methods: ${this.describeAuthMethods()}. ` +
-            "Set the required env var under acp.agents.<id>.env in config.json, " +
-            "collect it securely via 'assistant credentials prompt --service acp --field <field> --label \"<label>\"', " +
-            "or complete the agent's own login flow in the workspace.",
+        // Typed, so the session manager can still tell an auth failure from a
+        // crash and surface a re-authentication path. Thrown as a plain Error,
+        // this classification died here.
+        //
+        // The remediation text is split by what the agent actually advertises.
+        // Pointing at env vars and `credentials prompt` is useful only when
+        // the agent HAS an env_var method we failed to satisfy. Adapters that
+        // advertise only interactive `terminal` logins (claude-agent-acp among
+        // them) cannot be fixed that way, and saying otherwise sends the user
+        // and the model chasing a CLI workaround for a credential the app can
+        // repair on its own.
+        throw new AcpAuthRequiredError(
+          this.agentId,
+          this.hasEnvVarAuthMethod()
+            ? `ACP agent "${this.agentId}" requires authentication. ` +
+                `Advertised methods: ${this.describeAuthMethods()}. ` +
+                "Set the required env var under acp.agents.<id>.env in config.json, " +
+                "or collect it securely via 'assistant credentials prompt --service acp --field <field> --label \"<label>\"'."
+            : `ACP agent "${this.agentId}" requires authentication and its ` +
+                "stored credential was not accepted. Advertised methods: " +
+                `${this.describeAuthMethods()}. None can be completed headlessly, ` +
+                "so the credential has to be reconnected.",
         );
       }
 
@@ -323,6 +321,16 @@ export class AcpAgentProcess {
       await connection.authenticate({ methodId: method.id });
       return await op();
     }
+  }
+
+  /**
+   * Whether the agent advertises any `env_var` auth method at all, satisfiable
+   * or not. Distinguishes "we could not satisfy the env var it wants" from
+   * "env vars are not how this agent authenticates", which are different
+   * problems with different fixes.
+   */
+  private hasEnvVarAuthMethod(): boolean {
+    return this.authMethods.some(isEnvVarMethod);
   }
 
   /**

--- a/assistant/src/acp/auth-required.ts
+++ b/assistant/src/acp/auth-required.ts
@@ -1,0 +1,80 @@
+/**
+ * The ACP auth-required signal, and the marker that carries it to the client.
+ *
+ * When a Claude Code turn fails authentication, the CLI injects a synthetic
+ * "Please run /login" assistant message. `claude-agent-acp` deliberately does
+ * NOT pass that TUI-specific text through: it converts it into a structured ACP
+ * `auth_required` rejection so the client can run its own auth flow. That
+ * rejection is the one trustworthy, adapter-agnostic statement that a run died
+ * because its credential is no longer good, and it is what the inline
+ * re-authentication affordance is built on.
+ *
+ * Keeping the signal STRUCTURED matters. The human-readable text around it is
+ * not stable enough to key on: it varies by adapter and by failure mode, and
+ * `deriveFailureError` may replace it wholesale with whatever the adapter last
+ * wrote to stderr (for an expired Claude token, the provider's raw
+ * "401 OAuth access token has expired"). Matching on that string would be
+ * guessing at a moving target when the protocol already told us the answer.
+ */
+
+/**
+ * JSON-RPC error code agents use to signal that authentication is required
+ * (matches the SDK's `RequestError.authRequired()`).
+ */
+export const AUTH_REQUIRED_CODE = -32000;
+
+/**
+ * Raised when an agent rejected an operation with `auth_required` and the
+ * daemon has no way to satisfy it on the user's behalf.
+ *
+ * A distinct type rather than a plain `Error` so the classification survives
+ * the trip to the session manager, which is where the failure becomes an event
+ * the UI can act on. Thrown as a plain `Error`, the fact that this was an
+ * AUTH failure (rather than a crash, a timeout, or a bad prompt) was
+ * unrecoverable by the time anything could offer the user a fix.
+ */
+export class AcpAuthRequiredError extends Error {
+  constructor(
+    readonly agentId: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "AcpAuthRequiredError";
+  }
+}
+
+/**
+ * Detects the ACP auth-required signal in either shape it reaches us: the raw
+ * JSON-RPC rejection from the agent, or our own {@link AcpAuthRequiredError}
+ * after the retry path gave up. Checks the `code` property rather than
+ * `instanceof acp.RequestError` so plain JSON-RPC error objects are also
+ * recognized.
+ */
+export function isAcpAuthRequired(err: unknown): boolean {
+  if (err instanceof AcpAuthRequiredError) {
+    return true;
+  }
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as { code?: unknown }).code === AUTH_REQUIRED_CODE
+  );
+}
+
+/**
+ * Stable, machine-readable marker carried on `acp_session_error` when a
+ * `claude-agent-acp` run failed because its Claude credential needs to be
+ * reconnected. Lets the client offer the same inline "Connect Claude Code"
+ * affordance the missing-token path raises, instead of rendering dead error
+ * text. Kept in lockstep with the web literal in
+ * `clients/web/src/domains/chat/utils/acp-connect.ts`.
+ *
+ * Sibling of `ACP_CLAUDE_OAUTH_MISSING_CODE`, which covers the case where no
+ * token was ever stored. This one covers a token that exists but is no longer
+ * accepted, which is a POST-spawn failure and so cannot ride on the
+ * `acp_spawn` tool result the way the missing-token marker does.
+ */
+export const ACP_CLAUDE_AUTH_REQUIRED_CODE = "acp_claude_auth_required";
+
+/** The adapter whose auth failures the Connect Claude flow can repair. */
+export const CLAUDE_ACP_COMMAND = "claude-agent-acp";

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -16,6 +16,11 @@ import { acpSessionHistory } from "../persistence/schema/index.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { getLogger } from "../util/logger.js";
 import { AcpAgentProcess } from "./agent-process.js";
+import {
+  ACP_CLAUDE_AUTH_REQUIRED_CODE,
+  CLAUDE_ACP_COMMAND,
+  isAcpAuthRequired,
+} from "./auth-required.js";
 import { resolveAgentWithAutoInstall } from "./auto-install.js";
 import { VellumAcpClientHandler } from "./client-handler.js";
 import { deriveFailureError } from "./failure-error.js";
@@ -25,6 +30,46 @@ import { claudeResumeHint } from "./resume-hint.js";
 import type { AcpAgentConfig, AcpSessionState } from "./types.js";
 
 const log = getLogger("acp:session-manager");
+
+/**
+ * Appended to the parent-conversation notification when a run died because its
+ * Claude credential needs reconnecting, so the assistant relays the recovery
+ * the app is actually offering.
+ *
+ * Without this the model receives only the adapter's raw failure text (for an
+ * expired token, a bare "401 ... Re-authenticate to continue") and invents a
+ * remedy: typically `claude setup-token`, pasting a token into chat, or a
+ * Connect card it has not been told exists. Mirrors the wording discipline of
+ * the missing-token message in `prepare-agent-env.ts`, including the ban on
+ * describing where the card is, since placement is a UI detail the model
+ * cannot see.
+ */
+const ACP_AUTH_RECOVERY_GUIDANCE =
+  "The Claude Code connection needs to be re-authorized. The app shows the " +
+  'user an inline "Connect Claude Code" card. Reply with ONE short sentence: ' +
+  "ask them to click Connect to sign in again, and tell them you'll continue " +
+  "automatically once they are connected. Do NOT say where the card is; never " +
+  'say "below", "above", "at the bottom", or "here". Do NOT tell them to run ' +
+  "`claude setup-token`, paste a token in chat, run credential CLI commands, " +
+  "or re-run the agent yourself; the card and auto-continue handle it.";
+
+/**
+ * The client-facing marker for a run that failed because its Claude credential
+ * was rejected, or undefined when this failure is anything else.
+ *
+ * Gated on the adapter as well as the signal: `auth_required` is protocol-level
+ * and any agent can raise it, but the marker promises a repair the Connect
+ * Claude flow can actually perform. Raising it for a codex run would offer a
+ * card that fixes nothing.
+ */
+function claudeAuthRequiredCode(
+  err: unknown,
+  entry: { command: string },
+): string | undefined {
+  return isAcpAuthRequired(err) && entry.command === CLAUDE_ACP_COMMAND
+    ? ACP_CLAUDE_AUTH_REQUIRED_CODE
+    : undefined;
+}
 
 /**
  * The manager's "unknown session id" error. Thrown whenever an operation
@@ -1093,6 +1138,12 @@ export class AcpSessionManager {
             err.message,
             current.process.stderrSince(stderrMark),
           );
+          // Classify BEFORE the message is flattened. `deriveFailureError`
+          // answers "what should a human read", and for an expired Claude
+          // token it returns the provider's raw 401 text, which says nothing
+          // about how to recover. Whether this was an auth failure is a
+          // separate question, and only the structured error can answer it.
+          const errorCode = claudeAuthRequiredCode(err, current);
           if (current.state.status !== "cancelled") {
             current.state.status = "failed";
             current.state.completedAt = Date.now();
@@ -1100,13 +1151,14 @@ export class AcpSessionManager {
           }
           current.currentPrompt = null;
           log.error(
-            { acpSessionId, error: err.message, failureMessage },
+            { acpSessionId, error: err.message, failureMessage, errorCode },
             "ACP prompt failed",
           );
           current.sendToVellum({
             type: "acp_session_error",
             acpSessionId,
             error: failureMessage,
+            ...(errorCode ? { errorCode } : {}),
           });
 
           // Persist the terminal row before teardown clears the buffer.
@@ -1123,7 +1175,8 @@ export class AcpSessionManager {
           if (current.state.status !== "cancelled") {
             this.notifyParent(
               current,
-              `[ACP agent "${current.state.agentId}" failed]\n\n${failureMessage}`,
+              `[ACP agent "${current.state.agentId}" failed]\n\n${failureMessage}` +
+                (errorCode ? `\n\n${ACP_AUTH_RECOVERY_GUIDANCE}` : ""),
             );
           }
         }

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -1154,12 +1154,26 @@ export class AcpSessionManager {
             { acpSessionId, error: err.message, failureMessage, errorCode },
             "ACP prompt failed",
           );
+          // The failure event keeps its exact pre-existing shape so an older
+          // packaged client still parses it and renders the failure. The
+          // recovery signal rides a SEPARATE event, which such a client
+          // ignores rather than choking on; see `api/events/acp-auth-required.ts`.
           current.sendToVellum({
             type: "acp_session_error",
             acpSessionId,
             error: failureMessage,
-            ...(errorCode ? { errorCode } : {}),
           });
+          if (errorCode) {
+            current.sendToVellum({
+              type: "acp_auth_required",
+              acpSessionId,
+              authCode: errorCode,
+              agent: current.state.agentId,
+              ...(current.parentToolUseId
+                ? { parentToolUseId: current.parentToolUseId }
+                : {}),
+            });
+          }
 
           // Persist the terminal row before teardown clears the buffer.
           this.persistTerminal(acpSessionId, current);

--- a/assistant/src/api/events/acp-auth-required.ts
+++ b/assistant/src/api/events/acp-auth-required.ts
@@ -1,0 +1,55 @@
+/**
+ * `acp_auth_required` SSE event.
+ *
+ * Server to client notification that an ACP run failed because the agent
+ * rejected its stored credential, and the client can offer a re-authentication
+ * affordance. Always emitted immediately AFTER the `acp_session_error` that
+ * carries the human-readable failure.
+ *
+ * WHY A SEPARATE EVENT RATHER THAN A FIELD ON `acp_session_error`
+ *
+ * Every event schema here is `.strict()`, and clients parse with
+ * `AssistantEventSchema.safeParse`, falling back to an inert `unknown` event
+ * when parsing fails. A NEW FIELD on an existing event is therefore not
+ * backward compatible: an older packaged client (iOS and macOS bundle the web
+ * app, so they can lag the daemon) has the pre-change strict schema, rejects
+ * the whole event over the unrecognized key, and never handles it. For
+ * `acp_session_error` that would leave the run rendering as still active
+ * forever, which is worse than the plain failure it replaced.
+ *
+ * An unrecognized event TYPE degrades cleanly instead: it becomes the `unknown`
+ * event and is ignored. So old clients keep seeing an unchanged
+ * `acp_session_error` and render the failure exactly as before, while new
+ * clients additionally receive this and can offer the fix. Prefer this shape
+ * for any future additive signal on an existing event.
+ *
+ * Canonical wire-contract source. Re-exported to external consumers via
+ * `@vellumai/assistant-api` (the `api/index.ts` barrel).
+ */
+
+import { z } from "zod";
+
+export const AcpAuthRequiredEventSchema = z
+  .object({
+    type: z.literal("acp_auth_required"),
+    acpSessionId: z.string(),
+    /**
+     * Stable classification of what kind of re-authentication is needed, so
+     * clients branch on a machine-readable value rather than on the failure
+     * text (which varies by adapter and is routinely replaced by whatever the
+     * adapter last wrote to stderr). Currently only
+     * `acp_claude_auth_required`; see `acp/auth-required.ts`.
+     */
+    authCode: z.string(),
+    /** Agent id the run was spawned with, for display. */
+    agent: z.string(),
+    /**
+     * Tool-use id of the `acp_spawn` call that started this run, so the client
+     * can anchor an inline affordance to the right transcript row. Absent when
+     * the run was not started by a tool call.
+     */
+    parentToolUseId: z.string().optional(),
+  })
+  .strict();
+
+export type AcpAuthRequiredEvent = z.infer<typeof AcpAuthRequiredEventSchema>;

--- a/assistant/src/api/events/acp-session-error.ts
+++ b/assistant/src/api/events/acp-session-error.ts
@@ -15,6 +15,17 @@ export const AcpSessionErrorEventSchema = z
     type: z.literal("acp_session_error"),
     acpSessionId: z.string(),
     error: z.string(),
+    /**
+     * Stable classification of WHY the run failed, when the daemon can name it.
+     * The `error` string above is for a human to read and is not stable enough
+     * to branch on: it varies by adapter and is often replaced by whatever the
+     * adapter last wrote to stderr. This field is what clients key off to offer
+     * a targeted recovery affordance.
+     *
+     * Currently only `acp_claude_auth_required` (see `acp/auth-required.ts`).
+     * Optional, and absent for ordinary failures.
+     */
+    errorCode: z.string().optional(),
   })
   .strict();
 

--- a/assistant/src/api/events/acp-session-error.ts
+++ b/assistant/src/api/events/acp-session-error.ts
@@ -15,17 +15,6 @@ export const AcpSessionErrorEventSchema = z
     type: z.literal("acp_session_error"),
     acpSessionId: z.string(),
     error: z.string(),
-    /**
-     * Stable classification of WHY the run failed, when the daemon can name it.
-     * The `error` string above is for a human to read and is not stable enough
-     * to branch on: it varies by adapter and is often replaced by whatever the
-     * adapter last wrote to stderr. This field is what clients key off to offer
-     * a targeted recovery affordance.
-     *
-     * Currently only `acp_claude_auth_required` (see `acp/auth-required.ts`).
-     * Optional, and absent for ordinary failures.
-     */
-    errorCode: z.string().optional(),
   })
   .strict();
 

--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { AcpAuthRequiredEventSchema } from "./events/acp-auth-required.js";
 import { AcpSessionCompletedEventSchema } from "./events/acp-session-completed.js";
 import { AcpSessionErrorEventSchema } from "./events/acp-session-error.js";
 import { AcpSessionSpawnedEventSchema } from "./events/acp-session-spawned.js";
@@ -149,6 +150,10 @@ export {
   SSE_REPLAY_RING_COUNT_LIMIT,
 } from "./constants/sse-replay.js";
 export { DEFAULT_TOOL_EXECUTION_TIMEOUT_SEC } from "./constants/tool-execution.js";
+export {
+  type AcpAuthRequiredEvent,
+  AcpAuthRequiredEventSchema,
+} from "./events/acp-auth-required.js";
 export {
   type AcpSessionCompletedEvent,
   AcpSessionCompletedEventSchema,
@@ -895,6 +900,7 @@ export {
  * migration recipe.
  */
 export const AssistantEventSchema = z.discriminatedUnion("type", [
+  AcpAuthRequiredEventSchema,
   AcpSessionCompletedEventSchema,
   AcpSessionErrorEventSchema,
   AcpSessionSpawnedEventSchema,

--- a/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -73,6 +73,7 @@ import {
   handleAcpSessionUpdate,
   handleAcpSessionUsage,
   handleAcpSessionCompleted,
+  handleAcpAuthRequired,
   handleAcpSessionError,
 } from "@/domains/chat/utils/stream-handlers/acp-handlers";
 import {
@@ -432,6 +433,9 @@ export function useStreamEventHandler(
           break;
         case "acp_session_error":
           handleAcpSessionError(event);
+          break;
+        case "acp_auth_required":
+          handleAcpAuthRequired(event);
           break;
 
         case "background_tool_started":

--- a/clients/web/src/domains/chat/transcript/acp-connect-affordance.tsx
+++ b/clients/web/src/domains/chat/transcript/acp-connect-affordance.tsx
@@ -62,6 +62,9 @@ function AcpConnectAffordanceInner({ assistantId }: { assistantId: string }) {
   const connection = useConnectClaude(assistantId);
   const [pastedCode, setPastedCode] = useState("");
   const [alreadyConnected, setAlreadyConnected] = useState(false);
+  const reason = useInteractionStore(
+    (state) => state.pendingAcpConnect?.reason ?? "missing",
+  );
 
   // Self-heal: if Claude is already connected (e.g. connected from Settings out
   // of band), the store-held prompt is stale — retire it rather than show a CTA
@@ -70,7 +73,17 @@ function AcpConnectAffordanceInner({ assistantId }: { assistantId: string }) {
   // Only acts while the user hasn't started a flow in this card (`phase` still
   // `idle`), so a fresh in-card connect keeps showing its "connected"
   // confirmation instead of unmounting out from under the user.
+  //
+  // Skipped entirely for an `auth_required` prompt. That check answers "is a
+  // usable token stored", which is the right question only when the card was
+  // raised because none was. Here the daemon raised it because the token that
+  // IS stored got rejected by the agent, so a "yes" would retire the card over
+  // the very failure it exists to repair. Such a prompt clears by finishing the
+  // flow or by the user dismissing it, nothing else.
   useEffect(() => {
+    if (reason === "auth_required") {
+      return;
+    }
     let cancelled = false;
     void isClaudeConnected(assistantId)
       .then((connected) => {
@@ -84,7 +97,7 @@ function AcpConnectAffordanceInner({ assistantId }: { assistantId: string }) {
     return () => {
       cancelled = true;
     };
-  }, [assistantId]);
+  }, [assistantId, reason]);
 
   useEffect(() => {
     if (alreadyConnected && connection.phase === "idle") {

--- a/clients/web/src/domains/chat/utils/acp-connect.ts
+++ b/clients/web/src/domains/chat/utils/acp-connect.ts
@@ -13,6 +13,22 @@
 export const ACP_CLAUDE_OAUTH_MISSING_CODE = "acp_claude_oauth_missing";
 
 /**
+ * Sibling marker for a token that EXISTS but is no longer accepted.
+ *
+ * The daemon tags `acp_session_error` with this when a `claude-agent-acp` run
+ * failed on the adapter's structured ACP `auth_required` signal (see
+ * `ACP_CLAUDE_AUTH_REQUIRED_CODE` in `assistant/src/acp/auth-required.ts`).
+ *
+ * It needs its own path because it is a POST-spawn failure: the spawn
+ * succeeded, so there is no failed `acp_spawn` tool result to hang an
+ * `errorCode` on, and the missing-token machinery never fires. The run itself
+ * is what failed, so the affordance is anchored to the run's spawning tool call
+ * instead. The web literal and the daemon literal are a wire contract and must
+ * stay in sync.
+ */
+export const ACP_CLAUDE_AUTH_REQUIRED_CODE = "acp_claude_auth_required";
+
+/**
  * Hidden continuation prompt sent on the user's behalf once the inline Connect
  * card completes, so the assistant picks the task back up without the user
  * having to type "retry". Delivered as a `hidden` send (no user bubble); the

--- a/clients/web/src/domains/chat/utils/chat.ts
+++ b/clients/web/src/domains/chat/utils/chat.ts
@@ -73,6 +73,7 @@ const GLOBAL_STREAM_EVENT_TYPE_NAMES = [
   "acp_session_usage",
   "acp_session_completed",
   "acp_session_error",
+  "acp_auth_required",
   // Background-tool lifecycle events route by their `id` into the global
   // background-task store. They carry a top-level `conversationId`, but gating
   // them on the active conversation would drop a `background_tool_completed`

--- a/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.test.ts
@@ -4,6 +4,7 @@ import { useAcpRunStore } from "@/domains/chat/acp-run-store";
 import { useInteractionStore } from "@/domains/chat/interaction-store";
 import { ACP_CLAUDE_AUTH_REQUIRED_CODE } from "@/domains/chat/utils/acp-connect";
 import {
+  handleAcpAuthRequired,
   handleAcpSessionSpawned,
   handleAcpSessionUpdate,
   handleAcpSessionUsage,
@@ -248,7 +249,7 @@ describe("handleAcpSessionError", () => {
 // Connect Claude affordance on an auth_required failure
 // ---------------------------------------------------------------------------
 
-describe("handleAcpSessionError — Claude re-authentication", () => {
+describe("handleAcpAuthRequired", () => {
   beforeEach(() => {
     useInteractionStore.setState({
       pendingAcpConnect: null,
@@ -256,15 +257,20 @@ describe("handleAcpSessionError — Claude re-authentication", () => {
     });
   });
 
+  function authRequired(overrides: Record<string, unknown> = {}) {
+    handleAcpAuthRequired({
+      type: "acp_auth_required",
+      acpSessionId: "acp-1",
+      authCode: ACP_CLAUDE_AUTH_REQUIRED_CODE,
+      agent: "claude",
+      parentToolUseId: "tool-1",
+      ...overrides,
+    } as Parameters<typeof handleAcpAuthRequired>[0]);
+  }
+
   it("raises the Connect prompt anchored to the run's spawning tool call", () => {
     spawn();
-    handleAcpSessionError({
-      type: "acp_session_error",
-      acpSessionId: "acp-1",
-      error:
-        "Failed to authenticate. API Error: 401 OAuth access token expired",
-      errorCode: ACP_CLAUDE_AUTH_REQUIRED_CODE,
-    });
+    authRequired();
 
     // Anchored to the acp_spawn call, not the run: that is the transcript row
     // the affordance renders under.
@@ -278,25 +284,34 @@ describe("handleAcpSessionError — Claude re-authentication", () => {
     // The card's self-heal asks "is a token stored". Here one IS stored and the
     // agent rejected it, so answering that question must not retire the card.
     spawn();
-    handleAcpSessionError({
-      type: "acp_session_error",
-      acpSessionId: "acp-1",
-      error: "auth",
-      errorCode: ACP_CLAUDE_AUTH_REQUIRED_CODE,
-    });
+    authRequired();
 
     expect(useInteractionStore.getState().pendingAcpConnect?.reason).toBe(
       "auth_required",
     );
   });
 
-  it("leaves an ordinary failure alone", () => {
+  it("falls back to the run store when the event carries no anchor", () => {
+    // A session spawned before the daemon sent parentToolUseId on this event.
     spawn();
-    handleAcpSessionError({
-      type: "acp_session_error",
-      acpSessionId: "acp-1",
-      error: "boom",
-    });
+    authRequired({ parentToolUseId: undefined });
+
+    expect(useInteractionStore.getState().pendingAcpConnect?.toolUseId).toBe(
+      "tool-1",
+    );
+  });
+
+  it("skips the prompt when there is no anchor anywhere", () => {
+    // With no tool call to render under, the run keeps its plain failed
+    // rendering rather than putting a card in the wrong place.
+    authRequired({ acpSessionId: "acp-unknown", parentToolUseId: undefined });
+
+    expect(useInteractionStore.getState().pendingAcpConnect).toBeNull();
+  });
+
+  it("ignores an auth code it does not recognize", () => {
+    spawn();
+    authRequired({ authCode: "some_future_agent_auth" });
 
     expect(useInteractionStore.getState().pendingAcpConnect).toBeNull();
   });
@@ -304,33 +319,32 @@ describe("handleAcpSessionError — Claude re-authentication", () => {
   it("does not raise a prompt for a cancelled run", () => {
     spawn();
     getState().cancelRun({ acpSessionId: "acp-1", completedAt: Date.now() });
-    handleAcpSessionError({
-      type: "acp_session_error",
-      acpSessionId: "acp-1",
-      error: "auth",
-      errorCode: ACP_CLAUDE_AUTH_REQUIRED_CODE,
-    });
+    authRequired();
 
     expect(useInteractionStore.getState().pendingAcpConnect).toBeNull();
   });
+});
 
-  it("skips the prompt when the run has no spawning tool call to anchor to", () => {
-    // Older daemons omit parentToolUseId; with no anchor the transcript has
-    // nowhere to render the card, so the run keeps its plain failed rendering.
-    handleAcpSessionSpawned({
-      type: "acp_session_spawned",
-      acpSessionId: "acp-2",
-      agent: "claude",
-      parentConversationId: "conv-1",
-      task: "no anchor",
+describe("handleAcpSessionError stays additive-safe", () => {
+  beforeEach(() => {
+    useInteractionStore.setState({
+      pendingAcpConnect: null,
+      dismissedAcpConnectToolUseIds: new Set<string>(),
     });
+  });
+
+  it("marks the run failed and raises nothing on its own", () => {
+    // The failure event keeps its pre-existing shape so an older packaged
+    // client still parses it; the recovery signal rides its own event.
+    spawn();
     handleAcpSessionError({
       type: "acp_session_error",
-      acpSessionId: "acp-2",
-      error: "auth",
-      errorCode: ACP_CLAUDE_AUTH_REQUIRED_CODE,
+      acpSessionId: "acp-1",
+      error:
+        "Failed to authenticate. API Error: 401 OAuth access token expired",
     });
 
+    expect(getState().byId["acp-1"]?.status).toBe("failed");
     expect(useInteractionStore.getState().pendingAcpConnect).toBeNull();
   });
 });

--- a/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it } from "bun:test";
 
 import { useAcpRunStore } from "@/domains/chat/acp-run-store";
+import { useInteractionStore } from "@/domains/chat/interaction-store";
+import { ACP_CLAUDE_AUTH_REQUIRED_CODE } from "@/domains/chat/utils/acp-connect";
 import {
   handleAcpSessionSpawned,
   handleAcpSessionUpdate,
@@ -239,5 +241,96 @@ describe("handleAcpSessionError", () => {
     const entry = getState().byId["acp-1"];
     expect(entry?.status).toBe("cancelled");
     expect(entry?.error).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Connect Claude affordance on an auth_required failure
+// ---------------------------------------------------------------------------
+
+describe("handleAcpSessionError — Claude re-authentication", () => {
+  beforeEach(() => {
+    useInteractionStore.setState({
+      pendingAcpConnect: null,
+      dismissedAcpConnectToolUseIds: new Set<string>(),
+    });
+  });
+
+  it("raises the Connect prompt anchored to the run's spawning tool call", () => {
+    spawn();
+    handleAcpSessionError({
+      type: "acp_session_error",
+      acpSessionId: "acp-1",
+      error:
+        "Failed to authenticate. API Error: 401 OAuth access token expired",
+      errorCode: ACP_CLAUDE_AUTH_REQUIRED_CODE,
+    });
+
+    // Anchored to the acp_spawn call, not the run: that is the transcript row
+    // the affordance renders under.
+    expect(useInteractionStore.getState().pendingAcpConnect).toEqual({
+      toolUseId: "tool-1",
+      reason: "auth_required",
+    });
+  });
+
+  it("marks the prompt auth_required so it cannot self-dismiss on a presence check", () => {
+    // The card's self-heal asks "is a token stored". Here one IS stored and the
+    // agent rejected it, so answering that question must not retire the card.
+    spawn();
+    handleAcpSessionError({
+      type: "acp_session_error",
+      acpSessionId: "acp-1",
+      error: "auth",
+      errorCode: ACP_CLAUDE_AUTH_REQUIRED_CODE,
+    });
+
+    expect(useInteractionStore.getState().pendingAcpConnect?.reason).toBe(
+      "auth_required",
+    );
+  });
+
+  it("leaves an ordinary failure alone", () => {
+    spawn();
+    handleAcpSessionError({
+      type: "acp_session_error",
+      acpSessionId: "acp-1",
+      error: "boom",
+    });
+
+    expect(useInteractionStore.getState().pendingAcpConnect).toBeNull();
+  });
+
+  it("does not raise a prompt for a cancelled run", () => {
+    spawn();
+    getState().cancelRun({ acpSessionId: "acp-1", completedAt: Date.now() });
+    handleAcpSessionError({
+      type: "acp_session_error",
+      acpSessionId: "acp-1",
+      error: "auth",
+      errorCode: ACP_CLAUDE_AUTH_REQUIRED_CODE,
+    });
+
+    expect(useInteractionStore.getState().pendingAcpConnect).toBeNull();
+  });
+
+  it("skips the prompt when the run has no spawning tool call to anchor to", () => {
+    // Older daemons omit parentToolUseId; with no anchor the transcript has
+    // nowhere to render the card, so the run keeps its plain failed rendering.
+    handleAcpSessionSpawned({
+      type: "acp_session_spawned",
+      acpSessionId: "acp-2",
+      agent: "claude",
+      parentConversationId: "conv-1",
+      task: "no anchor",
+    });
+    handleAcpSessionError({
+      type: "acp_session_error",
+      acpSessionId: "acp-2",
+      error: "auth",
+      errorCode: ACP_CLAUDE_AUTH_REQUIRED_CODE,
+    });
+
+    expect(useInteractionStore.getState().pendingAcpConnect).toBeNull();
   });
 });

--- a/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.ts
@@ -1,4 +1,5 @@
 import type {
+  AcpAuthRequiredEvent,
   AcpSessionSpawnedEvent,
   AcpSessionUpdateEvent,
   AcpSessionUsageEvent,
@@ -88,31 +89,45 @@ export function handleAcpSessionError(event: AcpSessionErrorEvent): void {
   if (store.byId[event.acpSessionId]?.status === "cancelled") {
     return;
   }
-  const entry = store.byId[event.acpSessionId];
   store.setTerminal({
     acpSessionId: event.acpSessionId,
     status: "failed",
     error: event.error,
     completedAt: Date.now(),
   });
+}
 
-  // The run's Claude credential was rejected. Raise the same inline Connect
-  // affordance the missing-token path uses, anchored to the tool call that
-  // spawned this run so it renders under that activity group. Without an
-  // anchor there is nowhere to put it, so an older daemon that omitted
-  // `parentToolUseId` simply keeps the plain failed-run rendering.
-  //
-  // Held in the interaction store rather than on the run entry for the same
-  // reason as the missing-token prompt: it has to survive the routine
-  // post-turn `/messages` reseed, which rebuilds the transcript from
-  // persisted history.
+/**
+ * The run's Claude credential was rejected. Raise the same inline Connect
+ * affordance the missing-token path uses, anchored to the tool call that
+ * spawned the run so it renders under that activity group.
+ *
+ * Arrives as its own event, immediately after the `acp_session_error` that
+ * marked the run failed, so the failure still renders on clients too old to
+ * know this event exists.
+ *
+ * Held in the interaction store rather than on the run entry for the same
+ * reason as the missing-token prompt: it has to survive the routine post-turn
+ * `/messages` reseed, which rebuilds the transcript from persisted history.
+ */
+export function handleAcpAuthRequired(event: AcpAuthRequiredEvent): void {
+  // A run the user already stopped is not a failure to recover from.
   if (
-    event.errorCode === ACP_CLAUDE_AUTH_REQUIRED_CODE &&
-    entry?.parentToolUseId
+    useAcpRunStore.getState().byId[event.acpSessionId]?.status === "cancelled"
   ) {
-    useInteractionStore.getState().showAcpConnect({
-      toolUseId: entry.parentToolUseId,
-      reason: "auth_required",
-    });
+    return;
   }
+  // The daemon sends the anchor, falling back to the run store for a session
+  // spawned before it did. With neither there is nowhere to render the card,
+  // so the run keeps its plain failed rendering.
+  const toolUseId =
+    event.parentToolUseId ??
+    useAcpRunStore.getState().byId[event.acpSessionId]?.parentToolUseId;
+  if (event.authCode !== ACP_CLAUDE_AUTH_REQUIRED_CODE || !toolUseId) {
+    return;
+  }
+  useInteractionStore.getState().showAcpConnect({
+    toolUseId,
+    reason: "auth_required",
+  });
 }

--- a/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.ts
@@ -7,6 +7,8 @@ import type {
 } from "@vellumai/assistant-api";
 
 import { useAcpRunStore } from "@/domains/chat/acp-run-store";
+import { useInteractionStore } from "@/domains/chat/interaction-store";
+import { ACP_CLAUDE_AUTH_REQUIRED_CODE } from "@/domains/chat/utils/acp-connect";
 
 export function handleAcpSessionSpawned(event: AcpSessionSpawnedEvent): void {
   useAcpRunStore.getState().spawnRun({
@@ -86,10 +88,31 @@ export function handleAcpSessionError(event: AcpSessionErrorEvent): void {
   if (store.byId[event.acpSessionId]?.status === "cancelled") {
     return;
   }
+  const entry = store.byId[event.acpSessionId];
   store.setTerminal({
     acpSessionId: event.acpSessionId,
     status: "failed",
     error: event.error,
     completedAt: Date.now(),
   });
+
+  // The run's Claude credential was rejected. Raise the same inline Connect
+  // affordance the missing-token path uses, anchored to the tool call that
+  // spawned this run so it renders under that activity group. Without an
+  // anchor there is nowhere to put it, so an older daemon that omitted
+  // `parentToolUseId` simply keeps the plain failed-run rendering.
+  //
+  // Held in the interaction store rather than on the run entry for the same
+  // reason as the missing-token prompt: it has to survive the routine
+  // post-turn `/messages` reseed, which rebuilds the transcript from
+  // persisted history.
+  if (
+    event.errorCode === ACP_CLAUDE_AUTH_REQUIRED_CODE &&
+    entry?.parentToolUseId
+  ) {
+    useInteractionStore.getState().showAcpConnect({
+      toolUseId: entry.parentToolUseId,
+      reason: "auth_required",
+    });
+  }
 }

--- a/clients/web/src/types/interaction-ui-types.ts
+++ b/clients/web/src/types/interaction-ui-types.ts
@@ -71,9 +71,22 @@ export interface PendingQuestionState {
 }
 
 export interface PendingAcpConnectState {
-  /** The failed `acp_spawn` tool call this Connect prompt is anchored to, so
-   *  the inline affordance renders under the right activity group. */
+  /** The `acp_spawn` tool call this Connect prompt is anchored to, so the
+   *  inline affordance renders under the right activity group. For a
+   *  missing-token failure that is the call that failed; for `auth_required`
+   *  the spawn succeeded, so it is the call that started the failed run. */
   toolUseId: string;
+  /**
+   * Why Connect is being offered, which decides whether the affordance may
+   * self-dismiss once a token is present.
+   *
+   * - `missing` (default): no token was stored, so a token appearing means the
+   *   problem is solved and a stale card should retire itself.
+   * - `auth_required`: a token WAS stored and the agent rejected it. Presence
+   *   proves nothing here, so the card must not retire on a connected check;
+   *   only finishing the flow (or dismissing it) clears it.
+   */
+  reason?: "missing" | "auth_required";
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## TL;DR

When a Claude Code run fails because its credential was rejected, the user now gets the inline "Connect Claude Code" card instead of dead error text, and the task auto-continues once they reconnect.

Fixes [LUM-3205](https://linear.app/vellum/issue/LUM-3205/claude-acp-failures-do-not-expose-an-actionable-re-authentication-path).

> **Stacked on #40560** (base is `ashlee/lum-3205-acp-claude-token-refresh`, not `main`). It depends on the expiry tracking added there: without it the card self-dismisses on mount. Merge #40560 first.

## Why no card appeared

An expired token fails *after* the spawn succeeds. The existing Connect card is raised from a failed `acp_spawn` tool result carrying `acp_claude_oauth_missing`, and here the spawn worked fine, so none of that machinery runs. The failure arrives later, asynchronously, through `acp_session_error`.

The signal needed to fix it already existed and was being discarded. When a turn fails authentication, `claude-agent-acp` converts the CLI's TUI-specific "Please run /login" message into a **structured ACP `auth_required` rejection** (JSON-RPC `-32000`), with a comment in the adapter saying it does this so the client can run its own auth flow. Three layers erased it before anything could act:

1. `withAuthRetry` detected it, then rethrew a plain `Error` — dropping the classification.
2. `deriveFailureError` replaced even that message with the adapter's raw stderr `401 ... Re-authenticate to continue`.
3. `acp_session_error` carried only a human-readable string, so the client had nothing to branch on.

That is also why the assistant hallucinated a Connect card: `notifyParent` handed the model a bare failure string with no guidance, and it reached for the remedy it knew from the missing-token path.

## Design

**Carry the classification, don't re-derive it.** `AcpAuthRequiredError` keeps the fact alive from `agent-process` to the session manager. No string matching: the error text varies by adapter and is routinely replaced by stderr, so keying on it would mean guessing at a moving target when the protocol already told us the answer.

**The signal rides its own event, not a new field.** Every event schema is `.strict()`, and clients parse with `AssistantEventSchema.safeParse`, falling back to an inert `unknown` event on failure. A new *field* on `acp_session_error` is therefore not backward compatible: a packaged client that lags the daemon (iOS and macOS bundle the web app; the web bundle itself is always current) carries the pre-change schema, rejects the whole event over the unrecognized key, and never marks the run failed. It would render as still active forever, which is worse than the plain failure. An unrecognized event *type* degrades cleanly instead, so `acp_session_error` keeps its exact prior shape and a new `acp_auth_required` follows it. Old clients render the failure as before and ignore the new event.

**Gated on the adapter, not just the signal.** `auth_required` is protocol-level and any agent can raise it, but the marker promises a repair only the Connect Claude flow can perform. A codex run raising it would get a card that fixes nothing.

**Remediation text now matches what the agent advertises.** The old message recommended env vars and the credential-prompt CLI, which helps only when the agent advertises an `env_var` auth method. `claude-agent-acp` advertises only interactive `terminal` logins, so that advice sent the user and the model chasing a CLI workaround for a credential the app repairs itself.

**The card cannot self-dismiss here.** `PendingAcpConnectState` gains a `reason`. The affordance self-heals by asking "is a token stored", which is the right question only when it was raised because none was. For `auth_required` a token *is* stored and the agent rejected it, so that check would retire the card over the very failure it exists to repair.

## Why this is safe

- **Additive on the wire, verifiably.** `acp_session_error` is byte-identical to before, and a test asserts it *rejects* unknown keys so the reason this signal lives in its own event stays visible to whoever next wants to add a field to a wire event.
- **No behavior change for non-auth failures.** The classifier returns undefined, and the event, the run card, and the parent notification are unchanged.
- **Cancelled runs are untouched.** The existing cancel guard returns before the card logic, so stopping a run never raises a Connect prompt.
- **Degrades cleanly in both directions.** An older client ignores the new event and still shows the failure. Against an older daemon, no `parentToolUseId` means no anchor, so the transcript keeps its plain failed-run rendering rather than putting a card in the wrong place. The anchor comes from the daemon, which knows it authoritatively, with the run store as a fallback.
- **Reuses the audited flow.** The OAuth card, the version gate, the dismissal bookkeeping, and the auto-continue are all existing code; this adds a second way to raise the same prompt.
- **Survives the reseed.** The prompt is held in the interaction store, not on a reseed-able tool-call field, matching the missing-token path.

## What changes for the user

| Situation | Before | After |
|---|---|---|
| Claude run fails on a rejected credential | ACP panel shows a raw `401 ... Re-authenticate to continue` with nothing to click | Inline "Connect Claude Code" card under the same activity group |
| After reconnecting | Had to notice, re-ask, and re-run the task | Auto-continues via the existing hidden continuation prompt |
| What the assistant says | Invents a fix: a setup-token command, paste a token, or a card that isn't there | One sentence pointing at the card, with CLI workarounds explicitly ruled out |
| A codex (non-Claude) auth failure | Plain error | Unchanged: no card, since Connect Claude cannot repair it |
| Any other run failure | Plain error | Unchanged |

## Verification

`bunx tsc --noEmit` and `bun run lint` pass in both `assistant/` and `clients/web/`, and the pinned prettier is clean. Local test runs are blocked by a standing hook in this environment, so the suites run in CI.

Coverage: both shapes the signal travels in (the raw JSON-RPC object off the wire and our own error after the retry path gives up), the negative cases, and the two literals that form the wire contract with the web client. On the web side: the anchor lands on the spawning tool call, the prompt is marked `auth_required`, an ordinary failure raises nothing, a cancelled run raises nothing, and a run with no anchor is skipped.

## Deferred

- **A hard page reload loses the card.** The prompt lives in the interaction store, and unlike the missing-token path there is no persisted tool-call `errorCode` to rebuild it from, because the tool call succeeded. The routine post-turn `/messages` reseed (the common case) is unaffected. Rebuilding it would mean persisting the code on the ACP run row and hydrating it client-side; `seedFromHistory` on the ACP run store has no production caller yet, so that is its own piece of work.
- **[LUM-3212](https://linear.app/vellum/issue/LUM-3212/acp-resumesteer-auth-failures-reach-the-client-unclassified) — resume/steer auth failures are still unclassified.** The approval-gated resume worker in `acp-routes.ts` is the other producer of `acp_session_error` and forwards a bare message. Recovering the classification there is easy (`AcpResumeError` wraps the cause), but the adapter gate needs the session entry's `command`, which does not exist for a failure inside `resumeFromHistory`. Shipping only the half that works would leave a silent gap that reads as covered, so the design question is written down rather than half-fixed. Much of that path is also gated on LUM-3208 for the anchor.
- **A refreshed token that is still rejected** (an entitlement change rather than an expiry) shows the card, which reconnecting may not fix. Distinguishing that needs a signal the adapter does not currently give us.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
