### PR TITLE
fix(profiles): repoint managed cost-optimized pin to MiniMax M3 via Together

### DIFF
--- a/assistant/src/config/default-profile-catalog.ts
+++ b/assistant/src/config/default-profile-catalog.ts
@@ -98,7 +98,7 @@ const VELLUM_PROFILE_IMPLS: ProfileImpls = {
     },
   },
   "cost-optimized": {
-    model: "accounts/fireworks/models/deepseek-v4-pro",
+    model: "MiniMaxAI/MiniMax-M3",
     provider: "vellum",
     source: "managed",
     label: "Cost",

--- a/assistant/src/config/default-profile-catalog.ts
+++ b/assistant/src/config/default-profile-catalog.ts
@@ -98,7 +98,7 @@ const VELLUM_PROFILE_IMPLS: ProfileImpls = {
     },
   },
   "cost-optimized": {
-    model: "accounts/fireworks/models/deepseek-v4-flash",
+    model: "accounts/fireworks/models/deepseek-v4-pro",
     provider: "vellum",
     source: "managed",
     label: "Cost",

--- a/assistant/src/plugin-api/vision-support.test.ts
+++ b/assistant/src/plugin-api/vision-support.test.ts
@@ -161,7 +161,7 @@ describe("doesSupportVision", () => {
 
 describe("doesSupportVision with a BYO default provider", () => {
   test("judges a default profile against the default provider's column model", () => {
-    // Managed/vellum column: cost-optimized → deepseek-v4-flash (text-only,
+    // Managed/vellum column: cost-optimized → deepseek-v4-pro (text-only,
     // supportsVision: false). Anthropic column: cost-optimized carries
     // intent "latency-optimized" → claude-haiku-4-5 (supportsVision: true).
     // The judged model must be the one the BYO install actually runs.
@@ -171,7 +171,7 @@ describe("doesSupportVision with a BYO default provider", () => {
 
   test("without a default provider, a default profile judges the managed column", () => {
     // Null-reduction: no defaultProvider resolves cost-optimized through the
-    // vellum column (deepseek-v4-flash, text-only).
+    // vellum column (deepseek-v4-pro, text-only).
     setMockConfig({});
     expect(doesSupportVision(profile("cost-optimized"))).toBe(false);
   });

--- a/assistant/src/plugin-api/vision-support.test.ts
+++ b/assistant/src/plugin-api/vision-support.test.ts
@@ -161,19 +161,21 @@ describe("doesSupportVision", () => {
 
 describe("doesSupportVision with a BYO default provider", () => {
   test("judges a default profile against the default provider's column model", () => {
-    // Managed/vellum column: cost-optimized → deepseek-v4-pro (text-only,
-    // supportsVision: false). Anthropic column: cost-optimized carries
-    // intent "latency-optimized" → claude-haiku-4-5 (supportsVision: true).
-    // The judged model must be the one the BYO install actually runs.
-    setMockConfig({}, { provider: "anthropic" });
-    expect(doesSupportVision(profile("cost-optimized"))).toBe(true);
+    // Managed/vellum column: cost-optimized → MiniMax M3 (supportsVision:
+    // true). Fireworks column: cost-optimized → deepseek-v4-flash
+    // (text-only, supportsVision: false). The judged model must be the one
+    // the BYO install actually runs, so only the fireworks column's verdict
+    // is false here.
+    setMockConfig({}, { provider: "fireworks" });
+    expect(doesSupportVision(profile("cost-optimized"))).toBe(false);
   });
 
   test("without a default provider, a default profile judges the managed column", () => {
     // Null-reduction: no defaultProvider resolves cost-optimized through the
-    // vellum column (deepseek-v4-pro, text-only).
+    // vellum column (MiniMax M3, vision-capable). Vision resolution fails
+    // safe to false, so a true verdict proves the column resolved.
     setMockConfig({});
-    expect(doesSupportVision(profile("cost-optimized"))).toBe(false);
+    expect(doesSupportVision(profile("cost-optimized"))).toBe(true);
   });
 
   test("mix arms naming a default profile resolve through the same column", () => {

--- a/assistant/src/runtime/routes/__tests__/inference-send-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-send-routes.test.ts
@@ -252,7 +252,7 @@ describe("inference_send profile usability", () => {
     const err = await rejection({ ...hermes, status: "disabled" });
     expect(err).toBeInstanceOf(BadRequestError);
     expect(err.message).toContain("disabled");
-    expect(err.message).toContain("deepseek-v4-pro");
+    expect(err.message).toContain("MiniMaxAI/MiniMax-M3");
   });
 
   test("rejects a profile that lost its provider", async () => {

--- a/assistant/src/runtime/routes/__tests__/inference-send-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-send-routes.test.ts
@@ -252,7 +252,7 @@ describe("inference_send profile usability", () => {
     const err = await rejection({ ...hermes, status: "disabled" });
     expect(err).toBeInstanceOf(BadRequestError);
     expect(err.message).toContain("disabled");
-    expect(err.message).toContain("deepseek-v4-flash");
+    expect(err.message).toContain("deepseek-v4-pro");
   });
 
   test("rejects a profile that lost its provider", async () => {

--- a/clients/docs/src/app/docs/_components/model-profiles-content.tsx
+++ b/clients/docs/src/app/docs/_components/model-profiles-content.tsx
@@ -104,7 +104,7 @@ export function ModelProfilesContent() {
                   <td className="py-3 pr-4">
                     <span className="font-semibold text-stone-900 dark:text-stone-100">Cost</span>
                   </td>
-                  <td className="py-3 pr-4">DeepSeek V4 Pro</td>
+                  <td className="py-3 pr-4">MiniMax M3</td>
                   <td className="py-3">Simple, short, or structural tasks run at high volume</td>
                 </tr>
               </tbody>

--- a/clients/docs/src/app/docs/_components/model-profiles-content.tsx
+++ b/clients/docs/src/app/docs/_components/model-profiles-content.tsx
@@ -104,7 +104,7 @@ export function ModelProfilesContent() {
                   <td className="py-3 pr-4">
                     <span className="font-semibold text-stone-900 dark:text-stone-100">Cost</span>
                   </td>
-                  <td className="py-3 pr-4">DeepSeek V4 Flash</td>
+                  <td className="py-3 pr-4">DeepSeek V4 Pro</td>
                   <td className="py-3">Simple, short, or structural tasks run at high volume</td>
                 </tr>
               </tbody>


### PR DESCRIPTION
## Summary
- Swap the managed (vellum-column) `cost-optimized` profile pin in `default-profile-catalog.ts` from `accounts/fireworks/models/deepseek-v4-flash` to `MiniMaxAI/MiniMax-M3`. The bare id is owned by the Together catalog, so `getManagedUpstream` routes the managed Cost profile through Together. The vellum column is overwritten in workspace config on every daemon boot, so existing installs pick this up without a migration.
- Update the tests coupled to the pin: the `inference-send-routes` disabled-profile rejection now expects the new model id, and the `vision-support` column tests move their text-only contrast to the fireworks BYOK column because MiniMax M3 is vision-capable (the managed Cost profile now counts as vision-capable, which is a real behavior change of this pin move).
- Update the docs model-profiles table (Cost row) to MiniMax M3.
- No web-catalog change was needed: `clients/web/src/assistant/llm-model-catalog.ts` already lists `MiniMaxAI/MiniMax-M3` under together, which is in `VELLUM_SERVED_PROVIDERS`, so managed-upstream resolution works. Known cosmetic nit: the Vellum picker's `VELLUM_MODELS` union dedupes by display name and the fireworks-hosted MiniMax M3 wins, so the pinned together id falls back to the stripped-id label ("MiniMax-M3") in profile rows. BYOK intent tables (`model-intents.ts`) are deliberately untouched.

## Original prompt
Swap deepseek-v4-flash out of the managed cost-optimized profile in default-profile-catalog.ts and mirror the change user-facing. Initially targeted DeepSeek V4 Pro (Doctor-validated), then redirected mid-review to MiniMax M3 served via Together. Intended to retire the biggest recurring support-ticket class (~7 tickets/month) caused by the Flash pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F1wkkwYRRHWAc8Gz5uDKJm