### PR TITLE
test: de-cast the conversation doubles and fix the shapes underneath

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop-inference-profile.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-inference-profile.test.ts
@@ -325,6 +325,8 @@ mock.module("../persistence/llm-request-log-store.js", () => ({
 
 import type { Conversation } from "../daemon/conversation.js";
 import { runAgentLoopImpl } from "../daemon/conversation-agent-loop.js";
+import type { QueueDrainReason } from "../daemon/conversation-queue-manager.js";
+import { asConversation } from "./helpers/mock-conversation.js";
 
 // ── Test helpers ─────────────────────────────────────────────────────
 
@@ -363,7 +365,7 @@ function makeCtx(
     ];
   };
 
-  return {
+  return asConversation({
     conversationId: "test-conv",
     messages: [
       { role: "user", content: [{ type: "text", text: "Hello" }] },
@@ -433,12 +435,7 @@ function makeCtx(
     skillProjectionCache:
       new Map() as unknown as Conversation["skillProjectionCache"],
 
-    usageStats: {
-      totalInputTokens: 0,
-      totalOutputTokens: 0,
-      totalEstimatedCost: 0,
-      model: "",
-    },
+    usageStats: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
     turnCount: 0,
 
     lastAssistantAttachments: [],
@@ -456,12 +453,12 @@ function makeCtx(
     getQueueDepth: () => 0,
     hasQueuedMessages: () => false,
     canHandoffAtCheckpoint: () => false,
-    drainQueue: (_reason?: string) => {},
+    drainQueue: async (_reason?: QueueDrainReason) => {},
     // Forwards to drainQueue so tests that spy the drain observe the agent
     // loop's post-turn kick through the guarded entry point.
     kickDrainQueue(
-      this: { drainQueue: (reason?: string) => unknown },
-      reason: string = "loop_complete",
+      this: { drainQueue: (reason?: QueueDrainReason) => Promise<void> },
+      reason: QueueDrainReason = "loop_complete",
       _origin?: string,
     ) {
       return this.drainQueue(reason);
@@ -493,7 +490,7 @@ function makeCtx(
     } as unknown as Conversation["graphMemory"],
 
     ...overrides,
-  } as unknown as Conversation;
+  });
 }
 
 // ── Tests ────────────────────────────────────────────────────────────

--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -472,6 +472,8 @@ mock.module("../memory/archive-store.js", () => ({
 import { AgentLoop } from "../agent/loop.js";
 import type { Conversation } from "../daemon/conversation.js";
 import { runAgentLoopImpl } from "../daemon/conversation-agent-loop.js";
+import type { QueueDrainReason } from "../daemon/conversation-queue-manager.js";
+import { asConversation } from "./helpers/mock-conversation.js";
 import {
   createMockProvider,
   type ScriptedResponse,
@@ -519,7 +521,7 @@ function makeCtx(
     toolExecutor,
   });
 
-  const ctx = {
+  const ctx = asConversation({
     conversationId: "test-conv",
     messages: [
       { role: "user", content: [{ type: "text", text: "Hello" }] },
@@ -572,12 +574,7 @@ function makeCtx(
     skillProjectionCache:
       new Map() as unknown as Conversation["skillProjectionCache"],
 
-    usageStats: {
-      totalInputTokens: 0,
-      totalOutputTokens: 0,
-      totalEstimatedCost: 0,
-      model: "",
-    },
+    usageStats: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
     turnCount: 0,
 
     lastAssistantAttachments: [],
@@ -595,12 +592,12 @@ function makeCtx(
     getQueueDepth: () => 0,
     hasQueuedMessages: () => false,
     canHandoffAtCheckpoint: () => false,
-    drainQueue: (_reason?: string) => {},
+    drainQueue: async (_reason?: QueueDrainReason) => {},
     // Forwards to drainQueue so tests that spy the drain observe the agent
     // loop's post-turn kick through the guarded entry point.
     kickDrainQueue(
-      this: { drainQueue: (reason?: string) => unknown },
-      reason: string = "loop_complete",
+      this: { drainQueue: (reason?: QueueDrainReason) => Promise<void> },
+      reason: QueueDrainReason = "loop_complete",
       _origin?: string,
     ) {
       return this.drainQueue(reason);
@@ -632,7 +629,7 @@ function makeCtx(
     } as unknown as Conversation["graphMemory"],
 
     ...ctxOverrides,
-  } as unknown as Conversation;
+  });
   // The convergence driver resolves the turn-scoped overflow ladder off the
   // manager; give every fake manager the ladder methods unless a test supplied
   // its own.

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -268,7 +268,18 @@ const setConversationHistoryStrippedAtMock = mock(
 const updateConversationSlackContextWatermarkMock = mock(
   (_conversationId: string, _watermarkTs: string, _compactedAt?: number) => {},
 );
-let mockConversationRow: Record<string, unknown> = {
+interface MockConversationRow {
+  conversationType?: string;
+  source?: string;
+  contextSummary?: string | null;
+  contextCompactedMessageCount?: number;
+  contextCompactedAt?: number | null;
+  slackContextCompactionWatermarkTs?: string | null;
+  lastNotifiedInferenceProfile?: string | null;
+  processingStartedAt?: string | null;
+  [key: string]: unknown;
+}
+let mockConversationRow: MockConversationRow = {
   id: "conv-1",
   createdAt: 1_700_000_000_000,
   contextSummary: null,
@@ -675,7 +686,9 @@ import {
   applyCompactionResult,
   runAgentLoopImpl,
 } from "../daemon/conversation-agent-loop.js";
+import type { QueueDrainReason } from "../daemon/conversation-queue-manager.js";
 import { settleTurnTail } from "../daemon/turn-tail-chain.js";
+import { asConversation } from "./helpers/mock-conversation.js";
 import {
   createMockProvider,
   type ScriptedResponse,
@@ -731,7 +744,7 @@ function makeCtx(
     toolExecutor,
   });
 
-  const ctx = {
+  const ctx = asConversation({
     conversationId: "test-conv",
     messages: [
       { role: "user", content: [{ type: "text", text: "Hello" }] },
@@ -791,12 +804,7 @@ function makeCtx(
     skillProjectionCache:
       new Map() as unknown as Conversation["skillProjectionCache"],
 
-    usageStats: {
-      totalInputTokens: 0,
-      totalOutputTokens: 0,
-      totalEstimatedCost: 0,
-      model: "",
-    },
+    usageStats: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
     turnCount: 0,
 
     lastAssistantAttachments: [],
@@ -814,12 +822,12 @@ function makeCtx(
     getQueueDepth: () => 0,
     hasQueuedMessages: () => false,
     canHandoffAtCheckpoint: () => false,
-    drainQueue: (_reason?: string) => {},
+    drainQueue: async (_reason?: QueueDrainReason) => {},
     // Forwards to drainQueue so tests that spy the drain observe the agent
     // loop's post-turn kick through the guarded entry point.
     kickDrainQueue(
-      this: { drainQueue: (reason?: string) => unknown },
-      reason: string = "loop_complete",
+      this: { drainQueue: (reason?: QueueDrainReason) => Promise<void> },
+      reason: QueueDrainReason = "loop_complete",
       _origin?: string,
     ) {
       return this.drainQueue(reason);
@@ -851,7 +859,7 @@ function makeCtx(
     } as unknown as Conversation["graphMemory"],
 
     ...ctxOverrides,
-  } as unknown as Conversation;
+  });
   // Reactive overflow recovery resolves the turn-scoped reduction ladder off
   // the manager; give every fake manager the ladder methods unless a test
   // supplied its own.
@@ -1795,7 +1803,7 @@ describe("session-agent-loop", () => {
         ],
         toolExecutor: async () => ({ content: "file content", isError: false }),
         canHandoffAtCheckpoint: () => true,
-      } as unknown as Partial<Conversation>);
+      });
 
       await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
 
@@ -1826,7 +1834,7 @@ describe("session-agent-loop", () => {
         ],
         toolExecutor: async () => ({ content: "content", isError: false }),
         canHandoffAtCheckpoint: () => false,
-      } as unknown as Partial<Conversation>);
+      });
 
       await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
 
@@ -1975,13 +1983,13 @@ describe("session-agent-loop", () => {
 
     test("drains queue after completion", async () => {
       // GIVEN a real loop that answers in a single text turn
-      let drainReason: string | undefined;
+      let drainReason: QueueDrainReason | undefined;
       const ctx = makeCtx({
         providerResponses: [textResponse("ok")],
-        drainQueue: (reason: string) => {
+        drainQueue: async (reason?: QueueDrainReason) => {
           drainReason = reason;
         },
-      } as unknown as Partial<Conversation>);
+      });
 
       // WHEN the orchestrator runs the turn to completion
       await runAgentLoopImpl(ctx, "hi", "msg-1", () => {});
@@ -2018,10 +2026,10 @@ describe("session-agent-loop", () => {
         abortController,
         // Fire the watchdog quickly instead of the ~45s production default.
         abortWatchdogMs: 30,
-        drainQueue: (reason: string) => {
+        drainQueue: async (reason?: QueueDrainReason) => {
           drainReason = reason;
         },
-      } as unknown as Partial<Conversation>);
+      });
 
       try {
         // WHEN the orchestrator runs the turn
@@ -2520,7 +2528,7 @@ describe("session-agent-loop", () => {
           },
         ],
         toolExecutor: async () => ({ content: "file content", isError: false }),
-      } as unknown as Partial<Conversation>);
+      });
 
       await runAgentLoopImpl(ctx, "hello", "msg-user-daily", () => {});
 

--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -103,6 +103,7 @@ mock.module("../daemon/date-context.js", () => ({
   formatTurnTimestamp: () => FIXED_TURN_TIMESTAMP,
 }));
 
+import type { SurfaceDataByType } from "../api/surfaces.js";
 import { resolveCallSiteConfig } from "../config/llm-resolver.js";
 import { LLMSchema } from "../config/schemas/llm.js";
 import { REFUSAL_FALLBACK_TEXT } from "../context/refusal-quarantine.js";
@@ -136,7 +137,7 @@ import {
   stripInjectionsForCompaction,
   stripNowScratchpad,
 } from "../daemon/conversation-runtime-assembly.js";
-import type { SurfaceData, SurfaceType } from "../daemon/message-protocol.js";
+import type { SurfaceStateEntry } from "../daemon/conversation-surface-state.js";
 import { buildPkbReminder } from "../daemon/pkb-reminder-builder.js";
 import type { TrustContext } from "../daemon/trust-context-types.js";
 import {
@@ -161,6 +162,7 @@ import { wrapUntrustedContent } from "../security/untrusted-content.js";
 import { getSubagentManager } from "../subagent/index.js";
 import type { SubagentState } from "../subagent/types.js";
 import { getWorkspacePromptPath } from "../util/platform.js";
+import { asConversation } from "./helpers/mock-conversation.js";
 
 // `applyRuntimeInjections` self-resolves the Slack active-thread focus block by
 // reading the live conversation's persisted message rows, so the schema must
@@ -215,27 +217,30 @@ function seedActiveSurfaceConversation(
   conversationId: string,
   workspaceText: string,
   surfaceId: string,
-  data: SurfaceData,
+  data: SurfaceDataByType["dynamic_page"],
   channelCapabilities?: ChannelCapabilities,
   commandIntent?: { type: string; payload?: string; languageCode?: string },
   currentTurnTemporalSnapshot?: {
     clientTimezone: string | null;
+    timeSinceLastMessage: string | null;
   },
 ): void {
-  setConversation(conversationId, {
+  setConversation(
     conversationId,
-    workingDir: "/sandbox",
-    workspaceTopLevelContext: workspaceText,
-    workspaceTopLevelDirty: false,
-    currentActiveSurfaceId: surfaceId,
-    surfaceState: new Map<
-      string,
-      { surfaceType: SurfaceType; data: SurfaceData }
-    >([[surfaceId, { surfaceType: "dynamic_page", data }]]),
-    channelCapabilities: channelCapabilities ?? undefined,
-    commandIntent,
-    currentTurnTemporalSnapshot,
-  } as never);
+    asConversation({
+      conversationId,
+      workingDir: "/sandbox",
+      workspaceTopLevelContext: workspaceText,
+      workspaceTopLevelDirty: false,
+      currentActiveSurfaceId: surfaceId,
+      surfaceState: new Map<string, SurfaceStateEntry>([
+        [surfaceId, { surfaceType: "dynamic_page", data }],
+      ]),
+      channelCapabilities: channelCapabilities ?? undefined,
+      commandIntent,
+      currentTurnTemporalSnapshot,
+    }),
+  );
 }
 
 function clearWorkspaceContext(): void {
@@ -252,15 +257,18 @@ function seedChannelCapabilitiesConversation(
   caps: ChannelCapabilities | null,
   transportHints?: string[],
 ): void {
-  setConversation("runtime-assembly-fallback", {
-    conversationId: "runtime-assembly-fallback",
-    workingDir: "/sandbox",
-    workspaceTopLevelContext: "",
-    workspaceTopLevelDirty: false,
-    surfaceState: new Map(),
-    channelCapabilities: caps ?? undefined,
-    transportHints,
-  } as never);
+  setConversation(
+    "runtime-assembly-fallback",
+    asConversation({
+      conversationId: "runtime-assembly-fallback",
+      workingDir: "/sandbox",
+      workspaceTopLevelContext: "",
+      workspaceTopLevelDirty: false,
+      surfaceState: new Map(),
+      channelCapabilities: caps ?? undefined,
+      transportHints,
+    }),
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -986,6 +994,7 @@ describe("applyRuntimeInjections — injection mode", () => {
       { type: "start" },
       {
         clientTimezone: null,
+        timeSinceLastMessage: null,
       },
     );
   });
@@ -1023,15 +1032,18 @@ describe("applyRuntimeInjections — injection mode", () => {
     // rehydration-order tests in conversation-lifecycle.test.ts). background-turn
     // fires only for a background/scheduled live conversation, so register one
     // under the turn's conversation id.
-    setConversation("injection-mode-conv", {
-      conversationId: "injection-mode-conv",
-      workingDir: "/sandbox",
-      workspaceTopLevelContext: "",
-      workspaceTopLevelDirty: false,
-      surfaceState: new Map(),
-      channelCapabilities,
-      conversationType: "background",
-    } as never);
+    setConversation(
+      "injection-mode-conv",
+      asConversation({
+        conversationId: "injection-mode-conv",
+        workingDir: "/sandbox",
+        workspaceTopLevelContext: "",
+        workspaceTopLevelDirty: false,
+        surfaceState: new Map(),
+        channelCapabilities,
+        conversationType: "background",
+      }),
+    );
 
     const { blocks } = await applyRuntimeInjections(baseMessages, fullOptions);
 
@@ -2227,20 +2239,24 @@ describe("applyRuntimeInjections with unifiedTurnContext", () => {
   // context (so the injector sources the interface label to match
   // `sampleOptions.interfaceName`).
   function seedTemporalSnapshot(): void {
-    setConversation("runtime-assembly-fallback", {
-      conversationId: "runtime-assembly-fallback",
-      workingDir: "/sandbox",
-      workspaceTopLevelContext: "",
-      workspaceTopLevelDirty: false,
-      surfaceState: new Map(),
-      currentTurnTemporalSnapshot: {
-        clientTimezone: null,
-      },
-      currentTurnInterfaceContext: {
-        userMessageInterface: "macos",
-        assistantMessageInterface: "macos",
-      },
-    } as never);
+    setConversation(
+      "runtime-assembly-fallback",
+      asConversation({
+        conversationId: "runtime-assembly-fallback",
+        workingDir: "/sandbox",
+        workspaceTopLevelContext: "",
+        workspaceTopLevelDirty: false,
+        surfaceState: new Map(),
+        currentTurnTemporalSnapshot: {
+          clientTimezone: null,
+          timeSinceLastMessage: null,
+        },
+        currentTurnInterfaceContext: {
+          userMessageInterface: "macos",
+          assistantMessageInterface: "macos",
+        },
+      }),
+    );
   }
 
   test("injects the turn-context block when the inputs are provided", async () => {
@@ -2327,17 +2343,20 @@ describe("applyRuntimeInjections timezone resolution", () => {
     clientTimezone: string | null,
     timeSinceLastMessage: string | null = null,
   ): void {
-    setConversation("runtime-assembly-fallback", {
-      conversationId: "runtime-assembly-fallback",
-      workingDir: "/sandbox",
-      workspaceTopLevelContext: "",
-      workspaceTopLevelDirty: false,
-      surfaceState: new Map(),
-      currentTurnTemporalSnapshot: {
-        clientTimezone,
-        timeSinceLastMessage,
-      },
-    } as never);
+    setConversation(
+      "runtime-assembly-fallback",
+      asConversation({
+        conversationId: "runtime-assembly-fallback",
+        workingDir: "/sandbox",
+        workspaceTopLevelContext: "",
+        workspaceTopLevelDirty: false,
+        surfaceState: new Map(),
+        currentTurnTemporalSnapshot: {
+          clientTimezone,
+          timeSinceLastMessage,
+        },
+      }),
+    );
   }
 
   function injectedText(result: { messages: Message[] }): string {
@@ -2491,20 +2510,24 @@ describe("applyRuntimeInjections blocks.unifiedTurnContext", () => {
   // context (so the injector sources the interface label to match
   // `sampleOptions.interfaceName`).
   function seedTemporalSnapshot(): void {
-    setConversation("runtime-assembly-fallback", {
-      conversationId: "runtime-assembly-fallback",
-      workingDir: "/sandbox",
-      workspaceTopLevelContext: "",
-      workspaceTopLevelDirty: false,
-      surfaceState: new Map(),
-      currentTurnTemporalSnapshot: {
-        clientTimezone: null,
-      },
-      currentTurnInterfaceContext: {
-        userMessageInterface: "macos",
-        assistantMessageInterface: "macos",
-      },
-    } as never);
+    setConversation(
+      "runtime-assembly-fallback",
+      asConversation({
+        conversationId: "runtime-assembly-fallback",
+        workingDir: "/sandbox",
+        workspaceTopLevelContext: "",
+        workspaceTopLevelDirty: false,
+        surfaceState: new Map(),
+        currentTurnTemporalSnapshot: {
+          clientTimezone: null,
+          timeSinceLastMessage: null,
+        },
+        currentTurnInterfaceContext: {
+          userMessageInterface: "macos",
+          assistantMessageInterface: "macos",
+        },
+      }),
+    );
   }
 
   test("captures unifiedTurnContext when tail is a user message", async () => {
@@ -2688,15 +2711,18 @@ describe("applyRuntimeInjections — subagent status", () => {
   // a fallback fake carrying that delegation for the seeded children to
   // surface.
   beforeEach(() => {
-    setConversation(FALLBACK_CONVERSATION_ID, {
-      conversationId: FALLBACK_CONVERSATION_ID,
-      workingDir: "/sandbox",
-      workspaceTopLevelContext: "",
-      workspaceTopLevelDirty: false,
-      surfaceState: new Map(),
-      getSubagentChildren: () =>
-        getSubagentManager().getChildrenOf(FALLBACK_CONVERSATION_ID),
-    } as never);
+    setConversation(
+      FALLBACK_CONVERSATION_ID,
+      asConversation({
+        conversationId: FALLBACK_CONVERSATION_ID,
+        workingDir: "/sandbox",
+        workspaceTopLevelContext: "",
+        workspaceTopLevelDirty: false,
+        surfaceState: new Map(),
+        getSubagentChildren: () =>
+          getSubagentManager().getChildrenOf(FALLBACK_CONVERSATION_ID),
+      }),
+    );
   });
 
   afterEach(() => {
@@ -2750,14 +2776,17 @@ describe("applyRuntimeInjections — subagent status", () => {
 
   test("skips subagent status when the conversation is itself a subagent", async () => {
     // GIVEN the live conversation is itself a subagent (no nesting)
-    setConversation("runtime-assembly-fallback", {
-      conversationId: "runtime-assembly-fallback",
-      workingDir: "/sandbox",
-      workspaceTopLevelContext: "",
-      workspaceTopLevelDirty: false,
-      surfaceState: new Map(),
-      isSubagent: true,
-    } as never);
+    setConversation(
+      "runtime-assembly-fallback",
+      asConversation({
+        conversationId: "runtime-assembly-fallback",
+        workingDir: "/sandbox",
+        workspaceTopLevelContext: "",
+        workspaceTopLevelDirty: false,
+        surfaceState: new Map(),
+        isSubagent: true,
+      }),
+    );
     // AND a child is registered under its id
     seedSubagentChild(
       "runtime-assembly-fallback",
@@ -4317,19 +4346,22 @@ describe("Slack channel chronological rendering — multi-thread", () => {
         )
         .run();
     }
-    setConversation("runtime-assembly-fallback", {
-      conversationId: "runtime-assembly-fallback",
-      workingDir: "/sandbox",
-      workspaceTopLevelContext: "",
-      workspaceTopLevelDirty: false,
-      surfaceState: new Map(),
-      channelCapabilities: caps,
-      trustContext: { trustClass: "guardian" },
-      slackContextCompactionWatermarkTs:
-        compaction.slackContextCompactionWatermarkTs ?? null,
-      contextCompactedMessageCount:
-        compaction.contextCompactedMessageCount ?? 0,
-    } as never);
+    setConversation(
+      "runtime-assembly-fallback",
+      asConversation({
+        conversationId: "runtime-assembly-fallback",
+        workingDir: "/sandbox",
+        workspaceTopLevelContext: "",
+        workspaceTopLevelDirty: false,
+        surfaceState: new Map(),
+        channelCapabilities: caps,
+        trustContext: { trustClass: "guardian", sourceChannel: "vellum" },
+        slackContextCompactionWatermarkTs:
+          compaction.slackContextCompactionWatermarkTs ?? null,
+        contextCompactedMessageCount:
+          compaction.contextCompactedMessageCount ?? 0,
+      }),
+    );
   }
 
   // Re-run a Slack-channel turn through the public assembly path. The

--- a/assistant/src/__tests__/conversation-runtime-workspace.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-workspace.test.ts
@@ -9,6 +9,7 @@ import { applyRuntimeInjections } from "../daemon/conversation-runtime-assembly.
 import type { SurfaceData, SurfaceType } from "../daemon/message-protocol.js";
 import { registerDefaultPluginInjectors } from "../plugins/defaults/index.js";
 import type { Message } from "../providers/types.js";
+import { asConversation } from "./helpers/mock-conversation.js";
 
 // Populate the injector registry with the default plugins' injectors the way
 // bootstrap does in production, so `applyRuntimeInjections` walks a non-empty
@@ -33,16 +34,19 @@ const FALLBACK_CONVERSATION_ID = "runtime-assembly-fallback";
 // injectors resolve their blocks from it (the orchestrator no longer threads
 // workspace or active-surface content as options).
 function registerFallbackConversation(fields: Record<string, unknown>): void {
-  setConversation(FALLBACK_CONVERSATION_ID, {
-    conversationId: FALLBACK_CONVERSATION_ID,
-    workingDir: "/sandbox",
-    // Non-dirty empty workspace by default so the workspace-context injector
-    // skips both the filesystem rescan and the DB refresh unless a test
-    // explicitly seeds a block via `workspaceTopLevelContext`.
-    workspaceTopLevelContext: "",
-    workspaceTopLevelDirty: false,
-    ...fields,
-  } as never);
+  setConversation(
+    FALLBACK_CONVERSATION_ID,
+    asConversation({
+      conversationId: FALLBACK_CONVERSATION_ID,
+      workingDir: "/sandbox",
+      // Non-dirty empty workspace by default so the workspace-context injector
+      // skips both the filesystem rescan and the DB refresh unless a test
+      // explicitly seeds a block via `workspaceTopLevelContext`.
+      workspaceTopLevelContext: "",
+      workspaceTopLevelDirty: false,
+      ...fields,
+    }),
+  );
 }
 
 // Seed the live conversation registry with a pre-rendered top-level block. The

--- a/assistant/src/__tests__/discord-access-request-privacy.test.ts
+++ b/assistant/src/__tests__/discord-access-request-privacy.test.ts
@@ -342,7 +342,11 @@ describe("Discord access-request decisions stay out of the guild channel", () =>
   test("no Discord delivery is ever addressed to the originating conversation", async () => {
     // The umbrella invariant, swept across every decision this resolver takes,
     // so a newly added action cannot quietly reintroduce the leak.
-    for (const action of ["verify_code", "block", "leave_unverified"] as const) {
+    for (const action of [
+      "verify_code",
+      "block",
+      "leave_unverified",
+    ] as const) {
       resetState();
       const req = makeDiscordAccessRequest();
 

--- a/assistant/src/__tests__/discord-requester-notice-privacy.test.ts
+++ b/assistant/src/__tests__/discord-requester-notice-privacy.test.ts
@@ -27,9 +27,9 @@ describe("the dm-marked Discord route", () => {
     // regressed, the notice would fall through to the HTTP proxy, which cannot
     // fetch a base-less URL: the delivery would vanish rather than error, and
     // every behavioural assertion about where it landed would still pass.
-    expect(channelForCallback(resolveDeliverCallbackUrlForChannel("discord")!)).toBe(
-      "discord",
-    );
+    expect(
+      channelForCallback(resolveDeliverCallbackUrlForChannel("discord")!),
+    ).toBe("discord");
   });
 });
 

--- a/assistant/src/__tests__/helpers/mock-actor-context.ts
+++ b/assistant/src/__tests__/helpers/mock-actor-context.ts
@@ -1,0 +1,49 @@
+/**
+ * Typed fixture factories for actor identity in tests.
+ *
+ * Test doubles used to hand-roll `TrustContext` / `AuthContext` literals and
+ * cast them quiet, which let wrong-shaped fixtures ship: a trust context with
+ * no `trustClass`, an auth context carrying two of seven required fields.
+ * These factories produce complete, type-checked values with conservative
+ * defaults, so a fixture states only what its test is about and the compiler
+ * guards the rest.
+ *
+ * Type-only imports keep this helper out of the runtime import graph, per the
+ * test-machinery isolation rules in `assistant/CLAUDE.md`.
+ */
+
+import type { TrustContext } from "../../daemon/trust-context-types.js";
+import type { AuthContext, Scope } from "../../runtime/auth/types.js";
+
+/**
+ * A complete `TrustContext`. Defaults to the guardian on the vellum channel;
+ * pass overrides for anything the test cares about.
+ */
+export function mockTrustContext(
+  overrides: Partial<TrustContext> = {},
+): TrustContext {
+  return {
+    sourceChannel: "vellum",
+    trustClass: "guardian",
+    ...overrides,
+  };
+}
+
+/**
+ * A complete `AuthContext`. Defaults to a local principal with no scopes, the
+ * conservative shape, so a test that forgets to opt in exercises the
+ * restrictive branch rather than a silently permissive one.
+ */
+export function mockAuthContext(
+  overrides: Partial<AuthContext> = {},
+): AuthContext {
+  return {
+    subject: "local:self:test",
+    principalType: "local",
+    assistantId: "self",
+    scopeProfile: "local_v1",
+    scopes: new Set<Scope>(),
+    policyEpoch: 0,
+    ...overrides,
+  };
+}

--- a/assistant/src/__tests__/helpers/mock-actor-context.ts
+++ b/assistant/src/__tests__/helpers/mock-actor-context.ts
@@ -1,12 +1,12 @@
 /**
  * Typed fixture factories for actor identity in tests.
  *
- * Test doubles used to hand-roll `TrustContext` / `AuthContext` literals and
- * cast them quiet, which let wrong-shaped fixtures ship: a trust context with
- * no `trustClass`, an auth context carrying two of seven required fields.
- * These factories produce complete, type-checked values with conservative
- * defaults, so a fixture states only what its test is about and the compiler
- * guards the rest.
+ * A fixture built here is a complete, type-checked `TrustContext` or
+ * `AuthContext` with conservative defaults; a test overrides only the fields
+ * its scenario is about, and the compiler guards the rest. Hand-rolled
+ * literals cannot make that guarantee: a missing required field needs a cast
+ * to satisfy the checker, and the cast then hides every other mistake in the
+ * literal.
  *
  * Type-only imports keep this helper out of the runtime import graph, per the
  * test-machinery isolation rules in `assistant/CLAUDE.md`.

--- a/assistant/src/__tests__/injector-chain.test.ts
+++ b/assistant/src/__tests__/injector-chain.test.ts
@@ -67,6 +67,7 @@ const { registerDefaultPluginInjectors } =
   await import("../plugins/defaults/index.js");
 import { eq } from "drizzle-orm";
 
+import type { InterfaceId } from "../channels/types.js";
 import {
   clearConversations,
   setConversation,
@@ -86,6 +87,7 @@ import type { Message } from "../providers/types.js";
 import { getSubagentManager } from "../subagent/index.js";
 import type { SubagentState } from "../subagent/types.js";
 import { getWorkspacePromptPath } from "../util/platform.js";
+import { asConversation } from "./helpers/mock-conversation.js";
 
 // `applyRuntimeInjections` self-resolves the Slack active-thread focus block
 // from the persisted message rows, so the schema must exist for Slack-channel
@@ -153,26 +155,30 @@ function seedWorkspaceContext(
   text: string,
   currentTurnTemporalSnapshot?: {
     clientTimezone: string | null;
+    timeSinceLastMessage: string | null;
   },
-  interfaceName?: string,
+  interfaceName?: InterfaceId,
 ): void {
-  setConversation(TEST_CONVERSATION_ID, {
-    conversationId: TEST_CONVERSATION_ID,
-    workingDir: "/sandbox",
-    workspaceTopLevelContext: text,
-    workspaceTopLevelDirty: false,
-    currentTurnTemporalSnapshot,
-    currentTurnInterfaceContext: interfaceName
-      ? {
-          userMessageInterface: interfaceName,
-          assistantMessageInterface: interfaceName,
-        }
-      : undefined,
-    // Mirrors Conversation.getSubagentChildren: the `<active_subagents>` block
-    // is sourced from the live conversation, which delegates to the manager.
-    getSubagentChildren: () =>
-      getSubagentManager().getChildrenOf(TEST_CONVERSATION_ID),
-  } as never);
+  setConversation(
+    TEST_CONVERSATION_ID,
+    asConversation({
+      conversationId: TEST_CONVERSATION_ID,
+      workingDir: "/sandbox",
+      workspaceTopLevelContext: text,
+      workspaceTopLevelDirty: false,
+      currentTurnTemporalSnapshot,
+      currentTurnInterfaceContext: interfaceName
+        ? {
+            userMessageInterface: interfaceName,
+            assistantMessageInterface: interfaceName,
+          }
+        : undefined,
+      // Mirrors Conversation.getSubagentChildren: the `<active_subagents>` block
+      // is sourced from the live conversation, which delegates to the manager.
+      getSubagentChildren: () =>
+        getSubagentManager().getChildrenOf(TEST_CONVERSATION_ID),
+    }),
+  );
 }
 
 // `applyRuntimeInjections` gates the `<turn_context>` block on the live
@@ -181,13 +187,19 @@ function seedWorkspaceContext(
 // fall back to the runtime-assembly fallback conversation, so seed the snapshot
 // there.
 function seedFallbackTemporalSnapshot(): void {
-  setConversation("runtime-assembly-fallback", {
-    conversationId: "runtime-assembly-fallback",
-    workingDir: "/sandbox",
-    workspaceTopLevelContext: "",
-    workspaceTopLevelDirty: false,
-    currentTurnTemporalSnapshot: { clientTimezone: null },
-  } as never);
+  setConversation(
+    "runtime-assembly-fallback",
+    asConversation({
+      conversationId: "runtime-assembly-fallback",
+      workingDir: "/sandbox",
+      workspaceTopLevelContext: "",
+      workspaceTopLevelDirty: false,
+      currentTurnTemporalSnapshot: {
+        clientTimezone: null,
+        timeSinceLastMessage: null,
+      },
+    }),
+  );
 }
 
 // Persist Slack-channel rows for the turn conversation so
@@ -484,7 +496,11 @@ describe("injector chain", () => {
     seedSubagentChild(TEST_CONVERSATION_ID, subagentChild);
     const subagentBlock = buildSubagentStatusBlock([subagentChild])!;
 
-    seedWorkspaceContext(workspaceText, { clientTimezone: null }, "macos");
+    seedWorkspaceContext(
+      workspaceText,
+      { clientTimezone: null, timeSinceLastMessage: null },
+      "macos",
+    );
     const result = await applyRuntimeInjections(runMessages, {
       ...makeTurnContext(),
     });
@@ -562,20 +578,23 @@ describe("injector chain", () => {
         createdAt: 1700000005_000,
       },
     ]);
-    setConversation(TEST_CONVERSATION_ID, {
-      conversationId: TEST_CONVERSATION_ID,
-      workingDir: "/sandbox",
-      workspaceTopLevelContext: "",
-      workspaceTopLevelDirty: false,
-      trustContext: { trustClass: "guardian" },
-      channelCapabilities: {
-        channel: "slack",
-        dashboardCapable: false,
-        supportsDynamicUi: false,
-        supportsVoiceInput: false,
-        chatType: "channel",
-      },
-    } as never);
+    setConversation(
+      TEST_CONVERSATION_ID,
+      asConversation({
+        conversationId: TEST_CONVERSATION_ID,
+        workingDir: "/sandbox",
+        workspaceTopLevelContext: "",
+        workspaceTopLevelDirty: false,
+        trustContext: { trustClass: "guardian", sourceChannel: "vellum" },
+        channelCapabilities: {
+          channel: "slack",
+          dashboardCapable: false,
+          supportsDynamicUi: false,
+          supportsVoiceInput: false,
+          chatType: "channel",
+        },
+      }),
+    );
     const result = await applyRuntimeInjections(originalRun, {
       ...makeTurnContext(),
     });
@@ -614,7 +633,10 @@ describe("injector chain", () => {
       timestamp: FIXED_TURN_TIMESTAMP,
       interfaceName: "web",
     });
-    seedWorkspaceContext("", { clientTimezone: null });
+    seedWorkspaceContext("", {
+      clientTimezone: null,
+      timeSinceLastMessage: null,
+    });
     seedSubagentChild(
       TEST_CONVERSATION_ID,
       makeSubagentState("sub-1", "worker", "running"),

--- a/assistant/src/__tests__/injector-disk-pressure.test.ts
+++ b/assistant/src/__tests__/injector-disk-pressure.test.ts
@@ -14,6 +14,7 @@ mock.module("../daemon/date-context.js", () => ({
   formatTurnTimestamp: () => FIXED_TURN_TIMESTAMP,
 }));
 
+import type { Conversation } from "../daemon/conversation.js";
 import {
   clearConversations,
   setConversation,
@@ -39,6 +40,7 @@ import {
 } from "../plugins/defaults/workspace/injectors.js";
 import type { Injector, TurnContext } from "../plugins/types.js";
 import type { Message } from "../providers/types.js";
+import { asConversation } from "./helpers/mock-conversation.js";
 
 // `applyRuntimeInjections` self-resolves the Slack active-thread focus block
 // from the persisted message rows, so the schema must exist for Slack-channel
@@ -90,38 +92,23 @@ const diskPressureInjector = findInjector("disk-pressure-warning");
 // turn can exercise both; the seed helpers mutate and re-register the same
 // instance. An empty (non-dirty) workspace cache resolves to no block, so
 // disk-pressure-only tests don't trigger a directory scan.
-let liveConversation: {
-  conversationId: string;
-  workingDir: string;
-  workspaceTopLevelContext: string | null;
-  workspaceTopLevelDirty: boolean;
-  diskPressureCleanupModeActive: boolean;
-  channelCapabilities?: ChannelCapabilities;
-  trustContext?: { trustClass: string };
-  currentTurnTemporalSnapshot?: {
-    clientTimezone: string | null;
-  };
-  currentTurnInterfaceContext?: {
-    userMessageInterface: string;
-    assistantMessageInterface: string;
-  };
-};
+let liveConversation: Conversation;
 
 function resetLiveConversation(): void {
-  liveConversation = {
+  liveConversation = asConversation({
     conversationId: TEST_CONVERSATION_ID,
     workingDir: "/workspace",
     workspaceTopLevelContext: "",
     workspaceTopLevelDirty: false,
     diskPressureCleanupModeActive: false,
-    trustContext: { trustClass: "guardian" },
+    trustContext: { trustClass: "guardian", sourceChannel: "vellum" },
     // The unified-turn-context injector sources the interface label from the
     // live conversation's turn interface context; match the expected blocks.
     currentTurnInterfaceContext: {
       userMessageInterface: "macos",
       assistantMessageInterface: "macos",
     },
-  };
+  });
 }
 
 // `applyRuntimeInjections` gates the `<turn_context>` block on the live
@@ -130,24 +117,25 @@ function resetLiveConversation(): void {
 function seedTemporalSnapshot(): void {
   liveConversation.currentTurnTemporalSnapshot = {
     clientTimezone: null,
+    timeSinceLastMessage: null,
   };
-  setConversation(TEST_CONVERSATION_ID, liveConversation as never);
+  setConversation(TEST_CONVERSATION_ID, liveConversation);
 }
 
 function seedChannelCapabilities(caps: ChannelCapabilities): void {
   liveConversation.channelCapabilities = caps;
-  setConversation(TEST_CONVERSATION_ID, liveConversation as never);
+  setConversation(TEST_CONVERSATION_ID, liveConversation);
 }
 
 function seedDiskPressure(cleanupModeActive: boolean): void {
   liveConversation.diskPressureCleanupModeActive = cleanupModeActive;
-  setConversation(TEST_CONVERSATION_ID, liveConversation as never);
+  setConversation(TEST_CONVERSATION_ID, liveConversation);
 }
 
 function seedWorkspaceContext(text: string): void {
   liveConversation.workspaceTopLevelContext = text;
   liveConversation.workspaceTopLevelDirty = false;
-  setConversation(TEST_CONVERSATION_ID, liveConversation as never);
+  setConversation(TEST_CONVERSATION_ID, liveConversation);
 }
 
 // Persist Slack-channel rows for the turn conversation so

--- a/assistant/src/__tests__/memory-retrieval-hook.test.ts
+++ b/assistant/src/__tests__/memory-retrieval-hook.test.ts
@@ -173,16 +173,14 @@ function installConversation(
   graphMemory: ConversationGraphMemory,
   opts?: {
     trusted?: boolean;
-    signal?: AbortSignal;
+    abortController?: AbortController;
   },
 ): void {
   currentTrustClass = opts?.trusted === false ? "unknown" : "guardian";
   currentConversation = asConversation({
     graphMemory,
     trustContext: undefined,
-    abortController: (opts?.signal
-      ? { signal: opts.signal }
-      : new AbortController()) as AbortController,
+    abortController: opts?.abortController ?? new AbortController(),
   });
 }
 
@@ -495,7 +493,7 @@ describe("user-prompt-submit hook (memory retrieval)", () => {
     const controller = new AbortController();
     installConversation(graphMemory, {
       trusted: true,
-      signal: controller.signal,
+      abortController: controller,
     });
     const ctx = makeHookCtx();
 

--- a/assistant/src/__tests__/memory-retrieval-hook.test.ts
+++ b/assistant/src/__tests__/memory-retrieval-hook.test.ts
@@ -73,6 +73,7 @@ import type { QdrantSparseVector } from "../persistence/embeddings/qdrant-client
 import type { ConversationGraphMemory } from "../plugins/defaults/memory/graph/conversation-graph-memory.js";
 import userPromptSubmitMemoryRetrieval from "../plugins/defaults/memory/hooks/user-prompt-submit.js";
 import type { Message } from "../providers/types.js";
+import { asConversation } from "./helpers/mock-conversation.js";
 
 /** Canonical metrics payload the graph retriever attaches to a real hit. */
 function makeMetrics() {
@@ -176,11 +177,13 @@ function installConversation(
   },
 ): void {
   currentTrustClass = opts?.trusted === false ? "unknown" : "guardian";
-  currentConversation = {
+  currentConversation = asConversation({
     graphMemory,
     trustContext: undefined,
-    abortController: { signal: opts?.signal ?? new AbortController().signal },
-  } as unknown as Conversation;
+    abortController: (opts?.signal
+      ? { signal: opts.signal }
+      : new AbortController()) as AbortController,
+  });
 }
 
 beforeEach(() => {

--- a/assistant/src/__tests__/post-compaction-reinjection-idempotency.test.ts
+++ b/assistant/src/__tests__/post-compaction-reinjection-idempotency.test.ts
@@ -20,6 +20,7 @@ import { applyRuntimeInjections } from "../daemon/conversation-runtime-assembly.
 import { registerDefaultPluginInjectors } from "../plugins/defaults/index.js";
 import { stripTailInjectionsForReinjection } from "../plugins/defaults/memory/tail-reinjection-strip.js";
 import type { Message } from "../providers/types.js";
+import { asConversation } from "./helpers/mock-conversation.js";
 
 // Populate the injector registry with the default plugins' injectors the way
 // bootstrap does in production, so `applyRuntimeInjections` walks a non-empty
@@ -160,13 +161,19 @@ describe("applyRuntimeInjections re-injection idempotency", () => {
   // a frozen temporal snapshot so the non-presence-gated `<turn_context>` block
   // is produced every assembly.
   function seedConversation(): void {
-    setConversation(FALLBACK_CONVERSATION_ID, {
-      conversationId: FALLBACK_CONVERSATION_ID,
-      workingDir: "/sandbox",
-      workspaceTopLevelContext: WORKSPACE_BLOCK,
-      workspaceTopLevelDirty: false,
-      currentTurnTemporalSnapshot: { clientTimezone: null },
-    } as never);
+    setConversation(
+      FALLBACK_CONVERSATION_ID,
+      asConversation({
+        conversationId: FALLBACK_CONVERSATION_ID,
+        workingDir: "/sandbox",
+        workspaceTopLevelContext: WORKSPACE_BLOCK,
+        workspaceTopLevelDirty: false,
+        currentTurnTemporalSnapshot: {
+          clientTimezone: null,
+          timeSinceLastMessage: null,
+        },
+      }),
+    );
   }
 
   afterEach(() => {

--- a/assistant/src/__tests__/subagent-call-site-routing.test.ts
+++ b/assistant/src/__tests__/subagent-call-site-routing.test.ts
@@ -184,8 +184,11 @@ import {
   clearConversations,
   setConversation,
 } from "../daemon/conversation-registry.js";
+import type { TrustContext } from "../daemon/trust-context-types.js";
 import { CallSiteRoutingProvider } from "../providers/call-site-routing.js";
 import { SubagentManager } from "../subagent/manager.js";
+import { mockAuthContext } from "./helpers/mock-actor-context.js";
+import { asConversation } from "./helpers/mock-conversation.js";
 
 // Seed the workspace `llm` config per-case. The real loader schema-merges the
 // raw fragment over defaults exactly as the code path reads it.
@@ -304,26 +307,29 @@ describe("SubagentManager — provider call-site routing", () => {
   test("copies parent guardian and auth context into spawned conversation", async () => {
     setLlmConfig(makeLlmFixture());
 
-    const parentTrustContext = {
+    const parentTrustContext: TrustContext = {
       sourceChannel: "vellum",
       trustClass: "guardian",
       guardianPrincipalId: "guardian-1",
       guardianExternalUserId: "guardian-1",
     };
-    const parentAuthContext = {
+    const parentAuthContext = mockAuthContext({
       subject: "local:self:parent-perms",
       actorPrincipalId: "guardian-1",
-    };
+    });
 
     capturedConversations.length = 0;
     clearConversations();
     const manager = new SubagentManager();
-    setConversation("parent-perms", {
-      trustContext: parentTrustContext,
-      getAuthContext: () => parentAuthContext,
-      assistantId: "self",
-      getCurrentSystemPrompt: () => "parent system",
-    } as any);
+    setConversation(
+      "parent-perms",
+      asConversation({
+        trustContext: parentTrustContext,
+        getAuthContext: () => parentAuthContext,
+        assistantId: "self",
+        getCurrentSystemPrompt: () => "parent system",
+      }),
+    );
 
     await manager.spawn(
       {
@@ -354,11 +360,14 @@ describe("SubagentManager — provider call-site routing", () => {
     capturedConversations.length = 0;
     clearConversations();
     const manager = new SubagentManager();
-    setConversation("parent-scoped", {
-      enabledPlugins: parentScope,
-      getAuthContext: () => undefined,
-      getCurrentSystemPrompt: () => "parent system",
-    } as any);
+    setConversation(
+      "parent-scoped",
+      asConversation({
+        enabledPlugins: parentScope,
+        getAuthContext: () => undefined,
+        getCurrentSystemPrompt: () => "parent system",
+      }),
+    );
 
     await manager.spawn(
       {
@@ -383,11 +392,14 @@ describe("SubagentManager — provider call-site routing", () => {
     capturedConversations.length = 0;
     clearConversations();
     const manager = new SubagentManager();
-    setConversation("parent-unscoped", {
-      enabledPlugins: null,
-      getAuthContext: () => undefined,
-      getCurrentSystemPrompt: () => "parent system",
-    } as any);
+    setConversation(
+      "parent-unscoped",
+      asConversation({
+        enabledPlugins: null,
+        getAuthContext: () => undefined,
+        getCurrentSystemPrompt: () => "parent system",
+      }),
+    );
 
     await manager.spawn(
       {

--- a/assistant/src/__tests__/subagent-spawn-and-await.test.ts
+++ b/assistant/src/__tests__/subagent-spawn-and-await.test.ts
@@ -207,6 +207,7 @@ import {
   setConversation,
 } from "../daemon/conversation-registry.js";
 import { SubagentAbortedError, SubagentManager } from "../subagent/manager.js";
+import { asConversation } from "./helpers/mock-conversation.js";
 
 function makeConfig(overrides: Record<string, unknown> = {}) {
   return {
@@ -229,16 +230,19 @@ function registerFakeParent(parentConversationId: string): {
   enqueuedCount: () => number;
 } {
   let enqueued = 0;
-  setConversation(parentConversationId, {
-    // Accessors read by setUpSubagent when copying trust/auth context.
-    trustContext: undefined,
-    getAuthContext: () => undefined,
-    assistantId: undefined,
-    enqueueMessage: () => {
-      enqueued += 1;
-      return { rejected: false, queued: true };
-    },
-  } as never);
+  setConversation(
+    parentConversationId,
+    asConversation({
+      // Accessors read by setUpSubagent when copying trust/auth context.
+      trustContext: undefined,
+      getAuthContext: () => undefined,
+      assistantId: undefined,
+      enqueueMessage: () => {
+        enqueued += 1;
+        return { rejected: false, queued: true, requestId: "req-fake" };
+      },
+    }),
+  );
   return { enqueuedCount: () => enqueued };
 }
 

--- a/assistant/src/__tests__/visible-app-context.test.ts
+++ b/assistant/src/__tests__/visible-app-context.test.ts
@@ -25,6 +25,7 @@ import {
 import { registerDefaultPluginInjectors } from "../plugins/defaults/index.js";
 import type { Message } from "../providers/types.js";
 import { getWorkspacePluginsDir } from "../util/platform.js";
+import { asConversation } from "./helpers/mock-conversation.js";
 
 // The injector chain is registered by the daemon bootstrap in production; do
 // the same here so `applyRuntimeInjections` walks a non-empty chain.
@@ -151,15 +152,21 @@ describe("visible_app injection", () => {
   ];
 
   function seedConversation(currentTurnVisibleAppId: string | undefined): void {
-    setConversation(CONVERSATION_ID, {
-      conversationId: CONVERSATION_ID,
-      workingDir: "/sandbox",
-      workspaceTopLevelContext: "",
-      workspaceTopLevelDirty: false,
-      surfaceState: new Map(),
-      currentTurnVisibleAppId,
-      currentTurnTemporalSnapshot: { clientTimezone: null },
-    } as never);
+    setConversation(
+      CONVERSATION_ID,
+      asConversation({
+        conversationId: CONVERSATION_ID,
+        workingDir: "/sandbox",
+        workspaceTopLevelContext: "",
+        workspaceTopLevelDirty: false,
+        surfaceState: new Map(),
+        currentTurnVisibleAppId,
+        currentTurnTemporalSnapshot: {
+          clientTimezone: null,
+          timeSinceLastMessage: null,
+        },
+      }),
+    );
   }
 
   afterEach(() => {

--- a/assistant/src/permissions/confirmation-guardian-request.test.ts
+++ b/assistant/src/permissions/confirmation-guardian-request.test.ts
@@ -19,17 +19,19 @@ mock.module("../util/logger.js", () => ({
 }));
 
 mock.module("../daemon/conversation-registry.js", () => ({
-  findConversation: () => ({
-    assistantId: "self",
-    trustContext: {
-      sourceChannel: "telegram",
-      requesterExternalUserId: "tg-user-1",
-      requesterChatId: "tg-chat-1",
-      guardianExternalUserId: "tg-guardian-1",
-      guardianPrincipalId: "principal-1",
-    },
-    hasPendingConfirmation: () => confirmationPending,
-  }),
+  findConversation: () =>
+    asConversation({
+      assistantId: "self",
+      trustContext: {
+        trustClass: "trusted_contact",
+        sourceChannel: "telegram",
+        requesterExternalUserId: "tg-user-1",
+        requesterChatId: "tg-chat-1",
+        guardianExternalUserId: "tg-guardian-1",
+        guardianPrincipalId: "principal-1",
+      } satisfies TrustContext,
+      hasPendingConfirmation: () => confirmationPending,
+    }),
 }));
 
 mock.module("../channels/gateway-guardian-requests.js", () => ({
@@ -50,7 +52,9 @@ mock.module("../runtime/confirmation-request-guardian-bridge.js", () => ({
   },
 }));
 
+import { asConversation } from "../__tests__/helpers/mock-conversation.js";
 import type { AssistantEvent } from "../api/index.js";
+import type { TrustContext } from "../daemon/trust-context-types.js";
 import { createGuardianRequestForConfirmation } from "./confirmation-guardian-request.js";
 
 const MSG = {

--- a/assistant/src/permissions/question-guardian-request.test.ts
+++ b/assistant/src/permissions/question-guardian-request.test.ts
@@ -7,7 +7,10 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { mockTrustContext } from "../__tests__/helpers/mock-actor-context.js";
+import { asConversation } from "../__tests__/helpers/mock-conversation.js";
 import type { QuestionRequestEvent } from "../api/events/question-request.js";
+import type { TrustContext } from "../daemon/trust-context-types.js";
 
 const createGuardianRequestMock = mock(
   (params: Record<string, unknown>): Promise<Record<string, unknown>> =>
@@ -21,13 +24,18 @@ const withdrawCardsMock = mock((_params: Record<string, unknown>) =>
   Promise.resolve(),
 );
 
-let trustContext: Record<string, unknown> | undefined;
+let trustContext: TrustContext | undefined;
 let pendingInteraction: { kind: string } | undefined;
 let rowAfterExpire: Record<string, unknown> | null = null;
 
 mock.module("../daemon/conversation-registry.js", () => ({
   findConversation: (_id: string) =>
-    trustContext ? { trustContext, assistantId: "self" } : undefined,
+    trustContext
+      ? asConversation({
+          trustContext,
+          assistantId: "self",
+        })
+      : undefined,
 }));
 mock.module("../channels/gateway-guardian-requests.js", () => ({
   createGuardianRequest: (params: Record<string, unknown>) =>
@@ -77,9 +85,9 @@ function makeEvent(
 }
 
 function guardianTrustContext(
-  overrides: Record<string, unknown> = {},
-): Record<string, unknown> {
-  return {
+  overrides: Partial<TrustContext> = {},
+): TrustContext {
+  return mockTrustContext({
     trustClass: "guardian",
     sourceChannel: "telegram",
     guardianPrincipalId: "prin-guardian",
@@ -87,7 +95,7 @@ function guardianTrustContext(
     requesterExternalUserId: "tg-guardian",
     requesterChatId: "chat-1",
     ...overrides,
-  };
+  });
 }
 
 beforeEach(() => {


### PR DESCRIPTION
## TL;DR

De-casts the conversation test doubles across eleven suites and fixes the wrong shapes the casts were hiding. Tests only, no production code.

**Stacked on #40588** (the fixture factories); diff is shown against that branch. Second of two test-infrastructure PRs; #40577's accessor work then rebases to a production-only diff.

## Why this is needed

Doubles silenced with `as never` / `as any` / `as unknown as Conversation` are exempt from the type system: a double can be missing a member or carry a wrong-shaped one and nothing says so until runtime. That is not hypothetical — it is the mechanism behind this week's CI incident on #40577, where a production change from field reads to method calls turned into fourteen suites failing *silently* (the consumers wrap trust reads in best-effort try/catch, so missing methods became no-ops rather than TypeErrors).

`asConversation` already exists to prevent exactly this — its documented contract keeps field types checked against the real class while confining the single unavoidable widening to one place — but these suites bypassed it.

## What the checker found once the casts came off

| Shape | Defect |
|---|---|
| `usageStats` doubles | Carried `totalInputTokens`-shaped data that no code reads; now real `UsageStats` |
| `drainQueue` / `kickDrainQueue` | Synchronous, string-typed stand-ins for async `QueueDrainReason` methods |
| Temporal snapshots | Missing the required `timeSinceLastMessage` |
| Runtime-assembly surface map | Untyped; now `Map<string, SurfaceStateEntry>`, seed param narrowed to the `dynamic_page` variant it constructs |
| Agent-loop conversation-row mock | `Record<string, unknown>`, so every member read as `{}`; now a typed interface |
| Call-site-routing auth fixture | Built on `mockAuthContext()` from #40588 |

## What changes in behaviour

Nothing in production. Test behaviour changes only where fixtures were wrong: those suites now exercise the shapes production actually produces.

## Scope notes

- The two discord suites carry formatting-only hunks — they were merged unformatted, and prettier folds them in on first touch.
- **This PR adds zero casts.** Reviewers will still see pre-existing ones in the surrounding context of the agent-loop suites (~70 across the trio): sub-object doubles (`as unknown as Provider`, `Conversation["contextWindowManager"]`, ...) and `mock.calls` tuple narrowings. That is the same disease one level down, bounded to provider/window-manager shape drift (it cannot hide a trust defect), and it is tracked as LUM-3217 rather than ridden on this diff. `subagent-fork-spawn` and `subagent-spawn-tool-fork` carry the same pre-existing `as any` doubles and are in that ticket's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40589" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
