### PR TITLE
fix(bundler): remove the app bundler's package size cap

### DIFF
--- a/assistant/src/__tests__/app-compiler.test.ts
+++ b/assistant/src/__tests__/app-compiler.test.ts
@@ -20,6 +20,7 @@ import {
   packageName,
   resolvePackage,
 } from "../bundler/package-resolver.js";
+import { ensureBun } from "../util/bun-runtime.js";
 
 // ---------------------------------------------------------------------------
 // Shared temp directory
@@ -54,6 +55,29 @@ async function scaffold(
     await writeFile(filePath, content);
   }
   return appDir;
+}
+
+/**
+ * Download `pkg` into bun's global module cache via a throwaway install.
+ *
+ * `resolvePackage` bounds its own install at INSTALL_TIMEOUT_MS (10s), which a
+ * cold global cache can exceed for a large package on a slow network. Priming
+ * first is unbounded, so the install the test measures resolves from cache and
+ * stays well inside that bound.
+ */
+async function primeBunCache(pkg: string): Promise<void> {
+  const primeDir = join(tempDir, `prime-${pkg.replaceAll(/[^a-z0-9]/gi, "-")}`);
+  await mkdir(primeDir, { recursive: true });
+  await writeFile(
+    join(primeDir, "package.json"),
+    JSON.stringify({ name: "prime-cache", private: true }),
+  );
+  const proc = Bun.spawn([await ensureBun(), "install", "--no-save", pkg], {
+    cwd: primeDir,
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  await proc.exited;
 }
 
 const MINIMAL_HTML = `<!DOCTYPE html>
@@ -472,13 +496,15 @@ describe("package-resolver", () => {
     expect(ALLOWED_PACKAGES).not.toContain("lucide");
   });
 
-  // `chart.js` unpacks well past the 5 MB cap the resolver used to enforce,
-  // which deleted it right after install and broke every app that imported it.
+  // `chart.js` is a large allowlisted package: it must install into the shared
+  // cache and resolve so apps importing it can compile.
   test("resolvePackage installs a large allowlisted package", async () => {
+    await primeBunCache("chart.js");
+
     const result = await resolvePackage("chart.js");
     expect(result).not.toBeNull();
     expect(existsSync(join(getCacheDir(), "node_modules", "chart.js"))).toBe(
       true,
     );
-  }, 30_000);
+  }, 60_000);
 });

--- a/assistant/src/__tests__/app-compiler.test.ts
+++ b/assistant/src/__tests__/app-compiler.test.ts
@@ -466,10 +466,19 @@ describe("package-resolver", () => {
     expect(ALLOWED_PACKAGES).toContain("clsx");
   });
 
-  // `lucide` (the vanilla package) unpacks to ~29 MB, far above the resolver's
-  // size cap, so it is installed then deleted and never resolves. It also
-  // exports icon data arrays, not Preact components. Apps use inline SVG.
+  // `lucide` (the vanilla package) exports icon data arrays, not Preact
+  // components, and unpacks to ~29 MB for no benefit. Apps use inline SVG.
   test("ALLOWED_PACKAGES excludes lucide", () => {
     expect(ALLOWED_PACKAGES).not.toContain("lucide");
   });
+
+  // `chart.js` unpacks well past the 5 MB cap the resolver used to enforce,
+  // which deleted it right after install and broke every app that imported it.
+  test("resolvePackage installs a large allowlisted package", async () => {
+    const result = await resolvePackage("chart.js");
+    expect(result).not.toBeNull();
+    expect(existsSync(join(getCacheDir(), "node_modules", "chart.js"))).toBe(
+      true,
+    );
+  }, 30_000);
 });

--- a/assistant/src/bundler/package-resolver.ts
+++ b/assistant/src/bundler/package-resolver.ts
@@ -6,7 +6,7 @@
  */
 
 import { existsSync } from "node:fs";
-import { mkdir, stat } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 
 import { ensureBun } from "../util/bun-runtime.js";
@@ -24,8 +24,8 @@ export const ALLOWED_PACKAGES: readonly string[] = [
   "clsx",
 ] as const;
 
+/** Bounds a runaway install; the allowlist above bounds what may be installed. */
 const INSTALL_TIMEOUT_MS = 10_000;
-const MAX_PACKAGE_SIZE_BYTES = 5 * 1024 * 1024; // 5 MB
 
 /** In-flight install promises keyed by package name, to deduplicate concurrent requests. */
 const inflight = new Map<string, Promise<string | null>>();
@@ -148,37 +148,9 @@ async function installPackage(
       return null;
     }
 
-    // Enforce max size
-    if (existsSync(pkgDir)) {
-      const size = await dirSize(pkgDir);
-      if (size > MAX_PACKAGE_SIZE_BYTES) {
-        log.warn({ pkg, size }, "Package exceeds size limit, removing");
-        const { rm } = await import("node:fs/promises");
-        await rm(pkgDir, { recursive: true, force: true });
-        return null;
-      }
-    }
-
     return existsSync(pkgDir) ? nodeModulesDir : null;
   } catch (err) {
     log.warn({ pkg, err }, "Package resolution failed");
     return null;
   }
-}
-
-/** Recursively sum file sizes under a directory. */
-async function dirSize(dir: string): Promise<number> {
-  const { readdir } = await import("node:fs/promises");
-  const entries = await readdir(dir, { withFileTypes: true });
-  let total = 0;
-  for (const entry of entries) {
-    const full = join(dir, entry.name);
-    if (entry.isDirectory()) {
-      total += await dirSize(full);
-    } else {
-      const s = await stat(full);
-      total += s.size;
-    }
-  }
-  return total;
 }


### PR DESCRIPTION
## Prompt / plan

Remove the app bundler's package size cap, which silently deletes allowlisted packages.

### The bug

`assistant/src/bundler/package-resolver.ts` keeps an allowlist of packages that plugin and workspace apps may import (`date-fns`, `chart.js`, `lodash-es`, `zod`, `clsx`) and installs them on demand into the shared cache at `~/.vellum/package-cache/`. Directly after a successful install it measured the installed directory and deleted the package if it exceeded `MAX_PACKAGE_SIZE_BYTES = 5 MB`.

Two of the five allowlisted packages — `chart.js` and `date-fns` — unpack past 5 MB. Every app build installed them, measured them, deleted them, and then esbuild failed with "Could not resolve". The allowlist promised packages the resolver would never hand back, so any app that trusted the documented list could not compile.

The failure was almost silent: one `Package exceeds size limit, removing` warning in the monitor log, and "App compilation failed." in the Library. A telltale scar is that `chart.js`'s small dependency `@kurkle/color` survives in the cache while `chart.js` itself is gone.

### What changed

- Deleted `MAX_PACKAGE_SIZE_BYTES` and the post-install size-check/delete block.
- Deleted the now-unused `dirSize` helper and the `stat` import it needed.

### What still bounds installs

Nothing here loosens what may be installed. The explicit `ALLOWED_PACKAGES` allowlist remains the trust boundary — an unlisted package still resolves to `null` before any install runs — and `INSTALL_TIMEOUT_MS` (10s) remains the runaway bound.

## Test plan

- Reproduced first: with the cap in place, the new test fails — `resolvePackage("chart.js")` returns `null` in 16 ms (installed, then deleted).
- `bun test src/__tests__/app-compiler.test.ts` — 26 pass, 0 fail. Added `resolvePackage installs a large allowlisted package`, which asserts `chart.js` resolves and lands in the cache; replaced the stale size-cap rationale in the `excludes lucide` comment (lucide stays off the allowlist because it ships icon data arrays, not Preact components).
- The new test primes bun's global module cache with an unbounded throwaway install first, so the install `resolvePackage` performs resolves from cache and does not race `INSTALL_TIMEOUT_MS` (10s) on a cold CI cache. Verified with `BUN_INSTALL_CACHE_DIR` pointed at an empty temp dir: 6.4 MB of chart.js downloads fresh and the test still passes in 933 ms.
- `bun run typecheck:fast` — clean.
- `bun run lint` on both changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40679" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
