### PR TITLE
fix(web): mount the surface stories in the transcript's real column (LUM-3223)

### DIFF
--- a/clients/web/src/domains/chat/components/surfaces/access-request-card.stories.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/access-request-card.stories.tsx
@@ -2,6 +2,8 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import type { Surface } from "@/domains/chat/types/types";
 
+import { TranscriptColumn } from "@/domains/chat/transcript/transcript-column";
+
 import { SurfaceRouter } from "./surface-router";
 
 const meta: Meta = {
@@ -11,9 +13,9 @@ const meta: Meta = {
   },
   decorators: [
     (Story) => (
-      <div className="max-w-[520px]">
+      <TranscriptColumn>
         <Story />
-      </div>
+      </TranscriptColumn>
     ),
   ],
 };

--- a/clients/web/src/domains/chat/components/surfaces/choice-copy-surfaces.stories.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/choice-copy-surfaces.stories.tsx
@@ -5,6 +5,8 @@ import type { Surface } from "@/domains/chat/types/types";
 import type { ManagedOAuthConnectClient } from "@/domains/chat/api/managed-oauth";
 import type { OAuthConnection } from "@/generated/api/types.gen";
 
+import { TranscriptColumn } from "@/domains/chat/transcript/transcript-column";
+
 import { OAuthConnectSurface } from "./oauth-connect-surface";
 import { SurfaceRouter } from "./surface-router";
 
@@ -15,9 +17,9 @@ const meta: Meta = {
   },
   decorators: [
     (Story) => (
-      <div className="max-w-[920px]">
+      <TranscriptColumn>
         <Story />
-      </div>
+      </TranscriptColumn>
     ),
   ],
 };

--- a/clients/web/src/domains/chat/components/surfaces/form-surface.stories.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/form-surface.stories.tsx
@@ -3,6 +3,8 @@ import { useState } from "react";
 
 import type { Surface } from "@/domains/chat/types/types";
 
+import { TranscriptColumn } from "@/domains/chat/transcript/transcript-column";
+
 import { SurfaceRouter } from "./surface-router";
 
 const meta: Meta = {
@@ -12,9 +14,9 @@ const meta: Meta = {
   },
   decorators: [
     (Story) => (
-      <div className="max-w-[640px]">
+      <TranscriptColumn>
         <Story />
-      </div>
+      </TranscriptColumn>
     ),
   ],
 };

--- a/clients/web/src/domains/chat/components/surfaces/tool-approval-card.stories.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/tool-approval-card.stories.tsx
@@ -2,6 +2,8 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import type { Surface } from "@/domains/chat/types/types";
 
+import { TranscriptColumn } from "@/domains/chat/transcript/transcript-column";
+
 import { SurfaceRouter } from "./surface-router";
 
 const meta: Meta = {
@@ -11,9 +13,9 @@ const meta: Meta = {
   },
   decorators: [
     (Story) => (
-      <div className="max-w-[520px]">
+      <TranscriptColumn>
         <Story />
-      </div>
+      </TranscriptColumn>
     ),
   ],
 };

--- a/clients/web/src/domains/chat/components/surfaces/work-result-surface.stories.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/work-result-surface.stories.tsx
@@ -3,6 +3,8 @@ import { useState } from "react";
 
 import type { Surface } from "@/domains/chat/types/types";
 
+import { TranscriptColumn } from "@/domains/chat/transcript/transcript-column";
+
 import { SurfaceRouter } from "./surface-router";
 
 const meta: Meta = {
@@ -12,9 +14,9 @@ const meta: Meta = {
   },
   decorators: [
     (Story) => (
-      <div className="max-w-[920px]">
+      <TranscriptColumn>
         <Story />
-      </div>
+      </TranscriptColumn>
     ),
   ],
 };

--- a/clients/web/src/domains/chat/transcript/transcript-column.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-column.tsx
@@ -1,0 +1,53 @@
+/**
+ * The transcript's centered column. Every row in the scroller (history rows,
+ * the latest-turn cluster, and any surface the assistant sends) sits in one of
+ * these, so they share a width and a set of horizontal insets down the whole
+ * conversation.
+ *
+ * The `--chat-max-width` cap and the horizontal padding sit on the same
+ * element, so the cap measures the content *plus* its gutters and each row is
+ * inset from the composer's edge below it. `ChatColumn` (the footer stack)
+ * deliberately does the opposite, which is why these are two components and
+ * not one; see its docstring for that side.
+ *
+ * `contain: content` is layout *and paint* containment, so anything a row
+ * hangs past its own edge is hard-clipped rather than overflowing visibly:
+ * a reaction chip's corner overhang and the subagent row's Details label have
+ * both had to reserve their space inside the row instead. Keep it here, and
+ * keep stories mounting in this: a card whose chrome escapes the column is
+ * meant to look broken, in Storybook exactly as it does in the app.
+ */
+
+import type { CSSProperties, ReactNode } from "react";
+
+import { cn } from "@/utils/misc";
+
+interface TranscriptColumnProps {
+  /** Per-row framing: the latest-edge region adds a flex column. */
+  className?: string;
+  /**
+   * Pins the latest-edge region to the viewport height so its anchor user
+   * message sits at the top. The only style a column ever varies, which is
+   * why it is this prop and not a `style` passthrough.
+   */
+  minHeight?: CSSProperties["minHeight"];
+  children: ReactNode;
+}
+
+export function TranscriptColumn({
+  className,
+  minHeight,
+  children,
+}: TranscriptColumnProps) {
+  return (
+    <div
+      className={cn(
+        "mx-auto w-full max-w-[var(--chat-max-width)] contain-content px-4 sm:px-6",
+        className,
+      )}
+      style={minHeight === undefined ? undefined : { minHeight }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/transcript/transcript.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript.tsx
@@ -16,6 +16,7 @@ import { isSending, useTurnStore } from "@/domains/chat/turn-store";
 
 import { LatestTurnRow } from "@/domains/chat/transcript/latest-turn-row";
 import { PullRefreshSpinner } from "@/domains/chat/transcript/pull-refresh-spinner";
+import { TranscriptColumn } from "@/domains/chat/transcript/transcript-column";
 import { TranscriptRow } from "@/domains/chat/transcript/transcript-row";
 import { PULL_THRESHOLD_PX } from "@/domains/chat/transcript/pull-to-refresh-utils";
 import { usePullToRefresh } from "@/domains/chat/transcript/use-pull-to-refresh";
@@ -326,14 +327,14 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
            *  the latest turn owns the flag instead (see `LatestTurnRow`). */}
           {partition.historyItems.map((item, i) => (
             <Fragment key={item.key}>
-              <div className="mx-auto w-full max-w-[var(--chat-max-width)] contain-content px-4 sm:px-6">
+              <TranscriptColumn>
                 <TranscriptRow
                   item={item}
                   {...rowProps}
                   changedDocumentIds={changedDocumentIdsByKey.get(item.key)}
                   isLatestMessage={i === latestHistoryMessageIndex}
                 />
-              </div>
+              </TranscriptColumn>
             </Fragment>
           ))}
           {/* Latest-edge region: contains the latest-turn cluster and the
@@ -367,12 +368,10 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
            *  transition because React's reconciler tracks `fiber.index` (see
            *  the `transcript.test.tsx` regression test). */}
           {(partition.anchorMessage || rest.renderAvatar) && (
-            <div
-              className="mx-auto flex w-full max-w-[var(--chat-max-width)] flex-col contain-content px-4 sm:px-6"
-              style={
-                partition.anchorMessage
-                  ? { minHeight: viewportMinHeight }
-                  : undefined
+            <TranscriptColumn
+              className="flex flex-col"
+              minHeight={
+                partition.anchorMessage ? viewportMinHeight : undefined
               }
             >
               {partition.anchorMessage && (
@@ -399,7 +398,7 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
                 />
               )}
               <div aria-hidden data-latest-edge="true" />
-            </div>
+            </TranscriptColumn>
           )}
           {/* Spinner last = visual bottom in flex-col. Only rendered when
            *  the gesture is feature-flag-enabled so the flag-off path has


### PR DESCRIPTION
## TL;DR

The five surface story files each wrapped their subject in a width they invented, and no two agreed: **520px, 520px, 640px, 920px, 920px**. Production gives all five the same **752px**. This extracts the transcript's column (which `transcript.tsx` had inlined twice) as `TranscriptColumn` and has the stories mount in it, so there is no longer a width for a story to get wrong.

Fixes LUM-3223.

## Why the stories were wrong

A surface arrives as a top-level `kind: "surface"` transcript item. `transcript-row.tsx:227` renders `SurfaceRouter` with no wrapper of its own, directly inside the transcript column:

```
mx-auto w-full max-w-[var(--chat-max-width)] contain-content px-4 sm:px-6
```

`--chat-max-width` is `800px` (`packages/design-library/src/tokens.css:269`) and the `px-4 sm:px-6` sits *inside* the cap, so the content box is 752px. Measured off the rendered DOM rather than read off the source: probing that class chain in the Storybook stylesheet context returns `columnOuterWidth: 800, columnContentWidth: 752`.

Everything about a card that depends on its own width was being reviewed at the wrong width, five different ways:

- **Line wrapping.** `WorkResult / Inbox Cleanup` is 545px tall at 920px and 563px at 752px: the subtitle fits on one line in the story and wraps to two in the app. `ToolApproval / Long command context` moves 18px the other way.
- **Truncation thresholds.** `card-surface.tsx:243` puts a step's detail in a `max-w-[50%]` box with `truncate`, so whether it ellipsizes is a pure function of card width: 260px of room in the story vs 376px in the app.
- **Grid geometry.** The tool-approval metadata grid (`card-surface.tsx:362`) measures 486px in the story and 718px in the app, a 48% difference in the space a value has before it wraps.
- **Cross-story comparison.** A reviewer could not compare a work-result card against a tool-approval card, because they were drawn 400px apart.

## What changes for the reviewer

| | Before | After |
| --- | --- | --- |
| Tool approval / Access request | card at 520px | card at 752px |
| Form | card at 640px | card at 752px |
| Work result / Choice and copy | card at 920px | card at 752px |
| Where the width comes from | a number typed into each story file | the transcript column the app uses |
| A surface that wraps or truncates only at the app's width | invisible in Storybook | visible |
| Comparing two surface types side by side | different widths, not comparable | same width |
| `transcript.tsx` column markup | inlined twice | one `TranscriptColumn` |

## Why this is safe

Structure only, no shipped behaviour changed.

- **The class set is unchanged at both production call sites.** A computed-style diff over all **746** properties, between the class string `transcript.tsx` had before and the one `TranscriptColumn` emits now, reports **zero** differences for both variants (the history row and the `flex flex-col` latest-edge region). Both still measure 800px.
- **Verified after the change too**, since `cn` runs tailwind-merge over the list: the rendered transcript still emits exactly the two expected class strings, the latest-edge region still computes `display: flex`, and its anchored `min-height` still resolves (`718px` in the story viewport).
- The five story decorators are the only other change, and they are story-only files.
- `tsc --noEmit` clean; `eslint` clean on all seven files (the 16 repo warnings are pre-existing and in untouched files).

## Evidence

`WorkResult / Inbox Cleanup`, same story, same fixture. Before at the story's invented 920px the subtitle is one line; after at the app's 752px it wraps to two, which is what the app has always rendered:

- before (920px): subtitle one line, card 545px tall
- after (752px): subtitle two lines, card 563px tall

All five families re-measured after the change: `cardWidth: 752` for every one.

The regression it would now catch: a change that makes any surface's header, metadata grid, or truncated detail overflow or rewrap at the transcript's real width now shows up in the story. Before, a card could be clean at 920px and broken in the app.

## Deferred

`chat-skeleton.tsx:5` is a third copy of the same width and insets. It is deliberately not folded in: it carries no `contain-content`, so converting it would add paint containment to the loading state. That is a behaviour change rather than a structural one and wants its own verification, so it is noted on LUM-3223 rather than smuggled in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40626" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->