### PR TITLE
fix(voice): never speak inline reasoning spans through TTS

### DIFF
--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -21,6 +21,7 @@ import type { TrustContext } from "../daemon/trust-context-types.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { computeToolApprovalDigest } from "../security/tool-approval-digest.js";
 import { getCatalogProvider } from "../tts/provider-catalog.js";
+import { createReasoningTagFilter } from "../tts/reasoning-tag-filter.js";
 import { extractSpeakableSegments } from "../tts/speakable-segments.js";
 import {
   type AudioStoreSink,
@@ -728,6 +729,10 @@ export class CallController {
     // could be the start of a control marker.
     let ttsBuffer = "";
     let fullResponseText = "";
+    // Reasoning models can inline <think> spans in the content stream when a
+    // profile has not opted into parseThinkTags; the spoken path must never
+    // read them aloud. fullResponseText keeps the raw stream.
+    const reasoningFilter = createReasoningTagFilter();
 
     // Synthesized path: text is split at speakable boundaries as it streams
     // and each segment is synthesized while the LLM keeps generating. The
@@ -931,7 +936,7 @@ export class CallController {
           return;
         }
         fullResponseText += text;
-        ttsBuffer += text;
+        ttsBuffer += reasoningFilter.push(text);
         ttsBuffer = stripInternalSpeechMarkers(ttsBuffer);
         flushSafeText();
       };
@@ -1010,7 +1015,9 @@ export class CallController {
       return fullResponseText;
     }
 
-    // Final sweep: strip any remaining control markers from the buffer
+    // Final sweep: release any held-back partial tag, then strip any
+    // remaining control markers from the buffer.
+    ttsBuffer += reasoningFilter.flush();
     ttsBuffer = stripInternalSpeechMarkers(ttsBuffer);
     if (ttsBuffer.length > 0) {
       emitSafeChunk(ttsBuffer);

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -73,6 +73,10 @@ import type {
 import { getSubagentManager } from "../subagent/index.js";
 import { liveVoiceEndScreen } from "../telemetry/live-voice-funnel.js";
 import { getToolOwner } from "../tools/registry.js";
+import {
+  createReasoningTagFilter,
+  type ReasoningTagFilter,
+} from "../tts/reasoning-tag-filter.js";
 import { extractSpeakableSegments } from "../tts/speakable-segments.js";
 import { createAbortReason } from "../util/abort-reasons.js";
 import { hasLocalizedEntry } from "../util/language-subtag.js";
@@ -717,6 +721,10 @@ interface ActiveAssistantTurn {
   // the hand-off idempotent.
   escalationHandedOff: boolean;
   ttsBuffer: string;
+  // Strips inline <think> reasoning spans from the spoken stream. Stateful
+  // per turn because spans and tags cross delta boundaries; display frames
+  // keep the raw text.
+  ttsReasoningFilter: ReasoningTagFilter;
   // A non-empty speakable segment reached the TTS queue — gates the eager
   // first-segment flush that trades clause quality for speech onset.
   ttsSegmentEnqueued: boolean;
@@ -4503,6 +4511,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       deltaEpoch: 0,
       escalationHandedOff: false,
       ttsBuffer: "",
+      ttsReasoningFilter: createReasoningTagFilter(),
       ttsSegmentEnqueued: false,
       ttsJobs: [],
       ttsQueue: Promise.resolve(),
@@ -5492,7 +5501,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       return;
     }
 
-    activeTurn.ttsBuffer += text;
+    activeTurn.ttsBuffer += activeTurn.ttsReasoningFilter.push(text);
     this.flushTtsBuffer(token, false);
   }
 
@@ -5503,6 +5512,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
 
     this.clearFillerTimers(activeTurn);
+    activeTurn.ttsBuffer += activeTurn.ttsReasoningFilter.flush();
     this.flushTtsBuffer(token, true);
     activeTurn.ttsQueue = activeTurn.ttsQueue
       .catch(() => {})

--- a/assistant/src/tts/__tests__/reasoning-tag-filter.test.ts
+++ b/assistant/src/tts/__tests__/reasoning-tag-filter.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+
+import { createReasoningTagFilter } from "../reasoning-tag-filter.js";
+
+function run(chunks: string[]): string {
+  const filter = createReasoningTagFilter();
+  let out = "";
+  for (const chunk of chunks) {
+    out += filter.push(chunk);
+  }
+  out += filter.flush();
+  return out;
+}
+
+describe("ReasoningTagFilter", () => {
+  test("passes plain text through unchanged", () => {
+    expect(run(["Hello ", "there."])).toBe("Hello there.");
+  });
+
+  test("drops a complete think span within one delta", () => {
+    expect(run(["<think>hm, let me reason</think>Answer."])).toBe("Answer.");
+  });
+
+  test("drops a reasoning span crossing many deltas", () => {
+    expect(
+      run(["<thi", "nk>step one", " step two", "</th", "ink>Spoken reply"]),
+    ).toBe("Spoken reply");
+  });
+
+  test("drops thinking-tag variant and is case-insensitive", () => {
+    expect(run(["<Thinking>inner</Thinking>ok"])).toBe("ok");
+  });
+
+  test("keeps text before and after the span", () => {
+    expect(run(["Sure. <think>secret</think> Done."])).toBe("Sure.  Done.");
+  });
+
+  test("handles multiple spans in one turn", () => {
+    expect(run(["a<think>x</think>b", "<think>y", "z</think>c"])).toBe("abc");
+  });
+
+  test("an unclosed span at end of stream stays dropped", () => {
+    expect(run(["ok<think>never closes"])).toBe("ok");
+  });
+
+  test("a dangling partial open tag is released as literal text at flush", () => {
+    expect(run(["price <th"])).toBe("price <th");
+  });
+
+  test("a false partial that disambiguates to text is released", () => {
+    expect(run(["a <th", "ree-step plan"])).toBe("a <three-step plan");
+  });
+
+  test("does not touch angle brackets that are not think tags", () => {
+    expect(run(["use <b>bold</b> and x < y"])).toBe(
+      "use <b>bold</b> and x < y",
+    );
+  });
+
+  test("holds back nothing across an empty stream", () => {
+    expect(run([""])).toBe("");
+  });
+});

--- a/assistant/src/tts/reasoning-tag-filter.ts
+++ b/assistant/src/tts/reasoning-tag-filter.ts
@@ -1,0 +1,110 @@
+/**
+ * Streaming reasoning-tag filter for the TTS pipelines.
+ *
+ * Some OpenAI-compatible reasoning models emit their chain of thought inline
+ * in the content stream as `<think>...</think>` (or `<thinking>...</thinking>`)
+ * spans. When a profile has not opted into the chat-completions provider's
+ * `parseThinkTags` (which re-routes those spans to `thinking_delta`), the raw
+ * reasoning rides `text_delta`, and anything downstream that speaks text
+ * deltas would read the model's inner monologue aloud and delay real speech
+ * by the full length of the reasoning.
+ *
+ * This filter is the TTS-boundary guard: voice output must never speak
+ * reasoning regardless of profile configuration. It is stateful because a
+ * tag or a reasoning span routinely crosses delta boundaries; feed every
+ * delta through {@link ReasoningTagFilter.push} and call
+ * {@link ReasoningTagFilter.flush} when the turn's stream ends.
+ *
+ * Display paths are deliberately untouched: `assistant_text_delta` frames
+ * keep the raw text, exactly like the markdown handling in
+ * `calls/tts-text-sanitizer.ts`.
+ */
+
+const OPEN_TAGS = ["<think>", "<thinking>"] as const;
+const CLOSE_TAGS = ["</think>", "</thinking>"] as const;
+
+/** Longest suffix of `text` that is a proper prefix of any listed tag. */
+function partialTagSuffix(text: string, tags: readonly string[]): number {
+  const max = Math.max(...tags.map((tag) => tag.length)) - 1;
+  const window = Math.min(max, text.length);
+  for (let len = window; len > 0; len -= 1) {
+    const suffix = text.slice(text.length - len).toLowerCase();
+    if (tags.some((tag) => tag.startsWith(suffix))) {
+      return len;
+    }
+  }
+  return 0;
+}
+
+function indexOfAny(
+  haystack: string,
+  tags: readonly string[],
+): { index: number; tag: string } | null {
+  const lower = haystack.toLowerCase();
+  let best: { index: number; tag: string } | null = null;
+  for (const tag of tags) {
+    const index = lower.indexOf(tag);
+    if (index >= 0 && (best === null || index < best.index)) {
+      best = { index, tag };
+    }
+  }
+  return best;
+}
+
+export class ReasoningTagFilter {
+  private insideReasoning = false;
+  private pending = "";
+
+  /**
+   * Feed one streamed delta; returns the speakable text it releases.
+   * Reasoning spans are dropped; a partial tag at the end of the buffer is
+   * held back until the next delta disambiguates it.
+   */
+  push(text: string): string {
+    this.pending += text;
+    let out = "";
+    for (;;) {
+      if (this.insideReasoning) {
+        const close = indexOfAny(this.pending, CLOSE_TAGS);
+        if (close) {
+          this.pending = this.pending.slice(close.index + close.tag.length);
+          this.insideReasoning = false;
+          continue;
+        }
+        // Everything buffered is reasoning except a possible partial close
+        // tag at the end; drop the reasoning, keep the partial.
+        const partial = partialTagSuffix(this.pending, CLOSE_TAGS);
+        this.pending = partial > 0 ? this.pending.slice(-partial) : "";
+        return out;
+      }
+      const open = indexOfAny(this.pending, OPEN_TAGS);
+      if (open) {
+        out += this.pending.slice(0, open.index);
+        this.pending = this.pending.slice(open.index + open.tag.length);
+        this.insideReasoning = true;
+        continue;
+      }
+      const partial = partialTagSuffix(this.pending, OPEN_TAGS);
+      const safeLength = this.pending.length - partial;
+      out += this.pending.slice(0, safeLength);
+      this.pending = partial > 0 ? this.pending.slice(safeLength) : "";
+      return out;
+    }
+  }
+
+  /**
+   * End of stream: release any held-back partial. Outside a reasoning span a
+   * dangling "<thin" was ordinary text after all; inside one, the span never
+   * closed and its content stays dropped.
+   */
+  flush(): string {
+    const rest = this.insideReasoning ? "" : this.pending;
+    this.pending = "";
+    this.insideReasoning = false;
+    return rest;
+  }
+}
+
+export function createReasoningTagFilter(): ReasoningTagFilter {
+  return new ReasoningTagFilter();
+}


### PR DESCRIPTION
## TL;DR

Voice mode was speaking the model's raw chain of thought. Root cause: OpenAI-compatible reasoning models can emit reasoning inline in the content stream as `<think>`/`<thinking>` spans; when a profile has not opted into the chat-completions provider's `parseThinkTags`, those spans ride `text_delta`, and both voice paths synthesized them verbatim (inner monologue read aloud, speech onset delayed by the full reasoning length). This PR adds a stateful streaming `ReasoningTagFilter` at both TTS buffer feeds. Display paths keep the raw text.

## What changes for the user

| Before | After |
| --- | --- |
| With a think-tag reasoning model serving voice, TTS read the entire `<think>` block aloud before the answer | Reasoning spans are stripped from the spoken stream; speech starts at the actual reply |
| Long silent-then-monologue onset delays | Onset is bounded by the reply text, not the reasoning length |
| Chat/display output | Unchanged: `assistant_text_delta` frames keep raw text, mirroring the markdown handling in `tts-text-sanitizer` |

## Why the filter sits at the TTS boundary

I traced every voice ingestion path first: the daemon cleanly separates `assistant_text_delta` from `assistant_thinking_delta` (gated on `streamThinking`), the voice bridge forwards only text deltas, Anthropic/Responses providers route reasoning to `thinking_delta`, and Gemini's SDK (`@google/genai` 1.45.0) skips thought parts in its `text` getter. The only remaining vector is inline think tags in `text_delta` from chat-completions profiles without `parseThinkTags` — a per-profile config the voice path cannot rely on. Voice must never speak reasoning regardless of configuration, so the guard lives at the TTS feeds:

- `calls/call-controller.ts` (telephony): filters `ttsBuffer`; `fullResponseText` keeps the raw stream for persistence.
- `live-voice/live-voice-session.ts` (voice mode): per-turn filter ahead of `extractSpeakableSegments`; filter flushed at turn completion.

The filter is stateful because tags and spans routinely cross delta boundaries: partial tags are held back until disambiguated (`"a <th" + "ree-step plan"` speaks intact; `"<thi" + "nk>…"` is stripped), unclosed spans at end of stream stay dropped, and non-think angle brackets pass through.

## Why this is safe

- New module + 11 unit tests covering cross-delta spans, tag variants, case-insensitivity, false partials, unclosed spans, and non-tag angle brackets (CI runs them; local test runs are blocked by standing rule on this machine).
- `tsc --noEmit` and eslint green; pre-push hook type-checked the changed files.
- The two wiring points are single-line feeds into existing buffers; no changes to segmentation, sanitization order, barge-in, or persistence.
- Forcing `streamThinking: false` on voice requests was considered and rejected: it would not touch inline think tags (they are text, not thinking events) and would kill client-side thinking display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40673" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->