### PR TITLE
feat(web): attribute plans-takeover visits via billing telemetry

### DIFF
--- a/clients/web/src/domains/chat/components/credits-upsell-card.test.tsx
+++ b/clients/web/src/domains/chat/components/credits-upsell-card.test.tsx
@@ -58,7 +58,7 @@ mock.module("@/components/platform-login-notice", () => ({
 }));
 
 import { CreditsUpsellCard } from "./credits-upsell-card";
-import { routes } from "@/utils/routes";
+import { plansRouteForSource } from "@/lib/telemetry/plans-entry-source";
 
 beforeEach(() => {
   navigateTargets = [];
@@ -85,7 +85,7 @@ describe("CreditsUpsellCard", () => {
     ).toBeTruthy();
 
     fireEvent.click(getByRole("button", { name: "View plans" }));
-    expect(navigateTargets).toEqual([routes.plans]);
+    expect(navigateTargets).toEqual([plansRouteForSource("out_of_credits")]);
     expect(useAddCreditsModalStore.getState().open).toBe(false);
   });
 

--- a/clients/web/src/domains/chat/components/credits-upsell-card.tsx
+++ b/clients/web/src/domains/chat/components/credits-upsell-card.tsx
@@ -9,9 +9,9 @@ import {
 import { useIsFreePlan } from "@/hooks/use-is-free-plan";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
 import { ANDROID_BILLING_MESSAGE } from "@/lib/billing/android-consumption-only";
+import { plansRouteForSource } from "@/lib/telemetry/plans-entry-source";
 import { useIsNativeAndroid } from "@/runtime/platform-detection";
 import { useAddCreditsModalStore } from "@/stores/add-credits-modal-store";
-import { routes } from "@/utils/routes";
 
 /** Free-plan copy in the `upgrade-cta` experiment arm. */
 export const UPGRADE_COPY = {
@@ -92,7 +92,7 @@ export function CreditsUpsellCard() {
           : {
               label: copy.ctaLabel,
               onClick: isUpgrade
-                ? () => void navigate(routes.plans)
+                ? () => void navigate(plansRouteForSource("out_of_credits"))
                 : () => useAddCreditsModalStore.getState().setOpen(true),
             }
       }

--- a/clients/web/src/domains/chat/components/disk-pressure-banner-slot.tsx
+++ b/clients/web/src/domains/chat/components/disk-pressure-banner-slot.tsx
@@ -22,6 +22,10 @@ import {
   removeLocalSetting,
   setLocalBool,
 } from "@/utils/local-settings";
+import {
+  diskPressurePlansSource,
+  plansRouteForSource,
+} from "@/lib/telemetry/plans-entry-source";
 import { useIsNativeAndroid } from "@/runtime/platform-detection";
 import { routes } from "@/utils/routes";
 
@@ -124,7 +128,8 @@ export function DiskPressureBannerSlot({
       }
       onUpgradeStorage={
         assistantStateKind === "active" && !isNativeAndroid
-          ? () => void navigate(routes.plans)
+          ? () =>
+              void navigate(plansRouteForSource(diskPressurePlansSource(mode)))
           : null
       }
     />

--- a/clients/web/src/domains/settings/ai/email-managed-content.tsx
+++ b/clients/web/src/domains/settings/ai/email-managed-content.tsx
@@ -22,9 +22,9 @@ import {
 } from "@/generated/api/@tanstack/react-query.gen";
 import { ANDROID_BILLING_MESSAGE } from "@/lib/billing/android-consumption-only";
 import { captureError } from "@/lib/sentry/capture-error";
+import { plansRouteForSource } from "@/lib/telemetry/plans-entry-source";
 import { useIsNativeAndroid } from "@/runtime/platform-detection";
 import { extractErrorMessage } from "@/utils/api-errors";
-import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
 import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 import { Notice } from "@vellumai/design-library/components/notice";
@@ -295,7 +295,10 @@ export function EmailManagedContent({
         title="Give your assistant its own email address"
         actions={
           isNativeAndroid ? undefined : (
-            <Button size="compact" onClick={() => navigate(routes.plans)}>
+            <Button
+              size="compact"
+              onClick={() => navigate(plansRouteForSource("email_upsell"))}
+            >
               Upgrade
             </Button>
           )

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -112,9 +112,26 @@ let assistantFixture: Assistant | null = null;
 let activeAssistantFixture: Assistant | null = null;
 const assistantByIdCalls: (string | null)[] = [];
 let activeAssistantCalls = 0;
+// Entry-source telemetry rides the ingest endpoint; captured so the billing
+// plans_viewed emission can be asserted (and so tests never hit the wire).
+const telemetryIngestCalls: Captured[] = [];
+
+// Entry-source telemetry gates on analytics consent, which reads the
+// onboarding store — a cross-domain import this settings-domain test can't
+// make. Pin consent open at the lib seam instead.
+mock.module("@/lib/telemetry/consent", () => ({
+  readAnalyticsConsent: () => true,
+}));
 
 mock.module("@/generated/api/sdk.gen", () => ({
   ...sdkGen,
+  telemetryIngestCreate: (opts: Captured) => {
+    telemetryIngestCalls.push(opts);
+    return Promise.resolve({
+      data: { accepted: 1, persisted: 1, dropped: {} },
+      response: { ok: true },
+    });
+  },
   organizationsBillingSubscriptionChangePackageCreate: (opts: Captured) => {
     changePackageCall = opts;
     if (!changePackageAutoResolve) {
@@ -552,12 +569,15 @@ function renderInteractive(
     plans = fullCatalog(),
     onboardingData = onboarding(),
     seedOnboarding = true,
+    initialEntry = "/assistant/plans",
   }: {
     plans?: PlanListResponse;
     /** Null models a read that settled with no payload, e.g. one that failed. */
     onboardingData?: OnboardingStateResponse | null;
     /** False leaves the onboarding query to fetch, so it mounts unsettled. */
     seedOnboarding?: boolean;
+    /** Overridable so deep links (`?source=`, `?package=`) can be exercised. */
+    initialEntry?: string;
   } = {},
 ) {
   subscriptionFixture = subscription;
@@ -589,7 +609,7 @@ function renderInteractive(
     // Exposed so the checkout test can seed the avatar cache the stash reads.
     client,
     ...render(
-      <MemoryRouter initialEntries={["/assistant/plans"]}>
+      <MemoryRouter initialEntries={[initialEntry]}>
         <QueryClientProvider client={client}>
           <PlansPage />
         </QueryClientProvider>
@@ -626,6 +646,7 @@ beforeEach(() => {
   activeAssistantCalls = 0;
   toastSuccessCalls.length = 0;
   takeoverResizeContext = undefined;
+  telemetryIngestCalls.length = 0;
   // The stash and the assistants store are module-level globals, so reset both.
   clearTakeoverAvatarStash();
   useResolvedAssistantsStore.setState({
@@ -1606,5 +1627,48 @@ describe("PlansPage — Pro custom plan (change-tier)", () => {
     expect(getByTestId("loc").textContent).toBe("/assistant/plans");
     expect(machineTierCall).toBeNull();
     expect(upgradeCall).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Entry-source telemetry (`?source=` → billing plans_viewed emission)
+// ---------------------------------------------------------------------------
+
+/** The billing funnel events uploaded so far, across all captured batches. */
+function plansEntryEvents(): Array<Record<string, unknown>> {
+  return telemetryIngestCalls
+    .flatMap(
+      (call) =>
+        (call.body as { events?: Array<Record<string, unknown>> } | undefined)
+          ?.events ?? [],
+    )
+    .filter((event) => event.type === "billing");
+}
+
+describe("PlansPage entry-source telemetry", () => {
+  test("reports a tagged arrival once and strips the source param", async () => {
+    const { getByTestId } = renderInteractive(freeSubscription(), {
+      initialEntry: "/assistant/plans?source=out_of_credits",
+    });
+
+    // The consumed tag is stripped so a refresh can't re-report the entry.
+    await waitFor(() =>
+      expect(getByTestId("loc").textContent).toBe("/assistant/plans"),
+    );
+    const events = plansEntryEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "billing",
+      step: "plans_viewed",
+      entry_source: "out_of_credits",
+    });
+  });
+
+  test("reports an untagged arrival as direct", async () => {
+    const { getByTestId } = renderInteractive(freeSubscription());
+
+    await waitFor(() => expect(plansEntryEvents()).toHaveLength(1));
+    expect(plansEntryEvents()[0]).toMatchObject({ entry_source: "direct" });
+    expect(getByTestId("loc").textContent).toBe("/assistant/plans");
   });
 });

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -80,7 +80,8 @@ import { checkoutReturnTarget } from "@/lib/billing/checkout-return-target";
 import { lowersMachineCeiling } from "@/lib/billing/machine-sizes";
 import { openUrl } from "@/runtime/browser";
 import { isElectron } from "@/runtime/is-electron";
-import { PACKAGE_PARAM, routes } from "@/utils/routes";
+import { emitPlansEntryViewed } from "@/lib/telemetry/plans-entry-telemetry";
+import { PACKAGE_PARAM, PLANS_SOURCE_PARAM, routes } from "@/utils/routes";
 import { preloadBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 import { Button } from "@vellumai/design-library/components/button";
 import { toast } from "@vellumai/design-library/components/toast";
@@ -303,6 +304,10 @@ function PlansPageContent() {
   // `?package=<key>` is the one-shot deep link; it is live until the effects
   // below strip it.
   const packageParam = searchParams.get(PACKAGE_PARAM);
+  // `?source=<tag>` names the entry point that produced this visit (see
+  // `plans-entry-telemetry.ts`). Consumed once per mount, below.
+  const sourceParam = searchParams.get(PLANS_SOURCE_PARAM);
+  const sourceReportedRef = useRef(false);
 
   // The takeover only makes sense against a platform-hosted assistant with a
   // live package catalog. Anything else — self-hosted or no platform session,
@@ -331,6 +336,38 @@ function PlansPageContent() {
       navigate(target, { replace: true });
     }
   }, [cannotResolve, notPlatformHosted, navigate]);
+
+  // Report the entry source exactly once per mount — an untagged arrival
+  // counts as "direct". Reported even when the resolve bails redirect away:
+  // the user still followed that entry point here, and the bail states are
+  // already rare because most producers are platform-gated.
+  useEffect(() => {
+    if (sourceReportedRef.current) {
+      return;
+    }
+    sourceReportedRef.current = true;
+    emitPlansEntryViewed(sourceParam ?? "direct");
+  }, [sourceParam]);
+
+  // Strip the consumed source tag so a refresh or a shared URL doesn't
+  // re-report the original entry. Held while `cannotResolve` (the redirect
+  // effect above owns navigation this tick, and the param dies with the page)
+  // and while a `?package=` deep link is live — that flow's strip below drops
+  // both params in one navigation, since two same-tick setSearchParams calls
+  // would clobber each other.
+  useEffect(() => {
+    if (sourceParam == null || packageParam != null || cannotResolve) {
+      return;
+    }
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete(PLANS_SOURCE_PARAM);
+        return next;
+      },
+      { replace: true },
+    );
+  }, [sourceParam, packageParam, cannotResolve, setSearchParams]);
 
   const handleBack = () => {
     const idx = (window.history.state as { idx?: number } | null)?.idx ?? 0;
@@ -516,6 +553,9 @@ function PlansPageContent() {
       (prev) => {
         const next = new URLSearchParams(prev);
         next.delete(PACKAGE_PARAM);
+        // A marketing "Manage your plan" link carries both params; the
+        // source-strip effect above defers to this one, so drop both here.
+        next.delete(PLANS_SOURCE_PARAM);
         return next;
       },
       { replace: true },

--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -47,7 +47,7 @@ import {
   makeUltraPackage,
 } from "@/domains/settings/billing/plans/pro-package-test-fixtures";
 import * as takeoverAvatarStash from "@/lib/billing/takeover-avatar-stash";
-import { routes } from "@/utils/routes";
+import { plansRouteForSource } from "@/lib/telemetry/plans-entry-source";
 
 // Capture navigate() targets so the action-button wiring can be asserted
 // without a live Router.
@@ -603,7 +603,9 @@ describe("PlanCard action button", () => {
     // navigate() fires from the click handler; await it so the assertion never
     // races the handler's commit in the CI runner.
     await waitFor(() => {
-      expect(navigateArgs).toEqual([[routes.plans, undefined]]);
+      expect(navigateArgs).toEqual([
+        [plansRouteForSource("billing_plan_card"), undefined],
+      ]);
     });
     expect(onManage).not.toHaveBeenCalled();
   });
@@ -621,7 +623,9 @@ describe("PlanCard action button", () => {
     // navigate() fires from the click handler; await it so the assertion never
     // races the handler's commit in the CI runner.
     await waitFor(() => {
-      expect(navigateArgs).toEqual([[routes.plans, undefined]]);
+      expect(navigateArgs).toEqual([
+        [plansRouteForSource("billing_plan_card"), undefined],
+      ]);
     });
     expect(onManage).not.toHaveBeenCalled();
   });
@@ -664,7 +668,9 @@ describe("PlanCard action button", () => {
     fireEvent.click(await findByTestId("plan-card-plans-button"));
 
     await waitFor(() => {
-      expect(navigateArgs).toEqual([[routes.plans, undefined]]);
+      expect(navigateArgs).toEqual([
+        [plansRouteForSource("billing_plan_card"), undefined],
+      ]);
     });
     expect(onManage).not.toHaveBeenCalled();
   });
@@ -683,7 +689,9 @@ describe("PlanCard action button", () => {
     fireEvent.click(await findByTestId("plan-card-plans-button"));
 
     await waitFor(() => {
-      expect(navigateArgs).toEqual([[routes.plans, undefined]]);
+      expect(navigateArgs).toEqual([
+        [plansRouteForSource("billing_plan_card"), undefined],
+      ]);
     });
     expect(onManage).not.toHaveBeenCalled();
   });
@@ -708,7 +716,9 @@ describe("PlanCard action button", () => {
     fireEvent.click(await findByTestId("plan-card-plans-button"));
 
     await waitFor(() => {
-      expect(navigateArgs).toEqual([[routes.plans, undefined]]);
+      expect(navigateArgs).toEqual([
+        [plansRouteForSource("billing_plan_card"), undefined],
+      ]);
     });
     expect(onManage).not.toHaveBeenCalled();
   });
@@ -755,7 +765,9 @@ describe("PlanCard action button", () => {
     fireEvent.click(await findByTestId("plan-card-plans-button"));
 
     await waitFor(() => {
-      expect(navigateArgs).toEqual([[routes.plans, undefined]]);
+      expect(navigateArgs).toEqual([
+        [plansRouteForSource("billing_plan_card"), undefined],
+      ]);
     });
     expect(onManage).not.toHaveBeenCalled();
   });

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -38,7 +38,7 @@ import { useDocumentTheme } from "@/hooks/use-document-theme";
 import { saveCheckoutIntent } from "@/lib/billing/checkout-intent";
 import { checkoutReturnTarget } from "@/lib/billing/checkout-return-target";
 import { openUrl } from "@/runtime/browser";
-import { routes } from "@/utils/routes";
+import { plansRouteForSource } from "@/lib/telemetry/plans-entry-source";
 import { Button } from "@vellumai/design-library/components/button";
 import { Card } from "@vellumai/design-library/components/card";
 import { Notice } from "@vellumai/design-library/components/notice";
@@ -441,7 +441,9 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
           <Button
             variant="outlined"
             onClick={
-              canOpenPlansTakeover ? () => navigate(routes.plans) : onManage
+              canOpenPlansTakeover
+                ? () => navigate(plansRouteForSource("billing_plan_card"))
+                : onManage
             }
             data-testid="plan-card-plans-button"
             className="shrink-0"

--- a/clients/web/src/domains/settings/components/resize-card.tsx
+++ b/clients/web/src/domains/settings/components/resize-card.tsx
@@ -22,7 +22,7 @@ import {
   SIZE_LABEL,
 } from "@/lib/billing/machine-sizes";
 import { useIsNativeAndroid } from "@/runtime/platform-detection";
-import { routes } from "@/utils/routes";
+import { plansRouteForSource } from "@/lib/telemetry/plans-entry-source";
 import { Button } from "@vellumai/design-library/components/button";
 import { Select } from "@vellumai/design-library/components/select";
 import { Modal } from "@vellumai/design-library/components/modal";
@@ -405,7 +405,7 @@ export function ResizeCard({
             <Button
               onClick={() => {
                 setUpgradeModalOpen(false);
-                void navigate(routes.plans);
+                void navigate(plansRouteForSource("resize_upgrade_modal"));
               }}
             >
               Upgrade
@@ -479,7 +479,7 @@ export function ResizeCard({
               <span className="text-label-small-default text-[var(--content-tertiary)]">
                 Need more?{" "}
                 <Link
-                  to={routes.plans}
+                  to={plansRouteForSource("resize_modal_link")}
                   className="text-[var(--content-secondary)] underline decoration-[var(--border-element)] underline-offset-2 transition-colors hover:text-[var(--content-default)]"
                   onClick={() => setResizeModalOpen(false)}
                 >

--- a/clients/web/src/domains/settings/pages/general-page.tsx
+++ b/clients/web/src/domains/settings/pages/general-page.tsx
@@ -53,6 +53,10 @@ import {
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { useIsAuthenticated } from "@/stores/auth-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+import {
+  diskPressurePlansSource,
+  plansRouteForSource,
+} from "@/lib/telemetry/plans-entry-source";
 import { routes } from "@/utils/routes";
 
 export function GeneralPage() {
@@ -190,7 +194,14 @@ export function GeneralPage() {
           }
           onUpgradeStorage={
             infraGate === "full" && !isNativeAndroid
-              ? () => void navigate(routes.plans)
+              ? () =>
+                  void navigate(
+                    plansRouteForSource(
+                      diskPressurePlansSource(
+                        diskPressure.mode as DiskPressureBannerMode,
+                      ),
+                    ),
+                  )
               : null
           }
         />

--- a/clients/web/src/lib/telemetry/plans-entry-source.ts
+++ b/clients/web/src/lib/telemetry/plans-entry-source.ts
@@ -1,0 +1,61 @@
+import { PLANS_SOURCE_PARAM, routes } from "@/utils/routes";
+
+/**
+ * Entry-source tags for the plans takeover — the producer half of the
+ * "how did the user get to `/assistant/plans`?" attribution described in
+ * `plans-entry-telemetry.ts`. Kept separate from the emitter so navigation
+ * call sites don't pull in the ingest transport chain (generated sdk, client
+ * identity, consent store); they only build a tagged URL.
+ *
+ * The marketing pricing page lives in `vellum-assistant-platform`
+ * (`web/src/components/marketing/PricingPage/pricing-body.tsx`) and cannot
+ * import this module — it produces `source=marketing_pricing` as a raw
+ * string. Keep that spelling in the union below.
+ */
+
+/** Where a `/assistant/plans` visit came from. */
+export type PlansEntrySource =
+  /** Marketing `/pricing` CTAs (produced cross-app as a raw string). */
+  | "marketing_pricing"
+  /** Disk-pressure banner "Upgrade Storage" in its low-storage warning band. */
+  | "disk_pressure_warning"
+  /** Disk-pressure banner "Upgrade Storage" in its cleanup band. */
+  | "disk_pressure_cleanup"
+  /** Disk-pressure critical (acknowledgement-required) modal. */
+  | "disk_pressure_critical"
+  /** Out-of-credits upsell card "View plans" (upgrade experiment arm). */
+  | "out_of_credits"
+  /** Resize card's "Upgrade your plan" modal CTA. */
+  | "resize_upgrade_modal"
+  /** "Upgrade plan" link in the resize modal's footer. */
+  | "resize_modal_link"
+  /** Billing settings plan card's "View All Plans". */
+  | "billing_plan_card"
+  /** Managed-email entitlement wall "Upgrade". */
+  | "email_upsell"
+  /** No source tag on the URL — typed URL, refresh, internal redirects. */
+  | "direct";
+
+/** Plans-takeover URL tagged with the entry source that produced the visit. */
+export function plansRouteForSource(source: PlansEntrySource): string {
+  return `${routes.plans}?${PLANS_SOURCE_PARAM}=${encodeURIComponent(source)}`;
+}
+
+/**
+ * Entry source for a disk-pressure banner mode. Takes the mode as a literal
+ * union (structurally `DiskPressureBannerMode`) so `lib/` doesn't import from
+ * `components/`. The acknowledgement-required modal reports as `critical` —
+ * that's the state it renders.
+ */
+export function diskPressurePlansSource(
+  mode: "warning" | "cleanup" | "acknowledgement-required",
+): PlansEntrySource {
+  switch (mode) {
+    case "warning":
+      return "disk_pressure_warning";
+    case "cleanup":
+      return "disk_pressure_cleanup";
+    case "acknowledgement-required":
+      return "disk_pressure_critical";
+  }
+}

--- a/clients/web/src/lib/telemetry/plans-entry-telemetry.test.ts
+++ b/clients/web/src/lib/telemetry/plans-entry-telemetry.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Exercises the real ingest pipeline (mocking only the generated ingest sdk
+ * call, mirroring tips-telemetry.test.ts) so the payload mapping — a
+ * `type: "billing"` event with step = "plans_viewed" and the source in
+ * entry_source — and the consent gate are asserted end-to-end. The URL
+ * builders are pure and asserted directly.
+ */
+
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
+import * as sdkGen from "@/generated/api/sdk.gen";
+
+const ingestMock = mock(
+  async (_options: { body: unknown; keepalive?: boolean }) => ({
+    data: { accepted: 1, persisted: 1, dropped: {} },
+    error: undefined,
+    response: { ok: true, status: 200 } as Response,
+  }),
+);
+// Spread the real module so this mock stays inert for any test file sharing
+// the process — bun's mock.module patches the module registry globally.
+mock.module("@/generated/api/sdk.gen", () => ({
+  ...sdkGen,
+  telemetryIngestCreate: ingestMock,
+}));
+
+const { emitPlansEntryViewed } = await import(
+  "@/lib/telemetry/plans-entry-telemetry"
+);
+const { diskPressurePlansSource, plansRouteForSource } = await import(
+  "@/lib/telemetry/plans-entry-source"
+);
+
+function eventFromCall(callIndex: number): Record<string, unknown> {
+  const options = ingestMock.mock.calls[callIndex]?.[0] as
+    | { body: { events: Array<Record<string, unknown>> } }
+    | undefined;
+  if (!options) {
+    throw new Error(`No ingest call at index ${callIndex}`);
+  }
+  return options.body.events[0] ?? {};
+}
+
+beforeEach(() => {
+  sessionStorage.clear();
+  localStorage.clear();
+  useOnboardingStore.setState({ shareAnalytics: true });
+  ingestMock.mockClear();
+});
+
+describe("plansRouteForSource", () => {
+  it("tags the plans path with the source param", () => {
+    expect(plansRouteForSource("out_of_credits")).toBe(
+      "/assistant/plans?source=out_of_credits",
+    );
+  });
+});
+
+describe("diskPressurePlansSource", () => {
+  it("maps each banner mode to its entry source", () => {
+    expect(diskPressurePlansSource("warning")).toBe("disk_pressure_warning");
+    expect(diskPressurePlansSource("cleanup")).toBe("disk_pressure_cleanup");
+    expect(diskPressurePlansSource("acknowledgement-required")).toBe(
+      "disk_pressure_critical",
+    );
+  });
+});
+
+describe("emitPlansEntryViewed", () => {
+  it("maps the source to entry_source with a fixed step", () => {
+    emitPlansEntryViewed("marketing_pricing");
+
+    expect(ingestMock).toHaveBeenCalledTimes(1);
+    expect(eventFromCall(0)).toMatchObject({
+      type: "billing",
+      step: "plans_viewed",
+      entry_source: "marketing_pricing",
+    });
+  });
+
+  it("bounds an open-string source to the serializer's entry_source length", () => {
+    emitPlansEntryViewed("x".repeat(100));
+
+    expect(ingestMock).toHaveBeenCalledTimes(1);
+    expect((eventFromCall(0).entry_source as string).length).toBe(64);
+  });
+
+  it("ties events from one page load together with a stable session_id", () => {
+    emitPlansEntryViewed("direct");
+    emitPlansEntryViewed("out_of_credits");
+
+    expect(eventFromCall(0).session_id).toBe(
+      eventFromCall(1).session_id as string,
+    );
+  });
+
+  it("does not upload when analytics consent is off", () => {
+    useOnboardingStore.setState({ shareAnalytics: false });
+
+    emitPlansEntryViewed("direct");
+
+    expect(ingestMock).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/lib/telemetry/plans-entry-telemetry.ts
+++ b/clients/web/src/lib/telemetry/plans-entry-telemetry.ts
@@ -1,0 +1,65 @@
+import { readAnalyticsConsent } from "@/lib/telemetry/consent";
+import { postTelemetryEvents } from "@/lib/telemetry/ingest";
+
+/**
+ * Entry attribution for the plans takeover — answers "how did the user get to
+ * `/assistant/plans`?".
+ *
+ * Producers navigate via `plansRouteForSource` (in `plans-entry-source.ts`,
+ * kept separate so navigation call sites don't import the ingest transport),
+ * which tags the URL with `?source=<tag>`; the plans page consumes the tag
+ * once on mount and reports it here as a `type: "billing"` event — the
+ * billing-surface funnel family (`BillingTelemetryEventSerializer` on the
+ * platform), which is session-allowlisted alongside `onboarding` in
+ * `SESSION_INGEST_ALLOWED_EVENT_TYPES`. `step` is `plans_viewed` and
+ * `entry_source` carries the tag, so the analytics-side breakdown is
+ * `stg_telemetry__billing WHERE step = 'plans_viewed' GROUP BY entry_source`.
+ * Both are open strings server-side, so a new source needs no platform
+ * change; a new *step* in the family is likewise just a new value.
+ *
+ * Consent is read through the shared `readAnalyticsConsent()` in `lib/` so
+ * every producing domain can route here without a cross-domain import
+ * (`local/no-cross-domain-imports`).
+ */
+
+/**
+ * Per-page-load session id, generated once when this module first loads —
+ * mirrors the onboarding funnel's `session_id` semantics.
+ */
+const SESSION_ID = crypto.randomUUID();
+
+interface BillingTelemetryEvent {
+  type: "billing";
+  daemon_event_id: string;
+  recorded_at: number;
+  step: string;
+  entry_source: string;
+  session_id: string;
+}
+
+/**
+ * Report a plans-takeover view. `source` arrives from the URL, so it is an
+ * open string rather than the `PlansEntrySource` union — an unknown tag
+ * should surface in the data, not be dropped. Truncated to the serializer's
+ * `entry_source` bound (64); a value exceeding it would fail validation and
+ * be silently discarded server-side.
+ */
+export function emitPlansEntryViewed(source: string): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  if (!readAnalyticsConsent()) {
+    return;
+  }
+
+  const event: BillingTelemetryEvent = {
+    type: "billing",
+    daemon_event_id: crypto.randomUUID(),
+    recorded_at: Date.now(),
+    step: "plans_viewed",
+    entry_source: source.slice(0, 64),
+    session_id: SESSION_ID,
+  };
+
+  postTelemetryEvents([event]);
+}

--- a/clients/web/src/utils/routes.ts
+++ b/clients/web/src/utils/routes.ts
@@ -35,6 +35,15 @@ export const SCROLL_TO_MESSAGE_PARAM = "message";
  */
 export const PACKAGE_PARAM = "package";
 
+/**
+ * Search param naming the entry point that produced a plans-takeover visit
+ * (`/assistant/plans?source=<tag>`). Producers tag it via
+ * `plansRouteForSource` in `lib/telemetry/plans-entry-telemetry.ts`; the
+ * plans page reports the tag once on mount and strips it. Also produced
+ * cross-app by the marketing pricing page (`source=marketing_pricing`).
+ */
+export const PLANS_SOURCE_PARAM = "source";
+
 export const routes = {
   assistant: r("/assistant"),
   /**


### PR DESCRIPTION
## What

Answers **"how did the user get to `/assistant/plans`?"**. Every entry point navigates with a `?source=<tag>`; the plans page consumes the tag once per mount, emits a `type: "billing"` telemetry event (`step=plans_viewed`, `entry_source=<tag>`, analytics-consent-gated), and strips the param so refreshes/shared URLs don't re-report. Untagged arrivals report `entry_source=direct`.

Tagged entry points:
- Disk-pressure banner "Upgrade Storage" — per mode (`disk_pressure_warning` / `disk_pressure_cleanup` / `disk_pressure_critical`), both the chat slot and Settings → General
- Out-of-credits upsell card "View plans" (`out_of_credits`)
- Resize card: upgrade modal CTA (`resize_upgrade_modal`) and footer link (`resize_modal_link`)
- Billing plan card "View All Plans" (`billing_plan_card`)
- Managed-email entitlement wall (`email_upsell`)
- Marketing pricing page CTAs tag `marketing_pricing` cross-app (platform repo PR)

Design notes:
- `lib/telemetry/plans-entry-source.ts` (source union + URL builders) is split from `lib/telemetry/plans-entry-telemetry.ts` (emitter) so navigation call sites don't pull in the ingest transport chain.
- When a `?package=` deep link is live alongside `?source=` (marketing "Switch to X"), the package flow's strip drops both params in one navigation — two same-tick `setSearchParams` calls would clobber each other.

## ⚠️ Merge order

**Do not merge until [vellum-assistant-platform#9873](https://github.com/vellum-ai/vellum-assistant-platform/pull/9873) is merged and deployed** (it registers the `billing` serializer and session-allowlists the type). Events with an unregistered type are silently dropped by ingest. Also merge the auto-generated telemetry wire-sync PR that lands here after #9873 merges.

## Tests

- `bunx tsc --noEmit` clean, `bun run lint` clean
- New unit tests for the emitter/builders; plans-page tests assert the tagged-arrival emission + param strip and the `direct` fallback
- All affected suites green: plans-page (54), plans-page-checkout (18), plan-card (30), credits-upsell-card (7), resize-card, disk-pressure-banner-slot, ai-page, chat empty-state, transcript-row, billing-page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDakKZVnbnMGyysoxz9pfv
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40572" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->