### PR TITLE
fix(web): keep an open app beside any selected conversation

### DIFF
--- a/clients/web/src/domains/chat/app-viewer-actions.test.ts
+++ b/clients/web/src/domains/chat/app-viewer-actions.test.ts
@@ -1,6 +1,7 @@
-import { afterEach, describe, expect, it, mock } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 
 import { handleAppViewerAction } from "@/domains/chat/app-viewer-actions";
+import { stubViewportAxes } from "@/hooks/viewport-axes.test-helper";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useViewerStore } from "@/stores/viewer-store";
 
@@ -10,7 +11,17 @@ function makeCtx(isMobile = false) {
   return { navigate: mock((_to: string) => {}), isMobile };
 }
 
+let restoreViewport: (() => void) | undefined;
+
+beforeEach(() => {
+  restoreViewport = stubViewportAxes({
+    narrow: false,
+    coarsePointer: false,
+  });
+});
+
 afterEach(() => {
+  restoreViewport?.();
   useViewerStore.getState().reset();
   useConversationStore.setState({
     activeConversationId: null,
@@ -148,6 +159,24 @@ describe("handleAppViewerAction — open_conversation", () => {
     );
     // Must NOT contain a prompt param
     expect(ctx.navigate.mock.calls[0][0]).not.toContain("prompt=");
+  });
+
+  it("enters the side-by-side so the conversation is visible beside the app", () => {
+    useViewerStore.setState({
+      mainView: "app",
+      activeAppId: SAMPLE_APP.appId,
+      openedAppState: SAMPLE_APP,
+    });
+    const ctx = makeCtx();
+
+    handleAppViewerAction(ctx, "open_conversation", {
+      conversationId: "target-conv",
+    });
+
+    expect(useViewerStore.getState().mainView).toBe("app-editing");
+    expect(useConversationStore.getState().editingConversationId).toBe(
+      "target-conv",
+    );
   });
 
   it("is a no-op without a conversationId", () => {

--- a/clients/web/src/domains/chat/app-viewer-actions.ts
+++ b/clients/web/src/domains/chat/app-viewer-actions.ts
@@ -10,9 +10,11 @@
  *   repeatedly. No-op for `"active"` when no conversation is open.
  *
  * - `open_conversation` ({ conversationId }) — navigates to an existing
- *   conversation by ID without sending a message. Used by plugins that
- *   manage their own background conversations (e.g. battleship) to let the
- *   user view the conversation from within the app UI.
+ *   conversation by ID without sending a message. On a wide viewport the
+ *   app stays open in the side-by-side layout so the conversation is
+ *   visible. Used by plugins that manage their own background conversations
+ *   (e.g. battleship) to let the user view the conversation from within the
+ *   app UI.
  *
  * - `set_view` ({ view }) — moves the app panel: `"split"` (side by side with
  *   chat), `"full"` (full-width), or `"chat"` (close the app). Side-by-side has
@@ -26,6 +28,7 @@
 import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useViewerStore } from "@/stores/viewer-store";
+import { keepOpenAppBesideConversation } from "@/utils/conversation-navigation";
 import { routes } from "@/utils/routes";
 
 export interface AppViewerActionContext {
@@ -70,6 +73,7 @@ function openConversation(
     return;
   }
   useConversationStore.getState().setActiveConversationId(conversationId);
+  keepOpenAppBesideConversation(conversationId);
   ctx.navigate(routes.conversation(conversationId));
 }
 
@@ -96,8 +100,7 @@ function setView(
       if (!conversationId) {
         return;
       }
-      useConversationStore.getState().setEditingConversationId(conversationId);
-      viewer.enterAppEditing();
+      keepOpenAppBesideConversation(conversationId);
       return;
     }
     default:

--- a/clients/web/src/domains/chat/hooks/use-conversation-loader.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-loader.ts
@@ -28,6 +28,7 @@ import { useWorkflowStore } from "@/domains/chat/workflow-store";
 import { isNativeMobile } from "@/runtime/platform-detection";
 import { useConversationStore } from "@/stores/conversation-store";
 import { haptic } from "@/utils/haptics";
+import { revealConversationView } from "@/utils/conversation-navigation";
 import { routes } from "@/utils/routes";
 import { useNavigate } from "react-router";
 
@@ -445,8 +446,8 @@ export function useConversationLoader({
       useSubagentStore.getState().reset();
       useWorkflowStore.getState().reset();
       useViewerStore.getState().clearTranscriptPanelPayloads();
-      useViewerStore.getState().setMainView("chat");
       const draftConversationId = createDraftConversationId();
+      revealConversationView(draftConversationId);
       useConversationStore
         .getState()
         .setActiveConversationId(draftConversationId);

--- a/clients/web/src/domains/chat/hooks/use-open-app-from-chat.ts
+++ b/clients/web/src/domains/chat/hooks/use-open-app-from-chat.ts
@@ -19,11 +19,13 @@ import { haptic } from "@/utils/haptics";
  * explicit choice, never a side effect of opening:
  * - the user picks it through the viewer's "Edit" affordance
  *   (`use-edit-app.ts`), which binds a per-app edit conversation;
+ * - the user selects a conversation while an app is already open
+ *   (`keepOpenAppBesideConversation`), which binds that conversation;
  * - the app requests it through `set_view({ view: "split" })`
  *   (`app-viewer-actions.ts`), which binds the active conversation.
  *
- * Both bind `editingConversationId` themselves, and that value is only read
- * while `mainView` is `"app-editing"`, so this hook leaves it alone.
+ * Those paths bind `editingConversationId` themselves, and that value is only
+ * read while `mainView` is `"app-editing"`, so this hook leaves it alone.
  *
  * Returns a stable async callback `(appId: string) => Promise<void>` safe
  * to drop into deps arrays.

--- a/clients/web/src/domains/chat/utils/stream-handlers/navigation-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/navigation-handlers.test.ts
@@ -19,6 +19,7 @@ import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 
 import type { StreamHandlerContext } from "@/domains/chat/utils/stream-handlers/types";
 import type { OpenPanelEvent, OpenUrlEvent } from "@vellumai/assistant-api";
+import { stubViewportAxes } from "@/hooks/viewport-axes.test-helper";
 
 const submitSurfaceActionCalls: Array<{
   assistantId: string;
@@ -268,6 +269,12 @@ describe("handleOpenUrl", () => {
 });
 
 describe("handleOpenConversation", () => {
+  beforeEach(() => {
+    useViewerStore.getState().reset();
+    useConversationStore.getState().reset();
+    useSubagentStore.getState().reset();
+  });
+
   it("switches to and focuses the target conversation by default", () => {
     useConversationStore.getState().setActiveConversationId("conv-origin");
     const push = mock((_url: string) => {});
@@ -284,6 +291,39 @@ describe("handleOpenConversation", () => {
     );
     expect(push).toHaveBeenCalledTimes(1);
     expect(push.mock.calls[0]?.[0]).toContain("conv-target");
+  });
+
+  it("keeps an open app in the side-by-side layout instead of dismissing it", () => {
+    const restoreViewport = stubViewportAxes({
+      narrow: false,
+      coarsePointer: false,
+    });
+    useConversationStore.getState().setActiveConversationId("conv-origin");
+    useViewerStore.setState({
+      mainView: "app",
+      activeAppId: "app-1",
+      openedAppState: { appId: "app-1", name: "My App", html: "<h1>hi</h1>" },
+    });
+    const push = mock((_url: string) => {});
+    const ctx = { router: { push } } as unknown as StreamHandlerContext;
+
+    try {
+      handleOpenConversation(
+        { type: "open_conversation", conversationId: "conv-target" },
+        ctx,
+      );
+
+      expect(useViewerStore.getState().mainView).toBe("app-editing");
+      expect(useConversationStore.getState().editingConversationId).toBe(
+        "conv-target",
+      );
+      expect(useConversationStore.getState().activeConversationId).toBe(
+        "conv-target",
+      );
+    } finally {
+      restoreViewport();
+      useViewerStore.getState().reset();
+    }
   });
 
   it("does not switch focus when focus is false", () => {

--- a/clients/web/src/domains/chat/utils/stream-handlers/navigation-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/navigation-handlers.ts
@@ -7,6 +7,7 @@ import { submitSurfaceAction } from "@/domains/chat/api/surfaces";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useViewerStore } from "@/stores/viewer-store";
+import { revealConversationView } from "@/utils/conversation-navigation";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
 import { useWorkflowStore } from "@/domains/chat/workflow-store";
@@ -65,7 +66,7 @@ export function handleOpenConversation(
   if (event.focus === false) {
     return;
   }
-  useViewerStore.getState().setMainView("chat");
+  revealConversationView(event.conversationId);
   // Only wipe per-conversation process state on a genuine switch — a
   // daemon-directed open of the conversation already in view must not kill
   // the inline cards of still-running subagents (LUM-2875; the store only

--- a/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
@@ -32,6 +32,7 @@ import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { useViewerStore } from "@/stores/viewer-store";
 import { routes } from "@/utils/routes";
 import * as toastModule from "@vellumai/design-library/components/toast";
+import { stubViewportAxes } from "@/hooks/viewport-axes.test-helper";
 
 /**
  * Location the app is "on", advanced by the consumer's own `navigate` calls.
@@ -109,7 +110,7 @@ const asStarter = (start: (a: string, c: string | null) => void) => ({
 });
 
 const resetStores = () => {
-  useViewerStore.setState({ mainView: "chat" });
+  useViewerStore.getState().reset();
   useSubagentStore.getState().reset();
   useWorkflowStore.getState().reset();
   useConversationStore.getState().reset();
@@ -182,6 +183,35 @@ describe("deeplink.openThread", () => {
       "/assistant/conversations/abc-123",
     );
     expect(ensureMainWindowVisibleMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("keeps a loaded app in the side-by-side layout so the thread is visible beside it", () => {
+    const restoreViewport = stubViewportAxes({
+      narrow: false,
+      coarsePointer: false,
+    });
+    useViewerStore.setState({
+      mainView: "app",
+      activeAppId: "app-1",
+      openedAppState: { appId: "app-1", name: "My App", html: "<h1>hi</h1>" },
+    });
+    renderConsumer();
+
+    try {
+      act(() => {
+        publish("deeplink.openThread", { threadId: "abc-123" });
+      });
+
+      expect(useViewerStore.getState().mainView).toBe("app-editing");
+      expect(useConversationStore.getState().editingConversationId).toBe(
+        "abc-123",
+      );
+      expect(navigateMock).toHaveBeenCalledWith(
+        "/assistant/conversations/abc-123",
+      );
+    } finally {
+      restoreViewport();
+    }
   });
 
   test("resets the main view to chat so the thread isn't hidden behind the app viewer", () => {

--- a/clients/web/src/hooks/use-global-deep-link-consumer.ts
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.ts
@@ -17,8 +17,10 @@ import { ensureMainWindowVisible } from "@/runtime/main-window";
 import { useConnectDialogStore } from "@/stores/connect-dialog-store";
 import { useConversationStore } from "@/stores/conversation-store";
 import { usePendingDeepLinkStore } from "@/stores/pending-deep-link-store";
-import { useViewerStore } from "@/stores/viewer-store";
-import { navigateToConversation } from "@/utils/conversation-navigation";
+import {
+  navigateToConversation,
+  revealConversationView,
+} from "@/utils/conversation-navigation";
 import { routes } from "@/utils/routes";
 
 /**
@@ -136,7 +138,7 @@ export function useGlobalDeepLinkConsumer(): void {
   const openThread = (threadId: string) => {
     // Same thread: skip store resets — the id doesn't change, so re-seed effects wouldn't re-run and live cards would vanish.
     if (threadId === useConversationStore.getState().activeConversationId) {
-      useViewerStore.getState().setMainView("chat");
+      revealConversationView(threadId);
       navigateRef.current(routes.conversation(threadId));
       return;
     }

--- a/clients/web/src/stores/conversation-store.ts
+++ b/clients/web/src/stores/conversation-store.ts
@@ -12,7 +12,8 @@
  * This store owns only state that has no server counterpart:
  *
  * - `activeConversationId` — URL/navigation-local selection
- * - `editingConversationId` — UI mode (app-edit-chat target)
+ * - `editingConversationId` — conversation bound to the app side-by-side
+ *   layout (`mainView === "app-editing"`)
  * - `processingConversationIds` — in-flight assistant responses
  * - `processingSnapshots` — `latestAssistantMessageAt` snapshot taken when
  *   each conversation id was added to `processingConversationIds`; the

--- a/clients/web/src/stores/viewer-store.ts
+++ b/clients/web/src/stores/viewer-store.ts
@@ -611,9 +611,9 @@ export interface ViewerActions {
 
   /**
    * Drop the payloads of the panels whose content is scoped to one
-   * conversation's transcript. Called on conversation switch: the panels are
-   * already dismissed by the `setMainView("chat")` that accompanies it, and
-   * holding their payloads keeps the previous conversation's data alive -
+   * conversation's transcript. Called on conversation switch: overlay
+   * panels are dismissed when the viewer returns to chat, and holding
+   * their payloads keeps the previous conversation's data alive -
    * `activeMessageFiles` in particular retains decoded attachment blob/data
    * URLs. Leaves `mainView` alone; this is a memory concern, not navigation.
    */

--- a/clients/web/src/utils/conversation-navigation.test.ts
+++ b/clients/web/src/utils/conversation-navigation.test.ts
@@ -7,20 +7,23 @@
  * exactly one haptic tap, unless the caller opts out via `{ silent: true }`.
  * The fork action taps at action start and routes navigation through this
  * helper, so it relies on `silent` to avoid a double buzz.
+ *
+ * When an app is already on screen on a wide viewport, conversation
+ * navigation keeps that app in the side-by-side layout instead of
+ * dismissing it to chat.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { NavigateFunction } from "react-router";
 
+import { useSubagentStore } from "@/domains/chat/subagent-store";
+import { useWorkflowStore } from "@/domains/chat/workflow-store";
+import { stubViewportAxes } from "@/hooks/viewport-axes.test-helper";
+import { useConversationStore } from "@/stores/conversation-store";
+import { useViewerStore } from "@/stores/viewer-store";
 import { routes } from "@/utils/routes";
 
 const hapticLight = mock(() => {});
-const setMainView = mock((_view: string) => {});
-const clearTranscriptPanelPayloads = mock(() => {});
-const subagentReset = mock(() => {});
-const workflowReset = mock(() => {});
-const setActiveConversationId = mock((_id: string) => {});
-const registerDraftConversationId = mock((_id: string) => {});
 const playSound = mock((_name: string) => Promise.resolve());
 const composerFocus = mock(() => {});
 
@@ -32,49 +35,50 @@ mock.module("@/utils/haptics", () => ({
     error: () => {},
   },
 }));
-mock.module("@/stores/viewer-store", () => ({
-  useViewerStore: {
-    getState: () => ({ setMainView, clearTranscriptPanelPayloads }),
-  },
-}));
 mock.module("@/lib/sounds/sound-manager", () => ({
   getSoundManager: () => ({ play: playSound }),
 }));
 mock.module("@/domains/chat/composer-focus", () => ({
   requestComposerFocus: composerFocus,
 }));
-mock.module("@/domains/chat/subagent-store", () => ({
-  useSubagentStore: { getState: () => ({ reset: subagentReset }) },
-}));
-mock.module("@/domains/chat/workflow-store", () => ({
-  useWorkflowStore: { getState: () => ({ reset: workflowReset }) },
-}));
-let activeConversationId: string | null = null;
-mock.module("@/stores/conversation-store", () => ({
-  useConversationStore: {
-    getState: () => ({
-      activeConversationId,
-      setActiveConversationId,
-      registerDraftConversationId,
-    }),
-  },
-}));
 
-const { navigateToConversation, navigateToNewConversation } = await import(
-  "@/utils/conversation-navigation"
-);
+const {
+  navigateToConversation,
+  navigateToNewConversation,
+  keepOpenAppBesideConversation,
+  revealConversationView,
+} = await import("@/utils/conversation-navigation");
+
+const SAMPLE_APP = { appId: "app-1", name: "My App", html: "<h1>hi</h1>" };
+
+function openAppViewer(view: "app" | "app-editing" = "app"): void {
+  useViewerStore.setState({
+    mainView: view,
+    activeAppId: SAMPLE_APP.appId,
+    openedAppState: SAMPLE_APP,
+  });
+}
+
+let restoreViewport: (() => void) | undefined;
 
 beforeEach(() => {
   hapticLight.mockClear();
-  setMainView.mockClear();
-  clearTranscriptPanelPayloads.mockClear();
-  subagentReset.mockClear();
-  workflowReset.mockClear();
-  setActiveConversationId.mockClear();
-  registerDraftConversationId.mockClear();
   playSound.mockClear();
   composerFocus.mockClear();
-  activeConversationId = null;
+  useViewerStore.getState().reset();
+  useConversationStore.getState().reset();
+  useSubagentStore.getState().reset();
+  useWorkflowStore.getState().reset();
+  restoreViewport = stubViewportAxes({
+    narrow: false,
+    coarsePointer: false,
+  });
+});
+
+afterEach(() => {
+  restoreViewport?.();
+  useViewerStore.getState().reset();
+  useConversationStore.getState().reset();
 });
 
 describe("navigateToConversation", () => {
@@ -83,10 +87,8 @@ describe("navigateToConversation", () => {
     navigateToConversation(navigate as unknown as NavigateFunction, "conv-1");
 
     expect(hapticLight).toHaveBeenCalledTimes(1);
-    expect(setMainView).toHaveBeenCalledWith("chat");
-    expect(subagentReset).toHaveBeenCalledTimes(1);
-    expect(workflowReset).toHaveBeenCalledTimes(1);
-    expect(setActiveConversationId).toHaveBeenCalledWith("conv-1");
+    expect(useViewerStore.getState().mainView).toBe("chat");
+    expect(useConversationStore.getState().activeConversationId).toBe("conv-1");
     expect(navigate).toHaveBeenCalledWith(routes.conversation("conv-1"));
   });
 
@@ -97,10 +99,8 @@ describe("navigateToConversation", () => {
     });
 
     expect(hapticLight).not.toHaveBeenCalled();
-    expect(setMainView).toHaveBeenCalledWith("chat");
-    expect(subagentReset).toHaveBeenCalledTimes(1);
-    expect(workflowReset).toHaveBeenCalledTimes(1);
-    expect(setActiveConversationId).toHaveBeenCalledWith("conv-2");
+    expect(useViewerStore.getState().mainView).toBe("chat");
+    expect(useConversationStore.getState().activeConversationId).toBe("conv-2");
     expect(navigate).toHaveBeenCalledWith(routes.conversation("conv-2"));
   });
 
@@ -117,51 +117,96 @@ describe("navigateToConversation", () => {
   });
 
   test("same-conversation navigation keeps subagent/workflow state (LUM-2875)", () => {
-    activeConversationId = "conv-1";
+    useConversationStore.getState().setActiveConversationId("conv-1");
+    useSubagentStore.getState().spawnSubagent({
+      subagentId: "sub-1",
+      label: "auditor",
+      objective: "audit",
+      timestamp: Date.now(),
+    });
     const navigate = mock((_to: string) => {});
     navigateToConversation(navigate as unknown as NavigateFunction, "conv-1");
 
     // Still returns to the chat view and navigates, but must NOT wipe the
     // process stores — running subagents only repopulate from live SSE.
-    expect(setMainView).toHaveBeenCalledWith("chat");
-    expect(subagentReset).not.toHaveBeenCalled();
-    expect(workflowReset).not.toHaveBeenCalled();
-    expect(clearTranscriptPanelPayloads).not.toHaveBeenCalled();
+    expect(useViewerStore.getState().mainView).toBe("chat");
+    expect(useSubagentStore.getState().byId["sub-1"]).toBeDefined();
     expect(navigate).toHaveBeenCalledWith(routes.conversation("conv-1"));
   });
 
   test("genuine switch resets subagent/workflow state and panel payloads", () => {
-    activeConversationId = "conv-1";
+    useConversationStore.getState().setActiveConversationId("conv-1");
+    useSubagentStore.getState().spawnSubagent({
+      subagentId: "sub-1",
+      label: "auditor",
+      objective: "audit",
+      timestamp: Date.now(),
+    });
+    useViewerStore.setState({
+      activeMessageFiles: {
+        messageId: "msg-1",
+        attachments: [],
+      },
+    });
     const navigate = mock((_to: string) => {});
     navigateToConversation(navigate as unknown as NavigateFunction, "conv-2");
 
-    expect(subagentReset).toHaveBeenCalledTimes(1);
-    expect(workflowReset).toHaveBeenCalledTimes(1);
-    // A files or activity-steps panel opened from the previous transcript
-    // points at a message this conversation does not contain.
-    expect(clearTranscriptPanelPayloads).toHaveBeenCalledTimes(1);
+    expect(useSubagentStore.getState().byId["sub-1"]).toBeUndefined();
+    expect(useViewerStore.getState().activeMessageFiles).toBeNull();
+  });
+
+  test("keeps an open app in the side-by-side layout on a wide viewport", () => {
+    openAppViewer();
+    const navigate = mock((_to: string) => {});
+    navigateToConversation(navigate as unknown as NavigateFunction, "conv-9");
+
+    expect(useViewerStore.getState().mainView).toBe("app-editing");
+    expect(useConversationStore.getState().editingConversationId).toBe(
+      "conv-9",
+    );
+    expect(useConversationStore.getState().activeConversationId).toBe("conv-9");
+    expect(navigate).toHaveBeenCalledWith(routes.conversation("conv-9"));
+  });
+
+  test("dismisses an open app on a narrow viewport (no split layout)", () => {
+    restoreViewport?.();
+    restoreViewport = stubViewportAxes({
+      narrow: true,
+      coarsePointer: true,
+    });
+    openAppViewer();
+    const navigate = mock((_to: string) => {});
+    navigateToConversation(navigate as unknown as NavigateFunction, "conv-9");
+
+    expect(useViewerStore.getState().mainView).toBe("chat");
+    expect(useConversationStore.getState().editingConversationId).toBeNull();
   });
 });
 
 describe("navigateToNewConversation", () => {
   test("resets panel payloads and process stores, taps, focuses the composer", () => {
-    activeConversationId = "conv-1";
+    useConversationStore.getState().setActiveConversationId("conv-1");
     const navigate = mock((_to: string) => {});
     navigateToNewConversation(navigate as unknown as NavigateFunction);
 
     expect(hapticLight).toHaveBeenCalledTimes(1);
-    expect(setMainView).toHaveBeenCalledWith("chat");
-    expect(subagentReset).toHaveBeenCalledTimes(1);
-    expect(workflowReset).toHaveBeenCalledTimes(1);
-    expect(clearTranscriptPanelPayloads).toHaveBeenCalledTimes(1);
-    expect(setActiveConversationId).toHaveBeenCalledTimes(1);
-    // The minted key is registered as a draft, so the transcript skips its
-    // skeleton and lands the composer instead.
-    expect(registerDraftConversationId).toHaveBeenCalledTimes(1);
+    expect(useViewerStore.getState().mainView).toBe("chat");
+    const newId = useConversationStore.getState().activeConversationId;
+    expect(newId).toBeTruthy();
+    expect(newId).not.toBe("conv-1");
+    expect(
+      useConversationStore.getState().draftConversationIds.has(newId!),
+    ).toBe(true);
     expect(composerFocus).toHaveBeenCalledTimes(1);
   });
 
   test("silent suppresses the haptic and sound but still clears panel payloads", () => {
+    useViewerStore.setState({
+      activeMessageFiles: {
+        messageId: "msg-1",
+        attachments: [],
+      },
+    });
     const navigate = mock((_to: string) => {});
     navigateToNewConversation(navigate as unknown as NavigateFunction, {
       silent: true,
@@ -169,6 +214,61 @@ describe("navigateToNewConversation", () => {
 
     expect(hapticLight).not.toHaveBeenCalled();
     expect(playSound).not.toHaveBeenCalled();
-    expect(clearTranscriptPanelPayloads).toHaveBeenCalledTimes(1);
+    expect(useViewerStore.getState().activeMessageFiles).toBeNull();
+  });
+
+  test("keeps an open app in the side-by-side layout with the new draft", () => {
+    openAppViewer();
+    const navigate = mock((_to: string) => {});
+    navigateToNewConversation(navigate as unknown as NavigateFunction);
+
+    const newId = useConversationStore.getState().activeConversationId;
+    expect(useViewerStore.getState().mainView).toBe("app-editing");
+    expect(useConversationStore.getState().editingConversationId).toBe(newId);
+    expect(composerFocus).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("keepOpenAppBesideConversation", () => {
+  test("binds the conversation and enters the split when an app is on screen", () => {
+    openAppViewer();
+    expect(keepOpenAppBesideConversation("conv-4")).toBe(true);
+    expect(useConversationStore.getState().editingConversationId).toBe(
+      "conv-4",
+    );
+    expect(useViewerStore.getState().mainView).toBe("app-editing");
+  });
+
+  test("is a no-op when no app is loaded", () => {
+    useViewerStore.setState({ mainView: "app" });
+    expect(keepOpenAppBesideConversation("conv-4")).toBe(false);
+    expect(useViewerStore.getState().mainView).toBe("app");
+    expect(useConversationStore.getState().editingConversationId).toBeNull();
+  });
+
+  test("is a no-op for overlay views", () => {
+    useViewerStore.setState({
+      mainView: "document",
+      activeAppId: SAMPLE_APP.appId,
+      openedAppState: SAMPLE_APP,
+    });
+    expect(keepOpenAppBesideConversation("conv-4")).toBe(false);
+    expect(useViewerStore.getState().mainView).toBe("document");
+  });
+});
+
+describe("revealConversationView", () => {
+  test("returns to chat when nothing is keeping the app", () => {
+    revealConversationView("conv-4");
+    expect(useViewerStore.getState().mainView).toBe("chat");
+  });
+
+  test("keeps the app instead of returning to chat", () => {
+    openAppViewer("app-editing");
+    revealConversationView("conv-4");
+    expect(useViewerStore.getState().mainView).toBe("app-editing");
+    expect(useConversationStore.getState().editingConversationId).toBe(
+      "conv-4",
+    );
   });
 });

--- a/clients/web/src/utils/conversation-navigation.ts
+++ b/clients/web/src/utils/conversation-navigation.ts
@@ -10,6 +10,7 @@ import { useWorkflowStore } from "@/domains/chat/workflow-store";
 import { useViewerStore } from "@/stores/viewer-store";
 import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection";
 import { getSoundManager } from "@/lib/sounds/sound-manager";
+import { MOBILE_MEDIA_QUERY } from "@/hooks/use-is-mobile";
 
 export interface NavigateToConversationOptions {
   /** Anchor the transcript to a specific message on load. */
@@ -19,6 +20,51 @@ export interface NavigateToConversationOptions {
    * at action start (e.g. fork), so the navigation doesn't double-buzz.
    */
   silent?: boolean;
+}
+
+function isNarrowViewport(): boolean {
+  if (
+    typeof window === "undefined" ||
+    typeof window.matchMedia !== "function"
+  ) {
+    return false;
+  }
+  return window.matchMedia(MOBILE_MEDIA_QUERY).matches;
+}
+
+/**
+ * If an app is already on screen on a wide viewport, bind `conversationId`
+ * as the chat pane and keep the app in the side-by-side layout instead of
+ * dismissing it. Returns true when the app was kept.
+ *
+ * Narrow viewports have no split layout, so those still fall through to
+ * chat. Overlay views (document, tool detail, …) are not apps and are
+ * dismissed as before.
+ */
+export function keepOpenAppBesideConversation(conversationId: string): boolean {
+  if (isNarrowViewport()) {
+    return false;
+  }
+  const viewer = useViewerStore.getState();
+  if (viewer.mainView !== "app" && viewer.mainView !== "app-editing") {
+    return false;
+  }
+  if (!viewer.activeAppId && !viewer.openedAppState) {
+    return false;
+  }
+  useConversationStore.getState().setEditingConversationId(conversationId);
+  viewer.enterAppEditing();
+  return true;
+}
+
+/**
+ * Bring a conversation on screen. An already-open app on a wide viewport
+ * stays put in the side-by-side layout; otherwise the viewer returns to chat.
+ */
+export function revealConversationView(conversationId: string): void {
+  if (!keepOpenAppBesideConversation(conversationId)) {
+    useViewerStore.getState().setMainView("chat");
+  }
 }
 
 /**
@@ -36,7 +82,7 @@ export function navigateToConversation(
   if (!options?.silent) {
     haptic.light();
   }
-  useViewerStore.getState().setMainView("chat");
+  revealConversationView(conversationId);
   // Only wipe per-conversation process state on a genuine switch. Wiping on
   // a same-conversation navigation kills the inline cards for subagents
   // that are still running: the store repopulates only from live SSE
@@ -85,11 +131,11 @@ export function navigateToNewConversation(
     haptic.light();
     void getSoundManager().play("new_conversation");
   }
-  useViewerStore.getState().setMainView("chat");
   useSubagentStore.getState().reset();
   useWorkflowStore.getState().reset();
   useViewerStore.getState().clearTranscriptPanelPayloads();
   const draftId = createDraftConversationId();
+  revealConversationView(draftId);
   useConversationStore.getState().setActiveConversationId(draftId);
 
   let path: string = routes.conversation(draftId);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Selecting a conversation while an app is already open on desktop used to show that conversation beside the app. That stopped working because conversation navigation always forced the viewer back to chat, which hid the app. Split view was left only for the dedicated Edit thread (or an in-app `set_view: "split"` call).

This restores the old affordance without undoing LUM-2553:

- Opening an app still lands full-width, from chat, Home, or Library.
- If an app is already on screen on a wide viewport, picking any conversation (sidebar, new chat, deep link, in-app `open_conversation`) keeps the app and puts that conversation in the left pane.
- Narrow viewports have no split layout, so they still return to chat.

## Test Plan

- `cd clients/web && bun test src/utils/conversation-navigation.test.ts src/domains/chat/app-viewer-actions.test.ts src/domains/chat/utils/stream-handlers/navigation-handlers.test.ts src/hooks/use-global-deep-link-consumer.test.tsx src/domains/chat/hooks/use-open-app-from-chat.test.ts src/hooks/use-edit-app.test.tsx`
- Manual: open an app full-width on desktop, then click another conversation in the sidebar. Chat should appear on the left with the app still on the right. Repeat with New chat. On a narrow window, the app should still dismiss.

## Risk

Medium UX change. Overlay views (document, tool detail) still dismiss to chat. Leftover app state in the viewer store while you are on Home or Library can reappear in split if you then pick a conversation. That matches "the app was never closed," but is worth a look.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f067987-8fe0-4a33-9ae8-88e0d6ae73d0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f067987-8fe0-4a33-9ae8-88e0d6ae73d0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

