### PR TITLE
feat(web): surface the ChatGPT provider in the settings pickers

### DIFF
--- a/clients/web/src/assistant/llm-model-catalog.test.ts
+++ b/clients/web/src/assistant/llm-model-catalog.test.ts
@@ -98,8 +98,8 @@ describe("chatgpt identity catalog", () => {
     expect(models.some((m) => m.id === "gpt-5.4-nano")).toBe(false);
   });
 
-  test("defaults to the recommended everyday Codex model", () => {
-    expect(getDefaultModelForProvider("chatgpt")).toBe("gpt-5.6-terra");
+  test("defaults to the Balanced profile's model on the chatgpt column", () => {
+    expect(getDefaultModelForProvider("chatgpt")).toBe("gpt-5.6-luna");
   });
 });
 

--- a/clients/web/src/assistant/llm-model-catalog.test.ts
+++ b/clients/web/src/assistant/llm-model-catalog.test.ts
@@ -19,7 +19,9 @@ import { INFERENCE_PROVIDERS } from "@/domains/settings/ai/constants";
 import { CONNECTION_PROVIDERS } from "@/domains/settings/ai/provider-editor-constants";
 
 import {
+  CODEX_SUBSCRIPTION_MODEL_IDS,
   DEFAULT_MODEL_BY_PROVIDER,
+  getDefaultModelForProvider,
   MODELS_BY_PROVIDER,
   PROVIDER_DISPLAY_NAMES,
   PROVIDER_SUPPORTS_PLATFORM_AUTH,
@@ -83,6 +85,23 @@ function comparableModel(model: MetaCatalogModel) {
     adaptiveThinkingOnly: model.adaptiveThinkingOnly === true,
   };
 }
+
+describe("chatgpt identity catalog", () => {
+  test("serves the openai catalog restricted to the Codex set", () => {
+    const models = getModelsForProvider("chatgpt");
+    expect(models.length).toBeGreaterThan(0);
+    const openaiIds = new Set(getModelsForProvider("openai").map((m) => m.id));
+    for (const m of models) {
+      expect(openaiIds.has(m.id)).toBe(true);
+      expect(CODEX_SUBSCRIPTION_MODEL_IDS.has(m.id)).toBe(true);
+    }
+    expect(models.some((m) => m.id === "gpt-5.4-nano")).toBe(false);
+  });
+
+  test("defaults to the recommended everyday Codex model", () => {
+    expect(getDefaultModelForProvider("chatgpt")).toBe("gpt-5.6-terra");
+  });
+});
 
 describe("parity with meta/llm-provider-catalog.json", () => {
   // Intentional asymmetry between the web mirror and the meta catalog:

--- a/clients/web/src/assistant/llm-model-catalog.ts
+++ b/clients/web/src/assistant/llm-model-catalog.ts
@@ -1066,11 +1066,34 @@ export function getManagedUpstreamForModel(
   );
 }
 
+// Keep in sync with CODEX_SUBSCRIPTION_MODEL_IDS in
+// assistant/src/providers/openai/codex-models.ts. Lives in the catalog so
+// the "chatgpt" identity's model list resolves here like every provider's;
+// the settings domain re-exports it from codex-subscription-models.
+export const CODEX_SUBSCRIPTION_MODEL_IDS: ReadonlySet<string> = new Set([
+  "gpt-5.6-sol",
+  "gpt-5.6-terra",
+  "gpt-5.6-luna",
+  "gpt-5.5",
+  // OpenAI retires these two from ChatGPT sign-in on 2026-08-31; API-key
+  // auth is unaffected.
+  "gpt-5.4",
+  "gpt-5.4-mini",
+]);
+
 export function getModelsForProvider(
   provider: string,
 ): readonly LlmCatalogModel[] {
   if (provider === "vellum") {
     return VELLUM_MODELS;
+  }
+  // The "chatgpt" routing identity has no catalog of its own: it serves the
+  // OpenAI catalog restricted to what the Codex subscription endpoint
+  // accepts.
+  if (provider === "chatgpt") {
+    return MODELS_BY_PROVIDER.openai.filter((m) =>
+      CODEX_SUBSCRIPTION_MODEL_IDS.has(m.id),
+    );
   }
   return MODELS_BY_PROVIDER[provider as LlmProviderId] ?? [];
 }
@@ -1078,6 +1101,10 @@ export function getModelsForProvider(
 export function getDefaultModelForProvider(
   provider: string,
 ): string | undefined {
+  // OpenAI's recommended everyday Codex model.
+  if (provider === "chatgpt") {
+    return "gpt-5.6-terra";
+  }
   return DEFAULT_MODEL_BY_PROVIDER[provider as LlmProviderId];
 }
 

--- a/clients/web/src/assistant/llm-model-catalog.ts
+++ b/clients/web/src/assistant/llm-model-catalog.ts
@@ -1101,9 +1101,10 @@ export function getModelsForProvider(
 export function getDefaultModelForProvider(
   provider: string,
 ): string | undefined {
-  // OpenAI's recommended everyday Codex model.
+  // Matches the Balanced default profile's model on the chatgpt column so
+  // users see one consistent "default" for the subscription.
   if (provider === "chatgpt") {
-    return "gpt-5.6-terra";
+    return "gpt-5.6-luna";
   }
   return DEFAULT_MODEL_BY_PROVIDER[provider as LlmProviderId];
 }

--- a/clients/web/src/domains/settings/ai/call-site-overrides-row.test.tsx
+++ b/clients/web/src/domains/settings/ai/call-site-overrides-row.test.tsx
@@ -188,16 +188,70 @@ describe("CallSiteOverrideRow model picker under a ChatGPT subscription", () => 
     expect(labels.some((l) => l.includes("Nano"))).toBe(false);
   });
 
-  test("a migrated subscription row (provider chatgpt) filters the openai picker too", () => {
+  test("a migrated subscription row (provider chatgpt) does not gate the openai picker", () => {
+    // Post-366 semantics: dispatch matches connections by exact provider, so
+    // the subscription cannot serve an openai override. The subscription is
+    // offered as its own ChatGPT provider entry instead.
     renderRow({ provider: "openai", model: "gpt-5.6-luna" }, [
       SUBSCRIPTION_CONNECTION_366,
     ]);
 
     fireEvent.click(modelTrigger());
 
+    expect(optionLabels().some((l) => l.includes("Nano"))).toBe(true);
+  });
+
+  test("the subscription row adds ChatGPT to the provider picker", () => {
+    renderRow({ provider: "openai", model: "gpt-5.6-luna" }, [
+      SUBSCRIPTION_CONNECTION_366,
+    ]);
+
+    fireEvent.click(providerTrigger());
+
+    expect(optionLabels().some((l) => l.includes("ChatGPT Subscription"))).toBe(
+      true,
+    );
+  });
+
+  test("without the subscription row ChatGPT is not offered", () => {
+    renderRow({ provider: "openai", model: "gpt-5.6-luna" }, [
+      API_KEY_CONNECTION,
+    ]);
+
+    fireEvent.click(providerTrigger());
+
+    expect(optionLabels().some((l) => l.includes("ChatGPT Subscription"))).toBe(
+      false,
+    );
+  });
+
+  test("a chatgpt draft renders as itself with the Codex model list", () => {
+    renderRow({ provider: "chatgpt", model: "gpt-5.6-terra" }, [
+      SUBSCRIPTION_CONNECTION_366,
+    ]);
+
+    expect(
+      triggerLabels().some((l) => l.includes("ChatGPT Subscription")),
+    ).toBe(true);
+
+    fireEvent.click(modelTrigger());
     const labels = optionLabels();
-    expect(labels.some((l) => l.includes("GPT-5.6 Luna"))).toBe(true);
+    expect(labels.some((l) => l.includes("GPT-5.6 Terra"))).toBe(true);
     expect(labels.some((l) => l.includes("Nano"))).toBe(false);
+  });
+
+  test("a chatgpt draft without the subscription renders as an unavailable pin", () => {
+    renderRow({ provider: "chatgpt", model: "gpt-5.6-terra" }, [
+      API_KEY_CONNECTION,
+    ]);
+
+    fireEvent.click(providerTrigger());
+
+    expect(
+      optionLabels().some((l) =>
+        l.includes("ChatGPT Subscription (unavailable)"),
+      ),
+    ).toBe(true);
   });
 
   test("a vellum-managed connection lifts the restriction (openai routes through the managed proxy)", () => {

--- a/clients/web/src/domains/settings/ai/call-site-overrides-row.tsx
+++ b/clients/web/src/domains/settings/ai/call-site-overrides-row.tsx
@@ -113,9 +113,12 @@ export function CallSiteOverrideRow({
   // the pickable set still falls back rather than being offered as a row
   // the picker cannot represent. The `chatgpt` identity is pickable and
   // renders as itself.
-  const storedProvider = isInferenceProvider(draft?.provider)
-    ? draft.provider
-    : draft?.provider === CHATGPT_CONNECTION_PROVIDER
+  const draftProvider = draft?.provider;
+  const storedProvider: PickableProvider | undefined = isInferenceProvider(
+    draftProvider,
+  )
+    ? draftProvider
+    : draftProvider === CHATGPT_CONNECTION_PROVIDER
       ? CHATGPT_CONNECTION_PROVIDER
       : undefined;
   const storedProviderIsSelectable =
@@ -155,6 +158,25 @@ export function CallSiteOverrideRow({
     });
   }
   const hasModelError = !!draft?.provider && !draft?.model;
+  const providerOptions: { value: PickableProvider; label: string }[] = [
+    ...pickableProviders.map((p) => ({
+      value: p,
+      label: PROVIDER_DISPLAY_NAMES[p] ?? p,
+    })),
+    // Keeps the trigger honest and gives the user a way out: the row
+    // renders its real pin, and choosing any other provider is a genuine
+    // change that fires.
+    ...(storedProvider && !storedProviderIsSelectable
+      ? [
+          {
+            value: storedProvider,
+            label: `${
+              PROVIDER_DISPLAY_NAMES[storedProvider] ?? storedProvider
+            } (unavailable)`,
+          },
+        ]
+      : []),
+  ];
 
   function handleProfilePickerChange(val: string) {
     if (val === CUSTOM_SENTINEL) {
@@ -234,26 +256,7 @@ export function CallSiteOverrideRow({
               <Select
                 value={currentProvider ?? ""}
                 onChange={handleProviderChange}
-                options={[
-                  ...pickableProviders.map((p) => ({
-                    value: p,
-                    label: PROVIDER_DISPLAY_NAMES[p] ?? p,
-                  })),
-                  // Keeps the trigger honest and gives the user a way out:
-                  // the row renders its real pin, and choosing any other
-                  // provider is a genuine change that fires.
-                  ...(storedProvider && !storedProviderIsSelectable
-                    ? [
-                        {
-                          value: storedProvider,
-                          label: `${
-                            PROVIDER_DISPLAY_NAMES[storedProvider] ??
-                            storedProvider
-                          } (unavailable)`,
-                        },
-                      ]
-                    : []),
-                ]}
+                options={providerOptions}
               />
             </div>
             <div className="flex-1">

--- a/clients/web/src/domains/settings/ai/call-site-overrides-row.tsx
+++ b/clients/web/src/domains/settings/ai/call-site-overrides-row.tsx
@@ -12,6 +12,7 @@ import type {
 } from "@/generated/daemon/types.gen";
 
 import {
+  CHATGPT_CONNECTION_PROVIDER,
   INFERENCE_PROVIDERS,
   isInferenceProvider,
 } from "@/domains/settings/ai/constants";
@@ -36,6 +37,9 @@ interface ProfileOption {
   value: string;
   label: string;
 }
+
+type PickableProvider =
+  (typeof INFERENCE_PROVIDERS)[number] | typeof CHATGPT_CONNECTION_PROVIDER;
 
 export interface CallSiteOverrideRowProps {
   id: string;
@@ -84,6 +88,18 @@ export function CallSiteOverrideRow({
 
   const isCustom = profileVal === CUSTOM_SENTINEL;
   const selectableInferenceProviders = useSelectableInferenceProviders();
+  // The chatgpt identity joins the picker when the workspace holds the
+  // subscription row (provider "chatgpt"; only daemons that understand the
+  // identity return that shape). Migration 144 also writes chatgpt drafts,
+  // so the row must represent the value even without the subscription: the
+  // unavailable-pin branch below covers that.
+  const hasSubscription = (connections ?? []).some(
+    (c) => c.provider === CHATGPT_CONNECTION_PROVIDER,
+  );
+  const pickableProviders: PickableProvider[] = [
+    ...selectableInferenceProviders,
+    ...(hasSubscription ? ([CHATGPT_CONNECTION_PROVIDER] as const) : []),
+  ];
   const defaultProvider =
     selectableInferenceProviders[0] ?? INFERENCE_PROVIDERS[0];
   // Show what is actually pinned, even when this assistant cannot select it
@@ -93,15 +109,18 @@ export function CallSiteOverrideRow({
   // the value, so the change never fires.
   //
   // `LlmProvider` is wider than the picker's domain (it also carries the
-  // `openai-compatible`, `vellum` and `chatgpt` routing sentinels), so a pin
-  // outside `INFERENCE_PROVIDERS` still falls back rather than being offered
-  // as a row the picker cannot represent.
+  // `openai-compatible` and `vellum` routing sentinels), so a pin outside
+  // the pickable set still falls back rather than being offered as a row
+  // the picker cannot represent. The `chatgpt` identity is pickable and
+  // renders as itself.
   const storedProvider = isInferenceProvider(draft?.provider)
     ? draft.provider
-    : undefined;
+    : draft?.provider === CHATGPT_CONNECTION_PROVIDER
+      ? CHATGPT_CONNECTION_PROVIDER
+      : undefined;
   const storedProviderIsSelectable =
     storedProvider !== undefined &&
-    selectableInferenceProviders.some((p) => p === storedProvider);
+    pickableProviders.some((p) => p === storedProvider);
   const currentProvider = storedProvider ?? defaultProvider;
   // A call-site override pins no connection, so dispatch auto-resolves one.
   // When every connection that can serve the provider is a ChatGPT
@@ -152,9 +171,7 @@ export function CallSiteOverrideRow({
     }
   }
 
-  function handleProviderChange(
-    provider: (typeof INFERENCE_PROVIDERS)[number],
-  ) {
+  function handleProviderChange(provider: PickableProvider) {
     const defaultModel = getDefaultModelForProvider(provider) ?? "";
     onDraftChange(id, {
       ...(draft ?? {}),
@@ -218,7 +235,7 @@ export function CallSiteOverrideRow({
                 value={currentProvider ?? ""}
                 onChange={handleProviderChange}
                 options={[
-                  ...selectableInferenceProviders.map((p) => ({
+                  ...pickableProviders.map((p) => ({
                     value: p,
                     label: PROVIDER_DISPLAY_NAMES[p] ?? p,
                   })),

--- a/clients/web/src/domains/settings/ai/codex-subscription-models.ts
+++ b/clients/web/src/domains/settings/ai/codex-subscription-models.ts
@@ -1,21 +1,13 @@
-import { getModelsForProvider } from "@/assistant/llm-model-catalog";
+import {
+  CODEX_SUBSCRIPTION_MODEL_IDS,
+  getModelsForProvider,
+} from "@/assistant/llm-model-catalog";
 import type {
   ConnectionProvider,
   ProviderConnection,
 } from "@/generated/daemon/types.gen";
 
-// Keep in sync with CODEX_SUBSCRIPTION_MODEL_IDS in
-// assistant/src/providers/openai/codex-models.ts.
-export const CODEX_SUBSCRIPTION_MODEL_IDS: ReadonlySet<string> = new Set([
-  "gpt-5.6-sol",
-  "gpt-5.6-terra",
-  "gpt-5.6-luna",
-  "gpt-5.5",
-  // OpenAI retires these two from ChatGPT sign-in on 2026-08-31; API-key
-  // auth is unaffected.
-  "gpt-5.4",
-  "gpt-5.4-mini",
-]);
+export { CODEX_SUBSCRIPTION_MODEL_IDS };
 
 /** The provider's catalog models a ChatGPT subscription can dispatch. */
 export function codexServableModels(
@@ -32,6 +24,13 @@ export function codexServableModels(
  * connection hard-routes to the Codex endpoint, which rejects any model
  * outside the set with HTTP 400, so every surface that offers models for
  * such a connection must respect the limit.
+ *
+ * This matters only for the pre-migration-366 row shape, where daemons
+ * older than the identity work return the subscription row as provider
+ * "openai" and openai fragments auto-resolve onto it. Daemons past 366
+ * return the row as provider "chatgpt", exact-match filtering keeps it out
+ * of openai candidate lists, and the chatgpt picker entry carries the
+ * Codex-only model list itself.
  */
 export function restrictsToSubscriptionModels(
   provider: ConnectionProvider | "",

--- a/clients/web/src/domains/settings/ai/profile-editor-provider-section.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-provider-section.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * The provider section's ChatGPT-subscription behavior: the steering hint
+ * for stale openai profiles in subscription-only workspaces, and the Codex
+ * model list with no free-text escape for the chatgpt identity.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+mock.module("@/hooks/use-platform-gate", () => ({
+  usePlatformGate: () => "full",
+  useActiveAssistantIsSelfHosted: () => false,
+}));
+
+const { ProfileEditorProviderSection } =
+  await import("@/domains/settings/ai/profile-editor-provider-section");
+
+const SUBSCRIPTION_CONNECTION = {
+  name: "chatgpt-subscription",
+  provider: "chatgpt",
+  auth: { type: "oauth_subscription", credential: "credential/chatgpt" },
+};
+
+function renderSection(overrides: Record<string, unknown>) {
+  const connections = (overrides.connections ?? []) as never;
+  return render(
+    <ProfileEditorProviderSection
+      provider={"" as never}
+      model=""
+      providerConnection=""
+      onProviderChange={() => {}}
+      onModelChange={() => {}}
+      onConnectionChange={() => {}}
+      connections={connections}
+      isReadOnly={false}
+      availableConnectionsForProvider={[] as never}
+      connectionNotFound={false}
+      {...(overrides as object)}
+    />,
+  );
+}
+
+function optionLabels(): string[] {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>('[role="option"]'),
+  ).map((o) => o.textContent?.trim() ?? "");
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ProfileEditorProviderSection with a ChatGPT subscription", () => {
+  test("a stale openai profile shows the subscription steering hint", () => {
+    renderSection({
+      provider: "openai",
+      connections: [SUBSCRIPTION_CONNECTION],
+      availableConnectionsForProvider: [],
+    });
+
+    expect(
+      screen.queryByText(
+        "Your ChatGPT subscription is available as the ChatGPT provider.",
+      ),
+    ).toBeTruthy();
+  });
+
+  test("no hint without a subscription connection", () => {
+    renderSection({
+      provider: "openai",
+      connections: [],
+      availableConnectionsForProvider: [],
+    });
+
+    expect(
+      screen.queryByText(
+        "Your ChatGPT subscription is available as the ChatGPT provider.",
+      ),
+    ).toBeNull();
+  });
+
+  test("the chatgpt identity lists Codex models with no custom-id escape", () => {
+    renderSection({
+      provider: "chatgpt",
+      connections: [SUBSCRIPTION_CONNECTION],
+      availableConnectionsForProvider: [SUBSCRIPTION_CONNECTION],
+    });
+
+    const modelTrigger = screen.getByLabelText("Model");
+    fireEvent.click(modelTrigger);
+
+    const labels = optionLabels();
+    expect(labels.some((l) => l.includes("GPT-5.6 Terra"))).toBe(true);
+    expect(labels.some((l) => l.includes("Nano"))).toBe(false);
+    expect(labels.some((l) => l.includes("Enter a custom model ID"))).toBe(
+      false,
+    );
+  });
+});

--- a/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
@@ -14,7 +14,10 @@ import {
   codexServableModels,
   restrictsToSubscriptionModels,
 } from "@/domains/settings/ai/codex-subscription-models";
-import { OPENAI_COMPATIBLE_PROVIDER } from "@/domains/settings/ai/constants";
+import {
+  CHATGPT_CONNECTION_PROVIDER,
+  OPENAI_COMPATIBLE_PROVIDER,
+} from "@/domains/settings/ai/constants";
 import {
   endpointPickerValue,
   expandEndpointEntries,
@@ -152,7 +155,12 @@ export function ProfileEditorProviderSection({
     providerConnection,
     availableConnectionsForProvider,
   );
-  const allowsCustomModel = provider !== "" && !subscriptionRestricted;
+  // The chatgpt identity validates models against the Codex set at the
+  // schema, so a typed id outside the list could never save.
+  const allowsCustomModel =
+    provider !== "" &&
+    provider !== CHATGPT_CONNECTION_PROVIDER &&
+    !subscriptionRestricted;
 
   // Switching providers reopens the field on the new provider's model list;
   // a connection that bars custom ids also closes the free-text input.
@@ -202,6 +210,23 @@ export function ProfileEditorProviderSection({
   // so they are not told to.
   const noProviderConnections =
     providerOptionsSource.length === 0 && !isReadOnly;
+
+  // A stale openai profile in a workspace whose only OpenAI access is the
+  // subscription: nothing can serve it, but the fix is one picker entry
+  // away. Covers both row shapes (provider "chatgpt", and the pre-366 rows
+  // older daemons still return, where the subscription row stores provider
+  // "openai" with oauth_subscription auth).
+  const subscriptionSteeringHint =
+    provider === "openai" &&
+    !isReadOnly &&
+    availableConnectionsForProvider.length === 0 &&
+    (connections ?? []).some(
+      (c) =>
+        c.provider === CHATGPT_CONNECTION_PROVIDER ||
+        c.auth.type === "oauth_subscription",
+    )
+      ? "Your ChatGPT subscription is available as the ChatGPT provider."
+      : undefined;
 
   // For openai-compatible providers the static catalog is empty — use models
   // from the selected connection instead. When no specific connection is
@@ -337,7 +362,7 @@ export function ProfileEditorProviderSection({
           helperText={
             noProviderConnections && !providerError
               ? NO_PROVIDER_CONNECTIONS_HINT
-              : undefined
+              : subscriptionSteeringHint
           }
           value={
             provider === OPENAI_COMPATIBLE_PROVIDER && providerConnection

--- a/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 
+import { useTranslation } from "@/i18n";
+
 import { Button } from "@vellumai/design-library/components/button";
 import { Select } from "@vellumai/design-library/components/select";
 import { Input } from "@vellumai/design-library/components/input";
@@ -148,6 +150,7 @@ export function ProfileEditorProviderSection({
   // for a text input whose value is sent to the connection verbatim. It's
   // withheld from subscription-restricted connections, which only accept a
   // fixed model set.
+  const { t } = useTranslation("settings");
   const [isEnteringCustomModel, setIsEnteringCustomModel] = useState(false);
 
   const subscriptionRestricted = restrictsToSubscriptionModels(
@@ -225,7 +228,7 @@ export function ProfileEditorProviderSection({
         c.provider === CHATGPT_CONNECTION_PROVIDER ||
         c.auth.type === "oauth_subscription",
     )
-      ? "Your ChatGPT subscription is available as the ChatGPT provider."
+      ? t("profileEditor.subscriptionSteeringHint")
       : undefined;
 
   // For openai-compatible providers the static catalog is empty — use models

--- a/clients/web/src/domains/settings/ai/profile-param-visibility.ts
+++ b/clients/web/src/domains/settings/ai/profile-param-visibility.ts
@@ -215,7 +215,11 @@ export function resolveProfileParamVisibility(
     return VISIBILITY_NONE;
   }
 
-  const providerId = provider.toLowerCase();
+  // The chatgpt identity dispatches through the OpenAI Responses adapter
+  // (Codex subscription transport), so its parameter capabilities are
+  // openai's.
+  const rawProviderId = provider.toLowerCase();
+  const providerId = rawProviderId === "chatgpt" ? "openai" : rawProviderId;
   const modelId = model.toLowerCase();
   const usesAnthropicWire =
     providerId === "anthropic" ||

--- a/clients/web/src/domains/settings/ai/provider-availability.ts
+++ b/clients/web/src/domains/settings/ai/provider-availability.ts
@@ -19,11 +19,13 @@ const LOCAL_ONLY_PROVIDERS = new Set<string>(["ollama"]);
 
 /**
  * Whether a connection (identified by its stored `provider`) can serve
- * requests for `selectedProvider`. Two routing sentinels serve providers
- * other than their own column value: the provider-agnostic `vellum`
- * connection serves every managed-routable provider, and the `chatgpt`
- * subscription connection serves OpenAI (Codex models only; callers gate
- * the model set separately via `restrictsToSubscriptionModels`).
+ * requests for `selectedProvider`. One routing sentinel serves providers
+ * other than its own column value: the provider-agnostic `vellum`
+ * connection serves every managed-routable provider. The `chatgpt`
+ * subscription connection serves only its own identity: dispatch matches
+ * connections by exact provider, so an "openai" fragment cannot route
+ * through the subscription (migration 144 converts stranded ones to the
+ * chatgpt identity instead).
  */
 export function connectionServesProvider(
   connectionProvider: string,
@@ -32,15 +34,9 @@ export function connectionServesProvider(
   if (connectionProvider === selectedProvider) {
     return true;
   }
-  if (
+  return (
     connectionProvider === VELLUM_CONNECTION_PROVIDER &&
     MANAGED_ROUTABLE_PROVIDERS.has(selectedProvider)
-  ) {
-    return true;
-  }
-  return (
-    connectionProvider === CHATGPT_CONNECTION_PROVIDER &&
-    selectedProvider === "openai"
   );
 }
 
@@ -122,11 +118,17 @@ export function providersServedByConnections(
   if (selectable.includes(VELLUM_CONNECTION_PROVIDER)) {
     ordered.push(VELLUM_CONNECTION_PROVIDER);
   }
+  // The subscription identity sits with the other first-class routes rather
+  // than in the version-drift bucket at the end.
+  if (selectable.includes(CHATGPT_CONNECTION_PROVIDER)) {
+    ordered.push(CHATGPT_CONNECTION_PROVIDER);
+  }
   ordered.push(
     ...CONNECTION_PROVIDERS.filter((provider) => selectable.includes(provider)),
     ...selectable.filter(
       (provider) =>
         provider !== VELLUM_CONNECTION_PROVIDER &&
+        provider !== CHATGPT_CONNECTION_PROVIDER &&
         !CONNECTION_PROVIDERS.includes(provider),
     ),
   );

--- a/clients/web/src/domains/settings/ai/use-profile-editor.ts
+++ b/clients/web/src/domains/settings/ai/use-profile-editor.ts
@@ -16,10 +16,10 @@ import {
 } from "@/assistant/llm-model-catalog";
 import {
   CHATGPT_CONNECTION_PROVIDER,
-  MANAGED_ROUTABLE_PROVIDERS,
   VELLUM_CONNECTION_PROVIDER,
 } from "@/domains/settings/ai/constants";
 import { resolveModelDisplayName } from "@/domains/settings/ai/model-display";
+import { connectionServesProvider } from "@/domains/settings/ai/provider-availability";
 import { deriveProfileDefaults } from "@/domains/settings/ai/profile-prefill";
 import {
   isGeminiThinkingLevel,
@@ -46,27 +46,6 @@ import { badRequestMessage } from "@/utils/api-errors";
 
 export type ProfileEditorMode = "create" | "edit" | "view";
 export type EffortSelection = "inherit" | NonNullable<ProfileEntry["effort"]>;
-
-/**
- * Whether a connection (identified by its stored `provider`) can back a profile
- * whose provider is `selectedProvider`. The provider-agnostic Vellum-managed
- * connection stores the `vellum` sentinel but serves every managed-routable
- * provider, so it counts as available for those.
- */
-function connectionServesProvider(
-  connectionProvider: string,
-  selectedProvider: string,
-): boolean {
-  if (connectionProvider === selectedProvider) {
-    return true;
-  }
-  // Legacy wire shape: a managed profile stores its real upstream (e.g.
-  // "fireworks") while binding to the provider-agnostic vellum connection.
-  return (
-    connectionProvider === VELLUM_CONNECTION_PROVIDER &&
-    MANAGED_ROUTABLE_PROVIDERS.has(selectedProvider)
-  );
-}
 
 export interface UseProfileEditorArgs {
   mode: ProfileEditorMode;
@@ -211,11 +190,10 @@ export function useProfileEditor({
   // upstream is derived from the model at save time. The form opens on the
   // stored upstream and only promotes to Vellum once the loaded connections
   // prove the bound row is the managed sentinel (see the effect below).
-  // A stored "chatgpt" provider (written via the API or CLI) opens with no
-  // provider selected - ChatGPT is a connection sub-option, never a provider
-  // selection here.
+  // A stored "chatgpt" provider (migration 144 output, the picker, or the
+  // API) opens as the ChatGPT selection.
   const [provider, setProvider] = useState<ConnectionProvider | "">(
-    initialValues?.provider && initialValues.provider !== "chatgpt"
+    initialValues?.provider
       ? // The wire type is an open string (the daemon accepts entry names in
         // storage); the editor's selection set is the connection-provider
         // union, and a value outside it renders as no selection.
@@ -363,11 +341,21 @@ export function useProfileEditor({
   const availableConnectionsForProvider = useMemo(
     () =>
       provider
-        ? effectiveConnections.filter((c) =>
-            connectionServesProvider(c.provider, provider),
+        ? effectiveConnections.filter(
+            (c) =>
+              connectionServesProvider(c.provider, provider) ||
+              // Legacy pinned pairing dispatch still accepts: an openai
+              // profile bound by name to the canonical subscription row,
+              // whose stored provider is "chatgpt" once DB migration 366
+              // has run. Migration 144 leaves these pins in place; without
+              // this the editor reads the binding as missing and clears it
+              // on save.
+              (provider === "openai" &&
+                c.name === providerConnection &&
+                c.provider === CHATGPT_CONNECTION_PROVIDER),
           )
         : [],
-    [provider, effectiveConnections],
+    [provider, effectiveConnections, providerConnection],
   );
 
   // Saved binding no longer points at any known connection. The save handler

--- a/clients/web/src/domains/settings/ai/use-profile-editor.ts
+++ b/clients/web/src/domains/settings/ai/use-profile-editor.ts
@@ -15,6 +15,7 @@ import {
   type LlmCatalogModel,
 } from "@/assistant/llm-model-catalog";
 import {
+  CHATGPT_CONNECTION_PROVIDER,
   MANAGED_ROUTABLE_PROVIDERS,
   VELLUM_CONNECTION_PROVIDER,
 } from "@/domains/settings/ai/constants";
@@ -429,10 +430,15 @@ export function useProfileEditor({
     setModel("");
     // Auto-select connection: if exactly one connection exists for the new
     // provider, select it automatically. If multiple exist, clear so the user
-    // must pick. If zero, clear.
-    const connectionsForProvider = effectiveConnections.filter((c) =>
-      connectionServesProvider(c.provider, newProvider),
-    );
+    // must pick. If zero, clear. The chatgpt identity never binds a
+    // connection: dispatch resolves the canonical subscription row
+    // per-request, and the daemon rejects noncanonical pins.
+    const connectionsForProvider =
+      newProvider === CHATGPT_CONNECTION_PROVIDER
+        ? []
+        : effectiveConnections.filter((c) =>
+            connectionServesProvider(c.provider, newProvider),
+          );
     setProviderConnection(
       connectionsForProvider.length === 1 ? connectionsForProvider[0].name : "",
     );
@@ -625,9 +631,13 @@ export function useProfileEditor({
       // (`provider: "vellum"` + native model, no binding); older daemons get
       // the legacy shape: the model's managed upstream as `provider`, bound
       // to the provider-agnostic vellum connection.
+      // The chatgpt identity needs no version gate: the picker offers it
+      // only when the daemon returned a provider "chatgpt" row, which only
+      // daemons that understand the identity payload do.
       const writesIdentityPayload =
-        provider === VELLUM_CONNECTION_PROVIDER &&
-        (await assistantSupportsVellumProviderProfiles(assistantId));
+        provider === CHATGPT_CONNECTION_PROVIDER ||
+        (provider === VELLUM_CONNECTION_PROVIDER &&
+          (await assistantSupportsVellumProviderProfiles(assistantId)));
       const wireProvider =
         provider === VELLUM_CONNECTION_PROVIDER
           ? writesIdentityPayload

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -12,5 +12,8 @@
     "grantedToast": "{amount} in credits added to your account.",
     "unavailableToast": "This offer is no longer available.",
     "errorToast": "Could not add the credits. Please try again."
+  },
+  "profileEditor": {
+    "subscriptionSteeringHint": "Your ChatGPT subscription is available as the ChatGPT provider."
   }
 }

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -12,5 +12,8 @@
     "grantedToast": "Se añadieron {amount} en créditos a tu cuenta.",
     "unavailableToast": "Esta oferta ya no está disponible.",
     "errorToast": "No se pudieron añadir los créditos. Inténtalo de nuevo."
+  },
+  "profileEditor": {
+    "subscriptionSteeringHint": "Tu suscripción a ChatGPT está disponible como el proveedor ChatGPT."
   }
 }


### PR DESCRIPTION
## Summary
- The `chatgpt` identity gets a real model catalog: `getModelsForProvider("chatgpt")` returns the OpenAI catalog restricted to the Codex set (beside the existing `vellum` special case; the set moves into `llm-model-catalog` and is re-exported for the daemon-parity test), and `getDefaultModelForProvider("chatgpt")` returns `gpt-5.6-terra`. The profile editor and call-site override picker offer ChatGPT when the workspace holds the subscription row, with a Codex-only model list, no free-text model escape, and no connection binding (identity payload; the daemon rejects noncanonical pins).
- `connectionServesProvider` drops the interim chatgpt→openai mapping: dispatch matches connections by exact provider, so the subscription cannot serve an openai fragment (migration 144 converts stranded ones instead). `restrictsToSubscriptionModels` stays for the pre-366 row shape older daemons still return, documented as such. Call-site rows also stop mis-rendering stored `chatgpt` drafts (previously displayed the fallback provider while storing chatgpt).
- Steering copy: a stale openai profile in a subscription-only workspace shows "Your ChatGPT subscription is available as the ChatGPT provider." instead of an unexplained empty state.

## Original prompt
Follow-up to #40579 and migration 144 under the decided option-2 semantics (openai = the API, chatgpt = the subscription, no mapping between them): the web still hid `chatgpt` as a routing sentinel while migrations now create profiles and overrides carrying it, and #40553's interim serving mapping promised a dispatch path that no longer exists. The user asked to make ChatGPT a pickable provider across the settings pickers, remove the interim mapping while keeping the model-catalog mapping, fix the stored-vs-displayed mismatch for chatgpt drafts, and add subscription steering copy for stranded openai selections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uts2hxMb2vf6DfuNoK6B4X
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40596" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->