### PR TITLE
feat(web): show access and profile pills above the mobile composer only while focused

### DIFF
--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -614,6 +614,26 @@ type RenderComposerProps = Partial<Parameters<typeof ChatComposer>[0]> & {
   canSendAttachments?: boolean;
 };
 
+/** The composer under its default props, for `render` and `rerender` alike. */
+function composerElement(
+  props: Partial<Parameters<typeof ChatComposer>[0]> = {},
+) {
+  return (
+    <ChatComposer
+      placeholder="Custom placeholder"
+      onSubmit={() => {}}
+      inputRef={createRef<HTMLTextAreaElement>()}
+      typingDisabled={false}
+      sendDisabled={false}
+      onAddAttachmentFiles={() => {}}
+      onStopGenerating={() => {}}
+      isAssistantBusy={false}
+      assistantId="asst_test"
+      {...props}
+    />
+  );
+}
+
 /**
  * Mount the composer and hand back the testing-library result, for cases that
  * drive events at the mounted DOM. Cases that only read the rendered surface
@@ -635,20 +655,7 @@ function renderComposerView(props: RenderComposerProps = {}) {
       chatAttachments ??
       seedAttachments(attachmentsUploadingCount, canSendAttachments),
   });
-  return render(
-    <ChatComposer
-      placeholder="Custom placeholder"
-      onSubmit={() => {}}
-      inputRef={createRef<HTMLTextAreaElement>()}
-      typingDisabled={false}
-      sendDisabled={false}
-      onAddAttachmentFiles={() => {}}
-      onStopGenerating={() => {}}
-      isAssistantBusy={false}
-      assistantId="asst_test"
-      {...rest}
-    />,
-  );
+  return render(composerElement(rest));
 }
 
 function renderComposer(props: RenderComposerProps = {}) {
@@ -982,15 +989,23 @@ describe("ChatComposer: mobile settings pills row", () => {
     return renderComposerView({ ...SETTINGS_SLOTS, ...props });
   }
 
-  test("an unfocused phone composer shows neither pill anywhere", () => {
+  test("an unfocused phone composer keeps the row mounted but hidden", () => {
     // GIVEN a phone composer nobody has tapped into
     const { container } = renderPhoneComposer();
 
-    // THEN the row is absent, and the action row does not carry the pickers
-    // either: mobile moves them out of the card entirely.
-    expect(pillsRow(container)).toBeNull();
-    expect(container.innerHTML).not.toContain(">THR<");
-    expect(container.innerHTML).not.toContain(">PROFILE<");
+    // THEN the row is mounted, so each menu loads the state its pill gates on
+    // before the first focus of the session
+    const row = pillsRow(container);
+    expect(row?.textContent).toBe("THRPROFILE");
+
+    // AND it is hidden: `hidden` is display:none, which takes the resting row
+    // out of the layout, the tab order and the accessibility tree
+    expect(row?.hasAttribute("hidden")).toBe(true);
+    expect(row?.className).toBe("");
+
+    // AND the action row does not carry the pickers either: mobile moves them
+    // out of the card entirely
+    expect(container.querySelector("form")?.innerHTML).not.toContain(">THR<");
   });
 
   test("focusing the composer raises the row above the card, access first", () => {
@@ -1006,9 +1021,14 @@ describe("ChatComposer: mobile settings pills row", () => {
     expect(row?.closest("form")).toBeNull();
     const html = container.innerHTML;
     expect(html.indexOf(">THR<")).toBeLessThan(html.indexOf("<form"));
+
+    // AND it is shown, rising into place as the keyboard arrives
+    expect(row?.hasAttribute("hidden")).toBe(false);
+    expect(row?.className).toContain("animate-[fadeInUp");
+    expect(row?.className).toContain("motion-reduce:animate-none");
   });
 
-  test("blurring to the body puts the row away", () => {
+  test("blurring to the body puts the row away without unmounting its menus", () => {
     // GIVEN a focused phone composer
     const { container } = renderPhoneComposer();
     const textarea = textareaOf(container);
@@ -1017,8 +1037,10 @@ describe("ChatComposer: mobile settings pills row", () => {
     // WHEN focus leaves with nowhere to land, as the iOS keyboard dismiss does
     fireEvent.focusOut(textarea, { relatedTarget: null });
 
-    // THEN the row is gone
-    expect(pillsRow(container)).toBeNull();
+    // THEN the row is hidden again, with its menus still mounted underneath
+    const row = pillsRow(container);
+    expect(row?.hasAttribute("hidden")).toBe(true);
+    expect(row?.textContent).toBe("THRPROFILE");
   });
 
   test("an open settings sheet holds the row up after focus leaves", () => {
@@ -1031,7 +1053,24 @@ describe("ChatComposer: mobile settings pills row", () => {
     fireEvent.focusOut(textarea, { relatedTarget: null });
 
     // THEN the row the sheet was opened from stays put
-    expect(pillsRow(container)).not.toBeNull();
+    expect(pillsRow(container)?.hasAttribute("hidden")).toBe(false);
+  });
+
+  test("a sheet flag that goes false with focus gone puts the row away", () => {
+    // GIVEN a phone composer holding the row up for an open sheet, focus gone
+    const { container, rerender } = renderPhoneComposer({
+      settingsSheetOpen: true,
+    });
+    const textarea = textareaOf(container);
+    fireEvent.focusIn(textarea);
+    fireEvent.focusOut(textarea, { relatedTarget: null });
+
+    // WHEN the flag clears, as `useComposerSettingsSheets` clears it when the
+    // breakpoint swap unmounts the menu that owned the sheet
+    rerender(composerElement({ ...SETTINGS_SLOTS, settingsSheetOpen: false }));
+
+    // THEN nothing holds the row up any more
+    expect(pillsRow(container)?.hasAttribute("hidden")).toBe(true);
   });
 
   test("desktop keeps both pickers inside the action row, focused or not", () => {

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -607,14 +607,19 @@ function seedAttachments(
   return list;
 }
 
-function renderComposer(
-  props: Partial<Parameters<typeof ChatComposer>[0]> & {
-    input?: string;
-    chatAttachments?: ChatAttachment[];
-    attachmentsUploadingCount?: number;
-    canSendAttachments?: boolean;
-  } = {},
-) {
+type RenderComposerProps = Partial<Parameters<typeof ChatComposer>[0]> & {
+  input?: string;
+  chatAttachments?: ChatAttachment[];
+  attachmentsUploadingCount?: number;
+  canSendAttachments?: boolean;
+};
+
+/**
+ * Mount the composer and hand back the testing-library result, for cases that
+ * drive events at the mounted DOM. Cases that only read the rendered surface
+ * use `renderComposer` below, which returns the markup directly.
+ */
+function renderComposerView(props: RenderComposerProps = {}) {
   // The composer self-sources its draft + attachments from the store, so seed
   // them there rather than passing them as props.
   const {
@@ -630,7 +635,7 @@ function renderComposer(
       chatAttachments ??
       seedAttachments(attachmentsUploadingCount, canSendAttachments),
   });
-  const { container } = render(
+  return render(
     <ChatComposer
       placeholder="Custom placeholder"
       onSubmit={() => {}}
@@ -644,7 +649,10 @@ function renderComposer(
       {...rest}
     />,
   );
-  return container.innerHTML;
+}
+
+function renderComposer(props: RenderComposerProps = {}) {
+  return renderComposerView(props).container.innerHTML;
 }
 
 describe("ChatComposer — placeholder", () => {
@@ -944,6 +952,113 @@ describe("ChatComposer — optional slots", () => {
     // VoiceInputButton renders aria-label="Start voice input" / "Stop voice input".
     expect(html).not.toContain("Start voice input");
     expect(html).not.toContain("Stop voice input");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mobile settings pills: the focus-gated row above the card
+// ---------------------------------------------------------------------------
+
+describe("ChatComposer: mobile settings pills row", () => {
+  const SETTINGS_SLOTS = {
+    thresholdPickerSlot: <span>THR</span>,
+    modelPickerSlot: <span>PROFILE</span>,
+  };
+
+  function pillsRow(container: HTMLElement) {
+    return container.querySelector('[data-slot="composer-settings-pills"]');
+  }
+
+  function textareaOf(container: HTMLElement) {
+    const textarea = container.querySelector("textarea");
+    if (!textarea) {
+      throw new Error("composer rendered without a textarea");
+    }
+    return textarea;
+  }
+
+  function renderPhoneComposer(props: RenderComposerProps = {}) {
+    viewport.set({ narrow: true, coarsePointer: true });
+    return renderComposerView({ ...SETTINGS_SLOTS, ...props });
+  }
+
+  test("an unfocused phone composer shows neither pill anywhere", () => {
+    // GIVEN a phone composer nobody has tapped into
+    const { container } = renderPhoneComposer();
+
+    // THEN the row is absent, and the action row does not carry the pickers
+    // either: mobile moves them out of the card entirely.
+    expect(pillsRow(container)).toBeNull();
+    expect(container.innerHTML).not.toContain(">THR<");
+    expect(container.innerHTML).not.toContain(">PROFILE<");
+  });
+
+  test("focusing the composer raises the row above the card, access first", () => {
+    // GIVEN a phone composer
+    const { container } = renderPhoneComposer();
+
+    // WHEN it takes focus
+    fireEvent.focusIn(textareaOf(container));
+
+    // THEN both pills sit in one row outside the card, access before profile
+    const row = pillsRow(container);
+    expect(row?.textContent).toBe("THRPROFILE");
+    expect(row?.closest("form")).toBeNull();
+    const html = container.innerHTML;
+    expect(html.indexOf(">THR<")).toBeLessThan(html.indexOf("<form"));
+  });
+
+  test("blurring to the body puts the row away", () => {
+    // GIVEN a focused phone composer
+    const { container } = renderPhoneComposer();
+    const textarea = textareaOf(container);
+    fireEvent.focusIn(textarea);
+
+    // WHEN focus leaves with nowhere to land, as the iOS keyboard dismiss does
+    fireEvent.focusOut(textarea, { relatedTarget: null });
+
+    // THEN the row is gone
+    expect(pillsRow(container)).toBeNull();
+  });
+
+  test("an open settings sheet holds the row up after focus leaves", () => {
+    // GIVEN a phone composer whose access sheet is open
+    const { container } = renderPhoneComposer({ settingsSheetOpen: true });
+    const textarea = textareaOf(container);
+    fireEvent.focusIn(textarea);
+
+    // WHEN the sheet takes focus out of the composer
+    fireEvent.focusOut(textarea, { relatedTarget: null });
+
+    // THEN the row the sheet was opened from stays put
+    expect(pillsRow(container)).not.toBeNull();
+  });
+
+  test("desktop keeps both pickers inside the action row, focused or not", () => {
+    // GIVEN a desktop composer
+    viewport.set({ narrow: false, coarsePointer: false });
+    const { container } = renderComposerView(SETTINGS_SLOTS);
+
+    // WHEN it takes focus
+    fireEvent.focusIn(textareaOf(container));
+
+    // THEN the pickers stay in the card and no floating row is added
+    expect(pillsRow(container)).toBeNull();
+    const form = container.querySelector("form");
+    expect(form?.innerHTML).toContain(">THR<");
+    expect(form?.innerHTML).toContain(">PROFILE<");
+  });
+
+  test("a variant with no settings slots renders no row (app-editing panel)", () => {
+    // GIVEN a phone composer that was passed neither settings slot
+    viewport.set({ narrow: true, coarsePointer: true });
+    const { container } = renderComposerView();
+
+    // WHEN it takes focus
+    fireEvent.focusIn(textareaOf(container));
+
+    // THEN there is nothing to float, so no row is rendered
+    expect(pillsRow(container)).toBeNull();
   });
 });
 

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -658,10 +658,10 @@ export function ChatComposer({
   // passes neither slot (the app-editing panel) has no row to show.
   const rowThresholdPickerSlot = isMobile ? null : thresholdPickerSlot;
   const rowModelPickerSlot = isMobile ? null : modelPickerSlot;
-  const showSettingsPills =
-    isMobile &&
-    Boolean(thresholdPickerSlot || modelPickerSlot) &&
-    (composerFocusWithin || settingsSheetOpen);
+  const hasSettingsPills =
+    isMobile && Boolean(thresholdPickerSlot || modelPickerSlot);
+  const settingsPillsVisible =
+    hasSettingsPills && (composerFocusWithin || settingsSheetOpen);
 
   // No longer suppressed during a live-voice session: it was suppressed
   // because the streaming speech rendered in the ghost-suffix mirror's own
@@ -763,13 +763,26 @@ export function ChatComposer({
         </div>
       )}
       <div ref={composerShellRef} data-slot="chat-composer-shell">
-        {showSettingsPills && (
+        {hasSettingsPills && (
+          // Mounted for as long as the composer is, because each pill gates
+          // itself on server state its own menu loads (access waits on the
+          // global-threshold fetch), and a row that mounted on first focus
+          // would rise with that pill still missing. Only its visibility
+          // follows focus: `hidden` is `display: none`, which keeps the resting
+          // row out of the layout, the tab order and the accessibility tree,
+          // and lets the entrance animation run again on every reveal.
+          //
           // The row rises into place rather than appearing, since it arrives
           // with the keyboard; reduced motion keeps the placement and drops the
           // movement.
           <div
             data-slot="composer-settings-pills"
-            className="mb-3 flex animate-[fadeInUp_var(--anim-fast)_var(--anim-ease-out)_backwards] justify-end gap-1.5 motion-reduce:animate-none"
+            hidden={!settingsPillsVisible}
+            className={
+              settingsPillsVisible
+                ? "mb-3 flex animate-[fadeInUp_var(--anim-fast)_var(--anim-ease-out)_backwards] justify-end gap-1.5 motion-reduce:animate-none"
+                : undefined
+            }
           >
             {thresholdPickerSlot}
             {modelPickerSlot}

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -24,6 +24,7 @@ import {
   useComposerStore,
 } from "@/domains/chat/composer-store";
 import { useQuoteReplyStore } from "@/domains/chat/quote-reply-store";
+import { useComposerFocusWithin } from "@/domains/chat/hooks/use-composer-focus-within";
 import { ComposerDraftNotices } from "@/domains/chat/components/composer-draft-notices";
 import { StreamingWaveform } from "@/domains/chat/components/chat-composer/streaming-waveform";
 import {
@@ -152,7 +153,8 @@ export interface ChatComposerProps {
   // one. The app-editing variant, which has no voice, leaves this undefined.
   conversationId?: string | null;
 
-  // chrome surfacing existing buttons (rendered in the form's bottom-left row)
+  // chrome surfacing existing buttons (rendered in the form's bottom-left row
+  // on desktop; on mobile both settings slots move to the row above the card)
   thresholdPickerSlot?: ReactNode;
   contextWindowIndicatorSlot?: ReactNode;
   // Model-profile picker rendered on the row's right end, beside the mic
@@ -161,6 +163,11 @@ export interface ChatComposerProps {
   // below the compact card width, where `thresholdPickerSlot`'s menu absorbs
   // the profile section rather than the two triggers colliding.
   modelPickerSlot?: ReactNode;
+
+  // Whether a surface opened from one of the two settings slots is up. Opening
+  // one moves focus into a portal outside the composer, so the focus-gated
+  // mobile row needs it to stay put while the user is inside the sheet.
+  settingsSheetOpen?: boolean;
 
   // Slot rendered above the form (between the max-width wrapper and the form).
   // The main variant uses this for attachment-error / voice-error / disk-pressure
@@ -242,6 +249,7 @@ export function ChatComposer({
   conversationId,
   thresholdPickerSlot,
   modelPickerSlot,
+  settingsSheetOpen = false,
   contextWindowIndicatorSlot,
   noticesAboveFormSlot,
   hasBillingBanner = false,
@@ -505,6 +513,13 @@ export function ChatComposer({
   const compactSettings =
     useIsCompactComposerWidth(composerCardRef) && !isMobile;
 
+  // The shell wraps the pills row and the card together, so moving focus from
+  // the textarea to a pill is not a leave. `data-slot="chat-composer"` stays on
+  // the form: that is the box `composer-peek`, the onboarding tour, and the
+  // quote bubble measure.
+  const composerShellRef = useRef<HTMLDivElement>(null);
+  const composerFocusWithin = useComposerFocusWithin(composerShellRef);
+
   // Stable ref so handleSlashCommandSelect's autoSend path always calls the
   // latest onSubmit even after flushSync triggers a synchronous re-render.
   const onSubmitRef = useRef(onSubmit);
@@ -638,6 +653,16 @@ export function ChatComposer({
     !canSendMessageContent &&
     !isLiveVoiceActive;
 
+  // Mobile lifts the access and profile triggers out of the action row into a
+  // row that floats above the card while the composer is in use. A variant that
+  // passes neither slot (the app-editing panel) has no row to show.
+  const rowThresholdPickerSlot = isMobile ? null : thresholdPickerSlot;
+  const rowModelPickerSlot = isMobile ? null : modelPickerSlot;
+  const showSettingsPills =
+    isMobile &&
+    Boolean(thresholdPickerSlot || modelPickerSlot) &&
+    (composerFocusWithin || settingsSheetOpen);
+
   // No longer suppressed during a live-voice session: it was suppressed
   // because the streaming speech rendered in the ghost-suffix mirror's own
   // grid cell, and nothing renders there now. The textarea is an ordinary
@@ -737,426 +762,443 @@ export function ChatComposer({
           />
         </div>
       )}
-      <Popover.Root open={emoji.show || slash.show}>
-        <Popover.Anchor asChild>
-          <form
-            ref={composerCardRef}
-            data-slot="chat-composer"
-            onSubmit={onSubmit}
-            className={`overflow-hidden bg-[var(--surface-lift)] shadow-[0px_2px_2px_rgba(0,0,0,0.05)] ${
-              hasBillingBanner ? "rounded-b-[10px]" : COMPOSER_RADIUS_CLASS
-            }`}
+      <div ref={composerShellRef} data-slot="chat-composer-shell">
+        {showSettingsPills && (
+          // The row rises into place rather than appearing, since it arrives
+          // with the keyboard; reduced motion keeps the placement and drops the
+          // movement.
+          <div
+            data-slot="composer-settings-pills"
+            className="mb-3 flex animate-[fadeInUp_var(--anim-fast)_var(--anim-ease-out)_backwards] justify-end gap-1.5 motion-reduce:animate-none"
           >
-            {/* overflow-hidden lives here, not on the form itself: the form
-                casts the shadow above, and overflow-hidden on the same box
-                would clip that shadow along with the rounded corners. */}
-            <div
-              className={`overflow-hidden ${
+            {thresholdPickerSlot}
+            {modelPickerSlot}
+          </div>
+        )}
+        <Popover.Root open={emoji.show || slash.show}>
+          <Popover.Anchor asChild>
+            <form
+              ref={composerCardRef}
+              data-slot="chat-composer"
+              onSubmit={onSubmit}
+              className={`overflow-hidden bg-[var(--surface-lift)] shadow-[0px_2px_2px_rgba(0,0,0,0.05)] ${
                 hasBillingBanner ? "rounded-b-[10px]" : COMPOSER_RADIUS_CLASS
               }`}
             >
-              <ChatAttachmentsStrip
-                attachments={attachments}
-                onRemove={removeAttachment}
-              />
-              {/* CSS Grid hidden-mirror technique for auto-growing textarea.
+              {/* overflow-hidden lives here, not on the form itself: the form
+                casts the shadow above, and overflow-hidden on the same box
+                would clip that shadow along with the rounded corners. */}
+              <div
+                className={`overflow-hidden ${
+                  hasBillingBanner ? "rounded-b-[10px]" : COMPOSER_RADIUS_CLASS
+                }`}
+              >
+                <ChatAttachmentsStrip
+                  attachments={attachments}
+                  onRemove={removeAttachment}
+                />
+                {/* CSS Grid hidden-mirror technique for auto-growing textarea.
             A hidden div mirrors the textarea content in the same grid cell.
             The grid auto-sizes to max(mirror_height, textarea_intrinsic_height),
             so the textarea stretches to fit — no JS height measurement needed.
             This avoids the iOS WKWebView re-dispatch bug entirely: no DOM
             geometry mutation means no re-fired input events.
             Reference: https://css-tricks.com/the-cleanest-trick-for-autogrowing-textareas/ */}
-              <div className={hideTextareaRow ? "hidden" : "grid"}>
-                <div
-                  aria-hidden
-                  className="pointer-events-none col-start-1 row-start-1 overflow-hidden whitespace-pre-wrap break-words px-4 pt-3 pb-2 text-chat"
-                  style={{
-                    fontFamily: "inherit",
-                    letterSpacing: "inherit",
-                    maxHeight: `${textareaMaxHeightPx}px`,
-                  }}
-                >
-                  <span className="invisible">{input}</span>
-                  {ghostSuffix && (
-                    <span className="text-[var(--content-disabled)]">
-                      {ghostSuffix}
-                    </span>
-                  )}
-                  <span className="invisible"> </span>
-                </div>
-                <textarea
-                  ref={inputRef}
-                  value={input}
-                  autoComplete="off"
-                  data-1p-ignore
-                  data-lpignore="true"
-                  onChange={(e) => {
-                    const value = e.target.value;
-                    cursorRef.current = e.target.selectionStart ?? value.length;
-                    setInput(value);
-                    // The user has edited the text, so it's no longer a pristine
-                    // restored draft — retire the "draft restored" marker (and its
-                    // notice). Keeps `restoredDraftConversationId` an accurate
-                    // signal for "unedited restored draft" (see use-deep-link-consumer).
-                    if (
-                      useComposerStore.getState()
-                        .restoredDraftConversationId !== null
-                    ) {
-                      useComposerStore.getState().clearRestoredDraftNotice();
-                    }
-                  }}
-                  onPaste={(e) => {
-                    const items = e.clipboardData?.items;
-                    if (!items) {
-                      return;
-                    }
-                    const files: File[] = [];
-                    for (let i = 0; i < items.length; i++) {
-                      const item = items[i];
-                      if (item?.kind === "file") {
-                        const file = item.getAsFile();
-                        if (file) {
-                          files.push(file);
+                <div className={hideTextareaRow ? "hidden" : "grid"}>
+                  <div
+                    aria-hidden
+                    className="pointer-events-none col-start-1 row-start-1 overflow-hidden whitespace-pre-wrap break-words px-4 pt-3 pb-2 text-chat"
+                    style={{
+                      fontFamily: "inherit",
+                      letterSpacing: "inherit",
+                      maxHeight: `${textareaMaxHeightPx}px`,
+                    }}
+                  >
+                    <span className="invisible">{input}</span>
+                    {ghostSuffix && (
+                      <span className="text-[var(--content-disabled)]">
+                        {ghostSuffix}
+                      </span>
+                    )}
+                    <span className="invisible"> </span>
+                  </div>
+                  <textarea
+                    ref={inputRef}
+                    value={input}
+                    autoComplete="off"
+                    data-1p-ignore
+                    data-lpignore="true"
+                    onChange={(e) => {
+                      const value = e.target.value;
+                      cursorRef.current =
+                        e.target.selectionStart ?? value.length;
+                      setInput(value);
+                      // The user has edited the text, so it's no longer a pristine
+                      // restored draft, so retire the "draft restored" marker (and its
+                      // notice). Keeps `restoredDraftConversationId` an accurate
+                      // signal for "unedited restored draft" (see use-deep-link-consumer).
+                      if (
+                        useComposerStore.getState()
+                          .restoredDraftConversationId !== null
+                      ) {
+                        useComposerStore.getState().clearRestoredDraftNotice();
+                      }
+                    }}
+                    onPaste={(e) => {
+                      const items = e.clipboardData?.items;
+                      if (!items) {
+                        return;
+                      }
+                      const files: File[] = [];
+                      for (let i = 0; i < items.length; i++) {
+                        const item = items[i];
+                        if (item?.kind === "file") {
+                          const file = item.getAsFile();
+                          if (file) {
+                            files.push(file);
+                          }
                         }
                       }
-                    }
-                    if (files.length > 0) {
-                      e.preventDefault();
-                      onAddAttachmentFiles(files);
-                    }
-                  }}
-                  onKeyDown={(e) => {
-                    if (slash.show) {
-                      if (e.key === "ArrowUp") {
+                      if (files.length > 0) {
                         e.preventDefault();
-                        slash.moveUp();
-                        return;
+                        onAddAttachmentFiles(files);
                       }
-                      if (e.key === "ArrowDown") {
-                        e.preventDefault();
-                        slash.moveDown();
-                        return;
-                      }
-                      if (e.key === "Tab" || e.key === "Enter") {
-                        e.preventDefault();
-                        const cmd = slash.items[slash.selectedIndex];
-                        if (cmd) {
-                          handleSlashCommandSelect(cmd);
+                    }}
+                    onKeyDown={(e) => {
+                      if (slash.show) {
+                        if (e.key === "ArrowUp") {
+                          e.preventDefault();
+                          slash.moveUp();
+                          return;
                         }
-                        return;
-                      }
-                      if (e.key === "Escape") {
-                        e.preventDefault();
-                        slash.dismiss();
-                        setInput("");
-                        return;
-                      }
-                    }
-
-                    if (emoji.show) {
-                      if (e.key === "ArrowUp") {
-                        e.preventDefault();
-                        emoji.moveUp();
-                        return;
-                      }
-                      if (e.key === "ArrowDown") {
-                        e.preventDefault();
-                        emoji.moveDown();
-                        return;
-                      }
-                      if (e.key === "Tab" || e.key === "Enter") {
-                        e.preventDefault();
-                        const selected = emoji.items[emoji.selectedIndex];
-                        if (selected) {
-                          insertEmoji(selected);
+                        if (e.key === "ArrowDown") {
+                          e.preventDefault();
+                          slash.moveDown();
+                          return;
                         }
-                        return;
+                        if (e.key === "Tab" || e.key === "Enter") {
+                          e.preventDefault();
+                          const cmd = slash.items[slash.selectedIndex];
+                          if (cmd) {
+                            handleSlashCommandSelect(cmd);
+                          }
+                          return;
+                        }
+                        if (e.key === "Escape") {
+                          e.preventDefault();
+                          slash.dismiss();
+                          setInput("");
+                          return;
+                        }
                       }
-                      if (e.key === "Escape") {
+
+                      if (emoji.show) {
+                        if (e.key === "ArrowUp") {
+                          e.preventDefault();
+                          emoji.moveUp();
+                          return;
+                        }
+                        if (e.key === "ArrowDown") {
+                          e.preventDefault();
+                          emoji.moveDown();
+                          return;
+                        }
+                        if (e.key === "Tab" || e.key === "Enter") {
+                          e.preventDefault();
+                          const selected = emoji.items[emoji.selectedIndex];
+                          if (selected) {
+                            insertEmoji(selected);
+                          }
+                          return;
+                        }
+                        if (e.key === "Escape") {
+                          e.preventDefault();
+                          emoji.dismiss();
+                          return;
+                        }
+                      }
+
+                      if (
+                        e.key === "ArrowUp" &&
+                        !input.trim() &&
+                        onRecallLastMessage
+                      ) {
                         e.preventDefault();
-                        emoji.dismiss();
+                        onRecallLastMessage();
                         return;
                       }
-                    }
 
-                    if (
-                      e.key === "ArrowUp" &&
-                      !input.trim() &&
-                      onRecallLastMessage
-                    ) {
-                      e.preventDefault();
-                      onRecallLastMessage();
-                      return;
-                    }
+                      if (e.key === "Escape" && onCancelEdit) {
+                        e.preventDefault();
+                        onCancelEdit();
+                        return;
+                      }
 
-                    if (e.key === "Escape" && onCancelEdit) {
-                      e.preventDefault();
-                      onCancelEdit();
-                      return;
-                    }
+                      const marker = matchFormattingShortcut(e);
+                      if (marker) {
+                        e.preventDefault();
+                        const el = inputRef.current;
+                        const start = el?.selectionStart ?? input.length;
+                        const end = el?.selectionEnd ?? start;
+                        const result = applyMarkdownFormatting(
+                          input,
+                          start,
+                          end,
+                          marker,
+                        );
+                        cursorRef.current = result.selectionStart;
+                        setInput(result.text);
+                        requestAnimationFrame(() => {
+                          if (el) {
+                            el.setSelectionRange(
+                              result.selectionStart,
+                              result.selectionEnd,
+                            );
+                            el.focus();
+                          }
+                        });
+                        return;
+                      }
 
-                    const marker = matchFormattingShortcut(e);
-                    if (marker) {
-                      e.preventDefault();
-                      const el = inputRef.current;
-                      const start = el?.selectionStart ?? input.length;
-                      const end = el?.selectionEnd ?? start;
-                      const result = applyMarkdownFormatting(
-                        input,
-                        start,
-                        end,
-                        marker,
+                      if (e.key === "Tab" && ghostSuffix) {
+                        e.preventDefault();
+                        const accepted = input + ghostSuffix;
+                        cursorRef.current = accepted.length;
+                        setInput(accepted);
+                        return;
+                      }
+                      const decision = shouldSubmitOnEnter(
+                        {
+                          key: e.key,
+                          shiftKey: e.shiftKey,
+                          metaKey: e.metaKey,
+                          ctrlKey: e.ctrlKey,
+                          isComposing: e.nativeEvent.isComposing,
+                          keyCode: e.keyCode,
+                        },
+                        pointerCoarse,
+                        {
+                          input,
+                          canSendAttachments,
+                          sendDisabled,
+                          attachmentsUploadingCount,
+                          cmdEnterMode,
+                          hasStagedQuotes,
+                        },
                       );
-                      cursorRef.current = result.selectionStart;
-                      setInput(result.text);
-                      requestAnimationFrame(() => {
-                        if (el) {
-                          el.setSelectionRange(
-                            result.selectionStart,
-                            result.selectionEnd,
-                          );
-                          el.focus();
-                        }
-                      });
-                      return;
-                    }
-
-                    if (e.key === "Tab" && ghostSuffix) {
+                      if (decision === "ignore") {
+                        return;
+                      }
                       e.preventDefault();
-                      const accepted = input + ghostSuffix;
-                      cursorRef.current = accepted.length;
-                      setInput(accepted);
-                      return;
-                    }
-                    const decision = shouldSubmitOnEnter(
-                      {
-                        key: e.key,
-                        shiftKey: e.shiftKey,
-                        metaKey: e.metaKey,
-                        ctrlKey: e.ctrlKey,
-                        isComposing: e.nativeEvent.isComposing,
-                        keyCode: e.keyCode,
-                      },
-                      pointerCoarse,
-                      {
-                        input,
-                        canSendAttachments,
-                        sendDisabled,
-                        attachmentsUploadingCount,
-                        cmdEnterMode,
-                        hasStagedQuotes,
-                      },
-                    );
-                    if (decision === "ignore") {
-                      return;
-                    }
-                    e.preventDefault();
-                    if (decision === "submit") {
-                      onSubmit(e as unknown as FormEvent);
-                    }
-                  }}
-                  placeholder={ghostSuffix ? "" : placeholder}
-                  // A live-voice session leaves this alone: the bar above owns
-                  // the session, and typing alongside it is the point of moving
-                  // the bar out of the card.
-                  disabled={typingDisabled}
-                  rows={1}
-                  className="col-start-1 row-start-1 w-full resize-none overflow-y-auto border-none bg-transparent px-4 pt-3 pb-2 text-chat text-[var(--content-default)] placeholder:text-[var(--content-disabled)] focus:outline-none disabled:opacity-50"
-                  style={{ maxHeight: `${textareaMaxHeightPx}px` }}
-                />
-              </div>
-              {showInlineVoicePreview && (
-                // Non-Electron fallback: Electron uses the shared top-center
-                // dictation overlay for both focused and global recording.
-                // Browser/iOS hosts keep this inline waveform because the
-                // overlay bridge no-ops there.
-                <div
-                  className={hideTextareaForVoice ? "px-2 pt-3" : "px-2"}
-                  aria-label={
-                    voicePhase === "processing" ? "Transcribing" : "Recording"
-                  }
-                  aria-live="polite"
-                >
-                  <StreamingWaveform
-                    amplitude={amplitude}
-                    paused={voicePhase === "processing"}
+                      if (decision === "submit") {
+                        onSubmit(e as unknown as FormEvent);
+                      }
+                    }}
+                    placeholder={ghostSuffix ? "" : placeholder}
+                    // A live-voice session leaves this alone: the bar above owns
+                    // the session, and typing alongside it is the point of moving
+                    // the bar out of the card.
+                    disabled={typingDisabled}
+                    rows={1}
+                    className="col-start-1 row-start-1 w-full resize-none overflow-y-auto border-none bg-transparent px-4 pt-3 pb-2 text-chat text-[var(--content-default)] placeholder:text-[var(--content-disabled)] focus:outline-none disabled:opacity-50"
+                    style={{ maxHeight: `${textareaMaxHeightPx}px` }}
                   />
-                  {voicePhase === "processing" ? (
-                    <p className="mt-1 truncate text-[11px] italic text-[var(--content-tertiary)]">
-                      Transcribing…
-                    </p>
-                  ) : (
-                    voiceInterim && (
-                      // Partial transcript ghost text — mirrors macOS composerTextField
-                      // showing interim results in the input binding while speaking.
-                      <p className="mt-1 truncate text-[11px] italic text-[var(--content-tertiary)]">
-                        {voiceInterim}
-                      </p>
-                    )
-                  )}
                 </div>
-              )}
-              {/* Action row per Figma 7471-25234: attach | divider | access
+                {showInlineVoicePreview && (
+                  // Non-Electron fallback: Electron uses the shared top-center
+                  // dictation overlay for both focused and global recording.
+                  // Browser/iOS hosts keep this inline waveform because the
+                  // overlay bridge no-ops there.
+                  <div
+                    className={hideTextareaForVoice ? "px-2 pt-3" : "px-2"}
+                    aria-label={
+                      voicePhase === "processing" ? "Transcribing" : "Recording"
+                    }
+                    aria-live="polite"
+                  >
+                    <StreamingWaveform
+                      amplitude={amplitude}
+                      paused={voicePhase === "processing"}
+                    />
+                    {voicePhase === "processing" ? (
+                      <p className="mt-1 truncate text-[11px] italic text-[var(--content-tertiary)]">
+                        Transcribing…
+                      </p>
+                    ) : (
+                      voiceInterim && (
+                        // Partial transcript ghost text, mirroring macOS composerTextField
+                        // showing interim results in the input binding while speaking.
+                        <p className="mt-1 truncate text-[11px] italic text-[var(--content-tertiary)]">
+                          {voiceInterim}
+                        </p>
+                      )
+                    )}
+                  </div>
+                )}
+                {/* Action row per Figma 7471-25234: attach | divider | access
                 on the left; model profile | divider | mic, send on the
                 right. It stays mounted through a live-voice session — the
                 session's own controls live in the bar above the card, and
                 everything here (attach, model picker, send) keeps working
                 alongside it. */}
-              <ComposerCompactProvider compact={compactSettings}>
-                <div className="flex items-center justify-between gap-1 px-2 pb-2">
-                  <div className="flex min-w-0 items-center gap-2">
-                    {contextWindowIndicatorSlot}
-                    {!isAssistantBusy && (
-                      <AttachFileButton
-                        disabled={typingDisabled || !assistantId}
-                        onFilesSelected={onAddAttachmentFiles}
-                      />
-                    )}
-                    {!isAssistantBusy && thresholdPickerSlot ? (
-                      <div
-                        aria-hidden="true"
-                        className="h-4 w-px shrink-0 bg-[var(--border-hover)] touch-mobile:-mx-1"
-                      />
-                    ) : null}
-                    {thresholdPickerSlot}
-                  </div>
-                  <div className="flex shrink-0 items-center gap-2">
-                    {isAssistantBusy ? (
-                      sendReplacesStop ? (
-                        <Button
-                          variant="primary"
-                          iconOnly={
-                            <ArrowUp className="h-4 w-4" strokeWidth={2.5} />
-                          }
-                          type="submit"
-                          title="Send message"
-                          aria-label="Send message"
+                <ComposerCompactProvider compact={compactSettings}>
+                  <div className="flex items-center justify-between gap-1 px-2 pb-2">
+                    <div className="flex min-w-0 items-center gap-2">
+                      {contextWindowIndicatorSlot}
+                      {!isAssistantBusy && (
+                        <AttachFileButton
+                          disabled={typingDisabled || !assistantId}
+                          onFilesSelected={onAddAttachmentFiles}
                         />
+                      )}
+                      {!isAssistantBusy && rowThresholdPickerSlot ? (
+                        <div
+                          aria-hidden="true"
+                          className="h-4 w-px shrink-0 bg-[var(--border-hover)] touch-mobile:-mx-1"
+                        />
+                      ) : null}
+                      {rowThresholdPickerSlot}
+                    </div>
+                    <div className="flex shrink-0 items-center gap-2">
+                      {isAssistantBusy ? (
+                        sendReplacesStop ? (
+                          <Button
+                            variant="primary"
+                            iconOnly={
+                              <ArrowUp className="h-4 w-4" strokeWidth={2.5} />
+                            }
+                            type="submit"
+                            title="Send message"
+                            aria-label="Send message"
+                          />
+                        ) : (
+                          <Button
+                            variant="primary"
+                            iconOnly={
+                              <Square className="h-3 w-3" fill="currentColor" />
+                            }
+                            onClick={onStopGenerating}
+                            aria-label="Stop generating"
+                          />
+                        )
                       ) : (
-                        <Button
-                          variant="primary"
-                          iconOnly={
-                            <Square className="h-3 w-3" fill="currentColor" />
-                          }
-                          onClick={onStopGenerating}
-                          aria-label="Stop generating"
-                        />
-                      )
-                    ) : (
-                      <>
-                        {/* Compact: the model profile moves into the left
+                        <>
+                          {/* Compact: the model profile moves into the left
                           slot's hamburger alongside access, so nothing is
                           mounted here. */}
-                        {!compactSettings && modelPickerSlot}
-                        {!compactSettings &&
-                        modelPickerSlot &&
-                        showDictationButton ? (
-                          <div
-                            aria-hidden="true"
-                            className="h-4 w-px shrink-0 bg-[var(--border-hover)] touch-mobile:-mx-1"
-                          />
-                        ) : null}
-                        {showDictationButton && (
-                          <VoiceInputButton
-                            ref={voiceInputRef}
-                            assistantId={assistantId}
-                            // Mutual exclusion: a live-voice session in another
-                            // thread must block dictation, or two mic capture
-                            // flows could run at once. (This composer's own
-                            // session takes the button away entirely — see
-                            // `showDictationButton`.)
-                            disabled={typingDisabled || isLiveVoiceSessionLive}
-                            onTranscript={onVoiceTranscript}
-                            onInterimTranscript={onVoiceInterimTranscript}
-                            onError={onVoiceError}
-                            onBeforeStart={onVoiceBeforeStart}
-                            onStreamReady={(stream: MediaStream | null) => {
-                              voiceStreamRef.current = stream;
-                              setVoiceStream(stream);
-                            }}
-                          />
-                        )}
-                        {/* macOS parity: the send button is hidden during recording
+                          {!compactSettings && rowModelPickerSlot}
+                          {!compactSettings &&
+                          rowModelPickerSlot &&
+                          showDictationButton ? (
+                            <div
+                              aria-hidden="true"
+                              className="h-4 w-px shrink-0 bg-[var(--border-hover)] touch-mobile:-mx-1"
+                            />
+                          ) : null}
+                          {showDictationButton && (
+                            <VoiceInputButton
+                              ref={voiceInputRef}
+                              assistantId={assistantId}
+                              // Mutual exclusion: a live-voice session in another
+                              // thread must block dictation, or two mic capture
+                              // flows could run at once. (This composer's own
+                              // session takes the button away entirely, see
+                              // `showDictationButton`.)
+                              disabled={
+                                typingDisabled || isLiveVoiceSessionLive
+                              }
+                              onTranscript={onVoiceTranscript}
+                              onInterimTranscript={onVoiceInterimTranscript}
+                              onError={onVoiceError}
+                              onBeforeStart={onVoiceBeforeStart}
+                              onStreamReady={(stream: MediaStream | null) => {
+                                voiceStreamRef.current = stream;
+                                setVoiceStream(stream);
+                              }}
+                            />
+                          )}
+                          {/* macOS parity: the send button is hidden during recording
                       and while transcription is being processed. Only the voice
                       button (mic / stop / spinner) is shown. Otherwise the send
                       slot holds voice mode until there is something to send, at
                       which point the send arrow takes over. */}
-                        {!isVoiceActive &&
-                          (showVoiceModeInSendSlot ? (
-                            // Session entry point: once a session starts here the
-                            // slot gives way to the send arrow and the bar above
-                            // the card owns stopping. Disabled while dictation is
-                            // active or a live-voice session already runs
-                            // elsewhere, so a second mic/voice capture can't open
-                            // alongside it.
-                            <LiveVoiceButton
-                              onStart={handleLiveVoiceStart}
-                              disabled={
-                                typingDisabled ||
-                                isVoiceActive ||
-                                isLiveVoiceSessionLive
-                              }
-                            />
-                          ) : (
-                            <Button
-                              variant="primary"
-                              iconOnly={
-                                <ArrowUp
-                                  className="h-4 w-4"
-                                  strokeWidth={2.5}
-                                />
-                              }
-                              type="submit"
-                              disabled={
-                                sendDisabled ||
-                                attachmentsUploadingCount > 0 ||
-                                !canSendMessageContent
-                              }
-                              title={
-                                sendDisabled || !canSendMessageContent
-                                  ? "Type a message to send"
-                                  : attachmentsUploadingCount > 0
-                                    ? "Uploading attachments…"
-                                    : "Send message"
-                              }
-                              aria-label="Send message"
-                            />
-                          ))}
-                      </>
-                    )}
+                          {!isVoiceActive &&
+                            (showVoiceModeInSendSlot ? (
+                              // Session entry point: once a session starts here the
+                              // slot gives way to the send arrow and the bar above
+                              // the card owns stopping. Disabled while dictation is
+                              // active or a live-voice session already runs
+                              // elsewhere, so a second mic/voice capture can't open
+                              // alongside it.
+                              <LiveVoiceButton
+                                onStart={handleLiveVoiceStart}
+                                disabled={
+                                  typingDisabled ||
+                                  isVoiceActive ||
+                                  isLiveVoiceSessionLive
+                                }
+                              />
+                            ) : (
+                              <Button
+                                variant="primary"
+                                iconOnly={
+                                  <ArrowUp
+                                    className="h-4 w-4"
+                                    strokeWidth={2.5}
+                                  />
+                                }
+                                type="submit"
+                                disabled={
+                                  sendDisabled ||
+                                  attachmentsUploadingCount > 0 ||
+                                  !canSendMessageContent
+                                }
+                                title={
+                                  sendDisabled || !canSendMessageContent
+                                    ? "Type a message to send"
+                                    : attachmentsUploadingCount > 0
+                                      ? "Uploading attachments…"
+                                      : "Send message"
+                                }
+                                aria-label="Send message"
+                              />
+                            ))}
+                        </>
+                      )}
+                    </div>
                   </div>
-                </div>
-              </ComposerCompactProvider>
-            </div>
-          </form>
-        </Popover.Anchor>
-        <Popover.Content
-          side="top"
-          align="start"
-          sideOffset={4}
-          className="w-[var(--radix-popover-trigger-width)] rounded-none bg-transparent p-0 shadow-none"
-          onOpenAutoFocus={(e: Event) => e.preventDefault()}
-          onCloseAutoFocus={(e: Event) => e.preventDefault()}
-          onInteractOutside={(e: Event) => e.preventDefault()}
-          onEscapeKeyDown={(e: Event) => e.preventDefault()}
-          onPointerDownOutside={(e: Event) => e.preventDefault()}
-        >
-          {emoji.show && (
-            <EmojiPickerPopup
-              entries={emoji.items}
-              selectedIndex={emoji.selectedIndex}
-              onSelect={insertEmoji}
-            />
-          )}
-          {slash.show && (
-            <SlashCommandPopup
-              commands={slash.items}
-              selectedIndex={slash.selectedIndex}
-              onSelect={handleSlashCommandSelect}
-            />
-          )}
-        </Popover.Content>
-      </Popover.Root>
+                </ComposerCompactProvider>
+              </div>
+            </form>
+          </Popover.Anchor>
+          <Popover.Content
+            side="top"
+            align="start"
+            sideOffset={4}
+            className="w-[var(--radix-popover-trigger-width)] rounded-none bg-transparent p-0 shadow-none"
+            onOpenAutoFocus={(e: Event) => e.preventDefault()}
+            onCloseAutoFocus={(e: Event) => e.preventDefault()}
+            onInteractOutside={(e: Event) => e.preventDefault()}
+            onEscapeKeyDown={(e: Event) => e.preventDefault()}
+            onPointerDownOutside={(e: Event) => e.preventDefault()}
+          >
+            {emoji.show && (
+              <EmojiPickerPopup
+                entries={emoji.items}
+                selectedIndex={emoji.selectedIndex}
+                onSelect={insertEmoji}
+              />
+            )}
+            {slash.show && (
+              <SlashCommandPopup
+                commands={slash.items}
+                selectedIndex={slash.selectedIndex}
+                onSelect={handleSlashCommandSelect}
+              />
+            )}
+          </Popover.Content>
+        </Popover.Root>
+      </div>
     </>
   );
 }

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -1231,6 +1231,13 @@ export function ChatMainPanel({
 
   const cmdEnterMode = cmdEnterToSend.useValue();
 
+  // Whether the surface each settings menu owns is open. The mobile composer
+  // floats those two triggers above its card and hides them when focus leaves,
+  // and opening one takes focus out of the composer, so it needs the open state
+  // to hold the row in place underneath the sheet.
+  const [accessSurfaceOpen, setAccessSurfaceOpen] = useState(false);
+  const [profileSurfaceOpen, setProfileSurfaceOpen] = useState(false);
+
   // Explicit props (no spread bundle): the contract is visible here, and the
   // composer self-sources its own store state, so nothing high-frequency is
   // threaded through. `ChatBody` renders this node as-is.
@@ -1269,12 +1276,15 @@ export function ChatMainPanel({
       textareaMaxHeightPx={isEmptyConversation ? 320 : undefined}
       suggestion={suggestion}
       hasBillingBanner={composerBillingBanner !== null}
+      settingsSheetOpen={accessSurfaceOpen || profileSurfaceOpen}
       thresholdPickerSlot={
         assistantId ? (
           <ComposerSettingsMenu
             assistantId={assistantId}
             conversationId={activeConversation?.conversationId}
             segments="access"
+            triggerVariant={isMobile ? "labeled-pill" : "icon"}
+            onOpenChange={setAccessSurfaceOpen}
           />
         ) : undefined
       }
@@ -1284,6 +1294,8 @@ export function ChatMainPanel({
             assistantId={assistantId}
             conversationId={activeConversation?.conversationId}
             segments="profile"
+            triggerVariant={isMobile ? "labeled-pill" : "icon"}
+            onOpenChange={setProfileSurfaceOpen}
           />
         ) : undefined
       }

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -38,6 +38,7 @@ import { useChatUIState } from "@/domains/chat/hooks/use-chat-ui-state";
 import { useTranscriptData } from "@/domains/chat/hooks/use-transcript-data";
 import { useTranscriptMessages } from "@/domains/chat/transcript/use-transcript-messages";
 import { useChatEmptyState } from "@/domains/chat/hooks/use-chat-empty-state";
+import { useComposerSettingsSheets } from "@/domains/chat/hooks/use-composer-settings-sheets";
 import { useComposerSubmit } from "@/domains/chat/hooks/use-composer-submit";
 import { useDraftSecretDetection } from "@/domains/chat/hooks/use-draft-secret-detection";
 import type { SendChatMessageOptions } from "@/domains/chat/hooks/use-send-message";
@@ -1235,8 +1236,8 @@ export function ChatMainPanel({
   // floats those two triggers above its card and hides them when focus leaves,
   // and opening one takes focus out of the composer, so it needs the open state
   // to hold the row in place underneath the sheet.
-  const [accessSurfaceOpen, setAccessSurfaceOpen] = useState(false);
-  const [profileSurfaceOpen, setProfileSurfaceOpen] = useState(false);
+  const { settingsSheetOpen, onAccessOpenChange, onProfileOpenChange } =
+    useComposerSettingsSheets(isMobile);
 
   // Explicit props (no spread bundle): the contract is visible here, and the
   // composer self-sources its own store state, so nothing high-frequency is
@@ -1276,7 +1277,7 @@ export function ChatMainPanel({
       textareaMaxHeightPx={isEmptyConversation ? 320 : undefined}
       suggestion={suggestion}
       hasBillingBanner={composerBillingBanner !== null}
-      settingsSheetOpen={accessSurfaceOpen || profileSurfaceOpen}
+      settingsSheetOpen={settingsSheetOpen}
       thresholdPickerSlot={
         assistantId ? (
           <ComposerSettingsMenu
@@ -1284,7 +1285,7 @@ export function ChatMainPanel({
             conversationId={activeConversation?.conversationId}
             segments="access"
             triggerVariant={isMobile ? "labeled-pill" : "icon"}
-            onOpenChange={setAccessSurfaceOpen}
+            onOpenChange={onAccessOpenChange}
           />
         ) : undefined
       }
@@ -1295,7 +1296,7 @@ export function ChatMainPanel({
             conversationId={activeConversation?.conversationId}
             segments="profile"
             triggerVariant={isMobile ? "labeled-pill" : "icon"}
-            onOpenChange={setProfileSurfaceOpen}
+            onOpenChange={onProfileOpenChange}
           />
         ) : undefined
       }

--- a/clients/web/src/domains/chat/hooks/use-composer-settings-sheets.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-composer-settings-sheets.test.ts
@@ -1,0 +1,75 @@
+/**
+ * The flags that hold the mobile composer's pills row up while one of its
+ * settings sheets has focus, and the breakpoint swap that has to clear them.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+
+import { useComposerSettingsSheets } from "./use-composer-settings-sheets";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useComposerSettingsSheets", () => {
+  test("starts closed and reports either sheet as open", () => {
+    const { result } = renderHook(() => useComposerSettingsSheets(true));
+    expect(result.current.settingsSheetOpen).toBe(false);
+
+    act(() => result.current.onAccessOpenChange(true));
+    expect(result.current.settingsSheetOpen).toBe(true);
+
+    act(() => result.current.onAccessOpenChange(false));
+    act(() => result.current.onProfileOpenChange(true));
+    expect(result.current.settingsSheetOpen).toBe(true);
+  });
+
+  test("crossing the breakpoint clears an open sheet's flag", () => {
+    // GIVEN a phone with the access sheet open above the composer
+    const { result, rerender } = renderHook(
+      ({ isMobile }: { isMobile: boolean }) =>
+        useComposerSettingsSheets(isMobile),
+      { initialProps: { isMobile: true } },
+    );
+    act(() => result.current.onAccessOpenChange(true));
+    expect(result.current.settingsSheetOpen).toBe(true);
+
+    // WHEN it rotates into the desktop presentation, which unmounts the menu
+    // that owned the sheet without a close of its own
+    rerender({ isMobile: false });
+
+    // THEN the flag goes with the instance that set it
+    expect(result.current.settingsSheetOpen).toBe(false);
+
+    // AND rotating back leaves the row nothing to hold up
+    rerender({ isMobile: true });
+    expect(result.current.settingsSheetOpen).toBe(false);
+  });
+
+  test("clears the profile flag on the same swap", () => {
+    const { result, rerender } = renderHook(
+      ({ isMobile }: { isMobile: boolean }) =>
+        useComposerSettingsSheets(isMobile),
+      { initialProps: { isMobile: true } },
+    );
+    act(() => result.current.onProfileOpenChange(true));
+
+    rerender({ isMobile: false });
+
+    expect(result.current.settingsSheetOpen).toBe(false);
+  });
+
+  test("a re-render at the same presentation leaves an open sheet alone", () => {
+    const { result, rerender } = renderHook(
+      ({ isMobile }: { isMobile: boolean }) =>
+        useComposerSettingsSheets(isMobile),
+      { initialProps: { isMobile: true } },
+    );
+    act(() => result.current.onAccessOpenChange(true));
+
+    rerender({ isMobile: true });
+
+    expect(result.current.settingsSheetOpen).toBe(true);
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-composer-settings-sheets.ts
+++ b/clients/web/src/domains/chat/hooks/use-composer-settings-sheets.ts
@@ -1,0 +1,40 @@
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Open-state for the two surfaces the composer's settings menus own, held above
+ * the composer because its mobile pills row has to stay up while a sheet holds
+ * the focus that would otherwise put the row away.
+ *
+ * `isMobile` is the presentation: the triggers sit in the composer's action row
+ * on desktop and in the floating pills row on mobile, so crossing the
+ * breakpoint (a phone rotating) unmounts whichever menu had a sheet open. That
+ * instance reports nothing on its way out and its replacement suppresses the
+ * initial `false`, so both flags reset on the swap. An open flag must never
+ * outlive the instance that set it.
+ */
+export function useComposerSettingsSheets(isMobile: boolean): {
+  settingsSheetOpen: boolean;
+  onAccessOpenChange: (open: boolean) => void;
+  onProfileOpenChange: (open: boolean) => void;
+} {
+  const [accessOpen, setAccessOpen] = useState(false);
+  const [profileOpen, setProfileOpen] = useState(false);
+
+  const presentationRef = useRef(isMobile);
+  useEffect(() => {
+    if (presentationRef.current === isMobile) {
+      return;
+    }
+    presentationRef.current = isMobile;
+    setAccessOpen(false);
+    setProfileOpen(false);
+  }, [isMobile]);
+
+  // The setters are React's own, so they stay referentially stable: the menu
+  // notifies through an effect that lists its callback as a dependency.
+  return {
+    settingsSheetOpen: accessOpen || profileOpen,
+    onAccessOpenChange: setAccessOpen,
+    onProfileOpenChange: setProfileOpen,
+  };
+}


### PR DESCRIPTION
## Summary
- On mobile, the assistant-access and profile pills move out of the composer action row into a focus-gated row floating above the card, right-aligned
- Pills use the labeled-pill ComposerSettingsMenu variant and still open the existing bottom sheets; drawer-open state holds the row visible across the keyboard dismiss
- Desktop and the app-editing panel variant are unchanged

Part of plan: mobile-composer-redesign.md (PR 5 of 6)