### PR TITLE
feat(web): translate the onboarding screens

### DIFF
--- a/clients/web/eslint.config.mjs
+++ b/clients/web/eslint.config.mjs
@@ -205,10 +205,7 @@ const i18nEnforcedPaths = [
   "src/domains/library/**/*.{ts,tsx}",
   "src/domains/home/**/*.{ts,tsx}",
   "src/domains/contacts/**/*.{ts,tsx}",
-  // `screens/` follows in its own pass; this becomes a directory glob then.
-  "src/domains/onboarding/pages/**/*.{ts,tsx}",
-  "src/domains/onboarding/components/**/*.{ts,tsx}",
-  "src/domains/onboarding/hooks/**/*.{ts,tsx}",
+  "src/domains/onboarding/**/*.{ts,tsx}",
 ];
 
 const eslintConfig = defineConfig([

--- a/clients/web/src/domains/onboarding/screens/checkin-connect-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/checkin-connect-screen.tsx
@@ -5,6 +5,7 @@ import { useGoogleCalendarConnect } from "@/domains/onboarding/hooks/use-google-
 import { isElectron } from "@/runtime/is-electron";
 import { publicAsset } from "@/utils/public-asset";
 import { Button } from "@vellumai/design-library/components/button";
+import { useTranslation } from "@/i18n";
 
 interface CheckinConnectScreenProps {
   assistantId: string;
@@ -31,13 +32,15 @@ export function CheckinConnectScreen({
   onSkip,
   onBack,
 }: CheckinConnectScreenProps) {
+  const { t } = useTranslation("onboarding");
   const electron = isElectron();
   const { handleConnect, oauthInProgress } = useGoogleCalendarConnect({
     assistantId,
     onConnect,
   });
 
-  const assistantInlineName = assistantName || "your assistant";
+  const assistantInlineName =
+    assistantName.trim() || t("checkinConnectScreen.unnamedAssistant");
 
   return (
     <OnboardingLayout showCreatureFooter={false}>
@@ -52,7 +55,7 @@ export function CheckinConnectScreen({
             <button
               type="button"
               onClick={onBack}
-              aria-label="Back"
+              aria-label={t("actions.back")}
               className="flex h-8 w-8 cursor-pointer items-center justify-center rounded-md text-[var(--content-secondary)] transition-colors hover:bg-[var(--surface-base)]"
             >
               <ChevronLeft className="h-4 w-4" />
@@ -63,7 +66,7 @@ export function CheckinConnectScreen({
           <h1
             className={`text-center ${electron ? "text-title-large" : "text-3xl font-semibold tracking-tight"}`}
           >
-            Let&rsquo;s chat tomorrow
+            {t("checkinConnectScreen.title")}
           </h1>
           <div aria-hidden="true" className="h-8 w-8" />
         </div>
@@ -72,7 +75,7 @@ export function CheckinConnectScreen({
           className="mt-4 text-center text-body-medium-lighter text-[var(--content-secondary)]"
           style={{ animation: "fadeInUp 0.3s ease-out 0.15s both" }}
         >
-          Add a meeting in your calendar so we can pick up where we left off.
+          {t("checkinConnectScreen.body")}
         </p>
 
         <div
@@ -89,7 +92,10 @@ export function CheckinConnectScreen({
               loading="eager"
             />
             <span className="text-center text-xs leading-tight text-[var(--content-tertiary)]">
-              Google Calendar
+              {
+                // eslint-disable-next-line local/no-untranslated-strings -- brand name
+                "Google Calendar"
+              }
             </span>
           </div>
         </div>
@@ -98,7 +104,7 @@ export function CheckinConnectScreen({
           className="mt-8 text-center text-body-medium-lighter text-[var(--content-secondary)]"
           style={{ animation: "fadeInUp 0.3s ease-out 0.25s both" }}
         >
-          {`${assistantInlineName} will add a single Day 2 Check-in event. It gets permission to manage your calendar events and see your email address — not your inbox or files — and you can disconnect at any time.`}
+          {t("checkinConnectScreen.permissionBody", { name: assistantInlineName })}
         </p>
 
         <div
@@ -116,10 +122,10 @@ export function CheckinConnectScreen({
             {oauthInProgress ? (
               <span className="flex items-center justify-center gap-2">
                 <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
-                Waiting for authorization...
+                {t("checkinConnectScreen.waitingAuthorization")}
               </span>
             ) : (
-              "Connect Google Calendar"
+              t("checkinConnectScreen.connectGoogleCalendar")
             )}
           </Button>
           <Button
@@ -130,7 +136,7 @@ export function CheckinConnectScreen({
             disabled={oauthInProgress}
             className={`${electron ? "h-9" : "h-11 text-base"}`}
           >
-            Skip for now
+            {t("actions.skipForNow")}
           </Button>
         </div>
       </div>

--- a/clients/web/src/domains/onboarding/screens/create-personality-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/create-personality-step.tsx
@@ -37,6 +37,7 @@ import {
   useBundledAvatarComponents,
 } from "@/utils/use-bundled-avatar-components";
 import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
+import { useTranslation } from "@/i18n";
 
 // Warm the (~48 kB) bundled-avatar chunk the moment this lazy step's module
 // loads, so the peeking characters are ready by the time it paints.
@@ -69,11 +70,25 @@ interface CreatePersonalityStepProps {
  * character whose body/eyes/color evoke that end of the trait (e.g. a warm
  * gentle blob for "Companion", a sharp scowling star for "Execute"). The ten
  * trait-sets are all visually distinct.
+ *
+ * Left/right keys are written out per axis rather than composed from an id, so
+ * an axis added without its copy fails to compile and the keys stay greppable
+ * for the orphan check in `catalogs.test.ts`.
  */
 interface PersonalityAxis {
   id: string;
-  left: string;
-  right: string;
+  leftKey:
+    | "createPersonalityStep.axes.companionCoworker.left"
+    | "createPersonalityStep.axes.genzBoomer.left"
+    | "createPersonalityStep.axes.executeCollaborate.left"
+    | "createPersonalityStep.axes.playfulSerious.left"
+    | "createPersonalityStep.axes.politeUnfiltered.left";
+  rightKey:
+    | "createPersonalityStep.axes.companionCoworker.right"
+    | "createPersonalityStep.axes.genzBoomer.right"
+    | "createPersonalityStep.axes.executeCollaborate.right"
+    | "createPersonalityStep.axes.playfulSerious.right"
+    | "createPersonalityStep.axes.politeUnfiltered.right";
   leftAvatar: CharacterTraits;
   rightAvatar: CharacterTraits;
 }
@@ -81,36 +96,36 @@ interface PersonalityAxis {
 const PERSONALITY_AXES: PersonalityAxis[] = [
   {
     id: "companion-coworker",
-    left: "Companion",
-    right: "Coworker",
+    leftKey: "createPersonalityStep.axes.companionCoworker.left",
+    rightKey: "createPersonalityStep.axes.companionCoworker.right",
     leftAvatar: { bodyShape: "blob", eyeStyle: "gentle", color: "pink" },
     rightAvatar: { bodyShape: "ninja", eyeStyle: "curious", color: "purple" },
   },
   {
     id: "genz-boomer",
-    left: "Gen Z",
-    right: "Baby Boomer",
+    leftKey: "createPersonalityStep.axes.genzBoomer.left",
+    rightKey: "createPersonalityStep.axes.genzBoomer.right",
     leftAvatar: { bodyShape: "burst", eyeStyle: "quirky", color: "yellow" },
     rightAvatar: { bodyShape: "cloud", eyeStyle: "dazed", color: "green" },
   },
   {
     id: "execute-collaborate",
-    left: "Independent",
-    right: "Collaborative",
+    leftKey: "createPersonalityStep.axes.executeCollaborate.left",
+    rightKey: "createPersonalityStep.axes.executeCollaborate.right",
     leftAvatar: { bodyShape: "star", eyeStyle: "angry", color: "orange" },
     rightAvatar: { bodyShape: "flower", eyeStyle: "goofy", color: "teal" },
   },
   {
     id: "playful-serious",
-    left: "Playful",
-    right: "Serious",
+    leftKey: "createPersonalityStep.axes.playfulSerious.left",
+    rightKey: "createPersonalityStep.axes.playfulSerious.right",
     leftAvatar: { bodyShape: "star", eyeStyle: "goofy", color: "yellow" },
     rightAvatar: { bodyShape: "blob", eyeStyle: "grumpy", color: "purple" },
   },
   {
     id: "polite-unfiltered",
-    left: "Polite",
-    right: "Unfiltered",
+    leftKey: "createPersonalityStep.axes.politeUnfiltered.left",
+    rightKey: "createPersonalityStep.axes.politeUnfiltered.right",
     leftAvatar: { bodyShape: "sprout", eyeStyle: "bashful", color: "green" },
     rightAvatar: {
       bodyShape: "urchin",
@@ -252,13 +267,17 @@ function EdgePeekAvatar({
 
 /** One trait row: left label, the tinted track, right label. */
 function PersonalitySlider({
-  axis,
+  leftLabel,
+  rightLabel,
+  ariaLabel,
   value,
   onValueChange,
   fg,
   disabled,
 }: {
-  axis: PersonalityAxis;
+  leftLabel: string;
+  rightLabel: string;
+  ariaLabel: string;
   value: number;
   onValueChange: (next: number) => void;
   fg: string;
@@ -278,13 +297,13 @@ function PersonalitySlider({
         className="order-1 flex-1 text-left text-sm sm:w-32 sm:flex-none sm:text-right sm:text-[17px]"
         style={{ color: fg }}
       >
-        {axis.left}
+        {leftLabel}
       </span>
       <span
         className="order-2 flex-1 text-right text-sm sm:order-3 sm:w-32 sm:flex-none sm:text-left sm:text-[17px]"
         style={{ color: fg }}
       >
-        {axis.right}
+        {rightLabel}
       </span>
       <SliderPrimitive.Root
         className="relative order-3 flex h-6 w-full touch-none items-center select-none sm:order-2 sm:w-auto sm:flex-1"
@@ -294,7 +313,7 @@ function PersonalitySlider({
         min={0}
         max={100}
         step={1}
-        aria-label={`${axis.left} to ${axis.right}`}
+        aria-label={ariaLabel}
       >
         <SliderPrimitive.Track
           className="relative h-2 w-full grow rounded-full sm:h-3"
@@ -379,6 +398,7 @@ export function CreatePersonalityStep({
   onBack,
   onForward,
 }: CreatePersonalityStepProps) {
+  const { t } = useTranslation("onboarding");
   const tone = useOnboardingTone();
   const components = useBundledAvatarComponents();
   const { w: viewportWidth } = useLayoutViewportSize();
@@ -463,15 +483,14 @@ export function CreatePersonalityStep({
             className="text-center text-[2.6rem] leading-none"
             style={{ fontFamily: "var(--font-serif)" }}
           >
-            Create my personality
+            {t("createPersonalityStep.title")}
           </h1>
           {locked ? (
             <p
               className="text-center text-[15px]"
               style={{ color: tone.fgMuted }}
             >
-              Personality locked — chat with your assistant to make any more
-              updates
+              {t("createPersonalityStep.lockedBody")}
             </p>
           ) : null}
         </div>
@@ -480,20 +499,29 @@ export function CreatePersonalityStep({
           style={{ flexBasis: Math.round(40 + stageH * 0.03) }}
         />
 
-        {PERSONALITY_AXES.map((axis, i) => (
-          <Fragment key={axis.id}>
-            {i > 0 && (
-              <div className="w-full min-h-2.5 shrink basis-8 sm:basis-11" />
-            )}
-            <PersonalitySlider
-              axis={axis}
-              value={values[axis.id] ?? DEFAULT_VALUE}
-              onValueChange={(next) => onValueChange(axis.id, next)}
-              fg={tone.fg}
-              disabled={locked}
-            />
-          </Fragment>
-        ))}
+        {PERSONALITY_AXES.map((axis, i) => {
+          const leftLabel = t(axis.leftKey);
+          const rightLabel = t(axis.rightKey);
+          return (
+            <Fragment key={axis.id}>
+              {i > 0 && (
+                <div className="w-full min-h-2.5 shrink basis-8 sm:basis-11" />
+              )}
+              <PersonalitySlider
+                leftLabel={leftLabel}
+                rightLabel={rightLabel}
+                ariaLabel={t("createPersonalityStep.axisAriaLabel", {
+                  left: leftLabel,
+                  right: rightLabel,
+                })}
+                value={values[axis.id] ?? DEFAULT_VALUE}
+                onValueChange={(next) => onValueChange(axis.id, next)}
+                fg={tone.fg}
+                disabled={locked}
+              />
+            </Fragment>
+          );
+        })}
 
         <div className="w-full min-h-3 shrink-[2] basis-14" />
         <button
@@ -505,7 +533,7 @@ export function CreatePersonalityStep({
             color: tone.isLight ? "#FFFFFF" : "#1A1A1A",
           }}
         >
-          Continue
+          {t("actions.continue")}
           <ArrowRight className="h-4 w-4" />
         </button>
       </div>

--- a/clients/web/src/domains/onboarding/screens/existing-assistant-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/existing-assistant-step.tsx
@@ -12,6 +12,7 @@ import { Button } from "@vellumai/design-library/components/button";
 
 import { OnboardingTopBar } from "@/domains/onboarding/components/onboarding-top-bar";
 import { ONBOARDING_STEP_CONTENT } from "@/domains/onboarding/onboarding-step-layout";
+import { useTranslation } from "@/i18n";
 
 interface ExistingAssistantStepProps {
   /** Current name of the established assistant, when known. */
@@ -29,9 +30,9 @@ export function ExistingAssistantStep({
   onRedo,
   onBack,
 }: ExistingAssistantStepProps) {
+  const { t } = useTranslation("onboarding");
   const name = assistantName?.trim() || "";
-  const subject = name || "your assistant";
-  const possessive = name ? `${name}'s` : "its";
+  const hasName = name.length > 0;
 
   return (
     <div
@@ -50,17 +51,17 @@ export function ExistingAssistantStep({
             className="text-[2.2rem] leading-none"
             style={{ fontFamily: "var(--font-serif)" }}
           >
-            {name
-              ? `${name} is already up and running`
-              : "Your assistant is already up and running"}
+            {hasName
+              ? t("existingAssistantStep.titleNamed", { name })
+              : t("existingAssistantStep.title")}
           </h1>
           <p
             className="text-[15px]"
             style={{ color: "var(--content-secondary)" }}
           >
-            You two have history — a personality, memories, and past
-            conversations. Running setup again would overwrite who {subject} is
-            now.
+            {hasName
+              ? t("existingAssistantStep.bodyNamed", { name })
+              : t("existingAssistantStep.body")}
           </p>
         </div>
 
@@ -72,7 +73,9 @@ export function ExistingAssistantStep({
             onClick={onKeep}
             className="h-11 text-base"
           >
-            Keep {subject} and start chatting
+            {hasName
+              ? t("existingAssistantStep.keepNamed", { name })
+              : t("existingAssistantStep.keep")}
             <ArrowRight className="h-4 w-4" />
           </Button>
           <Button
@@ -82,7 +85,9 @@ export function ExistingAssistantStep({
             onClick={onRedo}
             className="h-11 text-base"
           >
-            Start over and rebuild {possessive} personality
+            {hasName
+              ? t("existingAssistantStep.redoNamed", { name })
+              : t("existingAssistantStep.redo")}
           </Button>
         </div>
       </div>

--- a/clients/web/src/domains/onboarding/screens/give-me-a-face-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/give-me-a-face-screen.tsx
@@ -36,6 +36,7 @@ import { randomCharacterTraits } from "@/utils/avatar-random";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 import type { CharacterTraits } from "@/types/avatar";
 import { Button } from "@vellumai/design-library/components/button";
+import { useTranslation } from "@/i18n";
 
 export interface GiveMeAFaceValues {
   traits: CharacterTraits;
@@ -86,6 +87,7 @@ export function GiveMeAFaceScreen({
   onForward,
   canAuditionVoice = true,
 }: GiveMeAFaceScreenProps) {
+  const { t } = useTranslation("onboarding");
   const components = useBundledAvatarComponents();
   const characters = useOnboardingAvatarPoolStore.use.characters();
   const ensureGenerated = useOnboardingAvatarPoolStore.use.ensureGenerated();
@@ -290,13 +292,13 @@ export function GiveMeAFaceScreen({
           animation: "fadeInUp 0.4s ease-out both",
         }}
       >
-        Give me a face and a name
+        {t("giveMeAFaceScreen.title")}
       </h1>
 
       {/* Cycle arrows, flanking the centered avatar */}
       <button
         type="button"
-        aria-label="Previous character"
+        aria-label={t("giveMeAFaceScreen.previousCharacter")}
         onClick={goPrev}
         className={`absolute left-[calc(50%-170px)] top-[43%] -translate-y-1/2 ${arrowClass}`}
       >
@@ -304,7 +306,7 @@ export function GiveMeAFaceScreen({
       </button>
       <button
         type="button"
-        aria-label="Next character"
+        aria-label={t("giveMeAFaceScreen.nextCharacter")}
         onClick={goNext}
         className={`absolute right-[calc(50%-170px)] top-[43%] -translate-y-1/2 ${arrowClass}`}
       >
@@ -329,8 +331,8 @@ export function GiveMeAFaceScreen({
                   setEditingName(false);
                 }
               }}
-              placeholder="Name your assistant"
-              aria-label="Assistant name"
+              placeholder={t("giveMeAFaceScreen.namePlaceholder")}
+              aria-label={t("giveMeAFaceScreen.nameAriaLabel")}
               className="w-[234px] rounded-2xl border border-[var(--border-element)] bg-transparent px-4 py-2.5 text-center text-lg text-[var(--content-default)] placeholder:text-[var(--content-tertiary)] outline-none transition-colors duration-150 focus:border-[var(--border-active)]"
             />
           ) : (
@@ -338,21 +340,21 @@ export function GiveMeAFaceScreen({
               <button
                 type="button"
                 onClick={() => setEditingName(true)}
-                aria-label="Edit name"
+                aria-label={t("giveMeAFaceScreen.editName")}
                 className="flex cursor-pointer items-center gap-2.5"
               >
                 <span
                   className={`text-2xl font-medium ${name ? "text-[var(--content-default)]" : "text-[var(--content-tertiary)]"}`}
                 >
-                  {name || "Name your assistant"}
+                  {name || t("giveMeAFaceScreen.namePlaceholder")}
                 </span>
                 <Pencil className="h-5 w-5 text-[var(--content-tertiary)]" />
               </button>
               <button
                 type="button"
                 onClick={randomizeCharacter}
-                aria-label="Shuffle name and appearance"
-                title="Shuffle name and appearance"
+                aria-label={t("giveMeAFaceScreen.shuffle")}
+                title={t("giveMeAFaceScreen.shuffle")}
                 className="cursor-pointer text-[var(--content-tertiary)] transition-[transform,color] duration-300 hover:rotate-180 hover:text-[var(--content-default)]"
               >
                 <Dices className="h-5 w-5" />
@@ -371,9 +373,11 @@ export function GiveMeAFaceScreen({
               type="button"
               onClick={toggleVoice}
               disabled={!centeredVoice}
-              title="Hear my voice"
+              title={t("giveMeAFaceScreen.hearVoice")}
               aria-label={
-                auditioning ? "Stop the voice sample" : "Hear my voice"
+                auditioning
+                  ? t("giveMeAFaceScreen.stopVoice")
+                  : t("giveMeAFaceScreen.hearVoice")
               }
               aria-busy={voicePending}
               className={`flex cursor-pointer items-center gap-2 rounded-full border border-[color-mix(in_srgb,var(--content-default)_22%,transparent)] px-4 py-2 text-sm text-[var(--content-default)] transition-colors duration-150 hover:bg-[color-mix(in_srgb,var(--content-default)_10%,transparent)] disabled:cursor-default ${voicePending ? "disabled:opacity-70" : "disabled:opacity-40"}`}
@@ -385,7 +389,7 @@ export function GiveMeAFaceScreen({
               ) : (
                 <Volume2 className="h-4 w-4" />
               )}
-              Hear my voice
+              {t("giveMeAFaceScreen.hearVoice")}
             </button>
           )}
         </div>
@@ -399,7 +403,7 @@ export function GiveMeAFaceScreen({
           onClick={handleContinue}
           className="h-11 w-[234px] text-base"
         >
-          Continue
+          {t("actions.continue")}
         </Button>
       </div>
     </OnboardingStage>

--- a/clients/web/src/domains/onboarding/screens/integration-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/integration-step.tsx
@@ -12,10 +12,12 @@ import { useState } from "react";
 import { ArrowRight } from "lucide-react";
 import { motion, useReducedMotion } from "motion/react";
 
+import { Trans } from "@/i18n";
 import { OnboardingCoin } from "@/domains/onboarding/components/onboarding-coin";
 import { OnboardingTopBar } from "@/domains/onboarding/components/onboarding-top-bar";
 import { useOnboardingStageSize } from "@/domains/onboarding/hooks/use-onboarding-stage-size";
 import { useOnboardingTone } from "@/domains/onboarding/onboarding-tone";
+import { useTranslation } from "@/i18n";
 
 interface IntegrationStepProps {
   onClaim: () => void;
@@ -37,6 +39,7 @@ export function IntegrationStep({
   onBack,
   onForward,
 }: IntegrationStepProps) {
+  const { t } = useTranslation("onboarding");
   const reduce = useReducedMotion();
   const tone = useOnboardingTone();
   const { h: vh } = useOnboardingStageSize();
@@ -68,8 +71,11 @@ export function IntegrationStep({
           className="text-[2.6rem] leading-[1.1] max-md:max-w-[80vw]"
           style={{ fontFamily: "var(--font-serif)" }}
         >
-          Here are some free credits
-          <br className="max-md:hidden" /> to get started.
+          <Trans
+            i18nKey="integrationStep.title"
+            ns="onboarding"
+            components={{ br: <br className="max-md:hidden" /> }}
+          />
         </h1>
 
         {/* Coin — drops to the eyes, gets bumped up, then falls away (2D flight
@@ -114,7 +120,7 @@ export function IntegrationStep({
               color: tone.isLight ? "#FFFFFF" : "#1A1A1A",
             }}
           >
-            Claim
+            {t("actions.claim")}
             <ArrowRight className="h-4 w-4" />
           </button>
         )}

--- a/clients/web/src/domains/onboarding/screens/intro-pitch-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/intro-pitch-steps.tsx
@@ -28,6 +28,7 @@ import {
 } from "motion/react";
 
 import { Button } from "@vellumai/design-library/components/button";
+import { useTranslation } from "@/i18n";
 import { AnimatedAvatar } from "@/components/avatar/animated-avatar";
 import {
   MotionEyes,
@@ -42,11 +43,6 @@ import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-component
 
 // Lines 1 + 2 carousel together from the setup framing to the first two payoff
 // lines; line 3 ("The less you do") is then added in last.
-const SETUP_LINE = "You’ve used AI that just answers questions.";
-const HELP_LINE = "The more I help,";
-const PUNCH_LINE = "I’m different.";
-const BETTER_LINE = "the better I get,";
-const LESS_LINE = "and the less you have to do.";
 
 // The little team that peeks in from the top-right on the second line, then
 // retracts. (Kept in sync with TOP_TEAM in onboarding-toned-backdrop.tsx.)
@@ -150,6 +146,13 @@ export function PitchStep({
   /** Redo into the next step — only set when the user has stepped back. */
   onForward?: () => void;
 }) {
+  const { t } = useTranslation("onboarding");
+  const setupLine = t("pitchStep.setupLine");
+  const helpLine = t("pitchStep.helpLine");
+  const punchLine = t("pitchStep.punchLine");
+  const betterLine = t("pitchStep.betterLine");
+  const lessLine = t("pitchStep.lessLine");
+
   const tone = useOnboardingTone();
   const reduce = useReducedMotion();
   const { art, eyesW, eyesH, restCy, centerX, w, h } = useOnboardingEyes();
@@ -410,19 +413,19 @@ export function PitchStep({
         style={{ width: blockW, fontFamily: "var(--font-serif)" }}
       >
         <span ref={m1aRef} className="block">
-          {SETUP_LINE}
+          {setupLine}
         </span>
         <span ref={m1bRef} className="block">
-          {HELP_LINE}
+          {helpLine}
         </span>
         <span ref={m2aRef} className="block">
-          {PUNCH_LINE}
+          {punchLine}
         </span>
         <span ref={m2bRef} className="block">
-          {BETTER_LINE}
+          {betterLine}
         </span>
         <span ref={m3Ref} className="block">
-          {LESS_LINE}
+          {lessLine}
         </span>
       </div>
 
@@ -510,8 +513,8 @@ export function PitchStep({
             firstH={firstH1}
             secondH={secondH1}
             color={tone.fgDeep}
-            firstText={SETUP_LINE}
-            secondText={HELP_LINE}
+            firstText={setupLine}
+            secondText={helpLine}
             revealed={reveal1}
             carouseled={carousel1}
             revealFrom="bottom"
@@ -523,8 +526,8 @@ export function PitchStep({
             firstH={firstH2}
             secondH={secondH2}
             color={tone.fg}
-            firstText={PUNCH_LINE}
-            secondText={BETTER_LINE}
+            firstText={punchLine}
+            secondText={betterLine}
             revealed={reveal2}
             carouseled={carousel2}
             revealFrom="top"
@@ -560,7 +563,7 @@ export function PitchStep({
                       : { duration: 0.5, ease: "easeOut" }
                   }
                 >
-                  {LESS_LINE}
+                  {lessLine}
                 </motion.span>
               </div>
             )}
@@ -581,7 +584,7 @@ export function PitchStep({
               onClick={onContinue}
               className="h-11 w-[234px] text-base"
             >
-              Continue
+              {t("actions.continue")}
             </Button>
           </motion.div>
         )}

--- a/clients/web/src/domains/onboarding/screens/introduction-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/introduction-screen.tsx
@@ -16,6 +16,7 @@ import { ArrowRight } from "lucide-react";
 import { motion, useReducedMotion } from "motion/react";
 import { Button } from "@vellumai/design-library/components/button";
 
+import { useTranslation } from "@/i18n";
 import { ONBOARDING_STEP_CONTENT } from "@/domains/onboarding/onboarding-step-layout";
 import { OnboardingPeekingEyes } from "@/domains/onboarding/components/onboarding-peeking-eyes";
 import { OnboardingStage } from "@/domains/onboarding/components/onboarding-stage";
@@ -94,6 +95,7 @@ export function IntroductionScreen({
   onBack,
   onForward,
 }: IntroductionScreenProps) {
+  const { t } = useTranslation("onboarding");
   const components = useBundledAvatarComponents();
   const characters = useOnboardingAvatarPoolStore.use.characters();
   const selectedIndex = useOnboardingAvatarPoolStore.use.selectedIndex();
@@ -114,10 +116,14 @@ export function IntroductionScreen({
     return { body, color: color.hex };
   }, [components, chosen]);
 
-  const greeting = firstName.trim() ? `Hey, ${firstName.trim()}!` : "Hey!";
-  const intro = assistantName?.trim()
-    ? `I’m ${assistantName.trim()}, your new AI assistant.`
-    : "I’m your new AI assistant.";
+  const trimmedFirstName = firstName.trim();
+  const trimmedAssistantName = assistantName?.trim() ?? "";
+  const greeting = trimmedFirstName
+    ? t("introductionScreen.greetingNamed", { name: trimmedFirstName })
+    : t("introductionScreen.greeting");
+  const intro = trimmedAssistantName
+    ? t("introductionScreen.introNamed", { name: trimmedAssistantName })
+    : t("introductionScreen.intro");
 
   if (!art) {
     return (
@@ -197,7 +203,7 @@ export function IntroductionScreen({
             onClick={onContinue}
             className="h-11 w-[234px] text-base"
           >
-            Continue
+            {t("actions.continue")}
           </Button>
         </motion.div>
       </div>

--- a/clients/web/src/domains/onboarding/screens/lets-chat-tomorrow-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/lets-chat-tomorrow-step.tsx
@@ -21,6 +21,7 @@ import { Loader2 } from "lucide-react";
 import { OnboardingTopBar } from "@/domains/onboarding/components/onboarding-top-bar";
 import { useGoogleCalendarConnect } from "@/domains/onboarding/hooks/use-google-calendar-connect";
 import { useOnboardingTone } from "@/domains/onboarding/onboarding-tone";
+import { useTranslation } from "@/i18n";
 
 interface LetsChatTomorrowStepProps {
   /** Hatched assistant id; null until the background hatch resolves. */
@@ -61,6 +62,7 @@ export function LetsChatTomorrowStep({
   onRetry,
   hatchError = null,
 }: LetsChatTomorrowStepProps) {
+  const { t } = useTranslation("onboarding");
   const tone = useOnboardingTone();
   const { handleConnect, oauthInProgress } = useGoogleCalendarConnect({
     assistantId: assistantId ?? "",
@@ -87,17 +89,17 @@ export function LetsChatTomorrowStep({
           style={{ fontFamily: "var(--font-serif)" }}
         >
           {waitingForAssistant
-            ? "Waking up"
+            ? t("letsChatTomorrowStep.wakingTitle")
             : missingCalendarScope
-              ? "Access not enabled"
-              : "Let me make this easy"}
+              ? t("letsChatTomorrowStep.missingScopeTitle")
+              : t("letsChatTomorrowStep.title")}
         </h1>
         <p className="text-[16px]" style={{ color: tone.fgMuted }}>
           {waitingForAssistant
-            ? "Your assistant is getting ready"
+            ? t("letsChatTomorrowStep.wakingBody")
             : missingCalendarScope
-              ? "Check the box next to the Google Calendar permission so I can book the check-in."
-              : "Connect your Google Calendar so I can find time to check in and start helping."}
+              ? t("letsChatTomorrowStep.missingScopeBody")
+              : t("letsChatTomorrowStep.body")}
         </p>
 
         <div className="mt-6 flex w-[234px] flex-col items-center gap-4">
@@ -114,17 +116,17 @@ export function LetsChatTomorrowStep({
             {waitingForAssistant ? (
               <>
                 <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
-                Starting assistant…
+                {t("letsChatTomorrowStep.startingAssistant")}
               </>
             ) : oauthInProgress ? (
               <>
                 <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
-                Waiting for authorization…
+                {t("letsChatTomorrowStep.waitingAuthorization")}
               </>
             ) : missingCalendarScope ? (
-              "Try again"
+              t("actions.tryAgain")
             ) : (
-              "Connect Calendar →"
+              t("letsChatTomorrowStep.connectCalendar")
             )}
           </button>
           {/* Skip sits directly under the connect button. Hidden while the
@@ -139,7 +141,7 @@ export function LetsChatTomorrowStep({
               className="cursor-pointer text-body-small-default transition-opacity hover:opacity-100 disabled:opacity-60"
               style={{ color: tone.fgMuted }}
             >
-              Skip for now
+              {t("actions.skipForNow")}
             </button>
           )}
         </div>

--- a/clients/web/src/domains/onboarding/screens/research-onboarding-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-onboarding-screen.tsx
@@ -19,6 +19,7 @@ import { Button } from "@vellumai/design-library/components/button";
 import { Input } from "@vellumai/design-library/components/input";
 
 import { MOBILE_INPUT_NO_ZOOM } from "@/domains/onboarding/onboarding-step-layout";
+import { useTranslation } from "@/i18n";
 
 export interface ResearchOnboardingValues {
   firstName: string;
@@ -53,6 +54,7 @@ export function ResearchOnboardingScreen({
   initialLastName = "",
   onSubmit,
 }: ResearchOnboardingScreenProps) {
+  const { t } = useTranslation("onboarding");
   const [firstName, setFirstName] = useState(initialFirstName);
   const [lastName, setLastName] = useState(initialLastName);
   const [role, setRole] = useState("");
@@ -86,14 +88,14 @@ export function ResearchOnboardingScreen({
             className="text-center font-serif text-[2.75rem] leading-[1.05] tracking-tight"
             style={riseIn(0.05)}
           >
-            Let&apos;s start with you.
+            {t("researchOnboardingScreen.title")}
           </h1>
 
           <p
             className="mt-3 text-center text-body-medium-lighter text-[var(--content-secondary)]"
             style={riseIn(0.12)}
           >
-            A few details so I can get to know you.
+            {t("researchOnboardingScreen.body")}
           </p>
 
           <div className="mt-10 flex w-full flex-col gap-5">
@@ -101,7 +103,7 @@ export function ResearchOnboardingScreen({
               <Input
                 label={
                   <>
-                    What should I call you?
+                    {t("researchOnboardingScreen.firstNameLabel")}
                     <span
                       aria-hidden
                       className="text-[var(--system-negative-strong)]"
@@ -110,7 +112,7 @@ export function ResearchOnboardingScreen({
                     </span>
                   </>
                 }
-                placeholder="Your name"
+                placeholder={t("researchOnboardingScreen.firstNamePlaceholder")}
                 value={firstName}
                 onChange={(e) => setFirstName(e.target.value)}
                 className={MOBILE_INPUT_NO_ZOOM}
@@ -122,8 +124,8 @@ export function ResearchOnboardingScreen({
 
             <div style={riseIn(0.27, 30)}>
               <Input
-                label="And your last name?"
-                placeholder="Your last name (optional)"
+                label={t("researchOnboardingScreen.lastNameLabel")}
+                placeholder={t("researchOnboardingScreen.lastNamePlaceholder")}
                 value={lastName}
                 onChange={(e) => setLastName(e.target.value)}
                 className={MOBILE_INPUT_NO_ZOOM}
@@ -133,8 +135,8 @@ export function ResearchOnboardingScreen({
 
             <div style={riseIn(0.34, 20)}>
               <Input
-                label="Your role"
-                placeholder="What do you do for work?"
+                label={t("researchOnboardingScreen.roleLabel")}
+                placeholder={t("researchOnboardingScreen.rolePlaceholder")}
                 value={role}
                 onChange={(e) => setRole(e.target.value)}
                 className={MOBILE_INPUT_NO_ZOOM}
@@ -145,8 +147,8 @@ export function ResearchOnboardingScreen({
 
             <div style={riseIn(0.41, 10)}>
               <TagAutocompleteInput
-                label="Any hobbies?"
-                placeholder="Cars, books, growing tomatoes?"
+                label={t("researchOnboardingScreen.hobbiesLabel")}
+                placeholder={t("researchOnboardingScreen.hobbiesPlaceholder")}
                 values={hobbies}
                 onChange={setHobbies}
                 suggestions={HOBBY_SUGGESTIONS}
@@ -164,7 +166,7 @@ export function ResearchOnboardingScreen({
               disabled={!canSubmit}
               className="h-11 text-base"
             >
-              Continue
+              {t("actions.continue")}
             </Button>
           </div>
         </form>

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -29,6 +29,7 @@ import {
   type OnboardingTone,
 } from "@/domains/onboarding/onboarding-tone";
 import { useLayoutViewportSize } from "@/hooks/use-element-size";
+import { Trans, useTranslation } from "@/i18n";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 import {
   pluginDisplayName,
@@ -119,13 +120,14 @@ export function MeetingCreatedStep({
   /** True while the check-in booking is still in flight; holds the step (capped) so a slow-but-successful booking can still reveal the time. */
   awaitingTime?: boolean;
 }) {
+  const { t } = useTranslation("onboarding");
   const { components, chosen } = useChosenAvatar();
   const reduce = useReducedMotion();
   const { w, h } = useLayoutViewportSize();
 
   const title = scheduledTime
-    ? `Check-in scheduled for tomorrow at ${scheduledTime}!`
-    : "Check-in scheduled!";
+    ? t("meetingCreatedStep.titleWithTime", { time: scheduledTime })
+    : t("meetingCreatedStep.title");
 
   // Hold the step long enough to reveal the booked time. While a booking is
   // still in flight and we don't yet have the time, wait up to the cap; once
@@ -225,36 +227,6 @@ export function MeetingCreatedStep({
 // Looking you up (loading carousel)
 // ---------------------------------------------------------------------------
 
-// Rotating status lines shown while the web-research turn settles in the
-// background. They loop until `ready`, so the copy is pure flavor — it never
-// gates progress. The personality rewrite is NOT narrated here: it runs
-// decoupled and is finished off in the dedicated FinishingUpStep, so this quick
-// loader isn't held hostage to the persona turn.
-const WEB_SEARCH_MESSAGES = [
-  "Searching the web to get to know you…",
-  "Reading public profiles…",
-  "Skimming the highlights…",
-  "Connecting the dots…",
-  "Piecing it together…",
-];
-
-// Persona-rewrite lines, shown by FinishingUpStep while the personality turn
-// wraps up right before the chat handoff.
-const PERSONALITY_MESSAGES = [
-  "Updating my personality…",
-  "Finding my voice…",
-  "Getting into character…",
-];
-
-// Shared closing line both carousels settle on.
-const LOOKING_CLOSING_MESSAGE = "Almost there…";
-
-/** The web-search carousel: search lines, then the shared closer. */
-const LOOKING_MESSAGES = [...WEB_SEARCH_MESSAGES, LOOKING_CLOSING_MESSAGE];
-
-/** The finishing carousel: persona lines, then the shared closer. */
-const FINISHING_MESSAGES = [...PERSONALITY_MESSAGES, LOOKING_CLOSING_MESSAGE];
-
 /** How long each rotating message lingers before advancing to the next. */
 const LOOKING_MESSAGE_INTERVAL_MS = 2800;
 
@@ -278,12 +250,21 @@ export function LookingYouUpStep({
    */
   ready: boolean;
 }) {
+  const { t } = useTranslation("onboarding");
+  const lookingMessages = [
+    t("lookingYouUpStep.searching"),
+    t("lookingYouUpStep.readingProfiles"),
+    t("lookingYouUpStep.skimming"),
+    t("lookingYouUpStep.connectingDots"),
+    t("lookingYouUpStep.piecing"),
+    t("lookingYouUpStep.almostThere"),
+  ];
   const tone = DARK_TONE;
   const [index, setIndex] = useState(0);
 
   useEffect(() => {
     onAdvance?.(index);
-    const isLast = index >= LOOKING_MESSAGES.length - 1;
+    const isLast = index >= lookingMessages.length - 1;
     // Finish on the last message once research is ready; otherwise keep cycling
     // (looping back to the start) until it lands.
     if (ready && isLast) {
@@ -291,11 +272,11 @@ export function LookingYouUpStep({
       return () => clearTimeout(done);
     }
     const next = setTimeout(
-      () => setIndex((i) => (i + 1) % LOOKING_MESSAGES.length),
+      () => setIndex((i) => (i + 1) % lookingMessages.length),
       LOOKING_MESSAGE_INTERVAL_MS,
     );
     return () => clearTimeout(next);
-  }, [index, ready, onDone, onAdvance]);
+  }, [index, ready, onDone, onAdvance, lookingMessages.length]);
 
   return (
     <div className="absolute inset-0 z-10" style={{ color: tone.fg }}>
@@ -318,7 +299,7 @@ export function LookingYouUpStep({
             exit={{ y: -12, opacity: 0 }}
             transition={{ duration: 0.35 }}
           >
-            {LOOKING_MESSAGES[index]}
+            {lookingMessages[index]}
           </motion.p>
         </AnimatePresence>
       </div>
@@ -348,11 +329,18 @@ export function FinishingUpStep({
   /** The personality rewrite has settled; hand off after the closing line. */
   ready: boolean;
 }) {
+  const { t } = useTranslation("onboarding");
+  const finishingMessages = [
+    t("finishingUpStep.updatingPersonality"),
+    t("finishingUpStep.findingVoice"),
+    t("finishingUpStep.gettingIntoCharacter"),
+    t("finishingUpStep.almostThere"),
+  ];
   const tone = DARK_TONE;
   const [index, setIndex] = useState(0);
 
   useEffect(() => {
-    const lastIndex = FINISHING_MESSAGES.length - 1;
+    const lastIndex = finishingMessages.length - 1;
     if (ready) {
       // Snap to the closing line first (so we don't hand off mid-list), hold a
       // beat, then enter chat.
@@ -364,11 +352,11 @@ export function FinishingUpStep({
       return () => clearTimeout(done);
     }
     const next = setTimeout(
-      () => setIndex((i) => (i + 1) % FINISHING_MESSAGES.length),
+      () => setIndex((i) => (i + 1) % finishingMessages.length),
       LOOKING_MESSAGE_INTERVAL_MS,
     );
     return () => clearTimeout(next);
-  }, [index, ready, onDone]);
+  }, [index, ready, onDone, finishingMessages.length]);
 
   return (
     <div className="absolute inset-0 z-10" style={{ color: tone.fg }}>
@@ -384,7 +372,7 @@ export function FinishingUpStep({
             exit={{ y: -12, opacity: 0 }}
             transition={{ duration: 0.35 }}
           >
-            {FINISHING_MESSAGES[index]}
+            {finishingMessages[index]}
           </motion.p>
         </AnimatePresence>
       </div>
@@ -424,6 +412,7 @@ export function ResearchResultsStep({
   /** Redo into the next step — only set when the user has stepped back. */
   onForward?: () => void;
 }) {
+  const { t } = useTranslation("onboarding");
   const tone = DARK_TONE;
   const reduce = useReducedMotion();
   // Locally track removed claims by their text so a user can prune what's wrong
@@ -450,17 +439,17 @@ export function ResearchResultsStep({
               className="text-[2.2rem] leading-none"
               style={{ fontFamily: "var(--font-serif)" }}
             >
-              This is what I found about you
+              {t("researchResultsStep.title")}
             </h1>
           </div>
           <p className="mb-7 mt-2 text-[15px]" style={{ color: tone.fgMuted }}>
             {hasClaims
               ? loading
-                ? "Still checking the rest. You can review these as they come in."
-                : "I searched the web. Feel free to remove anything that isn’t true."
+                ? t("researchResultsStep.bodyLoadingWithClaims")
+                : t("researchResultsStep.bodyReadyWithClaims")
               : loading
-                ? "Still putting this together…"
-                : "I didn’t turn up much — we can fill it in as we chat."}
+                ? t("researchResultsStep.bodyLoadingEmpty")
+                : t("researchResultsStep.bodyReadyEmpty")}
           </p>
 
           <div className="flex flex-col gap-3">
@@ -482,7 +471,9 @@ export function ResearchResultsStep({
                   <span>{fact.claim}</span>
                   <button
                     type="button"
-                    aria-label={`Remove "${fact.claim}"`}
+                    aria-label={t("researchResultsStep.removeClaim", {
+                      claim: fact.claim,
+                    })}
                     onClick={() =>
                       setRemoved((prev) => new Set(prev).add(fact.claim))
                     }
@@ -507,7 +498,7 @@ export function ResearchResultsStep({
               className="mt-5 self-start shrink-0 cursor-pointer text-[14px] underline underline-offset-2 transition-opacity hover:opacity-80"
               style={{ color: tone.fgMuted }}
             >
-              This is not me
+              {t("researchResultsStep.notMe")}
             </button>
           )}
         </div>
@@ -522,7 +513,7 @@ export function ResearchResultsStep({
             color: tone.isLight ? "#FFFFFF" : "#1A1A1A",
           }}
         >
-          {canContinue ? "Continue" : "Still searching…"}
+          {canContinue ? t("actions.continue") : t("researchResultsStep.stillSearching")}
           {canContinue && <ArrowRight className="h-4 w-4" />}
         </button>
       </div>
@@ -533,31 +524,6 @@ export function ResearchResultsStep({
 // ---------------------------------------------------------------------------
 // Suggestions
 // ---------------------------------------------------------------------------
-
-/**
- * Generic fallbacks shown only if the research turn produced no suggestions
- * (failure / sparse subject) so the step is never empty once it's done loading.
- * Each pairs the assistant-voiced card text with the user-voiced prompt sent on
- * click.
- */
-const FALLBACK_SUGGESTIONS: ResearchSuggestion[] = [
-  {
-    suggestion: "I'll pull together a quick brief on what's new in your field",
-    prompt: "Give me a quick brief on what's new in my field right now.",
-  },
-  {
-    suggestion: "I'll send a weekly briefing on news in your space",
-    prompt: "Set up a weekly briefing on news in my space.",
-  },
-  {
-    suggestion: "I'll help you get on top of your week",
-    prompt: "Help me get on top of my week.",
-  },
-  {
-    suggestion: "I'll draft something from a few rough notes",
-    prompt: "Draft something from a few rough notes I'll give you.",
-  },
-];
 
 /** A plugin name rendered as a pill tinted with the chosen avatar's color. */
 function PluginPill({ label, tone }: { label: string; tone: OnboardingTone }) {
@@ -572,12 +538,20 @@ function PluginPill({ label, tone }: { label: string; tone: OnboardingTone }) {
 }
 
 /** Interleave plugin pills with readable connectors: "A", "A and B", "A, B, and C". */
-function joinPills(labels: string[], tone: OnboardingTone) {
+function joinPills(
+  labels: string[],
+  tone: OnboardingTone,
+  connectors: { listAnd: string; listCommaAnd: string; listComma: string },
+) {
   return labels.map((label, i) => {
     let connector = "";
     if (i > 0) {
       const isLast = i === labels.length - 1;
-      connector = isLast ? (labels.length === 2 ? " and " : ", and ") : ", ";
+      connector = isLast
+        ? labels.length === 2
+          ? connectors.listAnd
+          : connectors.listCommaAnd
+        : connectors.listComma;
     }
     return (
       <Fragment key={label}>
@@ -618,7 +592,12 @@ function PluginSetupNote({
   /** True once the avatar has landed — the text only appears then. */
   revealed: boolean;
 }) {
-  const plural = pluginLabels.length > 1;
+  const { t } = useTranslation("onboarding");
+  const listConnectors = {
+    listAnd: t("suggestionsStep.listAnd"),
+    listCommaAnd: t("suggestionsStep.listCommaAnd"),
+    listComma: t("suggestionsStep.listComma"),
+  };
   return (
     <div className="mt-12 flex items-center gap-3">
       <div
@@ -633,8 +612,16 @@ function PluginSetupNote({
         animate={{ opacity: revealed ? 1 : 0, x: revealed ? 0 : -6 }}
         transition={reduce ? { duration: 0 } : { duration: 0.35 }}
       >
-        Already set up the {joinPills(pluginLabels, pillTone)} plugin
-        {plural ? "s" : ""} to help with your work
+        <Trans
+          i18nKey="suggestionsStep.alreadySetUp"
+          ns="onboarding"
+          count={pluginLabels.length}
+          components={{
+            plugins: (
+              <>{joinPills(pluginLabels, pillTone, listConnectors)}</>
+            ),
+          }}
+        />
       </motion.p>
     </div>
   );
@@ -734,14 +721,37 @@ export function SuggestionsStep({
   /** Redo into the next step — only set when the user has stepped back. */
   onForward?: () => void;
 }) {
+  const { t } = useTranslation("onboarding");
   // Constant dark surface for the UI; the avatar tone is only for the pills.
   const tone = DARK_TONE;
   const avatarTone = useOnboardingTone();
   const reduce = useReducedMotion();
+  const fallbackSuggestions: ResearchSuggestion[] = [
+    {
+      suggestion: t("suggestionsStep.fallbacks.brief.suggestion"),
+      prompt: t("suggestionsStep.fallbacks.brief.prompt"),
+    },
+    {
+      suggestion: t("suggestionsStep.fallbacks.weekly.suggestion"),
+      prompt: t("suggestionsStep.fallbacks.weekly.prompt"),
+    },
+    {
+      suggestion: t("suggestionsStep.fallbacks.week.suggestion"),
+      prompt: t("suggestionsStep.fallbacks.week.prompt"),
+    },
+    {
+      suggestion: t("suggestionsStep.fallbacks.draft.suggestion"),
+      prompt: t("suggestionsStep.fallbacks.draft.prompt"),
+    },
+  ];
   // Show real suggestions as they arrive; only fall back once the turn settles
   // with nothing, so we never flash generic prompts over an in-flight result.
   const items =
-    suggestions.length > 0 ? suggestions : loading ? [] : FALLBACK_SUGGESTIONS;
+    suggestions.length > 0
+      ? suggestions
+      : loading
+        ? []
+        : fallbackSuggestions;
 
   const pluginLabels = installedPlugins
     .map(pluginDisplayName)
@@ -827,24 +837,27 @@ export function SuggestionsStep({
             className="text-[2.2rem] leading-none"
             style={{ fontFamily: "var(--font-serif)" }}
           >
-            Here&rsquo;s what we could do first
+            {t("suggestionsStep.title")}
           </h1>
         </div>
         <p className="mb-7 mt-2 text-[15px]" style={{ color: tone.fgMuted }}>
           {items.length > 0 ? (
-            <>
-              Pick one to jump in — or start your own thing.{" "}
-              <button
-                type="button"
-                onClick={onSkip}
-                className="cursor-pointer underline underline-offset-2 transition-opacity hover:opacity-80"
-                style={{ color: tone.fg }}
-              >
-                Skip to Chat
-              </button>
-            </>
+            <Trans
+              i18nKey="suggestionsStep.pickOne"
+              ns="onboarding"
+              components={{
+                skip: (
+                  <button
+                    type="button"
+                    onClick={onSkip}
+                    className="cursor-pointer underline underline-offset-2 transition-opacity hover:opacity-80"
+                    style={{ color: tone.fg }}
+                  />
+                ),
+              }}
+            />
           ) : (
-            "Putting together a few ideas…"
+            t("suggestionsStep.loading")
           )}
         </p>
 
@@ -947,6 +960,7 @@ export function LetsChatReadyStep({
    */
   disabled?: boolean;
 }) {
+  const { t } = useTranslation("onboarding");
   // Constant dark surface for the UI (the plugin cards match the facts cards).
   const tone = DARK_TONE;
   const reduce = useReducedMotion();
@@ -1077,7 +1091,7 @@ export function LetsChatReadyStep({
             className="text-[2.2rem] leading-none"
             style={{ fontFamily: "var(--font-serif)" }}
           >
-            You&rsquo;re all set
+            {t("letsChatReadyStep.title")}
           </h1>
         </div>
 
@@ -1112,7 +1126,7 @@ export function LetsChatReadyStep({
             animate={{ opacity: landed ? 1 : 0, x: landed ? 0 : -6 }}
             transition={reduce ? { duration: 0 } : { duration: 0.35 }}
           >
-            I&rsquo;ve set myself up with plugins around who you are.
+            {t("letsChatReadyStep.setupNote")}
           </motion.p>
         </div>
 
@@ -1164,7 +1178,7 @@ export function LetsChatReadyStep({
             color: tone.isLight ? "#FFFFFF" : "#1A1A1A",
           }}
         >
-          {starting ? "Starting…" : "Let's chat"}
+          {starting ? t("actions.starting") : t("letsChatReadyStep.letsChat")}
           {!starting && <ArrowRight className="h-4 w-4" />}
         </button>
 

--- a/clients/web/src/i18n/locales/en/onboarding.json
+++ b/clients/web/src/i18n/locales/en/onboarding.json
@@ -14,7 +14,10 @@
     "logIn": "Log In",
     "logOut": "Log out",
     "loginToUse": "Log in to use",
-    "downloadMacApp": "Download the macOS app"
+    "downloadMacApp": "Download the macOS app",
+    "claim": "Claim",
+    "skipForNow": "Skip for now",
+    "starting": "Starting…"
   },
   "welcome": {
     "title": "Welcome to Vellum",
@@ -118,5 +121,160 @@
   },
   "googleCalendar": {
     "authorizationFailed": "Failed to start Google Calendar authorization."
+  },
+  "introductionScreen": {
+    "greetingNamed": "Hey, {name}!",
+    "greeting": "Hey!",
+    "introNamed": "I’m {name}, your new AI assistant.",
+    "intro": "I’m your new AI assistant."
+  },
+  "pitchStep": {
+    "setupLine": "You’ve used AI that just answers questions.",
+    "helpLine": "The more I help,",
+    "punchLine": "I’m different.",
+    "betterLine": "the better I get,",
+    "lessLine": "and the less you have to do."
+  },
+  "createPersonalityStep": {
+    "title": "Create my personality",
+    "lockedBody": "Personality locked, chat with your assistant to make any more updates",
+    "axisAriaLabel": "{left} to {right}",
+    "axes": {
+      "companionCoworker": {
+        "left": "Companion",
+        "right": "Coworker"
+      },
+      "genzBoomer": {
+        "left": "Gen Z",
+        "right": "Baby Boomer"
+      },
+      "executeCollaborate": {
+        "left": "Independent",
+        "right": "Collaborative"
+      },
+      "playfulSerious": {
+        "left": "Playful",
+        "right": "Serious"
+      },
+      "politeUnfiltered": {
+        "left": "Polite",
+        "right": "Unfiltered"
+      }
+    }
+  },
+  "giveMeAFaceScreen": {
+    "title": "Give me a face and a name",
+    "previousCharacter": "Previous character",
+    "nextCharacter": "Next character",
+    "namePlaceholder": "Name your assistant",
+    "nameAriaLabel": "Assistant name",
+    "editName": "Edit name",
+    "shuffle": "Shuffle name and appearance",
+    "hearVoice": "Hear my voice",
+    "stopVoice": "Stop the voice sample"
+  },
+  "integrationStep": {
+    "title": "Here are some free credits<br></br> to get started."
+  },
+  "researchOnboardingScreen": {
+    "title": "Let's start with you.",
+    "body": "A few details so I can get to know you.",
+    "firstNameLabel": "What should I call you?",
+    "firstNamePlaceholder": "Your name",
+    "lastNameLabel": "And your last name?",
+    "lastNamePlaceholder": "Your last name (optional)",
+    "roleLabel": "Your role",
+    "rolePlaceholder": "What do you do for work?",
+    "hobbiesLabel": "Any hobbies?",
+    "hobbiesPlaceholder": "Cars, books, growing tomatoes?"
+  },
+  "letsChatTomorrowStep": {
+    "wakingTitle": "Waking up",
+    "missingScopeTitle": "Access not enabled",
+    "title": "Let me make this easy",
+    "wakingBody": "Your assistant is getting ready",
+    "missingScopeBody": "Check the box next to the Google Calendar permission so I can book the check-in.",
+    "body": "Connect your Google Calendar so I can find time to check in and start helping.",
+    "startingAssistant": "Starting assistant…",
+    "waitingAuthorization": "Waiting for authorization…",
+    "connectCalendar": "Connect Calendar →"
+  },
+  "existingAssistantStep": {
+    "titleNamed": "{name} is already up and running",
+    "title": "Your assistant is already up and running",
+    "bodyNamed": "You two have history: a personality, memories, and past conversations. Running setup again would overwrite who {name} is now.",
+    "body": "You two have history: a personality, memories, and past conversations. Running setup again would overwrite who your assistant is now.",
+    "keepNamed": "Keep {name} and start chatting",
+    "keep": "Keep your assistant and start chatting",
+    "redoNamed": "Start over and rebuild {name}'s personality",
+    "redo": "Start over and rebuild its personality"
+  },
+  "checkinConnectScreen": {
+    "title": "Let's chat tomorrow",
+    "body": "Add a meeting in your calendar so we can pick up where we left off.",
+    "permissionBody": "{name} will add a single Day 2 Check-in event. It gets permission to manage your calendar events and see your email address, not your inbox or files, and you can disconnect at any time.",
+    "unnamedAssistant": "your assistant",
+    "waitingAuthorization": "Waiting for authorization...",
+    "connectGoogleCalendar": "Connect Google Calendar"
+  },
+  "meetingCreatedStep": {
+    "titleWithTime": "Check-in scheduled for tomorrow at {time}!",
+    "title": "Check-in scheduled!"
+  },
+  "lookingYouUpStep": {
+    "searching": "Searching the web to get to know you…",
+    "readingProfiles": "Reading public profiles…",
+    "skimming": "Skimming the highlights…",
+    "connectingDots": "Connecting the dots…",
+    "piecing": "Piecing it together…",
+    "almostThere": "Almost there…"
+  },
+  "finishingUpStep": {
+    "updatingPersonality": "Updating my personality…",
+    "findingVoice": "Finding my voice…",
+    "gettingIntoCharacter": "Getting into character…",
+    "almostThere": "Almost there…"
+  },
+  "researchResultsStep": {
+    "title": "This is what I found about you",
+    "bodyLoadingWithClaims": "Still checking the rest. You can review these as they come in.",
+    "bodyReadyWithClaims": "I searched the web. Feel free to remove anything that isn’t true.",
+    "bodyLoadingEmpty": "Still putting this together…",
+    "bodyReadyEmpty": "I didn’t turn up much, we can fill it in as we chat.",
+    "removeClaim": "Remove \"{claim}\"",
+    "notMe": "This is not me",
+    "stillSearching": "Still searching…"
+  },
+  "suggestionsStep": {
+    "title": "Here’s what we could do first",
+    "pickOne": "Pick one to jump in, or start your own thing. <skip>Skip to Chat</skip>",
+    "loading": "Putting together a few ideas…",
+    "alreadySetUp": "Already set up the <plugins></plugins> {count, plural, one {plugin} other {plugins}} to help with your work",
+    "listAnd": " and ",
+    "listCommaAnd": ", and ",
+    "listComma": ", ",
+    "fallbacks": {
+      "brief": {
+        "suggestion": "I'll pull together a quick brief on what's new in your field",
+        "prompt": "Give me a quick brief on what's new in my field right now."
+      },
+      "weekly": {
+        "suggestion": "I'll send a weekly briefing on news in your space",
+        "prompt": "Set up a weekly briefing on news in my space."
+      },
+      "week": {
+        "suggestion": "I'll help you get on top of your week",
+        "prompt": "Help me get on top of my week."
+      },
+      "draft": {
+        "suggestion": "I'll draft something from a few rough notes",
+        "prompt": "Draft something from a few rough notes I'll give you."
+      }
+    }
+  },
+  "letsChatReadyStep": {
+    "title": "You’re all set",
+    "setupNote": "I’ve set myself up with plugins around who you are.",
+    "letsChat": "Let's chat"
   }
 }

--- a/clients/web/src/i18n/locales/es/onboarding.json
+++ b/clients/web/src/i18n/locales/es/onboarding.json
@@ -14,7 +14,10 @@
     "logIn": "Iniciar sesión",
     "logOut": "Cerrar sesión",
     "loginToUse": "Inicia sesión para usar",
-    "downloadMacApp": "Descargar la app de macOS"
+    "downloadMacApp": "Descargar la app de macOS",
+    "claim": "Reclamar",
+    "skipForNow": "Omitir por ahora",
+    "starting": "Empezando…"
   },
   "welcome": {
     "title": "Te damos la bienvenida a Vellum",
@@ -118,5 +121,160 @@
   },
   "googleCalendar": {
     "authorizationFailed": "No se pudo iniciar la autorización de Google Calendar."
+  },
+  "introductionScreen": {
+    "greetingNamed": "¡Hola, {name}!",
+    "greeting": "¡Hola!",
+    "introNamed": "Soy {name}, tu nuevo asistente de IA.",
+    "intro": "Soy tu nuevo asistente de IA."
+  },
+  "pitchStep": {
+    "setupLine": "Has usado IA que solo responde preguntas.",
+    "helpLine": "Cuanto más ayudo,",
+    "punchLine": "Yo soy distinto.",
+    "betterLine": "mejor me vuelvo,",
+    "lessLine": "y menos tienes que hacer tú."
+  },
+  "createPersonalityStep": {
+    "title": "Crea mi personalidad",
+    "lockedBody": "Personalidad bloqueada, habla con tu asistente para hacer más cambios",
+    "axisAriaLabel": "De {left} a {right}",
+    "axes": {
+      "companionCoworker": {
+        "left": "Compañero",
+        "right": "Colega"
+      },
+      "genzBoomer": {
+        "left": "Gen Z",
+        "right": "Baby Boomer"
+      },
+      "executeCollaborate": {
+        "left": "Independiente",
+        "right": "Colaborativo"
+      },
+      "playfulSerious": {
+        "left": "Juguetón",
+        "right": "Serio"
+      },
+      "politeUnfiltered": {
+        "left": "Educado",
+        "right": "Sin filtro"
+      }
+    }
+  },
+  "giveMeAFaceScreen": {
+    "title": "Dame una cara y un nombre",
+    "previousCharacter": "Personaje anterior",
+    "nextCharacter": "Personaje siguiente",
+    "namePlaceholder": "Ponle nombre a tu asistente",
+    "nameAriaLabel": "Nombre del asistente",
+    "editName": "Editar nombre",
+    "shuffle": "Cambiar nombre y apariencia",
+    "hearVoice": "Escuchar mi voz",
+    "stopVoice": "Detener la muestra de voz"
+  },
+  "integrationStep": {
+    "title": "Aquí tienes algunos créditos gratis<br></br> para empezar."
+  },
+  "researchOnboardingScreen": {
+    "title": "Empecemos por ti.",
+    "body": "Unos detalles para que pueda conocerte.",
+    "firstNameLabel": "¿Cómo debería llamarte?",
+    "firstNamePlaceholder": "Tu nombre",
+    "lastNameLabel": "¿Y tu apellido?",
+    "lastNamePlaceholder": "Tu apellido (opcional)",
+    "roleLabel": "Tu rol",
+    "rolePlaceholder": "¿A qué te dedicas?",
+    "hobbiesLabel": "¿Algún hobby?",
+    "hobbiesPlaceholder": "Coches, libros, cultivar tomates?"
+  },
+  "letsChatTomorrowStep": {
+    "wakingTitle": "Despertando",
+    "missingScopeTitle": "Acceso no activado",
+    "title": "Déjame facilitártelo",
+    "wakingBody": "Tu asistente se está preparando",
+    "missingScopeBody": "Marca la casilla junto al permiso de Google Calendar para que pueda reservar el check-in.",
+    "body": "Conecta tu Google Calendar para que pueda encontrar un momento para hacer el check-in y empezar a ayudar.",
+    "startingAssistant": "Arrancando el asistente…",
+    "waitingAuthorization": "Esperando la autorización…",
+    "connectCalendar": "Conectar calendario →"
+  },
+  "existingAssistantStep": {
+    "titleNamed": "{name} ya está en marcha",
+    "title": "Tu asistente ya está en marcha",
+    "bodyNamed": "Los dos tenéis historia: una personalidad, recuerdos y conversaciones pasadas. Volver a hacer la configuración sobrescribiría quién es {name} ahora.",
+    "body": "Los dos tenéis historia: una personalidad, recuerdos y conversaciones pasadas. Volver a hacer la configuración sobrescribiría quién es tu asistente ahora.",
+    "keepNamed": "Conservar a {name} y empezar a chatear",
+    "keep": "Conservar a tu asistente y empezar a chatear",
+    "redoNamed": "Empezar de cero y reconstruir la personalidad de {name}",
+    "redo": "Empezar de cero y reconstruir su personalidad"
+  },
+  "checkinConnectScreen": {
+    "title": "Hablemos mañana",
+    "body": "Añade una reunión en tu calendario para retomar donde lo dejamos.",
+    "permissionBody": "{name} añadirá un único evento de check-in del día 2. Obtiene permiso para gestionar los eventos de tu calendario y ver tu dirección de correo, no tu bandeja de entrada ni tus archivos, y puedes desconectarlo en cualquier momento.",
+    "unnamedAssistant": "tu asistente",
+    "waitingAuthorization": "Esperando la autorización...",
+    "connectGoogleCalendar": "Conectar Google Calendar"
+  },
+  "meetingCreatedStep": {
+    "titleWithTime": "¡Check-in programado para mañana a las {time}!",
+    "title": "¡Check-in programado!"
+  },
+  "lookingYouUpStep": {
+    "searching": "Buscando en la web para conocerte…",
+    "readingProfiles": "Leyendo perfiles públicos…",
+    "skimming": "Repasando lo más destacado…",
+    "connectingDots": "Conectando los puntos…",
+    "piecing": "Ensamblando las piezas…",
+    "almostThere": "Casi listo…"
+  },
+  "finishingUpStep": {
+    "updatingPersonality": "Actualizando mi personalidad…",
+    "findingVoice": "Encontrando mi voz…",
+    "gettingIntoCharacter": "Entrando en personaje…",
+    "almostThere": "Casi listo…"
+  },
+  "researchResultsStep": {
+    "title": "Esto es lo que he encontrado sobre ti",
+    "bodyLoadingWithClaims": "Todavía estoy revisando el resto. Puedes ir mirando lo que va llegando.",
+    "bodyReadyWithClaims": "He buscado en la web. Siéntete libre de quitar cualquier cosa que no sea cierta.",
+    "bodyLoadingEmpty": "Todavía lo estoy armando…",
+    "bodyReadyEmpty": "No he encontrado mucho, lo iremos completando al chatear.",
+    "removeClaim": "Quitar «{claim}»",
+    "notMe": "Esto no soy yo",
+    "stillSearching": "Todavía buscando…"
+  },
+  "suggestionsStep": {
+    "title": "Esto es lo que podríamos hacer primero",
+    "pickOne": "Elige una para empezar, o empieza con lo tuyo. <skip>Ir al chat</skip>",
+    "loading": "Preparando algunas ideas…",
+    "alreadySetUp": "Ya he configurado {count, plural, one {el plugin} other {los plugins}} <plugins></plugins> para ayudarte con tu trabajo",
+    "listAnd": " y ",
+    "listCommaAnd": " y ",
+    "listComma": ", ",
+    "fallbacks": {
+      "brief": {
+        "suggestion": "Prepararé un resumen rápido de lo nuevo en tu campo",
+        "prompt": "Dame un resumen rápido de lo nuevo en mi campo ahora mismo."
+      },
+      "weekly": {
+        "suggestion": "Te enviaré un briefing semanal de noticias de tu ámbito",
+        "prompt": "Configura un briefing semanal de noticias de mi ámbito."
+      },
+      "week": {
+        "suggestion": "Te ayudaré a ponerte al día con tu semana",
+        "prompt": "Ayúdame a ponerme al día con mi semana."
+      },
+      "draft": {
+        "suggestion": "Redactaré algo a partir de unas notas sueltas",
+        "prompt": "Redacta algo a partir de unas notas sueltas que te daré."
+      }
+    }
+  },
+  "letsChatReadyStep": {
+    "title": "Ya está todo listo",
+    "setupNote": "Me he configurado con plugins según quién eres.",
+    "letsChat": "Hablemos"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Finishes the onboarding domain cutover that #40616 started. Moves the research-onboarding `screens/` subtree onto the existing `onboarding` namespace and widens the i18n ratchet from the three converted globs to `src/domains/onboarding/**`.

## Scope

Ten screen modules (plus shared result-step UI): introduction, pitch, personality, face/name, free credits, research form, calendar check-in, existing-assistant guard, check-in connect, and the post-research sequence (meeting created, looking you up, finishing up, results, suggestions, let's chat).

## Notes for review

- **Axis labels** use greppable per-axis key literals (same pattern as `PHASE_KEY` in the hatching screen) so `catalogs.test.ts` orphan detection still works.
- **Named vs unnamed** assistant copy on the existing-assistant guard is two full sentences each, not a assembled possessive, so Spanish can place the name correctly.
- **Inline markup**: credits title (`<br>`), suggestions "Skip to Chat", and the plugin setup line stay as one catalog entry with `<Trans>`.
- **Em dashes** in user-facing strings that this pass touched are normalized (colon/comma) per AGENTS.md.
- **"Google Calendar"** under the icon stays a brand-name escape.

## Verification

- `bun run lint` — 0 errors, 16 warnings (unchanged baseline)
- `bunx tsc --noEmit` clean
- `bun test` on screen tests + `catalogs.test.ts` — 80 pass
- `bun run build` emits the Spanish onboarding chunk

## What is left (from #40616 inventory)

`settings` (1585), `chat` (1066), `components` (463), `intelligence` (177), and a tail of ~23 in `hooks`/`utils`/`lib`. Onboarding is now fully under the ratchet.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7f2993b-c41a-4c7d-8427-a880d12f5a8a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7f2993b-c41a-4c7d-8427-a880d12f5a8a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

