### PR TITLE
fix(web): one-click reconnect for a stopped local assistant

### DIFF
--- a/clients/web/src/domains/onboarding/components/connect-recovery-dialog.test.tsx
+++ b/clients/web/src/domains/onboarding/components/connect-recovery-dialog.test.tsx
@@ -8,8 +8,9 @@
  * rendered so the destructive styling and `isPending` behavior asserted
  * here are the actual shipped behavior, not a mock's.
  *
- * What matters: the step machine. `onRepair`/`onRetire` must only ever
- * fire from their nested confirmation steps, never from the menu.
+ * What matters: repair is a single click (the reconnect path a user walks on
+ * every launch), while retire stays behind its destructive confirmation and
+ * out of the primary button stack.
  */
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
@@ -20,22 +21,29 @@ import { ConnectRecoveryDialog } from "@/domains/onboarding/components/connect-r
 
 afterEach(cleanup);
 
-function getButton(label: string): HTMLButtonElement {
+function findButton(label: string): HTMLButtonElement | undefined {
   // Modals portal into document.body, so query the document rather than
   // the render container.
-  const buttons = Array.from(
+  return Array.from(
     document.querySelectorAll<HTMLButtonElement>("button"),
-  );
-  const match = buttons.find((b) => b.textContent?.trim() === label);
+  ).find((b) => b.textContent?.trim() === label);
+}
+
+function getButton(label: string): HTMLButtonElement {
+  const match = findButton(label);
   if (!match) {
     throw new Error(
-      `expected to find a "${label}" button — saw: ${buttons
+      `expected to find a "${label}" button — saw: ${Array.from(
+        document.querySelectorAll<HTMLButtonElement>("button"),
+      )
         .map((b) => `"${b.textContent?.trim()}"`)
         .join(", ")}`,
     );
   }
   return match;
 }
+
+const RETIRE_ACTION = "Retire Assistant…";
 
 function renderDialog(
   overrides: Partial<Parameters<typeof ConnectRecoveryDialog>[0]> = {},
@@ -70,8 +78,27 @@ describe("Menu step", () => {
       "The authentication token for Local Assistant",
     );
     expect(getButton("Wake & Repair")).toBeTruthy();
-    expect(getButton("Retire Assistant")).toBeTruthy();
+    expect(getButton(RETIRE_ACTION)).toBeTruthy();
     expect(getButton("Cancel")).toBeTruthy();
+  });
+
+  test("states the repair side effect up front, since repair is one click", () => {
+    renderDialog();
+    expect(document.body.textContent).toContain(
+      "signed out and need to reconnect",
+    );
+  });
+
+  test("retire sits apart from the primary stack, compact and low-emphasis", () => {
+    renderDialog();
+    const repair = getButton("Wake & Repair");
+    const retire = getButton(RETIRE_ACTION);
+    // Not a sibling of the primary button: a stray click below "Wake & Repair"
+    // lands on Cancel, never on the destructive action.
+    expect(retire.parentElement).not.toBe(repair.parentElement);
+    expect(repair.parentElement?.contains(retire)).toBe(false);
+    expect(retire.className).toContain("h-6");
+    expect(retire.className).not.toContain("w-full");
   });
 
   test("renders nothing when open=false", () => {
@@ -88,49 +115,36 @@ describe("Menu step", () => {
   });
 });
 
-describe("Repair confirmation", () => {
-  test("Wake & Repair advances to the confirmation instead of firing onRepair", () => {
-    const { onRepair } = renderDialog();
+describe("Repair", () => {
+  test("Wake & Repair fires onRepair on a single click", () => {
+    const { onRepair, onRetire, onCancel } = renderDialog();
     fireEvent.click(getButton("Wake & Repair"));
-    expect(onRepair).not.toHaveBeenCalled();
-    expect(document.body.textContent).toContain("Repair Assistant?");
-    // The confirmation states the real side effect.
-    expect(document.body.textContent).toContain(
-      "signed out and need to reconnect",
-    );
-  });
-
-  test("confirming fires onRepair", () => {
-    const { onRepair } = renderDialog();
-    fireEvent.click(getButton("Wake & Repair"));
-    fireEvent.click(getButton("Repair"));
     expect(onRepair).toHaveBeenCalledTimes(1);
-  });
-
-  test("canceling the confirmation returns to the menu without firing callbacks", () => {
-    const { onRepair, onCancel } = renderDialog();
-    fireEvent.click(getButton("Wake & Repair"));
-    fireEvent.click(getButton("Cancel"));
-    expect(document.body.textContent).toContain("Can’t Authenticate Assistant");
-    expect(onRepair).not.toHaveBeenCalled();
+    expect(onRetire).not.toHaveBeenCalled();
     expect(onCancel).not.toHaveBeenCalled();
+    // No confirmation step stands between the click and the repair.
+    expect(document.body.textContent).not.toContain("Repair Assistant?");
   });
 
-  test("isPending disables the confirm button", () => {
-    const { rerender, onRepair } = renderDialog();
-    fireEvent.click(getButton("Wake & Repair"));
+  test("isPending shows progress and blocks a second repair", () => {
+    const { rerender, onRepair, onCancel } = renderDialog();
     rerender({ isPending: true });
-    const repair = getButton("Repair");
-    expect(repair.disabled).toBe(true);
-    fireEvent.click(repair);
+    expect(findButton("Wake & Repair")).toBeUndefined();
+    const repairing = getButton("Repairing…");
+    expect(repairing.disabled).toBe(true);
+    fireEvent.click(repairing);
     expect(onRepair).not.toHaveBeenCalled();
+    // The escape hatches are held too, so a click can't race the repair.
+    expect(getButton("Cancel").disabled).toBe(true);
+    expect(getButton(RETIRE_ACTION).disabled).toBe(true);
+    expect(onCancel).not.toHaveBeenCalled();
   });
 });
 
 describe("Retire confirmation", () => {
-  test("Retire Assistant advances to a destructive confirmation instead of firing onRetire", () => {
+  test("retire advances to a destructive confirmation instead of firing onRetire", () => {
     const { onRetire } = renderDialog();
-    fireEvent.click(getButton("Retire Assistant"));
+    fireEvent.click(getButton(RETIRE_ACTION));
     expect(onRetire).not.toHaveBeenCalled();
     expect(document.body.textContent).toContain(
       "This will permanently retire this assistant and all of its data.",
@@ -144,19 +158,19 @@ describe("Retire confirmation", () => {
 
   test("confirming fires onRetire; canceling returns to the menu", () => {
     const { onRetire } = renderDialog();
-    fireEvent.click(getButton("Retire Assistant"));
+    fireEvent.click(getButton(RETIRE_ACTION));
     fireEvent.click(getButton("Cancel"));
     expect(getButton("Wake & Repair")).toBeTruthy();
     expect(onRetire).not.toHaveBeenCalled();
 
-    fireEvent.click(getButton("Retire Assistant"));
+    fireEvent.click(getButton(RETIRE_ACTION));
     fireEvent.click(getButton("Retire"));
     expect(onRetire).toHaveBeenCalledTimes(1);
   });
 
   test("isPending disables the confirm button", () => {
     const { rerender, onRetire } = renderDialog();
-    fireEvent.click(getButton("Retire Assistant"));
+    fireEvent.click(getButton(RETIRE_ACTION));
     rerender({ isPending: true });
     const retire = getButton("Retire");
     expect(retire.disabled).toBe(true);
@@ -173,14 +187,13 @@ describe("Error display", () => {
     );
   });
 
-  test("errorMessage renders inside the active confirmation step", () => {
+  test("errorMessage renders inside the retire confirmation", () => {
     const { rerender } = renderDialog();
-    fireEvent.click(getButton("Wake & Repair"));
-    rerender({ errorMessage: "Repair failed. Please try again." });
-    // Still on the confirmation step, with the failure shown inline.
-    expect(document.body.textContent).toContain("Repair Assistant?");
+    fireEvent.click(getButton(RETIRE_ACTION));
+    rerender({ errorMessage: "Failed to retire assistant. Please try again." });
+    expect(document.body.textContent).toContain("Retire Assistant");
     expect(document.body.textContent).toContain(
-      "Repair failed. Please try again.",
+      "Failed to retire assistant. Please try again.",
     );
   });
 });
@@ -188,8 +201,10 @@ describe("Error display", () => {
 describe("Reset on reopen", () => {
   test("reopening lands on the menu even if closed mid-confirmation", () => {
     const { rerender } = renderDialog();
-    fireEvent.click(getButton("Wake & Repair"));
-    expect(document.body.textContent).toContain("Repair Assistant?");
+    fireEvent.click(getButton(RETIRE_ACTION));
+    expect(document.body.textContent).toContain(
+      "This will permanently retire this assistant",
+    );
 
     rerender({ open: false });
     rerender({ open: true });

--- a/clients/web/src/domains/onboarding/components/connect-recovery-dialog.tsx
+++ b/clients/web/src/domains/onboarding/components/connect-recovery-dialog.tsx
@@ -1,12 +1,10 @@
+import { Loader2 } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { Button } from "@vellumai/design-library/components/button";
-import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 import { Modal } from "@vellumai/design-library/components/modal";
 
 import { RetireConfirmDialog } from "@/components/retire-confirm-dialog";
-
-type RecoveryStep = "menu" | "confirm-repair" | "confirm-retire";
 
 interface ConnectRecoveryDialogProps {
   open: boolean;
@@ -17,7 +15,7 @@ interface ConnectRecoveryDialogProps {
   /** Failure from a repair/retire attempt, shown inline. */
   errorMessage?: string;
   onCancel: () => void;
-  /** Fired only after the nested repair confirmation. */
+  /** Fired directly by the primary action. */
   onRepair: () => void;
   /** Fired only after the nested retire confirmation. */
   onRetire: () => void;
@@ -25,10 +23,18 @@ interface ConnectRecoveryDialogProps {
 
 /**
  * Recovery dialog for a local assistant whose guardian token is missing or
- * can no longer be refreshed. Offers three paths: cancel back to the chooser,
- * wake-and-repair (re-provisions the token — revokes the assistant's other
- * device-bound tokens, so it sits behind an explicit confirmation), or retire
- * (destructive, also confirmed).
+ * can no longer be refreshed. Offers three paths: wake-and-repair, cancel back
+ * to the chooser, or retire.
+ *
+ * Repair is the way back in and fires on a single click. It re-provisions the
+ * token and so revokes the assistant's other device-bound tokens; that
+ * consequence is stated in the body copy, which is where a user reaching this
+ * dialog on every launch will actually read it, rather than behind a second
+ * confirmation step they learn to click through.
+ *
+ * Retire is destructive and unrelated to getting back in, so it sits below a
+ * divider in a compact, low-emphasis form instead of adjacent to the primary
+ * button, and keeps its own confirmation.
  */
 function ConnectRecoveryDialog({
   open,
@@ -39,11 +45,11 @@ function ConnectRecoveryDialog({
   onRepair,
   onRetire,
 }: ConnectRecoveryDialogProps) {
-  const [step, setStep] = useState<RecoveryStep>("menu");
+  const [confirmingRetire, setConfirmingRetire] = useState(false);
 
   useEffect(() => {
     if (open) {
-      setStep("menu");
+      setConfirmingRetire(false);
     }
   }, [open]);
 
@@ -54,35 +60,14 @@ function ConnectRecoveryDialog({
     </span>
   ) : null;
 
-  if (step === "confirm-repair") {
-    return (
-      <ConfirmDialog
-        open={open}
-        title="Repair Assistant?"
-        message={
-          <>
-            Repairing re-provisions this assistant&rsquo;s authentication token.
-            Any other devices or browser sessions connected to it will be signed
-            out and need to reconnect.
-            {errorLine}
-          </>
-        }
-        confirmLabel="Repair"
-        isPending={isPending}
-        onConfirm={onRepair}
-        onCancel={() => setStep("menu")}
-      />
-    );
-  }
-
-  if (step === "confirm-retire") {
+  if (confirmingRetire) {
     return (
       <RetireConfirmDialog
         open={open}
         isPending={isPending}
         extraMessage={errorLine}
         onConfirm={onRetire}
-        onCancel={() => setStep("menu")}
+        onCancel={() => setConfirmingRetire(false)}
       />
     );
   }
@@ -113,8 +98,10 @@ function ConnectRecoveryDialog({
         <Modal.Body>
           <Modal.Description>
             The authentication token for {assistantName} is missing or can no
-            longer be refreshed, so this assistant can&rsquo;t be connected. You
-            can repair it, retire it, or pick a different assistant.
+            longer be refreshed, so this assistant can&rsquo;t be connected.
+            Repairing wakes it and re-provisions the token; any other devices or
+            browser sessions connected to it will be signed out and need to
+            reconnect.
           </Modal.Description>
           {errorLine}
           <div className="mt-5 flex w-full flex-col gap-2">
@@ -122,17 +109,12 @@ function ConnectRecoveryDialog({
               variant="primary"
               fullWidth
               disabled={isPending}
-              onClick={() => setStep("confirm-repair")}
+              leftIcon={
+                isPending ? <Loader2 className="animate-spin" /> : undefined
+              }
+              onClick={onRepair}
             >
-              Wake &amp; Repair
-            </Button>
-            <Button
-              variant="dangerOutline"
-              fullWidth
-              disabled={isPending}
-              onClick={() => setStep("confirm-retire")}
-            >
-              Retire Assistant
+              {isPending ? "Repairing…" : "Wake & Repair"}
             </Button>
             <Button
               variant="outlined"
@@ -141,6 +123,16 @@ function ConnectRecoveryDialog({
               onClick={onCancel}
             >
               Cancel
+            </Button>
+          </div>
+          <div className="mt-4 flex justify-center border-t border-[var(--border-base)] pt-3">
+            <Button
+              variant="dangerGhost"
+              size="compact"
+              disabled={isPending}
+              onClick={() => setConfirmingRetire(true)}
+            >
+              Retire Assistant…
             </Button>
           </div>
         </Modal.Body>

--- a/clients/web/src/lib/local-mode-repair.test.ts
+++ b/clients/web/src/lib/local-mode-repair.test.ts
@@ -244,6 +244,61 @@ describe("primeLocalGatewayConnectionWithRepair", () => {
     expect(fetchGuardianTokenHost).toHaveBeenCalledTimes(3);
   });
 
+  test("rides out a post-wake guardian refresh 401, then reconnects", async () => {
+    // The reopen-the-app symptom: with the gateway down, the host's guardian
+    // refresh comes back empty and is reported as a 401. Wake restarts the
+    // gateway, but the refresh that follows can still land before it answers.
+    // Riding that out is what keeps a plain reopen from dead-ending on the
+    // recovery dialog.
+    let fetches = 0;
+    fetchGuardianTokenHost = mock(async (_id: string) => {
+      fetches++;
+      if (fetches <= 2) {
+        throw new GuardianTokenError(401, "Failed to refresh guardian token");
+      }
+      return "tok";
+    });
+
+    await primeLocalGatewayConnectionWithRepair();
+
+    expect(wakeLocalAssistantHost).toHaveBeenCalledTimes(1);
+    // One pre-wake fetch, one post-wake fetch ridden out, then the success.
+    expect(fetches).toBe(3);
+  });
+
+  test("a spent refresh token surfaces after a short window, not the full budget", async () => {
+    // A 401 that never clears is a genuinely spent refresh token: only the
+    // user-confirmed guardian re-provision fixes it, so the recovery controls
+    // must appear promptly rather than after the whole ride-out budget.
+    fetchGuardianTokenHost = mock(async (_id: string) => {
+      throw new GuardianTokenError(401, "Failed to refresh guardian token");
+    });
+
+    const err = await primeLocalGatewayConnectionWithRepair().catch(
+      (e: unknown) => e,
+    );
+
+    expect(err).toBeInstanceOf(GuardianTokenError);
+    expect(wakeLocalAssistantHost).toHaveBeenCalledTimes(1);
+    // One pre-wake fetch plus a three-attempt post-wake window, well short of
+    // the eight-attempt budget a still-starting gateway gets.
+    expect(fetchGuardianTokenHost).toHaveBeenCalledTimes(4);
+    expect(LOCAL_GATEWAY_STARTUP_RETRY.attempts).toBeGreaterThan(4);
+  });
+
+  test("a post-wake 404 never rides out — wake would already have written the token", async () => {
+    primeShouldSucceed = () => false;
+
+    const err = await primeLocalGatewayConnectionWithRepair().catch(
+      (e: unknown) => e,
+    );
+
+    expect(err).toBeInstanceOf(GuardianTokenError);
+    expect((err as InstanceType<typeof GuardianTokenError>).status).toBe(404);
+    // One pre-wake fetch and a single post-wake retry.
+    expect(fetchGuardianTokenHost).toHaveBeenCalledTimes(2);
+  });
+
   test("a wake-restarted gateway stuck starting surfaces the last error after the budget", async () => {
     // Wake succeeds but the gateway never finishes starting — the ride-out
     // exhausts its budget and the last transient error propagates so the recovery

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -931,16 +931,29 @@ function isGatewayStillStarting(error: unknown): boolean {
 }
 
 /**
- * A `wake`-restarted gateway that hasn't finished coming back up: it refuses
- * connections (a thrown transport error), answers `503`/`5xx`, or rejects the
- * mint with a repairable `401` while it re-provisions its guardian binding. A
- * `403` loopback-boundary refusal is terminal, and a missing/expired guardian
- * token or an unresolved gateway won't heal by waiting (the just-run `wake`
- * already re-seeded the token and recorded the port), so those fall through.
+ * How many of the ride-out's attempts a post-wake guardian-refresh `401` is
+ * retried for. The host reports `401` both for a refresh token that is
+ * genuinely spent and for a `vellum gateway token refresh` that simply came
+ * back empty, which is what happens while the just-restarted gateway is not
+ * answering yet. Retrying a short prefix of the budget covers the restart race
+ * without making a truly spent token sit through the whole window before the
+ * recovery controls appear.
  */
-function isGatewayRestartTransient(error: unknown): boolean {
+const GUARDIAN_REFRESH_RIDEOUT_ATTEMPTS = 3;
+
+/**
+ * A `wake`-restarted gateway that hasn't finished coming back up: it refuses
+ * connections (a thrown transport error), answers `503`/`5xx`, rejects the mint
+ * with a repairable `401` while it re-provisions its guardian binding, or fails
+ * the guardian refresh with a `401` for the first
+ * {@link GUARDIAN_REFRESH_RIDEOUT_ATTEMPTS} attempts. A `403` loopback-boundary
+ * refusal is terminal, and a missing guardian token (`404`) or an unresolved
+ * gateway won't heal by waiting (the just-run `wake` already re-seeded the token
+ * and recorded the port), so those fall through.
+ */
+function isGatewayRestartTransient(error: unknown, attempt: number): boolean {
   if (error instanceof GuardianTokenError) {
-    return false;
+    return error.status === 401 && attempt < GUARDIAN_REFRESH_RIDEOUT_ATTEMPTS;
   }
   if (error instanceof UnresolvedLocalGatewayError) {
     return false;
@@ -961,10 +974,13 @@ function isGatewayRestartTransient(error: unknown): boolean {
  * respects the "app launch never spawns daemon processes" boot contract. The
  * last error propagates once the retry budget is spent or the failure is not a
  * ride-out-able one, so the existing connect-error classification is preserved.
+ *
+ * `shouldRideOut` receives the 1-based attempt that just failed, so a classifier
+ * can hold a failure class to a shorter window than the full budget.
  */
 async function primeLocalGatewayWithStartupRideout(
   target: LockfileAssistant | undefined,
-  shouldRideOut: (error: unknown) => boolean,
+  shouldRideOut: (error: unknown, attempt: number) => boolean,
 ): Promise<void> {
   const { attempts, intervalMs } = LOCAL_GATEWAY_STARTUP_RETRY;
   for (let attempt = 1; attempt <= attempts; attempt++) {
@@ -972,7 +988,7 @@ async function primeLocalGatewayWithStartupRideout(
       await primeLocalGatewayConnection(target);
       return;
     } catch (error) {
-      if (attempt >= attempts || !shouldRideOut(error)) {
+      if (attempt >= attempts || !shouldRideOut(error, attempt)) {
         throw error;
       }
       await new Promise((resolve) => setTimeout(resolve, intervalMs));


### PR DESCRIPTION
## Prompt / plan

User report: after fully quitting and reopening the Mac app, getting back into a local assistant takes several steps (click the assistant, "Wake & Repair", then confirm "Repair" in a second popup), and "Retire Assistant" sits directly under the primary button where it invites misclicks. Requested: single-click reconnect, retire moved away from the primary action, and no repeated confirmation.

Two changes, one for each half of the complaint.

**Why the dialog appears at all.** With the assistant's gateway down, the host's guardian-token read finds an expired access token and shells out to `vellum gateway token refresh`, which cannot reach the stopped gateway. `refreshToken` maps any non-zero exit to `401`, which the renderer classifies as "the token can no longer be refreshed" and offers the recovery dialog for. `primeLocalGatewayConnectionWithRepair` already handles that correctly on the first pass: it runs a plain `wake` and re-primes. But the post-wake ride-out (`isGatewayRestartTransient`) treated *every* `GuardianTokenError` as terminal, so if the refresh that follows the wake lands before the restarted gateway accepts connections, the connect dead-ends on that first retry, and the user sees "Can't Authenticate Assistant" for an assistant that is healthy and now running.

A post-wake guardian `401` is now ridden out for the first few attempts of the existing retry budget, so a plain reopen reconnects on the Continue click with no dialog. Deliberately narrow:

- `404` (no token file on disk, which the just-run `wake` would have written) and `403` (loopback-boundary refusal) stay terminal, as does `UnresolvedLocalGatewayError`.
- The window is a short prefix of the budget (3 of 8 attempts), not the whole thing, so a genuinely spent refresh token still reaches the recovery controls in about two seconds instead of stalling for eight.
- Only the post-`wake` classifier changed. The boot restore still never wakes and still rides out only gateway-mint errors, so the "app launch never spawns daemon processes" contract is untouched.

**The dialog itself.** Repair is the way back in, so it fires on a single click now; the token re-provisioning consequence ("other devices will be signed out") moves into the dialog body, where a user who meets this dialog on every launch will actually read it, rather than behind a second confirmation they learn to click through. That also removes the repeated popup the report asked about, without persisting a "don't ask me again" flag for an action that revokes other devices' sessions.

Retire moves out of the primary button stack: below a divider, compact and low-emphasis, so a stray click under "Wake & Repair" lands on Cancel. It keeps its own destructive `RetireConfirmDialog`. It stays in the dialog rather than moving into settings because settings are unreachable while the assistant cannot be connected.

Net click count from a cold reopen: 4 before, 1 in the common case (Continue on the pre-selected assistant), 2 when a real guardian re-provision is genuinely needed.

## Test plan

- `bun test src/lib/local-mode-repair.test.ts` (16 pass). Three new cases: a post-wake guardian `401` is ridden out and reconnects; a `401` that never clears surfaces after the short window rather than the full budget; a post-wake `404` never rides out.
- `bun test src/domains/onboarding/components/connect-recovery-dialog.test.tsx` (13 pass). Rewritten for the new flow: repair fires on one click with no intermediate step, the side effect is stated up front, retire is not a sibling of the primary button and is compact, and the retire confirmation and pending states behave as before.
- `bun test src/domains/onboarding/pages/select-assistant-screen.test.tsx` (66 pass), `src/lib/local-mode.test.ts` (82), `src/stores/auth-store.test.ts` (113), `src/components/status-banner.test.tsx` (55).
- `bunx tsc --noEmit` and `bun run lint` clean.
- Not manually exercised on macOS: reproducing it needs a packaged app and a stopped local assistant. The ride-out change is covered by the unit tests above, and its failure mode is bounded (a few extra seconds before the same dialog that shows today).

One note for review: the underlying misclassification is in `packages/local-mode/src/guardian-token.ts`, where `refreshToken` returns `401` for any non-zero CLI exit, so a transport failure is indistinguishable from a real auth rejection. Fixing that at the source would let the renderer stop guessing, but it changes the guardian-token status contract shared by both hosts and the CLI, so I left it alone here.


---
_Generated by [Claude Code](https://claude.ai/code/session_018uwsjWDAMSq4JLyhGBsbAp)_