### PR TITLE
fix(web): refresh platform assistants on resume and chooser mount

### DIFF
--- a/clients/web/src/assistant/platform-assistants-sync.test.ts
+++ b/clients/web/src/assistant/platform-assistants-sync.test.ts
@@ -274,6 +274,34 @@ describe("refreshPlatformAssistantsIfStale", () => {
 
     expect(listAssistantsMock).not.toHaveBeenCalled();
   });
+
+  test("coalesces onto an in-flight reload instead of starting a duplicate", async () => {
+    const gates: Array<(result: unknown) => void> = [];
+    listAssistantsGates = gates;
+    authState = { platformSession: "present", user: { id: "u1" } };
+
+    const reload = reloadPlatformAssistants();
+    await tick();
+    expect(gates.length).toBe(1);
+
+    const refresh = refreshPlatformAssistantsIfStale();
+    await tick();
+    expect(listAssistantsMock).toHaveBeenCalledTimes(1);
+
+    const data = [{ id: "a1" }];
+    gates[0]!({ ok: true, status: 200, data });
+    await Promise.all([reload, refresh]);
+
+    // The lone reload's write lands; nothing superseded it.
+    expect(setFromApiMock).toHaveBeenCalledTimes(1);
+    expect(setFromApiMock).toHaveBeenCalledWith(data);
+
+    // The refresh path fetches again once the settled load goes stale.
+    advance(STALE_TIME_MS + 1);
+    listAssistantsGates = null;
+    await refreshPlatformAssistantsIfStale();
+    expect(listAssistantsMock).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("reloadPlatformAssistants", () => {

--- a/clients/web/src/assistant/platform-assistants-sync.test.ts
+++ b/clients/web/src/assistant/platform-assistants-sync.test.ts
@@ -1,4 +1,12 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  setSystemTime,
+  test,
+} from "bun:test";
 
 import type { PlatformSessionStatus } from "@/stores/session-status";
 
@@ -62,6 +70,20 @@ mock.module("@/lib/sentry/capture-error", () => ({
   captureError: captureErrorMock,
 }));
 
+// Event bus: capture the `app.resume` subscriber so tests can fire resume
+// signals, and count unsubscribes.
+type ResumeHandler = (payload: { signal: string }) => void;
+let resumeHandler: ResumeHandler | null = null;
+const resumeUnsubscribeMock = mock(() => {});
+mock.module("@/lib/event-bus", () => ({
+  subscribe: (topic: string, handler: ResumeHandler) => {
+    if (topic === "app.resume") {
+      resumeHandler = handler;
+    }
+    return resumeUnsubscribeMock;
+  },
+}));
+
 // Auth store: a getState + subscribe seam the sync module wires onto. Tests
 // drive transitions by invoking the captured subscriber with (next, prev) and
 // mutate `authState` directly to simulate logout / account-switch mid-load.
@@ -85,8 +107,11 @@ mock.module("@/stores/auth-store", () => ({
   },
 }));
 
-const { reloadPlatformAssistants, setupPlatformAssistantsSync } =
-  await import("@/assistant/platform-assistants-sync");
+const {
+  refreshPlatformAssistantsIfStale,
+  reloadPlatformAssistants,
+  setupPlatformAssistantsSync,
+} = await import("@/assistant/platform-assistants-sync");
 
 /** Move the mocked auth store to `next` (keeping the user) and notify. */
 function transition(next: PlatformSessionStatus): void {
@@ -98,7 +123,21 @@ function transition(next: PlatformSessionStatus): void {
 const tick = (): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, 0));
 
+// Frozen mock clock for the stale-refresh window. Each test starts a minute
+// past the previous one so any earlier stamp is already stale.
+const STALE_TIME_MS = 10_000;
+let now = new Date("2026-01-01T00:00:00Z").getTime();
+function advance(ms: number): void {
+  now += ms;
+  setSystemTime(new Date(now));
+}
+
+afterAll(() => {
+  setSystemTime();
+});
+
 beforeEach(() => {
+  advance(60_000);
   mockIsLocalClient = false;
   mockIsRemoteGatewayMode = false;
   mockIsGatewayAuthEnabled = false;
@@ -107,6 +146,8 @@ beforeEach(() => {
   listAssistantsGates = null;
   authState = { platformSession: "unknown", user: null };
   subscriber = null;
+  resumeHandler = null;
+  resumeUnsubscribeMock.mockClear();
   listAssistantsMock.mockClear();
   fetchOrganizationsMock.mockClear();
   setFromApiMock.mockClear();
@@ -160,12 +201,76 @@ describe("setupPlatformAssistantsSync", () => {
     expect(listAssistantsMock).not.toHaveBeenCalled();
   });
 
-  test("unsubscribing stops further reloads", async () => {
+  test("unsubscribing stops further reloads and drops the resume listener", async () => {
     const cleanup = setupPlatformAssistantsSync();
     cleanup();
 
     transition("present");
     await tick();
+
+    expect(listAssistantsMock).not.toHaveBeenCalled();
+    expect(resumeUnsubscribeMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("app.resume reloads when the list is stale and a session is present", async () => {
+    authState = { platformSession: "present", user: { id: "u1" } };
+    setupPlatformAssistantsSync();
+
+    resumeHandler?.({ signal: "visibility" });
+    await tick();
+
+    expect(listAssistantsMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("app.resume does not reload within the stale window", async () => {
+    authState = { platformSession: "present", user: { id: "u1" } };
+    setupPlatformAssistantsSync();
+
+    resumeHandler?.({ signal: "visibility" });
+    await tick();
+    expect(listAssistantsMock).toHaveBeenCalledTimes(1);
+
+    advance(STALE_TIME_MS / 2);
+    resumeHandler?.({ signal: "visibility" });
+    await tick();
+    expect(listAssistantsMock).toHaveBeenCalledTimes(1);
+
+    advance(STALE_TIME_MS);
+    resumeHandler?.({ signal: "visibility" });
+    await tick();
+    expect(listAssistantsMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("app.resume does not reload without a live platform session", async () => {
+    authState = { platformSession: "absent", user: null };
+    setupPlatformAssistantsSync();
+
+    resumeHandler?.({ signal: "visibility" });
+    await tick();
+
+    expect(listAssistantsMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("refreshPlatformAssistantsIfStale", () => {
+  test("respects the stale window across consecutive calls", async () => {
+    authState = { platformSession: "present", user: { id: "u1" } };
+
+    await refreshPlatformAssistantsIfStale();
+    expect(listAssistantsMock).toHaveBeenCalledTimes(1);
+
+    await refreshPlatformAssistantsIfStale();
+    expect(listAssistantsMock).toHaveBeenCalledTimes(1);
+
+    advance(STALE_TIME_MS + 1);
+    await refreshPlatformAssistantsIfStale();
+    expect(listAssistantsMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("no-ops when the platform session is not present", async () => {
+    authState = { platformSession: "unknown", user: null };
+
+    await refreshPlatformAssistantsIfStale();
 
     expect(listAssistantsMock).not.toHaveBeenCalled();
   });

--- a/clients/web/src/assistant/platform-assistants-sync.ts
+++ b/clients/web/src/assistant/platform-assistants-sync.ts
@@ -35,6 +35,11 @@ let latestReload = 0;
 const STALE_TIME_MS = 10_000;
 let lastLoadedAt = 0;
 
+// The reload currently in flight, if any. Stale-gated refreshes coalesce onto
+// it rather than starting a duplicate whose failure would supersede (and so
+// discard) the first reload's successful write.
+let inflightReload: Promise<void> | null = null;
+
 /**
  * Load the platform assistants list into the resolved-assistants store.
  *
@@ -49,10 +54,21 @@ let lastLoadedAt = 0;
  * signed-out session's route guard doesn't wait on `assistantsHydrated`, so
  * skipping the write there is correct.
  */
-export async function reloadPlatformAssistants(): Promise<void> {
+export function reloadPlatformAssistants(): Promise<void> {
   if (isLocalClient() || isRemoteGatewayMode() || isGatewayAuthEnabled()) {
-    return;
+    return Promise.resolve();
   }
+  const run = runReload();
+  inflightReload = run;
+  void run.finally(() => {
+    if (inflightReload === run) {
+      inflightReload = null;
+    }
+  });
+  return run;
+}
+
+async function runReload(): Promise<void> {
   const gen = ++latestReload;
   const startUserId = useAuthStore.getState().user?.id ?? null;
   const isStale = (): boolean =>
@@ -94,10 +110,16 @@ export async function reloadPlatformAssistants(): Promise<void> {
  * absent until a reload or re-auth. Called on app resume and on chooser mount,
  * the moments a user would look for the new assistant. Session and mode guards
  * live here and in `reloadPlatformAssistants`, so this is a no-op for
- * logged-out hubs and non-platform modes.
+ * logged-out hubs and non-platform modes. A reload already in flight is
+ * awaited instead of duplicated; direct `reloadPlatformAssistants` callers
+ * (auth transitions, account switches) keep their latest-wins start.
  */
 export async function refreshPlatformAssistantsIfStale(): Promise<void> {
   if (!hasLivePlatformSession(useAuthStore.getState().platformSession)) {
+    return;
+  }
+  if (inflightReload) {
+    await inflightReload;
     return;
   }
   if (Date.now() - lastLoadedAt <= STALE_TIME_MS) {

--- a/clients/web/src/assistant/platform-assistants-sync.ts
+++ b/clients/web/src/assistant/platform-assistants-sync.ts
@@ -14,11 +14,13 @@
  */
 import { listAssistants } from "@/assistant/api";
 import { isGatewayAuthEnabled } from "@/lib/auth/gateway-session";
+import { subscribe } from "@/lib/event-bus";
 import { isLocalClient, isRemoteGatewayMode } from "@/lib/local-mode";
 import { captureError } from "@/lib/sentry/capture-error";
 import { useAuthStore } from "@/stores/auth-store";
 import { useOrganizationStore } from "@/stores/organization-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import { hasLivePlatformSession } from "@/stores/session-status";
 
 // Monotonic id stamped on each reload. The load is fire-and-forget and awaits
 // two network hops, so a logout or account switch can land while it's in
@@ -26,6 +28,12 @@ import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 // allowed to write the resolved store, mirroring the auth store's own
 // `latestPlatformProbe` guard.
 let latestReload = 0;
+
+// Stale-refresh bookkeeping, mirroring setupOrganizationStore: resume and
+// chooser-mount refreshes only refetch when the last completed attempt is
+// older than this, so rapid signals on fresh data stay cheap.
+const STALE_TIME_MS = 10_000;
+let lastLoadedAt = 0;
 
 /**
  * Load the platform assistants list into the resolved-assistants store.
@@ -72,17 +80,42 @@ export async function reloadPlatformAssistants(): Promise<void> {
       return;
     }
     useResolvedAssistantsStore.getState().markHydrated();
+  } finally {
+    lastLoadedAt = Date.now();
   }
+}
+
+/**
+ * Reload the platform assistants list unless the last attempt is fresh.
+ *
+ * Covers the post-hatch window where a self-hosted registration exists but its
+ * `ingress_url` has not been provisioned yet: `setFromApi` drops the
+ * unreachable entry and nothing else refetches, so the assistant would stay
+ * absent until a reload or re-auth. Called on app resume and on chooser mount,
+ * the moments a user would look for the new assistant. Session and mode guards
+ * live here and in `reloadPlatformAssistants`, so this is a no-op for
+ * logged-out hubs and non-platform modes.
+ */
+export async function refreshPlatformAssistantsIfStale(): Promise<void> {
+  if (!hasLivePlatformSession(useAuthStore.getState().platformSession)) {
+    return;
+  }
+  if (Date.now() - lastLoadedAt <= STALE_TIME_MS) {
+    return;
+  }
+  await reloadPlatformAssistants();
 }
 
 /**
  * Subscribe to the auth store and reload the platform assistants list whenever
  * the platform session transitions to `"present"`. Register once at startup,
  * before `initSession`, so the boot `unknown → present` transition is caught.
- * Returns an unsubscribe cleanup.
+ * Also refreshes on `app.resume` when the list is stale, since a self-hosted
+ * assistant hatched elsewhere only becomes listable once its ingress
+ * provisions. Returns an unsubscribe cleanup covering both subscriptions.
  */
 export function setupPlatformAssistantsSync(): () => void {
-  return useAuthStore.subscribe((state, prevState) => {
+  const unsubAuth = useAuthStore.subscribe((state, prevState) => {
     if (
       prevState.platformSession !== "present" &&
       state.platformSession === "present"
@@ -90,4 +123,11 @@ export function setupPlatformAssistantsSync(): () => void {
       void reloadPlatformAssistants();
     }
   });
+  const unsubResume = subscribe("app.resume", () => {
+    void refreshPlatformAssistantsIfStale();
+  });
+  return () => {
+    unsubAuth();
+    unsubResume();
+  };
 }

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
@@ -109,6 +109,15 @@ mock.module("react-router", () => ({
   useSearchParams: () => [searchParams, setSearchParamsMock],
 }));
 
+// The screen refreshes the platform assistants list on mount; the real module
+// drags in @/assistant/api and the event bus, so it is fully mocked here.
+const refreshPlatformAssistantsIfStaleMock = mock(async () => {});
+mock.module("@/assistant/platform-assistants-sync", () => ({
+  refreshPlatformAssistantsIfStale: refreshPlatformAssistantsIfStaleMock,
+  reloadPlatformAssistants: async () => {},
+  setupPlatformAssistantsSync: () => () => {},
+}));
+
 mock.module("@/assistant/selection", () => ({
   resolveSelectedAssistantId: () => null,
   // Imported by switch-service (pulled in for the paired-removal branch);
@@ -489,6 +498,7 @@ beforeEach(() => {
   removePlatformAssistantFromLockfileMock.mockClear();
   activeAssistantIdValue = null;
   setActiveAssistantIdMock.mockClear();
+  refreshPlatformAssistantsIfStaleMock.mockClear();
   __resetConnectDialogForTesting();
 });
 
@@ -1661,5 +1671,15 @@ describe("SelectAssistantScreen local registrations on the platform hub", () => 
       expect(connectLocalAssistantMock).toHaveBeenCalledWith("asst-local"),
     );
     expect(connectPlatformAssistantMock).not.toHaveBeenCalled();
+  });
+
+  test("refreshes the platform assistants list on mount", async () => {
+    assistantsValue = [makePlatformAssistant()];
+
+    render(<SelectAssistantScreen />);
+
+    await waitFor(() =>
+      expect(refreshPlatformAssistantsIfStaleMock).toHaveBeenCalledTimes(1),
+    );
   });
 });

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -10,6 +10,7 @@ import {
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 
+import { refreshPlatformAssistantsIfStale } from "@/assistant/platform-assistants-sync";
 import { resolveSelectedAssistantId } from "@/assistant/selection";
 import { retireAssistant } from "@/assistant/retire-service";
 import { isCurrentOrigin, switchToOrigin } from "@/assistant/switch-origin";
@@ -258,6 +259,13 @@ export function SelectAssistantScreen() {
   // sudden auto-connect to the sole remaining assistant would be jarring, so
   // the auto-skip stands down for the rest of the visit.
   const removedThisVisitRef = useRef(false);
+
+  // Post-hatch ingress provisioning can land after the last list fetch;
+  // refresh on mount so the new assistant shows up. Session and mode guards
+  // live in the sync module, so this is a no-op off a logged-in hub.
+  useEffect(() => {
+    void refreshPlatformAssistantsIfStale();
+  }, []);
 
   // Platform-mode access gate: the hub chooser exists only behind the
   // assistant-switcher flag, whose real value lands asynchronously, so a


### PR DESCRIPTION
## Summary
- Add `refreshPlatformAssistantsIfStale()` to `platform-assistants-sync.ts`: reloads the platform assistants list when the last fetch attempt is older than 10s and a live platform session exists, modeled on `setupOrganizationStore`'s stale-refresh pattern.
- Wire it to the `app.resume` event-bus topic in `setupPlatformAssistantsSync()` (combined cleanup) and to a mount effect on the assistant chooser screen, so an assistant hatched on another machine appears once its ingress provisions, without a page reload or re-auth.
- Extend both test files: resume/stale-window/session-guard/cleanup coverage in the sync tests (with a mocked event bus and `setSystemTime`), and a mount-refresh assertion in the chooser screen tests.

## Original prompt
Follow-up to PR #40721 (hide unreachable local assistants from the platform-hub chooser), addressing Codex's remaining P2 (r3797704637): if the hub fetches the list during the post-hatch window where a self-hosted registration has `is_local=true` but a null `ingress_url`, the new `setFromApi` filter drops the entry and nothing ever refetches, so the assistant stays absent until a full reload or re-auth. The plan: refresh at the moments a user would actually look for the new assistant (app resume and chooser mount) via a stale-gated wrapper around the existing `reloadPlatformAssistants()`, rejecting the placeholder-card and timer-retry alternatives as complexity for a transient window.