### PR TITLE
feat(web): add Voice Mode keyboard shortcut

### DIFF
--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -93,6 +93,11 @@ import { ResearchResultsOverlay } from "@/domains/chat/onboarding-research/resea
 import { OnboardingCheckinOverlay } from "@/components/onboarding-checkin-overlay";
 import { OnboardingAvatarApplier } from "@/components/onboarding-avatar-applier";
 import { VoiceSessionPillHost } from "@/domains/chat/components/voice-session-pill-host";
+import {
+  endLiveVoiceSession,
+  isLiveVoiceSessionActive,
+  useLiveVoiceStore,
+} from "@/domains/chat/voice/live-voice/live-voice-store";
 import { useLiveVoiceSessionController } from "@/domains/chat/voice/live-voice/use-live-voice-session-controller";
 import { useSeedLiveVoiceSnapshot } from "@/domains/chat/voice/live-voice/use-seed-live-voice-snapshot";
 import { VoiceRoom } from "@/domains/chat/voice/voice-room/voice-room";
@@ -547,11 +552,21 @@ export function ChatLayout({
     [navigate],
   );
 
+  const toggleLiveVoiceMode = useCallback(() => {
+    const liveVoice = useLiveVoiceStore.getState();
+    if (isLiveVoiceSessionActive(liveVoice.state)) {
+      endLiveVoiceSession();
+      return;
+    }
+    liveVoice.entryHandler?.();
+  }, []);
+
   useChatLayoutShortcuts({
     toggleSidebar,
     onGoBack: handleGoBack,
     onGoForward: handleGoForward,
     onNewConversation: startNewConversation,
+    onToggleVoiceMode: toggleLiveVoiceMode,
   });
 
   const drawerRef = useChatLayoutDrawer({

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -550,6 +550,22 @@ export function ChatComposer({
     startLiveVoiceSession();
   }, [startLiveVoiceSession]);
 
+  // ChatLayout owns the global shortcut, but this composer owns the guarded
+  // entry flow, so register the same handler the button uses. Cleanup is
+  // identity-safe so an unmounting composer cannot clear a newer handler.
+  useEffect(() => {
+    if (!showVoiceInput) {
+      return;
+    }
+    useLiveVoiceStore.getState().setEntryHandler(handleLiveVoiceStart);
+    return () => {
+      const store = useLiveVoiceStore.getState();
+      if (store.entryHandler === handleLiveVoiceStart) {
+        store.setEntryHandler(null);
+      }
+    };
+  }, [handleLiveVoiceStart, showVoiceInput]);
+
   const pointerCoarse = useMemo(() => isPointerCoarse(), []);
   // `shouldSubmitOnEnter` ignores Enter under a coarse primary pointer, since a
   // soft keyboard's Enter inserts a newline. Anything that stands in for

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -554,7 +554,7 @@ export function ChatComposer({
   // entry flow, so register the same handler the button uses. Cleanup is
   // identity-safe so an unmounting composer cannot clear a newer handler.
   useEffect(() => {
-    if (!showVoiceInput) {
+    if (!showVoiceInput || !assistantId || !supportsLiveVoice) {
       return;
     }
     useLiveVoiceStore.getState().setEntryHandler(handleLiveVoiceStart);
@@ -564,7 +564,7 @@ export function ChatComposer({
         store.setEntryHandler(null);
       }
     };
-  }, [handleLiveVoiceStart, showVoiceInput]);
+  }, [assistantId, handleLiveVoiceStart, showVoiceInput, supportsLiveVoice]);
 
   const pointerCoarse = useMemo(() => isPointerCoarse(), []);
   // `shouldSubmitOnEnter` ignores Enter under a coarse primary pointer, since a

--- a/clients/web/src/domains/chat/hooks/use-chat-layout-shortcuts.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-chat-layout-shortcuts.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
+
+import {
+  shouldHandleShortcut,
+  useChatLayoutShortcuts,
+} from "./use-chat-layout-shortcuts";
+
+const callbacks = {
+  toggleSidebar: mock(() => {}),
+  onGoBack: mock(() => {}),
+  onGoForward: mock(() => {}),
+  onNewConversation: mock(() => {}),
+  onToggleVoiceMode: mock(() => {}),
+};
+
+beforeEach(() => {
+  for (const callback of Object.values(callbacks)) {
+    callback.mockClear();
+  }
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("shouldHandleShortcut", () => {
+  test("accepts shifted uppercase keys", () => {
+    expect(
+      shouldHandleShortcut(
+        { metaKey: true, ctrlKey: false, key: "V" },
+        document.body,
+        "v",
+      ),
+    ).toBe(true);
+  });
+
+  test("preserves paste-as-plain-text inside text-entry controls", () => {
+    const textarea = document.createElement("textarea");
+    document.body.append(textarea);
+    expect(
+      shouldHandleShortcut(
+        { metaKey: true, ctrlKey: false, key: "V" },
+        textarea,
+        "v",
+      ),
+    ).toBe(false);
+    textarea.remove();
+  });
+
+  test("preserves editing inside contenteditable elements", () => {
+    const editor = document.createElement("div");
+    editor.contentEditable = "true";
+    document.body.append(editor);
+    expect(
+      shouldHandleShortcut(
+        { metaKey: true, ctrlKey: false, key: "V" },
+        editor,
+        "v",
+      ),
+    ).toBe(false);
+    editor.remove();
+  });
+});
+
+describe("useChatLayoutShortcuts", () => {
+  test("toggles Voice Mode for Cmd/Ctrl+Shift+V and prevents the browser action", () => {
+    renderHook(() => useChatLayoutShortcuts(callbacks));
+    const event = new KeyboardEvent("keydown", {
+      key: "V",
+      metaKey: true,
+      shiftKey: true,
+      cancelable: true,
+    });
+
+    window.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(callbacks.onToggleVoiceMode).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not intercept Cmd/Ctrl+Shift+V from a textarea", () => {
+    const textarea = document.createElement("textarea");
+    document.body.append(textarea);
+    textarea.focus();
+    renderHook(() => useChatLayoutShortcuts(callbacks));
+    const event = new KeyboardEvent("keydown", {
+      key: "V",
+      metaKey: true,
+      shiftKey: true,
+      cancelable: true,
+    });
+
+    window.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(callbacks.onToggleVoiceMode).not.toHaveBeenCalled();
+    textarea.remove();
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-chat-layout-shortcuts.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-chat-layout-shortcuts.test.ts
@@ -25,12 +25,13 @@ afterEach(() => {
 });
 
 describe("shouldHandleShortcut", () => {
-  test("accepts shifted uppercase keys", () => {
+  test("accepts the physical Z key with Option/Alt", () => {
     expect(
       shouldHandleShortcut(
-        { metaKey: true, ctrlKey: false, key: "V" },
+        { metaKey: false, ctrlKey: false, altKey: true, key: "Ω", code: "KeyZ" },
         document.body,
-        "v",
+        "z",
+        "alt",
       ),
     ).toBe(true);
   });
@@ -40,9 +41,10 @@ describe("shouldHandleShortcut", () => {
     document.body.append(textarea);
     expect(
       shouldHandleShortcut(
-        { metaKey: true, ctrlKey: false, key: "V" },
+        { metaKey: false, ctrlKey: false, altKey: true, key: "Ω", code: "KeyZ" },
         textarea,
-        "v",
+        "z",
+        "alt",
       ),
     ).toBe(false);
     textarea.remove();
@@ -54,9 +56,10 @@ describe("shouldHandleShortcut", () => {
     document.body.append(editor);
     expect(
       shouldHandleShortcut(
-        { metaKey: true, ctrlKey: false, key: "V" },
+        { metaKey: false, ctrlKey: false, altKey: true, key: "Ω", code: "KeyZ" },
         editor,
-        "v",
+        "z",
+        "alt",
       ),
     ).toBe(false);
     editor.remove();
@@ -64,12 +67,12 @@ describe("shouldHandleShortcut", () => {
 });
 
 describe("useChatLayoutShortcuts", () => {
-  test("toggles Voice Mode for Cmd/Ctrl+Shift+V and prevents the browser action", () => {
+  test("toggles Voice Mode for Option+Z and prevents the browser action", () => {
     renderHook(() => useChatLayoutShortcuts(callbacks));
     const event = new KeyboardEvent("keydown", {
-      key: "V",
-      metaKey: true,
-      shiftKey: true,
+      key: "Ω",
+      code: "KeyZ",
+      altKey: true,
       cancelable: true,
     });
 
@@ -79,15 +82,15 @@ describe("useChatLayoutShortcuts", () => {
     expect(callbacks.onToggleVoiceMode).toHaveBeenCalledTimes(1);
   });
 
-  test("does not intercept Cmd/Ctrl+Shift+V from a textarea", () => {
+  test("does not intercept Option+Z from a textarea", () => {
     const textarea = document.createElement("textarea");
     document.body.append(textarea);
     textarea.focus();
     renderHook(() => useChatLayoutShortcuts(callbacks));
     const event = new KeyboardEvent("keydown", {
-      key: "V",
-      metaKey: true,
-      shiftKey: true,
+      key: "Ω",
+      code: "KeyZ",
+      altKey: true,
       cancelable: true,
     });
 

--- a/clients/web/src/domains/chat/hooks/use-chat-layout-shortcuts.ts
+++ b/clients/web/src/domains/chat/hooks/use-chat-layout-shortcuts.ts
@@ -4,20 +4,27 @@ import { openCommandPaletteWindow } from "@/runtime/command-palette-window";
 import { useCommandPaletteStore } from "@/stores/command-palette-store";
 
 /**
- * Returns `true` when the keyboard event matches Ctrl/Cmd + one of the given
- * keys and the active element is not an input surface.
+ * Returns `true` when the keyboard event matches the requested modifier plus
+ * one of the given keys and the active element is not an input surface.
  */
 export function shouldHandleShortcut(
-  event: Pick<KeyboardEvent, "metaKey" | "ctrlKey" | "key">,
+  event: Pick<KeyboardEvent, "metaKey" | "ctrlKey" | "altKey" | "key" | "code">,
   activeElement: Element | null,
   key: string | string[],
+  modifier: "command" | "alt" = "command",
 ): boolean {
-  const modifierPressed = event.metaKey || event.ctrlKey;
+  const modifierPressed =
+    modifier === "alt" ? event.altKey : event.metaKey || event.ctrlKey;
   if (!modifierPressed) {
     return false;
   }
   const keys = Array.isArray(key) ? key : [key];
-  if (!keys.some((candidate) => candidate.toLowerCase() === event.key.toLowerCase())) {
+  const keyMatches = keys.some(
+    (candidate) =>
+      candidate.toLowerCase() === event.key.toLowerCase() ||
+      `Key${candidate.toUpperCase()}` === event.code,
+  );
+  if (!keyMatches) {
     return false;
   }
   if (!activeElement) {
@@ -36,6 +43,7 @@ export function shouldHandleShortcut(
 /**
  * Registers global keyboard shortcuts for the chat layout:
  * - Ctrl/Cmd+Shift+O → new conversation (ChatGPT / Claude convention)
+ * - Option/Alt+Z → toggle Voice Mode
  * - Ctrl/Cmd+\ → toggle sidebar
  * - Ctrl/Cmd+K → toggle command palette
  * - Ctrl/Cmd+[ → navigate back
@@ -82,12 +90,9 @@ export function useChatLayoutShortcuts({
         return;
       }
 
-      // Cmd/Ctrl+Shift+V toggles Voice Mode, but deliberately yields to the
-      // platform's paste-as-plain-text command while editing text.
-      if (
-        event.shiftKey &&
-        shouldHandleShortcut(event, document.activeElement, "v")
-      ) {
+      // Option/Alt+Z toggles Voice Mode. Match the physical Z key because
+      // macOS reports Option+Z as Ω on a US keyboard, and yield to text entry.
+      if (shouldHandleShortcut(event, document.activeElement, "z", "alt")) {
         event.preventDefault();
         onToggleVoiceMode();
         return;

--- a/clients/web/src/domains/chat/hooks/use-chat-layout-shortcuts.ts
+++ b/clients/web/src/domains/chat/hooks/use-chat-layout-shortcuts.ts
@@ -7,7 +7,7 @@ import { useCommandPaletteStore } from "@/stores/command-palette-store";
  * Returns `true` when the keyboard event matches Ctrl/Cmd + one of the given
  * keys and the active element is not an input surface.
  */
-function shouldHandleShortcut(
+export function shouldHandleShortcut(
   event: Pick<KeyboardEvent, "metaKey" | "ctrlKey" | "key">,
   activeElement: Element | null,
   key: string | string[],
@@ -17,7 +17,7 @@ function shouldHandleShortcut(
     return false;
   }
   const keys = Array.isArray(key) ? key : [key];
-  if (!keys.includes(event.key)) {
+  if (!keys.some((candidate) => candidate.toLowerCase() === event.key.toLowerCase())) {
     return false;
   }
   if (!activeElement) {
@@ -46,11 +46,13 @@ export function useChatLayoutShortcuts({
   onGoBack,
   onGoForward,
   onNewConversation,
+  onToggleVoiceMode,
 }: {
   toggleSidebar: () => void;
   onGoBack: () => void;
   onGoForward: () => void;
   onNewConversation: () => void;
+  onToggleVoiceMode: () => void;
 }): void {
   useEffect(() => {
     const toggle = useCommandPaletteStore.getState().toggle;
@@ -80,6 +82,17 @@ export function useChatLayoutShortcuts({
         return;
       }
 
+      // Cmd/Ctrl+Shift+V toggles Voice Mode, but deliberately yields to the
+      // platform's paste-as-plain-text command while editing text.
+      if (
+        event.shiftKey &&
+        shouldHandleShortcut(event, document.activeElement, "v")
+      ) {
+        event.preventDefault();
+        onToggleVoiceMode();
+        return;
+      }
+
       if (shouldHandleShortcut(event, document.activeElement, "\\")) {
         event.preventDefault();
         toggleSidebar();
@@ -104,5 +117,11 @@ export function useChatLayoutShortcuts({
     return () => {
       window.removeEventListener("keydown", onKeyDown);
     };
-  }, [toggleSidebar, onGoBack, onGoForward, onNewConversation]);
+  }, [
+    toggleSidebar,
+    onGoBack,
+    onGoForward,
+    onNewConversation,
+    onToggleVoiceMode,
+  ]);
 }

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
@@ -34,6 +34,7 @@ beforeEach(() => {
   // reset() deliberately preserves the starter (mount-scoped); clear it
   // explicitly so tests can't leak a registered starter into each other.
   useLiveVoiceStore.getState().setStarter(null);
+  useLiveVoiceStore.getState().setEntryHandler(null);
 });
 
 function makeStarter() {
@@ -96,14 +97,17 @@ describe("useLiveVoiceStore — session starter", () => {
     expect(useLiveVoiceStore.getState().starter).toBeNull();
   });
 
-  test("reset preserves the starter — session teardown must not deregister the mounted controller", () => {
+  test("reset preserves the starter and entry handler — session teardown must not deregister mount-scoped seams", () => {
     const starter = makeStarter();
+    const entryHandler = mock(() => {});
     useLiveVoiceStore.getState().setStarter(starter);
+    useLiveVoiceStore.getState().setEntryHandler(entryHandler);
     // Simulate a full session lifecycle ending in teardown's reset().
     useLiveVoiceStore.getState().setSessionContext("assistant-1", "conv-1");
     useLiveVoiceStore.getState().setState("listening");
     useLiveVoiceStore.getState().reset();
     expect(useLiveVoiceStore.getState().starter).toBe(starter);
+    expect(useLiveVoiceStore.getState().entryHandler).toBe(entryHandler);
   });
 });
 

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -221,6 +221,12 @@ export interface LiveVoiceSessionStarter {
   start(assistantId: string, conversationId: string | null): void;
 }
 
+/**
+ * Entry handler registered by the visible composer so layout-level shortcuts
+ * reuse its preflight and first-run experience instead of bypassing it.
+ */
+export type LiveVoiceSessionEntryHandler = () => void;
+
 export interface LiveVoiceState {
   /** Current phase of the session lifecycle. */
   state: LiveVoiceSessionState;
@@ -278,6 +284,8 @@ export interface LiveVoiceState {
    * registered.
    */
   starter: LiveVoiceSessionStarter | null;
+  /** Entry handler registered by the visible voice-enabled composer. */
+  entryHandler: LiveVoiceSessionEntryHandler | null;
   /**
    * One short line describing what the current turn is doing ("Reading a
    * file"), or `""` when it is doing nothing nameable.
@@ -427,6 +435,8 @@ export interface LiveVoiceActions {
   setControls: (controls: LiveVoiceSessionControls | null) => void;
   /** Register (or clear) the mounted controller's session starter. */
   setStarter: (starter: LiveVoiceSessionStarter | null) => void;
+  /** Register (or clear) the visible composer's entry handler. */
+  setEntryHandler: (handler: LiveVoiceSessionEntryHandler | null) => void;
   setPartialTranscript: (text: string) => void;
   setFinalTranscript: (text: string) => void;
   /** Append a delta to the accumulated assistant transcript. */
@@ -558,8 +568,11 @@ export function isLiveVoiceSessionOwnedBy(
 // Store
 // ---------------------------------------------------------------------------
 
-/** Session-scoped fields restored by `reset()`. Excludes `starter` (mount-scoped). */
-const INITIAL_SESSION_STATE: Omit<LiveVoiceState, "starter"> = {
+/** Session-scoped fields restored by `reset()`. Excludes mount-scoped handlers. */
+const INITIAL_SESSION_STATE: Omit<
+  LiveVoiceState,
+  "starter" | "entryHandler"
+> = {
   state: "idle",
   assistantAudioActive: false,
   microphoneActive: false,
@@ -590,6 +603,7 @@ const INITIAL_SESSION_STATE: Omit<LiveVoiceState, "starter"> = {
 const useLiveVoiceStoreBase = create<LiveVoiceStore>()((set) => ({
   ...INITIAL_SESSION_STATE,
   starter: null,
+  entryHandler: null,
 
   setState: (state) => set({ state }),
   setAssistantAudioActive: (assistantAudioActive) =>
@@ -616,6 +630,7 @@ const useLiveVoiceStoreBase = create<LiveVoiceStore>()((set) => ({
     })),
   setControls: (controls) => set({ controls }),
   setStarter: (starter) => set({ starter }),
+  setEntryHandler: (entryHandler) => set({ entryHandler }),
   setPartialTranscript: (partialTranscript) => set({ partialTranscript }),
   setFinalTranscript: (finalTranscript) => set({ finalTranscript }),
   appendAssistantTranscript: (delta) =>


### PR DESCRIPTION
## Summary

- Add Option/Alt+Z to toggle Voice Mode from the chat layout.
- Match the physical Z key so macOS's Option+Z event (`Ω`) works reliably.
- Reuse the canonical ChatComposer preflight and first-run flow for starting Voice Mode.
- Stop active Voice Mode sessions through the existing live-voice controls.
- Register the shortcut entry handler only for assistants that support live voice.
- Preserve Ω typing and other editing behavior inside input, textarea, select, and contenteditable surfaces.
- Add shortcut, compatibility-gate, and mount-scoped entry-handler coverage.

## Verification

- Focused Bun tests: 55 passed, 0 failed, 108 assertions.
- Web TypeScript check passed.
- ESLint passed with 0 errors; one pre-existing warning remains in ChatComposer.
- `git diff --check` passed.
- Manual testing confirmed the shortcut works.
- Codex P2 review feedback addressed in the latest commit.
