### PR TITLE
fix(tools): bound file reads by characters instead of lines

### DIFF
--- a/assistant/src/__tests__/file-ops-service.test.ts
+++ b/assistant/src/__tests__/file-ops-service.test.ts
@@ -119,7 +119,7 @@ describe("FileSystemOps.readFileSafe", () => {
 
     const result = await ops.readFileSafe({
       path: "lines.txt",
-      startIndex: 3,
+      startIndex: 2,
       maxChars: 3,
     });
     expect(result.ok).toBe(true);
@@ -144,7 +144,7 @@ describe("FileSystemOps.readFileSafe", () => {
     const [body] = result.value.content.split("\n\n[Truncated:");
     expect(body).toHaveLength(READ_CHAR_BUDGET);
     expect(result.value.content).toContain(
-      `[Truncated: characters 1-${READ_CHAR_BUDGET} of ${total}. Read on with start_index=${READ_CHAR_BUDGET + 1}.]`,
+      `[Truncated: characters 0-${READ_CHAR_BUDGET} of ${total}. Read on with start_index=${READ_CHAR_BUDGET}.]`,
     );
   });
 
@@ -179,7 +179,7 @@ describe("FileSystemOps.readFileSafe", () => {
     const [body] = result.value.content.split("\n\n[Truncated:");
     expect(body).toHaveLength(10);
     expect(result.value.content).toContain(
-      "[Truncated: characters 1-10 of 500. Read on with start_index=11.]",
+      "[Truncated: characters 0-10 of 500. Read on with start_index=10.]",
     );
   });
 
@@ -193,11 +193,11 @@ describe("FileSystemOps.readFileSafe", () => {
     if (!first.ok) {
       return;
     }
-    expect(first.value.content).toContain("start_index=5");
+    expect(first.value.content).toContain("start_index=4");
 
     const second = await ops.readFileSafe({
       path: "big.txt",
-      startIndex: 5,
+      startIndex: 4,
       maxChars: 4,
     });
     expect(second.ok).toBe(true);
@@ -235,6 +235,99 @@ describe("FileSystemOps.readFileSafe", () => {
       return;
     }
     expect(result.value.content).not.toContain("[Truncated:");
+  });
+
+  test("a window boundary inside a surrogate pair does not corrupt it", async () => {
+    const dir = makeTempDir();
+    // "ab" + a 2-unit emoji + "cd": a maxChars of 3 would split the pair.
+    writeFileSync(join(dir, "emoji.txt"), `ab\u{1F600}cd`);
+    const ops = new FileSystemOps(sandboxPolicyFor(dir));
+
+    const result = await ops.readFileSafe({ path: "emoji.txt", maxChars: 3 });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    const [body] = result.value.content.split("\n\n[Truncated:");
+    expect(body).toBe("ab");
+    expect(body).not.toContain("\uFFFD");
+  });
+
+  test("paging across a surrogate pair reassembles the whole file", async () => {
+    const dir = makeTempDir();
+    const original = `ab\u{1F600}cd`;
+    writeFileSync(join(dir, "emoji.txt"), original);
+    const ops = new FileSystemOps(sandboxPolicyFor(dir));
+
+    let assembled = "";
+    let startIndex = 0;
+    for (let i = 0; i < 10; i++) {
+      const result = await ops.readFileSafe({
+        path: "emoji.txt",
+        startIndex,
+        maxChars: 3,
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) {
+        return;
+      }
+      const [body] = result.value.content.split("\n\n[Truncated:");
+      assembled += body;
+      const match = /start_index=(\d+)/.exec(result.value.content);
+      if (match?.[1] === undefined) {
+        break;
+      }
+      startIndex = Number(match[1]);
+    }
+    expect(assembled).toBe(original);
+  });
+
+  test("a lone-low-surrogate startIndex backs up onto the whole pair", async () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "emoji.txt"), `ab\u{1F600}cd`);
+    const ops = new FileSystemOps(sandboxPolicyFor(dir));
+
+    // Index 3 (0-indexed) is the low half of the emoji.
+    const result = await ops.readFileSafe({
+      path: "emoji.txt",
+      startIndex: 3,
+      maxChars: 2,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    const [body] = result.value.content.split("\n\n[Truncated:");
+    expect(body).toBe(`\u{1F600}`);
+    expect(body).not.toContain("\uFFFD");
+  });
+
+  test("legacy offset/limit are rejected rather than silently ignored", async () => {
+    const { fileReadTool } = await import("../tools/filesystem/read.js");
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "big.txt"), "x".repeat(500));
+
+    const result = await fileReadTool.execute(
+      { path: join(dir, "big.txt"), offset: 2001, limit: 2000 },
+      { workingDir: dir } as never,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("no longer takes");
+    expect(result.content).toContain("start_index");
+  });
+
+  test("legacy fields alongside current ones do not trigger the guard", async () => {
+    const { fileReadTool } = await import("../tools/filesystem/read.js");
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "big.txt"), "abcdefghij");
+
+    const result = await fileReadTool.execute(
+      { path: join(dir, "big.txt"), offset: 1, max_chars: 4 },
+      { workingDir: dir } as never,
+    );
+    expect(result.isError).toBe(false);
+    const [body] = result.content.split("\n\n[Truncated:");
+    expect(body).toBe("abcd");
   });
 
   test("the read budget stays under the tool-result spool threshold", () => {

--- a/assistant/src/__tests__/file-ops-service.test.ts
+++ b/assistant/src/__tests__/file-ops-service.test.ts
@@ -10,10 +10,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
 
+import { THRESHOLD_CHARS } from "../context/post-turn-tool-result-truncation.js";
 import {
-  DEFAULT_READ_LINE_LIMIT,
   FileSystemOps,
   type PathPolicy,
+  READ_CHAR_BUDGET,
 } from "../tools/shared/filesystem/file-ops-service.js";
 import { sandboxPolicy } from "../tools/shared/filesystem/path-policy.js";
 
@@ -111,34 +112,28 @@ describe("FileSystemOps.readFileSafe", () => {
     expect(result.error.code).toBe("PATH_OUT_OF_BOUNDS");
   });
 
-  test("respects offset and limit", async () => {
+  test("respects startIndex and maxChars", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "lines.txt"), "a\nb\nc\nd\ne\n");
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
     const result = await ops.readFileSafe({
       path: "lines.txt",
-      offset: 2,
-      limit: 2,
+      startIndex: 3,
+      maxChars: 3,
     });
     expect(result.ok).toBe(true);
     if (!result.ok) {
       return;
     }
-    // Assert on the numbered lines rather than bare letters: the truncation
-    // notice is prose, so a bare `toContain("d")` matches its wording.
     const [body] = result.value.content.split("\n\n[Truncated:");
-    expect(body).toContain("     2  b");
-    expect(body).toContain("     3  c");
-    expect(body).not.toContain("     1  a");
-    expect(body).not.toContain("     4  d");
+    expect(body).toBe("b\nc");
   });
 
-  test("caps an unbounded read at the default line limit and says so", async () => {
+  test("caps an unbounded read at the character budget and says so", async () => {
     const dir = makeTempDir();
-    const total = DEFAULT_READ_LINE_LIMIT + 500;
-    const lines = Array.from({ length: total }, (_, i) => `line${i + 1}`);
-    writeFileSync(join(dir, "big.txt"), lines.join("\n"));
+    const total = READ_CHAR_BUDGET + 500;
+    writeFileSync(join(dir, "big.txt"), "x".repeat(total));
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
     const result = await ops.readFileSafe({ path: "big.txt" });
@@ -146,36 +141,74 @@ describe("FileSystemOps.readFileSafe", () => {
     if (!result.ok) {
       return;
     }
-    const content = result.value.content;
-    expect(content).toContain(`  ${DEFAULT_READ_LINE_LIMIT}  line2000`);
-    expect(content).not.toContain("line2001");
-    expect(content).toContain(
-      `[Truncated: showing through line ${DEFAULT_READ_LINE_LIMIT} of ${total}. Read on with offset=${DEFAULT_READ_LINE_LIMIT + 1}`,
+    const [body] = result.value.content.split("\n\n[Truncated:");
+    expect(body).toHaveLength(READ_CHAR_BUDGET);
+    expect(result.value.content).toContain(
+      `[Truncated: characters 1-${READ_CHAR_BUDGET} of ${total}. Read on with start_index=${READ_CHAR_BUDGET + 1}.]`,
     );
   });
 
-  test("an explicit limit is honored rather than replaced by the default", async () => {
+  test("a maxChars above the budget is clamped to it", async () => {
     const dir = makeTempDir();
-    const lines = Array.from(
-      { length: DEFAULT_READ_LINE_LIMIT + 500 },
-      (_, i) => `line${i + 1}`,
-    );
-    writeFileSync(join(dir, "big.txt"), lines.join("\n"));
+    const total = READ_CHAR_BUDGET + 500;
+    writeFileSync(join(dir, "big.txt"), "x".repeat(total));
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
     const result = await ops.readFileSafe({
       path: "big.txt",
-      limit: DEFAULT_READ_LINE_LIMIT + 500,
+      maxChars: total,
     });
     expect(result.ok).toBe(true);
     if (!result.ok) {
       return;
     }
-    expect(result.value.content).toContain("line2500");
-    expect(result.value.content).not.toContain("[Truncated:");
+    const [body] = result.value.content.split("\n\n[Truncated:");
+    expect(body).toHaveLength(READ_CHAR_BUDGET);
   });
 
-  test("a read that reaches the last line carries no truncation notice", async () => {
+  test("a maxChars below the budget is honored as given", async () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "big.txt"), "x".repeat(500));
+    const ops = new FileSystemOps(sandboxPolicyFor(dir));
+
+    const result = await ops.readFileSafe({ path: "big.txt", maxChars: 10 });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    const [body] = result.value.content.split("\n\n[Truncated:");
+    expect(body).toHaveLength(10);
+    expect(result.value.content).toContain(
+      "[Truncated: characters 1-10 of 500. Read on with start_index=11.]",
+    );
+  });
+
+  test("paging with the offset from a notice returns the next window", async () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "big.txt"), "abcdefghij");
+    const ops = new FileSystemOps(sandboxPolicyFor(dir));
+
+    const first = await ops.readFileSafe({ path: "big.txt", maxChars: 4 });
+    expect(first.ok).toBe(true);
+    if (!first.ok) {
+      return;
+    }
+    expect(first.value.content).toContain("start_index=5");
+
+    const second = await ops.readFileSafe({
+      path: "big.txt",
+      startIndex: 5,
+      maxChars: 4,
+    });
+    expect(second.ok).toBe(true);
+    if (!second.ok) {
+      return;
+    }
+    const [body] = second.value.content.split("\n\n[Truncated:");
+    expect(body).toBe("efgh");
+  });
+
+  test("a read that reaches the end carries no truncation notice", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "small.txt"), "a\nb\nc");
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
@@ -193,12 +226,19 @@ describe("FileSystemOps.readFileSafe", () => {
     writeFileSync(join(dir, "small.txt"), "a\nb\nc");
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = await ops.readFileSafe({ path: "small.txt", offset: 100 });
+    const result = await ops.readFileSafe({
+      path: "small.txt",
+      startIndex: 100,
+    });
     expect(result.ok).toBe(true);
     if (!result.ok) {
       return;
     }
     expect(result.value.content).not.toContain("[Truncated:");
+  });
+
+  test("the read budget stays under the tool-result spool threshold", () => {
+    expect(READ_CHAR_BUDGET).toBeLessThan(THRESHOLD_CHARS);
   });
 });
 

--- a/assistant/src/__tests__/filesystem-tools.test.ts
+++ b/assistant/src/__tests__/filesystem-tools.test.ts
@@ -125,16 +125,19 @@ describe("FileSystemOps symlink handling", () => {
 });
 
 // ===========================================================================
-// FileSystemOps: read offset/limit edge cases
+// FileSystemOps: read character-window edge cases
 // ===========================================================================
 
-describe("FileSystemOps read offset/limit edge cases", () => {
-  test("offset beyond file length returns empty content", async () => {
+describe("FileSystemOps read character-window edge cases", () => {
+  test("startIndex beyond file length returns empty content", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "short.txt"), "a\nb\nc");
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = await ops.readFileSafe({ path: "short.txt", offset: 100 });
+    const result = await ops.readFileSafe({
+      path: "short.txt",
+      startIndex: 100,
+    });
     expect(result.ok).toBe(true);
     if (!result.ok) {
       return;
@@ -142,12 +145,12 @@ describe("FileSystemOps read offset/limit edge cases", () => {
     expect(result.value.content).toBe("");
   });
 
-  test("limit of zero returns empty content", async () => {
+  test("maxChars of zero returns empty content", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "file.txt"), "a\nb\nc");
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = await ops.readFileSafe({ path: "file.txt", limit: 0 });
+    const result = await ops.readFileSafe({ path: "file.txt", maxChars: 0 });
     expect(result.ok).toBe(true);
     if (!result.ok) {
       return;
@@ -155,61 +158,57 @@ describe("FileSystemOps read offset/limit edge cases", () => {
     expect(result.value.content).toBe("");
   });
 
-  test("offset=1 reads from first line (1-indexed)", async () => {
+  test("startIndex=1 reads from the first character (1-indexed)", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "file.txt"), "first\nsecond\nthird");
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
     const result = await ops.readFileSafe({
       path: "file.txt",
-      offset: 1,
-      limit: 1,
+      startIndex: 1,
+      maxChars: 5,
     });
     expect(result.ok).toBe(true);
     if (!result.ok) {
       return;
     }
-    expect(result.value.content).toContain("first");
-    expect(result.value.content).not.toContain("second");
+    const [body] = result.value.content.split("\n\n[Truncated:");
+    expect(body).toBe("first");
   });
 
-  test("limit exceeding file length returns all remaining lines", async () => {
+  test("maxChars exceeding file length returns the rest of the file", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "file.txt"), "a\nb");
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
     const result = await ops.readFileSafe({
       path: "file.txt",
-      offset: 1,
-      limit: 1000,
+      startIndex: 1,
+      maxChars: 1000,
     });
     expect(result.ok).toBe(true);
     if (!result.ok) {
       return;
     }
-    expect(result.value.content).toContain("a");
-    expect(result.value.content).toContain("b");
+    expect(result.value.content).toBe("a\nb");
   });
 
-  test("read adds line numbers starting from offset", async () => {
+  test("the window starts at startIndex and carries no line numbers", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "file.txt"), "a\nb\nc\nd\ne");
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
     const result = await ops.readFileSafe({
       path: "file.txt",
-      offset: 3,
-      limit: 2,
+      startIndex: 5,
+      maxChars: 3,
     });
     expect(result.ok).toBe(true);
     if (!result.ok) {
       return;
     }
-    // Lines should be numbered 3 and 4
-    expect(result.value.content).toContain("3");
-    expect(result.value.content).toContain("4");
-    expect(result.value.content).toContain("c");
-    expect(result.value.content).toContain("d");
+    const [body] = result.value.content.split("\n\n[Truncated:");
+    expect(body).toBe("c\nd");
   });
 });
 

--- a/assistant/src/__tests__/filesystem-tools.test.ts
+++ b/assistant/src/__tests__/filesystem-tools.test.ts
@@ -158,14 +158,14 @@ describe("FileSystemOps read character-window edge cases", () => {
     expect(result.value.content).toBe("");
   });
 
-  test("startIndex=1 reads from the first character (1-indexed)", async () => {
+  test("startIndex=0 reads from the first character (0-indexed)", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "file.txt"), "first\nsecond\nthird");
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
     const result = await ops.readFileSafe({
       path: "file.txt",
-      startIndex: 1,
+      startIndex: 0,
       maxChars: 5,
     });
     expect(result.ok).toBe(true);
@@ -183,7 +183,7 @@ describe("FileSystemOps read character-window edge cases", () => {
 
     const result = await ops.readFileSafe({
       path: "file.txt",
-      startIndex: 1,
+      startIndex: 0,
       maxChars: 1000,
     });
     expect(result.ok).toBe(true);
@@ -200,7 +200,7 @@ describe("FileSystemOps read character-window edge cases", () => {
 
     const result = await ops.readFileSafe({
       path: "file.txt",
-      startIndex: 5,
+      startIndex: 4,
       maxChars: 3,
     });
     expect(result.ok).toBe(true);

--- a/assistant/src/__tests__/host-file-read-tool.test.ts
+++ b/assistant/src/__tests__/host-file-read-tool.test.ts
@@ -27,7 +27,7 @@ mock.module("../daemon/host-file-proxy.js", () => ({
 }));
 
 import { hostFileReadTool } from "../tools/host-filesystem/read.js";
-import { DEFAULT_READ_LINE_LIMIT } from "../tools/shared/filesystem/file-ops-service.js";
+import { READ_CHAR_BUDGET } from "../tools/shared/filesystem/file-ops-service.js";
 import type { ToolContext } from "../tools/types.js";
 
 const testDirs: string[] = [];
@@ -77,19 +77,19 @@ describe("host_file_read tool", () => {
     expect(result.content).toContain("must be absolute");
   });
 
-  test("reads file with line numbers", async () => {
+  test("reads a character window", async () => {
     const dir = mkdtempSync(join(tmpdir(), "host-file-read-test-"));
     testDirs.push(dir);
     const filePath = join(dir, "sample.txt");
     writeFileSync(filePath, "first\nsecond\nthird\n");
 
     const result = await hostFileReadTool.execute(
-      { path: filePath, offset: 2, limit: 2 },
+      { path: filePath, start_index: 7, max_chars: 6 },
       makeContext(),
     );
     expect(result.isError).toBe(false);
-    expect(result.content).toContain("2  second");
-    expect(result.content).toContain("3  third");
+    expect(result.content).toContain("second");
+    expect(result.content).not.toContain("first");
   });
 
   test("returns error when file does not exist", async () => {
@@ -128,7 +128,7 @@ describe("host_file_read tool", () => {
     expect(result.content).toContain('Invalid input for tool "host_file_read"');
   });
 
-  test("reads entire file when no offset or limit specified", async () => {
+  test("reads the whole file when no window is specified", async () => {
     const dir = mkdtempSync(join(tmpdir(), "host-file-read-test-"));
     testDirs.push(dir);
     const filePath = join(dir, "full.txt");
@@ -139,9 +139,7 @@ describe("host_file_read tool", () => {
       makeContext(),
     );
     expect(result.isError).toBe(false);
-    expect(result.content).toContain("1  line1");
-    expect(result.content).toContain("2  line2");
-    expect(result.content).toContain("3  line3");
+    expect(result.content).toBe("line1\nline2\nline3\n");
   });
 
   test("handles empty file", async () => {
@@ -157,20 +155,19 @@ describe("host_file_read tool", () => {
     expect(result.isError).toBe(false);
   });
 
-  test("offset starts from the correct line (1-indexed)", async () => {
+  test("start_index is 1-indexed", async () => {
     const dir = mkdtempSync(join(tmpdir(), "host-file-read-test-"));
     testDirs.push(dir);
     const filePath = join(dir, "lines.txt");
     writeFileSync(filePath, "a\nb\nc\nd\ne\n");
 
     const result = await hostFileReadTool.execute(
-      { path: filePath, offset: 3, limit: 1 },
+      { path: filePath, start_index: 5, max_chars: 1 },
       makeContext(),
     );
     expect(result.isError).toBe(false);
-    expect(result.content).toContain("3  c");
-    expect(result.content).not.toContain("2  b");
-    expect(result.content).not.toContain("4  d");
+    const [body] = result.content.split("\n\n[Truncated:");
+    expect(body).toBe("c");
   });
 
   test("reads a file with symlinks resolved", async () => {
@@ -228,15 +225,15 @@ describe("host_file_read image support", () => {
     expect(result.isError).toBe(false);
     expect(result.contentBlocks).toHaveLength(1);
     // The proxied request carries the resolved default window, so a host read
-    // is bounded by the same limit as a local one rather than streaming a
+    // is bounded by the same budget as a local one rather than streaming a
     // whole file across the bridge.
     expect(requests).toEqual([
       {
         input: {
           operation: "read",
           path: "/host/screenshot.png",
-          offset: undefined,
-          limit: DEFAULT_READ_LINE_LIMIT,
+          startIndex: undefined,
+          maxChars: READ_CHAR_BUDGET,
         },
         conversationId: "test-conversation",
         signal: undefined,
@@ -306,8 +303,8 @@ describe("host_file_read image support", () => {
     );
 
     expect(result.isError).toBe(false);
-    expect(result.content).toContain("1  hello world");
-    expect(result.content).toContain("2  second line");
+    expect(result.content).toContain("hello world");
+    expect(result.content).toContain("second line");
     expect((result as any).contentBlocks).toBeUndefined();
   });
 

--- a/assistant/src/__tests__/host-file-read-tool.test.ts
+++ b/assistant/src/__tests__/host-file-read-tool.test.ts
@@ -84,7 +84,7 @@ describe("host_file_read tool", () => {
     writeFileSync(filePath, "first\nsecond\nthird\n");
 
     const result = await hostFileReadTool.execute(
-      { path: filePath, start_index: 7, max_chars: 6 },
+      { path: filePath, start_index: 6, max_chars: 6 },
       makeContext(),
     );
     expect(result.isError).toBe(false);
@@ -155,14 +155,14 @@ describe("host_file_read tool", () => {
     expect(result.isError).toBe(false);
   });
 
-  test("start_index is 1-indexed", async () => {
+  test("start_index is 0-indexed", async () => {
     const dir = mkdtempSync(join(tmpdir(), "host-file-read-test-"));
     testDirs.push(dir);
     const filePath = join(dir, "lines.txt");
     writeFileSync(filePath, "a\nb\nc\nd\ne\n");
 
     const result = await hostFileReadTool.execute(
-      { path: filePath, start_index: 5, max_chars: 1 },
+      { path: filePath, start_index: 4, max_chars: 1 },
       makeContext(),
     );
     expect(result.isError).toBe(false);

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -1457,7 +1457,11 @@ describe("ToolExecutor input-schema validation gate", () => {
     const executor = new ToolExecutor(makePrompter());
     const result = await executor.execute(
       "file_read",
-      { path: "a.txt", offset: "not-a-number", activity: "Reading a file" },
+      {
+        path: "a.txt",
+        start_index: "not-a-number",
+        activity: "Reading a file",
+      },
       makeContext(),
     );
 

--- a/assistant/src/api/events/host-file.ts
+++ b/assistant/src/api/events/host-file.ts
@@ -21,8 +21,8 @@ const HostFileReadRequestSchema = z.object({
   targetClientId: z.string().optional(),
   operation: z.literal("read"),
   path: z.string(),
-  offset: z.number().optional(),
-  limit: z.number().optional(),
+  startIndex: z.number().optional(),
+  maxChars: z.number().optional(),
 });
 
 const HostFileWriteRequestSchema = z.object({

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -520,7 +520,7 @@ function injectActiveSurfaceContext(
       "RULES FOR WORKSPACE MODIFICATION:",
       `1. Use \`file_edit\` to make surgical changes to app files. The file path is \`${getAppDirPath(ctx.appId)}/<path>\`.`,
       "2. Use `file_write` to create new files or rewrite files.",
-      "3. Use `file_read` to read any file with line numbers before editing.",
+      "3. Use `file_read` to read any file before editing, and `code_search` when you need a line reference.",
       "4. Use `bash ls` to see all files in the app directory.",
       `5. Call \`app_refresh\` with app_id "${ctx.appId}" ONCE after all changes are complete.`,
       "6. NEVER respond with only text — the user expects a visual update.",

--- a/assistant/src/subagent/types.ts
+++ b/assistant/src/subagent/types.ts
@@ -483,13 +483,13 @@ export const SUBAGENT_ROLE_REGISTRY: Record<SubagentRole, SubagentRoleConfig> =
       skillIds: [],
       systemPromptPreamble: [
         "You are a research subagent with read-only access: search the web, read and search files, and recall memories. There is no shell, and you cannot write or edit files.",
-        // `file_read` returns the first DEFAULT_READ_LINE_LIMIT (2000) lines
-        // unless a limit is passed, with a truncation notice naming the resume
-        // offset, and oversized results spool to .tool-results/ like any other
-        // tool's (only re-reads of spooled content stay inline). So a ranged
-        // read is both the cheap shape and the one that avoids a spool
-        // round-trip. The anti-slicing intent stays: one pass over the range
-        // that is needed rather than many small ones.
+        // `file_read` returns a bounded character window with a truncation
+        // notice naming the resume offset, and oversized results spool to
+        // .tool-results/ like any other tool's (only re-reads of spooled
+        // content stay inline). So a ranged read is both the cheap shape and
+        // the one that avoids a spool round-trip. The anti-slicing intent
+        // stays: one pass over the range that is needed rather than many
+        // small ones.
         "Working method: use code_search to search file contents across directories, file_list to enumerate paths, and file_read to read files and logs. Prefer broad code_search queries across a directory over one-symbol-at-a-time queries, and read the range you need in one pass rather than many small slices.",
         "Send notify_parent (urgency 'important') as soon as each finding is confirmed, so progress survives interruption.",
         "Your final message is the deliverable: a compact report that answers the objective, gives the evidence behind each claim (file:line references, URLs, or quotes), and names what you could not determine. For a root-cause investigation, use the sections Symptom, Root cause, Evidence, Suggested fix, Open questions.",

--- a/assistant/src/tools/__tests__/tool-input-schemas.test.ts
+++ b/assistant/src/tools/__tests__/tool-input-schemas.test.ts
@@ -185,7 +185,7 @@ describe("derived input_schema", () => {
       required: string[];
     };
     expect(schema.properties.start_index?.type).toBe("number");
-    expect(schema.properties.start_index?.description).toContain("1-indexed");
+    expect(schema.properties.start_index?.description).toContain("0-indexed");
     expect(schema.required).not.toContain("start_index");
     expect(schema.required).not.toContain("max_chars");
   });

--- a/assistant/src/tools/__tests__/tool-input-schemas.test.ts
+++ b/assistant/src/tools/__tests__/tool-input-schemas.test.ts
@@ -74,12 +74,12 @@ describe("parseToolInput", () => {
   test("file_read drops malformed optional fields the tool always ignored", () => {
     const result = parseToolInput("file_read", {
       path: "notes.md",
-      offset: "not-a-number",
-      limit: 10,
+      start_index: "not-a-number",
+      max_chars: 10,
     });
     expect(result).toEqual({
       ok: true,
-      data: { path: "notes.md", limit: 10 },
+      data: { path: "notes.md", max_chars: 10 },
     });
   });
 
@@ -184,9 +184,9 @@ describe("derived input_schema", () => {
       properties: Record<string, { type?: string; description?: string }>;
       required: string[];
     };
-    expect(schema.properties.offset?.type).toBe("number");
-    expect(schema.properties.offset?.description).toContain("1-indexed");
-    expect(schema.required).not.toContain("offset");
-    expect(schema.required).not.toContain("limit");
+    expect(schema.properties.start_index?.type).toBe("number");
+    expect(schema.properties.start_index?.description).toContain("1-indexed");
+    expect(schema.required).not.toContain("start_index");
+    expect(schema.required).not.toContain("max_chars");
   });
 });

--- a/assistant/src/tools/filesystem/read.ts
+++ b/assistant/src/tools/filesystem/read.ts
@@ -25,8 +25,8 @@ import type {
 
 /**
  * Model-input schema, the single source for both runtime validation (via
- * `TOOL_INPUT_SCHEMAS`) and the advertised `input_schema` below. `offset` and
- * `limit` catch to `undefined` because the tool has always ignored non-numeric
+ * `TOOL_INPUT_SCHEMAS`) and the advertised `input_schema` below. `start_index`
+ * and `max_chars` catch to `undefined` because the tool ignores non-numeric
  * values rather than failing the read.
  */
 export const fileReadInputSchema = z.looseObject({
@@ -36,14 +36,16 @@ export const fileReadInputSchema = z.looseObject({
     .describe(
       "The path to the file to read (absolute or relative to working directory)",
     ),
-  offset: z
+  start_index: z
     .number()
-    .describe("Line number to start reading from (1-indexed)")
+    .describe("Character to start reading from (1-indexed). Text files only.")
     .optional()
     .catch(undefined),
-  limit: z
+  max_chars: z
     .number()
-    .describe("Maximum number of lines to read (defaults to 2000)")
+    .describe(
+      "Maximum number of characters to read. Defaults to 20000, which is also the ceiling. Text files only.",
+    )
     .optional()
     .catch(undefined),
   activity: z
@@ -58,7 +60,7 @@ export const fileReadInputSchema = z.looseObject({
 export const fileReadTool = {
   name: "file_read",
   description:
-    "Read the contents of a file on your own machine. Text reads return the first 2000 lines unless you pass `limit`; when a read stops short the result says so, and `offset` pages on from there. For image files (JPEG, PNG, GIF, WebP), returns the image for visual analysis. For audio files (MP3, WAV, OGG, FLAC, AAC, M4A), returns the audio for listening. Use host_file_read for files on your guardian's device instead.",
+    "Read the contents of a file on your own machine. Text reads return the first 20000 characters unless you pass `max_chars`; when a read stops short the result says so, and `start_index` pages on from there. To find where something is in a large file, code_search is cheaper than paging through it. For image files (JPEG, PNG, GIF, WebP), returns the image for visual analysis. For audio files (MP3, WAV, OGG, FLAC, AAC, M4A), returns the audio for listening. Use host_file_read for files on your guardian's device instead.",
   category: "filesystem",
   executionTarget: "sandbox",
   defaultRiskLevel: RiskLevel.Low,
@@ -75,7 +77,11 @@ export const fileReadTool = {
     if (!parsed.success) {
       return invalidToolInputResult("file_read", parsed.error);
     }
-    const { path: rawPath, offset, limit } = parsed.data;
+    const {
+      path: rawPath,
+      start_index: startIndex,
+      max_chars: maxChars,
+    } = parsed.data;
 
     // For image files, delegate to the shared image reader.
     const ext = extname(rawPath).toLowerCase();
@@ -106,7 +112,11 @@ export const fileReadTool = {
       sandboxReadPolicy(path, context.workingDir, opts),
     );
 
-    const result = await ops.readFileSafe({ path: rawPath, offset, limit });
+    const result = await ops.readFileSafe({
+      path: rawPath,
+      startIndex,
+      maxChars,
+    });
 
     if (!result.ok) {
       const { error } = result;

--- a/assistant/src/tools/filesystem/read.ts
+++ b/assistant/src/tools/filesystem/read.ts
@@ -12,6 +12,7 @@ import {
   IMAGE_EXTENSIONS,
   readImageFile,
 } from "../shared/filesystem/image-read.js";
+import { legacyReadArgsError } from "../shared/filesystem/legacy-read-args.js";
 import { sandboxReadPolicy } from "../shared/filesystem/path-policy.js";
 import {
   invalidToolInputResult,
@@ -38,7 +39,7 @@ export const fileReadInputSchema = z.looseObject({
     ),
   start_index: z
     .number()
-    .describe("Character to start reading from (1-indexed). Text files only.")
+    .describe("Character to start reading from (0-indexed). Text files only.")
     .optional()
     .catch(undefined),
   max_chars: z
@@ -83,7 +84,8 @@ export const fileReadTool = {
       max_chars: maxChars,
     } = parsed.data;
 
-    // For image files, delegate to the shared image reader.
+    // For image files, delegate to the shared image reader. Media reads carry
+    // no window, so the legacy-argument guard below does not apply to them.
     const ext = extname(rawPath).toLowerCase();
     if (IMAGE_EXTENSIONS.has(ext)) {
       const pathCheck = sandboxReadPolicy(rawPath, context.workingDir);
@@ -106,6 +108,11 @@ export const fileReadTool = {
         };
       }
       return readAudioFile(pathCheck.resolved);
+    }
+
+    const legacyArgs = legacyReadArgsError("file_read", input);
+    if (legacyArgs !== undefined) {
+      return { content: legacyArgs, isError: true };
     }
 
     const ops = new FileSystemOps((path, opts) =>

--- a/assistant/src/tools/host-filesystem/read.ts
+++ b/assistant/src/tools/host-filesystem/read.ts
@@ -18,6 +18,7 @@ import {
   IMAGE_EXTENSIONS,
   readImageFile,
 } from "../shared/filesystem/image-read.js";
+import { legacyReadArgsError } from "../shared/filesystem/legacy-read-args.js";
 import { hostPolicy } from "../shared/filesystem/path-policy.js";
 import {
   invalidToolInputResult,
@@ -46,7 +47,7 @@ export const hostFileReadInputSchema = z.looseObject({
     ),
   start_index: z
     .number()
-    .describe("Character to start reading from (1-indexed). Text files only.")
+    .describe("Character to start reading from (0-indexed). Text files only.")
     .optional()
     .catch(undefined),
   max_chars: z
@@ -181,6 +182,11 @@ export const hostFileReadTool = {
         return { content: `Error: ${pathCheck.error}`, isError: true };
       }
       return readAudioFile(pathCheck.resolved);
+    }
+
+    const legacyArgs = legacyReadArgsError("host_file_read", input);
+    if (legacyArgs !== undefined) {
+      return { content: legacyArgs, isError: true };
     }
 
     const ops = new FileSystemOps(hostPolicy);

--- a/assistant/src/tools/host-filesystem/read.ts
+++ b/assistant/src/tools/host-filesystem/read.ts
@@ -11,8 +11,8 @@ import {
   readAudioFile,
 } from "../shared/filesystem/audio-read.js";
 import {
-  DEFAULT_READ_LINE_LIMIT,
   FileSystemOps,
+  READ_CHAR_BUDGET,
 } from "../shared/filesystem/file-ops-service.js";
 import {
   IMAGE_EXTENSIONS,
@@ -32,9 +32,9 @@ import type {
 /**
  * Model-input schema, the single source for both runtime validation (via
  * `TOOL_INPUT_SCHEMAS`) and the advertised `input_schema` below — mirrors
- * `filesystem/read.ts`. `offset`/`limit` catch to `undefined` so a
- * non-numeric value falls back to the default line window instead of failing
- * the call; `target_client_id` catches so a non-string (or empty) value means
+ * `filesystem/read.ts`. `start_index`/`max_chars` catch to `undefined` so a
+ * non-numeric value falls back to the default character window instead of
+ * failing the call; `target_client_id` catches so a non-string (or empty) value means
  * "untargeted".
  */
 export const hostFileReadInputSchema = z.looseObject({
@@ -44,14 +44,16 @@ export const hostFileReadInputSchema = z.looseObject({
     .describe(
       "Absolute path on the guardian's device, which is a separate filesystem from your workspace, to read.",
     ),
-  offset: z
+  start_index: z
     .number()
-    .describe("Line number to start reading from (1-indexed)")
+    .describe("Character to start reading from (1-indexed). Text files only.")
     .optional()
     .catch(undefined),
-  limit: z
+  max_chars: z
     .number()
-    .describe("Maximum number of lines to read (defaults to 2000)")
+    .describe(
+      "Maximum number of characters to read. Defaults to 20000, which is also the ceiling. Text files only.",
+    )
     .optional()
     .catch(undefined),
   target_client_id: z
@@ -66,7 +68,7 @@ export const hostFileReadInputSchema = z.looseObject({
 export const hostFileReadTool = {
   name: "host_file_read",
   description:
-    "Read the contents of a file on your guardian's device, including images (JPEG, PNG, GIF, WebP) and audio (MP3, WAV, OGG, FLAC, AAC, M4A). Text reads return the first 2000 lines unless you pass `limit`; when a read stops short the result says so, and `offset` pages on from there. For files on your own machine, use file_read instead.",
+    "Read the contents of a file on your guardian's device, including images (JPEG, PNG, GIF, WebP) and audio (MP3, WAV, OGG, FLAC, AAC, M4A). Text reads return the first 20000 characters unless you pass `max_chars`; when a read stops short the result says so, and `start_index` pages on from there. For files on your own machine, use file_read instead.",
   category: "host-filesystem",
   executionTarget: "host",
   defaultRiskLevel: RiskLevel.Medium,
@@ -81,12 +83,12 @@ export const hostFileReadTool = {
     if (!parsed.success) {
       return invalidToolInputResult("host_file_read", parsed.error);
     }
-    const { path: rawPath, offset } = parsed.data;
+    const { path: rawPath, start_index: startIndex } = parsed.data;
     // Resolve the default here rather than leaving it to the read, so the
     // proxied branch below is bounded by the same window as the local one. A
-    // proxied read that sent no limit would stream a whole host file across
+    // proxied read that sent no budget would stream a whole host file across
     // the bridge before anything could trim it.
-    const limit = parsed.data.limit ?? DEFAULT_READ_LINE_LIMIT;
+    const maxChars = parsed.data.max_chars ?? READ_CHAR_BUDGET;
 
     const targetClientId =
       parsed.data.target_client_id !== ""
@@ -153,8 +155,8 @@ export const hostFileReadTool = {
         {
           operation: "read",
           path: rawPath,
-          offset,
-          limit,
+          startIndex,
+          maxChars,
           targetClientId,
         },
         context.conversationId,
@@ -183,7 +185,11 @@ export const hostFileReadTool = {
 
     const ops = new FileSystemOps(hostPolicy);
 
-    const result = await ops.readFileSafe({ path: rawPath, offset, limit });
+    const result = await ops.readFileSafe({
+      path: rawPath,
+      startIndex,
+      maxChars,
+    });
 
     if (!result.ok) {
       const { error } = result;

--- a/assistant/src/tools/shared/filesystem/file-ops-service.ts
+++ b/assistant/src/tools/shared/filesystem/file-ops-service.ts
@@ -95,7 +95,38 @@ function truncationNotice(
   end: number,
   totalChars: number,
 ): string {
-  return `\n\n[Truncated: characters ${start + 1}-${end} of ${totalChars}. Read on with start_index=${end + 1}.]`;
+  return `\n\n[Truncated: characters ${start}-${end} of ${totalChars}. Read on with start_index=${end}.]`;
+}
+
+const isHighSurrogate = (code: number): boolean =>
+  code >= 0xd800 && code <= 0xdbff;
+const isLowSurrogate = (code: number): boolean =>
+  code >= 0xdc00 && code <= 0xdfff;
+
+/**
+ * Character window that never splits a surrogate pair. A split leaves a lone
+ * half at each edge, and each encodes to U+FFFD, so the character is lost from
+ * both this window and the next one paged in after it.
+ */
+export function surrogateSafeWindow(
+  total: number,
+  charCodeAt: (index: number) => number,
+  requestedStart: number,
+  maxChars: number,
+): { start: number; end: number } {
+  let start = Math.max(0, Math.min(requestedStart, total));
+  if (start > 0 && start < total && isLowSurrogate(charCodeAt(start))) {
+    start -= 1;
+  }
+
+  let end = Math.min(total, start + maxChars);
+  if (end > start && end < total && isHighSurrogate(charCodeAt(end - 1))) {
+    // Backing off would empty a one-character window, which stalls paging on
+    // the same offset, so take the whole pair instead.
+    end = end - 1 > start ? end - 1 : Math.min(total, end + 1);
+  }
+
+  return { start, end };
 }
 
 export class FileSystemOps {
@@ -138,15 +169,19 @@ export class FileSystemOps {
     try {
       const raw = await readFile(filePath, "utf-8");
 
-      const start = Math.max(0, (input.startIndex ?? 1) - 1);
       // A ceiling, not just a default: a larger window would be spooled to
       // disk and replaced with a stub, returning less than this.
       const maxChars = Math.min(
         READ_CHAR_BUDGET,
         Math.max(0, input.maxChars ?? READ_CHAR_BUDGET),
       );
-      const window = raw.slice(start, start + maxChars);
-      const end = start + window.length;
+      const { start, end } = surrogateSafeWindow(
+        raw.length,
+        (i) => raw.charCodeAt(i),
+        input.startIndex ?? 0,
+        maxChars,
+      );
+      const window = raw.slice(start, end);
 
       // An empty window means the caller paged past the end or asked for
       // nothing, which is not a truncated read.

--- a/assistant/src/tools/shared/filesystem/file-ops-service.ts
+++ b/assistant/src/tools/shared/filesystem/file-ops-service.ts
@@ -78,26 +78,24 @@ function pathError(
 }
 
 /**
- * Lines returned by a read that names no `limit`. Without a default the read
- * returns the whole file, and a file-read result is honored in full for the
- * rest of the turn (see `isSpoolEligible` in `context/tool-result-spool.ts`),
- * so one unbounded read of a large file rides every subsequent LLM call in
- * that turn. The cap bounds that; `offset`/`limit` page past it, and
- * {@link truncationNotice} tells the model when it is looking at a window
- * rather than the whole file.
+ * Characters returned by a read that names no `max_chars`. Stays under
+ * `THRESHOLD_CHARS` in `context/post-turn-tool-result-truncation.ts`, which
+ * spools any larger tool result to disk and replaces it inline with a short
+ * stub, so a default read returns content rather than a stub.
  */
-export const DEFAULT_READ_LINE_LIMIT = 2000;
+export const READ_CHAR_BUDGET = 20_000;
 
 /**
- * Trailing marker appended when a read stops short of the last line. Silent
- * truncation is the failure mode worth avoiding: a model that cannot tell a
- * window from a whole file reasons about code it never saw.
+ * Trailing marker appended when a read stops short of the end of the file. A
+ * model that cannot tell a window from a whole file reasons about code it
+ * never saw.
  */
 function truncationNotice(
-  lastLineReturned: number,
-  totalLines: number,
+  start: number,
+  end: number,
+  totalChars: number,
 ): string {
-  return `\n\n[Truncated: showing through line ${lastLineReturned} of ${totalLines}. Read on with offset=${lastLineReturned + 1}, or pass an explicit limit.]`;
+  return `\n\n[Truncated: characters ${start + 1}-${end} of ${totalChars}. Read on with start_index=${end + 1}.]`;
 }
 
 export class FileSystemOps {
@@ -139,28 +137,23 @@ export class FileSystemOps {
 
     try {
       const raw = await readFile(filePath, "utf-8");
-      const lines = raw.split("\n");
 
-      const offset = (input.offset ?? 1) - 1;
-      const start = Math.max(0, offset);
-      const limit = input.limit ?? DEFAULT_READ_LINE_LIMIT;
-      const selected = lines.slice(start, offset + limit);
+      const start = Math.max(0, (input.startIndex ?? 1) - 1);
+      // A ceiling, not just a default: a larger window would be spooled to
+      // disk and replaced with a stub, returning less than this.
+      const maxChars = Math.min(
+        READ_CHAR_BUDGET,
+        Math.max(0, input.maxChars ?? READ_CHAR_BUDGET),
+      );
+      const window = raw.slice(start, start + maxChars);
+      const end = start + window.length;
 
-      const numbered = selected
-        .map((line, i) => {
-          const lineNum = offset + i + 1;
-          return `${String(lineNum).padStart(6)}  ${line}`;
-        })
-        .join("\n");
-
-      // Only when the window stops before the last line. An empty window means
-      // the caller paged past the end or asked for nothing, which is not a
-      // truncated read.
-      const lastLineReturned = start + selected.length;
+      // An empty window means the caller paged past the end or asked for
+      // nothing, which is not a truncated read.
       const content =
-        selected.length > 0 && lastLineReturned < lines.length
-          ? numbered + truncationNotice(lastLineReturned, lines.length)
-          : numbered;
+        window.length > 0 && end < raw.length
+          ? window + truncationNotice(start, end, raw.length)
+          : window;
 
       return { ok: true, value: { content } };
     } catch (err) {

--- a/assistant/src/tools/shared/filesystem/legacy-read-args.ts
+++ b/assistant/src/tools/shared/filesystem/legacy-read-args.ts
@@ -1,0 +1,22 @@
+/**
+ * Guard for callers still passing the line-based `offset`/`limit` read
+ * arguments. The tool schemas are loose, so those keys parse and are then
+ * dropped, which would silently serve the start of the file to a caller that
+ * asked to page into the middle of it.
+ *
+ * There is no safe translation: `offset` counted lines and `start_index`
+ * counts characters, so mapping one onto the other would read the wrong
+ * region rather than fail. Naming the rename lets the caller correct itself.
+ */
+export function legacyReadArgsError(
+  toolName: string,
+  input: Record<string, unknown>,
+): string | undefined {
+  const usesLegacy = input.offset !== undefined || input.limit !== undefined;
+  const usesCurrent =
+    input.start_index !== undefined || input.max_chars !== undefined;
+  if (!usesLegacy || usesCurrent) {
+    return undefined;
+  }
+  return `Error: ${toolName} no longer takes \`offset\`/\`limit\` (lines). Use \`start_index\` (0-indexed characters) and \`max_chars\` instead.`;
+}

--- a/assistant/src/tools/shared/filesystem/types.ts
+++ b/assistant/src/tools/shared/filesystem/types.ts
@@ -6,10 +6,10 @@ import type { FsError } from "./errors.js";
 
 export interface ReadInput {
   path: string;
-  /** 1-indexed line number to start reading from. */
-  offset?: number;
-  /** Maximum number of lines to read. */
-  limit?: number;
+  /** 1-indexed character to start reading from. */
+  startIndex?: number;
+  /** Maximum number of characters to read. */
+  maxChars?: number;
 }
 
 export interface ReadOutput {

--- a/assistant/src/tools/shared/filesystem/types.ts
+++ b/assistant/src/tools/shared/filesystem/types.ts
@@ -6,14 +6,14 @@ import type { FsError } from "./errors.js";
 
 export interface ReadInput {
   path: string;
-  /** 1-indexed character to start reading from. */
+  /** 0-indexed character to start reading from. */
   startIndex?: number;
   /** Maximum number of characters to read. */
   maxChars?: number;
 }
 
 export interface ReadOutput {
-  /** The (possibly line-numbered) file content. */
+  /** The character window, with a truncation notice when it stops short. */
   content: string;
 }
 

--- a/clients/macos/src/main/executors/host-file-executor.test.ts
+++ b/clients/macos/src/main/executors/host-file-executor.test.ts
@@ -221,7 +221,7 @@ describe("host-file-executor", () => {
       const [body] = result.content!.split("\n\n[Truncated:");
       expect(body).toHaveLength(20_000);
       expect(result.content).toContain(
-        `[Truncated: characters 1-20000 of ${total}. Read on with start_index=20001.]`,
+        `[Truncated: characters 0-20000 of ${total}. Read on with start_index=20000.]`,
       );
     });
 
@@ -248,6 +248,57 @@ describe("host-file-executor", () => {
       expect(result.imageData).toBeUndefined();
     });
 
+    test("a window boundary inside a surrogate pair does not corrupt it", () => {
+      const dir = freshTmpDir();
+      const filePath = path.join(dir, "emoji.txt");
+      fs.writeFileSync(filePath, `ab\u{1F600}cd`);
+
+      const result = __testing.executeRead({ path: filePath, maxChars: 3 });
+      const [body] = result.content!.split("\n\n[Truncated:");
+      expect(body).toBe("ab");
+      expect(body).not.toContain("\uFFFD");
+    });
+
+    test("an older daemon's offset/limit still pages line by line", () => {
+      const dir = freshTmpDir();
+      const filePath = path.join(dir, "big.txt");
+      fs.writeFileSync(
+        filePath,
+        Array.from({ length: 2500 }, (_, i) => `line${i + 1}`).join("\n"),
+      );
+
+      // A daemon predating the character window sends only offset/limit. The
+      // window must advance rather than pinning every page to the file start.
+      const first = __testing.executeRead({ path: filePath, limit: 10 });
+      expect(first.content).toContain("line1");
+      expect(first.content).toContain("line10");
+      expect(first.content).not.toContain("line11");
+
+      const second = __testing.executeRead({
+        path: filePath,
+        offset: 11,
+        limit: 10,
+      });
+      expect(second.content).toContain("line11");
+      expect(second.content).not.toContain("line10\n");
+    });
+
+    test("current fields win when a request carries both sets", () => {
+      const dir = freshTmpDir();
+      const filePath = path.join(dir, "lines.txt");
+      fs.writeFileSync(filePath, "a\nb\nc\nd\ne");
+
+      const result = __testing.executeRead({
+        path: filePath,
+        startIndex: 4,
+        maxChars: 3,
+        offset: 1,
+        limit: 1,
+      });
+      const [body] = result.content!.split("\n\n[Truncated:");
+      expect(body).toBe("c\nd");
+    });
+
     test("respects startIndex and maxChars", () => {
       const dir = freshTmpDir();
       const filePath = path.join(dir, "lines.txt");
@@ -255,7 +306,7 @@ describe("host-file-executor", () => {
 
       const result = __testing.executeRead({
         path: filePath,
-        startIndex: 3,
+        startIndex: 2,
         maxChars: 3,
       });
       const [body] = result.content!.split("\n\n[Truncated:");

--- a/clients/macos/src/main/executors/host-file-executor.test.ts
+++ b/clients/macos/src/main/executors/host-file-executor.test.ts
@@ -211,34 +211,31 @@ describe("host-file-executor", () => {
       expect(result.content).toContain("exceeds the 100.0 MB limit");
     });
 
-    test("caps an unbounded read at the default line limit and says so", () => {
+    test("caps an unbounded read at the character budget and says so", () => {
       const dir = freshTmpDir();
       const filePath = path.join(dir, "big.txt");
-      const total = 2500;
-      fs.writeFileSync(
-        filePath,
-        Array.from({ length: total }, (_, i) => `line${i + 1}`).join("\n"),
-      );
+      const total = 20_500;
+      fs.writeFileSync(filePath, "x".repeat(total));
 
       const result = __testing.executeRead({ path: filePath });
-      expect(result.content).toContain("line2000");
-      expect(result.content).not.toContain("line2001");
+      const [body] = result.content!.split("\n\n[Truncated:");
+      expect(body).toHaveLength(20_000);
       expect(result.content).toContain(
-        `[Truncated: showing through line 2000 of ${total}. Read on with offset=2001`,
+        `[Truncated: characters 1-20000 of ${total}. Read on with start_index=20001.]`,
       );
     });
 
-    test("an explicit limit is honored rather than replaced by the default", () => {
+    test("a maxChars above the budget is clamped to it", () => {
       const dir = freshTmpDir();
       const filePath = path.join(dir, "big.txt");
-      fs.writeFileSync(
-        filePath,
-        Array.from({ length: 2500 }, (_, i) => `line${i + 1}`).join("\n"),
-      );
+      fs.writeFileSync(filePath, "x".repeat(20_500));
 
-      const result = __testing.executeRead({ path: filePath, limit: 2500 });
-      expect(result.content).toContain("line2500");
-      expect(result.content).not.toContain("[Truncated:");
+      const result = __testing.executeRead({
+        path: filePath,
+        maxChars: 20_500,
+      });
+      const [body] = result.content!.split("\n\n[Truncated:");
+      expect(body).toHaveLength(20_000);
     });
 
     test("reads text file and returns content", () => {
@@ -251,15 +248,15 @@ describe("host-file-executor", () => {
       expect(result.imageData).toBeUndefined();
     });
 
-    test("respects offset and limit", () => {
+    test("respects startIndex and maxChars", () => {
       const dir = freshTmpDir();
       const filePath = path.join(dir, "lines.txt");
       fs.writeFileSync(filePath, "a\nb\nc\nd\ne");
 
       const result = __testing.executeRead({
         path: filePath,
-        offset: 2,
-        limit: 2,
+        startIndex: 3,
+        maxChars: 3,
       });
       const [body] = result.content!.split("\n\n[Truncated:");
       expect(body).toBe("b\nc");

--- a/clients/macos/src/main/executors/host-file-executor.ts
+++ b/clients/macos/src/main/executors/host-file-executor.ts
@@ -23,13 +23,13 @@ const MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024;
 const DENIED_BASENAMES = new Set([".backup.key", "backup.key"]);
 
 /**
- * Lines returned by a read that names no `limit`. The daemon resolves this
- * same default before proxying, so this covers a client driven by an older
- * daemon that still sends none. Mirrors `DEFAULT_READ_LINE_LIMIT` in the
- * assistant's `tools/shared/filesystem/file-ops-service.ts`, which owns the
- * value and the wording of the notice below.
+ * Characters returned by a read that names no `maxChars`. The daemon resolves
+ * this same default before proxying, so this covers a client driven by an
+ * older daemon that sends none. Mirrors `READ_CHAR_BUDGET` in the assistant's
+ * `tools/shared/filesystem/file-ops-service.ts`, which owns the value and the
+ * wording of the notice below.
  */
-const DEFAULT_READ_LINE_LIMIT = 2000;
+const READ_CHAR_BUDGET = 20_000;
 
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
@@ -257,8 +257,8 @@ function detectAudioByMagicBytes(buf: Buffer): AudioDetection | null {
 
 interface ReadFields {
   path: string;
-  offset?: number;
-  limit?: number;
+  startIndex?: number;
+  maxChars?: number;
 }
 
 function executeRead(fields: ReadFields): {
@@ -291,18 +291,18 @@ function executeRead(fields: ReadFields): {
     return { audioData: raw.toString("base64"), audioMimeType: audio.mimeType };
   }
 
-  // Text file — apply line-based offset/limit
+  // Text file — apply the character window
   const text = raw.toString("utf-8");
-  const lines = text.split("\n");
-  const offset = (fields.offset ?? 1) - 1;
-  const start = Math.max(0, offset);
-  const limit = fields.limit ?? DEFAULT_READ_LINE_LIMIT;
-  const sliced = lines.slice(start, offset + limit);
-  const lastLineReturned = start + sliced.length;
-  const content = sliced.join("\n");
-  if (sliced.length > 0 && lastLineReturned < lines.length) {
+  const start = Math.max(0, (fields.startIndex ?? 1) - 1);
+  const maxChars = Math.min(
+    READ_CHAR_BUDGET,
+    Math.max(0, fields.maxChars ?? READ_CHAR_BUDGET),
+  );
+  const content = text.slice(start, start + maxChars);
+  const end = start + content.length;
+  if (content.length > 0 && end < text.length) {
     return {
-      content: `${content}\n\n[Truncated: showing through line ${lastLineReturned} of ${lines.length}. Read on with offset=${lastLineReturned + 1}, or pass an explicit limit.]`,
+      content: `${content}\n\n[Truncated: characters ${start + 1}-${end} of ${text.length}. Read on with start_index=${end + 1}.]`,
     };
   }
   return { content };
@@ -440,8 +440,8 @@ function handleRequest(
       case "read":
         result = executeRead({
           path: filePath,
-          offset: message.offset as number | undefined,
-          limit: message.limit as number | undefined,
+          startIndex: message.startIndex as number | undefined,
+          maxChars: message.maxChars as number | undefined,
         });
         break;
       case "write":

--- a/clients/macos/src/main/executors/host-file-executor.ts
+++ b/clients/macos/src/main/executors/host-file-executor.ts
@@ -31,6 +31,37 @@ const DENIED_BASENAMES = new Set([".backup.key", "backup.key"]);
  */
 const READ_CHAR_BUDGET = 20_000;
 
+const isHighSurrogate = (code: number): boolean =>
+  code >= 0xd800 && code <= 0xdbff;
+const isLowSurrogate = (code: number): boolean =>
+  code >= 0xdc00 && code <= 0xdfff;
+
+/**
+ * Character window that never splits a surrogate pair. A split leaves a lone
+ * half at each edge, and each encodes to U+FFFD, so the character is lost from
+ * both this window and the next one paged in after it.
+ */
+function surrogateSafeWindow(
+  total: number,
+  charCodeAt: (index: number) => number,
+  requestedStart: number,
+  maxChars: number,
+): { start: number; end: number } {
+  let start = Math.max(0, Math.min(requestedStart, total));
+  if (start > 0 && start < total && isLowSurrogate(charCodeAt(start))) {
+    start -= 1;
+  }
+
+  let end = Math.min(total, start + maxChars);
+  if (end > start && end < total && isHighSurrogate(charCodeAt(end - 1))) {
+    // Backing off would empty a one-character window, which stalls paging on
+    // the same offset, so take the whole pair instead.
+    end = end - 1 > start ? end - 1 : Math.min(total, end + 1);
+  }
+
+  return { start, end };
+}
+
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
@@ -259,6 +290,38 @@ interface ReadFields {
   path: string;
   startIndex?: number;
   maxChars?: number;
+  /** Line-based window sent by a daemon older than the character window. */
+  offset?: number;
+  /** Line-based window sent by a daemon older than the character window. */
+  limit?: number;
+}
+
+const LEGACY_READ_LINE_LIMIT = 2000;
+
+/**
+ * Line window for a daemon that predates the character window. This app
+ * auto-updates on its own cadence, so a newer client can be driven by an older
+ * daemon. Reading its `offset` as a character index would silently return the
+ * wrong region, and ignoring it would pin every page to the start of the file,
+ * so the old semantics are honored as they were. Delete once no daemon in the
+ * field sends these fields.
+ */
+function executeLegacyLineRead(
+  text: string,
+  offset: number | undefined,
+  limit: number | undefined,
+): { content: string } {
+  const lines = text.split("\n");
+  const start = Math.max(0, (offset ?? 1) - 1);
+  const sliced = lines.slice(start, start + (limit ?? LEGACY_READ_LINE_LIMIT));
+  const lastLineReturned = start + sliced.length;
+  const content = sliced.join("\n");
+  if (sliced.length > 0 && lastLineReturned < lines.length) {
+    return {
+      content: `${content}\n\n[Truncated: showing through line ${lastLineReturned} of ${lines.length}. Read on with offset=${lastLineReturned + 1}, or pass an explicit limit.]`,
+    };
+  }
+  return { content };
 }
 
 function executeRead(fields: ReadFields): {
@@ -291,18 +354,29 @@ function executeRead(fields: ReadFields): {
     return { audioData: raw.toString("base64"), audioMimeType: audio.mimeType };
   }
 
-  // Text file — apply the character window
+  // Text file: apply the character window
   const text = raw.toString("utf-8");
-  const start = Math.max(0, (fields.startIndex ?? 1) - 1);
+
+  if (fields.startIndex === undefined && fields.maxChars === undefined) {
+    if (fields.offset !== undefined || fields.limit !== undefined) {
+      return executeLegacyLineRead(text, fields.offset, fields.limit);
+    }
+  }
+
   const maxChars = Math.min(
     READ_CHAR_BUDGET,
     Math.max(0, fields.maxChars ?? READ_CHAR_BUDGET),
   );
-  const content = text.slice(start, start + maxChars);
-  const end = start + content.length;
+  const { start, end } = surrogateSafeWindow(
+    text.length,
+    (i) => text.charCodeAt(i),
+    fields.startIndex ?? 0,
+    maxChars,
+  );
+  const content = text.slice(start, end);
   if (content.length > 0 && end < text.length) {
     return {
-      content: `${content}\n\n[Truncated: characters ${start + 1}-${end} of ${text.length}. Read on with start_index=${end + 1}.]`,
+      content: `${content}\n\n[Truncated: characters ${start}-${end} of ${text.length}. Read on with start_index=${end}.]`,
     };
   }
   return { content };
@@ -442,6 +516,8 @@ function handleRequest(
           path: filePath,
           startIndex: message.startIndex as number | undefined,
           maxChars: message.maxChars as number | undefined,
+          offset: message.offset as number | undefined,
+          limit: message.limit as number | undefined,
         });
         break;
       case "write":


### PR DESCRIPTION
## Problem

A line count does not bound context cost. `file_read` defaulted to 2000 lines, but oversized tool results are spooled to disk and replaced inline with a stub once they exceed `THRESHOLD_CHARS` (25,000) in `context/post-turn-tool-result-truncation.ts`.

The two limits were badly misaligned. 25,000 / 2000 = **12.5 characters per line** — only files averaging under that could deliver a full default read. Typical TS/TSX runs 35-45 chars/line, so 2000 lines is 70-90k characters, 3-4x over the threshold. The result got spooled and stubbed to 1,200 characters.

So for essentially every real source file, a default `file_read` **spent a round trip and returned ~1.5% of what it fetched**, then made the model page it back. This is the failure the `web_fetch` spool exemption already calls out:

> Stubbing such a result at result time hands the model ~a tenth of the window it just sized — and it keeps paging blind against content it never saw.

`file_read` had that exact problem and no exemption.

## Change

Bound the read by characters, below the spool threshold, so a default read always returns real content plus an offset to resume from.

- **`READ_CHAR_BUDGET` (20,000) replaces `DEFAULT_READ_LINE_LIMIT` (2000).** It's a ceiling, not just a default — a larger `max_chars` would be spooled and stubbed, returning *less* than the ceiling would, so honoring it would be a lie.
- **`offset`/`limit` → `start_index`/`max_chars`** on `file_read` and `host_file_read`. See skew note below.
- **Dropped the six-character line-number gutter.** It cost 8 characters per line (over half the old threshold in numbering alone) and nothing consumes it: `file_edit` matches exact strings, and `code_search` already returns `path:line:` when a line reference is needed. Recovers ~19% more content per read.

## Media is deliberately untouched

Image and audio reads dispatch on extension *before* the text path, so the character window never touches them. Both already optimize-then-reject rather than truncate (`image-read.ts` compresses then caps at 20MB; `audio-read.ts` caps at Gemini's inline limit), which is the only correct handling for bytes that have to decode. Truncating them would produce corrupt files.

## Version skew

`host_file_read` proxies to a **duplicate implementation** in `clients/macos/src/main/executors/host-file-executor.ts`, which ships on its own auto-update cadence. Renaming the fields rather than redefining them is what makes the skew safe:

| | behavior |
|---|---|
| new daemon → old client | finds no `startIndex`/`maxChars`, falls back to its own default. Degraded, never wrong. |
| old daemon → new client | finds no `offset`/`limit`, uses the character default. Fine. |

Reusing the old names would have made an old client read 20,000 **lines** for a request meaning 20,000 characters.

This also fixes an existing inconsistency: the client copy returned un-numbered text while the daemon fallback returned numbered text, for the same tool.

## Verification

- `bun run typecheck:fast` clean (assistant), `bunx tsc --noEmit` clean (clients/macos)
- `bun run lint` clean
- 106 tests pass across `file-ops-service`, `filesystem-tools`, `host-file-read-tool`, `tool-input-schemas`, `execution-target`, `host-filesystem/read`, and the macOS `host-file-executor`
- `bun run generate:openapi` produces no diff (these events aren't in the HTTP spec)
- New drift guard asserts `READ_CHAR_BUDGET < THRESHOLD_CHARS`, so the read can never silently start re-tripping the spool

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->