### PR TITLE
test: consolidate attachment FileList fixtures and trim duplicated picker coverage

### DIFF
--- a/clients/web/src/domains/chat/components/chat-attachments/attach-file-button.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attach-file-button.test.tsx
@@ -1,144 +1,76 @@
-import {
-  afterAll,
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  mock,
-  test,
-} from "bun:test";
+/**
+ * Tests for the composer's paperclip trigger. The picker mechanics it delegates
+ * to (refocus on close, the iOS focus fallback, input attributes) are covered
+ * by `use-attachment-file-picker.test.tsx`; what is asserted here is the
+ * button's own contract: how it renders, when it is disabled, that it opens the
+ * picker, and that it forwards the selection to its callback.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 
-// The attach button re-focuses the composer when the native iOS picker closes
-// (both on file-select and on cancel). Mock the focus seam so we can assert the
-// request is made without mounting the whole composer/keyboard machinery.
-const requestComposerFocusMock = mock(() => {});
-mock.module("@/domains/chat/composer-focus", () => ({
-  requestComposerFocus: requestComposerFocusMock,
-}));
-
+import { selectFiles } from "@/domains/chat/components/chat-attachments/attachment-test-helpers";
 import { AttachFileButton } from "@/domains/chat/components/chat-attachments/chat-attachments";
 
-afterAll(() => {
-  mock.restore();
-});
 afterEach(() => {
   cleanup();
 });
-beforeEach(() => {
-  requestComposerFocusMock.mockClear();
-});
 
-function makeFileList(files: File[]): FileList {
-  const list = {
-    length: files.length,
-    item: (i: number) => files[i] ?? null,
-  } as unknown as FileList;
-  files.forEach((f, i) => {
-    (list as unknown as Record<number, File>)[i] = f;
-  });
-  return list;
+function renderButton(
+  props: Partial<Parameters<typeof AttachFileButton>[0]> = {},
+) {
+  const onFilesSelected = mock((_files: FileList) => {});
+  const result = render(
+    <AttachFileButton onFilesSelected={onFilesSelected} {...props} />,
+  );
+  const input = result.container.querySelector(
+    'input[type="file"]',
+  ) as HTMLInputElement;
+  const button = result.getByLabelText("Attach file") as HTMLButtonElement;
+  return { ...result, onFilesSelected, input, button };
 }
 
-describe("AttachFileButton — composer refocus on picker close", () => {
-  test("refocuses the composer after a file is selected", () => {
-    const onFilesSelected = mock(() => {});
-    const { container } = render(
-      <AttachFileButton onFilesSelected={onFilesSelected} />,
-    );
-    const input = container.querySelector(
-      'input[type="file"]',
-    ) as HTMLInputElement;
-    expect(input).not.toBeNull();
+describe("AttachFileButton", () => {
+  test("renders an icon trigger over a hidden multi-file input", () => {
+    const { button, input } = renderButton();
 
-    const file = new File(["hi"], "note.txt", { type: "text/plain" });
-    Object.defineProperty(input, "files", {
-      configurable: true,
-      value: makeFileList([file]),
-    });
-    fireEvent.change(input);
+    expect(button.querySelector("svg")).not.toBeNull();
+    expect(button.getAttribute("title")).toBe("Attach file");
+    expect(input).not.toBeNull();
+    expect(input.multiple).toBe(true);
+  });
+
+  test("takes a tooltip override while keeping its accessible name", () => {
+    const { button } = renderButton({ title: "Attach to this message" });
+
+    expect(button.getAttribute("title")).toBe("Attach to this message");
+    expect(button.getAttribute("aria-label")).toBe("Attach file");
+  });
+
+  test("disables the trigger when disabled", () => {
+    const { button } = renderButton({ disabled: true });
+
+    expect(button.disabled).toBe(true);
+  });
+
+  test("opens the picker on click", () => {
+    const { button, input } = renderButton();
+    const clicked = mock(() => {});
+    input.addEventListener("click", clicked);
+
+    fireEvent.click(button);
+
+    expect(clicked).toHaveBeenCalledTimes(1);
+  });
+
+  test("forwards the picked files to onFilesSelected", () => {
+    const { input, onFilesSelected } = renderButton();
+
+    const picked = selectFiles(input, [
+      new File(["hi"], "note.txt", { type: "text/plain" }),
+    ]);
 
     expect(onFilesSelected).toHaveBeenCalledTimes(1);
-    // Keyboard/layout restored after selection.
-    expect(requestComposerFocusMock).toHaveBeenCalled();
-  });
-
-  test("refocuses the composer when the picker is cancelled (input cancel event)", () => {
-    const { container } = render(
-      <AttachFileButton onFilesSelected={() => {}} />,
-    );
-    const input = container.querySelector(
-      'input[type="file"]',
-    ) as HTMLInputElement;
-
-    // A cancel fires no `change`; WebKit dispatches `cancel` on the input when
-    // the native picker is dismissed without a selection.
-    fireEvent(input, new Event("cancel"));
-    expect(requestComposerFocusMock).toHaveBeenCalledTimes(1);
-  });
-
-  test("does not refocus before any picker interaction", () => {
-    render(<AttachFileButton onFilesSelected={() => {}} />);
-    // Mounting the button alone must not refocus the composer.
-    expect(requestComposerFocusMock).not.toHaveBeenCalled();
-  });
-
-  test("refocuses via the one-shot window focus fallback (iOS 15–16.3)", () => {
-    const { getByLabelText } = render(
-      <AttachFileButton onFilesSelected={() => {}} />,
-    );
-    // Opening the picker arms the fallback; a window focus (web view regains
-    // first responder as the picker closes) restores the keyboard on engines
-    // that never fire the input `cancel` event.
-    fireEvent.click(getByLabelText("Attach file"));
-    expect(requestComposerFocusMock).not.toHaveBeenCalled();
-
-    window.dispatchEvent(new Event("focus"));
-    expect(requestComposerFocusMock).toHaveBeenCalledTimes(1);
-
-    // One-shot: a later focus (unrelated) does not refocus again.
-    window.dispatchEvent(new Event("focus"));
-    expect(requestComposerFocusMock).toHaveBeenCalledTimes(1);
-  });
-
-  test("disarms the focus fallback once the picker closes via cancel", () => {
-    const { getByLabelText, container } = render(
-      <AttachFileButton onFilesSelected={() => {}} />,
-    );
-    const input = container.querySelector(
-      'input[type="file"]',
-    ) as HTMLInputElement;
-
-    // Open the picker (arms the fallback), then close it via `cancel`.
-    fireEvent.click(getByLabelText("Attach file"));
-    fireEvent(input, new Event("cancel"));
-    expect(requestComposerFocusMock).toHaveBeenCalledTimes(1);
-
-    // A later unrelated window focus must NOT refocus — the fallback was
-    // disarmed by the cancel path, not left registered.
-    window.dispatchEvent(new Event("focus"));
-    expect(requestComposerFocusMock).toHaveBeenCalledTimes(1);
-  });
-
-  test("disarms the focus fallback once the picker closes via file select", () => {
-    const { getByLabelText, container } = render(
-      <AttachFileButton onFilesSelected={() => {}} />,
-    );
-    const input = container.querySelector(
-      'input[type="file"]',
-    ) as HTMLInputElement;
-
-    fireEvent.click(getByLabelText("Attach file"));
-    const file = new File(["hi"], "note.txt", { type: "text/plain" });
-    Object.defineProperty(input, "files", {
-      configurable: true,
-      value: makeFileList([file]),
-    });
-    fireEvent.change(input);
-    expect(requestComposerFocusMock).toHaveBeenCalledTimes(1);
-
-    // Fallback disarmed by the change path — a later focus does not refocus.
-    window.dispatchEvent(new Event("focus"));
-    expect(requestComposerFocusMock).toHaveBeenCalledTimes(1);
+    expect(onFilesSelected.mock.calls[0]?.[0]).toBe(picked);
   });
 });

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-test-helpers.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-test-helpers.tsx
@@ -1,7 +1,7 @@
 /**
- * Shared fixtures and stubs for the attachment renderers' tests
- * (`BubbleAttachments`, `MessageAttachments`, `MessageFilesPanel`) and the
- * viewer store's message-files actions.
+ * Shared fixtures and stubs for the attachment tests: the renderers
+ * (`BubbleAttachments`, `MessageAttachments`, `MessageFilesPanel`), the viewer
+ * store's message-files actions, and the file-picker surfaces.
  *
  * Fixtures live in `attachment-fixtures.ts`, which imports no test runner so
  * stories can share them; this module adds the `bun:test` stubs on top.
@@ -13,6 +13,7 @@
  */
 
 import { mock } from "bun:test";
+import { fireEvent } from "@testing-library/react";
 
 // Re-exported so existing test imports keep resolving from one place; the
 // factories themselves live in a test-runner-free module the stories share.
@@ -56,6 +57,35 @@ export function mockAttachmentPreviewModal(): void {
       ),
     }),
   );
+}
+
+/**
+ * A `FileList` over `files`. happy-dom ships no `FileList` constructor, and
+ * consumers read both `list.item(i)` and `list[i]`, so the shape is built by
+ * hand with both accessors.
+ */
+export function makeFileList(files: File[]): FileList {
+  const list = {
+    length: files.length,
+    item: (i: number) => files[i] ?? null,
+  } as unknown as FileList;
+  files.forEach((file, i) => {
+    (list as unknown as Record<number, File>)[i] = file;
+  });
+  return list;
+}
+
+/**
+ * Drive a hidden `<input type="file">` the way the native picker does: stash
+ * the selection on `files` (read-only in the DOM, so it takes a
+ * `defineProperty`) and fire `change`. Returns the `FileList` so callers can
+ * assert on the exact object handed to their callback.
+ */
+export function selectFiles(input: HTMLInputElement, files: File[]): FileList {
+  const list = makeFileList(files);
+  Object.defineProperty(input, "files", { configurable: true, value: list });
+  fireEvent.change(input);
+  return list;
 }
 
 /**

--- a/clients/web/src/domains/chat/components/chat-attachments/use-attachment-file-picker.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/use-attachment-file-picker.test.tsx
@@ -17,6 +17,7 @@ mock.module("@/domains/chat/composer-focus", () => ({
   requestComposerFocus: requestComposerFocusMock,
 }));
 
+import { selectFiles } from "@/domains/chat/components/chat-attachments/attachment-test-helpers";
 import { useAttachmentFilePicker } from "@/domains/chat/components/chat-attachments/use-attachment-file-picker";
 
 afterAll(() => {
@@ -55,24 +56,8 @@ function renderPicker(props: Parameters<typeof PickerProbe>[0]) {
   return { ...result, input, open };
 }
 
-function makeFileList(files: File[]): FileList {
-  const list = {
-    length: files.length,
-    item: (i: number) => files[i] ?? null,
-  } as unknown as FileList;
-  files.forEach((f, i) => {
-    (list as unknown as Record<number, File>)[i] = f;
-  });
-  return list;
-}
-
-function selectFile(input: HTMLInputElement, name = "note.txt") {
-  const file = new File(["hi"], name, { type: "text/plain" });
-  Object.defineProperty(input, "files", {
-    configurable: true,
-    value: makeFileList([file]),
-  });
-  fireEvent.change(input);
+function selectFile(input: HTMLInputElement, name = "note.txt"): FileList {
+  return selectFiles(input, [new File(["hi"], name, { type: "text/plain" })]);
 }
 
 describe("useAttachmentFilePicker", () => {

--- a/clients/web/src/domains/chat/components/chat-attachments/use-chat-attachment-drop-zone.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/use-chat-attachment-drop-zone.test.tsx
@@ -10,6 +10,7 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import { createRef, useImperativeHandle, forwardRef, type Ref } from "react";
 
+import { makeFileList } from "@/domains/chat/components/chat-attachments/attachment-test-helpers";
 import {
   useChatAttachmentDropZone,
   type ChatAttachmentDropZoneHandlers,
@@ -52,10 +53,7 @@ function makeDataTransfer(items: DropItemSpec[]): DataTransfer {
   return {
     types: ["Files"],
     items: itemObjs as unknown as DataTransferItemList,
-    files: {
-      length: items.length,
-      item: (i: number) => items[i]?.file ?? null,
-    } as unknown as FileList,
+    files: makeFileList(items.map(({ file }) => file)),
     dropEffect: "none",
     effectAllowed: "all",
     clearData: () => {},

--- a/clients/web/src/domains/chat/components/chat-composer/add-to-chat-sheet.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/add-to-chat-sheet.test.tsx
@@ -47,6 +47,7 @@ mock.module("@vellumai/design-library", () => ({
   },
 }));
 
+import { selectFiles } from "@/domains/chat/components/chat-attachments/attachment-test-helpers";
 import { AddToChatSheet } from "@/domains/chat/components/chat-composer/add-to-chat-sheet";
 
 afterAll(() => {
@@ -110,13 +111,8 @@ describe("AddToChatSheet", () => {
   test("delivers picked files to onAttachFiles", () => {
     const { onAttachFiles, gallery } = renderSheet();
     const file = new File(["hi"], "photo.png", { type: "image/png" });
-    const picked = [file] as unknown as FileList;
-    Object.defineProperty(gallery, "files", {
-      configurable: true,
-      value: picked,
-    });
 
-    fireEvent.change(gallery);
+    const picked = selectFiles(gallery, [file]);
 
     expect(onAttachFiles).toHaveBeenCalledTimes(1);
     expect(onAttachFiles.mock.calls[0]?.[0]).toBe(picked);


### PR DESCRIPTION
## Summary
Test-only cleanup from the mobile-composer-redesign review: one shared FileList/selectFiles fixture for the attachment domain, and attach-file-button.test.tsx trimmed to the button's own contract now that the picker mechanics are covered by the hook's test.