### PR TITLE
refactor(assistant): delete canonicalAssistantId

### DIFF
--- a/assistant/src/__tests__/call-setup-flow-name-capture.test.ts
+++ b/assistant/src/__tests__/call-setup-flow-name-capture.test.ts
@@ -360,7 +360,6 @@ describe("CallSetupFlow name capture", () => {
     ).toEqual({ from: PHONE_NUMBER, callerName: CALLER_NAME });
     expect(f.notifyCalls).toEqual([
       {
-        canonicalAssistantId: "self",
         sourceChannel: "phone",
         conversationExternalId: PHONE_NUMBER,
         actorExternalId: PHONE_NUMBER,

--- a/assistant/src/__tests__/non-member-access-request.test.ts
+++ b/assistant/src/__tests__/non-member-access-request.test.ts
@@ -501,7 +501,6 @@ describe("access-request-helper unit tests", () => {
 
   test("notifyGuardianOfAccessRequest returns no_sender_id when actorExternalId is absent", async () => {
     const result = await notifyGuardianOfAccessRequest({
-      canonicalAssistantId: "self",
       sourceChannel: "telegram",
       conversationExternalId: "chat-123",
       actorExternalId: undefined,
@@ -522,7 +521,6 @@ describe("access-request-helper unit tests", () => {
 
   test("notifyGuardianOfAccessRequest creates request with self-healed principal when no binding exists", async () => {
     const result = await notifyGuardianOfAccessRequest({
-      canonicalAssistantId: "self",
       sourceChannel: "telegram",
       conversationExternalId: "chat-123",
       actorExternalId: "unknown-user",
@@ -565,7 +563,6 @@ describe("access-request-helper unit tests", () => {
     });
 
     const result = await notifyGuardianOfAccessRequest({
-      canonicalAssistantId: "self",
       sourceChannel: "telegram",
       conversationExternalId: "tg-chat",
       actorExternalId: "unknown-tg-user",
@@ -619,7 +616,6 @@ describe("access-request-helper unit tests", () => {
     });
 
     const result = await notifyGuardianOfAccessRequest({
-      canonicalAssistantId: "self",
       sourceChannel: "telegram",
       conversationExternalId: "chat-123",
       actorExternalId: "unknown-user",
@@ -660,7 +656,6 @@ describe("access-request-helper unit tests", () => {
     });
 
     const result = await notifyGuardianOfAccessRequest({
-      canonicalAssistantId: "self",
       sourceChannel: "telegram",
       conversationExternalId: "chat-123",
       actorExternalId: "unknown-user",
@@ -688,7 +683,6 @@ describe("access-request-helper unit tests", () => {
   test("notifyGuardianOfAccessRequest resolves the vellum anchor from the gateway delivery", async () => {
     // Only the vellum anchor (seeded in resetState) is served by the gateway.
     const result = await notifyGuardianOfAccessRequest({
-      canonicalAssistantId: "self",
       sourceChannel: "telegram",
       conversationExternalId: "chat-123",
       actorExternalId: "unknown-user",
@@ -722,7 +716,6 @@ describe("access-request-helper unit tests", () => {
 
     await expect(
       notifyGuardianOfAccessRequest({
-        canonicalAssistantId: "self",
         sourceChannel: "telegram",
         conversationExternalId: "chat-123",
         actorExternalId: "unknown-user",
@@ -739,7 +732,6 @@ describe("access-request-helper unit tests", () => {
 
   test("notifyGuardianOfAccessRequest for voice channel includes actorDisplayName in contextPayload", async () => {
     const result = await notifyGuardianOfAccessRequest({
-      canonicalAssistantId: "self",
       sourceChannel: "phone",
       conversationExternalId: "+15559998888",
       actorExternalId: "+15559998888",
@@ -770,7 +762,6 @@ describe("access-request-helper unit tests", () => {
 
   test("notifyGuardianOfAccessRequest includes requestCode in contextPayload", async () => {
     const result = await notifyGuardianOfAccessRequest({
-      canonicalAssistantId: "self",
       sourceChannel: "telegram",
       conversationExternalId: "chat-123",
       actorExternalId: "unknown-user",
@@ -794,7 +785,6 @@ describe("access-request-helper unit tests", () => {
     // is created and the status is forwarded to the card payload. (A `revoked`
     // status would instead suppress — covered by the keep-out tests.)
     const result = await notifyGuardianOfAccessRequest({
-      canonicalAssistantId: "self",
       sourceChannel: "telegram",
       conversationExternalId: "chat-123",
       actorExternalId: "pending-user",
@@ -834,7 +824,6 @@ describe("access-request-helper unit tests", () => {
     };
 
     const result = await notifyGuardianOfAccessRequest({
-      canonicalAssistantId: "self",
       sourceChannel: "phone",
       conversationExternalId: "+15556667777",
       actorExternalId: "+15556667777",
@@ -897,7 +886,6 @@ describe("access-request-helper unit tests", () => {
     };
 
     const result = await notifyGuardianOfAccessRequest({
-      canonicalAssistantId: "self",
       sourceChannel: "telegram",
       conversationExternalId: "chat-123",
       actorExternalId: "unknown-user",
@@ -929,7 +917,6 @@ describe("access-request-helper unit tests", () => {
     // request row. A revoked/blocked contact is deliberately kept out — no new
     // prompt, signal, or pending request.
     const result = await notifyGuardianOfAccessRequest({
-      canonicalAssistantId: "self",
       sourceChannel: "telegram",
       conversationExternalId: "chat-kept-out",
       actorExternalId: "revoked-user",
@@ -969,7 +956,6 @@ describe("access-request-helper unit tests", () => {
     });
 
     const result = await notifyGuardianOfAccessRequest({
-      canonicalAssistantId: "self",
       sourceChannel: "telegram",
       conversationExternalId: "chat-parked",
       actorExternalId: "parked-user",
@@ -1006,7 +992,6 @@ describe("access-request-helper unit tests", () => {
     });
 
     const result = await notifyGuardianOfAccessRequest({
-      canonicalAssistantId: "self",
       sourceChannel: "telegram",
       conversationExternalId: "chat-approved",
       actorExternalId: "approved-user",
@@ -1047,7 +1032,6 @@ describe("access-request-helper unit tests", () => {
     bridgeState.requests.get(requestId)!.updatedAt = staleUpdatedAt;
 
     const result = await notifyGuardianOfAccessRequest({
-      canonicalAssistantId: "self",
       sourceChannel: "telegram",
       conversationExternalId: "chat-stale",
       actorExternalId: "stale-user",
@@ -1082,7 +1066,6 @@ describe("access-request-helper unit tests", () => {
     });
 
     const result = await notifyGuardianOfAccessRequest({
-      canonicalAssistantId: "self",
       sourceChannel: "telegram",
       conversationExternalId: "chat-flip",
       actorExternalId: "flip-user",
@@ -1101,7 +1084,6 @@ describe("access-request-helper unit tests", () => {
     // Suppression is scoped to the sender via their own contact status, so a
     // kept-out contact never bleeds into a different sender's prompt.
     const keptOut = await notifyGuardianOfAccessRequest({
-      canonicalAssistantId: "self",
       sourceChannel: "telegram",
       conversationExternalId: "chat-kept",
       actorExternalId: "revoked-user",
@@ -1112,7 +1094,6 @@ describe("access-request-helper unit tests", () => {
 
     // A different sender with no keep-out still gets a fresh prompt.
     const result = await notifyGuardianOfAccessRequest({
-      canonicalAssistantId: "self",
       sourceChannel: "telegram",
       conversationExternalId: "chat-fresh",
       actorExternalId: "fresh-user",
@@ -1141,7 +1122,6 @@ describe("maybeNotifyGuardianOfAdmittedContact", () => {
   });
 
   const baseParams = {
-    canonicalAssistantId: "self",
     sourceChannel: "telegram" as const,
     conversationExternalId: "chat-123",
     actorExternalId: "user-unknown-456",

--- a/assistant/src/__tests__/secret-ingress-channel.test.ts
+++ b/assistant/src/__tests__/secret-ingress-channel.test.ts
@@ -62,7 +62,6 @@ function makeParams(
       sourceChannel: "slack" as const,
     } as any,
     replyCallbackUrl: undefined,
-    canonicalAssistantId: "self",
     ...overrides,
   };
 }

--- a/assistant/src/calls/call-setup-flow.ts
+++ b/assistant/src/calls/call-setup-flow.ts
@@ -1393,7 +1393,6 @@ export class CallSetupFlow {
 
     try {
       const accessResult = await ndeps.notifyGuardianOfAccessRequest({
-        canonicalAssistantId: accessRequest.assistantId,
         sourceChannel: "phone",
         conversationExternalId: accessRequest.fromNumber,
         actorExternalId: accessRequest.fromNumber,

--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -29,6 +29,7 @@ import { buildVellumCardAffinity } from "../notifications/vellum-card-affinity.j
 import { IntegrityError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import { resolveAnchoredGuardian } from "./anchored-guardian.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "./assistant-scope.js";
 import { CHALLENGE_TTL_MS } from "./channel-verification-service.js";
 import {
   type AccessRequestTrigger,
@@ -46,7 +47,6 @@ const log = getLogger("access-request-helper");
 export type { AccessRequestTrigger } from "./introduction-policy.js";
 
 export interface AccessRequestParams {
-  canonicalAssistantId: string;
   sourceChannel: ChannelId;
   conversationExternalId: string;
   actorExternalId?: string;
@@ -93,15 +93,18 @@ export type AccessRequestResult =
 // ---------------------------------------------------------------------------
 
 /**
- * Assistant-scoped conversation id for an actor's access requests. Stable key
- * that dedupes pending prompts for the same (assistant, channel, actor).
+ * Conversation id for an actor's access requests. Stable key that dedupes
+ * pending prompts for the same (channel, actor).
+ *
+ * The `self` segment is part of a persisted id format: guardian request rows
+ * carry these ids, so the shape is fixed even though the daemon scopes all its
+ * storage to the one assistant (`DAEMON_INTERNAL_ASSISTANT_ID`).
  */
 export function accessRequestConversationId(
-  canonicalAssistantId: string,
   sourceChannel: string,
   actorExternalId: string,
 ): string {
-  return `access-req-${canonicalAssistantId}-${sourceChannel}-${actorExternalId}`;
+  return `access-req-${DAEMON_INTERNAL_ASSISTANT_ID}-${sourceChannel}-${actorExternalId}`;
 }
 
 /**
@@ -126,7 +129,6 @@ export function accessRequestConversationId(
  * fail-closed.
  */
 export async function isApprovalHandshakeInProgress(params: {
-  canonicalAssistantId: string;
   sourceChannel: string;
   actorExternalId: string;
 }): Promise<boolean> {
@@ -134,7 +136,6 @@ export async function isApprovalHandshakeInProgress(params: {
     return false;
   }
   const conversationId = accessRequestConversationId(
-    params.canonicalAssistantId,
     params.sourceChannel,
     params.actorExternalId,
   );
@@ -171,7 +172,6 @@ export async function notifyGuardianOfAccessRequest(
   params: AccessRequestParams,
 ): Promise<AccessRequestResult> {
   const {
-    canonicalAssistantId,
     sourceChannel,
     conversationExternalId,
     actorExternalId,
@@ -219,7 +219,6 @@ export async function notifyGuardianOfAccessRequest(
   // from assistant A could be returned for assistant B, allowing the caller
   // to piggyback on A's guardian approval.
   const conversationId = accessRequestConversationId(
-    canonicalAssistantId,
     sourceChannel,
     actorExternalId,
   );
@@ -270,7 +269,6 @@ export async function notifyGuardianOfAccessRequest(
   // re-prompting is allowed again.
   if (
     await isApprovalHandshakeInProgress({
-      canonicalAssistantId,
       sourceChannel,
       actorExternalId,
     })
@@ -283,7 +281,7 @@ export async function notifyGuardianOfAccessRequest(
   }
 
   const senderIdentifier = actorDisplayName || actorUsername || actorExternalId;
-  const requestId = `access-req-${canonicalAssistantId}-${sourceChannel}-${actorExternalId}-${Date.now()}`;
+  const requestId = `access-req-${DAEMON_INTERNAL_ASSISTANT_ID}-${sourceChannel}-${actorExternalId}-${Date.now()}`;
 
   // Access requests are decisionable: without a bound principal nobody could
   // ever decide them (mirrors the gateway create's integrity guard).
@@ -461,7 +459,6 @@ export async function maybeNotifyGuardianOfAdmittedContact(
   }
 
   const conversationId = accessRequestConversationId(
-    params.canonicalAssistantId,
     params.sourceChannel,
     params.actorExternalId,
   );

--- a/assistant/src/runtime/routes/channel-route-shared.ts
+++ b/assistant/src/runtime/routes/channel-route-shared.ts
@@ -2,18 +2,12 @@
  * Shared types, constants, and utilities used across channel route modules.
  */
 import type { ChannelId } from "../../channels/types.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import {
   type ApprovalAction,
   type ApprovalDecisionResult,
   type ApprovalUIMetadata,
   isApprovalAction,
 } from "../channel-approval-types.js";
-
-/** Canonicalize assistantId for channel ingress paths. */
-export function canonicalChannelAssistantId(_assistantId: string): string {
-  return DAEMON_INTERNAL_ASSISTANT_ID;
-}
 
 // ---------------------------------------------------------------------------
 // Actor role

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -101,7 +101,6 @@ import {
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import { deliverChannelReply } from "../gateway-client.js";
 import { trustContextFromVerdict } from "../trust-verdict-consumer.js";
-import { canonicalChannelAssistantId } from "./channel-route-shared.js";
 import { BadRequestError } from "./errors.js";
 import { handleApprovalInterception } from "./guardian-approval-interception.js";
 import {
@@ -371,16 +370,6 @@ export async function handleChannelInbound({
     throw new BadRequestError("content or attachmentIds is required");
   }
 
-  // Canonicalize the assistant ID so all DB-facing operations use the
-  // consistent 'self' key regardless of what the gateway sent.
-  const canonicalAssistantId = canonicalChannelAssistantId(assistantId);
-  if (canonicalAssistantId !== assistantId) {
-    log.debug(
-      { raw: assistantId, canonical: canonicalAssistantId },
-      "Canonicalized channel assistant ID",
-    );
-  }
-
   // Coerce actorExternalId to a string at the boundary — the field
   // comes from unvalidated JSON and may be a number, object, or other
   // non-string type. Non-string truthy values would throw inside
@@ -438,7 +427,6 @@ export async function handleChannelInbound({
       sourceInterface,
       conversationExternalId,
       externalMessageId,
-      canonicalAssistantId,
       rawSenderId,
       canonicalSenderId,
       actorDisplayName: body.actorDisplayName,
@@ -486,7 +474,6 @@ export async function handleChannelInbound({
     rawSenderId,
     sourceChannel,
     conversationExternalId,
-    canonicalAssistantId,
     trimmedContent,
     sourceMetadata: body.sourceMetadata,
     actorDisplayName: body.actorDisplayName,
@@ -839,7 +826,6 @@ export async function handleChannelInbound({
     if (isCallbackInteraction) {
       if (floorSenderId) {
         handshakeInProgress = await isApprovalHandshakeInProgress({
-          canonicalAssistantId,
           sourceChannel,
           actorExternalId: floorSenderId,
         });
@@ -847,7 +833,6 @@ export async function handleChannelInbound({
     } else {
       try {
         const accessResult = await notifyGuardianOfAccessRequest({
-          canonicalAssistantId,
           sourceChannel,
           conversationExternalId,
           actorExternalId: floorSenderId,
@@ -920,7 +905,7 @@ export async function handleChannelInbound({
       const replyPayload: Parameters<typeof deliverChannelReply>[1] = {
         chatId: conversationExternalId,
         text: replyText,
-        assistantId: canonicalAssistantId,
+        assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
       };
       if (sourceChannel === "slack" && (canonicalSenderId ?? rawSenderId)) {
         replyPayload.ephemeral = true;
@@ -982,7 +967,7 @@ export async function handleChannelInbound({
       const replyPayload: Parameters<typeof deliverChannelReply>[1] = {
         chatId: conversationExternalId,
         text: DISK_PRESSURE_REMOTE_BLOCK_REPLY,
-        assistantId: canonicalAssistantId,
+        assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
       };
       if (sourceChannel === "slack" && (canonicalSenderId ?? rawSenderId)) {
         replyPayload.ephemeral = true;
@@ -1054,7 +1039,6 @@ export async function handleChannelInbound({
     isDuplicate: result.duplicate,
     commandIntent,
     rawSenderId,
-    canonicalAssistantId,
     sourceChannel,
     conversationExternalId,
     eventId: result.eventId,
@@ -1076,7 +1060,6 @@ export async function handleChannelInbound({
     callbackData: body.callbackData,
     rawSenderId,
     canonicalSenderId,
-    canonicalAssistantId,
     sourceChannel,
     conversationExternalId,
     conversationId: result.conversationId,
@@ -1118,7 +1101,7 @@ export async function handleChannelInbound({
       actorExternalId: canonicalSenderId ?? rawSenderId,
       replyCallbackUrl,
       trustCtx,
-      assistantId: canonicalAssistantId,
+      assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
       approvalCopyGenerator,
       approvalConversationGenerator,
       approvalMessageTs,
@@ -1214,7 +1197,7 @@ export async function handleChannelInbound({
           chatId: conversationExternalId,
           text: "This approval request has been resolved.",
           messageTs: approvalMessageTs,
-          assistantId: canonicalAssistantId,
+          assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
         }).catch((err) => {
           log.error(
             { err, conversationId: result.conversationId },
@@ -1250,7 +1233,6 @@ export async function handleChannelInbound({
       actorUsername: body.actorUsername,
       trustCtx,
       replyCallbackUrl,
-      canonicalAssistantId,
     });
 
     if (ingressResult.blocked) {
@@ -1291,7 +1273,6 @@ export async function handleChannelInbound({
         const admittedSenderId = canonicalSenderId ?? rawSenderId;
         if (admittedSenderId) {
           void maybeNotifyGuardianOfAdmittedContact({
-            canonicalAssistantId,
             sourceChannel,
             conversationExternalId,
             actorExternalId: admittedSenderId,
@@ -1492,7 +1473,7 @@ export async function handleChannelInbound({
         commandIntent,
         sourceLanguageCode,
         replyCallbackUrl,
-        assistantId: canonicalAssistantId,
+        assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
         approvalCopyGenerator,
         chatType: sourceChatType,
         clientTimezone: inboundClientTimezone,

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
@@ -98,7 +98,6 @@ function makeParams(
     rawSenderId: "sender-1",
     sourceChannel: "telegram",
     conversationExternalId: "chat-1",
-    canonicalAssistantId: "assistant-1",
     trimmedContent: "hello",
     sourceMetadata: undefined,
     actorDisplayName: "Sender One",

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -90,7 +90,6 @@ export interface AclEnforcementParams {
   rawSenderId: string | undefined;
   sourceChannel: ChannelId;
   conversationExternalId: string;
-  canonicalAssistantId: string;
   trimmedContent: string;
   sourceMetadata: SourceMetadata | undefined;
   actorDisplayName: string | undefined;
@@ -190,7 +189,6 @@ export async function enforceIngressAcl(
     rawSenderId,
     sourceChannel,
     conversationExternalId,
-    canonicalAssistantId,
     trimmedContent,
     sourceMetadata,
     actorDisplayName,
@@ -426,7 +424,6 @@ export async function enforceIngressAcl(
             // Still notify the guardian about the access attempt
             try {
               await notifyGuardianOfAccessRequest({
-                canonicalAssistantId,
                 sourceChannel,
                 conversationExternalId,
                 actorExternalId: canonicalSenderId ?? rawSenderId,
@@ -509,7 +506,6 @@ export async function enforceIngressAcl(
           if (emailVerifyResult.initiated) {
             try {
               await notifyGuardianOfAccessRequest({
-                canonicalAssistantId,
                 sourceChannel,
                 conversationExternalId,
                 actorExternalId: canonicalSenderId ?? rawSenderId,
@@ -554,14 +550,12 @@ export async function enforceIngressAcl(
         let handshakeInProgress = false;
         if (isCallbackInteraction) {
           handshakeInProgress = await isApprovalHandshakeInProgress({
-            canonicalAssistantId,
             sourceChannel,
             actorExternalId: (canonicalSenderId ?? rawSenderId)!,
           });
         } else {
           try {
             const accessResult = await notifyGuardianOfAccessRequest({
-              canonicalAssistantId,
               sourceChannel,
               conversationExternalId,
               actorExternalId: canonicalSenderId ?? rawSenderId,
@@ -730,7 +724,6 @@ export async function enforceIngressAcl(
             if (slackVerifyResult.initiated) {
               try {
                 await notifyGuardianOfAccessRequest({
-                  canonicalAssistantId,
                   sourceChannel,
                   conversationExternalId,
                   actorExternalId: canonicalSenderId ?? rawSenderId,
@@ -803,14 +796,12 @@ export async function enforceIngressAcl(
           if (!terminallyKeptOut) {
             if (isCallbackInteraction) {
               handshakeInProgress = await isApprovalHandshakeInProgress({
-                canonicalAssistantId,
                 sourceChannel,
                 actorExternalId: (canonicalSenderId ?? rawSenderId)!,
               });
             } else {
               try {
                 const accessResult = await notifyGuardianOfAccessRequest({
-                  canonicalAssistantId,
                   sourceChannel,
                   conversationExternalId,
                   actorExternalId: canonicalSenderId ?? rawSenderId,

--- a/assistant/src/runtime/routes/inbound-stages/bootstrap-intercept.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/bootstrap-intercept.test.ts
@@ -54,7 +54,6 @@ function makeParams(
     isDuplicate: false,
     commandIntent: { type: "start", payload: "gv_token123" },
     rawSenderId: "user-42",
-    canonicalAssistantId: "self",
     sourceChannel: "telegram",
     conversationExternalId: "chat-123",
     eventId: "event-1",

--- a/assistant/src/runtime/routes/inbound-stages/bootstrap-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/bootstrap-intercept.ts
@@ -24,6 +24,7 @@ import {
 import type { ChannelId } from "../../../channels/types.js";
 import { sendTelegramReply } from "../../../messaging/providers/telegram-bot/send.js";
 import { getLogger } from "../../../util/logger.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../assistant-scope.js";
 import { RESEND_COOLDOWN_MS } from "../../verification-outbound-actions.js";
 import {
   composeVerificationText,
@@ -40,7 +41,6 @@ export interface BootstrapInterceptParams {
   isDuplicate: boolean;
   commandIntent: Record<string, unknown> | undefined;
   rawSenderId: string | undefined;
-  canonicalAssistantId: string;
   sourceChannel: ChannelId;
   conversationExternalId: string;
   eventId: string;
@@ -96,7 +96,6 @@ export async function handleBootstrapIntercept(
     isDuplicate,
     commandIntent,
     rawSenderId,
-    canonicalAssistantId,
     sourceChannel,
     conversationExternalId,
     eventId,
@@ -208,7 +207,7 @@ export async function handleBootstrapIntercept(
   deliverBootstrapVerificationTelegram(
     conversationExternalId,
     telegramBody,
-    canonicalAssistantId,
+    DAEMON_INTERNAL_ASSISTANT_ID,
   );
 
   // Update delivery tracking (best-effort — the code is already on its way)

--- a/assistant/src/runtime/routes/inbound-stages/guardian-reply-intercept.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-reply-intercept.test.ts
@@ -51,7 +51,6 @@ function makeParams(
     callbackData: undefined,
     rawSenderId: "user-42",
     canonicalSenderId: "user-42",
-    canonicalAssistantId: "self",
     sourceChannel: "slack" as const,
     conversationExternalId: "chat-123",
     conversationId: "conv-abc",

--- a/assistant/src/runtime/routes/inbound-stages/guardian-reply-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-reply-intercept.ts
@@ -15,6 +15,7 @@ import {
 } from "../../../channels/gateway-guardian-requests.js";
 import type { ChannelId } from "../../../channels/types.js";
 import { getLogger } from "../../../util/logger.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../assistant-scope.js";
 import { deliverChannelReply } from "../../gateway-client.js";
 import {
   type GuardianPendingScope,
@@ -41,7 +42,6 @@ export interface GuardianReplyInterceptParams {
   reactedMessageTs?: string;
   rawSenderId: string | undefined;
   canonicalSenderId: string | null;
-  canonicalAssistantId: string;
   sourceChannel: ChannelId;
   conversationExternalId: string;
   conversationId: string;
@@ -77,7 +77,6 @@ export async function handleGuardianReplyIntercept(
     reactedMessageTs,
     rawSenderId,
     canonicalSenderId,
-    canonicalAssistantId,
     sourceChannel,
     conversationExternalId,
     conversationId,
@@ -178,7 +177,7 @@ export async function handleGuardianReplyIntercept(
     channelDeliveryContext: {
       replyCallbackUrl,
       guardianChatId: conversationExternalId,
-      assistantId: canonicalAssistantId,
+      assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
     },
   });
 
@@ -188,7 +187,7 @@ export async function handleGuardianReplyIntercept(
       const routerReplyPayload: Parameters<typeof deliverChannelReply>[1] = {
         chatId: conversationExternalId,
         text: routerResult.replyText,
-        assistantId: canonicalAssistantId,
+        assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
       };
       // On Slack, send guardian management replies (disambiguation, pending
       // request lists, etc.) as ephemeral so only the guardian sees them.

--- a/assistant/src/runtime/routes/inbound-stages/reaction-intercept.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/reaction-intercept.test.ts
@@ -172,7 +172,6 @@ function buildParams(overrides: {
     sourceInterface: "slack" as const,
     conversationExternalId: SLACK_CHANNEL_ID,
     externalMessageId: `${SLACK_CHANNEL_ID}:1700000000.1:${msgCounter}`,
-    canonicalAssistantId: "assistant-1",
     rawSenderId: overrides.rawSenderId,
     canonicalSenderId: overrides.rawSenderId,
     actorDisplayName: "Reactor",

--- a/assistant/src/runtime/routes/inbound-stages/reaction-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/reaction-intercept.ts
@@ -35,7 +35,6 @@ import {
 import { markProcessed } from "../../../persistence/delivery-status.js";
 import { upsertBinding } from "../../../persistence/external-conversation-store.js";
 import { getLogger } from "../../../util/logger.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../assistant-scope.js";
 import type { ApprovalConversationGenerator } from "../../http-types.js";
 import {
   actorTrustContextFromVerdict,
@@ -100,7 +99,6 @@ export interface ReactionInterceptParams {
   sourceInterface: InterfaceId | undefined;
   conversationExternalId: string;
   externalMessageId: string;
-  canonicalAssistantId: string;
   rawSenderId: string | undefined;
   canonicalSenderId: string | null;
   actorDisplayName: string | undefined;
@@ -126,7 +124,6 @@ export async function handleSlackReactionIntercept(
     sourceInterface,
     conversationExternalId,
     externalMessageId,
-    canonicalAssistantId,
     rawSenderId,
     canonicalSenderId,
     actorDisplayName,
@@ -215,21 +212,17 @@ export async function handleSlackReactionIntercept(
     };
   }
 
-  // Maintain the conversation binding, matching the message pipeline. Scoped to
-  // the daemon's own assistant so assistant-scoped legacy routes don't clobber
-  // each other's binding metadata.
-  if (canonicalAssistantId === DAEMON_INTERNAL_ASSISTANT_ID) {
-    upsertBinding({
-      conversationId: result.conversationId,
-      sourceChannel,
-      externalChatId: conversationExternalId,
-      externalChatName: slackChannelName,
-      externalThreadId: threadTs ?? null,
-      externalUserId: canonicalSenderId ?? rawSenderId ?? null,
-      displayName: actorDisplayName ?? null,
-      username: actorUsername ?? null,
-    });
-  }
+  // Maintain the conversation binding, matching the message pipeline.
+  upsertBinding({
+    conversationId: result.conversationId,
+    sourceChannel,
+    externalChatId: conversationExternalId,
+    externalChatName: slackChannelName,
+    externalThreadId: threadTs ?? null,
+    externalUserId: canonicalSenderId ?? rawSenderId ?? null,
+    displayName: actorDisplayName ?? null,
+    username: actorUsername ?? null,
+  });
 
   // Guardian approval-by-reaction → guardian decision pipeline, exactly like
   // buttons and text replies. Only `reaction:` (added) expresses intent;
@@ -246,7 +239,6 @@ export async function handleSlackReactionIntercept(
       reactedMessageTs,
       rawSenderId,
       canonicalSenderId,
-      canonicalAssistantId,
       sourceChannel,
       conversationExternalId,
       conversationId: result.conversationId,

--- a/assistant/src/runtime/routes/inbound-stages/secret-ingress-check.ts
+++ b/assistant/src/runtime/routes/inbound-stages/secret-ingress-check.ts
@@ -14,6 +14,7 @@ import {
 } from "../../../persistence/delivery-crud.js";
 import { checkIngressForSecrets } from "../../../security/secret-ingress.js";
 import { getLogger } from "../../../util/logger.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../assistant-scope.js";
 
 const log = getLogger("runtime-http");
 
@@ -36,7 +37,6 @@ export interface SecretIngressCheckParams {
   actorUsername: string | undefined;
   trustCtx: TrustContext;
   replyCallbackUrl: string | undefined;
-  canonicalAssistantId: string;
 }
 
 export interface SecretIngressCheckResult {
@@ -69,7 +69,6 @@ export function runSecretIngressCheck(
     actorUsername,
     trustCtx,
     replyCallbackUrl,
-    canonicalAssistantId,
   } = params;
 
   // Persist the raw payload so dead-lettered events can always be replayed.
@@ -85,7 +84,7 @@ export function runSecretIngressCheck(
     senderUsername: actorUsername,
     trustCtx,
     replyCallbackUrl,
-    assistantId: canonicalAssistantId,
+    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
   });
 
   // ── Secret ingress scan ──


### PR DESCRIPTION
## Prompt / plan

> we should delete `canonicalAssistantId` in all forms

Zero occurrences repo-wide now, including `canonicalChannelAssistantId` itself. Net −75 lines.

The daemon is single-tenant and scopes its storage to `self`, and `canonicalChannelAssistantId` discarded its argument and answered `self` for every caller:

```ts
export function canonicalChannelAssistantId(_assistantId: string): string {
  return DAEMON_INTERNAL_ASSISTANT_ID;
}
```

Everything downstream therefore threaded a single value under a name implying a choice. Where a value is genuinely needed it is now `DAEMON_INTERNAL_ASSISTANT_ID` at the point of use.

### Two places keep the literal

Both embed it in a **persisted id format**, so the shape is fixed even though the parameter is not:

- `accessRequestConversationId` → `access-req-${self}-${channel}-${actor}`
- the guardian request id → `access-req-${self}-${channel}-${actor}-${Date.now()}`

Rows already carry these ids, same reasoning as the `asst:self:` conversation-key prefix.

### A dead gate falls out

`reaction-intercept` wrapped its `upsertBinding` in `if (canonicalAssistantId === DAEMON_INTERNAL_ASSISTANT_ID)` — the twin of the one removed in #40573, and equally undecidable. Gone; the binding is written unconditionally, matching the message pipeline.

### The calls path, checked rather than assumed

`call-setup-flow` passed `accessRequest.assistantId` into the access-request helper, a value off a call session rather than an obvious `self`. Traced: `twilio-routes` is the only inbound-call entry point and never supplies `assistantId`, so `createInboundVoiceSession` defaults it.

That also makes the non-self branch at `call-domain.ts:277` unreachable — `asst:${assistantId}:voice:inbound:${callSid}` can never be taken, only the flat `voice:inbound:${callSid}`. Left alone here: it belongs to the calls subsystem's own conversation keying, not to this symbol, and it wants its own change.

## Test plan

- All seven directly affected suites pass individually: `non-member-access-request`, `call-setup-flow-name-capture`, `secret-ingress-channel`, `acl-enforcement`, `reaction-intercept`, `bootstrap-intercept`, `guardian-reply-intercept`.
- Assistant typecheck and lint clean.
- Full suite shows the same 7 failures that fail on `origin/main` in this container (sandbox and script-proxy tests), verified previously in a scratch worktree at `origin/main`. No additions.

Behaviour-preserving throughout: every removed argument was already `self` at every call site.

---
_Generated by [Claude Code](https://claude.ai/code/session_013p1nTdvsuAtTJ7zyCSDLbx)_