### PR TITLE
fix(web): make work_result item links clickable and deep-link the skill History tab (LUM-3295)

### DIFF
--- a/assistant/src/api/surfaces.ts
+++ b/assistant/src/api/surfaces.ts
@@ -488,6 +488,11 @@ export const WorkResultItemSchema = z.object({
   status: tolerantString(),
   tone: WorkResultToneSchema.optional().catch(undefined),
   metadata: recordArray(WorkResultMetadataSchema).optional().catch(undefined),
+  /**
+   * Makes the item row a link. Clients follow an in-app path
+   * (`/assistant/skills/<skillId>?tab=history`) in place and open an http(s)
+   * URL externally; anything else renders as an unlinked row.
+   */
   href: tolerantString(),
 });
 export type WorkResultItem = z.infer<typeof WorkResultItemSchema>;

--- a/assistant/src/tools/ui-surface/surface-shape-docs.ts
+++ b/assistant/src/tools/ui-surface/surface-shape-docs.ts
@@ -123,7 +123,7 @@ export const SURFACE_SHAPE_DOCS: Record<string, SurfaceShapeDoc> = {
   work_result: {
     purpose: "structured receipt after completed work",
     shape:
-      '{ eyebrow?, status?: "completed"|"partial"|"failed"|"in_progress", summary?, metrics?: [{ label, value, detail?, tone?: "neutral"|"positive"|"warning"|"negative" }], sections?: [{ id?, title, description?, type?: "items"|"timeline"|"diff"|"artifacts"|"warnings", items?: [{ id?, title, description?, status?, tone?, metadata?: [{ label, value }], href? }], diffs?: [{ label?, before?, after? }] }] } — structured receipt after real work; keep display-only unless follow-up buttons are needed',
+      '{ eyebrow?, status?: "completed"|"partial"|"failed"|"in_progress", summary?, metrics?: [{ label, value, detail?, tone?: "neutral"|"positive"|"warning"|"negative" }], sections?: [{ id?, title, description?, type?: "items"|"timeline"|"diff"|"artifacts"|"warnings", items?: [{ id?, title, description?, status?, tone?, metadata?: [{ label, value }], href? }], diffs?: [{ label?, before?, after? }] }] }: structured receipt after real work; keep display-only unless follow-up buttons are needed. An item `href` makes the row a link: an in-app path (e.g. "/assistant/skills/<skillId>?tab=history") opens in place, an https URL opens externally; other schemes are ignored',
     missingContent: (data) =>
       hasContent(data)
         ? null

--- a/clients/web/src/domains/chat/components/surfaces/work-result-surface.stories.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/work-result-surface.stories.tsx
@@ -237,7 +237,7 @@ const documentDraftSurface = makeWorkResultSurface({
             title: "Beta launch decision memo",
             description: "Saved in the project workspace.",
             tone: "positive",
-            href: "#",
+            href: "/assistant/workspace",
             metadata: [
               { label: "Format", value: "Document" },
               { label: "Status", value: "Draft" },
@@ -568,6 +568,59 @@ const activationFollowThroughSurface: Surface = {
   },
 };
 
+/**
+ * The Level Up card the level-up plugin renders after the assistant edits one
+ * of its own skills: a diff preview plus a History row that deep-links to the
+ * skill page's History tab (an in-app row) beside an external reference (a
+ * new-tab row). Storybook's router has no page behind the in-app path, so
+ * clicking that row changes nothing visible here.
+ */
+const levelUpSurface = makeWorkResultSurface({
+  surfaceId: "level-up-surface",
+  title: "Level Up",
+  data: {
+    eyebrow: "Level up",
+    status: "completed",
+    summary:
+      "Linear skill now retries a 401 with the default viewer call before reporting auth failure.",
+    sections: [
+      {
+        id: "linear",
+        title: "skills/linear/SKILL.md",
+        description: "Default call + 401 diagnosis",
+        type: "diff",
+        diffs: [
+          {
+            before:
+              "- `401 Unauthorized` -> the credential is stale or revoked.",
+            after:
+              "- `401 Unauthorized` -> first assume the request is wrong. Re-run the default viewer call.",
+          },
+        ],
+      },
+      {
+        id: "history",
+        title: "History",
+        type: "items",
+        items: [
+          {
+            id: "history",
+            title: "Full level-up history",
+            description: "Every change to this skill, newest first.",
+            href: "/assistant/skills/linear?tab=history",
+          },
+          {
+            id: "docs",
+            title: "Linear API reference",
+            description: "The endpoint the retry now calls.",
+            href: "https://developers.linear.app/docs",
+          },
+        ],
+      },
+    ],
+  },
+});
+
 export const InboxCleanup: Story = {
   render: () => <WorkResultPreview surface={inboxCleanupSurface} />,
 };
@@ -578,6 +631,10 @@ export const CalendarPlanning: Story = {
 
 export const DocumentDiff: Story = {
   render: () => <WorkResultPreview surface={documentDraftSurface} />,
+};
+
+export const LevelUp: Story = {
+  render: () => <WorkResultPreview surface={levelUpSurface} />,
 };
 
 export const AutomationSetup: Story = {

--- a/clients/web/src/domains/chat/components/surfaces/work-result-surface.test.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/work-result-surface.test.tsx
@@ -1,8 +1,12 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { MemoryRouter, useLocation } from "react-router";
 
 import { SurfaceRouter } from "@/domains/chat/components/surfaces/surface-router";
-import { WorkResultSurface } from "@/domains/chat/components/surfaces/work-result-surface";
+import {
+  parseItemLink,
+  WorkResultSurface,
+} from "@/domains/chat/components/surfaces/work-result-surface";
 import type { Surface } from "@/domains/chat/types/types";
 
 afterEach(() => {
@@ -84,6 +88,100 @@ describe("WorkResultSurface", () => {
     );
 
     expect(getByText("Done")).toBeTruthy();
+  });
+});
+
+describe("WorkResultSurface item links", () => {
+  function linkedSurface(href: unknown): Surface {
+    return makeSurface({
+      data: {
+        sections: [
+          {
+            title: "History",
+            type: "items",
+            items: [{ id: "history", title: "Full level-up history", href }],
+          },
+        ],
+      },
+    });
+  }
+
+  function LocationProbe() {
+    const location = useLocation();
+    return <div>At: {location.pathname + location.search}</div>;
+  }
+
+  function renderLinked(href: unknown) {
+    return render(
+      <MemoryRouter initialEntries={["/assistant/conversations/conv-1"]}>
+        <WorkResultSurface surface={linkedSurface(href)} onAction={() => {}} />
+        <LocationProbe />
+      </MemoryRouter>,
+    );
+  }
+
+  test("an in-app path renders as a link that navigates in place", async () => {
+    const { getByRole, getByText } = renderLinked(
+      "/assistant/skills/linear?tab=history",
+    );
+
+    const link = getByRole("link", { name: /Full level-up history/ });
+    expect(link.getAttribute("href")).toBe(
+      "/assistant/skills/linear?tab=history",
+    );
+    // In-app: no new tab, no external-link affordance.
+    expect(link.getAttribute("target")).toBeNull();
+
+    fireEvent.click(link);
+    await waitFor(() => {
+      expect(
+        getByText("At: /assistant/skills/linear?tab=history"),
+      ).toBeTruthy();
+    });
+  });
+
+  test("an external URL renders as a new-tab anchor", () => {
+    const { getByRole, getByText } = renderLinked("https://example.com/report");
+
+    const link = getByRole("link", { name: /Full level-up history/ });
+    expect(link.getAttribute("href")).toBe("https://example.com/report");
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+    expect(getByText("At: /assistant/conversations/conv-1")).toBeTruthy();
+  });
+
+  test.each([
+    ["javascript:alert(1)"],
+    ["//evil.example/x"],
+    ["assistant/skills/linear"],
+    ["#"],
+    [""],
+    [42],
+  ])("%p is not a link", (href) => {
+    const { getByText, queryByRole } = renderLinked(href);
+
+    expect(getByText("Full level-up history")).toBeTruthy();
+    expect(queryByRole("link")).toBeNull();
+  });
+});
+
+describe("parseItemLink", () => {
+  test("classifies in-app paths and external schemes", () => {
+    expect(parseItemLink("/assistant/skills/linear?tab=history")).toEqual({
+      href: "/assistant/skills/linear?tab=history",
+      kind: "app",
+    });
+    expect(parseItemLink(" https://example.com ")).toEqual({
+      href: "https://example.com",
+      kind: "external",
+    });
+    expect(parseItemLink("mailto:someone@example.com")).toEqual({
+      href: "mailto:someone@example.com",
+      kind: "external",
+    });
+    expect(parseItemLink("//example.com")).toBeUndefined();
+    expect(parseItemLink("javascript:alert(1)")).toBeUndefined();
+    expect(parseItemLink(undefined)).toBeUndefined();
   });
 });
 

--- a/clients/web/src/domains/chat/components/surfaces/work-result-surface.test.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/work-result-surface.test.tsx
@@ -153,6 +153,13 @@ describe("WorkResultSurface item links", () => {
   test.each([
     ["javascript:alert(1)"],
     ["//evil.example/x"],
+    // The URL parser reads a backslash as a slash after a special scheme, and
+    // strips tabs and newlines before looking for an authority, so these
+    // resolve to another host for middle-click / copy-link.
+    ["/\\evil.example/x"],
+    ["/\t/evil.example/x"],
+    ["/\n\\evil.example/x"],
+    ["//["],
     ["assistant/skills/linear"],
     ["#"],
     [""],
@@ -179,7 +186,9 @@ describe("parseItemLink", () => {
       href: "mailto:someone@example.com",
       kind: "external",
     });
+    expect(parseItemLink("/")).toEqual({ href: "/", kind: "app" });
     expect(parseItemLink("//example.com")).toBeUndefined();
+    expect(parseItemLink("/\\example.com")).toBeUndefined();
     expect(parseItemLink("javascript:alert(1)")).toBeUndefined();
     expect(parseItemLink(undefined)).toBeUndefined();
   });

--- a/clients/web/src/domains/chat/components/surfaces/work-result-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/work-result-surface.tsx
@@ -1,6 +1,7 @@
 import {
   ArrowLeftRight,
   ArrowRight,
+  ChevronRight,
   CircleAlert,
   CircleCheck,
   Clock3,
@@ -9,6 +10,8 @@ import {
   ListChecks,
   OctagonX,
 } from "lucide-react";
+import type { ReactNode } from "react";
+import { Link } from "react-router";
 
 import type { Surface } from "@/domains/chat/types/types";
 
@@ -19,11 +22,17 @@ import {
   strOrNum,
 } from "@/domains/chat/components/surfaces/surface-parse-helpers";
 import { cn } from "@/utils/misc";
+import { handleNativeAnchorClick } from "@/utils/native-anchor";
+import { isRelayableExternalHref } from "@/utils/sandbox-bridge";
 
 type WorkResultStatus = "completed" | "partial" | "failed" | "in_progress";
 type WorkResultTone = "neutral" | "positive" | "warning" | "negative";
 type WorkResultSectionType =
-  "items" | "timeline" | "diff" | "artifacts" | "warnings";
+  | "items"
+  | "timeline"
+  | "diff"
+  | "artifacts"
+  | "warnings";
 
 interface WorkResultMetric {
   label: string;
@@ -37,6 +46,16 @@ interface WorkResultMetadata {
   value: string | number;
 }
 
+/**
+ * Where an item's `href` points. An `app` link is a path inside this client
+ * (`/assistant/skills/linear?tab=history`) and navigates in place; an
+ * `external` link (http(s), mailto, tel) opens outside the conversation.
+ */
+interface WorkResultItemLink {
+  href: string;
+  kind: "app" | "external";
+}
+
 interface WorkResultItem {
   id?: string;
   title: string;
@@ -44,7 +63,7 @@ interface WorkResultItem {
   status?: string;
   tone?: WorkResultTone;
   metadata?: WorkResultMetadata[];
-  href?: string;
+  link?: WorkResultItemLink;
 }
 
 interface WorkResultDiff {
@@ -122,6 +141,27 @@ function asSectionType(value: unknown): WorkResultSectionType | undefined {
     : undefined;
 }
 
+/**
+ * Narrow an item's `href` to a link the card will follow. Only in-app paths
+ * and the external schemes the host opens for sandboxed frames qualify: the
+ * model authors this field, so anything else (`javascript:`, protocol-relative
+ * `//host`, bare words) renders as plain text rather than becoming a
+ * clickable target.
+ */
+export function parseItemLink(value: unknown): WorkResultItemLink | undefined {
+  const href = asString(value)?.trim();
+  if (!href) {
+    return undefined;
+  }
+  if (href.startsWith("/") && !href.startsWith("//")) {
+    return { href, kind: "app" };
+  }
+  if (isRelayableExternalHref(href)) {
+    return { href, kind: "external" };
+  }
+  return undefined;
+}
+
 function parseMetadata(value: unknown): WorkResultMetadata[] {
   return filterRecords(value).flatMap((item) => {
     const label = asString(item.label);
@@ -146,7 +186,7 @@ function parseItems(value: unknown): WorkResultItem[] {
         status: asString(item.status),
         tone: asTone(item.tone),
         metadata: parseMetadata(item.metadata),
-        href: asString(item.href),
+        link: parseItemLink(item.href),
       },
     ];
   });
@@ -332,6 +372,62 @@ function MetadataRow({ metadata }: { metadata: WorkResultMetadata[] }) {
   );
 }
 
+const ITEM_ROW_CLASS = "flex gap-3 py-2.5 first:pt-0 last:pb-0";
+const LINKED_ITEM_ROW_CLASS = cn(
+  ITEM_ROW_CLASS,
+  "-mx-2 rounded-md px-2 transition-colors hover:bg-[var(--surface-hover)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]",
+);
+
+/**
+ * The row element for one item. A linked item is the whole row as one anchor
+ * (matching the clickable-row pattern in skill-created-card.tsx): an in-app
+ * path is a router `Link` so it navigates in place; an external URL opens
+ * outside the conversation, routed through the native opener on iOS where a
+ * `target="_blank"` anchor silently no-ops. An unlinked item is a plain row.
+ */
+function ItemRow({
+  link,
+  children,
+}: {
+  link: WorkResultItemLink | undefined;
+  children: ReactNode;
+}) {
+  if (!link) {
+    return <div className={ITEM_ROW_CLASS}>{children}</div>;
+  }
+  if (link.kind === "app") {
+    return (
+      <Link to={link.href} className={LINKED_ITEM_ROW_CLASS}>
+        {children}
+      </Link>
+    );
+  }
+  return (
+    <a
+      href={link.href}
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={(event) => handleNativeAnchorClick(event, link.href)}
+      className={LINKED_ITEM_ROW_CLASS}
+    >
+      {children}
+    </a>
+  );
+}
+
+function ItemLinkIcon({ link }: { link: WorkResultItemLink | undefined }) {
+  if (!link) {
+    return null;
+  }
+  const Icon = link.kind === "external" ? ExternalLink : ChevronRight;
+  return (
+    <Icon
+      aria-hidden
+      className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[var(--content-tertiary)]"
+    />
+  );
+}
+
 function ItemList({ items }: { items: WorkResultItem[] }) {
   if (items.length === 0) {
     return null;
@@ -341,10 +437,7 @@ function ItemList({ items }: { items: WorkResultItem[] }) {
       {items.map((item) => {
         const tone = toneClasses(item.tone);
         return (
-          <div
-            key={item.id ?? item.title}
-            className="flex gap-3 py-2.5 first:pt-0 last:pb-0"
-          >
+          <ItemRow key={item.id ?? item.title} link={item.link}>
             <span
               aria-hidden
               className={cn(
@@ -362,9 +455,7 @@ function ItemList({ items }: { items: WorkResultItem[] }) {
                     {item.status}
                   </span>
                 )}
-                {item.href && (
-                  <ExternalLink className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[var(--content-tertiary)]" />
-                )}
+                <ItemLinkIcon link={item.link} />
               </div>
               {item.description && (
                 <p className="mt-0.5 text-body-small-default text-[var(--content-quiet)]">
@@ -373,7 +464,7 @@ function ItemList({ items }: { items: WorkResultItem[] }) {
               )}
               <MetadataRow metadata={item.metadata ?? []} />
             </div>
-          </div>
+          </ItemRow>
         );
       })}
     </div>

--- a/clients/web/src/domains/chat/components/surfaces/work-result-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/work-result-surface.tsx
@@ -142,6 +142,35 @@ function asSectionType(value: unknown): WorkResultSectionType | undefined {
 }
 
 /**
+ * Base only used to resolve a candidate in-app path the way an anchor would;
+ * a `.invalid` host so the value can never coincide with a real origin.
+ */
+const APP_PATH_PROBE_ORIGIN = "https://work-result-item.invalid";
+
+/**
+ * Whether `href` stays on this origin when the browser resolves it as an
+ * anchor target. Resolving is the check, not a prefix test, because a
+ * middle-click or copy-link reads the raw attribute: `//host/x`, the spec's
+ * backslash form `/\host/x`, and `/<tab>/host/x` (the parser strips tabs and
+ * newlines before it looks for an authority) all leave the origin, and every
+ * other normalization the parser applies is covered the same way.
+ */
+function isAppRelativePath(href: string): boolean {
+  if (!href.startsWith("/")) {
+    return false;
+  }
+  try {
+    return (
+      new URL(href, APP_PATH_PROBE_ORIGIN).origin === APP_PATH_PROBE_ORIGIN
+    );
+  } catch {
+    // The parser rejected it (e.g. `//[` has an invalid host), which is the
+    // verdict itself: something a browser cannot resolve is not a link.
+    return false;
+  }
+}
+
+/**
  * Narrow an item's `href` to a link the card will follow. Only in-app paths
  * and the external schemes the host opens for sandboxed frames qualify: the
  * model authors this field, so anything else (`javascript:`, protocol-relative
@@ -153,7 +182,7 @@ export function parseItemLink(value: unknown): WorkResultItemLink | undefined {
   if (!href) {
     return undefined;
   }
-  if (href.startsWith("/") && !href.startsWith("//")) {
+  if (isAppRelativePath(href)) {
     return { href, kind: "app" };
   }
   if (isRelayableExternalHref(href)) {

--- a/clients/web/src/domains/chat/components/surfaces/work-result-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/work-result-surface.tsx
@@ -1,4 +1,16 @@
 import {
+  type WorkResultDiff,
+  type WorkResultItem,
+  type WorkResultMetadata,
+  type WorkResultMetric,
+  type WorkResultSection,
+  type WorkResultSectionType,
+  type WorkResultStatus,
+  type WorkResultSurfaceData,
+  WorkResultSurfaceDataSchema,
+  type WorkResultTone,
+} from "@vellumai/assistant-api";
+import {
   ArrowLeftRight,
   ArrowRight,
   ChevronRight,
@@ -10,83 +22,25 @@ import {
   ListChecks,
   OctagonX,
 } from "lucide-react";
-import type { ReactNode } from "react";
+import { type ReactNode, useMemo } from "react";
 import { Link } from "react-router";
 
 import type { Surface } from "@/domains/chat/types/types";
 
 import { SurfaceContainer } from "@/domains/chat/components/surfaces/surface-container";
-import {
-  filterRecords,
-  rec,
-  strOrNum,
-} from "@/domains/chat/components/surfaces/surface-parse-helpers";
 import { cn } from "@/utils/misc";
 import { handleNativeAnchorClick } from "@/utils/native-anchor";
 import { isRelayableExternalHref } from "@/utils/sandbox-bridge";
-
-type WorkResultStatus = "completed" | "partial" | "failed" | "in_progress";
-type WorkResultTone = "neutral" | "positive" | "warning" | "negative";
-type WorkResultSectionType =
-  | "items"
-  | "timeline"
-  | "diff"
-  | "artifacts"
-  | "warnings";
-
-interface WorkResultMetric {
-  label: string;
-  value: string | number;
-  detail?: string;
-  tone?: WorkResultTone;
-}
-
-interface WorkResultMetadata {
-  label: string;
-  value: string | number;
-}
 
 /**
  * Where an item's `href` points. An `app` link is a path inside this client
  * (`/assistant/skills/linear?tab=history`) and navigates in place; an
  * `external` link (http(s), mailto, tel) opens outside the conversation.
+ * A view-side classification of the wire's `href`, not a wire field.
  */
 interface WorkResultItemLink {
   href: string;
   kind: "app" | "external";
-}
-
-interface WorkResultItem {
-  id?: string;
-  title: string;
-  description?: string;
-  status?: string;
-  tone?: WorkResultTone;
-  metadata?: WorkResultMetadata[];
-  link?: WorkResultItemLink;
-}
-
-interface WorkResultDiff {
-  label?: string;
-  before?: string;
-  after?: string;
-}
-
-interface WorkResultSection {
-  id?: string;
-  title: string;
-  description?: string;
-  type?: WorkResultSectionType;
-  items?: WorkResultItem[];
-  diffs?: WorkResultDiff[];
-}
-
-interface WorkResultSurfaceData {
-  eyebrow?: string;
-  status?: WorkResultStatus;
-  summary?: string;
-  metrics?: WorkResultMetric[];
-  sections?: WorkResultSection[];
 }
 
 interface WorkResultSurfaceProps {
@@ -108,37 +62,13 @@ const STATUS_COPY: Record<
   in_progress: { label: "In progress", tone: "neutral" },
 };
 
-/** Narrow unknown → non-empty string. Rejects whitespace-only. */
-function asString(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value : undefined;
-}
-
-function asTone(value: unknown): WorkResultTone | undefined {
-  return value === "positive" ||
-    value === "warning" ||
-    value === "negative" ||
-    value === "neutral"
-    ? value
-    : undefined;
-}
-
-function asStatus(value: unknown): WorkResultStatus | undefined {
-  return value === "completed" ||
-    value === "partial" ||
-    value === "failed" ||
-    value === "in_progress"
-    ? value
-    : undefined;
-}
-
-function asSectionType(value: unknown): WorkResultSectionType | undefined {
-  return value === "items" ||
-    value === "timeline" ||
-    value === "diff" ||
-    value === "artifacts" ||
-    value === "warnings"
-    ? value
-    : undefined;
+/**
+ * The canonical schema is tolerant: a field the model got wrong parses to
+ * `""` / `undefined` rather than failing the payload. Blank text is dropped
+ * at render so a coerced-empty title or label never becomes an empty row.
+ */
+function hasText(value: string | number | undefined): boolean {
+  return typeof value === "number" || (value ?? "").trim().length > 0;
 }
 
 /**
@@ -177,8 +107,10 @@ function isAppRelativePath(href: string): boolean {
  * `//host`, bare words) renders as plain text rather than becoming a
  * clickable target.
  */
-export function parseItemLink(value: unknown): WorkResultItemLink | undefined {
-  const href = asString(value)?.trim();
+export function parseItemLink(
+  value: string | undefined,
+): WorkResultItemLink | undefined {
+  const href = value?.trim();
   if (!href) {
     return undefined;
   }
@@ -189,104 +121,6 @@ export function parseItemLink(value: unknown): WorkResultItemLink | undefined {
     return { href, kind: "external" };
   }
   return undefined;
-}
-
-function parseMetadata(value: unknown): WorkResultMetadata[] {
-  return filterRecords(value).flatMap((item) => {
-    const label = asString(item.label);
-    const metricValue = strOrNum(item.value);
-    return label && metricValue !== undefined
-      ? [{ label, value: metricValue }]
-      : [];
-  });
-}
-
-function parseItems(value: unknown): WorkResultItem[] {
-  return filterRecords(value).flatMap((item, index) => {
-    const title = asString(item.title);
-    if (!title) {
-      return [];
-    }
-    return [
-      {
-        id: asString(item.id) ?? `${index}`,
-        title,
-        description: asString(item.description),
-        status: asString(item.status),
-        tone: asTone(item.tone),
-        metadata: parseMetadata(item.metadata),
-        link: parseItemLink(item.href),
-      },
-    ];
-  });
-}
-
-function parseDiffs(value: unknown): WorkResultDiff[] {
-  return filterRecords(value).flatMap((item) => {
-    const before = asString(item.before);
-    const after = asString(item.after);
-    if (!before && !after) {
-      return [];
-    }
-    return [
-      {
-        label: asString(item.label),
-        before,
-        after,
-      },
-    ];
-  });
-}
-
-function parseMetrics(value: unknown): WorkResultMetric[] {
-  return filterRecords(value).flatMap((item) => {
-    const label = asString(item.label);
-    const metricValue = strOrNum(item.value);
-    if (!label || metricValue === undefined) {
-      return [];
-    }
-    return [
-      {
-        label,
-        value: metricValue,
-        detail: asString(item.detail),
-        tone: asTone(item.tone),
-      },
-    ];
-  });
-}
-
-function parseSections(value: unknown): WorkResultSection[] {
-  return filterRecords(value).flatMap((section, index) => {
-    const title = asString(section.title);
-    if (!title) {
-      return [];
-    }
-    return [
-      {
-        id: asString(section.id) ?? `${index}`,
-        title,
-        description: asString(section.description),
-        type: asSectionType(section.type),
-        items: parseItems(section.items),
-        diffs: parseDiffs(section.diffs),
-      },
-    ];
-  });
-}
-
-function parseData(value: unknown): WorkResultSurfaceData {
-  const obj = rec(value);
-  if (!obj) {
-    return {};
-  }
-  return {
-    eyebrow: asString(obj.eyebrow),
-    status: asStatus(obj.status),
-    summary: asString(obj.summary),
-    metrics: parseMetrics(obj.metrics),
-    sections: parseSections(obj.sections),
-  };
 }
 
 function toneClasses(tone: WorkResultTone | undefined): {
@@ -357,11 +191,11 @@ function MetricGrid({ metrics }: { metrics: WorkResultMetric[] }) {
   }
   return (
     <div className="mt-4 grid gap-px overflow-hidden rounded-md border border-[var(--border-base)] bg-[var(--border-base)] sm:grid-cols-3">
-      {metrics.map((metric) => {
+      {metrics.map((metric, index) => {
         const tone = toneClasses(metric.tone);
         return (
           <div
-            key={`${metric.label}-${metric.value}`}
+            key={`${metric.label}-${index}`}
             className="min-w-0 bg-[var(--surface-base)] px-3 py-2.5"
           >
             <div className={cn("text-title-small tabular-nums", tone.text)}>
@@ -370,7 +204,7 @@ function MetricGrid({ metrics }: { metrics: WorkResultMetric[] }) {
             <div className="mt-0.5 truncate text-body-small-default text-[var(--content-secondary)]">
               {metric.label}
             </div>
-            {metric.detail && (
+            {hasText(metric.detail) && (
               <div className="mt-1 truncate text-body-small-default text-[var(--content-tertiary)]">
                 {metric.detail}
               </div>
@@ -383,14 +217,15 @@ function MetricGrid({ metrics }: { metrics: WorkResultMetric[] }) {
 }
 
 function MetadataRow({ metadata }: { metadata: WorkResultMetadata[] }) {
-  if (metadata.length === 0) {
+  const shown = metadata.filter((meta) => hasText(meta.label));
+  if (shown.length === 0) {
     return null;
   }
   return (
     <div className="mt-1.5 flex flex-wrap gap-1.5">
-      {metadata.map((meta) => (
+      {shown.map((meta, index) => (
         <span
-          key={`${meta.label}-${meta.value}`}
+          key={`${meta.label}-${index}`}
           className="rounded-full bg-[var(--surface-active)] px-2 py-0.5 text-body-small-default text-[var(--content-tertiary)]"
         >
           {meta.label}:{" "}
@@ -463,10 +298,11 @@ function ItemList({ items }: { items: WorkResultItem[] }) {
   }
   return (
     <div className="mt-3 divide-y divide-[var(--border-base)]">
-      {items.map((item) => {
+      {items.map((item, index) => {
         const tone = toneClasses(item.tone);
+        const link = parseItemLink(item.href);
         return (
-          <ItemRow key={item.id ?? item.title} link={item.link}>
+          <ItemRow key={item.id ?? `${index}`} link={link}>
             <span
               aria-hidden
               className={cn(
@@ -479,14 +315,14 @@ function ItemList({ items }: { items: WorkResultItem[] }) {
                 <span className="min-w-0 flex-1 text-body-medium-default text-[var(--content-strong)]">
                   {item.title}
                 </span>
-                {item.status && (
+                {hasText(item.status) && (
                   <span className="shrink-0 rounded-full bg-[var(--surface-active)] px-2 py-0.5 text-label-small-default text-[var(--content-secondary)]">
                     {item.status}
                   </span>
                 )}
-                <ItemLinkIcon link={item.link} />
+                <ItemLinkIcon link={link} />
               </div>
-              {item.description && (
+              {hasText(item.description) && (
                 <p className="mt-0.5 text-body-small-default text-[var(--content-quiet)]">
                   {item.description}
                 </p>
@@ -508,7 +344,7 @@ function DiffBlock({ diffs }: { diffs: WorkResultDiff[] }) {
     <div className="mt-3 space-y-3">
       {diffs.map((diff, index) => (
         <div key={`${diff.label ?? "diff"}-${index}`}>
-          {diff.label && (
+          {hasText(diff.label) && (
             <div className="mb-1 text-label-medium-default text-[var(--content-secondary)]">
               {diff.label}
             </div>
@@ -519,7 +355,7 @@ function DiffBlock({ diffs }: { diffs: WorkResultDiff[] }) {
                 Before
               </div>
               <p className="whitespace-pre-wrap text-body-small-default text-[var(--content-secondary)]">
-                {diff.before ?? "Not set"}
+                {hasText(diff.before) ? diff.before : "Not set"}
               </p>
             </div>
             <div className="hidden items-center bg-[var(--surface-base)] px-2 text-[var(--content-tertiary)] sm:flex">
@@ -530,7 +366,7 @@ function DiffBlock({ diffs }: { diffs: WorkResultDiff[] }) {
                 After
               </div>
               <p className="whitespace-pre-wrap text-body-small-default text-[var(--content-strong)]">
-                {diff.after ?? "Removed"}
+                {hasText(diff.after) ? diff.after : "Removed"}
               </p>
             </div>
           </div>
@@ -563,10 +399,11 @@ function SectionIcon({ type }: { type: WorkResultSectionType }) {
 
 function ResultSection({ section }: { section: WorkResultSection }) {
   const type = section.type ?? "items";
-  const count =
-    type === "diff"
-      ? (section.diffs?.length ?? 0)
-      : (section.items?.length ?? 0);
+  const items = (section.items ?? []).filter((item) => hasText(item.title));
+  const diffs = (section.diffs ?? []).filter(
+    (diff) => hasText(diff.before) || hasText(diff.after),
+  );
+  const count = type === "diff" ? diffs.length : items.length;
   return (
     <section className="border-t border-[var(--border-base)] pt-4 first:border-t-0 first:pt-0">
       <div className="flex items-center gap-2">
@@ -580,15 +417,15 @@ function ResultSection({ section }: { section: WorkResultSection }) {
           </span>
         )}
       </div>
-      {section.description && (
+      {hasText(section.description) && (
         <p className="mt-1 text-body-small-default text-[var(--content-quiet)]">
           {section.description}
         </p>
       )}
       {type === "diff" ? (
-        <DiffBlock diffs={section.diffs ?? []} />
+        <DiffBlock diffs={diffs} />
       ) : (
-        <ItemList items={section.items ?? []} />
+        <ItemList items={items} />
       )}
     </section>
   );
@@ -598,9 +435,20 @@ export function WorkResultSurface({
   surface,
   onAction,
 }: WorkResultSurfaceProps) {
-  const data = parseData(surface.data);
+  // The wire keeps surface `data` opaque; narrow it with the canonical schema
+  // (tolerant, so a real payload never fails to parse) rather than an
+  // unchecked cast or a re-declared local interface.
+  const data = useMemo<WorkResultSurfaceData>(() => {
+    const parsed = WorkResultSurfaceDataSchema.safeParse(surface.data);
+    return parsed.success ? parsed.data : {};
+  }, [surface.data]);
   const title = surface.title || "Work completed";
-  const sections = data.sections ?? [];
+  const metrics = (data.metrics ?? []).filter(
+    (metric) => hasText(metric.label) && hasText(metric.value),
+  );
+  const sections = (data.sections ?? []).filter((section) =>
+    hasText(section.title),
+  );
   const surfaceWithoutContainerTitle = { ...surface, title: undefined };
 
   return (
@@ -611,7 +459,7 @@ export function WorkResultSurface({
       <div>
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0">
-            {data.eyebrow && (
+            {hasText(data.eyebrow) && (
               <div className="mb-1 text-label-small-default uppercase text-[var(--content-tertiary)]">
                 {data.eyebrow}
               </div>
@@ -619,7 +467,7 @@ export function WorkResultSurface({
             <h3 className="text-title-medium text-[var(--content-strong)]">
               {title}
             </h3>
-            {data.summary && (
+            {hasText(data.summary) && (
               <p className="mt-1 text-body-medium-lighter text-[var(--content-quiet)]">
                 {data.summary}
               </p>
@@ -628,15 +476,12 @@ export function WorkResultSurface({
           <ResultStatusBadge status={data.status} />
         </div>
 
-        <MetricGrid metrics={data.metrics ?? []} />
+        <MetricGrid metrics={metrics} />
 
         {sections.length > 0 && (
           <div className="mt-5 space-y-4">
-            {sections.map((section) => (
-              <ResultSection
-                key={section.id ?? section.title}
-                section={section}
-              />
+            {sections.map((section, index) => (
+              <ResultSection key={section.id ?? `${index}`} section={section} />
             ))}
           </div>
         )}

--- a/clients/web/src/domains/intelligence/components/skills/skill-detail.stories.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/skill-detail.stories.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { type ComponentProps, useState } from "react";
 
 import type { SkillInfo } from "@/domains/intelligence/skills/types";
 import {
@@ -161,14 +162,27 @@ function seededClient(options: {
   return client;
 }
 
+/**
+ * Holds the selected tab the way the route page does (there it rides
+ * `?tab=`), so clicking the tab strip works in a story. `tab` in args is the
+ * tab the story opens on.
+ */
+function SkillDetailWithTabState(props: ComponentProps<typeof SkillDetail>) {
+  const [tab, setTab] = useState(props.tab);
+  return <SkillDetail {...props} tab={tab} onTabChange={setTab} />;
+}
+
 const meta: Meta<typeof SkillDetail> = {
   title: "Intelligence/Skills/SkillDetail",
   component: SkillDetail,
   parameters: { layout: "fullscreen" },
+  render: (args) => <SkillDetailWithTabState {...args} />,
   args: {
     assistantId: ASSISTANT_ID,
     skill: SKILL,
     sourceConversationId: "conv_story",
+    tab: "files",
+    onTabChange: () => {},
     onBack: () => {},
     onRemove: () => {},
   },
@@ -195,11 +209,21 @@ function withShell(client: QueryClient) {
 
 /**
  * Landing on the page: Files is selected and History sits beside it. Click
- * History to see the revision list inside the page's own card. The tab is
- * uncontrolled, so this and the story below both open on Files.
+ * History to see the revision list inside the page's own card. This and the
+ * story below both open on Files.
  */
 export const Default: Story = {
   decorators: [withShell(seededClient({ historySupported: true }))],
+};
+
+/**
+ * Arriving by deep link: the in-chat Level Up card links to
+ * `/assistant/skills/:skillId?tab=history`, so the page opens straight onto
+ * the revision list.
+ */
+export const HistoryDeepLink: Story = {
+  decorators: [withShell(seededClient({ historySupported: true }))],
+  args: { tab: "history" },
 };
 
 /** Workspace history was squashed, so the list carries its caveat. */

--- a/clients/web/src/domains/intelligence/components/skills/skill-detail.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/skill-detail.tsx
@@ -37,9 +37,27 @@ import { openWorkspaceFile } from "@/utils/open-workspace-file";
 import { invalidateSkillsList, isRemovableSkill } from "@/utils/skills";
 import { Button, Card, Tabs } from "@vellumai/design-library";
 
+export type SkillDetailTab = "files" | "history";
+
+/**
+ * Narrow an arbitrary tab value (a `?tab=` param, a Radix `onValueChange`
+ * string) to a tab the page renders; anything else is Files.
+ */
+export function parseSkillDetailTab(value: string | null): SkillDetailTab {
+  return value === "history" ? "history" : "files";
+}
+
 interface SkillDetailProps {
   assistantId: string;
   skill: SkillInfo;
+  /**
+   * Which tab is selected. The route page owns it (it rides `?tab=` so a
+   * link can open the page straight onto History, as the in-chat Level Up
+   * card does); this component only pins it to Files while History is
+   * hidden.
+   */
+  tab: SkillDetailTab;
+  onTabChange: (tab: SkillDetailTab) => void;
   onBack: () => void;
   onInstall?: () => void;
   onRemove?: () => void;
@@ -55,6 +73,8 @@ interface SkillDetailProps {
 export function SkillDetail({
   assistantId,
   skill,
+  tab,
+  onTabChange,
   onBack,
   onInstall,
   onRemove,
@@ -90,10 +110,10 @@ export function SkillDetail({
     revisionCount: revisions.length,
   });
 
-  const [selectedTab, setSelectedTab] = useState("files");
   // Pin to Files whenever the strip is hidden, so the page never rests on an
-  // unrendered panel.
-  const activeTab = showHistory ? selectedTab : "files";
+  // unrendered panel. A History deep link therefore shows Files while the
+  // history query is in flight and switches once revisions arrive.
+  const activeTab: SkillDetailTab = showHistory ? tab : "files";
 
   const header = (
     <div className="mb-4 flex items-start gap-3">
@@ -275,12 +295,14 @@ export function SkillDetail({
       */}
       <Tabs.Root
         value={activeTab}
-        onValueChange={setSelectedTab}
+        onValueChange={(value) => onTabChange(parseSkillDetailTab(value))}
         className="flex min-h-0 flex-1 flex-col"
       >
         {showHistory && (
           <Tabs.List className="mb-3">
-            <Tabs.Trigger value="files">{t("skillDetail.filesTab")}</Tabs.Trigger>
+            <Tabs.Trigger value="files">
+              {t("skillDetail.filesTab")}
+            </Tabs.Trigger>
             <Tabs.Trigger value="history">
               {t("skillDetail.historyTab")}
             </Tabs.Trigger>

--- a/clients/web/src/domains/intelligence/skill-detail-page.test.tsx
+++ b/clients/web/src/domains/intelligence/skill-detail-page.test.tsx
@@ -12,13 +12,16 @@
  *   list, or a cached list that lacks it) the full-page error state renders
  *   instead of a false "Skill not found",
  * - the back button restores the My Superpowers list's query string passed
- *   as router state (search/filter/category survive detail navigation).
+ *   as router state (search/filter/category survive detail navigation),
+ * - the desktop Files/History tab rides `?tab=`: a `?tab=history` deep link
+ *   opens on History, and a tab change writes the param back (deleting it
+ *   for the default Files tab).
  *
  * The generated SDK's `skillsGet` is mocked with a per-test deferred so a
  * case can hold the list refetch pending; the heavy `SkillDetail` /
  * `SkillDetailMobile` views are stubbed with light stand-ins exposing the
- * `onBack` wiring. Mounted via `@testing-library/react` (happy-dom — see
- * `clients/web/test-setup.ts`).
+ * `onBack` and tab wiring. Mounted via `@testing-library/react` (happy-dom,
+ * see `clients/web/test-setup.ts`).
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -32,6 +35,8 @@ import {
 } from "@testing-library/react";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router";
 
+import type * as SkillDetailModule from "@/domains/intelligence/components/skills/skill-detail";
+import { parseSkillDetailTab } from "@/domains/intelligence/components/skills/skill-detail";
 import type { SkillInfo } from "@/domains/intelligence/skills/types";
 import type { SkillsGetResponse } from "@/generated/daemon/types.gen";
 
@@ -83,24 +88,31 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
   }),
 }));
 
-// Stub the heavy detail views — this suite targets the page's branching, not
-// the file browser. The stand-ins expose the `onBack` wiring under test.
-mock.module("@/domains/intelligence/components/skills/skill-detail", () => ({
-  SkillDetail: ({
-    skill,
-    onBack,
-  }: {
-    skill: SkillInfo;
-    onBack: () => void;
-  }) => (
-    <div>
-      <span>Detail: {skill.name}</span>
-      <button type="button" onClick={onBack}>
-        Back to skills
-      </button>
-    </div>
-  ),
-}));
+// Stub the heavy detail views: this suite targets the page's branching, not
+// the file browser. The stand-in exposes the `onBack` and tab wiring under
+// test. `parseSkillDetailTab` is the pure function the page reads `?tab=`
+// through, so the real one is passed through rather than stubbed.
+mock.module(
+  "@/domains/intelligence/components/skills/skill-detail",
+  (): Partial<typeof SkillDetailModule> => ({
+    parseSkillDetailTab,
+    SkillDetail: ({ skill, tab, onTabChange, onBack }) => (
+      <div>
+        <span>Detail: {skill.name}</span>
+        <span>Tab: {tab}</span>
+        <button type="button" onClick={() => onTabChange("history")}>
+          Open history
+        </button>
+        <button type="button" onClick={() => onTabChange("files")}>
+          Open files
+        </button>
+        <button type="button" onClick={onBack}>
+          Back to skills
+        </button>
+      </div>
+    ),
+  }),
+);
 mock.module(
   "@/domains/intelligence/components/skills/skill-detail-mobile",
   () => ({
@@ -141,17 +153,28 @@ function SuperpowersListLanding() {
   return <div>Superpowers list at: [{location.search}]</div>;
 }
 
+// Sentinel beside the detail route so tests can prove what a tab change wrote
+// to the URL.
+function DetailSearchProbe() {
+  const location = useLocation();
+  return <div>Detail search: [{location.search}]</div>;
+}
+
 function renderDetail({
   skillId,
+  search = "",
   listSearch,
   client = makeQueryClient(),
 }: {
   skillId: string;
+  /** Query string the detail route is entered with, e.g. `?tab=history`. */
+  search?: string;
   listSearch?: string;
   client?: QueryClient;
 }): void {
   const entry = {
     pathname: `/assistant/skills/${skillId}`,
+    search,
     state: listSearch === undefined ? null : { listSearch },
   };
   render(
@@ -160,7 +183,12 @@ function renderDetail({
         <Routes>
           <Route
             path="/assistant/skills/:skillId"
-            element={<SkillDetailPage />}
+            element={
+              <>
+                <SkillDetailPage />
+                <DetailSearchProbe />
+              </>
+            }
           />
           <Route
             path="/assistant/superpowers"
@@ -339,5 +367,49 @@ describe("SkillDetailPage back navigation", () => {
     await waitFor(() => {
       expect(screen.getByText("Superpowers list at: []")).toBeTruthy();
     });
+  });
+});
+
+describe("SkillDetailPage tab deep link", () => {
+  test("opens on Files with no ?tab= and on History with ?tab=history", async () => {
+    renderDetail({ skillId: "skill-1" });
+    await waitFor(() => {
+      expect(screen.getByText("Tab: files")).toBeTruthy();
+    });
+    cleanup();
+
+    renderDetail({ skillId: "skill-1", search: "?tab=history" });
+    await waitFor(() => {
+      expect(screen.getByText("Tab: history")).toBeTruthy();
+    });
+  });
+
+  test("falls back to Files for an unknown ?tab= value", async () => {
+    renderDetail({ skillId: "skill-1", search: "?tab=nope" });
+    await waitFor(() => {
+      expect(screen.getByText("Tab: files")).toBeTruthy();
+    });
+  });
+
+  test("a tab change writes ?tab=history and clears it for Files", async () => {
+    renderDetail({ skillId: "skill-1", search: "?other=1" });
+    await waitFor(() => {
+      expect(screen.getByText("Tab: files")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText("Open history"));
+    await waitFor(() => {
+      expect(screen.getByText("Tab: history")).toBeTruthy();
+    });
+    // Other params survive; only `tab` is written.
+    expect(
+      screen.getByText("Detail search: [?other=1&tab=history]"),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByText("Open files"));
+    await waitFor(() => {
+      expect(screen.getByText("Tab: files")).toBeTruthy();
+    });
+    expect(screen.getByText("Detail search: [?other=1]")).toBeTruthy();
   });
 });

--- a/clients/web/src/domains/intelligence/skill-detail-page.test.tsx
+++ b/clients/web/src/domains/intelligence/skill-detail-page.test.tsx
@@ -412,4 +412,30 @@ describe("SkillDetailPage tab deep link", () => {
     });
     expect(screen.getByText("Detail search: [?other=1]")).toBeTruthy();
   });
+
+  test("a tab change keeps the list search that Back restores", async () => {
+    // A tab change replaces the history entry; the router state carrying the
+    // list's query string has to ride along or Back lands on the plain list.
+    renderDetail({
+      skillId: "skill-1",
+      listSearch: "?filter=installed&category=email",
+    });
+    await waitFor(() => {
+      expect(screen.getByText("Tab: files")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText("Open history"));
+    await waitFor(() => {
+      expect(screen.getByText("Tab: history")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText("Back to skills"));
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "Superpowers list at: [?filter=installed&category=email]",
+        ),
+      ).toBeTruthy();
+    });
+  });
 });

--- a/clients/web/src/domains/intelligence/skill-detail-page.tsx
+++ b/clients/web/src/domains/intelligence/skill-detail-page.tsx
@@ -62,7 +62,8 @@ export function SkillDetailPage() {
   // can link straight to a skill's history
   // (`/assistant/skills/:skillId?tab=history`). Files is the default and
   // keeps the URL clean; a tab change replaces rather than pushes so Back
-  // still leaves the page.
+  // still leaves the page, and carries the entry's router state forward so
+  // the list search above survives the switch.
   const [searchParams, setSearchParams] = useSearchParams();
   const tab = parseSkillDetailTab(searchParams.get("tab"));
   const handleTabChange = useCallback(
@@ -73,9 +74,9 @@ export function SkillDetailPage() {
       } else {
         params.delete("tab");
       }
-      setSearchParams(params, { replace: true });
+      setSearchParams(params, { replace: true, state: location.state });
     },
-    [searchParams, setSearchParams],
+    [searchParams, setSearchParams, location.state],
   );
 
   const skillsQuery = useQuery({

--- a/clients/web/src/domains/intelligence/skill-detail-page.tsx
+++ b/clients/web/src/domains/intelligence/skill-detail-page.tsx
@@ -1,11 +1,21 @@
 import { useQuery } from "@tanstack/react-query";
 import { ArrowLeft, SearchX } from "lucide-react";
 import { useCallback, useMemo, useRef } from "react";
-import { Navigate, useLocation, useNavigate, useParams } from "react-router";
+import {
+  Navigate,
+  useLocation,
+  useNavigate,
+  useParams,
+  useSearchParams,
+} from "react-router";
 
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { SkillRemovalDialog } from "@/components/skill-removal-dialog";
-import { SkillDetail } from "@/domains/intelligence/components/skills/skill-detail";
+import {
+  parseSkillDetailTab,
+  SkillDetail,
+  type SkillDetailTab,
+} from "@/domains/intelligence/components/skills/skill-detail";
 import { SkillDetailMobile } from "@/domains/intelligence/components/skills/skill-detail-mobile";
 import { SkillsErrorState } from "@/domains/intelligence/components/skills/skills-error-state";
 import { SkillsLoadingState } from "@/domains/intelligence/components/skills/skills-loading-state";
@@ -47,6 +57,26 @@ export function SkillDetailPage() {
   const routerState = location.state as { listSearch?: unknown } | null;
   const listSearch =
     typeof routerState?.listSearch === "string" ? routerState.listSearch : "";
+
+  // The desktop view's Files/History tab rides `?tab=`, so an in-chat card
+  // can link straight to a skill's history
+  // (`/assistant/skills/:skillId?tab=history`). Files is the default and
+  // keeps the URL clean; a tab change replaces rather than pushes so Back
+  // still leaves the page.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const tab = parseSkillDetailTab(searchParams.get("tab"));
+  const handleTabChange = useCallback(
+    (next: SkillDetailTab) => {
+      const params = new URLSearchParams(searchParams);
+      if (next === "history") {
+        params.set("tab", "history");
+      } else {
+        params.delete("tab");
+      }
+      setSearchParams(params, { replace: true });
+    },
+    [searchParams, setSearchParams],
+  );
 
   const skillsQuery = useQuery({
     ...skillsGetOptions({
@@ -182,7 +212,7 @@ export function SkillDetailPage() {
           swipeContainerRef={swipeContainerRef}
         />
       ) : (
-        <SkillDetail {...detailProps} />
+        <SkillDetail {...detailProps} tab={tab} onTabChange={handleTabChange} />
       )}
       <SkillRemovalDialog
         skillName={skillPendingRemoval?.name ?? null}


### PR DESCRIPTION
Part of LUM-3295

## TL;DR

The Level Up card's "Full level-up history" row showed a link icon but nothing was clickable. `work_result` items with an `href` are now real links (in-app paths navigate in place, external URLs open outside), and the skill detail page accepts `?tab=history` so a card can land straight on a skill's History tab. While in the file, `work-result-surface.tsx` moves onto the canonical `WorkResultSurfaceDataSchema` from `@vellumai/assistant-api` instead of its own redeclared types.

## What changes for the user

| Before | After |
|---|---|
| A `work_result` item with an `href` shows an external-link icon; clicking the row does nothing | The whole row is a link. In-app paths (`/assistant/skills/<id>?tab=history`) navigate within the app and show a chevron; http(s)/mailto/tel URLs open in a new tab (system browser on Electron, `SFSafariViewController` on iOS) and show the external-link icon; anything else (`javascript:`, `//host`, `/\host`, bare words) renders as an unlinked row |
| The skill page always opens on Files; the tab is not in the URL | `/assistant/skills/<id>?tab=history` opens on History (once the history query resolves; the existing "hide the strip when there is nothing to show" rule is unchanged). Files stays the default with no param; switching tabs replaces the URL rather than pushing and keeps the router state, so Back still restores the filtered My Superpowers list |
| The `ui_show` shape docs list `href?` with no meaning | The docs and the schema comment say what `href` accepts |

## Design

- **Canonical schema.** `#38772` (LUM-2579) added `WorkResultSurfaceDataSchema` and migrated the other surface components to parse with the shared schemas, but `work-result-surface.tsx` kept a hand-written copy of the data shape plus its own `parse*` helpers, and the two had already drifted. It now does what choice/list/table do: `WorkResultSurfaceDataSchema.safeParse(surface.data)` in a `useMemo`, types from `@vellumai/assistant-api`. The schema is tolerant (a wrong field coerces to `""`/`undefined` rather than failing), so blank titles, labels and diffs are dropped at render, which is what the old parser did on the way in. Net: the local wire types and ~120 lines of parsing are gone; the only local type left is the view-side `WorkResultItemLink`.
- **Link classification.** `parseItemLink` narrows the model-authored `href`: an in-app path is one that resolves against a probe origin to the same origin (`new URL(href, base).origin === base`), which rejects `//host`, the spec's backslash form `/\host`, and `/<tab>/host` (the parser strips tabs/newlines before it looks for an authority) with one check; external is `isRelayableExternalHref` from `utils/sandbox-bridge.ts`, the same allowlist the sandboxed frames use.
- **Anchor rendering.** A linked row is one anchor (the clickable-row pattern in `skill-created-card.tsx`): a router `Link` for in-app paths; `target="_blank" rel="noopener noreferrer"` plus `handleNativeAnchorClick` for external, the same shape as `OAuthAwareLink` in `chat-markdown-message.tsx`. A real anchor keeps right-click / copy-link and gives the row an accessible role.
- **Tab param.** Lives in the route component `SkillDetailPage` (it already owns `useParams`, `location.state`, and the back navigation) and is passed to `SkillDetail` as `tab` / `onTabChange`. `parseSkillDetailTab` is the single place the value is narrowed; unknown values fall back to Files; the replace carries `location.state`. Same shape as `developer-page.tsx` / `integrations-page.tsx`.

## Why this is safe

- Client-only rendering over data the daemon already sends: `href` has been in `WorkResultItemSchema` all along. No version gate needed (`BACKWARDS_COMPAT.md`, "when a gate is unnecessary").
- Unlinked items render exactly as before (`ItemRow` falls through to the same `div`); the schema migration is render-identical for well-formed payloads (checked every existing WorkResult story in Storybook).
- `?tab=` is additive: URLs without it behave as today. `handleBack` navigates by path and is unaffected.
- No new copy, so no i18n keys. `SkillDetailMobile` has no tabs and ignores the param.
- Tests: `work-result-surface.test.tsx` covers in-app navigation, external anchor attributes, a rejected-href table (`javascript:`, `//host`, `/\host`, `/<tab>/host`, `//[`, relative, `#`, empty, non-string), and `parseItemLink`; `skill-detail-page.test.tsx` covers the deep link, unknown values, write-back preserving other params, and Back after a tab switch still restoring the list search (the `SkillDetail` stub is typed against the module). Stories: `Chat/Surfaces/WorkResult/LevelUp` (in-app + external rows) and `Intelligence/Skills/SkillDetail/HistoryDeepLink`; both checked in Storybook. Local `bun test` is blocked in this environment; CI runs them.

## Deferred

- The `level-up` plugin (`vellum-ai/level-up`) sends `/assistant/library/level-up`; vellum-ai/level-up#7 points each skill's row at `/assistant/skills/<name>?tab=history` (and gives the link section the title the host requires). After it merges, the pin in `plugins/marketplace.json` gets bumped. Separate repo, so separate PRs (tracked on LUM-3295).
- Mobile skill detail has no History tab, so `?tab=history` lands on the mobile detail's files view. Adding history to the mobile view is its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
