### PR TITLE
refactor(web): give "an element's viewport rect, kept live" one owner (LUM-3233)

### DIFF
--- a/clients/web/src/domains/chat/components/quote-reply-bubble.tsx
+++ b/clients/web/src/domains/chat/components/quote-reply-bubble.tsx
@@ -36,6 +36,7 @@ import {
 } from "@vellumai/design-library/components/markdown-message";
 
 import { useTouchMobile } from "@/hooks/use-touch-mobile";
+import { observeViewportRect } from "@/lib/observe-viewport-rect";
 import { useQuoteReplyStore } from "@/domains/chat/quote-reply-store";
 
 interface QuoteReplyBubbleProps {
@@ -69,20 +70,7 @@ function useComposerTopOffset(enabled: boolean): number {
       setOffset(window.innerHeight - rect.top);
     };
     measure();
-    const resizeObserver = new ResizeObserver(measure);
-    resizeObserver.observe(composer);
-    window.visualViewport?.addEventListener("resize", measure);
-    // iOS shifts layout via visualViewport scroll (keyboard offsetTop change)
-    // with no resize event; the root shell moves on this same signal, so the
-    // dock must remeasure here too or it drifts from the composer.
-    window.visualViewport?.addEventListener("scroll", measure);
-    window.addEventListener("resize", measure);
-    return () => {
-      resizeObserver.disconnect();
-      window.visualViewport?.removeEventListener("resize", measure);
-      window.visualViewport?.removeEventListener("scroll", measure);
-      window.removeEventListener("resize", measure);
-    };
+    return observeViewportRect(composer, measure);
   }, [enabled]);
 
   return offset;

--- a/clients/web/src/domains/chat/in-chat-onboarding/tour-overlay.tsx
+++ b/clients/web/src/domains/chat/in-chat-onboarding/tour-overlay.tsx
@@ -4,6 +4,7 @@ import { createPortal } from "react-dom";
 
 import { ChatComposer } from "@/domains/chat/components/chat-composer/chat-composer";
 import { type VoiceInputButtonHandle } from "@/domains/chat/components/voice-input-button";
+import { observeViewportRect } from "@/lib/observe-viewport-rect";
 
 import { TourNarration } from "./tour-narration";
 import { TOUR_COMPOSER, TOUR_VOICE, type TourStep } from "./tour-steps";
@@ -58,8 +59,9 @@ export function TourOverlay({
   // callback never fires.
   const sceneryVoiceInputRef = useRef<VoiceInputButtonHandle | null>(null);
 
-  // The sidebar bounces in mid-tour, so these edges are re-measured on
-  // every beat (and window resizes), not once.
+  // The sidebar bounces in mid-tour and the header's viewport offset moves with
+  // the notch inset and the iOS keyboard, so these edges are re-measured on
+  // every beat and on every signal that can move either element, not once.
   useEffect(() => {
     if (onIntroBeat) {
       setClearLeft(0);
@@ -67,11 +69,11 @@ export function TourOverlay({
       setColumnTop(0);
       return;
     }
+    const header = document.querySelector<HTMLElement>("header");
+    const menu = document.querySelector<HTMLElement>("#chat-side-menu");
     const update = () => {
-      const header = document.querySelector<HTMLElement>("header");
       setClearTop(header ? header.getBoundingClientRect().bottom : 0);
 
-      const menu = document.querySelector<HTMLElement>("#chat-side-menu");
       if (!menu) {
         setClearLeft(0);
         setColumnTop(0);
@@ -84,8 +86,7 @@ export function TourOverlay({
       setColumnTop(rect.top);
     };
     update();
-    window.addEventListener("resize", update);
-    return () => window.removeEventListener("resize", update);
+    return observeViewportRect([header, menu], update);
   }, [onIntroBeat, step]);
 
   return createPortal(

--- a/clients/web/src/domains/chat/voice/voice-room/use-chat-header-bottom.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-chat-header-bottom.ts
@@ -26,6 +26,8 @@
 
 import { useEffect, useState } from "react";
 
+import { observeViewportRect } from "@/lib/observe-viewport-rect";
+
 /** The header's own `data-slot`, set in `chat-layout-header.tsx`. */
 const HEADER_SELECTOR = '[data-slot="chat-layout-header"]';
 
@@ -42,20 +44,7 @@ export function useChatHeaderBottom(): number {
       setBottom(header.getBoundingClientRect().bottom);
     };
     measure();
-    const observer = new ResizeObserver(measure);
-    observer.observe(header);
-    // The observer covers the header's own box changing. Its viewport offset
-    // moves for reasons the observer never sees: a rotation changing the notch
-    // inset, or the iOS keyboard opening and shifting the whole shell down.
-    window.addEventListener("resize", measure);
-    window.visualViewport?.addEventListener("resize", measure);
-    window.visualViewport?.addEventListener("scroll", measure);
-    return () => {
-      observer.disconnect();
-      window.removeEventListener("resize", measure);
-      window.visualViewport?.removeEventListener("resize", measure);
-      window.visualViewport?.removeEventListener("scroll", measure);
-    };
+    return observeViewportRect(header, measure);
   }, []);
 
   return bottom;

--- a/clients/web/src/domains/chat/voice/voice-room/use-room-box.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-room-box.ts
@@ -15,13 +15,15 @@
  *
  * Measurement is synchronous in `useLayoutEffect`, before paint, so the room's
  * entrance animation starts from a real box on its first painted frame rather
- * than growing from a zero-sized one. After mount a `ResizeObserver` tracks the
- * panel's own size (the sidebar collapsing, a rail drag), and a window `resize`
- * listener catches offset changes the observer does not fire for, since the box
- * can slide without changing size.
+ * than growing from a zero-sized one. After mount `observeViewportRect` keeps it
+ * live: the box slides without changing size (the sidebar collapsing, a rail
+ * drag, the mobile sheet riding the iOS shell down as the keyboard opens), so
+ * the room's own `ResizeObserver` is only one of the signals that matter.
  */
 
 import { useCallback, useLayoutEffect, useRef, useState } from "react";
+
+import { observeViewportRect } from "@/lib/observe-viewport-rect";
 
 export interface RoomBox {
   /** Room width in CSS px. The look's geometry scales against this. */
@@ -110,15 +112,7 @@ export function useRoomBox(): {
       return;
     }
     measure();
-    const observer = new ResizeObserver(measure);
-    observer.observe(node);
-    // A ResizeObserver only fires on size changes; the panel's viewport offset
-    // also moves when the window itself resizes around a same-sized room.
-    window.addEventListener("resize", measure);
-    return () => {
-      observer.disconnect();
-      window.removeEventListener("resize", measure);
-    };
+    return observeViewportRect(node, measure);
   }, [measure]);
 
   return { ref, box };

--- a/clients/web/src/hooks/use-element-size.ts
+++ b/clients/web/src/hooks/use-element-size.ts
@@ -24,6 +24,10 @@
  *   from it would resize the artwork every time a field is focused.
  * - `useOnboardingWindowSize` (`use-onboarding-window-size.ts`) is the Electron
  *   OS window, driven over IPC. Nothing to do with either viewport.
+ * - `observeViewportRect` (`lib/observe-viewport-rect.ts`) is where an element
+ *   *sits* rather than how big it is. A position needs signals a size does not
+ *   (the iOS shell shifting under a same-sized element), so anything measuring
+ *   a `getBoundingClientRect()` live subscribes through there, not here.
  *
  * @see https://developer.mozilla.org/en-US/docs/Web/API/Visual_Viewport_API#visual_viewport_vs._layout_viewport
  */

--- a/clients/web/src/lib/observe-viewport-rect.test.ts
+++ b/clients/web/src/lib/observe-viewport-rect.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Tests for `observeViewportRect`, the one owner of "what can move an element's
+ * viewport rect".
+ *
+ * The contract under test is the *completeness* of the signal set, since that is
+ * the whole reason the module exists and the thing that drifts when it does not.
+ * Each signal gets its own assertion, so dropping any one fails a named test
+ * rather than quietly leaving a subscription that still looks like it works.
+ *
+ * `visualViewport` is stubbed because happy-dom does not implement it; the stub
+ * is a real `EventTarget` so the listeners under test are the ones dispatched
+ * to. `ResizeObserver` exists in happy-dom but never fires, so it is replaced
+ * with a recorder: "every target is observed, and the observer is disconnected
+ * on teardown" is only visible from the observer's side.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { observeViewportRect } from "@/lib/observe-viewport-rect";
+
+/** Targets an observer was asked to watch, newest instance last. */
+let observed: Element[][] = [];
+let disconnectCount = 0;
+
+const NativeResizeObserver = globalThis.ResizeObserver;
+
+class RecordingResizeObserver {
+  private readonly targets: Element[] = [];
+
+  constructor() {
+    observed.push(this.targets);
+  }
+
+  observe(target: Element): void {
+    this.targets.push(target);
+  }
+
+  disconnect(): void {
+    disconnectCount += 1;
+  }
+}
+
+function stubVisualViewport(): EventTarget {
+  const viewport = new EventTarget();
+  Object.defineProperty(window, "visualViewport", {
+    configurable: true,
+    value: viewport,
+  });
+  return viewport;
+}
+
+let visualViewport: EventTarget;
+/** Subscriptions a test did not tear down itself, released after it. */
+let openSubscriptions: (() => void)[] = [];
+
+beforeEach(() => {
+  observed = [];
+  disconnectCount = 0;
+  openSubscriptions = [];
+  globalThis.ResizeObserver =
+    RecordingResizeObserver as unknown as typeof ResizeObserver;
+  visualViewport = stubVisualViewport();
+});
+
+afterEach(() => {
+  for (const stop of openSubscriptions) {
+    stop();
+  }
+  globalThis.ResizeObserver = NativeResizeObserver;
+  Object.defineProperty(window, "visualViewport", {
+    configurable: true,
+    value: undefined,
+  });
+});
+
+function element(): HTMLElement {
+  return document.createElement("div");
+}
+
+/**
+ * Subscribe, registering the teardown so a `window` listener never outlives the
+ * test that made it. Tests asserting on teardown call the returned stop early;
+ * releasing twice is harmless.
+ */
+function observe(
+  targets: Parameters<typeof observeViewportRect>[0],
+  onChange: () => void,
+): () => void {
+  const stop = observeViewportRect(targets, onChange);
+  openSubscriptions.push(stop);
+  return stop;
+}
+
+describe("observeViewportRect", () => {
+  test("does not measure on subscribe: the caller owns the first read", () => {
+    const onChange = mock(() => {});
+    observe(element(), onChange);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test("fires on a window resize", () => {
+    const onChange = mock(() => {});
+    observe(element(), onChange);
+
+    window.dispatchEvent(new Event("resize"));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  test("fires on a visualViewport resize", () => {
+    const onChange = mock(() => {});
+    observe(element(), onChange);
+
+    visualViewport.dispatchEvent(new Event("resize"));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  test("fires on a visualViewport scroll", () => {
+    const onChange = mock(() => {});
+    observe(element(), onChange);
+
+    // The signal iOS delivers on its own: the shell shifts by `offsetTop` with
+    // no resize beside it, so a subscription without this one goes stale silently.
+    visualViewport.dispatchEvent(new Event("scroll"));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  test("observes every target it was given", () => {
+    const first = element();
+    const second = element();
+
+    observe([first, second], () => {});
+
+    expect(observed).toHaveLength(1);
+    expect(observed[0]).toEqual([first, second]);
+  });
+
+  test("skips nullish targets instead of throwing", () => {
+    const present = element();
+    const onChange = mock(() => {});
+
+    observe([null, present, undefined], onChange);
+
+    expect(observed[0]).toEqual([present]);
+    // The window-level signals still apply: a caller measuring one element that
+    // is there and one that is not still needs to hear about the viewport.
+    window.dispatchEvent(new Event("resize"));
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  test("registers the window-level listeners once, not once per target", () => {
+    const onChange = mock(() => {});
+    observe([element(), element(), element()], onChange);
+
+    window.dispatchEvent(new Event("resize"));
+    visualViewport.dispatchEvent(new Event("scroll"));
+
+    // Three targets, two events: a per-target registration would report six.
+    expect(onChange).toHaveBeenCalledTimes(2);
+  });
+
+  test("teardown releases every signal", () => {
+    const onChange = mock(() => {});
+    const stop = observe(element(), onChange);
+
+    stop();
+
+    window.dispatchEvent(new Event("resize"));
+    visualViewport.dispatchEvent(new Event("resize"));
+    visualViewport.dispatchEvent(new Event("scroll"));
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(disconnectCount).toBe(1);
+  });
+
+  test("survives a runtime with no visualViewport", () => {
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: undefined,
+    });
+    const onChange = mock(() => {});
+
+    const stop = observe(element(), onChange);
+    window.dispatchEvent(new Event("resize"));
+    stop();
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/web/src/lib/observe-viewport-rect.ts
+++ b/clients/web/src/lib/observe-viewport-rect.ts
@@ -1,0 +1,71 @@
+/**
+ * The signals that mean an element's rect in *viewport* space may have moved.
+ *
+ * `getBoundingClientRect()` is viewport-relative, so a caller that positions
+ * something `fixed` against another element has to re-measure whenever either
+ * the element's own box changes or the viewport moves underneath it. Those are
+ * three separate sources, and missing any one leaves the measurement stale
+ * without ever throwing:
+ *
+ * - a `ResizeObserver` on the element, for its own box changing;
+ * - `window`'s `resize`, for the layout viewport changing around a same-sized
+ *   element (a window drag, an orientation change);
+ * - `visualViewport`'s `resize` **and** `scroll`, for iOS. The soft keyboard
+ *   shrinks the visual viewport without touching `window.innerHeight` in mobile
+ *   Safari, and iOS then shifts the whole shell by changing `offsetTop`, which
+ *   arrives as a `scroll` with no `resize` beside it. `root-layout.tsx` stacks
+ *   that compensation onto the notch inset it already pads the shell by, so an
+ *   element measured before either lands sits at an offset that no longer
+ *   exists.
+ *
+ * Completeness is a property of the concept, not of any one call site, which is
+ * why the list lives in one place: a reader of a hand-rolled subscription has
+ * no way to tell whether theirs is the whole set.
+ *
+ * Deliberately does not measure, hold state, or resolve the element. Callers
+ * want different values out of the same rect (a `bottom`, a distance up from
+ * the viewport floor, a whole box) and pass their own `onChange`. Sharing the
+ * subscription rather than the measurement is what keeps this from becoming a
+ * hook with a parameter for every caller's difference.
+ *
+ * `onChange` is not invoked on subscribe. Callers measure once themselves, in
+ * the effect that sets this up, so the first value is visibly theirs.
+ *
+ * Related, for a size rather than a position: `hooks/use-element-size.ts`.
+ */
+
+/** An element to watch, or a nullish placeholder for one that is not there. */
+export type ViewportRectTarget = Element | null | undefined;
+
+/**
+ * Watch `targets` for anything that can change where they sit in the viewport,
+ * calling `onChange` each time. Returns the teardown.
+ *
+ * Accepts several targets so a caller measuring more than one element (the
+ * onboarding tour reads both the header and the side menu into one update)
+ * registers the window-level listeners once rather than per element. Nullish
+ * targets are skipped, so an optional element needs no guard at the call site.
+ */
+export function observeViewportRect(
+  targets: ViewportRectTarget | ViewportRectTarget[],
+  onChange: () => void,
+): () => void {
+  const observer = new ResizeObserver(onChange);
+  for (const target of Array.isArray(targets) ? targets : [targets]) {
+    if (target) {
+      observer.observe(target);
+    }
+  }
+
+  window.addEventListener("resize", onChange);
+  const visualViewport = window.visualViewport;
+  visualViewport?.addEventListener("resize", onChange);
+  visualViewport?.addEventListener("scroll", onChange);
+
+  return () => {
+    observer.disconnect();
+    window.removeEventListener("resize", onChange);
+    visualViewport?.removeEventListener("resize", onChange);
+    visualViewport?.removeEventListener("scroll", onChange);
+  };
+}


### PR DESCRIPTION
## TL;DR

`hooks/use-element-size.ts` owns *how big* an element is and *how big* the layout viewport is. Nothing owned the third case: **where** an element sits in the viewport. Four call sites hand-rolled that, and each one decided for itself which events mean "that rect may have moved". They disagreed.

This adds `lib/observe-viewport-rect.ts` as the single owner of the signal set, deletes all four hand-rolled subscriptions, and in doing so lands the fix that two of them were missing.

Fixes LUM-3233. Also fixes LUM-3234 (the behaviour half, filed separately so it is visible in the timeline rather than buried in a refactor).

## What was wrong

| File | `ResizeObserver` | `window resize` | `visualViewport` resize + scroll |
|---|---|---|---|
| `use-chat-header-bottom.ts` | yes | yes | **yes** |
| `quote-reply-bubble.tsx` (`useComposerTopOffset`) | yes | yes | **yes** |
| `use-room-box.ts` | yes | yes | **no** |
| `tour-overlay.tsx` | **no** | yes | **no** |

The two complete copies each explain the `visualViewport` pair in their own words — the same discovery, made twice, by two authors who could not see each other's comment. Neither comment was reachable from the two files that needed it. Completeness of a listener set is a property of the concept, not of any one file, so no reader of a single copy could tell whether theirs was right.

`tour-overlay.tsx` measured *the same value* `use-chat-header-bottom.ts` measures (the chat header's `getBoundingClientRect().bottom`) with a strictly smaller set of listeners.

## What changed

One plain function, `observeViewportRect(targets, onChange)`, owning the complete set. Each call site keeps its own `measure`: the values wanted out of the rect genuinely differ (`rect.bottom`, `innerHeight - rect.top`, `{w, h, left, top}`, `rect.left + max(rect.width, innerWidth)`), and only the subscription was duplicated. Sharing behaviour, not shape — a hook that also owned the state would need a parameter for every caller's difference, which preserves drift under a new name.

All four hand-rolled listener sets are deleted in this change. `hooks/use-element-size.ts` gains a pointer to it, in the list it already keeps of "the neighbouring things that are not this".

## Before / after, in plain language

| | Before | After |
|---|---|---|
| Chat header bottom (mobile voice sheet) | Followed the header everywhere it moved | Unchanged |
| Quote-reply dock above the composer | Followed the composer everywhere it moved | Unchanged |
| Voice room's own box | Went stale when the room moved without changing size | Follows the room |
| In-chat tour backdrop | Measured once per tour beat and on window resize only, so it drifted off the header and sidebar in between | Re-measured whenever either element moves or resizes |
| Everything on screen | — | Identical markup, class strings, and measured values |

## Why it is safe

- No JSX, no class strings, no styles, no measured expression changed. The diff is subscription plumbing; every `getBoundingClientRect()` call and every derived value is byte-identical.
- The two call sites that already had the complete set are pure deletions: they subscribe to exactly what they subscribed to before.
- The two that were short now re-measure on *more* signals. That is strictly more correct (each re-measure recomputes the same expression from live DOM), and it is the behaviour change LUM-3234 names.
- `lib/observe-viewport-rect.test.ts` asserts each signal separately, so dropping any one fails a named test rather than leaving a subscription that still looks like it works. It also pins the things that are easy to get quietly wrong: teardown releases every signal, nullish targets are skipped rather than thrown on, and N targets register the window listeners once rather than N times.
- Typecheck, ESLint, and Prettier are clean. Local `bun test` is blocked by a hook here, so the suite runs in CI.

## Verification not done

The in-chat tour is behind the `in-chat-onboarding-tour` flag and needs a live assistant, so the iOS-keyboard case is argued from `root-layout.tsx:414-455` (which stacks `visibleViewport.offsetTop` into the shell's top padding, driven by the same `visualViewport` signals) rather than observed on hardware. Noted on LUM-3234 as worth a device pass next time the tour is exercised.

## Deliberately not in scope

- `active-overlay-shell.tsx` measures a rect relative to its `offsetParent`, not the viewport, and additionally observes sibling pills and a `MutationObserver` on the row. Different value, different signals; a shared name over two different behaviours is the trap this ticket is about.
- `research-result-steps.tsx` measures animation flight anchors, one with an explicit "intentionally not re-measuring" comment. Re-pointing those changes *when* they measure, which is a behaviour change, and the file is already covered by LUM-3204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40631" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->