### PR TITLE
test: make consumed-grant expiry sweep assertion meaningful

### DIFF
--- a/assistant/src/__tests__/scoped-approval-grants.test.ts
+++ b/assistant/src/__tests__/scoped-approval-grants.test.ts
@@ -375,19 +375,24 @@ describe("scoped-approval-grants / expiry", () => {
   });
 
   test("already-consumed grants are not affected by expiry sweep", () => {
-    const _pastExpiry = Date.now() - 1_000;
+    const expiresAt = Date.now() + 60_000;
     createScopedApprovalGrant(
       grantParams({
         scopeMode: "request_id",
         requestId: "req-consumed",
-        expiresAt: Date.now() + 60_000,
+        expiresAt,
       }),
     );
-    consumeScopedApprovalGrantByRequestId("req-consumed", "c1");
+    const consumed = consumeScopedApprovalGrantByRequestId(
+      "req-consumed",
+      "c1",
+      expiresAt - 1,
+    );
+    expect(consumed.ok).toBe(true);
 
-    // Force the expiry time to the past for the consumed grant (simulating time passing)
-    // The sweep should not touch consumed grants
-    const count = expireScopedApprovalGrants();
+    // Sweep after the grant's expiresAt. Status is consumed, so the active-only
+    // expiry update must leave it alone.
+    const count = expireScopedApprovalGrants(expiresAt);
     expect(count).toBe(0);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Fixes a vacuous expiry-sweep test in `scoped-approval-grants.test.ts`.
- The unused `_pastExpiry` left the sweep at wall-clock while the grant still had a future `expiresAt`, so the case never proved consumed grants are skipped.
- Consume first, then sweep with `now` past `expiresAt`.

## Test plan

- [x] `cd assistant && bun test src/__tests__/scoped-approval-grants.test.ts --grep "already-consumed|expireScopedApprovalGrants transitions"`

Also using this PR to validate Cloud Agent GitHub authorship after reconnecting the Cursor GitHub App (expect `cursor[bot]` / App identity rather than a personal account).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51320280-4e9d-4d86-bae2-6d626c880f48?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51320280-4e9d-4d86-bae2-6d626c880f48&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

