### PR TITLE
fix(web): mount the quote-reply bubble story on a real composer (LUM-3232)

### DIFF
--- a/clients/web/src/domains/chat/components/chat-footer-fixtures.tsx
+++ b/clients/web/src/domains/chat/components/chat-footer-fixtures.tsx
@@ -1,0 +1,72 @@
+/**
+ * The chat footer as `chat-body` builds it, for the stories whose subject has
+ * a contract against the composer rather than against itself.
+ *
+ * Two do. `StagedQuotesStrip` sits directly on the composer, so its `mb-2` is
+ * a gap to a real element or it is a gap to nothing. `QuoteReplyBubble`'s
+ * touch-mobile dock positions itself by measuring `[data-slot="chat-composer"]`
+ * out of the document (`quote-reply-bubble.tsx:52-84`), so with no composer
+ * mounted it falls back to `bottom: 8px`: glued to the viewport, a position
+ * the app never produces, and rendered identically whether the measurement
+ * works or is broken.
+ *
+ * `ChatColumn` and `ChatComposer` are imported rather than mirrored, so the
+ * column's widths and insets and the composer's height reach these stories on
+ * their own. The one thing reproduced here is the arrangement: `chat-body.tsx`
+ * stacks the footer slots above `{composerSlot}` inside a `ChatColumn` with
+ * `pt-1 pb-2 sm:pb-0`, at the bottom of the chat body.
+ */
+
+import { useRef, type ReactNode } from "react";
+
+import { ChatColumn } from "@/domains/chat/components/chat-column";
+import { ChatComposer } from "@/domains/chat/components/chat-composer/chat-composer";
+
+/**
+ * The composer the footer stack actually sits on. Every prop it requires is an
+ * input the orchestrator hands down, so the real component mounts on
+ * story-supplied callbacks; nothing here stands in for a value the app
+ * derives.
+ */
+function StoryChatComposer() {
+  const inputRef = useRef<HTMLTextAreaElement | null>(null);
+  return (
+    <ChatComposer
+      placeholder="What would you like to do?"
+      onSubmit={(event) => event.preventDefault()}
+      inputRef={inputRef}
+      typingDisabled={false}
+      sendDisabled={false}
+      onAddAttachmentFiles={() => {}}
+      onStopGenerating={() => {}}
+      isAssistantBusy={false}
+      assistantId={null}
+    />
+  );
+}
+
+interface ChatFooterShellProps {
+  /**
+   * Stacked above the composer, inside the column, where `chat-body` puts the
+   * footer slots.
+   */
+  children?: ReactNode;
+  /**
+   * Story harness controls. Rendered below the column and outside it, so a
+   * control the app does not ship cannot be mistaken for part of the footer.
+   */
+  harness?: ReactNode;
+}
+
+/** The bottom-anchored chat page: the footer column, on a real composer. */
+export function ChatFooterShell({ children, harness }: ChatFooterShellProps) {
+  return (
+    <div className="flex h-screen flex-col justify-end">
+      <ChatColumn className="pt-1 pb-2 sm:pb-0">
+        {children}
+        <StoryChatComposer />
+      </ChatColumn>
+      {harness && <div className="px-3 py-3 sm:px-6">{harness}</div>}
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/quote-reply-bubble.stories.tsx
+++ b/clients/web/src/domains/chat/components/quote-reply-bubble.stories.tsx
@@ -1,49 +1,103 @@
+/**
+ * The reply-entry surface that opens when the user starts a reply from a text
+ * selection: the quoted passage, a reply field, and Cancel / Add to Chat
+ * (Rok's "Quote & Reply" polish, node 6485-155641).
+ *
+ * The bubble renders one of two different things, and both are positioned
+ * against something outside themselves, so neither is reviewable with the
+ * bubble standing alone:
+ *
+ * - **Desktop**: a popover anchored to the selection rect in the transcript.
+ * - **Touch-mobile**: a portal docked full width above the composer, placed by
+ *   measuring `[data-slot="chat-composer"]` out of the document.
+ *
+ * So these stories mount it where `chat-route-content` mounts it: as a sibling
+ * of the chat body, with the real footer stack (`ChatColumn` on the real
+ * `ChatComposer`) present in the page. Without that composer the dock has
+ * nothing to measure, falls back to the viewport bottom, and looks the same
+ * whether its measurement works or not.
+ *
+ * Reaching the touch branch needs a coarse pointer as well as a narrow
+ * viewport, which the Storybook viewport toolbar does not emulate; device
+ * emulation in a browser does. Tracked in LUM-3179.
+ */
+
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useEffect } from "react";
 
 import { QuoteReplyBubble } from "./quote-reply-bubble";
+import { ChatFooterShell } from "@/domains/chat/components/chat-footer-fixtures";
 import { useQuoteReplyStore } from "@/domains/chat/quote-reply-store";
 
 /**
- * The reply-entry modal that opens when the user starts a reply from a text
- * selection: the quoted passage, a reply field, and Cancel / Add to Chat
- * (Rok's "Quote & Reply" polish — node 6485-155641).
+ * Where in the viewport the quoted passage was selected. The app measures this
+ * off the selection range (`text-selection-popover.tsx:169-176`); a story has
+ * no selection, so this stands in for it, and it is the one value here that
+ * does. It only drives the desktop popover: the touch dock ignores the anchor
+ * and measures the composer instead.
  */
+const SELECTION_ANCHOR = { top: 220, left: 360, width: 0, height: 0 };
 
-/** Seeds the reply bubble into the shared store, then renders it. */
-function WithReplyBubble({ quotedText }: { quotedText: string }) {
+interface QuoteReplyStoryArgs {
+  /** The passage the user selected, as `openReplyBubble` receives it. */
+  quotedText: string;
+}
+
+/** Opens the bubble through the store's own write path, then renders it. */
+function OpenedBubble({ quotedText }: QuoteReplyStoryArgs) {
   useEffect(() => {
-    useQuoteReplyStore.setState({
-      replyBubble: {
-        quotedText,
-        sourceMessageId: "msg-1",
-        anchorRect: { top: 220, left: 360, width: 0, height: 0 },
-      },
+    useQuoteReplyStore.getState().openReplyBubble({
+      quotedText,
+      sourceMessageId: "msg-1",
+      anchorRect: SELECTION_ANCHOR,
     });
-    return () => useQuoteReplyStore.setState({ replyBubble: null });
+    return () => useQuoteReplyStore.getState().closeReplyBubble();
   }, [quotedText]);
+
   return <QuoteReplyBubble />;
 }
 
-const meta: Meta<typeof QuoteReplyBubble> = {
+const meta: Meta<QuoteReplyStoryArgs> = {
   title: "Chat/QuoteReplyBubble",
-  parameters: {
-    layout: "fullscreen",
-    controls: { disable: true },
+  parameters: { layout: "fullscreen" },
+  decorators: [
+    /* The bubble is a sibling of the chat body in `chat-route-content.tsx`, not
+       a child of the footer column, so it sits beside the shell rather than
+       inside it. The shell is what puts a real composer in the document for
+       the touch dock to measure. */
+    (Story) => (
+      <>
+        <ChatFooterShell />
+        <Story />
+      </>
+    ),
+  ],
+  args: {
+    quotedText: "This is a text that's being quoted",
   },
+  render: (args) => <OpenedBubble {...args} />,
 };
 
 export default meta;
-type Story = StoryObj<typeof QuoteReplyBubble>;
+type Story = StoryObj<QuoteReplyStoryArgs>;
 
-export const Default: Story = {
-  render: () => (
-    <WithReplyBubble quotedText="This is a text that's being quoted" />
-  ),
+/** A short passage: the card sizes to its fixed 360px popover width. */
+export const Default: Story = {};
+
+/** Past 200 characters the quote is truncated with an ellipsis. */
+export const LongQuote: Story = {
+  args: {
+    quotedText:
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation.",
+  },
 };
 
-export const LongQuote: Story = {
-  render: () => (
-    <WithReplyBubble quotedText="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation." />
-  ),
+/**
+ * A narrow window with a fine pointer, which is a shrunk desktop window rather
+ * than a phone. The popover keeps its 12px collision padding here instead of
+ * docking: the dock needs `pointer: coarse` too, and the viewport toolbar sets
+ * width only. Use browser device emulation to see the docked treatment.
+ */
+export const NarrowWindow: Story = {
+  globals: { viewport: { value: "sbMobile", isRotated: false } },
 };

--- a/clients/web/src/domains/chat/components/staged-quotes-strip.stories.tsx
+++ b/clients/web/src/domains/chat/components/staged-quotes-strip.stories.tsx
@@ -12,12 +12,11 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { Button } from "@vellumai/design-library";
 
 import { StagedQuotesStrip } from "./staged-quotes-strip";
-import { ChatColumn } from "@/domains/chat/components/chat-column";
-import { ChatComposer } from "@/domains/chat/components/chat-composer/chat-composer";
+import { ChatFooterShell } from "@/domains/chat/components/chat-footer-fixtures";
 import { useQuoteReplyStore } from "@/domains/chat/quote-reply-store";
 
 const SAMPLE_QUOTES = [
@@ -63,49 +62,24 @@ function SeededStrip({ count }: { count: number }) {
   return <StagedQuotesStrip />;
 }
 
-/**
- * The composer the strip actually sits on. Every required prop is an input the
- * orchestrator hands down, so the real component mounts on story-supplied
- * callbacks; nothing here stands in for a value the app derives.
- */
-function StoryComposer() {
-  const inputRef = useRef<HTMLTextAreaElement | null>(null);
-  return (
-    <ChatComposer
-      placeholder="What would you like to do?"
-      onSubmit={(event) => event.preventDefault()}
-      inputRef={inputRef}
-      typingDisabled={false}
-      sendDisabled={false}
-      onAddAttachmentFiles={() => {}}
-      onStopGenerating={() => {}}
-      isAssistantBusy={false}
-      assistantId={null}
-    />
-  );
-}
-
 const meta: Meta<typeof StagedQuotesStrip> = {
   title: "Chat/StagedQuotesStrip",
   parameters: { layout: "fullscreen", controls: { disable: true } },
   decorators: [
-    /* The real `ChatColumn` with the composer stack's own vertical padding,
-       inside a bottom-anchored body: the same arrangement `chat-body` builds
-       around the strip. Imported rather than mirrored, so a change to the
-       column reaches this story on its own. */
+    /* The real footer stack: `ChatColumn` on the real `ChatComposer`, inside a
+       bottom-anchored body, the same arrangement `chat-body` builds around the
+       strip. Shared with the quote-reply-bubble story, which has its own
+       contract against that composer. */
     (Story) => (
-      <div className="flex h-screen flex-col justify-end">
-        <ChatColumn className="pt-1 pb-2 sm:pb-0">
-          <Story />
-          <StoryComposer />
-        </ChatColumn>
-        {/* Harness control, deliberately outside the app column. */}
-        <div className="px-3 py-3 sm:px-6">
+      <ChatFooterShell
+        harness={
           <Button variant="outlined" size="compact" onClick={stageAnotherQuote}>
             Stage another quote
           </Button>
-        </div>
-      </div>
+        }
+      >
+        <Story />
+      </ChatFooterShell>
     ),
   ],
 };


### PR DESCRIPTION
## TL;DR

`QuoteReplyBubble`'s touch-mobile dock positions itself by measuring the composer out of the document. Its story had no composer, so the dock rendered glued to the viewport bottom, and rendered that **identically whether the measurement worked or was entirely broken**. Both stories now mount in the real footer stack, and the shell the staged-quotes story already built is extracted so both import it instead of copying it.

Fixes LUM-3232.

## What was wrong

`QuoteReplyBubble` renders one of two things (`quote-reply-bubble.tsx:190-232`):

- **Desktop**: a Radix popover anchored to the selection rect.
- **Touch-mobile**: a portal docked full width above the composer, placed by `useComposerTopOffset` (`:52-84`), which queries `[data-slot="chat-composer"]` and sets `bottom: offset + 8px`.

The story mounted the bubble alone. `#storybook-root` held exactly one node, the popover anchor span. With no composer, `useComposerTopOffset` takes its early return at `:64`, the offset stays `0`, and the `ResizeObserver` that tracks composer resizes is never attached at all.

## Evidence

Measured against the rendered DOM, viewport 375x812 with touch emulation so the dock branch actually mounts (the toolbar's width-only viewport cannot reach it).

| | `data-slot` query | dock `style` | gap to composer top |
|---|---|---|---|
| Before | no composer in document | `bottom: 8px` | no composer to measure |
| After | resolves | `bottom: 108px` | **8px**, exactly `COMPOSER_DOCK_GAP_PX` |

Sensitivity checked rather than assumed: renaming `data-slot="chat-composer"` on the composer moves the dock back to `bottom: 8px` and it then **overlaps** the composer by 92px. Before this change that same break produced no visible difference at all. (Probe reverted; not in the diff.)

The `StagedQuotesStrip` refactor is structural only. Its rendered DOM was captured before and after and is identical: same class strings and same x/y/w/h at every node, composer at `240,666.5 800x84` in both.

## Before / after for a reviewer

| | Before | After |
|---|---|---|
| Desktop story | Card floating on an empty canvas | Card over a real chat page with the real composer below it |
| Mobile dock | Stuck to the bottom of the window, a position the app never produces | Sits 8px above the real composer, as it does in the app |
| Renaming the composer's `data-slot` | Story looks unchanged | Dock visibly collides with the composer |
| Staged-quotes story | Built its own footer shell inline | Imports the shared one; renders identically |
| Story seeding | `setState`, reaching past the store | `openReplyBubble`, the store's own write path |
| Quoted text | Hardcoded per story | An `arg`, editable from Controls |

## Why it is safe

No production code changed. The diff is two story files and one new story-only fixture module; nothing outside `*.stories.tsx` imports `chat-footer-fixtures.tsx`. `ChatColumn` and `ChatComposer` are imported rather than mirrored, so the column's insets and the composer's height keep reaching these stories on their own. Typecheck, lint and Prettier pass on the touched files.

## Deferred, and why

**The desktop popover still takes a stand-in `anchorRect`** rather than deriving one from a real selection. Doing it properly means mounting `TranscriptMessageBody` (the only component carrying the `data-message-id` + `data-message-role` contract that `resolveAssistantSelection` keys on) and driving a real `window.getSelection()`, which pulls in a `DisplayMessage` fixture and five Zustand stores. Hand-drawing a paragraph instead would be exactly the invented scenery LUM-3193 just removed from the neighbouring story, so the value is named as a stand-in in the source rather than faked. Separable piece of work, worth its own ticket.

**The touch branch is still unreachable from the viewport toolbar**, which sets width but not `pointer: coarse`. That is LUM-3179. Module-mocking the touch signal was considered and rejected on the merits, not on scope: the component pairs a JS branch with `touch-mobile:` CSS variants keyed on the same media query, so mocking only the JS half would render a hybrid that is wrong in a new way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40632" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->