### PR TITLE
feat(web): light the collapsed-section unread dot from the index (LUM-3219)

### DIFF
--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -303,11 +303,15 @@ export function AssistantSideMenu({
   // Activity dot for a collapsed section header — surfaces processing/unread
   // conversations that live in a collapsed section (attention already
   // force-opens the section via effectiveOpen*). Null when the section is idle.
-  const collapsedActivityDot = (conversations: Conversation[]): ReactNode => {
+  const collapsedActivityDot = (
+    conversations: Conversation[],
+    section: SidebarSection,
+  ): ReactNode => {
     const state = getGroupIndicatorState(
       conversations,
       processingConversationIds,
       attentionConversationIds,
+      section.unread,
     );
     return state ? <GroupIndicatorDot state={state} /> : null;
   };

--- a/clients/web/src/domains/chat/components/collapsed-group-icon.test.tsx
+++ b/clients/web/src/domains/chat/components/collapsed-group-icon.test.tsx
@@ -97,6 +97,46 @@ function makeConversation(
 // ---------------------------------------------------------------------------
 
 describe("getGroupIndicatorState", () => {
+  test("an index count shows unread when no loaded row is unread", () => {
+    // The index counts the whole section; the loaded rows are a window.
+    const conversations = [makeConversation({ conversationId: "c1" })];
+
+    expect(getGroupIndicatorState(conversations, undefined, undefined, 2)).toBe(
+      "unread",
+    );
+  });
+
+  test("an index count of zero suppresses the row scan", () => {
+    // The index also wins in the quiet direction: a loaded row the server
+    // has already settled as seen must not keep the dot lit.
+    const conversations = [
+      makeConversation({
+        conversationId: "c1",
+        hasUnseenLatestAssistantMessage: true,
+      }),
+    ];
+
+    expect(
+      getGroupIndicatorState(conversations, undefined, undefined, 0),
+    ).toBeNull();
+  });
+
+  test("attention outranks an index unread count", () => {
+    const conversations = [makeConversation({ conversationId: "c1" })];
+
+    expect(
+      getGroupIndicatorState(conversations, undefined, new Set(["c1"]), 5),
+    ).toBe("attention");
+  });
+
+  test("processing outranks an index unread count", () => {
+    const conversations = [makeConversation({ conversationId: "c1" })];
+
+    expect(
+      getGroupIndicatorState(conversations, new Set(["c1"]), undefined, 5),
+    ).toBe("processing");
+  });
+
   test("returns null for empty conversations", () => {
     expect(getGroupIndicatorState([], undefined, undefined)).toBe(null);
   });

--- a/clients/web/src/domains/chat/components/collapsed-group-icon.tsx
+++ b/clients/web/src/domains/chat/components/collapsed-group-icon.tsx
@@ -16,14 +16,22 @@ export type GroupIndicatorState = "attention" | "processing" | "unread" | null;
  * Derive the highest-priority indicator state for a group of conversations.
  *
  * Priority: attention > processing > unread > null.
+ *
+ * `indexUnread` is the section's unread count per the daemon's section
+ * index. When defined it decides the unread bit outright, in both
+ * directions: the index counts the whole section while `conversations` is
+ * only what the client has loaded, so a scan can miss unread rows beyond
+ * the loaded window and can keep counting a row the server already settled.
+ * Attention and processing are client-only state and always scan.
  */
 export function getGroupIndicatorState(
   conversations: Conversation[],
   processingConversationIds: Set<string> | undefined,
   attentionConversationIds: Set<string> | undefined,
+  indexUnread?: number,
 ): GroupIndicatorState {
   let hasProcessing = false;
-  let hasUnread = false;
+  let hasUnread = indexUnread !== undefined && indexUnread > 0;
 
   for (const c of conversations) {
     if (attentionConversationIds?.has(c.conversationId)) {
@@ -32,7 +40,11 @@ export function getGroupIndicatorState(
     if (!hasProcessing && processingConversationIds?.has(c.conversationId)) {
       hasProcessing = true;
     }
-    if (!hasUnread && c.hasUnseenLatestAssistantMessage) {
+    if (
+      indexUnread === undefined &&
+      !hasUnread &&
+      c.hasUnseenLatestAssistantMessage
+    ) {
       hasUnread = true;
     }
   }

--- a/clients/web/src/domains/chat/components/collapsed-rail-sections.tsx
+++ b/clients/web/src/domains/chat/components/collapsed-rail-sections.tsx
@@ -47,6 +47,7 @@ function CollapsedRailSectionIcon({
         conversations,
         processingConversationIds,
         attentionConversationIds,
+        section.unread,
       )}
     >
       {(close, scrollParent) => (

--- a/clients/web/src/domains/chat/components/sidebar-section-item.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-section-item.tsx
@@ -46,7 +46,10 @@ export interface SidebarSectionItemProps {
   /** Section drag-reorder wiring; omit to pin the section in place. */
   drag?: CollapsibleNavSectionDrag;
   /** Activity dot shown in the header only while the section is collapsed. */
-  collapsedIndicator?: (conversations: Conversation[]) => ReactNode;
+  collapsedIndicator?: (
+    conversations: Conversation[],
+    section: SidebarSection,
+  ) => ReactNode;
   /**
    * Whether this is the bottom-most section in the list. Only it claims the
    * sidebar's leftover space when open; every section above it always sizes
@@ -88,7 +91,7 @@ export function SidebarSectionItem({
          (the channel-grouping toggle) on top of the bulk ones. */
       trailing={<GroupActionsMenu label={section.label} {...groupMenu} />}
       groupMenu={groupMenu}
-      collapsedIndicator={collapsedIndicator?.(conversations)}
+      collapsedIndicator={collapsedIndicator?.(conversations, section)}
       drag={drag}
       // Pinned collapses like every other section (one component, one
       // behavior; its open state defaults open and persists like the

--- a/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
@@ -335,19 +335,16 @@ export function useConversationActions({
           ...row,
           hasUnseenLatestAssistantMessage: true,
         });
-      const unreadCountDelta = startsContributing ? 1 : 0;
-      if (unreadCountDelta !== 0) {
+      const unreadRow = startsContributing ? row : undefined;
+      const unreadCountDelta = unreadRow ? 1 : 0;
+      if (unreadRow) {
         adjustUnreadCountCache(queryClient, aid, unreadCountDelta);
-        adjustSectionUnreadCache(queryClient, aid, row!, unreadCountDelta);
+        adjustSectionUnreadCache(queryClient, aid, unreadRow, unreadCountDelta);
       }
       patchConversation(queryClient, aid, conversationId, {
         hasUnseenLatestAssistantMessage: true,
       });
-      return {
-        snapshot,
-        unreadCountDelta,
-        unreadRow: unreadCountDelta !== 0 ? row : undefined,
-      };
+      return { snapshot, unreadCountDelta, unreadRow };
     },
     onError: (err, { assistantId: aid }, context) => {
       if (context?.snapshot) {

--- a/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
@@ -14,7 +14,10 @@ import {
   snapshotConversationCaches,
   type ConversationCacheSnapshot,
 } from "@/utils/conversation-cache";
-import { adjustUnreadCountCache } from "@/utils/conversation-cache-mutations";
+import {
+  adjustSectionUnreadCache,
+  adjustUnreadCountCache,
+} from "@/utils/conversation-cache-mutations";
 import {
   sectionListPrefix,
   sidebarSectionsQueryKey,
@@ -101,7 +104,11 @@ type PlacementContext = { token: number };
  * The mark-seen counterpart lives in `useMarkConversationSeenMutation`,
  * which two entry points share.
  */
-type MarkUnreadContext = MutationContext & { unreadCountDelta: number };
+type MarkUnreadContext = MutationContext & {
+  unreadCountDelta: number;
+  /** The row the deltas hit, for bucket-exact reversal; see MarkSeenContext. */
+  unreadRow?: Conversation;
+};
 
 // ---------------------------------------------------------------------------
 // Hook
@@ -331,11 +338,16 @@ export function useConversationActions({
       const unreadCountDelta = startsContributing ? 1 : 0;
       if (unreadCountDelta !== 0) {
         adjustUnreadCountCache(queryClient, aid, unreadCountDelta);
+        adjustSectionUnreadCache(queryClient, aid, row!, unreadCountDelta);
       }
       patchConversation(queryClient, aid, conversationId, {
         hasUnseenLatestAssistantMessage: true,
       });
-      return { snapshot, unreadCountDelta };
+      return {
+        snapshot,
+        unreadCountDelta,
+        unreadRow: unreadCountDelta !== 0 ? row : undefined,
+      };
     },
     onError: (err, { assistantId: aid }, context) => {
       if (context?.snapshot) {
@@ -343,6 +355,14 @@ export function useConversationActions({
       }
       if (context && context.unreadCountDelta !== 0) {
         adjustUnreadCountCache(queryClient, aid, -context.unreadCountDelta);
+        if (context.unreadRow) {
+          adjustSectionUnreadCache(
+            queryClient,
+            aid,
+            context.unreadRow,
+            -context.unreadCountDelta,
+          );
+        }
       }
       captureError(err, { context: "markConversationUnread" });
     },
@@ -646,9 +666,12 @@ export function useConversationActions({
       // One optimistic decrement for the rows that count toward the unread
       // badge (foreground, unarchived); rows that fail roll their share
       // back one at a time in `rollbackItem`.
-      const contributingCount = unread.filter(contributesToUnreadCount).length;
-      if (contributingCount > 0) {
-        adjustUnreadCountCache(queryClient, assistantId, -contributingCount);
+      const contributing = unread.filter(contributesToUnreadCount);
+      if (contributing.length > 0) {
+        adjustUnreadCountCache(queryClient, assistantId, -contributing.length);
+        for (const c of contributing) {
+          adjustSectionUnreadCache(queryClient, assistantId, c, -1);
+        }
       }
 
       for (const c of unread) {
@@ -676,6 +699,7 @@ export function useConversationActions({
           });
           if (contributesToUnreadCount(c)) {
             adjustUnreadCountCache(queryClient, assistantId, 1);
+            adjustSectionUnreadCache(queryClient, assistantId, c, 1);
           }
         },
         context: "markAllReadInGroup",

--- a/clients/web/src/domains/chat/hooks/use-mark-conversation-seen-mutation.ts
+++ b/clients/web/src/domains/chat/hooks/use-mark-conversation-seen-mutation.ts
@@ -73,24 +73,21 @@ export function useMarkConversationSeenMutation() {
       // Read the row before the patch flips its seen state: only a row that
       // was contributing to the badge should decrement it.
       const row = findConversation(queryClient, assistantId, conversationId);
-      const unreadCountDelta =
-        row !== undefined && contributesToUnreadCount(row) ? -1 : 0;
-      if (unreadCountDelta !== 0) {
+      const unreadRow =
+        row !== undefined && contributesToUnreadCount(row) ? row : undefined;
+      const unreadCountDelta = unreadRow ? -1 : 0;
+      if (unreadRow) {
         adjustUnreadCountCache(queryClient, assistantId, unreadCountDelta);
         adjustSectionUnreadCache(
           queryClient,
           assistantId,
-          row!,
+          unreadRow,
           unreadCountDelta,
         );
       }
 
       markConversationSeenLocal(queryClient, assistantId, conversationId);
-      return {
-        snapshot,
-        unreadCountDelta,
-        unreadRow: unreadCountDelta !== 0 ? row : undefined,
-      };
+      return { snapshot, unreadCountDelta, unreadRow };
     },
     onError: (err, { assistantId }, context) => {
       if (context?.snapshot) {

--- a/clients/web/src/domains/chat/hooks/use-mark-conversation-seen-mutation.ts
+++ b/clients/web/src/domains/chat/hooks/use-mark-conversation-seen-mutation.ts
@@ -31,10 +31,12 @@ import {
   type ConversationCacheSnapshot,
 } from "@/utils/conversation-cache";
 import {
+  adjustSectionUnreadCache,
   adjustUnreadCountCache,
   markConversationSeenLocal,
 } from "@/utils/conversation-cache-mutations";
 import { contributesToUnreadCount } from "@/utils/conversation-predicates";
+import type { Conversation } from "@/types/conversation-types";
 
 export interface MarkConversationSeenVars {
   assistantId: string;
@@ -45,6 +47,12 @@ interface MarkSeenContext {
   snapshot: ConversationCacheSnapshot;
   /** `-1` when the row was counted toward the unread badge, else `0`. */
   unreadCountDelta: number;
+  /**
+   * The row as it read when the deltas were applied, kept so `onError` can
+   * reverse the per-section adjustment against the same bucket it hit, even
+   * if a concurrent move has re-filed the live row since.
+   */
+  unreadRow?: Conversation;
 }
 
 export function useMarkConversationSeenMutation() {
@@ -69,10 +77,20 @@ export function useMarkConversationSeenMutation() {
         row !== undefined && contributesToUnreadCount(row) ? -1 : 0;
       if (unreadCountDelta !== 0) {
         adjustUnreadCountCache(queryClient, assistantId, unreadCountDelta);
+        adjustSectionUnreadCache(
+          queryClient,
+          assistantId,
+          row!,
+          unreadCountDelta,
+        );
       }
 
       markConversationSeenLocal(queryClient, assistantId, conversationId);
-      return { snapshot, unreadCountDelta };
+      return {
+        snapshot,
+        unreadCountDelta,
+        unreadRow: unreadCountDelta !== 0 ? row : undefined,
+      };
     },
     onError: (err, { assistantId }, context) => {
       if (context?.snapshot) {
@@ -84,6 +102,14 @@ export function useMarkConversationSeenMutation() {
           assistantId,
           -context.unreadCountDelta,
         );
+        if (context.unreadRow) {
+          adjustSectionUnreadCache(
+            queryClient,
+            assistantId,
+            context.unreadRow,
+            -context.unreadCountDelta,
+          );
+        }
       }
       captureError(err, { context: "markConversationRead" });
     },

--- a/clients/web/src/domains/chat/use-sidebar-state.test.tsx
+++ b/clients/web/src/domains/chat/use-sidebar-state.test.tsx
@@ -665,3 +665,68 @@ describe("useSidebarState with the section index", () => {
     expect(sectionFor(result.current.sections, "recents")).toBeDefined();
   });
 });
+
+describe("useSidebarState index unread threading", () => {
+  test("sections carry the index's unread counts", () => {
+    sidebarSectionsImpl = [
+      { kind: "pinned", total: 3, unread: 2 },
+      { kind: "chats", total: 5, unread: 1 },
+    ];
+
+    const { result } = renderHook(() =>
+      useSidebarState({ assistantId: "asst-1", conversations: [] }),
+    );
+
+    expect(sectionFor(result.current.sections, "pinned")).toMatchObject({
+      unread: 2,
+    });
+  });
+
+  test("the flat view's Chats sums the native and channel buckets", () => {
+    // The index buckets are disjoint, so the flat view's Chats holds all of
+    // them; the derived rows cannot answer this once the list is windowed.
+    sidebarSectionsImpl = [
+      { kind: "chats", total: 2, unread: 1 },
+      { kind: "channel", channelId: "slack", total: 4, unread: 2 },
+    ];
+
+    const { result } = renderHook(() =>
+      useSidebarState({ assistantId: "asst-1", conversations: [] }),
+    );
+
+    expect(sectionFor(result.current.sections, "recents")).toMatchObject({
+      unread: 3,
+    });
+  });
+
+  test("the grouped view's Chats counts the native bucket alone", () => {
+    seedGroupedView();
+    sidebarSectionsImpl = [
+      { kind: "chats", total: 2, unread: 1 },
+      { kind: "channel", channelId: "slack", total: 4, unread: 2 },
+    ];
+
+    const { result } = renderHook(() =>
+      useSidebarState({ assistantId: "asst-1", conversations: [] }),
+    );
+
+    expect(sectionFor(result.current.sections, "recents")).toMatchObject({
+      unread: 1,
+    });
+    expect(sectionFor(result.current.sections, "channel:slack")).toMatchObject({
+      unread: 2,
+    });
+  });
+
+  test("the derived path leaves unread undefined", () => {
+    // No index means no whole-section truth; the indicator scans rows.
+    const { result } = renderHook(() =>
+      useSidebarState({ assistantId: "asst-1", conversations: [] }),
+    );
+
+    expect(sectionFor(result.current.sections, "recents")).not.toHaveProperty(
+      "unread",
+      expect.anything(),
+    );
+  });
+});

--- a/clients/web/src/domains/chat/use-sidebar-state.ts
+++ b/clients/web/src/domains/chat/use-sidebar-state.ts
@@ -106,6 +106,14 @@ interface SidebarSectionBase {
   label: string;
   /** Every conversation in the section. */
   all: Conversation[];
+  /**
+   * Unread members per the daemon's section index, when the index is
+   * driving discovery. `undefined` on the derived path, where the unread
+   * bit is scanned from the rows instead. The collapsed indicator prefers
+   * this over the scan: the index counts the whole section, while the rows
+   * here are only what the client has loaded.
+   */
+  unread?: number;
 }
 
 /**
@@ -319,12 +327,14 @@ export function useSidebarState({
       const rowsByChannelId = new Map(
         grouped.channelSections.map((s) => [s.channelId, s.conversations]),
       );
-      if (indexSections.some((s) => s.kind === "pinned")) {
+      const pinnedRow = indexSections.find((s) => s.kind === "pinned");
+      if (pinnedRow) {
         list.push({
           type: "pinned",
           key: "pinned",
           label: "Pinned",
           all: grouped.pinned,
+          unread: pinnedRow.unread,
         });
       }
       const groupRows = indexSections
@@ -336,6 +346,7 @@ export function useSidebarState({
           key: row.groupId,
           label: row.name,
           all: bucketByGroupId.get(row.groupId)?.conversations ?? [],
+          unread: row.unread,
           group: {
             id: row.groupId,
             name: row.name,
@@ -345,17 +356,26 @@ export function useSidebarState({
           },
         });
       }
+      /* The index buckets are disjoint, so the flat view's Chats is the
+         native bucket plus every channel bucket, and the grouped view's is
+         the native bucket alone. */
+      const channelRows = indexSections
+        .filter((s) => s.kind === "channel")
+        .sort((a, b) => a.channelId.localeCompare(b.channelId));
+      const chatsUnread =
+        (indexSections.find((s) => s.kind === "chats")?.unread ?? 0) +
+        (viewMode !== "grouped"
+          ? channelRows.reduce((sum, row) => sum + row.unread, 0)
+          : 0);
       list.push({
         type: "recents",
         key: "recents",
         label: RECENTS_SECTION_LABEL,
         all: grouped.recents,
         holdsChannels: viewMode !== "grouped",
+        unread: chatsUnread,
       });
       if (viewMode === "grouped") {
-        const channelRows = indexSections
-          .filter((s) => s.kind === "channel")
-          .sort((a, b) => a.channelId.localeCompare(b.channelId));
         for (const row of channelRows) {
           list.push({
             type: "channel",
@@ -363,6 +383,7 @@ export function useSidebarState({
             label: getChannelLabel(row.channelId),
             all: rowsByChannelId.get(row.channelId) ?? [],
             channelId: row.channelId,
+            unread: row.unread,
           });
         }
       }

--- a/clients/web/src/utils/conversation-cache-mutations.test.ts
+++ b/clients/web/src/utils/conversation-cache-mutations.test.ts
@@ -11,10 +11,13 @@ import {
   backgroundConversationsQueryKey,
   scheduledConversationsQueryKey,
   archivedConversationsQueryKey,
+  sidebarSectionsQueryKey,
+  type SidebarIndexSection,
 } from "@/utils/conversation-list-fetchers";
 import { groupsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
 
 import {
+  adjustSectionUnreadCache,
   markConversationSeenLocal,
   mergeListFirstPage,
   prependConversation,
@@ -831,5 +834,153 @@ describe("mergeListFirstPage", () => {
       "c-pin-b",
       "c-older",
     ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// adjustSectionUnreadCache
+// ---------------------------------------------------------------------------
+
+describe("adjustSectionUnreadCache", () => {
+  const INDEX_KEY = sidebarSectionsQueryKey(ASSISTANT_ID);
+
+  function seedIndex(client: QueryClient): SidebarIndexSection[] {
+    const index: SidebarIndexSection[] = [
+      { kind: "pinned", total: 2, unread: 1 },
+      {
+        kind: "group",
+        groupId: "grp-1",
+        name: "G",
+        icon: null,
+        sortPosition: 0,
+        total: 3,
+        unread: 2,
+      },
+      { kind: "channel", channelId: "slack", total: 4, unread: 1 },
+      { kind: "chats", total: 5, unread: 3 },
+    ];
+    client.setQueryData<SidebarIndexSection[] | null>(INDEX_KEY, index);
+    return index;
+  }
+
+  function unreadOf(
+    client: QueryClient,
+    match: (s: SidebarIndexSection) => boolean,
+  ): number | undefined {
+    return client.getQueryData<SidebarIndexSection[]>(INDEX_KEY)?.find(match)
+      ?.unread;
+  }
+
+  test("a pinned row adjusts the Pinned bucket", () => {
+    const client = new QueryClient();
+    seedIndex(client);
+
+    const applied = adjustSectionUnreadCache(
+      client,
+      ASSISTANT_ID,
+      makeConversation({
+        conversationId: "c1",
+        isPinned: true,
+        groupId: "system:pinned",
+        // Bucket precedence: pinned wins even for a row that also carries a
+        // channel, mirroring the daemon's group-axis-first aggregation.
+        originChannel: "slack",
+      }),
+      -1,
+    );
+
+    expect(applied).toBe(true);
+    expect(unreadOf(client, (s) => s.kind === "pinned")).toBe(0);
+    expect(unreadOf(client, (s) => s.kind === "channel")).toBe(1);
+  });
+
+  test("a grouped row adjusts its group's bucket", () => {
+    const client = new QueryClient();
+    seedIndex(client);
+
+    adjustSectionUnreadCache(
+      client,
+      ASSISTANT_ID,
+      makeConversation({ conversationId: "c1", groupId: "grp-1" }),
+      -1,
+    );
+
+    expect(unreadOf(client, (s) => s.kind === "group")).toBe(1);
+  });
+
+  test("unattributed and vellum rows adjust the Chats bucket", () => {
+    const client = new QueryClient();
+    seedIndex(client);
+
+    adjustSectionUnreadCache(
+      client,
+      ASSISTANT_ID,
+      makeConversation({ conversationId: "c1" }),
+      -1,
+    );
+    adjustSectionUnreadCache(
+      client,
+      ASSISTANT_ID,
+      makeConversation({ conversationId: "c2", originChannel: "vellum" }),
+      -1,
+    );
+
+    expect(unreadOf(client, (s) => s.kind === "chats")).toBe(1);
+  });
+
+  test("a channel row adjusts its channel's bucket", () => {
+    const client = new QueryClient();
+    seedIndex(client);
+
+    adjustSectionUnreadCache(
+      client,
+      ASSISTANT_ID,
+      makeConversation({ conversationId: "c1", originChannel: "slack" }),
+      1,
+    );
+
+    expect(unreadOf(client, (s) => s.kind === "channel")).toBe(2);
+  });
+
+  test("a null index (assistant without the endpoint) is a no-op", () => {
+    const client = new QueryClient();
+    client.setQueryData<SidebarIndexSection[] | null>(INDEX_KEY, null);
+
+    expect(
+      adjustSectionUnreadCache(
+        client,
+        ASSISTANT_ID,
+        makeConversation({ conversationId: "c1" }),
+        -1,
+      ),
+    ).toBe(false);
+    expect(client.getQueryData(INDEX_KEY)).toBeNull();
+  });
+
+  test("a bucket the index does not carry is left to the settle refetch", () => {
+    const client = new QueryClient();
+    client.setQueryData<SidebarIndexSection[] | null>(INDEX_KEY, [
+      { kind: "chats", total: 5, unread: 3 },
+    ]);
+
+    expect(
+      adjustSectionUnreadCache(
+        client,
+        ASSISTANT_ID,
+        makeConversation({ conversationId: "c1", groupId: "grp-none" }),
+        -1,
+      ),
+    ).toBe(false);
+  });
+
+  test("a delta and its inverse restore the original counts exactly", () => {
+    const client = new QueryClient();
+    seedIndex(client);
+    const row = makeConversation({ conversationId: "c1", groupId: "grp-1" });
+
+    adjustSectionUnreadCache(client, ASSISTANT_ID, row, -1);
+    adjustSectionUnreadCache(client, ASSISTANT_ID, row, 1);
+
+    expect(unreadOf(client, (s) => s.kind === "group")).toBe(2);
   });
 });

--- a/clients/web/src/utils/conversation-cache-mutations.ts
+++ b/clients/web/src/utils/conversation-cache-mutations.ts
@@ -20,10 +20,9 @@ import type {
 } from "@/types/conversation-types";
 import {
   isBackgroundConversation,
-  isConversationPinned,
-  isCustomGroupId,
   isScheduledConversation,
 } from "@/utils/conversation-predicates";
+import { matchesIndexBucket } from "@/utils/section-membership";
 import {
   findConversation,
   updateAllConversationCaches,
@@ -157,21 +156,7 @@ export function adjustSectionUnreadCache(
     return false;
   }
 
-  const matchesBucket = (row: SidebarIndexSection): boolean => {
-    if (isConversationPinned(conversation)) {
-      return row.kind === "pinned";
-    }
-    if (isCustomGroupId(conversation.groupId)) {
-      return row.kind === "group" && row.groupId === conversation.groupId;
-    }
-    const channel = conversation.originChannel;
-    if (channel == null || channel === "vellum") {
-      return row.kind === "chats";
-    }
-    return row.kind === "channel" && row.channelId === channel;
-  };
-
-  const at = index.findIndex(matchesBucket);
+  const at = index.findIndex((row) => matchesIndexBucket(conversation, row));
   if (at === -1) {
     return false;
   }

--- a/clients/web/src/utils/conversation-cache-mutations.ts
+++ b/clients/web/src/utils/conversation-cache-mutations.ts
@@ -20,6 +20,8 @@ import type {
 } from "@/types/conversation-types";
 import {
   isBackgroundConversation,
+  isConversationPinned,
+  isCustomGroupId,
   isScheduledConversation,
 } from "@/utils/conversation-predicates";
 import {
@@ -35,7 +37,9 @@ import {
   parseSectionConversationsQueryKey,
   scheduledConversationsQueryKey,
   sectionListPrefix,
+  sidebarSectionsQueryKey,
   unreadConversationCountQueryKey,
+  type SidebarIndexSection,
 } from "@/utils/conversation-list-fetchers";
 import {
   type ConversationListPage,
@@ -119,6 +123,61 @@ export function adjustUnreadCountCache(
     return false;
   }
   queryClient.setQueryData<number | null>(queryKey, current + delta);
+  return true;
+}
+
+/**
+ * Apply a delta to one section's `unread` in the cached sidebar section
+ * index. Optimistic companion to {@link adjustUnreadCountCache}: wherever a
+ * seen/unseen mutation adjusts the global count for a row, the row's own
+ * section adjusts by the same delta, so the collapsed dot answers with the
+ * badge instead of one settle refetch behind it.
+ *
+ * The bucket mirrors the daemon's section aggregation: pinned wins, then a
+ * custom group, then the effective origin channel with NULL reading as
+ * native (the Chats bucket). Deliberately unclamped like the global count,
+ * so `+n` and `-n` are exact inverses; the dot lights on `> 0`, which reads
+ * a briefly negative value as dark.
+ *
+ * Returns `true` when a bucket row was adjusted. No-ops on a `null` index
+ * (assistant without the endpoint), an unfetched index, or a bucket the
+ * index does not carry; the settle refetch reconciles those.
+ */
+export function adjustSectionUnreadCache(
+  queryClient: QueryClient,
+  assistantId: string | null,
+  conversation: Conversation,
+  delta: number,
+): boolean {
+  const queryKey = sidebarSectionsQueryKey(assistantId);
+  const index = queryClient.getQueryData<SidebarIndexSection[] | null>(
+    queryKey,
+  );
+  if (index == null) {
+    return false;
+  }
+
+  const matchesBucket = (row: SidebarIndexSection): boolean => {
+    if (isConversationPinned(conversation)) {
+      return row.kind === "pinned";
+    }
+    if (isCustomGroupId(conversation.groupId)) {
+      return row.kind === "group" && row.groupId === conversation.groupId;
+    }
+    const channel = conversation.originChannel;
+    if (channel == null || channel === "vellum") {
+      return row.kind === "chats";
+    }
+    return row.kind === "channel" && row.channelId === channel;
+  };
+
+  const at = index.findIndex(matchesBucket);
+  if (at === -1) {
+    return false;
+  }
+  const next = [...index];
+  next[at] = { ...next[at], unread: next[at].unread + delta };
+  queryClient.setQueryData<SidebarIndexSection[] | null>(queryKey, next);
   return true;
 }
 

--- a/clients/web/src/utils/conversation-cache.ts
+++ b/clients/web/src/utils/conversation-cache.ts
@@ -380,7 +380,7 @@ export function patchConversation(
      too: a destination section the index does not know yet must appear with
      the optimistic write, or the row is visible nowhere until the settle
      refetch (the first pin, the first conversation moved into an empty
-     group). */
+     group, an unpin returning a channel's only conversation). */
   ensureSectionInIndex(queryClient, assistantId, patched);
   return reconcileSectionMembership(queryClient, assistantId, patched);
 }

--- a/clients/web/src/utils/section-membership.test.ts
+++ b/clients/web/src/utils/section-membership.test.ts
@@ -603,6 +603,48 @@ describe("ensureSectionInIndex", () => {
     expect(kinds(client)).toEqual(["chats"]);
   });
 
+  test("an unpinned channel row restores its emptied channel bucket", () => {
+    /* Pinning a channel's only conversation empties its bucket out of the
+       index; the unpin returning the row targets a section the index no
+       longer carries, and without the stub the row is visible nowhere until
+       the settle refetch. */
+    const client = indexClient([
+      { kind: "pinned", total: 1, unread: 0 },
+      { kind: "chats", total: 0, unread: 0 },
+    ]);
+
+    ensureSectionInIndex(
+      client,
+      ASSISTANT_ID,
+      conversation({ originChannel: "slack", groupId: "system:all" }),
+    );
+
+    expect(
+      client.getQueryData<SidebarIndexSection[]>(INDEX_KEY),
+    ).toContainEqual({
+      kind: "channel",
+      channelId: "slack",
+      total: 1,
+      unread: 0,
+    });
+  });
+
+  test("a native ungrouped row needs no stub", () => {
+    // Chats renders regardless and the daemon always indexes it.
+    const index: SidebarIndexSection[] = [
+      { kind: "chats", total: 0, unread: 0 },
+    ];
+    const client = indexClient(index);
+
+    ensureSectionInIndex(
+      client,
+      ASSISTANT_ID,
+      conversation({ groupId: "system:all" }),
+    );
+
+    expect(client.getQueryData<SidebarIndexSection[]>(INDEX_KEY)).toBe(index);
+  });
+
   test("a null index (assistant without the endpoint) is never written", () => {
     const client = indexClient(null);
 

--- a/clients/web/src/utils/section-membership.ts
+++ b/clients/web/src/utils/section-membership.ts
@@ -207,7 +207,8 @@ export function matchesSectionFilter(
  *
  * The index decides which sections *render*, so a placement whose
  * destination has no index row yet (the first pin, the first conversation
- * moved into an empty group) would otherwise leave the row visible nowhere:
+ * moved into an empty group, an unpin returning a channel's only
+ * conversation) would otherwise leave the row visible nowhere:
  * the membership pass removes it from its source section immediately, and
  * the destination section would not exist until the settle refetch answers.
  *
@@ -221,6 +222,30 @@ export function matchesSectionFilter(
  * groups cache does not know cannot be named and is skipped, leaving that
  * rare case on the settle refetch.
  */
+/**
+ * Whether `row` is the index bucket holding `conversation`, mirroring the
+ * daemon's aggregation axes: the group axis wins (pinned, then a custom
+ * group), then the effective origin channel with NULL reading as native
+ * (the Chats bucket). The one bucket rule, shared by the stub insertion
+ * here and the unread deltas in `conversation-cache-mutations.ts`.
+ */
+export function matchesIndexBucket(
+  conversation: Conversation,
+  row: SidebarIndexSection,
+): boolean {
+  if (isConversationPinned(conversation)) {
+    return row.kind === "pinned";
+  }
+  if (isCustomGroupId(conversation.groupId)) {
+    return row.kind === "group" && row.groupId === conversation.groupId;
+  }
+  const channel = conversation.originChannel;
+  if (channel == null || channel === NATIVE_ORIGIN_CHANNEL) {
+    return row.kind === "chats";
+  }
+  return row.kind === "channel" && row.channelId === channel;
+}
+
 export function ensureSectionInIndex(
   queryClient: QueryClient,
   assistantId: string | null,
@@ -233,45 +258,57 @@ export function ensureSectionInIndex(
   const index = queryClient.getQueryData<SidebarIndexSection[] | null>(
     queryKey,
   );
-  if (index == null) {
+  if (
+    index == null ||
+    index.some((row) => matchesIndexBucket(conversation, row))
+  ) {
     return;
   }
 
   if (isConversationPinned(conversation)) {
-    if (!index.some((s) => s.kind === "pinned")) {
-      queryClient.setQueryData<SidebarIndexSection[] | null>(queryKey, [
-        { kind: "pinned", total: 1, unread: 0 },
-        ...index,
-      ]);
-    }
+    queryClient.setQueryData<SidebarIndexSection[] | null>(queryKey, [
+      { kind: "pinned", total: 1, unread: 0 },
+      ...index,
+    ]);
     return;
   }
 
   const groupId = conversation.groupId;
-  if (!isCustomGroupId(groupId)) {
+  if (isCustomGroupId(groupId)) {
+    const groups = queryClient.getQueryData<GroupsGetResponse>(
+      groupsGetQueryKey({ path: { assistant_id: assistantId } }),
+    )?.groups;
+    const meta = groups?.find((g) => g.id === groupId);
+    if (!meta) {
+      return;
+    }
+    queryClient.setQueryData<SidebarIndexSection[] | null>(queryKey, [
+      ...index,
+      {
+        kind: "group",
+        groupId,
+        name: meta.name,
+        icon: meta.icon ?? null,
+        sortPosition: meta.sortPosition ?? 0,
+        total: 1,
+        unread: 0,
+      },
+    ]);
     return;
   }
-  if (index.some((s) => s.kind === "group" && s.groupId === groupId)) {
-    return;
-  }
-  const groups = queryClient.getQueryData<GroupsGetResponse>(
-    groupsGetQueryKey({ path: { assistant_id: assistantId } }),
-  )?.groups;
-  const meta = groups?.find((g) => g.id === groupId);
-  if (!meta) {
+
+  /* An ungrouped row's destination is its channel section, and that bucket
+     can be missing too: pinning a channel's only conversation empties its
+     bucket out of the index, so the unpin returning the row targets a
+     section the index no longer carries. The native bucket needs no stub;
+     Chats renders regardless and the daemon always indexes it. */
+  const channel = conversation.originChannel;
+  if (channel == null || channel === NATIVE_ORIGIN_CHANNEL) {
     return;
   }
   queryClient.setQueryData<SidebarIndexSection[] | null>(queryKey, [
     ...index,
-    {
-      kind: "group",
-      groupId,
-      name: meta.name,
-      icon: meta.icon ?? null,
-      sortPosition: meta.sortPosition ?? 0,
-      total: 1,
-      unread: 0,
-    },
+    { kind: "channel", channelId: channel, total: 1, unread: 0 },
   ]);
 }
 


### PR DESCRIPTION
## TL;DR

The collapsed sidebar indicator's unread bit currently scans the section's loaded rows — a window, not the section. With the daemon's section index driving discovery (#40594), each section now carries the index's per-section unread count and the indicator prefers it over the scan, **in both directions**: the dot lights when the unread rows sit beyond what the client loaded, and stays dark at index zero even when a loaded row is stale. This is the last user-visible LUM-2443 acceptance criterion, and it's what keeps the dots honest once the list is windowed.

Fixes LUM-3219. Part of LUM-2443.

## Design

- `getGroupIndicatorState` gains an optional `indexUnread`: defined means the index decides the unread bit outright; undefined means scan, exactly as today. Attention and processing are client-only state (pending interactions, live turns) — the server cannot know them, so they always scan and keep their priority above unread.
- Sections carry `unread` only on the index path (`use-sidebar-state`); the derived path leaves it undefined, so the fallback remains behavior-identical for assistants without the endpoint.
- The flat view's Chats sums the native and channel buckets — the index's buckets are disjoint by construction, so the sum is exact, and it's an answer the derived rows *cannot* give once the list is windowed. The grouped view counts the native bucket alone, with each channel section carrying its own.
- Freshness rides the wiring #40594 already built: the index refetches on placement settles, seen-state sync timers, and `conversationsList` signals; no new invalidation paths.

## Why it is safe

- Assistants without the index: `unread` is never set, the indicator scans, zero behavioral change (the branch is shared, not copied).
- The threading is presentational — no new queries, no cache writes; one optional field on `SidebarSection` and one optional parameter.
- Priority order among indicator states is unchanged and tested (attention > processing > unread).

## Testing

Local test runs are blocked on this machine; CI is the verifier. Fixtures hand-traced first:

- `collapsed-group-icon.test.tsx`: index count lights the dot with zero loaded unread rows; **index zero suppresses a stale loaded row** (this case fails against the pre-change scan); attention and processing each outrank the index count.
- `use-sidebar-state.test.tsx`: sections carry the index counts; flat-view Chats sums native + channels while grouped-view Chats counts native alone with per-channel counts on their sections; the derived path leaves `unread` undefined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40597" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->