### PR TITLE
docs(web): say how to tell you picked the wrong rung of the adaptation ladder

### DIFF
--- a/clients/web/docs/PLATFORM_ADAPTATION.md
+++ b/clients/web/docs/PLATFORM_ADAPTATION.md
@@ -184,6 +184,33 @@ mental model: `Platform.select` when only small parts differ, `.ios.tsx` / `.and
 the implementation genuinely diverges. Two files means two things to keep in sync, so this needs a
 reason a variant cannot cover.
 
+### How to tell you picked the wrong rung
+
+The ladder says pick the cheapest rung that expresses the difference, which leaves open how you find
+out you went too cheap. Two signals, both of which show up while you are writing the fix rather than
+in review:
+
+- **You had to add bookkeeping to make it work.** If landing the change means introducing a second
+  copy of something (a listener, a measurement, a piece of derived state) in order for the rung you
+  chose to behave, the difference is wider than that rung can express. Treat it as a stop, not as a
+  caveat for the PR description. A splitter cleanup in the design library learned this the expensive
+  way: extracting the shared *handle* left the sizing logic in four places, and publishing an honest
+  `aria-valuemax` from the extracted piece then required a `ResizeObserver` added to two separate
+  files, because the thing that knew the container was still four separate things. The added
+  duplication was the structure objecting to the seam, and it was written up as a footnote and
+  shipped as a draft PR before anyone read it as the signal it was
+  ([LUM-3200](https://linear.app/vellum/issue/LUM-3200)).
+- **You are wiring N call sites to a new part, rather than replacing N copies with one whole.** The
+  visible, repeated element is the easiest thing to extract and usually the least valuable.
+  Rung 3 says callers describe *intent*; if after the change each caller still assembles the
+  behaviour from pieces you handed it, you built a better piece and left the rung where it was.
+
+Neither signal is about the platform axes. They apply to any shared-behaviour extraction, which is
+why the same pair is recorded in the refactoring rubric
+([LUM-3175](https://linear.app/vellum/issue/LUM-3175)); they are repeated here because rung 3 is the
+one this codebase is in open violation of, and a partial extraction there looks like progress while
+leaving the drift in place.
+
 ---
 
 ## Navigation depth and back affordances


### PR DESCRIPTION
## TL;DR

`PLATFORM_ADAPTATION.md`'s ladder says pick the cheapest rung that expresses the difference, but not how you find out you went too cheap. This adds the two signals that show up *while writing the fix*, not in review.

Docs only. 27 added lines, no code.

## Why

This is the last of the four cleanup rubrics to get a lesson the other three already carry. LUM-3174, LUM-3175, and LUM-3164 were amended directly in Linear; this rubric lives in-repo, so it needs a PR.

The lesson came from #40552 (LUM-3200). That change extracted the shared drag *handle* from four resizable panes and left the sizing logic in four places. Publishing an honest `aria-valuemax` from the extracted piece then required adding a `ResizeObserver` to two separate files, because the thing that knew the container was still four separate things. The added duplication was the structure objecting to the seam. It was written up as "duplication worth noting" and shipped as a draft PR before anyone read it as a signal, and the real fix turned out to be one primitive owning the whole concept.

## What it says

Two signals, both observable before review:

- **You had to add bookkeeping to make it work.** A second copy of a listener, a measurement, or a piece of derived state, introduced so the chosen rung behaves, means the difference is wider than that rung expresses. Stop, do not caveat.
- **You are wiring N call sites to a new part rather than replacing N copies with one whole.** Rung 3 says callers describe intent; if each caller still assembles behaviour from pieces you handed it, you built a better piece and left the rung where it was.

## Why it belongs here rather than only in the refactoring rubric

Neither signal is about the platform axes, and both are recorded in LUM-3175, which is their general home. They are repeated here because **rung 3 is the rung this codebase is in open violation of** (roughly a dozen overlay callers still write the branch themselves, per LUM-3177), so it is where a partial extraction is most likely, and a partial extraction there looks like progress while leaving the drift in place. The text says so explicitly rather than presenting itself as new general advice.

## Note on formatting

The file does not satisfy the repo's prettier config today, on `main` and after this change alike. I left it unformatted rather than reflowing it, which would have buried 27 added lines in a whole-file diff. Happy to do the reflow as its own PR if you want it.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40576" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->