### PR TITLE
feat(web): translate the contacts list, detail, and connect surfaces

### DIFF
--- a/clients/web/eslint.config.mjs
+++ b/clients/web/eslint.config.mjs
@@ -204,6 +204,19 @@ const i18nEnforcedPaths = [
   "src/domains/logs/**/*.{ts,tsx}",
   "src/domains/library/**/*.{ts,tsx}",
   "src/domains/home/**/*.{ts,tsx}",
+  // Converted file by file: the merge and link dialogs and the channels
+  // section split sentences across elements and need `Trans`, so they follow
+  // in their own pass and this becomes a directory glob then.
+  "src/domains/contacts/contacts-page.tsx",
+  "src/domains/contacts/connect-page.tsx",
+  "src/domains/contacts/channel-type-labels.ts",
+  "src/domains/contacts/draft-contact.ts",
+  "src/domains/contacts/hooks/**/*.{ts,tsx}",
+  "src/domains/contacts/components/assistant-channels-detail.tsx",
+  "src/domains/contacts/components/assistant-contact-channels.tsx",
+  "src/domains/contacts/components/contact-detail-view.tsx",
+  "src/domains/contacts/components/contacts-list.tsx",
+  "src/domains/contacts/components/guardian-detail-view.tsx",
 ];
 
 const eslintConfig = defineConfig([

--- a/clients/web/src/domains/contacts/channel-type-labels.ts
+++ b/clients/web/src/domains/contacts/channel-type-labels.ts
@@ -1,0 +1,37 @@
+/**
+ * Display label for a contact channel's wire type.
+ *
+ * Written out per type rather than composed from the wire value, so every key
+ * stays a greppable literal for the orphan check in `catalogs.test.ts`. Most
+ * of these are product names that read the same in every language; `phone` and
+ * `email` are ordinary nouns and do get translated, which is why the mapping
+ * goes through the catalog rather than hard-coding the strings here.
+ *
+ * An unrecognized type falls through to the wire value: the daemon is free to
+ * add channels, and naming the one it reported beats showing nothing.
+ */
+import { t } from "@/i18n";
+
+function channelTypeKey(type: string) {
+  switch (type) {
+    case "slack":
+      return "channelType.slack";
+    case "telegram":
+      return "channelType.telegram";
+    case "whatsapp":
+      return "channelType.whatsapp";
+    case "a2a":
+      return "channelType.a2a";
+    case "phone":
+      return "channelType.phone";
+    case "email":
+      return "channelType.email";
+    default:
+      return null;
+  }
+}
+
+export function channelTypeLabel(type: string): string {
+  const key = channelTypeKey(type.toLowerCase());
+  return key ? t(key, { ns: "contacts" }) : type;
+}

--- a/clients/web/src/domains/contacts/components/assistant-channels-detail.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-channels-detail.tsx
@@ -1,4 +1,5 @@
 import { DetailCard } from "@/components/detail-card";
+import { useTranslation } from "@/i18n";
 import { assistantDisplayName } from "@/utils/assistant-display-name";
 import {
   AssistantContactChannels,
@@ -21,19 +22,22 @@ export function AssistantChannelsDetail({
   assistantName,
   ...channelsProps
 }: AssistantChannelsDetailProps) {
+  const { t } = useTranslation("contacts");
   const displayName = assistantDisplayName(assistantName);
 
   return (
     <div className="flex flex-col gap-6">
       <DetailCard
-        title={`${displayName} (Your Assistant)`}
+        title={t("assistantChannelsDetail.title", { name: displayName })}
         accessory={<ContactTypeBadge role="assistant" />}
         compactAccessory
       />
 
       <DetailCard
-        title="Channels"
-        subtitle={`Where ${displayName} can be reached.`}
+        title={t("assistantChannelsDetail.channelsTitle")}
+        subtitle={t("assistantChannelsDetail.channelsSubtitle", {
+          name: displayName,
+        })}
       >
         <AssistantContactChannels {...channelsProps} />
       </DetailCard>

--- a/clients/web/src/domains/contacts/components/assistant-contact-channels.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-contact-channels.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Button } from "@vellumai/design-library/components/button";
 import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 
+import { useTranslation } from "@/i18n";
 import type {
   AssistantChannelState,
   SetupChannelId,
@@ -32,6 +33,7 @@ export function AssistantContactChannels({
   onConnect,
   onDisconnect,
 }: AssistantContactChannelsProps) {
+  const { t } = useTranslation("contacts");
   const [pendingDisconnect, setPendingDisconnect] =
     useState<SetupChannelId | null>(null);
 
@@ -62,9 +64,11 @@ export function AssistantContactChannels({
 
       <ConfirmDialog
         open={pendingDisconnect !== null}
-        title={`Disconnect ${pendingDisconnect ? getChannelLabel(pendingDisconnect) : ""}?`}
-        message="This clears the stored credentials for this channel. You can reconnect later."
-        confirmLabel="Disconnect"
+        title={t("assistantContactChannels.disconnectConfirmTitle", {
+          channel: pendingDisconnect ? getChannelLabel(pendingDisconnect) : "",
+        })}
+        message={t("assistantContactChannels.disconnectConfirmMessage")}
+        confirmLabel={t("actions.disconnect")}
         destructive
         onConfirm={() => {
           if (pendingDisconnect && onDisconnect) {
@@ -91,6 +95,7 @@ function ChannelRow({
   onConnect,
   onDisconnect,
 }: ChannelRowProps) {
+  const { t } = useTranslation("contacts");
   const connected = channel.status === "ready";
 
   return (
@@ -118,14 +123,14 @@ function ChannelRow({
           <>
             <span className="inline-flex items-center gap-1 h-8 px-2.5 rounded-md whitespace-nowrap select-none text-body-small-emphasised leading-none bg-[var(--content-default)] text-[var(--surface-base)]">
               <CheckCircle className="h-3 w-3" />
-              Connected
+              {t("assistantContactChannels.connected")}
             </span>
             <Button
               variant="danger"
               onClick={onDisconnect}
               disabled={!onDisconnect || pending}
             >
-              {pending ? "Disconnecting…" : "Disconnect"}
+              {pending ? t("actions.disconnecting") : t("actions.disconnect")}
             </Button>
           </>
         ) : (
@@ -134,7 +139,7 @@ function ChannelRow({
             onClick={onConnect}
             disabled={!onConnect || pending}
           >
-            Connect
+            {t("actions.connect")}
           </Button>
         )}
       </div>

--- a/clients/web/src/domains/contacts/components/contact-detail-view.tsx
+++ b/clients/web/src/domains/contacts/components/contact-detail-view.tsx
@@ -7,7 +7,9 @@ import { Input } from "@vellumai/design-library/components/input";
 import { DetailCard } from "@/components/detail-card";
 import { ContactChannelsSection } from "@/domains/contacts/components/contact-channels-section";
 import { ContactTypeBadge } from "@/domains/contacts/components/contact-type-badge";
+import { isDraftContactName } from "@/domains/contacts/draft-contact";
 import type { ChannelInfo, ContactPayload } from "@/domains/contacts/types";
+import { useTranslation } from "@/i18n";
 
 interface ContactDetailViewProps {
   contact: ContactPayload;
@@ -49,7 +51,8 @@ function ContactDetailViewInner({
   onRevokeChannel,
   onLinkAccount,
 }: ContactDetailViewProps) {
-  const isNewContactDraft = contact.displayName === "New Contact";
+  const { t } = useTranslation("contacts");
+  const isNewContactDraft = isDraftContactName(contact.displayName);
   const [displayName, setDisplayName] = useState(
     isNewContactDraft ? "" : contact.displayName,
   );
@@ -69,8 +72,13 @@ function ContactDetailViewInner({
     contact.channels.length === 0 &&
     contact.interactionCount === 0;
 
-  const headerName = trimmedName || contact.displayName;
-  const interactionLabel = `${contact.interactionCount} interaction${contact.interactionCount === 1 ? "" : "s"}`;
+  const headerName =
+    trimmedName || (isNewContactDraft ? t("contact.draftName") : contact.displayName);
+  // ICU `plural` picks the category through `Intl.PluralRules`, so the count
+  // agrees in languages with more than the two forms English has.
+  const interactionLabel = t("contact.interactions", {
+    count: contact.interactionCount,
+  });
 
   const requestDelete = () => {
     if (isEmptyDraft) {
@@ -95,22 +103,22 @@ function ContactDetailViewInner({
       >
         <div className="flex flex-col gap-4">
           <Input
-            label="Name"
+            label={t("contact.nameLabel")}
             type="text"
             value={displayName}
             onChange={(e) => setDisplayName(e.target.value)}
-            placeholder="Give this human a name"
+            placeholder={t("contactDetailView.namePlaceholder")}
             autoFocus={isNewContactDraft}
             disabled={savePending || deletePending}
             fullWidth
           />
 
           <Input
-            label="Notes"
+            label={t("contact.notesLabel")}
             type="text"
             value={notes}
             onChange={(e) => setNotes(e.target.value)}
-            placeholder="Optional notes about the human which AI will take into account"
+            placeholder={t("contactDetailView.notesPlaceholder")}
             disabled={savePending || deletePending}
             fullWidth
           />
@@ -123,7 +131,7 @@ function ContactDetailViewInner({
               }
               disabled={!canSave}
             >
-              {savePending ? "Saving…" : "Save"}
+              {savePending ? t("actions.saving") : t("actions.save")}
             </Button>
             {onMerge ? (
               <Button
@@ -140,15 +148,15 @@ function ContactDetailViewInner({
                 }
                 title={
                   !canMerge
-                    ? "No other contacts available to merge"
+                    ? t("contact.mergeBlockedNoCandidates")
                     : isEmptyDraft
-                      ? "Save this contact before merging"
+                      ? t("contactDetailView.mergeBlockedUnsavedDraft")
                       : dirty
-                        ? "Save your changes before merging"
+                        ? t("contact.mergeBlockedUnsaved")
                         : undefined
                 }
               >
-                {mergePending ? "Merging…" : "Merge…"}
+                {mergePending ? t("actions.merging") : t("actions.merge")}
               </Button>
             ) : null}
             <Button
@@ -157,15 +165,17 @@ function ContactDetailViewInner({
               onClick={requestDelete}
               disabled={deletePending}
             >
-              {deletePending ? "Deleting…" : "Delete Contact"}
+              {deletePending
+                ? t("actions.deleting")
+                : t("contactDetailView.delete")}
             </Button>
           </div>
         </div>
       </DetailCard>
 
       <DetailCard
-        title="Linked accounts"
-        subtitle="Where the assistant recognizes this contact. Link accounts you know, invite the ones you don't."
+        title={t("contactDetailView.linkedAccountsTitle")}
+        subtitle={t("contactDetailView.linkedAccountsSubtitle")}
       >
         <ContactChannelsSection
           contactChannels={contact.channels}
@@ -182,9 +192,11 @@ function ContactDetailViewInner({
 
       <ConfirmDialog
         open={confirmOpen}
-        title={`Delete ${contact.displayName}?`}
-        message="This will permanently delete this contact and all their channels. This action cannot be undone."
-        confirmLabel="Delete"
+        title={t("contactDetailView.deleteConfirmTitle", {
+          name: headerName,
+        })}
+        message={t("contactDetailView.deleteConfirmMessage")}
+        confirmLabel={t("actions.delete")}
         destructive
         onConfirm={() => {
           setConfirmOpen(false);

--- a/clients/web/src/domains/contacts/components/contacts-list.tsx
+++ b/clients/web/src/domains/contacts/components/contacts-list.tsx
@@ -16,6 +16,7 @@ import { PanelItem } from "@vellumai/design-library/components/panel-item";
 import { Tag } from "@vellumai/design-library/components/tag";
 
 import { ContactTypeBadge } from "@/domains/contacts/components/contact-type-badge";
+import { useTranslation } from "@/i18n";
 import type {
   ContactSelection,
   ContactSummary,
@@ -42,6 +43,7 @@ export function ContactsList({
   onAddContact,
   addingContact = false,
 }: ContactsListProps) {
+  const { t } = useTranslation("contacts");
   const [search, setSearch] = useState("");
   const filtered = search.trim()
     ? regularContacts.filter((c) =>
@@ -57,7 +59,7 @@ export function ContactsList({
             className="text-title-medium"
             style={{ color: "var(--content-default)" }}
           >
-            Entries
+            {t("contactsList.heading")}
           </h2>
           <Button
             type="button"
@@ -71,7 +73,7 @@ export function ContactsList({
             }
             onClick={onAddContact}
             disabled={addingContact}
-            aria-label="Add contact"
+            aria-label={t("contactsList.addAriaLabel")}
             tintColor="var(--content-secondary)"
           />
         </div>
@@ -80,7 +82,9 @@ export function ContactsList({
           {guardian ? (
             <ContactRow
               name={
-                guardian.displayName ? `${guardian.displayName} (You)` : "You"
+                guardian.displayName
+                  ? t("contactsList.youNamed", { name: guardian.displayName })
+                  : t("contactsList.you")
               }
               role={guardian.role}
               channelTypes={guardian.channelTypes}
@@ -95,7 +99,7 @@ export function ContactsList({
             />
           ) : null}
           <ContactRow
-            name={assistantName?.trim() || "Your Assistant"}
+            name={assistantName?.trim() || t("contactsList.assistantFallback")}
             role="assistant"
             selected={selection?.kind === "assistant"}
             onClick={() => onSelect({ kind: "assistant" })}
@@ -113,7 +117,7 @@ export function ContactsList({
             type="text"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            placeholder="Search Contacts"
+            placeholder={t("contactsList.searchPlaceholder")}
             leftIcon={<Search className="h-3.5 w-3.5" aria-hidden />}
             fullWidth
           />
@@ -144,7 +148,7 @@ export function ContactsList({
                 className="px-3 py-4 text-center text-body-small-default"
                 style={{ color: "var(--content-tertiary)" }}
               >
-                No matching contacts
+                {t("contactsList.noMatches")}
               </p>
             ) : null}
           </div>
@@ -163,7 +167,7 @@ export function ContactsList({
               )
             }
           >
-            Add Contact
+            {t("contactsList.add")}
           </Button>
         )}
       </Card.Body>
@@ -193,6 +197,7 @@ function ContactRow({
   trailingIcon,
   verified,
 }: ContactRowProps) {
+  const { t } = useTranslation("contacts");
   const channelLabel =
     channelTypes && channelTypes.length > 0
       ? channelTypes.join(" | ")
@@ -231,7 +236,9 @@ function ContactRow({
         <span className="flex shrink-0 items-center gap-1">
           {verified !== undefined ? (
             <Tag tone={verified ? "positive" : "neutral"}>
-              {verified ? "Verified" : "Unverified"}
+              {verified
+                ? t("contactsList.verified")
+                : t("contactsList.unverified")}
             </Tag>
           ) : null}
           <ContactTypeBadge role={role} contactType={contactType} />

--- a/clients/web/src/domains/contacts/components/guardian-detail-view.tsx
+++ b/clients/web/src/domains/contacts/components/guardian-detail-view.tsx
@@ -8,6 +8,7 @@ import { ContactChannelsSection } from "@/domains/contacts/components/contact-ch
 import { ContactTypeBadge } from "@/domains/contacts/components/contact-type-badge";
 import { ShareConnectionLinkButton } from "@/components/share-connection-link-button";
 import type { ChannelInfo, ContactPayload } from "@/domains/contacts/types";
+import { useTranslation } from "@/i18n";
 
 interface GuardianDetailViewProps {
   contact: ContactPayload;
@@ -44,6 +45,7 @@ function GuardianDetailViewInner({
   onRevokeChannel,
   onGenerateInviteLink,
 }: GuardianDetailViewProps) {
+  const { t } = useTranslation("contacts");
   const principalId = contact.displayName.startsWith("vellum-principal-");
   const initialName = principalId ? "" : contact.displayName;
   const [name, setName] = useState(initialName);
@@ -56,8 +58,14 @@ function GuardianDetailViewInner({
     trimmedNotes !== (contact.notes ?? "").trim();
   const canSave = dirty && !savePending;
 
-  const interactionLabel = `${contact.interactionCount} interaction${contact.interactionCount === 1 ? "" : "s"}`;
-  const headerName = principalId ? "You" : `${contact.displayName} (You)`;
+  // ICU `plural` picks the category through `Intl.PluralRules`, so the count
+  // agrees in languages with more than the two forms English has.
+  const interactionLabel = t("contact.interactions", {
+    count: contact.interactionCount,
+  });
+  const headerName = principalId
+    ? t("contactsList.you")
+    : t("contactsList.youNamed", { name: contact.displayName });
 
   return (
     <div className="flex flex-col gap-6">
@@ -69,21 +77,21 @@ function GuardianDetailViewInner({
       >
         <div className="flex flex-col gap-4">
           <Input
-            label="Name"
+            label={t("contact.nameLabel")}
             type="text"
             value={name}
             onChange={(e) => setName(e.target.value)}
-            placeholder="Your name"
+            placeholder={t("guardianDetailView.namePlaceholder")}
             disabled={savePending}
             fullWidth
           />
 
           <Input
-            label="Notes"
+            label={t("contact.notesLabel")}
             type="text"
             value={notes}
             onChange={(e) => setNotes(e.target.value)}
-            placeholder="Notes about yourself which AI will take into account"
+            placeholder={t("guardianDetailView.notesPlaceholder")}
             disabled={savePending}
             fullWidth
           />
@@ -99,7 +107,7 @@ function GuardianDetailViewInner({
               }
               disabled={!canSave}
             >
-              {savePending ? "Saving…" : "Save"}
+              {savePending ? t("actions.saving") : t("actions.save")}
             </Button>
             {onMerge ? (
               <Button
@@ -108,13 +116,13 @@ function GuardianDetailViewInner({
                 disabled={!canMerge || dirty || mergePending || savePending}
                 title={
                   !canMerge
-                    ? "No other contacts available to merge"
+                    ? t("contact.mergeBlockedNoCandidates")
                     : dirty
-                      ? "Save your changes before merging"
+                      ? t("contact.mergeBlockedUnsaved")
                       : undefined
                 }
               >
-                {mergePending ? "Merging…" : "Merge…"}
+                {mergePending ? t("actions.merging") : t("actions.merge")}
               </Button>
             ) : null}
           </div>
@@ -122,14 +130,14 @@ function GuardianDetailViewInner({
       </DetailCard>
 
       <DetailCard
-        title="Channels"
-        subtitle="Once verified, your assistant will recognize you when you message from these channels."
+        title={t("guardianDetailView.channelsTitle")}
+        subtitle={t("guardianDetailView.channelsSubtitle")}
       >
         <ContactChannelsSection
           contactChannels={contact.channels}
           availableChannels={availableChannels}
           a2aEnabled={a2aEnabled}
-          setupLabel="Verify me"
+          setupLabel={t("guardianDetailView.setupLabel")}
           verifyLoading={verifyPending}
           onSetupChannel={onSetupChannel}
           onVerifyChannel={onVerifyChannel}

--- a/clients/web/src/domains/contacts/connect-page.tsx
+++ b/clients/web/src/domains/contacts/connect-page.tsx
@@ -9,6 +9,7 @@ import { toast } from "@vellumai/design-library/components/toast";
 import { Typography } from "@vellumai/design-library/components/typography";
 
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
+import { useTranslation } from "@/i18n";
 import { parseA2AInviteParams } from "@/domains/contacts/a2a-invite";
 import { redeemA2AInvite } from "@/domains/contacts/contacts-gateway";
 import { routes } from "@/utils/routes";
@@ -22,22 +23,24 @@ function isContactsGetKey(queryKey: readonly unknown[]): boolean {
   );
 }
 
-function mapErrorCode(
-  errorCode: string | undefined,
-  errorMessage: string | undefined,
-): string {
+/**
+ * Catalog key for a redemption failure the broker reports by code. Null when
+ * the code is unrecognized, which leaves the broker's own message (or the
+ * generic fallback) to speak for it.
+ */
+function inviteErrorKey(errorCode: string | undefined) {
   switch (errorCode) {
     case "expired":
     case "not_found":
-      return "This invite link has expired or already been used.";
+      return "connectPage.errorExpired";
     case "already_redeemed_by_other":
-      return "This invite has already been claimed by someone else.";
+      return "connectPage.errorAlreadyRedeemed";
     case "sender_not_found":
-      return "The sender's assistant could not be found.";
+      return "connectPage.errorSenderNotFound";
     case "not_platform_managed":
-      return "A2A invite links are only supported for platform-hosted assistants.";
+      return "connectPage.errorNotPlatformManaged";
     default:
-      return errorMessage || "Something went wrong. Please try again.";
+      return null;
   }
 }
 
@@ -53,6 +56,7 @@ export function ConnectPage() {
 }
 
 function ConnectPageInner({ assistantId }: { assistantId: string }) {
+  const { t } = useTranslation("contacts");
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [searchParams] = useSearchParams();
@@ -77,9 +81,9 @@ function ConnectPageInner({ assistantId }: { assistantId: string }) {
           predicate: (query) => isContactsGetKey(query.queryKey),
         });
         if (data.alreadyConnected) {
-          toast("Already connected");
+          toast(t("connectPage.alreadyConnected"));
         } else {
-          toast("Connected!");
+          toast(t("connectPage.connected"));
         }
         void navigate(routes.contacts.root);
       }
@@ -99,13 +103,17 @@ function ConnectPageInner({ assistantId }: { assistantId: string }) {
     if (mutation.isError) {
       return mutation.error instanceof Error
         ? mutation.error.message
-        : "Something went wrong. Please try again.";
+        : t("connectPage.errorGeneric");
     }
     if (mutation.data && !mutation.data.success) {
-      return mapErrorCode(mutation.data.errorCode, mutation.data.error);
+      const key = inviteErrorKey(mutation.data.errorCode);
+      if (key) {
+        return t(key);
+      }
+      return mutation.data.error || t("connectPage.errorGeneric");
     }
     return null;
-  }, [mutation.isError, mutation.error, mutation.data]);
+  }, [mutation.isError, mutation.error, mutation.data, t]);
 
   // Invalid link — no params
   if (!parsed) {
@@ -118,18 +126,19 @@ function ConnectPageInner({ assistantId }: { assistantId: string }) {
                 className="h-6 w-6"
                 style={{ color: "var(--system-negative-strong)" }}
               />
-              <Typography variant="title-small">Invalid invite link</Typography>
+              <Typography variant="title-small">
+                {t("connectPage.invalidTitle")}
+              </Typography>
             </div>
             <Typography
               variant="body-medium-lighter"
               style={{ color: "var(--content-secondary)" }}
             >
-              The link you followed is missing required parameters and cannot be
-              used.
+              {t("connectPage.invalidBody")}
             </Typography>
             <div className="flex gap-2 pt-2">
               <Button variant="primary" onClick={handleCancel}>
-                Go to Contacts
+                {t("connectPage.goToContacts")}
               </Button>
             </div>
           </div>
@@ -147,15 +156,16 @@ function ConnectPageInner({ assistantId }: { assistantId: string }) {
               className="h-6 w-6"
               style={{ color: "var(--content-secondary)" }}
             />
-            <Typography variant="title-small">Connect assistants</Typography>
+            <Typography variant="title-small">
+              {t("connectPage.title")}
+            </Typography>
           </div>
 
           <Typography
             variant="body-medium-lighter"
             style={{ color: "var(--content-secondary)" }}
           >
-            Accepting this link will create a trusted A2A connection between
-            your assistant and the sender&apos;s.
+            {t("connectPage.body")}
           </Typography>
 
           {errorMessage && (
@@ -182,10 +192,10 @@ function ConnectPageInner({ assistantId }: { assistantId: string }) {
               {mutation.isPending ? (
                 <span className="flex items-center gap-2">
                   <Loader2 className="h-4 w-4 animate-spin" />
-                  Connecting…
+                  {t("actions.connecting")}
                 </span>
               ) : (
-                "Connect"
+                t("actions.connect")
               )}
             </Button>
             <Button
@@ -193,7 +203,7 @@ function ConnectPageInner({ assistantId }: { assistantId: string }) {
               onClick={handleCancel}
               disabled={mutation.isPending}
             >
-              Cancel
+              {t("actions.cancel")}
             </Button>
           </div>
         </div>

--- a/clients/web/src/domains/contacts/contacts-page.tsx
+++ b/clients/web/src/domains/contacts/contacts-page.tsx
@@ -9,6 +9,8 @@ import {
   MobileSidebarTrigger,
 } from "@/components/mobile-sidebar-drawer";
 import { isVerifiedContactChannel } from "@/domains/contacts/channel-linking";
+import { channelTypeLabel } from "@/domains/contacts/channel-type-labels";
+import { DRAFT_CONTACT_NAME } from "@/domains/contacts/draft-contact";
 import { AssistantChannelsDetail } from "@/domains/contacts/components/assistant-channels-detail";
 import { ContactDetailView } from "@/domains/contacts/components/contact-detail-view";
 import { ContactMergeDialog } from "@/domains/contacts/components/contact-merge-dialog";
@@ -39,6 +41,7 @@ import {
 } from "@/generated/daemon/@tanstack/react-query.gen";
 import { channelsAvailableGet } from "@/generated/daemon/sdk.gen";
 import type { ChannelsAvailableGetResponse } from "@/generated/daemon/types.gen";
+import { useTranslation } from "@/i18n";
 import { assistantDisplayName } from "@/utils/assistant-display-name";
 import { useAssistantChannels } from "@/hooks/use-assistant-channels";
 import { useInviteLinkDialog } from "@/hooks/use-invite-link-dialog";
@@ -109,6 +112,7 @@ export function ContactsPage({
   assistantId,
   onStartSetupConversation,
 }: ContactsPageProps) {
+  const { t } = useTranslation("contacts");
   const a2aChannel = useAssistantFeatureFlagStore.use.a2aChannel();
   const identityName = useAssistantIdentityStore.use.name();
   const queryClient = useQueryClient();
@@ -227,7 +231,7 @@ export function ContactsPage({
 
   const createMutation = useMutation({
     mutationFn: () =>
-      upsertContact(assistantId, { displayName: "New Contact" }),
+      upsertContact(assistantId, { displayName: DRAFT_CONTACT_NAME }),
     onMutate: async () => {
       await queryClient.cancelQueries({ queryKey: contactsQueryKey });
     },
@@ -237,7 +241,7 @@ export function ContactsPage({
       );
       setSelection({ kind: "contact", contactId: contact.id });
     },
-    onError: toastOnError("Failed to create contact"),
+    onError: toastOnError(t("contactsPage.createFailed")),
     onSettled: () => invalidateContacts(),
   });
 
@@ -255,7 +259,7 @@ export function ContactsPage({
       );
       setSelection({ kind: "assistant" });
     },
-    onError: toastOnError("Failed to delete contact"),
+    onError: toastOnError(t("contactsPage.deleteFailed")),
     onSettled: () => invalidateContacts(),
   });
 
@@ -284,7 +288,7 @@ export function ContactsPage({
           : undefined,
       );
     },
-    onError: toastOnError("Failed to save contact"),
+    onError: toastOnError(t("contactsPage.saveFailed")),
     onSettled: () => invalidateContacts(),
   });
 
@@ -309,7 +313,7 @@ export function ContactsPage({
         setSelection({ kind: "contact", contactId: mergedContact.id });
       }
       setMergeDialogOpen(false);
-      toast.success("Contacts merged");
+      toast.success(t("contactsPage.mergeSucceeded"));
     },
     onSettled: () => invalidateContacts(),
   });
@@ -392,7 +396,7 @@ export function ContactsPage({
     mutationFn: (args: { channelId: string }) =>
       verifyContactChannel(assistantId, args.channelId),
     onSuccess: () => invalidateContacts(),
-    onError: toastOnError("Failed to verify channel"),
+    onError: toastOnError(t("contactsPage.verifyFailed")),
   });
 
   const handleVerifyChannel = useCallback(
@@ -517,7 +521,7 @@ export function ContactsPage({
       <MobileSidebarDrawer
         open={drawerOpen}
         onClose={() => setDrawerOpen(false)}
-        title="Contacts"
+        title={t("contactsPage.title")}
       >
         <ContactsList {...contactsListProps} onSelect={handleSelect} />
       </MobileSidebarDrawer>
@@ -606,7 +610,7 @@ export function ContactsPage({
             mergeMutation.error instanceof Error
               ? mergeMutation.error.message
               : mergeMutation.error
-                ? "Failed to merge contacts"
+                ? t("contactsPage.mergeFailed")
                 : null
           }
           onMerge={(donorId) =>
@@ -624,13 +628,13 @@ export function ContactsPage({
 
       <LinkAccountDialog
         open={slackLink.dialogOpen}
-        channelLabel="Slack"
+        channelLabel={channelTypeLabel("slack")}
         contactName={selectedContact?.displayName ?? ""}
         accounts={slackRosterQuery.data}
         loading={slackRosterQuery.isLoading}
         errorMessage={
           slackRosterQuery.isError
-            ? "Couldn’t load the workspace roster. Check the Slack connection and try again."
+            ? t("contactsPage.rosterLoadFailed")
             : slackLink.linkErrorMessage
         }
         pendingAccountId={slackLink.pendingAccountId}
@@ -656,26 +660,19 @@ export function ContactsPage({
 }
 
 function ContactsEmptyState() {
+  const { t } = useTranslation("contacts");
+
   return (
     <div className="flex h-full items-center justify-center py-16">
       <p
         className="text-body-medium-lighter"
         style={{ color: "var(--content-tertiary)" }}
       >
-        Select a contact
+        {t("contactsPage.emptyBody")}
       </p>
     </div>
   );
 }
-
-const CHANNEL_TYPE_LABEL: Record<string, string> = {
-  slack: "Slack",
-  telegram: "Telegram",
-  phone: "Phone",
-  email: "Email",
-  whatsapp: "WhatsApp",
-  a2a: "A2A",
-};
 
 /**
  * A contact reads as verified when any non-revoked channel is verified, or is
@@ -707,7 +704,7 @@ function channelTypeLabels(
       continue;
     }
     seen.add(key);
-    labels.push(CHANNEL_TYPE_LABEL[key] ?? ch.type);
+    labels.push(channelTypeLabel(key));
   }
   return labels;
 }

--- a/clients/web/src/domains/contacts/draft-contact.ts
+++ b/clients/web/src/domains/contacts/draft-contact.ts
@@ -1,0 +1,14 @@
+/**
+ * Name a freshly created contact is stored under until the user names it.
+ *
+ * The sentinel is persisted, so it stays in English regardless of the UI
+ * language: it is what the daemon holds and what every client compares
+ * against. Screens showing it substitute `contacts:contact.draftName`, which
+ * is why {@link isDraftContactName} exists rather than the comparison being
+ * inlined at each site.
+ */
+export const DRAFT_CONTACT_NAME = "New Contact";
+
+export function isDraftContactName(name: string | null | undefined): boolean {
+  return name === DRAFT_CONTACT_NAME;
+}

--- a/clients/web/src/domains/contacts/hooks/use-account-link.ts
+++ b/clients/web/src/domains/contacts/hooks/use-account-link.ts
@@ -15,6 +15,7 @@ import { toast } from "@vellumai/design-library/components/toast";
 
 import type { RosterAccount } from "@/domains/contacts/channel-linking";
 import { linkContactChannelAccount } from "@/domains/contacts/contacts-gateway";
+import { t } from "@/i18n";
 
 export interface AccountLinkController {
   channelType: string;
@@ -52,7 +53,12 @@ export function useAccountLink({
       }),
     onSuccess: (_result, args) => {
       setDialogOpen(false);
-      toast.success(`Linked as @${args.account.username}`);
+      toast.success(
+        t("accountLink.linked", {
+          ns: "contacts",
+          username: args.account.username,
+        }),
+      );
       onLinked();
     },
   });
@@ -84,7 +90,7 @@ export function useAccountLink({
     linkMutation.error instanceof Error
       ? linkMutation.error.message
       : linkMutation.error
-        ? "Failed to link account"
+        ? t("accountLink.linkFailed", { ns: "contacts" })
         : null;
 
   return {

--- a/clients/web/src/i18n/catalogs.ts
+++ b/clients/web/src/i18n/catalogs.ts
@@ -35,6 +35,7 @@
  */
 import enAccount from "@/i18n/locales/en/account.json";
 import enChannels from "@/i18n/locales/en/channels.json";
+import enContacts from "@/i18n/locales/en/contacts.json";
 import enCredentialRequests from "@/i18n/locales/en/credential-requests.json";
 import enHome from "@/i18n/locales/en/home.json";
 import enLibrary from "@/i18n/locales/en/library.json";
@@ -79,6 +80,7 @@ export const FALLBACK_CATALOGS: LocaleCatalogs = {
   logs: enLogs,
   library: enLibrary,
   home: enHome,
+  contacts: enContacts,
 };
 
 /** Loaders for the locales that are not bundled into the entry chunk. */
@@ -101,6 +103,7 @@ const CATALOG_LOADERS: Record<
     logs: () => import("@/i18n/locales/es/logs.json"),
     library: () => import("@/i18n/locales/es/library.json"),
     home: () => import("@/i18n/locales/es/home.json"),
+    contacts: () => import("@/i18n/locales/es/contacts.json"),
   },
 };
 

--- a/clients/web/src/i18n/i18next.d.ts
+++ b/clients/web/src/i18n/i18next.d.ts
@@ -14,6 +14,7 @@
  */
 import type account from "@/i18n/locales/en/account.json";
 import type channels from "@/i18n/locales/en/channels.json";
+import type contacts from "@/i18n/locales/en/contacts.json";
 import type credentialRequests from "@/i18n/locales/en/credential-requests.json";
 import type home from "@/i18n/locales/en/home.json";
 import type library from "@/i18n/locales/en/library.json";
@@ -43,6 +44,7 @@ declare module "i18next" {
       logs: typeof logs;
       library: typeof library;
       home: typeof home;
+      contacts: typeof contacts;
     };
     returnNull: false;
   }

--- a/clients/web/src/i18n/locales/en/contacts.json
+++ b/clients/web/src/i18n/locales/en/contacts.json
@@ -1,0 +1,99 @@
+{
+  "actions": {
+    "save": "Save",
+    "saving": "Saving…",
+    "merge": "Merge…",
+    "merging": "Merging…",
+    "delete": "Delete",
+    "deleting": "Deleting…",
+    "connect": "Connect",
+    "connecting": "Connecting…",
+    "disconnect": "Disconnect",
+    "disconnecting": "Disconnecting…",
+    "cancel": "Cancel"
+  },
+  "channelType": {
+    "slack": "Slack",
+    "telegram": "Telegram",
+    "whatsapp": "WhatsApp",
+    "a2a": "A2A",
+    "phone": "Phone",
+    "email": "Email"
+  },
+  "contact": {
+    "nameLabel": "Name",
+    "notesLabel": "Notes",
+    "draftName": "New Contact",
+    "interactions": "{count, plural, one {# interaction} other {# interactions}}",
+    "mergeBlockedNoCandidates": "No other contacts available to merge",
+    "mergeBlockedUnsaved": "Save your changes before merging"
+  },
+  "contactsPage": {
+    "title": "Contacts",
+    "mergeSucceeded": "Contacts merged",
+    "mergeFailed": "Failed to merge contacts",
+    "createFailed": "Failed to create contact",
+    "deleteFailed": "Failed to delete contact",
+    "saveFailed": "Failed to save contact",
+    "verifyFailed": "Failed to verify channel",
+    "rosterLoadFailed": "Couldn’t load the workspace roster. Check the Slack connection and try again.",
+    "emptyBody": "Select a contact"
+  },
+  "contactsList": {
+    "heading": "Entries",
+    "addAriaLabel": "Add contact",
+    "searchPlaceholder": "Search Contacts",
+    "noMatches": "No matching contacts",
+    "add": "Add Contact",
+    "verified": "Verified",
+    "unverified": "Unverified",
+    "you": "You",
+    "youNamed": "{name} (You)",
+    "assistantFallback": "Your Assistant"
+  },
+  "contactDetailView": {
+    "namePlaceholder": "Give this human a name",
+    "notesPlaceholder": "Optional notes about the human which AI will take into account",
+    "mergeBlockedUnsavedDraft": "Save this contact before merging",
+    "delete": "Delete Contact",
+    "linkedAccountsTitle": "Linked accounts",
+    "linkedAccountsSubtitle": "Where the assistant recognizes this contact. Link accounts you know, invite the ones you don't.",
+    "deleteConfirmTitle": "Delete {name}?",
+    "deleteConfirmMessage": "This will permanently delete this contact and all their channels. This action cannot be undone."
+  },
+  "guardianDetailView": {
+    "namePlaceholder": "Your name",
+    "notesPlaceholder": "Notes about yourself which AI will take into account",
+    "channelsTitle": "Channels",
+    "channelsSubtitle": "Once verified, your assistant will recognize you when you message from these channels.",
+    "setupLabel": "Verify me"
+  },
+  "assistantChannelsDetail": {
+    "title": "{name} (Your Assistant)",
+    "channelsTitle": "Channels",
+    "channelsSubtitle": "Where {name} can be reached."
+  },
+  "assistantContactChannels": {
+    "connected": "Connected",
+    "disconnectConfirmTitle": "Disconnect {channel}?",
+    "disconnectConfirmMessage": "This clears the stored credentials for this channel. You can reconnect later."
+  },
+  "accountLink": {
+    "linked": "Linked as @{username}",
+    "linkFailed": "Failed to link account"
+  },
+  "connectPage": {
+    "invalidTitle": "Invalid invite link",
+    "invalidBody": "The link you followed is missing required parameters and cannot be used.",
+    "goToContacts": "Go to Contacts",
+    "title": "Connect assistants",
+    "body": "Accepting this link will create a trusted A2A connection between your assistant and the sender's.",
+    "alreadyConnected": "Already connected",
+    "connected": "Connected!",
+    "errorExpired": "This invite link has expired or already been used.",
+    "errorAlreadyRedeemed": "This invite has already been claimed by someone else.",
+    "errorSenderNotFound": "The sender's assistant could not be found.",
+    "errorNotPlatformManaged": "A2A invite links are only supported for platform-hosted assistants.",
+    "errorGeneric": "Something went wrong. Please try again."
+  }
+}

--- a/clients/web/src/i18n/locales/es/contacts.json
+++ b/clients/web/src/i18n/locales/es/contacts.json
@@ -1,0 +1,99 @@
+{
+  "actions": {
+    "save": "Guardar",
+    "saving": "Guardando…",
+    "merge": "Combinar…",
+    "merging": "Combinando…",
+    "delete": "Eliminar",
+    "deleting": "Eliminando…",
+    "connect": "Conectar",
+    "connecting": "Conectando…",
+    "disconnect": "Desconectar",
+    "disconnecting": "Desconectando…",
+    "cancel": "Cancelar"
+  },
+  "channelType": {
+    "slack": "Slack",
+    "telegram": "Telegram",
+    "whatsapp": "WhatsApp",
+    "a2a": "A2A",
+    "phone": "Teléfono",
+    "email": "Correo"
+  },
+  "contact": {
+    "nameLabel": "Nombre",
+    "notesLabel": "Notas",
+    "draftName": "Contacto nuevo",
+    "interactions": "{count, plural, one {# interacción} other {# interacciones}}",
+    "mergeBlockedNoCandidates": "No hay otros contactos con los que combinar",
+    "mergeBlockedUnsaved": "Guarda los cambios antes de combinar"
+  },
+  "contactsPage": {
+    "title": "Contactos",
+    "mergeSucceeded": "Contactos combinados",
+    "mergeFailed": "No se pudieron combinar los contactos",
+    "createFailed": "No se pudo crear el contacto",
+    "deleteFailed": "No se pudo eliminar el contacto",
+    "saveFailed": "No se pudo guardar el contacto",
+    "verifyFailed": "No se pudo verificar el canal",
+    "rosterLoadFailed": "No se pudo cargar el directorio del espacio de trabajo. Comprueba la conexión con Slack y vuelve a intentarlo.",
+    "emptyBody": "Selecciona un contacto"
+  },
+  "contactsList": {
+    "heading": "Entradas",
+    "addAriaLabel": "Añadir contacto",
+    "searchPlaceholder": "Buscar contactos",
+    "noMatches": "No hay contactos que coincidan",
+    "add": "Añadir contacto",
+    "verified": "Verificado",
+    "unverified": "Sin verificar",
+    "you": "Tú",
+    "youNamed": "{name} (tú)",
+    "assistantFallback": "Tu asistente"
+  },
+  "contactDetailView": {
+    "namePlaceholder": "Ponle un nombre a esta persona",
+    "notesPlaceholder": "Notas opcionales sobre la persona que la IA tendrá en cuenta",
+    "mergeBlockedUnsavedDraft": "Guarda este contacto antes de combinar",
+    "delete": "Eliminar contacto",
+    "linkedAccountsTitle": "Cuentas vinculadas",
+    "linkedAccountsSubtitle": "Dónde reconoce el asistente a este contacto. Vincula las cuentas que conozcas e invita a las que no.",
+    "deleteConfirmTitle": "¿Eliminar a {name}?",
+    "deleteConfirmMessage": "Esto eliminará permanentemente este contacto y todos sus canales. Esta acción no se puede deshacer."
+  },
+  "guardianDetailView": {
+    "namePlaceholder": "Tu nombre",
+    "notesPlaceholder": "Notas sobre ti que la IA tendrá en cuenta",
+    "channelsTitle": "Canales",
+    "channelsSubtitle": "Una vez verificado, tu asistente te reconocerá cuando escribas desde estos canales.",
+    "setupLabel": "Verificarme"
+  },
+  "assistantChannelsDetail": {
+    "title": "{name} (tu asistente)",
+    "channelsTitle": "Canales",
+    "channelsSubtitle": "Dónde se puede contactar con {name}."
+  },
+  "assistantContactChannels": {
+    "connected": "Conectado",
+    "disconnectConfirmTitle": "¿Desconectar {channel}?",
+    "disconnectConfirmMessage": "Esto borra las credenciales guardadas de este canal. Puedes volver a conectarlo más tarde."
+  },
+  "accountLink": {
+    "linked": "Vinculado como @{username}",
+    "linkFailed": "No se pudo vincular la cuenta"
+  },
+  "connectPage": {
+    "invalidTitle": "Enlace de invitación no válido",
+    "invalidBody": "Al enlace que has seguido le faltan parámetros obligatorios y no se puede usar.",
+    "goToContacts": "Ir a Contactos",
+    "title": "Conectar asistentes",
+    "body": "Aceptar este enlace creará una conexión A2A de confianza entre tu asistente y el del remitente.",
+    "alreadyConnected": "Ya está conectado",
+    "connected": "¡Conectado!",
+    "errorExpired": "Este enlace de invitación ha caducado o ya se ha usado.",
+    "errorAlreadyRedeemed": "Otra persona ya ha reclamado esta invitación.",
+    "errorSenderNotFound": "No se ha encontrado el asistente del remitente.",
+    "errorNotPlatformManaged": "Los enlaces de invitación A2A solo se admiten en asistentes alojados en la plataforma.",
+    "errorGeneric": "Algo ha salido mal. Vuelve a intentarlo."
+  }
+}

--- a/clients/web/src/i18n/namespaces.ts
+++ b/clients/web/src/i18n/namespaces.ts
@@ -48,6 +48,7 @@ export const NAMESPACES = [
   "logs",
   "library",
   "home",
+  "contacts",
 ] as const;
 
 export type Namespace = (typeof NAMESPACES)[number];


### PR DESCRIPTION
Adds a `contacts` namespace and moves eight of the domain's eleven files onto it: the page, the list, both detail views, the assistant's channel card, the account-link hook, and the A2A connect page. 65 of the domain's 115 strings.

## Why this is a partial domain

The merge dialog, the link-account dialog, and the channels section are left for a second pass. All three split a sentence across elements and interpolate a name mid-clause, so they need `Trans` rather than flat keys:

```tsx
{duplicates.length} duplicate channel
{duplicates.length === 1 ? "" : "s"} already on {survivorLabel}{" "}
(skipped).
```

Two of them also pluralize with `? "" : "s"`, which is an English-only rule. That is real work with its own review surface, and mixing it into this diff would bury it. Until it lands, the ratchet lists the eight converted files individually and becomes a `src/domains/contacts/**` glob when the last three do.

## Found outside what the lint rule reports

Five of the six items below would have survived a green lint run, which is the same gap flagged in earlier reviews in this series:

- **Five `toastOnError("Failed to ...")` calls** in the page. The rule matches `toast.*` and does not follow copy passed to a helper.
- **Two interaction counts** built as `` `${n} interaction${n === 1 ? "" : "s"}` ``, now a single ICU `plural` shared by both detail views.
- **`mapErrorCode`** in the connect page returned five English sentences keyed by broker error code; it now returns catalog keys and an unrecognized code still falls through to the broker's own message.
- **The channel-type label map**, duplicated between the page and the merge dialog, is now one `channelTypeLabel` module. Slack, Telegram, WhatsApp, and A2A are product names that read the same in every language; `phone` and `email` are ordinary nouns and do get translated, which is the reason the mapping goes through the catalog at all rather than staying a hard-coded record.
- **The "New Contact" draft name** is persisted and compared against by the detail view, so the sentinel stays English in `draft-contact.ts` while the two screens that display it substitute translated copy.

## Deliberately not translated

`DEFAULT_CHANNELS` keeps its English labels, subtitles, and setup messages. It is a backward-compatibility fallback for gateways that do not serve `/v1/channels/available`, and the live path gets the same fields from the server. Translating only the fallback would make one screen change language depending on the gateway version, which is worse than leaving it consistent. Server-provided copy is its own problem, and not a client one.

## Verification

- survey of the eight converted files reports 0 remaining; the three deferred files still report 50
- `tsc --noEmit` clean
- `bun run lint` 0 errors, 16 warnings, unchanged from the baseline on main
- 933 test files pass
- `bun run build` emits the Spanish `contacts` chunk

## What is left

`settings` (1585), `chat` (1066), `components` (463), `onboarding` (194), `intelligence` (177), the three `contacts` dialogs (50), and a tail of 23 in `hooks`/`utils`/`lib`.

Still open from earlier PRs: a pseudolocale before starting `settings` or `chat`, and native-speaker review of the Spanish, which is now around 320 hand-written messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CD12TRfmDF3UiXjdbiWn3i

---
_Generated by [Claude Code](https://claude.ai/code/session_01CD12TRfmDF3UiXjdbiWn3i)_