### PR TITLE
feat(ios): Control Center control that opens the app

### DIFF
--- a/clients/ios/App/App/Shared/OpenVellumIntent.swift
+++ b/clients/ios/App/App/Shared/OpenVellumIntent.swift
@@ -1,0 +1,35 @@
+import AppIntents
+
+/// "Open Vellum": bring the app to the foreground, nothing more.
+///
+/// The action behind `OpenVellumControl`, the one-tap app launcher in Control
+/// Center and the Lock Screen. It deliberately carries no deep link: opening
+/// the app lands wherever the user left it, exactly as tapping the home-screen
+/// icon does, so there is no second launch destination to keep in sync with
+/// the web layer.
+///
+/// Lives in `Shared/` (compiled into the app *and* the VoiceActivity
+/// extension) rather than in `Intents/`, because `OpenVellumControl` builds a
+/// `ControlWidgetButton` around this exact type and a control is code in the
+/// appex. The launch-mode declarations below make the system perform the
+/// intent in the app process, so the appex's copy of `perform()` never runs.
+struct OpenVellumIntent: AppIntent {
+    static var title: LocalizedStringResource = "Open Vellum"
+    static var description = IntentDescription(
+        "Open Vellum and pick up where you left off."
+    )
+
+    /// Both launch-mode declarations are load-bearing; do not "clean this up".
+    /// `supportedModes` is the current API but is itself iOS 26.0+, while
+    /// `openAppWhenRun` is what launches the app on 17.0 through 25.x.
+    /// `.foreground(.immediate)` is the documented exact equivalent, so the
+    /// two agree. See `docs/NATIVE_VOICE.md` for the full explanation.
+    @available(iOS 26.0, *)
+    static var supportedModes: IntentModes { .foreground(.immediate) }
+
+    static var openAppWhenRun: Bool { true }
+
+    func perform() async throws -> some IntentResult {
+        return .result()
+    }
+}

--- a/clients/ios/App/VoiceActivity/Assets.xcassets/Contents.json
+++ b/clients/ios/App/VoiceActivity/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/clients/ios/App/VoiceActivity/Assets.xcassets/VellumV.symbolset/Contents.json
+++ b/clients/ios/App/VoiceActivity/Assets.xcassets/VellumV.symbolset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "symbols" : [
+    {
+      "filename" : "VellumV.svg",
+      "idiom" : "universal"
+    }
+  ]
+}

--- a/clients/ios/App/VoiceActivity/Assets.xcassets/VellumV.symbolset/VellumV.svg
+++ b/clients/ios/App/VoiceActivity/Assets.xcassets/VellumV.symbolset/VellumV.svg
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Custom SF Symbol template for the Vellum "V" brand glyph, used by the
+  Control Center control (OpenVellumControl). The path is the same letterform
+  as App/AppIcon*.icon/Assets/white-V.svg (a 92x92 viewBox), uniformly scaled
+  so its 92pt height fills the 400pt capline-to-baseline band of each size
+  and centered at x=1650. Regenerate by re-deriving the six path points from
+  white-V.svg if the brand mark ever changes: x' = 1650 + (x - 46) * s,
+  y' = capline + y * s, with s = 400 / 92.
+-->
+<svg width="3300" height="2200" viewBox="0 0 3300 2200" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <g id="Notes">
+    <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" x="263" y="80">template-version: 1.0</text>
+    <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" x="263" y="100">generator: hand-authored</text>
+  </g>
+  <g id="Guides">
+    <line id="Capline-S" style="fill:none;stroke:#27AAE1;stroke-width:0.5;" x1="263" y1="250" x2="3036" y2="250"/>
+    <line id="Baseline-S" style="fill:none;stroke:#27AAE1;stroke-width:0.5;" x1="263" y1="650" x2="3036" y2="650"/>
+    <line id="Capline-M" style="fill:none;stroke:#27AAE1;stroke-width:0.5;" x1="263" y1="850" x2="3036" y2="850"/>
+    <line id="Baseline-M" style="fill:none;stroke:#27AAE1;stroke-width:0.5;" x1="263" y1="1250" x2="3036" y2="1250"/>
+    <line id="Capline-L" style="fill:none;stroke:#27AAE1;stroke-width:0.5;" x1="263" y1="1450" x2="3036" y2="1450"/>
+    <line id="Baseline-L" style="fill:none;stroke:#27AAE1;stroke-width:0.5;" x1="263" y1="1850" x2="3036" y2="1850"/>
+  </g>
+  <g id="Symbols">
+    <g id="Regular-S">
+      <path d="M 1552.174 250 L 1650 460.182 L 1747.438 250 L 1845.652 250 L 1649.223 650 L 1454.348 250 Z"/>
+    </g>
+    <g id="Regular-M">
+      <path d="M 1552.174 850 L 1650 1060.182 L 1747.438 850 L 1845.652 850 L 1649.223 1250 L 1454.348 850 Z"/>
+    </g>
+    <g id="Regular-L">
+      <path d="M 1552.174 1450 L 1650 1660.182 L 1747.438 1450 L 1845.652 1450 L 1649.223 1850 L 1454.348 1450 Z"/>
+    </g>
+  </g>
+</svg>

--- a/clients/ios/App/VoiceActivity/OpenVellumControl.swift
+++ b/clients/ios/App/VoiceActivity/OpenVellumControl.swift
@@ -1,0 +1,44 @@
+import AppIntents
+import SwiftUI
+import WidgetKit
+
+/// One-tap "Open Vellum" for Control Center and the Lock Screen.
+///
+/// The app-launcher control other chat apps ship: tap the logo, be in the
+/// app. The action is `OpenVellumIntent`, which does nothing beyond
+/// foregrounding the app; state (which conversation, which screen) is the
+/// app's to restore, not the control's to dictate.
+///
+/// Title and gallery copy are read off the intent rather than restated, so
+/// the control cannot drift into reading like a different action in Control
+/// Center than it does in the Shortcuts app.
+///
+/// The glyph is the custom `VellumV` symbol (`Assets.xcassets` in this
+/// extension), the same "V" every app icon variant draws. A control is
+/// identified by its glyph alone once placed, and no system symbol reads as
+/// Vellum.
+///
+/// **iOS 18+.** `ControlWidget` did not exist before then and the app deploys
+/// to 17.0, so this is availability-gated exactly like `StartVoiceControl`:
+/// on 17.x the app installs and behaves as before, there is simply no control
+/// in the gallery.
+@available(iOS 18.0, *)
+struct OpenVellumControl: ControlWidget {
+    /// Stable identity for this control. iOS keys a user's placements off it,
+    /// so changing it orphans every control the user has already placed.
+    private static let kind = "open-app"
+
+    var body: some ControlWidgetConfiguration {
+        StaticControlConfiguration(kind: Self.kind) {
+            ControlWidgetButton(action: OpenVellumIntent()) {
+                Label {
+                    Text(OpenVellumIntent.title)
+                } icon: {
+                    Image("VellumV")
+                }
+            }
+        }
+        .displayName(OpenVellumIntent.title)
+        .description(OpenVellumIntent.description.descriptionText)
+    }
+}

--- a/clients/ios/App/VoiceActivity/VoiceActivityBundle.swift
+++ b/clients/ios/App/VoiceActivity/VoiceActivityBundle.swift
@@ -3,24 +3,27 @@ import WidgetKit
 
 /// Widget bundle entry point for the VoiceActivity extension.
 ///
-/// Two members: the live-voice Live Activity (`VoiceSessionLiveActivity.swift`)
-/// and the Control Center / Lock Screen control (`StartVoiceControl.swift`). A
-/// `WidgetBundle` can hold home-screen widgets alongside them, so anything
-/// added later joins this list rather than needing another extension target.
+/// Three members: the live-voice Live Activity
+/// (`VoiceSessionLiveActivity.swift`) and two Control Center / Lock Screen
+/// controls, one starting a voice conversation (`StartVoiceControl.swift`) and
+/// one opening the app (`OpenVellumControl.swift`). A `WidgetBundle` can hold
+/// home-screen widgets alongside them, so anything added later joins this list
+/// rather than needing another extension target.
 ///
-/// The control is `@available(iOS 18.0, *)` while the app deploys to 17.0, so
-/// it is listed under an `#available` check — the one shape that works here.
-/// `WidgetBundleBuilder.buildOptional` is `@available(*, unavailable)` for a
-/// plain `if`, and its overload accepting a `ControlWidget` exists only on
-/// iOS 18+, so an `#available` block is what routes the control through it.
-/// Listing the control unconditionally would not compile, and annotating the
-/// *bundle* instead would drag the Live Activity up to iOS 18 with it.
+/// The controls are `@available(iOS 18.0, *)` while the app deploys to 17.0,
+/// so they are listed under an `#available` check, the one shape that works
+/// here. `WidgetBundleBuilder.buildOptional` is `@available(*, unavailable)`
+/// for a plain `if`, and its overloads accepting a `ControlWidget` exist only
+/// on iOS 18+, so an `#available` block is what routes the controls through
+/// them. Listing a control unconditionally would not compile, and annotating
+/// the *bundle* instead would drag the Live Activity up to iOS 18 with it.
 @main
 struct VoiceActivityBundle: WidgetBundle {
     var body: some Widget {
         VoiceSessionLiveActivity()
         if #available(iOS 18.0, *) {
             StartVoiceControl()
+            OpenVellumControl()
         }
     }
 }

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -718,7 +718,7 @@ clients/
     │   │   ├── Shared/               # Compiled into app + widget extension
     │   │   └── Info.plist
     │   ├── VoiceActivity/            # WidgetKit extension: Live Activity
-    │   │                             # presentations + Control Center control
+    │   │                             # presentations + Control Center controls
     │   └── CapApp-SPM/               # SPM local package: pulls in @capacitor/ios
     │                                 # and any Capacitor plugin native deps
     └── debug.xcconfig                # Sets CAPACITOR_DEBUG for Debug builds

--- a/clients/ios/docs/NATIVE_VOICE.md
+++ b/clients/ios/docs/NATIVE_VOICE.md
@@ -22,7 +22,7 @@ exactly four things:
 | --- | --- |
 | `VoiceAudioSessionPlugin` | Owns `AVAudioSession` for the duration of a session (`.playAndRecord` / `.voiceChat`), and reports interruptions |
 | `VoiceLiveActivityPlugin` | Requests, updates, and ends the one ActivityKit activity mirroring the session |
-| `VoiceActivity` widget extension | Renders that activity on the Lock Screen and in the Dynamic Island, plus the Control Center control |
+| `VoiceActivity` widget extension | Renders that activity on the Lock Screen and in the Dynamic Island, plus the Control Center controls (the voice one below, and the non-voice "Open Vellum" app launcher) |
 | App Intents + `AppShortcutsProvider` | Turn a Siri phrase, a Spotlight hit, an Action Button press, or a control tap into a `<scheme>://voice` URL |
 
 Everything native is *additive*. Remove all of it and voice still works — that
@@ -762,7 +762,7 @@ agree character for character across the portal, the xcconfigs, and
 | `App/App/Shared/StartNewVoiceConversationIntent.swift` | In `Shared/` because the Control Center control needs the type |
 | `App/App/Shared/VoiceSessionControlIntent.swift` | The intent behind every island button; in `Shared/` so the appex can name it |
 | `App/App/Intents/` | The other two intents and `VoiceAppShortcuts` |
-| `App/VoiceActivity/` | Widget extension: bundle, Live Activity, island views, Control Center control |
+| `App/VoiceActivity/` | Widget extension: bundle, Live Activity, island views, Control Center controls |
 | `App/App/Config/Extension*.xcconfig` | Extension build settings; bundle IDs, schemes, profile specifiers |
 | `App/project.yml` | Six targets, `VOICE_ACTIVITY_EXTENSION`, embed relationships |
 


### PR DESCRIPTION
Summary:
Adds an "Open Vellum" Control Center / Lock Screen control to the iOS app (iOS 18+), the same one-tap app launcher other chat apps ship: tap the V, be in the app. It rides the existing VoiceActivity widget extension, so there are no new targets, entitlements, or provisioning profiles.

Changes:
- Add `OpenVellumIntent` in `App/Shared/` (compiled into app + appex): foregrounds the app with no deep link, using the documented `openAppWhenRun` + `supportedModes` dual declaration
- Add `OpenVellumControl`, an iOS 18+ `ControlWidget` with stable kind `open-app`, registered in `VoiceActivityBundle` under the existing `#available(iOS 18.0, *)` gate
- Add a hand-authored `VellumV` custom SF Symbol (new `Assets.xcassets` in the extension), derived from the app icon's `white-V.svg`, so the control shows the brand mark rather than a generic system glyph
- Pluralize "Control Center control" in `README.md` / `docs/NATIVE_VOICE.md` where the extension's contents are enumerated

Testing:
- `VoiceActivity Dev` extension target and the full `App Dev` scheme both build for the simulator locally (after `bun run ios:setup`)
- `xcrun assetutil --info` on the built appex's `Assets.car` confirms the symbol compiled into proper Vector Glyph renditions (Small/Medium/Large), so actool accepted the hand-authored template
- Outstanding manual QA on an iOS 18+ simulator/device with a normally signed build: add the control from the Control Center gallery, tap it, and check the glyph in light/dark (unsigned `CODE_SIGNING_ALLOWED=NO` installs silently drop widget extensions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)