### PR TITLE
feat(plugin-api): let a turn say which chat it belongs to

### DIFF
--- a/assistant/src/__tests__/channel-delivery-store.test.ts
+++ b/assistant/src/__tests__/channel-delivery-store.test.ts
@@ -504,23 +504,23 @@ describe("channel-delivery-store", () => {
     expect(r1.conversationId).not.toBe(r2.conversationId);
   });
 
-  test("same chat/channel but different assistantId uses different conversations", () => {
-    const r1 = recordInbound("telegram", "chat-1", "msg-1", {
-      assistantId: "asst-A",
-    });
-    const r2 = recordInbound("telegram", "chat-1", "msg-2", {
-      assistantId: "asst-B",
-    });
+  test("the same chat keeps the same conversation", () => {
+    const r1 = recordInbound("telegram", "chat-1", "msg-1");
+    const r2 = recordInbound("telegram", "chat-1", "msg-2");
 
-    expect(r1.conversationId).not.toBe(r2.conversationId);
+    expect(r1.conversationId).toBe(r2.conversationId);
   });
 
-  test("no assistantId defaults to self-scoped key", () => {
-    const r1 = recordInbound("telegram", "chat-1", "msg-1");
-    const r2 = recordInbound("telegram", "chat-1", "msg-2", {
-      assistantId: "self",
-    });
-    expect(r1.conversationId).toBe(r2.conversationId);
+  test("binds under the self-scoped key", () => {
+    // The prefix is a stored format, not an internal detail. It reads like a
+    // leftover of the assistant id that used to be interpolated into it, so
+    // pin it: rows already written under `asst:self:` stop resolving if a
+    // later tidy-up drops it.
+    const { conversationId } = recordInbound("telegram", "chat-1", "msg-1");
+
+    expect(
+      getConversationByKey("asst:self:telegram:chat-1")?.conversationId,
+    ).toBe(conversationId);
   });
 
   test("external bindings allow multiple Slack thread anchors per channel", () => {

--- a/assistant/src/__tests__/edit-propagation.test.ts
+++ b/assistant/src/__tests__/edit-propagation.test.ts
@@ -145,7 +145,6 @@ describe("Slack edit propagation", () => {
       conversationExternalId: seeded.conversationExternalId,
       externalMessageId: nextEditEventId(),
       sourceMessageId: seeded.channelTs,
-      canonicalAssistantId: "self",
       assistantId: "self",
       content: "new text",
     });
@@ -187,7 +186,6 @@ describe("Slack edit propagation", () => {
       externalMessageId: nextEditEventId(),
       sourceMessageId: seeded.channelTs,
       sourceThreadId: threadTs,
-      canonicalAssistantId: "self",
       assistantId: "self",
       content: "new text",
     });
@@ -216,7 +214,6 @@ describe("Slack edit propagation", () => {
       conversationExternalId: seeded.conversationExternalId,
       externalMessageId: nextEditEventId(),
       sourceMessageId: seeded.channelTs,
-      canonicalAssistantId: "self",
       assistantId: "self",
       content: "first edit",
     });
@@ -239,7 +236,6 @@ describe("Slack edit propagation", () => {
       conversationExternalId: seeded.conversationExternalId,
       externalMessageId: nextEditEventId(),
       sourceMessageId: seeded.channelTs,
-      canonicalAssistantId: "self",
       assistantId: "self",
       content: "second edit",
     });
@@ -272,7 +268,6 @@ describe("Slack edit propagation", () => {
       conversationExternalId: seeded.conversationExternalId,
       externalMessageId: nextEditEventId(),
       sourceMessageId: seeded.channelTs,
-      canonicalAssistantId: "self",
       assistantId: "self",
       // Same text as stored -- simulates a Slack unfurl `message_changed`
       // where only attachments changed.
@@ -313,7 +308,6 @@ describe("Slack edit propagation", () => {
       conversationExternalId: seeded.conversationExternalId,
       externalMessageId: nextEditEventId(),
       sourceMessageId: seeded.channelTs,
-      canonicalAssistantId: "self",
       assistantId: "self",
       content: "edited searchable text",
     });
@@ -341,7 +335,6 @@ describe("Slack edit propagation", () => {
       // sourceMessageId points at a ts that was never stored.
       externalMessageId: nextEditEventId(),
       sourceMessageId: "9999.0000",
-      canonicalAssistantId: "self",
       assistantId: "self",
       content: "new text",
     });

--- a/assistant/src/__tests__/run-conversation-turn-persistence.test.ts
+++ b/assistant/src/__tests__/run-conversation-turn-persistence.test.ts
@@ -5,12 +5,15 @@ import {
   ensureConversationExists,
   getConversation,
 } from "../persistence/conversation-crud.js";
+import { getConversationByKey } from "../persistence/conversation-key-store.js";
 import {
   isEchoSuppressedUserMessage,
   isReplyPushIneligibleUserMessage,
 } from "../persistence/conversation-types.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
+import { buildScopedConversationKey } from "../persistence/delivery-crud.js";
+import { getBindingByConversation } from "../persistence/external-conversation-store.js";
 
 await initializeDb();
 
@@ -191,5 +194,125 @@ describe("runConversationTurn provenance", () => {
     const metadata = lastEnqueueOptions?.metadata as Record<string, unknown>;
     expect(metadata).toEqual({ automated: true });
     expect(isReplyPushIneligibleUserMessage(metadata)).toBe(true);
+  });
+});
+
+/**
+ * Addressing a turn by chat rather than by conversation id.
+ *
+ * The point of these is not that the turn runs (that is the same code path
+ * either way) but that the conversation it runs in is the one the rest of
+ * the assistant already addresses by those coordinates. A caller keeping its
+ * own chat-to-conversation map would pass every test above and still be
+ * invisible to conversation reset, to the deny lanes, and to the channel
+ * metadata the conversation list renders.
+ */
+describe("runConversationTurn channel binding", () => {
+  const CHANNEL = {
+    sourceChannel: "plugin" as const,
+    externalChatId: "imessage:+12025550142",
+    displayName: "Ada",
+  };
+
+  beforeEach(() => {
+    const db = getDb();
+    db.run("DELETE FROM messages");
+    db.run("DELETE FROM external_conversation_bindings");
+    db.run("DELETE FROM conversation_keys");
+    db.run("DELETE FROM conversations");
+    listChangedCalls.length = 0;
+  });
+
+  test("resolves the chat to the conversation inbound would have used", async () => {
+    const result = await runConversationTurn({
+      channel: CHANNEL,
+      content: [{ type: "text", text: "hello" }],
+    });
+
+    // The public name for this conversation, which is what reset and the deny
+    // lanes address it by.
+    expect(
+      getConversationByKey(
+        buildScopedConversationKey(
+          CHANNEL.sourceChannel,
+          CHANNEL.externalChatId,
+        ),
+      )?.conversationId,
+    ).toBe(result.conversationId);
+  });
+
+  test("keeps the same chat in the same conversation across turns", async () => {
+    const first = await runConversationTurn({
+      channel: CHANNEL,
+      content: [{ type: "text", text: "hello" }],
+    });
+    const second = await runConversationTurn({
+      channel: CHANNEL,
+      content: [{ type: "text", text: "still me" }],
+    });
+
+    expect(second.conversationId).toBe(first.conversationId);
+    // Only the first turn minted a conversation.
+    expect(listChangedCalls).toEqual([
+      { kind: "created", conversationId: first.conversationId },
+    ]);
+  });
+
+  test("gives a different chat its own conversation", async () => {
+    const ada = await runConversationTurn({
+      channel: CHANNEL,
+      content: [{ type: "text", text: "hello" }],
+    });
+    const grace = await runConversationTurn({
+      channel: { ...CHANNEL, externalChatId: "imessage:+12025550188" },
+      content: [{ type: "text", text: "hello" }],
+    });
+
+    expect(grace.conversationId).not.toBe(ada.conversationId);
+  });
+
+  test("records the channel metadata the conversation list reads", async () => {
+    const result = await runConversationTurn({
+      channel: { ...CHANNEL, externalUserId: "+12025550142" },
+      content: [{ type: "text", text: "hello" }],
+    });
+
+    const binding = getBindingByConversation(result.conversationId);
+    expect(binding).toMatchObject({
+      sourceChannel: "plugin",
+      externalChatId: CHANNEL.externalChatId,
+      externalUserId: "+12025550142",
+      displayName: "Ada",
+    });
+  });
+
+  test("follows the vendor when a display name changes", async () => {
+    await runConversationTurn({
+      channel: CHANNEL,
+      content: [{ type: "text", text: "hello" }],
+    });
+    const result = await runConversationTurn({
+      channel: { ...CHANNEL, displayName: "Ada L." },
+      content: [{ type: "text", text: "renamed" }],
+    });
+
+    expect(getBindingByConversation(result.conversationId)?.displayName).toBe(
+      "Ada L.",
+    );
+  });
+
+  test("an explicit conversation id wins over the address", async () => {
+    // Two different conversations were named. Re-resolving would overrule the
+    // caller, so the explicit one is honoured and nothing is bound behind it.
+    const existing = createConversation({ title: "chosen" });
+
+    const result = await runConversationTurn({
+      conversationId: existing.id,
+      channel: CHANNEL,
+      content: [{ type: "text", text: "hello" }],
+    });
+
+    expect(result.conversationId).toBe(existing.id);
+    expect(getBindingByConversation(existing.id)).toBeNull();
   });
 });

--- a/assistant/src/__tests__/run-conversation-turn-persistence.test.ts
+++ b/assistant/src/__tests__/run-conversation-turn-persistence.test.ts
@@ -40,6 +40,7 @@ mock.module("../runtime/sync/resource-sync-events.js", () => ({
 let lastProcessMessageConversationId: string | undefined;
 let lastProcessMessageOptions: Record<string, unknown> | undefined;
 let lastEnqueueOptions: Record<string, unknown> | undefined;
+let lastTurnChannelContext: unknown;
 let conversationIsProcessing = false;
 mock.module("../daemon/conversation-store.js", () => ({
   getOrCreateConversation: async (
@@ -60,6 +61,9 @@ mock.module("../daemon/conversation-store.js", () => ({
     }
     return {
       abortController: undefined,
+      setTurnChannelContext: (ctx: unknown) => {
+        lastTurnChannelContext = ctx;
+      },
       isProcessing: () => conversationIsProcessing,
       async processMessage(processOptions: Record<string, unknown>) {
         // The row must already exist by the time the turn persists its user
@@ -98,6 +102,7 @@ describe("runConversationTurn persistence", () => {
     lastProcessMessageConversationId = undefined;
     lastProcessMessageOptions = undefined;
     lastEnqueueOptions = undefined;
+    lastTurnChannelContext = undefined;
     conversationIsProcessing = false;
   });
 
@@ -221,6 +226,10 @@ describe("runConversationTurn channel binding", () => {
     db.run("DELETE FROM conversation_keys");
     db.run("DELETE FROM conversations");
     listChangedCalls.length = 0;
+    lastProcessMessageOptions = undefined;
+    lastEnqueueOptions = undefined;
+    lastTurnChannelContext = undefined;
+    conversationIsProcessing = false;
   });
 
   test("resolves the chat to the conversation inbound would have used", async () => {
@@ -299,6 +308,96 @@ describe("runConversationTurn channel binding", () => {
     expect(getBindingByConversation(result.conversationId)?.displayName).toBe(
       "Ada L.",
     );
+  });
+
+  test("runs the turn on the channel it was addressed by", async () => {
+    // Runtime assembly reads the per-turn channel first and only then the
+    // conversation's origin, so a turn into a conversation whose origin was
+    // never recorded would otherwise run as `vellum`. That is the wrong
+    // channel for the message row and for the permission cascade the tools
+    // are approved against.
+    await runConversationTurn({
+      channel: CHANNEL,
+      content: [{ type: "text", text: "hello" }],
+    });
+
+    expect(lastTurnChannelContext).toEqual({
+      userMessageChannel: "plugin",
+      assistantMessageChannel: "plugin",
+    });
+    expect(lastProcessMessageOptions?.metadata).toMatchObject({
+      userMessageChannel: "plugin",
+      assistantMessageChannel: "plugin",
+    });
+  });
+
+  test("a queued turn carries its own channel rather than inheriting one", async () => {
+    // The drain happens after this call returns and reads the channel off the
+    // queued message, falling back to whichever turn was in flight. On a
+    // conversation shared with another channel that fallback is someone
+    // else's channel.
+    conversationIsProcessing = true;
+
+    const result = await runConversationTurn({
+      channel: CHANNEL,
+      content: [{ type: "text", text: "hello" }],
+    });
+
+    expect(result.queued).toBe(true);
+    expect(lastEnqueueOptions?.metadata).toMatchObject({
+      userMessageChannel: "plugin",
+      assistantMessageChannel: "plugin",
+    });
+  });
+
+  test("leaves the channel unset when the turn names none", async () => {
+    // Clearing rather than leaving whatever the last turn set: a stale
+    // context would report this turn on a channel it has nothing to do with.
+    await runConversationTurn({
+      content: [{ type: "text", text: "hello" }],
+    });
+
+    expect(lastTurnChannelContext).toBeNull();
+    expect(lastProcessMessageOptions?.metadata).toEqual({ automated: true });
+  });
+
+  test("keeps a known sender when a later turn omits it", async () => {
+    // A plugin that knows only the chat coordinates this time is silent about
+    // the sender, not asserting it has none. Erasing the stored name on that
+    // silence drops it from the conversation and session APIs.
+    await runConversationTurn({
+      channel: { ...CHANNEL, externalUserId: "+12025550142" },
+      content: [{ type: "text", text: "hello" }],
+    });
+
+    const result = await runConversationTurn({
+      channel: {
+        sourceChannel: CHANNEL.sourceChannel,
+        externalChatId: CHANNEL.externalChatId,
+      },
+      content: [{ type: "text", text: "still me" }],
+    });
+
+    expect(getBindingByConversation(result.conversationId)).toMatchObject({
+      externalUserId: "+12025550142",
+      displayName: "Ada",
+    });
+  });
+
+  test("clears a sender the caller explicitly says is gone", async () => {
+    await runConversationTurn({
+      channel: CHANNEL,
+      content: [{ type: "text", text: "hello" }],
+    });
+
+    const result = await runConversationTurn({
+      channel: { ...CHANNEL, displayName: null },
+      content: [{ type: "text", text: "anonymous now" }],
+    });
+
+    expect(
+      getBindingByConversation(result.conversationId)?.displayName,
+    ).toBeNull();
   });
 
   test("an explicit conversation id wins over the address", async () => {

--- a/assistant/src/__tests__/slack-edit-ordering-characterization.test.ts
+++ b/assistant/src/__tests__/slack-edit-ordering-characterization.test.ts
@@ -59,7 +59,6 @@ async function applyEdit(eventId: string, content: string): Promise<void> {
     conversationExternalId: CHANNEL,
     externalMessageId: eventId,
     sourceMessageId: ORIGINAL_TS,
-    canonicalAssistantId: "self",
     assistantId: "self",
     content,
   });

--- a/assistant/src/persistence/delivery-crud.ts
+++ b/assistant/src/persistence/delivery-crud.ts
@@ -8,8 +8,8 @@
 import { and, desc, eq, isNotNull, ne, or, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
+import type { ChannelId } from "../channels/types.js";
 import { readSlackMetadataFromMessageMetadata } from "../messaging/providers/slack/message-metadata.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import type { SlackInboundMessageMetadata } from "../runtime/http-types.js";
 import { parseJsonSafe } from "../util/json.js";
 import { isPlainObject } from "../util/object.js";
@@ -19,6 +19,7 @@ import {
   getOrCreateConversation,
   setConversationKeyIfAbsent,
 } from "./conversation-key-store.js";
+import type { NonScheduledConversationType } from "./conversation-types.js";
 import { getDb } from "./db-connection.js";
 import { channelInboundEvents, conversations } from "./schema.js";
 
@@ -31,7 +32,6 @@ export interface InboundResult {
 
 export interface RecordInboundOptions {
   sourceMessageId?: string;
-  assistantId?: string;
   sourceThreadId?: string;
 }
 
@@ -45,30 +45,31 @@ const SLACK_LEGACY_THREAD_EVIDENCE_MAX_SCAN = 500;
  */
 const THREAD_SCOPED_CHANNELS = new Set(["slack", "telegram"]);
 
-function buildScopedConversationKeyForAssistant(
-  assistantId: string,
-  sourceChannel: string,
-  externalChatId: string,
-  sourceThreadId?: string | null,
-): string {
-  const threadId = sourceThreadId?.trim();
-  if (THREAD_SCOPED_CHANNELS.has(sourceChannel) && threadId) {
-    return `asst:${assistantId}:${sourceChannel}:${externalChatId}:thread:${threadId}`;
-  }
-  return `asst:${assistantId}:${sourceChannel}:${externalChatId}`;
-}
+/**
+ * Scope prefix on every conversation key.
+ *
+ * An assistant id used to be interpolated here, but the daemon is
+ * single-tenant and the only value that ever reached it was `self`: channel
+ * inbound runs every caller through `canonicalChannelAssistantId`, which
+ * discards its argument and answers `self`. The parameter named one value,
+ * so it is gone.
+ *
+ * The literal stays, because this is a stored key format rather than an
+ * internal detail. Rows already written under `asst:self:...` have to keep
+ * matching, so the prefix is not ours to tidy.
+ */
+const CONVERSATION_KEY_SCOPE = "asst:self";
 
 export function buildScopedConversationKey(
   sourceChannel: string,
   externalChatId: string,
   sourceThreadId?: string | null,
 ): string {
-  return buildScopedConversationKeyForAssistant(
-    DAEMON_INTERNAL_ASSISTANT_ID,
-    sourceChannel,
-    externalChatId,
-    sourceThreadId,
-  );
+  const threadId = sourceThreadId?.trim();
+  if (THREAD_SCOPED_CHANNELS.has(sourceChannel) && threadId) {
+    return `${CONVERSATION_KEY_SCOPE}:${sourceChannel}:${externalChatId}:thread:${threadId}`;
+  }
+  return `${CONVERSATION_KEY_SCOPE}:${sourceChannel}:${externalChatId}`;
 }
 
 function legacySlackConversationHasThreadEvidence(
@@ -135,14 +136,24 @@ function legacySlackConversationHasThreadEvidence(
   return false;
 }
 
-function resolveInboundConversation(
-  assistantId: string,
+/**
+ * Applied only where this call is what creates the conversation. An address
+ * that already resolves is an existing conversation, and neither its type nor
+ * where it came from is the current message's to restate.
+ */
+export interface ResolveInboundConversationOptions {
+  conversationType?: NonScheduledConversationType;
+  /** Channel this conversation originates on, for first-message attribution. */
+  origin?: ChannelId;
+}
+
+export function resolveInboundConversation(
   sourceChannel: string,
   externalChatId: string,
   sourceThreadId?: string | null,
+  opts?: ResolveInboundConversationOptions,
 ): { conversationId: string } {
-  const threadedKey = buildScopedConversationKeyForAssistant(
-    assistantId,
+  const threadedKey = buildScopedConversationKey(
     sourceChannel,
     externalChatId,
     sourceThreadId,
@@ -155,7 +166,7 @@ function resolveInboundConversation(
   // other thread-scoped channel (Telegram topics) has no flat-key aliasing —
   // a thread id always resolves the threaded key directly.
   if (sourceChannel !== "slack" || !threadId) {
-    return getOrCreateConversation(threadedKey);
+    return getOrCreateConversation(threadedKey, opts);
   }
 
   const threadedMapping = getConversationByKey(threadedKey);
@@ -163,8 +174,7 @@ function resolveInboundConversation(
     return { conversationId: threadedMapping.conversationId };
   }
 
-  const legacyKey = buildScopedConversationKeyForAssistant(
-    assistantId,
+  const legacyKey = buildScopedConversationKey(
     sourceChannel,
     externalChatId,
     null,
@@ -185,7 +195,7 @@ function resolveInboundConversation(
     }
   }
 
-  return getOrCreateConversation(threadedKey);
+  return getOrCreateConversation(threadedKey, opts);
 }
 
 /**
@@ -276,9 +286,7 @@ export function recordInbound(
     };
   }
 
-  const assistantId = options?.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID;
   const mapping = resolveInboundConversation(
-    assistantId,
     sourceChannel,
     externalChatId,
     options?.sourceThreadId,

--- a/assistant/src/persistence/delivery-crud.ts
+++ b/assistant/src/persistence/delivery-crud.ts
@@ -48,15 +48,9 @@ const THREAD_SCOPED_CHANNELS = new Set(["slack", "telegram"]);
 /**
  * Scope prefix on every conversation key.
  *
- * An assistant id used to be interpolated here, but the daemon is
- * single-tenant and the only value that ever reached it was `self`: channel
- * inbound runs every caller through `canonicalChannelAssistantId`, which
- * discards its argument and answers `self`. The parameter named one value,
- * so it is gone.
- *
- * The literal stays, because this is a stored key format rather than an
- * internal detail. Rows already written under `asst:self:...` have to keep
- * matching, so the prefix is not ours to tidy.
+ * Part of the stored key format, so it is fixed: rows are written under
+ * `asst:self:` and stop resolving if it changes. The daemon is single-tenant
+ * and scopes all its storage to `self` (`DAEMON_INTERNAL_ASSISTANT_ID`).
  */
 const CONVERSATION_KEY_SCOPE = "asst:self";
 

--- a/assistant/src/persistence/external-conversation-store.ts
+++ b/assistant/src/persistence/external-conversation-store.ts
@@ -7,7 +7,8 @@
  * list APIs.
  */
 
-import { and, eq, inArray, isNull, sql } from "drizzle-orm";
+import { and, eq, inArray, isNull, type SQL, sql } from "drizzle-orm";
+import type { AnySQLiteColumn } from "drizzle-orm/sqlite-core";
 
 import { getDb } from "./db-connection.js";
 import { externalConversationBindings } from "./schema/index.js";
@@ -43,6 +44,19 @@ function normalizeExternalThreadId(
 ): string | null {
   const trimmed = externalThreadId?.trim();
   return trimmed ? trimmed : null;
+}
+
+/**
+ * An upsert value that leaves the stored column alone when the caller said
+ * nothing about it, distinguishing "I do not know" from "there is none".
+ */
+function keepStoredIfAbsent<T extends string | null | undefined>(
+  value: T,
+  column: AnySQLiteColumn,
+): Exclude<T, undefined> | SQL {
+  return value === undefined
+    ? sql`${column}`
+    : (value as Exclude<T, undefined>);
 }
 
 function normalizeExternalChatName(
@@ -103,9 +117,23 @@ export function upsertBinding(input: UpsertBindingInput): void {
           externalChatName ??
           sql`${externalConversationBindings.externalChatName}`,
         externalThreadId,
-        externalUserId: input.externalUserId ?? null,
-        displayName: input.displayName ?? null,
-        username: input.username ?? null,
+        // An omitted sender field keeps what is stored; an explicit value,
+        // including null, replaces it. A caller that knows only the chat
+        // coordinates on a message is silent about the sender rather than
+        // asserting there is none, and erasing a known name on that silence
+        // drops it from the conversation and session APIs.
+        externalUserId: keepStoredIfAbsent(
+          input.externalUserId,
+          externalConversationBindings.externalUserId,
+        ),
+        displayName: keepStoredIfAbsent(
+          input.displayName,
+          externalConversationBindings.displayName,
+        ),
+        username: keepStoredIfAbsent(
+          input.username,
+          externalConversationBindings.username,
+        ),
         updatedAt: now,
         lastInboundAt: now,
       },

--- a/assistant/src/plugin-api/conversation-turn.ts
+++ b/assistant/src/plugin-api/conversation-turn.ts
@@ -198,11 +198,11 @@ async function resolveChannelConversation(
   const { upsertBinding } =
     await import("../persistence/external-conversation-store.js");
 
-  // Asked before resolving, because resolving is what creates it. The caller
-  // needs to know a conversation is new to announce it, and by the time it
-  // holds the id there is nothing left to distinguish. This is the read-only
-  // mirror of the resolution below, so the two agree on what "already bound"
-  // means, including the Slack flat-key alias.
+  // Asked before resolving, because resolving is what creates it: once the id
+  // is in hand a new conversation is indistinguishable from an existing one,
+  // and the caller announces only the new. `findInboundConversationId` is the
+  // read-only mirror of the resolution below, so the two agree on what
+  // "already bound" means, including the Slack flat-key alias.
   const created =
     findInboundConversationId(
       channel.sourceChannel,
@@ -225,16 +225,19 @@ async function resolveChannelConversation(
 
   // Refreshed on every turn rather than only on creation, because the sender's
   // display name and the chat's name are the vendor's to change and the
-  // conversation list shows whichever we last heard.
+  // conversation list shows whichever we last heard. The optional fields pass
+  // through as given: a caller that omits one on a later turn knows only the
+  // chat coordinates this time, which `upsertBinding` reads as silence rather
+  // than as the sender having no name.
   upsertBinding({
     conversationId,
     sourceChannel: channel.sourceChannel,
     externalChatId: channel.externalChatId,
-    externalChatName: channel.externalChatName ?? null,
+    externalChatName: channel.externalChatName,
     externalThreadId: channel.externalThreadId ?? null,
-    externalUserId: channel.externalUserId ?? null,
-    displayName: channel.displayName ?? null,
-    username: channel.username ?? null,
+    externalUserId: channel.externalUserId,
+    displayName: channel.displayName,
+    username: channel.username,
   });
 
   return { conversationId, created };
@@ -298,9 +301,9 @@ export async function runConversationTurn(
       : undefined;
   const conversationId =
     options.conversationId ?? channelConversation?.conversationId ?? uuidv7();
-  // Resolving a channel address already created the row, so asking the DB
-  // whether it existed would answer yes for a conversation minted a line ago
-  // and swallow the announcement it is owed.
+  // A channel address reports its own novelty, since resolving it creates the
+  // row: asking the DB here answers yes for a conversation minted a line ago
+  // and swallows the announcement it is owed.
   const rowExisted = channelConversation
     ? !channelConversation.created
     : getConversation(conversationId) != null;
@@ -335,6 +338,28 @@ export async function runConversationTurn(
     resolveMediaSourceData,
   );
 
+  // The channel this turn speaks on. Runtime assembly reads the per-turn
+  // context first and falls back to the conversation's `originChannel`, then
+  // to `vellum`, so a turn into a conversation carrying no origin runs as
+  // `vellum` without this: the wrong channel for the message row and for the
+  // channel-permission cascade the tools are approved against. Null when the
+  // caller names no channel, which both restores that fallback and clears any
+  // context left by a previous turn.
+  const turnChannelContext = options.channel
+    ? {
+        userMessageChannel: options.channel.sourceChannel,
+        assistantMessageChannel: options.channel.sourceChannel,
+      }
+    : null;
+  // Carried on the metadata as well, because a queued turn is drained after
+  // this call returns and reads its channel from there. Without it the drain
+  // inherits whichever turn was in flight, which on a shared conversation is
+  // some other channel entirely.
+  const metadata = {
+    ...PLUGIN_TURN_MESSAGE_METADATA,
+    ...(turnChannelContext ?? {}),
+  };
+
   // Build the event emitter: fan out to SSE/event-hub subscribers via
   // broadcastMessage, then invoke the collector callback. This mirrors the
   // buildEventEmitter pattern from process-message.ts so plugin-driven
@@ -357,7 +382,7 @@ export async function runConversationTurn(
       onEvent,
       requestId,
       isInteractive: false,
-      metadata: { ...PLUGIN_TURN_MESSAGE_METADATA },
+      metadata,
     });
     if (enqueueResult.rejected) {
       throw new Error(
@@ -372,12 +397,14 @@ export async function runConversationTurn(
     };
   }
 
+  conversation.setTurnChannelContext(turnChannelContext);
+
   const userMessageId = await conversation.processMessage({
     content: text,
     attachments,
     onEvent,
     isInteractive: false,
-    metadata: { ...PLUGIN_TURN_MESSAGE_METADATA },
+    metadata,
     ...(options.callSite ? { callSite: options.callSite } : {}),
   });
 

--- a/assistant/src/plugin-api/conversation-turn.ts
+++ b/assistant/src/plugin-api/conversation-turn.ts
@@ -14,6 +14,7 @@
  */
 
 import type { AssistantEvent } from "../api/index.js";
+import type { ChannelId } from "../channels/types.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import type { UserMessageAttachment } from "../daemon/message-types/shared.js";
 import type { ContentBlock, MediaSource } from "../providers/types.js";
@@ -22,12 +23,62 @@ import type { ContentBlock, MediaSource } from "../providers/types.js";
 // Public types
 // ---------------------------------------------------------------------------
 
+/**
+ * The chat a turn belongs to, in the channel's own terms.
+ *
+ * Supplied instead of a `conversationId` when the caller knows where the
+ * message came from but not which conversation that is. The pair resolves to
+ * the same conversation an inbound message on those coordinates would land
+ * in, because it resolves through the same binding.
+ *
+ * That sameness is the reason this exists at all. A caller could keep its own
+ * `externalChatId -> conversationId` map and pass the id, and turns would run
+ * in the right place. What it could not do is make the rest of the assistant
+ * agree: conversation reset is addressed by channel coordinates
+ * (`handleDeleteConversation`), the deny lanes attach an access-request card
+ * by them (`findInboundConversationId`), and the conversation and session
+ * APIs read the channel, chat name and sender off the external binding. A
+ * private map is a second name for the same conversation, and everything
+ * keyed on the public one quietly misses.
+ */
+export interface ConversationChannelAddress {
+  /** Channel the message arrived on. */
+  sourceChannel: ChannelId;
+  /** The chat, in the channel's own id space. */
+  externalChatId: string;
+  /**
+   * Thread within the chat, where the channel has threads. Only Slack and
+   * Telegram scope a conversation by thread; elsewhere this is carried as
+   * binding metadata and does not split the conversation.
+   */
+  externalThreadId?: string | null;
+  /** Human-readable chat name, for the conversation list. */
+  externalChatName?: string | null;
+  /** Who sent it, in the channel's id space. */
+  externalUserId?: string | null;
+  displayName?: string | null;
+  username?: string | null;
+}
+
 export interface RunConversationTurnOptions {
   /**
    * Conversation to run the turn in. If omitted, a new conversation is
-   * created (its ID is generated with `uuidv7` and returned in the result).
+   * created (its ID is generated with `uuidv7` and returned in the result),
+   * unless {@link RunConversationTurnOptions.channel} says which chat this
+   * belongs to, in which case that chat's conversation is used.
    */
   conversationId?: string;
+  /**
+   * The chat this turn belongs to, resolved to a conversation and bound to
+   * the channel. See {@link ConversationChannelAddress}.
+   *
+   * Ignored when `conversationId` is given: an explicit conversation is the
+   * caller saying which one, and re-resolving would overrule it. A caller
+   * that wants both the binding and a conversation of its own choosing is
+   * describing two different conversations, which is a bug worth surfacing
+   * as one rather than silently picking a winner.
+   */
+  channel?: ConversationChannelAddress;
   /**
    * User message content blocks for this turn. Text blocks become the
    * user message body; image/file blocks are resolved to inline
@@ -121,6 +172,74 @@ function extractContentAndAttachments(
   return { text: textParts.join("\n"), attachments };
 }
 
+/**
+ * Resolve a chat to its conversation, binding the two if they are not already.
+ *
+ * Two writes, the same two `handleChannelInbound` makes for an arriving
+ * message, and for the same reasons. The conversation key is what makes the
+ * chat resolve to this conversation next time and what conversation reset
+ * addresses; the external binding is what the conversation and session APIs
+ * read to show which channel a conversation came from and who is on the other
+ * end. One without the other is a conversation that is half-registered, and
+ * which half is missing decides which feature quietly stops working.
+ *
+ * Deliberately not `recordInbound`, which is the same resolution plus an
+ * inbound event row. That row exists to dedup a vendor's redelivery and to
+ * correlate later edits, and a caller driving a turn on its own schedule has
+ * neither a vendor nor a message id to correlate. Plugin deliveries are
+ * deduped upstream in the gateway before the message ever gets here.
+ */
+async function resolveChannelConversation(
+  channel: ConversationChannelAddress,
+  conversationType?: "standard" | "background",
+): Promise<{ conversationId: string; created: boolean }> {
+  const { findInboundConversationId, resolveInboundConversation } =
+    await import("../persistence/delivery-crud.js");
+  const { upsertBinding } =
+    await import("../persistence/external-conversation-store.js");
+
+  // Asked before resolving, because resolving is what creates it. The caller
+  // needs to know a conversation is new to announce it, and by the time it
+  // holds the id there is nothing left to distinguish. This is the read-only
+  // mirror of the resolution below, so the two agree on what "already bound"
+  // means, including the Slack flat-key alias.
+  const created =
+    findInboundConversationId(
+      channel.sourceChannel,
+      channel.externalChatId,
+      channel.externalThreadId,
+    ) === null;
+
+  const { conversationId } = resolveInboundConversation(
+    channel.sourceChannel,
+    channel.externalChatId,
+    channel.externalThreadId,
+    // Both apply only if this call is what mints the conversation. `origin` is
+    // first-message attribution, which a chat's first turn is the only chance
+    // to record.
+    {
+      origin: channel.sourceChannel,
+      ...(conversationType ? { conversationType } : {}),
+    },
+  );
+
+  // Refreshed on every turn rather than only on creation, because the sender's
+  // display name and the chat's name are the vendor's to change and the
+  // conversation list shows whichever we last heard.
+  upsertBinding({
+    conversationId,
+    sourceChannel: channel.sourceChannel,
+    externalChatId: channel.externalChatId,
+    externalChatName: channel.externalChatName ?? null,
+    externalThreadId: channel.externalThreadId ?? null,
+    externalUserId: channel.externalUserId ?? null,
+    displayName: channel.displayName ?? null,
+    username: channel.username ?? null,
+  });
+
+  return { conversationId, created };
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -166,8 +285,25 @@ export async function runConversationTurn(
   // below) without requiring a client to approve prompts.
   const { INTERNAL_GUARDIAN_TRUST_CONTEXT } =
     await import("../daemon/trust-context.js");
-  const conversationId = options.conversationId ?? uuidv7();
-  const rowExisted = getConversation(conversationId) != null;
+
+  // A channel address resolves through the same binding an inbound message
+  // uses, so a turn addressed by chat lands in that chat's conversation
+  // rather than a private one only this caller can find.
+  const channelConversation =
+    !options.conversationId && options.channel
+      ? await resolveChannelConversation(
+          options.channel,
+          options.conversationType,
+        )
+      : undefined;
+  const conversationId =
+    options.conversationId ?? channelConversation?.conversationId ?? uuidv7();
+  // Resolving a channel address already created the row, so asking the DB
+  // whether it existed would answer yes for a conversation minted a line ago
+  // and swallow the announcement it is owed.
+  const rowExisted = channelConversation
+    ? !channelConversation.created
+    : getConversation(conversationId) != null;
   const conversation = await getOrCreateConversation(conversationId, {
     trustContext: INTERNAL_GUARDIAN_TRUST_CONTEXT,
     ...(options.conversationType

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -385,6 +385,7 @@ export { openTranscriptionSession } from "./transcription-session.js";
 // (e.g. meeting-bot flushing a transcript excerpt) should prefer this over the
 // stateless `provider.sendMessage()` call.
 export type {
+  ConversationChannelAddress,
   RunConversationTurnOptions,
   RunConversationTurnResult,
 } from "./conversation-turn.js";

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -728,13 +728,8 @@ export async function handleChannelInbound({
 
   const replyCallbackUrl = body.replyCallbackUrl;
 
-  // `external_conversation_bindings` is assistant-agnostic, and this write was
-  // gated on the caller resolving to self so assistant-scoped legacy routes
-  // could not overwrite each other's binding for one chat. The gate could not
-  // decide anything: `canonicalChannelAssistantId` discards its argument and
-  // answers self for every caller, so there is no second writer to guard
-  // against and the binding was either written or silently skipped for
-  // nobody.
+  // `external_conversation_bindings` is assistant-agnostic: one row per chat,
+  // whichever caller writes it.
   upsertBinding({
     conversationId: result.conversationId,
     sourceChannel,

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -709,7 +709,6 @@ export async function handleChannelInbound({
       externalMessageId,
       sourceMessageId,
       sourceThreadId: channelThreadId,
-      canonicalAssistantId,
       assistantId,
       content,
       channelId: resolvedMember?.channelId,
@@ -723,28 +722,29 @@ export async function handleChannelInbound({
     externalMessageId,
     {
       sourceMessageId,
-      assistantId: canonicalAssistantId,
       sourceThreadId: channelThreadId,
     },
   );
 
   const replyCallbackUrl = body.replyCallbackUrl;
 
-  // external_conversation_bindings is assistant-agnostic. Restrict writes to
-  // self so assistant-scoped legacy routes do not overwrite each other's
-  // channel binding metadata for the same chat.
-  if (canonicalAssistantId === DAEMON_INTERNAL_ASSISTANT_ID) {
-    upsertBinding({
-      conversationId: result.conversationId,
-      sourceChannel,
-      externalChatId: conversationExternalId,
-      externalChatName: slackChannelName,
-      externalThreadId: channelThreadId ?? null,
-      externalUserId: canonicalSenderId ?? rawSenderId ?? null,
-      displayName: body.actorDisplayName ?? null,
-      username: body.actorUsername ?? null,
-    });
-  }
+  // `external_conversation_bindings` is assistant-agnostic, and this write was
+  // gated on the caller resolving to self so assistant-scoped legacy routes
+  // could not overwrite each other's binding for one chat. The gate could not
+  // decide anything: `canonicalChannelAssistantId` discards its argument and
+  // answers self for every caller, so there is no second writer to guard
+  // against and the binding was either written or silently skipped for
+  // nobody.
+  upsertBinding({
+    conversationId: result.conversationId,
+    sourceChannel,
+    externalChatId: conversationExternalId,
+    externalChatName: slackChannelName,
+    externalThreadId: channelThreadId ?? null,
+    externalUserId: canonicalSenderId ?? rawSenderId ?? null,
+    displayName: body.actorDisplayName ?? null,
+    username: body.actorUsername ?? null,
+  });
 
   // ── Actor role resolution ──
   // Built from the gateway-stamped trust verdict (ACL + identity). An absent

--- a/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
@@ -45,7 +45,6 @@ export interface EditInterceptParams {
   externalMessageId: string;
   sourceMessageId: string;
   sourceThreadId?: string;
-  canonicalAssistantId: string;
   assistantId: string;
   content: string | undefined;
   /** Channel ID for channel-level interaction tracking. */
@@ -68,7 +67,6 @@ export async function handleEditIntercept(
     externalMessageId,
     sourceMessageId,
     sourceThreadId,
-    canonicalAssistantId,
     assistantId,
     content,
   } = params;
@@ -78,7 +76,7 @@ export async function handleEditIntercept(
     sourceChannel,
     conversationExternalId,
     externalMessageId,
-    { sourceMessageId, sourceThreadId, assistantId: canonicalAssistantId },
+    { sourceMessageId, sourceThreadId },
   );
 
   if (editResult.duplicate) {

--- a/assistant/src/runtime/routes/inbound-stages/reaction-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/reaction-intercept.ts
@@ -182,7 +182,6 @@ export async function handleSlackReactionIntercept(
     externalMessageId,
     {
       sourceMessageId: reactedMessageTs,
-      assistantId: canonicalAssistantId,
       sourceThreadId: threadTs,
     },
   );


### PR DESCRIPTION
## Prompt / plan

> let's keep binding, but build it into the `runConversationTurn` API
>
> we also want to keep removing logic referencing an internal assistant id so let's keep doing that

### Why binding, when a caller could keep its own map

`runConversationTurn` could only be told a conversation id, so a caller holding channel coordinates had nowhere to put them. It could keep its own `externalChatId -> conversationId` map and pass the id, and turns would run in the right place. What it could not do is make the rest of the assistant agree:

- **Conversation reset** is addressed by channel coordinates (`handleDeleteConversation`), so "reset this thread" would delete nothing and the caller would resurrect the old conversation from its private map.
- **The deny lanes** attach the access-request card by those coordinates (`findInboundConversationId`).
- **The conversation and session APIs** read the channel, chat name and sender off `external_conversation_bindings`, so the conversation would render with no channel and no sender.

A private map is a second name for the same conversation, and everything keyed on the public one quietly misses.

### What it does

`channel` resolves through the same two writes `handleChannelInbound` makes for an arriving message: the conversation key, which is what makes the chat resolve here next time, and the external binding, which is what the conversation list reads. One without the other leaves a half-registered conversation, and which half is missing decides which feature stops working.

Deliberately **not** `recordInbound`, which is that resolution plus an inbound event row. That row exists to dedup a vendor's redelivery and to correlate later edits; a caller driving a turn on its own schedule has neither a vendor retry nor a message id to correlate, and plugin deliveries are already deduped in the gateway (#40550).

An explicit `conversationId` still wins. A caller passing both is naming two different conversations, which is worth leaving as a visible bug rather than silently picking one.

`origin` and `conversationType` are threaded through `resolveInboundConversation` and apply only when the call actually mints the conversation. `origin` is first-message attribution, and a chat's first turn is the only chance to record it.

### One bug the tests caught

Resolving a channel address creates the conversation row, so by the time `runConversationTurn` asked "did this row already exist?", the answer was always yes, and a brand-new channel conversation never emitted its `created` list invalidation. Sidebars and sibling clients would never learn about it. Fixed by asking `findInboundConversationId` before resolving, which is the read-only mirror of the same lookup, so the two agree on what "already bound" means including the Slack flat-key alias.

### Assistant id removal

The binding path would otherwise have threaded a constant into new code. The daemon is single-tenant and `canonicalChannelAssistantId` discards its argument and answers `self` for every caller, so `recordInbound`'s `assistantId` option and the key builder's parameter only ever named one value. Removed, and two things fell out with it:

- The gate around `upsertBinding`, which compared that value to `self` and could not decide anything.
- A test asserting that two assistant ids get different conversations, which no caller could reach. Replaced with one pinning the `asst:self:` prefix, which stays: it is a stored key format, and a later tidy-up dropping it would strand every existing row.
- `canonicalAssistantId` on `EditInterceptParams`, which became unused.

**Scoped out on purpose:** the wider `canonicalAssistantId` threading through the intercept stages. It reaches the ACL and access-request helpers, so it wants its own pass. I started a blanket rename, found it half-landing across six modules, and backed it out rather than leave it straddling two states.

## Test plan

- 6 new tests on `runConversationTurn`: resolves the chat to the conversation inbound would have used; keeps the same chat in the same conversation across turns and announces it exactly once; gives a different chat its own conversation; records the channel metadata the conversation list reads; follows the vendor when a display name changes; an explicit conversation id wins over the address and binds nothing behind it.
- `channel-delivery-store` gains a test pinning the `asst:self:` key format.
- Assistant typecheck and lint clean. Full suite shows 7 failures, all of which fail identically on `origin/main` in this container (sandbox and script-proxy tests), verified in a scratch worktree at `origin/main`.

No new IPC routes, so the CLI verb checklist does not apply.

**Follow-up before this is usable from a plugin:** `@vellumai/plugin-api` publishes from `assistant/src/plugin-api/`, so the new `channel` option needs a package release.

---
_Generated by [Claude Code](https://claude.ai/code/session_013p1nTdvsuAtTJ7zyCSDLbx)_