### PR TITLE
test(plugin-api): run the turn-persistence tests against the real conversation store

### DIFF
--- a/assistant/src/__tests__/run-conversation-turn-persistence.test.ts
+++ b/assistant/src/__tests__/run-conversation-turn-persistence.test.ts
@@ -1,9 +1,32 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+/**
+ * `runConversationTurn` against the real conversation store, the real agent
+ * loop and the real database. The only thing stood in for is the provider's
+ * HTTP boundary — `resolveProviderFromConnection` hands back a scripted mock
+ * — so everything these tests read back (the `conversations` row, the user
+ * message and the metadata stamped on it, the channel binding) is what
+ * production wrote, not a stub mirroring what production is believed to do.
+ */
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
 
+import type { AssistantEvent } from "../api/index.js";
+import { clearAllActiveConversations } from "../daemon/conversation-store.js";
+import {
+  conversationMetadataSyncTag,
+  SYNC_TAGS,
+} from "../daemon/message-types/sync.js";
 import {
   createConversation,
-  ensureConversationExists,
   getConversation,
+  getMessages,
+  parseMessageMetadata,
 } from "../persistence/conversation-crud.js";
 import { getConversationByKey } from "../persistence/conversation-key-store.js";
 import {
@@ -14,97 +37,142 @@ import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { buildScopedConversationKey } from "../persistence/delivery-crud.js";
 import { getBindingByConversation } from "../persistence/external-conversation-store.js";
+import { createConnection } from "../providers/inference/connections.js";
+import * as providerRegistry from "../providers/registry.js";
+import type { Provider, ProviderResponse } from "../providers/types.js";
+import { createMockProvider, textResponse } from "./helpers/mock-provider.js";
+import { setConfig } from "./helpers/set-config.js";
+import { waitFor } from "./helpers/wait-for.js";
 
 await initializeDb();
 
-// Capture the list-invalidation calls `runConversationTurn` fires when it
-// creates a brand-new conversation row, without pulling in the real sync
-// publisher (which reaches for live SSE subscribers).
-const listChangedCalls: Array<{ kind: string; conversationId: string }> = [];
-mock.module("../runtime/sync/resource-sync-events.js", () => ({
-  publishConversationListAndMetadataChanged: (
-    kind: string,
-    conversationId: string,
-  ) => {
-    listChangedCalls.push({ kind, conversationId });
+// A conversation is built against the default provider, which resolves from
+// config through a connection row. Both are seeded for real so the store takes
+// the same path it takes in the daemon; only the provider the connection
+// resolves to is scripted.
+setConfig("llm", {
+  profiles: {
+    test: {
+      provider: "anthropic",
+      provider_connection: "test-conn",
+      model: "claude-opus-4-6",
+    },
   },
-}));
+  activeProfile: "test",
+});
+setConfig("memory", { enabled: false, v2: { enabled: false } });
 
-// Stub the heavy machinery: the in-memory conversation build (provider wiring,
-// system prompt, history hydration) and the SSE event fan-out. The agent turn
-// itself is a no-op — this test only asserts that the `conversations` row is
-// persisted before the turn runs. The real `getOrCreateConversation` now
-// creates the DB row before hydrating, so the mock mirrors that by calling
-// `ensureConversationExists`. The persistence module is intentionally NOT
-// mocked so the real `ensureConversationExists` runs against the real DB.
-let lastProcessMessageConversationId: string | undefined;
-let lastProcessMessageOptions: Record<string, unknown> | undefined;
-let lastEnqueueOptions: Record<string, unknown> | undefined;
-let lastTurnChannelContext: unknown;
-let conversationIsProcessing = false;
-mock.module("../daemon/conversation-store.js", () => ({
-  getOrCreateConversation: async (
-    conversationId: string,
-    options?: { conversationType?: string },
-  ) => {
-    if (!getConversation(conversationId)) {
-      if (options?.conversationType) {
-        createConversation({
-          id: conversationId,
-          conversationType: options.conversationType as
-            | "standard"
-            | "background",
-        });
-      } else {
-        ensureConversationExists(conversationId, "vellum");
-      }
-    }
-    return {
-      abortController: undefined,
-      setTurnChannelContext: (ctx: unknown) => {
-        lastTurnChannelContext = ctx;
-      },
-      isProcessing: () => conversationIsProcessing,
-      async processMessage(processOptions: Record<string, unknown>) {
-        // The row must already exist by the time the turn persists its user
-        // message — record the id so the FK precondition can be asserted.
-        lastProcessMessageConversationId = conversationId;
-        lastProcessMessageOptions = processOptions;
-        return "user-message-id";
-      },
-      enqueueMessage: (enqueueOptions: Record<string, unknown>) => {
-        lastEnqueueOptions = enqueueOptions;
-        return { rejected: false };
-      },
-    };
+createConnection(getDb(), {
+  name: "test-conn",
+  provider: "anthropic",
+  auth: { type: "api_key", credential: "credential/test/api_key" },
+});
+
+// The SSE fan-out is the one collaborator with nowhere to write in a test —
+// every publish the turn makes (including the list invalidations asserted
+// below, which reach clients through the real `resource-sync-events`) funnels
+// through here.
+const broadcasts: AssistantEvent[] = [];
+mock.module(
+  "../runtime/assistant-event-hub.js",
+  (): Partial<typeof import("../runtime/assistant-event-hub.js")> => ({
+    broadcastMessage: (msg: AssistantEvent) => {
+      broadcasts.push(msg);
+    },
+  }),
+);
+
+const { provider: scriptedProvider } = createMockProvider([
+  textResponse("scripted reply"),
+]);
+
+let gate: Promise<void> | undefined;
+let releaseGate: (() => void) | undefined;
+
+/**
+ * Park the next turn inside the provider call until released, so a second turn
+ * arrives while the conversation is genuinely processing rather than while a
+ * stub reports that it is.
+ */
+function holdTheTurnOpen(): void {
+  let resolveGate!: () => void;
+  gate = new Promise<void>((resolve) => {
+    resolveGate = resolve;
+  });
+  releaseGate = () => {
+    gate = undefined;
+    releaseGate = undefined;
+    resolveGate();
+  };
+}
+
+// A test that fails before releasing must not leave the next one parked on a
+// gate it never opened.
+afterEach(() => releaseGate?.());
+
+const provider: Provider = {
+  name: "scripted",
+  async sendMessage(messages, options): Promise<ProviderResponse> {
+    await gate;
+    return scriptedProvider.sendMessage(messages, options);
   },
-}));
+};
 
-mock.module("../runtime/assistant-event-hub.js", () => ({
-  broadcastMessage: () => {},
-}));
+spyOn(providerRegistry, "resolveProviderFromConnection").mockResolvedValue(
+  provider,
+);
 
-mock.module("../providers/media-resolve.js", () => ({
-  resolveMediaSourceData: () => null,
-}));
-
-// Import under test AFTER the mocks are registered so its dynamic imports
-// resolve to the stubs above.
 const { runConversationTurn } =
   await import("../plugin-api/conversation-turn.js");
 
+/**
+ * The list-level invalidations a turn published, as the tag sets clients
+ * consume. Only a shape-changing reason carries the list umbrella tag, so a
+ * reason that merely edits an existing row (a generated title) is excluded —
+ * these are the announcements that a conversation appeared or vanished.
+ */
+function listInvalidations(): string[][] {
+  return broadcasts
+    .filter((msg) => msg.type === "sync_changed")
+    .map((msg) => msg.tags)
+    .filter((tags) => tags.includes(SYNC_TAGS.conversationsList));
+}
+
+/** The tag set `publishConversationListAndMetadataChanged` emits for a new row. */
+function creationTags(conversationId: string): string[] {
+  return [
+    SYNC_TAGS.conversationsList,
+    conversationMetadataSyncTag(conversationId),
+  ];
+}
+
+/** User message rows of a conversation, oldest first. */
+function userRows(conversationId: string) {
+  return getMessages(conversationId).filter((row) => row.role === "user");
+}
+
+/** The metadata a turn persisted on a message row, parsed as consumers read it. */
+function metadataOf(
+  row: { metadata: string | null } | undefined,
+): Record<string, unknown> | undefined {
+  return parseMessageMetadata(row?.metadata ?? null);
+}
+
+function resetDb(): void {
+  // In-memory conversations outlive the rows they were hydrated from, and a
+  // reused id would otherwise hand the next test a Conversation whose
+  // `conversations` row this wipe just deleted.
+  clearAllActiveConversations();
+  const db = getDb();
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM external_conversation_bindings");
+  db.run("DELETE FROM conversation_keys");
+  db.run("DELETE FROM conversations");
+  broadcasts.length = 0;
+}
+
 describe("runConversationTurn persistence", () => {
-  beforeEach(() => {
-    const db = getDb();
-    db.run("DELETE FROM messages");
-    db.run("DELETE FROM conversations");
-    listChangedCalls.length = 0;
-    lastProcessMessageConversationId = undefined;
-    lastProcessMessageOptions = undefined;
-    lastEnqueueOptions = undefined;
-    lastTurnChannelContext = undefined;
-    conversationIsProcessing = false;
-  });
+  beforeEach(resetDb);
 
   test("persists a conversations row for a freshly-minted conversation", async () => {
     const result = await runConversationTurn({
@@ -112,16 +180,20 @@ describe("runConversationTurn persistence", () => {
     });
 
     // The row exists on disk — not just as an in-memory Conversation object —
-    // so the user-message persist inside the turn has its FK target.
-    const row = getConversation(result.conversationId);
-    expect(row?.id).toBe(result.conversationId);
-    expect(lastProcessMessageConversationId).toBe(result.conversationId);
+    // and the user message the turn persisted found its FK target there.
+    expect(getConversation(result.conversationId)?.id).toBe(
+      result.conversationId,
+    );
+    expect(userRows(result.conversationId).map((row) => row.id)).toEqual([
+      result.userMessageId,
+    ]);
 
     // Siblings/sidebars are told about the new conversation, mirroring the
     // send-message route.
-    expect(listChangedCalls).toEqual([
-      { kind: "created", conversationId: result.conversationId },
-    ]);
+    expect(listInvalidations()).toEqual([creationTags(result.conversationId)]);
+    expect(
+      broadcasts.filter((msg) => msg.type === "conversation_list_invalidated"),
+    ).toEqual([{ type: "conversation_list_invalidated", reason: "created" }]);
   });
 
   test("adopts a caller-supplied conversation id verbatim when no row exists", async () => {
@@ -134,12 +206,12 @@ describe("runConversationTurn persistence", () => {
 
     expect(result.conversationId).toBe(conversationId);
     expect(getConversation(conversationId)?.id).toBe(conversationId);
-    expect(listChangedCalls).toEqual([{ kind: "created", conversationId }]);
+    expect(listInvalidations()).toEqual([creationTags(conversationId)]);
   });
 
   test("is a no-op for an already-persisted conversation row", async () => {
     const existing = createConversation({ title: "already here" });
-    listChangedCalls.length = 0;
+    broadcasts.length = 0;
 
     const result = await runConversationTurn({
       conversationId: existing.id,
@@ -149,7 +221,7 @@ describe("runConversationTurn persistence", () => {
     expect(result.conversationId).toBe(existing.id);
     // Row is untouched and no duplicate "created" invalidation fires.
     expect(getConversation(existing.id)?.title).toBe("already here");
-    expect(listChangedCalls).toEqual([]);
+    expect(listInvalidations()).toEqual([]);
   });
 });
 
@@ -159,28 +231,24 @@ describe("runConversationTurn persistence", () => {
 // eligibility predicate's verdict on the stamped metadata, so the marker and
 // the gate that reads it cannot drift apart.
 describe("runConversationTurn provenance", () => {
-  beforeEach(() => {
-    const db = getDb();
-    db.run("DELETE FROM messages");
-    db.run("DELETE FROM conversations");
-    lastProcessMessageOptions = undefined;
-    lastEnqueueOptions = undefined;
-    conversationIsProcessing = false;
-  });
+  beforeEach(resetDb);
 
   test("stamps the initiating row automated so its reply raises no push", async () => {
     const existing = createConversation({ title: "standard conversation" });
 
-    await runConversationTurn({
+    const result = await runConversationTurn({
       conversationId: existing.id,
       content: [{ type: "text", text: "transcript excerpt" }],
     });
 
-    const metadata = lastProcessMessageOptions?.metadata as Record<
-      string,
-      unknown
-    >;
-    expect(metadata).toEqual({ automated: true });
+    // The scripted reply came back, so the marker below was stamped by a turn
+    // that ran rather than by one that fell over into an error row.
+    expect(result.content).toMatchObject([
+      { type: "text", text: "scripted reply" },
+    ]);
+
+    const metadata = metadataOf(userRows(existing.id)[0]);
+    expect(metadata).toMatchObject({ automated: true });
     expect(isReplyPushIneligibleUserMessage(metadata)).toBe(true);
     // Not an echo-suppression marker: the row still renders in the transcript.
     expect(isEchoSuppressedUserMessage(metadata)).toBe(false);
@@ -188,18 +256,37 @@ describe("runConversationTurn provenance", () => {
 
   test("stamps the same marker on a turn queued behind a busy conversation", async () => {
     const existing = createConversation({ title: "busy conversation" });
-    conversationIsProcessing = true;
+    holdTheTurnOpen();
+
+    const inFlight = runConversationTurn({
+      conversationId: existing.id,
+      content: [{ type: "text", text: "first excerpt" }],
+    });
+    await waitFor(() => userRows(existing.id).length === 1, {
+      timeoutMs: 5_000,
+      message: "the first turn never reached the provider",
+    });
 
     const result = await runConversationTurn({
       conversationId: existing.id,
       content: [{ type: "text", text: "transcript excerpt" }],
     });
-
     expect(result.queued).toBe(true);
-    const metadata = lastEnqueueOptions?.metadata as Record<string, unknown>;
-    expect(metadata).toEqual({ automated: true });
+
+    // The queue drains after the in-flight turn releases, and the marker has
+    // to survive that trip: it is stamped now but read off the persisted row
+    // much later.
+    releaseGate?.();
+    await inFlight;
+    await waitFor(() => userRows(existing.id).length === 2, {
+      timeoutMs: 5_000,
+      message: "the queued turn never drained",
+    });
+
+    const metadata = metadataOf(userRows(existing.id)[1]);
+    expect(metadata).toMatchObject({ automated: true });
     expect(isReplyPushIneligibleUserMessage(metadata)).toBe(true);
-  });
+  }, 20_000);
 });
 
 /**
@@ -219,18 +306,7 @@ describe("runConversationTurn channel binding", () => {
     displayName: "Ada",
   };
 
-  beforeEach(() => {
-    const db = getDb();
-    db.run("DELETE FROM messages");
-    db.run("DELETE FROM external_conversation_bindings");
-    db.run("DELETE FROM conversation_keys");
-    db.run("DELETE FROM conversations");
-    listChangedCalls.length = 0;
-    lastProcessMessageOptions = undefined;
-    lastEnqueueOptions = undefined;
-    lastTurnChannelContext = undefined;
-    conversationIsProcessing = false;
-  });
+  beforeEach(resetDb);
 
   test("resolves the chat to the conversation inbound would have used", async () => {
     const result = await runConversationTurn({
@@ -262,9 +338,7 @@ describe("runConversationTurn channel binding", () => {
 
     expect(second.conversationId).toBe(first.conversationId);
     // Only the first turn minted a conversation.
-    expect(listChangedCalls).toEqual([
-      { kind: "created", conversationId: first.conversationId },
-    ]);
+    expect(listInvalidations()).toEqual([creationTags(first.conversationId)]);
   });
 
   test("gives a different chat its own conversation", async () => {
@@ -314,18 +388,20 @@ describe("runConversationTurn channel binding", () => {
     // Runtime assembly reads the per-turn channel first and only then the
     // conversation's origin, so a turn into a conversation whose origin was
     // never recorded would otherwise run as `vellum`. That is the wrong
-    // channel for the message row and for the permission cascade the tools
+    // channel for the message rows and for the permission cascade the tools
     // are approved against.
-    await runConversationTurn({
+    const result = await runConversationTurn({
       channel: CHANNEL,
       content: [{ type: "text", text: "hello" }],
     });
 
-    expect(lastTurnChannelContext).toEqual({
+    const rows = getMessages(result.conversationId);
+    expect(metadataOf(rows[0])).toMatchObject({
       userMessageChannel: "plugin",
       assistantMessageChannel: "plugin",
     });
-    expect(lastProcessMessageOptions?.metadata).toMatchObject({
+    expect(rows[1].role).toBe("assistant");
+    expect(metadataOf(rows[1])).toMatchObject({
       userMessageChannel: "plugin",
       assistantMessageChannel: "plugin",
     });
@@ -333,32 +409,63 @@ describe("runConversationTurn channel binding", () => {
 
   test("a queued turn carries its own channel rather than inheriting one", async () => {
     // The drain happens after this call returns and reads the channel off the
-    // queued message, falling back to whichever turn was in flight. On a
-    // conversation shared with another channel that fallback is someone
-    // else's channel.
-    conversationIsProcessing = true;
+    // queued message, falling back to whichever turn was in flight. Here that
+    // fallback would be `vellum` — someone else's channel on a conversation
+    // shared with another channel.
+    const conversationId = "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d";
+    holdTheTurnOpen();
+
+    const inFlight = runConversationTurn({
+      conversationId,
+      content: [{ type: "text", text: "native turn" }],
+    });
+    await waitFor(() => userRows(conversationId).length === 1, {
+      timeoutMs: 5_000,
+      message: "the first turn never reached the provider",
+    });
 
     const result = await runConversationTurn({
+      conversationId,
       channel: CHANNEL,
       content: [{ type: "text", text: "hello" }],
     });
-
     expect(result.queued).toBe(true);
-    expect(lastEnqueueOptions?.metadata).toMatchObject({
+
+    releaseGate?.();
+    await inFlight;
+    await waitFor(() => userRows(conversationId).length === 2, {
+      timeoutMs: 5_000,
+      message: "the queued turn never drained",
+    });
+
+    expect(metadataOf(userRows(conversationId)[1])).toMatchObject({
       userMessageChannel: "plugin",
       assistantMessageChannel: "plugin",
     });
-  });
+  }, 20_000);
 
   test("leaves the channel unset when the turn names none", async () => {
     // Clearing rather than leaving whatever the last turn set: a stale
     // context would report this turn on a channel it has nothing to do with.
     await runConversationTurn({
+      channel: CHANNEL,
       content: [{ type: "text", text: "hello" }],
     });
 
-    expect(lastTurnChannelContext).toBeNull();
-    expect(lastProcessMessageOptions?.metadata).toEqual({ automated: true });
+    const result = await runConversationTurn({
+      content: [{ type: "text", text: "hello" }],
+    });
+
+    const rows = getMessages(result.conversationId);
+    const userMetadata = metadataOf(rows[0]);
+    expect(userMetadata).toMatchObject({ automated: true });
+    expect(userMetadata?.userMessageChannel).toBeUndefined();
+    // The conversation carries no origin either, so the turn falls back to the
+    // native channel rather than to the previous turn's.
+    expect(metadataOf(rows[1])).toMatchObject({
+      userMessageChannel: "vellum",
+      assistantMessageChannel: "vellum",
+    });
   });
 
   test("keeps a known sender when a later turn omits it", async () => {


### PR DESCRIPTION
## Prompt / plan

Continuing the `mock.module` cleanup: delete `mock.module("../daemon/conversation-store.js", …)` from `assistant/src/__tests__/run-conversation-turn-persistence.test.ts` and keep the tests passing.

The mock was load-bearing in the wrong direction. Its `getOrCreateConversation` stub called `ensureConversationExists` itself, so the file's central claim — that the `conversations` row exists before the turn persists its user message — was proven by the stub rather than by production. The comment above it said the stub "mirrors" what the real function does, which is exactly the drift a mirror cannot catch.

So rather than swapping one stub for another, the turn now runs for real:

- **Real conversation store, real agent loop, real DB.** The row creation, the list invalidation, the metadata stamping and the queue drain are all production code paths now.
- **Only the provider's HTTP boundary is scripted.** Config and a `provider_connections` row are seeded for real (`helpers/set-config`, `createConnection`), and `resolveProviderFromConnection` is replaced with a `spyOn` returning the shared `helpers/mock-provider` — a scoped spy, not a process-global module replacement.
- **`resource-sync-events` is un-mocked too.** List invalidations are read off the events the real publisher broadcasts, tags and all, so the test now covers which tags a "created" reason actually emits. The `providers/media-resolve` mock is gone as dead weight; the event-hub mock stays as the one place SSE fan-out has nowhere to write in a test.
- **Assertions move from stub call-recording to persisted state.** Metadata is read back off the message rows through `parseMessageMetadata`, and the two queued-turn cases hold a real turn open inside the provider call, let the queue drain, and read the marker off the row it survived to — which is the property those tests were describing all along.

Net: 4 `mock.module` calls → 1.

## Test plan

- `bun test src/__tests__/run-conversation-turn-persistence.test.ts` — 16 pass, 0 fail; run repeatedly for flake (~6s per run, no failures).
- `bunx tsgo --noEmit`, `eslint`, and `prettier` clean (also enforced by the pre-commit hook).
- No production code changed — the diff is this one test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GWLSadgc1AJnYCk86gu6Aq
