### PR TITLE
fix(gateway): let a delivery with no sender through to the plugin

### DIFF
--- a/gateway/src/channels/plugin-inbound.ts
+++ b/gateway/src/channels/plugin-inbound.ts
@@ -113,8 +113,9 @@ export interface ReadPluginInboundOptions {
 /**
  * Read a plugin's reply into an inbound event, or say why there isn't one.
  *
- * A reply is a message when it carries a conversation, a sender, and a message
- * id: the three the pipeline cannot proceed without. Conversation and sender
+ * A delivery is a message when it carries a sender, and with them a
+ * conversation and a message id: the three the pipeline cannot proceed
+ * without. Conversation and sender
  * are what the message is routed and admitted on, and the message id is the
  * dedup key that keeps a vendor's retry from starting a second turn. Content
  * is not among them — an attachment-only message is a real message with no
@@ -136,11 +137,23 @@ export function readPluginInbound(
   const actor = read("actorExternalId")?.trim();
   const messageId = read("externalMessageId")?.trim();
 
-  const present = [conversation, actor, messageId].filter(Boolean).length;
-  if (present === 0) {
+  // Naming neither a sender nor a chat is what a delivery that is not a
+  // message looks like: a vendor's probe, a delivery receipt, an echo of
+  // something we sent whose sender field the vendor leaves off. A message id
+  // alone does not make one, and treating these as malformed would answer a
+  // vendor's ordinary traffic with a 4xx, which is how a webhook gets
+  // disabled at the far end. There is nobody to admit, so there is nothing to
+  // gate, and only the plugin can say what the delivery meant.
+  if (!conversation && !actor) {
     return { status: "none" };
   }
-  if (present < 3) {
+
+  // Naming one of them and not the rest is the opposite: a delivery shaped
+  // like a message whose sender or address the declaration failed to find.
+  // Dropping it quietly would present a manifest that no longer matches the
+  // payload as a vendor that stopped delivering, and forwarding it would hand
+  // the plugin a sender the gateway never checked.
+  if (!conversation || !actor || !messageId) {
     const missing = [
       conversation ? null : "conversationExternalId",
       actor ? null : "actorExternalId",
@@ -148,7 +161,7 @@ export function readPluginInbound(
     ].filter((name): name is string => name !== null);
     return {
       status: "invalid",
-      reason: `reply is missing ${missing.join(", ")}`,
+      reason: `delivery is missing ${missing.join(", ")}`,
     };
   }
 

--- a/gateway/src/http/routes/plugin-webhook.test.ts
+++ b/gateway/src/http/routes/plugin-webhook.test.ts
@@ -1245,6 +1245,22 @@ describe("inbound delivery", () => {
     expect(res.status).toBe(200);
   });
 
+  it("forwards a delivery that names a message but no sender", async () => {
+    // The shape an echo of our own reply takes when the vendor omits the
+    // sender, and the shape many receipts take. There is nobody to admit, so
+    // answering 4xx would tell the vendor its ordinary traffic is malformed
+    // and invite it to disable the endpoint.
+    const { handled, forwards, deps } = harness();
+
+    const res = await deliver(deps, {
+      message: { externalMessageId: "msg-1", content: "delivered" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(handled).toHaveLength(0);
+    expect(forwards).toHaveLength(1);
+  });
+
   it("refuses a delivery the declaration matched only partly", async () => {
     // Half a message means the declaration and the payload disagree. Passing
     // it on would hand the plugin a sender the gateway never checked.


### PR DESCRIPTION
## Prompt / plan

> Echos should continue to pass through the gateway as a perfectly good message for the plugin to handle

Option 1 from the discussion on #40614: rather than add a `when` predicate to the declaration, widen what counts as "not a message" so a sender-less delivery reaches the plugin ungated.

### The problem

A delivery that resolved only `externalMessageId` was read as *half* a message and answered **400**. That is the ordinary shape of three routine things:

- a vendor's delivery probe
- a delivery receipt
- an echo of our own reply where the vendor omits the sender (Comms types `from` as optional)

Answering a vendor's routine traffic with a 4xx is how a webhook gets disabled at the far end, which is a worse failure than anything the strictness was buying.

### The rule now

| delivery | reading |
|---|---|
| names neither a sender nor a chat | `none` — forwarded to the plugin ungated |
| names a sender or a chat but not the rest | `invalid` — refused |
| names all three | a message — claimed, gated, forwarded |

A message id alone does not make a message. Naming a sender or a chat and *not* the rest still reports invalid: that is a delivery shaped like a message whose sender the declaration failed to find, and forwarding it would hand the plugin a sender the gateway never checked.

### On the rule I did not change

My first cut was blunter — "no sender → not a message" — and it broke two existing tests that turned out to encode a deliberate decision: `reports a reply that carries some of a message but not enough` and, for the vendor declarations, `reports a delivery with no sender rather than inventing one`. Both say that a delivery which *looks* like a message but has no sender is a manifest bug, not a non-message. That is right, and the rule above keeps it: the chat is what marks a delivery as being *about* a conversation, so a chat without a sender stays invalid.

Echoes that *do* carry a sender still parse as messages, get gated, and are dropped at the admission floor (our own line resolves as `unknown`), returning 200. That was the accepted outcome in the #40614 discussion.

## Test plan

- New: `forwards a delivery that names a message but no sender` — 200, the gate never runs, the plugin receives it.
- Unchanged and still passing: the partial-match refusal, the whitespace-sender refusal, and the Photon `sender: {}` refusal.
- 195 pass across `src/channels` and the plugin webhook route; full gateway suite green (251 files). Typecheck, lint, prettier clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_013p1nTdvsuAtTJ7zyCSDLbx)_