### PR TITLE
feat(android): append paired self-hosted servers to the remembered list

### DIFF
--- a/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
@@ -332,6 +332,7 @@ public class MainActivity extends BridgeActivity {
             return;
         }
         SelfHostedServer.store(this, pendingConnect.server());
+        SelfHostedServer.append(this, pendingConnect.server(), pendingConnect.name());
         pendingConnect = null;
     }
 


### PR DESCRIPTION
## Summary
- finishPendingConnect now also appends the paired server (with its connect-link name label) to the remembered-server list
- Keeps Android's deferred-persist property: nothing joins the list until the pair page actually loads

Part of plan: android-assistant-parity.md (PR 3 of 5)