### PR TITLE
chore(web): drop unused Electron-prefixed type aliases

### DIFF
--- a/clients/web/src/runtime/is-electron.ts
+++ b/clients/web/src/runtime/is-electron.ts
@@ -101,12 +101,6 @@ export type {
   VoiceActivityState,
 };
 
-// Legacy aliases — existing consumers import these `Electron`-prefixed names.
-// They are structurally identical to the contract types.
-export type ElectronShowNotificationPayload = ShowNotificationPayload;
-export type ElectronTextInsertionResult = TextInsertionResult;
-export type ElectronNotificationActionEvent = NotificationActionEvent;
-
 // ─── Window augmentation ────────────────────────────────────────────────
 // The renderer's `window.vellum` declaration intentionally marks many
 // capability groups optional for version-skew tolerance: a newer renderer

--- a/clients/web/src/runtime/text-insertion.ts
+++ b/clients/web/src/runtime/text-insertion.ts
@@ -1,11 +1,10 @@
-import {
-  isElectron,
-  type ElectronTextInsertionResult,
-} from "@/runtime/is-electron";
+import type { TextInsertionResult as BridgeTextInsertionResult } from "@vellumai/ipc-contract";
+
+import { isElectron } from "@/runtime/is-electron";
 import { openSystemPermissionSettings } from "@/runtime/system-permissions";
 
 export type TextInsertionResult =
-  ElectronTextInsertionResult | { status: "unavailable" };
+  BridgeTextInsertionResult | { status: "unavailable" };
 
 export async function insertTextIntoFrontApp(
   text: string,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan
Find a small, real cleanup in `vellum-assistant` to verify this Cloud Agent environment end to end (branch, commit, push, PR).

`@vellumai/ipc-contract` is the source of truth for Electron bridge payload types. The renderer-side `ElectronShowNotificationPayload`, `ElectronTextInsertionResult`, and `ElectronNotificationActionEvent` aliases were leftovers from before that package existed.

## Summary
- Remove the unused `Electron*`-prefixed type aliases from `is-electron.ts`.
- Point the one remaining `ElectronTextInsertionResult` consumer at the contract `TextInsertionResult` type.

## Test Plan
- Repo-wide search confirmed no remaining `ElectronShowNotificationPayload`, `ElectronTextInsertionResult`, or `ElectronNotificationActionEvent` callers (the only leftover mention is a naming-convention note in `packages/ipc-contract/src/types.ts`).
- `cd clients/web && bun test src/domains/chat/hooks/use-voice-input.test.tsx src/domains/chat/voice/global-push-to-talk-bridge.test.tsx` (11 pass).
- `cd clients/web && bunx tsc --noEmit` (clean).
- `cd clients/web && bun run lint -- src/runtime/is-electron.ts src/runtime/text-insertion.ts` (clean).

## Risk
Low. Dead-code removal plus one import path change. No behavior change.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-154151d5-2b4f-4818-8c93-ef8ecbfd4bc8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-154151d5-2b4f-4818-8c93-ef8ecbfd4bc8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

