### PR TITLE
fix(web): decide the Contacts/Channels/Workspace list on the pane, not the window

### DIFF
--- a/clients/web/src/components/side-list-drawer.tsx
+++ b/clients/web/src/components/side-list-drawer.tsx
@@ -6,9 +6,6 @@ import { Button } from "@vellumai/design-library";
 import { useBodyScrollLock } from "@/hooks/use-body-scroll-lock";
 import { useSwipeHorizontal } from "@/hooks/use-swipe-horizontal";
 
-/** Tailwind `sm` breakpoint — matches the `sm:hidden` class on the drawer. */
-const SM_MEDIA_QUERY = "(min-width: 640px)";
-
 const FOCUSABLE_SELECTOR = [
   "a[href]",
   "button:not([disabled])",
@@ -18,7 +15,7 @@ const FOCUSABLE_SELECTOR = [
   '[tabindex]:not([tabindex="-1"])',
 ].join(",");
 
-interface MobileSidebarDrawerProps {
+interface SideListDrawerProps {
   open: boolean;
   onClose: () => void;
   children: ReactNode;
@@ -26,16 +23,23 @@ interface MobileSidebarDrawerProps {
 }
 
 /**
- * Full-screen overlay drawer for Kit section sidebars on small screens
- * (< 640px). Uses body scroll lock, Escape-to-close, and a focus trap.
- * Hidden at the sm breakpoint and above via CSS.
+ * Full-screen overlay drawer holding a list-detail pane's list while the pane
+ * is too narrow to seat it beside the detail. Uses body scroll lock,
+ * Escape-to-close, and a focus trap.
+ *
+ * The drawer never decides for itself whether it applies: `useSideListRoom()`
+ * owns that one boolean for both this and the inline list it substitutes for,
+ * and this is mounted only while the substitution is on. Hiding it in CSS
+ * instead would put the threshold in two places, and the gap between them is a
+ * width where the list has no surface at all. See
+ * `docs/PLATFORM_ADAPTATION.md`.
  */
-export function MobileSidebarDrawer({
+export function SideListDrawer({
   open,
   onClose,
   children,
   title,
-}: MobileSidebarDrawerProps) {
+}: SideListDrawerProps) {
   const drawerRef = useRef<HTMLDivElement | null>(null);
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
   const onCloseRef = useRef(onClose);
@@ -44,7 +48,7 @@ export function MobileSidebarDrawer({
   });
 
   // Swipe right-to-left on the panel to close. Complements the backdrop tap
-  // and the close button — all three call the same onClose.
+  // and the close button: all three call the same onClose.
   const {
     dragOffset,
     isDragging,
@@ -64,14 +68,6 @@ export function MobileSidebarDrawer({
       return;
     }
     closeButtonRef.current?.focus();
-
-    const mql = window.matchMedia(SM_MEDIA_QUERY);
-    const handleMediaChange = (e: MediaQueryListEvent) => {
-      if (e.matches) {
-        onCloseRef.current();
-      }
-    };
-    mql.addEventListener("change", handleMediaChange);
 
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape" && !event.defaultPrevented) {
@@ -106,7 +102,6 @@ export function MobileSidebarDrawer({
     document.addEventListener("keydown", onKeyDown);
     return () => {
       document.removeEventListener("keydown", onKeyDown);
-      mql.removeEventListener("change", handleMediaChange);
     };
   }, [open]);
 
@@ -117,7 +112,7 @@ export function MobileSidebarDrawer({
   return (
     <div
       ref={drawerRef}
-      className="fixed inset-0 sm:hidden"
+      className="fixed inset-0"
       style={{ zIndex: 40 }}
       role="dialog"
       aria-modal="true"
@@ -183,10 +178,11 @@ export function MobileSidebarDrawer({
 }
 
 /**
- * Hamburger-menu button that opens the mobile sidebar drawer. Hidden at
- * the sm breakpoint and above.
+ * Hamburger-menu button that opens {@link SideListDrawer}. Rendered by the
+ * same owner, on the same signal, so it exists exactly when the inline list
+ * does not.
  */
-export function MobileSidebarTrigger({ onClick }: { onClick: () => void }) {
+export function SideListTrigger({ onClick }: { onClick: () => void }) {
   return (
     <Button
       type="button"
@@ -195,7 +191,6 @@ export function MobileSidebarTrigger({ onClick }: { onClick: () => void }) {
       onClick={onClick}
       aria-label="Open sidebar"
       tintColor="var(--content-secondary)"
-      className="sm:hidden"
     />
   );
 }

--- a/clients/web/src/domains/channels/components/assistant-channels-list.stories.tsx
+++ b/clients/web/src/domains/channels/components/assistant-channels-list.stories.tsx
@@ -106,6 +106,24 @@ export const ChannelsTabSlackConnected: Story = {
   },
 };
 
+/**
+ * The pane this tab actually gets on a 768px window: the chat layout's sidebar
+ * and the page shell's padding leave roughly 470px, which is not enough for the
+ * adapter rail beside a detail panel. The rail moves behind the hamburger,
+ * decided on the pane rather than the window, so it does not matter that the
+ * window itself is wide. Storybook's own frame is the window here.
+ */
+export const ChannelsTabInNarrowPane: Story = {
+  parameters: selectedAdapter("slack"),
+  decorators: [
+    (Story) => (
+      <div style={{ width: 470 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
 /** Disconnected Slack: the setup wizard in the "Slack setup" card. */
 export const ChannelsTabSlackDisconnected: Story = {
   parameters: selectedAdapter("slack"),

--- a/clients/web/src/domains/channels/components/assistant-channels-list.tsx
+++ b/clients/web/src/domains/channels/components/assistant-channels-list.tsx
@@ -4,10 +4,8 @@ import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialo
 
 import { useTranslation } from "@/i18n";
 import { DetailCard } from "@/components/detail-card";
-import {
-  MobileSidebarDrawer,
-  MobileSidebarTrigger,
-} from "@/components/mobile-sidebar-drawer";
+import { SideListDrawer, SideListTrigger } from "@/components/side-list-drawer";
+import { useSideListRoom } from "@/hooks/use-side-list-room";
 import type { MutationStatus } from "@/components/channel-setup-wizard";
 import { useChannelRouteSelection } from "@/domains/channels/hooks/use-channel-route-selection";
 import { CHANNEL_META } from "@/domains/channels/channel-meta";
@@ -160,7 +158,8 @@ export function AssistantChannelsList({
     channelKey: ChannelKey;
     policy: AdmissionPolicy;
   } | null>(null);
-  const [drawerOpen, setDrawerOpen] = useState(false);
+  const { paneRef, hasRoomForList, drawerOpen, openDrawer, closeDrawer } =
+    useSideListRoom();
   // Capture the `?setup=<channel>` deep link once at mount. `useSetupChannelParam`
   // consumes (clears) the param right after the first render, so reading the
   // prop later races against this component's own store update; the frozen
@@ -198,7 +197,7 @@ export function AssistantChannelsList({
 
   const handleSelect = (channelKey: string) => {
     selectAdapter(channelKey);
-    setDrawerOpen(false);
+    closeDrawer();
   };
 
   // A plugin channel can be selected, and can also vanish under the selection
@@ -269,32 +268,41 @@ export function AssistantChannelsList({
 
   return (
     <>
-      <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden sm:flex-row sm:gap-6">
-        <div className="flex items-center sm:hidden">
-          <MobileSidebarTrigger onClick={() => setDrawerOpen(true)} />
-        </div>
+      <div
+        ref={paneRef}
+        className={`flex min-h-0 flex-1 overflow-hidden ${
+          hasRoomForList ? "flex-row gap-6" : "flex-col gap-4"
+        }`}
+      >
+        {hasRoomForList ? (
+          <aside className="min-h-0 w-[320px] shrink-0 overflow-y-auto self-stretch">
+            <ChannelAdapterList
+              channels={channels}
+              pluginChannels={pluginChannels}
+              selectedKey={selectedKey}
+              onSelect={handleSelect}
+            />
+          </aside>
+        ) : (
+          <>
+            <div className="flex items-center">
+              <SideListTrigger onClick={openDrawer} />
+            </div>
 
-        <MobileSidebarDrawer
-          open={drawerOpen}
-          onClose={() => setDrawerOpen(false)}
-          title={t("assistantChannelsList.drawerTitle")}
-        >
-          <ChannelAdapterList
-            channels={channels}
-            pluginChannels={pluginChannels}
-            selectedKey={selectedKey}
-            onSelect={handleSelect}
-          />
-        </MobileSidebarDrawer>
-
-        <aside className="hidden min-h-0 w-[320px] shrink-0 overflow-y-auto self-stretch sm:block">
-          <ChannelAdapterList
-            channels={channels}
-            pluginChannels={pluginChannels}
-            selectedKey={selectedKey}
-            onSelect={handleSelect}
-          />
-        </aside>
+            <SideListDrawer
+              open={drawerOpen}
+              onClose={closeDrawer}
+              title={t("assistantChannelsList.drawerTitle")}
+            >
+              <ChannelAdapterList
+                channels={channels}
+                pluginChannels={pluginChannels}
+                selectedKey={selectedKey}
+                onSelect={handleSelect}
+              />
+            </SideListDrawer>
+          </>
+        )}
 
         {/* Slack brings its own cards (connection, default access, per-channel
             overrides) so it renders bare; the other adapters get a DetailCard

--- a/clients/web/src/domains/channels/components/channel-adapter-list.tsx
+++ b/clients/web/src/domains/channels/components/channel-adapter-list.tsx
@@ -35,8 +35,8 @@ export interface ChannelAdapterListProps {
  *
  * The card carries no "Channels" heading of its own: every surface that
  * mounts it already names it (`IntelligenceLayout`'s section `<h1>` on
- * desktop, the `MobileSidebarDrawer` title on mobile), so one here would
- * put the word on screen twice.
+ * desktop, the `SideListDrawer` title in a pane too narrow to seat this
+ * beside the detail), so one here would put the word on screen twice.
  *
  * Channels a plugin brings sit in the same list as the rest. They are
  * channels, they are selected the same way, and their panel is the thing

--- a/clients/web/src/domains/contacts/components/contacts-list.tsx
+++ b/clients/web/src/domains/contacts/components/contacts-list.tsx
@@ -6,7 +6,6 @@ import {
   Search,
   UserPlus,
 } from "lucide-react";
-import { useState } from "react";
 
 import { Button } from "@vellumai/design-library/components/button";
 import { Card } from "@vellumai/design-library/components/card";
@@ -31,6 +30,13 @@ interface ContactsListProps {
   onSelect: (selection: ContactSelection) => void;
   onAddContact: () => void;
   addingContact?: boolean;
+  /**
+   * The name filter, owned by the page. This list renders in two surfaces
+   * that substitute for each other, and switching between them remounts it,
+   * so state held here would be dropped when the pane crosses the threshold.
+   */
+  search: string;
+  onSearchChange: (search: string) => void;
 }
 
 export function ContactsList({
@@ -42,9 +48,10 @@ export function ContactsList({
   onSelect,
   onAddContact,
   addingContact = false,
+  search,
+  onSearchChange,
 }: ContactsListProps) {
   const { t } = useTranslation("contacts");
-  const [search, setSearch] = useState("");
   const filtered = search.trim()
     ? regularContacts.filter((c) =>
         c.displayName.toLowerCase().includes(search.trim().toLowerCase()),
@@ -116,7 +123,7 @@ export function ContactsList({
           <Input
             type="text"
             value={search}
-            onChange={(e) => setSearch(e.target.value)}
+            onChange={(e) => onSearchChange(e.target.value)}
             placeholder={t("contactsList.searchPlaceholder")}
             leftIcon={<Search className="h-3.5 w-3.5" aria-hidden />}
             fullWidth

--- a/clients/web/src/domains/contacts/contacts-page.tsx
+++ b/clients/web/src/domains/contacts/contacts-page.tsx
@@ -130,6 +130,11 @@ export function ContactsPage({
   const inviteDialog = useInviteLinkDialog(assistantId);
   const { paneRef, hasRoomForList, drawerOpen, openDrawer, closeDrawer } =
     useSideListRoom();
+  // Above the inline/drawer branch below, which remounts whichever list
+  // surface it swaps to: held inside `ContactsList` the filter would be
+  // dropped whenever the pane crosses the threshold, and dragging the chat
+  // sidebar is enough to cross it.
+  const [contactSearch, setContactSearch] = useState("");
   const [mergeDialogOpen, setMergeDialogOpen] = useState(false);
 
   const assistantName = assistantDisplayName(identityName);
@@ -509,6 +514,8 @@ export function ContactsPage({
     selection,
     onAddContact: handleAddContact,
     addingContact: createMutation.isPending,
+    search: contactSearch,
+    onSearchChange: setContactSearch,
   };
 
   return (

--- a/clients/web/src/domains/contacts/contacts-page.tsx
+++ b/clients/web/src/domains/contacts/contacts-page.tsx
@@ -4,10 +4,8 @@ import { Navigate, useSearchParams } from "react-router";
 
 import { toast } from "@vellumai/design-library/components/toast";
 
-import {
-  MobileSidebarDrawer,
-  MobileSidebarTrigger,
-} from "@/components/mobile-sidebar-drawer";
+import { SideListDrawer, SideListTrigger } from "@/components/side-list-drawer";
+import { useSideListRoom } from "@/hooks/use-side-list-room";
 import { isVerifiedContactChannel } from "@/domains/contacts/channel-linking";
 import { channelTypeLabel } from "@/domains/contacts/channel-type-labels";
 import { DRAFT_CONTACT_NAME } from "@/domains/contacts/draft-contact";
@@ -130,7 +128,8 @@ export function ContactsPage({
   });
 
   const inviteDialog = useInviteLinkDialog(assistantId);
-  const [drawerOpen, setDrawerOpen] = useState(false);
+  const { paneRef, hasRoomForList, drawerOpen, openDrawer, closeDrawer } =
+    useSideListRoom();
   const [mergeDialogOpen, setMergeDialogOpen] = useState(false);
 
   const assistantName = assistantDisplayName(identityName);
@@ -321,11 +320,11 @@ export function ContactsPage({
   const handleSelect = useCallback(
     (sel: ContactSelection) => {
       setSelection(sel);
-      setDrawerOpen(false);
+      closeDrawer();
       setMergeDialogOpen(false);
       mergeMutation.reset();
     },
-    [mergeMutation],
+    [closeDrawer, mergeMutation],
   );
 
   const handleOpenMerge = useCallback(() => {
@@ -513,22 +512,31 @@ export function ContactsPage({
   };
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden sm:flex-row sm:gap-6">
-      <div className="flex items-center sm:hidden">
-        <MobileSidebarTrigger onClick={() => setDrawerOpen(true)} />
-      </div>
+    <div
+      ref={paneRef}
+      className={`flex min-h-0 flex-1 overflow-hidden ${
+        hasRoomForList ? "flex-row gap-6" : "flex-col gap-4"
+      }`}
+    >
+      {hasRoomForList ? (
+        <aside className="min-h-0 w-[320px] shrink-0 overflow-y-auto self-stretch">
+          <ContactsList {...contactsListProps} onSelect={handleSelect} />
+        </aside>
+      ) : (
+        <>
+          <div className="flex items-center">
+            <SideListTrigger onClick={openDrawer} />
+          </div>
 
-      <MobileSidebarDrawer
-        open={drawerOpen}
-        onClose={() => setDrawerOpen(false)}
-        title={t("contactsPage.title")}
-      >
-        <ContactsList {...contactsListProps} onSelect={handleSelect} />
-      </MobileSidebarDrawer>
-
-      <aside className="hidden min-h-0 w-[320px] shrink-0 overflow-y-auto self-stretch sm:block">
-        <ContactsList {...contactsListProps} onSelect={handleSelect} />
-      </aside>
+          <SideListDrawer
+            open={drawerOpen}
+            onClose={closeDrawer}
+            title={t("contactsPage.title")}
+          >
+            <ContactsList {...contactsListProps} onSelect={handleSelect} />
+          </SideListDrawer>
+        </>
+      )}
 
       <section className="min-h-0 min-w-0 flex-1 overflow-y-auto">
         {selection.kind === "assistant" ||

--- a/clients/web/src/domains/workspace/components/workspace-browser.tsx
+++ b/clients/web/src/domains/workspace/components/workspace-browser.tsx
@@ -99,6 +99,10 @@ export function WorkspaceBrowser({ assistantId }: { assistantId: string }) {
 
   const { paneRef, hasRoomForList, drawerOpen, openDrawer, closeDrawer } =
     useSideListRoom();
+  // Above the inline/drawer branch below, which remounts whichever tree
+  // surface it swaps to. Sits with the expansion and selection state already
+  // lifted here for the same reason.
+  const [treeSearch, setTreeSearch] = useState("");
 
   const handleSelectPath = useCallback(
     (path: string) => {
@@ -161,6 +165,8 @@ export function WorkspaceBrowser({ assistantId }: { assistantId: string }) {
     onChangeSortMode: setSortMode,
     onPathDeleted: handlePathDeleted,
     onPathRenamed: handlePathRenamed,
+    search: treeSearch,
+    onSearchChange: setTreeSearch,
   };
 
   return (

--- a/clients/web/src/domains/workspace/components/workspace-browser.tsx
+++ b/clients/web/src/domains/workspace/components/workspace-browser.tsx
@@ -7,10 +7,8 @@ import { useCallback, useEffect, useState } from "react";
 
 import { useSearchParams } from "react-router";
 
-import {
-  MobileSidebarDrawer,
-  MobileSidebarTrigger,
-} from "@/components/mobile-sidebar-drawer";
+import { SideListDrawer, SideListTrigger } from "@/components/side-list-drawer";
+import { useSideListRoom } from "@/hooks/use-side-list-room";
 import { useTranslation } from "@/i18n";
 import { WorkspaceFileViewer } from "@/domains/workspace/components/workspace-file-viewer";
 import {
@@ -99,12 +97,16 @@ export function WorkspaceBrowser({ assistantId }: { assistantId: string }) {
     });
   }, []);
 
-  const [drawerOpen, setDrawerOpen] = useState(false);
+  const { paneRef, hasRoomForList, drawerOpen, openDrawer, closeDrawer } =
+    useSideListRoom();
 
-  const handleSelectPath = useCallback((path: string) => {
-    setSelectedPath(path);
-    setDrawerOpen(false);
-  }, []);
+  const handleSelectPath = useCallback(
+    (path: string) => {
+      setSelectedPath(path);
+      closeDrawer();
+    },
+    [closeDrawer],
+  );
 
   const [lastDelete, setLastDelete] = useState<{ path: string } | null>(null);
 
@@ -162,29 +164,39 @@ export function WorkspaceBrowser({ assistantId }: { assistantId: string }) {
   };
 
   return (
-    <div className="flex h-full min-h-0 flex-col gap-4">
-      <div className="flex items-center sm:hidden">
-        <MobileSidebarTrigger onClick={() => setDrawerOpen(true)} />
-      </div>
+    <div ref={paneRef} className="flex h-full min-h-0 flex-col gap-4">
+      {!hasRoomForList ? (
+        <>
+          <div className="flex items-center">
+            <SideListTrigger onClick={openDrawer} />
+          </div>
 
-      <MobileSidebarDrawer
-        open={drawerOpen}
-        onClose={() => setDrawerOpen(false)}
-        title={t("workspaceBrowser.drawerTitle")}
+          <SideListDrawer
+            open={drawerOpen}
+            onClose={closeDrawer}
+            title={t("workspaceBrowser.drawerTitle")}
+          >
+            <WorkspaceTree {...treeProps} />
+          </SideListDrawer>
+        </>
+      ) : null}
+
+      <div
+        className={`grid min-h-0 flex-1 gap-4 ${
+          hasRoomForList ? "grid-cols-[320px_1fr]" : "grid-cols-1"
+        }`}
       >
-        <WorkspaceTree {...treeProps} />
-      </MobileSidebarDrawer>
-
-      <div className="grid min-h-0 flex-1 grid-cols-1 gap-4 sm:grid-cols-[320px_1fr]">
-        <div
-          className="hidden min-h-0 min-w-0 flex-col overflow-hidden rounded-xl border sm:flex"
-          style={{
-            backgroundColor: "var(--surface-overlay)",
-            borderColor: "var(--border-base)",
-          }}
-        >
-          <WorkspaceTree {...treeProps} />
-        </div>
+        {hasRoomForList ? (
+          <div
+            className="flex min-h-0 min-w-0 flex-col overflow-hidden rounded-xl border"
+            style={{
+              backgroundColor: "var(--surface-overlay)",
+              borderColor: "var(--border-base)",
+            }}
+          >
+            <WorkspaceTree {...treeProps} />
+          </div>
+        ) : null}
         <div
           className="flex min-h-0 min-w-0 flex-col overflow-hidden rounded-xl border"
           style={{
@@ -198,7 +210,7 @@ export function WorkspaceBrowser({ assistantId }: { assistantId: string }) {
             showHidden={showHidden}
             viewMode={viewMode}
             onChangeViewMode={setViewMode}
-            onBrowse={() => setDrawerOpen(true)}
+            onBrowse={hasRoomForList ? undefined : openDrawer}
             pathRename={lastRename}
             pathDelete={lastDelete}
           />

--- a/clients/web/src/domains/workspace/components/workspace-file-viewer.tsx
+++ b/clients/web/src/domains/workspace/components/workspace-file-viewer.tsx
@@ -466,6 +466,11 @@ export function WorkspaceFileViewer({
   showHidden?: boolean;
   viewMode: WorkspaceViewMode;
   onChangeViewMode: (mode: WorkspaceViewMode) => void;
+  /**
+   * Opens the file tree's drawer from the empty state. Passed only while the
+   * tree is behind that drawer, so the button exists exactly when the tree is
+   * not already on screen beside this.
+   */
   onBrowse?: () => void;
   /** Last successful workspace rename, so edit state can follow the file. */
   pathRename?: { from: string; to: string } | null;
@@ -589,7 +594,6 @@ export function WorkspaceFileViewer({
             type="button"
             onClick={onBrowse}
             leftIcon={<FolderOpen aria-hidden />}
-            className="sm:hidden"
           >
             {t("workspaceFileViewer.browseFiles")}
           </Button>

--- a/clients/web/src/domains/workspace/components/workspace-tree.tsx
+++ b/clients/web/src/domains/workspace/components/workspace-tree.tsx
@@ -484,6 +484,8 @@ export function WorkspaceTree({
   onChangeSortMode,
   onPathDeleted,
   onPathRenamed,
+  search,
+  onSearchChange,
 }: {
   assistantId: string;
   expandedPaths: Set<string>;
@@ -497,10 +499,17 @@ export function WorkspaceTree({
   onChangeSortMode: (next: WorkspaceSortMode) => void;
   onPathDeleted: (path: string) => void;
   onPathRenamed: (oldPath: string, newPath: string) => void;
+  /**
+   * The name filter, owned by `WorkspaceBrowser` alongside the expansion and
+   * selection it already keeps there. This tree renders in two surfaces that
+   * substitute for each other, and switching between them remounts it, so
+   * state held here would be dropped when the pane crosses the threshold.
+   */
+  search: string;
+  onSearchChange: (search: string) => void;
 }) {
   const { t } = useTranslation("workspace");
   const queryClient = useQueryClient();
-  const [search, setSearch] = useState("");
   const searchLower = search.trim().toLowerCase();
 
   const [menuOpen, setMenuOpen] = useState(false);
@@ -748,7 +757,7 @@ export function WorkspaceTree({
           <Input
             type="text"
             value={search}
-            onChange={(e) => setSearch(e.target.value)}
+            onChange={(e) => onSearchChange(e.target.value)}
             placeholder={t("workspaceTree.searchPlaceholder")}
             leftIcon={<Search className="h-3.5 w-3.5" aria-hidden />}
             fullWidth
@@ -761,7 +770,7 @@ export function WorkspaceTree({
               variant="ghost"
               size="compact"
               iconOnly={<X aria-hidden />}
-              onClick={() => setSearch("")}
+              onClick={() => onSearchChange("")}
               aria-label={t("workspaceTree.clearSearchAria")}
               className="absolute right-1.5 top-1/2 -translate-y-1/2"
               tintColor="var(--content-tertiary)"

--- a/clients/web/src/hooks/use-element-size.ts
+++ b/clients/web/src/hooks/use-element-size.ts
@@ -141,6 +141,12 @@ export interface ElementSize {
  * mounts/unmounts — robust to containers that appear after the first render
  * (e.g. a step that's conditionally rendered). Returns the layout viewport
  * size until the element mounts.
+ *
+ * A measurement that leaves both dimensions alone keeps the previous object,
+ * the same caching contract `useLayoutViewportSize` above holds: an observed
+ * box is notified for far more than its own size (a sibling reflow, a scrollbar
+ * appearing), and a consumer reading only the width should not re-render for
+ * every one of those.
  */
 export function useElementSize(): ElementSize {
   const [el, setEl] = useState<HTMLElement | null>(null);
@@ -152,7 +158,11 @@ export function useElementSize(): ElementSize {
     }
     const measure = () => {
       const rect = el.getBoundingClientRect();
-      setSize({ w: rect.width, h: rect.height });
+      setSize((prev) =>
+        prev.w === rect.width && prev.h === rect.height
+          ? prev
+          : { w: rect.width, h: rect.height },
+      );
     };
     measure();
     const observer = new ResizeObserver(measure);

--- a/clients/web/src/hooks/use-side-list-room.test.tsx
+++ b/clients/web/src/hooks/use-side-list-room.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * Tests for `useSideListRoom`, the one owner of a list-detail pane's choice
+ * between an inline list column and the drawer that stands in for it.
+ *
+ * The shape worth pinning is that the answer follows the *pane*. These pages
+ * render inside the chat layout's content area, so the window is several
+ * hundred pixels wider than the box the list has to fit into, and a decision
+ * taken on the window is the bug this hook exists to prevent.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { act, render, screen } from "@testing-library/react";
+
+import { useSideListRoom } from "@/hooks/use-side-list-room";
+
+const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
+
+/**
+ * Make every measured element report `width`. happy-dom has no layout engine,
+ * so a real box has to be stubbed; its `ResizeObserver` is a no-op stub too,
+ * which is why the harness below remounts the pane to force a re-measure.
+ */
+function stubPaneWidth(width: number): void {
+  Element.prototype.getBoundingClientRect = function getBoundingClientRect() {
+    return { ...new DOMRect(0, 0, width, 600), width, height: 600 } as DOMRect;
+  };
+}
+
+afterEach(() => {
+  Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+});
+
+function Harness({ paneKey }: { paneKey: string }) {
+  const { paneRef, hasRoomForList, drawerOpen, openDrawer } = useSideListRoom();
+  return (
+    <>
+      {/* Keyed so a width change remounts the element and `useElementSize`
+          measures again, standing in for the ResizeObserver happy-dom lacks. */}
+      <div key={paneKey} ref={paneRef} />
+      <span data-testid="room">{String(hasRoomForList)}</span>
+      <span data-testid="drawer">{String(drawerOpen)}</span>
+      <button type="button" onClick={openDrawer}>
+        open
+      </button>
+    </>
+  );
+}
+
+function room(): string {
+  return screen.getByTestId("room").textContent ?? "";
+}
+
+describe("useSideListRoom", () => {
+  test("a pane too narrow for both columns has no room, in a wide window", () => {
+    // The window the app actually runs in stays wide throughout: 1024px is
+    // happy-dom's default and comfortably over the threshold. Only the pane is
+    // narrow, which is exactly the combination a viewport media query gets
+    // wrong. 470px is the pane at a 768px window with the sidebar expanded.
+    expect(window.innerWidth).toBeGreaterThan(640);
+    stubPaneWidth(470);
+    render(<Harness paneKey="narrow" />);
+    expect(room()).toBe("false");
+  });
+
+  test("a pane wide enough for both columns has room", () => {
+    stubPaneWidth(970);
+    render(<Harness paneKey="wide" />);
+    expect(room()).toBe("true");
+  });
+
+  test("an unmeasured pane falls back to the window rather than reading as zero", () => {
+    // A subtree with no layout reports a zero box. Treating that as "no room"
+    // would show the drawer on a full-width desktop pane for as long as the
+    // measurement is missing.
+    stubPaneWidth(0);
+    render(<Harness paneKey="unmeasured" />);
+    expect(room()).toBe("true");
+  });
+
+  test("the drawer does not survive the pane growing back", () => {
+    // The trigger is gone once the list is inline, so a drawer left open would
+    // reappear unprompted the next time the pane narrows, with nothing on
+    // screen having asked for it.
+    stubPaneWidth(470);
+    const view = render(<Harness paneKey="narrow" />);
+    act(() => {
+      screen.getByRole("button", { name: "open" }).click();
+    });
+    expect(screen.getByTestId("drawer").textContent).toBe("true");
+
+    stubPaneWidth(970);
+    view.rerender(<Harness paneKey="wide" />);
+    expect(room()).toBe("true");
+    expect(screen.getByTestId("drawer").textContent).toBe("false");
+
+    stubPaneWidth(470);
+    view.rerender(<Harness paneKey="narrow-again" />);
+    expect(room()).toBe("false");
+    expect(screen.getByTestId("drawer").textContent).toBe("false");
+  });
+});

--- a/clients/web/src/hooks/use-side-list-room.ts
+++ b/clients/web/src/hooks/use-side-list-room.ts
@@ -1,0 +1,83 @@
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  useElementSize,
+  useLayoutViewportSize,
+} from "@/hooks/use-element-size";
+
+/** Width of the list column when it sits beside the detail. */
+const SIDE_LIST_WIDTH_PX = 320;
+
+/** The `gap-6` between the list column and the detail. */
+const SIDE_LIST_GAP_PX = 24;
+
+/**
+ * Narrowest detail worth showing beside the list. Below this the detail is a
+ * column of single words with its trailing controls clipped, which is worse
+ * than reaching the list through the drawer.
+ */
+const MIN_DETAIL_WIDTH_PX = 296;
+
+/** Pane width at which the list can sit beside the detail rather than behind a trigger. */
+const MIN_PANE_WIDTH_PX =
+  SIDE_LIST_WIDTH_PX + SIDE_LIST_GAP_PX + MIN_DETAIL_WIDTH_PX;
+
+export interface SideListRoom {
+  /** Attach to the pane whose width decides this. Its width must come from its parent. */
+  paneRef: (el: HTMLElement | null) => void;
+  /** Whether the list fits beside the detail. When false, the drawer carries it. */
+  hasRoomForList: boolean;
+  drawerOpen: boolean;
+  openDrawer: () => void;
+  closeDrawer: () => void;
+}
+
+/**
+ * One owner for a list-detail pane's two list surfaces: the column beside the
+ * detail, and the {@link SideListDrawer} that stands in for it when the pane is
+ * too narrow to seat both.
+ *
+ * The measurement is the pane, not the window, because the pane is what the
+ * list has to fit into. These pages render inside the chat layout's content
+ * area, so a 230-400px sidebar and the page shell's padding sit between the
+ * two: a viewport media query calls a 470px pane roomy at a 768px window and
+ * leaves the detail 126px wide with no way to dismiss the list, since its
+ * substitute is keyed off the same window width that just declared there was
+ * room. Contacts, Channels, and Workspace all sit in that pane.
+ *
+ * A container query would express the same threshold in CSS, which is the
+ * cheaper rung, but it cannot hand the boolean to the drawer's open state,
+ * focus trap, and scroll lock. Two surfaces that substitute for each other are
+ * one decision, so both read this instead of one hiding itself in CSS while the
+ * other mirrors the threshold in JavaScript. See `docs/PLATFORM_ADAPTATION.md`.
+ *
+ * This is the window-size axis alone. Which overlay a trigger opens is the
+ * pointer's question and is not asked here.
+ */
+export function useSideListRoom(): SideListRoom {
+  const { ref: paneRef, size } = useElementSize();
+  // A zero box is an unmeasured pane, not a pane with no room: a subtree that
+  // has not been laid out reports one, and so does a DOM without a layout
+  // engine. Falling through to the window there keeps the answer the same as
+  // the one the pane will give once it has a box, rather than flashing the
+  // drawer at a reader whose window is plainly wide enough.
+  const unmeasured = size.w <= 0;
+  const viewport = useLayoutViewportSize(unmeasured);
+  const paneWidth = unmeasured ? viewport.w : size.w;
+  const hasRoomForList = paneWidth >= MIN_PANE_WIDTH_PX;
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  // The drawer unmounts the moment the pane can seat the list inline, and the
+  // state goes with it: left set, re-narrowing the pane would reopen a drawer
+  // nobody asked for.
+  useEffect(() => {
+    if (hasRoomForList) {
+      setDrawerOpen(false);
+    }
+  }, [hasRoomForList]);
+
+  const openDrawer = useCallback(() => setDrawerOpen(true), []);
+  const closeDrawer = useCallback(() => setDrawerOpen(false), []);
+
+  return { paneRef, hasRoomForList, drawerOpen, openDrawer, closeDrawer };
+}


### PR DESCRIPTION
## TL;DR

Contacts, Channels, and Workspace each seat a 320px list beside a detail panel, and each decided whether it fits by asking the **window** width. They do not get the window: they render inside the chat layout's content area, behind a 230-400px sidebar and the page shell's padding. At a 768px window the pane is about 470px, which `sm:` calls roomy, so the list mounts inline and the detail is left 126px wide with its trailing controls off-screen. The hamburger that would move the list out of the way is hidden by the same window width that just declared there was room, so there is no way out.

One owner, `useSideListRoom()`, now measures the **pane** and both surfaces follow from it.

Measured in Storybook, same pane width in both rows, only the window changed:

| Window | Pane | Before | After |
|---|---|---|---|
| 600px | 470px | hamburger + drawer | hamburger + drawer (unchanged) |
| 768px | 470px | list 320px, **detail 126px**, no hamburger | hamburger + drawer, detail gets all 470px |

## What changes for the user

| Where they are | Before | After |
|---|---|---|
| Desktop window ~1100px or wider, sidebar at its default | List beside the detail | Unchanged |
| Desktop window 768-1050px, or any width with the sidebar dragged wide | List beside a detail squeezed to 100-250px, controls clipped, no way to dismiss the list | List moves behind the hamburger; the detail gets the whole pane |
| iPad in portrait (768px) | Same squeeze | Same fix |
| Phone, or any window under 640px | Hamburger + drawer | Unchanged |
| Workspace empty state | "Browse files" button appeared under a 640px **window**, whether or not the tree was already on screen | Appears exactly when the tree is behind the drawer |

Nothing here is about the pointer or the platform. This is the window-size axis alone, measured against the right box.

## Why it is safe

- **The threshold has one home.** It was in three places that could disagree: a `sm:hidden`/`sm:block` pair in each page, a `(min-width: 640px)` constant in the drawer with a "matches the `sm:hidden` class" comment, and a third `sm:hidden` on the Workspace empty state's Browse button. All three are gone; `MIN_PANE_WIDTH_PX` is derived from the list width, the gap, and a minimum detail width, so the number is readable rather than magic.
- **The same effective size.** 640px was the old threshold and is still the threshold, applied to the pane instead of the window. On a full-width desktop window the pane clears it comfortably and nothing moves.
- **Exactly one list, always.** Verified in the browser: with the drawer open there is exactly one copy of the adapter list in the DOM, and it is inside the drawer. Previously both surfaces existed and CSS chose between them.
- **The drawer cannot linger.** It is mounted only while the substitution is on, and its open state resets when the pane grows, so re-narrowing cannot reopen a drawer nobody asked for. That replaces the `matchMedia("change")` listener that used to close it.
- **An unmeasured pane reads as the window, not as zero.** A subtree with no layout reports a zero box; treating that as "no room" would flash the drawer on a full-width desktop pane. `useSideListRoom` falls through to the layout viewport while unmeasured, and subscribes to `resize` only in that state.
- **New regression test** (`use-side-list-room.test.tsx`) pins the shape that matters: a narrow pane in a **wide** window has no room. Sensitivity-checked by reverting the hook to a window read, which fails 4 of its 8 assertions.
- **New Storybook story** `Channels/AssistantChannelsList/ChannelsTabInNarrowPane` frames the tab at the 470px pane it actually gets, so this stays visible.

`useElementSize` picks up a change-detection guard: a measurement that leaves both dimensions unchanged keeps the previous object. That is the caching contract `useLayoutViewportSize` beside it already documents, and without it a pane reflowing in height would re-render three pages that only read its width.

`mobile-sidebar-drawer.tsx` is renamed to `side-list-drawer.tsx`. The drawer was never about being mobile; it is what stands in when the pane is narrow, and the old name is part of what made the window look like the right thing to measure.

## Verification

Storybook only. Local `bun test` is blocked by a hook, so the new test runs in CI; its mechanics were exercised outside the test runner against the same happy-dom code path, and sensitivity-checked. Typecheck, lint (0 errors), and the pinned prettier are clean.

## State across a flip

Swapping the surface remounts the list, which `PLATFORM_ADAPTATION.md` calls out as inherent to this rung. So the filter each list used to hold locally is now owned by the page, above the branch: `ContactsList` and `WorkspaceTree` take `search` / `onSearchChange`, joining the expansion, selection, hidden-files and sort order `WorkspaceBrowser` already kept there for the same reason.

The workspace tree's create/rename/delete dialogs and their mutations still live inside the tree and are still lost on a flip. That is pre-existing rather than new: the drawer used to close itself on crossing 640px, discarding the identical draft, and in the other direction the inline tree went `display: none` while its portalled dialog stayed on screen over a surface that had vanished. Both directions already lost or corrupted this state. Lifting them out is a mutation-ownership change to a 990-line file and is listed below.

## Deferred

- **The workspace tree's dialogs and mutations should move up to `WorkspaceBrowser`** (LUM-3274). `dialog`, `dialogError`, `deleteTarget` and three `useMutation` blocks, roughly 250 lines. The intent boundary already exists (`onRequestCreate` / `onRequestRename` / `onRequestDelete`), and the hoist should drop the `onPathDeleted` / `onPathRenamed` props on the way. Kept separate so it is reviewed as mutation code rather than as part of a layout diff.
- **The drawer's backdrop is still viewport-sized.** It can now appear at a wide window with a narrow pane, where a full-screen scrim to show a 320px list is heavier than it needs to be. Scoping the overlay to the pane would change the drawer's shipped presentation on phones too, which is a design call rather than an adaptation fix, so it is left alone here.
- **Contacts and Channels now share near-identical pane JSX.** A shared `SideListPane` component would cover those two but not Workspace, which uses a grid with card chrome around its tree, and two ways to do it is a worse seam than one hook covering all three. The part that used to drift, the threshold, is single-sourced.

Fixes LUM-3273. Follow-ups: LUM-3274 (lift the workspace tree's dialogs and mutations out of the flipping surface), LUM-3275 (soft-keyboard compensation is off on a phone in landscape). Corrects the code read in LUM-3142, which recorded this pattern as already collapsing on any phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
