### PR TITLE
test: drop unused conversation-store mock from delete-schedule cleanup

### DIFF
--- a/assistant/src/__tests__/conversation-delete-schedule-cleanup.test.ts
+++ b/assistant/src/__tests__/conversation-delete-schedule-cleanup.test.ts
@@ -10,10 +10,6 @@ mock.module("../config/env.js", () => ({
   hasUngatedHttpAuthDisabled: () => false,
 }));
 
-mock.module("../daemon/conversation-store.js", () => ({
-  destroyActiveConversation: () => {},
-}));
-
 mock.module("../daemon/handlers/conversations.js", () => ({
   cancelGeneration: () => true,
   clearAllConversations: async () => 0,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Removes `mock.module("../daemon/conversation-store.js", …)` from `conversation-delete-schedule-cleanup.test.ts`.
- Same cleanup direction as #40608: the stub was a pure no-op (`destroyActiveConversation: () => {}`) because these tests never install an in-memory Conversation. The real store early-returns in that case, so the mock was not protecting anything the assertions depend on.

## Test Plan
- `cd assistant && bun test src/__tests__/conversation-delete-schedule-cleanup.test.ts` — 5 pass

## Risk
- Low. Test-only change; delete path still exercises real schedule cleanup against the DB.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47df1308-874e-498f-bbed-1d5ac44abec5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47df1308-874e-498f-bbed-1d5ac44abec5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

