### PR TITLE
Describe how the writer stores a fact body, not how it used to

### DIFF
--- a/assistant/src/plugins/defaults/memory/buffer-format.ts
+++ b/assistant/src/plugins/defaults/memory/buffer-format.ts
@@ -37,10 +37,11 @@ export interface BufferEntryStart {
  * Anchored at column 0, requiring a space after the dash, and spelling the
  * timestamp with the single spaces {@link formatBufferTimestamp} emits.
  * Everything else in the file is a continuation line belonging to the entry
- * above it, which is how a multiline fact keeps its body: `remember()` stores
- * the body verbatim after the timestamped first line. That rule is what makes
- * a bullet carrying other bracketed text (a `- [ ]` checklist item, a
- * `- [[wikilink]]` bullet) read as continuation rather than as a new fact.
+ * above it, which is how a multiline fact keeps its body: `remember()` writes
+ * only the opening line at column 0 and nests the body beneath it. That rule
+ * is what makes a bullet carrying other bracketed text (a `- [ ]` checklist
+ * item, a `- [[wikilink]]` bullet) read as continuation rather than as a new
+ * fact, and it is why a body line can never imitate an opening.
  *
  * Matching the writer's exact shape is the conservative choice in both
  * directions: a line the writer could not have produced stays body text, so an


### PR DESCRIPTION
## TL;DR

Comment-only. One docstring in `buffer-format.ts` still describes the old writer behavior. Caught in review of #40566 and flagged non-blocking, so it merged without it.

## What was stale

`matchBufferEntryStart`'s docstring explained why a body line is never mistaken for an entry opening, and gave the reason as:

> `remember()` stores the body verbatim after the timestamped first line.

`remember()` nests the body instead, and that nesting is precisely what makes the rule hold. The sentence explaining the invariant described the shape the invariant exists to prevent, which is the most confusing place for a comment to be wrong: a reader checking whether the guarantee is real would find a rationale that contradicts the code two functions down.

## After

> `remember()` writes only the opening line at column 0 and nests the body beneath it. That rule is what makes a bullet carrying other bracketed text (a `- [ ]` checklist item, a `- [[wikilink]]` bullet) read as continuation rather than as a new fact, and it is why a body line can never imitate an opening.

## Scope

No behavior change, no test change. I swept the rest of the module and the architecture doc for other stale `verbatim` claims: the remaining uses are accurate (the timestamp is returned verbatim, and `splitBufferEntries` does keep the file's lines verbatim).

Follow-up to #40566 (LUM-3207). Typecheck, lint and format pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40568" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->