### PR TITLE
fix(web): keep the last sidebar section visible past the virtualize threshold

### DIFF
--- a/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -128,6 +128,7 @@ import type {
   ConversationGroup,
 } from "@/types/conversation-types";
 import { AssistantSideMenu } from "@/domains/chat/components/assistant-side-menu";
+import { CONVERSATION_LIST_VIRTUALIZE_THRESHOLD } from "@/domains/chat/components/conversation-nav-section";
 import { useSidebarLayoutStore } from "@/domains/chat/sidebar-layout-store";
 import { usePinnedAppsStore } from "@/stores/pinned-apps-store";
 import type { PinnedAppEntry } from "@/utils/app-pin-storage";
@@ -1580,6 +1581,60 @@ describe("AssistantSideMenu · equal section treatment", () => {
     } finally {
       cleanup();
     }
+  });
+
+  /*
+   * Past CONVERSATION_LIST_VIRTUALIZE_THRESHOLD the bottom-most section
+   * windows its rows through virtuoso, and a windowed list renders only what
+   * fits its viewport: unlike mounted rows, it has no natural height of its
+   * own. Its box therefore needs two things, and losing either blanks the
+   * whole list while the caches stay fully populated: the accordion root must
+   * forward the sidebar body's height down to the card's flex-fill, and the
+   * box itself must floor at the section cap so a squeezed (or broken) chain
+   * still yields a scrollable section rather than a zero-height one.
+   */
+  test("past the virtualize threshold, Chats windows into a bounded, filling box", () => {
+    localStorage.setItem("vellum:sidebar-view-mode:asst-1", "all");
+    const container = parse(
+      renderMenu({
+        conversations: Array.from(
+          { length: CONVERSATION_LIST_VIRTUALIZE_THRESHOLD + 1 },
+          (_, index) =>
+            makeConversation({
+              conversationId: `r${index}`,
+              title: `Recent ${index}`,
+            }),
+        ),
+      }),
+    );
+
+    const sections = sectionElements(container);
+    const labels = sectionLabels(container);
+    const chats = sections[labels.indexOf("Chats")];
+    if (!chats) {
+      throw new Error("expected the Chats section");
+    }
+
+    // The windowed path: virtuoso owns the rows, no mounted scroller.
+    expect(chats.querySelector(".overflow-y-auto")).toBeNull();
+    const windowed = chats.querySelector<HTMLElement>(
+      '[data-slot="virtual-list"]',
+    );
+    if (!windowed?.parentElement) {
+      throw new Error("expected the windowed row list and its sizing box");
+    }
+
+    const box = windowed.parentElement;
+    expect(box.classList.contains("flex-1")).toBe(true);
+    expect(box.style.minHeight).toBe(`${SIDEBAR_SECTION_MAX_HEIGHT}px`);
+
+    // The fill above the floor only resolves if the accordion root passes
+    // the body's height to the card's flex-fill.
+    const root = container.querySelector<HTMLElement>(
+      '[data-slot="collapsible"]',
+    );
+    expect(root?.classList.contains("flex-1")).toBe(true);
+    expect(root?.classList.contains("min-h-0")).toBe(true);
   });
 
   test("every section renders through the same component with the same affordances", () => {

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -554,7 +554,13 @@ export function AssistantSideMenu({
                   action. */}
                 <CollapsibleNavSection.Root
                   type="multiple"
-                  className={SIDEBAR_STACK_GAP}
+                  /* min-h-0 flex-1: the root must claim the body's height so
+                     the bottom-most open card's flex-fill has leftover space
+                     to take. Without it every layer below sizes to content,
+                     and a windowed row list (which renders only what fits a
+                     bounded viewport) resolves to zero height and draws no
+                     rows at all. */
+                  className={cn(SIDEBAR_STACK_GAP, "min-h-0 flex-1")}
                   value={sidebar.effectiveOpenSections}
                   onValueChange={sidebar.onOpenSectionsChange}
                 >

--- a/clients/web/src/domains/chat/components/conversation-nav-section.tsx
+++ b/clients/web/src/domains/chat/components/conversation-nav-section.tsx
@@ -141,9 +141,22 @@ export function ConversationRowList({
      virtuoso's scroller sizes to 100%: the last section fills whatever
      height its own flex-fill sizing (see `CollapsibleNavSection.Section`)
      gives it, every other section gets a fixed height so a busy non-last
-     section still can't push its neighbours off screen. */
+     section still can't push its neighbours off screen.
+
+     The last section's fill only resolves while every ancestor between the
+     sidebar body and this box forwards the body's height (flex column with
+     flex-1/min-h-0 at each layer). A windowed list renders only what fits
+     its viewport, so unlike the mounted-rows path a broken chain here does
+     not degrade to a tall list, it degrades to an empty one. The min-height
+     floor caps that failure at "a section-sized scrollable box": rows stay
+     reachable even if a layout change above drops the chain. */
   return isLast ? (
-    <div className="min-h-0 h-full flex-1">{windowed}</div>
+    <div
+      className="h-full flex-1"
+      style={{ minHeight: SIDEBAR_SECTION_MAX_HEIGHT }}
+    >
+      {windowed}
+    </div>
   ) : (
     <div style={{ height: SIDEBAR_SECTION_MAX_HEIGHT }}>{windowed}</div>
   );


### PR DESCRIPTION
## Summary
- Past `CONVERSATION_LIST_VIRTUALIZE_THRESHOLD` (30 rows) the bottom-most sidebar section renders through virtuoso, which needs a bounded viewport; the flex height chain that was meant to provide one broke at `CollapsibleNavSection.Root` (no `flex-1 min-h-0`), so every layer below sized to content and the windowed list resolved to zero height and drew no rows. Pre-existing assistants (>30 conversations) saw an empty Chats card while every cache held the full list; fresh assistants stayed under the threshold on the mounted-rows path and looked fine.
- Fix is two-part: the accordion root now claims the sidebar body's height (`min-h-0 flex-1`) so the last card's flex-fill has real space to take, and the windowed box floors at `SIDEBAR_SECTION_MAX_HEIGHT` so a squeezed or future-broken chain degrades to a section-sized scrollable list instead of an empty one.
- Regression test renders 31 conversations and pins both halves (the root's chain classes and the box's floor); it fails on the previous code. Verified in Storybook (`All view · long list`, ~90 rows): before, virtuoso mounted at 0px and rendered zero rows; after, a 300px viewport with all rows reachable.

## Original prompt
A teammate on staging reported conversations "disappearing" on pre-existing assistants after updating to 0.11.4-staging.1, including newly created chats, while fresh assistants behaved normally. Investigation of the feedback bundle showed no data loss anywhere: the daemon served all rows and the client cached them, but the sidebar's virtualized last section collapsed to zero height once an account crossed 30 conversations. This PR implements the suggested fix: complete the flex height chain at the accordion root, give the virtualized last section a robust bounded floor, and add a regression test past the threshold.