### PR TITLE
feat(web): add a pseudolocale for finding untranslated copy

### DIFF
--- a/clients/web/docs/I18N.md
+++ b/clients/web/docs/I18N.md
@@ -202,3 +202,54 @@ location.reload();
 
 `document.documentElement.lang` reflects the active locale, which is the
 quickest check that resolution ran at all.
+
+## Finding copy the lint rule cannot see
+
+A clean lint run is not proof a screen is translated. The rule reads source and
+only recognizes the shapes it was written for, so copy has reached production
+past a green run as a `toastOnError("Failed to …")` argument, as a
+`setupLabel = "Invite"` default parameter, as the return of a helper, and as
+`` `${n} item${n === 1 ? "" : "s"}` ``. Every one of those is user-visible.
+
+The pseudolocale asks the other question: not what a rule can find in the
+source, but what is on the screen. Turn it on with
+
+```js
+localStorage.setItem("device:locale", "en-XA");
+location.reload();
+```
+
+and every string that came from `t()` renders accented, padded, and bracketed:
+
+```
+⟦Àðð Çöñŧàçŧ····⟧
+```
+
+Then read the screen. Three things to look for:
+
+- **Plain unaccented English** is copy that never reached a catalog. That is
+  the miss you are hunting.
+- **Text without its closing `⟧`** has been truncated by the layout. The
+  padding is about a third longer than the English, the headroom German and
+  Finnish typically need, so this is a control or column that will clip in
+  production.
+- **`⟦…⟧⟦…⟧` inside one sentence** is a sentence assembled from several `t()`
+  calls. It reads correctly in English by accident of word order; use `Trans`
+  or a single message with placeholders instead, as described under [writing
+  messages that survive translation](#writing-messages-that-survive-translation).
+
+Interpolated values stay plain, because they are data rather than copy:
+`⟦Ðéłéŧé Ada Lovelace?···⟧` is correct.
+
+Undo it the same way as any other locale:
+
+```js
+localStorage.removeItem("device:locale");
+location.reload();
+```
+
+The pseudolocale is derived from the English catalogs at runtime, so it never
+falls behind them and there is nothing to maintain. It is deliberately not in
+`SUPPORTED_LOCALES`: `negotiateLocale` cannot return it and a language picker
+cannot offer it, so setting the preference by hand is the only way in. See
+[`src/i18n/pseudo-locale.ts`](../src/i18n/pseudo-locale.ts) for the transform.

--- a/clients/web/src/i18n/catalogs.ts
+++ b/clients/web/src/i18n/catalogs.ts
@@ -48,7 +48,12 @@ import enCommon from "@/i18n/locales/en/common.json";
 import enSchedules from "@/i18n/locales/en/schedules.json";
 import enSettings from "@/i18n/locales/en/settings.json";
 import { NAMESPACES, type Namespace } from "@/i18n/namespaces";
-import { DEFAULT_LOCALE, type SupportedLocale } from "@/i18n/supported-locales";
+import {
+  DEFAULT_LOCALE,
+  isPseudoLocale,
+  type ActiveLocale,
+  type SupportedLocale,
+} from "@/i18n/supported-locales";
 
 /**
  * A parsed catalog. Values are ICU MessageFormat strings; nesting mirrors the
@@ -115,12 +120,22 @@ const CATALOG_LOADERS: Record<
  * treat that as "stay on {@link FALLBACK_CATALOGS}". Namespaces load together
  * rather than on demand because they are small and first paint can draw from
  * any of them; split this if a namespace ever grows large enough to matter.
+ *
+ * The pseudolocale is derived from English rather than loaded, so it cannot
+ * drift from it. Its transform is reached through a dynamic import for the
+ * same reason the other locales are: nobody who stays on a shipped locale
+ * should pay for it, and this keeps it in a chunk of its own.
  */
 export async function loadCatalogs(
-  locale: SupportedLocale,
+  locale: ActiveLocale,
 ): Promise<LocaleCatalogs> {
   if (locale === DEFAULT_LOCALE) {
     return FALLBACK_CATALOGS;
+  }
+
+  if (isPseudoLocale(locale)) {
+    const { pseudoCatalogs } = await import("@/i18n/pseudo-locale");
+    return pseudoCatalogs(FALLBACK_CATALOGS);
   }
 
   const loaders = CATALOG_LOADERS[locale];

--- a/clients/web/src/i18n/i18n.ts
+++ b/clients/web/src/i18n/i18n.ts
@@ -43,9 +43,9 @@ import { NAMESPACES } from "@/i18n/namespaces";
 import { systemLocales } from "@/i18n/system-locale";
 import {
   DEFAULT_LOCALE,
-  isSupportedLocale,
+  isActiveLocale,
   negotiateLocale,
-  type SupportedLocale,
+  type ActiveLocale,
 } from "@/i18n/supported-locales";
 import { captureError } from "@/lib/sentry/capture-error";
 import { getDeviceSetting, setDeviceSetting } from "@/utils/device-settings";
@@ -55,9 +55,12 @@ import { getDeviceSetting, setDeviceSetting } from "@/utils/device-settings";
  * host, then the default. Pure apart from the storage read, and exported so
  * tests and a future language picker can ask without initializing i18next.
  */
-export function resolveInitialLocale(): SupportedLocale {
+export function resolveInitialLocale(): ActiveLocale {
   const stored = getDeviceSetting("locale", "");
-  if (isSupportedLocale(stored)) {
+  // The stored preference is the one route to the pseudolocale: it is not in
+  // `SUPPORTED_LOCALES`, so `negotiateLocale` below can never return it and no
+  // host signal can select it.
+  if (isActiveLocale(stored)) {
     return stored;
   }
   return negotiateLocale(systemLocales());
@@ -78,7 +81,7 @@ export function resolveInitialLocale(): SupportedLocale {
  * - https://www.w3.org/International/questions/qa-html-language-declarations
  * - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getTextInfo
  */
-function applyDocumentLocale(locale: SupportedLocale): void {
+function applyDocumentLocale(locale: ActiveLocale): void {
   if (typeof document === "undefined") {
     return;
   }
@@ -105,7 +108,7 @@ function applyDocumentLocale(locale: SupportedLocale): void {
 }
 
 /** Load a locale's catalogs into i18next unless they are already registered. */
-async function ensureCatalogs(locale: SupportedLocale): Promise<void> {
+async function ensureCatalogs(locale: ActiveLocale): Promise<void> {
   const missing = NAMESPACES.filter(
     (namespace) => !i18next.hasResourceBundle(locale, namespace),
   );
@@ -132,7 +135,7 @@ async function ensureCatalogs(locale: SupportedLocale): Promise<void> {
  * the call site beyond staying on the locale already rendering, so it is a
  * warning rather than an error.
  */
-function reportCatalogFailure(error: unknown, locale: SupportedLocale): void {
+function reportCatalogFailure(error: unknown, locale: ActiveLocale): void {
   captureError(error, {
     context: "i18n_catalog_load",
     level: "warning",
@@ -149,7 +152,7 @@ function reportCatalogFailure(error: unknown, locale: SupportedLocale): void {
  * reachable. Returns the locale actually activated, which is English when the
  * preferred locale's catalog could not be loaded.
  */
-export async function initI18n(): Promise<SupportedLocale> {
+export async function initI18n(): Promise<ActiveLocale> {
   const requested = resolveInitialLocale();
 
   if (i18next.isInitialized) {
@@ -169,7 +172,7 @@ export async function initI18n(): Promise<SupportedLocale> {
   const resources: Record<string, LocaleCatalogs> = {
     [DEFAULT_LOCALE]: FALLBACK_CATALOGS,
   };
-  let locale: SupportedLocale = DEFAULT_LOCALE;
+  let locale: ActiveLocale = DEFAULT_LOCALE;
 
   if (requested !== DEFAULT_LOCALE) {
     try {
@@ -201,7 +204,7 @@ export async function initI18n(): Promise<SupportedLocale> {
  * active. Unlike {@link initI18n} this is user-initiated, so the caller is the
  * one that can say something useful about the failure.
  */
-export async function changeLocale(locale: SupportedLocale): Promise<void> {
+export async function changeLocale(locale: ActiveLocale): Promise<void> {
   await ensureCatalogs(locale);
   await i18next.changeLanguage(locale);
   setDeviceSetting("locale", locale);
@@ -209,9 +212,9 @@ export async function changeLocale(locale: SupportedLocale): Promise<void> {
 }
 
 /** The active locale, or `DEFAULT_LOCALE` before initialization. */
-export function currentLocale(): SupportedLocale {
+export function currentLocale(): ActiveLocale {
   const language = i18next.resolvedLanguage ?? i18next.language;
-  return isSupportedLocale(language) ? language : DEFAULT_LOCALE;
+  return isActiveLocale(language) ? language : DEFAULT_LOCALE;
 }
 
 export { i18next };

--- a/clients/web/src/i18n/index.ts
+++ b/clients/web/src/i18n/index.ts
@@ -41,9 +41,11 @@ export {
 export {
   DEFAULT_LOCALE,
   LOCALE_LABELS,
+  PSEUDO_LOCALE,
   SUPPORTED_LOCALES,
   isSupportedLocale,
   negotiateLocale,
+  type ActiveLocale,
   type SupportedLocale,
 } from "@/i18n/supported-locales";
 

--- a/clients/web/src/i18n/pseudo-locale.test.ts
+++ b/clients/web/src/i18n/pseudo-locale.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Tests for the pseudolocale transform.
+ *
+ * The property that matters is narrow: a pseudolocalized message must format
+ * exactly where its source formatted, with the same placeholders, the same
+ * plural categories, and the same markup. Everything else about it is
+ * cosmetic. The last test therefore runs the transform over every message in
+ * every shipped English catalog rather than over fixtures, so a catalog entry
+ * whose shape this module has not met fails here.
+ */
+import { describe, expect, test } from "bun:test";
+import IntlMessageFormat from "intl-messageformat";
+
+import { FALLBACK_CATALOGS } from "@/i18n/catalogs";
+import { pseudoCatalogs, pseudoLocalizeMessage } from "@/i18n/pseudo-locale";
+import { NAMESPACES } from "@/i18n/namespaces";
+
+/**
+ * Every argument name a message references, from its AST.
+ *
+ * Read from the parse rather than by pattern: a `plural` branch opens with a
+ * brace too, so a regex over the source cannot tell `{survivor}` from the `{`
+ * that starts the `=0 {No new channels…}` body.
+ */
+function argumentNames(message: string): string[] {
+  interface Node {
+    type: number;
+    value?: unknown;
+    children?: Node[];
+    options?: Record<string, { value: Node[] }>;
+  }
+  const names: string[] = [];
+  const walk = (nodes: Node[]): void => {
+    for (const node of nodes) {
+      // 0 is a literal and 7 is the `#` of a plural; 8 is a tag, whose `value`
+      // is its name. Everything between them names an argument.
+      if (node.type >= 1 && node.type <= 6 && typeof node.value === "string") {
+        names.push(node.value);
+      }
+      if (node.children) {
+        walk(node.children);
+      }
+      if (node.options) {
+        for (const option of Object.values(node.options)) {
+          walk(option.value);
+        }
+      }
+    }
+  };
+  walk(new IntlMessageFormat(message, "en").getAst() as Node[]);
+  return names.sort();
+}
+
+/** Format a message the way the runtime does, so the assertions see real output. */
+function format(message: string, values: Record<string, unknown> = {}): string {
+  return String(new IntlMessageFormat(message, "en").format(values));
+}
+
+/** Every leaf message of a catalog, keyed by its dotted path. */
+function flatten(value: unknown, prefix = ""): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (typeof value === "string") {
+    out[prefix] = value;
+    return out;
+  }
+  if (value && typeof value === "object") {
+    for (const [key, child] of Object.entries(value)) {
+      Object.assign(out, flatten(child, prefix ? `${prefix}.${key}` : key));
+    }
+  }
+  return out;
+}
+
+describe("pseudoLocalizeMessage", () => {
+  test("accents the letters of a plain message", () => {
+    const out = pseudoLocalizeMessage("Save");
+    expect(out).toContain("Šàṽé");
+    expect(out).not.toContain("Save");
+  });
+
+  test("brackets the message so truncation is visible", () => {
+    const out = pseudoLocalizeMessage("Save");
+    expect(out.startsWith("⟦")).toBe(true);
+    expect(out.endsWith("⟧")).toBe(true);
+  });
+
+  test("pads the message to leave room for a longer translation", () => {
+    // 30 letters of source, so the padding is a third of that and the message
+    // is meaningfully wider than its English.
+    const source = "Notes about yourself which AI";
+    const out = pseudoLocalizeMessage(source);
+    expect(out.length).toBeGreaterThan(source.length * 1.3);
+    expect(out).toContain("·");
+  });
+
+  test("leaves a placeholder's name untouched and still substitutes it", () => {
+    const out = pseudoLocalizeMessage("Delete {name}?");
+
+    expect(out).toContain("{name}");
+    expect(format(out, { name: "Ada" })).toContain("Ada");
+  });
+
+  test("accents inside plural branches, and still selects the right one", () => {
+    const source =
+      "{count, plural, one {# interaction} other {# interactions}}";
+    const out = pseudoLocalizeMessage(source);
+
+    // The branch a count selects is the copy a user reads. Left in plain
+    // English it would read as a miss on every screen showing a count.
+    expect(format(out, { count: 1 })).toContain("îñŧéŕàçŧîöñ");
+    expect(format(out, { count: 5 })).toContain("îñŧéŕàçŧîöñš");
+    expect(format(out, { count: 1 })).toContain("1");
+    expect(format(out, { count: 7 })).toContain("7");
+  });
+
+  test("keeps an explicit plural branch selectable", () => {
+    const out = pseudoLocalizeMessage(
+      "{count, plural, =0 {No channels} one {# channel} other {# channels}}",
+    );
+
+    expect(format(out, { count: 0 })).toContain("Ñö çĥàññéłš");
+    expect(format(out, { count: 2 })).toContain("2");
+  });
+
+  test("preserves tag names while accenting what they wrap", () => {
+    const out = pseudoLocalizeMessage("Marks it <emphasis>linked</emphasis>.");
+
+    expect(out).toContain("<emphasis>");
+    expect(out).toContain("</emphasis>");
+    expect(out).toContain("łîñķéð");
+  });
+
+  test("preserves a number placeholder's format", () => {
+    const out = pseudoLocalizeMessage("Used {bytes, number} of space");
+
+    expect(out).toContain("{bytes, number}");
+    expect(format(out, { bytes: 1234 })).toContain("1,234");
+  });
+
+  test("wraps a message that is nothing but a placeholder", () => {
+    const out = pseudoLocalizeMessage("{name}");
+
+    expect(out).toBe("⟦{name}⟧");
+    expect(format(out, { name: "Ada" })).toBe("⟦Ada⟧");
+  });
+
+  test("returns something formattable for a message it cannot parse", () => {
+    // Not reachable from a catalog that passes `catalogs.test.ts`, but a
+    // malformed entry must not take the app down before those tests run.
+    const out = pseudoLocalizeMessage("{unclosed");
+
+    expect(out).toContain("{unclosed");
+  });
+});
+
+describe("pseudoCatalogs", () => {
+  test("covers every namespace", () => {
+    const catalogs = pseudoCatalogs(FALLBACK_CATALOGS);
+
+    expect(Object.keys(catalogs).sort()).toEqual([...NAMESPACES].sort());
+  });
+
+  test("preserves the nesting the key paths depend on", () => {
+    const catalogs = pseudoCatalogs(FALLBACK_CATALOGS);
+    const source = flatten(FALLBACK_CATALOGS);
+    const pseudo = flatten(catalogs);
+
+    expect(Object.keys(pseudo).sort()).toEqual(Object.keys(source).sort());
+  });
+
+  test("every shipped English message survives the transform", () => {
+    const source = flatten(FALLBACK_CATALOGS);
+    const pseudo = flatten(pseudoCatalogs(FALLBACK_CATALOGS));
+
+    const broken: string[] = [];
+    for (const [key, message] of Object.entries(pseudo)) {
+      try {
+        new IntlMessageFormat(message, "en");
+      } catch {
+        broken.push(key);
+        continue;
+      }
+      // Every argument the source names must still be named, or a screen in
+      // the pseudolocale would be missing data the real one shows.
+      if (
+        argumentNames(source[key]).join(",") !== argumentNames(message).join(",")
+      ) {
+        broken.push(key);
+      }
+    }
+
+    expect(broken).toEqual([]);
+  });
+});

--- a/clients/web/src/i18n/pseudo-locale.ts
+++ b/clients/web/src/i18n/pseudo-locale.ts
@@ -1,0 +1,187 @@
+/**
+ * The pseudolocale: English copy, mechanically disguised, used to find copy
+ * that never reached a catalog.
+ *
+ * The lint rule catches untranslated strings it can parse, which is not the
+ * same set as the strings a user can read. It does not see copy passed to a
+ * helper, returned from a function, set as a default parameter, or built by
+ * concatenation. Every one of those has shipped past a clean lint run during
+ * this migration. A pseudolocale inverts the question: instead of asking what
+ * a rule can find in the source, it asks what is on the screen. Anything that
+ * renders in plain unbracketed ASCII did not come from `t()`.
+ *
+ * Three transforms, each answering a different question:
+ *
+ * - **Accents** (`Save` to `Šàvé`) make translated text obvious at a glance,
+ *   so anything still in plain English stands out without reading it.
+ * - **Padding** grows each message by roughly a third, the headroom German
+ *   and Finnish typically need over English, so a button or column that
+ *   cannot survive translation clips here rather than in production.
+ * - **Brackets** mark where a message starts and ends, so copy assembled from
+ *   several `t()` calls reads as `⟦…⟧⟦…⟧` and text truncated by CSS is
+ *   visibly missing its closing bracket.
+ *
+ * **Placeholders and markup are preserved byte for byte.** The message is
+ * parsed with the same parser the runtime formats it with, which reports each
+ * literal's offsets in the source; only those ranges are rewritten. Nothing
+ * reconstructs the ICU syntax, so no shape of message can be mangled by a
+ * serializer that did not anticipate it, and a pseudolocalized message parses
+ * exactly when its source did. The accent map only produces letters, so the
+ * substituted text can never introduce ICU's own metacharacters.
+ *
+ * The pseudolocale is not in `SUPPORTED_LOCALES`: `negotiateLocale` cannot
+ * return it and the language picker does not offer it, so no user reaches it
+ * by accident. It is opt-in through the stored `device:locale` preference
+ * alone. See `docs/I18N.md` for how to turn it on.
+ *
+ * Reference: https://www.unicode.org/reports/tr35/tr35-info.html (pseudolocale
+ * conventions; `en-XA` is the tag Android and Chrome use for accented English)
+ */
+import IntlMessageFormat from "intl-messageformat";
+
+import type { Catalog, LocaleCatalogs } from "@/i18n/catalogs";
+
+/**
+ * ASCII letters to look-alikes carrying diacritics. Only letters map, and only
+ * to letters: digits are frequently data rather than copy, and a mapping that
+ * emitted `{`, `}`, `'`, or `#` would turn a literal into ICU syntax.
+ */
+const ACCENTS: Record<string, string> = {
+  a: "à", b: "ƀ", c: "ç", d: "ð", e: "é", f: "ƒ", g: "ĝ", h: "ĥ", i: "î",
+  j: "ĵ", k: "ķ", l: "ł", m: "ɱ", n: "ñ", o: "ö", p: "þ", q: "ǫ", r: "ŕ",
+  s: "š", t: "ŧ", u: "û", v: "ṽ", w: "ŵ", x: "ẋ", y: "ý", z: "ž",
+  A: "À", B: "Ɓ", C: "Ç", D: "Ð", E: "É", F: "Ƒ", G: "Ĝ", H: "Ĥ", I: "Î",
+  J: "Ĵ", K: "Ķ", L: "Ł", M: "Ṁ", N: "Ñ", O: "Ö", P: "Þ", Q: "Ǫ", R: "Ŕ",
+  S: "Š", T: "Ŧ", U: "Û", V: "Ṽ", W: "Ŵ", X: "Ẋ", Y: "Ý", Z: "Ž",
+};
+
+/** Opens a pseudolocalized message. */
+const OPEN = "⟦";
+
+/** Closes it. Absent on screen means the message was truncated. */
+const CLOSE = "⟧";
+
+/** Filler character. Deliberately not a letter, so it reads as padding. */
+const PAD = "·";
+
+/**
+ * How much longer a translation runs than its English source, as a fraction.
+ * German and Finnish sit around a third for strings of this length; the
+ * padding is what makes a layout that cannot take that fail here.
+ */
+const EXPANSION = 0.35;
+
+function accent(text: string): string {
+  let out = "";
+  for (const char of text) {
+    out += ACCENTS[char] ?? char;
+  }
+  return out;
+}
+
+/** Literal spans of an ICU message, as offsets into its source. */
+interface LiteralSpan {
+  start: number;
+  end: number;
+  value: string;
+}
+
+/**
+ * The AST shape this module reads. `intl-messageformat` re-exports the node
+ * types, but only literals (0), tags (8), and the branch-bearing plural (6)
+ * and select (5) nodes matter here, so they are narrowed locally rather than
+ * pulling the full union in.
+ */
+interface AstNode {
+  type: number;
+  value?: unknown;
+  children?: AstNode[];
+  options?: Record<string, { value: AstNode[] }>;
+  location?: { start: { offset: number }; end: { offset: number } };
+}
+
+const LITERAL = 0;
+const TAG = 8;
+
+function collectLiterals(nodes: AstNode[], spans: LiteralSpan[]): void {
+  for (const node of nodes) {
+    if (node.type === LITERAL && node.location && typeof node.value === "string") {
+      spans.push({
+        start: node.location.start.offset,
+        end: node.location.end.offset,
+        value: node.value,
+      });
+    }
+    if (node.type === TAG && node.children) {
+      collectLiterals(node.children, spans);
+    }
+    // Plural and select carry a sub-message per branch, each with literals of
+    // its own. Without this, the branch a count actually selects would render
+    // in plain English and read as a miss.
+    if (node.options) {
+      for (const option of Object.values(node.options)) {
+        collectLiterals(option.value, spans);
+      }
+    }
+  }
+}
+
+/**
+ * Pseudolocalize one ICU message.
+ *
+ * Returns the message unchanged apart from the wrapper if it cannot be parsed.
+ * `catalogs.test.ts` proves every shipped message parses, so this only guards
+ * against a catalog edit that has not run the tests yet.
+ */
+export function pseudoLocalizeMessage(message: string): string {
+  let spans: LiteralSpan[] = [];
+  try {
+    const ast = new IntlMessageFormat(message, "en", undefined, {
+      captureLocation: true,
+    }).getAst() as AstNode[];
+    collectLiterals(ast, spans);
+  } catch {
+    spans = [];
+  }
+
+  // Right to left, so an earlier span's offsets are still valid after a later
+  // one has been spliced.
+  let out = message;
+  let literalLength = 0;
+  for (const span of [...spans].sort((a, b) => b.start - a.start)) {
+    literalLength += span.value.length;
+    out = out.slice(0, span.start) + accent(span.value) + out.slice(span.end);
+  }
+
+  const padding = PAD.repeat(Math.ceil(literalLength * EXPANSION));
+  return `${OPEN}${out}${padding}${CLOSE}`;
+}
+
+/** Pseudolocalize every message in a catalog, preserving its nesting. */
+export function pseudoLocalizeCatalog(catalog: Catalog): Catalog {
+  const out: Catalog = {};
+  for (const [key, value] of Object.entries(catalog)) {
+    if (typeof value === "string") {
+      out[key] = pseudoLocalizeMessage(value);
+    } else if (value && typeof value === "object") {
+      out[key] = pseudoLocalizeCatalog(value as Catalog);
+    } else {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+/**
+ * Derive the whole pseudolocale from the English catalogs.
+ *
+ * Nothing is stored on disk: the pseudolocale is a function of English, so it
+ * can never fall behind it the way a hand-maintained catalog would.
+ */
+export function pseudoCatalogs(source: LocaleCatalogs): LocaleCatalogs {
+  const out = {} as LocaleCatalogs;
+  for (const [namespace, catalog] of Object.entries(source)) {
+    out[namespace as keyof LocaleCatalogs] = pseudoLocalizeCatalog(catalog);
+  }
+  return out;
+}

--- a/clients/web/src/i18n/supported-locales.ts
+++ b/clients/web/src/i18n/supported-locales.ts
@@ -37,11 +37,44 @@ export const LOCALE_LABELS: Record<SupportedLocale, string> = {
   es: "Español",
 };
 
+/**
+ * Accented-English pseudolocale, for finding copy that never reached a
+ * catalog. See `pseudo-locale.ts` for what it does and `docs/I18N.md` for how
+ * to turn it on.
+ *
+ * Deliberately absent from {@link SUPPORTED_LOCALES}: it is not a language
+ * anyone reads, so {@link negotiateLocale} must never return it and a language
+ * picker driven by {@link LOCALE_LABELS} must never offer it. The only way in
+ * is to set the stored `device:locale` preference to it by hand.
+ *
+ * `en-XA` is the tag Android and Chrome use for this, so a developer who has
+ * met one of those recognizes it.
+ */
+export const PSEUDO_LOCALE = "en-XA";
+
+export type PseudoLocale = typeof PSEUDO_LOCALE;
+
+/**
+ * A locale the app can actually render: the shipped set plus the pseudolocale.
+ * Everything on the rendering path (catalog loading, the active locale, the
+ * document element) is typed against this; everything a user chooses from is
+ * typed against {@link SupportedLocale}.
+ */
+export type ActiveLocale = SupportedLocale | PseudoLocale;
+
 export function isSupportedLocale(value: unknown): value is SupportedLocale {
   return (
     typeof value === "string" &&
     (SUPPORTED_LOCALES as readonly string[]).includes(value)
   );
+}
+
+export function isPseudoLocale(value: unknown): value is PseudoLocale {
+  return value === PSEUDO_LOCALE;
+}
+
+export function isActiveLocale(value: unknown): value is ActiveLocale {
+  return isSupportedLocale(value) || isPseudoLocale(value);
 }
 
 /**


### PR DESCRIPTION
Tooling, not a domain. Nine namespaces in, the thing that keeps going wrong is not translating strings but *finding* them, and that gets worse with every domain left.

## Why

The lint rule reads source and recognizes the shapes it was written for, which is a smaller set than the strings a user can read. Copy has reached main past a green run as:

- a `toastOnError("Failed to …")` argument (the rule matches `toast.*`, not a helper)
- a `setupLabel = "Invite"` default parameter
- the return value of a helper (`mapErrorCode`, `formatSurvivorName`, `capitalizeStatus`)
- `` `${n} item${n === 1 ? "" : "s"}` ``

I found each by reading the files. That does not scale to the ~3,500 strings left in `settings`, `chat`, `components`, `onboarding`, and `intelligence`.

## What it does

Set `device:locale` to `en-XA` and reload. Every string that came from `t()` renders like this:

```
⟦Àðð Çöñŧàçŧ····⟧
⟦Ŵĥéŕé ŧĥé àššîšŧàñŧ ŕéçöĝñîžéš ŧĥîš çöñŧàçŧ. Łîñķ àççöûñŧš ýöû ķñöŵ.········⟧
⟦2 çĥàññéłš ŵîłł ɱöṽé ŧö Ada: Slack, Email.··························⟧
```

Then read the screen. Each transform answers a different question:

| What you see | What it means |
| --- | --- |
| Plain unaccented English | Never reached a catalog. This is the miss. |
| No closing `⟧` | Truncated by the layout, so it will clip in production |
| `⟦…⟧⟦…⟧` in one sentence | Assembled from several `t()` calls; needs `Trans` |

The padding is about a third longer than the English, the headroom German and Finnish typically need, so a button or column that cannot take a translation fails here instead of after launch. Interpolated values stay plain (`⟦Ðéłéŧé Ada Lovelace?···⟧`), because they are data rather than copy.

## How placeholders survive

This is the part worth reviewing. The message is parsed with the same parser the runtime formats it with (`IntlMessageFormat#getAst`, `captureLocation: true`), which reports each literal's start and end offsets **in the source**. Only those ranges are rewritten:

```ts
out = out.slice(0, span.start) + accent(span.value) + out.slice(span.end);
```

Nothing reconstructs ICU syntax, so no shape of message can be mangled by a serializer that did not anticipate it, and a pseudolocalized message parses exactly when its source did. The accent map emits only letters, so a substitution cannot introduce `{`, `}`, `'`, or `#`. Plural and select branches are walked, so the branch a count actually selects is accented too, rather than reading as a false miss on every screen with a number on it.

No new dependency: `intl-messageformat` is already a direct dependency and exposes the AST.

## Safety

`en-XA` is deliberately **not** in `SUPPORTED_LOCALES`, so `negotiateLocale` cannot return it and a language picker driven by `LOCALE_LABELS` cannot offer it. Setting the stored preference by hand is the only way in. The rendering path (catalog loading, active locale, document element) is typed `ActiveLocale`; what a user selects from stays `SupportedLocale`.

The catalogs are derived from English at runtime rather than stored, so they cannot fall behind it and there is nothing to maintain. The transform is dynamically imported, landing in a 1.3 kB chunk that only loads on opt-in.

## Tests

Unit tests cover the interesting shapes: placeholders, explicit and categorical plural branches, `Trans` tags, number formats, a message that is nothing but a placeholder, and an unparseable message.

The last test is the one that matters: it runs **every message in every shipped English catalog** through the transform and asserts each one still parses and still names the same arguments. A catalog entry whose shape this module has not met fails there rather than on someone's screen. That test also caught a bug in my first draft of the test itself, where a regex for placeholder names matched the `{` opening a `=0 {No new channels…}` branch body.

## Verification

- `tsc --noEmit` clean
- `bun run lint` 0 errors, 16 warnings, unchanged from the baseline on main
- 946 test files pass
- `bun run build` emits `pseudo-locale-*.js` at 1.30 kB as its own chunk

## Next

Back to domains, now with a way to check the result: `onboarding` (194) and `intelligence` (177), then `components` (463), `chat` (1066), and `settings` (1585).

Still outstanding and unrelated to this: the Spanish is ~370 hand-written messages with no native-speaker review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CD12TRfmDF3UiXjdbiWn3i

---
_Generated by [Claude Code](https://claude.ai/code/session_01CD12TRfmDF3UiXjdbiWn3i)_