### PR TITLE
refactor(web): delete the background/scheduled sidebar machinery (LUM-3222)

### DIFF
--- a/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -78,20 +78,6 @@ mock.module(
   (): Partial<typeof ConversationQueries> => ({
     /* Feature-off: these tests exercise the derived-discovery path. */
     useSidebarSectionsQuery: () => null,
-    useBackgroundConversationListQuery: () => ({
-      conversations: [],
-      isLoading: false,
-      isPending: false,
-      isError: false,
-      refetch: () => {},
-    }),
-    useScheduledConversationListQuery: () => ({
-      conversations: [],
-      isLoading: false,
-      isPending: false,
-      isError: false,
-      refetch: () => {},
-    }),
     useSectionConversationListQuery: (
       _assistantId: string | null,
       filter: { groupId?: string; originChannel?: string },

--- a/clients/web/src/domains/chat/hooks/use-attention-tracking.ts
+++ b/clients/web/src/domains/chat/hooks/use-attention-tracking.ts
@@ -231,7 +231,7 @@ export function useAttentionTracking({
     if (!assistantId || cause === "fresh") {
       return;
     }
-    void reconcileAttentionKeys(assistantId, queryClient, {
+    void reconcileAttentionKeys(assistantId, {
       pruneStale: true,
     });
   });
@@ -252,6 +252,6 @@ export function useAttentionTracking({
     }
     initialAttentionSweepDoneRef.current = true;
 
-    void reconcileAttentionKeys(assistantId, queryClient);
+    void reconcileAttentionKeys(assistantId);
   }, [assistantId, conversations, queryClient]);
 }

--- a/clients/web/src/domains/chat/hooks/use-attention-tracking.ts
+++ b/clients/web/src/domains/chat/hooks/use-attention-tracking.ts
@@ -1,5 +1,4 @@
 import { useEffect, useRef } from "react";
-import { useQueryClient } from "@tanstack/react-query";
 
 import { useConversationStore } from "@/stores/conversation-store";
 import { useConversationListQuery } from "@/hooks/conversation-queries";
@@ -51,7 +50,6 @@ export function useAttentionTracking({
   assistantId,
   assistantStateKind,
 }: UseAttentionTrackingParams) {
-  const queryClient = useQueryClient();
   const { conversations } = useConversationListQuery(
     assistantId,
     assistantStateKind === "active",
@@ -253,5 +251,5 @@ export function useAttentionTracking({
     initialAttentionSweepDoneRef.current = true;
 
     void reconcileAttentionKeys(assistantId);
-  }, [assistantId, conversations, queryClient]);
+  }, [assistantId, conversations]);
 }

--- a/clients/web/src/domains/chat/sidebar-layout-store.test.ts
+++ b/clients/web/src/domains/chat/sidebar-layout-store.test.ts
@@ -9,8 +9,6 @@ function resetStore() {
     openCategories: [],
     openCustomGroups: [],
     openPrimary: ["pinned", "recents"],
-    backgroundActivated: false,
-    scheduledActivated: false,
   });
 }
 
@@ -147,101 +145,6 @@ describe("SidebarLayoutStore", () => {
   });
 });
 
-describe("SidebarLayoutStore - independent lazy-section activation", () => {
-  test("both activation flags default to false", () => {
-    const state = useSidebarLayoutStore.getState();
-    expect(state.backgroundActivated).toBe(false);
-    expect(state.scheduledActivated).toBe(false);
-  });
-
-  test("activateBackground reveals Background without activating Scheduled", () => {
-    /**
-     * The Background and Scheduled lists are separate lazy queries;
-     * revealing one must never trigger the other's fetch.
-     */
-
-    // WHEN only the Background section is revealed
-    useSidebarLayoutStore.getState().activateBackground();
-
-    // THEN Background is activated and Scheduled stays dormant
-    const state = useSidebarLayoutStore.getState();
-    expect(state.backgroundActivated).toBe(true);
-    expect(state.scheduledActivated).toBe(false);
-  });
-
-  test("activateScheduled reveals Scheduled without activating Background", () => {
-    /**
-     * The mirror case: revealing Scheduled leaves Background dormant.
-     */
-
-    // WHEN only the Scheduled section is revealed
-    useSidebarLayoutStore.getState().activateScheduled();
-
-    // THEN Scheduled is activated and Background stays dormant
-    const state = useSidebarLayoutStore.getState();
-    expect(state.scheduledActivated).toBe(true);
-    expect(state.backgroundActivated).toBe(false);
-  });
-
-  test("expanding the Background category activates only Background", () => {
-    /**
-     * Expanding a section in the full sidebar counts as a reveal, but it
-     * must activate that section's query alone.
-     */
-
-    // GIVEN an assistant is selected
-    useSidebarLayoutStore.getState().setAssistantId("asst-1");
-
-    // WHEN the Background category is expanded
-    useSidebarLayoutStore.getState().setOpenCategories(["background"]);
-
-    // THEN only Background is activated
-    const state = useSidebarLayoutStore.getState();
-    expect(state.backgroundActivated).toBe(true);
-    expect(state.scheduledActivated).toBe(false);
-  });
-
-  test("setAssistantId hydrates each activation flag from persisted categories independently", () => {
-    /**
-     * A persisted open section counts as a reveal on load, but only for
-     * the section that was actually left open.
-     */
-
-    // GIVEN only Scheduled was persisted as open for this assistant
-    localStorage.setItem(
-      "vellum:sidebar-open-categories:asst-1",
-      JSON.stringify(["scheduled"]),
-    );
-
-    // WHEN the assistant is selected
-    useSidebarLayoutStore.getState().setAssistantId("asst-1");
-
-    // THEN Scheduled activates from storage and Background stays dormant
-    const state = useSidebarLayoutStore.getState();
-    expect(state.scheduledActivated).toBe(true);
-    expect(state.backgroundActivated).toBe(false);
-  });
-
-  test("switching assistant resets activation flags for the new assistant", () => {
-    /**
-     * Activation is per session and per assistant: a section revealed on
-     * one assistant must not leak its lazy fetch onto the next.
-     */
-
-    // GIVEN Background was revealed on the first assistant
-    useSidebarLayoutStore.getState().setAssistantId("asst-1");
-    useSidebarLayoutStore.getState().activateBackground();
-    expect(useSidebarLayoutStore.getState().backgroundActivated).toBe(true);
-
-    // WHEN switching to a second assistant with nothing persisted
-    useSidebarLayoutStore.getState().setAssistantId("asst-2");
-
-    // THEN both activation flags reset for the new assistant
-    const state = useSidebarLayoutStore.getState();
-    expect(state.backgroundActivated).toBe(false);
-    expect(state.scheduledActivated).toBe(false);
-  });
-
-  // The view mode is deliberately not held here: it reads from storage
-  // directly so it survives the first paint. See sidebar-view-mode.test.ts.
-});
+// The view mode is deliberately not held in this store: it reads from
+// storage directly so it survives the first paint. See
+// sidebar-view-mode.test.ts.

--- a/clients/web/src/domains/chat/sidebar-layout-store.test.ts
+++ b/clients/web/src/domains/chat/sidebar-layout-store.test.ts
@@ -28,7 +28,7 @@ describe("SidebarLayoutStore", () => {
   test("setAssistantId hydrates from localStorage", () => {
     localStorage.setItem(
       "vellum:sidebar-open-categories:asst-1",
-      JSON.stringify(["scheduled", "background"]),
+      JSON.stringify([channelSectionKey("slack"), channelSectionKey("email")]),
     );
     localStorage.setItem(
       "vellum:sidebar-open-custom-groups:asst-1",
@@ -39,18 +39,38 @@ describe("SidebarLayoutStore", () => {
 
     const state = useSidebarLayoutStore.getState();
     expect(state.assistantId).toBe("asst-1");
-    expect(state.openCategories).toEqual(["scheduled", "background"]);
+    expect(state.openCategories).toEqual([
+      channelSectionKey("slack"),
+      channelSectionKey("email"),
+    ]);
     expect(state.openCustomGroups).toEqual(["grp-abc"]);
   });
 
-  test("setAssistantId no-ops when assistantId is unchanged", () => {
-    useSidebarLayoutStore.getState().setAssistantId("asst-1");
-    useSidebarLayoutStore.getState().setOpenCategories(["scheduled"]);
+  test("legacy background/scheduled open-keys are dropped at hydration", () => {
+    // No section carries those keys; loading filters them, and the next
+    // save rewrites storage without them.
+    localStorage.setItem(
+      "vellum:sidebar-open-categories:asst-1",
+      JSON.stringify(["background", "scheduled", channelSectionKey("slack")]),
+    );
 
     useSidebarLayoutStore.getState().setAssistantId("asst-1");
 
     expect(useSidebarLayoutStore.getState().openCategories).toEqual([
-      "scheduled",
+      channelSectionKey("slack"),
+    ]);
+  });
+
+  test("setAssistantId no-ops when assistantId is unchanged", () => {
+    useSidebarLayoutStore.getState().setAssistantId("asst-1");
+    useSidebarLayoutStore
+      .getState()
+      .setOpenCategories([channelSectionKey("slack")]);
+
+    useSidebarLayoutStore.getState().setAssistantId("asst-1");
+
+    expect(useSidebarLayoutStore.getState().openCategories).toEqual([
+      channelSectionKey("slack"),
     ]);
   });
 
@@ -58,13 +78,12 @@ describe("SidebarLayoutStore", () => {
     useSidebarLayoutStore.getState().setAssistantId("asst-1");
     useSidebarLayoutStore
       .getState()
-      .setOpenCategories(["scheduled", "background"]);
+      .setOpenCategories([channelSectionKey("slack")]);
 
     const raw = localStorage.getItem("vellum:sidebar-open-categories:asst-1");
-    expect(JSON.parse(raw!)).toEqual(["scheduled", "background"]);
+    expect(JSON.parse(raw!)).toEqual([channelSectionKey("slack")]);
     expect(useSidebarLayoutStore.getState().openCategories).toEqual([
-      "scheduled",
-      "background",
+      channelSectionKey("slack"),
     ]);
   });
 
@@ -81,21 +100,20 @@ describe("SidebarLayoutStore", () => {
   test("switching assistant re-hydrates from new assistant's storage", () => {
     localStorage.setItem(
       "vellum:sidebar-open-categories:asst-1",
-      JSON.stringify(["scheduled"]),
+      JSON.stringify([channelSectionKey("email")]),
     );
     localStorage.setItem(
       "vellum:sidebar-open-categories:asst-2",
-      JSON.stringify(["background", channelSectionKey("slack")]),
+      JSON.stringify([channelSectionKey("slack")]),
     );
 
     useSidebarLayoutStore.getState().setAssistantId("asst-1");
     expect(useSidebarLayoutStore.getState().openCategories).toEqual([
-      "scheduled",
+      channelSectionKey("email"),
     ]);
 
     useSidebarLayoutStore.getState().setAssistantId("asst-2");
     expect(useSidebarLayoutStore.getState().openCategories).toEqual([
-      "background",
       channelSectionKey("slack"),
     ]);
   });
@@ -109,10 +127,12 @@ describe("SidebarLayoutStore", () => {
   });
 
   test("setOpenCategories does not persist when no assistantId is set", () => {
-    useSidebarLayoutStore.getState().setOpenCategories(["scheduled"]);
+    useSidebarLayoutStore
+      .getState()
+      .setOpenCategories([channelSectionKey("slack")]);
 
     expect(useSidebarLayoutStore.getState().openCategories).toEqual([
-      "scheduled",
+      channelSectionKey("slack"),
     ]);
     expect(localStorage.length).toBe(0);
   });

--- a/clients/web/src/domains/chat/sidebar-layout-store.ts
+++ b/clients/web/src/domains/chat/sidebar-layout-store.ts
@@ -7,7 +7,7 @@
  *
  * **Storage model:**
  *
- * - Built-in collapsible categories (scheduled, background, slack)
+ * - Built-in collapsible categories (the per-channel sections)
  *   and custom groups are stored as two separate `string[]` values,
  *   keyed per assistant. This mirrors the Radix Accordion `value` prop
  *   for `type="multiple"`.
@@ -58,21 +58,6 @@ export interface SidebarLayoutState {
    * `mergeSectionOrder`.
    */
   sectionOrder: string[];
-  /**
-   * Whether the user has revealed the Background section this session -
-   * either by expanding it in the full sidebar or opening its rail flyout.
-   * Gates the lazy background conversation fetch so it never runs on the
-   * initial load path. Transient (not persisted) and reset when the active
-   * assistant changes.
-   */
-  backgroundActivated: boolean;
-  /**
-   * Whether the user has revealed the Scheduled section this session.
-   * Tracked independently from `backgroundActivated` so revealing one
-   * section never triggers the other section's lazy fetch - the Scheduled
-   * and Background lists are separate queries.
-   */
-  scheduledActivated: boolean;
 }
 
 export interface SidebarLayoutActions {
@@ -81,12 +66,9 @@ export interface SidebarLayoutActions {
   setOpenCustomGroups: (next: string[]) => void;
   setOpenPrimary: (next: string[]) => void;
   setSectionOrder: (next: string[]) => void;
-  activateBackground: () => void;
-  activateScheduled: () => void;
 }
 
-export type SidebarLayoutStore = SidebarLayoutState &
-  SidebarLayoutActions;
+export type SidebarLayoutStore = SidebarLayoutState & SidebarLayoutActions;
 
 // ---------------------------------------------------------------------------
 // Initial state
@@ -100,91 +82,59 @@ const INITIAL_STATE: SidebarLayoutState = {
   // setAssistantId.
   openPrimary: [...PRIMARY_SECTION_KEYS],
   sectionOrder: [],
-  backgroundActivated: false,
-  scheduledActivated: false,
 };
 
 // ---------------------------------------------------------------------------
 // Store
 // ---------------------------------------------------------------------------
 
-const useSidebarLayoutStoreBase = create<SidebarLayoutStore>()(
-  (set, get) => ({
-    ...INITIAL_STATE,
+const useSidebarLayoutStoreBase = create<SidebarLayoutStore>()((set, get) => ({
+  ...INITIAL_STATE,
 
-    setAssistantId: (assistantId: string) => {
-      if (get().assistantId === assistantId) {
-        return;
-      }
-      const openCategories = loadOpenCategories(assistantId);
-      set({
-        assistantId,
-        openCategories,
-        openCustomGroups: loadOpenCustomGroups(assistantId),
-        openPrimary: loadOpenPrimary(assistantId),
-        sectionOrder: loadSectionOrder(assistantId),
-        // A persisted expanded section counts as a reveal, so each lazy
-        // fetch resumes for assistants the user already had that section
-        // open on - tracked per section so they stay independent.
-        backgroundActivated: openCategories.includes("background"),
-        scheduledActivated: openCategories.includes("scheduled"),
-      });
-    },
+  setAssistantId: (assistantId: string) => {
+    if (get().assistantId === assistantId) {
+      return;
+    }
+    set({
+      assistantId,
+      openCategories: loadOpenCategories(assistantId),
+      openCustomGroups: loadOpenCustomGroups(assistantId),
+      openPrimary: loadOpenPrimary(assistantId),
+      sectionOrder: loadSectionOrder(assistantId),
+    });
+  },
 
-    setOpenCategories: (next: string[]) => {
-      set((prev) => ({
-        openCategories: next,
-        backgroundActivated:
-          prev.backgroundActivated || next.includes("background"),
-        scheduledActivated:
-          prev.scheduledActivated || next.includes("scheduled"),
-      }));
-      const { assistantId } = get();
-      if (assistantId) {
-        saveOpenCategories(assistantId, next);
-      }
-    },
+  setOpenCategories: (next: string[]) => {
+    set({ openCategories: next });
+    const { assistantId } = get();
+    if (assistantId) {
+      saveOpenCategories(assistantId, next);
+    }
+  },
 
-    setOpenCustomGroups: (next: string[]) => {
-      set({ openCustomGroups: next });
-      const { assistantId } = get();
-      if (assistantId) {
-        saveOpenCustomGroups(assistantId, next);
-      }
-    },
+  setOpenCustomGroups: (next: string[]) => {
+    set({ openCustomGroups: next });
+    const { assistantId } = get();
+    if (assistantId) {
+      saveOpenCustomGroups(assistantId, next);
+    }
+  },
 
-    setOpenPrimary: (next: string[]) => {
-      set({ openPrimary: next });
-      const { assistantId } = get();
-      if (assistantId) {
-        saveOpenPrimary(assistantId, next);
-      }
-    },
+  setOpenPrimary: (next: string[]) => {
+    set({ openPrimary: next });
+    const { assistantId } = get();
+    if (assistantId) {
+      saveOpenPrimary(assistantId, next);
+    }
+  },
 
-    setSectionOrder: (next: string[]) => {
-      set({ sectionOrder: next });
-      const { assistantId } = get();
-      if (assistantId) {
-        saveSectionOrder(assistantId, next);
-      }
-    },
+  setSectionOrder: (next: string[]) => {
+    set({ sectionOrder: next });
+    const { assistantId } = get();
+    if (assistantId) {
+      saveSectionOrder(assistantId, next);
+    }
+  },
+}));
 
-    activateBackground: () => {
-      if (get().backgroundActivated) {
-        return;
-      }
-      set({ backgroundActivated: true });
-    },
-
-    activateScheduled: () => {
-      if (get().scheduledActivated) {
-        return;
-      }
-      set({ scheduledActivated: true });
-    },
-  }),
-);
-
-export const useSidebarLayoutStore = createSelectors(
-  useSidebarLayoutStoreBase,
-);
+export const useSidebarLayoutStore = createSelectors(useSidebarLayoutStoreBase);

--- a/clients/web/src/domains/chat/use-sidebar-state.test.tsx
+++ b/clients/web/src/domains/chat/use-sidebar-state.test.tsx
@@ -9,10 +9,7 @@ import { useSidebarLayoutStore } from "@/domains/chat/sidebar-layout-store";
    the dynamic `import` below is still what supplies the implementation. */
 import type { SidebarState } from "@/domains/chat/use-sidebar-state";
 
-/* The Background/Scheduled sections own their lazy queries; stub both so the
-   hook resolves without a QueryClient.
-
-   No section query is stubbed here: each section fetches its own rows where
+/* No section query is stubbed here: each section fetches its own rows where
    it renders (`useSectionConversations`). What this hook owns is the section
    *list* and the derived fallback rows, which is what these tests cover. */
 /* Controls the stubbed section index per test. `null` is the feature-off
@@ -24,20 +21,6 @@ mock.module(
   "@/hooks/conversation-queries",
   (): Partial<typeof ConversationQueries> => ({
     useSidebarSectionsQuery: () => sidebarSectionsImpl,
-    useBackgroundConversationListQuery: () => ({
-      conversations: [],
-      isLoading: false,
-      isPending: false,
-      isError: false,
-      refetch: () => {},
-    }),
-    useScheduledConversationListQuery: () => ({
-      conversations: [],
-      isLoading: false,
-      isPending: false,
-      isError: false,
-      refetch: () => {},
-    }),
   }),
 );
 

--- a/clients/web/src/domains/chat/use-sidebar-state.ts
+++ b/clients/web/src/domains/chat/use-sidebar-state.ts
@@ -67,12 +67,7 @@ import {
   useViewMode,
   type SidebarViewMode,
 } from "@/domains/chat/utils/sidebar-view-mode";
-import { mergeConversationLists } from "@/utils/conversation-cache";
-import {
-  useBackgroundConversationListQuery,
-  useScheduledConversationListQuery,
-  useSidebarSectionsQuery,
-} from "@/hooks/conversation-queries";
+import { useSidebarSectionsQuery } from "@/hooks/conversation-queries";
 import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
 import { getChannelLabel } from "@/utils/channel-presentation";
 import { RECENTS_SECTION_LABEL } from "@/domains/chat/utils/sidebar-section-icon";
@@ -232,58 +227,21 @@ export function useSidebarState({
     },
     [assistantId],
   );
-  const backgroundActivated = useSidebarLayoutStore.use.backgroundActivated();
-  const scheduledActivated = useSidebarLayoutStore.use.scheduledActivated();
-  const collapseAssistantId = useSidebarLayoutStore.use.assistantId();
-
-  // Background and scheduled jobs each load through their own lazy query,
-  // co-located here with the sections that toggle them. A query is enabled
-  // only once its section is revealed (`backgroundActivated` /
-  // `scheduledActivated`) and the collapse store has synced to the current
-  // assistant — so neither backlog touches the initial-load critical path,
-  // and revealing one section never pulls in the other. The activation flags
-  // briefly hold the previous assistant's values on a switch; gating on the
-  // sync guard stops a stale flag from fetching the new assistant's backlog
-  // on its first render.
-  const collapseSynced = collapseAssistantId === assistantId;
-  const backgroundReady = backgroundActivated && collapseSynced;
-  const scheduledReady = scheduledActivated && collapseSynced;
-  const { conversations: backgroundConversations } =
-    useBackgroundConversationListQuery(
-      assistantId,
-      isAssistantActive && backgroundReady,
-    );
-  const { conversations: scheduledConversations } =
-    useScheduledConversationListQuery(
-      assistantId,
-      isAssistantActive && scheduledReady,
-    );
-
   /* The daemon's section index: which sections exist and what their badges
      say, with no conversation rows. `null` when the assistant predates the
      endpoint or the read has not resolved, in which case existence keeps
      deriving from the loaded list below. */
   const indexSections = useSidebarSectionsQuery(assistantId, isAssistantActive);
 
-  const allConversations = useMemo(
-    () =>
-      mergeConversationLists(
-        conversations,
-        backgroundConversations,
-        scheduledConversations,
-      ),
-    [conversations, backgroundConversations, scheduledConversations],
-  );
-
   // --- Grouping (memoized per conversations reference) ---
 
   const grouped = useMemo(
     () =>
-      groupConversations(allConversations, {
+      groupConversations(conversations, {
         groups: conversationGroups,
         groupByChannel: viewMode === "grouped",
       }),
-    [allConversations, conversationGroups, viewMode],
+    [conversations, conversationGroups, viewMode],
   );
 
   // --- Section order ---
@@ -496,8 +454,7 @@ export function useSidebarState({
   // --- Open/closed state ---
 
   // The three storage buckets exist because they have different defaults
-  // (Pinned/Chats open, the rest closed) and because `setOpenCategories` owns
-  // the lazy-fetch activation side effects. That split is a *storage* concern:
+  // (Pinned/Chats open, the rest closed). That split is a *storage* concern:
   // every section shares one accordion root, so reads merge the buckets into
   // one value array and writes route each key back to its owner.
   const storedOpenSections = useMemo(

--- a/clients/web/src/domains/chat/utils/reconcile-attention-keys.test.ts
+++ b/clients/web/src/domains/chat/utils/reconcile-attention-keys.test.ts
@@ -5,25 +5,18 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { QueryClient } from "@tanstack/react-query";
 
 import { useConversationStore } from "@/stores/conversation-store";
-import { useSidebarLayoutStore } from "@/domains/chat/sidebar-layout-store";
 
 // ---------------------------------------------------------------------------
 // Module mocks
 // ---------------------------------------------------------------------------
 
 let pendingKeysImpl: () => Promise<Set<string>> = async () => new Set();
-let conversationsImpl: Array<{ conversationId: string }> = [];
 
 mock.module("@/domains/chat/api/interactions", () => ({
   listConversationIdsWithPendingInteractions: (_assistantId: string) =>
     pendingKeysImpl(),
-}));
-
-mock.module("@/utils/conversation-cache", () => ({
-  getConversations: () => conversationsImpl,
 }));
 
 const { reconcileAttentionKeys } =
@@ -33,13 +26,9 @@ const { reconcileAttentionKeys } =
 // Helpers
 // ---------------------------------------------------------------------------
 
-let queryClient: QueryClient;
-
 beforeEach(() => {
-  queryClient = new QueryClient();
   useConversationStore.getState().reset();
   pendingKeysImpl = async () => new Set();
-  conversationsImpl = [];
 });
 
 afterEach(() => {
@@ -49,12 +38,8 @@ afterEach(() => {
 describe("reconcileAttentionKeys", () => {
   test("adds pending keys to attention set", async () => {
     pendingKeysImpl = async () => new Set(["conv-1", "conv-2"]);
-    conversationsImpl = [
-      { conversationId: "conv-1" },
-      { conversationId: "conv-2" },
-    ];
 
-    await reconcileAttentionKeys("asst-1", queryClient);
+    await reconcileAttentionKeys("asst-1");
 
     const state = useConversationStore.getState();
     expect(state.attentionConversationIds.has("conv-1")).toBe(true);
@@ -64,12 +49,8 @@ describe("reconcileAttentionKeys", () => {
   test("skips the active conversation", async () => {
     useConversationStore.getState().setActiveConversationId("conv-active");
     pendingKeysImpl = async () => new Set(["conv-active", "conv-other"]);
-    conversationsImpl = [
-      { conversationId: "conv-active" },
-      { conversationId: "conv-other" },
-    ];
 
-    await reconcileAttentionKeys("asst-1", queryClient);
+    await reconcileAttentionKeys("asst-1");
 
     const state = useConversationStore.getState();
     expect(state.attentionConversationIds.has("conv-active")).toBe(false);
@@ -79,9 +60,8 @@ describe("reconcileAttentionKeys", () => {
   test("does not duplicate keys already in attention", async () => {
     useConversationStore.getState().addAttentionConversationId("conv-1");
     pendingKeysImpl = async () => new Set(["conv-1"]);
-    conversationsImpl = [{ conversationId: "conv-1" }];
 
-    await reconcileAttentionKeys("asst-1", queryClient);
+    await reconcileAttentionKeys("asst-1");
 
     const state = useConversationStore.getState();
     expect(state.attentionConversationIds.has("conv-1")).toBe(true);
@@ -90,9 +70,8 @@ describe("reconcileAttentionKeys", () => {
   test("does not add keys already in processing set", async () => {
     useConversationStore.getState().addProcessingConversationId("conv-1");
     pendingKeysImpl = async () => new Set(["conv-1"]);
-    conversationsImpl = [{ conversationId: "conv-1" }];
 
-    await reconcileAttentionKeys("asst-1", queryClient);
+    await reconcileAttentionKeys("asst-1");
 
     const state = useConversationStore.getState();
     // Stays in processing, not duplicated to attention.
@@ -104,12 +83,8 @@ describe("reconcileAttentionKeys", () => {
     useConversationStore.getState().addAttentionConversationId("conv-stale");
     useConversationStore.getState().addAttentionConversationId("conv-valid");
     pendingKeysImpl = async () => new Set(["conv-valid"]);
-    conversationsImpl = [
-      { conversationId: "conv-stale" },
-      { conversationId: "conv-valid" },
-    ];
 
-    await reconcileAttentionKeys("asst-1", queryClient, { pruneStale: true });
+    await reconcileAttentionKeys("asst-1", { pruneStale: true });
 
     const state = useConversationStore.getState();
     expect(state.attentionConversationIds.has("conv-stale")).toBe(false);
@@ -119,9 +94,8 @@ describe("reconcileAttentionKeys", () => {
   test("with pruneStale: promotes processing keys that are still pending", async () => {
     useConversationStore.getState().addProcessingConversationId("conv-promote");
     pendingKeysImpl = async () => new Set(["conv-promote"]);
-    conversationsImpl = [{ conversationId: "conv-promote" }];
 
-    await reconcileAttentionKeys("asst-1", queryClient, { pruneStale: true });
+    await reconcileAttentionKeys("asst-1", { pruneStale: true });
 
     const state = useConversationStore.getState();
     expect(state.attentionConversationIds.has("conv-promote")).toBe(true);
@@ -132,23 +106,12 @@ describe("reconcileAttentionKeys", () => {
     useConversationStore.getState().setActiveConversationId("conv-active");
     useConversationStore.getState().addAttentionConversationId("conv-active");
     pendingKeysImpl = async () => new Set(); // active is NOT pending
-    conversationsImpl = [{ conversationId: "conv-active" }];
 
-    await reconcileAttentionKeys("asst-1", queryClient, { pruneStale: true });
+    await reconcileAttentionKeys("asst-1", { pruneStale: true });
 
     const state = useConversationStore.getState();
     // Active key is preserved even though it's not in the pending set.
     expect(state.attentionConversationIds.has("conv-active")).toBe(true);
-  });
-
-  test("reveals lazy sidebar sections when pending key is not loaded", async () => {
-    pendingKeysImpl = async () => new Set(["conv-unloaded"]);
-    // conv-unloaded is NOT in the conversations list (not loaded).
-    conversationsImpl = [{ conversationId: "conv-other" }];
-
-    await reconcileAttentionKeys("asst-1", queryClient);
-
-    expect(useSidebarLayoutStore.getState().backgroundActivated).toBe(true);
   });
 
   test("silently no-ops when the fetch throws", async () => {
@@ -157,7 +120,7 @@ describe("reconcileAttentionKeys", () => {
       throw new Error("network failure");
     };
 
-    await reconcileAttentionKeys("asst-1", queryClient, { pruneStale: true });
+    await reconcileAttentionKeys("asst-1", { pruneStale: true });
 
     // State unchanged — the function returned early.
     const state = useConversationStore.getState();

--- a/clients/web/src/domains/chat/utils/reconcile-attention-keys.ts
+++ b/clients/web/src/domains/chat/utils/reconcile-attention-keys.ts
@@ -1,27 +1,5 @@
-import type { QueryClient } from "@tanstack/react-query";
-
 import { useConversationStore } from "@/stores/conversation-store";
-import { getConversations } from "@/utils/conversation-cache";
 import { listConversationIdsWithPendingInteractions } from "@/domains/chat/api/interactions";
-import { useSidebarLayoutStore } from "@/domains/chat/sidebar-layout-store";
-
-/**
- * Reveal lazy sidebar sections (Background / Scheduled) when a pending
- * interaction belongs to a conversation not yet loaded.
- */
-function revealLazySectionsIfPendingUnloaded(
-  pendingKeys: ReadonlySet<string>,
-  loadedConversationIds: ReadonlySet<string>,
-): void {
-  for (const key of pendingKeys) {
-    if (!loadedConversationIds.has(key)) {
-      const store = useSidebarLayoutStore.getState();
-      store.activateBackground();
-      store.activateScheduled();
-      return;
-    }
-  }
-}
 
 /**
  * Reconcile attention and processing keys against the daemon's pending
@@ -37,7 +15,6 @@ function revealLazySectionsIfPendingUnloaded(
  */
 export async function reconcileAttentionKeys(
   assistantId: string,
-  queryClient: QueryClient,
   opts: { pruneStale: boolean } = { pruneStale: false },
 ): Promise<void> {
   let pendingKeys: Set<string>;
@@ -46,11 +23,6 @@ export async function reconcileAttentionKeys(
   } catch {
     return; // Best-effort — SSE events will catch subsequent transitions.
   }
-
-  const currentConversations = getConversations(queryClient, assistantId);
-  const loadedIds = new Set(currentConversations.map((c) => c.conversationId));
-
-  revealLazySectionsIfPendingUnloaded(pendingKeys, loadedIds);
 
   // Read activeConversationId AFTER the await so we use the current
   // value, not one captured before the network call.

--- a/clients/web/src/domains/chat/utils/sidebar-group-collapse-storage.test.ts
+++ b/clients/web/src/domains/chat/utils/sidebar-group-collapse-storage.test.ts
@@ -36,20 +36,22 @@ describe("loadOpenCategories", () => {
   test("returns the stored categories when present", () => {
     memoryStorage.setItem(
       STORAGE_KEY,
-      JSON.stringify(["scheduled", "background"]),
+      JSON.stringify([channelSectionKey("slack"), channelSectionKey("email")]),
     );
     expect(loadOpenCategories(ASSISTANT_ID)).toEqual([
-      "scheduled",
-      "background",
+      channelSectionKey("slack"),
+      channelSectionKey("email"),
     ]);
   });
 
   test("filters stale flattened category values", () => {
     memoryStorage.setItem(
       STORAGE_KEY,
-      JSON.stringify(["pinned", "recents", "background"]),
+      JSON.stringify(["pinned", "recents", channelSectionKey("slack")]),
     );
-    expect(loadOpenCategories(ASSISTANT_ID)).toEqual(["background"]);
+    expect(loadOpenCategories(ASSISTANT_ID)).toEqual([
+      channelSectionKey("slack"),
+    ]);
   });
 
   test("returns empty array when stored value is an empty array", () => {
@@ -68,24 +70,29 @@ describe("loadOpenCategories", () => {
   });
 
   test("scopes lookups by assistant id", () => {
-    memoryStorage.setItem(STORAGE_KEY, JSON.stringify(["scheduled"]));
+    memoryStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify([channelSectionKey("slack")]),
+    );
     expect(loadOpenCategories("other_assistant")).toEqual([]);
   });
 
-  test("keeps per-channel section keys", () => {
+  test("keeps per-channel section keys and drops everything else", () => {
+    // "background"/"scheduled" are keys of sections that no longer exist;
+    // stored copies from older builds must not survive a load.
     memoryStorage.setItem(
       STORAGE_KEY,
       JSON.stringify([
         channelSectionKey("slack"),
         channelSectionKey("telegram"),
         "background",
+        "scheduled",
         "bogus",
       ]),
     );
     expect(loadOpenCategories(ASSISTANT_ID)).toEqual([
       "channel:slack",
       "channel:telegram",
-      "background",
     ]);
   });
 });
@@ -99,16 +106,21 @@ describe("channelSectionKey", () => {
 
 describe("saveOpenCategories", () => {
   test("writes the categories under the assistant-scoped storage key", () => {
-    saveOpenCategories(ASSISTANT_ID, ["scheduled", "background"]);
+    saveOpenCategories(ASSISTANT_ID, [channelSectionKey("slack")]);
     expect(memoryStorage.getItem(STORAGE_KEY)).toBe(
-      JSON.stringify(["scheduled", "background"]),
+      JSON.stringify([channelSectionKey("slack")]),
     );
   });
 
   test("overwrites any previously stored value", () => {
-    saveOpenCategories(ASSISTANT_ID, ["scheduled", "background"]);
-    saveOpenCategories(ASSISTANT_ID, ["background"]);
-    expect(loadOpenCategories(ASSISTANT_ID)).toEqual(["background"]);
+    saveOpenCategories(ASSISTANT_ID, [
+      channelSectionKey("slack"),
+      channelSectionKey("email"),
+    ]);
+    saveOpenCategories(ASSISTANT_ID, [channelSectionKey("email")]);
+    expect(loadOpenCategories(ASSISTANT_ID)).toEqual([
+      channelSectionKey("email"),
+    ]);
   });
 
   test("persists an empty array when all categories are collapsed", () => {
@@ -117,10 +129,14 @@ describe("saveOpenCategories", () => {
   });
 
   test("keeps values for different assistants isolated", () => {
-    saveOpenCategories(ASSISTANT_ID, ["background"]);
-    saveOpenCategories("other_assistant", ["scheduled"]);
-    expect(loadOpenCategories(ASSISTANT_ID)).toEqual(["background"]);
-    expect(loadOpenCategories("other_assistant")).toEqual(["scheduled"]);
+    saveOpenCategories(ASSISTANT_ID, [channelSectionKey("slack")]);
+    saveOpenCategories("other_assistant", [channelSectionKey("email")]);
+    expect(loadOpenCategories(ASSISTANT_ID)).toEqual([
+      channelSectionKey("slack"),
+    ]);
+    expect(loadOpenCategories("other_assistant")).toEqual([
+      channelSectionKey("email"),
+    ]);
   });
 });
 

--- a/clients/web/src/domains/chat/utils/sidebar-group-collapse-storage.ts
+++ b/clients/web/src/domains/chat/utils/sidebar-group-collapse-storage.ts
@@ -1,10 +1,10 @@
 // Persist the sidebar conversation group expand/collapse state to localStorage
 // so that the user's last-known toggle state for each collapsible group
-// (Scheduled, Background, per-channel sections, and custom groups) survives
+// (per-channel sections and custom groups) survives
 // page reloads.
 //
-// Primary sections (Pinned / Chats), built-in sections (scheduled / background
-// / per-channel), and custom groups are stored under SEPARATE keys, chiefly
+// Primary sections (Pinned / Chats), built-in sections (the per-channel
+// sections), and custom groups are stored under SEPARATE keys, chiefly
 // because they have different defaults: primary sections default to OPEN, the
 // other two to closed.
 //
@@ -18,8 +18,6 @@
 
 import { parseStringArray } from "@/domains/chat/utils/storage-validators";
 import { createKeyedStorageAccessor } from "@/utils/typed-storage";
-
-const OPEN_CATEGORY_KEYS = new Set(["scheduled", "background"]);
 
 /**
  * The always-present primary sections (Pinned, Chats). Unlike the built-in
@@ -56,13 +54,16 @@ export function isChannelSectionKey(key: string): boolean {
 }
 
 /**
- * True for the built-in collapsible categories (Scheduled, Background, and
- * every `channel:` section). Exported so the sidebar can route a key from the
+ * True for the built-in collapsible categories (every `channel:` section).
+ * Exported so the sidebar can route a key from the
  * shared accordion root into the right storage bucket: primary, category, or
  * - matching neither - a custom group id.
  */
 export function isKnownCategoryKey(category: string): boolean {
-  return OPEN_CATEGORY_KEYS.has(category) || isChannelSectionKey(category);
+  /* Channel sections are the only built-in category keys. Legacy persisted
+     "background"/"scheduled" entries fail this check, so `loadOpenCategories`
+     drops them at load and the next save rewrites storage without them. */
+  return isChannelSectionKey(category);
 }
 
 const categoriesStorage = createKeyedStorageAccessor<string[]>({


### PR DESCRIPTION
## TL;DR

Deletes the sidebar machinery that pre-loaded background/scheduled backlogs nothing renders: the attention reconcile's force-activation, the activation flags and store actions, the sidebar's two lazy backlog queries, and the merged-list grouping input. **285 net lines removed.** Backlog runs now reach the sidebar through exactly four explicit promotions — open (just shipped, #40601), send, pin, file — each through the shared surfacing/placement seams.

Fixes LUM-3222. Part of LUM-2443.

## Why now, and why it needed a decision first

LUM-2443 explicitly warned an earlier session against calling this machinery dead: two live paths activated it, and the force-activation had one legitimate purpose — making an attention-flagged conversation *reachable* when no section could show it. Removing it required the surface-on-open decision. That decision is settled (product-confirmed this session) and shipped (#40601): opening the conversation from the bell or feed now promotes it properly, which is what the force-activation was always reaching for. With that, the machinery's last consumer is gone — verified by census, not assumption: the activation flags' only producer was the attention reconcile, their only reader was the sidebar's lazy mounting.

## What is deleted vs. kept

**Deleted:** `revealLazySectionsIfPendingUnloaded` and its call; `backgroundActivated`/`scheduledActivated` (state, actions, hydration-from-storage, `setOpenCategories` derivation); the sidebar's two lazy query mounts and `mergeConversationLists` input (grouping now takes the foreground list directly); the `queryClient` parameter `reconcileAttentionKeys` held solely for the reveal's cache read (rippled through both callers and the test harness); the legacy `"background"`/`"scheduled"` entries in the known-category-key set.

**Kept, deliberately:** the backlog query hooks themselves — the notifications bell, conversation loader, active-conversation resolution, and archive view consume them legitimately (verified per consumer); and `reconcileAttentionKeys`' actual job, attention/processing key reconciliation, untouched — eight of its nine tests survive verbatim.

## The storage subtlety

Legacy persisted `"background"`/`"scheduled"` open-category keys now fail the narrowed key check. `loadOpenCategories` already filters through that check, so stale keys drop at load and the next save rewrites storage without them — the ticket's "clear rather than ignore" requirement, satisfied by the existing filter with no migration. They cannot be misfiled as custom groups: custom-group open state loads from a separate storage bucket, and the live accordion value array only ever carries rendered section keys.

## What changes for the user

Nothing visible. Cold loads and reconnects stop fetching backlogs that rendered nowhere (for users with legacy open-state or pending background interactions, that's real requests saved on every mount and reconnect); an attention dot can no longer point at a conversation no section shows — the bell and feed carry those, and opening promotes.

## Testing

Local test runs are blocked on this machine; CI is the verifier. The deletion's test story is mostly *removals* verified to leave the remaining suites meaningful: the activation describe (5 tests) deleted with its subject; the reveal test deleted with the reveal; stale fixture writes to a mock nothing calls removed; the bg/scheduled stubs deleted from both sidebar suites (their trees no longer call those hooks); one cross-reference comment preserved. Lint's unused-variable errors were used as the dead-code detector and chased to their roots rather than suppressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40604" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->