### PR TITLE
fix(web): decide the composer's busy-row send button on the pointer, not the width (LUM-3224)

### DIFF
--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -708,6 +708,90 @@ describe("ChatComposer — send/stop button visibility", () => {
     expect(shouldSubmitOnEnter(ENTER, false, READY_POLICY)).toBe("submit");
   });
 
+  // The whole adaptation matrix in one assertion, since the named cases above
+  // are instances of a single invariant: the busy row offers exactly one
+  // control, and never a disabled one. Counted rather than probed for presence,
+  // so a row that grows a second control, loses its only one, or keeps a send
+  // nobody can press reads as BROKEN here instead of quietly passing.
+  //
+  // The blocked-draft rows are the ones that invariant is load-bearing for. A
+  // send disabled by an in-flight upload or a prompt holding the send, in a row
+  // that has already given up stop, leaves a running turn with no usable
+  // control at all. Both are reachable on a phone as much as a tablet: the
+  // attachment drop zone is not gated on `isAssistantBusy`, so an upload can
+  // start mid-turn. `shouldSubmitOnEnter` refuses both above, and pinning the
+  // row to the same three conditions is what keeps the two in agreement.
+  test("the busy row always offers exactly one usable control", () => {
+    const AXES = [
+      { name: "desktop", narrow: false, coarsePointer: false },
+      { name: "narrow mouse window", narrow: true, coarsePointer: false },
+      { name: "phone", narrow: true, coarsePointer: true },
+      { name: "tablet", narrow: false, coarsePointer: true },
+    ];
+    const DRAFTS = [
+      { name: "no draft", props: { input: "" } },
+      { name: "draft", props: { input: "hello" } },
+      {
+        name: "draft, attachment uploading",
+        props: { input: "hello", attachmentsUploadingCount: 1 },
+      },
+      {
+        name: "draft, send blocked",
+        props: { input: "hello", sendDisabled: true },
+      },
+      {
+        name: "attachment only",
+        props: { input: "", canSendAttachments: true },
+      },
+    ];
+
+    const offered: Record<string, string> = {};
+    for (const axis of AXES) {
+      for (const draft of DRAFTS) {
+        cleanup();
+        viewport.set({
+          narrow: axis.narrow,
+          coarsePointer: axis.coarsePointer,
+        });
+        const html = renderComposer({ isAssistantBusy: true, ...draft.props });
+        const controls = [
+          ...html.matchAll(/aria-label="(Stop generating|Send message)"/g),
+        ].map((match) => match[1]!);
+        const usable =
+          controls.length === 1 && !sendButtonHasDisabledAttr(html);
+        offered[`${axis.name} / ${draft.name}`] = usable
+          ? controls[0]!
+          : `BROKEN: [${controls.join(", ")}]`;
+      }
+    }
+
+    // A fine pointer submits from the keyboard, so stop keeps the slot
+    // throughout. A coarse pointer hands it to send exactly when pressing send
+    // would queue the draft, which is never true for the two blocked rows.
+    expect(offered).toEqual({
+      "desktop / no draft": "Stop generating",
+      "desktop / draft": "Stop generating",
+      "desktop / draft, attachment uploading": "Stop generating",
+      "desktop / draft, send blocked": "Stop generating",
+      "desktop / attachment only": "Stop generating",
+      "narrow mouse window / no draft": "Stop generating",
+      "narrow mouse window / draft": "Stop generating",
+      "narrow mouse window / draft, attachment uploading": "Stop generating",
+      "narrow mouse window / draft, send blocked": "Stop generating",
+      "narrow mouse window / attachment only": "Stop generating",
+      "phone / no draft": "Stop generating",
+      "phone / draft": "Send message",
+      "phone / draft, attachment uploading": "Stop generating",
+      "phone / draft, send blocked": "Stop generating",
+      "phone / attachment only": "Send message",
+      "tablet / no draft": "Stop generating",
+      "tablet / draft": "Send message",
+      "tablet / draft, attachment uploading": "Stop generating",
+      "tablet / draft, send blocked": "Stop generating",
+      "tablet / attachment only": "Send message",
+    });
+  });
+
   test("isAssistantBusy=false keeps the Send button even during awaiting_user_input", () => {
     useTurnStore.setState({
       ...INITIAL_TURN_STATE,

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -22,6 +22,7 @@ import type { LiveVoicePreflightVerdict } from "@/domains/chat/voice/live-voice/
 import { INITIAL_TURN_STATE, useTurnStore } from "@/domains/chat/turn-store";
 import * as assistantAvatarMod from "@/hooks/use-assistant-avatar";
 import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
+import { viewportAxesStub } from "@/hooks/viewport-axes.test-helper";
 
 // Pure helpers live in `chat-composer-utils` (no mocks needed), so import them
 // statically. `ChatComposer` itself is imported dynamically *after* the mocks
@@ -33,11 +34,11 @@ import {
 } from "@/domains/chat/components/chat-composer/chat-composer-utils";
 import { useQuoteReplyStore } from "@/domains/chat/quote-reply-store";
 
-let mockIsMobile = false;
-mock.module("@/hooks/use-is-mobile", () => ({
-  useIsMobile: () => mockIsMobile,
-  MOBILE_MEDIA_QUERY: "(max-width: 767px)",
-}));
+// The two device-side axes are driven by stubbing `window.matchMedia`, not by
+// mocking `use-is-mobile`, so a test says which signal the composer actually
+// consults and the crossed shapes (roomy touch tablet, narrow mouse window)
+// are expressible at all. See `docs/PLATFORM_ADAPTATION.md`.
+const viewport = viewportAxesStub();
 
 let mockIsElectron = false;
 mock.module("@/runtime/is-electron", () => ({
@@ -550,10 +551,15 @@ describe("computeGhostSuffix", () => {
 // HTML rendering — placeholder and send/stop button surface
 // ---------------------------------------------------------------------------
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  viewport.restore();
+});
 beforeEach(() => {
   resetLiveVoiceMocks();
   mockCompactComposer = false;
+  // Roomy window, mouse: the desktop shape, unless a test says otherwise.
+  viewport.set({ narrow: false, coarsePointer: false });
   // The composer self-sources its draft + attachments from the store; reset
   // them between tests so seeded values can't leak across cases.
   useComposerStore.setState({
@@ -661,26 +667,45 @@ describe("ChatComposer — send/stop button visibility", () => {
   });
 
   test("isAssistantBusy=true on desktop renders only the Stop button (send/attach/voice hidden)", () => {
-    mockIsMobile = false;
+    viewport.set({ narrow: false, coarsePointer: false });
     const html = renderComposer({ isAssistantBusy: true });
     expect(html).toContain('aria-label="Stop generating"');
     expect(html).not.toContain('aria-label="Send message"');
   });
 
-  test("isAssistantBusy=true on mobile with no input renders only Stop button", () => {
-    mockIsMobile = true;
+  test("isAssistantBusy=true on a phone with no input renders only Stop button", () => {
+    viewport.set({ narrow: true, coarsePointer: true });
     const html = renderComposer({ input: "", isAssistantBusy: true });
     expect(html).toContain('aria-label="Stop generating"');
     expect(html).not.toContain('aria-label="Send message"');
-    mockIsMobile = false;
   });
 
-  test("isAssistantBusy=true on mobile with user input renders only Send button", () => {
-    mockIsMobile = true;
+  test("isAssistantBusy=true on a phone with user input renders only Send button", () => {
+    viewport.set({ narrow: true, coarsePointer: true });
     const html = renderComposer({ input: "hello", isAssistantBusy: true });
     expect(html).not.toContain('aria-label="Stop generating"');
     expect(html).toContain('aria-label="Send message"');
-    mockIsMobile = false;
+  });
+
+  // The two shapes where the axes come apart. The busy row's send button
+  // substitutes for Enter-to-submit, which `shouldSubmitOnEnter` refuses under a
+  // coarse pointer, so both halves read the pointer and each case pins the pair
+  // together: whichever way Enter goes, exactly one of the two controls is in
+  // the slot. LUM-3224.
+  test("a roomy touch device (tablet) with user input gets Send, since Enter cannot submit there", () => {
+    viewport.set({ narrow: false, coarsePointer: true });
+    const html = renderComposer({ input: "hello", isAssistantBusy: true });
+    expect(html).toContain('aria-label="Send message"');
+    expect(html).not.toContain('aria-label="Stop generating"');
+    expect(shouldSubmitOnEnter(ENTER, true, READY_POLICY)).toBe("ignore");
+  });
+
+  test("a narrow mouse-driven window keeps Stop, since Enter already submits there", () => {
+    viewport.set({ narrow: true, coarsePointer: false });
+    const html = renderComposer({ input: "hello", isAssistantBusy: true });
+    expect(html).toContain('aria-label="Stop generating"');
+    expect(html).not.toContain('aria-label="Send message"');
+    expect(shouldSubmitOnEnter(ENTER, false, READY_POLICY)).toBe("submit");
   });
 
   test("isAssistantBusy=false keeps the Send button even during awaiting_user_input", () => {

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -486,6 +486,12 @@ export function ChatComposer({
   }, [startLiveVoiceSession]);
 
   const pointerCoarse = useMemo(() => isPointerCoarse(), []);
+  // `shouldSubmitOnEnter` ignores Enter under a coarse primary pointer, since a
+  // soft keyboard's Enter inserts a newline. Anything that stands in for
+  // keyboard submit reads this, never the viewport width: the two disagree on a
+  // roomy tablet and on a narrowed desktop window, and the substitute belongs to
+  // the absence of the thing it replaces. See `docs/PLATFORM_ADAPTATION.md`.
+  const keyboardCanSubmit = !pointerCoarse;
   const isMobile = useIsMobile();
   const isNative = useIsNativePlatform();
   const isElectronHost = isElectron();
@@ -1004,8 +1010,11 @@ export function ChatComposer({
                   <div className="flex shrink-0 items-center gap-2">
                     {isAssistantBusy ? (
                       <>
-                        {/* Desktop: always show stop. Mobile: show stop only when there is no sendable content. */}
-                        {(!isMobile || !canSendMessageContent) && (
+                        {/* Stop holds the slot wherever the keyboard can send
+                          the draft instead. Where it cannot, the send button
+                          takes the slot as soon as there is something to
+                          queue, since it is the only way to send it. */}
+                        {(keyboardCanSubmit || !canSendMessageContent) && (
                           <Button
                             variant="primary"
                             iconOnly={
@@ -1015,8 +1024,7 @@ export function ChatComposer({
                             aria-label="Stop generating"
                           />
                         )}
-                        {/* Mobile: show send instead of stop when content can be queued. */}
-                        {isMobile && canSendMessageContent && (
+                        {!keyboardCanSubmit && canSendMessageContent && (
                           <Button
                             variant="primary"
                             iconOnly={

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -601,6 +601,19 @@ export function ChatComposer({
   const hasStagedQuotes = useQuoteReplyStore.use.stagedQuotes().length > 0;
   const canSendMessageContent =
     Boolean(input.trim()) || canSendAttachments || hasStagedQuotes;
+  // The busy row holds exactly one control, and stop is the default: it is the
+  // only escape from a turn already running. Send takes the slot only where it
+  // is strictly better, which is where the keyboard cannot submit AND pressing
+  // it would actually queue the draft. Those are the same three conditions
+  // `shouldSubmitOnEnter` requires before it answers "submit", so the two paths
+  // to sending open and close together, and a draft that cannot go anywhere yet
+  // (an attachment still uploading, a prompt holding the send) leaves stop in
+  // place rather than a send nobody can press.
+  const sendReplacesStop =
+    !keyboardCanSubmit &&
+    canSendMessageContent &&
+    !sendDisabled &&
+    attachmentsUploadingCount === 0;
   // Voice mode occupies the send slot while there is nothing to send: the
   // send arrow only earns that spot once the message has content. Eligibility
   // is a voice-enabled composer + a bound assistant new enough to serve live
@@ -1009,42 +1022,26 @@ export function ChatComposer({
                   </div>
                   <div className="flex shrink-0 items-center gap-2">
                     {isAssistantBusy ? (
-                      <>
-                        {/* Stop holds the slot wherever the keyboard can send
-                          the draft instead. Where it cannot, the send button
-                          takes the slot as soon as there is something to
-                          queue, since it is the only way to send it. */}
-                        {(keyboardCanSubmit || !canSendMessageContent) && (
-                          <Button
-                            variant="primary"
-                            iconOnly={
-                              <Square className="h-3 w-3" fill="currentColor" />
-                            }
-                            onClick={onStopGenerating}
-                            aria-label="Stop generating"
-                          />
-                        )}
-                        {!keyboardCanSubmit && canSendMessageContent && (
-                          <Button
-                            variant="primary"
-                            iconOnly={
-                              <ArrowUp className="h-4 w-4" strokeWidth={2.5} />
-                            }
-                            type="submit"
-                            disabled={
-                              sendDisabled || attachmentsUploadingCount > 0
-                            }
-                            title={
-                              sendDisabled
-                                ? "Type a message to send"
-                                : attachmentsUploadingCount > 0
-                                  ? "Uploading attachments…"
-                                  : "Send message"
-                            }
-                            aria-label="Send message"
-                          />
-                        )}
-                      </>
+                      sendReplacesStop ? (
+                        <Button
+                          variant="primary"
+                          iconOnly={
+                            <ArrowUp className="h-4 w-4" strokeWidth={2.5} />
+                          }
+                          type="submit"
+                          title="Send message"
+                          aria-label="Send message"
+                        />
+                      ) : (
+                        <Button
+                          variant="primary"
+                          iconOnly={
+                            <Square className="h-3 w-3" fill="currentColor" />
+                          }
+                          onClick={onStopGenerating}
+                          aria-label="Stop generating"
+                        />
+                      )
                     ) : (
                       <>
                         {/* Compact: the model profile moves into the left

--- a/clients/web/src/domains/chat/components/context-window-indicator.test.tsx
+++ b/clients/web/src/domains/chat/components/context-window-indicator.test.tsx
@@ -16,7 +16,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { cleanup, render, screen } from "@testing-library/react";
 
-import { stubViewportAxes } from "@/hooks/viewport-axes.test-helper";
+import { viewportAxesStub } from "@/hooks/viewport-axes.test-helper";
 
 let indicatorEnabled = false;
 
@@ -31,22 +31,16 @@ import { ContextWindowIndicator } from "@/domains/chat/components/context-window
 
 const USAGE = { tokens: 90_000, maxTokens: 200_000, fillRatio: 0.45 };
 
-let restoreViewport: () => void = () => {};
-
-function setViewport(axes: { narrow: boolean; coarsePointer: boolean }): void {
-  restoreViewport();
-  restoreViewport = stubViewportAxes(axes);
-}
+const viewport = viewportAxesStub();
 
 beforeEach(() => {
   indicatorEnabled = false;
-  setViewport({ narrow: false, coarsePointer: false });
+  viewport.set({ narrow: false, coarsePointer: false });
 });
 
 afterEach(() => {
   cleanup();
-  restoreViewport();
-  restoreViewport = () => {};
+  viewport.restore();
 });
 
 describe("ContextWindowIndicator", () => {
@@ -121,7 +115,7 @@ describe("ContextWindowIndicator presentation axis", () => {
     // GIVEN a tablet in landscape: a coarse pointer with plenty of room.
     // Roomy and thumb-driven is the combination the two axes only disagree
     // on, and the one a width check answers wrongly.
-    setViewport({ narrow: false, coarsePointer: true });
+    viewport.set({ narrow: false, coarsePointer: true });
 
     // WHEN the ring renders
     const { container } = render(
@@ -139,7 +133,7 @@ describe("ContextWindowIndicator presentation axis", () => {
 
   test("a phone-sized touch window gets the same tappable trigger", () => {
     // GIVEN a phone in portrait: coarse and narrow
-    setViewport({ narrow: true, coarsePointer: true });
+    viewport.set({ narrow: true, coarsePointer: true });
 
     // WHEN the ring renders
     const { container } = render(
@@ -154,7 +148,7 @@ describe("ContextWindowIndicator presentation axis", () => {
   test("a narrow mouse window keeps the hover presentation", () => {
     // GIVEN a desktop window dragged narrow, or an Electron shell: still a
     // mouse. Width alone must not push a hover-capable pointer to the sheet.
-    setViewport({ narrow: true, coarsePointer: false });
+    viewport.set({ narrow: true, coarsePointer: false });
 
     // WHEN the ring renders
     const { container } = render(

--- a/clients/web/src/hooks/viewport-axes.test-helper.ts
+++ b/clients/web/src/hooks/viewport-axes.test-helper.ts
@@ -40,6 +40,11 @@ function hoverHolds(query: string, coarsePointer: boolean): boolean {
   return true;
 }
 
+export interface ViewportAxes {
+  narrow: boolean;
+  coarsePointer: boolean;
+}
+
 /**
  * Answers media queries for a given device shape, so a test can drive the two
  * device-side platform-adaptation axes independently.
@@ -60,10 +65,7 @@ function hoverHolds(query: string, coarsePointer: boolean): boolean {
 export function stubViewportAxes({
   narrow,
   coarsePointer,
-}: {
-  narrow: boolean;
-  coarsePointer: boolean;
-}): () => void {
+}: ViewportAxes): () => void {
   const original = window.matchMedia;
   window.matchMedia = (query: string): MediaQueryList => {
     return {
@@ -82,5 +84,37 @@ export function stubViewportAxes({
   };
   return () => {
     window.matchMedia = original;
+  };
+}
+
+/**
+ * A `stubViewportAxes` installation a suite can re-point between tests, for the
+ * common shape of "one default device in `beforeEach`, a different one inside a
+ * handful of cases". Owns the restore fn so each suite stops hand-rolling the
+ * same module-level `let`.
+ *
+ * ```ts
+ * const viewport = viewportAxesStub();
+ * beforeEach(() => viewport.set({ narrow: false, coarsePointer: false }));
+ * afterEach(() => { cleanup(); viewport.restore(); });
+ * ```
+ *
+ * `set` restores the previous stub first, so the real `matchMedia` is always
+ * what `restore` puts back however many times the suite re-points.
+ */
+export function viewportAxesStub(): {
+  set: (axes: ViewportAxes) => void;
+  restore: () => void;
+} {
+  let restore: () => void = () => {};
+  return {
+    set: (axes) => {
+      restore();
+      restore = stubViewportAxes(axes);
+    },
+    restore: () => {
+      restore();
+      restore = () => {};
+    },
   };
 }


### PR DESCRIPTION
## TL;DR

While the assistant is busy, the composer's action slot holds a single control: **Stop generating** or **Send message**. It chose between them on `useIsMobile()`, a `(max-width: 767px)` query. But that send button only exists because `shouldSubmitOnEnter` refuses Enter under a coarse pointer, so one substitution had its two halves keyed to two different axes, and the swap did not check whether the send it swapped in could actually be pressed.

Both halves now read the pointer, and Send takes the slot only where it is strictly better: where the keyboard cannot submit **and** pressing send would actually queue the draft. `Fixes LUM-3224`.

## The rule

```
sendReplacesStop = !keyboardCanSubmit        // Enter inserts a newline here
                && canSendMessageContent     // there is something to queue
                && !sendDisabled             // nothing is holding the send
                && attachmentsUploadingCount === 0
```

The last three are exactly the conditions `shouldSubmitOnEnter` requires before it answers `"submit"`, so the keyboard path and the button path open and close together by construction rather than by two lists that have to be kept in step. Stop is the default and holds the slot in every other case, which matters because `onStopGenerating` has exactly one consumer: this button is the only way to cancel a running turn anywhere in the app.

Because Send is now only rendered when it would work, it is never rendered disabled, and its `disabled` and three-way `title` branches are gone.

## What changes for the user

| Device shape | Before | After |
|---|---|---|
| Desktop, full width, mouse | Stop | Stop (unchanged) |
| **iPad / Android tablet, either orientation** | **Stop only, and Enter does nothing: a draft typed mid-turn is stuck** | Send once there is a queueable draft, so it queues |
| **Desktop or Electron window dragged under 768px** | **Send replaces Stop whenever text is in the box** | Stop stays; Enter still queues, as it always did |
| Phone, draft that can be sent | Send | Send (unchanged) |
| **Any touch device, draft blocked by an in-flight upload or a pending prompt** | **Stop gone, Send present but disabled: no usable control at all** | Stop |

The last row is reachable on phones too, where it predates this branch: `useChatAttachmentDropZone` is gated on `typingDisabled || !assistantId`, not on `isAssistantBusy`, so a file dropped mid-turn starts an upload inside the busy row. The `sendDisabled` half is separately reachable via a secret/confirmation prompt.

Nothing else in the composer moves. The idle row, the voice slot, and the compact-settings collapse (a genuine size question, still on `useIsMobile()`) are untouched.

## Why it is safe

The shapes that ship today are unchanged: a phone with a sendable draft still gets Send, a full-width desktop still gets Stop. `!pointerCoarse` and `!isMobile` agree on both, because a phone is narrow **and** coarse and a desktop is roomy **and** fine. Everything that moves, moves from a missing or unpressable control to a working one.

The branch stays inside the composer (rung 2 of `PLATFORM_ADAPTATION.md`'s ladder). No new hook, no new signal, no platform check: it reuses the `pointerCoarse` the component already computes once at mount and already hands to `shouldSubmitOnEnter`. Being the pointer axis rather than a platform one, iPadOS and Android tablets are fixed by the same code with no per-OS branch, per `clients/AGENTS.md`.

## Verification

Browser, against the real `ChatComposer`, at each axis pair before and after:

| Viewport | Pointer | Draft state | Before | After |
|---|---|---|---|---|
| 1280x820 | fine | draft | Stop | Stop |
| 700x820 | coarse | draft | Send | Send |
| 1024x820 | coarse | draft | Stop (Enter `defaultPrevented: false`, draft unchanged) | Send |
| 700x820 | fine | draft | Send | Stop |
| 1024x820 | coarse | draft + upload in flight | disabled Send, no Stop | enabled Stop |
| 1024x820 | coarse | draft + `sendDisabled` | disabled Send, no Stop | enabled Stop |
| 700x820 | coarse | draft + upload in flight | disabled Send, no Stop | enabled Stop |

`bunx tsc --noEmit` clean; `bun run lint` 0 errors (the one warning on `chat-composer.tsx` predates this branch and is on an unrelated hook). Local `bun test` is blocked by a repo hook, so the suite runs in CI.

**Not device-verified.** Chrome couples touch emulation to a sub-768px viewport, so roomy-plus-coarse was reached by holding the viewport at a real 1024px and forcing `(pointer: coarse)` at the `matchMedia` layer, which is the exact read `isPointerCoarse()` performs. Not run on physical iPad or Android tablet hardware.

## Tests

The cases covering this stubbed `useIsMobile` through `mock.module`, so the pointer axis was invisible to the suite and neither crossed shape was expressible: the bug was untestable in the harness that owned it. They now drive `window.matchMedia` through the existing `stubViewportAxes` and name the device shape rather than "mobile".

On top of the four named shapes, one case asserts the invariant they are instances of: across every axis pair × draft state, the busy row offers **exactly one** control and never a disabled one. It counts matches instead of probing for presence, so a row that grows a second control, loses its only one, or keeps an unpressable Send reads as `BROKEN` in the assertion diff rather than passing quietly.

`context-window-indicator.test.tsx` had hand-rolled the same `let restore` / `setViewport` lifecycle around that helper and this branch was about to add a third copy, so the wrapper moves into the helper as `viewportAxesStub`. Net negative lines there. `use-touch-mobile.test.tsx` and `superpowers-tab.test.tsx` use the helper in different shapes (no re-pointing, and per-test `try`/`finally`) and are left alone.

## Deferred: [LUM-3235](https://linear.app/vellum/issue/LUM-3235)

This PR keeps cancellation available when queuing is blocked. It does not give it back when queuing is available: on any touch device, typing into the composer while the assistant works still removes the only stop control in the app, recoverable only by emptying the draft.

That is the shape underneath this bug. The busy row is one slot multiplexing two independent capabilities, cancel and queue, and it only ever worked because a hardware keyboard supplies the second path on desktop. It is not a space constraint: while busy, attach, model picker, dictation, and voice are all unmounted, so two controls would fit on the narrowest supported viewport. Landing that means putting a new visible control on the app's primary surface, which is a design call, and [LUM-3167](https://linear.app/vellum/issue/LUM-3167) is already exploring steer-vs-queue in the same row.

A colocated `ChatComposer` story would make all of this reviewable without a scratch harness, but honest axis controls in Storybook are [LUM-3179](https://linear.app/vellum/issue/LUM-3179)'s scope, and a story that forces `matchMedia` itself is the kind of plausible-looking harness that lies. The unit tests carry the coverage instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)