### PR TITLE
refactor(web): extract hidden file input + iOS refocus dance into useAttachmentFilePicker

### DIFF
--- a/clients/web/src/domains/chat/components/chat-attachments/chat-attachments.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/chat-attachments.tsx
@@ -1,13 +1,13 @@
 import { AlertCircle, Folder, Paperclip, X } from "lucide-react";
-import type { ChangeEvent, FC } from "react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import type { FC } from "react";
+import { useCallback, useState } from "react";
 
 import { Button } from "@vellumai/design-library";
 
-import { requestComposerFocus } from "@/domains/chat/composer-focus";
 import { AttachmentChip } from "@/domains/chat/components/chat-attachments/attachment-chip";
 import { AttachmentLoadingChip } from "@/domains/chat/components/chat-attachments/attachment-loading-chip";
 import { AttachmentPreviewModal } from "@/domains/chat/components/chat-attachments/attachment-preview-modal";
+import { useAttachmentFilePicker } from "@/domains/chat/components/chat-attachments/use-attachment-file-picker";
 import type {
   ChatAttachment,
   UploadedAttachment,
@@ -133,112 +133,27 @@ interface AttachFileButtonProps {
 
 /**
  * Paperclip button that triggers a hidden file input. Lives in the lower-left
- * of the composer action bar to match the macOS layout.
- *
- * On iOS (Capacitor WKWebView), clicking the hidden `<input type="file">`
- * presents the native document/photo picker, which resigns the web view's
- * first responder — dismissing the soft keyboard and collapsing the
- * keyboard-aware layout (`root-layout.tsx` sizes the shell from
- * `visualViewport`). The native picker and the keyboard are mutually
- * exclusive first responders, so the keyboard cannot stay up *during* the
- * picker. Instead we re-focus the composer the moment the picker closes,
- * keyed off the file input's own events so the signal is tied to the picker
- * (not to app foregrounding, which also fires when the app is backgrounded
- * and returned to while the picker is still open):
- *
- * - `change` — a file was selected.
- * - `cancel` — the picker was dismissed without a selection (WebKit / Safari
- *   16.4+). Precise: tied to the picker dismissal itself.
- * - one-shot `window` `focus` — fallback for iOS 15–16.3 WKWebViews (the app's
- *   deployment target is iOS 15) that predate the `cancel` event. Armed on
- *   picker open and removed after firing once, so a later real `cancel` on
- *   newer engines still works and the fallback can't linger. `focus` fires
- *   when the web view regains first responder as the picker closes.
- *
- * `requestComposerFocus()` is idempotent and a no-op on desktop (the textarea
- * is already focused there and the OS file dialog doesn't steal focus), so
- * running it from more than one of these paths is harmless.
+ * of the composer action bar to match the macOS layout. The input itself and
+ * the iOS keyboard-refocus dance it depends on live in
+ * `useAttachmentFilePicker`.
  */
 export const AttachFileButton: FC<AttachFileButtonProps> = ({
   disabled = false,
   onFilesSelected,
   title = "Attach file",
 }) => {
-  const inputRef = useRef<HTMLInputElement | null>(null);
-  // Cleanup for the armed iOS 15–16.3 focus fallback (see handleClick). Held
-  // in a ref so every picker-close path (change, cancel, unmount) can disarm
-  // it, not just a window focus event.
-  const disarmFocusFallbackRef = useRef<(() => void) | null>(null);
-
-  const refocusComposer = useCallback(() => {
-    // Any picker-close path lands here: disarm the pending focus fallback so it
-    // can't fire on a later unrelated window focus, then restore the keyboard.
-    disarmFocusFallbackRef.current?.();
-    disarmFocusFallbackRef.current = null;
-    requestComposerFocus();
-  }, []);
-
-  const handleClick = useCallback(() => {
-    // Fallback for iOS 15–16.3 WKWebViews that don't fire the input `cancel`
-    // event: refocus the composer the first time the window regains focus
-    // after the picker opens (the picker resigned it). On iOS 16.4+ the
-    // `cancel`/`change` paths fire first and disarm this via refocusComposer,
-    // so it never lingers past the picker session.
-    disarmFocusFallbackRef.current?.();
-    const onFocus = () => refocusComposer();
-    window.addEventListener("focus", onFocus, { once: true });
-    disarmFocusFallbackRef.current = () =>
-      window.removeEventListener("focus", onFocus);
-    inputRef.current?.click();
-  }, [refocusComposer]);
-
-  const handleChange = useCallback(
-    (event: ChangeEvent<HTMLInputElement>) => {
-      const { files } = event.target;
-      if (files && files.length > 0) {
-        onFilesSelected(files);
-      }
-      // Reset so selecting the same file twice still fires onChange.
-      event.target.value = "";
-      // Restore the keyboard/layout after the picker closes on selection.
-      refocusComposer();
-    },
-    [onFilesSelected, refocusComposer],
-  );
-
-  // Cancel path: the native picker fires `cancel` (not `change`) when
-  // dismissed without a selection. Refocusing here restores the keyboard
-  // without relying on app-foreground signals, which would misfire if the app
-  // is backgrounded and resumed while the picker is still open. Attached
-  // imperatively because the installed React typings don't yet expose the
-  // `onCancel` prop for `<input>` (the DOM event exists in WebKit 16.4+). The
-  // effect cleanup also disarms any pending focus fallback on unmount.
-  useEffect(() => {
-    const input = inputRef.current;
-    const onCancel = () => refocusComposer();
-    input?.addEventListener("cancel", onCancel);
-    return () => {
-      input?.removeEventListener("cancel", onCancel);
-      disarmFocusFallbackRef.current?.();
-      disarmFocusFallbackRef.current = null;
-    };
-  }, [refocusComposer]);
+  const { openPicker, inputNode } = useAttachmentFilePicker({
+    onFiles: onFilesSelected,
+    multiple: true,
+  });
 
   return (
     <div className="relative">
-      <input
-        ref={inputRef}
-        type="file"
-        multiple
-        className="absolute inset-0 opacity-0 pointer-events-none"
-        onChange={handleChange}
-        aria-hidden="true"
-        tabIndex={-1}
-      />
+      {inputNode}
       <Button
         variant="ghost"
         iconOnly={<Paperclip />}
-        onClick={handleClick}
+        onClick={openPicker}
         disabled={disabled}
         aria-label="Attach file"
         title={title}

--- a/clients/web/src/domains/chat/components/chat-attachments/use-attachment-file-picker.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/use-attachment-file-picker.test.tsx
@@ -1,0 +1,163 @@
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+// The picker re-focuses the composer whenever the native iOS picker closes.
+// Mock the focus seam so we can assert the request without mounting the whole
+// composer/keyboard machinery.
+const requestComposerFocusMock = mock(() => {});
+mock.module("@/domains/chat/composer-focus", () => ({
+  requestComposerFocus: requestComposerFocusMock,
+}));
+
+import { useAttachmentFilePicker } from "@/domains/chat/components/chat-attachments/use-attachment-file-picker";
+
+afterAll(() => {
+  mock.restore();
+});
+afterEach(() => {
+  cleanup();
+});
+beforeEach(() => {
+  requestComposerFocusMock.mockClear();
+});
+
+function PickerProbe(props: {
+  onFiles: (files: FileList) => void;
+  multiple?: boolean;
+  accept?: string;
+  capture?: boolean | "user" | "environment";
+}) {
+  const { openPicker, inputNode } = useAttachmentFilePicker(props);
+  return (
+    <>
+      {inputNode}
+      <button type="button" onClick={openPicker}>
+        open
+      </button>
+    </>
+  );
+}
+
+function renderPicker(props: Parameters<typeof PickerProbe>[0]) {
+  const result = render(<PickerProbe {...props} />);
+  const input = result.container.querySelector(
+    'input[type="file"]',
+  ) as HTMLInputElement;
+  const open = () => fireEvent.click(result.getByText("open"));
+  return { ...result, input, open };
+}
+
+function makeFileList(files: File[]): FileList {
+  const list = {
+    length: files.length,
+    item: (i: number) => files[i] ?? null,
+  } as unknown as FileList;
+  files.forEach((f, i) => {
+    (list as unknown as Record<number, File>)[i] = f;
+  });
+  return list;
+}
+
+function selectFile(input: HTMLInputElement, name = "note.txt") {
+  const file = new File(["hi"], name, { type: "text/plain" });
+  Object.defineProperty(input, "files", {
+    configurable: true,
+    value: makeFileList([file]),
+  });
+  fireEvent.change(input);
+}
+
+describe("useAttachmentFilePicker", () => {
+  test("openPicker clicks the hidden input", () => {
+    const { input, open } = renderPicker({ onFiles: () => {} });
+    const clicked = mock(() => {});
+    input.addEventListener("click", clicked);
+
+    open();
+
+    expect(clicked).toHaveBeenCalledTimes(1);
+  });
+
+  test("delivers selected files and refocuses the composer", () => {
+    const onFiles = mock(() => {});
+    const { input } = renderPicker({ onFiles });
+
+    selectFile(input);
+
+    expect(onFiles).toHaveBeenCalledTimes(1);
+    expect(requestComposerFocusMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("refocuses without delivering when change carries no files", () => {
+    const onFiles = mock(() => {});
+    const { input } = renderPicker({ onFiles });
+
+    fireEvent.change(input);
+
+    expect(onFiles).not.toHaveBeenCalled();
+    expect(requestComposerFocusMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("refocuses when the picker is dismissed (input cancel event)", () => {
+    const { input } = renderPicker({ onFiles: () => {} });
+
+    // A dismissal fires no `change`; WebKit dispatches `cancel` on the input.
+    fireEvent(input, new Event("cancel"));
+
+    expect(requestComposerFocusMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("refocuses via the one-shot window focus fallback (iOS 15 through 16.3)", () => {
+    const { open } = renderPicker({ onFiles: () => {} });
+
+    open();
+    expect(requestComposerFocusMock).not.toHaveBeenCalled();
+
+    window.dispatchEvent(new Event("focus"));
+    expect(requestComposerFocusMock).toHaveBeenCalledTimes(1);
+
+    // One-shot: a later unrelated focus does not refocus again.
+    window.dispatchEvent(new Event("focus"));
+    expect(requestComposerFocusMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("disarms the focus fallback once the picker closes", () => {
+    const { input, open } = renderPicker({ onFiles: () => {} });
+
+    open();
+    selectFile(input);
+    expect(requestComposerFocusMock).toHaveBeenCalledTimes(1);
+
+    window.dispatchEvent(new Event("focus"));
+    expect(requestComposerFocusMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("mirrors accept, capture, and multiple onto the input", () => {
+    const { input } = renderPicker({
+      onFiles: () => {},
+      accept: "image/*",
+      capture: "environment",
+      multiple: true,
+    });
+
+    expect(input.getAttribute("accept")).toBe("image/*");
+    expect(input.getAttribute("capture")).toBe("environment");
+    expect(input.multiple).toBe(true);
+  });
+
+  test("omits accept and capture and stays single-file by default", () => {
+    const { input } = renderPicker({ onFiles: () => {} });
+
+    expect(input.hasAttribute("accept")).toBe(false);
+    expect(input.hasAttribute("capture")).toBe(false);
+    expect(input.multiple).toBe(false);
+  });
+});

--- a/clients/web/src/domains/chat/components/chat-attachments/use-attachment-file-picker.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/use-attachment-file-picker.tsx
@@ -1,0 +1,151 @@
+import type { ChangeEvent, ReactElement } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from "react";
+
+import { requestComposerFocus } from "@/domains/chat/composer-focus";
+
+interface UseAttachmentFilePickerOptions {
+  /** Receives the picked files. Not called when the picker closes empty. */
+  onFiles: (files: FileList) => void;
+  /** Allow picking more than one file. */
+  multiple?: boolean;
+  /** `accept` attribute for the input, e.g. `"image/*"`. */
+  accept?: string;
+  /** `capture` attribute, e.g. `"environment"` for the rear camera. */
+  capture?: boolean | "user" | "environment";
+}
+
+interface UseAttachmentFilePickerResult {
+  /** Opens the native picker and arms the iOS focus fallback. */
+  openPicker: () => void;
+  /** Hidden `<input type="file">` the caller must render. */
+  inputNode: ReactElement;
+}
+
+/**
+ * Owns a hidden `<input type="file">` and the composer refocus that has to run
+ * whenever the native picker closes. Callers render `inputNode` and call
+ * `openPicker()` from their own trigger.
+ *
+ * On iOS (Capacitor WKWebView), clicking the hidden `<input type="file">`
+ * presents the native document/photo picker, which resigns the web view's
+ * first responder, dismissing the soft keyboard and collapsing the
+ * keyboard-aware layout (`root-layout.tsx` sizes the shell from
+ * `visualViewport`). The native picker and the keyboard are mutually
+ * exclusive first responders, so the keyboard cannot stay up *during* the
+ * picker. Instead we re-focus the composer the moment the picker closes,
+ * keyed off the file input's own events so the signal is tied to the picker
+ * (not to app foregrounding, which also fires when the app is backgrounded
+ * and returned to while the picker is still open):
+ *
+ * - `change`: a file was selected.
+ * - `cancel`: the picker was dismissed without a selection (WebKit / Safari
+ *   16.4+). Precise: tied to the picker dismissal itself.
+ * - one-shot `window` `focus`: fallback for iOS 15 through 16.3 WKWebViews
+ *   (the app's deployment target is iOS 15) that predate the `cancel` event.
+ *   Armed on picker open and removed after firing once, so a later real
+ *   `cancel` on newer engines still works and the fallback can't linger.
+ *   `focus` fires when the web view regains first responder as the picker
+ *   closes.
+ *
+ * `requestComposerFocus()` is idempotent and a no-op on desktop (the textarea
+ * is already focused there and the OS file dialog doesn't steal focus), so
+ * running it from more than one of these paths is harmless.
+ */
+export function useAttachmentFilePicker({
+  onFiles,
+  multiple = false,
+  accept,
+  capture,
+}: UseAttachmentFilePickerOptions): UseAttachmentFilePickerResult {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  // Kept in a ref so an unmemoized caller callback doesn't remint `inputNode`,
+  // which would remount the input mid-picker for consumers that render it.
+  const onFilesRef = useRef(onFiles);
+  useLayoutEffect(() => {
+    onFilesRef.current = onFiles;
+  }, [onFiles]);
+
+  // Cleanup for the armed iOS 15 through 16.3 focus fallback (see openPicker).
+  // Held in a ref so every picker-close path (change, cancel, unmount) can
+  // disarm it, not just a window focus event.
+  const disarmFocusFallbackRef = useRef<(() => void) | null>(null);
+
+  const refocusComposer = useCallback(() => {
+    // Any picker-close path lands here: disarm the pending focus fallback so it
+    // can't fire on a later unrelated window focus, then restore the keyboard.
+    disarmFocusFallbackRef.current?.();
+    disarmFocusFallbackRef.current = null;
+    requestComposerFocus();
+  }, []);
+
+  const openPicker = useCallback(() => {
+    // Fallback for iOS 15 through 16.3 WKWebViews that don't fire the input
+    // `cancel` event: refocus the composer the first time the window regains
+    // focus after the picker opens (the picker resigned it). On iOS 16.4+ the
+    // `cancel`/`change` paths fire first and disarm this via refocusComposer,
+    // so it never lingers past the picker session.
+    disarmFocusFallbackRef.current?.();
+    const onFocus = () => refocusComposer();
+    window.addEventListener("focus", onFocus, { once: true });
+    disarmFocusFallbackRef.current = () =>
+      window.removeEventListener("focus", onFocus);
+    inputRef.current?.click();
+  }, [refocusComposer]);
+
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const { files } = event.target;
+      if (files && files.length > 0) {
+        onFilesRef.current(files);
+      }
+      // Reset so selecting the same file twice still fires onChange.
+      event.target.value = "";
+      // Restore the keyboard/layout after the picker closes on selection.
+      refocusComposer();
+    },
+    [refocusComposer],
+  );
+
+  // Cancel path: the native picker fires `cancel` (not `change`) when
+  // dismissed without a selection. Refocusing here restores the keyboard
+  // without relying on app-foreground signals, which would misfire if the app
+  // is backgrounded and resumed while the picker is still open. Attached
+  // imperatively because the installed React typings don't yet expose the
+  // `onCancel` prop for `<input>` (the DOM event exists in WebKit 16.4+). The
+  // effect cleanup also disarms any pending focus fallback on unmount.
+  useEffect(() => {
+    const input = inputRef.current;
+    const onCancel = () => refocusComposer();
+    input?.addEventListener("cancel", onCancel);
+    return () => {
+      input?.removeEventListener("cancel", onCancel);
+      disarmFocusFallbackRef.current?.();
+      disarmFocusFallbackRef.current = null;
+    };
+  }, [refocusComposer]);
+
+  const inputNode = useMemo(
+    () => (
+      <input
+        ref={inputRef}
+        type="file"
+        multiple={multiple}
+        accept={accept}
+        capture={capture}
+        className="absolute inset-0 opacity-0 pointer-events-none"
+        onChange={handleChange}
+        aria-hidden="true"
+        tabIndex={-1}
+      />
+    ),
+    [multiple, accept, capture, handleChange],
+  );
+
+  return useMemo(() => ({ openPicker, inputNode }), [openPicker, inputNode]);
+}


### PR DESCRIPTION
## Summary
- Extracts the paperclip's hidden file input and iOS keyboard-refocus handling into a reusable useAttachmentFilePicker hook
- AttachFileButton behavior is unchanged; the hook adds accept/capture/multiple options for upcoming camera and gallery pickers

Part of plan: mobile-composer-redesign.md (PR 2 of 6)