### PR TITLE
fix(web): drop the orphaned schedules deleting catalog key

### DIFF
--- a/clients/web/src/i18n/locales/en/schedules.json
+++ b/clients/web/src/i18n/locales/en/schedules.json
@@ -47,7 +47,6 @@
     "delete": "Delete",
     "deleteConfirmMessage": "Delete \"{name}\"? This can't be undone.",
     "cancel": "Cancel",
-    "deleting": "Deleting…",
     "confirmDelete": "Yes, delete",
     "viewUsage": "View usage",
     "turnOnToRun": "Turn this schedule on to run it",

--- a/clients/web/src/i18n/locales/es/schedules.json
+++ b/clients/web/src/i18n/locales/es/schedules.json
@@ -47,7 +47,6 @@
     "delete": "Eliminar",
     "deleteConfirmMessage": "¿Eliminar \"{name}\"? Esta acción no se puede deshacer.",
     "cancel": "Cancelar",
-    "deleting": "Eliminando…",
     "confirmDelete": "Sí, eliminar",
     "viewUsage": "Ver el uso",
     "turnOnToRun": "Activa esta programación para ejecutarla",


### PR DESCRIPTION
## TL;DR

Deletes `schedules:scheduleDetail.deleting` from the `en` and `es` catalogs. #40639 removed its last call site but left the catalog entry, so the `catalog usage > no key in the English catalogs is unreferenced` test fails on `main` and turns every open PR's Test check red (first seen on #40638, whose diff is unrelated).

## Why it's safe

- The key has zero references anywhere in `clients/web/src` (verified by grep and by the failing test itself, which lists exactly this one orphan).
- Two-line deletion, JSON validated; sibling keys (`delete`, `cancel`, `confirmDelete`) are untouched and still referenced.
- This is the fix the test's own comment prescribes: "Delete it, or add the call site it was written for" — the call site was intentionally replaced by shared destructive-button chrome in #40639, so deletion is correct.

## What changes for the user

| Before | After |
| --- | --- |
| Nothing — the string was already unreachable | Nothing — dead copy removed from both locale bundles |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40644" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->