### PR TITLE
feat(web): add "Add to chat" bottom sheet with Camera, Gallery, and Files pickers

### DIFF
--- a/clients/web/eslint.config.mjs
+++ b/clients/web/eslint.config.mjs
@@ -191,6 +191,7 @@ const authBoundaryAllowedPaths = [
  */
 const i18nEnforcedPaths = [
   "src/components/not-found.tsx",
+  "src/domains/chat/components/chat-composer/add-to-chat-sheet.tsx",
   "src/domains/chat/components/conversation-assets-pill.tsx",
   "src/domains/chat/components/pinned-app-color-swatches.tsx",
   "src/domains/chat/components/sidebar-conversation-error.tsx",

--- a/clients/web/src/domains/chat/components/chat-composer/add-to-chat-sheet.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/add-to-chat-sheet.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * Tests for the mobile "Add to chat" bottom sheet.
+ *
+ * Mounted with `@testing-library/react` (happy-dom, see
+ * `clients/web/test-setup.ts`). The real Radix `BottomSheet` only mounts its
+ * content while open and renders it into a portal, so the design-library
+ * surface is mocked to render inline: the rows are always in the DOM and
+ * clickable, and the mocked `Content` carries a testid so a test can assert
+ * the hidden file inputs sit OUTSIDE it.
+ */
+
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+
+const passthrough = ({ children, ...props }: Record<string, unknown>) =>
+  createElement("div", props, children as ReactNode);
+
+mock.module("@vellumai/design-library", () => ({
+  BottomSheet: {
+    Root: ({
+      children,
+      open: _open,
+      onOpenChange: _onOpenChange,
+      ...props
+    }: Record<string, unknown>) =>
+      createElement("div", props, children as ReactNode),
+    Content: ({
+      children,
+      padded: _padded,
+      ...props
+    }: Record<string, unknown>) =>
+      createElement(
+        "div",
+        { "data-testid": "sheet-content", ...props },
+        children as ReactNode,
+      ),
+    Header: passthrough,
+    Title: passthrough,
+    Body: passthrough,
+    Close: ({ children, ...props }: Record<string, unknown>) =>
+      createElement(
+        "button",
+        { type: "button", ...props },
+        children as ReactNode,
+      ),
+  },
+}));
+
+import { AddToChatSheet } from "@/domains/chat/components/chat-composer/add-to-chat-sheet";
+
+afterAll(() => {
+  mock.restore();
+});
+afterEach(() => {
+  cleanup();
+});
+
+function renderSheet(
+  props: Partial<Parameters<typeof AddToChatSheet>[0]> = {},
+) {
+  const onOpenChange = mock((_open: boolean) => {});
+  const onAttachFiles = mock((_files: FileList) => {});
+  const result = render(
+    <AddToChatSheet
+      open
+      onOpenChange={onOpenChange}
+      onAttachFiles={onAttachFiles}
+      {...props}
+    />,
+  );
+  const inputs = Array.from(
+    result.container.querySelectorAll<HTMLInputElement>('input[type="file"]'),
+  );
+  const [camera, gallery, files] = inputs;
+  return { ...result, onOpenChange, onAttachFiles, camera, gallery, files };
+}
+
+describe("AddToChatSheet", () => {
+  test("renders the three attach rows", () => {
+    renderSheet();
+
+    expect(screen.getByText("Camera")).toBeTruthy();
+    expect(screen.getByText("Find in Gallery")).toBeTruthy();
+    expect(screen.getByText("Files")).toBeTruthy();
+  });
+
+  test("keeps the hidden inputs outside the sheet content", () => {
+    renderSheet();
+
+    // The inputs must survive the sheet content unmounting while the native
+    // picker is still up, so they cannot live inside the dialog.
+    const inside = screen
+      .getByTestId("sheet-content")
+      .querySelectorAll('input[type="file"]');
+    expect(inside.length).toBe(0);
+  });
+
+  test("tapping Files closes the sheet and opens its picker", () => {
+    const { onOpenChange, files } = renderSheet();
+    const clicked = mock(() => {});
+    files.addEventListener("click", clicked);
+
+    fireEvent.click(screen.getByText("Files"));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(clicked).toHaveBeenCalledTimes(1);
+  });
+
+  test("delivers picked files to onAttachFiles", () => {
+    const { onAttachFiles, gallery } = renderSheet();
+    const file = new File(["hi"], "photo.png", { type: "image/png" });
+    const picked = [file] as unknown as FileList;
+    Object.defineProperty(gallery, "files", {
+      configurable: true,
+      value: picked,
+    });
+
+    fireEvent.change(gallery);
+
+    expect(onAttachFiles).toHaveBeenCalledTimes(1);
+    expect(onAttachFiles.mock.calls[0]?.[0]).toBe(picked);
+  });
+
+  test("camera input asks for the rear camera and images only", () => {
+    const { camera } = renderSheet();
+
+    expect(camera.getAttribute("accept")).toBe("image/*");
+    expect(camera.getAttribute("capture")).toBe("environment");
+    expect(camera.multiple).toBe(false);
+  });
+
+  test("gallery input takes multiple images, files input mirrors the paperclip", () => {
+    const { gallery, files } = renderSheet();
+
+    expect(gallery.getAttribute("accept")).toBe("image/*,video/*");
+    expect(gallery.hasAttribute("capture")).toBe(false);
+    expect(gallery.multiple).toBe(true);
+
+    expect(files.hasAttribute("accept")).toBe(false);
+    expect(files.hasAttribute("capture")).toBe(false);
+    expect(files.multiple).toBe(true);
+  });
+});

--- a/clients/web/src/domains/chat/components/chat-composer/add-to-chat-sheet.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/add-to-chat-sheet.tsx
@@ -1,0 +1,131 @@
+import { BottomSheet } from "@vellumai/design-library";
+import {
+  Camera,
+  File as FileIcon,
+  Image as ImageIcon,
+  X,
+  type LucideIcon,
+} from "lucide-react";
+
+import { useAttachmentFilePicker } from "@/domains/chat/components/chat-attachments/use-attachment-file-picker";
+
+interface AddToChatRowProps {
+  icon: LucideIcon;
+  label: string;
+  onSelect: () => void;
+}
+
+function AddToChatRow({ icon: Icon, label, onSelect }: AddToChatRowProps) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className="flex w-full items-center gap-3 rounded-[8px] text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--primary-base)]"
+    >
+      <span className="flex size-10 shrink-0 items-center justify-center rounded-full bg-[var(--border-subtle)]">
+        <Icon className="size-4 text-[var(--content-secondary)]" />
+      </span>
+      <span className="min-w-0 truncate text-body-large-default text-[var(--content-default)]">
+        {label}
+      </span>
+    </button>
+  );
+}
+
+interface AddToChatSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Receives the files picked from any of the three rows. */
+  onAttachFiles: (files: FileList) => void;
+}
+
+/**
+ * Mobile "Add to chat" bottom sheet: Camera, Find in Gallery, and Files, each
+ * backed by its own hidden `<input type="file">`.
+ *
+ * The three inputs render as siblings of `BottomSheet.Root`, outside the
+ * dialog portal. A row tap closes the sheet before opening the native picker,
+ * so an input mounted inside the sheet content would unmount while its picker
+ * was still on screen and the selection would never reach `onAttachFiles`.
+ * They sit in a zero-size positioned box because the hook lays each input out
+ * as `absolute inset-0`, which would otherwise stretch across whichever
+ * positioned ancestor the sheet happens to be mounted under.
+ */
+export function AddToChatSheet({
+  open,
+  onOpenChange,
+  onAttachFiles,
+}: AddToChatSheetProps) {
+  const camera = useAttachmentFilePicker({
+    onFiles: onAttachFiles,
+    accept: "image/*",
+    capture: "environment",
+  });
+  const gallery = useAttachmentFilePicker({
+    onFiles: onAttachFiles,
+    accept: "image/*,video/*",
+    multiple: true,
+  });
+  const files = useAttachmentFilePicker({
+    onFiles: onAttachFiles,
+    multiple: true,
+  });
+
+  const closeThenPick = (openPicker: () => void) => () => {
+    onOpenChange(false);
+    openPicker();
+  };
+
+  return (
+    <>
+      <div className="relative h-0 w-0">
+        {camera.inputNode}
+        {gallery.inputNode}
+        {files.inputNode}
+      </div>
+      <BottomSheet.Root open={open} onOpenChange={onOpenChange}>
+        <BottomSheet.Content
+          aria-describedby={undefined}
+          padded={false}
+          // Three rows and a header already read as a sheet, so it hugs its
+          // content instead of the primitive's default floor.
+          className="min-h-0 pt-2 pb-[calc(8px+var(--safe-area-inset-bottom,env(safe-area-inset-bottom,0px)))]"
+        >
+          <span
+            aria-hidden="true"
+            className="mx-auto h-1 w-14 shrink-0 rounded-full bg-[var(--border-element)]"
+          />
+          <BottomSheet.Header className="flex-row items-center justify-between gap-2 px-4 pt-3 pb-2">
+            <BottomSheet.Title className="text-body-large-default text-[var(--content-tertiary)]">
+              Add to chat
+            </BottomSheet.Title>
+            {/* `-m-2 p-2` grows the tap target without moving the glyph. */}
+            <BottomSheet.Close
+              aria-label="Close"
+              className="-m-2 flex shrink-0 items-center justify-center p-2 text-[var(--content-tertiary)]"
+            >
+              <X className="size-4" />
+            </BottomSheet.Close>
+          </BottomSheet.Header>
+          <BottomSheet.Body className="flex flex-col gap-4 px-4 pt-3 pb-4">
+            <AddToChatRow
+              icon={Camera}
+              label="Camera"
+              onSelect={closeThenPick(camera.openPicker)}
+            />
+            <AddToChatRow
+              icon={ImageIcon}
+              label="Find in Gallery"
+              onSelect={closeThenPick(gallery.openPicker)}
+            />
+            <AddToChatRow
+              icon={FileIcon}
+              label="Files"
+              onSelect={closeThenPick(files.openPicker)}
+            />
+          </BottomSheet.Body>
+        </BottomSheet.Content>
+      </BottomSheet.Root>
+    </>
+  );
+}

--- a/clients/web/src/domains/chat/components/chat-composer/add-to-chat-sheet.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/add-to-chat-sheet.tsx
@@ -8,6 +8,7 @@ import {
 } from "lucide-react";
 
 import { useAttachmentFilePicker } from "@/domains/chat/components/chat-attachments/use-attachment-file-picker";
+import { useTranslation } from "@/i18n";
 
 interface AddToChatRowProps {
   icon: LucideIcon;
@@ -56,6 +57,7 @@ export function AddToChatSheet({
   onOpenChange,
   onAttachFiles,
 }: AddToChatSheetProps) {
+  const { t } = useTranslation("chat");
   const camera = useAttachmentFilePicker({
     onFiles: onAttachFiles,
     accept: "image/*",
@@ -97,11 +99,11 @@ export function AddToChatSheet({
           />
           <BottomSheet.Header className="flex-row items-center justify-between gap-2 px-4 pt-3 pb-2">
             <BottomSheet.Title className="text-body-large-default text-[var(--content-tertiary)]">
-              Add to chat
+              {t("addToChatSheet.title")}
             </BottomSheet.Title>
             {/* `-m-2 p-2` grows the tap target without moving the glyph. */}
             <BottomSheet.Close
-              aria-label="Close"
+              aria-label={t("addToChatSheet.closeAriaLabel")}
               className="-m-2 flex shrink-0 items-center justify-center p-2 text-[var(--content-tertiary)]"
             >
               <X className="size-4" />
@@ -110,17 +112,17 @@ export function AddToChatSheet({
           <BottomSheet.Body className="flex flex-col gap-4 px-4 pt-3 pb-4">
             <AddToChatRow
               icon={Camera}
-              label="Camera"
+              label={t("addToChatSheet.camera")}
               onSelect={closeThenPick(camera.openPicker)}
             />
             <AddToChatRow
               icon={ImageIcon}
-              label="Find in Gallery"
+              label={t("addToChatSheet.gallery")}
               onSelect={closeThenPick(gallery.openPicker)}
             />
             <AddToChatRow
               icon={FileIcon}
-              label="Files"
+              label={t("addToChatSheet.files")}
               onSelect={closeThenPick(files.openPicker)}
             />
           </BottomSheet.Body>

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -1,4 +1,11 @@
 {
+  "addToChatSheet": {
+    "title": "Add to chat",
+    "closeAriaLabel": "Close",
+    "camera": "Camera",
+    "gallery": "Find in Gallery",
+    "files": "Files"
+  },
   "conversationAssets": {
     "heading": "Assets",
     "label": "{count, plural, one {# asset} other {# assets}}",

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -1,4 +1,11 @@
 {
+  "addToChatSheet": {
+    "title": "Añadir al chat",
+    "closeAriaLabel": "Cerrar",
+    "camera": "Cámara",
+    "gallery": "Buscar en la galería",
+    "files": "Archivos"
+  },
   "conversationAssets": {
     "heading": "Recursos",
     "label": "{count, plural, one {# recurso} other {# recursos}}",


### PR DESCRIPTION
## Summary
- New AddToChatSheet bottom sheet (Camera, Find in Gallery, Files) built on the design-library BottomSheet and the useAttachmentFilePicker hook
- Hidden pickers stay mounted outside the sheet content so native pickers resolve after the sheet closes
- Not mounted anywhere yet; PR 6 wires it to the mobile composer plus button

Part of plan: mobile-composer-redesign.md (PR 3 of 6)