### PR TITLE
feat(web): let the daemon's section index drive sidebar discovery (LUM-3218)

### DIFF
--- a/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -76,6 +76,8 @@ function rowsMatching(filter: {
 mock.module(
   "@/hooks/conversation-queries",
   (): Partial<typeof ConversationQueries> => ({
+    /* Feature-off: these tests exercise the derived-discovery path. */
+    useSidebarSectionsQuery: () => null,
     useBackgroundConversationListQuery: () => ({
       conversations: [],
       isLoading: false,

--- a/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
@@ -15,7 +15,10 @@ import {
   type ConversationCacheSnapshot,
 } from "@/utils/conversation-cache";
 import { adjustUnreadCountCache } from "@/utils/conversation-cache-mutations";
-import { sectionListPrefix } from "@/utils/conversation-list-fetchers";
+import {
+  sectionListPrefix,
+  sidebarSectionsQueryKey,
+} from "@/utils/conversation-list-fetchers";
 import { contributesToUnreadCount } from "@/utils/conversation-predicates";
 import { executeBulkWithFallback } from "@/utils/bulk-with-fallback";
 import {
@@ -128,14 +131,27 @@ function reconcilePlacement(
   assistantId: string,
   sectionKeys: readonly (readonly unknown[])[] | undefined,
 ): Promise<unknown> {
+  /* The section index rides every placement settle: a move can create or
+     empty a section and always shifts its counts, and the daemon suppresses
+     sync echo to the originating client, so this settle is the only local
+     refresh the index gets. */
+  const refreshIndex = queryClient.invalidateQueries({
+    queryKey: sidebarSectionsQueryKey(assistantId),
+  });
   if (!sectionKeys?.length) {
-    return queryClient.invalidateQueries({
-      queryKey: sectionListPrefix(assistantId),
-    });
+    return Promise.all([
+      refreshIndex,
+      queryClient.invalidateQueries({
+        queryKey: sectionListPrefix(assistantId),
+      }),
+    ]);
   }
-  return Promise.all(
-    sectionKeys.map((queryKey) => queryClient.invalidateQueries({ queryKey })),
-  );
+  return Promise.all([
+    refreshIndex,
+    ...sectionKeys.map((queryKey) =>
+      queryClient.invalidateQueries({ queryKey }),
+    ),
+  ]);
 }
 
 /**

--- a/clients/web/src/domains/chat/hooks/use-conversation-group-actions.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-group-actions.ts
@@ -26,6 +26,7 @@ import {
   invalidateConversationQueries,
 } from "@/utils/conversation-cache";
 import { groupsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
+import { sidebarSectionsQueryKey } from "@/utils/conversation-list-fetchers";
 
 import { haptic } from "@/utils/haptics";
 import type { ConversationGroup } from "@/types/conversation-types";
@@ -162,6 +163,13 @@ export function useConversationGroupActions({
         });
       } finally {
         void queryClient.invalidateQueries({ queryKey: groupsKey });
+        /* The section index carries the group's name and icon, and the
+           daemon suppresses sync echo to this client, so the rename settle
+           is the index's only local refresh. Create needs no counterpart: a
+           new group is empty and an empty group has no index row. */
+        void queryClient.invalidateQueries({
+          queryKey: sidebarSectionsQueryKey(assistantId),
+        });
       }
     },
     [assistantId, conversationGroups, queryClient, patchGroupAsync],

--- a/clients/web/src/domains/chat/use-sidebar-state.test.tsx
+++ b/clients/web/src/domains/chat/use-sidebar-state.test.tsx
@@ -2,6 +2,7 @@ import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
 import type * as ConversationQueries from "@/hooks/conversation-queries";
+import type { SidebarIndexSection } from "@/utils/conversation-list-fetchers";
 import type { Conversation } from "@/types/conversation-types";
 import { useSidebarLayoutStore } from "@/domains/chat/sidebar-layout-store";
 /* Type-only, so it is erased before the `mock.module` above takes effect and
@@ -14,9 +15,15 @@ import type { SidebarState } from "@/domains/chat/use-sidebar-state";
    No section query is stubbed here: each section fetches its own rows where
    it renders (`useSectionConversations`). What this hook owns is the section
    *list* and the derived fallback rows, which is what these tests cover. */
+/* Controls the stubbed section index per test. `null` is the feature-off
+   answer (older daemon / unresolved read), which keeps every existing test on
+   the derived-discovery path it was written against. */
+let sidebarSectionsImpl: SidebarIndexSection[] | null = null;
+
 mock.module(
   "@/hooks/conversation-queries",
   (): Partial<typeof ConversationQueries> => ({
+    useSidebarSectionsQuery: () => sidebarSectionsImpl,
     useBackgroundConversationListQuery: () => ({
       conversations: [],
       isLoading: false,
@@ -52,6 +59,7 @@ function makeConversation(
 afterEach(() => {
   cleanup();
   localStorage.clear();
+  sidebarSectionsImpl = null;
   useSidebarLayoutStore.setState({
     assistantId: null,
     openCategories: [],
@@ -535,5 +543,125 @@ describe("useSidebarState curated sections", () => {
     const work = result.current.sections.find((s) => s.key === "grp-work");
     expect(work).toBeDefined();
     expect(work?.label).toBe("Work");
+  });
+});
+
+describe("useSidebarState with the section index", () => {
+  test("a group absent from the index gets no section, present in it does", () => {
+    const conversationGroups = [
+      { id: "grp-empty", name: "Empty", sortPosition: 0, isSystemGroup: false },
+      { id: "grp-full", name: "Full", sortPosition: 1, isSystemGroup: false },
+    ];
+    const conversations = [
+      makeConversation(0, { conversationId: "g1", groupId: "grp-full" }),
+    ];
+    sidebarSectionsImpl = [
+      {
+        kind: "group",
+        groupId: "grp-full",
+        name: "Full",
+        icon: null,
+        sortPosition: 1,
+        total: 1,
+        unread: 0,
+      },
+      { kind: "chats", total: 0, unread: 0 },
+    ];
+
+    const { result } = renderHook(() =>
+      useSidebarState({
+        assistantId: "asst-1",
+        conversations,
+        conversationGroups,
+      }),
+    );
+
+    const keys = result.current.sections.map((s) => s.key);
+    expect(keys).toContain("grp-full");
+    // The empty group is the index's call, not the groups query's: it stays
+    // a "Move to group" target but renders no card.
+    expect(keys).not.toContain("grp-empty");
+  });
+
+  test("group metadata comes from the index snapshot, not the groups query", () => {
+    const conversationGroups = [
+      {
+        id: "grp-a",
+        name: "Stale name",
+        sortPosition: 0,
+        isSystemGroup: false,
+      },
+    ];
+    sidebarSectionsImpl = [
+      {
+        kind: "group",
+        groupId: "grp-a",
+        name: "Fresh name",
+        icon: null,
+        sortPosition: 0,
+        total: 2,
+        unread: 0,
+      },
+      { kind: "chats", total: 0, unread: 0 },
+    ];
+
+    const { result } = renderHook(() =>
+      useSidebarState({
+        assistantId: "asst-1",
+        conversations: [],
+        conversationGroups,
+      }),
+    );
+
+    const section = result.current.sections.find((s) => s.key === "grp-a");
+    expect(section?.label).toBe("Fresh name");
+  });
+
+  test("Pinned exists exactly when the index says so", () => {
+    // Derived pinned rows exist either way; the index decides the section.
+    const conversations = [
+      makeConversation(0, { conversationId: "p1", isPinned: true }),
+    ];
+    sidebarSectionsImpl = [{ kind: "chats", total: 0, unread: 0 }];
+
+    const { result, rerender } = renderHook(() =>
+      useSidebarState({ assistantId: "asst-1", conversations }),
+    );
+    expect(result.current.sections.map((s) => s.key)).not.toContain("pinned");
+
+    sidebarSectionsImpl = [
+      { kind: "pinned", total: 1, unread: 0 },
+      { kind: "chats", total: 0, unread: 0 },
+    ];
+    rerender();
+    // The section exists per the index; its fallback rows are the derived
+    // pinned bucket.
+    expect(sectionFor(result.current.sections, "pinned").all).toHaveLength(1);
+  });
+
+  test("a channel section from the index renders even with no derived rows", () => {
+    seedGroupedView();
+    sidebarSectionsImpl = [
+      { kind: "channel", channelId: "slack", total: 3, unread: 1 },
+      { kind: "chats", total: 0, unread: 0 },
+    ];
+
+    const { result } = renderHook(() =>
+      useSidebarState({ assistantId: "asst-1", conversations: [] }),
+    );
+
+    // Its own query fills the contents; existence must not wait for derived
+    // rows the foreground page never carried.
+    expect(sectionFor(result.current.sections, "channel:slack").all).toEqual(
+      [],
+    );
+  });
+
+  test("Chats renders in both discovery modes", () => {
+    sidebarSectionsImpl = [{ kind: "chats", total: 0, unread: 0 }];
+    const { result } = renderHook(() =>
+      useSidebarState({ assistantId: "asst-1", conversations: [] }),
+    );
+    expect(sectionFor(result.current.sections, "recents")).toBeDefined();
   });
 });

--- a/clients/web/src/domains/chat/use-sidebar-state.ts
+++ b/clients/web/src/domains/chat/use-sidebar-state.ts
@@ -306,10 +306,11 @@ export function useSidebarState({
        for existence AND for group metadata: it is one consistent snapshot,
        where existence-from-index with names-from-the-groups-query could
        disagree between fetches. The derived buckets stay as each section's
-       `all` fallback rows either way. When the index is `null` (older
-       daemon, or not yet resolved), existence derives from the loaded list
-       exactly as before; that path must remain this untouched code, not a
-       re-implementation, so the fallback cannot drift. */
+       `all` fallback rows either way. When the index is `null` (an assistant
+       without the endpoint, or a read that has not resolved), existence
+       derives from the loaded list in the branch below, the one
+       implementation shared with every assistant that never serves the
+       index. */
     if (indexSections !== null) {
       const list: SidebarSection[] = [];
       const bucketByGroupId = new Map(

--- a/clients/web/src/domains/chat/use-sidebar-state.ts
+++ b/clients/web/src/domains/chat/use-sidebar-state.ts
@@ -71,6 +71,7 @@ import { mergeConversationLists } from "@/utils/conversation-cache";
 import {
   useBackgroundConversationListQuery,
   useScheduledConversationListQuery,
+  useSidebarSectionsQuery,
 } from "@/hooks/conversation-queries";
 import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
 import { getChannelLabel } from "@/utils/channel-presentation";
@@ -250,6 +251,12 @@ export function useSidebarState({
       isAssistantActive && scheduledReady,
     );
 
+  /* The daemon's section index: which sections exist and what their badges
+     say, with no conversation rows. `null` when the assistant predates the
+     endpoint or the read has not resolved, in which case existence keeps
+     deriving from the loaded list below. */
+  const indexSections = useSidebarSectionsQuery(assistantId, isAssistantActive);
+
   const allConversations = useMemo(
     () =>
       mergeConversationLists(
@@ -294,6 +301,73 @@ export function useSidebarState({
      before the list is built, and this hook cannot mount N queries for N
      groups. */
   const defaultSections = useMemo((): SidebarSection[] => {
+    /* Which sections exist has two possible sources, never mixed within one
+       render. When the daemon serves the section index, it is authoritative
+       for existence AND for group metadata: it is one consistent snapshot,
+       where existence-from-index with names-from-the-groups-query could
+       disagree between fetches. The derived buckets stay as each section's
+       `all` fallback rows either way. When the index is `null` (older
+       daemon, or not yet resolved), existence derives from the loaded list
+       exactly as before; that path must remain this untouched code, not a
+       re-implementation, so the fallback cannot drift. */
+    if (indexSections !== null) {
+      const list: SidebarSection[] = [];
+      const bucketByGroupId = new Map(
+        grouped.customGroups.map((g) => [g.id, g]),
+      );
+      const rowsByChannelId = new Map(
+        grouped.channelSections.map((s) => [s.channelId, s.conversations]),
+      );
+      if (indexSections.some((s) => s.kind === "pinned")) {
+        list.push({
+          type: "pinned",
+          key: "pinned",
+          label: "Pinned",
+          all: grouped.pinned,
+        });
+      }
+      const groupRows = indexSections
+        .filter((s) => s.kind === "group")
+        .sort((a, b) => a.sortPosition - b.sortPosition);
+      for (const row of groupRows) {
+        list.push({
+          type: "group",
+          key: row.groupId,
+          label: row.name,
+          all: bucketByGroupId.get(row.groupId)?.conversations ?? [],
+          group: {
+            id: row.groupId,
+            name: row.name,
+            icon: row.icon,
+            conversations:
+              bucketByGroupId.get(row.groupId)?.conversations ?? [],
+          },
+        });
+      }
+      list.push({
+        type: "recents",
+        key: "recents",
+        label: RECENTS_SECTION_LABEL,
+        all: grouped.recents,
+        holdsChannels: viewMode !== "grouped",
+      });
+      if (viewMode === "grouped") {
+        const channelRows = indexSections
+          .filter((s) => s.kind === "channel")
+          .sort((a, b) => a.channelId.localeCompare(b.channelId));
+        for (const row of channelRows) {
+          list.push({
+            type: "channel",
+            key: channelSectionKey(row.channelId),
+            label: getChannelLabel(row.channelId),
+            all: rowsByChannelId.get(row.channelId) ?? [],
+            channelId: row.channelId,
+          });
+        }
+      }
+      return list;
+    }
+
     const list: SidebarSection[] = [];
     if (grouped.pinned.length > 0) {
       list.push({
@@ -343,6 +417,7 @@ export function useSidebarState({
     return list;
   }, [
     viewMode,
+    indexSections,
     grouped.pinned,
     grouped.customGroups,
     grouped.recents,

--- a/clients/web/src/hooks/conversation-queries.ts
+++ b/clients/web/src/hooks/conversation-queries.ts
@@ -38,9 +38,13 @@ import {
   conversationListOptions,
   sectionConversationListOptions,
   scheduledConversationListOptions,
+  sidebarSectionsOptions,
   unreadConversationCountOptions,
 } from "@/utils/conversation-list-fetchers";
-import type { SectionConversationFilter } from "@/utils/conversation-list-fetchers";
+import type {
+  SectionConversationFilter,
+  SidebarIndexSection,
+} from "@/utils/conversation-list-fetchers";
 
 // ---------------------------------------------------------------------------
 // Queries
@@ -215,6 +219,32 @@ export function useSectionConversationListQuery(
     isError: query.isError,
     hasData: query.data !== undefined,
   };
+}
+
+/**
+ * Subscribe to the sidebar section index
+ * (`GET /v1/conversations/sections`).
+ *
+ * Returns the daemon's per-section rows, or `null` while unresolved and when
+ * the connected assistant does not serve the endpoint (pre-index daemons 404
+ * the read, which the fetcher maps to `null`). `null` is the signal to keep
+ * deriving section existence from the loaded conversation list; the two
+ * sources must never be mixed within one render.
+ *
+ * Freshness comes from the same channels as the unread count:
+ * `sync_changed`-driven invalidation and mutation settles, never focus
+ * refetches.
+ */
+export function useSidebarSectionsQuery(
+  assistantId: string | null,
+  enabled: boolean = true,
+): SidebarIndexSection[] | null {
+  const isOrgReady = useIsOrgReady();
+  const query = useQuery({
+    ...sidebarSectionsOptions(assistantId!),
+    enabled: enabled && Boolean(assistantId) && isOrgReady,
+  });
+  return query.data ?? null;
 }
 
 /**

--- a/clients/web/src/hooks/use-conversation-sync.ts
+++ b/clients/web/src/hooks/use-conversation-sync.ts
@@ -247,8 +247,8 @@ function scheduleUnreadCountRefetch(
     void queryClient.invalidateQueries({
       queryKey: unreadConversationCountQueryKey(assistantId),
     });
-    // Seen-state changes move per-section unread; the index carries those
-    // badges now, so it refetches on the same metadata-driven timer.
+    // Seen-state changes move per-section unread, and the index carries
+    // those badges, so it refetches on the same metadata-driven timer.
     void queryClient.invalidateQueries({
       queryKey: sidebarSectionsQueryKey(assistantId),
     });

--- a/clients/web/src/hooks/use-conversation-sync.ts
+++ b/clients/web/src/hooks/use-conversation-sync.ts
@@ -36,6 +36,7 @@ import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { groupsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
 import {
   archivedConversationsQueryKey,
+  sidebarSectionsQueryKey,
   unreadConversationCountQueryKey,
 } from "@/utils/conversation-list-fetchers";
 import { getClientId } from "@/lib/telemetry/client-identity";
@@ -220,6 +221,11 @@ function scheduleConversationListRefetch(
     void queryClient.invalidateQueries({
       queryKey: unreadConversationCountQueryKey(assistantId),
     });
+    // Section existence and badge counts change with the list shape; the
+    // index is one cheap GET, so it rides the same debounced signal.
+    void queryClient.invalidateQueries({
+      queryKey: sidebarSectionsQueryKey(assistantId),
+    });
   });
 }
 
@@ -240,6 +246,11 @@ function scheduleUnreadCountRefetch(
   scheduleDebounced(timerRef, () => {
     void queryClient.invalidateQueries({
       queryKey: unreadConversationCountQueryKey(assistantId),
+    });
+    // Seen-state changes move per-section unread; the index carries those
+    // badges now, so it refetches on the same metadata-driven timer.
+    void queryClient.invalidateQueries({
+      queryKey: sidebarSectionsQueryKey(assistantId),
     });
   });
 }

--- a/clients/web/src/utils/conversation-cache.ts
+++ b/clients/web/src/utils/conversation-cache.ts
@@ -44,6 +44,7 @@ import {
   unreadConversationCountQueryKey,
 } from "@/utils/conversation-list-fetchers";
 import {
+  ensureSectionInIndex,
   patchAffectsMembership,
   reconcileSectionMembership,
 } from "@/utils/section-membership";
@@ -375,5 +376,11 @@ export function patchConversation(
   if (!patched || !patchAffectsMembership(patch)) {
     return [];
   }
+  /* The index decides which sections render, so it is a membership cache
+     too: a destination section the index does not know yet must appear with
+     the optimistic write, or the row is visible nowhere until the settle
+     refetch (the first pin, the first conversation moved into an empty
+     group). */
+  ensureSectionInIndex(queryClient, assistantId, patched);
   return reconcileSectionMembership(queryClient, assistantId, patched);
 }

--- a/clients/web/src/utils/conversation-cache.ts
+++ b/clients/web/src/utils/conversation-cache.ts
@@ -40,6 +40,7 @@ import {
   conversationListPrefix,
   conversationsQueryKey,
   scheduledConversationsQueryKey,
+  sidebarSectionsQueryKey,
   unreadConversationCountQueryKey,
 } from "@/utils/conversation-list-fetchers";
 import {
@@ -126,10 +127,12 @@ export function restoreConversationCaches(
  * server. Used in `onSettled` to reconcile optimistic values with the
  * server-authoritative state regardless of mutation success or failure.
  *
- * Includes the unread-count cache (own key, see
- * `cancelConversationQueries`) so optimistic count deltas always
- * reconcile against the authoritative server count after a mutation
- * settles.
+ * Includes the unread-count cache and the sidebar section index (own keys,
+ * see `cancelConversationQueries`) so optimistic count deltas and section
+ * existence always reconcile against the authoritative server state after a
+ * mutation settles. The index needs the local settle path in particular:
+ * the daemon suppresses sync echo to the originating client, so nothing
+ * else refreshes it for the client that made the change.
  */
 export async function invalidateConversationQueries(
   queryClient: QueryClient,
@@ -141,6 +144,9 @@ export async function invalidateConversationQueries(
     }),
     queryClient.invalidateQueries({
       queryKey: unreadConversationCountQueryKey(assistantId),
+    }),
+    queryClient.invalidateQueries({
+      queryKey: sidebarSectionsQueryKey(assistantId),
     }),
   ]);
 }

--- a/clients/web/src/utils/conversation-list-fetchers.ts
+++ b/clients/web/src/utils/conversation-list-fetchers.ts
@@ -17,10 +17,17 @@
 import { queryOptions } from "@tanstack/react-query";
 import {
   conversationsGet,
+  conversationsSectionsGet,
   conversationsUnreadcountGet,
 } from "@/generated/daemon/sdk.gen";
-import { conversationsUnreadcountGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
-import type { ConversationsGetData } from "@/generated/daemon/types.gen";
+import {
+  conversationsSectionsGetQueryKey,
+  conversationsUnreadcountGetQueryKey,
+} from "@/generated/daemon/@tanstack/react-query.gen";
+import type {
+  ConversationsGetData,
+  ConversationsSectionsGetResponse,
+} from "@/generated/daemon/types.gen";
 import {
   ApiError,
   assertHasResponse,
@@ -696,6 +703,56 @@ export async function fetchUnreadConversationCount(
   return data?.count ?? null;
 }
 
+/** One renderable sidebar section as the daemon indexes it. */
+export type SidebarIndexSection =
+  ConversationsSectionsGetResponse["sections"][number];
+
+/**
+ * Key for the sidebar section index (`GET /v1/conversations/sections`). The
+ * cache holds `SidebarIndexSection[] | null` (see
+ * {@link fetchSidebarSections}).
+ *
+ * The generated key, NOT a child of {@link conversationListPrefix}, for the
+ * same reason as the unread count: the prefix-wide helpers in
+ * `conversation-cache.ts` treat every entry under the prefix as a
+ * `Conversation[]`, and this cache holds section rows.
+ */
+export function sidebarSectionsQueryKey(assistantId: string | null) {
+  return conversationsSectionsGetQueryKey({
+    path: { assistant_id: assistantId ?? "" },
+  });
+}
+
+/**
+ * Read the sidebar section index, mapping a 404 to `null`.
+ *
+ * An assistant without `GET /v1/conversations/sections` 404s this read;
+ * resolving `null` lets the sidebar keep deriving section existence from the
+ * loaded list, and lets a refetch clear an index from a since-rolled-back
+ * assistant instead of stranding it (see "When a gate is unnecessary" in
+ * BACKWARDS_COMPAT.md). Every other HTTP failure throws a status-carrying
+ * {@link ApiError} so the app-level no-retry-4xx policy applies; a missing
+ * response (network error) rethrows raw and retries as transient.
+ */
+export async function fetchSidebarSections(
+  assistantId: string,
+  signal?: AbortSignal,
+): Promise<SidebarIndexSection[] | null> {
+  const { data, error, response } = await conversationsSectionsGet({
+    path: { assistant_id: assistantId },
+    throwOnError: false,
+    signal,
+  });
+  assertHasResponse(response, error, "Failed to fetch sidebar sections.");
+  if (!response.ok) {
+    if (response.status === 404) {
+      return null;
+    }
+    throw toApiError(error, response);
+  }
+  return data?.sections ?? null;
+}
+
 // ---------------------------------------------------------------------------
 // First-page fetchers
 //
@@ -882,6 +939,24 @@ export function unreadConversationCountOptions(assistantId: string) {
   return queryOptions({
     queryKey: unreadConversationCountQueryKey(assistantId),
     queryFn: ({ signal }) => fetchUnreadConversationCount(assistantId, signal),
+    staleTime: QUERY_STALE_TIME_MS,
+    refetchOnWindowFocus: false,
+  });
+}
+
+/**
+ * Query options for the sidebar section index. The cache holds
+ * `SidebarIndexSection[] | null`; `null` means the connected assistant does
+ * not serve the endpoint (see {@link fetchSidebarSections}).
+ *
+ * `refetchOnWindowFocus` is disabled for the same reason as the unread
+ * count: freshness arrives via `sync_changed`-driven invalidation, and a
+ * focus refetch would re-issue the 404 against assistants without the route.
+ */
+export function sidebarSectionsOptions(assistantId: string) {
+  return queryOptions({
+    queryKey: sidebarSectionsQueryKey(assistantId),
+    queryFn: ({ signal }) => fetchSidebarSections(assistantId, signal),
     staleTime: QUERY_STALE_TIME_MS,
     refetchOnWindowFocus: false,
   });

--- a/clients/web/src/utils/section-membership.test.ts
+++ b/clients/web/src/utils/section-membership.test.ts
@@ -24,9 +24,13 @@ import type { Conversation } from "@/types/conversation-types";
 import {
   conversationsQueryKey,
   sectionConversationsQueryKey,
+  sidebarSectionsQueryKey,
   type SectionConversationFilter,
+  type SidebarIndexSection,
 } from "@/utils/conversation-list-fetchers";
+import { groupsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
 import {
+  ensureSectionInIndex,
   matchesSectionFilter,
   patchAffectsMembership,
   reconcileSectionMembership,
@@ -488,5 +492,138 @@ describe("reconcileSectionMembership", () => {
         .getQueryData<Conversation[]>(conversationsQueryKey(ASSISTANT_ID))
         ?.map((c) => c.conversationId),
     ).toEqual(["c1"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ensureSectionInIndex
+// ---------------------------------------------------------------------------
+
+describe("ensureSectionInIndex", () => {
+  const INDEX_KEY = sidebarSectionsQueryKey(ASSISTANT_ID);
+  const GROUPS_KEY = groupsGetQueryKey({
+    path: { assistant_id: ASSISTANT_ID },
+  });
+
+  function indexClient(
+    index: SidebarIndexSection[] | null | undefined,
+  ): QueryClient {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    if (index !== undefined) {
+      client.setQueryData(INDEX_KEY, index);
+    }
+    return client;
+  }
+
+  function kinds(client: QueryClient): string[] {
+    return (
+      client
+        .getQueryData<SidebarIndexSection[]>(INDEX_KEY)
+        ?.map((s) => s.kind) ?? []
+    );
+  }
+
+  test("the first pin inserts a Pinned stub the settle refetch reconciles", () => {
+    /* Without the stub the row is visible nowhere between the optimistic
+       write and the settle: the membership pass removes it from its source
+       section immediately, and no Pinned section renders until the index
+       refetch answers. */
+    const client = indexClient([{ kind: "chats", total: 3, unread: 0 }]);
+
+    ensureSectionInIndex(
+      client,
+      ASSISTANT_ID,
+      conversation({ isPinned: true, groupId: "system:pinned" }),
+    );
+
+    expect(kinds(client)).toContain("pinned");
+  });
+
+  test("an existing Pinned row is left alone", () => {
+    const index: SidebarIndexSection[] = [
+      { kind: "pinned", total: 2, unread: 1 },
+    ];
+    const client = indexClient(index);
+
+    ensureSectionInIndex(
+      client,
+      ASSISTANT_ID,
+      conversation({ isPinned: true, groupId: "system:pinned" }),
+    );
+
+    expect(client.getQueryData<SidebarIndexSection[]>(INDEX_KEY)).toBe(index);
+  });
+
+  test("the first row moved into an empty group inserts a stub with its metadata", () => {
+    const client = indexClient([{ kind: "chats", total: 3, unread: 0 }]);
+    client.setQueryData(GROUPS_KEY, {
+      groups: [
+        {
+          id: "group-uuid",
+          name: "Projects",
+          icon: "folder",
+          sortPosition: 2,
+          isSystemGroup: false,
+        },
+      ],
+    });
+
+    ensureSectionInIndex(
+      client,
+      ASSISTANT_ID,
+      conversation({ groupId: "group-uuid" }),
+    );
+
+    expect(
+      client.getQueryData<SidebarIndexSection[]>(INDEX_KEY),
+    ).toContainEqual({
+      kind: "group",
+      groupId: "group-uuid",
+      name: "Projects",
+      icon: "folder",
+      sortPosition: 2,
+      total: 1,
+      unread: 0,
+    });
+  });
+
+  test("a group the groups cache does not know is left to the settle refetch", () => {
+    // A stub without a name cannot render; the rare gap stays on the
+    // refetch rather than inventing metadata.
+    const client = indexClient([{ kind: "chats", total: 3, unread: 0 }]);
+
+    ensureSectionInIndex(
+      client,
+      ASSISTANT_ID,
+      conversation({ groupId: "group-uuid" }),
+    );
+
+    expect(kinds(client)).toEqual(["chats"]);
+  });
+
+  test("a null index (assistant without the endpoint) is never written", () => {
+    const client = indexClient(null);
+
+    ensureSectionInIndex(
+      client,
+      ASSISTANT_ID,
+      conversation({ isPinned: true, groupId: "system:pinned" }),
+    );
+
+    expect(client.getQueryData(INDEX_KEY)).toBeNull();
+  });
+
+  test("an ungrouped move inserts nothing", () => {
+    const client = indexClient([{ kind: "chats", total: 3, unread: 0 }]);
+
+    ensureSectionInIndex(
+      client,
+      ASSISTANT_ID,
+      conversation({ groupId: "system:all" }),
+    );
+
+    expect(kinds(client)).toEqual(["chats"]);
   });
 });

--- a/clients/web/src/utils/section-membership.ts
+++ b/clients/web/src/utils/section-membership.ts
@@ -21,13 +21,17 @@
 import type { QueryClient } from "@tanstack/react-query";
 
 import type { Conversation } from "@/types/conversation-types";
+import { groupsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
+import type { GroupsGetResponse } from "@/generated/daemon/types.gen";
 import {
   NATIVE_ORIGIN_CHANNEL,
   SYSTEM_ALL_GROUP_ID,
   SYSTEM_PINNED_GROUP_ID,
   parseSectionConversationsQueryKey,
   sectionListPrefix,
+  sidebarSectionsQueryKey,
   type SectionConversationFilter,
+  type SidebarIndexSection,
 } from "@/utils/conversation-list-fetchers";
 import { insertByRecency } from "@/utils/conversation-order";
 import {
@@ -197,6 +201,80 @@ export function matchesSectionFilter(
  *
  * @see {@link https://tanstack.com/query/latest/docs/reference/QueryClient#queryclientgetqueriesdata}
  */
+/**
+ * Make sure the section `conversation` now belongs to exists in the cached
+ * section index, inserting a stub row when it does not.
+ *
+ * The index decides which sections *render*, so a placement whose
+ * destination has no index row yet (the first pin, the first conversation
+ * moved into an empty group) would otherwise leave the row visible nowhere:
+ * the membership pass removes it from its source section immediately, and
+ * the destination section would not exist until the settle refetch answers.
+ *
+ * Insertion-only, deliberately. The removal directions (a section emptied by
+ * a move, a failed move's stub) merely linger as an empty or extra section
+ * until the settle refetch reconciles, which is benign; counts on the stub
+ * are approximations reconciled the same way. A `null` cache (assistant
+ * without the endpoint) and an absent cache are both left alone.
+ *
+ * Group metadata comes from the cached groups list; a stub for a group the
+ * groups cache does not know cannot be named and is skipped, leaving that
+ * rare case on the settle refetch.
+ */
+export function ensureSectionInIndex(
+  queryClient: QueryClient,
+  assistantId: string | null,
+  conversation: Conversation,
+): void {
+  if (!assistantId) {
+    return;
+  }
+  const queryKey = sidebarSectionsQueryKey(assistantId);
+  const index = queryClient.getQueryData<SidebarIndexSection[] | null>(
+    queryKey,
+  );
+  if (index == null) {
+    return;
+  }
+
+  if (isConversationPinned(conversation)) {
+    if (!index.some((s) => s.kind === "pinned")) {
+      queryClient.setQueryData<SidebarIndexSection[] | null>(queryKey, [
+        { kind: "pinned", total: 1, unread: 0 },
+        ...index,
+      ]);
+    }
+    return;
+  }
+
+  const groupId = conversation.groupId;
+  if (!isCustomGroupId(groupId)) {
+    return;
+  }
+  if (index.some((s) => s.kind === "group" && s.groupId === groupId)) {
+    return;
+  }
+  const groups = queryClient.getQueryData<GroupsGetResponse>(
+    groupsGetQueryKey({ path: { assistant_id: assistantId } }),
+  )?.groups;
+  const meta = groups?.find((g) => g.id === groupId);
+  if (!meta) {
+    return;
+  }
+  queryClient.setQueryData<SidebarIndexSection[] | null>(queryKey, [
+    ...index,
+    {
+      kind: "group",
+      groupId,
+      name: meta.name,
+      icon: meta.icon ?? null,
+      sortPosition: meta.sortPosition ?? 0,
+      total: 1,
+      unread: 0,
+    },
+  ]);
+}
+
 export function reconcileSectionMembership(
   queryClient: QueryClient,
   assistantId: string | null,

--- a/clients/web/src/utils/sidebar-sections.test.ts
+++ b/clients/web/src/utils/sidebar-sections.test.ts
@@ -1,0 +1,84 @@
+/**
+ * The sidebar section index fetcher: how it classifies responses.
+ *
+ * The index is read from `GET /v1/conversations/sections`. An assistant
+ * without the route 404s it, and the client treats that as "unavailable"
+ * (`null`) so the sidebar keeps deriving section existence from the loaded
+ * list. Every other failure has to stay a real failure, or an auth/server
+ * error would be silently indistinguishable from an old assistant.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { client as daemonClient } from "@/generated/daemon/client.gen";
+import { ApiError } from "@/utils/api-errors";
+import { fetchSidebarSections } from "@/utils/conversation-list-fetchers";
+
+const ASSISTANT_ID = "assistant-1";
+
+const originalGet = daemonClient.get;
+
+afterEach(() => {
+  daemonClient.get = originalGet;
+});
+
+/** Stub the daemon transport with one response for the next GET. */
+function stubResponse(opts: { status: number; body?: unknown }): void {
+  daemonClient.get = mock(async () => {
+    const ok = opts.status < 400;
+    return {
+      data: ok ? opts.body : null,
+      error: ok ? null : { message: "boom" },
+      response: new Response(JSON.stringify(opts.body ?? {}), {
+        status: opts.status,
+      }),
+    };
+  }) as typeof daemonClient.get;
+}
+
+/** Stub the daemon transport with a transport-level failure (no response). */
+function stubNetworkFailure(): void {
+  daemonClient.get = mock(async () => ({
+    data: null,
+    error: new Error("network down"),
+    response: undefined,
+  })) as unknown as typeof daemonClient.get;
+}
+
+describe("fetchSidebarSections", () => {
+  test("returns the sections from a successful response", async () => {
+    const sections = [
+      { kind: "pinned", total: 2, unread: 1 },
+      { kind: "chats", total: 5, unread: 0 },
+    ];
+    stubResponse({ status: 200, body: { sections } });
+
+    expect(await fetchSidebarSections(ASSISTANT_ID)).toEqual(
+      sections as Awaited<ReturnType<typeof fetchSidebarSections>>,
+    );
+  });
+
+  test("maps 404 to null so an assistant without the route reads as unavailable", async () => {
+    stubResponse({ status: 404 });
+
+    expect(await fetchSidebarSections(ASSISTANT_ID)).toBeNull();
+  });
+
+  test("throws a status-carrying ApiError on auth failure", async () => {
+    // A 401 must not read as "old assistant": the sidebar would silently
+    // stay on derived discovery while every other query surfaced the error.
+    stubResponse({ status: 401 });
+
+    await expect(fetchSidebarSections(ASSISTANT_ID)).rejects.toBeInstanceOf(
+      ApiError,
+    );
+  });
+
+  test("rethrows a transport failure raw so it retries as transient", async () => {
+    stubNetworkFailure();
+
+    await expect(fetchSidebarSections(ASSISTANT_ID)).rejects.not.toBeInstanceOf(
+      ApiError,
+    );
+  });
+});


### PR DESCRIPTION
## TL;DR

The web sidebar now reads `GET /v1/conversations/sections` (shipped in #40591) to decide which sections exist and what group sections are called — one consistent snapshot, no conversation rows. On daemons with the index: **empty custom groups stop rendering cards** (an unmet LUM-2443 acceptance criterion), a section can exist before any of its rows reach the foreground page, and group renames land in the section header from the same snapshot that decides the section exists. On daemons without it: byte-for-byte today's behavior, through the untouched existing code path.

Fixes LUM-3218. Part of LUM-2443.

## Design decisions, with the reasoning

**Gateless, not version-gated.** Checked against all four criteria in `BACKWARDS_COMPAT.md` "When a gate is unnecessary" rather than defaulting to a gate: pure read; a 404 degrades to exactly the feature-off state (derived discovery); the 404 is mapped to `null` **in the queryFn** so a stale success from a since-rolled-back assistant is cleared rather than stranded; and the query stays quiet under failure (no 4xx retry per the app QueryClient, `refetchOnWindowFocus: false` since freshness arrives via sync signals). Same shape as the workspace-theme and unread-count precedents, and it means same-source self-hosted daemons — which under-report their version and would read as unsupported under any gate — get the feature immediately.

**Existence and metadata never mix sources within one render.** When the index is present it is authoritative for *both* which sections exist and what group sections are called; when `null`, the loaded list decides both. The tempting middle — existence from the index, names from the groups query — is exactly the two-snapshots-disagree bug the index's inline metadata exists to prevent (a group present in the index whose groups-query copy is stale or missing would render wrong or vanish). The fallback path is deliberately the pre-existing code, not a re-implementation, so it cannot drift from what un-indexed daemons have always gotten.

**The index refreshes on local settles, and this is load-bearing, not belt-and-braces:** the daemon suppresses sync echo to the originating client, so a mutation's own settle is the *only* refresh that client gets. Without it, pinning your first conversation would not create the Pinned section until another client changed something. Wired at: placement settles (narrow and broad), the broad conversation reconcile (`invalidateConversationQueries`), group rename (the index carries the name now), and both debounced sync timers for other clients' changes. Group *creation* deliberately does not refresh it: a new group is empty, and an empty group has no index row.

## What this does NOT change

Section *contents* (each section's own query and derived fallback), the collapsed-rail indicator internals, Chats composition, and the foreground list's other ten consumers. Rail badge counts from the index are the next PR — the indicator mixes unread with attention/processing state that stays client-derived, so swapping its unread source is separable.

## Mock audit

`mock.module` replaces the whole module, so every suite mocking `@/hooks/conversation-queries` was audited (nine files): the two whose trees mount `use-sidebar-state` (`use-sidebar-state.test.tsx`, `assistant-side-menu.test.tsx`) now stub `useSidebarSectionsQuery` (returning `null`, keeping their existing tests on the derived path they were written against); the other seven never mount it, verified per file.

## Testing

Local test runs are blocked on this machine; CI is the verifier. Fixtures hand-traced through the seam before push, each with a named wrong-behavior that fails it:

- `sidebar-sections.test.ts`: the fetcher contract (sections through, 404→null, 401 throws `ApiError` — an auth failure must not impersonate an old assistant — transport failure rethrows raw).
- `use-sidebar-state.test.tsx`, new describe: empty group hidden exactly when the index omits it; group label from the index snapshot, not the groups query; Pinned existing exactly when the index says so (fails against derived discovery); a channel section rendering with zero derived rows (fails against derived discovery); Chats present in both modes. All pre-existing tests run against the `null` stub, i.e. the unchanged derived path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40594" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->