### PR TITLE
fix(web): stop the identity Memory card doubling its count (LUM-3289)

### DIFF
--- a/clients/web/src/domains/intelligence/components/identity-overview.tsx
+++ b/clients/web/src/domains/intelligence/components/identity-overview.tsx
@@ -450,9 +450,6 @@ function SectionCard({
   );
 
   if (mini) {
-    // The one-line form only; the hero numeral and unit label are the
-    // full-size card's layout.
-    const miniStat = stat?.text;
     // Bottom-strip tile per Figma (New-App 6944-89405): left-aligned,
     // 12px radius, 40px icon slot in the secondary tone, 16px title over
     // an 11px tertiary stat.
@@ -486,7 +483,7 @@ function SectionCard({
             >
               {section.label}
             </span>
-            {miniStat && (
+            {stat?.text && (
               <span
                 className={`truncate text-[11px] leading-normal font-medium transition-colors duration-300 ${
                   flooded
@@ -494,7 +491,7 @@ function SectionCard({
                     : "text-[var(--content-tertiary)]"
                 }`}
               >
-                {miniStat}
+                {stat.text}
               </span>
             )}
           </span>

--- a/clients/web/src/domains/intelligence/components/identity-overview.tsx
+++ b/clients/web/src/domains/intelligence/components/identity-overview.tsx
@@ -250,6 +250,7 @@ export function IdentityOverview({ assistantId }: IdentityOverviewProps) {
             label: t("identityOverview.memoryCountLabel", {
               count: memories,
             }),
+            text: t("identityOverview.memoryCount", { count: memories }),
           },
   };
 
@@ -449,8 +450,9 @@ function SectionCard({
   );
 
   if (mini) {
-    const miniStat =
-      stat?.value !== undefined ? `${stat.value} ${stat.label}` : stat?.text;
+    // The one-line form only; the hero numeral and unit label are the
+    // full-size card's layout.
+    const miniStat = stat?.text;
     // Bottom-strip tile per Figma (New-App 6944-89405): left-aligned,
     // 12px radius, 40px icon slot in the secondary tone, 16px title over
     // an 11px tertiary stat.

--- a/clients/web/src/domains/intelligence/identity-section-stat-labels.test.ts
+++ b/clients/web/src/domains/intelligence/identity-section-stat-labels.test.ts
@@ -1,10 +1,10 @@
 /**
  * A countable stat on the overview's bento cards has two copy shapes. The
  * full-size card draws the hero numeral (`IdentitySectionStat.value`) with a
- * small unit label under it (`IdentitySectionStat.label`), so the label must
- * name the unit only; one that also spells the count (`# memories`) shows it
- * twice: "34 34 memories". The mini tile renders `IdentitySectionStat.text`,
- * a whole ICU message, so that one must carry the count itself.
+ * small unit label under it (`IdentitySectionStat.label`), so the label names
+ * the unit only and the card supplies the number. The mini tile renders
+ * `IdentitySectionStat.text`, a whole ICU message, so that one carries the
+ * count itself.
  *
  * `catalogs.test.ts` proves these messages parse and keep their placeholders;
  * a `#` in the wrong shape passes both. This formats every key of each shape,
@@ -65,22 +65,26 @@ function lookup(catalog: unknown, key: string): string | undefined {
   return typeof node === "string" ? node : undefined;
 }
 
+function format(message: string, locale: string, count: number): string {
+  return String(new IntlMessageFormat(message, locale).format({ count }));
+}
+
 /**
- * The message under `key` rendered at each of `COUNTS`, or `undefined` when
- * the locale has no translation (it then falls back to English, which is
- * checked on its own pass).
+ * The message under `key` rendered at each of `COUNTS`. Empty when the locale
+ * has no translation: it then falls back to English, which is checked on its
+ * own pass.
  */
 function renderings(
   locale: string,
   key: string,
-): Array<{ count: number; rendered: string }> | undefined {
+): Array<{ count: number; rendered: string }> {
   const message = lookup(CATALOGS[locale].intelligence, key);
   if (message === undefined) {
-    return undefined;
+    return [];
   }
   return COUNTS.map((count) => ({
     count,
-    rendered: String(new IntlMessageFormat(message, locale).format({ count })),
+    rendered: format(message, locale, count),
   }));
 }
 
@@ -93,15 +97,14 @@ function requireEnglish(key: string): (count: number) => string {
   if (message === undefined) {
     throw new Error(`en catalog is missing ${key}`);
   }
-  return (count) =>
-    String(new IntlMessageFormat(message, "en").format({ count }));
+  return (count) => format(message, "en", count);
 }
 
 describe("identity section unit labels", () => {
   for (const locale of SUPPORTED_LOCALES) {
     for (const key of UNIT_LABEL_KEYS) {
       test(`${locale}/${key}: names the unit without repeating the count`, () => {
-        for (const { count, rendered } of renderings(locale, key) ?? []) {
+        for (const { count, rendered } of renderings(locale, key)) {
           expect(
             rendered,
             `${locale}/${key} at count=${count} rendered "${rendered}"`,
@@ -122,7 +125,7 @@ describe("identity section count phrases", () => {
   for (const locale of SUPPORTED_LOCALES) {
     for (const key of COUNT_PHRASE_KEYS) {
       test(`${locale}/${key}: states the count exactly once`, () => {
-        for (const { count, rendered } of renderings(locale, key) ?? []) {
+        for (const { count, rendered } of renderings(locale, key)) {
           expect(
             occurrences(rendered, String(count)),
             `${locale}/${key} at count=${count} rendered "${rendered}"`,

--- a/clients/web/src/domains/intelligence/identity-section-stat-labels.test.ts
+++ b/clients/web/src/domains/intelligence/identity-section-stat-labels.test.ts
@@ -1,0 +1,93 @@
+/**
+ * The overview's bento cards draw a countable stat as two elements: the hero
+ * numeral (`IdentitySectionStat.value`) and, under it, a small unit label
+ * (`IdentitySectionStat.label`). The mini tile joins the same two as
+ * `${value} ${label}`. Either way the card supplies the number, so a unit
+ * label that also spells the count (`# memories`) shows it twice: "34 34
+ * memories".
+ *
+ * `catalogs.test.ts` proves these messages parse and keep their placeholders;
+ * a `#` inside a plural branch passes both. This asserts the rendered label
+ * for every unit-label key, in every locale, never contains the count.
+ */
+import { describe, expect, test } from "bun:test";
+import IntlMessageFormat from "intl-messageformat";
+
+import { loadCatalogs, type LocaleCatalogs } from "@/i18n/catalogs";
+import { SUPPORTED_LOCALES } from "@/i18n/supported-locales";
+
+/**
+ * Every `intelligence` key read into `IdentitySectionStat.label` next to a
+ * `value` (see `use-identity-section-stats.ts` and the Memory card in
+ * `components/identity-overview.tsx`).
+ */
+const UNIT_LABEL_KEYS = [
+  "identityOverview.memoryCountLabel",
+  "useIdentitySectionStats.activeLabel",
+  "useIdentitySectionStats.connectedLabel",
+  "useIdentitySectionStats.itemLabel",
+  "useIdentitySectionStats.personLabel",
+] as const;
+
+/** Exercises the `one` and `other` categories and a multi-digit count. */
+const COUNTS = [0, 1, 34];
+
+const CATALOGS: Record<string, LocaleCatalogs> = Object.fromEntries(
+  await Promise.all(
+    SUPPORTED_LOCALES.map(async (locale) => [
+      locale,
+      await loadCatalogs(locale),
+    ]),
+  ),
+);
+
+function lookup(catalog: unknown, key: string): string | undefined {
+  let node: unknown = catalog;
+  for (const part of key.split(".")) {
+    if (node === null || typeof node !== "object") {
+      return undefined;
+    }
+    node = (node as Record<string, unknown>)[part];
+  }
+  return typeof node === "string" ? node : undefined;
+}
+
+describe("identity section unit labels", () => {
+  for (const locale of SUPPORTED_LOCALES) {
+    for (const key of UNIT_LABEL_KEYS) {
+      test(`${locale}/${key}: names the unit without repeating the count`, () => {
+        const message = lookup(CATALOGS[locale].intelligence, key);
+        // A missing translation falls back to English, which is checked on
+        // its own pass.
+        if (message === undefined) {
+          return;
+        }
+        for (const count of COUNTS) {
+          const rendered = String(
+            new IntlMessageFormat(message, locale).format({ count }),
+          );
+          expect(
+            rendered,
+            `${locale}/${key} at count=${count} rendered "${rendered}"`,
+          ).not.toContain(String(count));
+        }
+      });
+    }
+  }
+
+  test("en: the Memory card's unit label reads memory / memories", () => {
+    const message = lookup(
+      CATALOGS.en.intelligence,
+      "identityOverview.memoryCountLabel",
+    );
+    if (message === undefined) {
+      throw new Error(
+        "en catalog is missing identityOverview.memoryCountLabel",
+      );
+    }
+    const label = (count: number) =>
+      String(new IntlMessageFormat(message, "en").format({ count }));
+    expect(label(1)).toBe("memory");
+    expect(label(34)).toBe("memories");
+  });
+});

--- a/clients/web/src/domains/intelligence/identity-section-stat-labels.test.ts
+++ b/clients/web/src/domains/intelligence/identity-section-stat-labels.test.ts
@@ -1,14 +1,15 @@
 /**
- * The overview's bento cards draw a countable stat as two elements: the hero
- * numeral (`IdentitySectionStat.value`) and, under it, a small unit label
- * (`IdentitySectionStat.label`). The mini tile joins the same two as
- * `${value} ${label}`. Either way the card supplies the number, so a unit
- * label that also spells the count (`# memories`) shows it twice: "34 34
- * memories".
+ * A countable stat on the overview's bento cards has two copy shapes. The
+ * full-size card draws the hero numeral (`IdentitySectionStat.value`) with a
+ * small unit label under it (`IdentitySectionStat.label`), so the label must
+ * name the unit only; one that also spells the count (`# memories`) shows it
+ * twice: "34 34 memories". The mini tile renders `IdentitySectionStat.text`,
+ * a whole ICU message, so that one must carry the count itself.
  *
  * `catalogs.test.ts` proves these messages parse and keep their placeholders;
- * a `#` inside a plural branch passes both. This asserts the rendered label
- * for every unit-label key, in every locale, never contains the count.
+ * a `#` in the wrong shape passes both. This formats every key of each shape,
+ * in every locale, and asserts the count is absent from unit labels and
+ * present exactly once in the one-line phrases.
  */
 import { describe, expect, test } from "bun:test";
 import IntlMessageFormat from "intl-messageformat";
@@ -27,6 +28,18 @@ const UNIT_LABEL_KEYS = [
   "useIdentitySectionStats.connectedLabel",
   "useIdentitySectionStats.itemLabel",
   "useIdentitySectionStats.personLabel",
+] as const;
+
+/**
+ * Every `intelligence` key read into `IdentitySectionStat.text` for a
+ * countable stat (same producers as the unit labels).
+ */
+const COUNT_PHRASE_KEYS = [
+  "identityOverview.memoryCount",
+  "useIdentitySectionStats.activeCount",
+  "useIdentitySectionStats.connectedCount",
+  "useIdentitySectionStats.itemCount",
+  "useIdentitySectionStats.personCount",
 ] as const;
 
 /** Exercises the `one` and `other` categories and a multi-digit count. */
@@ -52,20 +65,43 @@ function lookup(catalog: unknown, key: string): string | undefined {
   return typeof node === "string" ? node : undefined;
 }
 
+/**
+ * The message under `key` rendered at each of `COUNTS`, or `undefined` when
+ * the locale has no translation (it then falls back to English, which is
+ * checked on its own pass).
+ */
+function renderings(
+  locale: string,
+  key: string,
+): Array<{ count: number; rendered: string }> | undefined {
+  const message = lookup(CATALOGS[locale].intelligence, key);
+  if (message === undefined) {
+    return undefined;
+  }
+  return COUNTS.map((count) => ({
+    count,
+    rendered: String(new IntlMessageFormat(message, locale).format({ count })),
+  }));
+}
+
+function occurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
+function requireEnglish(key: string): (count: number) => string {
+  const message = lookup(CATALOGS.en.intelligence, key);
+  if (message === undefined) {
+    throw new Error(`en catalog is missing ${key}`);
+  }
+  return (count) =>
+    String(new IntlMessageFormat(message, "en").format({ count }));
+}
+
 describe("identity section unit labels", () => {
   for (const locale of SUPPORTED_LOCALES) {
     for (const key of UNIT_LABEL_KEYS) {
       test(`${locale}/${key}: names the unit without repeating the count`, () => {
-        const message = lookup(CATALOGS[locale].intelligence, key);
-        // A missing translation falls back to English, which is checked on
-        // its own pass.
-        if (message === undefined) {
-          return;
-        }
-        for (const count of COUNTS) {
-          const rendered = String(
-            new IntlMessageFormat(message, locale).format({ count }),
-          );
+        for (const { count, rendered } of renderings(locale, key) ?? []) {
           expect(
             rendered,
             `${locale}/${key} at count=${count} rendered "${rendered}"`,
@@ -76,18 +112,29 @@ describe("identity section unit labels", () => {
   }
 
   test("en: the Memory card's unit label reads memory / memories", () => {
-    const message = lookup(
-      CATALOGS.en.intelligence,
-      "identityOverview.memoryCountLabel",
-    );
-    if (message === undefined) {
-      throw new Error(
-        "en catalog is missing identityOverview.memoryCountLabel",
-      );
-    }
-    const label = (count: number) =>
-      String(new IntlMessageFormat(message, "en").format({ count }));
+    const label = requireEnglish("identityOverview.memoryCountLabel");
     expect(label(1)).toBe("memory");
     expect(label(34)).toBe("memories");
+  });
+});
+
+describe("identity section count phrases", () => {
+  for (const locale of SUPPORTED_LOCALES) {
+    for (const key of COUNT_PHRASE_KEYS) {
+      test(`${locale}/${key}: states the count exactly once`, () => {
+        for (const { count, rendered } of renderings(locale, key) ?? []) {
+          expect(
+            occurrences(rendered, String(count)),
+            `${locale}/${key} at count=${count} rendered "${rendered}"`,
+          ).toBe(1);
+        }
+      });
+    }
+  }
+
+  test("en: the Memory tile reads N memory / N memories", () => {
+    const phrase = requireEnglish("identityOverview.memoryCount");
+    expect(phrase(1)).toBe("1 memory");
+    expect(phrase(34)).toBe("34 memories");
   });
 });

--- a/clients/web/src/domains/intelligence/use-identity-section-stats.ts
+++ b/clients/web/src/domains/intelligence/use-identity-section-stats.ts
@@ -37,9 +37,16 @@ export interface SchedulePreview {
 export interface IdentitySectionStat {
   /** Hero numeral, rendered display-size on the card. */
   value?: number;
-  /** Small unit label under the hero numeral ("installed", "people"). */
+  /**
+   * Small unit label under the hero numeral ("installed", "people"). Names
+   * the unit only; the card supplies the number.
+   */
   label?: string;
-  /** Plain one-liner for sections without a countable stat. */
+  /**
+   * The stat as one complete line ("34 memories", "Nothing scheduled yet").
+   * The mini tile renders this alone, so a countable stat carries it too,
+   * as a whole ICU message rather than the numeral and unit joined by hand.
+   */
   text?: string;
   /** Persisted personality slider values, drawn as the signature mark. */
   signature?: Record<string, number>;
@@ -196,6 +203,9 @@ export function useIdentitySectionStats(
             label: t("useIdentitySectionStats.itemLabel", {
               count: workspace.data,
             }),
+            text: t("useIdentitySectionStats.itemCount", {
+              count: workspace.data,
+            }),
           }
         : undefined,
     contacts:
@@ -203,6 +213,9 @@ export function useIdentitySectionStats(
         ? {
             value: contacts.data,
             label: t("useIdentitySectionStats.personLabel", {
+              count: contacts.data,
+            }),
+            text: t("useIdentitySectionStats.personCount", {
               count: contacts.data,
             }),
           }
@@ -214,6 +227,9 @@ export function useIdentitySectionStats(
             label: t("useIdentitySectionStats.connectedLabel", {
               count: channels.data,
             }),
+            text: t("useIdentitySectionStats.connectedCount", {
+              count: channels.data,
+            }),
           }
         : undefined,
     schedules:
@@ -223,6 +239,9 @@ export function useIdentitySectionStats(
           : {
               value: schedules.data.count,
               label: t("useIdentitySectionStats.activeLabel", {
+                count: schedules.data.count,
+              }),
+              text: t("useIdentitySectionStats.activeCount", {
                 count: schedules.data.count,
               }),
               schedules: {

--- a/clients/web/src/i18n/locales/en/intelligence.json
+++ b/clients/web/src/i18n/locales/en/intelligence.json
@@ -96,6 +96,7 @@
       "workspace": "All the files that power me"
     },
     "defaultAssistantName": "Assistant",
+    "memoryCount": "{count, plural, one {# memory} other {# memories}}",
     "memoryCountLabel": "{count, plural, one {memory} other {memories}}",
     "renameErrorToast": "The rename didn't go through. Please try again.",
     "renameSuccessToast": "Say hi to {newName}!",
@@ -382,12 +383,16 @@
     "upgradePluginAriaLabel": "Upgrade plugin"
   },
   "useIdentitySectionStats": {
+    "activeCount": "{count, plural, one {# active} other {# active}}",
     "activeLabel": "{count, plural, one {active} other {active}}",
     "appCount": "{count, plural, one {# app} other {# apps}}",
+    "connectedCount": "{count, plural, one {# connected} other {# connected}}",
     "connectedLabel": "{count, plural, one {connected} other {connected}}",
     "docCount": "{count, plural, one {# doc} other {# docs}}",
+    "itemCount": "{count, plural, one {# item} other {# items}}",
     "itemLabel": "{count, plural, one {item} other {items}}",
     "noSchedulesText": "Nothing scheduled yet",
+    "personCount": "{count, plural, one {# person} other {# people}}",
     "personLabel": "{count, plural, one {person} other {people}}",
     "pluginCount": "{count, plural, one {# plugin} other {# plugins}}",
     "skillCount": "{count, plural, one {# skill} other {# skills}}"

--- a/clients/web/src/i18n/locales/en/intelligence.json
+++ b/clients/web/src/i18n/locales/en/intelligence.json
@@ -96,7 +96,7 @@
       "workspace": "All the files that power me"
     },
     "defaultAssistantName": "Assistant",
-    "memoryCountLabel": "{count, plural, one {# memory} other {# memories}}",
+    "memoryCountLabel": "{count, plural, one {memory} other {memories}}",
     "renameErrorToast": "The rename didn't go through. Please try again.",
     "renameSuccessToast": "Say hi to {newName}!",
     "scheduleCadence": "{cadence} · next {nextRun}",

--- a/clients/web/src/i18n/locales/es/intelligence.json
+++ b/clients/web/src/i18n/locales/es/intelligence.json
@@ -96,7 +96,7 @@
       "workspace": "Todos los archivos que me hacen funcionar"
     },
     "defaultAssistantName": "Asistente",
-    "memoryCountLabel": "{count, plural, one {# recuerdo} other {# recuerdos}}",
+    "memoryCountLabel": "{count, plural, one {recuerdo} other {recuerdos}}",
     "renameErrorToast": "El cambio de nombre no se completó. Vuelve a intentarlo.",
     "renameSuccessToast": "¡Saluda a {newName}!",
     "scheduleCadence": "{cadence} · próxima {nextRun}",

--- a/clients/web/src/i18n/locales/es/intelligence.json
+++ b/clients/web/src/i18n/locales/es/intelligence.json
@@ -96,6 +96,7 @@
       "workspace": "Todos los archivos que me hacen funcionar"
     },
     "defaultAssistantName": "Asistente",
+    "memoryCount": "{count, plural, one {# recuerdo} other {# recuerdos}}",
     "memoryCountLabel": "{count, plural, one {recuerdo} other {recuerdos}}",
     "renameErrorToast": "El cambio de nombre no se completó. Vuelve a intentarlo.",
     "renameSuccessToast": "¡Saluda a {newName}!",
@@ -382,12 +383,16 @@
     "upgradePluginAriaLabel": "Actualizar plugin"
   },
   "useIdentitySectionStats": {
+    "activeCount": "{count, plural, one {# activa} other {# activas}}",
     "activeLabel": "{count, plural, one {activa} other {activas}}",
     "appCount": "{count, plural, one {# app} other {# apps}}",
+    "connectedCount": "{count, plural, one {# conectado} other {# conectados}}",
     "connectedLabel": "{count, plural, one {conectado} other {conectados}}",
     "docCount": "{count, plural, one {# documento} other {# documentos}}",
+    "itemCount": "{count, plural, one {# elemento} other {# elementos}}",
     "itemLabel": "{count, plural, one {elemento} other {elementos}}",
     "noSchedulesText": "Todavía no hay nada programado",
+    "personCount": "{count, plural, one {# persona} other {# personas}}",
     "personLabel": "{count, plural, one {persona} other {personas}}",
     "pluginCount": "{count, plural, one {# plugin} other {# plugins}}",
     "skillCount": "{count, plural, one {# habilidad} other {# habilidades}}"


### PR DESCRIPTION
## TL;DR

The identity overview's Memory card showed the count twice: "34 34 memories" on an existing assistant, "0 0 memories" on a new one. The unit label under the hero numeral was spelling the count itself. This makes the label unit-only again (in both catalogs), gives the mini tile a whole ICU phrase instead of a hand-joined `${value} ${label}`, and adds a catalog test so neither shape can drift again.

Fixes LUM-3289

## What changed for the user

| Where | Before | After |
|---|---|---|
| Identity overview → Memory card (bento) | Hero numeral **34**, label "34 memories" | Hero numeral **34**, label "memories" |
| Identity overview → Memory card (mini / bottom-strip tile) | "34 34 m…" | "34 memories" |
| Same card, Spanish | "34 34 recuerdos" | "34 recuerdos" |
| Other mini tiles (Workspace, Contacts, Channels, Schedules) | Number and unit joined in code | Same English text, now one translatable phrase |

## Why

The bento cards draw a countable stat as two elements: `IdentitySectionStat.value` is the hero numeral and `IdentitySectionStat.label` is the small unit line under it ("items", "people", "connected"). The intelligence i18n pass turned the Memory card's `memory` / `memories` label into `{count, plural, one {# memory} other {# memories}}`, so ICU rendered the count into the label and the card printed it again. The four sibling `*Label` keys were already unit-only; `memoryCountLabel` was the one exception.

The mini tile used to join those same two as `${value} ${label}`, which is the concatenation `clients/web/AGENTS.md` and `docs/I18N.md` rule out: a locale that puts the noun first, or inflects the phrase as a whole, has no way to say so. So `IdentitySectionStat.text` is now the one-line form every stat carries (countable stats add it next to `value` / `label`, as a complete ICU plural: `memoryCount`, `itemCount`, `personCount`, `connectedCount`, `activeCount`), and the mini tile renders `text` alone. The full-size card's hero numeral + unit label layout is unchanged.

## Why it's safe

- Catalog changes in `en` and `es` only; the one code-path change is the mini tile reading `stat.text` instead of assembling it, and every producer that sets `value` now also sets `text`.
- `identity-section-stat-labels.test.ts` formats every unit-label key and every count-phrase key at counts 0 / 1 / 34 in every supported locale: unit labels must never contain the count, phrases must state it exactly once. It also pins the English Memory copy (`memory` / `memories`, `1 memory` / `34 memories`). Sensitivity-checked: the pre-fix `# memories` label trips it.
- Typecheck, ESLint and prettier pass on the touched files.
