### PR TITLE
fix(voice): filtered stream for call side effects; shared, index-exact tag scanning (#40673 follow-ups)

### DIFF
--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -730,8 +730,10 @@ export class CallController {
     let ttsBuffer = "";
     let fullResponseText = "";
     // Reasoning models can inline <think> spans in the content stream when a
-    // profile has not opted into parseThinkTags; the spoken path must never
-    // read them aloud. fullResponseText keeps the raw stream.
+    // profile has not opted into parseThinkTags. Neither the spoken path nor
+    // the post-turn consumers of fullResponseText (transcripts,
+    // assistant_spoke, END_CALL/ASK_GUARDIAN detection) may see them: both
+    // are fed only filtered text.
     const reasoningFilter = createReasoningTagFilter();
 
     // Synthesized path: text is split at speakable boundaries as it streams
@@ -935,11 +937,10 @@ export class CallController {
         if (!this.isCurrentRun(runVersion)) {
           return;
         }
-        // One filter feeds BOTH consumers: the spoken stream and the text
+        // One filter feeds both consumers: the spoken stream and the text
         // used for transcripts, assistant_spoke, and END_CALL/ASK_GUARDIAN
-        // marker detection. A control marker the model writes inside a
-        // reasoning span must not trigger a real action the caller never
-        // heard (review: Codex P1 on #40673).
+        // marker detection. A control marker inside a reasoning span must
+        // never trigger a real action the caller did not hear.
         const speakable = reasoningFilter.push(text);
         fullResponseText += speakable;
         ttsBuffer += speakable;

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -935,8 +935,14 @@ export class CallController {
         if (!this.isCurrentRun(runVersion)) {
           return;
         }
-        fullResponseText += text;
-        ttsBuffer += reasoningFilter.push(text);
+        // One filter feeds BOTH consumers: the spoken stream and the text
+        // used for transcripts, assistant_spoke, and END_CALL/ASK_GUARDIAN
+        // marker detection. A control marker the model writes inside a
+        // reasoning span must not trigger a real action the caller never
+        // heard (review: Codex P1 on #40673).
+        const speakable = reasoningFilter.push(text);
+        fullResponseText += speakable;
+        ttsBuffer += speakable;
         ttsBuffer = stripInternalSpeechMarkers(ttsBuffer);
         flushSafeText();
       };
@@ -1015,9 +1021,11 @@ export class CallController {
       return fullResponseText;
     }
 
-    // Final sweep: release any held-back partial tag, then strip any
-    // remaining control markers from the buffer.
-    ttsBuffer += reasoningFilter.flush();
+    // Final sweep: release any held-back partial tag to both consumers,
+    // then strip any remaining control markers from the buffer.
+    const filterTail = reasoningFilter.flush();
+    fullResponseText += filterTail;
+    ttsBuffer += filterTail;
     ttsBuffer = stripInternalSpeechMarkers(ttsBuffer);
     if (ttsBuffer.length > 0) {
       emitSafeChunk(ttsBuffer);

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -5,6 +5,7 @@ import { isAbortReason } from "../../util/abort-reasons.js";
 import { ProviderError, type ProviderErrorReason } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
 import { extractRetryAfterMs } from "../../util/retry.js";
+import { partialTagSuffix as sharedPartialTagSuffix } from "../../util/think-tag-stream.js";
 import { escapeXmlAttr } from "../../util/xml.js";
 import {
   base64Source,
@@ -293,13 +294,11 @@ const OPENAI_SUPPORTED_IMAGE_TYPES = new Set([
   "image/webp",
 ]);
 
+// Think-tag scanning primitives are shared with the TTS reasoning filter
+// (util/think-tag-stream.ts) so the two stream parsers cannot drift. This
+// provider keeps its exact historical behavior: case-sensitive, <think> only.
 function partialTagSuffix(text: string, tag: string): number {
-  for (let len = Math.min(text.length, tag.length - 1); len > 0; len--) {
-    if (text.endsWith(tag.substring(0, len))) {
-      return len;
-    }
-  }
-  return 0;
+  return sharedPartialTagSuffix(text, [tag], false);
 }
 
 /**

--- a/assistant/src/tts/__tests__/reasoning-tag-filter.test.ts
+++ b/assistant/src/tts/__tests__/reasoning-tag-filter.test.ts
@@ -60,4 +60,19 @@ describe("ReasoningTagFilter", () => {
   test("holds back nothing across an empty stream", () => {
     expect(run([""])).toBe("");
   });
+
+  test("does not shift indexes for characters whose lowercase form is longer", () => {
+    // U+0130 (dotted capital I) lowers to two code units; positional
+    // scanning must never lowercase the haystack wholesale.
+    expect(run(["\u0130stanbul rocks. <think>hidden</think> Done."])).toBe(
+      "\u0130stanbul rocks.  Done.",
+    );
+    expect(run(["\u0130\u0130\u0130<THINK>x</THINK>ok"])).toBe(
+      "\u0130\u0130\u0130ok",
+    );
+  });
+
+  test("prefers the longer tag when both match at one index", () => {
+    expect(run(["a<thinking>x</thinking>b"])).toBe("ab");
+  });
 });

--- a/assistant/src/tts/reasoning-tag-filter.ts
+++ b/assistant/src/tts/reasoning-tag-filter.ts
@@ -18,38 +18,17 @@
  * Display paths are deliberately untouched: `assistant_text_delta` frames
  * keep the raw text, exactly like the markdown handling in
  * `calls/tts-text-sanitizer.ts`.
+ *
+ * Tag scanning lives in `util/think-tag-stream.ts`, shared with the
+ * chat-completions provider's think-tag router, and is positionally exact
+ * on the original string (no full-string lowercasing, which shifts indexes
+ * for characters like the dotted capital I).
  */
+
+import { indexOfTag, partialTagSuffix } from "../util/think-tag-stream.js";
 
 const OPEN_TAGS = ["<think>", "<thinking>"] as const;
 const CLOSE_TAGS = ["</think>", "</thinking>"] as const;
-
-/** Longest suffix of `text` that is a proper prefix of any listed tag. */
-function partialTagSuffix(text: string, tags: readonly string[]): number {
-  const max = Math.max(...tags.map((tag) => tag.length)) - 1;
-  const window = Math.min(max, text.length);
-  for (let len = window; len > 0; len -= 1) {
-    const suffix = text.slice(text.length - len).toLowerCase();
-    if (tags.some((tag) => tag.startsWith(suffix))) {
-      return len;
-    }
-  }
-  return 0;
-}
-
-function indexOfAny(
-  haystack: string,
-  tags: readonly string[],
-): { index: number; tag: string } | null {
-  const lower = haystack.toLowerCase();
-  let best: { index: number; tag: string } | null = null;
-  for (const tag of tags) {
-    const index = lower.indexOf(tag);
-    if (index >= 0 && (best === null || index < best.index)) {
-      best = { index, tag };
-    }
-  }
-  return best;
-}
 
 export class ReasoningTagFilter {
   private insideReasoning = false;
@@ -65,7 +44,7 @@ export class ReasoningTagFilter {
     let out = "";
     for (;;) {
       if (this.insideReasoning) {
-        const close = indexOfAny(this.pending, CLOSE_TAGS);
+        const close = indexOfTag(this.pending, CLOSE_TAGS, true);
         if (close) {
           this.pending = this.pending.slice(close.index + close.tag.length);
           this.insideReasoning = false;
@@ -73,18 +52,18 @@ export class ReasoningTagFilter {
         }
         // Everything buffered is reasoning except a possible partial close
         // tag at the end; drop the reasoning, keep the partial.
-        const partial = partialTagSuffix(this.pending, CLOSE_TAGS);
+        const partial = partialTagSuffix(this.pending, CLOSE_TAGS, true);
         this.pending = partial > 0 ? this.pending.slice(-partial) : "";
         return out;
       }
-      const open = indexOfAny(this.pending, OPEN_TAGS);
+      const open = indexOfTag(this.pending, OPEN_TAGS, true);
       if (open) {
         out += this.pending.slice(0, open.index);
         this.pending = this.pending.slice(open.index + open.tag.length);
         this.insideReasoning = true;
         continue;
       }
-      const partial = partialTagSuffix(this.pending, OPEN_TAGS);
+      const partial = partialTagSuffix(this.pending, OPEN_TAGS, true);
       const safeLength = this.pending.length - partial;
       out += this.pending.slice(0, safeLength);
       this.pending = partial > 0 ? this.pending.slice(safeLength) : "";

--- a/assistant/src/util/think-tag-stream.ts
+++ b/assistant/src/util/think-tag-stream.ts
@@ -1,0 +1,95 @@
+/**
+ * Shared primitives for streaming think-tag scanning.
+ *
+ * Two consumers parse inline `<think>` spans out of streamed model content
+ * and must not drift apart (single source of truth):
+ *
+ * - `providers/openai/chat-completions-provider.ts` ROUTES the spans to
+ *   `thinking_delta` events (content preserved, case-sensitive `<think>`
+ *   only, matching the models that emit it).
+ * - `tts/reasoning-tag-filter.ts` DROPS the spans from the spoken stream
+ *   (case-insensitive, `<think>` and `<thinking>` variants).
+ *
+ * The state machines stay separate because they do different things with
+ * the reasoning; what they share is the tag scanning below. All scanning is
+ * positionally exact on the ORIGINAL string: case-insensitive mode folds
+ * A-Z per character code and never calls `toLowerCase()` on the haystack,
+ * because Unicode lowercasing can change string length (e.g. dotted capital
+ * I, U+0130, lowers to two code units) and shift every subsequent index.
+ * Tags must be given in lowercase ASCII.
+ */
+
+function foldedCharCode(code: number, caseInsensitive: boolean): number {
+  return caseInsensitive && code >= 65 && code <= 90 ? code + 32 : code;
+}
+
+function tagMatchesAt(
+  haystack: string,
+  start: number,
+  tag: string,
+  caseInsensitive: boolean,
+): boolean {
+  if (start + tag.length > haystack.length) {
+    return false;
+  }
+  for (let k = 0; k < tag.length; k += 1) {
+    if (
+      foldedCharCode(haystack.charCodeAt(start + k), caseInsensitive) !==
+      tag.charCodeAt(k)
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * First occurrence of any tag in `haystack`, by original-string index.
+ * When several tags match at the same index the longest wins, so
+ * `<thinking>` is not consumed as `<think>` plus stray text.
+ */
+export function indexOfTag(
+  haystack: string,
+  tags: readonly string[],
+  caseInsensitive: boolean,
+): { index: number; tag: string } | null {
+  for (let i = 0; i < haystack.length; i += 1) {
+    let bestTag: string | null = null;
+    for (const tag of tags) {
+      if (tagMatchesAt(haystack, i, tag, caseInsensitive)) {
+        if (bestTag === null || tag.length > bestTag.length) {
+          bestTag = tag;
+        }
+      }
+    }
+    if (bestTag !== null) {
+      return { index: i, tag: bestTag };
+    }
+  }
+  return null;
+}
+
+/**
+ * Length of the longest suffix of `text` that is a proper prefix of any
+ * listed tag. Streaming scanners hold that many characters back so a tag
+ * split across deltas is not emitted before it can be recognized.
+ */
+export function partialTagSuffix(
+  text: string,
+  tags: readonly string[],
+  caseInsensitive: boolean,
+): number {
+  const longest = Math.max(...tags.map((tag) => tag.length)) - 1;
+  for (let len = Math.min(text.length, longest); len > 0; len -= 1) {
+    const start = text.length - len;
+    for (const tag of tags) {
+      if (
+        len < tag.length &&
+        tagMatchesAt(text, start, tag.slice(0, len), caseInsensitive)
+      ) {
+        return len;
+      }
+    }
+  }
+  return 0;
+}


### PR DESCRIPTION
## TL;DR

Implements the three blocking findings from #40673's review (that PR merged before its fixes landed). The critical one: END_CALL/ASK_GUARDIAN marker detection ran on the raw stream, so a reasoning model writing a control marker *inside* a `<think>` span could hang up a call the caller never heard about. Typecheck + lint green; İ regression tests added; CI runs the suite.

## What changes

| #40673 finding | Fix |
| --- | --- |
| `fullResponseText` raw → transcripts, `assistant_spoke`, and END_CALL/ASK_GUARDIAN detectors saw unfiltered reasoning (Codex P1, blocking) | One filter feeds both `ttsBuffer` and `fullResponseText` (per-delta push + final-sweep flush to both). Spoken text and side-effect text are now the same stream |
| Turkish-İ index drift: `toLowerCase()` changes string length, shifting slice offsets (blocking) | New shared scanner is positionally exact on the original string via per-char ASCII folding; regression tests with U+0130 |
| Duplicated think-tag state machine vs chat-completions provider (blocking, Single Source of Truth) | New `util/think-tag-stream.ts` owns the scanning primitives (`indexOfTag`, `partialTagSuffix`), consumed by both. The FSMs stay separate deliberately — the provider ROUTES reasoning to `thinking_delta`, the filter DROPS it — and the provider keeps its exact historical behavior (case-sensitive, `<think>` only) |

Bonus correctness: longest-tag-wins at a match index, so `<thinking>` is no longer consumable as `<think>` + stray text when both are in the buffer.

## Non-blocking findings from the same review

Stray close-tag-only streams and unclosed-span muting remain documented trade-offs, per the review-thread discussion (accepted there; unchanged here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40701" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->