### PR TITLE
fix: round-3 review findings for the mobile composer

### DIFF
--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -1274,13 +1274,20 @@ describe("ChatComposer: single-row mobile composer", () => {
     expect(onAddAttachmentFiles.mock.calls[0]?.[0]).toBe(SHEET_PICK);
   });
 
-  test("a phone leaves the hidden file inputs to the sheet", () => {
-    // GIVEN a phone composer, where the sheet owns the pickers
-    const { container } = renderPhoneComposer();
+  test("the hidden picker input outlives a swap of what the plus opens", () => {
+    // GIVEN a phone composer, whose plus opens the sheet
+    const { container, rerender } = renderPhoneComposer();
+    const before = fileInput(container);
+    expect(before).not.toBeNull();
 
-    // THEN the row mounts none of its own
-    expect(addSheet(container)).not.toBeNull();
-    expect(fileInput(container)).toBeNull();
+    // WHEN a keyboard is attached mid-session, handing the plus the picker
+    // instead, while an OS file dialog opened from it is still up
+    viewport.set({ narrow: true, coarsePointer: false });
+    rerender(composerElement());
+
+    // THEN the very same input is still mounted to receive the selection,
+    // rather than a fresh one that never opened the dialog
+    expect(fileInput(container)).toBe(before);
   });
 
   test("a narrow window a mouse drives keeps the plus and mounts no sheet", () => {
@@ -1364,6 +1371,22 @@ describe("ChatComposer: single-row mobile composer", () => {
 
     // THEN the sheet is still there to receive it, since what mounts it is the
     // pointer, which rotating does not change
+    expect(addSheet(container)?.getAttribute("data-open")).toBe("true");
+  });
+
+  test("attaching a keyboard leaves an open sheet up", () => {
+    // GIVEN a convertible on a touch screen with its sheet up
+    const { container, rerender } = renderPhoneComposer();
+    fireEvent.click(control(container, PLUS_LABEL)!);
+    expect(addSheet(container)?.getAttribute("data-open")).toBe("true");
+
+    // WHEN its keyboard is reattached, which flips the live pointer signal the
+    // sheet is mounted on
+    viewport.set({ narrow: true, coarsePointer: false });
+    rerender(composerElement());
+
+    // THEN the sheet the user is looking at stays up, rather than vanishing
+    // with its open state still set and reappearing on the next flip
     expect(addSheet(container)?.getAttribute("data-open")).toBe("true");
   });
 

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -268,46 +268,14 @@ function AddToChatButton({ disabled, label, onClick }: AddToChatButtonProps) {
       disabled={disabled}
       aria-label={label}
       title={label}
-      // Tertiary resting tone, matching the row's other glyphs.
+      // Tertiary resting tone, matching the row's other glyphs. `shrink-0`
+      // holds the circle at 40px however tight the row runs.
       className={cn(
         MOBILE_CONTROL_CLASS,
         MOBILE_GHOST_WASH_CLASS,
-        "[--vbtn-fg:var(--content-tertiary)]",
+        "shrink-0 [--vbtn-fg:var(--content-tertiary)]",
       )}
     />
-  );
-}
-
-interface AddToChatPickerButtonProps {
-  disabled: boolean;
-  label: string;
-  onAttachFiles: (files: FileList) => void;
-}
-
-/**
- * The plus a mouse gets: it opens the file picker directly, the same picker
- * behind the desktop paperclip, through the same hook so the iOS refocus dance
- * is identical. A window narrowed by dragging its edge takes the compact row,
- * chrome included, but not the touch sheet, whose Camera and Find-in-Gallery
- * rows have nothing to offer a pointer.
- */
-function AddToChatPickerButton({
-  disabled,
-  label,
-  onAttachFiles,
-}: AddToChatPickerButtonProps) {
-  const { openPicker, inputNode } = useAttachmentFilePicker({
-    onFiles: onAttachFiles,
-    multiple: true,
-  });
-
-  // The hook lays the input out as `absolute inset-0`, so it needs a positioned
-  // box of its own rather than whichever ancestor happens to be positioned.
-  return (
-    <div className="relative shrink-0">
-      {inputNode}
-      <AddToChatButton disabled={disabled} label={label} onClick={openPicker} />
-    </div>
   );
 }
 
@@ -766,6 +734,18 @@ export function ChatComposer({
   const pointerCoarseNow = usePointerCoarse();
   const usesAddSheet = isMobile && pointerCoarseNow;
 
+  // The picker the plus opens where the sheet has nothing to offer: the same
+  // picker behind the desktop paperclip, through the same hook so the iOS
+  // refocus dance is identical. Owned by the composer rather than by the plus,
+  // because both signals that decide what the plus opens can change while the
+  // OS picker is up (a keyboard reattached, a phone rotated), and an input that
+  // unmounted under an open picker would drop the selection.
+  const { openPicker: openAttachPicker, inputNode: attachPickerInput } =
+    useAttachmentFilePicker({
+      onFiles: onAddAttachmentFiles,
+      multiple: true,
+    });
+
   // Every surface opened from the composer moves focus into a portal, the
   // composer's own add-to-chat sheet included, so each one has to hold the row
   // up on its way out. Without the sheet's flag the row would drop away as the
@@ -800,17 +780,11 @@ export function ChatComposer({
       disabled={attachDisabled}
       onFilesSelected={onAddAttachmentFiles}
     />
-  ) : usesAddSheet ? (
+  ) : (
     <AddToChatButton
       disabled={attachDisabled}
       label={t("chatComposer.addToChat")}
-      onClick={() => setAddSheetOpen(true)}
-    />
-  ) : (
-    <AddToChatPickerButton
-      disabled={attachDisabled}
-      label={t("chatComposer.addToChat")}
-      onAttachFiles={onAddAttachmentFiles}
+      onClick={usesAddSheet ? () => setAddSheetOpen(true) : openAttachPicker}
     />
   );
 
@@ -1390,16 +1364,25 @@ export function ChatComposer({
               )}
             </Popover.Content>
           </Popover.Root>
-          {pointerCoarseNow && (
-            // Beside the form, not inside it: the sheet keeps hidden file inputs
-            // mounted while a native picker is up, and those have no business in
-            // the form the composer submits.
+          {/* Beside the form, not inside it: a hidden file input stays mounted
+              while a native picker is up, and has no business in the form the
+              composer submits. Mounted whatever the row is showing, so neither
+              signal behind the plus can pull it out from under an open picker.
+              The hook lays the input out as `absolute inset-0`, so it needs a
+              positioned box of its own. */}
+          <div className="relative">{attachPickerInput}</div>
+          {(pointerCoarseNow || addSheetOpen) && (
+            // The sheet's own three inputs, beside the form for the same reason.
             //
-            // Mounted on the pointer alone rather than on the compound that
-            // decides whether the plus opens it. Rotating a phone into landscape
-            // crosses the width breakpoint, and unmounting the inputs there would
+            // Mounted on the pointer rather than on the compound that decides
+            // whether the plus opens it. Rotating a phone into landscape crosses
+            // the width breakpoint, and unmounting the sheet's inputs there would
             // drop a camera or gallery pick still being made. A touch device at
             // desktop width just keeps a closed sheet mounted.
+            //
+            // The pointer is a live signal, so a convertible that regains its
+            // keyboard flips it mid-session: an already-open sheet holds itself
+            // up through that, rather than vanishing with its `open` still set.
             <AddToChatSheet
               open={addSheetOpen}
               onOpenChange={setAddSheetOpen}

--- a/clients/web/src/domains/chat/components/composer-peek.tsx
+++ b/clients/web/src/domains/chat/components/composer-peek.tsx
@@ -17,8 +17,9 @@
  *   the rim, while the input casts a soft unoffset shadow over it so
  *   the body reads as sitting behind the card. This peek is anchored
  *   toward the input's left side, and starts above the mobile settings
- *   pills whenever that row is floating between it and the card. In the
- *   browser the top dude retreats up off screen as it rises.
+ *   pills whenever that row reaches far enough left to sit between it
+ *   and the card. In the browser the top dude retreats up off screen as
+ *   it rises.
  *
  * The composer card is located by its `data-slot="chat-composer"` anchor
  * and its rect tracked per-frame, so the overlays stay glued through
@@ -51,7 +52,8 @@ interface TargetRect {
    *  can trace whatever corner the card is currently wearing. */
   radius: string;
   /** How far above the card's top edge the focus peek has to start, so it
-   *  clears the settings pills floating there. Zero whenever no row is up. */
+   *  clears the settings pills floating there. Zero whenever no row is up, or
+   *  whenever the row hangs clear of the avatar's own column. */
   pillsClearance: number;
 }
 
@@ -74,6 +76,26 @@ function withinComposer(node: EventTarget | null): boolean {
     return false;
   }
   return Boolean(node.closest(COMPOSER_SHELL_SELECTOR));
+}
+
+/**
+ * The left edge of the leftmost pill actually on screen, in viewport px, or
+ * `null` for a row with nothing in it. The row itself spans the card's full
+ * width and hangs its pills off the right end, so its own rect says nothing
+ * about where the pills start.
+ */
+function leftmostPillEdge(row: HTMLElement): number | null {
+  let leftmost: number | null = null;
+  for (const pill of Array.from(row.children)) {
+    const { left, width } = pill.getBoundingClientRect();
+    if (width === 0) {
+      continue;
+    }
+    if (leftmost === null || left < leftmost) {
+      leftmost = left;
+    }
+  }
+  return leftmost;
 }
 
 /**
@@ -102,6 +124,12 @@ const EXIT_MS = 300;
 /** Soft, unoffset shadow the input casts over the peeking avatar, so the
  *  body reads as sitting behind the card. */
 const PEEK_SHADOW = "0 0 20px rgba(0, 0, 0, 0.15)";
+
+/** Where the focus peek's avatar centres along the card's width, kept off the
+ *  card's left edge by half its own width plus a margin. */
+function peekAnchorX(cardWidth: number, peekSize: number): number {
+  return Math.max(peekSize / 2 + 16, cardWidth * PEEK_X_FRACTION);
+}
 
 /** The top-of-screen dude, sized off the input width (Figma ~half). */
 const TOP_SIZE_FRACTION = 0.45;
@@ -171,11 +199,36 @@ export function ComposerPeek({
     [components, traits],
   );
 
+  // Input peek geometry: expose down to just below the eye ink, capped, so
+  // low-faced bodies scale down rather than exposing a taller slab. Derived up
+  // here because the tracking effect needs the square's size to tell whether
+  // the avatar's column runs into the pills row.
+  const peekExposedFrac = metrics
+    ? Math.min(
+        0.95,
+        Math.max(
+          0.25,
+          metrics.eyeCenterFrac + metrics.eyeHalfFrac + PEEK_EYE_PAD_FRAC,
+        ),
+      )
+    : PEEK_EXPOSED_FRAC_FALLBACK;
+  const peekSize = Math.min(
+    PEEK_SIZE_MAX,
+    PEEK_EXPOSED_MAX_PX / peekExposedFrac,
+  );
+
   useEffect(() => {
     if (!runnable) {
       return;
     }
     let exitTimer: ReturnType<typeof setTimeout> | undefined;
+    // The pills row hides itself the instant focus leaves (`hidden` is
+    // `display: none`), while this avatar is still playing its exit off the rim
+    // it rose from. These two carry the row's clearance through that exit, or
+    // the clip would lose the row's height in a single frame and drop the
+    // avatar mid-animation.
+    let exiting = false;
+    let heldPillsClearance = 0;
 
     // Re-queried on every measure, never captured: the composer form
     // remounts (e.g. as a draft conversation settles), and a held
@@ -192,18 +245,33 @@ export function ComposerPeek({
       // caster has to trace the card's real corner, and the card is a
       // 10px panel on desktop and a deep pill on mobile.
       const radius = window.getComputedStyle(element).borderRadius;
-      // The mobile settings pills float between the card and this avatar, and
-      // the portal paints over them, so the peek starts above the row instead.
-      // Measured as layout height + margin rather than as a rect: the row
-      // rises into place on a transform, and a rect would move with it and put
-      // a `setRect` in every frame of that animation.
+      // The mobile settings pills float between the card and this avatar, so
+      // where they run into its column the peek starts above the row instead.
+      // The row hangs its pills off the card's right edge while this avatar
+      // rises on the left, so a short row leaves the rim clear and the peek
+      // stays on it, rather than floating a body height above nothing.
       const pills = element
         .closest(COMPOSER_SHELL_SELECTOR)
         ?.querySelector<HTMLElement>(COMPOSER_PILLS_SELECTOR);
-      const pillsClearance = pills
-        ? pills.offsetHeight +
-          (Number.parseFloat(window.getComputedStyle(pills).marginBottom) || 0)
-        : 0;
+      // Height comes from layout, not from a rect: the row rises into place on
+      // a transform, and a rect's top would move with it and put a `setRect` in
+      // every frame of that animation. The same animation is translateY-only,
+      // which leaves horizontal edges steady enough to read from a rect.
+      const pillsLeft = pills ? leftmostPillEdge(pills) : null;
+      const overlapsPills =
+        pillsLeft !== null &&
+        r.left + peekAnchorX(r.width, peekSize) + peekSize / 2 > pillsLeft;
+      const measuredClearance =
+        pills && overlapsPills
+          ? pills.offsetHeight +
+            (Number.parseFloat(window.getComputedStyle(pills).marginBottom) ||
+              0)
+          : 0;
+      if (measuredClearance > 0) {
+        heldPillsClearance = measuredClearance;
+      }
+      const pillsClearance =
+        measuredClearance || (exiting ? heldPillsClearance : 0);
       return {
         left: r.left,
         top: r.top,
@@ -215,12 +283,17 @@ export function ComposerPeek({
     };
     const enter = () => {
       clearTimeout(exitTimer);
+      exiting = false;
       setMode("focus");
     };
     const leave = () => {
       setMode((m) => (m === "focus" ? "focus-exit" : m));
       clearTimeout(exitTimer);
-      exitTimer = setTimeout(() => setMode("rest"), EXIT_MS);
+      exiting = true;
+      exitTimer = setTimeout(() => {
+        exiting = false;
+        setMode("rest");
+      }, EXIT_MS);
     };
     // Document-level so listeners survive composer remounts. Focus moving
     // within the composer (textarea → mic button → a pill floating above
@@ -291,7 +364,10 @@ export function ComposerPeek({
       setIntroRisen(false);
       setIntroDone(false);
     };
-  }, [runnable]);
+    // `peekSize` is a number derived from the avatar's own metrics, so it holds
+    // steady across the identity churn `components`/`traits` go through and
+    // this act is not restarted (and its hello replayed) on every render.
+  }, [runnable, peekSize]);
 
   // The native mobile hello runs off the first rect, when the avatar first
   // has an edge to peek over. It always runs to completion: a fresh chat
@@ -323,25 +399,11 @@ export function ComposerPeek({
   // stays out of the way rather than putting a second one on screen.
   const introActive = nativeMobile && !introDone;
 
-  // Input peek geometry: expose down to just below the eye ink, capped —
-  // low-faced bodies scale down rather than exposing a taller slab.
-  const peekExposedFrac = metrics
-    ? Math.min(
-        0.95,
-        Math.max(
-          0.25,
-          metrics.eyeCenterFrac + metrics.eyeHalfFrac + PEEK_EYE_PAD_FRAC,
-        ),
-      )
-    : PEEK_EXPOSED_FRAC_FALLBACK;
-  const peekSize = Math.min(
-    PEEK_SIZE_MAX,
-    PEEK_EXPOSED_MAX_PX / peekExposedFrac,
-  );
+  // The rest of the input peek's geometry, off the size derived above.
   const peekExposedPx = peekSize * peekExposedFrac;
   const clipHeight = peekExposedPx + CLIP_HEADROOM;
   const risePx = peekExposedPx + 8;
-  const peekX = Math.max(peekSize / 2 + 16, rect.width * PEEK_X_FRACTION);
+  const peekX = peekAnchorX(rect.width, peekSize);
 
   // Top dude geometry: centered over the input, hanging mirrored from
   // the screen's top edge with its eyes peering down just below the cut
@@ -468,8 +530,8 @@ export function ComposerPeek({
       )}
       {mode !== "rest" && !introActive && (
         /* Input-peek avatar, clipped at the input's top edge, or at the
-           settings pills' while that row is up, so the body reads as
-           peeking out from behind whichever rim is nearest. */
+           settings pills' where that row runs into its column, so the body
+           reads as peeking out from behind whichever rim is nearest. */
         <div
           key="focus-peek"
           className="absolute overflow-hidden"

--- a/clients/web/src/utils/pointer.test.ts
+++ b/clients/web/src/utils/pointer.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
+
+import { viewportAxesStub } from "@/hooks/viewport-axes.test-helper";
+
+import { isPointerCoarse, usePointerCoarse } from "./pointer";
+
+// Both forms answer `(pointer: coarse)`, so drive them the way every other
+// platform-adaptation suite does: by stubbing `window.matchMedia` for a device
+// shape. See `docs/PLATFORM_ADAPTATION.md`.
+const viewport = viewportAxesStub();
+
+afterEach(() => {
+  cleanup();
+  viewport.restore();
+});
+
+describe("isPointerCoarse", () => {
+  test("reports the primary pointer", () => {
+    viewport.set({ narrow: true, coarsePointer: true });
+    expect(isPointerCoarse()).toBe(true);
+
+    viewport.set({ narrow: false, coarsePointer: false });
+    expect(isPointerCoarse()).toBe(false);
+  });
+
+  test("is a width-independent signal", () => {
+    // A tablet has room to spare and still has no mouse.
+    viewport.set({ narrow: false, coarsePointer: true });
+    expect(isPointerCoarse()).toBe(true);
+  });
+});
+
+describe("usePointerCoarse", () => {
+  test("reads the same query as a subscribed snapshot", () => {
+    viewport.set({ narrow: true, coarsePointer: true });
+    const { result } = renderHook(() => usePointerCoarse());
+    expect(result.current).toBe(true);
+  });
+
+  test("re-reads the pointer rather than caching the mount-time answer", () => {
+    // GIVEN a convertible being driven by touch
+    viewport.set({ narrow: true, coarsePointer: true });
+    const { result, rerender } = renderHook(() => usePointerCoarse());
+    expect(result.current).toBe(true);
+
+    // WHEN its keyboard is reattached
+    viewport.set({ narrow: true, coarsePointer: false });
+    rerender();
+
+    // THEN the hook reports the pointer it has now, which is what the one-shot
+    // `isPointerCoarse()` cannot do
+    expect(result.current).toBe(false);
+  });
+});

--- a/clients/web/src/utils/pointer.ts
+++ b/clients/web/src/utils/pointer.ts
@@ -1,4 +1,4 @@
-import { useCallback, useSyncExternalStore } from "react";
+import { useMediaQuery } from "@/hooks/use-media-query";
 
 /** The primary pointer being a coarse one, i.e. a finger rather than a mouse. */
 const COARSE_POINTER_QUERY = "(pointer: coarse)";
@@ -26,20 +26,9 @@ export function isPointerCoarse(): boolean {
  * pointer changes, so a convertible whose keyboard comes off (or a tablet
  * docked into one) is picked up without a reload.
  *
- * Mirrors `useTouchSurface` in the design library, which subscribes to the
- * compound touch query the same way.
+ * The subscription, the snapshot and the `false` the server renders all come
+ * from {@link useMediaQuery}, the same shared machinery behind `useIsMobile`.
  */
 export function usePointerCoarse(): boolean {
-  const subscribe = useCallback((onChange: () => void) => {
-    const query = window.matchMedia(COARSE_POINTER_QUERY);
-    query.addEventListener("change", onChange);
-    return () => query.removeEventListener("change", onChange);
-  }, []);
-
-  const getSnapshot = useCallback(
-    () => window.matchMedia(COARSE_POINTER_QUERY).matches,
-    [],
-  );
-
-  return useSyncExternalStore(subscribe, getSnapshot, () => false);
+  return useMediaQuery(COARSE_POINTER_QUERY);
 }


### PR DESCRIPTION
## Summary
Final review-loop remediation for mobile-composer-redesign.md: usePointerCoarse delegates to the shared useMediaQuery, the hidden file input and the add-to-chat sheet survive presentation and pointer swaps, and the avatar peek's pills clearance applies only on real overlap and holds through the exit animation.