### PR TITLE
refactor(web): drop the two schedules indirections nothing was using

### DIFF
--- a/clients/web/src/domains/schedules/hooks/use-schedules-data.ts
+++ b/clients/web/src/domains/schedules/hooks/use-schedules-data.ts
@@ -1,10 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useCallback, useMemo, useState } from "react";
 
-import {
-  schedulesListQueryOptions,
-  toggleSchedule,
-} from "@/domains/settings/api/schedules";
+import { toggleSchedule } from "@/domains/settings/api/schedules";
 import type { Schedule } from "@/domains/settings/types/schedules";
 import {
   groupSchedules,
@@ -14,6 +11,7 @@ import {
 } from "@/domains/settings/utils/schedule-formatters";
 import { t } from "@/i18n";
 import { captureError } from "@/lib/sentry/capture-error";
+import { schedulesListQueryOptions } from "@/utils/schedules";
 import { useEffectiveTimezone } from "@/utils/use-effective-timezone";
 import { toast } from "@vellumai/design-library/components/toast";
 

--- a/clients/web/src/domains/settings/api/schedules.test.ts
+++ b/clients/web/src/domains/settings/api/schedules.test.ts
@@ -53,8 +53,10 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
   },
 }));
 
-const { fetchSchedules, fetchScheduleUsageSummary } =
-  await import("./schedules");
+const { fetchScheduleUsageSummary } = await import("./schedules");
+// The list read lives in `@/utils/schedules`; this file's SDK mock is module
+// wide, so it covers that module's `schedulesGet` call the same way.
+const { fetchSchedules } = await import("@/utils/schedules");
 
 afterEach(() => {
   usageSummaryCalls = [];

--- a/clients/web/src/domains/settings/api/schedules.ts
+++ b/clients/web/src/domains/settings/api/schedules.ts
@@ -1,7 +1,11 @@
 /**
- * Fetch wrappers for user-created schedule CRUD (list, create, update, toggle,
+ * Fetch wrappers for user-created schedule CRUD (create, update, toggle,
  * delete, runs, usage summary). System-task queries (heartbeat, consolidation,
- * retrospective) use generated SDK options directly — see use-system-tasks.ts.
+ * retrospective) use generated SDK options directly, see use-system-tasks.ts.
+ *
+ * Reading the schedule list is not here: `@/utils/schedules` owns it, because
+ * its consumers span domains (settings, schedules, home, intelligence) and a
+ * domain may not import a peer's internals.
  */
 import {
   schedulesByIdDelete,
@@ -18,10 +22,8 @@ import {
   assertHasResponse,
   extractErrorMessage,
 } from "@/utils/api-errors";
-import { fetchSchedules as fetchSharedSchedules } from "@/utils/schedules";
 
 import type {
-  Schedule,
   ScheduleRun,
   ScheduleUsageSummary,
 } from "@/domains/settings/types/schedules";
@@ -94,10 +96,6 @@ export async function updateSchedule(
   }
 }
 
-export async function fetchSchedules(assistantId: string): Promise<Schedule[]> {
-  return fetchSharedSchedules(assistantId);
-}
-
 const REASSIGN_PROFILE_ERROR =
   "Failed to move schedules to the selected profile.";
 
@@ -133,13 +131,6 @@ export async function reassignScheduleInferenceProfile(
   }
   return data?.reassigned ?? 0;
 }
-
-/**
- * Re-exported from `@/utils/schedules`, which owns the list's query key +
- * staleTime so that consumers in other domains (the Activity feed's entity
- * links) can read the same cache entry without importing this module.
- */
-export { schedulesListQueryOptions } from "@/utils/schedules";
 
 export async function fetchScheduleRuns(
   assistantId: string,


### PR DESCRIPTION
## TL;DR

Follow-up to #40567, which moved `schedulesListQueryOptions` into `@/utils/schedules` so the home domain could read it without a cross-domain import. That move left two shims behind in `domains/settings/api/schedules.ts`. Neither has a consumer that justifies it, so both go. No behavior change.

## What was there and why it goes

**1. A re-export serving exactly one caller.** I left `export { schedulesListQueryOptions } from "@/utils/schedules"` in the settings module so its existing callers would not have to change their import. There was one such caller — `domains/schedules/hooks/use-schedules-data.ts` — and it now imports from the owning module directly. A shim serving a single call site is a redirect with a docstring; leaving it in was me avoiding a one-line edit in another domain, which is the move I would flag in someone else's review.

**2. A pass-through that outlived its last caller.** `domains/settings/api/schedules.ts` also exported

```ts
export async function fetchSchedules(assistantId: string): Promise<Schedule[]> {
  return fetchSharedSchedules(assistantId);
}
```

which dates to the apps/clients consolidation (#35110) and existed so settings-domain callers could keep their import path. Its last in-file caller was the query options that #40567 moved out, and every real consumer — the billing usage tab, the identity stats card — already imports the shared function directly. Nothing but its own test was reaching it.

## What stays

The split itself, which is sound and is now stated at the top of both files rather than being implied:

| Module | Owns | Consumers |
|---|---|---|
| `utils/schedules.ts` | the list read: `AssistantSchedule`, `fetchSchedules`, `schedulesListQueryOptions` | settings, schedules, home, intelligence |
| `domains/settings/api/schedules.ts` | the CRUD surface: create, update, toggle, delete, run-now, reassign, runs, usage | settings, schedules |

A read used by four domains cannot live inside one of them — that is what `local/no-cross-domain-imports` exists to prevent. The CRUD surface has no such pressure and stays where it is.

## Why it is safe

- **Nothing changes at runtime.** Both removals are indirections; every remaining call site resolves to the same function it resolved to before.
- **No new imports cross a domain boundary.** `use-schedules-data.ts` still imports `toggleSchedule` and the shared types from settings, so its allowlist entry is unchanged; `audit:cross-domain:check` passes at 14.
- **The moved test tests more than it did.** `schedules.test.ts` asserted the `cadenceDescription` fallback through the pass-through, so it was already exercising `utils/schedules`'s implementation at one remove. It now imports that module directly. The file's `mock.module` on the generated SDK is module-wide, so it intercepts the same `schedulesGet` call either way.

## Testing

Typecheck, lint, and `audit:cross-domain:check` pass locally. Local test runs are blocked by a standing hook in this repo, so **CI is the first real run of the retargeted `fetchSchedules` test** — that is the one thing here worth watching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40581" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->