### PR TITLE
fix(skills): require activation_hints on scaffold_managed_skill (JARVIS-1533)

### DIFF
--- a/assistant/src/__tests__/managed-skill-lifecycle.test.ts
+++ b/assistant/src/__tests__/managed-skill-lifecycle.test.ts
@@ -47,6 +47,9 @@ import { skillLoadTool } from "../tools/skills/load.js";
 import { executeScaffoldManagedSkill } from "../tools/skills/scaffold-managed.js";
 import type { ToolContext } from "../tools/types.js";
 
+/** scaffold_managed_skill requires activation hints; a fixed set for tests. */
+const HINTS = ["user asks to run the lifecycle test procedure"];
+
 function makeContext(): ToolContext {
   return {
     workingDir: "/tmp",
@@ -126,6 +129,7 @@ Run the custom lifecycle verification procedure.
         name: "Lifecycle Test",
         description: "Integration test skill.",
         body_markdown: "Run the lifecycle test procedure.",
+        activation_hints: HINTS,
         emoji: "🧪",
       },
       makeContext(),
@@ -185,6 +189,7 @@ Run the custom lifecycle verification procedure.
         name: "V1",
         description: "Version 1.",
         body_markdown: "Original body.",
+        activation_hints: HINTS,
       },
       ctx,
     );
@@ -196,6 +201,7 @@ Run the custom lifecycle verification procedure.
         name: "V2",
         description: "Version 2.",
         body_markdown: "Updated body.",
+        activation_hints: HINTS,
         overwrite: true,
       },
       ctx,
@@ -241,6 +247,7 @@ Run the custom lifecycle verification procedure.
         description: "Created from scaffold.",
         body_markdown:
           "This skill was dynamically created.\n\nRun: `echo chain-test-ok`",
+        activation_hints: HINTS,
       },
       ctx,
     );

--- a/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
@@ -98,6 +98,12 @@ import { readInstallMeta, writeInstallMeta } from "../skills/install-meta.js";
 import { executeScaffoldManagedSkill } from "../tools/skills/scaffold-managed.js";
 import type { ToolContext } from "../tools/types.js";
 
+/**
+ * scaffold_managed_skill requires activation hints. Tests that are not about
+ * hints pass this fixed set so the input they exercise stays the subject.
+ */
+const HINTS = ["user asks to run the procedure under test"];
+
 function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
   return {
     workingDir: "/tmp",
@@ -161,6 +167,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Test Skill",
         description: "A test skill",
         body_markdown: "Do the thing.",
+        activation_hints: HINTS,
       },
       makeContext(),
     );
@@ -202,6 +209,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Legacy Input",
         description: "A test skill",
         body_markdown: "Do the thing.",
+        activation_hints: HINTS,
         add_to_index: true,
       },
       makeContext(),
@@ -222,6 +230,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Original",
         description: "First",
         body_markdown: "V1.",
+        activation_hints: HINTS,
       },
       makeContext(),
     );
@@ -232,6 +241,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Duplicate",
         description: "Second",
         body_markdown: "V2.",
+        activation_hints: HINTS,
       },
       makeContext(),
     );
@@ -244,6 +254,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Overwritten",
         description: "Third",
         body_markdown: "V3.",
+        activation_hints: HINTS,
         overwrite: true,
       },
       makeContext(),
@@ -278,6 +289,7 @@ describe("scaffold_managed_skill tool", () => {
         name: 'Test\ninjected_field: "evil"',
         description: "Desc\rwith\r\ncarriage returns",
         body_markdown: "Body content.",
+        activation_hints: HINTS,
         emoji: "🔥\nextra: true",
       },
       makeContext(),
@@ -306,6 +318,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Parent",
         description: "Has children",
         body_markdown: "Parent body.",
+        activation_hints: HINTS,
         includes: ["child-a", "child-b"],
       },
       makeContext(),
@@ -326,6 +339,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Normalized",
         description: "Tests normalization",
         body_markdown: "Body.",
+        activation_hints: HINTS,
         includes: ["  child-a  ", "child-b", "child-a"],
       },
       makeContext(),
@@ -346,6 +360,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Bad",
         description: "Has non-string",
         body_markdown: "Body.",
+        activation_hints: HINTS,
         includes: ["child-a", 42],
       },
       makeContext(),
@@ -362,6 +377,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Empty",
         description: "Has empty string",
         body_markdown: "Body.",
+        activation_hints: HINTS,
         includes: ["", "child-a"],
       },
       makeContext(),
@@ -378,6 +394,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Whitespace",
         description: "Has whitespace-only",
         body_markdown: "Body.",
+        activation_hints: HINTS,
         includes: ["child-a", "  "],
       },
       makeContext(),
@@ -394,6 +411,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Solo",
         description: "No children",
         body_markdown: "Body.",
+        activation_hints: HINTS,
       },
       makeContext(),
     );
@@ -521,24 +539,109 @@ describe("scaffold_managed_skill tool", () => {
     expect(result.content).toContain("must be an array");
   });
 
-  test("omits activation-hints / avoid-when when not provided", async () => {
+  test("omits avoid-when when not provided", async () => {
     const result = await executeScaffoldManagedSkill(
       {
-        skill_id: "no-hints",
-        name: "No Hints",
-        description: "No triggers",
+        skill_id: "no-avoid",
+        name: "No Avoid",
+        description: "No avoid clause",
         body_markdown: "Body.",
+        activation_hints: HINTS,
       },
       makeContext(),
     );
 
     expect(result.isError).toBe(false);
     const content = readFileSync(
-      join(TEST_DIR, "skills", "no-hints", "SKILL.md"),
+      join(TEST_DIR, "skills", "no-avoid", "SKILL.md"),
       "utf-8",
     );
-    expect(content).not.toContain("activation-hints");
+    expect(content).toContain("activation-hints");
     expect(content).not.toContain("avoid-when");
+  });
+
+  test("rejects a scaffold with no activation_hints and writes nothing, for user and retrospective origins alike", async () => {
+    // Omitted and empty are the same omission: both leave the skill with no
+    // "Use when" retrieval text.
+    const inputs = [
+      { skill_id: "no-hints-omitted" },
+      { skill_id: "no-hints-empty", activation_hints: [] },
+    ];
+    for (const context of [makeContext(), makeRetrospectiveContext()]) {
+      for (const extra of inputs) {
+        const result = await executeScaffoldManagedSkill(
+          {
+            name: "No Hints",
+            description: "No triggers",
+            body_markdown: "Body.",
+            ...extra,
+          },
+          context,
+        );
+        expect(result.isError).toBe(true);
+        expect(result.content).toContain("activation_hints is required");
+        // A rejected create leaves no half-written skill behind.
+        expect(
+          existsSync(join(TEST_DIR, "skills", extra.skill_id, "SKILL.md")),
+        ).toBe(false);
+      }
+    }
+  });
+
+  test("an overwrite that omits activation_hints is rejected, names the current hints, and leaves the skill untouched", async () => {
+    const hints = ["user asks to deploy staging", "user asks to cut a release"];
+    await executeScaffoldManagedSkill(
+      {
+        skill_id: "keep-hints",
+        name: "Keep Hints",
+        description: "V1",
+        body_markdown: "V1 body.",
+        activation_hints: hints,
+      },
+      makeContext(),
+    );
+
+    const result = await executeScaffoldManagedSkill(
+      {
+        skill_id: "keep-hints",
+        name: "Keep Hints",
+        description: "V2",
+        body_markdown: "V2 body.",
+        overwrite: true,
+      },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("activation_hints is required");
+    // The error quotes every current hint so the retry can carry them forward.
+    for (const hint of hints) {
+      expect(result.content).toContain(hint);
+    }
+    // Scaffolding rewrites the whole SKILL.md, so the rejected overwrite must
+    // not have reached disk: body and hints are still V1's.
+    const content = readFileSync(
+      join(TEST_DIR, "skills", "keep-hints", "SKILL.md"),
+      "utf-8",
+    );
+    expect(content).toContain("V1 body.");
+    expect(content).not.toContain("V2 body.");
+    const skill = loadSkillCatalog().find((s) => s.id === "keep-hints");
+    expect(skill!.activationHints).toEqual(hints);
+  });
+
+  test("a create with no activation_hints gets the plain error, with no current-hints clause", async () => {
+    const result = await executeScaffoldManagedSkill(
+      {
+        skill_id: "fresh-no-hints",
+        name: "Fresh",
+        description: "Never existed",
+        body_markdown: "Body.",
+      },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).not.toContain("currently declares");
   });
 
   test("passes category through to the written skill, lowercased and trimmed", async () => {
@@ -548,6 +651,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Categorized",
         description: "Has a category",
         body_markdown: "Body.",
+        activation_hints: HINTS,
         category: "  Development  ",
       },
       makeContext(),
@@ -571,6 +675,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Bad Category",
         description: "Non-string category",
         body_markdown: "Body.",
+        activation_hints: HINTS,
         category: 42,
       },
       makeContext(),
@@ -587,6 +692,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "No Category",
         description: "Uncategorized",
         body_markdown: "Body.",
+        activation_hints: HINTS,
       },
       makeContext(),
     );
@@ -606,6 +712,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Bad",
         description: "Bad",
         body_markdown: "Bad.",
+        activation_hints: HINTS,
       },
       makeContext(),
     );
@@ -621,6 +728,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Files Skill",
         description: "Has companion files",
         body_markdown: "See references/failure-modes.md.",
+        activation_hints: HINTS,
         files: [
           {
             path: "references/failure-modes.md",
@@ -654,6 +762,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Copy From Skill",
         description: "Bundles a proven script",
         body_markdown: "Run scripts/proven-script.py.",
+        activation_hints: HINTS,
         files: [{ path: "scripts/proven-script.py", copy_from: sourcePath }],
       },
       makeContext(),
@@ -684,6 +793,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Both",
         description: "Both content and copy_from",
         body_markdown: "Body.",
+        activation_hints: HINTS,
         files: [
           { path: "scripts/dupe.py", content: "x", copy_from: sourcePath },
         ],
@@ -703,6 +813,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Bad Type",
         description: "copy_from wrong type",
         body_markdown: "Body.",
+        activation_hints: HINTS,
         files: [{ path: "scripts/x.py", copy_from: 42 }],
       },
       makeContext(),
@@ -719,6 +830,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Traversal",
         description: "Bad path",
         body_markdown: "Body.",
+        activation_hints: HINTS,
         files: [{ path: "../escape.md", content: "owned" }],
       },
       makeContext(),
@@ -750,6 +862,7 @@ describe("scaffold_managed_skill tool", () => {
           name: "Bad",
           description: "Bad files",
           body_markdown: "Body.",
+          activation_hints: HINTS,
           files,
         },
         makeContext(),
@@ -765,6 +878,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "E2E Child",
         description: "Child for e2e test",
         body_markdown: "Child instructions.",
+        activation_hints: HINTS,
       },
       makeContext(),
     );
@@ -776,6 +890,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "E2E Parent",
         description: "Parent with includes",
         body_markdown: "Parent instructions.",
+        activation_hints: HINTS,
         includes: ["e2e-child"],
       },
       makeContext(),
@@ -806,6 +921,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Retro Skill",
         description: "Authored by a retrospective pass",
         body_markdown: "Do the procedure.",
+        activation_hints: HINTS,
       },
       makeRetrospectiveContext(),
     );
@@ -830,6 +946,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "User Skill",
         description: "Authored interactively",
         body_markdown: "Do the thing.",
+        activation_hints: HINTS,
       },
       makeContext(),
     );
@@ -846,6 +963,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Protected",
         description: "User authored",
         body_markdown: "Original body.",
+        activation_hints: HINTS,
       },
       makeContext(),
     );
@@ -858,6 +976,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Protected",
         description: "Rewritten by retrospective",
         body_markdown: "Rewritten body.",
+        activation_hints: HINTS,
         overwrite: true,
       },
       makeRetrospectiveContext(),
@@ -871,6 +990,36 @@ describe("scaffold_managed_skill tool", () => {
     expect(installMetaFor("protected")?.author).toBe("user");
   });
 
+  test("the ownership refusal is reported ahead of a missing activation_hints", async () => {
+    // A caller that may not touch the skill at all should hear that first,
+    // rather than fix its hints and then be refused on the retry.
+    await executeScaffoldManagedSkill(
+      {
+        skill_id: "protected-order",
+        name: "Protected",
+        description: "User authored",
+        body_markdown: "Original body.",
+        activation_hints: HINTS,
+      },
+      makeContext(),
+    );
+
+    const result = await executeScaffoldManagedSkill(
+      {
+        skill_id: "protected-order",
+        name: "Protected",
+        description: "Rewritten by retrospective",
+        body_markdown: "Rewritten body.",
+        overwrite: true,
+      },
+      makeRetrospectiveContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("not verifiably assistant-authored");
+    expect(result.content).not.toContain("activation_hints is required");
+  });
+
   test("retrospective refuses to write companion files into an author:user skill", async () => {
     await executeScaffoldManagedSkill(
       {
@@ -878,6 +1027,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Protected Files",
         description: "User authored",
         body_markdown: "Original body.",
+        activation_hints: HINTS,
       },
       makeContext(),
     );
@@ -888,6 +1038,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Protected Files",
         description: "Refine attempt",
         body_markdown: "Original body.",
+        activation_hints: HINTS,
         overwrite: true,
         files: [{ path: "references/notes.md", content: "gotchas" }],
       },
@@ -912,6 +1063,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Untagged",
         description: "No author",
         body_markdown: "Original body.",
+        activation_hints: HINTS,
       },
       makeContext(),
     );
@@ -929,6 +1081,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Untagged",
         description: "Rewritten by retrospective",
         body_markdown: "Rewritten body.",
+        activation_hints: HINTS,
         overwrite: true,
       },
       makeRetrospectiveContext(),
@@ -949,6 +1102,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Assistant Owned",
         description: "First pass",
         body_markdown: "V1 procedure.",
+        activation_hints: HINTS,
       },
       makeRetrospectiveContext(),
     );
@@ -960,6 +1114,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Assistant Owned",
         description: "Refined",
         body_markdown: "V2 procedure.",
+        activation_hints: HINTS,
         overwrite: true,
         files: [{ path: "references/failure-modes.md", content: "gotchas" }],
       },
@@ -998,6 +1153,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Lineage Skill",
         description: "Distilled from an observed procedure",
         body_markdown: "Do the procedure.",
+        activation_hints: HINTS,
       },
       makeRetrospectiveContext({ conversationId: "retro-run-conv" }),
       {
@@ -1023,6 +1179,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "User No Lineage",
         description: "Authored interactively",
         body_markdown: "Do the thing.",
+        activation_hints: HINTS,
       },
       makeContext(),
       { getConversation: lookup },
@@ -1054,6 +1211,7 @@ describe("scaffold_managed_skill tool", () => {
           name: "Orphan Lineage",
           description: "Parent not resolvable",
           body_markdown: "Do the procedure.",
+          activation_hints: HINTS,
         },
         makeRetrospectiveContext({ conversationId: "retro-run-conv" }),
         { getConversation: lookup },
@@ -1075,6 +1233,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Lookup Throws",
         description: "DB unavailable during lineage resolution",
         body_markdown: "Do the procedure.",
+        activation_hints: HINTS,
       },
       makeRetrospectiveContext({ conversationId: "retro-run-conv" }),
       {
@@ -1103,6 +1262,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "No Conversation",
         description: "Context carries no conversation id",
         body_markdown: "Do the procedure.",
+        activation_hints: HINTS,
       },
       context,
       { getConversation: lookup },
@@ -1125,6 +1285,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Deep Research",
         description: "Shadow attempt",
         body_markdown: "Body.",
+        activation_hints: HINTS,
       },
       makeRetrospectiveContext(),
       catalogSeam({ id: "deep-research", source: "bundled" }),
@@ -1146,6 +1307,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Blitz",
         description: "Shadow-overwrite attempt",
         body_markdown: "Body.",
+        activation_hints: HINTS,
         overwrite: true,
       },
       makeRetrospectiveContext(),
@@ -1165,6 +1327,7 @@ describe("scaffold_managed_skill tool", () => {
           name: "Covered",
           description: "Shadow attempt",
           body_markdown: "Body.",
+          activation_hints: HINTS,
         },
         makeRetrospectiveContext(),
         catalogSeam({ id: "covered-proc", source }),
@@ -1184,6 +1347,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "No Meta",
         description: "Lost provenance",
         body_markdown: "Original body.",
+        activation_hints: HINTS,
       },
       makeContext(),
     );
@@ -1197,6 +1361,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "No Meta",
         description: "Rewrite attempt",
         body_markdown: "Rewritten body.",
+        activation_hints: HINTS,
         overwrite: true,
       },
       makeRetrospectiveContext(),
@@ -1217,6 +1382,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Corrupt Meta",
         description: "Bad provenance",
         body_markdown: "Original body.",
+        activation_hints: HINTS,
       },
       makeContext(),
     );
@@ -1229,6 +1395,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Corrupt Meta",
         description: "Rewrite attempt",
         body_markdown: "Rewritten body.",
+        activation_hints: HINTS,
         overwrite: true,
       },
       makeRetrospectiveContext(),
@@ -1250,6 +1417,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Fresh Proc",
         description: "Newly observed procedure",
         body_markdown: "Do the procedure.",
+        activation_hints: HINTS,
       },
       makeRetrospectiveContext(),
       catalogSeam({ id: "something-else", source: "bundled" }),
@@ -1281,6 +1449,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "  Card\nSkill  ",
         description: " Does\r\ncard things ",
         body_markdown: "Do the procedure.",
+        activation_hints: HINTS,
         emoji: " 🧭 ",
       },
       makeRetrospectiveContext({ conversationId: "retro-run-conv" }),
@@ -1313,6 +1482,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "No Emoji",
         description: "Card without an emoji",
         body_markdown: "Do the procedure.",
+        activation_hints: HINTS,
         emoji: " \n ",
       },
       makeRetrospectiveContext({ conversationId: "retro-run-conv" }),
@@ -1355,6 +1525,7 @@ describe("scaffold_managed_skill tool", () => {
           name: "No Card",
           description: "Fork parent not resolvable",
           body_markdown: "Do the procedure.",
+          activation_hints: HINTS,
         },
         makeRetrospectiveContext({ conversationId: "retro-run-conv" }),
         { getConversation: lookup },
@@ -1376,6 +1547,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Refined Skill",
         description: "First pass",
         body_markdown: "V1 procedure.",
+        activation_hints: HINTS,
       },
       makeRetrospectiveContext({ conversationId: "retro-run-conv" }),
       lineageSeam(),
@@ -1390,6 +1562,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Refined Skill",
         description: "Refined",
         body_markdown: "V2 procedure.",
+        activation_hints: HINTS,
         overwrite: true,
       },
       makeRetrospectiveContext({ conversationId: "retro-run-conv" }),
@@ -1407,6 +1580,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Overwrite Fresh",
         description: "Overwrite flag on a fresh id",
         body_markdown: "Do the procedure.",
+        activation_hints: HINTS,
         overwrite: true,
       },
       makeRetrospectiveContext({ conversationId: "retro-run-conv" }),
@@ -1431,6 +1605,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "User No Card",
         description: "Authored interactively",
         body_markdown: "Do the thing.",
+        activation_hints: HINTS,
       },
       makeContext({ conversationId: "retro-run-conv" }),
       lineageSeam(),
@@ -1449,6 +1624,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Enqueue Throws",
         description: "Jobs DB unavailable at enqueue time",
         body_markdown: "Do the procedure.",
+        activation_hints: HINTS,
       },
       makeRetrospectiveContext({ conversationId: "retro-run-conv" }),
       lineageSeam(),
@@ -1469,6 +1645,7 @@ describe("scaffold_managed_skill tool", () => {
           name: `Skill ${skillId}`,
           description: `Does ${skillId}`,
           body_markdown: "Do the procedure.",
+          activation_hints: HINTS,
         },
         makeRetrospectiveContext({ conversationId: "retro-run-conv" }),
         lineageSeam(),
@@ -1507,6 +1684,7 @@ describe("background skill update notification", () => {
         name: "Weekly Report Export",
         description: `seeded ${id}`,
         body_markdown: body,
+        activation_hints: HINTS,
       },
       makeContext(),
     );
@@ -1536,6 +1714,7 @@ describe("background skill update notification", () => {
         name: "Weekly Report Export",
         description: "export the weekly usage report",
         body_markdown: "1. Refined steps.",
+        activation_hints: HINTS,
         overwrite: true,
       },
       makeRetrospectiveContext({ conversationId: "retro-run-conv" }),
@@ -1578,6 +1757,7 @@ describe("background skill update notification", () => {
         name: "Weekly Report Export",
         description: "export the weekly usage report",
         body_markdown: "1. Refined steps.",
+        activation_hints: HINTS,
         overwrite: true,
       },
       makeRetrospectiveContext({ conversationId: "retro-run-conv" }),
@@ -1597,6 +1777,7 @@ describe("background skill update notification", () => {
         name: "Brand New Skill",
         description: "something never seen before",
         body_markdown: "1. Do it.",
+        activation_hints: HINTS,
       },
       makeRetrospectiveContext({ conversationId: "retro-run-conv" }),
       lineage(),
@@ -1614,6 +1795,7 @@ describe("background skill update notification", () => {
         name: "User Skill",
         description: "asked for",
         body_markdown: "V1.",
+        activation_hints: HINTS,
       },
       makeContext(),
     );
@@ -1625,6 +1807,7 @@ describe("background skill update notification", () => {
         name: "User Skill",
         description: "asked for",
         body_markdown: "V2.",
+        activation_hints: HINTS,
         overwrite: true,
       },
       makeContext(),

--- a/assistant/src/config/bundled-skills/skill-management/TOOLS.json
+++ b/assistant/src/config/bundled-skills/skill-management/TOOLS.json
@@ -45,7 +45,7 @@
           "activation_hints": {
             "type": "array",
             "items": { "type": "string" },
-            "description": "Required. 1-4 short trigger phrases describing the situations where this skill should activate, phrased as the observed intent (e.g. \"user asks to deploy staging\"). Surfaced in memory as a \"Use when: …\" clause so the skill is retrievable by intent, not just by name. Scaffolding rewrites the whole SKILL.md, so on an overwrite pass the hints the skill should keep (revised if the procedure changed)."
+            "description": "Required. 1-4 short trigger phrases describing the situations where this skill should activate, phrased as the observed intent (e.g. \"user asks to deploy staging\"). Surfaced in memory as a \"Use when: …\" clause so the skill is retrievable by intent, not just by name. Scaffolding rewrites the whole SKILL.md, so an overwrite must pass the hints the skill should keep, revised if the procedure changed."
           },
           "avoid_when": {
             "type": "array",

--- a/assistant/src/config/bundled-skills/skill-management/TOOLS.json
+++ b/assistant/src/config/bundled-skills/skill-management/TOOLS.json
@@ -40,12 +40,12 @@
           "includes": {
             "type": "array",
             "items": { "type": "string" },
-            "description": "Optional list of child skill IDs that this skill includes (metadata only, no auto-activation)."
+            "description": "Optional list of child skill IDs this skill composes. When this skill is loaded via skill_load, each child's body is inlined after the parent's and the child's tools are projected, so the parent can rely on the child's procedure without re-stating it. Does not affect which skills get selected for a turn."
           },
           "activation_hints": {
             "type": "array",
             "items": { "type": "string" },
-            "description": "Optional trigger phrases describing the situations where this skill should activate, phrased as the observed intent (e.g. \"user asks to deploy staging\"). Surfaced in memory as a \"Use when: …\" clause so the skill is retrievable by intent, not just by name."
+            "description": "Required. 1-4 short trigger phrases describing the situations where this skill should activate, phrased as the observed intent (e.g. \"user asks to deploy staging\"). Surfaced in memory as a \"Use when: …\" clause so the skill is retrievable by intent, not just by name. Scaffolding rewrites the whole SKILL.md, so on an overwrite pass the hints the skill should keep (revised if the procedure changed)."
           },
           "avoid_when": {
             "type": "array",
@@ -79,7 +79,13 @@
             "description": "Deprecated no-op compatibility field. Skills are discovered from top-level SKILL.md files."
           }
         },
-        "required": ["skill_id", "name", "description", "body_markdown"]
+        "required": [
+          "skill_id",
+          "name",
+          "description",
+          "body_markdown",
+          "activation_hints"
+        ]
       },
       "executor": "tools/scaffold-managed.ts",
       "execution_target": "host"

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -104,11 +104,18 @@ export interface SkillSummary {
   owner?: OwnerInfo;
   /** Parsed tool manifest metadata, if the skill has a valid TOOLS.json. */
   toolManifest?: SkillToolManifestMeta;
-  /** IDs of child skills that this skill includes (metadata-only, not auto-activated). */
+  /**
+   * IDs of child skills this skill composes. `skill_load` inlines each child's
+   * body and projects its tools when the parent loads (tools/skills/load.ts);
+   * they play no part in which skills get selected for a turn.
+   */
   includes?: string[];
   /** Feature flag ID declared in frontmatter. Only skills with this field are subject to feature flag gating. */
   featureFlag?: string;
-  /** Compact routing cues projected into <available_skills> XML to guide skill selection. */
+  /**
+   * Intent phrases rendered into the skill's capability card as "Use when: ..."
+   * (memory substrate/skill-content.ts), which is the text skill routing scores.
+   */
   activationHints?: string[];
   /** Conditions under which this skill should NOT be loaded. */
   avoidWhen?: string[];

--- a/assistant/src/tools/skills/scaffold-managed.ts
+++ b/assistant/src/tools/skills/scaffold-managed.ts
@@ -371,15 +371,10 @@ export async function executeScaffoldManagedSkill(
     }
   }
 
-  // Activation hints are the skill's intent-phrased retrieval signal: routing
-  // scores each skill on description + "Use when: <hints>", so a skill without
-  // them competes on its description alone. Both authoring prompts (the
-  // skill-management SKILL.md and the retrospective instruction) already
-  // mandate hints; this is where the mandate holds. Checked after the
-  // ownership backstop so a caller that may not touch the skill at all hears
-  // that first. Because scaffolding rewrites the whole SKILL.md, an overwrite
-  // that omits hints would strip the ones the skill has, so the error names
-  // the current hints for the caller to carry forward.
+  // Hints are the skill's "Use when:" retrieval text, and scaffolding rewrites
+  // the whole SKILL.md, so an overwrite without them would strip the ones the
+  // skill has. Checked after the ownership backstop so a caller that may not
+  // touch the skill at all hears that first.
   if (!activationHints) {
     const currentHints = managedSkillExistedBefore
       ? loadCatalog().find((s) => s.id === id && s.source === "managed")

--- a/assistant/src/tools/skills/scaffold-managed.ts
+++ b/assistant/src/tools/skills/scaffold-managed.ts
@@ -28,10 +28,28 @@ function sanitizeFrontmatterValue(value: string): string {
 }
 
 /**
- * Validate + normalize an optional string-array input (sanitize, drop blanks,
- * dedupe). Returns `{ error }` on the first invalid element, or `{ value }`
- * holding the normalized array (undefined when empty). Shared by the
- * includes / activation_hints / avoid_when inputs so they behave identically.
+ * Self-correcting error for a scaffold call with no activation hints. When the
+ * skill already exists and declares hints, they are quoted so the retry can
+ * carry them forward instead of inventing new ones.
+ */
+function missingActivationHintsMessage(
+  skillId: string,
+  currentHints: string[] | undefined,
+): string {
+  const base =
+    'activation_hints is required: pass 1-4 short trigger phrases stating the intent this skill serves (for example "user asks to deploy staging") so it can be found later by intent, not just by name.';
+  if (!currentHints || currentHints.length === 0) {
+    return base;
+  }
+  return `${base} Scaffolding rewrites the whole SKILL.md, and skill "${skillId}" currently declares ${JSON.stringify(currentHints)}; pass them again, revised if the procedure changed.`;
+}
+
+/**
+ * Validate + normalize a string-array input (sanitize, drop blanks, dedupe).
+ * Returns `{ error }` on the first invalid element, or `{ value }` holding
+ * the normalized array (undefined when absent or empty). Shared by the
+ * includes / activation_hints / avoid_when inputs so they behave identically;
+ * whether an absent value is acceptable is the caller's call.
  * Each element goes through sanitizeFrontmatterValue: activation_hints /
  * avoid_when are concatenated verbatim into capability memory text (see
  * buildSkillContent), so an embedded newline could otherwise smuggle an extra
@@ -145,7 +163,11 @@ export async function executeScaffoldManagedSkill(
   input: Record<string, unknown>,
   context: ToolContext,
   deps: {
-    loadCatalog?: () => { id: string; source: SkillSource }[];
+    loadCatalog?: () => {
+      id: string;
+      source: SkillSource;
+      activationHints?: string[];
+    }[];
     getConversation?: (
       id: string,
     ) => { forkParentConversationId: string | null } | null;
@@ -184,9 +206,10 @@ export async function executeScaffoldManagedSkill(
     };
   }
 
-  // Validate and normalize the optional string-array inputs. `includes` lists
-  // child skill IDs; activation_hints / avoid_when become the skill's
-  // "Use when:" / "Avoid when:" retrieval signal in memory.
+  // Validate and normalize the string-array inputs. `includes` lists child
+  // skill IDs; activation_hints / avoid_when become the skill's "Use when:" /
+  // "Avoid when:" retrieval signal in memory. Shape errors surface here;
+  // activation_hints' presence is enforced below, once ownership is settled.
   const includesResult = normalizeOptionalStringArray(
     input.includes,
     "includes",
@@ -308,6 +331,8 @@ export async function executeScaffoldManagedSkill(
     join(getManagedSkillDir(id), "SKILL.md"),
   );
 
+  const loadCatalog = deps.loadCatalog ?? (() => loadSkillCatalog());
+
   // Ownership backstop (retrospective origin only): the retrospective may author
   // a skill ONLY if it owns it. Fail closed on either of two collisions.
   if (fromRetrospective) {
@@ -318,7 +343,6 @@ export async function executeScaffoldManagedSkill(
     // create AND overwrite. The prompt directs the model to skip when an
     // existing skill of any source already covers the procedure; this enforces
     // it.
-    const loadCatalog = deps.loadCatalog ?? (() => loadSkillCatalog());
     const nonManagedOwner = loadCatalog().find(
       (s) => s.id === id && s.source !== "managed",
     );
@@ -345,6 +369,26 @@ export async function executeScaffoldManagedSkill(
         isError: true,
       };
     }
+  }
+
+  // Activation hints are the skill's intent-phrased retrieval signal: routing
+  // scores each skill on description + "Use when: <hints>", so a skill without
+  // them competes on its description alone. Both authoring prompts (the
+  // skill-management SKILL.md and the retrospective instruction) already
+  // mandate hints; this is where the mandate holds. Checked after the
+  // ownership backstop so a caller that may not touch the skill at all hears
+  // that first. Because scaffolding rewrites the whole SKILL.md, an overwrite
+  // that omits hints would strip the ones the skill has, so the error names
+  // the current hints for the caller to carry forward.
+  if (!activationHints) {
+    const currentHints = managedSkillExistedBefore
+      ? loadCatalog().find((s) => s.id === id && s.source === "managed")
+          ?.activationHints
+      : undefined;
+    return {
+      content: `Error: ${missingActivationHintsMessage(id, currentHints)}`,
+      isError: true,
+    };
   }
 
   // Conversation lineage (retrospective origin only). The retrospective runs


### PR DESCRIPTION
Fixes JARVIS-1533

## TL;DR

`scaffold_managed_skill` now requires a non-empty `activation_hints`, in the tool schema and in the executor. Both prompts that drive the tool (the `skill-management` SKILL.md and the memory retrospective's instruction) already say hints are mandatory; the tool accepted a call without them, and an overwrite that omitted them silently stripped the hints the skill already had, because scaffolding rebuilds the whole SKILL.md. On an overwrite, the error quotes the skill's current hints so the retry can carry them forward.

Also corrects the `includes` description (it called a load-together field "metadata only, no auto-activation"; `skill_load` inlines each child's body and projects its tools) and two stale field comments in `config/skills.ts`.

## Why hints matter

Skill routing scores each skill's capability card, which is `description` + `Use when: <activation-hints>` + `Avoid when: <avoid-when>` as one text blob (`substrate/skill-content.ts`, embedded and BM25-indexed by `skill-store.ts`). A skill with no hints is still matched on its description, but it loses the intent-phrased text that hints exist to provide, so a thinner skill with sharp hints will out-rank a comprehensive one that has none. Nothing else in the loader or selector treats a hint-less skill specially; the whole effect is the missing text.

## What changes for the user

| | Before | After |
|---|---|---|
| Assistant authors a skill and forgets `activation_hints` | Skill is written with no `Use when:` text; retrievable by description only, silently | Tool returns a self-correcting error; the assistant retries with hints |
| Assistant refines an existing skill (`overwrite: true`) and omits `activation_hints` | The skill's existing hints are stripped from disk | Rejected before anything is written; the error quotes the current hints so the retry keeps them |
| Assistant passes `activation_hints: []` | Treated as "none", skill written without hints | Same rejection as omitted |
| Retrospective tries to overwrite a skill it does not own, without hints | Ownership refusal | Ownership refusal, unchanged (that error is reported ahead of the hints one) |
| Hand-authored SKILL.md without `activation-hints` | Loads fine | Loads fine, unchanged; the requirement is on the authoring tool, not the loader |
| Model reads the `includes` schema description | Told it is metadata only with no effect | Told what it does: child bodies inline and child tools project when the parent loads |

## Why it is safe

* Additive validation on one tool. Every existing scaffold that passes hints behaves exactly as before; the only new outcome is an error where a hint-less skill used to be written.
* No write happens on the new error path (it sits before `createManagedSkill`), so a rejected overwrite leaves the skill byte-for-byte as it was. Covered by a test that asserts the V1 body and hints survive.
* The `required` addition in TOOLS.json is checked by the schema validator (`skill-tool-factory.ts`) with the same self-correcting message shape as `description is required`; the executor check is the defense in depth for direct callers and covers the empty-array case the schema's presence check cannot.
* Reading the current hints for the error message goes through the existing `loadCatalog` seam and only on the error path when the skill already exists.
* Ordering with the retrospective's ownership backstop is pinned by a test, so a caller that may not touch the skill still hears that first.

## Tests

`scaffold-managed-skill-tool.test.ts`: rejects omitted and empty hints for user and retrospective origins with nothing written; an overwrite without hints is rejected, quotes every current hint, and leaves body and hints untouched; a fresh create gets the plain error; ownership refusal precedes the hints error. Existing scaffold calls in this file and `managed-skill-lifecycle.test.ts` pass a fixed hint set so their subject stays what it was.

Local test runs are blocked in this environment; typecheck, lint and prettier pass, and CI carries the suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40751" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->