### PR TITLE
docs: document Android self-hosted server list and switching

### DIFF
--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -112,15 +112,35 @@ vellum-assistant-dev://connect?url=https%3A%2F%2Fassistant.example.com&code=devi
 ```
 
 The production and staging builds use their matching auth schemes from the
-Build Variants table. Scanning a connect link switches the native shell to the
-validated server, opens `<server>/assistant/pair`, and keeps an existing server
-path prefix intact. Cold and warm app launches use the same route.
+Build Variants table. An optional `name=<label>` parameter supplies a
+user-facing label; the value is trimmed and a blank label is treated as
+absent. Scanning a connect link switches the native shell to the validated
+server, opens `<server>/assistant/pair`, and keeps an existing server path
+prefix intact. Cold and warm app launches use the same route.
 
-Only the validated server base is saved after the pairing page loads. The
-one-time device code is kept out of app preferences and the generated
-Capacitor configuration. HTTPS is required except for `localhost`, `127.0.0.1`,
-and the Android emulator host alias `10.0.2.2`. Use `adb reverse` when a physical
-development device needs to reach a service through `localhost`.
+Only the validated server base is saved after the pairing page loads — the
+same deferred write appends the server, with its label, to the remembered
+list. The one-time device code is kept out of app preferences and the
+generated Capacitor configuration. HTTPS is required except for `localhost`,
+`127.0.0.1`, and the Android emulator host alias `10.0.2.2`. Use `adb reverse`
+when a physical development device needs to reach a service through
+`localhost`.
+
+Paired servers accumulate in a remembered list, stored as JSON `{name?, url}`
+entries in the same `self_hosted_server` SharedPreferences file as the active
+server. Entries are keyed by the canonical URL the web chooser's
+`normalizeOriginUrl` also computes — scheme-default ports collapse, trailing
+slashes are stripped, and percent-escape casing and interior duplicate
+separators are preserved — so both sides agree on which strings mean the same
+server.
+
+The web assistant chooser is the management surface. The `SelfHostedServers`
+Capacitor plugin exposes the list to it and handles switch and forget
+(`list`/`add`/`remove`/`switchTo`/`switchToPath`). Switching recreates the
+activity so Capacitor starts on a configuration rebuilt around the new
+`server.url`; that configuration loads `<base>/assistant`, so a hosting path
+prefix survives the ingress redirect that would otherwise drop it. Forgetting
+the active server returns the shell to Vellum Cloud the same way.
 
 If Android terminates the app before the pairing page loads, scan the connect
 link again. The shell intentionally does not save the one-time code for process
@@ -215,6 +235,7 @@ clients/
     │       │   ├── NativeLaunchScreenPlugin.java
     │       │   ├── BiometricTokenStore.java
     │       │   ├── SelfHostedServer.java
+    │       │   ├── SelfHostedServersPlugin.java
     │       │   ├── VoiceAudioSessionPlugin.java
     │       │   ├── VoiceDeepLink.java
     │       │   ├── VoiceLiveActivityPlugin.java

--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -118,7 +118,7 @@ absent. Scanning a connect link switches the native shell to the validated
 server, opens `<server>/assistant/pair`, and keeps an existing server path
 prefix intact. Cold and warm app launches use the same route.
 
-Only the validated server base is saved after the pairing page loads — the
+Only the validated server base is saved after the pairing page loads; the
 same deferred write appends the server, with its label, to the remembered
 list. The one-time device code is kept out of app preferences and the
 generated Capacitor configuration. HTTPS is required except for `localhost`,
@@ -129,10 +129,13 @@ when a physical development device needs to reach a service through
 Paired servers accumulate in a remembered list, stored as JSON `{name?, url}`
 entries in the same `self_hosted_server` SharedPreferences file as the active
 server. Entries are keyed by the canonical URL the web chooser's
-`normalizeOriginUrl` also computes — scheme-default ports collapse, trailing
+`normalizeOriginUrl` also computes (scheme-default ports collapse, trailing
 slashes are stripped, and percent-escape casing and interior duplicate
-separators are preserved — so both sides agree on which strings mean the same
-server.
+separators are preserved), so both sides agree on which strings mean the same
+HTTPS server. The cleartext development hosts are the exception: the web
+normalizer rejects every non-HTTPS URL, so an `http://localhost`-style server
+stays in the native list and remains switchable through a connect link, but
+never surfaces as a chooser card.
 
 The web assistant chooser is the management surface. The `SelfHostedServers`
 Capacitor plugin exposes the list to it and handles switch and forget

--- a/clients/web/docs/CAPACITOR.md
+++ b/clients/web/docs/CAPACITOR.md
@@ -280,7 +280,7 @@ The bridge contract:
 | `add({url, name?})` | `{ ok }` | Deduped by canonical url. A nameless re-add keeps the stored label |
 | `remove({url})` | `{ ok }` | Forgetting the active url also clears the active slot, so the shell returns to the baked origin |
 | `switchTo({url?})` | `{ ok }` | Swaps the active slot and reloads the shell onto it (see the per-surface list below). An absent or empty `url` returns to the baked origin |
-| `switchToPath({url?, path})` | `{ ok }` | `switchTo` plus an initial in-app route loaded relative to the destination's app entry URL. A malformed `path` (empty, absolute, scheme-ful, or carrying a fragment) rejects up front; a path that passes those checks but fails route building (e.g. `..` segments) still switches and falls back to the app entry URL |
+| `switchToPath({url?, path})` | `{ ok }` | `switchTo` plus an initial in-app route loaded relative to the destination's app entry URL. A malformed `path` (empty, absolute, containing `://`, or carrying a fragment) rejects up front; a path that passes those checks but fails route building still switches and falls back to the app entry URL |
 
 Only genuinely invalid caller input rejects (an `add`/`switchTo`/`switchToPath`
 url that fails `SelfHostedServer.validate`, or a malformed `switchToPath`
@@ -291,7 +291,10 @@ Urls cross the bridge in one canonical form: `SelfHostedServer.canonicalize` and
 the store's `normalizeOriginUrl` implement the same rules (lowercase scheme and
 host, userinfo dropped, trailing slashes stripped, query and fragment dropped,
 path and port preserved), so both sides agree on which strings mean the same
-server. Changing one means changing the others.
+HTTPS server. Changing one means changing the others. The one divergence is
+deliberate: the Android shell also accepts cleartext development hosts
+(`http://localhost` and friends) that `normalizeOriginUrl` rejects, so those
+entries live in the native list but never surface as chooser cards.
 
 **Switching is per surface, and every surface has a working answer.**
 

--- a/clients/web/docs/CAPACITOR.md
+++ b/clients/web/docs/CAPACITOR.md
@@ -178,7 +178,7 @@ The shell registers **seven app-local** Capacitor plugins in [`MyViewController.
 | `VoiceAudioSession` | [`src/runtime/native-audio-session.ts`](../src/runtime/native-audio-session.ts) | iOS interruption events and Android audio-focus and microphone-service lifecycle. See the background-audio contract below |
 | `VoiceLiveActivity` | [`src/runtime/native-live-activity.ts`](../src/runtime/native-live-activity.ts) | One ActivityKit activity on iOS or ongoing notification on Android |
 | `ApnsEnvironment` | [`src/runtime/apns-environment.ts`](../src/runtime/apns-environment.ts) | The build's real APNs entitlement environment (`development` / `production` / `unknown`), read from the embedded provisioning profile |
-| `SelfHostedServers` | [`src/runtime/self-hosted-servers.ts`](../src/runtime/self-hosted-servers.ts) | List, add, remove, and switch between self-hosted server origins; `switchTo` swaps the shell's configured origin and reloads in place. See the section below |
+| `SelfHostedServers` | [`src/runtime/self-hosted-servers.ts`](../src/runtime/self-hosted-servers.ts) | List, add, remove, and switch between self-hosted server origins; `switchTo` swaps the shell's configured origin and reloads without leaving the app. See the section below |
 | `RecentChats` | [`src/runtime/recent-chats.ts`](../src/runtime/recent-chats.ts) | Mirrors the sidebar conversation list (ids + titles) into a UserDefaults cache that backs the Shortcuts app's chat picker (`ChatEntityQuery`); synced from `ChatLayout` once the list query has resolved |
 
 The two voice plugins are consumed only through `use-live-voice-session-controller.ts` (audio session) and `use-live-activity-mirror.ts` (Live Activity), both mounted at `ChatLayout` scope so their lifetime is exactly the session's.
@@ -259,13 +259,18 @@ References:
 
 The assistant chooser offers every origin this device knows about. On a native
 mobile shell those origins live natively, not in web storage, because the shell
-is the only thing that can point its `WKWebView` somewhere else without leaving
-the app, and because the same list is written by the native Settings pane and
-the `<scheme>://connect` deep link. The web side is
+is the only thing that can point its web view somewhere else without leaving
+the app, and because the same list is written by the `<scheme>://connect` deep
+link (and, on iOS, the native Settings pane). The web side is
 [`src/runtime/self-hosted-servers.ts`](../src/runtime/self-hosted-servers.ts);
 the native side is
 [`SelfHostedServersPlugin.swift`](../../../clients/ios/App/App/SelfHostedServersPlugin.swift)
-over [`SelfHostedServer.swift`](../../../clients/ios/App/App/SelfHostedServer.swift).
+over [`SelfHostedServer.swift`](../../../clients/ios/App/App/SelfHostedServer.swift)
+on iOS, and
+[`SelfHostedServersPlugin.java`](../../../clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServersPlugin.java)
+over
+[`SelfHostedServer.java`](../../../clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java)
+on Android.
 
 The bridge contract:
 
@@ -274,17 +279,19 @@ The bridge contract:
 | `list()` | `{ servers: [{name?, url}], activeUrl, bakedUrl }` | `activeUrl` is the configured self-hosted slot (`null` means the shell serves its baked origin); `bakedUrl` is the Vellum Cloud origin the build ships with |
 | `add({url, name?})` | `{ ok }` | Deduped by canonical url. A nameless re-add keeps the stored label |
 | `remove({url})` | `{ ok }` | Forgetting the active url also clears the active slot, so the shell returns to the baked origin |
-| `switchTo({url?})` | `{ ok }` | Swaps the active slot and reloads in place. An absent or empty `url` returns to the baked origin |
+| `switchTo({url?})` | `{ ok }` | Swaps the active slot and reloads the shell onto it (see the per-surface list below). An absent or empty `url` returns to the baked origin |
+| `switchToPath({url?, path})` | `{ ok }` | `switchTo` plus an initial in-app route loaded relative to the destination's app entry URL. An invalid `path` rejects before any state changes |
 
-Only genuinely invalid caller input rejects (an `add` or `switchTo` url that
-fails `SelfHostedServer.validate`). Empty state resolves with an empty list and
-nulls, so there is no "not configured" error branch to write.
+Only genuinely invalid caller input rejects (an `add`/`switchTo`/`switchToPath`
+url that fails `SelfHostedServer.validate`, or a malformed `switchToPath`
+path). Empty state resolves with an empty list and nulls, so there is no "not
+configured" error branch to write.
 
 Urls cross the bridge in one canonical form: `SelfHostedServer.canonicalize` and
 the store's `normalizeOriginUrl` implement the same rules (lowercase scheme and
 host, userinfo dropped, trailing slashes stripped, query and fragment dropped,
 path and port preserved), so both sides agree on which strings mean the same
-server. Changing one means changing the other.
+server. Changing one means changing the others.
 
 **Switching is per surface, and every surface has a working answer.**
 
@@ -296,8 +303,10 @@ server. Changing one means changing the other.
   ([`main-window.ts`](../../macos/src/main/main-window.ts)) sends any
   cross-origin https target to the system browser, so the origin opens there.
 - Native mobile with the plugin: `nativeSwitchToOrigin` hands the url to the
-  shell, which reloads the web view in place. The user never leaves the app,
-  and a "Vellum Cloud" card sourced from `list().bakedUrl` is the way back.
+  shell. iOS reloads the `WKWebView` in place; Android recreates the activity
+  onto a rebuilt Capacitor config, so a brief relaunch flash is expected.
+  Either way the user never leaves the app, and a "Vellum Cloud" card sourced
+  from `list().bakedUrl` is the way back.
 - Native mobile without the plugin: the same navigation the browser takes. That
   leaves the app for the system browser, which is degraded but is exactly what
   the pair-page path already does there.

--- a/clients/web/docs/CAPACITOR.md
+++ b/clients/web/docs/CAPACITOR.md
@@ -280,7 +280,7 @@ The bridge contract:
 | `add({url, name?})` | `{ ok }` | Deduped by canonical url. A nameless re-add keeps the stored label |
 | `remove({url})` | `{ ok }` | Forgetting the active url also clears the active slot, so the shell returns to the baked origin |
 | `switchTo({url?})` | `{ ok }` | Swaps the active slot and reloads the shell onto it (see the per-surface list below). An absent or empty `url` returns to the baked origin |
-| `switchToPath({url?, path})` | `{ ok }` | `switchTo` plus an initial in-app route loaded relative to the destination's app entry URL. An invalid `path` rejects before any state changes |
+| `switchToPath({url?, path})` | `{ ok }` | `switchTo` plus an initial in-app route loaded relative to the destination's app entry URL. A malformed `path` (empty, absolute, scheme-ful, or carrying a fragment) rejects up front; a path that passes those checks but fails route building (e.g. `..` segments) still switches and falls back to the app entry URL |
 
 Only genuinely invalid caller input rejects (an `add`/`switchTo`/`switchToPath`
 url that fails `SelfHostedServer.validate`, or a malformed `switchToPath`


### PR DESCRIPTION
## Summary
- android/README.md Self-Hosted section now covers the name label, remembered-server list, chooser-driven switching, and entry-URL prefix preservation
- CAPACITOR.md's SelfHostedServers section now names the Android native side and the recreate-based switching difference

Part of plan: android-assistant-parity.md (PR 5 of 5)