### PR TITLE
feat(web): translate the intelligence domain

### DIFF
--- a/clients/web/eslint-rules/no-untranslated-strings.mjs
+++ b/clients/web/eslint-rules/no-untranslated-strings.mjs
@@ -54,6 +54,9 @@ const STRUCTURAL_PROPS = new Set([
   "fill",
   "fontFamily",
   "points",
+  // SVG fit mode (`xMidYMid meet`) has spaces + capitals, so it reads as
+  // copy to `looksLikeCopy` without this.
+  "preserveAspectRatio",
   "stroke",
   "transform",
   "viewBox",

--- a/clients/web/eslint.config.mjs
+++ b/clients/web/eslint.config.mjs
@@ -206,6 +206,7 @@ const i18nEnforcedPaths = [
   "src/domains/home/**/*.{ts,tsx}",
   "src/domains/contacts/**/*.{ts,tsx}",
   "src/domains/onboarding/**/*.{ts,tsx}",
+  "src/domains/intelligence/**/*.{ts,tsx}",
 ];
 
 const eslintConfig = defineConfig([

--- a/clients/web/src/domains/intelligence/components/assistant-name-editor.tsx
+++ b/clients/web/src/domains/intelligence/components/assistant-name-editor.tsx
@@ -13,6 +13,8 @@
 import { useEffect, useState } from "react";
 import { useReducedMotion } from "motion/react";
 
+import { useTranslation } from "@/i18n";
+
 const TYPEWRITER_INTERVAL_MS = 65;
 /** Override lines are longer and transient — type them snappier. */
 const OVERRIDE_TYPEWRITER_INTERVAL_MS = 26;
@@ -61,7 +63,8 @@ export function AssistantNameEditor({
   isRenaming,
   overrideText = null,
 }: AssistantNameEditorProps) {
-  const greeting = overrideText ?? `Hi, I’m ${name}`;
+  const { t } = useTranslation("intelligence");
+  const greeting = overrideText ?? t("assistantNameEditor.greeting", { name });
   const { typed, typing } = useTypewriter(
     greeting,
     overrideText ? OVERRIDE_TYPEWRITER_INTERVAL_MS : TYPEWRITER_INTERVAL_MS,
@@ -89,7 +92,7 @@ export function AssistantNameEditor({
       </h1>
       {!overrideText && isRenaming && (
         <div
-          aria-label="Renaming in progress"
+          aria-label={t("assistantNameEditor.renamingInProgressAriaLabel")}
           className="h-5 w-5 shrink-0 animate-spin rounded-full border-2 border-[var(--border-base)]"
           style={{ borderTopColor: "var(--content-default)" }}
         />

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-detail-panel.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-detail-panel.tsx
@@ -11,6 +11,7 @@ import { useEffect, useState } from "react";
 
 import { FileMarkdown } from "@/components/file-markdown";
 import { memoryGraphNodeOptions } from "@/domains/intelligence/memory-graph/get-memory-graph-node";
+import { useTranslation } from "@/i18n";
 import { Button } from "@vellumai/design-library";
 
 import { EDGE_LEARNED_COLOR } from "./constants";
@@ -106,6 +107,7 @@ function buildNotePreview(content: string): string {
  */
 function ConceptNote({ content }: { content: string }) {
   const [expanded, setExpanded] = useState(false);
+  const { t } = useTranslation("intelligence");
 
   if (content.length <= LONG_NOTE_THRESHOLD) {
     return <FileMarkdown content={content} />;
@@ -127,7 +129,9 @@ function ConceptNote({ content }: { content: string }) {
           )
         }
       >
-        {expanded ? "Show less" : "Read full note"}
+        {expanded
+          ? t("conceptDetailPanel.showLess")
+          : t("conceptDetailPanel.readFullNote")}
       </Button>
     </>
   );
@@ -150,6 +154,7 @@ export function ConceptDetailPanel({
   onClose,
   onOpenThread,
 }: ConceptDetailPanelProps) {
+  const { t } = useTranslation("intelligence");
   const query = useQuery(memoryGraphNodeOptions(assistantId, node.id));
   const detail = query.data;
   const updated = formatUpdated(node.updatedAtMs);
@@ -199,7 +204,7 @@ export function ConceptDetailPanel({
             jump back + re-center via onCrumb; the ‹ back control mirrors it. */}
         {trail.length > 1 ? (
           <nav
-            aria-label="Concept trail"
+            aria-label={t("conceptDetailPanel.trailAriaLabel")}
             className="flex shrink-0 items-center gap-1 overflow-hidden border-b px-5 py-2 text-body-small-default"
             style={{
               borderColor: "var(--border-base)",
@@ -209,7 +214,7 @@ export function ConceptDetailPanel({
             <button
               type="button"
               onClick={() => onCrumb(trail.length - 2)}
-              aria-label="Back"
+              aria-label={t("conceptDetailPanel.backAriaLabel")}
               className="-ml-1 mr-0.5 flex shrink-0 items-center rounded p-0.5 hover:bg-[color-mix(in_srgb,var(--content-tertiary)_14%,transparent)]"
               style={{ color: "var(--content-tertiary)" }}
             >
@@ -265,7 +270,7 @@ export function ConceptDetailPanel({
                 className="mt-0.5 text-body-small-default"
                 style={{ color: "var(--content-tertiary)" }}
               >
-                Updated {updated}
+                {t("conceptDetailPanel.updated", { date: updated })}
               </p>
             ) : null}
           </div>
@@ -273,7 +278,7 @@ export function ConceptDetailPanel({
             variant="ghost"
             iconOnly={<X aria-hidden />}
             onClick={onClose}
-            aria-label="Close"
+            aria-label={t("conceptDetailPanel.closeAriaLabel")}
             tintColor="var(--content-tertiary)"
           />
         </header>
@@ -297,7 +302,7 @@ export function ConceptDetailPanel({
               className="text-body-medium-lighter"
               style={{ color: "var(--content-tertiary)" }}
             >
-              Couldn't load this concept. Try again in a moment.
+              {t("conceptDetailPanel.loadError")}
             </p>
           ) : detail?.found && detail.content?.trim() ? (
             // Keyed by node id so travelling to a new concept remounts the note
@@ -308,8 +313,7 @@ export function ConceptDetailPanel({
               className="text-body-medium-lighter"
               style={{ color: "var(--content-tertiary)" }}
             >
-              This concept doesn't have written content yet — it exists as a
-              link in the graph, but its page is empty.
+              {t("conceptDetailPanel.emptyContent")}
             </p>
           )}
 
@@ -326,14 +330,15 @@ export function ConceptDetailPanel({
                   className="text-body-small-default uppercase tracking-wide"
                   style={{ color: "var(--content-tertiary)" }}
                 >
-                  Wired to
+                  {t("conceptDetailPanel.wiredTo")}
                 </h3>
                 <span
                   className="text-body-small-default tabular-nums"
                   style={{ color: "var(--content-tertiary)" }}
                 >
-                  {neighbors.length} connection
-                  {neighbors.length === 1 ? "" : "s"}
+                  {t("conceptDetailPanel.connectionCount", {
+                    count: neighbors.length,
+                  })}
                 </span>
               </div>
               <ul className="flex list-none flex-col gap-0.5">
@@ -377,12 +382,10 @@ export function ConceptDetailPanel({
               className="flex-1"
               leftIcon={<MessageCircle size={16} aria-hidden />}
               onClick={() =>
-                onOpenThread(
-                  `Tell me what you remember about "${title}" and how it connects to the rest of what you know.`,
-                )
+                onOpenThread(t("conceptDetailPanel.askPrompt", { title }))
               }
             >
-              Ask about this
+              {t("conceptDetailPanel.askAboutThis")}
             </Button>
             <Button
               variant="primary"
@@ -390,12 +393,10 @@ export function ConceptDetailPanel({
               className="flex-1"
               leftIcon={<Sparkles size={16} aria-hidden />}
               onClick={() =>
-                onOpenThread(
-                  `I want to refine what you remember about "${title}". Ask me what's off and we'll correct it together.`,
-                )
+                onOpenThread(t("conceptDetailPanel.refinePrompt", { title }))
               }
             >
-              Refine
+              {t("conceptDetailPanel.refine")}
             </Button>
           </footer>
         ) : null}

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-intro-banner.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-intro-banner.tsx
@@ -1,5 +1,6 @@
 import { Sparkles, X } from "lucide-react";
 
+import { useTranslation } from "@/i18n";
 import { Button } from "@vellumai/design-library";
 
 interface ConceptGraphIntroBannerProps {
@@ -18,6 +19,7 @@ interface ConceptGraphIntroBannerProps {
 export function ConceptGraphIntroBanner({
   onDismiss,
 }: ConceptGraphIntroBannerProps) {
+  const { t } = useTranslation("intelligence");
   return (
     <div
       data-graph-control
@@ -40,22 +42,20 @@ export function ConceptGraphIntroBanner({
           className="text-body-medium-emphasised"
           style={{ color: "var(--content-default)" }}
         >
-          This is your assistant's mind
+          {t("conceptGraphIntroBanner.title")}
         </p>
         <p
           className="mt-0.5 text-body-small-default"
           style={{ color: "var(--content-tertiary)" }}
         >
-          Every idea it learns — and the links it draws between them — shows up
-          here. The map grows and rearranges itself as you talk, so the more you
-          share, the richer it gets.
+          {t("conceptGraphIntroBanner.description")}
         </p>
       </div>
       <Button
         variant="ghost"
         iconOnly={<X aria-hidden />}
         onClick={onDismiss}
-        aria-label="Dismiss"
+        aria-label={t("conceptGraphIntroBanner.dismissAriaLabel")}
         tintColor="var(--content-tertiary)"
       />
     </div>

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-legend.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-legend.tsx
@@ -1,10 +1,12 @@
 import type { CSSProperties } from "react";
 
+import { useTranslation } from "@/i18n";
+
 import {
   EDGE_LEARNED_COLOR,
   EDGE_LINK_COLOR,
   NODE_KIND_COLORS,
-  NODE_KIND_LABELS,
+  nodeKindLabel,
 } from "./constants";
 import type { ConceptNodeKind } from "./types";
 
@@ -47,6 +49,7 @@ export function ConceptGraphLegend({
   linkActive,
   learnedActive,
 }: ConceptGraphLegendProps) {
+  const { t } = useTranslation("intelligence");
   return (
     <div
       data-graph-control
@@ -67,7 +70,7 @@ export function ConceptGraphLegend({
             className="text-[11px]"
             style={{ color: "var(--content-tertiary)" }}
           >
-            {NODE_KIND_LABELS[kind]}
+            {nodeKindLabel(kind)}
           </span>
         </div>
       ))}
@@ -94,7 +97,9 @@ export function ConceptGraphLegend({
                 className="text-[11px]"
                 style={{ color: "var(--content-tertiary)" }}
               >
-                +{themes.length - MAX_THEMES} more
+                {t("conceptGraphLegend.moreThemes", {
+                  count: themes.length - MAX_THEMES,
+                })}
               </span>
             )}
           </>
@@ -103,7 +108,7 @@ export function ConceptGraphLegend({
             className="text-[11px]"
             style={{ color: "var(--content-tertiary)" }}
           >
-            Colored by theme
+            {t("conceptGraphLegend.coloredByTheme")}
           </span>
         ))}
       {(nodeKinds.length > 0 || coloredByTheme) && (hasLinks || hasLearned) && (
@@ -115,7 +120,7 @@ export function ConceptGraphLegend({
       {hasLinks && (
         <EdgeLegendRow
           swatchStyle={{ borderTop: `2px solid ${EDGE_LINK_COLOR}` }}
-          label="Link"
+          label={t("conceptGraphLegend.link")}
           onToggle={onToggleLink}
           active={linkActive}
         />
@@ -123,7 +128,7 @@ export function ConceptGraphLegend({
       {hasLearned && (
         <EdgeLegendRow
           swatchStyle={{ borderTop: `2px dashed ${EDGE_LEARNED_COLOR}` }}
-          label="Learned"
+          label={t("conceptGraphLegend.learned")}
           onToggle={onToggleLearned}
           active={learnedActive}
         />

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
@@ -20,6 +20,7 @@ import {
 import { VIRTUAL_CENTER } from "@/domains/intelligence/components/constellation-view/constants";
 import { memoryGraphOptions } from "@/domains/intelligence/memory-graph/get-memory-graph";
 import { emitMemoryEvent } from "@/domains/intelligence/memory-telemetry";
+import { useTranslation } from "@/i18n";
 import { Button } from "@vellumai/design-library";
 
 import { buildForceLayout } from "./build-force-layout";
@@ -201,6 +202,7 @@ export function ConceptGraphView({
   headerAction,
   handleRef,
 }: ConceptGraphViewProps) {
+  const { t } = useTranslation("intelligence");
   const containerRef = useRef<HTMLDivElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
 
@@ -1386,8 +1388,8 @@ export function ConceptGraphView({
   } else if (query.isError) {
     body = (
       <CenteredMessage
-        title="Couldn't load the memory graph"
-        detail="Something went wrong fetching your assistant's memory. Try again in a moment."
+        title={t("conceptGraphView.loadErrorTitle")}
+        detail={t("conceptGraphView.loadErrorDetail")}
       />
     );
   } else if (query.data?.kind === "unsupported") {
@@ -1402,8 +1404,8 @@ export function ConceptGraphView({
   } else if (!ready) {
     body = (
       <CenteredMessage
-        title="No concepts yet"
-        detail="As your assistant learns and links ideas, they'll appear here as a living map of its memory."
+        title={t("conceptGraphView.emptyTitle")}
+        detail={t("conceptGraphView.emptyDetail")}
       />
     );
   } else {
@@ -1445,7 +1447,7 @@ export function ConceptGraphView({
           className="pointer-events-none absolute bottom-4 right-4 text-[11px]"
           style={{ color: "var(--content-tertiary)" }}
         >
-          drag to rotate · scroll to zoom
+          {t("conceptGraphView.dragToRotateHint")}
         </div>
 
         {graph?.truncated ? (
@@ -1458,7 +1460,9 @@ export function ConceptGraphView({
               color: "var(--content-tertiary)",
             }}
           >
-            Showing the {layout.nodes.length} most-connected concepts
+            {t("conceptGraphView.truncatedNotice", {
+              count: layout.nodes.length,
+            })}
           </div>
         ) : null}
 
@@ -1470,22 +1474,22 @@ export function ConceptGraphView({
             variant="ghost"
             iconOnly={<ZoomIn />}
             onClick={() => zoomBy(1.25)}
-            aria-label="Zoom in"
-            tooltip="Zoom in"
+            aria-label={t("conceptGraphView.zoomInAriaLabel")}
+            tooltip={t("conceptGraphView.zoomInAriaLabel")}
           />
           <Button
             variant="ghost"
             iconOnly={<ZoomOut />}
             onClick={() => zoomBy(0.8)}
-            aria-label="Zoom out"
-            tooltip="Zoom out"
+            aria-label={t("conceptGraphView.zoomOutAriaLabel")}
+            tooltip={t("conceptGraphView.zoomOutAriaLabel")}
           />
           <Button
             variant="ghost"
             iconOnly={<RotateCcw />}
             onClick={resetView}
-            aria-label="Reset view"
-            tooltip="Reset view"
+            aria-label={t("conceptGraphView.resetViewAriaLabel")}
+            tooltip={t("conceptGraphView.resetViewAriaLabel")}
           />
         </div>
       </>
@@ -1514,8 +1518,16 @@ export function ConceptGraphView({
               variant="ghost"
               iconOnly={isFullscreen ? <Minimize2 /> : <Maximize2 />}
               onClick={onToggleFullscreen}
-              aria-label={isFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
-              tooltip={isFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
+              aria-label={
+                isFullscreen
+                  ? t("conceptGraphView.exitFullscreenAriaLabel")
+                  : t("conceptGraphView.enterFullscreenAriaLabel")
+              }
+              tooltip={
+                isFullscreen
+                  ? t("conceptGraphView.exitFullscreenAriaLabel")
+                  : t("conceptGraphView.enterFullscreenAriaLabel")
+              }
             />
           ) : null}
 
@@ -1525,8 +1537,8 @@ export function ConceptGraphView({
                 variant="ghost"
                 iconOnly={<Search />}
                 onClick={() => setSearchOpen(true)}
-                aria-label="Search concepts"
-                tooltip="Search concepts"
+                aria-label={t("conceptGraphView.searchConceptsAriaLabel")}
+                tooltip={t("conceptGraphView.searchConceptsAriaLabel")}
                 className={searchOpen ? "hidden" : "@2xl:hidden"}
               />
               <div
@@ -1582,8 +1594,8 @@ export function ConceptGraphView({
                         focusOn(searchResults[0].id);
                       }
                     }}
-                    placeholder="Search concepts…"
-                    aria-label="Search concepts"
+                    placeholder={t("conceptGraphView.searchConceptsPlaceholder")}
+                    aria-label={t("conceptGraphView.searchConceptsAriaLabel")}
                     className="w-36 bg-transparent text-[12px] outline-none placeholder:text-[var(--content-tertiary)]"
                     style={{ color: "var(--content-default)" }}
                   />
@@ -1602,7 +1614,7 @@ export function ConceptGraphView({
                         setSearch("");
                         setSearchOpen(false);
                       }}
-                      aria-label="Clear search"
+                      aria-label={t("conceptGraphView.clearSearchAriaLabel")}
                       className="flex items-center"
                       style={{ color: "var(--content-tertiary)" }}
                     >

--- a/clients/web/src/domains/intelligence/components/concept-graph/constants.ts
+++ b/clients/web/src/domains/intelligence/components/concept-graph/constants.ts
@@ -1,3 +1,5 @@
+import { t } from "@/i18n";
+
 import type { ConceptNodeKind } from "./types";
 
 /** Node fill/stroke color per taxonomy kind. Values are the resolved hex of
@@ -48,13 +50,20 @@ export const CLUSTER_PALETTE: string[] = [
   "#F5C94E", // amber-500 — gold
 ];
 
-export const NODE_KIND_LABELS: Record<ConceptNodeKind, string> = {
-  concept: "Concept",
-  skill: "Skill",
-  capability: "Capability",
-  pending: "Pending",
-  other: "Other",
+const NODE_KIND_LABEL_KEY: Record<
+  ConceptNodeKind,
+  `conceptGraphConstants.nodeKind.${ConceptNodeKind}`
+> = {
+  concept: "conceptGraphConstants.nodeKind.concept",
+  skill: "conceptGraphConstants.nodeKind.skill",
+  capability: "conceptGraphConstants.nodeKind.capability",
+  pending: "conceptGraphConstants.nodeKind.pending",
+  other: "conceptGraphConstants.nodeKind.other",
 };
+
+export function nodeKindLabel(kind: ConceptNodeKind): string {
+  return t(NODE_KIND_LABEL_KEY[kind], { ns: "intelligence" });
+}
 
 /** Authored/structural links use a neutral theme token; learned associations
  * use Vellum's warm accent (`--system-mid-strong` / amber-600) + dashes so the

--- a/clients/web/src/domains/intelligence/components/concept-graph/create-memory-modal.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/create-memory-modal.tsx
@@ -5,6 +5,7 @@ import { useCallback, useState } from "react";
 import { createMemory } from "@/domains/intelligence/memory-graph/create-memory";
 import { memoryGraphOptions } from "@/domains/intelligence/memory-graph/get-memory-graph";
 import { memoryStatsOptions } from "@/domains/intelligence/memory-graph/get-memory-stats";
+import { useTranslation } from "@/i18n";
 import { Button, Modal, toast, Typography } from "@vellumai/design-library";
 import { Textarea } from "@vellumai/design-library/components/input";
 
@@ -33,6 +34,7 @@ export function CreateMemoryModal({
   assistantId,
   onCreated,
 }: CreateMemoryModalProps) {
+  const { t } = useTranslation("intelligence");
   const queryClient = useQueryClient();
   const [content, setContent] = useState("");
   const [isSaving, setIsSaving] = useState(false);
@@ -51,15 +53,15 @@ export function CreateMemoryModal({
       // failure so the fact isn't lost and the user can retry.
       const result = await createMemory(assistantId, trimmed);
       if (!result.success) {
-        toast.error(result.message || "Couldn't save that memory.");
+        toast.error(result.message || t("createMemoryModal.saveError"));
         return;
       }
       // When the daemon returns the pending node id the map flies to it, so
       // the toast just confirms; otherwise it sets the "look for it" tone.
       toast.success(
         result.pendingNodeId
-          ? "Got it. Taking you to it."
-          : "Got it. It's on your map while I file it away.",
+          ? t("createMemoryModal.savedFoundToast")
+          : t("createMemoryModal.savedPendingToast"),
       );
       setContent("");
       onOpenChange(false);
@@ -80,24 +82,24 @@ export function CreateMemoryModal({
       ]);
     } catch (err) {
       const message =
-        err instanceof Error ? err.message : "Failed to create memory.";
+        err instanceof Error ? err.message : t("createMemoryModal.createError");
       toast.error(message);
     } finally {
       setIsSaving(false);
     }
-  }, [assistantId, content, onOpenChange, onCreated, queryClient]);
+  }, [assistantId, content, onOpenChange, onCreated, queryClient, t]);
 
   return (
     <Modal.Root open={open} onOpenChange={onOpenChange}>
       <Modal.Content size="sm">
         <Modal.Header>
-          <Modal.Title>New memory</Modal.Title>
+          <Modal.Title>{t("createMemoryModal.title")}</Modal.Title>
         </Modal.Header>
         <Modal.Body>
           <div className="flex flex-col gap-4">
             <Textarea
-              label="What should I remember?"
-              placeholder="e.g. I prefer concise, bulleted summaries."
+              label={t("createMemoryModal.contentLabel")}
+              placeholder={t("createMemoryModal.contentPlaceholder")}
               value={content}
               onChange={(e) => setContent(e.target.value)}
               disabled={isSaving}
@@ -109,15 +111,14 @@ export function CreateMemoryModal({
               variant="body-medium-lighter"
               className="text-(--content-secondary)"
             >
-              It lands on the map right away, then settles into a concept as
-              it's filed.
+              {t("createMemoryModal.helperText")}
             </Typography>
           </div>
         </Modal.Body>
         <Modal.Footer>
           <Modal.Close asChild>
             <Button variant="outlined" disabled={isSaving}>
-              Cancel
+              {t("createMemoryModal.cancel")}
             </Button>
           </Modal.Close>
           <Button
@@ -128,7 +129,9 @@ export function CreateMemoryModal({
               isSaving ? <Loader2 className="animate-spin" /> : undefined
             }
           >
-            {isSaving ? "Creating…" : "Create memory"}
+            {isSaving
+              ? t("createMemoryModal.creating")
+              : t("createMemoryModal.create")}
           </Button>
         </Modal.Footer>
       </Modal.Content>

--- a/clients/web/src/domains/intelligence/components/concept-graph/memory-unavailable-copy.test.ts
+++ b/clients/web/src/domains/intelligence/components/concept-graph/memory-unavailable-copy.test.ts
@@ -7,10 +7,10 @@ import { describe, expect, test } from "bun:test";
 
 import {
   describeMemoryUnavailable,
-  MEMORY_ENABLE_PROMPT,
-  MEMORY_STATUS_ERROR_COPY,
-  MEMORY_V1_UPGRADE_PROMPT,
-  MEMORY_V2_UPGRADE_PROMPT,
+  memoryEnablePrompt,
+  memoryStatusErrorCopy,
+  memoryV1UpgradePrompt,
+  memoryV2UpgradePrompt,
 } from "./memory-unavailable-copy";
 
 describe("describeMemoryUnavailable", () => {
@@ -72,60 +72,62 @@ describe("describeMemoryUnavailable", () => {
   });
 });
 
-describe("MEMORY_STATUS_ERROR_COPY", () => {
+describe("memoryStatusErrorCopy", () => {
   test("does not diagnose a tier it never managed to read", () => {
     // A failed stats read leaves `tier` undefined exactly as an older daemon
     // does. Borrowing the unknown-tier copy would tell the owner of a current,
     // momentarily unreachable assistant to go update it.
-    expect(MEMORY_STATUS_ERROR_COPY.title).not.toBe(
+    const statusError = memoryStatusErrorCopy();
+    expect(statusError.title).not.toBe(
       describeMemoryUnavailable(undefined).title,
     );
-    expect(MEMORY_STATUS_ERROR_COPY.detail).not.toMatch(
-      /update your assistant/i,
-    );
-    expect(MEMORY_STATUS_ERROR_COPY.detail).not.toContain("v3");
+    expect(statusError.detail).not.toMatch(/update your assistant/i);
+    expect(statusError.detail).not.toContain("v3");
   });
 
   test("offers the one action that can help", () => {
-    expect(MEMORY_STATUS_ERROR_COPY.action).toBe("retry");
+    expect(memoryStatusErrorCopy().action).toBe("retry");
   });
 });
 
 describe("the upgrade seed per legacy tier", () => {
   const seeds = {
-    v1: MEMORY_V1_UPGRADE_PROMPT,
-    v2: MEMORY_V2_UPGRADE_PROMPT,
+    v1: memoryV1UpgradePrompt,
+    v2: memoryV2UpgradePrompt,
   } as const;
 
   test.each(Object.entries(seeds))(
     "%s reaches the right tier",
-    (tier, seed) => {
+    (tier, seedFn) => {
+      const seed = seedFn();
       expect(seed).toContain(`from ${tier} to v3`);
       expect(describeMemoryUnavailable(tier as "v1" | "v2").prompt).toBe(seed);
     },
   );
 
   test("v2 points at the reform skill", () => {
-    expect(MEMORY_V2_UPGRADE_PROMPT).toContain("Memory v3 Migration");
+    expect(memoryV2UpgradePrompt()).toContain("Memory v3 Migration");
   });
 
   test("v1 points at both skills, in the order they have to run", () => {
     // The v2 migration backfills concepts/ from pkb/ and the buffer; the v3
     // migration reforms the result. Reaching for v3 first meets its
     // empty-corpus guard, so the order is the useful part of the hint.
-    const v2At = MEMORY_V1_UPGRADE_PROMPT.indexOf("Memory v2 Migration");
-    const v3At = MEMORY_V1_UPGRADE_PROMPT.indexOf("Memory v3 Migration");
+    const seed = memoryV1UpgradePrompt();
+    const v2At = seed.indexOf("Memory v2 Migration");
+    const v3At = seed.indexOf("Memory v3 Migration");
     expect(v2At).toBeGreaterThan(-1);
     expect(v3At).toBeGreaterThan(v2At);
   });
 
   test.each(Object.entries(seeds))(
     "%s names the skill as a pointer, not a mandate",
-    (_tier, seed) => {
+    (_tier, seedFn) => {
       // Both skills carry `avoid-when` rules and some corpus shapes are
       // claimed by neither, so a seed that commits to one can hand the
       // assistant an instruction it has to refuse. The hedge is what lets it
       // deviate; it reads the skills and counts the pages, this file can't.
+      const seed = seedFn();
       expect(seed).toContain("most likely");
       expect(seed.toLowerCase()).toContain("work out what");
     },
@@ -133,9 +135,10 @@ describe("the upgrade seed per legacy tier", () => {
 
   test.each(Object.entries(seeds))(
     "%s still binds the assistant to whatever it picks",
-    (_tier, seed) => {
+    (_tier, seedFn) => {
       // Delegating the choice is not loosening the rules: the skills' own hard
       // rules are what keep an irreversible corpus rewrite loss-proof.
+      const seed = seedFn();
       expect(seed.toLowerCase()).toContain("exactly");
       // The rules themselves stay in the skills, which version separately.
       expect(seed).not.toContain("Step 10");
@@ -144,7 +147,8 @@ describe("the upgrade seed per legacy tier", () => {
 
   test.each(Object.entries(seeds))(
     "%s runs in the background and reports back",
-    (_tier, seed) => {
+    (_tier, seedFn) => {
+      const seed = seedFn();
       expect(seed.toLowerCase()).toContain("in the background");
       expect(seed.toLowerCase()).toContain("blocks");
     },
@@ -152,7 +156,8 @@ describe("the upgrade seed per legacy tier", () => {
 
   test.each(Object.entries(seeds))(
     "%s says nothing about cost or credits",
-    (_tier, seed) => {
+    (_tier, seedFn) => {
+      const seed = seedFn();
       for (const word of ["cost", "credit", "spend", "estimate", "money"]) {
         expect(seed.toLowerCase()).not.toContain(word);
       }
@@ -162,24 +167,25 @@ describe("the upgrade seed per legacy tier", () => {
 
 describe("every seeded prompt", () => {
   const seeds = {
-    v2: MEMORY_V2_UPGRADE_PROMPT,
-    v1: MEMORY_V1_UPGRADE_PROMPT,
-    enable: MEMORY_ENABLE_PROMPT,
+    v2: memoryV2UpgradePrompt,
+    v1: memoryV1UpgradePrompt,
+    enable: memoryEnablePrompt,
   };
 
-  test.each(Object.entries(seeds))("%s uses no em dash", (_name, seed) => {
+  test.each(Object.entries(seeds))("%s uses no em dash", (_name, seedFn) => {
     // These land in the composer, where the assistant is forbidden from
     // writing one (SOUL.md), so a seed carrying an em dash puts words in its
     // mouth that it would never have typed. See the Em Dashes rule in
     // AGENTS.md.
-    expect(seed).not.toContain("—");
+    expect(seedFn()).not.toContain("—");
   });
 
   test.each(Object.entries(seeds))(
     "%s is reachable from a tier",
-    (_n, seed) => {
+    (_n, seedFn) => {
       // Every state a user can actually land in, so a seed can't be orphaned
       // by a future routing change.
+      const seed = seedFn();
       const prompts = (["off", "v1", "v2"] as const).map(
         (tier) => describeMemoryUnavailable(tier).prompt,
       );
@@ -188,12 +194,13 @@ describe("every seeded prompt", () => {
   );
 });
 
-describe("MEMORY_ENABLE_PROMPT", () => {
+describe("memoryEnablePrompt", () => {
   test("asks for the memory switch, not for a migration", () => {
     // This one runs for users who can't reach the Developer page's toggle, so
     // it must stay a plain request to flip `memory.enabled` — conflating it
     // with the v3 upgrade would start a corpus rewrite nobody asked for.
-    expect(MEMORY_ENABLE_PROMPT.toLowerCase()).toContain("memory back on");
-    expect(MEMORY_ENABLE_PROMPT).not.toContain("v3");
+    const seed = memoryEnablePrompt();
+    expect(seed.toLowerCase()).toContain("memory back on");
+    expect(seed).not.toContain("v3");
   });
 });

--- a/clients/web/src/domains/intelligence/components/concept-graph/memory-unavailable-copy.ts
+++ b/clients/web/src/domains/intelligence/components/concept-graph/memory-unavailable-copy.ts
@@ -8,11 +8,13 @@
  * owner switched Memory off (Settings), or the assistant is still on a legacy
  * engine (migrate to v3). `GET /memory/stats` reports which via `tier`.
  *
- * Pure, so the copy-per-tier decision is testable without a router or a query
- * client — the component in `memory-upgrade-prompt.tsx` only renders it.
+ * Pure aside from catalog reads, so the copy-per-tier decision is testable
+ * without a router or a query client — the component in
+ * `memory-upgrade-prompt.tsx` only renders it.
  */
 
 import type { MemoryTier } from "@/domains/intelligence/memory-graph/get-memory-stats";
+import { t } from "@/i18n";
 
 /**
  * Seeds the upgrade chat on a **v2** assistant.
@@ -24,9 +26,9 @@ import type { MemoryTier } from "@/domains/intelligence/memory-graph/get-memory-
  * pages and read those rules. "Work out what my corpus actually needs" is what
  * lets it deviate; "follow it exactly" is what keeps it honest once it picks.
  */
-export const MEMORY_V2_UPGRADE_PROMPT = `Migrate my memory from v2 to v3. That's most likely your "Memory v3 Migration" skill, but work out what my corpus actually needs and follow whichever skill you use exactly.
-
-Run it in the background and tell me when it's done, or if something blocks.`;
+export function memoryV2UpgradePrompt(): string {
+  return t("memoryUnavailable.prompts.v2", { ns: "intelligence" });
+}
 
 /**
  * Seeds the upgrade chat on a **v1** assistant, whose memory lives in the
@@ -41,9 +43,9 @@ Run it in the background and tell me when it's done, or if something blocks.`;
  * change. Stated as a mandate, this seed would describe a sequence that cannot
  * run.
  */
-export const MEMORY_V1_UPGRADE_PROMPT = `Migrate my memory from v1 to v3. That's most likely two hops, your "Memory v2 Migration" skill and then your "Memory v3 Migration" skill, but work out what my assistant actually needs and follow whichever skills you use exactly.
-
-Run it in the background and tell me when it's done, or if something blocks.`;
+export function memoryV1UpgradePrompt(): string {
+  return t("memoryUnavailable.prompts.v1", { ns: "intelligence" });
+}
 
 /**
  * Seeds the turn-memory-back-on chat. The Memory toggle lives on the Developer
@@ -51,9 +53,9 @@ Run it in the background and tell me when it's done, or if something blocks.`;
  * General Settings without it — so for most users the assistant is the only
  * reachable way to flip `memory.enabled`, not a fallback for one.
  */
-export const MEMORY_ENABLE_PROMPT =
-  "Turn my memory back on. I'd like you to start remembering things from our " +
-  "conversations again.";
+export function memoryEnablePrompt(): string {
+  return t("memoryUnavailable.prompts.enable", { ns: "intelligence" });
+}
 
 /** Which way out this surface offers, if any. */
 export type MemoryUnavailableAction = "upgrade" | "settings" | "retry" | "none";
@@ -82,12 +84,13 @@ export interface MemoryUnavailableCopy {
  * and a request that never landed is the case where we know least of all. Say
  * the read failed, and offer the only action that can help.
  */
-export const MEMORY_STATUS_ERROR_COPY: MemoryUnavailableCopy = {
-  title: "Couldn't check your memory settings",
-  detail:
-    "Something went wrong reading this assistant's memory status, so there's nothing reliable to tell you yet.",
-  action: "retry",
-};
+export function memoryStatusErrorCopy(): MemoryUnavailableCopy {
+  return {
+    title: t("memoryUnavailable.statusError.title", { ns: "intelligence" }),
+    detail: t("memoryUnavailable.statusError.detail", { ns: "intelligence" }),
+    action: "retry",
+  };
+}
 
 /**
  * Tier → what to say about the missing graph.
@@ -113,27 +116,24 @@ export function describeMemoryUnavailable(
 ): MemoryUnavailableCopy {
   if (tier === "off") {
     return {
-      title: "Memory is turned off",
-      detail:
-        "Your assistant isn't keeping anything from your conversations, so there's no map to draw. Turn Memory back on to start remembering again.",
+      title: t("memoryUnavailable.off.title", { ns: "intelligence" }),
+      detail: t("memoryUnavailable.off.detail", { ns: "intelligence" }),
       action: "settings",
-      prompt: MEMORY_ENABLE_PROMPT,
+      prompt: memoryEnablePrompt(),
     };
   }
   if (tier === "v1" || tier === "v2") {
     return {
-      title: "Upgrade to memory v3",
-      detail:
-        "Your assistant is on an older memory engine. Memory v3 reorganizes what it knows into a linked wiki of concepts, and that wiki is what this map draws.",
+      title: t("memoryUnavailable.legacy.title", { ns: "intelligence" }),
+      detail: t("memoryUnavailable.legacy.detail", { ns: "intelligence" }),
       action: "upgrade",
       prompt:
-        tier === "v1" ? MEMORY_V1_UPGRADE_PROMPT : MEMORY_V2_UPGRADE_PROMPT,
+        tier === "v1" ? memoryV1UpgradePrompt() : memoryV2UpgradePrompt(),
     };
   }
   return {
-    title: "Memory graph isn't available",
-    detail:
-      "This assistant's memory backend doesn't report enough to say why. Update your assistant, and this page will tell you what it needs.",
+    title: t("memoryUnavailable.unknown.title", { ns: "intelligence" }),
+    detail: t("memoryUnavailable.unknown.detail", { ns: "intelligence" }),
     action: "none",
   };
 }

--- a/clients/web/src/domains/intelligence/components/concept-graph/memory-upgrade-prompt.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/memory-upgrade-prompt.tsx
@@ -19,6 +19,7 @@ import { memoryStatsOptions } from "@/domains/intelligence/memory-graph/get-memo
 import { invalidateMemoryQueries } from "@/domains/intelligence/memory-graph/invalidate-memory-queries";
 import { emitMemoryEvent } from "@/domains/intelligence/memory-telemetry";
 import { useAssistantCapability } from "@/hooks/use-assistant-capability";
+import { useTranslation } from "@/i18n";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library";
@@ -26,7 +27,7 @@ import { Button } from "@vellumai/design-library";
 import { CenteredMessage } from "./centered-message";
 import {
   describeMemoryUnavailable,
-  MEMORY_STATUS_ERROR_COPY,
+  memoryStatusErrorCopy,
 } from "./memory-unavailable-copy";
 
 export interface MemoryUpgradePromptProps {
@@ -41,6 +42,7 @@ export function MemoryUpgradePrompt({
   assistantId,
   onOpenThread,
 }: MemoryUpgradePromptProps) {
+  const { t } = useTranslation("intelligence");
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   // Deduped with the Memory page's own stats query by React Query, so this
@@ -82,7 +84,7 @@ export function MemoryUpgradePrompt({
   // us", the other is "we couldn't ask". Only the first justifies telling
   // someone to update their assistant.
   const copy = stats.isError
-    ? MEMORY_STATUS_ERROR_COPY
+    ? memoryStatusErrorCopy()
     : describeMemoryUnavailable(tier);
 
   // Bound to a const so it narrows inside the click handlers.
@@ -102,7 +104,7 @@ export function MemoryUpgradePrompt({
           onOpenThread(seed);
         }}
       >
-        Upgrade memory
+        {t("memoryUpgradePrompt.upgradeMemory")}
       </Button>
     );
   } else if (copy.action === "retry") {
@@ -115,7 +117,7 @@ export function MemoryUpgradePrompt({
           void stats.refetch();
         }}
       >
-        Try again
+        {t("memoryUpgradePrompt.tryAgain")}
       </Button>
     );
   } else if (copy.action === "settings" && canOpenMemorySettings) {
@@ -126,7 +128,7 @@ export function MemoryUpgradePrompt({
         leftIcon={<Settings />}
         onClick={() => navigate(`${routes.settings.developer}?tab=memory`)}
       >
-        Memory settings
+        {t("memoryUpgradePrompt.memorySettings")}
       </Button>
     );
   } else if (copy.action === "settings" && onOpenThread && seed) {
@@ -142,7 +144,7 @@ export function MemoryUpgradePrompt({
           onOpenThread(seed);
         }}
       >
-        Turn memory on
+        {t("memoryUpgradePrompt.turnMemoryOn")}
       </Button>
     );
   }

--- a/clients/web/src/domains/intelligence/components/concept-graph/recency-lens.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/recency-lens.tsx
@@ -3,6 +3,8 @@ import {
   type SegmentControlItem,
 } from "@vellumai/design-library";
 
+import { useTranslation } from "@/i18n";
+
 /** The recency window the graph highlights. "all" disables the lens. */
 export type RecencyWindow = "all" | "month" | "week";
 
@@ -10,12 +12,6 @@ interface RecencyLensProps {
   value: RecencyWindow;
   onChange: (value: RecencyWindow) => void;
 }
-
-const ITEMS: SegmentControlItem<RecencyWindow>[] = [
-  { value: "all", label: "All" },
-  { value: "month", label: "Month" },
-  { value: "week", label: "Week" },
-];
 
 /**
  * Segmented "All · Month · Week" control that picks the recency window the graph
@@ -25,10 +21,16 @@ const ITEMS: SegmentControlItem<RecencyWindow>[] = [
  * orbit drag.
  */
 export function RecencyLens({ value, onChange }: RecencyLensProps) {
+  const { t } = useTranslation("intelligence");
+  const items: SegmentControlItem<RecencyWindow>[] = [
+    { value: "all", label: t("recencyLens.all") },
+    { value: "month", label: t("recencyLens.month") },
+    { value: "week", label: t("recencyLens.week") },
+  ];
   return (
     <SegmentControl<RecencyWindow>
-      ariaLabel="Recency window"
-      items={ITEMS}
+      ariaLabel={t("recencyLens.ariaLabel")}
+      items={items}
       value={value}
       onChange={onChange}
       // Labeled mode defaults to full width with flex-1 segments; keep it

--- a/clients/web/src/domains/intelligence/components/identity-overview.tsx
+++ b/clients/web/src/domains/intelligence/components/identity-overview.tsx
@@ -35,6 +35,7 @@ import { ChatAvatar } from "@/components/avatar/chat-avatar";
 import { PageShell } from "@/components/page-shell";
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import { useElementSize } from "@/hooks/use-element-size";
+import { useTranslation } from "@/i18n";
 import { useSupportsPluginsSurface } from "@/lib/backwards-compat/plugins-surface";
 import { useIsNativeMobile } from "@/runtime/platform-detection";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
@@ -112,15 +113,26 @@ const MINI_SECTION_KEYS = [
  * In-character center-text lines while the avatar is off hugging a card —
  * the greeting becomes his commentary on whatever you're pointing at.
  */
-const CARD_HOVER_LINES: Record<string, string> = {
-  personality: "Go ahead, tweak my soul",
-  superpowers: "Everything I know how to do",
-  memory: "Everything I remember",
-  library: "The apps and docs I've made for you",
-  schedules: "What I do on repeat",
-  workspace: "All the files that power me",
-  contacts: "The people I know and trust",
-  channels: "All the places you can reach me",
+const CARD_HOVER_LINE_KEY: Record<
+  string,
+  `identityOverview.cardHoverLine.${
+    | "personality"
+    | "superpowers"
+    | "memory"
+    | "library"
+    | "schedules"
+    | "workspace"
+    | "contacts"
+    | "channels"}`
+> = {
+  personality: "identityOverview.cardHoverLine.personality",
+  superpowers: "identityOverview.cardHoverLine.superpowers",
+  memory: "identityOverview.cardHoverLine.memory",
+  library: "identityOverview.cardHoverLine.library",
+  schedules: "identityOverview.cardHoverLine.schedules",
+  workspace: "identityOverview.cardHoverLine.workspace",
+  contacts: "identityOverview.cardHoverLine.contacts",
+  channels: "identityOverview.cardHoverLine.channels",
 };
 
 /** "14 Jul, 9:00 am" — compact next-fire time for the schedules preview. */
@@ -194,6 +206,7 @@ interface IdentityOverviewProps {
 }
 
 export function IdentityOverview({ assistantId }: IdentityOverviewProps) {
+  const { t } = useTranslation("intelligence");
   const queryClient = useQueryClient();
   const {
     components,
@@ -232,7 +245,12 @@ export function IdentityOverview({ assistantId }: IdentityOverviewProps) {
     memory:
       memories === undefined
         ? undefined
-        : { value: memories, label: memories === 1 ? "memory" : "memories" },
+        : {
+            value: memories,
+            label: t("identityOverview.memoryCountLabel", {
+              count: memories,
+            }),
+          },
   };
 
   const [modalOpen, setModalOpen] = useState(false);
@@ -255,13 +273,13 @@ export function IdentityOverview({ assistantId }: IdentityOverviewProps) {
           // Preserve the owner tag: a rename changes the name, not which
           // assistant the hydrated identity belongs to.
           setIdentity(newName, version, hydratedAssistantId);
-          toast.success(`Say hi to ${newName}!`);
+          toast.success(t("identityOverview.renameSuccessToast", { newName }));
         } else {
-          toast.error("The rename didn't go through. Please try again.");
+          toast.error(t("identityOverview.renameErrorToast"));
         }
       });
     },
-    [assistantId, queryClient],
+    [assistantId, queryClient, t],
   );
 
   const handleAvatarChange = useCallback(() => {
@@ -321,7 +339,10 @@ export function IdentityOverview({ assistantId }: IdentityOverviewProps) {
           components={components}
           traits={traits}
           customImageUrl={customImageUrl}
-          name={identityQuery.data?.identity?.name || "Assistant"}
+          name={
+            identityQuery.data?.identity?.name ||
+            t("identityOverview.defaultAssistantName")
+          }
           sections={sections}
           stats={sectionStats}
           avatarHex={avatarHex}
@@ -340,7 +361,10 @@ export function IdentityOverview({ assistantId }: IdentityOverviewProps) {
         customImageUrl={customImageUrl}
         onSaveCharacter={handleAvatarChange}
         onUploadImage={handleAvatarChange}
-        assistantName={identityQuery.data?.identity?.name || "Assistant"}
+        assistantName={
+          identityQuery.data?.identity?.name ||
+          t("identityOverview.defaultAssistantName")
+        }
         onRenameSubmit={handleRename}
         isRenaming={isRenaming}
       />
@@ -383,6 +407,7 @@ function SectionCard({
   linkRef?: (el: HTMLAnchorElement | null) => void;
   onHoverChange?: (hovering: boolean) => void;
 }) {
+  const { t } = useTranslation("intelligence");
   const Icon = SECTION_ICONS[section.key] ?? Sparkles;
 
   // Keep the last origin while draining so the water recedes back to
@@ -617,7 +642,10 @@ function SectionCard({
                 <span
                   className={`truncate text-[12px] transition-colors duration-300 ${fgMuted}`}
                 >
-                  {schedule.cadence} · next {formatNextRun(schedule.nextRunAt)}
+                  {t("identityOverview.scheduleCadence", {
+                    cadence: schedule.cadence,
+                    nextRun: formatNextRun(schedule.nextRunAt),
+                  })}
                 </span>
               </span>
             ))}
@@ -625,7 +653,9 @@ function SectionCard({
               <span
                 className={`text-[12px] font-medium transition-colors duration-300 ${fgMuted}`}
               >
-                View {stat.schedules.more} more…
+                {t("identityOverview.viewMoreSchedules", {
+                  count: stat.schedules.more,
+                })}
               </span>
             )}
           </span>
@@ -674,13 +704,14 @@ function CenterCell({
   isRenaming: boolean;
   onEdit: () => void;
 }) {
+  const { t } = useTranslation("intelligence");
   return (
     <div className="relative z-[1] flex flex-col items-center justify-center gap-5">
       <AssistantNameEditor name={name} isRenaming={isRenaming} />
       <button
         type="button"
-        aria-label="Update avatar and name"
-        title="Update avatar and name"
+        aria-label={t("identityOverview.updateAvatarAndName")}
+        title={t("identityOverview.updateAvatarAndName")}
         onClick={onEdit}
         className="avatar-edit-cursor outline-none keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)]"
       >
@@ -743,6 +774,7 @@ function OverviewBento({
   isRenaming: boolean;
   onOpenAvatarModal: () => void;
 }) {
+  const { t } = useTranslation("intelligence");
   const { ref, size } = useElementSize();
   const reduce = useReducedMotion();
   const useBento = size.w >= BENTO_MIN_W && size.h >= BENTO_MIN_H;
@@ -836,9 +868,10 @@ function OverviewBento({
 
   // While the avatar is off hugging a card, the center text becomes his
   // commentary on it.
-  const greetingOverride = activeHug
-    ? (CARD_HOVER_LINES[activeHug.key] ?? null)
-    : null;
+  const activeHoverLineKey = activeHug
+    ? CARD_HOVER_LINE_KEY[activeHug.key]
+    : undefined;
+  const greetingOverride = activeHoverLineKey ? t(activeHoverLineKey) : null;
 
   // Without a character color (custom image / not loaded) every surface
   // falls back to the regular theme tokens — no forced white/black card
@@ -1109,8 +1142,8 @@ function OverviewBento({
           <div
             role="button"
             tabIndex={0}
-            aria-label="Update avatar and name"
-            title="Update avatar and name"
+            aria-label={t("identityOverview.updateAvatarAndName")}
+            title={t("identityOverview.updateAvatarAndName")}
             onClick={onOpenAvatarModal}
             onKeyDown={(e) => {
               if (e.key === "Enter" || e.key === " ") {
@@ -1147,8 +1180,8 @@ function OverviewBento({
         >
           <button
             type="button"
-            aria-label="Update avatar and name"
-            title="Update avatar and name"
+            aria-label={t("identityOverview.updateAvatarAndName")}
+            title={t("identityOverview.updateAvatarAndName")}
             onClick={onOpenAvatarModal}
             className="avatar-edit-cursor rounded-full outline-none keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)]"
           >

--- a/clients/web/src/domains/intelligence/components/identity-sections.ts
+++ b/clients/web/src/domains/intelligence/components/identity-sections.ts
@@ -1,17 +1,14 @@
 /**
  * The drill-down sections reachable from the assistant overview page —
- * the replacement for the old About Assistant tab bar. Labels and paths
- * come from the shared `ABOUT_ASSISTANT_SECTIONS` registry in
- * `utils/routes.ts`; this module owns only what is overview-specific:
- * ordering and descriptions. Pure so the section list is unit-testable
- * without rendering the overview.
+ * the replacement for the old About Assistant tab bar. Paths come from the
+ * shared `ABOUT_ASSISTANT_SECTIONS` registry in `utils/routes.ts`; this
+ * module owns overview-specific ordering and the translated label /
+ * description pairs. Pure so the section list is unit-testable without
+ * rendering the overview.
  */
 
-import {
-  aboutAssistantSection,
-  type AboutAssistantSectionKey,
-  routes,
-} from "@/utils/routes";
+import { t } from "@/i18n";
+import { aboutAssistantSection, routes } from "@/utils/routes";
 
 export interface IdentitySection {
   key: string;
@@ -21,13 +18,68 @@ export interface IdentitySection {
   to: string;
 }
 
-/** Registry section + the overview's own description line. */
-function section(
-  key: AboutAssistantSectionKey,
-  description: string,
-): IdentitySection {
-  const { label, to } = aboutAssistantSection(key);
-  return { key, label, description, to };
+type IdentitySectionKey =
+  | "personality"
+  | "schedules"
+  | "superpowers"
+  | "memory"
+  | "library"
+  | "workspace"
+  | "contacts"
+  | "channels";
+
+/** Greppable label/description keys, one entry per overview section. */
+const SECTION_COPY_KEY: Record<
+  IdentitySectionKey,
+  {
+    label: `identitySections.${IdentitySectionKey}.label`;
+    description: `identitySections.${IdentitySectionKey}.description`;
+  }
+> = {
+  personality: {
+    label: "identitySections.personality.label",
+    description: "identitySections.personality.description",
+  },
+  schedules: {
+    label: "identitySections.schedules.label",
+    description: "identitySections.schedules.description",
+  },
+  superpowers: {
+    label: "identitySections.superpowers.label",
+    description: "identitySections.superpowers.description",
+  },
+  memory: {
+    label: "identitySections.memory.label",
+    description: "identitySections.memory.description",
+  },
+  library: {
+    label: "identitySections.library.label",
+    description: "identitySections.library.description",
+  },
+  workspace: {
+    label: "identitySections.workspace.label",
+    description: "identitySections.workspace.description",
+  },
+  contacts: {
+    label: "identitySections.contacts.label",
+    description: "identitySections.contacts.description",
+  },
+  channels: {
+    label: "identitySections.channels.label",
+    description: "identitySections.channels.description",
+  },
+};
+
+/** Registry section's path + the overview's own translated label/description. */
+function section(key: Exclude<IdentitySectionKey, "personality">) {
+  const { to } = aboutAssistantSection(key);
+  const copyKey = SECTION_COPY_KEY[key];
+  return {
+    key,
+    label: t(copyKey.label, { ns: "intelligence" }),
+    description: t(copyKey.description, { ns: "intelligence" }),
+    to,
+  } satisfies IdentitySection;
 }
 
 /**
@@ -61,27 +113,29 @@ export function buildIdentitySections({
     // registry section. The overview links it directly.
     {
       key: "personality",
-      label: "Personality",
-      description: "Tune how I talk",
+      label: t(SECTION_COPY_KEY.personality.label, { ns: "intelligence" }),
+      description: t(SECTION_COPY_KEY.personality.description, {
+        ns: "intelligence",
+      }),
       to: routes.personality,
     },
-    section("schedules", "My routines"),
+    section("schedules"),
     // Skills and plugins combined into one list; on assistants without the
     // plugin surface the page itself degrades to skills-only.
-    section("superpowers", "What I can do"),
+    section("superpowers"),
     // Never gated on backend capability. Memory is part of what every
     // assistant is, so wherever the card shows it is always the way in: an
     // assistant whose backend can't draw the concept graph (memory off, or a
     // pre-v3 engine) gets a Memory tab that explains that and offers the fix,
     // rather than a card that silently disappears. The native mobile filter
     // below is the only thing that removes it.
-    section("memory", "What I remember"),
+    section("memory"),
     // Library's list page wears the shared section chrome like its peers;
     // the app viewer (/assistant/library/:appId) renders full-bleed.
-    section("library", "My apps & docs"),
-    section("workspace", "My files"),
-    section("contacts", "People I know"),
-    section("channels", "Where I listen"),
+    section("library"),
+    section("workspace"),
+    section("contacts"),
+    section("channels"),
   ];
   if (!isNativeMobile) {
     return sections;

--- a/clients/web/src/domains/intelligence/components/personality-signature.tsx
+++ b/clients/web/src/domains/intelligence/components/personality-signature.tsx
@@ -19,6 +19,8 @@
 import { animate, useReducedMotion } from "motion/react";
 import { Fragment, useEffect, useState } from "react";
 
+import { useTranslation } from "@/i18n";
+
 import {
   PERSONALITY_AXES,
   PERSONALITY_AXIS_DEFAULT,
@@ -126,13 +128,22 @@ export function PersonalitySignature({
   values,
   className,
 }: PersonalitySignatureProps) {
+  const { t } = useTranslation("intelligence");
   const reduce = useReducedMotion();
 
   const axes = PERSONALITY_AXES.map((axis) => {
     const value = axisValue(values, axis.id);
     const lean = value - 50;
     const neutral = Math.abs(lean) <= DEAD_ZONE;
-    return { axis, value, lean, neutral, magnitude: Math.abs(lean) / 50 };
+    return {
+      axis,
+      left: t(axis.leftKey),
+      right: t(axis.rightKey),
+      value,
+      lean,
+      neutral,
+      magnitude: Math.abs(lean) / 50,
+    };
   });
 
   // The mark grows out of the neutral line on mount. A spring drives the
@@ -156,11 +167,14 @@ export function PersonalitySignature({
   const ys = axes.map((a) => yFor(50 + (a.value - 50) * grown));
 
   const ariaLabel = axes
-    .map(({ axis, lean, neutral, magnitude }) => {
+    .map(({ left, right, lean, neutral, magnitude }) => {
       if (neutral) {
-        return `${axis.left} and ${axis.right} balanced`;
+        return t("personalitySignature.axisBalanced", { left, right });
       }
-      return `${Math.round(magnitude * 100)}% ${lean > 0 ? axis.right : axis.left}`;
+      return t("personalitySignature.axisLean", {
+        percent: Math.round(magnitude * 100),
+        label: lean > 0 ? right : left,
+      });
     })
     .join(", ");
 
@@ -168,7 +182,7 @@ export function PersonalitySignature({
     <svg
       viewBox={`0 0 ${W} ${H}`}
       role="img"
-      aria-label={`Personality: ${ariaLabel}`}
+      aria-label={t("personalitySignature.ariaLabel", { summary: ariaLabel })}
       className={className}
     >
       <line
@@ -199,11 +213,11 @@ export function PersonalitySignature({
         />
       ))}
 
-      {axes.map(({ axis, lean, neutral, magnitude }, i) => (
+      {axes.map(({ axis, left, right, lean, neutral, magnitude }, i) => (
         <Fragment key={axis.id}>
           <PoleLabel
             x={XS[i]!}
-            label={axis.right}
+            label={right}
             above
             leaning={lean > 0}
             neutral={neutral}
@@ -211,7 +225,7 @@ export function PersonalitySignature({
           />
           <PoleLabel
             x={XS[i]!}
-            label={axis.left}
+            label={left}
             above={false}
             leaning={lean < 0}
             neutral={neutral}

--- a/clients/web/src/domains/intelligence/components/personality-slider-row.tsx
+++ b/clients/web/src/domains/intelligence/components/personality-slider-row.tsx
@@ -9,6 +9,7 @@
 
 import * as SliderPrimitive from "@radix-ui/react-slider";
 
+import { useTranslation } from "@/i18n";
 import type { AvatarTone } from "@/utils/avatar-tone";
 
 import {
@@ -36,6 +37,9 @@ export function PersonalitySliderRow({
   tone,
   disabled,
 }: PersonalitySliderRowProps) {
+  const { t } = useTranslation("intelligence");
+  const leftLabel = t(axis.leftKey);
+  const rightLabel = t(axis.rightKey);
   // Responsive: on mobile the labels sit on one line split to the slider's
   // two ends above a full-width track; on >=sm they flank the track in a
   // single row. Flex `order` + wrap drives the reflow.
@@ -48,13 +52,13 @@ export function PersonalitySliderRow({
         className="order-1 flex-1 text-left text-sm sm:w-32 sm:flex-none sm:text-right sm:text-[17px]"
         style={{ color: tone.fg }}
       >
-        {axis.left}
+        {leftLabel}
       </span>
       <span
         className="order-2 flex-1 text-right text-sm sm:order-3 sm:w-32 sm:flex-none sm:text-left sm:text-[17px]"
         style={{ color: tone.fg }}
       >
-        {axis.right}
+        {rightLabel}
       </span>
       <SliderPrimitive.Root
         className="relative order-3 flex h-6 w-full touch-none items-center select-none sm:order-2 sm:w-auto sm:flex-1"
@@ -66,7 +70,10 @@ export function PersonalitySliderRow({
         min={0}
         max={100}
         step={1}
-        aria-label={`${axis.left} to ${axis.right}`}
+        aria-label={t("personalitySliderRow.rangeAriaLabel", {
+          left: leftLabel,
+          right: rightLabel,
+        })}
       >
         <SliderPrimitive.Track
           className="relative h-2 w-full grow rounded-full sm:h-3"

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-mobile.tsx
@@ -16,6 +16,7 @@ import { UpdateAvailableBadge } from "@/domains/intelligence/components/plugins/
 import { usePluginDetail } from "@/domains/intelligence/plugins/use-plugin-detail";
 import { usePluginIconSrc } from "@/domains/intelligence/plugins/use-plugin-icon-src";
 import { usePluginToggle } from "@/domains/intelligence/plugins/use-plugin-toggle";
+import { useTranslation } from "@/i18n";
 import { Button, Card } from "@vellumai/design-library";
 
 interface PluginDetailMobileProps {
@@ -74,6 +75,7 @@ export function PluginDetailMobile({
     isUpgradeError,
     hasLocalEdits,
   } = usePluginDetail(assistantId, name, { onRemoved: onBack });
+  const { t } = useTranslation("intelligence");
   const { toggle, togglingName } = usePluginToggle(assistantId);
 
   // Resolve the full-screen portal target after commit (SSR-safe; the element
@@ -120,7 +122,7 @@ export function PluginDetailMobile({
           variant="ghost"
           iconOnly={<ArrowLeft aria-hidden />}
           expandOnMobile
-          aria-label="Back to plugins"
+          aria-label={t("pluginDetail.backToPluginsAriaLabel")}
           onClick={onBack}
           className="max-md:bg-[var(--surface-active)]"
         />
@@ -227,7 +229,7 @@ export function PluginDetailMobile({
                     className="text-body-medium-lighter"
                     style={{ color: "var(--content-tertiary)" }}
                   >
-                    This plugin doesn&apos;t ship a README.
+                    {t("pluginDetail.noReadme")}
                   </p>
                 )}
               </>

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.tsx
@@ -20,6 +20,7 @@ import {
 import { shortSha } from "@/domains/intelligence/plugins/utils";
 import type { PluginDrift } from "@/domains/intelligence/use-plugin-drift";
 import type { PluginsByNameGetResponse } from "@/generated/daemon/types.gen";
+import { useTranslation } from "@/i18n";
 import { cn } from "@/utils/misc";
 import { Button, ConfirmDialog, Toggle } from "@vellumai/design-library";
 
@@ -56,7 +57,11 @@ export function PluginDetailMetadata({
   surfaces = null,
   className,
 }: PluginDetailMetadataProps) {
-  const repo = plugin.source?.kind === "github" ? plugin.source.repo : "Local";
+  const { t } = useTranslation("intelligence");
+  const repo =
+    plugin.source?.kind === "github"
+      ? plugin.source.repo
+      : t("pluginDetailShared.localSource");
   const repoHref =
     plugin.source?.kind === "github"
       ? `https://github.com/${plugin.source.repo}`
@@ -64,33 +69,45 @@ export function PluginDetailMetadata({
 
   const rows: { label: string; value: string; href?: string }[] = [
     {
-      label: "Source",
+      label: t("pluginDetailShared.sourceLabel"),
       value: repo,
       href: repoHref ?? undefined,
     },
   ];
   if (plugin.homepage) {
     rows.push({
-      label: "Homepage",
+      label: t("pluginDetailShared.homepageLabel"),
       value: plugin.homepage,
       href: plugin.homepage,
     });
   }
   if (plugin.license) {
-    rows.push({ label: "License", value: plugin.license });
+    rows.push({
+      label: t("pluginDetailShared.licenseLabel"),
+      value: plugin.license,
+    });
   }
   // Surfaces are only present for an installed copy; list the non-empty
   // contributions (skills / hooks / tools) so the panel shows what the
   // plugin actually adds.
   if (surfaces) {
     if (surfaces.skills.length > 0) {
-      rows.push({ label: "Skills", value: String(surfaces.skills.length) });
+      rows.push({
+        label: t("pluginDetailShared.skillsLabel"),
+        value: String(surfaces.skills.length),
+      });
     }
     if (surfaces.hooks.length > 0) {
-      rows.push({ label: "Hooks", value: String(surfaces.hooks.length) });
+      rows.push({
+        label: t("pluginDetailShared.hooksLabel"),
+        value: String(surfaces.hooks.length),
+      });
     }
     if (surfaces.tools.length > 0) {
-      rows.push({ label: "Tools", value: String(surfaces.tools.length) });
+      rows.push({
+        label: t("pluginDetailShared.toolsLabel"),
+        value: String(surfaces.tools.length),
+      });
     }
   }
 
@@ -180,6 +197,7 @@ export function PluginDetailActions({
   onToggle,
   isToggling,
 }: PluginDetailActionsProps) {
+  const { t } = useTranslation("intelligence");
   const [confirmingRemove, setConfirmingRemove] = useState(false);
   const [confirmingUpgrade, setConfirmingUpgrade] = useState(false);
 
@@ -187,9 +205,10 @@ export function PluginDetailActions({
   const artifact = plugin.artifact ?? null;
   const updateAvailable = drift?.status === "update-available";
   const upgradeTitle = updateAvailable
-    ? `Upgrade ${shortSha(drift?.local?.commit ?? null)} → ${shortSha(
-        drift?.remote?.commit ?? null,
-      )}`
+    ? t("pluginDetailShared.upgradeTitle", {
+        fromSha: shortSha(drift?.local?.commit ?? null),
+        toSha: shortSha(drift?.remote?.commit ?? null),
+      })
     : undefined;
 
   const confirmRemove = () => {
@@ -223,7 +242,7 @@ export function PluginDetailActions({
               with no list row to source it from. Optimistic, no confirm. */}
           {enabled !== undefined && onToggle ? (
             <Toggle
-              label="Auto-include in chat"
+              label={t("pluginDetailShared.autoIncludeInChat")}
               checked={enabled}
               onChange={() => onToggle()}
               disabled={isToggling}
@@ -232,7 +251,7 @@ export function PluginDetailActions({
           {artifact ? (
             <Button asChild leftIcon={<Download aria-hidden />}>
               <a href={artifact.url} download>
-                {artifact.label ?? "Download"}
+                {artifact.label ?? t("pluginDetailShared.download")}
               </a>
             </Button>
           ) : null}
@@ -250,7 +269,7 @@ export function PluginDetailActions({
                 )
               }
             >
-              Upgrade
+              {t("pluginDetailShared.upgrade")}
             </Button>
           ) : null}
           <Button
@@ -266,7 +285,7 @@ export function PluginDetailActions({
               )
             }
           >
-            Remove
+            {t("pluginDetailShared.remove")}
           </Button>
         </div>
       ) : (
@@ -282,15 +301,15 @@ export function PluginDetailActions({
             )
           }
         >
-          Install
+          {t("pluginDetailShared.install")}
         </Button>
       )}
 
       <ConfirmDialog
         open={confirmingRemove}
-        title="Remove plugin"
+        title={t("pluginDetailShared.removePluginTitle")}
         message={pluginRemoveConfirmMessage(plugin.name)}
-        confirmLabel="Remove"
+        confirmLabel={t("pluginDetailShared.remove")}
         destructive
         onConfirm={confirmRemove}
         onCancel={() => setConfirmingRemove(false)}
@@ -298,7 +317,7 @@ export function PluginDetailActions({
 
       <ConfirmDialog
         open={confirmingUpgrade}
-        title="Upgrade plugin"
+        title={t("pluginDetailShared.upgradePluginTitle")}
         message={pluginRiskyUpgradeConfirmMessage(plugin.name)}
         confirmLabel={pluginRiskyUpgradeConfirmLabel}
         destructive
@@ -321,6 +340,7 @@ export function PluginDetailLoading() {
 }
 
 export function PluginDetailError() {
+  const { t } = useTranslation("intelligence");
   return (
     <div
       className="flex flex-col items-center justify-center gap-2 py-12 text-center"
@@ -328,10 +348,10 @@ export function PluginDetailError() {
     >
       <TriangleAlert className="h-6 w-6" aria-hidden />
       <p className="text-body-medium-default">
-        We couldn&apos;t load this plugin.
+        {t("pluginDetailShared.loadErrorTitle")}
       </p>
       <p className="text-body-small-default">
-        It may not exist, or your assistant may be on an older build.
+        {t("pluginDetailShared.loadErrorDetail")}
       </p>
     </div>
   );

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail.tsx
@@ -16,6 +16,7 @@ import { usePluginIconSrc } from "@/domains/intelligence/plugins/use-plugin-icon
 import { usePluginToggle } from "@/domains/intelligence/plugins/use-plugin-toggle";
 import type { PluginDrift } from "@/domains/intelligence/use-plugin-drift";
 import type { PluginsByNameGetResponse } from "@/generated/daemon/types.gen";
+import { useTranslation } from "@/i18n";
 import { Button, Card } from "@vellumai/design-library";
 
 interface PluginDetailProps {
@@ -71,6 +72,7 @@ export function PluginDetail({
     hasLocalEdits,
   } = usePluginDetail(assistantId, name, { onRemoved: onBack });
 
+  const { t } = useTranslation("intelligence");
   const { toggle, togglingName } = usePluginToggle(assistantId);
 
   const iconSrc = usePluginIconSrc(
@@ -87,7 +89,7 @@ export function PluginDetail({
           type="button"
           variant="ghost"
           iconOnly={<ArrowLeft aria-hidden />}
-          aria-label="Back to plugins"
+          aria-label={t("pluginDetail.backToPluginsAriaLabel")}
           onClick={onBack}
         />
         <Header
@@ -136,7 +138,7 @@ export function PluginDetail({
                   className="text-body-medium-lighter"
                   style={{ color: "var(--content-tertiary)" }}
                 >
-                  This plugin doesn&apos;t ship a README.
+                  {t("pluginDetail.noReadme")}
                 </p>
               )}
             </>
@@ -183,6 +185,7 @@ function Header({
   onToggle,
   isToggling,
 }: HeaderProps) {
+  const { t } = useTranslation("intelligence");
   const isExternal = plugin?.source?.kind === "github";
   // Gate the header icon on the loaded plugin, seeding the known external state
   // from the selected list row, so we never flash a wrong glyph (🧩 → 📦) while
@@ -218,7 +221,7 @@ function Header({
                 className="shrink-0 text-body-small-default"
                 style={{ color: "var(--content-tertiary)" }}
               >
-                v{plugin.version}
+                {t("pluginDetail.version", { version: plugin.version })}
               </span>
             ) : null}
             {plugin ? <PluginOriginBadge external={isExternal} /> : null}

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.tsx
@@ -6,6 +6,7 @@ import { UpdateAvailableBadge } from "@/domains/intelligence/components/plugins/
 import type { PluginListItem } from "@/domains/intelligence/plugins/types";
 import { usePluginIconSrc } from "@/domains/intelligence/plugins/use-plugin-icon-src";
 import type { PluginDrift } from "@/domains/intelligence/use-plugin-drift";
+import { useTranslation } from "@/i18n";
 import { Button, Card, Tag } from "@vellumai/design-library";
 
 interface PluginListRowProps {
@@ -41,6 +42,7 @@ export function PluginListRow({
   isRemoving = false,
   isUpgrading = false,
 }: PluginListRowProps) {
+  const { t } = useTranslation("intelligence");
   const available = item.status === "available";
   const updateAvailable = drift?.status === "update-available";
   // Read-only auto-include state. Rendered when the daemon reports it; changing
@@ -100,7 +102,7 @@ export function PluginListRow({
                 className="shrink-0 text-body-small-default"
                 style={{ color: "var(--content-tertiary)" }}
               >
-                v{item.version}
+                {t("pluginListRow.version", { version: item.version })}
               </span>
             ) : null}
             {/* The rows share the My Superpowers list with skills — the badge
@@ -109,7 +111,7 @@ export function PluginListRow({
                 tell Local from External. The detail view derives origin from
                 the plugin's own `source` instead.) */}
             <Tag tone="neutral" leftIcon={<Puzzle aria-hidden />}>
-              Plugin
+              {t("pluginListRow.pluginTag")}
             </Tag>
             {/* The chip is the Upgrade control; it shows on any drift,
                 regardless of the auto-include state. */}
@@ -124,7 +126,7 @@ export function PluginListRow({
             className="mt-1 truncate text-body-medium-lighter"
             style={{ color: "var(--content-tertiary)" }}
           >
-            {item.description ?? "No description provided."}
+            {item.description ?? t("pluginListRow.noDescription")}
           </p>
           {item.issues && item.issues.length > 0 ? (
             <p
@@ -136,8 +138,10 @@ export function PluginListRow({
             >
               {item.issues[0]}
               {item.issues.length > 1
-                ? ` (+${item.issues.length - 1} more)`
-                : ""}
+                ? t("pluginListRow.moreIssues", {
+                    count: item.issues.length - 1,
+                  })
+                : null}
             </p>
           ) : null}
         </div>
@@ -148,7 +152,7 @@ export function PluginListRow({
               type="button"
               iconOnly={<Loader2 className="animate-spin" aria-hidden />}
               disabled
-              aria-label="Installing"
+              aria-label={t("pluginListRow.installingAriaLabel")}
               expandOnMobile={false}
             />
           ) : (
@@ -160,7 +164,7 @@ export function PluginListRow({
                 onInstall?.();
               }}
               disabled={!onInstall}
-              aria-label="Install plugin"
+              aria-label={t("pluginListRow.installPluginAriaLabel")}
               expandOnMobile={false}
             />
           )
@@ -172,7 +176,9 @@ export function PluginListRow({
           <div className="flex shrink-0 items-center gap-2">
             {showEnablement ? (
               <Tag tone={item.enabled ? "positive" : "neutral"}>
-                {item.enabled ? "Enabled" : "Disabled"}
+                {item.enabled
+                  ? t("pluginListRow.enabled")
+                  : t("pluginListRow.disabled")}
               </Tag>
             ) : null}
             <Button
@@ -190,7 +196,7 @@ export function PluginListRow({
                 onRemove?.();
               }}
               disabled={isRemoving || isUpgrading || !onRemove}
-              aria-label="Remove plugin"
+              aria-label={t("pluginListRow.removePluginAriaLabel")}
               expandOnMobile={false}
             />
           </div>

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-origin-badge.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-origin-badge.tsx
@@ -1,6 +1,7 @@
 import { Globe, HardDrive } from "lucide-react";
 import { createElement } from "react";
 
+import { useTranslation } from "@/i18n";
 import { Tag } from "@vellumai/design-library";
 
 /**
@@ -15,9 +16,10 @@ export function PluginOriginBadge({
   external: boolean;
   className?: string;
 }) {
+  const { t } = useTranslation("intelligence");
   const meta = external
-    ? { label: "External", icon: Globe }
-    : { label: "Local", icon: HardDrive };
+    ? { label: t("pluginOriginBadge.external"), icon: Globe }
+    : { label: t("pluginOriginBadge.local"), icon: HardDrive };
 
   return (
     <Tag

--- a/clients/web/src/domains/intelligence/components/plugins/update-available-badge.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/update-available-badge.tsx
@@ -9,6 +9,7 @@
 import { ArrowUpCircle, Loader2 } from "lucide-react";
 import { createElement } from "react";
 
+import { useTranslation } from "@/i18n";
 import { Tag } from "@vellumai/design-library";
 
 interface UpdateAvailableBadgeProps {
@@ -25,6 +26,7 @@ export function UpdateAvailableBadge({
   onClick,
   isUpgrading = false,
 }: UpdateAvailableBadgeProps = {}) {
+  const { t } = useTranslation("intelligence");
   const badge = (
     <Tag
       tone="warning"
@@ -33,7 +35,7 @@ export function UpdateAvailableBadge({
       })}
       className="shrink-0"
     >
-      Update available
+      {t("updateAvailableBadge.updateAvailable")}
     </Tag>
   );
 
@@ -49,7 +51,7 @@ export function UpdateAvailableBadge({
         onClick();
       }}
       disabled={isUpgrading}
-      aria-label="Upgrade plugin"
+      aria-label={t("updateAvailableBadge.upgradePluginAriaLabel")}
       className="shrink-0 rounded-[6px] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] disabled:cursor-not-allowed"
     >
       {badge}

--- a/clients/web/src/domains/intelligence/components/skills/category-sidebar.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/category-sidebar.tsx
@@ -2,6 +2,7 @@ import { LayoutGrid } from "lucide-react";
 
 import { resolveCategoryIcon } from "@/domains/intelligence/skills/category-icon-map";
 import type { CategoryInfo } from "@/domains/intelligence/skills/use-skill-categories";
+import { useTranslation } from "@/i18n";
 import { Button } from "@vellumai/design-library";
 
 interface CategorySidebarProps {
@@ -22,17 +23,21 @@ export function CategorySidebar({
   totalCount,
   showCounts,
   categories,
-  ariaLabel = "Skill categories",
+  ariaLabel,
 }: CategorySidebarProps) {
+  const { t } = useTranslation("intelligence");
   const sortedCategories = [...categories].sort((a, b) =>
     a.label.localeCompare(b.label),
   );
 
   return (
-    <nav className="flex flex-col gap-1" aria-label={ariaLabel}>
+    <nav
+      className="flex flex-col gap-1"
+      aria-label={ariaLabel ?? t("categorySidebar.skillCategoriesAriaLabel")}
+    >
       <CategoryRow
         icon={LayoutGrid}
-        label="All"
+        label={t("categorySidebar.all")}
         count={totalCount}
         isActive={selected === null}
         showCount={showCounts}

--- a/clients/web/src/domains/intelligence/components/skills/skill-detail-mobile.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/skill-detail-mobile.tsx
@@ -22,6 +22,7 @@ import {
   useSkillDetailFiles,
   type SkillFileEntry,
 } from "@/hooks/use-skill-detail-files";
+import { useTranslation } from "@/i18n";
 import { isRemovableSkill } from "@/utils/skills";
 import { Button, Card, Menu, SegmentControl } from "@vellumai/design-library";
 import { SkillIcon } from "@/components/skill-icon";
@@ -79,6 +80,7 @@ export function SkillDetailMobile({
   swipeContainerRef,
   sourceConversationId,
 }: SkillDetailMobileProps) {
+  const { t } = useTranslation("intelligence");
   const available = isAvailableSkill(skill);
   const removable = isRemovableSkill(skill);
 
@@ -134,7 +136,7 @@ export function SkillDetailMobile({
           variant="ghost"
           iconOnly={<ArrowLeft aria-hidden />}
           expandOnMobile
-          aria-label="Back to skills"
+          aria-label={t("skillDetail.backToSkillsAriaLabel")}
           onClick={onBack}
           className="max-md:bg-[var(--surface-active)]"
         />
@@ -200,19 +202,19 @@ export function SkillDetailMobile({
             />
             <SegmentControl<"preview" | "raw">
               iconOnly
-              ariaLabel="File view mode"
+              ariaLabel={t("skillDetail.fileViewModeAriaLabel")}
               value={effectiveViewMode}
               onChange={setViewMode}
               items={[
                 {
                   value: "preview",
-                  label: "Preview",
+                  label: t("skillDetail.preview"),
                   icon: <Eye aria-hidden />,
                   disabled: !activeIsMarkdown,
                 },
                 {
                   value: "raw",
-                  label: "Source",
+                  label: t("skillDetail.source"),
                   icon: <Code aria-hidden />,
                 },
               ]}
@@ -239,7 +241,7 @@ export function SkillDetailMobile({
                 className="flex h-full items-center justify-center text-body-medium-lighter"
                 style={{ color: "var(--content-tertiary)" }}
               >
-                Select a file to view its contents.
+                {t("skillDetail.selectFilePrompt")}
               </p>
             )}
           </div>
@@ -266,6 +268,7 @@ function RightAction({
   onInstall?: () => void;
   onRemove?: () => void;
 }) {
+  const { t } = useTranslation("intelligence");
   if (isInstalling || isRemoving) {
     return (
       <Button
@@ -273,7 +276,7 @@ function RightAction({
         iconOnly={<Loader2 className="animate-spin" aria-hidden />}
         expandOnMobile
         disabled
-        aria-label="Pending"
+        aria-label={t("skillDetail.pendingAriaLabel")}
         className="max-md:bg-[var(--surface-active)]"
       />
     );
@@ -285,7 +288,7 @@ function RightAction({
         variant="ghost"
         iconOnly={<ArrowDownToLine aria-hidden />}
         expandOnMobile
-        aria-label="Install skill"
+        aria-label={t("skillRow.installSkillAriaLabel")}
         onClick={onInstall}
         disabled={!onInstall}
         className="max-md:bg-[var(--surface-active)]"
@@ -299,7 +302,7 @@ function RightAction({
         variant="dangerGhost"
         iconOnly={<Trash2 aria-hidden />}
         expandOnMobile
-        aria-label="Remove skill"
+        aria-label={t("skillRow.removeSkillAriaLabel")}
         onClick={onRemove}
         disabled={!onRemove}
         className="max-md:rounded-full max-md:bg-[var(--system-negative-weak)]"
@@ -314,8 +317,8 @@ function RightAction({
       iconOnly={<Trash2 aria-hidden />}
       expandOnMobile
       disabled
-      title="Bundled skills cannot be removed"
-      aria-label="Bundled skill cannot be removed"
+      title={t("skillRow.bundledSkillsCannotBeRemoved")}
+      aria-label={t("skillRow.bundledSkillCannotBeRemovedAriaLabel")}
       className="max-md:rounded-full max-md:bg-[var(--system-negative-weak)]"
     />
   );
@@ -336,7 +339,8 @@ function FileDropdown({
   activeName: string | null;
   onSelect: (path: string) => void;
 }) {
-  const label = activeName ?? "Select a file";
+  const { t } = useTranslation("intelligence");
+  const label = activeName ?? t("skillDetail.selectAFile");
 
   if (fileEntries.length === 0) {
     return (

--- a/clients/web/src/domains/intelligence/components/skills/skill-detail.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/skill-detail.tsx
@@ -31,6 +31,7 @@ import {
   shouldShowHistoryTab,
   useSkillHistory,
 } from "@/hooks/use-skill-history";
+import { useTranslation } from "@/i18n";
 import { captureError } from "@/lib/sentry/capture-error";
 import { openWorkspaceFile } from "@/utils/open-workspace-file";
 import { invalidateSkillsList, isRemovableSkill } from "@/utils/skills";
@@ -61,6 +62,7 @@ export function SkillDetail({
   isRemoving = false,
   sourceConversationId,
 }: SkillDetailProps) {
+  const { t } = useTranslation("intelligence");
   const available = isAvailableSkill(skill);
   const removable = isRemovableSkill(skill);
 
@@ -99,7 +101,7 @@ export function SkillDetail({
         type="button"
         variant="ghost"
         iconOnly={<ArrowLeft aria-hidden />}
-        aria-label="Back to skills"
+        aria-label={t("skillDetail.backToSkillsAriaLabel")}
         onClick={onBack}
       />
       <div className="flex min-w-0 flex-1 flex-col gap-3 sm:flex-row sm:items-center">
@@ -142,7 +144,7 @@ export function SkillDetail({
               disabled={!onInstall}
               leftIcon={<ArrowDownToLine aria-hidden />}
             >
-              Install
+              {t("skillDetail.install")}
             </Button>
           )
         ) : (
@@ -159,7 +161,7 @@ export function SkillDetail({
               )
             }
           >
-            Remove
+            {t("skillDetail.remove")}
           </Button>
         )}
       </div>
@@ -190,7 +192,7 @@ export function SkillDetail({
               className="px-3 py-4 text-center text-body-medium-lighter"
               style={{ color: "var(--content-tertiary)" }}
             >
-              No files available.
+              {t("skillDetail.noFilesAvailable")}
             </p>
           ) : (
             fileEntries.map((entry) => {
@@ -253,7 +255,7 @@ export function SkillDetail({
               className="flex h-full items-center justify-center text-body-medium-lighter"
               style={{ color: "var(--content-tertiary)" }}
             >
-              Select a file to view its contents.
+              {t("skillDetail.selectFilePrompt")}
             </p>
           )}
         </div>
@@ -278,8 +280,10 @@ export function SkillDetail({
       >
         {showHistory && (
           <Tabs.List className="mb-3">
-            <Tabs.Trigger value="files">Files</Tabs.Trigger>
-            <Tabs.Trigger value="history">History</Tabs.Trigger>
+            <Tabs.Trigger value="files">{t("skillDetail.filesTab")}</Tabs.Trigger>
+            <Tabs.Trigger value="history">
+              {t("skillDetail.historyTab")}
+            </Tabs.Trigger>
           </Tabs.List>
         )}
         <Tabs.Panel
@@ -324,6 +328,7 @@ function SkillFileContent({
   isBinary: boolean;
   editable: boolean;
 }) {
+  const { t } = useTranslation("intelligence");
   const queryClient = useQueryClient();
 
   const [isEditing, setIsEditing] = useState(false);
@@ -389,7 +394,7 @@ function SkillFileContent({
         className="flex h-full items-center justify-center text-body-medium-lighter"
         style={{ color: "var(--content-tertiary)" }}
       >
-        Binary file — no preview available.
+        {t("skillFileContent.binaryFile")}
       </p>
     );
   }
@@ -400,7 +405,7 @@ function SkillFileContent({
         className="flex h-full items-center justify-center text-body-medium-lighter"
         style={{ color: "var(--content-tertiary)" }}
       >
-        No preview available for {fileName}.
+        {t("skillFileContent.noPreviewAvailable", { fileName })}
       </p>
     );
   }
@@ -411,7 +416,7 @@ function SkillFileContent({
       size="regular"
       iconOnly={<ExternalLink aria-hidden />}
       onClick={() => void openWorkspaceFile(workspacePath)}
-      aria-label="Open in Workspace"
+      aria-label={t("skillDetail.openInWorkspaceAriaLabel")}
       className="hover:bg-[var(--surface-base)]"
     />
   ) : undefined;
@@ -466,7 +471,7 @@ function SkillFileContent({
         <EditFooter
           isDirty={isDirty}
           isSaving={saveMutation.isPending}
-          error={saveMutation.isError ? "Save failed" : null}
+          error={saveMutation.isError ? t("skillDetail.saveFailed") : null}
           onSave={handleSave}
           onDiscard={stopEditing}
         />

--- a/clients/web/src/domains/intelligence/components/skills/skill-file-content.test.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/skill-file-content.test.tsx
@@ -55,7 +55,7 @@ describe("SkillFileContent", () => {
     );
 
     expect(
-      screen.getByText("Binary file — no preview available."),
+      screen.getByText("Binary file. No preview available."),
     ).toBeTruthy();
   });
 });

--- a/clients/web/src/domains/intelligence/components/skills/skill-file-content.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/skill-file-content.tsx
@@ -1,4 +1,5 @@
 import { FileMarkdown, isMarkdown } from "@/components/file-markdown";
+import { useTranslation } from "@/i18n";
 
 /**
  * Standalone file-content viewer used by the mobile skill-detail view.
@@ -19,13 +20,14 @@ export function SkillFileContent({
   isBinary: boolean;
   viewMode?: "preview" | "raw";
 }) {
+  const { t } = useTranslation("intelligence");
   if (isBinary) {
     return (
       <p
         className="flex h-full items-center justify-center text-body-medium-lighter"
         style={{ color: "var(--content-tertiary)" }}
       >
-        Binary file — no preview available.
+        {t("skillFileContent.binaryFile")}
       </p>
     );
   }
@@ -36,7 +38,7 @@ export function SkillFileContent({
         className="flex h-full items-center justify-center text-body-medium-lighter"
         style={{ color: "var(--content-tertiary)" }}
       >
-        No preview available for {fileName}.
+        {t("skillFileContent.noPreviewAvailable", { fileName })}
       </p>
     );
   }

--- a/clients/web/src/domains/intelligence/components/skills/skill-origin-badge.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/skill-origin-badge.tsx
@@ -20,10 +20,8 @@ function brandOrCatalogLabel(
 ): string {
   switch (origin) {
     case "vellum":
-      // eslint-disable-next-line local/no-untranslated-strings -- brand name
       return "Vellum";
     case "clawhub":
-      // eslint-disable-next-line local/no-untranslated-strings -- brand name
       return "Clawhub";
     case "skillssh":
       return "skills.sh";

--- a/clients/web/src/domains/intelligence/components/skills/skill-origin-badge.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/skill-origin-badge.tsx
@@ -2,21 +2,46 @@ import { Box, Brain, Globe, Puzzle, Terminal, User } from "lucide-react";
 import { createElement } from "react";
 
 import type { SkillOrigin } from "@/domains/intelligence/skills/types";
+import { useTranslation } from "@/i18n";
 import { Tag } from "@vellumai/design-library";
 
-const ORIGIN_META: Record<SkillOrigin, { label: string; icon: typeof Globe }> =
-  {
-    vellum: { label: "Vellum", icon: Box },
-    clawhub: { label: "Clawhub", icon: Globe },
-    skillssh: { label: "skills.sh", icon: Terminal },
-    custom: { label: "Custom", icon: User },
-    "assistant-memory": { label: "Assistant's Memory", icon: Brain },
-  };
+const ORIGIN_ICON: Record<SkillOrigin, typeof Globe> = {
+  vellum: Box,
+  clawhub: Globe,
+  skillssh: Terminal,
+  custom: User,
+  "assistant-memory": Brain,
+};
+
+/** `vellum`, `clawhub`, and `skills.sh` are brand/product names, never translated. */
+function brandOrCatalogLabel(
+  origin: SkillOrigin,
+  t: (key: "skillOriginBadge.custom" | "skillOriginBadge.assistantMemory") => string,
+): string {
+  switch (origin) {
+    case "vellum":
+      // eslint-disable-next-line local/no-untranslated-strings -- brand name
+      return "Vellum";
+    case "clawhub":
+      // eslint-disable-next-line local/no-untranslated-strings -- brand name
+      return "Clawhub";
+    case "skillssh":
+      return "skills.sh";
+    case "custom":
+      return t("skillOriginBadge.custom");
+    case "assistant-memory":
+      return t("skillOriginBadge.assistantMemory");
+  }
+}
 
 export function SkillOriginBadge({ origin }: { origin: SkillOrigin | string }) {
+  const { t } = useTranslation("intelligence");
   const meta =
-    origin in ORIGIN_META
-      ? ORIGIN_META[origin as SkillOrigin]
+    origin in ORIGIN_ICON
+      ? {
+          label: brandOrCatalogLabel(origin as SkillOrigin, t),
+          icon: ORIGIN_ICON[origin as SkillOrigin],
+        }
       : { label: origin.replace(/-/g, " "), icon: Puzzle };
 
   return (

--- a/clients/web/src/domains/intelligence/components/skills/skill-revision-history.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/skill-revision-history.tsx
@@ -20,6 +20,7 @@ import {
   type DiffRow,
 } from "@/domains/intelligence/skills/parse-unified-diff";
 import { useSkillHistory, type SkillRevision } from "@/hooks/use-skill-history";
+import { useTranslation } from "@/i18n";
 import { formatFullLocalDate, formatRelativeDate } from "@/utils/format-date";
 import { Collapsible } from "@vellumai/design-library";
 
@@ -30,6 +31,7 @@ export function SkillRevisionHistory({
   assistantId: string;
   skillId: string;
 }) {
+  const { t } = useTranslation("intelligence");
   const { revisions, truncatedByCompaction, isLoading, isError } =
     useSkillHistory(assistantId, skillId);
 
@@ -38,7 +40,7 @@ export function SkillRevisionHistory({
   }
 
   if (isError) {
-    return <EmptyNote>Couldn&apos;t load revision history.</EmptyNote>;
+    return <EmptyNote>{t("skillRevisionHistory.loadError")}</EmptyNote>;
   }
 
   return (
@@ -63,8 +65,9 @@ export function SkillRevisionList({
   revisions: SkillRevision[];
   truncatedByCompaction: boolean;
 }) {
+  const { t } = useTranslation("intelligence");
   if (revisions.length === 0) {
-    return <EmptyNote>No changes recorded yet.</EmptyNote>;
+    return <EmptyNote>{t("skillRevisionHistory.noChanges")}</EmptyNote>;
   }
 
   return (
@@ -77,8 +80,7 @@ export function SkillRevisionList({
           className="px-1 pt-1 text-body-small-lighter"
           style={{ color: "var(--content-tertiary)" }}
         >
-          Showing recent changes. Older history is periodically compacted, so
-          this may not reach back to when the skill was created.
+          {t("skillRevisionHistory.truncatedNotice")}
         </p>
       )}
     </Collapsible.Root>
@@ -103,6 +105,7 @@ function RevisionRow({
   revision: SkillRevision;
   skillId: string;
 }) {
+  const { t } = useTranslation("intelligence");
   // Parsing walks the whole diff, and the collapsed row needs it only for the
   // +/- counts, so keep it off the render path for a list that may hold 20.
   const parsed = useMemo(
@@ -169,7 +172,7 @@ function RevisionRow({
             className="px-3 pb-3 text-body-small-lighter"
             style={{ color: "var(--content-tertiary)" }}
           >
-            No preview available for this change.
+            {t("skillRevisionHistory.noPreviewForChange")}
           </p>
         ) : (
           parsed.files.map((file) => (

--- a/clients/web/src/domains/intelligence/components/skills/skill-row.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/skill-row.tsx
@@ -7,6 +7,7 @@ import {
   isAvailableSkill,
   type SkillInfo,
 } from "@/domains/intelligence/skills/types";
+import { useTranslation } from "@/i18n";
 import { isRemovableSkill } from "@/utils/skills";
 import { Button, Card } from "@vellumai/design-library";
 
@@ -27,6 +28,7 @@ export function SkillRow({
   isInstalling = false,
   isRemoving = false,
 }: SkillRowProps) {
+  const { t } = useTranslation("intelligence");
   const available = isAvailableSkill(skill);
   const removable = isRemovableSkill(skill);
 
@@ -73,7 +75,7 @@ export function SkillRow({
               type="button"
               iconOnly={<Loader2 className="animate-spin" aria-hidden />}
               disabled
-              aria-label="Installing"
+              aria-label={t("skillRow.installingAriaLabel")}
               expandOnMobile={false}
             />
           ) : (
@@ -85,7 +87,7 @@ export function SkillRow({
                 onInstall?.();
               }}
               disabled={!onInstall}
-              aria-label="Install skill"
+              aria-label={t("skillRow.installSkillAriaLabel")}
               expandOnMobile={false}
             />
           )
@@ -106,9 +108,13 @@ export function SkillRow({
             }}
             disabled={!removable || isRemoving || !onRemove}
             aria-label={
-              removable ? "Remove skill" : "Bundled skill cannot be removed"
+              removable
+                ? t("skillRow.removeSkillAriaLabel")
+                : t("skillRow.bundledSkillCannotBeRemovedAriaLabel")
             }
-            title={removable ? undefined : "Bundled skills cannot be removed"}
+            title={
+              removable ? undefined : t("skillRow.bundledSkillsCannotBeRemoved")
+            }
             expandOnMobile={false}
           />
         )}

--- a/clients/web/src/domains/intelligence/components/skills/skills-error-state.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/skills-error-state.tsx
@@ -1,15 +1,18 @@
 import { TriangleAlert } from "lucide-react";
 
+import { useTranslation } from "@/i18n";
+
 import { SkillsStateCard } from "./skills-state-card";
 
 /** Error card shown when the skills list query fails. */
 export function SkillsErrorState() {
+  const { t } = useTranslation("intelligence");
   return (
     <SkillsStateCard
       icon={TriangleAlert}
       iconColor="var(--system-danger)"
-      title="Failed to load skills"
-      subtitle="Something went wrong. Try refreshing the page."
+      title={t("skillsErrorState.title")}
+      subtitle={t("skillsErrorState.subtitle")}
     />
   );
 }

--- a/clients/web/src/domains/intelligence/components/superpowers/superpowers-filters.tsx
+++ b/clients/web/src/domains/intelligence/components/superpowers/superpowers-filters.tsx
@@ -56,10 +56,8 @@ type TranslateFilterLabel = (
 function filterLabel(value: SuperpowerFilter, t: TranslateFilterLabel): string {
   switch (value) {
     case "vellum":
-      // eslint-disable-next-line local/no-untranslated-strings -- brand name
       return "Vellum";
     case "clawhub":
-      // eslint-disable-next-line local/no-untranslated-strings -- brand name
       return "Clawhub";
     case "skillssh":
       return "skills.sh";

--- a/clients/web/src/domains/intelligence/components/superpowers/superpowers-filters.tsx
+++ b/clients/web/src/domains/intelligence/components/superpowers/superpowers-filters.tsx
@@ -26,6 +26,7 @@ import { resolveCategoryIcon } from "@/domains/intelligence/skills/category-icon
 import type { CategoryInfo } from "@/domains/intelligence/skills/use-skill-categories";
 import type { SuperpowerFilter } from "@/domains/intelligence/superpowers/types";
 import { useTouchMobile } from "@/hooks/use-touch-mobile";
+import { useTranslation } from "@/i18n";
 import {
   BottomSheet,
   Button,
@@ -40,30 +41,82 @@ interface FilterOption {
   icon: typeof LayoutGrid;
 }
 
-const ALL_FILTER: FilterOption = {
-  value: "all",
-  label: "All",
-  icon: LayoutGrid,
-};
+type TranslateFilterLabel = (
+  key:
+    | "superpowersFilters.filterLabel.all"
+    | "superpowersFilters.filterLabel.installed"
+    | "superpowersFilters.filterLabel.available"
+    | "superpowersFilters.filterLabel.skills"
+    | "superpowersFilters.filterLabel.plugins"
+    | "superpowersFilters.filterLabel.custom"
+    | "superpowersFilters.filterLabel.assistantMemory",
+) => string;
 
-const STATUS_FILTERS: FilterOption[] = [
-  ALL_FILTER,
-  { value: "installed", label: "Installed", icon: CheckCircle },
-  { value: "available", label: "Available", icon: ArrowDownToLine },
-];
+/** `vellum`, `clawhub`, and `skills.sh` are brand/product names, never translated. */
+function filterLabel(value: SuperpowerFilter, t: TranslateFilterLabel): string {
+  switch (value) {
+    case "vellum":
+      // eslint-disable-next-line local/no-untranslated-strings -- brand name
+      return "Vellum";
+    case "clawhub":
+      // eslint-disable-next-line local/no-untranslated-strings -- brand name
+      return "Clawhub";
+    case "skillssh":
+      return "skills.sh";
+    case "all":
+      return t("superpowersFilters.filterLabel.all");
+    case "installed":
+      return t("superpowersFilters.filterLabel.installed");
+    case "available":
+      return t("superpowersFilters.filterLabel.available");
+    case "skills":
+      return t("superpowersFilters.filterLabel.skills");
+    case "plugins":
+      return t("superpowersFilters.filterLabel.plugins");
+    case "custom":
+      return t("superpowersFilters.filterLabel.custom");
+    case "assistant-memory":
+      return t("superpowersFilters.filterLabel.assistantMemory");
+  }
+}
 
-const TYPE_FILTERS: FilterOption[] = [
-  { value: "skills", label: "Skills", icon: Zap },
-  { value: "plugins", label: "Plugins", icon: Puzzle },
-];
-
-const ORIGIN_FILTERS: FilterOption[] = [
-  { value: "vellum", label: "Vellum", icon: Box },
-  { value: "clawhub", label: "Clawhub", icon: Globe },
-  { value: "skillssh", label: "skills.sh", icon: Terminal },
-  { value: "custom", label: "Custom", icon: User },
-  { value: "assistant-memory", label: "Assistant's Memory", icon: Brain },
-];
+function useFilterOptions(): {
+  statusFilters: FilterOption[];
+  typeFilters: FilterOption[];
+  originFilters: FilterOption[];
+} {
+  const { t } = useTranslation("intelligence");
+  return {
+    statusFilters: [
+      { value: "all", label: filterLabel("all", t), icon: LayoutGrid },
+      {
+        value: "installed",
+        label: filterLabel("installed", t),
+        icon: CheckCircle,
+      },
+      {
+        value: "available",
+        label: filterLabel("available", t),
+        icon: ArrowDownToLine,
+      },
+    ],
+    typeFilters: [
+      { value: "skills", label: filterLabel("skills", t), icon: Zap },
+      { value: "plugins", label: filterLabel("plugins", t), icon: Puzzle },
+    ],
+    originFilters: [
+      { value: "vellum", label: filterLabel("vellum", t), icon: Box },
+      { value: "clawhub", label: filterLabel("clawhub", t), icon: Globe },
+      { value: "skillssh", label: filterLabel("skillssh", t), icon: Terminal },
+      { value: "custom", label: filterLabel("custom", t), icon: User },
+      {
+        value: "assistant-memory",
+        label: filterLabel("assistant-memory", t),
+        icon: Brain,
+      },
+    ],
+  };
+}
 
 interface FilterBarProps {
   search: string;
@@ -109,6 +162,7 @@ export function FilterBar({
   pluginsSupported,
   showCategories,
 }: FilterBarProps) {
+  const { t } = useTranslation("intelligence");
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     onSearchChange(e.target.value);
   };
@@ -119,8 +173,8 @@ export function FilterBar({
         type="search"
         value={search}
         onChange={handleChange}
-        placeholder="Search superpowers"
-        aria-label="Search superpowers"
+        placeholder={t("superpowersFilters.searchPlaceholder")}
+        aria-label={t("superpowersFilters.searchAriaLabel")}
         leftIcon={<Search className="h-4 w-4" aria-hidden />}
         rightIcon={
           isSearching ? (
@@ -168,15 +222,17 @@ interface FilterControlProps {
  * on exactly one surface at any viewport.
  */
 function FilterControl(props: FilterControlProps) {
+  const { t } = useTranslation("intelligence");
   const isTouchMobile = useTouchMobile();
   const [open, setOpen] = useState(false);
+  const { statusFilters, typeFilters, originFilters } = useFilterOptions();
 
   const trigger = (
     <Button
       type="button"
       variant="outlined"
       iconOnly={<Filter aria-hidden />}
-      aria-label="Filter superpowers"
+      aria-label={t("superpowersFilters.filterAriaLabel")}
       aria-haspopup={isTouchMobile ? "dialog" : "listbox"}
       aria-expanded={open}
       tintColor="var(--primary-base)"
@@ -209,8 +265,8 @@ function FilterControl(props: FilterControlProps) {
       >
         <ul role="listbox">
           <FilterGroup
-            label="Status"
-            options={STATUS_FILTERS}
+            label={t("superpowersFilters.statusLabel")}
+            options={statusFilters}
             selected={props.filter}
             onSelect={selectAndClose}
           />
@@ -221,8 +277,8 @@ function FilterControl(props: FilterControlProps) {
                 style={{ borderColor: "var(--border-base)" }}
               />
               <FilterGroup
-                label="Type"
-                options={TYPE_FILTERS}
+                label={t("superpowersFilters.typeLabel")}
+                options={typeFilters}
                 selected={props.filter}
                 onSelect={selectAndClose}
               />
@@ -233,8 +289,8 @@ function FilterControl(props: FilterControlProps) {
             style={{ borderColor: "var(--border-base)" }}
           />
           <FilterGroup
-            label="Source"
-            options={ORIGIN_FILTERS}
+            label={t("superpowersFilters.sourceLabel")}
+            options={originFilters}
             selected={props.filter}
             onSelect={selectAndClose}
           />
@@ -250,6 +306,8 @@ function FilterControl(props: FilterControlProps) {
                 counts={props.counts}
                 totalCount={props.totalCount}
                 showCounts={props.showCounts}
+                allLabel={t("superpowersFilters.filterLabel.all")}
+                categoriesLabel={t("superpowersFilters.categoriesLabel")}
                 onSelect={(next) => {
                   props.onCategoryChange(next);
                   setOpen(false);
@@ -290,6 +348,8 @@ function FilterSheet({
   onOpenChange,
   trigger,
 }: FilterSheetProps) {
+  const { t } = useTranslation("intelligence");
+  const { statusFilters, typeFilters, originFilters } = useFilterOptions();
   return (
     <BottomSheet.Root open={open} onOpenChange={onOpenChange}>
       <BottomSheet.Trigger asChild>{trigger}</BottomSheet.Trigger>
@@ -302,11 +362,13 @@ function FilterSheet({
           className="mx-auto mb-3 h-1 w-9 shrink-0 rounded-full bg-[var(--border-element)]"
         />
         <BottomSheet.Header>
-          <BottomSheet.Title>Filters</BottomSheet.Title>
+          <BottomSheet.Title>
+            {t("superpowersFilters.filtersTitle")}
+          </BottomSheet.Title>
         </BottomSheet.Header>
         <BottomSheet.Body className="flex flex-col gap-3 pt-2">
-          <SheetSection label="Status">
-            {STATUS_FILTERS.map((option) => (
+          <SheetSection label={t("superpowersFilters.statusLabel")}>
+            {statusFilters.map((option) => (
               <FilterRow
                 key={option.value}
                 icon={option.icon}
@@ -318,8 +380,8 @@ function FilterSheet({
           </SheetSection>
 
           {pluginsSupported && (
-            <SheetSection label="Type">
-              {TYPE_FILTERS.map((option) => (
+            <SheetSection label={t("superpowersFilters.typeLabel")}>
+              {typeFilters.map((option) => (
                 <FilterRow
                   key={option.value}
                   icon={option.icon}
@@ -331,8 +393,8 @@ function FilterSheet({
             </SheetSection>
           )}
 
-          <SheetSection label="Source">
-            {ORIGIN_FILTERS.map((option) => (
+          <SheetSection label={t("superpowersFilters.sourceLabel")}>
+            {originFilters.map((option) => (
               <FilterRow
                 key={option.value}
                 icon={option.icon}
@@ -344,10 +406,10 @@ function FilterSheet({
           </SheetSection>
 
           {showCategories && (
-            <SheetSection label="Categories">
+            <SheetSection label={t("superpowersFilters.categoriesLabel")}>
               <FilterRow
                 icon={LayoutGrid}
-                label="All"
+                label={t("superpowersFilters.filterLabel.all")}
                 active={category === null}
                 badge={showCounts ? totalCount : undefined}
                 onSelect={() => onCategoryChange(null)}
@@ -372,7 +434,7 @@ function FilterSheet({
             fullWidth
             onClick={() => onOpenChange(false)}
           >
-            Done
+            {t("superpowersFilters.done")}
           </Button>
         </BottomSheet.Footer>
       </BottomSheet.Content>
@@ -452,6 +514,8 @@ function CategoryGroup({
   counts,
   totalCount,
   showCounts,
+  allLabel,
+  categoriesLabel,
   onSelect,
 }: {
   categories: CategoryInfo[];
@@ -459,10 +523,12 @@ function CategoryGroup({
   counts: Record<string, number>;
   totalCount: number;
   showCounts: boolean;
+  allLabel: string;
+  categoriesLabel: string;
   onSelect: (category: string | null) => void;
 }) {
   const rows: { slug: string | null; label: string; count: number }[] = [
-    { slug: null, label: "All", count: totalCount },
+    { slug: null, label: allLabel, count: totalCount },
     ...sortCategories(categories).map((cat) => ({
       slug: cat.slug,
       label: cat.label,
@@ -471,7 +537,7 @@ function CategoryGroup({
   ];
 
   return (
-    <OptionGroup label="Categories">
+    <OptionGroup label={categoriesLabel}>
       <ul className="max-h-48 overflow-y-auto">
         {rows.map((row) => {
           const isSelected = category === row.slug;

--- a/clients/web/src/domains/intelligence/components/superpowers/superpowers-tab.tsx
+++ b/clients/web/src/domains/intelligence/components/superpowers/superpowers-tab.tsx
@@ -76,6 +76,7 @@ import {
 } from "@/generated/daemon/@tanstack/react-query.gen";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import { useIsMobile } from "@/hooks/use-is-mobile";
+import { useTranslation } from "@/i18n";
 import { useSupportsPluginsSurface } from "@/lib/backwards-compat/plugins-surface";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { getLocalBool, setLocalBool } from "@/utils/local-settings";
@@ -133,6 +134,7 @@ function sortRows(rows: SuperpowerRow[]): SuperpowerRow[] {
  * the plugin queries stay disabled and the list is skills-only.
  */
 export function SuperpowersTab({ assistantId }: SuperpowersTabProps) {
+  const { t } = useTranslation("intelligence");
   const navigate = useNavigate();
   const location = useLocation();
   const queryClient = useQueryClient();
@@ -174,7 +176,7 @@ export function SuperpowersTab({ assistantId }: SuperpowersTabProps) {
     }
     successToastedRef.current = true;
     if (selectedPluginName) {
-      toast.success(`Installed ${selectedPluginName}`);
+      toast.success(t("pluginToast.installed", { name: selectedPluginName }));
     }
     setSearchParams(
       (prev) => {
@@ -184,7 +186,7 @@ export function SuperpowersTab({ assistantId }: SuperpowersTabProps) {
       },
       { replace: true },
     );
-  }, [successFlag, selectedPluginName, setSearchParams]);
+  }, [successFlag, selectedPluginName, setSearchParams, t]);
 
   // The search input stays in local state for responsive typing; the settled
   // (debounced) value is reflected into `?q=` below and drives the query.
@@ -353,7 +355,9 @@ export function SuperpowersTab({ assistantId }: SuperpowersTabProps) {
   const installMutation = usePluginsInstallPostMutation({
     onMutate: (variables) => setInstallingName(variables.body.name),
     onSuccess: (_data, variables) =>
-      toast.success(`Installed ${variables.body.name}`),
+      toast.success(
+        t("pluginToast.installed", { name: variables.body.name }),
+      ),
     onError: () => toast.error(PLUGIN_INSTALL_ERROR),
     onSettled: (_data, _error, variables) => {
       setInstallingName(null);
@@ -364,7 +368,7 @@ export function SuperpowersTab({ assistantId }: SuperpowersTabProps) {
   const removeMutation = usePluginsByNameDeleteMutation({
     onMutate: (variables) => setRemovingName(variables.path.name),
     onSuccess: (_data, variables) =>
-      toast.success(`Removed ${variables.path.name}`),
+      toast.success(t("pluginToast.removed", { name: variables.path.name })),
     onError: () => toast.error(PLUGIN_REMOVE_ERROR),
     onSettled: (_data, _error, variables) => {
       setRemovingName(null);
@@ -377,8 +381,11 @@ export function SuperpowersTab({ assistantId }: SuperpowersTabProps) {
     onSuccess: (result, variables) =>
       toast.success(
         result.outcome === "already-up-to-date"
-          ? `${variables.path.name} is already up to date`
-          : `Upgraded ${variables.path.name} to ${shortSha(result.toCommit)}`,
+          ? t("pluginToast.alreadyUpToDate", { name: variables.path.name })
+          : t("pluginToast.upgraded", {
+              name: variables.path.name,
+              sha: shortSha(result.toCommit),
+            }),
       ),
     onError: () => toast.error(PLUGIN_UPGRADE_ERROR),
     onSettled: (_data, _error, variables) => {
@@ -671,23 +678,25 @@ export function SuperpowersTab({ assistantId }: SuperpowersTabProps) {
       />
 
       {!isLoading && !allFailed && skillsFailed ? (
-        <DegradedNotice text="Skills are temporarily unavailable. Plugins are still listed below." />
+        <DegradedNotice text={t("superpowersTab.skillsUnavailableNotice")} />
       ) : null}
       {!isLoading && !allFailed && pluginsFailed ? (
-        <DegradedNotice text="Plugins are temporarily unavailable. Skills are still listed below." />
+        <DegradedNotice text={t("superpowersTab.pluginsUnavailableNotice")} />
       ) : null}
       {pluginsVisible &&
       catalogError &&
       !pluginsListLoading &&
       !pluginsFailed ? (
-        <DegradedNotice text="Plugin catalog browsing is temporarily unavailable. Installed plugins are still listed below." />
+        <DegradedNotice
+          text={t("superpowersTab.catalogBrowsingUnavailableNotice")}
+        />
       ) : null}
 
       <div className="flex min-h-0 flex-1 gap-6">
         {!isMobile && (
           <aside className="w-56 shrink-0 overflow-y-auto">
             <CategorySidebar
-              ariaLabel="Superpower categories"
+              ariaLabel={t("superpowersTab.categoriesAriaLabel")}
               selected={category}
               onSelect={handleCategoryChange}
               counts={counts}
@@ -709,11 +718,11 @@ export function SuperpowersTab({ assistantId }: SuperpowersTabProps) {
 
       <ConfirmDialog
         open={pendingRemoval !== null}
-        title="Remove plugin"
+        title={t("pluginDetailShared.removePluginTitle")}
         message={
           pendingRemoval ? pluginRemoveConfirmMessage(pendingRemoval.name) : ""
         }
-        confirmLabel="Remove"
+        confirmLabel={t("pluginDetailShared.remove")}
         destructive
         onConfirm={confirmPluginRemove}
         onCancel={() => setPendingRemoval(null)}
@@ -721,7 +730,7 @@ export function SuperpowersTab({ assistantId }: SuperpowersTabProps) {
 
       <ConfirmDialog
         open={pendingUpgrade !== null}
-        title="Upgrade plugin"
+        title={t("pluginDetailShared.upgradePluginTitle")}
         message={
           pendingUpgrade
             ? pluginRiskyUpgradeConfirmMessage(pendingUpgrade.name)
@@ -880,6 +889,7 @@ function InstalledPluginRow({
 }
 
 function TipBanner({ onDismiss }: { onDismiss: () => void }) {
+  const { t } = useTranslation("intelligence");
   return (
     <div
       className="flex items-center gap-2 rounded-lg px-4 py-2.5 text-body-small-default"
@@ -892,17 +902,14 @@ function TipBanner({ onDismiss }: { onDismiss: () => void }) {
         className="h-4 w-4 shrink-0"
         style={{ color: "var(--primary-base)" }}
       />
-      <p className="flex-1">
-        Create a new custom skill by describing what you want in chat, or
-        install plugins to extend your assistant.
-      </p>
+      <p className="flex-1">{t("superpowersTab.tipBannerText")}</p>
       <Button
         type="button"
         variant="ghost"
         size="compact"
         iconOnly={<X aria-hidden />}
         onClick={onDismiss}
-        aria-label="Dismiss tip"
+        aria-label={t("superpowersTab.dismissTipAriaLabel")}
         tintColor="var(--content-tertiary)"
         expandOnMobile={false}
       />
@@ -941,6 +948,7 @@ function LoadingState() {
 }
 
 function ErrorState() {
+  const { t } = useTranslation("intelligence");
   return (
     <Card.Root>
       <Card.Body className="flex flex-col items-center justify-center py-16 text-center">
@@ -953,13 +961,13 @@ function ErrorState() {
           className="text-title-small"
           style={{ color: "var(--content-default)" }}
         >
-          Failed to load superpowers
+          {t("superpowersTab.errorStateTitle")}
         </h3>
         <p
           className="mt-1 max-w-sm text-body-medium-lighter"
           style={{ color: "var(--content-tertiary)" }}
         >
-          Something went wrong. Try refreshing the page.
+          {t("superpowersTab.errorStateSubtitle")}
         </p>
       </Card.Body>
     </Card.Root>
@@ -973,84 +981,109 @@ function EmptyState({
   filter: SuperpowerFilter;
   category: string | null;
 }) {
-  const { title, subtitle, Icon } = getEmptyStateCopy(filter, category);
+  const { t } = useTranslation("intelligence");
+  const { title, subtitle, Icon } = getEmptyStateCopy(filter, category, t);
   return <SkillsStateCard icon={Icon} title={title} subtitle={subtitle} />;
 }
 
+type TranslateEmptyStateCopy = (
+  key:
+    | "superpowersTab.emptyState.categoryTitle"
+    | "superpowersTab.emptyState.categorySubtitle"
+    | "superpowersTab.emptyState.installedTitle"
+    | "superpowersTab.emptyState.installedSubtitle"
+    | "superpowersTab.emptyState.availableTitle"
+    | "superpowersTab.emptyState.availableSubtitle"
+    | "superpowersTab.emptyState.skillsTitle"
+    | "superpowersTab.emptyState.skillsSubtitle"
+    | "superpowersTab.emptyState.pluginsTitle"
+    | "superpowersTab.emptyState.pluginsSubtitle"
+    | "superpowersTab.emptyState.vellumTitle"
+    | "superpowersTab.emptyState.vellumSubtitle"
+    | "superpowersTab.emptyState.clawhubTitle"
+    | "superpowersTab.emptyState.clawhubSubtitle"
+    | "superpowersTab.emptyState.skillsshTitle"
+    | "superpowersTab.emptyState.skillsshSubtitle"
+    | "superpowersTab.emptyState.customTitle"
+    | "superpowersTab.emptyState.customSubtitle"
+    | "superpowersTab.emptyState.assistantMemoryTitle"
+    | "superpowersTab.emptyState.assistantMemorySubtitle"
+    | "superpowersTab.emptyState.defaultTitle"
+    | "superpowersTab.emptyState.defaultSubtitle",
+) => string;
+
+/** `Vellum`, `Clawhub`, and `skills.sh` in the empty-state copy are brand/product names, never translated. */
 function getEmptyStateCopy(
   filter: SuperpowerFilter,
   category: string | null,
+  t: TranslateEmptyStateCopy,
 ): { title: string; subtitle: string; Icon: typeof Puzzle } {
   if (category) {
     return {
-      title: "Nothing in this category",
-      subtitle: "Try selecting a different category or clearing the filter.",
+      title: t("superpowersTab.emptyState.categoryTitle"),
+      subtitle: t("superpowersTab.emptyState.categorySubtitle"),
       Icon: LayoutGrid,
     };
   }
   switch (filter) {
     case "installed":
       return {
-        title: "No Superpowers Installed",
-        subtitle:
-          "Ask your assistant in chat to search for and install new skills and plugins.",
+        title: t("superpowersTab.emptyState.installedTitle"),
+        subtitle: t("superpowersTab.emptyState.installedSubtitle"),
         Icon: Zap,
       };
     case "available":
       return {
-        title: "Nothing Left to Install",
-        subtitle: "All available skills and plugins are installed.",
+        title: t("superpowersTab.emptyState.availableTitle"),
+        subtitle: t("superpowersTab.emptyState.availableSubtitle"),
         Icon: CheckCircle,
       };
     case "skills":
       return {
-        title: "No Skills Found",
-        subtitle:
-          "Ask your assistant in chat to search for and install new skills.",
+        title: t("superpowersTab.emptyState.skillsTitle"),
+        subtitle: t("superpowersTab.emptyState.skillsSubtitle"),
         Icon: Zap,
       };
     case "plugins":
       return {
-        title: "No Plugins Found",
-        subtitle:
-          "Browse the catalog to install plugins that extend your assistant.",
+        title: t("superpowersTab.emptyState.pluginsTitle"),
+        subtitle: t("superpowersTab.emptyState.pluginsSubtitle"),
         Icon: Puzzle,
       };
     case "vellum":
       return {
-        title: "No Vellum Skills",
-        subtitle: "No bundled Vellum skills found.",
+        title: t("superpowersTab.emptyState.vellumTitle"),
+        subtitle: t("superpowersTab.emptyState.vellumSubtitle"),
         Icon: Zap,
       };
     case "clawhub":
       return {
-        title: "No Clawhub Skills",
-        subtitle: "No Clawhub skills found. Try searching the catalog.",
+        title: t("superpowersTab.emptyState.clawhubTitle"),
+        subtitle: t("superpowersTab.emptyState.clawhubSubtitle"),
         Icon: Zap,
       };
     case "skillssh":
       return {
-        title: "No skills.sh Skills",
-        subtitle: "No skills.sh skills found. Try searching the catalog.",
+        title: t("superpowersTab.emptyState.skillsshTitle"),
+        subtitle: t("superpowersTab.emptyState.skillsshSubtitle"),
         Icon: Zap,
       };
     case "custom":
       return {
-        title: "No Custom Skills",
-        subtitle: "Create a custom skill by describing what you want in chat.",
+        title: t("superpowersTab.emptyState.customTitle"),
+        subtitle: t("superpowersTab.emptyState.customSubtitle"),
         Icon: Zap,
       };
     case "assistant-memory":
       return {
-        title: "No Skills From Memory",
-        subtitle:
-          "Skills your assistant authors from past conversations will appear here.",
+        title: t("superpowersTab.emptyState.assistantMemoryTitle"),
+        subtitle: t("superpowersTab.emptyState.assistantMemorySubtitle"),
         Icon: Zap,
       };
     default:
       return {
-        title: "No Superpowers Available",
-        subtitle: "Check your connection to the Vellum catalog.",
+        title: t("superpowersTab.emptyState.defaultTitle"),
+        subtitle: t("superpowersTab.emptyState.defaultSubtitle"),
         Icon: CloudOff,
       };
   }

--- a/clients/web/src/domains/intelligence/identity-actions/apply-personality-update.ts
+++ b/clients/web/src/domains/intelligence/identity-actions/apply-personality-update.ts
@@ -9,6 +9,7 @@
  */
 
 import { buildPersonalityMessage } from "@/assistant/personality-rewrite";
+import { t } from "@/i18n";
 
 import { runIdentityRewrite } from "./run-identity-rewrite";
 
@@ -35,7 +36,9 @@ export async function applyPersonalityUpdate({
   return runIdentityRewrite({
     assistantId,
     content: buildPersonalityMessage(values, undefined, assistantName),
-    title: "Updating personality",
+    title: t("applyPersonalityUpdate.conversationTitle", {
+      ns: "intelligence",
+    }),
     context: "identity_personality_update",
   });
 }

--- a/clients/web/src/domains/intelligence/identity-actions/apply-rename.ts
+++ b/clients/web/src/domains/intelligence/identity-actions/apply-rename.ts
@@ -9,6 +9,8 @@
  * rewrites, and scopes the edit to the name alone.
  */
 
+import { t } from "@/i18n";
+
 import { runIdentityRewrite } from "./run-identity-rewrite";
 
 /**
@@ -37,7 +39,7 @@ export async function applyRename(
   return runIdentityRewrite({
     assistantId,
     content: buildRenameMessage(newName),
-    title: "Updating name",
+    title: t("applyRename.conversationTitle", { ns: "intelligence" }),
     context: "identity_overview_rename",
   });
 }

--- a/clients/web/src/domains/intelligence/identity-actions/personality-axes.ts
+++ b/clients/web/src/domains/intelligence/identity-actions/personality-axes.ts
@@ -10,16 +10,46 @@ import { PERSONALITY_SLIDER_DEFAULT } from "@/assistant/personality-sliders";
 
 export interface PersonalityAxisDefinition {
   id: string;
-  left: string;
-  right: string;
+  leftKey:
+    | "personalityAxes.companionCoworker.left"
+    | "personalityAxes.genzBoomer.left"
+    | "personalityAxes.executeCollaborate.left"
+    | "personalityAxes.playfulSerious.left"
+    | "personalityAxes.politeUnfiltered.left";
+  rightKey:
+    | "personalityAxes.companionCoworker.right"
+    | "personalityAxes.genzBoomer.right"
+    | "personalityAxes.executeCollaborate.right"
+    | "personalityAxes.playfulSerious.right"
+    | "personalityAxes.politeUnfiltered.right";
 }
 
 export const PERSONALITY_AXES: PersonalityAxisDefinition[] = [
-  { id: "companion-coworker", left: "Companion", right: "Coworker" },
-  { id: "genz-boomer", left: "Gen Z", right: "Baby Boomer" },
-  { id: "execute-collaborate", left: "Independent", right: "Collaborative" },
-  { id: "playful-serious", left: "Playful", right: "Serious" },
-  { id: "polite-unfiltered", left: "Polite", right: "Unfiltered" },
+  {
+    id: "companion-coworker",
+    leftKey: "personalityAxes.companionCoworker.left",
+    rightKey: "personalityAxes.companionCoworker.right",
+  },
+  {
+    id: "genz-boomer",
+    leftKey: "personalityAxes.genzBoomer.left",
+    rightKey: "personalityAxes.genzBoomer.right",
+  },
+  {
+    id: "execute-collaborate",
+    leftKey: "personalityAxes.executeCollaborate.left",
+    rightKey: "personalityAxes.executeCollaborate.right",
+  },
+  {
+    id: "playful-serious",
+    leftKey: "personalityAxes.playfulSerious.left",
+    rightKey: "personalityAxes.playfulSerious.right",
+  },
+  {
+    id: "polite-unfiltered",
+    leftKey: "personalityAxes.politeUnfiltered.left",
+    rightKey: "personalityAxes.politeUnfiltered.right",
+  },
 ];
 
 /** Sliders start centered — no axis is nudged either way until the user acts. */

--- a/clients/web/src/domains/intelligence/intelligence-layout.tsx
+++ b/clients/web/src/domains/intelligence/intelligence-layout.tsx
@@ -7,8 +7,33 @@ import { Typography } from "@vellumai/design-library";
 import { useChatLayoutSlotsStore } from "@/components/layout/chat-layout-slots-store";
 import { PageShell } from "@/components/page-shell";
 import { useIsMobile } from "@/hooks/use-is-mobile";
+import { useTranslation } from "@/i18n";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
-import { aboutAssistantSectionForPath, routes } from "@/utils/routes";
+import {
+  type AboutAssistantSectionKey,
+  aboutAssistantSectionForPath,
+  routes,
+} from "@/utils/routes";
+
+/**
+ * Greppable overview section titles shown in the layout's header (and
+ * mobile top bar). `plugins`/`skills` share the "My Superpowers" section
+ * with `superpowers` (see `ABOUT_ASSISTANT_SECTIONS` in `utils/routes.ts`).
+ */
+const SECTION_LABEL_KEY: Record<
+  AboutAssistantSectionKey,
+  `sections.${"schedules" | "superpowers" | "memory" | "library" | "workspace" | "contacts" | "channels"}`
+> = {
+  schedules: "sections.schedules",
+  superpowers: "sections.superpowers",
+  plugins: "sections.superpowers",
+  skills: "sections.superpowers",
+  memory: "sections.memory",
+  library: "sections.library",
+  workspace: "sections.workspace",
+  contacts: "sections.contacts",
+  channels: "sections.channels",
+};
 
 /**
  * Shared layout for the "About Assistant" pages. The overview
@@ -27,13 +52,16 @@ import { aboutAssistantSectionForPath, routes } from "@/utils/routes";
  * @see https://reactrouter.com/start/framework/routing#layout-routes
  */
 export function IntelligenceLayout() {
+  const { t } = useTranslation("intelligence");
   const assistantName = useAssistantIdentityStore.use.name();
   const { pathname } = useLocation();
   const isMobile = useIsMobile();
   const setTopBarCenter = useChatLayoutSlotsStore.use.setTopBarCenter();
 
   const section = aboutAssistantSectionForPath(pathname);
-  const mobileTitle = section?.label ?? null;
+  const sectionTitle = section
+    ? t(SECTION_LABEL_KEY[section.key as AboutAssistantSectionKey])
+    : null;
 
   // On mobile the section title moves out of the page body and into the
   // shared top bar — centered between the hamburger menu and the search
@@ -41,13 +69,13 @@ export function IntelligenceLayout() {
   // greeting on the stage already names the assistant. Desktop keeps the
   // in-body <h1> (section pages only) and leaves the top-bar center empty.
   useEffect(() => {
-    if (isMobile && mobileTitle) {
+    if (isMobile && sectionTitle) {
       setTopBarCenter(
         <Typography
           variant="body-medium-default"
           className="truncate text-[var(--content-secondary)]"
         >
-          {mobileTitle}
+          {sectionTitle}
         </Typography>,
       );
     } else {
@@ -56,7 +84,7 @@ export function IntelligenceLayout() {
     return () => {
       setTopBarCenter(null);
     };
-  }, [isMobile, mobileTitle, setTopBarCenter]);
+  }, [isMobile, sectionTitle, setTopBarCenter]);
 
   // The overview and personality pages paint their own full-bleed stage —
   // no shell, heading, or back chrome.
@@ -74,13 +102,17 @@ export function IntelligenceLayout() {
         <Link
           to={routes.identity}
           className="-ml-2 flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-md text-[var(--content-secondary)] transition-colors outline-none hover:bg-[var(--surface-hover)] hover:text-[var(--content-default)] focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
-          aria-label={`Back to ${assistantName || "Assistant"}`}
-          title={`Back to ${assistantName || "Assistant"}`}
+          aria-label={t("intelligenceLayout.backToAriaLabel", {
+            name: assistantName || t("identityOverview.defaultAssistantName"),
+          })}
+          title={t("intelligenceLayout.backToTitle", {
+            name: assistantName || t("identityOverview.defaultAssistantName"),
+          })}
         >
           <ChevronLeft className="h-5 w-5" aria-hidden />
         </Link>
         <h1 className="text-title-large text-[var(--content-default)] max-md:hidden">
-          {section.label}
+          {sectionTitle}
         </h1>
       </div>
 

--- a/clients/web/src/domains/intelligence/memories/format.ts
+++ b/clients/web/src/domains/intelligence/memories/format.ts
@@ -1,3 +1,5 @@
+import { t } from "@/i18n";
+
 const RELATIVE_FORMATTER =
   typeof Intl !== "undefined" && "RelativeTimeFormat" in Intl
     ? new Intl.RelativeTimeFormat(undefined, { style: "long", numeric: "auto" })
@@ -17,7 +19,7 @@ export function formatRelativeTime(epochMs: number): string {
   const diff = epochMs - Date.now();
   const absDiff = Math.abs(diff);
   if (absDiff < 30_000) {
-    return "just now";
+    return t("memoryFormat.justNow", { ns: "intelligence" });
   }
   if (!RELATIVE_FORMATTER) {
     return new Date(epochMs).toLocaleString();

--- a/clients/web/src/domains/intelligence/memories/types.ts
+++ b/clients/web/src/domains/intelligence/memories/types.ts
@@ -1,3 +1,5 @@
+import { t } from "@/i18n";
+
 export type MemoryKind =
   | "episodic"
   | "semantic"
@@ -59,13 +61,13 @@ export interface MemoryItemsListResponse {
 export function sourceTypeLabel(sourceType?: string | null): string | null {
   switch (sourceType) {
     case "direct":
-      return "Told directly";
+      return t("memoryTypes.sourceType.direct", { ns: "intelligence" });
     case "observed":
-      return "Observed";
+      return t("memoryTypes.sourceType.observed", { ns: "intelligence" });
     case "inferred":
-      return "Inferred";
+      return t("memoryTypes.sourceType.inferred", { ns: "intelligence" });
     case "told-by-other":
-      return "Told by other";
+      return t("memoryTypes.sourceType.toldByOther", { ns: "intelligence" });
     default:
       return null;
   }

--- a/clients/web/src/domains/intelligence/memory-graph/get-memory-graph-node.ts
+++ b/clients/web/src/domains/intelligence/memory-graph/get-memory-graph-node.ts
@@ -6,6 +6,7 @@
 import { queryOptions } from "@tanstack/react-query";
 
 import { memorygraphnodeGet } from "@/generated/daemon/sdk.gen";
+import { t } from "@/i18n";
 import {
   ApiError,
   assertHasResponse,
@@ -13,7 +14,9 @@ import {
 } from "@/utils/api-errors";
 import type { MemoryGraphNodeDetail } from "./types";
 
-const FAILURE_MESSAGE = "Failed to load this concept.";
+function failureMessage(): string {
+  return t("getMemoryGraphNode.failureMessage", { ns: "intelligence" });
+}
 
 export function memoryGraphNodeOptions(assistantId: string, id: string | null) {
   return queryOptions<MemoryGraphNodeDetail>({
@@ -26,12 +29,12 @@ export function memoryGraphNodeOptions(assistantId: string, id: string | null) {
         throwOnError: false,
       });
 
-      assertHasResponse(response, error, FAILURE_MESSAGE);
+      assertHasResponse(response, error, failureMessage());
 
       if (!response.ok) {
         throw new ApiError(
           response.status,
-          extractErrorMessage(error, response, FAILURE_MESSAGE),
+          extractErrorMessage(error, response, failureMessage()),
         );
       }
 

--- a/clients/web/src/domains/intelligence/memory-graph/get-memory-graph.ts
+++ b/clients/web/src/domains/intelligence/memory-graph/get-memory-graph.ts
@@ -12,6 +12,7 @@
 import { queryOptions } from "@tanstack/react-query";
 
 import { memorygraphGet } from "@/generated/daemon/sdk.gen";
+import { t } from "@/i18n";
 import {
   ApiError,
   assertHasResponse,
@@ -19,7 +20,9 @@ import {
 } from "@/utils/api-errors";
 import type { MemoryGraphResult } from "./types";
 
-const FAILURE_MESSAGE = "Failed to load the memory graph.";
+function failureMessage(): string {
+  return t("getMemoryGraph.failureMessage", { ns: "intelligence" });
+}
 
 export function memoryGraphOptions(assistantId: string) {
   return queryOptions<MemoryGraphResult>({
@@ -34,7 +37,7 @@ export function memoryGraphOptions(assistantId: string) {
         throwOnError: false,
       });
 
-      assertHasResponse(response, error, FAILURE_MESSAGE);
+      assertHasResponse(response, error, failureMessage());
 
       // An assistant/daemon predating the `/memory-graph` route answers 404;
       // treat that as "not supported here" so an older assistant shows the
@@ -46,7 +49,7 @@ export function memoryGraphOptions(assistantId: string) {
       if (!response.ok) {
         throw new ApiError(
           response.status,
-          extractErrorMessage(error, response, FAILURE_MESSAGE),
+          extractErrorMessage(error, response, failureMessage()),
         );
       }
 

--- a/clients/web/src/domains/intelligence/memory-page.tsx
+++ b/clients/web/src/domains/intelligence/memory-page.tsx
@@ -11,6 +11,7 @@ import { CreateMemoryModal } from "@/domains/intelligence/components/concept-gra
 import { memoryGraphOptions } from "@/domains/intelligence/memory-graph/get-memory-graph";
 import { memoryStatsOptions } from "@/domains/intelligence/memory-graph/get-memory-stats";
 import { emitMemoryEvent } from "@/domains/intelligence/memory-telemetry";
+import { useTranslation } from "@/i18n";
 import { Button } from "@vellumai/design-library";
 
 interface MemoryPageProps {
@@ -27,6 +28,7 @@ interface MemoryPageProps {
  * The skills constellation stays on the Identity tab.
  */
 export function MemoryPage({ onOpenThread }: MemoryPageProps) {
+  const { t } = useTranslation("intelligence");
   const assistantId = useActiveAssistantId();
   const [createOpen, setCreateOpen] = useState(false);
   // Imperative handle into the graph view: after a create, fly the map to the
@@ -78,7 +80,7 @@ export function MemoryPage({ onOpenThread }: MemoryPageProps) {
               leftIcon={<Plus />}
               onClick={() => setCreateOpen(true)}
             >
-              Create memory
+              {t("memoryPage.createMemory")}
             </Button>
           ) : undefined
         }

--- a/clients/web/src/domains/intelligence/memory-v2/list-concept-pages.ts
+++ b/clients/web/src/domains/intelligence/memory-v2/list-concept-pages.ts
@@ -18,6 +18,7 @@
 import { queryOptions } from "@tanstack/react-query";
 
 import { memoryV2ListconceptpagesPost } from "@/generated/daemon/sdk.gen";
+import { t } from "@/i18n";
 import {
   ApiError,
   assertHasResponse,
@@ -35,7 +36,10 @@ export function listConceptPagesOptions(assistantId: string) {
         throwOnError: false,
       });
 
-      assertHasResponse(response, error, "Failed to load concept pages.");
+      const failureMessage = t("listConceptPages.failureMessage", {
+        ns: "intelligence",
+      });
+      assertHasResponse(response, error, failureMessage);
 
       if (response.status === 409) {
         const errObj = error as Record<string, unknown> | undefined;
@@ -45,14 +49,14 @@ export function listConceptPagesOptions(assistantId: string) {
         }
         throw new ApiError(
           response.status,
-          extractErrorMessage(error, response, "Failed to load concept pages."),
+          extractErrorMessage(error, response, failureMessage),
         );
       }
 
       if (!response.ok) {
         throw new ApiError(
           response.status,
-          extractErrorMessage(error, response, "Failed to load concept pages."),
+          extractErrorMessage(error, response, failureMessage),
         );
       }
 

--- a/clients/web/src/domains/intelligence/personality-page.tsx
+++ b/clients/web/src/domains/intelligence/personality-page.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/assistant/personality-sliders";
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
+import { useTranslation } from "@/i18n";
 import { routes } from "@/utils/routes";
 
 import {
@@ -44,6 +45,7 @@ import {
 } from "./use-assistant-identity-details";
 
 export function PersonalityPage() {
+  const { t } = useTranslation("intelligence");
   const assistantId = useActiveAssistantId();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -62,7 +64,9 @@ export function PersonalityPage() {
   const [applying, setApplying] = useState(false);
   const values = edits ?? slidersQuery.data ?? {};
 
-  const assistantName = identityQuery.data?.identity?.name || "Assistant";
+  const assistantName =
+    identityQuery.data?.identity?.name ||
+    t("identityOverview.defaultAssistantName");
 
   const handleUpdate = () => {
     setApplying(true);
@@ -81,12 +85,10 @@ export function PersonalityPage() {
         void queryClient.invalidateQueries({
           queryKey: assistantIdentityDetailsQueryKey(assistantId),
         });
-        toast.success("Personality updated. Go say hi!");
+        toast.success(t("personalityPage.updateSuccessToast"));
         void navigate(routes.identity);
       } else {
-        toast.error(
-          "The personality update didn't go through. Please try again.",
-        );
+        toast.error(t("personalityPage.updateErrorToast"));
       }
     });
   };
@@ -132,6 +134,7 @@ function PersonalityBody({
   onUpdate: () => void;
   onBack: () => void;
 }) {
+  const { t } = useTranslation("intelligence");
   const { tone, bottomReserve } = useAssistantStage();
   const washClasses = tone.isLight
     ? "bg-black/10 hover:bg-black/20"
@@ -146,7 +149,7 @@ function PersonalityBody({
         style={{ color: tone.fg }}
       >
         <ArrowLeft className="h-4 w-4" aria-hidden />
-        Back
+        {t("personalityPage.back")}
       </button>
 
       <div
@@ -163,11 +166,10 @@ function PersonalityBody({
             className="text-[2.6rem] leading-none max-sm:text-[2rem]"
             style={{ fontFamily: "var(--font-serif)" }}
           >
-            Shape my personality
+            {t("personalityPage.title")}
           </h1>
           <p className="max-w-md text-[15px]" style={{ color: tone.fgMuted }}>
-            Slide the dials, then hit update — I&rsquo;ll rewrite myself to
-            match.
+            {t("personalityPage.subtitle")}
           </p>
         </div>
 
@@ -212,13 +214,15 @@ function PersonalityBody({
                 }}
               />
               <span className="min-w-0 text-center">
-                Updating {assistantName}&apos;s personality…
+                {t("personalityPage.updatingPersonality", {
+                  name: assistantName,
+                })}
               </span>
             </>
           ) : (
             <>
               <Sparkles className="h-4 w-4" aria-hidden />
-              Update personality
+              {t("personalityPage.updatePersonality")}
             </>
           )}
         </button>

--- a/clients/web/src/domains/intelligence/plugins/constants.ts
+++ b/clients/web/src/domains/intelligence/plugins/constants.ts
@@ -4,21 +4,35 @@
  * failure messages stay in lockstep across them.
  */
 
+import { t } from "@/i18n";
+
 /** Confirm-dialog body for removing an installed plugin. */
 export const pluginRemoveConfirmMessage = (name: string): string =>
-  `Remove "${name}" from this assistant?`;
+  t("pluginConstants.removeConfirmMessage", { ns: "intelligence", name });
 
 /** Confirm-dialog body for an upgrade that would clobber local edits. */
 export const pluginRiskyUpgradeConfirmMessage = (name: string): string =>
-  `"${name}" has local edits that will be overwritten by the upgrade. Continue?`;
+  t("pluginConstants.riskyUpgradeConfirmMessage", {
+    ns: "intelligence",
+    name,
+  });
 
 /** Confirm-dialog button label for the risky (local-edit-overwriting) upgrade. */
-export const pluginRiskyUpgradeConfirmLabel = "Upgrade anyway";
+export const pluginRiskyUpgradeConfirmLabel = t(
+  "pluginConstants.riskyUpgradeConfirmLabel",
+  { ns: "intelligence" },
+);
 
 /** Failure copy for a failed install / remove / upgrade attempt. */
-export const PLUGIN_INSTALL_ERROR =
-  "Failed to install plugin. Please try again.";
-export const PLUGIN_REMOVE_ERROR = "Failed to remove plugin. Please try again.";
-export const PLUGIN_UPGRADE_ERROR =
-  "Failed to upgrade plugin. Please try again.";
-export const PLUGIN_TOGGLE_ERROR = "Failed to update plugin. Please try again.";
+export const PLUGIN_INSTALL_ERROR = t("pluginConstants.installError", {
+  ns: "intelligence",
+});
+export const PLUGIN_REMOVE_ERROR = t("pluginConstants.removeError", {
+  ns: "intelligence",
+});
+export const PLUGIN_UPGRADE_ERROR = t("pluginConstants.upgradeError", {
+  ns: "intelligence",
+});
+export const PLUGIN_TOGGLE_ERROR = t("pluginConstants.toggleError", {
+  ns: "intelligence",
+});

--- a/clients/web/src/domains/intelligence/plugins/use-plugin-detail.ts
+++ b/clients/web/src/domains/intelligence/plugins/use-plugin-detail.ts
@@ -14,6 +14,7 @@ import {
   usePluginsInstallPostMutation,
 } from "@/generated/daemon/@tanstack/react-query.gen";
 import type { PluginsByNameGetResponse } from "@/generated/daemon/types.gen";
+import { useTranslation } from "@/i18n";
 import { toast } from "@vellumai/design-library";
 
 import { shortSha } from "./utils";
@@ -67,6 +68,7 @@ export function usePluginDetail(
   name: string,
   options?: UsePluginDetailOptions,
 ): UsePluginDetailResult {
+  const { t } = useTranslation("intelligence");
   const queryClient = useQueryClient();
   const onRemoved = options?.onRemoved;
 
@@ -93,7 +95,11 @@ export function usePluginDetail(
   const installMutation = usePluginsInstallPostMutation({
     onSuccess: () => {
       invalidate();
-      toast.success(`Installed ${name || "plugin"}`);
+      toast.success(
+        t("pluginToast.installed", {
+          name: name || t("pluginToast.pluginFallback"),
+        }),
+      );
     },
   });
 
@@ -109,8 +115,13 @@ export function usePluginDetail(
       invalidate();
       toast.success(
         result.outcome === "already-up-to-date"
-          ? `${name || "Plugin"} is already up to date`
-          : `Upgraded ${name || "plugin"} to ${shortSha(result.toCommit)}`,
+          ? t("pluginToast.alreadyUpToDate", {
+              name: name || t("pluginToast.pluginFallbackCapitalized"),
+            })
+          : t("pluginToast.upgraded", {
+              name: name || t("pluginToast.pluginFallback"),
+              sha: shortSha(result.toCommit),
+            }),
       );
     },
   });

--- a/clients/web/src/domains/intelligence/plugins/use-plugins-list.ts
+++ b/clients/web/src/domains/intelligence/plugins/use-plugins-list.ts
@@ -16,6 +16,7 @@ import {
 } from "@/generated/daemon/@tanstack/react-query.gen";
 import { pluginsGet } from "@/generated/daemon/sdk.gen";
 import type { PluginsGetResponse } from "@/generated/daemon/types.gen";
+import { t } from "@/i18n";
 import { installedPluginsQueryOptions } from "@/lib/installed-plugins-query";
 
 // The catalog (the daemon's cached, rate-limited GitHub listing) changes
@@ -103,7 +104,7 @@ async function fetchInstalled(
     return { plugins: [] } as PluginsGetResponse;
   }
   if (!result.response?.ok) {
-    throw new Error("Failed to load plugins");
+    throw new Error(t("usePluginsList.failureMessage", { ns: "intelligence" }));
   }
   return result.data ?? ({ plugins: [] } as PluginsGetResponse);
 }

--- a/clients/web/src/domains/intelligence/skill-detail-page.tsx
+++ b/clients/web/src/domains/intelligence/skill-detail-page.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/generated/daemon/@tanstack/react-query.gen";
 import { useEdgeSwipeBack } from "@/hooks/use-edge-swipe-back";
 import { useIsMobile } from "@/hooks/use-is-mobile";
+import { useTranslation } from "@/i18n";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library";
 
@@ -30,6 +31,7 @@ import { Button } from "@vellumai/design-library";
  * navigates back to the list.
  */
 export function SkillDetailPage() {
+  const { t } = useTranslation("intelligence");
   const assistantId = useActiveAssistantId();
   const { skillId } = useParams<{ skillId: string }>();
   const navigate = useNavigate();
@@ -145,8 +147,8 @@ export function SkillDetailPage() {
     return (
       <SkillsStateCard
         icon={SearchX}
-        title="Skill not found"
-        subtitle="This skill may have been removed, or the link is out of date."
+        title={t("skillDetailPage.notFoundTitle")}
+        subtitle={t("skillDetailPage.notFoundSubtitle")}
       >
         <Button
           type="button"
@@ -155,7 +157,7 @@ export function SkillDetailPage() {
           leftIcon={<ArrowLeft aria-hidden />}
           onClick={handleBack}
         >
-          Back to My Superpowers
+          {t("skillDetailPage.backToSuperpowers")}
         </Button>
       </SkillsStateCard>
     );

--- a/clients/web/src/domains/intelligence/skills/install.ts
+++ b/clients/web/src/domains/intelligence/skills/install.ts
@@ -4,6 +4,7 @@
 
 import { skillsInstallPost } from "@/generated/daemon/sdk.gen";
 import type { SkillsInstallPostResponse } from "@/generated/daemon/types.gen";
+import { t } from "@/i18n";
 import {
   ApiError,
   assertHasResponse,
@@ -20,11 +21,14 @@ export async function installSkill(
     body: version ? { slug, version } : { slug },
     throwOnError: false,
   });
-  assertHasResponse(response, error, "Failed to install skill.");
+  const failureMessage = t("installSkill.failureMessage", {
+    ns: "intelligence",
+  });
+  assertHasResponse(response, error, failureMessage);
   if (!response.ok) {
     throw new ApiError(
       response.status,
-      extractErrorMessage(error, response, "Failed to install skill."),
+      extractErrorMessage(error, response, failureMessage),
     );
   }
   return data ?? { ok: true };

--- a/clients/web/src/domains/intelligence/use-identity-section-stats.ts
+++ b/clients/web/src/domains/intelligence/use-identity-section-stats.ts
@@ -21,6 +21,7 @@ import {
   skillsGetOptions,
   workspaceTreeGetOptions,
 } from "@/generated/daemon/@tanstack/react-query.gen";
+import { useTranslation } from "@/i18n";
 import { installedPluginsQueryOptions } from "@/lib/installed-plugins-query";
 import { fetchSchedules } from "@/utils/schedules";
 
@@ -51,10 +52,6 @@ const STATS_STALE_MS = 60_000;
 
 const SCHEDULE_PREVIEW_COUNT = 3;
 
-function pluralLabel(n: number, singular: string, pluralForm: string): string {
-  return n === 1 ? singular : pluralForm;
-}
-
 interface UseIdentitySectionStatsOptions {
   /** Skip the plugin fetch on assistants without the plugin routes. */
   supportsPlugins: boolean;
@@ -69,6 +66,7 @@ export function useIdentitySectionStats(
   assistantId: string,
   { supportsPlugins, isNativeMobile }: UseIdentitySectionStatsOptions,
 ): Record<string, IdentitySectionStat | undefined> {
+  const { t } = useTranslation("intelligence");
   const path = { assistant_id: assistantId };
   const common = { staleTime: STATS_STALE_MS, retry: false, enabled: true };
 
@@ -163,10 +161,12 @@ export function useIdentitySectionStats(
       skills.data !== undefined
         ? {
             text: [
-              `${skills.data} ${pluralLabel(skills.data, "skill", "skills")}`,
+              t("useIdentitySectionStats.skillCount", { count: skills.data }),
               ...(plugins.data !== undefined
                 ? [
-                    `${plugins.data} ${pluralLabel(plugins.data, "plugin", "plugins")}`,
+                    t("useIdentitySectionStats.pluginCount", {
+                      count: plugins.data,
+                    }),
                   ]
                 : []),
             ].join(" · "),
@@ -178,10 +178,12 @@ export function useIdentitySectionStats(
       apps.data !== undefined
         ? {
             text: [
-              `${apps.data} ${pluralLabel(apps.data, "app", "apps")}`,
+              t("useIdentitySectionStats.appCount", { count: apps.data }),
               ...(documents.data !== undefined
                 ? [
-                    `${documents.data} ${pluralLabel(documents.data, "doc", "docs")}`,
+                    t("useIdentitySectionStats.docCount", {
+                      count: documents.data,
+                    }),
                   ]
                 : []),
             ].join(" · "),
@@ -191,27 +193,38 @@ export function useIdentitySectionStats(
       workspace.data !== undefined
         ? {
             value: workspace.data,
-            label: pluralLabel(workspace.data, "item", "items"),
+            label: t("useIdentitySectionStats.itemLabel", {
+              count: workspace.data,
+            }),
           }
         : undefined,
     contacts:
       contacts.data !== undefined
         ? {
             value: contacts.data,
-            label: pluralLabel(contacts.data, "person", "people"),
+            label: t("useIdentitySectionStats.personLabel", {
+              count: contacts.data,
+            }),
           }
         : undefined,
     channels:
       channels.data !== undefined
-        ? { value: channels.data, label: "connected" }
+        ? {
+            value: channels.data,
+            label: t("useIdentitySectionStats.connectedLabel", {
+              count: channels.data,
+            }),
+          }
         : undefined,
     schedules:
       schedules.data !== undefined
         ? schedules.data.count === 0
-          ? { text: "Nothing scheduled yet" }
+          ? { text: t("useIdentitySectionStats.noSchedulesText") }
           : {
               value: schedules.data.count,
-              label: "active",
+              label: t("useIdentitySectionStats.activeLabel", {
+                count: schedules.data.count,
+              }),
               schedules: {
                 items: schedules.data.items,
                 more: schedules.data.count - schedules.data.items.length,

--- a/clients/web/src/i18n/catalogs.ts
+++ b/clients/web/src/i18n/catalogs.ts
@@ -40,6 +40,7 @@ import enCredentialRequests from "@/i18n/locales/en/credential-requests.json";
 import enHome from "@/i18n/locales/en/home.json";
 import enLibrary from "@/i18n/locales/en/library.json";
 import enLogs from "@/i18n/locales/en/logs.json";
+import enIntelligence from "@/i18n/locales/en/intelligence.json";
 import enOnboarding from "@/i18n/locales/en/onboarding.json";
 import enRemoteWeb from "@/i18n/locales/en/remote-web.json";
 import enTerminal from "@/i18n/locales/en/terminal.json";
@@ -83,6 +84,7 @@ export const FALLBACK_CATALOGS: LocaleCatalogs = {
   home: enHome,
   contacts: enContacts,
   onboarding: enOnboarding,
+  intelligence: enIntelligence,
 };
 
 /** Loaders for the locales that are not bundled into the entry chunk. */
@@ -107,6 +109,7 @@ const CATALOG_LOADERS: Record<
     home: () => import("@/i18n/locales/es/home.json"),
     contacts: () => import("@/i18n/locales/es/contacts.json"),
     onboarding: () => import("@/i18n/locales/es/onboarding.json"),
+    intelligence: () => import("@/i18n/locales/es/intelligence.json"),
   },
 };
 

--- a/clients/web/src/i18n/i18next.d.ts
+++ b/clients/web/src/i18n/i18next.d.ts
@@ -17,6 +17,7 @@ import type channels from "@/i18n/locales/en/channels.json";
 import type contacts from "@/i18n/locales/en/contacts.json";
 import type credentialRequests from "@/i18n/locales/en/credential-requests.json";
 import type home from "@/i18n/locales/en/home.json";
+import type intelligence from "@/i18n/locales/en/intelligence.json";
 import type library from "@/i18n/locales/en/library.json";
 import type logs from "@/i18n/locales/en/logs.json";
 import type onboarding from "@/i18n/locales/en/onboarding.json";
@@ -47,6 +48,7 @@ declare module "i18next" {
       home: typeof home;
       contacts: typeof contacts;
       onboarding: typeof onboarding;
+      intelligence: typeof intelligence;
     };
     returnNull: false;
   }

--- a/clients/web/src/i18n/locales/en/intelligence.json
+++ b/clients/web/src/i18n/locales/en/intelligence.json
@@ -1,0 +1,421 @@
+{
+  "applyPersonalityUpdate": {
+    "conversationTitle": "Updating personality"
+  },
+  "applyRename": {
+    "conversationTitle": "Updating name"
+  },
+  "assistantNameEditor": {
+    "greeting": "Hi, I’m {name}",
+    "renamingInProgressAriaLabel": "Renaming in progress"
+  },
+  "categorySidebar": {
+    "all": "All",
+    "skillCategoriesAriaLabel": "Skill categories"
+  },
+  "conceptDetailPanel": {
+    "askAboutThis": "Ask about this",
+    "askPrompt": "Tell me what you remember about \"{title}\" and how it connects to the rest of what you know.",
+    "backAriaLabel": "Back",
+    "closeAriaLabel": "Close",
+    "connectionCount": "{count, plural, one {# connection} other {# connections}}",
+    "emptyContent": "This concept doesn't have written content yet. It exists as a link in the graph, but its page is empty.",
+    "loadError": "Couldn't load this concept. Try again in a moment.",
+    "readFullNote": "Read full note",
+    "refine": "Refine",
+    "refinePrompt": "I want to refine what you remember about \"{title}\". Ask me what's off and we'll correct it together.",
+    "showLess": "Show less",
+    "trailAriaLabel": "Concept trail",
+    "updated": "Updated {date}",
+    "wiredTo": "Wired to"
+  },
+  "conceptGraphConstants": {
+    "nodeKind": {
+      "capability": "Capability",
+      "concept": "Concept",
+      "other": "Other",
+      "pending": "Pending",
+      "skill": "Skill"
+    }
+  },
+  "conceptGraphIntroBanner": {
+    "description": "Every idea it learns, and the links it draws between them, shows up here. The map grows and rearranges itself as you talk, so the more you share, the richer it gets.",
+    "dismissAriaLabel": "Dismiss",
+    "title": "This is your assistant's mind"
+  },
+  "conceptGraphLegend": {
+    "coloredByTheme": "Colored by theme",
+    "learned": "Learned",
+    "link": "Link",
+    "moreThemes": "{count, plural, one {+# more} other {+# more}}"
+  },
+  "conceptGraphView": {
+    "clearSearchAriaLabel": "Clear search",
+    "dragToRotateHint": "drag to rotate · scroll to zoom",
+    "emptyDetail": "As your assistant learns and links ideas, they'll appear here as a living map of its memory.",
+    "emptyTitle": "No concepts yet",
+    "enterFullscreenAriaLabel": "Enter fullscreen",
+    "exitFullscreenAriaLabel": "Exit fullscreen",
+    "loadErrorDetail": "Something went wrong fetching your assistant's memory. Try again in a moment.",
+    "loadErrorTitle": "Couldn't load the memory graph",
+    "resetViewAriaLabel": "Reset view",
+    "searchConceptsAriaLabel": "Search concepts",
+    "searchConceptsPlaceholder": "Search concepts…",
+    "truncatedNotice": "{count, plural, one {Showing the # most-connected concept} other {Showing the # most-connected concepts}}",
+    "zoomInAriaLabel": "Zoom in",
+    "zoomOutAriaLabel": "Zoom out"
+  },
+  "createMemoryModal": {
+    "cancel": "Cancel",
+    "contentLabel": "What should I remember?",
+    "contentPlaceholder": "e.g. I prefer concise, bulleted summaries.",
+    "create": "Create memory",
+    "createError": "Failed to create memory.",
+    "creating": "Creating…",
+    "helperText": "It lands on the map right away, then settles into a concept as it's filed.",
+    "savedFoundToast": "Got it. Taking you to it.",
+    "savedPendingToast": "Got it. It's on your map while I file it away.",
+    "saveError": "Couldn't save that memory.",
+    "title": "New memory"
+  },
+  "getMemoryGraph": {
+    "failureMessage": "Failed to load the memory graph."
+  },
+  "getMemoryGraphNode": {
+    "failureMessage": "Failed to load this concept."
+  },
+  "identityOverview": {
+    "cardHoverLine": {
+      "channels": "All the places you can reach me",
+      "contacts": "The people I know and trust",
+      "library": "The apps and docs I've made for you",
+      "memory": "Everything I remember",
+      "personality": "Go ahead, tweak my soul",
+      "schedules": "What I do on repeat",
+      "superpowers": "Everything I know how to do",
+      "workspace": "All the files that power me"
+    },
+    "defaultAssistantName": "Assistant",
+    "memoryCountLabel": "{count, plural, one {# memory} other {# memories}}",
+    "renameErrorToast": "The rename didn't go through. Please try again.",
+    "renameSuccessToast": "Say hi to {newName}!",
+    "scheduleCadence": "{cadence} · next {nextRun}",
+    "updateAvatarAndName": "Update avatar and name",
+    "viewMoreSchedules": "{count, plural, one {View # more…} other {View # more…}}"
+  },
+  "identitySections": {
+    "channels": {
+      "description": "Where I listen",
+      "label": "Channels"
+    },
+    "contacts": {
+      "description": "People I know",
+      "label": "Contacts"
+    },
+    "library": {
+      "description": "My apps & docs",
+      "label": "Library"
+    },
+    "memory": {
+      "description": "What I remember",
+      "label": "Memory"
+    },
+    "personality": {
+      "description": "Tune how I talk",
+      "label": "Personality"
+    },
+    "schedules": {
+      "description": "My routines",
+      "label": "Schedules"
+    },
+    "superpowers": {
+      "description": "What I can do",
+      "label": "My Superpowers"
+    },
+    "workspace": {
+      "description": "My files",
+      "label": "Workspace"
+    }
+  },
+  "installSkill": {
+    "failureMessage": "Failed to install skill."
+  },
+  "intelligenceLayout": {
+    "backToAriaLabel": "Back to {name}",
+    "backToTitle": "Back to {name}"
+  },
+  "listConceptPages": {
+    "failureMessage": "Failed to load concept pages."
+  },
+  "memoryFormat": {
+    "justNow": "just now"
+  },
+  "memoryPage": {
+    "createMemory": "Create memory"
+  },
+  "memoryTypes": {
+    "sourceType": {
+      "direct": "Told directly",
+      "inferred": "Inferred",
+      "observed": "Observed",
+      "toldByOther": "Told by other"
+    }
+  },
+  "memoryUpgradePrompt": {
+    "memorySettings": "Memory settings",
+    "tryAgain": "Try again",
+    "turnMemoryOn": "Turn memory on",
+    "upgradeMemory": "Upgrade memory"
+  },
+  "personalityAxes": {
+    "companionCoworker": {
+      "left": "Companion",
+      "right": "Coworker"
+    },
+    "executeCollaborate": {
+      "left": "Independent",
+      "right": "Collaborative"
+    },
+    "genzBoomer": {
+      "left": "Gen Z",
+      "right": "Baby Boomer"
+    },
+    "playfulSerious": {
+      "left": "Playful",
+      "right": "Serious"
+    },
+    "politeUnfiltered": {
+      "left": "Polite",
+      "right": "Unfiltered"
+    }
+  },
+  "personalityPage": {
+    "back": "Back",
+    "subtitle": "Slide the dials, then hit update, I’ll rewrite myself to match.",
+    "title": "Shape my personality",
+    "updateErrorToast": "The personality update didn't go through. Please try again.",
+    "updatePersonality": "Update personality",
+    "updateSuccessToast": "Personality updated. Go say hi!",
+    "updatingPersonality": "Updating {name}'s personality…"
+  },
+  "personalitySignature": {
+    "ariaLabel": "Personality: {summary}",
+    "axisBalanced": "{left} and {right} balanced",
+    "axisLean": "{percent}% {label}"
+  },
+  "personalitySliderRow": {
+    "rangeAriaLabel": "{left} to {right}"
+  },
+  "pluginConstants": {
+    "installError": "Failed to install plugin. Please try again.",
+    "removeConfirmMessage": "Remove \"{name}\" from this assistant?",
+    "removeError": "Failed to remove plugin. Please try again.",
+    "riskyUpgradeConfirmLabel": "Upgrade anyway",
+    "riskyUpgradeConfirmMessage": "\"{name}\" has local edits that will be overwritten by the upgrade. Continue?",
+    "toggleError": "Failed to update plugin. Please try again.",
+    "upgradeError": "Failed to upgrade plugin. Please try again."
+  },
+  "pluginDetail": {
+    "backToPluginsAriaLabel": "Back to plugins",
+    "noReadme": "This plugin doesn't ship a README.",
+    "version": "v{version}"
+  },
+  "pluginDetailShared": {
+    "autoIncludeInChat": "Auto-include in chat",
+    "download": "Download",
+    "homepageLabel": "Homepage",
+    "hooksLabel": "Hooks",
+    "install": "Install",
+    "licenseLabel": "License",
+    "loadErrorDetail": "It may not exist, or your assistant may be on an older build.",
+    "loadErrorTitle": "We couldn't load this plugin.",
+    "localSource": "Local",
+    "remove": "Remove",
+    "removePluginTitle": "Remove plugin",
+    "skillsLabel": "Skills",
+    "sourceLabel": "Source",
+    "toolsLabel": "Tools",
+    "upgrade": "Upgrade",
+    "upgradePluginTitle": "Upgrade plugin",
+    "upgradeTitle": "Upgrade {fromSha} → {toSha}"
+  },
+  "pluginListRow": {
+    "disabled": "Disabled",
+    "enabled": "Enabled",
+    "installingAriaLabel": "Installing",
+    "installPluginAriaLabel": "Install plugin",
+    "moreIssues": "{count, plural, one { (+# more)} other { (+# more)}}",
+    "noDescription": "No description provided.",
+    "pluginTag": "Plugin",
+    "removePluginAriaLabel": "Remove plugin",
+    "version": "v{version}"
+  },
+  "pluginOriginBadge": {
+    "external": "External",
+    "local": "Local"
+  },
+  "pluginToast": {
+    "alreadyUpToDate": "{name} is already up to date",
+    "installed": "Installed {name}",
+    "pluginFallback": "plugin",
+    "pluginFallbackCapitalized": "Plugin",
+    "removed": "Removed {name}",
+    "upgraded": "Upgraded {name} to {sha}"
+  },
+  "recencyLens": {
+    "all": "All",
+    "ariaLabel": "Recency window",
+    "month": "Month",
+    "week": "Week"
+  },
+  "sections": {
+    "channels": "Channels",
+    "contacts": "Contacts",
+    "library": "Library",
+    "memory": "Memory",
+    "schedules": "Schedules",
+    "superpowers": "My Superpowers",
+    "workspace": "Workspace"
+  },
+  "skillDetail": {
+    "backToSkillsAriaLabel": "Back to skills",
+    "filesTab": "Files",
+    "fileViewModeAriaLabel": "File view mode",
+    "historyTab": "History",
+    "install": "Install",
+    "noFilesAvailable": "No files available.",
+    "openInWorkspaceAriaLabel": "Open in Workspace",
+    "pendingAriaLabel": "Pending",
+    "preview": "Preview",
+    "remove": "Remove",
+    "saveFailed": "Save failed",
+    "selectAFile": "Select a file",
+    "selectFilePrompt": "Select a file to view its contents.",
+    "source": "Source"
+  },
+  "skillDetailPage": {
+    "backToSuperpowers": "Back to My Superpowers",
+    "notFoundSubtitle": "This skill may have been removed, or the link is out of date.",
+    "notFoundTitle": "Skill not found"
+  },
+  "skillFileContent": {
+    "binaryFile": "Binary file. No preview available.",
+    "noPreviewAvailable": "No preview available for {fileName}."
+  },
+  "skillOriginBadge": {
+    "assistantMemory": "Assistant's Memory",
+    "custom": "Custom"
+  },
+  "skillRevisionHistory": {
+    "loadError": "Couldn't load revision history.",
+    "noChanges": "No changes recorded yet.",
+    "noPreviewForChange": "No preview available for this change.",
+    "truncatedNotice": "Showing recent changes. Older history is periodically compacted, so this may not reach back to when the skill was created."
+  },
+  "skillRow": {
+    "bundledSkillCannotBeRemovedAriaLabel": "Bundled skill cannot be removed",
+    "bundledSkillsCannotBeRemoved": "Bundled skills cannot be removed",
+    "installingAriaLabel": "Installing",
+    "installSkillAriaLabel": "Install skill",
+    "removeSkillAriaLabel": "Remove skill"
+  },
+  "skillsErrorState": {
+    "subtitle": "Something went wrong. Try refreshing the page.",
+    "title": "Failed to load skills"
+  },
+  "superpowersFilters": {
+    "categoriesLabel": "Categories",
+    "done": "Done",
+    "filterAriaLabel": "Filter superpowers",
+    "filterLabel": {
+      "all": "All",
+      "assistantMemory": "Assistant's Memory",
+      "available": "Available",
+      "custom": "Custom",
+      "installed": "Installed",
+      "plugins": "Plugins",
+      "skills": "Skills"
+    },
+    "filtersTitle": "Filters",
+    "searchAriaLabel": "Search superpowers",
+    "searchPlaceholder": "Search superpowers",
+    "sourceLabel": "Source",
+    "statusLabel": "Status",
+    "typeLabel": "Type"
+  },
+  "superpowersTab": {
+    "catalogBrowsingUnavailableNotice": "Plugin catalog browsing is temporarily unavailable. Installed plugins are still listed below.",
+    "categoriesAriaLabel": "Superpower categories",
+    "dismissTipAriaLabel": "Dismiss tip",
+    "emptyState": {
+      "assistantMemorySubtitle": "Skills your assistant authors from past conversations will appear here.",
+      "assistantMemoryTitle": "No Skills From Memory",
+      "availableSubtitle": "All available skills and plugins are installed.",
+      "availableTitle": "Nothing Left to Install",
+      "categorySubtitle": "Try selecting a different category or clearing the filter.",
+      "categoryTitle": "Nothing in this category",
+      "clawhubSubtitle": "No Clawhub skills found. Try searching the catalog.",
+      "clawhubTitle": "No Clawhub Skills",
+      "customSubtitle": "Create a custom skill by describing what you want in chat.",
+      "customTitle": "No Custom Skills",
+      "defaultSubtitle": "Check your connection to the Vellum catalog.",
+      "defaultTitle": "No Superpowers Available",
+      "installedSubtitle": "Ask your assistant in chat to search for and install new skills and plugins.",
+      "installedTitle": "No Superpowers Installed",
+      "pluginsSubtitle": "Browse the catalog to install plugins that extend your assistant.",
+      "pluginsTitle": "No Plugins Found",
+      "skillsshSubtitle": "No skills.sh skills found. Try searching the catalog.",
+      "skillsshTitle": "No skills.sh Skills",
+      "skillsSubtitle": "Ask your assistant in chat to search for and install new skills.",
+      "skillsTitle": "No Skills Found",
+      "vellumSubtitle": "No bundled Vellum skills found.",
+      "vellumTitle": "No Vellum Skills"
+    },
+    "errorStateSubtitle": "Something went wrong. Try refreshing the page.",
+    "errorStateTitle": "Failed to load superpowers",
+    "pluginsUnavailableNotice": "Plugins are temporarily unavailable. Skills are still listed below.",
+    "skillsUnavailableNotice": "Skills are temporarily unavailable. Plugins are still listed below.",
+    "tipBannerText": "Create a new custom skill by describing what you want in chat, or install plugins to extend your assistant."
+  },
+  "updateAvailableBadge": {
+    "updateAvailable": "Update available",
+    "upgradePluginAriaLabel": "Upgrade plugin"
+  },
+  "useIdentitySectionStats": {
+    "activeLabel": "{count, plural, one {active} other {active}}",
+    "appCount": "{count, plural, one {# app} other {# apps}}",
+    "connectedLabel": "{count, plural, one {connected} other {connected}}",
+    "docCount": "{count, plural, one {# doc} other {# docs}}",
+    "itemLabel": "{count, plural, one {item} other {items}}",
+    "noSchedulesText": "Nothing scheduled yet",
+    "personLabel": "{count, plural, one {person} other {people}}",
+    "pluginCount": "{count, plural, one {# plugin} other {# plugins}}",
+    "skillCount": "{count, plural, one {# skill} other {# skills}}"
+  },
+  "usePluginsList": {
+    "failureMessage": "Failed to load plugins"
+  },
+  "memoryUnavailable": {
+    "statusError": {
+      "title": "Couldn't check your memory settings",
+      "detail": "Something went wrong reading this assistant's memory status, so there's nothing reliable to tell you yet."
+    },
+    "off": {
+      "title": "Memory is turned off",
+      "detail": "Your assistant isn't keeping anything from your conversations, so there's no map to draw. Turn Memory back on to start remembering again."
+    },
+    "legacy": {
+      "title": "Upgrade to memory v3",
+      "detail": "Your assistant is on an older memory engine. Memory v3 reorganizes what it knows into a linked wiki of concepts, and that wiki is what this map draws."
+    },
+    "unknown": {
+      "title": "Memory graph isn't available",
+      "detail": "This assistant's memory backend doesn't report enough to say why. Update your assistant, and this page will tell you what it needs."
+    },
+    "prompts": {
+      "v2": "Migrate my memory from v2 to v3. That's most likely your \"Memory v3 Migration\" skill, but work out what my corpus actually needs and follow whichever skill you use exactly.\n\nRun it in the background and tell me when it's done, or if something blocks.",
+      "v1": "Migrate my memory from v1 to v3. That's most likely two hops, your \"Memory v2 Migration\" skill and then your \"Memory v3 Migration\" skill, but work out what my assistant actually needs and follow whichever skills you use exactly.\n\nRun it in the background and tell me when it's done, or if something blocks.",
+      "enable": "Turn my memory back on. I'd like you to start remembering things from our conversations again."
+    }
+  }
+}

--- a/clients/web/src/i18n/locales/es/intelligence.json
+++ b/clients/web/src/i18n/locales/es/intelligence.json
@@ -1,0 +1,421 @@
+{
+  "applyPersonalityUpdate": {
+    "conversationTitle": "Actualizando la personalidad"
+  },
+  "applyRename": {
+    "conversationTitle": "Actualizando el nombre"
+  },
+  "assistantNameEditor": {
+    "greeting": "Hola, soy {name}",
+    "renamingInProgressAriaLabel": "Cambio de nombre en curso"
+  },
+  "categorySidebar": {
+    "all": "Todas",
+    "skillCategoriesAriaLabel": "Categorías de habilidades"
+  },
+  "conceptDetailPanel": {
+    "askAboutThis": "Preguntar sobre esto",
+    "askPrompt": "Cuéntame qué recuerdas sobre \"{title}\" y cómo se conecta con el resto de lo que sabes.",
+    "backAriaLabel": "Atrás",
+    "closeAriaLabel": "Cerrar",
+    "connectionCount": "{count, plural, one {# conexión} other {# conexiones}}",
+    "emptyContent": "Este concepto todavía no tiene contenido escrito. Existe como un enlace en el grafo, pero su página está vacía.",
+    "loadError": "No se pudo cargar este concepto. Vuelve a intentarlo en un momento.",
+    "readFullNote": "Leer la nota completa",
+    "refine": "Refinar",
+    "refinePrompt": "Quiero refinar lo que recuerdas sobre \"{title}\". Pregúntame qué no es correcto y lo corregiremos juntos.",
+    "showLess": "Mostrar menos",
+    "trailAriaLabel": "Ruta de conceptos",
+    "updated": "Actualizado el {date}",
+    "wiredTo": "Conectado con"
+  },
+  "conceptGraphConstants": {
+    "nodeKind": {
+      "capability": "Capacidad",
+      "concept": "Concepto",
+      "other": "Otro",
+      "pending": "Pendiente",
+      "skill": "Habilidad"
+    }
+  },
+  "conceptGraphIntroBanner": {
+    "description": "Cada idea que aprende, y los vínculos que traza entre ellas, aparece aquí. El mapa crece y se reorganiza mientras hablas, así que cuanto más compartas, más rico se vuelve.",
+    "dismissAriaLabel": "Descartar",
+    "title": "Esta es la mente de tu asistente"
+  },
+  "conceptGraphLegend": {
+    "coloredByTheme": "Coloreado por tema",
+    "learned": "Aprendido",
+    "link": "Enlace",
+    "moreThemes": "{count, plural, one {+# más} other {+# más}}"
+  },
+  "conceptGraphView": {
+    "clearSearchAriaLabel": "Borrar búsqueda",
+    "dragToRotateHint": "arrastra para rotar · desplaza para hacer zoom",
+    "emptyDetail": "A medida que tu asistente aprende y conecta ideas, aparecerán aquí como un mapa vivo de su memoria.",
+    "emptyTitle": "Todavía no hay conceptos",
+    "enterFullscreenAriaLabel": "Entrar en pantalla completa",
+    "exitFullscreenAriaLabel": "Salir de pantalla completa",
+    "loadErrorDetail": "Algo salió mal al obtener la memoria de tu asistente. Vuelve a intentarlo en un momento.",
+    "loadErrorTitle": "No se pudo cargar el grafo de memoria",
+    "resetViewAriaLabel": "Restablecer la vista",
+    "searchConceptsAriaLabel": "Buscar conceptos",
+    "searchConceptsPlaceholder": "Buscar conceptos…",
+    "truncatedNotice": "{count, plural, one {Mostrando el # concepto más conectado} other {Mostrando los # conceptos más conectados}}",
+    "zoomInAriaLabel": "Acercar",
+    "zoomOutAriaLabel": "Alejar"
+  },
+  "createMemoryModal": {
+    "cancel": "Cancelar",
+    "contentLabel": "¿Qué debería recordar?",
+    "contentPlaceholder": "p. ej. Prefiero resúmenes concisos con viñetas.",
+    "create": "Crear recuerdo",
+    "createError": "No se pudo crear el recuerdo.",
+    "creating": "Creando…",
+    "helperText": "Aparece en el mapa de inmediato y luego se asienta en un concepto a medida que se archiva.",
+    "savedFoundToast": "Entendido. Te llevo hasta él.",
+    "savedPendingToast": "Entendido. Está en tu mapa mientras lo archivo.",
+    "saveError": "No se pudo guardar ese recuerdo.",
+    "title": "Nuevo recuerdo"
+  },
+  "getMemoryGraph": {
+    "failureMessage": "No se pudo cargar el grafo de memoria."
+  },
+  "getMemoryGraphNode": {
+    "failureMessage": "No se pudo cargar este concepto."
+  },
+  "identityOverview": {
+    "cardHoverLine": {
+      "channels": "Todos los lugares donde puedes contactarme",
+      "contacts": "Las personas que conozco y en quienes confío",
+      "library": "Las apps y documentos que he creado para ti",
+      "memory": "Todo lo que recuerdo",
+      "personality": "Adelante, ajusta mi alma",
+      "schedules": "Lo que hago en bucle",
+      "superpowers": "Todo lo que sé hacer",
+      "workspace": "Todos los archivos que me hacen funcionar"
+    },
+    "defaultAssistantName": "Asistente",
+    "memoryCountLabel": "{count, plural, one {# recuerdo} other {# recuerdos}}",
+    "renameErrorToast": "El cambio de nombre no se completó. Vuelve a intentarlo.",
+    "renameSuccessToast": "¡Saluda a {newName}!",
+    "scheduleCadence": "{cadence} · próxima {nextRun}",
+    "updateAvatarAndName": "Actualizar avatar y nombre",
+    "viewMoreSchedules": "{count, plural, one {Ver # más…} other {Ver # más…}}"
+  },
+  "identitySections": {
+    "channels": {
+      "description": "Donde escucho",
+      "label": "Canales"
+    },
+    "contacts": {
+      "description": "Personas que conozco",
+      "label": "Contactos"
+    },
+    "library": {
+      "description": "Mis apps y documentos",
+      "label": "Biblioteca"
+    },
+    "memory": {
+      "description": "Lo que recuerdo",
+      "label": "Memoria"
+    },
+    "personality": {
+      "description": "Ajusta cómo hablo",
+      "label": "Personalidad"
+    },
+    "schedules": {
+      "description": "Mis rutinas",
+      "label": "Programaciones"
+    },
+    "superpowers": {
+      "description": "Lo que puedo hacer",
+      "label": "Mis superpoderes"
+    },
+    "workspace": {
+      "description": "Mis archivos",
+      "label": "Espacio de trabajo"
+    }
+  },
+  "installSkill": {
+    "failureMessage": "No se pudo instalar la habilidad."
+  },
+  "intelligenceLayout": {
+    "backToAriaLabel": "Volver a {name}",
+    "backToTitle": "Volver a {name}"
+  },
+  "listConceptPages": {
+    "failureMessage": "No se pudieron cargar las páginas de conceptos."
+  },
+  "memoryFormat": {
+    "justNow": "justo ahora"
+  },
+  "memoryPage": {
+    "createMemory": "Crear recuerdo"
+  },
+  "memoryTypes": {
+    "sourceType": {
+      "direct": "Dicho directamente",
+      "inferred": "Inferido",
+      "observed": "Observado",
+      "toldByOther": "Dicho por otra persona"
+    }
+  },
+  "memoryUpgradePrompt": {
+    "memorySettings": "Ajustes de memoria",
+    "tryAgain": "Intentar de nuevo",
+    "turnMemoryOn": "Activar la memoria",
+    "upgradeMemory": "Actualizar memoria"
+  },
+  "personalityAxes": {
+    "companionCoworker": {
+      "left": "Compañero",
+      "right": "Colega"
+    },
+    "executeCollaborate": {
+      "left": "Independiente",
+      "right": "Colaborativo"
+    },
+    "genzBoomer": {
+      "left": "Gen Z",
+      "right": "Baby Boomer"
+    },
+    "playfulSerious": {
+      "left": "Juguetón",
+      "right": "Serio"
+    },
+    "politeUnfiltered": {
+      "left": "Educado",
+      "right": "Sin filtro"
+    }
+  },
+  "personalityPage": {
+    "back": "Atrás",
+    "subtitle": "Mueve los diales y luego pulsa actualizar: me reescribiré para encajar.",
+    "title": "Da forma a mi personalidad",
+    "updateErrorToast": "La actualización de personalidad no se completó. Vuelve a intentarlo.",
+    "updatePersonality": "Actualizar personalidad",
+    "updateSuccessToast": "Personalidad actualizada. ¡Ve a saludar!",
+    "updatingPersonality": "Actualizando la personalidad de {name}…"
+  },
+  "personalitySignature": {
+    "ariaLabel": "Personalidad: {summary}",
+    "axisBalanced": "{left} y {right} equilibrados",
+    "axisLean": "{percent}% {label}"
+  },
+  "personalitySliderRow": {
+    "rangeAriaLabel": "De {left} a {right}"
+  },
+  "pluginConstants": {
+    "installError": "No se pudo instalar el plugin. Vuelve a intentarlo.",
+    "removeConfirmMessage": "¿Quitar \"{name}\" de este asistente?",
+    "removeError": "No se pudo quitar el plugin. Vuelve a intentarlo.",
+    "riskyUpgradeConfirmLabel": "Actualizar de todos modos",
+    "riskyUpgradeConfirmMessage": "\"{name}\" tiene cambios locales que se sobrescribirán con la actualización. ¿Continuar?",
+    "toggleError": "No se pudo actualizar el plugin. Vuelve a intentarlo.",
+    "upgradeError": "No se pudo actualizar el plugin. Vuelve a intentarlo."
+  },
+  "pluginDetail": {
+    "backToPluginsAriaLabel": "Volver a los plugins",
+    "noReadme": "Este plugin no incluye un README.",
+    "version": "v{version}"
+  },
+  "pluginDetailShared": {
+    "autoIncludeInChat": "Incluir automáticamente en el chat",
+    "download": "Descargar",
+    "homepageLabel": "Sitio web",
+    "hooksLabel": "Hooks",
+    "install": "Instalar",
+    "licenseLabel": "Licencia",
+    "loadErrorDetail": "Puede que no exista, o que tu asistente tenga una versión anterior.",
+    "loadErrorTitle": "No pudimos cargar este plugin.",
+    "localSource": "Local",
+    "remove": "Quitar",
+    "removePluginTitle": "Quitar plugin",
+    "skillsLabel": "Habilidades",
+    "sourceLabel": "Fuente",
+    "toolsLabel": "Herramientas",
+    "upgrade": "Actualizar",
+    "upgradePluginTitle": "Actualizar plugin",
+    "upgradeTitle": "Actualizar {fromSha} → {toSha}"
+  },
+  "pluginListRow": {
+    "disabled": "Desactivado",
+    "enabled": "Activado",
+    "installingAriaLabel": "Instalando",
+    "installPluginAriaLabel": "Instalar plugin",
+    "moreIssues": "{count, plural, one { (+# más)} other { (+# más)}}",
+    "noDescription": "No se proporcionó descripción.",
+    "pluginTag": "Plugin",
+    "removePluginAriaLabel": "Quitar plugin",
+    "version": "v{version}"
+  },
+  "pluginOriginBadge": {
+    "external": "Externo",
+    "local": "Local"
+  },
+  "pluginToast": {
+    "alreadyUpToDate": "{name} ya está actualizado",
+    "installed": "Se instaló {name}",
+    "pluginFallback": "el plugin",
+    "pluginFallbackCapitalized": "El plugin",
+    "removed": "Se quitó {name}",
+    "upgraded": "Se actualizó {name} a {sha}"
+  },
+  "recencyLens": {
+    "all": "Todo",
+    "ariaLabel": "Ventana de antigüedad",
+    "month": "Mes",
+    "week": "Semana"
+  },
+  "sections": {
+    "channels": "Canales",
+    "contacts": "Contactos",
+    "library": "Biblioteca",
+    "memory": "Memoria",
+    "schedules": "Programaciones",
+    "superpowers": "Mis superpoderes",
+    "workspace": "Espacio de trabajo"
+  },
+  "skillDetail": {
+    "backToSkillsAriaLabel": "Volver a las habilidades",
+    "filesTab": "Archivos",
+    "fileViewModeAriaLabel": "Modo de vista de archivo",
+    "historyTab": "Historial",
+    "install": "Instalar",
+    "noFilesAvailable": "No hay archivos disponibles.",
+    "openInWorkspaceAriaLabel": "Abrir en el espacio de trabajo",
+    "pendingAriaLabel": "Pendiente",
+    "preview": "Vista previa",
+    "remove": "Quitar",
+    "saveFailed": "Error al guardar",
+    "selectAFile": "Selecciona un archivo",
+    "selectFilePrompt": "Selecciona un archivo para ver su contenido.",
+    "source": "Código"
+  },
+  "skillDetailPage": {
+    "backToSuperpowers": "Volver a Mis superpoderes",
+    "notFoundSubtitle": "Es posible que esta habilidad se haya eliminado, o que el enlace esté obsoleto.",
+    "notFoundTitle": "Habilidad no encontrada"
+  },
+  "skillFileContent": {
+    "binaryFile": "Archivo binario. No hay vista previa disponible.",
+    "noPreviewAvailable": "No hay vista previa disponible para {fileName}."
+  },
+  "skillOriginBadge": {
+    "assistantMemory": "Memoria del asistente",
+    "custom": "Personalizada"
+  },
+  "skillRevisionHistory": {
+    "loadError": "No se pudo cargar el historial de revisiones.",
+    "noChanges": "Todavía no se registraron cambios.",
+    "noPreviewForChange": "No hay vista previa disponible para este cambio.",
+    "truncatedNotice": "Se muestran los cambios recientes. El historial antiguo se compacta periódicamente, así que puede que no llegue hasta la creación de la habilidad."
+  },
+  "skillRow": {
+    "bundledSkillCannotBeRemovedAriaLabel": "No se puede quitar una habilidad incluida",
+    "bundledSkillsCannotBeRemoved": "Las habilidades incluidas no se pueden quitar",
+    "installingAriaLabel": "Instalando",
+    "installSkillAriaLabel": "Instalar habilidad",
+    "removeSkillAriaLabel": "Quitar habilidad"
+  },
+  "skillsErrorState": {
+    "subtitle": "Algo salió mal. Intenta actualizar la página.",
+    "title": "No se pudieron cargar las habilidades"
+  },
+  "superpowersFilters": {
+    "categoriesLabel": "Categorías",
+    "done": "Listo",
+    "filterAriaLabel": "Filtrar superpoderes",
+    "filterLabel": {
+      "all": "Todos",
+      "assistantMemory": "Memoria del asistente",
+      "available": "Disponibles",
+      "custom": "Personalizadas",
+      "installed": "Instalados",
+      "plugins": "Plugins",
+      "skills": "Habilidades"
+    },
+    "filtersTitle": "Filtros",
+    "searchAriaLabel": "Buscar superpoderes",
+    "searchPlaceholder": "Buscar superpoderes",
+    "sourceLabel": "Origen",
+    "statusLabel": "Estado",
+    "typeLabel": "Tipo"
+  },
+  "superpowersTab": {
+    "catalogBrowsingUnavailableNotice": "La navegación por el catálogo de plugins no está disponible temporalmente. Los plugins instalados siguen apareciendo abajo.",
+    "categoriesAriaLabel": "Categorías de superpoderes",
+    "dismissTipAriaLabel": "Descartar sugerencia",
+    "emptyState": {
+      "assistantMemorySubtitle": "Aquí aparecerán las habilidades que tu asistente crea a partir de conversaciones pasadas.",
+      "assistantMemoryTitle": "Ninguna habilidad de la memoria",
+      "availableSubtitle": "Todas las habilidades y plugins disponibles están instalados.",
+      "availableTitle": "No queda nada por instalar",
+      "categorySubtitle": "Intenta seleccionar otra categoría o borrar el filtro.",
+      "categoryTitle": "Nada en esta categoría",
+      "clawhubSubtitle": "No se encontraron habilidades de Clawhub. Intenta buscar en el catálogo.",
+      "clawhubTitle": "Ninguna habilidad de Clawhub",
+      "customSubtitle": "Crea una habilidad personalizada describiendo lo que quieres en el chat.",
+      "customTitle": "Ninguna habilidad personalizada",
+      "defaultSubtitle": "Comprueba tu conexión con el catálogo de Vellum.",
+      "defaultTitle": "No hay superpoderes disponibles",
+      "installedSubtitle": "Pídele a tu asistente en el chat que busque e instale nuevas habilidades y plugins.",
+      "installedTitle": "No hay superpoderes instalados",
+      "pluginsSubtitle": "Explora el catálogo para instalar plugins que amplíen tu asistente.",
+      "pluginsTitle": "No se encontraron plugins",
+      "skillsshSubtitle": "No se encontraron habilidades de skills.sh. Intenta buscar en el catálogo.",
+      "skillsshTitle": "Ninguna habilidad de skills.sh",
+      "skillsSubtitle": "Pídele a tu asistente en el chat que busque e instale nuevas habilidades.",
+      "skillsTitle": "No se encontraron habilidades",
+      "vellumSubtitle": "No se encontraron habilidades de Vellum incluidas.",
+      "vellumTitle": "Ninguna habilidad de Vellum"
+    },
+    "errorStateSubtitle": "Algo salió mal. Intenta actualizar la página.",
+    "errorStateTitle": "No se pudieron cargar los superpoderes",
+    "pluginsUnavailableNotice": "Los plugins no están disponibles temporalmente. Las habilidades siguen apareciendo abajo.",
+    "skillsUnavailableNotice": "Las habilidades no están disponibles temporalmente. Los plugins siguen apareciendo abajo.",
+    "tipBannerText": "Crea una habilidad personalizada describiendo lo que quieres en el chat, o instala plugins para ampliar tu asistente."
+  },
+  "updateAvailableBadge": {
+    "updateAvailable": "Actualización disponible",
+    "upgradePluginAriaLabel": "Actualizar plugin"
+  },
+  "useIdentitySectionStats": {
+    "activeLabel": "{count, plural, one {activa} other {activas}}",
+    "appCount": "{count, plural, one {# app} other {# apps}}",
+    "connectedLabel": "{count, plural, one {conectado} other {conectados}}",
+    "docCount": "{count, plural, one {# documento} other {# documentos}}",
+    "itemLabel": "{count, plural, one {elemento} other {elementos}}",
+    "noSchedulesText": "Todavía no hay nada programado",
+    "personLabel": "{count, plural, one {persona} other {personas}}",
+    "pluginCount": "{count, plural, one {# plugin} other {# plugins}}",
+    "skillCount": "{count, plural, one {# habilidad} other {# habilidades}}"
+  },
+  "usePluginsList": {
+    "failureMessage": "No se pudieron cargar los plugins"
+  },
+  "memoryUnavailable": {
+    "statusError": {
+      "title": "No se pudieron comprobar tus ajustes de memoria",
+      "detail": "Algo falló al leer el estado de memoria de este asistente, así que aún no hay nada fiable que contarte."
+    },
+    "off": {
+      "title": "La memoria está desactivada",
+      "detail": "Tu asistente no está guardando nada de vuestras conversaciones, así que no hay mapa que dibujar. Vuelve a activar la memoria para que empiece a recordar otra vez."
+    },
+    "legacy": {
+      "title": "Actualiza a memoria v3",
+      "detail": "Tu asistente usa un motor de memoria antiguo. La memoria v3 reorganiza lo que sabe en una wiki enlazada de conceptos, y esa wiki es lo que dibuja este mapa."
+    },
+    "unknown": {
+      "title": "El grafo de memoria no está disponible",
+      "detail": "El backend de memoria de este asistente no informa lo suficiente para decir por qué. Actualiza tu asistente y esta página te dirá qué necesita."
+    },
+    "prompts": {
+      "v2": "Migra mi memoria de v2 a v3. Lo más probable es que sea tu skill «Memory v3 Migration», pero averigua qué necesita realmente mi corpus y sigue exactamente la skill que uses.\n\nEjecútalo en segundo plano y avísame cuando termine, o si algo lo bloquea.",
+      "v1": "Migra mi memoria de v1 a v3. Lo más probable es que sean dos saltos, tu skill «Memory v2 Migration» y luego tu skill «Memory v3 Migration», pero averigua qué necesita realmente mi asistente y sigue exactamente las skills que uses.\n\nEjecútalo en segundo plano y avísame cuando termine, o si algo lo bloquea.",
+      "enable": "Vuelve a activar mi memoria. Me gustaría que empieces a recordar cosas de nuestras conversaciones otra vez."
+    }
+  }
+}

--- a/clients/web/src/i18n/namespaces.ts
+++ b/clients/web/src/i18n/namespaces.ts
@@ -50,6 +50,7 @@ export const NAMESPACES = [
   "home",
   "contacts",
   "onboarding",
+  "intelligence",
 ] as const;
 
 export type Namespace = (typeof NAMESPACES)[number];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds an `intelligence` namespace and moves About Assistant onto it: overview, personality, memory graph, skills, plugins, and superpowers. Then turns the ratchet on for `src/domains/intelligence/**`. ~177 JSX/toast hits plus the non-JSX modules the rule cannot see.

## Scope

- New `intelligence` catalogs (en + es), wired through `namespaces.ts` / `catalogs.ts` / `i18next.d.ts`
- Overview section cards resolve labels/descriptions via greppable per-section keys (not composed from wire ids)
- Layout section titles translated the same way (`plugins`/`skills` share the Superpowers title)
- Memory unavailable copy (including chat seeds) moved out of string constants into the catalog
- Personality axes, plugin confirm/error strings, node-kind labels, memory source labels, toasts, empty states

## Lint rule

`preserveAspectRatio` joins the structural-prop denylist. An SVG `preserveAspectRatio="xMidYMid meet"` has spaces and capitals, so `looksLikeCopy` read it as a sentence.

## Verification

- `bun run lint` — 0 errors, 16 warnings (baseline)
- `bunx tsc --noEmit` clean
- `bun test src/i18n/catalogs.test.ts` + focused intelligence tests (layout, identity-sections, memory-unavailable-copy, skill-file-content, run-identity-rewrite)
- `bun run build` emits the Spanish intelligence chunk

## What is left

`settings` (~1585), `chat` (~1066), `components` (~463), and a small `hooks`/`utils`/`lib` tail. `ABOUT_ASSISTANT_SECTIONS` labels in `utils/routes.ts` stay English for sidebar/path metadata; the intelligence surfaces that render them now translate by key.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7f2993b-c41a-4c7d-8427-a880d12f5a8a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7f2993b-c41a-4c7d-8427-a880d12f5a8a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

