### PR TITLE
fix(acp): point Connect Claude at the live authorize endpoint (JARVIS-1517)

### DIFF
--- a/assistant/src/acp/__tests__/acp-claude-oauth.test.ts
+++ b/assistant/src/acp/__tests__/acp-claude-oauth.test.ts
@@ -59,6 +59,9 @@ beforeEach(() => {
 
 describe("CLAUDE_OAUTH_CONFIG", () => {
   test("matches the verified endpoints, client id, and scope", () => {
+    // The single literal pin for the endpoint. Every other test asserts
+    // against CLAUDE_OAUTH_CONFIG.authorizeUrl, so an endpoint change edits
+    // exactly this one value.
     expect(CLAUDE_OAUTH_CONFIG.authorizeUrl).toBe(
       "https://claude.com/cai/oauth/authorize",
     );
@@ -92,8 +95,10 @@ describe("buildClaudeAuthorizeUrl", () => {
     });
 
     const parsed = new URL(url);
+    // The property under test is that the builder uses the configured
+    // endpoint; the value itself is guarded by the literal pin above.
     expect(`${parsed.origin}${parsed.pathname}`).toBe(
-      "https://claude.com/cai/oauth/authorize",
+      CLAUDE_OAUTH_CONFIG.authorizeUrl,
     );
 
     const params = parsed.searchParams;

--- a/assistant/src/acp/__tests__/acp-claude-oauth.test.ts
+++ b/assistant/src/acp/__tests__/acp-claude-oauth.test.ts
@@ -106,9 +106,8 @@ describe("buildClaudeAuthorizeUrl", () => {
     expect(params.get("state")).toBe("state-abc");
     expect(params.get("code_challenge")).toBe("challenge-123");
     expect(params.get("code_challenge_method")).toBe("S256");
-    // The manual flow's defining param: tells Claude to render `code#state` on
-    // the callback page. Without it the grant is rejected as an invalid
-    // request, so a sign-in can never complete (JARVIS-1517).
+    // The manual flow's defining param: tells Claude to render `code#state`
+    // on the callback page. Claude rejects a manual-redirect grant without it.
     expect(params.get("code")).toBe("true");
   });
 

--- a/assistant/src/acp/__tests__/acp-claude-oauth.test.ts
+++ b/assistant/src/acp/__tests__/acp-claude-oauth.test.ts
@@ -60,7 +60,7 @@ beforeEach(() => {
 describe("CLAUDE_OAUTH_CONFIG", () => {
   test("matches the verified endpoints, client id, and scope", () => {
     expect(CLAUDE_OAUTH_CONFIG.authorizeUrl).toBe(
-      "https://claude.ai/oauth/authorize",
+      "https://claude.com/cai/oauth/authorize",
     );
     expect(CLAUDE_OAUTH_CONFIG.tokenExchangeUrl).toBe(
       "https://platform.claude.com/v1/oauth/token",
@@ -93,7 +93,7 @@ describe("buildClaudeAuthorizeUrl", () => {
 
     const parsed = new URL(url);
     expect(`${parsed.origin}${parsed.pathname}`).toBe(
-      "https://claude.ai/oauth/authorize",
+      "https://claude.com/cai/oauth/authorize",
     );
 
     const params = parsed.searchParams;
@@ -106,6 +106,10 @@ describe("buildClaudeAuthorizeUrl", () => {
     expect(params.get("state")).toBe("state-abc");
     expect(params.get("code_challenge")).toBe("challenge-123");
     expect(params.get("code_challenge_method")).toBe("S256");
+    // The manual flow's defining param: tells Claude to render `code#state` on
+    // the callback page. Without it the grant is rejected as an invalid
+    // request, so a sign-in can never complete (JARVIS-1517).
+    expect(params.get("code")).toBe("true");
   });
 
   test("works with the manual redirect URI too", () => {

--- a/assistant/src/acp/acp-claude-oauth.ts
+++ b/assistant/src/acp/acp-claude-oauth.ts
@@ -36,10 +36,11 @@ export const CLAUDE_OAUTH_CONFIG: OAuth2Config = {
   // The claude.ai-account authorize endpoint, matching CLAUDE_AI_AUTHORIZE_URL
   // in Claude Code CLI 2.1.220. Shared by both flows: the loopback path builds
   // its URL from this in `prepareOAuth2Flow`, the manual path in
-  // `buildClaudeAuthorizeUrl`. Do NOT point this at claude.ai/oauth/authorize:
-  // that endpoint's frontend still renders a convincing consent screen, but its
-  // authorize POST rejects every grant with a 400 "Invalid request format", so
-  // sign-in can never complete there (JARVIS-1517).
+  // `buildClaudeAuthorizeUrl`. Only this claude.com/cai host completes a
+  // grant. The legacy claude.ai host still renders a working-looking consent
+  // screen, but its authorize POST rejects every grant with a 400 "Invalid
+  // request format", so a wrong host here looks functional until the final
+  // click of a real sign-in.
   authorizeUrl: "https://claude.com/cai/oauth/authorize",
   tokenExchangeUrl: "https://platform.claude.com/v1/oauth/token",
   clientId: "9d1c250a-e61b-44d9-88ed-5944d1962f5e",
@@ -64,12 +65,11 @@ export const CLAUDE_MANUAL_REDIRECT_URI =
  * Build the Claude authorize URL for the MANUAL (paste) PKCE flow.
  *
  * `code=true` tells Claude to render the `code#state` string on the callback
- * page for the user to copy, which is the whole mechanism of the manual flow.
- * The CLI's own setup-token URL carries it; without it the authorize grant is
- * rejected as an invalid request (JARVIS-1517). The loopback flow performs a
- * real redirect instead and must NOT send it; that URL is built separately in
- * `prepareOAuth2Flow`, which is why this builder can include the param
- * unconditionally.
+ * page for the user to copy, which is the whole mechanism of the manual flow;
+ * Claude rejects a manual-redirect grant without it. The loopback flow
+ * performs a real redirect instead and must NOT send it; that URL is built
+ * separately in `prepareOAuth2Flow`, which is why this builder can include
+ * the param unconditionally.
  */
 export function buildClaudeAuthorizeUrl(
   redirectUri: string,

--- a/assistant/src/acp/acp-claude-oauth.ts
+++ b/assistant/src/acp/acp-claude-oauth.ts
@@ -33,14 +33,13 @@ import {
  * `CLAUDE_CODE_OAUTH_TOKEN` requires.
  */
 export const CLAUDE_OAUTH_CONFIG: OAuth2Config = {
-  // The claude.ai-account authorize endpoint, matching CLAUDE_AI_AUTHORIZE_URL
-  // in Claude Code CLI 2.1.220. Shared by both flows: the loopback path builds
-  // its URL from this in `prepareOAuth2Flow`, the manual path in
-  // `buildClaudeAuthorizeUrl`. Only this claude.com/cai host completes a
-  // grant. The legacy claude.ai host still renders a working-looking consent
-  // screen, but its authorize POST rejects every grant with a 400 "Invalid
-  // request format", so a wrong host here looks functional until the final
-  // click of a real sign-in.
+  // The claude.ai-account authorize endpoint, matching the Claude Code CLI's
+  // own CLAUDE_AI_AUTHORIZE_URL. Shared by both flows: the loopback path
+  // builds its URL from this in `prepareOAuth2Flow`, the manual path in
+  // `buildClaudeAuthorizeUrl`. Only the claude.com/cai host completes a
+  // grant; the legacy claude.ai host still renders a working-looking consent
+  // screen but rejects every authorize POST, so a wrong host here looks
+  // functional until the final click of a real sign-in.
   authorizeUrl: "https://claude.com/cai/oauth/authorize",
   tokenExchangeUrl: "https://platform.claude.com/v1/oauth/token",
   clientId: "9d1c250a-e61b-44d9-88ed-5944d1962f5e",

--- a/assistant/src/acp/acp-claude-oauth.ts
+++ b/assistant/src/acp/acp-claude-oauth.ts
@@ -33,7 +33,14 @@ import {
  * `CLAUDE_CODE_OAUTH_TOKEN` requires.
  */
 export const CLAUDE_OAUTH_CONFIG: OAuth2Config = {
-  authorizeUrl: "https://claude.ai/oauth/authorize",
+  // The claude.ai-account authorize endpoint, matching CLAUDE_AI_AUTHORIZE_URL
+  // in Claude Code CLI 2.1.220. Shared by both flows: the loopback path builds
+  // its URL from this in `prepareOAuth2Flow`, the manual path in
+  // `buildClaudeAuthorizeUrl`. Do NOT point this at claude.ai/oauth/authorize:
+  // that endpoint's frontend still renders a convincing consent screen, but its
+  // authorize POST rejects every grant with a 400 "Invalid request format", so
+  // sign-in can never complete there (JARVIS-1517).
+  authorizeUrl: "https://claude.com/cai/oauth/authorize",
   tokenExchangeUrl: "https://platform.claude.com/v1/oauth/token",
   clientId: "9d1c250a-e61b-44d9-88ed-5944d1962f5e",
   scopes: ["user:inference"],
@@ -53,12 +60,23 @@ export const CLAUDE_OAUTH_CONFIG: OAuth2Config = {
 export const CLAUDE_MANUAL_REDIRECT_URI =
   "https://platform.claude.com/oauth/code/callback";
 
-/** Build the Claude authorize URL for a PKCE flow. */
+/**
+ * Build the Claude authorize URL for the MANUAL (paste) PKCE flow.
+ *
+ * `code=true` tells Claude to render the `code#state` string on the callback
+ * page for the user to copy, which is the whole mechanism of the manual flow.
+ * The CLI's own setup-token URL carries it; without it the authorize grant is
+ * rejected as an invalid request (JARVIS-1517). The loopback flow performs a
+ * real redirect instead and must NOT send it; that URL is built separately in
+ * `prepareOAuth2Flow`, which is why this builder can include the param
+ * unconditionally.
+ */
 export function buildClaudeAuthorizeUrl(
   redirectUri: string,
   pkce: { codeChallenge: string; state: string },
 ): string {
   const params = new URLSearchParams({
+    code: "true",
     response_type: "code",
     client_id: CLAUDE_OAUTH_CONFIG.clientId,
     redirect_uri: redirectUri,

--- a/assistant/src/runtime/routes/__tests__/acp-claude-auth-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/acp-claude-auth-routes.test.ts
@@ -298,7 +298,7 @@ describe("acp_claude_auth_start (cloud/manual)", () => {
     expect(url.searchParams.get("code_challenge_method")).toBe("S256");
     expect(url.searchParams.get("state")).toBe(result.state);
     // Manual flow requires `code=true` so the callback page renders the
-    // `code#state` string to paste back (JARVIS-1517).
+    // `code#state` string to paste back.
     expect(url.searchParams.get("code")).toBe("true");
 
     // The manual path must not bind a loopback.

--- a/assistant/src/runtime/routes/__tests__/acp-claude-auth-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/acp-claude-auth-routes.test.ts
@@ -47,7 +47,7 @@ mock.module("../../../security/oauth2.js", () => ({
 }));
 
 const actualClaudeOauth = await import("../../../acp/acp-claude-oauth.js");
-const { CLAUDE_MANUAL_REDIRECT_URI } = actualClaudeOauth;
+const { CLAUDE_MANUAL_REDIRECT_URI, CLAUDE_OAUTH_CONFIG } = actualClaudeOauth;
 const storeAcpClaudeTokenMock = mock(async (_token: string) => {});
 // The connect-status route reads token presence; mock it so the route test
 // doesn't reach real secure storage.
@@ -125,7 +125,7 @@ function deferredFlow(state: string): {
     reject = rej;
   });
   prepareOAuth2FlowMock.mockImplementationOnce(async () => ({
-    authorizeUrl: `https://claude.com/cai/oauth/authorize?state=${state}`,
+    authorizeUrl: `${CLAUDE_OAUTH_CONFIG.authorizeUrl}?state=${state}`,
     state,
     completion,
   }));
@@ -153,7 +153,7 @@ describe("acp_claude_auth_start", () => {
 
     const url = new URL(result.authorize_url);
     expect(`${url.origin}${url.pathname}`).toBe(
-      "https://claude.com/cai/oauth/authorize",
+      CLAUDE_OAUTH_CONFIG.authorizeUrl,
     );
     expect(url.searchParams.get("client_id")).toBe(CLAUDE_CLIENT_ID);
     expect(url.searchParams.get("code_challenge_method")).toBe("S256");
@@ -289,7 +289,7 @@ describe("acp_claude_auth_start (cloud/manual)", () => {
     expect(result.mode).toBe("manual");
     const url = new URL(result.authorize_url);
     expect(`${url.origin}${url.pathname}`).toBe(
-      "https://claude.com/cai/oauth/authorize",
+      CLAUDE_OAUTH_CONFIG.authorizeUrl,
     );
     expect(url.searchParams.get("redirect_uri")).toBe(
       CLAUDE_MANUAL_REDIRECT_URI,

--- a/assistant/src/runtime/routes/__tests__/acp-claude-auth-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/acp-claude-auth-routes.test.ts
@@ -125,7 +125,7 @@ function deferredFlow(state: string): {
     reject = rej;
   });
   prepareOAuth2FlowMock.mockImplementationOnce(async () => ({
-    authorizeUrl: `https://claude.ai/oauth/authorize?state=${state}`,
+    authorizeUrl: `https://claude.com/cai/oauth/authorize?state=${state}`,
     state,
     completion,
   }));
@@ -153,13 +153,18 @@ describe("acp_claude_auth_start", () => {
 
     const url = new URL(result.authorize_url);
     expect(`${url.origin}${url.pathname}`).toBe(
-      "https://claude.ai/oauth/authorize",
+      "https://claude.com/cai/oauth/authorize",
     );
     expect(url.searchParams.get("client_id")).toBe(CLAUDE_CLIENT_ID);
     expect(url.searchParams.get("code_challenge_method")).toBe("S256");
 
     const redirectUri = url.searchParams.get("redirect_uri") ?? "";
     expect(redirectUri).toMatch(/^http:\/\/localhost:\d+\/callback$/);
+
+    // The loopback flow performs a REAL redirect to the localhost callback;
+    // `code=true` (render the code on the page) belongs to the manual flow
+    // only and must not leak into this URL.
+    expect(url.searchParams.get("code")).toBeNull();
 
     expect(result.state).toBeTruthy();
     expect(url.searchParams.get("state")).toBe(result.state);
@@ -284,7 +289,7 @@ describe("acp_claude_auth_start (cloud/manual)", () => {
     expect(result.mode).toBe("manual");
     const url = new URL(result.authorize_url);
     expect(`${url.origin}${url.pathname}`).toBe(
-      "https://claude.ai/oauth/authorize",
+      "https://claude.com/cai/oauth/authorize",
     );
     expect(url.searchParams.get("redirect_uri")).toBe(
       CLAUDE_MANUAL_REDIRECT_URI,
@@ -292,6 +297,9 @@ describe("acp_claude_auth_start (cloud/manual)", () => {
     expect(url.searchParams.get("client_id")).toBe(CLAUDE_CLIENT_ID);
     expect(url.searchParams.get("code_challenge_method")).toBe("S256");
     expect(url.searchParams.get("state")).toBe(result.state);
+    // Manual flow requires `code=true` so the callback page renders the
+    // `code#state` string to paste back (JARVIS-1517).
+    expect(url.searchParams.get("code")).toBe("true");
 
     // The manual path must not bind a loopback.
     expect(prepareOAuth2FlowMock).not.toHaveBeenCalled();


### PR DESCRIPTION
## TL;DR

The "Connect Claude Code" sign-in cannot currently complete on either path. This is an upstream regression: the flow shipped working in #38180 (2026-07-16), and Anthropic has since moved the claude.ai-account authorize endpoint out from under it. A second defect rides along: the manual (paste) flow omits the parameter that makes the paste flow work. This PR fixes both. Two lines of production code plus comments and test pins.

Fixes [JARVIS-1517](https://linear.app/vellum/issue/JARVIS-1517/connect-claude-acp-sign-in-can-never-complete-authorize-endpoint-moved). Blocking for the LUM-3205 recovery UX, whose Connect card dead-ends at this bug.

## The two defects

1. **Deprecated endpoint.** Production authorizes against `claude.ai/oauth/authorize`, unchanged since the flow shipped. That host's frontend still renders a convincing consent screen — which is exactly why the regression survived casual checks — but its authorize POST now rejects every grant, after sign-in, with `400 invalid_request_error: "Invalid request format"`. The current Claude Code CLI (2.1.220) uses `https://claude.com/cai/oauth/authorize` (`CLAUDE_AI_AUTHORIZE_URL` in its embedded config; the claude.ai path appears nowhere in it).
2. **Manual flow missing `code=true`.** That parameter tells Claude to render the `code#state` string on the callback page for the user to copy — the mechanism the paste flow exists to use. The CLI's own setup-token URL carries it; ours did not.

Everything else already matched the CLI byte-for-byte: same client id, same manual redirect URI, same single `user:inference` scope.

## Evidence

- **Byte-exact capture of the working URL** from `claude setup-token` (CLI 2.1.220, isolated pty, isolated `CLAUDE_CONFIG_DIR`): identical to ours except the host and `code=true`.
- **Live reproduction**: a signed-in browser on production's exact URL renders consent, and clicking Authorize yields `POST /v1/oauth/{org}/authorize → 400 Invalid request format`. Adding `code=true` on the same dead host still 400s at the grant step — the host and the param are independently required.
- **Flow scoping from the CLI's embedded config**: one authorize constant serves the whole claude.ai-account flow family (login/loopback and setup-token/manual), so the endpoint fix covers both paths; the CLI's loopback parameter set carries no `code` param, so `code=true` is manual-only.

## Why the fix lands where it does

`CLAUDE_OAUTH_CONFIG.authorizeUrl` is shared: the loopback path builds its URL from it inside `prepareOAuth2Flow`, the manual path inside `buildClaudeAuthorizeUrl`. So the endpoint change fixes both flows in one place. `buildClaudeAuthorizeUrl` has exactly one caller — the manual route — so `code=true` lives there unconditionally, and cannot leak into the loopback URL.

## Why the regression produced no signal

- It happened server-side, with no change in this repo to review or bisect.
- The route tests mock `prepareOAuth2Flow` and `exchangeCodeForTokens`, so nothing exercises the real authorize page and no CI signal exists for an upstream endpoint change (true before and after this PR; see the verification note below).
- The deprecated frontend still renders a real-looking consent screen, so even a human walking the flow sees success right up until the final click.

## What changes for the user

| Situation | Before | After |
|---|---|---|
| Connect Claude from the desktop app (loopback) | Sign in → "Authorization failed / Invalid request format", every time | Completes |
| Connect Claude from browser/cloud (paste flow) | Same failure, and no code would render even past authorize | Completes; callback page shows the `code#state` to paste |
| Everything downstream of Connect (ACP spawns, recovery card) | Unreachable via the in-app flow | Reachable |

## Verification

`bunx tsc --noEmit`, lint, and the pinned prettier pass; suites run in CI (local runs blocked by a standing hook). Tests pin the three load-bearing facts: the endpoint constant, `code=true` present on the manual URL, `code=true` absent from the loopback URL.

Honest limit: end-to-end confirmation (a completed exchange against the new endpoint) requires a real sign-in, which hasn't been run yet — the evidence is byte-parity with the URL the CLI uses successfully in production today. The first live Connect after merge is the final check; the callback capture, exchange, and storage layers are unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
