### PR TITLE
fix(web): mark channel-setup close-notify sends as scripted

### DIFF
--- a/clients/web/src/domains/chat/channel-setup-close-notify.test.ts
+++ b/clients/web/src/domains/chat/channel-setup-close-notify.test.ts
@@ -110,6 +110,9 @@ describe("notifyChannelSetupClosed", () => {
     );
     // Hidden: persisted and LLM-visible, but suppressed from the transcript.
     expect(postCalls[0]?.body.hidden).toBe(true);
+    // Scripted: machine-authored marker — an unmarked send is stamped
+    // scripted:false by the daemon and pollutes activation metrics.
+    expect(postCalls[0]?.body.scripted).toBe(true);
     // The wire field is version-gated (conversationId vs conversationKey);
     // either way it must target the originating conversation.
     expect(
@@ -186,5 +189,6 @@ describe("notifyChannelSetupHandedOff", () => {
       "[User action on channel_setup surface: moved the slack setup to the Contacts page]",
     );
     expect(postCalls[0]?.body.hidden).toBe(true);
+    expect(postCalls[0]?.body.scripted).toBe(true);
   });
 });

--- a/clients/web/src/domains/chat/channel-setup-close-notify.test.ts
+++ b/clients/web/src/domains/chat/channel-setup-close-notify.test.ts
@@ -110,7 +110,7 @@ describe("notifyChannelSetupClosed", () => {
     );
     // Hidden: persisted and LLM-visible, but suppressed from the transcript.
     expect(postCalls[0]?.body.hidden).toBe(true);
-    // Scripted: machine-authored marker — an unmarked send is stamped
+    // Scripted: machine-authored marker. An unmarked send is stamped
     // scripted:false by the daemon and pollutes activation metrics.
     expect(postCalls[0]?.body.scripted).toBe(true);
     // The wire field is version-gated (conversationId vs conversationKey);

--- a/clients/web/src/domains/chat/channel-setup-close-notify.ts
+++ b/clients/web/src/domains/chat/channel-setup-close-notify.ts
@@ -86,11 +86,16 @@ async function sendChannelSetupSignal(
     if (!(await resolveSupportsChannelSetupCloseNotify())) {
       return;
     }
+    // `scripted: true` is required: this text is machine-authored (the
+    // `[User action on ...]` synthetic convention), and the daemon defaults
+    // unmarked sends to `scripted: false` ("the user typed this"), which
+    // counts the turn toward activation and trips the
+    // `assert_scripted_signals_agree` dbt test against the text classifier.
     const result = await postChatMessage(
       payload.assistantId,
       conversationId,
       content,
-      { hidden: true },
+      { hidden: true, scripted: true },
     );
     if (!result.ok) {
       captureError(


### PR DESCRIPTION
## What

Adds `scripted: true` to the two `postChatMessage` calls in `sendChannelSetupSignal` (channel-setup drawer closed / handed off to Contacts), plus test assertions for both paths.

## Why

These sends are machine-authored (they use the synthetic `[User action on channel_setup surface: ...]` convention) but were posted with only `{ hidden: true }`. Since the Aug 4 release, the daemon stamps a `scripted: false` default on every unmarked send (ANT-10), so these markers land as "the user typed this." Two consequences:

1. They count toward activation metrics (turn counts) for owners the trace classifier can't cover.
2. They trip the `assert_scripted_signals_agree` dbt test in the platform repo (61 of the 74 failing rows are this path), which made every dbt CD run fail since **2026-08-05**, skipping `fct_onboarding_funnel` and freezing the admin activation dashboards for 12 days (the fake -87% on /admin/top-of-funnel).

## Provenance: how the bug arose

No single PR was wrong in isolation; the freeze is the interaction of three changes:

- **#36954** introduced the channel-setup close-notify path with unmarked synthetic sends. Harmless at the time: the `scripted` field did not exist yet, and these turns were only classifiable via the trace text-matcher.
- **#39814** (merged Aug 3, prod via the Aug 4 release train) made the daemon persist `scripted` on every user message with a **`false` default**, on the assumption that every auto-send path marks itself `true`. This path was missed, turning its unmarked sends into explicit wrong assertions.
- **vellum-ai/vellum-assistant-platform#9715** (merged Aug 3) added the build-blocking `assert_scripted_signals_agree` dbt test comparing the flag against the trace classifier. The first contradiction rows from this path landed Aug 5 and failed every dbt CD run from then on.

## Verification

- `bun test src/domains/chat/channel-setup-close-notify.test.ts`: 9 pass, 0 fail, including new `scripted: true` assertions on both marker paths.

## Rollout

- Platform PR vellum-ai/vellum-assistant-platform#9882 (bounded test severity) unfreezes the mart independently and is already merged; it does not depend on this PR.
- This PR rides the next release train. Once it is live in production, the platform test should be restored to plain `severity: error` with a `dt` floor at the go-live date (noted in #9882).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40709" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->