### PR TITLE
feat(web): translate the onboarding pages and shared components

### DIFF
--- a/clients/web/eslint-rules/no-untranslated-strings.mjs
+++ b/clients/web/eslint-rules/no-untranslated-strings.mjs
@@ -52,6 +52,7 @@ const STRUCTURAL_PROPS = new Set([
   "clipPath",
   "d",
   "fill",
+  "fontFamily",
   "points",
   "stroke",
   "transform",

--- a/clients/web/eslint.config.mjs
+++ b/clients/web/eslint.config.mjs
@@ -205,6 +205,10 @@ const i18nEnforcedPaths = [
   "src/domains/library/**/*.{ts,tsx}",
   "src/domains/home/**/*.{ts,tsx}",
   "src/domains/contacts/**/*.{ts,tsx}",
+  // `screens/` follows in its own pass; this becomes a directory glob then.
+  "src/domains/onboarding/pages/**/*.{ts,tsx}",
+  "src/domains/onboarding/components/**/*.{ts,tsx}",
+  "src/domains/onboarding/hooks/**/*.{ts,tsx}",
 ];
 
 const eslintConfig = defineConfig([

--- a/clients/web/src/domains/onboarding/components/add-remote-origin-dialog.tsx
+++ b/clients/web/src/domains/onboarding/components/add-remote-origin-dialog.tsx
@@ -10,6 +10,7 @@ import {
   useRememberedOriginsStore,
   type RememberedOrigin,
 } from "@/stores/remembered-origins-store";
+import { useTranslation } from "@/i18n";
 
 const ADD_FAILED_COPY = "Failed to add the assistant. Please try again.";
 
@@ -52,6 +53,7 @@ function AddRemoteOriginDialog({
   onClose,
   onAdded,
 }: AddRemoteOriginDialogProps) {
+  const { t } = useTranslation("onboarding");
   const [url, setUrl] = useState("");
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -115,9 +117,9 @@ function AddRemoteOriginDialog({
     >
       <Modal.Content size="md">
         <Modal.Header icon={Globe}>
-          <Modal.Title>Add a Remote Assistant</Modal.Title>
+          <Modal.Title>{t("addRemoteOriginDialog.title")}</Modal.Title>
           <Modal.Description>
-            Paste the https link your assistant&rsquo;s pairing page gave you.
+            {t("addRemoteOriginDialog.body")}
           </Modal.Description>
         </Modal.Header>
 
@@ -128,7 +130,7 @@ function AddRemoteOriginDialog({
                 className="text-body-small-default text-[var(--content-secondary)]"
                 htmlFor="add-remote-origin-url"
               >
-                Assistant address
+                {t("addRemoteOriginDialog.addressLabel")}
               </label>
               <Input
                 id="add-remote-origin-url"
@@ -151,14 +153,14 @@ function AddRemoteOriginDialog({
 
         <Modal.Footer>
           <Button variant="ghost" onClick={handleClose} disabled={pending}>
-            Cancel
+            {t("actions.cancel")}
           </Button>
           <Button
             variant="primary"
             onClick={() => void handleSubmit()}
             disabled={!url.trim() || pending}
           >
-            {pending ? "Adding…" : "Add"}
+            {pending ? t("actions.adding") : t("actions.add")}
           </Button>
         </Modal.Footer>
       </Modal.Content>

--- a/clients/web/src/domains/onboarding/components/connect-assistant-dialog.tsx
+++ b/clients/web/src/domains/onboarding/components/connect-assistant-dialog.tsx
@@ -7,6 +7,7 @@ import { Modal } from "@vellumai/design-library/components/modal";
 import { Notice } from "@vellumai/design-library/components/notice";
 
 import { importPairedAssistantBundle } from "@/lib/local-mode";
+import { Trans, useTranslation } from "@/i18n";
 
 interface ConnectAssistantDialogProps {
   open: boolean;
@@ -38,6 +39,7 @@ function ConnectAssistantDialog({
   onClose,
   onImported,
 }: ConnectAssistantDialogProps) {
+  const { t } = useTranslation("onboarding");
   const [bundle, setBundle] = useState("");
   const [name, setName] = useState("");
   const [pending, setPending] = useState(false);
@@ -106,13 +108,13 @@ function ConnectAssistantDialog({
       >
         <Modal.Content size="sm">
           <Modal.Header icon={Link2}>
-            <Modal.Title>Pairing Imported</Modal.Title>
+            <Modal.Title>
+              {t("connectAssistantDialog.importedTitle")}
+            </Modal.Title>
           </Modal.Header>
           <Modal.Body>
             <Notice tone="warning">
-              This pairing is access-only: its access expires and cannot renew
-              itself. Re-run vellum pair on the assistant&rsquo;s machine and
-              import the new bundle when it expires.
+              {t("connectAssistantDialog.importedBody")}
             </Notice>
           </Modal.Body>
           <Modal.Footer>
@@ -120,7 +122,7 @@ function ConnectAssistantDialog({
               variant="primary"
               onClick={() => onImported(accessOnlyAssistantId)}
             >
-              Continue
+              {t("actions.continue")}
             </Button>
           </Modal.Footer>
         </Modal.Content>
@@ -139,11 +141,16 @@ function ConnectAssistantDialog({
     >
       <Modal.Content size="md">
         <Modal.Header icon={Link2}>
-          <Modal.Title>Connect a Remote Assistant</Modal.Title>
+          <Modal.Title>{t("connectAssistantDialog.title")}</Modal.Title>
           <Modal.Description>
-            On the assistant&rsquo;s machine, run{" "}
-            <code>vellum pair --url https://...</code> and paste the bundle
-            here.
+            {/* The command sits mid-sentence, so the whole instruction is
+                one entry and a language that reorders it keeps the code tag
+                with the command. */}
+            <Trans
+              i18nKey="connectAssistantDialog.instruction"
+              ns="onboarding"
+              components={{ code: <code /> }}
+            />
           </Modal.Description>
         </Modal.Header>
 
@@ -156,7 +163,7 @@ function ConnectAssistantDialog({
                 className="text-body-small-default text-[var(--content-secondary)]"
                 htmlFor="connect-assistant-bundle"
               >
-                Pairing bundle
+                {t("connectAssistantDialog.bundleLabel")}
               </label>
               <Textarea
                 id="connect-assistant-bundle"
@@ -174,7 +181,7 @@ function ConnectAssistantDialog({
                 className="text-body-small-default text-[var(--content-secondary)]"
                 htmlFor="connect-assistant-name"
               >
-                Name (optional)
+                {t("connectAssistantDialog.nameLabel")}
               </label>
               <Input
                 id="connect-assistant-name"
@@ -196,14 +203,14 @@ function ConnectAssistantDialog({
 
         <Modal.Footer>
           <Button variant="ghost" onClick={handleClose} disabled={pending}>
-            Cancel
+            {t("actions.cancel")}
           </Button>
           <Button
             variant="primary"
             onClick={() => void handleSubmit()}
             disabled={!bundle.trim() || pending}
           >
-            {pending ? "Connecting…" : "Connect"}
+            {pending ? t("actions.connecting") : t("actions.connect")}
           </Button>
         </Modal.Footer>
       </Modal.Content>

--- a/clients/web/src/domains/onboarding/components/connect-recovery-dialog.tsx
+++ b/clients/web/src/domains/onboarding/components/connect-recovery-dialog.tsx
@@ -5,6 +5,7 @@ import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialo
 import { Modal } from "@vellumai/design-library/components/modal";
 
 import { RetireConfirmDialog } from "@/components/retire-confirm-dialog";
+import { useTranslation } from "@/i18n";
 
 type RecoveryStep = "menu" | "confirm-repair" | "confirm-retire";
 
@@ -39,6 +40,7 @@ function ConnectRecoveryDialog({
   onRepair,
   onRetire,
 }: ConnectRecoveryDialogProps) {
+  const { t } = useTranslation("onboarding");
   const [step, setStep] = useState<RecoveryStep>("menu");
 
   useEffect(() => {
@@ -58,16 +60,14 @@ function ConnectRecoveryDialog({
     return (
       <ConfirmDialog
         open={open}
-        title="Repair Assistant?"
+        title={t("connectRecoveryDialog.repairTitle")}
         message={
           <>
-            Repairing re-provisions this assistant&rsquo;s authentication token.
-            Any other devices or browser sessions connected to it will be signed
-            out and need to reconnect.
+            {t("connectRecoveryDialog.repairBody")}
             {errorLine}
           </>
         }
-        confirmLabel="Repair"
+        confirmLabel={t("connectRecoveryDialog.repairConfirm")}
         isPending={isPending}
         onConfirm={onRepair}
         onCancel={() => setStep("menu")}
@@ -108,13 +108,15 @@ function ConnectRecoveryDialog({
         }}
       >
         <Modal.Header>
-          <Modal.Title>Can&rsquo;t Authenticate Assistant</Modal.Title>
+          <Modal.Title>
+            {t("connectRecoveryDialog.authFailedTitle")}
+          </Modal.Title>
         </Modal.Header>
         <Modal.Body>
           <Modal.Description>
-            The authentication token for {assistantName} is missing or can no
-            longer be refreshed, so this assistant can&rsquo;t be connected. You
-            can repair it, retire it, or pick a different assistant.
+            {t("connectRecoveryDialog.authFailedBody", {
+              name: assistantName,
+            })}
           </Modal.Description>
           {errorLine}
           <div className="mt-5 flex w-full flex-col gap-2">
@@ -124,7 +126,7 @@ function ConnectRecoveryDialog({
               disabled={isPending}
               onClick={() => setStep("confirm-repair")}
             >
-              Wake &amp; Repair
+              {t("connectRecoveryDialog.wakeAndRepair")}
             </Button>
             <Button
               variant="dangerOutline"
@@ -132,7 +134,7 @@ function ConnectRecoveryDialog({
               disabled={isPending}
               onClick={() => setStep("confirm-retire")}
             >
-              Retire Assistant
+              {t("connectRecoveryDialog.retire")}
             </Button>
             <Button
               variant="outlined"
@@ -140,7 +142,7 @@ function ConnectRecoveryDialog({
               disabled={isPending}
               onClick={onCancel}
             >
-              Cancel
+              {t("actions.cancel")}
             </Button>
           </div>
         </Modal.Body>

--- a/clients/web/src/domains/onboarding/components/consent-controls.tsx
+++ b/clients/web/src/domains/onboarding/components/consent-controls.tsx
@@ -4,6 +4,7 @@ import { SettingRow } from "@/components/setting-row";
 import { legalUrl, routes } from "@/utils/routes";
 import { Card } from "@vellumai/design-library/components/card";
 import { Checkbox } from "@vellumai/design-library/components/checkbox";
+import { Trans, useTranslation } from "@/i18n";
 
 /**
  * Consent controls shared by the onboarding privacy screen and the
@@ -58,15 +59,23 @@ function ConsentCheckbox({
       onCheckedChange={(next) => onChange(next === true)}
       label={
         <span className="text-body-medium-lighter text-[var(--content-default)]">
-          I agree to the{" "}
-          <a
-            href={legalUrl(link.href)}
-            target="_blank"
-            rel="noreferrer"
-            className="underline"
-          >
-            {link.text}
-          </a>
+          {/* The policy's name is data, so the sentence keeps it as a value
+              inside the link rather than being split around the anchor. */}
+          <Trans
+            i18nKey="consentControls.agreeTo"
+            ns="onboarding"
+            values={{ policy: link.text }}
+            components={{
+              link: (
+                <a
+                  href={legalUrl(link.href)}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="underline"
+                />
+              ),
+            }}
+          />
         </span>
       }
       aria-label={link.aria}
@@ -86,13 +95,14 @@ function Divider() {
 // change itself to the most legible line in the card — it's why the user is
 // here. Renders nothing when there are no notes.
 function PolicyChangeNotes({ notes }: { notes?: string[] }) {
+  const { t } = useTranslation("onboarding");
   if (!notes || notes.length === 0) {
     return null;
   }
   return (
     <div className="rounded-r-md border-l-2 border-[var(--content-secondary)] bg-[var(--surface-base)] py-3 pl-3.5 pr-3.5">
       <p className="text-body-small-default font-medium text-[var(--content-secondary)]">
-        What&apos;s changed
+        {t("consentControls.whatsChanged")}
       </p>
       {notes.length === 1 ? (
         <p className="mt-1.5 text-body-medium-lighter text-[var(--content-default)]">
@@ -139,15 +149,18 @@ export function PrivacyPreferencesCard({
   className?: string;
   style?: CSSProperties;
 }) {
+  const { t } = useTranslation("onboarding");
   return (
     <section className={className} style={style}>
-      <p className={SECTION_LABEL_CLASS}>Privacy preferences</p>
+      <p className={SECTION_LABEL_CLASS}>
+        {t("consentControls.privacyPreferences")}
+      </p>
       <Card padding={electron ? "sm" : "md"} className="w-full">
         <div className={`flex flex-col ${electron ? "gap-3" : "gap-4"}`}>
           {showAnalytics && (
             <SettingRow
-              label="Share Analytics"
-              helperText="Send aggregated product usage data"
+              label={t("consentControls.analyticsLabel")}
+              helperText={t("consentControls.analyticsHelp")}
               checked={shareAnalytics}
               onChange={onShareAnalyticsChange}
             />
@@ -155,8 +168,8 @@ export function PrivacyPreferencesCard({
           {showAnalytics && showDiagnostics && <Divider />}
           {showDiagnostics && (
             <SettingRow
-              label="Share Diagnostics"
-              helperText="Send crash reports, conversation traces, and session replay data"
+              label={t("consentControls.diagnosticsLabel")}
+              helperText={t("consentControls.diagnosticsHelp")}
               checked={shareDiagnostics}
               onChange={onShareDiagnosticsChange}
             />
@@ -192,9 +205,10 @@ export function AgreementsCard({
   className?: string;
   style?: CSSProperties;
 }) {
+  const { t } = useTranslation("onboarding");
   return (
     <section className={className} style={style}>
-      <p className={SECTION_LABEL_CLASS}>Agreements</p>
+      <p className={SECTION_LABEL_CLASS}>{t("consentControls.agreements")}</p>
       <Card padding={electron ? "sm" : "md"} className="w-full">
         <div className={`flex flex-col ${electron ? "gap-3.5" : "gap-4"}`}>
           {showPrivacy && (

--- a/clients/web/src/domains/onboarding/components/hatch-error-overlay.tsx
+++ b/clients/web/src/domains/onboarding/components/hatch-error-overlay.tsx
@@ -3,6 +3,7 @@ import { Notice } from "@vellumai/design-library/components/notice";
 import { createPortal } from "react-dom";
 
 import { PLATFORM_HOSTED_DISABLED_MESSAGE } from "@/assistant/lifecycle";
+import { useTranslation } from "@/i18n";
 
 interface HatchErrorOverlayProps {
   /** Terminal failure message from the background hatch. */
@@ -31,23 +32,24 @@ interface HatchErrorOverlayProps {
  * `h-10`), so it clears both them and the notch.
  */
 export function HatchErrorOverlay({ error, onRetry }: HatchErrorOverlayProps) {
+  const { t } = useTranslation("onboarding");
   const platformHostedDisabled = error === PLATFORM_HOSTED_DISABLED_MESSAGE;
   return createPortal(
     <div className="pointer-events-none fixed inset-x-0 top-0 z-50 flex justify-center px-4 pt-[calc(var(--safe-area-inset-top,env(safe-area-inset-top,0px))+5rem)]">
       <Notice
         tone="error"
-        title="Something went wrong"
+        title={t("hatchingScreen.genericFailure")}
         className="pointer-events-auto w-auto max-w-[480px] shadow-xl"
         actions={
           platformHostedDisabled ? (
             <Button asChild variant="primary" size="regular">
               <a href={`${window.location.origin}/download`}>
-                Download the macOS app
+                {t("actions.downloadMacApp")}
               </a>
             </Button>
           ) : (
             <Button variant="primary" size="regular" onClick={onRetry}>
-              Try again
+              {t("actions.tryAgain")}
             </Button>
           )
         }
@@ -55,7 +57,7 @@ export function HatchErrorOverlay({ error, onRetry }: HatchErrorOverlayProps) {
         {error}
         {platformHostedDisabled ? (
           <p className="mt-1 text-[color:var(--content-default)]">
-            Get started today with a local assistant
+            {t("hatchingScreen.localFallbackPitch")}
           </p>
         ) : null}
       </Notice>

--- a/clients/web/src/domains/onboarding/components/onboarding-autocomplete.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-autocomplete.tsx
@@ -32,6 +32,7 @@ import { Tag } from "@vellumai/design-library/components/tag";
 import { cn } from "@vellumai/design-library/utils/cn";
 
 import { MOBILE_INPUT_NO_ZOOM } from "@/domains/onboarding/onboarding-step-layout";
+import { useTranslation } from "@/i18n";
 
 /** Field shell shared by both fields — label + token-matched container. */
 const FIELD_BOX = cn(
@@ -105,6 +106,7 @@ function SuggestionList({
   onPick: (value: string) => void;
   onHover: (index: number) => void;
 }) {
+  const { t } = useTranslation("onboarding");
   return (
     <ul
       id={id}
@@ -139,9 +141,11 @@ function SuggestionList({
                 size={15}
                 className="shrink-0 text-[var(--content-tertiary)]"
               />
-              <span className="min-w-0 truncate">Add “{opt.value}”</span>
+              <span className="min-w-0 truncate">
+                {t("onboardingAutocomplete.addOption", { value: opt.value })}
+              </span>
               <span className="ml-auto shrink-0 text-body-small-default text-[var(--content-tertiary)]">
-                ↵ Enter
+                {t("onboardingAutocomplete.enterHint")}
               </span>
             </>
           ) : (
@@ -154,7 +158,7 @@ function SuggestionList({
           role="presentation"
           className="mt-0.5 border-t border-[var(--border-base)] px-2.5 pb-0.5 pt-1.5 text-body-small-default text-[var(--content-tertiary)]"
         >
-          Type anything and press ↵ to add your own
+          {t("onboardingAutocomplete.freeTextHint")}
         </li>
       )}
     </ul>
@@ -221,6 +225,7 @@ export function TagAutocompleteInput({
   onChange,
   suggestions,
 }: TagAutocompleteInputProps) {
+  const { t } = useTranslation("onboarding");
   const reactId = useId();
   const inputId = `tac-${reactId}`;
   const listId = `tac-list-${reactId}`;
@@ -334,7 +339,7 @@ export function TagAutocompleteInput({
           <Tag
             key={v}
             onRemove={() => removeChip(v)}
-            removeLabel={`Remove ${v}`}
+            removeLabel={t("actions.remove", { value: v })}
             // Default tag bg (--tag-bg-neutral) collides with --field-bg in dark
             // mode; --surface-base contrasts against the field in both themes.
             className="border border-[var(--border-base)] bg-[var(--surface-base)]"

--- a/clients/web/src/domains/onboarding/components/onboarding-top-bar.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-top-bar.tsx
@@ -13,6 +13,7 @@
 import { ArrowLeft, ArrowRight } from "lucide-react";
 
 import { useOnboardingTone } from "@/domains/onboarding/onboarding-tone";
+import { useTranslation } from "@/i18n";
 
 export function OnboardingTopBar({
   onBack,
@@ -29,6 +30,7 @@ export function OnboardingTopBar({
    */
   tone?: "dark" | "light";
 }) {
+  const { t } = useTranslation("onboarding");
   const auto = useOnboardingTone();
   const fg = tone ? (tone === "dark" ? "#1A1A1A" : "#FFFFFF") : auto.fg;
   // Matches the avatar-picker's cycle arrows: a circular button tinted by its
@@ -41,7 +43,7 @@ export function OnboardingTopBar({
       <button
         type="button"
         onClick={onBack}
-        aria-label="Back"
+        aria-label={t("actions.back")}
         className="flex cursor-pointer h-10 w-10 items-center justify-center rounded-full transition-colors duration-150"
         style={{ color: fg, backgroundColor: restBg }}
         onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = hoverBg)}
@@ -54,7 +56,7 @@ export function OnboardingTopBar({
         <button
           type="button"
           onClick={onNext}
-          aria-label="Forward"
+          aria-label={t("actions.forward")}
           className="flex cursor-pointer h-10 w-10 items-center justify-center rounded-full transition-colors duration-150"
           style={{ color: fg, backgroundColor: restBg }}
           onMouseEnter={(e) =>

--- a/clients/web/src/domains/onboarding/components/step-indicator-dots.tsx
+++ b/clients/web/src/domains/onboarding/components/step-indicator-dots.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from "@/i18n";
+
 interface StepIndicatorDotsProps {
   current: number;
   total: number;
@@ -15,11 +17,15 @@ export function StepIndicatorDots({
   total,
   color,
 }: StepIndicatorDotsProps) {
+  const { t } = useTranslation("onboarding");
   return (
     <div
       className="flex items-center gap-1.5"
       role="group"
-      aria-label={`Step ${current + 1} of ${total}`}
+      aria-label={t("stepIndicator.ariaLabel", {
+        current: current + 1,
+        total,
+      })}
     >
       {Array.from({ length: total }, (_, i) => (
         <div

--- a/clients/web/src/domains/onboarding/hooks/use-google-calendar-connect.ts
+++ b/clients/web/src/domains/onboarding/hooks/use-google-calendar-connect.ts
@@ -37,6 +37,7 @@ import type { OAuthCompleteDeepLinkPayload } from "@/runtime/native-deep-link";
 import { extractErrorMessage } from "@/utils/api-errors";
 import { wait } from "@/utils/oauth-connection-utils";
 import { routes } from "@/utils/routes";
+import { t } from "@/i18n";
 
 const GOOGLE_PROVIDER_KEY = "google";
 
@@ -333,7 +334,9 @@ export function useGoogleCalendarConnect({
         toast.error(
           error instanceof Error
             ? error.message
-            : "Failed to start Google Calendar authorization.",
+            : t("googleCalendar.authorizationFailed", {
+                ns: "onboarding",
+              }),
         );
         return;
       }

--- a/clients/web/src/domains/onboarding/pages/api-key-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/api-key-screen.tsx
@@ -15,6 +15,7 @@ import {
   setPendingProviderKey,
 } from "@/domains/onboarding/provider-key";
 import { isElectron } from "@/runtime/is-electron";
+import { useTranslation } from "@/i18n";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
 import { Select } from "@vellumai/design-library/components/select";
@@ -23,6 +24,7 @@ import { Input } from "@vellumai/design-library/components/input";
 import { MOBILE_INPUT_NO_ZOOM } from "@/domains/onboarding/onboarding-step-layout";
 
 export function ApiKeyScreen() {
+  const { t } = useTranslation("onboarding");
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const hosting = searchParams.get("hosting");
@@ -102,13 +104,13 @@ export function ApiKeyScreen() {
           }
           style={{ animation: "fadeInUp 0.5s ease-out 0.1s both" }}
         >
-          Connect a Model Provider
+          {t("apiKeyScreen.title")}
         </h1>
         <p
           className={`text-center text-body-medium-lighter text-[var(--content-tertiary)] ${electron ? "mt-3.5" : "mt-3"}`}
           style={{ animation: "fadeInUp 0.5s ease-out 0.3s both" }}
         >
-          Choose the model provider your assistant should use.
+          {t("apiKeyScreen.body")}
         </p>
 
         <div
@@ -117,10 +119,10 @@ export function ApiKeyScreen() {
         >
           <div className={`flex flex-col ${electron ? "gap-2" : "gap-1"}`}>
             <label className="text-body-small-default text-[var(--content-tertiary)]">
-              Provider
+              {t("apiKeyScreen.providerLabel")}
             </label>
             <Select
-              aria-label="Provider"
+              aria-label={t("apiKeyScreen.providerLabel")}
               value={provider}
               onChange={(v) => {
                 const match = onboardingProvider(v);
@@ -140,10 +142,10 @@ export function ApiKeyScreen() {
           {models.length > 0 && (
             <div className={`flex flex-col ${electron ? "gap-2" : "gap-1"}`}>
               <label className="text-body-small-default text-[var(--content-tertiary)]">
-                Model
+                {t("apiKeyScreen.modelLabel")}
               </label>
               <Select
-                aria-label="Model"
+                aria-label={t("apiKeyScreen.modelLabel")}
                 value={model}
                 onChange={setModel}
                 options={models.map((option) => ({
@@ -158,7 +160,7 @@ export function ApiKeyScreen() {
             <>
               <div className={`flex flex-col ${electron ? "gap-2" : "gap-1"}`}>
                 <label className="text-body-small-default text-[var(--content-tertiary)]">
-                  Base URL
+                  {t("apiKeyScreen.baseUrlLabel")}
                 </label>
                 <Input
                   type="text"
@@ -170,17 +172,17 @@ export function ApiKeyScreen() {
               </div>
               <div className={`flex flex-col ${electron ? "gap-2" : "gap-1"}`}>
                 <label className="text-body-small-default text-[var(--content-tertiary)]">
-                  Models
+                  {t("apiKeyScreen.modelsLabel")}
                 </label>
                 <Input
                   type="text"
-                  placeholder="model-1, model-2"
+                  placeholder={t("apiKeyScreen.modelsPlaceholder")}
                   value={customModels}
                   onChange={(e) => setCustomModels(e.target.value)}
                   fullWidth
                 />
                 <p className="text-body-small-default text-[var(--content-tertiary)]">
-                  Comma-separated model identifiers exposed by your endpoint.
+                  {t("apiKeyScreen.modelsHelp")}
                 </p>
               </div>
             </>
@@ -190,8 +192,12 @@ export function ApiKeyScreen() {
             <div className="flex flex-col gap-3">
               <Input
                 type="password"
-                label={`${entry.displayName} API Key`}
-                placeholder={entry.apiKeyPlaceholder ?? "Enter your API key"}
+                label={t("apiKeyScreen.apiKeyLabel", {
+                  provider: entry.displayName,
+                })}
+                placeholder={
+                  entry.apiKeyPlaceholder ?? t("apiKeyScreen.apiKeyPlaceholder")
+                }
                 value={apiKey}
                 onChange={(e) => setApiKey(e.target.value)}
                 className={MOBILE_INPUT_NO_ZOOM}
@@ -199,14 +205,14 @@ export function ApiKeyScreen() {
               />
               {entry.docsUrl && (
                 <p className="self-start text-body-medium-lighter text-[var(--content-tertiary)]">
-                  Don't have it?{" "}
+                  {t("apiKeyScreen.noKeyPrompt")}{" "}
                   <a
                     href={entry.docsUrl}
                     target="_blank"
                     rel="noreferrer"
                     className="text-[var(--content-default)] underline"
                   >
-                    Get an API key here
+                    {t("apiKeyScreen.getKeyLink")}
                   </a>
                 </p>
               )}
@@ -226,7 +232,7 @@ export function ApiKeyScreen() {
             onClick={onContinue}
             className={electron ? undefined : "h-11 text-base"}
           >
-            Continue
+            {t("actions.continue")}
           </Button>
           <Button
             variant="outlined"
@@ -235,7 +241,7 @@ export function ApiKeyScreen() {
             onClick={onBack}
             className={electron ? undefined : "h-11 text-base"}
           >
-            Back
+            {t("actions.back")}
           </Button>
         </div>
       </div>

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -63,6 +63,7 @@ import { composeSvg } from "@/utils/avatar-svg-compositor";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
 import { ProgressBar } from "@vellumai/design-library/components/progress-bar";
+import { useTranslation } from "@/i18n";
 
 const COMPLETION_NAVIGATE_DELAY_MS = 800;
 
@@ -110,12 +111,15 @@ const PHASE_TARGET: Record<HatchPhase, number> = {
 
 const SEGMENT_DURATION_MS = 1500;
 
-const PHASE_LABEL: Record<HatchPhase, string> = {
-  initializing: "Getting things ready…",
-  provisioning: "Setting up your assistant…",
-  connecting: "Connecting to your assistant…",
-  resizing: "Setting up your machine…",
-  ready: "Ready",
+// Written out per phase rather than composed from the phase name, so a phase
+// added without its copy fails to compile and the key stays greppable for the
+// orphan check in `catalogs.test.ts`.
+const PHASE_KEY: Record<HatchPhase, `hatchingScreen.phase.${HatchPhase}`> = {
+  initializing: "hatchingScreen.phase.initializing",
+  provisioning: "hatchingScreen.phase.provisioning",
+  connecting: "hatchingScreen.phase.connecting",
+  resizing: "hatchingScreen.phase.resizing",
+  ready: "hatchingScreen.phase.ready",
 };
 
 export function interpolateSegmentProgress(
@@ -148,6 +152,7 @@ export function decideHatchGate(): HatchGateDecision {
 }
 
 export function HatchingScreen() {
+  const { t } = useTranslation("onboarding");
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [searchParams] = useSearchParams();
@@ -772,7 +777,9 @@ export function HatchingScreen() {
                 : "text-3xl font-semibold tracking-tight"
             }
           >
-            {apiKeyRejected ? "Your API key didn't work" : "Something went wrong"}
+            {apiKeyRejected
+              ? t("hatchingScreen.apiKeyFailed")
+              : t("hatchingScreen.genericFailure")}
           </h1>
           <p
             className={`text-body-medium-lighter text-[var(--content-tertiary)] ${electron ? "mt-3.5" : "mt-4"}`}
@@ -782,7 +789,7 @@ export function HatchingScreen() {
           {platformHostedDisabled && (
             <div className="mt-6 flex w-full max-w-sm flex-col items-center gap-3">
               <p className="text-body-medium-default text-[var(--content-default)]">
-                Get started today with a local assistant
+                {t("hatchingScreen.localFallbackPitch")}
               </p>
               <Button
                 asChild
@@ -792,7 +799,7 @@ export function HatchingScreen() {
                 className={electron ? undefined : "h-11 text-base"}
               >
                 <a href={`${window.location.origin}/download`}>
-                  Download the macOS app
+                  {t("actions.downloadMacApp")}
                 </a>
               </Button>
             </div>
@@ -822,7 +829,7 @@ export function HatchingScreen() {
                   )
                 }
               >
-                Update API key
+                {t("hatchingScreen.updateApiKey")}
               </Button>
             ) : (
               <Button
@@ -843,7 +850,7 @@ export function HatchingScreen() {
                   setAttempt((n) => n + 1);
                 }}
               >
-                Try again
+                {t("actions.tryAgain")}
               </Button>
             )}
             <Button
@@ -860,7 +867,7 @@ export function HatchingScreen() {
                 )
               }
             >
-              Back
+              {t("actions.back")}
             </Button>
           </div>
         </div>
@@ -886,14 +893,15 @@ export function HatchingScreen() {
               : "text-3xl font-semibold tracking-tight"
           }
         >
-          {phase === "ready" ? "Your assistant is ready!" : "Waking up…"}
+          {phase === "ready"
+            ? t("hatchingScreen.ready")
+            : t("hatchingScreen.waking")}
         </h1>
         {phase !== "ready" && (
           <p
             className={`text-body-medium-lighter text-[var(--content-tertiary)] ${electron ? "mt-3.5" : "mt-4"}`}
           >
-            Hang tight — your assistant will have a few questions for you once
-            it&apos;s up.
+            {t("hatchingScreen.wakingBody")}
           </p>
         )}
         <img
@@ -907,12 +915,12 @@ export function HatchingScreen() {
           value={displayProgress}
           height={6}
           className={`w-full ${electron ? "max-w-[200px]" : "max-w-sm"}`}
-          aria-label="Assistant startup progress"
+          aria-label={t("hatchingScreen.progressAriaLabel")}
         />
         <p
           className={`text-[var(--content-tertiary)] ${electron ? "mt-4 text-label-small-default" : "mt-3 text-body-small-default"}`}
         >
-          {PHASE_LABEL[phase]}
+          {t(PHASE_KEY[phase])}
         </p>
       </div>
     </OnboardingLayout>

--- a/clients/web/src/domains/onboarding/pages/hosting-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hosting-screen.tsx
@@ -13,6 +13,7 @@ import { isElectron } from "@/runtime/is-electron";
 import { useHasPlatformSession } from "@/stores/auth-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import { useTranslation } from "@/i18n";
 import { docsUrl, routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
 
@@ -64,6 +65,7 @@ function useHostingOptions(): HostingOption[] {
 }
 
 export function HostingScreen() {
+  const { t } = useTranslation("onboarding");
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const fromSelectAssistant = searchParams.get("from") === "select-assistant";
@@ -135,20 +137,20 @@ export function HostingScreen() {
           }
           style={{ animation: "fadeInUp 0.5s ease-out 0.1s both" }}
         >
-          Hosting
+          {t("hostingScreen.title")}
         </h1>
         <p
           className={`text-body-medium-lighter text-[var(--content-tertiary)] ${electron ? "mt-3.5" : "mt-3"}`}
           style={{ animation: "fadeInUp 0.5s ease-out 0.3s both" }}
         >
-          Choose where you want your assistant to live.{" "}
+          {t("hostingScreen.body")}{" "}
           <a
             href={docsUrl(routes.docs.hostingOptions)}
             target="_blank"
             rel="noreferrer"
             className="underline transition-colors hover:text-[var(--content-default)]"
           >
-            Need help deciding?
+            {t("hostingScreen.needHelp")}
           </a>
         </p>
 
@@ -160,7 +162,7 @@ export function HostingScreen() {
 
         <div
           role="radiogroup"
-          aria-label="Hosting options"
+          aria-label={t("hostingScreen.optionsAriaLabel")}
           onKeyDown={handleRadioCardArrowNav}
           className={`grid w-full ${electron ? "mt-8 gap-2" : "auto-rows-fr mt-10 gap-3"}`}
           style={{ animation: "fadeInUp 0.5s ease-out 0.4s both" }}
@@ -176,7 +178,9 @@ export function HostingScreen() {
                   setSelected(opt.mode);
                 }
               }}
-              loginLabel={loginLoading ? "Cancel" : "Log in to use"}
+              loginLabel={
+                loginLoading ? t("actions.cancel") : t("actions.loginToUse")
+              }
               onLogin={
                 opt.disabled && opt.mode === "vellum-cloud" && showLogin
                   ? loginLoading
@@ -199,7 +203,7 @@ export function HostingScreen() {
             className={electron ? undefined : "h-11 text-base"}
             onClick={onContinue}
           >
-            Continue
+            {t("actions.continue")}
           </Button>
         </div>
         <div
@@ -214,7 +218,7 @@ export function HostingScreen() {
             onClick={onBack}
             disabled={loginLoading}
           >
-            Back
+            {t("actions.back")}
           </Button>
         </div>
 

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -34,10 +34,12 @@ import { isElectron } from "@/runtime/is-electron";
 import { useIsNativePlatform } from "@/runtime/native-auth";
 import { useAuthStore, useHasPlatformSession } from "@/stores/auth-store";
 import { saveConsent } from "@/lib/consent/consent-persistence";
+import { useTranslation } from "@/i18n";
 import { PACKAGE_PARAM, routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
 
 export function PrivacyScreen() {
+  const { t } = useTranslation("onboarding");
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const userId = useAuthStore.use.user()?.id ?? null;
@@ -184,14 +186,13 @@ export function PrivacyScreen() {
           }
           style={{ animation: "fadeInUp 0.5s ease-out 0.1s both" }}
         >
-          Before You Start
+          {t("privacyScreen.title")}
         </h1>
         <p
           className={`text-center text-body-medium-lighter text-[var(--content-tertiary)] ${electron ? "mt-3.5" : "mt-4"}`}
           style={{ animation: "fadeInUp 0.5s ease-out 0.3s both" }}
         >
-          Choose your privacy preferences. You can update these anytime in the
-          Settings.
+          {t("privacyScreen.body")}
         </p>
 
         <PrivacyPreferencesCard
@@ -227,7 +228,7 @@ export function PrivacyScreen() {
             onClick={onStart}
             className={electron ? undefined : "h-11 text-base"}
           >
-            Start
+            {t("actions.start")}
           </Button>
           {/*
            * Back's destination is mode-specific, but always stays inside the SPA
@@ -257,7 +258,7 @@ export function PrivacyScreen() {
             }
             className={electron ? undefined : "h-11 text-base"}
           >
-            Back
+            {t("actions.back")}
           </Button>
         </div>
       </div>

--- a/clients/web/src/domains/onboarding/pages/review-terms-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/review-terms-screen.tsx
@@ -29,10 +29,12 @@ import {
   saveConsent,
 } from "@/lib/consent/consent-persistence";
 import { sanitizeReturnTo } from "@/utils/return-to";
+import { useTranslation } from "@/i18n";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
 
 export function ReviewTermsScreen() {
+  const { t } = useTranslation("onboarding");
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const userId = useAuthStore.use.user()?.id ?? null;
@@ -233,7 +235,7 @@ export function ReviewTermsScreen() {
             onClick={onContinue}
             className={electron ? undefined : "h-11 text-base"}
           >
-            Continue
+            {t("actions.continue")}
           </Button>
           <Button
             variant="outlined"
@@ -242,7 +244,7 @@ export function ReviewTermsScreen() {
             onClick={handleLogout}
             className={electron ? undefined : "h-11 text-base"}
           >
-            Log out
+            {t("actions.logOut")}
           </Button>
         </div>
       </div>

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -61,6 +61,7 @@ import { routes } from "@/utils/routes";
 import { pairedHostLabel } from "@vellumai/local-mode/contract";
 import { Button } from "@vellumai/design-library/components/button";
 import { Menu } from "@vellumai/design-library/components/menu";
+import { useTranslation } from "@/i18n";
 
 function assistantLabel(a: ResolvedAssistant): string {
   if (a.name) {
@@ -126,6 +127,7 @@ function withoutRegisterParams(params: URLSearchParams): URLSearchParams {
 }
 
 export function SelectAssistantScreen() {
+  const { t } = useTranslation("onboarding");
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const fromLogin = searchParams.get("fromLogin") === "1";
@@ -688,7 +690,7 @@ export function SelectAssistantScreen() {
             animation: "fadeInUp 0.5s ease-out 0.1s both",
           }}
         >
-          Choose an Assistant
+          {t("selectAssistantScreen.title")}
         </h1>
 
         {displayError && (
@@ -699,7 +701,7 @@ export function SelectAssistantScreen() {
 
         <div
           role="radiogroup"
-          aria-label="Assistants"
+          aria-label={t("selectAssistantScreen.listAriaLabel")}
           onKeyDown={handleRadioCardArrowNav}
           className={`flex w-full flex-col ${electron ? "mt-8 gap-2" : "mt-10 gap-3"}`}
           style={{ animation: "fadeInUp 0.5s ease-out 0.3s both" }}
@@ -722,7 +724,9 @@ export function SelectAssistantScreen() {
                     setSelected(assistant.id);
                   }
                 }}
-                loginLabel={loginLoading ? "Cancel" : "Log in to use"}
+                loginLabel={
+                  loginLoading ? t("actions.cancel") : t("actions.loginToUse")
+                }
                 loginDisabled={connecting}
                 onLogin={
                   !accessible && assistant.isPlatformHosted
@@ -787,7 +791,7 @@ export function SelectAssistantScreen() {
           {localClient && (
             <DashedActionButton
               icon={<Plus className="h-4 w-4" />}
-              label="Create a new assistant"
+              label={t("selectAssistantScreen.createNew")}
               disabled={connecting || loginLoading}
               onClick={() =>
                 void navigate(
@@ -799,7 +803,7 @@ export function SelectAssistantScreen() {
           {localModeHostAvailable && (
             <DashedActionButton
               icon={<Link2 className="h-4 w-4" />}
-              label="Connect a remote assistant"
+              label={t("selectAssistantScreen.connectRemote")}
               disabled={connecting || loginLoading}
               onClick={() =>
                 useConnectDialogStore.getState().openConnectDialog()
@@ -812,7 +816,7 @@ export function SelectAssistantScreen() {
           {assistantSwitcher && !localModeHostAvailable && (
             <DashedActionButton
               icon={<Globe className="h-4 w-4" />}
-              label="Add a remote assistant"
+              label={t("selectAssistantScreen.addRemote")}
               disabled={connecting || loginLoading}
               onClick={() => setAddOriginOpen(true)}
             />
@@ -832,7 +836,7 @@ export function SelectAssistantScreen() {
               onClick={onContinue}
               disabled={!selected || connecting}
             >
-              {connecting ? "Connecting…" : "Continue"}
+              {connecting ? t("actions.connecting") : t("actions.continue")}
             </Button>
           </div>
         )}
@@ -847,7 +851,7 @@ export function SelectAssistantScreen() {
             onClick={onBack}
             disabled={connecting || loginLoading}
           >
-            Back
+            {t("actions.back")}
           </Button>
         </div>
         </div>
@@ -879,7 +883,9 @@ export function SelectAssistantScreen() {
         open={removeTarget != null}
         kind={removeTarget?.isPaired ? "paired" : "platform"}
         assistantName={
-          removeTarget ? assistantLabel(removeTarget) : "the assistant"
+          removeTarget
+            ? assistantLabel(removeTarget)
+            : t("selectAssistantScreen.unnamedAssistant")
         }
         errorMessage={removeError ?? undefined}
         isPending={removePending}
@@ -890,7 +896,9 @@ export function SelectAssistantScreen() {
         open={removeOriginTarget != null}
         kind="origin"
         assistantName={
-          removeOriginTarget ? originLabel(removeOriginTarget) : "the assistant"
+          removeOriginTarget
+            ? originLabel(removeOriginTarget)
+            : t("selectAssistantScreen.unnamedAssistant")
         }
         errorMessage={removeOriginError ?? undefined}
         isPending={removeOriginPending}
@@ -903,11 +911,12 @@ export function SelectAssistantScreen() {
 
 /** Full-screen "Connecting…" hold shown while a decision or connect lands. */
 function ConnectingHold() {
+  const { t } = useTranslation("onboarding");
   return (
     <OnboardingLayout showAvatarWave>
       <div className="mx-auto flex min-h-screen w-full max-w-xl flex-col items-center justify-center px-6 text-[var(--content-default)]">
         <p className="text-body-medium-lighter text-[var(--content-tertiary)]">
-          Connecting to your assistant…
+          {t("selectAssistantScreen.connectingToAssistant")}
         </p>
       </div>
     </OnboardingLayout>
@@ -960,6 +969,7 @@ function RemoveCardMenu({
   label: string;
   onRemove: () => void;
 }) {
+  const { t } = useTranslation("onboarding");
   return (
     <Menu.Root>
       <Menu.Trigger asChild>
@@ -968,7 +978,9 @@ function RemoveCardMenu({
           size="regular"
           className="text-[var(--content-tertiary)]"
           iconOnly={<EllipsisVertical />}
-          aria-label={`Actions for ${label}`}
+          aria-label={t("selectAssistantScreen.rowActionsAriaLabel", {
+            name: label,
+          })}
         />
       </Menu.Trigger>
       <Menu.Content align="end" sideOffset={4}>
@@ -976,7 +988,7 @@ function RemoveCardMenu({
           onSelect={onRemove}
           className="text-[var(--system-negative-strong)] data-[highlighted]:text-[var(--system-negative-strong)]"
         >
-          Remove from this device…
+          {t("selectAssistantScreen.removeFromDevice")}
         </Menu.Item>
       </Menu.Content>
     </Menu.Root>

--- a/clients/web/src/domains/onboarding/pages/start-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/start-screen.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from "react-router";
 
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
 import { SETUP_NAVIGATE } from "@/domains/onboarding/onboarding-navigation";
+import { useTranslation } from "@/i18n";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
 
@@ -21,6 +22,7 @@ import { Button } from "@vellumai/design-library/components/button";
  * entrypoint — reached only via Back — so the happy path is unchanged.
  */
 export function StartScreen() {
+  const { t } = useTranslation("onboarding");
   const navigate = useNavigate();
 
   return (
@@ -31,13 +33,13 @@ export function StartScreen() {
             className="text-3xl font-semibold tracking-tight"
             style={{ animation: "fadeInUp 0.5s ease-out 0.1s both" }}
           >
-            Welcome to Vellum
+            {t("welcome.title")}
           </h1>
           <p
             className="mt-3 text-center text-body-medium-lighter text-[var(--content-tertiary)]"
             style={{ animation: "fadeInUp 0.5s ease-out 0.3s both" }}
           >
-            Your own personal intelligence is just a step away.
+            {t("welcome.body")}
           </p>
 
           <div
@@ -53,7 +55,7 @@ export function StartScreen() {
                 void navigate(routes.onboarding.privacy, SETUP_NAVIGATE)
               }
             >
-              Create your assistant
+              {t("startScreen.createAssistant")}
             </Button>
           </div>
         </div>

--- a/clients/web/src/domains/onboarding/pages/welcome-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/welcome-screen.tsx
@@ -4,10 +4,12 @@ import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-lay
 import { SETUP_NAVIGATE } from "@/domains/onboarding/onboarding-navigation";
 import { useOnboardingLogin } from "@/hooks/use-onboarding-login";
 import { hasAssistants } from "@/lib/local-mode";
+import { useTranslation } from "@/i18n";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
 
 export function WelcomeScreen() {
+  const { t } = useTranslation("onboarding");
   const navigate = useNavigate();
   const { loading, error, login, cancel } = useOnboardingLogin();
 
@@ -41,13 +43,13 @@ export function WelcomeScreen() {
               animation: "fadeInUp 0.5s ease-out 0.1s both",
             }}
           >
-            Welcome to Vellum
+            {t("welcome.title")}
           </h1>
           <p
             className="mt-3 text-body-large-lighter text-[var(--content-tertiary)]"
             style={{ animation: "fadeInUp 0.5s ease-out 0.3s both" }}
           >
-            Your own personal intelligence is just a step away.
+            {t("welcome.body")}
           </p>
 
           {error && (
@@ -67,7 +69,7 @@ export function WelcomeScreen() {
               className="h-11 text-base"
               onClick={loading ? cancel : () => void login()}
             >
-              {loading ? "Cancel" : "Log In"}
+              {loading ? t("actions.cancel") : t("actions.logIn")}
             </Button>
             <Button
               variant="ghost"
@@ -76,7 +78,7 @@ export function WelcomeScreen() {
               className="h-11 text-base"
               onClick={handleContinueWithoutAccount}
             >
-              Continue without account
+              {t("welcome.continueWithoutAccount")}
             </Button>
           </div>
         </div>

--- a/clients/web/src/i18n/catalogs.ts
+++ b/clients/web/src/i18n/catalogs.ts
@@ -40,6 +40,7 @@ import enCredentialRequests from "@/i18n/locales/en/credential-requests.json";
 import enHome from "@/i18n/locales/en/home.json";
 import enLibrary from "@/i18n/locales/en/library.json";
 import enLogs from "@/i18n/locales/en/logs.json";
+import enOnboarding from "@/i18n/locales/en/onboarding.json";
 import enRemoteWeb from "@/i18n/locales/en/remote-web.json";
 import enTerminal from "@/i18n/locales/en/terminal.json";
 import enWorkspace from "@/i18n/locales/en/workspace.json";
@@ -81,6 +82,7 @@ export const FALLBACK_CATALOGS: LocaleCatalogs = {
   library: enLibrary,
   home: enHome,
   contacts: enContacts,
+  onboarding: enOnboarding,
 };
 
 /** Loaders for the locales that are not bundled into the entry chunk. */
@@ -104,6 +106,7 @@ const CATALOG_LOADERS: Record<
     library: () => import("@/i18n/locales/es/library.json"),
     home: () => import("@/i18n/locales/es/home.json"),
     contacts: () => import("@/i18n/locales/es/contacts.json"),
+    onboarding: () => import("@/i18n/locales/es/onboarding.json"),
   },
 };
 

--- a/clients/web/src/i18n/i18next.d.ts
+++ b/clients/web/src/i18n/i18next.d.ts
@@ -19,6 +19,7 @@ import type credentialRequests from "@/i18n/locales/en/credential-requests.json"
 import type home from "@/i18n/locales/en/home.json";
 import type library from "@/i18n/locales/en/library.json";
 import type logs from "@/i18n/locales/en/logs.json";
+import type onboarding from "@/i18n/locales/en/onboarding.json";
 import type remoteWeb from "@/i18n/locales/en/remote-web.json";
 import type terminal from "@/i18n/locales/en/terminal.json";
 import type workspace from "@/i18n/locales/en/workspace.json";
@@ -45,6 +46,7 @@ declare module "i18next" {
       library: typeof library;
       home: typeof home;
       contacts: typeof contacts;
+      onboarding: typeof onboarding;
     };
     returnNull: false;
   }

--- a/clients/web/src/i18n/locales/en/onboarding.json
+++ b/clients/web/src/i18n/locales/en/onboarding.json
@@ -1,0 +1,122 @@
+{
+  "actions": {
+    "continue": "Continue",
+    "back": "Back",
+    "forward": "Forward",
+    "cancel": "Cancel",
+    "start": "Start",
+    "add": "Add",
+    "adding": "Adding…",
+    "connect": "Connect",
+    "connecting": "Connecting…",
+    "tryAgain": "Try again",
+    "remove": "Remove {value}",
+    "logIn": "Log In",
+    "logOut": "Log out",
+    "loginToUse": "Log in to use",
+    "downloadMacApp": "Download the macOS app"
+  },
+  "welcome": {
+    "title": "Welcome to Vellum",
+    "body": "Your own personal intelligence is just a step away.",
+    "continueWithoutAccount": "Continue without account"
+  },
+  "startScreen": {
+    "createAssistant": "Create your assistant"
+  },
+  "privacyScreen": {
+    "title": "Before You Start",
+    "body": "Choose your privacy preferences. You can update these anytime in the Settings."
+  },
+  "hostingScreen": {
+    "title": "Hosting",
+    "body": "Choose where you want your assistant to live.",
+    "needHelp": "Need help deciding?",
+    "optionsAriaLabel": "Hosting options"
+  },
+  "apiKeyScreen": {
+    "title": "Connect a Model Provider",
+    "body": "Choose the model provider your assistant should use.",
+    "providerLabel": "Provider",
+    "modelLabel": "Model",
+    "baseUrlLabel": "Base URL",
+    "modelsLabel": "Models",
+    "modelsPlaceholder": "model-1, model-2",
+    "modelsHelp": "Comma-separated model identifiers exposed by your endpoint.",
+    "apiKeyLabel": "{provider} API Key",
+    "apiKeyPlaceholder": "Enter your API key",
+    "noKeyPrompt": "Don't have it?",
+    "getKeyLink": "Get an API key here"
+  },
+  "selectAssistantScreen": {
+    "title": "Choose an Assistant",
+    "listAriaLabel": "Assistants",
+    "createNew": "Create a new assistant",
+    "connectRemote": "Connect a remote assistant",
+    "addRemote": "Add a remote assistant",
+    "unnamedAssistant": "the assistant",
+    "connectingToAssistant": "Connecting to your assistant…",
+    "rowActionsAriaLabel": "Actions for {name}",
+    "removeFromDevice": "Remove from this device…"
+  },
+  "hatchingScreen": {
+    "apiKeyFailed": "Your API key didn't work",
+    "genericFailure": "Something went wrong",
+    "localFallbackPitch": "Get started today with a local assistant",
+    "updateApiKey": "Update API key",
+    "ready": "Your assistant is ready!",
+    "waking": "Waking up…",
+    "wakingBody": "Hang tight, your assistant will have a few questions for you once it's up.",
+    "progressAriaLabel": "Assistant startup progress",
+    "phase": {
+      "initializing": "Getting things ready…",
+      "provisioning": "Setting up your assistant…",
+      "connecting": "Connecting to your assistant…",
+      "resizing": "Setting up your machine…",
+      "ready": "Ready"
+    }
+  },
+  "addRemoteOriginDialog": {
+    "title": "Add a Remote Assistant",
+    "body": "Paste the https link your assistant’s pairing page gave you.",
+    "addressLabel": "Assistant address"
+  },
+  "connectAssistantDialog": {
+    "importedTitle": "Pairing Imported",
+    "importedBody": "This pairing is access-only: its access expires and cannot renew itself. Re-run vellum pair on the assistant’s machine and import the new bundle when it expires.",
+    "title": "Connect a Remote Assistant",
+    "bundleLabel": "Pairing bundle",
+    "nameLabel": "Name (optional)",
+    "instruction": "On the assistant’s machine, run <code>vellum pair --url https://...</code> and paste the bundle here."
+  },
+  "connectRecoveryDialog": {
+    "repairTitle": "Repair Assistant?",
+    "repairBody": "Repairing re-provisions this assistant’s authentication token. Any other devices or browser sessions connected to it will be signed out and need to reconnect.",
+    "repairConfirm": "Repair",
+    "authFailedTitle": "Can’t Authenticate Assistant",
+    "authFailedBody": "The authentication token for {name} is missing or can no longer be refreshed, so this assistant can’t be connected. You can repair it, retire it, or pick a different assistant.",
+    "wakeAndRepair": "Wake & Repair",
+    "retire": "Retire Assistant"
+  },
+  "consentControls": {
+    "whatsChanged": "What's changed",
+    "privacyPreferences": "Privacy preferences",
+    "analyticsLabel": "Share Analytics",
+    "analyticsHelp": "Send aggregated product usage data",
+    "diagnosticsLabel": "Share Diagnostics",
+    "diagnosticsHelp": "Send crash reports, conversation traces, and session replay data",
+    "agreements": "Agreements",
+    "agreeTo": "I agree to the <link>{policy}</link>"
+  },
+  "onboardingAutocomplete": {
+    "addOption": "Add “{value}”",
+    "enterHint": "↵ Enter",
+    "freeTextHint": "Type anything and press ↵ to add your own"
+  },
+  "stepIndicator": {
+    "ariaLabel": "Step {current} of {total}"
+  },
+  "googleCalendar": {
+    "authorizationFailed": "Failed to start Google Calendar authorization."
+  }
+}

--- a/clients/web/src/i18n/locales/es/onboarding.json
+++ b/clients/web/src/i18n/locales/es/onboarding.json
@@ -1,0 +1,122 @@
+{
+  "actions": {
+    "continue": "Continuar",
+    "back": "Atrás",
+    "forward": "Adelante",
+    "cancel": "Cancelar",
+    "start": "Empezar",
+    "add": "Añadir",
+    "adding": "Añadiendo…",
+    "connect": "Conectar",
+    "connecting": "Conectando…",
+    "tryAgain": "Volver a intentarlo",
+    "remove": "Quitar {value}",
+    "logIn": "Iniciar sesión",
+    "logOut": "Cerrar sesión",
+    "loginToUse": "Inicia sesión para usar",
+    "downloadMacApp": "Descargar la app de macOS"
+  },
+  "welcome": {
+    "title": "Te damos la bienvenida a Vellum",
+    "body": "Tu propia inteligencia personal está a un paso.",
+    "continueWithoutAccount": "Continuar sin cuenta"
+  },
+  "startScreen": {
+    "createAssistant": "Crear tu asistente"
+  },
+  "privacyScreen": {
+    "title": "Antes de empezar",
+    "body": "Elige tus preferencias de privacidad. Puedes cambiarlas cuando quieras en los ajustes."
+  },
+  "hostingScreen": {
+    "title": "Alojamiento",
+    "body": "Elige dónde quieres que viva tu asistente.",
+    "needHelp": "¿Necesitas ayuda para decidir?",
+    "optionsAriaLabel": "Opciones de alojamiento"
+  },
+  "apiKeyScreen": {
+    "title": "Conectar un proveedor de modelos",
+    "body": "Elige el proveedor de modelos que debe usar tu asistente.",
+    "providerLabel": "Proveedor",
+    "modelLabel": "Modelo",
+    "baseUrlLabel": "URL base",
+    "modelsLabel": "Modelos",
+    "modelsPlaceholder": "modelo-1, modelo-2",
+    "modelsHelp": "Identificadores de modelo separados por comas que expone tu endpoint.",
+    "apiKeyLabel": "Clave de API de {provider}",
+    "apiKeyPlaceholder": "Introduce tu clave de API",
+    "noKeyPrompt": "¿No la tienes?",
+    "getKeyLink": "Consigue una clave de API aquí"
+  },
+  "selectAssistantScreen": {
+    "title": "Elige un asistente",
+    "listAriaLabel": "Asistentes",
+    "createNew": "Crear un asistente nuevo",
+    "connectRemote": "Conectar un asistente remoto",
+    "addRemote": "Añadir un asistente remoto",
+    "unnamedAssistant": "el asistente",
+    "connectingToAssistant": "Conectando con tu asistente…",
+    "rowActionsAriaLabel": "Acciones de {name}",
+    "removeFromDevice": "Quitar de este dispositivo…"
+  },
+  "hatchingScreen": {
+    "apiKeyFailed": "Tu clave de API no ha funcionado",
+    "genericFailure": "Algo ha salido mal",
+    "localFallbackPitch": "Empieza hoy con un asistente local",
+    "updateApiKey": "Actualizar la clave de API",
+    "ready": "¡Tu asistente está listo!",
+    "waking": "Despertando…",
+    "wakingBody": "Un momento, tu asistente te hará algunas preguntas en cuanto esté en marcha.",
+    "progressAriaLabel": "Progreso del arranque del asistente",
+    "phase": {
+      "initializing": "Preparándolo todo…",
+      "provisioning": "Configurando tu asistente…",
+      "connecting": "Conectando con tu asistente…",
+      "resizing": "Preparando tu máquina…",
+      "ready": "Listo"
+    }
+  },
+  "addRemoteOriginDialog": {
+    "title": "Añadir un asistente remoto",
+    "body": "Pega el enlace https que te dio la página de emparejamiento de tu asistente.",
+    "addressLabel": "Dirección del asistente"
+  },
+  "connectAssistantDialog": {
+    "importedTitle": "Emparejamiento importado",
+    "importedBody": "Este emparejamiento es solo de acceso: su acceso caduca y no puede renovarse por sí solo. Vuelve a ejecutar vellum pair en la máquina del asistente e importa el nuevo paquete cuando caduque.",
+    "title": "Conectar un asistente remoto",
+    "bundleLabel": "Paquete de emparejamiento",
+    "nameLabel": "Nombre (opcional)",
+    "instruction": "En la máquina del asistente, ejecuta <code>vellum pair --url https://...</code> y pega aquí el paquete."
+  },
+  "connectRecoveryDialog": {
+    "repairTitle": "¿Reparar el asistente?",
+    "repairBody": "Reparar vuelve a aprovisionar el token de autenticación de este asistente. Se cerrará la sesión en cualquier otro dispositivo o navegador conectado y tendrán que volver a conectarse.",
+    "repairConfirm": "Reparar",
+    "authFailedTitle": "No se puede autenticar el asistente",
+    "authFailedBody": "Falta el token de autenticación de {name} o ya no se puede renovar, así que no es posible conectar este asistente. Puedes repararlo, retirarlo o elegir otro asistente.",
+    "wakeAndRepair": "Despertar y reparar",
+    "retire": "Retirar el asistente"
+  },
+  "consentControls": {
+    "agreeTo": "Acepto <link>{policy}</link>",
+    "whatsChanged": "Qué ha cambiado",
+    "privacyPreferences": "Preferencias de privacidad",
+    "analyticsLabel": "Compartir analíticas",
+    "analyticsHelp": "Enviar datos agregados de uso del producto",
+    "diagnosticsLabel": "Compartir diagnósticos",
+    "diagnosticsHelp": "Enviar informes de fallos, trazas de conversación y datos de repetición de sesión",
+    "agreements": "Acuerdos"
+  },
+  "onboardingAutocomplete": {
+    "addOption": "Añadir «{value}»",
+    "enterHint": "↵ Intro",
+    "freeTextHint": "Escribe lo que quieras y pulsa ↵ para añadirlo"
+  },
+  "stepIndicator": {
+    "ariaLabel": "Paso {current} de {total}"
+  },
+  "googleCalendar": {
+    "authorizationFailed": "No se pudo iniciar la autorización de Google Calendar."
+  }
+}

--- a/clients/web/src/i18n/namespaces.ts
+++ b/clients/web/src/i18n/namespaces.ts
@@ -49,6 +49,7 @@ export const NAMESPACES = [
   "library",
   "home",
   "contacts",
+  "onboarding",
 ] as const;
 
 export type Namespace = (typeof NAMESPACES)[number];


### PR DESCRIPTION
Adds an `onboarding` namespace and moves the funnel's eight pages, its eight shared components, and the calendar-connect hook onto it. 113 of the domain's 194 strings.

`screens/` (81 strings across ten files, several of them long copy-driven step sequences) follows in its own pass, so the ratchet lists the three converted subtrees and becomes a `src/domains/onboarding/**` glob then.

## Found outside what the lint rule reports

- **`PHASE_LABEL`**, a `Record<HatchPhase, string>` of five English progress labels in the hatching screen. It is the line a user stares at for the length of a provision, and it was invisible to the rule. Now `PHASE_KEY`, written out per phase and typed against the union so a phase added without copy fails to compile.
- **`setupLabel = "Invite"`** had a sibling here in the same default-parameter shape as the one in #40607.
- **Two labels built by concatenation**: `` label={`${entry.displayName} API Key`} `` and `` aria-label={`Actions for ${label}`} ``, both now messages with placeholders.

## Sentences that wrap an element

Two, both kept as one entry with a named tag rather than split into fragments:

```
I agree to the <link>{policy}</link>
On the assistant’s machine, run <code>vellum pair --url https://...</code> and paste the bundle here.
```

The policy's name and the command are the parts a translator must be able to move; splitting them around the anchor would fix the English word order into every language.

## Copy changes

One, required rather than chosen: the hatching screen's "Hang tight — your assistant will have a few questions" used an em dash in user-facing copy. AGENTS.md calls that the strict case and asks for it to be fixed on lines already being changed, so it reads "Hang tight, your assistant will …" now.

Every other string is the shipped copy verbatim. Worth noting because my first draft of the catalog paraphrased several strings the survey had truncated ("run" for "live", "this endpoint" for "your endpoint", "will use" for "should use"); I caught it by extracting each one from source before converting, and the diff now matches character for character.

## Lint rule

`fontFamily` joins the structural-prop denylist. An SVG `fontFamily="var(--font-sans), system-ui, sans-serif"` is a CSS font stack, but it contains spaces, so `looksLikeCopy` read it as a sentence. It was the only false positive in the domain.

## Verification

- survey of `pages/`, `components/`, `hooks/` reports 0
- `tsc --noEmit` clean
- `bun run lint` 0 errors, 16 warnings, unchanged from the baseline on main
- 945 test files pass
- `bun run build` emits the Spanish `onboarding` chunk

## What is left

`settings` (1585), `chat` (1066), `components` (463), `intelligence` (177), onboarding `screens/` (81), and a tail of 23 in `hooks`/`utils`/`lib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CD12TRfmDF3UiXjdbiWn3i

---
_Generated by [Claude Code](https://claude.ai/code/session_01CD12TRfmDF3UiXjdbiWn3i)_