### PR TITLE
fix(web): hide unreachable local assistants from the platform-hub chooser

### DIFF
--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
@@ -314,6 +314,9 @@ mock.module("@/stores/resolved-assistants-store", () => ({
       setActiveAssistantId: setActiveAssistantIdMock,
     }),
   },
+  // Mirrors the real predicate; the module is fully replaced by this mock.
+  isConnectableFromThisDevice: (a: ResolvedAssistant) =>
+    !a.isLocal || a.cloud != null || a.ingressUrl != null,
 }));
 
 mock.module("@/utils/routes", () => ({
@@ -1543,5 +1546,91 @@ describe("SelectAssistantScreen platform-mode gate", () => {
       expect(screen.getByText("Choose an Assistant")).toBeTruthy(),
     );
     expect(screen.queryByText("Create a new assistant")).toBeNull();
+  });
+});
+
+describe("SelectAssistantScreen local registrations on the platform hub", () => {
+  // API-sourced self-hosted entries as the hub sees them: no lockfile behind
+  // them, so `cloud` is unset and reachability hinges on `ingressUrl`.
+  const makeLocalRegistration = (
+    overrides: Partial<ResolvedAssistant> = {},
+  ): ResolvedAssistant => ({
+    id: "local-reg-1",
+    name: "Mac Mini",
+    isLocal: true,
+    isPlatformHosted: false,
+    isPaired: false,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    isLocalClientValue = false;
+    hasPlatformSessionValue = true;
+    assistantSwitcherValue = true;
+  });
+
+  test("hides a local registration with no ingress", async () => {
+    assistantsValue = [
+      makePlatformAssistant(),
+      makeLocalRegistration({ ingressUrl: null }),
+    ];
+
+    render(<SelectAssistantScreen />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Choose an Assistant")).toBeTruthy(),
+    );
+    const radios = screen.getAllByRole("radio");
+    expect(radios).toHaveLength(1);
+    expect(radios[0].textContent).toContain("Cloud Helper");
+    expect(screen.queryByText("Mac Mini")).toBeNull();
+  });
+
+  test("a local registration with an ingress renders and connects through the platform path", async () => {
+    assistantsValue = [
+      makePlatformAssistant(),
+      makeLocalRegistration({ ingressUrl: "https://mac.example.com" }),
+    ];
+
+    render(<SelectAssistantScreen />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Choose an Assistant")).toBeTruthy(),
+    );
+    const card = screen
+      .getAllByRole("radio")
+      .find((r) => r.textContent?.includes("Mac Mini"));
+    expect(card).toBeTruthy();
+    fireEvent.click(card!);
+    fireEvent.click(screen.getByText("Continue"));
+
+    await waitFor(() =>
+      expect(connectPlatformAssistantMock).toHaveBeenCalledWith("local-reg-1"),
+    );
+    expect(connectLocalAssistantMock).not.toHaveBeenCalled();
+  });
+
+  test("a local entry on a local client still connects through the local path", async () => {
+    isLocalClientValue = true;
+    hasPlatformSessionValue = false;
+    assistantSwitcherValue = false;
+    assistantsValue = [
+      makeLocalRegistration({ id: "asst-local", cloud: "local" }),
+      makePlatformAssistant(),
+    ];
+
+    render(<SelectAssistantScreen />);
+
+    const card = screen
+      .getAllByRole("radio")
+      .find((r) => r.textContent?.includes("Mac Mini"));
+    expect(card).toBeTruthy();
+    fireEvent.click(card!);
+    fireEvent.click(screen.getByText("Continue"));
+
+    await waitFor(() =>
+      expect(connectLocalAssistantMock).toHaveBeenCalledWith("asst-local"),
+    );
+    expect(connectPlatformAssistantMock).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
@@ -1610,6 +1610,35 @@ describe("SelectAssistantScreen local registrations on the platform hub", () => 
     expect(connectLocalAssistantMock).not.toHaveBeenCalled();
   });
 
+  test("labels a hub-listed self-hosted entry with its ingress host", async () => {
+    assistantsValue = [
+      makeLocalRegistration({ ingressUrl: "https://mac.example.com" }),
+    ];
+
+    render(<SelectAssistantScreen />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Self-hosted · mac.example.com")).toBeTruthy(),
+    );
+    expect(screen.queryByText("On this computer")).toBeNull();
+  });
+
+  test("locks an ingress-backed local entry behind login when the platform session is gone", async () => {
+    hasPlatformSessionValue = false;
+    assistantsValue = [
+      makeLocalRegistration({ ingressUrl: "https://mac.example.com" }),
+    ];
+
+    render(<SelectAssistantScreen />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Choose an Assistant")).toBeTruthy(),
+    );
+    // Locked: no selectable radio, and the card offers the login affordance.
+    expect(screen.queryAllByRole("radio")).toHaveLength(0);
+    expect(screen.getByText("Log in to use")).toBeTruthy();
+  });
+
   test("a local entry on a local client still connects through the local path", async () => {
     isLocalClientValue = true;
     hasPlatformSessionValue = false;

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -63,6 +63,7 @@ import { pairedHostLabel } from "@vellumai/local-mode/contract";
 import { Button } from "@vellumai/design-library/components/button";
 import { Menu } from "@vellumai/design-library/components/menu";
 import { useTranslation } from "@/i18n";
+import type { TFunction } from "i18next";
 
 function assistantLabel(a: ResolvedAssistant): string {
   if (a.name) {
@@ -75,24 +76,32 @@ function assistantLabel(a: ResolvedAssistant): string {
 }
 
 /** A hub-listed self-hosted entry lives on another machine; name its host. */
-function selfHostedHostLabel(ingressUrl: string | null | undefined): string {
+function selfHostedHostLabel(
+  ingressUrl: string | null | undefined,
+  t: TFunction<"onboarding">,
+): string {
   if (ingressUrl) {
     try {
-      return `Self-hosted · ${new URL(ingressUrl).hostname}`;
+      return t("selectAssistantScreen.selfHostedWithHost", {
+        host: new URL(ingressUrl).hostname,
+      });
     } catch {
       // Unparseable ingress url: plain label.
     }
   }
-  return "Self-hosted";
+  return t("selectAssistantScreen.selfHosted");
 }
 
-function assistantSubtitle(a: ResolvedAssistant): string {
+function assistantSubtitle(
+  a: ResolvedAssistant,
+  t: TFunction<"onboarding">,
+): string {
   const hosting = a.isPaired
     ? pairedHostLabel(a.runtimeUrl)
     : a.isLocal
       ? isLocalClient()
         ? "On this computer"
-        : selfHostedHostLabel(a.ingressUrl)
+        : selfHostedHostLabel(a.ingressUrl, t)
       : "Cloud-hosted";
   if (!a.hatchedAt) {
     return hosting;
@@ -1175,6 +1184,7 @@ function AssistantCard({
   /** Present when the entry can be forgotten on this device: opens the confirm. */
   onRemove?: () => void;
 }) {
+  const { t } = useTranslation("onboarding");
   const label = assistantLabel(assistant);
   return (
     <ChooserCard
@@ -1188,7 +1198,7 @@ function AssistantCard({
         )
       }
       title={label}
-      subtitle={assistantSubtitle(assistant)}
+      subtitle={assistantSubtitle(assistant, t)}
       selected={selected}
       locked={locked}
       tabStop={tabStop}

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -74,11 +74,25 @@ function assistantLabel(a: ResolvedAssistant): string {
   return a.isLocal ? "Local Assistant" : "Cloud Assistant";
 }
 
+/** A hub-listed self-hosted entry lives on another machine; name its host. */
+function selfHostedHostLabel(ingressUrl: string | null | undefined): string {
+  if (ingressUrl) {
+    try {
+      return `Self-hosted · ${new URL(ingressUrl).hostname}`;
+    } catch {
+      // Unparseable ingress url: plain label.
+    }
+  }
+  return "Self-hosted";
+}
+
 function assistantSubtitle(a: ResolvedAssistant): string {
   const hosting = a.isPaired
     ? pairedHostLabel(a.runtimeUrl)
     : a.isLocal
-      ? "On this computer"
+      ? isLocalClient()
+        ? "On this computer"
+        : selfHostedHostLabel(a.ingressUrl)
       : "Cloud-hosted";
   if (!a.hatchedAt) {
     return hosting;
@@ -167,8 +181,11 @@ export function SelectAssistantScreen() {
   // render.
   const cloudOriginOffered = cloudOrigin !== null;
 
+  // A local entry is session-free only where a local transport exists; on
+  // the hub it connects through the platform path, so like a managed entry
+  // it needs the platform session.
   const isAccessible = (a: ResolvedAssistant): boolean =>
-    a.isLocal || a.isPaired || hasPlatformSession;
+    a.isPaired || (a.isLocal && localClient) || hasPlatformSession;
 
   // `setFromApi` already drops unreachable local registrations, but a
   // lifecycle upsert of a stale persisted selection can still land one in the
@@ -736,7 +753,9 @@ export function SelectAssistantScreen() {
                 }
                 loginDisabled={connecting}
                 onLogin={
-                  !accessible && assistant.isPlatformHosted
+                  // Locked platform-hosted and hub-local cards both unlock
+                  // with a platform login (both connect via the platform).
+                  !accessible && (assistant.isPlatformHosted || assistant.isLocal)
                     ? loginLoading
                       ? cancelLogin
                       : () => void login()
@@ -1151,7 +1170,7 @@ function AssistantCard({
   onSelect: () => void;
   loginLabel: string;
   loginDisabled: boolean;
-  /** Present only on locked platform cards: log in to unlock this assistant. */
+  /** Present only on locked platform-routed cards: log in to unlock. */
   onLogin?: () => void;
   /** Present when the entry can be forgotten on this device: opens the confirm. */
   onRemove?: () => void;

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -54,6 +54,7 @@ import {
   type RememberedOrigin,
 } from "@/stores/remembered-origins-store";
 import {
+  isConnectableFromThisDevice,
   useResolvedAssistantsStore,
   type ResolvedAssistant,
 } from "@/stores/resolved-assistants-store";
@@ -169,7 +170,11 @@ export function SelectAssistantScreen() {
   const isAccessible = (a: ResolvedAssistant): boolean =>
     a.isLocal || a.isPaired || hasPlatformSession;
 
-  const accessibleAssistants = assistants.filter(isAccessible);
+  // `setFromApi` already drops unreachable local registrations, but a
+  // lifecycle upsert of a stale persisted selection can still land one in the
+  // store; keep dead entries off the chooser regardless of how they arrived.
+  const visibleAssistants = assistants.filter(isConnectableFromThisDevice);
+  const accessibleAssistants = visibleAssistants.filter(isAccessible);
   // Origin cards are always selectable, so any kind of entry gives Continue
   // something to act on.
   const hasSelectableEntries =
@@ -365,9 +370,11 @@ export function SelectAssistantScreen() {
     try {
       if (assistant.isPaired) {
         await useAuthStore.getState().connectPairedAssistant(assistant.id);
-      } else if (assistant.isLocal) {
+      } else if (assistant.isLocal && localClient) {
         await useAuthStore.getState().connectLocalAssistant(assistant.id);
       } else {
+        // A hub-listed local entry has no lockfile behind it; the platform
+        // path reaches it (lifecycle projects self-hosted via `ingress_url`).
         await useAuthStore.getState().connectPlatformAssistant(assistant.id);
       }
       void navigate(routes.assistant, { replace: true });
@@ -604,16 +611,16 @@ export function SelectAssistantScreen() {
     if (connecting || autoSkipping || connectDialogOpen) {
       return;
     }
-    if (assistants.length === 0) {
+    if (visibleAssistants.length === 0) {
       return;
     }
-    if (assistants.length === 1 && accessibleAssistants.length === 1) {
+    if (visibleAssistants.length === 1 && accessibleAssistants.length === 1) {
       setAutoSkipping(true);
       void handleConnect(accessibleAssistants[0]);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
-    assistants.length,
+    visibleAssistants.length,
     accessibleAssistants.length,
     deepLinkDrainSettled,
     localClient,
@@ -647,7 +654,7 @@ export function SelectAssistantScreen() {
       }
       return;
     }
-    const assistant = assistants.find((a) => a.id === selected);
+    const assistant = visibleAssistants.find((a) => a.id === selected);
     if (assistant) {
       void handleConnect(assistant);
     }
@@ -706,7 +713,7 @@ export function SelectAssistantScreen() {
           className={`flex w-full flex-col ${electron ? "mt-8 gap-2" : "mt-10 gap-3"}`}
           style={{ animation: "fadeInUp 0.5s ease-out 0.3s both" }}
         >
-          {assistants.map((assistant) => {
+          {visibleAssistants.map((assistant) => {
             const accessible = isAccessible(assistant);
             return (
               <AssistantCard

--- a/clients/web/src/i18n/locales/en/onboarding.json
+++ b/clients/web/src/i18n/locales/en/onboarding.json
@@ -60,7 +60,9 @@
     "unnamedAssistant": "the assistant",
     "connectingToAssistant": "Connecting to your assistant…",
     "rowActionsAriaLabel": "Actions for {name}",
-    "removeFromDevice": "Remove from this device…"
+    "removeFromDevice": "Remove from this device…",
+    "selfHosted": "Self-hosted",
+    "selfHostedWithHost": "Self-hosted · {host}"
   },
   "hatchingScreen": {
     "apiKeyFailed": "Your API key didn't work",

--- a/clients/web/src/i18n/locales/es/onboarding.json
+++ b/clients/web/src/i18n/locales/es/onboarding.json
@@ -60,7 +60,9 @@
     "unnamedAssistant": "el asistente",
     "connectingToAssistant": "Conectando con tu asistente…",
     "rowActionsAriaLabel": "Acciones de {name}",
-    "removeFromDevice": "Quitar de este dispositivo…"
+    "removeFromDevice": "Quitar de este dispositivo…",
+    "selfHosted": "Autoalojado",
+    "selfHostedWithHost": "Autoalojado · {host}"
   },
   "hatchingScreen": {
     "apiKeyFailed": "Tu clave de API no ha funcionado",

--- a/clients/web/src/stores/resolved-assistants-store.test.ts
+++ b/clients/web/src/stores/resolved-assistants-store.test.ts
@@ -321,6 +321,65 @@ describe("upsertFromApi", () => {
   });
 });
 
+describe("setFromApi connectability", () => {
+  type ApiAssistant = Parameters<
+    ReturnType<typeof useResolvedAssistantsStore.getState>["setFromApi"]
+  >[0][number];
+
+  const apiEntry = (overrides: Partial<ApiAssistant>): ApiAssistant =>
+    ({
+      id: "asst-api",
+      name: "Api",
+      created: "2026-01-01T00:00:00Z",
+      is_local: false,
+      ingress_url: null,
+      current_release_version: null,
+      release_channel: "stable",
+      ...overrides,
+    }) as ApiAssistant;
+
+  it("drops a local registration with no ingress and no lockfile entry", () => {
+    useResolvedAssistantsStore.getState().setFromApi([
+      apiEntry({ id: "asst-cloud" }),
+      apiEntry({ id: "asst-dead-local", is_local: true, ingress_url: null }),
+    ]);
+
+    const assistants = useResolvedAssistantsStore.getState().assistants;
+    expect(assistants.map((a) => a.id)).toEqual(["asst-cloud"]);
+    expect(useResolvedAssistantsStore.getState().assistantsHydrated).toBe(true);
+  });
+
+  it("keeps a local registration with a public ingress and carries its url", () => {
+    useResolvedAssistantsStore.getState().setFromApi([
+      apiEntry({
+        id: "asst-tunneled",
+        is_local: true,
+        ingress_url: "https://mac.example.com",
+      }),
+    ]);
+
+    const entry = useResolvedAssistantsStore.getState().assistants[0];
+    expect(entry.id).toBe("asst-tunneled");
+    expect(entry.isLocal).toBe(true);
+    expect(entry.ingressUrl).toBe("https://mac.example.com");
+  });
+
+  it("keeps an ingress-less local registration the lockfile knows", () => {
+    useLockfileStore.getState().setLockfile({
+      assistants: [localAssistant],
+      activeAssistant: "asst-local",
+    });
+
+    useResolvedAssistantsStore.getState().setFromApi([
+      apiEntry({ id: "asst-local", is_local: true, ingress_url: null }),
+    ]);
+
+    const entry = useResolvedAssistantsStore.getState().assistants[0];
+    expect(entry.id).toBe("asst-local");
+    expect(entry.cloud).toBe("local");
+  });
+});
+
 describe("assistantsValidForOrg", () => {
   const local: ResolvedAssistant = {
     id: "local",

--- a/clients/web/src/stores/resolved-assistants-store.ts
+++ b/clients/web/src/stores/resolved-assistants-store.ts
@@ -71,7 +71,7 @@ export interface ResolvedAssistant {
  * the lockfile, so its presence means a local/paired transport exists here),
  * or a platform-registered public ingress (`ingressUrl`, the phone-to-Mac
  * self-hosted path). A local API entry with none of these is unreachable from
- * this client — the platform proxy 404s — so list surfaces should not offer
+ * this client (the platform proxy 404s), so list surfaces should not offer
  * it.
  */
 export function isConnectableFromThisDevice(a: ResolvedAssistant): boolean {

--- a/clients/web/src/stores/resolved-assistants-store.ts
+++ b/clients/web/src/stores/resolved-assistants-store.ts
@@ -56,9 +56,26 @@ export interface ResolvedAssistant {
   isPaired: boolean;
   /** Remote gateway URL for paired entries; only the lockfile carries it. */
   runtimeUrl?: string;
+  /** Public ingress registered with the platform for self-hosted local
+   *  entries; only the API carries it. Null/undefined means the platform has
+   *  no route to this assistant. */
+  ingressUrl?: string | null;
   /** Owning org for platform entries; only the lockfile carries it, so
    *  API-sourced entries leave this undefined. */
   organizationId?: string;
+}
+
+/**
+ * Whether this device has some transport to the assistant: the platform proxy
+ * (cloud and paired entries), a lockfile entry (`cloud` is only ever set from
+ * the lockfile, so its presence means a local/paired transport exists here),
+ * or a platform-registered public ingress (`ingressUrl`, the phone-to-Mac
+ * self-hosted path). A local API entry with none of these is unreachable from
+ * this client — the platform proxy 404s — so list surfaces should not offer
+ * it.
+ */
+export function isConnectableFromThisDevice(a: ResolvedAssistant): boolean {
+  return !a.isLocal || a.cloud != null || a.ingressUrl != null;
 }
 
 /**
@@ -152,24 +169,32 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
     // The platform `Assistant` API carries no org field, so API-sourced
     // entries intentionally leave `organizationId` undefined (unlike
     // `setFromLockfile`). Don't "fix" this by inventing an org here.
+    //
+    // Unreachable local registrations are dropped: `hosting=all` returns
+    // every local assistant ever registered, and one this device cannot
+    // reach must not count toward `hasAssistants` or render as a dead card.
     setFromApi: (assistants) =>
       set({
         assistantsHydrated: true,
-        assistants: assistants.map((a) => {
-          const lockfileFields = getLockfileFields(a.id);
-          return {
-            id: a.id,
-            name: a.name,
-            hatchedAt: a.created,
-            cloud: lockfileFields.cloud,
-            runtimeVersion: lockfileFields.runtimeVersion,
-            runtimeUrl: lockfileFields.runtimeUrl,
-            currentReleaseVersion: a.current_release_version,
-            releaseChannel: a.release_channel,
-            isActiveLockfileAssistant: lockfileFields.isActiveLockfileAssistant,
-            ...classifyApiEntry(a.is_local, lockfileFields.isPaired),
-          };
-        }),
+        assistants: assistants
+          .map((a): ResolvedAssistant => {
+            const lockfileFields = getLockfileFields(a.id);
+            return {
+              id: a.id,
+              name: a.name,
+              hatchedAt: a.created,
+              cloud: lockfileFields.cloud,
+              runtimeVersion: lockfileFields.runtimeVersion,
+              runtimeUrl: lockfileFields.runtimeUrl,
+              ingressUrl: a.ingress_url,
+              currentReleaseVersion: a.current_release_version,
+              releaseChannel: a.release_channel,
+              isActiveLockfileAssistant:
+                lockfileFields.isActiveLockfileAssistant,
+              ...classifyApiEntry(a.is_local, lockfileFields.isPaired),
+            };
+          })
+          .filter(isConnectableFromThisDevice),
       }),
 
     markHydrated: () => set({ assistantsHydrated: true }),
@@ -185,6 +210,7 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
           id: assistant.id,
           name: assistant.name,
           hatchedAt: assistant.created,
+          ingressUrl: assistant.ingress_url,
           currentReleaseVersion: assistant.current_release_version,
           releaseChannel: assistant.release_channel,
           ...classifyApiEntry(


### PR DESCRIPTION
## Summary
- The platform-hub chooser (iOS app, remote web) rendered every `hosting=all` registration from the platform, including self-hosted local assistants with no public ingress — cards that can never connect from that device (the platform proxy 404s and `connectLocalAssistant` has no lockfile behind it).
- `setFromApi` now carries `ingress_url` into the resolved-assistants store and drops local registrations this device has no transport to, via a new `isConnectableFromThisDevice` predicate (cloud entries, lockfile-known entries, and ingress'd self-hosted entries all pass). The chooser applies the same predicate at render as a guard against lifecycle upserts reintroducing a stale entry.
- On non-local clients the chooser now connects a listed local (self-hosted, ingress'd) entry through `connectPlatformAssistant`, so the lifecycle projects it as self-hosted via `ingress_url` + platform actor token; the lockfile-backed `connectLocalAssistant` path is reserved for local clients.

## Original prompt
Noa saw assistants of type "local" in the iOS app's choose-assistant screen and expected only cloud and directly-connectable entries. Investigation traced them to platform-side self-hosted-local registrations (created by `ensure-registration` at hatch time) returned by the `hosting=all` list query, which the SPA rendered without checking reachability. The ask: filter out assistants that are impossible to connect to from the device, while continuing to display assistants that are directly connectable — cloud-hosted, paired, or self-hosted with a registered public ingress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)