### PR TITLE
feat(android): parse the optional name label from connect deep links

### DIFF
--- a/clients/android/app/src/main/java/ai/vellum/assistant/ConnectDeepLink.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/ConnectDeepLink.java
@@ -14,10 +14,12 @@ final class ConnectDeepLink {
 
     private final URI server;
     private final URI pairPage;
+    private final String name;
 
-    private ConnectDeepLink(URI server, URI pairPage) {
+    private ConnectDeepLink(URI server, URI pairPage, String name) {
         this.server = server;
         this.pairPage = pairPage;
+        this.name = name;
     }
 
     static boolean handles(String raw, String expectedScheme) {
@@ -66,7 +68,7 @@ final class ConnectDeepLink {
         if (pairPage == null) {
             return null;
         }
-        return new ConnectDeepLink(server, pairPage);
+        return new ConnectDeepLink(server, pairPage, normalizeName(query.get("name")));
     }
 
     URI server() {
@@ -75,6 +77,18 @@ final class ConnectDeepLink {
 
     URI pairPage() {
         return pairPage;
+    }
+
+    String name() {
+        return name;
+    }
+
+    private static String normalizeName(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
     }
 
     private static URI parseUri(String raw) {

--- a/clients/android/app/src/test/java/ai/vellum/assistant/ConnectDeepLinkTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/ConnectDeepLinkTest.java
@@ -53,6 +53,42 @@ public class ConnectDeepLinkTest {
     }
 
     @Test
+    public void decodesAndTrimsTheOptionalNameLabel() {
+        ConnectDeepLink connect = ConnectDeepLink.parse(
+            SCHEME + "://connect?url=https%3A%2F%2Fexample.com&code=device-code&name=Living+Room",
+            SCHEME
+        );
+
+        assertEquals("Living Room", connect.name());
+    }
+
+    @Test
+    public void preservesEscapedPlusSignsInNameLabels() {
+        ConnectDeepLink connect = ConnectDeepLink.parse(
+            SCHEME + "://connect?url=https%3A%2F%2Fexample.com&code=device-code&name=A%2BB",
+            SCHEME
+        );
+
+        assertEquals("A+B", connect.name());
+    }
+
+    @Test
+    public void collapsesMissingOrBlankNameLabelsToNull() {
+        ConnectDeepLink withoutName = ConnectDeepLink.parse(
+            SCHEME + "://connect?url=https%3A%2F%2Fexample.com&code=device-code",
+            SCHEME
+        );
+        ConnectDeepLink blankName = ConnectDeepLink.parse(
+            SCHEME + "://connect?url=https%3A%2F%2Fexample.com&code=device-code&name=",
+            SCHEME
+        );
+
+        assertNull(withoutName.name());
+        assertEquals("https://example.com", blankName.server().toASCIIString());
+        assertNull(blankName.name());
+    }
+
+    @Test
     public void ownsConnectLinksThatStrictUriParsingRejects() {
         String raw = SCHEME + "://connect?url=https%3A%2F%2Fexample.com&code=bare value%";
 


### PR DESCRIPTION
## Summary
- ConnectDeepLink now captures the optional name=<label> query param (trimmed, blank collapses to null), matching the iOS connect deep link
- URLDecoder's form decoding already gives the iOS-compatible '+' -> space tolerance for labels

Part of plan: android-assistant-parity.md (PR 2 of 5)