### PR TITLE
fix(ios): cancel the composer pill press on mousedown, not pointerdown

### DIFF
--- a/clients/web/docs/CAPACITOR.md
+++ b/clients/web/docs/CAPACITOR.md
@@ -102,6 +102,25 @@ References:
 
 ---
 
+## Cancelling `pointerdown` also cancels the tap's `click` on iOS
+
+A tap on iOS Safari/WKWebView produces `pointerdown`, `touchstart`, `pointerup`, `touchend`, then the compatibility `mousedown`, `mouseup`, and `click`. Calling `preventDefault()` on `pointerdown` suppresses **the entire remainder of that sequence, `click` included**. The Pointer Events spec says `click` should still be dispatched, and Chromium does dispatch it, so this is a WebKit-only divergence that a desktop or Android check will not catch.
+
+The practical case is holding focus on an input while a button is pressed, which needs the focus transfer suppressed without losing the activation. The focus transfer rides on the compatibility `mousedown`, so cancel that one:
+
+```tsx
+// Keeps the textarea focused; the button's click still fires.
+<button onMouseDown={(event) => event.preventDefault()} />
+```
+
+Cancelling `touchstart` has the same fatal effect as cancelling `pointerdown`. Reach for `pointerdown` only when you actually want to swallow the whole gesture, and remember that Radix menus (`DropdownMenu`, `Select`, `ContextMenu`) open **on `pointerdown`**, so cancelling it there makes the trigger inert; Radix `Dialog` and `BottomSheet` triggers open on `click` and are the ones this section is about.
+
+References:
+- W3C: [Pointer Events, compatibility mouse events](https://www.w3.org/TR/pointerevents/#compatibility-mapping-with-mouse-events)
+- MDN: [`preventDefault()` on pointer events](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events)
+
+---
+
 ## Programmatic text selection requires frame deferral on iOS
 
 iOS Safari/WKWebView ignores `HTMLInputElement.select()` and `setSelectionRange()` when called synchronously during `focus()` — the editing context (keyboard, selection system) isn't initialized until the next animation frame. This affects any code that programmatically focuses an input and immediately tries to select its content.

--- a/clients/web/src/domains/chat/components/composer-settings-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.test.tsx
@@ -804,10 +804,16 @@ describe("mobile pill triggers", () => {
     renderMenu({ props: { onOpenChange } });
 
     const accessTrigger = await screen.findByLabelText(ACCESS_TRIGGER_LABEL);
-    // iOS blurs the textarea before the click if pointerdown is allowed to
+    // WebKit blurs the textarea before the click if the press is allowed to
     // move focus. The pill must cancel that transfer so the focus-gated row
     // remains mounted long enough for the sheet trigger to receive the click.
-    expect(fireEvent.pointerDown(accessTrigger)).toBe(false);
+    //
+    // Both halves of the press matter. `mousedown` is the one that carries the
+    // focus transfer, so it has to be cancelled; `pointerdown` must be left
+    // alone, because WebKit drops the rest of the sequence when it is
+    // cancelled and the sheet would never get its click.
+    expect(fireEvent.pointerDown(accessTrigger)).toBe(true);
+    expect(fireEvent.mouseDown(accessTrigger)).toBe(false);
     fireEvent.click(accessTrigger);
     await waitFor(() => {
       expect(onOpenChange).toHaveBeenLastCalledWith(true);
@@ -829,6 +835,10 @@ describe("mobile pill triggers", () => {
     renderMenu({ props: { onOpenChange } });
 
     const profileTrigger = await screen.findByLabelText(/^Model profile/);
+    // Same press contract as the access pill: hold the focus on mousedown,
+    // leave pointerdown alone so the click still lands.
+    expect(fireEvent.pointerDown(profileTrigger)).toBe(true);
+    expect(fireEvent.mouseDown(profileTrigger)).toBe(false);
     fireEvent.click(profileTrigger);
     await waitFor(() => {
       expect(onOpenChange).toHaveBeenLastCalledWith(true);

--- a/clients/web/src/domains/chat/components/composer-settings-menu.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.tsx
@@ -13,7 +13,7 @@ import {
   useMemo,
   useRef,
   useState,
-  type PointerEvent as ReactPointerEvent,
+  type MouseEvent as ReactMouseEvent,
   type ReactNode,
 } from "react";
 
@@ -61,15 +61,21 @@ import {
 import { toast } from "@vellumai/design-library/components/toast";
 
 /**
- * Keeps a press from moving focus off the composer's textarea. iOS blurs the
+ * Keeps a press from moving focus off the composer's textarea. WebKit blurs the
  * textarea on a press without focusing the pressed button, and the pills row is
  * focus-gated, so it goes away before the tap's click reaches the trigger.
  *
- * Only ever wired on the touch presentation: its bottom sheet opens on the
- * click that follows, while the mouse presentation's menu opens on the
- * pointerdown itself and cancelling that would leave the pill inert.
+ * `mousedown` is the press to cancel, not `pointerdown`. WebKit drops the whole
+ * compatibility sequence when `pointerdown` is cancelled, `click` included, and
+ * the bottom sheet opens on that click. Cancelling the compatibility `mousedown`
+ * suppresses the focus transfer and nothing else. See
+ * `clients/web/docs/CAPACITOR.md` for the event ordering this relies on.
+ *
+ * Only ever wired on the touch presentation, whose sheet opens on click. The
+ * mouse presentation's menu opens on the pointerdown before it, which this
+ * leaves alone.
  */
-function preventPointerFocusTransfer(event: ReactPointerEvent<HTMLElement>) {
+function preventPressFocusTransfer(event: ReactMouseEvent<HTMLElement>) {
   event.preventDefault();
 }
 
@@ -673,10 +679,8 @@ export function ComposerSettingsMenu({
       title={accessLabel}
       className={pillClass}
       // Touch only: the bottom sheet opens on the click that follows, so the
-      // press has to leave the composer's focus alone until then. The mouse
-      // presentation below wraps this same pill in a menu that opens on
-      // pointerdown, which this would cancel outright.
-      onPointerDown={isTouchMobile ? preventPointerFocusTransfer : undefined}
+      // press has to leave the composer's focus alone until then.
+      onMouseDown={isTouchMobile ? preventPressFocusTransfer : undefined}
     >
       <span aria-hidden="true" className={pillIconClass}>
         <AccessIcon />
@@ -724,7 +728,7 @@ export function ComposerSettingsMenu({
         className={pillClass}
         // Match the access pill: hold the composer's focus for the sheet's
         // click, and only on the touch presentation that opens that way.
-        onPointerDown={isTouchMobile ? preventPointerFocusTransfer : undefined}
+        onMouseDown={isTouchMobile ? preventPressFocusTransfer : undefined}
       >
         <span aria-hidden="true" className={pillIconClass}>
           <Sparkles />
@@ -737,7 +741,7 @@ export function ComposerSettingsMenu({
         aria-label={profileLabel}
         title={profileLabel}
         className={pillIconOnlyClass}
-        onPointerDown={isTouchMobile ? preventPointerFocusTransfer : undefined}
+        onMouseDown={isTouchMobile ? preventPressFocusTransfer : undefined}
       >
         <span aria-hidden="true" className={pillIconClass}>
           <SlidersHorizontal />


### PR DESCRIPTION
## Summary

The mobile composer's **Assistant access** and **Model profile** pills do nothing when tapped on iOS. Neither bottom sheet opens.

#40694 already tried to fix this and did not, so this PR replaces its mechanism rather than adding to it.

## Root cause

The pills row is gated on `useComposerFocusWithin` and hidden with `hidden={!settingsPillsVisible}` (`chat-composer.tsx:773`, `:1337`). WebKit blurs the textarea on the tap's compatibility `mousedown` without focusing the pressed button, `focusout` fires with a null `relatedTarget`, the row becomes `display: none`, and the `click` that `BottomSheet.Trigger` opens on never reaches it. Radix `Dialog.Trigger` opens on `onClick` (`@radix-ui/react-dialog@1.1.18`), so the click is load-bearing.

#40694 cancelled `pointerdown` to hold the focus. That half works, but **WebKit drops the whole remainder of the compatibility sequence when `pointerdown` is cancelled, `click` included**, so the pill stays dead. The Pointer Events spec says `click` should still be dispatched and Chromium does dispatch it, which is why this passed review and CI: the bug and the broken fix are both WebKit-only.

This PR cancels the compatibility `mousedown` instead. That is the event the focus transfer actually rides on, and suppressing it leaves the click intact.

## Verification

Driven under Playwright WebKit with iPhone 14 emulation, against the real Radix `Dialog.Trigger` and the real `useComposerFocusWithin` hook wired the way `chat-composer.tsx` wires the pills row:

| engine | press cancelled | sheet opens? | pills hidden after? | focus lands |
| --- | --- | --- | --- | --- |
| WebKit | none (shipped in `v0.11.4-staging.1`) | **no** | yes | `body` |
| WebKit | `pointerdown` (#40694, current main) | **no** | no | textarea |
| WebKit | `mousedown` (this PR) | **yes** | no | sheet |
| Chromium | all three | yes | no | sheet |

Also ran:

- `bun scripts/run-tests.ts src/domains/chat/components/composer-settings-menu.test.tsx` passes. Reverting the component to `onPointerDown` makes the two new assertions fail, so the guard is real.
- `bunx tsc --noEmit`: 6 errors, byte-identical to the same run on the unmodified base commit (stale worktree `node_modules`, all in untouched files). Zero introduced.
- `bunx eslint` clean on both changed files.

Not yet checked on a physical handset.

## Changes

- `composer-settings-menu.tsx`: the three pill triggers (access, labelled profile, icon-only profile) cancel `mousedown` rather than `pointerdown`. The `isTouchMobile` gate is unchanged, so the mouse presentation's `pointerdown`-activated menu is untouched.
- `composer-settings-menu.test.tsx`: the regression assertion now pins both halves of the contract, that `mousedown` is cancelled and `pointerdown` is not. The second half is what #40694 lacked.
- `docs/CAPACITOR.md`: new section recording the WebKit divergence, next to the existing iOS click-event gotcha.

## Note on rollout

This does not unblock anyone already on a build. `v0.11.4-staging.1` was cut 2026-08-14 12:08 UTC and contains the redesign (#40675) but not #40694, which merged at 23:15 UTC the same day. Any device seeing the pills today needs a new build cut, not just this merge.

Reviewer: @Jasonnnz
