### PR TITLE
refactor(web): give the id-copy menus back the guarded clipboard write (LUM-3276)

### DIFF
--- a/clients/web/src/domains/chat/utils/copy-id-to-clipboard.test.ts
+++ b/clients/web/src/domains/chat/utils/copy-id-to-clipboard.test.ts
@@ -1,0 +1,89 @@
+/**
+ * The two failure cases pin the delegation: a helper owning its own
+ * `navigator.clipboard.writeText` throws where the Clipboard API is absent
+ * and reports nothing where the write is refused, and both reach the user as
+ * a menu item that silently does nothing.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const toastSuccess = mock(() => {});
+const toastError = mock(() => {});
+mock.module("@vellumai/design-library/components/toast", () => ({
+  toast: { success: toastSuccess, error: toastError },
+}));
+
+const captureErrorMock = mock(() => {});
+mock.module("@/lib/sentry/capture-error", () => ({
+  captureError: captureErrorMock,
+}));
+
+const { copyIdToClipboard } = await import("./copy-id-to-clipboard");
+
+let writeTextResult: Promise<void>;
+const writeText = mock((_text: string) => writeTextResult);
+
+Object.defineProperty(navigator, "clipboard", {
+  configurable: true,
+  value: { writeText },
+});
+
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+beforeEach(() => {
+  toastSuccess.mockClear();
+  toastError.mockClear();
+  captureErrorMock.mockClear();
+  writeText.mockClear();
+  writeTextResult = Promise.resolve();
+});
+
+describe("copyIdToClipboard", () => {
+  test("writes the id and names it in the success toast", async () => {
+    copyIdToClipboard("conv_123", "Conversation ID");
+    await flushMicrotasks();
+
+    expect(writeText).toHaveBeenCalledWith("conv_123");
+    expect(toastSuccess).toHaveBeenCalledWith(
+      "Conversation ID copied to clipboard.",
+    );
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  test("reports the failure as well as toasting when the write is refused", async () => {
+    writeTextResult = Promise.reject(new Error("denied"));
+
+    copyIdToClipboard("grp_456", "Group ID");
+    await flushMicrotasks();
+
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(toastError).toHaveBeenCalledWith("Couldn't copy the group id.");
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("toasts and reports instead of throwing when the Clipboard API is absent", () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: undefined,
+    });
+    try {
+      // A bare `navigator.clipboard.writeText` throws a TypeError here, and it
+      // throws inside the menu's click handler, so nothing is toasted.
+      expect(() =>
+        copyIdToClipboard("conv_123", "Conversation ID"),
+      ).not.toThrow();
+
+      expect(toastSuccess).not.toHaveBeenCalled();
+      expect(toastError).toHaveBeenCalledWith(
+        "Couldn't copy the conversation id.",
+      );
+      expect(captureErrorMock).toHaveBeenCalledTimes(1);
+    } finally {
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: { writeText },
+      });
+    }
+  });
+});

--- a/clients/web/src/domains/chat/utils/copy-id-to-clipboard.test.ts
+++ b/clients/web/src/domains/chat/utils/copy-id-to-clipboard.test.ts
@@ -5,10 +5,16 @@
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-const copyToClipboardMock = mock((_text: string, _options: unknown) => {});
-mock.module("@/lib/copy-to-clipboard", () => ({
-  copyToClipboard: copyToClipboardMock,
-}));
+import type * as CopyToClipboardModule from "@/lib/copy-to-clipboard";
+
+const copyToClipboardMock =
+  mock<typeof CopyToClipboardModule.copyToClipboard>();
+mock.module(
+  "@/lib/copy-to-clipboard",
+  (): Partial<typeof CopyToClipboardModule> => ({
+    copyToClipboard: copyToClipboardMock,
+  }),
+);
 
 const { copyIdToClipboard } = await import("./copy-id-to-clipboard");
 

--- a/clients/web/src/domains/chat/utils/copy-id-to-clipboard.test.ts
+++ b/clients/web/src/domains/chat/utils/copy-id-to-clipboard.test.ts
@@ -1,8 +1,7 @@
 /**
- * Pins the delegation and the wording, which is all this helper owns. What
- * happens when a write is refused or the Clipboard API is missing belongs to
- * `copyToClipboard` and is covered in `lib/copy-to-clipboard.test.ts`; a
- * helper that writes for itself is a helper that skips both of those.
+ * Covers the delegation and the wording, which is all this helper owns. The
+ * outcome of the write itself belongs to `copyToClipboard` and is covered in
+ * `lib/copy-to-clipboard.test.ts`.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 

--- a/clients/web/src/domains/chat/utils/copy-id-to-clipboard.test.ts
+++ b/clients/web/src/domains/chat/utils/copy-id-to-clipboard.test.ts
@@ -1,89 +1,38 @@
 /**
- * The two failure cases pin the delegation: a helper owning its own
- * `navigator.clipboard.writeText` throws where the Clipboard API is absent
- * and reports nothing where the write is refused, and both reach the user as
- * a menu item that silently does nothing.
+ * Pins the delegation and the wording, which is all this helper owns. What
+ * happens when a write is refused or the Clipboard API is missing belongs to
+ * `copyToClipboard` and is covered in `lib/copy-to-clipboard.test.ts`; a
+ * helper that writes for itself is a helper that skips both of those.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-const toastSuccess = mock(() => {});
-const toastError = mock(() => {});
-mock.module("@vellumai/design-library/components/toast", () => ({
-  toast: { success: toastSuccess, error: toastError },
-}));
-
-const captureErrorMock = mock(() => {});
-mock.module("@/lib/sentry/capture-error", () => ({
-  captureError: captureErrorMock,
+const copyToClipboardMock = mock((_text: string, _options: unknown) => {});
+mock.module("@/lib/copy-to-clipboard", () => ({
+  copyToClipboard: copyToClipboardMock,
 }));
 
 const { copyIdToClipboard } = await import("./copy-id-to-clipboard");
 
-let writeTextResult: Promise<void>;
-const writeText = mock((_text: string) => writeTextResult);
-
-Object.defineProperty(navigator, "clipboard", {
-  configurable: true,
-  value: { writeText },
-});
-
-function flushMicrotasks(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 0));
-}
-
 beforeEach(() => {
-  toastSuccess.mockClear();
-  toastError.mockClear();
-  captureErrorMock.mockClear();
-  writeText.mockClear();
-  writeTextResult = Promise.resolve();
+  copyToClipboardMock.mockClear();
 });
 
 describe("copyIdToClipboard", () => {
-  test("writes the id and names it in the success toast", async () => {
+  test("hands the id and both messages to the shared clipboard helper", () => {
     copyIdToClipboard("conv_123", "Conversation ID");
-    await flushMicrotasks();
 
-    expect(writeText).toHaveBeenCalledWith("conv_123");
-    expect(toastSuccess).toHaveBeenCalledWith(
-      "Conversation ID copied to clipboard.",
-    );
-    expect(toastError).not.toHaveBeenCalled();
-  });
-
-  test("reports the failure as well as toasting when the write is refused", async () => {
-    writeTextResult = Promise.reject(new Error("denied"));
-
-    copyIdToClipboard("grp_456", "Group ID");
-    await flushMicrotasks();
-
-    expect(toastSuccess).not.toHaveBeenCalled();
-    expect(toastError).toHaveBeenCalledWith("Couldn't copy the group id.");
-    expect(captureErrorMock).toHaveBeenCalledTimes(1);
-  });
-
-  test("toasts and reports instead of throwing when the Clipboard API is absent", () => {
-    Object.defineProperty(navigator, "clipboard", {
-      configurable: true,
-      value: undefined,
+    expect(copyToClipboardMock).toHaveBeenCalledWith("conv_123", {
+      successMessage: "Conversation ID copied to clipboard.",
+      errorMessage: "Couldn't copy the conversation id.",
     });
-    try {
-      // A bare `navigator.clipboard.writeText` throws a TypeError here, and it
-      // throws inside the menu's click handler, so nothing is toasted.
-      expect(() =>
-        copyIdToClipboard("conv_123", "Conversation ID"),
-      ).not.toThrow();
+  });
 
-      expect(toastSuccess).not.toHaveBeenCalled();
-      expect(toastError).toHaveBeenCalledWith(
-        "Couldn't copy the conversation id.",
-      );
-      expect(captureErrorMock).toHaveBeenCalledTimes(1);
-    } finally {
-      Object.defineProperty(navigator, "clipboard", {
-        configurable: true,
-        value: { writeText },
-      });
-    }
+  test("lower-cases the label in the failure message only", () => {
+    copyIdToClipboard("grp_456", "Group ID");
+
+    expect(copyToClipboardMock).toHaveBeenCalledWith("grp_456", {
+      successMessage: "Group ID copied to clipboard.",
+      errorMessage: "Couldn't copy the group id.",
+    });
   });
 });

--- a/clients/web/src/domains/chat/utils/copy-id-to-clipboard.ts
+++ b/clients/web/src/domains/chat/utils/copy-id-to-clipboard.ts
@@ -1,13 +1,18 @@
-import { toast } from "@vellumai/design-library/components/toast";
+import { copyToClipboard } from "@/lib/copy-to-clipboard";
 
 /**
  * Copy an identifier (conversation id, group id) to the clipboard with toast
  * feedback. Shared by the conversation and group overflow menus so users can
  * paste a precise reference into chat for the assistant to act on.
+ *
+ * Owns the wording only. `copyToClipboard` owns the write, and is the one
+ * place that guards a missing Clipboard API and reports failures through
+ * `captureError`. That reporting matters because the shell can refuse a write
+ * the page considers fine, as an Electron permission did in LUM-2321.
  */
 export function copyIdToClipboard(id: string, label: string): void {
-  navigator.clipboard.writeText(id).then(
-    () => toast.success(`${label} copied to clipboard.`),
-    () => toast.error(`Couldn't copy the ${label.toLowerCase()}.`),
-  );
+  copyToClipboard(id, {
+    successMessage: `${label} copied to clipboard.`,
+    errorMessage: `Couldn't copy the ${label.toLowerCase()}.`,
+  });
 }


### PR DESCRIPTION
## TL;DR

`copy-id-to-clipboard.ts` was the second implementation of "write to the clipboard and tell the user", and it was the one that could not report a failure. It now delegates to `lib/copy-to-clipboard.ts`, which already owns that job for every other clipboard caller in the client.

Fixes LUM-3276.

## What was wrong

The helper did two things: build toast wording from a label, **and** write to the clipboard. The second half duplicated `copyToClipboard`, minus the parts that matter:

| | `lib/copy-to-clipboard.ts` (owner) | `copy-id-to-clipboard.ts` (before) |
| --- | --- | --- |
| Clipboard API missing | toasts, reports | throws `TypeError` in the click handler |
| Write refused | toasts, reports | toasts, reports nothing |

Three menu items go through it: "Copy conversation ID" in the chat header and the sidebar conversation row, and "Copy group ID" in the side menu.

## How it got here

#39399 extracted the owner and moved eleven call sites onto it, this file included. The `Release v0.11.0` commit (`6cc0273a6c`, #39456) reverted this one file to its pre-extraction form. It is the only one of the eleven that regressed, and it has been that way on `main` since 2026-07-28.

## Why the reporting half matters

LUM-2321 was this exact failure: the Electron shell refused the write because the trusted renderer was missing `clipboard-sanitized-write`. Nothing reported it, so it surfaced only when a user posted about it in Slack. These three menu items were the last copy paths in the client that still could not report a recurrence.

## Before / after for a user

| Situation | Before | After |
| --- | --- | --- |
| Copy succeeds | "Conversation ID copied to clipboard." | unchanged |
| Copy refused by the shell | "Couldn't copy the conversation ID.", nothing recorded | same toast, and the failure reaches Sentry |
| No Clipboard API available | menu item does nothing at all, silently | "Couldn't copy the conversation ID.", failure reaches Sentry |

## Why it is safe

- `copyIdToClipboard(id, label)` keeps its signature, so no call site changes. The diff is two files, one of them the new test.
- The success path is unchanged in text and behaviour: same `writeText` call, same toast string.
- The two changed rows above are failure paths that previously produced a silent dead menu item or a silent gap in telemetry. That is the bug named in LUM-3276, fixed here because the structural change is what removes it; there is no separate behaviour change riding along.
- `clients/web` typecheck, eslint, and the pinned prettier all pass. Local `bun test` is blocked by a standing hook, so the new test is verified by CI.

## The test

This helper owns the delegation and the two message strings, so the test asserts those against a mocked `copyToClipboard`. What happens when a write is refused or the Clipboard API is absent belongs to the owner and is already covered in `lib/copy-to-clipboard.test.ts`.

It still fails against the implementation being replaced, and for a legible reason: the reverted helper never calls `copyToClipboard` at all. So a future revert of this file does not pass CI.
