### PR TITLE
docs(web): describe the sidebar's present section-membership rules (LUM-3126)

### DIFF
--- a/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -1366,12 +1366,11 @@ describe("AssistantSideMenu · default section order", () => {
   });
 });
 
-/* Membership in `sidebar.sections` and what renders have to be decided by
-   one predicate. When they were two - the list built unconditionally, the
-   section returning `null` when its query came back empty - `curatedSectionCount`
-   counted an entry nothing drew, so the curated rule appeared over an empty
-   tier and the header menu offered a move that swapped with an off-screen
-   section. */
+/* Membership in `sidebar.sections` and what renders are decided by one
+   predicate. Were they two, a section could be listed while drawing
+   nothing, and the header menu's move-up/move-down nudges count listed
+   entries: the menu would offer a move that swapped with a section the
+   user cannot see. */
 describe("AssistantSideMenu · a listed section is a rendered section", () => {
   test("a custom group with no conversations still renders its header", () => {
     const html = renderMenu({

--- a/clients/web/src/domains/chat/use-sidebar-state.ts
+++ b/clients/web/src/domains/chat/use-sidebar-state.ts
@@ -254,18 +254,17 @@ export function useSidebarState({
   // below them.
   /* This list decides which sections exist, and it is the only thing that
      does. A section's *contents* come from its own query, but every entry
-     here renders: `curatedSectionCount` and the move-up/move-down nudges
-     count these entries, so an entry that renders nothing draws the curated
-     rule over an empty tier and offers a move that swaps with something off
+     here renders: the move-up/move-down nudges count these entries, so an
+     entry that renders nothing offers a move that swaps with something off
      screen. One predicate for membership and visibility, or the two drift.
 
-     Membership comes from the loaded list, which is accurate while that list
-     drains in full. It stops being accurate under a windowed list
-     (LUM-2444), the same change that removes `groupConversations`, so
-     section existence needs a server-side source at that point. A section
-     cannot answer this for itself in the meantime: emptiness has to be known
-     before the list is built, and this hook cannot mount N queries for N
-     groups. */
+     Membership has two sources and the branch below picks between them: the
+     daemon's section index where it is served, and the loaded list
+     otherwise. The fallback is accurate only while that list drains in full,
+     which a windowed list does not do, so the index is what keeps existence
+     correct there. A section cannot answer this for itself either way:
+     emptiness has to be known before the list is built, and this hook cannot
+     mount N queries for N groups. */
   const defaultSections = useMemo((): SidebarSection[] => {
     /* Which sections exist has two possible sources, never mixed within one
        render. When the daemon serves the section index, it is authoritative


### PR DESCRIPTION
## TL;DR

Two sidebar comments described a codebase we no longer have. Comments only, no behaviour change.

Fixes LUM-3126.

## What was stale

**The dead identifier** (what the ticket was filed for). Both comments named `curatedSectionCount`, deleted along with the curated rule it counted. Verified: no `curated` treatment survives in `sidebar-section-item.tsx`. The surviving reason a listed section must draw something is the move-up/move-down nudges in `group-actions-menu.tsx`, which count listed entries, so the consequence is a move that swaps with a section the user cannot see.

**The stale forward-reference** (found while fixing the above, and the more misleading half). The same block said membership comes from the loaded list and "section existence needs a server-side source" once a windowed list lands, naming LUM-2444 as future work.

LUM-2444 shipped in `d6a5fd802b`, and the branch immediately below the comment **is** that server-side source: `if (indexSections !== null)` reads the daemon's section index, falling back to the loaded list otherwise. So the comment described as pending the exact thing the code under it already does, which is worse than a dead identifier: a reader trusts it and goes looking for work that is done.

**The test comment** explained the bug it was originally written to catch rather than the invariant it asserts. `STYLE_GUIDE.md` calls this out for test comments specifically ("explain the behavior the test asserts in terms of the current code, not the bug it was originally written to catch"). Restated in present terms.

## Why it is safe

Comments only. No code, no test assertions, no exports touched. `tsc --noEmit` and the pinned prettier both pass.

## Scope note

The ticket described this as "two comment lines, no behaviour". That was accurate when filed on 2026-08-07; the windowing work landing since is what made the surrounding paragraph wrong too. I did not rewrite the membership architecture narrative beyond that: the inner comment on the `indexSections` branch already explains the two sources correctly and in more detail, so the outer paragraph now points at it rather than restating it.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40754" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->