### PR TITLE
docs(web): correct four stale claims in the web conventions docs

### DIFF
--- a/clients/web/docs/CONVENTIONS.md
+++ b/clients/web/docs/CONVENTIONS.md
@@ -278,8 +278,8 @@ src/
     conversation-cache-mutations.ts #  domain-level cache mutation helpers
     conversation-list-fetchers.ts  #   pure async fetch functions for conversation lists
     conversation-transforms.ts     #   daemon → client field mapping
-    format.ts
-    browser.ts
+    format-date.ts
+    semver.ts
   types/                           # cross-domain shared types (no owning module)
     window.d.ts
     event-types.ts
@@ -290,7 +290,7 @@ src/
     feature-flags/                 #   feature flag provider
     sync/                          #   server state sync (query-tag keys, sync types)
     streaming/                     #   SSE transport, event parsing, debug tracking
-    api-client.ts                  #   HeyAPI configured client + interceptors
+    api-interceptors.ts            #   HeyAPI client interceptors (auth, routing)
     telemetry/                     #   client identity for daemon registration
   runtime/                         # framework adapters, platform bridges
     native-auth.ts
@@ -478,9 +478,9 @@ owns it.
 | `assistant/` | Core business-domain code for the assistant itself — the central concept every feature composes around. Every domain may depend on it; it depends on no domain. New top-level business-concept folders require explicit team approval. | `api.ts`, `lifecycle.ts`, `types.ts`, `llm-model-catalog.ts` |
 | `stores/` | App-level Zustand stores (cross-domain state) | `viewer-store.ts`, `sse-connected-store.ts`, `assistant-feature-flag-store.ts` |
 | `hooks/` | Cross-domain React hooks | `use-is-mobile.ts`, `use-visible-viewport.ts`, `use-feature-flag-bus-sync.ts` |
-| `utils/` | Pure utility functions (no side effects, no third-party SDKs) | `format.ts`, `browser.ts`, `network-status.ts`, `stable-id.ts` |
+| `utils/` | Pure utility functions (no side effects, no third-party SDKs) | `format-date.ts`, `semver.ts`, `to-error.ts`, `create-selectors.ts` |
 | `types/` | Cross-domain shared type definitions with no clear owning module. Types consumed by a single module live with that module. Types produced by a module live in the module that produces them — consumers use `import type`. | `window.d.ts`, `event-types.ts`, `conversation-types.ts` |
-| `lib/` | Third-party SDK wrappers and app-internal infrastructure (registries, transports, interceptors). Side effects, module-level state, or lifecycle ownership. See [`lib/` vs `utils/`](#lib-vs-utils--where-does-my-code-go) below. | `sentry/` (error reporting), `auth/` (allauth + CSRF), `feature-flags/` (catalog + registry), `sync/` (state sync), `streaming/` (SSE transport), `event-bus.ts` (pub/sub registry), `diagnostics.ts` (session ring buffer), `api-client.ts` (HeyAPI) |
+| `lib/` | Third-party SDK wrappers and app-internal infrastructure (registries, transports, interceptors). Side effects, module-level state, or lifecycle ownership. See [`lib/` vs `utils/`](#lib-vs-utils--where-does-my-code-go) below. | `sentry/` (error reporting), `auth/` (allauth + CSRF), `feature-flags/` (catalog + registry), `sync/` (state sync), `streaming/` (SSE transport), `event-bus.ts` (pub/sub registry), `diagnostics.ts` (session ring buffer), `api-interceptors.ts` (HeyAPI) |
 | `runtime/` | Framework adapters and native platform bridges | `route-adapter.ts`, `native-auth.ts`, `native-deep-link.ts`, `app-bridge.ts` |
 | `components/` | Cross-domain shared UI | `error-boundary.tsx`, `sign-in-gate.tsx`, `providers.tsx` |
 
@@ -494,7 +494,7 @@ owns it.
 | **Side effects?** | Yes — module-level state, listener registration, SDK init, interceptors, or pub/sub registries | No — pure input→output, no global state, no I/O |
 | **Third-party SDK dependency?** | Optional — third-party wrappers (`@sentry/react`, `@heyapi/client-fetch`) AND first-party infrastructure (`event-bus.ts`, `chunk-errors.ts`, `local-mode.ts`) both belong here | No — only standard library / language utilities |
 | **Subdirectories?** | When a single integration warrants multiple files (`lib/sentry/`, `lib/auth/`, `lib/sync/`); single-file infrastructure stays at the `lib/` top level (`lib/diagnostics.ts`, `lib/event-bus.ts`) | Flat — individual utility files at the top level |
-| **Examples** | `lib/sentry/sentry-init.ts`, `lib/auth/allauth-client.ts`, `lib/api-client.ts`, `lib/event-bus.ts`, `lib/diagnostics.ts`, `lib/chunk-errors.ts` | `utils/format.ts`, `utils/browser.ts`, `utils/cn.ts` |
+| **Examples** | `lib/sentry/sentry-init.ts`, `lib/auth/allauth-client.ts`, `lib/api-interceptors.ts`, `lib/event-bus.ts`, `lib/diagnostics.ts`, `lib/chunk-errors.ts` | `utils/format-date.ts`, `utils/semver.ts`, `utils/to-error.ts` |
 
 If the code holds state at module scope, registers global listeners,
 configures an SDK, manages a session, or runs at startup, it belongs
@@ -852,8 +852,10 @@ Reference: [Vite — SSR guidance](https://vite.dev/guide/ssr.html)
 
 Domain-agnostic UI primitives (Button, Card, Modal, Typography, etc.)
 live in `packages/design-library/` outside `clients/web/`. The package is
-consumed as a `file:` dependency and resolved via its `exports` field
-in `package.json` — no Vite alias or tsconfig `paths` needed.
+a `workspace:*` dependency resolved via its `exports` field in
+`package.json`, so no Vite alias or tsconfig `paths` are needed. See
+[`clients/web/AGENTS.md`](../AGENTS.md) for why local packages must stay
+workspace members rather than `file:` dependencies.
 
 ```ts
 import { Button, Typography } from "@vellumai/design-library";

--- a/clients/web/docs/STYLE_GUIDE.md
+++ b/clients/web/docs/STYLE_GUIDE.md
@@ -553,9 +553,10 @@ so it's obvious at a glance exactly what the branch runs. They also close
 a common footgun — a second line added under a braceless condition reads
 as if it sits inside the branch, but executes unconditionally.
 
-The `curly` ESLint rule flags braceless bodies (currently at `warn`). It
-is fully auto-fixable — `eslint --fix` adds the braces with no behavior
-change — so add braces to any control statement you touch.
+The `curly` ESLint rule flags braceless bodies at `error`, in both
+`clients/web/` and `assistant/`, so a braceless body fails lint rather
+than warning. It is fully auto-fixable: `eslint --fix` adds the braces
+with no behavior change.
 
 Reference: [ESLint — `curly`](https://eslint.org/docs/latest/rules/curly)
 


### PR DESCRIPTION
## TL;DR

Four claims in `clients/web/docs/` describe a codebase we no longer have. One of them tells you to do the exact thing `clients/web/AGENTS.md` forbids. Documentation only, no code changes.

Found while reading the governing docs end to end; each claim was verified against the code, not against another doc.

## What was wrong

| Claim | Where | Reality |
| --- | --- | --- |
| The design library "is consumed as a `file:` dependency" | `CONVENTIONS.md:855` | `clients/web/package.json:74` has `workspace:*`, and `clients/web/AGENTS.md:39` explicitly forbids `file:` deps for local packages |
| The `curly` rule is "currently at `warn`" | `STYLE_GUIDE.md:556` | `curly: ["error", "all"]` in both `clients/web/eslint.config.mjs:233` and `assistant/eslint.config.mjs:18` |
| `lib/api-client.ts` | `CONVENTIONS.md` x3 | The module is `lib/api-interceptors.ts` |
| `utils/format.ts`, `utils/browser.ts`, `utils/cn.ts`, `utils/stable-id.ts`, `utils/network-status.ts` | `CONVENTIONS.md` x3 | None of the five exist |

## Why the first one matters most

`clients/web/AGENTS.md:39` bans `file:` deps for local packages because `preserveSymlinks` plus per-package React plus `file:` produced the two-Reacts white-screen, reverted in #34771 to #34773. Doc precedence already resolves this in AGENTS.md's favour, since the nested doc wins. But precedence only helps a reader who knows there is a conflict, and `CONVENTIONS.md` is the doc `AGENTS.md` sends people to first. Now the umbrella agrees with the specific doc and points at it for the reasoning.

The `curly` correction is the one most likely to waste someone's time day to day: reading `warn` and finding a failed CI lint job is a confusing five minutes.

## Why it is safe

Prose and table cells only. No code, no config, no rule changes: every edit brings a doc into line with what the code already does, and the two rules that actually changed meaning (`file:` and `curly`) were both already stated correctly in the more specific doc.

## Not included

Both files already fail `prettier --check` on `main` (verified against `origin/main`, not just locally). Running `--write` would rewrap around 1500 lines and bury four one-line corrections, which `STYLE_GUIDE.md:506` warns against. Worth its own pass if we want these docs prettier-clean.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40729" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->