### PR TITLE
fix(web): render GFM tables in the document editor

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -220,6 +220,7 @@
         "@tiptap/core": "3.23.5",
         "@tiptap/extension-bubble-menu": "3.23.5",
         "@tiptap/extension-link": "3.23.5",
+        "@tiptap/extension-table": "3.23.5",
         "@tiptap/pm": "3.23.5",
         "@tiptap/react": "3.23.5",
         "@tiptap/starter-kit": "3.23.5",
@@ -1582,6 +1583,8 @@
     "@tiptap/extension-paragraph": ["@tiptap/extension-paragraph@3.27.1", "", { "peerDependencies": { "@tiptap/core": "3.27.1" } }, "sha512-7K7eo1gruOgAsnbK+GCV23AUVUI0cL1bTig8HaPneoFMVbig7vddk8jNLKBWO8TXVbG7TuHdnDN4F98vdtwh5Q=="],
 
     "@tiptap/extension-strike": ["@tiptap/extension-strike@3.27.1", "", { "peerDependencies": { "@tiptap/core": "3.27.1" } }, "sha512-Y3DW1jlSlCNCyMGHP3+3qBNNPS83wuFz4RTYGjZtvRRTCRh7apZme9XRWMq1rN5mJ2Cr7fKocA2/5Bs13KgN6Q=="],
+
+    "@tiptap/extension-table": ["@tiptap/extension-table@3.23.5", "", { "peerDependencies": { "@tiptap/core": "3.23.5", "@tiptap/pm": "3.23.5" } }, "sha512-3uTaC+LsilQHaMGTW6vK4fXHsTYL/TPGM0mxoBz8UvMl+G/uzL149RcMC0d0qKvYPxInFQ2rFzxPTpnY3Rg3UA=="],
 
     "@tiptap/extension-text": ["@tiptap/extension-text@3.27.1", "", { "peerDependencies": { "@tiptap/core": "3.27.1" } }, "sha512-6ZwaZwSrDh+KFFv6V1J79oO37yPs7y1bFxvk1/9Ih2rn3Xr5AWz+eMS+n8RpH3djBVVAQpdIAeYQgcn+VCSsTg=="],
 

--- a/clients/web/package.json
+++ b/clients/web/package.json
@@ -66,6 +66,7 @@
     "@tiptap/core": "3.23.5",
     "@tiptap/extension-bubble-menu": "3.23.5",
     "@tiptap/extension-link": "3.23.5",
+    "@tiptap/extension-table": "3.23.5",
     "@tiptap/pm": "3.23.5",
     "@tiptap/react": "3.23.5",
     "@tiptap/starter-kit": "3.23.5",

--- a/clients/web/src/domains/chat/components/tiptap-document-editor.tsx
+++ b/clients/web/src/domains/chat/components/tiptap-document-editor.tsx
@@ -7,13 +7,8 @@
  * - Text selection tracking with character offset conversion
  */
 
-import { Extension } from "@tiptap/core";
-import Link from "@tiptap/extension-link";
-import { Plugin, PluginKey } from "@tiptap/pm/state";
-import { Decoration, DecorationSet } from "@tiptap/pm/view";
 import { EditorContent, useEditor } from "@tiptap/react";
 import { BubbleMenu } from "@tiptap/react/menus";
-import StarterKit from "@tiptap/starter-kit";
 import { cn } from "@vellumai/design-library";
 import {
   Bold,
@@ -31,8 +26,13 @@ import {
   useRef,
   useState,
 } from "react";
-import { Markdown, type MarkdownStorage } from "tiptap-markdown";
 
+import {
+  activeHighlightPluginKey,
+  buildDocumentEditorExtensions,
+  commentAnchorPluginKey,
+  getEditorMarkdown,
+} from "@/domains/chat/components/tiptap-editor-extensions";
 import type { CommentAnchor } from "@/domains/chat/utils/tiptap-position-map";
 import {
   charOffsetToPmPos,
@@ -60,151 +60,6 @@ interface TiptapDocumentEditorProps {
   onCommentSubmit?: (comment: string) => void;
   commentSubmitting?: boolean;
   className?: string;
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/** Extract the current markdown from a tiptap editor with the Markdown extension. */
-function getEditorMarkdown(editor: import("@tiptap/core").Editor): string {
-  const storage = editor.storage as unknown as { markdown: MarkdownStorage };
-  return storage.markdown.getMarkdown();
-}
-
-// ---------------------------------------------------------------------------
-// Decoration plugin keys
-// ---------------------------------------------------------------------------
-
-const commentAnchorPluginKey = new PluginKey("commentAnchorHighlights");
-const activeHighlightPluginKey = new PluginKey("activeHighlight");
-
-// ---------------------------------------------------------------------------
-// Comment anchor decoration extension
-// ---------------------------------------------------------------------------
-
-const CommentAnchorHighlightExtension = Extension.create<{
-  anchors: CommentAnchor[];
-}>({
-  name: "commentAnchorHighlight",
-
-  addOptions() {
-    return { anchors: [] };
-  },
-
-  addProseMirrorPlugins() {
-    const { anchors } = this.options;
-    return [
-      new Plugin({
-        key: commentAnchorPluginKey,
-        state: {
-          init(_, { doc }) {
-            return buildCommentDecorations(doc, anchors);
-          },
-          apply(tr, oldDecorations) {
-            const meta = tr.getMeta(commentAnchorPluginKey);
-            if (meta) {
-              return buildCommentDecorations(tr.doc, meta.anchors);
-            }
-            if (tr.docChanged) {
-              return oldDecorations.map(tr.mapping, tr.doc);
-            }
-            return oldDecorations;
-          },
-        },
-        props: {
-          decorations(state) {
-            return this.getState(state);
-          },
-        },
-      }),
-    ];
-  },
-});
-
-function buildCommentDecorations(
-  doc: import("@tiptap/pm/model").Node,
-  anchors: CommentAnchor[],
-): DecorationSet {
-  const decorations: Decoration[] = [];
-
-  for (const anchor of anchors) {
-    const from = charOffsetToPmPos(doc, anchor.anchorStart);
-    const to = charOffsetToPmPos(doc, anchor.anchorEnd);
-    if (from < to) {
-      decorations.push(
-        Decoration.inline(from, to, {
-          class: "comment-anchor-highlight",
-        }),
-      );
-    }
-  }
-
-  return DecorationSet.create(doc, decorations);
-}
-
-// ---------------------------------------------------------------------------
-// Active highlight decoration extension
-// ---------------------------------------------------------------------------
-
-const ActiveHighlightExtension = Extension.create<{
-  range: { start: number; end: number } | null;
-}>({
-  name: "activeHighlight",
-
-  addOptions() {
-    return { range: null };
-  },
-
-  addProseMirrorPlugins() {
-    const { range } = this.options;
-    return [
-      new Plugin({
-        key: activeHighlightPluginKey,
-        state: {
-          init(_, { doc }) {
-            return buildActiveHighlightDecorations(doc, range);
-          },
-          apply(tr, oldDecorations) {
-            const meta = tr.getMeta(activeHighlightPluginKey);
-            if (meta) {
-              return buildActiveHighlightDecorations(tr.doc, meta.range);
-            }
-            if (tr.docChanged) {
-              return oldDecorations.map(tr.mapping, tr.doc);
-            }
-            return oldDecorations;
-          },
-        },
-        props: {
-          decorations(state) {
-            return this.getState(state);
-          },
-        },
-      }),
-    ];
-  },
-});
-
-function buildActiveHighlightDecorations(
-  doc: import("@tiptap/pm/model").Node,
-  range: { start: number; end: number } | null,
-): DecorationSet {
-  if (!range) {
-    return DecorationSet.empty;
-  }
-
-  const from = charOffsetToPmPos(doc, range.start);
-  const to = charOffsetToPmPos(doc, range.end);
-  if (from >= to) {
-    return DecorationSet.empty;
-  }
-
-  return DecorationSet.create(doc, [
-    Decoration.inline(from, to, {
-      class: "active-highlight",
-    }),
-  ]);
 }
 
 // ---------------------------------------------------------------------------
@@ -427,15 +282,10 @@ export function TiptapDocumentEditor({
   });
 
   const editor = useEditor({
-    extensions: [
-      StarterKit.configure({
-        // History is included in StarterKit
-      }),
-      Link.configure({ openOnClick: false }),
-      Markdown,
-      CommentAnchorHighlightExtension.configure({ anchors: commentAnchors }),
-      ActiveHighlightExtension.configure({ range: highlightRange }),
-    ],
+    extensions: buildDocumentEditorExtensions({
+      commentAnchors,
+      highlightRange,
+    }),
     content,
     editable,
     onUpdate({ editor: ed }) {

--- a/clients/web/src/domains/chat/components/tiptap-editor-extensions.test.ts
+++ b/clients/web/src/domains/chat/components/tiptap-editor-extensions.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for the document editor extension list, using a headless tiptap
+ * Editor (no React mount). The critical behavior is GFM table support:
+ * tiptap-markdown parses pipe tables into <table> HTML, and the schema must
+ * have table nodes to hold them. Without them ProseMirror flattens cell text
+ * into paragraphs, and the next save writes the corrupted doc back to disk.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { Editor } from "@tiptap/core";
+
+import {
+  buildDocumentEditorExtensions,
+  getEditorMarkdown,
+} from "./tiptap-editor-extensions";
+
+const TABLE_MARKDOWN = [
+  "# Demo",
+  "",
+  "| config | output |",
+  "|---|---|",
+  "| unsteered | a plain poem |",
+  "| steered 0.9 | an elegy |",
+].join("\n");
+
+let editor: Editor | null = null;
+
+function createEditor(content: string): Editor {
+  editor = new Editor({
+    extensions: buildDocumentEditorExtensions(),
+    content,
+  });
+  return editor;
+}
+
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+});
+
+describe("buildDocumentEditorExtensions", () => {
+  test("parses GFM tables into table nodes instead of flattening cells", () => {
+    const ed = createEditor(TABLE_MARKDOWN);
+    const html = ed.getHTML();
+
+    expect(html).toContain("<table");
+    expect(html.match(/<th/g)?.length).toBe(2);
+    expect(html.match(/<td/g)?.length).toBe(4);
+    // Cell text must stay in separate cells, not run together in a paragraph.
+    expect(html).not.toContain("configoutput");
+    expect(html).not.toContain("unsteereda plain poem");
+  });
+
+  test("round-trips a table back to pipe markdown on serialize", () => {
+    const ed = createEditor(TABLE_MARKDOWN);
+    const md = getEditorMarkdown(ed);
+
+    expect(md).toContain("| config | output |");
+    expect(md).toContain("| --- | --- |");
+    expect(md).toContain("| unsteered | a plain poem |");
+    expect(md).toContain("| steered 0.9 | an elegy |");
+  });
+
+  test("editing outside a table preserves the table on serialize", () => {
+    const ed = createEditor(TABLE_MARKDOWN);
+    ed.commands.insertContentAt(ed.state.doc.content.size, {
+      type: "paragraph",
+      content: [{ type: "text", text: "closing note" }],
+    });
+
+    const md = getEditorMarkdown(ed);
+    expect(md).toContain("closing note");
+    expect(md).toContain("| config | output |");
+    expect(md).toContain("| --- | --- |");
+  });
+});

--- a/clients/web/src/domains/chat/components/tiptap-editor-extensions.ts
+++ b/clients/web/src/domains/chat/components/tiptap-editor-extensions.ts
@@ -1,0 +1,198 @@
+/**
+ * Tiptap extension configuration for the document editor, shared between the
+ * React component and headless usage (tests). Includes the decoration
+ * extensions for comment anchors and the active highlight range.
+ */
+
+import type { Editor } from "@tiptap/core";
+import { Extension } from "@tiptap/core";
+import Link from "@tiptap/extension-link";
+import {
+  Table,
+  TableCell,
+  TableHeader,
+  TableRow,
+} from "@tiptap/extension-table";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+import StarterKit from "@tiptap/starter-kit";
+import { Markdown, type MarkdownStorage } from "tiptap-markdown";
+
+import type { CommentAnchor } from "@/domains/chat/utils/tiptap-position-map";
+import { charOffsetToPmPos } from "@/domains/chat/utils/tiptap-position-map";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Extract the current markdown from a tiptap editor with the Markdown extension. */
+export function getEditorMarkdown(editor: Editor): string {
+  const storage = editor.storage as unknown as { markdown: MarkdownStorage };
+  return storage.markdown.getMarkdown();
+}
+
+// ---------------------------------------------------------------------------
+// Decoration plugin keys
+// ---------------------------------------------------------------------------
+
+export const commentAnchorPluginKey = new PluginKey("commentAnchorHighlights");
+export const activeHighlightPluginKey = new PluginKey("activeHighlight");
+
+// ---------------------------------------------------------------------------
+// Comment anchor decoration extension
+// ---------------------------------------------------------------------------
+
+const CommentAnchorHighlightExtension = Extension.create<{
+  anchors: CommentAnchor[];
+}>({
+  name: "commentAnchorHighlight",
+
+  addOptions() {
+    return { anchors: [] };
+  },
+
+  addProseMirrorPlugins() {
+    const { anchors } = this.options;
+    return [
+      new Plugin({
+        key: commentAnchorPluginKey,
+        state: {
+          init(_, { doc }) {
+            return buildCommentDecorations(doc, anchors);
+          },
+          apply(tr, oldDecorations) {
+            const meta = tr.getMeta(commentAnchorPluginKey);
+            if (meta) {
+              return buildCommentDecorations(tr.doc, meta.anchors);
+            }
+            if (tr.docChanged) {
+              return oldDecorations.map(tr.mapping, tr.doc);
+            }
+            return oldDecorations;
+          },
+        },
+        props: {
+          decorations(state) {
+            return this.getState(state);
+          },
+        },
+      }),
+    ];
+  },
+});
+
+function buildCommentDecorations(
+  doc: import("@tiptap/pm/model").Node,
+  anchors: CommentAnchor[],
+): DecorationSet {
+  const decorations: Decoration[] = [];
+
+  for (const anchor of anchors) {
+    const from = charOffsetToPmPos(doc, anchor.anchorStart);
+    const to = charOffsetToPmPos(doc, anchor.anchorEnd);
+    if (from < to) {
+      decorations.push(
+        Decoration.inline(from, to, {
+          class: "comment-anchor-highlight",
+        }),
+      );
+    }
+  }
+
+  return DecorationSet.create(doc, decorations);
+}
+
+// ---------------------------------------------------------------------------
+// Active highlight decoration extension
+// ---------------------------------------------------------------------------
+
+const ActiveHighlightExtension = Extension.create<{
+  range: { start: number; end: number } | null;
+}>({
+  name: "activeHighlight",
+
+  addOptions() {
+    return { range: null };
+  },
+
+  addProseMirrorPlugins() {
+    const { range } = this.options;
+    return [
+      new Plugin({
+        key: activeHighlightPluginKey,
+        state: {
+          init(_, { doc }) {
+            return buildActiveHighlightDecorations(doc, range);
+          },
+          apply(tr, oldDecorations) {
+            const meta = tr.getMeta(activeHighlightPluginKey);
+            if (meta) {
+              return buildActiveHighlightDecorations(tr.doc, meta.range);
+            }
+            if (tr.docChanged) {
+              return oldDecorations.map(tr.mapping, tr.doc);
+            }
+            return oldDecorations;
+          },
+        },
+        props: {
+          decorations(state) {
+            return this.getState(state);
+          },
+        },
+      }),
+    ];
+  },
+});
+
+function buildActiveHighlightDecorations(
+  doc: import("@tiptap/pm/model").Node,
+  range: { start: number; end: number } | null,
+): DecorationSet {
+  if (!range) {
+    return DecorationSet.empty;
+  }
+
+  const from = charOffsetToPmPos(doc, range.start);
+  const to = charOffsetToPmPos(doc, range.end);
+  if (from >= to) {
+    return DecorationSet.empty;
+  }
+
+  return DecorationSet.create(doc, [
+    Decoration.inline(from, to, {
+      class: "active-highlight",
+    }),
+  ]);
+}
+
+// ---------------------------------------------------------------------------
+// Extension list
+// ---------------------------------------------------------------------------
+
+/**
+ * The full extension list for the document editor. Table nodes are required:
+ * tiptap-markdown parses GFM pipe tables into <table> HTML, and without table
+ * nodes in the schema ProseMirror drops the structure and flattens cell text
+ * into paragraphs (corrupting the file on the next save).
+ */
+export function buildDocumentEditorExtensions(
+  opts: {
+    commentAnchors?: CommentAnchor[];
+    highlightRange?: { start: number; end: number } | null;
+  } = {},
+) {
+  return [
+    StarterKit,
+    Link.configure({ openOnClick: false }),
+    Table,
+    TableRow,
+    TableHeader,
+    TableCell,
+    Markdown,
+    CommentAnchorHighlightExtension.configure({
+      anchors: opts.commentAnchors ?? [],
+    }),
+    ActiveHighlightExtension.configure({ range: opts.highlightRange ?? null }),
+  ];
+}


### PR DESCRIPTION
## Summary
- Register `@tiptap/extension-table` nodes (`Table`, `TableRow`, `TableHeader`, `TableCell`) in the document editor so GFM pipe tables render as tables instead of flattened, run-together cell text. The editor already shipped table CSS and tiptap-markdown already bundles a GFM pipe-table serializer; both were dead code until the schema had table nodes.
- This also fixes silent data corruption: without table nodes, any edit in the document viewer serialized the flattened doc back to markdown on autosave, destroying the tables in the file on disk.
- Extract the editor extension list (plus the comment-anchor and active-highlight decoration extensions) into `tiptap-editor-extensions.ts` so the new headless tests exercise the production config: table parse (cells stay separate), markdown round-trip (pipes and delimiter row preserved), and edit-elsewhere-preserves-table.

Known limitation: column alignment markers (`:---:`) are not captured by the table nodes and serialize back as plain `---`. Tables with spans or multi-block cells fall back to tiptap-markdown's raw-HTML serialization; neither is reachable from GFM pipe input.

## Original prompt
A markdown file full of GFM pipe tables rendered in the file editor UI (the document viewer with the Comments button) with the table cells mashed together into paragraphs. Investigation showed the file was valid markdown and every other markdown surface renders tables fine; the document editor's ProseMirror schema was simply missing table nodes, so the parsed table structure was dropped. The user asked to fix it per the plan: add the exact-pinned `@tiptap/extension-table@3.23.5`, register the table nodes, and cover the behavior with headless editor tests.