### PR TITLE
fix(providers): classify OpenAI per-part "string too long" 400 as context overflow

### DIFF
--- a/assistant/src/providers/__tests__/context-overflow-error.test.ts
+++ b/assistant/src/providers/__tests__/context-overflow-error.test.ts
@@ -239,6 +239,20 @@ describe("detectOpenAICompatibleContextOverflow", () => {
     expect(detectOpenAICompatibleContextOverflow(err)).toBeNull();
   });
 
+  test("matches OpenAI's per-part 10MiB string_above_max_length 400", () => {
+    const err = buildOpenAIApiError(400, {
+      message:
+        "Invalid 'input[191].content[1].text': string too long. Expected a string with maximum length 10485760, but got a string with length 11436754 instead.",
+      type: "invalid_request_error",
+      code: "string_above_max_length",
+    });
+    const out = detectOpenAICompatibleContextOverflow(err);
+    expect(out).not.toBeNull();
+    // Byte lengths in this message must not be misread as token counts.
+    expect(out?.actualTokens).toBeUndefined();
+    expect(out?.maxTokens).toBeUndefined();
+  });
+
   test("matches 'too many input tokens' variant emitted by some OpenAI-compatible providers", () => {
     const err = buildOpenAIApiError(400, {
       message: "too many input tokens: 250000",

--- a/assistant/src/providers/__tests__/context-overflow-error.test.ts
+++ b/assistant/src/providers/__tests__/context-overflow-error.test.ts
@@ -253,6 +253,16 @@ describe("detectOpenAICompatibleContextOverflow", () => {
     expect(out?.maxTokens).toBeUndefined();
   });
 
+  test("returns null for string_above_max_length on a non-content field", () => {
+    const err = buildOpenAIApiError(400, {
+      message:
+        "Invalid 'tools[0].function.description': string too long. Expected a string with maximum length 1048576, but got a string with length 2000000 instead.",
+      type: "invalid_request_error",
+      code: "string_above_max_length",
+    });
+    expect(detectOpenAICompatibleContextOverflow(err)).toBeNull();
+  });
+
   test("matches 'too many input tokens' variant emitted by some OpenAI-compatible providers", () => {
     const err = buildOpenAIApiError(400, {
       message: "too many input tokens: 250000",

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -75,14 +75,17 @@ export function detectOpenAICompatibleContextOverflow(
   const code = error.code;
   const codeMatches =
     typeof code === "string" &&
-    /context_length_exceeded|context_window_exceeded|input_too_long|prompt_too_long/i.test(
+    /context_length_exceeded|context_window_exceeded|input_too_long|prompt_too_long|string_above_max_length/i.test(
       code,
     );
   // Include the normalized upstream message: the SDK's `error.message` is often
   // generic ("400 Provider returned error") while the real signal is in the body.
   const message = `${error.message ?? ""} ${extraMessage ?? ""}`;
+  // "string too long" / string_above_max_length: OpenAI's per-content-part
+  // 10 MiB cap. Not a token overflow, but the overflow ladder's media
+  // stubbing is what shrinks the oversized part, so route it there.
   const messageMatches =
-    /context.?length.?exceeded|context.?window.?exceeded|prompt.?is.?too.?long|prompt_too_long|input.?too.?long|too.?many.?(?:input.?)?tokens|maximum.?context/i.test(
+    /context.?length.?exceeded|context.?window.?exceeded|prompt.?is.?too.?long|prompt_too_long|input.?too.?long|too.?many.?(?:input.?)?tokens|maximum.?context|string.?too.?long|string_above_max_length/i.test(
       message,
     );
   if (!codeMatches && !messageMatches) {

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -75,20 +75,27 @@ export function detectOpenAICompatibleContextOverflow(
   const code = error.code;
   const codeMatches =
     typeof code === "string" &&
-    /context_length_exceeded|context_window_exceeded|input_too_long|prompt_too_long|string_above_max_length/i.test(
+    /context_length_exceeded|context_window_exceeded|input_too_long|prompt_too_long/i.test(
       code,
     );
   // Include the normalized upstream message: the SDK's `error.message` is often
   // generic ("400 Provider returned error") while the real signal is in the body.
   const message = `${error.message ?? ""} ${extraMessage ?? ""}`;
-  // "string too long" / string_above_max_length: OpenAI's per-content-part
-  // 10 MiB cap. Not a token overflow, but the overflow ladder's media
-  // stubbing is what shrinks the oversized part, so route it there.
   const messageMatches =
-    /context.?length.?exceeded|context.?window.?exceeded|prompt.?is.?too.?long|prompt_too_long|input.?too.?long|too.?many.?(?:input.?)?tokens|maximum.?context|string.?too.?long|string_above_max_length/i.test(
+    /context.?length.?exceeded|context.?window.?exceeded|prompt.?is.?too.?long|prompt_too_long|input.?too.?long|too.?many.?(?:input.?)?tokens|maximum.?context/i.test(
       message,
     );
-  if (!codeMatches && !messageMatches) {
+  // string_above_max_length is OpenAI's generic oversized-string validation
+  // code, so only treat it as overflow when the error points at a message
+  // content part (e.g. "Invalid 'input[191].content[1].text': string too
+  // long" — OpenAI's per-part 10 MiB cap). The overflow ladder can shrink
+  // message content (media stubbing collapses a file's extracted_text to a
+  // preview) but cannot fix other oversized fields like tool definitions.
+  const oversizedContentPart =
+    /string.?too.?long|string_above_max_length/i.test(
+      `${code ?? ""} ${message}`,
+    ) && /\b(?:input|messages)\[\d+\]\.content/i.test(message);
+  if (!codeMatches && !messageMatches && !oversizedContentPart) {
     return null;
   }
   // OpenAI-compatible providers rarely report usable token counts; best-effort extract.


### PR DESCRIPTION
## Summary
- `detectOpenAICompatibleContextOverflow` now matches `string_above_max_length` (error code) and "string too long" (message), so OpenAI's per-content-part 10MiB cap throws `ContextOverflowError` and enters the overflow recovery ladder instead of surfacing as a generic `PROVIDER_API` 400.
- The ladder's media-stubbing rung is the existing mechanism that collapses an oversized `file.extracted_text` to a preview, so already-wedged conversations recover on their next turn.
- Adds a test with the real reported error body, also asserting the byte lengths (10485760/11436754) are not misparsed as token counts.

## Original prompt
A user hit `HTTP 400: Invalid 'input[191].content[1].text': string too long. Expected a string with maximum length 10485760, but got a string with length 11436754` — a file attachment whose extracted text was inlined verbatim as one `input_text` part. Investigation showed every truncation mechanism keys on `tool_result` blocks, the overflow detector had no pattern for this 400, and the persisted oversized message permanently wedged the conversation (every turn resends it; compaction hits the same 400 and trips its circuit breaker). This PR is the classification fix that unwedges affected conversations; ingress capping of `extracted_text` is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CzL87sV9vwccCwMK3ADSHx
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->