### PR TITLE
fix(assistant): allow .sh script uploads in chat

### DIFF
--- a/assistant/src/__tests__/attachments-store.test.ts
+++ b/assistant/src/__tests__/attachments-store.test.ts
@@ -722,12 +722,6 @@ describe("validateAttachmentUpload", () => {
       expect(exeResult.error).toContain(".exe");
     }
 
-    const shResult = validateAttachmentUpload("script.sh", "text/plain");
-    expect(shResult.ok).toBe(false);
-    if (!shResult.ok) {
-      expect(shResult.error).toContain(".sh");
-    }
-
     const isoResult = validateAttachmentUpload(
       "disk.iso",
       "application/octet-stream",
@@ -736,6 +730,24 @@ describe("validateAttachmentUpload", () => {
     if (!isoResult.ok) {
       expect(isoResult.error).toContain(".iso");
     }
+  });
+
+  test("accepts shell scripts as text attachments", () => {
+    expect(validateAttachmentUpload("script.sh", "text/plain").ok).toBe(true);
+    expect(validateAttachmentUpload("script.SH", "text/plain").ok).toBe(true);
+    expect(
+      validateAttachmentUpload("setup.sh", "application/x-sh").ok,
+    ).toBe(true);
+    expect(
+      validateAttachmentUpload("run.sh", "application/x-shellscript").ok,
+    ).toBe(true);
+    expect(validateAttachmentUpload("run.sh", "text/x-sh").ok).toBe(true);
+    expect(validateAttachmentUpload("run.sh", "text/x-shellscript").ok).toBe(
+      true,
+    );
+    expect(
+      validateAttachmentUpload("run.sh", "application/octet-stream").ok,
+    ).toBe(true);
   });
 
   test("rejects dangerous extensions regardless of claimed MIME type", () => {
@@ -748,7 +760,9 @@ describe("validateAttachmentUpload", () => {
     expect(
       validateAttachmentUpload("PROGRAM.EXE", "application/octet-stream").ok,
     ).toBe(false);
-    expect(validateAttachmentUpload("script.SH", "text/plain").ok).toBe(false);
+    expect(validateAttachmentUpload("INSTALL.DMG", "application/octet-stream").ok).toBe(
+      false,
+    );
   });
 
   test("rejects unsupported MIME types", () => {
@@ -812,11 +826,6 @@ describe("validateAttachmentUpload", () => {
     ).toBe(true);
     expect(
       validateAttachmentUpload("payload.exe", "application/octet-stream", {
-        trustedSource: true,
-      }).ok,
-    ).toBe(true);
-    expect(
-      validateAttachmentUpload("build.sh", "text/plain", {
         trustedSource: true,
       }).ok,
     ).toBe(true);

--- a/assistant/src/persistence/attachments-store.ts
+++ b/assistant/src/persistence/attachments-store.ts
@@ -477,6 +477,11 @@ const ALLOWED_MIME_TYPES = new Set([
   // Source code
   "text/javascript",
   "text/typescript",
+  // Shell scripts (browsers and OS file pickers report these for .sh files)
+  "application/x-sh",
+  "application/x-shellscript",
+  "text/x-sh",
+  "text/x-shellscript",
   // Archives
   "application/zip",
   "application/gzip",
@@ -504,7 +509,6 @@ const ALLOWED_MIME_TYPES = new Set([
  */
 const DANGEROUS_EXTENSIONS = new Set([
   "exe",
-  "sh",
   "bat",
   "cmd",
   "com",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Chat uploads of `.sh` files failed immediately with a 415 because `validateAttachmentUpload` treated `.sh` as a dangerous executable extension.
- Remove `.sh` from the dangerous-extension blocklist and allow common shell-script MIME types (`application/x-sh`, `application/x-shellscript`, `text/x-sh`, `text/x-shellscript`).
- Binary/installer extensions (`.exe`, `.dmg`, `.msi`, etc.) stay blocked for untrusted uploads.

## Test Plan
- [x] `cd assistant && bun test src/__tests__/attachments-store.test.ts`
- [ ] Manually attach a `.sh` file in chat and confirm it uploads and can be sent with a message

## Risk
Low. Narrows the blocklist for text shell scripts only. Untrusted channel senders can now attach `.sh` files (guardians already could via `trustedSource`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-32b0b7a1-18b2-4816-ab5c-62f024712422?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32b0b7a1-18b2-4816-ab5c-62f024712422&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

