### PR TITLE
refactor(web): give the peeking eyes one implementation instead of two

### DIFF
--- a/clients/web/src/components/avatar/peeking-eyes.tsx
+++ b/clients/web/src/components/avatar/peeking-eyes.tsx
@@ -1,0 +1,235 @@
+/**
+ * An avatar's eyes peeking up from the bottom edge of a stage.
+ *
+ * Renders the eye art (whites + pupils, in the style's own shapes) sized
+ * against the stage box and cut off by its bottom edge, with an idle blink and
+ * a slight cursor parallax. Pass `entrance` to play the grow-in: the eyes drop
+ * from the stage's center (where a full avatar sits), dipping a touch below
+ * rest before settling with two blinks.
+ *
+ * Presentational and decorative: `aria-hidden`, `pointer-events-none`,
+ * reduced-motion safe. It takes the art and the stage box as props and knows
+ * nothing about where either came from, so onboarding's backdrop (picker pool
+ * plus onboarding stage) and the About Assistant stage (the real assistant's
+ * avatar plus its own container) get one set of geometry, timings and motion
+ * rather than a copy each.
+ */
+
+import { useEffect, useState } from "react";
+import { motion, useAnimationControls, useReducedMotion } from "motion/react";
+
+import type { StageSize } from "@/hooks/use-element-size";
+import type { BBox } from "@/utils/eye-bbox";
+
+/** How much of the eyes sits below the bottom edge: at rest, and at the dip. */
+const EYE_REST_CUTOFF = 0.25;
+const EYE_DIP_CUTOFF = 0.46;
+/** Eye sizing: height is at most 30% of the stage, capped so width stays
+ *  inside the stage. */
+const EYE_TARGET_HEIGHT = 0.3;
+const EYE_MAX_WIDTH = 0.85;
+/** Entrance hand-off: the eyes start from the stage's centered position. */
+const STAGE_CENTER_FRACTION = 0.4;
+/** Slight whole-eye cursor parallax. */
+const CURSOR_MAX_X = 14;
+const CURSOR_MAX_Y = 8;
+
+/** An eye style's paths plus the union bounding box that frames them. */
+export interface PeekingEyeArt {
+  paths: { svgPath: string; color: string }[];
+  bbox: BBox;
+}
+
+export interface PeekingEyesProps {
+  art: PeekingEyeArt;
+  /** The stage container's box. The eyes anchor to its bottom edge. */
+  stage: StageSize;
+  /**
+   * Play the grow-in entrance, and the two settle blinks that close it out.
+   * Otherwise the eyes are at rest and simply idle-blink, as if carried over
+   * from a previous step.
+   */
+  entrance?: boolean;
+  /** Delay before the entrance starts. */
+  entranceDelay?: number;
+  /**
+   * Extra sink below the resting position, as a fraction of stage height, for
+   * stages whose bottom edge is not where the eyes should read as cut off.
+   */
+  restSinkFraction?: number;
+  /**
+   * Increment to make the eyes jolt upward once (a Mario-style "bump", e.g. to
+   * knock the integration-step coin up). Omit to leave out the bump layer.
+   */
+  bumpNonce?: number;
+}
+
+export function PeekingEyes({
+  art,
+  stage,
+  entrance = false,
+  entranceDelay = 0,
+  restSinkFraction = 0,
+  bumpNonce,
+}: PeekingEyesProps) {
+  const reduce = useReducedMotion();
+  const { w, h } = stage;
+
+  const [pointer, setPointer] = useState({ x: 0, y: 0 });
+  useEffect(() => {
+    if (reduce) {
+      return;
+    }
+    const onMove = (e: MouseEvent) => {
+      setPointer({
+        x: (e.clientX / window.innerWidth - 0.5) * 2,
+        y: (e.clientY / window.innerHeight - 0.5) * 2,
+      });
+    };
+    window.addEventListener("mousemove", onMove);
+    return () => window.removeEventListener("mousemove", onMove);
+  }, [reduce]);
+
+  const playEntrance = entrance && !reduce;
+
+  // A one-shot upward jolt when `bumpNonce` increments (Mario block bump).
+  const bumpControls = useAnimationControls();
+  useEffect(() => {
+    if ((bumpNonce ?? 0) > 0 && !reduce) {
+      void bumpControls.start({
+        y: [0, -34, 8, 0],
+        transition: { duration: 0.45, ease: "easeOut" },
+      });
+    }
+  }, [bumpNonce, reduce, bumpControls]);
+
+  // Two blinks once settled (after an entrance), then a slow random idle
+  // blink; resting eyes skip the settle blinks and just idle.
+  const [blinking, setBlinking] = useState(false);
+  const [entranceDone, setEntranceDone] = useState(!entrance);
+  useEffect(() => {
+    if (reduce || !entranceDone) {
+      return;
+    }
+    let cancelled = false;
+    let t: ReturnType<typeof setTimeout>;
+    const blink = (next: () => void) => {
+      if (cancelled) {
+        return;
+      }
+      setBlinking(true);
+      t = setTimeout(() => {
+        if (cancelled) {
+          return;
+        }
+        setBlinking(false);
+        t = setTimeout(next, 140);
+      }, 140);
+    };
+    const idle = () => {
+      t = setTimeout(() => blink(idle), 2500 + Math.random() * 4000);
+    };
+    if (entrance) {
+      blink(() => blink(idle));
+    } else {
+      idle();
+    }
+    return () => {
+      cancelled = true;
+      clearTimeout(t);
+    };
+  }, [reduce, entranceDone, entrance]);
+
+  if (w === 0 || h === 0) {
+    return null;
+  }
+
+  // Size by the smaller stage dimension so the eyes shrink on narrow stages
+  // (in portrait, height alone would make them oversized), capped to the stage
+  // width so wide eye styles never get cut off sideways.
+  const maxEyesW = w * EYE_MAX_WIDTH;
+  const eyesH = Math.min(
+    Math.min(w, h) * EYE_TARGET_HEIGHT,
+    (maxEyesW * art.bbox.h) / art.bbox.w,
+  );
+  const eyesW = (eyesH * art.bbox.w) / art.bbox.h;
+  const eyesLeft = (w - eyesW) / 2;
+  const eyesRestTop = h - (1 - EYE_REST_CUTOFF) * eyesH + h * restSinkFraction;
+  const eyesStartY = STAGE_CENTER_FRACTION * h - (eyesRestTop + eyesH / 2);
+  const eyesDipY = (EYE_DIP_CUTOFF - EYE_REST_CUTOFF) * eyesH;
+  const eyeCx = art.bbox.x + art.bbox.w / 2;
+  const eyeCy = art.bbox.y + art.bbox.h / 2;
+
+  const eyes = (
+    // Slight parallax: the whole eyes drift smoothly toward the cursor.
+    <div
+      style={{
+        transform: `translate(${pointer.x * CURSOR_MAX_X}px, ${pointer.y * CURSOR_MAX_Y}px)`,
+        transition: "transform 0.5s cubic-bezier(0.22, 1, 0.36, 1)",
+      }}
+    >
+      <svg
+        viewBox={`${art.bbox.x} ${art.bbox.y} ${art.bbox.w} ${art.bbox.h}`}
+        width={eyesW}
+        height={eyesH}
+        style={{ overflow: "visible", display: "block" }}
+      >
+        <g
+          style={{
+            transform: blinking ? "scaleY(0.1)" : "scaleY(1)",
+            transformOrigin: `${eyeCx}px ${eyeCy}px`,
+            transition: "transform 0.14s ease-in-out",
+          }}
+        >
+          {art.paths.map((p, i) => (
+            <path key={i} d={p.svgPath} fill={p.color} />
+          ))}
+        </g>
+      </svg>
+    </div>
+  );
+
+  return (
+    <motion.div
+      aria-hidden="true"
+      className="pointer-events-none absolute z-[2]"
+      style={{
+        left: eyesLeft,
+        top: eyesRestTop,
+        width: eyesW,
+        height: eyesH,
+        transformOrigin: "center",
+      }}
+      initial={playEntrance ? { y: eyesStartY, scale: 0.35 } : false}
+      animate={
+        playEntrance
+          ? { y: [eyesStartY, eyesDipY, 0], scale: [0.35, 1, 1] }
+          : { y: 0, scale: 1 }
+      }
+      transition={
+        playEntrance
+          ? {
+              duration: 1,
+              delay: entranceDelay,
+              times: [0, 0.7, 1],
+              ease: "easeInOut",
+            }
+          : { duration: 0 }
+      }
+      onAnimationComplete={() => setEntranceDone(true)}
+    >
+      {bumpNonce === undefined ? (
+        eyes
+      ) : (
+        <motion.div animate={bumpControls}>{eyes}</motion.div>
+      )}
+    </motion.div>
+  );
+}
+
+/**
+ * Fraction of the stage's smaller dimension covered by the eyes' visible
+ * portion. Content columns reserve this much at the bottom so foreground
+ * controls always clear the eyes.
+ */
+export const EYES_VISIBLE_FRACTION = EYE_TARGET_HEIGHT * (1 - EYE_REST_CUTOFF);

--- a/clients/web/src/domains/intelligence/components/assistant-peeking-eyes.tsx
+++ b/clients/web/src/domains/intelligence/components/assistant-peeking-eyes.tsx
@@ -1,42 +1,20 @@
 /**
- * The assistant's eyes peeking up from the bottom edge of an About
- * Assistant stage — the same visual and entrance choreography as
- * onboarding's peeking eyes, but driven by the real assistant's avatar
- * (components + traits props) instead of the onboarding picker pool, and
- * sized against the stage container rather than the viewport.
- *
- * Renders the avatar's eye art (whites + pupils, in the style's own shapes)
- * ~25% cut off at the bottom, with an idle blink and a slight cursor
- * parallax. Pass `entrance` to play the onboarding grow-in — the eyes drop
- * from the stage's center (where the overview shows the full avatar),
- * dipping a touch below rest before settling with two blinks. Decorative:
- * `aria-hidden`, `pointer-events-none`, reduced-motion safe.
+ * The About Assistant stage's peeking eyes: {@link PeekingEyes} driven by the
+ * real assistant's avatar (components + traits props), sized against the stage
+ * container rather than the viewport.
  */
 
-import { useEffect, useMemo, useState } from "react";
-import { motion, useReducedMotion } from "motion/react";
+import { useMemo } from "react";
 
+import { PeekingEyes } from "@/components/avatar/peeking-eyes";
 import type { StageSize } from "@/hooks/use-element-size";
 import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
 import { pathBBox, unionBBox } from "@/utils/eye-bbox";
 
-/** How much of the eyes sits below the bottom edge — at rest, and at the dip. */
-const EYE_REST_CUTOFF = 0.25;
-const EYE_DIP_CUTOFF = 0.46;
-/** Eye sizing: height is at most 30% of the stage, capped so width stays
- *  inside the stage. */
-const EYE_TARGET_HEIGHT = 0.3;
-const EYE_MAX_WIDTH = 0.85;
-/** Entrance hand-off: the eyes start from the stage's centered position. */
-const STAGE_CENTER_FRACTION = 0.4;
-/** Slight whole-eye cursor parallax. */
-const CURSOR_MAX_X = 14;
-const CURSOR_MAX_Y = 8;
-
 interface AssistantPeekingEyesProps {
   components: CharacterComponents;
   traits: CharacterTraits;
-  /** The stage container's box — the eyes anchor to its bottom edge. */
+  /** The stage container's box. The eyes anchor to its bottom edge. */
   stage: StageSize;
   /** Play the grow-in entrance. Otherwise the eyes are at rest. */
   entrance?: boolean;
@@ -51,64 +29,7 @@ export function AssistantPeekingEyes({
   entrance = false,
   entranceDelay = 0,
 }: AssistantPeekingEyesProps) {
-  const reduce = useReducedMotion();
-  const { w, h } = stage;
-
-  const [pointer, setPointer] = useState({ x: 0, y: 0 });
-  useEffect(() => {
-    if (reduce) {
-      return;
-    }
-    const onMove = (e: MouseEvent) => {
-      setPointer({
-        x: (e.clientX / window.innerWidth - 0.5) * 2,
-        y: (e.clientY / window.innerHeight - 0.5) * 2,
-      });
-    };
-    window.addEventListener("mousemove", onMove);
-    return () => window.removeEventListener("mousemove", onMove);
-  }, [reduce]);
-
-  const playEntrance = entrance && !reduce;
-
-  // Two blinks once settled (after an entrance), then a slow random idle
-  // blink; resting eyes skip the settle blinks and just idle.
-  const [blinking, setBlinking] = useState(false);
-  const [entranceDone, setEntranceDone] = useState(!entrance);
-  useEffect(() => {
-    if (reduce || !entranceDone) {
-      return;
-    }
-    let cancelled = false;
-    let t: ReturnType<typeof setTimeout>;
-    const blink = (next: () => void) => {
-      if (cancelled) {
-        return;
-      }
-      setBlinking(true);
-      t = setTimeout(() => {
-        if (cancelled) {
-          return;
-        }
-        setBlinking(false);
-        t = setTimeout(next, 140);
-      }, 140);
-    };
-    const idle = () => {
-      t = setTimeout(() => blink(idle), 2500 + Math.random() * 4000);
-    };
-    if (entrance) {
-      blink(() => blink(idle));
-    } else {
-      idle();
-    }
-    return () => {
-      cancelled = true;
-      clearTimeout(t);
-    };
-  }, [reduce, entranceDone, entrance]);
-
-  const eye = useMemo(() => {
+  const art = useMemo(() => {
     const def = components.eyeStyles.find((e) => e.id === traits.eyeStyle);
     if (!def) {
       return null;
@@ -119,88 +40,16 @@ export function AssistantPeekingEyes({
     };
   }, [components, traits.eyeStyle]);
 
-  if (!eye || w === 0 || h === 0) {
+  if (!art) {
     return null;
   }
 
-  // Size by the smaller stage dimension so the eyes shrink on narrow
-  // stages, capped to the stage width so wide eye styles never get cut off
-  // sideways.
-  const maxEyesW = w * EYE_MAX_WIDTH;
-  const eyesH = Math.min(
-    Math.min(w, h) * EYE_TARGET_HEIGHT,
-    (maxEyesW * eye.bbox.h) / eye.bbox.w,
-  );
-  const eyesW = (eyesH * eye.bbox.w) / eye.bbox.h;
-  const eyesLeft = (w - eyesW) / 2;
-  const eyesRestTop = h - (1 - EYE_REST_CUTOFF) * eyesH;
-  const eyesStartY = STAGE_CENTER_FRACTION * h - (eyesRestTop + eyesH / 2);
-  const eyesDipY = (EYE_DIP_CUTOFF - EYE_REST_CUTOFF) * eyesH;
-  const eyeCx = eye.bbox.x + eye.bbox.w / 2;
-  const eyeCy = eye.bbox.y + eye.bbox.h / 2;
-
   return (
-    <motion.div
-      aria-hidden="true"
-      className="pointer-events-none absolute z-[2]"
-      style={{
-        left: eyesLeft,
-        top: eyesRestTop,
-        width: eyesW,
-        height: eyesH,
-        transformOrigin: "center",
-      }}
-      initial={playEntrance ? { y: eyesStartY, scale: 0.35 } : false}
-      animate={
-        playEntrance
-          ? { y: [eyesStartY, eyesDipY, 0], scale: [0.35, 1, 1] }
-          : { y: 0, scale: 1 }
-      }
-      transition={
-        playEntrance
-          ? {
-              duration: 1,
-              delay: entranceDelay,
-              times: [0, 0.7, 1],
-              ease: "easeInOut",
-            }
-          : { duration: 0 }
-      }
-      onAnimationComplete={() => setEntranceDone(true)}
-    >
-      {/* Slight parallax: the whole eyes drift smoothly toward the cursor. */}
-      <div
-        style={{
-          transform: `translate(${pointer.x * CURSOR_MAX_X}px, ${pointer.y * CURSOR_MAX_Y}px)`,
-          transition: "transform 0.5s cubic-bezier(0.22, 1, 0.36, 1)",
-        }}
-      >
-        <svg
-          viewBox={`${eye.bbox.x} ${eye.bbox.y} ${eye.bbox.w} ${eye.bbox.h}`}
-          width={eyesW}
-          height={eyesH}
-          style={{ overflow: "visible", display: "block" }}
-        >
-          <g
-            style={{
-              transform: blinking ? "scaleY(0.1)" : "scaleY(1)",
-              transformOrigin: `${eyeCx}px ${eyeCy}px`,
-              transition: "transform 0.14s ease-in-out",
-            }}
-          >
-            {eye.paths.map((p, i) => (
-              <path key={i} d={p.svgPath} fill={p.color} />
-            ))}
-          </g>
-        </svg>
-      </div>
-    </motion.div>
+    <PeekingEyes
+      art={art}
+      stage={stage}
+      entrance={entrance}
+      entranceDelay={entranceDelay}
+    />
   );
 }
-
-/**
- * Fraction of the stage's smaller dimension covered by the eyes' visible
- * portion — content columns reserve this much at the bottom so foreground
- * controls always clear the eyes.
- */
-export const EYES_VISIBLE_FRACTION = EYE_TARGET_HEIGHT * (1 - EYE_REST_CUTOFF);

--- a/clients/web/src/domains/intelligence/components/assistant-stage.tsx
+++ b/clients/web/src/domains/intelligence/components/assistant-stage.tsx
@@ -20,15 +20,13 @@ import {
 } from "react";
 import { cn } from "@vellumai/design-library";
 
+import { EYES_VISIBLE_FRACTION } from "@/components/avatar/peeking-eyes";
 import { useElementSize, type StageSize } from "@/hooks/use-element-size";
 import { usePageSurfaceStore } from "@/stores/page-surface-store";
 import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
 import { toneForBg, type AvatarTone } from "@/utils/avatar-tone";
 
-import {
-  AssistantPeekingEyes,
-  EYES_VISIBLE_FRACTION,
-} from "./assistant-peeking-eyes";
+import { AssistantPeekingEyes } from "./assistant-peeking-eyes";
 
 /**
  * Backdrop when there is no avatar color to paint — a custom-image or

--- a/clients/web/src/domains/onboarding/components/onboarding-peeking-eyes.stories.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-peeking-eyes.stories.tsx
@@ -7,10 +7,10 @@
  * (`InsetByASafeArea` below), and nothing in the running app shows both cases
  * side by side.
  *
- * The same component also reads `window.innerWidth` / `innerHeight` directly for
- * its cursor parallax, ten lines from where it reads the stage box. That mixture
- * is the subject of LUM-3198; these stories are what make the difference between
- * the two boxes visible rather than argued about.
+ * The shared `PeekingEyes` it renders takes that stage box as a prop, yet reads
+ * `window.innerWidth` / `innerHeight` directly for its cursor parallax. That
+ * mixture is the subject of LUM-3198; these stories are what make the
+ * difference between the two boxes visible rather than argued about.
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
@@ -24,10 +24,9 @@ const meta: Meta<typeof OnboardingPeekingEyes> = {
   parameters: { layout: "fullscreen" },
   argTypes: {
     entrance: { control: "boolean" },
-    settleBlink: { control: "boolean" },
     entranceDelay: { control: { type: "number", step: 0.1 } },
   },
-  args: { entrance: false, settleBlink: false },
+  args: { entrance: false },
   render: (args) => (
     <StageHost>
       <OnboardingStage className="bg-[var(--surface-base)]">
@@ -47,7 +46,7 @@ export const Resting: Story = {};
 
 /** The Introduction step's grow-in, delayed behind the body cover. */
 export const Entrance: Story = {
-  args: { entrance: true, entranceDelay: 0.3, settleBlink: true },
+  args: { entrance: true, entranceDelay: 0.3 },
 };
 
 /** Phone width, where the eyes are sized from the smaller stage dimension. */

--- a/clients/web/src/domains/onboarding/components/onboarding-peeking-eyes.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-peeking-eyes.tsx
@@ -1,38 +1,24 @@
 /**
- * The assistant's eyes peeking up from the bottom edge — shared by the
+ * The onboarding backdrop's peeking eyes: {@link PeekingEyes} driven by the
+ * avatar picker's chosen character and the onboarding stage box, shared by the
  * Introduction and "How should I talk?" steps for continuity.
  *
- * SPIKE — research-onboarding flow.
- *
- * Renders the chosen avatar's eyes (whites + pupils, in the style's own
- * shapes) at the bottom of the screen, ~25% cut off, with an idle blink and a
- * slight cursor parallax. Pass `entrance` to play the Introduction grow-in
- * (the eyes rise into place, dipping a touch below rest first); otherwise they
- * sit at rest, as if carried over from the previous step.
- *
- * Decorative: `aria-hidden`, `pointer-events-none`, reduced-motion safe.
+ * SPIKE - research-onboarding flow.
  */
 
-import { useEffect, useMemo, useState } from "react";
-import { motion, useAnimationControls, useReducedMotion } from "motion/react";
+import { useMemo } from "react";
 
-import { pathBBox, unionBBox } from "@/utils/eye-bbox";
+import { PeekingEyes } from "@/components/avatar/peeking-eyes";
 import { useOnboardingStageSize } from "@/domains/onboarding/hooks/use-onboarding-stage-size";
 import { useOnboardingAvatarPoolStore } from "@/domains/onboarding/onboarding-avatar-pool-store";
+import { pathBBox, unionBBox } from "@/utils/eye-bbox";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 
-/** How much of the eyes sits below the bottom edge — at rest, and at the dip. */
-const EYE_REST_CUTOFF = 0.25;
-const EYE_DIP_CUTOFF = 0.46;
-/** Eye sizing: height is at most 30% of the viewport, capped so width stays
- *  on-screen. */
-const EYE_TARGET_HEIGHT = 0.3;
-const EYE_MAX_WIDTH = 0.85;
-/** Entrance hand-off: the eyes start from the picker's centered position. */
-const PICKER_CENTER_VH = 40;
-/** Slight whole-eye cursor parallax. */
-const CURSOR_MAX_X = 14;
-const CURSOR_MAX_Y = 8;
+/**
+ * The onboarding stage's bottom edge sits above where the eyes should read as
+ * cut off, so they sink a further 5% of stage height below rest.
+ */
+const REST_SINK_FRACTION = 0.05;
 
 interface OnboardingPeekingEyesProps {
   /** Play the grow-in entrance (Introduction). Otherwise the eyes are at rest. */
@@ -44,93 +30,21 @@ interface OnboardingPeekingEyesProps {
    * knock the integration-step coin up).
    */
   bumpNonce?: number;
-  /**
-   * Play the two settle blinks when the eyes settle. Off for resting eyes that
-   * are simply carried over from a previous step (they just idle-blink).
-   */
-  settleBlink?: boolean;
 }
 
 export function OnboardingPeekingEyes({
   entrance = false,
   entranceDelay = 0,
   bumpNonce = 0,
-  settleBlink = true,
 }: OnboardingPeekingEyesProps) {
   const components = useBundledAvatarComponents();
   const characters = useOnboardingAvatarPoolStore.use.characters();
   const selectedIndex = useOnboardingAvatarPoolStore.use.selectedIndex();
-  const reduce = useReducedMotion();
-  const { w, h } = useOnboardingStageSize();
-
-  const [pointer, setPointer] = useState({ x: 0, y: 0 });
-  useEffect(() => {
-    if (reduce) {
-      return;
-    }
-    const onMove = (e: MouseEvent) => {
-      setPointer({
-        x: (e.clientX / window.innerWidth - 0.5) * 2,
-        y: (e.clientY / window.innerHeight - 0.5) * 2,
-      });
-    };
-    window.addEventListener("mousemove", onMove);
-    return () => window.removeEventListener("mousemove", onMove);
-  }, [reduce]);
-
-  const playEntrance = entrance && !reduce;
-
-  // A one-shot upward jolt when `bumpNonce` increments (Mario block bump).
-  const bumpControls = useAnimationControls();
-  useEffect(() => {
-    if (bumpNonce > 0 && !reduce) {
-      void bumpControls.start({
-        y: [0, -34, 8, 0],
-        transition: { duration: 0.45, ease: "easeOut" },
-      });
-    }
-  }, [bumpNonce, reduce, bumpControls]);
-
-  // Two blinks once settled (when `settleBlink`), then a slow random idle blink.
-  const [blinking, setBlinking] = useState(false);
-  const [entranceDone, setEntranceDone] = useState(!entrance);
-  useEffect(() => {
-    if (reduce || !entranceDone) {
-      return;
-    }
-    let cancelled = false;
-    let t: ReturnType<typeof setTimeout>;
-    const blink = (next: () => void) => {
-      if (cancelled) {
-        return;
-      }
-      setBlinking(true);
-      t = setTimeout(() => {
-        if (cancelled) {
-          return;
-        }
-        setBlinking(false);
-        t = setTimeout(next, 140);
-      }, 140);
-    };
-    const idle = () => {
-      t = setTimeout(() => blink(idle), 2500 + Math.random() * 4000);
-    };
-    // Resting eyes (carried over) skip the settle blinks and just idle.
-    if (settleBlink) {
-      blink(() => blink(idle));
-    } else {
-      idle();
-    }
-    return () => {
-      cancelled = true;
-      clearTimeout(t);
-    };
-  }, [reduce, entranceDone, settleBlink]);
+  const stage = useOnboardingStageSize();
 
   const chosen = characters.length > 0 ? characters[selectedIndex] : undefined;
 
-  const eye = useMemo(() => {
+  const art = useMemo(() => {
     if (!components || !chosen) {
       return null;
     }
@@ -144,84 +58,18 @@ export function OnboardingPeekingEyes({
     };
   }, [components, chosen]);
 
-  if (!eye) {
+  if (!art) {
     return null;
   }
 
-  // Size by the smaller viewport dimension so the eyes shrink on mobile (in
-  // portrait, height alone would make them oversized), capped to the viewport
-  // width so wide eye styles never get cut off sideways.
-  const maxEyesW = w * EYE_MAX_WIDTH;
-  const eyesH = Math.min(
-    Math.min(w, h) * EYE_TARGET_HEIGHT,
-    (maxEyesW * eye.bbox.h) / eye.bbox.w,
-  );
-  const eyesW = (eyesH * eye.bbox.w) / eye.bbox.h;
-  const eyesLeft = (w - eyesW) / 2;
-  const eyesRestTop = h - (1 - EYE_REST_CUTOFF) * eyesH + h * 0.05;
-  const eyesStartY = (PICKER_CENTER_VH / 100) * h - (eyesRestTop + eyesH / 2);
-  const eyesDipY = (EYE_DIP_CUTOFF - EYE_REST_CUTOFF) * eyesH;
-  const eyeCx = eye.bbox.x + eye.bbox.w / 2;
-  const eyeCy = eye.bbox.y + eye.bbox.h / 2;
-
   return (
-    <motion.div
-      aria-hidden="true"
-      className="pointer-events-none absolute z-[2]"
-      style={{
-        left: eyesLeft,
-        top: eyesRestTop,
-        width: eyesW,
-        height: eyesH,
-        transformOrigin: "center",
-      }}
-      initial={playEntrance ? { y: eyesStartY, scale: 0.35 } : false}
-      animate={
-        playEntrance
-          ? { y: [eyesStartY, eyesDipY, 0], scale: [0.35, 1, 1] }
-          : { y: 0, scale: 1 }
-      }
-      transition={
-        playEntrance
-          ? {
-              duration: 1,
-              delay: entranceDelay,
-              times: [0, 0.7, 1],
-              ease: "easeInOut",
-            }
-          : { duration: 0 }
-      }
-      onAnimationComplete={() => setEntranceDone(true)}
-    >
-      {/* Mario-style bump (jolts up to knock the coin). */}
-      <motion.div animate={bumpControls}>
-        {/* Slight parallax: the whole eyes drift smoothly toward the cursor. */}
-        <div
-          style={{
-            transform: `translate(${pointer.x * CURSOR_MAX_X}px, ${pointer.y * CURSOR_MAX_Y}px)`,
-            transition: "transform 0.5s cubic-bezier(0.22, 1, 0.36, 1)",
-          }}
-        >
-          <svg
-            viewBox={`${eye.bbox.x} ${eye.bbox.y} ${eye.bbox.w} ${eye.bbox.h}`}
-            width={eyesW}
-            height={eyesH}
-            style={{ overflow: "visible", display: "block" }}
-          >
-            <g
-              style={{
-                transform: blinking ? "scaleY(0.1)" : "scaleY(1)",
-                transformOrigin: `${eyeCx}px ${eyeCy}px`,
-                transition: "transform 0.14s ease-in-out",
-              }}
-            >
-              {eye.paths.map((p, i) => (
-                <path key={i} d={p.svgPath} fill={p.color} />
-              ))}
-            </g>
-          </svg>
-        </div>
-      </motion.div>
-    </motion.div>
+    <PeekingEyes
+      art={art}
+      stage={stage}
+      entrance={entrance}
+      entranceDelay={entranceDelay}
+      restSinkFraction={REST_SINK_FRACTION}
+      bumpNonce={bumpNonce}
+    />
   );
 }

--- a/clients/web/src/domains/onboarding/components/onboarding-toned-backdrop.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-toned-backdrop.tsx
@@ -195,7 +195,6 @@ export function OnboardingTonedBackdrop({
       {showBottomEyes && (
         <OnboardingPeekingEyes
           bumpNonce={eyesBumpNonce}
-          settleBlink={eyesEntrance}
           entrance={eyesEntrance}
         />
       )}

--- a/clients/web/src/domains/onboarding/screens/create-personality-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/create-personality-step.tsx
@@ -27,6 +27,7 @@ import { ArrowRight } from "lucide-react";
 import * as SliderPrimitive from "@radix-ui/react-slider";
 
 import { AnimatedAvatar } from "@/components/avatar/animated-avatar";
+import { EYES_VISIBLE_FRACTION } from "@/components/avatar/peeking-eyes";
 import { OnboardingTopBar } from "@/domains/onboarding/components/onboarding-top-bar";
 import { useOnboardingStageSize } from "@/domains/onboarding/hooks/use-onboarding-stage-size";
 import { useOnboardingAvatarPoolStore } from "@/domains/onboarding/onboarding-avatar-pool-store";
@@ -145,14 +146,6 @@ const AVATAR_TOPS = ["9%", "27%", "45%", "62%", "79%"];
 
 /** Sliders start centered — no axis is nudged either way until the user acts. */
 const DEFAULT_VALUE = 50;
-
-/**
- * Fraction of the stage's smaller dimension covered by the backdrop eyes'
- * visible portion — mirrors `OnboardingPeekingEyes` (EYE_TARGET_HEIGHT 0.3 ×
- * (1 − EYE_REST_CUTOFF 0.25)). The content column reserves this much at the
- * bottom so the Continue button always clears the eyes.
- */
-const EYES_VISIBLE_FRACTION = 0.3 * (1 - 0.25);
 
 /**
  * Slider styling from Figma (node 6279-576): a thick, uniformly-tinted track


### PR DESCRIPTION
## TL;DR

`AssistantPeekingEyes` (About Assistant stage) and `OnboardingPeekingEyes` (onboarding backdrop) were the same component written twice. This collapses them onto one shared `PeekingEyes` and deletes both copies. Net **-79 lines**. No observable behavior change.

## What was duplicated

Its own docstring admitted it: *"the same visual and entrance choreography as onboarding's peeking eyes"*. The two files shared, verbatim:

- the sizing math (`EYE_TARGET_HEIGHT`, `EYE_MAX_WIDTH`, the smaller-dimension cap and the width clamp)
- the blink state machine (two settle blinks, then a `2500 + random*4000` idle loop)
- the cursor parallax effect and its `CURSOR_MAX_X` / `CURSOR_MAX_Y`
- the entrance motion config (`y` keyframes, `scale`, `times: [0, 0.7, 1]`)
- the SVG render and blink squish

The entrance hand-off constant was the same number written two ways: `STAGE_CENTER_FRACTION = 0.4` in one file, `PICKER_CENTER_VH = 40` in the other.

A third copy sat in [`create-personality-step.tsx`](clients/web/src/domains/onboarding/screens/create-personality-step.tsx), which restated the derived reserve as a literal `0.3 * (1 - 0.25)` under a comment asking the reader to keep it in sync with `OnboardingPeekingEyes` by hand. Meanwhile `assistant-stage.tsx` imported the real `EYES_VISIBLE_FRACTION`. One value, two owners, one of them a copy.

## The regression this structure hid

Change `EYE_TARGET_HEIGHT` on either component and only that component moves. Change it on `OnboardingPeekingEyes` and the personality step's bottom reserve does not follow at all, because it is a literal: the Continue button drifts under the eyes with nothing to catch it, since the constant it depends on lives in a file it does not import. After this change there is one constant and one derived export, so a sizing edit reaches every reserve site or fails to compile.

## Why it is safe

Structural only, and measured rather than argued. I rendered the emitted DOM before and after and compared element tree, class strings, style strings and geometry:

| Case | Before | After |
|---|---|---|
| Onboarding `Resting` (1280x720 stage) | `left: 491.161px; top: 594px; width: 297.678px; height: 216px` | identical |
| Onboarding `InsetByASafeArea` (390x751 stage) | `left: 114.379px; top: 700.8px; width: 161.242px; height: 117px` | identical |
| Assistant path (old and new rendered side by side) | `left: 196.135px; top: 372px; width: 247.73px; height: 144px` | identical |

Element trees matched too, including the bump wrapper being present for onboarding and absent for the assistant. `bumpNonce` is omitted rather than defaulted on the assistant side precisely so its DOM stays byte-identical.

Typecheck, lint and prettier are clean. Local `bun test` is blocked by a hook, so CI is the test signal here.

## What changes for the user

| | Before | After |
|---|---|---|
| Onboarding eyes: size, position, blink, parallax, entrance | as shipped | unchanged (measured identical) |
| About Assistant eyes: size, position, blink, parallax, entrance | as shipped | unchanged (measured identical) |
| Personality step: Continue button clearance | reserved from a hand-copied literal | reserved from the constant the eyes actually use (same value today) |
| Editing the eye sizing | edit two files, remember a third | edit one file |

## Two deliberate omissions

**`settleBlink` is deleted, not moved.** All three shipped call sites passed it equal to `entrance` (`onboarding-toned-backdrop` passed `settleBlink={eyesEntrance} entrance={eyesEntrance}`; `introduction-screen` passed `entrance` alone with the `true` default; the assistant copy tied it to `entrance` internally). It was a prop the component could derive, and a Storybook control that let the story diverge from anything the app can produce. The shared component derives it.

**`voice-room-eyes.tsx` and `onboarding-motion-eyes.tsx` are not folded in.** They render the eyes from caller-driven motion values, not this component, and voice deliberately tunes different constants (`0.22` / `0.6` plus an absolute px ceiling). Sharing them would mean publishing a JS geometry primitive, and [`use-element-size.ts`](clients/web/src/hooks/use-element-size.ts) says LUM-3204 tracks getting JS-computed clamps *out* of exactly these decorative layers. Making that easier to write is the wrong direction; the geometry here stays inside the one component that owns it.

## Follow-up worth filing

`unionBBox(def.paths.map((p) => pathBBox(p.svgPath)))` next to `components.eyeStyles.find(...)` appears at **8 call sites** (chat nav item, avatar tour, tour narration, amoeba avatar, voice room, motion eyes, and the two adapters here). A `resolveEyeArt(components, eyeStyleId)` helper in `utils/eye-bbox.ts` is the right home, but it reaches into six files outside this change, two of them in the directory #40699 is currently editing. Left out on purpose rather than half-extracted.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40705" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->