### PR TITLE
fix(schedule): only arm and fire plugin schedules for plugins the daemon activated

### DIFF
--- a/assistant/src/__tests__/run-due-schedules.test.ts
+++ b/assistant/src/__tests__/run-due-schedules.test.ts
@@ -55,6 +55,18 @@ mock.module("../persistence/lifecycle-quiesce.js", () => ({
   isLifecycleQuiesced: () => quiesceAnswers.shift() ?? false,
 }));
 
+/**
+ * Whether the daemon activated the fixture plugin. The gate answers only for
+ * plugins this process brought up, and the worker tick runs no plugin loader,
+ * so the double says "activated" unless a case turns it off.
+ */
+let pluginActivated = true;
+const realMtimeCache = await import("../plugins/mtime-cache.js");
+mock.module("../plugins/mtime-cache.js", () => ({
+  ...realMtimeCache,
+  isPluginDirActivated: () => pluginActivated,
+}));
+
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import {
@@ -253,6 +265,7 @@ describe("fire-time source-availability gate", () => {
     );
     // The feature ships off, so the healthy-plugin cases below need it on.
     setOverridesForTesting({ "plugin-schedules": true });
+    pluginActivated = true;
   });
 
   function skipRunsFor(jobId: string): Array<{
@@ -340,6 +353,28 @@ describe("fire-time source-availability gate", () => {
     expect(result.skipped).toBe(1);
     expect(existsSync(marker)).toBe(false);
     expect(skipRunsFor(job.id)).toHaveLength(1);
+  });
+
+  test("does not execute a due sourced row whose plugin the daemon never activated", async () => {
+    const job = await seedDueSourcedScript();
+    // The plugin's files are all in place; nothing has run its `init`, so its
+    // hooks and tools are not live and its schedules must not fire either.
+    pluginActivated = false;
+
+    const result = await runDueSchedulesOnce();
+
+    expect(result.claimed).toBe(1);
+    expect(result.skipped).toBe(1);
+    expect(result.completed).toBe(0);
+    expect(existsSync(marker)).toBe(false);
+    const runs = skipRunsFor(job.id);
+    expect(runs).toHaveLength(1);
+    expect(runs[0].status).toBe("error");
+    // An administrative skip, so the retry budget is untouched.
+    const row = rawDb()
+      .query("SELECT retry_count FROM cron_jobs WHERE id = ?")
+      .get(job.id) as { retry_count: number };
+    expect(row.retry_count).toBe(0);
   });
 
   test("does not execute a due sourced row while the feature flag is off", async () => {

--- a/assistant/src/__tests__/run-due-schedules.test.ts
+++ b/assistant/src/__tests__/run-due-schedules.test.ts
@@ -55,20 +55,9 @@ mock.module("../persistence/lifecycle-quiesce.js", () => ({
   isLifecycleQuiesced: () => quiesceAnswers.shift() ?? false,
 }));
 
-/**
- * Whether the daemon activated the fixture plugin. The gate answers only for
- * plugins this process brought up, and the worker tick runs no plugin loader,
- * so the double says "activated" unless a case turns it off.
- */
-let pluginActivated = true;
-const realMtimeCache = await import("../plugins/mtime-cache.js");
-mock.module("../plugins/mtime-cache.js", () => ({
-  ...realMtimeCache,
-  isPluginDirActivated: () => pluginActivated,
-}));
-
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
+import { isPluginDirActivated } from "../plugins/mtime-cache.js";
 import {
   createSchedule,
   deferClaimedSchedule,
@@ -265,7 +254,6 @@ describe("fire-time source-availability gate", () => {
     );
     // The feature ships off, so the healthy-plugin cases below need it on.
     setOverridesForTesting({ "plugin-schedules": true });
-    pluginActivated = true;
   });
 
   function skipRunsFor(jobId: string): Array<{
@@ -355,26 +343,24 @@ describe("fire-time source-availability gate", () => {
     expect(skipRunsFor(job.id)).toHaveLength(1);
   });
 
-  test("does not execute a due sourced row whose plugin the daemon never activated", async () => {
+  test("executes an armed sourced row even though no plugin is activated in this process", async () => {
     const job = await seedDueSourcedScript();
-    // The plugin's files are all in place; nothing has run its `init`, so its
-    // hooks and tools are not live and its schedules must not fire either.
-    pluginActivated = false;
+    // The tick runs in the schedule worker, which activates no plugins, so the
+    // activation ledger is empty here. The gate must therefore read the disk
+    // alone: reading activation would skip every plugin schedule. Arming is
+    // the daemon-side reconciler's call.
+    expect(isPluginDirActivated(pluginDir)).toBe(false);
 
     const result = await runDueSchedulesOnce();
 
-    expect(result.claimed).toBe(1);
-    expect(result.skipped).toBe(1);
-    expect(result.completed).toBe(0);
-    expect(existsSync(marker)).toBe(false);
-    const runs = skipRunsFor(job.id);
+    expect(result.completed).toBe(1);
+    expect(result.skipped).toBe(0);
+    expect(existsSync(marker)).toBe(true);
+    const runs = rawDb()
+      .query("SELECT status FROM cron_runs WHERE job_id = ?")
+      .all(job.id) as Array<{ status: string }>;
     expect(runs).toHaveLength(1);
-    expect(runs[0].status).toBe("error");
-    // An administrative skip, so the retry budget is untouched.
-    const row = rawDb()
-      .query("SELECT retry_count FROM cron_jobs WHERE id = ?")
-      .get(job.id) as { retry_count: number };
-    expect(row.retry_count).toBe(0);
+    expect(runs[0].status).toBe("ok");
   });
 
   test("does not execute a due sourced row while the feature flag is off", async () => {

--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -40,6 +40,18 @@ mock.module("../daemon/conversation-store.js", () => ({
   },
 }));
 
+/**
+ * Whether the daemon activated the fixture plugin. Run-now answers only for
+ * plugins this process brought up, and no route test runs the plugin loader,
+ * so the double says "activated" unless a case turns it off.
+ */
+let pluginActivated = true;
+const realMtimeCache = await import("../plugins/mtime-cache.js");
+mock.module("../plugins/mtime-cache.js", () => ({
+  ...realMtimeCache,
+  isPluginDirActivated: () => pluginActivated,
+}));
+
 import type { AssistantEventEnvelope } from "../api/index.js";
 import { SYNC_TAGS } from "../daemon/message-types/sync.js";
 import {
@@ -1574,6 +1586,7 @@ describe("plugin-sourced schedules over routes", () => {
 
     beforeEach(() => {
       rmSync(RUN_MARKER, { force: true });
+      pluginActivated = true;
     });
 
     function seedSourcedScript() {
@@ -1621,6 +1634,16 @@ describe("plugin-sourced schedules over routes", () => {
         ),
         { recursive: true, force: true },
       );
+
+      await expect(runNow(sourced.id)).rejects.toThrow(BadRequestError);
+      expect(existsSync(RUN_MARKER)).toBe(false);
+    });
+
+    test("refuses a sourced row whose plugin the daemon never activated", async () => {
+      const sourced = await seedSourcedScript();
+      // The declaration is intact on disk, but nothing ran the plugin's
+      // `init`, so run-now must not execute its script.
+      pluginActivated = false;
 
       await expect(runNow(sourced.id)).rejects.toThrow(BadRequestError);
       expect(existsSync(RUN_MARKER)).toBe(false);

--- a/assistant/src/__tests__/schedule-store.test.ts
+++ b/assistant/src/__tests__/schedule-store.test.ts
@@ -14,19 +14,6 @@ mock.module("../background-wake/publisher.js", () => ({
   refreshBackgroundWakeIntent: () => {},
 }));
 
-/**
- * Whether the daemon activated the fixture plugin. `setUserEnabled` re-arms a
- * sourced row only for a plugin this process brought up, and no store-level
- * test runs the plugin loader, so the double says "activated" unless a case
- * turns it off.
- */
-let pluginActivated = true;
-const realMtimeCache = await import("../plugins/mtime-cache.js");
-mock.module("../plugins/mtime-cache.js", () => ({
-  ...realMtimeCache,
-  isPluginDirActivated: () => pluginActivated,
-}));
-
 import type { AssistantEventEnvelope } from "../api/index.js";
 import { SYNC_TAGS } from "../daemon/message-types/sync.js";
 import {
@@ -36,6 +23,7 @@ import {
 } from "../persistence/conversation-crud.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
+import { isPluginDirActivated } from "../plugins/mtime-cache.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import {
   hasOwnerDeferProvenance,
@@ -1577,7 +1565,6 @@ describe("declared schedules", () => {
   beforeEach(() => {
     getDb().run("DELETE FROM cron_runs");
     getDb().run("DELETE FROM cron_jobs");
-    pluginActivated = true;
     rmSync(examplePluginDir(), { recursive: true, force: true });
     const declarationDir = join(examplePluginDir(), "schedules", "daily");
     mkdirSync(declarationDir, { recursive: true });
@@ -1870,17 +1857,20 @@ describe("declared schedules", () => {
     expect(result!.enabled).toBe(false);
   });
 
-  test("enabling a schedule whose plugin was never activated records the override without re-arming", async () => {
+  test("enabling a schedule re-arms it on the on-disk declaration alone", async () => {
     const created = await upsertDeclaredSchedule(SOURCE_KEY, makeDefinition());
     await setUserEnabled(created.id, false);
-    // The declaration is intact on disk, but nothing brought the plugin up, so
-    // a toggle must not put its schedule back in the firing set.
-    pluginActivated = false;
+    // A schedule tool reaches this from a conversation turn, which can run in
+    // a sidecar worker process where no plugin is activated. The probe must
+    // therefore read the disk alone: asking about activation here would refuse
+    // every re-enable. Whether the plugin stays armed is the reconciler's
+    // call, and its next sweep disarms the row if it should not be.
+    expect(isPluginDirActivated(examplePluginDir())).toBe(false);
 
     const result = await setUserEnabled(created.id, true);
 
     expect(result!.userEnabled).toBe(true);
-    expect(result!.enabled).toBe(false);
+    expect(result!.enabled).toBe(true);
   });
 
   test("enabling a schedule whose plugin manifest is broken records the override without re-arming", async () => {

--- a/assistant/src/__tests__/schedule-store.test.ts
+++ b/assistant/src/__tests__/schedule-store.test.ts
@@ -14,6 +14,19 @@ mock.module("../background-wake/publisher.js", () => ({
   refreshBackgroundWakeIntent: () => {},
 }));
 
+/**
+ * Whether the daemon activated the fixture plugin. `setUserEnabled` re-arms a
+ * sourced row only for a plugin this process brought up, and no store-level
+ * test runs the plugin loader, so the double says "activated" unless a case
+ * turns it off.
+ */
+let pluginActivated = true;
+const realMtimeCache = await import("../plugins/mtime-cache.js");
+mock.module("../plugins/mtime-cache.js", () => ({
+  ...realMtimeCache,
+  isPluginDirActivated: () => pluginActivated,
+}));
+
 import type { AssistantEventEnvelope } from "../api/index.js";
 import { SYNC_TAGS } from "../daemon/message-types/sync.js";
 import {
@@ -1564,6 +1577,7 @@ describe("declared schedules", () => {
   beforeEach(() => {
     getDb().run("DELETE FROM cron_runs");
     getDb().run("DELETE FROM cron_jobs");
+    pluginActivated = true;
     rmSync(examplePluginDir(), { recursive: true, force: true });
     const declarationDir = join(examplePluginDir(), "schedules", "daily");
     mkdirSync(declarationDir, { recursive: true });
@@ -1849,6 +1863,19 @@ describe("declared schedules", () => {
     // must keep the enable probe from re-arming the row before the next
     // reconcile pass.
     writeFileSync(join(examplePluginDir(), ".disabled"), "");
+
+    const result = await setUserEnabled(created.id, true);
+
+    expect(result!.userEnabled).toBe(true);
+    expect(result!.enabled).toBe(false);
+  });
+
+  test("enabling a schedule whose plugin was never activated records the override without re-arming", async () => {
+    const created = await upsertDeclaredSchedule(SOURCE_KEY, makeDefinition());
+    await setUserEnabled(created.id, false);
+    // The declaration is intact on disk, but nothing brought the plugin up, so
+    // a toggle must not put its schedule back in the firing set.
+    pluginActivated = false;
 
     const result = await setUserEnabled(created.id, true);
 

--- a/assistant/src/plugins/mtime-cache.ts
+++ b/assistant/src/plugins/mtime-cache.ts
@@ -220,6 +220,10 @@ export function getDiscoveredUserPluginNames(): Iterable<string> {
  * hooks and tools stay live, so its schedules must too. What membership
  * excludes is a directory dropped in out-of-band that no boot scan and no
  * reconcile pass has activated yet.
+ *
+ * The backing map is per-process, so a process that runs no plugin loader (the
+ * schedule worker, sidecar turn workers) reads `false` for every directory.
+ * Only code that provably runs in the main daemon may treat this as an answer.
  */
 export function isPluginDirActivated(dir: string): boolean {
   return discoveredPluginDirs.has(dir);

--- a/assistant/src/plugins/mtime-cache.ts
+++ b/assistant/src/plugins/mtime-cache.ts
@@ -212,6 +212,19 @@ export function getDiscoveredUserPluginNames(): Iterable<string> {
   return discoveredPluginDirs.values();
 }
 
+/**
+ * True when this daemon process brought the plugin directory `dir` up:
+ * {@link bringUpPlugin} ran for it and its `init` was attempted. An `init` that
+ * threw still counts, because activation never aborts on init failure (see
+ * {@link activatePlugin}), and that is deliberate: an init-failed plugin's
+ * hooks and tools stay live, so its schedules must too. What membership
+ * excludes is a directory dropped in out-of-band that no boot scan and no
+ * reconcile pass has activated yet.
+ */
+export function isPluginDirActivated(dir: string): boolean {
+  return discoveredPluginDirs.has(dir);
+}
+
 // ─── Source-versions reconcile ───────────────────────────────────────────────
 
 /**

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -17,7 +17,7 @@ import {
 } from "../../persistence/llm-usage-store.js";
 import { isDeferSchedule } from "../../schedule/defer-provenance.js";
 import { validateScheduleInferenceProfile } from "../../schedule/inference-profile.js";
-import { declarationExistsOnDisk } from "../../schedule/plugin-schedule-declarations.js";
+import { pluginScheduleSourceAvailable } from "../../schedule/plugin-schedule-availability.js";
 import { isPluginSchedulesEnabled } from "../../schedule/plugin-schedules-gate.js";
 import {
   describeRRuleExpression,
@@ -1240,15 +1240,16 @@ async function handleRunScheduleNow(
 
   // A plugin-sourced row runs the plugin's own script or prompt, so run-now is
   // only offered while that plugin is something the runtime would activate.
-  // `declarationExistsOnDisk` is the same probe the enable path uses: it covers
-  // a disabled plugin, an unreadable or invalid manifest, and a declaration
-  // that is simply gone. Turning the feature flag off retires the surface
-  // wholesale and takes the same path. The row can still be armed at this
-  // point, because the reconciler that disarms it runs on its own schedule.
+  // `pluginScheduleSourceAvailable` is the same probe the enable path uses: it
+  // covers a plugin the daemon never activated, a disabled plugin, an
+  // unreadable or invalid manifest, and a declaration that is simply gone.
+  // Turning the feature flag off retires the surface wholesale and takes the
+  // same path. The row can still be armed at this point, because the
+  // reconciler that disarms it runs on its own schedule.
   if (
     schedule.sourceKey !== null &&
     (!isPluginSchedulesEnabled() ||
-      !(await declarationExistsOnDisk(schedule.sourceKey)))
+      !(await pluginScheduleSourceAvailable(schedule.sourceKey)))
   ) {
     throw new BadRequestError(
       "This schedule's plugin is disabled or no longer declares it, so it cannot be run.",

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -1240,12 +1240,15 @@ async function handleRunScheduleNow(
 
   // A plugin-sourced row runs the plugin's own script or prompt, so run-now is
   // only offered while that plugin is something the runtime would activate.
-  // `pluginScheduleSourceAvailable` is the same probe the enable path uses: it
-  // covers a plugin the daemon never activated, a disabled plugin, an
-  // unreadable or invalid manifest, and a declaration that is simply gone.
-  // Turning the feature flag off retires the surface wholesale and takes the
-  // same path. The row can still be armed at this point, because the
-  // reconciler that disarms it runs on its own schedule.
+  // `pluginScheduleSourceAvailable` covers a plugin the daemon never
+  // activated, a disabled plugin, an unreadable or invalid manifest, and a
+  // declaration that is simply gone. Turning the feature flag off retires the
+  // surface wholesale and takes the same path. The row can still be armed at
+  // this point, because the reconciler that disarms it runs on its own
+  // schedule.
+  // Routes are served by the daemon, so the activation half of the probe reads
+  // a live ledger here. Paths that run in worker processes cannot ask that
+  // question and use the on-disk probe alone.
   if (
     schedule.sourceKey !== null &&
     (!isPluginSchedulesEnabled() ||

--- a/assistant/src/schedule/__tests__/plugin-schedule-reconciler.test.ts
+++ b/assistant/src/schedule/__tests__/plugin-schedule-reconciler.test.ts
@@ -45,9 +45,29 @@ mock.module("../../notifications/emit-signal.js", () => ({
   },
 }));
 
+/**
+ * Plugin directories the daemon has not activated. The reconciler arms only
+ * plugins this process brought up, and no test here runs the plugin loader, so
+ * the double answers "activated" unless a case says otherwise.
+ */
+const notActivatedDirs = new Set<string>();
+
+/** Every directory the reconciler put through the activation predicate. */
+const activationProbes: string[] = [];
+
+const realMtimeCache = await import("../../plugins/mtime-cache.js");
+mock.module("../../plugins/mtime-cache.js", () => ({
+  ...realMtimeCache,
+  isPluginDirActivated: (dir: string) => {
+    activationProbes.push(dir);
+    return !notActivatedDirs.has(dir);
+  },
+}));
+
 import { setOverridesForTesting } from "../../__tests__/feature-flag-test-helpers.js";
 import { getDb } from "../../persistence/db-connection.js";
 import { initializeDb } from "../../persistence/db-init.js";
+import { listInstalledPluginDirs } from "../../plugins/installed-plugin-dirs.js";
 import { getWorkspacePluginsDir } from "../../util/platform.js";
 import {
   reconcilePluginSchedules,
@@ -175,6 +195,8 @@ function resetReconcilerFixtures(): void {
   emittedSignals.length = 0;
   emitResultOverride = null;
   emitGate = null;
+  notActivatedDirs.clear();
+  activationProbes.length = 0;
   resetDefinitionErrorEmitGuardForTests();
 }
 
@@ -968,6 +990,65 @@ describe("reconcilePluginSchedules", () => {
       unknown
     >;
     expect(payload.reason).toContain("no upcoming occurrences");
+  });
+
+  test("a plugin the daemon never activated arms nothing", async () => {
+    // Everything the parser needs is on disk; only the activation is missing,
+    // which is what a directory dropped into the plugins root looks like.
+    const dir = writePlugin("news", digest());
+    notActivatedDirs.add(dir);
+
+    await reconcilePluginSchedules();
+
+    expect(listDeclaredSchedules()).toHaveLength(0);
+    expect(emittedSignals).toHaveLength(0);
+  });
+
+  test("a row disarms once its plugin is no longer activated", async () => {
+    const dir = writePlugin("news", digest());
+    await reconcilePluginSchedules();
+    const created = listDeclaredSchedules()[0]!;
+    expect(created.enabled).toBe(true);
+
+    notActivatedDirs.add(dir);
+    await reconcilePluginSchedules();
+
+    const row = listDeclaredSchedules()[0]!;
+    expect(row.id).toBe(created.id);
+    expect(row.enabled).toBe(false);
+  });
+
+  test("a plugin activated between passes arms on the second one", async () => {
+    const dir = writePlugin("news", digest());
+    notActivatedDirs.add(dir);
+    await reconcilePluginSchedules();
+    expect(listDeclaredSchedules()).toHaveLength(0);
+
+    notActivatedDirs.delete(dir);
+    await reconcilePluginSchedules();
+
+    const rows = listDeclaredSchedules();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.sourceKey).toBe(DIGEST_KEY);
+    expect(rows[0]!.enabled).toBe(true);
+    // The row arms for the first time here, so it announces its arrival.
+    const declared = emittedSignals.filter(
+      (s) => s.sourceEventName === "schedule.declared",
+    );
+    expect(declared).toHaveLength(1);
+    expect(declared[0]!.sourceContextId).toBe(DIGEST_KEY);
+  });
+
+  test("the activation probe sees the directory string the walk yields", async () => {
+    // The predicate is keyed by directory path, so the enumeration the
+    // reconciler walks and the map the daemon activates into have to agree on
+    // the exact string. Both come from `listInstalledPluginDirs`.
+    const dir = writePlugin("news", digest());
+
+    await reconcilePluginSchedules();
+
+    expect(listInstalledPluginDirs().map((p) => p.dir)).toEqual([dir]);
+    expect(activationProbes).toEqual([dir]);
   });
 
   test("a suppressed error emit still latches the day guard", async () => {

--- a/assistant/src/schedule/plugin-schedule-availability.ts
+++ b/assistant/src/schedule/plugin-schedule-availability.ts
@@ -1,0 +1,44 @@
+/**
+ * Availability probe for a plugin-declared schedule's source.
+ *
+ * Composes the daemon's activation state with the on-disk declaration probe,
+ * so arming, firing, run-now, and re-enable all answer the same question: did
+ * this process bring the plugin up, and is its declaration still sourceable.
+ *
+ * The composition lives here rather than in `./plugin-schedule-declarations.ts`
+ * because that parser is reachable from the plugin loader's own static graph
+ * and must stay free of daemon runtime state. `plugins/mtime-cache.ts` reaches
+ * the schedule side only through a dynamic import, so importing it here does
+ * not close a static cycle.
+ */
+
+import { join } from "node:path";
+
+import { isPluginDirActivated } from "../plugins/mtime-cache.js";
+import { getWorkspacePluginsDir } from "../util/platform.js";
+import { declarationExistsOnDisk } from "./plugin-schedule-declarations.js";
+
+/**
+ * True when the schedule behind `sourceKey`
+ * (`plugin:<pluginName>/<scheduleName>`) may run: the daemon activated the
+ * plugin, and {@link declarationExistsOnDisk} still finds the declaration.
+ *
+ * The activation half is what keeps a plugin directory dropped into the
+ * plugins root out of the scheduler. Such a directory has files the disk probe
+ * accepts, but no `init` has run for it, so its hooks and tools are not live
+ * and its schedules must not be either.
+ */
+export async function pluginScheduleSourceAvailable(
+  sourceKey: string,
+): Promise<boolean> {
+  const match = /^plugin:([^/]+)\/(.+)$/.exec(sourceKey);
+  if (!match) {
+    return false;
+  }
+  const [, pluginName] = match;
+  const pluginDir = join(getWorkspacePluginsDir(), pluginName!);
+  return (
+    isPluginDirActivated(pluginDir) &&
+    (await declarationExistsOnDisk(sourceKey))
+  );
+}

--- a/assistant/src/schedule/plugin-schedule-availability.ts
+++ b/assistant/src/schedule/plugin-schedule-availability.ts
@@ -1,9 +1,23 @@
 /**
  * Availability probe for a plugin-declared schedule's source.
  *
- * Composes the daemon's activation state with the on-disk declaration probe,
- * so arming, firing, run-now, and re-enable all answer the same question: did
- * this process bring the plugin up, and is its declaration still sourceable.
+ * Composes the daemon's activation state with the on-disk declaration probe:
+ * did this process bring the plugin up, and is its declaration still
+ * sourceable.
+ *
+ * **This probe is only meaningful in the main daemon process.** Activation is
+ * tracked in an in-memory map that `bringUpPlugin` writes, so only the process
+ * that ran the plugin loader can answer for it. HTTP routes and the plugin
+ * schedule reconciler run there, so they may use this. Worker processes (the
+ * schedule worker in `schedule/worker.ts`, sidecar turn workers) activate no
+ * plugins, so their ledger is empty and every plugin would read as
+ * unactivated. Those paths call {@link declarationExistsOnDisk} directly.
+ *
+ * That split is safe because the reconciler owns arming and runs in the
+ * daemon: a plugin it has not activated never arms, and its sweep disarms the
+ * rows of a plugin that stops being activated within one pass. The window
+ * between those passes is the whole exposure of the worker-side disk-only
+ * probes.
  *
  * The composition lives here rather than in `./plugin-schedule-declarations.ts`
  * because that parser is reachable from the plugin loader's own static graph

--- a/assistant/src/schedule/plugin-schedule-reconciler.ts
+++ b/assistant/src/schedule/plugin-schedule-reconciler.ts
@@ -33,6 +33,7 @@ import type { AttentionHints } from "../notifications/signal.js";
 import { isPluginDisabled } from "../plugins/disabled-state.js";
 import { parsePluginManifest } from "../plugins/external-plugin-loader.js";
 import { listInstalledPluginDirs } from "../plugins/installed-plugin-dirs.js";
+import { isPluginDirActivated } from "../plugins/mtime-cache.js";
 import { getLogger } from "../util/logger.js";
 import {
   type DeclarationError,
@@ -264,9 +265,14 @@ function isCompletedRecurrence(
  * as the plugin source collector) and gather their schedule declarations.
  * Identity = the directory basename, mirroring `parsePluginManifest`.
  *
- * Disabled plugins and plugins without a `schedules/` directory are skipped
- * entirely; in particular, only schedule-declaring plugins pay the manifest
- * parse each pass. A schedule-declaring plugin whose manifest fails
+ * Disabled plugins, plugins this daemon has not activated
+ * ({@link isPluginDirActivated}), and plugins without a `schedules/` directory
+ * are skipped entirely; in particular, only schedule-declaring plugins pay the
+ * manifest parse each pass. The activation gate is what keeps a directory
+ * dropped into the plugins root out of the desired set: nothing has run its
+ * `init`, so its hooks and tools are not live and its schedules must not arm
+ * either. It joins the set on the pass after the boot scan or an imperative
+ * reconcile brings it up. A schedule-declaring plugin whose manifest fails
  * `parsePluginManifest` (unreadable or schema-invalid `package.json`) also
  * contributes nothing to the desired set: the runtime loader refuses to
  * bring such a plugin up, so its schedules must not stay armed either. Each
@@ -280,6 +286,9 @@ async function collectDesiredDeclarations(): Promise<CollectedDeclarations> {
 
   for (const { name, dir } of listInstalledPluginDirs()) {
     if (isPluginDisabled(name)) {
+      continue;
+    }
+    if (!isPluginDirActivated(dir)) {
       continue;
     }
     if (!existsSync(join(dir, "schedules"))) {

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -33,7 +33,7 @@ import {
   resolveDefaultScheduleInferenceProfile,
   resolveWakeScheduleInferenceProfile,
 } from "./inference-profile.js";
-import { declarationExistsOnDisk } from "./plugin-schedule-declarations.js";
+import { pluginScheduleSourceAvailable } from "./plugin-schedule-availability.js";
 import {
   computeNextRunAt as computeNextRunAtEngine,
   isValidScheduleExpression,
@@ -1045,16 +1045,17 @@ export async function setUserEnabled(
     updatedAt: Date.now(),
   };
   if (value !== existing.enabled && !isEngineLatched(existing)) {
-    // Enabling a row whose declaration is no longer sourceable (plugin
-    // uninstalled or disabled, manifest broken, schedule file removed) would
-    // let it fire an orphaned run before the next reconcile pass disarms it
-    // again. The reconciler is the authority on the declaration set; this
-    // probe only closes that fire-before-next-sweep window. The override
-    // itself is still recorded, so it applies if the declaration returns.
-    if (value && !(await declarationExistsOnDisk(existing.sourceKey))) {
+    // Enabling a row whose declaration is no longer available (plugin never
+    // activated, uninstalled or disabled, manifest broken, schedule file
+    // removed) would let it fire an orphaned run before the next reconcile
+    // pass disarms it again. The reconciler is the authority on the
+    // declaration set; this probe only closes that fire-before-next-sweep
+    // window. The override itself is still recorded, so it applies if the
+    // declaration returns.
+    if (value && !(await pluginScheduleSourceAvailable(existing.sourceKey))) {
       logger.info(
         { scheduleId: id, sourceKey: existing.sourceKey },
-        "Enable override recorded without re-arming: declaration missing on disk",
+        "Enable override recorded without re-arming: schedule source unavailable",
       );
     } else {
       set.enabled = value;

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -33,7 +33,7 @@ import {
   resolveDefaultScheduleInferenceProfile,
   resolveWakeScheduleInferenceProfile,
 } from "./inference-profile.js";
-import { pluginScheduleSourceAvailable } from "./plugin-schedule-availability.js";
+import { declarationExistsOnDisk } from "./plugin-schedule-declarations.js";
 import {
   computeNextRunAt as computeNextRunAtEngine,
   isValidScheduleExpression,
@@ -1045,17 +1045,20 @@ export async function setUserEnabled(
     updatedAt: Date.now(),
   };
   if (value !== existing.enabled && !isEngineLatched(existing)) {
-    // Enabling a row whose declaration is no longer available (plugin never
-    // activated, uninstalled or disabled, manifest broken, schedule file
-    // removed) would let it fire an orphaned run before the next reconcile
-    // pass disarms it again. The reconciler is the authority on the
-    // declaration set; this probe only closes that fire-before-next-sweep
-    // window. The override itself is still recorded, so it applies if the
-    // declaration returns.
-    if (value && !(await pluginScheduleSourceAvailable(existing.sourceKey))) {
+    // Enabling a row whose declaration is no longer sourceable (plugin
+    // uninstalled or disabled, manifest broken, schedule file removed) would
+    // let it fire an orphaned run before the next reconcile pass disarms it
+    // again. The reconciler is the authority on the declaration set; this
+    // probe only closes that fire-before-next-sweep window. The override
+    // itself is still recorded, so it applies if the declaration returns.
+    // The probe is deliberately disk-only. A schedule tool calls this from a
+    // conversation turn, which can run in a sidecar worker process where the
+    // daemon's activation ledger is empty, so consulting activation here would
+    // refuse to re-arm anything. Activation stays the reconciler's call.
+    if (value && !(await declarationExistsOnDisk(existing.sourceKey))) {
       logger.info(
         { scheduleId: id, sourceKey: existing.sourceKey },
-        "Enable override recorded without re-arming: schedule source unavailable",
+        "Enable override recorded without re-arming: declaration missing on disk",
       );
     } else {
       set.enabled = value;

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -27,7 +27,7 @@ import {
 import { runWatchersOnce } from "../watcher/engine.js";
 import { normalizeCapabilityManifest } from "../workflows/capabilities.js";
 import { getWorkflowRunManager } from "../workflows/run-manager.js";
-import { declarationExistsOnDisk } from "./plugin-schedule-declarations.js";
+import { pluginScheduleSourceAvailable } from "./plugin-schedule-availability.js";
 import { isPluginSchedulesEnabled } from "./plugin-schedules-gate.js";
 import { hasSetConstructs } from "./recurrence-engine.js";
 import { applyRetryDecision, decideRetry } from "./retry-policy.js";
@@ -528,11 +528,12 @@ export async function runDueSchedulesOnce(
     }
 
     // Fire-time gate for plugin-sourced rows, covering every way the source
-    // can go away under an armed row. `declarationExistsOnDisk` is the probe
-    // the run-now route and the enable path use, and it answers for all of
-    // them: a `.disabled` sentinel, a plugin directory a local uninstall
-    // removed, a manifest that no longer parses, and a declaration that is
-    // simply gone. Turning the feature flag off retires the whole surface.
+    // can go away under an armed row. `pluginScheduleSourceAvailable` is the
+    // probe the run-now route and the enable path use, and it answers for all
+    // of them: a plugin the daemon never activated, a `.disabled` sentinel, a
+    // plugin directory a local uninstall removed, a manifest that no longer
+    // parses, and a declaration that is simply gone. Turning the feature flag
+    // off retires the whole surface.
     // The reconciler is what disarms the rows any of these own, and it runs
     // on its own schedule, so re-reading here is what makes the change take
     // effect immediately: a row still armed (or already claimed) at that
@@ -542,7 +543,7 @@ export async function runDueSchedulesOnce(
     if (
       sourceKey !== null &&
       (!isPluginSchedulesEnabled() ||
-        !(await declarationExistsOnDisk(sourceKey)))
+        !(await pluginScheduleSourceAvailable(sourceKey)))
     ) {
       const sourcePlugin = describeScheduleSource(sourceKey) ?? sourceKey;
       log.info(

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -27,7 +27,7 @@ import {
 import { runWatchersOnce } from "../watcher/engine.js";
 import { normalizeCapabilityManifest } from "../workflows/capabilities.js";
 import { getWorkflowRunManager } from "../workflows/run-manager.js";
-import { pluginScheduleSourceAvailable } from "./plugin-schedule-availability.js";
+import { declarationExistsOnDisk } from "./plugin-schedule-declarations.js";
 import { isPluginSchedulesEnabled } from "./plugin-schedules-gate.js";
 import { hasSetConstructs } from "./recurrence-engine.js";
 import { applyRetryDecision, decideRetry } from "./retry-policy.js";
@@ -528,12 +528,16 @@ export async function runDueSchedulesOnce(
     }
 
     // Fire-time gate for plugin-sourced rows, covering every way the source
-    // can go away under an armed row. `pluginScheduleSourceAvailable` is the
-    // probe the run-now route and the enable path use, and it answers for all
-    // of them: a plugin the daemon never activated, a `.disabled` sentinel, a
-    // plugin directory a local uninstall removed, a manifest that no longer
-    // parses, and a declaration that is simply gone. Turning the feature flag
-    // off retires the whole surface.
+    // can go away under an armed row. `declarationExistsOnDisk` is the probe
+    // the enable path uses, and it answers for all of them: a `.disabled`
+    // sentinel, a plugin directory a local uninstall removed, a manifest that
+    // no longer parses, and a declaration that is simply gone. Turning the
+    // feature flag off retires the whole surface.
+    // The probe is deliberately disk-only. Schedule execution runs in the
+    // schedule worker process, which activates no plugins, so the daemon's
+    // in-memory activation ledger is empty here and reading it would skip
+    // every plugin schedule. Activation is gated where the daemon owns it: the
+    // reconciler decides what arms, and the run-now route refuses by hand.
     // The reconciler is what disarms the rows any of these own, and it runs
     // on its own schedule, so re-reading here is what makes the change take
     // effect immediately: a row still armed (or already claimed) at that
@@ -543,7 +547,7 @@ export async function runDueSchedulesOnce(
     if (
       sourceKey !== null &&
       (!isPluginSchedulesEnabled() ||
-        !(await pluginScheduleSourceAvailable(sourceKey)))
+        !(await declarationExistsOnDisk(sourceKey)))
     ) {
       const sourcePlugin = describeScheduleSource(sourceKey) ?? sourceKey;
       log.info(


### PR DESCRIPTION
## Summary
- The schedule reconciler now arms declarations only for plugins the daemon has activated, so a directory dropped into the plugins root cannot fire schedules before the plugin is ever loaded.
- Fire-time, run-now, and re-enable go through the same availability check (activation plus the existing on-disk probe).
- Plugins whose init hook failed keep their schedules, matching their still-live hooks and tools.