### PR TITLE
refactor(skills): keep the activation_hints check where the tool path reaches it (JARVIS-1533)

### DIFF
--- a/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
@@ -125,6 +125,27 @@ function installMetaFor(skillId: string) {
   return readInstallMeta(join(TEST_DIR, "skills", skillId));
 }
 
+/** The scaffold_managed_skill entry as declared in the skill-management manifest. */
+function readScaffoldToolEntry(): {
+  input_schema: {
+    properties: Record<string, unknown>;
+    required: string[];
+  };
+} {
+  const tools = JSON.parse(
+    readFileSync(
+      join(
+        import.meta.dirname,
+        "../config/bundled-skills/skill-management/TOOLS.json",
+      ),
+      "utf-8",
+    ),
+  );
+  return tools.tools.find(
+    (tool: { name: string }) => tool.name === "scaffold_managed_skill",
+  );
+}
+
 beforeEach(() => {
   mkdirSync(join(TEST_DIR, "skills"), { recursive: true });
   mockRefreshSkillCapabilityMemories.mockClear();
@@ -140,18 +161,7 @@ afterEach(() => {
 
 describe("scaffold_managed_skill tool", () => {
   test("keeps legacy index control as a deprecated no-op schema field", () => {
-    const tools = JSON.parse(
-      readFileSync(
-        join(
-          import.meta.dirname,
-          "../config/bundled-skills/skill-management/TOOLS.json",
-        ),
-        "utf-8",
-      ),
-    );
-    const scaffoldTool = tools.tools.find(
-      (tool: { name: string }) => tool.name === "scaffold_managed_skill",
-    );
+    const scaffoldTool = readScaffoldToolEntry();
 
     expect(scaffoldTool).toBeDefined();
     expect(scaffoldTool.input_schema.properties.add_to_index).toEqual({
@@ -165,18 +175,7 @@ describe("scaffold_managed_skill tool", () => {
     // A call through the registered tool is validated against TOOLS.json
     // first (skill-tool-factory), so the requirement has to live in the
     // schema's `required` list, not only in the executor.
-    const tools = JSON.parse(
-      readFileSync(
-        join(
-          import.meta.dirname,
-          "../config/bundled-skills/skill-management/TOOLS.json",
-        ),
-        "utf-8",
-      ),
-    );
-    const scaffoldTool = tools.tools.find(
-      (tool: { name: string }) => tool.name === "scaffold_managed_skill",
-    );
+    const scaffoldTool = readScaffoldToolEntry();
     expect(scaffoldTool.input_schema.required).toContain("activation_hints");
 
     const result = validateInputAgainstSchema(

--- a/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
@@ -95,6 +95,7 @@ function catalogSeam(...entries: { id: string; source: SkillSource }[]) {
 
 import { loadSkillCatalog } from "../config/skills.js";
 import { readInstallMeta, writeInstallMeta } from "../skills/install-meta.js";
+import { validateInputAgainstSchema } from "../skills/validate-input.js";
 import { executeScaffoldManagedSkill } from "../tools/skills/scaffold-managed.js";
 import type { ToolContext } from "../tools/types.js";
 
@@ -158,6 +159,40 @@ describe("scaffold_managed_skill tool", () => {
       description:
         "Deprecated no-op compatibility field. Skills are discovered from top-level SKILL.md files.",
     });
+  });
+
+  test("the registered tool's schema rejects an omitted activation_hints before the executor runs", () => {
+    // A call through the registered tool is validated against TOOLS.json
+    // first (skill-tool-factory), so the requirement has to live in the
+    // schema's `required` list, not only in the executor.
+    const tools = JSON.parse(
+      readFileSync(
+        join(
+          import.meta.dirname,
+          "../config/bundled-skills/skill-management/TOOLS.json",
+        ),
+        "utf-8",
+      ),
+    );
+    const scaffoldTool = tools.tools.find(
+      (tool: { name: string }) => tool.name === "scaffold_managed_skill",
+    );
+    expect(scaffoldTool.input_schema.required).toContain("activation_hints");
+
+    const result = validateInputAgainstSchema(
+      "scaffold_managed_skill",
+      {
+        skill_id: "s",
+        name: "N",
+        description: "D",
+        body_markdown: "B",
+      },
+      scaffoldTool.input_schema,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors).toEqual(["activation_hints is required"]);
+    }
   });
 
   test("creates a valid skill discovered from its SKILL.md directory", async () => {
@@ -588,7 +623,7 @@ describe("scaffold_managed_skill tool", () => {
     }
   });
 
-  test("an overwrite that omits activation_hints is rejected, names the current hints, and leaves the skill untouched", async () => {
+  test("an overwrite that omits activation_hints is rejected and leaves the skill untouched", async () => {
     const hints = ["user asks to deploy staging", "user asks to cut a release"];
     await executeScaffoldManagedSkill(
       {
@@ -614,10 +649,6 @@ describe("scaffold_managed_skill tool", () => {
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain("activation_hints is required");
-    // The error quotes every current hint so the retry can carry them forward.
-    for (const hint of hints) {
-      expect(result.content).toContain(hint);
-    }
     // Scaffolding rewrites the whole SKILL.md, so the rejected overwrite must
     // not have reached disk: body and hints are still V1's.
     const content = readFileSync(
@@ -628,20 +659,6 @@ describe("scaffold_managed_skill tool", () => {
     expect(content).not.toContain("V2 body.");
     const skill = loadSkillCatalog().find((s) => s.id === "keep-hints");
     expect(skill!.activationHints).toEqual(hints);
-  });
-
-  test("a create with no activation_hints gets the plain error, with no current-hints clause", async () => {
-    const result = await executeScaffoldManagedSkill(
-      {
-        skill_id: "fresh-no-hints",
-        name: "Fresh",
-        description: "Never existed",
-        body_markdown: "Body.",
-      },
-      makeContext(),
-    );
-    expect(result.isError).toBe(true);
-    expect(result.content).not.toContain("currently declares");
   });
 
   test("passes category through to the written skill, lowercased and trimmed", async () => {
@@ -988,36 +1005,6 @@ describe("scaffold_managed_skill tool", () => {
     const skillFile = join(TEST_DIR, "skills", "protected", "SKILL.md");
     expect(readFileSync(skillFile, "utf-8")).toContain("Original body.");
     expect(installMetaFor("protected")?.author).toBe("user");
-  });
-
-  test("the ownership refusal is reported ahead of a missing activation_hints", async () => {
-    // A caller that may not touch the skill at all should hear that first,
-    // rather than fix its hints and then be refused on the retry.
-    await executeScaffoldManagedSkill(
-      {
-        skill_id: "protected-order",
-        name: "Protected",
-        description: "User authored",
-        body_markdown: "Original body.",
-        activation_hints: HINTS,
-      },
-      makeContext(),
-    );
-
-    const result = await executeScaffoldManagedSkill(
-      {
-        skill_id: "protected-order",
-        name: "Protected",
-        description: "Rewritten by retrospective",
-        body_markdown: "Rewritten body.",
-        overwrite: true,
-      },
-      makeRetrospectiveContext(),
-    );
-
-    expect(result.isError).toBe(true);
-    expect(result.content).toContain("not verifiably assistant-authored");
-    expect(result.content).not.toContain("activation_hints is required");
   });
 
   test("retrospective refuses to write companion files into an author:user skill", async () => {

--- a/assistant/src/tools/skills/scaffold-managed.ts
+++ b/assistant/src/tools/skills/scaffold-managed.ts
@@ -28,21 +28,13 @@ function sanitizeFrontmatterValue(value: string): string {
 }
 
 /**
- * Self-correcting error for a scaffold call with no activation hints. When the
- * skill already exists and declares hints, they are quoted so the retry can
- * carry them forward instead of inventing new ones.
+ * Self-correcting error for a scaffold call with no activation hints. Matches
+ * the shape of the schema validator's required-field error, which is what a
+ * call through the registered tool hits first; this covers direct callers and
+ * an explicit empty list, which the schema's presence check accepts.
  */
-function missingActivationHintsMessage(
-  skillId: string,
-  currentHints: string[] | undefined,
-): string {
-  const base =
-    'activation_hints is required: pass 1-4 short trigger phrases stating the intent this skill serves (for example "user asks to deploy staging") so it can be found later by intent, not just by name.';
-  if (!currentHints || currentHints.length === 0) {
-    return base;
-  }
-  return `${base} Scaffolding rewrites the whole SKILL.md, and skill "${skillId}" currently declares ${JSON.stringify(currentHints)}; pass them again, revised if the procedure changed.`;
-}
+const MISSING_ACTIVATION_HINTS =
+  'activation_hints is required: pass 1-4 short trigger phrases stating the intent this skill serves (for example "user asks to deploy staging") so it can be found later by intent, not just by name.';
 
 /**
  * Validate + normalize a string-array input (sanitize, drop blanks, dedupe).
@@ -163,11 +155,7 @@ export async function executeScaffoldManagedSkill(
   input: Record<string, unknown>,
   context: ToolContext,
   deps: {
-    loadCatalog?: () => {
-      id: string;
-      source: SkillSource;
-      activationHints?: string[];
-    }[];
+    loadCatalog?: () => { id: string; source: SkillSource }[];
     getConversation?: (
       id: string,
     ) => { forkParentConversationId: string | null } | null;
@@ -208,8 +196,7 @@ export async function executeScaffoldManagedSkill(
 
   // Validate and normalize the string-array inputs. `includes` lists child
   // skill IDs; activation_hints / avoid_when become the skill's "Use when:" /
-  // "Avoid when:" retrieval signal in memory. Shape errors surface here;
-  // activation_hints' presence is enforced below, once ownership is settled.
+  // "Avoid when:" retrieval signal in memory.
   const includesResult = normalizeOptionalStringArray(
     input.includes,
     "includes",
@@ -227,6 +214,14 @@ export async function executeScaffoldManagedSkill(
     return { content: `Error: ${activationHintsResult.error}`, isError: true };
   }
   const activationHints = activationHintsResult.value;
+  // Hints are the skill's "Use when:" retrieval text, and scaffolding rewrites
+  // the whole SKILL.md, so a write without them leaves (or strips) none.
+  if (!activationHints) {
+    return {
+      content: `Error: ${MISSING_ACTIVATION_HINTS}`,
+      isError: true,
+    };
+  }
 
   const avoidWhenResult = normalizeOptionalStringArray(
     input.avoid_when,
@@ -331,8 +326,6 @@ export async function executeScaffoldManagedSkill(
     join(getManagedSkillDir(id), "SKILL.md"),
   );
 
-  const loadCatalog = deps.loadCatalog ?? (() => loadSkillCatalog());
-
   // Ownership backstop (retrospective origin only): the retrospective may author
   // a skill ONLY if it owns it. Fail closed on either of two collisions.
   if (fromRetrospective) {
@@ -343,6 +336,7 @@ export async function executeScaffoldManagedSkill(
     // create AND overwrite. The prompt directs the model to skip when an
     // existing skill of any source already covers the procedure; this enforces
     // it.
+    const loadCatalog = deps.loadCatalog ?? (() => loadSkillCatalog());
     const nonManagedOwner = loadCatalog().find(
       (s) => s.id === id && s.source !== "managed",
     );
@@ -369,21 +363,6 @@ export async function executeScaffoldManagedSkill(
         isError: true,
       };
     }
-  }
-
-  // Hints are the skill's "Use when:" retrieval text, and scaffolding rewrites
-  // the whole SKILL.md, so an overwrite without them would strip the ones the
-  // skill has. Checked after the ownership backstop so a caller that may not
-  // touch the skill at all hears that first.
-  if (!activationHints) {
-    const currentHints = managedSkillExistedBefore
-      ? loadCatalog().find((s) => s.id === id && s.source === "managed")
-          ?.activationHints
-      : undefined;
-    return {
-      content: `Error: ${missingActivationHintsMessage(id, currentHints)}`,
-      isError: true,
-    };
   }
 
   // Conversation lineage (retrospective origin only). The retrospective runs


### PR DESCRIPTION
Related to JARVIS-1533. Follow-up to #40751, addressing the Codex review comment there.

## TL;DR

A call through the registered `scaffold_managed_skill` tool is validated against TOOLS.json before the executor runs, so an omitted `activation_hints` already fails at `skill-tool-factory.ts` with `activation_hints is required`. The executor's overwrite-aware message (quoting the skill's current hints) and its placement after the retrospective ownership backstop were therefore reachable only for an explicit `[]` or a direct caller. This removes that unreachable enrichment: the executor check moves next to the other required-field checks and returns the same plain, self-correcting error. A new test pins the schema-level requirement, which is the path production actually takes.

## What changes for the user

| | Before (#40751) | After |
|---|---|---|
| Assistant omits `activation_hints` through the tool | Schema validator: `activation_hints is required` | Unchanged |
| Assistant passes `activation_hints: []` on an overwrite | Executor error quoting the skill's current hints | Executor error, plain: `activation_hints is required: pass 1-4 short trigger phrases ...` |
| Retrospective overwrites a skill it does not own, with hints omitted | Schema error first, ownership refusal on retry | Unchanged (that was already the real-path behaviour) |

## Why it is safe

* Net deletion (-34 lines in the executor). No new behaviour; the only user-visible difference is a shorter error in the `[]`-on-overwrite corner.
* The rejected-overwrite-leaves-the-skill-untouched invariant keeps its test; the removed tests only asserted the quoted-hints text and the ordering.
* New test reads the real TOOLS.json entry and asserts `activation_hints` is in `required` and that `validateInputAgainstSchema` rejects its omission, so the schema half cannot silently regress.

Local test runs are blocked in this environment; typecheck, lint and prettier pass, and CI carries the suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40753" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->