### PR TITLE
chore(web): drop unused ChatRouteContent aliases

### DIFF
--- a/clients/web/docs/PLATFORM_ADAPTATION.md
+++ b/clients/web/docs/PLATFORM_ADAPTATION.md
@@ -265,7 +265,7 @@ it too, per [`clients/AGENTS.md`](../../AGENTS.md).
   `BottomSheet` under a thumb and a `Menu` under a mouse, so it reads `useTouchMobile()`. A narrow
   desktop window keeps the dropdown, because a mouse can hit it.
 - **Whether a detail pane docks beside the chat or floats over it** is the size axis. A side-by-side
-  split cannot fit at 767px whatever the pointer is, so `ChatRouteContent` reads `useIsMobile()`.
+  split cannot fit at 767px whatever the pointer is, so `ChatMainPanel` reads `useIsMobile()`.
 - **Safe-area padding under a full-screen sheet** is the platform axis, resolved in CSS off
   `data-native-platform` rather than by a component asking which OS it is on.
 

--- a/clients/web/docs/STYLE_GUIDE.md
+++ b/clients/web/docs/STYLE_GUIDE.md
@@ -259,7 +259,7 @@ Use `type` for unions, intersections, mapped types, and utility types.
 
 ```ts
 // Good
-interface ChatRouteContentProps {
+interface ChatMainPanelProps {
   messages: DisplayMessage[];
   turnState: TurnState;
 }

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -216,9 +216,6 @@ export interface ChatMainPanelProps {
   onboardingConversationId: string | null;
 }
 
-/** @deprecated Use {@link ChatMainPanelProps} — kept as a re-export for migration. */
-export type ChatRouteContentProps = ChatMainPanelProps;
-
 /**
  * Builds the registry-driven row of active background-process overlays.
  *
@@ -1524,6 +1521,3 @@ export function ChatMainPanel({
     </>
   );
 }
-
-/** @deprecated Use {@link ChatMainPanel} — kept for migration. */
-export const ChatRouteContent = ChatMainPanel;

--- a/clients/web/src/domains/chat/process-registry/descriptors/background-task.tsx
+++ b/clients/web/src/domains/chat/process-registry/descriptors/background-task.tsx
@@ -25,8 +25,8 @@ import { useViewerStore } from "@/stores/viewer-store";
  * The descriptor contract's `useActiveIds` is zero-arg, but
  * `useActiveBackgroundTaskIds` is conversation-scoped (the store is global
  * across conversations). Bind it to the active conversation id here so the
- * registry sees only the tasks for the conversation on screen — exactly what
- * `ChatRouteContent` does today.
+ * registry sees only the tasks for the conversation on screen, matching
+ * `ChatMainPanel`.
  */
 function useActiveIds(): string[] {
   const conversationId = useConversationStore((s) => s.activeConversationId);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan
Find a small, real cleanup in `vellum-assistant` to verify this Cloud Agent environment end to end (branch, commit, push, PR).

`ChatMainPanel` is the live chat orchestrator name. The deprecated `ChatRouteContent` / `ChatRouteContentProps` re-exports had no remaining callers after that rename.

## Summary
- Remove the unused `ChatRouteContent` and `ChatRouteContentProps` aliases from `chat-route-content.tsx`.
- Point leftover docs and comments at `ChatMainPanel`.

## Test Plan
- Repo-wide search confirmed no remaining `ChatRouteContent` references.
- `cd clients/web && bun test src/domains/chat/components/chat-route-content.test.tsx src/domains/chat/process-registry/descriptors/background-task.test.ts` (13 pass).
- No new tests: deletion-only of unused aliases.

## Risk
Low. Dead-code removal plus comment/doc name updates. No behavior change. The file is still named `chat-route-content.tsx` because renaming it is a larger import churn that this PR does not attempt.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1129c292-e054-4dd0-8328-1451e5f2563c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1129c292-e054-4dd0-8328-1451e5f2563c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

