### PR TITLE
Re-point Fireworks DeepSeek V4 Flash to dated deepseek-v4-flash-0731 ID

### DIFF
--- a/assistant/src/__tests__/byok-default-profile-ensure.test.ts
+++ b/assistant/src/__tests__/byok-default-profile-ensure.test.ts
@@ -284,7 +284,22 @@ describe("ensureByokDefaultProfiles", () => {
     ["fireworks", "balanced", "accounts/fireworks/models/kimi-k2p6"],
     [
       "fireworks",
+      "balanced",
+      "accounts/fireworks/models/deepseek-v4-flash-0731",
+    ],
+    [
+      "fireworks",
       "quality-optimized",
+      "accounts/fireworks/models/deepseek-v4-flash",
+    ],
+    [
+      "fireworks",
+      "quality-optimized",
+      "accounts/fireworks/models/deepseek-v4-flash-0731",
+    ],
+    [
+      "fireworks",
+      "cost-optimized",
       "accounts/fireworks/models/deepseek-v4-flash",
     ],
   ] as const)(

--- a/assistant/src/__tests__/workspace-migration-146-repair-retired-fireworks-deepseek-flash-model-id.test.ts
+++ b/assistant/src/__tests__/workspace-migration-146-repair-retired-fireworks-deepseek-flash-model-id.test.ts
@@ -7,10 +7,12 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { repairRetiredFireworksDeepseekFlashModelIdMigration } from "../workspace/migrations/146-repair-retired-fireworks-deepseek-flash-model-id.js";
 import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
+import { assertNotLiveDb } from "./assert-not-live-db.js";
 
 const STALE = "accounts/fireworks/models/deepseek-v4-flash";
 const REPLACEMENT = "accounts/fireworks/models/deepseek-v4-flash-0731";
@@ -36,12 +38,31 @@ function readConfig(): Record<string, unknown> {
   return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
 }
 
+function seedRows(rows: Array<{ name: string; provider: string }>): void {
+  mkdirSync(join(workspaceDir, "data", "db"), { recursive: true });
+  const db = new Database(join(workspaceDir, "data", "db", "assistant.db"));
+  db.run(`CREATE TABLE IF NOT EXISTS provider_connections (
+    name TEXT PRIMARY KEY,
+    provider TEXT NOT NULL,
+    auth TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+  )`);
+  for (const row of rows) {
+    db.query(
+      `INSERT INTO provider_connections (name, provider, auth, created_at, updated_at) VALUES (?, ?, '{"type":"api_key"}', 1, 1)`,
+    ).run(row.name, row.provider);
+  }
+  db.close();
+}
+
 beforeEach(() => {
   freshWorkspace();
 });
 
 afterEach(() => {
   if (existsSync(workspaceDir)) {
+    assertNotLiveDb(workspaceDir);
     rmSync(workspaceDir, { recursive: true, force: true });
   }
 });
@@ -88,14 +109,39 @@ describe("146-repair-retired-fireworks-deepseek-flash-model-id migration", () =>
     expect(llm.profiles.legacy.model).toBe(REPLACEMENT);
   });
 
+  test("repairs entry-bound fragments whose row kind is fireworks or vellum", () => {
+    seedRows([
+      { name: "my-fireworks", provider: "fireworks" },
+      { name: "managed-alt", provider: "vellum" },
+    ]);
+    writeConfig({
+      llm: {
+        profiles: {
+          bound: { provider: "my-fireworks", model: STALE },
+          managed: { provider: "managed-alt", model: STALE },
+        },
+      },
+    });
+
+    repairRetiredFireworksDeepseekFlashModelIdMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as Record<string, any>;
+    expect(llm.profiles.bound.model).toBe(REPLACEMENT);
+    expect(llm.profiles.managed.model).toBe(REPLACEMENT);
+  });
+
   test("leaves fragments with an explicit other provider untouched", () => {
+    seedRows([{ name: "byo-compat", provider: "openai-compatible" }]);
     writeConfig({
       llm: {
         default: { provider: "openai-compatible", model: STALE },
         profiles: {
           byo: { provider: "openai-compatible", model: STALE },
-          // Post-145 entry-bound profile: provider holds an entry name.
-          bound: { provider: "my-fireworks", model: STALE },
+          // Entry-bound profile whose row kind is not repairable.
+          compatBound: { provider: "byo-compat", model: STALE },
+          // Entry name with no row: dangling, so nothing proves it is a
+          // fireworks-kind route.
+          dangling: { provider: "ghost", model: STALE },
         },
       },
     });
@@ -105,7 +151,52 @@ describe("146-repair-retired-fireworks-deepseek-flash-model-id migration", () =>
     const llm = readConfig().llm as Record<string, any>;
     expect(llm.default.model).toBe(STALE);
     expect(llm.profiles.byo.model).toBe(STALE);
+    expect(llm.profiles.compatBound.model).toBe(STALE);
+    expect(llm.profiles.dangling.model).toBe(STALE);
+  });
+
+  test("leaves entry-name providers untouched when no DB file exists", () => {
+    writeConfig({
+      llm: {
+        profiles: { bound: { provider: "my-fireworks", model: STALE } },
+      },
+    });
+
+    repairRetiredFireworksDeepseekFlashModelIdMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as Record<string, any>;
     expect(llm.profiles.bound.model).toBe(STALE);
+  });
+
+  test("throws when an entry-name provider needs rows and the DB is unreadable", () => {
+    // A DB file without the provider_connections table is unqueryable, so
+    // the run must fail (and retry later) instead of skipping the profile.
+    mkdirSync(join(workspaceDir, "data", "db"), { recursive: true });
+    writeFileSync(join(workspaceDir, "data", "db", "assistant.db"), "");
+    writeConfig({
+      llm: {
+        profiles: { bound: { provider: "my-fireworks", model: STALE } },
+      },
+    });
+
+    expect(() =>
+      repairRetiredFireworksDeepseekFlashModelIdMigration.run(workspaceDir),
+    ).toThrow();
+    const llm = readConfig().llm as Record<string, any>;
+    expect(llm.profiles.bound.model).toBe(STALE);
+
+    // Vendor and absent providers never need the rows, so the same broken
+    // DB does not block their repair.
+    writeConfig({
+      llm: {
+        default: { provider: "fireworks", model: STALE },
+        profiles: { legacy: { model: STALE } },
+      },
+    });
+    repairRetiredFireworksDeepseekFlashModelIdMigration.run(workspaceDir);
+    const repaired = readConfig().llm as Record<string, any>;
+    expect(repaired.default.model).toBe(REPLACEMENT);
+    expect(repaired.profiles.legacy.model).toBe(REPLACEMENT);
   });
 
   test("is idempotent and a no-op without the stale ID", () => {

--- a/assistant/src/__tests__/workspace-migration-146-repair-retired-fireworks-deepseek-flash-model-id.test.ts
+++ b/assistant/src/__tests__/workspace-migration-146-repair-retired-fireworks-deepseek-flash-model-id.test.ts
@@ -1,0 +1,144 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { repairRetiredFireworksDeepseekFlashModelIdMigration } from "../workspace/migrations/146-repair-retired-fireworks-deepseek-flash-model-id.js";
+import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
+
+const STALE = "accounts/fireworks/models/deepseek-v4-flash";
+const REPLACEMENT = "accounts/fireworks/models/deepseek-v4-flash-0731";
+
+let workspaceDir: string;
+
+function freshWorkspace(): void {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-146-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+}
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+beforeEach(() => {
+  freshWorkspace();
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+describe("146-repair-retired-fireworks-deepseek-flash-model-id migration", () => {
+  test("has correct migration id and is registered", () => {
+    expect(repairRetiredFireworksDeepseekFlashModelIdMigration.id).toBe(
+      "146-repair-retired-fireworks-deepseek-flash-model-id",
+    );
+    expect(WORKSPACE_MIGRATIONS.map((m) => m.id)).toContain(
+      "146-repair-retired-fireworks-deepseek-flash-model-id",
+    );
+  });
+
+  test("repairs the stale ID in default, call sites, and profiles", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "fireworks", model: STALE },
+        callSites: {
+          recall: { model: STALE, maxTokens: 4096 },
+          heartbeat: { model: `${STALE}-tuned` },
+          malformed: STALE,
+        },
+        profiles: {
+          "cost-optimized": { provider: "vellum", model: STALE },
+          legacy: { model: STALE },
+        },
+      },
+    });
+
+    repairRetiredFireworksDeepseekFlashModelIdMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as Record<string, any>;
+    expect(llm.default.model).toBe(REPLACEMENT);
+    expect(llm.callSites.recall.model).toBe(REPLACEMENT);
+    expect(llm.callSites.recall.maxTokens).toBe(4096);
+    // Non-exact matches and malformed leaves are untouched. The dated
+    // replacement itself extends the stale ID, so the exact match must not
+    // fire on already-repaired leaves.
+    expect(llm.callSites.heartbeat.model).toBe(`${STALE}-tuned`);
+    expect(llm.callSites.malformed).toBe(STALE);
+    // Managed profiles stamped provider "vellum" carry Fireworks model IDs.
+    expect(llm.profiles["cost-optimized"].model).toBe(REPLACEMENT);
+    expect(llm.profiles.legacy.model).toBe(REPLACEMENT);
+  });
+
+  test("leaves fragments with an explicit other provider untouched", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "openai-compatible", model: STALE },
+        profiles: {
+          byo: { provider: "openai-compatible", model: STALE },
+          // Post-145 entry-bound profile: provider holds an entry name.
+          bound: { provider: "my-fireworks", model: STALE },
+        },
+      },
+    });
+
+    repairRetiredFireworksDeepseekFlashModelIdMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as Record<string, any>;
+    expect(llm.default.model).toBe(STALE);
+    expect(llm.profiles.byo.model).toBe(STALE);
+    expect(llm.profiles.bound.model).toBe(STALE);
+  });
+
+  test("is idempotent and a no-op without the stale ID", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "fireworks", model: STALE },
+        profiles: { fine: { provider: "fireworks", model: REPLACEMENT } },
+      },
+    });
+
+    repairRetiredFireworksDeepseekFlashModelIdMigration.run(workspaceDir);
+    const first = readConfig();
+    repairRetiredFireworksDeepseekFlashModelIdMigration.run(workspaceDir);
+    expect(readConfig()).toEqual(first);
+
+    const llm = first.llm as Record<string, any>;
+    expect(llm.default.model).toBe(REPLACEMENT);
+    expect(llm.profiles.fine.model).toBe(REPLACEMENT);
+  });
+
+  test("handles missing config, missing llm block, and invalid JSON", () => {
+    // No config.json at all.
+    expect(() =>
+      repairRetiredFireworksDeepseekFlashModelIdMigration.run(workspaceDir),
+    ).not.toThrow();
+
+    writeConfig({ theme: "dark" });
+    repairRetiredFireworksDeepseekFlashModelIdMigration.run(workspaceDir);
+    expect(readConfig()).toEqual({ theme: "dark" });
+
+    writeFileSync(join(workspaceDir, "config.json"), "{not json");
+    expect(() =>
+      repairRetiredFireworksDeepseekFlashModelIdMigration.run(workspaceDir),
+    ).not.toThrow();
+  });
+});

--- a/assistant/src/config/default-profile-catalog.ts
+++ b/assistant/src/config/default-profile-catalog.ts
@@ -98,7 +98,7 @@ const VELLUM_PROFILE_IMPLS: ProfileImpls = {
     },
   },
   "cost-optimized": {
-    model: "accounts/fireworks/models/deepseek-v4-flash",
+    model: "accounts/fireworks/models/deepseek-v4-flash-0731",
     provider: "vellum",
     source: "managed",
     label: "Cost",

--- a/assistant/src/plugin-api/vision-support.test.ts
+++ b/assistant/src/plugin-api/vision-support.test.ts
@@ -107,7 +107,7 @@ describe("doesSupportVision", () => {
       managed: { provider: "vellum", model: "claude-fable-5" },
       "managed-text": {
         provider: "vellum",
-        model: "accounts/fireworks/models/deepseek-v4-flash",
+        model: "accounts/fireworks/models/deepseek-v4-flash-0731",
       },
     });
     expect(doesSupportVision(profile("managed"))).toBe(true);

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -939,7 +939,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         pricing: { inputPer1mTokens: 1.74, outputPer1mTokens: 3.48 },
       },
       {
-        id: "accounts/fireworks/models/deepseek-v4-flash",
+        id: "accounts/fireworks/models/deepseek-v4-flash-0731",
         displayName: "DeepSeek V4 Flash",
         contextWindowTokens: 1040000,
         maxOutputTokens: 131072,
@@ -951,11 +951,11 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         pricing: {
           inputPer1mTokens: 0.14,
           outputPer1mTokens: 0.28,
-          cacheReadPer1mTokens: 0.03,
+          cacheReadPer1mTokens: 0.028,
         },
       },
     ],
-    defaultModel: "accounts/fireworks/models/deepseek-v4-flash",
+    defaultModel: "accounts/fireworks/models/deepseek-v4-flash-0731",
     apiKeyUrl: "https://fireworks.ai/account/api-keys",
     apiKeyPlaceholder: "fw_...",
   },

--- a/assistant/src/providers/model-intents.ts
+++ b/assistant/src/providers/model-intents.ts
@@ -46,8 +46,8 @@ const PROVIDER_MODEL_INTENTS: Record<string, Record<ModelIntent, string>> = {
   },
   fireworks: {
     balanced: "accounts/fireworks/models/minimax-m3",
-    "cost-optimized": "accounts/fireworks/models/deepseek-v4-flash",
-    "latency-optimized": "accounts/fireworks/models/deepseek-v4-flash",
+    "cost-optimized": "accounts/fireworks/models/deepseek-v4-flash-0731",
+    "latency-optimized": "accounts/fireworks/models/deepseek-v4-flash-0731",
     "quality-optimized": "accounts/fireworks/models/kimi-k2p6",
     "vision-optimized": "accounts/fireworks/models/kimi-k2p6",
   },

--- a/assistant/src/workspace/byok-default-profile-ensure.ts
+++ b/assistant/src/workspace/byok-default-profile-ensure.ts
@@ -164,8 +164,9 @@ function foldPersonalEntryName(provider: string): string {
  * 123) deliberately rewrite only the managed default entries (`custom-*` is
  * the user's to manage), so an untouched copy still carries whichever value
  * its hatch-era intent resolved to. Migrations 136 and 146 are the
- * exceptions: they rewrote stale Fireworks pins (`custom-*` included) in
- * place. A model listed here counts as unedited only when every non-model
+ * exceptions: they rewrite stale Fireworks pins (`custom-*` included) in
+ * place, so their targets are machinery-authored values too. A model listed
+ * here counts as unedited only when every non-model
  * field still matches the template.
  */
 const HISTORICAL_INTENT_MODELS: Record<
@@ -184,7 +185,7 @@ const HISTORICAL_INTENT_MODELS: Record<
       "accounts/fireworks/models/kimi-k2p6",
       // migration 136's in-place rewrite of a kimi-k2p5 pin.
       "accounts/fireworks/models/deepseek-v4-flash",
-      // migration 146's in-place rewrite of a 136-rewritten pin.
+      // the ID migration 146 writes over stale deepseek-v4-flash pins.
       "accounts/fireworks/models/deepseek-v4-flash-0731",
     ],
   },
@@ -210,7 +211,7 @@ const HISTORICAL_INTENT_MODELS: Record<
       "accounts/fireworks/models/kimi-k2p5",
       // migration 136's in-place rewrite of a kimi-k2p5 pin.
       "accounts/fireworks/models/deepseek-v4-flash",
-      // migration 146's in-place rewrite of a 136-rewritten pin.
+      // the ID migration 146 writes over stale deepseek-v4-flash pins.
       "accounts/fireworks/models/deepseek-v4-flash-0731",
     ],
   },
@@ -225,13 +226,13 @@ const HISTORICAL_INTENT_MODELS: Record<
     ],
     fireworks: [
       // latency intent 2026-05-05 (#29755) to 2026-07-28 (#39446). On live
-      // configs migration 136 rewrote it to deepseek-v4-flash, so this
+      // configs migration 136 rewrites it to deepseek-v4-flash, so this
       // survives only in configs restored from pre-136 backups.
       "accounts/fireworks/models/kimi-k2p5",
-      // latency intent 2026-07-28 (#39446) until Fireworks retired the
-      // undated ID for deepseek-v4-flash-0731 (2026-08-17); also migration
-      // 136's rewrite target. On live configs migration 146 rewrites it to
-      // the dated ID, so this survives only in pre-146 backups.
+      // latency intent 2026-07-28 (#39446) to the 2026-08-17 dated-ID
+      // repoint; also the ID migration 136 writes. On live configs migration
+      // 146 rewrites it to the dated ID, so this survives only in pre-146
+      // backups.
       "accounts/fireworks/models/deepseek-v4-flash",
     ],
   },

--- a/assistant/src/workspace/byok-default-profile-ensure.ts
+++ b/assistant/src/workspace/byok-default-profile-ensure.ts
@@ -163,8 +163,8 @@ function foldPersonalEntryName(provider: string): string {
  * 2026-05-05, #29755), and the profile-model migrations (100, 103, 109, 113,
  * 123) deliberately rewrite only the managed default entries (`custom-*` is
  * the user's to manage), so an untouched copy still carries whichever value
- * its hatch-era intent resolved to. Migration 136 is the one exception: it
- * rewrote kimi-k2p5 pins (`custom-*` included) to deepseek-v4-flash in
+ * its hatch-era intent resolved to. Migrations 136 and 146 are the
+ * exceptions: they rewrote stale Fireworks pins (`custom-*` included) in
  * place. A model listed here counts as unedited only when every non-model
  * field still matches the template.
  */
@@ -184,6 +184,8 @@ const HISTORICAL_INTENT_MODELS: Record<
       "accounts/fireworks/models/kimi-k2p6",
       // migration 136's in-place rewrite of a kimi-k2p5 pin.
       "accounts/fireworks/models/deepseek-v4-flash",
+      // migration 146's in-place rewrite of a 136-rewritten pin.
+      "accounts/fireworks/models/deepseek-v4-flash-0731",
     ],
   },
   "quality-optimized": {
@@ -208,6 +210,8 @@ const HISTORICAL_INTENT_MODELS: Record<
       "accounts/fireworks/models/kimi-k2p5",
       // migration 136's in-place rewrite of a kimi-k2p5 pin.
       "accounts/fireworks/models/deepseek-v4-flash",
+      // migration 146's in-place rewrite of a 136-rewritten pin.
+      "accounts/fireworks/models/deepseek-v4-flash-0731",
     ],
   },
   "cost-optimized": {
@@ -221,10 +225,14 @@ const HISTORICAL_INTENT_MODELS: Record<
     ],
     fireworks: [
       // latency intent 2026-05-05 (#29755) to 2026-07-28 (#39446). On live
-      // configs migration 136 rewrote it to deepseek-v4-flash (the current
-      // intent), so this survives only in configs restored from pre-136
-      // backups.
+      // configs migration 136 rewrote it to deepseek-v4-flash, so this
+      // survives only in configs restored from pre-136 backups.
       "accounts/fireworks/models/kimi-k2p5",
+      // latency intent 2026-07-28 (#39446) until Fireworks retired the
+      // undated ID for deepseek-v4-flash-0731 (2026-08-17); also migration
+      // 136's rewrite target. On live configs migration 146 rewrites it to
+      // the dated ID, so this survives only in pre-146 backups.
+      "accounts/fireworks/models/deepseek-v4-flash",
     ],
   },
 };

--- a/assistant/src/workspace/migrations/146-repair-retired-fireworks-deepseek-flash-model-id.ts
+++ b/assistant/src/workspace/migrations/146-repair-retired-fireworks-deepseek-flash-model-id.ts
@@ -7,13 +7,12 @@ import type { WorkspaceMigration } from "./types.js";
  * Repair the retired undated Fireworks DeepSeek V4 Flash model ID in
  * workspace LLM config.
  *
- * Fireworks removed the undated `accounts/fireworks/models/deepseek-v4-flash`
- * deployment (404 "Model not found, inaccessible, and/or not deployed") and
- * now serves only the dated official release
- * `accounts/fireworks/models/deepseek-v4-flash-0731`. Existing configs can
- * still pin the undated ID in `llm.default`, `llm.callSites.*`, and
- * `llm.profiles.*` — the cost-optimized default profile carried it and
- * migration 136 rewrote stale kimi-k2p5 pins to it.
+ * Fireworks serves DeepSeek V4 Flash only under the dated official release
+ * ID `accounts/fireworks/models/deepseek-v4-flash-0731`; the undated
+ * `accounts/fireworks/models/deepseek-v4-flash` has no deployment and every
+ * call to it fails with a 404 "Model not found, inaccessible, and/or not
+ * deployed". Existing configs can still pin the undated ID in
+ * `llm.default`, `llm.callSites.*`, and `llm.profiles.*`.
  *
  * Repair those leaves only on an exact stale match, replacing with the
  * dated ID.
@@ -21,11 +20,10 @@ import type { WorkspaceMigration } from "./types.js";
  * Provider guard: the stale ID belongs to the `fireworks` provider and also
  * appears in managed profiles stamped `provider: "vellum"` (which route
  * Fireworks-account model IDs through the managed proxy). A fragment is
- * repaired when its `provider` is `"fireworks"`, `"vellum"`, or absent; an
- * explicit other provider — including a connection entry name written by
- * migration 145 — is left untouched: an `openai-compatible` endpoint may
- * legitimately serve a model by the stale name, and an entry-bound profile
- * is the user's to manage.
+ * repaired when its `provider` is `"fireworks"`, `"vellum"`, or absent. An
+ * explicit other provider, including a connection entry name, is left
+ * untouched: an `openai-compatible` endpoint may legitimately serve a model
+ * by the stale name, and an entry-bound profile is the user's to manage.
  */
 export const repairRetiredFireworksDeepseekFlashModelIdMigration: WorkspaceMigration =
   {

--- a/assistant/src/workspace/migrations/146-repair-retired-fireworks-deepseek-flash-model-id.ts
+++ b/assistant/src/workspace/migrations/146-repair-retired-fireworks-deepseek-flash-model-id.ts
@@ -1,0 +1,131 @@
+import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+/**
+ * Repair the retired undated Fireworks DeepSeek V4 Flash model ID in
+ * workspace LLM config.
+ *
+ * Fireworks removed the undated `accounts/fireworks/models/deepseek-v4-flash`
+ * deployment (404 "Model not found, inaccessible, and/or not deployed") and
+ * now serves only the dated official release
+ * `accounts/fireworks/models/deepseek-v4-flash-0731`. Existing configs can
+ * still pin the undated ID in `llm.default`, `llm.callSites.*`, and
+ * `llm.profiles.*` — the cost-optimized default profile carried it and
+ * migration 136 rewrote stale kimi-k2p5 pins to it.
+ *
+ * Repair those leaves only on an exact stale match, replacing with the
+ * dated ID.
+ *
+ * Provider guard: the stale ID belongs to the `fireworks` provider and also
+ * appears in managed profiles stamped `provider: "vellum"` (which route
+ * Fireworks-account model IDs through the managed proxy). A fragment is
+ * repaired when its `provider` is `"fireworks"`, `"vellum"`, or absent; an
+ * explicit other provider — including a connection entry name written by
+ * migration 145 — is left untouched: an `openai-compatible` endpoint may
+ * legitimately serve a model by the stale name, and an entry-bound profile
+ * is the user's to manage.
+ */
+export const repairRetiredFireworksDeepseekFlashModelIdMigration: WorkspaceMigration =
+  {
+    id: "146-repair-retired-fireworks-deepseek-flash-model-id",
+    description:
+      "Repair retired Fireworks accounts/fireworks/models/deepseek-v4-flash model ID in workspace LLM config",
+    run(workspaceDir: string): void {
+      const configPath = join(workspaceDir, "config.json");
+      if (!existsSync(configPath)) {
+        return;
+      }
+
+      // Read outside the parse catch: a transient filesystem error (EIO,
+      // EACCES) must reach the runner so the migration retries, while
+      // malformed JSON is a permanent state this migration cannot repair.
+      const rawText = readFileSync(configPath, "utf-8");
+
+      let config: Record<string, unknown>;
+      try {
+        const raw = JSON.parse(rawText);
+        if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+          return;
+        }
+        config = raw as Record<string, unknown>;
+      } catch {
+        return;
+      }
+
+      const llm = readObject(config.llm);
+      if (llm === null) {
+        return;
+      }
+
+      let changed = false;
+
+      changed = repairFragment(readObject(llm.default)) || changed;
+
+      const callSites = readObject(llm.callSites);
+      if (callSites !== null) {
+        for (const rawConfig of Object.values(callSites)) {
+          changed = repairFragment(readObject(rawConfig)) || changed;
+        }
+      }
+
+      const profiles = readObject(llm.profiles);
+      if (profiles !== null) {
+        for (const rawProfile of Object.values(profiles)) {
+          changed = repairFragment(readObject(rawProfile)) || changed;
+        }
+      }
+
+      if (!changed) {
+        return;
+      }
+
+      // Write-then-rename so an interrupted write cannot leave config.json
+      // truncated: a torn in-place write would parse as invalid JSON on the
+      // retry, which the catch above treats as "nothing to do", letting the
+      // runner checkpoint the migration as completed against a corrupt file.
+      const tmpPath = `${configPath}.migration-146.tmp`;
+      writeFileSync(tmpPath, JSON.stringify(config, null, 2) + "\n");
+      renameSync(tmpPath, configPath);
+    },
+    // The exact-match rewrite is idempotent, so a transient failure (full
+    // disk, I/O error) is safe to retry on later startups.
+    retryFailedCheckpoint: true,
+    down(_workspaceDir: string): void {
+      // Forward-only: reintroducing the retired model ID would break
+      // Fireworks calls.
+    },
+  };
+
+// ---------------------------------------------------------------------------
+// Helpers: self-contained per workspace migrations AGENTS.md
+// ---------------------------------------------------------------------------
+
+const STALE_MODEL_ID = "accounts/fireworks/models/deepseek-v4-flash";
+const REPLACEMENT_MODEL_ID = "accounts/fireworks/models/deepseek-v4-flash-0731";
+const REPAIRABLE_PROVIDERS = new Set(["fireworks", "vellum"]);
+
+function repairFragment(fragment: Record<string, unknown> | null): boolean {
+  if (fragment === null) {
+    return false;
+  }
+  if (fragment.model !== STALE_MODEL_ID) {
+    return false;
+  }
+  if (
+    fragment.provider !== undefined &&
+    !REPAIRABLE_PROVIDERS.has(fragment.provider as string)
+  ) {
+    return false;
+  }
+  fragment.model = REPLACEMENT_MODEL_ID;
+  return true;
+}
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}

--- a/assistant/src/workspace/migrations/146-repair-retired-fireworks-deepseek-flash-model-id.ts
+++ b/assistant/src/workspace/migrations/146-repair-retired-fireworks-deepseek-flash-model-id.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { Database } from "bun:sqlite";
 
 import type { WorkspaceMigration } from "./types.js";
 
@@ -19,11 +20,14 @@ import type { WorkspaceMigration } from "./types.js";
  *
  * Provider guard: the stale ID belongs to the `fireworks` provider and also
  * appears in managed profiles stamped `provider: "vellum"` (which route
- * Fireworks-account model IDs through the managed proxy). A fragment is
- * repaired when its `provider` is `"fireworks"`, `"vellum"`, or absent. An
- * explicit other provider, including a connection entry name, is left
- * untouched: an `openai-compatible` endpoint may legitimately serve a model
- * by the stale name, and an entry-bound profile is the user's to manage.
+ * Fireworks-account model IDs through the managed proxy). Under the entries
+ * model (migration 145) `provider` can also hold a `provider_connections`
+ * entry name whose row kind drives dispatch. A fragment is repaired when
+ * its `provider` is `"fireworks"`, `"vellum"`, absent, or an entry name
+ * whose row kind is one of those: every fireworks-kind route serves the
+ * dated ID and only the dated ID. Any other provider is left untouched: an
+ * `openai-compatible` endpoint may legitimately serve a model by the stale
+ * name.
  */
 export const repairRetiredFireworksDeepseekFlashModelIdMigration: WorkspaceMigration =
   {
@@ -57,21 +61,54 @@ export const repairRetiredFireworksDeepseekFlashModelIdMigration: WorkspaceMigra
         return;
       }
 
+      // Entry rows load lazily: only a stale fragment whose provider is
+      // neither a repairable vendor nor absent needs them. An unreadable DB
+      // then fails the run (retried next boot) rather than checkpointing a
+      // pass that skips entry-bound profiles.
+      let rows: Map<string, string> | null | undefined;
+      const isRepairableProvider = (provider: unknown): boolean => {
+        if (provider === undefined) {
+          return true;
+        }
+        if (typeof provider !== "string") {
+          return false;
+        }
+        if (REPAIRABLE_PROVIDERS.has(provider)) {
+          return true;
+        }
+        if (rows === undefined) {
+          rows = readConnectionRows(workspaceDir);
+        }
+        if (rows === null) {
+          throw new Error(
+            "provider_connections is not readable; retrying the model-ID repair on the next run",
+          );
+        }
+        const kind = rows.get(provider);
+        return kind !== undefined && REPAIRABLE_PROVIDERS.has(kind);
+      };
+
       let changed = false;
 
-      changed = repairFragment(readObject(llm.default)) || changed;
+      changed =
+        repairFragment(readObject(llm.default), isRepairableProvider) ||
+        changed;
 
       const callSites = readObject(llm.callSites);
       if (callSites !== null) {
         for (const rawConfig of Object.values(callSites)) {
-          changed = repairFragment(readObject(rawConfig)) || changed;
+          changed =
+            repairFragment(readObject(rawConfig), isRepairableProvider) ||
+            changed;
         }
       }
 
       const profiles = readObject(llm.profiles);
       if (profiles !== null) {
         for (const rawProfile of Object.values(profiles)) {
-          changed = repairFragment(readObject(rawProfile)) || changed;
+          changed =
+            repairFragment(readObject(rawProfile), isRepairableProvider) ||
+            changed;
         }
       }
 
@@ -104,21 +141,50 @@ const STALE_MODEL_ID = "accounts/fireworks/models/deepseek-v4-flash";
 const REPLACEMENT_MODEL_ID = "accounts/fireworks/models/deepseek-v4-flash-0731";
 const REPAIRABLE_PROVIDERS = new Set(["fireworks", "vellum"]);
 
-function repairFragment(fragment: Record<string, unknown> | null): boolean {
+function repairFragment(
+  fragment: Record<string, unknown> | null,
+  isRepairableProvider: (provider: unknown) => boolean,
+): boolean {
   if (fragment === null) {
     return false;
   }
   if (fragment.model !== STALE_MODEL_ID) {
     return false;
   }
-  if (
-    fragment.provider !== undefined &&
-    !REPAIRABLE_PROVIDERS.has(fragment.provider as string)
-  ) {
+  if (!isRepairableProvider(fragment.provider)) {
     return false;
   }
   fragment.model = REPLACEMENT_MODEL_ID;
   return true;
+}
+
+/**
+ * Connection name -> provider kind, or null when the DB or table is not
+ * readable. The caller fails the run on null: entry-name providers must be
+ * judged against real rows, never guessed. An absent DB file is a real
+ * state (no rows, so every entry name is dangling and stays untouched).
+ */
+function readConnectionRows(workspaceDir: string): Map<string, string> | null {
+  const dbPath = join(workspaceDir, "data", "db", "assistant.db");
+  if (!existsSync(dbPath)) {
+    return new Map();
+  }
+  let db: Database;
+  try {
+    db = new Database(dbPath);
+  } catch {
+    return null;
+  }
+  try {
+    const rows = db
+      .query(`SELECT name, provider FROM provider_connections`)
+      .all() as Array<{ name: string; provider: string }>;
+    return new Map(rows.map((r) => [r.name, r.provider]));
+  } catch {
+    return null;
+  } finally {
+    db.close();
+  }
 }
 
 function readObject(value: unknown): Record<string, unknown> | null {

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -143,6 +143,7 @@ import { consolidateVoiceFrontDoorMigration } from "./142-consolidate-voice-fron
 import { repairDeprecatedCodexModelIdMigration } from "./143-repair-deprecated-codex-model-id.js";
 import { convertStrandedSubscriptionOpenaiProfilesMigration } from "./144-convert-stranded-subscription-openai-profiles.js";
 import { collapseProfileBindingsToEntriesMigration } from "./145-collapse-profile-bindings-to-entries.js";
+import { repairRetiredFireworksDeepseekFlashModelIdMigration } from "./146-repair-retired-fireworks-deepseek-flash-model-id.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -301,4 +302,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   repairDeprecatedCodexModelIdMigration,
   convertStrandedSubscriptionOpenaiProfilesMigration,
   collapseProfileBindingsToEntriesMigration,
+  repairRetiredFireworksDeepseekFlashModelIdMigration,
 ];

--- a/clients/web/src/assistant/llm-model-catalog.ts
+++ b/clients/web/src/assistant/llm-model-catalog.ts
@@ -351,7 +351,7 @@ export const MODELS_BY_PROVIDER = {
       supportsThinking: true,
     },
     {
-      id: "accounts/fireworks/models/deepseek-v4-flash",
+      id: "accounts/fireworks/models/deepseek-v4-flash-0731",
       displayName: "DeepSeek V4 Flash",
       contextWindowTokens: 1_040_000,
       defaultContextWindowTokens: 200_000,
@@ -923,7 +923,7 @@ export const DEFAULT_MODEL_BY_PROVIDER: Record<LlmProviderId, string> = {
   openai: "gpt-5.5",
   gemini: "gemini-2.5-flash",
   ollama: "llama3.2",
-  fireworks: "accounts/fireworks/models/deepseek-v4-flash",
+  fireworks: "accounts/fireworks/models/deepseek-v4-flash-0731",
   together: "MiniMaxAI/MiniMax-M3",
   openrouter: "x-ai/grok-4.20",
   "vercel-ai-gateway": "anthropic/claude-sonnet-4.6",

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -722,7 +722,7 @@
         "linkLabel": "Open Fireworks Dashboard"
       },
       "supportsPlatformAuth": true,
-      "defaultModel": "accounts/fireworks/models/deepseek-v4-flash",
+      "defaultModel": "accounts/fireworks/models/deepseek-v4-flash-0731",
       "models": [
         {
           "id": "accounts/fireworks/models/kimi-k3",
@@ -826,7 +826,7 @@
           }
         },
         {
-          "id": "accounts/fireworks/models/deepseek-v4-flash",
+          "id": "accounts/fireworks/models/deepseek-v4-flash-0731",
           "displayName": "DeepSeek V4 Flash",
           "contextWindowTokens": 1040000,
           "maxOutputTokens": 131072,
@@ -839,7 +839,7 @@
           "pricing": {
             "inputPer1mTokens": 0.14,
             "outputPer1mTokens": 0.28,
-            "cacheReadPer1mTokens": 0.03
+            "cacheReadPer1mTokens": 0.028
           }
         }
       ]


### PR DESCRIPTION
## Summary
- Fireworks removed the undated `accounts/fireworks/models/deepseek-v4-flash` deployment (404 "Model not found"; only the dated official release `deepseek-v4-flash-0731` is served now). Renames the model in `model-catalog.ts` (id + `defaultModel`), regenerates `meta/llm-provider-catalog.json` via `bun run sync:llm-catalog` so the platform's next vendored sync doesn't revert vellum-ai/vellum-assistant-platform#9881, and mirrors the change in the hand-maintained web catalog. Also corrects cached-input pricing $0.03 → $0.028/MTok per Fireworks' current model page.
- Repoints the fireworks `cost-optimized`/`latency-optimized` intents and the managed `cost-optimized` default profile to the dated ID, and records the era transitions in `HISTORICAL_INTENT_MODELS` (undated ID under cost-optimized; dated ID under balanced/quality as migration 146's rewrite of 136's output) so unedited `custom-*` copies keep converting.
- Adds workspace migration 146, mirroring migration 136's exact-match repair: rewrites undated pins to the dated ID in `llm.default`, `llm.callSites.*`, and `llm.profiles.*` when the fragment's provider is `fireworks`, `vellum`, or absent; entry-bound and other explicit providers are left untouched. Shipped migration 136 (whose replacement target was the undated ID) is unchanged — 146 runs after it and repairs its output.

## Original prompt
The platform repo renamed the Fireworks DeepSeek V4 Flash rate-card key to the dated `deepseek-v4-flash-0731` ID after Fireworks retired the undated deployment (vellum-ai/vellum-assistant-platform#9881), and that PR's rollout notes flagged a follow-up here: apply the same rename to the upstream catalog so the vendored sync doesn't revert it and daemon/native clients pick up the new ID. The user asked what this repo owed and then to ship it as one PR: catalog + intents + default-profile repoint, the HISTORICAL_INTENT_MODELS standing rule, a 136-style repair migration for existing config pins, and the web catalog mirror.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40716" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

Closes #40717 (the post-merge platform re-vendor called out there is a follow-up in vellum-ai/vellum-assistant-platform).
