### PR TITLE
feat(web): entry-picker binding UX behind the entries version gate

### DIFF
--- a/clients/web/src/domains/settings/ai/profile-detail-panel.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-detail-panel.test.tsx
@@ -75,9 +75,8 @@ const connection: ProviderConnection = {
 
 const { configGetQueryKey, inferenceProviderconnectionsGetQueryKey } =
   await import("@/generated/daemon/@tanstack/react-query.gen");
-const { ProfileDetailPanel } = await import(
-  "@/domains/settings/ai/profile-detail-panel"
-);
+const { ProfileDetailPanel } =
+  await import("@/domains/settings/ai/profile-detail-panel");
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -100,7 +99,10 @@ function Wrapper({ children }: { children: ReactNode }) {
   return createElement(QueryClientProvider, { client }, children);
 }
 
-function renderPanel(profileName: string | null, onClose: () => void = () => {}) {
+function renderPanel(
+  profileName: string | null,
+  onClose: () => void = () => {},
+) {
   return render(
     <Wrapper>
       <ProfileDetailPanel
@@ -174,14 +176,23 @@ function selectModel(label: string): void {
   throw new Error(`expected a Model dropdown offering "${label}"`);
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   toastSuccessCalls = [];
   configPatchBodies = [];
   profilesState = {};
+  // Seed a hydrated version: the save path awaits
+  // whenAssistantVersionKnown(), and an unhydrated store would stall each
+  // save until that helper's timeout.
+  const { useAssistantIdentityStore } =
+    await import("@/stores/assistant-identity-store");
+  useAssistantIdentityStore.getState().setIdentity("test-asst", "0.11.3");
 });
 
-afterEach(() => {
+afterEach(async () => {
   cleanup();
+  const { useAssistantIdentityStore } =
+    await import("@/stores/assistant-identity-store");
+  useAssistantIdentityStore.getState().clearIdentity();
 });
 
 // ---------------------------------------------------------------------------

--- a/clients/web/src/domains/settings/ai/profile-editor-fields.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-fields.tsx
@@ -16,7 +16,6 @@ import {
 import {
   entryPickerValue,
   expandEndpointEntries,
-  multiEntryProviderKinds,
   parseEntryPickerValue,
   providersServedByConnections,
   unconnectedSelectableProviders,
@@ -29,6 +28,7 @@ import type {
   ProviderConnection,
 } from "@/generated/daemon/types.gen";
 import { useActiveAssistantIsSelfHosted } from "@/hooks/use-platform-gate";
+import { useTranslation } from "@/i18n";
 
 // Sentinel value for the "+ Create new provider" option in the create-mode
 // Provider dropdown. Picking it mounts the inline ProviderCreateForm instead
@@ -210,6 +210,7 @@ export function ProfileEditorFields({
   // Every provider this assistant can dispatch through, connected ones first,
   // then the rest annotated with what they still need, then the always-present
   // "+ Create new provider" sentinel for custom endpoints.
+  const { t } = useTranslation("settings");
   const createModeProviderOptions = useMemo(() => {
     const opts: { value: string; label: string; suffix?: ReactNode }[] =
       expandEndpointEntries(
@@ -219,6 +220,7 @@ export function ProfileEditorFields({
         ),
         editor.effectiveConnections,
         (p) => PROVIDER_DISPLAY_NAMES[p] ?? p,
+        t("aiProviderPicker.defaultEntryMeta"),
       ).map(({ value, label, meta }) => ({
         value,
         label,
@@ -240,6 +242,7 @@ export function ProfileEditorFields({
     activeAssistantIsSelfHosted,
     editor.effectiveConnections,
     unconnectedProviders,
+    t,
   ]);
 
   const createProviderSection = (
@@ -257,10 +260,14 @@ export function ProfileEditorFields({
               ? (editor.pendingCreateProvider ?? CREATE_NEW_PROVIDER_SENTINEL)
               : editor.provider &&
                   editor.providerConnection &&
-                  (editor.provider === OPENAI_COMPATIBLE_PROVIDER ||
-                    multiEntryProviderKinds(editor.effectiveConnections).has(
-                      editor.provider,
-                    ))
+                  createModeProviderOptions.some(
+                    (option) =>
+                      option.value ===
+                      entryPickerValue(
+                        editor.provider,
+                        editor.providerConnection,
+                      ),
+                  )
                 ? entryPickerValue(editor.provider, editor.providerConnection)
                 : editor.provider
           }

--- a/clients/web/src/domains/settings/ai/profile-editor-fields.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-fields.tsx
@@ -14,9 +14,10 @@ import {
   ProfileEditorProviderSection,
 } from "@/domains/settings/ai/profile-editor-provider-section";
 import {
-  endpointPickerValue,
+  entryPickerValue,
   expandEndpointEntries,
-  parseEndpointPickerValue,
+  multiEntryProviderKinds,
+  parseEntryPickerValue,
   providersServedByConnections,
   unconnectedSelectableProviders,
 } from "@/domains/settings/ai/provider-availability";
@@ -254,9 +255,13 @@ export function ProfileEditorFields({
           value={
             editor.creatingProvider
               ? (editor.pendingCreateProvider ?? CREATE_NEW_PROVIDER_SENTINEL)
-              : editor.provider === OPENAI_COMPATIBLE_PROVIDER &&
-                  editor.providerConnection
-                ? endpointPickerValue(editor.providerConnection)
+              : editor.provider &&
+                  editor.providerConnection &&
+                  (editor.provider === OPENAI_COMPATIBLE_PROVIDER ||
+                    multiEntryProviderKinds(editor.effectiveConnections).has(
+                      editor.provider,
+                    ))
+                ? entryPickerValue(editor.provider, editor.providerConnection)
                 : editor.provider
           }
           onChange={(next) => {
@@ -269,18 +274,20 @@ export function ProfileEditorFields({
             if (!next) {
               return;
             }
-            const endpoint = parseEndpointPickerValue(next);
-            if (endpoint) {
-              // Each endpoint entry implies the openai-compatible provider
-              // plus its binding; switching endpoints re-picks the model.
+            const entry = parseEntryPickerValue(next);
+            if (entry) {
+              // An entry row implies its kind plus the binding. Endpoint
+              // model lists differ per entry, so switching endpoints
+              // re-picks the model; same-kind catalog entries share one
+              // list, so the model survives.
               editor.setCreatingProvider(false);
               editor.setPendingCreateProvider(null);
-              if (editor.provider !== OPENAI_COMPATIBLE_PROVIDER) {
-                editor.handleProviderChange(OPENAI_COMPATIBLE_PROVIDER);
-              } else {
+              if (editor.provider !== entry.provider) {
+                editor.handleProviderChange(entry.provider);
+              } else if (entry.provider === OPENAI_COMPATIBLE_PROVIDER) {
                 editor.setModel("");
               }
-              editor.setProviderConnection(endpoint);
+              editor.setProviderConnection(entry.connectionName);
               return;
             }
             const picked = next as ConnectionProvider;
@@ -295,6 +302,12 @@ export function ProfileEditorFields({
             editor.setCreatingProvider(false);
             editor.setPendingCreateProvider(null);
             editor.handleProviderChange(picked);
+            // Re-picking the current kind's bare row means "the default
+            // entry": the explicit binding must clear, and the provider
+            // change above no-ops so it won't do it.
+            if (picked === editor.provider) {
+              editor.setProviderConnection("");
+            }
           }}
           placeholder="Select a provider…"
           aria-labelledby="profile-editor-provider-label"

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -2078,6 +2078,52 @@ describe("entries wire shape", () => {
     }
   });
 
+  test("a vendor id is never read as an entry name, even when a row carries it", async () => {
+    // Self-named rows predate the daemon's reservation guard. Opening a
+    // plain unbound profile must not pin it to the same-named row.
+    const selfNamed = makeConnection("anthropic");
+    const { saveCalls, onSave } = collectSaves();
+    renderEdit(
+      {
+        name: "plain",
+        label: "Plain",
+        provider: "anthropic",
+        model: "claude-opus-4-8",
+      },
+      onSave,
+      [selfNamed, anthropicPersonal],
+    );
+
+    fireEvent.click(getSaveBtn());
+    await waitFor(() => {
+      expect(saveCalls.length).toBe(1);
+    });
+    expect(saveCalls[0].entry.provider).toBe("anthropic");
+    // Two siblings, so no auto-resolve: the profile stays unbound instead
+    // of quietly adopting the self-named row.
+    expect(saveCalls[0].entry.provider_connection).toBeNull();
+  });
+
+  test("a stale binding among surviving siblings still labels the trigger", async () => {
+    renderEdit(
+      {
+        name: "stale",
+        label: "Stale",
+        provider: "anthropic",
+        provider_connection: "deleted-key",
+        model: "claude-opus-4-8",
+      },
+      undefined,
+      [anthropicWork, anthropicPersonal],
+    );
+
+    // The encoded value matches no option, so the trigger must fall back
+    // to the bare kind rather than the placeholder.
+    await waitFor(() => {
+      expect(providerTrigger().textContent).toContain("Anthropic");
+    });
+  });
+
   test("a stored entry-name profile opens translated and round-trips", async () => {
     const store = await gateOn();
     try {

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -86,9 +86,8 @@ mock.module("@/domains/settings/ai/use-provider-credentials-list", () => ({
   }),
 }));
 
-const { ProfileEditorModal } = await import(
-  "@/domains/settings/ai/profile-editor-modal"
-);
+const { ProfileEditorModal } =
+  await import("@/domains/settings/ai/profile-editor-modal");
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -402,17 +401,15 @@ beforeEach(async () => {
   // Seed a hydrated pre-gate version: the save path awaits
   // whenAssistantVersionKnown(), and an unhydrated store would stall each
   // save until that helper's timeout. Gate-on tests override per-test.
-  const { useAssistantIdentityStore } = await import(
-    "@/stores/assistant-identity-store"
-  );
+  const { useAssistantIdentityStore } =
+    await import("@/stores/assistant-identity-store");
   useAssistantIdentityStore.getState().setIdentity("test-asst", "0.10.11");
 });
 
 afterEach(async () => {
   cleanup();
-  const { useAssistantIdentityStore } = await import(
-    "@/stores/assistant-identity-store"
-  );
+  const { useAssistantIdentityStore } =
+    await import("@/stores/assistant-identity-store");
   useAssistantIdentityStore.getState().clearIdentity();
 });
 
@@ -643,9 +640,8 @@ describe("ProfileEditorModal create mode — provider-first", () => {
   });
 
   test("a new-enough assistant gets the identity payload: provider vellum, no binding", async () => {
-    const { useAssistantIdentityStore } = await import(
-      "@/stores/assistant-identity-store"
-    );
+    const { useAssistantIdentityStore } =
+      await import("@/stores/assistant-identity-store");
     useAssistantIdentityStore
       .getState()
       .setIdentity("test-asst", "0.10.12", ASSISTANT_ID);
@@ -677,9 +673,8 @@ describe("ProfileEditorModal create mode — provider-first", () => {
   });
 
   test("an older assistant keeps the legacy payload byte-identical", async () => {
-    const { useAssistantIdentityStore } = await import(
-      "@/stores/assistant-identity-store"
-    );
+    const { useAssistantIdentityStore } =
+      await import("@/stores/assistant-identity-store");
     useAssistantIdentityStore.getState().setIdentity("test-asst", "0.10.11");
     try {
       const saveCalls: { name: string; entry: Record<string, unknown> }[] = [];
@@ -1906,5 +1901,211 @@ describe("ProfileEditorModal: explains why Save is blocked", () => {
     renderCreate([makeConnection("anthropic")]);
 
     expect(fieldErrors()).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Entries wire shape (version-gated): daemons at the entry-binding gate store
+// the binding IN the provider value and never receive provider_connection.
+// ---------------------------------------------------------------------------
+
+describe("entries wire shape", () => {
+  const anthropicWork = {
+    ...makeConnection("anthropic-work"),
+    label: "Work key",
+  } as unknown as ProviderConnection;
+  const anthropicPersonal = makeConnection("anthropic-personal");
+
+  async function gateOn() {
+    const { useAssistantIdentityStore } =
+      await import("@/stores/assistant-identity-store");
+    useAssistantIdentityStore
+      .getState()
+      .setIdentity("test-asst", "0.11.4", ASSISTANT_ID);
+    return useAssistantIdentityStore;
+  }
+
+  function collectSaves() {
+    const saveCalls: { name: string; entry: Record<string, unknown> }[] = [];
+    const onSave = (name: string, entry: unknown) => {
+      saveCalls.push({ name, entry: entry as Record<string, unknown> });
+      return Promise.resolve();
+    };
+    return { saveCalls, onSave };
+  }
+
+  test("a multi-key kind expands into labeled entry rows plus a default row", () => {
+    renderCreate([anthropicWork, anthropicPersonal]);
+    fireEvent.click(providerTrigger());
+    expect(optionRows().slice(0, 3)).toEqual([
+      { label: "Anthropic", meta: "Default" },
+      { label: "Work key", meta: "Anthropic" },
+      { label: "anthropic-personal", meta: "Anthropic" },
+    ]);
+  });
+
+  test("a single-key kind stays one bare row", () => {
+    renderCreate([anthropicPersonal]);
+    fireEvent.click(providerTrigger());
+    expect(optionRows()[0]).toEqual({ label: "Anthropic", meta: "" });
+  });
+
+  test("a gated assistant writes the picked entry name as the provider", async () => {
+    const store = await gateOn();
+    try {
+      const { saveCalls, onSave } = collectSaves();
+      renderCreate([anthropicWork, anthropicPersonal], onSave);
+
+      selectProvider("Work key");
+      selectModel("Claude Opus 4.8");
+
+      await waitFor(() => {
+        expect(getSaveBtn().disabled).toBe(false);
+      });
+      fireEvent.click(getSaveBtn());
+
+      await waitFor(() => {
+        expect(saveCalls.length).toBe(1);
+      });
+      expect(saveCalls[0].entry.provider).toBe("anthropic-work");
+      expect(saveCalls[0].entry.model).toBe("claude-opus-4-8");
+      expect(saveCalls[0].entry.provider_connection).toBeUndefined();
+    } finally {
+      store.getState().clearIdentity();
+    }
+  });
+
+  test("an ungated assistant writes the picked entry as the legacy binding", async () => {
+    const { saveCalls, onSave } = collectSaves();
+    renderCreate([anthropicWork, anthropicPersonal], onSave);
+
+    selectProvider("Work key");
+    selectModel("Claude Opus 4.8");
+
+    await waitFor(() => {
+      expect(getSaveBtn().disabled).toBe(false);
+    });
+    fireEvent.click(getSaveBtn());
+
+    await waitFor(() => {
+      expect(saveCalls.length).toBe(1);
+    });
+    expect(saveCalls[0].entry.provider).toBe("anthropic");
+    expect(saveCalls[0].entry.provider_connection).toBe("anthropic-work");
+  });
+
+  test("a gated single-key save writes the bare vendor and no binding", async () => {
+    const store = await gateOn();
+    try {
+      const { saveCalls, onSave } = collectSaves();
+      renderCreate([anthropicPersonal], onSave);
+
+      selectProvider("Anthropic");
+      selectModel("Claude Opus 4.8");
+
+      await waitFor(() => {
+        expect(getSaveBtn().disabled).toBe(false);
+      });
+      fireEvent.click(getSaveBtn());
+
+      await waitFor(() => {
+        expect(saveCalls.length).toBe(1);
+      });
+      // Bare vendor id = the kind's default entry; the auto-resolved
+      // explicit binding is a legacy-shape concern.
+      expect(saveCalls[0].entry.provider).toBe("anthropic");
+      expect(saveCalls[0].entry.provider_connection).toBeUndefined();
+    } finally {
+      store.getState().clearIdentity();
+    }
+  });
+
+  test("a gated endpoint save writes the endpoint name as the provider", async () => {
+    const store = await gateOn();
+    try {
+      const lmStudio = {
+        ...makeConnection("lm-studio", "openai-compatible"),
+        models: [{ id: "model-1", displayName: "Model 1" }],
+      } as unknown as ProviderConnection;
+      const { saveCalls, onSave } = collectSaves();
+      renderCreate([lmStudio], onSave);
+
+      selectProvider("lm-studio");
+      selectModel("Model 1");
+
+      await waitFor(() => {
+        expect(getSaveBtn().disabled).toBe(false);
+      });
+      fireEvent.click(getSaveBtn());
+
+      await waitFor(() => {
+        expect(saveCalls.length).toBe(1);
+      });
+      expect(saveCalls[0].entry.provider).toBe("lm-studio");
+      expect(saveCalls[0].entry.provider_connection).toBeUndefined();
+    } finally {
+      store.getState().clearIdentity();
+    }
+  });
+
+  test("a user row merely named vellum keeps the legacy shape under the gate", async () => {
+    const store = await gateOn();
+    try {
+      const userVellum = {
+        ...makeConnection("vellum"),
+        provider: "anthropic",
+      } as unknown as ProviderConnection;
+      const { saveCalls, onSave } = collectSaves();
+      renderCreate([userVellum], onSave);
+
+      selectProvider("Anthropic");
+      selectModel("Claude Opus 4.8");
+
+      await waitFor(() => {
+        expect(getSaveBtn().disabled).toBe(false);
+      });
+      fireEvent.click(getSaveBtn());
+
+      await waitFor(() => {
+        expect(saveCalls.length).toBe(1);
+      });
+      // "vellum" as a provider value would flip the profile to the managed
+      // identity, so the binding stays in the legacy field.
+      expect(saveCalls[0].entry.provider).toBe("anthropic");
+      expect(saveCalls[0].entry.provider_connection).toBe("vellum");
+    } finally {
+      store.getState().clearIdentity();
+    }
+  });
+
+  test("a stored entry-name profile opens translated and round-trips", async () => {
+    const store = await gateOn();
+    try {
+      const { saveCalls, onSave } = collectSaves();
+      renderEdit(
+        {
+          name: "work",
+          label: "Work",
+          provider: "anthropic-work",
+          model: "claude-opus-4-8",
+        },
+        onSave,
+        [anthropicWork, anthropicPersonal],
+      );
+
+      // The trigger shows the entry row, not a raw entry name.
+      await waitFor(() => {
+        expect(providerTrigger().textContent).toContain("Work key");
+      });
+
+      fireEvent.click(getSaveBtn());
+      await waitFor(() => {
+        expect(saveCalls.length).toBe(1);
+      });
+      expect(saveCalls[0].entry.provider).toBe("anthropic-work");
+      expect(saveCalls[0].entry.provider_connection).toBeNull();
+    } finally {
+      store.getState().clearIdentity();
+    }
   });
 });

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -2079,8 +2079,8 @@ describe("entries wire shape", () => {
   });
 
   test("a vendor id is never read as an entry name, even when a row carries it", async () => {
-    // Self-named rows predate the daemon's reservation guard. Opening a
-    // plain unbound profile must not pin it to the same-named row.
+    // A row can carry its vendor's own name; opening a plain unbound
+    // profile must not pin it to that row.
     const selfNamed = makeConnection("anthropic");
     const { saveCalls, onSave } = collectSaves();
     renderEdit(
@@ -2102,6 +2102,61 @@ describe("entries wire shape", () => {
     // Two siblings, so no auto-resolve: the profile stays unbound instead
     // of quietly adopting the self-named row.
     expect(saveCalls[0].entry.provider_connection).toBeNull();
+  });
+
+  test("an explicit pin to a self-named row keeps the legacy shape under the gate", async () => {
+    const store = await gateOn();
+    try {
+      // A row named exactly after its vendor cannot be written as an entry
+      // name (the daemon reads the bare id as "the kind's default entry"),
+      // so the explicit pin must stay in the legacy binding field.
+      const selfNamed = makeConnection("anthropic");
+      const { saveCalls, onSave } = collectSaves();
+      renderEdit(
+        {
+          name: "pinned",
+          label: "Pinned",
+          provider: "anthropic",
+          provider_connection: "anthropic",
+          model: "claude-opus-4-8",
+        },
+        onSave,
+        [selfNamed, anthropicPersonal],
+      );
+
+      fireEvent.click(getSaveBtn());
+      await waitFor(() => {
+        expect(saveCalls.length).toBe(1);
+      });
+      expect(saveCalls[0].entry.provider).toBe("anthropic");
+      expect(saveCalls[0].entry.provider_connection).toBe("anthropic");
+    } finally {
+      store.getState().clearIdentity();
+    }
+  });
+
+  test("a cross-kind identity binding shows the identity in the trigger", async () => {
+    const chatgptRow = {
+      ...makeConnection("chatgpt", "chatgpt"),
+      auth: { type: "oauth_subscription", credential: "credential/chatgpt" },
+    } as unknown as ProviderConnection;
+    renderEdit(
+      {
+        name: "codex",
+        label: "Codex",
+        provider: "openai",
+        provider_connection: "chatgpt",
+        model: "gpt-5.6-sol",
+      },
+      undefined,
+      [chatgptRow, makeConnection("openai-work", "openai")],
+    );
+
+    // The profile dispatches through the ChatGPT row, so the trigger names
+    // that route rather than bare OpenAI.
+    await waitFor(() => {
+      expect(providerTrigger().textContent).toContain("ChatGPT");
+    });
   });
 
   test("a stale binding among surviving siblings still labels the trigger", async () => {

--- a/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
@@ -23,7 +23,6 @@ import {
 import {
   entryPickerValue,
   expandEndpointEntries,
-  multiEntryProviderKinds,
   parseEntryPickerValue,
   providersServedByConnections,
   useSelectableCatalogProviders,
@@ -345,6 +344,69 @@ export function ProfileEditorProviderSection({
     }
   }, [model, availableModels, onModelChange, provider, isEnteringCustomModel]);
 
+  const defaultEntryMetaLabel = t("aiProviderPicker.defaultEntryMeta");
+
+  // Options are computed ahead of the JSX so the trigger value can be
+  // membership-checked below: a value with no matching option makes the
+  // Select render its placeholder, which reads as an empty picker on a
+  // working profile (stale binding among surviving siblings, or a
+  // cross-kind binding such as a chatgpt row serving openai).
+  const providerOptions = useMemo(() => {
+    const base = expandEndpointEntries(
+      providerOptionsSource,
+      connections ?? [],
+      (p) => PROVIDER_DISPLAY_NAMES[p] ?? p,
+      defaultEntryMetaLabel,
+    ).map(({ value, label, meta }) => ({
+      value,
+      label,
+      suffix: meta ? <PickerMeta text={meta} /> : undefined,
+    }));
+    // A bound endpoint whose row was deleted still renders on the
+    // trigger; the warning below explains the state.
+    if (
+      connectionNotFound &&
+      provider === OPENAI_COMPATIBLE_PROVIDER &&
+      providerConnection
+    ) {
+      base.push({
+        value: entryPickerValue(OPENAI_COMPATIBLE_PROVIDER, providerConnection),
+        label: `${providerConnection} (not found)`,
+        suffix: undefined,
+      });
+    }
+    // An unbound openai-compatible profile has no endpoint entry to
+    // select; the bare protocol value keeps the trigger labeled.
+    // Picking an endpoint entry from this same list binds it.
+    if (provider === OPENAI_COMPATIBLE_PROVIDER && !providerConnection) {
+      base.push({
+        value: OPENAI_COMPATIBLE_PROVIDER,
+        label:
+          PROVIDER_DISPLAY_NAMES[OPENAI_COMPATIBLE_PROVIDER] ??
+          OPENAI_COMPATIBLE_PROVIDER,
+        suffix: undefined,
+      });
+    }
+    return base;
+  }, [
+    providerOptionsSource,
+    connections,
+    connectionNotFound,
+    provider,
+    providerConnection,
+    defaultEntryMetaLabel,
+  ]);
+
+  const entryValue =
+    provider && providerConnection
+      ? entryPickerValue(provider, providerConnection)
+      : null;
+  const selectValue =
+    entryValue !== null &&
+    providerOptions.some((option) => option.value === entryValue)
+      ? entryValue
+      : provider;
+
   return (
     <>
       {/* Provider — required. Filtered to providers with at least one
@@ -368,14 +430,7 @@ export function ProfileEditorProviderSection({
               ? NO_PROVIDER_CONNECTIONS_HINT
               : subscriptionSteeringHint
           }
-          value={
-            provider &&
-            providerConnection &&
-            (provider === OPENAI_COMPATIBLE_PROVIDER ||
-              multiEntryProviderKinds(connections ?? []).has(provider))
-              ? entryPickerValue(provider, providerConnection)
-              : provider
-          }
+          value={selectValue}
           onChange={(next) => {
             const entry = parseEntryPickerValue(next);
             if (entry) {
@@ -396,45 +451,7 @@ export function ProfileEditorProviderSection({
           }}
           disabled={isReadOnly}
           placeholder="Select a provider…"
-          options={[
-            ...expandEndpointEntries(
-              providerOptionsSource,
-              connections ?? [],
-              (p) => PROVIDER_DISPLAY_NAMES[p] ?? p,
-            ).map(({ value, label, meta }) => ({
-              value,
-              label,
-              suffix: meta ? <PickerMeta text={meta} /> : undefined,
-            })),
-            // A bound endpoint whose row was deleted still renders on the
-            // trigger; the warning below explains the state.
-            ...(connectionNotFound &&
-            provider === OPENAI_COMPATIBLE_PROVIDER &&
-            providerConnection
-              ? [
-                  {
-                    value: entryPickerValue(
-                      OPENAI_COMPATIBLE_PROVIDER,
-                      providerConnection,
-                    ),
-                    label: `${providerConnection} (not found)`,
-                  },
-                ]
-              : []),
-            // An unbound openai-compatible profile has no endpoint entry to
-            // select; the bare protocol value keeps the trigger labeled.
-            // Picking an endpoint entry from this same list binds it.
-            ...(provider === OPENAI_COMPATIBLE_PROVIDER && !providerConnection
-              ? [
-                  {
-                    value: OPENAI_COMPATIBLE_PROVIDER,
-                    label:
-                      PROVIDER_DISPLAY_NAMES[OPENAI_COMPATIBLE_PROVIDER] ??
-                      OPENAI_COMPATIBLE_PROVIDER,
-                  },
-                ]
-              : []),
-          ]}
+          options={providerOptions}
         />
       )}
 

--- a/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
@@ -21,9 +21,10 @@ import {
   OPENAI_COMPATIBLE_PROVIDER,
 } from "@/domains/settings/ai/constants";
 import {
-  endpointPickerValue,
+  entryPickerValue,
   expandEndpointEntries,
-  parseEndpointPickerValue,
+  multiEntryProviderKinds,
+  parseEntryPickerValue,
   providersServedByConnections,
   useSelectableCatalogProviders,
 } from "@/domains/settings/ai/provider-availability";
@@ -368,20 +369,30 @@ export function ProfileEditorProviderSection({
               : subscriptionSteeringHint
           }
           value={
-            provider === OPENAI_COMPATIBLE_PROVIDER && providerConnection
-              ? endpointPickerValue(providerConnection)
+            provider &&
+            providerConnection &&
+            (provider === OPENAI_COMPATIBLE_PROVIDER ||
+              multiEntryProviderKinds(connections ?? []).has(provider))
+              ? entryPickerValue(provider, providerConnection)
               : provider
           }
           onChange={(next) => {
-            const endpoint = parseEndpointPickerValue(next);
-            if (endpoint) {
-              // Each endpoint entry implies the openai-compatible
-              // provider plus its binding.
-              onProviderChange(OPENAI_COMPATIBLE_PROVIDER);
-              onConnectionChange(endpoint);
+            const entry = parseEntryPickerValue(next);
+            if (entry) {
+              // An entry row implies its kind plus the binding; a same-kind
+              // entry switch keeps the model (onProviderChange no-ops).
+              onProviderChange(entry.provider);
+              onConnectionChange(entry.connectionName);
               return;
             }
             onProviderChange(next as ConnectionProvider);
+            // Re-picking the current kind's bare row means "the default
+            // entry": the explicit binding must clear, and the provider
+            // change above no-ops so it won't do it. A different provider
+            // resolves its own binding there instead.
+            if (next === provider) {
+              onConnectionChange("");
+            }
           }}
           disabled={isReadOnly}
           placeholder="Select a provider…"
@@ -402,7 +413,10 @@ export function ProfileEditorProviderSection({
             providerConnection
               ? [
                   {
-                    value: endpointPickerValue(providerConnection),
+                    value: entryPickerValue(
+                      OPENAI_COMPATIBLE_PROVIDER,
+                      providerConnection,
+                    ),
                     label: `${providerConnection} (not found)`,
                   },
                 ]

--- a/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
@@ -19,6 +19,7 @@ import {
 import {
   CHATGPT_CONNECTION_PROVIDER,
   OPENAI_COMPATIBLE_PROVIDER,
+  VELLUM_CONNECTION_PROVIDER,
 } from "@/domains/settings/ai/constants";
 import {
   entryPickerValue,
@@ -401,11 +402,30 @@ export function ProfileEditorProviderSection({
     provider && providerConnection
       ? entryPickerValue(provider, providerConnection)
       : null;
+  // A binding to an identity row (a chatgpt row serving openai, a vellum
+  // row serving a managed-routable vendor) has no entry option of its own:
+  // identity rows never expand. The identity's bare option names the route
+  // the profile actually dispatches through, so the trigger shows it
+  // rather than the vendor.
+  const boundIdentityKind = (() => {
+    if (!providerConnection) {
+      return null;
+    }
+    const row = connections?.find((c) => c.name === providerConnection);
+    return row &&
+      (row.provider === VELLUM_CONNECTION_PROVIDER ||
+        row.provider === CHATGPT_CONNECTION_PROVIDER)
+      ? row.provider
+      : null;
+  })();
+  const optionExists = (value: string) =>
+    providerOptions.some((option) => option.value === value);
   const selectValue =
-    entryValue !== null &&
-    providerOptions.some((option) => option.value === entryValue)
+    entryValue !== null && optionExists(entryValue)
       ? entryValue
-      : provider;
+      : boundIdentityKind !== null && optionExists(boundIdentityKind)
+        ? boundIdentityKind
+        : provider;
 
   return (
     <>

--- a/clients/web/src/domains/settings/ai/provider-availability.ts
+++ b/clients/web/src/domains/settings/ai/provider-availability.ts
@@ -204,8 +204,8 @@ const ROUTING_IDENTITY_KINDS = new Set<string>([
 /**
  * Catalog kinds with two or more connections of that same kind. These expand
  * into per-entry picker rows so a profile can name WHICH key it uses. The
- * identity rows (vellum/chatgpt) never expand — they are canonical
- * singletons — and openai-compatible always expands regardless of count.
+ * identity rows (vellum/chatgpt) never expand, being canonical singletons,
+ * and openai-compatible always expands regardless of count.
  */
 export function multiEntryProviderKinds(
   connections: ProviderConnection[],
@@ -237,6 +237,9 @@ export function expandEndpointEntries(
   providers: readonly ConnectionProvider[],
   connections: ProviderConnection[],
   labelFor: (provider: ConnectionProvider) => string,
+  // User-facing copy is caller-supplied so it can come from the locale
+  // catalog; the fallback keeps the pure helper usable in tests.
+  defaultEntryMetaLabel = "Default",
 ): { value: string; label: string; meta?: string }[] {
   const multiEntryKinds = multiEntryProviderKinds(connections);
   const entries: { value: string; label: string; meta?: string }[] = [];
@@ -271,7 +274,7 @@ export function expandEndpointEntries(
     entries.push({
       value: provider,
       label: labelFor(provider),
-      meta: "Default",
+      meta: defaultEntryMetaLabel,
     });
     for (const c of connections) {
       if (c.provider !== provider) {

--- a/clients/web/src/domains/settings/ai/provider-availability.ts
+++ b/clients/web/src/domains/settings/ai/provider-availability.ts
@@ -161,40 +161,84 @@ export function unconnectedSelectableProviders(
 }
 
 // ---------------------------------------------------------------------------
-// Per-endpoint picker entries
+// Per-entry picker entries
 // ---------------------------------------------------------------------------
 
 /**
- * Picker-value encoding for one openai-compatible endpoint presented as its
- * own provider-like entry. Each custom endpoint is a named entry; the
- * profile pickers list them individually (labeled by the endpoint) instead
- * of one generic "OpenAI-compatible" entry plus a second field. The `::`
- * separator cannot collide with provider ids, which contain no colons.
+ * Picker-value encoding for one connection (entry) presented as its own
+ * provider-like row: `<provider>::<connection name>`. Every openai-compatible
+ * endpoint is a named entry; a catalog provider expands into named entries
+ * only when it has more than one connection (a single-key user never sees
+ * entry naming). The `::` separator cannot collide with provider ids, which
+ * contain no colons.
  */
-const ENDPOINT_PICKER_PREFIX = `${OPENAI_COMPATIBLE_PROVIDER}::`;
+const ENTRY_PICKER_SEPARATOR = "::";
 
-export function endpointPickerValue(connectionName: string): string {
-  return `${ENDPOINT_PICKER_PREFIX}${connectionName}`;
+export function entryPickerValue(
+  provider: string,
+  connectionName: string,
+): string {
+  return `${provider}${ENTRY_PICKER_SEPARATOR}${connectionName}`;
 }
 
-/** The endpoint name inside a picker value, or null for plain provider ids. */
-export function parseEndpointPickerValue(value: string): string | null {
-  return value.startsWith(ENDPOINT_PICKER_PREFIX)
-    ? value.slice(ENDPOINT_PICKER_PREFIX.length)
-    : null;
+/** The provider and entry name inside a picker value, or null for plain
+ * provider ids. */
+export function parseEntryPickerValue(
+  value: string,
+): { provider: ConnectionProvider; connectionName: string } | null {
+  const index = value.indexOf(ENTRY_PICKER_SEPARATOR);
+  if (index <= 0) {
+    return null;
+  }
+  return {
+    provider: value.slice(0, index) as ConnectionProvider,
+    connectionName: value.slice(index + ENTRY_PICKER_SEPARATOR.length),
+  };
+}
+
+const ROUTING_IDENTITY_KINDS = new Set<string>([
+  VELLUM_CONNECTION_PROVIDER,
+  CHATGPT_CONNECTION_PROVIDER,
+]);
+
+/**
+ * Catalog kinds with two or more connections of that same kind. These expand
+ * into per-entry picker rows so a profile can name WHICH key it uses. The
+ * identity rows (vellum/chatgpt) never expand — they are canonical
+ * singletons — and openai-compatible always expands regardless of count.
+ */
+export function multiEntryProviderKinds(
+  connections: ProviderConnection[],
+): Set<ConnectionProvider> {
+  const counts = new Map<ConnectionProvider, number>();
+  for (const c of connections) {
+    if (
+      ROUTING_IDENTITY_KINDS.has(c.provider) ||
+      c.provider === OPENAI_COMPATIBLE_PROVIDER
+    ) {
+      continue;
+    }
+    counts.set(c.provider, (counts.get(c.provider) ?? 0) + 1);
+  }
+  return new Set(
+    [...counts.entries()].filter(([, n]) => n >= 2).map(([p]) => p),
+  );
 }
 
 /**
- * Provider dropdown entries with openai-compatible expanded per endpoint:
- * every other provider is one entry keyed by its id; each openai-compatible
- * connection is its own entry keyed by `endpointPickerValue(name)` and
- * labeled by the endpoint's label (falling back to its name).
+ * Provider dropdown entries with multi-entry kinds expanded per connection:
+ * a single-connection catalog provider is one entry keyed by its id; each
+ * openai-compatible connection is its own entry; a catalog provider with two
+ * or more connections keeps its bare id row (the kind's default entry) and
+ * adds one row per named entry, labeled by the entry's label (falling back
+ * to its name).
  */
 export function expandEndpointEntries(
   providers: readonly ConnectionProvider[],
   connections: ProviderConnection[],
   labelFor: (provider: ConnectionProvider) => string,
 ): { value: string; label: string; meta?: string }[] {
+  const multiEntryKinds = multiEntryProviderKinds(connections);
   const entries: { value: string; label: string; meta?: string }[] = [];
   for (const provider of providers) {
     if (provider === VELLUM_CONNECTION_PROVIDER) {
@@ -205,18 +249,38 @@ export function expandEndpointEntries(
       });
       continue;
     }
-    if (provider !== OPENAI_COMPATIBLE_PROVIDER) {
+    if (provider === OPENAI_COMPATIBLE_PROVIDER) {
+      for (const c of connections) {
+        if (c.provider !== OPENAI_COMPATIBLE_PROVIDER) {
+          continue;
+        }
+        entries.push({
+          value: entryPickerValue(provider, c.name),
+          label: c.label && c.label.trim() !== "" ? c.label : c.name,
+          meta: "Custom",
+        });
+      }
+      continue;
+    }
+    if (!multiEntryKinds.has(provider)) {
       entries.push({ value: provider, label: labelFor(provider) });
       continue;
     }
+    // The bare id row stays selectable: it means "the kind's default
+    // entry", which is how unbound profiles dispatch.
+    entries.push({
+      value: provider,
+      label: labelFor(provider),
+      meta: "Default",
+    });
     for (const c of connections) {
-      if (c.provider !== OPENAI_COMPATIBLE_PROVIDER) {
+      if (c.provider !== provider) {
         continue;
       }
       entries.push({
-        value: endpointPickerValue(c.name),
+        value: entryPickerValue(provider, c.name),
         label: c.label && c.label.trim() !== "" ? c.label : c.name,
-        meta: "Custom",
+        meta: labelFor(provider),
       });
     }
   }

--- a/clients/web/src/domains/settings/ai/use-profile-editor.ts
+++ b/clients/web/src/domains/settings/ai/use-profile-editor.ts
@@ -413,10 +413,9 @@ export function useProfileEditor({
     if (!stored || provider !== stored) {
       return;
     }
-    // A provider id is never an entry name, even when a legacy row carries
-    // that exact name (self-named rows predate the daemon's reservation
-    // guard): a bare id means "the kind's default entry", and treating it
-    // as a name would pin or even re-vendor the profile on open.
+    // A provider id is never an entry name: the daemon reads a bare id as
+    // "the kind's default entry", so a row that happens to carry such a
+    // name must not pin or re-vendor the profile on open.
     if (
       CONNECTION_PROVIDERS.includes(stored as ConnectionProvider) ||
       stored === VELLUM_CONNECTION_PROVIDER ||
@@ -687,18 +686,24 @@ export function useProfileEditor({
         effectiveBinding !== ""
           ? effectiveConnections.find((c) => c.name === effectiveBinding)
           : undefined;
-      const boundRowIsIdentity =
+      // A binding is only expressible as an entry name when the daemon
+      // would read that name back as this row. Identity rows dispatch by
+      // their own rules, and a row named after a provider id or identity
+      // value reads as "the kind's default entry" or the identity, not as
+      // the row: all of those keep the legacy shape so the pin survives.
+      const bindingInexpressibleAsEntryName =
         boundRow !== undefined &&
         (boundRow.provider === VELLUM_CONNECTION_PROVIDER ||
           boundRow.provider === CHATGPT_CONNECTION_PROVIDER ||
           boundRow.name === VELLUM_CONNECTION_PROVIDER ||
-          boundRow.name === CHATGPT_CONNECTION_PROVIDER);
+          boundRow.name === CHATGPT_CONNECTION_PROVIDER ||
+          CONNECTION_PROVIDERS.includes(boundRow.name as ConnectionProvider));
       let entryWireProvider = wireProvider;
       if (
         !writesIdentityPayload &&
         provider !== "" &&
         provider !== VELLUM_CONNECTION_PROVIDER &&
-        !boundRowIsIdentity &&
+        !bindingInexpressibleAsEntryName &&
         (await assistantSupportsEntryProviderBinding(assistantId))
       ) {
         const kindSiblings = effectiveConnections.filter(

--- a/clients/web/src/domains/settings/ai/use-profile-editor.ts
+++ b/clients/web/src/domains/settings/ai/use-profile-editor.ts
@@ -16,6 +16,7 @@ import {
 } from "@/assistant/llm-model-catalog";
 import {
   CHATGPT_CONNECTION_PROVIDER,
+  OPENAI_COMPATIBLE_PROVIDER,
   VELLUM_CONNECTION_PROVIDER,
 } from "@/domains/settings/ai/constants";
 import { resolveModelDisplayName } from "@/domains/settings/ai/model-display";
@@ -41,6 +42,7 @@ import type {
   ProfileStatus,
   ProviderConnection,
 } from "@/generated/daemon/types.gen";
+import { assistantSupportsEntryProviderBinding } from "@/lib/backwards-compat/entry-provider-binding";
 import { assistantSupportsVellumProviderProfiles } from "@/lib/backwards-compat/vellum-profile-provider";
 import { badRequestMessage } from "@/utils/api-errors";
 
@@ -401,6 +403,29 @@ export function useProfileEditor({
     }
   }, [connections, provider, initialValues]);
 
+  // Open a stored entry-name provider (the entries model: the binding lives
+  // IN the provider value) as its row's kind plus the row as the binding,
+  // so the picker and model logic stay vendor-keyed. Skipped once the user
+  // changes the provider; identity rows keep their own flows above.
+  useEffect(() => {
+    const stored = initialValues?.provider;
+    if (!stored || provider !== stored) {
+      return;
+    }
+    const row = connections?.find((c) => c.name === stored);
+    if (
+      !row ||
+      row.provider === VELLUM_CONNECTION_PROVIDER ||
+      row.provider === CHATGPT_CONNECTION_PROVIDER
+    ) {
+      return;
+    }
+    setProvider(row.provider);
+    if (providerConnection === "") {
+      setProviderConnection(row.name);
+    }
+  }, [connections, provider, providerConnection, initialValues]);
+
   // Reset dirty tracking when the editor re-opens with new values.
   useEffect(() => {
     resetDirty();
@@ -638,13 +663,48 @@ export function useProfileEditor({
       const wireModel = nativeModel;
       // Identity payloads carry no binding; sending null on edit clears a
       // legacy-shape binding left on the stored profile.
-      const wireBinding = writesIdentityPayload ? "" : effectiveBinding;
+      let wireBinding = writesIdentityPayload ? "" : effectiveBinding;
+      // Entries wire shape (version-gated): gated daemons store the binding
+      // IN the provider value — the entry name when the user picked a named
+      // row among siblings (openai-compatible endpoints always), the bare
+      // vendor id (the kind's default entry) otherwise — and never a
+      // provider_connection. Identity-bound rows keep their existing
+      // payloads: rewriting a vellum/chatgpt binding as an entry name would
+      // change what the daemon bills the request to.
+      const boundRow =
+        effectiveBinding !== ""
+          ? effectiveConnections.find((c) => c.name === effectiveBinding)
+          : undefined;
+      const boundRowIsIdentity =
+        boundRow !== undefined &&
+        (boundRow.provider === VELLUM_CONNECTION_PROVIDER ||
+          boundRow.provider === CHATGPT_CONNECTION_PROVIDER ||
+          boundRow.name === VELLUM_CONNECTION_PROVIDER ||
+          boundRow.name === CHATGPT_CONNECTION_PROVIDER);
+      let entryWireProvider = wireProvider;
+      if (
+        !writesIdentityPayload &&
+        provider !== "" &&
+        provider !== VELLUM_CONNECTION_PROVIDER &&
+        !boundRowIsIdentity &&
+        (await assistantSupportsEntryProviderBinding(assistantId))
+      ) {
+        const kindSiblings = effectiveConnections.filter(
+          (c) => c.provider === provider,
+        ).length;
+        entryWireProvider =
+          boundRow !== undefined &&
+          (provider === OPENAI_COMPATIBLE_PROVIDER || kindSiblings >= 2)
+            ? boundRow.name
+            : provider;
+        wireBinding = "";
+      }
       if (effectiveMode === "edit") {
         // In edit mode send null for cleared fields so the server deep-merges
         // them as cleared rather than silently preserving the old value.
         entry.label = label.trim() || null;
         entry.description = description.trim() || null;
-        entry.provider = wireProvider || null;
+        entry.provider = entryWireProvider || null;
         entry.model = wireModel || null;
         entry.provider_connection = wireBinding || null;
       } else {
@@ -655,8 +715,8 @@ export function useProfileEditor({
         if (description.trim()) {
           entry.description = description.trim();
         }
-        if (wireProvider) {
-          entry.provider = wireProvider;
+        if (entryWireProvider) {
+          entry.provider = entryWireProvider;
         }
         if (wireModel) {
           entry.model = wireModel;

--- a/clients/web/src/domains/settings/ai/use-profile-editor.ts
+++ b/clients/web/src/domains/settings/ai/use-profile-editor.ts
@@ -21,6 +21,7 @@ import {
 } from "@/domains/settings/ai/constants";
 import { resolveModelDisplayName } from "@/domains/settings/ai/model-display";
 import { connectionServesProvider } from "@/domains/settings/ai/provider-availability";
+import { CONNECTION_PROVIDERS } from "@/domains/settings/ai/provider-editor-constants";
 import { deriveProfileDefaults } from "@/domains/settings/ai/profile-prefill";
 import {
   isGeminiThinkingLevel,
@@ -412,6 +413,17 @@ export function useProfileEditor({
     if (!stored || provider !== stored) {
       return;
     }
+    // A provider id is never an entry name, even when a legacy row carries
+    // that exact name (self-named rows predate the daemon's reservation
+    // guard): a bare id means "the kind's default entry", and treating it
+    // as a name would pin or even re-vendor the profile on open.
+    if (
+      CONNECTION_PROVIDERS.includes(stored as ConnectionProvider) ||
+      stored === VELLUM_CONNECTION_PROVIDER ||
+      stored === CHATGPT_CONNECTION_PROVIDER
+    ) {
+      return;
+    }
     const row = connections?.find((c) => c.name === stored);
     if (
       !row ||
@@ -665,12 +677,12 @@ export function useProfileEditor({
       // legacy-shape binding left on the stored profile.
       let wireBinding = writesIdentityPayload ? "" : effectiveBinding;
       // Entries wire shape (version-gated): gated daemons store the binding
-      // IN the provider value — the entry name when the user picked a named
-      // row among siblings (openai-compatible endpoints always), the bare
-      // vendor id (the kind's default entry) otherwise — and never a
-      // provider_connection. Identity-bound rows keep their existing
-      // payloads: rewriting a vellum/chatgpt binding as an entry name would
-      // change what the daemon bills the request to.
+      // IN the provider value (the entry name when the user picked a named
+      // row among siblings and always for openai-compatible endpoints, the
+      // bare vendor id meaning the kind's default entry otherwise) and
+      // never a provider_connection. Identity-bound rows keep their
+      // existing payloads: rewriting a vellum/chatgpt binding as an entry
+      // name would change what the daemon bills the request to.
       const boundRow =
         effectiveBinding !== ""
           ? effectiveConnections.find((c) => c.name === effectiveBinding)

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -15,5 +15,8 @@
   },
   "profileEditor": {
     "subscriptionSteeringHint": "Your ChatGPT subscription is available as the ChatGPT provider."
+  },
+  "aiProviderPicker": {
+    "defaultEntryMeta": "Default"
   }
 }

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -15,5 +15,8 @@
   },
   "profileEditor": {
     "subscriptionSteeringHint": "Tu suscripción a ChatGPT está disponible como el proveedor ChatGPT."
+  },
+  "aiProviderPicker": {
+    "defaultEntryMeta": "Predeterminado"
   }
 }

--- a/clients/web/src/lib/backwards-compat/entry-provider-binding.test.ts
+++ b/clients/web/src/lib/backwards-compat/entry-provider-binding.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { assistantSupportsEntryProviderBinding } from "@/lib/backwards-compat/entry-provider-binding";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+
+function setVersion(version: string | null) {
+  useAssistantIdentityStore.getState().setIdentity("test-asst", version);
+}
+
+beforeEach(() => {
+  useAssistantIdentityStore.getState().clearIdentity();
+});
+
+afterEach(() => {
+  useAssistantIdentityStore.getState().clearIdentity();
+});
+
+// Exhaustive truth-table for the underlying semver gate lives in
+// `utils.test.ts`. Here we verify the boundary on each side of 0.11.4
+// plus the conservative-on-unknown policy after the bounded version wait.
+describe("assistantSupportsEntryProviderBinding", () => {
+  test("returns false when the version stays unknown past the wait", async () => {
+    setVersion(null);
+    expect(await assistantSupportsEntryProviderBinding(null, 1)).toBe(false);
+  });
+
+  test("waits for hydration before deciding", async () => {
+    setVersion(null);
+    const decision = assistantSupportsEntryProviderBinding(null, 1_000);
+    setVersion("0.11.4");
+    expect(await decision).toBe(true);
+  });
+
+  test("returns false for assistants on 0.11.3 and older", async () => {
+    setVersion("0.11.3");
+    expect(await assistantSupportsEntryProviderBinding()).toBe(false);
+    setVersion("0.10.12");
+    expect(await assistantSupportsEntryProviderBinding()).toBe(false);
+  });
+
+  test("returns true from 0.11.4, including pre-releases", async () => {
+    setVersion("0.11.4");
+    expect(await assistantSupportsEntryProviderBinding()).toBe(true);
+    setVersion("0.11.4-staging.1");
+    expect(await assistantSupportsEntryProviderBinding()).toBe(true);
+    setVersion("0.12.0");
+    expect(await assistantSupportsEntryProviderBinding()).toBe(true);
+  });
+
+  test("a hydrated identity for a different assistant gates to legacy", async () => {
+    useAssistantIdentityStore
+      .getState()
+      .setIdentity("other-asst", "0.11.4", "asst-B");
+    expect(await assistantSupportsEntryProviderBinding("asst-A")).toBe(false);
+    expect(await assistantSupportsEntryProviderBinding("asst-B")).toBe(true);
+    expect(await assistantSupportsEntryProviderBinding(null)).toBe(true);
+  });
+
+  test("an un-owned hydrated identity gates to legacy when an owner is required", async () => {
+    useAssistantIdentityStore.getState().setIdentity("some-asst", "0.11.4");
+    expect(await assistantSupportsEntryProviderBinding("asst-A")).toBe(false);
+  });
+});

--- a/clients/web/src/lib/backwards-compat/entry-provider-binding.test.ts
+++ b/clients/web/src/lib/backwards-compat/entry-provider-binding.test.ts
@@ -16,8 +16,9 @@ afterEach(() => {
 });
 
 // Exhaustive truth-table for the underlying semver gate lives in
-// `utils.test.ts`. Here we verify the boundary on each side of 0.11.4
-// plus the conservative-on-unknown policy after the bounded version wait.
+// `utils.test.ts`. Here we verify the boundary on each side of the dev
+// floor (the assistant commit that landed entry-name writes) plus the
+// conservative-on-unknown policy after the bounded version wait.
 describe("assistantSupportsEntryProviderBinding", () => {
   test("returns false when the version stays unknown past the wait", async () => {
     setVersion(null);
@@ -31,17 +32,27 @@ describe("assistantSupportsEntryProviderBinding", () => {
     expect(await decision).toBe(true);
   });
 
-  test("returns false for assistants on 0.11.3 and older", async () => {
+  test("returns false for the 0.11.3 stable release and older", async () => {
     setVersion("0.11.3");
     expect(await assistantSupportsEntryProviderBinding()).toBe(false);
     setVersion("0.10.12");
     expect(await assistantSupportsEntryProviderBinding()).toBe(false);
   });
 
-  test("returns true from 0.11.4, including pre-releases", async () => {
-    setVersion("0.11.4");
+  test("returns false for dev builds cut before the feature commit", async () => {
+    setVersion("0.11.3-dev.202608102357.aaaaaaa");
+    expect(await assistantSupportsEntryProviderBinding()).toBe(false);
+  });
+
+  test("returns true from the feature commit's dev build onward", async () => {
+    setVersion("0.11.3-dev.202608102358.ef1568c");
     expect(await assistantSupportsEntryProviderBinding()).toBe(true);
-    setVersion("0.11.4-staging.1");
+    setVersion("0.11.3-dev.202608110001.bbbbbbb");
+    expect(await assistantSupportsEntryProviderBinding()).toBe(true);
+  });
+
+  test("returns true for every later release, whatever it is numbered", async () => {
+    setVersion("0.11.4");
     expect(await assistantSupportsEntryProviderBinding()).toBe(true);
     setVersion("0.12.0");
     expect(await assistantSupportsEntryProviderBinding()).toBe(true);

--- a/clients/web/src/lib/backwards-compat/entry-provider-binding.ts
+++ b/clients/web/src/lib/backwards-compat/entry-provider-binding.ts
@@ -2,28 +2,33 @@
  * Backwards-compat gate: the wire payload for entry-bound profiles.
  *
  * Daemons at `MIN_VERSION` and later store and dispatch profiles whose
- * `provider` holds a connection (entry) name — the entries model: the
+ * `provider` holds a connection (entry) name (the entries model: the
  * binding lives IN the provider value, a bare catalog id means the kind's
- * default entry, and `provider_connection` is never written. Older daemons
+ * default entry, and `provider_connection` is never written). Older daemons
  * reject entry names at the profile write route, so the editor writes the
  * legacy shape instead: the vendor as `provider` plus the entry name as
  * `provider_connection`. The UI is identical either way.
  *
- * RELEASE-CUT: verify the first release carrying migration
- * 145-collapse-profile-bindings-to-entries is in fact `MIN_VERSION`.
+ * The floor is the dev version of ef1568cea2, the assistant commit that
+ * landed the entries collapse (migration 145) and entry-name writes.
+ * Base-version comparison means every later release satisfies it no
+ * matter how it is numbered, and dev builds cut after that commit light
+ * up immediately; a hotfix numbered like the next release but cut
+ * without the commit does not (see BACKWARDS_COMPAT.md, "Prefer a dev
+ * floor to a predicted release number").
  *
  * Async and owner-scoped for the same reasons as
  * `vellum-profile-provider.ts` (the PR 14 precedent): this gates a WRITE
  * path whose legacy fallback newer daemons merely tolerate, so the check
  * awaits a hydrated version, and a supplied `ownerAssistantId` must match
- * the hydrated identity exactly — an un-owned or mismatched identity gates
+ * the hydrated identity exactly; an un-owned or mismatched identity gates
  * to the legacy payload, the only shape safe on every daemon.
  */
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 
 import { assistantSupports, whenAssistantVersionKnown } from "./utils";
 
-const MIN_VERSION = "0.11.4";
+const MIN_VERSION = "0.11.3-dev.202608102358.ef1568c";
 
 export async function assistantSupportsEntryProviderBinding(
   ownerAssistantId?: string | null,

--- a/clients/web/src/lib/backwards-compat/entry-provider-binding.ts
+++ b/clients/web/src/lib/backwards-compat/entry-provider-binding.ts
@@ -1,0 +1,38 @@
+/**
+ * Backwards-compat gate: the wire payload for entry-bound profiles.
+ *
+ * Daemons at `MIN_VERSION` and later store and dispatch profiles whose
+ * `provider` holds a connection (entry) name — the entries model: the
+ * binding lives IN the provider value, a bare catalog id means the kind's
+ * default entry, and `provider_connection` is never written. Older daemons
+ * reject entry names at the profile write route, so the editor writes the
+ * legacy shape instead: the vendor as `provider` plus the entry name as
+ * `provider_connection`. The UI is identical either way.
+ *
+ * RELEASE-CUT: verify the first release carrying migration
+ * 145-collapse-profile-bindings-to-entries is in fact `MIN_VERSION`.
+ *
+ * Async and owner-scoped for the same reasons as
+ * `vellum-profile-provider.ts` (the PR 14 precedent): this gates a WRITE
+ * path whose legacy fallback newer daemons merely tolerate, so the check
+ * awaits a hydrated version, and a supplied `ownerAssistantId` must match
+ * the hydrated identity exactly — an un-owned or mismatched identity gates
+ * to the legacy payload, the only shape safe on every daemon.
+ */
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+
+import { assistantSupports, whenAssistantVersionKnown } from "./utils";
+
+const MIN_VERSION = "0.11.4";
+
+export async function assistantSupportsEntryProviderBinding(
+  ownerAssistantId?: string | null,
+  versionWaitTimeoutMs?: number,
+): Promise<boolean> {
+  await whenAssistantVersionKnown(versionWaitTimeoutMs);
+  const hydratedAssistantId = useAssistantIdentityStore.getState().assistantId;
+  if (ownerAssistantId != null && hydratedAssistantId !== ownerAssistantId) {
+    return false;
+  }
+  return assistantSupports(MIN_VERSION);
+}


### PR DESCRIPTION
## Summary

Step 3b of the entries model (13b, design: `.private/plans/entries-model-13b.md` §3e): the web profile editor can now express "profile A on Anthropic key 1, profile B on Anthropic key 2" — the multi-key UX gap that motivated the entries model.

- **Entry picker**: a catalog kind with two or more connections expands into per-entry picker rows (entry label falling back to name, kind chip as meta) plus a bare default row, generalizing the existing `openai-compatible::<name>` endpoint expansion. Single-key kinds stay one bare row — single-key users never see entry naming (Q3).
- **Version-gated wire shape**: saves against daemons at `0.11.4` (the release carrying migration 145, #40592) store the binding IN the provider value — the picked entry name among siblings (openai-compatible endpoints always), the bare vendor id (the kind's default entry) otherwise — and never write `provider_connection`. Older daemons keep today's legacy vendor + binding payload byte-identical. Same owner-matched async gate pattern as `vellum-profile-provider.ts` (PR 14 precedent).
- **Read side**: stored entry-name profiles (produced by migration 145 or gated writes) open translated to their row's kind plus binding, so picker and model logic stay vendor-keyed and the trigger shows the entry's label.
- **Identity guard**: rows bound to the vellum/chatgpt identities (by row kind, or a legacy user row merely named `vellum`/`chatgpt`) keep their existing payloads — rewriting them as entry names would change what the daemon bills the request to.

## Release-cut action item

`MIN_VERSION = "0.11.4"` in `entry-provider-binding.ts` assumes the next release (first carrying migration 145) is 0.11.4 — verify at cut, same drill as the 0.10.12 gate.

## Testing

- New gate unit suite (`entry-provider-binding.test.ts`): boundary both sides of 0.11.4, hydration wait, owner matching.
- Modal suite additions: multi-key expansion rows, single-key bare row, gated entry-name payload, ungated legacy payload, gated bare-vendor single-key payload, gated endpoint-name payload, user-row-named-vellum guard, stored entry-name profile translation + round-trip.
- Existing modal/panel/backwards-compat suites green; batch-mode failures verified identical to the stashed baseline (pre-existing mock leakage).
- `tsc`, eslint, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ma7ZMzsQkJCG4t4uSGLoLT
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40599" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->