### PR TITLE
fix: track measured peek clearance and latch the add-sheet mount once presented

### DIFF
--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -244,8 +244,9 @@ mock.module("react-router", () => ({
 // "Add to chat" sheet. Stubbed to a probe that surfaces its open state plus a
 // button standing in for a completed pick, so these cases assert the
 // composer's wiring: the plus opens the sheet, and files chosen inside it
-// reach the same attach callback the paperclip feeds. The real sheet, its
-// three hidden file inputs included, is covered by
+// reach the same attach callback the paperclip feeds. A second button stands
+// in for the real sheet closing itself before it launches the OS picker. The
+// real sheet, its three hidden file inputs included, is covered by
 // `add-to-chat-sheet.test.tsx`.
 const SHEET_PICK = [new File(["x"], "picked.png", { type: "image/png" })];
 mock.module(
@@ -253,11 +254,15 @@ mock.module(
   () => ({
     AddToChatSheet: (props: {
       open: boolean;
+      onOpenChange: (open: boolean) => void;
       onAttachFiles: (files: File[]) => void;
     }) => (
       <div data-testid="add-to-chat-sheet" data-open={String(props.open)}>
         <button type="button" onClick={() => props.onAttachFiles(SHEET_PICK)}>
           sheet-pick
+        </button>
+        <button type="button" onClick={() => props.onOpenChange(false)}>
+          sheet-close
         </button>
       </div>
     ),
@@ -1388,6 +1393,24 @@ describe("ChatComposer: single-row mobile composer", () => {
     // THEN the sheet the user is looking at stays up, rather than vanishing
     // with its open state still set and reappearing on the next flip
     expect(addSheet(container)?.getAttribute("data-open")).toBe("true");
+  });
+
+  test("a sheet closed into an OS picker outlives a keyboard reattach", () => {
+    // GIVEN a phone whose sheet has been up and then closed itself, which is
+    // what its rows do before handing off to the OS picker
+    const { container, getByText, rerender } = renderPhoneComposer();
+    fireEvent.click(control(container, PLUS_LABEL)!);
+    fireEvent.click(getByText("sheet-close"));
+    expect(addSheet(container)?.getAttribute("data-open")).toBe("false");
+
+    // WHEN a keyboard is attached while that picker is still up, flipping the
+    // live pointer with the sheet's own open flag already back to false
+    viewport.set({ narrow: true, coarsePointer: false });
+    rerender(composerElement());
+
+    // THEN the latch keeps the sheet's hidden inputs mounted to receive the
+    // selection, rather than both live mount terms going false together
+    expect(addSheet(container)).not.toBeNull();
   });
 
   test("the plus opens the picker directly when a mouse drives the window", () => {

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -728,6 +728,17 @@ export function ChatComposer({
   );
 
   const [addSheetOpen, setAddSheetOpen] = useState(false);
+  // Latched on the first open and never reset. The sheet closes itself before
+  // it hands off to the OS picker, so on a convertible that regained its
+  // keyboard while that picker was up both live terms below would go false in
+  // the same commit and take the sheet's hidden inputs with them.
+  const [addSheetEverPresented, setAddSheetEverPresented] = useState(false);
+  const handleAddSheetOpenChange = useCallback((open: boolean) => {
+    if (open) {
+      setAddSheetEverPresented(true);
+    }
+    setAddSheetOpen(open);
+  }, []);
   // Subscribed rather than read once: a convertible whose keyboard comes off
   // mid-session changes what the plus should open, and the sheet has to be
   // mounted by then to receive the press.
@@ -784,7 +795,9 @@ export function ChatComposer({
     <AddToChatButton
       disabled={attachDisabled}
       label={t("chatComposer.addToChat")}
-      onClick={usesAddSheet ? () => setAddSheetOpen(true) : openAttachPicker}
+      onClick={
+        usesAddSheet ? () => handleAddSheetOpenChange(true) : openAttachPicker
+      }
     />
   );
 
@@ -1371,7 +1384,7 @@ export function ChatComposer({
               The hook lays the input out as `absolute inset-0`, so it needs a
               positioned box of its own. */}
           <div className="relative">{attachPickerInput}</div>
-          {(pointerCoarseNow || addSheetOpen) && (
+          {(pointerCoarseNow || addSheetOpen || addSheetEverPresented) && (
             // The sheet's own three inputs, beside the form for the same reason.
             //
             // Mounted on the pointer rather than on the compound that decides
@@ -1383,9 +1396,15 @@ export function ChatComposer({
             // The pointer is a live signal, so a convertible that regains its
             // keyboard flips it mid-session: an already-open sheet holds itself
             // up through that, rather than vanishing with its `open` still set.
+            //
+            // Both of those are live, though, and a sheet row closes the sheet
+            // before it launches the OS picker, so the keyboard case could take
+            // them false together while a pick is in flight. The latch keeps a
+            // sheet that has ever been presented mounted for the rest of the
+            // session, which costs one hidden row and cannot drop a selection.
             <AddToChatSheet
               open={addSheetOpen}
-              onOpenChange={setAddSheetOpen}
+              onOpenChange={handleAddSheetOpenChange}
               onAttachFiles={onAddAttachmentFiles}
             />
           )}

--- a/clients/web/src/domains/chat/components/composer-peek.tsx
+++ b/clients/web/src/domains/chat/components/composer-peek.tsx
@@ -267,7 +267,10 @@ export function ComposerPeek({
             (Number.parseFloat(window.getComputedStyle(pills).marginBottom) ||
               0)
           : 0;
-      if (measuredClearance > 0) {
+      // Tracks the last measured value, zero included: holding only non-zero
+      // ones would let a blur taken after the row stopped overlapping (or
+      // unmounted) apply a stale clearance and teleport the exiting avatar up.
+      if (!exiting) {
         heldPillsClearance = measuredClearance;
       }
       const pillsClearance =


### PR DESCRIPTION
## Summary
Final micro-fixes from the mobile-composer-redesign review loop: the exiting avatar peek holds the last measured clearance (including zero), and the add-to-chat sheet stays mounted once it has ever been presented so a pointer-capability flip cannot drop an in-flight pick.