### PR TITLE
feat(plugins): add turn-tally in-repo example plugin covering every core surface

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -6,7 +6,9 @@ skills, and more.
 If you're authoring a plugin against the current convention, this file is
 your map. Read [`vellum-ai/simple-memory`](https://github.com/vellum-ai/simple-memory)
 alongside, it's the canonical reference implementation and exercises every
-wired surface.
+wired surface. For a miniature in-repo example that demonstrates each core
+surface (hooks with self-contained SQLite state, a tool, a route, and a
+skill) in one small install, see [`turn-tally/`](turn-tally/).
 
 ## Table of contents
 

--- a/plugins/turn-tally/README.md
+++ b/plugins/turn-tally/README.md
@@ -1,0 +1,67 @@
+# turn-tally
+
+An intentionally small example plugin that keeps a per-conversation
+activity tally: prompts submitted, tool calls run (per tool name when
+enabled), and how each turn ended. Its job is to demonstrate, in one
+place, every core surface a plugin can ship and the state-ownership
+contract they share. Read it alongside the `plugin-builder` skill
+(`skills/plugin-builder/`), whose reference files document each contract
+in full.
+
+## Surface map
+
+| File | Surface | Demonstrates |
+| ---- | ------- | ------------ |
+| `package.json` | Manifest | `name`, `version`, and the `@vellumai/plugin-api` peer-dependency range the loader checks. |
+| `config.json` | User config | A default the user can edit in place; read via `InitContext.config` and preserved across upgrades. |
+| `hooks/init.ts` | Lifecycle hook | Opens plugin-owned SQLite storage under `InitContext.pluginStorageDir` and applies schema idempotently. |
+| `hooks/user-prompt-submit.ts` | Agent-loop hook | Observes each user prompt and emits a transient `ctx.broadcast` event. |
+| `hooks/post-tool-use.ts` | Agent-loop hook | Observes each tool result, resolving the tool name from the history by `tool_use_id`. |
+| `hooks/stop.ts` | Agent-loop hook | Records the turn's terminal `exitReason` once per run. |
+| `hooks/conversation-deleted.ts` | Cleanup hook | Purges the deleted conversation's rows. |
+| `hooks/conversations-cleared.ts` | Cleanup hook | Wipes all rows on the clear-all reset. |
+| `hooks/shutdown.ts` | Lifecycle hook | Closes the storage handle opened by `init`. |
+| `tools/turn_tally.ts` | Model-visible tool | A low-risk tool in the shared catalog; the file basename is the tool name. |
+| `routes/tally.ts` | HTTP route | `GET /x/plugins/turn-tally/tally` serving the tallies as JSON. |
+| `skills/tally-report/SKILL.md` | Skill | On-demand instructions that drive the `turn_tally` tool. |
+| `src/tally-store.ts` | Internal module | Shared helpers; `src/` is not walked by the loader. |
+
+The one core surface not shown here is apps (a compiled Preact bundle
+rendered in the workspace panel); see
+`skills/plugin-builder/references/apps.md` for that contract.
+
+## State is plugin-owned
+
+All durable state lives in one SQLite file inside the plugin's `data/`
+directory. `init` creates it, `shutdown` closes it,
+`conversation-deleted` and `conversations-cleared` purge it, and
+uninstall removes the whole directory. Nothing touches the assistant's
+own database. Every store operation fails open: a broken store degrades
+to no-op tallies rather than blocking the turn.
+
+One wrinkle worth copying: the route module cannot share the hooks'
+in-memory handle, because the dispatcher re-imports route files with a
+cache-busting URL. The store therefore lazily opens the same file from
+the plugin's data directory (derived from `getWorkspaceDir()`) whenever
+a surface with a fresh module instance touches it.
+
+## Try it
+
+Copy the directory into a workspace (or install it from a GitHub URL,
+see `skills/plugin-builder/references/distribution.md`):
+
+```
+cp -R plugins/turn-tally "$VELLUM_WORKSPACE_DIR/plugins/turn-tally"
+assistant plugins list        # status should be "ok"
+```
+
+Then exercise each surface the way a user would:
+
+- **Hooks**: send a few messages, including one that runs a tool.
+- **Tool / skill**: ask "how many prompts have I sent in this
+  conversation?" and the model answers via `turn_tally` (guided by the
+  `tally-report` skill when it activates).
+- **Route**: `GET /x/plugins/turn-tally/tally` against the assistant's
+  API base returns the tallies as JSON.
+- **Cleanup**: delete the conversation and re-check the route; its rows
+  are gone.

--- a/plugins/turn-tally/README.md
+++ b/plugins/turn-tally/README.md
@@ -39,11 +39,14 @@ uninstall removes the whole directory. Nothing touches the assistant's
 own database. Every store operation fails open: a broken store degrades
 to no-op tallies rather than blocking the turn.
 
-One wrinkle worth copying: the route module cannot share the hooks'
-in-memory handle, because the dispatcher re-imports route files with a
-cache-busting URL. The store therefore lazily opens the same file from
-the plugin's data directory (derived from `getWorkspaceDir()`) whenever
-a surface with a fresh module instance touches it.
+One wrinkle worth copying: module state set by `init` is not always
+there. Route modules are re-imported with a cache-busting URL, and hooks
+can be dispatched in processes that never run the plugin lifecycle
+(sidecar workers waking a conversation). The store therefore lazily
+opens the same file from the plugin's data directory (derived from
+`getWorkspaceDir()`), and the parsed config is lazily re-read from
+`config.json` the same way, whenever a surface runs where `init` has
+not.
 
 ## Try it
 

--- a/plugins/turn-tally/config.json
+++ b/plugins/turn-tally/config.json
@@ -1,0 +1,3 @@
+{
+  "trackToolNames": true
+}

--- a/plugins/turn-tally/hooks/conversation-deleted.ts
+++ b/plugins/turn-tally/hooks/conversation-deleted.ts
@@ -1,0 +1,24 @@
+/**
+ * `conversation-deleted` hook: purges the deleted conversation's tally
+ * rows so derived data does not outlive the conversation that produced
+ * it. By the time this fires the conversation's own rows are already
+ * gone; the id is the only key needed.
+ */
+
+import type {
+  ConversationDeletedContext,
+  HookFunction,
+} from "@vellumai/plugin-api";
+
+import { purgeConversation } from "../src/tally-store.js";
+
+const conversationDeleted: HookFunction<ConversationDeletedContext> = async (
+  ctx,
+) => {
+  const removed = purgeConversation(ctx.conversationId);
+  if (removed > 0) {
+    ctx.logger.info({ removed }, "purged turn-tally rows");
+  }
+};
+
+export default conversationDeleted;

--- a/plugins/turn-tally/hooks/conversations-cleared.ts
+++ b/plugins/turn-tally/hooks/conversations-cleared.ts
@@ -1,0 +1,20 @@
+/**
+ * `conversations-cleared` hook: wipes every tally when the clear-all
+ * reset removes every conversation at once. The context carries no
+ * conversation id, so per-conversation state is dropped wholesale.
+ */
+
+import type {
+  ConversationsClearedContext,
+  HookFunction,
+} from "@vellumai/plugin-api";
+
+import { purgeAll } from "../src/tally-store.js";
+
+const conversationsCleared: HookFunction<ConversationsClearedContext> = async (
+  _ctx,
+) => {
+  purgeAll();
+};
+
+export default conversationsCleared;

--- a/plugins/turn-tally/hooks/init.ts
+++ b/plugins/turn-tally/hooks/init.ts
@@ -1,0 +1,25 @@
+/**
+ * `init` hook: parses `config.json` and opens the plugin-owned tally
+ * database (`tally.sqlite` in the plugin's storage dir), applying its
+ * schema idempotently. Fail-open: when the store cannot be opened the
+ * plugin keeps loading and every tally operation degrades to a no-op.
+ */
+
+import { join } from "node:path";
+
+import type { HookFunction, InitContext } from "@vellumai/plugin-api";
+
+import { parseConfig, setActiveConfig } from "../src/plugin-config.js";
+import { openTallyStore } from "../src/tally-store.js";
+
+const init: HookFunction<InitContext> = async (ctx) => {
+  const config = parseConfig(ctx.config);
+  setActiveConfig(config);
+  openTallyStore(join(ctx.pluginStorageDir, "tally.sqlite"));
+  ctx.logger.info(
+    { trackToolNames: config.trackToolNames },
+    "turn-tally store ready",
+  );
+};
+
+export default init;

--- a/plugins/turn-tally/hooks/post-tool-use.ts
+++ b/plugins/turn-tally/hooks/post-tool-use.ts
@@ -1,0 +1,36 @@
+/**
+ * `post-tool-use` hook: counts each tool result against the conversation's
+ * tally. The context carries the result but not the tool's name, so the
+ * hook resolves it from the issuing `tool_use` block in the history
+ * (matched by `tool_use_id`). Observation-only: `toolResponse` flows to
+ * the provider untouched.
+ */
+
+import type { HookFunction, PostToolUseContext } from "@vellumai/plugin-api";
+
+import { getActiveConfig } from "../src/plugin-config.js";
+import { recordToolUse } from "../src/tally-store.js";
+
+/** Find the name of the tool_use block that produced this result. */
+function resolveToolName(ctx: PostToolUseContext): string | null {
+  for (let i = ctx.messages.length - 1; i >= 0; i--) {
+    for (const block of ctx.messages[i].content) {
+      if (
+        block.type === "tool_use" &&
+        block.id === ctx.toolResponse.tool_use_id
+      ) {
+        return block.name;
+      }
+    }
+  }
+  return null;
+}
+
+const postToolUse: HookFunction<PostToolUseContext> = async (ctx) => {
+  const toolName = getActiveConfig().trackToolNames
+    ? resolveToolName(ctx)
+    : null;
+  recordToolUse(ctx.conversationId, toolName);
+};
+
+export default postToolUse;

--- a/plugins/turn-tally/hooks/shutdown.ts
+++ b/plugins/turn-tally/hooks/shutdown.ts
@@ -1,0 +1,16 @@
+/**
+ * `shutdown` hook: closes the tally database handle opened by `init`.
+ * Best-effort teardown only; every write is already durable, and
+ * `shutdown` may run in a different process than `init`, in which case
+ * there is no open handle and this is a no-op.
+ */
+
+import type { HookFunction, ShutdownContext } from "@vellumai/plugin-api";
+
+import { closeTallyStore } from "../src/tally-store.js";
+
+const shutdown: HookFunction<ShutdownContext> = async () => {
+  closeTallyStore();
+};
+
+export default shutdown;

--- a/plugins/turn-tally/hooks/stop.ts
+++ b/plugins/turn-tally/hooks/stop.ts
@@ -1,0 +1,16 @@
+/**
+ * `stop` hook: records how the turn ended on the conversation's tally.
+ * Fires exactly once per run at every terminal exit, which makes it the
+ * right boundary for a per-turn closing write (nothing re-enters the loop
+ * this run).
+ */
+
+import type { HookFunction, StopContext } from "@vellumai/plugin-api";
+
+import { recordExit } from "../src/tally-store.js";
+
+const stop: HookFunction<StopContext> = async (ctx) => {
+  recordExit(ctx.conversationId, ctx.exitReason);
+};
+
+export default stop;

--- a/plugins/turn-tally/hooks/user-prompt-submit.ts
+++ b/plugins/turn-tally/hooks/user-prompt-submit.ts
@@ -1,0 +1,30 @@
+/**
+ * `user-prompt-submit` hook: counts each real user prompt against the
+ * conversation's tally and broadcasts the running total as a transient
+ * `hook_event` for any UI watching the conversation.
+ *
+ * Observation-only: the hook never touches `latestMessages`, so the turn
+ * the model sees is unchanged.
+ */
+
+import type {
+  HookFunction,
+  UserPromptSubmitContext,
+} from "@vellumai/plugin-api";
+
+import { recordPrompt } from "../src/tally-store.js";
+
+const userPromptSubmit: HookFunction<UserPromptSubmitContext> = async (
+  ctx,
+) => {
+  // Machine signals (e.g. wizard-close markers) are not user speech.
+  if (ctx.isHiddenPrompt === true) {
+    return;
+  }
+  const prompts = recordPrompt(ctx.conversationId);
+  if (prompts !== null) {
+    ctx.broadcast({ event: "prompt-recorded", prompts });
+  }
+};
+
+export default userPromptSubmit;

--- a/plugins/turn-tally/package.json
+++ b/plugins/turn-tally/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "turn-tally",
+  "version": "0.1.0",
+  "description": "Example plugin: per-conversation activity tallies, demonstrating every core plugin surface.",
+  "type": "module",
+  "license": "MIT",
+  "peerDependencies": {
+    "@vellumai/plugin-api": "^0.11.0"
+  },
+  "vellum": {}
+}

--- a/plugins/turn-tally/package.json
+++ b/plugins/turn-tally/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "license": "MIT",
   "peerDependencies": {
-    "@vellumai/plugin-api": "^0.11.0"
+    "@vellumai/plugin-api": ">=0.11.0"
   },
   "vellum": {}
 }

--- a/plugins/turn-tally/routes/tally.ts
+++ b/plugins/turn-tally/routes/tally.ts
@@ -1,0 +1,29 @@
+/**
+ * HTTP route: read tallies over the plugin's reserved namespace.
+ *
+ *   GET /x/plugins/turn-tally/tally                      -> every tally
+ *   GET /x/plugins/turn-tally/tally?conversationId=<id>  -> one tally (404 when unknown)
+ *
+ * Route files are re-imported by the dispatcher with a cache-busting URL,
+ * so this module cannot share the hooks' in-memory handle; the store
+ * lazily opens the same SQLite file from the plugin's data directory.
+ */
+
+import { getTally, listTallies } from "../src/tally-store.js";
+
+export async function GET(request: Request): Promise<Response> {
+  const conversationId = new URL(request.url).searchParams.get(
+    "conversationId",
+  );
+  if (conversationId !== null) {
+    const tally = getTally(conversationId);
+    if (tally === null) {
+      return Response.json(
+        { error: `no tally recorded for conversation ${conversationId}` },
+        { status: 404 },
+      );
+    }
+    return Response.json(tally);
+  }
+  return Response.json({ tallies: listTallies() });
+}

--- a/plugins/turn-tally/skills/tally-report/SKILL.md
+++ b/plugins/turn-tally/skills/tally-report/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: tally-report
+description: >-
+  Present a readable activity report for the current conversation from the
+  turn-tally plugin's recorded counts. Use when the user asks how much
+  activity, how many prompts, or how many tool calls this conversation has
+  had.
+metadata:
+  emoji: "🧮"
+  vellum:
+    display-name: "Tally Report"
+    category: "development"
+    activation-hints:
+      - "User asks how many prompts or messages they have sent"
+      - "User asks how many tool calls the conversation has used"
+      - "User asks for a conversation activity or usage report"
+    avoid-when:
+      - "User asks about token usage or billing, which this plugin does not track"
+---
+
+Produce a short activity report for the current conversation.
+
+## Steps
+
+1. Call the `turn_tally` tool with no arguments to read the current
+   conversation's tally.
+2. Present the counts as a short list: prompts sent, total tool uses, and
+   the per-tool breakdown when one is present.
+3. If the tool reports no recorded activity, say so plainly; do not
+   estimate counts from the visible history.
+
+Keep the report to a few lines. The counts come from the plugin's own
+store and cover this conversation only.

--- a/plugins/turn-tally/src/plugin-config.ts
+++ b/plugins/turn-tally/src/plugin-config.ts
@@ -2,7 +2,21 @@
  * Typed view over the plugin's `config.json` (`InitContext.config`).
  * Unknown or malformed input falls back to defaults so a bad user edit
  * degrades the plugin instead of aborting its load.
+ *
+ * `init` seeds the parsed config for the main daemon process. Hooks can
+ * also be dispatched in processes that never run the plugin lifecycle
+ * (sidecar workers waking a conversation), and route modules get a fresh
+ * module instance; for those, {@link getActiveConfig} lazily reads
+ * `config.json` from the installed plugin's directory, mirroring the
+ * tally store's lazy open.
  */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { getWorkspaceDir } from "@vellumai/plugin-api";
+
+import { PLUGIN_NAME } from "./tally-store.js";
 
 export interface TurnTallyConfig {
   /** When true, `post-tool-use` also keeps per-tool-name counts. */
@@ -11,7 +25,7 @@ export interface TurnTallyConfig {
 
 export const DEFAULT_CONFIG: TurnTallyConfig = { trackToolNames: true };
 
-let activeConfig: TurnTallyConfig = DEFAULT_CONFIG;
+let activeConfig: TurnTallyConfig | null = null;
 
 export function parseConfig(raw: unknown): TurnTallyConfig {
   if (typeof raw !== "object" || raw === null) {
@@ -26,11 +40,27 @@ export function parseConfig(raw: unknown): TurnTallyConfig {
   };
 }
 
+/** Fallback for processes where `init` has not run: read the user's edit from disk. */
+function loadConfigFromDisk(): TurnTallyConfig {
+  try {
+    const raw = readFileSync(
+      join(getWorkspaceDir(), "plugins", PLUGIN_NAME, "config.json"),
+      "utf8",
+    );
+    return parseConfig(JSON.parse(raw));
+  } catch {
+    return DEFAULT_CONFIG;
+  }
+}
+
 /** Set by `init` so per-turn hooks read the parsed config without re-parsing. */
 export function setActiveConfig(config: TurnTallyConfig): void {
   activeConfig = config;
 }
 
 export function getActiveConfig(): TurnTallyConfig {
+  if (activeConfig === null) {
+    activeConfig = loadConfigFromDisk();
+  }
   return activeConfig;
 }

--- a/plugins/turn-tally/src/plugin-config.ts
+++ b/plugins/turn-tally/src/plugin-config.ts
@@ -1,0 +1,36 @@
+/**
+ * Typed view over the plugin's `config.json` (`InitContext.config`).
+ * Unknown or malformed input falls back to defaults so a bad user edit
+ * degrades the plugin instead of aborting its load.
+ */
+
+export interface TurnTallyConfig {
+  /** When true, `post-tool-use` also keeps per-tool-name counts. */
+  trackToolNames: boolean;
+}
+
+export const DEFAULT_CONFIG: TurnTallyConfig = { trackToolNames: true };
+
+let activeConfig: TurnTallyConfig = DEFAULT_CONFIG;
+
+export function parseConfig(raw: unknown): TurnTallyConfig {
+  if (typeof raw !== "object" || raw === null) {
+    return DEFAULT_CONFIG;
+  }
+  const candidate = (raw as { trackToolNames?: unknown }).trackToolNames;
+  return {
+    trackToolNames:
+      typeof candidate === "boolean"
+        ? candidate
+        : DEFAULT_CONFIG.trackToolNames,
+  };
+}
+
+/** Set by `init` so per-turn hooks read the parsed config without re-parsing. */
+export function setActiveConfig(config: TurnTallyConfig): void {
+  activeConfig = config;
+}
+
+export function getActiveConfig(): TurnTallyConfig {
+  return activeConfig;
+}

--- a/plugins/turn-tally/src/tally-store.ts
+++ b/plugins/turn-tally/src/tally-store.ts
@@ -1,0 +1,299 @@
+/**
+ * Plugin-owned SQLite store for per-conversation activity tallies
+ * (`tally.sqlite` in the plugin's storage dir).
+ *
+ * The store follows the plugin state-ownership contract: the `init` hook
+ * opens it and applies the schema idempotently, `shutdown` closes it,
+ * `conversation-deleted` purges the deleted conversation's rows, and
+ * `conversations-cleared` wipes it wholesale. Nothing is persisted outside
+ * the plugin's own `data/` directory.
+ *
+ * Every operation fails open: when the database cannot be opened or a
+ * statement errors, reads return empty results and writes are dropped, so
+ * a broken store never surfaces an error into the turn.
+ *
+ * Surfaces that the host imports outside the plugin's module graph (HTTP
+ * routes are re-imported with a cache-busting URL, so they get a fresh
+ * module instance whose handle starts unset) reach the same file through
+ * {@link ensureOpen}, which lazily opens the database at the installed
+ * plugin's storage path derived from the workspace dir.
+ */
+
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+
+import { getWorkspaceDir } from "@vellumai/plugin-api";
+
+/** Install-directory name; keep in sync with the plugin directory. */
+export const PLUGIN_NAME = "turn-tally";
+
+/** One conversation's recorded activity. */
+export interface ConversationTally {
+  conversationId: string;
+  prompts: number;
+  toolUses: number;
+  lastExitReason: string | null;
+  updatedAt: number;
+  /** Per-tool counts, present only when tool-name tracking is enabled. */
+  toolBreakdown: Array<{ toolName: string; uses: number }>;
+}
+
+let db: Database | null = null;
+
+/** Storage path for an installed copy: `<workspaceDir>/plugins/<name>/data/`. */
+function defaultDbPath(): string {
+  const dir = join(getWorkspaceDir(), "plugins", PLUGIN_NAME, "data");
+  mkdirSync(dir, { recursive: true });
+  return join(dir, "tally.sqlite");
+}
+
+/**
+ * Open (or create) the tally database at `dbPath` and ensure its schema.
+ * Called by the `init` hook with a path inside `ctx.pluginStorageDir`.
+ * Idempotent and fail-open: on error the handle stays unset and every
+ * operation degrades to a no-op.
+ */
+export function openTallyStore(dbPath: string): void {
+  try {
+    closeTallyStore();
+    const handle = new Database(dbPath);
+    handle.exec("PRAGMA journal_mode=WAL");
+    handle.exec(/*sql*/ `
+      CREATE TABLE IF NOT EXISTS conversation_tallies (
+        conversation_id  TEXT PRIMARY KEY,
+        prompts          INTEGER NOT NULL DEFAULT 0,
+        tool_uses        INTEGER NOT NULL DEFAULT 0,
+        last_exit_reason TEXT,
+        updated_at       INTEGER NOT NULL
+      )
+    `);
+    handle.exec(/*sql*/ `
+      CREATE TABLE IF NOT EXISTS tool_use_tallies (
+        conversation_id TEXT NOT NULL,
+        tool_name       TEXT NOT NULL,
+        uses            INTEGER NOT NULL DEFAULT 0,
+        PRIMARY KEY (conversation_id, tool_name)
+      )
+    `);
+    db = handle;
+  } catch {
+    db = null;
+  }
+}
+
+/** Close the tally database. Called by the `shutdown` hook. */
+export function closeTallyStore(): void {
+  try {
+    db?.close();
+  } catch {
+    // Already closed or unusable; either way the handle is discarded.
+  }
+  db = null;
+}
+
+/** Return the open handle, lazily opening at the default path when unset. */
+function ensureOpen(): Database | null {
+  if (db === null) {
+    openTallyStore(defaultDbPath());
+  }
+  return db;
+}
+
+/** Upsert the conversation row, adding the given deltas. Returns the new prompt total. */
+function bumpConversation(
+  handle: Database,
+  conversationId: string,
+  promptDelta: number,
+  toolUseDelta: number,
+): number {
+  const row = handle
+    .query(
+      /*sql*/ `
+      INSERT INTO conversation_tallies (conversation_id, prompts, tool_uses, updated_at)
+      VALUES (?, ?, ?, ?)
+      ON CONFLICT(conversation_id) DO UPDATE SET
+        prompts = prompts + excluded.prompts,
+        tool_uses = tool_uses + excluded.tool_uses,
+        updated_at = excluded.updated_at
+      RETURNING prompts
+    `,
+    )
+    .get(conversationId, promptDelta, toolUseDelta, Date.now()) as {
+    prompts: number;
+  };
+  return row.prompts;
+}
+
+/**
+ * Count one submitted user prompt. Returns the conversation's updated
+ * prompt total, or `null` when the store is unavailable.
+ */
+export function recordPrompt(conversationId: string): number | null {
+  const handle = ensureOpen();
+  if (handle === null) {
+    return null;
+  }
+  try {
+    return bumpConversation(handle, conversationId, 1, 0);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Count one tool result. `toolName` is `null` when the caller could not
+ * resolve it (or tool-name tracking is disabled); the total still counts.
+ */
+export function recordToolUse(
+  conversationId: string,
+  toolName: string | null,
+): void {
+  const handle = ensureOpen();
+  if (handle === null) {
+    return;
+  }
+  try {
+    bumpConversation(handle, conversationId, 0, 1);
+    if (toolName !== null) {
+      handle
+        .query(
+          /*sql*/ `
+          INSERT INTO tool_use_tallies (conversation_id, tool_name, uses)
+          VALUES (?, ?, 1)
+          ON CONFLICT(conversation_id, tool_name) DO UPDATE SET
+            uses = uses + 1
+        `,
+        )
+        .run(conversationId, toolName);
+    }
+  } catch {
+    // Fail open: the tally is best-effort.
+  }
+}
+
+/** Record how the conversation's most recent turn ended. */
+export function recordExit(conversationId: string, exitReason: string): void {
+  const handle = ensureOpen();
+  if (handle === null) {
+    return;
+  }
+  try {
+    handle
+      .query(
+        /*sql*/ `
+        INSERT INTO conversation_tallies (conversation_id, last_exit_reason, updated_at)
+        VALUES (?, ?, ?)
+        ON CONFLICT(conversation_id) DO UPDATE SET
+          last_exit_reason = excluded.last_exit_reason,
+          updated_at = excluded.updated_at
+      `,
+      )
+      .run(conversationId, exitReason, Date.now());
+  } catch {
+    // Fail open: the tally is best-effort.
+  }
+}
+
+function readBreakdown(
+  handle: Database,
+  conversationId: string,
+): Array<{ toolName: string; uses: number }> {
+  const rows = handle
+    .query(
+      /*sql*/ `SELECT tool_name, uses FROM tool_use_tallies WHERE conversation_id = ? ORDER BY uses DESC, tool_name ASC`,
+    )
+    .all(conversationId) as Array<{ tool_name: string; uses: number }>;
+  return rows.map((row) => ({ toolName: row.tool_name, uses: row.uses }));
+}
+
+interface TallyRow {
+  conversation_id: string;
+  prompts: number;
+  tool_uses: number;
+  last_exit_reason: string | null;
+  updated_at: number;
+}
+
+function rowToTally(handle: Database, row: TallyRow): ConversationTally {
+  return {
+    conversationId: row.conversation_id,
+    prompts: row.prompts,
+    toolUses: row.tool_uses,
+    lastExitReason: row.last_exit_reason,
+    updatedAt: row.updated_at,
+    toolBreakdown: readBreakdown(handle, row.conversation_id),
+  };
+}
+
+/** Read one conversation's tally, or `null` when none is recorded. */
+export function getTally(conversationId: string): ConversationTally | null {
+  const handle = ensureOpen();
+  if (handle === null) {
+    return null;
+  }
+  try {
+    const row = handle
+      .query(
+        /*sql*/ `SELECT * FROM conversation_tallies WHERE conversation_id = ?`,
+      )
+      .get(conversationId) as TallyRow | null;
+    return row === null ? null : rowToTally(handle, row);
+  } catch {
+    return null;
+  }
+}
+
+/** Read every recorded tally, most recently active first. */
+export function listTallies(): ConversationTally[] {
+  const handle = ensureOpen();
+  if (handle === null) {
+    return [];
+  }
+  try {
+    const rows = handle
+      .query(
+        /*sql*/ `SELECT * FROM conversation_tallies ORDER BY updated_at DESC`,
+      )
+      .all() as TallyRow[];
+    return rows.map((row) => rowToTally(handle, row));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Remove a deleted conversation's rows. Returns how many rows were
+ * removed across both tables (0 when the store is unavailable).
+ */
+export function purgeConversation(conversationId: string): number {
+  const handle = ensureOpen();
+  if (handle === null) {
+    return 0;
+  }
+  try {
+    let removed = handle
+      .query(/*sql*/ `DELETE FROM conversation_tallies WHERE conversation_id = ?`)
+      .run(conversationId).changes;
+    removed += handle
+      .query(/*sql*/ `DELETE FROM tool_use_tallies WHERE conversation_id = ?`)
+      .run(conversationId).changes;
+    return removed;
+  } catch {
+    return 0;
+  }
+}
+
+/** Wipe every tally. Called when all conversations are cleared at once. */
+export function purgeAll(): void {
+  const handle = ensureOpen();
+  if (handle === null) {
+    return;
+  }
+  try {
+    handle.exec(/*sql*/ `DELETE FROM conversation_tallies`);
+    handle.exec(/*sql*/ `DELETE FROM tool_use_tallies`);
+  } catch {
+    // Fail open: uninstall removes the data directory outright.
+  }
+}

--- a/plugins/turn-tally/tools/turn_tally.ts
+++ b/plugins/turn-tally/tools/turn_tally.ts
@@ -1,0 +1,68 @@
+/**
+ * Model-visible tool: read a conversation's recorded activity tally.
+ * The file basename becomes the tool name (`turn_tally`), and the tool
+ * lands in the same catalog as built-in tools.
+ */
+
+import {
+  RiskLevel,
+  type ToolContext,
+  type ToolDefinition,
+  type ToolExecutionResult,
+} from "@vellumai/plugin-api";
+
+import { type ConversationTally, getTally } from "../src/tally-store.js";
+
+function formatTally(tally: ConversationTally): string {
+  const lines = [
+    `Turn tally for conversation ${tally.conversationId}:`,
+    `- prompts: ${tally.prompts}`,
+    `- tool uses: ${tally.toolUses}`,
+  ];
+  for (const entry of tally.toolBreakdown) {
+    lines.push(`  - ${entry.toolName}: ${entry.uses}`);
+  }
+  if (tally.lastExitReason !== null) {
+    lines.push(`- last turn ended: ${tally.lastExitReason}`);
+  }
+  return lines.join("\n");
+}
+
+const turnTally: ToolDefinition = {
+  description:
+    "Read the activity tally the turn-tally plugin keeps for a conversation: " +
+    "how many prompts the user has sent, how many tool calls ran (per tool " +
+    "when tracked), and how the last turn ended. Use when the user asks how " +
+    "much activity this conversation has had.",
+  defaultRiskLevel: RiskLevel.Low,
+  input_schema: {
+    type: "object",
+    properties: {
+      conversationId: {
+        type: "string",
+        description:
+          "Conversation to report on. Defaults to the current conversation.",
+      },
+    },
+  },
+  async execute(
+    input: Record<string, unknown>,
+    ctx: ToolContext,
+  ): Promise<ToolExecutionResult> {
+    const requested = input.conversationId;
+    const conversationId =
+      typeof requested === "string" && requested.length > 0
+        ? requested
+        : ctx.conversationId;
+    const tally = getTally(conversationId);
+    if (tally === null) {
+      return {
+        content: `No activity recorded yet for conversation ${conversationId}.`,
+        isError: false,
+      };
+    }
+    return { content: formatTally(tally), isError: false };
+  },
+};
+
+export default turnTally;


### PR DESCRIPTION
## Summary
- Adds `plugins/turn-tally/`, a small example plugin that keeps per-conversation activity tallies (prompts, tool uses per tool name, last exit reason) and demonstrates every core plugin surface: `init`/`shutdown`, `user-prompt-submit` (with `ctx.broadcast`), `post-tool-use`, `stop`, `conversation-deleted`, `conversations-cleared`, a low-risk `turn_tally` tool, a `GET /x/plugins/turn-tally/tally` route, a `tally-report` skill, and editable `config.json`.
- State follows the plugin self-containment contract end to end: one SQLite file under the plugin's `data/` dir, schema applied idempotently in `init`, closed in `shutdown`, purged on delete/clear, and every operation fails open. The store also lazily reopens from the workspace-derived path so route modules (re-imported with cache-busting URLs) reach the same file.
- Points `plugins/README.md` at the new example, and the plugin's own README maps each file to the surface it demonstrates with pointers into the `plugin-builder` skill references.

## Verification
- Drove the real external plugin loader (`buildExternalPlugin`) against the plugin in a temp workspace: all 7 hooks and the tool are discovered, the hook chain records tallies, the tool and route read them back (including the 404 and list paths), and delete/clear purge them. 24/24 checks pass.
- Typechecked the plugin sources against the real `@vellumai/plugin-api` types with a throwaway tsconfig (clean).

## Original prompt
Asked in-session: create a simple plugin that is easy to test, chosen at my discretion, whose main purpose is to show how a plugin is built with good coverage of the surfaces plugins are meant to ship, then raise a PR. Research for the implementation came from the `plugin-builder` skill references, the `@vellumai/plugin-api` source, and the `image-fallback` default plugin's storage pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cn6sKhZC4NrmyuG2TnsLaw
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40643" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->