### PR TITLE
fix: round-2 review findings for the mobile composer

### DIFF
--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -17,11 +17,17 @@ import {
   type ChatAttachment,
   useComposerStore,
 } from "@/domains/chat/composer-store";
+import { selectFiles } from "@/domains/chat/components/chat-attachments/attachment-test-helpers";
+import {
+  MOBILE_CONTROL_CLASS,
+  MOBILE_GLYPH_CLASS,
+} from "@/domains/chat/components/chat-composer/composer-mobile-chrome";
 import type { VoiceInputButtonHandle } from "@/domains/chat/components/voice-input-button";
 import type { LiveVoicePreflightVerdict } from "@/domains/chat/voice/live-voice/live-voice-preflight-api";
 import { INITIAL_TURN_STATE, useTurnStore } from "@/domains/chat/turn-store";
 import * as assistantAvatarMod from "@/hooks/use-assistant-avatar";
 import * as emojiCatalogMod from "@/domains/chat/components/chat-composer/emoji-catalog";
+import * as nativeAuthMod from "@/runtime/native-auth";
 import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 import { viewportAxesStub } from "@/hooks/viewport-axes.test-helper";
 
@@ -54,6 +60,15 @@ mock.module("@/runtime/is-electron", () => ({
 let mockIsNativeIOS = false;
 mock.module("@/runtime/platform-detection", () => ({
   isNativeIOS: () => mockIsNativeIOS,
+}));
+
+// The native shell, which is the only place dictation's inline preview takes
+// the textarea's place in the row. Defaults to the browser; the row-layout
+// cases below flip it.
+let mockIsNativePlatform = false;
+mock.module("@/runtime/native-auth", () => ({
+  ...nativeAuthMod,
+  useIsNativePlatform: () => mockIsNativePlatform,
 }));
 
 // Live-voice integration. The session controller (`useLiveVoice`) lives in
@@ -262,6 +277,7 @@ function resetLiveVoiceMocks() {
   mockSupportsLiveVoice = true;
   mockIsElectron = false;
   mockIsNativeIOS = false;
+  mockIsNativePlatform = false;
   mockVoicePhase = "idle";
   mockPreflightVerdict = { status: "ready" };
   preflightSpy.mockClear();
@@ -760,18 +776,6 @@ function textareaOf(container: HTMLElement) {
  */
 function glyphClassOf(button: Element | null): string {
   return button?.querySelector("span")?.className ?? "";
-}
-
-/** A `FileList` stand-in, which the test DOM cannot construct. */
-function fileListOf(files: File[]): FileList {
-  const list = {
-    length: files.length,
-    item: (index: number) => files[index] ?? null,
-  } as unknown as FileList;
-  files.forEach((file, index) => {
-    (list as unknown as Record<number, File>)[index] = file;
-  });
-  return list;
 }
 
 describe("ChatComposer — placeholder", () => {
@@ -1300,9 +1304,28 @@ describe("ChatComposer: single-row mobile composer", () => {
       // THEN the plus is the row's 40x40 circle carrying a 20px glyph in both,
       // rather than a desktop control sitting inside a mobile row
       const plus = control(container, PLUS_LABEL);
-      expect(plus?.className).toContain("h-10 w-10 rounded-full");
-      expect(glyphClassOf(plus)).toContain("size-5");
+      expect(plus?.className).toContain(MOBILE_CONTROL_CLASS);
+      expect(glyphClassOf(plus)).toContain(MOBILE_GLYPH_CLASS);
     }
+  });
+
+  test("native dictation leaves the row's right controls anchored right", () => {
+    // GIVEN a phone in the native shell mid-dictation, where the inline
+    // waveform takes the textarea's place in the row
+    mockIsNativePlatform = true;
+    mockVoicePhase = "recording";
+    viewport.set({ narrow: true, coarsePointer: true });
+    const { container, queryByLabelText } = renderVoiceComposer();
+
+    // THEN the text field is out of the layout, and its `flex-1` with it
+    expect(container.querySelector("textarea")?.parentElement?.className).toBe(
+      "hidden",
+    );
+
+    // WHILE the right-hand group anchors itself rather than packing against
+    // the plus on the row's left edge
+    const rightGroup = queryByLabelText("Start voice input")?.parentElement;
+    expect(rightGroup?.className).toContain("ml-auto");
   });
 
   test("the context-window indicator centres against the row's controls", () => {
@@ -1374,11 +1397,7 @@ describe("ChatComposer: single-row mobile composer", () => {
 
     // WHEN the picker returns a file
     const picked = new File(["x"], "picked.png", { type: "image/png" });
-    Object.defineProperty(input, "files", {
-      configurable: true,
-      value: fileListOf([picked]),
-    });
-    fireEvent.change(input);
+    selectFiles(input, [picked]);
 
     // THEN it lands on the same callback the paperclip and the sheet feed
     expect(onAddAttachmentFiles).toHaveBeenCalledTimes(1);
@@ -1435,10 +1454,10 @@ describe("ChatComposer: single-row mobile composer", () => {
 // ---------------------------------------------------------------------------
 
 describe("ChatComposer: the mobile send slot", () => {
-  // Plain, unprefixed classes: the row's chrome answers to the same width
-  // signal that produces the row, so it lands on every narrow window rather
-  // than only on the coarse-pointer ones the `touch-mobile:` variant reaches.
-  const CIRCLE_CLASS = "h-10 w-10 rounded-full";
+  // The row's own chrome (`MOBILE_CONTROL_CLASS`) carries plain, unprefixed
+  // classes: it answers to the same width signal that produces the row, so it
+  // lands on every narrow window rather than only on the coarse-pointer ones
+  // the `touch-mobile:` variant reaches.
   const SEND_FILL_CLASS = "bg-[var(--system-positive-strong)]";
 
   test("an empty draft leaves the circular live-voice button in the slot", () => {
@@ -1448,7 +1467,7 @@ describe("ChatComposer: the mobile send slot", () => {
 
     // THEN voice mode holds the slot as a filled circle
     const voice = queryByLabelText("Start voice mode");
-    expect(voice?.className).toContain(CIRCLE_CLASS);
+    expect(voice?.className).toContain(MOBILE_CONTROL_CLASS);
     expect(queryByLabelText("Send message")).toBeNull();
   });
 
@@ -1459,7 +1478,7 @@ describe("ChatComposer: the mobile send slot", () => {
 
     // THEN send takes the circle over, in the filled tone of the design
     const send = queryByLabelText("Send message");
-    expect(send?.className).toContain(CIRCLE_CLASS);
+    expect(send?.className).toContain(MOBILE_CONTROL_CLASS);
     expect(send?.className).toContain(SEND_FILL_CLASS);
     expect(queryByLabelText("Start voice mode")).toBeNull();
 
@@ -1478,7 +1497,7 @@ describe("ChatComposer: the mobile send slot", () => {
     // THEN the circle stays but the filled tone does not, so a blocked send
     // never reads as one waiting to be pressed
     const send = queryByLabelText("Send message");
-    expect(send?.className).toContain(CIRCLE_CLASS);
+    expect(send?.className).toContain(MOBILE_CONTROL_CLASS);
     expect(send?.className).not.toContain(SEND_FILL_CLASS);
   });
 
@@ -1509,8 +1528,8 @@ describe("ChatComposer: the mobile send slot", () => {
     // THEN a turn starting does not shrink the row's right end back to a
     // desktop control
     const stop = empty.queryByLabelText("Stop generating");
-    expect(stop?.className).toContain(CIRCLE_CLASS);
-    expect(glyphClassOf(stop)).toContain("size-5");
+    expect(stop?.className).toContain(MOBILE_CONTROL_CLASS);
+    expect(glyphClassOf(stop)).toContain(MOBILE_GLYPH_CLASS);
 
     // AND the send it gives the slot to, once there is a draft, is the same
     // filled circle the resting composer offers
@@ -1520,7 +1539,7 @@ describe("ChatComposer: the mobile send slot", () => {
       isAssistantBusy: true,
     });
     const send = drafted.queryByLabelText("Send message");
-    expect(send?.className).toContain(CIRCLE_CLASS);
+    expect(send?.className).toContain(MOBILE_CONTROL_CLASS);
     expect(send?.className).toContain(SEND_FILL_CLASS);
   });
 
@@ -1532,9 +1551,9 @@ describe("ChatComposer: the mobile send slot", () => {
     // THEN the row it takes carries the row's chrome throughout, rather than
     // pairing a mobile layout with desktop controls
     const send = queryByLabelText("Send message");
-    expect(send?.className).toContain(CIRCLE_CLASS);
+    expect(send?.className).toContain(MOBILE_CONTROL_CLASS);
     expect(send?.className).toContain(SEND_FILL_CLASS);
-    expect(glyphClassOf(send)).toContain("size-5");
+    expect(glyphClassOf(send)).toContain(MOBILE_GLYPH_CLASS);
   });
 
   test("the voice circle follows the same signal as the send it shares with", () => {
@@ -1546,8 +1565,8 @@ describe("ChatComposer: the mobile send slot", () => {
 
       // THEN voice mode holds the slot as the same filled circle either way
       const voice = queryByLabelText("Start voice mode");
-      expect(voice?.className).toContain(CIRCLE_CLASS);
-      expect(glyphClassOf(voice)).toContain("size-5");
+      expect(voice?.className).toContain(MOBILE_CONTROL_CLASS);
+      expect(glyphClassOf(voice)).toContain(MOBILE_GLYPH_CLASS);
     }
   });
 
@@ -1560,7 +1579,7 @@ describe("ChatComposer: the mobile send slot", () => {
     const send = queryByLabelText("Send message");
     expect(send?.className).not.toContain("rounded-full");
     expect(send?.className).not.toContain(SEND_FILL_CLASS);
-    expect(glyphClassOf(send)).not.toContain("size-5");
+    expect(glyphClassOf(send)).not.toContain(MOBILE_GLYPH_CLASS);
   });
 });
 

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -34,6 +34,12 @@ import {
   useIsCompactComposerWidth,
 } from "@/domains/chat/components/chat-composer/composer-compact";
 import {
+  MOBILE_CONTROL_CLASS,
+  MOBILE_GHOST_WASH_CLASS,
+  MOBILE_GLYPH_CLASS,
+} from "@/domains/chat/components/chat-composer/composer-mobile-chrome";
+import {
+  COMPOSER_MOBILE_RADIUS_CLASS,
   COMPOSER_RADIUS_CLASS,
   VoiceComposerBar,
 } from "@/domains/chat/components/chat-composer/voice-composer-bar";
@@ -68,7 +74,7 @@ import { isElectron } from "@/runtime/is-electron";
 import { isPopoutWindowLifetime } from "@/runtime/popout-window";
 import { useIsNativePlatform } from "@/runtime/native-auth";
 import { isNativeIOS } from "@/runtime/platform-detection";
-import { isPointerCoarse } from "@/utils/pointer";
+import { isPointerCoarse, usePointerCoarse } from "@/utils/pointer";
 import { routes } from "@/utils/routes";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
 import { useTranslation } from "@/i18n";
@@ -232,30 +238,6 @@ function measureVoiceOriginAvatar(): { x: number; y: number } | null {
   }
   return { x: best.left + best.width / 2, y: best.top + best.height / 2 };
 }
-
-/**
- * The 40x40 circle the mobile row's controls stand at.
- *
- * Driven from the composer's own `isMobile` branch, the same signal that
- * produces the row, rather than from the `touch-mobile:` variant. The two
- * disagree on a window dragged under the breakpoint, which would otherwise take
- * the mobile row's structure while every control in it kept desktop chrome. The
- * primitive's own mobile growth is switched off (`expandOnMobile={false}`)
- * wherever these classes land, so one signal owns the whole control. See
- * `docs/PLATFORM_ADAPTATION.md`.
- */
-const MOBILE_CONTROL_CLASS = "h-10 w-10 rounded-full";
-
-/** The 20px glyphs those 40x40 controls carry. */
-const MOBILE_GLYPH_CLASS = "size-5 [&_svg]:size-5";
-
-/**
- * The press wash under the row's unfilled glyphs. The primitive paints one for
- * ghost icon-only buttons under `touch-mobile:` alone, so the row carries its
- * own and every narrow window lights up the same way.
- */
-const MOBILE_GHOST_WASH_CLASS =
-  "hover:bg-[var(--surface-active)] active:bg-[var(--surface-active)]";
 
 /**
  * The mobile send button's filled circle. Applied only while the button can
@@ -610,8 +592,8 @@ export function ChatComposer({
   // Narrow-card collapse: below the compact width the labelled access and
   // model-profile triggers collide, so the pair folds into one hamburger menu
   // (mounted in the access slot, keeping the row's attach | settings | mic |
-  // voice order). Mobile is excluded: its triggers are already icon-only and
-  // open bottom sheets, which fit.
+  // voice order). Mobile is excluded: its settings triggers live in the pills
+  // row above the card, so they never compete for the action row's width.
   const composerCardRef = useRef<HTMLFormElement>(null);
   const compactSettings =
     useIsCompactComposerWidth(composerCardRef) && !isMobile;
@@ -778,7 +760,11 @@ export function ChatComposer({
   );
 
   const [addSheetOpen, setAddSheetOpen] = useState(false);
-  const usesAddSheet = isMobile && pointerCoarse;
+  // Subscribed rather than read once: a convertible whose keyboard comes off
+  // mid-session changes what the plus should open, and the sheet has to be
+  // mounted by then to receive the press.
+  const pointerCoarseNow = usePointerCoarse();
+  const usesAddSheet = isMobile && pointerCoarseNow;
 
   // Every surface opened from the composer moves focus into a portal, the
   // composer's own add-to-chat sheet included, so each one has to hold the row
@@ -788,14 +774,14 @@ export function ChatComposer({
     hasSettingsPills &&
     (composerFocusWithin || settingsSheetOpen || addSheetOpen);
 
-  // 26px is half the mobile card's 52px collapsed height, so the resting
-  // composer is a pill and keeps that corner once attachments make it taller.
-  // The shared `COMPOSER_RADIUS_CLASS` stays the desktop card's, which the
-  // live-voice bar draws from too.
+  // A pill at mobile widths (half the card's 52px collapsed height), the 10px
+  // panel elsewhere, both from the live-voice bar's module: the bar stacks on
+  // this card and has to wear whichever corner it is showing. The banner
+  // variants stay literal, since a bottom-only corner is not the same class.
   const cardShapeClass = isMobile
     ? hasBillingBanner
       ? "rounded-b-[26px]"
-      : "rounded-[26px]"
+      : COMPOSER_MOBILE_RADIUS_CLASS
     : hasBillingBanner
       ? "rounded-b-[10px]"
       : COMPOSER_RADIUS_CLASS;
@@ -1240,51 +1226,54 @@ export function ChatComposer({
         </div>
       )}
       <div ref={composerShellRef} data-slot="chat-composer-shell">
-        {hasSettingsPills && (
-          // Mounted for as long as the composer is, because each pill gates
-          // itself on server state its own menu loads (access waits on the
-          // global-threshold fetch), and a row that mounted on first focus
-          // would rise with that pill still missing. Only its visibility
-          // follows focus: `hidden` is `display: none`, which keeps the resting
-          // row out of the layout, the tab order and the accessibility tree,
-          // and lets the entrance animation run again on every reveal.
-          //
-          // The row rises into place rather than appearing, since it arrives
-          // with the keyboard; reduced motion keeps the placement and drops the
-          // movement.
-          <div
-            data-slot="composer-settings-pills"
-            hidden={!settingsPillsVisible}
-            className={
-              settingsPillsVisible
-                ? "mb-3 flex animate-[fadeInUp_var(--anim-fast)_var(--anim-ease-out)_backwards] justify-end gap-1.5 motion-reduce:animate-none"
-                : undefined
-            }
-          >
-            {thresholdPickerSlot}
-            {modelPickerSlot}
-          </div>
-        )}
-        <Popover.Root open={emoji.show || slash.show}>
-          <Popover.Anchor asChild>
-            <form
-              ref={composerCardRef}
-              data-slot="chat-composer"
-              onSubmit={onSubmit}
-              className={`overflow-hidden bg-[var(--surface-lift)] shadow-[0px_2px_2px_rgba(0,0,0,0.05)] ${cardShapeClass}`}
+        {/* Above every slot placement, the pills row included: what a control
+            does when the card runs narrow is the control's own business, and
+            must not depend on which row it happens to be sitting in. */}
+        <ComposerCompactProvider compact={compactSettings}>
+          {hasSettingsPills && (
+            // Mounted for as long as the composer is, because each pill gates
+            // itself on server state its own menu loads (access waits on the
+            // global-threshold fetch), and a row that mounted on first focus
+            // would rise with that pill still missing. Only its visibility
+            // follows focus: `hidden` is `display: none`, which keeps the resting
+            // row out of the layout, the tab order and the accessibility tree,
+            // and lets the entrance animation run again on every reveal.
+            //
+            // The row rises into place rather than appearing, since it arrives
+            // with the keyboard; reduced motion keeps the placement and drops the
+            // movement.
+            <div
+              data-slot="composer-settings-pills"
+              hidden={!settingsPillsVisible}
+              // The right inset lands the last pill's edge over the send
+              // circle's, so the row reads as hung off the card rather than
+              // floated past it.
+              className={
+                settingsPillsVisible
+                  ? "mb-3 flex animate-[fadeInUp_var(--anim-fast)_var(--anim-ease-out)_backwards] justify-end gap-1.5 pr-1.5 motion-reduce:animate-none"
+                  : undefined
+              }
             >
-              {/* overflow-hidden lives here, not on the form itself: the form
+              {thresholdPickerSlot}
+              {modelPickerSlot}
+            </div>
+          )}
+          <Popover.Root open={emoji.show || slash.show}>
+            <Popover.Anchor asChild>
+              <form
+                ref={composerCardRef}
+                data-slot="chat-composer"
+                onSubmit={onSubmit}
+                className={`overflow-hidden bg-[var(--surface-lift)] shadow-[0px_2px_2px_rgba(0,0,0,0.05)] ${cardShapeClass}`}
+              >
+                {/* overflow-hidden lives here, not on the form itself: the form
                 casts the shadow above, and overflow-hidden on the same box
                 would clip that shadow along with the rounded corners. */}
-              <div className={`overflow-hidden ${cardShapeClass}`}>
-                <ChatAttachmentsStrip
-                  attachments={attachments}
-                  onRemove={removeAttachment}
-                />
-                {/* Above both layouts: what a control does when the card runs
-                    narrow is the control's own business, and must not depend on
-                    which row it happens to be sitting in. */}
-                <ComposerCompactProvider compact={compactSettings}>
+                <div className={`overflow-hidden ${cardShapeClass}`}>
+                  <ChatAttachmentsStrip
+                    attachments={attachments}
+                    onRemove={removeAttachment}
+                  />
                   {isMobile ? (
                     <>
                       {inlineVoicePreview}
@@ -1310,8 +1299,11 @@ export function ChatComposer({
                         {textFieldBlock}
                         {/* The mic's 40x40 box carries 10px of slack around its
                           20px glyph, so 6px of gap lands that glyph the
-                          design's 16px from the voice circle. */}
-                        <div className="flex shrink-0 items-end gap-1.5">
+                          design's 16px from the voice circle. `ml-auto` is the
+                          fallback anchor: native dictation takes the textarea
+                          out of the row, and with its `flex-1` gone there is
+                          nothing left to push this group over. */}
+                        <div className="ml-auto flex shrink-0 items-end gap-1.5">
                           {isAssistantBusy ? (
                             busyRowControl
                           ) : (
@@ -1368,53 +1360,53 @@ export function ChatComposer({
                       </div>
                     </>
                   )}
-                </ComposerCompactProvider>
-              </div>
-            </form>
-          </Popover.Anchor>
-          <Popover.Content
-            side="top"
-            align="start"
-            sideOffset={4}
-            className="w-[var(--radix-popover-trigger-width)] rounded-none bg-transparent p-0 shadow-none"
-            onOpenAutoFocus={(e: Event) => e.preventDefault()}
-            onCloseAutoFocus={(e: Event) => e.preventDefault()}
-            onInteractOutside={(e: Event) => e.preventDefault()}
-            onEscapeKeyDown={(e: Event) => e.preventDefault()}
-            onPointerDownOutside={(e: Event) => e.preventDefault()}
-          >
-            {emoji.show && (
-              <EmojiPickerPopup
-                entries={emoji.items}
-                selectedIndex={emoji.selectedIndex}
-                onSelect={insertEmoji}
-              />
-            )}
-            {slash.show && (
-              <SlashCommandPopup
-                commands={slash.items}
-                selectedIndex={slash.selectedIndex}
-                onSelect={handleSlashCommandSelect}
-              />
-            )}
-          </Popover.Content>
-        </Popover.Root>
-        {pointerCoarse && (
-          // Beside the form, not inside it: the sheet keeps hidden file inputs
-          // mounted while a native picker is up, and those have no business in
-          // the form the composer submits.
-          //
-          // Mounted on the pointer alone rather than on the compound that
-          // decides whether the plus opens it. Rotating a phone into landscape
-          // crosses the width breakpoint, and unmounting the inputs there would
-          // drop a camera or gallery pick still being made. A touch device at
-          // desktop width just keeps a closed sheet mounted.
-          <AddToChatSheet
-            open={addSheetOpen}
-            onOpenChange={setAddSheetOpen}
-            onAttachFiles={onAddAttachmentFiles}
-          />
-        )}
+                </div>
+              </form>
+            </Popover.Anchor>
+            <Popover.Content
+              side="top"
+              align="start"
+              sideOffset={4}
+              className="w-[var(--radix-popover-trigger-width)] rounded-none bg-transparent p-0 shadow-none"
+              onOpenAutoFocus={(e: Event) => e.preventDefault()}
+              onCloseAutoFocus={(e: Event) => e.preventDefault()}
+              onInteractOutside={(e: Event) => e.preventDefault()}
+              onEscapeKeyDown={(e: Event) => e.preventDefault()}
+              onPointerDownOutside={(e: Event) => e.preventDefault()}
+            >
+              {emoji.show && (
+                <EmojiPickerPopup
+                  entries={emoji.items}
+                  selectedIndex={emoji.selectedIndex}
+                  onSelect={insertEmoji}
+                />
+              )}
+              {slash.show && (
+                <SlashCommandPopup
+                  commands={slash.items}
+                  selectedIndex={slash.selectedIndex}
+                  onSelect={handleSlashCommandSelect}
+                />
+              )}
+            </Popover.Content>
+          </Popover.Root>
+          {pointerCoarseNow && (
+            // Beside the form, not inside it: the sheet keeps hidden file inputs
+            // mounted while a native picker is up, and those have no business in
+            // the form the composer submits.
+            //
+            // Mounted on the pointer alone rather than on the compound that
+            // decides whether the plus opens it. Rotating a phone into landscape
+            // crosses the width breakpoint, and unmounting the inputs there would
+            // drop a camera or gallery pick still being made. A touch device at
+            // desktop width just keeps a closed sheet mounted.
+            <AddToChatSheet
+              open={addSheetOpen}
+              onOpenChange={setAddSheetOpen}
+              onAttachFiles={onAddAttachmentFiles}
+            />
+          )}
+        </ComposerCompactProvider>
       </div>
     </>
   );

--- a/clients/web/src/domains/chat/components/chat-composer/composer-mobile-chrome.ts
+++ b/clients/web/src/domains/chat/components/chat-composer/composer-mobile-chrome.ts
@@ -1,0 +1,33 @@
+/**
+ * The chrome the mobile composer row's controls wear.
+ *
+ * Its own module because the controls live outside the composer: the composer
+ * assembles the row and passes the switch down, while `VoiceInputButton` and
+ * `LiveVoiceButton` paint themselves. Importing the classes back from
+ * `chat-composer.tsx` would close a cycle, and re-typing them in each control
+ * is how the row drifts apart one button at a time.
+ */
+
+/**
+ * The 40x40 circle the mobile row's controls stand at.
+ *
+ * Driven from the composer's own `isMobile` branch, the same signal that
+ * produces the row, rather than from the `touch-mobile:` variant. The two
+ * disagree on a window dragged under the breakpoint, which would otherwise take
+ * the mobile row's structure while every control in it kept desktop chrome. The
+ * primitive's own mobile growth is switched off (`expandOnMobile={false}`)
+ * wherever these classes land, so one signal owns the whole control. See
+ * `docs/PLATFORM_ADAPTATION.md`.
+ */
+export const MOBILE_CONTROL_CLASS = "h-10 w-10 rounded-full";
+
+/** The 20px glyphs those 40x40 controls carry. */
+export const MOBILE_GLYPH_CLASS = "size-5 [&_svg]:size-5";
+
+/**
+ * The press wash under the row's unfilled glyphs. The primitive paints one for
+ * ghost icon-only buttons under `touch-mobile:` alone, so the row carries its
+ * own and every narrow window lights up the same way.
+ */
+export const MOBILE_GHOST_WASH_CLASS =
+  "hover:bg-[var(--surface-active)] active:bg-[var(--surface-active)]";

--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
@@ -105,11 +105,12 @@ export const COMPOSER_RADIUS_CLASS = "rounded-[10px]";
 
 /**
  * The same corner at mobile widths, where the composer card is a 26px pill
- * (half its 52px collapsed height, see `chat-composer.tsx`) rather than the
- * desktop panel. The bar tracks whichever card it is stacked on, so the two
- * still read as one control area; a 10px bar over a pill would not.
+ * (half its 52px collapsed height) rather than the desktop panel. The bar
+ * tracks whichever card it is stacked on, so the two still read as one control
+ * area; a 10px bar over a pill would not. Exported for the same reason as its
+ * desktop sibling: the card and the bar cannot be allowed to drift.
  */
-const COMPOSER_MOBILE_RADIUS_CLASS = "rounded-[26px]";
+export const COMPOSER_MOBILE_RADIUS_CLASS = "rounded-[26px]";
 
 export interface VoiceComposerBarProps {
   state: LiveVoiceSessionState;

--- a/clients/web/src/domains/chat/components/composer-peek.tsx
+++ b/clients/web/src/domains/chat/components/composer-peek.tsx
@@ -16,8 +16,9 @@
  *   surfaces over the input's top edge, its lower half hidden behind
  *   the rim, while the input casts a soft unoffset shadow over it so
  *   the body reads as sitting behind the card. This peek is anchored
- *   toward the input's left side. In the browser the top dude retreats
- *   up off screen as it rises.
+ *   toward the input's left side, and starts above the mobile settings
+ *   pills whenever that row is floating between it and the card. In the
+ *   browser the top dude retreats up off screen as it rises.
  *
  * The composer card is located by its `data-slot="chat-composer"` anchor
  * and its rect tracked per-frame, so the overlays stay glued through
@@ -49,6 +50,9 @@ interface TargetRect {
   /** The card's own computed `border-radius`, so the shadow caster below
    *  can trace whatever corner the card is currently wearing. */
   radius: string;
+  /** How far above the card's top edge the focus peek has to start, so it
+   *  clears the settings pills floating there. Zero whenever no row is up. */
+  pillsClearance: number;
 }
 
 /** The composer card itself, which the overlays are measured against. */
@@ -56,19 +60,20 @@ const COMPOSER_SELECTOR = '[data-slot="chat-composer"]';
 /** The wrapper around the card, which also holds controls that float
  *  outside it (the mobile settings pills). */
 const COMPOSER_SHELL_SELECTOR = '[data-slot="chat-composer-shell"]';
+/** Those pills, while they are up. The row stays mounted when it is away, so
+ *  the `hidden` attribute is what separates the two. */
+const COMPOSER_PILLS_SELECTOR =
+  '[data-slot="composer-settings-pills"]:not([hidden])';
 
 /**
  * Whether a focus target belongs to the composer. The shell is the
- * boundary, so tapping a pill floating above the card is not a leave;
- * the card is the fallback for variants that render no shell.
+ * boundary, so tapping a pill floating above the card is not a leave.
  */
 function withinComposer(node: EventTarget | null): boolean {
   if (!(node instanceof Element)) {
     return false;
   }
-  return Boolean(
-    node.closest(COMPOSER_SHELL_SELECTOR) ?? node.closest(COMPOSER_SELECTOR),
-  );
+  return Boolean(node.closest(COMPOSER_SHELL_SELECTOR));
 }
 
 /**
@@ -94,10 +99,6 @@ const CLIP_HEADROOM = 14;
 const PEEK_X_FRACTION = 0.15;
 /** Exit choreography length before the input-peek overlay unmounts. */
 const EXIT_MS = 300;
-/** Radius the shadow caster falls back to when the card's computed one
- *  can't be read. The card's own radius wins wherever it can: mobile
- *  wears a far rounder corner than this. */
-const PANEL_RADIUS_FALLBACK = "10px";
 /** Soft, unoffset shadow the input casts over the peeking avatar, so the
  *  body reads as sitting behind the card. */
 const PEEK_SHADOW = "0 0 20px rgba(0, 0, 0, 0.15)";
@@ -190,14 +191,26 @@ export function ComposerPeek({
       // Read alongside the rect, which has already flushed layout: the
       // caster has to trace the card's real corner, and the card is a
       // 10px panel on desktop and a deep pill on mobile.
-      const radius =
-        window.getComputedStyle(element).borderRadius || PANEL_RADIUS_FALLBACK;
+      const radius = window.getComputedStyle(element).borderRadius;
+      // The mobile settings pills float between the card and this avatar, and
+      // the portal paints over them, so the peek starts above the row instead.
+      // Measured as layout height + margin rather than as a rect: the row
+      // rises into place on a transform, and a rect would move with it and put
+      // a `setRect` in every frame of that animation.
+      const pills = element
+        .closest(COMPOSER_SHELL_SELECTOR)
+        ?.querySelector<HTMLElement>(COMPOSER_PILLS_SELECTOR);
+      const pillsClearance = pills
+        ? pills.offsetHeight +
+          (Number.parseFloat(window.getComputedStyle(pills).marginBottom) || 0)
+        : 0;
       return {
         left: r.left,
         top: r.top,
         width: r.width,
         height: r.height,
         radius,
+        pillsClearance,
       };
     };
     const enter = () => {
@@ -247,7 +260,8 @@ export function ComposerPeek({
           next.top !== last.top ||
           next.width !== last.width ||
           next.height !== last.height ||
-          next.radius !== last.radius)
+          next.radius !== last.radius ||
+          next.pillsClearance !== last.pillsClearance)
       ) {
         last = next;
         recordUpdate("composer-peek");
@@ -453,14 +467,15 @@ export function ComposerPeek({
         </div>
       )}
       {mode !== "rest" && !introActive && (
-        /* Input-peek avatar, clipped at the input's top edge so the
-           body reads as peeking out from behind the rim. */
+        /* Input-peek avatar, clipped at the input's top edge, or at the
+           settings pills' while that row is up, so the body reads as
+           peeking out from behind whichever rim is nearest. */
         <div
           key="focus-peek"
           className="absolute overflow-hidden"
           style={{
             left: rect.left,
-            top: rect.top - clipHeight,
+            top: rect.top - rect.pillsClearance - clipHeight,
             width: rect.width,
             height: clipHeight,
           }}

--- a/clients/web/src/domains/chat/components/live-voice-button.test.tsx
+++ b/clients/web/src/domains/chat/components/live-voice-button.test.tsx
@@ -11,6 +11,10 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 
+import {
+  MOBILE_CONTROL_CLASS,
+  MOBILE_GLYPH_CLASS,
+} from "@/domains/chat/components/chat-composer/composer-mobile-chrome";
 import { LiveVoiceButton } from "@/domains/chat/components/live-voice-button";
 
 const onStartSpy = mock(() => {});
@@ -52,14 +56,16 @@ describe("LiveVoiceButton", () => {
     // THEN it is the design's filled circle, sized here rather than by the
     // primitive's own mobile growth, so every narrow window gets the same one
     const button = getByLabelText("Start voice mode");
-    expect(button.className).toContain("h-10 w-10 rounded-full");
-    expect(button.querySelector("span")?.className).toContain("[&_svg]:size-5");
+    expect(button.className).toContain(MOBILE_CONTROL_CLASS);
+    expect(button.querySelector("span")?.className).toContain(
+      MOBILE_GLYPH_CLASS,
+    );
 
     // WHILE the default leaves the primitive's sizing alone
     cleanup();
     const desktop = render(<LiveVoiceButton onStart={onStartSpy} />);
     const plain = desktop.getByLabelText("Start voice mode");
-    expect(plain.className).not.toContain("h-10 w-10 rounded-full");
+    expect(plain.className).not.toContain(MOBILE_CONTROL_CLASS);
     expect(plain.className).toContain("touch-mobile:h-10");
   });
 

--- a/clients/web/src/domains/chat/components/live-voice-button.tsx
+++ b/clients/web/src/domains/chat/components/live-voice-button.tsx
@@ -17,6 +17,10 @@
 
 import { AudioLines } from "lucide-react";
 
+import {
+  MOBILE_CONTROL_CLASS,
+  MOBILE_GLYPH_CLASS,
+} from "@/domains/chat/components/chat-composer/composer-mobile-chrome";
 import { Button } from "@vellumai/design-library";
 
 interface LiveVoiceButtonProps {
@@ -54,9 +58,9 @@ export function LiveVoiceButton({
       // The row's own signal sizes the circle, so the primitive's mobile growth
       // steps aside; the fill is the `primary` token the design's light circle
       // resolves to.
-      iconOnlyGlyphClassName={mobileRow ? "size-5 [&_svg]:size-5" : undefined}
+      iconOnlyGlyphClassName={mobileRow ? MOBILE_GLYPH_CLASS : undefined}
       expandOnMobile={!mobileRow}
-      className={mobileRow ? "h-10 w-10 rounded-full" : undefined}
+      className={mobileRow ? MOBILE_CONTROL_CLASS : undefined}
       // Anchor for the in-chat tour's closing beat, which lands the assistant's
       // avatar on this control.
       data-tour-id="voice-mode"

--- a/clients/web/src/domains/chat/components/voice-input-button.test.tsx
+++ b/clients/web/src/domains/chat/components/voice-input-button.test.tsx
@@ -22,6 +22,13 @@ import {
   waitFor,
 } from "@testing-library/react";
 
+// The row chrome the component wears under `mobileRow`, asserted from the
+// same constants it paints with so the two cannot drift.
+import {
+  MOBILE_CONTROL_CLASS,
+  MOBILE_GLYPH_CLASS,
+} from "@/domains/chat/components/chat-composer/composer-mobile-chrome";
+
 const addBreadcrumbSpy = mock((_breadcrumb: unknown) => {});
 mock.module("@sentry/react", () => ({
   addBreadcrumb: addBreadcrumbSpy,
@@ -620,8 +627,10 @@ describe("VoiceInputButton: mobile composer row chrome", () => {
     // primitive's default, and the row sizes the control itself so a narrow
     // mouse-driven window gets the same mic a phone does
     const button = screen.getByRole("button", { name: "Start voice input" });
-    expect(button.className).toContain("h-10 w-10 rounded-full");
-    expect(button.querySelector("span")?.className).toContain("[&_svg]:size-5");
+    expect(button.className).toContain(MOBILE_CONTROL_CLASS);
+    expect(button.querySelector("span")?.className).toContain(
+      MOBILE_GLYPH_CLASS,
+    );
   });
 
   test("the default leaves the idle mic at the primitive's sizing", () => {
@@ -636,10 +645,10 @@ describe("VoiceInputButton: mobile composer row chrome", () => {
     // THEN the row's own sizing does not reach it, and the primitive's
     // `touch-mobile:` chrome is left in charge
     const button = screen.getByRole("button", { name: "Start voice input" });
-    expect(button.className).not.toContain("h-10 w-10 rounded-full");
+    expect(button.className).not.toContain(MOBILE_CONTROL_CLASS);
     expect(button.className).toContain("touch-mobile:h-10");
     expect(button.querySelector("span")?.className).not.toContain(
-      "[&_svg]:size-5",
+      MOBILE_GLYPH_CLASS,
     );
   });
 });

--- a/clients/web/src/domains/chat/components/voice-input-button.tsx
+++ b/clients/web/src/domains/chat/components/voice-input-button.tsx
@@ -24,6 +24,11 @@ import {
   type SttFailureReason,
 } from "@/domains/chat/voice/stt-api";
 import { useVoiceRecordingStore } from "@/domains/chat/voice/voice-recording-store";
+import {
+  MOBILE_CONTROL_CLASS,
+  MOBILE_GHOST_WASH_CLASS,
+  MOBILE_GLYPH_CLASS,
+} from "@/domains/chat/components/chat-composer/composer-mobile-chrome";
 import { useIsNativePlatform } from "@/runtime/native-auth";
 import { useVellumCommands } from "@/runtime/vellum-commands";
 import { getVoiceInputMediaStream } from "@/utils/voice-input-device";
@@ -1074,7 +1079,7 @@ export const VoiceInputButton = forwardRef<
       // loader keep the Button's default icon-only sizing.
       iconOnlyGlyphClassName={
         mobileRow
-          ? "size-5 [&_svg]:size-5"
+          ? MOBILE_GLYPH_CLASS
           : recording
             ? "[&_svg]:size-5 touch-mobile:[&_svg]:size-5"
             : undefined
@@ -1105,8 +1110,7 @@ export const VoiceInputButton = forwardRef<
         // The press wash comes with the sizing: the primitive paints one for
         // ghost icon-only buttons under `touch-mobile:` alone, which a narrow
         // mouse-driven window never matches.
-        mobileRow &&
-          "h-10 w-10 rounded-full hover:bg-[var(--surface-active)] active:bg-[var(--surface-active)]",
+        mobileRow && cn(MOBILE_CONTROL_CLASS, MOBILE_GHOST_WASH_CLASS),
         isNative && recording && "h-12 w-12 max-md:h-12 max-md:w-12",
       )}
     />

--- a/clients/web/src/utils/pointer.ts
+++ b/clients/web/src/utils/pointer.ts
@@ -1,13 +1,45 @@
+import { useCallback, useSyncExternalStore } from "react";
+
+/** The primary pointer being a coarse one, i.e. a finger rather than a mouse. */
+const COARSE_POINTER_QUERY = "(pointer: coarse)";
+
 /**
  * Whether the primary pointer is coarse (touch screen). Returns `false`
  * server-side. Coarse pointers imply a soft keyboard and touch-first
  * interaction model.
+ *
+ * A one-shot read: fine for anything that stands in for the shape the session
+ * started in. Anything that must follow a pointer changing mid-session reads
+ * {@link usePointerCoarse} instead.
  *
  * @see https://developer.mozilla.org/en-US/docs/Web/CSS/@media/pointer
  */
 export function isPointerCoarse(): boolean {
   return (
     typeof window !== "undefined" &&
-    window.matchMedia("(pointer: coarse)").matches
+    window.matchMedia(COARSE_POINTER_QUERY).matches
   );
+}
+
+/**
+ * {@link isPointerCoarse} as a subscribed signal: re-renders when the primary
+ * pointer changes, so a convertible whose keyboard comes off (or a tablet
+ * docked into one) is picked up without a reload.
+ *
+ * Mirrors `useTouchSurface` in the design library, which subscribes to the
+ * compound touch query the same way.
+ */
+export function usePointerCoarse(): boolean {
+  const subscribe = useCallback((onChange: () => void) => {
+    const query = window.matchMedia(COARSE_POINTER_QUERY);
+    query.addEventListener("change", onChange);
+    return () => query.removeEventListener("change", onChange);
+  }, []);
+
+  const getSnapshot = useCallback(
+    () => window.matchMedia(COARSE_POINTER_QUERY).matches,
+    [],
+  );
+
+  return useSyncExternalStore(subscribe, getSnapshot, () => false);
 }


### PR DESCRIPTION
## Summary
Round-2 review remediation for mobile-composer-redesign.md: the avatar peek clears the pills row, ComposerCompactProvider covers both slot placements, native dictation keeps the right controls anchored, the pills row gains its 6px inset, the mobile radius and chrome constants are shared instead of re-typed, the add-sheet decision subscribes to pointer changes, and stale comments and duplicate test fixtures are cleaned up.