### PR TITLE
fix: unify mobile composer chrome on the width signal and stabilize sheet mounting

### DIFF
--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -21,6 +21,7 @@ import type { VoiceInputButtonHandle } from "@/domains/chat/components/voice-inp
 import type { LiveVoicePreflightVerdict } from "@/domains/chat/voice/live-voice/live-voice-preflight-api";
 import { INITIAL_TURN_STATE, useTurnStore } from "@/domains/chat/turn-store";
 import * as assistantAvatarMod from "@/hooks/use-assistant-avatar";
+import * as emojiCatalogMod from "@/domains/chat/components/chat-composer/emoji-catalog";
 import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 import { viewportAxesStub } from "@/hooks/viewport-axes.test-helper";
 
@@ -174,6 +175,18 @@ mock.module("@/domains/chat/voice/live-voice/live-voice-preflight-api", () => ({
 let mockSupportsLiveVoice = true;
 mock.module("@/lib/backwards-compat/use-supports-live-voice", () => ({
   useSupportsLiveVoice: () => mockSupportsLiveVoice,
+}));
+
+// Emoji autocomplete. The real hook `import()`s ~150 kB of catalog data on
+// first mount and sets state when it lands, a tick after most of these test
+// bodies have returned, which React reports as an update outside `act`. Serve
+// an already-loaded (empty) catalog so no composer takes a late state update.
+// The catalog's own search behavior is covered by its consumers' tests. The
+// real module is spread back in so the trigger regex and threshold the composer
+// reads survive the mock.
+mock.module("@/domains/chat/components/chat-composer/emoji-catalog", () => ({
+  ...emojiCatalogMod,
+  useEmojiSearch: () => () => [],
 }));
 
 // Composer-card width measurement. happy-dom has no layout engine (every box
@@ -685,6 +698,82 @@ function renderComposer(props: RenderComposerProps = {}) {
   return renderComposerView(props).container.innerHTML;
 }
 
+/** The access + profile pickers, the pair the mobile pills row floats. */
+const SETTINGS_SLOTS = {
+  thresholdPickerSlot: <span>THR</span>,
+  modelPickerSlot: <span>PROFILE</span>,
+};
+
+const PLUS_LABEL = "Add to chat";
+
+/**
+ * The device shapes the composer adapts to, one helper each. They are separate
+ * rather than parameterised on a single flag because the crossed shapes are the
+ * point: a phone is narrow AND coarse, a window dragged under the breakpoint is
+ * narrow with a mouse still driving it, and a tablet is coarse with room to
+ * spare. See `docs/PLATFORM_ADAPTATION.md`.
+ */
+function renderPhoneComposer(props: RenderComposerProps = {}) {
+  viewport.set({ narrow: true, coarsePointer: true });
+  return renderComposerView(props);
+}
+
+/** A window dragged narrow that a mouse still drives: web, or Electron. */
+function renderNarrowMouseComposer(props: RenderComposerProps = {}) {
+  viewport.set({ narrow: true, coarsePointer: false });
+  return renderComposerView(props);
+}
+
+/** A roomy touch device: a tablet, or a phone turned into landscape. */
+function renderTouchTabletComposer(props: RenderComposerProps = {}) {
+  viewport.set({ narrow: false, coarsePointer: true });
+  return renderComposerView(props);
+}
+
+function pillsRow(container: HTMLElement) {
+  return container.querySelector('[data-slot="composer-settings-pills"]');
+}
+
+function addSheet(container: HTMLElement) {
+  return container.querySelector('[data-testid="add-to-chat-sheet"]');
+}
+
+function control(container: HTMLElement, label: string) {
+  return container.querySelector(`[aria-label="${label}"]`);
+}
+
+function fileInput(container: HTMLElement) {
+  return container.querySelector<HTMLInputElement>('input[type="file"]');
+}
+
+function textareaOf(container: HTMLElement) {
+  const textarea = container.querySelector("textarea");
+  if (!textarea) {
+    throw new Error("composer rendered without a textarea");
+  }
+  return textarea;
+}
+
+/**
+ * The class list on an icon-only button's glyph wrapper, which is where the
+ * `Button` primitive puts the glyph sizing.
+ */
+function glyphClassOf(button: Element | null): string {
+  return button?.querySelector("span")?.className ?? "";
+}
+
+/** A `FileList` stand-in, which the test DOM cannot construct. */
+function fileListOf(files: File[]): FileList {
+  const list = {
+    length: files.length,
+    item: (index: number) => files[index] ?? null,
+  } as unknown as FileList;
+  files.forEach((file, index) => {
+    (list as unknown as Record<number, File>)[index] = file;
+  });
+  return list;
+}
+
 describe("ChatComposer — placeholder", () => {
   test("renders the `placeholder` prop on the textarea", () => {
     const html = renderComposer({ placeholder: "Type something cool" });
@@ -990,31 +1079,9 @@ describe("ChatComposer — optional slots", () => {
 // ---------------------------------------------------------------------------
 
 describe("ChatComposer: mobile settings pills row", () => {
-  const SETTINGS_SLOTS = {
-    thresholdPickerSlot: <span>THR</span>,
-    modelPickerSlot: <span>PROFILE</span>,
-  };
-
-  function pillsRow(container: HTMLElement) {
-    return container.querySelector('[data-slot="composer-settings-pills"]');
-  }
-
-  function textareaOf(container: HTMLElement) {
-    const textarea = container.querySelector("textarea");
-    if (!textarea) {
-      throw new Error("composer rendered without a textarea");
-    }
-    return textarea;
-  }
-
-  function renderPhoneComposer(props: RenderComposerProps = {}) {
-    viewport.set({ narrow: true, coarsePointer: true });
-    return renderComposerView({ ...SETTINGS_SLOTS, ...props });
-  }
-
   test("an unfocused phone composer keeps the row mounted but hidden", () => {
     // GIVEN a phone composer nobody has tapped into
-    const { container } = renderPhoneComposer();
+    const { container } = renderPhoneComposer(SETTINGS_SLOTS);
 
     // THEN the row is mounted, so each menu loads the state its pill gates on
     // before the first focus of the session
@@ -1033,7 +1100,7 @@ describe("ChatComposer: mobile settings pills row", () => {
 
   test("focusing the composer raises the row above the card, access first", () => {
     // GIVEN a phone composer
-    const { container } = renderPhoneComposer();
+    const { container } = renderPhoneComposer(SETTINGS_SLOTS);
 
     // WHEN it takes focus
     fireEvent.focusIn(textareaOf(container));
@@ -1053,7 +1120,7 @@ describe("ChatComposer: mobile settings pills row", () => {
 
   test("blurring to the body puts the row away without unmounting its menus", () => {
     // GIVEN a focused phone composer
-    const { container } = renderPhoneComposer();
+    const { container } = renderPhoneComposer(SETTINGS_SLOTS);
     const textarea = textareaOf(container);
     fireEvent.focusIn(textarea);
 
@@ -1068,7 +1135,10 @@ describe("ChatComposer: mobile settings pills row", () => {
 
   test("an open settings sheet holds the row up after focus leaves", () => {
     // GIVEN a phone composer whose access sheet is open
-    const { container } = renderPhoneComposer({ settingsSheetOpen: true });
+    const { container } = renderPhoneComposer({
+      ...SETTINGS_SLOTS,
+      settingsSheetOpen: true,
+    });
     const textarea = textareaOf(container);
     fireEvent.focusIn(textarea);
 
@@ -1079,9 +1149,26 @@ describe("ChatComposer: mobile settings pills row", () => {
     expect(pillsRow(container)?.hasAttribute("hidden")).toBe(false);
   });
 
+  test("the composer's own add-to-chat sheet holds the row up too", () => {
+    // GIVEN a focused phone composer
+    const { container } = renderPhoneComposer(SETTINGS_SLOTS);
+    const textarea = textareaOf(container);
+    fireEvent.focusIn(textarea);
+
+    // WHEN the plus opens the add-to-chat sheet, which takes focus into a
+    // portal of its own
+    fireEvent.click(control(container, PLUS_LABEL)!);
+    fireEvent.focusOut(textarea, { relatedTarget: null });
+
+    // THEN the row stays up, rather than dropping away and shifting the card
+    // down under the sheet's scrim
+    expect(pillsRow(container)?.hasAttribute("hidden")).toBe(false);
+  });
+
   test("a sheet flag that goes false with focus gone puts the row away", () => {
     // GIVEN a phone composer holding the row up for an open sheet, focus gone
     const { container, rerender } = renderPhoneComposer({
+      ...SETTINGS_SLOTS,
       settingsSheetOpen: true,
     });
     const textarea = textareaOf(container);
@@ -1129,43 +1216,6 @@ describe("ChatComposer: mobile settings pills row", () => {
 // ---------------------------------------------------------------------------
 
 describe("ChatComposer: single-row mobile composer", () => {
-  const PLUS_LABEL = "Add to chat";
-
-  function renderPhoneComposer(props: RenderComposerProps = {}) {
-    viewport.set({ narrow: true, coarsePointer: true });
-    return renderComposerView(props);
-  }
-
-  /** A window dragged narrow that a mouse still drives: web, or Electron. */
-  function renderNarrowMouseComposer(props: RenderComposerProps = {}) {
-    viewport.set({ narrow: true, coarsePointer: false });
-    return renderComposerView(props);
-  }
-
-  function control(container: HTMLElement, label: string) {
-    return container.querySelector(`[aria-label="${label}"]`);
-  }
-
-  function addSheet(container: HTMLElement) {
-    return container.querySelector('[data-testid="add-to-chat-sheet"]');
-  }
-
-  function fileInput(container: HTMLElement) {
-    return container.querySelector<HTMLInputElement>('input[type="file"]');
-  }
-
-  /** A `FileList` stand-in, which the test DOM cannot construct. */
-  function fileListOf(files: File[]): FileList {
-    const list = {
-      length: files.length,
-      item: (index: number) => files[index] ?? null,
-    } as unknown as FileList;
-    files.forEach((file, index) => {
-      (list as unknown as Record<number, File>)[index] = file;
-    });
-    return list;
-  }
-
   test("a phone composer swaps the paperclip for the plus", () => {
     // GIVEN a phone composer
     const { container } = renderPhoneComposer();
@@ -1238,6 +1288,60 @@ describe("ChatComposer: single-row mobile composer", () => {
     // and gallery rows have nothing to offer a mouse, never mounts
     expect(control(container, PLUS_LABEL)).not.toBeNull();
     expect(addSheet(container)).toBeNull();
+  });
+
+  test("the plus wears the row's chrome on either narrow window", () => {
+    // GIVEN each of the two narrow shapes: a phone, and a window a mouse drags
+    // under the breakpoint
+    for (const mount of [renderPhoneComposer, renderNarrowMouseComposer]) {
+      cleanup();
+      const { container } = mount();
+
+      // THEN the plus is the row's 40x40 circle carrying a 20px glyph in both,
+      // rather than a desktop control sitting inside a mobile row
+      const plus = control(container, PLUS_LABEL);
+      expect(plus?.className).toContain("h-10 w-10 rounded-full");
+      expect(glyphClassOf(plus)).toContain("size-5");
+    }
+  });
+
+  test("the context-window indicator centres against the row's controls", () => {
+    // GIVEN a phone composer with the device preference on
+    const { getByText } = renderPhoneComposer({
+      contextWindowIndicatorSlot: <span>CTX</span>,
+    });
+
+    // THEN it sits in a control-height box that centres it, rather than flush
+    // on the card's bottom edge as a bare child of the `items-end` row
+    const box = getByText("CTX").parentElement;
+    expect(box?.className).toContain("items-center");
+    expect(box?.className).toContain("h-10");
+  });
+
+  test("a touch device at desktop width keeps the sheet mounted", () => {
+    // GIVEN a tablet, or a phone turned into landscape
+    const { container } = renderTouchTabletComposer();
+
+    // THEN the room it has takes the desktop row back, while the sheet stays
+    // mounted so its hidden inputs outlive the swap
+    expect(control(container, "Attach file")).not.toBeNull();
+    expect(addSheet(container)?.getAttribute("data-open")).toBe("false");
+  });
+
+  test("rotating mid-pick leaves the open sheet and its inputs mounted", () => {
+    // GIVEN a phone whose add-to-chat sheet is up
+    const { container, rerender } = renderPhoneComposer();
+    fireEvent.click(control(container, PLUS_LABEL)!);
+    expect(addSheet(container)?.getAttribute("data-open")).toBe("true");
+
+    // WHEN the phone turns into landscape, crossing the width breakpoint while
+    // the camera or gallery pick is still resolving
+    viewport.set({ narrow: false, coarsePointer: true });
+    rerender(composerElement());
+
+    // THEN the sheet is still there to receive it, since what mounts it is the
+    // pointer, which rotating does not change
+    expect(addSheet(container)?.getAttribute("data-open")).toBe("true");
   });
 
   test("the plus opens the picker directly when a mouse drives the window", () => {
@@ -1324,18 +1428,6 @@ describe("ChatComposer: single-row mobile composer", () => {
       html.indexOf('aria-label="Attach file"'),
     );
   });
-
-  test("a variant with no settings slots attaches but grows no pill row", () => {
-    // GIVEN the app-editing variant on a phone: no settings slots. Attach is
-    // part of every variant, so the plus is the control it gets.
-    const { container } = renderPhoneComposer();
-
-    // THEN there is nothing to float above the card
-    expect(
-      container.querySelector('[data-slot="composer-settings-pills"]'),
-    ).toBeNull();
-    expect(control(container, PLUS_LABEL)).not.toBeNull();
-  });
 });
 
 // ---------------------------------------------------------------------------
@@ -1343,8 +1435,11 @@ describe("ChatComposer: single-row mobile composer", () => {
 // ---------------------------------------------------------------------------
 
 describe("ChatComposer: the mobile send slot", () => {
-  const CIRCLE_CLASS = "touch-mobile:rounded-full";
-  const SEND_FILL_CLASS = "touch-mobile:bg-[var(--system-positive-strong)]";
+  // Plain, unprefixed classes: the row's chrome answers to the same width
+  // signal that produces the row, so it lands on every narrow window rather
+  // than only on the coarse-pointer ones the `touch-mobile:` variant reaches.
+  const CIRCLE_CLASS = "h-10 w-10 rounded-full";
+  const SEND_FILL_CLASS = "bg-[var(--system-positive-strong)]";
 
   test("an empty draft leaves the circular live-voice button in the slot", () => {
     // GIVEN a phone composer with nothing to send
@@ -1404,6 +1499,68 @@ describe("ChatComposer: the mobile send slot", () => {
     });
     expect(drafted.queryByLabelText("Send message")).not.toBeNull();
     expect(drafted.queryByLabelText("Stop generating")).toBeNull();
+  });
+
+  test("the busy row's control wears the same circle the resting slot does", () => {
+    // GIVEN a busy turn on a phone with nothing drafted
+    viewport.set({ narrow: true, coarsePointer: true });
+    const empty = renderVoiceComposer({ input: "", isAssistantBusy: true });
+
+    // THEN a turn starting does not shrink the row's right end back to a
+    // desktop control
+    const stop = empty.queryByLabelText("Stop generating");
+    expect(stop?.className).toContain(CIRCLE_CLASS);
+    expect(glyphClassOf(stop)).toContain("size-5");
+
+    // AND the send it gives the slot to, once there is a draft, is the same
+    // filled circle the resting composer offers
+    cleanup();
+    const drafted = renderVoiceComposer({
+      input: "hello",
+      isAssistantBusy: true,
+    });
+    const send = drafted.queryByLabelText("Send message");
+    expect(send?.className).toContain(CIRCLE_CLASS);
+    expect(send?.className).toContain(SEND_FILL_CLASS);
+  });
+
+  test("a narrow mouse-driven window gets the circle a phone gets", () => {
+    // GIVEN a window dragged under the breakpoint that a mouse still drives
+    viewport.set({ narrow: true, coarsePointer: false });
+    const { queryByLabelText } = renderVoiceComposer({ input: "hello" });
+
+    // THEN the row it takes carries the row's chrome throughout, rather than
+    // pairing a mobile layout with desktop controls
+    const send = queryByLabelText("Send message");
+    expect(send?.className).toContain(CIRCLE_CLASS);
+    expect(send?.className).toContain(SEND_FILL_CLASS);
+    expect(glyphClassOf(send)).toContain("size-5");
+  });
+
+  test("the voice circle follows the same signal as the send it shares with", () => {
+    // GIVEN each narrow shape with nothing to send
+    for (const coarsePointer of [true, false]) {
+      cleanup();
+      viewport.set({ narrow: true, coarsePointer });
+      const { queryByLabelText } = renderVoiceComposer({ input: "" });
+
+      // THEN voice mode holds the slot as the same filled circle either way
+      const voice = queryByLabelText("Start voice mode");
+      expect(voice?.className).toContain(CIRCLE_CLASS);
+      expect(glyphClassOf(voice)).toContain("size-5");
+    }
+  });
+
+  test("desktop keeps the primitive's own send chrome", () => {
+    // GIVEN a roomy window
+    viewport.set({ narrow: false, coarsePointer: false });
+    const { queryByLabelText } = renderVoiceComposer({ input: "hello" });
+
+    // THEN none of the row's chrome reaches it
+    const send = queryByLabelText("Send message");
+    expect(send?.className).not.toContain("rounded-full");
+    expect(send?.className).not.toContain(SEND_FILL_CLASS);
+    expect(glyphClassOf(send)).not.toContain("size-5");
   });
 });
 

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -64,7 +64,6 @@ import { useVoiceSurfacePaint } from "@/domains/chat/voice/voice-room/use-voice-
 import { useVoiceRecordingStore } from "@/domains/chat/voice/voice-recording-store";
 import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 import { useIsMobile } from "@/hooks/use-is-mobile";
-import { useTouchMobile } from "@/hooks/use-touch-mobile";
 import { isElectron } from "@/runtime/is-electron";
 import { isPopoutWindowLifetime } from "@/runtime/popout-window";
 import { useIsNativePlatform } from "@/runtime/native-auth";
@@ -234,16 +233,38 @@ function measureVoiceOriginAvatar(): { x: number; y: number } | null {
   return { x: best.left + best.width / 2, y: best.top + best.height / 2 };
 }
 
-/** The 20px glyphs the mobile row's 40x40 controls carry. */
-const MOBILE_GLYPH_CLASS = "touch-mobile:size-5 touch-mobile:[&_svg]:size-5";
+/**
+ * The 40x40 circle the mobile row's controls stand at.
+ *
+ * Driven from the composer's own `isMobile` branch, the same signal that
+ * produces the row, rather than from the `touch-mobile:` variant. The two
+ * disagree on a window dragged under the breakpoint, which would otherwise take
+ * the mobile row's structure while every control in it kept desktop chrome. The
+ * primitive's own mobile growth is switched off (`expandOnMobile={false}`)
+ * wherever these classes land, so one signal owns the whole control. See
+ * `docs/PLATFORM_ADAPTATION.md`.
+ */
+const MOBILE_CONTROL_CLASS = "h-10 w-10 rounded-full";
+
+/** The 20px glyphs those 40x40 controls carry. */
+const MOBILE_GLYPH_CLASS = "size-5 [&_svg]:size-5";
+
+/**
+ * The press wash under the row's unfilled glyphs. The primitive paints one for
+ * ghost icon-only buttons under `touch-mobile:` alone, so the row carries its
+ * own and every narrow window lights up the same way.
+ */
+const MOBILE_GHOST_WASH_CLASS =
+  "hover:bg-[var(--surface-active)] active:bg-[var(--surface-active)]";
 
 /**
  * The mobile send button's filled circle. Applied only while the button can
  * actually send, so a blocked draft keeps the `Button` primitive's disabled
- * fill rather than a green control nobody can press.
+ * fill rather than a green control nobody can press. Hover holds the fill
+ * alongside active, since a mouse reaches this row too.
  */
 const MOBILE_SEND_FILL_CLASS =
-  "touch-mobile:bg-[var(--system-positive-strong)] touch-mobile:active:bg-[var(--system-positive-strong)] touch-mobile:[--vbtn-fg:var(--aux-white)]";
+  "bg-[var(--system-positive-strong)] hover:bg-[var(--system-positive-strong)] active:bg-[var(--system-positive-strong)] [--vbtn-fg:var(--aux-white)]";
 
 interface AddToChatButtonProps {
   disabled: boolean;
@@ -258,14 +279,19 @@ function AddToChatButton({ disabled, label, onClick }: AddToChatButtonProps) {
       variant="ghost"
       iconOnly={<Plus strokeWidth={2} />}
       iconOnlyGlyphClassName={MOBILE_GLYPH_CLASS}
+      // The row sizes its own controls, so the primitive's mobile growth is
+      // off here and every narrow window gets the same plus.
+      expandOnMobile={false}
       onClick={onClick}
       disabled={disabled}
       aria-label={label}
       title={label}
-      // Tertiary resting tone, matching the row's other glyphs. The
-      // touch-mobile override beats the ghost icon-only variant's default-tone
-      // mobile chrome.
-      className="[--vbtn-fg:var(--content-tertiary)] touch-mobile:[--vbtn-fg:var(--content-tertiary)]"
+      // Tertiary resting tone, matching the row's other glyphs.
+      className={cn(
+        MOBILE_CONTROL_CLASS,
+        MOBILE_GHOST_WASH_CLASS,
+        "[--vbtn-fg:var(--content-tertiary)]",
+      )}
     />
   );
 }
@@ -279,9 +305,9 @@ interface AddToChatPickerButtonProps {
 /**
  * The plus a mouse gets: it opens the file picker directly, the same picker
  * behind the desktop paperclip, through the same hook so the iOS refocus dance
- * is identical. A window narrowed by dragging its edge takes the compact row
- * but not the touch sheet, whose Camera and Find-in-Gallery rows have nothing
- * to offer a pointer and whose `touch-mobile:` chrome does not apply here.
+ * is identical. A window narrowed by dragging its edge takes the compact row,
+ * chrome included, but not the touch sheet, whose Camera and Find-in-Gallery
+ * rows have nothing to offer a pointer.
  */
 function AddToChatPickerButton({
   disabled,
@@ -353,7 +379,6 @@ export function ChatComposer({
     voicePhase === "recording" || voicePhase === "processing";
   // Holds the MediaStream opened by VoiceInputButton so we can reuse it for
   // amplitude analysis rather than opening a second getUserMedia request.
-  const voiceStreamRef = useRef<MediaStream | null>(null);
   const [voiceStream, setVoiceStream] = useState<MediaStream | null>(null);
   const { amplitude } = useAudioAmplitude({
     active: voicePhase === "recording" && voiceStream !== null,
@@ -574,12 +599,11 @@ export function ChatComposer({
   // roomy tablet and on a narrowed desktop window, and the substitute belongs to
   // the absence of the thing it replaces. See `docs/PLATFORM_ADAPTATION.md`.
   const keyboardCanSubmit = !pointerCoarse;
+  // The compact row and everything in it follow the window's width; what the
+  // plus opens follows the input. A narrowed desktop or Electron window keeps
+  // the row, and still wants the picker a mouse can drive. See
+  // `docs/PLATFORM_ADAPTATION.md`.
   const isMobile = useIsMobile();
-  // The compact single row follows the window's width; what the plus opens
-  // follows the input. Both halves are load-bearing for the sheet: a narrowed
-  // desktop or Electron window keeps the row, and still wants the picker a
-  // mouse can drive. See `docs/PLATFORM_ADAPTATION.md`.
-  const isTouchMobile = useTouchMobile();
   const isNative = useIsNativePlatform();
   const isElectronHost = isElectron();
 
@@ -687,11 +711,11 @@ export function ChatComposer({
     phase === "queued" || phase === "thinking" || phase === "streaming";
   const showInlineVoicePreview =
     isVoiceActive && !isLocallyGenerating && !isElectronHost;
+  // Dictation's inline preview takes the textarea's place on native. A
+  // live-voice session does not: its bar sits above the card and the composer
+  // stays a working composer underneath, so the user can type and send
+  // mid-session.
   const hideTextareaForVoice = isNative && showInlineVoicePreview;
-  // A live-voice session no longer touches the textarea row: the bar sits
-  // above the card and the composer stays a working composer underneath, so
-  // the user can type and send mid-session.
-  const hideTextareaRow = hideTextareaForVoice;
   const hasStagedQuotes = useQuoteReplyStore.use.stagedQuotes().length > 0;
   const canSendMessageContent =
     Boolean(input.trim()) || canSendAttachments || hasStagedQuotes;
@@ -737,8 +761,6 @@ export function ChatComposer({
   // passes neither slot (the app-editing panel) has no row to show.
   const hasSettingsPills =
     isMobile && Boolean(thresholdPickerSlot || modelPickerSlot);
-  const settingsPillsVisible =
-    hasSettingsPills && (composerFocusWithin || settingsSheetOpen);
 
   // No longer suppressed during a live-voice session: it was suppressed
   // because the streaming speech rendered in the ghost-suffix mirror's own
@@ -756,7 +778,15 @@ export function ChatComposer({
   );
 
   const [addSheetOpen, setAddSheetOpen] = useState(false);
-  const usesAddSheet = isMobile && isTouchMobile;
+  const usesAddSheet = isMobile && pointerCoarse;
+
+  // Every surface opened from the composer moves focus into a portal, the
+  // composer's own add-to-chat sheet included, so each one has to hold the row
+  // up on its way out. Without the sheet's flag the row would drop away as the
+  // sheet rises and the card would shift down under the scrim.
+  const settingsPillsVisible =
+    hasSettingsPills &&
+    (composerFocusWithin || settingsSheetOpen || addSheetOpen);
 
   // 26px is half the mobile card's 52px collapsed height, so the resting
   // composer is a pill and keeps that corner once attachments make it taller.
@@ -811,10 +841,8 @@ export function ChatComposer({
       onInterimTranscript={onVoiceInterimTranscript}
       onError={onVoiceError}
       onBeforeStart={onVoiceBeforeStart}
-      onStreamReady={(stream: MediaStream | null) => {
-        voiceStreamRef.current = stream;
-        setVoiceStream(stream);
-      }}
+      onStreamReady={setVoiceStream}
+      mobileRow={isMobile}
     />
   ) : null;
 
@@ -833,12 +861,14 @@ export function ChatComposer({
     <LiveVoiceButton
       onStart={handleLiveVoiceStart}
       disabled={typingDisabled || isVoiceActive || isLiveVoiceSessionLive}
+      mobileRow={isMobile}
     />
   ) : (
     <Button
       variant="primary"
       iconOnly={<ArrowUp className="h-4 w-4" strokeWidth={2.5} />}
-      iconOnlyGlyphClassName={MOBILE_GLYPH_CLASS}
+      iconOnlyGlyphClassName={isMobile ? MOBILE_GLYPH_CLASS : undefined}
+      expandOnMobile={!isMobile}
       type="submit"
       disabled={sendBlocked}
       title={
@@ -850,26 +880,40 @@ export function ChatComposer({
       }
       aria-label="Send message"
       className={cn(
-        "touch-mobile:rounded-full",
-        !sendBlocked && MOBILE_SEND_FILL_CLASS,
+        isMobile && MOBILE_CONTROL_CLASS,
+        isMobile && !sendBlocked && MOBILE_SEND_FILL_CLASS,
       )}
     />
   );
 
+  // The busy row's single control wears the same chrome as the resting slot it
+  // stands in for, so a turn starting does not shrink the row's right end back
+  // to a desktop control.
   const busyRowControl = sendReplacesStop ? (
     <Button
       variant="primary"
       iconOnly={<ArrowUp className="h-4 w-4" strokeWidth={2.5} />}
+      iconOnlyGlyphClassName={isMobile ? MOBILE_GLYPH_CLASS : undefined}
+      expandOnMobile={!isMobile}
       type="submit"
       title="Send message"
       aria-label="Send message"
+      className={cn(
+        // Reachable only when the draft can actually go, so the filled tone
+        // never lands on a send nobody can press.
+        isMobile && MOBILE_CONTROL_CLASS,
+        isMobile && MOBILE_SEND_FILL_CLASS,
+      )}
     />
   ) : (
     <Button
       variant="primary"
       iconOnly={<Square className="h-3 w-3" fill="currentColor" />}
+      iconOnlyGlyphClassName={isMobile ? MOBILE_GLYPH_CLASS : undefined}
+      expandOnMobile={!isMobile}
       onClick={onStopGenerating}
       aria-label="Stop generating"
+      className={isMobile ? MOBILE_CONTROL_CLASS : undefined}
     />
   );
 
@@ -916,7 +960,11 @@ export function ChatComposer({
   const textFieldBlock = (
     <div
       className={
-        hideTextareaRow ? "hidden" : isMobile ? "grid min-w-0 flex-1" : "grid"
+        hideTextareaForVoice
+          ? "hidden"
+          : isMobile
+            ? "grid min-w-0 flex-1"
+            : "grid"
       }
     >
       <div
@@ -1233,43 +1281,56 @@ export function ChatComposer({
                   attachments={attachments}
                   onRemove={removeAttachment}
                 />
-                {isMobile ? (
-                  <>
-                    {inlineVoicePreview}
-                    {/* One row: add, divider, input, mic, voice-or-send.
+                {/* Above both layouts: what a control does when the card runs
+                    narrow is the control's own business, and must not depend on
+                    which row it happens to be sitting in. */}
+                <ComposerCompactProvider compact={compactSettings}>
+                  {isMobile ? (
+                    <>
+                      {inlineVoicePreview}
+                      {/* One row: add, divider, input, mic, voice-or-send.
                         `items-end` holds the fixed-height controls on the
                         card's bottom edge while the textarea grows upward. */}
-                    <div className="flex items-end py-1.5 pl-0.5 pr-1.5">
-                      {contextWindowIndicatorSlot}
-                      {!isAssistantBusy && attachControl}
-                      {!isAssistantBusy && (
-                        <div
-                          aria-hidden="true"
-                          className="-ml-0.5 mb-2 h-6 w-px shrink-0 bg-[var(--border-hover)]"
-                        />
-                      )}
-                      {textFieldBlock}
-                      <div className="flex shrink-0 items-end gap-1.5">
-                        {isAssistantBusy ? (
-                          busyRowControl
-                        ) : (
-                          <>
-                            {dictationButton}
-                            {sendSlot}
-                          </>
+                      <div className="flex items-end py-1.5 pl-0.5 pr-1.5">
+                        {contextWindowIndicatorSlot ? (
+                          // A bare slot in an `items-end` row sits flush on the
+                          // card's bottom edge; a control-height box centres it
+                          // against the glyphs beside it instead.
+                          <div className="mr-1 flex h-10 shrink-0 items-center">
+                            {contextWindowIndicatorSlot}
+                          </div>
+                        ) : null}
+                        {!isAssistantBusy && attachControl}
+                        {!isAssistantBusy && (
+                          <div
+                            aria-hidden="true"
+                            className="-ml-0.5 mb-2 h-6 w-px shrink-0 bg-[var(--border-hover)]"
+                          />
                         )}
+                        {textFieldBlock}
+                        {/* The mic's 40x40 box carries 10px of slack around its
+                          20px glyph, so 6px of gap lands that glyph the
+                          design's 16px from the voice circle. */}
+                        <div className="flex shrink-0 items-end gap-1.5">
+                          {isAssistantBusy ? (
+                            busyRowControl
+                          ) : (
+                            <>
+                              {dictationButton}
+                              {sendSlot}
+                            </>
+                          )}
+                        </div>
                       </div>
-                    </div>
-                  </>
-                ) : (
-                  <>
-                    {textFieldBlock}
-                    {inlineVoicePreview}
-                    {/* Action row: attach, divider, access on the left; model
+                    </>
+                  ) : (
+                    <>
+                      {textFieldBlock}
+                      {inlineVoicePreview}
+                      {/* Action row: attach, divider, access on the left; model
                         profile, divider, mic, send on the right. It stays
                         mounted through a live-voice session, whose own
                         controls live in the bar above the card. */}
-                    <ComposerCompactProvider compact={compactSettings}>
                       <div className="flex items-center justify-between gap-1 px-2 pb-2">
                         <div className="flex min-w-0 items-center gap-2">
                           {contextWindowIndicatorSlot}
@@ -1305,9 +1366,9 @@ export function ChatComposer({
                           )}
                         </div>
                       </div>
-                    </ComposerCompactProvider>
-                  </>
-                )}
+                    </>
+                  )}
+                </ComposerCompactProvider>
               </div>
             </form>
           </Popover.Anchor>
@@ -1338,10 +1399,16 @@ export function ChatComposer({
             )}
           </Popover.Content>
         </Popover.Root>
-        {usesAddSheet && (
+        {pointerCoarse && (
           // Beside the form, not inside it: the sheet keeps hidden file inputs
           // mounted while a native picker is up, and those have no business in
           // the form the composer submits.
+          //
+          // Mounted on the pointer alone rather than on the compound that
+          // decides whether the plus opens it. Rotating a phone into landscape
+          // crosses the width breakpoint, and unmounting the inputs there would
+          // drop a camera or gallery pick still being made. A touch device at
+          // desktop width just keeps a closed sheet mounted.
           <AddToChatSheet
             open={addSheetOpen}
             onOpenChange={setAddSheetOpen}

--- a/clients/web/src/domains/chat/components/live-voice-button.test.tsx
+++ b/clients/web/src/domains/chat/components/live-voice-button.test.tsx
@@ -43,6 +43,26 @@ describe("LiveVoiceButton", () => {
     expect(onStartSpy).toHaveBeenCalledTimes(1);
   });
 
+  test("mobileRow renders the composer row's 40x40 circle with a 20px glyph", () => {
+    // GIVEN the button in the mobile composer row
+    const { getByLabelText } = render(
+      <LiveVoiceButton onStart={onStartSpy} mobileRow />,
+    );
+
+    // THEN it is the design's filled circle, sized here rather than by the
+    // primitive's own mobile growth, so every narrow window gets the same one
+    const button = getByLabelText("Start voice mode");
+    expect(button.className).toContain("h-10 w-10 rounded-full");
+    expect(button.querySelector("span")?.className).toContain("[&_svg]:size-5");
+
+    // WHILE the default leaves the primitive's sizing alone
+    cleanup();
+    const desktop = render(<LiveVoiceButton onStart={onStartSpy} />);
+    const plain = desktop.getByLabelText("Start voice mode");
+    expect(plain.className).not.toContain("h-10 w-10 rounded-full");
+    expect(plain.className).toContain("touch-mobile:h-10");
+  });
+
   test("prevents starting a session when disabled", () => {
     // GIVEN a button the parent has disabled
     const { getByLabelText } = render(

--- a/clients/web/src/domains/chat/components/live-voice-button.tsx
+++ b/clients/web/src/domains/chat/components/live-voice-button.tsx
@@ -28,11 +28,20 @@ interface LiveVoiceButtonProps {
   onStart: (origin?: { x: number; y: number }) => void;
   /** Disable the control (e.g. while dictation is recording). */
   disabled?: boolean;
+  /**
+   * Render as the mobile composer row's send-slot control: a 40x40 filled
+   * circle holding a 20px glyph. The composer drives this from the same
+   * window-width signal that produces that row, so a phone and a window
+   * dragged narrow get the same circle. Off by default, which leaves the
+   * `Button` primitive's own sizing in charge.
+   */
+  mobileRow?: boolean;
 }
 
 export function LiveVoiceButton({
   onStart,
   disabled = false,
+  mobileRow = false,
 }: LiveVoiceButtonProps) {
   return (
     <Button
@@ -42,12 +51,12 @@ export function LiveVoiceButton({
       // fill) — rather than a low-emphasis ghost that reads as secondary.
       variant="primary"
       iconOnly={<AudioLines strokeWidth={2} />}
-      // Mobile reads the slot as a 40x40 filled circle holding a 20px glyph.
-      // The primitive already grows icon-only buttons to 40x40 under
-      // `touch-mobile:`, so only the corner and the glyph size are left; the
-      // fill is the `primary` token the design's light circle resolves to.
-      iconOnlyGlyphClassName="touch-mobile:size-5 touch-mobile:[&_svg]:size-5"
-      className="touch-mobile:rounded-full"
+      // The row's own signal sizes the circle, so the primitive's mobile growth
+      // steps aside; the fill is the `primary` token the design's light circle
+      // resolves to.
+      iconOnlyGlyphClassName={mobileRow ? "size-5 [&_svg]:size-5" : undefined}
+      expandOnMobile={!mobileRow}
+      className={mobileRow ? "h-10 w-10 rounded-full" : undefined}
       // Anchor for the in-chat tour's closing beat, which lands the assistant's
       // avatar on this control.
       data-tour-id="voice-mode"

--- a/clients/web/src/domains/chat/components/voice-input-button.test.tsx
+++ b/clients/web/src/domains/chat/components/voice-input-button.test.tsx
@@ -599,3 +599,47 @@ describe("VoiceInputButton — forced native provider (macOS Native Dictation)",
     expect(lastBreadcrumb().data.outcome).toBe("error");
   });
 });
+
+describe("VoiceInputButton: mobile composer row chrome", () => {
+  afterEach(() => {
+    cleanup();
+    useVoiceRecordingStore.getState().reset();
+  });
+
+  test("mobileRow gives the idle mic the row's 40x40 circle and 20px glyph", () => {
+    // GIVEN the mic in the mobile composer row
+    render(
+      <VoiceInputButton
+        assistantId="assistant-1"
+        onTranscript={async () => {}}
+        mobileRow
+      />,
+    );
+
+    // THEN the resting mic reads at the design's 20px rather than at the
+    // primitive's default, and the row sizes the control itself so a narrow
+    // mouse-driven window gets the same mic a phone does
+    const button = screen.getByRole("button", { name: "Start voice input" });
+    expect(button.className).toContain("h-10 w-10 rounded-full");
+    expect(button.querySelector("span")?.className).toContain("[&_svg]:size-5");
+  });
+
+  test("the default leaves the idle mic at the primitive's sizing", () => {
+    // GIVEN the mic anywhere else, the desktop action row included
+    render(
+      <VoiceInputButton
+        assistantId="assistant-1"
+        onTranscript={async () => {}}
+      />,
+    );
+
+    // THEN the row's own sizing does not reach it, and the primitive's
+    // `touch-mobile:` chrome is left in charge
+    const button = screen.getByRole("button", { name: "Start voice input" });
+    expect(button.className).not.toContain("h-10 w-10 rounded-full");
+    expect(button.className).toContain("touch-mobile:h-10");
+    expect(button.querySelector("span")?.className).not.toContain(
+      "[&_svg]:size-5",
+    );
+  });
+});

--- a/clients/web/src/domains/chat/components/voice-input-button.tsx
+++ b/clients/web/src/domains/chat/components/voice-input-button.tsx
@@ -246,6 +246,14 @@ interface VoiceInputButtonProps {
   disabled?: boolean;
   onBeforeStart?: () => boolean | Promise<boolean>;
   renderButton?: boolean;
+  /**
+   * Render as the mobile composer row's mic: a 40x40 circular control holding
+   * a 20px glyph. The composer drives this from the same window-width signal
+   * that produces that row, so a phone and a window dragged narrow get the
+   * same mic. Off by default, which leaves the `Button` primitive's own sizing
+   * in charge.
+   */
+  mobileRow?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -265,6 +273,7 @@ export const VoiceInputButton = forwardRef<
     disabled = false,
     onBeforeStart,
     renderButton = true,
+    mobileRow = false,
   },
   ref,
 ) {
@@ -1060,11 +1069,18 @@ export const VoiceInputButton = forwardRef<
           <Mic strokeWidth={2} />
         )
       }
-      // The recording "stop" glyph reads at 20px per the design; the mic /
+      // Every glyph in the mobile composer row reads at 20px, and the recording
+      // "stop" glyph does everywhere per the design. Outside those the mic and
       // loader keep the Button's default icon-only sizing.
       iconOnlyGlyphClassName={
-        recording ? "[&_svg]:size-5 touch-mobile:[&_svg]:size-5" : undefined
+        mobileRow
+          ? "size-5 [&_svg]:size-5"
+          : recording
+            ? "[&_svg]:size-5 touch-mobile:[&_svg]:size-5"
+            : undefined
       }
+      // The row sizes its own controls when it owns this one.
+      expandOnMobile={!mobileRow}
       onClick={() => {
         if (processing) {
           return;
@@ -1086,6 +1102,11 @@ export const VoiceInputButton = forwardRef<
         // ghost icon-only variant's default-tone mobile chrome so mobile
         // matches desktop.
         "[--vbtn-fg:var(--content-tertiary)] touch-mobile:[--vbtn-fg:var(--content-tertiary)]",
+        // The press wash comes with the sizing: the primitive paints one for
+        // ghost icon-only buttons under `touch-mobile:` alone, which a narrow
+        // mouse-driven window never matches.
+        mobileRow &&
+          "h-10 w-10 rounded-full hover:bg-[var(--surface-active)] active:bg-[var(--surface-active)]",
         isNative && recording && "h-12 w-12 max-md:h-12 max-md:w-12",
       )}
     />


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for mobile-composer-redesign.md: mobile chrome now follows the same width signal as the layout (narrow mouse windows get coherent styling), the busy control and mic match the design's 20px glyphs and circular chrome, the add-to-chat sheet survives rotation mid-picker, the pills row stays up while the sheet is open, and small dead code is removed.