### PR TITLE
feat(web): unify sidepanel body chrome, header actions, and toggle sizes

### DIFF
--- a/clients/web/src/components/detail-card.stories.tsx
+++ b/clients/web/src/components/detail-card.stories.tsx
@@ -1,0 +1,98 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Button, Toggle } from "@vellumai/design-library";
+
+import { DetailCard } from "./detail-card";
+
+/**
+ * The page-level details card: settings pages, contacts, channels. For a card
+ * nested inside a sidepanel body or a modal, reach for
+ * `Components/InsetDetailCard` instead: this one's 20px title and 16px
+ * corners are scaled for a full surface.
+ */
+const meta: Meta<typeof DetailCard> = {
+  title: "Components/DetailCard",
+  component: DetailCard,
+  parameters: { layout: "centered" },
+  decorators: [
+    (Story) => (
+      <div className="w-[560px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof DetailCard>;
+
+function Body({ text }: { text: string }) {
+  return (
+    <p className="text-body-medium-lighter text-[var(--content-secondary)]">
+      {text}
+    </p>
+  );
+}
+
+export const Default: Story = {
+  args: {
+    title: "Recent runs",
+    children: <Body text="The last few times this task ran." />,
+  },
+};
+
+export const WithSubtitle: Story = {
+  args: {
+    title: "Memory",
+    subtitle: "What your assistant remembers between conversations.",
+    children: <Body text="Memory is on." />,
+  },
+};
+
+/** Header right-hand slot: a control that acts on the whole card. */
+export const WithAccessory: Story = {
+  args: {
+    title: "Share diagnostics",
+    subtitle: "Send crash reports and session replay data.",
+    accessory: <Toggle checked onChange={() => {}} aria-label="Share diagnostics" />,
+    children: null,
+  },
+};
+
+/** `compactAccessory` keeps the accessory on the title's row at every width. */
+export const CompactAccessory: Story = {
+  args: {
+    title: "Pair a device",
+    compactAccessory: true,
+    accessory: (
+      <Button variant="outlined" size="compact">
+        Pair
+      </Button>
+    ),
+    children: <Body text="Scan the code from your phone." />,
+  },
+};
+
+/** `showBorder={false}` drops the card chrome, keeping only the heading rhythm. */
+export const Borderless: Story = {
+  args: {
+    title: "Advanced",
+    showBorder: false,
+    children: <Body text="Settings most people never need to touch." />,
+  },
+};
+
+/** The destructive variant, for irreversible actions. */
+export const Danger: Story = {
+  args: {
+    title: "Delete assistant",
+    variant: "danger",
+    subtitle: "This cannot be undone.",
+    children: (
+      <Button variant="dangerOutline" size="compact">
+        Delete
+      </Button>
+    ),
+  },
+};
+

--- a/clients/web/src/components/detail-card.stories.tsx
+++ b/clients/web/src/components/detail-card.stories.tsx
@@ -13,6 +13,11 @@ import { DetailCard } from "./detail-card";
 const meta: Meta<typeof DetailCard> = {
   title: "Components/DetailCard",
   component: DetailCard,
+  argTypes: {
+    variant: { control: "inline-radio", options: ["default", "danger"] },
+    accessory: { control: false },
+    children: { control: false },
+  },
   parameters: { layout: "centered" },
   decorators: [
     (Story) => (

--- a/clients/web/src/components/detail-shell.tsx
+++ b/clients/web/src/components/detail-shell.tsx
@@ -88,7 +88,15 @@ export function DetailShellHeader({
             {title}
           </Typography>
         )}
-        {headerTrailing}
+        {/* `-ml-1.5` trims the cluster's `gap-3` (12px) down to 6px between the
+            title and the tag or status badge that sits next to it. Every other
+            header gap stays at 12px, since the negative margin only pulls in
+            this one edge. */}
+        {headerTrailing && (
+          <span className="-ml-1.5 flex shrink-0 items-center">
+            {headerTrailing}
+          </span>
+        )}
       </div>
       {headerActions}
       <Button

--- a/clients/web/src/components/inset-detail-card.stories.tsx
+++ b/clients/web/src/components/inset-detail-card.stories.tsx
@@ -1,0 +1,122 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Button } from "@vellumai/design-library";
+
+import { DetailCard } from "./detail-card";
+import { InsetDetailCard } from "./inset-detail-card";
+
+/**
+ * The details card for **inset** surfaces: a sidepanel body, a modal, or
+ * anything already nested inside its own card. `DetailCard` is the page-level
+ * counterpart. See `Components/DetailCard` for the side-by-side.
+ */
+const meta: Meta<typeof InsetDetailCard> = {
+  title: "Components/InsetDetailCard",
+  component: InsetDetailCard,
+  parameters: { layout: "centered" },
+  decorators: [
+    (Story) => (
+      <div className="w-[420px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof InsetDetailCard>;
+
+/** A label/value stack, the shape these panels most often wrap. */
+function Rows({
+  rows,
+}: {
+  rows: [label: string, value: string][];
+}) {
+  return (
+    <div className="space-y-2 text-body-medium-lighter">
+      {rows.map(([label, value]) => (
+        <div key={label} className="flex items-center justify-between gap-4">
+          <span className="text-[var(--content-secondary)]">{label}</span>
+          <span className="text-[var(--content-default)]">{value}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const DETAIL_ROWS: [string, string][] = [
+  ["Status", "On"],
+  ["Model profile", "Balanced"],
+  ["Repeats", "Every 1 hr"],
+  ["Next run", "Today at 3:00 PM"],
+  ["Last run", "Today at 2:00 PM"],
+];
+
+export const Default: Story = {
+  args: {
+    title: "Details",
+    children: <Rows rows={DETAIL_ROWS} />,
+  },
+};
+
+export const WithSubtitle: Story = {
+  args: {
+    title: "Details",
+    subtitle: "How and when this task runs.",
+    children: <Rows rows={DETAIL_ROWS} />,
+  },
+};
+
+/** The header's right-hand slot, e.g. a pagination control. */
+export const WithAccessory: Story = {
+  args: {
+    title: "Recent runs",
+    accessory: (
+      <Button variant="outlined" size="compact">
+        Load more
+      </Button>
+    ),
+    children: <Rows rows={[["Today at 2:00 PM", "Completed"]]} />,
+  },
+};
+
+/** No header: just the inset surface around arbitrary content. */
+export const Titleless: Story = {
+  args: { children: <Rows rows={DETAIL_ROWS} /> },
+};
+
+/**
+ * The case this component exists for. Both cards sit inside a mock sidepanel
+ * body: `DetailCard`'s 20px title competes with the panel's own header title
+ * and its 16px corners tie with the panel's, while `InsetDetailCard` reads
+ * as nested.
+ */
+export const InsetVsPageLevel: StoryObj = {
+  render: () => (
+    <div className="flex h-full flex-col overflow-hidden rounded-xl bg-[var(--surface-lift)]">
+      <div className="flex shrink-0 items-center gap-3 border-b border-[var(--border-hover)] px-5 py-4">
+        <span className="text-title-medium leading-snug text-[var(--content-default)]">
+          Heartbeat
+        </span>
+      </div>
+      <div className="space-y-6 px-4 py-4">
+        <div className="space-y-2">
+          <p className="text-body-small-default text-[var(--content-tertiary)]">
+            InsetDetailCard: 16px title, 12px corners
+          </p>
+          <InsetDetailCard title="Details">
+            <Rows rows={DETAIL_ROWS} />
+          </InsetDetailCard>
+        </div>
+        <div className="space-y-2">
+          <p className="text-body-small-default text-[var(--content-tertiary)]">
+            DetailCard: 20px title, 16px corners (too large here)
+          </p>
+          <DetailCard title="Details">
+            <Rows rows={DETAIL_ROWS} />
+          </DetailCard>
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/clients/web/src/components/inset-detail-card.stories.tsx
+++ b/clients/web/src/components/inset-detail-card.stories.tsx
@@ -13,6 +13,12 @@ import { InsetDetailCard } from "./inset-detail-card";
 const meta: Meta<typeof InsetDetailCard> = {
   title: "Components/InsetDetailCard",
   component: InsetDetailCard,
+  // No union props here; the slots are marked uneditable so Controls offers
+  // only the text props it can actually drive.
+  argTypes: {
+    accessory: { control: false },
+    children: { control: false },
+  },
   parameters: { layout: "centered" },
   decorators: [
     (Story) => (

--- a/clients/web/src/components/inset-detail-card.tsx
+++ b/clients/web/src/components/inset-detail-card.tsx
@@ -1,0 +1,75 @@
+import type { ReactNode } from "react";
+
+import { Card, Typography, cn } from "@vellumai/design-library";
+
+/**
+ * A details card sized for **inset** contexts: inside a sidepanel body, a
+ * modal, or anywhere already nested in its own surface.
+ *
+ * Use this instead of `DetailCard`, which is the page-level card and is scaled
+ * for larger surfaces. Two differences carry that distinction:
+ *
+ * - **16px title** (`title-small`) rather than `DetailCard`'s 20px
+ *   `title-medium`, which competes with a sidepanel header's own title.
+ * - **12px corners** (`rounded-lg` → `--radius-lg`) rather than the 16px
+ *   `rounded-xl` the `Card` primitive defaults to, so the inner card reads as
+ *   nested inside the panel's own rounding rather than tying with it.
+ */
+export interface InsetDetailCardProps {
+  id?: string;
+  title?: string;
+  /** Secondary line under the title (e.g. what the section covers). */
+  subtitle?: ReactNode;
+  /** Right-aligned slot on the header row (e.g. a "Load more" button). */
+  accessory?: ReactNode;
+  children?: ReactNode;
+  className?: string;
+}
+
+export function InsetDetailCard({
+  id,
+  title,
+  subtitle,
+  accessory,
+  children,
+  className,
+}: InsetDetailCardProps) {
+  const hasHeader = Boolean(title || subtitle || accessory);
+
+  return (
+    // `rounded-lg` (12px) lands after the Card's own classes, so tailwind-merge
+    // drops the primitive's `rounded-xl` (16px).
+    <Card asChild className={cn("rounded-lg", className)}>
+      <section id={id}>
+        {hasHeader && (
+          <div className="flex flex-row items-start justify-between gap-4">
+            <div className="flex min-w-0 flex-col gap-1">
+              {title && (
+                <Typography
+                  variant="title-small"
+                  as="h2"
+                  className="text-[var(--content-emphasised)]"
+                >
+                  {title}
+                </Typography>
+              )}
+              {subtitle && (
+                <Typography
+                  variant="body-small-default"
+                  as="p"
+                  className="text-[var(--content-tertiary)]"
+                >
+                  {subtitle}
+                </Typography>
+              )}
+            </div>
+            {accessory && <div className="shrink-0">{accessory}</div>}
+          </div>
+        )}
+        {children != null && (
+          <div className={hasHeader ? "mt-3" : ""}>{children}</div>
+        )}
+      </section>
+    </Card>
+  );
+}

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-run-chat-view.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-run-chat-view.tsx
@@ -12,8 +12,8 @@
 import {
   ArrowDown,
   ArrowDownToLine,
-  ArrowLeft,
   ArrowUpFromLine,
+  ChevronLeft,
   ChevronRight,
   Send,
 } from "lucide-react";
@@ -393,7 +393,7 @@ function ChatViewHeader({
           {showBack && (
             <Button
               variant="outlined"
-              iconOnly={<ArrowLeft />}
+              iconOnly={<ChevronLeft />}
               onClick={onBack}
               aria-label="Back to conversation"
               tooltip="Back"

--- a/clients/web/src/domains/chat/components/activity-steps-panel.tsx
+++ b/clients/web/src/domains/chat/components/activity-steps-panel.tsx
@@ -26,6 +26,7 @@ import { Button, Typography } from "@vellumai/design-library";
 
 import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
 import { DetailShell } from "@/components/detail-shell";
+import { useTranslation } from "@/i18n";
 import { StreamingShimmerText } from "@/domains/chat/components/streaming-shimmer-text";
 import {
   activityRunSummaryLabel,
@@ -79,6 +80,7 @@ export function ActivityStepsPanel({
    */
   assistantId?: string | null;
 }) {
+  const { t } = useTranslation("chat");
   // Level-2 drill-in: the step detail currently open, or null for the
   // timeline. Local state — the drawer level is navigation within the panel,
   // not shared app state.
@@ -125,8 +127,8 @@ export function ActivityStepsPanel({
           <Button
             variant="outlined"
             iconOnly={<ChevronLeft />}
-            aria-label="Back to all steps"
-            tooltip="All steps"
+            aria-label={t("activityStepsPanel.backAria")}
+            tooltip={t("activityStepsPanel.backTooltip")}
             onClick={() => setStepDetail(null)}
             className="shrink-0"
           />

--- a/clients/web/src/domains/chat/components/activity-steps-panel.tsx
+++ b/clients/web/src/domains/chat/components/activity-steps-panel.tsx
@@ -117,27 +117,31 @@ export function ActivityStepsPanel({
 
   return (
     <DetailShell
+      // Drilled into a step, the back control takes the leading slot the glyph
+      // would occupy: same placement, variant, and spacing as the subagent,
+      // workflow, and ACP run panels' Back buttons.
+      icon={
+        stepDetail ? (
+          <Button
+            variant="outlined"
+            iconOnly={<ChevronLeft />}
+            aria-label="Back to all steps"
+            tooltip="All steps"
+            onClick={() => setStepDetail(null)}
+            className="shrink-0"
+          />
+        ) : undefined
+      }
       titleNode={
         stepDetail ? (
-          // Drilled into a step: back chevron + the step's title replace the
-          // run summary, so the header always names what the body shows.
-          <span className="flex min-w-0 items-center gap-1 py-0.5">
-            {/* Full-size ghost icon button, mirroring the shell's close X. */}
-            <Button
-              variant="ghost"
-              iconOnly={<ChevronLeft />}
-              aria-label="Back to all steps"
-              tooltip="All steps"
-              onClick={() => setStepDetail(null)}
-              className="-ml-2.5 shrink-0"
-            />
-            <Typography
-              variant="title-medium"
-              className="min-w-0 shrink truncate leading-snug text-[var(--content-default)]"
-            >
-              {stepDetailTitle}
-            </Typography>
-          </span>
+          // Drilled into a step: the step's title replaces the run summary, so
+          // the header always names what the body shows.
+          <Typography
+            variant="title-medium"
+            className="min-w-0 shrink truncate py-0.5 leading-snug text-[var(--content-default)]"
+          >
+            {stepDetailTitle}
+          </Typography>
         ) : (
           // Timeline level, per Figma: title · N steps — inline at the same
           // size, separated by a 3px midline dot, count in the secondary tone.

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -955,7 +955,7 @@ export function ChatComposer({
   ) : (
     <Button
       variant="primary"
-      iconOnly={<Square className="h-3 w-3" fill="currentColor" />}
+      iconOnly={<Square className="h-3 w-3" />}
       iconOnlyGlyphClassName={isMobile ? MOBILE_GLYPH_CLASS : undefined}
       expandOnMobile={!isMobile}
       onClick={onStopGenerating}

--- a/clients/web/src/domains/chat/components/detail-panel-stop-button.tsx
+++ b/clients/web/src/domains/chat/components/detail-panel-stop-button.tsx
@@ -20,6 +20,7 @@
 
 import { Square } from "lucide-react";
 
+import { useTranslation } from "@/i18n";
 import { Button } from "@vellumai/design-library";
 
 export interface DetailPanelStopButtonProps {
@@ -35,12 +36,13 @@ export function DetailPanelStopButton({
   ariaLabel,
   disabled,
 }: DetailPanelStopButtonProps) {
+  const { t } = useTranslation("chat");
   return (
     <Button
       variant="dangerOutline"
       iconOnly={<Square />}
       aria-label={ariaLabel}
-      tooltip="Stop"
+      tooltip={t("detailPanelStopButton.tooltip")}
       onClick={onStop}
       disabled={disabled}
       className="shrink-0 hover:border-[var(--system-negative-strong)] hover:bg-[var(--system-negative-weak)] hover:[--vbtn-fg:var(--system-negative-strong)]"

--- a/clients/web/src/domains/chat/components/detail-panel-stop-button.tsx
+++ b/clients/web/src/domains/chat/components/detail-panel-stop-button.tsx
@@ -1,21 +1,21 @@
 /**
- * Outlined danger "Stop" button for detail-panel headers (subagent, background
- * task). A bordered button with a filled square glyph + a "Stop" label — the
- * shared right-aligned header control, distinct from the inline cards'
- * `dangerGhost` icon-only stop. Keeping both panels on this one component stops
- * their headers from drifting apart.
+ * Icon-only danger "Stop" control for detail-panel headers (subagent,
+ * workflow, background task, ACP run). A bordered square button holding a
+ * square glyph, the shared right-aligned header control. Keeping every panel
+ * on this one component stops their headers from drifting apart.
  *
- * Corner radius is the design-library default (no override) so it matches the
- * sibling Back/Close buttons in the same header.
+ * Corner radius and glyph size are both the design-library defaults (no
+ * override) so this matches the sibling Back/Close buttons in the same header.
+ * The glyph is stroked, not filled, for the same reason.
  *
  * The gap to the Close button that always follows is trimmed to 8px by
  * `DetailShellHeader` itself, not by this component: every `headerActions`
  * control gets that treatment for free.
  *
  * The hover override keeps this button's weak-fill hover instead of
- * `dangerOutline`'s text/border recolor. Letting the recolor land on top of the
- * fill drops the label to ~2.4:1 in light and ~2.0:1 in dark; holding the
- * foreground at `--system-negative-strong` keeps it at ~3.2:1 / ~2.9:1.
+ * `dangerOutline`'s foreground/border recolor. Letting the recolor land on top
+ * of the fill drops the glyph to ~2.4:1 in light and ~2.0:1 in dark; holding
+ * the foreground at `--system-negative-strong` keeps it at ~3.2:1 / ~2.9:1.
  */
 
 import { Square } from "lucide-react";
@@ -38,13 +38,12 @@ export function DetailPanelStopButton({
   return (
     <Button
       variant="dangerOutline"
-      leftIcon={<Square className="h-3 w-3" fill="currentColor" />}
+      iconOnly={<Square />}
       aria-label={ariaLabel}
+      tooltip="Stop"
       onClick={onStop}
       disabled={disabled}
       className="shrink-0 hover:border-[var(--system-negative-strong)] hover:bg-[var(--system-negative-weak)] hover:[--vbtn-fg:var(--system-negative-strong)]"
-    >
-      Stop
-    </Button>
+    />
   );
 }

--- a/clients/web/src/domains/chat/components/skill-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/skill-detail-panel.tsx
@@ -114,9 +114,13 @@ export function SkillDetailPanel({ skillId, onClose }: SkillDetailPanelProps) {
             <Menu.Root>
               <Menu.Trigger asChild>
                 <Button
-                  variant="ghost"
+                  // Matches the header's Close button: same `outlined`
+                  // variant, same bare `iconOnly` glyph (the Button sizes it),
+                  // and a short tooltip beside the descriptive aria-label.
+                  variant="outlined"
                   iconOnly={<MoreHorizontal />}
                   aria-label="Skill actions"
+                  tooltip="More"
                   className="shrink-0"
                 />
               </Menu.Trigger>

--- a/clients/web/src/domains/chat/components/skill-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/skill-detail-panel.tsx
@@ -21,6 +21,7 @@ import { useNavigate } from "react-router";
 
 import { Button, Menu, Typography } from "@vellumai/design-library";
 
+import { useTranslation } from "@/i18n";
 import { FileMarkdown } from "@/components/file-markdown";
 import { SkillLineageLink } from "@/components/skill-lineage-link";
 import { SkillRemovalDialog } from "@/components/skill-removal-dialog";
@@ -41,6 +42,7 @@ interface SkillDetailPanelProps {
 }
 
 export function SkillDetailPanel({ skillId, onClose }: SkillDetailPanelProps) {
+  const { t } = useTranslation("chat");
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
@@ -119,8 +121,8 @@ export function SkillDetailPanel({ skillId, onClose }: SkillDetailPanelProps) {
                   // and a short tooltip beside the descriptive aria-label.
                   variant="outlined"
                   iconOnly={<MoreHorizontal />}
-                  aria-label="Skill actions"
-                  tooltip="More"
+                  aria-label={t("skillDetailPanel.actionsAria")}
+                  tooltip={t("skillDetailPanel.moreTooltip")}
                   className="shrink-0"
                 />
               </Menu.Trigger>

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -1,9 +1,9 @@
 import {
   ArrowDownToLine,
-  ArrowLeft,
   ArrowUpFromLine,
   Bolt,
   ChevronDown,
+  ChevronLeft,
   ChevronRight,
 } from "lucide-react";
 
@@ -316,7 +316,7 @@ export function SubagentDetailPanel({
           {activeDetail && (
             <Button
               variant="outlined"
-              iconOnly={<ArrowLeft />}
+              iconOnly={<ChevronLeft />}
               onClick={handleBack}
               aria-label="Back to timeline"
               tooltip="Back"

--- a/clients/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.tsx
+++ b/clients/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.tsx
@@ -527,7 +527,18 @@ function TimelineNodeIcon({
       />
     );
   }
-  return <ThreeDotIndicator data-testid={testId} className="shrink-0" />;
+  // 3px dots with a 2px gap measure 13px, matching the 14px `CheckCircle2`
+  // this swaps with almost exactly. The 8px default is ~30px wide and made the
+  // node jump in size the moment a step started running. Same sizing the
+  // subagent avatar badge uses.
+  return (
+    <ThreeDotIndicator
+      data-testid={testId}
+      className="shrink-0"
+      dotSize={3}
+      gap={2}
+    />
+  );
 }
 
 /**

--- a/clients/web/src/domains/chat/components/voice-input-button.tsx
+++ b/clients/web/src/domains/chat/components/voice-input-button.tsx
@@ -1066,10 +1066,10 @@ export const VoiceInputButton = forwardRef<
         processing ? (
           <Loader2 className="animate-spin" strokeWidth={2} />
         ) : recording ? (
-          // Filled rounded-square "stop" glyph (matches the detail-panel stop
-          // button + the design in Figma 6764:6744). Sized to 20px via
+          // Rounded-square "stop" glyph, stroked to match the detail-panel
+          // stop button and the rest of the icon set. Sized to 20px via
           // `iconOnlyGlyphClassName` below.
-          <Square fill="currentColor" strokeWidth={2} />
+          <Square strokeWidth={2} />
         ) : (
           <Mic strokeWidth={2} />
         )

--- a/clients/web/src/domains/chat/components/workflow-detail-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/workflow-detail-panel.test.tsx
@@ -1,5 +1,5 @@
 /**
- * The detail panel renders the run header (icon tile + label + status badge),
+ * The detail panel renders the run header (glyph + label + status badge),
  * a metrics row, an Objective section, and a live "Subagents" list. Each
  * subagent row is keyed by `seq` and shows a lead indicator that resolves in
  * place — a three-dot pulse while running, a status glyph once terminal — the

--- a/clients/web/src/domains/chat/components/workflow-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/workflow-detail-panel.tsx
@@ -1,7 +1,7 @@
 import {
   ArrowDownToLine,
-  ArrowLeft,
   ArrowUpFromLine,
+  ChevronLeft,
   ChevronRight,
   Users,
   Workflow,
@@ -137,7 +137,7 @@ export function WorkflowDetailPanel({
           {selectedLeaf && (
             <Button
               variant="outlined"
-              iconOnly={<ArrowLeft />}
+              iconOnly={<ChevronLeft />}
               onClick={handleBack}
               aria-label="Back to subagents"
               tooltip="Back"
@@ -157,12 +157,13 @@ export function WorkflowDetailPanel({
               <div style={{ width: 32, height: 32, flexShrink: 0 }} aria-hidden />
             )
           ) : (
-            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[6px] bg-[var(--surface-overlay)]">
-              <Workflow
-                className="h-4 w-4"
-                style={{ color: "var(--content-secondary)" }}
-              />
-            </div>
+            // Bare 20px glyph, matching what `DetailShellHeader` renders for a
+            // `Glyph` prop, so this header's icon box lines up with the other
+            // panels'. The leaf branch above keeps its 32px avatar.
+            <Workflow
+              className="h-5 w-5 shrink-0 text-[var(--content-secondary)]"
+              aria-hidden
+            />
           )}
         </>
       }

--- a/clients/web/src/domains/chat/process-registry/inline-process-card.tsx
+++ b/clients/web/src/domains/chat/process-registry/inline-process-card.tsx
@@ -110,7 +110,7 @@ export function InlineProcessCard({
           <Button
             variant="dangerGhost"
             size="compact"
-            iconOnly={<Square fill="currentColor" />}
+            iconOnly={<Square />}
             aria-label={stopAriaLabel ?? "Stop"}
             data-testid="inline-process-card-stop"
             onClick={handleStop}

--- a/clients/web/src/domains/schedules/components/schedule-detail-panel.test.tsx
+++ b/clients/web/src/domains/schedules/components/schedule-detail-panel.test.tsx
@@ -270,24 +270,25 @@ describe("ScheduleDetailPanel model profile", () => {
 });
 
 describe("ScheduleDetailPanel plugin-sourced treatment", () => {
+  // The header Delete is icon-only, so it is addressed by accessible name.
   test("user-created schedules keep the Delete button", async () => {
-    const { getByText, queryByText } = renderPanel(makeSchedule());
+    const { getByLabelText, queryByText } = renderPanel(makeSchedule());
 
     await waitFor(() => {
-      expect(getByText("Delete")).toBeTruthy();
+      expect(getByLabelText("Delete")).toBeTruthy();
     });
     expect(queryByText(/Managed by plugin/)).toBeNull();
   });
 
   test("plugin-sourced schedules hide Delete and show plugin attribution", async () => {
-    const { getByText, queryByText } = renderPanel(
+    const { getByText, queryByLabelText } = renderPanel(
       makeSchedule({ sourceKey: "plugin:gmail/poll-inbox" }),
     );
 
     await waitFor(() => {
       expect(getByText("Managed by plugin gmail")).toBeTruthy();
     });
-    expect(queryByText("Delete")).toBeNull();
+    expect(queryByLabelText("Delete")).toBeNull();
   });
 });
 

--- a/clients/web/src/domains/schedules/components/schedule-detail-panel.tsx
+++ b/clients/web/src/domains/schedules/components/schedule-detail-panel.tsx
@@ -13,6 +13,7 @@ import { useState } from "react";
 import { useNavigate } from "react-router";
 
 import { DetailShellHeader } from "@/components/detail-shell";
+import { InsetDetailCard } from "@/components/inset-detail-card";
 import { useTranslation } from "@/i18n";
 import { SCHEDULE_USAGE_WINDOW_DAYS } from "@/utils/usage-window";
 import { pluginNameFromSourceKey } from "@/domains/schedules/plugin-source";
@@ -41,28 +42,22 @@ import {
 } from "@/generated/daemon/@tanstack/react-query.gen";
 import { navigateToConversation } from "@/utils/conversation-navigation";
 import { routes } from "@/utils/routes";
-import { Button, Skeleton, Typography, cn } from "@vellumai/design-library";
+import { Button, Skeleton, cn } from "@vellumai/design-library";
 import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 import { toast } from "@vellumai/design-library/components/toast";
 
 import type { Schedule, ScheduleRun } from "@/domains/settings/types/schedules";
 
-function SectionLabel({ children }: { children: string }) {
-  return (
-    <Typography
-      variant="label-small-default"
-      as="div"
-      className="mb-2 uppercase tracking-wider text-[var(--content-tertiary)]"
-    >
-      {children}
-    </Typography>
-  );
-}
-
+/**
+ * One label/value line in the Details card. `min-h-6` pins the row to 24px
+ * whatever the value slot holds, matching `SystemTaskDetailPanel` so the two
+ * schedules panels share one row rhythm; the enclosing stack owns the gap
+ * between rows.
+ */
 function InfoRow({ label, value }: { label: string; value: ReactNode }) {
   return (
-    <div className="flex items-center justify-between gap-4 py-1">
-      <span className="text-body-medium-lighter text-[var(--content-secondary)]">
+    <div className="flex min-h-6 items-center justify-between gap-4">
+      <span className="shrink-0 text-body-medium-lighter text-[var(--content-secondary)]">
         {label}
       </span>
       <span className="min-w-0 text-right text-body-medium-lighter text-[var(--content-default)]">
@@ -141,7 +136,7 @@ function ScheduleModelProfileField({
           label={t("scheduleDetail.modelProfile")}
           value={t("scheduleDetail.notUsedForWorkflow")}
         />
-        <p className="pb-1 text-body-small-default text-[var(--content-tertiary)]">
+        <p className="text-body-small-default text-[var(--content-tertiary)]">
           {t("scheduleDetail.modelProfileWorkflowNote")}
         </p>
       </>
@@ -150,7 +145,7 @@ function ScheduleModelProfileField({
 
   if (isPast) {
     return (
-      <div className="py-1 text-body-medium-lighter text-[var(--content-default)]">
+      <div className="text-body-medium-lighter text-[var(--content-default)]">
         <ModelProfileRow
           assistantId={assistantId}
           pinnedProfile={schedule.inferenceProfile}
@@ -465,7 +460,10 @@ function RecentRuns({
     );
   }
   return (
-    <div className="divide-y divide-[var(--border-base)]">
+    // `-mx-2` cancels the rows' own `px-2` against the enclosing
+    // `InsetDetailCard` padding, so row text lines up with the card's edge
+    // while each row's hover fill still bleeds the full width.
+    <div className="-mx-2 divide-y divide-[var(--border-base)]">
       {runs.map((run, index) => (
         <RunRow
           key={run.id}
@@ -568,11 +566,11 @@ export function ScheduleDetailPanel({
             pluginName ? undefined : (
               <Button
                 variant="dangerOutline"
-                leftIcon={<Trash2 className="h-3.5 w-3.5" />}
+                iconOnly={<Trash2 />}
+                aria-label={t("scheduleDetail.delete")}
+                tooltip={t("scheduleDetail.delete")}
                 onClick={() => setConfirmingDelete(true)}
-              >
-                {t("scheduleDetail.delete")}
-              </Button>
+              />
             )
           }
           closeLabel={t("scheduleDetail.closeAria")}
@@ -588,9 +586,8 @@ export function ScheduleDetailPanel({
             </p>
           ) : null}
 
-          <section>
-            <SectionLabel>{t("scheduleDetail.details")}</SectionLabel>
-            <div className="rounded-lg border border-[var(--border-base)] bg-[var(--surface-lift)] px-4 py-2">
+          <InsetDetailCard title={t("scheduleDetail.details")}>
+            <div className="space-y-2">
               {schedule.cadenceDescription ? (
                 <InfoRow
                   label={t("scheduleDetail.cadence")}
@@ -627,12 +624,11 @@ export function ScheduleDetailPanel({
                 />
               ) : null}
             </div>
-          </section>
+          </InsetDetailCard>
 
           <StatCards usage={usage} />
 
-          <section>
-            <SectionLabel>{t("scheduleDetail.recentRuns")}</SectionLabel>
+          <InsetDetailCard title={t("scheduleDetail.recentRuns")}>
             <RecentRuns
               runs={runs?.runs}
               isLoading={isLoading}
@@ -641,7 +637,7 @@ export function ScheduleDetailPanel({
                 navigateToConversation(navigate, conversationId)
               }
             />
-          </section>
+          </InsetDetailCard>
         </div>
 
         {/* Footer actions */}

--- a/clients/web/src/domains/schedules/components/system-task-detail-panel.tsx
+++ b/clients/web/src/domains/schedules/components/system-task-detail-panel.tsx
@@ -3,6 +3,7 @@ import { Loader2, Play, Settings } from "lucide-react";
 import { useNavigate } from "react-router";
 
 import { DetailShellHeader } from "@/components/detail-shell";
+import { InsetDetailCard } from "@/components/inset-detail-card";
 import { useTranslation } from "@/i18n";
 import { SCHEDULE_RUNS_PAGE_SIZE } from "@/domains/settings/api/schedules";
 import { ModelProfileRow } from "@/domains/settings/components/model-profile-row";
@@ -23,9 +24,11 @@ import {
   retrospectiveRunsGetInfiniteOptions,
 } from "@/generated/daemon/@tanstack/react-query.gen";
 import { routes } from "@/utils/routes";
-import { Button, Typography, cn } from "@vellumai/design-library";
+import { Button, cn } from "@vellumai/design-library";
 import { Notice } from "@vellumai/design-library/components/notice";
 import { Toggle } from "@vellumai/design-library/components/toggle";
+
+import type { ReactNode } from "react";
 
 import type { SystemTaskKind } from "@/domains/settings/types/schedules";
 import type { ResolvableCallSite } from "@/hooks/use-call-site-default-profile";
@@ -40,21 +43,26 @@ const SYSTEM_TASK_PROFILE_CALL_SITES: Record<
   retrospective: "memoryRetrospective",
 };
 
+/**
+ * One label/value line in the Details card. `min-h-6` pins every row to 24px
+ * whatever sits in the value slot, so the 16px toggle on Status and the plain
+ * text on the other rows keep one rhythm. The value slot is itself a flex row
+ * so a control can sit beside its text.
+ */
+function InfoRow({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <div className="flex min-h-6 items-center justify-between gap-4">
+      <span className="shrink-0 text-[var(--content-secondary)]">{label}</span>
+      <span className="flex min-w-0 items-center justify-end gap-2 text-right text-[var(--content-default)]">
+        {value}
+      </span>
+    </div>
+  );
+}
+
 type SystemTasksData = ReturnType<
   typeof import("@/domains/settings/hooks/use-system-tasks").useSystemTasks
 >;
-
-function SectionLabel({ children }: { children: string }) {
-  return (
-    <Typography
-      variant="label-small-default"
-      as="div"
-      className="mb-2 uppercase tracking-wider text-[var(--content-tertiary)]"
-    >
-      {children}
-    </Typography>
-  );
-}
 
 export interface SystemTaskDetailPanelProps {
   kind: SystemTaskKind;
@@ -200,26 +208,7 @@ export function SystemTaskDetailPanel({
       )}
     >
       <DetailShellHeader
-        titleNode={
-          <div className="min-w-0 flex-1">
-            <Typography
-              variant="title-medium"
-              title={name}
-              className="truncate py-0.5 leading-snug text-[var(--content-default)]"
-            >
-              {name}
-            </Typography>
-            {subtitle ? (
-              <Typography
-                variant="body-small-default"
-                as="p"
-                className="truncate text-[var(--content-tertiary)]"
-              >
-                {subtitle}
-              </Typography>
-            ) : null}
-          </div>
-        }
+        title={name}
         closeLabel={t("scheduleDetail.closeAria")}
         closeTooltip={t("scheduleDetail.close")}
         onClose={onClose}
@@ -227,49 +216,59 @@ export function SystemTaskDetailPanel({
 
       {/* Scrollable body */}
       <div className="flex-1 space-y-6 overflow-y-auto px-[var(--app-spacing-lg)] py-[var(--app-spacing-lg)]">
-        <section>
-          <SectionLabel>{t("scheduleDetail.details")}</SectionLabel>
-          <div className="space-y-2 rounded-lg border border-[var(--border-base)] bg-[var(--surface-lift)] px-4 py-3 text-body-medium-lighter">
-            <ModelProfileRow
-              assistantId={assistantId}
-              defaultCallSite={SYSTEM_TASK_PROFILE_CALL_SITES[kind]}
-              fallbackLabel={t("systemTaskDetail.fallbackModelProfile")}
-              respectCallSiteOverride
-            />
-            <div className="flex items-center justify-between gap-4">
-              <span className="text-[var(--content-secondary)]">
-                {t("scheduleDetail.status")}
-              </span>
-              <span className="flex items-center gap-2 text-[var(--content-default)]">
-                <span>{statusValue}</span>
-                {!isMemoryManaged ? (
-                  <Toggle
-                    checked={enabled}
-                    onChange={systemTasks.toggleHeartbeat}
-                    aria-label={t("scheduleDetail.toggleAria", { name })}
-                  />
-                ) : null}
-              </span>
+        <div>
+          <InsetDetailCard title={t("scheduleDetail.details")}>
+            <div className="space-y-2 text-body-medium-lighter">
+              <InfoRow
+                label={t("scheduleDetail.status")}
+                value={
+                  <>
+                    <span className="truncate">{statusValue}</span>
+                    {!isMemoryManaged ? (
+                      <Toggle
+                        size="sm"
+                        checked={enabled}
+                        onChange={systemTasks.toggleHeartbeat}
+                        aria-label={t("scheduleDetail.toggleAria", { name })}
+                      />
+                    ) : null}
+                  </>
+                }
+              />
+              <ModelProfileRow
+                assistantId={assistantId}
+                defaultCallSite={SYSTEM_TASK_PROFILE_CALL_SITES[kind]}
+                fallbackLabel={t("systemTaskDetail.fallbackModelProfile")}
+                respectCallSiteOverride
+              />
+              {/* The task's cadence, e.g. "Every 1 hr". Omitted until the config
+                query resolves, rather than rendering a labelled blank. */}
+              {subtitle ? (
+                <InfoRow
+                  label={t("systemTaskDetail.repeats")}
+                  value={<span className="truncate">{subtitle}</span>}
+                />
+              ) : null}
+              {!isRetrospective ? (
+                <InfoRow
+                  label={t("scheduleDetail.nextRun")}
+                  value={
+                    <span className="truncate">
+                      {formatTimestamp(nextRunAt)}
+                    </span>
+                  }
+                />
+              ) : null}
+              <InfoRow
+                label={t("scheduleDetail.lastRun")}
+                value={
+                  <span className="truncate">
+                    {formatTimestamp(lastRunAtDisplay)}
+                  </span>
+                }
+              />
             </div>
-            {!isRetrospective ? (
-              <div className="flex items-center justify-between gap-4">
-                <span className="text-[var(--content-secondary)]">
-                  {t("scheduleDetail.nextRun")}
-                </span>
-                <span className="text-[var(--content-default)]">
-                  {formatTimestamp(nextRunAt)}
-                </span>
-              </div>
-            ) : null}
-            <div className="flex items-center justify-between gap-4">
-              <span className="text-[var(--content-secondary)]">
-                {t("scheduleDetail.lastRun")}
-              </span>
-              <span className="text-[var(--content-default)]">
-                {formatTimestamp(lastRunAtDisplay)}
-              </span>
-            </div>
-          </div>
+          </InsetDetailCard>
           {isMemoryPaused ? (
             <Notice
               tone="warning"
@@ -293,7 +292,7 @@ export function SystemTaskDetailPanel({
               {pausedNotice}
             </Notice>
           ) : null}
-        </section>
+        </div>
 
         <RecentRunsCard
           runs={runs}

--- a/clients/web/src/domains/settings/ai/profile-detail-panel.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-detail-panel.test.tsx
@@ -254,11 +254,8 @@ describe("ProfileDetailPanel - managed profiles", () => {
         (b) => b.textContent?.trim() === "Save As New",
       ),
     ).toBe(true);
-    expect(
-      Array.from(document.querySelectorAll("button")).some(
-        (b) => b.textContent?.trim() === "Delete",
-      ),
-    ).toBe(false);
+    // The header Delete is icon-only, so it is addressed by accessible name.
+    expect(document.querySelector('button[aria-label="Delete"]')).toBeNull();
   });
 });
 
@@ -290,6 +287,8 @@ describe("ProfileDetailPanel - edit flow", () => {
     // Editable, with the panel footer's Save Changes and a header Delete.
     expect(getInputByPlaceholder("e.g. Fast & Cheap").disabled).toBe(false);
     expect(getButton("Save Changes")).toBeDefined();
-    expect(getButton("Delete")).toBeDefined();
+    expect(
+      document.querySelector('button[aria-label="Delete"]'),
+    ).not.toBeNull();
   });
 });

--- a/clients/web/src/domains/settings/ai/profile-detail-panel.tsx
+++ b/clients/web/src/domains/settings/ai/profile-detail-panel.tsx
@@ -1,4 +1,4 @@
-import { Trash2 } from "lucide-react";
+import { Loader2, Trash2 } from "lucide-react";
 import { useEffect, useMemo } from "react";
 
 import { useQuery } from "@tanstack/react-query";
@@ -117,7 +117,9 @@ export function ProfileDetailPanel({
   const title =
     editor.effectiveMode === "create"
       ? t("profileDetailPanel.newProfileTitle")
-      : (initialValues?.label ?? profileName ?? t("profileDetailPanel.defaultTitle"));
+      : (initialValues?.label ??
+        profileName ??
+        t("profileDetailPanel.defaultTitle"));
 
   return (
     <>
@@ -134,18 +136,28 @@ export function ProfileDetailPanel({
           editor.effectiveMode !== "create" && !editor.isReadOnly ? (
             <Button
               variant="dangerOutline"
-              leftIcon={<Trash2 />}
+              // Icon-only, so the in-flight state rides the glyph and the
+              // accessible name rather than a visible "Deleting…" label.
+              iconOnly={
+                deletePending ? (
+                  <Loader2 className="animate-spin" />
+                ) : (
+                  <Trash2 />
+                )
+              }
+              aria-label={
+                deletePending
+                  ? t("profileDetailPanel.deleting")
+                  : t("profileDetailPanel.delete")
+              }
+              tooltip={t("profileDetailPanel.delete")}
               onClick={() => {
                 if (profileName != null) {
                   deleteFlow.requestDelete(profileName);
                 }
               }}
               disabled={editor.saving || deletePending}
-            >
-              {deletePending
-                ? t("profileDetailPanel.deleting")
-                : t("profileDetailPanel.delete")}
-            </Button>
+            />
           ) : null
         }
         footer={

--- a/clients/web/src/domains/settings/ai/provider-create-form.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useRef, useState, type ReactNode } from "react";
+import { createPortal } from "react-dom";
 
 import { useQueryClient } from "@tanstack/react-query";
 import { Button } from "@vellumai/design-library/components/button";
@@ -75,6 +76,14 @@ export interface ProviderCreateFormProps {
   onCancel: () => void;
   /** "modal" wraps the form in Modal chrome; "inline" drops it for embedding. */
   variant?: "modal" | "inline";
+  /**
+   * Where the Cancel/Add row renders, for `variant="inline"` hosts that pin
+   * their actions outside the scrollable body (see `DetailShell`'s `footer`).
+   * Omit to keep the row inline at the end of the fields; pass the element to
+   * portal into it. `null` means the host's slot has not mounted yet, so the
+   * row is withheld for that one commit rather than rendered in both places.
+   */
+  actionsSlot?: HTMLElement | null;
 }
 
 export function ProviderCreateForm({
@@ -86,6 +95,7 @@ export function ProviderCreateForm({
   onCreated,
   onCancel,
   variant = "modal",
+  actionsSlot,
 }: ProviderCreateFormProps) {
   const { t } = useTranslation("settings");
   const selectableConnectionProviders = useSelectableConnectionProviders();
@@ -578,7 +588,11 @@ export function ProviderCreateForm({
     return (
       <div className="space-y-4">
         {body}
-        <div className="flex justify-end gap-2">{footer}</div>
+        {actionsSlot === undefined ? (
+          <div className="flex justify-end gap-2">{footer}</div>
+        ) : (
+          actionsSlot && createPortal(footer, actionsSlot)
+        )}
       </div>
     );
   }

--- a/clients/web/src/domains/settings/ai/provider-detail-panel.tsx
+++ b/clients/web/src/domains/settings/ai/provider-detail-panel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
@@ -35,6 +35,10 @@ export function ProviderDetailPanel({
 }: ProviderDetailPanelProps) {
   const { t } = useTranslation("settings");
   const queryClient = useQueryClient();
+  // Set by the footer row's callback ref, then handed to the editor as its
+  // portal target. Null on the first render, so the actions land one commit
+  // after the body.
+  const [actionsSlot, setActionsSlot] = useState<HTMLDivElement | null>(null);
   const { data } = useQuery(
     inferenceProviderconnectionsGetOptions({
       path: { assistant_id: assistantId },
@@ -86,6 +90,10 @@ export function ProviderDetailPanel({
       }
       closeVariant="outlined"
       onClose={onClose}
+      // The editor owns the save state, so rather than lifting it we hand it
+      // this row to portal its Cancel/Save into. That puts the actions in the
+      // shell's pinned footer, matching `ProfileDetailPanel`.
+      footer={<div ref={setActionsSlot} className="flex justify-end gap-2" />}
     >
       {/* Wait for the list before mounting an edit session so the editor
           never snapshots an absent connection. The add flow has no
@@ -95,6 +103,7 @@ export function ProviderDetailPanel({
           mode={connection ? "edit" : "create"}
           connection={connection}
           variant="panel"
+          actionsSlot={actionsSlot}
           assistantId={assistantId}
           existingNames={connections.map((c) => c.name)}
           connections={connections}

--- a/clients/web/src/domains/settings/ai/provider-editor-content.tsx
+++ b/clients/web/src/domains/settings/ai/provider-editor-content.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
 
 import { useQueryClient } from "@tanstack/react-query";
 import { Button } from "@vellumai/design-library/components/button";
@@ -57,6 +58,14 @@ export interface ProviderEditorContentProps {
    * the settings sidepanel (DetailShell body).
    */
   variant?: "modal" | "panel";
+  /**
+   * Where the Cancel/Save row renders, for `variant="panel"` hosts that pin
+   * their actions outside the scrollable body (see `DetailShell`'s `footer`).
+   * Omit to keep the row inline at the end of the fields; pass the element to
+   * portal into it. `null` means the host's slot has not mounted yet, so the
+   * row is withheld for that one commit rather than rendered in both places.
+   */
+  actionsSlot?: HTMLElement | null;
   onSave: (connection: ProviderConnection) => void;
   onCancel: () => void;
 }
@@ -68,6 +77,7 @@ export function ProviderEditorContent({
   existingNames,
   connections,
   variant = "modal",
+  actionsSlot,
   onSave,
   onCancel,
 }: ProviderEditorContentProps) {
@@ -313,6 +323,7 @@ export function ProviderEditorContent({
     return (
       <ProviderCreateForm
         variant={variant === "panel" ? "inline" : "modal"}
+        actionsSlot={actionsSlot}
         assistantId={assistantId}
         existingNames={existingNames}
         connections={connections}
@@ -444,7 +455,11 @@ export function ProviderEditorContent({
     return (
       <div className="space-y-4">
         {body}
-        <div className="flex justify-end gap-2">{footer}</div>
+        {actionsSlot === undefined ? (
+          <div className="flex justify-end gap-2">{footer}</div>
+        ) : (
+          actionsSlot && createPortal(footer, actionsSlot)
+        )}
       </div>
     );
   }

--- a/clients/web/src/domains/settings/components/model-profile-row.tsx
+++ b/clients/web/src/domains/settings/components/model-profile-row.tsx
@@ -85,9 +85,18 @@ export function ModelProfileRow({
           : fallbackLabel;
 
   return (
-    <div className="flex items-center justify-between gap-4">
-      <span className="text-[var(--content-secondary)]">Model profile</span>
-      <span className="min-w-0 text-right">{profileLabel}</span>
+    // `min-h-6` matches the sibling rows in the schedules detail cards. The
+    // value truncates rather than wrapping: the label resolves from a query,
+    // so a wrap would grow the row after mount, and the long forms ("Default
+    // (assistant's main model)") wrap in a sidepanel-width card. `title`
+    // keeps the full text reachable on hover.
+    <div className="flex min-h-6 items-center justify-between gap-4">
+      <span className="shrink-0 text-[var(--content-secondary)]">
+        Model profile
+      </span>
+      <span className="min-w-0 truncate text-right" title={profileLabel}>
+        {profileLabel}
+      </span>
     </div>
   );
 }

--- a/clients/web/src/domains/settings/components/recent-runs-card.tsx
+++ b/clients/web/src/domains/settings/components/recent-runs-card.tsx
@@ -2,7 +2,7 @@ import { ChevronRight, Loader2 } from "lucide-react";
 import { useState } from "react";
 import { useNavigate } from "react-router";
 
-import { DetailCard } from "@/components/detail-card";
+import { InsetDetailCard } from "@/components/inset-detail-card";
 import { StatusDot } from "@/domains/settings/components/schedule-shared-ui";
 import {
   formatDuration,
@@ -63,7 +63,7 @@ export function RecentRunsCard({
     ) : null;
 
   return (
-    <DetailCard title="Recent runs">
+    <InsetDetailCard title="Recent runs">
       {isLoading ? (
         <div className="flex items-center justify-center py-8">
           <Loader2 className="h-5 w-5 animate-spin text-stone-400" />
@@ -184,6 +184,6 @@ export function RecentRunsCard({
           {loadMoreControl}
         </div>
       )}
-    </DetailCard>
+    </InsetDetailCard>
   );
 }

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -1,4 +1,8 @@
 {
+  "activityStepsPanel": {
+    "backAria": "Back to all steps",
+    "backTooltip": "All steps"
+  },
   "addToChatSheet": {
     "title": "Add to chat",
     "closeAriaLabel": "Close",
@@ -143,6 +147,9 @@
   "copyButton": {
     "copied": "Copied",
     "copyFailed": "Could not copy to the clipboard."
+  },
+  "detailPanelStopButton": {
+    "tooltip": "Stop"
   },
   "exportProgressModal": {
     "cancel": "Cancel",
@@ -491,6 +498,10 @@
   "sidebarConversationError": {
     "message": "Your conversations failed to load.",
     "retry": "Try again"
+  },
+  "skillDetailPanel": {
+    "actionsAria": "Skill actions",
+    "moreTooltip": "More"
   },
   "skillsTab": {
     "callLink": "Call {number}",

--- a/clients/web/src/i18n/locales/en/schedules.json
+++ b/clients/web/src/i18n/locales/en/schedules.json
@@ -64,6 +64,7 @@
     "turnOnMemory": "Turn on Memory",
     "memorySettings": "Memory settings",
     "fallbackModelProfile": "Default (system task model)",
+    "repeats": "Repeats",
     "nameHeartbeat": "Heartbeat",
     "nameConsolidation": "Consolidation",
     "nameRetrospective": "Memory retrospective",

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -1,4 +1,8 @@
 {
+  "activityStepsPanel": {
+    "backAria": "Volver a todos los pasos",
+    "backTooltip": "Todos los pasos"
+  },
   "addToChatSheet": {
     "title": "Añadir al chat",
     "closeAriaLabel": "Cerrar",
@@ -143,6 +147,9 @@
   "copyButton": {
     "copied": "Copiado",
     "copyFailed": "No se pudo copiar al portapapeles."
+  },
+  "detailPanelStopButton": {
+    "tooltip": "Detener"
   },
   "exportProgressModal": {
     "cancel": "Cancelar",
@@ -491,6 +498,10 @@
   "sidebarConversationError": {
     "message": "No se pudieron cargar tus conversaciones.",
     "retry": "Reintentar"
+  },
+  "skillDetailPanel": {
+    "actionsAria": "Acciones de habilidad",
+    "moreTooltip": "Más"
   },
   "skillsTab": {
     "callLink": "Llamada {number}",

--- a/clients/web/src/i18n/locales/es/schedules.json
+++ b/clients/web/src/i18n/locales/es/schedules.json
@@ -64,6 +64,7 @@
     "turnOnMemory": "Activar Memoria",
     "memorySettings": "Configuración de Memoria",
     "fallbackModelProfile": "Predeterminado (modelo de tareas del sistema)",
+    "repeats": "Se repite",
     "nameHeartbeat": "Latido",
     "nameConsolidation": "Consolidación",
     "nameRetrospective": "Retrospectiva de memoria",

--- a/packages/design-library/src/components/toggle.stories.tsx
+++ b/packages/design-library/src/components/toggle.stories.tsx
@@ -6,10 +6,17 @@ import { Toggle } from "./toggle";
 const meta: Meta<typeof Toggle> = {
   title: "Components/Toggle",
   component: Toggle,
+  argTypes: {
+    size: { control: "inline-radio", options: ["md", "sm"] },
+    onChange: { control: false },
+  },
   args: {
     checked: false,
     label: "Airplane mode",
     disabled: false,
+    // Mirrors the component's own default, so Controls opens on the real
+    // starting value instead of a blank size.
+    size: "md",
   },
   // Controlled: drive `checked` from the arg and write it back on change so
   // the Controls panel and canvas stay in sync.

--- a/packages/design-library/src/components/toggle.stories.tsx
+++ b/packages/design-library/src/components/toggle.stories.tsx
@@ -64,3 +64,39 @@ export const AllStates: Story = {
 export const NoLabel: Story = {
   args: { label: undefined, "aria-label": "Standalone toggle" },
 };
+
+/** The 16px-track size, for dense rows (e.g. inside a sidepanel details card). */
+export const Small: Story = {
+  args: { size: "sm", checked: true, label: "Airplane mode" },
+};
+
+/**
+ * Both sizes together. `md` (24px track) is the page-level default; `sm`
+ * (16px) is for dense contexts. Each is shown off and on, since the knob
+ * offset is derived per size.
+ */
+export const Sizes: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+      <Toggle
+        checked={false}
+        label="md - off (24px track)"
+        onChange={() => {}}
+      />
+      <Toggle checked label="md - on (24px track)" onChange={() => {}} />
+      <Toggle
+        size="sm"
+        checked={false}
+        label="sm - off (16px track)"
+        onChange={() => {}}
+      />
+      <Toggle
+        size="sm"
+        checked
+        label="sm - on (16px track)"
+        onChange={() => {}}
+      />
+    </div>
+  ),
+};

--- a/packages/design-library/src/components/toggle.tsx
+++ b/packages/design-library/src/components/toggle.tsx
@@ -3,6 +3,8 @@ import { type ReactNode, useId } from "react";
 import { Typography } from "./typography";
 import { cn } from "../utils/cn";
 
+export type ToggleSize = "md" | "sm";
+
 export interface ToggleProps {
   checked: boolean;
   onChange: (next: boolean) => void;
@@ -12,7 +14,25 @@ export interface ToggleProps {
   id?: string;
   "aria-label"?: string;
   className?: string;
+  /**
+   * Track height. `md` (24px) is the page-level default; `sm` (16px) suits
+   * dense contexts such as a row inside a sidepanel's details card.
+   */
+  size?: ToggleSize;
 }
+
+/**
+ * Per-size geometry. The knob insets 2px on every edge, so the checked
+ * offset is always `track width − knob − 2×inset`: 36−20−4=12 at `md`,
+ * 24−12−4=8 at `sm`.
+ */
+const SIZES: Record<
+  ToggleSize,
+  { track: string; knob: string; translate: string }
+> = {
+  md: { track: "h-6 w-9", knob: "h-5 w-5", translate: "translate-x-3" },
+  sm: { track: "h-4 w-6", knob: "h-3 w-3", translate: "translate-x-2" },
+};
 
 /**
  * Pure click-handler contract used by the `<button>` and verifiable in tests
@@ -28,8 +48,9 @@ export function handleToggleClick(
 }
 
 /**
- * On/off toggle switch. Track is 36×24 px with a 20×20 px knob offset 2 px
- * from the edges. Uses CSS variable tokens for light/dark theming.
+ * On/off toggle switch. Two sizes, both with the knob inset 2 px from the
+ * track edges: `md` is a 36×24 px track with a 20 px knob, `sm` a 24×16 px
+ * track with a 12 px knob. Uses CSS variable tokens for light/dark theming.
  */
 export function Toggle({
   checked,
@@ -40,6 +61,7 @@ export function Toggle({
   id,
   "aria-label": ariaLabel,
   className,
+  size = "md",
 }: ToggleProps) {
   const reactId = useId();
   const buttonId = id ?? reactId;
@@ -48,8 +70,11 @@ export function Toggle({
 
   const toggle = () => handleToggleClick(checked, disabled, onChange);
 
+  const geometry = SIZES[size];
+
   const trackClasses = cn(
-    "relative inline-flex h-6 w-9 shrink-0 items-center rounded-full transition-colors",
+    "relative inline-flex shrink-0 items-center rounded-full transition-colors",
+    geometry.track,
     "keyboard-focus:outline-none keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)] keyboard-focus:ring-offset-2",
     disabled
       ? "cursor-not-allowed bg-[var(--primary-disabled)]"
@@ -59,9 +84,10 @@ export function Toggle({
   );
 
   const knobClasses = cn(
-    "absolute top-0.5 inline-block h-5 w-5 rounded-full shadow transition-transform",
+    "absolute top-0.5 left-0.5 inline-block rounded-full shadow transition-transform",
+    geometry.knob,
     disabled ? "bg-[var(--content-disabled)]" : "bg-[var(--aux-white)]",
-    checked ? "left-0.5 translate-x-3" : "left-0.5 translate-x-0",
+    checked ? geometry.translate : "translate-x-0",
   );
 
   const toggleButton = (
@@ -83,7 +109,11 @@ export function Toggle({
   );
 
   if (!label && !helperText) {
-    return <span data-slot="toggle" className={className}>{toggleButton}</span>;
+    return (
+      <span data-slot="toggle" className={className}>
+        {toggleButton}
+      </span>
+    );
   }
 
   return (


### PR DESCRIPTION
Follow-up to #40639, which unified sidepanel header height and typography. This pass takes the same treatment into the panel bodies and the remaining header controls.

Inset cards. DetailCard is a page-level component (20px title, 16px corners) and read wrong nested inside a panel, so add InsetDetailCard: a 16px title on 12px corners for sidepanels, modals, and anything already inside a card. Migrate the schedules, system-task, and recent-runs sections onto it, and give both cards Storybook coverage.

Row rhythm. The schedules detail cards ran two different row models: 18px content boxes in one panel, 26px py-1 rows in the other, and a Model profile value that wrapped to two lines once its query resolved. Pin every row to a 24px min-height with the gap owned by the enclosing stack, and truncate the profile label (full text stays on hover via title).

Header actions. Stop and Delete become icon-only outlined buttons, the skill panel's More menu matches the Close button's variant and tooltip, and the activity-steps back button moves into the icon slot so it stops being clipped by the title cluster's overflow-hidden. Back buttons standardize on ChevronLeft, and the Stop glyph is outlined to match every other icon.

Provider editor. Cancel and Save move to a pinned footer via a portal, so the provider panel matches the profile panel instead of scrolling its actions with the form.

Toggle. Add a 16px `sm` size for dense rows and use it on the system task Status row. `md` stays the default, so no existing call site changes.

<!-- PR title format: type(scope): description -->
<!-- Examples: feat(slack): add user token support, fix(cli): handle missing config, docs(architecture): update API table -->

## Prompt / plan
<!-- What prompt or plan was used to generate this code? Link to a plan file, paste the prompt, or describe the approach. -->

## Test plan
<!-- How was this change verified? e.g. unit tests, manual testing, CI checks -->

## CLI verb checklist
<!-- For PRs that add a new IPC route under assistant/src/runtime/routes/: -->
<!-- - [ ] Does this route need an `assistant` CLI verb? If yes, add a thin -->
<!--       wrapper in assistant/src/cli/commands/ via registerCommand (same -->
<!--       PR or a follow-up). -->
<!-- - [ ] If no, leave a one-line note explaining why (e.g. internal-only, -->
<!--       composed by another command). -->
<!-- Delete this section if your PR does not add any new routes. -->
