### PR TITLE
docs(web): correct four stale claims in the web conventions and style guide

### DIFF
--- a/clients/web/docs/CONVENTIONS.md
+++ b/clients/web/docs/CONVENTIONS.md
@@ -50,7 +50,7 @@ to hide irrelevant sections.
 
 ```
 routes.tsx
-  <App />            ← shared shell (nav, layout, providers)
+  <RootLayout />     ← shared shell (nav, layout, providers)
     <Outlet />
       <ChatPage />           ← lifecycle guards → mounts ActiveChatView
       <LibraryPage />        ← library listing
@@ -59,7 +59,7 @@ routes.tsx
 
 Push hooks down to the route component that needs them. Lift shared
 state to the nearest common ancestor — typically a layout route or a
-context provider mounted in `<App />`.
+context provider mounted in `<RootLayout />`.
 
 ### Layout header slots
 
@@ -852,8 +852,11 @@ Reference: [Vite — SSR guidance](https://vite.dev/guide/ssr.html)
 
 Domain-agnostic UI primitives (Button, Card, Modal, Typography, etc.)
 live in `packages/design-library/` outside `clients/web/`. The package is
-consumed as a `file:` dependency and resolved via its `exports` field
-in `package.json` — no Vite alias or tsconfig `paths` needed.
+a `workspace:*` dependency resolved via its `exports` field in
+`package.json`, so no Vite alias or tsconfig `paths` is needed. Do not
+switch it to a `file:` dependency: that, combined with per-package
+React installs, is what caused the two-Reacts white screen (see
+[`clients/web/AGENTS.md`](../AGENTS.md)).
 
 ```ts
 import { Button, Typography } from "@vellumai/design-library";

--- a/clients/web/docs/STYLE_GUIDE.md
+++ b/clients/web/docs/STYLE_GUIDE.md
@@ -24,8 +24,8 @@ chat-body.tsx               # component
 stream-event-types.ts       # types
 ```
 
-The only exceptions are `App.tsx` (conventional React entry-point name)
-and generated files that follow their generator's convention.
+The only exception is generated files, which follow their generator's
+convention.
 
 Reference: [TypeScript Deep Dive — File naming](https://basarat.gitbook.io/typescript/styleguide#filename)
 
@@ -61,7 +61,7 @@ Colocated test files append `.test` before the extension:
 
 ```
 src/
-  App.tsx                    # root layout component
+  root-layout.tsx            # shared shell mounted by the root route
   main.tsx                   # entry point (createRoot, RouterProvider)
   routes.tsx                 # route tree (createBrowserRouter)
   stores/                    # app-level Zustand stores (cross-domain)
@@ -553,7 +553,7 @@ so it's obvious at a glance exactly what the branch runs. They also close
 a common footgun — a second line added under a braceless condition reads
 as if it sits inside the branch, but executes unconditionally.
 
-The `curly` ESLint rule flags braceless bodies (currently at `warn`). It
+The `curly` ESLint rule flags braceless bodies, at `error`. It
 is fully auto-fixable — `eslint --fix` adds the braces with no behavior
 change — so add braces to any control statement you touch.
 


### PR DESCRIPTION
## TL;DR

Four statements in `clients/web/docs/` are checkably wrong against the tree. Docs-only, no code changes.

Found while reading the governing docs before working in `clients/web`; each was verified against the source rather than taken from another doc's word.

## What changes for a reader

| Doc said | Actually true | Verified by |
| --- | --- | --- |
| The design library is consumed as a `file:` dependency | It is `workspace:*`, and `clients/web/AGENTS.md` names `file:` deps + per-package React installs as the cause of the two-Reacts white screen | `clients/web/package.json:74` |
| The shared shell is `<App />` | There is no `App` component anywhere in `clients/web/src`. The shell is `RootLayout` | `grep -rE "export (default )?function App\b"` returns nothing; `src/routes.tsx:8` imports `RootLayout` from `@/root-layout` |
| `App.tsx` is the root component, and the one hand-written exception to kebab-case | No such file exists | `find src -iname "App.tsx"` returns nothing |
| The `curly` ESLint rule is "currently at `warn`" | It is `["error", "all"]` in both configs, which is what root `AGENTS.md` already says | `clients/web/eslint.config.mjs:233`, `assistant/eslint.config.mjs:18` |

The first one is the one worth reading twice: the doc was recommending, as current architecture, the exact dependency form its own sibling doc calls a known outage cause. The replacement text states which form is in use **and** why not to change it, so the next reader gets the warning at the point of temptation.

## Why it is safe

Documentation only. No source, config, or test file is touched.

## On formatting

Both files already fail `prettier --check` on `main`, before this change. Running `--write` would bury four corrected lines under a whole-file reformat, so formatting is deliberately left alone; the new lines match the surrounding wrap width (median 66, p90 72).

## Follow-up, deliberately not in this PR

Removing `App.tsx` from the kebab-case exception list leaves the doc saying generated files are the only exception, and there is one real violation: `clients/web/src/pages/BundleConfirmPage.tsx` (hand-written, one importer, lazily imported at `src/routes.tsx:265`). That is a code rename, not a doc fix, so it does not belong here. Happy to file or take it separately.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40730" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->