### PR TITLE
probe(LUM-2987): route Conversation emissions through the hub [scratch, do not merge]

### DIFF
--- a/assistant/src/__tests__/conversation-slash-queue.test.ts
+++ b/assistant/src/__tests__/conversation-slash-queue.test.ts
@@ -62,6 +62,9 @@ mock.module("../persistence/conversation-crud.js", () => ({
   getLastUserTimestampBefore: () => 0,
   reserveMessage: mock(async () => ({ id: "msg-reserve" })),
   updateMessageContent: mock(() => {}),
+  // Probe: hub-routed emissions stamp seqs, so the drain now reaches the real
+  // recorder with seq > 0 and it hits SQLite the crud mock exists to avoid.
+  recordConversationPersistedSeq: () => {},
 }));
 
 mock.module("../persistence/conversation-queries.js", () => ({

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -1801,7 +1801,7 @@ export class Conversation {
   } {
     return enqueueMessageImpl(this, {
       ...options,
-      onEvent: options.onEvent ?? this.sendToClient,
+      onEvent: options.onEvent ?? broadcastMessage,
     });
   }
 
@@ -1977,7 +1977,7 @@ export class Conversation {
       ...params,
     } as AssistantEvent;
     try {
-      this.sendToClient(msg);
+      broadcastMessage(msg);
     } catch (err) {
       log.warn(
         { err, conversationId: this.conversationId },
@@ -2009,7 +2009,7 @@ export class Conversation {
     } as AssistantEvent;
     this.lastActivityStateMsg = msg;
     try {
-      this.sendToClient(msg);
+      broadcastMessage(msg);
     } catch (err) {
       log.warn(
         { err, conversationId: this.conversationId },
@@ -2069,7 +2069,7 @@ export class Conversation {
     onEvent?: (msg: AssistantEvent) => void,
   ): void {
     try {
-      (onEvent ?? this.sendToClient)({
+      (onEvent ?? broadcastMessage)({
         type: "context_window_usage",
         conversationId: this.conversationId,
         tokens,
@@ -2722,7 +2722,7 @@ export class Conversation {
       this,
       content,
       userMessageId,
-      onEvent ?? this.sendToClient,
+      onEvent ?? broadcastMessage,
       rest,
     );
   }
@@ -2748,7 +2748,7 @@ export class Conversation {
     this.cacheWarmAbort = undefined;
     return processMessageImpl(this, {
       ...options,
-      onEvent: options.onEvent ?? this.sendToClient,
+      onEvent: options.onEvent ?? broadcastMessage,
     });
   }
 


### PR DESCRIPTION
Scratch CI probe for LUM-2987, not for review or merge. It reproduces the prior local experiment that broke `conversation-slash-queue.test.ts` ("passthrough batch is terminated by a /compact in the middle of the queue") so CI can show the actual failure mode. Will be closed once read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)