### PR TITLE
feat(android): SelfHostedServers plugin with in-app origin switching

### DIFF
--- a/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
@@ -32,6 +32,7 @@ public class MainActivity extends BridgeActivity {
     private static final long LAUNCH_SCREEN_LOAD_FALLBACK_MS = 2_000;
     private static final long LAUNCH_SCREEN_TIMEOUT_MS = 15_000;
     private static ConnectDeepLink recreationConnect;
+    private static String recreationRoutePath;
 
     private final Handler launchScreenHandler = new Handler(Looper.getMainLooper());
     private AlertDialog unreachableDialog;
@@ -104,6 +105,7 @@ public class MainActivity extends BridgeActivity {
         NativeFailureGuard.run("Unable to deliver the Android app link", this::deliverPendingAppLink);
         NativeFailureGuard.run("Unable to deliver the Android connect launch", this::deliverPendingConnect);
         NativeFailureGuard.run("Unable to deliver the Android new chat launch", this::deliverPendingNewChat);
+        NativeFailureGuard.run("Unable to deliver the Android route launch", this::deliverPendingRoute);
     }
 
     @Override
@@ -362,7 +364,7 @@ public class MainActivity extends BridgeActivity {
             return;
         }
         String destination = pendingConnect == null
-            ? effectiveServer.toASCIIString()
+            ? SelfHostedServer.appEntryUrl(effectiveServer).toASCIIString()
             : pendingConnect.pairPage().toASCIIString();
         bridge.getWebView().loadUrl(destination);
     }
@@ -379,11 +381,17 @@ public class MainActivity extends BridgeActivity {
      * so no field needs resetting beyond the pending launch state.
      */
     void recreateForServerChange() {
+        recreateForServerChange(null);
+    }
+
+    /** Same, plus an initial in-app route to load once the new origin is up. */
+    void recreateForServerChange(String routePath) {
         // A live voice session does not survive an origin swap.
         VoiceLiveActivityPlugin.clearStatus(this);
         pendingConnect = null;
         pendingNewChat = false;
         setRecreationConnect(null);
+        setRecreationRoutePath(routePath);
         setIntent(withoutData(getIntent()));
         recreate();
     }
@@ -423,6 +431,32 @@ public class MainActivity extends BridgeActivity {
         }
         pendingNewChat = false;
         bridge.getWebView().loadUrl(bridge.getServerUrl());
+    }
+
+    /**
+     * Load a route stashed by {@link #recreateForServerChange(String)}.
+     * bridge.getServerUrl() is already the app entry URL (override or baked);
+     * an unusable route silently falls back to the default entry load.
+     */
+    private void deliverPendingRoute() {
+        String path = takeRecreationRoutePath();
+        if (path == null || bridge == null || bridge.getServerUrl() == null) {
+            return;
+        }
+        String route = SelfHostedServer.appRoute(bridge.getServerUrl(), path);
+        if (route != null) {
+            bridge.getWebView().loadUrl(route);
+        }
+    }
+
+    private static synchronized String takeRecreationRoutePath() {
+        String path = recreationRoutePath;
+        recreationRoutePath = null;
+        return path;
+    }
+
+    private static synchronized void setRecreationRoutePath(String path) {
+        recreationRoutePath = path;
     }
 
     private static synchronized ConnectDeepLink takeRecreationConnect() {

--- a/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
@@ -126,6 +126,7 @@ public class MainActivity extends BridgeActivity {
         registerPlugin(AndroidPushRegistrationPlugin.class);
         registerPlugin(VoiceAudioSessionPlugin.class);
         registerPlugin(VoiceLiveActivityPlugin.class);
+        registerPlugin(SelfHostedServersPlugin.class);
         registerPlugin(SafePushNotificationsPlugin.class);
         super.load();
     }
@@ -367,12 +368,22 @@ public class MainActivity extends BridgeActivity {
     }
 
     private void useVellumCloud() {
-        VoiceLiveActivityPlugin.clearStatus(this);
         SelfHostedServer.clear(this);
+        effectiveServer = null;
+        recreateForServerChange();
+    }
+
+    /**
+     * Recreate onto whatever server slot {@link SelfHostedServer} now holds.
+     * The caller has already written the slot; onCreate re-reads everything,
+     * so no field needs resetting beyond the pending launch state.
+     */
+    void recreateForServerChange() {
+        // A live voice session does not survive an origin swap.
+        VoiceLiveActivityPlugin.clearStatus(this);
         pendingConnect = null;
         pendingNewChat = false;
         setRecreationConnect(null);
-        effectiveServer = null;
         setIntent(withoutData(getIntent()));
         recreate();
     }

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
@@ -210,6 +210,48 @@ final class SelfHostedServer {
         return active != null && url != null && canonicalString(active).equals(canonicalString(url));
     }
 
+    /**
+     * The SPA entry point for a server base, {@code <base>/assistant}. The
+     * ingress redirects a bare base to a prefixless {@code /assistant/},
+     * dropping a hosting prefix, so the segment is appended here instead,
+     * mirroring iOS {@code appEntryURL}. Stored identity keeps the bare base.
+     */
+    static URI appEntryUrl(URI base) {
+        String path = base.getRawPath();
+        if (path != null && path.endsWith("/assistant")) {
+            return base;
+        }
+        try {
+            return new URI(base.toASCIIString() + "/assistant");
+        } catch (URISyntaxException exception) {
+            return base;
+        }
+    }
+
+    /**
+     * A route under an entry URL: {@code <entry>/<path>}, the path's query
+     * kept verbatim. Null (caller falls back to the entry) when the path is
+     * unusable: blank, absolute, scheme-ful, fragment-carrying, or climbing.
+     */
+    static String appRoute(String entryUrl, String path) {
+        String trimmed = path == null ? "" : path.trim();
+        if (trimmed.isEmpty() || trimmed.startsWith("/") || trimmed.contains("://") || trimmed.contains("#")) {
+            return null;
+        }
+        int query = trimmed.indexOf('?');
+        String pathPart = query < 0 ? trimmed : trimmed.substring(0, query);
+        for (String segment : pathPart.split("/", -1)) {
+            if ("..".equals(segment)) {
+                return null;
+            }
+        }
+        String base = entryUrl;
+        while (base.endsWith("/")) {
+            base = base.substring(0, base.length() - 1);
+        }
+        return base + "/" + trimmed;
+    }
+
     /** The baked server.url from the bundled Capacitor config, or null when unreadable. */
     static String bakedServerUrl(Context context) {
         try {
@@ -348,7 +390,7 @@ final class SelfHostedServer {
         String source = readAsset(context, CONFIG_FILE);
         JSONObject root = new JSONObject(source);
         JSONObject serverConfig = root.getJSONObject("server");
-        serverConfig.put("url", server.toASCIIString());
+        serverConfig.put("url", appEntryUrl(server).toASCIIString());
 
         File directory = new File(context.getCacheDir(), CONFIG_DIRECTORY);
         if (!directory.exists() && !directory.mkdirs()) {

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServersPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServersPlugin.java
@@ -15,7 +15,8 @@ import java.util.List;
  * mirroring iOS's {@code SelfHostedServersPlugin.swift}. Per the skew rule in
  * {@code clients/web/docs/CAPACITOR.md}, one result shape encodes every
  * state: empty state resolves with an empty list and nulls; only an
- * {@code add}/{@code switchTo} url failing {@link SelfHostedServer#validate}
+ * {@code add}/{@code switchTo}/{@code switchToPath} url failing
+ * {@link SelfHostedServer#validate} (or a malformed switchToPath path)
  * rejects.
  */
 @CapacitorPlugin(name = "SelfHostedServers")
@@ -74,7 +75,7 @@ public class SelfHostedServersPlugin extends Plugin {
         // down, so a web caller awaiting this call would otherwise never settle.
         call.resolve(okResult());
         if (removedActive) {
-            scheduleRecreate();
+            scheduleRecreate(null);
         }
     }
 
@@ -87,28 +88,59 @@ public class SelfHostedServersPlugin extends Plugin {
      */
     @PluginMethod
     public void switchTo(PluginCall call) {
+        if (!applySwitchUrl(call)) {
+            return;
+        }
+        // Same ordering constraint as remove: settle the call, then recreate.
+        call.resolve(okResult());
+        scheduleRecreate(null);
+    }
+
+    /**
+     * switchTo plus an initial in-app route under the destination's entry
+     * URL, mirroring iOS. An invalid path rejects before any state changes.
+     */
+    @PluginMethod
+    public void switchToPath(PluginCall call) {
+        String raw = call.getString("path");
+        String path = raw == null ? "" : raw.trim();
+        if (path.isEmpty() || path.startsWith("/") || path.contains("://") || path.contains("#")) {
+            call.reject("invalid path");
+            return;
+        }
+        if (!applySwitchUrl(call)) {
+            return;
+        }
+        call.resolve(okResult());
+        scheduleRecreate(path);
+    }
+
+    /**
+     * Shared switchTo/switchToPath url handling: absent or empty returns to
+     * the baked origin; a valid url is stored and remembered nameless,
+     * keeping any stored label; invalid rejects and returns false.
+     */
+    private boolean applySwitchUrl(PluginCall call) {
         String raw = call.getString("url");
         String trimmed = raw == null ? "" : raw.trim();
         if (trimmed.isEmpty()) {
             SelfHostedServer.clear(getContext());
-        } else {
-            URI url = SelfHostedServer.validate(trimmed);
-            if (url == null) {
-                call.reject("invalid url");
-                return;
-            }
-            SelfHostedServer.store(getContext(), url);
-            SelfHostedServer.append(getContext(), url, null);
+            return true;
         }
-        // Same ordering constraint as remove: settle the call, then recreate.
-        call.resolve(okResult());
-        scheduleRecreate();
+        URI url = SelfHostedServer.validate(trimmed);
+        if (url == null) {
+            call.reject("invalid url");
+            return false;
+        }
+        SelfHostedServer.store(getContext(), url);
+        SelfHostedServer.append(getContext(), url, null);
+        return true;
     }
 
-    private void scheduleRecreate() {
+    private void scheduleRecreate(String routePath) {
         Activity activity = getActivity();
         if (activity instanceof MainActivity mainActivity) {
-            activity.runOnUiThread(mainActivity::recreateForServerChange);
+            activity.runOnUiThread(() -> mainActivity.recreateForServerChange(routePath));
         }
     }
 

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServersPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServersPlugin.java
@@ -1,0 +1,118 @@
+package ai.vellum.assistant;
+
+import android.app.Activity;
+import com.getcapacitor.JSArray;
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+import java.net.URI;
+import java.util.List;
+
+/**
+ * Exposes the remembered self-hosted server list to the web chooser,
+ * mirroring iOS's {@code SelfHostedServersPlugin.swift}. Per the skew rule in
+ * {@code clients/web/docs/CAPACITOR.md}, one result shape encodes every
+ * state: empty state resolves with an empty list and nulls; only an
+ * {@code add}/{@code switchTo} url failing {@link SelfHostedServer#validate}
+ * rejects.
+ */
+@CapacitorPlugin(name = "SelfHostedServers")
+public class SelfHostedServersPlugin extends Plugin {
+
+    @PluginMethod
+    public void list(PluginCall call) {
+        URI active = SelfHostedServer.configured(getContext());
+        call.resolve(
+            listPayload(
+                SelfHostedServer.servers(getContext()),
+                active == null ? null : active.toASCIIString(),
+                SelfHostedServer.bakedServerUrl(getContext())
+            )
+        );
+    }
+
+    static JSObject listPayload(List<SelfHostedServer.Entry> servers, String activeUrl, String bakedUrl) {
+        JSArray items = new JSArray();
+        for (SelfHostedServer.Entry entry : servers) {
+            JSObject item = new JSObject();
+            if (entry.name != null) {
+                item.put("name", entry.name);
+            }
+            item.put("url", entry.url);
+            items.put(item);
+        }
+        JSObject payload = new JSObject();
+        payload.put("servers", items);
+        payload.put("activeUrl", activeUrl == null ? JSObject.NULL : activeUrl);
+        payload.put("bakedUrl", bakedUrl == null ? JSObject.NULL : bakedUrl);
+        return payload;
+    }
+
+    @PluginMethod
+    public void add(PluginCall call) {
+        URI url = SelfHostedServer.validate(call.getString("url"));
+        if (url == null) {
+            call.reject("invalid url");
+            return;
+        }
+        SelfHostedServer.append(getContext(), url, call.getString("name"));
+        call.resolve(okResult());
+    }
+
+    /**
+     * Forgetting a url that is not (or cannot be) in the list is a no-op, so
+     * this never rejects. Removing the active server clears the active slot,
+     * so the shell recreates back to the baked origin like {@code switchTo({})}.
+     */
+    @PluginMethod
+    public void remove(PluginCall call) {
+        URI url = SelfHostedServer.validate(call.getString("url"));
+        boolean removedActive = url != null && SelfHostedServer.removeEntry(getContext(), url);
+        // Resolve before scheduling the recreate: recreation tears the bridge
+        // down, so a web caller awaiting this call would otherwise never settle.
+        call.resolve(okResult());
+        if (removedActive) {
+            scheduleRecreate();
+        }
+    }
+
+    /**
+     * Switching to a url implies remembering it, so the target is appended to
+     * the list alongside the active-slot write (nameless, keeping any stored
+     * label). An absent or empty url returns to the baked origin. Always
+     * recreates, even onto the same origin, matching iOS's unconditional
+     * reload.
+     */
+    @PluginMethod
+    public void switchTo(PluginCall call) {
+        String raw = call.getString("url");
+        String trimmed = raw == null ? "" : raw.trim();
+        if (trimmed.isEmpty()) {
+            SelfHostedServer.clear(getContext());
+        } else {
+            URI url = SelfHostedServer.validate(trimmed);
+            if (url == null) {
+                call.reject("invalid url");
+                return;
+            }
+            SelfHostedServer.store(getContext(), url);
+            SelfHostedServer.append(getContext(), url, null);
+        }
+        // Same ordering constraint as remove: settle the call, then recreate.
+        call.resolve(okResult());
+        scheduleRecreate();
+    }
+
+    private void scheduleRecreate() {
+        Activity activity = getActivity();
+        if (activity instanceof MainActivity mainActivity) {
+            activity.runOnUiThread(mainActivity::recreateForServerChange);
+        }
+    }
+
+    private static JSObject okResult() {
+        return new JSObject().put("ok", true);
+    }
+}

--- a/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
@@ -234,6 +234,43 @@ public class SelfHostedServerTest {
     }
 
     @Test
+    public void appEntryUrlAppendsTheAssistantSegmentPreservingPrefixes() {
+        assertEquals(
+            "https://example.com/assistant-123/assistant",
+            SelfHostedServer.appEntryUrl(SelfHostedServer.validate("https://example.com/assistant-123")).toASCIIString()
+        );
+        assertEquals(
+            "https://example.com/assistant",
+            SelfHostedServer.appEntryUrl(SelfHostedServer.validate("https://example.com")).toASCIIString()
+        );
+        assertEquals(
+            "https://example.com/assistant",
+            SelfHostedServer.appEntryUrl(SelfHostedServer.validate("https://example.com/assistant")).toASCIIString()
+        );
+    }
+
+    @Test
+    public void appRouteJoinsRelativePathsKeepingQueries() {
+        assertEquals(
+            "https://host/assistant-123/assistant/select-assistant?noAutoSkip=1",
+            SelfHostedServer.appRoute("https://host/assistant-123/assistant", "select-assistant?noAutoSkip=1")
+        );
+        assertEquals(
+            "https://host/assistant/pair",
+            SelfHostedServer.appRoute("https://host/assistant/", "pair")
+        );
+    }
+
+    @Test
+    public void appRouteRejectsAbsoluteSchemefulFragmentClimbingAndBlankPaths() {
+        assertNull(SelfHostedServer.appRoute("https://host/assistant", "/absolute"));
+        assertNull(SelfHostedServer.appRoute("https://host/assistant", "https://evil.example/route"));
+        assertNull(SelfHostedServer.appRoute("https://host/assistant", "pair#fragment"));
+        assertNull(SelfHostedServer.appRoute("https://host/assistant", "a/../b"));
+        assertNull(SelfHostedServer.appRoute("https://host/assistant", "   "));
+    }
+
+    @Test
     public void parsesBakedServerUrlFromCapacitorConfig() {
         assertEquals(
             "https://www.vellum.ai/assistant",

--- a/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServersPluginTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServersPluginTest.java
@@ -1,0 +1,69 @@
+package ai.vellum.assistant;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import com.getcapacitor.JSObject;
+import java.util.Arrays;
+import java.util.Collections;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Test;
+
+public class SelfHostedServersPluginTest {
+    @Test
+    public void emptyStateResolvesEmptyListAndJsonNulls() throws JSONException {
+        JSObject payload = SelfHostedServersPlugin.listPayload(Collections.emptyList(), null, null);
+
+        assertEquals(0, payload.getJSONArray("servers").length());
+        assertTrue(payload.has("activeUrl"));
+        assertTrue(payload.isNull("activeUrl"));
+        assertSame(JSONObject.NULL, payload.get("activeUrl"));
+        assertTrue(payload.has("bakedUrl"));
+        assertTrue(payload.isNull("bakedUrl"));
+        assertSame(JSONObject.NULL, payload.get("bakedUrl"));
+    }
+
+    @Test
+    public void namedEntriesCarryTheNameKey() throws JSONException {
+        JSObject payload = SelfHostedServersPlugin.listPayload(
+            Collections.singletonList(new SelfHostedServer.Entry("Work", "https://work.example.com")),
+            "https://work.example.com",
+            "https://app.vellum.ai"
+        );
+
+        JSONArray servers = payload.getJSONArray("servers");
+        assertEquals(1, servers.length());
+        JSONObject entry = servers.getJSONObject(0);
+        assertEquals("Work", entry.getString("name"));
+        assertEquals("https://work.example.com", entry.getString("url"));
+        assertEquals("https://work.example.com", payload.getString("activeUrl"));
+        assertEquals("https://app.vellum.ai", payload.getString("bakedUrl"));
+    }
+
+    @Test
+    public void unnamedEntriesOmitTheNameKeyEntirely() throws JSONException {
+        JSObject payload = SelfHostedServersPlugin.listPayload(
+            Arrays.asList(
+                new SelfHostedServer.Entry(null, "https://one.example.com"),
+                new SelfHostedServer.Entry("Two", "https://two.example.com/base")
+            ),
+            null,
+            "https://app.vellum.ai"
+        );
+
+        JSONArray servers = payload.getJSONArray("servers");
+        assertEquals(2, servers.length());
+        JSONObject unnamed = servers.getJSONObject(0);
+        assertFalse(unnamed.has("name"));
+        assertEquals("https://one.example.com", unnamed.getString("url"));
+        JSONObject named = servers.getJSONObject(1);
+        assertEquals("Two", named.getString("name"));
+        assertEquals("https://two.example.com/base", named.getString("url"));
+        assertTrue(payload.isNull("activeUrl"));
+        assertEquals("https://app.vellum.ai", payload.getString("bakedUrl"));
+    }
+}


### PR DESCRIPTION
- Adds `SelfHostedServersPlugin` (`list`/`add`/`remove`/`switchTo`) over the PR-1 `SelfHostedServer` list store, mirroring iOS's `SelfHostedServersPlugin.swift` and the bridge contract in `clients/web/docs/CAPACITOR.md` § Self-hosted origins: one result shape encodes every state, and only an `add`/`switchTo` url failing `SelfHostedServer.validate` rejects with `invalid url`.
- `list` resolves `{ servers: [{name?, url}], activeUrl, bakedUrl }` with JSON nulls for absent active/baked urls and the `name` key omitted (never null) for unnamed entries; payload construction lives in a unit-tested `listPayload` helper.
- `remove` of a non-listed/invalid url is a no-op that still resolves `{ok: true}`; removing the active server clears the slot and recreates back to the baked origin. `switchTo` writes the slot, appends namelessly (switching implies remembering; keeps any stored label), and always recreates, even onto the same origin. Both resolve BEFORE scheduling `recreate()` — recreation tears the bridge down, so an awaiting web caller would otherwise never settle.
- `MainActivity` gains a package-private `recreateForServerChange()` (voice-status clear + pending-launch reset + `recreate()`); `useVellumCloud()` now delegates to it after clearing the slot, preserving its exact behavior.
- Plain JUnit 4 tests cover `listPayload` shapes against real org.json semantics (name-key omission, `JSONObject.NULL` round-trip, empty state).

Manual QA (needs a device/emulator): with the `vellum:ff:assistant-switcher` flag override on, the web chooser on Android must list natively-stored servers, show the "Vellum Cloud" card while self-hosted (sourced from `bakedUrl`), and switch origins without leaving the app (a brief relaunch flash from `recreate()` is expected). Also verify a path-prefixed base (e.g. `https://host/assistant-123`) still lands on the SPA after `switchTo` — the shell loads the config's `server.url` as-is; if the ingress bare-/ redirect drops the prefix, follow iOS's fix of loading `<base>/assistant` explicitly (`MyViewController.swift` `appEntryURL`).

Part of plan: android-assistant-parity.md (PR 4 of 5)