### PR TITLE
refactor(web): drop the ?prompt= target gate the send-to-chat shortcut no longer needs (LUM-3230)

### DIFF
--- a/clients/web/src/domains/chat/active-chat-view.tsx
+++ b/clients/web/src/domains/chat/active-chat-view.tsx
@@ -73,14 +73,7 @@ import { useChatHeaderRegistration } from "@/domains/chat/hooks/use-chat-header-
 import { useConversationChangeEffects } from "@/domains/chat/hooks/use-conversation-change-effects";
 import { useSubagentReconcile } from "@/domains/chat/hooks/use-subagent-reconcile";
 import { useComposerKeyboard } from "@/domains/chat/hooks/use-composer-keyboard";
-import {
-  useAutoSendEffects,
-  type UrlPromptTargetResolution,
-} from "@/domains/chat/hooks/use-auto-send-effects";
-import { useQuery } from "@tanstack/react-query";
-
-import { conversationsByIdGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
-import { ConversationNotFoundError } from "@/utils/fetch-conversation-detail";
+import { useAutoSendEffects } from "@/domains/chat/hooks/use-auto-send-effects";
 import { useOnboardingAttribution } from "@/hooks/use-onboarding-attribution";
 
 import { ChatContentLayout } from "@/domains/chat/components/chat-content-layout";
@@ -300,50 +293,10 @@ export function ActiveChatView() {
     refreshConversations,
   });
 
-  // Resolve the ?prompt= target against live data so the auto-send below can
-  // refuse ids the send path would otherwise treat as new-conversation drafts
-  // (a stale iOS Shortcuts pick, a deleted chat). `activeConversation` covers
-  // every loaded cache (foreground, background, scheduled, archived) plus the
-  // single-row fetch `useActiveConversation` fires for a thread in none of
-  // them; the probe below passively observes that fetch's query entry
-  // (`enabled: false`, never fetches) so a settled 404 is distinguishable
-  // from "still resolving". Only a definitive not-found flips to "missing":
-  // a transient fetch error keeps holding the send rather than dropping it.
-  const conversationRowProbe = useQuery({
-    ...conversationsByIdGetOptions({
-      path: {
-        assistant_id: assistantId ?? "",
-        id: activeConversationId ?? "",
-      },
-    }),
-    enabled: false,
-  });
-  const draftConversationIds = useConversationStore.use.draftConversationIds();
-  const urlPromptTargetResolution: UrlPromptTargetResolution = useMemo(() => {
-    if (!activeConversationId) {
-      return "unresolved";
-    }
-    if (draftConversationIds.has(activeConversationId)) {
-      return "exists";
-    }
-    if (activeConversation) {
-      return "exists";
-    }
-    return conversationRowProbe.error instanceof ConversationNotFoundError
-      ? "missing"
-      : "unresolved";
-  }, [
-    activeConversationId,
-    draftConversationIds,
-    activeConversation,
-    conversationRowProbe.error,
-  ]);
-
   // Auto-send: URL ?prompt=, pre-chat reachability probe, onboarding message.
   useAutoSendEffects({
     assistantId,
     activeConversationId,
-    urlPromptTargetResolution,
     searchParams,
     setSearchParams,
     sendMessage,

--- a/clients/web/src/domains/chat/hooks/use-auto-send-effects.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-auto-send-effects.test.tsx
@@ -10,10 +10,7 @@ import { afterEach, describe, expect, it, mock } from "bun:test";
 
 import { cleanup, renderHook } from "@testing-library/react";
 
-import {
-  useAutoSendEffects,
-  type UrlPromptTargetResolution,
-} from "@/domains/chat/hooks/use-auto-send-effects";
+import { useAutoSendEffects } from "@/domains/chat/hooks/use-auto-send-effects";
 
 afterEach(() => cleanup());
 
@@ -26,7 +23,6 @@ function baseProps(
   return {
     assistantId: "assistant-1",
     activeConversationId: "conv-1",
-    urlPromptTargetResolution: "exists" as UrlPromptTargetResolution,
     searchParams: new URLSearchParams(search),
     setSearchParams: mock((..._args: SetSearchParamsArgs) => {}),
     sendMessage,
@@ -91,62 +87,5 @@ describe("useAutoSendEffects — URL prompt dedupe", () => {
 
     expect(sendMessage).toHaveBeenCalledTimes(1);
     expect(props.setSearchParams).not.toHaveBeenCalled();
-  });
-});
-
-describe("useAutoSendEffects — URL prompt target gating", () => {
-  it("holds the send while the target is unresolved, then fires once it exists", () => {
-    const sendMessage = mock(async (_content: string) => {});
-    const props = {
-      ...baseProps("prompt=hello", sendMessage),
-      urlPromptTargetResolution: "unresolved" as UrlPromptTargetResolution,
-    };
-    const { rerender } = renderHook(
-      (p: ReturnType<typeof baseProps>) => useAutoSendEffects(p),
-      { initialProps: props },
-    );
-    expect(sendMessage).not.toHaveBeenCalled();
-
-    rerender({ ...props, urlPromptTargetResolution: "exists" });
-    expect(sendMessage).toHaveBeenCalledTimes(1);
-    expect(sendMessage).toHaveBeenLastCalledWith("hello");
-  });
-
-  it("drops the send for a missing target and strips prompt + relay so it cannot retry", () => {
-    const sendMessage = mock(async (_content: string) => {});
-    const props = {
-      ...baseProps("prompt=hello&relay=a&vref=keep", sendMessage),
-      urlPromptTargetResolution: "missing" as UrlPromptTargetResolution,
-    };
-    renderHook((p: ReturnType<typeof baseProps>) => useAutoSendEffects(p), {
-      initialProps: props,
-    });
-
-    // The send path would server-mint a NEW conversation for an unknown id,
-    // so a missing target must never reach sendMessage.
-    expect(sendMessage).not.toHaveBeenCalled();
-    expect(props.setSearchParams).toHaveBeenCalledTimes(1);
-    const updater = props.setSearchParams.mock.calls[0][0] as (
-      prev: URLSearchParams,
-    ) => URLSearchParams;
-    const next = updater(new URLSearchParams("prompt=hello&relay=a&vref=keep"));
-    expect(next.has("prompt")).toBe(false);
-    expect(next.has("relay")).toBe(false);
-    expect(next.get("vref")).toBe("keep");
-  });
-
-  it("a target that resolves to missing after being unresolved never sends", () => {
-    const sendMessage = mock(async (_content: string) => {});
-    const props = {
-      ...baseProps("prompt=hello", sendMessage),
-      urlPromptTargetResolution: "unresolved" as UrlPromptTargetResolution,
-    };
-    const { rerender } = renderHook(
-      (p: ReturnType<typeof baseProps>) => useAutoSendEffects(p),
-      { initialProps: props },
-    );
-
-    rerender({ ...props, urlPromptTargetResolution: "missing" });
-    expect(sendMessage).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/chat/hooks/use-auto-send-effects.ts
+++ b/clients/web/src/domains/chat/hooks/use-auto-send-effects.ts
@@ -5,10 +5,7 @@
  *    active conversation exists (used by "Submit Feedback" and similar
  *    deep-link flows). One-shot callers have the `prompt` stripped from the URL
  *    after dispatch so a refresh can't re-send it; relay callers keep theirs to
- *    re-fire on a new token. The send is gated on the target resolving against
- *    live conversation data (see {@link UrlPromptTargetResolution}): a missing
- *    target is refused with a visible error instead of letting the send path
- *    server-mint a new conversation for it.
+ *    re-fire on a new token.
  *
  * 2. **Pre-chat reachability probe** — when a pending onboarding message
  *    exists in sessionStorage, kicks off a background reachability probe
@@ -21,38 +18,17 @@
  */
 
 import { useEffect, useLayoutEffect, useRef } from "react";
-import * as Sentry from "@sentry/react";
 
 import type { SetURLSearchParams } from "react-router";
-
-import { toast } from "@vellumai/design-library/components/toast";
 
 import type {
   ReachabilityProbeOptions,
   ReachabilityState,
 } from "@/assistant/use-assistant-reachability";
 
-/**
- * Where the active conversation stands against live conversation data, for
- * gating the URL `?prompt=` auto-send:
- *
- * - `"unresolved"`: the conversation list has not loaded yet; hold the send
- *   until it has (the effect re-runs when this settles).
- * - `"exists"`: the id is a known conversation row or a registered
- *   client-side draft; safe to send.
- * - `"missing"`: the target definitively does not exist (a settled 404 on
- *   its row) and it is no registered draft. The send must be dropped: the
- *   send path treats an unknown id as a draft and server-mints a NEW
- *   conversation, so relaying would silently send the message outside the
- *   chat the caller targeted (a conversation deleted since the relay URL
- *   was built, or an id from another assistant).
- */
-export type UrlPromptTargetResolution = "unresolved" | "exists" | "missing";
-
 export interface UseAutoSendEffectsOptions {
   assistantId: string | null;
   activeConversationId: string | null;
-  urlPromptTargetResolution: UrlPromptTargetResolution;
   searchParams: URLSearchParams;
   setSearchParams: SetURLSearchParams;
   sendMessage: (
@@ -75,7 +51,6 @@ export interface UseAutoSendEffectsOptions {
 export function useAutoSendEffects({
   assistantId,
   activeConversationId,
-  urlPromptTargetResolution,
   searchParams,
   setSearchParams,
   sendMessage,
@@ -103,32 +78,6 @@ export function useAutoSendEffects({
     if (!prompt || !activeConversationId) {
       return;
     }
-    // Hold until the target is resolvable, and refuse a missing target: see
-    // {@link UrlPromptTargetResolution} for why sending anyway would create
-    // a new conversation instead of failing.
-    if (urlPromptTargetResolution === "unresolved") {
-      return;
-    }
-    if (urlPromptTargetResolution === "missing") {
-      Sentry.addBreadcrumb({
-        category: "deeplink",
-        level: "warning",
-        message:
-          "?prompt= target conversation not found; dropping the auto-send",
-      });
-      toast.error("Couldn't find that chat, so the message wasn't sent.");
-      // Strip the whole relay payload so a reload or back-navigation cannot
-      // retry a send that was just refused.
-      setSearchParams(
-        (prev) => {
-          prev.delete("prompt");
-          prev.delete("relay");
-          return prev;
-        },
-        { replace: true },
-      );
-      return;
-    }
     // A relay token makes each dispatch unique so repeated identical prompts
     // re-fire; one-shot callers (deep links, doc feedback) omit it and dedupe
     // on the prompt text.
@@ -153,13 +102,7 @@ export function useAutoSendEffects({
         { replace: true },
       );
     }
-  }, [
-    searchParams,
-    setSearchParams,
-    activeConversationId,
-    urlPromptTargetResolution,
-    sendMessage,
-  ]);
+  }, [searchParams, setSearchParams, activeConversationId, sendMessage]);
 
   // 2. Pre-chat reachability probe — eagerly start the probe cycle.
   useEffect(() => {


### PR DESCRIPTION
## TL;DR

Removes ~170 lines of hardening from #40637 that outlived their reason: the `?prompt=` auto-send target gate. Nothing user-visible changes; the send-to-chat shortcut is unaffected. Part of LUM-3230.

## What changes for the user

| | Before | After |
|---|---|---|
| Send-to-chat shortcut | Stages the message in the chosen chat's composer | Same |
| Existing `?prompt=` flows (quick input, doc feedback, launch buttons, app-viewer relay…) | Send once the target resolves; a settled-404 target toasts and drops | Send once an active conversation exists (the behavior before #40637) |

## Why this exists

During #40637's review, the shortcut relayed its message through the `?prompt=` auto-send. That surfaced a real hazard: the send path treats an unknown id as a draft and server-mints a **new** conversation for it, so a stale picker id would have silently sent outside the chosen chat. I added a resolution gate (`unresolved` → hold, `missing` → drop with a toast) to close it.

Then, still in review, the shortcut moved off `?prompt=` entirely — it now parks the message in the composer (the no-auto-send contract from #40636). The gate was left behind, guarding a shared pathway with **19 producers, none of which can hit the case**: every one either registers a client draft first (`createDraftConversationId` → immediately resolves) or targets a live row. Its only remaining effect was a hold-until-resolved on a hot seam plus a row-probe query, toast, and Sentry import in `useAutoSendEffects` — complexity with no justification and a small regression surface (a row fetch that never settles would hold a send forever).

Cleaner to remove it than to carry it. If a `?prompt=` producer ever *does* need target integrity, the right fix belongs in the send path itself (refuse to mint for an id the caller claimed exists), not in a URL-param consumer.

## What stays from #40637

The `useDeepLinkConsumer` registration-order move in `ActiveChatView`. That fixes a real, pre-existing misfile — a parked composer message and its navigation land in one commit, and with the consumer registered before the switch owner, `handleConversationSwitch` saved the message as the *outgoing* conversation's draft. It applies to `deeplink.send` and LUM-3229's prompt as much as to the shortcut, so it stands on its own.

## Why this is safe

- The three touched files are restored **byte-for-byte to their pre-#40637 state** (`git checkout 2c7a000854^ -- …`) except the consumer reorder, so this reintroduces exactly the well-tested behavior of a week ago, no hand edits.
- No live producer depended on the gate; the shortcut never shipped through it.
- typecheck / lint / prettier clean; the pre-existing auto-send tests (dedupe, relay, strip) are unchanged and cover the restored behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40712" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->