### PR TITLE
feat(usage): work-origin classifier for inference cost attribution

### DIFF
--- a/assistant/src/usage/__tests__/work-origin-channel-conversations.test.ts
+++ b/assistant/src/usage/__tests__/work-origin-channel-conversations.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import type { ChannelId } from "../../channels/types.js";
+import {
+  ensureConversationExists,
+  getConversation,
+} from "../../persistence/conversation-crud.js";
+import { getDb } from "../../persistence/db-connection.js";
+import { initializeDb } from "../../persistence/db-init.js";
+import { classifyWorkOrigin } from "../work-origin.js";
+
+await initializeDb();
+
+/**
+ * A person messaging the assistant over Slack or Telegram is waiting on the
+ * reply exactly like a person typing in the app, so the spend is interactive.
+ * The classifier reads that off `conversation_type` and `source`, which the
+ * channel adoption path leaves at their defaults. These tests pin both the
+ * persisted values and the bucket they produce, so a change to channel
+ * conversation creation fails here instead of silently reclassifying a
+ * waiting user as background work.
+ */
+describe("work origin of channel conversations", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run("DELETE FROM messages");
+    db.run("DELETE FROM conversations");
+  });
+
+  const channels: Array<{ id: string; origin: ChannelId }> = [
+    { id: "conv-slack-1", origin: "slack" },
+    { id: "conv-telegram-1", origin: "telegram" },
+  ];
+
+  for (const { id, origin } of channels) {
+    test(`a ${origin} conversation is a standard user conversation`, () => {
+      expect(ensureConversationExists(id, origin)).toBe(true);
+
+      const row = getConversation(id);
+      expect(row?.conversationType).toBe("standard");
+      expect(row?.source).toBe("user");
+      expect(row?.originChannel).toBe(origin);
+    });
+
+    test(`a ${origin} conversation classifies as user_interactive`, () => {
+      ensureConversationExists(id, origin);
+
+      const row = getConversation(id);
+      expect(
+        classifyWorkOrigin({
+          conversationType: row?.conversationType ?? null,
+          conversationSource: row?.source ?? null,
+          callSite: null,
+          parentConversationId: null,
+        }),
+      ).toBe("user_interactive");
+    });
+  }
+});

--- a/assistant/src/usage/work-origin.test.ts
+++ b/assistant/src/usage/work-origin.test.ts
@@ -328,6 +328,8 @@ describe("classifyWorkOrigin", () => {
         "interactionClassifier",
         "skillCategoryInference",
         "inviteInstructionGenerator",
+        "identityIntro",
+        "emptyStateGreeting",
       ] as const
     ).map((callSite) => ({
       name: `conversationless ${callSite} call maps to user_interactive`,

--- a/assistant/src/usage/work-origin.test.ts
+++ b/assistant/src/usage/work-origin.test.ts
@@ -330,6 +330,8 @@ describe("classifyWorkOrigin", () => {
         "inviteInstructionGenerator",
         "identityIntro",
         "emptyStateGreeting",
+        "homeGreeting",
+        "homeSuggestedPrompts",
       ] as const
     ).map((callSite) => ({
       name: `conversationless ${callSite} call maps to user_interactive`,

--- a/assistant/src/usage/work-origin.test.ts
+++ b/assistant/src/usage/work-origin.test.ts
@@ -315,7 +315,22 @@ describe("classifyWorkOrigin", () => {
       }),
       expected: "user_created_schedule",
     },
-    // 10. User-invoked call sites that run without a conversation.
+    // 6. System-upkeep call sites pinned to other_system.
+    {
+      name: "preferenceExtraction with no conversation maps to other_system",
+      input: input({ callSite: "preferenceExtraction" }),
+      expected: "other_system",
+    },
+    {
+      name: "preferenceExtraction inside a standard user conversation stays other_system (internal-state upkeep, not the user's chat)",
+      input: input({
+        conversationType: "standard",
+        conversationSource: "user",
+        callSite: "preferenceExtraction",
+      }),
+      expected: "other_system",
+    },
+    // 11. User-invoked call sites that run without a conversation.
     ...(
       [
         "inference",
@@ -332,6 +347,7 @@ describe("classifyWorkOrigin", () => {
         "emptyStateGreeting",
         "homeGreeting",
         "homeSuggestedPrompts",
+        "conversationStarters",
       ] as const
     ).map((callSite) => ({
       name: `conversationless ${callSite} call maps to user_interactive`,

--- a/assistant/src/usage/work-origin.test.ts
+++ b/assistant/src/usage/work-origin.test.ts
@@ -123,6 +123,26 @@ describe("classifyWorkOrigin", () => {
       }),
       expected: "user_created_schedule",
     },
+    {
+      name: "wake schedule firing in a standard user conversation maps to user_created_schedule (cron run id is the only signal)",
+      input: input({
+        conversationType: "standard",
+        conversationSource: "user",
+        callSite: "mainAgent",
+        cronRunId: "cron-run-123",
+      }),
+      expected: "user_created_schedule",
+    },
+    {
+      name: "parent linkage wins over a cron run id",
+      input: input({
+        conversationType: "background",
+        conversationSource: "subagent",
+        parentConversationId: "parent-3",
+        cronRunId: "cron-run-123",
+      }),
+      expected: "delegated_child",
+    },
     // 4. Heartbeat.
     {
       name: "heartbeat call site alone maps to heartbeat",
@@ -304,6 +324,9 @@ describe("classifyWorkOrigin", () => {
         "guardianQuestionCopy",
         "voiceFrontDoor",
         "voiceProgressNarration",
+        "interactionClassifier",
+        "skillCategoryInference",
+        "inviteInstructionGenerator",
       ] as const
     ).map((callSite) => ({
       name: `conversationless ${callSite} call maps to user_interactive`,

--- a/assistant/src/usage/work-origin.test.ts
+++ b/assistant/src/usage/work-origin.test.ts
@@ -183,6 +183,7 @@ describe("classifyWorkOrigin", () => {
         "filingAgent",
         "patternScan",
         "narrativeRefinement",
+        "conversationSummarization",
       ] as const
     ).map((callSite) => ({
       name: `${callSite} call site maps to memory_maintenance`,

--- a/assistant/src/usage/work-origin.test.ts
+++ b/assistant/src/usage/work-origin.test.ts
@@ -160,6 +160,7 @@ describe("classifyWorkOrigin", () => {
         "memoryV2Consolidation",
         "memoryRetrospective",
         "recall",
+        "filingAgent",
       ] as const
     ).map((callSite) => ({
       name: `${callSite} call site maps to memory_maintenance`,
@@ -250,13 +251,22 @@ describe("classifyWorkOrigin", () => {
     },
     // 8. System-owned conversation sources.
     {
-      name: "notification source maps to other_system",
+      name: "background notification conversation maps to other_system",
       input: input({
         conversationType: "background",
         conversationSource: "notification",
         callSite: "mainAgent",
       }),
       expected: "other_system",
+    },
+    {
+      name: "standard notification thread the user replies in maps to user_interactive",
+      input: input({
+        conversationType: "standard",
+        conversationSource: "notification",
+        callSite: "mainAgent",
+      }),
+      expected: "user_interactive",
     },
     {
       name: "auto-analysis source maps to other_system",
@@ -299,10 +309,9 @@ describe("classifyWorkOrigin", () => {
 });
 
 /**
- * Guard against reintroducing a residual bucket. An earlier design ended with
- * `if (conversationType !== null) return "user_created_background"`, so every
- * unrecognized conversation kind was reported as work the user asked for.
- * Buckets are allowlists: anything unrecognized belongs in `unknown`.
+ * Guard against a residual bucket. Every named bucket is an allowlist, so an
+ * unrecognized type/source combination must land in `unknown`, where it stays
+ * visible, and never in a bucket whose name asserts a cause nobody verified.
  */
 describe("classifyWorkOrigin residual-bucket guard: unrecognized combinations stay unknown", () => {
   const residualCases: Array<{ name: string; input: WorkOriginInput }> = [

--- a/assistant/src/usage/work-origin.test.ts
+++ b/assistant/src/usage/work-origin.test.ts
@@ -294,7 +294,32 @@ describe("classifyWorkOrigin", () => {
       }),
       expected: "user_created_schedule",
     },
-    // 10. Recognized call site, no conversation.
+    // 10. User-invoked call sites that run without a conversation.
+    ...(
+      [
+        "inference",
+        "trustRuleSuggestion",
+        "approvalCopy",
+        "approvalConversation",
+        "guardianQuestionCopy",
+        "voiceFrontDoor",
+        "voiceProgressNarration",
+      ] as const
+    ).map((callSite) => ({
+      name: `conversationless ${callSite} call maps to user_interactive`,
+      input: input({ callSite }),
+      expected: "user_interactive" as WorkOrigin,
+    })),
+    {
+      name: "inference call inside a background conversation is not conversationless user work",
+      input: input({
+        conversationType: "background",
+        conversationSource: "plugin-reengage",
+        callSite: "inference",
+      }),
+      expected: "unknown",
+    },
+    // 11. Recognized call site, no conversation.
     {
       name: "recognized call site with no conversation maps to other_system",
       input: input({ callSite: "conversationTitle" }),

--- a/assistant/src/usage/work-origin.test.ts
+++ b/assistant/src/usage/work-origin.test.ts
@@ -1,0 +1,388 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  classifyWorkOrigin,
+  type WorkOrigin,
+  type WorkOriginInput,
+} from "./work-origin.js";
+
+const base: WorkOriginInput = {
+  conversationType: null,
+  conversationSource: null,
+  callSite: null,
+  parentConversationId: null,
+};
+
+function input(overrides: Partial<WorkOriginInput>): WorkOriginInput {
+  return { ...base, ...overrides };
+}
+
+describe("classifyWorkOrigin", () => {
+  const cases: Array<{
+    name: string;
+    input: WorkOriginInput;
+    expected: WorkOrigin;
+  }> = [
+    // 1. Delegated child: parent linkage present, whatever else is set.
+    {
+      name: "subagent spawn (parent + background) maps to delegated_child",
+      input: input({
+        conversationType: "background",
+        conversationSource: "subagent",
+        callSite: "mainAgent",
+        parentConversationId: "conv-parent-1",
+      }),
+      expected: "delegated_child",
+    },
+    {
+      name: "retrospective fork (parent resolved, memory call site) maps to delegated_child",
+      input: input({
+        conversationType: "background",
+        conversationSource: "memory-retrospective",
+        callSite: "memoryRetrospective",
+        parentConversationId: "conv-source-1",
+      }),
+      expected: "delegated_child",
+    },
+    {
+      name: "parent linkage wins over a scheduled type",
+      input: input({
+        conversationType: "scheduled",
+        conversationSource: "schedule",
+        parentConversationId: "conv-parent-2",
+      }),
+      expected: "delegated_child",
+    },
+    // 2. Delegated child recovered from the record-time source when the
+    // spawning conversation was deleted before flush.
+    {
+      name: "deleted-parent retrospective fork (stamped source, no parent) maps to delegated_child",
+      input: input({
+        conversationType: "background",
+        conversationSource: "memory-retrospective-fork",
+        callSite: "memoryRetrospective",
+      }),
+      expected: "delegated_child",
+    },
+    {
+      name: "deleted-parent legacy retrospective (stamped source, no parent) maps to delegated_child",
+      input: input({
+        conversationType: "background",
+        conversationSource: "memory-retrospective",
+        callSite: "memoryRetrospective",
+      }),
+      expected: "delegated_child",
+    },
+    {
+      name: "deleted-parent subagent conversation (stamped source, no parent) maps to delegated_child",
+      input: input({
+        conversationType: "background",
+        conversationSource: "subagent",
+        callSite: "mainAgent",
+      }),
+      expected: "delegated_child",
+    },
+    {
+      name: "stamped spawn source wins over a scheduled type when parent linkage is gone",
+      input: input({
+        conversationType: "scheduled",
+        conversationSource: "subagent",
+      }),
+      expected: "delegated_child",
+    },
+    // 3. Schedule origin.
+    {
+      name: "scheduled conversation maps to user_created_schedule",
+      input: input({
+        conversationType: "scheduled",
+        conversationSource: "schedule",
+        callSite: "mainAgent",
+      }),
+      expected: "user_created_schedule",
+    },
+    {
+      name: "scheduled type alone maps to user_created_schedule",
+      input: input({ conversationType: "scheduled", callSite: "mainAgent" }),
+      expected: "user_created_schedule",
+    },
+    {
+      name: "scheduled wins over a memory call site",
+      input: input({
+        conversationType: "scheduled",
+        conversationSource: "schedule",
+        callSite: "recall",
+      }),
+      expected: "user_created_schedule",
+    },
+    {
+      name: "manually run schedule (schedule source, standard type) maps to user_created_schedule",
+      input: input({
+        conversationType: "standard",
+        conversationSource: "schedule",
+        callSite: "mainAgent",
+      }),
+      expected: "user_created_schedule",
+    },
+    // 4. Heartbeat.
+    {
+      name: "heartbeat call site alone maps to heartbeat",
+      input: input({ callSite: "heartbeatAgent" }),
+      expected: "heartbeat",
+    },
+    {
+      name: "heartbeat source alone maps to heartbeat",
+      input: input({
+        conversationType: "background",
+        conversationSource: "heartbeat",
+        callSite: "mainAgent",
+      }),
+      expected: "heartbeat",
+    },
+    {
+      name: "heartbeat call site wins over a memory source",
+      input: input({
+        conversationType: "background",
+        conversationSource: "filing",
+        callSite: "heartbeatAgent",
+      }),
+      expected: "heartbeat",
+    },
+    // 5. Memory maintenance: every dedicated call site.
+    ...(
+      [
+        "memoryExtraction",
+        "memoryConsolidation",
+        "memoryRetrieval",
+        "memoryV2Migration",
+        "memoryV2Sweep",
+        "memoryRouter",
+        "memoryV3SelectL2",
+        "memoryV2Consolidation",
+        "memoryRetrospective",
+        "recall",
+      ] as const
+    ).map((callSite) => ({
+      name: `${callSite} call site maps to memory_maintenance`,
+      input: input({ callSite }),
+      expected: "memory_maintenance" as WorkOrigin,
+    })),
+    {
+      name: "recall inside a standard user conversation maps to memory_maintenance (call site wins over user_interactive)",
+      input: input({
+        conversationType: "standard",
+        conversationSource: "user",
+        callSite: "recall",
+      }),
+      expected: "memory_maintenance",
+    },
+    {
+      name: "memory consolidation with no conversation maps to memory_maintenance",
+      input: input({ callSite: "memoryConsolidation" }),
+      expected: "memory_maintenance",
+    },
+    // 5b. Memory maintenance: every dedicated conversation source.
+    ...(["memory_v2_consolidation", "filing", "memory"] as const).map(
+      (conversationSource) => ({
+        name: `${conversationSource} source maps to memory_maintenance`,
+        input: input({
+          conversationType: "background",
+          conversationSource,
+          callSite: "mainAgent",
+        }),
+        expected: "memory_maintenance" as WorkOrigin,
+      }),
+    ),
+    // 6. User interactive.
+    {
+      name: "standard user conversation maps to user_interactive",
+      input: input({
+        conversationType: "standard",
+        conversationSource: "user",
+        callSite: "mainAgent",
+      }),
+      expected: "user_interactive",
+    },
+    {
+      name: "standard home-feed conversation maps to user_interactive",
+      input: input({
+        conversationType: "standard",
+        conversationSource: "home-feed",
+        callSite: "mainAgent",
+      }),
+      expected: "user_interactive",
+    },
+    {
+      name: "standard imported conversation maps to user_interactive",
+      input: input({
+        conversationType: "standard",
+        conversationSource: "import:chatgpt",
+        callSite: "mainAgent",
+      }),
+      expected: "user_interactive",
+    },
+    // 7. User created background.
+    {
+      name: "background conversation the user created maps to user_created_background",
+      input: input({
+        conversationType: "background",
+        conversationSource: "user",
+        callSite: "mainAgent",
+      }),
+      expected: "user_created_background",
+    },
+    {
+      name: "watcher source maps to user_created_background",
+      input: input({
+        conversationType: "background",
+        conversationSource: "watcher",
+        callSite: "mainAgent",
+      }),
+      expected: "user_created_background",
+    },
+    {
+      name: "sequence source maps to user_created_background",
+      input: input({
+        conversationType: "background",
+        conversationSource: "sequence",
+        callSite: "mainAgent",
+      }),
+      expected: "user_created_background",
+    },
+    // 8. System-owned conversation sources.
+    {
+      name: "notification source maps to other_system",
+      input: input({
+        conversationType: "background",
+        conversationSource: "notification",
+        callSite: "mainAgent",
+      }),
+      expected: "other_system",
+    },
+    {
+      name: "auto-analysis source maps to other_system",
+      input: input({
+        conversationType: "background",
+        conversationSource: "auto-analysis",
+        callSite: "mainAgent",
+      }),
+      expected: "other_system",
+    },
+    // 9. Recognized call site, no conversation.
+    {
+      name: "recognized call site with no conversation maps to other_system",
+      input: input({ callSite: "conversationTitle" }),
+      expected: "other_system",
+    },
+    {
+      name: "auxiliary call site (commitMessage) with no conversation maps to other_system",
+      input: input({ callSite: "commitMessage" }),
+      expected: "other_system",
+    },
+    // 10. Nothing to attribute.
+    {
+      name: "no conversation and no call site maps to unknown",
+      input: base,
+      expected: "unknown",
+    },
+    {
+      name: "unrecognized call site with no conversation maps to unknown",
+      input: input({ callSite: "someRetiredCallSite" }),
+      expected: "unknown",
+    },
+  ];
+
+  for (const c of cases) {
+    test(c.name, () => {
+      expect(classifyWorkOrigin(c.input)).toBe(c.expected);
+    });
+  }
+});
+
+/**
+ * Guard against reintroducing a residual bucket. An earlier design ended with
+ * `if (conversationType !== null) return "user_created_background"`, so every
+ * unrecognized conversation kind was reported as work the user asked for.
+ * Buckets are allowlists: anything unrecognized belongs in `unknown`.
+ */
+describe("classifyWorkOrigin residual-bucket guard: unrecognized combinations stay unknown", () => {
+  const residualCases: Array<{ name: string; input: WorkOriginInput }> = [
+    {
+      name: "background conversation with an arbitrary plugin source",
+      input: input({
+        conversationType: "background",
+        conversationSource: "someplugin-custom-source",
+        callSite: "mainAgent",
+      }),
+    },
+    {
+      name: "standard conversation with a non-user source",
+      input: input({
+        conversationType: "standard",
+        conversationSource: "runtime-export",
+        callSite: "mainAgent",
+      }),
+    },
+    {
+      name: "background conversation with a background-tool source",
+      input: input({
+        conversationType: "background",
+        conversationSource: "background-tool",
+        callSite: "mainAgent",
+      }),
+    },
+    {
+      name: "background conversation with no source",
+      input: input({ conversationType: "background", callSite: "mainAgent" }),
+    },
+    {
+      name: "standard conversation with no source",
+      input: input({ conversationType: "standard", callSite: "mainAgent" }),
+    },
+    {
+      name: "unrecognized conversation type with a user source",
+      input: input({
+        conversationType: "experimental",
+        conversationSource: "user",
+        callSite: "mainAgent",
+      }),
+    },
+    {
+      name: "import-prefixed source outside a standard conversation",
+      input: input({
+        conversationType: "background",
+        conversationSource: "import:chatgpt",
+        callSite: "mainAgent",
+      }),
+    },
+    {
+      name: "home-feed source outside a standard conversation",
+      input: input({
+        conversationType: "background",
+        conversationSource: "home-feed",
+        callSite: "mainAgent",
+      }),
+    },
+    // Legacy and ambiguous sources: each denotes too little to name a cause.
+    ...(["background", "compaction", "direct", "reminder", "task"] as const)
+      .flatMap((conversationSource) =>
+        (["standard", "background"] as const).map((conversationType) => ({
+          conversationSource,
+          conversationType,
+        })),
+      )
+      .map(({ conversationSource, conversationType }) => ({
+        name: `legacy source "${conversationSource}" in a ${conversationType} conversation`,
+        input: input({
+          conversationType,
+          conversationSource,
+          callSite: "mainAgent",
+        }),
+      })),
+  ];
+
+  for (const c of residualCases) {
+    test(`${c.name} is unknown, not a named bucket`, () => {
+      expect(classifyWorkOrigin(c.input)).toBe("unknown");
+    });
+  }
+});

--- a/assistant/src/usage/work-origin.test.ts
+++ b/assistant/src/usage/work-origin.test.ts
@@ -161,6 +161,8 @@ describe("classifyWorkOrigin", () => {
         "memoryRetrospective",
         "recall",
         "filingAgent",
+        "patternScan",
+        "narrativeRefinement",
       ] as const
     ).map((callSite) => ({
       name: `${callSite} call site maps to memory_maintenance`,

--- a/assistant/src/usage/work-origin.test.ts
+++ b/assistant/src/usage/work-origin.test.ts
@@ -277,7 +277,22 @@ describe("classifyWorkOrigin", () => {
       }),
       expected: "other_system",
     },
-    // 9. Recognized call site, no conversation.
+    // 9. Workflow leaves: user-caused work with no persisted conversation.
+    {
+      name: "workflowLeaf call with no conversation maps to user_created_background",
+      input: input({ callSite: "workflowLeaf" }),
+      expected: "user_created_background",
+    },
+    {
+      name: "workflowLeaf inside a scheduled conversation maps to user_created_schedule (schedule wins)",
+      input: input({
+        conversationType: "scheduled",
+        conversationSource: "schedule",
+        callSite: "workflowLeaf",
+      }),
+      expected: "user_created_schedule",
+    },
+    // 10. Recognized call site, no conversation.
     {
       name: "recognized call site with no conversation maps to other_system",
       input: input({ callSite: "conversationTitle" }),

--- a/assistant/src/usage/work-origin.ts
+++ b/assistant/src/usage/work-origin.ts
@@ -155,7 +155,9 @@ const RECOGNIZED_CALL_SITES: ReadonlySet<string> = new Set(
  * requests, the approval and guardian copy generators shown to a waiting
  * user, the live-voice front door and progress narration a caller is
  * listening to, the dictation classifier, the skill-draft category
- * inference, and the invite instruction generator.
+ * inference, the invite instruction generator, and the BTW sidechain calls a
+ * client fetch triggers while the person watches a spinner (identity intro,
+ * empty-state greeting).
  */
 const USER_INVOKED_CONVERSATIONLESS_CALL_SITES: ReadonlySet<string> = new Set([
   "inference",
@@ -168,6 +170,8 @@ const USER_INVOKED_CONVERSATIONLESS_CALL_SITES: ReadonlySet<string> = new Set([
   "interactionClassifier",
   "skillCategoryInference",
   "inviteInstructionGenerator",
+  "identityIntro",
+  "emptyStateGreeting",
 ]);
 
 /**

--- a/assistant/src/usage/work-origin.ts
+++ b/assistant/src/usage/work-origin.ts
@@ -29,7 +29,10 @@ import { MEMORY_V2_CONSOLIDATION_SOURCE } from "../persistence/conversation-type
  *   (in-turn recall) or detached from any conversation.
  * - `user_interactive`: a standard conversation the user is present in,
  *   opened from any surface (the app, a Home feed item, imported history, a
- *   messaging channel, or a notification thread they reply in).
+ *   messaging channel, or a notification thread they reply in), or a
+ *   user-invoked call site that legitimately runs without a conversation
+ *   (direct inference sends, approval copy shown to a waiting user, live
+ *   voice; {@link USER_INVOKED_CONVERSATIONLESS_CALL_SITES}).
  * - `other_system`: system work with no user-facing conversation behind it,
  *   either an explicitly system-owned conversation source
  *   ({@link OTHER_SYSTEM_SOURCES}) or a recognized call site running with no
@@ -140,6 +143,27 @@ const RECOGNIZED_CALL_SITES: ReadonlySet<string> = new Set(
 );
 
 /**
+ * Call sites a user invokes directly that legitimately run without a
+ * conversation, so a null conversation must not shove their spend into
+ * `other_system`: direct inference sends (the HTTP route behind
+ * `assistant inference send`; background reuse of the `inference` site
+ * routes through a background conversation turn and never reaches the
+ * conversationless path), the trust-rule suggestion an approval surface
+ * requests, the approval and guardian copy generators shown to a waiting
+ * user, and the live-voice front door and progress narration a caller is
+ * listening to.
+ */
+const USER_INVOKED_CONVERSATIONLESS_CALL_SITES: ReadonlySet<string> = new Set([
+  "inference",
+  "trustRuleSuggestion",
+  "approvalCopy",
+  "approvalConversation",
+  "guardianQuestionCopy",
+  "voiceFrontDoor",
+  "voiceProgressNarration",
+]);
+
+/**
  * The record-time conversation metadata (and call site) a usage row carries,
  * as resolved by the telemetry read path. `callSite` is stored free-form: it
  * is matched against {@link LLMCallSiteEnum} rather than assumed valid.
@@ -174,10 +198,12 @@ export interface WorkOriginInput {
  *   8. a system-owned conversation source,
  *   9. a workflow-leaf call, user-caused work that runs without a
  *      persisted conversation,
- *  10. a recognized call site with no conversation behind it,
- *  11. `unknown`.
+ *  10. a user-invoked call site that runs without a conversation
+ *      ({@link USER_INVOKED_CONVERSATIONLESS_CALL_SITES}),
+ *  11. a recognized call site with no conversation behind it,
+ *  12. `unknown`.
  *
- * Rules 6 to 10 are allowlists. Nothing here may become a residual that
+ * Rules 6 to 11 are allowlists. Nothing here may become a residual that
  * absorbs unrecognized combinations: an unnamed kind of work belongs in
  * `unknown`, where it is visible, not in a bucket whose name asserts a cause
  * nobody verified.
@@ -245,6 +271,14 @@ export function classifyWorkOrigin(input: WorkOriginInput): WorkOrigin {
     // workflow spend lands here too rather than in user_created_schedule; a
     // finer split requires threading run provenance onto usage rows.
     return "user_created_background";
+  }
+  if (
+    conversationType === null &&
+    conversationSource === null &&
+    callSite !== null &&
+    USER_INVOKED_CONVERSATIONLESS_CALL_SITES.has(callSite)
+  ) {
+    return "user_interactive";
   }
   if (
     conversationType === null &&

--- a/assistant/src/usage/work-origin.ts
+++ b/assistant/src/usage/work-origin.ts
@@ -156,8 +156,9 @@ const RECOGNIZED_CALL_SITES: ReadonlySet<string> = new Set(
  * user, the live-voice front door and progress narration a caller is
  * listening to, the dictation classifier, the skill-draft category
  * inference, the invite instruction generator, and the BTW sidechain calls a
- * client fetch triggers while the person watches a spinner (identity intro,
- * empty-state greeting).
+ * client fetch triggers (identity intro and empty-state greeting shown behind
+ * a spinner; Home greeting and suggested-prompt refreshes that run only when
+ * a person fetches Home).
  */
 const USER_INVOKED_CONVERSATIONLESS_CALL_SITES: ReadonlySet<string> = new Set([
   "inference",
@@ -172,6 +173,8 @@ const USER_INVOKED_CONVERSATIONLESS_CALL_SITES: ReadonlySet<string> = new Set([
   "inviteInstructionGenerator",
   "identityIntro",
   "emptyStateGreeting",
+  "homeGreeting",
+  "homeSuggestedPrompts",
 ]);
 
 /**

--- a/assistant/src/usage/work-origin.ts
+++ b/assistant/src/usage/work-origin.ts
@@ -1,0 +1,233 @@
+import { LLMCallSiteEnum } from "../config/schemas/llm.js";
+
+/**
+ * Coarse attribution of *why* an LLM call happened, derived from the durable
+ * usage row's conversation metadata and call site. One bucket per call; the
+ * buckets are mutually exclusive by construction (see
+ * {@link classifyWorkOrigin}).
+ *
+ * - `delegated_child`: the call's conversation was spawned by another
+ *   conversation (subagent spawn, or a retrospective fork). Its cost belongs
+ *   to the delegating turn, captured by the row's parent linkage. Recognized
+ *   by a resolved parent conversation id, or, when the spawning conversation
+ *   was deleted before the usage batch flushed (fork GC, user deletion) and
+ *   the linkage is unresolvable, by the record-time conversation source
+ *   ({@link SPAWNED_CONVERSATION_SOURCES}).
+ * - `user_created_schedule`: a user-created schedule fired the work, either
+ *   on its cron trigger (a `scheduled` conversation) or through a manual run
+ *   (a conversation bootstrapped with source `schedule`).
+ * - `user_created_background`: background work a user explicitly asked for.
+ *   An allowlist ({@link USER_CREATED_BACKGROUND_SOURCES} plus a `background`
+ *   conversation the user created), never a residual: a bucket that reads as
+ *   user-driven must only hold work that is.
+ * - `heartbeat`: the periodic heartbeat agent.
+ * - `memory_maintenance`: memory extraction / consolidation / retrieval /
+ *   filing / recall upkeep, whether it runs inside a user conversation
+ *   (in-turn recall) or detached from any conversation.
+ * - `user_interactive`: a standard conversation the user is present in,
+ *   opened from any surface (the app, a Home feed item, imported history, or
+ *   a messaging channel).
+ * - `other_system`: system work with no user-facing conversation behind it,
+ *   either an explicitly system-owned conversation source
+ *   ({@link OTHER_SYSTEM_SOURCES}) or a recognized call site running with no
+ *   conversation at all (title generation, commit messages, and similar).
+ * - `unknown`: nothing attributable. Unrecognized conversation kinds, legacy
+ *   or ambiguous sources, and plugin-supplied sources land here on purpose,
+ *   where they stay visible instead of inflating a named bucket.
+ */
+export type WorkOrigin =
+  | "delegated_child"
+  | "user_created_schedule"
+  | "user_created_background"
+  | "heartbeat"
+  | "memory_maintenance"
+  | "user_interactive"
+  | "other_system"
+  | "unknown";
+
+/**
+ * Every set below holds persisted `conversations.source` values as string
+ * literals rather than imports. Historical usage rows carry these exact
+ * strings whatever the stamping code does later, and some of the stamping
+ * code lives inside plugins (`plugins/defaults/memory/`) that host code must
+ * not import across the plugin boundary. The classifier tests pin them.
+ */
+
+/**
+ * Sources stamped on conversations another conversation delegated to: a
+ * subagent spawn (advisor consults share the subagent source) and both kinds
+ * of memory retrospective fork. These conversations carry parent linkage
+ * while their spawning conversation exists, so the parent id normally
+ * settles them. This set is the recovery path for a spawning conversation
+ * deleted before the usage batch flushed: the linkage is gone, the
+ * record-time source survives on the usage row and still denotes delegated
+ * work.
+ */
+const SPAWNED_CONVERSATION_SOURCES: ReadonlySet<string> = new Set([
+  "subagent",
+  "memory-retrospective",
+  "memory-retrospective-fork",
+]);
+
+/**
+ * Call sites whose work is memory maintenance regardless of the conversation
+ * (or absence of one) they run in. `recall` fires inside ordinary user turns;
+ * the consolidation / extraction / migration / sweep sites run detached from
+ * any conversation.
+ */
+const MEMORY_MAINTENANCE_CALL_SITES: ReadonlySet<string> = new Set([
+  "memoryExtraction",
+  "memoryConsolidation",
+  "memoryRetrieval",
+  "memoryV2Migration",
+  "memoryV2Sweep",
+  "memoryRouter",
+  "memoryV3SelectL2",
+  "memoryV2Consolidation",
+  "memoryRetrospective",
+  "recall",
+]);
+
+/**
+ * Conversation sources owned by memory upkeep jobs. `filing` is the memory v1
+ * filing job; `memory` is a legacy persisted source; `memory_v2_consolidation`
+ * is the v2 background consolidation run.
+ */
+const MEMORY_MAINTENANCE_SOURCES: ReadonlySet<string> = new Set([
+  "memory_v2_consolidation",
+  "filing",
+  "memory",
+]);
+
+/**
+ * Sources of background work a user explicitly created: a watcher they set up
+ * and a sequence they queued.
+ */
+const USER_CREATED_BACKGROUND_SOURCES: ReadonlySet<string> = new Set([
+  "watcher",
+  "sequence",
+]);
+
+/**
+ * Sources of system-owned conversations with no user request behind them:
+ * `notification` marks the delivery conversations paired with a notification,
+ * `auto-analysis` marks retired ambient analysis rows.
+ */
+const OTHER_SYSTEM_SOURCES: ReadonlySet<string> = new Set([
+  "notification",
+  "auto-analysis",
+]);
+
+/**
+ * Prefix of the source stamped on conversations built from history the user
+ * imported (`import:<provider>`) and then chats in.
+ */
+const IMPORTED_CONVERSATION_SOURCE_PREFIX = "import:";
+
+const RECOGNIZED_CALL_SITES: ReadonlySet<string> = new Set(
+  LLMCallSiteEnum.options,
+);
+
+/**
+ * The record-time conversation metadata (and call site) a usage row carries,
+ * as resolved by the telemetry read path. `callSite` is stored free-form: it
+ * is matched against {@link LLMCallSiteEnum} rather than assumed valid.
+ */
+export interface WorkOriginInput {
+  /** `conversations.conversation_type`: `"standard"` / `"background"` / `"scheduled"`, or null when the call has no conversation. */
+  conversationType: string | null;
+  /** `conversations.source`, e.g. `"user"`, `"subagent"`, `"schedule"`, or null when the call has no conversation. */
+  conversationSource: string | null;
+  /** The call site that produced the LLM request, or null when unattributed. */
+  callSite: string | null;
+  /** Resolved spawning conversation id (subagent parent, or fork parent); null when the conversation was not spawned by another. */
+  parentConversationId: string | null;
+}
+
+/**
+ * Classify a usage row's {@link WorkOrigin} from its record-time conversation
+ * metadata and call site. Pure and total: every input maps to exactly one
+ * bucket, falling through to `unknown` when nothing is attributable.
+ *
+ * Precedence (highest first), so overlapping signals resolve deterministically:
+ *   1. parent linkage: delegated work is billed to the delegating turn,
+ *   2. a spawn source, recovering delegation when the spawning conversation
+ *      was deleted before flush,
+ *   3. schedule origin, by conversation type or by the `schedule` source a
+ *      manual run stamps,
+ *   4. heartbeat, by call site or by source,
+ *   5. memory maintenance, by call site or by source, so in-turn recall is
+ *      billed as upkeep rather than as the user's chat,
+ *   6. a standard conversation the user is chatting in,
+ *   7. background work the user explicitly created,
+ *   8. a system-owned conversation source,
+ *   9. a recognized call site with no conversation behind it,
+ *  10. `unknown`.
+ *
+ * Rules 6 to 9 are allowlists. Nothing here may become a residual that
+ * absorbs unrecognized combinations: an unnamed kind of work belongs in
+ * `unknown`, where it is visible, not in a bucket whose name asserts a cause
+ * nobody verified.
+ */
+export function classifyWorkOrigin(input: WorkOriginInput): WorkOrigin {
+  const {
+    conversationType,
+    conversationSource,
+    callSite,
+    parentConversationId,
+  } = input;
+
+  if (parentConversationId !== null) {
+    return "delegated_child";
+  }
+  if (
+    conversationSource !== null &&
+    SPAWNED_CONVERSATION_SOURCES.has(conversationSource)
+  ) {
+    return "delegated_child";
+  }
+  if (conversationType === "scheduled" || conversationSource === "schedule") {
+    return "user_created_schedule";
+  }
+  if (callSite === "heartbeatAgent" || conversationSource === "heartbeat") {
+    return "heartbeat";
+  }
+  if (
+    (callSite !== null && MEMORY_MAINTENANCE_CALL_SITES.has(callSite)) ||
+    (conversationSource !== null &&
+      MEMORY_MAINTENANCE_SOURCES.has(conversationSource))
+  ) {
+    return "memory_maintenance";
+  }
+  if (
+    conversationType === "standard" &&
+    conversationSource !== null &&
+    (conversationSource === "user" ||
+      conversationSource === "home-feed" ||
+      conversationSource.startsWith(IMPORTED_CONVERSATION_SOURCE_PREFIX))
+  ) {
+    return "user_interactive";
+  }
+  if (
+    (conversationType === "background" && conversationSource === "user") ||
+    (conversationSource !== null &&
+      USER_CREATED_BACKGROUND_SOURCES.has(conversationSource))
+  ) {
+    return "user_created_background";
+  }
+  if (
+    conversationSource !== null &&
+    OTHER_SYSTEM_SOURCES.has(conversationSource)
+  ) {
+    return "other_system";
+  }
+  if (
+    conversationType === null &&
+    conversationSource === null &&
+    callSite !== null &&
+    RECOGNIZED_CALL_SITES.has(callSite)
+  ) {
+    return "other_system";
+  }
+  return "unknown";
+}

--- a/assistant/src/usage/work-origin.ts
+++ b/assistant/src/usage/work-origin.ts
@@ -15,9 +15,10 @@ import { MEMORY_V2_CONSOLIDATION_SOURCE } from "../persistence/conversation-type
  *   was deleted before the usage batch flushed (fork GC, user deletion) and
  *   the linkage is unresolvable, by the record-time conversation source
  *   ({@link SPAWNED_CONVERSATION_SOURCES}).
- * - `user_created_schedule`: a user-created schedule fired the work, either
- *   on its cron trigger (a `scheduled` conversation) or through a manual run
- *   (a conversation bootstrapped with source `schedule`).
+ * - `user_created_schedule`: a user-created schedule fired the work: a cron
+ *   trigger (a `scheduled` conversation), a manual run (a conversation
+ *   bootstrapped with source `schedule`), or a wake/defer firing inside an
+ *   ordinary conversation (signaled only by the usage row's cron run id).
  * - `user_created_background`: background work a user explicitly asked for.
  *   An allowlist ({@link USER_CREATED_BACKGROUND_SOURCES}, a `background`
  *   conversation the user created, and conversationless workflow-leaf
@@ -150,8 +151,9 @@ const RECOGNIZED_CALL_SITES: ReadonlySet<string> = new Set(
  * routes through a background conversation turn and never reaches the
  * conversationless path), the trust-rule suggestion an approval surface
  * requests, the approval and guardian copy generators shown to a waiting
- * user, and the live-voice front door and progress narration a caller is
- * listening to.
+ * user, the live-voice front door and progress narration a caller is
+ * listening to, the dictation classifier, the skill-draft category
+ * inference, and the invite instruction generator.
  */
 const USER_INVOKED_CONVERSATIONLESS_CALL_SITES: ReadonlySet<string> = new Set([
   "inference",
@@ -161,6 +163,9 @@ const USER_INVOKED_CONVERSATIONLESS_CALL_SITES: ReadonlySet<string> = new Set([
   "guardianQuestionCopy",
   "voiceFrontDoor",
   "voiceProgressNarration",
+  "interactionClassifier",
+  "skillCategoryInference",
+  "inviteInstructionGenerator",
 ]);
 
 /**
@@ -177,6 +182,13 @@ export interface WorkOriginInput {
   callSite: string | null;
   /** Resolved spawning conversation id (subagent parent, or fork parent); null when the conversation was not spawned by another. */
   parentConversationId: string | null;
+  /**
+   * Id of the schedule firing that triggered the turn, or null when the turn
+   * was not schedule-driven. A wake or defer schedule can fire inside a
+   * conversation whose persisted type and source stay `standard`/`user`, so
+   * this is the only signal that the spend is schedule-driven.
+   */
+  cronRunId?: string | null;
 }
 
 /**
@@ -188,8 +200,8 @@ export interface WorkOriginInput {
  *   1. parent linkage: delegated work is billed to the delegating turn,
  *   2. a spawn source, recovering delegation when the spawning conversation
  *      was deleted before flush,
- *   3. schedule origin, by conversation type or by the `schedule` source a
- *      manual run stamps,
+ *   3. schedule origin, by conversation type, by the `schedule` source a
+ *      manual run stamps, or by the cron run id a wake/defer firing carries,
  *   4. heartbeat, by call site or by source,
  *   5. memory maintenance, by call site or by source, so in-turn recall is
  *      billed as upkeep rather than as the user's chat,
@@ -215,6 +227,7 @@ export function classifyWorkOrigin(input: WorkOriginInput): WorkOrigin {
     callSite,
     parentConversationId,
   } = input;
+  const cronRunId = input.cronRunId ?? null;
 
   if (parentConversationId !== null) {
     return "delegated_child";
@@ -225,7 +238,13 @@ export function classifyWorkOrigin(input: WorkOriginInput): WorkOrigin {
   ) {
     return "delegated_child";
   }
-  if (conversationType === "scheduled" || conversationSource === "schedule") {
+  if (
+    conversationType === "scheduled" ||
+    conversationSource === "schedule" ||
+    cronRunId !== null
+  ) {
+    // A wake or defer schedule can fire inside a standard user conversation;
+    // the cron run id on the usage row is then the only schedule signal.
     return "user_created_schedule";
   }
   if (callSite === "heartbeatAgent" || conversationSource === "heartbeat") {

--- a/assistant/src/usage/work-origin.ts
+++ b/assistant/src/usage/work-origin.ts
@@ -19,9 +19,10 @@ import { MEMORY_V2_CONSOLIDATION_SOURCE } from "../persistence/conversation-type
  *   on its cron trigger (a `scheduled` conversation) or through a manual run
  *   (a conversation bootstrapped with source `schedule`).
  * - `user_created_background`: background work a user explicitly asked for.
- *   An allowlist ({@link USER_CREATED_BACKGROUND_SOURCES} plus a `background`
- *   conversation the user created), never a residual: a bucket that reads as
- *   user-driven must only hold work that is.
+ *   An allowlist ({@link USER_CREATED_BACKGROUND_SOURCES}, a `background`
+ *   conversation the user created, and conversationless workflow-leaf
+ *   calls), never a residual: a bucket that reads as user-driven must only
+ *   hold work that is.
  * - `heartbeat`: the periodic heartbeat agent.
  * - `memory_maintenance`: memory extraction / consolidation / retrieval /
  *   filing / recall upkeep, whether it runs inside a user conversation
@@ -167,10 +168,12 @@ export interface WorkOriginInput {
  *   6. a standard conversation the user is chatting in,
  *   7. background work the user explicitly created,
  *   8. a system-owned conversation source,
- *   9. a recognized call site with no conversation behind it,
- *  10. `unknown`.
+ *   9. a workflow-leaf call, user-caused work that runs without a
+ *      persisted conversation,
+ *  10. a recognized call site with no conversation behind it,
+ *  11. `unknown`.
  *
- * Rules 6 to 9 are allowlists. Nothing here may become a residual that
+ * Rules 6 to 10 are allowlists. Nothing here may become a residual that
  * absorbs unrecognized combinations: an unnamed kind of work belongs in
  * `unknown`, where it is visible, not in a bucket whose name asserts a cause
  * nobody verified.
@@ -230,6 +233,14 @@ export function classifyWorkOrigin(input: WorkOriginInput): WorkOrigin {
     OTHER_SYSTEM_SOURCES.has(conversationSource)
   ) {
     return "other_system";
+  }
+  if (callSite === "workflowLeaf") {
+    // Workflow leaves run without a persisted conversation, but every launch
+    // path is user-caused: a user-started workflow run or a user-created
+    // schedule. Leaf usage rows carry no schedule provenance, so scheduled
+    // workflow spend lands here too rather than in user_created_schedule; a
+    // finer split requires threading run provenance onto usage rows.
+    return "user_created_background";
   }
   if (
     conversationType === null &&

--- a/assistant/src/usage/work-origin.ts
+++ b/assistant/src/usage/work-origin.ts
@@ -175,6 +175,21 @@ const USER_INVOKED_CONVERSATIONLESS_CALL_SITES: ReadonlySet<string> = new Set([
   "emptyStateGreeting",
   "homeGreeting",
   "homeSuggestedPrompts",
+  "conversationStarters",
+]);
+
+/**
+ * Call sites whose work is internal-state upkeep the user never sees, pinned
+ * to `other_system` regardless of conversation metadata: preference
+ * extraction runs as an asynchronous pass over persisted messages and
+ * produces notification-preference state, not content the user asked for.
+ * The pin keeps the bucket stable even when a caller threads a conversation
+ * id onto the send. The line against the user-invoked set above: fetch
+ * triggered generation of user-visible content is user work; extraction of
+ * internal state is not.
+ */
+const SYSTEM_UPKEEP_CALL_SITES: ReadonlySet<string> = new Set([
+  "preferenceExtraction",
 ]);
 
 /**
@@ -214,17 +229,19 @@ export interface WorkOriginInput {
  *   4. heartbeat, by call site or by source,
  *   5. memory maintenance, by call site or by source, so in-turn recall is
  *      billed as upkeep rather than as the user's chat,
- *   6. a standard conversation the user is chatting in,
- *   7. background work the user explicitly created,
- *   8. a system-owned conversation source,
- *   9. a workflow-leaf call, user-caused work that runs without a
+ *   6. system-upkeep call sites pinned to `other_system` whatever
+ *      conversation they run against ({@link SYSTEM_UPKEEP_CALL_SITES}),
+ *   7. a standard conversation the user is chatting in,
+ *   8. background work the user explicitly created,
+ *   9. a system-owned conversation source,
+ *  10. a workflow-leaf call, user-caused work that runs without a
  *      persisted conversation,
- *  10. a user-invoked call site that runs without a conversation
+ *  11. a user-invoked call site that runs without a conversation
  *      ({@link USER_INVOKED_CONVERSATIONLESS_CALL_SITES}),
- *  11. a recognized call site with no conversation behind it,
- *  12. `unknown`.
+ *  12. a recognized call site with no conversation behind it,
+ *  13. `unknown`.
  *
- * Rules 6 to 11 are allowlists. Nothing here may become a residual that
+ * Rules 6 to 12 are allowlists. Nothing here may become a residual that
  * absorbs unrecognized combinations: an unnamed kind of work belongs in
  * `unknown`, where it is visible, not in a bucket whose name asserts a cause
  * nobody verified.
@@ -265,6 +282,9 @@ export function classifyWorkOrigin(input: WorkOriginInput): WorkOrigin {
       MEMORY_MAINTENANCE_SOURCES.has(conversationSource))
   ) {
     return "memory_maintenance";
+  }
+  if (callSite !== null && SYSTEM_UPKEEP_CALL_SITES.has(callSite)) {
+    return "other_system";
   }
   if (
     conversationType === "standard" &&

--- a/assistant/src/usage/work-origin.ts
+++ b/assistant/src/usage/work-origin.ts
@@ -1,4 +1,6 @@
 import { LLMCallSiteEnum } from "../config/schemas/llm.js";
+import { AUTO_ANALYSIS_SOURCE } from "../persistence/auto-analysis-constants.js";
+import { MEMORY_V2_CONSOLIDATION_SOURCE } from "../persistence/conversation-types.js";
 
 /**
  * Coarse attribution of *why* an LLM call happened, derived from the durable
@@ -25,8 +27,8 @@ import { LLMCallSiteEnum } from "../config/schemas/llm.js";
  *   filing / recall upkeep, whether it runs inside a user conversation
  *   (in-turn recall) or detached from any conversation.
  * - `user_interactive`: a standard conversation the user is present in,
- *   opened from any surface (the app, a Home feed item, imported history, or
- *   a messaging channel).
+ *   opened from any surface (the app, a Home feed item, imported history, a
+ *   messaging channel, or a notification thread they reply in).
  * - `other_system`: system work with no user-facing conversation behind it,
  *   either an explicitly system-owned conversation source
  *   ({@link OTHER_SYSTEM_SOURCES}) or a recognized call site running with no
@@ -46,11 +48,12 @@ export type WorkOrigin =
   | "unknown";
 
 /**
- * Every set below holds persisted `conversations.source` values as string
- * literals rather than imports. Historical usage rows carry these exact
- * strings whatever the stamping code does later, and some of the stamping
- * code lives inside plugins (`plugins/defaults/memory/`) that host code must
- * not import across the plugin boundary. The classifier tests pin them.
+ * The sets below hold persisted `conversations.source` values. Values whose
+ * stamping code lives inside plugins (`plugins/defaults/memory/`) are string
+ * literals, because host code must not import across the plugin boundary and
+ * historical usage rows carry these exact strings whatever the stamping code
+ * does later. Values with host-side exported constants are imported. The
+ * classifier tests pin every value either way.
  */
 
 /**
@@ -72,8 +75,8 @@ const SPAWNED_CONVERSATION_SOURCES: ReadonlySet<string> = new Set([
 /**
  * Call sites whose work is memory maintenance regardless of the conversation
  * (or absence of one) they run in. `recall` fires inside ordinary user turns;
- * the consolidation / extraction / migration / sweep sites run detached from
- * any conversation.
+ * `filingAgent` is the memory v1 filing job; the consolidation / extraction /
+ * migration / sweep sites run detached from any conversation.
  */
 const MEMORY_MAINTENANCE_CALL_SITES: ReadonlySet<string> = new Set([
   "memoryExtraction",
@@ -86,6 +89,7 @@ const MEMORY_MAINTENANCE_CALL_SITES: ReadonlySet<string> = new Set([
   "memoryV2Consolidation",
   "memoryRetrospective",
   "recall",
+  "filingAgent",
 ]);
 
 /**
@@ -94,7 +98,7 @@ const MEMORY_MAINTENANCE_CALL_SITES: ReadonlySet<string> = new Set([
  * is the v2 background consolidation run.
  */
 const MEMORY_MAINTENANCE_SOURCES: ReadonlySet<string> = new Set([
-  "memory_v2_consolidation",
+  MEMORY_V2_CONSOLIDATION_SOURCE,
   "filing",
   "memory",
 ]);
@@ -110,12 +114,14 @@ const USER_CREATED_BACKGROUND_SOURCES: ReadonlySet<string> = new Set([
 
 /**
  * Sources of system-owned conversations with no user request behind them:
- * `notification` marks the delivery conversations paired with a notification,
+ * `notification` marks the delivery conversations paired with a notification
+ * (only its non-standard rows land here; a standard notification thread is a
+ * visible conversation the user replies in, so it classifies as interactive),
  * `auto-analysis` marks retired ambient analysis rows.
  */
 const OTHER_SYSTEM_SOURCES: ReadonlySet<string> = new Set([
   "notification",
-  "auto-analysis",
+  AUTO_ANALYSIS_SOURCE,
 ]);
 
 /**
@@ -204,8 +210,12 @@ export function classifyWorkOrigin(input: WorkOriginInput): WorkOrigin {
     conversationSource !== null &&
     (conversationSource === "user" ||
       conversationSource === "home-feed" ||
+      conversationSource === "notification" ||
       conversationSource.startsWith(IMPORTED_CONVERSATION_SOURCE_PREFIX))
   ) {
+    // A standard notification thread is user-visible in the sidebar and keeps
+    // its `notification` source when the user replies in it, so its turns are
+    // interactive spend; only non-standard notification rows are system work.
     return "user_interactive";
   }
   if (

--- a/assistant/src/usage/work-origin.ts
+++ b/assistant/src/usage/work-origin.ts
@@ -76,8 +76,10 @@ const SPAWNED_CONVERSATION_SOURCES: ReadonlySet<string> = new Set([
 /**
  * Call sites whose work is memory maintenance regardless of the conversation
  * (or absence of one) they run in. `recall` fires inside ordinary user turns;
- * `filingAgent` is the memory v1 filing job; the consolidation / extraction /
- * migration / sweep sites run detached from any conversation.
+ * `filingAgent` is the memory v1 filing job; `patternScan` and
+ * `narrativeRefinement` are the v1 memory-graph maintenance jobs; the
+ * consolidation / extraction / migration / sweep sites run detached from any
+ * conversation.
  */
 const MEMORY_MAINTENANCE_CALL_SITES: ReadonlySet<string> = new Set([
   "memoryExtraction",
@@ -91,6 +93,8 @@ const MEMORY_MAINTENANCE_CALL_SITES: ReadonlySet<string> = new Set([
   "memoryRetrospective",
   "recall",
   "filingAgent",
+  "patternScan",
+  "narrativeRefinement",
 ]);
 
 /**

--- a/assistant/src/usage/work-origin.ts
+++ b/assistant/src/usage/work-origin.ts
@@ -81,9 +81,10 @@ const SPAWNED_CONVERSATION_SOURCES: ReadonlySet<string> = new Set([
  * Call sites whose work is memory maintenance regardless of the conversation
  * (or absence of one) they run in. `recall` fires inside ordinary user turns;
  * `filingAgent` is the memory v1 filing job; `patternScan` and
- * `narrativeRefinement` are the v1 memory-graph maintenance jobs; the
- * consolidation / extraction / migration / sweep sites run detached from any
- * conversation.
+ * `narrativeRefinement` are the v1 memory-graph maintenance jobs;
+ * `conversationSummarization` is the debounced summary job that runs against
+ * ordinary conversations; the consolidation / extraction / migration / sweep
+ * sites run detached from any conversation.
  */
 const MEMORY_MAINTENANCE_CALL_SITES: ReadonlySet<string> = new Set([
   "memoryExtraction",
@@ -99,6 +100,7 @@ const MEMORY_MAINTENANCE_CALL_SITES: ReadonlySet<string> = new Set([
   "filingAgent",
   "patternScan",
   "narrativeRefinement",
+  "conversationSummarization",
 ]);
 
 /**


### PR DESCRIPTION
Part 1 of the work-origin cost-attribution stack (targets `aaron/work-origin-attribution`, not main). Rebuilds the classifier from closed PR #39057 with a redesigned residual bucket.

## What

Adds `assistant/src/usage/work-origin.ts`: a pure, total classifier mapping a usage row's record-time conversation type, conversation source, call site, and parent linkage to one of eight frozen work-origin values:

`delegated_child`, `user_created_schedule`, `user_created_background`, `heartbeat`, `memory_maintenance`, `user_interactive`, `other_system`, `unknown`.

No wiring in this PR; persistence and emission land in later parts of the stack.

## Residual-bucket redesign (the delta vs #39057)

The old classifier ended with `if (conversationType !== null) return "user_created_background"`, which made that bucket mean "had a conversation, matched nothing else". Any new conversation kind would be silently swallowed into a bucket people read as user-driven.

Now every named bucket is an allowlist:
- `user_created_background` = (`background` type + `user` source) or user-configured automations (`watcher`, `sequence`).
- `other_system` gains explicitly system-owned sources (`notification`, `auto-analysis`).
- Unclear legacy sources (`background`, `compaction`, `direct`, `reminder`, `task`) and any unrecognized type/source combination fall to `unknown`, where they are visible. Tests guard against reintroducing a residual.

Source sets were built from a survey of every `conversations.source` writer on main; values are string literals because they are persisted data and some writers live behind the plugin import boundary.

## Tests

- 59 pure table tests covering every precedence rule, conflicts between rules, and the residual guard.
- 4 DB-backed tests pinning that Slack and Telegram conversations persist as `standard`/`user` and classify `user_interactive`, so a change to channel conversation creation cannot silently reclassify a waiting user as background spend.

## Verify

```
cd assistant
bun test src/usage/work-origin.test.ts
bun test src/usage/__tests__/work-origin-channel-conversations.test.ts
bun run typecheck:fast && bun run lint
```

Part of the CAS-023 cost-attribution effort (Velcro case_c30f7ae1-bc36-47ea-ad9a-987ccdec2888).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40761" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->