### PR TITLE
feat(plugins): publish the unabyss plugin to the marketplace

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -423,6 +423,19 @@
       "icon": "✈️"
     },
     {
+      "name": "unabyss",
+      "source": {
+        "source": "github",
+        "repo": "vellum-ai/unabyss-vellum",
+        "ref": "bc2c6d815fdbb36b58ca78ca4bb28f507fc415c3"
+      },
+      "description": "Personal and company context from Unabyss, available to your agent through the Unabyss MCP server.",
+      "category": "memory",
+      "homepage": "https://unabyss.com",
+      "license": "MIT",
+      "icon": "🌊"
+    },
+    {
       "name": "vellum-client-qa",
       "source": {
         "source": "github",


### PR DESCRIPTION
## Prompt / plan

Publish the Unabyss plugin to the curated catalog, so it installs by name (`assistant plugins install unabyss`) instead of via the untrusted direct-URL path.

One entry added to `plugins/marketplace.json`, alphabetically placed:

```json
{
  "name": "unabyss",
  "source": {
    "source": "github",
    "repo": "vellum-ai/unabyss-vellum",
    "ref": "bc2c6d815fdbb36b58ca78ca4bb28f507fc415c3"
  },
  "description": "Personal and company context from Unabyss, available to your agent through the Unabyss MCP server.",
  "category": "memory",
  "homepage": "https://unabyss.com",
  "license": "MIT",
  "icon": "🌊"
}
```

Notes on the choices:

- **`ref`** is the full SHA of `vellum-ai/unabyss-vellum`'s current `main` HEAD (`bc2c6d8`, "docs: distinguish the published install from the QA install", #3), per the curation rule that tags and branches are mutable and rejected.
- **No postinstall adapter needed.** The plugin is authored for this loader: a root `mcp.json` declaring the Unabyss MCP server (`streamable-http`, `https://mcp.unabyss.com`), plus its bundled `skills/`. No hooks or tools to bridge.
- **`memory`** category, alongside `cognee` and `simple-memory` — what it supplies the agent is personal and company context.

Independent of #40557 (branched from `main`, no overlapping files), though the two are related: that PR is what makes a plugin's `mcp.json` servers actually connect. Until it lands, installing this from the catalog registers the plugin and its skills but leaves the MCP server declared-not-connected.

## Test plan

- Validated the edited manifest against the real `marketplaceManifestSchema` from `assistant/src/cli/lib/plugin-marketplace.ts` — parses clean, and the entry round-trips with every field retained (the 40-hex `COMMIT_SHA_RE` and kebab-case name checks both pass).
- `plugin-catalog-local`, `search-plugins`, `plugins-install-offline`, and `plugins-routes` suites pass (146 tests).
- `prettier --check` clean. `meta/sync-bundled-copies.ts` runs clean; its only target here, `assistant/src/cli/lib/bundled-marketplace.json`, is gitignored and regenerated by CI, so the canonical file is the sole change.

---
_Generated by [Claude Code](https://claude.ai/code/session_016DpUibHyfia8WfnPL4vCS5)_