### PR TITLE
feat(web): translate settings billing

### DIFF
--- a/clients/web/eslint.config.mjs
+++ b/clients/web/eslint.config.mjs
@@ -210,6 +210,7 @@ const i18nEnforcedPaths = [
   "src/domains/intelligence/**/*.{ts,tsx}",
   "src/domains/settings/ai/**/*.{ts,tsx}",
   "src/domains/chat/inspector/**/*.{ts,tsx}",
+  "src/domains/settings/billing/**/*.{ts,tsx}",
 ];
 
 const eslintConfig = defineConfig([

--- a/clients/web/src/domains/settings/billing/billing-page.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.tsx
@@ -93,6 +93,7 @@ function FinishProSetupNotice({
 }: {
   onFinishSetup: () => void;
 }) {
+  const { t } = useTranslation("settings");
   // Gate the query chain on org readiness (and subscribe to it, so the notice
   // re-evaluates when the org hydrates): a request fired before the org store
   // settles omits `Vellum-Organization-Id` and the platform rejects it.
@@ -124,7 +125,9 @@ function FinishProSetupNotice({
   return (
     <Notice
       tone="info"
-      title={`Finish setting up your ${proPackageDisplayName(subscription?.package)} plan`}
+      title={t("billingPage.finishSetupTitle", {
+        plan: proPackageDisplayName(subscription?.package),
+      })}
       actions={
         <Button
           variant="outlined"
@@ -132,17 +135,18 @@ function FinishProSetupNotice({
           onClick={onFinishSetup}
           data-testid="finish-pro-setup-button"
         >
-          Finish setup
+          {t("billingPage.finishSetupButton")}
         </Button>
       }
       data-testid="finish-pro-setup-notice"
     >
-      Your assistant&apos;s email address hasn&apos;t been set up yet.
+      {t("billingPage.finishSetupBody")}
     </Notice>
   );
 }
 
 function BillingTabContent() {
+  const { t } = useTranslation("settings");
   const platformGate = usePlatformGate({ platformHostedOnly: true });
   const billingGate = usePlatformGate();
   const isPlatformHosted = useActiveAssistantIsPlatformHosted();
@@ -237,7 +241,7 @@ function BillingTabContent() {
     return (
       <div className="space-y-4">
         <PlatformLoginNotice>
-          Log in to the Vellum platform to manage billing and usage.
+          {t("billingPage.platformLoginNotice")}
         </PlatformLoginNotice>
       </div>
     );
@@ -248,7 +252,7 @@ function BillingTabContent() {
       <div className="space-y-4">
         <div className="flex items-center gap-2 py-6 text-body-medium-lighter text-[var(--content-secondary)]">
           <Loader2 className="h-4 w-4 animate-spin" />
-          Loading billing…
+          {t("billingPage.loadingBilling")}
         </div>
       </div>
     );
@@ -270,7 +274,7 @@ function BillingTabContent() {
     return (
       <div className="space-y-4">
         <Notice tone="warning">
-          Billing isn&apos;t available for the current assistant state.
+          {t("billingPage.billingUnavailable")}
         </Notice>
       </div>
     );
@@ -347,6 +351,7 @@ function UsagePanel() {
 }
 
 export function BillingPage() {
+  const { t } = useTranslation("settings");
   const billingGate = usePlatformGate();
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
@@ -400,9 +405,11 @@ export function BillingPage() {
       <Tabs.Root value={activeTab} onValueChange={handleTabChange}>
         <Tabs.List>
           {showBillingTab && (
-            <Tabs.Trigger value="billing">Billing</Tabs.Trigger>
+            <Tabs.Trigger value="billing">
+              {t("billingPage.billingTab")}
+            </Tabs.Trigger>
           )}
-          <Tabs.Trigger value="usage">Usage</Tabs.Trigger>
+          <Tabs.Trigger value="usage">{t("billingPage.usageTab")}</Tabs.Trigger>
         </Tabs.List>
         {showBillingTab && (
           <Tabs.Panel value="billing" className="pt-4">

--- a/clients/web/src/domains/settings/billing/checkout-page.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/lib/billing/takeover-avatar-stash";
 import { organizationsBillingSubscriptionUpgradeCreateMutation } from "@/generated/api/@tanstack/react-query.gen";
 import { useOrgHeaderReadiness } from "@/hooks/use-is-org-ready";
+import { useTranslation } from "@/i18n";
 import { useMarketingPricingTakeover } from "@/hooks/use-marketing-pricing-takeover";
 import { usePlatformGateWithPending } from "@/hooks/use-platform-gate";
 import { checkoutContinuation } from "@/lib/billing/checkout-continuation";
@@ -93,6 +94,7 @@ function abandonCheckout() {
  * them off this route.
  */
 function CheckoutPageContent() {
+  const { t } = useTranslation("settings");
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const packageKey = searchParams.get(PACKAGE_PARAM) ?? "";
@@ -134,7 +136,9 @@ function CheckoutPageContent() {
   // carried onboarding continuation is not the plans takeover, and a label
   // naming one destination while taking another is worse than either wording.
   const bailLabel =
-    bailTarget === routes.plans ? "View plans" : "Continue setup";
+    bailTarget === routes.plans
+      ? t("checkoutPage.viewPlans")
+      : t("checkoutPage.continueSetup");
 
   const queryClient = useQueryClient();
   const { mutateAsync } = useMutation(
@@ -325,10 +329,10 @@ function CheckoutPageContent() {
     return (
       <div className="flex h-full w-full flex-col items-center justify-center gap-4 px-6 text-center">
         <p className="text-[var(--content-default)]">
-          We couldn&rsquo;t start your checkout. Please try again.
+          {t("checkoutPage.checkoutFailedMessage")}
         </p>
         <div className="flex items-center gap-4">
-          <Button onClick={retryCheckout}>Try again</Button>
+          <Button onClick={retryCheckout}>{t("checkoutPage.tryAgain")}</Button>
           {/*
            * Taking the escape ends the attempt, so both stashes go with it.
            * Nothing was bought, and a signup-marked intent left behind is one
@@ -350,11 +354,12 @@ function CheckoutPageContent() {
     return (
       <div className="flex h-full w-full flex-col items-center justify-center gap-4 px-6 text-center">
         <p className="text-[var(--content-default)]">
-          Checkout opened in your browser. Finish there to complete your
-          upgrade.
+          {t("checkoutPage.awaitingReturnMessage")}
         </p>
         <div className="flex items-center gap-4">
-          <Button onClick={retryCheckout}>Reopen checkout</Button>
+          <Button onClick={retryCheckout}>
+            {t("checkoutPage.reopenCheckout")}
+          </Button>
           {/*
            * No `abandonCheckout` here, unlike the failure escape: a
            * checkout that reached Stripe may have been paid for, and this page
@@ -377,10 +382,10 @@ function CheckoutPageContent() {
     <div className="flex h-full w-full flex-col items-center justify-center gap-3">
       <Loader2
         className="h-6 w-6 animate-spin text-[var(--content-tertiary)]"
-        aria-label="Preparing checkout"
+        aria-label={t("checkoutPage.preparingCheckoutAriaLabel")}
       />
       <p className="text-sm text-[var(--content-tertiary)]">
-        Preparing checkout&hellip;
+        {t("checkoutPage.preparingCheckout")}
       </p>
     </div>
   );

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.tsx
@@ -20,6 +20,7 @@ import type {
   StorageTier,
   StorageTierEnum,
 } from "@/generated/api/types.gen";
+import { useTranslation } from "@/i18n";
 import { handleNativeAnchorClick } from "@/utils/native-anchor";
 import { Button } from "@vellumai/design-library/components/button";
 import {
@@ -101,10 +102,12 @@ function PickerLabel({
   label,
   docsUrl,
   docsLabel,
+  learnMore,
 }: {
   label: string;
   docsUrl: string;
   docsLabel: string;
+  learnMore: string;
 }) {
   return (
     <div className="flex items-center justify-between gap-2">
@@ -119,7 +122,7 @@ function PickerLabel({
         onClick={(e) => handleNativeAnchorClick(e, docsUrl)}
         className="text-[11px] font-medium text-[var(--content-tertiary)] underline hover:text-[var(--content-default)]"
       >
-        Learn more
+        {learnMore}
       </a>
     </div>
   );
@@ -143,6 +146,8 @@ export function CustomPlanModal({
   onClose,
   onContinue,
 }: CustomPlanModalProps) {
+  const { t } = useTranslation("settings");
+
   // A Pro reconfigure seeds the current tiers so the default is a no-op; base
   // checkout passes none and leaves every dimension empty. A baseline machine
   // (null) seeds the sentinel, mirroring how a null credit tier seeds
@@ -372,23 +377,24 @@ export function CustomPlanModal({
                 </div>
                 <div className="flex min-w-0 flex-col gap-1">
                   <Modal.Title className="text-[16px] font-medium text-[var(--content-emphasised)]">
-                    Create a custom plan
+                    {t("customPlanModal.title")}
                   </Modal.Title>
                   <Modal.Description className="mt-0 text-[14px] font-medium leading-[18px] text-[var(--content-tertiary)]">
-                    Just better.
+                    {t("customPlanModal.subtitle")}
                   </Modal.Description>
                 </div>
               </div>
 
               <div className="flex flex-col gap-1">
                 <PickerLabel
-                  label="Select a machine size:"
+                  label={t("customPlanModal.machineSizeLabel")}
                   docsUrl={MACHINE_DOCS_URL}
-                  docsLabel="Learn more about machine sizes"
+                  docsLabel={t("customPlanModal.machineSizeDocsAriaLabel")}
+                  learnMore={t("customPlanModal.learnMore")}
                 />
                 <Select<MachineChoice>
-                  aria-label="Machine size"
-                  placeholder="Select a machine size"
+                  aria-label={t("customPlanModal.machineSizeAriaLabel")}
+                  placeholder={t("customPlanModal.machineSizePlaceholder")}
                   value={machineTier}
                   onChange={setMachineTier}
                   options={machineOptions}
@@ -397,13 +403,14 @@ export function CustomPlanModal({
 
               <div className="flex flex-col gap-1">
                 <PickerLabel
-                  label="Select storage:"
+                  label={t("customPlanModal.storageLabel")}
                   docsUrl={STORAGE_DOCS_URL}
-                  docsLabel="Learn more about storage"
+                  docsLabel={t("customPlanModal.storageDocsAriaLabel")}
+                  learnMore={t("customPlanModal.learnMore")}
                 />
                 <Select<StorageTierEnum>
-                  aria-label="Storage"
-                  placeholder="Select storage"
+                  aria-label={t("customPlanModal.storageAriaLabel")}
+                  placeholder={t("customPlanModal.storagePlaceholder")}
                   value={storageTier}
                   onChange={setStorageTier}
                   options={storageOptions}
@@ -412,13 +419,14 @@ export function CustomPlanModal({
 
               <div className="flex flex-col gap-1">
                 <PickerLabel
-                  label="Bundle some credits:"
+                  label={t("customPlanModal.creditsLabel")}
                   docsUrl={CREDIT_DOCS_URL}
-                  docsLabel="Learn more about credit bundles"
+                  docsLabel={t("customPlanModal.creditsDocsAriaLabel")}
+                  learnMore={t("customPlanModal.learnMore")}
                 />
                 <Select<CreditChoice>
-                  aria-label="Credit bundle"
-                  placeholder="Select a credit bundle"
+                  aria-label={t("customPlanModal.creditBundleAriaLabel")}
+                  placeholder={t("customPlanModal.creditBundlePlaceholder")}
                   value={creditChoice}
                   onChange={setCreditChoice}
                   options={creditOptions}
@@ -428,7 +436,7 @@ export function CustomPlanModal({
 
             <div className="flex min-w-0 flex-1 flex-col gap-16 md:pt-[5px]">
               <span className="text-[16px] font-medium text-[var(--content-emphasised)]">
-                Recap
+                {t("customPlanModal.recap")}
               </span>
 
               <div className="flex flex-col gap-4">
@@ -442,19 +450,21 @@ export function CustomPlanModal({
                       <span
                         className={`text-[12px] font-medium ${diff.deltaCents > 0 ? "text-[var(--system-positive-strong)]" : "text-[var(--system-negative-strong)]"}`}
                       >
-                        {formatDelta(diff.deltaCents)} compared to previous (
-                        {formatDollars(diff.previousTotalCents)})
+                        {t("customPlanModal.comparedToPrevious", {
+                          delta: formatDelta(diff.deltaCents),
+                          previous: formatDollars(diff.previousTotalCents),
+                        })}
                       </span>
                     )}
                   <span className="text-[11px] font-medium text-[var(--content-tertiary)]">
-                    Total · Billed monthly
+                    {t("customPlanModal.totalBilledMonthly")}
                   </span>
                 </div>
 
                 <div className="h-px w-full bg-[var(--border-hover)]" />
 
                 <span className="text-[12px] font-medium text-[var(--content-tertiary)]">
-                  Your selection:
+                  {t("customPlanModal.yourSelection")}
                 </span>
 
                 <ul className="flex flex-col gap-2">
@@ -496,7 +506,7 @@ export function CustomPlanModal({
                   disabled={!complete || matchesSeed || pending}
                   onClick={handleContinue}
                 >
-                  Continue
+                  {t("customPlanModal.continue")}
                 </Button>
                 <Button
                   variant="ghost"
@@ -504,7 +514,7 @@ export function CustomPlanModal({
                   disabled={pending}
                   onClick={onClose}
                 >
-                  Cancel
+                  {t("customPlanModal.cancel")}
                 </Button>
               </div>
             </div>

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-row.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-row.tsx
@@ -1,10 +1,8 @@
 import { SlidersHorizontal } from "lucide-react";
 
+import { useTranslation } from "@/i18n";
 import { Button } from "@vellumai/design-library/components/button";
 import { Tag } from "@vellumai/design-library/components/tag";
-
-const GENERIC_DESCRIPTOR =
-  "Select custom CPU power, Ram and Storage. Or just throw in some tokens.";
 
 export interface CustomPlanRowProps {
   className?: string;
@@ -39,12 +37,13 @@ export function CustomPlanRow({
   isCurrent = false,
   currentSummary,
 }: CustomPlanRowProps) {
+  const { t } = useTranslation("settings");
   return (
     <div
       className={`flex w-full flex-col items-center gap-8 ${className ?? ""}`}
     >
       <p className="text-center text-[20px] font-medium text-[var(--content-tertiary)]">
-        Need something more tailored to your needs?
+        {t("customPlanRow.prompt")}
       </p>
       <div className="flex w-[840px] max-w-full flex-col items-start gap-4 rounded-2xl bg-[var(--surface-lift)] p-4 sm:flex-row sm:items-center sm:justify-between sm:gap-6">
         <div className="flex min-w-0 items-center gap-4">
@@ -57,16 +56,16 @@ export function CustomPlanRow({
           <div className="flex min-w-0 flex-col gap-1">
             <div className="flex flex-wrap items-center gap-2">
               <span className="text-[16px] font-medium text-[var(--content-emphasised)]">
-                Custom Plan
+                {t("customPlanRow.title")}
               </span>
               {isCurrent ? (
                 <Tag className="bg-[var(--feed-digest-weak)] text-[var(--content-default)]">
-                  Your Current Plan
+                  {t("customPlanRow.currentPlanTag")}
                 </Tag>
               ) : null}
             </div>
             <span className="text-[14px] font-medium text-[var(--content-tertiary)]">
-              {currentSummary ?? GENERIC_DESCRIPTOR}
+              {currentSummary ?? t("customPlanRow.genericDescriptor")}
             </span>
           </div>
         </div>
@@ -76,7 +75,7 @@ export function CustomPlanRow({
             onClick={onConfigure}
             disabled={configureDisabled}
           >
-            Configure
+            {t("customPlanRow.configure")}
           </Button>
         </div>
       </div>

--- a/clients/web/src/domains/settings/billing/plans/free-downgrade-confirm-modal.tsx
+++ b/clients/web/src/domains/settings/billing/plans/free-downgrade-confirm-modal.tsx
@@ -1,5 +1,6 @@
 import { AlertTriangle } from "lucide-react";
 
+import { useTranslation } from "@/i18n";
 import { Button } from "@vellumai/design-library/components/button";
 import { Modal } from "@vellumai/design-library/components/modal";
 import { Typography } from "@vellumai/design-library/components/typography";
@@ -32,6 +33,7 @@ export function FreeDowngradeConfirmModal({
   onCancel,
   onConfirm,
 }: FreeDowngradeConfirmModalProps) {
+  const { t } = useTranslation("settings");
   const hasLostFeatures = lostFeatures.length > 0;
   return (
     <Modal.Root
@@ -44,7 +46,7 @@ export function FreeDowngradeConfirmModal({
     >
       <Modal.Content size="md" hideCloseButton>
         <Modal.Header icon={AlertTriangle}>
-          <Modal.Title>Downgrade to Base?</Modal.Title>
+          <Modal.Title>{t("freeDowngradeConfirmModal.title")}</Modal.Title>
         </Modal.Header>
         <Modal.Body>
           <Typography
@@ -53,8 +55,8 @@ export function FreeDowngradeConfirmModal({
             className="text-(--content-secondary)"
           >
             {hasLostFeatures
-              ? "Downgrading removes the following Pro features. You'll be taken to Stripe to cancel your subscription."
-              : "You'll be taken to Stripe to cancel your subscription."}
+              ? t("freeDowngradeConfirmModal.bodyWithFeatures")
+              : t("freeDowngradeConfirmModal.bodyCancelOnly")}
           </Typography>
           {hasLostFeatures ? (
             <ul className="mt-4 list-disc space-y-2 pl-5">
@@ -70,7 +72,7 @@ export function FreeDowngradeConfirmModal({
         </Modal.Body>
         <Modal.Footer>
           <Button variant="outlined" onClick={onCancel} disabled={pending}>
-            Cancel
+            {t("freeDowngradeConfirmModal.cancel")}
           </Button>
           <Button
             variant="danger"
@@ -78,7 +80,7 @@ export function FreeDowngradeConfirmModal({
             disabled={pending}
             data-testid="confirm-free-downgrade-button"
           >
-            Downgrade to Base
+            {t("freeDowngradeConfirmModal.confirm")}
           </Button>
         </Modal.Footer>
       </Modal.Content>

--- a/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.tsx
+++ b/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.tsx
@@ -11,6 +11,7 @@ import { packageHighlights } from "@/domains/settings/billing/plan-spec";
 import { packageSwitchCopy } from "@/domains/settings/billing/plans/package-switch-copy";
 import { getPlanTierCopy } from "@/domains/settings/billing/plans/plans-copy";
 import { formatMonthly } from "@/domains/settings/components/tier-pricing";
+import { useTranslation } from "@/i18n";
 import { Button } from "@vellumai/design-library/components/button";
 import { Modal } from "@vellumai/design-library/components/modal";
 import { Typography } from "@vellumai/design-library/components/typography";
@@ -53,6 +54,7 @@ export function PackageSwitchConfirmModal({
   onCancel,
   onConfirm,
 }: PackageSwitchConfirmModalProps) {
+  const { t } = useTranslation("settings");
   const cancelRef = useRef<HTMLButtonElement>(null);
   const noteId = useId();
   const copy = packageSwitchCopy(
@@ -221,7 +223,7 @@ export function PackageSwitchConfirmModal({
             onClick={onCancel}
             disabled={pending}
           >
-            Cancel
+            {t("packageSwitchConfirmModal.cancel")}
           </Button>
         </Modal.Footer>
       </Modal.Content>

--- a/clients/web/src/domains/settings/billing/plans/plan-column-card.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plan-column-card.tsx
@@ -2,6 +2,7 @@ import { CircleCheck } from "lucide-react";
 
 import { PlanTierAvatar } from "@/domains/settings/billing/plan-tier-meta";
 import type { TierRelation } from "@/domains/settings/billing/package-types";
+import { useTranslation } from "@/i18n";
 import { Button } from "@vellumai/design-library/components/button";
 import { Tag } from "@vellumai/design-library/components/tag";
 
@@ -55,6 +56,7 @@ export function PlanColumnCard({
   pending,
   onCta,
 }: PlanColumnCardProps) {
+  const { t } = useTranslation("settings");
   const isDowngrade = intent === "downgrade" && !isCurrent;
   return (
     <div
@@ -70,7 +72,7 @@ export function PlanColumnCard({
           </span>
           {recommended && !isDowngrade && !isCurrent ? (
             <Tag className="bg-[var(--feed-digest-weak)] text-[12px] font-semibold uppercase text-[var(--credits-accent)]">
-              Recommended
+              {t("planColumnCard.recommended")}
             </Tag>
           ) : null}
         </div>
@@ -97,14 +99,14 @@ export function PlanColumnCard({
         disabled={isCurrent || pending}
         onClick={onCta}
       >
-        {isCurrent ? "Current Plan" : ctaLabel}
+        {isCurrent ? t("planColumnCard.currentPlan") : ctaLabel}
       </Button>
 
       <div className="h-px w-full bg-[var(--border-hover)]" />
 
       <div className="flex flex-col gap-2 sm:gap-4">
         <span className="text-[12px] font-medium text-[var(--content-tertiary)]">
-          Includes:
+          {t("planColumnCard.includes")}
         </span>
         <ul className="flex flex-col gap-2">
           {features.map((feature) => (

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -32,9 +32,9 @@ import { FreeDowngradeConfirmModal } from "@/domains/settings/billing/plans/free
 import { PackageSwitchConfirmModal } from "@/domains/settings/billing/plans/package-switch-confirm-modal";
 import { PlanColumnCard } from "@/domains/settings/billing/plans/plan-column-card";
 import {
-  downgradeLabel,
   getPlanTierCopy,
 } from "@/domains/settings/billing/plans/plans-copy";
+import { Trans, useTranslation } from "@/i18n";
 import {
   BillingOnboardingModal,
   type ResizeTakeoverContext,
@@ -106,24 +106,31 @@ const TAKEOVER_DIRECTION: Record<SwitchRelation, TakeoverDirection> = {
 // module load so they resolve before first paint instead of popping in.
 preloadBundledAvatarComponents();
 
-const FREE_FEATURES: readonly string[] = [
-  "Small Computer",
-  `${FREE_STORAGE_GIB} GB Storage`,
-  "Pay-as-you-go credits",
-];
+type SettingsTranslate = ReturnType<typeof useTranslation<"settings">>["t"];
 
 /** Machine label for a package's feature row, e.g. "Medium Computer". */
-function machineComputerLabel(pkg: ProPackage): string {
-  return `${machineLabel(pkg)} Computer`;
+function machineComputerLabel(
+  pkg: ProPackage,
+  translate: SettingsTranslate,
+): string {
+  return translate("plansPage.featureComputer", {
+    machine: machineLabel(pkg),
+  });
 }
 
 /** Catalog-derived feature rows, plus any static extras from the copy. */
-function packageFeatures(pkg: ProPackage, extra: readonly string[]): string[] {
+function packageFeatures(
+  pkg: ProPackage,
+  extra: readonly string[],
+  translate: SettingsTranslate,
+): string[] {
   const credits = pkg.credits_usd ?? FREE_CREDITS_USD;
   return [
-    machineComputerLabel(pkg),
-    `${pkg.storage_gib} GB Storage`,
-    `${formatDollars(credits * 100)} in credits included`,
+    machineComputerLabel(pkg, translate),
+    translate("plansPage.featureStorage", { gib: pkg.storage_gib }),
+    translate("plansPage.featureCreditsIncluded", {
+      amount: formatDollars(credits * 100),
+    }),
     ...extra,
   ];
 }
@@ -145,6 +152,7 @@ function customCurrentSummary(current: CurrentTiers, proPlan: ProPlan): string {
  * the billing page.
  */
 function PlansPageContent() {
+  const { t } = useTranslation("settings");
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const queryClient = useQueryClient();
@@ -374,7 +382,7 @@ function PlansPageContent() {
       toast.error(
         extractMutationError(
           error,
-          "Failed to start the upgrade checkout. Please try again.",
+          t("plansPage.checkoutFailedToast"),
         ),
       );
     } finally {
@@ -632,7 +640,7 @@ function PlansPageContent() {
       setSwitchTarget(null);
       if (result.status === "no_op") {
         // Already on this package — nothing to provision.
-        toast.success("You're already on this plan.");
+        toast.success(t("plansPage.alreadyOnPlanToast"));
         return;
       }
       // status === "ok": every direction restarts the pod, a downgrade included
@@ -694,7 +702,7 @@ function PlansPageContent() {
         });
         setResizeTakeoverOpen(true);
       } else {
-        toast.success("Plan updated.");
+        toast.success(t("plansPage.planUpdatedToast"));
       }
     };
 
@@ -726,6 +734,12 @@ function PlansPageContent() {
       ? "downgrade"
       : tierRelation(currentTierKey, "free");
 
+    const freeFeatures = [
+      t("plansPage.freeFeatureSmallComputer"),
+      t("plansPage.freeFeatureStorage", { gib: FREE_STORAGE_GIB }),
+      t("plansPage.freeFeaturePayAsYouGo"),
+    ];
+
     body = (
       <div className="my-auto flex w-full flex-col items-center">
         <header className="flex flex-col items-center gap-2 text-center">
@@ -738,10 +752,10 @@ function PlansPageContent() {
               letterSpacing: "1.2px",
             }}
           >
-            Give your assistant more power
+            {t("plansPage.heading")}
           </h1>
           <p className="text-[20px] font-medium text-[var(--content-tertiary)]">
-            Choose the level that matches how much you want it to take on.
+            {t("plansPage.subheading")}
           </p>
         </header>
 
@@ -754,14 +768,14 @@ function PlansPageContent() {
             tierKey="free"
             name="Base"
             tagline={freeCopy?.tagline ?? ""}
-            priceLabel="Free"
-            priceCaption={freeCopy?.priceCaption ?? "Forever"}
+            priceLabel={t("plansPage.freePriceLabel")}
+            priceCaption={freeCopy?.priceCaption ?? t("plansPage.foreverCaption")}
             ctaLabel={
               freeRelation === "downgrade"
-                ? downgradeLabel("Base")
-                : (freeCopy?.cta ?? "Start Free")
+                ? t("plansPage.downgradeTo", { name: "Base" })
+                : (freeCopy?.cta ?? t("plansPage.startFreeCta"))
             }
-            features={FREE_FEATURES}
+            features={freeFeatures}
             tone="dark"
             isCurrent={currentTierKey === "free"}
             intent={freeRelation}
@@ -778,13 +792,15 @@ function PlansPageContent() {
                 name={pkg.name}
                 tagline={copy?.tagline ?? ""}
                 priceLabel={priceLabelFromCents(pkg.total_price_cents)}
-                priceCaption={copy?.priceCaption ?? "Billed monthly"}
+                priceCaption={
+                  copy?.priceCaption ?? t("plansPage.billedMonthlyCaption")
+                }
                 ctaLabel={
                   relation === "downgrade"
-                    ? downgradeLabel(pkg.name)
+                    ? t("plansPage.downgradeTo", { name: pkg.name })
                     : (copy?.cta ?? pkg.name)
                 }
-                features={packageFeatures(pkg, copy?.extraFeatures ?? [])}
+                features={packageFeatures(pkg, copy?.extraFeatures ?? [], t)}
                 recommended={copy?.recommended}
                 tone={copy?.recommended ? "light" : "dark"}
                 isCurrent={currentTierKey === pkg.key}
@@ -853,15 +869,20 @@ function PlansPageContent() {
         />
 
         <p className="mt-6 text-center text-[12px] font-medium text-[var(--content-tertiary)] sm:mt-10">
-          You can cancel or change your plan anytime you want. To learn more{" "}
-          <a
-            href={PRICING_DOCS_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-[var(--content-default)] underline"
-          >
-            Read our Docs.
-          </a>
+          <Trans
+            ns="settings"
+            i18nKey="plansPage.cancelAnytimeFooter"
+            components={{
+              docsLink: (
+                <a
+                  href={PRICING_DOCS_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-[var(--content-default)] underline"
+                />
+              ),
+            }}
+          />
         </p>
       </div>
     );
@@ -870,7 +891,7 @@ function PlansPageContent() {
       <div className="my-auto flex items-center justify-center">
         <Loader2
           className="h-6 w-6 animate-spin text-[var(--content-tertiary)]"
-          aria-label="Loading plans"
+          aria-label={t("plansPage.loadingPlansAriaLabel")}
         />
       </div>
     );
@@ -894,7 +915,7 @@ function PlansPageContent() {
           onClick={handleBack}
           className="[-webkit-app-region:no-drag]"
         >
-          Back
+          {t("plansPage.back")}
         </Button>
       </div>
 

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -14,6 +14,7 @@ import {
   readPurchasedCheckoutIntent,
   type CheckoutIntent,
 } from "@/lib/billing/checkout-intent";
+import { useTranslation } from "@/i18n";
 import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 import { Modal } from "@vellumai/design-library/components/modal";
 import { toast } from "@vellumai/design-library/components/toast";
@@ -122,6 +123,7 @@ export function BillingOnboardingModal({
   mode = "checkout",
   resizeContext,
 }: BillingOnboardingModalProps) {
+  const { t } = useTranslation("settings");
   const isResize = mode === "resize";
   const queryClient = useQueryClient();
   const [step, setStep] = useState<WizardStep>("provisioning");
@@ -503,10 +505,10 @@ export function BillingOnboardingModal({
         // confirm is open closes it declaratively, so its buttons can't act
         // after the wizard has advanced past provisioning.
         open={backgroundConfirmOpen && machineBusy}
-        title="Continue in the background?"
+        title={t("billingOnboardingModal.backgroundConfirmTitle")}
         message={copy.backgroundConfirmMessage}
-        confirmLabel="Continue"
-        cancelLabel="Keep waiting"
+        confirmLabel={t("billingOnboardingModal.backgroundConfirmContinue")}
+        cancelLabel={t("billingOnboardingModal.backgroundConfirmKeepWaiting")}
         onConfirm={confirmBackgroundExit}
         onCancel={cancelBackgroundExit}
       />

--- a/clients/web/src/domains/settings/billing/pro-onboarding/complete-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/complete-state.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from "react-router";
 
 import { setSelectedAssistant } from "@/assistant/selection";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
+import { useTranslation } from "@/i18n";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
 
@@ -19,9 +20,11 @@ export function CompleteState({
   direction?: TakeoverDirection;
 }) {
   const navigate = useNavigate();
+  const { t } = useTranslation("settings");
   const isOrgReady = useIsOrgReady();
   const assistant = usePreferredOrActiveAssistant(assistantId, isOrgReady);
-  const assistantName = assistant?.name || "your assistant";
+  const assistantName =
+    assistant?.name || t("completeState.assistantFallbackName");
 
   return (
     <div className="relative flex min-h-[320px] flex-col items-center justify-center overflow-hidden px-8 pb-16 [animation:onboarding-step-in_350ms_ease-out] motion-reduce:[animation:none]">
@@ -30,7 +33,7 @@ export function CompleteState({
       {/* `relative` lifts the content above the absolute creature layer. */}
       <div className="relative flex w-full flex-col items-center">
         <WizardCardHeading
-          title="You're all set!"
+          title={t("completeState.title")}
           subtitle={takeoverCopy(direction).completeSubtitle}
         />
 
@@ -49,7 +52,7 @@ export function CompleteState({
               navigate(routes.assistant, { replace: true });
             }}
           >
-            Return to {assistantName}
+            {t("completeState.returnTo", { assistantName })}
           </Button>
         </div>
       </div>

--- a/clients/web/src/domains/settings/billing/pro-onboarding/domain-step.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/domain-step.test.tsx
@@ -231,7 +231,7 @@ describe("DomainStep machine busy", () => {
     await waitFor(() =>
       expect(
         getByText(
-          "Your assistant is restarting — you can set the domain in a moment.",
+          "Your assistant is restarting - you can set the domain in a moment.",
         ),
       ).toBeTruthy(),
     );

--- a/clients/web/src/domains/settings/billing/pro-onboarding/domain-step.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/domain-step.tsx
@@ -8,6 +8,7 @@ import {
   organizationsBillingSubscriptionOnboardingDomainCreateMutation,
   organizationsBillingSubscriptionOnboardingRetrieveQueryKey,
 } from "@/generated/api/@tanstack/react-query.gen";
+import { useTranslation } from "@/i18n";
 import { useEnvironmentStore } from "@/stores/environment-store";
 import { Button } from "@vellumai/design-library/components/button";
 import { Modal } from "@vellumai/design-library/components/modal";
@@ -37,6 +38,7 @@ export function DomainStep({
   /** The provisioning target assistant (onboarding primary, else active). */
   assistantId?: string | null;
 }) {
+  const { t } = useTranslation("settings");
   const queryClient = useQueryClient();
   const emailRootDomain = useEnvironmentStore.use.emailRootDomain();
   const { assistant, assistantId, domains } = useAssistantDomains(
@@ -116,7 +118,7 @@ export function DomainStep({
           setErrorMsg(
             extractOnboardingErrorMessage(
               err,
-              "Couldn't register that subdomain. Try a different one.",
+              t("domainStep.registerSubdomainFailed"),
             ),
           );
         },
@@ -142,8 +144,8 @@ export function DomainStep({
       <Modal.Body className="animate-[onboarding-step-in_350ms_ease-out] space-y-6 pb-0 motion-reduce:animate-none">
         <CreatureCorners variant="top" />
         <WizardCardHeading
-          title="Assistant Email"
-          subtitle="Set up an email for your assistant."
+          title={t("domainStep.title")}
+          subtitle={t("domainStep.subtitle")}
         />
 
         <div className="space-y-1.5">
@@ -153,7 +155,7 @@ export function DomainStep({
                 htmlFor="onboarding-email-prefix"
                 className={LABEL_CLASSES}
               >
-                Prefix
+                {t("domainStep.prefixLabel")}
               </label>
               <input
                 id="onboarding-email-prefix"
@@ -163,7 +165,7 @@ export function DomainStep({
                 }
                 disabled={busy || isLocked}
                 readOnly={isLocked}
-                placeholder="hi"
+                placeholder={t("emailManagedContent.emailUsernamePlaceholder")}
                 className={`${FIELD_CLASSES} w-24`}
               />
             </div>
@@ -175,7 +177,7 @@ export function DomainStep({
                 htmlFor="onboarding-email-handle"
                 className={LABEL_CLASSES}
               >
-                Handle (public)
+                {t("domainStep.handleLabel")}
               </label>
               <input
                 id="onboarding-email-handle"
@@ -189,7 +191,7 @@ export function DomainStep({
                 disabled={busy || isLocked}
                 readOnly={isLocked}
                 autoFocus
-                placeholder="my-assistant"
+                placeholder={t("emailManagedContent.subdomainExamplePlaceholder")}
                 aria-invalid={!!errorMsg}
                 className={`${FIELD_CLASSES} w-full min-w-0`}
               />
@@ -205,25 +207,23 @@ export function DomainStep({
           )}
           {isLocked && (
             <p className="text-body-small-default text-[var(--content-tertiary)]">
-              This domain has been set and cannot be changed.
+              {t("domainStep.domainLockedMessage")}
             </p>
           )}
         </div>
 
         {machineBusy && !isLocked && (
-          <Notice tone="neutral">
-            Your assistant is restarting — you can set the domain in a moment.
-          </Notice>
+          <Notice tone="neutral">{t("domainStep.machineBusyNotice")}</Notice>
         )}
         {!isLocked && (
           <Notice tone="info" className={SUBTLE_NOTICE_CLASS}>
             <span className={SUBTLE_NOTICE_TEXT_CLASS}>
-              You won&apos;t be able to change the handle once set.
+              {t("domainStep.handleImmutableNotice")}
             </span>
           </Notice>
         )}
         {confirmed ? (
-          <Notice tone="success">Domain set — redirecting…</Notice>
+          <Notice tone="success">{t("domainStep.domainSetRedirecting")}</Notice>
         ) : null}
       </Modal.Body>
       <Modal.Footer className="items-center pt-6">
@@ -233,7 +233,7 @@ export function DomainStep({
             data-testid="onboarding-domain-continue"
             onClick={onExit}
           >
-            Continue
+            {t("domainStep.continue")}
           </Button>
         ) : (
           <>
@@ -243,7 +243,7 @@ export function DomainStep({
               disabled={busy}
               onClick={handleSkip}
             >
-              Skip
+              {t("domainStep.skip")}
             </Button>
             <Button
               variant="primary"
@@ -251,7 +251,7 @@ export function DomainStep({
               disabled={!subdomain || busy || machineBusy}
               onClick={handleSet}
             >
-              Next
+              {t("domainStep.next")}
             </Button>
           </>
         )}

--- a/clients/web/src/domains/settings/billing/pro-onboarding/error-states.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/error-states.tsx
@@ -1,5 +1,6 @@
 import { AlertCircle } from "lucide-react";
 
+import { useTranslation } from "@/i18n";
 import { Button } from "@vellumai/design-library/components/button";
 import { Typography } from "@vellumai/design-library/components/typography";
 
@@ -14,12 +15,14 @@ export function FetchErrorState({
   /** Which way the change whose billing reads failed was going. */
   direction?: TakeoverDirection;
 }) {
+  const { t } = useTranslation("settings");
+
   return (
     <div className="flex flex-col items-center gap-4 px-6 py-10 text-center">
       <IconBadge icon={AlertCircle} />
       <div className="space-y-1.5">
         <Typography variant="title-small" as="h1">
-          Couldn&apos;t reach billing
+          {t("errorStates.fetchErrorTitle")}
         </Typography>
         <Typography
           variant="body-medium-lighter"
@@ -34,7 +37,7 @@ export function FetchErrorState({
         data-testid="onboarding-go-to-billing"
         onClick={onGoToBilling}
       >
-        Go to billing
+        {t("errorStates.goToBilling")}
       </Button>
     </div>
   );

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
@@ -286,7 +286,7 @@ describe("waiting / resizing", () => {
       </QueryClientProvider>,
     );
     expect(
-      getByText("Still working — this can take a minute or two."),
+      getByText("Still working. This can take a minute or two."),
     ).toBeTruthy();
   });
 

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
@@ -21,6 +21,7 @@ import type { MachineSizeEnum } from "@/generated/api/types.gen";
 import type { CheckoutIntent } from "@/lib/billing/checkout-intent";
 import { MACHINE_TIER_LABEL } from "@/lib/billing/machine-sizes";
 import type { ProvisioningDimensionFlags } from "@/lib/billing/provisioning-targets";
+import { useTranslation } from "@/i18n";
 import { SURFACE_GROUND } from "@/utils/avatar-tone";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 import { Button } from "@vellumai/design-library/components/button";
@@ -343,11 +344,12 @@ function DimensionChip({
   pending?: boolean;
   testId?: string;
 }) {
+  const { t } = useTranslation("settings");
   let status: string | null = null;
   if (done) {
-    status = "Complete";
+    status = t("provisioningState.statusComplete");
   } else if (pending) {
-    status = "Pending";
+    status = t("provisioningState.statusPending");
   }
   return (
     <div
@@ -375,7 +377,7 @@ function DimensionChip({
           {from && (
             <>
               <span>{from}</span>
-              <span className="sr-only">to</span>
+              <span className="sr-only">{t("provisioningState.srOnlyTo")}</span>
               <ArrowRight
                 className="h-3 w-3 shrink-0 text-[var(--content-tertiary)]"
                 aria-hidden="true"
@@ -512,6 +514,7 @@ function ResourceChangeChips({
   allDone?: boolean;
   creditsOnly?: boolean;
 }) {
+  const { t } = useTranslation("settings");
   // Checkout reads the stashed intent, an in-place change carries its own
   // tiers, and a takeover runs in exactly one of those modes, so at most one of
   // these resolves.
@@ -540,7 +543,9 @@ function ResourceChangeChips({
     .join(", ");
   const [completedAtFirstPaint] = useState(completed);
   const announcement =
-    completed === completedAtFirstPaint ? "" : `${completed} complete`;
+    completed === completedAtFirstPaint
+      ? ""
+      : t("provisioningState.dimensionsComplete", { dimensions: completed });
 
   if (changes.length === 0) {
     return null;
@@ -574,12 +579,15 @@ function ResourceChangeChips({
 
 /** CONFIRMING chips: derived from the stashed intent before any API data lands. */
 function IntentChips({ intent }: { intent: CheckoutIntent }) {
+  const { t } = useTranslation("settings");
   if (intent.kind === "package") {
     const name =
       intent.packageKey.charAt(0).toUpperCase() + intent.packageKey.slice(1);
     return (
       <ChipRow>
-        <TextChip label={`${name} package`} />
+        <TextChip
+          label={t("provisioningState.packageChip", { name })}
+        />
       </ChipRow>
     );
   }
@@ -595,20 +603,22 @@ function IntentChips({ intent }: { intent: CheckoutIntent }) {
       {intent.machineTier != null && (
         <DimensionChip
           icon={Cpu}
-          label="Machine"
+          label={t("provisioningState.machineLabel")}
           to={MACHINE_TIER_LABEL[intent.machineTier] ?? intent.machineTier}
         />
       )}
       {intent.storageTier != null && (
         <DimensionChip
           icon={HardDrive}
-          label="Storage"
+          label={t("provisioningState.storageLabel")}
           to={intent.storageTier.toUpperCase()}
         />
       )}
       {intent.creditTier != null && (
         <TextChip
-          label={`${intent.creditTier.replace("credits_", "")} credits`}
+          label={t("provisioningState.creditsChip", {
+            count: intent.creditTier.replace("credits_", ""),
+          })}
         />
       )}
     </ChipRow>
@@ -636,6 +646,7 @@ export function ProvisioningState({
   dwellMs = PROVISION_MIN_DWELL_MS,
   phaseMinMs = PROVISION_PHASE_MIN_MS,
 }: ProvisioningStateProps) {
+  const { t } = useTranslation("settings");
   const copy = takeoverCopy(direction);
   const onCelebrationEndRef = useRef(onCelebrationEnd);
   useEffect(() => {
@@ -709,7 +720,7 @@ export function ProvisioningState({
     </div>
   );
 
-  function escapeButton(label = "Continue in the background") {
+  function escapeButton(label = t("provisioningState.continueInBackground")) {
     if (!escapeAvailable) {
       return null;
     }
@@ -749,7 +760,7 @@ export function ProvisioningState({
         <>
           <Copy
             status={copy.confirmingStatus}
-            caption="This might take a couple seconds."
+            caption={t("provisioningState.confirmingCaption")}
           />
           {intent && <IntentChips intent={intent} />}
           {escapeButton()}
@@ -764,8 +775,8 @@ export function ProvisioningState({
             status={copy.waitingStatus}
             caption={
               softWaiting
-                ? "Still working — this can take a minute or two."
-                : "This might take a couple seconds."
+                ? t("provisioningState.waitingCaptionLong")
+                : t("provisioningState.waitingCaptionShort")
             }
           />
           {resourceChips()}
@@ -777,7 +788,7 @@ export function ProvisioningState({
     if (heldState === "DONE") {
       return (
         <>
-          <Copy status="All done!" />
+          <Copy status={t("provisioningState.allDoneStatus")} />
           {resourceChips({ allDone: true })}
         </>
       );
@@ -790,7 +801,7 @@ export function ProvisioningState({
       // resource chip could only report a dimension that stayed put.
       return (
         <>
-          <Copy status="Your plan is ready" />
+          <Copy status={t("provisioningState.planReadyStatus")} />
           {resourceChips({ allDone: true, creditsOnly: true })}
         </>
       );
@@ -805,7 +816,9 @@ export function ProvisioningState({
         <>
           <Copy
             status={
-              snag ? copy.snagStatus : "This is taking longer than expected"
+              snag
+                ? copy.snagStatus
+                : t("provisioningState.takingLongerStatus")
             }
             caption={
               snag
@@ -814,11 +827,13 @@ export function ProvisioningState({
                     copy.snagCaption,
                     direction,
                   )
-                : "This may take a couple of minutes."
+                : t("provisioningState.stalledCaption")
             }
           />
           {resourceChips()}
-          {snag ? escapeButton("Retry in the background") : escapeButton()}
+          {snag
+            ? escapeButton(t("provisioningState.retryInBackground"))
+            : escapeButton()}
         </>
       );
     }
@@ -836,14 +851,14 @@ export function ProvisioningState({
               data-testid="onboarding-go-to-billing"
               onClick={confirm.onGoToBilling}
             >
-              Go to billing
+              {t("provisioningState.goToBilling")}
             </Button>
             <Button
               variant="primary"
               data-testid="onboarding-retry"
               onClick={confirm.onRetry}
             >
-              Try again
+              {t("provisioningState.tryAgain")}
             </Button>
           </div>
         </>

--- a/clients/web/src/domains/settings/billing/upgrade-cancel-page.tsx
+++ b/clients/web/src/domains/settings/billing/upgrade-cancel-page.tsx
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 import { Navigate, useNavigate } from "react-router";
 
 import { PlatformLoginNotice } from "@/components/platform-login-notice";
+import { useTranslation } from "@/i18n";
 import {
   useActiveAssistantIsPlatformHosted,
   useActiveAssistantLifecycleIsLoading,
@@ -27,6 +28,7 @@ import { Typography } from "@vellumai/design-library/components/typography";
  * abandoned-checkout bonus offer.
  */
 export function UpgradeCancelPage() {
+  const { t } = useTranslation("settings");
   // Defense in depth: this page is only reachable from a Stripe Checkout
   // session that started on the Billing tab (itself gated). But deep-link
   // or bookmark navigation can still land a self-hosted user here, together
@@ -78,7 +80,7 @@ export function UpgradeCancelPage() {
     return (
       <div className="max-w-4xl space-y-6">
         <PlatformLoginNotice>
-          Log in to the Vellum platform to manage billing and usage.
+          {t("upgradeCancelPage.platformLoginNotice")}
         </PlatformLoginNotice>
       </div>
     );
@@ -93,7 +95,7 @@ export function UpgradeCancelPage() {
     return (
       <div className="max-w-4xl space-y-6">
         <Notice tone="warning">
-          Billing isn&apos;t available for the current assistant state.
+          {t("upgradeCancelPage.billingUnavailable")}
         </Notice>
         <div className="flex justify-end">
           <Button
@@ -102,7 +104,7 @@ export function UpgradeCancelPage() {
               navigate(routes.settings.usageBilling, { replace: true })
             }
           >
-            Return to billing
+            {t("upgradeCancelPage.returnToBilling")}
           </Button>
         </div>
       </div>
@@ -113,10 +115,10 @@ export function UpgradeCancelPage() {
     <div className="max-w-4xl space-y-6">
       <Card padding="lg">
         <Typography as="h1" variant="title-large">
-          Upgrade canceled
+          {t("upgradeCancelPage.title")}
         </Typography>
         <Typography as="p" variant="body-medium-default" className="mt-2">
-          Returning you to billing settings…
+          {t("upgradeCancelPage.redirectingBody")}
         </Typography>
       </Card>
     </div>

--- a/clients/web/src/domains/settings/billing/upgrade-success-page.tsx
+++ b/clients/web/src/domains/settings/billing/upgrade-success-page.tsx
@@ -6,6 +6,7 @@ import { Navigate, useNavigate } from "react-router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { PlatformLoginNotice } from "@/components/platform-login-notice";
+import { useTranslation } from "@/i18n";
 import {
   organizationsBillingSubscriptionRetrieveOptions,
   organizationsBillingSubscriptionRetrieveQueryKey,
@@ -36,6 +37,7 @@ export const POLL_TIMEOUT_MS = 10_000;
 export const SUCCESS_REDIRECT_DELAY_MS = 2500;
 
 export function UpgradeSuccessPage() {
+  const { t } = useTranslation("settings");
   // Same predicate as the billing page itself for the page-level chrome.
   const platformGate = usePlatformGate({ platformHostedOnly: true });
   // Strict hosting predicate for the *Fetch*-tier `enabled` below.
@@ -146,7 +148,7 @@ export function UpgradeSuccessPage() {
     return (
       <div className="max-w-4xl space-y-6">
         <PlatformLoginNotice>
-          Log in to the Vellum platform to manage billing and usage.
+          {t("upgradeSuccessPage.platformLoginNotice")}
         </PlatformLoginNotice>
       </div>
     );
@@ -163,8 +165,7 @@ export function UpgradeSuccessPage() {
     return (
       <div className="max-w-4xl space-y-6">
         <Notice tone="warning">
-          We can&apos;t confirm your upgrade for the current assistant. Return
-          to billing to retry.
+          {t("upgradeSuccessPage.cantConfirmUpgrade")}
         </Notice>
         <div className="flex justify-end">
           <Button
@@ -172,7 +173,7 @@ export function UpgradeSuccessPage() {
             data-testid="upgrade-success-go-to-billing"
             onClick={goToBilling}
           >
-            Go to billing
+            {t("upgradeSuccessPage.goToBilling")}
           </Button>
         </div>
       </div>
@@ -198,7 +199,7 @@ export function UpgradeSuccessPage() {
               data-testid="upgrade-success-go-to-billing"
               onClick={goToBilling}
             >
-              Go to billing
+              {t("upgradeSuccessPage.goToBilling")}
             </Button>
           </div>
         )}
@@ -208,6 +209,8 @@ export function UpgradeSuccessPage() {
 }
 
 function PendingState() {
+  const { t } = useTranslation("settings");
+
   return (
     <div className="flex flex-col items-center gap-3 py-6 text-center">
       <Loader2
@@ -215,21 +218,22 @@ function PendingState() {
         aria-hidden="true"
       />
       <Typography variant="title-small" as="h1">
-        Finalizing your upgrade…
+        {t("upgradeSuccessPage.finalizingTitle")}
       </Typography>
       <Typography
         variant="body-medium-lighter"
         as="p"
         className="text-[var(--content-secondary)]"
       >
-        Stripe is confirming your subscription. This usually takes a few
-        seconds.
+        {t("upgradeSuccessPage.finalizingBody")}
       </Typography>
     </div>
   );
 }
 
 function SuccessState() {
+  const { t } = useTranslation("settings");
+
   return (
     <div className="flex flex-col items-center gap-3 py-6 text-center">
       <CheckCircle2
@@ -237,30 +241,32 @@ function SuccessState() {
         aria-hidden="true"
       />
       <Typography variant="title-small" as="h1">
-        Welcome to Pro
+        {t("upgradeSuccessPage.welcomeTitle")}
       </Typography>
       <Typography
         variant="body-medium-lighter"
         as="p"
         className="text-[var(--content-secondary)]"
       >
-        Your Pro plan is active. You&apos;ll be redirected back to billing in a
-        moment.
+        {t("upgradeSuccessPage.successBody")}
       </Typography>
     </div>
   );
 }
 
 function ProcessingFallbackState() {
+  const { t } = useTranslation("settings");
+
   return (
     <Notice tone="warning">
-      We&apos;re processing your upgrade — refresh in a moment to see your new
-      plan.
+      {t("upgradeSuccessPage.processingFallback")}
     </Notice>
   );
 }
 
 function FetchErrorState() {
+  const { t } = useTranslation("settings");
+
   return (
     <div className="flex flex-col items-center gap-3 py-6 text-center">
       <AlertCircle
@@ -268,15 +274,14 @@ function FetchErrorState() {
         aria-hidden="true"
       />
       <Typography variant="title-small" as="h1">
-        Couldn&apos;t reach billing
+        {t("upgradeSuccessPage.fetchErrorTitle")}
       </Typography>
       <Typography
         variant="body-medium-lighter"
         as="p"
         className="text-[var(--content-secondary)]"
       >
-        We hit a problem checking your subscription. Your upgrade may still be
-        processing — return to billing to refresh.
+        {t("upgradeSuccessPage.fetchErrorBody")}
       </Typography>
     </div>
   );

--- a/clients/web/src/domains/settings/billing/usage/usage-tab.tsx
+++ b/clients/web/src/domains/settings/billing/usage/usage-tab.tsx
@@ -47,12 +47,12 @@ import {
   shouldFallbackUsageGroupBy,
   shouldFetchUsageSeries,
   shouldRetryUsageGroupQuery,
-  trendTitle,
   USAGE_GROUP_BY_OPTIONS,
   type UsageSearchParamsUpdate,
 } from "@/domains/settings/billing/usage/usage-tab-state";
 import type {
   UsageBreakdownResponse,
+  UsageGranularity,
   UsageGroupBreakdown,
   UsageGroupBy,
   UsageTimeRange,
@@ -69,6 +69,7 @@ import {
   schedulesGetQueryKey,
 } from "@/generated/daemon/@tanstack/react-query.gen";
 import { PromptLaunchButton } from "@/components/prompt-launch-button";
+import { useTranslation } from "@/i18n";
 import { navigateToConversation } from "@/utils/conversation-navigation";
 import { isModifiedLinkClick } from "@/utils/link-click";
 import { extractUsageProfileMetadata } from "@/utils/profile-metadata";
@@ -80,19 +81,54 @@ interface UsageTabProps {
   assistantId: string;
 }
 
+type SettingsTranslate = ReturnType<typeof useTranslation<"settings">>["t"];
+
 type UsageBreakdownState = {
   groupBy: UsageGroupBy;
   response: UsageBreakdownResponse;
 };
 
-const RANGE_OPTIONS: { value: UsageTimeRange; label: string }[] = [
-  { value: "today", label: "Today" },
-  { value: "yesterday", label: "Yesterday" },
-  { value: "7d", label: "Last 7 days" },
-  { value: "30d", label: "Last 30 days" },
-  { value: "90d", label: "Last 90 days" },
-  { value: "all", label: "All time" },
-];
+const USAGE_RANGE_KEYS: Record<UsageTimeRange, "usageTab.rangeToday" | "usageTab.rangeYesterday" | "usageTab.range7d" | "usageTab.range30d" | "usageTab.range90d" | "usageTab.rangeAll"> = {
+  today: "usageTab.rangeToday",
+  yesterday: "usageTab.rangeYesterday",
+  "7d": "usageTab.range7d",
+  "30d": "usageTab.range30d",
+  "90d": "usageTab.range90d",
+  all: "usageTab.rangeAll",
+};
+
+const USAGE_GROUP_BY_KEYS: Record<UsageGroupBy, "usageTab.groupByTask" | "usageTab.groupByProfile" | "usageTab.groupByModel" | "usageTab.groupByProvider" | "usageTab.groupByActor" | "usageTab.groupByConversation" | "usageTab.groupBySchedule"> = {
+  task: "usageTab.groupByTask",
+  profile: "usageTab.groupByProfile",
+  model: "usageTab.groupByModel",
+  provider: "usageTab.groupByProvider",
+  actor: "usageTab.groupByActor",
+  conversation: "usageTab.groupByConversation",
+  schedule: "usageTab.groupBySchedule",
+};
+
+function usageGroupLabel(t: SettingsTranslate, groupBy: UsageGroupBy): string {
+  return t(USAGE_GROUP_BY_KEYS[groupBy]);
+}
+
+function usageTrendTitle(
+  t: SettingsTranslate,
+  rangeGranularity: UsageGranularity,
+  groupBy?: UsageGroupBy,
+): string {
+  const prefix =
+    rangeGranularity === "hourly"
+      ? t("usageTab.hourlyTrend")
+      : t("usageTab.dailyTrend");
+  if (!groupBy || groupBy === "conversation") {
+    return prefix;
+  }
+
+  const group = usageGroupLabel(t, groupBy);
+  return rangeGranularity === "hourly"
+    ? t("usageTab.hourlyTrendBy", { group })
+    : t("usageTab.dailyTrendBy", { group });
+}
 
 const PROFILE_METADATA_STALE_TIME_MS = 5 * 60 * 1000;
 const COST_ANALYSIS_PROMPT = [
@@ -109,6 +145,7 @@ const COST_OPTIMIZATION_PROMPT = [
 ].join(" ");
 
 export function UsageTab({ assistantId }: UsageTabProps) {
+  const { t } = useTranslation("settings");
   const [searchParams, setSearchParams] = useSearchParams();
   const { range, groupBy, scheduleId } = useMemo(
     () => readUsageUrlState(searchParams),
@@ -374,8 +411,12 @@ export function UsageTab({ assistantId }: UsageTabProps) {
       return undefined;
     }
 
-    return buildSelectedScheduleLegendItems(schedulesQuery.data, scheduleId);
-  }, [effectiveGroupBy, scheduleId, schedulesQuery.data]);
+    return buildSelectedScheduleLegendItems(
+      schedulesQuery.data,
+      scheduleId,
+      t,
+    );
+  }, [effectiveGroupBy, scheduleId, schedulesQuery.data, t]);
 
   const handleGroupByChange = (nextGroupBy: UsageGroupBy) => {
     updateUsageSearchParams({
@@ -391,14 +432,14 @@ export function UsageTab({ assistantId }: UsageTabProps) {
           className="text-title-small"
           style={{ color: "var(--content-default)" }}
         >
-          Usage
+          {t("usageTab.title")}
         </h3>
         <div className="flex flex-wrap items-center justify-end gap-2">
           <TimeRangeStrip range={range} onChange={handleRangeChange} />
         </div>
       </div>
 
-      <section aria-label="Totals">
+      <section aria-label={t("usageTab.totalsAriaLabel")}>
         <QueryState
           query={totalsQuery}
           skeleton={<TotalsSkeleton />}
@@ -406,14 +447,14 @@ export function UsageTab({ assistantId }: UsageTabProps) {
         />
       </section>
 
-      <Section title="Inference Usage">
+      <Section title={t("usageTab.inferenceUsageTitle")}>
         <div className="flex flex-col gap-3">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <h4
               className="text-body-medium-default"
               style={{ color: "var(--content-default)" }}
             >
-              {trendTitle(effectiveGranularity, trendGroupBy)}
+              {usageTrendTitle(t, effectiveGranularity, trendGroupBy)}
             </h4>
             <div className="flex flex-wrap items-center justify-end gap-2">
               <GroupByPicker
@@ -446,6 +487,7 @@ export function UsageTab({ assistantId }: UsageTabProps) {
 function buildSelectedScheduleLegendItems(
   schedules: readonly Pick<AssistantSchedule, "id" | "name">[] | undefined,
   selectedScheduleId: string,
+  t: SettingsTranslate,
 ): UsageTrendChartLegendItem[] {
   const knownSchedules = schedules ?? [];
   const hasSelectedSchedule = knownSchedules.some(
@@ -457,7 +499,9 @@ function buildSelectedScheduleLegendItems(
       : [
           {
             id: selectedScheduleId,
-            label: unknownScheduleLabel(selectedScheduleId),
+            label: t("usageTab.unknownSchedule", {
+              scheduleId: selectedScheduleId,
+            }),
           },
         ]),
     ...knownSchedules.map((schedule) => ({
@@ -474,11 +518,9 @@ function buildSelectedScheduleLegendItems(
   }));
 }
 
-function unknownScheduleLabel(scheduleId: string) {
-  return `Unknown schedule (${scheduleId})`;
-}
-
 function CostAssistantSection() {
+  const { t } = useTranslation("settings");
+
   return (
     <div className="flex flex-col gap-3">
       <div
@@ -489,15 +531,15 @@ function CostAssistantSection() {
         }}
       />
       <Section
-        title="Cost assistant"
-        subtitle="Review recent spend and tune model profile choices."
+        title={t("usageTab.costAssistantTitle")}
+        subtitle={t("usageTab.costAssistantSubtitle")}
       >
         <div className="flex flex-col gap-2 rounded-md px-3 py-3 sm:flex-row sm:items-center">
           <PromptLaunchButton prompt={COST_ANALYSIS_PROMPT}>
-            Analyze costs with assistant
+            {t("usageTab.analyzeCostsButton")}
           </PromptLaunchButton>
           <PromptLaunchButton prompt={COST_OPTIMIZATION_PROMPT} variant="ghost">
-            Optimize settings
+            {t("usageTab.optimizeSettingsButton")}
           </PromptLaunchButton>
         </div>
       </Section>
@@ -512,15 +554,22 @@ function TimeRangeStrip({
   range: UsageTimeRange;
   onChange: (range: UsageTimeRange) => void;
 }) {
+  const { t } = useTranslation("settings");
+  const rangeOptions = (
+    Object.entries(USAGE_RANGE_KEYS) as Array<
+      [UsageTimeRange, (typeof USAGE_RANGE_KEYS)[UsageTimeRange]]
+    >
+  ).map(([value, key]) => ({
+    value,
+    label: t(key),
+  }));
+
   return (
     <div className="flex items-center">
       <Select<UsageTimeRange>
         value={range}
         onChange={onChange}
-        options={RANGE_OPTIONS.map((option) => ({
-          value: option.value,
-          label: option.label,
-        }))}
+        options={rangeOptions}
       />
     </div>
   );
@@ -580,6 +629,8 @@ function QueryState<T>({
   skeleton: ReactNode;
   render: (data: T) => ReactNode;
 }) {
+  const { t } = useTranslation("settings");
+
   if (query.isLoading) {
     return <>{skeleton}</>;
   }
@@ -587,7 +638,7 @@ function QueryState<T>({
     const message =
       query.error instanceof Error
         ? query.error.message
-        : "Failed to load usage.";
+        : t("usageTab.failedToLoadUsage");
     return <ErrorRow message={message} onRetry={() => query.refetch()} />;
   }
   if (!query.data) {
@@ -597,6 +648,8 @@ function QueryState<T>({
 }
 
 function TotalsGrid({ totals }: { totals: UsageTotals }) {
+  const { t } = useTranslation("settings");
+
   return (
     <div className="flex flex-col gap-4">
       <div className="flex flex-wrap items-baseline justify-between gap-4">
@@ -615,7 +668,7 @@ function TotalsGrid({ totals }: { totals: UsageTotals }) {
             className="text-body-small-default"
             style={{ color: "var(--content-secondary)" }}
           >
-            Cost
+            {t("usageTab.costLabel")}
           </span>
         </div>
         <div className="flex flex-col gap-1">
@@ -629,26 +682,26 @@ function TotalsGrid({ totals }: { totals: UsageTotals }) {
             className="text-body-small-default"
             style={{ color: "var(--content-secondary)" }}
           >
-            LLM Calls
+            {t("usageTab.llmCallsLabel")}
           </span>
         </div>
       </div>
 
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
         <SecondaryMetric
-          label="Direct Input Tokens"
+          label={t("usageTab.directInputTokensLabel")}
           value={formatTokens(totals.totalInputTokens)}
         />
         <SecondaryMetric
-          label="Output Tokens"
+          label={t("usageTab.outputTokensLabel")}
           value={formatTokens(totals.totalOutputTokens)}
         />
         <SecondaryMetric
-          label="Cache Created"
+          label={t("usageTab.cacheCreatedLabel")}
           value={formatTokens(totals.totalCacheCreationTokens)}
         />
         <SecondaryMetric
-          label="Cache Read"
+          label={t("usageTab.cacheReadLabel")}
           value={formatTokens(totals.totalCacheReadTokens)}
         />
       </div>
@@ -719,6 +772,8 @@ function GroupByPicker({
   value: UsageGroupBy;
   onChange: (value: UsageGroupBy) => void;
 }) {
+  const { t } = useTranslation("settings");
+
   return (
     <div className="flex items-center">
       <Select<UsageGroupBy>
@@ -728,7 +783,7 @@ function GroupByPicker({
         menuMinWidth={196}
         options={USAGE_GROUP_BY_OPTIONS.map((option) => ({
           value: option.value,
-          label: option.label,
+          label: usageGroupLabel(t, option.value),
         }))}
       />
     </div>
@@ -744,6 +799,7 @@ function BreakdownSection({
   query: QueryStateValue<UsageBreakdownState>;
   groups: UsageGroupBreakdown[] | undefined;
 }) {
+  const { t } = useTranslation("settings");
   const [visibleColumns, setVisibleColumns] = useState<
     Set<BreakdownOptionalColumn>
   >(new Set());
@@ -761,21 +817,21 @@ function BreakdownSection({
   };
 
   return (
-    <Section title="Breakdown">
+    <Section title={t("usageTab.breakdownTitle")}>
       <div className="flex flex-col gap-3">
         <div className="flex flex-wrap items-center gap-2">
           <ColumnToggle
-            label="% of total"
+            label={t("usageTab.percentOfTotalLabel")}
             active={visibleColumns.has("pct")}
             onClick={() => toggleColumn("pct")}
           />
           <ColumnToggle
-            label="Tokens"
+            label={t("usageTab.tokensLabel")}
             active={visibleColumns.has("tokens")}
             onClick={() => toggleColumn("tokens")}
           />
           <ColumnToggle
-            label="Turns"
+            label={t("usageTab.turnsLabel")}
             active={visibleColumns.has("turns")}
             onClick={() => toggleColumn("turns")}
           />
@@ -838,13 +894,14 @@ function BreakdownTable({
   showTokens: boolean;
   showTurns: boolean;
 }) {
+  const { t } = useTranslation("settings");
   const navigate = useNavigate();
 
   if (groups.length === 0) {
     return (
       <EmptyState
-        title="No breakdown data"
-        subtitle="No usage recorded for this grouping"
+        title={t("usageTab.noBreakdownDataTitle")}
+        subtitle={t("usageTab.noBreakdownDataSubtitle")}
       />
     );
   }
@@ -860,14 +917,14 @@ function BreakdownTable({
               className="px-3 py-2.5 text-left text-label-medium-default"
               style={{ color: "var(--content-tertiary)" }}
             >
-              Group
+              {t("usageTab.groupColumnLabel")}
             </th>
             {showTokens ? (
               <th
                 className="px-3 py-2.5 text-left text-label-medium-default"
                 style={{ color: "var(--content-tertiary)", width: "35%" }}
               >
-                Tokens
+                {t("usageTab.tokensLabel")}
               </th>
             ) : null}
             {showTurns ? (
@@ -875,7 +932,7 @@ function BreakdownTable({
                 className="px-3 py-2.5 text-right text-label-medium-default"
                 style={{ color: "var(--content-tertiary)", width: "72px" }}
               >
-                Turns
+                {t("usageTab.turnsLabel")}
               </th>
             ) : null}
             {showPct ? (
@@ -890,7 +947,7 @@ function BreakdownTable({
               className="px-3 py-2.5 text-right text-label-medium-default"
               style={{ color: "var(--content-tertiary)", width: "100px" }}
             >
-              Cost
+              {t("usageTab.costLabel")}
             </th>
           </tr>
         </thead>
@@ -1076,6 +1133,8 @@ function ErrorRow({
   message: string;
   onRetry?: () => void;
 }) {
+  const { t } = useTranslation("settings");
+
   return (
     <div className="flex flex-col gap-2 py-2">
       <div className="flex items-start gap-2">
@@ -1101,7 +1160,7 @@ function ErrorRow({
             color: "var(--content-default)",
           }}
         >
-          Retry
+          {t("usageTab.retry")}
         </button>
       ) : null}
     </div>

--- a/clients/web/src/domains/settings/billing/usage/usage-trend-chart.tsx
+++ b/clients/web/src/domains/settings/billing/usage/usage-trend-chart.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState, type MouseEvent } from "react";
 
 import { formatCost } from "@/domains/settings/billing/usage/format";
+import { t, useTranslation } from "@/i18n";
 import {
   buildUsageSeriesLegend,
   sortUsageSeriesBuckets,
@@ -88,6 +89,7 @@ export function UsageTrendChart({
   isHourly,
   legendItems,
 }: UsageTrendChartProps) {
+  const { t: translate } = useTranslation("settings");
   const [tooltip, setTooltip] = useState<SegmentTooltip | null>(null);
   const sorted = useMemo(() => sortUsageSeriesBuckets(buckets), [buckets]);
   const bucketLegend = useMemo(
@@ -120,8 +122,12 @@ export function UsageTrendChart({
   if (sorted.length === 0) {
     const emptyState = (
       <EmptyState
-        title={isHourly ? "No hourly data" : "No daily data"}
-        subtitle="No usage recorded in this time range"
+        title={
+          isHourly
+            ? translate("usageTrendChart.noHourlyData")
+            : translate("usageTrendChart.noDailyData")
+        }
+        subtitle={translate("usageTrendChart.noUsageInRange")}
       />
     );
     if (visibleLegendItems.length === 0) {
@@ -270,7 +276,7 @@ function StackedBar({
   if (nonEmptyGroups.length === 0 && !hasGroupedData && !hasLegendOverride) {
     const bucketLabel = formatBucketLabel(bucket);
     const tooltipContent = {
-      label: "Total",
+      label: t("settings:usageTrendChart.total"),
       bucketLabel,
       cost: formatCost(bucket.totalEstimatedCostUsd),
     };

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -7,6 +7,21 @@
   "aiProviderPicker": {
     "defaultEntryMeta": "Default"
   },
+  "billingOnboardingModal": {
+    "backgroundConfirmContinue": "Continue",
+    "backgroundConfirmKeepWaiting": "Keep waiting",
+    "backgroundConfirmTitle": "Continue in the background?"
+  },
+  "billingPage": {
+    "billingTab": "Billing",
+    "billingUnavailable": "Billing isn't available for the current assistant state.",
+    "finishSetupBody": "Your assistant's email address hasn't been set up yet.",
+    "finishSetupButton": "Finish setup",
+    "finishSetupTitle": "Finish setting up your {plan} plan",
+    "loadingBilling": "Loading billing…",
+    "platformLoginNotice": "Log in to the Vellum platform to manage billing and usage.",
+    "usageTab": "Usage"
+  },
   "billingStatusHandler": {
     "successToast": "Payment received! Your credit balance will update shortly.",
     "topUpCancelToast": "Checkout was cancelled. No credits were added.",
@@ -69,6 +84,65 @@
     "title": "Here's {amount} on us",
     "unavailableToast": "This offer is no longer available."
   },
+  "checkoutPage": {
+    "awaitingReturnMessage": "Checkout opened in your browser. Finish there to complete your upgrade.",
+    "checkoutFailedMessage": "We couldn't start your checkout. Please try again.",
+    "continueSetup": "Continue setup",
+    "preparingCheckout": "Preparing checkout…",
+    "preparingCheckoutAriaLabel": "Preparing checkout",
+    "reopenCheckout": "Reopen checkout",
+    "tryAgain": "Try again",
+    "viewPlans": "View plans"
+  },
+  "completeState": {
+    "assistantFallbackName": "your assistant",
+    "returnTo": "Return to {assistantName}",
+    "title": "You're all set!"
+  },
+  "customPlanModal": {
+    "cancel": "Cancel",
+    "comparedToPrevious": "{delta} compared to previous ({previous})",
+    "continue": "Continue",
+    "creditBundleAriaLabel": "Credit bundle",
+    "creditBundlePlaceholder": "Select a credit bundle",
+    "creditsDocsAriaLabel": "Learn more about credit bundles",
+    "creditsLabel": "Bundle some credits:",
+    "learnMore": "Learn more",
+    "machineSizeAriaLabel": "Machine size",
+    "machineSizeDocsAriaLabel": "Learn more about machine sizes",
+    "machineSizeLabel": "Select a machine size:",
+    "machineSizePlaceholder": "Select a machine size",
+    "recap": "Recap",
+    "storageAriaLabel": "Storage",
+    "storageDocsAriaLabel": "Learn more about storage",
+    "storageLabel": "Select storage:",
+    "storagePlaceholder": "Select storage",
+    "subtitle": "Just better.",
+    "title": "Create a custom plan",
+    "totalBilledMonthly": "Total · Billed monthly",
+    "yourSelection": "Your selection:"
+  },
+  "customPlanRow": {
+    "configure": "Configure",
+    "currentPlanTag": "Your Current Plan",
+    "genericDescriptor": "Select custom CPU power, Ram and Storage. Or just throw in some tokens.",
+    "prompt": "Need something more tailored to your needs?",
+    "title": "Custom Plan"
+  },
+  "domainStep": {
+    "continue": "Continue",
+    "domainLockedMessage": "This domain has been set and cannot be changed.",
+    "domainSetRedirecting": "Domain set - redirecting…",
+    "handleImmutableNotice": "You won't be able to change the handle once set.",
+    "handleLabel": "Handle (public)",
+    "machineBusyNotice": "Your assistant is restarting - you can set the domain in a moment.",
+    "next": "Next",
+    "prefixLabel": "Prefix",
+    "registerSubdomainFailed": "Couldn't register that subdomain. Try a different one.",
+    "skip": "Skip",
+    "subtitle": "Set up an email for your assistant.",
+    "title": "Assistant Email"
+  },
   "emailManagedContent": {
     "addressLabel": "Address",
     "checkingSubscription": "Checking subscription…",
@@ -124,6 +198,17 @@
     "setupInstructions": "Configure {providerName} via the assistant CLI: ask the assistant to run the <code>{setupSkill}</code> skill. It walks you through storing the API key, detecting the domain, and (optionally) wiring up an inbound webhook.",
     "subtitle": "Configure how your assistant sends and receives email",
     "title": "Email"
+  },
+  "errorStates": {
+    "fetchErrorTitle": "Couldn't reach billing",
+    "goToBilling": "Go to billing"
+  },
+  "freeDowngradeConfirmModal": {
+    "bodyCancelOnly": "You'll be taken to Stripe to cancel your subscription.",
+    "bodyWithFeatures": "Downgrading removes the following Pro features. You'll be taken to Stripe to cancel your subscription.",
+    "cancel": "Cancel",
+    "confirm": "Downgrade to Base",
+    "title": "Downgrade to Base?"
   },
   "imageGenerationCard": {
     "activeModelLabel": "Active Model",
@@ -193,6 +278,35 @@
     "saveFailedToast": "Failed to save overrides. Please try again.",
     "searchPlaceholder": "Search actions…",
     "title": "Action Overrides"
+  },
+  "packageSwitchConfirmModal": {
+    "cancel": "Cancel"
+  },
+  "planColumnCard": {
+    "currentPlan": "Current Plan",
+    "includes": "Includes:",
+    "recommended": "Recommended"
+  },
+  "plansPage": {
+    "alreadyOnPlanToast": "You're already on this plan.",
+    "back": "Back",
+    "billedMonthlyCaption": "Billed monthly",
+    "cancelAnytimeFooter": "You can cancel or change your plan anytime you want. To learn more <docsLink>Read our Docs.</docsLink>",
+    "checkoutFailedToast": "Failed to start the upgrade checkout. Please try again.",
+    "downgradeTo": "Downgrade to {name}",
+    "featureComputer": "{machine} Computer",
+    "featureCreditsIncluded": "{amount} in credits included",
+    "featureStorage": "{gib} GB Storage",
+    "foreverCaption": "Forever",
+    "freeFeaturePayAsYouGo": "Pay-as-you-go credits",
+    "freeFeatureSmallComputer": "Small Computer",
+    "freeFeatureStorage": "{gib} GB Storage",
+    "freePriceLabel": "Free",
+    "heading": "Give your assistant more power",
+    "loadingPlansAriaLabel": "Loading plans",
+    "planUpdatedToast": "Plan updated.",
+    "startFreeCta": "Start Free",
+    "subheading": "Choose the level that matches how much you want it to take on."
   },
   "profileAdvancedParams": {
     "contextWindowLabel": "Context Window",
@@ -384,6 +498,27 @@
     "loadError": "Failed to load providers. Please try again.",
     "title": "Providers"
   },
+  "provisioningState": {
+    "allDoneStatus": "All done!",
+    "confirmingCaption": "This might take a couple seconds.",
+    "continueInBackground": "Continue in the background",
+    "creditsChip": "{count} credits",
+    "dimensionsComplete": "{dimensions} complete",
+    "goToBilling": "Go to billing",
+    "machineLabel": "Machine",
+    "packageChip": "{name} package",
+    "planReadyStatus": "Your plan is ready",
+    "retryInBackground": "Retry in the background",
+    "srOnlyTo": "to",
+    "stalledCaption": "This may take a couple of minutes.",
+    "statusComplete": "Complete",
+    "statusPending": "Pending",
+    "storageLabel": "Storage",
+    "takingLongerStatus": "This is taking longer than expected",
+    "tryAgain": "Try again",
+    "waitingCaptionLong": "Still working. This can take a minute or two.",
+    "waitingCaptionShort": "This might take a couple seconds."
+  },
   "sharedUi": {
     "checkingDomain": "Checking domain…",
     "domainVerified": "Domain verified",
@@ -406,6 +541,73 @@
   "textToSpeechCard": {
     "subtitle": "Configure how your assistant speaks",
     "title": "Text-to-Speech"
+  },
+  "upgradeCancelPage": {
+    "billingUnavailable": "Billing isn't available for the current assistant state.",
+    "platformLoginNotice": "Log in to the Vellum platform to manage billing and usage.",
+    "redirectingBody": "Returning you to billing settings…",
+    "returnToBilling": "Return to billing",
+    "title": "Upgrade canceled"
+  },
+  "upgradeSuccessPage": {
+    "cantConfirmUpgrade": "We can't confirm your upgrade for the current assistant. Return to billing to retry.",
+    "fetchErrorBody": "We hit a problem checking your subscription. Your upgrade may still be processing. Return to billing to refresh.",
+    "fetchErrorTitle": "Couldn't reach billing",
+    "finalizingBody": "Stripe is confirming your subscription. This usually takes a few seconds.",
+    "finalizingTitle": "Finalizing your upgrade…",
+    "goToBilling": "Go to billing",
+    "platformLoginNotice": "Log in to the Vellum platform to manage billing and usage.",
+    "processingFallback": "We're processing your upgrade. Refresh in a moment to see your new plan.",
+    "successBody": "Your Pro plan is active. You'll be redirected back to billing in a moment.",
+    "welcomeTitle": "Welcome to Pro"
+  },
+  "usageTab": {
+    "analyzeCostsButton": "Analyze costs with assistant",
+    "breakdownTitle": "Breakdown",
+    "cacheCreatedLabel": "Cache Created",
+    "cacheReadLabel": "Cache Read",
+    "costAssistantSubtitle": "Review recent spend and tune model profile choices.",
+    "costAssistantTitle": "Cost assistant",
+    "costLabel": "Cost",
+    "dailyTrend": "Daily Trend",
+    "dailyTrendBy": "Daily Trend by {group}",
+    "directInputTokensLabel": "Direct Input Tokens",
+    "failedToLoadUsage": "Failed to load usage.",
+    "groupByActor": "Actor",
+    "groupByConversation": "Conversation",
+    "groupByModel": "Model",
+    "groupByProfile": "Profile",
+    "groupByProvider": "Provider",
+    "groupBySchedule": "Schedule",
+    "groupByTask": "Action",
+    "groupColumnLabel": "Group",
+    "hourlyTrend": "Hourly Trend",
+    "hourlyTrendBy": "Hourly Trend by {group}",
+    "inferenceUsageTitle": "Inference Usage",
+    "llmCallsLabel": "LLM Calls",
+    "noBreakdownDataSubtitle": "No usage recorded for this grouping",
+    "noBreakdownDataTitle": "No breakdown data",
+    "optimizeSettingsButton": "Optimize settings",
+    "outputTokensLabel": "Output Tokens",
+    "percentOfTotalLabel": "% of total",
+    "range30d": "Last 30 days",
+    "range7d": "Last 7 days",
+    "range90d": "Last 90 days",
+    "rangeAll": "All time",
+    "rangeToday": "Today",
+    "rangeYesterday": "Yesterday",
+    "retry": "Retry",
+    "title": "Usage",
+    "tokensLabel": "Tokens",
+    "totalsAriaLabel": "Totals",
+    "turnsLabel": "Turns",
+    "unknownSchedule": "Unknown schedule ({scheduleId})"
+  },
+  "usageTrendChart": {
+    "noDailyData": "No daily data",
+    "noHourlyData": "No hourly data",
+    "noUsageInRange": "No usage recorded in this time range",
+    "total": "Total"
   },
   "useDaemonConfig": {
     "assistantNotReadyToast": "Assistant not ready. Please try again.",

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -7,6 +7,21 @@
   "aiProviderPicker": {
     "defaultEntryMeta": "Predeterminado"
   },
+  "billingOnboardingModal": {
+    "backgroundConfirmContinue": "Continuar",
+    "backgroundConfirmKeepWaiting": "Seguir esperando",
+    "backgroundConfirmTitle": "¿Continuar en segundo plano?"
+  },
+  "billingPage": {
+    "billingTab": "Facturación",
+    "billingUnavailable": "La facturación no está disponible para el estado actual del asistente.",
+    "finishSetupBody": "La dirección de correo de tu asistente aún no se ha configurado.",
+    "finishSetupButton": "Finalizar configuración",
+    "finishSetupTitle": "Termina de configurar tu plan {plan}",
+    "loadingBilling": "Cargando facturación…",
+    "platformLoginNotice": "Inicia sesión en la plataforma Vellum para administrar la facturación y el uso.",
+    "usageTab": "Uso"
+  },
   "billingStatusHandler": {
     "successToast": "¡Pago recibido! Tu saldo de créditos se actualizará en breve.",
     "topUpCancelToast": "Se canceló el pago. No se añadieron créditos.",
@@ -69,6 +84,65 @@
     "title": "Aquí tienes {amount} de nuestra parte",
     "unavailableToast": "Esta oferta ya no está disponible."
   },
+  "checkoutPage": {
+    "awaitingReturnMessage": "El pago se abrió en tu navegador. Complétalo allí para finalizar la mejora.",
+    "checkoutFailedMessage": "No pudimos iniciar el pago. Inténtalo de nuevo.",
+    "continueSetup": "Continuar configuración",
+    "preparingCheckout": "Preparando pago…",
+    "preparingCheckoutAriaLabel": "Preparando pago",
+    "reopenCheckout": "Reabrir pago",
+    "tryAgain": "Intentar de nuevo",
+    "viewPlans": "Ver planes"
+  },
+  "completeState": {
+    "assistantFallbackName": "tu asistente",
+    "returnTo": "Volver a {assistantName}",
+    "title": "¡Ya está todo listo!"
+  },
+  "customPlanModal": {
+    "cancel": "Cancelar",
+    "comparedToPrevious": "{delta} en comparación con el anterior ({previous})",
+    "continue": "Continuar",
+    "creditBundleAriaLabel": "Paquete de créditos",
+    "creditBundlePlaceholder": "Selecciona un paquete de créditos",
+    "creditsDocsAriaLabel": "Más información sobre paquetes de créditos",
+    "creditsLabel": "Añade créditos:",
+    "learnMore": "Más información",
+    "machineSizeAriaLabel": "Tamaño de máquina",
+    "machineSizeDocsAriaLabel": "Más información sobre tamaños de máquina",
+    "machineSizeLabel": "Selecciona un tamaño de máquina:",
+    "machineSizePlaceholder": "Selecciona un tamaño de máquina",
+    "recap": "Resumen",
+    "storageAriaLabel": "Almacenamiento",
+    "storageDocsAriaLabel": "Más información sobre almacenamiento",
+    "storageLabel": "Selecciona almacenamiento:",
+    "storagePlaceholder": "Selecciona almacenamiento",
+    "subtitle": "Simplemente mejor.",
+    "title": "Crear un plan personalizado",
+    "totalBilledMonthly": "Total · Facturación mensual",
+    "yourSelection": "Tu selección:"
+  },
+  "customPlanRow": {
+    "configure": "Configurar",
+    "currentPlanTag": "Tu plan actual",
+    "genericDescriptor": "Selecciona potencia de CPU, RAM y almacenamiento personalizados. O añade algunos tokens.",
+    "prompt": "¿Necesitas algo más adaptado a tus necesidades?",
+    "title": "Plan personalizado"
+  },
+  "domainStep": {
+    "continue": "Continuar",
+    "domainLockedMessage": "Este dominio ya está establecido y no se puede cambiar.",
+    "domainSetRedirecting": "Dominio establecido. Redirigiendo…",
+    "handleImmutableNotice": "No podrás cambiar el identificador una vez establecido.",
+    "handleLabel": "Identificador (público)",
+    "machineBusyNotice": "Tu asistente se está reiniciando; podrás establecer el dominio en un momento.",
+    "next": "Siguiente",
+    "prefixLabel": "Prefijo",
+    "registerSubdomainFailed": "No se pudo registrar ese subdominio. Prueba con otro.",
+    "skip": "Omitir",
+    "subtitle": "Configura un correo para tu asistente.",
+    "title": "Correo del asistente"
+  },
   "emailManagedContent": {
     "addressLabel": "Dirección",
     "checkingSubscription": "Comprobando suscripción…",
@@ -124,6 +198,17 @@
     "setupInstructions": "Configura {providerName} mediante la CLI del asistente: pídele al asistente que ejecute la habilidad <code>{setupSkill}</code>. Te guiará para guardar la clave API, detectar el dominio y (opcionalmente) configurar un webhook entrante.",
     "subtitle": "Configura cómo tu asistente envía y recibe correo",
     "title": "Correo"
+  },
+  "errorStates": {
+    "fetchErrorTitle": "No se pudo acceder a facturación",
+    "goToBilling": "Ir a facturación"
+  },
+  "freeDowngradeConfirmModal": {
+    "bodyCancelOnly": "Se te llevará a Stripe para cancelar tu suscripción.",
+    "bodyWithFeatures": "Al bajar de plan se eliminan las siguientes funciones Pro. Se te llevará a Stripe para cancelar tu suscripción.",
+    "cancel": "Cancelar",
+    "confirm": "Bajar a Base",
+    "title": "¿Bajar a Base?"
   },
   "imageGenerationCard": {
     "activeModelLabel": "Modelo activo",
@@ -193,6 +278,35 @@
     "saveFailedToast": "No se pudieron guardar las anulaciones. Inténtalo de nuevo.",
     "searchPlaceholder": "Buscar acciones…",
     "title": "Anulaciones de acciones"
+  },
+  "packageSwitchConfirmModal": {
+    "cancel": "Cancelar"
+  },
+  "planColumnCard": {
+    "currentPlan": "Plan actual",
+    "includes": "Incluye:",
+    "recommended": "Recomendado"
+  },
+  "plansPage": {
+    "alreadyOnPlanToast": "Ya estás en este plan.",
+    "back": "Atrás",
+    "billedMonthlyCaption": "Facturación mensual",
+    "cancelAnytimeFooter": "Puedes cancelar o cambiar tu plan cuando quieras. Para obtener más información, <docsLink>Lee nuestra documentación.</docsLink>",
+    "checkoutFailedToast": "No se pudo iniciar el pago de mejora. Inténtalo de nuevo.",
+    "downgradeTo": "Bajar a {name}",
+    "featureComputer": "Ordenador {machine}",
+    "featureCreditsIncluded": "{amount} en créditos incluidos",
+    "featureStorage": "{gib} GB de almacenamiento",
+    "foreverCaption": "Para siempre",
+    "freeFeaturePayAsYouGo": "Créditos de pago por uso",
+    "freeFeatureSmallComputer": "Ordenador pequeño",
+    "freeFeatureStorage": "{gib} GB de almacenamiento",
+    "freePriceLabel": "Gratis",
+    "heading": "Dale más potencia a tu asistente",
+    "loadingPlansAriaLabel": "Cargando planes",
+    "planUpdatedToast": "Plan actualizado.",
+    "startFreeCta": "Empezar gratis",
+    "subheading": "Elige el nivel que se ajuste a cuánto quieres que se encargue."
   },
   "profileAdvancedParams": {
     "contextWindowLabel": "Ventana de contexto",
@@ -384,6 +498,27 @@
     "loadError": "No se pudieron cargar los proveedores. Inténtalo de nuevo.",
     "title": "Proveedores"
   },
+  "provisioningState": {
+    "allDoneStatus": "¡Todo listo!",
+    "confirmingCaption": "Esto puede tardar unos segundos.",
+    "continueInBackground": "Continuar en segundo plano",
+    "creditsChip": "{count} créditos",
+    "dimensionsComplete": "{dimensions} completado",
+    "goToBilling": "Ir a facturación",
+    "machineLabel": "Máquina",
+    "packageChip": "paquete {name}",
+    "planReadyStatus": "Tu plan está listo",
+    "retryInBackground": "Reintentar en segundo plano",
+    "srOnlyTo": "a",
+    "stalledCaption": "Esto puede tardar un par de minutos.",
+    "statusComplete": "Completado",
+    "statusPending": "Pendiente",
+    "storageLabel": "Almacenamiento",
+    "takingLongerStatus": "Esto está tardando más de lo esperado",
+    "tryAgain": "Intentar de nuevo",
+    "waitingCaptionLong": "Seguimos trabajando. Esto puede tardar uno o dos minutos.",
+    "waitingCaptionShort": "Esto puede tardar unos segundos."
+  },
   "sharedUi": {
     "checkingDomain": "Comprobando dominio…",
     "domainVerified": "Dominio verificado",
@@ -406,6 +541,73 @@
   "textToSpeechCard": {
     "subtitle": "Configura cómo habla tu asistente",
     "title": "Texto a voz"
+  },
+  "upgradeCancelPage": {
+    "billingUnavailable": "La facturación no está disponible para el estado actual del asistente.",
+    "platformLoginNotice": "Inicie sesión en la plataforma Vellum para administrar facturación y uso.",
+    "redirectingBody": "Regresándolo a la configuración de facturación…",
+    "returnToBilling": "Volver a facturación",
+    "title": "Actualización cancelada"
+  },
+  "upgradeSuccessPage": {
+    "cantConfirmUpgrade": "No podemos confirmar su actualización para el asistente actual. Vuelva a facturación para reintentar.",
+    "fetchErrorBody": "Tuvimos un problema al verificar su suscripción. Su actualización puede seguir procesándose. Vuelva a facturación para actualizar.",
+    "fetchErrorTitle": "No se pudo acceder a facturación",
+    "finalizingBody": "Stripe está confirmando su suscripción. Esto suele tardar unos segundos.",
+    "finalizingTitle": "Finalizando su actualización…",
+    "goToBilling": "Ir a facturación",
+    "platformLoginNotice": "Inicie sesión en la plataforma Vellum para administrar facturación y uso.",
+    "processingFallback": "Estamos procesando su actualización. Actualice en un momento para ver su nuevo plan.",
+    "successBody": "Su plan Pro está activo. Será redirigido a facturación en un momento.",
+    "welcomeTitle": "Bienvenido a Pro"
+  },
+  "usageTab": {
+    "analyzeCostsButton": "Analizar costos con el asistente",
+    "breakdownTitle": "Desglose",
+    "cacheCreatedLabel": "Caché creada",
+    "cacheReadLabel": "Caché leída",
+    "costAssistantSubtitle": "Revise el gasto reciente y ajuste las opciones de perfil del modelo.",
+    "costAssistantTitle": "Asistente de costos",
+    "costLabel": "Costo",
+    "dailyTrend": "Tendencia diaria",
+    "dailyTrendBy": "Tendencia diaria por {group}",
+    "directInputTokensLabel": "Tokens de entrada directa",
+    "failedToLoadUsage": "No se pudo cargar el uso.",
+    "groupByActor": "Actor",
+    "groupByConversation": "Conversación",
+    "groupByModel": "Modelo",
+    "groupByProfile": "Perfil",
+    "groupByProvider": "Proveedor",
+    "groupBySchedule": "Programación",
+    "groupByTask": "Acción",
+    "groupColumnLabel": "Grupo",
+    "hourlyTrend": "Tendencia por hora",
+    "hourlyTrendBy": "Tendencia por hora por {group}",
+    "inferenceUsageTitle": "Uso de inferencia",
+    "llmCallsLabel": "Llamadas LLM",
+    "noBreakdownDataSubtitle": "No hay uso registrado para esta agrupación",
+    "noBreakdownDataTitle": "Sin datos de desglose",
+    "optimizeSettingsButton": "Optimizar ajustes",
+    "outputTokensLabel": "Tokens de salida",
+    "percentOfTotalLabel": "% del total",
+    "range30d": "Últimos 30 días",
+    "range7d": "Últimos 7 días",
+    "range90d": "Últimos 90 días",
+    "rangeAll": "Todo el tiempo",
+    "rangeToday": "Hoy",
+    "rangeYesterday": "Ayer",
+    "retry": "Reintentar",
+    "title": "Uso",
+    "tokensLabel": "Tokens",
+    "totalsAriaLabel": "Totales",
+    "turnsLabel": "Turnos",
+    "unknownSchedule": "Programación desconocida ({scheduleId})"
+  },
+  "usageTrendChart": {
+    "noDailyData": "Sin datos diarios",
+    "noHourlyData": "Sin datos por hora",
+    "noUsageInRange": "No hay uso registrado en este intervalo",
+    "total": "Total"
   },
   "useDaemonConfig": {
     "assistantNotReadyToast": "El asistente no está listo. Inténtalo de nuevo.",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan
Continue the web i18n cutover after chat inspector (#40654). Next mid-sized slice: translate `clients/web/src/domains/settings/billing/**` into the existing `settings` namespace, then ratchet `local/no-untranslated-strings`.

## Summary
- Move user-facing copy in `src/domains/settings/billing/**` into `settings` catalogs (en + es), read through `t()` / `<Trans>` from `@/i18n`.
- Cover billing/usage tabs, plans (including custom plan and package switch), checkout/upgrade return pages, and pro-onboarding (domain step, provisioning, complete/error).
- Reuse existing `billingStatusHandler` / `checkoutBonusModal` keys; ratchet enforcement to `src/domains/settings/billing/**/*.{ts,tsx}` (supersedes the prior single-file checkout-bonus glob coverage).
- Update two tests that asserted em-dash copy now written with hyphen/period per user-facing punctuation rules.

## Test plan
- [x] `bunx eslint "src/domains/settings/billing/**/*.{ts,tsx}"` — 0 `no-untranslated-strings` errors
- [x] `bun test src/i18n/catalogs.test.ts`
- [x] Focused billing tests: usage-tab, plans, domain-step, provisioning-state, checkout/billing pages
- [x] `bun run lint` — 0 errors (existing warnings only)

## Risk
Low. Catalog cutover plus call-site wiring; no API or persistence changes. Some longer plan/provisioning copy lives in helper `.ts` modules (`plans-copy`, `takeover-copy`, etc.) and remains English until a follow-up; JSX ratchet is clean.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7f2993b-c41a-4c7d-8427-a880d12f5a8a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7f2993b-c41a-4c7d-8427-a880d12f5a8a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

