### PR TITLE
fix(plugins): point the unabyss entry at the upstream repo

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -426,8 +426,8 @@
       "name": "unabyss",
       "source": {
         "source": "github",
-        "repo": "vellum-ai/unabyss-vellum",
-        "ref": "bc2c6d815fdbb36b58ca78ca4bb28f507fc415c3"
+        "repo": "Unabyss/unabyss-vellum",
+        "ref": "9f0bb0753dad09dace8578e242961bc2da912af3"
       },
       "description": "Personal and company context from Unabyss, available to your agent through the Unabyss MCP server.",
       "category": "memory",


### PR DESCRIPTION
## Prompt / plan

Follow-up to #40606, which pinned the catalog entry at `vellum-ai/unabyss-vellum` — our fork. The plugin's own repo is `Unabyss/unabyss-vellum`.

```diff
-        "repo": "vellum-ai/unabyss-vellum",
-        "ref": "bc2c6d815fdbb36b58ca78ca4bb28f507fc415c3"
+        "repo": "Unabyss/unabyss-vellum",
+        "ref": "9f0bb0753dad09dace8578e242961bc2da912af3"
```

Evidence this is the root, not another fork: `Unabyss/unabyss-vellum` reports `fork: false` with exactly one fork (ours), and its `plugin.json` names `https://github.com/Unabyss/unabyss-vellum` as the plugin's repository — ours still names `vellum-ai`.

**The new SHA is strictly ahead of the old one, not a parallel history.** Upstream merged our fork into `main` (`cc8aff3`, "Merge pull request #1 from vellum-ai/main", which carries `bc2c6d8`), then landed one more change of its own (`9f0bb07` ← #2): setup split into its own skill, manifests corrected, CI added. So this both fixes the ownership and moves the catalog forward — installs now get `skills/unabyss-context` **and** `skills/unabyss-setup`, where the old pin stopped before the split.

Verified at the new commit rather than assumed: `plugin.json` name `unabyss` v0.3.0, `mcp.json` unchanged (`streamable-http` → `https://mcp.unabyss.com`), MIT license present. Every other field on the entry is untouched.

## Test plan

- Validated the edited manifest against the real `marketplaceManifestSchema` — parses clean, entry round-trips with all fields. Confirmed `REPO_SLUG_RE` accepts the `Unabyss` owner casing (`/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/`), and the new ref satisfies the 40-hex `COMMIT_SHA_RE`.
- Confirmed `9f0bb07` is the tip of upstream `main` by cloning the repo, not by reading it off a web page.
- `plugin-catalog-local`, `search-plugins`, `plugins-install-offline`, `plugins-routes` all pass (146 tests). `prettier --check` clean; `meta/sync-bundled-copies.ts` runs clean and its only target is gitignored, so the canonical file is the sole change.

---
_Generated by [Claude Code](https://claude.ai/code/session_016DpUibHyfia8WfnPL4vCS5)_