### PR TITLE
feat(usage): persist conversation_source on llm_usage_events at record time

### DIFF
--- a/assistant/src/__tests__/llm-usage-store.test.ts
+++ b/assistant/src/__tests__/llm-usage-store.test.ts
@@ -1829,6 +1829,91 @@ describe("queryUnreportedUsageEvents", () => {
     expect(events[0].conversationType).toBe("scheduled");
   });
 
+  // -------------------------------------------------------------------------
+  // Conversation source (migration 367): stamped on the row at record time
+  // (survives deletion of the parent conversation before flush) with a JOIN
+  // fallback for pre-migration rows, mirroring conversationType above.
+  // -------------------------------------------------------------------------
+
+  test("conversationSource resolves from the conversations table", () => {
+    const db = getDb();
+    const now = Date.now();
+    db.run(
+      `INSERT INTO conversations (id, conversation_type, source, created_at, updated_at) VALUES ('conv-u', 'standard', 'user', ${now}, ${now})`,
+    );
+    db.run(
+      `INSERT INTO conversations (id, conversation_type, source, created_at, updated_at) VALUES ('conv-sub', 'background', 'subagent', ${now}, ${now})`,
+    );
+
+    insertEventAt(1000, { conversationId: "conv-u" });
+    insertEventAt(2000, { conversationId: "conv-sub" });
+    insertEventAt(3000, { conversationId: null });
+
+    const events = queryUnreportedUsageEvents(0, undefined, 100);
+    expect(events).toHaveLength(3);
+    expect(events[0].conversationSource).toBe("user");
+    expect(events[1].conversationSource).toBe("subagent");
+    // LLM calls without a parent conversation get null: LEFT JOIN, not INNER.
+    expect(events[2].conversationSource).toBeNull();
+  });
+
+  test("conversationSource is stamped on the row at record time", () => {
+    const db = getDb();
+    const now = Date.now();
+    db.run(
+      `INSERT INTO conversations (id, conversation_type, source, created_at, updated_at) VALUES ('conv-stamp-src', 'background', 'memory-retrospective', ${now}, ${now})`,
+    );
+
+    const event = recordUsageEvent(
+      makeInput({ conversationId: "conv-stamp-src" }),
+      pricedResult,
+    );
+
+    const row = getSqlite()
+      .query("SELECT conversation_source FROM llm_usage_events WHERE id = ?")
+      .get(event.id) as { conversation_source: string | null } | null;
+    expect(row?.conversation_source).toBe("memory-retrospective");
+  });
+
+  test("conversationSource survives deletion of the parent conversation before flush", () => {
+    // Same deletion-survival mechanism as conversationType: the
+    // retrospective fork's background conversation is GC'd once superseded,
+    // so a flush-time JOIN alone would null out the source.
+    const db = getDb();
+    const now = Date.now();
+    db.run(
+      `INSERT INTO conversations (id, conversation_type, source, created_at, updated_at) VALUES ('conv-src-gone', 'background', 'memory-retrospective', ${now}, ${now})`,
+    );
+    insertEventAt(1000, {
+      conversationId: "conv-src-gone",
+      callSite: "memoryRetrospective",
+    });
+
+    db.run(`DELETE FROM conversations WHERE id = 'conv-src-gone'`);
+
+    const events = queryUnreportedUsageEvents(0, undefined, 100);
+    expect(events).toHaveLength(1);
+    expect(events[0].conversationId).toBe("conv-src-gone");
+    expect(events[0].conversationSource).toBe("memory-retrospective");
+  });
+
+  test("conversationSource falls back to the JOIN for pre-migration rows", () => {
+    const db = getDb();
+    const now = Date.now();
+    db.run(
+      `INSERT INTO conversations (id, conversation_type, source, created_at, updated_at) VALUES ('conv-src-legacy', 'scheduled', 'schedule', ${now}, ${now})`,
+    );
+    insertEventAt(1000, { conversationId: "conv-src-legacy" });
+    // Simulate a row persisted before migration 367 stamped the column.
+    db.run(
+      `UPDATE llm_usage_events SET conversation_source = NULL WHERE conversation_id = 'conv-src-legacy'`,
+    );
+
+    const events = queryUnreportedUsageEvents(0, undefined, 100);
+    expect(events).toHaveLength(1);
+    expect(events[0].conversationSource).toBe("schedule");
+  });
+
   test("turnIndex counts real user turns up to the LLM call's createdAt", () => {
     const db = getDb();
     const now = Date.now();

--- a/assistant/src/persistence/llm-usage-store.ts
+++ b/assistant/src/persistence/llm-usage-store.ts
@@ -46,26 +46,35 @@ import {
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve the parent conversation's `conversation_type` at record time.
- * Usage rows outlive conversation rows (retrospective forks are GC'd,
- * users delete conversations), so the type must be captured while the
- * conversation still exists — the telemetry flush can run after the
- * parent row is gone. Best-effort: a lookup failure degrades to null
- * (same as the pre-column behavior) rather than dropping the usage row.
+ * Resolve the parent conversation's `conversation_type` and `source` at
+ * record time, in one lookup. Usage rows outlive conversation rows
+ * (retrospective forks are GC'd, users delete conversations), so both must
+ * be captured while the conversation still exists: the telemetry flush can
+ * run after the parent row is gone. Best-effort: a lookup failure (or a
+ * missing row) degrades to nulls rather than dropping the usage row.
  */
-function lookupConversationType(conversationId: string | null): string | null {
+function lookupConversationAttribution(conversationId: string | null): {
+  conversationType: string | null;
+  conversationSource: string | null;
+} {
   if (conversationId === null) {
-    return null;
+    return { conversationType: null, conversationSource: null };
   }
   try {
     const row = getDb()
-      .select({ conversationType: conversations.conversationType })
+      .select({
+        conversationType: conversations.conversationType,
+        conversationSource: conversations.source,
+      })
       .from(conversations)
       .where(eq(conversations.id, conversationId))
       .get();
-    return row?.conversationType ?? null;
+    return {
+      conversationType: row?.conversationType ?? null,
+      conversationSource: row?.conversationSource ?? null,
+    };
   } catch {
-    return null;
+    return { conversationType: null, conversationSource: null };
   }
 }
 
@@ -87,6 +96,7 @@ export function recordUsageEvent(
     pricingStatus: pricing.pricingStatus,
     assistantVersion: APP_VERSION,
   };
+  const attribution = lookupConversationAttribution(event.conversationId);
   db.insert(llmUsageEvents)
     .values({
       id: event.id,
@@ -115,10 +125,11 @@ export function recordUsageEvent(
       // the assistant happens to be running on at upload time. See
       // migration 267 + `TelemetryEventBase.assistant_version` (wire).
       assistantVersion: event.assistantVersion,
-      // Capture the parent conversation's type at RECORD time for the
-      // same reason: the conversation row may be deleted before the
-      // telemetry flush joins against it. See migration 353.
-      conversationType: lookupConversationType(event.conversationId),
+      // Capture the parent conversation's type and source at RECORD time
+      // for the same reason: the conversation row may be deleted before the
+      // telemetry flush joins against it. See migrations 353 and 367.
+      conversationType: attribution.conversationType,
+      conversationSource: attribution.conversationSource,
     })
     .run();
   return event;
@@ -230,6 +241,15 @@ export interface UnreportedUsageEvent extends UsageEvent {
    * (memory consolidation, background embedding work, etc.).
    */
   conversationType: string | null;
+  /**
+   * `source` of the parent conversation (`"user"` / `"subagent"` /
+   * `"schedule"` / `"memory-retrospective"` / ...). Sourced from the value
+   * captured at record time (survives deletion of the parent conversation
+   * before flush), with a JOIN to `conversations` as the fallback for rows
+   * persisted before migration 367. Null when the LLM call has no
+   * `conversationId`.
+   */
+  conversationSource: string | null;
   /**
    * 1-indexed position of the user turn this LLM call belongs to within
    * the parent conversation, counting only real user turns (tool-result
@@ -356,6 +376,14 @@ export function queryUnreportedUsageEvents(
       >`COALESCE(${llmUsageEvents.conversationType}, ${conversations.conversationType})`.as(
         "resolved_conversation_type",
       ),
+      // `conversationSource` follows the same record-time-stamp-then-JOIN
+      // fallback as `conversationType` (migration 367): the stored value
+      // survives parent deletion; the LEFT JOIN covers pre-367 rows.
+      conversationSource: sql<
+        string | null
+      >`COALESCE(${llmUsageEvents.conversationSource}, ${conversations.source})`.as(
+        "resolved_conversation_source",
+      ),
       // Null when conversationId is null (no parent conversation).
       // Otherwise the count of eligible user turns up to and including
       // this LLM call's createdAt. The COALESCE guard returns null
@@ -417,6 +445,7 @@ export function queryUnreportedUsageEvents(
   return rows.map((row) => ({
     ...rowToUsageEvent(row),
     conversationType: row.conversationType,
+    conversationSource: row.conversationSource,
     // SQLite returns COUNT(*) as 0 when no rows match; the CASE in the
     // subquery already collapses the no-conversation case to NULL.
     // Convert the integer column to `number | null` for the typed

--- a/assistant/src/persistence/migrations/367-add-llm-usage-conversation-source.test.ts
+++ b/assistant/src/persistence/migrations/367-add-llm-usage-conversation-source.test.ts
@@ -1,0 +1,110 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import * as schema from "../schema.js";
+import { migrateAddLlmUsageConversationSource } from "./367-add-llm-usage-conversation-source.js";
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  // Pre-367 shape: only the columns the migration and tests touch.
+  sqlite.exec(/*sql*/ `
+    CREATE TABLE conversations (
+      id TEXT PRIMARY KEY,
+      source TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+    CREATE TABLE llm_usage_events (
+      id TEXT PRIMARY KEY,
+      created_at INTEGER NOT NULL,
+      conversation_id TEXT,
+      provider TEXT NOT NULL,
+      model TEXT NOT NULL,
+      input_tokens INTEGER NOT NULL,
+      output_tokens INTEGER NOT NULL,
+      pricing_status TEXT NOT NULL
+    );
+  `);
+  return { sqlite, db: drizzle(sqlite, { schema }) };
+}
+
+function insertConversation(
+  sqlite: Database,
+  id: string,
+  source: string,
+): void {
+  sqlite.run(
+    `INSERT INTO conversations (id, source, created_at, updated_at) VALUES (?, ?, 1000, 1000)`,
+    [id, source],
+  );
+}
+
+function insertUsageEvent(
+  sqlite: Database,
+  id: string,
+  conversationId: string | null,
+): void {
+  sqlite.run(
+    `INSERT INTO llm_usage_events (id, created_at, conversation_id, provider, model, input_tokens, output_tokens, pricing_status)
+     VALUES (?, 1000, ?, 'anthropic', 'test-model', 1, 1, 'priced')`,
+    [id, conversationId],
+  );
+}
+
+function sourceOf(sqlite: Database, eventId: string): unknown {
+  const row = sqlite
+    .query("SELECT conversation_source FROM llm_usage_events WHERE id = ?")
+    .get(eventId) as { conversation_source: unknown };
+  return row.conversation_source;
+}
+
+describe("migration 367: llm_usage_events.conversation_source", () => {
+  test("adds the nullable column", () => {
+    const { sqlite, db } = createTestDb();
+    migrateAddLlmUsageConversationSource(db);
+
+    const columns = (
+      sqlite.query("PRAGMA table_info(llm_usage_events)").all() as Array<{
+        name: string;
+        notnull: number;
+      }>
+    ).filter((c) => c.name === "conversation_source");
+    expect(columns).toHaveLength(1);
+    expect(columns[0].notnull).toBe(0);
+  });
+
+  test("backfills existing rows from surviving parent conversations", () => {
+    const { sqlite, db } = createTestDb();
+    insertConversation(sqlite, "conv-retro", "memory-retrospective");
+    insertUsageEvent(sqlite, "evt-live-parent", "conv-retro");
+    // Parent already deleted before the upgrade: unrecoverable, stays NULL.
+    insertUsageEvent(sqlite, "evt-gone-parent", "conv-gone");
+    insertUsageEvent(sqlite, "evt-no-parent", null);
+
+    migrateAddLlmUsageConversationSource(db);
+
+    expect(sourceOf(sqlite, "evt-live-parent")).toBe("memory-retrospective");
+    expect(sourceOf(sqlite, "evt-gone-parent")).toBeNull();
+    expect(sourceOf(sqlite, "evt-no-parent")).toBeNull();
+  });
+
+  test("re-run never overwrites existing stamps", () => {
+    const { sqlite, db } = createTestDb();
+    insertConversation(sqlite, "conv-user", "user");
+    insertUsageEvent(sqlite, "evt-1", "conv-user");
+
+    migrateAddLlmUsageConversationSource(db);
+    expect(sourceOf(sqlite, "evt-1")).toBe("user");
+
+    // The stamp is the record-time truth, so when it disagrees with the value
+    // the JOIN would produce, a re-run must fill only NULLs and leave the
+    // existing value alone.
+    sqlite.run(
+      `UPDATE llm_usage_events SET conversation_source = 'subagent' WHERE id = 'evt-1'`,
+    );
+    migrateAddLlmUsageConversationSource(db);
+    expect(sourceOf(sqlite, "evt-1")).toBe("subagent");
+  });
+});

--- a/assistant/src/persistence/migrations/367-add-llm-usage-conversation-source.ts
+++ b/assistant/src/persistence/migrations/367-add-llm-usage-conversation-source.ts
@@ -15,8 +15,9 @@ const COLUMN_DEFINITION = "conversation_source TEXT";
  * memory-retrospective forks are GC'd once a newer run supersedes them (or
  * deleted immediately on wake failure), and users delete conversations. Any
  * row flushed after its parent conversation's deletion would report a null
- * `conversation_source` despite carrying a `conversation_id`. This mirrors the
- * record-time stamping migration 353 added for `conversation_type`.
+ * `conversation_source` despite carrying a `conversation_id`. The column
+ * follows the same record-time stamping pattern as `conversation_type`
+ * (migration 353).
  *
  * The backfill stamps every existing row whose parent conversation still
  * exists, so usage rows pending flush at upgrade time (delayed or offline

--- a/assistant/src/persistence/migrations/367-add-llm-usage-conversation-source.ts
+++ b/assistant/src/persistence/migrations/367-add-llm-usage-conversation-source.ts
@@ -1,0 +1,51 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { tableHasColumn } from "./schema-introspection.js";
+
+const COLUMN_NAME = "conversation_source";
+const COLUMN_DEFINITION = "conversation_source TEXT";
+
+/**
+ * Add `conversation_source` column to the `llm_usage_events` table and
+ * backfill it from `conversations` for existing rows.
+ *
+ * The column captures the parent conversation's `source` (`"user"` /
+ * `"subagent"` / `"schedule"` / `"memory-retrospective"` / ...) at the moment
+ * the usage event is RECORDED. A flush-time LEFT JOIN to `conversations`
+ * cannot stand on its own, because usage rows outlive conversation rows:
+ * memory-retrospective forks are GC'd once a newer run supersedes them (or
+ * deleted immediately on wake failure), and users delete conversations. Any
+ * row flushed after its parent conversation's deletion would report a null
+ * `conversation_source` despite carrying a `conversation_id`. This mirrors the
+ * record-time stamping migration 353 added for `conversation_type`.
+ *
+ * The backfill stamps every existing row whose parent conversation still
+ * exists, so usage rows pending flush at upgrade time (delayed or offline
+ * telemetry) keep their source even if the parent conversation is deleted
+ * before the next successful flush. Rows whose parents are already gone stay
+ * NULL, since their source is unrecoverable. The telemetry read path
+ * (`queryUnreportedUsageEvents`) COALESCEs the stored value with the JOIN as a
+ * final fallback.
+ *
+ * Idempotent: the ALTER is guarded with `tableHasColumn` so a crash between
+ * the `ALTER TABLE` and the checkpoint write doesn't cause a duplicate-column
+ * error on the next boot, and the backfill only fills NULL values so a re-run
+ * never overwrites record-time stamps.
+ */
+export function migrateAddLlmUsageConversationSource(
+  database: DrizzleDb,
+): void {
+  if (!tableHasColumn(database, "llm_usage_events", COLUMN_NAME)) {
+    database.run(
+      `ALTER TABLE llm_usage_events ADD COLUMN ${COLUMN_DEFINITION}`,
+    );
+  }
+  database.run(
+    `UPDATE llm_usage_events
+     SET conversation_source = (
+       SELECT c.source FROM conversations AS c
+       WHERE c.id = llm_usage_events.conversation_id
+     )
+     WHERE conversation_id IS NOT NULL
+       AND conversation_source IS NULL`,
+  );
+}

--- a/assistant/src/persistence/schema/infrastructure.ts
+++ b/assistant/src/persistence/schema/infrastructure.ts
@@ -290,6 +290,17 @@ export const llmUsageEvents = sqliteTable(
      * telemetry read path falls back to the JOIN for those).
      */
     conversationType: text("conversation_type"),
+    /**
+     * `conversations.source` of the parent conversation (`"user"`,
+     * `"subagent"`, `"schedule"`, `"memory-retrospective"`, ...), captured at
+     * RECORD time for the same deletion-survival reason as
+     * `conversation_type`: the parent conversation can be deleted before the
+     * telemetry flush joins against it, so a flush-time JOIN alone loses the
+     * source. Null when the call has no parent conversation and for rows
+     * persisted before migration 367 ran (the telemetry read path falls back
+     * to the JOIN for those).
+     */
+    conversationSource: text("conversation_source"),
   },
   (table) => [
     index("idx_llm_usage_events_conversation_id").on(table.conversationId),

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -474,6 +474,7 @@ import { migrateBackfillScheduleInferenceProfile } from "./migrations/363-backfi
 import { migrateAddScheduleSourceKey } from "./migrations/364-add-schedule-source-key.js";
 import { migrateAddConversationForkStrategy } from "./migrations/365-add-conversation-fork-strategy.js";
 import { migrateChatgptSubscriptionRowIdentity } from "./migrations/366-chatgpt-subscription-row-identity.js";
+import { migrateAddLlmUsageConversationSource } from "./migrations/367-add-llm-usage-conversation-source.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1582,4 +1583,5 @@ export const migrationSteps: MigrationStep[] = [
     // permanently checkpoint the no-op.
     dependsOn: ["migrateCreateProviderConnections"],
   },
+  migrateAddLlmUsageConversationSource,
 ];

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -251,12 +251,13 @@ await initializeDb();
 let eventIdCounter = 0;
 
 // The reporter consumes `UnreportedUsageEvent` (UsageEvent + the
-// JOIN-computed fields `conversationType`, `turnIndex`,
-// `parentConversationId`, and `parentTurnIndex`). Build that shape
-// directly so the mock matches `queryUnreportedUsageEvents`' return type
-// exactly.
+// conversation-level fields `conversationType`, `conversationSource`,
+// `turnIndex`, `parentConversationId`, and `parentTurnIndex`). Build that
+// shape directly so the mock matches `queryUnreportedUsageEvents`' return
+// type exactly.
 type UnreportedUsageEventFixture = UsageEvent & {
   conversationType: string | null;
+  conversationSource: string | null;
   turnIndex: number | null;
   parentConversationId: string | null;
   parentTurnIndex: number | null;
@@ -289,6 +290,7 @@ function makeUsageEvent(
     pricingStatus: "priced",
     assistantVersion: "test-app-version",
     conversationType: "standard",
+    conversationSource: "user",
     turnIndex: 1,
     parentConversationId: null,
     parentTurnIndex: null,


### PR DESCRIPTION
Part 2 of the work-origin cost-attribution stack (stacked on #40761; will be retargeted to `aaron/work-origin-attribution` once part 1 merges; never targets main).

## What

Adds migration 367: a nullable `conversation_source` column on `llm_usage_events`, backfilled from surviving parent conversations. `recordUsageEvent` stamps conversation type and source together from one best-effort lookup (the two-column generalization of the lookup that stamps `conversation_type`), and `queryUnreportedUsageEvents` resolves the source as `COALESCE(stamped value, JOIN fallback)`, the same pattern migration 353 established for `conversation_type`.

## Why record-time stamping

Usage rows outlive conversation rows: retrospective forks are GC'd and users delete conversations before the telemetry flush runs, and the watermark cursor advances on ship, so anything captured incorrectly at flush time is frozen forever. Stamping at record time preserves the attribution the classifier (part 1) and the wire emission (part 3) need.

## Notes for review

- Migration 367 is idempotent (`tableHasColumn` guard, backfill fills only NULLs, re-run never overwrites stamps) and registered as its own entry at the end of `migrationSteps`.
- `lookupConversationType` is deleted; `lookupConversationAttribution` replaces it (both columns, one read, degrades to nulls on failure so an attribution detail can never drop a usage row).
- One telemetry test file changed: `usage-telemetry-reporter.test.ts` keeps a hand-maintained structural copy of `UnreportedUsageEvent`, which needed the new field to compile. No telemetry production code is touched here; wire emission is part 3.

## Verify

```
cd assistant
bun test src/persistence/migrations/367-add-llm-usage-conversation-source.test.ts
bun test src/__tests__/llm-usage-store.test.ts
bun test src/persistence/migrations/__tests__/migration-prefix-guard.test.ts
bun run typecheck:fast && bun run lint
```

Part of the CAS-023 cost-attribution effort (Velcro case_c30f7ae1-bc36-47ea-ad9a-987ccdec2888).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40763" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->