### PR TITLE
Fix Windows native authentication callback

### DIFF
--- a/clients/windows/src/main/auth-callback.test.ts
+++ b/clients/windows/src/main/auth-callback.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+
+import { startWindowsAuthCallback } from "./auth-callback";
+
+function callbackHarness() {
+  let listener: (url: string) => void = () => {};
+  let unsubscribeCalls = 0;
+  return {
+    emit: (url: string) => listener(url),
+    get unsubscribeCalls() {
+      return unsubscribeCalls;
+    },
+    subscribe: (next: (url: string) => void) => {
+      listener = next;
+      return () => {
+        unsubscribeCalls += 1;
+      };
+    },
+  };
+}
+
+describe("startWindowsAuthCallback", () => {
+  test("accepts a state-matched code on the registered app scheme", async () => {
+    const harness = callbackHarness();
+    const callback = await startWindowsAuthCallback("expected", {
+      scheme: "vellum-assistant-dev",
+      subscribe: harness.subscribe,
+    });
+
+    expect(callback.redirectUri).toBe("vellum-assistant-dev://auth/callback");
+
+    harness.emit(
+      "vellum-assistant-dev://auth/callback?code=wrong&state=unexpected",
+    );
+    harness.emit("https://example.com/callback?code=wrong&state=expected");
+    harness.emit(
+      "vellum-assistant-dev://auth/callback?code=good&state=expected",
+    );
+
+    expect(await callback.waitForCode).toBe("good");
+    expect(harness.unsubscribeCalls).toBe(1);
+  });
+
+  test("surfaces a state-matched provider error", async () => {
+    const harness = callbackHarness();
+    const callback = await startWindowsAuthCallback("expected", {
+      scheme: "vellum-assistant-dev",
+      subscribe: harness.subscribe,
+    });
+    const result = callback.waitForCode.catch((error: Error) => error);
+
+    harness.emit(
+      "vellum-assistant-dev://auth/callback?error=access_denied&error_description=Denied&state=expected",
+    );
+
+    await expect(result).resolves.toMatchObject({
+      message: "Authentication failed: access_denied: Denied",
+    });
+    expect(harness.unsubscribeCalls).toBe(1);
+  });
+
+  test("close cancels the pending callback and unsubscribes", async () => {
+    const harness = callbackHarness();
+    const callback = await startWindowsAuthCallback("expected", {
+      scheme: "vellum-assistant-dev",
+      subscribe: harness.subscribe,
+    });
+    const result = callback.waitForCode.catch((error: Error) => error);
+
+    callback.close("Sign-in timed out.");
+
+    await expect(result).resolves.toMatchObject({
+      message: "Sign-in timed out.",
+    });
+    expect(harness.unsubscribeCalls).toBe(1);
+  });
+});

--- a/clients/windows/src/main/auth-callback.ts
+++ b/clients/windows/src/main/auth-callback.ts
@@ -1,0 +1,82 @@
+import type { NativeAuthCallback } from "@vellumai/electron-desktop/native-auth";
+
+export interface WindowsAuthCallbackOptions {
+  scheme: string;
+  subscribe: (listener: (url: string) => void) => () => void;
+}
+
+const CALLBACK_HOST = "auth";
+const CALLBACK_PATH = "/callback";
+
+export function startWindowsAuthCallback(
+  expectedState: string,
+  options: WindowsAuthCallbackOptions,
+): Promise<NativeAuthCallback> {
+  let resolveCode: (code: string) => void = () => {};
+  let rejectCode: (error: Error) => void = () => {};
+  let unsubscribe = () => {};
+  let settled = false;
+
+  const waitForCode = new Promise<string>((resolve, reject) => {
+    resolveCode = resolve;
+    rejectCode = reject;
+  });
+
+  const finish = (result: { code: string } | { error: Error }): void => {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    unsubscribe();
+    if ("code" in result) {
+      resolveCode(result.code);
+    } else {
+      rejectCode(result.error);
+    }
+  };
+
+  const onUrl = (input: string): void => {
+    let url: URL;
+    try {
+      url = new URL(input);
+    } catch {
+      return;
+    }
+    if (
+      url.protocol !== `${options.scheme}:` ||
+      url.host !== CALLBACK_HOST ||
+      url.pathname !== CALLBACK_PATH ||
+      url.searchParams.get("state") !== expectedState
+    ) {
+      return;
+    }
+
+    const error = url.searchParams.get("error");
+    const code = url.searchParams.get("code");
+    if (error || !code) {
+      const description = url.searchParams.get("error_description");
+      const detail = description ? `${error}: ${description}` : error;
+      finish({
+        error: new Error(
+          `Authentication failed: ${detail ?? "no authorization code received"}`,
+        ),
+      });
+      return;
+    }
+    finish({ code });
+  };
+
+  const stop = options.subscribe(onUrl);
+  unsubscribe = stop;
+  if (settled) {
+    stop();
+  }
+
+  return Promise.resolve({
+    redirectUri: `${options.scheme}://${CALLBACK_HOST}${CALLBACK_PATH}`,
+    waitForCode,
+    close: (reason?: string) => {
+      finish({ error: new Error(reason ?? "Auth flow cancelled.") });
+    },
+  });
+}

--- a/clients/windows/src/main/features/auth.ts
+++ b/clients/windows/src/main/features/auth.ts
@@ -4,7 +4,7 @@ import type {
   CapabilityModule,
   DesktopCapabilityRegistry,
 } from "@vellumai/electron-desktop/capability-registry";
-import { resolveRegisteredSchemes } from "@vellumai/electron-desktop/deep-links";
+import { resolveAuthCallbackScheme } from "@vellumai/electron-desktop/deep-links";
 import {
   configureNativeAuth,
   installNativeAuth,
@@ -49,14 +49,9 @@ const subscribeToAuthCallback = (
 const authFeature: CapabilityModule<DesktopCapabilityRegistry> = {
   id: "native-auth",
   install: () => {
-    const [authScheme] = resolveRegisteredSchemes(
+    const authScheme = resolveAuthCallbackScheme(
       resolveEnvironmentName(process.env),
     );
-    if (!authScheme) {
-      throw new Error(
-        "No Windows authentication callback scheme is registered",
-      );
-    }
     setSessionTokenLogger(log);
     configureNativeAuth({
       activateWindow: () => {
@@ -68,11 +63,15 @@ const authFeature: CapabilityModule<DesktopCapabilityRegistry> = {
       openExternal: (url) => shell.openExternal(url),
       removeCookie: (url, name) =>
         session.defaultSession.cookies.remove(url, name),
-      startCallback: (expectedState) =>
-        startWindowsAuthCallback(expectedState, {
-          scheme: authScheme,
-          subscribe: subscribeToAuthCallback,
-        }),
+      ...(app.isPackaged
+        ? {
+            startCallback: (expectedState: string) =>
+              startWindowsAuthCallback(expectedState, {
+                scheme: authScheme,
+                subscribe: subscribeToAuthCallback,
+              }),
+          }
+        : {}),
       sessionStore: {
         clear: clearSessionToken,
         get: getSessionToken,

--- a/clients/windows/src/main/features/auth.ts
+++ b/clients/windows/src/main/features/auth.ts
@@ -1,9 +1,10 @@
-import { app, session, shell } from "electron";
+import { app, session, shell, type Event } from "electron";
 
 import type {
   CapabilityModule,
   DesktopCapabilityRegistry,
 } from "@vellumai/electron-desktop/capability-registry";
+import { resolveRegisteredSchemes } from "@vellumai/electron-desktop/deep-links";
 import {
   configureNativeAuth,
   installNativeAuth,
@@ -14,15 +15,48 @@ import {
   saveSessionToken,
   setSessionTokenLogger,
 } from "@vellumai/electron-desktop/session-token-store";
-import { resolveLocalConfigFromEnv } from "@vellumai/local-mode";
+import {
+  resolveEnvironmentName,
+  resolveLocalConfigFromEnv,
+} from "@vellumai/local-mode";
 
+import { startWindowsAuthCallback } from "../auth-callback";
 import { handle, handleSync } from "../ipc.client";
 import log from "../logger";
 import { ensureVisible } from "../main-window";
 
+const subscribeToAuthCallback = (
+  listener: (url: string) => void,
+): (() => void) => {
+  const onSecondInstance = (_event: Event, argv: string[]): void => {
+    for (const arg of argv) {
+      listener(arg);
+    }
+  };
+  const onOpenUrl = (event: Event, url: string): void => {
+    event.preventDefault();
+    listener(url);
+  };
+
+  app.on("second-instance", onSecondInstance);
+  app.on("open-url", onOpenUrl);
+  return () => {
+    app.off("second-instance", onSecondInstance);
+    app.off("open-url", onOpenUrl);
+  };
+};
+
 const authFeature: CapabilityModule<DesktopCapabilityRegistry> = {
   id: "native-auth",
   install: () => {
+    const [authScheme] = resolveRegisteredSchemes(
+      resolveEnvironmentName(process.env),
+    );
+    if (!authScheme) {
+      throw new Error(
+        "No Windows authentication callback scheme is registered",
+      );
+    }
     setSessionTokenLogger(log);
     configureNativeAuth({
       activateWindow: () => {
@@ -34,6 +68,11 @@ const authFeature: CapabilityModule<DesktopCapabilityRegistry> = {
       openExternal: (url) => shell.openExternal(url),
       removeCookie: (url, name) =>
         session.defaultSession.cookies.remove(url, name),
+      startCallback: (expectedState) =>
+        startWindowsAuthCallback(expectedState, {
+          scheme: authScheme,
+          subscribe: subscribeToAuthCallback,
+        }),
       sessionStore: {
         clear: clearSessionToken,
         get: getSessionToken,

--- a/packages/electron-desktop/src/deep-links.test.ts
+++ b/packages/electron-desktop/src/deep-links.test.ts
@@ -72,6 +72,7 @@ const {
   installDeepLinks,
   parseVellumUrl,
   resolveAcceptedSchemes,
+  resolveAuthCallbackScheme,
   resolveRegisteredSchemes,
 } = await import("./deep-links");
 const { resolveEnvironmentName } = await import("@vellumai/local-mode");
@@ -813,6 +814,16 @@ describe("resolveRegisteredSchemes", () => {
 
   test("unknown env derives scheme from env name", () => {
     expect(resolveRegisteredSchemes("test")).toEqual(["vellum-assistant-test"]);
+  });
+});
+
+describe("resolveAuthCallbackScheme", () => {
+  test("uses the app-specific production scheme", () => {
+    expect(resolveAuthCallbackScheme("production")).toBe("vellum-assistant");
+  });
+
+  test("uses the environment-specific non-production scheme", () => {
+    expect(resolveAuthCallbackScheme("dev")).toBe("vellum-assistant-dev");
   });
 });
 

--- a/packages/electron-desktop/src/deep-links.ts
+++ b/packages/electron-desktop/src/deep-links.ts
@@ -75,7 +75,7 @@ export const configureDeepLinks = (next: DeepLinkRuntime): void => {
 
 const PRODUCTION_SCHEME = "vellum-assistant";
 
-function schemeForEnv(env: string): string {
+export function resolveAuthCallbackScheme(env: string): string {
   return env === "production"
     ? PRODUCTION_SCHEME
     : `${PRODUCTION_SCHEME}-${env}`;
@@ -88,7 +88,7 @@ export function resolveRegisteredSchemes(env: string): string[] {
   if (env === "production") {
     return ["vellum", PRODUCTION_SCHEME];
   }
-  return [schemeForEnv(env)];
+  return [resolveAuthCallbackScheme(env)];
 }
 
 // Schemes to ACCEPT when parsing inbound URLs. Superset of registered
@@ -97,7 +97,7 @@ export function resolveRegisteredSchemes(env: string): string[] {
 export function resolveAcceptedSchemes(env: string): string[] {
   const accepted = new Set(["vellum:", `${PRODUCTION_SCHEME}:`]);
   if (env !== "production") {
-    accepted.add(`${schemeForEnv(env)}:`);
+    accepted.add(`${resolveAuthCallbackScheme(env)}:`);
   }
   return [...accepted];
 }

--- a/packages/electron-desktop/src/native-auth.ts
+++ b/packages/electron-desktop/src/native-auth.ts
@@ -27,12 +27,19 @@ type IpcRegistrar = Pick<
   "handle" | "handleSync"
 >;
 
+export interface NativeAuthCallback {
+  redirectUri: string;
+  waitForCode: Promise<string>;
+  close: (reason?: string) => void;
+}
+
 export interface NativeAuthOptions {
   activateWindow: () => void | Promise<void>;
   getPlatformUrl: () => string;
   ipc: IpcRegistrar;
   openExternal: (url: string) => void | Promise<void>;
   removeCookie: (url: string, name: string) => Promise<void>;
+  startCallback?: (expectedState: string) => Promise<NativeAuthCallback>;
   sessionStore: {
     clear: typeof clearSessionToken;
     get: typeof getSessionToken;
@@ -82,7 +89,9 @@ async function startOAuth(options: {
   const clientId = await fetchWorkosClientId(platformUrl);
   const state = generateState();
   const { verifier, challenge } = generatePkcePair();
-  const listener = await startLoopbackListener(state);
+  const listener = await (
+    runtimeOptions.startCallback ?? startLoopbackListener
+  )(state);
 
   const timer = setTimeout(
     () => listener.close("Sign-in timed out. Please try again."),


### PR DESCRIPTION
## Summary
- route packaged Windows PKCE callbacks through the registered environment-specific Vellum protocol
- keep the existing loopback callback as the default for macOS
- validate callback scheme, path, and state before accepting authorization codes

## Original prompt
The packaged Windows app reached AuthKit but failed after social sign-in, while the normal browser flow worked. Fix the Windows-specific native authentication path and open this PR against the Windows parity step 1 branch.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40724" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->