### PR TITLE
fix(schedule): hash only config.json and the entrypoint in plugin schedule definitions

### DIFF
--- a/assistant/src/schedule/__tests__/plugin-schedule-declarations.test.ts
+++ b/assistant/src/schedule/__tests__/plugin-schedule-declarations.test.ts
@@ -487,11 +487,39 @@ describe("parsePluginScheduleDeclarations", () => {
       expect(after).not.toBe(before);
     });
 
-    test("changes when a helper file inside a directory declaration is edited or renamed", () => {
+    test("changes when config.json is edited", () => {
+      const pluginDir = makePlugin(FULL_DIGEST);
+      const before = parsePluginScheduleDeclarations(pluginDir, "p")
+        .declarations[0]!.definitionHash;
+      writeFileSync(
+        join(pluginDir, "schedules", "digest", "config.json"),
+        JSON.stringify({ expression: "0 10 * * *" }),
+      );
+      const after = parsePluginScheduleDeclarations(pluginDir, "p")
+        .declarations[0]!.definitionHash;
+      expect(after).not.toBe(before);
+    });
+
+    test("changes when the index.sh entrypoint is edited", () => {
+      const pluginDir = makePlugin({
+        "backup/config.json": JSON.stringify({ expression: "0 3 * * *" }),
+        "backup/index.sh": "echo v1\n",
+      });
+      const parse = () =>
+        parsePluginScheduleDeclarations(pluginDir, "p").declarations[0]!
+          .definitionHash;
+      const before = parse();
+      writeFileSync(
+        join(pluginDir, "schedules", "backup", "index.sh"),
+        "echo v2\n",
+      );
+      expect(parse()).not.toBe(before);
+    });
+
+    test("ignores every other file under the declaration directory", () => {
       const pluginDir = makePlugin({
         "backup/config.json": JSON.stringify({ expression: "0 3 * * *" }),
         "backup/index.sh": "sh lib/helper.sh\n",
-        "backup/lib/helper.sh": "echo v1\n",
       });
       const parse = () =>
         parsePluginScheduleDeclarations(pluginDir, "p").declarations[0]!
@@ -505,15 +533,50 @@ describe("parsePluginScheduleDeclarations", () => {
         "lib",
         "helper.sh",
       );
+      mkdirSync(dirname(helperPath), { recursive: true });
+      writeFileSync(helperPath, "echo v1\n");
+      const statePath = join(
+        pluginDir,
+        "schedules",
+        "backup",
+        "data",
+        "state.json",
+      );
+      mkdirSync(dirname(statePath), { recursive: true });
+      writeFileSync(statePath, JSON.stringify({ lastRun: 1 }));
+      expect(parse()).toBe(original);
+
       writeFileSync(helperPath, "echo v2\n");
-      const afterEdit = parse();
-      expect(afterEdit).not.toBe(original);
+      writeFileSync(statePath, JSON.stringify({ lastRun: 2 }));
+      expect(parse()).toBe(original);
 
       renameSync(
         helperPath,
         join(pluginDir, "schedules", "backup", "lib", "helper2.sh"),
       );
-      expect(parse()).not.toBe(afterEdit);
+      expect(parse()).toBe(original);
+
+      rmSync(join(pluginDir, "schedules", "backup", "data"), {
+        recursive: true,
+        force: true,
+      });
+      expect(parse()).toBe(original);
+    });
+
+    test("hashes a two-file declaration to its known value", () => {
+      const pluginDir = makePlugin({
+        "backup/config.json": JSON.stringify({ expression: "0 3 * * *" }),
+        "backup/index.sh": "echo backup\n",
+      });
+      // Pinned so stored rows keep their hash across upgrades. It holds only
+      // while the hashed paths stay `<name>/config.json` and
+      // `<name>/<entrypoint>`, relative to schedules/.
+      expect(
+        parsePluginScheduleDeclarations(pluginDir, "p").declarations[0]!
+          .definitionHash,
+      ).toBe(
+        "0b5722fc45abdd2c46672f275e3bcf548016ee5c0722da5a0588ef45fa7bbcab",
+      );
     });
 
     test("differs between two schedules with different names but same content", () => {

--- a/assistant/src/schedule/plugin-schedule-declarations.ts
+++ b/assistant/src/schedule/plugin-schedule-declarations.ts
@@ -30,7 +30,6 @@ import { z } from "zod";
 import { isPluginDisabled } from "../plugins/disabled-state.js";
 import { parsePluginManifest } from "../plugins/external-plugin-loader.js";
 import { isInsidePluginRoot } from "../plugins/installed-plugin-dirs.js";
-import { walkPluginTree } from "../plugins/plugin-tree-walk.js";
 import { FRONTMATTER_REGEX } from "../skills/frontmatter.js";
 import { getWorkspacePluginsDir } from "../util/platform.js";
 import {
@@ -77,9 +76,13 @@ export interface ScheduleDeclaration {
   scriptInvocation: string | null;
   config: PluginScheduleConfig;
   /**
-   * Stable sha256 over the declaration's file contents and their paths
-   * relative to `schedules/`. Any edit, addition, removal, or rename of a
-   * declaration file changes the hash.
+   * Stable sha256 over the declaration's `config.json` and its entrypoint,
+   * each hashed together with its path relative to `schedules/`. Nothing else
+   * under the declaration directory takes part. Helper scripts, and any state
+   * a script writes beside itself, do not change the stored row definition, so
+   * hashing them would report a definition change every time a stateful
+   * schedule runs. Scripts execute by path, so an edit to a helper takes
+   * effect without a definition change.
    */
   definitionHash: string;
 }
@@ -292,21 +295,6 @@ function hashDeclarationFiles(files: DeclarationFile[]): string {
   return hash.digest("hex");
 }
 
-/**
- * Collect every regular file under `dir` (recursively, dot entries and
- * symlinks skipped) with paths relative to the schedules/ root.
- */
-function collectDeclarationFiles(
-  dir: string,
-  relPrefix: string,
-): DeclarationFile[] {
-  const files: DeclarationFile[] = [];
-  walkPluginTree(dir, { excludeDotEntries: true }, (rel, abs) => {
-    files.push({ relPath: `${relPrefix}${rel}`, content: readFileSync(abs) });
-  });
-  return files;
-}
-
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
@@ -395,25 +383,24 @@ function parseDirectoryDeclaration(
   let message: string | null = null;
   let scriptInvocation: string | null = null;
   let mode: PluginScheduleMode;
+  let entrypointText: string;
   if (entrypoint === "index.md") {
-    const content = readFileSync(join(dirPath, "index.md"), "utf8");
-    if (FRONTMATTER_REGEX.test(content)) {
+    entrypointText = readFileSync(join(dirPath, "index.md"), "utf8");
+    if (FRONTMATTER_REGEX.test(entrypointText)) {
       return {
         error:
           "index.md must not contain frontmatter: directory-form config belongs in config.json",
       };
     }
-    message = content.trim();
+    message = entrypointText.trim();
     if (!message) {
       return { error: "prompt body is empty" };
     }
     mode = "execute";
   } else {
     const scriptPath = join(dirPath, "index.sh");
-    scriptInvocation = buildScriptInvocation(
-      scriptPath,
-      readFileSync(scriptPath, "utf8"),
-    );
+    entrypointText = readFileSync(scriptPath, "utf8");
+    scriptInvocation = buildScriptInvocation(scriptPath, entrypointText);
     mode = "script";
   }
 
@@ -422,7 +409,16 @@ function parseDirectoryDeclaration(
     message,
     scriptInvocation,
     config: configResult.config,
-    files: collectDeclarationFiles(dirPath, `${dirName}/`),
+    files: [
+      {
+        relPath: `${dirName}/config.json`,
+        content: Buffer.from(rawConfigText),
+      },
+      {
+        relPath: `${dirName}/${entrypoint}`,
+        content: Buffer.from(entrypointText),
+      },
+    ],
   };
 }
 


### PR DESCRIPTION
## Summary
- Plugin schedule definition hashes now cover exactly config.json and the entrypoint, so helper files or state written under a declaration directory no longer churn definitions or emit definition-changed notifications.
- Two-file declarations keep their existing hash, so no rows re-hash on upgrade.