### PR TITLE
feat(plugins): add secure external plugin platform capabilities

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -57,6 +57,29 @@ This file is the cross-system architecture index. Detailed designs live in domai
 - **Context overflow resilience**: The session loop implements a deterministic overflow convergence pipeline that recovers from context-too-large failures without surfacing errors to users. A preflight budget check catches overflow before provider calls; a tiered reducer (forced compaction, tool-result truncation, media stubbing, injection downgrade) iteratively shrinks the payload; and when all tiers are exhausted the overflow policy resolver auto-compresses the latest turn with no user prompt — this applies equally to interactive and non-interactive sessions. Setting `contextWindow.overflowRecovery.interactiveLatestTurnCompression` to `"drop"` opts interactive sessions out, and `contextWindow.overflowRecovery.nonInteractiveLatestTurnCompression: "drop"` opts non-interactive/background sessions out independently — either short-circuits to a graceful failure for that session type; setting `contextWindow.overflowRecovery.enabled: false` also yields a graceful failure. Config lives under `contextWindow.overflowRecovery`. See [`assistant/ARCHITECTURE.md`](assistant/ARCHITECTURE.md#context-overflow-recovery) for the full design and [`assistant/docs/architecture/memory.md`](assistant/docs/architecture/memory.md#context-compaction-and-overflow-recovery-interaction) for compaction interaction details.
 - **Embedding-dimension reconciliation**: The embedding dimension is a committed property of the Qdrant collection, derived from the backend that built it. At daemon startup `reconcileEmbeddingIdentity` probes the configured backend and reconciles the committed dimension confirm-before-destroy: backend down → defer (recall degrades to empty results, surfaced via `memory_worker_status`'s `embedding.degraded`); no committed dimension → commit the probed dimension and create the collections; match → no-op; mismatch with an explicit provider → migrate (recreate, the only destructive path, gated on a successful probe); mismatch under `auto` → no-op (no thrash on transient backend availability). Platform intent is a fill-only deployment default (`IS_PLATFORM` → `provider: "gemini"`, in-memory, not persisted) — there is no on-disk provider/dimension migration. See [`assistant/docs/architecture/memory.md`](assistant/docs/architecture/memory.md#embedding-dimension-reconciliation).
 
+## External Plugin Platform
+
+Installed plugins pass a static eligibility check before the host imports any executable contribution. A plugin can opt into `host-requirements.json` to require named, versioned host capabilities. Plugins without that file retain the legacy compatibility path. Invalid requirements, unsupported capabilities, failed initialization, and failed initial worker recovery keep every plugin surface unavailable.
+
+```mermaid
+flowchart LR
+    FILES["Installed plugin files"] --> ELIGIBILITY["Static eligibility and compatibility"]
+    ELIGIBILITY --> INIT["Initialization hook"]
+    INIT --> WORKERS["Initial worker recovery"]
+    WORKERS --> READY["Persisted readiness generation"]
+    READY --> ASSISTANT_SURFACES["Assistant routes, apps, skills, schedules, and channels"]
+    READY --> GATEWAY_INGRESS["Gateway plugin ingress"]
+    ASSISTANT_SURFACES --> ROUTE_HOST["Plugin route host process"]
+    ROUTE_HOST --> BROKER["Closed route-host broker"]
+    BROKER --> ASSISTANT["Main assistant process"]
+```
+
+The assistant owns the readiness snapshot at `data/plugin-readiness-v1.json`. Each ready entry binds a host-derived plugin ID to the current source fingerprint. The source watcher publishes the matching fingerprint in `data/monitoring/plugin-source-versions.json`. The gateway reads both documents through `@vellumai/service-contracts/plugin-readiness` and fails closed when either document is missing, malformed, disabled, not ready, or stale. Persisted generations let a gateway-only restart recover settled readiness without importing plugin code.
+
+Plugin workers run once after successful initialization and recover durable work from the plugin's `data/` directory. Disable, reload, and uninstall invalidate readiness before teardown. Shutdown stops workers before running shutdown hooks. Plugins do not store durable state in the main assistant database.
+
+Opted-in route manifests declare each path, method, and host-owned authorization class. Authorization runs before route-module import. Route handlers receive a host-derived plugin ID, actor scopes, request ID, abort signal, and optional verified peer operation context. The route host uses a closed broker for approved main-process operations; direct public conversation-store and conversation-loop calls are rejected there. The route host is process isolation for liveness and an API boundary, not a filesystem sandbox against hostile code running as the same OS user.
+
 ## Environment and Data Layout
 
 Environments are **namespaces**, not containers. `VELLUM_ENVIRONMENT` selects a path prefix (`vellum` for `production`, `vellum-<env>` for the non-production seeds `dev`, `staging`, `test`, `local`). It does not own data. Data directories are always per-assistant, and the lockfile's `resources.instanceDir` field is the source of truth for any given assistant's on-disk location.

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -23688,6 +23688,26 @@ paths:
                           description:
                             Whether the plugin is active in this workspace. `false` when a `.disabled` sentinel is present under its
                             directory; `true` otherwise.
+                        activation:
+                          type: object
+                          properties:
+                            status:
+                              type: string
+                              enum:
+                                - disabled
+                                - initializing
+                                - ready
+                                - incompatible
+                                - failed
+                                - unavailable
+                            code:
+                              type: string
+                            message:
+                              type: string
+                          required:
+                            - status
+                          additionalProperties: false
+                          description: Host activation state. Plugin surfaces are available only when status is `ready`.
                         description:
                           anyOf:
                             - type: string
@@ -23730,6 +23750,7 @@ paths:
                         - id
                         - name
                         - enabled
+                        - activation
                         - description
                         - version
                       additionalProperties: false

--- a/assistant/src/__tests__/external-plugin-loader.test.ts
+++ b/assistant/src/__tests__/external-plugin-loader.test.ts
@@ -252,25 +252,58 @@ describe("loadExternalPlugin — plugin-api peerDependency", () => {
     expect(registeredNames()).toContain("requirements-ok");
   });
 
-  test("refreshes compatibility when a same-mtime requirement changes size", () => {
+  test("refreshes compatibility after a same-size same-mtime rewrite", () => {
     const dir = freshPluginDir("requirements-signature-refresh");
     writePackageJson(dir, {
       name: "requirements-signature-refresh-package",
       version: "0.1.0",
       peerDependencies: { "@vellumai/plugin-api": "*" },
     });
-    writeHostRequirements(dir, { "plugins.unknown": "^1.0.0" });
+    writeHostRequirements(dir);
     const requirementsPath = join(dir, "host-requirements.json");
     const originalStat = statSync(requirementsPath);
-
-    expect(getPluginActivationEligibility(dir).eligible).toBe(false);
-
-    writeHostRequirements(dir);
-    utimesSync(requirementsPath, originalStat.atime, originalStat.mtime);
 
     expect(getPluginActivationEligibility(dir)).toMatchObject({
       eligible: true,
       mode: "requirements",
+    });
+
+    writeHostRequirements(dir, {
+      "plugins.activation.requirements": "^9.0.0",
+    });
+    expect(statSync(requirementsPath).size).toBe(originalStat.size);
+    utimesSync(requirementsPath, originalStat.atime, originalStat.mtime);
+
+    expect(getPluginActivationEligibility(dir)).toMatchObject({
+      eligible: false,
+      code: "host_capability_unsatisfied",
+    });
+  });
+
+  test("refreshes package compatibility after a same-size same-mtime rewrite", () => {
+    const dir = freshPluginDir("package-signature-refresh");
+    writePackageJson(dir, {
+      name: "package-signature-refresh-package",
+      version: "0.1.0",
+      peerDependencies: { "@vellumai/plugin-api": "*" },
+    });
+    writeHostRequirements(dir);
+    const packagePath = join(dir, "package.json");
+    const originalStat = statSync(packagePath);
+
+    expect(getPluginActivationEligibility(dir).eligible).toBe(true);
+
+    writePackageJson(dir, {
+      name: "package-signature-refresh-package",
+      version: "0.1.0",
+      peerDependencies: { "@vellumai/plugin-api": "!" },
+    });
+    expect(statSync(packagePath).size).toBe(originalStat.size);
+    utimesSync(packagePath, originalStat.atime, originalStat.mtime);
+
+    expect(getPluginActivationEligibility(dir)).toMatchObject({
+      eligible: false,
+      code: "plugin_api_peer_invalid",
     });
   });
 

--- a/assistant/src/__tests__/external-plugin-loader.test.ts
+++ b/assistant/src/__tests__/external-plugin-loader.test.ts
@@ -9,11 +9,22 @@
  * tempdir. Surface files use plain TypeScript with default exports so
  * bun can dynamic-import them at runtime without a build step.
  */
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  rmSync,
+  statSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 
+import {
+  getPluginActivationEligibility,
+  resetPluginActivationEligibilityCacheForTests,
+} from "../plugins/activation-eligibility.js";
 import {
   loadExternalPlugin,
   parsePluginManifest,
@@ -39,6 +50,18 @@ function writePackageJson(dir: string, pkg: Record<string, unknown>): void {
   writeFileSync(join(dir, "package.json"), JSON.stringify(pkg, null, 2));
 }
 
+function writeHostRequirements(
+  dir: string,
+  requires: Record<string, string> = {
+    "plugins.activation.requirements": "^1.0.0",
+  },
+): void {
+  writeFileSync(
+    join(dir, "host-requirements.json"),
+    JSON.stringify({ schemaVersion: 1, requires }, null, 2),
+  );
+}
+
 function writeSurfaceFile(dir: string, relPath: string, body: string): void {
   const parts = relPath.split("/");
   parts.pop();
@@ -54,6 +77,7 @@ function registeredNames(): string[] {
 
 beforeEach(() => {
   resetPluginRegistryForTests();
+  resetPluginActivationEligibilityCacheForTests();
 });
 
 afterAll(() => {
@@ -214,7 +238,79 @@ describe("loadExternalPlugin — plugin-api peerDependency", () => {
     expect(registeredNames()).toContain("compat-ok");
   });
 
-  test("loads plugin whose peerDependency range excludes assistant version (logs error)", async () => {
+  test("loads an opted-in plugin with satisfied host requirements", async () => {
+    const dir = freshPluginDir("requirements-ok");
+    writePackageJson(dir, {
+      name: "requirements-ok",
+      version: "0.1.0",
+      peerDependencies: { "@vellumai/plugin-api": "*" },
+    });
+    writeHostRequirements(dir);
+
+    await loadExternalPlugin(dir);
+
+    expect(registeredNames()).toContain("requirements-ok");
+  });
+
+  test("refreshes compatibility when a same-mtime requirement changes size", () => {
+    const dir = freshPluginDir("requirements-signature-refresh");
+    writePackageJson(dir, {
+      name: "requirements-signature-refresh-package",
+      version: "0.1.0",
+      peerDependencies: { "@vellumai/plugin-api": "*" },
+    });
+    writeHostRequirements(dir, { "plugins.unknown": "^1.0.0" });
+    const requirementsPath = join(dir, "host-requirements.json");
+    const originalStat = statSync(requirementsPath);
+
+    expect(getPluginActivationEligibility(dir).eligible).toBe(false);
+
+    writeHostRequirements(dir);
+    utimesSync(requirementsPath, originalStat.atime, originalStat.mtime);
+
+    expect(getPluginActivationEligibility(dir)).toMatchObject({
+      eligible: true,
+      mode: "requirements",
+    });
+  });
+
+  test("rejects an opted-in plugin before importing a surface", async () => {
+    const dir = freshPluginDir("requirements-incompatible");
+    const marker = join(ROOT, "incompatible-imported.txt");
+    rmSync(marker, { force: true });
+    writePackageJson(dir, {
+      name: "requirements-incompatible",
+      version: "0.1.0",
+      peerDependencies: { "@vellumai/plugin-api": "*" },
+    });
+    writeHostRequirements(dir, { "plugins.unknown": "^1.0.0" });
+    writeSurfaceFile(
+      dir,
+      "tools/unsafe.ts",
+      `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(marker)}, "imported"); export default {};`,
+    );
+
+    await loadExternalPlugin(dir);
+
+    expect(registeredNames()).not.toContain("requirements-incompatible");
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  test("rejects an opted-in plugin with an unsatisfied plugin API range", async () => {
+    const dir = freshPluginDir("requirements-peer-incompatible");
+    writePackageJson(dir, {
+      name: "requirements-peer-incompatible",
+      version: "0.1.0",
+      peerDependencies: { "@vellumai/plugin-api": ">=999.0.0" },
+    });
+    writeHostRequirements(dir);
+
+    await loadExternalPlugin(dir);
+
+    expect(registeredNames()).not.toContain("requirements-peer-incompatible");
+  });
+
+  test("keeps a legacy plugin whose peerDependency range excludes assistant version", async () => {
     // The host-compat gate is soft while the installation flow is in
     // flux — an unsatisfied range produces a `log.error` but the
     // plugin still loads. Once installation settles, this case should
@@ -232,7 +328,7 @@ describe("loadExternalPlugin — plugin-api peerDependency", () => {
     expect(registeredNames()).toContain("compat-bad");
   });
 
-  test("loads plugin whose peerDependency range is unparseable (logs error)", async () => {
+  test("keeps a legacy plugin whose peerDependency range is unparseable", async () => {
     // Same soft-gate rationale as the excluded-range case above.
     const dir = freshPluginDir("compat-bogus");
     writePackageJson(dir, {

--- a/assistant/src/__tests__/external-plugin-loader.test.ts
+++ b/assistant/src/__tests__/external-plugin-loader.test.ts
@@ -62,6 +62,23 @@ function writeHostRequirements(
   );
 }
 
+function writeAssistantPeerRouteManifest(dir: string): void {
+  writeSurfaceFile(
+    dir,
+    "routes/manifest.json",
+    JSON.stringify({
+      schemaVersion: 1,
+      routes: [
+        {
+          path: "exchange",
+          method: "POST",
+          authorization: { principal: "assistant_peer" },
+        },
+      ],
+    }),
+  );
+}
+
 function writeSurfaceFile(dir: string, relPath: string, body: string): void {
   const parts = relPath.split("/");
   parts.pop();
@@ -250,6 +267,31 @@ describe("loadExternalPlugin — plugin-api peerDependency", () => {
     await loadExternalPlugin(dir);
 
     expect(registeredNames()).toContain("requirements-ok");
+  });
+
+  test("fails closed until assistant-peer route support is advertised", async () => {
+    const dir = freshPluginDir("peer-routes-staged");
+    writePackageJson(dir, {
+      name: "peer-routes-staged",
+      version: "0.1.0",
+      peerDependencies: { "@vellumai/plugin-api": "*" },
+    });
+    writeHostRequirements(dir, {
+      "plugins.routes.assistant-peer": "^1.0.0",
+    });
+    writeAssistantPeerRouteManifest(dir);
+
+    const eligibility = getPluginActivationEligibility(dir);
+    await loadExternalPlugin(dir);
+
+    expect(eligibility).toMatchObject({
+      eligible: false,
+      code: "host_capability_unsatisfied",
+      missingCapabilities: [
+        { id: "plugins.routes.assistant-peer", hostVersion: undefined },
+      ],
+    });
+    expect(registeredNames()).not.toContain("peer-routes-staged");
   });
 
   test("refreshes compatibility after a same-size same-mtime rewrite", () => {

--- a/assistant/src/__tests__/list-all-apps.test.ts
+++ b/assistant/src/__tests__/list-all-apps.test.ts
@@ -9,6 +9,10 @@ import {
   listPluginApps,
   resolveAppSource,
 } from "../apps/app-store.js";
+import {
+  markPluginReady,
+  resetPluginReadinessForTests,
+} from "../plugins/plugin-readiness.js";
 import { getWorkspacePluginsDir } from "../util/platform.js";
 
 let workspaceDir: string;
@@ -37,6 +41,7 @@ function installPlugin(
   if (opts.disabled) {
     writeFileSync(join(pluginDir, ".disabled"), "");
   }
+  markPluginReady(name, "a".repeat(64));
   return pluginDir;
 }
 
@@ -52,6 +57,7 @@ function bundleApp(pluginDir: string, app: string): void {
 beforeEach(() => {
   workspaceDir = freshWorkspace();
   process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+  resetPluginReadinessForTests();
 });
 
 afterEach(() => {
@@ -124,6 +130,7 @@ describe("listAllApps", () => {
 
     mkdirSync(getWorkspacePluginsDir(), { recursive: true });
     symlinkSync(realPluginDir, join(getWorkspacePluginsDir(), "acme"));
+    markPluginReady("acme", "a".repeat(64));
 
     const plugin = listPluginApps();
     expect(plugin).toHaveLength(1);
@@ -137,6 +144,15 @@ describe("listAllApps", () => {
 
     expect(listPluginApps()).toEqual([]);
     expect(listAllApps()).toEqual([]);
+  });
+
+  test("excludes apps until the plugin is ready", () => {
+    const pluginDir = installPlugin("acme");
+    bundleApp(pluginDir, "acme-dashboard");
+    resetPluginReadinessForTests();
+
+    expect(listPluginApps()).toEqual([]);
+    expect(resolveAppSource("plugins~acme~acme-dashboard")).toBeNull();
   });
 });
 

--- a/assistant/src/__tests__/list-all-apps.test.ts
+++ b/assistant/src/__tests__/list-all-apps.test.ts
@@ -30,14 +30,29 @@ function freshWorkspace(): string {
  */
 function installPlugin(
   name: string,
-  opts: { disabled?: boolean } = {},
+  opts: { disabled?: boolean; optsIntoReadiness?: boolean } = {},
 ): string {
   const pluginDir = join(getWorkspacePluginsDir(), name);
   mkdirSync(pluginDir, { recursive: true });
   writeFileSync(
     join(pluginDir, "package.json"),
-    JSON.stringify({ name, version: "1.0.0" }),
+    JSON.stringify({
+      name,
+      version: "1.0.0",
+      ...(opts.optsIntoReadiness
+        ? { peerDependencies: { "@vellumai/plugin-api": "*" } }
+        : {}),
+    }),
   );
+  if (opts.optsIntoReadiness) {
+    writeFileSync(
+      join(pluginDir, "host-requirements.json"),
+      JSON.stringify({
+        schemaVersion: 1,
+        requires: { "plugins.readiness": "^1.0.0" },
+      }),
+    );
+  }
   if (opts.disabled) {
     writeFileSync(join(pluginDir, ".disabled"), "");
   }
@@ -95,6 +110,7 @@ describe("listAllApps", () => {
     });
     const pluginDir = installPlugin("acme");
     bundleApp(pluginDir, "acme-dashboard");
+    resetPluginReadinessForTests();
 
     const plugin = listPluginApps();
     expect(plugin).toHaveLength(1);
@@ -147,7 +163,7 @@ describe("listAllApps", () => {
   });
 
   test("excludes apps until the plugin is ready", () => {
-    const pluginDir = installPlugin("acme");
+    const pluginDir = installPlugin("acme", { optsIntoReadiness: true });
     bundleApp(pluginDir, "acme-dashboard");
     resetPluginReadinessForTests();
 

--- a/assistant/src/__tests__/mtime-cache.test.ts
+++ b/assistant/src/__tests__/mtime-cache.test.ts
@@ -41,6 +41,7 @@ import {
 import { getPluginReadiness } from "../plugins/plugin-readiness.js";
 import {
   getSourceVersionsPath,
+  readSourceVersions,
   SOURCE_VERSIONS_FORMAT,
 } from "../plugins/source-versions.js";
 import {
@@ -188,6 +189,20 @@ afterAll(() => {
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe("plugin mtime cache (per-surface)", () => {
+  test("boot publishes a source baseline without the monitor process", async () => {
+    const dir = freshPluginDir("boot-source-baseline");
+    writePackageJson(dir, {
+      ...SIMPLE_PKG,
+      name: "boot-source-baseline",
+    });
+
+    await populateCacheAtBoot();
+
+    const sourceVersions = readSourceVersions();
+    expect(sourceVersions).not.toBeNull();
+    expect(sourceVersions?.plugins[dir]?.disabled).toBe(false);
+  });
+
   test("an incompatible plugin imports no surfaces", async () => {
     const dir = freshPluginDir("incompatible-plugin");
     const marker = join(ROOT, "incompatible-init-imported.txt");
@@ -698,6 +713,42 @@ async function reconcileAndPull(): Promise<void> {
 }
 
 describe("plugin runtime activation", () => {
+  test("concurrent boot callers share one in-flight activation", async () => {
+    const dir = freshPluginDir("concurrent-activation");
+    const started = join(ROOT, "concurrent-started");
+    const release = join(ROOT, "concurrent-release");
+    writePackageJson(dir, {
+      ...SIMPLE_PKG,
+      name: "concurrent-activation",
+    });
+    writeHook(
+      dir,
+      "init",
+      `import { existsSync, writeFileSync } from "node:fs";
+       export default async function init() {
+         writeFileSync(${JSON.stringify(started)}, "yes");
+         while (!existsSync(${JSON.stringify(release)})) {
+           await Bun.sleep(1);
+         }
+       }`,
+    );
+
+    const first = populateCacheAtBoot();
+    while (!existsSync(started)) {
+      await Bun.sleep(1);
+    }
+    let secondSettled = false;
+    const second = populateCacheAtBoot().finally(() => {
+      secondSettled = true;
+    });
+    await Bun.sleep(10);
+
+    expect(secondSettled).toBe(false);
+    writeFileSync(release, "yes");
+    await Promise.all([first, second]);
+    expect(getPluginReadiness("concurrent-activation")?.status).toBe("ready");
+  });
+
   test("a plugin installed after boot becomes live once reconciled", async () => {
     await populateCacheAtBoot(); // empty plugins dir
     expect(getAllToolDefinitions().some((t) => t.name === "late-tool")).toBe(

--- a/assistant/src/__tests__/mtime-cache.test.ts
+++ b/assistant/src/__tests__/mtime-cache.test.ts
@@ -38,7 +38,11 @@ import {
   reconcilePluginSourcesNow,
   resetPluginCacheForTests,
 } from "../plugins/mtime-cache.js";
-import { getSourceVersionsPath } from "../plugins/source-versions.js";
+import { getPluginReadiness } from "../plugins/plugin-readiness.js";
+import {
+  getSourceVersionsPath,
+  SOURCE_VERSIONS_FORMAT,
+} from "../plugins/source-versions.js";
 import {
   __resetRegistryForTesting,
   getAllToolDefinitions,
@@ -49,12 +53,13 @@ import {
 
 // ─── Test fixtures ───────────────────────────────────────────────────────────
 
-const ROOT = join(
+const ROOT_PARENT = join(
   tmpdir(),
   `vellum-mtime-cache-test-${process.pid}-${Date.now()}`,
 );
+let ROOT = join(ROOT_PARENT, "initial");
 
-const PLUGINS_DIR = join(ROOT, "plugins");
+let PLUGINS_DIR = join(ROOT, "plugins");
 
 function ensurePluginsDir(): void {
   rmSync(PLUGINS_DIR, { recursive: true, force: true });
@@ -70,6 +75,18 @@ function freshPluginDir(name: string): string {
 
 function writePackageJson(dir: string, pkg: Record<string, unknown>): void {
   writeFileSync(join(dir, "package.json"), JSON.stringify(pkg, null, 2));
+}
+
+function writeHostRequirements(
+  dir: string,
+  requires: Record<string, string> = {
+    "plugins.activation.requirements": "^1.0.0",
+  },
+): void {
+  writeFileSync(
+    join(dir, "host-requirements.json"),
+    JSON.stringify({ schemaVersion: 1, requires }, null, 2),
+  );
 }
 
 function writeHook(dir: string, hookName: string, body: string): void {
@@ -100,7 +117,7 @@ function writeTool(dir: string, toolName: string, body: string): void {
 }
 
 /** The standalone workspace hooks directory (`<workspace>/hooks/`). */
-const WORKSPACE_HOOKS_DIR = join(ROOT, "hooks");
+let WORKSPACE_HOOKS_DIR = join(ROOT, "hooks");
 
 function ensureWorkspaceHooksDir(): void {
   rmSync(WORKSPACE_HOOKS_DIR, { recursive: true, force: true });
@@ -132,6 +149,7 @@ const SIMPLE_PKG = {
 
 /** Strictly increasing mtime offset for source-file touches within one test. */
 let touchSeq = 0;
+let fixtureSeq = 0;
 
 /**
  * Apply pending source changes exactly the way production does: the
@@ -149,6 +167,10 @@ beforeAll(() => {
 });
 
 beforeEach(() => {
+  ROOT = join(ROOT_PARENT, String(fixtureSeq++));
+  PLUGINS_DIR = join(ROOT, "plugins");
+  WORKSPACE_HOOKS_DIR = join(ROOT, "hooks");
+  process.env.VELLUM_WORKSPACE_DIR = ROOT;
   ensurePluginsDir();
   ensureWorkspaceHooksDir();
   rmSync(getSourceVersionsPath(), { force: true });
@@ -160,12 +182,63 @@ beforeEach(() => {
 });
 
 afterAll(() => {
-  rmSync(ROOT, { recursive: true, force: true });
+  rmSync(ROOT_PARENT, { recursive: true, force: true });
 });
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe("plugin mtime cache (per-surface)", () => {
+  test("an incompatible plugin imports no surfaces", async () => {
+    const dir = freshPluginDir("incompatible-plugin");
+    const marker = join(ROOT, "incompatible-init-imported.txt");
+    rmSync(marker, { force: true });
+    writePackageJson(dir, {
+      ...SIMPLE_PKG,
+      name: "incompatible-plugin",
+    });
+    writeHostRequirements(dir, { "plugins.unknown": "^1.0.0" });
+    writeHook(
+      dir,
+      "init",
+      `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(marker)}, "imported"); export default () => {};`,
+    );
+
+    await populateCacheAtBoot();
+
+    expect(existsSync(marker)).toBe(false);
+    expect(getPluginReadiness("incompatible-plugin")?.status).toBe(
+      "incompatible",
+    );
+    expect(_inspectToolCacheForTests()).toHaveLength(0);
+  });
+
+  test("a plugin whose init fails contributes no cached surface", async () => {
+    const dir = freshPluginDir("failed-plugin");
+    const toolImportMarker = join(ROOT, "failed-tool-imported.txt");
+    rmSync(toolImportMarker, { force: true });
+    writePackageJson(dir, { ...SIMPLE_PKG, name: "failed-plugin" });
+    writeHook(
+      dir,
+      "init",
+      `export default () => { throw new Error("boom"); };`,
+    );
+    writeHook(dir, "user-prompt-submit", `export default () => "unsafe";`);
+    writeTool(
+      dir,
+      "failed-tool",
+      `import { writeFileSync } from "node:fs";
+writeFileSync(${JSON.stringify(toolImportMarker)}, "imported");
+export default { description: "failed tool", execute: async () => "unsafe" };`,
+    );
+
+    await populateCacheAtBoot();
+
+    expect(await getUserHooksFor("user-prompt-submit")).toHaveLength(0);
+    expect(getCachedUserTools()).toHaveLength(0);
+    expect(existsSync(toolImportMarker)).toBe(false);
+    expect(getPluginReadiness("failed-plugin")?.status).toBe("failed");
+  });
+
   test("populateCacheAtBoot discovers and caches hooks", async () => {
     const dir = freshPluginDir("hook-plugin");
     writePackageJson(dir, { ...SIMPLE_PKG, name: "hook-plugin" });
@@ -981,12 +1054,13 @@ describe("plugin root validation (ATL-983)", () => {
     writeFileSync(
       sentinelPath,
       JSON.stringify({
-        format: 1,
+        format: SOURCE_VERSIONS_FORMAT,
         generation: 1,
         writtenAt: new Date().toISOString(),
         plugins: {
           [evilDir]: {
             fingerprint: snapshot.fingerprint,
+            sourceFingerprint: "a".repeat(64),
             evictionPaths: snapshot.evictionPaths,
             disabled: false,
           },

--- a/assistant/src/__tests__/mtime-cache.test.ts
+++ b/assistant/src/__tests__/mtime-cache.test.ts
@@ -254,6 +254,33 @@ export default { description: "failed tool", execute: async () => "unsafe" };`,
     expect(getPluginReadiness("failed-plugin")?.status).toBe("failed");
   });
 
+  test("an unchanged reconcile retries a failed activation", async () => {
+    const dir = freshPluginDir("retry-plugin");
+    const activationGate = join(ROOT, "retry-plugin-ready.txt");
+    writePackageJson(dir, { ...SIMPLE_PKG, name: "retry-plugin" });
+    writeHook(
+      dir,
+      "init",
+      `import { existsSync } from "node:fs";
+export default () => {
+  if (!existsSync(${JSON.stringify(activationGate)})) {
+    throw new Error("not ready");
+  }
+};`,
+    );
+    writeHook(dir, "user-prompt-submit", `export default () => "recovered";`);
+
+    await populateCacheAtBoot();
+    expect(getPluginReadiness("retry-plugin")?.status).toBe("failed");
+    expect(await getUserHooksFor("user-prompt-submit")).toHaveLength(0);
+
+    writeFileSync(activationGate, "ready");
+    await reconcilePluginSourcesNow();
+
+    expect(getPluginReadiness("retry-plugin")?.status).toBe("ready");
+    expect(await getUserHooksFor("user-prompt-submit")).toHaveLength(1);
+  });
+
   test("populateCacheAtBoot discovers and caches hooks", async () => {
     const dir = freshPluginDir("hook-plugin");
     writePackageJson(dir, { ...SIMPLE_PKG, name: "hook-plugin" });

--- a/assistant/src/__tests__/plugin-worker-runner.test.ts
+++ b/assistant/src/__tests__/plugin-worker-runner.test.ts
@@ -242,6 +242,39 @@ export default function run(context) {
     expect(readFileSync(countPath, "utf8")).toBe("2");
   });
 
+  test("honors a wake request after a non-initial failure", async () => {
+    const pluginDir = createPlugin("worker-failed-wake");
+    const countPath = join(pluginDir, "data", "count.txt");
+    writeWorker(
+      pluginDir,
+      "wake",
+      `import { existsSync, readFileSync, writeFileSync } from "node:fs";
+export default function run(context) {
+  const countPath = context.pluginStorageDir + "/count.txt";
+  const count = existsSync(countPath) ? Number(readFileSync(countPath, "utf8")) + 1 : 1;
+  writeFileSync(countPath, String(count));
+  if (count <= 2) {
+    context.requestWake();
+  }
+  if (count === 2) {
+    throw new Error("retry requested");
+  }
+}
+`,
+    );
+
+    await startPluginWorkers(pluginDir);
+    const deadline = Date.now() + 1_000;
+    while (
+      (!existsSync(countPath) || readFileSync(countPath, "utf8") !== "3") &&
+      Date.now() <= deadline
+    ) {
+      await new Promise<void>((resolve) => setTimeout(resolve, 1));
+    }
+
+    expect(readFileSync(countPath, "utf8")).toBe("3");
+  });
+
   test("aborts an active worker when its plugin stops", async () => {
     const pluginDir = createPlugin("worker-stop");
     const startedPath = join(pluginDir, "data", "started.txt");

--- a/assistant/src/__tests__/plugin-worker-runner.test.ts
+++ b/assistant/src/__tests__/plugin-worker-runner.test.ts
@@ -211,6 +211,37 @@ export default function run(context) {
     );
   });
 
+  test("keeps a synchronous wake request ahead of a future wake", async () => {
+    const pluginDir = createPlugin("worker-sync-wake");
+    const countPath = join(pluginDir, "data", "count.txt");
+    writeWorker(
+      pluginDir,
+      "wake",
+      `import { existsSync, readFileSync, writeFileSync } from "node:fs";
+export default function run(context) {
+  const countPath = context.pluginStorageDir + "/count.txt";
+  const count = existsSync(countPath) ? Number(readFileSync(countPath, "utf8")) + 1 : 1;
+  writeFileSync(countPath, String(count));
+  if (count === 1) {
+    context.requestWake();
+    return { nextWakeAt: Date.now() + 60_000 };
+  }
+}
+`,
+    );
+
+    await startPluginWorkers(pluginDir);
+    const deadline = Date.now() + 1_000;
+    while (
+      (!existsSync(countPath) || readFileSync(countPath, "utf8") !== "2") &&
+      Date.now() <= deadline
+    ) {
+      await new Promise<void>((resolve) => setTimeout(resolve, 1));
+    }
+
+    expect(readFileSync(countPath, "utf8")).toBe("2");
+  });
+
   test("aborts an active worker when its plugin stops", async () => {
     const pluginDir = createPlugin("worker-stop");
     const startedPath = join(pluginDir, "data", "started.txt");

--- a/assistant/src/__tests__/plugin-worker-runner.test.ts
+++ b/assistant/src/__tests__/plugin-worker-runner.test.ts
@@ -1,0 +1,309 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+
+import { resetPluginActivationEligibilityCacheForTests } from "../plugins/activation-eligibility.js";
+import {
+  discoverExternalPluginWorkers,
+  loadExternalPluginWorkers,
+} from "../plugins/external-plugin-workers.js";
+import {
+  getActivePluginWorkerCount,
+  resetPluginWorkerRunnerForTests,
+  startPluginWorkers,
+  stopPluginWorkers,
+  waitForPluginWorkersIdleForTests,
+} from "../plugins/plugin-worker-runner.js";
+import { getWorkspaceDir } from "../util/platform.js";
+
+const ROOT = join(
+  tmpdir(),
+  `vellum-plugin-worker-runner-test-${process.pid}-${Date.now()}`,
+);
+
+function createPlugin(pluginId: string): string {
+  const pluginDir = join(ROOT, pluginId);
+  mkdirSync(join(pluginDir, "workers"), { recursive: true });
+  writeFileSync(
+    join(pluginDir, "package.json"),
+    JSON.stringify({ name: `${pluginId}-package`, version: "1.0.0" }),
+  );
+  return pluginDir;
+}
+
+function writeWorker(pluginDir: string, name: string, source: string): void {
+  writeFileSync(join(pluginDir, "workers", `${name}.ts`), source);
+}
+
+async function waitForFile(path: string): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (!existsSync(path)) {
+    if (Date.now() > deadline) {
+      throw new Error(`timed out waiting for ${path}`);
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, 1));
+  }
+}
+
+beforeEach(() => {
+  resetPluginActivationEligibilityCacheForTests();
+});
+
+afterEach(async () => {
+  await resetPluginWorkerRunnerForTests();
+});
+
+afterAll(() => {
+  rmSync(ROOT, { recursive: true, force: true });
+});
+
+describe("external plugin worker discovery", () => {
+  test("prefers compiled workers and sorts by worker name", () => {
+    const pluginDir = createPlugin("worker-discovery");
+    writeWorker(pluginDir, "zeta", "export default () => {};\n");
+    writeWorker(pluginDir, "alpha", "export default () => {};\n");
+    writeFileSync(
+      join(pluginDir, "workers", "alpha.js"),
+      "export default () => {};\n",
+    );
+
+    const workers = discoverExternalPluginWorkers(pluginDir);
+
+    expect(workers.map((worker) => worker.name)).toEqual(["alpha", "zeta"]);
+    expect(workers[0]?.path.endsWith("alpha.js")).toBe(true);
+    expect(
+      workers.every((worker) => worker.pluginId === "worker-discovery"),
+    ).toBe(true);
+  });
+
+  test("does not import workers for an incompatible plugin", async () => {
+    const pluginDir = createPlugin("worker-incompatible");
+    const importedMarker = join(pluginDir, "imported.txt");
+    writeFileSync(
+      join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "worker-incompatible-package",
+        version: "1.0.0",
+        peerDependencies: { "@vellumai/plugin-api": "*" },
+      }),
+    );
+    writeFileSync(
+      join(pluginDir, "host-requirements.json"),
+      JSON.stringify({
+        schemaVersion: 1,
+        requires: { "plugins.capability.not-implemented": "1.x" },
+      }),
+    );
+    writeWorker(
+      pluginDir,
+      "side-effect",
+      `import { writeFileSync } from "node:fs";\nwriteFileSync(${JSON.stringify(importedMarker)}, "imported");\nexport default () => {};\n`,
+    );
+
+    await expect(loadExternalPluginWorkers(pluginDir)).rejects.toThrow(
+      "is not eligible for workers",
+    );
+    expect(existsSync(importedMarker)).toBe(false);
+  });
+});
+
+describe("plugin worker lifecycle", () => {
+  test("migrates legacy durable state before initial recovery", async () => {
+    const pluginId = "worker-storage-migration";
+    const pluginDir = createPlugin(pluginId);
+    const legacyDir = join(getWorkspaceDir(), "plugins-data", pluginId);
+    rmSync(legacyDir, { recursive: true, force: true });
+    mkdirSync(legacyDir, { recursive: true });
+    writeFileSync(join(legacyDir, "pending.txt"), "durable work");
+    writeWorker(
+      pluginDir,
+      "outbox",
+      `import { readFileSync, writeFileSync } from "node:fs";
+export default function run(context) {
+  const pending = readFileSync(context.pluginStorageDir + "/pending.txt", "utf8");
+  writeFileSync(context.pluginStorageDir + "/recovered.txt", pending);
+}
+`,
+    );
+
+    await startPluginWorkers(pluginDir);
+    await waitForPluginWorkersIdleForTests(pluginId);
+
+    expect(existsSync(legacyDir)).toBe(false);
+    expect(readFileSync(join(pluginDir, "data", "recovered.txt"), "utf8")).toBe(
+      "durable work",
+    );
+  });
+
+  test("runs once per activation and recovers durable work after restart", async () => {
+    const pluginDir = createPlugin("worker-recovery");
+    writeWorker(
+      pluginDir,
+      "outbox",
+      `import { existsSync, readFileSync, writeFileSync } from "node:fs";
+export default async function run(context) {
+  const path = context.pluginStorageDir + "/runs.txt";
+  const prior = existsSync(path) ? Number(readFileSync(path, "utf8")) : 0;
+  writeFileSync(path, String(prior + 1));
+}
+`,
+    );
+
+    const first = await startPluginWorkers(pluginDir);
+    const duplicate = await startPluginWorkers(pluginDir);
+    await waitForPluginWorkersIdleForTests("worker-recovery");
+
+    expect(first).toEqual({
+      pluginId: "worker-recovery",
+      workerCount: 1,
+      started: true,
+    });
+    expect(duplicate.started).toBe(false);
+    expect(readFileSync(join(pluginDir, "data", "runs.txt"), "utf8")).toBe("1");
+
+    await stopPluginWorkers("worker-recovery");
+    await startPluginWorkers(pluginDir);
+    await waitForPluginWorkersIdleForTests("worker-recovery");
+
+    expect(readFileSync(join(pluginDir, "data", "runs.txt"), "utf8")).toBe("2");
+  });
+
+  test("passes host identity and honors an immediate wake request", async () => {
+    const pluginDir = createPlugin("worker-context");
+    writeWorker(
+      pluginDir,
+      "wake",
+      `import { existsSync, readFileSync, writeFileSync } from "node:fs";
+export default function run(context) {
+  const countPath = context.pluginStorageDir + "/count.txt";
+  const count = existsSync(countPath) ? Number(readFileSync(countPath, "utf8")) + 1 : 1;
+  writeFileSync(countPath, String(count));
+  writeFileSync(context.pluginStorageDir + "/identity.txt", context.pluginId);
+  if (count === 1) {
+    context.requestWake();
+  }
+}
+`,
+    );
+
+    await startPluginWorkers(pluginDir);
+    await waitForPluginWorkersIdleForTests("worker-context");
+
+    expect(readFileSync(join(pluginDir, "data", "count.txt"), "utf8")).toBe(
+      "2",
+    );
+    expect(readFileSync(join(pluginDir, "data", "identity.txt"), "utf8")).toBe(
+      "worker-context",
+    );
+  });
+
+  test("aborts an active worker when its plugin stops", async () => {
+    const pluginDir = createPlugin("worker-stop");
+    const startedPath = join(pluginDir, "data", "started.txt");
+    const abortedPath = join(pluginDir, "data", "aborted.txt");
+    writeWorker(
+      pluginDir,
+      "blocking",
+      `import { writeFileSync } from "node:fs";
+export default async function run(context) {
+  writeFileSync(context.pluginStorageDir + "/started.txt", "yes");
+  await new Promise((resolve) => {
+    context.signal.addEventListener("abort", () => {
+      writeFileSync(context.pluginStorageDir + "/aborted.txt", "yes");
+      resolve();
+    }, { once: true });
+  });
+}
+`,
+    );
+
+    const startPromise = startPluginWorkers(pluginDir);
+    await waitForFile(startedPath);
+    expect(getActivePluginWorkerCount("worker-stop")).toBe(1);
+
+    await stopPluginWorkers("worker-stop");
+    await startPromise;
+
+    expect(readFileSync(abortedPath, "utf8")).toBe("yes");
+    expect(getActivePluginWorkerCount("worker-stop")).toBe(0);
+  });
+
+  test("rejects activation and stops sibling workers after initial failure", async () => {
+    const pluginDir = createPlugin("worker-initial-failure");
+    const abortedPath = join(pluginDir, "data", "sibling-aborted.txt");
+    writeWorker(
+      pluginDir,
+      "blocking",
+      `import { writeFileSync } from "node:fs";
+export default async function run(context) {
+  await new Promise((resolve) => {
+    context.signal.addEventListener("abort", () => {
+      writeFileSync(context.pluginStorageDir + "/sibling-aborted.txt", "yes");
+      resolve();
+    }, { once: true });
+  });
+}
+`,
+    );
+    writeWorker(
+      pluginDir,
+      "failure",
+      `export default function run() {
+  throw new Error("initial recovery failed");
+}
+`,
+    );
+
+    await expect(startPluginWorkers(pluginDir)).rejects.toThrow(
+      "initial recovery failed",
+    );
+
+    await waitForFile(abortedPath);
+    expect(getActivePluginWorkerCount("worker-initial-failure")).toBe(0);
+  });
+
+  test("prevents restart while a worker is still stopping", async () => {
+    const pluginDir = createPlugin("worker-slow-stop");
+    const startedPath = join(pluginDir, "data", "started.txt");
+    const releasePath = join(pluginDir, "data", "release.txt");
+    writeWorker(
+      pluginDir,
+      "blocking",
+      `import { existsSync, writeFileSync } from "node:fs";
+export default async function run(context) {
+  writeFileSync(context.pluginStorageDir + "/started.txt", "yes");
+  while (!existsSync(context.pluginStorageDir + "/release.txt")) {
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+}
+`,
+    );
+
+    const startPromise = startPluginWorkers(pluginDir);
+    await waitForFile(startedPath);
+    await stopPluginWorkers("worker-slow-stop", { timeoutMs: 10 });
+
+    await expect(startPluginWorkers(pluginDir)).rejects.toThrow(
+      "workers are still stopping",
+    );
+
+    writeFileSync(releasePath, "yes");
+    await startPromise;
+    await waitForPluginWorkersIdleForTests("worker-slow-stop");
+    await startPluginWorkers(pluginDir);
+  });
+});

--- a/assistant/src/__tests__/plugin-worker-runner.test.ts
+++ b/assistant/src/__tests__/plugin-worker-runner.test.ts
@@ -276,6 +276,53 @@ export default async function run(context) {
     expect(getActivePluginWorkerCount("worker-initial-failure")).toBe(0);
   });
 
+  test("bounds initial recovery and aborts the timed-out plugin", async () => {
+    const pluginDir = createPlugin("worker-initial-timeout");
+    const abortedPath = join(pluginDir, "data", "aborted.txt");
+    writeWorker(
+      pluginDir,
+      "blocking",
+      `import { writeFileSync } from "node:fs";
+export default async function run(context) {
+  await new Promise((resolve) => {
+    context.signal.addEventListener("abort", () => {
+      writeFileSync(context.pluginStorageDir + "/aborted.txt", "yes");
+      resolve();
+    }, { once: true });
+  });
+}
+`,
+    );
+
+    await expect(
+      startPluginWorkers(pluginDir, { initialRunTimeoutMs: 10 }),
+    ).rejects.toThrow("initial worker run timed out");
+
+    await waitForFile(abortedPath);
+    expect(getActivePluginWorkerCount("worker-initial-timeout")).toBe(0);
+  });
+
+  test("does not run a distant next wake immediately", async () => {
+    const pluginDir = createPlugin("worker-distant-wake");
+    writeWorker(
+      pluginDir,
+      "scheduled",
+      `import { existsSync, readFileSync, writeFileSync } from "node:fs";
+export default function run(context) {
+  const path = context.pluginStorageDir + "/runs.txt";
+  const prior = existsSync(path) ? Number(readFileSync(path, "utf8")) : 0;
+  writeFileSync(path, String(prior + 1));
+  return { nextWakeAt: Date.now() + 2_147_483_647 + 60_000 };
+}
+`,
+    );
+
+    await startPluginWorkers(pluginDir);
+    await new Promise<void>((resolve) => setTimeout(resolve, 25));
+
+    expect(readFileSync(join(pluginDir, "data", "runs.txt"), "utf8")).toBe("1");
+  });
+
   test("prevents restart while a worker is still stopping", async () => {
     const pluginDir = createPlugin("worker-slow-stop");
     const startedPath = join(pluginDir, "data", "started.txt");

--- a/assistant/src/apps/app-store.ts
+++ b/assistant/src/apps/app-store.ts
@@ -37,7 +37,7 @@ import {
 import { resolveConversationLineage } from "../daemon/conversation-lineage.js";
 import { rawAll } from "../persistence/raw-query.js";
 import { isPluginDisabled } from "../plugins/disabled-state.js";
-import { isPluginReady } from "../plugins/plugin-readiness.js";
+import { isPluginSurfaceReady } from "../plugins/plugin-readiness.js";
 import type { EditEngineResult } from "../tools/shared/filesystem/edit-engine.js";
 import { applyEdit } from "../tools/shared/filesystem/edit-engine.js";
 import { getLogger } from "../util/logger.js";
@@ -808,7 +808,7 @@ export function listPluginApps(): EnumeratedApp[] {
     if (!existsSync(join(pluginDir, "package.json"))) {
       continue;
     }
-    if (isPluginDisabled(name) || !isPluginReady(name)) {
+    if (isPluginDisabled(name) || !isPluginSurfaceReady(name, pluginDir)) {
       continue;
     }
     apps.push(...listAppsForPlugin(name, pluginDir));
@@ -894,7 +894,10 @@ export function resolveAppSource(id: string): ResolvedAppSource | null {
     if (!existsSync(join(pluginDir, "package.json"))) {
       return null;
     }
-    if (isPluginDisabled(pluginName) || !isPluginReady(pluginName)) {
+    if (
+      isPluginDisabled(pluginName) ||
+      !isPluginSurfaceReady(pluginName, pluginDir)
+    ) {
       return null;
     }
     const sourceDir = join(pluginDir, "apps", appDirName);

--- a/assistant/src/apps/app-store.ts
+++ b/assistant/src/apps/app-store.ts
@@ -37,6 +37,7 @@ import {
 import { resolveConversationLineage } from "../daemon/conversation-lineage.js";
 import { rawAll } from "../persistence/raw-query.js";
 import { isPluginDisabled } from "../plugins/disabled-state.js";
+import { isPluginReady } from "../plugins/plugin-readiness.js";
 import type { EditEngineResult } from "../tools/shared/filesystem/edit-engine.js";
 import { applyEdit } from "../tools/shared/filesystem/edit-engine.js";
 import { getLogger } from "../util/logger.js";
@@ -775,14 +776,13 @@ function listAppsForPlugin(
 }
 
 /**
- * Enumerate apps bundled by installed, enabled plugins under
+ * Enumerate apps bundled by installed, ready plugins under
  * `<workspace>/plugins/<name>/apps/`.
  *
  * Plugin discovery mirrors the plugin loader's `scanPlugins`: a plugin is an
  * entry that resolves to a directory (following symlinks) and carries a
  * `package.json` manifest. Stray directories without a manifest are ignored,
- * and disabled plugins (those with a `.disabled` sentinel) contribute nothing,
- * matching how their other surfaces (tools, hooks, routes) are gated.
+ * and plugins that are disabled or not ready contribute nothing.
  */
 export function listPluginApps(): EnumeratedApp[] {
   const pluginsRoot = getWorkspacePluginsDir();
@@ -808,7 +808,7 @@ export function listPluginApps(): EnumeratedApp[] {
     if (!existsSync(join(pluginDir, "package.json"))) {
       continue;
     }
-    if (isPluginDisabled(name)) {
+    if (isPluginDisabled(name) || !isPluginReady(name)) {
       continue;
     }
     apps.push(...listAppsForPlugin(name, pluginDir));
@@ -865,7 +865,7 @@ function isSafeIdSegment(segment: string): boolean {
  * UUID, looked up via {@link getApp}) and plugin-bundled apps
  * (`plugins~<name>~<app>`, resolved by direct path build). Returns null when
  * the app does not exist, or when a plugin id fails the same installed-plugin
- * gates as discovery (directory, `package.json` manifest, not disabled).
+ * gates as discovery (directory, `package.json` manifest, enabled and ready).
  */
 export function resolveAppSource(id: string): ResolvedAppSource | null {
   if (id.startsWith(PLUGIN_APP_ID_PREFIX)) {
@@ -894,7 +894,7 @@ export function resolveAppSource(id: string): ResolvedAppSource | null {
     if (!existsSync(join(pluginDir, "package.json"))) {
       return null;
     }
-    if (isPluginDisabled(pluginName)) {
+    if (isPluginDisabled(pluginName) || !isPluginReady(pluginName)) {
       return null;
     }
     const sourceDir = join(pluginDir, "apps", appDirName);

--- a/assistant/src/channels/__tests__/plugin-channel-declarations.test.ts
+++ b/assistant/src/channels/__tests__/plugin-channel-declarations.test.ts
@@ -11,6 +11,7 @@ import { join } from "node:path";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 const workspacePluginsDir = mkdtempSync(join(tmpdir(), "plugin-channels-"));
+const readyPlugins = new Set<string>();
 
 const realPlatform = await import("../../util/platform.js");
 
@@ -19,9 +20,12 @@ mock.module("../../util/platform.js", () => ({
   getWorkspacePluginsDir: () => workspacePluginsDir,
 }));
 
-const { discoverPluginChannels } = await import(
-  "../plugin-channel-declarations.js"
-);
+mock.module("../../plugins/plugin-readiness.js", () => ({
+  isPluginReady: (pluginId: string) => readyPlugins.has(pluginId),
+}));
+
+const { discoverPluginChannels } =
+  await import("../plugin-channel-declarations.js");
 
 interface PluginOptions {
   /** Contents of `channels/ingress.json`; omit for a plugin with no ingress. */
@@ -44,10 +48,12 @@ function writePlugin(name: string, options: PluginOptions = {}): string {
     mkdirSync(join(dir, "channels"), { recursive: true });
     writeFileSync(join(dir, "channels", "ingress.json"), options.ingress);
   }
+  readyPlugins.add(name);
   return dir;
 }
 
 beforeEach(() => {
+  readyPlugins.clear();
   rmSync(workspacePluginsDir, { recursive: true, force: true });
   mkdirSync(workspacePluginsDir, { recursive: true });
 });
@@ -109,6 +115,13 @@ describe("discoverPluginChannels", () => {
     // disabled plugin would otherwise offer a setup flow that cannot run.
     const dir = writePlugin("courier", { ingress: INGRESS });
     writeFileSync(join(dir, ".disabled"), "");
+
+    expect(await discoverPluginChannels()).toEqual([]);
+  });
+
+  test("skips a channel until the plugin is ready", async () => {
+    writePlugin("courier", { ingress: INGRESS });
+    readyPlugins.clear();
 
     expect(await discoverPluginChannels()).toEqual([]);
   });

--- a/assistant/src/channels/__tests__/plugin-channel-declarations.test.ts
+++ b/assistant/src/channels/__tests__/plugin-channel-declarations.test.ts
@@ -10,18 +10,17 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
-const workspacePluginsDir = mkdtempSync(join(tmpdir(), "plugin-channels-"));
-const readyPlugins = new Set<string>();
+import {
+  markPluginReady,
+  resetPluginReadinessForTests,
+} from "../../plugins/plugin-readiness.js";
 
+const workspacePluginsDir = mkdtempSync(join(tmpdir(), "plugin-channels-"));
 const realPlatform = await import("../../util/platform.js");
 
 mock.module("../../util/platform.js", () => ({
   ...realPlatform,
   getWorkspacePluginsDir: () => workspacePluginsDir,
-}));
-
-mock.module("../../plugins/plugin-readiness.js", () => ({
-  isPluginReady: (pluginId: string) => readyPlugins.has(pluginId),
 }));
 
 const { discoverPluginChannels } =
@@ -31,6 +30,7 @@ interface PluginOptions {
   /** Contents of `channels/ingress.json`; omit for a plugin with no ingress. */
   ingress?: string;
   manifest?: Record<string, unknown>;
+  optsIntoReadiness?: boolean;
 }
 
 const INGRESS = JSON.stringify({
@@ -42,18 +42,33 @@ function writePlugin(name: string, options: PluginOptions = {}): string {
   mkdirSync(dir, { recursive: true });
   writeFileSync(
     join(dir, "package.json"),
-    JSON.stringify({ name, ...options.manifest }),
+    JSON.stringify({
+      name,
+      ...(options.optsIntoReadiness
+        ? { peerDependencies: { "@vellumai/plugin-api": "*" } }
+        : {}),
+      ...options.manifest,
+    }),
   );
+  if (options.optsIntoReadiness) {
+    writeFileSync(
+      join(dir, "host-requirements.json"),
+      JSON.stringify({
+        schemaVersion: 1,
+        requires: { "plugins.readiness": "^1.0.0" },
+      }),
+    );
+  }
   if (options.ingress !== undefined) {
     mkdirSync(join(dir, "channels"), { recursive: true });
     writeFileSync(join(dir, "channels", "ingress.json"), options.ingress);
   }
-  readyPlugins.add(name);
+  markPluginReady(name, "a".repeat(64));
   return dir;
 }
 
 beforeEach(() => {
-  readyPlugins.clear();
+  resetPluginReadinessForTests();
   rmSync(workspacePluginsDir, { recursive: true, force: true });
   mkdirSync(workspacePluginsDir, { recursive: true });
 });
@@ -120,10 +135,17 @@ describe("discoverPluginChannels", () => {
   });
 
   test("skips a channel until the plugin is ready", async () => {
-    writePlugin("courier", { ingress: INGRESS });
-    readyPlugins.clear();
+    writePlugin("courier", { ingress: INGRESS, optsIntoReadiness: true });
+    resetPluginReadinessForTests();
 
     expect(await discoverPluginChannels()).toEqual([]);
+  });
+
+  test("keeps a legacy channel visible without readiness state", async () => {
+    writePlugin("courier", { ingress: INGRESS });
+    resetPluginReadinessForTests();
+
+    expect((await discoverPluginChannels())[0]?.id).toBe("courier");
   });
 
   test("refuses to let a plugin take a built-in channel's id", async () => {

--- a/assistant/src/channels/plugin-channel-declarations.ts
+++ b/assistant/src/channels/plugin-channel-declarations.ts
@@ -26,7 +26,7 @@ import { join } from "node:path";
 import { isPluginDisabled } from "../plugins/disabled-state.js";
 import { parsePluginPresentation } from "../plugins/external-plugin-loader.js";
 import { listInstalledPluginDirs } from "../plugins/installed-plugin-dirs.js";
-import { isPluginReady } from "../plugins/plugin-readiness.js";
+import { isPluginSurfaceReady } from "../plugins/plugin-readiness.js";
 import { type AvailableChannel, isChannelId } from "./types.js";
 
 /**
@@ -80,7 +80,7 @@ export async function discoverPluginChannels(): Promise<AvailableChannel[]> {
   for (const { name, dir } of listInstalledPluginDirs()) {
     if (
       isPluginDisabled(name) ||
-      !isPluginReady(name) ||
+      !isPluginSurfaceReady(name, dir) ||
       isChannelId(name) ||
       !declaresIngress(dir)
     ) {

--- a/assistant/src/channels/plugin-channel-declarations.ts
+++ b/assistant/src/channels/plugin-channel-declarations.ts
@@ -26,6 +26,7 @@ import { join } from "node:path";
 import { isPluginDisabled } from "../plugins/disabled-state.js";
 import { parsePluginPresentation } from "../plugins/external-plugin-loader.js";
 import { listInstalledPluginDirs } from "../plugins/installed-plugin-dirs.js";
+import { isPluginReady } from "../plugins/plugin-readiness.js";
 import { type AvailableChannel, isChannelId } from "./types.js";
 
 /**
@@ -62,16 +63,14 @@ function declaresIngress(pluginDir: string): boolean {
 }
 
 /**
- * Every channel brought by an installed, enabled plugin.
+ * Every channel brought by an installed, ready plugin.
  *
  * A plugin whose directory name is one of the assistant's own channels is
  * skipped: two rows sharing an id would be ambiguous to any client keying on
  * one, and the resolution that lets a plugin win would let it impersonate a
  * built-in channel. The assistant's keep the name.
  *
- * Disabled plugins are skipped too, matching the source of truth the loader
- * uses for hooks, tools and routes: a disabled plugin holds no ingress either,
- * and one that reappeared here would offer a setup flow that cannot run.
+ * Disabled and unready plugins are skipped because their ingress cannot run.
  *
  * Order follows the plugins directory, and is stable for a stable install set.
  */
@@ -79,7 +78,12 @@ export async function discoverPluginChannels(): Promise<AvailableChannel[]> {
   const channels: AvailableChannel[] = [];
 
   for (const { name, dir } of listInstalledPluginDirs()) {
-    if (isPluginDisabled(name) || isChannelId(name) || !declaresIngress(dir)) {
+    if (
+      isPluginDisabled(name) ||
+      !isPluginReady(name) ||
+      isChannelId(name) ||
+      !declaresIngress(dir)
+    ) {
       continue;
     }
     const presentation = await parsePluginPresentation(dir);

--- a/assistant/src/cli/lib/__tests__/publish-plugin.test.ts
+++ b/assistant/src/cli/lib/__tests__/publish-plugin.test.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { describe, expect, it } from "bun:test";
 
 import {
@@ -10,6 +10,7 @@ import {
   formatPayloadForPrint,
   formatPublishResult,
   formatValidationResult,
+  inventoryPluginSurfaces,
   type ParsedPackageJson,
   type PublishValidation,
   runPublish,
@@ -201,7 +202,7 @@ describe("validatePluginForPublish", () => {
     const result = validatePluginForPublish(dir);
     expect(result.valid).toBe(true);
     expect(result.warnings.length).toBeGreaterThan(0);
-    expect(result.warnings.some((w) => w.includes("No hooks/"))).toBe(true);
+    expect(result.warnings.some((w) => w.includes("No supported"))).toBe(true);
     rmSync(dir, { recursive: true });
   });
 
@@ -212,6 +213,136 @@ describe("validatePluginForPublish", () => {
     const result = validatePluginForPublish(dir);
     expect(result.valid).toBe(true);
     expect(result.warnings.some((w) => w.includes("orphan.js"))).toBe(true);
+    rmSync(dir, { recursive: true });
+  });
+
+  it("inventories and validates every supported external plugin surface", () => {
+    const dir = makePluginDir(tmpdir(), validPkg);
+    const write = (relativePath: string, contents: string): void => {
+      const path = join(dir, relativePath);
+      mkdirSync(dirname(path), { recursive: true });
+      writeFileSync(path, contents);
+    };
+
+    write("hooks/init.ts", 'throw new Error("must not import");');
+    write("tools/ping.ts", 'throw new Error("must not import");');
+    write("routes/capabilities.ts", 'throw new Error("must not import");');
+    write(
+      "routes/manifest.json",
+      JSON.stringify({
+        schemaVersion: 1,
+        routes: [
+          {
+            path: "capabilities",
+            method: "GET",
+            authorization: {
+              principal: "actor",
+              requiredScopes: ["settings.read"],
+            },
+          },
+        ],
+      }),
+    );
+    write(
+      "workers/outbox.ts",
+      'throw new Error("must not import"); export default async function run() {}',
+    );
+    write("apps/connections/src/index.html", "<main></main>");
+    write(
+      "skills/contact-assistant/SKILL.md",
+      "---\nname: contact-assistant\ndescription: Contact another assistant.\n---\n\nInstructions.\n",
+    );
+    write(
+      "schedules/digest/config.json",
+      JSON.stringify({ expression: "0 9 * * *" }),
+    );
+    write("schedules/digest/index.md", "Summarize the day.\n");
+    write(
+      "channels/ingress.json",
+      JSON.stringify({
+        routes: [
+          { path: "events", kind: "http", description: "Inbound events" },
+        ],
+      }),
+    );
+    write(
+      "host-requirements.json",
+      JSON.stringify({ schemaVersion: 1, requires: {} }),
+    );
+    write(
+      "ui/contacts-detail.json",
+      JSON.stringify({ schemaVersion: 1, sections: [] }),
+    );
+    write(
+      "ui/locales/en.json",
+      JSON.stringify({ "contacts.title": "Collaboration" }),
+    );
+
+    const result = validatePluginForPublish(dir);
+    expect(result.valid).toBe(true);
+    expect(result.issues).toEqual([]);
+    expect(inventoryPluginSurfaces(dir)).toEqual({
+      hooks: ["init.ts"],
+      tools: ["ping.ts"],
+      routes: ["manifest.json", "capabilities.ts"],
+      workers: ["outbox.ts"],
+      apps: ["connections"],
+      skills: ["contact-assistant"],
+      schedules: ["digest"],
+      ingress: ["channels/ingress.json"],
+      hostRequirements: ["host-requirements.json"],
+      uiDescriptors: ["contacts-detail.json", "locales/en.json"],
+    });
+    rmSync(dir, { recursive: true });
+  });
+
+  it("reports malformed declarative and executable surface contracts", () => {
+    const dir = makePluginDir(tmpdir(), validPkg);
+    const write = (relativePath: string, contents: string): void => {
+      const path = join(dir, relativePath);
+      mkdirSync(dirname(path), { recursive: true });
+      writeFileSync(path, contents);
+    };
+
+    write("workers/outbox.ts", "export function run() {}");
+    write("apps/connections/README.md", "missing source");
+    write("skills/contact-assistant/SKILL.md", "missing frontmatter");
+    write("schedules/digest/index.py", "print('unsupported')");
+    write("channels/ingress.json", JSON.stringify({ routes: [{}] }));
+    write(
+      "routes/manifest.json",
+      JSON.stringify({
+        schemaVersion: 1,
+        routes: [
+          {
+            path: "settings",
+            method: "POST",
+            authorization: { principal: "actor", requiredScopes: ["admin"] },
+          },
+        ],
+      }),
+    );
+    write(
+      "host-requirements.json",
+      JSON.stringify({
+        schemaVersion: 1,
+        requires: { "plugins.readiness": "not-a-range" },
+      }),
+    );
+    write("ui/contacts-detail.json", JSON.stringify(["not", "an", "object"]));
+
+    const result = validatePluginForPublish(dir);
+    expect(result.valid).toBe(false);
+    expect(result.issues.join("\n")).toContain("host-requirements.json");
+    expect(result.issues.join("\n")).toContain("routes/manifest.json");
+    expect(result.issues.join("\n")).toContain("default plugin worker");
+    expect(result.issues.join("\n")).toContain("apps/connections");
+    expect(result.issues.join("\n")).toContain("must contain frontmatter");
+    expect(result.issues.join("\n")).toContain("schedules/digest:");
+    expect(result.issues.join("\n")).toContain("channels/ingress.json route 0");
+    expect(result.issues.join("\n")).toContain(
+      "ui/contacts-detail.json must contain a JSON object",
+    );
     rmSync(dir, { recursive: true });
   });
 });

--- a/assistant/src/cli/lib/__tests__/uninstall-plugin.test.ts
+++ b/assistant/src/cli/lib/__tests__/uninstall-plugin.test.ts
@@ -24,6 +24,10 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { resetHookCacheForTests } from "../../../hooks/hook-loader.js";
+import {
+  resetPluginWorkerRunnerForTests,
+  startPluginWorkers,
+} from "../../../plugins/plugin-worker-runner.js";
 import { getWorkspacePluginsDir } from "../../../util/platform.js";
 import { InvalidPluginNameError } from "../install-from-github.js";
 import {
@@ -40,7 +44,8 @@ beforeEach(() => {
   resetHookCacheForTests();
 });
 
-afterEach(() => {
+afterEach(async () => {
+  await resetPluginWorkerRunnerForTests();
   rmSync(pluginsDir, { recursive: true, force: true });
 });
 
@@ -94,6 +99,51 @@ describe("uninstallPlugin", () => {
     expect(existsSync(target)).toBe(false);
     expect(existsSync(marker)).toBe(true);
     expect(readFileSync(marker, "utf8")).toBe("uninstall");
+  });
+
+  test("stops plugin workers before running shutdown", async () => {
+    const target = writePlugin("worker-shutdown-order");
+    const marker = join(pluginsDir, "shutdown-worker-state.txt");
+    const startedMarker = join(target, "data", "worker-started.txt");
+    const stoppedMarker = join(target, "data", "worker-stopped.txt");
+    mkdirSync(join(target, "workers"), { recursive: true });
+    writeFileSync(
+      join(target, "workers", "blocking.ts"),
+      `import { writeFileSync } from "node:fs";
+export default async (ctx: { pluginStorageDir: string; signal: AbortSignal }) => {
+  writeFileSync(ctx.pluginStorageDir + "/worker-started.txt", "yes");
+  await new Promise<void>((resolve) => {
+    ctx.signal.addEventListener("abort", () => {
+      writeFileSync(ctx.pluginStorageDir + "/worker-stopped.txt", "yes");
+      resolve();
+    }, { once: true });
+  });
+};\n`,
+    );
+    writeFileSync(
+      join(target, "hooks", "shutdown.ts"),
+      `import { existsSync, writeFileSync } from "node:fs";\n` +
+        `export default () => {\n` +
+        `  writeFileSync(${JSON.stringify(marker)}, String(existsSync(${JSON.stringify(stoppedMarker)})));\n` +
+        `};\n`,
+    );
+
+    const activation = startPluginWorkers(target);
+    const deadline = Date.now() + 1_000;
+    while (!existsSync(startedMarker)) {
+      if (Date.now() > deadline) {
+        throw new Error("timed out waiting for plugin worker to start");
+      }
+      await new Promise<void>((resolve) => setTimeout(resolve, 1));
+    }
+
+    await uninstallPlugin({
+      name: "worker-shutdown-order",
+      workspacePluginsDir: pluginsDir,
+    });
+    await activation;
+
+    expect(readFileSync(marker, "utf8")).toBe("true");
   });
 
   test("throws PluginNotInstalledError when no directory exists", async () => {
@@ -161,6 +211,40 @@ describe("uninstallPlugin", () => {
     expect(existsSync(target)).toBe(false);
     // The shutdown hook must NOT have run — a disabled plugin's code
     // should never execute, including during uninstall.
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  test("does not import shutdown for an incompatible plugin", async () => {
+    const target = writePlugin("incompatible-plugin");
+    const marker = join(pluginsDir, "shutdown-imported.txt");
+    writeFileSync(
+      join(target, "package.json"),
+      JSON.stringify({
+        name: "incompatible-plugin",
+        version: "0.0.1",
+        peerDependencies: { "@vellumai/plugin-api": "*" },
+      }),
+    );
+    writeFileSync(
+      join(target, "host-requirements.json"),
+      JSON.stringify({
+        schemaVersion: 1,
+        requires: { "plugins.unsupported": "1.x" },
+      }),
+    );
+    writeFileSync(
+      join(target, "hooks", "shutdown.ts"),
+      `import { writeFileSync } from "node:fs";\n` +
+        `writeFileSync(${JSON.stringify(marker)}, "imported");\n` +
+        `export default () => {};\n`,
+    );
+
+    await uninstallPlugin({
+      name: "incompatible-plugin",
+      workspacePluginsDir: pluginsDir,
+    });
+
+    expect(existsSync(target)).toBe(false);
     expect(existsSync(marker)).toBe(false);
   });
 

--- a/assistant/src/cli/lib/publish-plugin.ts
+++ b/assistant/src/cli/lib/publish-plugin.ts
@@ -17,7 +17,10 @@ import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
 import { promisify } from "node:util";
 
-import { readHostRequirements } from "../../plugins/host-requirements.js";
+import {
+  HOST_REQUIREMENTS_FILENAME,
+  readHostRequirements,
+} from "../../plugins/host-requirements.js";
 import { readPluginRouteManifest } from "../../plugins/plugin-route-manifest.js";
 import { walkPluginTree } from "../../plugins/plugin-tree-walk.js";
 import { parsePluginScheduleDeclarations } from "../../schedule/plugin-schedule-declarations.js";
@@ -168,7 +171,7 @@ export function inventoryPluginSurfaces(
     existsSync(join(pluginDir, "skills", id, "SKILL.md")),
   );
   const ingressPath = join(pluginDir, "channels", "ingress.json");
-  const requirementsPath = join(pluginDir, "host-requirements.json");
+  const requirementsPath = join(pluginDir, HOST_REQUIREMENTS_FILENAME);
   const routeManifestPath = join(pluginDir, "routes", "manifest.json");
 
   return {
@@ -184,7 +187,7 @@ export function inventoryPluginSurfaces(
     schedules: listImmediateDirectories(join(pluginDir, "schedules")),
     ingress: existsSync(ingressPath) ? ["channels/ingress.json"] : [],
     hostRequirements: existsSync(requirementsPath)
-      ? ["host-requirements.json"]
+      ? [HOST_REQUIREMENTS_FILENAME]
       : [],
     uiDescriptors: listRecursiveFiles(join(pluginDir, "ui"), (path) =>
       path.endsWith(".json"),

--- a/assistant/src/cli/lib/publish-plugin.ts
+++ b/assistant/src/cli/lib/publish-plugin.ts
@@ -13,9 +13,18 @@
  */
 
 import { execFile } from "node:child_process";
-import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
 import { promisify } from "node:util";
+
+import { readHostRequirements } from "../../plugins/host-requirements.js";
+import { readPluginRouteManifest } from "../../plugins/plugin-route-manifest.js";
+import { walkPluginTree } from "../../plugins/plugin-tree-walk.js";
+import { parsePluginScheduleDeclarations } from "../../schedule/plugin-schedule-declarations.js";
+import {
+  FRONTMATTER_REGEX,
+  parseFrontmatterFields,
+} from "../../skills/frontmatter.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -29,6 +38,21 @@ export interface PublishValidation {
   warnings: string[];
   packageJson: ParsedPackageJson;
   pluginDir: string;
+  /** Static inventory collected without importing plugin code. */
+  surfaces?: PublishSurfaceInventory;
+}
+
+export interface PublishSurfaceInventory {
+  readonly hooks: readonly string[];
+  readonly tools: readonly string[];
+  readonly routes: readonly string[];
+  readonly workers: readonly string[];
+  readonly apps: readonly string[];
+  readonly skills: readonly string[];
+  readonly schedules: readonly string[];
+  readonly ingress: readonly string[];
+  readonly hostRequirements: readonly string[];
+  readonly uiDescriptors: readonly string[];
 }
 
 export interface ParsedPackageJson {
@@ -83,6 +107,321 @@ export interface PublishDeps {
 // Plugin discovery + validation
 // ---------------------------------------------------------------------------
 
+const CODE_SURFACE_DIRS = ["hooks", "tools", "routes", "workers"] as const;
+const MAX_DESCRIPTOR_BYTES = 256 * 1024;
+const MAX_DESCRIPTOR_DEPTH = 12;
+const MAX_DESCRIPTOR_NODES = 5_000;
+const MAX_DESCRIPTOR_STRING_LENGTH = 32_768;
+
+function isModuleFile(name: string): boolean {
+  return (
+    !name.endsWith(".d.ts") && (name.endsWith(".ts") || name.endsWith(".js"))
+  );
+}
+
+function isDirectory(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function listDirectModules(dir: string): string[] {
+  try {
+    return readdirSync(dir)
+      .filter((entry) => isModuleFile(entry))
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+function listImmediateDirectories(dir: string): string[] {
+  try {
+    return readdirSync(dir)
+      .filter((entry) => isDirectory(join(dir, entry)))
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+function listRecursiveFiles(
+  root: string,
+  include: (relativePath: string) => boolean,
+): string[] {
+  const files: string[] = [];
+  walkPluginTree(root, { bestEffort: true }, (relativePath) => {
+    if (include(relativePath)) {
+      files.push(relativePath);
+    }
+  });
+  return files.sort();
+}
+
+export function inventoryPluginSurfaces(
+  pluginDir: string,
+): PublishSurfaceInventory {
+  const skillDirs = listImmediateDirectories(join(pluginDir, "skills"));
+  const skills = skillDirs.filter((id) =>
+    existsSync(join(pluginDir, "skills", id, "SKILL.md")),
+  );
+  const ingressPath = join(pluginDir, "channels", "ingress.json");
+  const requirementsPath = join(pluginDir, "host-requirements.json");
+  const routeManifestPath = join(pluginDir, "routes", "manifest.json");
+
+  return {
+    hooks: listDirectModules(join(pluginDir, "hooks")),
+    tools: listDirectModules(join(pluginDir, "tools")),
+    routes: [
+      ...(existsSync(routeManifestPath) ? ["manifest.json"] : []),
+      ...listRecursiveFiles(join(pluginDir, "routes"), isModuleFile),
+    ],
+    workers: listDirectModules(join(pluginDir, "workers")),
+    apps: listImmediateDirectories(join(pluginDir, "apps")),
+    skills,
+    schedules: listImmediateDirectories(join(pluginDir, "schedules")),
+    ingress: existsSync(ingressPath) ? ["channels/ingress.json"] : [],
+    hostRequirements: existsSync(requirementsPath)
+      ? ["host-requirements.json"]
+      : [],
+    uiDescriptors: listRecursiveFiles(join(pluginDir, "ui"), (path) =>
+      path.endsWith(".json"),
+    ),
+  };
+}
+
+function readJsonDescriptor(
+  path: string,
+  label: string,
+  issues: string[],
+): unknown | undefined {
+  let size: number;
+  try {
+    size = statSync(path).size;
+  } catch (err) {
+    issues.push(
+      `${label} cannot be read: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return undefined;
+  }
+  if (size > MAX_DESCRIPTOR_BYTES) {
+    issues.push(`${label} exceeds ${MAX_DESCRIPTOR_BYTES} bytes`);
+    return undefined;
+  }
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch (err) {
+    issues.push(
+      `${label} is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return undefined;
+  }
+}
+
+function descriptorBoundsError(value: unknown): string | undefined {
+  let nodes = 0;
+
+  function visit(current: unknown, depth: number): string | undefined {
+    nodes += 1;
+    if (nodes > MAX_DESCRIPTOR_NODES) {
+      return `contains more than ${MAX_DESCRIPTOR_NODES} values`;
+    }
+    if (depth > MAX_DESCRIPTOR_DEPTH) {
+      return `is nested more than ${MAX_DESCRIPTOR_DEPTH} levels`;
+    }
+    if (typeof current === "string") {
+      return current.length > MAX_DESCRIPTOR_STRING_LENGTH
+        ? `contains a string longer than ${MAX_DESCRIPTOR_STRING_LENGTH} characters`
+        : undefined;
+    }
+    if (Array.isArray(current)) {
+      for (const item of current) {
+        const error = visit(item, depth + 1);
+        if (error) {
+          return error;
+        }
+      }
+      return undefined;
+    }
+    if (current !== null && typeof current === "object") {
+      for (const [key, item] of Object.entries(current)) {
+        if (key.length > 256) {
+          return "contains an object key longer than 256 characters";
+        }
+        const error = visit(item, depth + 1);
+        if (error) {
+          return error;
+        }
+      }
+    }
+    return undefined;
+  }
+
+  return visit(value, 0);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function validateBoundedObjectDescriptor(
+  path: string,
+  label: string,
+  issues: string[],
+): Record<string, unknown> | undefined {
+  const value = readJsonDescriptor(path, label, issues);
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!isRecord(value)) {
+    issues.push(`${label} must contain a JSON object`);
+    return undefined;
+  }
+  const boundsError = descriptorBoundsError(value);
+  if (boundsError) {
+    issues.push(`${label} ${boundsError}`);
+    return undefined;
+  }
+  return value;
+}
+
+function validateRouteManifest(pluginDir: string, issues: string[]): void {
+  const manifest = readPluginRouteManifest(pluginDir);
+  if (manifest.kind === "invalid") {
+    issues.push(`routes/manifest.json is invalid: ${manifest.reason}`);
+  }
+}
+
+function validateIngressManifest(pluginDir: string, issues: string[]): void {
+  const path = join(pluginDir, "channels", "ingress.json");
+  if (!existsSync(path)) {
+    return;
+  }
+  const raw = validateBoundedObjectDescriptor(
+    path,
+    "channels/ingress.json",
+    issues,
+  );
+  if (!raw) {
+    return;
+  }
+  if (!Array.isArray(raw.routes) || raw.routes.length === 0) {
+    issues.push("channels/ingress.json must declare a non-empty routes array");
+    return;
+  }
+  for (const [index, route] of raw.routes.entries()) {
+    if (
+      !isRecord(route) ||
+      typeof route.path !== "string" ||
+      route.path.length === 0 ||
+      (route.kind !== "http" && route.kind !== "websocket") ||
+      typeof route.description !== "string" ||
+      route.description.length === 0
+    ) {
+      issues.push(`channels/ingress.json route ${index} has an invalid shape`);
+    }
+  }
+}
+
+function validateWorkerModules(pluginDir: string, issues: string[]): void {
+  for (const file of listDirectModules(join(pluginDir, "workers"))) {
+    const path = join(pluginDir, "workers", file);
+    let source: string;
+    try {
+      source = readFileSync(path, "utf8");
+    } catch (err) {
+      issues.push(
+        `workers/${file} cannot be read: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      continue;
+    }
+    if (
+      !/\bexport\s+default\b/.test(source) &&
+      !/\bexport\s*{[^}]*\bas\s+default\b/s.test(source)
+    ) {
+      issues.push(`workers/${file} must export a default plugin worker`);
+    }
+  }
+}
+
+function validateScheduleDeclarations(
+  pluginDir: string,
+  issues: string[],
+): void {
+  const parsed = parsePluginScheduleDeclarations(
+    pluginDir,
+    basename(pluginDir),
+  );
+  for (const error of parsed.errors) {
+    issues.push(`schedules/${error.scheduleName}: ${error.reason}`);
+  }
+}
+
+function validateAppDirectories(
+  pluginDir: string,
+  apps: readonly string[],
+  issues: string[],
+): void {
+  for (const app of apps) {
+    const appDir = join(pluginDir, "apps", app);
+    if (
+      !isDirectory(join(appDir, "src")) &&
+      !existsSync(join(appDir, "index.html"))
+    ) {
+      issues.push(`apps/${app} must contain src/ or index.html`);
+    }
+  }
+}
+
+function validateSkillDirectories(pluginDir: string, issues: string[]): void {
+  for (const skill of listImmediateDirectories(join(pluginDir, "skills"))) {
+    const path = join(pluginDir, "skills", skill, "SKILL.md");
+    if (!existsSync(path)) {
+      issues.push(`skills/${skill} must contain SKILL.md`);
+      continue;
+    }
+    try {
+      const source = readFileSync(path, "utf8");
+      const parsed = parseFrontmatterFields(source);
+      if (parsed === null && FRONTMATTER_REGEX.test(source)) {
+        issues.push(`skills/${skill}/SKILL.md has invalid frontmatter`);
+      } else if (parsed === null) {
+        issues.push(`skills/${skill}/SKILL.md must contain frontmatter`);
+      }
+    } catch (err) {
+      issues.push(
+        `skills/${skill}/SKILL.md cannot be read: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+}
+
+function validateStaticSurfaces(
+  pluginDir: string,
+  surfaces: PublishSurfaceInventory,
+  issues: string[],
+): void {
+  const requirements = readHostRequirements(pluginDir);
+  if (requirements.kind === "invalid") {
+    issues.push(`host-requirements.json is invalid: ${requirements.reason}`);
+  }
+  validateRouteManifest(pluginDir, issues);
+  validateWorkerModules(pluginDir, issues);
+  validateAppDirectories(pluginDir, surfaces.apps, issues);
+  validateSkillDirectories(pluginDir, issues);
+  validateScheduleDeclarations(pluginDir, issues);
+  validateIngressManifest(pluginDir, issues);
+  for (const descriptor of surfaces.uiDescriptors) {
+    validateBoundedObjectDescriptor(
+      join(pluginDir, "ui", descriptor),
+      `ui/${descriptor}`,
+      issues,
+    );
+  }
+}
+
 /**
  * Walk up from `startDir` to find the nearest directory containing a
  * `package.json`. Returns the directory path, or `null` if none is found
@@ -107,12 +446,13 @@ export function findPluginRoot(startDir: string): string | null {
  *
  * Checks the same things the review team will verify:
  * - package.json exists with name, version, and @vellumai/plugin-api peer dep
- * - At least one surface directory (hooks/, tools/, skills/) has entries
+ * - Every supported plugin surface is inventoried and statically validated
  * - No stale .js artifacts without matching .ts source
  */
 export function validatePluginForPublish(dir: string): PublishValidation {
   const issues: string[] = [];
   const warnings: string[] = [];
+  const surfaces = inventoryPluginSurfaces(dir);
 
   const pkgPath = join(dir, "package.json");
   if (!existsSync(pkgPath)) {
@@ -122,6 +462,7 @@ export function validatePluginForPublish(dir: string): PublishValidation {
       warnings: [],
       packageJson: {},
       pluginDir: dir,
+      surfaces,
     };
   }
 
@@ -135,6 +476,7 @@ export function validatePluginForPublish(dir: string): PublishValidation {
       warnings: [],
       packageJson: {},
       pluginDir: dir,
+      surfaces,
     };
   }
 
@@ -157,26 +499,24 @@ export function validatePluginForPublish(dir: string): PublishValidation {
     );
   }
 
-  // Check for at least one surface directory with entries
-  const surfaceDirs = ["hooks", "tools", "skills"];
-  const hasAnySurface = surfaceDirs.some((d) => {
-    const dirPath = join(dir, d);
-    return existsSync(dirPath) && readdirSync(dirPath).length > 0;
-  });
+  const hasAnySurface = Object.values(surfaces).some(
+    (surface) => surface.length > 0,
+  );
   if (!hasAnySurface) {
     warnings.push(
-      "No hooks/, tools/, or skills/ directories with entries found. The plugin may not contribute any surfaces.",
+      "No supported plugin surfaces found. The plugin may not contribute anything.",
     );
   }
 
   // Check for stale .js without matching .ts
-  for (const d of surfaceDirs) {
+  for (const d of CODE_SURFACE_DIRS) {
     const dirPath = join(dir, d);
-    if (!existsSync(dirPath)) {
-      continue;
-    }
-    for (const file of readdirSync(dirPath)) {
-      if (file.endsWith(".js") && !file.endsWith(".d.ts")) {
+    const files =
+      d === "routes"
+        ? listRecursiveFiles(dirPath, isModuleFile)
+        : listDirectModules(dirPath);
+    for (const file of files) {
+      if (file.endsWith(".js")) {
         const tsFile = file.replace(/\.js$/, ".ts");
         if (!existsSync(join(dirPath, tsFile))) {
           warnings.push(`Stale .js found without matching .ts: ${d}/${file}`);
@@ -185,12 +525,15 @@ export function validatePluginForPublish(dir: string): PublishValidation {
     }
   }
 
+  validateStaticSurfaces(dir, surfaces, issues);
+
   return {
     valid: issues.length === 0,
     issues,
     warnings,
     packageJson: pkg,
     pluginDir: dir,
+    surfaces,
   };
 }
 
@@ -642,7 +985,7 @@ export function formatPublishResult(result: PublishResult): string {
     "  • Pinned commit is reachable and public",
     "  • package.json has @vellumai/plugin-api peer dependency",
     "  • Plugin loads cleanly (hooks register, tools validate)",
-    "  • Surfaces contribute on boot (not silently failing)",
+    "  • Declarative routes, workers, apps, skills, schedules, ingress, requirements, and UI validate",
     "",
     "You'll get a notification when the review is complete.",
   ];

--- a/assistant/src/cli/lib/uninstall-plugin.ts
+++ b/assistant/src/cli/lib/uninstall-plugin.ts
@@ -15,7 +15,9 @@ import { existsSync, rmSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 import { runShutdownHook } from "../../hooks/hook-loader.js";
+import { getPluginActivationEligibility } from "../../plugins/activation-eligibility.js";
 import { isPluginDisabled } from "../../plugins/disabled-state.js";
+import { stopPluginWorkers } from "../../plugins/plugin-worker-runner.js";
 import { getWorkspacePluginsDir } from "../../util/platform.js";
 import {
   InvalidPluginNameError,
@@ -87,13 +89,21 @@ export async function uninstallPlugin(
     throw new PluginNotInstalledError(name, target);
   }
 
+  // Stop workers before shutdown and deletion so no durable work races either.
+  // This is unconditional because a disable and uninstall can overlap before
+  // the assistant has reconciled the `.disabled` sentinel.
+  await stopPluginWorkers(name);
+
   // Skip the shutdown hook when the plugin is disabled. A `.disabled` plugin
   // is never loaded — no hooks, tools, or init — so its shutdown was never
   // paired with an init. Running it on uninstall would be the first and only
   // execution of the plugin's code, which inverts the disabled contract and
   // is especially dangerous for untrusted/direct-installed plugins where
   // removal should never be the action that first runs plugin code.
-  if (!isPluginDisabled(name)) {
+  if (
+    !isPluginDisabled(name) &&
+    getPluginActivationEligibility(target).eligible
+  ) {
     await runShutdownHook("plugin", name, "uninstall");
   }
 

--- a/assistant/src/config/__tests__/default-plugin-skill-discovery.test.ts
+++ b/assistant/src/config/__tests__/default-plugin-skill-discovery.test.ts
@@ -19,6 +19,10 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { getDefaultPluginSkillRoots } from "../../plugins/defaults/main.js";
+import {
+  markPluginReady,
+  resetPluginReadinessForTests,
+} from "../../plugins/plugin-readiness.js";
 import { getWorkspacePluginsDir } from "../../util/platform.js";
 import {
   discoverDefaultPluginResidentSkills,
@@ -57,6 +61,7 @@ function writeWorkspacePlugin(dirName: string, skillIds: string[]): void {
     join(pluginDir, "package.json"),
     JSON.stringify({ name: dirName, version: "1.0.0" }),
   );
+  markPluginReady(dirName, "b".repeat(64));
   for (const id of skillIds) {
     const skillDir = join(pluginDir, "skills", id);
     mkdirSync(skillDir, { recursive: true });
@@ -76,6 +81,7 @@ function disablePlugin(pluginName: string): void {
 
 describe("default plugin resident skills", () => {
   beforeEach(() => {
+    resetPluginReadinessForTests();
     const pluginsDir = getWorkspacePluginsDir();
     if (existsSync(pluginsDir)) {
       rmSync(pluginsDir, { recursive: true, force: true });

--- a/assistant/src/config/__tests__/plugin-resident-skill-discovery.test.ts
+++ b/assistant/src/config/__tests__/plugin-resident-skill-discovery.test.ts
@@ -14,6 +14,10 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { beforeEach, describe, expect, test } from "bun:test";
 
+import {
+  markPluginReady,
+  resetPluginReadinessForTests,
+} from "../../plugins/plugin-readiness.js";
 import { getWorkspacePluginsDir } from "../../util/platform.js";
 import { loadSkillCatalog } from "../skills.js";
 
@@ -44,6 +48,8 @@ function writePlugin(
     writeFileSync(join(pluginDir, ".disabled"), "");
   }
 
+  markPluginReady(dirName, "c".repeat(64));
+
   for (const skill of skills) {
     const skillDir = join(pluginDir, "skills", skill.id);
     mkdirSync(skillDir, { recursive: true });
@@ -60,6 +66,7 @@ function skillById(id: string) {
 
 describe("discoverPluginResidentSkills (via loadSkillCatalog)", () => {
   beforeEach(() => {
+    resetPluginReadinessForTests();
     const pluginsDir = getWorkspacePluginsDir();
     if (existsSync(pluginsDir)) {
       rmSync(pluginsDir, { recursive: true, force: true });
@@ -136,5 +143,14 @@ describe("discoverPluginResidentSkills (via loadSkillCatalog)", () => {
     );
 
     expect(skillById("qa-disabled-skill")).toBeUndefined();
+  });
+
+  test("hides resident skills until the plugin is ready", () => {
+    writePlugin("initializing-plugin", "initializing-pkg", [
+      { id: "qa-initializing-skill", description: "Hidden during init." },
+    ]);
+    resetPluginReadinessForTests();
+
+    expect(skillById("qa-initializing-skill")).toBeUndefined();
   });
 });

--- a/assistant/src/config/__tests__/plugin-resident-skill-discovery.test.ts
+++ b/assistant/src/config/__tests__/plugin-resident-skill-discovery.test.ts
@@ -25,7 +25,11 @@ function writePlugin(
   dirName: string,
   packageName: string,
   skills: Array<{ id: string; description: string }>,
-  opts: { disabled?: boolean; packageJson?: string | null } = {},
+  opts: {
+    disabled?: boolean;
+    packageJson?: string | null;
+    optsIntoReadiness?: boolean;
+  } = {},
 ): void {
   const pluginDir = join(getWorkspacePluginsDir(), dirName);
   mkdirSync(pluginDir, { recursive: true });
@@ -46,6 +50,16 @@ function writePlugin(
 
   if (opts.disabled) {
     writeFileSync(join(pluginDir, ".disabled"), "");
+  }
+
+  if (opts.optsIntoReadiness) {
+    writeFileSync(
+      join(pluginDir, "host-requirements.json"),
+      JSON.stringify({
+        schemaVersion: 1,
+        requires: { "plugins.readiness": "^1.0.0" },
+      }),
+    );
   }
 
   markPluginReady(dirName, "c".repeat(64));
@@ -146,9 +160,12 @@ describe("discoverPluginResidentSkills (via loadSkillCatalog)", () => {
   });
 
   test("hides resident skills until the plugin is ready", () => {
-    writePlugin("initializing-plugin", "initializing-pkg", [
-      { id: "qa-initializing-skill", description: "Hidden during init." },
-    ]);
+    writePlugin(
+      "initializing-plugin",
+      "initializing-pkg",
+      [{ id: "qa-initializing-skill", description: "Hidden during init." }],
+      { optsIntoReadiness: true },
+    );
     resetPluginReadinessForTests();
 
     expect(skillById("qa-initializing-skill")).toBeUndefined();

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -20,6 +20,7 @@ import { z } from "zod";
 
 import { getDefaultPluginSkillRoots } from "../plugins/defaults/main.js";
 import { isPluginDisabled } from "../plugins/disabled-state.js";
+import { isPluginReady } from "../plugins/plugin-readiness.js";
 import { parseFrontmatterFields } from "../skills/frontmatter.js";
 import type { InlineCommandExpansion } from "../skills/inline-command-expansions.js";
 import { parseInlineCommandExpansions } from "../skills/inline-command-expansions.js";
@@ -872,10 +873,12 @@ function discoverInstalledPluginResidentSkills(): SkillSummary[] {
       continue;
     }
 
-    // Honor the `.disabled` sentinel the runtime plugin scan checks
-    // (`plugins/mtime-cache.ts`): a disabled plugin contributes no hooks or
-    // tools, so its resident skills must not be loadable either.
+    // A disabled plugin contributes no resident skills.
     if (existsSync(join(pluginDir, ".disabled"))) {
+      continue;
+    }
+
+    if (!isPluginReady(entry.name)) {
       continue;
     }
 

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -20,7 +20,7 @@ import { z } from "zod";
 
 import { getDefaultPluginSkillRoots } from "../plugins/defaults/main.js";
 import { isPluginDisabled } from "../plugins/disabled-state.js";
-import { isPluginReady } from "../plugins/plugin-readiness.js";
+import { isPluginSurfaceReady } from "../plugins/plugin-readiness.js";
 import { parseFrontmatterFields } from "../skills/frontmatter.js";
 import type { InlineCommandExpansion } from "../skills/inline-command-expansions.js";
 import { parseInlineCommandExpansions } from "../skills/inline-command-expansions.js";
@@ -878,7 +878,7 @@ function discoverInstalledPluginResidentSkills(): SkillSummary[] {
       continue;
     }
 
-    if (!isPluginReady(entry.name)) {
+    if (!isPluginSurfaceReady(entry.name, pluginDir)) {
       continue;
     }
 

--- a/assistant/src/daemon/external-plugins-bootstrap.ts
+++ b/assistant/src/daemon/external-plugins-bootstrap.ts
@@ -44,7 +44,7 @@
  * bring-up, via {@link teardownPlugin}.
  */
 
-import { existsSync, mkdirSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 
 import { getConfig } from "../config/loader.js";
@@ -61,6 +61,8 @@ import {
 } from "../plugins/injector-registry.js";
 import { registerDeclaredCredentialKeyPatterns } from "../plugins/mtime-cache.js";
 import { runInPluginContext } from "../plugins/plugin-execution-context.js";
+import { resetPluginReadinessForBoot } from "../plugins/plugin-readiness.js";
+import { resolvePluginStorageDir } from "../plugins/plugin-storage.js";
 import { getRegisteredPlugins, unregisterPlugin } from "../plugins/registry.js";
 import {
   type Plugin,
@@ -74,7 +76,7 @@ import {
   unregisterPluginTools,
 } from "../tools/registry.js";
 import { getLogger } from "../util/logger.js";
-import { getWorkspaceDir, getWorkspacePluginsDir } from "../util/platform.js";
+import { getWorkspacePluginsDir } from "../util/platform.js";
 import { APP_VERSION } from "../version.js";
 
 const log = getLogger("plugins-bootstrap");
@@ -124,15 +126,6 @@ function getPluginConfigRaw(
 }
 
 /**
- * Ensure `<workspaceDir>/plugins-data/<name>/` exists and return its absolute path.
- */
-function ensurePluginStorageDir(pluginName: string): string {
-  const dir = join(getWorkspaceDir(), "plugins-data", pluginName);
-  mkdirSync(dir, { recursive: true });
-  return dir;
-}
-
-/**
  * Bring the plugin layer up during daemon startup. Runs the full sequence in
  * the one order the rest of the system depends on:
  *
@@ -148,7 +141,15 @@ function ensurePluginStorageDir(pluginName: string): string {
  */
 export async function initializePlugins(): Promise<void> {
   registerDefaultPlugins();
-  await loadUserPlugins();
+  try {
+    resetPluginReadinessForBoot();
+    await loadUserPlugins();
+  } catch (err) {
+    log.error(
+      { err },
+      "External plugin readiness could not be initialized, skipping user plugins",
+    );
+  }
   try {
     await bootstrapPlugins();
   } catch (err) {
@@ -278,7 +279,7 @@ async function initializePlugin(
     const initContext = {
       config,
       logger: log.child({ plugin: name }),
-      pluginStorageDir: ensurePluginStorageDir(name),
+      pluginStorageDir: resolvePluginStorageDir(name, null),
       assistantVersion: APP_VERSION,
     };
 

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -15,6 +15,7 @@ import { stopQdrantManager } from "../persistence/embeddings/qdrant-manager.js";
 import { stopConsentRefresh } from "../platform/consent-cache.js";
 import { HOOKS } from "../plugin-api/constants.js";
 import { runHook } from "../plugins/pipeline.js";
+import { stopAllPluginWorkers } from "../plugins/plugin-worker-runner.js";
 import { stopRouteHost } from "../routes/control.js";
 import { stopRuntimeHttpServer } from "../runtime/http-server.js";
 import { stopScheduler } from "../schedule/scheduler.js";
@@ -102,6 +103,8 @@ async function shutdown(): Promise<void> {
 
   // Stop the periodic consent-cache refresh (a daemon-owned interval).
   await stopConsentRefresh();
+
+  await stopAllPluginWorkers();
 
   // Fire plugin / user / workspace / skill `shutdown` hooks through the unified
   // hook pipeline — the same dispatch path every other lifecycle hook uses —

--- a/assistant/src/hooks/hook-loader.ts
+++ b/assistant/src/hooks/hook-loader.ts
@@ -44,14 +44,7 @@
  * this module lets it sit below the plugin cache with no import cycle.
  */
 
-import {
-  cpSync,
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import type { HookEventOwner } from "../api/events/hook-event.js";
@@ -63,6 +56,7 @@ import type {
   ShutdownContext,
 } from "../plugin-api/types.js";
 import { listSurfaceDir } from "../plugins/external-plugin-loader.js";
+import { resolvePluginStorageDir } from "../plugins/plugin-storage.js";
 import {
   evictModule,
   importWithTimeout,
@@ -71,7 +65,6 @@ import {
 import type { HookEntry } from "../plugins/types.js";
 import { getLogger } from "../util/logger.js";
 import {
-  getWorkspaceDir,
   getWorkspaceHooksDir,
   getWorkspacePluginsDir,
 } from "../util/platform.js";
@@ -313,16 +306,18 @@ export function hasWorkspaceHooks(): boolean {
 export async function runInitHook(
   ownerName: string,
   pluginDir: string | null = null,
-): Promise<void> {
+): Promise<boolean> {
   // A plugin always has a directory; only the workspace owner passes `null`.
   const kind: HookOwnerKind = pluginDir === null ? "workspace" : "plugin";
 
-  const initHook = await resolveHook(kind, ownerName, HOOKS.INIT);
-  if (initHook === null) {
-    return;
-  }
-
   try {
+    const hasInitHook = listSurfaceDir(ownerHooksDir(kind, ownerName)).some(
+      (file) => file.name === HOOKS.INIT,
+    );
+    const initHook = await resolveHook(kind, ownerName, HOOKS.INIT);
+    if (initHook === null) {
+      return !hasInitHook;
+    }
     const initContext: InitContext = {
       config: resolvePluginConfig(ownerName, pluginDir),
       logger: log.child({ plugin: ownerName }),
@@ -331,11 +326,13 @@ export async function runInitHook(
     };
     await initHook(initContext);
     log.info({ plugin: ownerName }, "user hooks initialized");
+    return true;
   } catch (err) {
     log.error(
       { err, plugin: ownerName },
-      `User hooks for ${ownerName} init() failed — continuing`,
+      `User hooks for ${ownerName} init() failed`,
     );
+    return false;
   }
 }
 
@@ -415,11 +412,6 @@ export function clearPluginHooks(): void {
 const PLUGIN_CONFIG_FILENAME = "config.json";
 
 /**
- * Directory name for per-plugin runtime data inside the plugin directory.
- */
-const PLUGIN_DATA_DIRNAME = "data";
-
-/**
  * Resolve a plugin's config for the init context. For user plugins with a
  * `pluginDir`, config lives at `<pluginDir>/config.json`. If that file
  * doesn't exist yet but the old global config block (`config.plugins.<name>`)
@@ -471,62 +463,6 @@ function resolvePluginConfig(
     );
     return undefined;
   }
-}
-
-/**
- * Resolve a plugin's runtime data directory for the init context. For user
- * plugins with a `pluginDir`, data lives at `<pluginDir>/data/`. If that
- * directory doesn't exist but the old `<workspace>/plugins-data/<name>/` does,
- * its contents are moved into the new location as a one-time migration.
- *
- * For standalone workspace hooks (no `pluginDir`), the old
- * `<workspace>/plugins-data/<name>/` path is used and created as-is.
- */
-function resolvePluginStorageDir(
-  ownerName: string,
-  pluginDir: string | null,
-): string {
-  if (pluginDir === null) {
-    return ensureLegacyStorageDir(ownerName);
-  }
-
-  const dataDir = join(pluginDir, PLUGIN_DATA_DIRNAME);
-
-  // Migrate: if data/ doesn't exist but the old plugins-data/<name>/ does,
-  // move its contents into the new location.
-  if (!existsSync(dataDir)) {
-    const oldDir = join(getWorkspaceDir(), "plugins-data", ownerName);
-    if (existsSync(oldDir)) {
-      try {
-        mkdirSync(dataDir, { recursive: true });
-        cpSync(oldDir, dataDir, { recursive: true });
-        rmSync(oldDir, { recursive: true, force: true });
-        log.info(
-          { plugin: ownerName, oldDir, dataDir },
-          "migrated plugin data from plugins-data to plugin directory",
-        );
-      } catch (err) {
-        log.warn(
-          { err, plugin: ownerName, oldDir, dataDir },
-          "failed to migrate plugin data to plugin directory — using old location",
-        );
-        return ensureLegacyStorageDir(ownerName);
-      }
-    }
-  }
-
-  mkdirSync(dataDir, { recursive: true });
-  return dataDir;
-}
-
-/**
- * Ensure `<workspaceDir>/plugins-data/<name>/` exists and return its path.
- * Used only for standalone workspace hooks and as a fallback during migration.
- */
-function ensureLegacyStorageDir(ownerName: string): string {
-  const dir = join(getWorkspaceDir(), "plugins-data", ownerName);
-  mkdirSync(dir, { recursive: true });
-  return dir;
 }
 
 // ─── Test hooks ──────────────────────────────────────────────────────────────

--- a/assistant/src/monitoring/plugin-source-watch.ts
+++ b/assistant/src/monitoring/plugin-source-watch.ts
@@ -22,14 +22,7 @@
  * a walk trips over a half-written plugin directory.
  */
 
-import {
-  existsSync,
-  mkdirSync,
-  readdirSync,
-  renameSync,
-  statSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 import { collectSourceVersions } from "../plugins/collect-source-versions.js";
@@ -38,12 +31,11 @@ import type {
   SourceVersionsDocument,
 } from "../plugins/source-versions.js";
 import {
-  getSourceVersionsPath,
   readSourceVersions,
   SOURCE_VERSIONS_FORMAT,
+  writeSourceVersions,
 } from "../plugins/source-versions.js";
 import { getLogger } from "../util/logger.js";
-import { getMonitoringDataDir } from "../util/platform.js";
 
 const log = getLogger("plugin-source-watch");
 
@@ -176,7 +168,7 @@ export function runSourceWatchPass(state: SourceWatchState): boolean {
       writtenAt: new Date().toISOString(),
       plugins: current,
     };
-    writeSentinelAtomically(doc);
+    writeSourceVersions(doc);
     state.lastPlugins = current;
 
     log.info(
@@ -201,19 +193,6 @@ export function runSourceWatchPass(state: SourceWatchState): boolean {
     log.error({ err }, "plugin source watch pass failed — will retry");
     return false;
   }
-}
-
-/**
- * Write the sentinel via temp-file + rename so readers never observe a torn
- * document. Both files live in the monitoring data directory, outside every
- * fingerprint walk and outside the workspace git surface.
- */
-function writeSentinelAtomically(doc: SourceVersionsDocument): void {
-  const path = getSourceVersionsPath();
-  mkdirSync(getMonitoringDataDir(), { recursive: true });
-  const tmpPath = `${path}.tmp`;
-  writeFileSync(tmpPath, JSON.stringify(doc, null, 2));
-  renameSync(tmpPath, path);
 }
 
 /** Handle for the running watcher loop. */

--- a/assistant/src/persistence/conversation-plugin-facade.ts
+++ b/assistant/src/persistence/conversation-plugin-facade.ts
@@ -1,3 +1,4 @@
+import { assertNotPluginRouteHost } from "../plugin-api/route-context.js";
 import type {
   AddMessageOptions,
   ConversationRow,
@@ -40,6 +41,7 @@ type AddMessageResult = Awaited<
 export async function getConversation(
   id: string,
 ): Promise<ConversationRow | null> {
+  assertNotPluginRouteHost("Conversation store access");
   const { getConversation: fn } = await import("./conversation-crud.js");
   return fn(id);
 }
@@ -48,12 +50,14 @@ export async function getConversation(
 export async function getMessages(
   conversationId: string,
 ): Promise<MessageRow[]> {
+  assertNotPluginRouteHost("Conversation store access");
   const { getMessages: fn } = await import("./conversation-crud.js");
   return fn(conversationId);
 }
 
 /** Whether the conversation currently has a turn in flight. */
 export async function isConversationProcessing(id: string): Promise<boolean> {
+  assertNotPluginRouteHost("Conversation store access");
   const { isConversationProcessing: fn } =
     await import("./conversation-crud.js");
   return fn(id);
@@ -68,6 +72,7 @@ export async function isConversationProcessing(id: string): Promise<boolean> {
 export async function getConversationProcessingStartedAt(
   id: string,
 ): Promise<number | null> {
+  assertNotPluginRouteHost("Conversation store access");
   const { getConversationProcessingStartedAt: fn } =
     await import("./conversation-crud.js");
   return fn(id);
@@ -77,6 +82,7 @@ export async function getConversationProcessingStartedAt(
 export async function parseMessageMetadata(
   metadataJson: string | null,
 ): Promise<MessageMetadata> {
+  assertNotPluginRouteHost("Conversation store access");
   const { parseMessageMetadata: fn } = await import("./conversation-crud.js");
   return fn(metadataJson);
 }
@@ -86,6 +92,7 @@ export async function updateMessageMetadata(
   messageId: string,
   updates: Record<string, unknown>,
 ): Promise<void> {
+  assertNotPluginRouteHost("Conversation store access");
   const { updateMessageMetadata: fn } = await import("./conversation-crud.js");
   return fn(messageId, updates);
 }
@@ -104,6 +111,7 @@ export async function addMessage(
   content: string,
   options?: AddMessageOptions,
 ): Promise<AddMessageResult> {
+  assertNotPluginRouteHost("Conversation store access");
   const { addMessage: fn } = await import("./conversation-crud.js");
   return fn(conversationId, role, content, options);
 }
@@ -116,6 +124,7 @@ export async function addMessage(
  * purge runs inside the delete itself via the persistence hook.
  */
 export async function deleteConversation(id: string): Promise<void> {
+  assertNotPluginRouteHost("Conversation store access");
   const [{ deleteConversationGently: fn }, { enqueueMemoryJob }] =
     await Promise.all([
       import("./conversation-crud.js"),
@@ -150,6 +159,7 @@ export async function listConversations(
   archiveStatus?: ArchiveStatusFilter,
   originChannel?: string,
 ): Promise<ConversationRow[]> {
+  assertNotPluginRouteHost("Conversation store access");
   const { listConversations: fn } = await import("./conversation-queries.js");
   return fn({
     ...(limit !== undefined ? { limit } : {}),
@@ -166,6 +176,7 @@ export async function searchMessageIdsLexical(
   limit: number,
   opts?: { conversationId?: string },
 ): Promise<MessageLexicalSearchResult[]> {
+  assertNotPluginRouteHost("Conversation store access");
   const { searchMessageIdsLexical: fn } =
     await import("./conversation-search-lexical.js");
   return fn(query, limit, opts);
@@ -173,6 +184,7 @@ export async function searchMessageIdsLexical(
 
 /** Whether the text tokenizes to at least one lexical search token. */
 export async function hasLexicalTokens(text: string): Promise<boolean> {
+  assertNotPluginRouteHost("Conversation store access");
   const { hasLexicalTokens: fn } = await import("./conversation-queries.js");
   return fn(text);
 }
@@ -186,6 +198,7 @@ export async function buildMessageExcerpt(
   rawContent: string,
   query: string,
 ): Promise<string> {
+  assertNotPluginRouteHost("Conversation store access");
   const { buildRecallEvidenceExcerpt: fn } =
     await import("./conversation-queries.js");
   return fn(rawContent, query);
@@ -199,6 +212,7 @@ export async function getConversationDirPath(
   id: string,
   createdAtMs: number,
 ): Promise<string> {
+  assertNotPluginRouteHost("Conversation store access");
   const { getConversationDirPath: fn } =
     await import("./conversation-directories.js");
   return fn(id, createdAtMs);
@@ -210,6 +224,7 @@ export async function syncMessageToDisk(
   messageId: string,
   createdAtMs: number,
 ): Promise<void> {
+  assertNotPluginRouteHost("Conversation store access");
   const { syncMessageToDisk: fn } = await import("./conversation-disk-view.js");
   return fn(conversationId, messageId, createdAtMs);
 }

--- a/assistant/src/plugin-api/activation.ts
+++ b/assistant/src/plugin-api/activation.ts
@@ -1,0 +1,15 @@
+import type { PluginLogger } from "./types.js";
+
+/** Host-owned identity and lifecycle values for an active plugin surface. */
+export interface PluginActivationContext {
+  /** Install-directory slug assigned by the host. */
+  readonly pluginId: string;
+  /** Writable directory reserved for this plugin's durable state. */
+  readonly pluginStorageDir: string;
+  /** Assistant semver for compatibility checks. */
+  readonly assistantVersion: string;
+  /** Aborted when this plugin activation is stopped. */
+  readonly signal: AbortSignal;
+  /** Logger bound to this plugin surface. */
+  readonly logger: PluginLogger;
+}

--- a/assistant/src/plugin-api/conversation-turn.ts
+++ b/assistant/src/plugin-api/conversation-turn.ts
@@ -18,6 +18,7 @@ import type { ChannelId } from "../channels/types.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import type { UserMessageAttachment } from "../daemon/message-types/shared.js";
 import type { ContentBlock, MediaSource } from "../providers/types.js";
+import { assertNotPluginRouteHost } from "./route-context.js";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -269,6 +270,7 @@ async function resolveChannelConversation(
 export async function runConversationTurn(
   options: RunConversationTurnOptions,
 ): Promise<RunConversationTurnResult> {
+  assertNotPluginRouteHost("Conversation turns");
   const { v7: uuidv7 } = await import("uuid");
   const { getOrCreateConversation } =
     await import("../daemon/conversation-store.js");

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -66,8 +66,31 @@
  * - {@link ToolExecutionResult} — return shape of a plugin tool's `execute`
  */
 
+export type { PluginActivationContext } from "./activation.js";
 export type { HookName } from "./constants.js";
 export { HOOKS, INTERNAL_NUDGE_OUTPUT_SUPPRESSION } from "./constants.js";
+export type {
+  PluginWorker,
+  PluginWorkerContext,
+  PluginWorkerResult,
+  PluginWorkerWakeTime,
+} from "./plugin-worker.js";
+export type {
+  PluginRouteActorContext,
+  PluginRouteContext,
+  PluginRouteHost,
+  PluginRoutePrincipalType,
+} from "./route-context.js";
+export {
+  getPluginRouteContext,
+  requirePluginRouteContext,
+} from "./route-context.js";
+export type { VerifiedPeerOperationContext } from "./verified-peer-context.js";
+export {
+  parseVerifiedPeerOperationContext,
+  PeerOperationKindSchema,
+  VerifiedPeerOperationContextSchema,
+} from "./verified-peer-context.js";
 // Conversation message/content shapes. A hook receives the live message
 // history (e.g. `PostToolUseContext.latestMessages: Message[]`), so plugins
 // that inspect or narrow content blocks — reading a `tool_use` block's input,

--- a/assistant/src/plugin-api/plugin-worker.ts
+++ b/assistant/src/plugin-api/plugin-worker.ts
@@ -1,0 +1,19 @@
+import type { PluginActivationContext } from "./activation.js";
+
+/** Absolute wall-clock time at which a worker wants another invocation. */
+export type PluginWorkerWakeTime = Date | number;
+
+export interface PluginWorkerResult {
+  /** Date or Unix epoch milliseconds for the next host-managed invocation. */
+  readonly nextWakeAt?: PluginWorkerWakeTime | null;
+}
+
+export interface PluginWorkerContext extends PluginActivationContext {
+  /** Ask the host to invoke this worker again as soon as its current run ends. */
+  readonly requestWake: () => void;
+}
+
+/** A bounded batch of durable work owned by one external plugin. */
+export type PluginWorker = (
+  context: PluginWorkerContext,
+) => Promise<PluginWorkerResult | void> | PluginWorkerResult | void;

--- a/assistant/src/plugin-api/route-context.ts
+++ b/assistant/src/plugin-api/route-context.ts
@@ -1,0 +1,73 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+import type { VerifiedPeerOperationContext } from "./verified-peer-context.js";
+
+const ROUTE_HOST_PROCESS_KEY = Symbol.for("vellum.plugin-route-host-process");
+
+export type PluginRoutePrincipalType =
+  | "actor"
+  | "svc_gateway"
+  | "svc_daemon"
+  | "local"
+  | "assistant_peer";
+
+export interface PluginRouteActorContext {
+  readonly principalType: PluginRoutePrincipalType;
+  /** Opaque local actor principal ID, or null for non-actor principals. */
+  readonly principalId: string | null;
+  readonly scopes: readonly string[];
+}
+
+export interface PluginRouteHost {
+  /** Resolve this plugin's host-owned durable storage directory. */
+  getPluginStorageDir(): Promise<string>;
+}
+
+export interface PluginRouteContext {
+  /** Installed plugin directory ID, derived by the host from the route path. */
+  readonly pluginId: string;
+  readonly actor: PluginRouteActorContext;
+  /** Host-minted correlation ID for this route invocation. */
+  readonly requestId: string;
+  readonly signal: AbortSignal;
+  readonly verifiedPeer: VerifiedPeerOperationContext | null;
+  readonly host: PluginRouteHost;
+}
+
+const routeContextStorage = new AsyncLocalStorage<PluginRouteContext>();
+
+/** Return the active plugin route context, if called from a route handler. */
+export function getPluginRouteContext(): PluginRouteContext | undefined {
+  return routeContextStorage.getStore();
+}
+
+/** Return the active plugin route context or fail outside route execution. */
+export function requirePluginRouteContext(): PluginRouteContext {
+  const context = getPluginRouteContext();
+  if (!context) {
+    throw new Error("plugin route context is unavailable");
+  }
+  return context;
+}
+
+/** @internal Mark this process as the isolated plugin route host. */
+export function markCurrentProcessAsPluginRouteHost(): void {
+  (globalThis as Record<symbol, unknown>)[ROUTE_HOST_PROCESS_KEY] = true;
+}
+
+/** @internal Reject main-process-only APIs inside the plugin route host. */
+export function assertNotPluginRouteHost(operation: string): void {
+  if (
+    (globalThis as Record<symbol, unknown>)[ROUTE_HOST_PROCESS_KEY] === true
+  ) {
+    throw new Error(`${operation} is unavailable in the plugin route host`);
+  }
+}
+
+/** @internal Establish host-owned context around one plugin route call. */
+export function runInPluginRouteContext<T>(
+  context: PluginRouteContext,
+  fn: () => T,
+): T {
+  return routeContextStorage.run(context, fn);
+}

--- a/assistant/src/plugin-api/verified-peer-context.ts
+++ b/assistant/src/plugin-api/verified-peer-context.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+
+const BOUNDED_IDENTIFIER = /^[a-zA-Z0-9][a-zA-Z0-9._:-]*$/;
+const OPERATION_KIND_PATTERN =
+  /^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*(?:\.[a-z0-9]+)*$/;
+const SHA256_DIGEST = /^sha256:[a-f0-9]{64}$/;
+
+export const PeerOperationKindSchema = z
+  .string()
+  .min(1)
+  .max(80)
+  .regex(OPERATION_KIND_PATTERN);
+
+const VerifiedPeerOperationSchema = z
+  .object({
+    id: z.string().min(1).max(128).regex(BOUNDED_IDENTIFIER),
+    kind: PeerOperationKindSchema,
+    payloadHash: z.string().regex(SHA256_DIGEST),
+  })
+  .strict();
+
+/**
+ * Host-verified peer metadata attached to one inbound plugin operation.
+ * External assistant IDs, endpoints, credentials, keys, and signatures are
+ * deliberately absent from this contract.
+ */
+export const VerifiedPeerOperationContextSchema = z
+  .object({
+    peerId: z.string().min(1).max(128).regex(BOUNDED_IDENTIFIER),
+    generation: z.string().min(1).max(128).regex(BOUNDED_IDENTIFIER),
+    operation: VerifiedPeerOperationSchema,
+  })
+  .strict();
+
+export type VerifiedPeerOperationContext = Readonly<
+  z.infer<typeof VerifiedPeerOperationContextSchema>
+>;
+
+export function parseVerifiedPeerOperationContext(
+  value: unknown,
+): VerifiedPeerOperationContext {
+  return VerifiedPeerOperationContextSchema.parse(value);
+}

--- a/assistant/src/plugins/activation-eligibility.ts
+++ b/assistant/src/plugins/activation-eligibility.ts
@@ -1,0 +1,182 @@
+import { readFileSync } from "node:fs";
+import { basename, join } from "node:path";
+
+import semver from "semver";
+import { z } from "zod";
+
+import assistantPkg from "../../package.json" with { type: "json" };
+import {
+  findUnsatisfiedHostCapabilities,
+  readHostRequirements,
+  type UnsatisfiedHostCapability,
+} from "./host-requirements.js";
+import { getFileSignature } from "./surface-import.js";
+
+const PLUGIN_API_PEER_DEP = "@vellumai/plugin-api";
+
+const PackageCompatibilitySchema = z
+  .object({
+    peerDependencies: z.record(z.string(), z.string()).optional(),
+  })
+  .passthrough();
+
+export type PluginIncompatibilityCode =
+  | "host_requirements_invalid"
+  | "plugin_manifest_invalid"
+  | "plugin_api_peer_missing"
+  | "plugin_api_peer_invalid"
+  | "plugin_api_peer_unsatisfied"
+  | "host_capability_unsatisfied";
+
+export type PluginActivationEligibility =
+  | {
+      readonly eligible: true;
+      readonly mode: "legacy" | "requirements";
+      readonly pluginId: string;
+      readonly pluginApiRange?: string;
+    }
+  | {
+      readonly eligible: false;
+      readonly pluginId: string;
+      readonly code: PluginIncompatibilityCode;
+      readonly reason: string;
+      readonly pluginApiRange?: string;
+      readonly missingCapabilities?: readonly UnsatisfiedHostCapability[];
+    };
+
+interface CachedEligibility {
+  readonly packageSignature: string;
+  readonly requirementsSignature: string;
+  readonly value: PluginActivationEligibility;
+}
+
+const cache = new Map<string, CachedEligibility>();
+
+function incompatible(
+  pluginId: string,
+  code: PluginIncompatibilityCode,
+  reason: string,
+  extras: Pick<
+    Extract<PluginActivationEligibility, { eligible: false }>,
+    "pluginApiRange" | "missingCapabilities"
+  > = {},
+): PluginActivationEligibility {
+  return { eligible: false, pluginId, code, reason, ...extras };
+}
+
+export function evaluatePluginActivation(
+  pluginDir: string,
+): PluginActivationEligibility {
+  const pluginId = basename(pluginDir);
+  const requirements = readHostRequirements(pluginDir);
+  if (requirements.kind === "legacy") {
+    return { eligible: true, mode: "legacy", pluginId };
+  }
+  if (requirements.kind === "invalid") {
+    return incompatible(
+      pluginId,
+      "host_requirements_invalid",
+      requirements.reason,
+    );
+  }
+
+  let rawPackage: unknown;
+  try {
+    rawPackage = JSON.parse(
+      readFileSync(join(pluginDir, "package.json"), "utf8"),
+    );
+  } catch (err) {
+    return incompatible(
+      pluginId,
+      "plugin_manifest_invalid",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+
+  const parsedPackage = PackageCompatibilitySchema.safeParse(rawPackage);
+  if (!parsedPackage.success) {
+    return incompatible(
+      pluginId,
+      "plugin_manifest_invalid",
+      parsedPackage.error.message,
+    );
+  }
+
+  const pluginApiRange =
+    parsedPackage.data.peerDependencies?.[PLUGIN_API_PEER_DEP];
+  if (pluginApiRange === undefined) {
+    return incompatible(
+      pluginId,
+      "plugin_api_peer_missing",
+      `package.json must declare peerDependencies[${JSON.stringify(PLUGIN_API_PEER_DEP)}] when host-requirements.json is present`,
+    );
+  }
+  if (semver.validRange(pluginApiRange) === null) {
+    return incompatible(
+      pluginId,
+      "plugin_api_peer_invalid",
+      `plugin API peer range ${JSON.stringify(pluginApiRange)} is invalid`,
+      { pluginApiRange },
+    );
+  }
+  if (
+    !semver.satisfies(assistantPkg.version, pluginApiRange, {
+      includePrerelease: true,
+    })
+  ) {
+    return incompatible(
+      pluginId,
+      "plugin_api_peer_unsatisfied",
+      `plugin API peer range ${JSON.stringify(pluginApiRange)} does not include assistant ${assistantPkg.version}`,
+      { pluginApiRange },
+    );
+  }
+
+  const missingCapabilities = findUnsatisfiedHostCapabilities(
+    requirements.requirements,
+  );
+  if (missingCapabilities.length > 0) {
+    return incompatible(
+      pluginId,
+      "host_capability_unsatisfied",
+      "one or more required host capabilities are unavailable",
+      { pluginApiRange, missingCapabilities },
+    );
+  }
+
+  return {
+    eligible: true,
+    mode: "requirements",
+    pluginId,
+    pluginApiRange,
+  };
+}
+
+export function getPluginActivationEligibility(
+  pluginDir: string,
+): PluginActivationEligibility {
+  const packagePath = join(pluginDir, "package.json");
+  const requirementsPath = join(pluginDir, "host-requirements.json");
+  const packageSignature = getFileSignature(packagePath);
+  const requirementsSignature = getFileSignature(requirementsPath);
+  const cached = cache.get(pluginDir);
+  if (
+    cached?.packageSignature === packageSignature &&
+    cached.requirementsSignature === requirementsSignature
+  ) {
+    return cached.value;
+  }
+
+  const value = evaluatePluginActivation(pluginDir);
+  cache.set(pluginDir, { packageSignature, requirementsSignature, value });
+  return value;
+}
+
+/** Drop the cached compatibility decision for one plugin directory. */
+export function evictPluginActivationEligibility(pluginDir: string): void {
+  cache.delete(pluginDir);
+}
+
+export function resetPluginActivationEligibilityCacheForTests(): void {
+  cache.clear();
+}

--- a/assistant/src/plugins/activation-eligibility.ts
+++ b/assistant/src/plugins/activation-eligibility.ts
@@ -65,7 +65,7 @@ function incompatible(
   return { eligible: false, pluginId, code, reason, ...extras };
 }
 
-export function evaluatePluginActivation(
+function evaluatePluginActivation(
   pluginDir: string,
 ): PluginActivationEligibility {
   const pluginId = basename(pluginDir);

--- a/assistant/src/plugins/activation-eligibility.ts
+++ b/assistant/src/plugins/activation-eligibility.ts
@@ -6,12 +6,17 @@ import semver from "semver";
 import { z } from "zod";
 
 import assistantPkg from "../../package.json" with { type: "json" };
+import { ASSISTANT_PEER_ROUTES_CAPABILITY_ID } from "./host-capabilities.js";
 import {
   findUnsatisfiedHostCapabilities,
   HOST_REQUIREMENTS_FILENAME,
   readHostRequirements,
   type UnsatisfiedHostCapability,
 } from "./host-requirements.js";
+import {
+  PLUGIN_ROUTE_MANIFEST_PATH,
+  readPluginRouteManifest,
+} from "./plugin-route-manifest.js";
 
 const PLUGIN_API_PEER_DEP = "@vellumai/plugin-api";
 const MAX_SIGNATURE_FILE_BYTES = 1024 * 1024;
@@ -49,6 +54,7 @@ export type PluginActivationEligibility =
 interface CachedEligibility {
   readonly packageSignature: string;
   readonly requirementsSignature: string;
+  readonly routeManifestSignature: string;
   readonly value: PluginActivationEligibility;
 }
 
@@ -95,15 +101,43 @@ function evaluatePluginActivation(
 ): PluginActivationEligibility {
   const pluginId = basename(pluginDir);
   const requirements = readHostRequirements(pluginDir);
-  if (requirements.kind === "legacy") {
-    return { eligible: true, mode: "legacy", pluginId };
-  }
   if (requirements.kind === "invalid") {
     return incompatible(
       pluginId,
       "host_requirements_invalid",
       requirements.reason,
     );
+  }
+
+  const routeManifest = readPluginRouteManifest(pluginDir);
+  const declaresAssistantPeerRoute =
+    routeManifest.kind === "valid" &&
+    routeManifest.manifest.routes.some(
+      (route) => route.authorization.principal === "assistant_peer",
+    );
+  if (declaresAssistantPeerRoute) {
+    if (requirements.kind === "legacy") {
+      return incompatible(
+        pluginId,
+        "host_requirements_invalid",
+        `assistant-peer routes require host-requirements.json to declare ${ASSISTANT_PEER_ROUTES_CAPABILITY_ID}`,
+      );
+    }
+    if (
+      requirements.requirements.requires[
+        ASSISTANT_PEER_ROUTES_CAPABILITY_ID
+      ] === undefined
+    ) {
+      return incompatible(
+        pluginId,
+        "host_requirements_invalid",
+        `assistant-peer routes require capability ${ASSISTANT_PEER_ROUTES_CAPABILITY_ID}`,
+      );
+    }
+  }
+
+  if (requirements.kind === "legacy") {
+    return { eligible: true, mode: "legacy", pluginId };
   }
 
   let rawPackage: unknown;
@@ -183,14 +217,18 @@ export function getPluginActivationEligibility(
 ): PluginActivationEligibility {
   const packagePath = join(pluginDir, "package.json");
   const requirementsPath = join(pluginDir, HOST_REQUIREMENTS_FILENAME);
+  const routeManifestPath = join(pluginDir, PLUGIN_ROUTE_MANIFEST_PATH);
   const packageContent = getContentSignature(packagePath);
   const requirementsContent = getContentSignature(requirementsPath);
+  const routeManifestContent = getContentSignature(routeManifestPath);
   const packageSignature = packageContent.value;
   const requirementsSignature = requirementsContent.value;
+  const routeManifestSignature = routeManifestContent.value;
   const cached = cache.get(pluginDir);
   if (
     cached?.packageSignature === packageSignature &&
-    cached.requirementsSignature === requirementsSignature
+    cached.requirementsSignature === requirementsSignature &&
+    cached.routeManifestSignature === routeManifestSignature
   ) {
     return cached.value;
   }
@@ -211,7 +249,12 @@ export function getPluginActivationEligibility(
   } else {
     value = evaluatePluginActivation(pluginDir);
   }
-  cache.set(pluginDir, { packageSignature, requirementsSignature, value });
+  cache.set(pluginDir, {
+    packageSignature,
+    requirementsSignature,
+    routeManifestSignature,
+    value,
+  });
   return value;
 }
 

--- a/assistant/src/plugins/activation-eligibility.ts
+++ b/assistant/src/plugins/activation-eligibility.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { basename, join } from "node:path";
 
@@ -11,9 +12,9 @@ import {
   readHostRequirements,
   type UnsatisfiedHostCapability,
 } from "./host-requirements.js";
-import { getFileSignature } from "./surface-import.js";
 
 const PLUGIN_API_PEER_DEP = "@vellumai/plugin-api";
+const MAX_SIGNATURE_FILE_BYTES = 1024 * 1024;
 
 const PackageCompatibilitySchema = z
   .object({
@@ -52,6 +53,30 @@ interface CachedEligibility {
 }
 
 const cache = new Map<string, CachedEligibility>();
+
+interface BoundedContentSignature {
+  readonly value: string;
+  readonly oversized: boolean;
+}
+
+function getContentSignature(path: string): BoundedContentSignature {
+  try {
+    const content = readFileSync(path);
+    if (content.byteLength > MAX_SIGNATURE_FILE_BYTES) {
+      return { value: `oversized:${content.byteLength}`, oversized: true };
+    }
+    return {
+      value: createHash("sha256").update(content).digest("hex"),
+      oversized: false,
+    };
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    return {
+      value: code === "ENOENT" ? "missing" : `unreadable:${code ?? "unknown"}`,
+      oversized: false,
+    };
+  }
+}
 
 function incompatible(
   pluginId: string,
@@ -158,8 +183,10 @@ export function getPluginActivationEligibility(
 ): PluginActivationEligibility {
   const packagePath = join(pluginDir, "package.json");
   const requirementsPath = join(pluginDir, HOST_REQUIREMENTS_FILENAME);
-  const packageSignature = getFileSignature(packagePath);
-  const requirementsSignature = getFileSignature(requirementsPath);
+  const packageContent = getContentSignature(packagePath);
+  const requirementsContent = getContentSignature(requirementsPath);
+  const packageSignature = packageContent.value;
+  const requirementsSignature = requirementsContent.value;
   const cached = cache.get(pluginDir);
   if (
     cached?.packageSignature === packageSignature &&
@@ -168,7 +195,22 @@ export function getPluginActivationEligibility(
     return cached.value;
   }
 
-  const value = evaluatePluginActivation(pluginDir);
+  let value: PluginActivationEligibility;
+  if (requirementsContent.oversized) {
+    value = incompatible(
+      basename(pluginDir),
+      "host_requirements_invalid",
+      `host-requirements.json exceeds ${MAX_SIGNATURE_FILE_BYTES} bytes`,
+    );
+  } else if (requirementsSignature !== "missing" && packageContent.oversized) {
+    value = incompatible(
+      basename(pluginDir),
+      "plugin_manifest_invalid",
+      `package.json exceeds ${MAX_SIGNATURE_FILE_BYTES} bytes`,
+    );
+  } else {
+    value = evaluatePluginActivation(pluginDir);
+  }
   cache.set(pluginDir, { packageSignature, requirementsSignature, value });
   return value;
 }

--- a/assistant/src/plugins/activation-eligibility.ts
+++ b/assistant/src/plugins/activation-eligibility.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 import assistantPkg from "../../package.json" with { type: "json" };
 import {
   findUnsatisfiedHostCapabilities,
+  HOST_REQUIREMENTS_FILENAME,
   readHostRequirements,
   type UnsatisfiedHostCapability,
 } from "./host-requirements.js";
@@ -156,7 +157,7 @@ export function getPluginActivationEligibility(
   pluginDir: string,
 ): PluginActivationEligibility {
   const packagePath = join(pluginDir, "package.json");
-  const requirementsPath = join(pluginDir, "host-requirements.json");
+  const requirementsPath = join(pluginDir, HOST_REQUIREMENTS_FILENAME);
   const packageSignature = getFileSignature(packagePath);
   const requirementsSignature = getFileSignature(requirementsPath);
   const cached = cache.get(pluginDir);

--- a/assistant/src/plugins/collect-source-versions.ts
+++ b/assistant/src/plugins/collect-source-versions.ts
@@ -17,7 +17,10 @@ import { join } from "node:path";
 
 import { getWorkspaceHooksDir } from "../util/platform.js";
 import { listInstalledPluginDirs } from "./installed-plugin-dirs.js";
-import { snapshotPluginSource } from "./source-fingerprint.js";
+import {
+  derivePluginSourceFingerprint,
+  snapshotPluginSource,
+} from "./source-fingerprint.js";
 import type { PluginSourceVersion } from "./source-versions.js";
 
 /**
@@ -35,7 +38,8 @@ export function collectSourceVersions(): Record<string, PluginSourceVersion> {
     const snapshot = snapshotPluginSource(dir);
     out[dir] = {
       fingerprint: snapshot.fingerprint,
-      evictionPaths: snapshot.evictionPaths,
+      sourceFingerprint: derivePluginSourceFingerprint(snapshot.fingerprint),
+      evictionPaths: [...snapshot.evictionPaths],
       disabled: existsSync(join(dir, ".disabled")),
     };
   }
@@ -45,7 +49,8 @@ export function collectSourceVersions(): Record<string, PluginSourceVersion> {
     const snapshot = snapshotPluginSource(workspaceHooksDir);
     out[workspaceHooksDir] = {
       fingerprint: snapshot.fingerprint,
-      evictionPaths: snapshot.evictionPaths,
+      sourceFingerprint: derivePluginSourceFingerprint(snapshot.fingerprint),
+      evictionPaths: [...snapshot.evictionPaths],
       disabled: false,
     };
   }

--- a/assistant/src/plugins/external-plugin-loader.ts
+++ b/assistant/src/plugins/external-plugin-loader.ts
@@ -53,6 +53,7 @@ import { PLUGIN_SECRET_PATTERN_LIMITS } from "../security/plugin-secret-patterns
 import { finalizeTool } from "../tools/tool-defaults.js";
 import type { Tool, ToolDefinition } from "../tools/types.js";
 import { getLogger } from "../util/logger.js";
+import { getPluginActivationEligibility } from "./activation-eligibility.js";
 import { registerPlugin } from "./registry.js";
 import type {
   HookFunction,
@@ -270,6 +271,13 @@ async function loadHooks(
  * timeout/try-catch/register triple.
  */
 async function buildPluginFromDir(pluginDir: string): Promise<Plugin> {
+  const eligibility = getPluginActivationEligibility(pluginDir);
+  if (!eligibility.eligible) {
+    throw new Error(
+      `external plugin ${eligibility.pluginId} is incompatible (${eligibility.code}): ${eligibility.reason}`,
+    );
+  }
+
   const pkgPath = join(pluginDir, "package.json");
   let rawPkg: unknown;
   try {
@@ -311,7 +319,7 @@ async function buildPluginFromDir(pluginDir: string): Promise<Plugin> {
   // If the peerDep is absent, the plugin loads without a host-compat
   // claim; we log a warning so the omission is visible at boot.
   const range = pkg.peerDependencies?.[PLUGIN_API_PEER_DEP];
-  if (range !== undefined) {
+  if (eligibility.mode === "legacy" && range !== undefined) {
     if (!semver.validRange(range)) {
       log.error(
         { pluginDir, plugin: name, peerDep: PLUGIN_API_PEER_DEP, range },
@@ -333,7 +341,7 @@ async function buildPluginFromDir(pluginDir: string): Promise<Plugin> {
         `external plugin ${name}: peerDependencies["${PLUGIN_API_PEER_DEP}"] requires "${range}" but assistant is ${assistantPkg.version} — loading anyway`,
       );
     }
-  } else {
+  } else if (eligibility.mode === "legacy") {
     log.warn(
       { pluginDir, plugin: name, peerDep: PLUGIN_API_PEER_DEP },
       "external plugin missing plugin-api peerDependency — loading without host-compat claim",

--- a/assistant/src/plugins/external-plugin-workers.ts
+++ b/assistant/src/plugins/external-plugin-workers.ts
@@ -1,0 +1,63 @@
+import { basename, join } from "node:path";
+
+import type { PluginWorker } from "../plugin-api/plugin-worker.js";
+import { getPluginActivationEligibility } from "./activation-eligibility.js";
+import { listSurfaceDir, type SurfaceFile } from "./external-plugin-loader.js";
+import { importWithTimeout } from "./surface-import.js";
+
+export interface ExternalPluginWorkerSource extends SurfaceFile {
+  readonly pluginId: string;
+}
+
+export interface ExternalPluginWorker extends ExternalPluginWorkerSource {
+  readonly run: PluginWorker;
+}
+
+export class PluginWorkersIneligibleError extends Error {
+  constructor(
+    readonly pluginId: string,
+    readonly reason: string,
+  ) {
+    super(`external plugin ${pluginId} is not eligible for workers: ${reason}`);
+    this.name = "PluginWorkersIneligibleError";
+  }
+}
+
+/** List worker files without importing plugin code. */
+export function discoverExternalPluginWorkers(
+  pluginDir: string,
+): ExternalPluginWorkerSource[] {
+  const pluginId = basename(pluginDir);
+  return listSurfaceDir(join(pluginDir, "workers")).map((source) => ({
+    ...source,
+    pluginId,
+  }));
+}
+
+/** Load every worker only after the plugin passes the static activation gate. */
+export async function loadExternalPluginWorkers(
+  pluginDir: string,
+  importTimeoutMs?: number,
+): Promise<ExternalPluginWorker[]> {
+  const pluginId = basename(pluginDir);
+  const eligibility = getPluginActivationEligibility(pluginDir);
+  if (!eligibility.eligible) {
+    throw new PluginWorkersIneligibleError(pluginId, eligibility.reason);
+  }
+
+  const workers: ExternalPluginWorker[] = [];
+  for (const source of discoverExternalPluginWorkers(pluginDir)) {
+    const value = await importWithTimeout<unknown>(
+      source.path,
+      importTimeoutMs,
+    );
+    if (typeof value !== "function") {
+      const actual = value === undefined ? "undefined" : typeof value;
+      throw new TypeError(
+        `external plugin ${pluginId}: workers/${source.name} default export must be a function (got ${actual})`,
+      );
+    }
+    workers.push({ ...source, run: value as PluginWorker });
+  }
+  return workers;
+}

--- a/assistant/src/plugins/external-plugin-workers.ts
+++ b/assistant/src/plugins/external-plugin-workers.ts
@@ -13,7 +13,7 @@ export interface ExternalPluginWorker extends ExternalPluginWorkerSource {
   readonly run: PluginWorker;
 }
 
-export class PluginWorkersIneligibleError extends Error {
+class PluginWorkersIneligibleError extends Error {
   constructor(
     readonly pluginId: string,
     readonly reason: string,

--- a/assistant/src/plugins/host-capabilities.ts
+++ b/assistant/src/plugins/host-capabilities.ts
@@ -7,18 +7,6 @@ export const HOST_CAPABILITIES = Object.freeze({
 
 export type HostCapabilityId = keyof typeof HOST_CAPABILITIES;
 
-export interface HostCapability {
-  readonly id: HostCapabilityId;
-  readonly version: string;
-}
-
-export function listHostCapabilities(): HostCapability[] {
-  return Object.entries(HOST_CAPABILITIES).map(([id, version]) => ({
-    id: id as HostCapabilityId,
-    version,
-  }));
-}
-
 export function resolveHostCapabilityVersion(id: string): string | undefined {
   return Object.prototype.hasOwnProperty.call(HOST_CAPABILITIES, id)
     ? HOST_CAPABILITIES[id as HostCapabilityId]

--- a/assistant/src/plugins/host-capabilities.ts
+++ b/assistant/src/plugins/host-capabilities.ts
@@ -1,0 +1,37 @@
+import semver from "semver";
+
+export const HOST_CAPABILITIES = Object.freeze({
+  "plugins.activation.requirements": "1.0.0",
+  "plugins.readiness": "1.0.0",
+} as const);
+
+export type HostCapabilityId = keyof typeof HOST_CAPABILITIES;
+
+export interface HostCapability {
+  readonly id: HostCapabilityId;
+  readonly version: string;
+}
+
+export function listHostCapabilities(): HostCapability[] {
+  return Object.entries(HOST_CAPABILITIES).map(([id, version]) => ({
+    id: id as HostCapabilityId,
+    version,
+  }));
+}
+
+export function resolveHostCapabilityVersion(id: string): string | undefined {
+  return Object.prototype.hasOwnProperty.call(HOST_CAPABILITIES, id)
+    ? HOST_CAPABILITIES[id as HostCapabilityId]
+    : undefined;
+}
+
+export function satisfiesHostCapability(
+  id: string,
+  requiredRange: string,
+): boolean {
+  const version = resolveHostCapabilityVersion(id);
+  return (
+    version !== undefined &&
+    semver.satisfies(version, requiredRange, { includePrerelease: true })
+  );
+}

--- a/assistant/src/plugins/host-capabilities.ts
+++ b/assistant/src/plugins/host-capabilities.ts
@@ -1,5 +1,8 @@
 import semver from "semver";
 
+export const ASSISTANT_PEER_ROUTES_CAPABILITY_ID =
+  "plugins.routes.assistant-peer";
+
 export const HOST_CAPABILITIES = Object.freeze({
   "plugins.activation.requirements": "1.0.0",
   "plugins.readiness": "1.0.0",

--- a/assistant/src/plugins/host-requirements.ts
+++ b/assistant/src/plugins/host-requirements.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { PLUGIN_HOST_REQUIREMENTS_FILENAME } from "@vellumai/service-contracts/plugin-readiness";
 import semver from "semver";
 import { z } from "zod";
 
@@ -9,7 +10,7 @@ import {
   satisfiesHostCapability,
 } from "./host-capabilities.js";
 
-export const HOST_REQUIREMENTS_FILENAME = "host-requirements.json";
+export const HOST_REQUIREMENTS_FILENAME = PLUGIN_HOST_REQUIREMENTS_FILENAME;
 
 const CAPABILITY_ID = /^[a-z][a-z0-9.-]{0,127}$/;
 

--- a/assistant/src/plugins/host-requirements.ts
+++ b/assistant/src/plugins/host-requirements.ts
@@ -1,0 +1,88 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import semver from "semver";
+import { z } from "zod";
+
+import {
+  resolveHostCapabilityVersion,
+  satisfiesHostCapability,
+} from "./host-capabilities.js";
+
+export const HOST_REQUIREMENTS_FILENAME = "host-requirements.json";
+
+const CAPABILITY_ID = /^[a-z][a-z0-9.-]{0,127}$/;
+
+export const HostRequirementsSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    requires: z.record(
+      z.string().regex(CAPABILITY_ID),
+      z.string().min(1).max(128),
+    ),
+  })
+  .strict();
+
+export type HostRequirements = z.infer<typeof HostRequirementsSchema>;
+
+export type HostRequirementsReadResult =
+  | { readonly kind: "legacy" }
+  | { readonly kind: "valid"; readonly requirements: HostRequirements }
+  | { readonly kind: "invalid"; readonly reason: string };
+
+export interface UnsatisfiedHostCapability {
+  readonly id: string;
+  readonly requiredRange: string;
+  readonly hostVersion?: string;
+}
+
+export function readHostRequirements(
+  pluginDir: string,
+): HostRequirementsReadResult {
+  const path = join(pluginDir, HOST_REQUIREMENTS_FILENAME);
+  if (!existsSync(path)) {
+    return { kind: "legacy" };
+  }
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(path, "utf8"));
+  } catch (err) {
+    return {
+      kind: "invalid",
+      reason: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  const parsed = HostRequirementsSchema.safeParse(raw);
+  if (!parsed.success) {
+    return { kind: "invalid", reason: parsed.error.message };
+  }
+
+  for (const [id, range] of Object.entries(parsed.data.requires)) {
+    if (semver.validRange(range) === null) {
+      return {
+        kind: "invalid",
+        reason: `capability ${id} has invalid semver range ${JSON.stringify(range)}`,
+      };
+    }
+  }
+
+  return { kind: "valid", requirements: parsed.data };
+}
+
+export function findUnsatisfiedHostCapabilities(
+  requirements: HostRequirements,
+): UnsatisfiedHostCapability[] {
+  const missing: UnsatisfiedHostCapability[] = [];
+  for (const [id, requiredRange] of Object.entries(requirements.requires)) {
+    if (!satisfiesHostCapability(id, requiredRange)) {
+      missing.push({
+        id,
+        requiredRange,
+        hostVersion: resolveHostCapabilityVersion(id),
+      });
+    }
+  }
+  return missing;
+}

--- a/assistant/src/plugins/mtime-cache.ts
+++ b/assistant/src/plugins/mtime-cache.ts
@@ -32,7 +32,7 @@
  */
 
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 
 import type { Logger } from "pino";
 
@@ -60,6 +60,11 @@ import {
   getWorkspaceHooksDir,
   getWorkspacePluginsDir,
 } from "../util/platform.js";
+import {
+  evictPluginActivationEligibility,
+  getPluginActivationEligibility,
+  resetPluginActivationEligibilityCacheForTests,
+} from "./activation-eligibility.js";
 import { collectSourceVersions } from "./collect-source-versions.js";
 import {
   deriveToolName,
@@ -67,6 +72,21 @@ import {
   parsePluginManifest,
 } from "./external-plugin-loader.js";
 import { isInsidePluginRoot } from "./installed-plugin-dirs.js";
+import {
+  derivePluginSourceFingerprint,
+  getPluginReadiness,
+  isPluginReady,
+  markPluginFailed,
+  markPluginIncompatible,
+  markPluginInitializing,
+  markPluginReady,
+  removePluginReadiness,
+  resetPluginReadinessForTests,
+} from "./plugin-readiness.js";
+import {
+  startPluginWorkers,
+  stopPluginWorkers,
+} from "./plugin-worker-runner.js";
 import { snapshotPluginSource } from "./source-fingerprint.js";
 import type { PluginSourceVersion } from "./source-versions.js";
 import {
@@ -230,7 +250,7 @@ export async function getUserHookEntriesFor<TCtx = unknown>(
 ): Promise<HookEntry<TCtx>[]> {
   return collectUserHookEntries<TCtx>(
     hookName,
-    discoveredPluginDirs.values(),
+    Array.from(discoveredPluginDirs.values()).filter(isPluginReady),
     effectiveEnabledPlugins,
   );
 }
@@ -398,15 +418,22 @@ async function applySourceVersions(
       if (activeName !== undefined && !shouldBeUp) {
         const reason: ShutdownReason =
           after === undefined ? "uninstall" : "disable";
+        removePluginReadiness(activeName);
         await deactivatePlugin(activeName, reason);
         await evictPlugin(dir, activeName);
         sweepModules(before, after);
         membershipChanged = true;
-      } else if (activeName === undefined && shouldBeUp) {
+      } else if (
+        activeName === undefined &&
+        shouldBeUp &&
+        (before === undefined ||
+          before.disabled ||
+          before.fingerprint !== after.fingerprint)
+      ) {
         // Reinstalls land at the same path: sweep any modules cached from a
         // prior install before the fresh import.
         sweepModules(before, after);
-        if (await bringUpPlugin(dir)) {
+        if (await bringUpPlugin(dir, after.sourceFingerprint)) {
           membershipChanged = true;
         }
       } else if (
@@ -419,6 +446,7 @@ async function applySourceVersions(
           { plugin: activeName, dir },
           "plugin source changed — reloading",
         );
+        markPluginInitializing(activeName, after.sourceFingerprint);
         // Tear the old version down first: `deactivatePlugin` runs `shutdown`,
         // then `evictHooksForOwner` drops the owner's cached resolutions so the
         // next read re-resolves fresh.
@@ -426,24 +454,13 @@ async function applySourceVersions(
         evictHooksForOwner("plugin", activeName);
         evictToolCacheEntries(activeName);
         sweepModules(before, after);
-        // Re-read the manifest — the edit may have renamed the plugin (or
-        // broken the manifest, in which case the plugin stays down until a
-        // later edit fixes it and moves the fingerprint again).
-        const manifest = await parsePluginManifest(dir);
-        if (manifest === undefined) {
-          discoveredPluginDirs.delete(dir);
-          membershipChanged = true;
-        } else {
-          if (manifest.name !== activeName) {
-            discoveredPluginDirs.set(dir, manifest.name);
-            membershipChanged = true;
-          }
-          await reconcilePluginTools(dir, manifest.name);
-          await activatePlugin(
-            dir,
-            manifest.name,
-            manifest.credentialKeyPatterns,
-          );
+        discoveredPluginDirs.delete(dir);
+        await bringUpPlugin(dir, after.sourceFingerprint);
+        membershipChanged = true;
+      } else if (!shouldBeUp) {
+        removePluginReadiness(basename(dir));
+        if (after === undefined) {
+          evictPluginActivationEligibility(dir);
         }
       }
     }
@@ -471,17 +488,49 @@ async function applySourceVersions(
  * whether the plugin joined the discovered set (a malformed manifest is
  * logged by the parser and the directory is skipped until it changes again).
  */
-async function bringUpPlugin(dir: string): Promise<boolean> {
+async function bringUpPlugin(
+  dir: string,
+  sourceFingerprint: string,
+): Promise<boolean> {
+  const eligibility = getPluginActivationEligibility(dir);
+  if (!eligibility.eligible) {
+    markPluginIncompatible(eligibility, sourceFingerprint);
+    log.warn(
+      {
+        plugin: eligibility.pluginId,
+        code: eligibility.code,
+        reason: eligibility.reason,
+      },
+      "plugin is incompatible, skipping activation",
+    );
+    return false;
+  }
+
+  markPluginInitializing(eligibility.pluginId, sourceFingerprint);
   const manifest = await parsePluginManifest(dir);
   if (manifest === undefined) {
+    markPluginFailed(
+      eligibility.pluginId,
+      sourceFingerprint,
+      "plugin manifest could not be parsed",
+    );
+    return false;
+  }
+  disabledPluginDirs.delete(dir);
+  log.info({ plugin: manifest.name, dir }, "plugin discovered");
+  const activated = await activatePlugin(
+    dir,
+    manifest.name,
+    sourceFingerprint,
+    manifest.credentialKeyPatterns,
+  );
+  if (!activated) {
+    evictHooksForOwner("plugin", manifest.name);
+    evictToolCacheEntries(manifest.name);
     return false;
   }
   discoveredPluginDirs.set(dir, manifest.name);
-  disabledPluginDirs.delete(dir);
-  log.info({ plugin: manifest.name, dir }, "plugin discovered");
-  await reconcilePluginTools(dir, manifest.name);
-  await activatePlugin(dir, manifest.name, manifest.credentialKeyPatterns);
-  return true;
+  return activated;
 }
 
 /**
@@ -538,25 +587,7 @@ async function reconcileWorkspaceHooks(
  * loaded (an unchanged plugin costs a fingerprint compare, not a redeploy).
  */
 function seedVersionBaseline(): void {
-  const seeded: Record<string, PluginSourceVersion> = {};
-  for (const [dir] of discoveredPluginDirs) {
-    const snapshot = snapshotPluginSource(dir);
-    seeded[dir] = {
-      fingerprint: snapshot.fingerprint,
-      evictionPaths: snapshot.evictionPaths,
-      disabled: false,
-    };
-  }
-  const workspaceHooksDir = getWorkspaceHooksDir();
-  if (existsSync(workspaceHooksDir)) {
-    const snapshot = snapshotPluginSource(workspaceHooksDir);
-    seeded[workspaceHooksDir] = {
-      fingerprint: snapshot.fingerprint,
-      evictionPaths: snapshot.evictionPaths,
-      disabled: false,
-    };
-  }
-  lastVersions = seeded;
+  lastVersions = collectSourceVersions();
 }
 
 // ─── Tool cache ──────────────────────────────────────────────────────────────
@@ -757,6 +788,7 @@ async function scanPlugins(): Promise<void> {
     string,
     PluginCredentialKeyPattern[] | undefined
   >();
+  const sourceFingerprintsByDir = new Map<string, string>();
 
   for (const entry of entries) {
     const pluginDir = join(pluginsDir, entry);
@@ -789,6 +821,7 @@ async function scanPlugins(): Promise<void> {
     if (existsSync(join(pluginDir, ".disabled"))) {
       const manifest = await parsePluginManifest(pluginDir);
       const pluginName = manifest?.name ?? entry;
+      removePluginReadiness(pluginName);
       if (discoveredPluginDirs.has(pluginDir)) {
         await deactivatePlugin(pluginName, "disable");
         await evictPlugin(pluginDir, pluginName);
@@ -803,22 +836,43 @@ async function scanPlugins(): Promise<void> {
       continue;
     }
 
+    const rawSourceFingerprint = snapshotPluginSource(pluginDir).fingerprint;
+    const sourceFingerprint =
+      derivePluginSourceFingerprint(rawSourceFingerprint);
+    const eligibility = getPluginActivationEligibility(pluginDir);
+    if (!eligibility.eligible) {
+      markPluginIncompatible(eligibility, sourceFingerprint);
+      log.warn(
+        {
+          plugin: eligibility.pluginId,
+          code: eligibility.code,
+          reason: eligibility.reason,
+        },
+        "plugin is incompatible, skipping activation",
+      );
+      continue;
+    }
+    markPluginInitializing(eligibility.pluginId, sourceFingerprint);
+
     const manifest = await parsePluginManifest(pluginDir);
     if (manifest === undefined) {
+      markPluginFailed(
+        eligibility.pluginId,
+        sourceFingerprint,
+        "plugin manifest could not be parsed",
+      );
       continue;
     }
     const { name: pluginName } = manifest;
 
     currentDirs.set(pluginDir, pluginName);
     credentialPatternsByDir.set(pluginDir, manifest.credentialKeyPatterns);
+    sourceFingerprintsByDir.set(pluginDir, sourceFingerprint);
     disabledPluginDirs.delete(pluginDir);
 
     if (!discoveredPluginDirs.has(pluginDir)) {
       log.info({ plugin: pluginName, pluginDir }, "plugin discovered");
     }
-
-    // Reconcile this plugin's tools (re-imports changed files).
-    await reconcilePluginTools(pluginDir, pluginName);
   }
 
   // Deactivate and evict cache entries for deleted plugins.
@@ -839,11 +893,24 @@ async function scanPlugins(): Promise<void> {
 
   // Activate any plugin not yet brought up. Idempotent: already-active plugins
   // are skipped by the `activatedNames` guard, so steady-state scans (one per
-  // hook dispatch) cost only a membership check per plugin. Tools were imported
-  // into `toolCache` by `reconcilePluginTools` above, so they are visible to
-  // the registry's pull reconcile as soon as activation flips.
+  // hook dispatch) cost only a membership check per plugin. Successful
+  // activation imports tools into `toolCache` before the plugin becomes ready.
   for (const [dir, name] of discoveredPluginDirs) {
-    await activatePlugin(dir, name, credentialPatternsByDir.get(dir));
+    const sourceFingerprint = sourceFingerprintsByDir.get(dir);
+    if (sourceFingerprint === undefined) {
+      continue;
+    }
+    const activated = await activatePlugin(
+      dir,
+      name,
+      sourceFingerprint,
+      credentialPatternsByDir.get(dir),
+    );
+    if (!activated) {
+      discoveredPluginDirs.delete(dir);
+      evictHooksForOwner("plugin", name);
+      evictToolCacheEntries(name);
+    }
   }
 }
 
@@ -887,6 +954,7 @@ async function evictPlugin(
   );
   discoveredPluginDirs.delete(pluginDir);
   installDateCache.delete(pluginDir);
+  evictPluginActivationEligibility(pluginDir);
 }
 
 /** Drop every `toolCache` entry owned by `pluginName`. */
@@ -907,8 +975,10 @@ function evictToolCacheEntries(pluginName: string): void {
  */
 async function evictAll(): Promise<void> {
   clearPluginHooks();
-  for (const pluginName of discoveredPluginDirs.values()) {
+  for (const [pluginDir, pluginName] of discoveredPluginDirs) {
     unregisterPluginSecretPatterns(pluginName);
+    removePluginReadiness(pluginName);
+    evictPluginActivationEligibility(pluginDir);
   }
   toolCache.clear();
   discoveredPluginDirs.clear();
@@ -933,13 +1003,12 @@ async function evictAll(): Promise<void> {
 const activatedPlugins: Array<{ kind: HookOwnerKind; name: string }> = [];
 
 /**
- * Names in {@link activatedPlugins}, kept as a set for O(1) membership and —
- * critically — reserved *synchronously* at the top of `activatePlugin`. The
- * per-turn hook dispatch reaches `scanPlugins` on every turn (sometimes
- * concurrently), so the synchronous reservation is what prevents a second scan
- * from double-activating a plugin while its async `init()` is still in flight.
+ * Names in {@link activatedPlugins}, kept as a set for O(1) membership.
+ * {@link activatingNames} reserves a name synchronously before async init so
+ * overlapping lifecycle callers cannot activate the same plugin twice.
  */
 const activatedNames = new Set<string>();
+const activatingNames = new Set<string>();
 
 /**
  * Activate a single discovered plugin: mark its cached tools live (the tool
@@ -947,38 +1016,66 @@ const activatedNames = new Set<string>();
  * reconcile) and run its `init` hook. Running `init` also resolves the owner's
  * `shutdown` (caching it for teardown), so no separate pre-import step is
  * needed; dispatch hooks resolve on their first read. Idempotent — a plugin
- * already activated (or mid-activation) is skipped. Never throws; per-surface
- * failures are logged and the plugin still counts as activated so the shutdown
- * teardown handles whatever came up (mirrors boot semantics).
- *
- * Called from `scanPlugins`, which runs both at boot and on every subsequent
- * scan — so a plugin whose files appear at runtime (installed via the CLI or
- * provisioned out-of-band) becomes live without a daemon restart.
+ * already activated is a no-op. A concurrent activation or failed required
+ * surface returns false, and failed partial activation is rolled back.
  */
 async function activatePlugin(
   pluginDir: string,
   pluginName: string,
+  sourceFingerprint: string,
   credentialKeyPatterns?: PluginCredentialKeyPattern[],
-): Promise<void> {
+): Promise<boolean> {
   if (activatedNames.has(pluginName)) {
-    return;
+    return true;
   }
-  // Reserve synchronously, before any await, so a re-entrant or concurrent
-  // scan observes this plugin as already handled. From this point the
-  // plugin's cached tools are visible to the registry's pull reconcile.
-  activatedNames.add(pluginName);
+  if (activatingNames.has(pluginName)) {
+    return false;
+  }
+  activatingNames.add(pluginName);
+  try {
+    // Register declared credential key patterns before `init` so init-time
+    // logging is covered by redaction. Every failed path unregisters them.
+    registerDeclaredCredentialKeyPatterns(
+      pluginName,
+      credentialKeyPatterns,
+      log,
+    );
 
-  // Register declared credential key patterns BEFORE the `init` hook runs so
-  // init-time logging (including caught-error paths that echo a configured
-  // key) is already covered by log redaction — mirroring the default-plugin
-  // bootstrap. Activation never aborts (init failures are swallowed below and
-  // the plugin still counts as activated), so every teardown path unregisters.
-  registerDeclaredCredentialKeyPatterns(pluginName, credentialKeyPatterns, log);
+    const initialized = await runInitHook(pluginName, pluginDir);
+    if (!initialized) {
+      unregisterPluginSecretPatterns(pluginName);
+      markPluginFailed(
+        pluginName,
+        sourceFingerprint,
+        "plugin init hook failed",
+      );
+      return false;
+    }
 
-  // Run the `init` hook if present.
-  await runInitHook(pluginName, pluginDir);
+    try {
+      // Plugin modules outside `init` cannot execute until initialization has
+      // succeeded. Workers run only after the tool cache is fully reconciled.
+      await reconcilePluginTools(pluginDir, pluginName);
+      await startPluginWorkers(pluginDir);
+    } catch (err) {
+      await stopPluginWorkers(pluginName);
+      await runShutdownHook("plugin", pluginName, "reload");
+      unregisterPluginSecretPatterns(pluginName);
+      evictHooksForOwner("plugin", pluginName);
+      evictToolCacheEntries(pluginName);
+      const message = err instanceof Error ? err.message : String(err);
+      markPluginFailed(pluginName, sourceFingerprint, message);
+      log.error({ err, plugin: pluginName }, "plugin surfaces failed to start");
+      return false;
+    }
 
-  activatedPlugins.push({ kind: "plugin", name: pluginName });
+    activatedNames.add(pluginName);
+    activatedPlugins.push({ kind: "plugin", name: pluginName });
+    markPluginReady(pluginName, sourceFingerprint);
+    return true;
+  } finally {
+    activatingNames.delete(pluginName);
+  }
 }
 
 /**
@@ -1018,20 +1115,6 @@ export function registerDeclaredCredentialKeyPatterns(
 }
 
 /**
- * Deactivate a plugin that was disabled (`disable`), removed (`uninstall`), or
- * is being redeployed (`reload`) at runtime: drop it from the active set (the
- * tool registry's pull reconcile removes its tools on its next pass) and run
- * its `shutdown` hook. Must run *before* `evictPlugin` / `evictHooksForOwner`
- * clear the owner's cache. Idempotent — a plugin that was never activated is a
- * no-op.
- *
- * `disable` and `reload` keep the directory present, so {@link runShutdownHook}
- * resolves and runs the on-disk `shutdown` (via the same resolution the dispatch
- * path uses). `uninstall` runs nothing here: a managed uninstall runs `shutdown`
- * *before* removing the directory (see `cli/lib/uninstall-plugin.ts`), and an
- * out-of-band `rm` leaves nothing to resolve.
- */
-/**
  * Deactivate a plugin ahead of an in-place upgrade's file swap: run the
  * outgoing version's `shutdown` while its files are still on disk and drop
  * its cached hook/tool resolutions. The upgrade route passes this as the
@@ -1044,15 +1127,21 @@ export function registerDeclaredCredentialKeyPatterns(
 export async function deactivatePluginForUpdate(
   pluginName: string,
 ): Promise<void> {
+  const readiness = getPluginReadiness(pluginName);
+  if (readiness !== undefined) {
+    markPluginInitializing(pluginName, readiness.sourceFingerprint);
+  }
   await deactivatePlugin(pluginName, "reload");
   evictHooksForOwner("plugin", pluginName);
   evictToolCacheEntries(pluginName);
 }
 
+/** Stop workers and remove one plugin from the active lifecycle set. */
 async function deactivatePlugin(
   pluginName: string,
   reason: ShutdownReason,
 ): Promise<void> {
+  await stopPluginWorkers(pluginName);
   if (!activatedNames.has(pluginName)) {
     return;
   }
@@ -1142,9 +1231,12 @@ export function resetPluginCacheForTests(): void {
   installDateCache.clear();
   activatedPlugins.length = 0;
   activatedNames.clear();
+  activatingNames.clear();
   disabledPluginDirs.clear();
   lastVersions = {};
   reconcileInFlight = null;
+  resetPluginActivationEligibilityCacheForTests();
+  resetPluginReadinessForTests();
 }
 
 /**

--- a/assistant/src/plugins/mtime-cache.ts
+++ b/assistant/src/plugins/mtime-cache.ts
@@ -426,16 +426,16 @@ async function applySourceVersions(
         await evictPlugin(dir, activeName);
         sweepModules(before, after);
         membershipChanged = true;
-      } else if (
-        activeName === undefined &&
-        shouldBeUp &&
-        (before === undefined ||
+      } else if (activeName === undefined && shouldBeUp) {
+        if (
+          before === undefined ||
           before.disabled ||
-          before.fingerprint !== after.fingerprint)
-      ) {
-        // Reinstalls land at the same path: sweep any modules cached from a
-        // prior install before the fresh import.
-        sweepModules(before, after);
+          before.fingerprint !== after.fingerprint
+        ) {
+          // Reinstalls land at the same path: sweep any modules cached from a
+          // prior install before the fresh import.
+          sweepModules(before, after);
+        }
         if (await bringUpPlugin(dir, after.sourceFingerprint)) {
           membershipChanged = true;
         }

--- a/assistant/src/plugins/mtime-cache.ts
+++ b/assistant/src/plugins/mtime-cache.ts
@@ -88,7 +88,10 @@ import {
   stopPluginWorkers,
 } from "./plugin-worker-runner.js";
 import { snapshotPluginSource } from "./source-fingerprint.js";
-import type { PluginSourceVersion } from "./source-versions.js";
+import {
+  type PluginSourceVersion,
+  publishSourceVersions,
+} from "./source-versions.js";
 import {
   clearSurfaceImportInflight,
   evictModule,
@@ -475,6 +478,7 @@ async function applySourceVersions(
     );
 
     lastVersions = { ...next };
+    publishSourceVersions(lastVersions);
   } catch (err) {
     log.error(
       { err },
@@ -588,6 +592,7 @@ async function reconcileWorkspaceHooks(
  */
 function seedVersionBaseline(): void {
   lastVersions = collectSourceVersions();
+  publishSourceVersions(lastVersions);
 }
 
 // ─── Tool cache ──────────────────────────────────────────────────────────────
@@ -1004,11 +1009,9 @@ const activatedPlugins: Array<{ kind: HookOwnerKind; name: string }> = [];
 
 /**
  * Names in {@link activatedPlugins}, kept as a set for O(1) membership.
- * {@link activatingNames} reserves a name synchronously before async init so
- * overlapping lifecycle callers cannot activate the same plugin twice.
  */
 const activatedNames = new Set<string>();
-const activatingNames = new Set<string>();
+const activationPromises = new Map<string, Promise<boolean>>();
 
 /**
  * Activate a single discovered plugin: mark its cached tools live (the tool
@@ -1016,8 +1019,8 @@ const activatingNames = new Set<string>();
  * reconcile) and run its `init` hook. Running `init` also resolves the owner's
  * `shutdown` (caching it for teardown), so no separate pre-import step is
  * needed; dispatch hooks resolve on their first read. Idempotent — a plugin
- * already activated is a no-op. A concurrent activation or failed required
- * surface returns false, and failed partial activation is rolled back.
+ * already activated is a no-op. Concurrent callers share the same activation,
+ * and failed partial activation is rolled back.
  */
 async function activatePlugin(
   pluginDir: string,
@@ -1028,54 +1031,65 @@ async function activatePlugin(
   if (activatedNames.has(pluginName)) {
     return true;
   }
-  if (activatingNames.has(pluginName)) {
+  const current = activationPromises.get(pluginName);
+  if (current !== undefined) {
+    return current;
+  }
+
+  const activation = performPluginActivation(
+    pluginDir,
+    pluginName,
+    sourceFingerprint,
+    credentialKeyPatterns,
+  );
+  activationPromises.set(pluginName, activation);
+  try {
+    return await activation;
+  } finally {
+    if (activationPromises.get(pluginName) === activation) {
+      activationPromises.delete(pluginName);
+    }
+  }
+}
+
+async function performPluginActivation(
+  pluginDir: string,
+  pluginName: string,
+  sourceFingerprint: string,
+  credentialKeyPatterns?: PluginCredentialKeyPattern[],
+): Promise<boolean> {
+  // Register declared credential key patterns before `init` so init-time
+  // logging is covered by redaction. Every failed path unregisters them.
+  registerDeclaredCredentialKeyPatterns(pluginName, credentialKeyPatterns, log);
+
+  const initialized = await runInitHook(pluginName, pluginDir);
+  if (!initialized) {
+    unregisterPluginSecretPatterns(pluginName);
+    markPluginFailed(pluginName, sourceFingerprint, "plugin init hook failed");
     return false;
   }
-  activatingNames.add(pluginName);
+
   try {
-    // Register declared credential key patterns before `init` so init-time
-    // logging is covered by redaction. Every failed path unregisters them.
-    registerDeclaredCredentialKeyPatterns(
-      pluginName,
-      credentialKeyPatterns,
-      log,
-    );
-
-    const initialized = await runInitHook(pluginName, pluginDir);
-    if (!initialized) {
-      unregisterPluginSecretPatterns(pluginName);
-      markPluginFailed(
-        pluginName,
-        sourceFingerprint,
-        "plugin init hook failed",
-      );
-      return false;
-    }
-
-    try {
-      // Plugin modules outside `init` cannot execute until initialization has
-      // succeeded. Workers run only after the tool cache is fully reconciled.
-      await reconcilePluginTools(pluginDir, pluginName);
-      await startPluginWorkers(pluginDir);
-    } catch (err) {
-      await stopPluginWorkers(pluginName);
-      await runShutdownHook("plugin", pluginName, "reload");
-      unregisterPluginSecretPatterns(pluginName);
-      evictHooksForOwner("plugin", pluginName);
-      evictToolCacheEntries(pluginName);
-      const message = err instanceof Error ? err.message : String(err);
-      markPluginFailed(pluginName, sourceFingerprint, message);
-      log.error({ err, plugin: pluginName }, "plugin surfaces failed to start");
-      return false;
-    }
-
-    activatedNames.add(pluginName);
-    activatedPlugins.push({ kind: "plugin", name: pluginName });
-    markPluginReady(pluginName, sourceFingerprint);
-    return true;
-  } finally {
-    activatingNames.delete(pluginName);
+    // Plugin modules outside `init` cannot execute until initialization has
+    // succeeded. Workers run only after the tool cache is fully reconciled.
+    await reconcilePluginTools(pluginDir, pluginName);
+    await startPluginWorkers(pluginDir);
+  } catch (err) {
+    await stopPluginWorkers(pluginName);
+    await runShutdownHook("plugin", pluginName, "reload");
+    unregisterPluginSecretPatterns(pluginName);
+    evictHooksForOwner("plugin", pluginName);
+    evictToolCacheEntries(pluginName);
+    const message = err instanceof Error ? err.message : String(err);
+    markPluginFailed(pluginName, sourceFingerprint, message);
+    log.error({ err, plugin: pluginName }, "plugin surfaces failed to start");
+    return false;
   }
+
+  activatedNames.add(pluginName);
+  activatedPlugins.push({ kind: "plugin", name: pluginName });
+  markPluginReady(pluginName, sourceFingerprint);
+  return true;
 }
 
 /**
@@ -1231,7 +1245,7 @@ export function resetPluginCacheForTests(): void {
   installDateCache.clear();
   activatedPlugins.length = 0;
   activatedNames.clear();
-  activatingNames.clear();
+  activationPromises.clear();
   disabledPluginDirs.clear();
   lastVersions = {};
   reconcileInFlight = null;

--- a/assistant/src/plugins/plugin-readiness.ts
+++ b/assistant/src/plugins/plugin-readiness.ts
@@ -1,0 +1,155 @@
+import { randomUUID } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+
+import {
+  PLUGIN_READINESS_FILENAME,
+  type PluginReadinessEntry,
+  type PluginReadinessSnapshot,
+  PluginReadinessSnapshotSchema,
+} from "@vellumai/service-contracts/plugin-readiness";
+
+import { getWorkspaceDir } from "../util/platform.js";
+import type { PluginActivationEligibility } from "./activation-eligibility.js";
+export { derivePluginSourceFingerprint } from "./source-fingerprint.js";
+
+let snapshot: PluginReadinessSnapshot = createSnapshot();
+
+function createSnapshot(): PluginReadinessSnapshot {
+  return { schemaVersion: 1, generation: randomUUID(), plugins: {} };
+}
+
+export function getPluginReadinessPath(
+  workspaceDir = getWorkspaceDir(),
+): string {
+  return join(workspaceDir, "data", PLUGIN_READINESS_FILENAME);
+}
+
+function persistSnapshot(): void {
+  const path = getPluginReadinessPath();
+  mkdirSync(dirname(path), { recursive: true });
+  const tempPath = `${path}.${process.pid}.tmp`;
+  writeFileSync(tempPath, `${JSON.stringify(snapshot)}\n`, { mode: 0o600 });
+  renameSync(tempPath, path);
+}
+
+function update(entry: PluginReadinessEntry): void {
+  const current = snapshot.plugins[entry.pluginId];
+  if (
+    current?.sourceFingerprint === entry.sourceFingerprint &&
+    current.status === entry.status &&
+    current.code === entry.code &&
+    current.message === entry.message
+  ) {
+    return;
+  }
+  snapshot = {
+    ...snapshot,
+    plugins: { ...snapshot.plugins, [entry.pluginId]: entry },
+  };
+  persistSnapshot();
+}
+
+export function resetPluginReadinessForBoot(): void {
+  snapshot = createSnapshot();
+  persistSnapshot();
+}
+
+export function markPluginInitializing(
+  pluginId: string,
+  sourceFingerprint: string,
+): void {
+  update({
+    pluginId,
+    sourceFingerprint,
+    status: "initializing",
+    updatedAt: new Date().toISOString(),
+  });
+}
+
+export function markPluginReady(
+  pluginId: string,
+  sourceFingerprint: string,
+): void {
+  update({
+    pluginId,
+    sourceFingerprint,
+    status: "ready",
+    updatedAt: new Date().toISOString(),
+  });
+}
+
+export function markPluginIncompatible(
+  eligibility: Extract<PluginActivationEligibility, { eligible: false }>,
+  sourceFingerprint: string,
+): void {
+  update({
+    pluginId: eligibility.pluginId,
+    sourceFingerprint,
+    status: "incompatible",
+    code: eligibility.code,
+    message: eligibility.reason,
+    updatedAt: new Date().toISOString(),
+  });
+}
+
+export function markPluginFailed(
+  pluginId: string,
+  sourceFingerprint: string,
+  message: string,
+): void {
+  update({
+    pluginId,
+    sourceFingerprint,
+    status: "failed",
+    code: "plugin_initialization_failed",
+    message,
+    updatedAt: new Date().toISOString(),
+  });
+}
+
+export function removePluginReadiness(pluginId: string): void {
+  if (!(pluginId in snapshot.plugins)) {
+    return;
+  }
+  const plugins = { ...snapshot.plugins };
+  delete plugins[pluginId];
+  snapshot = { ...snapshot, plugins };
+  persistSnapshot();
+}
+
+export function getPluginReadiness(
+  pluginId: string,
+): PluginReadinessEntry | undefined {
+  return snapshot.plugins[pluginId];
+}
+
+export function isPluginReady(pluginId: string): boolean {
+  return getPluginReadiness(pluginId)?.status === "ready";
+}
+
+export function readPluginReadinessSnapshot(
+  workspaceDir = getWorkspaceDir(),
+): PluginReadinessSnapshot | undefined {
+  const path = getPluginReadinessPath(workspaceDir);
+  if (!existsSync(path)) {
+    return undefined;
+  }
+  try {
+    return PluginReadinessSnapshotSchema.parse(
+      JSON.parse(readFileSync(path, "utf8")),
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+export function resetPluginReadinessForTests(): void {
+  snapshot = createSnapshot();
+}

--- a/assistant/src/plugins/plugin-readiness.ts
+++ b/assistant/src/plugins/plugin-readiness.ts
@@ -20,9 +20,28 @@ import {
   getPluginActivationEligibility,
   type PluginActivationEligibility,
 } from "./activation-eligibility.js";
+import {
+  derivePluginSourceFingerprint,
+  snapshotPluginSource,
+} from "./source-fingerprint.js";
+import { getFileSignature } from "./surface-import.js";
 export { derivePluginSourceFingerprint } from "./source-fingerprint.js";
 
 let snapshot: PluginReadinessSnapshot = createSnapshot();
+let durableReadsEnabled =
+  process.env.BUN_TEST !== "1" && process.env.NODE_ENV !== "test";
+let durableSnapshotCache:
+  | {
+      readonly path: string;
+      readonly signature: string;
+      readonly value: PluginReadinessSnapshot | undefined;
+    }
+  | undefined;
+const sourceFingerprintCache = new Map<
+  string,
+  { readonly checkedAt: number; readonly fingerprint: string }
+>();
+const SOURCE_FINGERPRINT_CACHE_MS = 1_000;
 
 function createSnapshot(): PluginReadinessSnapshot {
   return { schemaVersion: 1, generation: randomUUID(), plugins: {} };
@@ -162,7 +181,9 @@ export function getPluginSurfaceActivation(
     return { status: "ready" };
   }
 
-  const readiness = getPluginReadiness(pluginId);
+  const readiness =
+    getPluginReadiness(pluginId) ??
+    getDurablePluginReadiness(pluginId, pluginDir);
   if (!readiness) {
     return {
       status: "initializing",
@@ -190,6 +211,36 @@ export function getPluginSurfaceActivation(
   };
 }
 
+function getDurablePluginReadiness(
+  pluginId: string,
+  pluginDir: string,
+): PluginReadinessEntry | undefined {
+  if (!durableReadsEnabled) {
+    return undefined;
+  }
+  const readiness = readPluginReadinessSnapshot()?.plugins[pluginId];
+  if (!readiness) {
+    return undefined;
+  }
+  const now = Date.now();
+  const cached = sourceFingerprintCache.get(pluginDir);
+  let sourceFingerprint: string;
+  if (cached && now - cached.checkedAt < SOURCE_FINGERPRINT_CACHE_MS) {
+    sourceFingerprint = cached.fingerprint;
+  } else {
+    sourceFingerprint = derivePluginSourceFingerprint(
+      snapshotPluginSource(pluginDir).fingerprint,
+    );
+    sourceFingerprintCache.set(pluginDir, {
+      checkedAt: now,
+      fingerprint: sourceFingerprint,
+    });
+  }
+  return readiness.sourceFingerprint === sourceFingerprint
+    ? readiness
+    : undefined;
+}
+
 export function isPluginSurfaceReady(
   pluginId: string,
   pluginDir: string,
@@ -197,22 +248,36 @@ export function isPluginSurfaceReady(
   return getPluginSurfaceActivation(pluginId, pluginDir).status === "ready";
 }
 
-export function readPluginReadinessSnapshot(
+function readPluginReadinessSnapshot(
   workspaceDir = getWorkspaceDir(),
 ): PluginReadinessSnapshot | undefined {
   const path = getPluginReadinessPath(workspaceDir);
-  if (!existsSync(path)) {
-    return undefined;
+  const signature = getFileSignature(path);
+  if (
+    durableSnapshotCache?.path === path &&
+    durableSnapshotCache.signature === signature
+  ) {
+    return durableSnapshotCache.value;
   }
+  let value: PluginReadinessSnapshot | undefined;
   try {
-    return PluginReadinessSnapshotSchema.parse(
-      JSON.parse(readFileSync(path, "utf8")),
-    );
+    value = existsSync(path)
+      ? PluginReadinessSnapshotSchema.parse(
+          JSON.parse(readFileSync(path, "utf8")),
+        )
+      : undefined;
   } catch {
-    return undefined;
+    value = undefined;
   }
+  durableSnapshotCache = { path, signature, value };
+  return value;
 }
 
-export function resetPluginReadinessForTests(): void {
+export function resetPluginReadinessForTests(
+  options: { readonly durableReads?: boolean } = {},
+): void {
   snapshot = createSnapshot();
+  durableReadsEnabled = options.durableReads ?? false;
+  durableSnapshotCache = undefined;
+  sourceFingerprintCache.clear();
 }

--- a/assistant/src/plugins/plugin-readiness.ts
+++ b/assistant/src/plugins/plugin-readiness.ts
@@ -16,7 +16,10 @@ import {
 } from "@vellumai/service-contracts/plugin-readiness";
 
 import { getWorkspaceDir } from "../util/platform.js";
-import type { PluginActivationEligibility } from "./activation-eligibility.js";
+import {
+  getPluginActivationEligibility,
+  type PluginActivationEligibility,
+} from "./activation-eligibility.js";
 export { derivePluginSourceFingerprint } from "./source-fingerprint.js";
 
 let snapshot: PluginReadinessSnapshot = createSnapshot();
@@ -132,6 +135,66 @@ export function getPluginReadiness(
 
 export function isPluginReady(pluginId: string): boolean {
   return getPluginReadiness(pluginId)?.status === "ready";
+}
+
+export type PluginSurfaceActivation =
+  | { readonly status: "ready" }
+  | {
+      readonly status: "initializing" | "incompatible" | "failed";
+      readonly code: string;
+      readonly message: string;
+    };
+
+/** Resolve whether an installed plugin may contribute disk-backed surfaces. */
+export function getPluginSurfaceActivation(
+  pluginId: string,
+  pluginDir: string,
+): PluginSurfaceActivation {
+  const eligibility = getPluginActivationEligibility(pluginDir);
+  if (!eligibility.eligible) {
+    return {
+      status: "incompatible",
+      code: eligibility.code,
+      message: eligibility.reason,
+    };
+  }
+  if (eligibility.mode === "legacy") {
+    return { status: "ready" };
+  }
+
+  const readiness = getPluginReadiness(pluginId);
+  if (!readiness) {
+    return {
+      status: "initializing",
+      code: "plugin_initializing",
+      message: "Plugin is initializing",
+    };
+  }
+  if (readiness.status === "ready") {
+    return { status: "ready" };
+  }
+  return {
+    status: readiness.status,
+    code:
+      readiness.code ??
+      (readiness.status === "failed"
+        ? "plugin_initialization_failed"
+        : readiness.status === "incompatible"
+          ? "plugin_incompatible"
+          : "plugin_initializing"),
+    message:
+      readiness.message ??
+      (readiness.status === "initializing"
+        ? "Plugin is initializing"
+        : "Plugin is unavailable"),
+  };
+}
+
+export function isPluginSurfaceReady(
+  pluginId: string,
+  pluginDir: string,
+): boolean {
+  return getPluginSurfaceActivation(pluginId, pluginDir).status === "ready";
 }
 
 export function readPluginReadinessSnapshot(

--- a/assistant/src/plugins/plugin-route-manifest.ts
+++ b/assistant/src/plugins/plugin-route-manifest.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 
@@ -141,14 +142,13 @@ export type PluginRouteManifestResult =
   | { readonly kind: "invalid"; readonly reason: string };
 
 interface CachedManifest {
-  readonly mtimeMs: number;
-  readonly size: number;
+  readonly contentSignature: string;
   readonly result: PluginRouteManifestResult;
 }
 
 const cache = new Map<string, CachedManifest>();
 
-export function getPluginRouteManifestPath(pluginDir: string): string {
+function getPluginRouteManifestPath(pluginDir: string): string {
   return join(pluginDir, PLUGIN_ROUTE_MANIFEST_PATH);
 }
 
@@ -170,12 +170,8 @@ export function readPluginRouteManifest(
     };
   }
 
-  const cached = cache.get(pluginDir);
-  if (cached?.mtimeMs === stat.mtimeMs && cached.size === stat.size) {
-    return cached.result;
-  }
-
   let result: PluginRouteManifestResult;
+  let contentSignature = `${stat.dev}:${stat.ino}:${stat.size}`;
   if (!stat.isFile()) {
     result = { kind: "invalid", reason: "route manifest must be a file" };
   } else if (stat.size > MAX_MANIFEST_BYTES) {
@@ -185,8 +181,14 @@ export function readPluginRouteManifest(
     };
   } else {
     try {
+      const contents = readFileSync(manifestPath);
+      contentSignature = createHash("sha256").update(contents).digest("hex");
+      const cached = cache.get(pluginDir);
+      if (cached?.contentSignature === contentSignature) {
+        return cached.result;
+      }
       const parsed = PluginRouteManifestSchema.safeParse(
-        JSON.parse(readFileSync(manifestPath, "utf8")),
+        JSON.parse(contents.toString("utf8")),
       );
       result = parsed.success
         ? { kind: "valid", manifest: parsed.data }
@@ -199,7 +201,7 @@ export function readPluginRouteManifest(
     }
   }
 
-  cache.set(pluginDir, { mtimeMs: stat.mtimeMs, size: stat.size, result });
+  cache.set(pluginDir, { contentSignature, result });
   return result;
 }
 

--- a/assistant/src/plugins/plugin-route-manifest.ts
+++ b/assistant/src/plugins/plugin-route-manifest.ts
@@ -1,0 +1,218 @@
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { z } from "zod";
+
+import { PeerOperationKindSchema } from "../plugin-api/verified-peer-context.js";
+
+export const PLUGIN_ROUTE_MANIFEST_PATH = join("routes", "manifest.json");
+
+const MAX_MANIFEST_BYTES = 128 * 1024;
+const MAX_ROUTES = 256;
+const ROUTE_PATH_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._~/-]*$/;
+const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+function isActorMutationScope(scope: string): boolean {
+  return (
+    scope.endsWith(".write") ||
+    scope === "local.all" ||
+    scope === "speech.relay"
+  );
+}
+
+export const PluginRouteMethodSchema = z.enum([
+  "GET",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+  "HEAD",
+  "OPTIONS",
+]);
+
+export const PluginRouteScopeSchema = z.enum([
+  "chat.read",
+  "chat.write",
+  "approval.read",
+  "approval.write",
+  "settings.read",
+  "settings.write",
+  "attachments.read",
+  "attachments.write",
+  "calls.read",
+  "calls.write",
+  "ingress.write",
+  "internal.write",
+  "feature_flags.read",
+  "feature_flags.write",
+  "speech.relay",
+  "local.all",
+]);
+
+const ActorRouteAuthorizationSchema = z
+  .object({
+    principal: z.literal("actor"),
+    requiredScopes: z.array(PluginRouteScopeSchema).min(1).max(8),
+  })
+  .strict();
+
+const AssistantPeerRouteAuthorizationSchema = z
+  .object({
+    principal: z.literal("assistant_peer"),
+    operationKinds: z.array(PeerOperationKindSchema).min(1).max(32).optional(),
+  })
+  .strict();
+
+export const PluginRouteAuthorizationSchema = z.discriminatedUnion(
+  "principal",
+  [ActorRouteAuthorizationSchema, AssistantPeerRouteAuthorizationSchema],
+);
+
+export const PluginRouteDeclarationSchema = z
+  .object({
+    path: z.string().min(1).max(240).regex(ROUTE_PATH_PATTERN),
+    method: PluginRouteMethodSchema,
+    authorization: PluginRouteAuthorizationSchema,
+  })
+  .strict()
+  .superRefine((route, ctx) => {
+    if (
+      route.path.startsWith("/") ||
+      route.path.endsWith("/") ||
+      route.path.split("/").some((segment) => segment === "..")
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["path"],
+        message: "route paths must be normalized relative paths",
+      });
+    }
+    if (
+      MUTATING_METHODS.has(route.method) &&
+      route.authorization.principal === "actor" &&
+      !route.authorization.requiredScopes.some(isActorMutationScope)
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["authorization", "requiredScopes"],
+        message: "mutating actor routes require a write or action scope",
+      });
+    }
+  });
+
+export const PluginRouteManifestSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    routes: z.array(PluginRouteDeclarationSchema).max(MAX_ROUTES),
+  })
+  .strict()
+  .superRefine((manifest, ctx) => {
+    const seen = new Set<string>();
+    for (let index = 0; index < manifest.routes.length; index += 1) {
+      const route = manifest.routes[index];
+      const key = `${route.method} ${route.path}`;
+      if (seen.has(key)) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["routes", index],
+          message: `duplicate route declaration: ${key}`,
+        });
+      }
+      seen.add(key);
+    }
+  });
+
+export type PluginRouteMethod = z.infer<typeof PluginRouteMethodSchema>;
+export type PluginRouteScope = z.infer<typeof PluginRouteScopeSchema>;
+export type PluginRouteAuthorization = z.infer<
+  typeof PluginRouteAuthorizationSchema
+>;
+export type PluginRouteDeclaration = z.infer<
+  typeof PluginRouteDeclarationSchema
+>;
+export type PluginRouteManifest = z.infer<typeof PluginRouteManifestSchema>;
+
+export type PluginRouteManifestResult =
+  | { readonly kind: "legacy" }
+  | {
+      readonly kind: "valid";
+      readonly manifest: PluginRouteManifest;
+    }
+  | { readonly kind: "invalid"; readonly reason: string };
+
+interface CachedManifest {
+  readonly mtimeMs: number;
+  readonly size: number;
+  readonly result: PluginRouteManifestResult;
+}
+
+const cache = new Map<string, CachedManifest>();
+
+export function getPluginRouteManifestPath(pluginDir: string): string {
+  return join(pluginDir, PLUGIN_ROUTE_MANIFEST_PATH);
+}
+
+export function readPluginRouteManifest(
+  pluginDir: string,
+): PluginRouteManifestResult {
+  const manifestPath = getPluginRouteManifestPath(pluginDir);
+  if (!existsSync(manifestPath)) {
+    return { kind: "legacy" };
+  }
+
+  let stat: ReturnType<typeof statSync>;
+  try {
+    stat = statSync(manifestPath);
+  } catch (err) {
+    return {
+      kind: "invalid",
+      reason: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  const cached = cache.get(pluginDir);
+  if (cached?.mtimeMs === stat.mtimeMs && cached.size === stat.size) {
+    return cached.result;
+  }
+
+  let result: PluginRouteManifestResult;
+  if (!stat.isFile()) {
+    result = { kind: "invalid", reason: "route manifest must be a file" };
+  } else if (stat.size > MAX_MANIFEST_BYTES) {
+    result = {
+      kind: "invalid",
+      reason: `route manifest exceeds ${MAX_MANIFEST_BYTES} bytes`,
+    };
+  } else {
+    try {
+      const parsed = PluginRouteManifestSchema.safeParse(
+        JSON.parse(readFileSync(manifestPath, "utf8")),
+      );
+      result = parsed.success
+        ? { kind: "valid", manifest: parsed.data }
+        : { kind: "invalid", reason: parsed.error.message };
+    } catch (err) {
+      result = {
+        kind: "invalid",
+        reason: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  cache.set(pluginDir, { mtimeMs: stat.mtimeMs, size: stat.size, result });
+  return result;
+}
+
+export function findPluginRouteDeclaration(
+  manifest: PluginRouteManifest,
+  path: string,
+  method: string,
+): PluginRouteDeclaration | undefined {
+  return manifest.routes.find(
+    (route) => route.path === path && route.method === method,
+  );
+}
+
+export function resetPluginRouteManifestCacheForTests(): void {
+  cache.clear();
+}

--- a/assistant/src/plugins/plugin-storage.ts
+++ b/assistant/src/plugins/plugin-storage.ts
@@ -1,0 +1,49 @@
+import { cpSync, existsSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+
+import { getLogger } from "../util/logger.js";
+import { getWorkspaceDir } from "../util/platform.js";
+
+const log = getLogger("plugin-storage");
+const PLUGIN_DATA_DIRNAME = "data";
+
+function ensureLegacyStorageDir(pluginId: string): string {
+  const dir = join(getWorkspaceDir(), "plugins-data", pluginId);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+/** Resolve and create the durable storage directory for one plugin owner. */
+export function resolvePluginStorageDir(
+  pluginId: string,
+  pluginDir: string | null,
+): string {
+  if (pluginDir === null) {
+    return ensureLegacyStorageDir(pluginId);
+  }
+
+  const dataDir = join(pluginDir, PLUGIN_DATA_DIRNAME);
+  if (!existsSync(dataDir)) {
+    const oldDir = join(getWorkspaceDir(), "plugins-data", pluginId);
+    if (existsSync(oldDir)) {
+      try {
+        mkdirSync(dataDir, { recursive: true });
+        cpSync(oldDir, dataDir, { recursive: true });
+        rmSync(oldDir, { recursive: true, force: true });
+        log.info(
+          { plugin: pluginId, oldDir, dataDir },
+          "migrated plugin data from plugins-data to plugin directory",
+        );
+      } catch (err) {
+        log.warn(
+          { err, plugin: pluginId, oldDir, dataDir },
+          "failed to migrate plugin data to plugin directory, using old location",
+        );
+        return ensureLegacyStorageDir(pluginId);
+      }
+    }
+  }
+
+  mkdirSync(dataDir, { recursive: true });
+  return dataDir;
+}

--- a/assistant/src/plugins/plugin-worker-runner.ts
+++ b/assistant/src/plugins/plugin-worker-runner.ts
@@ -1,0 +1,332 @@
+import { basename } from "node:path";
+
+import type { PluginLogger } from "../hooks/types.js";
+import type {
+  PluginWorkerContext,
+  PluginWorkerResult,
+  PluginWorkerWakeTime,
+} from "../plugin-api/plugin-worker.js";
+import { getLogger } from "../util/logger.js";
+import { APP_VERSION } from "../version.js";
+import {
+  type ExternalPluginWorker,
+  loadExternalPluginWorkers,
+} from "./external-plugin-workers.js";
+import { runInPluginContext } from "./plugin-execution-context.js";
+import { resolvePluginStorageDir } from "./plugin-storage.js";
+
+const STOP_TIMEOUT_MS = 5_000;
+const MIN_WAKE_DELAY_MS = 10;
+const log = getLogger("plugin-worker-runner");
+
+export interface StartPluginWorkersOptions {
+  readonly importTimeoutMs?: number;
+}
+
+export interface StartPluginWorkersResult {
+  readonly pluginId: string;
+  readonly workerCount: number;
+  readonly started: boolean;
+}
+
+export interface StopPluginWorkersOptions {
+  readonly timeoutMs?: number;
+}
+
+interface WorkerRuntime {
+  readonly definition: ExternalPluginWorker;
+  readonly context: PluginWorkerContext;
+  readonly controller: AbortController;
+  timer: ReturnType<typeof setTimeout> | null;
+  inFlight: Promise<void> | null;
+  wakeRequested: boolean;
+  stopped: boolean;
+}
+
+interface PluginWorkerActivation {
+  readonly workers: WorkerRuntime[];
+  state: "active" | "stopping";
+}
+
+const activations = new Map<string, PluginWorkerActivation>();
+
+function toWakeEpoch(value: PluginWorkerWakeTime): number | null {
+  const epoch = value instanceof Date ? value.getTime() : value;
+  return Number.isFinite(epoch) ? epoch : null;
+}
+
+function clearWakeTimer(runtime: WorkerRuntime): void {
+  if (runtime.timer !== null) {
+    clearTimeout(runtime.timer);
+    runtime.timer = null;
+  }
+}
+
+function scheduleWorker(runtime: WorkerRuntime, delayMs: number): void {
+  if (runtime.stopped || runtime.controller.signal.aborted) {
+    return;
+  }
+  clearWakeTimer(runtime);
+  runtime.timer = setTimeout(
+    () => {
+      runtime.timer = null;
+      void invokeWorker(runtime);
+    },
+    Math.max(0, delayMs),
+  );
+  runtime.timer.unref?.();
+}
+
+function requestWorkerWake(runtime: WorkerRuntime): void {
+  if (runtime.stopped || runtime.controller.signal.aborted) {
+    return;
+  }
+  if (runtime.inFlight !== null) {
+    runtime.wakeRequested = true;
+    return;
+  }
+  scheduleWorker(runtime, 0);
+}
+
+function scheduleNextWake(
+  runtime: WorkerRuntime,
+  result: PluginWorkerResult | void,
+): void {
+  if (runtime.wakeRequested) {
+    runtime.wakeRequested = false;
+    scheduleWorker(runtime, 0);
+    return;
+  }
+  if (result?.nextWakeAt === undefined || result.nextWakeAt === null) {
+    return;
+  }
+  const epoch = toWakeEpoch(result.nextWakeAt);
+  if (epoch === null) {
+    runtime.context.logger.warn(
+      { nextWakeAt: result.nextWakeAt },
+      "plugin worker returned an invalid next wake time",
+    );
+    return;
+  }
+  scheduleWorker(runtime, Math.max(MIN_WAKE_DELAY_MS, epoch - Date.now()));
+}
+
+async function executeWorker(
+  runtime: WorkerRuntime,
+  rejectOnFailure: boolean,
+): Promise<void> {
+  let result: PluginWorkerResult | void;
+  try {
+    result = await runInPluginContext(runtime.definition.pluginId, () =>
+      runtime.definition.run(runtime.context),
+    );
+  } catch (err) {
+    if (rejectOnFailure) {
+      throw err;
+    }
+    if (!runtime.controller.signal.aborted) {
+      runtime.context.logger.error({ err }, "plugin worker failed");
+    }
+    return;
+  }
+  if (!runtime.stopped && !runtime.controller.signal.aborted) {
+    scheduleNextWake(runtime, result);
+  }
+}
+
+async function invokeWorker(
+  runtime: WorkerRuntime,
+  rejectOnFailure = false,
+): Promise<void> {
+  if (
+    runtime.stopped ||
+    runtime.controller.signal.aborted ||
+    runtime.inFlight !== null
+  ) {
+    return;
+  }
+  const run = executeWorker(runtime, rejectOnFailure);
+  runtime.inFlight = run;
+  try {
+    await run;
+  } finally {
+    if (runtime.inFlight === run) {
+      runtime.inFlight = null;
+    }
+  }
+}
+
+function createWorkerRuntime(
+  worker: ExternalPluginWorker,
+  pluginStorageDir: string,
+): WorkerRuntime {
+  const controller = new AbortController();
+  const logger = log.child({
+    plugin: worker.pluginId,
+    worker: worker.name,
+  }) as PluginLogger;
+  const runtime: WorkerRuntime = {
+    definition: worker,
+    context: {
+      pluginId: worker.pluginId,
+      pluginStorageDir,
+      assistantVersion: APP_VERSION,
+      signal: controller.signal,
+      logger,
+      requestWake: () => requestWorkerWake(runtime),
+    },
+    controller,
+    timer: null,
+    inFlight: null,
+    wakeRequested: false,
+    stopped: false,
+  };
+  return runtime;
+}
+
+/** Load and start one host-managed activation for an external plugin. */
+export async function startPluginWorkers(
+  pluginDir: string,
+  options: StartPluginWorkersOptions = {},
+): Promise<StartPluginWorkersResult> {
+  const pluginId = basename(pluginDir);
+  const current = activations.get(pluginId);
+  if (current !== undefined) {
+    if (current.state === "stopping") {
+      throw new Error(`plugin ${pluginId} workers are still stopping`);
+    }
+    return {
+      pluginId,
+      workerCount: current.workers.length,
+      started: false,
+    };
+  }
+
+  const workers = await loadExternalPluginWorkers(
+    pluginDir,
+    options.importTimeoutMs,
+  );
+  const pluginStorageDir = resolvePluginStorageDir(pluginId, pluginDir);
+  const activation: PluginWorkerActivation = {
+    workers: workers.map((worker) =>
+      createWorkerRuntime(worker, pluginStorageDir),
+    ),
+    state: "active",
+  };
+  activations.set(pluginId, activation);
+  try {
+    await Promise.all(
+      activation.workers.map((runtime) => invokeWorker(runtime, true)),
+    );
+  } catch (err) {
+    await stopPluginWorkers(pluginId);
+    log.error({ err, plugin: pluginId }, "plugin initial worker run failed");
+    throw err;
+  }
+  return { pluginId, workerCount: workers.length, started: true };
+}
+
+async function awaitStoppedWorkers(
+  workers: readonly WorkerRuntime[],
+  timeoutMs: number,
+): Promise<boolean> {
+  const pending = workers.flatMap((worker) =>
+    worker.inFlight === null ? [] : [worker.inFlight],
+  );
+  if (pending.length === 0) {
+    return true;
+  }
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      Promise.allSettled(pending).then(() => true),
+      new Promise<boolean>((resolve) => {
+        timer = setTimeout(() => resolve(false), timeoutMs);
+        timer.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+    }
+  }
+}
+
+/** Abort and drain all workers for one plugin activation. */
+export async function stopPluginWorkers(
+  pluginId: string,
+  options: StopPluginWorkersOptions = {},
+): Promise<void> {
+  const activation = activations.get(pluginId);
+  if (activation === undefined) {
+    return;
+  }
+  activation.state = "stopping";
+  for (const worker of activation.workers) {
+    worker.stopped = true;
+    clearWakeTimer(worker);
+    worker.controller.abort(new Error(`plugin ${pluginId} stopped`));
+  }
+  const stopped = await awaitStoppedWorkers(
+    activation.workers,
+    options.timeoutMs ?? STOP_TIMEOUT_MS,
+  );
+  if (stopped) {
+    if (activations.get(pluginId) === activation) {
+      activations.delete(pluginId);
+    }
+    return;
+  }
+
+  const pending = activation.workers.flatMap((worker) =>
+    worker.inFlight === null ? [] : [worker.inFlight],
+  );
+  log.warn(
+    { plugin: pluginId, workerCount: pending.length },
+    "plugin workers did not stop before timeout",
+  );
+  void Promise.allSettled(pending).then(() => {
+    if (activations.get(pluginId) === activation) {
+      activations.delete(pluginId);
+    }
+  });
+}
+
+/** Abort every active external plugin worker. */
+export async function stopAllPluginWorkers(
+  options: StopPluginWorkersOptions = {},
+): Promise<void> {
+  await Promise.all(
+    [...activations.keys()].map((pluginId) =>
+      stopPluginWorkers(pluginId, options),
+    ),
+  );
+}
+
+/** Current worker count for one activation. */
+export function getActivePluginWorkerCount(pluginId: string): number {
+  return activations.get(pluginId)?.workers.length ?? 0;
+}
+
+/** Wait until a plugin has no active invocation. Test-only. */
+export async function waitForPluginWorkersIdleForTests(
+  pluginId: string,
+): Promise<void> {
+  for (;;) {
+    const activation = activations.get(pluginId);
+    if (
+      activation === undefined ||
+      activation.workers.every(
+        (worker) => worker.inFlight === null && worker.timer === null,
+      )
+    ) {
+      return;
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, 1));
+  }
+}
+
+/** Stop workers and clear runner state. Test-only. */
+export async function resetPluginWorkerRunnerForTests(): Promise<void> {
+  await stopAllPluginWorkers({ timeoutMs: 100 });
+}

--- a/assistant/src/plugins/plugin-worker-runner.ts
+++ b/assistant/src/plugins/plugin-worker-runner.ts
@@ -16,11 +16,14 @@ import { runInPluginContext } from "./plugin-execution-context.js";
 import { resolvePluginStorageDir } from "./plugin-storage.js";
 
 const STOP_TIMEOUT_MS = 5_000;
+const INITIAL_RUN_TIMEOUT_MS = 30_000;
 const MIN_WAKE_DELAY_MS = 10;
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
 const log = getLogger("plugin-worker-runner");
 
 export interface StartPluginWorkersOptions {
   readonly importTimeoutMs?: number;
+  readonly initialRunTimeoutMs?: number;
 }
 
 export interface StartPluginWorkersResult {
@@ -40,6 +43,7 @@ interface WorkerRuntime {
   timer: ReturnType<typeof setTimeout> | null;
   inFlight: Promise<void> | null;
   wakeRequested: boolean;
+  nextWakeAt: number | null;
   stopped: boolean;
 }
 
@@ -60,6 +64,29 @@ function clearWakeTimer(runtime: WorkerRuntime): void {
     clearTimeout(runtime.timer);
     runtime.timer = null;
   }
+  runtime.nextWakeAt = null;
+}
+
+function armWakeTimer(runtime: WorkerRuntime): void {
+  if (runtime.stopped || runtime.controller.signal.aborted) {
+    return;
+  }
+  const nextWakeAt = runtime.nextWakeAt;
+  if (nextWakeAt === null) {
+    return;
+  }
+  const remainingMs = nextWakeAt - Date.now();
+  const delayMs = Math.min(MAX_TIMER_DELAY_MS, Math.max(0, remainingMs));
+  runtime.timer = setTimeout(() => {
+    runtime.timer = null;
+    if (runtime.nextWakeAt !== null && runtime.nextWakeAt > Date.now()) {
+      armWakeTimer(runtime);
+      return;
+    }
+    runtime.nextWakeAt = null;
+    void invokeWorker(runtime);
+  }, delayMs);
+  runtime.timer.unref?.();
 }
 
 function scheduleWorker(runtime: WorkerRuntime, delayMs: number): void {
@@ -67,14 +94,8 @@ function scheduleWorker(runtime: WorkerRuntime, delayMs: number): void {
     return;
   }
   clearWakeTimer(runtime);
-  runtime.timer = setTimeout(
-    () => {
-      runtime.timer = null;
-      void invokeWorker(runtime);
-    },
-    Math.max(0, delayMs),
-  );
-  runtime.timer.unref?.();
+  runtime.nextWakeAt = Date.now() + Math.max(0, delayMs);
+  armWakeTimer(runtime);
 }
 
 function requestWorkerWake(runtime: WorkerRuntime): void {
@@ -179,6 +200,7 @@ function createWorkerRuntime(
     timer: null,
     inFlight: null,
     wakeRequested: false,
+    nextWakeAt: null,
     stopped: false,
   };
   return runtime;
@@ -214,14 +236,31 @@ export async function startPluginWorkers(
     state: "active",
   };
   activations.set(pluginId, activation);
+  let initialRunTimer: ReturnType<typeof setTimeout> | undefined;
   try {
-    await Promise.all(
-      activation.workers.map((runtime) => invokeWorker(runtime, true)),
-    );
+    await Promise.race([
+      Promise.all(
+        activation.workers.map((runtime) => invokeWorker(runtime, true)),
+      ),
+      new Promise<never>((_, reject) => {
+        initialRunTimer = setTimeout(
+          () =>
+            reject(
+              new Error(`plugin ${pluginId} initial worker run timed out`),
+            ),
+          options.initialRunTimeoutMs ?? INITIAL_RUN_TIMEOUT_MS,
+        );
+        initialRunTimer.unref?.();
+      }),
+    ]);
   } catch (err) {
     await stopPluginWorkers(pluginId);
     log.error({ err, plugin: pluginId }, "plugin initial worker run failed");
     throw err;
+  } finally {
+    if (initialRunTimer !== undefined) {
+      clearTimeout(initialRunTimer);
+    }
   }
   return { pluginId, workerCount: workers.length, started: true };
 }

--- a/assistant/src/plugins/plugin-worker-runner.ts
+++ b/assistant/src/plugins/plugin-worker-runner.ts
@@ -166,7 +166,9 @@ async function invokeWorker(
   ) {
     return;
   }
-  const run = executeWorker(runtime, rejectOnFailure);
+  const run = Promise.resolve().then(() =>
+    executeWorker(runtime, rejectOnFailure),
+  );
   runtime.inFlight = run;
   try {
     await run;

--- a/assistant/src/plugins/plugin-worker-runner.ts
+++ b/assistant/src/plugins/plugin-worker-runner.ts
@@ -136,7 +136,7 @@ async function executeWorker(
   runtime: WorkerRuntime,
   rejectOnFailure: boolean,
 ): Promise<void> {
-  let result: PluginWorkerResult | void;
+  let result: PluginWorkerResult | void = undefined;
   try {
     result = await runInPluginContext(runtime.definition.pluginId, () =>
       runtime.definition.run(runtime.context),
@@ -148,7 +148,6 @@ async function executeWorker(
     if (!runtime.controller.signal.aborted) {
       runtime.context.logger.error({ err }, "plugin worker failed");
     }
-    return;
   }
   if (!runtime.stopped && !runtime.controller.signal.aborted) {
     scheduleNextWake(runtime, result);

--- a/assistant/src/plugins/source-fingerprint.ts
+++ b/assistant/src/plugins/source-fingerprint.ts
@@ -30,6 +30,7 @@
  * unsupported.
  */
 
+import { createHash } from "node:crypto";
 import { realpathSync, statSync } from "node:fs";
 
 import {
@@ -58,6 +59,11 @@ export interface SourceSnapshot {
    * depending on the path the importer used.
    */
   readonly evictionPaths: readonly string[];
+}
+
+/** Stable readiness digest for a source snapshot fingerprint. */
+export function derivePluginSourceFingerprint(fingerprint: string): string {
+  return createHash("sha256").update(fingerprint).digest("hex");
 }
 
 /**

--- a/assistant/src/plugins/source-versions.ts
+++ b/assistant/src/plugins/source-versions.ts
@@ -1,8 +1,8 @@
 /**
  * The plugin source-versions sentinel — the broadcast contract between the
- * resource monitor's source watcher (the single writer, running in its own
- * OS process) and every process that holds plugin code in a module registry
- * (the readers: the daemon, platform workers, plugin-spawned workers).
+ * assistant lifecycle, resource monitor, and every process that holds plugin
+ * code in a module registry. The assistant publishes a boot/reconcile baseline
+ * while the monitor continues polling for out-of-band source changes.
  *
  * The watcher rewrites the document atomically (temp + rename) and only when
  * plugin source actually changed, so "the sentinel's mtime moved" is exactly
@@ -18,7 +18,7 @@
  * fingerprint diffs stay idempotent across restarts.
  */
 
-import { readFileSync } from "node:fs";
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import {
@@ -72,4 +72,48 @@ export function readSourceVersions(): SourceVersionsDocument | null {
   } catch {
     return null;
   }
+}
+
+/** Atomically publish a complete source-version snapshot. */
+export function writeSourceVersions(doc: SourceVersionsDocument): void {
+  const path = getSourceVersionsPath();
+  mkdirSync(getMonitoringDataDir(), { recursive: true });
+  const tempPath = `${path}.${process.pid}.${Date.now()}.tmp`;
+  writeFileSync(tempPath, JSON.stringify(doc, null, 2));
+  renameSync(tempPath, path);
+}
+
+/** Publish source versions when the durable snapshot is missing or stale. */
+export function publishSourceVersions(
+  plugins: Readonly<Record<string, PluginSourceVersion>>,
+): boolean {
+  const existing = readSourceVersions();
+  if (existing && sameSourceVersions(existing.plugins, plugins)) {
+    return false;
+  }
+  writeSourceVersions({
+    format: SOURCE_VERSIONS_FORMAT,
+    generation: (existing?.generation ?? 0) + 1,
+    writtenAt: new Date().toISOString(),
+    plugins: { ...plugins },
+  });
+  return true;
+}
+
+function sameSourceVersions(
+  left: Readonly<Record<string, PluginSourceVersion>>,
+  right: Readonly<Record<string, PluginSourceVersion>>,
+): boolean {
+  const leftKeys = Object.keys(left);
+  if (leftKeys.length !== Object.keys(right).length) {
+    return false;
+  }
+  return leftKeys.every((key) => {
+    const other = right[key];
+    return (
+      other !== undefined &&
+      left[key]?.fingerprint === other.fingerprint &&
+      left[key]?.disabled === other.disabled
+    );
+  });
 }

--- a/assistant/src/plugins/source-versions.ts
+++ b/assistant/src/plugins/source-versions.ts
@@ -21,6 +21,14 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
+import {
+  PLUGIN_SOURCE_VERSIONS_FILENAME,
+  PLUGIN_SOURCE_VERSIONS_FORMAT,
+  type PluginSourceVersion,
+  type PluginSourceVersionsSnapshot,
+  PluginSourceVersionsSnapshotSchema,
+} from "@vellumai/service-contracts/plugin-readiness";
+
 import { getMonitoringDataDir } from "../util/platform.js";
 
 /**
@@ -30,51 +38,19 @@ import { getMonitoringDataDir } from "../util/platform.js";
  * workspace git-service ignore rules — the document carries absolute
  * host-specific paths that must never be committed into workspace history.
  */
-export const SOURCE_VERSIONS_FILENAME = "plugin-source-versions.json";
+export const SOURCE_VERSIONS_FILENAME = PLUGIN_SOURCE_VERSIONS_FILENAME;
 
 /** Document format version; readers ignore documents from a different format. */
-export const SOURCE_VERSIONS_FORMAT = 1;
+export const SOURCE_VERSIONS_FORMAT = PLUGIN_SOURCE_VERSIONS_FORMAT;
 
 /**
  * One watched directory's source state: a plugin directory, or the
  * standalone workspace hooks directory.
  */
-export interface PluginSourceVersion {
-  /**
-   * Opaque stamp over the directory's source files (see
-   * `./source-fingerprint.ts`). Changes iff a source file was edited,
-   * added, removed, or renamed.
-   */
-  readonly fingerprint: string;
-  /**
-   * Absolute module paths a reader must evict from its module registry when
-   * this fingerprint changes — the realpath of every source file, plus
-   * symlink-rooted aliases when the directory is reached through a symlink.
-   * Eviction cost scales with the plugin, not with the reader's whole
-   * module graph.
-   */
-  readonly evictionPaths: readonly string[];
-  /** Whether a `.disabled` sentinel is present. Dotfiles are excluded from
-   * the fingerprint, so this surfaces disable/enable transitions. */
-  readonly disabled: boolean;
-}
+export type { PluginSourceVersion };
 
 /** The on-disk sentinel document. */
-export interface SourceVersionsDocument {
-  readonly format: number;
-  /** Increments on every rewrite within one watcher lifetime. Bookkeeping
-   * only — readers diff fingerprints, not this. */
-  readonly generation: number;
-  /** ISO timestamp of the last rewrite, for staleness logging. */
-  readonly writtenAt: string;
-  /**
-   * Keyed by the absolute directory path as the platform helpers construct
-   * it (`getWorkspacePluginsDir()`-derived plugin dirs, plus
-   * `getWorkspaceHooksDir()` for standalone workspace hooks), so readers
-   * can key their own state the same way without any name resolution.
-   */
-  readonly plugins: Readonly<Record<string, PluginSourceVersion>>;
-}
+export type SourceVersionsDocument = PluginSourceVersionsSnapshot;
 
 /** Absolute path of the sentinel document. */
 export function getSourceVersionsPath(): string {
@@ -91,17 +67,8 @@ export function readSourceVersions(): SourceVersionsDocument | null {
     const raw: unknown = JSON.parse(
       readFileSync(getSourceVersionsPath(), "utf8"),
     );
-    if (typeof raw !== "object" || raw === null) {
-      return null;
-    }
-    const doc = raw as SourceVersionsDocument;
-    if (doc.format !== SOURCE_VERSIONS_FORMAT) {
-      return null;
-    }
-    if (typeof doc.plugins !== "object" || doc.plugins === null) {
-      return null;
-    }
-    return doc;
+    const parsed = PluginSourceVersionsSnapshotSchema.safeParse(raw);
+    return parsed.success ? parsed.data : null;
   } catch {
     return null;
   }

--- a/assistant/src/routes/__tests__/route-host-broker.test.ts
+++ b/assistant/src/routes/__tests__/route-host-broker.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+
+import { dispatchRouteHostBrokerRequest } from "../route-host-broker.js";
+
+const context = {
+  pluginId: "example-plugin",
+  pluginStorageDir: "/tmp/example-plugin-data",
+};
+
+describe("route host broker", () => {
+  test("rejects request fields outside the closed contract", async () => {
+    await expect(
+      dispatchRouteHostBrokerRequest(
+        { operation: "plugin.storage-dir", extra: true },
+        context,
+      ),
+    ).rejects.toThrow();
+
+    await expect(
+      dispatchRouteHostBrokerRequest(
+        { operation: "conversation.read" },
+        context,
+      ),
+    ).rejects.toThrow();
+  });
+});

--- a/assistant/src/routes/__tests__/route-host.test.ts
+++ b/assistant/src/routes/__tests__/route-host.test.ts
@@ -332,6 +332,105 @@ describe("route host subprocess", () => {
     );
   });
 
+  test("an acknowledged abort does not later kill the shared host", async () => {
+    const startedMarker = join(handlerDir, "noncooperative-started");
+    const { filePath } = writeHandler(
+      "noncooperative-abort.ts",
+      `import { writeFileSync } from "node:fs";
+       export function GET(request) {
+         if (new URL(request.url).searchParams.has("slow")) {
+           writeFileSync(${JSON.stringify(startedMarker)}, String(process.pid));
+           return new Promise((resolve) => {
+             setTimeout(() => resolve(new Response("late")), 1500);
+           });
+         }
+         return Response.json({ pid: process.pid });
+       }`,
+    );
+    const controller = new AbortController();
+    const invocation = client.invoke(
+      {
+        filePath,
+        method: "GET",
+        url: `${url("noncooperative-abort")}?slow=1`,
+        headers: [],
+      },
+      { body: null, signal: controller.signal },
+    );
+    for (
+      let attempt = 0;
+      attempt < 100 && !existsSync(startedMarker);
+      attempt++
+    ) {
+      await Bun.sleep(10);
+    }
+    const originalPid = Number(readFileSync(startedMarker, "utf8"));
+    controller.abort();
+    await expect(invocation).rejects.toMatchObject({ name: "AbortError" });
+
+    await Bun.sleep(1100);
+    const response = await client.invoke(
+      {
+        filePath,
+        method: "GET",
+        url: url("noncooperative-abort"),
+        headers: [],
+      },
+      { body: null },
+    );
+
+    expect(decode(response.body)).toEqual({ pid: originalPid });
+  });
+
+  test("waits for in-flight work before recycling changed route source", async () => {
+    const startedMarker = join(handlerDir, "drain-started");
+    const slow = writeHandler(
+      "drain-slow.ts",
+      `import { writeFileSync } from "node:fs";
+       export async function GET() {
+         writeFileSync(${JSON.stringify(startedMarker)}, "yes");
+         await new Promise((resolve) => setTimeout(resolve, 100));
+         return new Response("completed");
+       }`,
+    );
+    const first = client.invoke(
+      {
+        filePath: slow.filePath,
+        method: "GET",
+        url: url("drain-slow"),
+        headers: [],
+      },
+      { body: null },
+    );
+    for (
+      let attempt = 0;
+      attempt < 100 && !existsSync(startedMarker);
+      attempt++
+    ) {
+      await Bun.sleep(10);
+    }
+    const next = writeHandler(
+      "drain-next.ts",
+      `export function GET() { return new Response("next"); }`,
+    );
+    const second = client.invoke(
+      {
+        filePath: next.filePath,
+        method: "GET",
+        url: url("drain-next"),
+        headers: [],
+      },
+      { body: null },
+    );
+
+    expect(new TextDecoder().decode((await first).body ?? undefined)).toBe(
+      "completed",
+    );
+    expect(new TextDecoder().decode((await second).body ?? undefined)).toBe(
+      "next",
+    );
+  });
+
   test("a synchronous stall is hard-killed on timeout, and the host recovers", async () => {
     const stall = writeHandler(
       "stall.ts",

--- a/assistant/src/routes/__tests__/route-host.test.ts
+++ b/assistant/src/routes/__tests__/route-host.test.ts
@@ -1,8 +1,8 @@
 import {
   existsSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
-  statSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -29,6 +29,11 @@ import { ROUTE_HOST_PROC_NAME } from "../route-host-protocol.js";
 // stall test kills the host and the next invoke transparently respawns it.
 let client: RouteHostClient;
 let handlerDir: string;
+
+const PLUGIN_API_MODULE_URL = new URL(
+  "../../plugin-api/index.ts",
+  import.meta.url,
+).href;
 
 beforeAll(() => {
   handlerDir = mkdtempSync(join(tmpdir(), "route-host-"));
@@ -60,13 +65,10 @@ function cleanProcFiles(): void {
   }
 }
 
-function writeHandler(
-  name: string,
-  content: string,
-): { filePath: string; mtimeMs: number } {
+function writeHandler(name: string, content: string): { filePath: string } {
   const filePath = join(handlerDir, name);
   writeFileSync(filePath, content);
-  return { filePath, mtimeMs: statSync(filePath).mtimeMs };
+  return { filePath };
 }
 
 function url(name: string): string {
@@ -82,13 +84,13 @@ function decode(body: Uint8Array | null): unknown {
 
 describe("route host subprocess", () => {
   test("runs a GET handler in the subprocess and returns its response", async () => {
-    const { filePath, mtimeMs } = writeHandler(
+    const { filePath } = writeHandler(
       "ok.ts",
       `export function GET() { return Response.json({ ok: true, pid: process.pid }); }`,
     );
     const res = await client.invoke(
-      { filePath, mtimeMs, method: "GET", url: url("ok"), headers: [] },
-      null,
+      { filePath, method: "GET", url: url("ok"), headers: [] },
+      { body: null },
     );
     expect(res.status).toBe(200);
     const body = decode(res.body) as { ok: boolean; pid: number };
@@ -98,7 +100,7 @@ describe("route host subprocess", () => {
   });
 
   test("round-trips a POST body through the subprocess", async () => {
-    const { filePath, mtimeMs } = writeHandler(
+    const { filePath } = writeHandler(
       "echo.ts",
       `export async function POST(req) {
         const body = await req.json();
@@ -111,41 +113,184 @@ describe("route host subprocess", () => {
     const res = await client.invoke(
       {
         filePath,
-        mtimeMs,
         method: "POST",
         url: url("echo"),
         headers: [["content-type", "application/json"]],
       },
-      payload,
+      { body: payload },
     );
     expect(res.status).toBe(201);
     expect(decode(res.body)).toEqual({ echoed: { hello: "world" } });
   });
 
   test("returns 405 with Allow when the method handler is missing", async () => {
-    const { filePath, mtimeMs } = writeHandler(
+    const { filePath } = writeHandler(
       "post-only.ts",
       `export function POST() { return new Response("p"); }`,
     );
     const res = await client.invoke(
-      { filePath, mtimeMs, method: "GET", url: url("post-only"), headers: [] },
-      null,
+      { filePath, method: "GET", url: url("post-only"), headers: [] },
+      { body: null },
     );
     expect(res.status).toBe(405);
     expect(res.headers).toContainEqual(["allow", "POST"]);
   });
 
   test("a handler that throws rejects the invocation", async () => {
-    const { filePath, mtimeMs } = writeHandler(
+    const { filePath } = writeHandler(
       "boom.ts",
       `export function GET() { throw new Error("boom in handler"); }`,
     );
     await expect(
       client.invoke(
-        { filePath, mtimeMs, method: "GET", url: url("boom"), headers: [] },
-        null,
+        { filePath, method: "GET", url: url("boom"), headers: [] },
+        { body: null },
       ),
     ).rejects.toThrow("boom in handler");
+  });
+
+  test("carries plugin context and brokers an approved host call", async () => {
+    const { filePath } = writeHandler(
+      "context.ts",
+      `import { requirePluginRouteContext } from ${JSON.stringify(PLUGIN_API_MODULE_URL)};
+       export async function GET() {
+         const context = requirePluginRouteContext();
+         const storageDir = await context.host.getPluginStorageDir();
+         return Response.json({
+           pluginId: context.pluginId,
+           principalId: context.actor.principalId,
+           requestId: context.requestId,
+           hasSignal: context.signal instanceof AbortSignal,
+           storageDir,
+         });
+       }`,
+    );
+    const pluginStorageDir = join(handlerDir, "plugin-data");
+    const res = await client.invoke(
+      {
+        filePath,
+        method: "GET",
+        url: url("context"),
+        headers: [],
+        pluginContext: {
+          pluginId: "example-plugin",
+          actor: {
+            principalType: "actor",
+            principalId: "user-123",
+            scopes: ["settings.read"],
+          },
+          requestId: "request-123",
+          verifiedPeer: null,
+        },
+      },
+      {
+        body: null,
+        brokerContext: {
+          pluginId: "example-plugin",
+          pluginStorageDir,
+        },
+      },
+    );
+
+    expect(res.status).toBe(200);
+    expect(decode(res.body)).toEqual({
+      pluginId: "example-plugin",
+      principalId: "user-123",
+      requestId: "request-123",
+      hasSignal: true,
+      storageDir: pluginStorageDir,
+    });
+  });
+
+  test("blocks direct conversation-store access in the route host", async () => {
+    const { filePath } = writeHandler(
+      "conversation-store.ts",
+      `import { getMessages } from ${JSON.stringify(PLUGIN_API_MODULE_URL)};
+       export async function GET() {
+         await getMessages("conv-xyz");
+         return new Response("unexpected");
+       }`,
+    );
+
+    await expect(
+      client.invoke(
+        {
+          filePath,
+          method: "GET",
+          url: url("conversation-store"),
+          headers: [],
+        },
+        { body: null },
+      ),
+    ).rejects.toThrow("Conversation store access is unavailable");
+  });
+
+  test("propagates caller abort to the handler without waiting for timeout", async () => {
+    const abortMarker = join(handlerDir, "request-aborted");
+    const { filePath } = writeHandler(
+      "abort.ts",
+      `import { writeFileSync } from "node:fs";
+       import { requirePluginRouteContext } from ${JSON.stringify(PLUGIN_API_MODULE_URL)};
+       export function GET(request) {
+         return new Promise((resolve) => {
+           const onAbort = async () => {
+             const context = requirePluginRouteContext();
+             try {
+               await context.host.getPluginStorageDir();
+               writeFileSync(${JSON.stringify(abortMarker)}, "broker allowed");
+             } catch (error) {
+               writeFileSync(${JSON.stringify(abortMarker)}, error.message);
+             }
+             resolve(new Response("aborted"));
+           };
+           if (request.signal.aborted) {
+             onAbort();
+             return;
+           }
+           request.signal.addEventListener("abort", onAbort, { once: true });
+         });
+       }`,
+    );
+    const controller = new AbortController();
+    const startedAt = Date.now();
+    const invocation = client.invoke(
+      {
+        filePath,
+        method: "GET",
+        url: url("abort"),
+        headers: [],
+        pluginContext: {
+          pluginId: "example-plugin",
+          actor: {
+            principalType: "actor",
+            principalId: "user-123",
+            scopes: ["settings.read"],
+          },
+          requestId: "request-abort",
+          verifiedPeer: null,
+        },
+      },
+      {
+        body: null,
+        signal: controller.signal,
+        brokerContext: {
+          pluginId: "example-plugin",
+          pluginStorageDir: join(handlerDir, "plugin-data"),
+        },
+      },
+    );
+
+    controller.abort();
+
+    await expect(invocation).rejects.toMatchObject({ name: "AbortError" });
+    expect(Date.now() - startedAt).toBeLessThan(500);
+    for (let attempt = 0; attempt < 50 && !existsSync(abortMarker); attempt++) {
+      await Bun.sleep(10);
+    }
+    expect(existsSync(abortMarker)).toBe(true);
+    expect(readFileSync(abortMarker, "utf8")).toBe(
+      "broker request rejected after invocation abort",
+    );
   });
 
   test("a synchronous stall is hard-killed on timeout, and the host recovers", async () => {
@@ -173,12 +318,11 @@ describe("route host subprocess", () => {
       client.invoke(
         {
           filePath: stall.filePath,
-          mtimeMs: stall.mtimeMs,
           method: "GET",
           url: url("stall"),
           headers: [],
         },
-        null,
+        { body: null },
       ),
     ).rejects.toBeInstanceOf(RouteHostTimeoutError);
 
@@ -190,12 +334,11 @@ describe("route host subprocess", () => {
     const res = await client.invoke(
       {
         filePath: ok.filePath,
-        mtimeMs: ok.mtimeMs,
         method: "GET",
         url: url("after"),
         headers: [],
       },
-      null,
+      { body: null },
     );
     expect(res.status).toBe(200);
     expect(decode(res.body)).toEqual({ recovered: true });

--- a/assistant/src/routes/__tests__/route-host.test.ts
+++ b/assistant/src/routes/__tests__/route-host.test.ts
@@ -225,16 +225,47 @@ describe("route host subprocess", () => {
     ).rejects.toThrow("Conversation store access is unavailable");
   });
 
-  test("propagates caller abort to the handler without waiting for timeout", async () => {
+  test("aborts while the route host is starting without invoking the handler", async () => {
+    const invokedMarker = join(handlerDir, "startup-abort-invoked");
+    const { filePath } = writeHandler(
+      "startup-abort.ts",
+      `import { writeFileSync } from "node:fs";
+       export function GET() {
+         writeFileSync(${JSON.stringify(invokedMarker)}, "invoked");
+         return new Promise(() => {});
+       }`,
+    );
+    const controller = new AbortController();
+    const startedAt = Date.now();
+    const invocation = client.invoke(
+      {
+        filePath,
+        method: "GET",
+        url: url("startup-abort"),
+        headers: [],
+      },
+      { body: null, signal: controller.signal },
+    );
+
+    controller.abort();
+
+    await expect(invocation).rejects.toMatchObject({ name: "AbortError" });
+    expect(Date.now() - startedAt).toBeLessThan(500);
+    expect(existsSync(invokedMarker)).toBe(false);
+  });
+
+  test("propagates caller abort to an active handler", async () => {
+    const startedMarker = join(handlerDir, "request-started");
     const abortMarker = join(handlerDir, "request-aborted");
     const { filePath } = writeHandler(
       "abort.ts",
       `import { writeFileSync } from "node:fs";
        import { requirePluginRouteContext } from ${JSON.stringify(PLUGIN_API_MODULE_URL)};
        export function GET(request) {
+         const context = requirePluginRouteContext();
+         writeFileSync(${JSON.stringify(startedMarker)}, "started");
          return new Promise((resolve) => {
            const onAbort = async () => {
-             const context = requirePluginRouteContext();
              try {
                await context.host.getPluginStorageDir();
                writeFileSync(${JSON.stringify(abortMarker)}, "broker allowed");
@@ -252,7 +283,6 @@ describe("route host subprocess", () => {
        }`,
     );
     const controller = new AbortController();
-    const startedAt = Date.now();
     const invocation = client.invoke(
       {
         filePath,
@@ -280,10 +310,19 @@ describe("route host subprocess", () => {
       },
     );
 
+    for (
+      let attempt = 0;
+      attempt < 100 && !existsSync(startedMarker);
+      attempt++
+    ) {
+      await Bun.sleep(10);
+    }
+    expect(existsSync(startedMarker)).toBe(true);
+    const abortStartedAt = Date.now();
     controller.abort();
 
     await expect(invocation).rejects.toMatchObject({ name: "AbortError" });
-    expect(Date.now() - startedAt).toBeLessThan(500);
+    expect(Date.now() - abortStartedAt).toBeLessThan(500);
     for (let attempt = 0; attempt < 50 && !existsSync(abortMarker); attempt++) {
       await Bun.sleep(10);
     }

--- a/assistant/src/routes/route-host-broker.ts
+++ b/assistant/src/routes/route-host-broker.ts
@@ -1,0 +1,67 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+import { z } from "zod";
+
+const PluginStorageDirBrokerRequestSchema = z
+  .object({
+    operation: z.literal("plugin.storage-dir"),
+  })
+  .strict();
+
+export const RouteHostBrokerRequestSchema = z.union([
+  PluginStorageDirBrokerRequestSchema,
+]);
+
+export type RouteHostBrokerRequest = z.infer<
+  typeof RouteHostBrokerRequestSchema
+>;
+
+export type RouteHostBrokerResult = {
+  readonly operation: "plugin.storage-dir";
+  readonly pluginStorageDir: string;
+};
+
+export interface RouteHostBrokerContext {
+  readonly pluginId: string;
+  readonly pluginStorageDir: string;
+}
+
+type RouteHostBrokerTransport = (
+  request: RouteHostBrokerRequest,
+) => Promise<RouteHostBrokerResult>;
+
+const transportStorage = new AsyncLocalStorage<RouteHostBrokerTransport>();
+
+/** Dispatch a broker request in the main assistant process. */
+export async function dispatchRouteHostBrokerRequest(
+  value: unknown,
+  context: RouteHostBrokerContext,
+): Promise<RouteHostBrokerResult> {
+  const request = RouteHostBrokerRequestSchema.parse(value);
+  switch (request.operation) {
+    case "plugin.storage-dir":
+      return {
+        operation: request.operation,
+        pluginStorageDir: context.pluginStorageDir,
+      };
+  }
+}
+
+/** @internal Install the authenticated local IPC transport for one route call. */
+export function runWithRouteHostBroker<T>(
+  transport: RouteHostBrokerTransport,
+  fn: () => T,
+): T {
+  return transportStorage.run(transport, fn);
+}
+
+/** @internal Call the main-process broker from a route-host plugin API. */
+export function callRouteHostBroker(
+  request: RouteHostBrokerRequest,
+): Promise<RouteHostBrokerResult> {
+  const transport = transportStorage.getStore();
+  if (!transport) {
+    throw new Error("route host broker is unavailable");
+  }
+  return transport(request);
+}

--- a/assistant/src/routes/route-host-client.ts
+++ b/assistant/src/routes/route-host-client.ts
@@ -135,7 +135,7 @@ export class RouteHostClient {
       this.killHost("route source changed");
     }
     this.sourceFingerprints.set(sourceRoot, sourceFingerprint);
-    const socket = await this.ensureConnected();
+    const socket = await this.ensureConnectedOrAbort(signal);
     const id = String(++this.idSeq);
 
     return new Promise<RouteInvokeResponse>((resolve, reject) => {
@@ -187,6 +187,37 @@ export class RouteHostClient {
       if (signal?.aborted) {
         onAbort?.();
       }
+    });
+  }
+
+  private async ensureConnectedOrAbort(signal?: AbortSignal): Promise<Socket> {
+    if (!signal) {
+      return this.ensureConnected();
+    }
+    if (signal.aborted) {
+      throw signal.reason ?? new DOMException("Aborted", "AbortError");
+    }
+
+    const connecting = this.ensureConnected();
+    return new Promise<Socket>((resolve, reject) => {
+      const onAbort = () => {
+        reject(
+          signal.reason instanceof Error
+            ? signal.reason
+            : new DOMException("Aborted", "AbortError"),
+        );
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+      void connecting.then(
+        (socket) => {
+          signal.removeEventListener("abort", onAbort);
+          resolve(socket);
+        },
+        (error: unknown) => {
+          signal.removeEventListener("abort", onAbort);
+          reject(error);
+        },
+      );
     });
   }
 

--- a/assistant/src/routes/route-host-client.ts
+++ b/assistant/src/routes/route-host-client.ts
@@ -23,12 +23,21 @@ import { connect, type Socket } from "node:net";
 import type { IpcEnvelope } from "@vellumai/ipc-server-utils";
 import { IpcFrameReader, writeMessage } from "@vellumai/ipc-server-utils";
 
+import { snapshotPluginSource } from "../plugins/source-fingerprint.js";
+import { sourceRootForHandler } from "../runtime/routes/user-route-import.js";
 import { getLogger } from "../util/logger.js";
 import { getProcPidPath, getProcSocketPath } from "../util/platform.js";
 import { spawnWorkerProcess } from "../util/worker-process.js";
 import {
+  dispatchRouteHostBrokerRequest,
+  type RouteHostBrokerContext,
+} from "./route-host-broker.js";
+import {
+  ROUTE_BROKER_METHOD,
+  ROUTE_CANCEL_METHOD,
   ROUTE_HOST_PROC_NAME,
   ROUTE_INVOKE_METHOD,
+  type RouteBrokerParams,
   type RouteInvokeParams,
   type RouteInvokeResult,
 } from "./route-host-protocol.js";
@@ -64,6 +73,16 @@ interface Pending {
   resolve: (value: RouteInvokeResponse) => void;
   reject: (err: Error) => void;
   timer: ReturnType<typeof setTimeout>;
+  brokerContext?: RouteHostBrokerContext;
+  signal?: AbortSignal;
+  onAbort?: () => void;
+  aborted: boolean;
+}
+
+export interface RouteHostInvokeOptions {
+  readonly body: Uint8Array | null;
+  readonly signal?: AbortSignal;
+  readonly brokerContext?: RouteHostBrokerContext;
 }
 
 export interface RouteHostClientOptions {
@@ -83,6 +102,7 @@ export class RouteHostClient {
   private connecting: Promise<Socket> | undefined;
   private pid: number | undefined;
   private readonly pending = new Map<string, Pending>();
+  private readonly sourceFingerprints = new Map<string, string>();
   private idSeq = 0;
 
   constructor(options?: RouteHostClientOptions) {
@@ -99,14 +119,59 @@ export class RouteHostClient {
    */
   async invoke(
     params: RouteInvokeParams,
-    body: Uint8Array | null,
+    options: RouteHostInvokeOptions,
   ): Promise<RouteInvokeResponse> {
+    const { body, signal, brokerContext } = options;
+    if (signal?.aborted) {
+      throw signal.reason ?? new DOMException("Aborted", "AbortError");
+    }
+    const sourceRoot = sourceRootForHandler(params.filePath);
+    const sourceFingerprint = snapshotPluginSource(sourceRoot).fingerprint;
+    const previousFingerprint = this.sourceFingerprints.get(sourceRoot);
+    if (
+      previousFingerprint !== undefined &&
+      previousFingerprint !== sourceFingerprint
+    ) {
+      this.killHost("route source changed");
+    }
+    this.sourceFingerprints.set(sourceRoot, sourceFingerprint);
     const socket = await this.ensureConnected();
     const id = String(++this.idSeq);
 
     return new Promise<RouteInvokeResponse>((resolve, reject) => {
       const timer = setTimeout(() => this.onTimeout(id), this.invokeTimeoutMs);
-      this.pending.set(id, { resolve, reject, timer });
+      const onAbort = signal
+        ? () => {
+            const pending = this.pending.get(id);
+            if (pending) {
+              pending.aborted = true;
+              pending.reject(
+                signal.reason instanceof Error
+                  ? signal.reason
+                  : new DOMException("Aborted", "AbortError"),
+              );
+            }
+            if (!socket.destroyed) {
+              writeMessage(socket, {
+                id: `cancel:${id}`,
+                method: ROUTE_CANCEL_METHOD,
+                params: { requestId: id },
+              });
+            }
+          }
+        : undefined;
+      if (signal && onAbort) {
+        signal.addEventListener("abort", onAbort, { once: true });
+      }
+      this.pending.set(id, {
+        resolve,
+        reject,
+        timer,
+        brokerContext,
+        signal,
+        onAbort,
+        aborted: false,
+      });
 
       const envelope: IpcEnvelope = {
         id,
@@ -118,6 +183,9 @@ export class RouteHostClient {
         writeMessage(socket, envelope, body);
       } else {
         writeMessage(socket, envelope);
+      }
+      if (signal?.aborted) {
+        onAbort?.();
       }
     });
   }
@@ -194,6 +262,10 @@ export class RouteHostClient {
     envelope: IpcEnvelope,
     binary: Uint8Array | undefined,
   ): void {
+    if (envelope.method === ROUTE_BROKER_METHOD && envelope.id) {
+      void this.onBrokerRequest(envelope);
+      return;
+    }
     if (!envelope.id) {
       return;
     }
@@ -202,7 +274,7 @@ export class RouteHostClient {
       return;
     }
     this.pending.delete(envelope.id);
-    clearTimeout(pending.timer);
+    this.cleanupPending(pending);
 
     if (envelope.error != null) {
       pending.reject(new Error(envelope.error));
@@ -220,12 +292,52 @@ export class RouteHostClient {
     });
   }
 
+  private async onBrokerRequest(envelope: IpcEnvelope): Promise<void> {
+    const socket = this.socket;
+    if (!socket || socket.destroyed || !envelope.id) {
+      return;
+    }
+    const params = envelope.params as unknown as RouteBrokerParams;
+    const invocation = this.pending.get(params.invokeId);
+    if (!invocation?.brokerContext) {
+      writeMessage(socket, {
+        id: envelope.id,
+        error: "broker request has no active plugin invocation",
+      });
+      return;
+    }
+    if (invocation.aborted) {
+      writeMessage(socket, {
+        id: envelope.id,
+        error: "broker request rejected after invocation abort",
+      });
+      return;
+    }
+
+    try {
+      const result = await dispatchRouteHostBrokerRequest(
+        params.request,
+        invocation.brokerContext,
+      );
+      writeMessage(socket, {
+        id: envelope.id,
+        result: result as unknown as Record<string, unknown>,
+      });
+    } catch (err) {
+      writeMessage(socket, {
+        id: envelope.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
   private onTimeout(id: string): void {
     const pending = this.pending.get(id);
     if (!pending) {
       return;
     }
     this.pending.delete(id);
+    this.cleanupPending(pending);
     log.error(
       { id, pid: this.pid, timeoutMs: this.invokeTimeoutMs },
       "Route handler timed out — hard-killing route host",
@@ -282,9 +394,16 @@ export class RouteHostClient {
 
   private rejectAllPending(err: Error): void {
     for (const [, pending] of this.pending) {
-      clearTimeout(pending.timer);
+      this.cleanupPending(pending);
       pending.reject(err);
     }
     this.pending.clear();
+  }
+
+  private cleanupPending(pending: Pending): void {
+    clearTimeout(pending.timer);
+    if (pending.signal && pending.onAbort) {
+      pending.signal.removeEventListener("abort", pending.onAbort);
+    }
   }
 }

--- a/assistant/src/routes/route-host-client.ts
+++ b/assistant/src/routes/route-host-client.ts
@@ -17,14 +17,16 @@
  * follow-up; the daemon stays responsive regardless.
  */
 
+import { randomBytes } from "node:crypto";
 import { existsSync, unlinkSync } from "node:fs";
 import { connect, type Socket } from "node:net";
+import { dirname } from "node:path";
 
 import type { IpcEnvelope } from "@vellumai/ipc-server-utils";
 import { IpcFrameReader, writeMessage } from "@vellumai/ipc-server-utils";
 
 import { snapshotPluginSource } from "../plugins/source-fingerprint.js";
-import { sourceRootForHandler } from "../runtime/routes/user-route-import.js";
+import { getFileSignature } from "../plugins/surface-import.js";
 import { getLogger } from "../util/logger.js";
 import { getProcPidPath, getProcSocketPath } from "../util/platform.js";
 import { spawnWorkerProcess } from "../util/worker-process.js";
@@ -40,6 +42,7 @@ import {
   type RouteBrokerParams,
   type RouteInvokeParams,
   type RouteInvokeResult,
+  type RouteInvokeWireParams,
 } from "./route-host-protocol.js";
 
 const log = getLogger("route-host-client");
@@ -77,6 +80,12 @@ interface Pending {
   signal?: AbortSignal;
   onAbort?: () => void;
   aborted: boolean;
+  brokerCapability: string | null;
+}
+
+interface RouteSourceVersion {
+  readonly fingerprint: string;
+  readonly entrySignatures: Map<string, string>;
 }
 
 export interface RouteHostInvokeOptions {
@@ -102,7 +111,9 @@ export class RouteHostClient {
   private connecting: Promise<Socket> | undefined;
   private pid: number | undefined;
   private readonly pending = new Map<string, Pending>();
-  private readonly sourceFingerprints = new Map<string, string>();
+  private readonly sourceVersions = new Map<string, RouteSourceVersion>();
+  private readonly drainWaiters = new Set<() => void>();
+  private sourceReloadPromise: Promise<void> | undefined;
   private idSeq = 0;
 
   constructor(options?: RouteHostClientOptions) {
@@ -125,16 +136,38 @@ export class RouteHostClient {
     if (signal?.aborted) {
       throw signal.reason ?? new DOMException("Aborted", "AbortError");
     }
-    const sourceRoot = sourceRootForHandler(params.filePath);
-    const sourceFingerprint = snapshotPluginSource(sourceRoot).fingerprint;
-    const previousFingerprint = this.sourceFingerprints.get(sourceRoot);
+    const sourceRoot = params.sourceRoot ?? dirname(params.filePath);
+    const entrySignature = getFileSignature(params.filePath);
+    const sourceVersion = this.sourceVersions.get(sourceRoot);
     if (
-      previousFingerprint !== undefined &&
-      previousFingerprint !== sourceFingerprint
+      sourceVersion === undefined ||
+      sourceVersion.entrySignatures.get(params.filePath) !== entrySignature
     ) {
-      this.killHost("route source changed");
+      const fingerprint = snapshotPluginSource(sourceRoot).fingerprint;
+      const sourceChanged =
+        sourceVersion !== undefined &&
+        sourceVersion.fingerprint !== fingerprint;
+      const entrySignatures = sourceChanged
+        ? new Map<string, string>()
+        : new Map(sourceVersion?.entrySignatures);
+      entrySignatures.set(params.filePath, entrySignature);
+      const nextSourceVersion = {
+        fingerprint,
+        entrySignatures,
+      };
+      if (sourceChanged) {
+        await this.reloadHostAfterPendingInvocations(signal);
+      }
+      this.sourceVersions.set(sourceRoot, nextSourceVersion);
     }
-    this.sourceFingerprints.set(sourceRoot, sourceFingerprint);
+    const brokerCapability = brokerContext
+      ? randomBytes(32).toString("base64url")
+      : null;
+    const wireParams: RouteInvokeWireParams = {
+      ...params,
+      sourceRoot,
+      brokerCapability,
+    };
     const socket = await this.ensureConnectedOrAbort(signal);
     const id = String(++this.idSeq);
 
@@ -171,12 +204,13 @@ export class RouteHostClient {
         signal,
         onAbort,
         aborted: false,
+        brokerCapability,
       });
 
       const envelope: IpcEnvelope = {
         id,
         method: ROUTE_INVOKE_METHOD,
-        params: params as unknown as Record<string, unknown>,
+        params: wireParams as unknown as Record<string, unknown>,
       };
       if (body && body.byteLength > 0) {
         envelope.headers = { "content-length": String(body.byteLength) };
@@ -300,12 +334,27 @@ export class RouteHostClient {
     if (!envelope.id) {
       return;
     }
+    if (envelope.id.startsWith("cancel:")) {
+      const invocationId = envelope.id.slice("cancel:".length);
+      const pending = this.pending.get(invocationId);
+      if (pending?.aborted) {
+        this.pending.delete(invocationId);
+        this.cleanupPending(pending);
+        this.notifyPendingDrained();
+      }
+      return;
+    }
     const pending = this.pending.get(envelope.id);
     if (!pending) {
       return;
     }
     this.pending.delete(envelope.id);
     this.cleanupPending(pending);
+    this.notifyPendingDrained();
+
+    if (pending.aborted) {
+      return;
+    }
 
     if (envelope.error != null) {
       pending.reject(new Error(envelope.error));
@@ -344,6 +393,16 @@ export class RouteHostClient {
       });
       return;
     }
+    if (
+      invocation.brokerCapability === null ||
+      params.capability !== invocation.brokerCapability
+    ) {
+      writeMessage(socket, {
+        id: envelope.id,
+        error: "broker request capability is invalid",
+      });
+      return;
+    }
 
     try {
       const result = await dispatchRouteHostBrokerRequest(
@@ -369,6 +428,7 @@ export class RouteHostClient {
     }
     this.pending.delete(id);
     this.cleanupPending(pending);
+    this.notifyPendingDrained();
     log.error(
       { id, pid: this.pid, timeoutMs: this.invokeTimeoutMs },
       "Route handler timed out — hard-killing route host",
@@ -429,6 +489,7 @@ export class RouteHostClient {
       pending.reject(err);
     }
     this.pending.clear();
+    this.notifyPendingDrained();
   }
 
   private cleanupPending(pending: Pending): void {
@@ -436,5 +497,59 @@ export class RouteHostClient {
     if (pending.signal && pending.onAbort) {
       pending.signal.removeEventListener("abort", pending.onAbort);
     }
+  }
+
+  private async reloadHostAfterPendingInvocations(
+    signal: AbortSignal | undefined,
+  ): Promise<void> {
+    if (!this.sourceReloadPromise) {
+      this.sourceReloadPromise = this.waitForPendingInvocations()
+        .then(() => this.killHost("route source changed"))
+        .finally(() => {
+          this.sourceReloadPromise = undefined;
+        });
+    }
+    if (!signal) {
+      await this.sourceReloadPromise;
+      return;
+    }
+    if (signal.aborted) {
+      throw signal.reason ?? new DOMException("Aborted", "AbortError");
+    }
+    await Promise.race([
+      this.sourceReloadPromise,
+      new Promise<never>((_, reject) => {
+        const onAbort = () => {
+          reject(
+            signal.reason instanceof Error
+              ? signal.reason
+              : new DOMException("Aborted", "AbortError"),
+          );
+        };
+        signal.addEventListener("abort", onAbort, { once: true });
+        void this.sourceReloadPromise?.finally(() => {
+          signal.removeEventListener("abort", onAbort);
+        });
+      }),
+    ]);
+  }
+
+  private waitForPendingInvocations(): Promise<void> {
+    if (this.pending.size === 0) {
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      this.drainWaiters.add(resolve);
+    });
+  }
+
+  private notifyPendingDrained(): void {
+    if (this.pending.size !== 0) {
+      return;
+    }
+    for (const resolve of this.drainWaiters) {
+      resolve();
+    }
+    this.drainWaiters.clear();
   }
 }

--- a/assistant/src/routes/route-host-protocol.ts
+++ b/assistant/src/routes/route-host-protocol.ts
@@ -10,11 +10,31 @@
  * rather than base64'd through JSON.
  */
 
+import type { PluginRouteActorContext } from "../plugin-api/route-context.js";
+import type { VerifiedPeerOperationContext } from "../plugin-api/verified-peer-context.js";
+import type {
+  RouteHostBrokerRequest,
+  RouteHostBrokerResult,
+} from "./route-host-broker.js";
+
 /** Subprocess name → its `procs/<name>/` runtime dir, socket, and PID file. */
 export const ROUTE_HOST_PROC_NAME = "routes";
 
 /** The one IPC method the route host serves. */
 export const ROUTE_INVOKE_METHOD = "invoke";
+
+/** Cancel one in-flight invocation after its caller disconnects. */
+export const ROUTE_CANCEL_METHOD = "cancel";
+
+/** Restricted host API call from the route host to the main process. */
+export const ROUTE_BROKER_METHOD = "broker";
+
+export interface SerializedPluginRouteContext {
+  readonly pluginId: string;
+  readonly actor: PluginRouteActorContext;
+  readonly requestId: string;
+  readonly verifiedPeer: VerifiedPeerOperationContext | null;
+}
 
 /**
  * Request metadata (daemon → host). The resolved handler file is passed in —
@@ -25,15 +45,25 @@ export const ROUTE_INVOKE_METHOD = "invoke";
 export interface RouteInvokeParams {
   /** Absolute path to the resolved handler module. */
   readonly filePath: string;
-  /** The handler file's mtime (ms) — the host's import cache-buster. */
-  readonly mtimeMs: number;
   /** HTTP method whose exported handler should run. */
   readonly method: string;
   /** Full synthetic request URL (`http://localhost/v1/x/<path>?<query>`). */
   readonly url: string;
   /** Request header entries as `[name, value]` pairs (preserves duplicates). */
   readonly headers: ReadonlyArray<readonly [string, string]>;
+  readonly pluginContext?: SerializedPluginRouteContext | null;
 }
+
+export interface RouteCancelParams {
+  readonly requestId: string;
+}
+
+export interface RouteBrokerParams {
+  readonly invokeId: string;
+  readonly request: unknown;
+}
+
+export type { RouteHostBrokerRequest, RouteHostBrokerResult };
 
 /**
  * Response metadata (host → daemon). The response body, if any, rides in the

--- a/assistant/src/routes/route-host-protocol.ts
+++ b/assistant/src/routes/route-host-protocol.ts
@@ -52,6 +52,14 @@ export interface RouteInvokeParams {
   /** Request header entries as `[name, value]` pairs (preserves duplicates). */
   readonly headers: ReadonlyArray<readonly [string, string]>;
   readonly pluginContext?: SerializedPluginRouteContext | null;
+  /** Source tree to reload as one unit. Production callers provide this. */
+  readonly sourceRoot?: string;
+}
+
+/** Internal daemon-to-host invocation fields. */
+export interface RouteInvokeWireParams extends RouteInvokeParams {
+  readonly sourceRoot: string;
+  readonly brokerCapability: string | null;
 }
 
 export interface RouteCancelParams {
@@ -60,6 +68,7 @@ export interface RouteCancelParams {
 
 export interface RouteBrokerParams {
   readonly invokeId: string;
+  readonly capability: string;
   readonly request: unknown;
 }
 

--- a/assistant/src/routes/worker.ts
+++ b/assistant/src/routes/worker.ts
@@ -12,10 +12,8 @@
  * the socket, then write the PID file as the readiness signal, arm the
  * PID-file guard so a superseded instance self-exits, and clean up on exit.
  *
- * Handlers run with **no injected context**. Reaching daemon state (publishing
- * events, running conversation turns) is deferred to the plugin-api once it is
- * safe out-of-process; today the host serves pure request→response handlers
- * (CRUD, file persistence, external API proxying).
+ * Plugin handlers run inside a host-derived route context. Its bounded host
+ * facade uses the closed local broker for approved main-process operations.
  */
 
 import { existsSync, unlinkSync, writeFileSync } from "node:fs";
@@ -24,12 +22,14 @@ import { createServer, type Server, type Socket } from "node:net";
 import type { IpcEnvelope } from "@vellumai/ipc-server-utils";
 import { IpcFrameReader, writeMessage } from "@vellumai/ipc-server-utils";
 
-import { disableStreamSeqStamping } from "../runtime/assistant-stream-state.js";
 import {
-  evictRouteSourceTree,
-  importRouteModule,
-  sourceRootForHandler,
-} from "../runtime/routes/user-route-import.js";
+  markCurrentProcessAsPluginRouteHost,
+  type PluginRouteContext,
+  runInPluginRouteContext,
+} from "../plugin-api/route-context.js";
+import { runInPluginContext } from "../plugins/plugin-execution-context.js";
+import { disableStreamSeqStamping } from "../runtime/assistant-stream-state.js";
+import { importRouteModule } from "../runtime/routes/user-route-import.js";
 import { getLogger } from "../util/logger.js";
 import {
   ensureProcDir,
@@ -41,15 +41,31 @@ import {
   startWorkerPidFileGuard,
 } from "../util/worker-process.js";
 import {
+  callRouteHostBroker,
+  type RouteHostBrokerRequest,
+  type RouteHostBrokerResult,
+  runWithRouteHostBroker,
+} from "./route-host-broker.js";
+import {
+  ROUTE_BROKER_METHOD,
+  ROUTE_CANCEL_METHOD,
   ROUTE_HOST_PROC_NAME,
   ROUTE_INVOKE_METHOD,
+  type RouteCancelParams,
   type RouteInvokeParams,
 } from "./route-host-protocol.js";
 
 const log = getLogger("route-host");
 
-/** Last entry-file mtime imported in this process, keyed by handler path. */
-const lastHandlerMtime = new Map<string, number>();
+const activeAbortControllers = new Map<string, AbortController>();
+
+interface PendingBrokerCall {
+  resolve: (result: RouteHostBrokerResult) => void;
+  reject: (error: Error) => void;
+}
+
+const pendingBrokerCalls = new Map<string, PendingBrokerCall>();
+let brokerCallSeq = 0;
 
 const socketPath = getProcSocketPath(ROUTE_HOST_PROC_NAME);
 const pidPath = getProcPidPath(ROUTE_HOST_PROC_NAME);
@@ -69,12 +85,13 @@ function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
 function reconstructRequest(
   params: RouteInvokeParams,
   body: Uint8Array | undefined,
+  signal: AbortSignal,
 ): Request {
   const headers = new Headers();
   for (const [name, value] of params.headers) {
     headers.append(name, value);
   }
-  const init: RequestInit = { method: params.method, headers };
+  const init: RequestInit = { method: params.method, headers, signal };
   if (body && params.method !== "GET" && params.method !== "HEAD") {
     init.body = toArrayBuffer(body);
   }
@@ -118,51 +135,109 @@ async function handleInvoke(
   params: RouteInvokeParams,
   body: Uint8Array | undefined,
 ): Promise<void> {
-  // Each worker has its own module cache. When the entry file's mtime
-  // moves, evict the whole source tree so a new handler cannot bind to a
-  // stale helper, then re-import.
-  const lastMtime = lastHandlerMtime.get(params.filePath);
-  if (lastMtime !== params.mtimeMs) {
-    evictRouteSourceTree(sourceRootForHandler(params.filePath));
-    lastHandlerMtime.set(params.filePath, params.mtimeMs);
-  }
-  const mod = await importRouteModule(params.filePath);
+  const abortController = new AbortController();
+  activeAbortControllers.set(id, abortController);
+  try {
+    const mod = await importRouteModule(params.filePath);
 
-  const handler = mod[params.method];
-  if (typeof handler !== "function") {
-    const allowed = HTTP_METHODS.filter((m) => typeof mod[m] === "function");
+    const handler = mod[params.method];
+    if (typeof handler !== "function") {
+      const allowed = HTTP_METHODS.filter((m) => typeof mod[m] === "function");
+      replyResult(
+        socket,
+        id,
+        405,
+        allowed.length ? [["allow", allowed.join(", ")]] : [],
+        null,
+      );
+      return;
+    }
+
+    const request = reconstructRequest(params, body, abortController.signal);
+    const serializedContext = params.pluginContext;
+    const pluginContext: PluginRouteContext | undefined = serializedContext
+      ? {
+          pluginId: serializedContext.pluginId,
+          actor: serializedContext.actor,
+          requestId: serializedContext.requestId,
+          signal: abortController.signal,
+          verifiedPeer: serializedContext.verifiedPeer,
+          host: {
+            async getPluginStorageDir(): Promise<string> {
+              const result = await callRouteHostBroker({
+                operation: "plugin.storage-dir",
+              });
+              return result.pluginStorageDir;
+            },
+          },
+        }
+      : undefined;
+    const invoke = () => (handler as (req: Request) => unknown)(request);
+    const response = (await (pluginContext
+      ? runWithRouteHostBroker(createBrokerTransport(socket, id), () =>
+          runInPluginContext(pluginContext.pluginId, () =>
+            runInPluginRouteContext(pluginContext, invoke),
+          ),
+        )
+      : invoke())) as Response;
+
+    const buffer = new Uint8Array(await response.arrayBuffer());
+    const headers: [string, string][] = [];
+    response.headers.forEach((value, name) => {
+      headers.push([name, value]);
+    });
     replyResult(
       socket,
       id,
-      405,
-      allowed.length ? [["allow", allowed.join(", ")]] : [],
-      null,
+      response.status,
+      headers,
+      buffer.byteLength > 0 ? buffer : null,
     );
-    return;
+  } finally {
+    activeAbortControllers.delete(id);
   }
+}
 
-  const request = reconstructRequest(params, body);
-  const response = (await (handler as (req: Request) => unknown)(
-    request,
-  )) as Response;
-
-  const buffer = new Uint8Array(await response.arrayBuffer());
-  const headers: [string, string][] = [];
-  response.headers.forEach((value, name) => {
-    headers.push([name, value]);
-  });
-  replyResult(
-    socket,
-    id,
-    response.status,
-    headers,
-    buffer.byteLength > 0 ? buffer : null,
-  );
+function createBrokerTransport(
+  socket: Socket,
+  invokeId: string,
+): (request: RouteHostBrokerRequest) => Promise<RouteHostBrokerResult> {
+  return (request) => {
+    const id = `broker:${process.pid}:${++brokerCallSeq}`;
+    return new Promise<RouteHostBrokerResult>((resolve, reject) => {
+      pendingBrokerCalls.set(id, { resolve, reject });
+      writeMessage(socket, {
+        id,
+        method: ROUTE_BROKER_METHOD,
+        params: { invokeId, request } as unknown as Record<string, unknown>,
+      });
+    });
+  };
 }
 
 function onConnection(socket: Socket): void {
   const reader = new IpcFrameReader(
     (envelope, binary) => {
+      if (envelope.id && pendingBrokerCalls.has(envelope.id)) {
+        const pending = pendingBrokerCalls.get(envelope.id)!;
+        pendingBrokerCalls.delete(envelope.id);
+        if (envelope.error != null) {
+          pending.reject(new Error(envelope.error));
+        } else {
+          pending.resolve(envelope.result as RouteHostBrokerResult);
+        }
+        return;
+      }
+      if (envelope.method === ROUTE_CANCEL_METHOD) {
+        const params = envelope.params as unknown as RouteCancelParams;
+        const controller = activeAbortControllers.get(params.requestId);
+        if (controller) {
+          controller.abort(
+            new DOMException("Route request aborted", "AbortError"),
+          );
+        }
+        return;
+      }
       if (envelope.method !== ROUTE_INVOKE_METHOD || !envelope.id) {
         return;
       }
@@ -178,6 +253,12 @@ function onConnection(socket: Socket): void {
   );
 
   socket.on("data", (chunk: Buffer) => reader.push(chunk));
+  socket.on("close", () => {
+    for (const [, pending] of pendingBrokerCalls) {
+      pending.reject(new Error("route host broker connection closed"));
+    }
+    pendingBrokerCalls.clear();
+  });
   socket.on("error", (err) => log.warn({ err }, "Route host socket error"));
 }
 
@@ -202,6 +283,8 @@ function shutdown(reason: string): void {
 }
 
 function start(): void {
+  markCurrentProcessAsPluginRouteHost();
+
   // Only the daemon stamps SSE seqs and writes the shared reservation file; a
   // worker that stamped would issue overlapping seqs and race the daemon.
   disableStreamSeqStamping();

--- a/assistant/src/routes/worker.ts
+++ b/assistant/src/routes/worker.ts
@@ -41,7 +41,6 @@ import {
   startWorkerPidFileGuard,
 } from "../util/worker-process.js";
 import {
-  callRouteHostBroker,
   type RouteHostBrokerRequest,
   type RouteHostBrokerResult,
   runWithRouteHostBroker,
@@ -155,26 +154,30 @@ async function handleInvoke(
 
     const request = reconstructRequest(params, body, abortController.signal);
     const serializedContext = params.pluginContext;
-    const pluginContext: PluginRouteContext | undefined = serializedContext
-      ? {
-          pluginId: serializedContext.pluginId,
-          actor: serializedContext.actor,
-          requestId: serializedContext.requestId,
-          signal: abortController.signal,
-          verifiedPeer: serializedContext.verifiedPeer,
-          host: {
-            async getPluginStorageDir(): Promise<string> {
-              const result = await callRouteHostBroker({
-                operation: "plugin.storage-dir",
-              });
-              return result.pluginStorageDir;
-            },
-          },
-        }
+    const brokerTransport = serializedContext
+      ? createBrokerTransport(socket, id)
       : undefined;
+    const pluginContext: PluginRouteContext | undefined =
+      serializedContext && brokerTransport
+        ? {
+            pluginId: serializedContext.pluginId,
+            actor: serializedContext.actor,
+            requestId: serializedContext.requestId,
+            signal: abortController.signal,
+            verifiedPeer: serializedContext.verifiedPeer,
+            host: {
+              async getPluginStorageDir(): Promise<string> {
+                const result = await brokerTransport({
+                  operation: "plugin.storage-dir",
+                });
+                return result.pluginStorageDir;
+              },
+            },
+          }
+        : undefined;
     const invoke = () => (handler as (req: Request) => unknown)(request);
-    const response = (await (pluginContext
-      ? runWithRouteHostBroker(createBrokerTransport(socket, id), () =>
+    const response = (await (pluginContext && brokerTransport
+      ? runWithRouteHostBroker(brokerTransport, () =>
           runInPluginContext(pluginContext.pluginId, () =>
             runInPluginRouteContext(pluginContext, invoke),
           ),

--- a/assistant/src/routes/worker.ts
+++ b/assistant/src/routes/worker.ts
@@ -51,7 +51,7 @@ import {
   ROUTE_HOST_PROC_NAME,
   ROUTE_INVOKE_METHOD,
   type RouteCancelParams,
-  type RouteInvokeParams,
+  type RouteInvokeWireParams,
 } from "./route-host-protocol.js";
 
 const log = getLogger("route-host");
@@ -59,6 +59,7 @@ const log = getLogger("route-host");
 const activeAbortControllers = new Map<string, AbortController>();
 
 interface PendingBrokerCall {
+  readonly invokeId: string;
   resolve: (result: RouteHostBrokerResult) => void;
   reject: (error: Error) => void;
 }
@@ -82,7 +83,7 @@ function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
 }
 
 function reconstructRequest(
-  params: RouteInvokeParams,
+  params: RouteInvokeWireParams,
   body: Uint8Array | undefined,
   signal: AbortSignal,
 ): Request {
@@ -131,7 +132,7 @@ const HTTP_METHODS = [
 async function handleInvoke(
   socket: Socket,
   id: string,
-  params: RouteInvokeParams,
+  params: RouteInvokeWireParams,
   body: Uint8Array | undefined,
 ): Promise<void> {
   const abortController = new AbortController();
@@ -155,7 +156,7 @@ async function handleInvoke(
     const request = reconstructRequest(params, body, abortController.signal);
     const serializedContext = params.pluginContext;
     const brokerTransport = serializedContext
-      ? createBrokerTransport(socket, id)
+      ? createBrokerTransport(socket, id, params.brokerCapability)
       : undefined;
     const pluginContext: PluginRouteContext | undefined =
       serializedContext && brokerTransport
@@ -198,21 +199,36 @@ async function handleInvoke(
     );
   } finally {
     activeAbortControllers.delete(id);
+    for (const [brokerId, pending] of pendingBrokerCalls) {
+      if (pending.invokeId === id) {
+        pendingBrokerCalls.delete(brokerId);
+        pending.reject(new Error("route invocation completed"));
+      }
+    }
   }
 }
 
 function createBrokerTransport(
   socket: Socket,
   invokeId: string,
+  capability: string | null,
 ): (request: RouteHostBrokerRequest) => Promise<RouteHostBrokerResult> {
   return (request) => {
     const id = `broker:${process.pid}:${++brokerCallSeq}`;
     return new Promise<RouteHostBrokerResult>((resolve, reject) => {
-      pendingBrokerCalls.set(id, { resolve, reject });
+      if (capability === null) {
+        reject(new Error("route host broker capability is unavailable"));
+        return;
+      }
+      pendingBrokerCalls.set(id, { invokeId, resolve, reject });
       writeMessage(socket, {
         id,
         method: ROUTE_BROKER_METHOD,
-        params: { invokeId, request } as unknown as Record<string, unknown>,
+        params: {
+          invokeId,
+          capability,
+          request,
+        } as unknown as Record<string, unknown>,
       });
     });
   };
@@ -239,13 +255,19 @@ function onConnection(socket: Socket): void {
             new DOMException("Route request aborted", "AbortError"),
           );
         }
+        if (envelope.id) {
+          writeMessage(socket, {
+            id: envelope.id,
+            result: { cancelled: controller !== undefined },
+          });
+        }
         return;
       }
       if (envelope.method !== ROUTE_INVOKE_METHOD || !envelope.id) {
         return;
       }
       const id = envelope.id;
-      const params = envelope.params as unknown as RouteInvokeParams;
+      const params = envelope.params as unknown as RouteInvokeWireParams;
       handleInvoke(socket, id, params, binary).catch((err: unknown) => {
         const message = err instanceof Error ? err.message : String(err);
         log.error({ err, id }, "Route handler invocation failed");

--- a/assistant/src/runtime/auth/__tests__/route-policy.test.ts
+++ b/assistant/src/runtime/auth/__tests__/route-policy.test.ts
@@ -213,6 +213,13 @@ describe("ROUTES policy declarations", () => {
     expect(route!.policy!.allowedPrincipalTypes).toContain("actor");
     expect(route!.policy!.allowedPrincipalTypes).toContain("local");
     expect(route!.policy!.requiredScopes).toContain("settings.read");
+
+    const peerCtx = buildTestContext({
+      principalType: "assistant_peer",
+      scopes: ["settings.read"],
+    });
+    const denied = enforcePolicy(route!.endpoint, route!.policy!, peerCtx);
+    expect(denied?.status).toBe(403);
   });
 
   test("confirm declares an approval-write policy", async () => {

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -12,6 +12,9 @@
  */
 
 import { isHttpAuthDisabled } from "../../config/env.js";
+import type { PluginRouteActorContext } from "../../plugin-api/route-context.js";
+import type { VerifiedPeerOperationContext } from "../../plugin-api/verified-peer-context.js";
+import type { PluginRouteAuthorization } from "../../plugins/plugin-route-manifest.js";
 import { getLogger } from "../../util/logger.js";
 import type { AuthContext, PrincipalType, Scope } from "./types.js";
 
@@ -61,6 +64,15 @@ export const GATEWAY_PRINCIPALS: PrincipalType[] = ["svc_gateway"];
  * IPC socket.
  */
 export const LOCAL_PRINCIPALS: PrincipalType[] = ["local"];
+
+/** Verified peer operations can call only routes that opt into this principal. */
+export const ASSISTANT_PEER_PRINCIPALS: PrincipalType[] = ["assistant_peer"];
+
+/** Principals admitted to the dynamic plugin route policy check. */
+export const PLUGIN_ROUTE_PRINCIPALS: PrincipalType[] = [
+  ...ACTOR_PRINCIPALS,
+  ...ASSISTANT_PEER_PRINCIPALS,
+];
 
 // ---------------------------------------------------------------------------
 // Enforcement
@@ -134,5 +146,61 @@ export function enforcePolicy(
     }
   }
 
+  return null;
+}
+
+function forbidden(message: string): Response {
+  return Response.json(
+    { error: { code: "FORBIDDEN", message } },
+    { status: 403 },
+  );
+}
+
+/**
+ * Enforce one static plugin route declaration before its handler module is
+ * imported. Local actor routes and verified peer routes are disjoint.
+ */
+export function enforcePluginRoutePolicy(
+  endpoint: string,
+  pluginId: string,
+  authorization: PluginRouteAuthorization,
+  actor: PluginRouteActorContext,
+  verifiedPeer: VerifiedPeerOperationContext | null,
+): Response | null {
+  if (authorization.principal === "actor") {
+    if (!ACTOR_PRINCIPALS.includes(actor.principalType)) {
+      log.warn(
+        { endpoint, pluginId, principalType: actor.principalType },
+        "Plugin route policy denied: actor principal required",
+      );
+      return forbidden("Local actor principal required for this plugin route");
+    }
+
+    const hasLocalAuthority = actor.scopes.includes("local.all");
+    for (const scope of authorization.requiredScopes) {
+      if (!hasLocalAuthority && !actor.scopes.includes(scope)) {
+        log.warn(
+          { endpoint, pluginId, missingScope: scope },
+          "Plugin route policy denied: missing required scope",
+        );
+        return forbidden(`Missing required scope: ${scope}`);
+      }
+    }
+    return null;
+  }
+
+  if (actor.principalType !== "assistant_peer" || !verifiedPeer) {
+    log.warn(
+      { endpoint, pluginId, principalType: actor.principalType },
+      "Plugin route policy denied: verified peer required",
+    );
+    return forbidden("Verified assistant peer required for this plugin route");
+  }
+  if (
+    authorization.operationKinds &&
+    !authorization.operationKinds.includes(verifiedPeer.operation.kind)
+  ) {
+    return forbidden("Peer operation kind is not permitted for this route");
+  }
   return null;
 }

--- a/assistant/src/runtime/auth/types.ts
+++ b/assistant/src/runtime/auth/types.ts
@@ -5,6 +5,8 @@
  * and the normalized AuthContext that downstream code consumes.
  */
 
+import type { VerifiedPeerOperationContext } from "../../plugin-api/verified-peer-context.js";
+
 // ---------------------------------------------------------------------------
 // Scope profiles — named bundles of permissions
 // ---------------------------------------------------------------------------
@@ -43,7 +45,12 @@ export type Scope =
 // Principal types — derived from the sub pattern
 // ---------------------------------------------------------------------------
 
-export type PrincipalType = "actor" | "svc_gateway" | "svc_daemon" | "local";
+export type PrincipalType =
+  | "actor"
+  | "svc_gateway"
+  | "svc_daemon"
+  | "local"
+  | "assistant_peer";
 
 // ---------------------------------------------------------------------------
 // Token audience — which service the JWT is intended for
@@ -79,4 +86,6 @@ export interface AuthContext {
   scopeProfile: ScopeProfile;
   scopes: ReadonlySet<Scope>;
   policyEpoch: number;
+  /** Present only after the host verifies an assistant-peer operation. */
+  verifiedPeerContext?: VerifiedPeerOperationContext;
 }

--- a/assistant/src/runtime/routes/__tests__/default-plugin-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/default-plugin-routes.test.ts
@@ -54,6 +54,10 @@ function writeWorkspacePluginHandler(
     relativePath,
   );
   mkdirSync(dirname(full), { recursive: true });
+  writeFileSync(
+    join(getWorkspacePluginsDir(), pluginName, "package.json"),
+    JSON.stringify({ name: pluginName }),
+  );
   writeFileSync(full, content);
 }
 

--- a/assistant/src/runtime/routes/__tests__/default-plugin-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/default-plugin-routes.test.ts
@@ -41,6 +41,20 @@ const DEFAULT_PLUGIN_DIR = "platform-hosted";
 /** Its route namespace = `default-<dir>` by convention. */
 const DEFAULT_PLUGIN = `default-${DEFAULT_PLUGIN_DIR}`;
 
+function dispatch(
+  dispatcher: UserRouteDispatcher,
+  routePath: string,
+  request: Request,
+): Promise<Response> {
+  return dispatcher.dispatch(routePath, request, {
+    actor: {
+      principalType: "local",
+      principalId: null,
+      scopes: ["local.all"],
+    },
+  });
+}
+
 /** Create a workspace plugin dir; returns its `routes/` dir. Cleaned up per test. */
 function writeWorkspacePluginHandler(
   pluginName: string,
@@ -137,7 +151,8 @@ describe("default plugin route source resolution", () => {
 describe("default plugin route dispatch", () => {
   test("serves the default plugin's source route (GET on a POST-only handler → 405)", async () => {
     const dispatcher = new UserRouteDispatcher();
-    const response = await dispatcher.dispatch(
+    const response = await dispatch(
+      dispatcher,
       `plugins/${DEFAULT_PLUGIN}/reengage`,
       new Request(`http://localhost/v1/x/plugins/${DEFAULT_PLUGIN}/reengage`, {
         method: "GET",
@@ -163,7 +178,8 @@ describe("default plugin route dispatch", () => {
     ).toBe(false);
 
     const dispatcher = new UserRouteDispatcher();
-    const response = await dispatcher.dispatch(
+    const response = await dispatch(
+      dispatcher,
       `plugins/${DEFAULT_PLUGIN}/reengage`,
       new Request(`http://localhost/v1/x/plugins/${DEFAULT_PLUGIN}/reengage`, {
         method: "GET",
@@ -185,7 +201,8 @@ describe("default plugin route dispatch", () => {
     );
 
     const dispatcher = new UserRouteDispatcher();
-    const response = await dispatcher.dispatch(
+    const response = await dispatch(
+      dispatcher,
       `plugins/${DEFAULT_PLUGIN}/reengage`,
       new Request(`http://localhost/v1/x/plugins/${DEFAULT_PLUGIN}/reengage`, {
         method: "GET",
@@ -216,7 +233,8 @@ describe("default plugin route dispatch", () => {
 
     const dispatcher = new UserRouteDispatcher();
     for (const path of ["poison.test", "__tests__/poison"]) {
-      const response = await dispatcher.dispatch(
+      const response = await dispatch(
+        dispatcher,
         `plugins/${DEFAULT_PLUGIN}/${path}`,
         new Request(`http://localhost/v1/x/plugins/${DEFAULT_PLUGIN}/${path}`, {
           method: "GET",

--- a/assistant/src/runtime/routes/__tests__/plugin-readiness-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugin-readiness-routes.test.ts
@@ -15,15 +15,32 @@ import { UserRouteDispatcher } from "../user-route-dispatcher.js";
 
 const SOURCE_FINGERPRINT = "a".repeat(64);
 
-function writeRouteFixture(pluginId: string): string {
+function writeRouteFixture(
+  pluginId: string,
+  opts: { optsIntoReadiness?: boolean } = { optsIntoReadiness: true },
+): string {
   const pluginDir = join(getWorkspacePluginsDir(), pluginId);
   const routesDir = join(pluginDir, "routes");
   const marker = join(pluginDir, "imported");
   mkdirSync(routesDir, { recursive: true });
   writeFileSync(
     join(pluginDir, "package.json"),
-    JSON.stringify({ name: pluginId }),
+    JSON.stringify({
+      name: pluginId,
+      ...(opts.optsIntoReadiness
+        ? { peerDependencies: { "@vellumai/plugin-api": "*" } }
+        : {}),
+    }),
   );
+  if (opts.optsIntoReadiness) {
+    writeFileSync(
+      join(pluginDir, "host-requirements.json"),
+      JSON.stringify({
+        schemaVersion: 1,
+        requires: { "plugins.readiness": "^1.0.0" },
+      }),
+    );
+  }
   writeFileSync(
     join(routesDir, "status.ts"),
     `import { writeFileSync } from "node:fs";
@@ -68,6 +85,17 @@ afterEach(() => {
 });
 
 describe("plugin route readiness", () => {
+  test("serves a legacy plugin route without readiness state", async () => {
+    const pluginId = "legacy-route";
+    const marker = writeRouteFixture(pluginId, { optsIntoReadiness: false });
+
+    const response = await dispatch(pluginId);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+    expect(existsSync(marker)).toBe(true);
+  });
+
   test("keeps the timestamp for an unchanged readiness state", async () => {
     const pluginId = "stable-readiness";
     markPluginFailed(pluginId, SOURCE_FINGERPRINT, "initialization failed");
@@ -95,6 +123,24 @@ describe("plugin route readiness", () => {
     expect(body.error.details).toMatchObject({
       pluginId,
       status: "initializing",
+    });
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  test("fails closed on an invalid readiness opt-in", async () => {
+    const pluginId = "invalid-readiness-opt-in";
+    const marker = writeRouteFixture(pluginId);
+    writeFileSync(
+      join(getWorkspacePluginsDir(), pluginId, "host-requirements.json"),
+      "{invalid",
+    );
+
+    const response = await dispatch(pluginId);
+
+    expect(response.status).toBe(503);
+    expect((await response.json()).error).toMatchObject({
+      code: "plugin_incompatible",
+      details: { pluginId, status: "incompatible" },
     });
     expect(existsSync(marker)).toBe(false);
   });

--- a/assistant/src/runtime/routes/__tests__/plugin-readiness-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugin-readiness-routes.test.ts
@@ -1,8 +1,15 @@
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import {
+  derivePluginSourceFingerprint,
   getPluginReadiness,
   markPluginFailed,
   markPluginInitializing,
@@ -10,6 +17,7 @@ import {
   resetPluginReadinessForTests,
 } from "../../../plugins/plugin-readiness.js";
 import { resetPluginRouteManifestCacheForTests } from "../../../plugins/plugin-route-manifest.js";
+import { snapshotPluginSource } from "../../../plugins/source-fingerprint.js";
 import { getWorkspacePluginsDir } from "../../../util/platform.js";
 import { UserRouteDispatcher } from "../user-route-dispatcher.js";
 
@@ -70,6 +78,13 @@ async function dispatch(pluginId: string, method = "GET"): Promise<Response> {
   return new UserRouteDispatcher().dispatch(
     `plugins/${pluginId}/status`,
     new Request("http://localhost/v1/x/status", { method }),
+    {
+      actor: {
+        principalType: "local",
+        principalId: null,
+        scopes: ["local.all"],
+      },
+    },
   );
 }
 
@@ -94,6 +109,36 @@ describe("plugin route readiness", () => {
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ ok: true });
     expect(existsSync(marker)).toBe(true);
+  });
+
+  test("uses a durable ready snapshot only for matching plugin source", async () => {
+    const pluginId = "durable-ready-route";
+    const marker = writeRouteFixture(pluginId);
+    const pluginDir = join(getWorkspacePluginsDir(), pluginId);
+    const sourceFingerprint = derivePluginSourceFingerprint(
+      snapshotPluginSource(pluginDir).fingerprint,
+    );
+    markPluginReady(pluginId, sourceFingerprint);
+    resetPluginReadinessForTests({ durableReads: true });
+
+    const ready = await dispatch(pluginId);
+
+    expect(ready.status).toBe(200);
+    rmSync(marker, { force: true });
+    writeFileSync(
+      join(pluginDir, "routes", "status.ts"),
+      `import { writeFileSync } from "node:fs";
+       writeFileSync(${JSON.stringify(marker)}, "changed");
+       export function GET() { return Response.json({ changed: true }); }`,
+    );
+    const changedAt = new Date(Date.now() + 2_000);
+    utimesSync(join(pluginDir, "routes", "status.ts"), changedAt, changedAt);
+    resetPluginReadinessForTests({ durableReads: true });
+
+    const stale = await dispatch(pluginId);
+
+    expect(stale.status).toBe(503);
+    expect(existsSync(marker)).toBe(false);
   });
 
   test("keeps the timestamp for an unchanged readiness state", async () => {

--- a/assistant/src/runtime/routes/__tests__/plugin-readiness-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugin-readiness-routes.test.ts
@@ -1,0 +1,189 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  getPluginReadiness,
+  markPluginFailed,
+  markPluginInitializing,
+  markPluginReady,
+  resetPluginReadinessForTests,
+} from "../../../plugins/plugin-readiness.js";
+import { resetPluginRouteManifestCacheForTests } from "../../../plugins/plugin-route-manifest.js";
+import { getWorkspacePluginsDir } from "../../../util/platform.js";
+import { UserRouteDispatcher } from "../user-route-dispatcher.js";
+
+const SOURCE_FINGERPRINT = "a".repeat(64);
+
+function writeRouteFixture(pluginId: string): string {
+  const pluginDir = join(getWorkspacePluginsDir(), pluginId);
+  const routesDir = join(pluginDir, "routes");
+  const marker = join(pluginDir, "imported");
+  mkdirSync(routesDir, { recursive: true });
+  writeFileSync(
+    join(pluginDir, "package.json"),
+    JSON.stringify({ name: pluginId }),
+  );
+  writeFileSync(
+    join(routesDir, "status.ts"),
+    `import { writeFileSync } from "node:fs";
+     writeFileSync(${JSON.stringify(marker)}, "yes");
+     export function GET() { return Response.json({ ok: true }); }`,
+  );
+  writeFileSync(
+    join(routesDir, "manifest.json"),
+    JSON.stringify({
+      schemaVersion: 1,
+      routes: [
+        {
+          path: "status",
+          method: "GET",
+          authorization: {
+            principal: "actor",
+            requiredScopes: ["settings.read"],
+          },
+        },
+      ],
+    }),
+  );
+  return marker;
+}
+
+async function dispatch(pluginId: string, method = "GET"): Promise<Response> {
+  return new UserRouteDispatcher().dispatch(
+    `plugins/${pluginId}/status`,
+    new Request("http://localhost/v1/x/status", { method }),
+  );
+}
+
+beforeEach(() => {
+  resetPluginReadinessForTests();
+  resetPluginRouteManifestCacheForTests();
+});
+
+afterEach(() => {
+  resetPluginReadinessForTests();
+  resetPluginRouteManifestCacheForTests();
+  rmSync(getWorkspacePluginsDir(), { recursive: true, force: true });
+});
+
+describe("plugin route readiness", () => {
+  test("keeps the timestamp for an unchanged readiness state", async () => {
+    const pluginId = "stable-readiness";
+    markPluginFailed(pluginId, SOURCE_FINGERPRINT, "initialization failed");
+    const firstUpdatedAt = getPluginReadiness(pluginId)?.updatedAt;
+
+    await Bun.sleep(2);
+    markPluginFailed(pluginId, SOURCE_FINGERPRINT, "initialization failed");
+
+    expect(getPluginReadiness(pluginId)?.updatedAt).toBe(firstUpdatedAt);
+
+    await Bun.sleep(2);
+    markPluginFailed(pluginId, SOURCE_FINGERPRINT, "different failure");
+    expect(getPluginReadiness(pluginId)?.updatedAt).not.toBe(firstUpdatedAt);
+  });
+
+  test("returns initializing before importing an opted-in plugin route", async () => {
+    const pluginId = "initializing-route";
+    const marker = writeRouteFixture(pluginId);
+
+    const response = await dispatch(pluginId);
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body.error.code).toBe("plugin_initializing");
+    expect(body.error.details).toMatchObject({
+      pluginId,
+      status: "initializing",
+    });
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  test("keeps failed generations inert and serves only a ready generation", async () => {
+    const pluginId = "generation-route";
+    const marker = writeRouteFixture(pluginId);
+
+    markPluginInitializing(pluginId, SOURCE_FINGERPRINT);
+    const initializing = await dispatch(pluginId);
+    expect(initializing.status).toBe(503);
+    expect((await initializing.json()).error.code).toBe("plugin_initializing");
+    expect(existsSync(marker)).toBe(false);
+
+    markPluginFailed(
+      pluginId,
+      SOURCE_FINGERPRINT,
+      "fixture initialization failed",
+    );
+    const failed = await dispatch(pluginId);
+    expect(failed.status).toBe(503);
+    expect((await failed.json()).error).toMatchObject({
+      code: "plugin_initialization_failed",
+      message: "fixture initialization failed",
+    });
+    expect(existsSync(marker)).toBe(false);
+
+    markPluginReady(pluginId, SOURCE_FINGERPRINT);
+    const ready = await dispatch(pluginId);
+    expect(ready.status).toBe(200);
+    expect(await ready.json()).toEqual({ ok: true });
+    expect(existsSync(marker)).toBe(true);
+  });
+
+  test("does not import a route behind an invalid static manifest", async () => {
+    const pluginId = "invalid-route-manifest";
+    const marker = writeRouteFixture(pluginId);
+    const manifestPath = join(
+      getWorkspacePluginsDir(),
+      pluginId,
+      "routes",
+      "manifest.json",
+    );
+    mkdirSync(dirname(manifestPath), { recursive: true });
+    writeFileSync(manifestPath, "{invalid");
+    resetPluginRouteManifestCacheForTests();
+    markPluginReady(pluginId, SOURCE_FINGERPRINT);
+
+    const response = await dispatch(pluginId);
+    expect(response.status).toBe(503);
+    expect((await response.json()).error.code).toBe(
+      "plugin_route_manifest_invalid",
+    );
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  test("rejects a mutating actor route with read-only scopes before import", async () => {
+    const pluginId = "read-only-mutation";
+    const marker = writeRouteFixture(pluginId);
+    const manifestPath = join(
+      getWorkspacePluginsDir(),
+      pluginId,
+      "routes",
+      "manifest.json",
+    );
+    writeFileSync(
+      manifestPath,
+      JSON.stringify({
+        schemaVersion: 1,
+        routes: [
+          {
+            path: "status",
+            method: "PATCH",
+            authorization: {
+              principal: "actor",
+              requiredScopes: ["settings.read"],
+            },
+          },
+        ],
+      }),
+    );
+    resetPluginRouteManifestCacheForTests();
+    markPluginReady(pluginId, SOURCE_FINGERPRINT);
+
+    const response = await dispatch(pluginId, "PATCH");
+    expect(response.status).toBe(503);
+    expect((await response.json()).error.code).toBe(
+      "plugin_route_manifest_invalid",
+    );
+    expect(existsSync(marker)).toBe(false);
+  });
+});

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -490,6 +490,7 @@ describe("GET /v1/plugins", () => {
       name: "alpha",
       // No `.disabled` sentinel → the plugin is enabled.
       enabled: true,
+      activation: { status: "ready" },
       description: "Alpha plugin",
       version: "1.2.3",
       path: "/workspace/plugins/alpha",

--- a/assistant/src/runtime/routes/__tests__/user-route-dispatcher-host.test.ts
+++ b/assistant/src/runtime/routes/__tests__/user-route-dispatcher-host.test.ts
@@ -16,6 +16,9 @@ interface InvokeCall {
   params: RouteInvokeParams;
   body: Uint8Array | null;
 }
+interface InvokeOptions {
+  body: Uint8Array | null;
+}
 
 let hostEnabled = false;
 let invokeImpl: (call: InvokeCall) => Promise<RouteInvokeResponse>;
@@ -37,8 +40,8 @@ mock.module("../../../routes/route-host-client.js", () => ({
     constructor(options?: { invokeTimeoutMs?: number }) {
       ctorOptions.push(options);
     }
-    async invoke(params: RouteInvokeParams, body: Uint8Array | null) {
-      const call = { params, body };
+    async invoke(params: RouteInvokeParams, options: InvokeOptions) {
+      const call = { params, body: options.body };
       invokeCalls.push(call);
       return invokeImpl(call);
     }

--- a/assistant/src/runtime/routes/__tests__/user-route-dispatcher-host.test.ts
+++ b/assistant/src/runtime/routes/__tests__/user-route-dispatcher-host.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { RouteInvokeParams } from "../../../routes/route-host-protocol.js";
 import { getWorkspaceRoutesDir } from "../../../util/platform.js";
+import type { UserRouteDispatchContext } from "../user-route-dispatcher.js";
 
 // The dispatcher constructs the route host client inline and reads the enabled
 // flag from config, so both are mocked here (there is no injection seam).
@@ -52,8 +53,25 @@ mock.module("../../../routes/route-host-client.js", () => ({
 
 const { UserRouteDispatcher } = await import("../user-route-dispatcher.js");
 
+const LOCAL_DISPATCH_CONTEXT = {
+  actor: {
+    principalType: "local",
+    principalId: null,
+    scopes: ["local.all"],
+  },
+} as const satisfies UserRouteDispatchContext;
+
 function makeDispatcher() {
-  return new UserRouteDispatcher();
+  const dispatcher = new UserRouteDispatcher();
+  return {
+    dispatch(
+      routePath: string,
+      request: Request,
+      context: UserRouteDispatchContext = LOCAL_DISPATCH_CONTEXT,
+    ) {
+      return dispatcher.dispatch(routePath, request, context);
+    },
+  };
 }
 
 function writeHandler(name: string, content: string): void {

--- a/assistant/src/runtime/routes/__tests__/user-route-dispatcher.test.ts
+++ b/assistant/src/runtime/routes/__tests__/user-route-dispatcher.test.ts
@@ -907,7 +907,7 @@ describe("plugin routes", () => {
     });
   });
 
-  test("keeps actor and assistant-peer route policies disjoint", async () => {
+  test("keeps assistant-peer routes unavailable before host support", async () => {
     const plugin = "peer-policy";
     writePluginHandler(
       plugin,
@@ -940,7 +940,7 @@ describe("plugin routes", () => {
         },
       },
     );
-    expect(actorResponse.status).toBe(403);
+    expect(actorResponse.status).toBe(503);
 
     const verifiedPeer = {
       peerId: "peer-123",
@@ -963,8 +963,13 @@ describe("plugin routes", () => {
         verifiedPeer,
       },
     );
-    expect(peerResponse.status).toBe(200);
-    expect(await peerResponse.json()).toEqual(verifiedPeer);
+    expect(peerResponse.status).toBe(503);
+    expect(await readErrorBody(peerResponse)).toMatchObject({
+      error: {
+        code: "plugin_incompatible",
+        message: expect.stringContaining("plugins.routes.assistant-peer"),
+      },
+    });
   });
 
   test("a new route export is not bound to a stale helper after upgrade", async () => {

--- a/assistant/src/runtime/routes/__tests__/user-route-dispatcher.test.ts
+++ b/assistant/src/runtime/routes/__tests__/user-route-dispatcher.test.ts
@@ -1,4 +1,11 @@
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  rmSync,
+  statSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
@@ -6,7 +13,10 @@ import {
   markPluginReady,
   resetPluginReadinessForTests,
 } from "../../../plugins/plugin-readiness.js";
-import { resetPluginRouteManifestCacheForTests } from "../../../plugins/plugin-route-manifest.js";
+import {
+  readPluginRouteManifest,
+  resetPluginRouteManifestCacheForTests,
+} from "../../../plugins/plugin-route-manifest.js";
 // ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
@@ -14,7 +24,10 @@ import {
   getWorkspacePluginsDir,
   getWorkspaceRoutesDir,
 } from "../../../util/platform.js";
-import { UserRouteDispatcher } from "../user-route-dispatcher.js";
+import {
+  type UserRouteDispatchContext,
+  UserRouteDispatcher,
+} from "../user-route-dispatcher.js";
 
 const PLUGIN_ROUTE_CONTEXT_MODULE_URL = new URL(
   "../../../plugin-api/route-context.ts",
@@ -26,10 +39,31 @@ const PLUGIN_ROUTE_CONTEXT_MODULE_URL = new URL(
 // ---------------------------------------------------------------------------
 
 /** Create a dispatcher with optional overrides. */
+const LOCAL_DISPATCH_CONTEXT = {
+  actor: {
+    principalType: "local",
+    principalId: null,
+    scopes: ["local.all"],
+  },
+} as const satisfies UserRouteDispatchContext;
+
+interface TestDispatcher {
+  dispatch(
+    routePath: string,
+    request: Request,
+    context?: UserRouteDispatchContext,
+  ): Promise<Response>;
+}
+
 function makeDispatcher(options?: {
   handlerTimeoutMs?: number;
-}): UserRouteDispatcher {
-  return new UserRouteDispatcher(options);
+}): TestDispatcher {
+  const dispatcher = new UserRouteDispatcher(options);
+  return {
+    dispatch(routePath, request, context = LOCAL_DISPATCH_CONTEXT) {
+      return dispatcher.dispatch(routePath, request, context);
+    },
+  };
 }
 
 function makeRequest(
@@ -551,7 +585,7 @@ describe("plugin routes", () => {
     expect(body.plugin).toBe(true);
   });
 
-  test("keeps legacy POST routes compatible with read-only actors", async () => {
+  test("requires write scope for legacy mutating routes", async () => {
     writePluginHandler(
       "legacy-post",
       "submit.ts",
@@ -570,7 +604,38 @@ describe("plugin routes", () => {
       },
     );
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(403);
+
+    const allowed = await makeDispatcher().dispatch(
+      "plugins/legacy-post/submit",
+      makeRequest("POST"),
+      {
+        actor: {
+          principalType: "actor",
+          principalId: "user-123",
+          scopes: ["settings.write"],
+        },
+      },
+    );
+    expect(allowed.status).toBe(200);
+  });
+
+  test("fails closed without verified dispatch context", async () => {
+    writePluginHandler(
+      "missing-context",
+      "status.ts",
+      `export function GET() { return new Response("unexpected"); }`,
+    );
+    const dispatcher = new UserRouteDispatcher();
+
+    const response = await (
+      dispatcher.dispatch as unknown as (
+        routePath: string,
+        request: Request,
+      ) => Promise<Response>
+    )("plugins/missing-context/status", makeRequest("GET"));
+
+    expect(response.status).toBe(403);
   });
 
   test("resolves nested paths and the index (namespace root)", async () => {
@@ -680,6 +745,76 @@ describe("plugin routes", () => {
       makeRequest("GET"),
     );
     expect(other.status).toBe(404);
+  });
+
+  test("does not execute routes from a directory without package metadata", async () => {
+    const pluginDir = join(getWorkspacePluginsDir(), "uninstalled-plugin");
+    const marker = join(pluginDir, "imported");
+    mkdirSync(join(pluginDir, "routes"), { recursive: true });
+    writeFileSync(
+      join(pluginDir, "routes", "status.ts"),
+      `import { writeFileSync } from "node:fs";
+       writeFileSync(${JSON.stringify(marker)}, "yes");
+       export function GET() { return new Response("unexpected"); }`,
+    );
+
+    const response = await makeDispatcher().dispatch(
+      "plugins/uninstalled-plugin/status",
+      makeRequest("GET"),
+    );
+
+    expect(response.status).toBe(404);
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  test("reloads a same-size route manifest with preserved mtime", () => {
+    const plugin = "manifest-replacement";
+    writePluginRouteManifest(plugin, [
+      {
+        path: "status",
+        method: "GET",
+        authorization: {
+          principal: "actor",
+          requiredScopes: ["settings.write"],
+        },
+      },
+    ]);
+    const manifestPath = join(
+      getWorkspacePluginsDir(),
+      plugin,
+      "routes",
+      "manifest.json",
+    );
+    const first = readPluginRouteManifest(
+      join(getWorkspacePluginsDir(), plugin),
+    );
+    const before = statSync(manifestPath);
+    const replacement = JSON.stringify({
+      schemaVersion: 1,
+      routes: [
+        {
+          path: "status",
+          method: "PUT",
+          authorization: {
+            principal: "actor",
+            requiredScopes: ["settings.write"],
+          },
+        },
+      ],
+    });
+    expect(Buffer.byteLength(replacement)).toBe(before.size);
+
+    writeFileSync(manifestPath, replacement);
+    utimesSync(manifestPath, before.atime, before.mtime);
+    const second = readPluginRouteManifest(
+      join(getWorkspacePluginsDir(), plugin),
+    );
+
+    expect(first.kind).toBe("valid");
+    expect(second.kind).toBe("valid");
+    if (second.kind === "valid") {
+      expect(second.manifest.routes[0]?.method).toBe("PUT");
+    }
   });
 
   test("denies a read-only actor on a declared write route before import", async () => {

--- a/assistant/src/runtime/routes/__tests__/user-route-dispatcher.test.ts
+++ b/assistant/src/runtime/routes/__tests__/user-route-dispatcher.test.ts
@@ -1,7 +1,12 @@
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
+import {
+  markPluginReady,
+  resetPluginReadinessForTests,
+} from "../../../plugins/plugin-readiness.js";
+import { resetPluginRouteManifestCacheForTests } from "../../../plugins/plugin-route-manifest.js";
 // ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
@@ -10,6 +15,11 @@ import {
   getWorkspaceRoutesDir,
 } from "../../../util/platform.js";
 import { UserRouteDispatcher } from "../user-route-dispatcher.js";
+
+const PLUGIN_ROUTE_CONTEXT_MODULE_URL = new URL(
+  "../../../plugin-api/route-context.ts",
+  import.meta.url,
+).href;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -44,16 +54,32 @@ function writePluginHandler(
   relativePath: string,
   content: string,
 ): string {
-  const fullPath = join(
+  const pluginDir = join(getWorkspacePluginsDir(), pluginName);
+  const fullPath = join(pluginDir, "routes", relativePath);
+  const dir = fullPath.substring(0, fullPath.lastIndexOf("/"));
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(pluginDir, "package.json"),
+    JSON.stringify({ name: pluginName }),
+  );
+  writeFileSync(fullPath, content);
+  markPluginReady(pluginName, "a".repeat(64));
+  return fullPath;
+}
+
+function writePluginRouteManifest(
+  pluginName: string,
+  routes: Array<Record<string, unknown>>,
+): void {
+  const path = join(
     getWorkspacePluginsDir(),
     pluginName,
     "routes",
-    relativePath,
+    "manifest.json",
   );
-  const dir = fullPath.substring(0, fullPath.lastIndexOf("/"));
-  mkdirSync(dir, { recursive: true });
-  writeFileSync(fullPath, content);
-  return fullPath;
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify({ schemaVersion: 1, routes }));
+  resetPluginRouteManifestCacheForTests();
 }
 
 async function readErrorBody(
@@ -67,10 +93,14 @@ async function readErrorBody(
 // ---------------------------------------------------------------------------
 
 beforeEach(() => {
+  resetPluginReadinessForTests();
+  resetPluginRouteManifestCacheForTests();
   mkdirSync(getWorkspaceRoutesDir(), { recursive: true });
 });
 
 afterEach(() => {
+  resetPluginReadinessForTests();
+  resetPluginRouteManifestCacheForTests();
   rmSync(getWorkspaceRoutesDir(), { recursive: true, force: true });
   rmSync(getWorkspacePluginsDir(), { recursive: true, force: true });
 });
@@ -162,6 +192,61 @@ describe("successful dispatch", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.format).toBe("js");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Workspace route authorization
+// ---------------------------------------------------------------------------
+
+describe("workspace route authorization", () => {
+  test("requires settings.read or local.all before importing the handler", async () => {
+    const importMarker = join(getWorkspaceRoutesDir(), "imported");
+    writeHandler(
+      "protected.ts",
+      `import { writeFileSync } from "node:fs";
+       writeFileSync(${JSON.stringify(importMarker)}, "yes");
+       export function GET() { return Response.json({ ok: true }); }`,
+    );
+    const dispatcher = makeDispatcher();
+
+    const denied = await dispatcher.dispatch("protected", makeRequest("GET"), {
+      actor: {
+        principalType: "actor",
+        principalId: "user-123",
+        scopes: ["chat.read"],
+      },
+    });
+
+    expect(denied.status).toBe(403);
+    expect(existsSync(importMarker)).toBe(false);
+
+    const settingsReader = await dispatcher.dispatch(
+      "protected",
+      makeRequest("GET"),
+      {
+        actor: {
+          principalType: "actor",
+          principalId: "user-123",
+          scopes: ["settings.read"],
+        },
+      },
+    );
+    expect(settingsReader.status).toBe(200);
+    expect(existsSync(importMarker)).toBe(true);
+
+    const localCaller = await dispatcher.dispatch(
+      "protected",
+      makeRequest("GET"),
+      {
+        actor: {
+          principalType: "local",
+          principalId: null,
+          scopes: ["local.all"],
+        },
+      },
+    );
+    expect(localCaller.status).toBe(200);
   });
 });
 
@@ -466,6 +551,28 @@ describe("plugin routes", () => {
     expect(body.plugin).toBe(true);
   });
 
+  test("keeps legacy POST routes compatible with read-only actors", async () => {
+    writePluginHandler(
+      "legacy-post",
+      "submit.ts",
+      `export function POST() { return new Response("ok"); }`,
+    );
+
+    const response = await makeDispatcher().dispatch(
+      "plugins/legacy-post/submit",
+      makeRequest("POST"),
+      {
+        actor: {
+          principalType: "actor",
+          principalId: "user-123",
+          scopes: ["settings.read"],
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+  });
+
   test("resolves nested paths and the index (namespace root)", async () => {
     writePluginHandler(
       "my-plugin",
@@ -575,6 +682,156 @@ describe("plugin routes", () => {
     expect(other.status).toBe(404);
   });
 
+  test("denies a read-only actor on a declared write route before import", async () => {
+    const plugin = "write-policy";
+    const importMarker = join(getWorkspacePluginsDir(), plugin, "imported");
+    writePluginHandler(
+      plugin,
+      "settings.ts",
+      `import { writeFileSync } from "node:fs";
+       writeFileSync(${JSON.stringify(importMarker)}, "yes");
+       export function PATCH() { return Response.json({ ok: true }); }`,
+    );
+    writePluginRouteManifest(plugin, [
+      {
+        path: "settings",
+        method: "PATCH",
+        authorization: {
+          principal: "actor",
+          requiredScopes: ["settings.write"],
+        },
+      },
+    ]);
+    markPluginReady(plugin, "a".repeat(64));
+
+    const response = await makeDispatcher().dispatch(
+      `plugins/${plugin}/settings`,
+      makeRequest("PATCH"),
+      {
+        actor: {
+          principalType: "actor",
+          principalId: "user-123",
+          scopes: ["settings.read"],
+        },
+      },
+    );
+
+    expect(response.status).toBe(403);
+    expect(existsSync(importMarker)).toBe(false);
+  });
+
+  test("exposes host-derived route context to an authorized handler", async () => {
+    const plugin = "route-context";
+    writePluginHandler(
+      plugin,
+      "settings.ts",
+      `import { requirePluginRouteContext } from ${JSON.stringify(PLUGIN_ROUTE_CONTEXT_MODULE_URL)};
+       export async function PATCH() {
+         const context = requirePluginRouteContext();
+         return Response.json({
+           pluginId: context.pluginId,
+           principalId: context.actor.principalId,
+           requestId: context.requestId,
+           hasSignal: context.signal instanceof AbortSignal,
+           storageDir: await context.host.getPluginStorageDir(),
+         });
+       }`,
+    );
+    writePluginRouteManifest(plugin, [
+      {
+        path: "settings",
+        method: "PATCH",
+        authorization: {
+          principal: "actor",
+          requiredScopes: ["settings.write"],
+        },
+      },
+    ]);
+    markPluginReady(plugin, "b".repeat(64));
+
+    const response = await makeDispatcher().dispatch(
+      `plugins/${plugin}/settings`,
+      makeRequest("PATCH"),
+      {
+        actor: {
+          principalType: "actor",
+          principalId: "user-123",
+          scopes: ["settings.write"],
+        },
+        requestId: "request-123",
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      pluginId: plugin,
+      principalId: "user-123",
+      requestId: "request-123",
+      hasSignal: true,
+      storageDir: join(getWorkspacePluginsDir(), plugin, "data"),
+    });
+  });
+
+  test("keeps actor and assistant-peer route policies disjoint", async () => {
+    const plugin = "peer-policy";
+    writePluginHandler(
+      plugin,
+      "exchange.ts",
+      `import { requirePluginRouteContext } from ${JSON.stringify(PLUGIN_ROUTE_CONTEXT_MODULE_URL)};
+       export function POST() {
+         return Response.json(requirePluginRouteContext().verifiedPeer);
+       }`,
+    );
+    writePluginRouteManifest(plugin, [
+      {
+        path: "exchange",
+        method: "POST",
+        authorization: {
+          principal: "assistant_peer",
+          operationKinds: ["conversation.copy"],
+        },
+      },
+    ]);
+    markPluginReady(plugin, "c".repeat(64));
+
+    const actorResponse = await makeDispatcher().dispatch(
+      `plugins/${plugin}/exchange`,
+      makeRequest("POST"),
+      {
+        actor: {
+          principalType: "actor",
+          principalId: "user-123",
+          scopes: ["settings.write"],
+        },
+      },
+    );
+    expect(actorResponse.status).toBe(403);
+
+    const verifiedPeer = {
+      peerId: "peer-123",
+      generation: "generation-1",
+      operation: {
+        id: "operation-123",
+        kind: "conversation.copy",
+        payloadHash: `sha256:${"d".repeat(64)}`,
+      },
+    } as const;
+    const peerResponse = await makeDispatcher().dispatch(
+      `plugins/${plugin}/exchange`,
+      makeRequest("POST"),
+      {
+        actor: {
+          principalType: "assistant_peer",
+          principalId: null,
+          scopes: [],
+        },
+        verifiedPeer,
+      },
+    );
+    expect(peerResponse.status).toBe(200);
+    expect(await peerResponse.json()).toEqual(verifiedPeer);
+  });
+
   test("a new route export is not bound to a stale helper after upgrade", async () => {
     // Reproduces the browser plugin 500: `/frame` loaded `src/http.ts`
     // first, then an upgrade added `requireNumber` to http.ts and a new
@@ -583,10 +840,7 @@ describe("plugin routes", () => {
     const plugin = "stale-helper";
     const helperPath = join(getWorkspacePluginsDir(), plugin, "src", "http.ts");
     mkdirSync(dirname(helperPath), { recursive: true });
-    writeFileSync(
-      helperPath,
-      `export function label() { return "v1"; }\n`,
-    );
+    writeFileSync(helperPath, `export function label() { return "v1"; }\n`);
     writePluginHandler(
       plugin,
       "frame.ts",

--- a/assistant/src/runtime/routes/__tests__/user-routes-cli.test.ts
+++ b/assistant/src/runtime/routes/__tests__/user-routes-cli.test.ts
@@ -42,8 +42,13 @@ function writeWorkspaceRoute(relPath: string): void {
 }
 
 function writePluginRoute(plugin: string, relPath: string): void {
-  const full = join(getWorkspacePluginsDir(), plugin, "routes", relPath);
+  const pluginDir = join(getWorkspacePluginsDir(), plugin);
+  const full = join(pluginDir, "routes", relPath);
   mkdirSync(full.slice(0, full.lastIndexOf("/")), { recursive: true });
+  writeFileSync(
+    join(pluginDir, "package.json"),
+    JSON.stringify({ name: plugin, version: "1.0.0" }),
+  );
   writeFileSync(full, GET_HANDLER);
 }
 

--- a/assistant/src/runtime/routes/deprecated-route-context.ts
+++ b/assistant/src/runtime/routes/deprecated-route-context.ts
@@ -1,13 +1,11 @@
 /**
- * Deprecated `/x/*` route context — a telemetry-emitting compatibility shim.
+ * Deprecated `/x/*` route context, with compatibility-use telemetry.
  *
- * Route handlers now reach daemon capabilities through `@vellumai/plugin-api`
- * (`publishEvent`, `runConversationTurn`), which work identically in-process and
- * in the route-host subprocess. Installed route files written against the older
- * `(request, context)` signature keep working: each `context` field delegates
- * to its plugin-api equivalent and records a deprecation-usage telemetry signal
- * the first time a given route touches it, so usage can be watched down to zero
- * before the argument is removed.
+ * The in-process dispatcher passes this shim to installed route files written
+ * against the older `(request, context)` signature. Each field delegates to
+ * its plugin-api equivalent and records a deprecation-usage telemetry signal
+ * the first time a route touches it. The route-host subprocess does not expose
+ * this compatibility argument or main-process-only conversation APIs.
  *
  * This whole module — and the handler's second parameter — is intended to be
  * deleted once the telemetry shows no route still depends on `context`.

--- a/assistant/src/runtime/routes/http-adapter.ts
+++ b/assistant/src/runtime/routes/http-adapter.ts
@@ -120,6 +120,7 @@ export function routeDefinitionsToHTTPRoutes(
         // the gateway IPC proxy (gateway/src/http/routes/ipc-runtime-proxy.ts).
         delete headers["x-vellum-actor-principal-id"];
         delete headers["x-vellum-principal-type"];
+        delete headers["x-vellum-scope-profile"];
 
         // Inject auth context fields so transport-agnostic handlers can
         // resolve trust context without importing auth internals.
@@ -129,6 +130,9 @@ export function routeDefinitionsToHTTPRoutes(
         if (authContext?.principalType) {
           headers["x-vellum-principal-type"] = authContext.principalType;
         }
+        if (authContext?.scopeProfile) {
+          headers["x-vellum-scope-profile"] = authContext.scopeProfile;
+        }
 
         const result = await r.handler({
           pathParams,
@@ -137,6 +141,7 @@ export function routeDefinitionsToHTTPRoutes(
           rawBody,
           headers,
           abortSignal: req.signal,
+          authContext,
         });
 
         const headerArgs: ResponseHeaderArgs = {

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -96,7 +96,7 @@ import {
   deactivatePluginForUpdate,
   reconcilePluginSourcesNow,
 } from "../../plugins/mtime-cache.js";
-import { getPluginReadiness } from "../../plugins/plugin-readiness.js";
+import { getPluginSurfaceActivation } from "../../plugins/plugin-readiness.js";
 import { getLocalCategorySlugs } from "../../skills/categories-cache.js";
 import { getLogger } from "../../util/logger.js";
 import { getWorkspacePluginsDir } from "../../util/platform.js";
@@ -813,18 +813,9 @@ function projectPlugin(entry: InstalledPluginInfo): PluginView {
   // be scoped (e.g. `@vendor/plugin-name`) which is fine for npm but not
   // what the CLI uses to install — so we don't surface it as `name`.
   const enabled = !isPluginDisabled(entry.name);
-  const readiness = getPluginReadiness(entry.name);
   const activation: PluginView["activation"] = !enabled
     ? { status: "disabled" }
-    : readiness === undefined
-      ? { status: "unavailable" }
-      : {
-          status: readiness.status,
-          ...(readiness.code === undefined ? {} : { code: readiness.code }),
-          ...(readiness.message === undefined
-            ? {}
-            : { message: readiness.message }),
-        };
+    : getPluginSurfaceActivation(entry.name, entry.target);
   const view: PluginView = {
     id: entry.name,
     name: entry.name,

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -96,6 +96,7 @@ import {
   deactivatePluginForUpdate,
   reconcilePluginSourcesNow,
 } from "../../plugins/mtime-cache.js";
+import { getPluginReadiness } from "../../plugins/plugin-readiness.js";
 import { getLocalCategorySlugs } from "../../skills/categories-cache.js";
 import { getLogger } from "../../util/logger.js";
 import { getWorkspacePluginsDir } from "../../util/platform.js";
@@ -130,6 +131,22 @@ const pluginInfoSchema = z.object({
     .boolean()
     .describe(
       "Whether the plugin is active in this workspace. `false` when a `.disabled` sentinel is present under its directory; `true` otherwise.",
+    ),
+  activation: z
+    .object({
+      status: z.enum([
+        "disabled",
+        "initializing",
+        "ready",
+        "incompatible",
+        "failed",
+        "unavailable",
+      ]),
+      code: z.string().optional(),
+      message: z.string().optional(),
+    })
+    .describe(
+      "Host activation state. Plugin surfaces are available only when status is `ready`.",
     ),
   description: z
     .string()
@@ -770,6 +787,17 @@ interface PluginView {
   id: string;
   name: string;
   enabled: boolean;
+  activation: {
+    status:
+      | "disabled"
+      | "initializing"
+      | "ready"
+      | "incompatible"
+      | "failed"
+      | "unavailable";
+    code?: string;
+    message?: string;
+  };
   description: string | null;
   version: string | null;
   path: string;
@@ -784,11 +812,25 @@ function projectPlugin(entry: InstalledPluginInfo): PluginView {
   // `id` and `name` both track the directory name. `package.json#name` can
   // be scoped (e.g. `@vendor/plugin-name`) which is fine for npm but not
   // what the CLI uses to install — so we don't surface it as `name`.
+  const enabled = !isPluginDisabled(entry.name);
+  const readiness = getPluginReadiness(entry.name);
+  const activation: PluginView["activation"] = !enabled
+    ? { status: "disabled" }
+    : readiness === undefined
+      ? { status: "unavailable" }
+      : {
+          status: readiness.status,
+          ...(readiness.code === undefined ? {} : { code: readiness.code }),
+          ...(readiness.message === undefined
+            ? {}
+            : { message: readiness.message }),
+        };
   const view: PluginView = {
     id: entry.name,
     name: entry.name,
     // `entry.name` is the plugin directory name, which is the sentinel key.
-    enabled: !isPluginDisabled(entry.name),
+    enabled,
+    activation,
     description: entry.packageJson?.description ?? null,
     version: entry.packageJson?.version ?? null,
     path: entry.target,

--- a/assistant/src/runtime/routes/types.ts
+++ b/assistant/src/runtime/routes/types.ts
@@ -5,6 +5,7 @@
 import type { z } from "zod";
 
 import type { RoutePolicy } from "../auth/route-policy.js";
+import type { AuthContext } from "../auth/types.js";
 
 export interface RouteQueryParam {
   name: string;
@@ -115,6 +116,12 @@ export interface RouteHandlerArgs {
    * `undefined` when no abort semantic is available.
    */
   abortSignal?: AbortSignal;
+  /**
+   * Verified HTTP actor context. It is intentionally not serialized through
+   * IPC; IPC routes continue to receive their trusted identity projection in
+   * `headers`.
+   */
+  authContext?: AuthContext;
 }
 
 /**

--- a/assistant/src/runtime/routes/user-route-dispatcher.ts
+++ b/assistant/src/runtime/routes/user-route-dispatcher.ts
@@ -91,6 +91,7 @@ const HTTP_METHODS = [
   "HEAD",
   "OPTIONS",
 ] as const;
+const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
 type HttpMethod = (typeof HTTP_METHODS)[number];
 
@@ -163,8 +164,11 @@ export class UserRouteDispatcher {
   async dispatch(
     routePath: string,
     request: Request,
-    dispatchContext?: UserRouteDispatchContext,
+    dispatchContext: UserRouteDispatchContext,
   ): Promise<Response> {
+    if (!dispatchContext) {
+      return httpError("FORBIDDEN", "Verified route context is required", 403);
+    }
     if (routePath.includes("..")) {
       return httpError("BAD_REQUEST", "Path traversal is not allowed", 400);
     }
@@ -180,7 +184,7 @@ export class UserRouteDispatcher {
 
     if (
       !location.pluginId &&
-      dispatchContext?.actor.principalType === "assistant_peer"
+      dispatchContext.actor.principalType === "assistant_peer"
     ) {
       return Response.json(
         {
@@ -195,7 +199,6 @@ export class UserRouteDispatcher {
 
     if (
       !location.pluginId &&
-      dispatchContext &&
       !dispatchContext.actor.scopes.includes("settings.read") &&
       !dispatchContext.actor.scopes.includes("local.all")
     ) {
@@ -235,7 +238,7 @@ export class UserRouteDispatcher {
         location.pluginId,
         authorization,
         this.resolvePluginRouteActor(dispatchContext),
-        dispatchContext?.verifiedPeer ?? null,
+        dispatchContext.verifiedPeer ?? null,
       );
       if (denied) {
         return denied;
@@ -261,7 +264,13 @@ export class UserRouteDispatcher {
       : undefined;
 
     if (isRouteHostEnabled()) {
-      return this.dispatchViaHost(filePath, routePath, request, pluginRoute);
+      return this.dispatchViaHost(
+        filePath,
+        routeSourceRoot(location.routesDir),
+        routePath,
+        request,
+        pluginRoute,
+      );
     }
 
     const mod = await this.loadModule(filePath, location.routesDir);
@@ -288,9 +297,9 @@ export class UserRouteDispatcher {
     pluginId: string,
     pluginDir: string | undefined,
     request: Request,
-    dispatchContext: UserRouteDispatchContext | undefined,
+    dispatchContext: UserRouteDispatchContext,
   ): PluginRouteExecution {
-    const actor = this.resolvePluginRouteActor(dispatchContext);
+    const actor = dispatchContext.actor;
     const pluginStorageDir = resolvePluginStorageDir(
       pluginId,
       pluginDir ?? null,
@@ -298,9 +307,9 @@ export class UserRouteDispatcher {
     const context: PluginRouteContext = {
       pluginId,
       actor,
-      requestId: dispatchContext?.requestId ?? randomUUID(),
-      signal: dispatchContext?.signal ?? request.signal,
-      verifiedPeer: dispatchContext?.verifiedPeer ?? null,
+      requestId: dispatchContext.requestId ?? randomUUID(),
+      signal: dispatchContext.signal ?? request.signal,
+      verifiedPeer: dispatchContext.verifiedPeer ?? null,
       host: {
         async getPluginStorageDir(): Promise<string> {
           return pluginStorageDir;
@@ -314,15 +323,9 @@ export class UserRouteDispatcher {
   }
 
   private resolvePluginRouteActor(
-    dispatchContext: UserRouteDispatchContext | undefined,
+    dispatchContext: UserRouteDispatchContext,
   ): PluginRouteActorContext {
-    return (
-      dispatchContext?.actor ?? {
-        principalType: "local",
-        principalId: null,
-        scopes: ["local.all"],
-      }
-    );
+    return dispatchContext.actor;
   }
 
   private pluginUnavailableResponse(
@@ -387,7 +390,12 @@ export class UserRouteDispatcher {
     manifest: PluginRouteManifestResult | undefined,
   ): PluginRouteAuthorization | Response {
     if (!manifest || manifest.kind === "legacy") {
-      return { principal: "actor", requiredScopes: ["settings.read"] };
+      return {
+        principal: "actor",
+        requiredScopes: [
+          MUTATING_METHODS.has(method) ? "settings.write" : "settings.read",
+        ],
+      };
     }
     if (manifest.kind === "invalid") {
       return this.pluginStatusResponse(
@@ -432,6 +440,7 @@ export class UserRouteDispatcher {
    */
   private async dispatchViaHost(
     filePath: string,
+    sourceRoot: string,
     routePath: string,
     request: Request,
     pluginRoute: PluginRouteExecution | undefined,
@@ -450,6 +459,7 @@ export class UserRouteDispatcher {
       const result = await this.routeHostClient.invoke(
         {
           filePath,
+          sourceRoot,
           method: request.method,
           url: request.url,
           headers,

--- a/assistant/src/runtime/routes/user-route-dispatcher.ts
+++ b/assistant/src/runtime/routes/user-route-dispatcher.ts
@@ -44,7 +44,7 @@ import {
 } from "../../plugin-api/route-context.js";
 import type { VerifiedPeerOperationContext } from "../../plugin-api/verified-peer-context.js";
 import { runInPluginContext } from "../../plugins/plugin-execution-context.js";
-import { getPluginReadiness } from "../../plugins/plugin-readiness.js";
+import { getPluginSurfaceActivation } from "../../plugins/plugin-readiness.js";
 import {
   findPluginRouteDeclaration,
   type PluginRouteAuthorization,
@@ -211,11 +211,10 @@ export class UserRouteDispatcher {
     }
 
     if (location.pluginId) {
-      const isInstalledPlugin = location.pluginDir !== undefined;
       const unavailable = this.pluginUnavailableResponse(
         location.pluginId,
+        location.pluginDir,
         location.routeManifest,
-        isInstalledPlugin,
       );
       if (unavailable) {
         return unavailable;
@@ -328,8 +327,8 @@ export class UserRouteDispatcher {
 
   private pluginUnavailableResponse(
     pluginId: string,
+    pluginDir: string | undefined,
     manifest: PluginRouteManifestResult | undefined,
-    isInstalledPlugin: boolean,
   ): Response | null {
     if (manifest?.kind === "invalid") {
       return this.pluginStatusResponse(
@@ -340,37 +339,26 @@ export class UserRouteDispatcher {
       );
     }
 
-    if (!isInstalledPlugin) {
+    if (!pluginDir) {
       return null;
     }
 
-    const readiness = getPluginReadiness(pluginId);
-    if (!readiness) {
-      return this.pluginStatusResponse(
-        pluginId,
-        "initializing",
-        "plugin_initializing",
-        "Plugin is initializing",
-      );
-    }
-    if (readiness.status === "ready") {
+    const activation = getPluginSurfaceActivation(pluginId, pluginDir);
+    if (activation.status === "ready") {
       return null;
     }
 
     const code =
-      readiness.status === "incompatible"
+      activation.status === "incompatible"
         ? "plugin_incompatible"
-        : readiness.status === "failed"
+        : activation.status === "failed"
           ? "plugin_initialization_failed"
           : "plugin_initializing";
     return this.pluginStatusResponse(
       pluginId,
-      readiness.status,
+      activation.status,
       code,
-      readiness.message ??
-        (readiness.status === "initializing"
-          ? "Plugin is initializing"
-          : "Plugin is unavailable"),
+      activation.message,
     );
   }
 

--- a/assistant/src/runtime/routes/user-route-dispatcher.ts
+++ b/assistant/src/runtime/routes/user-route-dispatcher.ts
@@ -14,10 +14,9 @@
  *   each other.
  *
  * Each handler file exports named functions for HTTP methods (GET, POST, PUT,
- * etc.) using the standard Web API Request/Response signature. New handlers
- * reach daemon capabilities by importing `@vellumai/plugin-api` (e.g.
- * `publishEvent`, `runConversationTurn`), which broker process-safe access — so
- * a handler behaves identically in-process and in the route-host subprocess.
+ * etc.) using the standard Web API Request/Response signature. Plugin handlers
+ * receive a bounded route context from `@vellumai/plugin-api`. Its host facade
+ * exposes only operations approved for both execution modes.
  *
  * For backward compatibility, the in-process path still passes a **deprecated**
  * `context` second argument (see `deprecated-route-context.ts`): a thin shim
@@ -35,15 +34,32 @@
  * of time.
  */
 
+import { randomUUID } from "node:crypto";
 import { statSync } from "node:fs";
 
+import {
+  type PluginRouteActorContext,
+  type PluginRouteContext,
+  runInPluginRouteContext,
+} from "../../plugin-api/route-context.js";
+import type { VerifiedPeerOperationContext } from "../../plugin-api/verified-peer-context.js";
+import { runInPluginContext } from "../../plugins/plugin-execution-context.js";
+import { getPluginReadiness } from "../../plugins/plugin-readiness.js";
+import {
+  findPluginRouteDeclaration,
+  type PluginRouteAuthorization,
+  type PluginRouteManifestResult,
+} from "../../plugins/plugin-route-manifest.js";
+import { resolvePluginStorageDir } from "../../plugins/plugin-storage.js";
 import { isRouteHostEnabled } from "../../routes/control.js";
+import type { RouteHostBrokerContext } from "../../routes/route-host-broker.js";
 import {
   RouteHostClient,
   RouteHostTimeoutError,
   RouteHostUnavailableError,
 } from "../../routes/route-host-client.js";
 import { getLogger } from "../../util/logger.js";
+import { enforcePluginRoutePolicy } from "../auth/route-policy.js";
 import { httpError } from "../http-errors.js";
 import {
   buildDeprecatedRouteContext,
@@ -100,6 +116,18 @@ interface CachedModule {
   mtimeMs: number;
 }
 
+interface PluginRouteExecution {
+  readonly context: PluginRouteContext;
+  readonly brokerContext: RouteHostBrokerContext;
+}
+
+export interface UserRouteDispatchContext {
+  readonly actor: PluginRouteActorContext;
+  readonly requestId?: string;
+  readonly verifiedPeer?: VerifiedPeerOperationContext | null;
+  readonly signal?: AbortSignal;
+}
+
 /** Default per-request timeout for user-defined route handlers (2 minutes). */
 const DEFAULT_HANDLER_TIMEOUT_MS = 120_000;
 
@@ -132,17 +160,17 @@ export class UserRouteDispatcher {
    * @param request   The original HTTP request.
    * @returns A Response from the handler, or an error response (404, 405, 500).
    */
-  async dispatch(routePath: string, request: Request): Promise<Response> {
+  async dispatch(
+    routePath: string,
+    request: Request,
+    dispatchContext?: UserRouteDispatchContext,
+  ): Promise<Response> {
     if (routePath.includes("..")) {
       return httpError("BAD_REQUEST", "Path traversal is not allowed", 400);
     }
 
     const location = resolveRouteLocation(routePath);
-    const filePath = location
-      ? resolveHandlerFile(location.routesDir, location.subPath)
-      : null;
-
-    if (!location || !filePath) {
+    if (!location) {
       return httpError(
         "NOT_FOUND",
         `No route handler found for /x/${routePath}`,
@@ -150,8 +178,91 @@ export class UserRouteDispatcher {
       );
     }
 
+    if (
+      !location.pluginId &&
+      dispatchContext?.actor.principalType === "assistant_peer"
+    ) {
+      return Response.json(
+        {
+          error: {
+            code: "FORBIDDEN",
+            message: "Assistant peers cannot call workspace routes",
+          },
+        },
+        { status: 403 },
+      );
+    }
+
+    if (
+      !location.pluginId &&
+      dispatchContext &&
+      !dispatchContext.actor.scopes.includes("settings.read") &&
+      !dispatchContext.actor.scopes.includes("local.all")
+    ) {
+      return Response.json(
+        {
+          error: {
+            code: "FORBIDDEN",
+            message: "Missing required scope: settings.read",
+          },
+        },
+        { status: 403 },
+      );
+    }
+
+    if (location.pluginId) {
+      const isInstalledPlugin = location.pluginDir !== undefined;
+      const unavailable = this.pluginUnavailableResponse(
+        location.pluginId,
+        location.routeManifest,
+        isInstalledPlugin,
+      );
+      if (unavailable) {
+        return unavailable;
+      }
+
+      const authorization = this.resolveAuthorization(
+        location.pluginId,
+        location.subPath,
+        request.method,
+        location.routeManifest,
+      );
+      if (authorization instanceof Response) {
+        return authorization;
+      }
+
+      const denied = enforcePluginRoutePolicy(
+        `/x/${routePath}`,
+        location.pluginId,
+        authorization,
+        this.resolvePluginRouteActor(dispatchContext),
+        dispatchContext?.verifiedPeer ?? null,
+      );
+      if (denied) {
+        return denied;
+      }
+    }
+
+    const filePath = resolveHandlerFile(location.routesDir, location.subPath);
+    if (!filePath) {
+      return httpError(
+        "NOT_FOUND",
+        `No route handler found for /x/${routePath}`,
+        404,
+      );
+    }
+
+    const pluginRoute = location.pluginId
+      ? this.buildPluginRouteContext(
+          location.pluginId,
+          location.pluginDir,
+          request,
+          dispatchContext,
+        )
+      : undefined;
+
     if (isRouteHostEnabled()) {
-      return this.dispatchViaHost(filePath, routePath, request);
+      return this.dispatchViaHost(filePath, routePath, request, pluginRoute);
     }
 
     const mod = await this.loadModule(filePath, location.routesDir);
@@ -166,7 +277,162 @@ export class UserRouteDispatcher {
       });
     }
 
-    return this.executeHandler(handler, request, routePath);
+    return this.executeHandler(
+      handler,
+      request,
+      routePath,
+      pluginRoute?.context,
+    );
+  }
+
+  private buildPluginRouteContext(
+    pluginId: string,
+    pluginDir: string | undefined,
+    request: Request,
+    dispatchContext: UserRouteDispatchContext | undefined,
+  ): PluginRouteExecution {
+    const actor = this.resolvePluginRouteActor(dispatchContext);
+    const pluginStorageDir = resolvePluginStorageDir(
+      pluginId,
+      pluginDir ?? null,
+    );
+    const context: PluginRouteContext = {
+      pluginId,
+      actor,
+      requestId: dispatchContext?.requestId ?? randomUUID(),
+      signal: dispatchContext?.signal ?? request.signal,
+      verifiedPeer: dispatchContext?.verifiedPeer ?? null,
+      host: {
+        async getPluginStorageDir(): Promise<string> {
+          return pluginStorageDir;
+        },
+      },
+    };
+    return {
+      context,
+      brokerContext: { pluginId, pluginStorageDir },
+    };
+  }
+
+  private resolvePluginRouteActor(
+    dispatchContext: UserRouteDispatchContext | undefined,
+  ): PluginRouteActorContext {
+    return (
+      dispatchContext?.actor ?? {
+        principalType: "local",
+        principalId: null,
+        scopes: ["local.all"],
+      }
+    );
+  }
+
+  private pluginUnavailableResponse(
+    pluginId: string,
+    manifest: PluginRouteManifestResult | undefined,
+    isInstalledPlugin: boolean,
+  ): Response | null {
+    if (manifest?.kind === "invalid") {
+      return this.pluginStatusResponse(
+        pluginId,
+        "failed",
+        "plugin_route_manifest_invalid",
+        manifest.reason,
+      );
+    }
+
+    if (!isInstalledPlugin) {
+      return null;
+    }
+
+    const readiness = getPluginReadiness(pluginId);
+    if (!readiness) {
+      return this.pluginStatusResponse(
+        pluginId,
+        "initializing",
+        "plugin_initializing",
+        "Plugin is initializing",
+      );
+    }
+    if (readiness.status === "ready") {
+      return null;
+    }
+
+    const code =
+      readiness.status === "incompatible"
+        ? "plugin_incompatible"
+        : readiness.status === "failed"
+          ? "plugin_initialization_failed"
+          : "plugin_initializing";
+    return this.pluginStatusResponse(
+      pluginId,
+      readiness.status,
+      code,
+      readiness.message ??
+        (readiness.status === "initializing"
+          ? "Plugin is initializing"
+          : "Plugin is unavailable"),
+    );
+  }
+
+  private pluginStatusResponse(
+    pluginId: string,
+    status: "initializing" | "incompatible" | "failed",
+    code: string,
+    message: string,
+  ): Response {
+    return Response.json(
+      {
+        error: {
+          code,
+          message,
+          details: { pluginId, status },
+        },
+      },
+      { status: 503 },
+    );
+  }
+
+  private resolveAuthorization(
+    pluginId: string,
+    subPath: string,
+    method: string,
+    manifest: PluginRouteManifestResult | undefined,
+  ): PluginRouteAuthorization | Response {
+    if (!manifest || manifest.kind === "legacy") {
+      return { principal: "actor", requiredScopes: ["settings.read"] };
+    }
+    if (manifest.kind === "invalid") {
+      return this.pluginStatusResponse(
+        pluginId,
+        "failed",
+        "plugin_route_manifest_invalid",
+        manifest.reason,
+      );
+    }
+
+    const declaration = findPluginRouteDeclaration(
+      manifest.manifest,
+      subPath,
+      method,
+    );
+    if (declaration) {
+      return declaration.authorization;
+    }
+
+    const allowed = manifest.manifest.routes
+      .filter((route) => route.path === subPath)
+      .map((route) => route.method);
+    if (allowed.length > 0) {
+      return new Response(null, {
+        status: 405,
+        headers: { Allow: allowed.join(", ") },
+      });
+    }
+    return httpError(
+      "NOT_FOUND",
+      `No route handler found for /x/plugins/${pluginId}/${subPath}`,
+      404,
+    );
   }
 
   /**
@@ -180,9 +446,8 @@ export class UserRouteDispatcher {
     filePath: string,
     routePath: string,
     request: Request,
+    pluginRoute: PluginRouteExecution | undefined,
   ): Promise<Response> {
-    const mtimeMs = statSync(filePath).mtimeMs;
-
     const headers: [string, string][] = [];
     request.headers.forEach((value, name) => {
       headers.push([name, value]);
@@ -197,12 +462,23 @@ export class UserRouteDispatcher {
       const result = await this.routeHostClient.invoke(
         {
           filePath,
-          mtimeMs,
           method: request.method,
           url: request.url,
           headers,
+          pluginContext: pluginRoute
+            ? {
+                pluginId: pluginRoute.context.pluginId,
+                actor: pluginRoute.context.actor,
+                requestId: pluginRoute.context.requestId,
+                verifiedPeer: pluginRoute.context.verifiedPeer,
+              }
+            : null,
         },
-        body,
+        {
+          body,
+          signal: pluginRoute?.context.signal ?? request.signal,
+          brokerContext: pluginRoute?.brokerContext,
+        },
       );
       const responseHeaders = new Headers();
       for (const [name, value] of result.headers) {
@@ -303,12 +579,20 @@ export class UserRouteDispatcher {
     handler: RouteHandler,
     request: Request,
     routePath: string,
+    pluginContext: PluginRouteContext | undefined,
   ): Promise<Response> {
     try {
-      const result = await Promise.race([
+      const invoke = () =>
         Promise.resolve(
           handler(request, buildDeprecatedRouteContext(routePath)),
-        ),
+        );
+      const execution = pluginContext
+        ? runInPluginContext(pluginContext.pluginId, () =>
+            runInPluginRouteContext(pluginContext, invoke),
+          )
+        : invoke();
+      const result = await Promise.race([
+        execution,
         new Promise<never>((_, reject) =>
           setTimeout(
             () => reject(new Error("Handler timed out")),

--- a/assistant/src/runtime/routes/user-route-import.ts
+++ b/assistant/src/runtime/routes/user-route-import.ts
@@ -52,18 +52,37 @@ export function sourceRootForHandler(filePath: string): string {
  * including query-string aliases (`file.ts?t=mtime`) the dispatcher uses to
  * cache-bust the entry file.
  */
-export function evictRouteSourceTree(sourceRoot: string): void {
+export function evictRouteSourceTree(
+  sourceRoot: string,
+  preserveFilePath?: string,
+): void {
   const { evictionPaths } = snapshotPluginSource(sourceRoot);
   for (const path of evictionPaths) {
-    evictModule(path);
+    if (path === preserveFilePath) {
+      continue;
+    }
+    if (Object.prototype.hasOwnProperty.call(require.cache, path)) {
+      evictModule(path);
+    }
   }
-  evictRegistryAliases(sourceRoot);
+  evictRegistryAliases(sourceRoot, preserveFilePath);
 }
 
-function evictRegistryAliases(sourceRoot: string): void {
+function evictRegistryAliases(
+  sourceRoot: string,
+  preserveFilePath?: string,
+): void {
   const prefix = sourceRoot.endsWith("/") ? sourceRoot : `${sourceRoot}/`;
   const fileUrlPrefix = pathToFileURL(prefix).href;
   for (const key of Object.keys(require.cache)) {
+    const bareKey = key.split("?")[0] ?? key;
+    if (
+      preserveFilePath &&
+      (bareKey === preserveFilePath ||
+        bareKey === pathToFileURL(preserveFilePath).href)
+    ) {
+      continue;
+    }
     if (!keyBelongsToTree(key, sourceRoot, prefix, fileUrlPrefix)) {
       continue;
     }

--- a/assistant/src/runtime/routes/user-route-import.ts
+++ b/assistant/src/runtime/routes/user-route-import.ts
@@ -14,7 +14,7 @@
  */
 
 import { statSync } from "node:fs";
-import { dirname, sep } from "node:path";
+import { dirname } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { snapshotPluginSource } from "../../plugins/source-fingerprint.js";
@@ -35,54 +35,24 @@ export function routeSourceRoot(routesDir: string): string {
 }
 
 /**
- * Infer the source root from a handler path when the caller has no
- * {@link routeSourceRoot} (the route-host worker only sees `filePath`).
- */
-export function sourceRootForHandler(filePath: string): string {
-  const marker = `${sep}routes${sep}`;
-  const idx = filePath.lastIndexOf(marker);
-  if (idx !== -1) {
-    return filePath.slice(0, idx);
-  }
-  return dirname(filePath);
-}
-
-/**
  * Drop every source module under `sourceRoot` from the runtime registry,
  * including query-string aliases (`file.ts?t=mtime`) the dispatcher uses to
  * cache-bust the entry file.
  */
-export function evictRouteSourceTree(
-  sourceRoot: string,
-  preserveFilePath?: string,
-): void {
+export function evictRouteSourceTree(sourceRoot: string): void {
   const { evictionPaths } = snapshotPluginSource(sourceRoot);
   for (const path of evictionPaths) {
-    if (path === preserveFilePath) {
-      continue;
-    }
     if (Object.prototype.hasOwnProperty.call(require.cache, path)) {
       evictModule(path);
     }
   }
-  evictRegistryAliases(sourceRoot, preserveFilePath);
+  evictRegistryAliases(sourceRoot);
 }
 
-function evictRegistryAliases(
-  sourceRoot: string,
-  preserveFilePath?: string,
-): void {
+function evictRegistryAliases(sourceRoot: string): void {
   const prefix = sourceRoot.endsWith("/") ? sourceRoot : `${sourceRoot}/`;
   const fileUrlPrefix = pathToFileURL(prefix).href;
   for (const key of Object.keys(require.cache)) {
-    const bareKey = key.split("?")[0] ?? key;
-    if (
-      preserveFilePath &&
-      (bareKey === preserveFilePath ||
-        bareKey === pathToFileURL(preserveFilePath).href)
-    ) {
-      continue;
-    }
     if (!keyBelongsToTree(key, sourceRoot, prefix, fileUrlPrefix)) {
       continue;
     }

--- a/assistant/src/runtime/routes/user-route-resolution.ts
+++ b/assistant/src/runtime/routes/user-route-resolution.ts
@@ -29,6 +29,11 @@ import {
   getDefaultPluginRoutesDir,
 } from "../../plugins/defaults/main.js";
 import { isPluginDisabled } from "../../plugins/disabled-state.js";
+import { isPluginReady } from "../../plugins/plugin-readiness.js";
+import {
+  type PluginRouteManifestResult,
+  readPluginRouteManifest,
+} from "../../plugins/plugin-route-manifest.js";
 import {
   getWorkspacePluginsDir,
   getWorkspaceRoutesDir,
@@ -64,6 +69,12 @@ export interface RouteLocation {
   routesDir: string;
   /** Path within `routesDir`, relative and without the `/x/` prefix. */
   subPath: string;
+  /** Host-derived install-directory plugin ID for plugin routes. */
+  pluginId?: string;
+  /** Absolute installed plugin directory. Omitted for workspace/default routes. */
+  pluginDir?: string;
+  /** Static policy manifest for installed plugin routes. */
+  routeManifest?: PluginRouteManifestResult;
 }
 
 /**
@@ -97,9 +108,15 @@ export function resolveRouteLocation(routePath: string): RouteLocation | null {
     if (isPluginDisabled(pluginName)) {
       return null;
     }
+    const pluginRoot = resolvePluginRoutesDir(pluginName);
     return {
-      routesDir: resolvePluginRoutesDir(pluginName),
+      routesDir: pluginRoot.routesDir,
       subPath: segments.slice(2).join("/"),
+      pluginId: pluginName,
+      pluginDir: pluginRoot.pluginDir,
+      routeManifest: pluginRoot.pluginDir
+        ? readPluginRouteManifest(pluginRoot.pluginDir)
+        : { kind: "legacy" },
     };
   }
   return { routesDir: getWorkspaceRoutesDir(), subPath: routePath };
@@ -113,20 +130,23 @@ export function resolveRouteLocation(routePath: string): RouteLocation | null {
  * Falls back to the (missing) workspace path when the name matches neither, so
  * {@link resolveHandlerFile} reports a 404.
  */
-function resolvePluginRoutesDir(pluginName: string): string {
-  const workspaceRoutesDir = join(
-    getWorkspacePluginsDir(),
-    pluginName,
-    "routes",
-  );
-  if (existsSync(workspaceRoutesDir)) {
-    return workspaceRoutesDir;
+function resolvePluginRoutesDir(pluginName: string): {
+  routesDir: string;
+  pluginDir?: string;
+} {
+  const pluginDir = join(getWorkspacePluginsDir(), pluginName);
+  const workspaceRoutesDir = join(pluginDir, "routes");
+  const isInstalled = existsSync(join(pluginDir, "package.json"));
+  if (isInstalled && existsSync(workspaceRoutesDir)) {
+    return { routesDir: workspaceRoutesDir, pluginDir };
   }
   const defaultRoutesDir = getDefaultPluginRoutesDir(pluginName);
   if (defaultRoutesDir && existsSync(defaultRoutesDir)) {
-    return defaultRoutesDir;
+    return { routesDir: defaultRoutesDir };
   }
-  return workspaceRoutesDir;
+  return isInstalled
+    ? { routesDir: workspaceRoutesDir, pluginDir }
+    : { routesDir: workspaceRoutesDir };
 }
 
 /**
@@ -208,7 +228,12 @@ export function listPluginRouteRoots(): {
         continue;
       }
       const routesDir = join(pluginsDir, entry.name, "routes");
-      if (existsSync(routesDir) && statSync(routesDir).isDirectory()) {
+      const pluginDir = join(pluginsDir, entry.name);
+      if (
+        existsSync(routesDir) &&
+        statSync(routesDir).isDirectory() &&
+        isPluginRouteRootDiscoverable(entry.name, pluginDir)
+      ) {
         byName.set(entry.name, routesDir);
       }
     }
@@ -218,4 +243,15 @@ export function listPluginRouteRoots(): {
     pluginName,
     routesDir,
   }));
+}
+
+function isPluginRouteRootDiscoverable(
+  pluginId: string,
+  pluginDir: string,
+): boolean {
+  const manifest = readPluginRouteManifest(pluginDir);
+  if (manifest.kind === "invalid") {
+    return false;
+  }
+  return isPluginReady(pluginId);
 }

--- a/assistant/src/runtime/routes/user-route-resolution.ts
+++ b/assistant/src/runtime/routes/user-route-resolution.ts
@@ -109,6 +109,9 @@ export function resolveRouteLocation(routePath: string): RouteLocation | null {
       return null;
     }
     const pluginRoot = resolvePluginRoutesDir(pluginName);
+    if (pluginRoot === null) {
+      return null;
+    }
     return {
       routesDir: pluginRoot.routesDir,
       subPath: segments.slice(2).join("/"),
@@ -133,7 +136,7 @@ export function resolveRouteLocation(routePath: string): RouteLocation | null {
 function resolvePluginRoutesDir(pluginName: string): {
   routesDir: string;
   pluginDir?: string;
-} {
+} | null {
   const pluginDir = join(getWorkspacePluginsDir(), pluginName);
   const workspaceRoutesDir = join(pluginDir, "routes");
   const isInstalled = existsSync(join(pluginDir, "package.json"));
@@ -144,9 +147,7 @@ function resolvePluginRoutesDir(pluginName: string): {
   if (defaultRoutesDir && existsSync(defaultRoutesDir)) {
     return { routesDir: defaultRoutesDir };
   }
-  return isInstalled
-    ? { routesDir: workspaceRoutesDir, pluginDir }
-    : { routesDir: workspaceRoutesDir };
+  return isInstalled ? { routesDir: workspaceRoutesDir, pluginDir } : null;
 }
 
 /**
@@ -230,6 +231,7 @@ export function listPluginRouteRoots(): {
       const routesDir = join(pluginsDir, entry.name, "routes");
       const pluginDir = join(pluginsDir, entry.name);
       if (
+        existsSync(join(pluginDir, "package.json")) &&
         existsSync(routesDir) &&
         statSync(routesDir).isDirectory() &&
         isPluginRouteRootDiscoverable(entry.name, pluginDir)

--- a/assistant/src/runtime/routes/user-route-resolution.ts
+++ b/assistant/src/runtime/routes/user-route-resolution.ts
@@ -29,7 +29,7 @@ import {
   getDefaultPluginRoutesDir,
 } from "../../plugins/defaults/main.js";
 import { isPluginDisabled } from "../../plugins/disabled-state.js";
-import { isPluginReady } from "../../plugins/plugin-readiness.js";
+import { isPluginSurfaceReady } from "../../plugins/plugin-readiness.js";
 import {
   type PluginRouteManifestResult,
   readPluginRouteManifest,
@@ -253,5 +253,5 @@ function isPluginRouteRootDiscoverable(
   if (manifest.kind === "invalid") {
     return false;
   }
-  return isPluginReady(pluginId);
+  return isPluginSurfaceReady(pluginId, pluginDir);
 }

--- a/assistant/src/runtime/routes/user-routes.ts
+++ b/assistant/src/runtime/routes/user-routes.ts
@@ -15,10 +15,15 @@
  * over both HTTP and IPC.
  */
 
-import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import { PLUGIN_ROUTE_PRINCIPALS } from "../auth/route-policy.js";
+import { resolveScopeProfile } from "../auth/scopes.js";
+import type { ScopeProfile } from "../auth/types.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 import { RouteResponse } from "./types.js";
-import { UserRouteDispatcher } from "./user-route-dispatcher.js";
+import {
+  type UserRouteDispatchContext,
+  UserRouteDispatcher,
+} from "./user-route-dispatcher.js";
 
 const dispatcher = new UserRouteDispatcher();
 
@@ -84,6 +89,45 @@ function decomposeResponse(response: Response): RouteResponse {
   return new RouteResponse(response.body, headers, response.status);
 }
 
+function buildDispatchContext(
+  args: RouteHandlerArgs,
+): UserRouteDispatchContext {
+  const authContext = args.authContext;
+  if (authContext) {
+    return {
+      actor: {
+        principalType: authContext.principalType,
+        principalId: authContext.actorPrincipalId ?? null,
+        scopes: [...authContext.scopes],
+      },
+      verifiedPeer: authContext.verifiedPeerContext ?? null,
+      signal: args.abortSignal,
+    };
+  }
+
+  const principalType =
+    args.headers?.["x-vellum-principal-type"] === "local"
+      ? "local"
+      : "svc_gateway";
+  const forwardedProfile = args.headers?.["x-vellum-scope-profile"] as
+    | ScopeProfile
+    | undefined;
+  return {
+    actor: {
+      principalType,
+      principalId: args.headers?.["x-vellum-actor-principal-id"] ?? null,
+      scopes:
+        principalType === "local"
+          ? ["local.all"]
+          : forwardedProfile
+            ? [...resolveScopeProfile(forwardedProfile)]
+            : [],
+    },
+    verifiedPeer: null,
+    signal: args.abortSignal,
+  };
+}
+
 /**
  * HTTP methods supported by user-defined route handlers.
  *
@@ -109,14 +153,15 @@ export const ROUTES: RouteDefinition[] = METHODS.map((method) => ({
   description: `Dispatches ${method} requests to user-defined handler files in the workspace routes directory.`,
   tags: ["user-routes"],
   policy: {
-    requiredScopes: ["settings.read"],
-    allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    requiredScopes: [],
+    allowedPrincipalTypes: PLUGIN_ROUTE_PRINCIPALS,
   },
   handler: async (args: RouteHandlerArgs) => {
     const request = synthesizeRequest(method, args);
     const response = await dispatcher.dispatch(
       args.pathParams?.path ?? "",
       request,
+      buildDispatchContext(args),
     );
     return decomposeResponse(response);
   },

--- a/assistant/src/schedule/__tests__/plugin-schedule-reconciler.test.ts
+++ b/assistant/src/schedule/__tests__/plugin-schedule-reconciler.test.ts
@@ -84,13 +84,32 @@ function rawJob(id: string): Record<string, unknown> {
  * Write a plugin fixture: a `package.json` plus the given files under
  * `schedules/` (paths relative to the schedules dir).
  */
-function writePlugin(name: string, files: Record<string, string>): string {
+function writePlugin(
+  name: string,
+  files: Record<string, string>,
+  opts: { optsIntoReadiness?: boolean } = {},
+): string {
   const dir = join(pluginsDir, name);
   mkdirSync(dir, { recursive: true });
   writeFileSync(
     join(dir, "package.json"),
-    JSON.stringify({ name, version: "1.0.0" }),
+    JSON.stringify({
+      name,
+      version: "1.0.0",
+      ...(opts.optsIntoReadiness
+        ? { peerDependencies: { "@vellumai/plugin-api": "*" } }
+        : {}),
+    }),
   );
+  if (opts.optsIntoReadiness) {
+    writeFileSync(
+      join(dir, "host-requirements.json"),
+      JSON.stringify({
+        schemaVersion: 1,
+        requires: { "plugins.readiness": "^1.0.0" },
+      }),
+    );
+  }
   markPluginReady(name, "d".repeat(64));
   for (const [rel, content] of Object.entries(files)) {
     const abs = join(dir, "schedules", rel);
@@ -405,7 +424,7 @@ describe("reconcilePluginSchedules", () => {
   });
 
   test("a plugin that is not ready contributes no armed schedules", async () => {
-    writePlugin("news", digest());
+    writePlugin("news", digest(), { optsIntoReadiness: true });
     await reconcilePluginSchedules();
     const created = listDeclaredSchedules()[0]!;
     expect(created.enabled).toBe(true);

--- a/assistant/src/schedule/__tests__/plugin-schedule-reconciler.test.ts
+++ b/assistant/src/schedule/__tests__/plugin-schedule-reconciler.test.ts
@@ -48,6 +48,10 @@ mock.module("../../notifications/emit-signal.js", () => ({
 import { setOverridesForTesting } from "../../__tests__/feature-flag-test-helpers.js";
 import { getDb } from "../../persistence/db-connection.js";
 import { initializeDb } from "../../persistence/db-init.js";
+import {
+  markPluginReady,
+  resetPluginReadinessForTests,
+} from "../../plugins/plugin-readiness.js";
 import { getWorkspacePluginsDir } from "../../util/platform.js";
 import {
   reconcilePluginSchedules,
@@ -87,6 +91,7 @@ function writePlugin(name: string, files: Record<string, string>): string {
     join(dir, "package.json"),
     JSON.stringify({ name, version: "1.0.0" }),
   );
+  markPluginReady(name, "d".repeat(64));
   for (const [rel, content] of Object.entries(files)) {
     const abs = join(dir, "schedules", rel);
     mkdirSync(dirname(abs), { recursive: true });
@@ -175,6 +180,7 @@ function resetReconcilerFixtures(): void {
   emittedSignals.length = 0;
   emitResultOverride = null;
   emitGate = null;
+  resetPluginReadinessForTests();
   resetDefinitionErrorEmitGuardForTests();
 }
 
@@ -396,6 +402,20 @@ describe("reconcilePluginSchedules", () => {
     expect(restored.id).toBe(created.id);
     expect(restored.enabled).toBe(true);
     expect(restored.userEnabled).toBeNull();
+  });
+
+  test("a plugin that is not ready contributes no armed schedules", async () => {
+    writePlugin("news", digest());
+    await reconcilePluginSchedules();
+    const created = listDeclaredSchedules()[0]!;
+    expect(created.enabled).toBe(true);
+
+    resetPluginReadinessForTests();
+    await reconcilePluginSchedules();
+
+    const disarmed = listDeclaredSchedules()[0]!;
+    expect(disarmed.id).toBe(created.id);
+    expect(disarmed.enabled).toBe(false);
   });
 
   test("a parse error keeps the last-good execute row running and emits a deduped notification", async () => {

--- a/assistant/src/schedule/plugin-schedule-reconciler.ts
+++ b/assistant/src/schedule/plugin-schedule-reconciler.ts
@@ -33,6 +33,7 @@ import type { AttentionHints } from "../notifications/signal.js";
 import { isPluginDisabled } from "../plugins/disabled-state.js";
 import { parsePluginManifest } from "../plugins/external-plugin-loader.js";
 import { listInstalledPluginDirs } from "../plugins/installed-plugin-dirs.js";
+import { isPluginReady } from "../plugins/plugin-readiness.js";
 import { getLogger } from "../util/logger.js";
 import {
   type DeclarationError,
@@ -264,7 +265,7 @@ function isCompletedRecurrence(
  * as the plugin source collector) and gather their schedule declarations.
  * Identity = the directory basename, mirroring `parsePluginManifest`.
  *
- * Disabled plugins and plugins without a `schedules/` directory are skipped
+ * Disabled, unready, and schedule-free plugins are skipped
  * entirely; in particular, only schedule-declaring plugins pay the manifest
  * parse each pass. A schedule-declaring plugin whose manifest fails
  * `parsePluginManifest` (unreadable or schema-invalid `package.json`) also
@@ -279,7 +280,7 @@ async function collectDesiredDeclarations(): Promise<CollectedDeclarations> {
   const manifestFailures: DeclarationError[] = [];
 
   for (const { name, dir } of listInstalledPluginDirs()) {
-    if (isPluginDisabled(name)) {
+    if (isPluginDisabled(name) || !isPluginReady(name)) {
       continue;
     }
     if (!existsSync(join(dir, "schedules"))) {

--- a/assistant/src/schedule/plugin-schedule-reconciler.ts
+++ b/assistant/src/schedule/plugin-schedule-reconciler.ts
@@ -33,7 +33,7 @@ import type { AttentionHints } from "../notifications/signal.js";
 import { isPluginDisabled } from "../plugins/disabled-state.js";
 import { parsePluginManifest } from "../plugins/external-plugin-loader.js";
 import { listInstalledPluginDirs } from "../plugins/installed-plugin-dirs.js";
-import { isPluginReady } from "../plugins/plugin-readiness.js";
+import { isPluginSurfaceReady } from "../plugins/plugin-readiness.js";
 import { getLogger } from "../util/logger.js";
 import {
   type DeclarationError,
@@ -280,7 +280,7 @@ async function collectDesiredDeclarations(): Promise<CollectedDeclarations> {
   const manifestFailures: DeclarationError[] = [];
 
   for (const { name, dir } of listInstalledPluginDirs()) {
-    if (isPluginDisabled(name) || !isPluginReady(name)) {
+    if (isPluginDisabled(name) || !isPluginSurfaceReady(name, dir)) {
       continue;
     }
     if (!existsSync(join(dir, "schedules"))) {

--- a/gateway/src/channels/plugin-ingress-approvals.test.ts
+++ b/gateway/src/channels/plugin-ingress-approvals.test.ts
@@ -239,7 +239,7 @@ describe("ingressDeclarationDigest", () => {
 });
 
 describe("resolvePluginIngress", () => {
-  it("holds an unapproved declaration as pending, never approved", () => {
+  it("keeps a legacy unapproved declaration pending", () => {
     const workspaceDir = makeWorkspace();
     writePlugin(workspaceDir, "meeting-bot");
 

--- a/gateway/src/channels/plugin-ingress.test.ts
+++ b/gateway/src/channels/plugin-ingress.test.ts
@@ -1,6 +1,10 @@
+import { createHash } from "node:crypto";
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
+  renameSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -8,7 +12,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
 
 import {
   PLUGIN_INGRESS_MANIFEST_RELPATH,
@@ -35,6 +39,91 @@ function makeWorkspace(): string {
   return dir;
 }
 
+function writeAtomically(path: string, contents: string): void {
+  const temporaryPath = `${path}.tmp`;
+  writeFileSync(temporaryPath, contents);
+  renameSync(temporaryPath, path);
+}
+
+function setReadiness(
+  workspaceDir: string,
+  plugin: string,
+  status: "initializing" | "ready" | "incompatible" | "failed" = "ready",
+): void {
+  const rawSourceFingerprint = `source:${plugin}`;
+  const sourceFingerprint = createHash("sha256")
+    .update(rawSourceFingerprint)
+    .digest("hex");
+  const path = join(workspaceDir, "data", "plugin-readiness-v1.json");
+  let plugins: Record<string, unknown> = {};
+  if (existsSync(path)) {
+    plugins = JSON.parse(readFileSync(path, "utf8")).plugins;
+  }
+  mkdirSync(join(workspaceDir, "data"), { recursive: true });
+  writeAtomically(
+    path,
+    JSON.stringify({
+      schemaVersion: 1,
+      generation: "11111111-1111-4111-8111-111111111111",
+      plugins: {
+        ...plugins,
+        [plugin]: {
+          pluginId: plugin,
+          sourceFingerprint,
+          status,
+          updatedAt: new Date().toISOString(),
+        },
+      },
+    }),
+  );
+  const sourceVersionsPath = join(
+    workspaceDir,
+    "data",
+    "monitoring",
+    "plugin-source-versions.json",
+  );
+  let versions: Record<string, unknown> = {};
+  if (existsSync(sourceVersionsPath)) {
+    try {
+      versions = JSON.parse(readFileSync(sourceVersionsPath, "utf8")).plugins;
+    } catch {
+      versions = {};
+    }
+  }
+  mkdirSync(join(workspaceDir, "data", "monitoring"), { recursive: true });
+  writeAtomically(
+    sourceVersionsPath,
+    JSON.stringify({
+      format: 2,
+      generation: 1,
+      writtenAt: new Date().toISOString(),
+      plugins: {
+        ...versions,
+        [join(workspaceDir, "plugins", plugin)]: {
+          fingerprint: rawSourceFingerprint,
+          sourceFingerprint,
+          evictionPaths: [],
+          disabled: false,
+        },
+      },
+    }),
+  );
+}
+
+function writeStaleSourceVersion(workspaceDir: string, plugin: string): void {
+  const path = join(
+    workspaceDir,
+    "data",
+    "monitoring",
+    "plugin-source-versions.json",
+  );
+  const document = JSON.parse(readFileSync(path, "utf8"));
+  document.generation += 1;
+  document.plugins[join(workspaceDir, "plugins", plugin)].sourceFingerprint =
+    "b".repeat(64);
+  writeAtomically(path, JSON.stringify(document));
+}
+
 /** Write a plugin's ingress manifest (raw string, so invalid JSON is testable). */
 function writeManifest(
   workspaceDir: string,
@@ -48,6 +137,7 @@ function writeManifest(
     JSON.stringify({ name: plugin }),
   );
   writeFileSync(join(pluginDir, PLUGIN_INGRESS_MANIFEST_RELPATH), contents);
+  setReadiness(workspaceDir, plugin);
   return pluginDir;
 }
 
@@ -499,6 +589,76 @@ describe("discoverPluginIngress", () => {
     expect(discoverPluginIngress({ workspaceDir }).plugins).toEqual([]);
   });
 
+  it("fails closed until the assistant marks the plugin ready", () => {
+    const workspaceDir = makeWorkspace();
+    writeManifest(workspaceDir, "meeting-bot", VALID);
+    setReadiness(workspaceDir, "meeting-bot", "initializing");
+
+    expect(discoverPluginIngress({ workspaceDir }).plugins).toEqual([]);
+
+    setReadiness(workspaceDir, "meeting-bot", "ready");
+    expect(
+      discoverPluginIngress({ workspaceDir }).plugins.map((p) => p.plugin),
+    ).toEqual(["meeting-bot"]);
+  });
+
+  it("fails closed before scanning when readiness is missing or invalid", async () => {
+    const workspaceDir = makeWorkspace();
+    writeManifest(workspaceDir, "meeting-bot", VALID);
+    const readinessPath = join(
+      workspaceDir,
+      "data",
+      "plugin-readiness-v1.json",
+    );
+    const fs = await import("node:fs");
+    const readdirSpy = spyOn(fs, "readdirSync");
+
+    try {
+      rmSync(readinessPath);
+      expect(discoverPluginIngress({ workspaceDir }).plugins).toEqual([]);
+      expect(readdirSpy).not.toHaveBeenCalled();
+
+      writeFileSync(readinessPath, "{ not json");
+      expect(discoverPluginIngress({ workspaceDir }).plugins).toEqual([]);
+      expect(readdirSpy).not.toHaveBeenCalled();
+    } finally {
+      readdirSpy.mockRestore();
+    }
+  });
+
+  it("fails closed before scanning when source versions are missing or invalid", async () => {
+    const workspaceDir = makeWorkspace();
+    writeManifest(workspaceDir, "meeting-bot", VALID);
+    const sourceVersionsPath = join(
+      workspaceDir,
+      "data",
+      "monitoring",
+      "plugin-source-versions.json",
+    );
+    const fs = await import("node:fs");
+    const readdirSpy = spyOn(fs, "readdirSync");
+
+    try {
+      rmSync(sourceVersionsPath);
+      expect(discoverPluginIngress({ workspaceDir }).plugins).toEqual([]);
+      expect(readdirSpy).not.toHaveBeenCalled();
+
+      writeFileSync(sourceVersionsPath, "{ not json");
+      expect(discoverPluginIngress({ workspaceDir }).plugins).toEqual([]);
+      expect(readdirSpy).not.toHaveBeenCalled();
+    } finally {
+      readdirSpy.mockRestore();
+    }
+  });
+
+  it("fails closed when source versions are stale", () => {
+    const workspaceDir = makeWorkspace();
+    writeManifest(workspaceDir, "meeting-bot", VALID);
+
+    writeStaleSourceVersion(workspaceDir, "meeting-bot");
+    expect(discoverPluginIngress({ workspaceDir }).plugins).toEqual([]);
+  });
+
   it("discovers a plugin installed as a symlinked root", () => {
     // Plugins may be installed by symlinking a checkout into place, where
     // Dirent.isDirectory() is false but the target is a directory.
@@ -514,6 +674,7 @@ describe("discoverPluginIngress", () => {
 
     mkdirSync(join(workspaceDir, "plugins"), { recursive: true });
     symlinkSync(target, join(workspaceDir, "plugins", "meeting-bot"));
+    setReadiness(workspaceDir, "meeting-bot");
 
     const { plugins, problems } = discoverPluginIngress({ workspaceDir });
     expect(problems).toEqual([]);
@@ -582,29 +743,83 @@ describe("discoverPluginIngress", () => {
 });
 
 describe("PluginIngressCache", () => {
-  it("serves a cached snapshot within the TTL and re-scans after it", () => {
+  it("does not reread unchanged files within the TTL", async () => {
     const workspaceDir = makeWorkspace();
-    const cache = new PluginIngressCache({ workspaceDir, ttlMs: 10_000 });
-    expect(cache.get().plugins).toEqual([]);
-
     writeManifest(workspaceDir, "meeting-bot", VALID);
-    // Still inside the TTL — the new plugin is not visible yet.
-    expect(cache.get().plugins).toEqual([]);
+    const cache = new PluginIngressCache({ workspaceDir, ttlMs: 10_000 });
+    const fs = await import("node:fs");
+    const readSpy = spyOn(fs, "readFileSync");
 
-    // Invalidating stands in for the TTL elapsing, so the test does not
-    // have to sleep.
-    cache.invalidate();
+    try {
+      expect(cache.get().plugins.map((p) => p.plugin)).toEqual(["meeting-bot"]);
+      readSpy.mockClear();
+
+      expect(cache.get().plugins.map((p) => p.plugin)).toEqual(["meeting-bot"]);
+      expect(readSpy).not.toHaveBeenCalled();
+    } finally {
+      readSpy.mockRestore();
+    }
+  });
+
+  it("rereads files after the TTL expires", async () => {
+    const workspaceDir = makeWorkspace();
+    writeManifest(workspaceDir, "meeting-bot", VALID);
+    const cache = new PluginIngressCache({ workspaceDir, ttlMs: 0 });
+    const fs = await import("node:fs");
+    const readSpy = spyOn(fs, "readFileSync");
+
+    try {
+      cache.get();
+      readSpy.mockClear();
+
+      cache.get();
+      expect(readSpy).toHaveBeenCalled();
+    } finally {
+      readSpy.mockRestore();
+    }
+  });
+
+  it("serves a cached snapshot until invalidated", () => {
+    const workspaceDir = makeWorkspace();
+    const pluginDir = writeManifest(workspaceDir, "meeting-bot", VALID);
+    const cache = new PluginIngressCache({ workspaceDir, ttlMs: 10_000 });
     expect(cache.get().plugins.map((p) => p.plugin)).toEqual(["meeting-bot"]);
+
+    rmSync(pluginDir, { recursive: true, force: true });
+    expect(cache.get().plugins.map((p) => p.plugin)).toEqual(["meeting-bot"]);
+
+    cache.invalidate();
+    expect(cache.get().plugins).toEqual([]);
   });
 
   it("force re-scans regardless of the TTL", () => {
     const workspaceDir = makeWorkspace();
+    const pluginDir = writeManifest(workspaceDir, "meeting-bot", VALID);
+    const cache = new PluginIngressCache({ workspaceDir, ttlMs: 10_000 });
+    expect(cache.get().plugins.map((p) => p.plugin)).toEqual(["meeting-bot"]);
+
+    rmSync(pluginDir, { recursive: true, force: true });
+    expect(cache.get({ force: true }).plugins).toEqual([]);
+  });
+
+  it("refreshes immediately after an atomic readiness rewrite", () => {
+    const workspaceDir = makeWorkspace();
+    writeManifest(workspaceDir, "meeting-bot", VALID);
+    setReadiness(workspaceDir, "meeting-bot", "initializing");
     const cache = new PluginIngressCache({ workspaceDir, ttlMs: 10_000 });
     expect(cache.get().plugins).toEqual([]);
 
+    setReadiness(workspaceDir, "meeting-bot", "ready");
+    expect(cache.get().plugins.map((p) => p.plugin)).toEqual(["meeting-bot"]);
+  });
+
+  it("refreshes immediately after an atomic source-version rewrite", () => {
+    const workspaceDir = makeWorkspace();
     writeManifest(workspaceDir, "meeting-bot", VALID);
-    expect(cache.get({ force: true }).plugins.map((p) => p.plugin)).toEqual([
-      "meeting-bot",
-    ]);
+    const cache = new PluginIngressCache({ workspaceDir, ttlMs: 10_000 });
+    expect(cache.get().plugins.map((p) => p.plugin)).toEqual(["meeting-bot"]);
+
+    writeStaleSourceVersion(workspaceDir, "meeting-bot");
+    expect(cache.get().plugins).toEqual([]);
   });
 });

--- a/gateway/src/channels/plugin-ingress.test.ts
+++ b/gateway/src/channels/plugin-ingress.test.ts
@@ -12,6 +12,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { PLUGIN_HOST_REQUIREMENTS_FILENAME } from "@vellumai/service-contracts/plugin-readiness";
 import { afterEach, describe, expect, it, spyOn } from "bun:test";
 
 import {
@@ -137,8 +138,23 @@ function writeManifest(
     JSON.stringify({ name: plugin }),
   );
   writeFileSync(join(pluginDir, PLUGIN_INGRESS_MANIFEST_RELPATH), contents);
-  setReadiness(workspaceDir, plugin);
   return pluginDir;
+}
+
+function writeHostRequirements(workspaceDir: string, plugin: string): void {
+  writeFileSync(
+    join(workspaceDir, "plugins", plugin, PLUGIN_HOST_REQUIREMENTS_FILENAME),
+    JSON.stringify({ schemaVersion: 1, requires: {} }),
+  );
+}
+
+function optIntoReadiness(
+  workspaceDir: string,
+  plugin: string,
+  status: "initializing" | "ready" | "incompatible" | "failed" = "ready",
+): void {
+  writeHostRequirements(workspaceDir, plugin);
+  setReadiness(workspaceDir, plugin, status);
 }
 
 const VALID = JSON.stringify({
@@ -560,7 +576,7 @@ describe("discoverPluginIngress", () => {
     });
   });
 
-  it("discovers a declaring plugin and composes its paths", () => {
+  it("keeps a legacy declaration visible without activation snapshots", () => {
     const workspaceDir = makeWorkspace();
     writeManifest(workspaceDir, "meeting-bot", VALID);
 
@@ -592,7 +608,7 @@ describe("discoverPluginIngress", () => {
   it("fails closed until the assistant marks the plugin ready", () => {
     const workspaceDir = makeWorkspace();
     writeManifest(workspaceDir, "meeting-bot", VALID);
-    setReadiness(workspaceDir, "meeting-bot", "initializing");
+    optIntoReadiness(workspaceDir, "meeting-bot", "initializing");
 
     expect(discoverPluginIngress({ workspaceDir }).plugins).toEqual([]);
 
@@ -602,58 +618,43 @@ describe("discoverPluginIngress", () => {
     ).toEqual(["meeting-bot"]);
   });
 
-  it("fails closed before scanning when readiness is missing or invalid", async () => {
+  it("fails closed for opted-in plugins when readiness is missing or invalid", () => {
     const workspaceDir = makeWorkspace();
     writeManifest(workspaceDir, "meeting-bot", VALID);
+    writeHostRequirements(workspaceDir, "meeting-bot");
     const readinessPath = join(
       workspaceDir,
       "data",
       "plugin-readiness-v1.json",
     );
-    const fs = await import("node:fs");
-    const readdirSpy = spyOn(fs, "readdirSync");
+    expect(discoverPluginIngress({ workspaceDir }).plugins).toEqual([]);
 
-    try {
-      rmSync(readinessPath);
-      expect(discoverPluginIngress({ workspaceDir }).plugins).toEqual([]);
-      expect(readdirSpy).not.toHaveBeenCalled();
-
-      writeFileSync(readinessPath, "{ not json");
-      expect(discoverPluginIngress({ workspaceDir }).plugins).toEqual([]);
-      expect(readdirSpy).not.toHaveBeenCalled();
-    } finally {
-      readdirSpy.mockRestore();
-    }
+    mkdirSync(join(workspaceDir, "data"), { recursive: true });
+    writeFileSync(readinessPath, "{ not json");
+    expect(discoverPluginIngress({ workspaceDir }).plugins).toEqual([]);
   });
 
-  it("fails closed before scanning when source versions are missing or invalid", async () => {
+  it("fails closed for opted-in plugins when source versions are missing or invalid", () => {
     const workspaceDir = makeWorkspace();
     writeManifest(workspaceDir, "meeting-bot", VALID);
+    writeHostRequirements(workspaceDir, "meeting-bot");
     const sourceVersionsPath = join(
       workspaceDir,
       "data",
       "monitoring",
       "plugin-source-versions.json",
     );
-    const fs = await import("node:fs");
-    const readdirSpy = spyOn(fs, "readdirSync");
+    expect(discoverPluginIngress({ workspaceDir }).plugins).toEqual([]);
 
-    try {
-      rmSync(sourceVersionsPath);
-      expect(discoverPluginIngress({ workspaceDir }).plugins).toEqual([]);
-      expect(readdirSpy).not.toHaveBeenCalled();
-
-      writeFileSync(sourceVersionsPath, "{ not json");
-      expect(discoverPluginIngress({ workspaceDir }).plugins).toEqual([]);
-      expect(readdirSpy).not.toHaveBeenCalled();
-    } finally {
-      readdirSpy.mockRestore();
-    }
+    mkdirSync(join(workspaceDir, "data", "monitoring"), { recursive: true });
+    writeFileSync(sourceVersionsPath, "{ not json");
+    expect(discoverPluginIngress({ workspaceDir }).plugins).toEqual([]);
   });
 
   it("fails closed when source versions are stale", () => {
     const workspaceDir = makeWorkspace();
     writeManifest(workspaceDir, "meeting-bot", VALID);
+    optIntoReadiness(workspaceDir, "meeting-bot");
 
     writeStaleSourceVersion(workspaceDir, "meeting-bot");
     expect(discoverPluginIngress({ workspaceDir }).plugins).toEqual([]);
@@ -674,8 +675,6 @@ describe("discoverPluginIngress", () => {
 
     mkdirSync(join(workspaceDir, "plugins"), { recursive: true });
     symlinkSync(target, join(workspaceDir, "plugins", "meeting-bot"));
-    setReadiness(workspaceDir, "meeting-bot");
-
     const { plugins, problems } = discoverPluginIngress({ workspaceDir });
     expect(problems).toEqual([]);
     expect(plugins.map((p) => p.plugin)).toEqual(["meeting-bot"]);
@@ -805,7 +804,7 @@ describe("PluginIngressCache", () => {
   it("refreshes immediately after an atomic readiness rewrite", () => {
     const workspaceDir = makeWorkspace();
     writeManifest(workspaceDir, "meeting-bot", VALID);
-    setReadiness(workspaceDir, "meeting-bot", "initializing");
+    optIntoReadiness(workspaceDir, "meeting-bot", "initializing");
     const cache = new PluginIngressCache({ workspaceDir, ttlMs: 10_000 });
     expect(cache.get().plugins).toEqual([]);
 
@@ -816,6 +815,7 @@ describe("PluginIngressCache", () => {
   it("refreshes immediately after an atomic source-version rewrite", () => {
     const workspaceDir = makeWorkspace();
     writeManifest(workspaceDir, "meeting-bot", VALID);
+    optIntoReadiness(workspaceDir, "meeting-bot");
     const cache = new PluginIngressCache({ workspaceDir, ttlMs: 10_000 });
     expect(cache.get().plugins.map((p) => p.plugin)).toEqual(["meeting-bot"]);
 

--- a/gateway/src/channels/plugin-ingress.ts
+++ b/gateway/src/channels/plugin-ingress.ts
@@ -3,6 +3,14 @@
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join, posix } from "node:path";
 
+import {
+  PLUGIN_READINESS_FILENAME,
+  PLUGIN_SOURCE_VERSIONS_FILENAME,
+  PluginReadinessSnapshotSchema,
+  PluginSourceVersionsSnapshotSchema,
+  type PluginReadinessSnapshot,
+  type PluginSourceVersionsSnapshot,
+} from "@vellumai/service-contracts/plugin-readiness";
 import { z } from "zod";
 
 import { getLogger } from "../logger.js";
@@ -293,15 +301,96 @@ export interface DiscoverPluginIngressOptions {
   workspaceDir?: string;
 }
 
+interface PluginActivationPaths {
+  readiness: string;
+  sourceVersions: string;
+}
+
+interface PluginActivationSignatures {
+  readiness: string | null;
+  sourceVersions: string | null;
+}
+
+function getPluginActivationPaths(workspaceDir: string): PluginActivationPaths {
+  return {
+    readiness: join(workspaceDir, "data", PLUGIN_READINESS_FILENAME),
+    sourceVersions: join(
+      workspaceDir,
+      "data",
+      "monitoring",
+      PLUGIN_SOURCE_VERSIONS_FILENAME,
+    ),
+  };
+}
+
+function getFileSignature(path: string): string | null {
+  try {
+    const stats = statSync(path);
+    return `${stats.dev}:${stats.ino}:${stats.size}:${stats.mtimeMs}`;
+  } catch {
+    return null;
+  }
+}
+
+function getPluginActivationSignatures(
+  paths: PluginActivationPaths,
+): PluginActivationSignatures {
+  return {
+    readiness: getFileSignature(paths.readiness),
+    sourceVersions: getFileSignature(paths.sourceVersions),
+  };
+}
+
+function signaturesMatch(
+  left: PluginActivationSignatures | undefined,
+  right: PluginActivationSignatures,
+): boolean {
+  return (
+    left?.readiness === right.readiness &&
+    left.sourceVersions === right.sourceVersions
+  );
+}
+
+function readJsonSnapshot<T>(
+  path: string,
+  schema: z.ZodType<T>,
+): T | undefined {
+  try {
+    return schema.parse(JSON.parse(readFileSync(path, "utf8")));
+  } catch {
+    return undefined;
+  }
+}
+
+function readPluginActivationSnapshots(
+  paths: PluginActivationPaths,
+  signatures?: PluginActivationSignatures,
+): {
+  readiness: PluginReadinessSnapshot | undefined;
+  sourceVersions: PluginSourceVersionsSnapshot | undefined;
+} {
+  return {
+    readiness:
+      signatures?.readiness === null
+        ? undefined
+        : readJsonSnapshot(paths.readiness, PluginReadinessSnapshotSchema),
+    sourceVersions:
+      signatures?.sourceVersions === null
+        ? undefined
+        : readJsonSnapshot(
+            paths.sourceVersions,
+            PluginSourceVersionsSnapshotSchema,
+          ),
+  };
+}
+
 /**
  * Scan the workspace for plugin ingress declarations.
  *
  * A manifest is untrusted input from the assistant and is validated here
  * independently of any checks the plugin performs on itself.
  *
- * Plugins carrying a `.disabled` sentinel are skipped, matching the source
- * of truth the assistant uses for hooks, tools, and routes, so a disabled
- * plugin holds no public routes.
+ * Disabled or unready plugins hold no public routes.
  *
  * Only workspace-installed plugins are visible. Default plugins ship
  * inside the assistant binary, which the gateway cannot read.
@@ -310,9 +399,28 @@ export function discoverPluginIngress(
   opts: DiscoverPluginIngressOptions = {},
 ): PluginIngressDiscovery {
   const workspaceDir = opts.workspaceDir ?? getWorkspaceDir();
-  const pluginsDir = join(workspaceDir, "plugins");
+  const activation = readPluginActivationSnapshots(
+    getPluginActivationPaths(workspaceDir),
+  );
+  return discoverPluginIngressWithReadiness(
+    workspaceDir,
+    activation.readiness,
+    activation.sourceVersions,
+  );
+}
+
+function discoverPluginIngressWithReadiness(
+  workspaceDir: string,
+  readiness: PluginReadinessSnapshot | undefined,
+  sourceVersions: PluginSourceVersionsSnapshot | undefined,
+): PluginIngressDiscovery {
   const plugins: DiscoveredPluginIngress[] = [];
   const problems: PluginIngressProblem[] = [];
+  if (!readiness || !sourceVersions) {
+    return { plugins, problems };
+  }
+
+  const pluginsDir = join(workspaceDir, "plugins");
 
   let entries: string[];
   try {
@@ -333,7 +441,6 @@ export function discoverPluginIngress(
     } catch {
       continue;
     }
-
     // A directory only counts as a plugin when it carries a package.json,
     // the same gate the assistant's scan applies. Without it a symlink to
     // any directory holding an ingress manifest would hold public routes
@@ -352,6 +459,17 @@ export function discoverPluginIngress(
     }
 
     if (existsSync(join(pluginDir, ".disabled"))) {
+      continue;
+    }
+
+    const readinessEntry = readiness?.plugins[plugin];
+    const sourceVersion = sourceVersions?.plugins[pluginDir];
+    if (
+      readinessEntry?.status !== "ready" ||
+      sourceVersion === undefined ||
+      sourceVersion.disabled ||
+      sourceVersion.sourceFingerprint !== readinessEntry.sourceFingerprint
+    ) {
       continue;
     }
 
@@ -396,15 +514,16 @@ export function discoverPluginIngress(
 const DEFAULT_TTL_MS = 5000;
 
 /**
- * TTL-cached view of {@link discoverPluginIngress}, so the request path
- * does not re-walk the filesystem per connection and plugin installs or
- * toggles take effect without a gateway restart.
+ * TTL-cached view of {@link discoverPluginIngress}. Readiness document changes
+ * bypass the TTL so an assistant restart or activation transition closes or
+ * opens ingress immediately.
  */
 export class PluginIngressCache {
   private readonly ttlMs: number;
   private readonly workspaceDir: string | undefined;
   private snapshot: PluginIngressDiscovery = { plugins: [], problems: [] };
   private lastReadAt = 0;
+  private activationSignatures: PluginActivationSignatures | undefined;
 
   constructor(opts?: { ttlMs?: number; workspaceDir?: string }) {
     this.ttlMs = opts?.ttlMs ?? DEFAULT_TTL_MS;
@@ -414,10 +533,24 @@ export class PluginIngressCache {
   /** Current discovery, refreshed if the snapshot is stale. */
   get(opts?: { force?: boolean }): PluginIngressDiscovery {
     const now = Date.now();
-    if (opts?.force || now - this.lastReadAt >= this.ttlMs) {
-      this.snapshot = discoverPluginIngress({
-        workspaceDir: this.workspaceDir,
-      });
+    const workspaceDir = this.workspaceDir ?? getWorkspaceDir();
+    const activationPaths = getPluginActivationPaths(workspaceDir);
+    const activationSignatures = getPluginActivationSignatures(activationPaths);
+    if (
+      opts?.force ||
+      !signaturesMatch(this.activationSignatures, activationSignatures) ||
+      now - this.lastReadAt >= this.ttlMs
+    ) {
+      const activation = readPluginActivationSnapshots(
+        activationPaths,
+        activationSignatures,
+      );
+      this.snapshot = discoverPluginIngressWithReadiness(
+        workspaceDir,
+        activation.readiness,
+        activation.sourceVersions,
+      );
+      this.activationSignatures = activationSignatures;
       this.lastReadAt = Date.now();
     }
     return this.snapshot;

--- a/gateway/src/channels/plugin-ingress.ts
+++ b/gateway/src/channels/plugin-ingress.ts
@@ -4,6 +4,7 @@ import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join, posix } from "node:path";
 
 import {
+  PLUGIN_HOST_REQUIREMENTS_FILENAME,
   PLUGIN_READINESS_FILENAME,
   PLUGIN_SOURCE_VERSIONS_FILENAME,
   PluginReadinessSnapshotSchema,
@@ -390,7 +391,9 @@ function readPluginActivationSnapshots(
  * A manifest is untrusted input from the assistant and is validated here
  * independently of any checks the plugin performs on itself.
  *
- * Disabled or unready plugins hold no public routes.
+ * Legacy plugins retain the historical disk-backed behavior. A plugin opts
+ * into activation readiness by declaring host requirements, and then holds no
+ * public routes until the assistant publishes a matching ready generation.
  *
  * Only workspace-installed plugins are visible. Default plugins ship
  * inside the assistant binary, which the gateway cannot read.
@@ -416,9 +419,6 @@ function discoverPluginIngressWithReadiness(
 ): PluginIngressDiscovery {
   const plugins: DiscoveredPluginIngress[] = [];
   const problems: PluginIngressProblem[] = [];
-  if (!readiness || !sourceVersions) {
-    return { plugins, problems };
-  }
 
   const pluginsDir = join(workspaceDir, "plugins");
 
@@ -462,15 +462,17 @@ function discoverPluginIngressWithReadiness(
       continue;
     }
 
-    const readinessEntry = readiness?.plugins[plugin];
-    const sourceVersion = sourceVersions?.plugins[pluginDir];
-    if (
-      readinessEntry?.status !== "ready" ||
-      sourceVersion === undefined ||
-      sourceVersion.disabled ||
-      sourceVersion.sourceFingerprint !== readinessEntry.sourceFingerprint
-    ) {
-      continue;
+    if (existsSync(join(pluginDir, PLUGIN_HOST_REQUIREMENTS_FILENAME))) {
+      const readinessEntry = readiness?.plugins[plugin];
+      const sourceVersion = sourceVersions?.plugins[pluginDir];
+      if (
+        readinessEntry?.status !== "ready" ||
+        sourceVersion === undefined ||
+        sourceVersion.disabled ||
+        sourceVersion.sourceFingerprint !== readinessEntry.sourceFingerprint
+      ) {
+        continue;
+      }
     }
 
     const manifestPath = join(pluginDir, PLUGIN_INGRESS_MANIFEST_RELPATH);

--- a/gateway/src/http/routes/channel-ingress.test.ts
+++ b/gateway/src/http/routes/channel-ingress.test.ts
@@ -110,7 +110,7 @@ describe("approve", () => {
     expect(getPluginIngressApproval("meeting-bot")?.digest).toBe(digest);
   });
 
-  it("refuses a digest that is not what the plugin currently declares", async () => {
+  it("returns a digest conflict for a legacy declaration", async () => {
     // Otherwise a guardian could record a grant for routes nobody has seen,
     // which would activate the moment a manifest happened to match.
     writePlugin("meeting-bot");
@@ -205,7 +205,7 @@ describe("revoke", () => {
 });
 
 describe("list", () => {
-  it("says what is pending and which digest would approve it", async () => {
+  it("lists a legacy declaration and the digest that would approve it", async () => {
     // The only place this is visible. On the public surface a route held back
     // by approval 404s exactly like one nobody declared.
     writePlugin("meeting-bot");

--- a/gateway/src/http/routes/ipc-runtime-proxy.ts
+++ b/gateway/src/http/routes/ipc-runtime-proxy.ts
@@ -155,6 +155,7 @@ export async function tryIpcProxy(
   // `assistant/src/runtime/routes/http-adapter.ts`.
   delete headers["x-vellum-actor-principal-id"];
   delete headers["x-vellum-principal-type"];
+  delete headers["x-vellum-scope-profile"];
   if (claims) {
     const sub = parseSub(claims.sub);
     if (sub.ok) {
@@ -162,6 +163,7 @@ export async function tryIpcProxy(
       if (sub.actorPrincipalId) {
         headers["x-vellum-actor-principal-id"] = sub.actorPrincipalId;
       }
+      headers["x-vellum-scope-profile"] = claims.scope_profile;
     }
   }
 

--- a/packages/service-contracts/package.json
+++ b/packages/service-contracts/package.json
@@ -18,6 +18,7 @@
     "./rpc": "./src/rpc.ts",
     "./attachment-naming": "./src/attachment-naming.ts",
     "./redacted-credential": "./src/redacted-credential.ts",
+    "./plugin-readiness": "./src/plugin-readiness.ts",
     "./secret-detection": "./src/secret-detection.ts",
     "./stripe-currency": "./src/stripe-currency.ts",
     "./error": "./src/error.ts"

--- a/packages/service-contracts/src/plugin-readiness.ts
+++ b/packages/service-contracts/src/plugin-readiness.ts
@@ -1,0 +1,61 @@
+import { z } from "zod";
+
+export const PLUGIN_READINESS_FILENAME = "plugin-readiness-v1.json";
+export const PLUGIN_SOURCE_VERSIONS_FILENAME = "plugin-source-versions.json";
+export const PLUGIN_SOURCE_VERSIONS_FORMAT = 2;
+
+export const PluginReadinessStatusSchema = z.enum([
+  "initializing",
+  "ready",
+  "incompatible",
+  "failed",
+]);
+
+export const PluginReadinessEntrySchema = z
+  .object({
+    pluginId: z.string().min(1),
+    sourceFingerprint: z.string().regex(/^[a-f0-9]{64}$/),
+    status: PluginReadinessStatusSchema,
+    code: z.string().min(1).optional(),
+    message: z.string().min(1).optional(),
+    updatedAt: z.string().datetime(),
+  })
+  .strict();
+
+export const PluginReadinessSnapshotSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    generation: z.string().uuid(),
+    plugins: z.record(z.string(), PluginReadinessEntrySchema),
+  })
+  .strict();
+
+export const PluginSourceVersionSchema = z
+  .object({
+    fingerprint: z.string(),
+    sourceFingerprint: z.string().regex(/^[a-f0-9]{64}$/),
+    evictionPaths: z.array(z.string()),
+    disabled: z.boolean(),
+  })
+  .strict();
+
+export const PluginSourceVersionsSnapshotSchema = z
+  .object({
+    format: z.literal(PLUGIN_SOURCE_VERSIONS_FORMAT),
+    generation: z.number().int().nonnegative(),
+    writtenAt: z.string().datetime(),
+    plugins: z.record(z.string(), PluginSourceVersionSchema),
+  })
+  .strict();
+
+export type PluginReadinessStatus = z.infer<
+  typeof PluginReadinessStatusSchema
+>;
+export type PluginReadinessEntry = z.infer<typeof PluginReadinessEntrySchema>;
+export type PluginReadinessSnapshot = z.infer<
+  typeof PluginReadinessSnapshotSchema
+>;
+export type PluginSourceVersion = z.infer<typeof PluginSourceVersionSchema>;
+export type PluginSourceVersionsSnapshot = z.infer<
+  typeof PluginSourceVersionsSnapshotSchema
+>;

--- a/packages/service-contracts/src/plugin-readiness.ts
+++ b/packages/service-contracts/src/plugin-readiness.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 export const PLUGIN_READINESS_FILENAME = "plugin-readiness-v1.json";
+export const PLUGIN_HOST_REQUIREMENTS_FILENAME = "host-requirements.json";
 export const PLUGIN_SOURCE_VERSIONS_FILENAME = "plugin-source-versions.json";
 export const PLUGIN_SOURCE_VERSIONS_FORMAT = 2;
 


### PR DESCRIPTION
Adds the external plugin activation, route authorization, worker lifecycle, readiness, compatibility, and validation foundation required by the Assistant Network host plan. Part of the assistant-network-host feature branch.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40682" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->