### PR TITLE
feat(providers): make chatgpt a first-class default-provider choice

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4826,6 +4826,7 @@ paths:
                     - gemini
                     - fireworks
                     - openrouter
+                    - chatgpt
                     - vellum
                     - together
                     - vercel-ai-gateway
@@ -34540,6 +34541,7 @@ components:
                     - gemini
                     - fireworks
                     - openrouter
+                    - chatgpt
                     - vellum
                     - together
                     - vercel-ai-gateway
@@ -34917,6 +34919,7 @@ components:
                 - gemini
                 - fireworks
                 - openrouter
+                - chatgpt
                 - vellum
                 - together
                 - vercel-ai-gateway

--- a/assistant/src/config/__tests__/default-profile-catalog.test.ts
+++ b/assistant/src/config/__tests__/default-profile-catalog.test.ts
@@ -7,6 +7,7 @@ import {
   CODE_DEFAULT_PROFILE_ENTRIES,
   getEffectiveProfile,
   getEffectiveProfiles,
+  getEffectiveProfilesForProvider,
   PROFILE_IMPLS,
   resolveDefaultProfileForProvider,
 } from "../default-profile-catalog.js";
@@ -333,7 +334,7 @@ describe("resolveDefaultProfileForProvider", () => {
         expect(typeof entry?.model).toBe("string");
         expect(entry?.provider).toBeDefined();
         // Identity columns stamp no connection; BYOK columns always do.
-        if (entry?.provider === "vellum") {
+        if (entry?.provider === "vellum" || entry?.provider === "chatgpt") {
           expect(entry?.provider_connection).toBeUndefined();
         } else {
           expect(entry?.provider_connection).toBeDefined();
@@ -341,6 +342,27 @@ describe("resolveDefaultProfileForProvider", () => {
         expect(entry?.source).toBe("managed");
       }
     }
+  });
+
+  test("the chatgpt column resolves Codex-pinned models with no connection stamp", () => {
+    const byKey: Record<string, string> = {
+      balanced: "gpt-5.6-luna",
+      "quality-optimized": "gpt-5.6-sol",
+      "cost-optimized": "gpt-5.6-luna",
+      "latency-optimized": "gpt-5.6-luna",
+    };
+    const effective = getEffectiveProfilesForProvider(undefined, dp("chatgpt"));
+    for (const [key, model] of Object.entries(byKey)) {
+      const entry = effective[key];
+      expect(entry?.provider).toBe("chatgpt");
+      expect(entry?.model).toBe(model);
+      expect(entry?.provider_connection).toBeUndefined();
+      expect(entry?.source).toBe("managed");
+    }
+    // Cost opts out of reasoning entirely; Speed keeps low effort.
+    expect(effective["cost-optimized"]?.effort).toBe("none");
+    expect(effective["latency-optimized"]?.effort).toBe("low");
+    expect(effective.balanced?.thinking?.enabled).toBe(true);
   });
 
   test("a provider without a named matrix column materializes from the shared BYOK templates", () => {

--- a/assistant/src/config/__tests__/default-profile-catalog.test.ts
+++ b/assistant/src/config/__tests__/default-profile-catalog.test.ts
@@ -359,9 +359,9 @@ describe("resolveDefaultProfileForProvider", () => {
       expect(entry?.provider_connection).toBeUndefined();
       expect(entry?.source).toBe("managed");
     }
-    // Cost opts out of reasoning entirely; Speed keeps low effort.
+    // Cost and Speed both opt fully out of reasoning.
     expect(effective["cost-optimized"]?.effort).toBe("none");
-    expect(effective["latency-optimized"]?.effort).toBe("low");
+    expect(effective["latency-optimized"]?.effort).toBe("none");
     expect(effective.balanced?.thinking?.enabled).toBe(true);
   });
 

--- a/assistant/src/config/__tests__/default-provider.test.ts
+++ b/assistant/src/config/__tests__/default-provider.test.ts
@@ -157,6 +157,12 @@ describe("resolveDefaultConnectionName", () => {
     );
   });
 
+  test("chatgpt resolves to the canonical subscription connection name", () => {
+    expect(resolveDefaultConnectionName({ provider: "chatgpt" })).toBe(
+      "chatgpt-subscription",
+    );
+  });
+
   test("every other provider resolves to its personal connection", () => {
     expect(resolveDefaultConnectionName({ provider: "anthropic" })).toBe(
       "anthropic-personal",

--- a/assistant/src/config/default-profile-catalog.ts
+++ b/assistant/src/config/default-profile-catalog.ts
@@ -166,7 +166,9 @@ const CHATGPT_PROFILE_IMPLS: ProfileImpls = {
     source: "managed",
     label: "Balanced",
     description: "Good balance of quality, cost, and speed",
-    maxTokens: 16000,
+    // Matches the vellum column's Balanced (same model): the Codex path
+    // sends no max_output_tokens, so this only sizes internal budgeting.
+    maxTokens: 32000,
     effort: "high",
     thinking: { enabled: true, streamThinking: true },
     contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },

--- a/assistant/src/config/default-profile-catalog.ts
+++ b/assistant/src/config/default-profile-catalog.ts
@@ -155,8 +155,9 @@ const VELLUM_PROFILE_IMPLS: ProfileImpls = {
  * `chatgpt-subscription` row via `resolveRoutingIdentity` with no pinned
  * connection. Models are pinned (never intents): the intent tables are
  * keyed by concrete dispatch providers, and the Codex endpoint serves only
- * `CODEX_SUBSCRIPTION_MODEL_IDS`. Cost and Speed share Balanced's model
- * (the subscription has no cheaper tier); the split is reasoning effort.
+ * `CODEX_SUBSCRIPTION_MODEL_IDS`. Cost and Speed are identical
+ * implementations here: the subscription serves no tier cheaper or faster
+ * than luna, and both profiles advertise reasoning off.
  */
 const CHATGPT_PROFILE_IMPLS: ProfileImpls = {
   balanced: {
@@ -199,7 +200,11 @@ const CHATGPT_PROFILE_IMPLS: ProfileImpls = {
     label: "Speed",
     description: "Fastest responses, with reasoning turned off",
     maxTokens: 8192,
-    effort: "low",
+    // Explicit reasoning opt-out, matching the other columns: this profile
+    // advertises reasoning as off, and OpenAI-compat APIs default reasoning
+    // to "medium" when the field is omitted, so the opt-out has to be stated
+    // rather than implied.
+    effort: "none",
     thinking: { enabled: false, streamThinking: false },
     contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
   },

--- a/assistant/src/config/default-profile-catalog.ts
+++ b/assistant/src/config/default-profile-catalog.ts
@@ -4,6 +4,7 @@ import {
   isModelInCatalog,
 } from "../providers/model-catalog.js";
 import { resolveModelIntent } from "../providers/model-intents.js";
+import { isCodexSubscriptionModel } from "../providers/openai/codex-models.js";
 import type { ModelIntent } from "../providers/types.js";
 import { getManagedUpstream } from "../providers/vellum-model-routing.js";
 import {
@@ -31,7 +32,8 @@ import {
  * structured as an intent × provider matrix: each default profile is an
  * intent, and each provider that can serve default profiles has a concrete
  * implementation of that intent (model, token budget, effort, thinking).
- * The `vellum` column is the platform-managed implementation; the other
+ * The `vellum` column is the platform-managed implementation and the
+ * `chatgpt` column is the ChatGPT-subscription implementation; the other
  * columns are the BYOK implementations resolved through `llm.defaultProvider`
  * on off-platform installs.
  *
@@ -148,6 +150,62 @@ const VELLUM_PROFILE_IMPLS: ProfileImpls = {
 };
 
 /**
+ * The `chatgpt` column: ChatGPT-subscription implementations, stamped
+ * `provider: "chatgpt"` so dispatch routes through the canonical
+ * `chatgpt-subscription` row via `resolveRoutingIdentity` with no pinned
+ * connection. Models are pinned (never intents): the intent tables are
+ * keyed by concrete dispatch providers, and the Codex endpoint serves only
+ * `CODEX_SUBSCRIPTION_MODEL_IDS`. Cost and Speed share Balanced's model
+ * (the subscription has no cheaper tier); the split is reasoning effort.
+ */
+const CHATGPT_PROFILE_IMPLS: ProfileImpls = {
+  balanced: {
+    model: "gpt-5.6-luna",
+    provider: "chatgpt",
+    source: "managed",
+    label: "Balanced",
+    description: "Good balance of quality, cost, and speed",
+    maxTokens: 16000,
+    effort: "high",
+    thinking: { enabled: true, streamThinking: true },
+    contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
+  },
+  "quality-optimized": {
+    model: "gpt-5.6-sol",
+    provider: "chatgpt",
+    source: "managed",
+    label: "Quality",
+    description: "Best results with the most capable model",
+    maxTokens: 32000,
+    effort: "high",
+    thinking: { enabled: true, streamThinking: true },
+    contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
+  },
+  "cost-optimized": {
+    model: "gpt-5.6-luna",
+    provider: "chatgpt",
+    source: "managed",
+    label: "Cost",
+    description: "Cheapest responses, for high-volume work",
+    maxTokens: 8192,
+    effort: "none",
+    thinking: { enabled: false, streamThinking: false },
+    contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
+  },
+  "latency-optimized": {
+    model: "gpt-5.6-luna",
+    provider: "chatgpt",
+    source: "managed",
+    label: "Speed",
+    description: "Fastest responses, with reasoning turned off",
+    maxTokens: 8192,
+    effort: "low",
+    thinking: { enabled: false, streamThinking: false },
+    contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
+  },
+};
+
+/**
  * The BYOK implementation of each default profile intent, shared by every
  * non-vellum provider. The concrete model resolves per provider from the
  * `intent` via `resolveModelIntent` at materialization time (falling back to
@@ -219,7 +277,9 @@ export const PROFILE_IMPLS: Record<
         provider,
         provider === "vellum"
           ? VELLUM_PROFILE_IMPLS[key]
-          : { ...BYOK_PROFILE_IMPLS[key], provider },
+          : provider === "chatgpt"
+            ? CHATGPT_PROFILE_IMPLS[key]
+            : { ...BYOK_PROFILE_IMPLS[key], provider },
       ]),
     ) as Record<DefaultProfileProvider, DefaultProfileTemplate>,
   ]),
@@ -372,21 +432,23 @@ for (const key of DEFAULT_PROFILE_KEYS) {
         `PROFILE_IMPLS[${key}][${provider}] must set exactly one of \`intent\` or \`model\`.`,
       );
     }
-    if (impl.provider === "vellum" && impl.model == null) {
+    if (ROUTING_IDENTITY_PROVIDERS.has(impl.provider) && impl.model == null) {
       throw new Error(
-        `PROFILE_IMPLS[${key}][${provider}] must pin a \`model\`: the vellum ` +
-          `column has no intent table, and the model selects the upstream.`,
+        `PROFILE_IMPLS[${key}][${provider}] must pin a \`model\`: routing ` +
+          `identities have no intent table, and the model selects the route.`,
       );
     }
     if (impl.model != null) {
       const routable =
         impl.provider === "vellum"
           ? getManagedUpstream(impl.model) !== null
-          : isModelInCatalog(impl.provider, impl.model);
+          : impl.provider === "chatgpt"
+            ? isCodexSubscriptionModel(impl.model)
+            : isModelInCatalog(impl.provider, impl.model);
       if (!routable) {
         throw new Error(
           `PROFILE_IMPLS[${key}][${provider}] references model "${impl.model}" ` +
-            `which is not ${impl.provider === "vellum" ? "served by any managed upstream" : `in PROVIDER_CATALOG for provider "${impl.provider}"`}. ` +
+            `which is not ${impl.provider === "vellum" ? "served by any managed upstream" : impl.provider === "chatgpt" ? "in CODEX_SUBSCRIPTION_MODEL_IDS" : `in PROVIDER_CATALOG for provider "${impl.provider}"`}. ` +
             `Update model-catalog.ts or default-profile-catalog.ts.`,
         );
       }
@@ -517,7 +579,9 @@ function resolveAgainstBody(
  * Non-obvious rules:
  *
  * - The `vellum` column stamps `provider: "vellum"` with no connection —
- *   dispatch derives the upstream from the model per-request.
+ *   dispatch derives the upstream from the model per-request. The `chatgpt`
+ *   column likewise stamps its routing identity with no connection;
+ *   dispatch resolves the canonical subscription row per-request.
  * - A default provider without a named matrix column materializes from the
  *   shared `BYOK_PROFILE_IMPLS` templates, with `resolveModelIntent`
  *   falling back to the provider's catalog `defaultModel`.

--- a/assistant/src/config/default-profile-names.ts
+++ b/assistant/src/config/default-profile-names.ts
@@ -38,7 +38,9 @@ export const OS_BETA_PROFILE_KEY = "os-beta";
 /**
  * The named columns of the intent × provider matrix. `vellum` is the
  * platform-managed column (routed through the single `vellum` connection to
- * an underlying provider per profile); the rest are BYOK columns whose
+ * an underlying provider per profile) and `chatgpt` is the
+ * ChatGPT-subscription column (routed through the `chatgpt-subscription`
+ * connection to the Codex endpoint); the rest are BYOK columns whose
  * models resolve per provider via `resolveModelIntent`. The full set of
  * providers that can back `llm.defaultProvider` is wider, see
  * `DEFAULT_PROVIDER_CHOICES` in `schemas/llm.ts`.
@@ -53,6 +55,7 @@ export const DEFAULT_PROFILE_PROVIDERS = [
   "gemini",
   "fireworks",
   "openrouter",
+  "chatgpt",
   "vellum",
 ] as const;
 export type DefaultProfileProvider = (typeof DEFAULT_PROFILE_PROVIDERS)[number];

--- a/assistant/src/config/default-provider-resolution.ts
+++ b/assistant/src/config/default-provider-resolution.ts
@@ -6,6 +6,7 @@
  * conveniences (`getDefaultProvider()` without an argument,
  * `setDefaultProvider`) live in `default-provider.ts`.
  */
+import { CHATGPT_SUBSCRIPTION_CONNECTION_NAME } from "../providers/inference/auth.js";
 import { VELLUM_MANAGED_CONNECTION_NAME } from "../providers/vellum-model-routing.js";
 import type { DefaultProviderConfig } from "./schemas/llm.js";
 import type { AssistantConfig } from "./types.js";
@@ -28,6 +29,9 @@ export function resolveDefaultConnectionName(
   }
   if (dp.provider === "vellum") {
     return VELLUM_MANAGED_CONNECTION_NAME;
+  }
+  if (dp.provider === "chatgpt") {
+    return CHATGPT_SUBSCRIPTION_CONNECTION_NAME;
   }
   return `${dp.provider}-personal`;
 }

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
 
-import { PROVIDERS_REQUIRING_BASE_URL_AND_MODELS } from "../../providers/inference/auth.js";
+import {
+  PROVIDERS_REQUIRING_BASE_URL_AND_MODELS,
+  ROUTING_IDENTITY_PROVIDERS,
+} from "../../providers/inference/auth.js";
 import { PROVIDER_CATALOG } from "../../providers/model-catalog.js";
 import { isCodexSubscriptionModel } from "../../providers/openai/codex-models.js";
 import {
@@ -84,13 +87,15 @@ export function isDefaultProviderChoice(value: string): value is LLMProvider {
 
 /**
  * Default-provider choices whose profiles materialize from the shared BYOK
- * templates: every choice except the `vellum` routing identity, whose
- * defaults are pinned managed models.
+ * templates: every choice except the routing identities (`vellum`,
+ * `chatgpt`), whose defaults are pinned models on code-owned columns.
  */
 export function isByokDefaultProviderChoice(
   value: string,
 ): value is LLMProvider {
-  return value !== "vellum" && isDefaultProviderChoice(value);
+  return (
+    !ROUTING_IDENTITY_PROVIDERS.has(value) && isDefaultProviderChoice(value)
+  );
 }
 
 const DefaultProviderEnum = z.enum(

--- a/assistant/src/runtime/routes/__tests__/default-provider-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/default-provider-routes.test.ts
@@ -432,6 +432,31 @@ describe("PUT config/llm/default-provider", () => {
     expect(availability(result)).toEqual({ status: "ok" });
   });
 
+  test("chatgpt persists and resolves the canonical subscription row", async () => {
+    seedConnection({
+      name: "chatgpt-subscription",
+      provider: "chatgpt",
+      auth: {
+        type: "oauth_subscription",
+        credential: "credential/chatgpt/access_token",
+      },
+    });
+    secureKeyResults["credential/chatgpt/access_token"] = {
+      value: "token",
+      unreachable: false,
+    };
+
+    const result = (await put({ provider: "chatgpt" })) as Record<
+      string,
+      unknown
+    >;
+
+    expect(persistedDefaultProvider()).toEqual({ provider: "chatgpt" });
+    expect(result.provider).toBe("chatgpt");
+    expect(result.resolvedConnectionName).toBe("chatgpt-subscription");
+    expect(availability(result)).toEqual({ status: "ok" });
+  });
+
   test("persists an explicit connectionName", async () => {
     await put({ provider: "openai", connectionName: "work-openai" });
     expect(persistedDefaultProvider()).toEqual({

--- a/assistant/src/runtime/routes/__tests__/default-provider-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/default-provider-routes.test.ts
@@ -474,6 +474,42 @@ describe("PUT config/llm/default-provider", () => {
     expect(availability(result).status).toBe("missing_connection");
   });
 
+  test("a noncanonical pin on a routing identity → 400 naming the canonical row", async () => {
+    for (const [provider, canonical] of [
+      ["chatgpt", "chatgpt-subscription"],
+      ["vellum", "vellum"],
+    ] as const) {
+      const err = await put({
+        provider,
+        connectionName: "some-other-row",
+      }).catch((e: unknown) => e);
+      expect(String(err)).toContain(canonical);
+    }
+  });
+
+  test("the canonical pin on a routing identity is accepted", async () => {
+    seedConnection({
+      name: "chatgpt-subscription",
+      provider: "chatgpt",
+      auth: {
+        type: "oauth_subscription",
+        credential: "credential/chatgpt/access_token",
+      },
+    });
+    secureKeyResults["credential/chatgpt/access_token"] = {
+      value: "token",
+      unreachable: false,
+    };
+
+    const result = (await put({
+      provider: "chatgpt",
+      connectionName: "chatgpt-subscription",
+    })) as Record<string, unknown>;
+
+    expect(result.resolvedConnectionName).toBe("chatgpt-subscription");
+    expect(availability(result)).toEqual({ status: "ok" });
+  });
+
   test("invalid provider → 400 naming the allowed providers", async () => {
     const err = await put({ provider: "not-a-provider" }).catch(
       (e: unknown) => e,

--- a/assistant/src/runtime/routes/default-provider-routes.ts
+++ b/assistant/src/runtime/routes/default-provider-routes.ts
@@ -25,11 +25,11 @@ import {
   DEFAULT_PROVIDER_CHOICES,
   DefaultProviderSchema,
 } from "../../config/schemas/llm.js";
+import { ROUTING_IDENTITY_PROVIDERS } from "../../providers/inference/auth.js";
 import {
   computeConnectionAvailability,
   CONNECTION_AVAILABILITY_STATUSES,
 } from "../../providers/inference/connection-availability.js";
-import { ROUTING_IDENTITY_PROVIDERS } from "../../providers/inference/auth.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { BadRequestError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";

--- a/assistant/src/runtime/routes/default-provider-routes.ts
+++ b/assistant/src/runtime/routes/default-provider-routes.ts
@@ -29,6 +29,7 @@ import {
   computeConnectionAvailability,
   CONNECTION_AVAILABILITY_STATUSES,
 } from "../../providers/inference/connection-availability.js";
+import { ROUTING_IDENTITY_PROVIDERS } from "../../providers/inference/auth.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { BadRequestError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
@@ -92,6 +93,20 @@ async function handlePutDefaultProvider({
         ", ",
       )}; "connectionName" is optional and must be a non-empty string.`,
     );
+  }
+  // Routing identities dispatch through their canonical row regardless of
+  // any stored pin (`resolveRoutingIdentity`), so a noncanonical
+  // connectionName would be judged by availability and the deletion guards
+  // while inference uses a different row. Reject it here rather than
+  // persisting a pin that status and dispatch disagree about.
+  const { provider, connectionName } = result.data;
+  if (connectionName != null && ROUTING_IDENTITY_PROVIDERS.has(provider)) {
+    const canonical = resolveDefaultConnectionName({ provider });
+    if (connectionName !== canonical) {
+      throw new BadRequestError(
+        `Provider "${provider}" always dispatches through its canonical connection "${canonical}". Omit "connectionName" or pass "${canonical}".`,
+      );
+    }
   }
   setDefaultProvider(result.data);
   return handleGetDefaultProvider();

--- a/assistant/src/workspace/byok-default-profile-ensure.ts
+++ b/assistant/src/workspace/byok-default-profile-ensure.ts
@@ -18,6 +18,7 @@ import {
   type LLMProvider,
   type ProfileEntry,
 } from "../config/schemas/llm.js";
+import { ROUTING_IDENTITY_PROVIDERS } from "../providers/inference/auth.js";
 import { getLogger } from "../util/logger.js";
 import { completedProfileBody } from "./custom-profile-ensure.js";
 
@@ -267,11 +268,13 @@ export function ensureByokDefaultProfiles(workspaceDir: string): void {
   const completionBase = LLMConfigBase.safeParse(llm.default ?? {}).data;
 
   // The default provider on a BYOK default, or the uniform hatch provider
-  // across the complete copy set on a vellum default; null converts nothing.
-  const candidateProvider =
-    parsedDefault.data.provider !== "vellum"
-      ? parsedDefault.data.provider
-      : uniformCopyProvider(profiles);
+  // across the complete copy set on a routing-identity default (vellum,
+  // chatgpt); null converts nothing.
+  const candidateProvider = ROUTING_IDENTITY_PROVIDERS.has(
+    parsedDefault.data.provider,
+  )
+    ? uniformCopyProvider(profiles)
+    : parsedDefault.data.provider;
   const convertibleProvider =
     candidateProvider !== null && isByokDefaultProviderChoice(candidateProvider)
       ? candidateProvider

--- a/clients/web/src/domains/settings/ai/provider-row-meta.test.ts
+++ b/clients/web/src/domains/settings/ai/provider-row-meta.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, test } from "bun:test";
 
 import { getModelsForProvider } from "@/assistant/llm-model-catalog";
 import { CODEX_SUBSCRIPTION_MODEL_IDS } from "@/domains/settings/ai/codex-subscription-models";
-import { providerRowMeta } from "@/domains/settings/ai/provider-row-meta";
+import {
+  isDefaultProviderId,
+  providerRowMeta,
+} from "@/domains/settings/ai/provider-row-meta";
 import type { ProviderConnection } from "@/generated/daemon/types.gen";
 
 function connection(auth: ProviderConnection["auth"]): ProviderConnection {
@@ -12,6 +15,12 @@ function connection(auth: ProviderConnection["auth"]): ProviderConnection {
     auth,
   } as ProviderConnection;
 }
+
+describe("default-provider eligibility", () => {
+  test("the chatgpt identity row can be set as default", () => {
+    expect(isDefaultProviderId("chatgpt")).toBe(true);
+  });
+});
 
 describe("providerRowMeta model counts", () => {
   test("an api-key openai row counts the full catalog", () => {

--- a/clients/web/src/domains/settings/ai/provider-row-meta.ts
+++ b/clients/web/src/domains/settings/ai/provider-row-meta.ts
@@ -19,6 +19,7 @@ const DEFAULT_PROVIDER_ELIGIBLE: Record<DefaultProviderId, true> = {
   gemini: true,
   fireworks: true,
   openrouter: true,
+  chatgpt: true,
   vellum: true,
   together: true,
   "vercel-ai-gateway": true,


### PR DESCRIPTION
## Summary
- Add a `chatgpt` column to the default-profile intent matrix with Codex-pinned implementations (Quality → `gpt-5.6-sol`; Balanced/Cost/Speed → `gpt-5.6-luna`, tiers split by reasoning effort) and extend the module-load validation so chatgpt-column pins must be in `CODEX_SUBSCRIPTION_MODEL_IDS`. Materialized chatgpt defaults carry no `provider_connection`: dispatch resolves the canonical subscription row per-request via `resolveRoutingIdentity`, so the pinned-connection compat-gate bypass cannot occur on this path.
- `resolveDefaultConnectionName` maps provider `chatgpt` → the `chatgpt-subscription` row (like `vellum` → the managed row); `isByokDefaultProviderChoice` and the BYOK boot-ensure now exclude all routing identities rather than only `vellum`.
- Regenerated the OpenAPI spec, and the web adds `chatgpt: true` to `DEFAULT_PROVIDER_ELIGIBLE` (the record is exhaustive against the regenerated enum), restoring the Set as default action on the subscription row; the Default badge keys on `resolvedConnectionName` and works unchanged.

## Original prompt
PR #40166 (migration 366) stamps the subscription row with `provider: "chatgpt"`, which silently removed Set as default from that row: eligibility keys on the row's provider being a legal `llm.defaultProvider` value, and `chatgpt` was never in `DEFAULT_PROVIDER_CHOICES` (the row previously qualified only by masquerading as `openai`). Following the decided option-2 semantics (no chatgpt↔openai mapping; the subscription is its own provider identity), the user asked to make `chatgpt` a first-class default-provider choice with a Codex-pinned matrix column, the canonical connection-name convention, spec regeneration, and web eligibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uts2hxMb2vf6DfuNoK6B4X
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40579" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->