### PR TITLE
feat(web): dress the conversation actions sheet to its Figma mock

### DIFF
--- a/clients/web/eslint.config.mjs
+++ b/clients/web/eslint.config.mjs
@@ -192,6 +192,7 @@ const authBoundaryAllowedPaths = [
 const i18nEnforcedPaths = [
   "src/components/not-found.tsx",
   "src/domains/chat/components/chat-composer/add-to-chat-sheet.tsx",
+  "src/domains/chat/components/conversation-actions-menu.tsx",
   "src/domains/chat/components/conversation-assets-pill.tsx",
   "src/domains/chat/components/pinned-app-color-swatches.tsx",
   "src/domains/chat/components/sidebar-conversation-error.tsx",

--- a/clients/web/src/domains/chat/components/conversation-actions-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/conversation-actions-menu.test.tsx
@@ -15,6 +15,12 @@
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import i18next from "i18next";
+
+// The builders take a namespace-bound `t`, the same thing
+// `useTranslation("chat")` hands their component callers. The bare export
+// resolves against `common` and would return the key instead of the copy.
+const t = i18next.getFixedT(null, "chat");
 import { createElement, type ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
@@ -150,6 +156,7 @@ describe("renderConversationMenuItems", () => {
       <>
         {renderConversationMenuItems({
           Primitive: Menu as unknown as ConversationMenuPrimitive,
+          t,
           onPinToggle: () => {},
           onRename: () => {},
         })}
@@ -164,6 +171,7 @@ describe("renderConversationMenuItems", () => {
       <>
         {renderConversationMenuItems({
           Primitive: Menu as unknown as ConversationMenuPrimitive,
+          t,
           isPinned: true,
           onPinToggle: () => {},
         })}
@@ -178,6 +186,7 @@ describe("renderConversationMenuItems", () => {
       <>
         {renderConversationMenuItems({
           Primitive: Menu as unknown as ConversationMenuPrimitive,
+          t,
           onArchive: () => {},
         })}
       </>,
@@ -190,6 +199,7 @@ describe("renderConversationMenuItems", () => {
       <>
         {renderConversationMenuItems({
           Primitive: Menu as unknown as ConversationMenuPrimitive,
+          t,
           isArchived: true,
           onUnarchive: () => {},
         })}
@@ -203,6 +213,7 @@ describe("renderConversationMenuItems", () => {
       <>
         {renderConversationMenuItems({
           Primitive: Menu as unknown as ConversationMenuPrimitive,
+          t,
           isReadonly: true,
           onArchive: () => {},
           onMarkUnread: () => {},
@@ -218,6 +229,7 @@ describe("renderConversationMenuItems", () => {
       <>
         {renderConversationMenuItems({
           Primitive: Menu as unknown as ConversationMenuPrimitive,
+          t,
           variant: "header",
           channelSourceLink: {
             href: "https://slack.com/archives/C01ABC/p1700000000000100",
@@ -235,6 +247,7 @@ describe("renderConversationMenuItems", () => {
       <>
         {renderConversationMenuItems({
           Primitive: Menu as unknown as ConversationMenuPrimitive,
+          t,
           variant: "header",
           onPinToggle: () => {},
         })}
@@ -248,6 +261,7 @@ describe("renderConversationMenuItems", () => {
       <>
         {renderConversationMenuItems({
           Primitive: Menu as unknown as ConversationMenuPrimitive,
+          t,
           variant: "header",
           onCopyConversation: () => {},
           onForkConversation: () => {},
@@ -281,6 +295,7 @@ describe("renderConversationMenuItems", () => {
       const html = renderToStaticMarkup(
         <>{renderConversationMenuItems({
           Primitive: Menu as unknown as ConversationMenuPrimitive,
+          t,
           variant,
           onCopyConversationId: () => {},
         })}</>,
@@ -293,6 +308,7 @@ describe("renderConversationMenuItems", () => {
     const html = renderToStaticMarkup(
       <>{renderConversationMenuItems({
         Primitive: Menu as unknown as ConversationMenuPrimitive,
+          t,
         onRename: () => {},
       })}</>,
     );
@@ -310,6 +326,7 @@ describe("renderConversationMenuItems — Move to group submenu", () => {
       <>
         {renderConversationMenuItems({
           Primitive: Menu as unknown as ConversationMenuPrimitive,
+          t,
           onPinToggle: () => {},
         })}
       </>,
@@ -322,6 +339,7 @@ describe("renderConversationMenuItems — Move to group submenu", () => {
       <>
         {renderConversationMenuItems({
           Primitive: Menu as unknown as ConversationMenuPrimitive,
+          t,
           moveToGroups: [],
           onMoveToGroup: () => {},
           onCreateGroupInto: () => {},
@@ -337,6 +355,7 @@ describe("renderConversationMenuItems — Move to group submenu", () => {
       <>
         {renderConversationMenuItems({
           Primitive: Menu as unknown as ConversationMenuPrimitive,
+          t,
           moveToGroups: [
             { id: "g_research", name: "Research" },
             { id: "g_ideas", name: "Ideas" },
@@ -356,6 +375,7 @@ describe("renderConversationMenuItems — Move to group submenu", () => {
       <>
         {renderConversationMenuItems({
           Primitive: Menu as unknown as ConversationMenuPrimitive,
+          t,
           moveToGroups: [{ id: "g_research", name: "Research" }],
           onMoveToGroup: () => {},
           onCreateGroupInto: () => {},
@@ -369,6 +389,7 @@ describe("renderConversationMenuItems — Move to group submenu", () => {
       <>
         {renderConversationMenuItems({
           Primitive: Menu as unknown as ConversationMenuPrimitive,
+          t,
           moveToGroups: [{ id: "g_research", name: "Research" }],
           onMoveToGroup: () => {},
           onCreateGroupInto: () => {},
@@ -382,6 +403,7 @@ describe("renderConversationMenuItems — Move to group submenu", () => {
     const html = renderToStaticMarkup(
       <>
         {renderConversationMenuItemsAsPanelItems({
+          t,
           moveToGroups: [{ id: "g_research", name: "Research" }],
           onMoveToGroup: () => {},
           onCreateGroupInto: () => {},
@@ -445,6 +467,7 @@ describe("renderConversationMenuItems — mark read/unread exclusivity", () => {
       <>
         {renderConversationMenuItems({
           Primitive: Menu as unknown as ConversationMenuPrimitive,
+          t,
           onMarkRead: () => {},
           onMarkUnread: () => {},
         })}
@@ -638,6 +661,7 @@ describe("renderConversationMenuItemsAsPanelItems", () => {
     const html = renderToStaticMarkup(
       <>
         {renderConversationMenuItemsAsPanelItems({
+          t,
           onPinToggle: () => {},
           onRename: () => {},
           onArchive: () => {},
@@ -654,6 +678,7 @@ describe("renderConversationMenuItemsAsPanelItems", () => {
     const html = renderToStaticMarkup(
       <>
         {renderConversationMenuItemsAsPanelItems({
+          t,
           variant: "header",
           channelSourceLink: {
             href: "https://slack.com/archives/C01ABC/p1700000000000100",

--- a/clients/web/src/domains/chat/components/conversation-actions-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/conversation-actions-menu.test.tsx
@@ -85,16 +85,28 @@ mock.module("@vellumai/design-library", () => {
     Header: passthrough,
     Title: passthrough,
     Body: passthrough,
+    Grabber: () => createElement("div", { "data-testid": "sheet-grabber" }),
+    Close: ({ children, ...rest }: Record<string, unknown>) =>
+      createElement(
+        "button",
+        { "data-testid": "sheet-close", ...rest },
+        children as ReactNode,
+      ),
   };
 
+  // `leadingSlot` is rendered rather than spread: the sheet passes its icon
+  // chip through it, and spreading a ReactNode onto a DOM node would both warn
+  // and hide whether the chip was built at all.
   const PanelItemMock = ({
     label,
     icon: _icon,
+    leadingSlot,
     ...rest
   }: Record<string, unknown>) =>
     createElement(
       "div",
       { "data-testid": "panel-item", ...rest },
+      leadingSlot as ReactNode,
       label as string,
     );
 
@@ -239,15 +251,29 @@ describe("renderConversationMenuItems", () => {
           variant: "header",
           onCopyConversation: () => {},
           onForkConversation: () => {},
+          onInspect: () => {},
+          onRefresh: () => {},
           onPinToggle: () => {},
           onRename: () => {},
+          onArchive: () => {},
         })}
       </>,
     );
-    expect(html).toContain("Copy full conversation");
-    expect(html).toContain("Fork conversation");
-    expect(html).toContain("Pin");
-    expect(html).toContain("Rename");
+    // Order, not just presence: the mobile sheet renders the same sequence
+    // from a parallel builder, so a reshuffle here that the sheet does not
+    // follow is exactly the drift both surfaces exist to avoid.
+    const order = [
+      "Copy Full Conversation",
+      "Fork Conversation",
+      "Analyze Conversation",
+      "Refresh",
+      "Pin",
+      "Rename",
+      "Archive",
+    ];
+    const positions = order.map((label) => html.indexOf(label));
+    expect(positions).not.toContain(-1);
+    expect(positions).toEqual([...positions].sort((a, b) => a - b));
   });
 
   test("renders Copy conversation ID in both variants when wired", () => {
@@ -442,6 +468,11 @@ describe("ConversationActionsMenu — mobile panel details", () => {
     expect(html).toContain('disabled=""');
     expect(html).toContain("cursor-not-allowed");
     expect(html).toContain("text-[var(--content-disabled)]");
+    // The chip dims with the label. The sheet's own brighter label colour is
+    // conditional for this reason, so this guards against it being made
+    // unconditional again and merging over the dim treatment above.
+    expect(html).toContain("[--panel-item-icon-fg:var(--content-disabled)]");
+    expect(html).not.toContain("text-[var(--content-default)]");
   });
 
   test("hides Open in New Window on native iOS bottom sheet", () => {
@@ -473,7 +504,7 @@ describe("ConversationActionsMenu — mobile panel details", () => {
         onRename={() => {}}
       />,
     );
-    expect(html).toContain("Open in new window");
+    expect(html).toContain("Open in New Window");
   });
 
   test("variant header renders header-order items on mobile", () => {
@@ -483,14 +514,27 @@ describe("ConversationActionsMenu — mobile panel details", () => {
         variant="header"
         onCopyConversation={() => {}}
         onForkConversation={() => {}}
+        onInspect={() => {}}
+        onRefresh={() => {}}
         onPinToggle={() => {}}
         onRename={() => {}}
+        onArchive={() => {}}
       />,
     );
-    expect(html).toContain("Copy full conversation");
-    expect(html).toContain("Fork conversation");
-    expect(html).toContain("Pin");
-    expect(html).toContain("Rename");
+    // The sheet's sequence has to track the dropdown's; see the matching
+    // order assertion over `renderConversationMenuItems` above.
+    const order = [
+      "Copy Full Conversation",
+      "Fork Conversation",
+      "Analyze Conversation",
+      "Refresh",
+      "Pin",
+      "Rename",
+      "Archive",
+    ];
+    const positions = order.map((label) => html.indexOf(label));
+    expect(positions).not.toContain(-1);
+    expect(positions).toEqual([...positions].sort((a, b) => a - b));
   });
 });
 
@@ -508,9 +552,38 @@ describe("ConversationActionsSheet", () => {
         onRename={() => {}}
       />,
     );
-    expect(html).toContain("Conversation actions");
+    expect(html).toContain("Conversation Actions");
     expect(html).toContain("Pin");
     expect(html).toContain("Rename");
+  });
+
+  test("renders the sheet's grabber and an explicit close control", () => {
+    const html = renderToStaticMarkup(
+      <ConversationActionsSheet
+        open
+        onOpenChange={() => {}}
+        onRename={() => {}}
+      />,
+    );
+    expect(html).toContain('data-testid="sheet-grabber"');
+    expect(html).toContain('aria-label="Close conversation actions"');
+  });
+
+  test("gives every action row a leading chip", () => {
+    const html = renderToStaticMarkup(
+      <ConversationActionsSheet
+        open
+        onOpenChange={() => {}}
+        onPinToggle={() => {}}
+        onRename={() => {}}
+        onArchive={() => {}}
+      />,
+    );
+    // One chip per action row. Counting them, rather than asserting the class
+    // appears at all, is what catches a row added through the plain
+    // `buildPanelMenuItem` and left bare beside its chipped neighbours.
+    const chips = html.match(/rounded-full bg-\[var\(--border-hover\)\]/g);
+    expect(chips).toHaveLength(3);
   });
 
   test("renders a trigger when one is provided (ellipsis path)", () => {
@@ -534,8 +607,10 @@ describe("ConversationActionsSheet", () => {
         onArchive={() => {}}
       />,
     );
-    // No trigger button, but the sheet body still renders the item set.
-    expect(html).not.toContain("<button");
+    // No trigger, but the sheet body still renders the item set. Asserted
+    // against the trigger's own marker rather than `<button`, which the
+    // header's close control now legitimately contributes.
+    expect(html).not.toContain('data-testid="trigger"');
     expect(html).toContain("Archive");
   });
 
@@ -550,7 +625,7 @@ describe("ConversationActionsSheet", () => {
         onPinToggle={() => {}}
       />,
     );
-    expect(html).not.toContain("Open in new window");
+    expect(html).not.toContain("Open in New Window");
     expect(html).toContain("Pin");
   });
 });

--- a/clients/web/src/domains/chat/components/conversation-actions-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/conversation-actions-menu.test.tsx
@@ -566,7 +566,10 @@ describe("ConversationActionsSheet", () => {
       />,
     );
     expect(html).toContain('data-testid="sheet-grabber"');
-    expect(html).toContain('aria-label="Close conversation actions"');
+    // Both strings come from the `chat` catalog, so this also pins them to
+    // `t()` rather than the literals they replaced.
+    expect(html).toContain('data-testid="sheet-close"');
+    expect(html).toContain('aria-label="Close"');
   });
 
   test("gives every action row a leading chip", () => {

--- a/clients/web/src/domains/chat/components/conversation-actions-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/conversation-actions-menu.test.tsx
@@ -15,12 +15,12 @@
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
-import i18next from "i18next";
+import { fixedT } from "@/i18n";
 
 // The builders take a namespace-bound `t`, the same thing
-// `useTranslation("chat")` hands their component callers. The bare export
-// resolves against `common` and would return the key instead of the copy.
-const t = i18next.getFixedT(null, "chat");
+// `useTranslation("chat")` hands their component callers. The unbound `t`
+// resolves against `common` and returns the key instead of the copy.
+const t = fixedT("chat");
 import { createElement, type ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
@@ -589,8 +589,7 @@ describe("ConversationActionsSheet", () => {
       />,
     );
     expect(html).toContain('data-testid="sheet-grabber"');
-    // Both strings come from the `chat` catalog, so this also pins them to
-    // `t()` rather than the literals they replaced.
+    // Both strings come from the `chat` catalog.
     expect(html).toContain('data-testid="sheet-close"');
     expect(html).toContain('aria-label="Close"');
   });
@@ -633,9 +632,8 @@ describe("ConversationActionsSheet", () => {
         onArchive={() => {}}
       />,
     );
-    // No trigger, but the sheet body still renders the item set. Asserted
-    // against the trigger's own marker rather than `<button`, which the
-    // header's close control now legitimately contributes.
+    // The header always carries a close button, so absence of a trigger is
+    // asserted against the trigger's own marker rather than `<button`.
     expect(html).not.toContain('data-testid="trigger"');
     expect(html).toContain("Archive");
   });

--- a/clients/web/src/domains/chat/components/conversation-actions-menu.tsx
+++ b/clients/web/src/domains/chat/components/conversation-actions-menu.tsx
@@ -8,24 +8,28 @@ import {
   FolderInput,
   GitBranch,
   MessageCircle,
-  Microscope,
   MoreHorizontal,
   Pencil,
   Pin,
   PinOff,
   RefreshCw,
+  Sparkles,
+  X,
 } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { useState, type ReactNode } from "react";
 
 import {
   buildPanelMenuItem,
   PanelMenuDivider,
+  type PanelMenuItemOptions,
 } from "@/domains/chat/components/panel-menu-item";
 import type { MoveToGroupTarget } from "@/domains/chat/utils/group-conversations";
 import { useTouchMobile } from "@/hooks/use-touch-mobile";
 import { openExternalUrl } from "@/runtime/browser";
 import { useIsNativePlatform } from "@/runtime/native-auth";
 import { BottomSheet, ContextMenu, Menu } from "@vellumai/design-library";
+import { cn } from "@vellumai/design-library/utils/cn";
 
 /**
  * Hover-revealed "more" menu for a conversation row. Renders an ellipsis
@@ -286,7 +290,7 @@ export function renderConversationMenuItems({
       leftIcon={<ExternalLink size={14} />}
       onSelect={onOpenInNewWindow}
     >
-      {variant === "header" ? "Open in new window" : "Open in New Window"}
+      Open in New Window
     </Primitive.Item>
   ) : null;
 
@@ -300,8 +304,8 @@ export function renderConversationMenuItems({
   ) : null;
 
   const inspectItem = onInspect ? (
-    <Primitive.Item leftIcon={<Microscope size={14} />} onSelect={onInspect}>
-      Inspect
+    <Primitive.Item leftIcon={<Sparkles size={14} />} onSelect={onInspect}>
+      Analyze Conversation
     </Primitive.Item>
   ) : null;
 
@@ -322,7 +326,7 @@ export function renderConversationMenuItems({
             leftIcon={<Copy size={14} />}
             onSelect={onCopyConversation}
           >
-            Copy full conversation
+            Copy Full Conversation
           </Primitive.Item>
         ) : null}
 
@@ -331,10 +335,11 @@ export function renderConversationMenuItems({
             leftIcon={<GitBranch size={14} />}
             onSelect={onForkConversation}
           >
-            Fork conversation
+            Fork Conversation
           </Primitive.Item>
         ) : null}
 
+        {inspectItem}
         {channelSourceLinkItem}
         {openInNewWindowItem}
 
@@ -352,7 +357,6 @@ export function renderConversationMenuItems({
         {moveToGroupItem}
         {archiveItem}
         {copyConversationIdItem}
-        {inspectItem}
       </>
     );
   }
@@ -389,6 +393,71 @@ export function renderConversationMenuItems({
       ) : null}
     </>
   );
+}
+
+/**
+ * The sheet's leading affordance: a 40px circle carrying the action's glyph,
+ * which is what separates a touch action list from the dense 14px rows the
+ * dropdown uses.
+ *
+ * The glyph reads `--panel-item-icon-fg`, the property `PanelItem` colours a
+ * bare icon with, so a chip picks up any tint the surrounding surface sets
+ * instead of pinning a colour the rest of the row would not follow.
+ */
+function actionChip(Icon: LucideIcon): ReactNode {
+  return (
+    <span
+      aria-hidden
+      className="flex size-10 shrink-0 items-center justify-center rounded-full bg-[var(--border-hover)]"
+    >
+      <Icon
+        size={16}
+        className="text-[color:var(--panel-item-icon-fg,var(--content-secondary))]"
+      />
+    </span>
+  );
+}
+
+/**
+ * Row geometry for the sheet. The chip is the row's height, so the row's own
+ * vertical padding becomes the gap between rows: 8px here reproduces the
+ * mock's 16px rhythm while leaving a 56px target to tap, which the 40px chip
+ * alone would not. Horizontal padding goes to zero because the sheet body
+ * already insets the column.
+ */
+const SHEET_ROW_CLASSES = "px-0 py-2 max-md:py-2";
+
+/** Indent for the rows under "Move to group", aligning them past the chip column. */
+const SHEET_SUBROW_CLASSES = "pl-[52px]";
+
+/**
+ * A sheet row: {@link buildPanelMenuItem} with the chip and row geometry
+ * applied. Every row in this surface goes through it, so no call site can
+ * forget the chip and render a bare glyph next to eight chipped neighbours.
+ */
+function buildSheetMenuItem({
+  icon,
+  className,
+  disabled,
+  ...options
+}: PanelMenuItemOptions): ReactNode {
+  return buildPanelMenuItem({
+    ...options,
+    disabled,
+    leadingSlot: icon ? actionChip(icon) : undefined,
+    className: cn(
+      SHEET_ROW_CLASSES,
+      // Both of these are conditional because `buildPanelMenuItem` expresses
+      // "disabled" as a text colour: an unconditional brighter label here
+      // would merge straight over the dim treatment and leave a disabled row
+      // looking live. The chip follows the label through the property it
+      // already reads for its glyph.
+      disabled
+        ? "[--panel-item-icon-fg:var(--content-disabled)]"
+        : "text-[var(--content-default)]",
+      className,
+    ),
+  });
 }
 
 /**
@@ -430,7 +499,7 @@ export function renderConversationMenuItemsAsPanelItems({
   // flattened into an inline labeled block (mirrors the desktop submenu).
   const showMoveToGroup = Boolean(onMoveToGroup && onCreateGroupInto);
   const pinItem = onPinToggle
-    ? buildPanelMenuItem({
+    ? buildSheetMenuItem({
         key: "pin",
         icon: isPinned ? PinOff : Pin,
         label: isPinned ? "Unpin" : "Pin",
@@ -440,7 +509,7 @@ export function renderConversationMenuItemsAsPanelItems({
     : null;
 
   const renameItem = onRename
-    ? buildPanelMenuItem({
+    ? buildSheetMenuItem({
         key: "rename",
         icon: Pencil,
         label: "Rename",
@@ -451,7 +520,7 @@ export function renderConversationMenuItemsAsPanelItems({
 
   const archiveItem =
     isArchived && onUnarchive
-      ? buildPanelMenuItem({
+      ? buildSheetMenuItem({
           key: "unarchive",
           icon: ArchiveRestore,
           label: "Unarchive",
@@ -459,7 +528,7 @@ export function renderConversationMenuItemsAsPanelItems({
           onClose,
         })
       : onArchive
-        ? buildPanelMenuItem({
+        ? buildSheetMenuItem({
             key: "archive",
             icon: Archive,
             label: "Archive",
@@ -470,7 +539,7 @@ export function renderConversationMenuItemsAsPanelItems({
 
   const markReadUnreadItem =
     !isReadonly && onMarkRead
-      ? buildPanelMenuItem({
+      ? buildSheetMenuItem({
           key: "mark-read",
           icon: CircleCheck,
           label: "Mark as read",
@@ -478,7 +547,7 @@ export function renderConversationMenuItemsAsPanelItems({
           onClose,
         })
       : !isReadonly && onMarkUnread
-        ? buildPanelMenuItem({
+        ? buildSheetMenuItem({
             key: "mark-unread",
             icon: Circle,
             label: "Mark as unread",
@@ -496,26 +565,26 @@ export function renderConversationMenuItemsAsPanelItems({
         Move to group
       </div>
       {(moveToGroups ?? []).map((group) =>
-        buildPanelMenuItem({
+        buildSheetMenuItem({
           key: `move-to-${group.id}`,
           label: group.name,
-          className: "pl-7",
+          className: SHEET_SUBROW_CLASSES,
           run: () => onMoveToGroup?.(group.id),
           onClose,
         }),
       )}
-      {buildPanelMenuItem({
+      {buildSheetMenuItem({
         key: "move-to-new-group",
         label: "New group…",
-        className: "pl-7",
+        className: SHEET_SUBROW_CLASSES,
         run: () => onCreateGroupInto?.(),
         onClose,
       })}
       {onRemoveFromGroup
-        ? buildPanelMenuItem({
+        ? buildSheetMenuItem({
             key: "remove-from-group",
             label: "Remove from group",
-            className: "pl-7",
+            className: SHEET_SUBROW_CLASSES,
             run: onRemoveFromGroup,
             onClose,
           })
@@ -525,18 +594,17 @@ export function renderConversationMenuItemsAsPanelItems({
 
   const openInNewWindowItem =
     onOpenInNewWindow && !isNativePlatform
-      ? buildPanelMenuItem({
+      ? buildSheetMenuItem({
           key: "open-in-new-window",
           icon: ExternalLink,
-          label:
-            variant === "header" ? "Open in new window" : "Open in New Window",
+          label: "Open in New Window",
           run: onOpenInNewWindow,
           onClose,
         })
       : null;
 
   const channelSourceLinkItem = channelSourceLink
-    ? buildPanelMenuItem({
+    ? buildSheetMenuItem({
         key: "channel-source-link",
         icon: ExternalLink,
         label: channelSourceLink.label,
@@ -546,17 +614,17 @@ export function renderConversationMenuItemsAsPanelItems({
     : null;
 
   const inspectItem = onInspect
-    ? buildPanelMenuItem({
+    ? buildSheetMenuItem({
         key: "inspect",
-        icon: Microscope,
-        label: "Inspect",
+        icon: Sparkles,
+        label: "Analyze Conversation",
         run: onInspect,
         onClose,
       })
     : null;
 
   const copyConversationIdItem = onCopyConversationId
-    ? buildPanelMenuItem({
+    ? buildSheetMenuItem({
         key: "copy-conversation-id",
         icon: Copy,
         label: "Copy conversation ID",
@@ -569,30 +637,31 @@ export function renderConversationMenuItemsAsPanelItems({
     return (
       <>
         {onCopyConversation
-          ? buildPanelMenuItem({
+          ? buildSheetMenuItem({
               key: "copy",
               icon: Copy,
-              label: "Copy full conversation",
+              label: "Copy Full Conversation",
               run: onCopyConversation,
               onClose,
             })
           : null}
 
         {onForkConversation
-          ? buildPanelMenuItem({
+          ? buildSheetMenuItem({
               key: "fork",
               icon: GitBranch,
-              label: "Fork conversation",
+              label: "Fork Conversation",
               run: onForkConversation,
               onClose,
             })
           : null}
 
+        {inspectItem}
         {channelSourceLinkItem}
         {openInNewWindowItem}
 
         {onRefresh
-          ? buildPanelMenuItem({
+          ? buildSheetMenuItem({
               key: "refresh",
               icon: RefreshCw,
               label: "Refresh",
@@ -606,7 +675,6 @@ export function renderConversationMenuItemsAsPanelItems({
         {archiveItem}
         {moveToGroupBlock}
         {copyConversationIdItem}
-        {inspectItem}
       </>
     );
   }
@@ -624,7 +692,7 @@ export function renderConversationMenuItemsAsPanelItems({
       {onShareFeedback ? (
         <>
           <PanelMenuDivider />
-          {buildPanelMenuItem({
+          {buildSheetMenuItem({
             key: "share-feedback",
             icon: MessageCircle,
             label: "Share Feedback",
@@ -679,18 +747,32 @@ export function ConversationActionsSheet({
           reliably favor a plain (unmarked) override here. Once content
           would come within 120px of the top of the screen, the sheet stops
           growing and its body scrolls instead. */}
+      {/* `padded={false}`: the bands below carry different insets, the header
+          sitting tighter to the grabber than the rows sit to each other, which
+          the shared uniform padding cannot express. An unpadded sheet owns its
+          safe-area allowance, hence the bottom padding here. */}
       <BottomSheet.Content
         aria-describedby={undefined}
-        className="max-h-[calc(100dvh-120px)]!"
+        padded={false}
+        className="max-h-[calc(100dvh-120px)]! pt-2 pb-[calc(24px+var(--safe-area-inset-bottom,env(safe-area-inset-bottom,0px)))]"
       >
-        <BottomSheet.Header className="sr-only">
-          <BottomSheet.Title>Conversation actions</BottomSheet.Title>
+        <BottomSheet.Grabber />
+        <BottomSheet.Header className="flex-row items-center justify-between px-4 pt-3 pb-2">
+          <BottomSheet.Title className="text-body-large-default text-[var(--content-tertiary)]">
+            Conversation Actions
+          </BottomSheet.Title>
+          <BottomSheet.Close
+            aria-label="Close conversation actions"
+            className="flex size-4 shrink-0 items-center justify-center text-[var(--content-tertiary)] outline-none keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)]"
+          >
+            <X size={16} aria-hidden />
+          </BottomSheet.Close>
         </BottomSheet.Header>
         {/* Scrollbar hidden, not just at rest: this sheet has no fixed
             track-width budget to spare, so a hover-revealed thumb would
             shift the row content instead. Scroll itself (wheel/trackpad/
             touch) is unaffected. */}
-        <BottomSheet.Body className="pt-0 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        <BottomSheet.Body className="px-4 pt-3 [--panel-item-gap:12px] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           {renderConversationMenuItemsAsPanelItems({
             ...itemProps,
             onClose: () => onOpenChange(false),

--- a/clients/web/src/domains/chat/components/conversation-actions-menu.tsx
+++ b/clients/web/src/domains/chat/components/conversation-actions-menu.tsx
@@ -16,6 +16,7 @@ import {
   Sparkles,
   X,
 } from "lucide-react";
+import type { TFunction } from "i18next";
 import type { LucideIcon } from "lucide-react";
 import { useState, type ReactNode } from "react";
 
@@ -178,6 +179,7 @@ export interface ConversationMenuItemsProps {
  */
 export function renderConversationMenuItems({
   Primitive,
+  t,
   isPinned = false,
   isArchived = false,
   onPinToggle,
@@ -203,6 +205,9 @@ export function renderConversationMenuItems({
   variant = "sidebar",
 }: ConversationMenuItemsProps & {
   Primitive: ConversationMenuPrimitive;
+  /** Threaded in: these builders are plain functions, so they cannot hold
+   *  the hook themselves and their callers own the reactive binding. */
+  t: TFunction<"chat">;
 }): ReactNode {
   // The submenu shows whenever move + create are wired, even with zero
   // existing groups — "New group…" is always a valid action and is the only
@@ -214,13 +219,13 @@ export function renderConversationMenuItems({
       leftIcon={isPinned ? <PinOff size={14} /> : <Pin size={14} />}
       onSelect={onPinToggle}
     >
-      {isPinned ? "Unpin" : "Pin"}
+      {isPinned ? t("conversationActions.unpin") : t("conversationActions.pin")}
     </Primitive.Item>
   ) : null;
 
   const renameItem = onRename ? (
     <Primitive.Item leftIcon={<Pencil size={14} />} onSelect={onRename}>
-      Rename
+      {t("conversationActions.rename")}
     </Primitive.Item>
   ) : null;
 
@@ -230,11 +235,11 @@ export function renderConversationMenuItems({
         leftIcon={<ArchiveRestore size={14} />}
         onSelect={onUnarchive}
       >
-        Unarchive
+        {t("conversationActions.unarchive")}
       </Primitive.Item>
     ) : onArchive ? (
       <Primitive.Item leftIcon={<Archive size={14} />} onSelect={onArchive}>
-        Archive
+        {t("conversationActions.archive")}
       </Primitive.Item>
     ) : null;
 
@@ -244,7 +249,7 @@ export function renderConversationMenuItems({
         leftIcon={<CircleCheck size={14} />}
         onSelect={onMarkRead}
       >
-        Mark as read
+        {t("conversationActions.markRead")}
       </Primitive.Item>
     ) : !isReadonly && onMarkUnread ? (
       <Primitive.Item
@@ -252,14 +257,14 @@ export function renderConversationMenuItems({
         onSelect={onMarkUnread}
         disabled={isMarkUnreadDisabled}
       >
-        Mark as unread
+        {t("conversationActions.markUnread")}
       </Primitive.Item>
     ) : null;
 
   const moveToGroupItem = showMoveToGroup ? (
     <Primitive.Sub>
       <Primitive.SubTrigger leftIcon={<FolderInput size={14} />}>
-        Move to group
+        {t("conversationActions.moveToGroup")}
       </Primitive.SubTrigger>
       <Primitive.SubContent>
         {(moveToGroups ?? []).map((group) => (
@@ -273,12 +278,14 @@ export function renderConversationMenuItems({
         {moveToGroups && moveToGroups.length > 0 ? (
           <Primitive.Separator />
         ) : null}
-        <Primitive.Item onSelect={onCreateGroupInto}>New group…</Primitive.Item>
+        <Primitive.Item onSelect={onCreateGroupInto}>
+          {t("conversationActions.newGroup")}
+        </Primitive.Item>
         {onRemoveFromGroup ? (
           <>
             <Primitive.Separator />
             <Primitive.Item onSelect={onRemoveFromGroup}>
-              Remove from group
+              {t("conversationActions.removeFromGroup")}
             </Primitive.Item>
           </>
         ) : null}
@@ -291,7 +298,7 @@ export function renderConversationMenuItems({
       leftIcon={<ExternalLink size={14} />}
       onSelect={onOpenInNewWindow}
     >
-      Open in New Window
+      {t("conversationActions.openInNewWindow")}
     </Primitive.Item>
   ) : null;
 
@@ -306,7 +313,7 @@ export function renderConversationMenuItems({
 
   const inspectItem = onInspect ? (
     <Primitive.Item leftIcon={<Sparkles size={14} />} onSelect={onInspect}>
-      Analyze Conversation
+      {t("conversationActions.inspect")}
     </Primitive.Item>
   ) : null;
 
@@ -315,7 +322,7 @@ export function renderConversationMenuItems({
       leftIcon={<Copy size={14} />}
       onSelect={onCopyConversationId}
     >
-      Copy conversation ID
+      {t("conversationActions.copyConversationId")}
     </Primitive.Item>
   ) : null;
 
@@ -327,7 +334,7 @@ export function renderConversationMenuItems({
             leftIcon={<Copy size={14} />}
             onSelect={onCopyConversation}
           >
-            Copy Full Conversation
+            {t("conversationActions.copyConversation")}
           </Primitive.Item>
         ) : null}
 
@@ -336,7 +343,7 @@ export function renderConversationMenuItems({
             leftIcon={<GitBranch size={14} />}
             onSelect={onForkConversation}
           >
-            Fork Conversation
+            {t("conversationActions.forkConversation")}
           </Primitive.Item>
         ) : null}
 
@@ -349,7 +356,7 @@ export function renderConversationMenuItems({
             leftIcon={<RefreshCw size={14} />}
             onSelect={onRefresh}
           >
-            Refresh
+            {t("conversationActions.refresh")}
           </Primitive.Item>
         ) : null}
 
@@ -380,7 +387,7 @@ export function renderConversationMenuItems({
             leftIcon={<MessageCircle size={14} />}
             onSelect={onShareFeedback}
           >
-            Share Feedback
+            {t("conversationActions.shareFeedback")}
           </Primitive.Item>
         </>
       ) : null}
@@ -467,6 +474,7 @@ function buildSheetMenuItem({
  * `PanelItem` rows.
  */
 export function renderConversationMenuItemsAsPanelItems({
+  t,
   isPinned = false,
   isArchived = false,
   onPinToggle,
@@ -495,6 +503,7 @@ export function renderConversationMenuItemsAsPanelItems({
 }: ConversationMenuItemsProps & {
   onClose: () => void;
   isNativePlatform?: boolean;
+  t: TFunction<"chat">;
 }): ReactNode {
   // BottomSheet is a single-level surface, so the "Move to group" submenu is
   // flattened into an inline labeled block (mirrors the desktop submenu).
@@ -503,7 +512,9 @@ export function renderConversationMenuItemsAsPanelItems({
     ? buildSheetMenuItem({
         key: "pin",
         icon: isPinned ? PinOff : Pin,
-        label: isPinned ? "Unpin" : "Pin",
+        label: isPinned
+          ? t("conversationActions.unpin")
+          : t("conversationActions.pin"),
         run: onPinToggle,
         onClose,
       })
@@ -513,7 +524,7 @@ export function renderConversationMenuItemsAsPanelItems({
     ? buildSheetMenuItem({
         key: "rename",
         icon: Pencil,
-        label: "Rename",
+        label: t("conversationActions.rename"),
         run: onRename,
         onClose,
       })
@@ -524,7 +535,7 @@ export function renderConversationMenuItemsAsPanelItems({
       ? buildSheetMenuItem({
           key: "unarchive",
           icon: ArchiveRestore,
-          label: "Unarchive",
+          label: t("conversationActions.unarchive"),
           run: onUnarchive,
           onClose,
         })
@@ -532,7 +543,7 @@ export function renderConversationMenuItemsAsPanelItems({
         ? buildSheetMenuItem({
             key: "archive",
             icon: Archive,
-            label: "Archive",
+            label: t("conversationActions.archive"),
             run: onArchive,
             onClose,
           })
@@ -543,7 +554,7 @@ export function renderConversationMenuItemsAsPanelItems({
       ? buildSheetMenuItem({
           key: "mark-read",
           icon: CircleCheck,
-          label: "Mark as read",
+          label: t("conversationActions.markRead"),
           run: onMarkRead,
           onClose,
         })
@@ -551,7 +562,7 @@ export function renderConversationMenuItemsAsPanelItems({
         ? buildSheetMenuItem({
             key: "mark-unread",
             icon: Circle,
-            label: "Mark as unread",
+            label: t("conversationActions.markUnread"),
             disabled: isMarkUnreadDisabled,
             run: onMarkUnread,
             onClose,
@@ -563,7 +574,7 @@ export function renderConversationMenuItemsAsPanelItems({
       <PanelMenuDivider />
       <div className="flex items-center gap-2 px-2 pt-2 pb-1 text-body-small-default uppercase tracking-wide text-[var(--content-tertiary)]">
         <FolderInput size={14} aria-hidden />
-        Move to group
+        {t("conversationActions.moveToGroup")}
       </div>
       {(moveToGroups ?? []).map((group) =>
         buildSheetMenuItem({
@@ -576,7 +587,7 @@ export function renderConversationMenuItemsAsPanelItems({
       )}
       {buildSheetMenuItem({
         key: "move-to-new-group",
-        label: "New group…",
+        label: t("conversationActions.newGroup"),
         className: SHEET_SUBROW_CLASSES,
         run: () => onCreateGroupInto?.(),
         onClose,
@@ -584,7 +595,7 @@ export function renderConversationMenuItemsAsPanelItems({
       {onRemoveFromGroup
         ? buildSheetMenuItem({
             key: "remove-from-group",
-            label: "Remove from group",
+            label: t("conversationActions.removeFromGroup"),
             className: SHEET_SUBROW_CLASSES,
             run: onRemoveFromGroup,
             onClose,
@@ -598,7 +609,7 @@ export function renderConversationMenuItemsAsPanelItems({
       ? buildSheetMenuItem({
           key: "open-in-new-window",
           icon: ExternalLink,
-          label: "Open in New Window",
+          label: t("conversationActions.openInNewWindow"),
           run: onOpenInNewWindow,
           onClose,
         })
@@ -618,7 +629,7 @@ export function renderConversationMenuItemsAsPanelItems({
     ? buildSheetMenuItem({
         key: "inspect",
         icon: Sparkles,
-        label: "Analyze Conversation",
+        label: t("conversationActions.inspect"),
         run: onInspect,
         onClose,
       })
@@ -628,7 +639,7 @@ export function renderConversationMenuItemsAsPanelItems({
     ? buildSheetMenuItem({
         key: "copy-conversation-id",
         icon: Copy,
-        label: "Copy conversation ID",
+        label: t("conversationActions.copyConversationId"),
         run: onCopyConversationId,
         onClose,
       })
@@ -641,7 +652,7 @@ export function renderConversationMenuItemsAsPanelItems({
           ? buildSheetMenuItem({
               key: "copy",
               icon: Copy,
-              label: "Copy Full Conversation",
+              label: t("conversationActions.copyConversation"),
               run: onCopyConversation,
               onClose,
             })
@@ -651,7 +662,7 @@ export function renderConversationMenuItemsAsPanelItems({
           ? buildSheetMenuItem({
               key: "fork",
               icon: GitBranch,
-              label: "Fork Conversation",
+              label: t("conversationActions.forkConversation"),
               run: onForkConversation,
               onClose,
             })
@@ -665,7 +676,7 @@ export function renderConversationMenuItemsAsPanelItems({
           ? buildSheetMenuItem({
               key: "refresh",
               icon: RefreshCw,
-              label: "Refresh",
+              label: t("conversationActions.refresh"),
               run: onRefresh,
               onClose,
             })
@@ -696,7 +707,7 @@ export function renderConversationMenuItemsAsPanelItems({
           {buildSheetMenuItem({
             key: "share-feedback",
             icon: MessageCircle,
-            label: "Share Feedback",
+            label: t("conversationActions.shareFeedback"),
             run: onShareFeedback,
             onClose,
           })}
@@ -736,11 +747,6 @@ export function ConversationActionsSheet({
   trigger?: ReactNode;
 }) {
   const isNativePlatform = useIsNativePlatform();
-  // The sheet's own chrome reads from the catalog. The action labels below
-  // still do not: they are built by `renderConversationMenuItemsAsPanelItems`,
-  // a plain function rather than a component, so translating them means
-  // threading a `t` through both builders and every call site. That is the
-  // file's conversion into `i18nEnforcedPaths`, not this sheet's header.
   const { t } = useTranslation("chat");
   return (
     <BottomSheet.Root open={open} onOpenChange={onOpenChange}>
@@ -768,9 +774,11 @@ export function ConversationActionsSheet({
           <BottomSheet.Title className="text-body-large-default text-[var(--content-tertiary)]">
             {t("conversationActionsSheet.title")}
           </BottomSheet.Title>
+          {/* `-m-2 p-2` grows the tap target to 32px without moving the
+              glyph or changing the header's height. */}
           <BottomSheet.Close
             aria-label={t("conversationActionsSheet.closeAriaLabel")}
-            className="flex size-4 shrink-0 items-center justify-center text-[var(--content-tertiary)] outline-none keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)]"
+            className="-m-2 flex shrink-0 items-center justify-center p-2 text-[var(--content-tertiary)] outline-none keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)]"
           >
             <X size={16} aria-hidden />
           </BottomSheet.Close>
@@ -782,6 +790,7 @@ export function ConversationActionsSheet({
         <BottomSheet.Body className="px-4 pt-3 [--panel-item-gap:12px] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           {renderConversationMenuItemsAsPanelItems({
             ...itemProps,
+            t,
             onClose: () => onOpenChange(false),
             isNativePlatform,
           })}
@@ -813,12 +822,13 @@ export function ConversationActionsMenu({
   ...itemProps
 }: ConversationActionsMenuProps) {
   const isTouchMobile = useTouchMobile();
+  const { t } = useTranslation("chat");
   const [open, setOpen] = useState(false);
 
   const defaultTrigger = (
     <button
       type="button"
-      aria-label="Conversation actions"
+      aria-label={t("conversationActions.triggerAriaLabel")}
       onClick={(event) => event.stopPropagation()}
       onContextMenu={(event) => {
         event.stopPropagation();
@@ -856,7 +866,7 @@ export function ConversationActionsMenu({
         sideOffset={sideOffset}
         onClick={(event) => event.stopPropagation()}
       >
-        {renderConversationMenuItems({ Primitive: Menu, ...itemProps })}
+        {renderConversationMenuItems({ Primitive: Menu, t, ...itemProps })}
       </Menu.Content>
     </Menu.Root>
   );

--- a/clients/web/src/domains/chat/components/conversation-actions-menu.tsx
+++ b/clients/web/src/domains/chat/components/conversation-actions-menu.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/domains/chat/components/panel-menu-item";
 import type { MoveToGroupTarget } from "@/domains/chat/utils/group-conversations";
 import { useTouchMobile } from "@/hooks/use-touch-mobile";
+import { useTranslation } from "@/i18n";
 import { openExternalUrl } from "@/runtime/browser";
 import { useIsNativePlatform } from "@/runtime/native-auth";
 import { BottomSheet, ContextMenu, Menu } from "@vellumai/design-library";
@@ -735,6 +736,12 @@ export function ConversationActionsSheet({
   trigger?: ReactNode;
 }) {
   const isNativePlatform = useIsNativePlatform();
+  // The sheet's own chrome reads from the catalog. The action labels below
+  // still do not: they are built by `renderConversationMenuItemsAsPanelItems`,
+  // a plain function rather than a component, so translating them means
+  // threading a `t` through both builders and every call site. That is the
+  // file's conversion into `i18nEnforcedPaths`, not this sheet's header.
+  const { t } = useTranslation("chat");
   return (
     <BottomSheet.Root open={open} onOpenChange={onOpenChange}>
       {trigger ? (
@@ -759,10 +766,10 @@ export function ConversationActionsSheet({
         <BottomSheet.Grabber />
         <BottomSheet.Header className="flex-row items-center justify-between px-4 pt-3 pb-2">
           <BottomSheet.Title className="text-body-large-default text-[var(--content-tertiary)]">
-            Conversation Actions
+            {t("conversationActionsSheet.title")}
           </BottomSheet.Title>
           <BottomSheet.Close
-            aria-label="Close conversation actions"
+            aria-label={t("conversationActionsSheet.closeAriaLabel")}
             className="flex size-4 shrink-0 items-center justify-center text-[var(--content-tertiary)] outline-none keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)]"
           >
             <X size={16} aria-hidden />

--- a/clients/web/src/domains/chat/components/conversation-actions-menu.tsx
+++ b/clients/web/src/domains/chat/components/conversation-actions-menu.tsx
@@ -16,7 +16,6 @@ import {
   Sparkles,
   X,
 } from "lucide-react";
-import type { TFunction } from "i18next";
 import type { LucideIcon } from "lucide-react";
 import { useState, type ReactNode } from "react";
 
@@ -27,7 +26,7 @@ import {
 } from "@/domains/chat/components/panel-menu-item";
 import type { MoveToGroupTarget } from "@/domains/chat/utils/group-conversations";
 import { useTouchMobile } from "@/hooks/use-touch-mobile";
-import { useTranslation } from "@/i18n";
+import { useTranslation, type TFunction } from "@/i18n";
 import { openExternalUrl } from "@/runtime/browser";
 import { useIsNativePlatform } from "@/runtime/native-auth";
 import { BottomSheet, ContextMenu, Menu } from "@vellumai/design-library";

--- a/clients/web/src/domains/chat/components/conversation-row.tsx
+++ b/clients/web/src/domains/chat/components/conversation-row.tsx
@@ -24,6 +24,7 @@ import {
   renderConversationMenuItems,
   type ConversationMenuItemsProps,
 } from "@/domains/chat/components/conversation-actions-menu";
+import { useTranslation } from "@/i18n";
 import { useLongPressSheet } from "@/hooks/use-long-press-sheet";
 import {
   hasThreadStatus,
@@ -187,6 +188,7 @@ export function ConversationRow({
 }: ConversationRowProps) {
   const ctx = useConversationListContext();
   const { conversationId } = conversation;
+  const { t } = useTranslation("chat");
 
   const isProcessing =
     conversationId === ctx.activeConversationId
@@ -290,7 +292,11 @@ export function ConversationRow({
     <ContextMenu.Root>
       <ContextMenu.Trigger>{panelItem}</ContextMenu.Trigger>
       <ContextMenu.Content onClick={(event) => event.stopPropagation()}>
-        {renderConversationMenuItems({ Primitive: ContextMenu, ...menuProps })}
+        {renderConversationMenuItems({
+          Primitive: ContextMenu,
+          t,
+          ...menuProps,
+        })}
       </ContextMenu.Content>
     </ContextMenu.Root>
   );

--- a/clients/web/src/domains/chat/components/panel-menu-item.tsx
+++ b/clients/web/src/domains/chat/components/panel-menu-item.tsx
@@ -25,6 +25,12 @@ export function PanelMenuDivider() {
 export interface PanelMenuItemOptions {
   key: string;
   icon?: LucideIcon;
+  /**
+   * Custom leading content, replacing `icon`'s slot. The conversation sheet
+   * passes its circular icon chip through here; surfaces that want the plain
+   * glyph keep using `icon`.
+   */
+  leadingSlot?: ReactNode;
   label: string;
   disabled?: boolean;
   className?: string;
@@ -41,6 +47,7 @@ export interface PanelMenuItemOptions {
 export function buildPanelMenuItem({
   key,
   icon,
+  leadingSlot,
   label,
   disabled,
   className,
@@ -51,6 +58,7 @@ export function buildPanelMenuItem({
     <PanelItem
       key={key}
       icon={icon}
+      leadingSlot={leadingSlot}
       label={label}
       // `disabled` keeps the row's `role="button"` and keyboard semantics and
       // blocks activation itself — dropping `onSelect` instead falls through

--- a/clients/web/src/i18n/index.ts
+++ b/clients/web/src/i18n/index.ts
@@ -29,6 +29,10 @@
  * module augmentation in `i18next.d.ts`, so a typo or a key deleted from the
  * catalog fails `tsc`, not QA.
  */
+import i18next, { type TFunction } from "i18next";
+
+import type { Namespace } from "@/i18n/namespaces";
+
 export { Trans, useTranslation } from "react-i18next";
 
 export {
@@ -64,3 +68,22 @@ export {
  * it will keep showing the previous language after a switch.
  */
 export { t } from "i18next";
+
+/**
+ * The type of a namespace-bound `t`, for a helper that is handed one rather
+ * than holding it. A plain function cannot call `useTranslation()`, so it
+ * takes a parameter of this type and its component caller owns the reactive
+ * binding.
+ */
+export type { TFunction } from "i18next";
+
+/**
+ * A `t` bound to one namespace, for call sites outside React that read a
+ * single namespace and would otherwise resolve against `common`.
+ *
+ * Carries the same caveat as {@link t}: it reads the active locale but is not
+ * reactive, so anything rendering its result belongs on `useTranslation()`.
+ */
+export function fixedT<N extends Namespace>(namespace: N): TFunction<N> {
+  return i18next.getFixedT(null, namespace);
+}

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -138,6 +138,26 @@
     "tokenRangeWithReduction": "{before} → {after}  ({reduction})",
     "trigger": "Trigger"
   },
+  "conversationActions": {
+    "archive": "Archive",
+    "copyConversation": "Copy Full Conversation",
+    "copyConversationId": "Copy conversation ID",
+    "forkConversation": "Fork Conversation",
+    "inspect": "Analyze Conversation",
+    "markRead": "Mark as read",
+    "markUnread": "Mark as unread",
+    "moveToGroup": "Move to group",
+    "newGroup": "New group…",
+    "openInNewWindow": "Open in New Window",
+    "pin": "Pin",
+    "refresh": "Refresh",
+    "removeFromGroup": "Remove from group",
+    "rename": "Rename",
+    "shareFeedback": "Share Feedback",
+    "triggerAriaLabel": "Conversation actions",
+    "unarchive": "Unarchive",
+    "unpin": "Unpin"
+  },
   "conversationActionsSheet": {
     "closeAriaLabel": "Close",
     "title": "Conversation Actions"

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -138,6 +138,10 @@
     "tokenRangeWithReduction": "{before} → {after}  ({reduction})",
     "trigger": "Trigger"
   },
+  "conversationActionsSheet": {
+    "closeAriaLabel": "Close",
+    "title": "Conversation Actions"
+  },
   "conversationAssets": {
     "ariaLabel": "Conversation assets, {count, plural, one {# item} other {# items}}",
     "ariaLabelUnseen": "Conversation assets, {count, plural, one {# item} other {# items}} (unseen changes)",

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -138,6 +138,10 @@
     "tokenRangeWithReduction": "{before} → {after}  ({reduction})",
     "trigger": "Disparador"
   },
+  "conversationActionsSheet": {
+    "closeAriaLabel": "Cerrar",
+    "title": "Acciones de conversación"
+  },
   "conversationAssets": {
     "ariaLabel": "Recursos de la conversación, {count, plural, one {# elemento} other {# elementos}}",
     "ariaLabelUnseen": "Recursos de la conversación, {count, plural, one {# elemento} other {# elementos}} (cambios sin ver)",

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -138,6 +138,26 @@
     "tokenRangeWithReduction": "{before} → {after}  ({reduction})",
     "trigger": "Disparador"
   },
+  "conversationActions": {
+    "archive": "Archivar",
+    "copyConversation": "Copiar conversación completa",
+    "copyConversationId": "Copiar ID de conversación",
+    "forkConversation": "Bifurcar conversación",
+    "inspect": "Analizar conversación",
+    "markRead": "Marcar como leída",
+    "markUnread": "Marcar como no leída",
+    "moveToGroup": "Mover al grupo",
+    "newGroup": "Nuevo grupo…",
+    "openInNewWindow": "Abrir en una ventana nueva",
+    "pin": "Fijar",
+    "refresh": "Actualizar",
+    "removeFromGroup": "Quitar del grupo",
+    "rename": "Cambiar nombre",
+    "shareFeedback": "Enviar comentarios",
+    "triggerAriaLabel": "Acciones de conversación",
+    "unarchive": "Desarchivar",
+    "unpin": "Dejar de fijar"
+  },
   "conversationActionsSheet": {
     "closeAriaLabel": "Cerrar",
     "title": "Acciones de conversación"

--- a/packages/design-library/src/components/bottom-sheet.stories.tsx
+++ b/packages/design-library/src/components/bottom-sheet.stories.tsx
@@ -120,7 +120,7 @@ export const WithGrabber: Story = {
     description: "",
     showIcon: false,
   },
-  render: ({ triggerLabel, title }) => (
+  render: ({ triggerLabel, title, description, showIcon }) => (
     <BottomSheet.Root>
       <BottomSheet.Trigger asChild>
         <Button>{triggerLabel}</Button>
@@ -131,8 +131,11 @@ export const WithGrabber: Story = {
         aria-describedby={undefined}
       >
         <BottomSheet.Grabber />
-        <BottomSheet.Header className="flex-row items-center justify-between px-4 pt-3 pb-2">
-          <BottomSheet.Title className="text-body-large-default text-[var(--content-tertiary)]">
+        <BottomSheet.Header className="flex-row items-center justify-between gap-2 px-4 pt-3 pb-2">
+          <BottomSheet.Title
+            icon={showIcon ? Share : undefined}
+            className="text-body-large-default text-[var(--content-tertiary)]"
+          >
             {title}
           </BottomSheet.Title>
           {/* `outline-none` matters here rather than being boilerplate: Radix
@@ -148,6 +151,11 @@ export const WithGrabber: Story = {
           </BottomSheet.Close>
         </BottomSheet.Header>
         <BottomSheet.Body className="px-4 pt-3">
+          {description ? (
+            <BottomSheet.Description className="mt-0 mb-3">
+              {description}
+            </BottomSheet.Description>
+          ) : null}
           <div className="flex flex-col gap-2">
             <Button variant="ghost" className="justify-start">
               Rename

--- a/packages/design-library/src/components/bottom-sheet.stories.tsx
+++ b/packages/design-library/src/components/bottom-sheet.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { Share } from "lucide-react";
+import { Share, X } from "lucide-react";
 
 import { Button } from "./button";
 import { BottomSheet } from "./bottom-sheet";
@@ -99,6 +99,61 @@ export const WithIcon: Story = {
             </Button>
             <Button variant="ghost" className="justify-start">
               Send via Email
+            </Button>
+          </div>
+        </BottomSheet.Body>
+      </BottomSheet.Content>
+    </BottomSheet.Root>
+  ),
+};
+
+/**
+ * An action sheet that announces itself: `Grabber` draws the pill at the top
+ * edge, and the header pairs a quiet title with an explicit close control
+ * rather than relying on the overlay alone. `padded={false}` lets each band
+ * carry its own spacing, so the sheet owns its safe-area allowance.
+ */
+export const WithGrabber: Story = {
+  args: {
+    triggerLabel: "Open action sheet",
+    title: "Conversation Actions",
+    description: "",
+    showIcon: false,
+  },
+  render: ({ triggerLabel, title }) => (
+    <BottomSheet.Root>
+      <BottomSheet.Trigger asChild>
+        <Button>{triggerLabel}</Button>
+      </BottomSheet.Trigger>
+      <BottomSheet.Content
+        padded={false}
+        className="pt-2 pb-[calc(24px+var(--safe-area-inset-bottom,env(safe-area-inset-bottom,0px)))]"
+        aria-describedby={undefined}
+      >
+        <BottomSheet.Grabber />
+        <BottomSheet.Header className="flex-row items-center justify-between px-4 pt-3 pb-2">
+          <BottomSheet.Title className="text-body-large-default text-[var(--content-tertiary)]">
+            {title}
+          </BottomSheet.Title>
+          {/* `outline-none` matters here rather than being boilerplate: Radix
+              moves focus to the first focusable child on open, which is this
+              button, and the user-agent outline would otherwise ring it every
+              time the sheet appears. `keyboard-focus` is modality-aware, so a
+              keyboard user still gets a ring and a tap does not. */}
+          <BottomSheet.Close
+            aria-label="Close"
+            className="flex size-4 shrink-0 items-center justify-center text-[var(--content-tertiary)] outline-none keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)]"
+          >
+            <X size={16} aria-hidden />
+          </BottomSheet.Close>
+        </BottomSheet.Header>
+        <BottomSheet.Body className="px-4 pt-3">
+          <div className="flex flex-col gap-2">
+            <Button variant="ghost" className="justify-start">
+              Rename
+            </Button>
+            <Button variant="ghost" className="justify-start">
+              Archive
             </Button>
           </div>
         </BottomSheet.Body>

--- a/packages/design-library/src/components/bottom-sheet.tsx
+++ b/packages/design-library/src/components/bottom-sheet.tsx
@@ -37,8 +37,8 @@ const BottomSheetContext = createContext<{
  *
  * Compound API: `BottomSheet.Root`, `BottomSheet.Trigger`,
  * `BottomSheet.Content`, `BottomSheet.Title`, `BottomSheet.Description`,
- * `BottomSheet.Close`, `BottomSheet.Header`, `BottomSheet.Body`,
- * `BottomSheet.Footer`.
+ * `BottomSheet.Close`, `BottomSheet.Grabber`, `BottomSheet.Header`,
+ * `BottomSheet.Body`, `BottomSheet.Footer`.
  *
  * Adoption is consumer-driven: consumers decide whether to mount
  * `BottomSheet.Root` or an anchored surface such as `Popover.Root`. That
@@ -189,6 +189,30 @@ function Close(props: ComponentProps<typeof Dialog.Close>) {
   return <Dialog.Close data-slot="bottom-sheet-close" {...props} />;
 }
 
+/**
+ * The pill at the top edge that reads as "this panel came up from the bottom".
+ * Opt-in, so sheets that already open under a header or carry their own
+ * chrome are unchanged.
+ *
+ * Decorative only: it is not a drag target, and dismissal stays with the
+ * overlay, Escape, and whatever close control the header carries. Hidden from
+ * assistive technology for that reason, rather than announced as a control
+ * that does nothing.
+ */
+function Grabber({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="bottom-sheet-grabber"
+      aria-hidden="true"
+      className={cn(
+        "mx-auto h-1 w-14 shrink-0 rounded-full bg-[var(--content-disabled)]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
 function Header({
   className,
   children,
@@ -247,6 +271,7 @@ const BottomSheet = {
   Title,
   Description,
   Close,
+  Grabber,
   Header,
   Body,
   Footer,

--- a/packages/design-library/src/components/bottom-sheet.tsx
+++ b/packages/design-library/src/components/bottom-sheet.tsx
@@ -205,7 +205,7 @@ function Grabber({ className, ...props }: ComponentProps<"div">) {
       data-slot="bottom-sheet-grabber"
       aria-hidden="true"
       className={cn(
-        "mx-auto h-1 w-14 shrink-0 rounded-full bg-[var(--content-disabled)]",
+        "mx-auto h-1 w-14 shrink-0 rounded-full bg-[var(--border-element)]",
         className,
       )}
       {...props}

--- a/packages/design-library/src/components/panel-item/panel-item.tsx
+++ b/packages/design-library/src/components/panel-item/panel-item.tsx
@@ -313,7 +313,15 @@ const ACTIVE_BRANDED_CLASSES = [
   "aria-[current=page]:font-medium",
 ].join(" ");
 
-const LEFT_CLUSTER_CLASSES = "flex min-w-0 flex-1 items-center gap-[8px]";
+/**
+ * `--panel-item-gap` opens the leading-icon-to-label gap to callers whose
+ * leading slot is larger than an icon (a chip, an avatar), where 8px reads as
+ * cramped. Same recipe as the `--panel-item-*` colour properties above:
+ * declare it on an ancestor, fall back to the default, and a row that never
+ * declares it is unchanged.
+ */
+const LEFT_CLUSTER_CLASSES =
+  "flex min-w-0 flex-1 items-center gap-[var(--panel-item-gap,8px)]";
 
 /**
  * `--panel-item-icon-fg` lets a caller recolor just the leading icon (e.g. the


### PR DESCRIPTION
Matches the mobile conversation-actions sheet to [Figma 7842-9343](https://www.figma.com/design/cCGBcpVDbn22kj3OPU58W8/New-App?node-id=7842-9343).

The sheet was reaching for the dropdown's dense 14px rows, so it read as a menu that happened to slide up rather than a touch surface. It now has chrome of its own.

## What changed

**Sheet shell** — a grabber at the top edge, a titled header (`Conversation Actions`) with an explicit close control, replacing the `sr-only` title.

**Rows** — each action's icon now sits in a 40px circular chip, with the label at `--content-default` and 12px between chip and label.

**Ordering and casing** — the mock's Title Case throughout, and Inspect becomes **Analyze Conversation** (Sparkles, promoted to third). It stays gated behind `canUseLlmInspector`, so most users see seven rows rather than eight.

Both entry points (the thread-name dropdown and the sidebar row long-press) share one `ConversationActionsSheet`, so they pick this up together. The ordering and label changes also land on the desktop dropdown, which is the point of that shared builder: promoting Inspect on mobile alone is exactly the drift the two surfaces exist to avoid.

## Design-library additions

Both additive and opt-in, so no existing sheet or row changes appearance:

- `BottomSheet.Grabber` — the pill at a sheet's top edge, decorative and `aria-hidden`.
- `--panel-item-gap` on `PanelItem` — follows the `--panel-item-*` recipe already in the component. A chip needs more room than the 8px an icon wants.

## A regression caught on the way

Styling the rows initially merged `text-[var(--content-default)]` over the *disabled* row's dim treatment, which `buildPanelMenuItem` expresses as a text colour. A disabled "Mark as unread" would have looked live. The brighter label is now conditional on `disabled`, the chip dims with it via `--panel-item-icon-fg`, and a test guards both.

## Verification

Measured in Storybook at 402x874, not eyeballed:

| | Mock | Rendered |
|---|---|---|
| Grabber | 56x4, `#5A6672` | 56x4, `rgb(90,102,114)`, centered |
| Title | 16/500, `#8D99A5`, 16px inset | 16/500, `rgb(141,153,165)`, x=16 |
| Close | 16x16, 16px from right | 16x16, right edge 16px |

Also confirmed the close control takes no focus ring under pointer modality (Radix autofocuses it on open, and the user-agent outline would otherwise ring it on every tap), while keyboard users still get one.

Typecheck, lint, and 5 test suites green.

## Open question for design

The chip binds `--border-hover`, which is exactly the style bound in Figma (`Border-Dark/Hover`) and correct in dark. In light that token is `#F6F5F4` on a `#FFFFFF` sheet, roughly 1.03:1, so the chip circle is effectively invisible and only the glyph reads. `--surface-active` fixes light but breaks dark (`#444D56` is far lighter than the mock's `#2D3339`). I kept dark fidelity rather than inventing a light value.

Not addressed here: `useTouchMobile` is `@deprecated` in favour of a design-library `ActionMenu` primitive (LUM-3177). Separate migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)