### PR TITLE
feat(web): translate the contacts merge, link, and channel dialogs

### DIFF
--- a/clients/web/eslint.config.mjs
+++ b/clients/web/eslint.config.mjs
@@ -204,19 +204,7 @@ const i18nEnforcedPaths = [
   "src/domains/logs/**/*.{ts,tsx}",
   "src/domains/library/**/*.{ts,tsx}",
   "src/domains/home/**/*.{ts,tsx}",
-  // Converted file by file: the merge and link dialogs and the channels
-  // section split sentences across elements and need `Trans`, so they follow
-  // in their own pass and this becomes a directory glob then.
-  "src/domains/contacts/contacts-page.tsx",
-  "src/domains/contacts/connect-page.tsx",
-  "src/domains/contacts/channel-type-labels.ts",
-  "src/domains/contacts/draft-contact.ts",
-  "src/domains/contacts/hooks/**/*.{ts,tsx}",
-  "src/domains/contacts/components/assistant-channels-detail.tsx",
-  "src/domains/contacts/components/assistant-contact-channels.tsx",
-  "src/domains/contacts/components/contact-detail-view.tsx",
-  "src/domains/contacts/components/contacts-list.tsx",
-  "src/domains/contacts/components/guardian-detail-view.tsx",
+  "src/domains/contacts/**/*.{ts,tsx}",
 ];
 
 const eslintConfig = defineConfig([

--- a/clients/web/src/domains/contacts/components/assistant-contact-channels.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-contact-channels.tsx
@@ -123,7 +123,7 @@ function ChannelRow({
           <>
             <span className="inline-flex items-center gap-1 h-8 px-2.5 rounded-md whitespace-nowrap select-none text-body-small-emphasised leading-none bg-[var(--content-default)] text-[var(--surface-base)]">
               <CheckCircle className="h-3 w-3" />
-              {t("assistantContactChannels.connected")}
+              {t("channelStatus.connected")}
             </span>
             <Button
               variant="danger"

--- a/clients/web/src/domains/contacts/components/contact-channels-section.tsx
+++ b/clients/web/src/domains/contacts/components/contact-channels-section.tsx
@@ -23,6 +23,7 @@ import type {
   ChannelInfo,
   ContactChannelPayload,
 } from "@/domains/contacts/types";
+import { useTranslation } from "@/i18n";
 
 const KNOWN_CHANNEL_IDS: ReadonlySet<string> = new Set<ChannelInfo["id"]>([
   "telegram",
@@ -65,7 +66,7 @@ export function getChannelActionState(
   if (verified) {
     return { kind: "verified" };
   }
-  // Don't offer to verify a blocked channel — verifying flips it to active and clears the ban.
+  // Don't offer to verify a blocked channel: verifying flips it to active and clears the ban.
   if (existing?.status === "blocked") {
     return { kind: "none" };
   }
@@ -165,7 +166,7 @@ export function ContactChannelsSection({
   contactChannels,
   availableChannels,
   a2aEnabled,
-  setupLabel = "Invite",
+  setupLabel,
   verifyLoading,
   verifySubject = "self",
   onSetupChannel,
@@ -173,6 +174,7 @@ export function ContactChannelsSection({
   onRevokeChannel,
   onLinkAccount,
 }: ContactChannelsSectionProps) {
+  const { t } = useTranslation("contacts");
   const [verifyPending, setVerifyPending] = useState<ChannelInfo | null>(null);
   const [revokePending, setRevokePending] = useState<{
     channelId: string;
@@ -219,7 +221,9 @@ export function ContactChannelsSection({
               <ChannelRow
                 info={info}
                 existing={existing}
-                setupLabel={setupLabel}
+                setupLabel={
+                  setupLabel ?? t("contactChannelsSection.setupDefault")
+                }
                 verifyLoading={verifyLoading}
                 onSetup={
                   onSetupChannel ? () => onSetupChannel(info.id) : undefined
@@ -252,13 +256,19 @@ export function ContactChannelsSection({
       {verifyPending && (
         <ConfirmDialog
           open={true}
-          title={`Verify ${verifyPending.label}`}
+          title={t("contactChannelsSection.verifyConfirmTitle", {
+            channel: verifyPending.label,
+          })}
           message={
             verifySubject === "contact"
-              ? `This will mark this contact's ${verifyPending.label} channel as verified. Your assistant will recognize them when they reach out from it.`
-              : `This will mark your ${verifyPending.label} channel as verified. Your assistant will recognize you when you reach out from it.`
+              ? t("contactChannelsSection.verifyConfirmMessageContact", {
+                  channel: verifyPending.label,
+                })
+              : t("contactChannelsSection.verifyConfirmMessageGuardian", {
+                  channel: verifyPending.label,
+                })
           }
-          confirmLabel="Verify"
+          confirmLabel={t("actions.verify")}
           onConfirm={handleVerifyConfirm}
           onCancel={() => setVerifyPending(null)}
         />
@@ -267,9 +277,11 @@ export function ContactChannelsSection({
       {revokePending && (
         <ConfirmDialog
           open={true}
-          title={`Revoke ${revokePending.channel.label}`}
-          message="This will disconnect the verified channel. The contact will need to re-verify to use this channel again."
-          confirmLabel="Revoke"
+          title={t("contactChannelsSection.revokeConfirmTitle", {
+            channel: revokePending.channel.label,
+          })}
+          message={t("contactChannelsSection.revokeConfirmMessage")}
+          confirmLabel={t("actions.revoke")}
           destructive
           onConfirm={() => {
             onRevokeChannel?.(
@@ -306,6 +318,7 @@ function ChannelRow({
   onRevoke,
   onLinkAccount,
 }: ChannelRowProps) {
+  const { t } = useTranslation("contacts");
   const actionState = getChannelActionState(info, existing);
 
   return (
@@ -334,11 +347,11 @@ function ChannelRow({
           <>
             <span className="inline-flex items-center gap-1 h-8 px-2.5 rounded-md whitespace-nowrap select-none text-body-small-emphasised leading-none bg-[var(--content-default)] text-[var(--surface-base)]">
               <CheckCircle className="h-3 w-3" />
-              Connected
+              {t("channelStatus.connected")}
             </span>
             {onRevoke ? (
               <Button variant="danger" onClick={onRevoke}>
-                Revoke
+                {t("actions.revoke")}
               </Button>
             ) : null}
           </>
@@ -346,11 +359,11 @@ function ChannelRow({
           <>
             <span className="inline-flex items-center gap-1 h-8 px-2.5 rounded-md whitespace-nowrap select-none text-body-small-emphasised leading-none bg-[var(--content-default)] text-[var(--surface-base)]">
               <CheckCircle className="h-3 w-3" />
-              Verified
+              {t("channelStatus.verified")}
             </span>
             {onRevoke ? (
               <Button variant="danger" onClick={onRevoke}>
-                Revoke
+                {t("actions.revoke")}
               </Button>
             ) : null}
           </>
@@ -360,7 +373,7 @@ function ChannelRow({
             onClick={onVerify}
             disabled={!onVerify || verifyLoading}
           >
-            {verifyLoading ? "Verifying…" : "Verify"}
+            {verifyLoading ? t("actions.verifying") : t("actions.verify")}
           </Button>
         ) : actionState.kind === "setup" ? (
           info.id === "a2a" ? null : (
@@ -368,7 +381,7 @@ function ChannelRow({
               {onLinkAccount ? (
                 <Button onClick={onLinkAccount}>
                   <Link2 className="h-3.5 w-3.5" />
-                  Link account
+                  {t("contactChannelsSection.linkAccount")}
                 </Button>
               ) : null}
               <Button variant="outlined" onClick={onSetup} disabled={!onSetup}>

--- a/clients/web/src/domains/contacts/components/contact-merge-dialog.tsx
+++ b/clients/web/src/domains/contacts/components/contact-merge-dialog.tsx
@@ -7,7 +7,9 @@ import { Modal } from "@vellumai/design-library/components/modal";
 import { PanelItem } from "@vellumai/design-library/components/panel-item";
 import { Typography } from "@vellumai/design-library/components/typography";
 
+import { channelTypeLabel } from "@/domains/contacts/channel-type-labels";
 import type { ContactPayload } from "@/domains/contacts/types";
+import { t as translate, Trans, useTranslation } from "@/i18n";
 
 export interface ContactMergeDialogProps {
   open: boolean;
@@ -37,6 +39,7 @@ function ContactMergeDialogInner({
   onMerge,
   onClose,
 }: ContactMergeDialogProps) {
+  const { t } = useTranslation("contacts");
   const [search, setSearch] = useState("");
   const [donorId, setDonorId] = useState<string | null>(null);
 
@@ -73,13 +76,18 @@ function ContactMergeDialogInner({
         <Modal.Header icon={GitMerge}>
           <Modal.Title>
             {donor
-              ? `Merge "${donor.displayName}" into ${survivorLabel}?`
-              : `Merge another contact into ${survivorLabel}`}
+              ? t("contactMergeDialog.titlePicked", {
+                  donor: donor.displayName,
+                  survivor: survivorLabel,
+                })
+              : t("contactMergeDialog.titlePicking", {
+                  survivor: survivorLabel,
+                })}
           </Modal.Title>
           <Modal.Description>
             {donor
-              ? "Channels and notes from the merged contact will move over. The merged contact will be deleted."
-              : "The contact you pick will be deleted. Its channels and notes will be added to this one."}
+              ? t("contactMergeDialog.descriptionPicked")
+              : t("contactMergeDialog.descriptionPicking")}
           </Modal.Description>
         </Modal.Header>
         <Modal.Body className="flex flex-col gap-3">
@@ -115,19 +123,19 @@ function ContactMergeDialogInner({
                 disabled={pending}
                 leftIcon={<ArrowLeft aria-hidden />}
               >
-                Back
+                {t("actions.back")}
               </Button>
               <Button
                 variant="danger"
                 onClick={() => onMerge(donor.id)}
                 disabled={pending}
               >
-                {pending ? "Merging…" : "Merge"}
+                {pending ? t("actions.merging") : t("contactMergeDialog.confirm")}
               </Button>
             </>
           ) : (
             <Button variant="outlined" onClick={onClose} disabled={pending}>
-              Cancel
+              {t("actions.cancel")}
             </Button>
           )}
         </Modal.Footer>
@@ -149,20 +157,22 @@ function CandidateList({
   candidates,
   onPick,
 }: CandidateListProps) {
+  const { t } = useTranslation("contacts");
+
   return (
     <>
       <Input
         type="text"
         value={search}
         onChange={(e) => onSearch(e.target.value)}
-        placeholder="Search contacts"
+        placeholder={t("contactMergeDialog.searchPlaceholder")}
         leftIcon={<Search className="h-3.5 w-3.5" aria-hidden />}
         fullWidth
       />
       <div
         className="flex max-h-[320px] min-h-[120px] flex-col gap-1 overflow-y-auto"
         role="listbox"
-        aria-label="Select a contact to merge"
+        aria-label={t("contactMergeDialog.listAriaLabel")}
       >
         {candidates.length === 0 ? (
           <Typography
@@ -170,7 +180,7 @@ function CandidateList({
             variant="body-small-default"
             className="px-3 py-4 text-center text-(--content-tertiary)"
           >
-            No matching contacts
+            {t("contactsList.noMatches")}
           </Typography>
         ) : (
           candidates.map((contact) => (
@@ -226,72 +236,86 @@ function MergeSummary({
   survivor: ContactPayload;
   donor: ContactPayload;
 }) {
+  const { t } = useTranslation("contacts");
   const survivorLabel = formatSurvivorName(survivor);
   const { moved, duplicates } = classifyMergedChannels(survivor, donor);
 
+  // ICU `plural` picks the category through `Intl.PluralRules`, so both counts
+  // agree in languages with more than the two forms English has. The zero case
+  // is its own `=0` branch rather than a separate key, because it is the same
+  // sentence with nothing to list.
   return (
     <ul className="flex flex-col gap-2 text-body-medium-lighter text-(--content-secondary)">
       <li>
-        <span className="text-(--content-default)">
-          &ldquo;{donor.displayName}&rdquo;
-        </span>{" "}
-        will be deleted.
+        <Trans
+          i18nKey="contactMergeDialog.donorDeleted"
+          ns="contacts"
+          values={{ donor: donor.displayName }}
+          components={{ donor: <span className="text-(--content-default)" /> }}
+        />
       </li>
       <li>
-        {moved.length === 0
-          ? `No new channels will move to ${survivorLabel}.`
-          : `${moved.length} channel${moved.length === 1 ? "" : "s"} will move to ${survivorLabel}: ${moved.map((ch) => describeChannel(ch.type)).join(", ")}.`}
+        {t("contactMergeDialog.channelsMoved", {
+          count: moved.length,
+          survivor: survivorLabel,
+          channels: moved.map((ch) => channelTypeLabel(ch.type)).join(", "),
+        })}
       </li>
       {duplicates.length > 0 ? (
         <li className="text-(--content-tertiary)">
-          {duplicates.length} duplicate channel
-          {duplicates.length === 1 ? "" : "s"} already on {survivorLabel}{" "}
-          (skipped).
+          {t("contactMergeDialog.duplicatesSkipped", {
+            count: duplicates.length,
+            survivor: survivorLabel,
+          })}
         </li>
       ) : null}
-      {donor.notes ? (
-        <li>Notes from the merged contact will be appended.</li>
-      ) : null}
-      <li className="text-(--content-tertiary)">This cannot be undone.</li>
+      {donor.notes ? <li>{t("contactMergeDialog.notesAppended")}</li> : null}
+      <li className="text-(--content-tertiary)">
+        {t("contactMergeDialog.irreversible")}
+      </li>
     </ul>
   );
 }
 
 function MergeEmptyState() {
+  const { t } = useTranslation("contacts");
+
   return (
     <Typography
       as="p"
       variant="body-medium-lighter"
       className="px-3 py-6 text-center text-(--content-tertiary)"
     >
-      No other contacts available to merge.
+      {t("contactMergeDialog.empty")}
     </Typography>
   );
 }
 
+/**
+ * How the surviving contact is named inside the dialog's sentences.
+ *
+ * Reads the bound `t` rather than the hook: this is called from render and is
+ * also exported for the page, so it cannot take a hook of its own. Every
+ * caller renders inside a component that does subscribe, so a locale switch
+ * still repaints it.
+ */
 export function formatSurvivorName(contact: ContactPayload): string {
   if (contact.role === "guardian") {
     if (
       !contact.displayName ||
       contact.displayName.startsWith("vellum-principal-")
     ) {
-      return "you";
+      return translate("survivorName.you", { ns: "contacts" });
     }
-    return `${contact.displayName} (you)`;
+    return translate("survivorName.youNamed", {
+      ns: "contacts",
+      name: contact.displayName,
+    });
   }
-  return contact.displayName || "this contact";
-}
-
-const CHANNEL_TYPE_LABEL: Record<string, string> = {
-  slack: "Slack",
-  telegram: "Telegram",
-  phone: "Phone",
-  email: "Email",
-  whatsapp: "WhatsApp",
-};
-
-function describeChannel(type: string): string {
-  return CHANNEL_TYPE_LABEL[type.toLowerCase()] ?? type;
+  return (
+    contact.displayName ||
+    translate("survivorName.thisContact", { ns: "contacts" })
+  );
 }
 
 export function classifyMergedChannels(
@@ -333,7 +357,7 @@ function mergeDialogChannelTypeLabels(contact: ContactPayload): string[] {
       continue;
     }
     seen.add(key);
-    labels.push(CHANNEL_TYPE_LABEL[key] ?? ch.type);
+    labels.push(channelTypeLabel(key));
   }
   return labels;
 }

--- a/clients/web/src/domains/contacts/components/link-account-dialog.tsx
+++ b/clients/web/src/domains/contacts/components/link-account-dialog.tsx
@@ -6,6 +6,7 @@ import { Input } from "@vellumai/design-library/components/input";
 import { Modal } from "@vellumai/design-library/components/modal";
 
 import type { RosterAccount } from "@/domains/contacts/channel-linking";
+import { Trans, useTranslation } from "@/i18n";
 
 /** Name/@handle search over the roster (leading `@` optional). */
 export function filterRosterAccounts(
@@ -50,7 +51,7 @@ export interface LinkAccountDialogProps {
 
 /**
  * Roster picker behind a linkable channel row's "Link account" action.
- * Picking an account marks it guardian-linked — the guardian vouches for
+ * Picking an account marks it guardian-linked: the guardian vouches for
  * the identity, no handshake needed. Channel-agnostic: the adapter supplies
  * the roster (see `domains/contacts/channel-linking.ts`).
  */
@@ -66,6 +67,7 @@ export function LinkAccountDialog({
   onClose,
   onInviteInstead,
 }: LinkAccountDialogProps) {
+  const { t } = useTranslation("contacts");
   const [search, setSearch] = useState("");
 
   // A fresh open starts with a clean search, not the previous session's.
@@ -86,13 +88,23 @@ export function LinkAccountDialog({
     <Modal.Root open={open} onOpenChange={(next) => !next && onClose()}>
       <Modal.Content size="sm">
         <Modal.Header>
-          <Modal.Title>Link {channelLabel} account</Modal.Title>
+          <Modal.Title>
+            {t("linkAccountDialog.title", { channel: channelLabel })}
+          </Modal.Title>
           <Modal.Description>
-            Search your {channelLabel} workspace and pick{" "}
-            <span className="text-[color:var(--content-default)]">
-              {contactName}
-            </span>
-            &rsquo;s account.
+            {/* One sentence with the contact's name styled mid-clause, so it
+                has to stay one catalog entry: a language that puts the
+                possessive somewhere else can move the tag with it. */}
+            <Trans
+              i18nKey="linkAccountDialog.description"
+              ns="contacts"
+              values={{ channel: channelLabel, name: contactName }}
+              components={{
+                contact: (
+                  <span className="text-[color:var(--content-default)]" />
+                ),
+              }}
+            />
           </Modal.Description>
         </Modal.Header>
         <Modal.Body className="flex flex-col gap-3">
@@ -100,8 +112,10 @@ export function LinkAccountDialog({
             type="search"
             value={search}
             onChange={(event) => setSearch(event.target.value)}
-            placeholder="Search by name or @handle"
-            aria-label={`Search ${channelLabel} workspace accounts`}
+            placeholder={t("linkAccountDialog.searchPlaceholder")}
+            aria-label={t("linkAccountDialog.searchAriaLabel", {
+              channel: channelLabel,
+            })}
             leftIcon={<Search className="h-4 w-4" />}
             fullWidth
           />
@@ -113,13 +127,13 @@ export function LinkAccountDialog({
           <div className="max-h-80 overflow-y-auto">
             {loading ? (
               <p className="py-4 text-center text-body-small-default text-[color:var(--content-tertiary)]">
-                Loading workspace members…
+                {t("linkAccountDialog.loading")}
               </p>
             ) : visibleAccounts.length === 0 ? (
               <p className="py-4 text-center text-body-small-default text-[color:var(--content-tertiary)]">
                 {(accounts?.length ?? 0) === 0
-                  ? "No workspace members found."
-                  : "No members match."}
+                  ? t("linkAccountDialog.noMembers")
+                  : t("linkAccountDialog.noMatches")}
               </p>
             ) : (
               <ul className="flex flex-col">
@@ -155,7 +169,7 @@ export function LinkAccountDialog({
                       </span>
                       {pendingAccountId === account.id ? (
                         <span className="ml-auto shrink-0 text-body-small-default text-[color:var(--content-tertiary)]">
-                          Linking…
+                          {t("linkAccountDialog.linking")}
                         </span>
                       ) : null}
                     </button>
@@ -167,11 +181,15 @@ export function LinkAccountDialog({
         </Modal.Body>
         <Modal.Footer className="items-center justify-between gap-3 border-t border-[var(--border-base)]">
           <p className="text-body-small-default text-[color:var(--content-tertiary)]">
-            Picking marks this account as{" "}
-            <span className="text-[color:var(--content-secondary)]">
-              guardian-linked
-            </span>{" "}
-            — you vouch for the identity, no handshake needed.
+            <Trans
+              i18nKey="linkAccountDialog.guardianLinkNote"
+              ns="contacts"
+              components={{
+                emphasis: (
+                  <span className="text-[color:var(--content-secondary)]" />
+                ),
+              }}
+            />
           </p>
           {onInviteInstead ? (
             <Button
@@ -180,7 +198,7 @@ export function LinkAccountDialog({
               onClick={onInviteInstead}
               disabled={linking}
             >
-              Or send an invite instead
+              {t("linkAccountDialog.inviteInstead")}
               <ArrowRight className="h-3.5 w-3.5" />
             </Button>
           ) : null}

--- a/clients/web/src/domains/contacts/contacts-i18n.test.tsx
+++ b/clients/web/src/domains/contacts/contacts-i18n.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * Rendering checks for the contacts catalog entries that are not plain
+ * strings.
+ *
+ * `catalogs.test.ts` already proves every message parses as ICU and that no
+ * placeholder is dropped in translation. Neither of those catches the two ways
+ * these particular entries break:
+ *
+ * - A `Trans` tag whose name does not match a key in the call site's
+ *   `components` map renders as literal text instead of an element, so the
+ *   sentence still reads correctly in a snapshot of its text content while the
+ *   markup is wrong. These assert the text and the element separately.
+ * - A `plural` branch can be well-formed and still select the wrong category,
+ *   or lose the count. Each form is asserted at the boundary that selects it.
+ *
+ * The expected strings are the English copy verbatim, so a copy edit that
+ * forgets a catalog is a failure here rather than a bug report.
+ */
+import { expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { Trans, useTranslation } from "@/i18n";
+
+function textOf(markup: string): string {
+  return markup.replace(/<[^>]+>/g, "");
+}
+
+test("the link dialog names the contact inside the sentence", () => {
+  const markup = renderToStaticMarkup(
+    <Trans
+      i18nKey="linkAccountDialog.description"
+      ns="contacts"
+      values={{ channel: "Slack", name: "Ada" }}
+      components={{ contact: <span className="highlight" /> }}
+    />,
+  );
+
+  expect(textOf(markup)).toBe(
+    "Search your Slack workspace and pick Ada’s account.",
+  );
+  expect(markup).toContain('<span class="highlight">Ada</span>');
+});
+
+test("the link dialog emphasizes the guardian-linked term", () => {
+  const markup = renderToStaticMarkup(
+    <Trans
+      i18nKey="linkAccountDialog.guardianLinkNote"
+      ns="contacts"
+      components={{ emphasis: <span className="highlight" /> }}
+    />,
+  );
+
+  expect(textOf(markup)).toBe(
+    "Picking marks this account as guardian-linked: you vouch for the identity, no handshake needed.",
+  );
+  expect(markup).toContain('<span class="highlight">guardian-linked</span>');
+});
+
+test("the merge summary quotes the donor inside the sentence", () => {
+  const markup = renderToStaticMarkup(
+    <Trans
+      i18nKey="contactMergeDialog.donorDeleted"
+      ns="contacts"
+      values={{ donor: "Bob" }}
+      components={{ donor: <span className="highlight" /> }}
+    />,
+  );
+
+  expect(textOf(markup)).toBe("“Bob” will be deleted.");
+  expect(markup).toContain('<span class="highlight">“Bob”</span>');
+});
+
+function Message({
+  render,
+}: {
+  render: (t: ReturnType<typeof useTranslation<"contacts">>["t"]) => string;
+}) {
+  const { t } = useTranslation("contacts");
+  return <>{render(t)}</>;
+}
+
+function messageText(
+  render: (t: ReturnType<typeof useTranslation<"contacts">>["t"]) => string,
+): string {
+  return textOf(renderToStaticMarkup(<Message render={render} />));
+}
+
+test("moved channels read correctly at none, one, and many", () => {
+  expect(
+    messageText((t) =>
+      t("contactMergeDialog.channelsMoved", {
+        count: 0,
+        survivor: "you",
+        channels: "",
+      }),
+    ),
+  ).toBe("No new channels will move to you.");
+
+  expect(
+    messageText((t) =>
+      t("contactMergeDialog.channelsMoved", {
+        count: 1,
+        survivor: "Ada",
+        channels: "Slack",
+      }),
+    ),
+  ).toBe("1 channel will move to Ada: Slack.");
+
+  expect(
+    messageText((t) =>
+      t("contactMergeDialog.channelsMoved", {
+        count: 2,
+        survivor: "Ada",
+        channels: "Slack, Email",
+      }),
+    ),
+  ).toBe("2 channels will move to Ada: Slack, Email.");
+});
+
+test("skipped duplicates read correctly at one and many", () => {
+  expect(
+    messageText((t) =>
+      t("contactMergeDialog.duplicatesSkipped", { count: 1, survivor: "Ada" }),
+    ),
+  ).toBe("1 duplicate channel already on Ada (skipped).");
+
+  expect(
+    messageText((t) =>
+      t("contactMergeDialog.duplicatesSkipped", { count: 3, survivor: "Ada" }),
+    ),
+  ).toBe("3 duplicate channels already on Ada (skipped).");
+});
+
+test("the interaction count agrees with its number", () => {
+  expect(messageText((t) => t("contact.interactions", { count: 1 }))).toBe(
+    "1 interaction",
+  );
+  expect(messageText((t) => t("contact.interactions", { count: 5 }))).toBe(
+    "5 interactions",
+  );
+});

--- a/clients/web/src/i18n/locales/en/contacts.json
+++ b/clients/web/src/i18n/locales/en/contacts.json
@@ -10,7 +10,11 @@
     "connecting": "Connecting…",
     "disconnect": "Disconnect",
     "disconnecting": "Disconnecting…",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "back": "Back",
+    "verify": "Verify",
+    "verifying": "Verifying…",
+    "revoke": "Revoke"
   },
   "channelType": {
     "slack": "Slack",
@@ -74,7 +78,6 @@
     "channelsSubtitle": "Where {name} can be reached."
   },
   "assistantContactChannels": {
-    "connected": "Connected",
     "disconnectConfirmTitle": "Disconnect {channel}?",
     "disconnectConfirmMessage": "This clears the stored credentials for this channel. You can reconnect later."
   },
@@ -95,5 +98,50 @@
     "errorSenderNotFound": "The sender's assistant could not be found.",
     "errorNotPlatformManaged": "A2A invite links are only supported for platform-hosted assistants.",
     "errorGeneric": "Something went wrong. Please try again."
+  },
+  "channelStatus": {
+    "connected": "Connected",
+    "verified": "Verified"
+  },
+  "contactChannelsSection": {
+    "verifyConfirmTitle": "Verify {channel}",
+    "verifyConfirmMessageContact": "This will mark this contact's {channel} channel as verified. Your assistant will recognize them when they reach out from it.",
+    "verifyConfirmMessageGuardian": "This will mark your {channel} channel as verified. Your assistant will recognize you when you reach out from it.",
+    "revokeConfirmTitle": "Revoke {channel}",
+    "revokeConfirmMessage": "This will disconnect the verified channel. The contact will need to re-verify to use this channel again.",
+    "linkAccount": "Link account",
+    "setupDefault": "Invite"
+  },
+  "linkAccountDialog": {
+    "title": "Link {channel} account",
+    "description": "Search your {channel} workspace and pick <contact>{name}</contact>’s account.",
+    "searchPlaceholder": "Search by name or @handle",
+    "searchAriaLabel": "Search {channel} workspace accounts",
+    "loading": "Loading workspace members…",
+    "noMembers": "No workspace members found.",
+    "noMatches": "No members match.",
+    "linking": "Linking…",
+    "guardianLinkNote": "Picking marks this account as <emphasis>guardian-linked</emphasis>: you vouch for the identity, no handshake needed.",
+    "inviteInstead": "Or send an invite instead"
+  },
+  "contactMergeDialog": {
+    "titlePicked": "Merge \"{donor}\" into {survivor}?",
+    "titlePicking": "Merge another contact into {survivor}",
+    "descriptionPicked": "Channels and notes from the merged contact will move over. The merged contact will be deleted.",
+    "descriptionPicking": "The contact you pick will be deleted. Its channels and notes will be added to this one.",
+    "confirm": "Merge",
+    "searchPlaceholder": "Search contacts",
+    "listAriaLabel": "Select a contact to merge",
+    "empty": "No other contacts available to merge.",
+    "donorDeleted": "<donor>“{donor}”</donor> will be deleted.",
+    "channelsMoved": "{count, plural, =0 {No new channels will move to {survivor}.} one {# channel will move to {survivor}: {channels}.} other {# channels will move to {survivor}: {channels}.}}",
+    "duplicatesSkipped": "{count, plural, one {# duplicate channel already on {survivor} (skipped).} other {# duplicate channels already on {survivor} (skipped).}}",
+    "notesAppended": "Notes from the merged contact will be appended.",
+    "irreversible": "This cannot be undone."
+  },
+  "survivorName": {
+    "you": "you",
+    "youNamed": "{name} (you)",
+    "thisContact": "this contact"
   }
 }

--- a/clients/web/src/i18n/locales/es/contacts.json
+++ b/clients/web/src/i18n/locales/es/contacts.json
@@ -10,7 +10,11 @@
     "connecting": "Conectando…",
     "disconnect": "Desconectar",
     "disconnecting": "Desconectando…",
-    "cancel": "Cancelar"
+    "cancel": "Cancelar",
+    "back": "Atrás",
+    "verify": "Verificar",
+    "verifying": "Verificando…",
+    "revoke": "Revocar"
   },
   "channelType": {
     "slack": "Slack",
@@ -74,7 +78,6 @@
     "channelsSubtitle": "Dónde se puede contactar con {name}."
   },
   "assistantContactChannels": {
-    "connected": "Conectado",
     "disconnectConfirmTitle": "¿Desconectar {channel}?",
     "disconnectConfirmMessage": "Esto borra las credenciales guardadas de este canal. Puedes volver a conectarlo más tarde."
   },
@@ -95,5 +98,50 @@
     "errorSenderNotFound": "No se ha encontrado el asistente del remitente.",
     "errorNotPlatformManaged": "Los enlaces de invitación A2A solo se admiten en asistentes alojados en la plataforma.",
     "errorGeneric": "Algo ha salido mal. Vuelve a intentarlo."
+  },
+  "channelStatus": {
+    "connected": "Conectado",
+    "verified": "Verificado"
+  },
+  "contactChannelsSection": {
+    "verifyConfirmTitle": "Verificar {channel}",
+    "verifyConfirmMessageContact": "Esto marcará el canal de {channel} de este contacto como verificado. Tu asistente lo reconocerá cuando escriba desde ahí.",
+    "verifyConfirmMessageGuardian": "Esto marcará tu canal de {channel} como verificado. Tu asistente te reconocerá cuando escribas desde ahí.",
+    "revokeConfirmTitle": "Revocar {channel}",
+    "revokeConfirmMessage": "Esto desconectará el canal verificado. El contacto tendrá que volver a verificarse para usarlo de nuevo.",
+    "linkAccount": "Vincular cuenta",
+    "setupDefault": "Invitar"
+  },
+  "linkAccountDialog": {
+    "title": "Vincular una cuenta de {channel}",
+    "description": "Busca en tu espacio de trabajo de {channel} y elige la cuenta de <contact>{name}</contact>.",
+    "searchPlaceholder": "Buscar por nombre o @usuario",
+    "searchAriaLabel": "Buscar cuentas del espacio de trabajo de {channel}",
+    "loading": "Cargando los miembros del espacio de trabajo…",
+    "noMembers": "No se han encontrado miembros del espacio de trabajo.",
+    "noMatches": "Ningún miembro coincide.",
+    "linking": "Vinculando…",
+    "guardianLinkNote": "Elegirla marca esta cuenta como <emphasis>vinculada por el tutor</emphasis>: tú respondes por la identidad, sin necesidad de confirmación.",
+    "inviteInstead": "O enviar una invitación"
+  },
+  "contactMergeDialog": {
+    "titlePicked": "¿Combinar «{donor}» con {survivor}?",
+    "titlePicking": "Combinar otro contacto con {survivor}",
+    "descriptionPicked": "Los canales y las notas del contacto combinado se trasladarán. El contacto combinado se eliminará.",
+    "descriptionPicking": "El contacto que elijas se eliminará. Sus canales y sus notas se añadirán a este.",
+    "confirm": "Combinar",
+    "searchPlaceholder": "Buscar contactos",
+    "listAriaLabel": "Selecciona un contacto para combinar",
+    "empty": "No hay otros contactos con los que combinar.",
+    "donorDeleted": "<donor>«{donor}»</donor> se eliminará.",
+    "channelsMoved": "{count, plural, =0 {No se trasladará ningún canal nuevo a {survivor}.} one {# canal se trasladará a {survivor}: {channels}.} other {# canales se trasladarán a {survivor}: {channels}.}}",
+    "duplicatesSkipped": "{count, plural, one {# canal duplicado ya está en {survivor} (omitido).} other {# canales duplicados ya están en {survivor} (omitidos).}}",
+    "notesAppended": "Las notas del contacto combinado se añadirán al final.",
+    "irreversible": "Esta acción no se puede deshacer."
+  },
+  "survivorName": {
+    "you": "ti",
+    "youNamed": "{name} (tú)",
+    "thisContact": "este contacto"
   }
 }


### PR DESCRIPTION
Finishes the contacts domain: the merge dialog, the link-account dialog, and the channels section, the three files held back from #40570 because their copy is not flat strings. The ratchet drops the per-file list for a `src/domains/contacts/**` glob.

## Plurals that only worked in English

Two counts were agreeing with English grammar and nothing else:

```ts
`${moved.length} channel${moved.length === 1 ? "" : "s"} will move to ${survivorLabel}: …`
```

Both are ICU `plural` now, so the category comes from `Intl.PluralRules` for the active locale (English has two forms, Polish four, Arabic six). The empty case is an `=0` branch of the same message rather than a second key, because it is the same sentence with nothing to list:

```
{count, plural,
  =0 {No new channels will move to {survivor}.}
  one {# channel will move to {survivor}: {channels}.}
  other {# channels will move to {survivor}: {channels}.}}
```

## Sentences that wrap an element

Three sentences style part of their own text: the contact's name in the link dialog, the `guardian-linked` term in its footer, and the donor's quoted name in the merge summary. Each stays one catalog entry with a named tag, following `channels.slackChannelTypeDefaults.subtitle`:

```
Search your {channel} workspace and pick <contact>{name}</contact>’s account.
```

A language that puts the possessive elsewhere can move the tag with it, rather than being handed three fragments to reassemble in a fixed order.

## Found outside what the lint rule reports

- **`setupLabel = "Invite"`**, a default parameter, so invisible to the rule and rendered straight into a button. The section supplies the fallback from the catalog now and the row keeps a required label.
- **`formatSurvivorName`**, which returned `"you"`, `"{name} (you)"`, and `"this contact"`. It is the grammatical subject of most of the summary's sentences, so leaving it English would have left them half-translated.
- **The merge dialog's own copy of the channel-type label map**, now the shared `channelTypeLabel` added in #40570. That deduplication is what let both files agree on which channel names are product names and which are ordinary nouns.

## A test for the shapes the catalog tests miss

`catalogs.test.ts` proves every message parses as ICU and keeps its placeholders. Neither catches the two ways these entries break:

- A `Trans` tag whose name does not match a key in the call site's `components` map renders as **literal text**. The sentence still reads correctly, so a text-only assertion passes while the markup is wrong. The new tests assert the text and the element separately.
- A `plural` branch can be well-formed and still select the wrong category or drop the count. Each form is asserted at the boundary that selects it.

Expected values are the English copy verbatim, so a copy edit that forgets a catalog fails here instead of shipping.

## One copy change

The link dialog's footer used an em dash in user-facing copy. AGENTS.md asks for those to be fixed on lines already being changed and calls user-facing copy the strict case, so it reads `guardian-linked: you vouch for the identity` now. Every other string is byte-identical to what shipped, which the new tests pin.

## Verification

- survey of `src/domains/contacts/**` reports 0
- `tsc --noEmit` clean
- `bun run lint` 0 errors, 16 warnings, unchanged from the baseline on main
- 945 test files pass
- `bun run build` clean

## What is left

`settings` (1585), `chat` (1066), `components` (463), `onboarding` (194), `intelligence` (177), and a tail of 23 in `hooks`/`utils`/`lib`.

That is the end of the small and mid-sized domains. Everything remaining except the tail is large enough that I would rather build a pseudolocale first, for the reason this PR illustrates: the two plurals, the default parameter, and `formatSurvivorName` were all invisible to a green lint run, and a pseudolocale catches copy by what reaches the screen instead of by what a rule can parse. The Spanish is also now around 370 hand-written messages with no native-speaker review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CD12TRfmDF3UiXjdbiWn3i

---
_Generated by [Claude Code](https://claude.ai/code/session_01CD12TRfmDF3UiXjdbiWn3i)_