### PR TITLE
fix(hooks): return first-party default plugin hooks from getUserHooksFor

### DIFF
--- a/assistant/src/__tests__/default-plugin-names-guard.test.ts
+++ b/assistant/src/__tests__/default-plugin-names-guard.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
 import { getAllDefaultPlugins } from "../plugins/defaults/index.js";
-import { getAllDefaultPluginNames } from "../plugins/defaults/main.js";
+import {
+  getAllDefaultPluginNames,
+  isFirstPartyDefaultPlugin,
+} from "../plugins/defaults/main.js";
 
 /**
  * Guard: the filesystem-backed default-plugin registry (`defaults/main.ts`)
@@ -24,5 +27,13 @@ describe("default plugin names", () => {
     for (const name of getAllDefaultPluginNames()) {
       expect(name).toMatch(/^default-[a-z0-9-]+$/);
     }
+  });
+
+  test("isFirstPartyDefaultPlugin matches the filesystem registry and rejects other names", () => {
+    for (const name of getAllDefaultPluginNames()) {
+      expect(isFirstPartyDefaultPlugin(name)).toBe(true);
+    }
+    expect(isFirstPartyDefaultPlugin("default-a")).toBe(false);
+    expect(isFirstPartyDefaultPlugin("uplug-a")).toBe(false);
   });
 });

--- a/assistant/src/__tests__/mtime-cache.test.ts
+++ b/assistant/src/__tests__/mtime-cache.test.ts
@@ -38,6 +38,7 @@ import {
   reconcilePluginSourcesNow,
   resetPluginCacheForTests,
 } from "../plugins/mtime-cache.js";
+import { resetPluginRegistryForTests } from "../plugins/registry.js";
 import { getSourceVersionsPath } from "../plugins/source-versions.js";
 import {
   __resetRegistryForTesting,
@@ -157,6 +158,7 @@ beforeEach(() => {
   // The registry pulls plugin tools via loadPluginTools(); clear its side
   // (tools + pulled fingerprints) so registrations never leak across tests.
   __resetRegistryForTesting();
+  resetPluginRegistryForTests();
 });
 
 afterAll(() => {

--- a/assistant/src/__tests__/plugin-disabled-state.test.ts
+++ b/assistant/src/__tests__/plugin-disabled-state.test.ts
@@ -22,6 +22,7 @@ import {
   getRegisteredInjectors,
   registerPluginInjectors,
 } from "../plugins/injector-registry.js";
+import { resetPluginCacheForTests } from "../plugins/mtime-cache.js";
 import {
   registerPlugin,
   resetPluginRegistryForTests,
@@ -85,6 +86,7 @@ function makeFakeTool(name: string): Tool {
 
 beforeEach(() => {
   resetPluginRegistryForTests();
+  resetPluginCacheForTests();
   clearInjectorRegistry();
 });
 

--- a/assistant/src/__tests__/plugin-effective-enabled-set.test.ts
+++ b/assistant/src/__tests__/plugin-effective-enabled-set.test.ts
@@ -8,14 +8,18 @@
  * non-null Set is an allowlist, `null` means no restriction. This suite locks
  * the contract that the hook gather sites honor it:
  *  - `getHooksFor(name, { conversationId })` resolves the conversation's scope
- *    and excludes in-process default-plugin hooks outside it; omitting the
+ *    and excludes user-plugin hooks outside it. First-party default plugins
+ *    always remain (they are core runtime, not per-chat toggles). Omitting the
  *    conversationId imposes no restriction.
+ *  - `getUserHooksFor` returns those same in-process default-plugin hooks
+ *    (plus user-land hooks), not only filesystem plugins.
  *  - `collectUserHookEntries(name, dirs, set)` excludes user-land plugin hooks
  *    outside the set, while standalone workspace hooks (not owned by a plugin)
  *    still run.
  *
  * The per-chat scope layers on top of (does not replace) the global
- * `.disabled` sentinel check — a plugin excluded by either is excluded.
+ * `.disabled` sentinel check. A user plugin excluded by either is excluded.
+ * A first-party default plugin is excluded only by `.disabled`.
  * Injectors are intentionally NOT per-chat scoped (see
  * `getRegisteredInjectors`): they run inside already-scoped plugin hooks, and
  * every injector-contributing plugin is a first-party default.
@@ -39,7 +43,7 @@ import {
   collectUserHookEntries,
   resetHookCacheForTests,
 } from "../hooks/hook-loader.js";
-import { getHooksFor } from "../hooks/registry.js";
+import { getHooksFor, getUserHooksFor } from "../hooks/registry.js";
 import {
   registerPlugin,
   resetPluginRegistryForTests,
@@ -135,6 +139,52 @@ describe("getHooksFor per-chat plugin scope (in-process default hooks)", () => {
     expect(
       await getHooksFor("user-prompt-submit", { conversationId: "c1" }),
     ).toHaveLength(0);
+  });
+
+  test("getUserHooksFor returns in-process default plugin hooks", async () => {
+    registerPlugin(
+      buildPlugin("default-memory", {
+        "user-prompt-submit": () => Promise.resolve(),
+      }),
+    );
+    expect(await getUserHooksFor("user-prompt-submit")).toHaveLength(1);
+  });
+
+  test("a first-party default plugin's hooks run even when the chat scope omits it", async () => {
+    let ran = 0;
+    registerPlugin(
+      buildPlugin("default-memory", {
+        "user-prompt-submit": () => {
+          ran++;
+          return Promise.resolve();
+        },
+      }),
+    );
+    resolveScopeMock.mockImplementation(() => new Set(["user-a"]));
+
+    const hooks = await getHooksFor("user-prompt-submit", {
+      conversationId: "c1",
+    });
+    expect(hooks).toHaveLength(1);
+    await hooks[0]!({});
+    expect(ran).toBe(1);
+  });
+
+  test("a workspace-disabled first-party default is still excluded", async () => {
+    registerPlugin(
+      buildPlugin("default-memory", {
+        "user-prompt-submit": () => Promise.resolve(),
+      }),
+    );
+    const dir = join(getWorkspacePluginsDir(), "default-memory");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, ".disabled"), "");
+    try {
+      expect(await getHooksFor("user-prompt-submit")).toHaveLength(0);
+      expect(await getUserHooksFor("user-prompt-submit")).toHaveLength(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/assistant/src/__tests__/plugin-effective-enabled-set.test.ts
+++ b/assistant/src/__tests__/plugin-effective-enabled-set.test.ts
@@ -44,6 +44,7 @@ import {
   resetHookCacheForTests,
 } from "../hooks/hook-loader.js";
 import { getHooksFor, getUserHooksFor } from "../hooks/registry.js";
+import { resetPluginCacheForTests } from "../plugins/mtime-cache.js";
 import {
   registerPlugin,
   resetPluginRegistryForTests,
@@ -70,6 +71,7 @@ function buildPlugin(
 describe("getHooksFor per-chat plugin scope (in-process default hooks)", () => {
   beforeEach(() => {
     resetPluginRegistryForTests();
+    resetPluginCacheForTests();
     resolveScopeMock.mockReset();
     resolveScopeMock.mockImplementation(() => null);
   });

--- a/assistant/src/__tests__/user-plugin-loader.test.ts
+++ b/assistant/src/__tests__/user-plugin-loader.test.ts
@@ -28,6 +28,7 @@ import {
   getCachedUserTools,
   resetPluginCacheForTests,
 } from "../plugins/mtime-cache.js";
+import { resetPluginRegistryForTests } from "../plugins/registry.js";
 import { loadUserPlugins } from "../plugins/user-loader.js";
 
 // Isolate every run under its own tempdir so parallel test files (and
@@ -71,6 +72,7 @@ function clearPluginsDir(): void {
 describe("user plugin loader", () => {
   beforeEach(() => {
     resetPluginCacheForTests();
+    resetPluginRegistryForTests();
     clearPluginsDir();
   });
 

--- a/assistant/src/hooks/registry.ts
+++ b/assistant/src/hooks/registry.ts
@@ -11,13 +11,16 @@
  * boot, plus the user-land lookup that walks discovered plugin names from
  * the plugin cache.
  *
- * {@link getHooksFor} combines both sources: in-process hooks from this
- * registry (filtered by `isPluginDisabled` at read time) and user-land hooks
- * from the plugin cache. The read-time filtering is what makes `assistant
- * plugins disable default-*` take effect immediately in a running assistant:
- * the hooks stay registered but are filtered out on the next turn.
+ * {@link getHooksFor} and {@link getUserHooksFor} both resolve through
+ * {@link getUserHookEntriesFor}, which prepends in-process default-plugin
+ * hooks from this registry (filtered by `isPluginDisabled` at read time)
+ * ahead of user-land hooks from the plugin cache. The read-time filtering
+ * is what makes `assistant plugins disable default-*` take effect immediately
+ * in a running assistant: the hooks stay registered but are filtered out on
+ * the next turn.
  */
 
+import { isFirstPartyDefaultPlugin } from "../plugins/defaults/main.js";
 import { isPluginDisabled } from "../plugins/disabled-state.js";
 import { getDiscoveredUserPluginNames } from "../plugins/mtime-cache.js";
 import type { HookEntry, HookFunction } from "../plugins/types.js";
@@ -78,35 +81,74 @@ export function unregisterPluginHooks(pluginName: string): void {
 // ─── Queries ─────────────────────────────────────────────────────────────────
 
 /**
- * Get all hooks for a given event name from user plugins and standalone
- * workspace hooks, from the hook loader's in-memory cache. Plugin hooks run
+ * In-process (default plugin) hook entries for `name`, filtered by the
+ * `.disabled` sentinel at read time. First-party default plugins always pass
+ * the per-chat allowlist; other in-process registrations (test fixtures) honor
+ * it. Used by {@link getUserHookEntriesFor} so `getUserHooksFor` returns the
+ * same default-plugin hooks {@link getHooksFor} does.
+ */
+function collectInProcessHookEntries<TCtx = unknown>(
+  name: string,
+  effectiveEnabledPlugins?: Set<string> | null,
+): HookEntry<TCtx>[] {
+  const defaultEntries: HookEntry<TCtx>[] = [];
+  for (const entry of hookRegistry.get(name) ?? []) {
+    if (isPluginDisabled(entry.pluginName)) {
+      continue;
+    }
+    if (
+      effectiveEnabledPlugins != null &&
+      !effectiveEnabledPlugins.has(entry.pluginName) &&
+      !isFirstPartyDefaultPlugin(entry.pluginName)
+    ) {
+      continue;
+    }
+    defaultEntries.push({
+      fn: entry.fn as HookFunction<TCtx>,
+      owner: { kind: "plugin", id: entry.pluginName },
+    });
+  }
+  return defaultEntries;
+}
+
+/**
+ * Get all hooks for a given event name: in-process default-plugin hooks
+ * first, then user plugins and standalone workspace hooks. Plugin hooks run
  * in install-date order, the workspace hook runs last.
  *
- * This is a pure cache read: it never scans disk, activates a plugin, or
- * runs `init`. Activation happens only at boot (`populateCacheAtBoot`)
- * and through the imperative install/uninstall poke
- * (`reconcilePluginSourcesNow`), both main-daemon paths, so a
+ * Default-plugin hooks come from the in-process registry (registration at
+ * boot). User-land hooks are a pure cache read: this never scans disk,
+ * activates a plugin, or runs `init`. Activation happens only at boot
+ * (`populateCacheAtBoot`) and through the imperative install/uninstall
+ * poke (`reconcilePluginSourcesNow`), both main-daemon paths, so a
  * sidecar process that dispatches hooks (a worker running conversation
  * turns) can never bring a plugin up in its own process.
  *
  * `effectiveEnabledPlugins` carries the per-chat plugin scope: when non-null,
- * user plugins outside the set are skipped (standalone workspace hooks always
- * run). `null`/omitted means no per-chat restriction.
+ * user plugins outside the set are skipped. First-party default plugins
+ * always pass that allowlist (a workspace `.disabled` sentinel still
+ * excludes them). Standalone workspace hooks always run. `null`/omitted
+ * means no per-chat restriction.
  */
 export async function getUserHookEntriesFor<TCtx = unknown>(
   hookName: string,
   effectiveEnabledPlugins?: Set<string> | null,
 ): Promise<HookEntry<TCtx>[]> {
-  return collectUserHookEntries<TCtx>(
+  const defaultEntries = collectInProcessHookEntries<TCtx>(
+    hookName,
+    effectiveEnabledPlugins,
+  );
+  const userEntries = await collectUserHookEntries<TCtx>(
     hookName,
     getDiscoveredUserPluginNames(),
     effectiveEnabledPlugins,
   );
+  return [...defaultEntries, ...userEntries];
 }
 
 /**
  * {@link getUserHookEntriesFor} without owner attribution. Returns just the
- * hook functions in the same order.
+ * hook functions in the same order, including in-process default-plugin hooks.
  */
 export async function getUserHooksFor<TCtx = unknown>(
   hookName: string,
@@ -131,17 +173,19 @@ export async function getUserHooksFor<TCtx = unknown>(
  * (async, pure cache read). Default hooks are prepended so they compose
  * innermost, ahead of any user plugins.
  *
- * The `TCtx` generic mirrors {@link HookFunction}'s — callers parameterize
+ * The `TCtx` generic mirrors {@link HookFunction}'s: callers parameterize
  * over the concrete context type their hook receives. Hooks that mutate the
  * context in place return `void`; hooks that return a new context replace
  * the threaded value for the next hook in the chain.
  *
  * When `conversationId` is given, the conversation's effective plugin scope is
  * resolved from it (memory, then DB) and layered on top of the global disabled
- * check: a hook's contributing plugin must also be a member of that set or the
- * hook is excluded for this turn (applies to both in-process default plugins
- * and user-land plugins). Omit it (or pass a conversation with no per-chat
- * restriction) and every globally-enabled plugin's hooks run, unchanged.
+ * check: a user plugin must also be a member of that set or its hook is
+ * excluded for this turn. First-party default plugins are not subject to the
+ * per-chat allowlist (they are core runtime infrastructure; the chat pills
+ * only list user-installed plugins), but a workspace `.disabled` sentinel
+ * still excludes them. Omit `conversationId` (or pass a conversation with no
+ * per-chat restriction) and every globally-enabled plugin's hooks run.
  */
 export async function getHookEntriesFor<TCtx = unknown>(
   name: string,
@@ -160,37 +204,7 @@ export async function getHookEntriesFor<TCtx = unknown>(
       options.conversationId,
     );
   }
-  // First-party defaults from the hook registry, filtered by the `.disabled`
-  // sentinel at read time. This is what makes `assistant plugins disable
-  // default-*` take effect immediately in a running assistant: the hooks stay
-  // registered but are filtered out on the next turn.
-  const defaultEntries: HookEntry<TCtx>[] = [];
-  for (const entry of hookRegistry.get(name) ?? []) {
-    if (isPluginDisabled(entry.pluginName)) {
-      continue;
-    }
-    if (
-      effectiveEnabledPlugins != null &&
-      !effectiveEnabledPlugins.has(entry.pluginName)
-    ) {
-      continue;
-    }
-    defaultEntries.push({
-      fn: entry.fn as HookFunction<TCtx>,
-      owner: { kind: "plugin", id: entry.pluginName },
-    });
-  }
-
-  // User-land hooks from the plugin cache (async, pure cache read; dispatch
-  // never activates plugins). The per-chat
-  // scope is threaded through so a deselected user plugin's hooks are excluded
-  // too — standalone workspace hooks (not owned by a plugin) always run.
-  const userEntries = await getUserHookEntriesFor<TCtx>(
-    name,
-    effectiveEnabledPlugins,
-  );
-
-  return [...defaultEntries, ...userEntries];
+  return getUserHookEntriesFor<TCtx>(name, effectiveEnabledPlugins);
 }
 
 /**

--- a/assistant/src/plugins/defaults/main.ts
+++ b/assistant/src/plugins/defaults/main.ts
@@ -29,6 +29,7 @@ const DEFAULTS_DIR = import.meta.dir;
 const DEFAULT_PLUGIN_NAMESPACE_PREFIX = "default-";
 
 let cachedNames: readonly string[] | null = null;
+let cachedNameSet: ReadonlySet<string> | null = null;
 let cachedDirToManifest: ReadonlyMap<string, string> | null = null;
 
 /**
@@ -58,8 +59,22 @@ export function getAllDefaultPluginNames(): readonly string[] {
       }
     }
     cachedNames = names.sort();
+    cachedNameSet = new Set(cachedNames);
   }
   return cachedNames;
+}
+
+/**
+ * Whether `name` is one of the first-party default plugins that ship in
+ * `plugins/defaults/` (e.g. `default-memory`). Used by hook collection so
+ * those plugins' hooks are not dropped by a per-chat allowlist that only
+ * names user-installed plugins.
+ */
+export function isFirstPartyDefaultPlugin(name: string): boolean {
+  if (cachedNameSet === null) {
+    getAllDefaultPluginNames();
+  }
+  return cachedNameSet !== null && cachedNameSet.has(name);
 }
 
 /**

--- a/assistant/src/plugins/pipeline.ts
+++ b/assistant/src/plugins/pipeline.ts
@@ -303,9 +303,10 @@ export async function callWithTimeout<T>(
  *
  * When `initialCtx` carries a `conversationId`, it is passed to
  * {@link getHookEntriesFor}, which resolves the conversation's per-chat plugin
- * scope (memory, then DB) and skips a hook whose contributing plugin is outside
- * the effective set. Contexts without a `conversationId` impose no restriction —
- * every globally-enabled plugin's hook runs.
+ * scope (memory, then DB) and skips a user-plugin hook whose owner is
+ * outside the effective set. First-party default plugins always run (unless
+ * workspace-disabled). Contexts without a `conversationId` impose no
+ * restriction: every globally-enabled plugin's hook runs.
  *
  * Before each hook runs, the pipeline stamps the {@link BaseHookContext}
  * capabilities onto its (freshly-cloned) draft, both bound to that hook's


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

Rebased onto `main` after #40647 landed.

`getUserHooksFor` / `getUserHookEntriesFor` now prepend in-process default-plugin hooks from the hook registry, so they return the same first-party defaults `getHooksFor` does (not only filesystem user plugins).

Per-chat plugin allowlists no longer drop first-party default plugins. Those hooks are core runtime (memory, tool-result truncate, empty-response, and the rest) and the chat pills only list user-installed plugins. A workspace `.disabled` sentinel still excludes them.

Review follow-ups from the previous revision:
- Dropped the `collectUserHookEntries` first-party allowlist bypass. User plugins cannot be named `default-*` (`RESERVED_PLUGIN_PREFIXES`), so that check was unnecessary.
- Lookup lives in `hooks/registry.ts` (via #40647).

Scoped down from #40620: this does not lazily register defaults in workers, does not discover user plugins at dispatch, and does not run plugin `init` outside the daemon. Worker bootstrap remains a separate change (#40215).

## Test plan

- `cd assistant && bun test src/__tests__/plugin-effective-enabled-set.test.ts src/__tests__/default-plugin-names-guard.test.ts src/__tests__/mtime-cache.test.ts src/__tests__/user-plugin-loader.test.ts src/__tests__/plugin-secret-pattern-contribution.test.ts src/__tests__/plugin-disabled-state.test.ts`
- `cd assistant && bun run typecheck:fast`

## Risk

Low. Production `getEffectiveEnabledPluginSet` already unions first-party defaults into a non-null chat scope, so the allowlist bypass is a read-site guarantee rather than a new production path. `assistant plugins disable default-*` is unchanged.

Does not populate an empty registry. Processes that never call `registerDefaultPlugins()` still see no in-process defaults; that is #40215.

## CLI verb checklist

No new routes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1e64f5d-117a-4f57-9eb5-5dbf63a80223?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1e64f5d-117a-4f57-9eb5-5dbf63a80223&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

