### PR TITLE
feat(web): labeled-pill trigger variant and open-state callback for ComposerSettingsMenu

### DIFF
--- a/clients/web/src/domains/chat/components/composer-settings-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.test.tsx
@@ -106,27 +106,35 @@ const SurfaceTrigger = ({
     children as ReactNode,
   );
 };
+// Radix dismisses a dropdown when one of its items is selected, so the mocked
+// item reports the close through the same Root callback after running onSelect.
+const MenuItem = ({
+  children,
+  onSelect,
+  leftIcon,
+  ...rest
+}: Record<string, unknown>) => {
+  const onOpenChange = useContext(OpenChangeContext);
+  return createElement(
+    "button",
+    {
+      "data-testid": "menu-item",
+      onClick: () => {
+        (onSelect as (() => void) | undefined)?.();
+        onOpenChange?.(false);
+      },
+      ...rest,
+    },
+    leftIcon as ReactNode,
+    children as ReactNode,
+  );
+};
 mock.module("@vellumai/design-library", () => {
   const MenuMock = {
     Root: surfaceRoot,
     Trigger: SurfaceTrigger,
     Content: passthrough,
-    Item: ({
-      children,
-      onSelect,
-      leftIcon,
-      ...rest
-    }: Record<string, unknown>) =>
-      createElement(
-        "button",
-        {
-          "data-testid": "menu-item",
-          onClick: onSelect as (() => void) | undefined,
-          ...rest,
-        },
-        leftIcon as ReactNode,
-        children as ReactNode,
-      ),
+    Item: MenuItem,
     Label: passthrough,
     Separator: () => createElement("hr"),
   };
@@ -784,7 +792,10 @@ describe("labeled-pill trigger variant", () => {
 });
 
 describe("compact composer collapse", () => {
-  function renderCompact(segments: "both" | "access" | "profile") {
+  function renderCompact(
+    segments: "both" | "access" | "profile",
+    onOpenChange?: (open: boolean) => void,
+  ) {
     const queryClient = new QueryClient({
       defaultOptions: {
         queries: { retry: false },
@@ -801,6 +812,7 @@ describe("compact composer collapse", () => {
             assistantId: "assistant-1",
             conversationId: "conv-1",
             segments,
+            onOpenChange,
           }),
         }),
       ),
@@ -826,6 +838,32 @@ describe("compact composer collapse", () => {
     // Access presets live in the same menu, under their own section label.
     expect(screen.getByText("Assistant Access")).toBeTruthy();
     expect(screen.getByText("Model Profile")).toBeTruthy();
+  });
+
+  test("reports the hamburger menu's open state", async () => {
+    // The compact branch is the only surface this instance opens, so a parent
+    // holding its trigger chrome visible has to hear about it too.
+    const onOpenChange = mock((_open: boolean) => {});
+    renderCompact("access", onOpenChange);
+
+    const trigger = await screen.findByLabelText(
+      "Assistant access and model profile",
+    );
+    fireEvent.click(trigger);
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenLastCalledWith(true);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Smart")).toBeTruthy();
+    });
+    const smart = screen
+      .getAllByTestId("menu-item")
+      .find((row) => row.textContent?.includes("Smart"));
+    fireEvent.click(smart!);
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenLastCalledWith(false);
+    });
   });
 
   test("stays split when the composer is wide", async () => {

--- a/clients/web/src/domains/chat/components/composer-settings-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.test.tsx
@@ -516,7 +516,7 @@ describe("Profile trigger updates", () => {
     });
 
     renderMenu();
-    const trigger = await screen.findByLabelText("Model profile");
+    const trigger = await screen.findByLabelText(/^Model profile/);
     await waitFor(() => expect(trigger.textContent).toContain("Balanced"));
 
     const qualityItem = screen
@@ -734,10 +734,29 @@ describe("labeled-pill trigger variant", () => {
     const accessTrigger = await screen.findByLabelText(ACCESS_TRIGGER_LABEL);
     expect(accessTrigger.textContent).toContain("Conservative");
 
-    const profileTrigger = await screen.findByLabelText("Model profile");
+    const profileTrigger = await screen.findByLabelText(/^Model profile/);
     await waitFor(() => {
       expect(profileTrigger.textContent).toContain("Smart");
     });
+  });
+
+  test("names the profile pill by the profile it displays", async () => {
+    // An aria-label overrides the pill's visible text, so a generic one leaves
+    // a screen reader unable to announce the selection and voice control unable
+    // to activate the pill by the words it shows.
+    renderVariant({ triggerVariant: "labeled-pill" });
+
+    const profileTrigger = await screen.findByLabelText(/^Model profile/);
+    await waitFor(() => {
+      expect(profileTrigger.getAttribute("aria-label")).toBe(
+        "Model profile: Smart",
+      );
+    });
+    expect(profileTrigger.textContent).toContain("Smart");
+
+    // The access pill already carries its own selection in its name.
+    const accessTrigger = await screen.findByLabelText(ACCESS_TRIGGER_LABEL);
+    expect(accessTrigger.textContent).toContain("Conservative");
   });
 
   test("the default icon variant keeps the mobile triggers unlabeled", async () => {
@@ -745,7 +764,7 @@ describe("labeled-pill trigger variant", () => {
 
     const accessTrigger = await screen.findByLabelText(ACCESS_TRIGGER_LABEL);
     expect(accessTrigger.textContent).toBe("");
-    expect((await screen.findByLabelText("Model profile")).textContent).toBe(
+    expect((await screen.findByLabelText(/^Model profile/)).textContent).toBe(
       "",
     );
   });
@@ -775,7 +794,7 @@ describe("labeled-pill trigger variant", () => {
     const onOpenChange = mock((_open: boolean) => {});
     renderVariant({ triggerVariant: "labeled-pill", onOpenChange });
 
-    const profileTrigger = await screen.findByLabelText("Model profile");
+    const profileTrigger = await screen.findByLabelText(/^Model profile/);
     fireEvent.click(profileTrigger);
     await waitFor(() => {
       expect(onOpenChange).toHaveBeenLastCalledWith(true);
@@ -830,7 +849,7 @@ describe("compact composer collapse", () => {
     );
     expect(trigger).toBeTruthy();
     // No labelled split triggers alongside it.
-    expect(screen.queryByLabelText("Model profile")).toBeNull();
+    expect(screen.queryByLabelText(/^Model profile/)).toBeNull();
 
     await waitFor(() => {
       expect(screen.getByText("Smart")).toBeTruthy();
@@ -870,10 +889,63 @@ describe("compact composer collapse", () => {
     renderMenu();
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Model profile")).toBeTruthy();
+      expect(screen.getByLabelText(/^Model profile/)).toBeTruthy();
     });
     expect(
       screen.queryByLabelText("Assistant access and model profile"),
     ).toBeNull();
+  });
+
+  test("stops reporting open when the width swap unmounts the open branch", async () => {
+    // Resizing across the compact threshold unmounts whichever branch was
+    // open. Its flag survives the unmount, so the report has to follow the
+    // branch that is actually mounted or a parent holding trigger chrome
+    // visible never hears the surface close.
+    const onOpenChange = mock((_open: boolean) => {});
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    const tree = (compact: boolean) =>
+      createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        createElement(ComposerCompactProvider, {
+          compact,
+          children: createElement(ComposerSettingsMenu, {
+            assistantId: "assistant-1",
+            conversationId: "conv-1",
+            segments: "both",
+            onOpenChange,
+          }),
+        }),
+      );
+
+    const { rerender } = render(tree(false));
+
+    const profileTrigger = await screen.findByLabelText(/^Model profile/);
+    fireEvent.click(profileTrigger);
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenLastCalledWith(true);
+    });
+
+    // The composer narrows: the split triggers give way to the hamburger.
+    rerender(tree(true));
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenLastCalledWith(false);
+    });
+
+    // Widening back must not resurrect the surface the resize took away.
+    rerender(tree(false));
+    await screen.findByLabelText(/^Model profile/);
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenLastCalledWith(false);
+    });
+    expect(onOpenChange.mock.calls.map((call) => call[0])).toEqual([
+      true,
+      false,
+    ]);
   });
 });

--- a/clients/web/src/domains/chat/components/composer-settings-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.test.tsx
@@ -26,7 +26,12 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { createElement, type ReactNode } from "react";
+import {
+  createContext,
+  createElement,
+  useContext,
+  type ReactNode,
+} from "react";
 
 // --- use-is-mobile -----------------------------------------------------------
 const isMobileRef = { value: false };
@@ -72,10 +77,39 @@ mock.module("@/components/profile-quick-add-provider", () => ({
 // --- design-library surfaces (render content inline) -------------------------
 const passthrough = ({ children, ...props }: Record<string, unknown>) =>
   createElement("div", props, children as ReactNode);
+// Radix owns the open state on the Root and flips it when the trigger is
+// activated. The mock hands the Root's `onOpenChange` down to its Trigger so a
+// click on a trigger opens the surface the way it does in the app.
+const OpenChangeContext = createContext<((open: boolean) => void) | undefined>(
+  undefined,
+);
+const surfaceRoot = ({
+  children,
+  open: _open,
+  onOpenChange,
+  ...props
+}: Record<string, unknown>) =>
+  createElement(
+    OpenChangeContext.Provider,
+    { value: onOpenChange as ((open: boolean) => void) | undefined },
+    createElement("div", props, children as ReactNode),
+  );
+const SurfaceTrigger = ({
+  children,
+  asChild: _asChild,
+  ...props
+}: Record<string, unknown>) => {
+  const onOpenChange = useContext(OpenChangeContext);
+  return createElement(
+    "div",
+    { ...props, onClick: () => onOpenChange?.(true) },
+    children as ReactNode,
+  );
+};
 mock.module("@vellumai/design-library", () => {
   const MenuMock = {
-    Root: passthrough,
-    Trigger: passthrough,
+    Root: surfaceRoot,
+    Trigger: SurfaceTrigger,
     Content: passthrough,
     Item: ({
       children,
@@ -97,8 +131,8 @@ mock.module("@vellumai/design-library", () => {
     Separator: () => createElement("hr"),
   };
   const BottomSheetMock = {
-    Root: passthrough,
-    Trigger: passthrough,
+    Root: surfaceRoot,
+    Trigger: SurfaceTrigger,
     Content: passthrough,
     Header: passthrough,
     Title: passthrough,
@@ -633,6 +667,118 @@ describe("Profile activation rejected by the daemon", () => {
       expect(toastError).toHaveBeenCalledWith(
         "Failed to switch profile. Please try again.",
       );
+    });
+  });
+});
+
+describe("labeled-pill trigger variant", () => {
+  // Preset[1] ("Conservative") is what the mocked global threshold of 50
+  // resolves to, so it is the label the access trigger settles on.
+  const ACCESS_TRIGGER_LABEL = "Assistant access: Conservative";
+
+  function renderVariant(props: {
+    triggerVariant?: "icon" | "labeled-pill";
+    onOpenChange?: (open: boolean) => void;
+  }) {
+    isMobileRef.value = true;
+    isTouchMobileRef.value = true;
+    // Guard against a hanging/altered impl leaking from a prior test.
+    configGetMock.mockImplementation(async () => ({
+      data: {
+        llm: {
+          profileOrder: ["smart"],
+          profiles: {
+            smart: {
+              label: "Smart",
+              provider: "anthropic",
+              model: "claude-fable-5",
+            },
+          },
+          activeProfile: "smart",
+        },
+      },
+    }));
+    conversationsByIdGetMock.mockImplementation(async () => ({
+      data: { conversation: { inferenceProfile: null } },
+    }));
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    return render(
+      createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        createElement(ComposerSettingsMenu, {
+          assistantId: "assistant-1",
+          conversationId: "conv-1",
+          ...props,
+        }),
+      ),
+    );
+  }
+
+  test("renders the resolved access and profile labels on the pills", async () => {
+    renderVariant({ triggerVariant: "labeled-pill" });
+
+    const accessTrigger = await screen.findByLabelText(ACCESS_TRIGGER_LABEL);
+    expect(accessTrigger.textContent).toContain("Conservative");
+
+    const profileTrigger = await screen.findByLabelText("Model profile");
+    await waitFor(() => {
+      expect(profileTrigger.textContent).toContain("Smart");
+    });
+  });
+
+  test("the default icon variant keeps the mobile triggers unlabeled", async () => {
+    renderVariant({});
+
+    const accessTrigger = await screen.findByLabelText(ACCESS_TRIGGER_LABEL);
+    expect(accessTrigger.textContent).toBe("");
+    expect((await screen.findByLabelText("Model profile")).textContent).toBe(
+      "",
+    );
+  });
+
+  test("tapping a pill opens the same bottom sheet and reports the open state", async () => {
+    const onOpenChange = mock((_open: boolean) => {});
+    renderVariant({ triggerVariant: "labeled-pill", onOpenChange });
+
+    const accessTrigger = await screen.findByLabelText(ACCESS_TRIGGER_LABEL);
+    fireEvent.click(accessTrigger);
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenLastCalledWith(true);
+    });
+
+    // The sheet the pill opens holds the same access rows the icon trigger
+    // opens today; picking one closes it again.
+    const relaxed = screen
+      .getAllByTestId("panel-item")
+      .find((row) => row.textContent?.includes("Relaxed"));
+    fireEvent.click(relaxed!);
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenLastCalledWith(false);
+    });
+  });
+
+  test("reports the profile sheet's open state too", async () => {
+    const onOpenChange = mock((_open: boolean) => {});
+    renderVariant({ triggerVariant: "labeled-pill", onOpenChange });
+
+    const profileTrigger = await screen.findByLabelText("Model profile");
+    fireEvent.click(profileTrigger);
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenLastCalledWith(true);
+    });
+
+    const smart = screen
+      .getAllByTestId("panel-item")
+      .find((row) => row.textContent?.includes("Smart"));
+    fireEvent.click(smart!);
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenLastCalledWith(false);
     });
   });
 });

--- a/clients/web/src/domains/chat/components/composer-settings-menu.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.tsx
@@ -81,7 +81,7 @@ interface Props {
    */
   triggerVariant?: "icon" | "labeled-pill";
   /**
-   * Called with whether either of this instance's drawers is open. A parent
+   * Called with whether any of this instance's drawers is open. A parent
    * that positions the triggers itself uses it to hold that surface visible
    * while focus sits inside the drawer's portal.
    */
@@ -110,12 +110,14 @@ export function ComposerSettingsMenu({
   const [profileOpen, setProfileOpen] = useState(false);
   const [compactOpen, setCompactOpen] = useState(false);
 
-  // Both flags are set from several places (trigger, row selection, quick
-  // add), so the notification reads the settled pair once instead of being
-  // threaded through every setter. The ref keeps it a transition callback like
-  // the Radix one it mirrors: a parent passing an inline closure re-runs the
-  // effect on every render, and the drawers start closed.
-  const anyDrawerOpen = accessOpen || profileOpen;
+  // All three flags are set from several places (trigger, row selection, quick
+  // add), so the notification reads the settled trio once instead of being
+  // threaded through every setter. `compactOpen` counts too: the compact branch
+  // renders a single hamburger whose menu is the only surface this instance
+  // opens. The ref keeps it a transition callback like the Radix one it
+  // mirrors: a parent passing an inline closure re-runs the effect on every
+  // render, and the drawers start closed.
+  const anyDrawerOpen = accessOpen || profileOpen || compactOpen;
   const notifiedOpenRef = useRef(false);
   useEffect(() => {
     if (notifiedOpenRef.current === anyDrawerOpen) {

--- a/clients/web/src/domains/chat/components/composer-settings-menu.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.tsx
@@ -73,12 +73,27 @@ interface Props {
    * single instance whose hamburger menu carries both sections.
    */
   segments?: "both" | "access" | "profile";
+  /**
+   * `"icon"` renders the composer action-row triggers: icon-only on mobile,
+   * icon plus label on desktop. `"labeled-pill"` renders both segments as
+   * filled rounded chips carrying their resolved label, for the pill row that
+   * floats above the mobile composer.
+   */
+  triggerVariant?: "icon" | "labeled-pill";
+  /**
+   * Called with whether either of this instance's drawers is open. A parent
+   * that positions the triggers itself uses it to hold that surface visible
+   * while focus sits inside the drawer's portal.
+   */
+  onOpenChange?: (open: boolean) => void;
 }
 
 export function ComposerSettingsMenu({
   assistantId,
   conversationId,
   segments = "both",
+  triggerVariant = "icon",
+  onOpenChange,
 }: Props) {
   const isMobile = useIsMobile();
   const isTouchMobile = useTouchMobile();
@@ -94,6 +109,21 @@ export function ComposerSettingsMenu({
   const [accessOpen, setAccessOpen] = useState(false);
   const [profileOpen, setProfileOpen] = useState(false);
   const [compactOpen, setCompactOpen] = useState(false);
+
+  // Both flags are set from several places (trigger, row selection, quick
+  // add), so the notification reads the settled pair once instead of being
+  // threaded through every setter. The ref keeps it a transition callback like
+  // the Radix one it mirrors: a parent passing an inline closure re-runs the
+  // effect on every render, and the drawers start closed.
+  const anyDrawerOpen = accessOpen || profileOpen;
+  const notifiedOpenRef = useRef(false);
+  useEffect(() => {
+    if (notifiedOpenRef.current === anyDrawerOpen) {
+      return;
+    }
+    notifiedOpenRef.current = anyDrawerOpen;
+    onOpenChange?.(anyDrawerOpen);
+  }, [anyDrawerOpen, onOpenChange]);
 
   // ---------------------------------------------------------------------------
   // Server-state queries — replace the old useEffect + async IIFE pattern.
@@ -558,11 +588,29 @@ export function ComposerSettingsMenu({
     "[--vbtn-fg:var(--content-tertiary)] touch-mobile:[--vbtn-fg:var(--content-tertiary)] data-[state=open]:bg-[color-mix(in_srgb,var(--primary-second-hover)_15%,transparent)]";
   const triggerLabelClass = "gap-1.5 px-1.5 text-body-small-default";
 
+  // Labeled pills carry their own fill because they float on the chat
+  // background rather than sitting inside the composer card, so the action
+  // row's transparent ghost chrome would leave them unreadable there.
+  const labeledPill = triggerVariant === "labeled-pill";
+  const pillClass =
+    "h-8 min-w-0 rounded-full bg-[var(--surface-lift)] pl-1.5 pr-2 text-body-small-default [--vbtn-fg:var(--content-secondary)] hover:bg-[var(--surface-active)] active:bg-[var(--surface-active)] data-[state=open]:bg-[var(--surface-active)]";
+  const pillIconClass = "h-3.5 w-3.5 shrink-0 text-[var(--content-tertiary)]";
+
   // Access trigger — icon plus, on desktop, the active preset's name
   // (Figma 7471-25243). Mobile stays icon-only to keep the bottom bar
   // compact; there the label lives in the tooltip and the sheet.
   const accessLabel = `Assistant access: ${activePreset.label}`;
-  const accessTrigger = isMobile ? (
+  const accessTrigger = labeledPill ? (
+    <Button
+      variant="ghost"
+      leftIcon={<AccessIcon className={pillIconClass} />}
+      aria-label={accessLabel}
+      title={accessLabel}
+      className={pillClass}
+    >
+      {activePreset.label}
+    </Button>
+  ) : isMobile ? (
     <Button
       variant="ghost"
       iconOnly={<AccessIcon />}
@@ -589,8 +637,27 @@ export function ComposerSettingsMenu({
   const profileLabel = activeProfileLabel
     ? `Model profile: ${activeProfileLabel}`
     : "Model profile";
+  // min-w-0 + truncate keeps a long label from pushing the composer's action
+  // buttons off-screen on narrow viewports. leading-snug: text-body-small-default
+  // is line-height:1, so truncate clips descenders (e.g. the "g" in profile
+  // names).
+  const profileLabelText = (
+    <span className="max-w-[10rem] truncate leading-snug">
+      {activeProfileLabel}
+    </span>
+  );
   const profileTrigger =
-    isMobile || !activeProfileLabel ? (
+    labeledPill && activeProfileLabel ? (
+      <Button
+        variant="ghost"
+        leftIcon={<Sparkles className={pillIconClass} />}
+        aria-label="Model profile"
+        title={profileLabel}
+        className={pillClass}
+      >
+        {profileLabelText}
+      </Button>
+    ) : isMobile || !activeProfileLabel ? (
       <Button
         variant="ghost"
         iconOnly={activeProfileLabel ? <Sparkles /> : <SlidersHorizontal />}
@@ -606,13 +673,7 @@ export function ComposerSettingsMenu({
         title={profileLabel}
         className={`${triggerClass} ${triggerLabelClass} min-w-0`}
       >
-        {/* min-w-0 + truncate keeps a long label from pushing the composer's
-            action buttons off-screen on narrow viewports. leading-snug:
-            text-body-small-default is line-height:1, so truncate clips
-            descenders (e.g. the "g" in profile names). */}
-        <span className="max-w-[10rem] truncate leading-snug">
-          {activeProfileLabel}
-        </span>
+        {profileLabelText}
       </Button>
     );
 

--- a/clients/web/src/domains/chat/components/composer-settings-menu.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.tsx
@@ -110,23 +110,6 @@ export function ComposerSettingsMenu({
   const [profileOpen, setProfileOpen] = useState(false);
   const [compactOpen, setCompactOpen] = useState(false);
 
-  // All three flags are set from several places (trigger, row selection, quick
-  // add), so the notification reads the settled trio once instead of being
-  // threaded through every setter. `compactOpen` counts too: the compact branch
-  // renders a single hamburger whose menu is the only surface this instance
-  // opens. The ref keeps it a transition callback like the Radix one it
-  // mirrors: a parent passing an inline closure re-runs the effect on every
-  // render, and the drawers start closed.
-  const anyDrawerOpen = accessOpen || profileOpen || compactOpen;
-  const notifiedOpenRef = useRef(false);
-  useEffect(() => {
-    if (notifiedOpenRef.current === anyDrawerOpen) {
-      return;
-    }
-    notifiedOpenRef.current = anyDrawerOpen;
-    onOpenChange?.(anyDrawerOpen);
-  }, [anyDrawerOpen, onOpenChange]);
-
   // ---------------------------------------------------------------------------
   // Server-state queries — replace the old useEffect + async IIFE pattern.
   // Each query shares its TanStack Query cache entry with the rest of the app.
@@ -582,6 +565,43 @@ export function ComposerSettingsMenu({
   const showAccess = accessSettled && segments !== "profile";
   const showProfile = segments !== "access";
 
+  // Only the branch this render mounts can hold an open surface: the compact
+  // hamburger owns `compactOpen`, the split layout owns whichever of
+  // access/profile it renders. Crossing the compact width (or losing a segment)
+  // unmounts the open branch without React clearing its flag, so the report
+  // below reads the mounted branch only.
+  const anyDrawerOpen = compact
+    ? compactOpen
+    : (showAccess && accessOpen) || (showProfile && profileOpen);
+
+  // Clear the flags the mounted branch doesn't own, so crossing back doesn't
+  // reopen a surface the user left behind at the old width.
+  useEffect(() => {
+    if (compact || !showAccess) {
+      setAccessOpen(false);
+    }
+    if (compact || !showProfile) {
+      setProfileOpen(false);
+    }
+    if (!compact) {
+      setCompactOpen(false);
+    }
+  }, [compact, showAccess, showProfile]);
+
+  // The flags are set from several places (trigger, row selection, quick add),
+  // so the notification reads the settled value once instead of being threaded
+  // through every setter. The ref keeps it a transition callback like the Radix
+  // one it mirrors: a parent passing an inline closure re-runs the effect on
+  // every render, and the drawers start closed.
+  const notifiedOpenRef = useRef(false);
+  useEffect(() => {
+    if (notifiedOpenRef.current === anyDrawerOpen) {
+      return;
+    }
+    notifiedOpenRef.current = anyDrawerOpen;
+    onOpenChange?.(anyDrawerOpen);
+  }, [anyDrawerOpen, onOpenChange]);
+
   // Each trigger is the design library's ghost Button — same chrome and
   // sizing as the row's other icon buttons (attach, mic) — in the action
   // row's tertiary resting tone, held open-highlighted while its own menu
@@ -636,6 +656,10 @@ export function ComposerSettingsMenu({
   // (the label lives in the sheet there), matching the access trigger.
   // Falls back to the sliders icon until the active profile resolves so
   // there's always an affordance to open it.
+  // `profileLabel` is the accessible name on every variant, mirroring
+  // `accessLabel`: an aria-label overrides the visible text, so it has to carry
+  // the selection a labelled trigger shows, or the name says nothing about it
+  // and voice control can't reach the control by what it reads.
   const profileLabel = activeProfileLabel
     ? `Model profile: ${activeProfileLabel}`
     : "Model profile";
@@ -653,7 +677,7 @@ export function ComposerSettingsMenu({
       <Button
         variant="ghost"
         leftIcon={<Sparkles className={pillIconClass} />}
-        aria-label="Model profile"
+        aria-label={profileLabel}
         title={profileLabel}
         className={pillClass}
       >
@@ -663,7 +687,7 @@ export function ComposerSettingsMenu({
       <Button
         variant="ghost"
         iconOnly={activeProfileLabel ? <Sparkles /> : <SlidersHorizontal />}
-        aria-label="Model profile"
+        aria-label={profileLabel}
         title={profileLabel}
         className={triggerClass}
       />
@@ -671,7 +695,7 @@ export function ComposerSettingsMenu({
       <Button
         variant="ghost"
         leftIcon={<Sparkles className="h-3.5 w-3.5 shrink-0" />}
-        aria-label="Model profile"
+        aria-label={profileLabel}
         title={profileLabel}
         className={`${triggerClass} ${triggerLabelClass} min-w-0`}
       >


### PR DESCRIPTION
## Summary
- Adds an opt-in labeled-pill trigger variant (icon + resolved label) to ComposerSettingsMenu for the mobile composer redesign
- Adds an onOpenChange callback exposing whether any of the instance's drawers is open
- Existing icon triggers and the access/profile bottom sheets are unchanged

Part of plan: mobile-composer-redesign.md (PR 4 of 6)