### PR TITLE
feat(assistant): index the sidebar sections in one read (LUM-3216)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6594,8 +6594,8 @@ paths:
           description:
             Filter to a single group, so each sidebar section can load independently of the paginated list. Pass
             "system:all" for conversations in no group, "system:pinned" for the Pinned section, or a custom group id. A
-            group-scoped request is ordered by the user's arrangement (display order, then recency) and never has pinned
-            rows appended to it. Omit to span every group.
+            group-scoped request is recency-ordered like every list read (COALESCE(last_message_at, updated_at)
+            descending) and never has pinned rows appended to it. Omit to span every group.
       responses:
         "200":
           description: Successful response
@@ -9382,6 +9382,107 @@ paths:
                 required:
                   - query
                   - results
+                additionalProperties: false
+  /v1/conversations/sections:
+    get:
+      operationId: conversations_sections_get
+      summary: Sidebar section index
+      description:
+        "One row per renderable sidebar section (Pinned, each non-empty custom group, each origin channel with
+        unassigned conversations, Chats) with total and unread counts and no conversation rows. Lets a client know which
+        sections exist, and what their badges say, without fetching any conversation list. Totals follow the standard
+        listing visibility; unread applies the same rules as GET /v1/conversations/unread-count scoped to the section.
+        Chats is always present, even at zero: it is the leftover bucket and renders regardless."
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  sections:
+                    type: array
+                    items:
+                      oneOf:
+                        - type: object
+                          properties:
+                            kind:
+                              type: string
+                              const: pinned
+                            total:
+                              type: number
+                            unread:
+                              type: number
+                          required:
+                            - kind
+                            - total
+                            - unread
+                          additionalProperties: false
+                        - type: object
+                          properties:
+                            kind:
+                              type: string
+                              const: group
+                            groupId:
+                              type: string
+                            name:
+                              type: string
+                            icon:
+                              anyOf:
+                                - type: string
+                                - type: "null"
+                            sortPosition:
+                              type: number
+                            total:
+                              type: number
+                            unread:
+                              type: number
+                          required:
+                            - kind
+                            - groupId
+                            - name
+                            - icon
+                            - sortPosition
+                            - total
+                            - unread
+                          additionalProperties: false
+                        - type: object
+                          properties:
+                            kind:
+                              type: string
+                              const: channel
+                            channelId:
+                              type: string
+                            total:
+                              type: number
+                            unread:
+                              type: number
+                          required:
+                            - kind
+                            - channelId
+                            - total
+                            - unread
+                          additionalProperties: false
+                        - type: object
+                          properties:
+                            kind:
+                              type: string
+                              const: chats
+                            total:
+                              type: number
+                            unread:
+                              type: number
+                          required:
+                            - kind
+                            - total
+                            - unread
+                          additionalProperties: false
+                      type: object
+                required:
+                  - sections
                 additionalProperties: false
   /v1/conversations/seen:
     post:

--- a/assistant/src/persistence/conversation-queries.ts
+++ b/assistant/src/persistence/conversation-queries.ts
@@ -598,6 +598,100 @@ export function countUnreadConversations(): number {
   return total;
 }
 
+/** Totals for one sidebar section: every member, and the unread among them. */
+export interface ConversationSectionCount {
+  total: number;
+  unread: number;
+}
+
+/**
+ * Row counts for every non-empty sidebar section, with no rows fetched.
+ *
+ * Two axes, disjoint by construction because `group_id` is single-valued:
+ *
+ * - `groups`: rows filed somewhere, bucketed by `group_id`. Contains
+ *   `'system:pinned'` and custom-group ids; the background/scheduled system
+ *   buckets are excluded because no section renders them.
+ * - `channels`: rows filed nowhere, bucketed by effective origin channel,
+ *   where NULL reads as {@link NATIVE_ORIGIN_CHANNEL} exactly as
+ *   {@link originChannelClause} reads it. The native bucket is the Chats
+ *   section; each other bucket is that channel's section.
+ *
+ * Only buckets with at least one row appear: GROUP BY cannot emit an empty
+ * bucket, and an empty section renders no card.
+ *
+ * `total` follows the standard-listing visibility
+ * ({@link conversationTypeClause}), active rows only, so it counts exactly
+ * the rows `GET /v1/conversations` would return for that section's filter.
+ * `unread` applies the same rules as {@link countUnreadConversations} on top
+ * (not an unsurfaced background/scheduled row, unseen per the attention
+ * projection), composed from the same predicates rather than restated, so
+ * the per-section numbers always sum against the global count.
+ */
+export interface ConversationSectionCounts {
+  groups: Array<{ groupId: string } & ConversationSectionCount>;
+  channels: Array<{ channel: string } & ConversationSectionCount>;
+}
+
+export function countConversationSections(): ConversationSectionCounts {
+  ensureGroupMigration();
+  const db = getDb();
+
+  /* `countUnreadConversations` gets the same effect with an INNER JOIN and
+     the unseen conditions in its WHERE; here every row must be counted and
+     only unread rows summed, so the join is LEFT and the conditions move
+     into the CASE. A row with no attention projection has NULL columns,
+     fails the conditions, and sums 0: identical membership. */
+  const unread = sql<number>`SUM(CASE WHEN ${and(
+    sql.raw(notBackgroundVisibilitySql()),
+    ...unseenAttentionStateConditions(),
+  )} THEN 1 ELSE 0 END)`;
+
+  const attentionJoin = eq(
+    conversationAssistantAttentionState.conversationId,
+    conversations.id,
+  );
+
+  const groups = db
+    .select({
+      groupId: sql<string>`group_id`,
+      total: count(),
+      unread,
+    })
+    .from(conversations)
+    .leftJoin(conversationAssistantAttentionState, attentionJoin)
+    .where(
+      and(
+        conversationTypeClause("standard"),
+        isNull(conversations.archivedAt),
+        sql`(group_id = ${PINNED_GROUP_ID} OR (group_id IS NOT NULL AND group_id NOT LIKE 'system:%'))`,
+      ),
+    )
+    .groupBy(sql`group_id`)
+    .all();
+
+  const effectiveChannel = sql<string>`COALESCE(${conversations.originChannel}, ${NATIVE_ORIGIN_CHANNEL})`;
+  const channels = db
+    .select({
+      channel: effectiveChannel,
+      total: count(),
+      unread,
+    })
+    .from(conversations)
+    .leftJoin(conversationAssistantAttentionState, attentionJoin)
+    .where(
+      and(
+        conversationTypeClause("standard"),
+        isNull(conversations.archivedAt),
+        groupIdClause(UNGROUPED_GROUP_ID),
+      ),
+    )
+    .groupBy(effectiveChannel)
+    .all();
+
+  return { groups, channels };
+}
+
 /**
  * Check whether the last user message in a conversation is a tool_result-only
  * message (i.e., not a real user-typed message). This is used by undo() to

--- a/assistant/src/runtime/routes/__tests__/conversation-list-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-list-routes.test.ts
@@ -25,7 +25,7 @@ import { createConversation } from "../../../persistence/conversation-crud.js";
 import { getDb } from "../../../persistence/db-connection.js";
 import { initializeDb } from "../../../persistence/db-init.js";
 import { createGroup } from "../../../persistence/group-crud.js";
-import { rawRun } from "../../../persistence/raw-query.js";
+import { rawExec, rawRun } from "../../../persistence/raw-query.js";
 import {
   conversationAssistantAttentionState,
   conversationAttentionEvents,
@@ -961,10 +961,21 @@ describe("GET /v1/conversations/sections", () => {
   });
 
   test("a dangling group id is skipped, not surfaced", () => {
-    fileIntoGroup(
-      createConversation({ title: "dangling" }).id,
-      "00000000-0000-4000-8000-00000000dead",
-    );
+    /* Live write paths cannot create this state: group_id carries a foreign
+       key, and the placement write sanitizes unknown groups precisely to
+       avoid violating it. A restored snapshot can, though: in-place restore
+       swaps the SQLite file without running migrations in-process (the same
+       window that lets legacy private rows exist transiently), so the
+       fixture creates the state the way reality does, with enforcement off. */
+    rawExec("PRAGMA foreign_keys = OFF");
+    try {
+      fileIntoGroup(
+        createConversation({ title: "dangling" }).id,
+        "00000000-0000-4000-8000-00000000dead",
+      );
+    } finally {
+      rawExec("PRAGMA foreign_keys = ON");
+    }
 
     const sections = invokeSections();
 

--- a/assistant/src/runtime/routes/__tests__/conversation-list-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-list-routes.test.ts
@@ -782,3 +782,210 @@ describe("GET /v1/conversations/unread-count", () => {
     expect(invokeUnreadCount()).toEqual({ count: 1 });
   });
 });
+
+describe("GET /v1/conversations/sections", () => {
+  const sectionsHandler = findHandler(
+    CONVERSATION_LIST_ROUTES,
+    "getConversationSections",
+  );
+
+  interface SectionRow {
+    kind: "pinned" | "group" | "channel" | "chats";
+    groupId?: string;
+    name?: string;
+    icon?: string | null;
+    sortPosition?: number;
+    channelId?: string;
+    total: number;
+    unread: number;
+  }
+
+  function invokeSections(): SectionRow[] {
+    return (sectionsHandler({}) as { sections: SectionRow[] }).sections;
+  }
+
+  function fileIntoGroup(conversationId: string, groupId: string): void {
+    rawRun(
+      "test:fileIntoGroup",
+      "UPDATE conversations SET group_id = ? WHERE id = ?",
+      groupId,
+      conversationId,
+    );
+  }
+
+  function stampChannel(conversationId: string, channel: string): void {
+    rawRun(
+      "test:stampChannel",
+      "UPDATE conversations SET origin_channel = ? WHERE id = ?",
+      channel,
+      conversationId,
+    );
+  }
+
+  function pin(conversationId: string): void {
+    rawRun(
+      "test:pinConversation",
+      "UPDATE conversations SET is_pinned = 1, group_id = 'system:pinned' WHERE id = ?",
+      conversationId,
+    );
+  }
+
+  function seedUnseen(conversationId: string): void {
+    projectAssistantMessage({
+      conversationId,
+      messageId: `msg-${conversationId}`,
+      messageAt: Date.now(),
+    });
+  }
+
+  beforeEach(() => {
+    clearConversations();
+  });
+
+  test("an empty conversation table yields Chats alone, at zero", () => {
+    // Chats is the leftover bucket and renders regardless, so its counts
+    // are part of the contract even when nothing exists.
+    expect(invokeSections()).toEqual([{ kind: "chats", total: 0, unread: 0 }]);
+  });
+
+  test("every section kind appears with its own totals", () => {
+    const pinned = createConversation({ title: "pinned-1" });
+    pin(pinned.id);
+    const group = createGroup("Sections Spread Group");
+    fileIntoGroup(createConversation({ title: "g-1" }).id, group.id);
+    fileIntoGroup(createConversation({ title: "g-2" }).id, group.id);
+    stampChannel(createConversation({ title: "slack-1" }).id, "slack");
+    createConversation({ title: "native-unstamped" });
+    stampChannel(createConversation({ title: "native-stamped" }).id, "vellum");
+
+    const sections = invokeSections();
+
+    expect(sections).toContainEqual({ kind: "pinned", total: 1, unread: 0 });
+    expect(sections).toContainEqual({
+      kind: "group",
+      groupId: group.id,
+      name: "Sections Spread Group",
+      icon: null,
+      sortPosition: group.sortPosition,
+      total: 2,
+      unread: 0,
+    });
+    expect(sections).toContainEqual({
+      kind: "channel",
+      channelId: "slack",
+      total: 1,
+      unread: 0,
+    });
+    // NULL origin_channel reads as native, exactly as the list filter reads
+    // it, so the stamped and unstamped native rows share the Chats bucket.
+    expect(sections).toContainEqual({ kind: "chats", total: 2, unread: 0 });
+  });
+
+  test("unread counts follow the seen state per section", () => {
+    const pinned = createConversation({ title: "pinned-seen" });
+    pin(pinned.id);
+    seedUnseen(pinned.id);
+    recordConversationSeenSignal({
+      conversationId: pinned.id,
+      sourceChannel: "vellum",
+      signalType: "macos_conversation_opened",
+      confidence: "explicit",
+      source: "test",
+    });
+
+    const group = createGroup("Sections Unread Group");
+    const unreadInGroup = createConversation({ title: "g-unread" });
+    fileIntoGroup(unreadInGroup.id, group.id);
+    seedUnseen(unreadInGroup.id);
+    // A member with no attention projection at all reads as seen.
+    fileIntoGroup(createConversation({ title: "g-quiet" }).id, group.id);
+
+    const chatsUnread = createConversation({ title: "chat-unread" });
+    seedUnseen(chatsUnread.id);
+
+    const sections = invokeSections();
+
+    expect(sections).toContainEqual({ kind: "pinned", total: 1, unread: 0 });
+    expect(sections).toContainEqual({
+      kind: "group",
+      groupId: group.id,
+      name: "Sections Unread Group",
+      icon: null,
+      sortPosition: group.sortPosition,
+      total: 2,
+      unread: 1,
+    });
+    expect(sections).toContainEqual({ kind: "chats", total: 1, unread: 1 });
+  });
+
+  test("a background row filed into a group counts toward total but never unread", () => {
+    // Mirrors the unread-count contract: the custom-group visibility arm
+    // admits the row into the section, and the not-background unread rule
+    // keeps it out of the badge.
+    const group = createGroup("Sections Background Group");
+    const bg = createConversation({
+      title: "bg-in-group",
+      conversationType: "background",
+    });
+    fileIntoGroup(bg.id, group.id);
+    seedUnseen(bg.id);
+
+    const sections = invokeSections();
+
+    expect(sections).toContainEqual({
+      kind: "group",
+      groupId: group.id,
+      name: "Sections Background Group",
+      icon: null,
+      sortPosition: group.sortPosition,
+      total: 1,
+      unread: 0,
+    });
+  });
+
+  test("an empty custom group gets no section", () => {
+    const group = createGroup("Sections Empty Group");
+
+    const sections = invokeSections();
+
+    expect(sections.some((s) => s.groupId === group.id)).toBe(false);
+  });
+
+  test("archived rows count toward no section", () => {
+    const group = createGroup("Sections Archived Group");
+    fileIntoGroup(seedArchived("archived-in-group"), group.id);
+
+    const sections = invokeSections();
+
+    expect(sections.some((s) => s.groupId === group.id)).toBe(false);
+  });
+
+  test("a dangling group id is skipped, not surfaced", () => {
+    fileIntoGroup(
+      createConversation({ title: "dangling" }).id,
+      "00000000-0000-4000-8000-00000000dead",
+    );
+
+    const sections = invokeSections();
+
+    expect(sections.some((s) => s.kind === "group")).toBe(false);
+    // Grouped, so it does not leak into the ungrouped Chats bucket either.
+    expect(sections).toContainEqual({ kind: "chats", total: 0, unread: 0 });
+  });
+
+  test("an unsurfaced background row pinned by raw column writes stays invisible", () => {
+    // Standard-listing visibility admits a pinned background row only when
+    // it is surfaced (the pinned group fails the custom-group arm on its
+    // system: prefix), so it appears in neither the Pinned list nor the
+    // Pinned count.
+    const bg = createConversation({
+      title: "bg-pinned",
+      conversationType: "background",
+    });
+    pin(bg.id);
+
+    const sections = invokeSections();
+
+    expect(sections.some((s) => s.kind === "pinned")).toBe(false);
+  });
+});

--- a/assistant/src/runtime/routes/conversation-list-routes.ts
+++ b/assistant/src/runtime/routes/conversation-list-routes.ts
@@ -3,6 +3,7 @@
  *
  * GET    /v1/conversations              — paginated conversation list
  * GET    /v1/conversations/unread-count - count of unseen foreground conversations
+ * GET    /v1/conversations/sections     - per-section totals for the sidebar index
  * POST   /v1/conversations/seen         — record a seen signal (single)
  * POST   /v1/conversations/seen/bulk    — record seen signals (batch)
  * POST   /v1/conversations/unread       — mark a conversation unread
@@ -29,6 +30,7 @@ import { resolveConversationId } from "../../persistence/conversation-key-store.
 import {
   type ConversationListFilter,
   countConversations,
+  countConversationSections,
   countUnreadConversations,
   listConversations,
   listPinnedConversations,
@@ -153,6 +155,42 @@ const conversationDetailResponseSchema = z.object({
 
 const unreadConversationCountResponseSchema = z.object({
   count: z.number(),
+});
+
+const sectionCountFields = {
+  total: z.number(),
+  unread: z.number(),
+};
+
+/**
+ * One renderable sidebar section. Discriminated by `kind` so clients get a
+ * typed union: group sections carry their metadata inline (one consistent
+ * snapshot, no join against `GET /v1/groups` that could disagree with it),
+ * channel sections carry only the id (labels are client-side i18n), and
+ * `chats` is the ungrouped-native bucket. In a view without channel sections
+ * the Chats card holds every ungrouped row: the buckets are disjoint, so
+ * that reading is `chats` plus the sum of `channel` entries.
+ */
+const conversationSectionSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("pinned"), ...sectionCountFields }),
+  z.object({
+    kind: z.literal("group"),
+    groupId: z.string(),
+    name: z.string(),
+    icon: z.string().nullable(),
+    sortPosition: z.number(),
+    ...sectionCountFields,
+  }),
+  z.object({
+    kind: z.literal("channel"),
+    channelId: z.string(),
+    ...sectionCountFields,
+  }),
+  z.object({ kind: z.literal("chats"), ...sectionCountFields }),
+]);
+
+const conversationSectionsResponseSchema = z.object({
+  sections: z.array(conversationSectionSchema),
 });
 
 // ---------------------------------------------------------------------------
@@ -290,6 +328,64 @@ function handleListConversations({ queryParams = {} }: RouteHandlerArgs) {
 
 function handleGetUnreadConversationCount() {
   return { count: countUnreadConversations() };
+}
+
+/**
+ * One row per non-empty sidebar section, no conversation rows. What this
+ * exists to answer without a list drain: which sections render at all,
+ * and what their rail badges say.
+ *
+ * A count row whose `group_id` names no existing non-system group is
+ * skipped rather than surfaced: those rows are unreachable as a section
+ * (the sidebar builds group sections from the groups table), and a
+ * dangling id is a transient state around group deletion, not a section.
+ */
+function handleGetConversationSections() {
+  const counts = countConversationSections();
+  const groupsById = new Map(listGroups().map((g) => [g.id, g]));
+  const sections: Array<z.infer<typeof conversationSectionSchema>> = [];
+
+  for (const row of counts.groups) {
+    if (row.groupId === "system:pinned") {
+      sections.push({ kind: "pinned", total: row.total, unread: row.unread });
+      continue;
+    }
+    const meta = groupsById.get(row.groupId);
+    if (!meta || meta.isSystemGroup) {
+      continue;
+    }
+    sections.push({
+      kind: "group",
+      groupId: row.groupId,
+      name: meta.name,
+      icon: meta.icon,
+      sortPosition: meta.sortPosition,
+      total: row.total,
+      unread: row.unread,
+    });
+  }
+
+  for (const row of counts.channels) {
+    if (row.channel === "vellum") {
+      sections.push({ kind: "chats", total: row.total, unread: row.unread });
+      continue;
+    }
+    sections.push({
+      kind: "channel",
+      channelId: row.channel,
+      total: row.total,
+      unread: row.unread,
+    });
+  }
+
+  /* Every other section exists only when it has rows; Chats is the leftover
+     bucket and renders regardless, so its counts are part of the contract
+     even at zero. */
+  if (!sections.some((s) => s.kind === "chats")) {
+    sections.push({ kind: "chats", total: 0, unread: 0 });
+  }
+
+  return { sections };
 }
 
 function handleRecordSeen({ body = {}, headers }: RouteHandlerArgs) {
@@ -482,7 +578,7 @@ export const ROUTES: RouteDefinition[] = [
         type: "string",
         required: false,
         description:
-          'Filter to a single group, so each sidebar section can load independently of the paginated list. Pass "system:all" for conversations in no group, "system:pinned" for the Pinned section, or a custom group id. A group-scoped request is ordered by the user\'s arrangement (display order, then recency) and never has pinned rows appended to it. Omit to span every group.',
+          'Filter to a single group, so each sidebar section can load independently of the paginated list. Pass "system:all" for conversations in no group, "system:pinned" for the Pinned section, or a custom group id. A group-scoped request is recency-ordered like every list read (COALESCE(last_message_at, updated_at) descending) and never has pinned rows appended to it. Omit to span every group.',
       },
     ],
     responseBody: listConversationsResponseSchema,
@@ -502,6 +598,21 @@ export const ROUTES: RouteDefinition[] = [
     tags: ["conversations"],
     responseBody: unreadConversationCountResponseSchema,
     handler: handleGetUnreadConversationCount,
+  },
+  {
+    operationId: "getConversationSections",
+    endpoint: "conversations/sections",
+    method: "GET",
+    policy: {
+      requiredScopes: ["chat.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Sidebar section index",
+    description:
+      "One row per renderable sidebar section (Pinned, each non-empty custom group, each origin channel with unassigned conversations, Chats) with total and unread counts and no conversation rows. Lets a client know which sections exist, and what their badges say, without fetching any conversation list. Totals follow the standard listing visibility; unread applies the same rules as GET /v1/conversations/unread-count scoped to the section. Chats is always present, even at zero: it is the leftover bucket and renders regardless.",
+    tags: ["conversations"],
+    responseBody: conversationSectionsResponseSchema,
+    handler: handleGetConversationSections,
   },
   {
     operationId: "recordConversationSeen",


### PR DESCRIPTION
## TL;DR

New daemon read, `GET /v1/conversations/sections`: one row per renderable sidebar section (Pinned, each non-empty custom group, each origin channel with unassigned conversations, Chats) with total and unread counts and **no conversation rows**. Today the client answers "which sections exist" and "what do the rail badges say" by draining the entire foreground conversation list — the coupling that keeps a windowed list (LUM-2444) unshippable. This is the server half; the client cutover follows as its own PR.

Fixes LUM-3216. Part of LUM-2443.

## Design

Two aggregate queries answer everything, and the axes are disjoint by construction because `group_id` is single-valued:

- **Rows filed somewhere** bucket by `group_id` (Pinned plus custom groups; the background/scheduled system buckets are excluded because no section renders them).
- **Rows filed nowhere** bucket by effective origin channel, with NULL reading as native *exactly* as the list filter reads it (`originChannelClause`), so the stamped-vellum and not-yet-attributed rows share the Chats bucket.

Because the buckets are disjoint, both sidebar views derive from one response: the grouped view renders the rows directly, and the flat view's Chats is `chats + sum(channels)`.

**Counts are composed from the executing predicates, not restated.** `total` uses the same standard-listing visibility (`conversationTypeClause`) as the list endpoint, so each bucket counts exactly the rows `GET /v1/conversations` returns for that section's filter — including the arms that are easy to get wrong (surfaced background rows count; an unsurfaced background row pinned by raw column writes doesn't; private and subagent rows are excluded by the same arms that exclude them from the list). `unread` embeds `notBackgroundVisibilitySql` + `unseenAttentionStateConditions` — the identical fragments `countUnreadConversations` uses — as a SUM(CASE) over a LEFT JOIN, so per-section unread always sums against the global count. The join-shape difference (LEFT + conditions in the CASE, vs the count's INNER + conditions in WHERE) is commented at the definition with why membership is identical.

Group sections carry `name`/`icon`/`sortPosition` inline: one consistent snapshot rather than a client join against `GET /v1/groups` that could disagree with it. Channel sections carry only the id — labels are client-side i18n. Chats is present even at zero, because it's the leftover bucket and renders regardless; every other section exists only when it has rows, which is what finally lets the client stop rendering cards for empty groups (an unmet LUM-2443 acceptance criterion).

## What this is *not*

No conversation rows, no pagination, no new sync tags (the existing `conversationsList` invalidations cover refetch), no version gate (daemon-side; the client decides gate-vs-gateless-404 per `BACKWARDS_COMPAT.md` when it consumes this), and no client changes.

## Also in here

The `groupId` parameter description on the list endpoint claimed group-scoped reads are ordered by "the user's arrangement (display order, then recency)". The executing `ORDER BY` is `COALESCE(last_message_at, updated_at) DESC, id DESC` — recency only, nothing has consulted `display_order` since LUM-3108. Corrected while in the file; this stale text misdirected real work earlier in this arc.

## Why it is safe

- Pure read; satisfies the GET-idempotency rule in `runtime/AGENTS.md`. No schema changes, no migrations.
- Additive endpoint at a literal path; the router's typed segments already disambiguate literals from `conversations/:id` (the `unread-count` precedent).
- Visibility and unread logic is reused, not duplicated — a future change to either predicate flows into these counts by construction.

## Testing

Local test runs are blocked on this machine (standing rule); CI is the verifier. Eight scenarios in the route test file, added to the same harness the list/unread tests use (real in-memory DB), each hand-traced through the SQL arms before push: the empty table (Chats alone at zero), every section kind with its own totals, per-section seen-state math (seen, unseen, and no-projection members), the background-row-in-group case (counts toward total, never unread — the unread-count contract scoped to a section), empty groups omitted, archived rows counting toward nothing, a dangling `group_id` skipped without leaking into Chats, and the unsurfaced-pinned-background row staying invisible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40591" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->