### PR TITLE
feat(migrations): convert stranded subscription-only openai fragments to the chatgpt identity

### DIFF
--- a/assistant/src/__tests__/workspace-migration-144-convert-stranded-subscription-openai-profiles.test.ts
+++ b/assistant/src/__tests__/workspace-migration-144-convert-stranded-subscription-openai-profiles.test.ts
@@ -1,0 +1,235 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { convertStrandedSubscriptionOpenaiProfilesMigration } from "../workspace/migrations/144-convert-stranded-subscription-openai-profiles.js";
+import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
+import { assertNotLiveDb } from "./assert-not-live-db.js";
+
+let workspaceDir: string;
+
+function freshWorkspace(): void {
+  // realpathSync canonicalizes macOS's /var -> /private/var symlink so the
+  // assertNotLiveDb tmp-root containment check sees matching prefixes.
+  workspaceDir = join(
+    realpathSync(tmpdir()),
+    `vellum-migration-144-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+}
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+interface SeedRow {
+  name: string;
+  provider: string;
+  authType: string;
+}
+
+function seedConnections(rows: SeedRow[]): void {
+  const dbDir = join(workspaceDir, "data", "db");
+  mkdirSync(dbDir, { recursive: true });
+  const db = new Database(join(dbDir, "assistant.db"));
+  db.run(
+    `CREATE TABLE IF NOT EXISTS provider_connections (name TEXT PRIMARY KEY, provider TEXT NOT NULL, auth TEXT NOT NULL)`,
+  );
+  for (const row of rows) {
+    db.run(
+      `INSERT INTO provider_connections (name, provider, auth) VALUES (?, ?, ?)`,
+      [row.name, row.provider, JSON.stringify({ type: row.authType })],
+    );
+  }
+  db.close();
+}
+
+// Both on-disk shapes of the canonical row: before DB migration 366 flips
+// the provider column, and after.
+const SUBSCRIPTION_PRE_366: SeedRow = {
+  name: "chatgpt-subscription",
+  provider: "openai",
+  authType: "oauth_subscription",
+};
+const SUBSCRIPTION_POST_366: SeedRow = {
+  name: "chatgpt-subscription",
+  provider: "chatgpt",
+  authType: "oauth_subscription",
+};
+const OPENAI_KEY_ROW: SeedRow = {
+  name: "openai-personal",
+  provider: "openai",
+  authType: "api_key",
+};
+
+const STRANDED_CONFIG = {
+  llm: {
+    profiles: {
+      mine: { provider: "openai", model: "gpt-5.5", source: "user" },
+      nano: { provider: "openai", model: "gpt-5.4-nano", source: "user" },
+      pinned: {
+        provider: "openai",
+        model: "gpt-5.5",
+        provider_connection: "openai-personal",
+      },
+      other: { provider: "anthropic", model: "claude-sonnet-4-6" },
+      managed: { provider: "openai", model: "gpt-5.5", source: "managed" },
+    },
+    callSites: {
+      recall: { provider: "openai", model: "gpt-5.6-luna" },
+      malformed: "openai",
+    },
+  },
+};
+
+beforeEach(() => {
+  freshWorkspace();
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    assertNotLiveDb(join(workspaceDir, "data", "db", "assistant.db"));
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+describe("144-convert-stranded-subscription-openai-profiles migration", () => {
+  test("has correct migration id and is registered in order", () => {
+    expect(convertStrandedSubscriptionOpenaiProfilesMigration.id).toBe(
+      "144-convert-stranded-subscription-openai-profiles",
+    );
+    const index = WORKSPACE_MIGRATIONS.findIndex(
+      (migration) =>
+        migration.id === "144-convert-stranded-subscription-openai-profiles",
+    );
+    expect(index).toBeGreaterThan(-1);
+    for (const later of WORKSPACE_MIGRATIONS.slice(index + 1)) {
+      expect(later.id > "144").toBe(true);
+    }
+  });
+
+  test.each([
+    ["pre-366 row shape", SUBSCRIPTION_PRE_366],
+    ["post-366 row shape", SUBSCRIPTION_POST_366],
+  ] as const)(
+    "converts unpinned openai fragments in a subscription-only workspace (%s)",
+    (_label, subscriptionRow) => {
+      writeConfig(STRANDED_CONFIG);
+      seedConnections([subscriptionRow]);
+
+      convertStrandedSubscriptionOpenaiProfilesMigration.run(workspaceDir);
+
+      const llm = readConfig().llm as Record<string, any>;
+      // Codex-servable models are kept; others fall back to terra.
+      expect(llm.profiles.mine).toMatchObject({
+        provider: "chatgpt",
+        model: "gpt-5.5",
+      });
+      expect(llm.profiles.nano).toMatchObject({
+        provider: "chatgpt",
+        model: "gpt-5.6-terra",
+      });
+      expect(llm.callSites.recall).toMatchObject({
+        provider: "chatgpt",
+        model: "gpt-5.6-luna",
+      });
+      // Pinned, other-provider, and managed fragments stay untouched.
+      expect(llm.profiles.pinned.provider).toBe("openai");
+      expect(llm.profiles.other.provider).toBe("anthropic");
+      expect(llm.profiles.managed.provider).toBe("openai");
+    },
+  );
+
+  test("does not convert when an openai api-key connection exists", () => {
+    writeConfig(STRANDED_CONFIG);
+    seedConnections([SUBSCRIPTION_POST_366, OPENAI_KEY_ROW]);
+    const before = readFileSync(join(workspaceDir, "config.json"), "utf-8");
+
+    convertStrandedSubscriptionOpenaiProfilesMigration.run(workspaceDir);
+
+    expect(readFileSync(join(workspaceDir, "config.json"), "utf-8")).toBe(
+      before,
+    );
+  });
+
+  test("does not convert without the subscription row", () => {
+    writeConfig(STRANDED_CONFIG);
+    seedConnections([
+      { name: "vellum", provider: "vellum", authType: "platform" },
+    ]);
+    const before = readFileSync(join(workspaceDir, "config.json"), "utf-8");
+
+    convertStrandedSubscriptionOpenaiProfilesMigration.run(workspaceDir);
+
+    expect(readFileSync(join(workspaceDir, "config.json"), "utf-8")).toBe(
+      before,
+    );
+  });
+
+  test("a claiming key-auth row under the canonical name blocks conversion", () => {
+    writeConfig(STRANDED_CONFIG);
+    seedConnections([
+      { name: "chatgpt-subscription", provider: "openai", authType: "api_key" },
+    ]);
+    const before = readFileSync(join(workspaceDir, "config.json"), "utf-8");
+
+    convertStrandedSubscriptionOpenaiProfilesMigration.run(workspaceDir);
+
+    expect(readFileSync(join(workspaceDir, "config.json"), "utf-8")).toBe(
+      before,
+    );
+  });
+
+  test("converts nothing when the DB or its table is absent", () => {
+    writeConfig(STRANDED_CONFIG);
+    const before = readFileSync(join(workspaceDir, "config.json"), "utf-8");
+
+    convertStrandedSubscriptionOpenaiProfilesMigration.run(workspaceDir);
+    expect(readFileSync(join(workspaceDir, "config.json"), "utf-8")).toBe(
+      before,
+    );
+
+    // DB file exists but the table does not.
+    const dbDir = join(workspaceDir, "data", "db");
+    mkdirSync(dbDir, { recursive: true });
+    new Database(join(dbDir, "assistant.db")).close();
+    convertStrandedSubscriptionOpenaiProfilesMigration.run(workspaceDir);
+    expect(readFileSync(join(workspaceDir, "config.json"), "utf-8")).toBe(
+      before,
+    );
+  });
+
+  test("is idempotent and tolerates missing or malformed config", () => {
+    expect(() =>
+      convertStrandedSubscriptionOpenaiProfilesMigration.run(workspaceDir),
+    ).not.toThrow();
+
+    writeFileSync(join(workspaceDir, "config.json"), "not json {{{");
+    seedConnections([SUBSCRIPTION_POST_366]);
+    expect(() =>
+      convertStrandedSubscriptionOpenaiProfilesMigration.run(workspaceDir),
+    ).not.toThrow();
+
+    writeConfig(STRANDED_CONFIG);
+    convertStrandedSubscriptionOpenaiProfilesMigration.run(workspaceDir);
+    const once = readFileSync(join(workspaceDir, "config.json"), "utf-8");
+    convertStrandedSubscriptionOpenaiProfilesMigration.run(workspaceDir);
+    expect(readFileSync(join(workspaceDir, "config.json"), "utf-8")).toBe(once);
+  });
+});

--- a/assistant/src/__tests__/workspace-migration-144-convert-stranded-subscription-openai-profiles.test.ts
+++ b/assistant/src/__tests__/workspace-migration-144-convert-stranded-subscription-openai-profiles.test.ts
@@ -252,6 +252,20 @@ describe("144-convert-stranded-subscription-openai-profiles migration", () => {
     );
   });
 
+  test("an unreadable existing DB throws so the failed checkpoint retries", () => {
+    writeConfig(STRANDED_CONFIG);
+    const dbDir = join(workspaceDir, "data", "db");
+    mkdirSync(dbDir, { recursive: true });
+    writeFileSync(join(dbDir, "assistant.db"), "not a sqlite file");
+
+    expect(() =>
+      convertStrandedSubscriptionOpenaiProfilesMigration.run(workspaceDir),
+    ).toThrow();
+    // Nothing converts on the failed attempt.
+    const llm = readConfig().llm as Record<string, any>;
+    expect(llm.profiles.mine.provider).toBe("openai");
+  });
+
   test("is idempotent and tolerates missing or malformed config", () => {
     expect(() =>
       convertStrandedSubscriptionOpenaiProfilesMigration.run(workspaceDir),

--- a/assistant/src/__tests__/workspace-migration-144-convert-stranded-subscription-openai-profiles.test.ts
+++ b/assistant/src/__tests__/workspace-migration-144-convert-stranded-subscription-openai-profiles.test.ts
@@ -160,6 +160,36 @@ describe("144-convert-stranded-subscription-openai-profiles migration", () => {
     },
   );
 
+  test("an invalid pin leaf counts as unpinned and is dropped on conversion", () => {
+    writeConfig({
+      llm: {
+        defaultProvider: { provider: "openai", connectionName: null },
+        profiles: {
+          nullPin: {
+            provider: "openai",
+            model: "gpt-5.5",
+            provider_connection: null,
+          },
+          emptyPin: {
+            provider: "openai",
+            model: "gpt-5.5",
+            provider_connection: "",
+          },
+        },
+      },
+    });
+    seedConnections([SUBSCRIPTION_POST_366]);
+
+    convertStrandedSubscriptionOpenaiProfilesMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as Record<string, any>;
+    expect(llm.profiles.nullPin.provider).toBe("chatgpt");
+    expect("provider_connection" in llm.profiles.nullPin).toBe(false);
+    expect(llm.profiles.emptyPin.provider).toBe("chatgpt");
+    expect("provider_connection" in llm.profiles.emptyPin).toBe(false);
+    expect(llm.defaultProvider).toEqual({ provider: "chatgpt" });
+  });
+
   test("a pinned defaultProvider connectionName stays untouched", () => {
     writeConfig({
       llm: {

--- a/assistant/src/__tests__/workspace-migration-144-convert-stranded-subscription-openai-profiles.test.ts
+++ b/assistant/src/__tests__/workspace-migration-144-convert-stranded-subscription-openai-profiles.test.ts
@@ -80,6 +80,7 @@ const OPENAI_KEY_ROW: SeedRow = {
 
 const STRANDED_CONFIG = {
   llm: {
+    defaultProvider: { provider: "openai" },
     profiles: {
       mine: { provider: "openai", model: "gpt-5.5", source: "user" },
       nano: { provider: "openai", model: "gpt-5.4-nano", source: "user" },
@@ -153,8 +154,44 @@ describe("144-convert-stranded-subscription-openai-profiles migration", () => {
       expect(llm.profiles.pinned.provider).toBe("openai");
       expect(llm.profiles.other.provider).toBe("anthropic");
       expect(llm.profiles.managed.provider).toBe("openai");
+      // The unpinned default provider anchors the code-owned defaults and
+      // converts with them.
+      expect(llm.defaultProvider).toEqual({ provider: "chatgpt" });
     },
   );
+
+  test("a pinned defaultProvider connectionName stays untouched", () => {
+    writeConfig({
+      llm: {
+        defaultProvider: {
+          provider: "openai",
+          connectionName: "openai-personal",
+        },
+      },
+    });
+    seedConnections([SUBSCRIPTION_POST_366]);
+    const before = readFileSync(join(workspaceDir, "config.json"), "utf-8");
+
+    convertStrandedSubscriptionOpenaiProfilesMigration.run(workspaceDir);
+
+    expect(readFileSync(join(workspaceDir, "config.json"), "utf-8")).toBe(
+      before,
+    );
+  });
+
+  test("a hidden legacy openai-managed row does not block the conversion", () => {
+    writeConfig(STRANDED_CONFIG);
+    seedConnections([
+      SUBSCRIPTION_POST_366,
+      { name: "openai-managed", provider: "openai", authType: "platform" },
+    ]);
+
+    convertStrandedSubscriptionOpenaiProfilesMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as Record<string, any>;
+    expect(llm.profiles.mine.provider).toBe("chatgpt");
+    expect(llm.defaultProvider).toEqual({ provider: "chatgpt" });
+  });
 
   test("does not convert when an openai api-key connection exists", () => {
     writeConfig(STRANDED_CONFIG);

--- a/assistant/src/workspace/migrations/144-convert-stranded-subscription-openai-profiles.ts
+++ b/assistant/src/workspace/migrations/144-convert-stranded-subscription-openai-profiles.ts
@@ -1,0 +1,225 @@
+import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+
+import { getLogger } from "../../util/logger.js";
+import type { WorkspaceMigration } from "./types.js";
+
+const log = getLogger("migration-144");
+
+/**
+ * Convert stranded subscription-only `provider: "openai"` fragments to the
+ * `chatgpt` routing identity.
+ *
+ * The ChatGPT-subscription connection row carries `provider: "chatgpt"`
+ * (DB migration 366 stamps existing rows). An UNPINNED profile or call-site
+ * fragment with `provider: "openai"` resolves by listing active openai
+ * connections at dispatch; in a workspace whose only OpenAI access is the
+ * subscription, that listing is now empty and every request on the fragment
+ * fails with missing_connection. Workspace migration 133 converted fragments
+ * that PINNED the subscription row; this converts the unpinned cohort.
+ *
+ * Conversion requires proof from the workspace DB that the fragment is
+ * genuinely stranded: the canonical subscription row exists (matched by
+ * name + oauth_subscription auth, valid for both the pre- and post-366 row
+ * shapes) and no `provider: "openai"` row exists (an API-key row means
+ * openai fragments still resolve). When the DB or table is absent or
+ * unreadable, nothing converts.
+ *
+ * A converted fragment gets `provider: "chatgpt"`, and a model outside the
+ * Codex subscription set is replaced with `gpt-5.6-terra` (the "chatgpt"
+ * identity requires a Codex-servable model at schema validation; on the
+ * subscription every model bills the same). Fragments with a
+ * `provider_connection` pin, any other provider, or a managed source are
+ * left untouched. `llm.default` is not swept: migration 133 drops that
+ * legacy blob and runs earlier in the chain.
+ */
+export const convertStrandedSubscriptionOpenaiProfilesMigration: WorkspaceMigration =
+  {
+    id: "144-convert-stranded-subscription-openai-profiles",
+    description:
+      'Convert unpinned provider "openai" LLM fragments to the "chatgpt" routing identity in subscription-only workspaces',
+    run(workspaceDir: string): void {
+      const configPath = join(workspaceDir, "config.json");
+      if (!existsSync(configPath)) {
+        return;
+      }
+      if (!isSubscriptionOnlyWorkspace(workspaceDir)) {
+        return;
+      }
+
+      // Read outside the parse catch: a transient filesystem error (EIO,
+      // EACCES) must reach the runner so the migration retries, while
+      // malformed JSON is a permanent state this migration cannot repair.
+      const rawText = readFileSync(configPath, "utf-8");
+
+      let config: Record<string, unknown>;
+      try {
+        const raw = JSON.parse(rawText);
+        if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+          return;
+        }
+        config = raw as Record<string, unknown>;
+      } catch {
+        return;
+      }
+
+      const llm = readObject(config.llm);
+      if (llm === null) {
+        return;
+      }
+
+      let changed = false;
+
+      const profiles = readObject(llm.profiles);
+      if (profiles !== null) {
+        for (const [name, rawProfile] of Object.entries(profiles)) {
+          if (convertFragment(readObject(rawProfile))) {
+            changed = true;
+            log.info({ profile: name }, "Converted stranded openai profile");
+          }
+        }
+      }
+
+      const callSites = readObject(llm.callSites);
+      if (callSites !== null) {
+        for (const [id, rawConfig] of Object.entries(callSites)) {
+          if (convertFragment(readObject(rawConfig))) {
+            changed = true;
+            log.info(
+              { callSite: id },
+              "Converted stranded openai call-site fragment",
+            );
+          }
+        }
+      }
+
+      if (!changed) {
+        return;
+      }
+
+      // Write-then-rename so an interrupted write cannot leave config.json
+      // truncated: a torn in-place write would parse as invalid JSON on the
+      // retry, which the catch above treats as "nothing to do", letting the
+      // runner checkpoint the migration as completed against a corrupt file.
+      const tmpPath = `${configPath}.migration-144.tmp`;
+      writeFileSync(tmpPath, JSON.stringify(config, null, 2) + "\n");
+      renameSync(tmpPath, configPath);
+    },
+    // The exact-match rewrite is idempotent, so a transient failure (full
+    // disk, I/O error) is safe to retry on later startups.
+    retryFailedCheckpoint: true,
+    down(_workspaceDir: string): void {
+      // Forward-only: converting back would restore fragments that cannot
+      // resolve a connection.
+    },
+  };
+
+// ---------------------------------------------------------------------------
+// Helpers: self-contained per workspace migrations AGENTS.md
+// ---------------------------------------------------------------------------
+
+const SUBSCRIPTION_CONNECTION_NAME = "chatgpt-subscription";
+
+const CODEX_SUBSCRIPTION_MODEL_IDS = new Set([
+  "gpt-5.6-sol",
+  "gpt-5.6-terra",
+  "gpt-5.6-luna",
+  "gpt-5.5",
+  "gpt-5.4",
+  "gpt-5.4-mini",
+]);
+
+const FALLBACK_CODEX_MODEL = "gpt-5.6-terra";
+
+/**
+ * True only when the workspace DB proves the stranded condition: the
+ * canonical subscription row is present and no openai row exists. Any
+ * failure to read counts as unproven.
+ */
+function isSubscriptionOnlyWorkspace(workspaceDir: string): boolean {
+  const dbPath = join(workspaceDir, "data", "db", "assistant.db");
+  if (!existsSync(dbPath)) {
+    return false;
+  }
+
+  let db: Database;
+  try {
+    db = new Database(dbPath, { readonly: true });
+  } catch {
+    return false;
+  }
+
+  try {
+    const tableExists = db
+      .query(
+        `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'provider_connections'`,
+      )
+      .get();
+    if (!tableExists) {
+      return false;
+    }
+
+    const subscription = db
+      .query(`SELECT auth FROM provider_connections WHERE name = ?`)
+      .get(SUBSCRIPTION_CONNECTION_NAME) as { auth: string } | null;
+    if (!subscription) {
+      return false;
+    }
+    try {
+      const parsed: unknown = JSON.parse(subscription.auth);
+      const authType =
+        parsed !== null && typeof parsed === "object"
+          ? (parsed as { type?: unknown }).type
+          : undefined;
+      if (authType !== "oauth_subscription") {
+        return false;
+      }
+    } catch {
+      return false;
+    }
+
+    // The canonical row itself stores provider "openai" until DB migration
+    // 366 flips it, and this migration checkpoints once; counting the row
+    // as an openai connection here would skip the conversion forever on
+    // exactly the upgrade boot that needs it. Its subscription auth is
+    // already verified above, so exclusion by name is safe.
+    const openaiRow = db
+      .query(
+        `SELECT 1 FROM provider_connections WHERE provider = 'openai' AND name != ?`,
+      )
+      .get(SUBSCRIPTION_CONNECTION_NAME);
+    return openaiRow === null;
+  } catch {
+    return false;
+  } finally {
+    db.close();
+  }
+}
+
+function convertFragment(fragment: Record<string, unknown> | null): boolean {
+  if (fragment === null) {
+    return false;
+  }
+  if (fragment.provider !== "openai" || "provider_connection" in fragment) {
+    return false;
+  }
+  if (fragment.source === "managed") {
+    return false;
+  }
+  fragment.provider = "chatgpt";
+  if (
+    typeof fragment.model !== "string" ||
+    !CODEX_SUBSCRIPTION_MODEL_IDS.has(fragment.model)
+  ) {
+    fragment.model = FALLBACK_CODEX_MODEL;
+  }
+  return true;
+}
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}

--- a/assistant/src/workspace/migrations/144-convert-stranded-subscription-openai-profiles.ts
+++ b/assistant/src/workspace/migrations/144-convert-stranded-subscription-openai-profiles.ts
@@ -102,9 +102,14 @@ export const convertStrandedSubscriptionOpenaiProfilesMigration: WorkspaceMigrat
       if (
         defaultProvider !== null &&
         defaultProvider.provider === "openai" &&
-        !("connectionName" in defaultProvider)
+        !isConnectionPin(defaultProvider.connectionName)
       ) {
         defaultProvider.provider = "chatgpt";
+        // An invalid connectionName leaf (null, empty) would fail
+        // DefaultProviderSchema at load, whose catch drops the whole value.
+        if ("connectionName" in defaultProvider) {
+          delete defaultProvider.connectionName;
+        }
         changed = true;
         log.info("Converted stranded openai default provider");
       }
@@ -214,17 +219,35 @@ function isSubscriptionOnlyWorkspace(workspaceDir: string): boolean {
   }
 }
 
+/**
+ * Only a non-empty string names a pinned connection. The config loader
+ * strips `null`, empty, or non-string values as invalid leaves, so runtime
+ * treats fragments carrying them as unpinned; the conversion must judge
+ * them the same way or those fragments stay stranded.
+ */
+function isConnectionPin(value: unknown): boolean {
+  return typeof value === "string" && value.length > 0;
+}
+
 function convertFragment(fragment: Record<string, unknown> | null): boolean {
   if (fragment === null) {
     return false;
   }
-  if (fragment.provider !== "openai" || "provider_connection" in fragment) {
+  if (
+    fragment.provider !== "openai" ||
+    isConnectionPin(fragment.provider_connection)
+  ) {
     return false;
   }
   if (fragment.source === "managed") {
     return false;
   }
   fragment.provider = "chatgpt";
+  // An invalid pin leaf (null, empty) rode along as unpinned; the chatgpt
+  // identity carries no connection reference, so drop it outright.
+  if ("provider_connection" in fragment) {
+    delete fragment.provider_connection;
+  }
   if (
     typeof fragment.model !== "string" ||
     !CODEX_SUBSCRIPTION_MODEL_IDS.has(fragment.model)

--- a/assistant/src/workspace/migrations/144-convert-stranded-subscription-openai-profiles.ts
+++ b/assistant/src/workspace/migrations/144-convert-stranded-subscription-openai-profiles.ts
@@ -23,8 +23,9 @@ const log = getLogger("migration-144");
  * genuinely stranded: the canonical subscription row exists (matched by
  * name + oauth_subscription auth, valid for both the pre- and post-366 row
  * shapes) and no `provider: "openai"` row exists (an API-key row means
- * openai fragments still resolve). When the DB or table is absent or
- * unreadable, nothing converts.
+ * openai fragments still resolve). An absent DB or table converts nothing;
+ * an open or query failure on an existing DB propagates so the runner
+ * records a failed checkpoint and retries on a later boot.
  *
  * A converted fragment gets `provider: "chatgpt"`, and a model outside the
  * Codex subscription set is replaced with `gpt-5.6-terra` (the "chatgpt"
@@ -159,13 +160,11 @@ function isSubscriptionOnlyWorkspace(workspaceDir: string): boolean {
     return false;
   }
 
-  let db: Database;
-  try {
-    db = new Database(dbPath, { readonly: true });
-  } catch {
-    return false;
-  }
-
+  // An open or query failure on an existing DB (locked, I/O error, corrupt
+  // header) is not proof of anything: swallowing it would checkpoint the
+  // migration as completed against unread state. Let it propagate so
+  // retryFailedCheckpoint reattempts on a later boot.
+  const db = new Database(dbPath, { readonly: true });
   try {
     const tableExists = db
       .query(
@@ -210,8 +209,6 @@ function isSubscriptionOnlyWorkspace(workspaceDir: string): boolean {
       )
       .get(SUBSCRIPTION_CONNECTION_NAME, LEGACY_MANAGED_OPENAI_NAME);
     return openaiRow === null;
-  } catch {
-    return false;
   } finally {
     db.close();
   }

--- a/assistant/src/workspace/migrations/144-convert-stranded-subscription-openai-profiles.ts
+++ b/assistant/src/workspace/migrations/144-convert-stranded-subscription-openai-profiles.ts
@@ -29,9 +29,12 @@ const log = getLogger("migration-144");
  * A converted fragment gets `provider: "chatgpt"`, and a model outside the
  * Codex subscription set is replaced with `gpt-5.6-terra` (the "chatgpt"
  * identity requires a Codex-servable model at schema validation; on the
- * subscription every model bills the same). Fragments with a
- * `provider_connection` pin, any other provider, or a managed source are
- * left untouched. `llm.default` is not swept: migration 133 drops that
+ * subscription every model bills the same). An unpinned
+ * `llm.defaultProvider` of "openai" converts the same way: it anchors the
+ * code-owned default profiles and background call sites, which are equally
+ * stranded. Fragments with a `provider_connection` pin, a pinned
+ * defaultProvider connectionName, any other provider, or a managed source
+ * are left untouched. `llm.default` is not swept: migration 133 drops that
  * legacy blob and runs earlier in the chain.
  */
 export const convertStrandedSubscriptionOpenaiProfilesMigration: WorkspaceMigration =
@@ -94,6 +97,17 @@ export const convertStrandedSubscriptionOpenaiProfilesMigration: WorkspaceMigrat
         }
       }
 
+      const defaultProvider = readObject(llm.defaultProvider);
+      if (
+        defaultProvider !== null &&
+        defaultProvider.provider === "openai" &&
+        !("connectionName" in defaultProvider)
+      ) {
+        defaultProvider.provider = "chatgpt";
+        changed = true;
+        log.info("Converted stranded openai default provider");
+      }
+
       if (!changed) {
         return;
       }
@@ -120,6 +134,8 @@ export const convertStrandedSubscriptionOpenaiProfilesMigration: WorkspaceMigrat
 // ---------------------------------------------------------------------------
 
 const SUBSCRIPTION_CONNECTION_NAME = "chatgpt-subscription";
+
+const LEGACY_MANAGED_OPENAI_NAME = "openai-managed";
 
 const CODEX_SUBSCRIPTION_MODEL_IDS = new Set([
   "gpt-5.6-sol",
@@ -179,16 +195,20 @@ function isSubscriptionOnlyWorkspace(workspaceDir: string): boolean {
       return false;
     }
 
+    // Two openai-provider rows do not count as usable openai connections.
     // The canonical row itself stores provider "openai" until DB migration
-    // 366 flips it, and this migration checkpoints once; counting the row
-    // as an openai connection here would skip the conversion forever on
-    // exactly the upgrade boot that needs it. Its subscription auth is
-    // already verified above, so exclusion by name is safe.
+    // 366 flips it, and this migration checkpoints once; counting it would
+    // skip the conversion forever on exactly the upgrade boot that needs it
+    // (its subscription auth is already verified above). The legacy
+    // "openai-managed" row is a pre-consolidation platform leftover that the
+    // connection listings hide (LEGACY_MANAGED_CONNECTION_NAMES in
+    // providers/inference/connections.ts); treating it as a live connection
+    // would block the repair on installs that still carry it.
     const openaiRow = db
       .query(
-        `SELECT 1 FROM provider_connections WHERE provider = 'openai' AND name != ?`,
+        `SELECT 1 FROM provider_connections WHERE provider = 'openai' AND name NOT IN (?, ?)`,
       )
-      .get(SUBSCRIPTION_CONNECTION_NAME);
+      .get(SUBSCRIPTION_CONNECTION_NAME, LEGACY_MANAGED_OPENAI_NAME);
     return openaiRow === null;
   } catch {
     return false;

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -141,6 +141,7 @@ import { repairSeedPinnedMemoryV3LiveMigration } from "./140-repair-seed-pinned-
 import { sttEnglishDefaultToMultilingualMigration } from "./141-stt-english-default-to-multilingual.js";
 import { consolidateVoiceFrontDoorMigration } from "./142-consolidate-voice-front-door.js";
 import { repairDeprecatedCodexModelIdMigration } from "./143-repair-deprecated-codex-model-id.js";
+import { convertStrandedSubscriptionOpenaiProfilesMigration } from "./144-convert-stranded-subscription-openai-profiles.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -297,4 +298,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   sttEnglishDefaultToMultilingualMigration,
   consolidateVoiceFrontDoorMigration,
   repairDeprecatedCodexModelIdMigration,
+  convertStrandedSubscriptionOpenaiProfilesMigration,
 ];


### PR DESCRIPTION
## Summary
- Workspace migration 144 converts UNPINNED `provider: "openai"` profiles and call-site fragments to the `chatgpt` routing identity, but only when the workspace DB proves the stranded condition: the canonical `chatgpt-subscription` row exists (matched by name + `oauth_subscription` auth, so both the pre- and post-366 row shapes qualify) and no other `provider: "openai"` row exists. Unprovable state (missing DB/table, unreadable auth) converts nothing.
- Converted fragments keep their model when it is Codex-servable and fall back to `gpt-5.6-terra` otherwise (the `chatgpt` identity requires a Codex model at schema validation; the subscription bills every model the same). Pinned fragments, other providers, and managed-source entries stay untouched; `llm.default` is left to migration 133, which drops it earlier in the chain.
- The openai-row check excludes the canonical row by name: the row itself stores `provider: "openai"` until DB migration 366 flips it, and this migration checkpoints once, so counting it would skip the conversion forever on exactly the upgrade boot that needs it.

## Original prompt
DB migration 366 (#40166) renamed the subscription row's provider to "chatgpt", so provider-keyed auto-resolution for "openai" no longer finds it. A profile or call-site override with provider "openai" and no connection pin, in a workspace whose only OpenAI access is the subscription, therefore fails every request with missing_connection (it worked before the rename). Migration 133 converted the pinned cohort; the user asked for a standalone PR converting this unpinned cohort under the decided option-2 semantics (openai = the API, chatgpt = the subscription, no mapping between them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uts2hxMb2vf6DfuNoK6B4X
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40593" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->