### PR TITLE
docs: retarget the settings-sheet test comment to the menu's own unmount report

### DIFF
--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -1175,8 +1175,8 @@ describe("ChatComposer: mobile settings pills row", () => {
     fireEvent.focusIn(textarea);
     fireEvent.focusOut(textarea, { relatedTarget: null });
 
-    // WHEN the flag clears, as `useComposerSettingsSheets` clears it when the
-    // breakpoint swap unmounts the menu that owned the sheet
+    // WHEN the flag clears, as the settings menu clears it on its way out when
+    // the breakpoint swap unmounts the menu that owned the sheet
     rerender(composerElement({ ...SETTINGS_SLOTS, settingsSheetOpen: false }));
 
     // THEN nothing holds the row up any more


### PR DESCRIPTION
## Summary
Follow-up to #40667. The composer test's "sheet flag goes false" case still pointed at `useComposerSettingsSheets`, deleted in #40666. Retargets the comment to the mechanism that replaced it: the settings menu reports false on its way out when the breakpoint swap unmounts it. Comment only, no behavior change.