### PR TITLE
test: typed fixture factories for actor identity, and the two bugs they caught

### DIFF
--- a/assistant/src/__tests__/helpers/mock-actor-context.ts
+++ b/assistant/src/__tests__/helpers/mock-actor-context.ts
@@ -1,0 +1,49 @@
+/**
+ * Typed fixture factories for actor identity in tests.
+ *
+ * Test doubles used to hand-roll `TrustContext` / `AuthContext` literals and
+ * cast them quiet, which let wrong-shaped fixtures ship: a trust context with
+ * no `trustClass`, an auth context carrying two of seven required fields.
+ * These factories produce complete, type-checked values with conservative
+ * defaults, so a fixture states only what its test is about and the compiler
+ * guards the rest.
+ *
+ * Type-only imports keep this helper out of the runtime import graph, per the
+ * test-machinery isolation rules in `assistant/CLAUDE.md`.
+ */
+
+import type { TrustContext } from "../../daemon/trust-context-types.js";
+import type { AuthContext, Scope } from "../../runtime/auth/types.js";
+
+/**
+ * A complete `TrustContext`. Defaults to the guardian on the vellum channel;
+ * pass overrides for anything the test cares about.
+ */
+export function mockTrustContext(
+  overrides: Partial<TrustContext> = {},
+): TrustContext {
+  return {
+    sourceChannel: "vellum",
+    trustClass: "guardian",
+    ...overrides,
+  };
+}
+
+/**
+ * A complete `AuthContext`. Defaults to a local principal with no scopes, the
+ * conservative shape, so a test that forgets to opt in exercises the
+ * restrictive branch rather than a silently permissive one.
+ */
+export function mockAuthContext(
+  overrides: Partial<AuthContext> = {},
+): AuthContext {
+  return {
+    subject: "local:self:test",
+    principalType: "local",
+    assistantId: "self",
+    scopeProfile: "local_v1",
+    scopes: new Set<Scope>(),
+    policyEpoch: 0,
+    ...overrides,
+  };
+}

--- a/assistant/src/__tests__/helpers/mock-actor-context.ts
+++ b/assistant/src/__tests__/helpers/mock-actor-context.ts
@@ -1,12 +1,12 @@
 /**
  * Typed fixture factories for actor identity in tests.
  *
- * Test doubles used to hand-roll `TrustContext` / `AuthContext` literals and
- * cast them quiet, which let wrong-shaped fixtures ship: a trust context with
- * no `trustClass`, an auth context carrying two of seven required fields.
- * These factories produce complete, type-checked values with conservative
- * defaults, so a fixture states only what its test is about and the compiler
- * guards the rest.
+ * A fixture built here is a complete, type-checked `TrustContext` or
+ * `AuthContext` with conservative defaults; a test overrides only the fields
+ * its scenario is about, and the compiler guards the rest. Hand-rolled
+ * literals cannot make that guarantee: a missing required field needs a cast
+ * to satisfy the checker, and the cast then hides every other mistake in the
+ * literal.
  *
  * Type-only imports keep this helper out of the runtime import graph, per the
  * test-machinery isolation rules in `assistant/CLAUDE.md`.

--- a/assistant/src/__tests__/subagent-call-site-routing.test.ts
+++ b/assistant/src/__tests__/subagent-call-site-routing.test.ts
@@ -184,8 +184,11 @@ import {
   clearConversations,
   setConversation,
 } from "../daemon/conversation-registry.js";
+import type { TrustContext } from "../daemon/trust-context-types.js";
 import { CallSiteRoutingProvider } from "../providers/call-site-routing.js";
 import { SubagentManager } from "../subagent/manager.js";
+import { mockAuthContext } from "./helpers/mock-actor-context.js";
+import { asConversation } from "./helpers/mock-conversation.js";
 
 // Seed the workspace `llm` config per-case. The real loader schema-merges the
 // raw fragment over defaults exactly as the code path reads it.
@@ -304,26 +307,29 @@ describe("SubagentManager — provider call-site routing", () => {
   test("copies parent guardian and auth context into spawned conversation", async () => {
     setLlmConfig(makeLlmFixture());
 
-    const parentTrustContext = {
+    const parentTrustContext: TrustContext = {
       sourceChannel: "vellum",
       trustClass: "guardian",
       guardianPrincipalId: "guardian-1",
       guardianExternalUserId: "guardian-1",
     };
-    const parentAuthContext = {
+    const parentAuthContext = mockAuthContext({
       subject: "local:self:parent-perms",
       actorPrincipalId: "guardian-1",
-    };
+    });
 
     capturedConversations.length = 0;
     clearConversations();
     const manager = new SubagentManager();
-    setConversation("parent-perms", {
-      trustContext: parentTrustContext,
-      getAuthContext: () => parentAuthContext,
-      assistantId: "self",
-      getCurrentSystemPrompt: () => "parent system",
-    } as any);
+    setConversation(
+      "parent-perms",
+      asConversation({
+        trustContext: parentTrustContext,
+        getAuthContext: () => parentAuthContext,
+        assistantId: "self",
+        getCurrentSystemPrompt: () => "parent system",
+      }),
+    );
 
     await manager.spawn(
       {
@@ -354,11 +360,14 @@ describe("SubagentManager — provider call-site routing", () => {
     capturedConversations.length = 0;
     clearConversations();
     const manager = new SubagentManager();
-    setConversation("parent-scoped", {
-      enabledPlugins: parentScope,
-      getAuthContext: () => undefined,
-      getCurrentSystemPrompt: () => "parent system",
-    } as any);
+    setConversation(
+      "parent-scoped",
+      asConversation({
+        enabledPlugins: parentScope,
+        getAuthContext: () => undefined,
+        getCurrentSystemPrompt: () => "parent system",
+      }),
+    );
 
     await manager.spawn(
       {
@@ -383,11 +392,14 @@ describe("SubagentManager — provider call-site routing", () => {
     capturedConversations.length = 0;
     clearConversations();
     const manager = new SubagentManager();
-    setConversation("parent-unscoped", {
-      enabledPlugins: null,
-      getAuthContext: () => undefined,
-      getCurrentSystemPrompt: () => "parent system",
-    } as any);
+    setConversation(
+      "parent-unscoped",
+      asConversation({
+        enabledPlugins: null,
+        getAuthContext: () => undefined,
+        getCurrentSystemPrompt: () => "parent system",
+      }),
+    );
 
     await manager.spawn(
       {

--- a/assistant/src/permissions/confirmation-guardian-request.test.ts
+++ b/assistant/src/permissions/confirmation-guardian-request.test.ts
@@ -19,17 +19,19 @@ mock.module("../util/logger.js", () => ({
 }));
 
 mock.module("../daemon/conversation-registry.js", () => ({
-  findConversation: () => ({
-    assistantId: "self",
-    trustContext: {
-      sourceChannel: "telegram",
-      requesterExternalUserId: "tg-user-1",
-      requesterChatId: "tg-chat-1",
-      guardianExternalUserId: "tg-guardian-1",
-      guardianPrincipalId: "principal-1",
-    },
-    hasPendingConfirmation: () => confirmationPending,
-  }),
+  findConversation: () =>
+    asConversation({
+      assistantId: "self",
+      trustContext: {
+        trustClass: "trusted_contact",
+        sourceChannel: "telegram",
+        requesterExternalUserId: "tg-user-1",
+        requesterChatId: "tg-chat-1",
+        guardianExternalUserId: "tg-guardian-1",
+        guardianPrincipalId: "principal-1",
+      } satisfies TrustContext,
+      hasPendingConfirmation: () => confirmationPending,
+    }),
 }));
 
 mock.module("../channels/gateway-guardian-requests.js", () => ({
@@ -50,7 +52,9 @@ mock.module("../runtime/confirmation-request-guardian-bridge.js", () => ({
   },
 }));
 
+import { asConversation } from "../__tests__/helpers/mock-conversation.js";
 import type { AssistantEvent } from "../api/index.js";
+import type { TrustContext } from "../daemon/trust-context-types.js";
 import { createGuardianRequestForConfirmation } from "./confirmation-guardian-request.js";
 
 const MSG = {

--- a/assistant/src/permissions/question-guardian-request.test.ts
+++ b/assistant/src/permissions/question-guardian-request.test.ts
@@ -7,7 +7,10 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { mockTrustContext } from "../__tests__/helpers/mock-actor-context.js";
+import { asConversation } from "../__tests__/helpers/mock-conversation.js";
 import type { QuestionRequestEvent } from "../api/events/question-request.js";
+import type { TrustContext } from "../daemon/trust-context-types.js";
 
 const createGuardianRequestMock = mock(
   (params: Record<string, unknown>): Promise<Record<string, unknown>> =>
@@ -21,13 +24,18 @@ const withdrawCardsMock = mock((_params: Record<string, unknown>) =>
   Promise.resolve(),
 );
 
-let trustContext: Record<string, unknown> | undefined;
+let trustContext: TrustContext | undefined;
 let pendingInteraction: { kind: string } | undefined;
 let rowAfterExpire: Record<string, unknown> | null = null;
 
 mock.module("../daemon/conversation-registry.js", () => ({
   findConversation: (_id: string) =>
-    trustContext ? { trustContext, assistantId: "self" } : undefined,
+    trustContext
+      ? asConversation({
+          trustContext,
+          assistantId: "self",
+        })
+      : undefined,
 }));
 mock.module("../channels/gateway-guardian-requests.js", () => ({
   createGuardianRequest: (params: Record<string, unknown>) =>
@@ -77,9 +85,9 @@ function makeEvent(
 }
 
 function guardianTrustContext(
-  overrides: Record<string, unknown> = {},
-): Record<string, unknown> {
-  return {
+  overrides: Partial<TrustContext> = {},
+): TrustContext {
+  return mockTrustContext({
     trustClass: "guardian",
     sourceChannel: "telegram",
     guardianPrincipalId: "prin-guardian",
@@ -87,7 +95,7 @@ function guardianTrustContext(
     requesterExternalUserId: "tg-guardian",
     requesterChatId: "chat-1",
     ...overrides,
-  };
+  });
 }
 
 beforeEach(() => {


### PR DESCRIPTION
## TL;DR

Typed fixture factories for actor identity in tests, plus the two broken fixtures the type checker found the moment they stopped being cast quiet.

No production code. Part of LUM-3161's cleanup arc; first of two small test-infrastructure PRs.

## Why this is needed

Test doubles hand-roll `TrustContext` / `AuthContext` literals and silence them with casts (`as never`, `Record<string, unknown>`), so a wrong-shaped fixture ships without a compile error. Typing them found two that were genuinely wrong:

| Fixture | Defect |
|---|---|
| `confirmation-guardian-request.test.ts` trust double | **Never carried `trustClass`** — a required field. The suite has exercised that path with an undefined trust class since it was written. |
| `subagent-call-site-routing.test.ts` auth context | Supplied 2 of `AuthContext`'s 7 required fields (no `principalType`, `assistantId`, `scopeProfile`, `scopes`, `policyEpoch`). |

Neither was hiding a production bug that we know of, but both mean the tests were exercising shapes production never produces — which is precisely how doubles drift from reality.

## What changed

`__tests__/helpers/mock-actor-context.ts`: `mockTrustContext()` and `mockAuthContext()`. Complete, type-checked values with conservative defaults (guardian-on-vellum; local principal with no scopes), overridable per test. A fixture now states only what its test is about; the compiler guards the rest.

The two guardian-request suites build their fixtures on the factories, typed end to end, casts removed.

## What changes in behaviour

Nothing in production — this touches only tests. The confirmation suite now runs with the `trusted_contact` trust class its scenario describes, rather than `undefined`.

## Follow-ups

A second PR de-casts the remaining conversation doubles (agent-loop, runtime-assembly, subagent suites) on top of this one. The accessor work on #40577 then rebases to a production-only diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40588" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->