### PR TITLE
feat(web): show the external-models disclaimer under the mobile composer while unfocused

### DIFF
--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -755,6 +755,10 @@ function pillsRow(container: HTMLElement) {
   return container.querySelector('[data-slot="composer-settings-pills"]');
 }
 
+function disclaimer(container: HTMLElement) {
+  return container.querySelector('[data-slot="composer-disclaimer"]');
+}
+
 function addSheet(container: HTMLElement) {
   return container.querySelector('[data-testid="add-to-chat-sheet"]');
 }
@@ -1217,6 +1221,107 @@ describe("ChatComposer: mobile settings pills row", () => {
 
     // THEN there is nothing to float, so no row is rendered
     expect(pillsRow(container)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The resting caption below the card, the pills row's opposite number
+// ---------------------------------------------------------------------------
+
+describe("ChatComposer: the mobile external-models caption", () => {
+  const DISCLAIMER = "Vellum uses external AI models and can make mistakes";
+
+  test("an unfocused phone composer stands the caption under the card", () => {
+    // GIVEN a phone composer nobody has tapped into
+    const { container } = renderPhoneComposer(SETTINGS_SLOTS);
+
+    // THEN the caption is shown, below the card and outside it
+    const caption = disclaimer(container);
+    expect(caption?.textContent).toBe(DISCLAIMER);
+    expect(caption?.hasAttribute("hidden")).toBe(false);
+    expect(caption?.closest("form")).toBeNull();
+    const html = container.innerHTML;
+    expect(html.indexOf("<form")).toBeLessThan(
+      html.indexOf('data-slot="composer-disclaimer"'),
+    );
+  });
+
+  test("focusing the composer takes the caption away, as the keyboard covers it", () => {
+    // GIVEN a phone composer
+    const { container } = renderPhoneComposer(SETTINGS_SLOTS);
+
+    // WHEN it takes focus
+    fireEvent.focusIn(textareaOf(container));
+
+    // THEN the caption is hidden, still mounted, exactly as the pills row it
+    // trades places with
+    const caption = disclaimer(container);
+    expect(caption?.hasAttribute("hidden")).toBe(true);
+    expect(pillsRow(container)?.hasAttribute("hidden")).toBe(false);
+  });
+
+  test("an open settings sheet keeps the caption away with focus gone", () => {
+    // GIVEN a phone composer whose access sheet is open
+    const { container } = renderPhoneComposer({
+      ...SETTINGS_SLOTS,
+      settingsSheetOpen: true,
+    });
+    const textarea = textareaOf(container);
+    fireEvent.focusIn(textarea);
+
+    // WHEN the sheet takes focus out of the composer
+    fireEvent.focusOut(textarea, { relatedTarget: null });
+
+    // THEN the caption stays away rather than surfacing under the scrim
+    expect(disclaimer(container)?.hasAttribute("hidden")).toBe(true);
+  });
+
+  test("the composer's own add-to-chat sheet keeps it away too", () => {
+    // GIVEN a focused phone composer
+    const { container } = renderPhoneComposer(SETTINGS_SLOTS);
+    const textarea = textareaOf(container);
+    fireEvent.focusIn(textarea);
+
+    // WHEN the plus opens the add-to-chat sheet, which takes focus into a
+    // portal of its own
+    fireEvent.click(control(container, PLUS_LABEL)!);
+    fireEvent.focusOut(textarea, { relatedTarget: null });
+
+    // THEN the caption stays away for as long as the sheet is up
+    expect(disclaimer(container)?.hasAttribute("hidden")).toBe(true);
+  });
+
+  test("blurring back to the body brings the caption back", () => {
+    // GIVEN a focused phone composer
+    const { container } = renderPhoneComposer(SETTINGS_SLOTS);
+    const textarea = textareaOf(container);
+    fireEvent.focusIn(textarea);
+
+    // WHEN focus leaves with nowhere to land, as the iOS keyboard dismiss does
+    fireEvent.focusOut(textarea, { relatedTarget: null });
+
+    // THEN the composer is at rest again and the caption is back
+    expect(disclaimer(container)?.hasAttribute("hidden")).toBe(false);
+  });
+
+  test("desktop renders no caption, focused or not", () => {
+    // GIVEN a desktop composer
+    viewport.set({ narrow: false, coarsePointer: false });
+    const { container } = renderComposerView(SETTINGS_SLOTS);
+
+    // THEN nothing hangs under the card, and focus does not add it
+    expect(disclaimer(container)).toBeNull();
+    fireEvent.focusIn(textareaOf(container));
+    expect(disclaimer(container)).toBeNull();
+  });
+
+  test("a variant with no settings slots renders no caption (app-editing panel)", () => {
+    // GIVEN a phone composer that was passed neither settings slot
+    viewport.set({ narrow: true, coarsePointer: true });
+    const { container } = renderComposerView();
+
+    // THEN the panel's composer carries no caption of its own
+    expect(disclaimer(container)).toBeNull();
   });
 });
 

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -707,9 +707,10 @@ export function ChatComposer({
     !isLiveVoiceActive;
 
   // Mobile lifts the access and profile triggers out of the action row into a
-  // row that floats above the card while the composer is in use. A variant that
-  // passes neither slot (the app-editing panel) has no row to show.
-  const hasSettingsPills =
+  // row that floats above the card while the composer is in use, and hangs a
+  // caption under the card while it rests. A variant that passes neither
+  // settings slot is the app-editing panel, which gets neither.
+  const isMobileMainComposer =
     isMobile && Boolean(thresholdPickerSlot || modelPickerSlot);
 
   // No longer suppressed during a live-voice session: it was suppressed
@@ -761,9 +762,13 @@ export function ChatComposer({
   // composer's own add-to-chat sheet included, so each one has to hold the row
   // up on its way out. Without the sheet's flag the row would drop away as the
   // sheet rises and the card would shift down under the scrim.
-  const settingsPillsVisible =
-    hasSettingsPills &&
-    (composerFocusWithin || settingsSheetOpen || addSheetOpen);
+  const composerInUse =
+    composerFocusWithin || settingsSheetOpen || addSheetOpen;
+  const settingsPillsVisible = isMobileMainComposer && composerInUse;
+  // The caption is the row's opposite number: it stands under the card at rest
+  // and steps aside the moment anything takes the bottom of the screen, which
+  // is where the keyboard and every sheet cover it anyway.
+  const disclaimerVisible = isMobileMainComposer && !composerInUse;
 
   // A pill at mobile widths (half the card's 52px collapsed height), the 10px
   // panel elsewhere, both from the live-voice bar's module: the bar stacks on
@@ -1217,7 +1222,7 @@ export function ChatComposer({
             does when the card runs narrow is the control's own business, and
             must not depend on which row it happens to be sitting in. */}
         <ComposerCompactProvider compact={compactSettings}>
-          {hasSettingsPills && (
+          {isMobileMainComposer && (
             // Mounted for as long as the composer is, because each pill gates
             // itself on server state its own menu loads (access waits on the
             // global-threshold fetch), and a row that mounted on first focus
@@ -1377,6 +1382,21 @@ export function ChatComposer({
               )}
             </Popover.Content>
           </Popover.Root>
+          {isMobileMainComposer && (
+            // Mounted for as long as the composer is and toggled with `hidden`,
+            // the same treatment the pills row above the card gets: one caption
+            // that comes and goes rather than a node that mounts and unmounts
+            // under the card the composer is anchored to. Inside the shell, so
+            // focus judged against the shell is unaffected, and below the form,
+            // which is the box `composer-peek` measures.
+            <p
+              data-slot="composer-disclaimer"
+              hidden={!disclaimerVisible}
+              className="mt-2 px-4 text-center text-[10px] leading-3 text-[var(--content-tertiary)]"
+            >
+              {t("chatComposer.disclaimer")}
+            </p>
+          )}
           {/* Beside the form, not inside it: a hidden file input stays mounted
               while a native picker is up, and has no business in the form the
               composer submits. Mounted whatever the row is showing, so neither

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -8,7 +8,8 @@
   },
   "chatComposer": {
     "addToChat": "Add to chat",
-    "askAssistantPlaceholder": "Ask {assistantName}"
+    "askAssistantPlaceholder": "Ask {assistantName}",
+    "disclaimer": "Vellum uses external AI models and can make mistakes"
   },
   "conversationAssets": {
     "heading": "Assets",

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -8,7 +8,8 @@
   },
   "chatComposer": {
     "addToChat": "Añadir al chat",
-    "askAssistantPlaceholder": "Pregunta a {assistantName}"
+    "askAssistantPlaceholder": "Pregunta a {assistantName}",
+    "disclaimer": "Vellum usa modelos de IA externos y puede cometer errores"
   },
   "conversationAssets": {
     "heading": "Recursos",


### PR DESCRIPTION
## Summary
- Adds the Figma resting-state caption (Vellum uses external AI models and can make mistakes) below the mobile composer card
- Visible only while the composer is unfocused with no sheet up, mirroring the design where the keyboard covers it; desktop and the app-editing panel are unchanged
- Copy flows through the chat i18n catalog (en + es)

Part of plan: mobile-composer-redesign.md (follow-up to PR 6)