### PR TITLE
feat(schedule): say why a plugin schedule is off

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -25778,6 +25778,20 @@ paths:
                           description:
                             User enable/disable override on a plugin-sourced schedule; null when the declaration's own enabled value
                             applies. Always null for user-created schedules.
+                        disarmReason:
+                          anyOf:
+                            - type: string
+                              enum:
+                                - user_disabled
+                                - plugin_removed
+                                - plugin_disabled
+                                - declaration_removed
+                                - declaration_disabled
+                            - type: "null"
+                          description:
+                            "Why a plugin-sourced schedule is off: the user turned it off, the plugin is gone, the plugin is disabled,
+                            the declaration is gone, or the plugin's own files turned it off. Null whenever the schedule
+                            is on, and always null for user-created schedules."
                         isOneShot:
                           type: boolean
                         isDeferred:
@@ -25814,6 +25828,7 @@ paths:
                         - workflowName
                         - sourceKey
                         - userEnabled
+                        - disarmReason
                         - isOneShot
                         - isDeferred
                       additionalProperties: false
@@ -26011,6 +26026,20 @@ paths:
                         description:
                           User enable/disable override on a plugin-sourced schedule; null when the declaration's own enabled value
                           applies. Always null for user-created schedules.
+                      disarmReason:
+                        anyOf:
+                          - type: string
+                            enum:
+                              - user_disabled
+                              - plugin_removed
+                              - plugin_disabled
+                              - declaration_removed
+                              - declaration_disabled
+                          - type: "null"
+                        description:
+                          "Why a plugin-sourced schedule is off: the user turned it off, the plugin is gone, the plugin is disabled,
+                          the declaration is gone, or the plugin's own files turned it off. Null whenever the schedule
+                          is on, and always null for user-created schedules."
                       isOneShot:
                         type: boolean
                       isDeferred:
@@ -26047,6 +26076,7 @@ paths:
                       - workflowName
                       - sourceKey
                       - userEnabled
+                      - disarmReason
                       - isOneShot
                       - isDeferred
                     additionalProperties: false
@@ -26196,6 +26226,20 @@ paths:
                           description:
                             User enable/disable override on a plugin-sourced schedule; null when the declaration's own enabled value
                             applies. Always null for user-created schedules.
+                        disarmReason:
+                          anyOf:
+                            - type: string
+                              enum:
+                                - user_disabled
+                                - plugin_removed
+                                - plugin_disabled
+                                - declaration_removed
+                                - declaration_disabled
+                            - type: "null"
+                          description:
+                            "Why a plugin-sourced schedule is off: the user turned it off, the plugin is gone, the plugin is disabled,
+                            the declaration is gone, or the plugin's own files turned it off. Null whenever the schedule
+                            is on, and always null for user-created schedules."
                         isOneShot:
                           type: boolean
                         isDeferred:
@@ -26232,6 +26276,7 @@ paths:
                         - workflowName
                         - sourceKey
                         - userEnabled
+                        - disarmReason
                         - isOneShot
                         - isDeferred
                       additionalProperties: false
@@ -26378,6 +26423,20 @@ paths:
                         description:
                           User enable/disable override on a plugin-sourced schedule; null when the declaration's own enabled value
                           applies. Always null for user-created schedules.
+                      disarmReason:
+                        anyOf:
+                          - type: string
+                            enum:
+                              - user_disabled
+                              - plugin_removed
+                              - plugin_disabled
+                              - declaration_removed
+                              - declaration_disabled
+                          - type: "null"
+                        description:
+                          "Why a plugin-sourced schedule is off: the user turned it off, the plugin is gone, the plugin is disabled,
+                          the declaration is gone, or the plugin's own files turned it off. Null whenever the schedule
+                          is on, and always null for user-created schedules."
                       isOneShot:
                         type: boolean
                       isDeferred:
@@ -26414,6 +26473,7 @@ paths:
                       - workflowName
                       - sourceKey
                       - userEnabled
+                      - disarmReason
                       - isOneShot
                       - isDeferred
                     additionalProperties: false
@@ -26620,6 +26680,20 @@ paths:
                           description:
                             User enable/disable override on a plugin-sourced schedule; null when the declaration's own enabled value
                             applies. Always null for user-created schedules.
+                        disarmReason:
+                          anyOf:
+                            - type: string
+                              enum:
+                                - user_disabled
+                                - plugin_removed
+                                - plugin_disabled
+                                - declaration_removed
+                                - declaration_disabled
+                            - type: "null"
+                          description:
+                            "Why a plugin-sourced schedule is off: the user turned it off, the plugin is gone, the plugin is disabled,
+                            the declaration is gone, or the plugin's own files turned it off. Null whenever the schedule
+                            is on, and always null for user-created schedules."
                         isOneShot:
                           type: boolean
                         isDeferred:
@@ -26656,6 +26730,7 @@ paths:
                         - workflowName
                         - sourceKey
                         - userEnabled
+                        - disarmReason
                         - isOneShot
                         - isDeferred
                       additionalProperties: false
@@ -26805,6 +26880,20 @@ paths:
                           description:
                             User enable/disable override on a plugin-sourced schedule; null when the declaration's own enabled value
                             applies. Always null for user-created schedules.
+                        disarmReason:
+                          anyOf:
+                            - type: string
+                              enum:
+                                - user_disabled
+                                - plugin_removed
+                                - plugin_disabled
+                                - declaration_removed
+                                - declaration_disabled
+                            - type: "null"
+                          description:
+                            "Why a plugin-sourced schedule is off: the user turned it off, the plugin is gone, the plugin is disabled,
+                            the declaration is gone, or the plugin's own files turned it off. Null whenever the schedule
+                            is on, and always null for user-created schedules."
                         isOneShot:
                           type: boolean
                         isDeferred:
@@ -26841,6 +26930,7 @@ paths:
                         - workflowName
                         - sourceKey
                         - userEnabled
+                        - disarmReason
                         - isOneShot
                         - isDeferred
                       additionalProperties: false
@@ -26992,6 +27082,20 @@ paths:
                           description:
                             User enable/disable override on a plugin-sourced schedule; null when the declaration's own enabled value
                             applies. Always null for user-created schedules.
+                        disarmReason:
+                          anyOf:
+                            - type: string
+                              enum:
+                                - user_disabled
+                                - plugin_removed
+                                - plugin_disabled
+                                - declaration_removed
+                                - declaration_disabled
+                            - type: "null"
+                          description:
+                            "Why a plugin-sourced schedule is off: the user turned it off, the plugin is gone, the plugin is disabled,
+                            the declaration is gone, or the plugin's own files turned it off. Null whenever the schedule
+                            is on, and always null for user-created schedules."
                         isOneShot:
                           type: boolean
                         isDeferred:
@@ -27028,6 +27132,7 @@ paths:
                         - workflowName
                         - sourceKey
                         - userEnabled
+                        - disarmReason
                         - isOneShot
                         - isDeferred
                       additionalProperties: false
@@ -27314,6 +27419,20 @@ paths:
                           description:
                             User enable/disable override on a plugin-sourced schedule; null when the declaration's own enabled value
                             applies. Always null for user-created schedules.
+                        disarmReason:
+                          anyOf:
+                            - type: string
+                              enum:
+                                - user_disabled
+                                - plugin_removed
+                                - plugin_disabled
+                                - declaration_removed
+                                - declaration_disabled
+                            - type: "null"
+                          description:
+                            "Why a plugin-sourced schedule is off: the user turned it off, the plugin is gone, the plugin is disabled,
+                            the declaration is gone, or the plugin's own files turned it off. Null whenever the schedule
+                            is on, and always null for user-created schedules."
                         isOneShot:
                           type: boolean
                         isDeferred:
@@ -27350,6 +27469,7 @@ paths:
                         - workflowName
                         - sourceKey
                         - userEnabled
+                        - disarmReason
                         - isOneShot
                         - isDeferred
                       additionalProperties: false

--- a/assistant/src/cli/commands/schedules.ts
+++ b/assistant/src/cli/commands/schedules.ts
@@ -39,7 +39,37 @@ interface ScheduleRecord {
   wakeConversationId: string | null;
   sourceKey: string | null;
   userEnabled: boolean | null;
+  disarmReason: string | null;
   isOneShot: boolean;
+}
+
+/** Plain-language copy for each `disarmReason` the daemon sends. */
+const DISARM_REASON_TEXT: Record<string, string> = {
+  user_disabled: "turned off by you",
+  plugin_removed: "plugin removed",
+  plugin_disabled: "plugin disabled",
+  declaration_removed: "removed from plugin",
+  declaration_disabled: "paused by plugin",
+};
+
+/**
+ * Why a schedule is off, when the daemon knows. An off row with no reason (an
+ * imperative schedule, or a plugin row from a daemon that predates the field)
+ * reads as plain "disabled".
+ */
+function describeDisarmReason(schedule: ScheduleRecord): string | null {
+  if (schedule.enabled || !schedule.disarmReason) {
+    return null;
+  }
+  return DISARM_REASON_TEXT[schedule.disarmReason] ?? null;
+}
+
+function formatEnabledCell(schedule: ScheduleRecord): string {
+  if (schedule.enabled) {
+    return "enabled";
+  }
+  const reason = describeDisarmReason(schedule);
+  return reason ? `off (${reason})` : "disabled";
 }
 
 interface ListSchedulesResponse {
@@ -116,7 +146,7 @@ export function registerSchedulesCommand(program: Command): void {
           const rows = entries.map((schedule) => ({
             id: schedule.id,
             name: schedule.name,
-            enabled: schedule.enabled ? "enabled" : "disabled",
+            enabled: formatEnabledCell(schedule),
             mode: schedule.mode,
             source: describeScheduleSource(schedule.sourceKey) ?? "",
             schedule: describeSchedule(schedule),
@@ -247,6 +277,10 @@ export function registerSchedulesCommand(program: Command): void {
             ["Source conversation", schedule.createdFromConversationId ?? "—"],
             ["Plugin", describeScheduleSource(schedule.sourceKey) ?? "-"],
           ];
+          const disarmReason = describeDisarmReason(schedule);
+          if (disarmReason) {
+            fields.push(["Paused", disarmReason]);
+          }
           const labelWidth = Math.max(...fields.map(([label]) => label.length));
           for (const [label, value] of fields) {
             log.info(`${`${label}:`.padEnd(labelWidth + 2)}${value}`);

--- a/assistant/src/runtime/routes/__tests__/schedule-routes-disarm-reason.test.ts
+++ b/assistant/src/runtime/routes/__tests__/schedule-routes-disarm-reason.test.ts
@@ -11,6 +11,7 @@ import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { beforeEach, describe, expect, test } from "bun:test";
 
+import { setOverridesForTesting } from "../../../__tests__/feature-flag-test-helpers.js";
 import { getDb } from "../../../persistence/db-connection.js";
 import { initializeDb } from "../../../persistence/db-init.js";
 import {
@@ -104,10 +105,20 @@ async function declaredRow(
   return job.id;
 }
 
+/** Stamp the engine's exhaust latch onto a row: off, spent, and last run. */
+function latchAsCompleted(id: string): void {
+  getDb().run(
+    `UPDATE cron_jobs SET enabled = 0, next_run_at = 0, last_run_at = ${Date.now()} WHERE id = '${id}'`,
+  );
+}
+
 beforeEach(() => {
   getDb().run("DELETE FROM cron_runs");
   getDb().run("DELETE FROM cron_jobs");
   rmSync(pluginsDir, { recursive: true, force: true });
+  // The feature ships off, so every case states the flag it runs under rather
+  // than inheriting the registry default.
+  setOverridesForTesting({ "plugin-schedules": true });
 });
 
 describe("schedule serialization: disarmReason", () => {
@@ -157,6 +168,28 @@ describe("schedule serialization: disarmReason", () => {
 
     const row = await listed(id);
     expect(row.enabled).toBe(true);
+    expect(row.disarmReason).toBeNull();
+    expect((await fetched(id)).disarmReason).toBeNull();
+  });
+
+  test("a run-to-completion row reads as finished, not paused", async () => {
+    writePlugin("news", { declaration: "digest" });
+    const id = await declaredRow("news", true);
+    latchAsCompleted(id);
+
+    const row = await listed(id);
+    expect(row.enabled).toBe(false);
+    expect(row.disarmReason).toBeNull();
+    expect((await fetched(id)).disarmReason).toBeNull();
+  });
+
+  test("the kill switch being off is not a per-row cause", async () => {
+    writePlugin("news", { declaration: "digest" });
+    const id = await declaredRow("news", false);
+    setOverridesForTesting({ "plugin-schedules": false });
+
+    const row = await listed(id);
+    expect(row.enabled).toBe(false);
     expect(row.disarmReason).toBeNull();
     expect((await fetched(id)).disarmReason).toBeNull();
   });

--- a/assistant/src/runtime/routes/__tests__/schedule-routes-disarm-reason.test.ts
+++ b/assistant/src/runtime/routes/__tests__/schedule-routes-disarm-reason.test.ts
@@ -1,0 +1,182 @@
+/**
+ * The schedule list and detail routes say why a plugin-sourced schedule is
+ * off, so a client never has to show an unexplained disabled row.
+ *
+ * The reason is derived from the row plus the plugin's files, so the fixtures
+ * here write real plugin directories under the per-test-process workspace
+ * plugins dir and converge them against the real schedule store.
+ */
+
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { getDb } from "../../../persistence/db-connection.js";
+import { initializeDb } from "../../../persistence/db-init.js";
+import {
+  createSchedule,
+  setUserEnabled,
+  upsertDeclaredSchedule,
+} from "../../../schedule/schedule-store.js";
+import { getWorkspacePluginsDir } from "../../../util/platform.js";
+import { ROUTES } from "../schedule-routes.js";
+
+await initializeDb();
+
+const pluginsDir = getWorkspacePluginsDir();
+
+function routeHandler(operationId: string) {
+  const route = ROUTES.find((r) => r.operationId === operationId);
+  if (!route) {
+    throw new Error(`${operationId} route not found`);
+  }
+  return route.handler;
+}
+
+const listHandler = routeHandler("listSchedules");
+const getHandler = routeHandler("getSchedule");
+
+interface SerializedSchedule {
+  id: string;
+  sourceKey: string | null;
+  enabled: boolean;
+  disarmReason: string | null;
+}
+
+async function listed(id: string): Promise<SerializedSchedule> {
+  const { schedules } = (await listHandler({ queryParams: {} })) as {
+    schedules: SerializedSchedule[];
+  };
+  const found = schedules.find((s) => s.id === id);
+  if (!found) {
+    throw new Error(`schedule ${id} missing from the list response`);
+  }
+  return found;
+}
+
+async function fetched(id: string): Promise<SerializedSchedule> {
+  const { schedule } = (await getHandler({ pathParams: { id } })) as {
+    schedule: SerializedSchedule;
+  };
+  return schedule;
+}
+
+/** Write a plugin dir holding one `schedules/<name>/` declaration. */
+function writePlugin(
+  pluginName: string,
+  options: { declaration?: string; disabled?: boolean } = {},
+): void {
+  const dir = join(pluginsDir, pluginName);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, "package.json"),
+    JSON.stringify({ name: pluginName, version: "1.0.0" }),
+  );
+  if (options.declaration) {
+    const declarationDir = join(dir, "schedules", options.declaration);
+    mkdirSync(declarationDir, { recursive: true });
+    writeFileSync(
+      join(declarationDir, "config.json"),
+      JSON.stringify({ expression: "* * * * *" }),
+    );
+    writeFileSync(join(declarationDir, "index.md"), "Summarize the day.\n");
+  }
+  if (options.disabled) {
+    writeFileSync(join(dir, ".disabled"), "");
+  }
+}
+
+/** A declared row for `plugin:<pluginName>/digest`, armed or not. */
+async function declaredRow(
+  pluginName: string,
+  enabled: boolean,
+): Promise<string> {
+  const job = await upsertDeclaredSchedule(`plugin:${pluginName}/digest`, {
+    name: `${pluginName}-digest`,
+    description: "Daily digest",
+    syntax: "cron",
+    expression: "* * * * *",
+    message: "Summarize the day.",
+    mode: "execute",
+    enabled,
+    definitionHash: `hash-${pluginName}`,
+  });
+  return job.id;
+}
+
+beforeEach(() => {
+  getDb().run("DELETE FROM cron_runs");
+  getDb().run("DELETE FROM cron_jobs");
+  rmSync(pluginsDir, { recursive: true, force: true });
+});
+
+describe("schedule serialization: disarmReason", () => {
+  test("a user's own override outranks whatever the plugin's files say", async () => {
+    writePlugin("news", { declaration: "digest" });
+    const id = await declaredRow("news", true);
+    await setUserEnabled(id, false);
+
+    expect((await listed(id)).disarmReason).toBe("user_disabled");
+    expect((await fetched(id)).disarmReason).toBe("user_disabled");
+  });
+
+  test("a plugin that is gone from disk reads as removed", async () => {
+    const id = await declaredRow("news", false);
+
+    expect((await listed(id)).disarmReason).toBe("plugin_removed");
+    expect((await fetched(id)).disarmReason).toBe("plugin_removed");
+  });
+
+  test("a plugin carrying the .disabled sentinel reads as disabled", async () => {
+    writePlugin("news", { declaration: "digest", disabled: true });
+    const id = await declaredRow("news", false);
+
+    expect((await listed(id)).disarmReason).toBe("plugin_disabled");
+    expect((await fetched(id)).disarmReason).toBe("plugin_disabled");
+  });
+
+  test("a declaration dropped from a plugin that is still installed", async () => {
+    writePlugin("news");
+    const id = await declaredRow("news", false);
+
+    expect((await listed(id)).disarmReason).toBe("declaration_removed");
+    expect((await fetched(id)).disarmReason).toBe("declaration_removed");
+  });
+
+  test("a declaration still on disk means the plugin's files turned it off", async () => {
+    writePlugin("news", { declaration: "digest" });
+    const id = await declaredRow("news", false);
+
+    expect((await listed(id)).disarmReason).toBe("declaration_disabled");
+    expect((await fetched(id)).disarmReason).toBe("declaration_disabled");
+  });
+
+  test("an armed plugin row has no reason to give", async () => {
+    writePlugin("news", { declaration: "digest" });
+    const id = await declaredRow("news", true);
+
+    const row = await listed(id);
+    expect(row.enabled).toBe(true);
+    expect(row.disarmReason).toBeNull();
+    expect((await fetched(id)).disarmReason).toBeNull();
+  });
+
+  test("a user-created schedule never carries one, off or on", async () => {
+    const job = await createSchedule({
+      name: "wt-imperative",
+      description: "d",
+      message: "do the thing",
+      mode: "execute",
+      enabled: false,
+      timezone: null,
+      expression: "* * * * *",
+      syntax: "cron",
+    });
+
+    const row = await listed(job.id);
+    expect(row.sourceKey).toBeNull();
+    expect(row.enabled).toBe(false);
+    expect(row.disarmReason).toBeNull();
+    expect((await fetched(job.id)).disarmReason).toBeNull();
+  });
+});

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -5,6 +5,9 @@
  * the shared ROUTES array.
  */
 
+import { statSync } from "node:fs";
+import { join } from "node:path";
+
 import { z } from "zod";
 
 import { getOrCreateConversation } from "../../daemon/conversation-store.js";
@@ -15,6 +18,7 @@ import {
   getUsageCostForRun,
   listRunConversationIds,
 } from "../../persistence/llm-usage-store.js";
+import { isPluginDisabled } from "../../plugins/disabled-state.js";
 import { isDeferSchedule } from "../../schedule/defer-provenance.js";
 import { validateScheduleInferenceProfile } from "../../schedule/inference-profile.js";
 import { declarationExistsOnDisk } from "../../schedule/plugin-schedule-declarations.js";
@@ -49,6 +53,7 @@ import { buildWakeScheduleOptions } from "../../schedule/wake-schedule-options.j
 import { initializeTools } from "../../tools/registry.js";
 import { UserError } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
+import { getWorkspacePluginsDir } from "../../util/platform.js";
 import { normalizeCapabilityManifest } from "../../workflows/capabilities.js";
 import { getWorkflowRunManager } from "../../workflows/run-manager.js";
 import { isOwnerCaller } from "../auth/owner-caller.js";
@@ -108,6 +113,57 @@ async function assertWakeMutationAllowed(
 // Response schemas (shared by all schedule routes)
 // ---------------------------------------------------------------------------
 
+const DISARM_REASONS = [
+  "user_disabled",
+  "plugin_removed",
+  "plugin_disabled",
+  "declaration_removed",
+  "declaration_disabled",
+] as const;
+
+type DisarmReason = (typeof DISARM_REASONS)[number];
+
+/**
+ * Why a plugin-sourced schedule sits disarmed, so a client can say so instead
+ * of showing an off row with no explanation.
+ *
+ * Only a sourced row that is off can have one, which also bounds the disk
+ * probes below to those rows. The first matching cause wins, ordered so the
+ * most specific answer comes first: the user's own override outranks anything
+ * the plugin's files say, a plugin that is gone outranks one that is merely
+ * disabled, and a declaration that is gone outranks one that is still there.
+ * `declaration_disabled` is the fallback the plugin's own files account for:
+ * a declared `enabled: false`, a declaration too broken to arm, or a manifest
+ * that no longer parses.
+ */
+function deriveDisarmReason(
+  job: Pick<ScheduleJob, "sourceKey" | "enabled" | "userEnabled">,
+): DisarmReason | null {
+  if (job.sourceKey === null || job.enabled) {
+    return null;
+  }
+  if (job.userEnabled === false) {
+    return "user_disabled";
+  }
+  const match = /^plugin:([^/]+)\/(.+)$/.exec(job.sourceKey);
+  if (!match) {
+    return null;
+  }
+  const [, pluginName, scheduleName] = match;
+  const pluginDir = join(getWorkspacePluginsDir(), pluginName!);
+  if (!statSync(pluginDir, { throwIfNoEntry: false })?.isDirectory()) {
+    return "plugin_removed";
+  }
+  if (isPluginDisabled(pluginName!)) {
+    return "plugin_disabled";
+  }
+  const declarationDir = join(pluginDir, "schedules", scheduleName!);
+  if (!statSync(declarationDir, { throwIfNoEntry: false })?.isDirectory()) {
+    return "declaration_removed";
+  }
+  return "declaration_disabled";
+}
+
 const scheduleSchema = z.object({
   id: z.string(),
   name: z.string(),
@@ -149,6 +205,12 @@ const scheduleSchema = z.object({
     .nullable()
     .describe(
       "User enable/disable override on a plugin-sourced schedule; null when the declaration's own enabled value applies. Always null for user-created schedules.",
+    ),
+  disarmReason: z
+    .enum(DISARM_REASONS)
+    .nullable()
+    .describe(
+      "Why a plugin-sourced schedule is off: the user turned it off, the plugin is gone, the plugin is disabled, the declaration is gone, or the plugin's own files turned it off. Null whenever the schedule is on, and always null for user-created schedules.",
     ),
   isOneShot: z.boolean(),
   // A deferred wake ("remind me about this tomorrow") is an ordinary schedule
@@ -302,6 +364,7 @@ function serializeSchedule(
     workflowName: j.workflowName,
     sourceKey: j.sourceKey,
     userEnabled: j.userEnabled,
+    disarmReason: deriveDisarmReason(j),
     isOneShot: isOneShotForDisplay(j),
     isDeferred: isDeferSchedule(j.createdBy),
   };

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -42,6 +42,7 @@ import {
   getLastScheduleConversationId,
   getSchedule,
   getScheduleRuns,
+  isEngineLatched,
   listSchedules,
   resolveScheduleConversationGroupId,
   type ScheduleJob,
@@ -135,15 +136,34 @@ type DisarmReason = (typeof DISARM_REASONS)[number];
  * `declaration_disabled` is the fallback the plugin's own files account for:
  * a declared `enabled: false`, a declaration too broken to arm, or a manifest
  * that no longer parses.
+ *
+ * Two off states never get a reason, because in neither did the plugin's files
+ * turn the schedule off. A row the engine latched (a fired or cancelled
+ * one-shot, a bounded recurrence the claim path exhausted) is a schedule that
+ * finished, not one that is paused. And when the `plugin-schedules` kill switch
+ * is off the reconciler disarms every sourced row regardless of what its
+ * declaration says, so no per-row cause is the true one. Both return null, and
+ * clients show the row like any other schedule that is off.
  */
 function deriveDisarmReason(
-  job: Pick<ScheduleJob, "sourceKey" | "enabled" | "userEnabled">,
+  job: Pick<
+    ScheduleJob,
+    | "sourceKey"
+    | "enabled"
+    | "userEnabled"
+    | "status"
+    | "nextRunAt"
+    | "lastRunAt"
+  >,
 ): DisarmReason | null {
   if (job.sourceKey === null || job.enabled) {
     return null;
   }
   if (job.userEnabled === false) {
     return "user_disabled";
+  }
+  if (isEngineLatched(job) || !isPluginSchedulesEnabled()) {
+    return null;
   }
   const match = /^plugin:([^/]+)\/(.+)$/.exec(job.sourceKey);
   if (!match) {

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -840,7 +840,7 @@ export function listDeclaredSchedules(): ScheduleJob[] {
  * a null `lastRunAt` is a declared schedule inserted disabled, not an engine
  * latch, and stays re-armable.
  */
-function isEngineLatched(row: {
+export function isEngineLatched(row: {
   status: string;
   nextRunAt: number;
   lastRunAt: number | null;

--- a/clients/web/src/domains/schedules/components/schedule-detail-panel.stories.tsx
+++ b/clients/web/src/domains/schedules/components/schedule-detail-panel.stories.tsx
@@ -42,6 +42,7 @@ const SCHEDULE: ScheduleDetailPanelProps["schedule"] = {
   workflowName: null,
   sourceKey: null,
   userEnabled: null,
+  disarmReason: null,
 } as ScheduleDetailPanelProps["schedule"];
 
 function seededClient() {

--- a/clients/web/src/domains/schedules/components/schedule-detail-panel.test.tsx
+++ b/clients/web/src/domains/schedules/components/schedule-detail-panel.test.tsx
@@ -11,8 +11,9 @@
  *
  * Plugin-sourced treatment: sourced schedules hide the Delete affordance and
  * show plugin attribution in its place; user-created schedules keep the Delete
- * button. Run now is withheld from a plugin-sourced schedule that is turned
- * off, since the daemon refuses to run one whose plugin is disabled.
+ * button. An off schedule states why alongside that attribution. Run now is
+ * withheld from a plugin-sourced schedule that is turned off, since the daemon
+ * refuses to run one whose plugin is disabled.
  *
  * The generated daemon SDK is mocked so the config and runs queries resolve
  * without a daemon.
@@ -289,6 +290,24 @@ describe("ScheduleDetailPanel plugin-sourced treatment", () => {
       expect(getByText("Managed by plugin gmail")).toBeTruthy();
     });
     expect(queryByLabelText("Delete")).toBeNull();
+  });
+
+  // The armed case is the sibling test above: it matches the attribution
+  // exactly, so a reason appended to it would fail there.
+  test("an off plugin schedule says why alongside the attribution", async () => {
+    const { getByText } = renderPanel(
+      makeSchedule({
+        sourceKey: "plugin:gmail/poll-inbox",
+        enabled: false,
+        disarmReason: "declaration_removed",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(
+        getByText("Managed by plugin gmail · off, removed from plugin"),
+      ).toBeTruthy();
+    });
   });
 });
 

--- a/clients/web/src/domains/schedules/components/schedule-detail-panel.tsx
+++ b/clients/web/src/domains/schedules/components/schedule-detail-panel.tsx
@@ -16,7 +16,10 @@ import { DetailShellHeader } from "@/components/detail-shell";
 import { InsetDetailCard } from "@/components/inset-detail-card";
 import { useTranslation } from "@/i18n";
 import { SCHEDULE_USAGE_WINDOW_DAYS } from "@/utils/usage-window";
-import { pluginNameFromSourceKey } from "@/domains/schedules/plugin-source";
+import {
+  disarmReasonLabelKey,
+  pluginNameFromSourceKey,
+} from "@/domains/schedules/plugin-source";
 import {
   deleteSchedule,
   fetchScheduleRuns,
@@ -518,6 +521,7 @@ export function ScheduleDetailPanel({
   const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const pluginName = pluginNameFromSourceKey(schedule.sourceKey);
+  const disarmReasonKey = disarmReasonLabelKey(schedule);
   // A plugin-sourced schedule is off either because the user turned it off or
   // because the plugin is disabled. Running it would execute the plugin's
   // script anyway, which the daemon refuses, so the affordance is disabled
@@ -639,9 +643,16 @@ export function ScheduleDetailPanel({
           {pluginName ? (
             // Plugin-sourced schedules cannot be deleted here; the plugin's
             // schedule file is the source of truth, so only attribution shows.
-            // Delete itself now lives in the header, next to Close.
+            // Delete itself lives in the header, next to Close. An off
+            // schedule says why alongside it, since the user is not
+            // necessarily the one who turned it off.
             <span className="text-body-small-default text-[var(--content-tertiary)]">
-              {t("scheduleDetail.managedByPlugin", { plugin: pluginName })}
+              {disarmReasonKey
+                ? t("scheduleDetail.managedByPluginPaused", {
+                    plugin: pluginName,
+                    reason: t(disarmReasonKey),
+                  })
+                : t("scheduleDetail.managedByPlugin", { plugin: pluginName })}
             </span>
           ) : (
             <span />

--- a/clients/web/src/domains/schedules/components/schedule-row.test.tsx
+++ b/clients/web/src/domains/schedules/components/schedule-row.test.tsx
@@ -1,7 +1,8 @@
 /**
  * Tests for ScheduleRow's plugin-sourced treatment: rows whose schedule
  * carries a `sourceKey` render a plugin-name badge while keeping the enabled
- * toggle; user-created rows render no badge.
+ * toggle; user-created rows render no badge. An off row says why it is off
+ * when the daemon tells it.
  */
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
@@ -55,5 +56,42 @@ describe("ScheduleRow plugin attribution", () => {
 
     fireEvent.click(getByLabelText("Toggle Daily digest"));
     expect(onToggle).toHaveBeenCalledWith(false);
+  });
+});
+
+describe("ScheduleRow disarm reason", () => {
+  test("an off row says why it is off", () => {
+    const { getByText } = render(
+      <ScheduleRow
+        schedule={makeSchedule({
+          sourceKey: "plugin:gmail/poll-inbox",
+          enabled: false,
+          disarmReason: "plugin_disabled",
+        })}
+        usage={{ status: "error" }}
+        onClick={() => {}}
+        onToggle={() => {}}
+      />,
+    );
+
+    expect(getByText("plugin disabled")).toBeTruthy();
+  });
+
+  test("an armed row shows no reason", () => {
+    const { queryByText } = render(
+      <ScheduleRow
+        schedule={makeSchedule({
+          sourceKey: "plugin:gmail/poll-inbox",
+          enabled: true,
+          disarmReason: null,
+        })}
+        usage={{ status: "error" }}
+        onClick={() => {}}
+        onToggle={() => {}}
+      />,
+    );
+
+    expect(queryByText("plugin disabled")).toBeNull();
+    expect(queryByText("turned off by you")).toBeNull();
   });
 });

--- a/clients/web/src/domains/schedules/components/schedule-row.tsx
+++ b/clients/web/src/domains/schedules/components/schedule-row.tsx
@@ -2,7 +2,10 @@ import { Fragment, type ReactNode } from "react";
 
 import { ChevronRight } from "lucide-react";
 
-import { pluginNameFromSourceKey } from "@/domains/schedules/plugin-source";
+import {
+  disarmReasonLabelKey,
+  pluginNameFromSourceKey,
+} from "@/domains/schedules/plugin-source";
 import { useTranslation } from "@/i18n";
 import {
   formatScheduleCost,
@@ -139,9 +142,14 @@ export function ScheduleRow({
   const { t } = useTranslation("schedules");
   const cadence = schedule.isOneShot ? "" : schedule.cadenceDescription.trim();
   const runAt = schedule.lastRunAt ?? schedule.nextRunAt;
-  const metaParts = [cadence, runAt ? formatTimestamp(runAt) : ""].filter(
-    Boolean,
-  );
+  // Why the schedule is off leads the meta line: on a row whose toggle is
+  // already visibly off, it is the fact the reader is looking for.
+  const reasonKey = disarmReasonLabelKey(schedule);
+  const metaParts = [
+    reasonKey ? t(reasonKey) : "",
+    cadence,
+    runAt ? formatTimestamp(runAt) : "",
+  ].filter(Boolean);
   const pluginName = pluginNameFromSourceKey(schedule.sourceKey);
 
   return (

--- a/clients/web/src/domains/schedules/components/schedule-test-fixtures.ts
+++ b/clients/web/src/domains/schedules/components/schedule-test-fixtures.ts
@@ -40,6 +40,7 @@ export function makeSchedule(overrides: Partial<Schedule> = {}): Schedule {
     workflowName: null,
     sourceKey: null,
     userEnabled: null,
+    disarmReason: null,
     isOneShot: false,
     isDeferred: false,
     ...overrides,

--- a/clients/web/src/domains/schedules/plugin-source.ts
+++ b/clients/web/src/domains/schedules/plugin-source.ts
@@ -15,3 +15,33 @@ export function pluginNameFromSourceKey(
   const match = /^plugin:([^/]+)\//.exec(sourceKey ?? "");
   return match?.[1] ?? null;
 }
+
+const DISARM_REASON_KEYS = {
+  user_disabled: "scheduleDisarmReason.userDisabled",
+  plugin_removed: "scheduleDisarmReason.pluginRemoved",
+  plugin_disabled: "scheduleDisarmReason.pluginDisabled",
+  declaration_removed: "scheduleDisarmReason.declarationRemoved",
+  declaration_disabled: "scheduleDisarmReason.declarationDisabled",
+} as const;
+
+type DisarmReasonKey =
+  (typeof DISARM_REASON_KEYS)[keyof typeof DISARM_REASON_KEYS];
+
+/**
+ * Schedules-namespace key naming why a schedule is off, or null when there is
+ * nothing to say: the schedule is on, it is user-created, or the daemon
+ * predates the field.
+ */
+export function disarmReasonLabelKey(schedule: {
+  enabled: boolean;
+  disarmReason?: string | null;
+}): DisarmReasonKey | null {
+  if (schedule.enabled || !schedule.disarmReason) {
+    return null;
+  }
+  return (
+    DISARM_REASON_KEYS[
+      schedule.disarmReason as keyof typeof DISARM_REASON_KEYS
+    ] ?? null
+  );
+}

--- a/clients/web/src/i18n/locales/en/schedules.json
+++ b/clients/web/src/i18n/locales/en/schedules.json
@@ -44,6 +44,7 @@
     "noRunsYet": "No runs yet.",
     "recentRuns": "Recent runs",
     "managedByPlugin": "Managed by plugin {plugin}",
+    "managedByPluginPaused": "Managed by plugin {plugin} · off, {reason}",
     "delete": "Delete",
     "deleteConfirmMessage": "Delete \"{name}\"? This can't be undone.",
     "cancel": "Cancel",
@@ -76,5 +77,12 @@
   },
   "scheduleRow": {
     "toggleAria": "Toggle {name}"
+  },
+  "scheduleDisarmReason": {
+    "userDisabled": "turned off by you",
+    "pluginRemoved": "plugin removed",
+    "pluginDisabled": "plugin disabled",
+    "declarationRemoved": "removed from plugin",
+    "declarationDisabled": "paused by plugin"
   }
 }

--- a/clients/web/src/i18n/locales/es/schedules.json
+++ b/clients/web/src/i18n/locales/es/schedules.json
@@ -44,6 +44,7 @@
     "noRunsYet": "Aún no hay ejecuciones.",
     "recentRuns": "Ejecuciones recientes",
     "managedByPlugin": "Gestionada por el plugin {plugin}",
+    "managedByPluginPaused": "Gestionada por el plugin {plugin} · desactivada, {reason}",
     "delete": "Eliminar",
     "deleteConfirmMessage": "¿Eliminar \"{name}\"? Esta acción no se puede deshacer.",
     "cancel": "Cancelar",
@@ -76,5 +77,12 @@
   },
   "scheduleRow": {
     "toggleAria": "Alternar {name}"
+  },
+  "scheduleDisarmReason": {
+    "userDisabled": "la desactivaste tú",
+    "pluginRemoved": "plugin eliminado",
+    "pluginDisabled": "plugin desactivado",
+    "declarationRemoved": "eliminada del plugin",
+    "declarationDisabled": "pausada por el plugin"
   }
 }


### PR DESCRIPTION
## Summary
- Schedule list and detail responses now carry a disarmReason for plugin schedules that are off (turned off by you, plugin removed, plugin disabled, removed from plugin, paused by plugin).
- The CLI and the web schedules UI surface the reason instead of showing an unexplained disabled row.