### PR TITLE
docs(web): correct three convention docs that disagree with the code

### DIFF
--- a/clients/web/docs/CONVENTIONS.md
+++ b/clients/web/docs/CONVENTIONS.md
@@ -851,9 +851,15 @@ Reference: [Vite — SSR guidance](https://vite.dev/guide/ssr.html)
 ### `packages/design-library/`
 
 Domain-agnostic UI primitives (Button, Card, Modal, Typography, etc.)
-live in `packages/design-library/` outside `clients/web/`. The package is
-consumed as a `file:` dependency and resolved via its `exports` field
-in `package.json` — no Vite alias or tsconfig `paths` needed.
+live in `packages/design-library/` outside `clients/web/`. The package is a
+`workspace:*` dependency resolved via its `exports` field in `package.json`,
+so Vite serves it as source and edits hot-update live. No Vite alias or
+tsconfig `paths` needed.
+
+**Do not convert it to a `file:` dependency.** A `file:` dep (especially
+paired with `preserveSymlinks` or a per-package React install) resolves a
+second copy of React and white-screens the app. See
+[`clients/web/AGENTS.md`](../AGENTS.md) for the full constraint.
 
 ```ts
 import { Button, Typography } from "@vellumai/design-library";
@@ -897,8 +903,8 @@ export function ChatMarkdownMessage(props: ChatMarkdownMessageProps) {
 ```
 
 For component authoring conventions (React 19 ref-as-prop, `data-slot`,
-variant patterns, file organization), see
-[`packages/design-library/README.md`](../../../packages/design-library/README.md).
+variant patterns, file organization, story rules), see
+[`packages/design-library/AGENTS.md`](../../../packages/design-library/AGENTS.md).
 
 References:
 - [Node.js — Package exports](https://nodejs.org/api/packages.html#exports)

--- a/clients/web/docs/CONVENTIONS.md
+++ b/clients/web/docs/CONVENTIONS.md
@@ -50,7 +50,7 @@ to hide irrelevant sections.
 
 ```
 routes.tsx
-  <App />            ← shared shell (nav, layout, providers)
+  <RootLayout />     ← shared shell (nav, layout, providers)
     <Outlet />
       <ChatPage />           ← lifecycle guards → mounts ActiveChatView
       <LibraryPage />        ← library listing
@@ -59,7 +59,7 @@ routes.tsx
 
 Push hooks down to the route component that needs them. Lift shared
 state to the nearest common ancestor — typically a layout route or a
-context provider mounted in `<App />`.
+context provider mounted in `<RootLayout />`.
 
 ### Layout header slots
 
@@ -278,8 +278,8 @@ src/
     conversation-cache-mutations.ts #  domain-level cache mutation helpers
     conversation-list-fetchers.ts  #   pure async fetch functions for conversation lists
     conversation-transforms.ts     #   daemon → client field mapping
-    format.ts
-    browser.ts
+    format-date.ts
+    semver.ts
   types/                           # cross-domain shared types (no owning module)
     window.d.ts
     event-types.ts
@@ -290,7 +290,7 @@ src/
     feature-flags/                 #   feature flag provider
     sync/                          #   server state sync (query-tag keys, sync types)
     streaming/                     #   SSE transport, event parsing, debug tracking
-    api-client.ts                  #   HeyAPI configured client + interceptors
+    api-interceptors.ts            #   HeyAPI client interceptors (auth, routing)
     telemetry/                     #   client identity for daemon registration
   runtime/                         # framework adapters, platform bridges
     native-auth.ts
@@ -478,9 +478,9 @@ owns it.
 | `assistant/` | Core business-domain code for the assistant itself — the central concept every feature composes around. Every domain may depend on it; it depends on no domain. New top-level business-concept folders require explicit team approval. | `api.ts`, `lifecycle.ts`, `types.ts`, `llm-model-catalog.ts` |
 | `stores/` | App-level Zustand stores (cross-domain state) | `viewer-store.ts`, `sse-connected-store.ts`, `assistant-feature-flag-store.ts` |
 | `hooks/` | Cross-domain React hooks | `use-is-mobile.ts`, `use-visible-viewport.ts`, `use-feature-flag-bus-sync.ts` |
-| `utils/` | Pure utility functions (no side effects, no third-party SDKs) | `format.ts`, `browser.ts`, `network-status.ts`, `stable-id.ts` |
+| `utils/` | Pure utility functions (no side effects, no third-party SDKs) | `format-date.ts`, `semver.ts`, `to-error.ts`, `create-selectors.ts` |
 | `types/` | Cross-domain shared type definitions with no clear owning module. Types consumed by a single module live with that module. Types produced by a module live in the module that produces them — consumers use `import type`. | `window.d.ts`, `event-types.ts`, `conversation-types.ts` |
-| `lib/` | Third-party SDK wrappers and app-internal infrastructure (registries, transports, interceptors). Side effects, module-level state, or lifecycle ownership. See [`lib/` vs `utils/`](#lib-vs-utils--where-does-my-code-go) below. | `sentry/` (error reporting), `auth/` (allauth + CSRF), `feature-flags/` (catalog + registry), `sync/` (state sync), `streaming/` (SSE transport), `event-bus.ts` (pub/sub registry), `diagnostics.ts` (session ring buffer), `api-client.ts` (HeyAPI) |
+| `lib/` | Third-party SDK wrappers and app-internal infrastructure (registries, transports, interceptors). Side effects, module-level state, or lifecycle ownership. See [`lib/` vs `utils/`](#lib-vs-utils--where-does-my-code-go) below. | `sentry/` (error reporting), `auth/` (allauth + CSRF), `feature-flags/` (catalog + registry), `sync/` (state sync), `streaming/` (SSE transport), `event-bus.ts` (pub/sub registry), `diagnostics.ts` (session ring buffer), `api-interceptors.ts` (HeyAPI) |
 | `runtime/` | Framework adapters and native platform bridges | `route-adapter.ts`, `native-auth.ts`, `native-deep-link.ts`, `app-bridge.ts` |
 | `components/` | Cross-domain shared UI | `error-boundary.tsx`, `sign-in-gate.tsx`, `providers.tsx` |
 
@@ -494,7 +494,7 @@ owns it.
 | **Side effects?** | Yes — module-level state, listener registration, SDK init, interceptors, or pub/sub registries | No — pure input→output, no global state, no I/O |
 | **Third-party SDK dependency?** | Optional — third-party wrappers (`@sentry/react`, `@heyapi/client-fetch`) AND first-party infrastructure (`event-bus.ts`, `chunk-errors.ts`, `local-mode.ts`) both belong here | No — only standard library / language utilities |
 | **Subdirectories?** | When a single integration warrants multiple files (`lib/sentry/`, `lib/auth/`, `lib/sync/`); single-file infrastructure stays at the `lib/` top level (`lib/diagnostics.ts`, `lib/event-bus.ts`) | Flat — individual utility files at the top level |
-| **Examples** | `lib/sentry/sentry-init.ts`, `lib/auth/allauth-client.ts`, `lib/api-client.ts`, `lib/event-bus.ts`, `lib/diagnostics.ts`, `lib/chunk-errors.ts` | `utils/format.ts`, `utils/browser.ts`, `utils/cn.ts` |
+| **Examples** | `lib/sentry/sentry-init.ts`, `lib/auth/allauth-client.ts`, `lib/api-interceptors.ts`, `lib/event-bus.ts`, `lib/diagnostics.ts`, `lib/chunk-errors.ts` | `utils/format-date.ts`, `utils/semver.ts`, `utils/to-error.ts` |
 
 If the code holds state at module scope, registers global listeners,
 configures an SDK, manages a session, or runs at startup, it belongs

--- a/clients/web/docs/STYLE_GUIDE.md
+++ b/clients/web/docs/STYLE_GUIDE.md
@@ -553,9 +553,9 @@ so it's obvious at a glance exactly what the branch runs. They also close
 a common footgun — a second line added under a braceless condition reads
 as if it sits inside the branch, but executes unconditionally.
 
-The `curly` ESLint rule flags braceless bodies (currently at `warn`). It
-is fully auto-fixable — `eslint --fix` adds the braces with no behavior
-change — so add braces to any control statement you touch.
+The `curly` ESLint rule flags braceless bodies at `error`, so a braceless
+body fails lint and blocks CI. It is fully auto-fixable: `eslint --fix`
+adds the braces with no behavior change.
 
 Reference: [ESLint — `curly`](https://eslint.org/docs/latest/rules/curly)
 

--- a/clients/web/docs/STYLE_GUIDE.md
+++ b/clients/web/docs/STYLE_GUIDE.md
@@ -24,8 +24,8 @@ chat-body.tsx               # component
 stream-event-types.ts       # types
 ```
 
-The only exceptions are `App.tsx` (conventional React entry-point name)
-and generated files that follow their generator's convention.
+The only exception is generated files, which follow their generator's
+convention.
 
 Reference: [TypeScript Deep Dive — File naming](https://basarat.gitbook.io/typescript/styleguide#filename)
 
@@ -61,7 +61,7 @@ Colocated test files append `.test` before the extension:
 
 ```
 src/
-  App.tsx                    # root layout component
+  root-layout.tsx            # shared shell mounted by the root route
   main.tsx                   # entry point (createRoot, RouterProvider)
   routes.tsx                 # route tree (createBrowserRouter)
   stores/                    # app-level Zustand stores (cross-domain)

--- a/packages/design-library/AGENTS.md
+++ b/packages/design-library/AGENTS.md
@@ -37,10 +37,14 @@ Applies to all code under `packages/design-library/`. Subordinate to root [`AGEN
    to the component's rendering logic — splitting them across files adds
    indirection without benefit. This matches the shadcn/ui convention where
    even multi-part components (Card with CardHeader, CardBody, etc.) live in a
-   single file. Only break into a directory when the file exceeds 300 lines
-   with multiple independently useful subcomponents.
+   single file. Break into a directory only when the component has 300+ lines
+   **and** multiple independently useful subcomponents, or when it carries
+   colocated tests or component-specific utilities.
 
-7. **Customization via props, not wrappers.** When a component needs
+7. **Props interfaces are named `{Component}Props`** and extend the element's
+   own props, e.g. `interface TagProps extends ComponentProps<"span">`.
+
+8. **Customization via props, not wrappers.** When a component needs
    domain-specific behavior (e.g. custom link rendering), expose a callback
    or component prop with a sensible default. Consumers inject behavior at
    the call site. This follows the patterns used by

--- a/packages/design-library/AGENTS.md
+++ b/packages/design-library/AGENTS.md
@@ -41,8 +41,11 @@ Applies to all code under `packages/design-library/`. Subordinate to root [`AGEN
    **and** multiple independently useful subcomponents, or when it carries
    colocated tests or component-specific utilities.
 
-7. **Props interfaces are named `{Component}Props`** and extend the element's
-   own props, e.g. `interface TagProps extends ComponentProps<"span">`.
+7. **Props interfaces are named `{Component}Props`.** Naming only: a component
+   that wraps one element extends that element's props (rule 1 says which
+   type), and one that composes several or takes an abstract API declares its
+   own. `SelectProps`, `FieldProps`, and `SliderProps` forward no element's
+   props and are correct as they are.
 
 8. **Customization via props, not wrappers.** When a component needs
    domain-specific behavior (e.g. custom link rendering), expose a callback

--- a/packages/design-library/README.md
+++ b/packages/design-library/README.md
@@ -4,68 +4,14 @@ Shared UI component library for Vellum web applications. Built with React 19 and
 
 ## Component authoring conventions
 
-### React 19 ref-as-prop (no `forwardRef`)
+The rules live in [`AGENTS.md`](./AGENTS.md) beside this file: ref-as-prop
+(no `forwardRef`), `data-slot` on every root, function declarations, exported
+CVA variant functions, named exports only, single-file components,
+`{Component}Props` naming, and customization through props rather than
+wrappers. That file also carries the Storybook story rules and the PR review
+checklist.
 
-React 19 passes `ref` as a regular prop. Do **not** use `forwardRef` — it is
-deprecated.
-
-```tsx
-// ✅ Correct — React 19 ref-as-prop
-export function Tag({ ref, className, ...rest }: TagProps) {
-  return <span ref={ref} {...rest} />;
-}
-
-// ❌ Wrong — legacy forwardRef pattern
-export const Tag = forwardRef<HTMLSpanElement, TagProps>(function Tag(props, ref) {
-  return <span ref={ref} {...props} />;
-});
-```
-
-For element props including ref, use `ComponentProps<"element">` (which
-includes `ref` in React 19) instead of `HTMLAttributes<HTMLElement>` (which
-does not).
-
-References:
-- [React 19 — ref as a prop](https://react.dev/blog/2024/12/05/react-19#ref-as-a-prop)
-- [React — Manipulating the DOM with Refs](https://react.dev/learn/manipulating-the-dom-with-refs)
-
-### `data-slot` attribute
-
-Every component's root element must include `data-slot="component-name"`.
-Multi-part components add a slot to each part (`data-slot="card"`,
-`data-slot="card-header"`, etc.). This enables CSS-only style overrides
-without touching component source — the consuming app can target
-`[data-slot="tag"]` from its own stylesheet.
-
-References:
-- [shadcn/ui v4 — data-slot pattern](https://ui.shadcn.com/docs/changelog/2025-03-data-slot)
-- [Tailwind CSS — Styling based on data attributes](https://tailwindcss.com/docs/hover-focus-and-other-states#data-attributes)
-
-### Function declarations
-
-Use function declarations (not `const` + arrow) for components. This keeps
-names visible in stack traces and React DevTools.
-
-```tsx
-export function Tag({ ... }: TagProps) { /* ... */ }
-```
-
-### Props interface naming
-
-Props interfaces use `{Component}Props`:
-
-```tsx
-export interface TagProps extends ComponentProps<"span"> { /* ... */ }
-```
-
-### Export variant functions
-
-When a component uses CVA, export the variants function so consumers can
-compose variant classes without rendering the component:
-
-```tsx
-export { Tag, tagVariants };
-```
+`AGENTS.md` is the single owner of these rules. Add a rule there, not here.
 
 ## Tailwind class patterns
 
@@ -104,16 +50,8 @@ References:
 
 ## File organization
 
-Components live as **single flat files** in `src/components/`. This matches
-the [shadcn/ui convention](https://ui.shadcn.com/docs) — even multi-part
-components (Card with CardHeader, CardBody, etc.) are in a single file.
-
-Break a component into its own directory only when it has:
-- 300+ lines **and** multiple independently useful subcomponents
-- Colocated tests or component-specific utilities
-
-Variants, types, and helper constants stay in the component file — they are
-tightly coupled to the component's rendering logic.
+Components are single flat files in `src/components/`. See
+[`AGENTS.md`](./AGENTS.md) for when a component earns its own directory.
 
 ## Usage
 


### PR DESCRIPTION
## TL;DR

Three of our governing docs assert things the code contradicts. Found by reading the whole `AGENTS.md` tree plus the `docs/` beside each and checking every claim I would have relied on. Docs only, no code, no rule changes meaning.

## What was wrong

| Doc | Said | Actually |
|---|---|---|
| `CONVENTIONS.md` § Design system | design library is "consumed as a `file:` dependency" | `clients/web/package.json:74` says `workspace:*`, and `clients/web/AGENTS.md` **forbids** the `file:` form |
| `STYLE_GUIDE.md` § Braces | `curly` is "currently at `warn`" | `["error", "all"]` in `clients/web/eslint.config.mjs:233` and `assistant/eslint.config.mjs:18` |
| `CONVENTIONS.md` pointer to design-library `README.md` | the place to read "component authoring conventions" | the README carries 5 of the 8 rules in `packages/design-library/AGENTS.md`, and none of the story rules or review checklist |

The first is the one that matters. `file:` paired with `preserveSymlinks` or a per-package React install is exactly the shape that resolved two Reacts and white-screened the app (the `#34771` to `#34773` revert). A reader who trusted the older sentence would reproduce a known outage, and the doc gave no hint the shape was load-bearing.

The second is a live-fire difference: "warn" reads as "clean it up when you are nearby", `error` blocks CI.

## What changed

- **`CONVENTIONS.md`** states the real dependency form, says why it must stay that way, and links the constraint in `clients/web/AGENTS.md`.
- **`STYLE_GUIDE.md`** says `error`, and that a braceless body fails lint. Kept the auto-fix note, which is still true and still the fastest path.
- **`packages/design-library/AGENTS.md` becomes the single owner** of the authoring rules. It absorbs the only two things the README had that it lacked: props-interface naming (now rule 7) and colocated tests as a second reason to break a component into a directory (folded into rule 6). The old rule 7 renumbers to 8.
- **`README.md`** keeps a pointer instead of a partial copy. Its operational content (Tailwind setup, tokens, Storybook commands, testing, MCP, publishing) is untouched.
- **`CONVENTIONS.md`** now points at `AGENTS.md` rather than the README.

## Why it is safe

- Documentation only. No source file, config, or test is touched.
- **No rule changes meaning.** Two docs are corrected to match the code they already described. The third moves rules between files without editing any of them.
- **Nothing is lost.** The two details that existed only in the README were moved into `AGENTS.md` first, verified by diffing the two rule sets before deleting anything.
- **Nothing links to what was removed.** A repo-wide grep for `design-library/README` and for the `#component-authoring-conventions` anchor returns zero hits, so the replaced sections had no inbound references.
- **No unrelated reformatting.** Three of the four files already fail `prettier --check` on `main`, and no CI job formats markdown, so the edits match surrounding style rather than reflowing the files. Prettier status is identical before and after for all four.

## The judgement call

Which file owns the design-library rules is a choice, not a fact, so: `AGENTS.md` wins because it is the file the repo's own convention index lists, it is already the superset, and it is what the nested-`AGENTS.md` precedence rule points readers to. The package is `private: true`, so no external npm consumer loses anything by the README deferring. Easy to flip if the team prefers the README as owner, since the rules moved wholesale rather than being rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40726" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Also folded in

Two sibling PRs (#40729, #40730) found the same three claims independently and each carried one more fix; both are closed in favor of this one. Their unique corrections are here:

| Doc said | Actually | Verified by |
|---|---|---|
| Code-org tree and `lib/`/`utils/` examples name `format.ts`, `browser.ts`, `network-status.ts`, `stable-id.ts`, `lib/api-client.ts` | Those files do not exist; the real ones are `format-date.ts`, `semver.ts`, `to-error.ts`, `create-selectors.ts`, `lib/api-interceptors.ts` | every listed path checked with `ls` under `clients/web/src` |
| The shared shell is `<App />` / `App.tsx` | There is no `App` component; the shell is `RootLayout` (`src/root-layout.tsx`) | grep |
