### PR TITLE
fix(gateway): forward Slack thread_broadcast replies in tracked threads

### DIFF
--- a/gateway/src/__tests__/slack-socket-mode-catchup.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-catchup.test.ts
@@ -625,6 +625,49 @@ describe("replayMissedEvents", () => {
     }
   });
 
+  test("recovers a missed unmentioned thread_broadcast from an active thread", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+    client.ws = ws;
+
+    store.setLastSeenTsIfGreater("1700000000.000000");
+    store.trackThread("1700000000.000000", "CROUTED01", 24 * 60 * 60 * 1_000);
+
+    fetchMock = mock(async (input) => {
+      const url = String(input);
+      if (url.includes("conversations.replies")) {
+        return makeHistoryResponse([
+          {
+            type: "message",
+            subtype: "thread_broadcast",
+            user: "U-reply",
+            text: "also sending this to the channel",
+            ts: "1700000065.000000",
+            thread_ts: "1700000000.000000",
+          },
+        ]);
+      }
+      return makeHistoryResponse([]);
+    });
+
+    try {
+      await client.replayMissedEvents(ws);
+      await flushAsyncEventEmission();
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0].event.source.updateId).toBe(
+        "replay:CROUTED01:1700000065.000000",
+      );
+      expect(emitted[0].event.message.content).toBe(
+        "also sending this to the channel",
+      );
+      expect(emitted[0].threadTs).toBe("1700000000.000000");
+    } finally {
+      rawDb.close();
+    }
+  });
+
   test("recovers a missed @-mention in a thread the bot posted to first (JARVIS-1086)", async () => {
     const { rawDb, store } = createSlackStore();
     const emitted: NormalizedSlackEvent[] = [];

--- a/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
@@ -500,6 +500,111 @@ describe("SlackSocketModeClient thread tracking", () => {
     }
   });
 
+  test("accepts an unmentioned thread_broadcast reply in a tracked thread", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+
+    try {
+      await Promise.all([
+        resolveSlackUser("U-mentioned", "xoxb-test"),
+        resolveSlackUser("U-reply", "xoxb-test"),
+      ]);
+
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: "env-mention-broadcast",
+          type: "events_api",
+          payload: {
+            event_id: "Ev-mention-broadcast",
+            event: {
+              type: "app_mention",
+              user: "U-mentioned",
+              text: "<@UBOT> can you help here?",
+              ts: "1700000000.000100",
+              channel: "C-thread",
+              thread_ts: "1700000000.000000",
+            },
+          },
+        }),
+        ws,
+      );
+      await flushAsyncEventEmission();
+      expect(emitted).toHaveLength(1);
+
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: "env-broadcast-reply",
+          type: "events_api",
+          payload: {
+            event_id: "Ev-broadcast-reply",
+            event: {
+              type: "message",
+              subtype: "thread_broadcast",
+              user: "U-reply",
+              text: "following up in the thread and the channel",
+              ts: "1700000000.000250",
+              channel: "C-thread",
+              channel_type: "channel",
+              thread_ts: "1700000000.000000",
+            },
+          },
+        }),
+        ws,
+      );
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(2);
+      expect(emitted[1].event.source.updateId).toBe("Ev-broadcast-reply");
+      expect(emitted[1].event.message.content).toBe(
+        "following up in the thread and the channel",
+      );
+      expect(emitted[1].threadTs).toBe("1700000000.000000");
+      expect(emitted[1].event.source.threadId).toBe("1700000000.000000");
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("still drops a thread_broadcast reply in an untracked thread", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+
+    try {
+      await resolveSlackUser("U-reply", "xoxb-test");
+
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: "env-untracked-broadcast",
+          type: "events_api",
+          payload: {
+            event_id: "Ev-untracked-broadcast",
+            event: {
+              type: "message",
+              subtype: "thread_broadcast",
+              user: "U-reply",
+              text: "also send this to the channel",
+              ts: "1700000000.000260",
+              channel: "C-thread",
+              channel_type: "channel",
+              thread_ts: "1700000000.000000",
+            },
+          },
+        }),
+        ws,
+      );
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(0);
+      expect(store.hasThread("1700000000.000000")).toBe(false);
+    } finally {
+      rawDb.close();
+    }
+  });
+
   test("stamps payload-level team_id onto events lacking an inner team", async () => {
     const { rawDb, store } = createSlackStore();
     const emitted: NormalizedSlackEvent[] = [];

--- a/gateway/src/slack/message-normalizer.ts
+++ b/gateway/src/slack/message-normalizer.ts
@@ -14,6 +14,21 @@ import type { GatewayConfig } from "../config.js";
 import { resolveAssistant, isRejection } from "../routing/resolve-assistant.js";
 import type { RouteResult } from "../routing/types.js";
 
+/**
+ * Message subtypes that are still a person saying something. Plain messages
+ * omit `subtype`. `file_share` is an upload. `thread_broadcast` is a thread
+ * reply that was also posted to the channel. Edits, deletes, and bot/system
+ * subtypes have their own paths or are dropped.
+ */
+const ADMITTED_MESSAGE_SUBTYPES = new Set(["file_share", "thread_broadcast"]);
+
+/** True when `subtype` is present and is not a human message we ingest. */
+export function isIgnoredSlackMessageSubtype(
+  subtype: string | undefined,
+): boolean {
+  return subtype !== undefined && !ADMITTED_MESSAGE_SUBTYPES.has(subtype);
+}
+
 /** The per-event-type differences across the plain-message normalizers. */
 type SlackMessageShape = {
   /** `source.chatType`; omitted for `app_mention`. */
@@ -140,9 +155,9 @@ export function normalizeSlackDirectMessage(
   if (!parsed.success) return null;
   const msg = parsed.data;
 
-  // Only plain user messages; file_share carries uploads. Edits/deletes have
-  // their own normalizers.
-  if (msg.subtype && msg.subtype !== "file_share") return null;
+  // Only plain user messages, uploads, and thread broadcasts. Edits/deletes
+  // have their own normalizers.
+  if (isIgnoredSlackMessageSubtype(msg.subtype)) return null;
   if (!msg.user || !msg.channel || !msg.ts) return null;
 
   const routing = resolveAssistant(config, msg.channel, msg.user);
@@ -196,7 +211,7 @@ export function normalizeSlackGroupDirectMessage(
   if (!parsed.success) return null;
   const msg = parsed.data;
 
-  if (msg.subtype && msg.subtype !== "file_share") return null;
+  if (isIgnoredSlackMessageSubtype(msg.subtype)) return null;
   if (!msg.user || !msg.channel || !msg.ts) return null;
 
   const routing = resolveAssistant(config, msg.channel, msg.user);
@@ -236,8 +251,9 @@ export function normalizeSlackChannelMessage(
   if (!parsed.success) return null;
   const msg = parsed.data;
 
-  // file_share is allowed so image/file uploads are delivered to the assistant.
-  if (msg.subtype && msg.subtype !== "file_share") return null;
+  // file_share (uploads) and thread_broadcast (also-send-to-channel replies)
+  // are still human messages.
+  if (isIgnoredSlackMessageSubtype(msg.subtype)) return null;
   if (!msg.user || !msg.channel || !msg.ts) return null;
 
   const routing = resolveAssistant(config, msg.channel, msg.user);

--- a/gateway/src/slack/normalize.test.ts
+++ b/gateway/src/slack/normalize.test.ts
@@ -1158,6 +1158,24 @@ describe("attachment extraction in normalize functions", () => {
 
         expect(result).toBeNull();
       });
+
+      it("normalizes a thread_broadcast channel reply", () => {
+        const config = makeConfig();
+        const event = makeChannelEvent({
+          subtype: "thread_broadcast",
+          text: "also sending this to the channel",
+          thread_ts: "1234567890.000001",
+          ts: "1234567890.123456",
+        });
+        const result = normalizeSlackChannelMessage(event, "evt-tb-1", config);
+
+        expect(result).not.toBeNull();
+        expect(result!.event.message.content).toBe(
+          "also sending this to the channel",
+        );
+        expect(result!.threadTs).toBe("1234567890.000001");
+        expect(result!.event.source.threadId).toBe("1234567890.000001");
+      });
     });
   });
 

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -30,6 +30,7 @@ import {
   normalizeSlackDirectMessage,
   normalizeSlackGroupDirectMessage,
   normalizeSlackChannelMessage,
+  isIgnoredSlackMessageSubtype,
 } from "./message-normalizer.js";
 import {
   normalizeSlackMessageEdit,
@@ -1798,13 +1799,7 @@ export class SlackSocketModeClient {
     // filter would already drop these and replaying them risks loops.
     if (msg.user === botUserId) return false;
     if (msg.bot_id) return false;
-    if (
-      msg.subtype &&
-      msg.subtype !== "thread_broadcast" &&
-      msg.subtype !== "file_share"
-    ) {
-      return false;
-    }
+    if (isIgnoredSlackMessageSubtype(msg.subtype)) return false;
 
     const mentionsBot = msg.text?.includes(`<@${botUserId}>`) ?? false;
     // `conversations.history`/`replies` carry no `channel_type`, so classify


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- An unmentioned Slack thread reply with subtype `thread_broadcast` (Also send to channel) was admitted by the active-thread filter, then dropped by the live message normalizers, so the assistant never woke.
- Reconnect catch-up already treated `thread_broadcast` as a human message, but live dedup marked the dropped event seen, so recovery could not repair it.
- Share one subtype allowlist (`file_share`, `thread_broadcast`) between the normalizers and catch-up. Untracked threads still drop these replies.

This is a neighboring gap to LUM-2941 (replies under the assistant's own top-level posts) and JARVIS-1086 (threads the assistant joins first). Those paths already arm and admit ordinary unmentioned thread replies. `thread_broadcast` was the remaining live-path miss.

## Test Plan
- `cd gateway && bun test src/slack/normalize.test.ts` (pass)
- `cd gateway && bun test src/__tests__/slack-socket-mode-thread-tracking.test.ts` (pass)
- `cd gateway && bun test src/__tests__/slack-socket-mode-catchup.test.ts` (pass)
- `cd gateway && bun test src/__tests__/slack-socket-mode-outbound-root.test.ts src/slack/classify-event.test.ts` (pass; LUM-2941 still holds)
- New coverage: channel `thread_broadcast` normalizes, a tracked-thread broadcast is forwarded, an untracked broadcast still drops, catch-up recovers an unmentioned broadcast.

## Risk
- Low. Admission is unchanged: only replies that already pass the active-thread (or DM) filter are forwarded. `bot_message` and other system subtypes still drop.
- Residual uncertainty: the source report had no raw Slack payload, so a different silent-drop (expired TTL, `mention_only`, sleeping assistant) remains possible.

## Prompt / plan
Investigate a customer-reported Slack thread reply that did not wake the assistant. Work from main, inspect ingress/arming/binding/wake/delivery, reproduce with existing tests, and patch only a evidenced neighboring gap. Keep investigation metadata generalized.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7fb437d2-670b-4623-90ca-fa85f1dc4bbc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fb437d2-670b-4623-90ca-fa85f1dc4bbc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

