### PR TITLE
feat(gateway): gate a plugin delivery before the plugin sees it

### DIFF
--- a/assistant/src/runtime/routes/inbound-stages/admission-policy.ts
+++ b/assistant/src/runtime/routes/inbound-stages/admission-policy.ts
@@ -27,6 +27,7 @@ import {
   ADMISSION_FLOOR,
   type AdmissionPolicy,
   isAdmissionPolicyExemptChannel,
+  TRUST_CLASS_RANK,
 } from "@vellumai/gateway-client";
 
 import type { ChannelId } from "../../../channels/types.js";
@@ -72,23 +73,6 @@ export type AdmissionPolicyResult =
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
-
-/**
- * Trust-class ordinal compared against {@link ADMISSION_FLOOR} to make the
- * admission decision (`rank >= floor`). Higher rank = more trusted.
- * Blocked/revoked never reach this comparison — they short-circuit to deny on
- * member status above — so they carry no rank here.
- *
- * The two halves of the floor check: this table is keyed by `TrustClass`,
- * `ADMISSION_FLOOR` (from `@vellumai/gateway-client`) by `AdmissionPolicy`.
- * They are only ever read together, here, so they live next to their use.
- */
-const TRUST_CLASS_RANK: Record<TrustClass, number> = {
-  guardian: 4,
-  trusted_contact: 3,
-  unverified_contact: 2,
-  unknown: 1,
-};
 
 /**
  * Policies under which completing verification could lift the sender past

--- a/gateway/src/handlers/handle-inbound.ts
+++ b/gateway/src/handlers/handle-inbound.ts
@@ -63,6 +63,23 @@ export type HandleInboundOptions = {
    * result, and preserves the resolved verdict.
    */
   senderAuthenticated?: boolean;
+  /**
+   * Where an admitted message goes, when that is not the assistant runtime.
+   *
+   * The gate is everything above the forward: the kill switch, the trust
+   * verdict, identity canonicalization, the verification and invite
+   * intercepts. A channel that delivers its own messages still has to pass
+   * all of it, and the way to guarantee that is for it to change only the
+   * destination and share the rest of this function verbatim. A second
+   * pipeline that re-implemented the ordering would be free to drift, and the
+   * drift would be silent, since a gate that is skipped looks exactly like a
+   * gate that admitted.
+   *
+   * Receives the same payload the runtime would have, so a caller sees the
+   * normalized message plus the verdict on `sourceMetadata`, and answers with
+   * the same shape so the outcome reads identically either way.
+   */
+  deliver?: typeof forwardToRuntime;
 };
 
 function normalizeTransportHints(hints: string[] | undefined): string[] {
@@ -262,8 +279,12 @@ export async function handleInbound(
   const transportUxBrief = options?.transportMetadata?.uxBrief?.trim();
   const sourceChannelName = event.source.channelName?.trim();
 
+  // Everything above this point is the gate. `deliver` only changes where an
+  // admitted message goes, never whether it is admitted.
+  const deliver = options?.deliver ?? forwardToRuntime;
+
   try {
-    const response = await forwardToRuntime(
+    const response = await deliver(
       config,
       {
         sourceChannel: event.sourceChannel,

--- a/gateway/src/handlers/handle-inbound.ts
+++ b/gateway/src/handlers/handle-inbound.ts
@@ -1,4 +1,5 @@
 import {
+  type AdmissionPolicy,
   makeResolutionFailedVerdict,
   makeUnauthenticatedSenderVerdict,
   type SourceMetadata,
@@ -39,6 +40,24 @@ export type InboundResult = {
   rejectionReason?: string;
 };
 
+/**
+ * What the gate decided, and what an admitted message carries with it.
+ *
+ * `admissionPolicy` and `trustVerdict` are the two halves a caller needs to
+ * apply the ranked floor itself (see {@link admitInbound}); the runtime gets
+ * them stamped on `sourceMetadata` and does the same comparison there.
+ */
+export type InboundAdmission =
+  | { admitted: false; result: InboundResult }
+  | {
+      admitted: true;
+      routing: RouteResult;
+      trustVerdict: TrustVerdict | undefined;
+      /** Null on a channel exempt from the floor entirely. */
+      admissionPolicy: AdmissionPolicy | null;
+      displayName: string | undefined;
+    };
+
 export type TransportMetadataOverrides = {
   hints?: string[];
   uxBrief?: string;
@@ -63,23 +82,6 @@ export type HandleInboundOptions = {
    * result, and preserves the resolved verdict.
    */
   senderAuthenticated?: boolean;
-  /**
-   * Where an admitted message goes, when that is not the assistant runtime.
-   *
-   * The gate is everything above the forward: the kill switch, the trust
-   * verdict, identity canonicalization, the verification and invite
-   * intercepts. A channel that delivers its own messages still has to pass
-   * all of it, and the way to guarantee that is for it to change only the
-   * destination and share the rest of this function verbatim. A second
-   * pipeline that re-implemented the ordering would be free to drift, and the
-   * drift would be silent, since a gate that is skipped looks exactly like a
-   * gate that admitted.
-   *
-   * Receives the same payload the runtime would have, so a caller sees the
-   * normalized message plus the verdict on `sourceMetadata`, and answers with
-   * the same shape so the outcome reads identically either way.
-   */
-  deliver?: typeof forwardToRuntime;
 };
 
 function normalizeTransportHints(hints: string[] | undefined): string[] {
@@ -95,11 +97,27 @@ function normalizeTransportHints(hints: string[] | undefined): string[] {
   return normalized;
 }
 
-export async function handleInbound(
+/**
+ * Everything that decides whether an inbound message may reach the assistant.
+ *
+ * Split out from {@link handleInbound} because a channel that delivers its own
+ * messages still has to pass all of it. Sharing this function is what makes
+ * that guaranteed rather than intended: a second implementation would be free
+ * to drift, and the drift would be silent, since a gate that is skipped looks
+ * exactly like a gate that admitted.
+ *
+ * What it does **not** decide is the ranked admission floor. `no_one` is
+ * enforced here as a kill switch, but `guardian_only` and below are compared
+ * against the sender's trust rank by whoever receives the message: the runtime
+ * does it in its admission stage, and a caller delivering somewhere else owes
+ * the same check with {@link meetsAdmissionFloor}, because nothing downstream
+ * of it will.
+ */
+export async function admitInbound(
   config: GatewayConfig,
   event: GatewayInboundEvent,
   options?: HandleInboundOptions,
-): Promise<InboundResult> {
+): Promise<InboundAdmission> {
   // ── Admission policy: `no_one` kill switch ──
   // Channel-global hard-deny, evaluated BEFORE routing so a channel set to
   // `no_one` denies every inbound with the kill-switch reason — even an
@@ -124,9 +142,12 @@ export async function handleInbound(
       "Inbound event hard-denied by admission policy 'no_one'",
     );
     return {
-      forwarded: false,
-      rejected: true,
-      rejectionReason: "admission_no_one",
+      admitted: false,
+      result: {
+        forwarded: false,
+        rejected: true,
+        rejectionReason: "admission_no_one",
+      },
     };
   }
 
@@ -147,9 +168,12 @@ export async function handleInbound(
       "Inbound event rejected by routing",
     );
     return {
-      forwarded: false,
-      rejected: true,
-      rejectionReason: routing.reason,
+      admitted: false,
+      result: {
+        forwarded: false,
+        rejected: true,
+        rejectionReason: routing.reason,
+      },
     };
   }
 
@@ -179,10 +203,13 @@ export async function handleInbound(
       "Text verification intercepted — not forwarding to runtime",
     );
     return {
-      forwarded: false,
-      rejected: false,
-      verificationIntercepted: true,
-      verificationReplyText: verificationResult.pendingReplyText,
+      admitted: false,
+      result: {
+        forwarded: false,
+        rejected: false,
+        verificationIntercepted: true,
+        verificationReplyText: verificationResult.pendingReplyText,
+      },
     };
   }
 
@@ -265,13 +292,35 @@ export async function handleInbound(
         "Invite redemption intercepted — not forwarding to runtime",
       );
       return {
-        forwarded: false,
-        rejected: false,
-        inviteIntercepted: true,
-        inviteReplyText: inviteResult.pendingReplyText,
+        admitted: false,
+        result: {
+          forwarded: false,
+          rejected: false,
+          inviteIntercepted: true,
+          inviteReplyText: inviteResult.pendingReplyText,
+        },
       };
     }
   }
+  return {
+    admitted: true,
+    routing,
+    trustVerdict,
+    admissionPolicy,
+    displayName,
+  };
+}
+
+export async function handleInbound(
+  config: GatewayConfig,
+  event: GatewayInboundEvent,
+  options?: HandleInboundOptions,
+): Promise<InboundResult> {
+  const admission = await admitInbound(config, event, options);
+  if (!admission.admitted) {
+    return admission.result;
+  }
+  const { routing, trustVerdict, admissionPolicy, displayName } = admission;
 
   const transportHints = normalizeTransportHints(
     options?.transportMetadata?.hints,
@@ -279,12 +328,8 @@ export async function handleInbound(
   const transportUxBrief = options?.transportMetadata?.uxBrief?.trim();
   const sourceChannelName = event.source.channelName?.trim();
 
-  // Everything above this point is the gate. `deliver` only changes where an
-  // admitted message goes, never whether it is admitted.
-  const deliver = options?.deliver ?? forwardToRuntime;
-
   try {
-    const response = await deliver(
+    const response = await forwardToRuntime(
       config,
       {
         sourceChannel: event.sourceChannel,

--- a/gateway/src/http/routes/plugin-webhook.test.ts
+++ b/gateway/src/http/routes/plugin-webhook.test.ts
@@ -26,7 +26,10 @@ import {
   INBOUND_CLAIM_LEASE_MS,
 } from "../../db/inbound-dedup-store.js";
 import { inboundSeenEvents } from "../../db/schema.js";
-import type { HandleInboundOptions } from "../../handlers/handle-inbound.js";
+import type {
+  HandleInboundOptions,
+  InboundAdmission,
+} from "../../handlers/handle-inbound.js";
 import {
   createPluginWebhookHandler,
   type PluginWebhookHandlerDeps,
@@ -1021,7 +1024,7 @@ describe("inbound delivery", () => {
    */
   function harness(
     opts: {
-      handleInboundImpl?: PluginWebhookHandlerDeps["handleInboundImpl"];
+      admitInboundImpl?: PluginWebhookHandlerDeps["admitInboundImpl"];
       pluginStatus?: number;
       route?: IngressRoute;
     } = {},
@@ -1044,19 +1047,22 @@ describe("inbound delivery", () => {
         });
         return new Response("{}", { status: opts.pluginStatus ?? 200 });
       },
-      handleInboundImpl:
-        opts.handleInboundImpl ??
+      admitInboundImpl:
+        opts.admitInboundImpl ??
         (async (
           _config: GatewayConfig,
           event: GatewayInboundEvent,
           o?: HandleInboundOptions,
-        ) => {
+        ): Promise<InboundAdmission> => {
           handled.push(event);
           options.push(o);
-          // Stand in for the real pipeline's admit path: run whatever the
-          // gateway wants delivered, exactly as `handleInbound` would.
-          await o?.deliver?.(_config, {} as never, undefined);
-          return { forwarded: true, rejected: false };
+          return {
+            admitted: true,
+            routing: { assistantId: "self" } as never,
+            trustVerdict: { trustClass: "guardian" } as never,
+            admissionPolicy: "trusted_contacts",
+            displayName: undefined,
+          };
         }),
     };
     return { handled, options, forwards, deps };
@@ -1106,10 +1112,13 @@ describe("inbound delivery", () => {
     // The point of gating first. A rejected sender must not reach a plugin
     // that would otherwise run a turn for them.
     const { forwards, deps } = harness({
-      handleInboundImpl: async () => ({
-        forwarded: false,
-        rejected: true,
-        rejectionReason: "admission_no_one",
+      admitInboundImpl: async () => ({
+        admitted: false,
+        result: {
+          forwarded: false,
+          rejected: true,
+          rejectionReason: "admission_no_one",
+        },
       }),
     });
 
@@ -1117,6 +1126,61 @@ describe("inbound delivery", () => {
 
     expect(forwards).toEqual([]);
     expect(res.status).toBe(200);
+  });
+
+  it("does not reach the plugin when the sender is below the admission floor", async () => {
+    // The gate stops at the kill switch and leaves the ranked floors to
+    // whoever receives the message. For a built-in channel that is the
+    // runtime's admission stage; here there is nothing downstream but the
+    // plugin, so a floor unenforced here is a floor unenforced at all.
+    const { forwards, deps } = harness({
+      admitInboundImpl: async () => ({
+        admitted: true,
+        routing: { assistantId: "self" } as never,
+        trustVerdict: { trustClass: "unknown" } as never,
+        admissionPolicy: "trusted_contacts",
+        displayName: undefined,
+      }),
+    });
+
+    const res = await deliver(deps);
+
+    expect(forwards).toEqual([]);
+    expect(res.status).toBe(200);
+  });
+
+  it("reaches the plugin when the sender clears the floor", async () => {
+    const { forwards, deps } = harness({
+      admitInboundImpl: async () => ({
+        admitted: true,
+        routing: { assistantId: "self" } as never,
+        trustVerdict: { trustClass: "trusted_contact" } as never,
+        admissionPolicy: "trusted_contacts",
+        displayName: undefined,
+      }),
+    });
+
+    await deliver(deps);
+
+    expect(forwards).toHaveLength(1);
+  });
+
+  it("treats a missing verdict as the least trusted sender", async () => {
+    // Verdict resolution can fail. Reading that as "no constraint" would
+    // admit exactly the sender the floor exists to stop.
+    const { forwards, deps } = harness({
+      admitInboundImpl: async () => ({
+        admitted: true,
+        routing: { assistantId: "self" } as never,
+        trustVerdict: undefined,
+        admissionPolicy: "trusted_contacts",
+        displayName: undefined,
+      }),
+    });
+
+    await deliver(deps);
+
+    expect(forwards).toEqual([]);
   });
 
   it("tells the pipeline which plugin and which route it came from", async () => {
@@ -1192,7 +1256,7 @@ describe("inbound delivery", () => {
 
   it("asks the vendor to retry when the pipeline throws", async () => {
     const { deps } = harness({
-      handleInboundImpl: async () => {
+      admitInboundImpl: async () => {
         throw new Error("runtime is down");
       },
     });
@@ -1265,7 +1329,7 @@ describe("inbound delivery", () => {
 
     it("lets the retry through after the pipeline threw", async () => {
       const failing = harness({
-        handleInboundImpl: async () => {
+        admitInboundImpl: async () => {
           throw new Error("runtime is down");
         },
       });
@@ -1299,7 +1363,7 @@ describe("inbound delivery", () => {
         enter = resolve;
       });
       const { deps } = harness({
-        handleInboundImpl: () => {
+        admitInboundImpl: () => {
           enter();
           return new Promise<never>(() => {});
         },

--- a/gateway/src/http/routes/plugin-webhook.test.ts
+++ b/gateway/src/http/routes/plugin-webhook.test.ts
@@ -7,6 +7,7 @@ import {
   describe,
   expect,
   it,
+  mock,
 } from "bun:test";
 
 import "../../__tests__/test-preload.js";
@@ -30,10 +31,38 @@ import type {
   HandleInboundOptions,
   InboundAdmission,
 } from "../../handlers/handle-inbound.js";
-import {
-  createPluginWebhookHandler,
-  type PluginWebhookHandlerDeps,
-} from "./plugin-webhook.js";
+
+/**
+ * The gate reaches the ACL database and the trust resolver, neither of which a
+ * test of this route's decisions should have to stand up. Mocked at the module
+ * rather than injected, so the route calls it the way production does.
+ */
+let admitImpl: (
+  config: GatewayConfig,
+  event: GatewayInboundEvent,
+  options?: HandleInboundOptions,
+) => Promise<InboundAdmission> = async () => ADMIT_GUARDIAN;
+const gateCalls: {
+  events: GatewayInboundEvent[];
+  options: (HandleInboundOptions | undefined)[];
+} = { events: [], options: [] };
+
+mock.module("../../handlers/handle-inbound.js", () => ({
+  admitInbound: (
+    config: GatewayConfig,
+    event: GatewayInboundEvent,
+    options?: HandleInboundOptions,
+  ) => {
+    gateCalls.events.push(event);
+    gateCalls.options.push(options);
+    return admitImpl(config, event, options);
+  },
+}));
+
+const { createPluginWebhookHandler } = await import("./plugin-webhook.js");
+type PluginWebhookHandlerDeps = Parameters<
+  typeof createPluginWebhookHandler
+>[0];
 
 // The handler mints a real service token for the upstream hop. Initialising
 // the key beats mocking token-exchange, which is process-wide in bun and
@@ -57,7 +86,18 @@ afterAll(() => {
 // against each other rather than against a redelivery.
 beforeEach(() => {
   getGatewayDb().delete(inboundSeenEvents).run();
+  gateCalls.events.length = 0;
+  gateCalls.options.length = 0;
 });
+
+/** An admitted delivery from a guardian, which clears every floor. */
+const ADMIT_GUARDIAN = {
+  admitted: true,
+  routing: { assistantId: "self" },
+  trustVerdict: { trustClass: "guardian" },
+  admissionPolicy: "trusted_contacts",
+  displayName: undefined,
+} as unknown as InboundAdmission;
 
 const CONFIG = {
   assistantRuntimeBaseUrl: "http://runtime.test:7821",
@@ -1024,14 +1064,17 @@ describe("inbound delivery", () => {
    */
   function harness(
     opts: {
-      admitInboundImpl?: PluginWebhookHandlerDeps["admitInboundImpl"];
+      admit?: typeof admitImpl;
       pluginStatus?: number;
       route?: IngressRoute;
     } = {},
   ) {
-    const handled: GatewayInboundEvent[] = [];
-    const options: (HandleInboundOptions | undefined)[] = [];
     const forwards: { url: string; body: string }[] = [];
+    // A fresh harness is a fresh scenario, so what the gate saw under the
+    // previous one is not this one's evidence.
+    gateCalls.events.length = 0;
+    gateCalls.options.length = 0;
+    admitImpl = opts.admit ?? (async () => ADMIT_GUARDIAN);
 
     const deps: PluginWebhookHandlerDeps = {
       config: CONFIG,
@@ -1047,25 +1090,13 @@ describe("inbound delivery", () => {
         });
         return new Response("{}", { status: opts.pluginStatus ?? 200 });
       },
-      admitInboundImpl:
-        opts.admitInboundImpl ??
-        (async (
-          _config: GatewayConfig,
-          event: GatewayInboundEvent,
-          o?: HandleInboundOptions,
-        ): Promise<InboundAdmission> => {
-          handled.push(event);
-          options.push(o);
-          return {
-            admitted: true,
-            routing: { assistantId: "self" } as never,
-            trustVerdict: { trustClass: "guardian" } as never,
-            admissionPolicy: "trusted_contacts",
-            displayName: undefined,
-          };
-        }),
     };
-    return { handled, options, forwards, deps };
+    return {
+      handled: gateCalls.events,
+      options: gateCalls.options,
+      forwards,
+      deps,
+    };
   }
 
   function deliver(
@@ -1112,7 +1143,7 @@ describe("inbound delivery", () => {
     // The point of gating first. A rejected sender must not reach a plugin
     // that would otherwise run a turn for them.
     const { forwards, deps } = harness({
-      admitInboundImpl: async () => ({
+      admit: async () => ({
         admitted: false,
         result: {
           forwarded: false,
@@ -1134,7 +1165,7 @@ describe("inbound delivery", () => {
     // runtime's admission stage; here there is nothing downstream but the
     // plugin, so a floor unenforced here is a floor unenforced at all.
     const { forwards, deps } = harness({
-      admitInboundImpl: async () => ({
+      admit: async () => ({
         admitted: true,
         routing: { assistantId: "self" } as never,
         trustVerdict: { trustClass: "unknown" } as never,
@@ -1151,7 +1182,7 @@ describe("inbound delivery", () => {
 
   it("reaches the plugin when the sender clears the floor", async () => {
     const { forwards, deps } = harness({
-      admitInboundImpl: async () => ({
+      admit: async () => ({
         admitted: true,
         routing: { assistantId: "self" } as never,
         trustVerdict: { trustClass: "trusted_contact" } as never,
@@ -1169,7 +1200,7 @@ describe("inbound delivery", () => {
     // Verdict resolution can fail. Reading that as "no constraint" would
     // admit exactly the sender the floor exists to stop.
     const { forwards, deps } = harness({
-      admitInboundImpl: async () => ({
+      admit: async () => ({
         admitted: true,
         routing: { assistantId: "self" } as never,
         trustVerdict: undefined,
@@ -1256,7 +1287,7 @@ describe("inbound delivery", () => {
 
   it("asks the vendor to retry when the pipeline throws", async () => {
     const { deps } = harness({
-      admitInboundImpl: async () => {
+      admit: async () => {
         throw new Error("runtime is down");
       },
     });
@@ -1329,7 +1360,7 @@ describe("inbound delivery", () => {
 
     it("lets the retry through after the pipeline threw", async () => {
       const failing = harness({
-        admitInboundImpl: async () => {
+        admit: async () => {
           throw new Error("runtime is down");
         },
       });
@@ -1363,7 +1394,7 @@ describe("inbound delivery", () => {
         enter = resolve;
       });
       const { deps } = harness({
-        admitInboundImpl: () => {
+        admit: () => {
           enter();
           return new Promise<never>(() => {});
         },

--- a/gateway/src/http/routes/plugin-webhook.test.ts
+++ b/gateway/src/http/routes/plugin-webhook.test.ts
@@ -27,7 +27,10 @@ import {
 } from "../../db/inbound-dedup-store.js";
 import { inboundSeenEvents } from "../../db/schema.js";
 import type { HandleInboundOptions } from "../../handlers/handle-inbound.js";
-import { createPluginWebhookHandler } from "./plugin-webhook.js";
+import {
+  createPluginWebhookHandler,
+  type PluginWebhookHandlerDeps,
+} from "./plugin-webhook.js";
 
 // The handler mints a real service token for the upstream hop. Initialising
 // the key beats mocking token-exchange, which is process-wide in bun and
@@ -979,6 +982,15 @@ describe("upstream failures", () => {
   });
 });
 
+/**
+ * Gating a delivery before the plugin sees it.
+ *
+ * The ordering is the whole subject. A plugin may run an agent turn the moment
+ * a delivery reaches it, so anything that could refuse the sender has to have
+ * run first. These assert on two things: that the gate ran against what the
+ * vendor sent, and that the plugin is reached exactly once and only for a
+ * message the gate admitted.
+ */
 describe("inbound delivery", () => {
   const INBOUND_ROUTE: IngressRoute = {
     ...ROUTE,
@@ -986,34 +998,7 @@ describe("inbound delivery", () => {
     inbound: IngressInboundSchema.parse({ identity: "phone" }),
   };
 
-  /** A plugin reply, and a recorder for what reached the inbound pipeline. */
-  function replyingWith(body: unknown, status = 200) {
-    const handled: GatewayInboundEvent[] = [];
-    const options: (HandleInboundOptions | undefined)[] = [];
-    return {
-      handled,
-      options,
-      deps: {
-        config: CONFIG,
-        credentials: CREDENTIALS,
-        resolve: () => approvedWith([INBOUND_ROUTE]),
-        fetchImpl: async () =>
-          new Response(typeof body === "string" ? body : JSON.stringify(body), {
-            status,
-          }),
-        handleInboundImpl: async (
-          _config: GatewayConfig,
-          event: GatewayInboundEvent,
-          opts?: HandleInboundOptions,
-        ) => {
-          handled.push(event);
-          options.push(opts);
-          return { forwarded: true, rejected: false };
-        },
-      },
-    };
-  }
-
+  /** What a vendor sends, in the shape the declaration's defaults read. */
   const MESSAGE = {
     message: {
       content: "hello",
@@ -1023,17 +1008,78 @@ describe("inbound delivery", () => {
     actor: { actorExternalId: "(202) 555-0142", displayName: "Ada" },
   };
 
-  it("runs the plugin's reply through the inbound pipeline", async () => {
-    // The whole point: the delivery the gateway already authenticated is what
-    // produces the message, so nothing new has to be opened to receive one.
-    const { handled, deps } = replyingWith(MESSAGE);
-    const handle = createPluginWebhookHandler(deps);
+  /** What MESSAGE is claimed under, once the plugin scoping is applied. */
+  const DEDUP_KEY = {
+    sourceChannel: "plugin",
+    externalChatId: "meeting-bot:chat-1",
+    externalMessageId: "meeting-bot:msg-1",
+  };
 
-    const res = await handle(
-      post("/webhooks/plugins/meeting-bot/events"),
+  /**
+   * A handler over the route, recording what the gate saw and what the plugin
+   * was sent.
+   */
+  function harness(
+    opts: {
+      handleInboundImpl?: PluginWebhookHandlerDeps["handleInboundImpl"];
+      pluginStatus?: number;
+      route?: IngressRoute;
+    } = {},
+  ) {
+    const handled: GatewayInboundEvent[] = [];
+    const options: (HandleInboundOptions | undefined)[] = [];
+    const forwards: { url: string; body: string }[] = [];
+
+    const deps: PluginWebhookHandlerDeps = {
+      config: CONFIG,
+      credentials: CREDENTIALS,
+      resolve: () => approvedWith([opts.route ?? INBOUND_ROUTE]),
+      fetchImpl: async (input, init) => {
+        forwards.push({
+          url: String(input),
+          body:
+            init?.body instanceof ArrayBuffer
+              ? new TextDecoder().decode(init.body)
+              : "",
+        });
+        return new Response("{}", { status: opts.pluginStatus ?? 200 });
+      },
+      handleInboundImpl:
+        opts.handleInboundImpl ??
+        (async (
+          _config: GatewayConfig,
+          event: GatewayInboundEvent,
+          o?: HandleInboundOptions,
+        ) => {
+          handled.push(event);
+          options.push(o);
+          // Stand in for the real pipeline's admit path: run whatever the
+          // gateway wants delivered, exactly as `handleInbound` would.
+          await o?.deliver?.(_config, {} as never, undefined);
+          return { forwarded: true, rejected: false };
+        }),
+    };
+    return { handled, options, forwards, deps };
+  }
+
+  function deliver(
+    deps: PluginWebhookHandlerDeps,
+    vendorBody: unknown = MESSAGE,
+  ) {
+    const body = JSON.stringify(vendorBody);
+    return createPluginWebhookHandler(deps)(
+      post("/webhooks/plugins/meeting-bot/events", body),
       "meeting-bot",
       "events",
     );
+  }
+
+  it("gates on what the vendor sent, not on anything the plugin says", async () => {
+    // The declaration reads the sender out of the delivery itself, which is
+    // what lets the gate run before the plugin is involved at all.
+    const { handled, deps } = harness();
+
+    const res = await deliver(deps);
 
     expect(res.status).toBe(200);
     expect(handled).toHaveLength(1);
@@ -1042,138 +1088,24 @@ describe("inbound delivery", () => {
     expect(handled[0]!.actor.actorExternalId).toBe("meeting-bot:+12025550142");
   });
 
-  it("tells the pipeline which plugin and which route it came from", async () => {
-    // A plugin can declare several routes, and knowing which one a turn
-    // arrived on separates a provider misconfiguration from a plugin bug.
-    const { options, deps } = replyingWith(MESSAGE);
-    const handle = createPluginWebhookHandler(deps);
+  it("reaches the plugin exactly once, with the vendor's own payload", async () => {
+    // One crossing, and the plugin gets what the vendor sent rather than the
+    // gateway's reading of it: only the plugin knows which event this is.
+    const { forwards, deps } = harness();
 
-    await handle(
-      post("/webhooks/plugins/meeting-bot/events"),
-      "meeting-bot",
-      "events",
+    await deliver(deps);
+
+    expect(forwards).toHaveLength(1);
+    expect(forwards[0]!.url).toBe(
+      "http://runtime.test:7821/v1/x/plugins/meeting-bot/events",
     );
-
-    expect(options[0]?.sourceMetadata).toEqual({
-      plugin: "meeting-bot",
-      ingressRoute: "events",
-    });
+    expect(JSON.parse(forwards[0]!.body)).toEqual(MESSAGE as never);
   });
 
-  it("does not echo the plugin's reply back to the vendor", async () => {
-    // The reply was addressed to us. A plugin normalizing a delivery into an
-    // event should not thereby send the sender's message back to the vendor.
-    const { deps } = replyingWith(MESSAGE);
-    const handle = createPluginWebhookHandler(deps);
-
-    const res = await handle(
-      post("/webhooks/plugins/meeting-bot/events"),
-      "meeting-bot",
-      "events",
-    );
-
-    expect(await res.json()).toEqual({ ok: true });
-  });
-
-  it("leaves a route that declares no delivery a plain proxy", async () => {
-    // Every declaration written before `inbound` existed means this, so the
-    // reply has to reach the vendor untouched and nothing may be delivered.
-    const { handled, deps } = replyingWith(MESSAGE);
-    const handle = createPluginWebhookHandler({
-      ...deps,
-      resolve: () => approvedWith([{ ...INBOUND_ROUTE, inbound: undefined }]),
-    });
-
-    const res = await handle(
-      post("/webhooks/plugins/meeting-bot/events"),
-      "meeting-bot",
-      "events",
-    );
-
-    expect(handled).toHaveLength(0);
-    expect(await res.json()).toEqual(MESSAGE as never);
-  });
-
-  it("delivers nothing when the plugin only acknowledged", async () => {
-    // The ordinary case. Receipts, echoes, and events the plugin does not
-    // handle all reply like this, and none of them is a turn.
-    const { handled, deps } = replyingWith({ ok: true, ignored: "an echo" });
-    const handle = createPluginWebhookHandler(deps);
-
-    const res = await handle(
-      post("/webhooks/plugins/meeting-bot/events"),
-      "meeting-bot",
-      "events",
-    );
-
-    expect(res.status).toBe(200);
-    expect(handled).toHaveLength(0);
-  });
-
-  it("still acknowledges the vendor when the reply cannot be read", async () => {
-    // The delivery was authentic and the plugin accepted it, so a failure to
-    // interpret its answer is ours. A 5xx here would have the vendor retry a
-    // delivery that fails the same way every time.
-    const { handled, deps } = replyingWith("not json at all");
-    const handle = createPluginWebhookHandler(deps);
-
-    const res = await handle(
-      post("/webhooks/plugins/meeting-bot/events"),
-      "meeting-bot",
-      "events",
-    );
-
-    expect(res.status).toBe(200);
-    expect(handled).toHaveLength(0);
-  });
-
-  it("asks the vendor to retry when the pipeline throws", async () => {
-    // A message that never reached the runtime would land on the next attempt.
-    // Acknowledging it loses a real message for the length of an outage, so
-    // this answers retryably and lets the vendor's own retry carry it.
-    const { deps } = replyingWith(MESSAGE);
-    const handle = createPluginWebhookHandler({
-      ...deps,
-      handleInboundImpl: async () => {
-        throw new Error("runtime is down");
-      },
-    });
-
-    const res = await handle(
-      post("/webhooks/plugins/meeting-bot/events"),
-      "meeting-bot",
-      "events",
-    );
-
-    expect(res.status).toBe(503);
-    expect(res.headers.get("Retry-After")).toBe("30");
-  });
-
-  it("asks the vendor to retry when the forward failed", async () => {
-    // `handleInbound` reports a runtime it could not reach as `forwarded:
-    // false` rather than by throwing, so the quiet case needs the same answer
-    // as the loud one.
-    const { deps } = replyingWith(MESSAGE);
-    const handle = createPluginWebhookHandler({
-      ...deps,
-      handleInboundImpl: async () => ({ forwarded: false, rejected: false }),
-    });
-
-    const res = await handle(
-      post("/webhooks/plugins/meeting-bot/events"),
-      "meeting-bot",
-      "events",
-    );
-
-    expect(res.status).toBe(503);
-  });
-
-  it("acknowledges a message the pipeline decided against", async () => {
-    // A rejection is a decision, not a failure: the message reached the
-    // pipeline and the pipeline said no. Sending it again changes nothing.
-    const { deps } = replyingWith(MESSAGE);
-    const handle = createPluginWebhookHandler({
-      ...deps,
+  it("does not reach the plugin at all when the gate refuses", async () => {
+    // The point of gating first. A rejected sender must not reach a plugin
+    // that would otherwise run a turn for them.
+    const { forwards, deps } = harness({
       handleInboundImpl: async () => ({
         forwarded: false,
         rejected: true,
@@ -1181,54 +1113,109 @@ describe("inbound delivery", () => {
       }),
     });
 
-    const res = await handle(
-      post("/webhooks/plugins/meeting-bot/events"),
+    const res = await deliver(deps);
+
+    expect(forwards).toEqual([]);
+    expect(res.status).toBe(200);
+  });
+
+  it("tells the pipeline which plugin and which route it came from", async () => {
+    const { options, deps } = harness();
+
+    await deliver(deps);
+
+    expect(options[0]?.sourceMetadata).toEqual({
+      plugin: "meeting-bot",
+      ingressRoute: "events",
+    });
+  });
+
+  it("does not echo the plugin's body back to the vendor", async () => {
+    const { deps } = harness();
+
+    const res = await deliver(deps);
+
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("forwards a delivery with no sender without gating it", async () => {
+    // A vendor's delivery probe. There is nobody to admit, so there is no
+    // admission decision to make, and the plugin still needs to see it.
+    const { handled, forwards, deps } = harness();
+
+    const res = await deliver(deps, { event: "probe" });
+
+    expect(handled).toHaveLength(0);
+    expect(forwards).toHaveLength(1);
+    expect(res.status).toBe(200);
+  });
+
+  it("refuses a delivery the declaration matched only partly", async () => {
+    // Half a message means the declaration and the payload disagree. Passing
+    // it on would hand the plugin a sender the gateway never checked.
+    const { handled, forwards, deps } = harness();
+
+    const res = await deliver(deps, {
+      message: { conversationExternalId: "chat-1" },
+      actor: { actorExternalId: "(202) 555-0142" },
+    });
+
+    expect(res.status).toBe(400);
+    expect(handled).toHaveLength(0);
+    expect(forwards).toEqual([]);
+  });
+
+  it("forwards an unparsable body rather than dropping it", async () => {
+    // The signature checked out, so this is the vendor sending something the
+    // gateway cannot read, not an attacker. The plugin may still know it.
+    const { forwards, deps } = harness();
+    const res = await createPluginWebhookHandler(deps)(
+      post("/webhooks/plugins/meeting-bot/events", "{ not json"),
       "meeting-bot",
       "events",
     );
 
     expect(res.status).toBe(200);
+    expect(forwards).toHaveLength(1);
   });
 
-  it("carries the vendor payload the plugin kept", async () => {
-    // The gateway understands only the declared fields, so anything the vendor
-    // sent beyond them survives on `raw` or nowhere.
-    const { handled, deps } = replyingWith({
-      ...MESSAGE,
-      raw: { reactions: ["heart"] },
+  it("leaves a route that declares no inbound a plain proxy", async () => {
+    const { handled, forwards, deps } = harness({
+      route: { ...INBOUND_ROUTE, inbound: undefined },
     });
-    const handle = createPluginWebhookHandler(deps);
 
-    await handle(
-      post("/webhooks/plugins/meeting-bot/events"),
-      "meeting-bot",
-      "events",
-    );
+    await deliver(deps);
 
-    expect(handled[0]!.raw).toEqual({ reactions: ["heart"] });
+    expect(handled).toHaveLength(0);
+    expect(forwards).toHaveLength(1);
   });
 
-  it("delivers nothing from a reply the plugin itself failed", async () => {
-    // A plugin reporting a failure is not reporting a message, and the vendor
-    // gets that status back so its own retry logic can act on it.
-    const { handled, deps } = replyingWith(MESSAGE, 500);
-    const handle = createPluginWebhookHandler(deps);
+  it("asks the vendor to retry when the pipeline throws", async () => {
+    const { deps } = harness({
+      handleInboundImpl: async () => {
+        throw new Error("runtime is down");
+      },
+    });
 
-    const res = await handle(
-      post("/webhooks/plugins/meeting-bot/events"),
-      "meeting-bot",
-      "events",
-    );
+    const res = await deliver(deps);
 
-    expect(res.status).toBe(500);
-    expect(handled).toHaveLength(0);
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("30");
+  });
+
+  it("asks the vendor to retry when the plugin refuses an admitted delivery", async () => {
+    // The gate said yes and the plugin could not take it. Acknowledging would
+    // lose a message the sender was entitled to have delivered.
+    const { deps } = harness({ pluginStatus: 500 });
+
+    const res = await deliver(deps);
+
+    expect(res.status).toBe(503);
   });
 
   it("delivers nothing from a route awaiting approval", async () => {
-    // The gate stands in front of this like everything else: a declaration
-    // that can start conversations must be one a guardian decided about.
-    const { handled, deps } = replyingWith(MESSAGE);
-    const handle = createPluginWebhookHandler({
+    const { handled, forwards, deps } = harness();
+    const res = await createPluginWebhookHandler({
       ...deps,
       resolve: () =>
         resolution({
@@ -1240,233 +1227,91 @@ describe("inbound delivery", () => {
             },
           ],
         }),
-    });
-
-    const res = await handle(
-      post("/webhooks/plugins/meeting-bot/events"),
+    })(
+      post("/webhooks/plugins/meeting-bot/events", JSON.stringify(MESSAGE)),
       "meeting-bot",
       "events",
     );
 
     expect(res.status).toBe(409);
     expect(handled).toHaveLength(0);
+    expect(forwards).toEqual([]);
   });
-});
 
-describe("inbound dedup", () => {
-  const INBOUND_ROUTE: IngressRoute = {
-    ...ROUTE,
-    path: "events",
-    inbound: IngressInboundSchema.parse({ identity: "phone" }),
-  };
+  describe("dedup", () => {
+    it("runs a redelivered message once, and acknowledges the second copy", async () => {
+      const { handled, forwards, deps } = harness();
 
-  const MESSAGE = {
-    message: {
-      content: "hello",
-      conversationExternalId: "chat-1",
-      externalMessageId: "msg-1",
-    },
-    actor: { actorExternalId: "(202) 555-0142" },
-  };
+      const first = await deliver(deps);
+      const second = await deliver(deps);
 
-  /** What MESSAGE is claimed under, once the plugin scoping is applied. */
-  const DEDUP_KEY = {
-    sourceChannel: "plugin",
-    externalChatId: "meeting-bot:chat-1",
-    externalMessageId: "meeting-bot:msg-1",
-  };
-
-  /**
-   * A handler over a fixed plugin reply, recording what reached the pipeline.
-   *
-   * `handleInboundImpl` is a parameter rather than fixed because what the
-   * pipeline did is exactly what decides whether the claim is kept: a message
-   * it handled stays claimed, a message it could not take is released so the
-   * vendor's retry is not answered as a duplicate.
-   */
-  function handlerFor(
-    handleInboundImpl: NonNullable<
-      Parameters<typeof createPluginWebhookHandler>[0]["handleInboundImpl"]
-    >,
-    reply: unknown = MESSAGE,
-  ) {
-    return createPluginWebhookHandler({
-      config: CONFIG,
-      credentials: CREDENTIALS,
-      resolve: () => approvedWith([INBOUND_ROUTE]),
-      fetchImpl: async () => new Response(JSON.stringify(reply)),
-      handleInboundImpl,
+      expect(handled).toHaveLength(1);
+      expect(forwards).toHaveLength(1);
+      expect(first.status).toBe(200);
+      expect(second.status).toBe(200);
     });
-  }
 
-  function deliver(handle: ReturnType<typeof createPluginWebhookHandler>) {
-    return handle(
-      post("/webhooks/plugins/meeting-bot/events"),
-      "meeting-bot",
-      "events",
-    );
-  }
+    it("does not treat the next message in a conversation as a retry", async () => {
+      const { handled, deps } = harness();
 
-  function accepting() {
-    const handled: GatewayInboundEvent[] = [];
-    return {
-      handled,
-      impl: async (_c: GatewayConfig, event: GatewayInboundEvent) => {
-        handled.push(event);
-        return { forwarded: true, rejected: false };
-      },
-    };
-  }
-
-  it("runs a redelivered message once, and acknowledges the second copy", async () => {
-    // Every vendor retries: on a timeout, on a 5xx, on an ack it did not see.
-    // The assistant deduped this already, but on the far side of the handoff,
-    // so without the claim a retry still costs a crossing and lands wherever
-    // the pipeline happens to be idempotent.
-    const { handled, impl } = accepting();
-    const handle = handlerFor(impl);
-
-    const first = await deliver(handle);
-    const second = await deliver(handle);
-
-    expect(handled).toHaveLength(1);
-    expect(first.status).toBe(200);
-    // 200, not an error: the delivery did land, and anything else asks the
-    // vendor to keep sending it.
-    expect(second.status).toBe(200);
-  });
-
-  it("does not treat the next message in a conversation as a retry", async () => {
-    const { handled, impl } = accepting();
-
-    await deliver(handlerFor(impl));
-    await deliver(
-      handlerFor(impl, {
+      await deliver(deps);
+      await deliver(deps, {
         ...MESSAGE,
         message: { ...MESSAGE.message, externalMessageId: "msg-2" },
-      }),
-    );
+      });
 
-    expect(handled).toHaveLength(2);
-  });
-
-  it("lets the retry through after the pipeline threw", async () => {
-    // The 503 asked for this delivery again. Keeping the claim would answer
-    // the retry we requested as a duplicate, which is how a message is lost
-    // while both sides report having done the right thing.
-    const failing = await deliver(
-      handlerFor(async () => {
-        throw new Error("runtime is down");
-      }),
-    );
-    expect(failing.status).toBe(503);
-
-    const { handled, impl } = accepting();
-    const retried = await deliver(handlerFor(impl));
-
-    expect(retried.status).toBe(200);
-    expect(handled).toHaveLength(1);
-  });
-
-  it("lets the retry through after the forward quietly failed", async () => {
-    // `handleInbound` reports an unreachable runtime as `forwarded: false`
-    // rather than by throwing, so the quiet path needs the same release.
-    const failing = await deliver(
-      handlerFor(async () => ({ forwarded: false, rejected: false })),
-    );
-    expect(failing.status).toBe(503);
-
-    const { handled, impl } = accepting();
-    await deliver(handlerFor(impl));
-
-    expect(handled).toHaveLength(1);
-  });
-
-  it("holds the claim on a message the pipeline decided against", async () => {
-    // A rejection is a decision the pipeline already made. Re-running it on
-    // every vendor retry would re-run its side effects too, and the denial
-    // reply is one of them.
-    let calls = 0;
-    const handle = handlerFor(async () => {
-      calls += 1;
-      return {
-        forwarded: false,
-        rejected: true,
-        rejectionReason: "admission_no_one",
-      };
+      expect(handled).toHaveLength(2);
     });
 
-    await deliver(handle);
-    const second = await deliver(handle);
+    it("lets the retry through after the pipeline threw", async () => {
+      const failing = harness({
+        handleInboundImpl: async () => {
+          throw new Error("runtime is down");
+        },
+      });
+      expect((await deliver(failing.deps)).status).toBe(503);
 
-    expect(calls).toBe(1);
-    expect(second.status).toBe(200);
-  });
+      const retried = harness();
+      await deliver(retried.deps);
 
-  it("claims nothing for a reply that carried no message", async () => {
-    // A receipt or an echo is not a delivery to dedup, and claiming one would
-    // put a row in the table for every event a plugin ever declines.
-    const { handled, impl } = accepting();
-    await deliver(handlerFor(impl, { ok: true, ignored: "an echo" }));
-
-    expect(handled).toHaveLength(0);
-    expect(getGatewayDb().select().from(inboundSeenEvents).all()).toHaveLength(
-      0,
-    );
-  });
-
-  it("claims under the plugin-scoped id, not the vendor's", async () => {
-    // One channel id covers every installed plugin, so two vendors both
-    // numbering messages from 1 would otherwise be each other's duplicates.
-    const { impl } = accepting();
-    await deliver(handlerFor(impl));
-
-    expect(getGatewayDb().select().from(inboundSeenEvents).all()).toEqual([
-      expect.objectContaining({
-        sourceChannel: "plugin",
-        externalChatId: "meeting-bot:chat-1",
-        externalMessageId: "meeting-bot:msg-1",
-      }),
-    ] as never);
-  });
-
-  it("commits the claim once the message reached the runtime", async () => {
-    // Committing is what turns the in-flight lease into the dedup window. A
-    // delivery that landed and stayed `pending` would start admitting retries
-    // again the moment its lease lapsed.
-    const { impl } = accepting();
-    await deliver(handlerFor(impl));
-
-    expect(readInboundEventClaim(DEDUP_KEY)?.state).toBe("committed");
-  });
-
-  it("leaves a delivery reclaimable when the gateway dies mid-handoff", async () => {
-    // The failure nothing can roll back: a deploy, an OOM, a host crash
-    // between claiming the delivery and handing it over. Nothing runs, so
-    // nothing releases, and the row survives the restart. If it were the full
-    // window it would answer every retry as already-delivered for a day,
-    // outliving the vendor's retry schedule and losing the message for good.
-    // The lease is what makes that recoverable, so the claim must be short and
-    // uncommitted while the handoff is in flight.
-    // Freeze the handoff at the point the gateway would have died: entered,
-    // never returning. Waiting on `entered` rather than a tick keeps this
-    // deterministic, since the claim is taken just before the pipeline runs.
-    let enter!: () => void;
-    const entered = new Promise<void>((resolve) => {
-      enter = resolve;
+      expect(retried.handled).toHaveLength(1);
     });
-    void deliver(
-      handlerFor(() => {
-        enter();
-        return new Promise<never>(() => {});
-      }),
-    );
-    await entered;
 
-    const claim = readInboundEventClaim(DEDUP_KEY);
-    expect(claim?.state).toBe("pending");
-    expect(claim!.expiresAt - claim!.seenAt).toBeLessThanOrEqual(
-      INBOUND_CLAIM_LEASE_MS,
-    );
+    it("claims under the plugin-scoped id, not the vendor's", async () => {
+      const { deps } = harness();
+      await deliver(deps);
+
+      expect(readInboundEventClaim(DEDUP_KEY)?.state).toBe("committed");
+    });
+
+    it("claims nothing for a delivery that carried no sender", async () => {
+      const { deps } = harness();
+      await deliver(deps, { event: "probe" });
+
+      expect(
+        getGatewayDb().select().from(inboundSeenEvents).all(),
+      ).toHaveLength(0);
+    });
+
+    it("leaves a delivery reclaimable when the gateway dies mid-handoff", async () => {
+      let enter!: () => void;
+      const entered = new Promise<void>((resolve) => {
+        enter = resolve;
+      });
+      const { deps } = harness({
+        handleInboundImpl: () => {
+          enter();
+          return new Promise<never>(() => {});
+        },
+      });
+      void deliver(deps);
+      await entered;
+
+      const claim = readInboundEventClaim(DEDUP_KEY);
+      expect(claim?.state).toBe("pending");
+      expect(claim!.expiresAt - claim!.seenAt).toBeLessThanOrEqual(
+        INBOUND_CLAIM_LEASE_MS,
+      );
+    });
   });
 });

--- a/gateway/src/http/routes/plugin-webhook.ts
+++ b/gateway/src/http/routes/plugin-webhook.ts
@@ -15,13 +15,16 @@
  * — and, for a route a third party calls, how the signature is formed at all
  * (`IngressRouteSchema.verification`).
  *
- * A route may also declare that its replies carry messages
+ * A route may also declare that its deliveries carry messages
  * (`IngressRouteSchema.inbound`), which is how a plugin channel receives
- * anything at all. The plugin parses its vendor's delivery and answers with
- * the result; the gateway reads that answer, claims it against redelivery,
- * and runs it through the same `handleInbound` every built-in channel uses.
- * See `plugin-inbound.ts` for what of the reply the gateway believes, and
- * `db/inbound-dedup-store.ts` for the claim.
+ * anything at all. The declaration says where the sender and the chat sit in
+ * the vendor's payload, which is the whole reason it exists: with those the
+ * gateway can run the same `handleInbound` every built-in channel runs
+ * *before* the plugin sees anything. The plugin is then free to act on a
+ * delivery the moment it arrives, because everything that could refuse it
+ * already has. See `plugin-inbound.ts` for what the gateway reads,
+ * `db/inbound-dedup-store.ts` for the redelivery claim, and
+ * `deliverGatedInbound` below for the ordering.
  */
 
 import {
@@ -53,7 +56,7 @@ import {
   verifySecretWithRefresh,
 } from "../../credential-refresh.js";
 import { getLogger } from "../../logger.js";
-import { readLimitedBody, readLimitedBodyBytes } from "../read-limited-body.js";
+import { readLimitedBodyBytes } from "../read-limited-body.js";
 import { verifyVellumSignature } from "../vellum-signature.js";
 import { proxyForwardToResponse } from "@vellumai/assistant-client";
 
@@ -283,113 +286,121 @@ export function createPluginWebhookHandler(deps: PluginWebhookHandlerDeps) {
     // ignores a trailing slash, and the plugin serves the path it declared.
     const upstreamPath = pluginRouteUpstreamPath(plugin, route.path);
     const search = new URL(req.url).search;
-    const start = performance.now();
-    // The body is already drained, so hand the proxy a request carrying the
-    // bytes we accepted rather than the consumed original.
-    const forwardable = new Request(req.url, {
-      method: req.method,
-      headers: req.headers,
-      body: METHODS_WITHOUT_BODY.has(req.method) ? undefined : body.bytes,
-    });
-    const response = await proxyForwardToResponse(forwardable, {
-      baseUrl: config.assistantRuntimeBaseUrl,
-      path: upstreamPath,
-      search: search || undefined,
-      serviceToken: mintServiceToken(),
-      timeoutMs: config.runtimeTimeoutMs,
-      fetchImpl,
-    });
-    const duration = Math.round(performance.now() - start);
 
-    if (response.status >= 500) {
-      log.error(
-        { plugin, path, status: response.status, duration },
-        "Plugin webhook upstream error",
-      );
-      return response;
-    }
-    if (response.status >= 400) {
-      log.warn(
-        { plugin, path, status: response.status, duration },
-        "Plugin webhook upstream error",
-      );
-      return response;
-    }
+    /**
+     * Hand the vendor's delivery to the plugin, verbatim.
+     *
+     * The plugin gets what the vendor sent rather than the gateway's reading
+     * of it: only the plugin knows which of its vendor's events this is, and
+     * the declaration covers just the few fields the gate needs. Re-parsing
+     * on the far side is the plugin doing the job it exists for.
+     */
+    const forwardToPlugin = async (): Promise<Response> => {
+      const start = performance.now();
+      // The body is already drained, so hand the proxy a request carrying the
+      // bytes we accepted rather than the consumed original.
+      const forwardable = new Request(req.url, {
+        method: req.method,
+        headers: req.headers,
+        body: METHODS_WITHOUT_BODY.has(req.method) ? undefined : body.bytes,
+      });
+      const forwarded = await proxyForwardToResponse(forwardable, {
+        baseUrl: config.assistantRuntimeBaseUrl,
+        path: upstreamPath,
+        search: search || undefined,
+        serviceToken: mintServiceToken(),
+        timeoutMs: config.runtimeTimeoutMs,
+        fetchImpl,
+      });
+      const duration = Math.round(performance.now() - start);
+      if (forwarded.status >= 500) {
+        log.error(
+          { plugin, path, status: forwarded.status, duration },
+          "Plugin webhook upstream error",
+        );
+      } else if (forwarded.status >= 400) {
+        log.warn(
+          { plugin, path, status: forwarded.status, duration },
+          "Plugin webhook upstream error",
+        );
+      }
+      return forwarded;
+    };
 
     const inbound = route.inbound;
     if (!inbound) {
-      return response;
+      // A route that receives no messages is a plain proxy: nothing to read,
+      // nothing to gate.
+      return forwardToPlugin();
     }
-    return deliverPluginInbound({
+
+    return deliverGatedInbound({
       config,
       plugin,
       routePath: route.path,
       inbound,
-      response,
+      body: body.bytes,
+      forwardToPlugin,
       handleInboundImpl,
     });
   };
 }
 
 /**
- * Run a plugin's reply through the inbound pipeline and answer the vendor.
+ * Gate a delivery, then hand it to the plugin once.
  *
- * Only reached for a 2xx, because a reply the plugin itself is reporting a
- * failure on is not a message. The vendor gets the plugin's status back but
- * not its body: the body was addressed to us, and a plugin that normalizes a
- * delivery into an event should not thereby echo the sender's message back to
- * the vendor that sent it.
+ * The ordering is the point. The gateway reads the sender and the chat out of
+ * the vendor's payload with the route's declaration, runs the same
+ * `handleInbound` every built-in channel runs, and only then forwards. A
+ * plugin that receives a delivery may therefore act on it immediately, up to
+ * and including running an agent turn, because by the time it sees anything
+ * the kill switch, the trust verdict and the intercepts have already had their
+ * say. Gating after the forward would make all of that advisory.
  *
- * Two kinds of failure, answered differently. A reply the gateway cannot make
- * sense of — unreadable, not JSON, half a message — fails the same way on
- * every retry, so the vendor is acknowledged and the reason goes to the log;
- * that is the retry storm the 409 on unapproved routes exists to avoid.
+ * One crossing, not two. The plugin is the only thing downstream, so the
+ * runtime hop `handleInbound` would otherwise make is replaced by the forward
+ * to the plugin's own route (see `HandleInboundOptions.deliver`), and the
+ * plugin owns what happens next: which of its vendor's events this is, whether
+ * it becomes a turn, and how a reply goes back out over its own transport.
  *
- * A failure to *forward* is the opposite: the runtime is down, the circuit
- * breaker is open, the message is well-formed and would land on the next
- * attempt. Acknowledging that would lose a real message for the length of an
- * assistant outage, so it answers 503 and lets the vendor's own retry carry
- * the delivery. This is what `processInboundResult` does for the built-in
- * channels; the shape differs only because the plugin's reply, not the
- * vendor's request, is what carries the message here.
- *
- * Which makes the dedup claim part of the same decision. Asking for a retry
- * and keeping the claim that would answer it as a duplicate is how a message
- * is lost while both sides look correct, so every path that answers 503
- * releases first, and the claim is only widened to the full dedup window once
- * the message has actually landed. See `reserveInboundEvent`.
+ * A delivery carrying no sender is not a message the gateway can gate. A
+ * vendor's delivery probe is the usual case, and it reaches the plugin
+ * ungated, because there is nobody to admit and nothing to admit them to.
  */
-async function deliverPluginInbound(opts: {
+async function deliverGatedInbound(opts: {
   config: GatewayConfig;
   plugin: string;
   /** The declared path, for logs. Not the requested spelling. */
   routePath: string;
   inbound: IngressInbound;
-  response: Response;
+  /** The vendor's payload, as accepted. */
+  body: Uint8Array;
+  forwardToPlugin: () => Promise<Response>;
   handleInboundImpl: typeof handleInbound;
 }): Promise<Response> {
-  const { config, plugin, routePath, inbound, response, handleInboundImpl } =
-    opts;
-  const ack = Response.json({ ok: true }, { status: response.status });
-
-  const body = await readLimitedBody(response, config.maxWebhookPayloadBytes);
-  if (body.status !== "ok") {
-    log.warn(
-      { plugin, path: routePath, reason: body.status },
-      "Could not read the plugin's reply for inbound delivery",
-    );
-    return ack;
-  }
+  const {
+    config,
+    plugin,
+    routePath,
+    inbound,
+    body,
+    forwardToPlugin,
+    handleInboundImpl,
+  } = opts;
 
   let parsed: unknown;
   try {
-    parsed = body.text.trim() === "" ? undefined : JSON.parse(body.text);
+    const text = new TextDecoder().decode(body);
+    parsed = text.trim() === "" ? undefined : JSON.parse(text);
   } catch {
+    // Authentic but unreadable. The signature checked out, so this is the
+    // vendor sending something we cannot parse rather than an attacker; the
+    // plugin may still recognise it.
     log.warn(
       { plugin, path: routePath },
-      "Plugin reply on an inbound route is not JSON",
+      "Plugin webhook payload is not JSON, forwarding ungated",
     );
-    return ack;
+    return forwardToPlugin();
   }
 
   const reading = readPluginInbound({
@@ -400,32 +411,26 @@ async function deliverPluginInbound(opts: {
   });
 
   if (reading.status === "none") {
-    // The ordinary case: a receipt, an echo, an event the plugin does not
-    // handle. Debug rather than info — every delivery would log otherwise.
+    // The ordinary case for a probe or a receipt: no sender, so no admission
+    // decision to make. Debug rather than info, since every such delivery
+    // would log otherwise.
     log.debug(
       { plugin, path: routePath },
-      "Plugin reply carried no inbound message",
+      "Delivery carries no sender, forwarding ungated",
     );
-    return ack;
+    return forwardToPlugin();
   }
   if (reading.status === "invalid") {
+    // Some of a message but not enough of one. Declining to gate a delivery
+    // the declaration half-matched would hand the plugin a sender the gateway
+    // never checked, so this is refused outright.
     log.warn(
       { plugin, path: routePath, reason: reading.reason },
-      "Plugin reply on an inbound route is not a usable message",
+      "Delivery matched the inbound declaration only partly, refusing",
     );
-    return ack;
+    return Response.json({ error: "Bad Request" }, { status: 400 });
   }
 
-  // Claimed before the handoff, not after it. The assistant dedups on this
-  // same triple in `recordInbound`, but that is on the far side of the
-  // crossing, so without this a vendor's retry still costs a forward and
-  // relies on everything upstream of that record being idempotent. See
-  // `reserveInboundEvent`.
-  //
-  // As early as it can currently be: the message only exists once the plugin
-  // has parsed the delivery, so a redelivery still reaches the plugin, which
-  // must keep its own parse free of side effects. That ends when the gateway
-  // parses the vendor payload itself and the claim can precede the forward.
   const dedupKey = {
     sourceChannel: reading.event.sourceChannel,
     externalChatId: reading.event.message.conversationExternalId,
@@ -442,8 +447,11 @@ async function deliverPluginInbound(opts: {
       },
       "Duplicate plugin inbound delivery, acknowledged without forwarding",
     );
-    return ack;
+    return Response.json({ ok: true }, { status: 200 });
   }
+
+  // Set by `deliver` below, which only runs for a message the gate admitted.
+  let pluginResponse: Response | undefined;
 
   let result: InboundResult;
   try {
@@ -453,6 +461,23 @@ async function deliverPluginInbound(opts: {
       // arrived on is the difference between a provider misconfiguration and a
       // plugin bug.
       sourceMetadata: { plugin, ingressRoute: routePath },
+      deliver: async () => {
+        pluginResponse = await forwardToPlugin();
+        if (pluginResponse.status >= 400) {
+          throw new Error(
+            `Plugin route answered ${pluginResponse.status} for an admitted delivery`,
+          );
+        }
+        // `handleInbound` reports on the delivery through this shape. The
+        // plugin owns the turn, so there is no runtime event id to carry and
+        // no assistant reply to hand back; the delivery is accepted and never
+        // a duplicate, the gateway's own claim having already settled that.
+        return {
+          accepted: true,
+          duplicate: false,
+          eventId: dedupKey.externalMessageId,
+        };
+      },
     });
   } catch (err) {
     // `CircuitBreakerOpenError` reaches here by design: `handleInbound` lets it
@@ -482,16 +507,16 @@ async function deliverPluginInbound(opts: {
 
   // Rejected and intercepted are decisions, not failures: the message reached
   // the pipeline and the pipeline said no, or consumed it. Only a message that
-  // never reached the runtime is worth sending again.
-  const reachedRuntime =
+  // never reached the plugin is worth sending again.
+  const settled =
     result.forwarded ||
     result.rejected ||
     result.verificationIntercepted === true ||
     result.inviteIntercepted === true;
-  if (!reachedRuntime) {
+  if (!settled) {
     log.error(
       { plugin, path: routePath },
-      "Plugin inbound message was not forwarded to the runtime",
+      "Plugin inbound message was not delivered",
     );
     releaseInboundEvent(dedupKey);
     return retryLater();
@@ -503,7 +528,10 @@ async function deliverPluginInbound(opts: {
   // retry as already-delivered.
   commitInboundEvent(dedupKey);
 
-  return ack;
+  // The vendor gets a bare acknowledgement, never the plugin's body: that was
+  // addressed to us, and a plugin handling a delivery should not thereby echo
+  // the sender's own message back to the vendor that sent it.
+  return Response.json({ ok: true }, { status: pluginResponse?.status ?? 200 });
 }
 
 /**

--- a/gateway/src/http/routes/plugin-webhook.ts
+++ b/gateway/src/http/routes/plugin-webhook.ts
@@ -120,6 +120,67 @@ function pluginRouteUpstreamPath(plugin: string, path: string): string {
   return `/v1/x/plugins/${plugin}/${path}`;
 }
 
+/**
+ * What a forward to the plugin needs, gathered once at the route.
+ */
+interface PluginForward {
+  config: GatewayConfig;
+  plugin: string;
+  /** The declared path, not the requested spelling. */
+  routePath: string;
+  req: Request;
+  /** The vendor's payload, as accepted. */
+  body: Uint8Array<ArrayBuffer>;
+  search: string;
+  fetchImpl?: (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ) => Promise<Response>;
+}
+
+/**
+ * Hand the vendor's delivery to the plugin, verbatim.
+ *
+ * The plugin gets what the vendor sent rather than the gateway's reading of
+ * it: only the plugin knows which of its vendor's events this is, and the
+ * declaration covers just the few fields the gate needs. Re-parsing on the far
+ * side is the plugin doing the job it exists for.
+ */
+async function forwardToPlugin(forward: PluginForward): Promise<Response> {
+  const { config, plugin, routePath, req, body, search, fetchImpl } = forward;
+  const start = performance.now();
+  // The body is already drained, so hand the proxy a request carrying the
+  // bytes we accepted rather than the consumed original.
+  const forwardable = new Request(req.url, {
+    method: req.method,
+    headers: req.headers,
+    body: METHODS_WITHOUT_BODY.has(req.method) ? undefined : body,
+  });
+  const forwarded = await proxyForwardToResponse(forwardable, {
+    baseUrl: config.assistantRuntimeBaseUrl,
+    // Forward under the declared path, not the requested spelling: matching
+    // ignores a trailing slash, and the plugin serves the path it declared.
+    path: pluginRouteUpstreamPath(plugin, routePath),
+    search: search || undefined,
+    serviceToken: mintServiceToken(),
+    timeoutMs: config.runtimeTimeoutMs,
+    fetchImpl,
+  });
+  const duration = Math.round(performance.now() - start);
+  if (forwarded.status >= 500) {
+    log.error(
+      { plugin, path: routePath, status: forwarded.status, duration },
+      "Plugin webhook upstream error",
+    );
+  } else if (forwarded.status >= 400) {
+    log.warn(
+      { plugin, path: routePath, status: forwarded.status, duration },
+      "Plugin webhook upstream error",
+    );
+  }
+  return forwarded;
+}
+
 export interface PluginWebhookHandlerDeps {
   config: GatewayConfig;
   /** Approved-ingress view; cached by the caller so this stays off the disk. */
@@ -130,12 +191,6 @@ export interface PluginWebhookHandlerDeps {
     input: string | URL | Request,
     init?: RequestInit,
   ) => Promise<Response>;
-  /**
-   * The gate, injected for the same reason `fetchImpl` is: it reaches the ACL
-   * database and the trust resolver, neither of which a test of this route's
-   * decisions should have to stand up.
-   */
-  admitInboundImpl?: typeof admitInbound;
 }
 
 /**
@@ -160,13 +215,7 @@ export interface PluginWebhookHandlerDeps {
  * by the same body cap as everything else here.
  */
 export function createPluginWebhookHandler(deps: PluginWebhookHandlerDeps) {
-  const {
-    config,
-    resolve,
-    credentials,
-    fetchImpl,
-    admitInboundImpl = admitInbound,
-  } = deps;
+  const { config, resolve, credentials, fetchImpl } = deps;
 
   return async (req: Request, plugin: string, path: string) => {
     let match: ReturnType<typeof findDeclaredRoute>;
@@ -284,67 +333,26 @@ export function createPluginWebhookHandler(deps: PluginWebhookHandlerDeps) {
       );
     }
 
-    // Forward under the declared path, not the requested spelling: matching
-    // ignores a trailing slash, and the plugin serves the path it declared.
-    const upstreamPath = pluginRouteUpstreamPath(plugin, route.path);
     const search = new URL(req.url).search;
 
-    /**
-     * Hand the vendor's delivery to the plugin, verbatim.
-     *
-     * The plugin gets what the vendor sent rather than the gateway's reading
-     * of it: only the plugin knows which of its vendor's events this is, and
-     * the declaration covers just the few fields the gate needs. Re-parsing
-     * on the far side is the plugin doing the job it exists for.
-     */
-    const forwardToPlugin = async (): Promise<Response> => {
-      const start = performance.now();
-      // The body is already drained, so hand the proxy a request carrying the
-      // bytes we accepted rather than the consumed original.
-      const forwardable = new Request(req.url, {
-        method: req.method,
-        headers: req.headers,
-        body: METHODS_WITHOUT_BODY.has(req.method) ? undefined : body.bytes,
-      });
-      const forwarded = await proxyForwardToResponse(forwardable, {
-        baseUrl: config.assistantRuntimeBaseUrl,
-        path: upstreamPath,
-        search: search || undefined,
-        serviceToken: mintServiceToken(),
-        timeoutMs: config.runtimeTimeoutMs,
-        fetchImpl,
-      });
-      const duration = Math.round(performance.now() - start);
-      if (forwarded.status >= 500) {
-        log.error(
-          { plugin, path, status: forwarded.status, duration },
-          "Plugin webhook upstream error",
-        );
-      } else if (forwarded.status >= 400) {
-        log.warn(
-          { plugin, path, status: forwarded.status, duration },
-          "Plugin webhook upstream error",
-        );
-      }
-      return forwarded;
+    const forward = {
+      config,
+      plugin,
+      routePath: route.path,
+      req,
+      body: body.bytes,
+      search,
+      fetchImpl,
     };
 
     const inbound = route.inbound;
     if (!inbound) {
       // A route that receives no messages is a plain proxy: nothing to read,
       // nothing to gate.
-      return forwardToPlugin();
+      return forwardToPlugin(forward);
     }
 
-    return deliverGatedInbound({
-      config,
-      plugin,
-      routePath: route.path,
-      inbound,
-      body: body.bytes,
-      forwardToPlugin,
-      admitInboundImpl,
-    });
+    return deliverGatedInbound({ inbound, forward });
   };
 }
 
@@ -370,25 +378,11 @@ export function createPluginWebhookHandler(deps: PluginWebhookHandlerDeps) {
  * ungated, because there is nobody to admit and nothing to admit them to.
  */
 async function deliverGatedInbound(opts: {
-  config: GatewayConfig;
-  plugin: string;
-  /** The declared path, for logs. Not the requested spelling. */
-  routePath: string;
   inbound: IngressInbound;
-  /** The vendor's payload, as accepted. */
-  body: Uint8Array;
-  forwardToPlugin: () => Promise<Response>;
-  admitInboundImpl: typeof admitInbound;
+  forward: PluginForward;
 }): Promise<Response> {
-  const {
-    config,
-    plugin,
-    routePath,
-    inbound,
-    body,
-    forwardToPlugin,
-    admitInboundImpl,
-  } = opts;
+  const { inbound, forward } = opts;
+  const { config, plugin, routePath, body } = forward;
 
   let parsed: unknown;
   try {
@@ -402,7 +396,7 @@ async function deliverGatedInbound(opts: {
       { plugin, path: routePath },
       "Plugin webhook payload is not JSON, forwarding ungated",
     );
-    return forwardToPlugin();
+    return forwardToPlugin(forward);
   }
 
   const reading = readPluginInbound({
@@ -420,7 +414,7 @@ async function deliverGatedInbound(opts: {
       { plugin, path: routePath },
       "Delivery carries no sender, forwarding ungated",
     );
-    return forwardToPlugin();
+    return forwardToPlugin(forward);
   }
   if (reading.status === "invalid") {
     // Some of a message but not enough of one. Declining to gate a delivery
@@ -454,7 +448,7 @@ async function deliverGatedInbound(opts: {
 
   let admission: InboundAdmission;
   try {
-    admission = await admitInboundImpl(config, reading.event, {
+    admission = await admitInbound(config, reading.event, {
       // Which plugin, for the runtime and for anyone reading a transcript. The
       // route too: a plugin can declare several, and knowing which one a turn
       // arrived on is the difference between a provider misconfiguration and a
@@ -516,7 +510,7 @@ async function deliverGatedInbound(opts: {
     return Response.json({ ok: true }, { status: 200 });
   }
 
-  const pluginResponse = await forwardToPlugin();
+  const pluginResponse = await forwardToPlugin(forward);
   if (pluginResponse.status >= 400) {
     // The gate said yes and the plugin could not take it. Acknowledging would
     // lose a message the sender was entitled to have delivered.

--- a/gateway/src/http/routes/plugin-webhook.ts
+++ b/gateway/src/http/routes/plugin-webhook.ts
@@ -27,6 +27,8 @@
  * `deliverGatedInbound` below for the ordering.
  */
 
+import { meetsAdmissionFloor } from "@vellumai/gateway-client";
+
 import {
   findDeclaredRoute,
   type PluginIngressResolution,
@@ -39,8 +41,8 @@ import { readPluginInbound } from "../../channels/plugin-inbound.js";
 import type { IngressInbound } from "../../channels/ingress-inbound.js";
 import type { IngressSigner } from "../../channels/plugin-ingress.js";
 import {
-  handleInbound,
-  type InboundResult,
+  admitInbound,
+  type InboundAdmission,
 } from "../../handlers/handle-inbound.js";
 import { mintServiceToken } from "../../auth/token-exchange.js";
 import type { GatewayConfig } from "../../config.js";
@@ -129,11 +131,11 @@ export interface PluginWebhookHandlerDeps {
     init?: RequestInit,
   ) => Promise<Response>;
   /**
-   * The inbound pipeline, injected for the same reason `fetchImpl` is: it
-   * reaches the ACL database, the trust resolver, and the runtime, none of
-   * which a test of this route's decisions should have to stand up.
+   * The gate, injected for the same reason `fetchImpl` is: it reaches the ACL
+   * database and the trust resolver, neither of which a test of this route's
+   * decisions should have to stand up.
    */
-  handleInboundImpl?: typeof handleInbound;
+  admitInboundImpl?: typeof admitInbound;
 }
 
 /**
@@ -163,7 +165,7 @@ export function createPluginWebhookHandler(deps: PluginWebhookHandlerDeps) {
     resolve,
     credentials,
     fetchImpl,
-    handleInboundImpl = handleInbound,
+    admitInboundImpl = admitInbound,
   } = deps;
 
   return async (req: Request, plugin: string, path: string) => {
@@ -341,7 +343,7 @@ export function createPluginWebhookHandler(deps: PluginWebhookHandlerDeps) {
       inbound,
       body: body.bytes,
       forwardToPlugin,
-      handleInboundImpl,
+      admitInboundImpl,
     });
   };
 }
@@ -376,7 +378,7 @@ async function deliverGatedInbound(opts: {
   /** The vendor's payload, as accepted. */
   body: Uint8Array;
   forwardToPlugin: () => Promise<Response>;
-  handleInboundImpl: typeof handleInbound;
+  admitInboundImpl: typeof admitInbound;
 }): Promise<Response> {
   const {
     config,
@@ -385,7 +387,7 @@ async function deliverGatedInbound(opts: {
     inbound,
     body,
     forwardToPlugin,
-    handleInboundImpl,
+    admitInboundImpl,
   } = opts;
 
   let parsed: unknown;
@@ -450,41 +452,21 @@ async function deliverGatedInbound(opts: {
     return Response.json({ ok: true }, { status: 200 });
   }
 
-  // Set by `deliver` below, which only runs for a message the gate admitted.
-  let pluginResponse: Response | undefined;
-
-  let result: InboundResult;
+  let admission: InboundAdmission;
   try {
-    result = await handleInboundImpl(config, reading.event, {
+    admission = await admitInboundImpl(config, reading.event, {
       // Which plugin, for the runtime and for anyone reading a transcript. The
       // route too: a plugin can declare several, and knowing which one a turn
       // arrived on is the difference between a provider misconfiguration and a
       // plugin bug.
       sourceMetadata: { plugin, ingressRoute: routePath },
-      deliver: async () => {
-        pluginResponse = await forwardToPlugin();
-        if (pluginResponse.status >= 400) {
-          throw new Error(
-            `Plugin route answered ${pluginResponse.status} for an admitted delivery`,
-          );
-        }
-        // `handleInbound` reports on the delivery through this shape. The
-        // plugin owns the turn, so there is no runtime event id to carry and
-        // no assistant reply to hand back; the delivery is accepted and never
-        // a duplicate, the gateway's own claim having already settled that.
-        return {
-          accepted: true,
-          duplicate: false,
-          eventId: dedupKey.externalMessageId,
-        };
-      },
     });
   } catch (err) {
-    // `CircuitBreakerOpenError` reaches here by design: `handleInbound` lets it
+    // `CircuitBreakerOpenError` reaches here by design: the gate lets it
     // through precisely so a caller can answer retryably instead of 500ing.
     log.error(
       { err, plugin, path: routePath },
-      "Plugin inbound message could not be handled",
+      "Plugin inbound message could not be gated",
     );
     // Answering 503 asks for the delivery again, so the claim has to go with
     // it. Keeping it would have the retry we just asked for answered as a
@@ -494,29 +476,53 @@ async function deliverGatedInbound(opts: {
     return retryLater();
   }
 
-  log.info(
-    {
-      plugin,
-      path: routePath,
-      forwarded: result.forwarded,
-      rejected: result.rejected,
-      rejectionReason: result.rejectionReason,
-    },
-    "Plugin inbound message handled",
-  );
+  if (!admission.admitted) {
+    // A decision, not a failure: the message reached the gate and the gate
+    // said no, or consumed it. Sending it again changes nothing, so the
+    // vendor is acknowledged and the claim stands.
+    log.info(
+      {
+        plugin,
+        path: routePath,
+        rejected: admission.result.rejected,
+        rejectionReason: admission.result.rejectionReason,
+      },
+      "Plugin inbound message was not admitted",
+    );
+    commitInboundEvent(dedupKey);
+    return Response.json({ ok: true }, { status: 200 });
+  }
 
-  // Rejected and intercepted are decisions, not failures: the message reached
-  // the pipeline and the pipeline said no, or consumed it. Only a message that
-  // never reached the plugin is worth sending again.
-  const settled =
-    result.forwarded ||
-    result.rejected ||
-    result.verificationIntercepted === true ||
-    result.inviteIntercepted === true;
-  if (!settled) {
+  // The ranked admission floor, which the gate deliberately leaves to whoever
+  // receives the message. For a built-in channel that is the runtime's own
+  // admission stage; here there is nothing downstream but the plugin, so a
+  // floor unenforced here is a floor unenforced at all, and an unknown sender
+  // would reach a plugin free to answer them.
+  const { admissionPolicy, trustVerdict } = admission;
+  if (
+    admissionPolicy &&
+    !meetsAdmissionFloor(admissionPolicy, trustVerdict?.trustClass ?? "unknown")
+  ) {
+    log.info(
+      {
+        plugin,
+        path: routePath,
+        admissionPolicy,
+        trustClass: trustVerdict?.trustClass ?? "unknown",
+      },
+      "Plugin inbound message denied by the admission floor",
+    );
+    commitInboundEvent(dedupKey);
+    return Response.json({ ok: true }, { status: 200 });
+  }
+
+  const pluginResponse = await forwardToPlugin();
+  if (pluginResponse.status >= 400) {
+    // The gate said yes and the plugin could not take it. Acknowledging would
+    // lose a message the sender was entitled to have delivered.
     log.error(
-      { plugin, path: routePath },
-      "Plugin inbound message was not delivered",
+      { plugin, path: routePath, status: pluginResponse.status },
+      "Plugin refused an admitted delivery",
     );
     releaseInboundEvent(dedupKey);
     return retryLater();

--- a/packages/gateway-client/src/admission-policy-contract.ts
+++ b/packages/gateway-client/src/admission-policy-contract.ts
@@ -10,6 +10,8 @@
 
 import { z } from "zod";
 
+import type { TrustClass } from "./trust-verdict-contract.js";
+
 /**
  * Per-channel inbound admission policy — ordered from most-restrictive
  * (`no_one`, hard kill switch) to most-permissive (`strangers`, admits any
@@ -100,4 +102,36 @@ export function isAdmissionPolicy(value: unknown): value is AdmissionPolicy {
     typeof value === "string" &&
     (ADMISSION_POLICY_VALUES as readonly string[]).includes(value)
   );
+}
+
+/**
+ * Trust-class ordinal compared against {@link ADMISSION_FLOOR} to make the
+ * admission decision. Higher rank = more trusted. Blocked and revoked members
+ * never reach this comparison, short-circuiting to deny on member status, so
+ * they carry no rank.
+ */
+export const TRUST_CLASS_RANK: Record<TrustClass, number> = {
+  guardian: 4,
+  trusted_contact: 3,
+  unverified_contact: 2,
+  unknown: 1,
+};
+
+/**
+ * Whether a sender of this trust class clears a channel's admission floor.
+ *
+ * The two halves of the check live together because they are meaningless
+ * apart: this compares a table keyed by {@link TrustClass} against one keyed
+ * by {@link AdmissionPolicy}, and a floor added to one without a rank in the
+ * other silently admits or denies everyone.
+ *
+ * Both enforcement points read this. The runtime's admission stage answers for
+ * every channel it receives; the gateway answers for a channel it delivers
+ * somewhere other than the runtime, where there is no later stage to ask.
+ */
+export function meetsAdmissionFloor(
+  policy: AdmissionPolicy,
+  trustClass: TrustClass,
+): boolean {
+  return TRUST_CLASS_RANK[trustClass] >= ADMISSION_FLOOR[policy];
 }

--- a/packages/gateway-client/src/index.ts
+++ b/packages/gateway-client/src/index.ts
@@ -71,6 +71,8 @@ export {
   isAdmissionPolicy,
   isAdmissionPolicyExemptChannel,
   isAdmissionPolicyHiddenChannel,
+  meetsAdmissionFloor,
+  TRUST_CLASS_RANK,
 } from "./admission-policy-contract.js";
 
 export type { AdmissionPolicy } from "./admission-policy-contract.js";


### PR DESCRIPTION
## Prompt / plan

> yes, the main thing is still outstanding — can you start working on it

First half of the rewiring: cross from gateway to plugin **once**, and do it **after** the gate.

### The ordering problem

A plugin route was forwarded to first and gated afterwards, because the normalized message came back on the plugin's reply. That order holds only while a plugin does nothing but normalize. The moment it acts on a delivery — runs an agent turn, sends something — everything the gate could have refused has already happened, and the gate becomes advisory.

So the gateway now reads the sender and the chat out of the **vendor's payload** itself, using the route's `inbound` declaration, which is what that declaration was built for (`ingress-inbound-vendors.test.ts` already proved both vendors are expressible). Verify → parse → gate → forward.

### Admission is enforced where the message lands

`handleInbound` enforces the `no_one` kill switch; the four **ranked** floors are compared against the sender's trust rank by whoever receives the message. For a built-in channel that is the runtime's admission stage. A plugin route no longer reaches the runtime, so the floor is enforced here — otherwise an unknown sender would arrive at a plugin under the default `trusted_contacts` policy, and a plugin is free to answer whoever reaches it.

Both halves of that comparison now live together in `packages/gateway-client`: `ADMISSION_FLOOR` was already there and `TRUST_CLASS_RANK` joins it, behind a shared `meetsAdmissionFloor(policy, trustClass)` that both enforcement points call. Keeping the rank table beside its use in the runtime was right while the runtime was its only reader; two copies is how a policy ends up with a floor in one table and no rank in the other.

An **absent trust verdict counts as `unknown`**, the least trusted class. Verdict resolution can fail, and reading a failure as "no constraint" would admit exactly the sender the floor exists to refuse.

### Shape

The gate is split out as `admitInbound`, returning the decision plus the verdict and the policy it resolved under. `handleInbound` is that call plus the runtime forward; the plugin route calls `admitInbound` and then forwards to the plugin, directly and in sequence. Nothing is injected into the pipeline.

The plugin receives the vendor's payload **verbatim** rather than the gateway's reading of it. Only the plugin knows which of its vendor's events a delivery is; the declaration covers just the handful of fields the gate needs.

### Outcomes

| delivery | behaviour |
|---|---|
| no sender in the payload (a probe, a receipt) | forwarded ungated — nothing to admit |
| matches the declaration only partly | refused 400 — forwarding it would hand the plugin a sender the gateway never checked |
| gate refuses, or sender below the floor | acknowledged, plugin never reached |
| admitted | claimed against redelivery, forwarded once |

## Test plan

- The gate, signature and verification tests pass untouched — the blast radius I wanted.
- Inbound tests rewritten to put the message in the vendor's request rather than the plugin's reply. Carrying the point of the change: `does not reach the plugin at all when the gate refuses`, `reaches the plugin exactly once, with the vendor's own payload`, `does not reach the plugin when the sender is below the admission floor`, `treats a missing verdict as the least trusted sender`. 56 pass in that file.
- Full gateway suite green (251 files). Assistant suite shows only its 7 known-pre-existing failures plus one timeout-under-load flake that passes in isolation. Typecheck, lint, prettier clean across gateway, assistant and the contract package.

## Known gaps, both deliberate

**1. Intercept replies have no transport.** The verification and invite intercepts produce `pendingReplyText`, and `deliverVerificationReply` POSTs it to a `replyCallbackUrl` that plugin channels do not have. A verification code sent to a plugin channel still has nowhere to go. This predates the change and wants a plugin-declared reply route.

**2. Echoes are not yet distinguishable, so no plugin manifest should declare vendor field paths against these routes yet.** Comms delivers our own outbound replies back to the same webhook (`message.sent`), and Photon does the same via `isFromMe`. The plugin filters those today, before the gateway sees them — but with the parse now gateway-side, an echo parses as a real message whose sender is whatever `from` names. The declaration cannot express "only when `direction` is inbound", and a value map without a `default` falls through to the raw value rather than yielding nothing, so it is not expressible with the current primitives either. Resolution is under discussion — most likely a narrow `when` predicate (field path → required value, ANDed) on the route's `inbound`, evaluated in the gateway and folded into the approval digest.