### PR TITLE
docs: drop references to a test, a script, and nine slash commands that no longer exist

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -10,7 +10,7 @@ Most commands, phases, and scripts are shared from the [`claude-skills`](https:/
 path/to/claude-skills/setup
 ```
 
-This creates symlinks for 18 commands, 7 phase files, and 6 utility scripts. See the [claude-skills README](https://github.com/vellum-ai/claude-skills) for the full command reference.
+This creates the command, phase-file, and utility-script symlinks. See the [claude-skills README](https://github.com/vellum-ai/claude-skills) for the full, current command reference.
 
 Re-run `setup` after pulling updates to the claude-skills repo.
 
@@ -79,13 +79,12 @@ The only exception is `/check-reviews` since that's not a time-sensitive command
 
 ## Typical workflow
 
-3 shells with Claude Code open, one for each of work/swarm, check-reviews, and brainstorm.
+3 shells with Claude Code open, one for each of do/swarm, check-reviews, and brainstorm.
 
-### Work / Swarm
+### Do / Swarm
 
 ```
-/work
-/work Fix the broken login flow
+/do Fix the broken login flow
 /swarm 4 20
 ```
 
@@ -105,6 +104,6 @@ The only exception is `/check-reviews` since that's not a time-sensitive command
 
 ## Using with other coding agents
 
-These commands are designed for Claude Code, but you can use them in other coding agents by telling them to follow the instructions in the corresponding command file (e.g., `Follow the instructions in .claude/commands/work.md`).
+These commands are designed for Claude Code, but you can use them in other coding agents by telling them to follow the instructions in the corresponding command file (e.g., `Follow the instructions in .claude/commands/do.md`).
 
 The swarm command specifically relies on Claude Code's Agent Teams, so you might not be able to use it in other agents.

--- a/assistant/AGENTS.md
+++ b/assistant/AGENTS.md
@@ -67,7 +67,7 @@ Three response shapes are supported:
 - **Binary**: a JSON envelope with `headers: { "content-length": "<n>" }` followed by one binary frame of exactly `n` bytes.
 - **Chunked streaming**: a JSON envelope with `headers: { "transfer-encoding": "chunked" }` followed by one or more binary frames, terminated by a zero-length frame.
 
-The server auto-detects legacy newline-delimited JSON from old CLI clients and handles it transparently. New code must use length-prefixed framing via `writeMessage()` / `IpcFrameReader` in `src/ipc/ipc-framing.ts`.
+The server auto-detects legacy newline-delimited JSON from old CLI clients and handles it transparently. New code must use length-prefixed framing via `writeMessage()` / `IpcFrameReader` from `@vellumai/ipc-server-utils` (`packages/ipc-server-utils/src/ipc-framing.ts`).
 
 ### CLI ↔ daemon version skew
 

--- a/docs/internal-reference.md
+++ b/docs/internal-reference.md
@@ -45,11 +45,11 @@ Detailed reference documentation for the Vellum Assistant platform. For an overv
 
 ### Git Hooks
 
-This repository includes git hooks to help maintain code quality and security. The hooks are installed by running the install script directly.
+This repository includes git hooks to help maintain code quality and security. They are wired up automatically: `assistant/`'s `postinstall` (and `setup.sh`) point `core.hooksPath` at `.githooks/`.
 
-To manually install or update hooks:
+To wire them up by hand:
 ```bash
-./.githooks/install.sh
+git config core.hooksPath .githooks
 ```
 
 See [.githooks/README.md](../.githooks/README.md) for more details about available hooks.
@@ -535,17 +535,14 @@ VELLUM_DAEMON_URL=http://localhost:8741 open -a Vellum
 
 ### Claude Code Workflow
 
-This repo includes Claude Code slash commands for agent-driven development. Most are shared from the [`claude-skills`](https://github.com/vellum-ai/claude-skills) repo via symlinks; repo-local commands live in `.claude/skills/<name>/` as local skill directories (see `.claude/README.md`).
+This repo includes Claude Code slash commands for agent-driven development. Most are shared from the [`claude-skills`](https://github.com/vellum-ai/claude-skills) repo via symlinks; repo-local commands live in `.claude/skills/<name>/` as local skill directories (see `.claude/README.md`). The tables below cover the commands this doc's workflows depend on; the `claude-skills` README is the complete, current reference, and a command listed there but not here is not deprecated.
 
 #### Single-task commands
 
 | Command | Purpose |
 |---------|---------|
 | `/do <description>` | Implement a change in an isolated worktree, create a PR, squash-merge it to main, and clean up. |
-| `/safe-do <description>` | Like `/do` but creates a PR without auto-merging — pauses for human review. Keeps the worktree for feedback. |
 | `/mainline` | Ship uncommitted changes already in your working tree to main via a squash-merged PR. |
-| `/ship-and-merge [title]` | Ship uncommitted changes via a PR with automated review feedback loop — waits for Codex/Devin reviews, fixes valid feedback (up to 3 rounds), and squash-merges. |
-| `/work` | Pick up the next task from `.private/TODO.md` (or a task you specify), implement it, PR it, and merge it. |
 
 #### Multi-task / parallel commands
 
@@ -556,36 +553,21 @@ This repo includes Claude Code slash commands for agent-driven development. Most
 | `/blitz <feature>` | End-to-end feature delivery — plans the feature, creates GitHub issues on a project board, swarm-executes them in parallel, then gates each PR on Codex/Devin review approval before merging (per-PR feedback loops with up to 3 fix cycles). Runs a **recursive sweep loop** (check reviews, swarm to address feedback, review and merge feedback PRs, repeat) until all PRs — including transitive feedback PRs — are fully reviewed with no remaining action items. Merges directly to main. Supports `--auto`, `--workers N`, `--skip-plan`, `--skip-reviews`. Pass `--skip-reviews` to merge PRs immediately without waiting for reviews (opt-in; default is to wait). Derives a namespace from the feature description for branch naming, collision avoidance, and scoping review sweeps/TODO items to only this blitz's PRs. |
 | `/safe-blitz <feature>` | End-to-end feature delivery on a feature branch — plans, creates issues, executes milestones sequentially with per-milestone **direct-push feedback loops** (check reviews, push fixes directly to the milestone branch, re-request reviews, repeat until clean or 3 cycles), then automatically runs a final sweep on the entire feature branch (no user approval prompt). All milestone PRs merge into a feature branch (not main). Creates a final PR for manual review. Does not switch your working tree. Derives a namespace from the feature description for branch naming, collision avoidance, and scoping review sweeps/TODO items to only this blitz's PRs. Supports `--workers N`, `--skip-plan`, `--branch NAME`. |
 | `/safe-blitz-done [PR\|branch]` | Finalize a safe-blitz — squash-merges the feature branch PR into main, sets the project issue to Done, closes the issue, and deletes the local branch. Auto-detects the PR from current branch, open `feature/*` PRs, or project board "In Review" items. |
-| `/execute-plan <file>` | Sequential multi-PR rollout — reads a plan file from `.private/plans/`, executes each PR in order, mainlining each before moving to the next. |
 | `/check-reviews-and-swarm [workers] [max-tasks] [--namespace NAME]` | Combined review sweep + execution pass — runs review checks, then swarms on actionable feedback items. When `--namespace` is provided, it is passed to both `/check-reviews` (to filter PRs and prefix TODO items) and `/swarm` (to filter TODO items and namespace branches). When omitted, `/check-reviews` still infers namespaces from PR branch names matching `swarm/<NAME>/...`. |
 
-#### Human-in-the-loop plan execution
-
-A three-command workflow for executing plans one PR at a time with human review between each step. Each plan gets its own state file in `.private/safe-plan-state/`, so multiple plans can run concurrently in separate sessions.
+#### Plan execution
 
 | Command | Purpose |
 |---------|---------|
-| `/safe-execute-plan <file>` | Start a plan from `.private/plans/` — implements the next PR, creates it (without merging), automatically runs an **automated review feedback loop** (up to 3 fix cycles with Codex/Devin), then auto-initiates `/safe-check-review` after 60 seconds to await human merge approval. |
-| `/safe-check-review [file]` | Check the active plan PR for feedback from codex/devin/humans and CI. Runs an **automated feedback loop** (up to 3 fix cycles): fetches full review data (reviews, inline comments, review threads, reactions, CI checks), determines aggregate status including CI state and human unresolved threads, addresses `changes_requested` by pushing fixes, re-requests reviews, and polls for fresh responses — only concluding approved once all reviewers (bots and humans) and CI are green. Auto-detects the plan if only one is active. |
-| `/resume-plan [file]` | Merge the current PR, implement the next one, create it, and stop again. Repeats until the plan is complete. Auto-detects the plan if only one is active. |
-
-**Typical flow:**
-
-1. **`/safe-execute-plan MY_PLAN.md`** — starts the plan, creates PR 1, automatically handles Codex/Devin review feedback (up to 3 cycles), then auto-initiates `/safe-check-review` after 60 seconds
-2. **`/resume-plan MY_PLAN.md`** — merge PR 1 (automated reviews already complete), create PR 2, stop
-3. Repeat step 2 until the plan is complete
-
-The automated review loop in `/safe-execute-plan` triggers Codex and Devin reviews, waits for their feedback (up to 15 minutes for initial reviews, 10 minutes for subsequent cycles), addresses any `changes_requested` feedback by pushing fixes directly to the PR branch, and re-requests reviews — repeating up to 3 cycles. After the review loop completes, it waits 60 seconds then automatically invokes `/safe-check-review` to hand off to you for merge approval.
-
-Multiple plans can run in parallel — just specify the plan name to disambiguate.
+| `/create-plan <feature>` | Break a feature into a handoff-ready PR-by-PR plan with explicit dependency tracking for parallel execution. Writes a private draft to `.private/plans/<slug>.md`. |
+| `/run-plan <slug>` | Execute a plan from `.private/plans/<slug>.md` with dependency-aware parallel execution, self-review, and gap remediation. Attaches the full plan to implementation PRs as the durable papertrail. |
+| `/safe-check-review [file]` | Check the active safe-plan PR for review feedback from Codex, Devin, humans, and CI, and address it. |
 
 #### Utility
 
 | Command | Purpose |
 |---------|---------|
-| `/plan-html <topic\|plan-name>` | Create or refresh a rollout plan in `.private/plans/` with both markdown and a polished, review-friendly HTML view (including per-PR file lists). |
 | `/release [bump]` | Cut a release in two steps: dispatch `create-release-branch.yml` (cuts `release/vX.Y.Z` from main → staging bake), then after the bake is green dispatch `release.yml` on the release branch for the full production release. |
-| `/triage [user\|assistant\|device]` | Search Sentry for recent errors and log reports by user, assistant, or device in the `vellum-assistant-brain` project, then cross-reference with Linear issues to produce a triage summary. |
 | `/update` | Pull latest from `main`, kill stale processes, rebuild and launch the macOS app. The app manages its own assistant and gateway lifecycle (hatching on first launch). Prints a startup summary. |
 
 #### Review
@@ -602,8 +584,6 @@ Multiple plans can run in parallel — just specify the plan name to disambiguat
 4. **`/swarm`** again — address the feedback
 
 Or for a focused feature: **`/blitz <feature>`** handles all of the above in one shot (plan, issues, swarm, sweep, report). Use **`/safe-blitz <feature>`** for the same workflow but with a feature branch and a final PR for manual review, then **`/safe-blitz-done`** to merge it when ready.
-
-For controlled, sequential plan execution with automated bot reviews and human merge approval: **`/safe-execute-plan <file>`** (creates PR + auto-handles Codex/Devin feedback + auto-initiates `/safe-check-review` after 60s) -> **`/resume-plan`** -> repeat.
 
 All workflows use squash-merge (no merge commits), worktree isolation for parallel work, and track state in `.private/TODO.md` and `.private/UNREVIEWED_PRS.md`.
 

--- a/gateway/src/risk/command-registry/AGENTS.md
+++ b/gateway/src/risk/command-registry/AGENTS.md
@@ -57,6 +57,4 @@ After registry changes, run scoped checks from `gateway/`:
 1. `bun test src/risk/command-registry.test.ts src/risk/bash-risk-classifier.test.ts src/risk/risk-classifier-parity.test.ts src/__tests__/bash-risk-classifier.test.ts`
 2. `bunx tsc --noEmit`
 
-When `commands/assistant.ts` changes, also run from `assistant/`:
-
-1. `bun test src/__tests__/cli-command-risk-guard.test.ts`
+`src/risk/command-registry.test.ts` covers `commands/assistant.ts` too, so a change there needs no extra run.


### PR DESCRIPTION
## TL;DR

Three governing docs outside `clients/web` point at things that are gone: a moved module path, a deleted test, a nonexistent install script, and nine slash commands removed from `claude-skills`. Docs only. Every replacement was verified against `main` (or, for the commands, against the `claude-skills` repo's own removal commits).

## What was wrong

| Doc | Said | Actually |
|---|---|---|
| `assistant/AGENTS.md` § IPC framing | `writeMessage()` / `IpcFrameReader` live in `src/ipc/ipc-framing.ts` | They are exported from `@vellumai/ipc-server-utils` (`packages/ipc-server-utils/src/ipc-framing.ts`); `assistant/src/ipc/cli-client.ts` imports them from the package |
| `gateway/src/risk/command-registry/AGENTS.md` § Validation | after touching `commands/assistant.ts`, run `assistant/src/__tests__/cli-command-risk-guard.test.ts` | That test was deleted in #28033. `gateway/src/risk/command-registry.test.ts`, already step 1 of the same list, is what covers `commands/assistant.ts` |
| `docs/internal-reference.md` § Git Hooks | run `./.githooks/install.sh` | No such file. `assistant/package.json` `postinstall` and `setup.sh` set `core.hooksPath .githooks`, which is also what `.githooks/README.md` says |
| `docs/internal-reference.md` § Claude Code Workflow | documents `/safe-do`, `/work`, `/ship-and-merge`, `/execute-plan`, `/safe-execute-plan`, `/resume-plan`, `/plan-html`, `/triage` | All removed from `claude-skills` (its #87 removed eight, #240 removed `triage`); none is symlinked into `.claude/commands/` |

## What changed

- The two AGENTS.md lines are corrected in place.
- In `internal-reference.md`, the dead command rows and the all-dead "Human-in-the-loop plan execution" subsection (`/safe-execute-plan`, `/resume-plan`) are removed, along with the "Typical flow" paragraph that walked through them. `/safe-check-review` still exists and keeps a row. A short "Plan execution" table names the current `/create-plan`, `/run-plan`, `/safe-check-review`, with descriptions taken from those skills' own frontmatter.
- The section intro now says the `claude-skills` README is the complete reference and that a command listed there but not here is not deprecated, so this doc stops being read as an exhaustive inventory (which is how it rotted).

## Why it is safe

- Documentation only. No source, config, or test changes.
- Nothing is added that describes behaviour beyond a skill's own one-line description; nothing existing is re-described.
- Independent of #40746 (which edits other lines of `assistant/AGENTS.md`); checked the diffs do not overlap.
- Prettier passes on `assistant/` and `gateway/` (pre-commit ran it); `docs/internal-reference.md` is not under a formatter.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40752" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->