### PR TITLE
test(persistence): ratchet direct messages-table reads outside persistence

### DIFF
--- a/assistant/src/__tests__/messages-read-boundary-guard.test.ts
+++ b/assistant/src/__tests__/messages-read-boundary-guard.test.ts
@@ -1,0 +1,119 @@
+import { readFileSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+import { Glob } from "bun";
+
+/**
+ * Ratchet over direct reads of the `messages` table outside `persistence/`.
+ *
+ * Every row in `messages` is conversation content in some state of
+ * completeness, and each read encodes a visibility decision (completed
+ * history vs. any row). `persistence/` owns that contract: named accessors in
+ * `message-reads.ts` and the history readers in `conversation-crud.ts` state
+ * their decision in their name; everything else should go through them. The
+ * fork-corruption and phantom-turn incidents both came from direct readers
+ * that silently re-decided visibility, so new direct reads are a reviewed
+ * exception, not a default.
+ *
+ * The BASELINE lists every file outside `persistence/` that reads the table
+ * directly today. Each entry has been audited and carries its visibility
+ * decision as a comment at the read site. The guard fails when a file outside
+ * the baseline gains a direct read (route it through an accessor, or audit it
+ * and baseline it with a site comment explaining the decision in your PR),
+ * and when a baseline entry goes stale (remove it, so coverage cannot rot).
+ *
+ * Detection is deliberately shape-based (`.from(messages)` for drizzle,
+ * `FROM messages` for raw SQL): this is a ratchet against sprawl, not a
+ * proof, and matching the two read shapes keeps it free of false positives
+ * from unrelated identifiers.
+ *
+ * Regenerate after an intentional change with:
+ *   UPDATE_MESSAGES_READ_BASELINE=1 bun test src/__tests__/messages-read-boundary-guard.test.ts
+ * and paste the printed list here, explaining the new read in your PR.
+ */
+
+const SRC_REL = "src";
+const SRC_ABS = join(process.cwd(), SRC_REL);
+
+/** Files outside persistence/ with audited direct reads of `messages`. */
+const BASELINE: readonly string[] = [
+  "src/apps/app-store.ts",
+  "src/daemon/credential-transcript-scrub.ts",
+  "src/live-voice/live-voice-archive.ts",
+  "src/monitoring/recovery/inflight-content.ts",
+  "src/plugins/defaults/memory/context-search/sources/conversations.ts",
+  "src/plugins/defaults/memory/graph/image-ref-utils.ts",
+  "src/plugins/defaults/memory/indexer.ts",
+  "src/plugins/defaults/memory/memory-retrospective-accounting.ts",
+  "src/plugins/defaults/memory/substrate/sweep-job.ts",
+  "src/plugins/defaults/memory/v1/graph/extraction.ts",
+  "src/plugins/defaults/memory/v1/job-handlers/backfill.ts",
+  "src/plugins/defaults/memory/v1/job-handlers/embedding.ts",
+  "src/plugins/defaults/memory/v1/job-handlers/index-maintenance.ts",
+  "src/plugins/defaults/memory/v2/harness/oracle.ts",
+  "src/plugins/defaults/memory/v2/harness/replay-input.ts",
+  "src/plugins/defaults/memory/v3-eval/eval-packets.ts",
+  "src/plugins/defaults/memory/v3/prune.ts",
+  "src/plugins/defaults/memory/v3/selection-log-store.ts",
+  "src/runtime/pre-first-message-gate.ts",
+  "src/runtime/routes/log-export-routes.ts",
+  "src/runtime/routes/surface-conversation-resolver.ts",
+  "src/telemetry/turn-events-store.ts",
+  "src/telemetry/turn-trace-store.ts",
+  "src/workspace/migrations/rebuild-conversation-disk-view.ts",
+];
+
+const DRIZZLE_READ = /\.from\(\s*messages\s*\)/;
+const RAW_SQL_READ = /FROM\s+messages\b/;
+
+function isExempt(relPath: string): boolean {
+  const parts = relPath.split(sep);
+  return (
+    parts[1] === "persistence" ||
+    parts.includes("__tests__") ||
+    relPath.endsWith(".test.ts")
+  );
+}
+
+async function scanDirectReaders(): Promise<string[]> {
+  const glob = new Glob("**/*.ts");
+  const found: string[] = [];
+  for await (const file of glob.scan({ cwd: SRC_ABS, absolute: true })) {
+    const relPath = join(SRC_REL, relative(SRC_ABS, file));
+    if (isExempt(relPath)) {
+      continue;
+    }
+    const source = readFileSync(file, "utf-8");
+    if (DRIZZLE_READ.test(source) || RAW_SQL_READ.test(source)) {
+      found.push(relPath);
+    }
+  }
+  return found.sort();
+}
+
+describe("messages read boundary", () => {
+  test("no new direct messages reads beyond the audited baseline", async () => {
+    const found = await scanDirectReaders();
+
+    if (process.env.UPDATE_MESSAGES_READ_BASELINE === "1") {
+      console.log(JSON.stringify(found, null, 2));
+    }
+
+    const baseline = new Set(BASELINE);
+    const newReaders = found.filter((file) => !baseline.has(file));
+    expect(
+      newReaders,
+      `New direct reads of the messages table outside persistence/ (route ` +
+        `through an accessor in persistence/message-reads.ts, or audit the ` +
+        `read, state its visibility decision at the site, and baseline it):`,
+    ).toEqual([]);
+
+    const foundSet = new Set(found);
+    const stale = BASELINE.filter((file) => !foundSet.has(file));
+    expect(
+      stale,
+      "Stale baseline entries (the file no longer reads messages directly; remove it so coverage cannot rot):",
+    ).toEqual([]);
+  });
+});

--- a/assistant/src/__tests__/messages-read-boundary-guard.test.ts
+++ b/assistant/src/__tests__/messages-read-boundary-guard.test.ts
@@ -11,10 +11,10 @@ import { Glob } from "bun";
  * completeness, and each read encodes a visibility decision (completed
  * history vs. any row). `persistence/` owns that contract: named accessors in
  * `message-reads.ts` and the history readers in `conversation-crud.ts` state
- * their decision in their name; everything else should go through them. The
- * fork-corruption and phantom-turn incidents both came from direct readers
- * that silently re-decided visibility, so new direct reads are a reviewed
- * exception, not a default.
+ * their decision in their name; everything else should go through them. A
+ * direct reader that re-decides visibility on its own is how the contract
+ * fails silently, so a new direct read is a reviewed exception, not a
+ * default.
  *
  * The BASELINE lists every file outside `persistence/` that reads the table
  * directly today. Each entry has been audited and carries its visibility
@@ -23,10 +23,10 @@ import { Glob } from "bun";
  * and baseline it with a site comment explaining the decision in your PR),
  * and when a baseline entry goes stale (remove it, so coverage cannot rot).
  *
- * Detection is deliberately shape-based (`.from(messages)` for drizzle,
- * `FROM messages` for raw SQL): this is a ratchet against sprawl, not a
- * proof, and matching the two read shapes keeps it free of false positives
- * from unrelated identifiers.
+ * Detection is deliberately shape-based (from/join of `messages` in drizzle
+ * builders, `FROM messages` / `JOIN messages` in raw SQL): this is a ratchet
+ * against sprawl, not a proof, and matching the read shapes keeps it free of
+ * false positives from unrelated identifiers.
  *
  * Regenerate after an intentional change with:
  *   UPDATE_MESSAGES_READ_BASELINE=1 bun test src/__tests__/messages-read-boundary-guard.test.ts
@@ -71,8 +71,9 @@ const BASELINE: Readonly<Record<string, number>> = {
   "src/workspace/migrations/rebuild-conversation-disk-view.ts": 1,
 };
 
-const DRIZZLE_READ = /\.from\(\s*messages\s*\)/g;
-const RAW_SQL_READ = /FROM\s+messages\b/g;
+const DRIZZLE_READ =
+  /\.(?:from|innerJoin|leftJoin|rightJoin|fullJoin)\(\s*messages\s*[,)]/g;
+const RAW_SQL_READ = /(?:FROM|JOIN)\s+messages\b/g;
 
 function isExempt(relPath: string): boolean {
   const parts = relPath.split(sep);

--- a/assistant/src/__tests__/messages-read-boundary-guard.test.ts
+++ b/assistant/src/__tests__/messages-read-boundary-guard.test.ts
@@ -36,36 +36,43 @@ import { Glob } from "bun";
 const SRC_REL = "src";
 const SRC_ABS = join(process.cwd(), SRC_REL);
 
-/** Files outside persistence/ with audited direct reads of `messages`. */
-const BASELINE: readonly string[] = [
-  "src/apps/app-store.ts",
-  "src/daemon/credential-transcript-scrub.ts",
-  "src/live-voice/live-voice-archive.ts",
-  "src/monitoring/recovery/inflight-content.ts",
-  "src/plugins/defaults/memory/context-search/sources/conversations.ts",
-  "src/plugins/defaults/memory/graph/image-ref-utils.ts",
-  "src/plugins/defaults/memory/indexer.ts",
-  "src/plugins/defaults/memory/memory-retrospective-accounting.ts",
-  "src/plugins/defaults/memory/substrate/sweep-job.ts",
-  "src/plugins/defaults/memory/v1/graph/extraction.ts",
-  "src/plugins/defaults/memory/v1/job-handlers/backfill.ts",
-  "src/plugins/defaults/memory/v1/job-handlers/embedding.ts",
-  "src/plugins/defaults/memory/v1/job-handlers/index-maintenance.ts",
-  "src/plugins/defaults/memory/v2/harness/oracle.ts",
-  "src/plugins/defaults/memory/v2/harness/replay-input.ts",
-  "src/plugins/defaults/memory/v3-eval/eval-packets.ts",
-  "src/plugins/defaults/memory/v3/prune.ts",
-  "src/plugins/defaults/memory/v3/selection-log-store.ts",
-  "src/runtime/pre-first-message-gate.ts",
-  "src/runtime/routes/log-export-routes.ts",
-  "src/runtime/routes/surface-conversation-resolver.ts",
-  "src/telemetry/turn-events-store.ts",
-  "src/telemetry/turn-trace-store.ts",
-  "src/workspace/migrations/rebuild-conversation-disk-view.ts",
-];
+/**
+ * Audited direct readers outside persistence/, as file -> count of matching
+ * read sites. Counts, not just filenames: a new read added inside an
+ * already-baselined file must fail the ratchet too, since each site carries
+ * its own visibility decision. A same-file refactor that replaces one read
+ * with another at equal count passes; that is accepted ratchet granularity
+ * (the diff still shows the site to its reviewer).
+ */
+const BASELINE: Readonly<Record<string, number>> = {
+  "src/apps/app-store.ts": 1,
+  "src/daemon/credential-transcript-scrub.ts": 1,
+  "src/live-voice/live-voice-archive.ts": 1,
+  "src/monitoring/recovery/inflight-content.ts": 2,
+  "src/plugins/defaults/memory/context-search/sources/conversations.ts": 1,
+  "src/plugins/defaults/memory/graph/image-ref-utils.ts": 1,
+  "src/plugins/defaults/memory/indexer.ts": 2,
+  "src/plugins/defaults/memory/memory-retrospective-accounting.ts": 4,
+  "src/plugins/defaults/memory/substrate/sweep-job.ts": 1,
+  "src/plugins/defaults/memory/v1/graph/extraction.ts": 3,
+  "src/plugins/defaults/memory/v1/job-handlers/backfill.ts": 1,
+  "src/plugins/defaults/memory/v1/job-handlers/embedding.ts": 1,
+  "src/plugins/defaults/memory/v1/job-handlers/index-maintenance.ts": 1,
+  "src/plugins/defaults/memory/v2/harness/oracle.ts": 1,
+  "src/plugins/defaults/memory/v2/harness/replay-input.ts": 1,
+  "src/plugins/defaults/memory/v3-eval/eval-packets.ts": 2,
+  "src/plugins/defaults/memory/v3/prune.ts": 1,
+  "src/plugins/defaults/memory/v3/selection-log-store.ts": 1,
+  "src/runtime/pre-first-message-gate.ts": 1,
+  "src/runtime/routes/log-export-routes.ts": 1,
+  "src/runtime/routes/surface-conversation-resolver.ts": 2,
+  "src/telemetry/turn-events-store.ts": 2,
+  "src/telemetry/turn-trace-store.ts": 2,
+  "src/workspace/migrations/rebuild-conversation-disk-view.ts": 1,
+};
 
-const DRIZZLE_READ = /\.from\(\s*messages\s*\)/;
-const RAW_SQL_READ = /FROM\s+messages\b/;
+const DRIZZLE_READ = /\.from\(\s*messages\s*\)/g;
+const RAW_SQL_READ = /FROM\s+messages\b/g;
 
 function isExempt(relPath: string): boolean {
   const parts = relPath.split(sep);
@@ -76,20 +83,23 @@ function isExempt(relPath: string): boolean {
   );
 }
 
-async function scanDirectReaders(): Promise<string[]> {
+async function scanDirectReaders(): Promise<Map<string, number>> {
   const glob = new Glob("**/*.ts");
-  const found: string[] = [];
+  const found = new Map<string, number>();
   for await (const file of glob.scan({ cwd: SRC_ABS, absolute: true })) {
     const relPath = join(SRC_REL, relative(SRC_ABS, file));
     if (isExempt(relPath)) {
       continue;
     }
     const source = readFileSync(file, "utf-8");
-    if (DRIZZLE_READ.test(source) || RAW_SQL_READ.test(source)) {
-      found.push(relPath);
+    const count =
+      [...source.matchAll(DRIZZLE_READ)].length +
+      [...source.matchAll(RAW_SQL_READ)].length;
+    if (count > 0) {
+      found.set(relPath, count);
     }
   }
-  return found.sort();
+  return found;
 }
 
 describe("messages read boundary", () => {
@@ -97,23 +107,27 @@ describe("messages read boundary", () => {
     const found = await scanDirectReaders();
 
     if (process.env.UPDATE_MESSAGES_READ_BASELINE === "1") {
-      console.log(JSON.stringify(found, null, 2));
+      console.log(
+        JSON.stringify(Object.fromEntries([...found].sort()), null, 2),
+      );
     }
 
-    const baseline = new Set(BASELINE);
-    const newReaders = found.filter((file) => !baseline.has(file));
+    const grown = [...found]
+      .filter(([file, count]) => count > (BASELINE[file] ?? 0))
+      .map(([file, count]) => `${file}: ${BASELINE[file] ?? 0} -> ${count}`);
     expect(
-      newReaders,
+      grown,
       `New direct reads of the messages table outside persistence/ (route ` +
         `through an accessor in persistence/message-reads.ts, or audit the ` +
         `read, state its visibility decision at the site, and baseline it):`,
     ).toEqual([]);
 
-    const foundSet = new Set(found);
-    const stale = BASELINE.filter((file) => !foundSet.has(file));
+    const shrunk = Object.entries(BASELINE)
+      .filter(([file, count]) => (found.get(file) ?? 0) < count)
+      .map(([file, count]) => `${file}: ${count} -> ${found.get(file) ?? 0}`);
     expect(
-      stale,
-      "Stale baseline entries (the file no longer reads messages directly; remove it so coverage cannot rot):",
+      shrunk,
+      "Stale baseline entries (fewer direct reads than baselined; ratchet the count down so coverage cannot rot):",
     ).toEqual([]);
   });
 });

--- a/assistant/src/apps/app-store.ts
+++ b/assistant/src/apps/app-store.ts
@@ -1422,6 +1422,9 @@ export function backfillAppConversationIds(): void {
   }
 
   try {
+    // Unfinalized rows cannot match: their content is a { ref } pointer,
+    // never inline surface JSON, so this scan sees finalized content only by
+    // shape. No completeness predicate needed.
     const rows = rawAll<{ conversation_id: string; content: string }>(
       "apps:backfillConversationIds",
       `SELECT conversation_id, content FROM messages WHERE content LIKE '%"type":"ui_surface"%'`,


### PR DESCRIPTION
## TL;DR

Final PR of the messages-reader consolidation (Part of JARVIS-1478). Adds a repo-scan ratchet, modeled on the plugin import-boundary guard, that fails CI when a file outside `persistence/` gains a direct read of the `messages` table (`.from(messages)` or raw `FROM messages`) beyond an audited baseline — and when a baseline entry goes stale, so coverage cannot rot in either direction.

This is the payoff PR: it converts the arc from "cleaned up" to "stays clean."

## Why this is needed

Every read of `messages` encodes a visibility decision (completed history vs. any row), and both incidents this arc fixed — fork corruption copying mid-stream rows, phantom user turns in telemetry — came from direct readers that re-decided visibility silently. The review cycle proved the sprawl mode concretely: the phantom-turn fix landed at the shared fragment and still missed a fourth consumer that had *inlined a copy* of the predicate. A ratchet catches that class of drift the day it is written, not months later via a corrupted fork.

## What changes for the user

Nothing at runtime — this is a test. For engineers: adding a direct `messages` read outside `persistence/` now fails CI with instructions (route through an accessor in `message-reads.ts`, or audit the read, state its visibility decision at the site, and baseline it in the PR).

## Why this is the right way to do it

- **Ratchet-with-baseline, not a wall.** Every baseline entry is a read that was audited during this arc and carries its visibility decision as a comment at the site: the correct-by-construction batch jobs, the safe-by-provenance id lookups, the deliberate any-state reads (log export, crash recovery), and the plugin family (which the plugin import-boundary guard keeps from deepening its host coupling). Blanket-forbidding them would be a suppression wall; baselining them keeps the audit's value while stopping new sprawl.
- **Shape-based detection on purpose.** Matching the two read shapes keeps the guard free of false positives from unrelated identifiers; it is a sprawl ratchet, not a soundness proof. Both directions are enforced (new readers fail; stale entries fail), mirroring the plugin guard's design.
- **Seeding the baseline was itself an audit**: it surfaced one reader the census had missed (`app-store`'s surface backfill scan), which is audited and annotated in this PR (safe by shape: unfinalized rows' `{ ref }` content cannot match the inline surface-JSON probe).

## Why this is safe

- Zero runtime change; the only production edit is a comment.
- Baseline parity with the actual tree was verified by replicating the scan independently before pushing (local `bun test` is hook-blocked in this environment; CI runs the guard itself).
- Regeneration instructions are in the guard's doc (`UPDATE_MESSAGES_READ_BASELINE=1`), same convention as the plugin boundary guard.

## Arc status after this merges

JARVIS-1478's enforcement outcome is in place: the visibility contract lives in `persistence/` (accessors + history readers), every remaining direct read is audited and named, and new ones are a reviewed exception. Remaining on the ticket: the eventual `@vellumai/plugin-api` read surface for the plugin family's baselined reads (ledger L9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40587" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->