### PR TITLE
feat(config): collapse profile bindings into entry names and enable them

### DIFF
--- a/assistant/src/__tests__/custom-profile-ensure.test.ts
+++ b/assistant/src/__tests__/custom-profile-ensure.test.ts
@@ -53,8 +53,9 @@ describe("ensureCompleteCustomProfiles", () => {
     ensureCompleteCustomProfiles(workspaceDir);
     const saved = readProfiles().partial;
     expect(saved.model).toBe("claude-haiku-4-5-20251001");
-    expect(saved.provider).toBe("anthropic");
-    // Completion never stamps a binding under the entries model.
+    // The default's binding is inherited IN the provider value (entries
+    // representation), never as a stamped binding field.
+    expect(saved.provider).toBe("anthropic-personal");
     expect(saved.provider_connection).toBeUndefined();
     expect(saved.maxTokens).toBe(12345);
     expect(saved.temperature).toBe(0.7);
@@ -165,7 +166,7 @@ describe("ensureCompleteCustomProfiles", () => {
     });
     ensureCompleteCustomProfiles(workspaceDir);
     expect(readProfiles().partial.futureField).toBe("keep-me");
-    expect(readProfiles().partial.provider).toBe("anthropic");
+    expect(readProfiles().partial.provider).toBe("anthropic-personal");
   });
 
   test("does not bake null default sampling; preserves explicit profile null", () => {

--- a/assistant/src/__tests__/custom-profile-ensure.test.ts
+++ b/assistant/src/__tests__/custom-profile-ensure.test.ts
@@ -53,10 +53,12 @@ describe("ensureCompleteCustomProfiles", () => {
     ensureCompleteCustomProfiles(workspaceDir);
     const saved = readProfiles().partial;
     expect(saved.model).toBe("claude-haiku-4-5-20251001");
-    // The default's binding is inherited IN the provider value (entries
-    // representation), never as a stamped binding field.
-    expect(saved.provider).toBe("anthropic-personal");
-    expect(saved.provider_connection).toBeUndefined();
+    // This workspace has no connection rows, so the binding is unverifiable
+    // and passes through in the legacy field for the collapse migration to
+    // judge; with a verified row it would fold into the provider value (see
+    // profile-materialization.test.ts).
+    expect(saved.provider).toBe("anthropic");
+    expect(saved.provider_connection).toBe("anthropic-personal");
     expect(saved.maxTokens).toBe(12345);
     expect(saved.temperature).toBe(0.7);
     expect(saved.logitBias).toBeUndefined();
@@ -166,7 +168,7 @@ describe("ensureCompleteCustomProfiles", () => {
     });
     ensureCompleteCustomProfiles(workspaceDir);
     expect(readProfiles().partial.futureField).toBe("keep-me");
-    expect(readProfiles().partial.provider).toBe("anthropic-personal");
+    expect(readProfiles().partial.provider).toBe("anthropic");
   });
 
   test("does not bake null default sampling; preserves explicit profile null", () => {

--- a/assistant/src/__tests__/custom-profile-ensure.test.ts
+++ b/assistant/src/__tests__/custom-profile-ensure.test.ts
@@ -54,7 +54,8 @@ describe("ensureCompleteCustomProfiles", () => {
     const saved = readProfiles().partial;
     expect(saved.model).toBe("claude-haiku-4-5-20251001");
     expect(saved.provider).toBe("anthropic");
-    expect(saved.provider_connection).toBe("anthropic-personal");
+    // Completion never stamps a binding under the entries model.
+    expect(saved.provider_connection).toBeUndefined();
     expect(saved.maxTokens).toBe(12345);
     expect(saved.temperature).toBe(0.7);
     expect(saved.logitBias).toBeUndefined();
@@ -91,7 +92,7 @@ describe("ensureCompleteCustomProfiles", () => {
       },
     });
     ensureCompleteCustomProfiles(workspaceDir);
-    expect(readProfiles().gpt.provider_connection).toBe("vellum");
+    expect(readProfiles().gpt.provider_connection).toBeUndefined();
     expect(readProfiles().router.provider_connection).toBeUndefined();
   });
 

--- a/assistant/src/__tests__/llm-context-resolution.test.ts
+++ b/assistant/src/__tests__/llm-context-resolution.test.ts
@@ -1,4 +1,21 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
+
+// Entry-name providers resolve context limits through their row's kind, so
+// the tests control the row store directly. A dangling label (no row) falls
+// back to the model's catalog owner.
+const connectionRows = new Map<string, { name: string; provider: string }>([
+  ["openai-work", { name: "openai-work", provider: "openai" }],
+  ["my-endpoint", { name: "my-endpoint", provider: "openai-compatible" }],
+]);
+mock.module("../persistence/db-connection.js", () => ({
+  getDb: () => ({}),
+}));
+mock.module("../providers/inference/connections.js", () => ({
+  getConnection: (_db: unknown, name: string) =>
+    connectionRows.get(name) ?? null,
+  listConnections: () => [],
+  canonicalVellumConnection: () => null,
+}));
 
 import { resolveEffectiveContextWindow } from "../config/llm-context-resolution.js";
 import { LLMSchema } from "../config/schemas/llm.js";
@@ -131,13 +148,13 @@ describe("resolveEffectiveContextWindow", () => {
     expect(resolved.modelMaxInputTokens).toBe(1050000);
   });
 
-  test("an entry-name provider resolves the model's own context limits", () => {
+  test("an entry of a catalog kind resolves the model's own context limits", () => {
     // The entries collapse stores connection names in the provider field;
-    // the model's catalog owner carries its limits regardless of which key
-    // serves it, so an entry label must not fall back to the 200k default.
+    // the row's kind carries the model's limits, so an entry label must not
+    // fall back to the 200k default when its kind serves the model.
     const llm = LLMSchema.parse({
       profiles: {
-        work: { provider: "anthropic-work", model: "gpt-5.5" },
+        work: { provider: "openai-work", model: "gpt-5.5" },
       },
       activeProfile: "work",
     });
@@ -149,6 +166,41 @@ describe("resolveEffectiveContextWindow", () => {
 
     expect(resolved.modelMaxInputTokens).toBe(1050000);
     expect(resolved.maxOutputTokens).toBeDefined();
+  });
+
+  test("a custom-endpoint entry keeps the conservative default for a catalog-colliding model id", () => {
+    // An openai-compatible endpoint's "gpt-5.5" is not OpenAI's; inheriting
+    // the built-in 1.05M limit would let oversized requests through.
+    const llm = LLMSchema.parse({
+      profiles: {
+        custom: { provider: "my-endpoint", model: "gpt-5.5" },
+      },
+      activeProfile: "custom",
+    });
+
+    const resolved = resolveEffectiveContextWindow({
+      llm,
+      callSite: "mainAgent",
+    });
+
+    expect(resolved.modelMaxInputTokens).toBe(200000);
+    expect(resolved.maxOutputTokens).toBeUndefined();
+  });
+
+  test("a label with no row falls back to the model's catalog owner", () => {
+    const llm = LLMSchema.parse({
+      profiles: {
+        gone: { provider: "deleted-entry", model: "gpt-5.5" },
+      },
+      activeProfile: "gone",
+    });
+
+    const resolved = resolveEffectiveContextWindow({
+      llm,
+      callSite: "mainAgent",
+    });
+
+    expect(resolved.modelMaxInputTokens).toBe(1050000);
   });
 
   test("unknown catalog model falls back safely to the default 200k cap", () => {

--- a/assistant/src/__tests__/llm-context-resolution.test.ts
+++ b/assistant/src/__tests__/llm-context-resolution.test.ts
@@ -131,6 +131,26 @@ describe("resolveEffectiveContextWindow", () => {
     expect(resolved.modelMaxInputTokens).toBe(1050000);
   });
 
+  test("an entry-name provider resolves the model's own context limits", () => {
+    // The entries collapse stores connection names in the provider field;
+    // the model's catalog owner carries its limits regardless of which key
+    // serves it, so an entry label must not fall back to the 200k default.
+    const llm = LLMSchema.parse({
+      profiles: {
+        work: { provider: "anthropic-work", model: "gpt-5.5" },
+      },
+      activeProfile: "work",
+    });
+
+    const resolved = resolveEffectiveContextWindow({
+      llm,
+      callSite: "mainAgent",
+    });
+
+    expect(resolved.modelMaxInputTokens).toBe(1050000);
+    expect(resolved.maxOutputTokens).toBeDefined();
+  });
+
   test("unknown catalog model falls back safely to the default 200k cap", () => {
     const llm = LLMSchema.parse({
       callSites: {

--- a/assistant/src/__tests__/provider-commit-message-generator.test.ts
+++ b/assistant/src/__tests__/provider-commit-message-generator.test.ts
@@ -62,6 +62,7 @@ const mockProvider: Provider = {
 let resolvedProvider: {
   provider: Provider;
   configuredProviderName: string;
+  entryRouted?: boolean;
 } | null = {
   provider: mockProvider,
   configuredProviderName: "anthropic",
@@ -344,6 +345,25 @@ describe("ProviderCommitMessageGenerator", () => {
       configuredProviderName: "vellum",
     };
     const commitMsg = "fix: managed-route commit";
+    mockSendMessage.mockResolvedValueOnce(makeSuccessResponse(commitMsg));
+    const gen = getCommitMessageGenerator();
+    const result = await gen.generateCommitMessage(baseContext, {
+      changedFiles: baseContext.changedFiles,
+    });
+    expect(result.source).toBe("llm");
+    expect(result.message).toBe(commitMsg);
+  });
+
+  // 14. Entry-routed profile — the row's own credential signed resolution,
+  // so no generic per-vendor key needs to exist for the preflight to pass.
+  test("entry-routed result — skips the vendor API-key preflight", async () => {
+    mockSecureKeys = {};
+    resolvedProvider = {
+      provider: mockProvider,
+      configuredProviderName: "anthropic",
+      entryRouted: true,
+    };
+    const commitMsg = "fix: entry-route commit";
     mockSendMessage.mockResolvedValueOnce(makeSuccessResponse(commitMsg));
     const gen = getCommitMessageGenerator();
     const result = await gen.generateCommitMessage(baseContext, {

--- a/assistant/src/__tests__/workspace-migration-145-collapse-profile-bindings-to-entries.test.ts
+++ b/assistant/src/__tests__/workspace-migration-145-collapse-profile-bindings-to-entries.test.ts
@@ -180,8 +180,8 @@ describe("145-collapse-profile-bindings-to-entries", () => {
     expect(managed).not.toHaveProperty("provider_connection");
   });
 
-  test("deletes a self-referential binding without rewriting the provider", () => {
-    seedRows([{ name: "anthropic", provider: "anthropic" }]);
+  test("deletes a self-referential binding when no row claims that name", () => {
+    seedRows([{ name: "anthropic-work", provider: "anthropic" }]);
     writeConfig({
       llm: {
         profiles: {
@@ -200,7 +200,7 @@ describe("145-collapse-profile-bindings-to-entries", () => {
     expect(readProfiles().plain).not.toHaveProperty("provider_connection");
   });
 
-  test("throws (for retry) when bindings exist but the DB is unreadable", () => {
+  test("an absent DB file means genuinely dangling bindings (restored config)", () => {
     writeConfig({
       llm: {
         profiles: {
@@ -212,7 +212,30 @@ describe("145-collapse-profile-bindings-to-entries", () => {
         },
       },
     });
-    // No DB seeded at all.
+    // No DB at all: a config restored into a fresh workspace has no rows.
+
+    run();
+
+    const bound = readProfiles().bound;
+    expect(bound.provider).toBe("anthropic");
+    expect(bound).not.toHaveProperty("provider_connection");
+  });
+
+  test("throws (for retry) when bindings exist but the DB is unqueryable", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          bound: {
+            provider: "anthropic",
+            provider_connection: "anthropic-work",
+            model: "claude-opus-4-8",
+          },
+        },
+      },
+    });
+    // DB file exists but carries no provider_connections table.
+    mkdirSync(join(workspaceDir, "data", "db"), { recursive: true });
+    new Database(join(workspaceDir, "data", "db", "assistant.db")).close();
 
     expect(() => run()).toThrow(/not readable/);
     // Config untouched: no destructive guess was made.
@@ -220,6 +243,61 @@ describe("145-collapse-profile-bindings-to-entries", () => {
     expect(
       collapseProfileBindingsToEntriesMigration.retryFailedCheckpoint,
     ).toBe(true);
+  });
+
+  test("folds a canonical vellum binding only for identity-servable models", () => {
+    seedRows([{ name: "vellum", provider: "vellum" }]);
+    writeConfig({
+      llm: {
+        profiles: {
+          routable: {
+            provider: "anthropic",
+            provider_connection: "vellum",
+            model: "claude-opus-4-8",
+          },
+          stale: {
+            provider: "anthropic",
+            provider_connection: "vellum",
+            model: "claude-ancient-1",
+          },
+        },
+      },
+    });
+
+    run();
+
+    const routable = readProfiles().routable;
+    expect(routable.provider).toBe("vellum");
+    expect(routable).not.toHaveProperty("provider_connection");
+    // An unservable model would be stripped by the read-path schema if
+    // folded to the identity; the profile stays untouched instead.
+    const stale = readProfiles().stale;
+    expect(stale.provider).toBe("anthropic");
+    expect(stale.provider_connection).toBe("vellum");
+  });
+
+  test("keeps a self-named binding when a row by that name exists", () => {
+    seedRows([
+      { name: "anthropic", provider: "anthropic" },
+      { name: "anthropic-2", provider: "anthropic" },
+    ]);
+    writeConfig({
+      llm: {
+        profiles: {
+          pinned: {
+            provider: "anthropic",
+            provider_connection: "anthropic",
+            model: "claude-opus-4-8",
+          },
+        },
+      },
+    });
+
+    run();
+
+    // The explicit pin survives: with sibling rows, the bare vendor would
+    // auto-resolve differently.
+    expect(readProfiles().pinned.provider_connection).toBe("anthropic");
   });
 
   test("no-ops without bindings and is idempotent", () => {

--- a/assistant/src/__tests__/workspace-migration-145-collapse-profile-bindings-to-entries.test.ts
+++ b/assistant/src/__tests__/workspace-migration-145-collapse-profile-bindings-to-entries.test.ts
@@ -1,0 +1,247 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { collapseProfileBindingsToEntriesMigration } from "../workspace/migrations/145-collapse-profile-bindings-to-entries.js";
+import { assertNotLiveDb } from "./assert-not-live-db.js";
+
+let workspaceDir: string;
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readProfiles(): Record<string, Record<string, unknown>> {
+  const raw = JSON.parse(
+    readFileSync(join(workspaceDir, "config.json"), "utf-8"),
+  ) as { llm?: { profiles?: Record<string, Record<string, unknown>> } };
+  return raw.llm?.profiles ?? {};
+}
+
+function seedRows(rows: Array<{ name: string; provider: string }>): void {
+  mkdirSync(join(workspaceDir, "data", "db"), { recursive: true });
+  const db = new Database(join(workspaceDir, "data", "db", "assistant.db"));
+  db.run(`CREATE TABLE IF NOT EXISTS provider_connections (
+    name TEXT PRIMARY KEY,
+    provider TEXT NOT NULL,
+    auth TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+  )`);
+  for (const row of rows) {
+    db.query(
+      `INSERT INTO provider_connections (name, provider, auth, created_at, updated_at) VALUES (?, ?, '{"type":"api_key"}', 1, 1)`,
+    ).run(row.name, row.provider);
+  }
+  db.close();
+}
+
+function run(): void {
+  collapseProfileBindingsToEntriesMigration.run(workspaceDir);
+}
+
+beforeEach(() => {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-145-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    assertNotLiveDb(workspaceDir);
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+describe("145-collapse-profile-bindings-to-entries", () => {
+  test("folds a kind-agreeing binding into provider as the entry name", () => {
+    seedRows([{ name: "anthropic-work", provider: "anthropic" }]);
+    writeConfig({
+      llm: {
+        profiles: {
+          work: {
+            provider: "anthropic",
+            provider_connection: "anthropic-work",
+            model: "claude-opus-4-8",
+          },
+        },
+      },
+    });
+
+    run();
+
+    const work = readProfiles().work;
+    expect(work.provider).toBe("anthropic-work");
+    expect(work).not.toHaveProperty("provider_connection");
+    expect(work.model).toBe("claude-opus-4-8");
+  });
+
+  test("maps identity kinds when judging agreement", () => {
+    seedRows([
+      { name: "team-managed", provider: "vellum" },
+      { name: "chatgpt-subscription", provider: "chatgpt" },
+    ]);
+    writeConfig({
+      llm: {
+        profiles: {
+          managed: {
+            provider: "anthropic",
+            provider_connection: "team-managed",
+            model: "claude-opus-4-8",
+          },
+          codex: {
+            provider: "openai",
+            provider_connection: "chatgpt-subscription",
+            model: "gpt-5.5",
+          },
+        },
+      },
+    });
+
+    run();
+
+    expect(readProfiles().managed.provider).toBe("team-managed");
+    expect(readProfiles().codex.provider).toBe("chatgpt-subscription");
+  });
+
+  test("keeps the vendor and drops a dangling binding with a warn", () => {
+    seedRows([]);
+    writeConfig({
+      llm: {
+        profiles: {
+          stale: {
+            provider: "anthropic",
+            provider_connection: "deleted-row",
+            model: "claude-opus-4-8",
+          },
+        },
+      },
+    });
+
+    run();
+
+    const stale = readProfiles().stale;
+    expect(stale.provider).toBe("anthropic");
+    expect(stale).not.toHaveProperty("provider_connection");
+  });
+
+  test("keeps the vendor and drops a kind-disagreeing binding", () => {
+    seedRows([{ name: "ollama-local", provider: "ollama" }]);
+    writeConfig({
+      llm: {
+        profiles: {
+          conflicted: {
+            provider: "anthropic",
+            provider_connection: "ollama-local",
+            model: "claude-opus-4-8",
+          },
+        },
+      },
+    });
+
+    run();
+
+    const conflicted = readProfiles().conflicted;
+    expect(conflicted.provider).toBe("anthropic");
+    expect(conflicted).not.toHaveProperty("provider_connection");
+  });
+
+  test("strips a stray binding from a routing-identity profile", () => {
+    seedRows([{ name: "vellum", provider: "vellum" }]);
+    writeConfig({
+      llm: {
+        profiles: {
+          managed: {
+            provider: "vellum",
+            provider_connection: "vellum",
+            model: "claude-opus-4-8",
+          },
+        },
+      },
+    });
+
+    run();
+
+    const managed = readProfiles().managed;
+    expect(managed.provider).toBe("vellum");
+    expect(managed).not.toHaveProperty("provider_connection");
+  });
+
+  test("deletes a self-referential binding without rewriting the provider", () => {
+    seedRows([{ name: "anthropic", provider: "anthropic" }]);
+    writeConfig({
+      llm: {
+        profiles: {
+          plain: {
+            provider: "anthropic",
+            provider_connection: "anthropic",
+            model: "claude-opus-4-8",
+          },
+        },
+      },
+    });
+
+    run();
+
+    expect(readProfiles().plain.provider).toBe("anthropic");
+    expect(readProfiles().plain).not.toHaveProperty("provider_connection");
+  });
+
+  test("throws (for retry) when bindings exist but the DB is unreadable", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          bound: {
+            provider: "anthropic",
+            provider_connection: "anthropic-work",
+            model: "claude-opus-4-8",
+          },
+        },
+      },
+    });
+    // No DB seeded at all.
+
+    expect(() => run()).toThrow(/not readable/);
+    // Config untouched: no destructive guess was made.
+    expect(readProfiles().bound.provider_connection).toBe("anthropic-work");
+    expect(
+      collapseProfileBindingsToEntriesMigration.retryFailedCheckpoint,
+    ).toBe(true);
+  });
+
+  test("no-ops without bindings and is idempotent", () => {
+    seedRows([{ name: "anthropic-work", provider: "anthropic" }]);
+    writeConfig({
+      llm: {
+        profiles: {
+          work: {
+            provider: "anthropic",
+            provider_connection: "anthropic-work",
+            model: "claude-opus-4-8",
+          },
+          unbound: { provider: "vellum", model: "claude-opus-4-8" },
+        },
+      },
+    });
+
+    run();
+    const afterFirst = readProfiles();
+    run();
+
+    expect(readProfiles()).toEqual(afterFirst);
+    expect(afterFirst.unbound.provider).toBe("vellum");
+  });
+});

--- a/assistant/src/config/__tests__/profile-materialization.test.ts
+++ b/assistant/src/config/__tests__/profile-materialization.test.ts
@@ -29,7 +29,9 @@ describe("completeCustomProfile", () => {
     });
     expect(completed.model).toBe("claude-fable-5");
     expect(completed.provider).toBe("anthropic");
-    expect(completed.provider_connection).toBe("anthropic-personal");
+    // Completion never stamps a binding: the provider value alone
+    // carries the route under the entries model.
+    expect(completed.provider_connection).toBeUndefined();
     expect(completed.maxTokens).toBe(64000);
     expect(completed.effort).toBe("max");
     expect(completed.speed).toBe("standard");
@@ -83,7 +85,9 @@ describe("completeCustomProfile", () => {
       model: "claude-fable-5",
     });
     expect(completed.provider).toBe("anthropic");
-    expect(completed.provider_connection).toBe("anthropic-personal");
+    // Completion never stamps a binding: the provider value alone
+    // carries the route under the entries model.
+    expect(completed.provider_connection).toBeUndefined();
   });
 
   test("stamps the catalog owner for a model the default provider does not serve, and drops the default's connection", () => {
@@ -123,28 +127,23 @@ describe("completeCustomProfile", () => {
     expect(completed.provider_connection).toBeUndefined();
   });
 
-  test("inherits the vellum managed connection across a provider change, but only onto managed-routable providers", () => {
+  test("never inherits a connection binding, managed default included", () => {
+    // The provider value alone carries the route under the entries model;
+    // completion inheriting the managed binding would re-introduce the
+    // collapsed field on disk.
     const managedDefault = LLMConfigBase.parse({
       ...fullDefault,
       provider_connection: VELLUM_MANAGED_CONNECTION_NAME,
     });
     const implied = completeCustomProfile(managedDefault, { model: "gpt-5.5" });
     expect(implied.provider).toBe("openai");
-    expect(implied.provider_connection).toBe(VELLUM_MANAGED_CONNECTION_NAME);
+    expect(implied.provider_connection).toBeUndefined();
 
     const explicit = completeCustomProfile(managedDefault, {
       provider: "openai",
       model: "gpt-5.4",
     });
-    expect(explicit.provider_connection).toBe(VELLUM_MANAGED_CONNECTION_NAME);
-
-    // The vellum connection can't route a non-managed provider; baking it in
-    // would fail dispatch's mismatch path instead of auto-resolving.
-    const nonRoutable = completeCustomProfile(managedDefault, {
-      provider: "openrouter",
-      model: "minimax/minimax-m3",
-    });
-    expect(nonRoutable.provider_connection).toBeUndefined();
+    expect(explicit.provider_connection).toBeUndefined();
   });
 
   test("keeps the inherited provider for a model unknown to the catalog", () => {
@@ -152,7 +151,9 @@ describe("completeCustomProfile", () => {
       model: "totally-custom-model",
     });
     expect(completed.provider).toBe("anthropic");
-    expect(completed.provider_connection).toBe("anthropic-personal");
+    // Completion never stamps a binding: the provider value alone
+    // carries the route under the entries model.
+    expect(completed.provider_connection).toBeUndefined();
   });
 
   test("passes mix profiles through untouched", () => {

--- a/assistant/src/config/__tests__/profile-materialization.test.ts
+++ b/assistant/src/config/__tests__/profile-materialization.test.ts
@@ -28,9 +28,9 @@ describe("completeCustomProfile", () => {
       model: "claude-fable-5",
     });
     expect(completed.model).toBe("claude-fable-5");
-    expect(completed.provider).toBe("anthropic");
-    // Completion never stamps a binding: the provider value alone
-    // carries the route under the entries model.
+    // The default's explicit binding is inherited IN the provider value
+    // (the entries-model representation), never as a stamped binding.
+    expect(completed.provider).toBe("anthropic-personal");
     expect(completed.provider_connection).toBeUndefined();
     expect(completed.maxTokens).toBe(64000);
     expect(completed.effort).toBe("max");
@@ -80,13 +80,11 @@ describe("completeCustomProfile", () => {
     expect(completed.contextWindow?.overflowRecovery?.enabled).toBe(true);
   });
 
-  test("keeps the inherited provider when it serves the profile's model", () => {
+  test("inherits the default's binding as the entry name when the provider serves the model", () => {
     const completed = completeCustomProfile(fullDefault, {
       model: "claude-fable-5",
     });
-    expect(completed.provider).toBe("anthropic");
-    // Completion never stamps a binding: the provider value alone
-    // carries the route under the entries model.
+    expect(completed.provider).toBe("anthropic-personal");
     expect(completed.provider_connection).toBeUndefined();
   });
 
@@ -127,32 +125,28 @@ describe("completeCustomProfile", () => {
     expect(completed.provider_connection).toBeUndefined();
   });
 
-  test("never inherits a connection binding, managed default included", () => {
-    // The provider value alone carries the route under the entries model;
-    // completion inheriting the managed binding would re-introduce the
-    // collapsed field on disk.
+  test("a managed default's binding becomes the routing identity, never a stamped field", () => {
     const managedDefault = LLMConfigBase.parse({
       ...fullDefault,
       provider_connection: VELLUM_MANAGED_CONNECTION_NAME,
     });
     const implied = completeCustomProfile(managedDefault, { model: "gpt-5.5" });
-    expect(implied.provider).toBe("openai");
+    expect(implied.provider).toBe("vellum");
     expect(implied.provider_connection).toBeUndefined();
 
     const explicit = completeCustomProfile(managedDefault, {
       provider: "openai",
       model: "gpt-5.4",
     });
+    expect(explicit.provider).toBe("vellum");
     expect(explicit.provider_connection).toBeUndefined();
   });
 
-  test("keeps the inherited provider for a model unknown to the catalog", () => {
+  test("inherits the binding as the entry name even for a model unknown to the catalog", () => {
     const completed = completeCustomProfile(fullDefault, {
       model: "totally-custom-model",
     });
-    expect(completed.provider).toBe("anthropic");
-    // Completion never stamps a binding: the provider value alone
-    // carries the route under the entries model.
+    expect(completed.provider).toBe("anthropic-personal");
     expect(completed.provider_connection).toBeUndefined();
   });
 

--- a/assistant/src/config/__tests__/profile-materialization.test.ts
+++ b/assistant/src/config/__tests__/profile-materialization.test.ts
@@ -197,7 +197,7 @@ describe("completeCustomProfile", () => {
     }
   });
 
-  test("a managed default binding passes through when the identity cannot serve the model", () => {
+  test("a managed default binding is not inherited when the identity cannot serve the model", () => {
     const managedDefault = LLMConfigBase.parse({
       ...fullDefault,
       provider_connection: VELLUM_MANAGED_CONNECTION_NAME,
@@ -205,8 +205,10 @@ describe("completeCustomProfile", () => {
     const completed = completeCustomProfile(managedDefault, {
       model: "totally-custom-model",
     });
+    // Dispatch auto-resolves by vendor instead of pinning an unservable
+    // managed route.
     expect(completed.provider).toBe("anthropic");
-    expect(completed.provider_connection).toBe(VELLUM_MANAGED_CONNECTION_NAME);
+    expect(completed.provider_connection).toBeUndefined();
   });
 
   test("passes mix profiles through untouched", () => {

--- a/assistant/src/config/__tests__/profile-materialization.test.ts
+++ b/assistant/src/config/__tests__/profile-materialization.test.ts
@@ -1,4 +1,17 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
+
+// Entry-name folds are gated on the named row existing with an agreeing
+// kind, so the tests control the row store directly.
+const connectionRows = new Map<string, { name: string; provider: string }>([
+  ["anthropic-personal", { name: "anthropic-personal", provider: "anthropic" }],
+]);
+mock.module("../../persistence/db-connection.js", () => ({
+  getDb: () => ({}),
+}));
+mock.module("../../providers/inference/connections.js", () => ({
+  getConnection: (_db: unknown, name: string) =>
+    connectionRows.get(name) ?? null,
+}));
 
 import { VELLUM_MANAGED_CONNECTION_NAME } from "../../providers/vellum-model-routing.js";
 import { completeCustomProfile } from "../profile-materialization.js";
@@ -148,6 +161,52 @@ describe("completeCustomProfile", () => {
     });
     expect(completed.provider).toBe("anthropic-personal");
     expect(completed.provider_connection).toBeUndefined();
+  });
+
+  test("a dangling default binding passes through as the legacy field", () => {
+    const dangling = LLMConfigBase.parse({
+      ...fullDefault,
+      provider_connection: "deleted-row",
+    });
+    const completed = completeCustomProfile(dangling, {
+      model: "claude-fable-5",
+    });
+    // Folding an unverifiable binding would hide it from the collapse
+    // migration's dangling recovery; the legacy field keeps it visible.
+    expect(completed.provider).toBe("anthropic");
+    expect(completed.provider_connection).toBe("deleted-row");
+  });
+
+  test("a kind-disagreeing default binding passes through as the legacy field", () => {
+    connectionRows.set("mislabeled", {
+      name: "mislabeled",
+      provider: "openai",
+    });
+    try {
+      const mismatched = LLMConfigBase.parse({
+        ...fullDefault,
+        provider_connection: "mislabeled",
+      });
+      const completed = completeCustomProfile(mismatched, {
+        model: "claude-fable-5",
+      });
+      expect(completed.provider).toBe("anthropic");
+      expect(completed.provider_connection).toBe("mislabeled");
+    } finally {
+      connectionRows.delete("mislabeled");
+    }
+  });
+
+  test("a managed default binding passes through when the identity cannot serve the model", () => {
+    const managedDefault = LLMConfigBase.parse({
+      ...fullDefault,
+      provider_connection: VELLUM_MANAGED_CONNECTION_NAME,
+    });
+    const completed = completeCustomProfile(managedDefault, {
+      model: "totally-custom-model",
+    });
+    expect(completed.provider).toBe("anthropic");
+    expect(completed.provider_connection).toBe(VELLUM_MANAGED_CONNECTION_NAME);
   });
 
   test("passes mix profiles through untouched", () => {

--- a/assistant/src/config/llm-context-resolution.ts
+++ b/assistant/src/config/llm-context-resolution.ts
@@ -1,3 +1,4 @@
+import { resolveEntryProviderKind } from "../providers/connection-resolution.js";
 import { ROUTING_IDENTITY_PROVIDERS } from "../providers/inference/auth.js";
 import {
   getCatalogProviderForModel,
@@ -54,16 +55,18 @@ export function resolveEffectiveContextWindow({
     forceOverrideProfile,
     selectionSeed,
   });
-  // Routing identities and entry-name providers are not catalog providers;
-  // the model's catalog owner carries its context-window limits either way,
-  // so any provider value without a catalog entry resolves through the
-  // model. This stays a pure catalog lookup (no row read): the model's
-  // limits are the model's regardless of which key serves it.
-  const catalogProviderId =
-    ROUTING_IDENTITY_PROVIDERS.has(resolved.provider) ||
-    !PROVIDER_CATALOG.some((p) => p.id === resolved.provider)
-      ? getCatalogProviderForModel(resolved.model)
-      : resolved.provider;
+  // Routing identities dispatch built-in catalog models, so the model's
+  // catalog owner carries their limits. An entry-name provider resolves
+  // through its row's kind instead: a custom-endpoint kind has no catalog
+  // models, so its models keep the conservative default even when a model
+  // id collides with a built-in one (the custom endpoint's "gpt-5.5" is not
+  // OpenAI's). Labels with no row fall back to the model's catalog owner.
+  const catalogProviderId = ROUTING_IDENTITY_PROVIDERS.has(resolved.provider)
+    ? getCatalogProviderForModel(resolved.model)
+    : PROVIDER_CATALOG.some((p) => p.id === resolved.provider)
+      ? resolved.provider
+      : (resolveEntryProviderKind(resolved.provider, resolved.model) ??
+        getCatalogProviderForModel(resolved.model));
   const catalogModel = PROVIDER_CATALOG.find(
     (provider) => provider.id === catalogProviderId,
   )?.models.find((model) => model.id === resolved.model);

--- a/assistant/src/config/llm-context-resolution.ts
+++ b/assistant/src/config/llm-context-resolution.ts
@@ -54,11 +54,16 @@ export function resolveEffectiveContextWindow({
     forceOverrideProfile,
     selectionSeed,
   });
-  // Routing identities are not catalog providers; the model's catalog owner
-  // carries its context-window limits.
-  const catalogProviderId = ROUTING_IDENTITY_PROVIDERS.has(resolved.provider)
-    ? getCatalogProviderForModel(resolved.model)
-    : resolved.provider;
+  // Routing identities and entry-name providers are not catalog providers;
+  // the model's catalog owner carries its context-window limits either way,
+  // so any provider value without a catalog entry resolves through the
+  // model. This stays a pure catalog lookup (no row read): the model's
+  // limits are the model's regardless of which key serves it.
+  const catalogProviderId =
+    ROUTING_IDENTITY_PROVIDERS.has(resolved.provider) ||
+    !PROVIDER_CATALOG.some((p) => p.id === resolved.provider)
+      ? getCatalogProviderForModel(resolved.model)
+      : resolved.provider;
   const catalogModel = PROVIDER_CATALOG.find(
     (provider) => provider.id === catalogProviderId,
   )?.models.find((model) => model.id === resolved.model);

--- a/assistant/src/config/profile-materialization.ts
+++ b/assistant/src/config/profile-materialization.ts
@@ -116,17 +116,15 @@ export function completeCustomProfile(
     dflt.provider_connection !== undefined
   ) {
     if (dflt.provider_connection === VELLUM_MANAGED_CONNECTION_NAME) {
+      // Only managed-servable pairs inherit the managed binding; anything
+      // else inherits nothing and lets dispatch auto-resolve by vendor,
+      // matching the pre-entries inheritance contract.
       if (
         MANAGED_ROUTABLE_PROVIDERS.has(completed.provider) &&
         completed.model !== undefined &&
         getManagedUpstream(completed.model) !== null
       ) {
         completed.provider = "vellum";
-      } else {
-        // The identity cannot serve this pair; keep the legacy binding so
-        // dispatch keeps its managed routing and the collapse migration's
-        // recovery still sees it.
-        completed.provider_connection = dflt.provider_connection;
       }
     } else if (completed.provider === dflt.provider) {
       // Folding to the entry name is only safe against a verified row; a

--- a/assistant/src/config/profile-materialization.ts
+++ b/assistant/src/config/profile-materialization.ts
@@ -1,4 +1,6 @@
+import { getDb } from "../persistence/db-connection.js";
 import { ROUTING_IDENTITY_PROVIDERS } from "../providers/inference/auth.js";
+import { getConnection } from "../providers/inference/connections.js";
 import {
   getCatalogProviderForModel,
   isModelInCatalog,
@@ -113,21 +115,43 @@ export function completeCustomProfile(
     profile.provider_connection === undefined &&
     dflt.provider_connection !== undefined
   ) {
-    if (
-      dflt.provider_connection === VELLUM_MANAGED_CONNECTION_NAME &&
-      MANAGED_ROUTABLE_PROVIDERS.has(completed.provider) &&
-      completed.model !== undefined &&
-      getManagedUpstream(completed.model) !== null
-    ) {
-      completed.provider = "vellum";
-    } else if (
-      dflt.provider_connection !== VELLUM_MANAGED_CONNECTION_NAME &&
-      completed.provider === dflt.provider
-    ) {
-      completed.provider = dflt.provider_connection;
+    if (dflt.provider_connection === VELLUM_MANAGED_CONNECTION_NAME) {
+      if (
+        MANAGED_ROUTABLE_PROVIDERS.has(completed.provider) &&
+        completed.model !== undefined &&
+        getManagedUpstream(completed.model) !== null
+      ) {
+        completed.provider = "vellum";
+      } else {
+        // The identity cannot serve this pair; keep the legacy binding so
+        // dispatch keeps its managed routing and the collapse migration's
+        // recovery still sees it.
+        completed.provider_connection = dflt.provider_connection;
+      }
+    } else if (completed.provider === dflt.provider) {
+      // Folding to the entry name is only safe against a verified row; a
+      // dangling or kind-disagreeing binding stays in the legacy field,
+      // where the collapse migration's recovery can judge it.
+      if (bindingRowKind(dflt.provider_connection) === completed.provider) {
+        completed.provider = dflt.provider_connection;
+      } else {
+        completed.provider_connection = dflt.provider_connection;
+      }
     }
   }
   return structuredClone(completed);
+}
+
+/**
+ * The provider kind stored on a connection row, or null when the row is
+ * missing or the DB is unavailable (both mean "unverifiable" to callers).
+ */
+function bindingRowKind(name: string): string | null {
+  try {
+    return getConnection(getDb(), name)?.provider ?? null;
+  } catch {
+    return null;
+  }
 }
 
 type PlainObject = Record<string, unknown>;

--- a/assistant/src/config/profile-materialization.ts
+++ b/assistant/src/config/profile-materialization.ts
@@ -4,6 +4,11 @@ import {
   isModelInCatalog,
 } from "../providers/model-catalog.js";
 import {
+  getManagedUpstream,
+  MANAGED_ROUTABLE_PROVIDERS,
+  VELLUM_MANAGED_CONNECTION_NAME,
+} from "../providers/vellum-model-routing.js";
+import {
   type LLMConfigBase,
   type ProfileEntry,
   routingIdentityModelIssue,
@@ -93,11 +98,35 @@ export function completeCustomProfile(
     }
   }
 
-  // Completion never stamps a `provider_connection`: under the entries
-  // model the provider value alone carries the route (a vendor means the
-  // default entry of that kind, an entry name means its row, and
-  // routing-identity providers resolve their connection per-request), so an
-  // inherited binding would only re-introduce the collapsed field on disk.
+  // Completion never stamps a `provider_connection`; an inherited binding
+  // would only re-introduce the collapsed field on disk. The default's
+  // explicit binding is instead inherited IN the provider value, the
+  // entries-model representation: the vellum binding becomes the routing
+  // identity (only when it can serve the model, or the read-path schema
+  // would strip the profile), and a same-vendor binding becomes the entry
+  // name, so a completed profile keeps signing with the credential the
+  // workspace default names rather than whatever auto-resolution finds
+  // first.
+  if (
+    completed.provider !== undefined &&
+    !ROUTING_IDENTITY_PROVIDERS.has(completed.provider) &&
+    profile.provider_connection === undefined &&
+    dflt.provider_connection !== undefined
+  ) {
+    if (
+      dflt.provider_connection === VELLUM_MANAGED_CONNECTION_NAME &&
+      MANAGED_ROUTABLE_PROVIDERS.has(completed.provider) &&
+      completed.model !== undefined &&
+      getManagedUpstream(completed.model) !== null
+    ) {
+      completed.provider = "vellum";
+    } else if (
+      dflt.provider_connection !== VELLUM_MANAGED_CONNECTION_NAME &&
+      completed.provider === dflt.provider
+    ) {
+      completed.provider = dflt.provider_connection;
+    }
+  }
   return structuredClone(completed);
 }
 

--- a/assistant/src/config/profile-materialization.ts
+++ b/assistant/src/config/profile-materialization.ts
@@ -4,10 +4,6 @@ import {
   isModelInCatalog,
 } from "../providers/model-catalog.js";
 import {
-  MANAGED_ROUTABLE_PROVIDERS,
-  VELLUM_MANAGED_CONNECTION_NAME,
-} from "../providers/vellum-model-routing.js";
-import {
   type LLMConfigBase,
   type ProfileEntry,
   routingIdentityModelIssue,
@@ -97,34 +93,11 @@ export function completeCustomProfile(
     }
   }
 
-  // A provider-specific connection baked onto a different provider would pin
-  // a mismatch (dispatch auto-resolves an absent connection by provider
-  // instead). The Vellum managed connection must survive a provider change —
-  // dispatch routes it via `expectedProvider` — but only onto providers it
-  // can actually route; a non-managed-routable provider (openrouter, ollama)
-  // would hit the mismatch path instead of auto-resolution.
-  // Routing-identity providers resolve their connection per-request from
-  // the provider value; a stamped provider_connection would be dead weight
-  // at best and a misroute at worst.
-  if (
-    completed.provider !== undefined &&
-    ROUTING_IDENTITY_PROVIDERS.has(completed.provider)
-  ) {
-    return structuredClone(completed);
-  }
-
-  const vellumRoutable =
-    dflt.provider_connection === VELLUM_MANAGED_CONNECTION_NAME &&
-    completed.provider !== undefined &&
-    MANAGED_ROUTABLE_PROVIDERS.has(completed.provider);
-  if (
-    profile.provider_connection === undefined &&
-    dflt.provider_connection !== undefined &&
-    (completed.provider === dflt.provider || vellumRoutable)
-  ) {
-    completed.provider_connection = dflt.provider_connection;
-  }
-
+  // Completion never stamps a `provider_connection`: under the entries
+  // model the provider value alone carries the route (a vendor means the
+  // default entry of that kind, an entry name means its row, and
+  // routing-identity providers resolve their connection per-request), so an
+  // inherited binding would only re-introduce the collapsed field on disk.
   return structuredClone(completed);
 }
 

--- a/assistant/src/providers/__tests__/preflight-resolved-config.test.ts
+++ b/assistant/src/providers/__tests__/preflight-resolved-config.test.ts
@@ -220,6 +220,29 @@ describe("preflightResolvedConfig", () => {
     ).resolves.toBeUndefined();
   });
 
+  test("an explicit connection outranks an entry-name provider, matching dispatch", async () => {
+    // A healthy entry row must not mask the row the request actually uses.
+    connectionsByName["anthropic-work"] = {
+      name: "anthropic-work",
+      provider: "anthropic",
+      auth: {
+        type: "api_key",
+        credential: "credential/anthropic-work/api_key",
+      },
+    };
+    secureKeys["credential/anthropic-work/api_key"] = "healthy";
+
+    const err = await preflightError(
+      resolved({
+        provider: "anthropic-work",
+        provider_connection: "deleted-row",
+        model: "claude-opus-4-8",
+      }),
+    );
+    expect(err?.reason).toBe("not_found");
+    expect(err?.connectionName).toBe("deleted-row");
+  });
+
   test("a chatgpt-identity subscription row preflights the same way", async () => {
     // Migration 366 stamps the row with provider "chatgpt"; preflight judges
     // its subscription credential, not a provider equality with the openai

--- a/assistant/src/providers/connection-resolution.ts
+++ b/assistant/src/providers/connection-resolution.ts
@@ -591,6 +591,9 @@ export async function preflightResolvedConfig(
   const identity = resolveRoutingIdentity(resolved.provider, resolved.model);
   // An entry-name provider IS the connection name, and the row's kind is
   // what the checks below judge against (same translation dispatch uses).
+  // Precedence matches dispatch exactly: an explicit provider_connection
+  // wins over the entry name, so preflight judges the row the request
+  // actually uses rather than a healthy entry the request ignores.
   const entryName = identity
     ? null
     : resolveEntryConnectionName(resolved.provider);
@@ -600,7 +603,7 @@ export async function preflightResolvedConfig(
       ? (connectionProviderKind(entryName, resolved.model) ?? resolved.provider)
       : resolved.provider;
   const connectionName =
-    identity?.connectionName ?? entryName ?? resolved.provider_connection;
+    identity?.connectionName ?? resolved.provider_connection ?? entryName;
   if (!connectionName) {
     return;
   }

--- a/assistant/src/providers/connection-resolution.ts
+++ b/assistant/src/providers/connection-resolution.ts
@@ -32,6 +32,7 @@ import {
   resolveCallSiteConfig,
   selectWinningProfile,
 } from "../config/llm-resolver.js";
+import { unknownLlmProviderIssue } from "../config/schemas/llm.js";
 import { getDb } from "../persistence/db-connection.js";
 import { credentialKey } from "../security/credential-key.js";
 import { ProviderNotConfiguredError } from "../util/errors.js";
@@ -88,6 +89,30 @@ export function resolveEntryConnectionName(
   } catch {
     return null;
   }
+}
+
+/**
+ * Write-surface membership for a PROFILE provider value: the known vendor
+ * and identity set, plus existing connection entry rows. Fail-closed on DB
+ * unavailability (an unverifiable entry name is rejected; the write is
+ * retryable), unlike the selection-time predicate below, which is
+ * fail-open so a DB blip never heals away a valid profile. Call-site
+ * fragments keep vendor-only membership: overrides become model-only with
+ * the entries demolition, so entries must not leak into them meanwhile.
+ */
+export function writableProfileProviderIssue(provider: string): string | null {
+  const issue = unknownLlmProviderIssue(provider);
+  if (issue === null) {
+    return null;
+  }
+  try {
+    if (getConnection(getDb(), provider) != null) {
+      return null;
+    }
+  } catch {
+    // Unverifiable: fall through to the rejection.
+  }
+  return `Invalid provider "${provider}". Use a known provider or the name of an existing connection.`;
 }
 
 /**
@@ -564,9 +589,18 @@ export async function preflightResolvedConfig(
   // upstream; an unroutable vellum model throws here — it is statically
   // detectable, exactly what preflight exists to surface.
   const identity = resolveRoutingIdentity(resolved.provider, resolved.model);
-  const provider = identity?.expectedProvider ?? resolved.provider;
+  // An entry-name provider IS the connection name, and the row's kind is
+  // what the checks below judge against (same translation dispatch uses).
+  const entryName = identity
+    ? null
+    : resolveEntryConnectionName(resolved.provider);
+  const provider = identity
+    ? identity.expectedProvider
+    : entryName
+      ? (connectionProviderKind(entryName, resolved.model) ?? resolved.provider)
+      : resolved.provider;
   const connectionName =
-    identity?.connectionName ?? resolved.provider_connection;
+    identity?.connectionName ?? entryName ?? resolved.provider_connection;
   if (!connectionName) {
     return;
   }

--- a/assistant/src/providers/inference/connection-availability.ts
+++ b/assistant/src/providers/inference/connection-availability.ts
@@ -335,19 +335,22 @@ export async function computeProfileAvailability(
     }
   }
 
-  // An entry-name provider IS the connection name; judge the row against
-  // its own dispatchable kind, the same translation dispatch uses.
+  // Precedence matches dispatch: an explicit provider_connection wins over
+  // an entry-name provider, and the vendor judged is the entry's
+  // dispatchable kind either way (the same translation dispatch uses).
   const entryName = resolveEntryConnectionName(provider);
-  if (entryName !== null) {
-    return computeConnectionAvailability(
-      connectionProviderKind(entryName, model) ?? provider,
-      entryName,
-    );
-  }
+  const entryKind =
+    entryName !== null
+      ? (connectionProviderKind(entryName, model) ?? provider)
+      : provider;
 
   const pinned = entry.provider_connection;
   if (typeof pinned === "string") {
-    return computeConnectionAvailability(provider, pinned);
+    return computeConnectionAvailability(entryKind, pinned);
+  }
+
+  if (entryName !== null) {
+    return computeConnectionAvailability(entryKind, entryName);
   }
 
   // Mirror the dispatch-time auto-resolve (`resolveConfiguredProvider`): with

--- a/assistant/src/providers/inference/connection-availability.ts
+++ b/assistant/src/providers/inference/connection-availability.ts
@@ -23,6 +23,10 @@ import {
   describeSubscriptionModelIncompatibility,
   isConnectionCompatibleWithModel,
 } from "../connection-model-compat.js";
+import {
+  connectionProviderKind,
+  resolveEntryConnectionName,
+} from "../connection-resolution.js";
 import { PROVIDER_CATALOG } from "../model-catalog.js";
 import { resolveManagedProxyContext } from "../platform-proxy/context.js";
 import {
@@ -329,6 +333,16 @@ export async function computeProfileAvailability(
             : `Model "${model ?? "<unset>"}" cannot be routed by provider "${provider}".`,
       };
     }
+  }
+
+  // An entry-name provider IS the connection name; judge the row against
+  // its own dispatchable kind, the same translation dispatch uses.
+  const entryName = resolveEntryConnectionName(provider);
+  if (entryName !== null) {
+    return computeConnectionAvailability(
+      connectionProviderKind(entryName, model) ?? provider,
+      entryName,
+    );
   }
 
   const pinned = entry.provider_connection;

--- a/assistant/src/providers/provider-send-message.ts
+++ b/assistant/src/providers/provider-send-message.ts
@@ -41,6 +41,13 @@ const log = getLogger("provider-send-message");
 export interface ConfiguredProviderResult {
   provider: Provider;
   configuredProviderName: string;
+  /**
+   * True when the profile's provider was an entry label and dispatch routed
+   * through that row. The row's own credential already signed resolution, so
+   * vendor-keyed preflights (which check the generic per-vendor key slot)
+   * do not apply to this result.
+   */
+  entryRouted: boolean;
 }
 
 export type ConfiguredProviderOptions = Pick<
@@ -256,6 +263,7 @@ export async function resolveConfiguredProvider(
       (entryRoute
         ? connectionProviderKind(entryRoute, resolved.model)
         : undefined) ?? inferenceProvider,
+    entryRouted: entryRoute !== null,
   };
 }
 

--- a/assistant/src/providers/provider-send-message.ts
+++ b/assistant/src/providers/provider-send-message.ts
@@ -17,6 +17,7 @@ import {
   isConnectionCompatibleWithModel,
 } from "./connection-model-compat.js";
 import {
+  connectionProviderKind,
   dispatchProviderResolvable,
   expectedVendorProvider,
   resolveEntryConnectionName,
@@ -248,7 +249,13 @@ export async function resolveConfiguredProvider(
       opts.overrideProfile,
       opts.forceOverrideProfile,
     ),
-    configuredProviderName: inferenceProvider,
+    // The dispatched vendor kind, not the config label: an entry-name
+    // provider reports its row's kind so provider-keyed consumers
+    // (telemetry, pricing) never see a label that matches no catalog id.
+    configuredProviderName:
+      (entryRoute
+        ? connectionProviderKind(entryRoute, resolved.model)
+        : undefined) ?? inferenceProvider,
   };
 }
 

--- a/assistant/src/runtime/routes/__tests__/inference-profiles-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-profiles-routes.test.ts
@@ -150,10 +150,23 @@ describe("POST inference/profiles (create) validation", () => {
     ).rejects.toBeInstanceOf(BadRequestError);
   });
 
-  test("rejects an entry-name provider while entry writes are locked", async () => {
-    // Dispatch can translate a provider naming a connection row, but the
-    // write surface stays restricted to the known provider set until the
-    // entries model enables entry binding.
+  test("creates an entry-backed profile, validating the model by the row's kind", async () => {
+    seedConnection("anthropic-work", "anthropic", {
+      type: "api_key",
+      credential: "credential/anthropic-work/api_key",
+    });
+    const result = (await call("inference_profiles_create", {
+      body: {
+        name: "work-profile",
+        provider: "anthropic-work",
+        model: "claude-opus-4-8",
+      },
+    })) as { entry: Record<string, unknown> };
+    expect(result.entry.provider).toBe("anthropic-work");
+    expect(result.entry.model).toBe("claude-opus-4-8");
+  });
+
+  test("rejects an entry-backed profile whose model the row's kind cannot serve", async () => {
     seedConnection("anthropic-work", "anthropic", {
       type: "api_key",
       credential: "credential/anthropic-work/api_key",
@@ -163,6 +176,18 @@ describe("POST inference/profiles (create) validation", () => {
         body: {
           name: "work-profile",
           provider: "anthropic-work",
+          model: "gpt-5.5",
+        },
+      }),
+    ).rejects.toBeInstanceOf(BadRequestError);
+  });
+
+  test("rejects a provider naming no known vendor or entry", async () => {
+    await expect(
+      call("inference_profiles_create", {
+        body: {
+          name: "ghost-profile",
+          provider: "no-such-entry",
           model: "claude-opus-4-8",
         },
       }),

--- a/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
@@ -451,7 +451,7 @@ describe("POST inference/provider-connections (create)", () => {
           models: [{ id: "my-model" }],
         },
       }),
-    ).rejects.toThrow(/belongs to a built-in provider/);
+    ).rejects.toThrow(/reserved as a provider id/);
 
     await call(findHandler("inference_provider_connections_create"), {
       body: {

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -97,6 +97,7 @@ import { type LogRow } from "../../persistence/llm-request-log-store.js";
 import { getMemoryRecallLogByMessageIds } from "../../plugins/defaults/memory/memory-recall-log-store.js";
 import { getMemoryV2ActivationLogByMessageIds } from "../../plugins/defaults/memory/v2/activation-log-store.js";
 import { getMemoryV3SelectionForInspectorByMessageIds } from "../../plugins/defaults/memory/v3/selection-log-store.js";
+import { writableProfileProviderIssue } from "../../providers/connection-resolution.js";
 import { ROUTING_IDENTITY_PROVIDERS } from "../../providers/inference/auth.js";
 import { PROVIDERS_REQUIRING_BASE_URL_AND_MODELS } from "../../providers/inference/auth.js";
 import {
@@ -1397,9 +1398,13 @@ function assertRoutableIdentityEntries(
     // providers this write introduces or changes: a stored value outside
     // the known set is readable and dispatchable by design, and
     // re-validating it on every write would make all later settings saves
-    // fail with no in-product repair path.
+    // fail with no in-product repair path. Profiles accept entry names;
+    // call-site fragments and the legacy default blob stay vendor-only
+    // (overrides become model-only with the entries demolition).
     if (entry.provider !== priorProviders.get(label)) {
-      const providerIssue = unknownLlmProviderIssue(entry.provider);
+      const providerIssue = label.startsWith("llm.profiles.")
+        ? writableProfileProviderIssue(entry.provider)
+        : unknownLlmProviderIssue(entry.provider);
       if (providerIssue) {
         throw new BadRequestError(`${providerIssue} (${label})`);
       }

--- a/assistant/src/runtime/routes/inference-profiles-routes.ts
+++ b/assistant/src/runtime/routes/inference-profiles-routes.ts
@@ -33,7 +33,10 @@ import {
   routingIdentityModelIssue,
 } from "../../config/schemas/llm.js";
 import { getDb } from "../../persistence/db-connection.js";
-import { writableProfileProviderIssue } from "../../providers/connection-resolution.js";
+import {
+  resolveEntryProviderKind,
+  writableProfileProviderIssue,
+} from "../../providers/connection-resolution.js";
 import { ROUTING_IDENTITY_PROVIDERS } from "../../providers/inference/auth.js";
 import type { ConnectionAvailability } from "../../providers/inference/connection-availability.js";
 import {
@@ -181,31 +184,38 @@ function validateModel(
     }
     return [];
   }
-  if (isModelInCatalog(provider, model)) {
+  // An entry-name provider validates against its row's dispatchable kind,
+  // the same translation dispatch uses; the entry itself also serves as the
+  // model-list connection for custom endpoints below.
+  const entryKind = resolveEntryProviderKind(provider, model);
+  const catalogProvider = entryKind ?? provider;
+  if (isModelInCatalog(catalogProvider, model)) {
     return [];
   }
   // The named connection's advertised model list is authoritative for models
   // the code-owned catalog doesn't know — a custom (openai-compatible)
   // endpoint declares its own models at connection-create time.
-  if (connectionName) {
-    const connection = getConnection(getDb(), connectionName);
+  const modelListConnection =
+    connectionName ?? (entryKind !== null ? provider : undefined);
+  if (modelListConnection) {
+    const connection = getConnection(getDb(), modelListConnection);
     if (connection?.models?.some((m) => m.id === model)) {
       return [];
     }
   }
   if (!allowUnlisted) {
     const remedy =
-      provider === "openai-compatible"
+      catalogProvider === "openai-compatible"
         ? `Pass allowUnlisted to create it anyway, or declare the model on the connection ` +
           `("assistant inference providers update <name> --model ${model}").`
         : `Pass allowUnlisted to create it anyway, or run ` +
           `"assistant inference models list --provider ${provider}" to see valid ids.`;
     throw new BadRequestError(
-      `Model "${model}" is not in the catalog for provider "${provider}". ${remedy}`,
+      `Model "${model}" is not in the catalog for provider "${catalogProvider}". ${remedy}`,
     );
   }
   return [
-    `Model "${model}" is not in the catalog for provider "${provider}" — created anyway (allowUnlisted).`,
+    `Model "${model}" is not in the catalog for provider "${catalogProvider}"; created anyway (allowUnlisted).`,
   ];
 }
 

--- a/assistant/src/runtime/routes/inference-profiles-routes.ts
+++ b/assistant/src/runtime/routes/inference-profiles-routes.ts
@@ -31,9 +31,9 @@ import {
 import {
   ProfileEntry,
   routingIdentityModelIssue,
-  unknownLlmProviderIssue,
 } from "../../config/schemas/llm.js";
 import { getDb } from "../../persistence/db-connection.js";
+import { writableProfileProviderIssue } from "../../providers/connection-resolution.js";
 import { ROUTING_IDENTITY_PROVIDERS } from "../../providers/inference/auth.js";
 import type { ConnectionAvailability } from "../../providers/inference/connection-availability.js";
 import {
@@ -150,7 +150,7 @@ const updateRequestSchema = z.object({
 // ---------------------------------------------------------------------------
 
 function assertValidProvider(provider: string): void {
-  const issue = unknownLlmProviderIssue(provider);
+  const issue = writableProfileProviderIssue(provider);
   if (issue) {
     throw new BadRequestError(issue);
   }

--- a/assistant/src/runtime/routes/inference-provider-connection-routes.ts
+++ b/assistant/src/runtime/routes/inference-provider-connection-routes.ts
@@ -336,6 +336,15 @@ async function handleCreateConnection({ body = {} }: RouteHandlerArgs) {
       `Connection name "${name}" is reserved for the Vellum-managed connection. Pick another name.`,
     );
   }
+  // Provider ids and routing identities are labels in profile config, so an
+  // entry under one of those names could never be referenced by name (the
+  // label reads as the vendor), and a future catalog addition must never
+  // capture an existing user name. Reserve the whole vocabulary.
+  if (VALID_CONNECTION_PROVIDERS.includes(name)) {
+    throw new BadRequestError(
+      `Connection name "${name}" is reserved as a provider id. Pick another name.`,
+    );
+  }
 
   const providerResult = ConnectionProviderSchema.safeParse(provider);
   if (!providerResult.success) {
@@ -616,10 +625,21 @@ async function handleDeleteConnection({ pathParams = {} }: RouteHandlerArgs) {
   // above; this keeps the scan a faithful backstop rather than one that
   // silently skips the defaults.
   const profiles = getEffectiveProfilesForProvider(config.llm?.profiles, dp);
+  // A binding lives in `provider` (the entry name) under the entries model,
+  // or in the legacy `provider_connection` field; both count, or deleting a
+  // bound entry would dangle the profile behind selection's silent healing.
+  // Provider values count only for non-vendor names: a profile saying
+  // "vellum" references the routing identity, never a row that happens to
+  // claim that name, and the claiming-row delete is the recovery path.
+  const nameIsEntryName = !VALID_CONNECTION_PROVIDERS.includes(name);
   const referencingProfiles = Object.entries(profiles)
-    .filter(
-      ([, p]) => (p as Record<string, unknown>).provider_connection === name,
-    )
+    .filter(([, p]) => {
+      const entry = p as Record<string, unknown>;
+      return (
+        entry.provider_connection === name ||
+        (nameIsEntryName && entry.provider === name)
+      );
+    })
     .map(([profileName]) => profileName);
 
   const result = deleteConnection(getDb(), name, {

--- a/assistant/src/workspace/byok-default-profile-ensure.ts
+++ b/assistant/src/workspace/byok-default-profile-ensure.ts
@@ -136,9 +136,25 @@ const ERA_COPY_LABEL_SUFFIX = " (Custom Provider)";
 /**
  * Comparison ignores `label` and `status` (user overlay state, preserved via
  * `userOverlayState`) and `model` (checked separately against the current
- * intent resolution and `HISTORICAL_INTENT_MODELS`).
+ * intent resolution and `HISTORICAL_INTENT_MODELS`). The CONVENTIONAL
+ * `<vendor>-personal` binding is normalized away before comparison (it was
+ * machinery-written across several eras); a non-conventional binding is a
+ * user selection and keeps blocking conversion.
  */
 const IGNORED_COMPARISON_KEYS = new Set(["label", "status", "model"]);
+
+/**
+ * Fold the conventional personal entry name back to its vendor. The entries
+ * collapse (migration 145) rewrites a hatch copy's binding into its
+ * provider as `<vendor>-personal`; the matcher folds that shape so every
+ * era of stored copy keeps converting (the same discipline as
+ * `HISTORICAL_INTENT_MODELS`).
+ */
+function foldPersonalEntryName(provider: string): string {
+  return provider.endsWith("-personal")
+    ? provider.slice(0, -"-personal".length)
+    : provider;
+}
 
 /**
  * Per-provider model ids that earlier intent eras pinned onto `custom-*`
@@ -350,7 +366,11 @@ function isKnownUneditedBody(
   // (hatch materialized it once; the default provider may have changed
   // since); equality with the corroborated provider rules out a user
   // re-provision.
-  if (convertibleProvider === null || entry.provider !== convertibleProvider) {
+  if (
+    convertibleProvider === null ||
+    typeof entry.provider !== "string" ||
+    foldPersonalEntryName(entry.provider) !== convertibleProvider
+  ) {
     return false;
   }
   const copyProvider = convertibleProvider;
@@ -358,11 +378,13 @@ function isKnownUneditedBody(
   if (template === undefined) {
     return false;
   }
-  const materialized = materializeProfile(
-    template,
-    copyProvider,
-    `${copyProvider}-personal`,
-  ) as Record<string, unknown>;
+  // No connection binding: the bare provider means the default entry of
+  // that kind, and a stamped binding would re-introduce the collapsed
+  // field on disk.
+  const materialized = materializeProfile(template, copyProvider) as Record<
+    string,
+    unknown
+  >;
   if (
     entry.model !== materialized.model &&
     !(HISTORICAL_INTENT_MODELS[key][copyProvider] ?? []).includes(entry.model)
@@ -372,11 +394,20 @@ function isKnownUneditedBody(
   // Completion skips managed-source bodies, so a copy from the era whose
   // templates wrote `source: "managed"` (#29755 to #29768, 2026-05-05) is
   // compared as if user-source to keep both sides normalized identically.
+  const normalizedEntry: Record<string, unknown> = {
+    ...entry,
+    provider: copyProvider,
+    ...(entry.source === "managed" ? { source: "user" } : {}),
+  };
+  // The conventional personal binding is machinery-written (hatch stamps,
+  // completion re-stamps); normalize it away. Any other binding is user
+  // state and stays in the comparison, where the unbound template side
+  // makes it block conversion.
+  if (normalizedEntry.provider_connection === `${copyProvider}-personal`) {
+    delete normalizedEntry.provider_connection;
+  }
   const body = comparableBody(
-    withCompletionBaked(
-      entry.source === "managed" ? { ...entry, source: "user" } : entry,
-      completionBase,
-    ),
+    withCompletionBaked(normalizedEntry, completionBase),
   );
   const known = comparableBody(
     withCompletionBaked(materialized, completionBase),
@@ -403,9 +434,10 @@ function uniformCopyProvider(profiles: Record<string, unknown>): string | null {
     if (typeof entry.provider !== "string") {
       return null;
     }
+    const entryProvider = foldPersonalEntryName(entry.provider);
     if (provider === null) {
-      provider = entry.provider;
-    } else if (provider !== entry.provider) {
+      provider = entryProvider;
+    } else if (provider !== entryProvider) {
       return null;
     }
   }

--- a/assistant/src/workspace/migrations/145-collapse-profile-bindings-to-entries.ts
+++ b/assistant/src/workspace/migrations/145-collapse-profile-bindings-to-entries.ts
@@ -50,6 +50,70 @@ const MANAGED_ROUTABLE = new Set([
   "together",
 ]);
 
+// A binding literally named "vellum" or "chatgpt" folds into the ROUTING
+// IDENTITY value, whose model the read-path schema validates (an unroutable
+// pair strips the whole profile on read). Folding is therefore gated on the
+// model being servable by that identity, judged against frozen snapshots of
+// the routing tables as of 2026-08-10; a model outside the snapshot leaves
+// the profile untouched (dispatch keeps honoring the legacy binding).
+const VELLUM_ROUTABLE_MODELS = new Set([
+  "claude-fable-5",
+  "claude-opus-5",
+  "claude-opus-4-8",
+  "claude-opus-4-7",
+  "claude-opus-4-6",
+  "claude-sonnet-5",
+  "claude-sonnet-4-6",
+  "claude-sonnet-4-5-20250929",
+  "claude-opus-4-5-20251101",
+  "claude-haiku-4-5-20251001",
+  "gpt-5.6-sol",
+  "gpt-5.6-terra",
+  "gpt-5.6-luna",
+  "gpt-5.5",
+  "gpt-5.5-pro",
+  "gpt-5.4",
+  "gpt-5.2",
+  "gpt-5.4-mini",
+  "gpt-5.4-nano",
+  "gemini-3.6-flash",
+  "gemini-3.5-flash",
+  "gemini-3.5-flash-lite",
+  "gemini-3.1-pro-preview",
+  "gemini-3.1-pro-preview-customtools",
+  "gemini-3-flash-preview",
+  "gemini-3.1-flash-lite-preview",
+  "gemini-3.1-flash-lite",
+  "gemini-2.5-flash",
+  "gemini-2.5-flash-lite",
+  "gemini-2.5-pro",
+  "accounts/fireworks/models/kimi-k3",
+  "accounts/fireworks/models/kimi-k2p6",
+  "accounts/fireworks/models/glm-5p2",
+  "accounts/fireworks/models/minimax-m3",
+  "accounts/fireworks/models/minimax-m2p7",
+  "accounts/fireworks/models/deepseek-v4-pro",
+  "accounts/fireworks/models/deepseek-v4-flash",
+  "MiniMaxAI/MiniMax-M3",
+]);
+const CODEX_MODELS = new Set([
+  "gpt-5.6-sol",
+  "gpt-5.6-terra",
+  "gpt-5.6-luna",
+  "gpt-5.5",
+  "gpt-5.4",
+  "gpt-5.4-mini",
+]);
+
+function identitySafeModel(identity: string, model: unknown): boolean {
+  if (typeof model !== "string") {
+    return false;
+  }
+  return identity === "vellum"
+    ? VELLUM_ROUTABLE_MODELS.has(model)
+    : CODEX_MODELS.has(model);
+}
+
 export const collapseProfileBindingsToEntriesMigration: WorkspaceMigration = {
   id: "145-collapse-profile-bindings-to-entries",
   description:
@@ -90,9 +154,12 @@ export const collapseProfileBindingsToEntriesMigration: WorkspaceMigration = {
       return;
     }
 
-    // Bindings exist, so the rewrite needs the rows. An unreadable DB must
-    // fail the run (retried next boot) rather than checkpoint a pass that
-    // would take the destructive dangling path for every binding.
+    // Bindings exist, so the rewrite needs the rows. An ABSENT DB file is a
+    // real state (a config restored into a fresh workspace has no rows, so
+    // every binding is genuinely dangling); an unreadable or unqueryable DB
+    // must instead fail the run (retried next boot) rather than checkpoint
+    // a pass that would take the destructive dangling path for every
+    // binding.
     const rows = readConnectionRows(workspaceDir);
     if (rows === null) {
       throw new Error(
@@ -124,12 +191,45 @@ export const collapseProfileBindingsToEntriesMigration: WorkspaceMigration = {
       }
 
       if (binding === provider) {
+        // A row named exactly like its vendor was an explicit pin under the
+        // old create route; with several rows of that kind, the bare vendor
+        // would auto-resolve differently, so the pin stays until the entry
+        // picker can express it. Without such a row the field is a plain
+        // conventional shape and the bare vendor already means the default.
+        if (rows.has(binding)) {
+          log.info(
+            { profile: key, provider },
+            "Kept self-named binding (an explicit pin among possible siblings)",
+          );
+          continue;
+        }
         delete entry.provider_connection;
         changed = true;
         log.info(
           { profile: key, provider },
           "Deleted self-referential binding (bare vendor means the default entry)",
         );
+        continue;
+      }
+
+      if (ROUTING_IDENTITIES.has(binding)) {
+        // Folding writes the identity VALUE itself; gate on the model the
+        // identity can serve, or the read-path schema would strip the
+        // profile. An unservable model leaves the profile untouched.
+        if (identitySafeModel(binding, entry.model)) {
+          entry.provider = binding;
+          delete entry.provider_connection;
+          changed = true;
+          log.info(
+            { profile: key, previousProvider: provider, identity: binding },
+            "Folded canonical binding into the routing identity",
+          );
+        } else {
+          log.warn(
+            { profile: key, provider, binding, reason: "model_not_servable" },
+            "Left canonical binding in place; the identity cannot serve this model",
+          );
+        }
         continue;
       }
 
@@ -207,7 +307,7 @@ function kindAgrees(rowKind: string, provider: string | undefined): boolean {
 function readConnectionRows(workspaceDir: string): Map<string, string> | null {
   const dbPath = join(workspaceDir, "data", "db", "assistant.db");
   if (!existsSync(dbPath)) {
-    return null;
+    return new Map();
   }
   let db: Database;
   try {

--- a/assistant/src/workspace/migrations/145-collapse-profile-bindings-to-entries.ts
+++ b/assistant/src/workspace/migrations/145-collapse-profile-bindings-to-entries.ts
@@ -1,0 +1,228 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+
+import { getLogger } from "../../util/logger.js";
+import type { WorkspaceMigration } from "./types.js";
+
+const log = getLogger("migrations/145-collapse-profile-bindings-to-entries");
+
+// Fold each profile's `provider_connection` into its `provider` as a
+// connection entry name. Under the entries model the provider field holds
+// the entry name and the row's own provider (its kind) drives dispatch, so
+// an explicit binding needs no second field.
+//
+// Rules per `llm.profiles.<key>`:
+// - Routing-identity providers ("vellum"/"chatgpt") carry no binding by
+//   definition: a stray `provider_connection` is deleted verbatim.
+// - A binding whose row EXISTS and whose kind AGREES with the profile's
+//   declared provider becomes the provider value (the entry name), and the
+//   binding field is deleted. Kind agreement, with the identity kinds
+//   mapped the way dispatch maps them: a row of the same provider, a
+//   "chatgpt" row for a declared "openai", or a "vellum" row for a declared
+//   managed-routable provider.
+// - A dangling binding (row deleted) or a kind-disagreeing binding keeps
+//   the declared provider and deletes only the binding, with a structured
+//   warn: dispatch's auto-resolution then behaves the way it always has
+//   for an unbound vendor profile, and a rewrite would either strand the
+//   profile on a nonexistent entry or silently change vendors.
+// - A binding equal to the declared provider (conventional shapes older
+//   migrations kept) is a plain delete: the bare vendor value already
+//   means the default entry of that kind.
+//
+// Call-site fragments and `llm.defaultProvider.connectionName` are NOT
+// touched: call-site overrides become model-only together with the
+// resolver's tweak blocks (one coherent change, later), and the default
+// provider keeps its closed vendor enum, so its binding needs its own
+// design before it can collapse.
+//
+// The identity mapping and managed-routable set are frozen snapshots
+// (migrations are self-contained): openai/anthropic/gemini/fireworks/
+// together as of 2026-08-10. A provider outside the snapshot takes the
+// conservative keep-provider path.
+
+const ROUTING_IDENTITIES = new Set(["vellum", "chatgpt"]);
+const MANAGED_ROUTABLE = new Set([
+  "openai",
+  "anthropic",
+  "gemini",
+  "fireworks",
+  "together",
+]);
+
+export const collapseProfileBindingsToEntriesMigration: WorkspaceMigration = {
+  id: "145-collapse-profile-bindings-to-entries",
+  description:
+    "Fold llm.profiles.*.provider_connection into provider as connection entry names",
+  retryFailedCheckpoint: true,
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) {
+      return;
+    }
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+        return;
+      }
+      config = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    const llm = asObject(config.llm);
+    const profiles = llm === null ? null : asObject(llm.profiles);
+    if (profiles === null) {
+      return;
+    }
+
+    const bindings = Object.values(profiles).some((value) => {
+      const entry = asObject(value);
+      return (
+        entry !== null &&
+        typeof entry.provider_connection === "string" &&
+        entry.provider_connection.length > 0
+      );
+    });
+    if (!bindings) {
+      return;
+    }
+
+    // Bindings exist, so the rewrite needs the rows. An unreadable DB must
+    // fail the run (retried next boot) rather than checkpoint a pass that
+    // would take the destructive dangling path for every binding.
+    const rows = readConnectionRows(workspaceDir);
+    if (rows === null) {
+      throw new Error(
+        "provider_connections is not readable; retrying the binding collapse on the next run",
+      );
+    }
+
+    let changed = false;
+    for (const [key, value] of Object.entries(profiles)) {
+      const entry = asObject(value);
+      if (entry === null) {
+        continue;
+      }
+      const binding = entry.provider_connection;
+      if (typeof binding !== "string" || binding.length === 0) {
+        continue;
+      }
+      const provider =
+        typeof entry.provider === "string" ? entry.provider : undefined;
+
+      if (provider !== undefined && ROUTING_IDENTITIES.has(provider)) {
+        delete entry.provider_connection;
+        changed = true;
+        log.info(
+          { profile: key, provider, binding },
+          "Deleted stray binding on a routing-identity profile",
+        );
+        continue;
+      }
+
+      if (binding === provider) {
+        delete entry.provider_connection;
+        changed = true;
+        log.info(
+          { profile: key, provider },
+          "Deleted self-referential binding (bare vendor means the default entry)",
+        );
+        continue;
+      }
+
+      const rowKind = rows.get(binding);
+      if (rowKind === undefined) {
+        delete entry.provider_connection;
+        changed = true;
+        log.warn(
+          { profile: key, provider, binding, reason: "row_missing" },
+          "Deleted dangling binding; profile keeps its declared provider",
+        );
+        continue;
+      }
+
+      if (!kindAgrees(rowKind, provider)) {
+        delete entry.provider_connection;
+        changed = true;
+        log.warn(
+          { profile: key, provider, binding, rowKind, reason: "kind_mismatch" },
+          "Deleted kind-disagreeing binding; profile keeps its declared provider",
+        );
+        continue;
+      }
+
+      entry.provider = binding;
+      delete entry.provider_connection;
+      changed = true;
+      log.info(
+        { profile: key, previousProvider: provider, entry: binding },
+        "Folded profile binding into provider as an entry name",
+      );
+    }
+
+    if (changed) {
+      writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+    }
+  },
+  down(_workspaceDir: string): void {
+    // Forward-only.
+  },
+};
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+/**
+ * Whether a row of `rowKind` can serve a profile declaring `provider`,
+ * mirroring dispatch's identity mapping. An undeclared provider agrees with
+ * any row: the entry alone defines the route.
+ */
+function kindAgrees(rowKind: string, provider: string | undefined): boolean {
+  if (provider === undefined) {
+    return true;
+  }
+  if (rowKind === provider) {
+    return true;
+  }
+  if (rowKind === "chatgpt") {
+    return provider === "openai";
+  }
+  if (rowKind === "vellum") {
+    return MANAGED_ROUTABLE.has(provider);
+  }
+  return false;
+}
+
+/**
+ * Connection name -> provider kind, or null when the DB or table is not
+ * readable. The caller fails the run on null: bindings must be judged
+ * against real rows, never guessed.
+ */
+function readConnectionRows(workspaceDir: string): Map<string, string> | null {
+  const dbPath = join(workspaceDir, "data", "db", "assistant.db");
+  if (!existsSync(dbPath)) {
+    return null;
+  }
+  let db: Database;
+  try {
+    db = new Database(dbPath);
+  } catch {
+    return null;
+  }
+  try {
+    const rows = db
+      .query(`SELECT name, provider FROM provider_connections`)
+      .all() as Array<{ name: string; provider: string }>;
+    return new Map(rows.map((r) => [r.name, r.provider]));
+  } catch {
+    return null;
+  } finally {
+    db.close();
+  }
+}

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -142,6 +142,7 @@ import { sttEnglishDefaultToMultilingualMigration } from "./141-stt-english-defa
 import { consolidateVoiceFrontDoorMigration } from "./142-consolidate-voice-front-door.js";
 import { repairDeprecatedCodexModelIdMigration } from "./143-repair-deprecated-codex-model-id.js";
 import { convertStrandedSubscriptionOpenaiProfilesMigration } from "./144-convert-stranded-subscription-openai-profiles.js";
+import { collapseProfileBindingsToEntriesMigration } from "./145-collapse-profile-bindings-to-entries.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -299,4 +300,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   consolidateVoiceFrontDoorMigration,
   repairDeprecatedCodexModelIdMigration,
   convertStrandedSubscriptionOpenaiProfilesMigration,
+  collapseProfileBindingsToEntriesMigration,
 ];

--- a/assistant/src/workspace/provider-commit-message-generator.ts
+++ b/assistant/src/workspace/provider-commit-message-generator.ts
@@ -162,13 +162,15 @@ class ProviderCommitMessageGenerator {
     const providerName = resolved.configuredProviderName;
 
     // Step 2b: API key preflight for the configured provider. Skipped for
-    // keyless providers and for routing identities, which authenticate
-    // through their connection row (platform token / ChatGPT OAuth) — no
-    // provider API key exists for them, and resolution already verified the
-    // connection credential.
+    // keyless providers, for routing identities, and for entry-routed
+    // results, since all three authenticate through their connection row
+    // (platform token / ChatGPT OAuth / the row's own credential slot), so
+    // no generic per-vendor key needs to exist, and resolution already
+    // verified the connection credential.
     if (
       !KEYLESS_PROVIDERS.has(providerName) &&
-      !ROUTING_IDENTITY_PROVIDERS.has(providerName)
+      !ROUTING_IDENTITY_PROVIDERS.has(providerName) &&
+      !resolved.entryRouted
     ) {
       const providerApiKey = await getProviderKeyAsync(providerName);
       if (!providerApiKey) {


### PR DESCRIPTION
## Summary

Step 3a of the entries model (`.private/plans/entries-model-13b.md`): the collapse. `provider_connection` folds into `provider` as entry names, the write-lock lifts for profiles, and every review-accumulated gate from #40562 lands with it. After this bakes, only the web binding UX (3b) stands between users and "profile A on key 1, profile B on key 2".

## The pieces, and why they ship atomically

**Migration 144** rewrites each profile's binding into its provider as the entry name — validated against real rows: kind agreement uses the identity mapping (a vellum row serves managed-routable vendors, a chatgpt row serves openai), a dangling or kind-disagreeing binding keeps the vendor and drops the binding with a structured warn (never manufacturing a dangler that selection's self-healing would silently eat), and an unreadable DB **fails the run for retry** (`retryFailedCheckpoint`) rather than checkpointing a destructive guess — the #39906 lesson applied in advance.

**The persisted writers stop stamping bindings in the same release** — this is why 3a cannot split further: the completion and byok-ensure writers run every boot, so a migration without the writer-stop gets re-polluted immediately. Completion no longer inherits a binding; the byok-ensure conversion writes none.

**The byok-ensure matcher learns the new shapes** (the `HISTORICAL_INTENT_MODELS` discipline): it folds the conventional `<vendor>-personal` entry name back to its vendor and normalizes machinery-written conventional bindings out of comparison — while a **non-conventional** binding remains user state and still blocks conversion, preserved by test. Without this, migration 144 would strand every hatch-era cohort mid-conversion.

**Write-lock lifts for profiles only**: profile writes accept known providers plus existing entry rows (fail-closed on DB unavailability — the opposite polarity from selection's fail-open healing predicate, each justified in comments). Call-site fragments and the legacy default blob stay vendor-only until overrides become model-only (Q1, step 4). `defaultProvider.connectionName` is also deferred: it keeps its closed vendor enum by explicit decision, so its binding needs its own design.

**The guards from the #40562 review**: entry creation reserves provider ids as names (future catalog additions can never capture a user's name), and the connection delete guard counts provider-field references — scoped to non-vendor names, since a profile saying `vellum` references the identity, never a claiming row, and the claiming-row delete is the recovery path (caught by an existing test mid-implementation).

**Label-leak consumers (§3d-bis)**: `configuredProviderName` reports the dispatched kind, and preflight + availability judge entry rows the way dispatch routes them. Usage attribution already records the adapter-level provider via `actualProvider` stamping.

## Testing

Migration fixtures (fold, identity-kind agreement, dangling, kind-mismatch, identity-strip, self-referential, DB-unreadable retry, idempotency); byok-ensure's full 50-test suite green across all era shapes including the non-conventional-binding preservation; 194 tests across the three write-surface suites; consumer suites green; `tsc`, eslint, prettier clean; circular-dependency count unchanged from baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ma7ZMzsQkJCG4t4uSGLoLT
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40592" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->