### PR TITLE
fix(desktop): inline zod so sandboxed preloads keep the vellum bridge

### DIFF
--- a/clients/macos/electron.vite.config.ts
+++ b/clients/macos/electron.vite.config.ts
@@ -21,11 +21,16 @@ import { defineConfig, externalizeDepsPlugin } from "electron-vite";
 // Workspace dependencies such as `@vellumai/local-mode` and
 // `@vellumai/electron-utils` export TypeScript source with no build step.
 // Inlining lets Rollup compile their source into the bundle.
+//
+// `zod` must be inlined too: `@vellumai/ipc-contract` imports it at module
+// scope, and the sandboxed preload can't `require("zod")` at runtime. An
+// external zod kills the whole preload script (no `window.vellum` bridge).
 const DEPS_TO_INLINE = [
   "electron-log",
   "electron-store",
   "electron-updater",
   "conf",
+  "zod",
   "@vellumai/electron-utils",
   "@vellumai/electron-desktop",
   "@vellumai/ipc-contract",

--- a/clients/macos/electron.vite.config.ts
+++ b/clients/macos/electron.vite.config.ts
@@ -4,39 +4,21 @@ import path from "node:path";
 
 import { defineConfig, externalizeDepsPlugin } from "electron-vite";
 
+import { SHARED_DESKTOP_INLINE_DEPS } from "../../packages/electron-desktop/src/inline-deps";
+
 // Reference: https://electron-vite.org/config/
 //
 // No renderer config: the renderer is the clients/web/ Vite project, served in
 // dev via http://localhost:5173 and in prod via a custom `app://` protocol.
 //
 // Dependencies that must be bundled inline rather than externalized as
-// runtime `require(...)` calls.
-//
-// `electron-store` (and its `conf` parent) are ESM-only. electron-vite's
-// default externalize plugin would emit `require("electron-store")` in the
-// CJS main bundle, which returns the module namespace rather than the
-// default export and breaks `new Store(...)`. Bundling their ESM source
-// inline lets Rollup handle the CJS interop correctly at bundle time.
-//
-// Workspace dependencies such as `@vellumai/local-mode` and
-// `@vellumai/electron-utils` export TypeScript source with no build step.
-// Inlining lets Rollup compile their source into the bundle.
-//
-// `zod` must be inlined too: `@vellumai/ipc-contract` imports it at module
-// scope, and the sandboxed preload can't `require("zod")` at runtime. An
-// external zod kills the whole preload script (no `window.vellum` bridge).
+// runtime `require(...)` calls. The cross-client rules (and the sandboxed
+// preload rationale) live in the shared list; only macOS-specific deps are
+// added here. Guarded by scripts/preload-externals.test.ts.
 const DEPS_TO_INLINE = [
-  "electron-log",
-  "electron-store",
+  ...SHARED_DESKTOP_INLINE_DEPS,
   "electron-updater",
-  "conf",
-  "zod",
-  "@vellumai/electron-utils",
-  "@vellumai/electron-desktop",
-  "@vellumai/ipc-contract",
-  "@vellumai/local-mode",
   "@vellumai/native-sidecar",
-  "@vellumai/environments",
 ];
 
 // Resolved at config-evaluation time and inlined into the main bundle via

--- a/clients/macos/scripts/preload-externals.test.ts
+++ b/clients/macos/scripts/preload-externals.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "bun:test";
+import path from "node:path";
+
+import {
+  ALLOWED_PRELOAD_EXTERNALS,
+  buildPreloadAndScanExternals,
+} from "../../../packages/electron-desktop/src/preload-externals";
+
+// Regression guard: a dependency reachable from the preload but missing from
+// DEPS_TO_INLINE becomes a bare require() the sandboxed preload can't
+// resolve, silently killing the whole window.vellum bridge.
+test("built preload bundle externalizes only sandbox-safe modules", async () => {
+  const externals = await buildPreloadAndScanExternals(
+    path.join(import.meta.dir, ".."),
+  );
+  expect(externals).toEqual(ALLOWED_PRELOAD_EXTERNALS);
+}, 180_000);

--- a/clients/windows/electron.vite.config.ts
+++ b/clients/windows/electron.vite.config.ts
@@ -13,10 +13,15 @@ import { resolveShortBuildCommitSha } from "./scripts/build-metadata";
 // Workspace dependencies such as `@vellumai/local-mode` and
 // `@vellumai/electron-utils` export TypeScript source with no build step.
 // Inlining lets Rollup compile their source into the bundle.
+//
+// `zod` must be inlined too: `@vellumai/ipc-contract` imports it at module
+// scope, and the sandboxed preload can't `require("zod")` at runtime. An
+// external zod kills the whole preload script (no `window.vellum` bridge).
 const DEPS_TO_INLINE = [
   "electron-log",
   "electron-store",
   "conf",
+  "zod",
   "@vellumai/electron-utils",
   "@vellumai/electron-desktop",
   "@vellumai/ipc-contract",

--- a/clients/windows/electron.vite.config.ts
+++ b/clients/windows/electron.vite.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig, externalizeDepsPlugin } from "electron-vite";
 
+import { SHARED_DESKTOP_INLINE_DEPS } from "../../packages/electron-desktop/src/inline-deps";
+
 import { resolveShortBuildCommitSha } from "./scripts/build-metadata";
 
 // Reference: https://electron-vite.org/config/
@@ -8,26 +10,10 @@ import { resolveShortBuildCommitSha } from "./scripts/build-metadata";
 // dev via http://localhost:5173 and in prod via a custom `app://` protocol.
 //
 // Dependencies that must be bundled inline rather than externalized as
-// runtime `require(...)` calls.
-//
-// Workspace dependencies such as `@vellumai/local-mode` and
-// `@vellumai/electron-utils` export TypeScript source with no build step.
-// Inlining lets Rollup compile their source into the bundle.
-//
-// `zod` must be inlined too: `@vellumai/ipc-contract` imports it at module
-// scope, and the sandboxed preload can't `require("zod")` at runtime. An
-// external zod kills the whole preload script (no `window.vellum` bridge).
-const DEPS_TO_INLINE = [
-  "electron-log",
-  "electron-store",
-  "conf",
-  "zod",
-  "@vellumai/electron-utils",
-  "@vellumai/electron-desktop",
-  "@vellumai/ipc-contract",
-  "@vellumai/local-mode",
-  "@vellumai/environments",
-];
+// runtime `require(...)` calls. The cross-client rules (and the sandboxed
+// preload rationale) live in the shared list; Windows adds nothing yet.
+// Guarded by scripts/preload-externals.test.ts.
+const DEPS_TO_INLINE = [...SHARED_DESKTOP_INLINE_DEPS];
 
 const BUILD_DEFINES = {
   __VELLUM_BUILD_SHA__: JSON.stringify(resolveShortBuildCommitSha()),

--- a/clients/windows/scripts/preload-externals.test.ts
+++ b/clients/windows/scripts/preload-externals.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "bun:test";
+import path from "node:path";
+
+import {
+  ALLOWED_PRELOAD_EXTERNALS,
+  buildPreloadAndScanExternals,
+} from "../../../packages/electron-desktop/src/preload-externals";
+
+// Regression guard: a dependency reachable from the preload but missing from
+// DEPS_TO_INLINE becomes a bare require() the sandboxed preload can't
+// resolve, silently killing the whole window.vellum bridge.
+test("built preload bundle externalizes only sandbox-safe modules", async () => {
+  const externals = await buildPreloadAndScanExternals(
+    path.join(import.meta.dir, ".."),
+  );
+  expect(externals).toEqual(ALLOWED_PRELOAD_EXTERNALS);
+}, 180_000);

--- a/packages/electron-desktop/src/inline-deps.ts
+++ b/packages/electron-desktop/src/inline-deps.ts
@@ -1,0 +1,27 @@
+/**
+ * Dependencies every desktop client's electron-vite config must bundle inline
+ * instead of externalizing as runtime `require(...)` calls.
+ *
+ * - `electron-store` and `conf` are ESM-only: an externalized CJS
+ *   `require(...)` returns the module namespace and breaks `new Store(...)`.
+ * - `zod` is imported at module scope by `@vellumai/ipc-contract`, which the
+ *   preload bundles pull in. The sandboxed preload can only require
+ *   `electron`, so one bare external require kills the whole preload script
+ *   and `window.vellum` is never exposed (see `preload-externals.ts`).
+ * - The `@vellumai/*` workspace packages ship raw TypeScript with no build
+ *   step; inlining lets Rollup compile their source into the bundle.
+ *
+ * Clients import this RELATIVELY (not via the package entry): electron-vite
+ * loads configs under Node, which cannot require raw-TS package subpaths.
+ */
+export const SHARED_DESKTOP_INLINE_DEPS = [
+  "electron-log",
+  "electron-store",
+  "conf",
+  "zod",
+  "@vellumai/electron-utils",
+  "@vellumai/electron-desktop",
+  "@vellumai/ipc-contract",
+  "@vellumai/local-mode",
+  "@vellumai/environments",
+];

--- a/packages/electron-desktop/src/preload-externals.ts
+++ b/packages/electron-desktop/src/preload-externals.ts
@@ -1,0 +1,45 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+/**
+ * Modules a sandboxed preload is allowed to `require(...)` at runtime.
+ * Electron's sandbox polyfills only a tiny set; anything else throws at load
+ * and kills the whole preload script, so `window.vellum` is never exposed
+ * (the renderer then loses window dragging, traffic-light clearance, and
+ * every other bridge-gated feature). Keep this to `electron` unless a new
+ * sandbox-safe module is deliberately added.
+ */
+export const ALLOWED_PRELOAD_EXTERNALS = ["electron"];
+
+/** Distinct module ids from bare `require("...")` calls in a built bundle. */
+export const scanExternalRequires = (bundleSource: string): string[] => {
+  const externals = new Set<string>();
+  for (const match of bundleSource.matchAll(/\brequire\((["'])([^"']+)\1\)/g)) {
+    externals.add(match[2]);
+  }
+  return [...externals].sort();
+};
+
+/**
+ * Build a desktop client with electron-vite and return the external requires
+ * left in its emitted preload bundle. A dependency missing from the client's
+ * `DEPS_TO_INLINE` shows up here, so tests can fail it before it ships.
+ */
+export const buildPreloadAndScanExternals = async (
+  clientRoot: string,
+): Promise<string[]> => {
+  const proc = Bun.spawn(["bunx", "electron-vite", "build"], {
+    cwd: clientRoot,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  if ((await proc.exited) !== 0) {
+    const stderr = await new Response(proc.stderr).text();
+    throw new Error(`electron-vite build failed in ${clientRoot}:\n${stderr}`);
+  }
+  const bundle = await readFile(
+    path.join(clientRoot, "out/preload/index.js"),
+    "utf8",
+  );
+  return scanExternalRequires(bundle);
+};


### PR DESCRIPTION
## Summary
- Add `zod` to `DEPS_TO_INLINE` in `clients/macos/electron.vite.config.ts` and `clients/windows/electron.vite.config.ts` so the preload bundles stop emitting a bare `require("zod")`
- The preload runs sandboxed (`hardenedWebPreferences` sets `sandbox: true`), so that external require fails at load (`Error: module not found: zod` in vellum.log) and the entire preload dies: `window.vellum` is never exposed, `detectElectronHostOS()` returns null, and the renderer loses the title-bar drag region and the 80px macOS traffic-light clearance
- Verified by rebuilding both clients: `out/preload/index.js` now externalizes only `require("electron")`

## Original prompt
On the windoze-parity-step-1 branch the macOS desktop app could no longer be dragged by its title bar, and the traffic lights overlapped the sidebar toggle and search buttons. Investigation traced both symptoms to one regression: the branch's shared preload refactor imports channel constants from `@vellumai/ipc-contract`, whose single entry point re-exports `schemas.ts` with its top-level zod import, while zod stayed externalized in the electron-vite config. The ask was to find the regression and fix it via /do in a separate worktree, with the PR targeting windoze-parity-step-1 rather than main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40738" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->