### PR TITLE
feat(android): remembered self-hosted server list with canonical URL identity

### DIFF
--- a/clients/android/app/build.gradle
+++ b/clients/android/app/build.gradle
@@ -152,6 +152,7 @@ dependencies {
     implementation "com.google.firebase:firebase-messaging:$firebaseMessagingVersion"
     implementation project(':capacitor-android')
     testImplementation "junit:junit:$junitVersion"
+    testImplementation "org.json:json:20240303"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
     implementation project(':capacitor-cordova-android-plugins')

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
@@ -297,11 +297,11 @@ final class SelfHostedServer {
         if (containsEncodedDotSegment(parsed.getRawPath())) {
             return null;
         }
-        URI normalized = parsed.normalize();
-        if (containsDotSegment(normalized.getRawPath())) {
+        String resolved = resolveDotSegments(parsed.getRawPath());
+        if (resolved == null) {
             return null;
         }
-        String path = normalizePath(normalized.getRawPath());
+        String path = normalizePath(resolved);
         try {
             return new URI(scheme + "://" + formatAuthority(host, parsed.getPort()) + path);
         } catch (URISyntaxException exception) {
@@ -450,16 +450,37 @@ final class SelfHostedServer {
         return false;
     }
 
-    private static boolean containsDotSegment(String rawPath) {
-        if (rawPath == null) {
-            return false;
+    /**
+     * RFC 3986 §5.2.4 dot-segment removal that preserves empty segments, which
+     * {@code URI.normalize()} collapses; iOS and the web canonicalizer keep
+     * interior duplicate separators as distinct route characters. Returns null
+     * when a {@code ..} would climb above the root.
+     */
+    private static String resolveDotSegments(String rawPath) {
+        if (rawPath == null || rawPath.isEmpty()) {
+            return "";
         }
-        for (String segment : rawPath.split("/", -1)) {
-            if (".".equals(segment) || "..".equals(segment)) {
-                return true;
+        String[] parts = rawPath.split("/", -1);
+        List<String> segments = new ArrayList<>();
+        for (int index = 1; index < parts.length; index++) {
+            String segment = parts[index];
+            if (".".equals(segment)) {
+                continue;
+            }
+            if ("..".equals(segment)) {
+                if (segments.isEmpty()) {
+                    return null;
+                }
+                segments.remove(segments.size() - 1);
+            } else {
+                segments.add(segment);
             }
         }
-        return false;
+        StringBuilder resolved = new StringBuilder();
+        for (String segment : segments) {
+            resolved.append('/').append(segment);
+        }
+        return resolved.toString();
     }
 
     private static String formatAuthority(String host, int port) {

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
@@ -12,7 +12,11 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -21,6 +25,7 @@ final class SelfHostedServer {
     private static final String CONFIG_FILE = "capacitor.config.json";
     private static final String PREFERENCES_NAME = "self_hosted_server";
     private static final String SERVER_URL_KEY = "server_url";
+    private static final String SERVERS_KEY = "servers";
 
     interface Store {
         String read();
@@ -28,6 +33,31 @@ final class SelfHostedServer {
         boolean write(String value);
 
         void clear();
+
+        String readServers();
+
+        void writeServers(String json);
+    }
+
+    /** A remembered self-hosted server: a canonical url plus an optional user-facing label. */
+    static final class Entry {
+        final String name;
+        final String url;
+
+        Entry(String name, String url) {
+            this.name = name;
+            this.url = url;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof Entry entry && Objects.equals(name, entry.name) && Objects.equals(url, entry.url);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name, url);
+        }
     }
 
     private SelfHostedServer() {}
@@ -58,6 +88,182 @@ final class SelfHostedServer {
 
     static void clear(Store store) {
         store.clear();
+    }
+
+    /**
+     * Canonical identity of a validated server URL, shared with the web chooser's
+     * remembered-origins store (normalizeOriginUrl) and iOS: the scheme-default
+     * port is collapsed, everything else is already normalized by validate.
+     */
+    static URI canonicalize(URI validated) {
+        int port = validated.getPort();
+        String scheme = validated.getScheme();
+        boolean schemeDefaultPort = ("https".equals(scheme) && port == 443) || ("http".equals(scheme) && port == 80);
+        if (!schemeDefaultPort) {
+            return validated;
+        }
+        try {
+            return new URI(scheme + "://" + validated.getHost() + normalizePath(validated.getRawPath()));
+        } catch (URISyntaxException exception) {
+            return validated;
+        }
+    }
+
+    /** canonicalize as the string used for list entries and equality. */
+    static String canonicalString(URI validated) {
+        return canonicalize(validated).toASCIIString();
+    }
+
+    static List<Entry> servers(Context context) {
+        return servers(new PreferencesStore(context));
+    }
+
+    /**
+     * The remembered server list, entries keyed by canonical URL. Entries failing
+     * validate are dropped, stored urls re-canonicalize on read (deduping any
+     * pre-canonical duplicates, first entry wins), and a legacy active URL absent
+     * from the stored list is included (name null) without writing back until the
+     * next mutation.
+     */
+    static List<Entry> servers(Store store) {
+        List<Entry> entries = new ArrayList<>();
+        String raw = store.readServers();
+        if (raw != null) {
+            try {
+                JSONArray stored = new JSONArray(raw);
+                for (int index = 0; index < stored.length(); index++) {
+                    JSONObject item = stored.optJSONObject(index);
+                    URI url = item == null ? null : validate(item.optString("url", null));
+                    if (url == null) {
+                        continue;
+                    }
+                    String canonical = canonicalString(url);
+                    if (indexOfUrl(entries, canonical) < 0) {
+                        entries.add(new Entry(normalizedName(item.optString("name", null)), canonical));
+                    }
+                }
+            } catch (JSONException exception) {
+                // A corrupt list reads as empty; the active slot below still surfaces.
+            }
+        }
+        URI active = configured(store);
+        if (active != null) {
+            String canonical = canonicalString(active);
+            if (indexOfUrl(entries, canonical) < 0) {
+                entries.add(new Entry(null, canonical));
+            }
+        }
+        return entries;
+    }
+
+    static void append(Context context, URI url, String name) {
+        append(new PreferencesStore(context), url, name);
+    }
+
+    /**
+     * Remember an origin, deduped by canonical URL. A re-append with a name
+     * updates the label; a nameless re-append keeps the existing one.
+     */
+    static void append(Store store, URI url, String name) {
+        List<Entry> entries = servers(store);
+        String canonical = canonicalString(url);
+        String label = normalizedName(name);
+        int index = indexOfUrl(entries, canonical);
+        if (index < 0) {
+            entries.add(new Entry(label, canonical));
+        } else if (label != null) {
+            entries.set(index, new Entry(label, canonical));
+        }
+        persist(store, entries);
+    }
+
+    static boolean removeEntry(Context context, URI url) {
+        return removeEntry(new PreferencesStore(context), url);
+    }
+
+    /**
+     * Forget an origin, matched by canonical URL. When it is also the active
+     * slot, the slot is cleared too; returns whether that happened.
+     */
+    static boolean removeEntry(Store store, URI url) {
+        List<Entry> entries = servers(store);
+        String canonical = canonicalString(url);
+        int index = indexOfUrl(entries, canonical);
+        if (index >= 0) {
+            entries.remove(index);
+        }
+        persist(store, entries);
+        if (isActive(store, url)) {
+            clear(store);
+            return true;
+        }
+        return false;
+    }
+
+    static boolean isActive(Context context, URI url) {
+        return isActive(new PreferencesStore(context), url);
+    }
+
+    /** Whether a URL canonically matches the active slot. */
+    static boolean isActive(Store store, URI url) {
+        URI active = configured(store);
+        return active != null && url != null && canonicalString(active).equals(canonicalString(url));
+    }
+
+    /** The baked server.url from the bundled Capacitor config, or null when unreadable. */
+    static String bakedServerUrl(Context context) {
+        try {
+            return parseBakedServerUrl(readAsset(context, CONFIG_FILE));
+        } catch (Exception exception) {
+            return null;
+        }
+    }
+
+    static String parseBakedServerUrl(String configJson) {
+        if (configJson == null) {
+            return null;
+        }
+        try {
+            JSONObject server = new JSONObject(configJson).optJSONObject("server");
+            String url = server == null ? null : server.optString("url", null);
+            return url == null || url.trim().isEmpty() ? null : url;
+        } catch (JSONException exception) {
+            return null;
+        }
+    }
+
+    private static int indexOfUrl(List<Entry> entries, String canonicalUrl) {
+        for (int index = 0; index < entries.size(); index++) {
+            if (entries.get(index).url.equals(canonicalUrl)) {
+                return index;
+            }
+        }
+        return -1;
+    }
+
+    private static void persist(Store store, List<Entry> entries) {
+        JSONArray array = new JSONArray();
+        try {
+            for (Entry entry : entries) {
+                JSONObject item = new JSONObject();
+                if (entry.name != null) {
+                    item.put("name", entry.name);
+                }
+                item.put("url", entry.url);
+                array.put(item);
+            }
+        } catch (JSONException exception) {
+            return;
+        }
+        store.writeServers(array.toString());
+    }
+
+    private static String normalizedName(String name) {
+        if (name == null) {
+            return null;
+        }
+        String trimmed = name.trim();
+        return trimmed.isEmpty() ? null : trimmed;
     }
 
     static URI validate(String raw) {
@@ -284,6 +490,16 @@ final class SelfHostedServer {
         @Override
         public void clear() {
             preferences.edit().remove(SERVER_URL_KEY).commit();
+        }
+
+        @Override
+        public String readServers() {
+            return preferences.getString(SERVERS_KEY, null);
+        }
+
+        @Override
+        public void writeServers(String json) {
+            preferences.edit().putString(SERVERS_KEY, json).commit();
         }
     }
 }

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
@@ -397,7 +397,7 @@ final class SelfHostedServer {
         // Percent-escape casing is preserved, matching the iOS canonicalizer
         // and the web normalizeOriginUrl.
         String normalized = rawPath;
-        while (normalized.endsWith("/") && normalized.length() > 1) {
+        while (normalized.endsWith("/")) {
             normalized = normalized.substring(0, normalized.length() - 1);
         }
         return normalized;

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
@@ -324,8 +324,8 @@ final class SelfHostedServer {
             return false;
         }
 
-        String basePath = normalizePath(server.getRawPath());
-        String candidatePath = normalizePath(candidate.getRawPath());
+        String basePath = foldEscapeCase(normalizePath(server.getRawPath()));
+        String candidatePath = foldEscapeCase(normalizePath(candidate.getRawPath()));
         if (basePath.isEmpty()) {
             return true;
         }
@@ -340,7 +340,8 @@ final class SelfHostedServer {
             && expected.getScheme().equalsIgnoreCase(actual.getScheme())
             && expected.getHost().equalsIgnoreCase(actual.getHost())
             && effectivePort(expected) == effectivePort(actual)
-            && normalizePath(expected.getRawPath()).equals(normalizePath(actual.getRawPath()));
+            && foldEscapeCase(normalizePath(expected.getRawPath()))
+                .equals(foldEscapeCase(normalizePath(actual.getRawPath())));
     }
 
     static CapConfig overrideCapacitorConfig(Context context, URI server) throws IOException, JSONException {
@@ -401,6 +402,24 @@ final class SelfHostedServer {
             normalized = normalized.substring(0, normalized.length() - 1);
         }
         return normalized;
+    }
+
+    /**
+     * Uppercase percent-escape hex for comparison only: escape hex digits are
+     * case-insensitive per RFC 3986, so navigation checks must match `%2f`
+     * against `%2F`, while canonical list identity keeps the original casing.
+     */
+    private static String foldEscapeCase(String path) {
+        StringBuilder folded = new StringBuilder(path.length());
+        for (int index = 0; index < path.length(); index++) {
+            char item = path.charAt(index);
+            folded.append(item);
+            if (item == '%' && index + 2 < path.length()) {
+                folded.append(Character.toUpperCase(path.charAt(++index)));
+                folded.append(Character.toUpperCase(path.charAt(++index)));
+            }
+        }
+        return folded.toString();
     }
 
     private static boolean containsEncodedDotSegment(String rawPath) {

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
@@ -394,20 +394,13 @@ final class SelfHostedServer {
         if (rawPath == null || rawPath.isEmpty() || "/".equals(rawPath)) {
             return "";
         }
+        // Percent-escape casing is preserved, matching the iOS canonicalizer
+        // and the web normalizeOriginUrl.
         String normalized = rawPath;
         while (normalized.endsWith("/") && normalized.length() > 1) {
             normalized = normalized.substring(0, normalized.length() - 1);
         }
-        StringBuilder canonical = new StringBuilder(normalized.length());
-        for (int index = 0; index < normalized.length(); index++) {
-            char item = normalized.charAt(index);
-            canonical.append(item);
-            if (item == '%' && index + 2 < normalized.length()) {
-                canonical.append(Character.toUpperCase(normalized.charAt(++index)));
-                canonical.append(Character.toUpperCase(normalized.charAt(++index)));
-            }
-        }
-        return canonical.toString();
+        return normalized;
     }
 
     private static boolean containsEncodedDotSegment(String rawPath) {

--- a/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
@@ -126,6 +126,19 @@ public class SelfHostedServerTest {
     }
 
     @Test
+    public void stripsEveryTrailingSlashLikeIosAndWebCanonicalizers() {
+        assertEquals("https://example.com", SelfHostedServer.validate("https://example.com//").toASCIIString());
+        assertEquals(
+            "https://example.com",
+            SelfHostedServer.canonicalString(SelfHostedServer.validate("https://example.com:443///"))
+        );
+        assertEquals(
+            "https://example.com/assistant-123",
+            SelfHostedServer.canonicalString(SelfHostedServer.validate("https://example.com/assistant-123//"))
+        );
+    }
+
+    @Test
     public void appendDedupesByCanonicalUrlAndKeepsLabelsAcrossNamelessReappends() {
         FakeStore store = new FakeStore();
         URI server = SelfHostedServer.validate("https://example.com:443/assistant-123/");

--- a/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
@@ -126,6 +126,40 @@ public class SelfHostedServerTest {
     }
 
     @Test
+    public void preservesInteriorDuplicateSeparators() {
+        assertEquals(
+            "https://example.com/tenant//assistant",
+            SelfHostedServer.validate("https://example.com/tenant//assistant").toASCIIString()
+        );
+        assertEquals(
+            "https://example.com/tenant//assistant",
+            SelfHostedServer.canonicalString(SelfHostedServer.validate("https://example.com/tenant//assistant"))
+        );
+    }
+
+    @Test
+    public void navigationChecksMatchPercentEscapesCaseInsensitively() {
+        assertTrue(
+            SelfHostedServer.samePage(
+                "https://example.com/tenant%2fabc/assistant/pair",
+                "https://example.com/tenant%2Fabc/assistant/pair"
+            )
+        );
+        assertTrue(
+            SelfHostedServer.contains(
+                SelfHostedServer.validate("https://example.com/tenant%2fabc"),
+                "https://example.com/tenant%2Fabc/conversations"
+            )
+        );
+        assertFalse(
+            SelfHostedServer.contains(
+                SelfHostedServer.validate("https://example.com/tenant%2fabc"),
+                "https://example.com/tenant/abc/conversations"
+            )
+        );
+    }
+
+    @Test
     public void stripsEveryTrailingSlashLikeIosAndWebCanonicalizers() {
         assertEquals("https://example.com", SelfHostedServer.validate("https://example.com//").toASCIIString());
         assertEquals(

--- a/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.net.URI;
+import java.util.List;
 import org.junit.Test;
 
 public class SelfHostedServerTest {
@@ -102,8 +103,101 @@ public class SelfHostedServerTest {
         assertFalse(SelfHostedServer.samePage(pairPage, "https://example.com/other/assistant/pair"));
     }
 
+    @Test
+    public void canonicalizationCollapsesSchemeDefaultPortsOnly() {
+        assertEquals(
+            "https://example.com/assistant-123",
+            SelfHostedServer.canonicalString(SelfHostedServer.validate("https://example.com:443/assistant-123/"))
+        );
+        assertEquals(
+            "https://example.com:8443/assistant-123",
+            SelfHostedServer.canonicalString(SelfHostedServer.validate("https://example.com:8443/assistant-123"))
+        );
+        assertEquals(
+            "http://localhost:8787",
+            SelfHostedServer.canonicalString(SelfHostedServer.validate("http://localhost:8787"))
+        );
+        assertEquals(
+            "http://localhost",
+            SelfHostedServer.canonicalString(SelfHostedServer.validate("http://localhost:80"))
+        );
+    }
+
+    @Test
+    public void appendDedupesByCanonicalUrlAndKeepsLabelsAcrossNamelessReappends() {
+        FakeStore store = new FakeStore();
+        URI server = SelfHostedServer.validate("https://example.com:443/assistant-123/");
+
+        SelfHostedServer.append(store, server, "  Living Room  ");
+        SelfHostedServer.append(store, SelfHostedServer.validate("https://example.com/assistant-123"), null);
+
+        List<SelfHostedServer.Entry> servers = SelfHostedServer.servers(store);
+        assertEquals(1, servers.size());
+        assertEquals(new SelfHostedServer.Entry("Living Room", "https://example.com/assistant-123"), servers.get(0));
+
+        SelfHostedServer.append(store, server, "Kitchen");
+        assertEquals("Kitchen", SelfHostedServer.servers(store).get(0).name);
+    }
+
+    @Test
+    public void readingDropsInvalidEntriesAndDedupesPreCanonicalDuplicates() {
+        FakeStore store = new FakeStore();
+        store.servers =
+            "[{\"url\":\"http://example.com\"},"
+                + "{\"name\":\"First\",\"url\":\"https://example.com:443/assistant-123\"},"
+                + "{\"name\":\"Second\",\"url\":\"https://example.com/assistant-123/\"},"
+                + "{\"name\":\"\",\"url\":\"https://other.example.com/assistant-456\"}]";
+
+        List<SelfHostedServer.Entry> servers = SelfHostedServer.servers(store);
+
+        assertEquals(2, servers.size());
+        assertEquals(new SelfHostedServer.Entry("First", "https://example.com/assistant-123"), servers.get(0));
+        assertEquals(new SelfHostedServer.Entry(null, "https://other.example.com/assistant-456"), servers.get(1));
+    }
+
+    @Test
+    public void foldsInLegacyActiveUrlWithoutWritingBack() {
+        FakeStore store = new FakeStore();
+        SelfHostedServer.store(store, SelfHostedServer.validate("https://example.com:443/assistant-123"));
+
+        List<SelfHostedServer.Entry> servers = SelfHostedServer.servers(store);
+
+        assertEquals(1, servers.size());
+        assertEquals(new SelfHostedServer.Entry(null, "https://example.com/assistant-123"), servers.get(0));
+        assertNull(store.servers);
+    }
+
+    @Test
+    public void removingTheActiveEntryClearsTheActiveSlot() {
+        FakeStore store = new FakeStore();
+        URI active = SelfHostedServer.validate("https://example.com/assistant-123");
+        URI other = SelfHostedServer.validate("https://other.example.com/assistant-456");
+        SelfHostedServer.append(store, active, "Active");
+        SelfHostedServer.append(store, other, "Other");
+        SelfHostedServer.store(store, active);
+
+        assertFalse(SelfHostedServer.removeEntry(store, other));
+        assertTrue(SelfHostedServer.isActive(store, active));
+
+        assertTrue(SelfHostedServer.removeEntry(store, SelfHostedServer.validate("https://example.com:443/assistant-123")));
+        assertNull(SelfHostedServer.configured(store));
+        assertTrue(SelfHostedServer.servers(store).isEmpty());
+    }
+
+    @Test
+    public void parsesBakedServerUrlFromCapacitorConfig() {
+        assertEquals(
+            "https://www.vellum.ai/assistant",
+            SelfHostedServer.parseBakedServerUrl("{\"server\":{\"url\":\"https://www.vellum.ai/assistant\"}}")
+        );
+        assertNull(SelfHostedServer.parseBakedServerUrl("not json"));
+        assertNull(SelfHostedServer.parseBakedServerUrl("{\"server\":{}}"));
+        assertNull(SelfHostedServer.parseBakedServerUrl(null));
+    }
+
     private static final class FakeStore implements SelfHostedServer.Store {
         private String value;
+        private String servers;
 
         @Override
         public String read() {
@@ -119,6 +213,16 @@ public class SelfHostedServerTest {
         @Override
         public void clear() {
             value = null;
+        }
+
+        @Override
+        public String readServers() {
+            return servers;
+        }
+
+        @Override
+        public void writeServers(String json) {
+            servers = json;
         }
     }
 }

--- a/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
@@ -19,9 +19,11 @@ public class SelfHostedServerTest {
 
     @Test
     public void preservesEscapedReservedCharacters() {
-        URI server = SelfHostedServer.validate("https://example.com/tenant%2fabc/");
+        URI lower = SelfHostedServer.validate("https://example.com/tenant%2fabc/");
+        URI upper = SelfHostedServer.validate("https://example.com/tenant%2Fabc/");
 
-        assertEquals("https://example.com/tenant%2Fabc", server.toASCIIString());
+        assertEquals("https://example.com/tenant%2fabc", lower.toASCIIString());
+        assertEquals("https://example.com/tenant%2Fabc", upper.toASCIIString());
     }
 
     @Test
@@ -86,7 +88,7 @@ public class SelfHostedServerTest {
     public void keepsEscapedSeparatorsDistinctWhenMatchingPrefixes() {
         URI server = SelfHostedServer.validate("https://example.com/tenant%2Fabc");
 
-        assertTrue(SelfHostedServer.contains(server, "https://example.com/tenant%2fabc/assistant/pair"));
+        assertTrue(SelfHostedServer.contains(server, "https://example.com/tenant%2Fabc/assistant/pair"));
         assertFalse(SelfHostedServer.contains(server, "https://example.com/tenant/abc/assistant/pair"));
     }
 


### PR DESCRIPTION
## Summary
- Adds a remembered {name?, url} self-hosted server list to SelfHostedServer, JSON-encoded in the existing self_hosted_server SharedPreferences file
- Adds canonical URL identity (scheme-default port collapse) matching iOS SelfHostedServer.canonicalize and the web chooser's normalizeOriginUrl
- Adds a baked-server-url reader from the bundled capacitor.config.json asset, plus JVM-testable org.json via testImplementation

Part of plan: android-assistant-parity.md (PR 1 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)