### PR TITLE
fix(web): anchor the tour backdrop to the chat header, and give that header's slot one owner

### DIFF
--- a/clients/web/src/domains/chat/chat-layout-header.tsx
+++ b/clients/web/src/domains/chat/chat-layout-header.tsx
@@ -28,6 +28,17 @@ import { useTitleBarStore } from "@/stores/title-bar-store";
 // Off Electron the inset is 0.
 const ELECTRON_TRAFFIC_LIGHT_CLEARANCE = 80;
 
+/**
+ * The `data-slot` this header publishes, and the selector that finds it.
+ *
+ * Surfaces portalled out of the chat layout position themselves against this
+ * header's bottom edge and have to locate it from outside the tree. They read
+ * these rather than writing the attribute name again, so the published name
+ * has one owner: the component that publishes it.
+ */
+export const CHAT_LAYOUT_HEADER_SLOT = "chat-layout-header";
+export const CHAT_LAYOUT_HEADER_SELECTOR = `[data-slot="${CHAT_LAYOUT_HEADER_SLOT}"]`;
+
 export interface ChatLayoutHeaderProps {
   isMobile: boolean;
   drawerOpen: boolean;
@@ -124,7 +135,7 @@ export function ChatLayoutHeader({
 
   return (
     <header
-      data-slot="chat-layout-header"
+      data-slot={CHAT_LAYOUT_HEADER_SLOT}
       className={`flex w-full shrink-0 items-center gap-4 px-4 pt-4${isMobile && !electron ? " pb-4" : ""}${
         electron
           ? " select-none [-webkit-app-region:drag] [&_a]:[-webkit-app-region:no-drag] [&_button]:[-webkit-app-region:no-drag]"

--- a/clients/web/src/domains/chat/in-chat-onboarding/tour-overlay.tsx
+++ b/clients/web/src/domains/chat/in-chat-onboarding/tour-overlay.tsx
@@ -68,7 +68,12 @@ export function TourOverlay({
       return;
     }
     const update = () => {
-      const header = document.querySelector<HTMLElement>("header");
+      // The chat layout's own header, by the `data-slot` it publishes. A bare
+      // `header` tag selector matches whichever `<header>` comes first in the
+      // document, which the detail panels also render.
+      const header = document.querySelector<HTMLElement>(
+        '[data-slot="chat-layout-header"]',
+      );
       setClearTop(header ? header.getBoundingClientRect().bottom : 0);
 
       const menu = document.querySelector<HTMLElement>("#chat-side-menu");

--- a/clients/web/src/domains/chat/in-chat-onboarding/tour-overlay.tsx
+++ b/clients/web/src/domains/chat/in-chat-onboarding/tour-overlay.tsx
@@ -2,6 +2,7 @@ import { motion } from "motion/react";
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 
+import { CHAT_LAYOUT_HEADER_SELECTOR } from "@/domains/chat/chat-layout-header";
 import { ChatComposer } from "@/domains/chat/components/chat-composer/chat-composer";
 import { type VoiceInputButtonHandle } from "@/domains/chat/components/voice-input-button";
 
@@ -68,11 +69,11 @@ export function TourOverlay({
       return;
     }
     const update = () => {
-      // The chat layout's own header, by the `data-slot` it publishes. A bare
-      // `header` tag selector matches whichever `<header>` comes first in the
-      // document, which the detail panels also render.
+      // The chat layout's own header. A bare `header` tag selector matches
+      // whichever `<header>` comes first in the document, which the detail
+      // panels also render.
       const header = document.querySelector<HTMLElement>(
-        '[data-slot="chat-layout-header"]',
+        CHAT_LAYOUT_HEADER_SELECTOR,
       );
       setClearTop(header ? header.getBoundingClientRect().bottom : 0);
 

--- a/clients/web/src/domains/chat/voice/voice-room/use-chat-header-bottom.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-chat-header-bottom.ts
@@ -26,14 +26,13 @@
 
 import { useEffect, useState } from "react";
 
-/** The header's own `data-slot`, set in `chat-layout-header.tsx`. */
-const HEADER_SELECTOR = '[data-slot="chat-layout-header"]';
+import { CHAT_LAYOUT_HEADER_SELECTOR } from "@/domains/chat/chat-layout-header";
 
 export function useChatHeaderBottom(): number {
   const [bottom, setBottom] = useState(0);
 
   useEffect(() => {
-    const header = document.querySelector(HEADER_SELECTOR);
+    const header = document.querySelector(CHAT_LAYOUT_HEADER_SELECTOR);
     if (!header) {
       setBottom(0);
       return;


### PR DESCRIPTION
## TL;DR

`tour-overlay.tsx` found the chat header with `document.querySelector("header")`, which matches whichever `<header>` is first in the document. It now reads the `data-slot` the header publishes, and that slot name is exported from the header rather than written as a literal in three places.

## Why the selector was wrong

`chat-layout-header.tsx` renders `<header data-slot="chat-layout-header">`, and that slot is how the rest of the app refers to it: `use-chat-header-bottom.ts` already looked it up that way for the mobile voice sheet. The tour was the one place reaching for it positionally.

Two other components render a `<header>`: `suggestion-detail-panel.tsx` and `concept-detail-panel.tsx`. If either is in the DOM ahead of the chat header when the tour measures, the takeover's backdrop clears the wrong element and either exposes the chat header or covers it.

## Why the constant moved to the header

Fixing the selector created a second literal copy of the slot name, which both reviewers flagged against AGENTS.md "Single Source of Truth". Both suggested a shared module the two *readers* import.

That does not close the drift. The writer was a third independent literal: rename the attribute on the header, leave a reader-side constant alone, and both readers silently match an attribute nothing publishes. So the name is owned where it is written:

```ts
export const CHAT_LAYOUT_HEADER_SLOT = "chat-layout-header";
export const CHAT_LAYOUT_HEADER_SELECTOR = `[data-slot="${CHAT_LAYOUT_HEADER_SLOT}"]`;
```

`<header data-slot={CHAT_LAYOUT_HEADER_SLOT}>`, and both readers import the selector. One definition, and a rename is one edit the type system carries. No new module, and it survives `use-chat-header-bottom.ts` being deleted, which [LUM-3233](https://linear.app/vellum/issue/LUM-3233/web-the-overlay-portal-container-is-a-zero-size-div-give-it-a-real-box) step 2 plans, because the owner is the header rather than the hook.

The selector is shared; the lookup is not. The two call sites want different things from the element (a live-tracked `bottom` vs a one-shot read alongside two unrelated measurements), so a shared `getChatHeader()` would be a wrapper over `document.querySelector` with no behaviour in it. The duplicated thing was the name.

## Why it is safe

- In the chat route the layout header is first in document order today, so the tour resolves to the same node and its rendered output is unchanged. What changes is that the lookup states which element it means instead of depending on document order.
- `CHAT_LAYOUT_HEADER_SELECTOR` is built from `CHAT_LAYOUT_HEADER_SLOT`, so the emitted attribute and every lookup cannot disagree by construction.
- No import cycle: `chat-layout-header.tsx` imports only design-library, lucide, react, a constants module, runtime helpers and stores, nothing from `voice-room/` or `in-chat-onboarding/`. Verified with a production build.
- `voice-room.test.tsx:527` and `chat-layout-header.test.tsx:106` deliberately keep their own literals. They pin the published name from outside, so a rename fails there loudly rather than being carried silently into every reader at once.
- Typecheck, lint (0 errors), pinned prettier, and `bun run build` all pass.

## What changes for the user

| | Before | After |
| --- | --- | --- |
| Tour backdrop in the chat route | Clears the chat header | Unchanged |
| Tour backdrop with a detail panel's `<header>` earlier in the DOM | Clears that panel's header instead | Clears the chat header |
| Mobile voice sheet | Rests below the chat header | Unchanged |

## Deliberately not in this PR

The tour's header measurement also misses displacement it should track: an in-flow banner or voice-session row above the header moves it with no resize event and no change to its own box. That is not fixable here without either duplicating the voice room's subscription set or sharing it, and sharing it was tried in #40699 and closed unmerged. Every in-place fix for it needs another observer at another level, which is the signal that the measurement is the wrong mechanism rather than an under-subscribed one.

LUM-3233 step 2 removes the *voice room's* copy of that measurement, not the tour's: the tour paints over the sidebar as well as the content region, and its takeover is one of six body-portalled layers coordinating by z-index, so it cannot move into a nested content region. It keeps a header measurement until that surface gets its own decision.

So this PR outlives that work rather than being undone by it, and the exported slot keeps earning its place afterwards: the duplication it removes is between the component that *writes* the attribute and whoever reads it, which exists at one reader just as much as at two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
