### PR TITLE
fix(skills): keep assistant browser off the workspace plugin

### DIFF
--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -916,8 +916,12 @@ describe("managed browser skill", () => {
     const browserSkill = catalog.find((s) => s.id === "vellum-browser-use");
     expect(browserSkill).toBeDefined();
     expect(browserSkill!.description).toBe(
-      "Browse the web using `assistant browser` CLI commands",
+      "Browse the web using `assistant browser` CLI commands (Chrome extension, CDP inspect, or local Playwright). Do not use this when the user wants the workspace Browser plugin app; that plugin ships its own skill.",
     );
+    expect(browserSkill!.avoidWhen).toEqual([
+      "User wants to use the workspace Browser plugin or the Browser app",
+      "User asks to browse via plugins~browser~browser",
+    ]);
   });
 
   test("browser skill has no tool manifest", () => {

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1026,19 +1026,23 @@
     {
       "id": "vellum-browser-use",
       "name": "vellum-browser-use",
-      "description": "Browse the web using `assistant browser` CLI commands",
+      "description": "Browse the web using `assistant browser` CLI commands (Chrome extension, CDP inspect, or local Playwright). Do not use this when the user wants the workspace Browser plugin app; that plugin ships its own skill.",
       "metadata": {
         "emoji": "🌐",
         "vellum": {
           "category": "browsing",
           "display-name": "Browser",
           "activation-hints": [
-            "Load first if you need to browse the web (navigating, clicking, extracting web content) via `assistant browser` commands"
+            "Load when the user wants the Chrome extension, assistant browser CLI, or their real Chrome tabs"
+          ],
+          "avoid-when": [
+            "User wants to use the workspace Browser plugin or the Browser app",
+            "User asks to browse via plugins~browser~browser"
           ]
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-07T20:33:02.000Z"
+      "updatedAt": "2026-08-14T00:00:00.000Z"
     },
     {
       "id": "vellum-conversation-management",

--- a/skills/vellum-browser-use/SKILL.md
+++ b/skills/vellum-browser-use/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: vellum-browser-use
-description: Browse the web using `assistant browser` CLI commands
+description: >-
+  Browse the web using `assistant browser` CLI commands (Chrome extension,
+  CDP inspect, or local Playwright). Do not use this when the user wants the
+  workspace Browser plugin app; that plugin ships its own skill.
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🌐"
@@ -8,10 +11,19 @@ metadata:
     category: "browsing"
     display-name: "Browser"
     activation-hints:
-      - "Load first if you need to browse the web (navigating, clicking, extracting web content) via `assistant browser` commands"
+      - "Load when the user wants the Chrome extension, assistant browser CLI, or their real Chrome tabs"
+    avoid-when:
+      - "User wants to use the workspace Browser plugin or the Browser app"
+      - "User asks to browse via plugins~browser~browser"
 ---
 
-Use this skill to browse the web. All browser operations are executed through the `assistant browser` CLI, invoked via `bash` or `host_bash`. Each operation is a subcommand:
+Use this skill to browse the web through the `assistant browser` CLI (Chrome
+extension, CDP inspect, or local Playwright), invoked via `bash` or
+`host_bash`. Each operation is a subcommand.
+
+If the user wants the workspace Browser app (`plugins~browser~browser`), do
+not use this skill. Load the plugin's `browser` skill and drive that session
+through its scripts. That is a different browser.
 
 | Command                               | Description                                        |
 | ------------------------------------- | -------------------------------------------------- |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

The assistant kept using `assistant browser` (Chrome extension / CDP inspect / local Playwright) when asked to interact with the workspace Browser plugin. That plugin ships its own skill. This change tells the catalog skill to stay out of those turns.

Companion: https://github.com/vellum-ai/browser/pull/12 (plugin skill `skills/browser/` plus snapshot/element routes).

## What changed

- `vellum-browser-use` description no longer says "load first" for any web browsing.
- `avoid-when` covers the workspace Browser plugin and `plugins~browser~browser`.
- Activation hint is now the Chrome extension / CLI / real Chrome tabs path.
- Body tells the model to load the plugin's `browser` skill instead.
- `skills/catalog.json` matches the SKILL.md frontmatter.

## Test plan

- `cd assistant && bun test src/__tests__/skills.test.ts --grep "managed browser skill"`
- After both PRs land, ask the assistant to click or extract in the workspace Browser app and confirm it loads the plugin skill, not `assistant browser`.

## CLI verb checklist

No new IPC routes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fd99dd9-9f64-4c53-980a-1a3a9778a7a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fd99dd9-9f64-4c53-980a-1a3a9778a7a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

