### PR TITLE
fix(ci): ignore cancelled runs when finding the last dev release

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -8,10 +8,7 @@ on:
 
 concurrency:
   group: dev-release
-  # Serialize releases. A newer hourly tick waits rather than killing an
-  # in-progress deploy: GitHub keeps the newest pending run and drops older
-  # queued ones. The idle gate still self-cancels when HEAD has not moved.
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 env:
   ASSISTANT_IMAGE_NAME: sandbox-images/assistant-server
@@ -23,14 +20,11 @@ jobs:
   # The schedule fires hourly regardless of repo activity. Rebuilding an
   # unchanged HEAD wastes CI minutes and republishes byte-identical images, so
   # cancel the run when nothing has landed since the last *successful* dev
-  # release. "Successful" means register-release succeeded on a run that was
-  # not cancelled (the same anchor notify-dev-release uses for its changelog).
-  # A run that registered a real release but failed in a later job (e.g.
-  # build-electron) still counts. A cancelled run does not, even if
-  # register-release finished before the cancel landed: that deploy did not
-  # complete, and treating it as done would skip every later attempt of the
-  # same SHA. Manual workflow_dispatch runs always proceed: the operator
-  # explicitly asked for a build.
+  # release. "Successful" is keyed off the register-release job conclusion —
+  # the same anchor notify-dev-release uses for its changelog — so a run that
+  # registered a real release but failed in a later job (e.g. build-electron)
+  # still counts as the last release. Manual workflow_dispatch runs always
+  # proceed: the operator explicitly asked for a build.
   #
   # All root jobs (compute-version + the ci-* jobs) gate on this job's
   # has_new_commits output so they never spin up runners on an idle run. The
@@ -64,13 +58,10 @@ jobs:
             exit 0
           fi
 
-          # Walk recent completed, non-cancelled runs newest-first and pick
-          # the first whose register-release job succeeded; that run's head
-          # SHA is the last released commit. Cancelled runs are excluded even
-          # when register-release completed: a cancel mid-workflow is not a
-          # finished deploy. (See notify-dev-release for why a later job
-          # failure, e.g. build-electron, still counts.) Keep this walk-back
-          # in sync with the copy in notify-dev-release.
+          # Walk recent completed runs newest-first and pick the first whose
+          # register-release job succeeded; that run's head SHA is the last
+          # released commit. (See notify-dev-release for why we key off the job
+          # conclusion rather than the overall run conclusion.)
           #
           # The jobs listing MUST be paginated: this workflow has >30 jobs and
           # the API defaults to 30 per page, so register-release lands on page 2
@@ -828,9 +819,9 @@ jobs:
   # gating in release.yml, where a UI ahead of its backend actually matters.
   #
   # !cancelled() (rather than always()) keeps this quiet when a run is
-  # cancelled (idle-gate self-cancel, or a user cancel). No has_new_commits
-  # check is needed: ci-web is itself gated on that job, so an idle run skips
-  # ci-web and this job with it.
+  # superseded by the next hourly release via concurrency.cancel-in-progress.
+  # No has_new_commits check is needed: ci-web is itself gated on that job, so
+  # an idle run skips ci-web and this job with it.
   deploy-web-spa:
     name: Deploy Web SPA (dev)
     needs: [ci-web, register-release]
@@ -1302,7 +1293,7 @@ jobs:
   # clients — which is exactly the toggle behaviour we want here. The channel
   # stays tidy even when a release spans many commits. The diff is taken
   # since the last *successful* dev release (skipping any intervening failed
-  # or cancelled runs), so no commits are dropped.
+  # runs), so no commits are dropped.
   #
   # On failure: posts a short alert without a changelog.
   #
@@ -1315,8 +1306,8 @@ jobs:
   notify-dev-release:
     needs: [compute-version, register-release, register-preview-release, build-electron, upload-electron-updates, deploy-web-spa]
     # Run on success and failure alike, but not when the run was cancelled
-    # (idle-gate self-cancel, or a user cancel). A cancelled run is not a
-    # real failure and should not alert the channel.
+    # (e.g. superseded by a newer hourly run via cancel-in-progress) — a
+    # cancelled run is not a real failure and should not alert the channel.
     if: ${{ always() && !cancelled() }}
     runs-on: ubuntu-latest
     # A Slack outage must not fail the release run: that would both mar the run
@@ -1399,10 +1390,8 @@ jobs:
           # …), so a later failure leaves a real release on a run
           # whose conclusion is "failure". Keying off the run would then diff from
           # an older SHA and re-announce already-released commits. Walk recent
-          # completed, non-cancelled runs newest-first and pick the first whose
-          # register-release job succeeded. Cancelled runs are excluded even when
-          # register-release completed: a cancel mid-workflow is not a finished
-          # deploy. Keep this walk-back in sync with check-for-new-commits.
+          # completed runs newest-first and pick the first whose register-release
+          # job succeeded.
           #
           # The jobs listing MUST be paginated: this workflow has >30 jobs and
           # the API defaults to 30 per page, so register-release lands on page 2

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -8,7 +8,10 @@ on:
 
 concurrency:
   group: dev-release
-  cancel-in-progress: true
+  # Serialize releases. A newer hourly tick waits rather than killing an
+  # in-progress deploy: GitHub keeps the newest pending run and drops older
+  # queued ones. The idle gate still self-cancels when HEAD has not moved.
+  cancel-in-progress: false
 
 env:
   ASSISTANT_IMAGE_NAME: sandbox-images/assistant-server
@@ -20,11 +23,14 @@ jobs:
   # The schedule fires hourly regardless of repo activity. Rebuilding an
   # unchanged HEAD wastes CI minutes and republishes byte-identical images, so
   # cancel the run when nothing has landed since the last *successful* dev
-  # release. "Successful" is keyed off the register-release job conclusion —
-  # the same anchor notify-dev-release uses for its changelog — so a run that
-  # registered a real release but failed in a later job (e.g. build-electron)
-  # still counts as the last release. Manual workflow_dispatch runs always
-  # proceed: the operator explicitly asked for a build.
+  # release. "Successful" means register-release succeeded on a run that was
+  # not cancelled (the same anchor notify-dev-release uses for its changelog).
+  # A run that registered a real release but failed in a later job (e.g.
+  # build-electron) still counts. A cancelled run does not, even if
+  # register-release finished before the cancel landed: that deploy did not
+  # complete, and treating it as done would skip every later attempt of the
+  # same SHA. Manual workflow_dispatch runs always proceed: the operator
+  # explicitly asked for a build.
   #
   # All root jobs (compute-version + the ci-* jobs) gate on this job's
   # has_new_commits output so they never spin up runners on an idle run. The
@@ -58,10 +64,13 @@ jobs:
             exit 0
           fi
 
-          # Walk recent completed runs newest-first and pick the first whose
-          # register-release job succeeded; that run's head SHA is the last
-          # released commit. (See notify-dev-release for why we key off the job
-          # conclusion rather than the overall run conclusion.)
+          # Walk recent completed, non-cancelled runs newest-first and pick
+          # the first whose register-release job succeeded; that run's head
+          # SHA is the last released commit. Cancelled runs are excluded even
+          # when register-release completed: a cancel mid-workflow is not a
+          # finished deploy. (See notify-dev-release for why a later job
+          # failure, e.g. build-electron, still counts.) Keep this walk-back
+          # in sync with the copy in notify-dev-release.
           #
           # The jobs listing MUST be paginated: this workflow has >30 jobs and
           # the API defaults to 30 per page, so register-release lands on page 2
@@ -92,7 +101,7 @@ jobs:
             fi
           done < <(gh api \
             "repos/${REPO}/actions/workflows/dev-release.yaml/runs?branch=main&status=completed&per_page=100&exclude_pull_requests=true" \
-            --jq ".workflow_runs[] | select(.id != ${RUN_ID}) | \"\(.id) \(.head_sha)\"")
+            --jq ".workflow_runs[] | select(.id != ${RUN_ID} and .conclusion != \"cancelled\") | \"\(.id) \(.head_sha)\"")
 
           echo "Last successful dev release SHA: ${PREV_SHA:-<none>}"
           echo "Current SHA: ${HEAD_SHA}"
@@ -819,9 +828,9 @@ jobs:
   # gating in release.yml, where a UI ahead of its backend actually matters.
   #
   # !cancelled() (rather than always()) keeps this quiet when a run is
-  # superseded by the next hourly release via concurrency.cancel-in-progress.
-  # No has_new_commits check is needed: ci-web is itself gated on that job, so
-  # an idle run skips ci-web and this job with it.
+  # cancelled (idle-gate self-cancel, or a user cancel). No has_new_commits
+  # check is needed: ci-web is itself gated on that job, so an idle run skips
+  # ci-web and this job with it.
   deploy-web-spa:
     name: Deploy Web SPA (dev)
     needs: [ci-web, register-release]
@@ -1293,7 +1302,7 @@ jobs:
   # clients — which is exactly the toggle behaviour we want here. The channel
   # stays tidy even when a release spans many commits. The diff is taken
   # since the last *successful* dev release (skipping any intervening failed
-  # runs), so no commits are dropped.
+  # or cancelled runs), so no commits are dropped.
   #
   # On failure: posts a short alert without a changelog.
   #
@@ -1306,8 +1315,8 @@ jobs:
   notify-dev-release:
     needs: [compute-version, register-release, register-preview-release, build-electron, upload-electron-updates, deploy-web-spa]
     # Run on success and failure alike, but not when the run was cancelled
-    # (e.g. superseded by a newer hourly run via cancel-in-progress) — a
-    # cancelled run is not a real failure and should not alert the channel.
+    # (idle-gate self-cancel, or a user cancel). A cancelled run is not a
+    # real failure and should not alert the channel.
     if: ${{ always() && !cancelled() }}
     runs-on: ubuntu-latest
     # A Slack outage must not fail the release run: that would both mar the run
@@ -1390,8 +1399,10 @@ jobs:
           # …), so a later failure leaves a real release on a run
           # whose conclusion is "failure". Keying off the run would then diff from
           # an older SHA and re-announce already-released commits. Walk recent
-          # completed runs newest-first and pick the first whose register-release
-          # job succeeded.
+          # completed, non-cancelled runs newest-first and pick the first whose
+          # register-release job succeeded. Cancelled runs are excluded even when
+          # register-release completed: a cancel mid-workflow is not a finished
+          # deploy. Keep this walk-back in sync with check-for-new-commits.
           #
           # The jobs listing MUST be paginated: this workflow has >30 jobs and
           # the API defaults to 30 per page, so register-release lands on page 2
@@ -1415,7 +1426,7 @@ jobs:
             fi
           done < <(gh api \
             "repos/${REPO}/actions/workflows/dev-release.yaml/runs?branch=main&status=completed&per_page=100&exclude_pull_requests=true" \
-            --jq ".workflow_runs[] | select(.id != ${RUN_ID}) | \"\(.id) \(.head_sha)\"")
+            --jq ".workflow_runs[] | select(.id != ${RUN_ID} and .conclusion != \"cancelled\") | \"\(.id) \(.head_sha)\"")
 
           echo "Previous dev release SHA: ${PREV_SHA:-<none>}"
           echo "Current SHA: ${HEAD_SHA}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

[Dev Release #2433](https://github.com/vellum-ai/vellum-assistant/actions/runs/31627297461) cancelled itself because the idle gate thought HEAD `4a2dc5b` was already the last successful deploy. The last run that actually finished was [Dev Release #2412](https://github.com/vellum-ai/vellum-assistant/actions/runs/31545924134) on `90149a2`.

A `workflow_dispatch` of `4a2dc5b` got as far as `register-release` succeeding, then was cancelled. The idle gate keyed off that job conclusion and treated the SHA as done.

## Summary

- Skip cancelled workflow runs in both walk-backs (idle gate and `#dev-releases` changelog) when finding the last successful `register-release`.

## Test Plan

- [x] Replayed the updated jq filter against the GitHub Actions API for the failing run; last successful SHA is `90149a2`, not `4a2dc5b`.
- [ ] After merge, the next scheduled (or dispatched) Dev Release on a SHA newer than `90149a2` should proceed instead of idle-cancelling.

## Risk

Low. Failed-after-register runs still count as the last release. Only cancelled runs are skipped.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ef9ee44-d29a-4cbe-8947-538520e5a03f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ef9ee44-d29a-4cbe-8947-538520e5a03f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

