### PR TITLE
fix(hooks): resolve default and user-plugin hooks at dispatch, not only at boot

### DIFF
--- a/assistant/src/__tests__/worker-hook-registry-guard.test.ts
+++ b/assistant/src/__tests__/worker-hook-registry-guard.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Guard test: hook dispatch is self-populating
+ *
+ * The standalone memory jobs worker (`plugins/defaults/memory/worker.ts`) and
+ * the schedule worker (`schedule/worker.ts`) host real agent conversations —
+ * retrospective and consolidation passes, scheduled runs, plus any subagents
+ * they spawn — and those turns run the same `agent/loop.ts` hook chain the
+ * daemon does. Neither process runs plugin bootstrap, so a dispatch that
+ * required prior registration would resolve against an empty registry and
+ * silently skip every hook: no `tool-result-truncate` on oversized results, no
+ * `tool-error` retry coaching, no `empty-response` re-query, no
+ * `conversation-deleted` cleanup.
+ *
+ * The contract pinned here is that a worker needs no registration call at all —
+ * the first read of a hook name populates from all three sources (first-party
+ * defaults, discovered user plugins, standalone workspace hooks). This is the
+ * hook-registry analogue of `memory-worker-tool-registry-guard.test.ts`, which
+ * pins the same property for the tool registry.
+ *
+ * The load-bearing half is the second test: populating must be REGISTRATION,
+ * never ACTIVATION. Running plugin `init` in a worker would run daemon-owned
+ * lifecycle in the wrong process — and for `default-memory` specifically,
+ * `init` calls `runMemoryStartup`, which starts the memory jobs worker, so the
+ * memory worker would try to spawn a memory worker from inside itself.
+ */
+
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { getHookEntriesFor } from "../hooks/registry.js";
+import { resetPluginCacheForTests } from "../plugins/mtime-cache.js";
+import { resetPluginRegistryForTests } from "../plugins/registry.js";
+import {
+  getWorkspaceHooksDir,
+  getWorkspacePluginsDir,
+} from "../util/platform.js";
+
+const pluginsRoot = getWorkspacePluginsDir();
+const workspaceHooksDir = getWorkspaceHooksDir();
+
+/** Marker the fixture plugin's `init` writes if it is ever run. */
+const initMarker = join(pluginsRoot, "init-ran.marker");
+
+const PASSTHROUGH_HOOK = "export default function (ctx) { return ctx; }\n";
+
+/**
+ * Fixture user plugin carrying a `post-tool-use` hook and an `init` that
+ * writes {@link initMarker} — so "was this plugin activated?" is observable.
+ */
+function writeFixturePlugin(name: string): string {
+  const dir = join(pluginsRoot, name);
+  mkdirSync(join(dir, "hooks"), { recursive: true });
+  writeFileSync(
+    join(dir, "package.json"),
+    JSON.stringify({ name, version: "1.0.0" }),
+  );
+  writeFileSync(join(dir, "hooks", "post-tool-use.ts"), PASSTHROUGH_HOOK);
+  writeFileSync(
+    join(dir, "hooks", "init.ts"),
+    `import { writeFileSync } from "node:fs";\n` +
+      `export default function () { writeFileSync(${JSON.stringify(initMarker)}, "ran"); }\n`,
+  );
+  return dir;
+}
+
+/** Owner ids for a hook name, in chain order. */
+async function ownersFor(hookName: string): Promise<string[]> {
+  const entries = await getHookEntriesFor(hookName);
+  return entries.map((e) => e.owner.id);
+}
+
+/**
+ * Drop every registration the process has accumulated, so the next dispatch
+ * starts from the same empty state a freshly booted worker does.
+ */
+function simulateFreshWorkerProcess(): void {
+  resetPluginRegistryForTests();
+  resetPluginCacheForTests();
+}
+
+beforeEach(() => {
+  rmSync(pluginsRoot, { recursive: true, force: true });
+  rmSync(workspaceHooksDir, { recursive: true, force: true });
+  mkdirSync(pluginsRoot, { recursive: true });
+  simulateFreshWorkerProcess();
+});
+
+afterEach(() => {
+  rmSync(pluginsRoot, { recursive: true, force: true });
+  rmSync(workspaceHooksDir, { recursive: true, force: true });
+  simulateFreshWorkerProcess();
+});
+
+describe("hook dispatch in a worker process", () => {
+  test("registers the first-party defaults with no bootstrap call", async () => {
+    const owners = await ownersFor("post-tool-use");
+
+    // The specific defaults a background pass depends on. Named individually
+    // rather than by count so a plugin that stops contributing the hook fails
+    // here instead of being masked by a new one arriving.
+    expect(owners).toContain("default-tool-result-truncate");
+    expect(owners).toContain("default-tool-error");
+
+    // `conversation-deleted` fires from the shared delete primitives, which the
+    // memory retrospective drives in-process when it GCs its own forks.
+    expect(await ownersFor("conversation-deleted")).toContain("default-memory");
+  });
+
+  test("discovers user plugins without running their init", async () => {
+    writeFixturePlugin("fixture-worker-plugin");
+
+    expect(await ownersFor("post-tool-use")).toContain("fixture-worker-plugin");
+
+    // The whole point of the split: discovery populated the plugin set and the
+    // hook resolved from disk, but no plugin lifecycle ran in this process.
+    expect(existsSync(initMarker)).toBe(false);
+  });
+
+  test("chains defaults, then user plugins, then workspace hooks", async () => {
+    writeFixturePlugin("fixture-order-plugin");
+    mkdirSync(workspaceHooksDir, { recursive: true });
+    writeFileSync(
+      join(workspaceHooksDir, "post-tool-use.ts"),
+      PASSTHROUGH_HOOK,
+    );
+
+    const owners = await ownersFor("post-tool-use");
+    const pluginIdx = owners.indexOf("fixture-order-plugin");
+    const workspaceIdx = owners.length - 1;
+    const lastDefaultIdx = owners.reduce(
+      (acc, id, i) => (id.startsWith("default-") ? i : acc),
+      -1,
+    );
+
+    expect(lastDefaultIdx).toBeGreaterThanOrEqual(0);
+    expect(pluginIdx).toBeGreaterThan(lastDefaultIdx);
+    expect(workspaceIdx).toBeGreaterThan(pluginIdx);
+  });
+
+  test("skips a user plugin carrying the .disabled sentinel", async () => {
+    const dir = writeFixturePlugin("fixture-disabled-plugin");
+    writeFileSync(join(dir, ".disabled"), "");
+
+    expect(await ownersFor("post-tool-use")).not.toContain(
+      "fixture-disabled-plugin",
+    );
+    expect(existsSync(initMarker)).toBe(false);
+  });
+});

--- a/assistant/src/hooks/registry.ts
+++ b/assistant/src/hooks/registry.ts
@@ -8,18 +8,25 @@
  * User-land hooks (from the filesystem) are owned by
  * {@link ./hook-loader.ts} and surfaced through `getUserHooksFor` in
  * `plugins/mtime-cache.ts`. This module owns only the in-process hooks that
- * default plugins register at boot.
+ * default plugins register.
  *
  * {@link getHooksFor} combines both sources: in-process hooks from this
  * registry (filtered by `isPluginDisabled` at read time) and user-land hooks
  * from the plugin cache. The read-time filtering is what makes `assistant
  * plugins disable default-*` take effect immediately in a running assistant
  * — the hooks stay registered but are filtered out on the next turn.
+ *
+ * Reads are self-populating: a dispatch in a process that never ran plugin
+ * bootstrap registers the defaults on its first read
+ * ({@link ensureDefaultHooksRegistered}), so the sidecar workers that host
+ * agent conversations run the same hook chain the daemon does without an
+ * entry-point registration call. Registration only — `init` stays daemon-only.
  */
 
 import { isPluginDisabled } from "../plugins/disabled-state.js";
 import { getUserHookEntriesFor } from "../plugins/mtime-cache.js";
 import type { HookEntry, HookFunction } from "../plugins/types.js";
+import { getLogger } from "../util/logger.js";
 
 // ─── Internal state ──────────────────────────────────────────────────────────
 
@@ -31,6 +38,74 @@ const hookRegistry = new Map<
   string,
   Array<{ fn: HookFunction; pluginName: string }>
 >();
+
+/**
+ * Whether anything has registered hooks into this process's registry. Set by
+ * {@link registerPluginHooks}, so it is true as soon as a real bootstrap (or a
+ * test fixture) has claimed ownership — see
+ * {@link ensureDefaultHooksRegistered}.
+ */
+let hasRegisteredHooks = false;
+
+/**
+ * Memoized lazy registration of the first-party defaults — see
+ * {@link ensureDefaultHooksRegistered}. `null` until the first read asks for
+ * it; afterwards the settled promise is returned without repeating the work.
+ */
+let defaultRegistrationPromise: Promise<void> | null = null;
+
+/**
+ * Populate the registry with the first-party defaults when nothing else has.
+ *
+ * The rule is "whoever registered first owns the registry". A process that
+ * runs plugin bootstrap (the daemon, via `initializePlugins()`) has already
+ * registered the defaults before it ever dispatches, so this is a no-op there.
+ * A process that does NOT run bootstrap gets them here, on its first dispatch:
+ * the memory jobs worker and the schedule worker both host real agent
+ * conversations, and those turns run the same `agent/loop.ts` hook chain, so
+ * without this their dispatches resolve against an empty registry and silently
+ * skip every default.
+ *
+ * Gating on {@link hasRegisteredHooks} rather than populating unconditionally
+ * is what keeps the registry controllable: a caller that has deliberately
+ * registered a specific set (every hook test that drives `runHook` over one
+ * fixture plugin) still sees exactly that set, instead of having eighteen
+ * defaults appear underneath it.
+ *
+ * Registration is NOT activation. This only inserts each default's hook
+ * functions into the map; it never runs `init`, which must stay confined to
+ * the daemon (see `plugins/mtime-cache.ts`). Running `init` here would be
+ * actively harmful — `default-memory`'s `init` calls `runMemoryStartup`, which
+ * starts the memory jobs worker, so the memory worker would try to spawn a
+ * memory worker from inside itself.
+ *
+ * Imported dynamically so the default plugins' implementation graph stays out
+ * of this module's static imports, and out of module evaluation — this runs at
+ * hook-dispatch, well after boot, and the module cache makes repeat calls free.
+ *
+ * Never rejects. A failure here must not take down the turn that happened to
+ * be the first dispatcher, so it is logged and the latch is cleared for a
+ * later retry; that dispatch proceeds with whatever is registered.
+ */
+function ensureDefaultHooksRegistered(): Promise<void> {
+  if (hasRegisteredHooks) {
+    return Promise.resolve();
+  }
+  if (defaultRegistrationPromise === null) {
+    defaultRegistrationPromise = (async () => {
+      const { registerDefaultPlugins } =
+        await import("../plugins/defaults/index.js");
+      registerDefaultPlugins();
+    })().catch((err: unknown) => {
+      defaultRegistrationPromise = null;
+      getLogger("hook-registry").error(
+        { err },
+        "Failed to register default plugin hooks; dispatch continues without them",
+      );
+    });
+  }
+  return defaultRegistrationPromise;
+}
 
 // ─── Registration ────────────────────────────────────────────────────────────
 
@@ -48,6 +123,9 @@ export function registerPluginHooks(
     if (typeof fn !== "function") {
       continue;
     }
+    // Someone is populating the registry explicitly, so the lazy default
+    // registration must stand down — see `ensureDefaultHooksRegistered`.
+    hasRegisteredHooks = true;
     let list = hookRegistry.get(hookName);
     if (!list) {
       list = [];
@@ -103,6 +181,10 @@ export async function getHookEntriesFor<TCtx = unknown>(
   name: string,
   options?: { conversationId?: string },
 ): Promise<HookEntry<TCtx>[]> {
+  // Make sure the defaults are in the map before reading it. In the daemon
+  // they already are (boot registered them); in a sidecar worker this first
+  // read is what puts them there. Registration only — never activation.
+  await ensureDefaultHooksRegistered();
   // Resolve the per-chat scope through a lazy import: a static import of the
   // daemon resolver would add `hooks/ → daemon/conversation-tool-setup` to the
   // module-init graph and perturb the capability-seed init order. Importing at
@@ -178,4 +260,10 @@ export function resetHookRegistryForTests(): void {
     );
   }
   hookRegistry.clear();
+  // Drop the lazy-registration state too, so a reset genuinely returns the
+  // process to "nobody owns this registry": a test that resets and dispatches
+  // without registering anything gets the defaults, and one that resets and
+  // registers its own fixtures keeps seeing only those.
+  hasRegisteredHooks = false;
+  defaultRegistrationPromise = null;
 }

--- a/assistant/src/plugins/mtime-cache.ts
+++ b/assistant/src/plugins/mtime-cache.ts
@@ -213,12 +213,17 @@ let reconcileInFlight: Promise<void> | null = null;
  * workspace hooks, from the hook loader's in-memory cache. Plugin hooks run
  * in install-date order, the workspace hook runs last.
  *
- * This is a pure cache read: it never scans disk, activates a plugin, or
- * runs `init`. Activation happens only at boot ({@link populateCacheAtBoot})
- * and through the imperative install/uninstall poke
- * ({@link reconcilePluginSourcesNow}) — both main-daemon paths — so a
- * sidecar process that dispatches hooks (a worker running conversation
- * turns) can never bring a plugin up in its own process.
+ * This read never activates a plugin or runs `init`. Activation happens only
+ * at boot ({@link populateCacheAtBoot}) and through the imperative
+ * install/uninstall poke ({@link reconcilePluginSourcesNow}) — both
+ * main-daemon paths — so a sidecar process that dispatches hooks (a worker
+ * running conversation turns) can never bring a plugin up in its own process.
+ *
+ * It does ensure the plugin set is *discovered* first
+ * ({@link ensureUserPluginsDiscovered}), which is what lets those same sidecar
+ * processes resolve user-plugin hooks at all. That walk is memoized per
+ * process and is a no-op in the daemon, so this stays a map read in the steady
+ * state.
  *
  * `effectiveEnabledPlugins` carries the per-chat plugin scope: when non-null,
  * user plugins outside the set are skipped (standalone workspace hooks always
@@ -228,6 +233,7 @@ export async function getUserHookEntriesFor<TCtx = unknown>(
   hookName: string,
   effectiveEnabledPlugins?: Set<string> | null,
 ): Promise<HookEntry<TCtx>[]> {
+  await ensureUserPluginsDiscovered();
   return collectUserHookEntries<TCtx>(
     hookName,
     discoveredPluginDirs.values(),
@@ -285,6 +291,10 @@ export async function reconcilePluginSourcesNow(): Promise<void> {
   reconcileInFlight = (async () => {
     try {
       await applySourceVersions(collectSourceVersions());
+      // This apply is authoritative for the discovered set, so settle the
+      // lazy-discovery latch against it rather than leaving a stale walk (or
+      // an un-run one) to fight it on the next dispatch.
+      discoveryPromise = Promise.resolve();
     } catch (err) {
       log.error({ err }, "imperative plugin reconcile failed");
     }
@@ -713,6 +723,156 @@ export function getActiveUserPluginTools(): Map<string, ActivePluginTools> {
 // ─── Plugin discovery ────────────────────────────────────────────────────────
 
 /**
+ * What a directory under the plugins root turns out to be. Deciding this is
+ * read-only — a few `stat`s and a manifest parse — which is what lets the
+ * discovery-only walk ({@link ensureUserPluginsDiscovered}) and the full scan
+ * ({@link scanPlugins}) share it without the former inheriting the latter's
+ * eviction and activation side effects.
+ */
+type PluginDirClassification =
+  | { kind: "skip" }
+  | { kind: "disabled"; pluginName: string }
+  | {
+      kind: "active";
+      pluginName: string;
+      credentialKeyPatterns?: PluginCredentialKeyPattern[];
+    };
+
+/**
+ * Classify one directory under the plugins root: not a plugin, disabled via
+ * the `.disabled` sentinel, or an active plugin (with its manifest name and
+ * declared credential key patterns).
+ *
+ * Read-only by construction — it mutates no module state and runs no plugin
+ * code. Callers own whatever their result implies.
+ */
+async function classifyPluginDir(
+  pluginDir: string,
+  pluginsDir: string,
+  entry: string,
+): Promise<PluginDirClassification> {
+  try {
+    if (!statSync(pluginDir).isDirectory()) {
+      return { kind: "skip" };
+    }
+  } catch {
+    return { kind: "skip" };
+  }
+  // Judge the entry by where it resolves. A symlinked plugin root pointing
+  // out of the plugins directory is not an install, and activating one at
+  // boot would run code that enumeration and the reload path both refuse to
+  // touch.
+  if (!isInsidePluginRoot(pluginDir, pluginsDir)) {
+    log.warn(
+      { pluginDir },
+      "plugin root resolves outside the plugins directory, skipping",
+    );
+    return { kind: "skip" };
+  }
+  if (!existsSync(join(pluginDir, "package.json"))) {
+    return { kind: "skip" };
+  }
+
+  // A plugin is disabled when a file named `.disabled` exists inside its
+  // plugin directory. Disabled plugins contribute nothing — no hooks, no
+  // tools, no cache entries.
+  if (existsSync(join(pluginDir, ".disabled"))) {
+    const manifest = await parsePluginManifest(pluginDir);
+    return { kind: "disabled", pluginName: manifest?.name ?? entry };
+  }
+
+  const manifest = await parsePluginManifest(pluginDir);
+  if (manifest === undefined) {
+    return { kind: "skip" };
+  }
+  return {
+    kind: "active",
+    pluginName: manifest.name,
+    credentialKeyPatterns: manifest.credentialKeyPatterns,
+  };
+}
+
+/**
+ * Memoized discovery-only walk — see {@link ensureUserPluginsDiscovered}.
+ * `null` until the first caller needs it; `populateCacheAtBoot` settles it so
+ * the daemon never runs the lazy walk on top of its own scan.
+ */
+let discoveryPromise: Promise<void> | null = null;
+
+/**
+ * Populate {@link discoveredPluginDirs} if no full scan has done so already.
+ *
+ * Discovery answers only "which plugin directories exist, in what order" — a
+ * readdir, a few `stat`s, and a manifest parse per entry. That is all a hook
+ * dispatch needs: {@link collectUserHookEntries} resolves each
+ * `(plugin, hookName)` from disk on demand, so with the set populated a
+ * sidecar worker resolves user-plugin hooks the same way the daemon does.
+ *
+ * Deliberately NOT activation. It registers no tools, evicts nothing, and
+ * runs no `init` — those stay owned by the boot scan and the imperative poke,
+ * both daemon-only, so a worker can never bring a plugin up in its own
+ * process against daemon-owned plugin storage.
+ *
+ * Memoized per process, so the walk is paid once rather than per dispatch. In
+ * the daemon it never runs at all: `populateCacheAtBoot` settles the latch,
+ * and runtime plugin changes reach the cache through
+ * {@link reconcilePluginSourcesNow}, which re-arms it. A sidecar worker sees
+ * no such poke, so it holds the plugin set it discovered on first dispatch
+ * until it restarts — a worker is torn down with the daemon, and the daemon
+ * restarts on plugin install, so the staleness window is bounded.
+ *
+ * Never rejects: a discovery failure must not fail the turn that happened to
+ * dispatch first.
+ */
+export function ensureUserPluginsDiscovered(): Promise<void> {
+  if (discoveryPromise === null) {
+    discoveryPromise = discoverPluginDirs().catch((err: unknown) => {
+      discoveryPromise = null;
+      log.error(
+        { err },
+        "user-plugin discovery failed; hook dispatch continues without user plugins",
+      );
+    });
+  }
+  return discoveryPromise;
+}
+
+/**
+ * The discovery-only walk itself: classify every entry under the plugins root
+ * and record the active ones, in install-date order. Writes
+ * {@link discoveredPluginDirs} and nothing else.
+ */
+async function discoverPluginDirs(): Promise<void> {
+  const pluginsDir = getWorkspacePluginsDir();
+  if (!existsSync(pluginsDir)) {
+    return;
+  }
+  let entries: string[];
+  try {
+    entries = readdirSync(pluginsDir);
+  } catch {
+    log.warn(
+      { pluginsDir },
+      "discoverPluginDirs: failed to read plugins directory",
+    );
+    return;
+  }
+
+  for (const entry of entries) {
+    const pluginDir = join(pluginsDir, entry);
+    const classification = await classifyPluginDir(
+      pluginDir,
+      pluginsDir,
+      entry,
+    );
+    if (classification.kind === "active") {
+      discoveredPluginDirs.set(pluginDir, classification.pluginName);
+    }
+  }
+  sortDiscoveredPluginDirs();
+}
+
+/**
  * Scan the plugins directory, update the discovered set, and reconcile
  * tools for each plugin. Also evicts cache entries for deleted plugins.
  *
@@ -748,35 +908,20 @@ async function scanPlugins(): Promise<void> {
 
   for (const entry of entries) {
     const pluginDir = join(pluginsDir, entry);
-    try {
-      if (!statSync(pluginDir).isDirectory()) {
-        continue;
-      }
-    } catch {
-      continue;
-    }
-    // Judge the entry by where it resolves. A symlinked plugin root pointing
-    // out of the plugins directory is not an install, and activating one at
-    // boot would run code that enumeration and the reload path both refuse to
-    // touch.
-    if (!isInsidePluginRoot(pluginDir, pluginsDir)) {
-      log.warn(
-        { pluginDir },
-        "plugin root resolves outside the plugins directory, skipping",
-      );
-      continue;
-    }
-    if (!existsSync(join(pluginDir, "package.json"))) {
+    const classification = await classifyPluginDir(
+      pluginDir,
+      pluginsDir,
+      entry,
+    );
+
+    if (classification.kind === "skip") {
       continue;
     }
 
-    // Check for the .disabled sentinel. A plugin is disabled when a file
-    // named `.disabled` exists inside its plugin directory. Disabled
-    // plugins are skipped entirely — no hooks, no tools, no cache entries.
-    // If the plugin was previously active, its cache entries are evicted.
-    if (existsSync(join(pluginDir, ".disabled"))) {
-      const manifest = await parsePluginManifest(pluginDir);
-      const pluginName = manifest?.name ?? entry;
+    // Disabled plugins are skipped entirely. If the plugin was previously
+    // active, its cache entries are evicted.
+    if (classification.kind === "disabled") {
+      const { pluginName } = classification;
       if (discoveredPluginDirs.has(pluginDir)) {
         await deactivatePlugin(pluginName, "disable");
         await evictPlugin(pluginDir, pluginName);
@@ -791,14 +936,13 @@ async function scanPlugins(): Promise<void> {
       continue;
     }
 
-    const manifest = await parsePluginManifest(pluginDir);
-    if (manifest === undefined) {
-      continue;
-    }
-    const { name: pluginName } = manifest;
+    const { pluginName } = classification;
 
     currentDirs.set(pluginDir, pluginName);
-    credentialPatternsByDir.set(pluginDir, manifest.credentialKeyPatterns);
+    credentialPatternsByDir.set(
+      pluginDir,
+      classification.credentialKeyPatterns,
+    );
     disabledPluginDirs.delete(pluginDir);
 
     if (!discoveredPluginDirs.has(pluginDir)) {
@@ -922,10 +1066,10 @@ const activatedPlugins: Array<{ kind: HookOwnerKind; name: string }> = [];
 
 /**
  * Names in {@link activatedPlugins}, kept as a set for O(1) membership and —
- * critically — reserved *synchronously* at the top of `activatePlugin`. The
- * per-turn hook dispatch reaches `scanPlugins` on every turn (sometimes
- * concurrently), so the synchronous reservation is what prevents a second scan
- * from double-activating a plugin while its async `init()` is still in flight.
+ * critically — reserved *synchronously* at the top of `activatePlugin`. Two
+ * activation paths can overlap (the boot scan and an install poke, or two
+ * concurrent pokes), so the synchronous reservation is what prevents one from
+ * double-activating a plugin while the other's async `init()` is in flight.
  */
 const activatedNames = new Set<string>();
 
@@ -939,8 +1083,8 @@ const activatedNames = new Set<string>();
  * failures are logged and the plugin still counts as activated so the shutdown
  * teardown handles whatever came up (mirrors boot semantics).
  *
- * Called from `scanPlugins`, which runs both at boot and on every subsequent
- * scan — so a plugin whose files appear at runtime (installed via the CLI or
+ * Called from `scanPlugins` at boot and from the imperative install/uninstall
+ * poke — so a plugin whose files appear at runtime (installed via the CLI or
  * provisioned out-of-band) becomes live without a daemon restart.
  */
 async function activatePlugin(
@@ -1093,6 +1237,11 @@ export async function populateCacheAtBoot(
   // Scans + activates every discovered plugin (tools registered + `init` run).
   await scanPlugins();
 
+  // The boot scan has populated `discoveredPluginDirs` authoritatively, so
+  // settle the lazy-discovery latch: in the daemon the discovery-only walk
+  // must never run on top of this.
+  discoveryPromise = Promise.resolve();
+
   // Activate standalone workspace hooks under `<workspace>/hooks/`. These
   // carry no package.json, no tools, and no install-date ordering — just hook
   // files. Running their `init` hook resolves the workspace `init`/`shutdown`,
@@ -1133,6 +1282,10 @@ export function resetPluginCacheForTests(): void {
   disabledPluginDirs.clear();
   lastVersions = {};
   reconcileInFlight = null;
+  // Re-arm lazy discovery alongside the set it populates, so a test that
+  // clears the caches and then dispatches rediscovers instead of reading an
+  // empty map behind a settled promise.
+  discoveryPromise = null;
 }
 
 /**

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -1055,11 +1055,12 @@ export function getAllToolDefinitions(): Tool[] {
  * without repeating it, so it is safe to call from multiple entry points or
  * lazily on demand.
  *
- * This is the tool-registry analogue of the hook registry's
- * `maybeReconcileFromSentinel()` — the lazy "make sure the registry is
- * populated" step. As the registry read getters migrate to async (mirroring
- * `getHooksFor`), they will `await` this before reading the map, so a read can
- * no longer observe an un-initialized registry.
+ * This is the tool-registry analogue of the hook registry's lazy "make sure
+ * the registry is populated" step (`ensureDefaultHooksRegistered` in
+ * `hooks/registry.ts`, plus `ensureUserPluginsDiscovered` in
+ * `plugins/mtime-cache.ts`). As the registry read getters migrate to async
+ * (mirroring `getHooksFor`), they will `await` this before reading the map, so
+ * a read can no longer observe an un-initialized registry.
  */
 export function initializeTools(): Promise<void> {
   if (!toolsInitPromise) {


### PR DESCRIPTION
## Prompt / plan

Started as a question: is it true that default hooks aren't registered during memory retrospective jobs? It is, and the cause is broader than retrospectives.

`registerDefaultPlugins()` is reachable only from `daemon/lifecycle.ts` → `initializePlugins()`. Memory jobs never run there — `jobs-worker.ts` spawns the standalone memory worker as "the sole drainer of the memory job queue", and `worker.ts` says outright that it does not run plugin bootstrap. `schedule/worker.ts` is in the same position, as is the CLI's `memory retrospective run`, which calls `runForkBasedRetrospective` in-process.

Those processes host real agent conversations and run the same `agent/loop.ts` hook chain, so `pre-model-call`, `post-model-call`, `post-tool-use`, `post-compact`, `stop`, and `conversation-deleted` all resolved to nothing. Concretely, in a retrospective: no `tool-result-truncate` on oversized tool output, no `tool-error` retry coaching when a `remember` fails, no `empty-response` re-query (which interacts directly with the `requireUsableOutput` path), and no `conversation-deleted` cleanup when the run GCs its own forks.

Standalone workspace hooks (`<workspace>/hooks/*`) were the exception — `hook-loader.ts` already resolves those from disk per `(owner, hookName)` on demand. The fix extends that same on-demand model to the other two sources, so a worker needs no registration call:

- **`ensureDefaultHooksRegistered`** (`hooks/registry.ts`) registers the first-party defaults on the first read, gated on nothing else having registered hooks. Whoever registers first owns the registry: the daemon's boot registration wins, and a caller that deliberately registers a specific set still sees exactly that set rather than eighteen defaults appearing underneath it.
- **`ensureUserPluginsDiscovered`** (`plugins/mtime-cache.ts`) splits discovery out of the full scan — a readdir, a stat, and a manifest parse populate `discoveredPluginDirs` so `collectUserHookEntries` can resolve each hook from disk. Memoized per process, and settled by both `populateCacheAtBoot` and `reconcilePluginSourcesNow` so the daemon never runs it.
- **`classifyPluginDir`** is extracted so the discovery-only walk and the full scan share one read-only judgement of what a directory under the plugins root is.

Registration and discovery are deliberately **not** activation. Plugin `init` stays confined to the daemon: `default-memory`'s `init` calls `runMemoryStartup`, which starts the memory jobs worker — so a worker that ran `init` would try to spawn a memory worker from inside itself (`jobs-worker.ts` warns about exactly this recursion). The guard test pins that hooks resolve with `init` never running.

Also drops three comments describing a per-dispatch scan the code no longer does, including a reference to a `maybeReconcileFromSentinel()` that `git log -S` shows never existed in the tree.

## Test plan

- New `src/__tests__/worker-hook-registry-guard.test.ts` (4 tests), the hook-registry sibling of `memory-worker-tool-registry-guard.test.ts`: dispatch registers the defaults with no bootstrap call; a user plugin's hook resolves while its `init` never runs; the chain orders defaults → user plugins → workspace; a `.disabled` plugin contributes nothing.
- Verified out-of-band against a worker-parity process (importing exactly what `worker.ts` imports at startup) in a real workspace. Before: `post-tool-use` → `0 (none)`. After: the five defaults, then the user plugin, then the workspace hook — with the `init` marker file absent.
- Full `bun run test`: the same 7 files fail before and after this change (82 pass / 19 fail on both), all environment-related in this container — network-dependent proxy tests, the sandbox-escape timeouts, and a read-only-workspace test that can't fail as root. No test file regressed.
- `tsc --noEmit`, `eslint`, and `prettier --check` clean.

**One thing to flag:** `lint:circular` goes from 195 to 303 cycles. All 115 new chains run through the one new edge, `hooks/registry.ts → plugins/defaults/index.ts`. It is a dynamic `import()`, so there is no module-initialization cycle at runtime — madge counts dynamic imports in its static graph (it already counts this file's existing dynamic import of `conversation-plugin-scope`). I checked whether splitting the plugin definitions out of `defaults/index.ts` would help: it wouldn't, because the return paths run through the hook implementations themselves (`memory/hooks/conversation-deleted.ts` alone accounts for 41), not through `plugins/registry.ts`. Any dispatch-time population of compiled-in defaults pulls that graph in, since the dispatch site sits low and the implementations sit high. `lint:circular` is not wired into CI and already exits non-zero on `main`, so this doesn't newly break anything — but it is a real move in a number the team tracks, and the alternative is a one-line import in each of the two worker entrypoints instead. Happy to switch if you'd rather hold the line there.

## CLI verb checklist

No new routes.

---
_Generated by [Claude Code](https://claude.ai/code/session_012oPddLMb8oGByXXywemCCK)_