### PR TITLE
fix: give plugin vendors a trailing-slash webhook URL

### DIFF
--- a/assistant/src/__tests__/plugin-api-webhook-url.test.ts
+++ b/assistant/src/__tests__/plugin-api-webhook-url.test.ts
@@ -26,7 +26,7 @@ describe("resolveWebhookUrl", () => {
     });
 
     expect(url).toBe(
-      "https://callbacks.vellum.ai/abc/webhooks/plugins/imessage/events-photon",
+      "https://callbacks.vellum.ai/abc/webhooks/plugins/imessage/events-photon/",
     );
     expect(spy.mock.calls[0]![1]).toBe(
       "webhooks/plugins/imessage/events-photon",
@@ -124,10 +124,10 @@ describe("resolveWebhookUrl", () => {
     }
   });
 
-  test("hands the vendor a URL with no trailing slash", async () => {
-    // The platform appends one, and a provider delivers to the URL it was
-    // given verbatim. The gateway matches the declared path, which never ends
-    // in a slash, so a registration carrying one 404s every delivery.
+  test("hands the vendor a URL with a trailing slash", async () => {
+    // Django in front of managed callbacks canonicalizes onto `/`. A vendor
+    // given the slashless spelling is 301'd, and clients that follow a 301
+    // on POST typically retry as GET and drop the body.
     const spy = spyOn(registration, "resolveCallbackUrl").mockResolvedValue(
       "https://callbacks.vellum.ai/abc/webhooks/plugins/imessage/events-comms/",
     );
@@ -135,13 +135,16 @@ describe("resolveWebhookUrl", () => {
     await expect(
       resolveWebhookUrl({ plugin: "imessage", path: "events-comms" }),
     ).resolves.toBe(
-      "https://callbacks.vellum.ai/abc/webhooks/plugins/imessage/events-comms",
+      "https://callbacks.vellum.ai/abc/webhooks/plugins/imessage/events-comms/",
+    );
+    expect(spy.mock.calls[0]![1]).toBe(
+      "webhooks/plugins/imessage/events-comms",
     );
     spy.mockRestore();
   });
 
   test("leaves a URL carrying a query string alone", async () => {
-    // Trimming there would cut into the query rather than the path.
+    // Appending there would cut into the query rather than the path.
     const spy = spyOn(registration, "resolveCallbackUrl").mockResolvedValue(
       "https://example.test/webhooks/plugins/imessage/events-comms?token=abc/",
     );

--- a/assistant/src/plugin-api/webhook-url.ts
+++ b/assistant/src/plugin-api/webhook-url.ts
@@ -90,22 +90,24 @@ function registrationType(plugin: string, route: string): string {
 }
 
 /**
- * Drop a trailing slash from a resolved callback URL.
+ * Keep a trailing slash on a resolved callback URL.
  *
- * The platform appends one to the callback URLs it hands back, and a provider
- * given `.../events-comms/` delivers to that spelling verbatim. The gateway
- * matches a plugin route against its declared path, which may never end in a
- * slash (see `IngressRouteSchema`), so the slash comes off once here rather
- * than at each plugin that registers a URL.
+ * Django in front of managed callbacks canonicalizes onto `/`. A vendor given
+ * the slashless spelling is 301'd, and clients that follow a 301 on POST
+ * typically retry as GET and drop the body. The gateway serves both spellings
+ * of a plugin webhook, so the slashed URL is the one to hand out.
  *
- * Only the path is ever trimmed: this resolver passes no query parameters, and
- * a URL carrying one is left alone rather than truncated.
+ * Query-bearing URLs are left alone: this resolver passes no query
+ * parameters, and appending there would cut into the query rather than the
+ * path. The callback path registered with the platform stays slashless. The
+ * platform strips slashes on store, and Django's path converter typically
+ * does not include the final `/` in the lookup key.
  */
-function withoutTrailingSlash(url: string): string {
+function withTrailingSlash(url: string): string {
   if (url.includes("?") || url.includes("#")) {
     return url;
   }
-  return url.replace(/\/+$/, "");
+  return url.endsWith("/") ? url : `${url}/`;
 }
 
 /**
@@ -147,5 +149,5 @@ export async function resolveWebhookUrl(
     undefined,
     sourceIdentifier,
   );
-  return withoutTrailingSlash(resolved);
+  return withTrailingSlash(resolved);
 }

--- a/gateway/src/__tests__/route-schema-guard.test.ts
+++ b/gateway/src/__tests__/route-schema-guard.test.ts
@@ -174,9 +174,10 @@ function regexToOpenApiPath(escaped: string): string | null {
   path = path.replace(/\(\?(?:=|!|<=|<!).*?\)/g, "");
 
   // Replace capture groups with numbered params.
-  // Handles both `([^/]+)` (single segment) and `(.+)` (greedy) patterns.
+  // Handles `([^/]+)` (single segment), `(.+)` (greedy), and `(.+?)`
+  // (non-greedy, used when an optional trailing slash sits outside the group).
   let paramIndex = 0;
-  path = path.replace(/\(\[\^\/\]\+\)|\(\.\+\)/g, () => {
+  path = path.replace(/\(\[\^\/\]\+\)|\(\.\+\??\)/g, () => {
     paramIndex++;
     return `{param${paramIndex}}`;
   });

--- a/gateway/src/channels/plugin-ingress.test.ts
+++ b/gateway/src/channels/plugin-ingress.test.ts
@@ -12,6 +12,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 
 import {
   PLUGIN_INGRESS_MANIFEST_RELPATH,
+  PLUGIN_WEBHOOK_PATH_PATTERN,
   PLUGIN_WEBHOOK_PREFIX,
   PluginIngressCache,
   discoverPluginIngress,
@@ -55,6 +56,35 @@ const VALID = JSON.stringify({
   routes: [
     { path: "realtime", kind: "websocket", description: "realtime events" },
   ],
+});
+
+describe("PLUGIN_WEBHOOK_PATH_PATTERN", () => {
+  it("captures plugin and route on the slashless spelling", () => {
+    const match = "/webhooks/plugins/imessage/events-photon".match(
+      PLUGIN_WEBHOOK_PATH_PATTERN,
+    );
+    expect(match?.[1]).toBe("imessage");
+    expect(match?.[2]).toBe("events-photon");
+  });
+
+  it("does not capture an optional trailing slash", () => {
+    // Regex routes are not trailing-slash-normalized in the router.
+    // Managed callbacks canonicalize onto `/`, so the capture has to drop
+    // that slash rather than treat it as part of the declared path.
+    const match = "/webhooks/plugins/imessage/events-photon/".match(
+      PLUGIN_WEBHOOK_PATH_PATTERN,
+    );
+    expect(match?.[1]).toBe("imessage");
+    expect(match?.[2]).toBe("events-photon");
+  });
+
+  it("does not capture a trailing slash on a multi-segment route", () => {
+    const match = "/webhooks/plugins/imessage/a/b/c/".match(
+      PLUGIN_WEBHOOK_PATH_PATTERN,
+    );
+    expect(match?.[1]).toBe("imessage");
+    expect(match?.[2]).toBe("a/b/c");
+  });
 });
 
 describe("pluginWebhookPath", () => {

--- a/gateway/src/channels/plugin-ingress.ts
+++ b/gateway/src/channels/plugin-ingress.ts
@@ -224,9 +224,13 @@ export interface PluginIngressDiscovery {
  * Matches a public plugin route path, capturing plugin name and route path.
  * Shared by the HTTP route entry and the WebSocket upgrade branch so the two
  * halves of the surface cannot come to disagree about its shape.
+ *
+ * An optional trailing slash is accepted and not captured. Regex routes are
+ * not trailing-slash-normalized in the router, and managed callbacks
+ * canonicalize onto `/`.
  */
 export const PLUGIN_WEBHOOK_PATH_PATTERN =
-  /^\/webhooks\/plugins\/([^/]+)\/(.+)$/;
+  /^\/webhooks\/plugins\/([^/]+)\/(.+?)\/?$/;
 
 /** Compose the absolute public path the gateway serves for a route. */
 export function pluginWebhookPath(plugin: string, path: string): string {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

Photon stores an inbound iMessage and has an active `message.received` webhook, but the managed gateway never sees the delivery. Photon is given a slashless callback URL. Django in front of managed callbacks 301s that onto `/`. Clients that follow a 301 on POST typically retry as GET and drop the body, so the slashed follow-up 404s before HMAC.

`resolveWebhookUrl` was stripping the trailing slash because a stale comment claimed the gateway 404s slashed plugin routes. Declared-route matching already ignores one trailing slash, and `plugin-webhook.test.ts` already covers `POST .../realtime/`. Regex routes are not trailing-slash-normalized, so `PLUGIN_WEBHOOK_PATH_PATTERN` could still capture the slash.

Plugin-side workaround already shipped: https://github.com/vellum-ai/imessage/pull/34

## Summary

- `resolveWebhookUrl` keeps or adds a trailing slash on the URL handed to vendors. Query-bearing URLs are left alone. The `callback_path` registered with the platform stays slashless (`webhooks/plugins/<plugin>/<route>`).
- `PLUGIN_WEBHOOK_PATH_PATTERN` accepts an optional trailing slash and does not capture it, same idea as `/v1/migrations/import/:id/status/?`.

## Test plan

- `cd assistant && bun test src/__tests__/plugin-api-webhook-url.test.ts`
- `cd gateway && bun test src/channels/plugin-ingress.test.ts src/http/routes/plugin-webhook.test.ts src/__tests__/route-schema-guard.test.ts`

The first gateway CI run failed on unrelated `beforeEach`/`afterEach` hook timeouts (15s) in `bash-risk-classifier`, `channel-admission-policy-routes`, `channel-permission-overrides-routes`, and `channel-permission-store`. Plugin webhook / ingress tests in that run passed. Retriggered.

## Risk

Low. Vendor URLs become slashed (what Django already canonicalizes to). Platform lookup keys stay slashless. Existing slashless POSTs still match the regex.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09030aa5-c6fd-4408-be6c-0f9fb7d2e9a8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09030aa5-c6fd-4408-be6c-0f9fb7d2e9a8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

