### PR TITLE
refactor(hooks): move getUserHooksFor into the hooks registry

### DIFF
--- a/assistant/src/__tests__/mtime-cache.test.ts
+++ b/assistant/src/__tests__/mtime-cache.test.ts
@@ -29,11 +29,11 @@ import {
   test,
 } from "bun:test";
 
+import { getUserHooksFor } from "../hooks/registry.js";
 import { _inspectHookCacheForTests } from "../hooks/hook-loader.js";
 import {
   _inspectToolCacheForTests,
   getCachedUserTools,
-  getUserHooksFor,
   populateCacheAtBoot,
   reconcilePluginSourcesNow,
   resetPluginCacheForTests,

--- a/assistant/src/__tests__/mtime-cache.test.ts
+++ b/assistant/src/__tests__/mtime-cache.test.ts
@@ -29,8 +29,8 @@ import {
   test,
 } from "bun:test";
 
-import { getUserHooksFor } from "../hooks/registry.js";
 import { _inspectHookCacheForTests } from "../hooks/hook-loader.js";
+import { getUserHooksFor } from "../hooks/registry.js";
 import {
   _inspectToolCacheForTests,
   getCachedUserTools,

--- a/assistant/src/__tests__/plugin-secret-pattern-contribution.test.ts
+++ b/assistant/src/__tests__/plugin-secret-pattern-contribution.test.ts
@@ -34,8 +34,8 @@ import {
 } from "bun:test";
 
 import { bootstrapPlugins } from "../daemon/external-plugins-bootstrap.js";
+import { getUserHooksFor } from "../hooks/registry.js";
 import {
-  getUserHooksFor,
   populateCacheAtBoot,
   reconcilePluginSourcesNow,
   resetPluginCacheForTests,

--- a/assistant/src/__tests__/user-plugin-loader.test.ts
+++ b/assistant/src/__tests__/user-plugin-loader.test.ts
@@ -23,9 +23,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { beforeEach, describe, expect, test } from "bun:test";
 
+import { getUserHooksFor } from "../hooks/registry.js";
 import {
   getCachedUserTools,
-  getUserHooksFor,
   resetPluginCacheForTests,
 } from "../plugins/mtime-cache.js";
 import { loadUserPlugins } from "../plugins/user-loader.js";

--- a/assistant/src/hooks/hook-loader.ts
+++ b/assistant/src/hooks/hook-loader.ts
@@ -39,9 +39,9 @@
  * registry, so the next read re-resolves fresh.
  *
  * Plugin *discovery* (which plugin directories exist, in what order) lives in
- * `../plugins/mtime-cache.ts`; the orchestrator there passes the discovered
- * directories into {@link collectUserHookEntries}. Keeping discovery out of
- * this module lets it sit below the plugin cache with no import cycle.
+ * `../plugins/mtime-cache.ts`; hook lookup in `./registry.ts` passes the
+ * discovered names into {@link collectUserHookEntries}. Keeping discovery out
+ * of this module lets it sit below the plugin cache with no import cycle.
  */
 
 import {

--- a/assistant/src/hooks/registry.ts
+++ b/assistant/src/hooks/registry.ts
@@ -18,10 +18,10 @@
  * the hooks stay registered but are filtered out on the next turn.
  */
 
-import { collectUserHookEntries } from "./hook-loader.js";
 import { isPluginDisabled } from "../plugins/disabled-state.js";
 import { getDiscoveredUserPluginNames } from "../plugins/mtime-cache.js";
 import type { HookEntry, HookFunction } from "../plugins/types.js";
+import { collectUserHookEntries } from "./hook-loader.js";
 
 // ─── Internal state ──────────────────────────────────────────────────────────
 

--- a/assistant/src/hooks/registry.ts
+++ b/assistant/src/hooks/registry.ts
@@ -6,19 +6,21 @@
  * hook-chain ordering.
  *
  * User-land hooks (from the filesystem) are owned by
- * {@link ./hook-loader.ts} and surfaced through `getUserHooksFor` in
- * `plugins/mtime-cache.ts`. This module owns only the in-process hooks that
- * default plugins register at boot.
+ * {@link ./hook-loader.ts} and surfaced through {@link getUserHooksFor}.
+ * This module owns the in-process hooks that default plugins register at
+ * boot, plus the user-land lookup that walks discovered plugin names from
+ * the plugin cache.
  *
  * {@link getHooksFor} combines both sources: in-process hooks from this
  * registry (filtered by `isPluginDisabled` at read time) and user-land hooks
  * from the plugin cache. The read-time filtering is what makes `assistant
- * plugins disable default-*` take effect immediately in a running assistant
- * — the hooks stay registered but are filtered out on the next turn.
+ * plugins disable default-*` take effect immediately in a running assistant:
+ * the hooks stay registered but are filtered out on the next turn.
  */
 
+import { collectUserHookEntries } from "./hook-loader.js";
 import { isPluginDisabled } from "../plugins/disabled-state.js";
-import { getUserHookEntriesFor } from "../plugins/mtime-cache.js";
+import { getDiscoveredUserPluginNames } from "../plugins/mtime-cache.js";
 import type { HookEntry, HookFunction } from "../plugins/types.js";
 
 // ─── Internal state ──────────────────────────────────────────────────────────
@@ -74,6 +76,48 @@ export function unregisterPluginHooks(pluginName: string): void {
 }
 
 // ─── Queries ─────────────────────────────────────────────────────────────────
+
+/**
+ * Get all hooks for a given event name from user plugins and standalone
+ * workspace hooks, from the hook loader's in-memory cache. Plugin hooks run
+ * in install-date order, the workspace hook runs last.
+ *
+ * This is a pure cache read: it never scans disk, activates a plugin, or
+ * runs `init`. Activation happens only at boot (`populateCacheAtBoot`)
+ * and through the imperative install/uninstall poke
+ * (`reconcilePluginSourcesNow`), both main-daemon paths, so a
+ * sidecar process that dispatches hooks (a worker running conversation
+ * turns) can never bring a plugin up in its own process.
+ *
+ * `effectiveEnabledPlugins` carries the per-chat plugin scope: when non-null,
+ * user plugins outside the set are skipped (standalone workspace hooks always
+ * run). `null`/omitted means no per-chat restriction.
+ */
+export async function getUserHookEntriesFor<TCtx = unknown>(
+  hookName: string,
+  effectiveEnabledPlugins?: Set<string> | null,
+): Promise<HookEntry<TCtx>[]> {
+  return collectUserHookEntries<TCtx>(
+    hookName,
+    getDiscoveredUserPluginNames(),
+    effectiveEnabledPlugins,
+  );
+}
+
+/**
+ * {@link getUserHookEntriesFor} without owner attribution. Returns just the
+ * hook functions in the same order.
+ */
+export async function getUserHooksFor<TCtx = unknown>(
+  hookName: string,
+  effectiveEnabledPlugins?: Set<string> | null,
+): Promise<HookFunction<TCtx>[]> {
+  const entries = await getUserHookEntriesFor<TCtx>(
+    hookName,
+    effectiveEnabledPlugins,
+  );
+  return entries.map((e) => e.fn);
+}
 
 /**
  * Collect every registered hook for the given name, in registration order.

--- a/assistant/src/plugins/mtime-cache.ts
+++ b/assistant/src/plugins/mtime-cache.ts
@@ -26,9 +26,9 @@
  * - Plugins are never "registered" as a unit — we register their tools into
  *   the global tool registry.
  *
- * Tools are populated at boot by `loadUserPlugins()`; `getHooksFor` reads
- * hooks on every dispatch via {@link getUserHookEntriesFor}, which resolves
- * each hook through the hook loader on demand.
+ * Tools are populated at boot by `loadUserPlugins()`; hook dispatch reads
+ * discovered plugin names from this cache via {@link getDiscoveredUserPluginNames}
+ * and resolves each hook through the hook loader on demand.
  */
 
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
@@ -38,7 +38,6 @@ import type { Logger } from "pino";
 
 import {
   clearPluginHooks,
-  collectUserHookEntries,
   evictHooksForOwner,
   hasWorkspaceHooks,
   type HookOwnerKind,
@@ -47,7 +46,7 @@ import {
   runShutdownHook,
   WORKSPACE_HOOKS_OWNER,
 } from "../hooks/hook-loader.js";
-import type { HookFunction, ShutdownReason } from "../plugin-api/types.js";
+import type { ShutdownReason } from "../plugin-api/types.js";
 import {
   registerPluginSecretPatterns,
   resetPluginSecretPatternsForTests,
@@ -76,11 +75,7 @@ import {
   importWithTimeout,
   setSurfaceImportTimeout,
 } from "./surface-import.js";
-import type { HookEntry, PluginCredentialKeyPattern } from "./types.js";
-
-// Re-export for type compat — consumers that import HookFunction from
-// the mtime cache module still resolve.
-export type { HookFunction } from "./types.js";
+import type { PluginCredentialKeyPattern } from "./types.js";
 
 const log = getLogger("plugin-mtime-cache");
 
@@ -206,48 +201,15 @@ let lastVersions: Record<string, PluginSourceVersion> = {};
 /** In-flight reconcile — concurrent imperative pokes await it rather than racing. */
 let reconcileInFlight: Promise<void> | null = null;
 
-// ─── Hook reads ──────────────────────────────────────────────────────────────
+// ─── Discovery reads ─────────────────────────────────────────────────────────
 
 /**
- * Get all hooks for a given event name from user plugins and standalone
- * workspace hooks, from the hook loader's in-memory cache. Plugin hooks run
- * in install-date order, the workspace hook runs last.
- *
- * This is a pure cache read: it never scans disk, activates a plugin, or
- * runs `init`. Activation happens only at boot ({@link populateCacheAtBoot})
- * and through the imperative install/uninstall poke
- * ({@link reconcilePluginSourcesNow}) — both main-daemon paths — so a
- * sidecar process that dispatches hooks (a worker running conversation
- * turns) can never bring a plugin up in its own process.
- *
- * `effectiveEnabledPlugins` carries the per-chat plugin scope: when non-null,
- * user plugins outside the set are skipped (standalone workspace hooks always
- * run). `null`/omitted means no per-chat restriction.
+ * Plugin names currently in the discovery cache, in install-date order.
+ * Hook lookup in `hooks/registry.ts` walks this set; the cache itself does
+ * not resolve hooks.
  */
-export async function getUserHookEntriesFor<TCtx = unknown>(
-  hookName: string,
-  effectiveEnabledPlugins?: Set<string> | null,
-): Promise<HookEntry<TCtx>[]> {
-  return collectUserHookEntries<TCtx>(
-    hookName,
-    discoveredPluginDirs.values(),
-    effectiveEnabledPlugins,
-  );
-}
-
-/**
- * {@link getUserHookEntriesFor} without owner attribution — returns just the
- * hook functions in the same order.
- */
-export async function getUserHooksFor<TCtx = unknown>(
-  hookName: string,
-  effectiveEnabledPlugins?: Set<string> | null,
-): Promise<HookFunction<TCtx>[]> {
-  const entries = await getUserHookEntriesFor<TCtx>(
-    hookName,
-    effectiveEnabledPlugins,
-  );
-  return entries.map((e) => e.fn);
+export function getDiscoveredUserPluginNames(): Iterable<string> {
+  return discoveredPluginDirs.values();
 }
 
 // ─── Source-versions reconcile ───────────────────────────────────────────────

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -431,7 +431,8 @@ export function unregisterPluginTools(pluginName: string): void {
  * {@link import("../plugins/mtime-cache.js").getActiveUserPluginTools} and diffs
  * the result into the registry: plugins that vanished are unregistered, new
  * plugins register, and a plugin whose per-tool source mtimes moved is
- * re-registered. Mirrors how hooks resolve through `getUserHookEntriesFor`.
+ * re-registered. Mirrors how hooks resolve through `getUserHookEntriesFor`
+ * in `hooks/registry.ts`.
  *
  * This is a pure read of the plugin cache — it does NOT reconcile the cache
  * against the source-versions sentinel, so it never activates a plugin or runs


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

Review on #40625 asked to move `getUserHookEntriesFor` / `getUserHooksFor` out of `plugins/mtime-cache.ts` and into the hooks package before the default-hook lookup fix.

This PR is that move only. No behavior change.

- Hook lookup (`getUserHookEntriesFor`, `getUserHooksFor`) now lives next to `getHooksFor` in `hooks/registry.ts`.
- The plugin cache exposes `getDiscoveredUserPluginNames()` so the hooks package can walk the discovered set without owning discovery.
- Callers and tests import the lookup from `hooks/registry.ts`.

`getUserHooksFor` still returns only filesystem user-plugin hooks. The follow-up on #40625 will make first-party default plugin hooks show up on that path after this lands.

## Test plan

- `cd assistant && bun test src/__tests__/mtime-cache.test.ts src/__tests__/user-plugin-loader.test.ts src/__tests__/plugin-secret-pattern-contribution.test.ts`: all pass
- `cd assistant && bun test src/__tests__/plugin-effective-enabled-set.test.ts`: all pass in isolation (a combined run with `mtime-cache.test.ts` can leak in-memory discovery state; that isolation gap is pre-existing)
- `cd assistant && bun run typecheck:fast`: pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1e64f5d-117a-4f57-9eb5-5dbf63a80223?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1e64f5d-117a-4f57-9eb5-5dbf63a80223&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

