### PR TITLE
fix(web): anchor the personality peekers to the stage, not the layout viewport

### DIFF
--- a/clients/web/src/domains/onboarding/components/onboarding-story-fixtures.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-story-fixtures.tsx
@@ -39,10 +39,19 @@ export function StageHost({
   children,
   insetTop = 0,
   insetBottom = 0,
+  insetLeft = 0,
+  insetRight = 0,
 }: {
   children: ReactNode;
   insetTop?: number;
   insetBottom?: number;
+  /**
+   * Horizontal insets, which the shell applies in landscape on a notched
+   * device. They make the stage narrower than the layout viewport, which is
+   * the case a `vw`-anchored child gets wrong.
+   */
+  insetLeft?: number;
+  insetRight?: number;
 }) {
   return (
     <div
@@ -51,6 +60,8 @@ export function StageHost({
         height: "100dvh",
         paddingTop: insetTop,
         paddingBottom: insetBottom,
+        paddingLeft: insetLeft,
+        paddingRight: insetRight,
       }}
     >
       <div

--- a/clients/web/src/domains/onboarding/screens/create-personality-step.stories.tsx
+++ b/clients/web/src/domains/onboarding/screens/create-personality-step.stories.tsx
@@ -1,0 +1,92 @@
+/**
+ * The five personality sliders, with an avatar peeking in from each screen edge
+ * as a slider is dragged toward that end.
+ *
+ * The peeking avatars anchor with `calc(50% - 50vw)`, which mixes two boxes:
+ * `50%` resolves against the containing block, `50vw` against the layout
+ * viewport. They agree only while the stage is exactly viewport-width, so
+ * `LandscapeWithSideInsets` is the story that matters: the app shell pads by
+ * `env(safe-area-inset-left/right)` in landscape on a notched device, and the
+ * two boxes come apart by that inset.
+ *
+ * The avatars are hidden below 640px, so every story here is at a width that
+ * shows them.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+
+import { CreatePersonalityStep } from "./create-personality-step";
+import { OnboardingStage } from "@/domains/onboarding/components/onboarding-stage";
+import {
+  SeededAvatarPool,
+  StageHost,
+} from "@/domains/onboarding/components/onboarding-story-fixtures";
+
+/** Drives the sliders as the route does, so dragging moves the avatars. */
+function PersonalityStep({ initial }: { initial?: Record<string, number> }) {
+  const [values, setValues] = useState<Record<string, number>>(initial ?? {});
+  return (
+    <CreatePersonalityStep
+      values={values}
+      onValueChange={(axisId, value) =>
+        setValues((prev) => ({ ...prev, [axisId]: value }))
+      }
+      locked={false}
+      onContinue={() => {}}
+      onBack={() => {}}
+    />
+  );
+}
+
+/** Every slider pushed to its right end, so all five right-side avatars show. */
+const ALL_RIGHT: Record<string, number> = {
+  "companion-coworker": 100,
+  "genz-boomer": 100,
+  "execute-collaborate": 100,
+  "playful-serious": 100,
+  "polite-unfiltered": 100,
+};
+
+const meta: Meta<typeof CreatePersonalityStep> = {
+  title: "Onboarding/CreatePersonalityStep",
+  parameters: { layout: "fullscreen", controls: { disable: true } },
+  render: () => (
+    <StageHost>
+      <OnboardingStage className="bg-[var(--surface-base)] text-[var(--content-default)]">
+        <SeededAvatarPool>
+          <PersonalityStep initial={ALL_RIGHT} />
+        </SeededAvatarPool>
+      </OnboardingStage>
+    </StageHost>
+  ),
+};
+
+export default meta;
+type Story = StoryObj<typeof CreatePersonalityStep>;
+
+/** Desktop, no insets: the stage is viewport-width, so the two boxes agree. */
+export const Desktop: Story = {
+  globals: { viewport: { value: "sbDesktop" } },
+};
+
+/**
+ * Landscape on a notched device: the shell pads 59px on the notch side and 34px
+ * for the home indicator, so the stage is narrower than the viewport and the
+ * `50vw` half of the anchor no longer matches the `50%` half.
+ *
+ * The peeking avatars should rest against the stage's edge, inside the padded
+ * frame. Any part of them sitting on the light inset band is the anchor
+ * resolving against the wrong box.
+ */
+export const LandscapeWithSideInsets: Story = {
+  render: () => (
+    <StageHost insetLeft={59} insetRight={34} insetTop={0} insetBottom={21}>
+      <OnboardingStage className="bg-[var(--surface-base)] text-[var(--content-default)]">
+        <SeededAvatarPool>
+          <PersonalityStep initial={ALL_RIGHT} />
+        </SeededAvatarPool>
+      </OnboardingStage>
+    </StageHost>
+  ),
+};

--- a/clients/web/src/domains/onboarding/screens/create-personality-step.stories.tsx
+++ b/clients/web/src/domains/onboarding/screens/create-personality-step.stories.tsx
@@ -82,7 +82,10 @@ export const Desktop: Story = {
  * the `EDGE_GAP` intends, is the anchor resolving against the wrong box.
  */
 export const LandscapeWithSideInsets: Story = {
-  globals: { viewport: { value: "sbDesktop" } },
+  // Rotated phone: 844x390, wide enough for the avatars to render at all
+  // (they are hidden below 640px) and the shape a notched device is in when
+  // the shell applies left/right insets.
+  globals: { viewport: { value: "sbMobile", isRotated: true } },
   render: function Render(args) {
     const [{ values }, updateArgs] = useArgs<{
       values: Record<string, number>;

--- a/clients/web/src/domains/onboarding/screens/create-personality-step.stories.tsx
+++ b/clients/web/src/domains/onboarding/screens/create-personality-step.stories.tsx
@@ -2,44 +2,26 @@
  * The five personality sliders, with an avatar peeking in from each screen edge
  * as a slider is dragged toward that end.
  *
- * The peeking avatars anchor with `calc(50% - 50vw)`, which mixes two boxes:
- * `50%` resolves against the containing block, `50vw` against the layout
- * viewport. They agree only while the stage is exactly viewport-width, so
- * `LandscapeWithSideInsets` is the story that matters: the app shell pads by
- * `env(safe-area-inset-left/right)` in landscape on a notched device, and the
- * two boxes come apart by that inset.
+ * The peeking avatars anchor to the edge of the box they live in. `50%` in a
+ * CSS inset resolves against the containing block and `vw` against the layout
+ * viewport, so anchoring with a mix of the two only lands correctly while the
+ * stage is exactly viewport-width. `LandscapeWithSideInsets` is the story that
+ * holds that honest: the app shell pads by `env(safe-area-inset-left/right)`,
+ * and an avatar anchored to the viewport is pushed
+ * `(stageWidth - viewportWidth) / 2` outside the stage, where `overflow-hidden`
+ * clips it.
  *
- * The avatars are hidden below 640px, so every story here is at a width that
- * shows them.
+ * The avatars are hidden below 640px, so every story here is wider than that.
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { useState } from "react";
+import { useArgs } from "storybook/preview-api";
 
 import { CreatePersonalityStep } from "./create-personality-step";
 import { OnboardingStage } from "@/domains/onboarding/components/onboarding-stage";
-import {
-  SeededAvatarPool,
-  StageHost,
-} from "@/domains/onboarding/components/onboarding-story-fixtures";
+import { StageHost } from "@/domains/onboarding/components/onboarding-story-fixtures";
 
-/** Drives the sliders as the route does, so dragging moves the avatars. */
-function PersonalityStep({ initial }: { initial?: Record<string, number> }) {
-  const [values, setValues] = useState<Record<string, number>>(initial ?? {});
-  return (
-    <CreatePersonalityStep
-      values={values}
-      onValueChange={(axisId, value) =>
-        setValues((prev) => ({ ...prev, [axisId]: value }))
-      }
-      locked={false}
-      onContinue={() => {}}
-      onBack={() => {}}
-    />
-  );
-}
-
-/** Every slider pushed to its right end, so all five right-side avatars show. */
+/** Every slider at its right end, so all five right-side avatars are fully in. */
 const ALL_RIGHT: Record<string, number> = {
   "companion-coworker": 100,
   "genz-boomer": 100,
@@ -50,43 +32,73 @@ const ALL_RIGHT: Record<string, number> = {
 
 const meta: Meta<typeof CreatePersonalityStep> = {
   title: "Onboarding/CreatePersonalityStep",
-  parameters: { layout: "fullscreen", controls: { disable: true } },
-  render: () => (
-    <StageHost>
-      <OnboardingStage className="bg-[var(--surface-base)] text-[var(--content-default)]">
-        <SeededAvatarPool>
-          <PersonalityStep initial={ALL_RIGHT} />
-        </SeededAvatarPool>
-      </OnboardingStage>
-    </StageHost>
-  ),
+  parameters: { layout: "fullscreen" },
+  args: {
+    values: ALL_RIGHT,
+    locked: false,
+    onContinue: () => {},
+    onBack: () => {},
+  },
+  argTypes: {
+    locked: { control: "boolean" },
+    values: { control: "object" },
+  },
+  render: function Render(args) {
+    // Controlled component: the route owns `values`, so the story owns them
+    // through args and the sliders stay draggable.
+    const [{ values }, updateArgs] = useArgs<{
+      values: Record<string, number>;
+    }>();
+    return (
+      <StageHost>
+        <OnboardingStage className="bg-[var(--surface-base)] text-[var(--content-default)]">
+          <CreatePersonalityStep
+            {...args}
+            values={values}
+            onValueChange={(axisId, value) =>
+              updateArgs({ values: { ...values, [axisId]: value } })
+            }
+          />
+        </OnboardingStage>
+      </StageHost>
+    );
+  },
 };
 
 export default meta;
 type Story = StoryObj<typeof CreatePersonalityStep>;
 
-/** Desktop, no insets: the stage is viewport-width, so the two boxes agree. */
+/** Desktop, no insets: the stage is viewport-width, so both boxes agree. */
 export const Desktop: Story = {
   globals: { viewport: { value: "sbDesktop" } },
 };
 
 /**
  * Landscape on a notched device: the shell pads 59px on the notch side and 34px
- * for the home indicator, so the stage is narrower than the viewport and the
- * `50vw` half of the anchor no longer matches the `50%` half.
+ * for the home indicator, so the stage is narrower than the viewport.
  *
  * The peeking avatars should rest against the stage's edge, inside the padded
- * frame. Any part of them sitting on the light inset band is the anchor
- * resolving against the wrong box.
+ * frame. Any of them sitting on the light inset band, or cut off harder than
+ * the `EDGE_GAP` intends, is the anchor resolving against the wrong box.
  */
 export const LandscapeWithSideInsets: Story = {
-  render: () => (
-    <StageHost insetLeft={59} insetRight={34} insetTop={0} insetBottom={21}>
-      <OnboardingStage className="bg-[var(--surface-base)] text-[var(--content-default)]">
-        <SeededAvatarPool>
-          <PersonalityStep initial={ALL_RIGHT} />
-        </SeededAvatarPool>
-      </OnboardingStage>
-    </StageHost>
-  ),
+  globals: { viewport: { value: "sbDesktop" } },
+  render: function Render(args) {
+    const [{ values }, updateArgs] = useArgs<{
+      values: Record<string, number>;
+    }>();
+    return (
+      <StageHost insetLeft={59} insetRight={34} insetBottom={21}>
+        <OnboardingStage className="bg-[var(--surface-base)] text-[var(--content-default)]">
+          <CreatePersonalityStep
+            {...args}
+            values={values}
+            onValueChange={(axisId, value) =>
+              updateArgs({ values: { ...values, [axisId]: value } })
+            }
+          />
+        </OnboardingStage>
+      </StageHost>
+    );
+  },
 };

--- a/clients/web/src/domains/onboarding/screens/create-personality-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/create-personality-step.tsx
@@ -192,12 +192,16 @@ function resolveSideColors(
 }
 
 /**
- * One personality avatar peeking in from a screen edge. It's anchored to the
- * true viewport edge via `calc(50% - 50vw)` — the overlay is full-width, so 50%
- * is screen-center and pulling back 50vw lands on the edge — and to `top` for
- * its scattered vertical slot. `progress` (0 at center → 1 at the far end)
- * drives how far it slides in, plus a little grow + fade so the entrance feels
- * alive. Never intercepts pointer events.
+ * One personality avatar peeking in from a stage edge, and `top` for its
+ * scattered vertical slot. `progress` (0 at center to 1 at the far end) drives
+ * how far it slides in, plus a little grow + fade so the entrance feels alive.
+ * Never intercepts pointer events.
+ *
+ * The inset is `0`, resolving against the overlay (`inset-0` on the stage), so
+ * the avatar rests on the edge of the box it lives in. Anchoring to the layout
+ * viewport instead would put it `(stageWidth - viewportWidth) / 2` outside the
+ * stage, where `overflow-hidden` clips it: on a notched device in landscape
+ * that is 46.5px of a 160px avatar. See the `LandscapeWithSideInsets` story.
  */
 function EdgePeekAvatar({
   components,
@@ -224,7 +228,7 @@ function EdgePeekAvatar({
       aria-hidden="true"
       className="pointer-events-none absolute"
       style={{
-        [side]: "calc(50% - 50vw)",
+        [side]: 0,
         top,
         width: size,
         height: size,


### PR DESCRIPTION
## TL;DR

`EdgePeekAvatar` anchored itself with `calc(50% - 50vw)`, mixing two boxes: `50%` resolves against the containing block, `50vw` against the layout viewport. On a notched device in landscape the app shell pads by `env(safe-area-inset-left/right)`, the two come apart, and **29% of each avatar is silently clipped**.

One-line fix: the inset becomes `0`, so it resolves against the box it lives in.

Fixes LUM-3198.

## Measured, not argued

On an 844x390 viewport with 59px/34px side insets (`LandscapeWithSideInsets`, added here):

| | Before | After |
|---|---|---|
| Stage width | 751px (viewport 844px) | same |
| Computed inset | **-46.5px** | **0px** |
| Right peeker vs stage edge | 46.5px **outside**, clipped | 26px **inside** |

`-46.5` is exactly `(751 - 844) / 2`. The `26px` inside is the intended `EDGE_GAP` (0.16 x 160px = 25.6). At that width the avatars are 160px, so the old anchor cut 46.5px off each one.

## Why this is safe

With no insets the stage is viewport-width, so `calc(50% - 50vw)` already evaluated to `0`. **Desktop is byte-identical**; only the inset case changes, and it changes to what the design intended. Verified in Storybook at 1280x760 and 844x390.

## A correction to the ticket

LUM-3198 framed this as mainly a *vertical* problem, naming `research-result-steps` first. Tracing it to an observable output says otherwise:

- **`create-personality-step` is a real defect**, but a *horizontal* one, and only when left/right insets are non-zero. That is what this PR fixes.
- **`research-result-steps` looks internally consistent.** Its flight geometry pairs the layout viewport with `getBoundingClientRect()` slots, which are themselves viewport-relative, so the two agree. I could not produce a misalignment from it. I have not changed it, and I have updated the ticket rather than leave the claim standing.

The vertical half of the original claim (the eyes) was already disproved during the stories work: shrinking the stage 34px moves them with it.

## Follow-up not taken here

`avatarSize` still scales off the layout viewport (`clamp(160px, 16vw, 300px)` written in JS). In practice the 160px floor dominates at every width where insets exist, so it makes no visible difference today. It belongs to LUM-3204 with the rest of the JS-computed sizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40565" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->