### PR TITLE
fix(web): gate conversation queries on pod health so a waking assistant recovers

### DIFF
--- a/clients/web/eslint.config.mjs
+++ b/clients/web/eslint.config.mjs
@@ -193,6 +193,7 @@ const i18nEnforcedPaths = [
   "src/components/not-found.tsx",
   "src/domains/chat/components/conversation-assets-pill.tsx",
   "src/domains/chat/components/pinned-app-color-swatches.tsx",
+  "src/domains/chat/components/sidebar-conversation-error.tsx",
   "src/domains/schedules/**/*.{ts,tsx}",
   "src/domains/account/**/*.{ts,tsx}",
   "src/domains/channels/**/*.{ts,tsx}",

--- a/clients/web/src/assistant/operational-status.test.tsx
+++ b/clients/web/src/assistant/operational-status.test.tsx
@@ -69,7 +69,12 @@ mock.module("@/hooks/use-is-org-ready", () => ({
 }));
 
 import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
-import { useAssistantOperationalStatus } from "@/assistant/operational-status";
+import {
+  isServingOperationalStatus,
+  useAssistantIsServing,
+  useAssistantOperationalStatus,
+} from "@/assistant/operational-status";
+import type { OperationalStatus } from "@/generated/api/types.gen";
 import { useAuthStore } from "@/stores/auth-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 
@@ -285,5 +290,120 @@ describe("useAssistantOperationalStatus", () => {
     await settleQueries();
 
     expect(recordLifecycleDiagnosticMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * The gate that decides whether daemon queries may run.
+ *
+ * "Not known to be down" rather than "healthy" is the question, because
+ * operational status is a platform-only signal and is absent for every
+ * assistant whose health lives somewhere else. A gate that read absence as
+ * "down" would strand them behind a signal that never arrives.
+ */
+describe("isServingOperationalStatus", () => {
+  function status(state: string): OperationalStatus {
+    return { state } as OperationalStatus;
+  }
+
+  test("opens when the pod is active", () => {
+    expect(isServingOperationalStatus(status("active"))).toBe(true);
+  });
+
+  test("closes while the pod is waking", () => {
+    // The case this exists for: the daemon 503s every request through the wake
+    // window while the assistant record still reads `active`.
+    expect(isServingOperationalStatus(status("waking"))).toBe(false);
+  });
+
+  test("closes for every other non-serving state", () => {
+    for (const state of [
+      "sleeping",
+      "initializing",
+      "provisioning",
+      "migrating",
+      "restarting",
+      "crash_loop",
+      "unreachable",
+      "not_found",
+    ]) {
+      expect(isServingOperationalStatus(status(state))).toBe(false);
+    }
+  });
+
+  test("opens when status is absent", () => {
+    // `null` is a local/self-hosted assistant, a non-`full` platform gate, or a
+    // 403/404. `undefined` is the window before the first poll resolves.
+    // Closing on either would block assistants that never report here at all,
+    // and would put the status poll in front of every cold load.
+    expect(isServingOperationalStatus(null)).toBe(true);
+    expect(isServingOperationalStatus(undefined)).toBe(true);
+  });
+});
+
+describe("useAssistantIsServing", () => {
+  test("is open for a local assistant, which never reports status", async () => {
+    setLifecycle({ kind: "active", isLocal: true });
+
+    const { result } = renderHook(
+      () => useAssistantIsServing("assistant-local"),
+      { wrapper },
+    );
+    await settleQueries();
+
+    expect(sdkMock).not.toHaveBeenCalled();
+    expect(result.current).toBe(true);
+  });
+
+  test("closes while a platform-hosted pod is waking", async () => {
+    setLifecycle({ kind: "active", isLocal: false });
+    sdkMock.mockImplementation(async () => ({
+      data: { state: "waking", detail_state: "pod_pending" },
+      error: undefined,
+      response: new Response(null, { status: 200 }),
+    }));
+
+    const { result } = renderHook(
+      () => useAssistantIsServing("assistant-waking"),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current).toBe(false);
+    });
+  });
+
+  test("reopens when the pod finishes waking", async () => {
+    // The recovery edge. A list query gated on this is refetched by TanStack
+    // Query when the flag flips back to true, which is what carries a sidebar
+    // out of a failed load once the pod comes up.
+    setLifecycle({ kind: "active", isLocal: false });
+    let podState = "waking";
+    sdkMock.mockImplementation(async () => ({
+      data: { state: podState, detail_state: "", poll_after_ms: 1000 },
+      error: undefined,
+      response: new Response(null, { status: 200 }),
+    }));
+
+    const { result } = renderHook(
+      () => useAssistantIsServing("assistant-recovering"),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current).toBe(false);
+    });
+
+    podState = "active";
+
+    // Generous relative to the 1s floor on the poll interval, so the reopen
+    // has room to land on a slow machine rather than racing the default 1s
+    // `waitFor` budget.
+    await waitFor(
+      () => {
+        expect(result.current).toBe(true);
+      },
+      { timeout: 5000 },
+    );
   });
 });

--- a/clients/web/src/assistant/operational-status.test.tsx
+++ b/clients/web/src/assistant/operational-status.test.tsx
@@ -316,19 +316,39 @@ describe("isServingOperationalStatus", () => {
     expect(isServingOperationalStatus(status("waking"))).toBe(false);
   });
 
-  test("closes for every other non-serving state", () => {
+  test("closes for every state where the daemon cannot answer", () => {
     for (const state of [
       "sleeping",
       "initializing",
       "provisioning",
       "migrating",
       "restarting",
+      "restoring_backup",
+      "upgrading_assistant_version",
+      "resizing_machine",
+      "resizing_storage",
+      "maintenance_mode",
       "crash_loop",
-      "unreachable",
       "not_found",
+      "retiring",
     ]) {
       expect(isServingOperationalStatus(status(state))).toBe(false);
     }
+  });
+
+  test("stays open when the control plane cannot reach the pod", () => {
+    // `unreachable` is the control plane failing to confirm reachability, not
+    // evidence the pod is down. Paired with a live SSE connection it is this
+    // module's split-brain fingerprint: daemon requests succeed while the
+    // status pipeline cannot see the pod. Closing here would blank the sidebar
+    // of an assistant that is answering perfectly well.
+    expect(isServingOperationalStatus(status("unreachable"))).toBe(true);
+  });
+
+  test("stays open for a state this client's schema predates", () => {
+    // `state` is an open string on the wire. A platform that adds one must not
+    // silently lock every client below it out of its own conversations.
+    expect(isServingOperationalStatus(status("some_future_state"))).toBe(true);
   });
 
   test("opens when status is absent", () => {

--- a/clients/web/src/assistant/operational-status.ts
+++ b/clients/web/src/assistant/operational-status.ts
@@ -196,3 +196,46 @@ export function isHealthyOperationalStatus(
 ): boolean {
   return status?.state === "active";
 }
+
+/**
+ * Whether data-plane requests to this assistant's daemon should be allowed to
+ * run: either the pod is serving, or its health is not knowable from here.
+ *
+ * The distinction the caller needs is not "healthy" but "not known to be
+ * down". Operational status is a platform-only signal: it is `null` for local
+ * and self-hosted assistants, for an org whose platform gate is not `"full"`,
+ * and for any 403/404, and it is `undefined` until the first poll resolves.
+ * Treating any of those as "not serving" would strand every assistant whose
+ * health lives somewhere else (`LocalAssistantHealth`, maintained by the
+ * lifecycle service's heartbeat probes) behind a signal that will never
+ * arrive. So absence opens the gate and only a present, non-`active` status
+ * closes it.
+ *
+ * `state: "waking"` is the case this exists for. The daemon 503s every request
+ * while the pod warms, and the assistant record stays `status: "active"`
+ * throughout, so nothing in {@link AssistantState} can express the difference.
+ */
+export function isServingOperationalStatus(
+  status: OperationalStatus | null | undefined,
+): boolean {
+  if (status === null || status === undefined) {
+    return true;
+  }
+  return isHealthyOperationalStatus(status);
+}
+
+/**
+ * Gate for queries against the assistant's daemon, true when the pod is
+ * serving or its health is unknowable. See
+ * {@link isServingOperationalStatus} for why absence opens the gate.
+ *
+ * Pass this into a query's `enabled` rather than checking it before a manual
+ * fetch. A query gated this way stops issuing requests into a wake window
+ * (where they 503 and burn the retry budget), and TanStack Query refetches it
+ * when the flag flips back to true, which is the edge that carries a sidebar
+ * out of a failed load once the pod comes up.
+ */
+export function useAssistantIsServing(assistantId: string | null): boolean {
+  const { data: status } = useAssistantOperationalStatus(assistantId);
+  return isServingOperationalStatus(status);
+}

--- a/clients/web/src/assistant/operational-status.ts
+++ b/clients/web/src/assistant/operational-status.ts
@@ -198,6 +198,42 @@ export function isHealthyOperationalStatus(
 }
 
 /**
+ * Whether the daemon can serve requests in each operational state.
+ *
+ * Exhaustive over the generated enum, so a state added to the platform schema
+ * is a compile error here rather than picking up a silent default. Which way a
+ * new state goes is a real decision, and the two mistakes are not symmetric:
+ * wrongly closing the gate blanks a working assistant's sidebar until the
+ * control plane changes its mind, while wrongly opening it costs one failed
+ * request that surfaces with a retry.
+ *
+ * `unreachable` is open deliberately. It means the control plane could not
+ * confirm reachability, which is absence of knowledge rather than evidence the
+ * pod is down. `unreachable` while SSE is connected is this module's
+ * documented split-brain fingerprint: the pod's events are flowing and its
+ * requests succeed while the status pipeline cannot see it (see
+ * {@link recordOperationalStatusTransition}).
+ */
+const DAEMON_SERVES_IN_STATE: Record<OperationalStatusStateEnum, boolean> = {
+  active: true,
+  unreachable: true,
+  waking: false,
+  sleeping: false,
+  initializing: false,
+  provisioning: false,
+  migrating: false,
+  restarting: false,
+  restoring_backup: false,
+  upgrading_assistant_version: false,
+  resizing_machine: false,
+  resizing_storage: false,
+  maintenance_mode: false,
+  crash_loop: false,
+  not_found: false,
+  retiring: false,
+};
+
+/**
  * Whether data-plane requests to this assistant's daemon should be allowed to
  * run: either the pod is serving, or its health is not knowable from here.
  *
@@ -208,8 +244,8 @@ export function isHealthyOperationalStatus(
  * Treating any of those as "not serving" would strand every assistant whose
  * health lives somewhere else (`LocalAssistantHealth`, maintained by the
  * lifecycle service's heartbeat probes) behind a signal that will never
- * arrive. So absence opens the gate and only a present, non-`active` status
- * closes it.
+ * arrive. So absence opens the gate, and so does a state that carries no
+ * verdict; only a state that means the daemon cannot answer closes it.
  *
  * `state: "waking"` is the case this exists for. The daemon 503s every request
  * while the pod warms, and the assistant record stays `status: "active"`
@@ -221,7 +257,9 @@ export function isServingOperationalStatus(
   if (status === null || status === undefined) {
     return true;
   }
-  return isHealthyOperationalStatus(status);
+  // `state` is an open string on the wire, so a value this client's schema
+  // predates lands here as `undefined` and opens the gate.
+  return DAEMON_SERVES_IN_STATE[status.state] ?? true;
 }
 
 /**

--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -206,8 +206,17 @@ export function ChatLayout({
   // is gated on `isAssistantActive`, and a gated query is pending without
   // fetching, which would leave the sidebar under placeholders for as long as
   // the assistant took to come up (or forever, if it never did).
-  const { conversations, isLoading: isLoadingConversations } =
-    useConversationListQuery(assistantId, isAssistantActive);
+  //
+  // `isAssistantActive` is the assistant record: does this assistant exist and
+  // is it provisioned. Whether its pod is reachable is a separate question,
+  // answered inside the query hook itself, since these keys are shared with
+  // call sites that pass no gate of their own.
+  const {
+    conversations,
+    isLoading: isLoadingConversations,
+    isError: conversationsFailed,
+    refetch: retryConversations,
+  } = useConversationListQuery(assistantId, isAssistantActive);
   const { conversationGroups } = useConversationGroupsQuery(
     assistantId,
     isAssistantActive,
@@ -908,6 +917,8 @@ export function ChatLayout({
       onWidthChange={args.onWidthChange}
       conversations={conversations}
       isLoadingConversations={isLoadingConversations}
+      conversationsFailed={conversationsFailed}
+      onRetryConversations={retryConversations}
       conversationGroups={conversationGroups}
       activeConversationId={sidebarActiveConversationId}
       processingConversationIds={processingConversationIds}

--- a/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -106,6 +106,18 @@ mock.module(
   }),
 );
 
+// Each section gates its fetch on the pod being reachable, which polls
+// operational status through React Query; stub it so static SSR rendering
+// resolves without a QueryClient. Open, because these tests are about what the
+// sidebar draws from the rows it is handed, not about the gate. The gate's own
+// behavior is covered in `assistant/operational-status.test.tsx`.
+mock.module(
+  "@/assistant/operational-status",
+  (): Partial<typeof OperationalStatus> => ({
+    useAssistantIsServing: () => true,
+  }),
+);
+
 // The assistant nav item reads the avatar through React Query; stub it so
 // static SSR rendering resolves without a QueryClient.
 mock.module("@/hooks/use-assistant-avatar", () => ({
@@ -119,6 +131,7 @@ mock.module("@/hooks/use-assistant-avatar", () => ({
 }));
 
 import type * as ConversationQueries from "@/hooks/conversation-queries";
+import type * as OperationalStatus from "@/assistant/operational-status";
 import type {
   Conversation,
   ConversationGroup,
@@ -162,6 +175,8 @@ function renderMenu(props: {
   includeFooterAction?: boolean;
   includeTipCard?: boolean;
   isLoadingConversations?: boolean;
+  conversationsFailed?: boolean;
+  onRetryConversations?: () => void;
   onWidthChange?: (width: number) => void;
 }): string {
   setSectionRows(props.conversations);
@@ -173,6 +188,8 @@ function renderMenu(props: {
       variant: props.variant ?? "rail",
       conversations: props.conversations,
       isLoadingConversations: props.isLoadingConversations,
+      conversationsFailed: props.conversationsFailed,
+      onRetryConversations: props.onRetryConversations,
       conversationGroups: props.conversationGroups,
       activeConversationId: props.activeConversationId,
       width: props.onWidthChange ? 280 : undefined,
@@ -1748,5 +1765,76 @@ describe("AssistantSideMenu · conversation list loading state", () => {
 
     expect(html).not.toContain(SKELETON);
     expect(html).toContain(">Recent thread<");
+  });
+});
+
+/**
+ * A conversation list that failed before it ever loaded renders the same empty
+ * scrollport as an assistant with no conversations: every section derives from
+ * this list, and an empty section is dropped from the sidebar. These assert
+ * the failure stays visible as a failure, and that it never displaces rows the
+ * sidebar already holds.
+ */
+describe("AssistantSideMenu · conversation list failure state", () => {
+  const ERROR = 'data-slot="sidebar-conversation-error"';
+  const SKELETON = 'data-slot="sidebar-conversation-skeleton"';
+
+  test("draws the failure instead of an empty section tree", () => {
+    const html = renderMenu({
+      conversations: [],
+      conversationsFailed: true,
+    });
+
+    expect(html).toContain(ERROR);
+    // The empty tree is what this stands in for, so it must not render too.
+    expect(html).not.toContain(">Chats<");
+  });
+
+  test("offers a retry when one is wired", () => {
+    const html = renderMenu({
+      conversations: [],
+      conversationsFailed: true,
+      onRetryConversations: () => {},
+    });
+
+    expect(html).toContain("Try again");
+  });
+
+  test("draws no failure once an empty list has loaded", () => {
+    // The sensitivity check: an assistant with genuinely no conversations must
+    // not be told its list failed.
+    const html = renderMenu({
+      conversations: [],
+      conversationsFailed: false,
+    });
+
+    expect(html).not.toContain(ERROR);
+  });
+
+  test("keeps live rows when a refetch fails", () => {
+    // React Query holds the last successful data through a failed refetch, so
+    // those rows are still the real list and must beat the failure state.
+    const html = renderMenu({
+      conversations: [
+        makeConversation({ conversationId: "r1", title: "Recent thread" }),
+      ],
+      conversationsFailed: true,
+    });
+
+    expect(html).not.toContain(ERROR);
+    expect(html).toContain(">Recent thread<");
+  });
+
+  test("prefers the failure over placeholders when both are set", () => {
+    // A retry puts the query back in flight while it still holds the previous
+    // failure. Reverting to placeholders would re-hide that the list failed.
+    const html = renderMenu({
+      conversations: [],
+      conversationsFailed: true,
+      isLoadingConversations: true,
+    });
+
+    expect(html).toContain(ERROR);
+    expect(html).not.toContain(SKELETON);
   });
 });

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -25,6 +25,7 @@ import { SidebarSectionItem } from "@/domains/chat/components/sidebar-section-it
 import { SideMenuBuiltInNav } from "@/domains/chat/components/side-menu-built-in-nav";
 import { SideMenuOverlayBottomColumn } from "@/domains/chat/components/side-menu-overlay-bottom-column";
 import { SidebarBackToTop } from "@/domains/chat/components/sidebar-back-to-top";
+import { SidebarConversationError } from "@/domains/chat/components/sidebar-conversation-error";
 import { SidebarConversationSkeleton } from "@/domains/chat/components/sidebar-conversation-skeleton";
 import { useSectionDragReorder } from "@/domains/chat/hooks/use-section-drag-reorder";
 import { useScrolledPast } from "@/domains/chat/hooks/use-scrolled-past";
@@ -48,6 +49,17 @@ export interface AssistantSideMenuProps extends UseSidebarStateParams {
    * populated sidebar never replaces live rows with placeholders.
    */
   isLoadingConversations?: boolean;
+  /**
+   * The conversation list failed before it ever loaded. Draws the failure and
+   * a retry instead of the (empty) section tree, so a load that did not happen
+   * does not read as an assistant with no conversations. Like
+   * {@link AssistantSideMenuProps.isLoadingConversations}, only consulted
+   * while `conversations` is empty: a failed refetch over a populated sidebar
+   * still holds the real rows and keeps drawing them.
+   */
+  conversationsFailed?: boolean;
+  /** Refetch the conversation list. Omit to draw the failure without a retry. */
+  onRetryConversations?: () => void;
   collapsed: boolean;
   variant: "rail" | "overlay";
   width?: number;
@@ -172,6 +184,8 @@ function SearchButton() {
  */
 export function AssistantSideMenu({
   isLoadingConversations,
+  conversationsFailed,
+  onRetryConversations,
   assistantId,
   assistantName,
   collapsed,
@@ -222,11 +236,14 @@ export function AssistantSideMenu({
   /* Mirrors `SideMenu`'s own condition for mounting the resize handle. */
   const isResizable = variant === "rail" && !collapsed && onWidthChange != null;
 
-  /* Gated on an empty list, not on the loading flag alone: a refetch over a
+  /* Both gated on an empty list, not on their flag alone: a refetch over a
      populated sidebar keeps drawing the rows it already has rather than
-     blanking them back to placeholders. */
+     blanking them back to placeholders or to a failure. */
+  const hasNoConversations = conversations.length === 0;
   const showConversationSkeleton =
-    isLoadingConversations === true && conversations.length === 0;
+    isLoadingConversations === true && hasNoConversations;
+  const showConversationError =
+    conversationsFailed === true && hasNoConversations;
 
   // --- Overlay bottom reserve ---
   // The overlay's floating bottom column (tip card + action pills) covers the
@@ -507,6 +524,8 @@ export function AssistantSideMenu({
               processingConversationIds={processingConversationIds}
               attentionConversationIds={attentionConversationIds}
             />
+          ) : showConversationError ? (
+            <SidebarConversationError onRetry={onRetryConversations} />
           ) : showConversationSkeleton ? (
             <SidebarConversationSkeleton />
           ) : (

--- a/clients/web/src/domains/chat/components/sidebar-conversation-error.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-conversation-error.tsx
@@ -16,7 +16,15 @@
 
 import { Button } from "@vellumai/design-library";
 
-export function SidebarConversationError({ onRetry }: { onRetry?: () => void }) {
+import { useTranslation } from "@/i18n";
+
+export function SidebarConversationError({
+  onRetry,
+}: {
+  onRetry?: () => void;
+}) {
+  const { t } = useTranslation("chat");
+
   return (
     <div
       className="flex flex-col items-start gap-2 px-1.5 py-2"
@@ -24,11 +32,11 @@ export function SidebarConversationError({ onRetry }: { onRetry?: () => void }) 
       role="status"
     >
       <p className="text-muted-foreground text-xs">
-        Your conversations didn't load. They're still here.
+        {t("sidebarConversationError.message")}
       </p>
       {onRetry ? (
         <Button variant="ghost" size="compact" onClick={onRetry}>
-          Try again
+          {t("sidebarConversationError.retry")}
         </Button>
       ) : null}
     </div>

--- a/clients/web/src/domains/chat/components/sidebar-conversation-error.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-conversation-error.tsx
@@ -1,0 +1,36 @@
+/**
+ * Shown in place of the section tree when the sidebar's conversation list
+ * failed before it ever loaded.
+ *
+ * An empty section is dropped from the sidebar, and every section falls back
+ * to rows derived from this same list, so a failed first load renders as a
+ * sidebar with nothing in it at all. That is indistinguishable from an
+ * assistant whose conversations have been deleted, which is how users read it.
+ * This says the list did not load and offers the retry, so the failure stays a
+ * failure.
+ *
+ * Only for the never-loaded case. React Query keeps the last successful data
+ * when a later refetch fails, and those rows are still the real list, so a
+ * failed refetch over a populated sidebar must keep drawing them.
+ */
+
+import { Button } from "@vellumai/design-library";
+
+export function SidebarConversationError({ onRetry }: { onRetry?: () => void }) {
+  return (
+    <div
+      className="flex flex-col items-start gap-2 px-1.5 py-2"
+      data-slot="sidebar-conversation-error"
+      role="status"
+    >
+      <p className="text-muted-foreground text-xs">
+        Your conversations didn't load. They're still here.
+      </p>
+      {onRetry ? (
+        <Button variant="ghost" size="compact" onClick={onRetry}>
+          Try again
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/clients/web/src/hooks/conversation-queries-gating.test.tsx
+++ b/clients/web/src/hooks/conversation-queries-gating.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * The daemon preconditions shared by every query in `conversation-queries.ts`.
+ *
+ * These hooks share their query keys across many call sites, and TanStack
+ * Query fetches when any observer is enabled, so the gate only holds if it
+ * lives inside the hooks rather than at the call sites. That is what these
+ * cover: not whether the pod-health predicate is correct (see
+ * `assistant/operational-status.test.tsx`), but whether the hooks consult it
+ * at all, and whether a call site passing `enabled: true` can defeat it.
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+
+const conversationsGetMock = mock(async () => ({
+  data: { conversations: [], hasMore: false },
+  error: undefined,
+  response: new Response(null, { status: 200 }),
+}));
+
+let podIsServing = true;
+let orgIsReady = true;
+
+/* Spread over the real module rather than replacing it: the generated SDK is a
+   single barrel that unrelated modules in this import graph also pull from, and
+   a bare object drops every export this file does not name. */
+const realDaemonSdk = await import("@/generated/daemon/sdk.gen");
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...realDaemonSdk,
+  conversationsGet: conversationsGetMock,
+}));
+
+mock.module("@/assistant/operational-status", () => ({
+  useAssistantIsServing: () => podIsServing,
+}));
+
+/* A completed drain posts to the telemetry ingest, which has no listener here
+   and surfaces as an unhandled ECONNREFUSED after the assertions. */
+mock.module("@/lib/telemetry/client-perf", () => ({
+  emitClientPerfEvent: () => {},
+}));
+
+mock.module("@/hooks/use-is-org-ready", () => ({
+  useIsOrgReady: () => orgIsReady,
+}));
+
+const { useConversationListQuery } = await import(
+  "@/hooks/conversation-queries"
+);
+
+const ASSISTANT_ID = "asst-1";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+async function settle() {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+beforeEach(() => {
+  conversationsGetMock.mockClear();
+  podIsServing = true;
+  orgIsReady = true;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("conversation queries · daemon gate", () => {
+  test("fetches when the pod is serving", async () => {
+    renderHook(() => useConversationListQuery(ASSISTANT_ID), { wrapper });
+
+    await waitFor(() => {
+      expect(conversationsGetMock).toHaveBeenCalled();
+    });
+  });
+
+  test("does not fetch while the pod is not serving", async () => {
+    // A waking pod 503s every request, and the list query has a bounded retry
+    // budget. Spending it inside the wake window leaves the query in a
+    // terminal error state that nothing clears, which renders as an assistant
+    // with no conversations.
+    podIsServing = false;
+
+    renderHook(() => useConversationListQuery(ASSISTANT_ID), { wrapper });
+    await settle();
+
+    expect(conversationsGetMock).not.toHaveBeenCalled();
+  });
+
+  test("a call site passing enabled cannot open the gate itself", async () => {
+    // Several call sites mount this query with a hardcoded `true`. Since every
+    // observer shares one query key, a gate applied at the call sites would be
+    // defeated by whichever mount passed no gate of its own.
+    podIsServing = false;
+
+    renderHook(() => useConversationListQuery(ASSISTANT_ID, true), { wrapper });
+    await settle();
+
+    expect(conversationsGetMock).not.toHaveBeenCalled();
+  });
+
+  test("fetches once a waking pod comes up", async () => {
+    // The recovery edge: flipping `enabled` back to true is what makes
+    // TanStack Query re-issue a fetch that was never allowed to run.
+    podIsServing = false;
+
+    const { rerender } = renderHook(
+      () => useConversationListQuery(ASSISTANT_ID),
+      { wrapper },
+    );
+    await settle();
+    expect(conversationsGetMock).not.toHaveBeenCalled();
+
+    podIsServing = true;
+    rerender();
+
+    await waitFor(() => {
+      expect(conversationsGetMock).toHaveBeenCalled();
+    });
+  });
+
+  test("still honors org readiness", async () => {
+    // The gate is an AND of both preconditions, so the pod being up must not
+    // let a request through before the org header is available.
+    orgIsReady = false;
+
+    renderHook(() => useConversationListQuery(ASSISTANT_ID), { wrapper });
+    await settle();
+
+    expect(conversationsGetMock).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/hooks/conversation-queries.ts
+++ b/clients/web/src/hooks/conversation-queries.ts
@@ -8,7 +8,7 @@
  *
  * Each hook spreads a `queryOptions` factory from
  * `utils/conversation-list-fetchers.ts` and adds runtime concerns
- * (`enabled` gating via `useIsOrgReady()`, `select` transforms). This
+ * (`enabled` gating via `useCanQueryDaemon()`, `select` transforms). This
  * co-locates `queryKey` + `queryFn` + `staleTime` in one place so they
  * can be reused across hooks, prefetches, and imperative cache reads.
  *
@@ -26,6 +26,7 @@ import { useQuery } from "@tanstack/react-query";
 import { groupsGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
 import type { Options } from "@/generated/daemon/sdk.gen";
 import type { GroupsGetData } from "@/generated/daemon/types.gen";
+import { useAssistantIsServing } from "@/assistant/operational-status";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import type {
   Conversation,
@@ -49,6 +50,28 @@ import type { SectionConversationFilter } from "@/utils/conversation-list-fetche
 // Stable empty references so consumers don't churn on `??` fallback.
 const EMPTY_CONVERSATIONS: Conversation[] = [];
 const EMPTY_GROUPS: ConversationGroup[] = [];
+
+/**
+ * The preconditions every daemon-backed query in this module shares: the org
+ * header the interceptor needs is available, and the assistant's pod is not
+ * known to be down.
+ *
+ * Applied inside each hook rather than asked of callers, because these queries
+ * share their query keys across many call sites and TanStack Query fetches
+ * when *any* observer is enabled. A precondition enforced at one call site is
+ * a precondition some other mount defeats, so the only place it holds is here.
+ *
+ * The pod half matters most while an assistant is waking: the daemon 503s
+ * every request through that window, and a list query that spends its retry
+ * budget there gives up for good. Gating instead of retrying also supplies the
+ * recovery edge, since TanStack Query refetches when `enabled` flips back to
+ * true. See {@link useAssistantIsServing}.
+ */
+function useCanQueryDaemon(assistantId: string | null): boolean {
+  const isOrgReady = useIsOrgReady();
+  const isServing = useAssistantIsServing(assistantId);
+  return isOrgReady && isServing;
+}
 
 /**
  * Subscribe to the foreground conversation list for the given assistant.
@@ -80,10 +103,10 @@ export function useConversationListQuery(
   error: Error | null;
   refetch: () => void;
 } {
-  const isOrgReady = useIsOrgReady();
+  const canQuery = useCanQueryDaemon(assistantId);
   const query = useQuery({
     ...conversationListOptions(assistantId!),
-    enabled: enabled && Boolean(assistantId) && isOrgReady,
+    enabled: enabled && Boolean(assistantId) && canQuery,
   });
   return {
     conversations: query.data ?? EMPTY_CONVERSATIONS,
@@ -118,10 +141,10 @@ export function useBackgroundConversationListQuery(
   isError: boolean;
   refetch: () => void;
 } {
-  const isOrgReady = useIsOrgReady();
+  const canQuery = useCanQueryDaemon(assistantId);
   const query = useQuery({
     ...backgroundConversationListOptions(assistantId!),
-    enabled: enabled && Boolean(assistantId) && isOrgReady,
+    enabled: enabled && Boolean(assistantId) && canQuery,
   });
   return {
     conversations: query.data ?? EMPTY_CONVERSATIONS,
@@ -156,10 +179,10 @@ export function useScheduledConversationListQuery(
   isError: boolean;
   refetch: () => void;
 } {
-  const isOrgReady = useIsOrgReady();
+  const canQuery = useCanQueryDaemon(assistantId);
   const query = useQuery({
     ...scheduledConversationListOptions(assistantId!),
-    enabled: enabled && Boolean(assistantId) && isOrgReady,
+    enabled: enabled && Boolean(assistantId) && canQuery,
   });
   return {
     conversations: query.data ?? EMPTY_CONVERSATIONS,
@@ -203,10 +226,10 @@ export function useSectionConversationListQuery(
   /** Whether the query has ever resolved; survives a failed refetch. */
   hasData: boolean;
 } {
-  const isOrgReady = useIsOrgReady();
+  const canQuery = useCanQueryDaemon(assistantId);
   const query = useQuery({
     ...sectionConversationListOptions(assistantId!, filter),
-    enabled: enabled && Boolean(assistantId) && isOrgReady,
+    enabled: enabled && Boolean(assistantId) && canQuery,
   });
   return {
     conversations: query.data ?? EMPTY_CONVERSATIONS,
@@ -239,10 +262,10 @@ export function useUnreadConversationCountQuery(
   assistantId: string | null,
   enabled: boolean = true,
 ): number | null {
-  const isOrgReady = useIsOrgReady();
+  const canQuery = useCanQueryDaemon(assistantId);
   const query = useQuery({
     ...unreadConversationCountOptions(assistantId!),
-    enabled: enabled && Boolean(assistantId) && isOrgReady,
+    enabled: enabled && Boolean(assistantId) && canQuery,
   });
   return query.data ?? null;
 }
@@ -297,10 +320,10 @@ export function useArchivedConversationListQuery(
   error: Error | null;
   refetch: () => void;
 } {
-  const isOrgReady = useIsOrgReady();
+  const canQuery = useCanQueryDaemon(assistantId);
   const query = useQuery({
     ...archivedConversationListOptions(assistantId!),
-    enabled: enabled && Boolean(assistantId) && isOrgReady,
+    enabled: enabled && Boolean(assistantId) && canQuery,
   });
   return {
     conversations: query.data ?? EMPTY_CONVERSATIONS,
@@ -321,13 +344,13 @@ export function useConversationGroupsQuery(
   assistantId: string | null,
   enabled: boolean = true,
 ): { conversationGroups: ConversationGroup[]; isLoading: boolean } {
-  const isOrgReady = useIsOrgReady();
+  const canQuery = useCanQueryDaemon(assistantId);
   const query = useQuery({
     ...groupsGetOptions({
       path: { assistant_id: assistantId ?? "" },
     } as Options<GroupsGetData>),
     select: (data) => data.groups,
-    enabled: enabled && Boolean(assistantId) && isOrgReady,
+    enabled: enabled && Boolean(assistantId) && canQuery,
     staleTime: 30_000,
   });
   return {

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -15,5 +15,9 @@
       "teal": "Teal",
       "yellow": "Yellow"
     }
+  },
+  "sidebarConversationError": {
+    "message": "Your conversations failed to load.",
+    "retry": "Try again"
   }
 }

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -15,5 +15,9 @@
       "teal": "Turquesa",
       "yellow": "Amarillo"
     }
+  },
+  "sidebarConversationError": {
+    "message": "No se pudieron cargar tus conversaciones.",
+    "retry": "Reintentar"
   }
 }


### PR DESCRIPTION
## Prompt / plan

From a support report: "My assistant was scanning my email, and now the entire thing seems to have died. My assistant and all chats are gone."

The attached feedback bundle showed no data loss. Timeline from the diagnostics rings:

| Time (UTC) | Event |
| --- | --- |
| 16:45:56, 16:46:56 | `app.hidden` x2 (Android Chrome backgrounded) |
| 16:47:10.459 | status poll: `state: waking`, `healthz_ok: false`, `sseConnected: false` |
| 16:47:10.9 to 16:47:18.9 | foreground conversation list: 4x HTTP 503, then silence |
| 16:48:05 | bundle collected, 47s later, no further attempts |

Those four attempts are spaced +0, +1.3s, +2.5s, +4.3s, which is `queryRetryDelay`'s 1s/2s/4s backoff against `MAX_RETRIES = 3`. The list query spent its whole retry budget inside the wake window and landed in a terminal error state. `detail_state: pod_pending_without_restart_history` means a cold start, not a crash or OOM, and conversations live in SQLite on the persistent workspace, so nothing was deleted. The email scan was incidental.

### Why it never recovered

Every path was closed. Focus refetch goes through the event bus's `app.resume`, and the lifecycle ring recorded two `app.hidden` and zero `app.resume`. SSE-driven invalidation needs a stream that was down. The `waking` to `active` transition was consumed only by `status-banner.tsx` and `runtime-upgrade-banner.tsx`; nothing invalidated the conversation caches. Only a hard reload cleared it.

### Why it rendered as total loss

`chat-layout.tsx` dropped `isError` (its one consumer, in `chat-page.tsx`, is gated on the `self_hosted` branch), so there was no error surface and no retry. Every section falls back to `section.all`, which derives from the same failed list, and an empty section is dropped from the sidebar entirely, taking Pinned, every custom group, and every channel section off both the sidebar and the rail. The "Assistant is waking" banner clears once the pod reports `active`, so the terminal state is a healthy-looking assistant with an empty sidebar and no explanation.

### Root cause

Two notions of assistant health existed and were never joined:

- `assistantState.kind === "active"` comes from `resolveAssistantLifecycleState`, which maps the platform *record* status. It stays `active` for a sleeping, waking, or crash-looping pod. This is what gated the requests.
- `OperationalStatus` (`state: "waking"`, `healthz_ok: false`) is the only signal that knows the pod is not serving, and it fed nothing that issues requests.

## Approach

Gate the daemon queries on pod health rather than lengthening the retry budget, which would only widen the race. The same change closes both halves of the bug: the queries stop firing into a wake window, and TanStack Query re-issues them when `enabled` flips back to true, which supplies the missing recovery edge.

- **`isServingOperationalStatus` / `useAssistantIsServing`** (`assistant/operational-status.ts`): true when the pod is serving *or its health is unknowable*. Operational status is platform-only: `null` for local and self-hosted assistants, for a non-`full` platform gate, and for any 403/404, and `undefined` until the first poll resolves. Absence opens the gate, so assistants whose health lives in `LocalAssistantHealth` are unaffected and the status poll never lands in front of a cold load.
- **The gate lives in `useCanQueryDaemon`** inside `conversation-queries.ts`, alongside the existing org-readiness precondition. It has to live there rather than at the call sites: these queries share query keys across many mounts, several of which pass a hardcoded `true` (`chat-route-content`, `command-palette-window-page`, `home-page-route`), and TanStack Query fetches when *any* observer is enabled, so a gate at one call site is defeated by another mount.
- **`SidebarConversationError`**: surfaces the failure with a retry for every assistant, not only self-hosted ones.

## Test plan

- `bun test src/hooks/conversation-queries-gating.test.tsx` (new, 5 tests) covers the wiring: no fetch while the pod is not serving, a call site passing `enabled: true` cannot open the gate itself, a fetch once the pod comes up (the recovery edge), and org-readiness still honored.
- `bun test src/assistant/operational-status.test.tsx` (+7) covers the predicate across `active` / `waking` / every other non-serving state / absent, plus the waking-to-active reopen through the live poll.
- `bun test src/domains/chat/components/assistant-side-menu.test.tsx` (+5) covers the failure state, its retry, and that it never displaces rows the sidebar already holds (React Query keeps last-successful data through a failed refetch).
- Ran every test file touching the gated hooks, isolated as CI runs them (19 files): all pass.
- `bunx tsc --noEmit` clean; `bun run lint` reports 0 errors (16 pre-existing warnings, none in touched files).

Not covered by tests: the end-to-end wake cycle against a real sleeping pod.

## Follow-up worth tracking separately

The bundle recorded two `app.hidden` exactly 60.05s apart with **no** `app.resume`, while the user was demonstrably interacting (they filed the report at 16:48). The recorder was live, since it captured both hidden events. If `app.resume` is unreliable on Android Chrome, focus refetch is disabled for *every* query in the app on that platform and this bug is just where it surfaced. Not actionable from a single bundle, and out of scope here.

## CLI verb checklist

No new IPC routes.

---
_Generated by [Claude Code](https://claude.ai/code/session_019Tm44hNKaZsKUXfGZZvyaS)_