### PR TITLE
revert(config): route the managed balanced profile back to GLM 5.2

### DIFF
--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -669,7 +669,7 @@ describe("loadConfig startup behavior", () => {
     expect(raw.llm.profiles).toEqual({});
     // Default content resolves from the code catalog via the effective view.
     const effectiveBalanced = getEffectiveProfile(raw.llm.profiles, "balanced");
-    expect(effectiveBalanced?.model).toBe("gpt-5.6-luna");
+    expect(effectiveBalanced?.model).toBe("accounts/fireworks/models/glm-5p2");
     expect(effectiveBalanced?.provider).toBe("vellum");
     expect(effectiveBalanced?.provider_connection).toBeUndefined();
   });
@@ -997,7 +997,7 @@ describe("loadConfig startup behavior", () => {
     // Resolution ignores the drifted body: a managed-source entry contributes
     // only label/status/topP, everything else comes from the catalog.
     const effectiveBalanced = getEffectiveProfile(raw.llm.profiles, "balanced");
-    expect(effectiveBalanced?.model).toBe("gpt-5.6-luna");
+    expect(effectiveBalanced?.model).toBe("accounts/fireworks/models/glm-5p2");
     expect(effectiveBalanced?.provider_connection).toBeUndefined();
   });
 
@@ -1077,7 +1077,7 @@ describe("loadConfig startup behavior", () => {
     expect(raw.llm.profiles.balanced).toEqual(drifted);
     expect(raw.llm.activeProfile).toBe("balanced");
     const effectiveBalanced = getEffectiveProfile(raw.llm.profiles, "balanced");
-    expect(effectiveBalanced?.model).toBe("gpt-5.6-luna");
+    expect(effectiveBalanced?.model).toBe("accounts/fireworks/models/glm-5p2");
     expect(effectiveBalanced?.maxTokens).toBe(32000);
     expect(effectiveBalanced?.provider_connection).toBeUndefined();
     // The catalog body carries no topP and the entry has none, so the
@@ -1109,7 +1109,7 @@ describe("loadConfig startup behavior", () => {
     expect(raw.llm.profiles.balanced).toEqual(edited);
     const effectiveBalanced = getEffectiveProfile(raw.llm.profiles, "balanced");
     // Content is served from the catalog...
-    expect(effectiveBalanced?.model).toBe("gpt-5.6-luna");
+    expect(effectiveBalanced?.model).toBe("accounts/fireworks/models/glm-5p2");
     // ...with the user's label and status overlaid.
     expect(effectiveBalanced?.label).toBe("My Default");
     expect(effectiveBalanced?.status).toBe("disabled");
@@ -1134,7 +1134,7 @@ describe("loadConfig startup behavior", () => {
     expect(raw.llm.profiles.balanced).toEqual(stub);
     const effectiveBalanced = getEffectiveProfile(raw.llm.profiles, "balanced");
     expect(effectiveBalanced?.label).toBe("My Default");
-    expect(effectiveBalanced?.model).toBe("gpt-5.6-luna");
+    expect(effectiveBalanced?.model).toBe("accounts/fireworks/models/glm-5p2");
   });
 
   test("off-platform boot preserves user-toggled status on a managed stub", () => {
@@ -1156,7 +1156,7 @@ describe("loadConfig startup behavior", () => {
     expect(effectiveBalanced?.status).toBe("disabled");
     // Content still comes from the catalog — only label/status/topP are
     // workspace-owned.
-    expect(effectiveBalanced?.model).toBe("gpt-5.6-luna");
+    expect(effectiveBalanced?.model).toBe("accounts/fireworks/models/glm-5p2");
   });
 
   test("boot preserves a user-edited topP override on a managed stub", () => {
@@ -1180,7 +1180,7 @@ describe("loadConfig startup behavior", () => {
     expect(effectiveBalanced?.topP).toBe(0.5);
     // Content still comes from the catalog — topP is workspace-owned, the
     // rest is code-owned.
-    expect(effectiveBalanced?.model).toBe("gpt-5.6-luna");
+    expect(effectiveBalanced?.model).toBe("accounts/fireworks/models/glm-5p2");
   });
 
   test("effective balanced profile carries no topP override by default", () => {
@@ -1235,7 +1235,7 @@ describe("loadConfig startup behavior", () => {
     expect(raw.llm.profiles.balanced).toBeUndefined();
     const effectiveBalanced = getEffectiveProfile(raw.llm.profiles, "balanced");
     expect(effectiveBalanced?.label).toBe("Balanced");
-    expect(effectiveBalanced?.model).toBe("gpt-5.6-luna");
+    expect(effectiveBalanced?.model).toBe("accounts/fireworks/models/glm-5p2");
     // Status is unset — the default resolves active.
     expect("status" in (effectiveBalanced ?? {})).toBe(false);
   });
@@ -1314,7 +1314,7 @@ describe("loadConfig startup behavior", () => {
     // overlay boot. The overlay-set label is what shows through the
     // effective view.
     expect(mainAgentConfig.provider).toBe("vellum");
-    expect(mainAgentConfig.model).toBe("gpt-5.6-luna");
+    expect(mainAgentConfig.model).toBe("accounts/fireworks/models/glm-5p2");
 
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
     expect(raw.llm.profiles.balanced).toEqual({
@@ -1345,7 +1345,7 @@ describe("loadConfig startup behavior", () => {
     );
     expect(effectiveBalanced?.provider).toBe("vellum");
     expect(effectiveBalanced?.provider_connection).toBeUndefined();
-    expect(effectiveBalanced?.model).toBe("gpt-5.6-luna");
+    expect(effectiveBalanced?.model).toBe("accounts/fireworks/models/glm-5p2");
     expect(effectiveBalanced?.maxTokens).toBe(32000);
     expect(effectiveBalanced?.thinking).toEqual({
       enabled: true,

--- a/assistant/src/__tests__/managed-profile-guard.test.ts
+++ b/assistant/src/__tests__/managed-profile-guard.test.ts
@@ -1090,7 +1090,7 @@ describe("code-owned default profiles — wire view and write normalization", ()
     });
     const response = (await getRoute.handler({})) as Record<string, any>;
     const wireBalanced = response.llm.profiles.balanced;
-    expect(wireBalanced.model).toBe("gpt-5.6-luna");
+    expect(wireBalanced.model).toBe("accounts/fireworks/models/glm-5p2");
     expect(wireBalanced.provider).toBe("vellum");
     expect(wireBalanced.provider_connection).toBeUndefined();
     expect(wireBalanced.status).toBe("disabled");
@@ -1337,7 +1337,9 @@ describe("code-owned default profiles — echoes over stale on-disk bodies", () 
     });
     const response = (await getRoute.handler({})) as Record<string, any>;
     // The wire view serves catalog content, not the stale body.
-    expect(response.llm.profiles.balanced.model).toBe("gpt-5.6-luna");
+    expect(response.llm.profiles.balanced.model).toBe(
+      "accounts/fireworks/models/glm-5p2",
+    );
     const result = await patchRoute.handler({
       body: { llm: { profiles: response.llm.profiles } },
     });

--- a/assistant/src/config/__tests__/default-profile-catalog.test.ts
+++ b/assistant/src/config/__tests__/default-profile-catalog.test.ts
@@ -56,12 +56,12 @@ describe("getEffectiveProfiles", () => {
     }
   });
 
-  test("the managed Balanced profile routes GPT-5.6 Luna through OpenAI", () => {
+  test("the managed Balanced profile routes GLM 5.2 through Fireworks", () => {
     const balanced = CODE_DEFAULT_PROFILE_ENTRIES.balanced;
-    expect(balanced.model).toBe("gpt-5.6-luna");
+    expect(balanced.model).toBe("accounts/fireworks/models/glm-5p2");
     expect(resolveRoutingIdentity(balanced.provider, balanced.model)).toEqual({
       connectionName: "vellum",
-      expectedProvider: "openai",
+      expectedProvider: "fireworks",
     });
   });
 

--- a/assistant/src/config/default-profile-catalog.ts
+++ b/assistant/src/config/default-profile-catalog.ts
@@ -70,7 +70,7 @@ type ProfileImpls = Record<DefaultProfileKey, DefaultProfileTemplate>;
  */
 const VELLUM_PROFILE_IMPLS: ProfileImpls = {
   balanced: {
-    model: "gpt-5.6-luna",
+    model: "accounts/fireworks/models/glm-5p2",
     provider: "vellum",
     source: "managed",
     label: "Balanced",
@@ -127,8 +127,8 @@ const VELLUM_PROFILE_IMPLS: ProfileImpls = {
     // provisioned in every environment, and it alone selects the upstream:
     // `provider` below is the provider-agnostic managed sentinel, so
     // `getManagedUpstream` resolves the real upstream from the model's catalog
-    // owner. Sharing `balanced`'s model is deliberate: the split is effort
-    // and thinking, and this model is the one live-voice TTFT drives validated.
+    // owner. This model is the one live-voice TTFT drives validated, so it is
+    // pinned independently of the other profiles' pins.
     model: "gpt-5.6-luna",
     provider: "vellum",
     source: "managed",


### PR DESCRIPTION
## Summary

Reverts the managed **Balanced** profile pin from GPT-5.6 Luna back to GLM 5.2 on Fireworks.

The switch to Luna landed in #39685 ("feat(config): route managed balanced profile to GPT-5.6 Luna"). That is the only PR that moved this pin. This change puts `VELLUM_PROFILE_IMPLS.balanced` back to `accounts/fireworks/models/glm-5p2` and follows the pin through the suites that encode it.

The catalog is the single source of truth for default profile content, so the pin ships in a release with no workspace migration: managed entries on disk contribute only `label`/`status`/`topP`, and resolution serves the body from code.

## Scope

Only the managed (`vellum`) column of `balanced` moves. BYOK installs resolve `balanced` through the `intent` table for the provider the user chose and are untouched.

`latency-optimized` keeps its own Luna pin (set separately in #39527) because Luna is the model the live-voice TTFT drives validated. Its comment claimed it shared `balanced`'s model, which is no longer true, so that sentence is corrected.

## Known consequence: vision

GLM 5.2 is text-only (`supportsVision: false`) where Luna is vision-capable. The managed balanced profile therefore stops passing `doesSupportVision`, and image input on it routes through the image-fallback captioning plugin again. That path has not changed since #39685, so this restores the exact behavior that shipped before the Luna pin rather than exercising anything new.

The two `vision-support` cases that #39685 moved off `balanced` stay on `cost-optimized`. That pair still discriminates between the columns (vellum: deepseek-v4-flash, text-only; anthropic: claude-haiku-4-5, vision-capable), and `vision-support.test.ts` keeps a direct `doesSupportVision("accounts/fireworks/models/glm-5p2") === false` assertion, so moving them back would add nothing.

## Interaction with the open A/B test

PR #40391 (open, not merged) adds `experiment-balanced-model-2026-08-06` with `control = gpt-5.6-luna` as "the shipped pin". If both land, that experiment's `control` arm needs to be repointed to GLM 5.2 so `control` still means "the shipped body". Flagging for whoever picks that PR back up.

## Testing

- `default-profile-catalog`, `config-loader-backfill`, `managed-profile-guard`, `vision-support`, `byok-default-profile-ensure`, `inference-profiles-routes`, `config-schema`, `model-intents`, `agent-loop-override-profile`, `retry-callsite`, `conversation-agent-loop`, `sync-gated-profiles`, `dispatch-connection-routing`: all pass.
- `bun run typecheck:fast` clean; eslint and prettier clean.

Note: running `src/config/__tests__` plus `dispatch-connection-routing` in one `bun test` invocation produces 14 failures. Those reproduce identically on an untouched tree (verified by stash + re-run) and every affected file passes on its own, so it is pre-existing cross-file mock leakage in the batch runner, not this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->