### PR TITLE
Bake APP_VERSION into the assistant image as a build arg

### DIFF
--- a/assistant/Dockerfile
+++ b/assistant/Dockerfile
@@ -266,6 +266,12 @@ EXPOSE 3001
 ENV RUNTIME_HTTP_PORT=3001
 ENV IS_CONTAINERIZED=true
 
+# Dev builds pass the full build identity here so the runtime reports the exact
+# build it came from, for example 0.11.3-local.<ts>.<sha>. Release builds leave
+# this empty and assistant/src/version.ts falls back to the package.json version.
+ARG APP_VERSION=""
+ENV APP_VERSION=${APP_VERSION}
+
 COPY packages/block-volume-bootstrap/scripts/*.sh /usr/local/bin/
 
 RUN chmod +x \


### PR DESCRIPTION
The runner stage now accepts an `APP_VERSION` build arg and stamps it into the image config, so the build identity travels with the code instead of being injected per pod. When the arg is not passed the value is empty and `assistant/src/version.ts` falls back to the package.json version.

Pairs with a vel/vembda change in the platform repo that passes the build arg.