### PR TITLE
feat(web): surface a background or scheduled run when the user opens it (LUM-3221)

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-attention-tracking.ts
+++ b/clients/web/src/domains/chat/hooks/use-attention-tracking.ts
@@ -12,6 +12,7 @@ import { reconcileAttentionKeys } from "@/domains/chat/utils/reconcile-attention
 
 import { useActiveConversation } from "./use-active-conversation";
 import { useMarkSeenOnOpen } from "./use-mark-seen-on-open";
+import { useSurfaceOnOpen } from "./use-surface-on-open";
 
 interface UseAttentionTrackingParams {
   /** From `useAssistantLifecycle` in `ChatLayout`. */
@@ -74,6 +75,16 @@ export function useAttentionTracking({
   // Mark conversation as seen when opened
   // -------------------------------------------------------------------------
   useMarkSeenOnOpen({
+    assistantId,
+    assistantStateKind,
+    activeConversationId,
+    activeConversation,
+  });
+
+  // -------------------------------------------------------------------------
+  // Surface a background/scheduled run when opened
+  // -------------------------------------------------------------------------
+  useSurfaceOnOpen({
     assistantId,
     assistantStateKind,
     activeConversationId,

--- a/clients/web/src/domains/chat/hooks/use-send-message.ts
+++ b/clients/web/src/domains/chat/hooks/use-send-message.ts
@@ -51,7 +51,7 @@ import {
   prependConversation,
   removeConversation,
   resolveDraftKey,
-  shouldSurfaceConversationOnUserSend,
+  shouldSurfaceConversation,
   surfaceConversationInCaches,
 } from "@/utils/conversation-cache-mutations";
 import {
@@ -281,7 +281,7 @@ export function useSendMessage({
         }
       }
 
-      if (!shouldSurfaceConversationOnUserSend(conversation)) {
+      if (!shouldSurfaceConversation(conversation)) {
         return;
       }
 

--- a/clients/web/src/domains/chat/hooks/use-surface-on-open.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-surface-on-open.test.tsx
@@ -1,0 +1,216 @@
+/**
+ * Tests for surfacing a background/scheduled run on open.
+ *
+ * The invariant: opening is the promotion. An unsurfaced background run
+ * whose conversation becomes active fires exactly one surface POST and
+ * lands in the foreground cache with the server's `surfacedAt`; everything
+ * already visible (surfaced, standard, pinned, grouped) fires nothing.
+ *
+ * Server-first means failure needs no rollback, only a released guard so
+ * the next effect evaluation retries.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+
+import type * as ConversationsApi from "@/domains/chat/api/conversations";
+import type { Conversation } from "@/types/conversation-types";
+import { conversationsQueryKey } from "@/utils/conversation-list-fetchers";
+
+const surfaceCalls: Array<{ assistantId: string; conversationId: string }> = [];
+let surfaceImpl: () => Promise<number> = async () => 4242;
+
+mock.module(
+  "@/domains/chat/api/conversations",
+  (): Partial<typeof ConversationsApi> => ({
+    surfaceConversation: async (
+      assistantId: string,
+      conversationId: string,
+    ) => {
+      surfaceCalls.push({ assistantId, conversationId });
+      return surfaceImpl();
+    },
+  }),
+);
+
+mock.module("@sentry/react", () => ({
+  captureException: () => {},
+  captureMessage: () => {},
+  addBreadcrumb: () => {},
+}));
+
+const { useSurfaceOnOpen } =
+  await import("@/domains/chat/hooks/use-surface-on-open");
+
+const ASSISTANT_ID = "asst-1";
+
+function conversation(overrides: Partial<Conversation> = {}): Conversation {
+  return { conversationId: "bg1", lastMessageAt: 1000, ...overrides };
+}
+
+function renderSurfaceOnOpen(
+  client: QueryClient,
+  activeConversation: Conversation | undefined,
+) {
+  return renderHook(
+    (props: { activeConversation: Conversation | undefined }) =>
+      useSurfaceOnOpen({
+        assistantId: ASSISTANT_ID,
+        assistantStateKind: "active",
+        activeConversationId: props.activeConversation?.conversationId ?? null,
+        activeConversation: props.activeConversation,
+      }),
+    {
+      initialProps: { activeConversation },
+      wrapper: ({ children }: { children: ReactNode }) =>
+        createElement(QueryClientProvider, { client }, children),
+    },
+  );
+}
+
+beforeEach(() => {
+  surfaceCalls.length = 0;
+  surfaceImpl = async () => 4242;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useSurfaceOnOpen", () => {
+  test("opening an unsurfaced background run surfaces it once", async () => {
+    const client = new QueryClient();
+    const bg = conversation({ conversationType: "background" });
+    client.setQueryData<Conversation[]>(
+      conversationsQueryKey(ASSISTANT_ID),
+      [],
+    );
+
+    const { rerender } = renderSurfaceOnOpen(client, bg);
+
+    await waitFor(() => {
+      expect(surfaceCalls).toEqual([
+        { assistantId: ASSISTANT_ID, conversationId: "bg1" },
+      ]);
+    });
+    await waitFor(() => {
+      expect(
+        client
+          .getQueryData<Conversation[]>(conversationsQueryKey(ASSISTANT_ID))
+          ?.map((c) => c.surfacedAt),
+      ).toEqual([4242]);
+    });
+
+    // A re-render with the same row must not fire again.
+    await act(async () => {
+      rerender({ activeConversation: bg });
+    });
+    expect(surfaceCalls).toHaveLength(1);
+  });
+
+  test("an already-surfaced run fires nothing", async () => {
+    const client = new QueryClient();
+    const { rerender } = renderSurfaceOnOpen(
+      client,
+      conversation({ conversationType: "background", surfacedAt: 7 }),
+    );
+    rerender({
+      activeConversation: conversation({
+        conversationType: "background",
+        surfacedAt: 7,
+      }),
+    });
+
+    expect(surfaceCalls).toHaveLength(0);
+  });
+
+  test("a standard conversation fires nothing", () => {
+    const client = new QueryClient();
+    renderSurfaceOnOpen(client, conversation({}));
+
+    expect(surfaceCalls).toHaveLength(0);
+  });
+
+  test("a pinned or filed run fires nothing", () => {
+    // Pinning or filing already made the row visible; there is nothing to
+    // promote, and the placement write already stamped surfaced_at.
+    const client = new QueryClient();
+    renderSurfaceOnOpen(
+      client,
+      conversation({ conversationType: "background", isPinned: true }),
+    );
+    renderSurfaceOnOpen(
+      client,
+      conversation({
+        conversationId: "bg2",
+        conversationType: "scheduled",
+        groupId: "group-uuid",
+      }),
+    );
+
+    expect(surfaceCalls).toHaveLength(0);
+  });
+
+  test("a failed surface leaves caches untouched and retries on the next open", async () => {
+    const client = new QueryClient();
+    client.setQueryData<Conversation[]>(
+      conversationsQueryKey(ASSISTANT_ID),
+      [],
+    );
+    surfaceImpl = async () => {
+      throw new Error("surface failed");
+    };
+    const bg = conversation({ conversationType: "background" });
+
+    const { rerender } = renderSurfaceOnOpen(client, bg);
+    await waitFor(() => {
+      expect(surfaceCalls).toHaveLength(1);
+    });
+    expect(
+      client.getQueryData<Conversation[]>(conversationsQueryKey(ASSISTANT_ID)),
+    ).toEqual([]);
+
+    // Guard released: a fresh evaluation (new row identity) tries again.
+    surfaceImpl = async () => 4242;
+    await act(async () => {
+      rerender({
+        activeConversation: conversation({ conversationType: "background" }),
+      });
+    });
+    await waitFor(() => {
+      expect(surfaceCalls).toHaveLength(2);
+    });
+  });
+
+  test("a pending request blocks a duplicate while prop identity churns", async () => {
+    const client = new QueryClient();
+    client.setQueryData<Conversation[]>(
+      conversationsQueryKey(ASSISTANT_ID),
+      [],
+    );
+    let resolveSurface!: (at: number) => void;
+    surfaceImpl = () =>
+      new Promise<number>((resolve) => {
+        resolveSurface = resolve;
+      });
+    const bg = conversation({ conversationType: "background" });
+
+    const { rerender } = renderSurfaceOnOpen(client, bg);
+    await waitFor(() => {
+      expect(surfaceCalls).toHaveLength(1);
+    });
+
+    // A new object for the same conversation (a cache write elsewhere) must
+    // not start a second request while the first is in flight.
+    rerender({
+      activeConversation: conversation({ conversationType: "background" }),
+    });
+    expect(surfaceCalls).toHaveLength(1);
+
+    await act(async () => {
+      resolveSurface(4242);
+    });
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-surface-on-open.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-surface-on-open.test.tsx
@@ -20,7 +20,7 @@ import type { Conversation } from "@/types/conversation-types";
 import { conversationsQueryKey } from "@/utils/conversation-list-fetchers";
 
 const surfaceCalls: Array<{ assistantId: string; conversationId: string }> = [];
-let surfaceImpl: () => Promise<number> = async () => 4242;
+let surfaceImpl: (conversationId: string) => Promise<number> = async () => 4242;
 
 mock.module(
   "@/domains/chat/api/conversations",
@@ -30,7 +30,7 @@ mock.module(
       conversationId: string,
     ) => {
       surfaceCalls.push({ assistantId, conversationId });
-      return surfaceImpl();
+      return surfaceImpl(conversationId);
     },
   }),
 );
@@ -181,6 +181,59 @@ describe("useSurfaceOnOpen", () => {
     });
     await waitFor(() => {
       expect(surfaceCalls).toHaveLength(2);
+    });
+  });
+
+  test("one run's settle does not release another run's in-flight guard", async () => {
+    /* Open A, then open B while A is still out. A settling must delete only
+       its own guard entry: releasing B's would let B's next identity churn
+       fire a duplicate promotion for a run already being promoted. */
+    const client = new QueryClient();
+    client.setQueryData<Conversation[]>(
+      conversationsQueryKey(ASSISTANT_ID),
+      [],
+    );
+    const resolvers = new Map<string, (at: number) => void>();
+    surfaceImpl = (conversationId) =>
+      new Promise<number>((resolve) => {
+        resolvers.set(conversationId, resolve);
+      });
+
+    const runA = conversation({
+      conversationId: "run-a",
+      conversationType: "background",
+    });
+    const { rerender } = renderSurfaceOnOpen(client, runA);
+    await waitFor(() => {
+      expect(surfaceCalls).toHaveLength(1);
+    });
+
+    rerender({
+      activeConversation: conversation({
+        conversationId: "run-b",
+        conversationType: "background",
+      }),
+    });
+    await waitFor(() => {
+      expect(surfaceCalls).toHaveLength(2);
+    });
+
+    // A settles while B is still in flight.
+    await act(async () => {
+      resolvers.get("run-a")!(4242);
+    });
+
+    // B's identity churns (a cache write elsewhere): still guarded.
+    rerender({
+      activeConversation: conversation({
+        conversationId: "run-b",
+        conversationType: "background",
+      }),
+    });
+    expect(surfaceCalls).toHaveLength(2);
+
+    await act(async () => {
+      resolvers.get("run-b")!(4242);
     });
   });
 

--- a/clients/web/src/domains/chat/hooks/use-surface-on-open.ts
+++ b/clients/web/src/domains/chat/hooks/use-surface-on-open.ts
@@ -1,0 +1,97 @@
+import { useEffect, useRef } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+
+import { surfaceConversation } from "@/domains/chat/api/conversations";
+import { captureError } from "@/lib/sentry/capture-error";
+import type { AssistantState } from "@/assistant/types";
+import type { Conversation } from "@/types/conversation-types";
+import {
+  applySurfacedConversation,
+  shouldSurfaceConversation,
+} from "@/utils/conversation-cache-mutations";
+
+/**
+ * Surfaces the active conversation when the user opens an unsurfaced
+ * background or scheduled run.
+ *
+ * Opening is the promotion: a run the sidebar deliberately hides as noise
+ * becomes a conversation the user has chosen to look at, so it belongs in
+ * the sidebar like any other surfaced row, highlighted as active and still
+ * there afterwards. Without this, a run opened from the activity feed
+ * renders a chat with no corresponding sidebar row until the user sends a
+ * message (`surfaceConversationAfterUserSend` owns that entry point; both
+ * gate on {@link shouldSurfaceConversation}, so their eligibility cannot
+ * drift).
+ *
+ * Server-first, like the send path: the POST carries the authoritative
+ * `surfacedAt`, and the caches are written only from its response, so a
+ * failed request leaves nothing to roll back. The guard ref keeps one
+ * request in flight per conversation and releases on failure so the next
+ * effect evaluation retries; on success the row's own `surfacedAt` makes
+ * the predicate false and the effect quiesces.
+ */
+export function useSurfaceOnOpen({
+  assistantId,
+  assistantStateKind,
+  activeConversationId,
+  activeConversation,
+}: {
+  assistantId: string | null;
+  assistantStateKind: AssistantState["kind"];
+  activeConversationId: string | null;
+  activeConversation: Conversation | undefined;
+}) {
+  const queryClient = useQueryClient();
+  const surfacingConversationIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (
+      assistantStateKind !== "active" ||
+      !assistantId ||
+      !activeConversationId
+    ) {
+      return;
+    }
+    if (
+      !activeConversation ||
+      activeConversation.conversationId !== activeConversationId
+    ) {
+      return;
+    }
+    if (!shouldSurfaceConversation(activeConversation)) {
+      return;
+    }
+    if (surfacingConversationIdRef.current === activeConversationId) {
+      return;
+    }
+
+    surfacingConversationIdRef.current = activeConversationId;
+    const conversation = activeConversation;
+
+    void surfaceConversation(assistantId, activeConversationId)
+      .then((surfacedAt) => {
+        applySurfacedConversation(
+          queryClient,
+          assistantId,
+          conversation,
+          surfacedAt,
+        );
+      })
+      .catch((err: unknown) => {
+        captureError(err, {
+          context: "useSurfaceOnOpen",
+          bestEffort: true,
+          extra: { conversationId: activeConversationId },
+        });
+      })
+      .finally(() => {
+        surfacingConversationIdRef.current = null;
+      });
+  }, [
+    activeConversation,
+    activeConversationId,
+    assistantId,
+    assistantStateKind,
+    queryClient,
+  ]);
+}

--- a/clients/web/src/domains/chat/hooks/use-surface-on-open.ts
+++ b/clients/web/src/domains/chat/hooks/use-surface-on-open.ts
@@ -25,10 +25,12 @@ import {
  *
  * Server-first, like the send path: the POST carries the authoritative
  * `surfacedAt`, and the caches are written only from its response, so a
- * failed request leaves nothing to roll back. The guard ref keeps one
- * request in flight per conversation and releases on failure so the next
- * effect evaluation retries; on success the row's own `surfacedAt` makes
- * the predicate false and the effect quiesces.
+ * failed request leaves nothing to roll back. The in-flight set keeps one
+ * request per conversation (the send path's idiom: each settle deletes only
+ * its own entry, so overlapping opens of different runs cannot release each
+ * other's guard) and releases on settle so a failed request retries on the
+ * next effect evaluation; on success the row's own `surfacedAt` makes the
+ * predicate false and the effect quiesces.
  */
 export function useSurfaceOnOpen({
   assistantId,
@@ -42,7 +44,7 @@ export function useSurfaceOnOpen({
   activeConversation: Conversation | undefined;
 }) {
   const queryClient = useQueryClient();
-  const surfacingConversationIdRef = useRef<string | null>(null);
+  const surfacingConversationIdsRef = useRef(new Set<string>());
 
   useEffect(() => {
     if (
@@ -61,11 +63,11 @@ export function useSurfaceOnOpen({
     if (!shouldSurfaceConversation(activeConversation)) {
       return;
     }
-    if (surfacingConversationIdRef.current === activeConversationId) {
+    if (surfacingConversationIdsRef.current.has(activeConversationId)) {
       return;
     }
 
-    surfacingConversationIdRef.current = activeConversationId;
+    surfacingConversationIdsRef.current.add(activeConversationId);
     const conversation = activeConversation;
 
     void surfaceConversation(assistantId, activeConversationId)
@@ -85,7 +87,7 @@ export function useSurfaceOnOpen({
         });
       })
       .finally(() => {
-        surfacingConversationIdRef.current = null;
+        surfacingConversationIdsRef.current.delete(activeConversationId);
       });
   }, [
     activeConversation,

--- a/clients/web/src/utils/conversation-cache-mutations.test.ts
+++ b/clients/web/src/utils/conversation-cache-mutations.test.ts
@@ -18,11 +18,12 @@ import { groupsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen"
 
 import {
   adjustSectionUnreadCache,
+  applySurfacedConversation,
   markConversationSeenLocal,
   mergeListFirstPage,
   prependConversation,
   removeConversation,
-  shouldSurfaceConversationOnUserSend,
+  shouldSurfaceConversation,
   surfaceConversationInCaches,
   resolveDraftKey,
   appendGroup,
@@ -312,10 +313,10 @@ describe("removeConversation", () => {
 // surfaceConversationInCaches
 // ---------------------------------------------------------------------------
 
-describe("shouldSurfaceConversationOnUserSend", () => {
+describe("shouldSurfaceConversation", () => {
   test("allows unsurfaced scheduled and background conversations", () => {
     expect(
-      shouldSurfaceConversationOnUserSend(
+      shouldSurfaceConversation(
         makeConversation({
           conversationId: "scheduled-1",
           conversationType: "scheduled",
@@ -323,7 +324,7 @@ describe("shouldSurfaceConversationOnUserSend", () => {
       ),
     ).toBe(true);
     expect(
-      shouldSurfaceConversationOnUserSend(
+      shouldSurfaceConversation(
         makeConversation({
           conversationId: "background-1",
           conversationType: "background",
@@ -331,7 +332,7 @@ describe("shouldSurfaceConversationOnUserSend", () => {
       ),
     ).toBe(true);
     expect(
-      shouldSurfaceConversationOnUserSend(
+      shouldSurfaceConversation(
         makeConversation({
           conversationId: "legacy-scheduled-1",
           groupId: "system:scheduled",
@@ -342,12 +343,12 @@ describe("shouldSurfaceConversationOnUserSend", () => {
 
   test("skips conversations already displayed outside run buckets", () => {
     expect(
-      shouldSurfaceConversationOnUserSend(
+      shouldSurfaceConversation(
         makeConversation({ conversationId: "standard-1" }),
       ),
     ).toBe(false);
     expect(
-      shouldSurfaceConversationOnUserSend(
+      shouldSurfaceConversation(
         makeConversation({
           conversationId: "surfaced-1",
           conversationType: "scheduled",
@@ -356,7 +357,7 @@ describe("shouldSurfaceConversationOnUserSend", () => {
       ),
     ).toBe(false);
     expect(
-      shouldSurfaceConversationOnUserSend(
+      shouldSurfaceConversation(
         makeConversation({
           conversationId: "pinned-1",
           conversationType: "background",
@@ -365,7 +366,7 @@ describe("shouldSurfaceConversationOnUserSend", () => {
       ),
     ).toBe(false);
     expect(
-      shouldSurfaceConversationOnUserSend(
+      shouldSurfaceConversation(
         makeConversation({
           conversationId: "custom-1",
           conversationType: "scheduled",
@@ -374,7 +375,7 @@ describe("shouldSurfaceConversationOnUserSend", () => {
       ),
     ).toBe(false);
     expect(
-      shouldSurfaceConversationOnUserSend(
+      shouldSurfaceConversation(
         makeConversation({
           conversationId: "archived-1",
           conversationType: "background",
@@ -982,5 +983,72 @@ describe("adjustSectionUnreadCache", () => {
     adjustSectionUnreadCache(client, ASSISTANT_ID, row, 1);
 
     expect(unreadOf(client, (s) => s.kind === "group")).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applySurfacedConversation
+// ---------------------------------------------------------------------------
+
+describe("applySurfacedConversation", () => {
+  test("a background-cache row reaches the foreground at its recency position", () => {
+    const bg = makeConversation({
+      conversationId: "bg1",
+      conversationType: "background",
+      lastMessageAt: 3000,
+    });
+    seedBackground(qc, [bg]);
+    seedForeground(qc, [
+      makeConversation({ conversationId: "newer", lastMessageAt: 5000 }),
+      makeConversation({ conversationId: "older", lastMessageAt: 1000 }),
+    ]);
+
+    applySurfacedConversation(qc, ASSISTANT_ID, bg, 4242);
+
+    // Recency position, not the top: the server writes only surfaced_at on
+    // a bare surface, so nothing about the row's ordering moves.
+    expect(getForeground(qc).map((c) => c.conversationId)).toEqual([
+      "newer",
+      "bg1",
+      "older",
+    ]);
+    expect(getBackground(qc)[0].surfacedAt).toBe(4242);
+    expect(getForeground(qc)[1].surfacedAt).toBe(4242);
+  });
+
+  test("a row already in the foreground is not duplicated", () => {
+    const row = makeConversation({
+      conversationId: "c1",
+      conversationType: "scheduled",
+    });
+    seedForeground(qc, [row]);
+
+    applySurfacedConversation(qc, ASSISTANT_ID, row, 4242);
+
+    expect(getForeground(qc)).toHaveLength(1);
+    expect(getForeground(qc)[0].surfacedAt).toBe(4242);
+  });
+
+  test("the surfaced row joins its section cache through the membership pass", () => {
+    const bg = makeConversation({
+      conversationId: "bg1",
+      conversationType: "background",
+    });
+    seedBackground(qc, [bg]);
+    // Chats section contents cache: {groupId: system:all, no channel}.
+    const chatsKey = [
+      "conversation-list",
+      ASSISTANT_ID,
+      "section",
+      "system:all",
+      "vellum",
+    ] as const;
+    qc.setQueryData(chatsKey, []);
+
+    applySurfacedConversation(qc, ASSISTANT_ID, bg, 4242);
+
+    expect(
+      qc.getQueryData<Conversation[]>(chatsKey)?.map((c) => c.conversationId),
+    ).toEqual(["bg1"]);
   });
 });

--- a/clients/web/src/utils/conversation-cache-mutations.test.ts
+++ b/clients/web/src/utils/conversation-cache-mutations.test.ts
@@ -314,6 +314,20 @@ describe("removeConversation", () => {
 // ---------------------------------------------------------------------------
 
 describe("shouldSurfaceConversation", () => {
+  test("a subagent-sourced run is never surfaceable", () => {
+    // The daemon's surfaced visibility arm excludes subagent runs; a
+    // surface POST could never make one listable.
+    expect(
+      shouldSurfaceConversation(
+        makeConversation({
+          conversationId: "sub1",
+          conversationType: "background",
+          source: "subagent",
+        }),
+      ),
+    ).toBe(false);
+  });
+
   test("allows unsurfaced scheduled and background conversations", () => {
     expect(
       shouldSurfaceConversation(
@@ -1027,6 +1041,29 @@ describe("applySurfacedConversation", () => {
 
     expect(getForeground(qc)).toHaveLength(1);
     expect(getForeground(qc)[0].surfacedAt).toBe(4242);
+  });
+
+  test("a write landing mid-request is not replayed backwards by the snapshot", () => {
+    /* Mark-seen-on-open fires from the same render as the surface, so the
+       seen patch lands while the POST is out. The captured snapshot still
+       says unseen; applying it verbatim would resurrect the flag. */
+    const stale = makeConversation({
+      conversationId: "bg1",
+      conversationType: "background",
+      hasUnseenLatestAssistantMessage: true,
+    });
+    seedBackground(qc, [stale]);
+    // The mark-seen patch lands before the surface response.
+    seedBackground(qc, [{ ...stale, hasUnseenLatestAssistantMessage: false }]);
+    seedForeground(qc, []);
+
+    applySurfacedConversation(qc, ASSISTANT_ID, stale, 4242);
+
+    expect(getForeground(qc)[0]).toMatchObject({
+      conversationId: "bg1",
+      hasUnseenLatestAssistantMessage: false,
+      surfacedAt: 4242,
+    });
   });
 
   test("the surfaced row joins its section cache through the membership pass", () => {

--- a/clients/web/src/utils/conversation-cache-mutations.ts
+++ b/clients/web/src/utils/conversation-cache-mutations.ts
@@ -23,8 +23,10 @@ import {
   isScheduledConversation,
 } from "@/utils/conversation-predicates";
 import { matchesIndexBucket } from "@/utils/section-membership";
+import { insertByRecency } from "@/utils/conversation-order";
 import {
   findConversation,
+  patchConversation,
   updateAllConversationCaches,
   updateBackgroundConversationsCache,
   updateConversationsCache,
@@ -189,9 +191,7 @@ export function removeConversation(
   updateAllConversationCaches(queryClient, assistantId, drop);
 }
 
-export function shouldSurfaceConversationOnUserSend(
-  conversation: Conversation,
-): boolean {
+export function shouldSurfaceConversation(conversation: Conversation): boolean {
   if (conversation.archivedAt != null) {
     return false;
   }
@@ -211,6 +211,37 @@ export function shouldSurfaceConversationOnUserSend(
     isScheduledConversation(conversation) ||
     isBackgroundConversation(conversation)
   );
+}
+
+/**
+ * Write a just-surfaced conversation into the caches for the open path.
+ *
+ * Differs from {@link surfaceConversationInCaches} (the send path) on the
+ * two axes where a bare surface differs from a send: the server writes only
+ * `surfaced_at` on surface, so neither `lastMessageAt` nor `groupId` moves,
+ * and the row takes its recency position rather than the top of the list.
+ *
+ * The row reaches the foreground cache if no list held it yet (a background
+ * run opened from the activity feed lives in the background cache at most),
+ * because the foreground cache is the standard listing and a surfaced row
+ * belongs to it. Section membership and the index stub ride
+ * `patchConversation`, which `surfacedAt` triggers as a membership field.
+ */
+export function applySurfacedConversation(
+  queryClient: QueryClient,
+  assistantId: string | null,
+  conversation: Conversation,
+  surfacedAt: number,
+): void {
+  const surfaced: Conversation = { ...conversation, surfacedAt };
+  updateConversationsCache(queryClient, assistantId, (conversations) =>
+    conversations.some((c) => c.conversationId === conversation.conversationId)
+      ? conversations
+      : insertByRecency(conversations, surfaced),
+  );
+  patchConversation(queryClient, assistantId, conversation.conversationId, {
+    surfacedAt,
+  });
 }
 
 export function surfaceConversationInCaches(

--- a/clients/web/src/utils/conversation-cache-mutations.ts
+++ b/clients/web/src/utils/conversation-cache-mutations.ts
@@ -195,6 +195,13 @@ export function shouldSurfaceConversation(conversation: Conversation): boolean {
   if (conversation.archivedAt != null) {
     return false;
   }
+  /* The daemon's surfaced visibility arm excludes subagent runs, so a
+     surface can never make one listable; firing it would insert a row the
+     next refetch drops. Mirrors `isSidebarVisible` and
+     `surfacedVisibilitySql`. */
+  if (conversation.source === "subagent") {
+    return false;
+  }
   if (conversation.surfacedAt != null) {
     return false;
   }
@@ -233,7 +240,17 @@ export function applySurfacedConversation(
   conversation: Conversation,
   surfacedAt: number,
 ): void {
-  const surfaced: Conversation = { ...conversation, surfacedAt };
+  /* The caller captured `conversation` before its POST left, and other
+     writes land while the request is out: mark-seen-on-open fires from the
+     same render and patches the row's seen state. Inserting the captured
+     snapshot would replay those fields backwards, and the membership pass
+     would spread the resurrected values into every section cache. The
+     freshest cached row wins; the snapshot is only the fallback when no
+     cache holds the row at all. */
+  const latest =
+    findConversation(queryClient, assistantId, conversation.conversationId) ??
+    conversation;
+  const surfaced: Conversation = { ...latest, surfacedAt };
   updateConversationsCache(queryClient, assistantId, (conversations) =>
     conversations.some((c) => c.conversationId === conversation.conversationId)
       ? conversations


### PR DESCRIPTION
## TL;DR

Opening is the promotion. Background/scheduled runs stay out of the sidebar as noise by design — and a run the user chooses to open stops being noise: it now surfaces on open, appears in the sidebar highlighted as active, and stays there. Until now only *sending a message* promoted, so a run opened from the activity feed rendered a chat with no corresponding sidebar row. This was LUM-2443's explicitly decided behavior, confirmed by Ashlee this session, never built.

Fixes LUM-3221. Part of LUM-2443.

## Design

- **`useSurfaceOnOpen`** mounts beside `useMarkSeenOnOpen` on the same active-conversation resolution (which already fetches the row on demand, so a run opened from the feed is resolvable before any sidebar section loaded it).
- **Server-first, like the send path**: the POST carries the authoritative `surfacedAt`, caches are written only from the response, so failure needs no rollback — just a released guard so the next effect evaluation retries. An in-flight guard blocks duplicates under prop-identity churn.
- **One eligibility predicate for both entry points**: `shouldSurfaceConversationOnUserSend` renamed to `shouldSurfaceConversation`, now gating send and open alike, so the two promotions cannot drift. Pinned/filed runs fire nothing (the placement write already stamped `surfaced_at` server-side — verified in `batchSetConversationPlacement` earlier in this arc).
- **The open-path cache write differs from the send one on exactly the axes where a bare surface differs from a send** (verified against the daemon: `setConversationSurfaced` writes `surfaced_at` and `updated_at` only): neither `lastMessageAt` nor `groupId` moves, so the row takes its *recency position* in the foreground list rather than the top. Section membership and the index stub ride `patchConversation`, which `surfacedAt` triggers as a membership field — meaning this path goes through the modern placement seam rather than the send path's older direct-write helper.

## What this unlocks

The background/scheduled machinery deletion (`reconcile-attention-keys` force-activation, the merged backlog buckets): its one legitimate purpose — making an attention-flagged hidden conversation reachable — is subsumed by open-time promotion. That deletion is the next PR, kept separate because it's behavioral removal deserving its own review.

## Why it is safe

- The surface endpoint predates this arc and the send path already calls it ungated; the daemon publishes list+metadata sync on it, so other clients converge as they always have.
- Everything already visible (surfaced, standard, pinned, grouped) fires nothing — four eligibility tests plus the shared-predicate rename keep that tight.
- A failed POST changes nothing locally and retries on the next open.

## Testing

Local test runs are blocked on this machine; CI is the verifier. Fixtures hand-traced first:

- `use-surface-on-open.test.tsx`: surfaces once with the server's timestamp; re-render does not refire; already-surfaced/standard/pinned/filed fire nothing; failure leaves caches untouched and retries; a pending request blocks duplicates under identity churn.
- `applySurfacedConversation` (in the mutations suite): a background-cache row reaches the foreground at its recency position (not the top — asserts ordering across three rows); no duplication when already present; the surfaced row joins its section-contents cache through the membership pass.
- Predicate rename covered by the existing eligibility describe, renamed with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40601" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->