### PR TITLE
feat(telemetry): emit conversation_source and work_origin on llm_usage

### DIFF
--- a/assistant/src/telemetry/__tests__/telemetry-event-fixtures.ts
+++ b/assistant/src/telemetry/__tests__/telemetry-event-fixtures.ts
@@ -43,6 +43,9 @@ const llmUsage: LlmUsageTelemetryEvent = {
   // Zero is legitimate (wire bound is min(0)): a subagent can be spawned
   // before the parent's first real user turn.
   parent_turn_index: 0,
+  conversation_source: "subagent",
+  // Parent linkage present, so the coarse bucket is the delegated child.
+  work_origin: "delegated_child",
   subagent_role: "advisor",
   subagent_spawn_mode: "advisor_consult",
   provider: "anthropic",

--- a/assistant/src/telemetry/telemetry-event-sources.ts
+++ b/assistant/src/telemetry/telemetry-event-sources.ts
@@ -266,6 +266,25 @@ export function orphanOutboxDrainSource(): TelemetryEventSource {
 // Sources
 // ---------------------------------------------------------------------------
 
+/**
+ * Bound a conversation source to the `llm_usage` wire contract (trimmed,
+ * 1 to 64 characters). The persisted column is unconstrained: `import:` and
+ * plugin-supplied sources are free-form, and one out-of-contract value would
+ * fail wire validation for the whole event, which the ingest silently skips
+ * while the watermark advances past the row. An out-of-contract source is
+ * emitted as null; `work_origin` is classified from the raw value.
+ */
+function boundConversationSourceForWire(source: string | null): string | null {
+  if (source === null) {
+    return null;
+  }
+  const trimmed = source.trim();
+  if (trimmed.length === 0 || trimmed.length > 64) {
+    return null;
+  }
+  return trimmed;
+}
+
 const usageSource = simpleSource(
   "usage",
   (afterCreatedAt, afterId, limit) =>
@@ -286,8 +305,9 @@ const usageSource = simpleSource(
     // the coarse bucket derived from it plus the type, call site, and parent
     // linkage. Source is null for calls with no conversation; work_origin is
     // still classified from the call site, falling back to `unknown` and
-    // never null.
-    conversation_source: e.conversationSource,
+    // never null. The source is bounded to the wire contract, while the
+    // classifier sees the raw value.
+    conversation_source: boundConversationSourceForWire(e.conversationSource),
     work_origin: classifyWorkOrigin({
       conversationType: e.conversationType,
       conversationSource: e.conversationSource,

--- a/assistant/src/telemetry/telemetry-event-sources.ts
+++ b/assistant/src/telemetry/telemetry-event-sources.ts
@@ -313,6 +313,7 @@ const usageSource = simpleSource(
       conversationSource: e.conversationSource,
       callSite: e.callSite,
       parentConversationId: e.parentConversationId,
+      cronRunId: e.cronRunId,
     }),
     // Delegated-work decomposition. Every subagent variety shares
     // `llm_call_site = "subagentSpawn"`; these two orthogonal dimensions are

--- a/assistant/src/telemetry/telemetry-event-sources.ts
+++ b/assistant/src/telemetry/telemetry-event-sources.ts
@@ -15,6 +15,7 @@ import {
   getCachedShareDiagnosticsVersion,
 } from "../platform/consent-cache.js";
 import type { UsageAttributionProfileSource } from "../usage/types.js";
+import { classifyWorkOrigin } from "../usage/work-origin.js";
 import { getLogger } from "../util/logger.js";
 import { APP_VERSION } from "../version.js";
 import {
@@ -281,6 +282,18 @@ const usageSource = simpleSource(
     turn_index: e.turnIndex,
     parent_conversation_id: e.parentConversationId,
     parent_turn_index: e.parentTurnIndex,
+    // `conversation_source` is the raw record-time source; `work_origin` is
+    // the coarse bucket derived from it plus the type, call site, and parent
+    // linkage. Source is null for calls with no conversation; work_origin is
+    // still classified from the call site, falling back to `unknown` and
+    // never null.
+    conversation_source: e.conversationSource,
+    work_origin: classifyWorkOrigin({
+      conversationType: e.conversationType,
+      conversationSource: e.conversationSource,
+      callSite: e.callSite,
+      parentConversationId: e.parentConversationId,
+    }),
     // Delegated-work decomposition. Every subagent variety shares
     // `llm_call_site = "subagentSpawn"`; these two orthogonal dimensions are
     // what make advisor consults, forks, and regular spawns separable. Null

--- a/assistant/src/telemetry/telemetry-wire.generated.ts
+++ b/assistant/src/telemetry/telemetry-wire.generated.ts
@@ -95,6 +95,8 @@ export const llmUsageTelemetryEventSchema = z.object({
     .nullable()
     .optional(),
   parent_turn_index: z.number().int().min(0).nullable().optional(),
+  conversation_source: z.string().trim().min(1).max(64).nullable().optional(),
+  work_origin: z.string().trim().min(1).max(64).nullable().optional(),
   subagent_role: z.string().trim().min(1).max(64).nullable().optional(),
   subagent_spawn_mode: z.string().trim().min(1).max(64).nullable().optional(),
 });

--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -1,5 +1,6 @@
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import type { UsageAttributionProfileSource } from "../usage/types.js";
+import type { WorkOrigin } from "../usage/work-origin.js";
 import type * as wire from "./telemetry-wire.generated.js";
 import { telemetryEventSchema } from "./telemetry-wire.generated.js";
 import type { TurnOutcome } from "./turn-outcome.js";
@@ -114,6 +115,20 @@ export interface LlmUsageTelemetryEvent extends TelemetryEventBase {
    * parent conversation.
    */
   parent_turn_index: number | null;
+  /**
+   * `source` of the parent conversation (`"user"` / `"subagent"` /
+   * `"schedule"` / `"memory-retrospective"` / ...), captured at record time
+   * (it survives deletion of the parent conversation before flush). Null when
+   * the LLM call has no conversation. This is the raw value;
+   * {@link LlmUsageTelemetryEvent.work_origin} is the derived coarse bucket.
+   */
+  conversation_source: string | null;
+  /**
+   * Coarse work-origin bucket derived from the row's conversation metadata
+   * and call site (see {@link WorkOrigin}). Always present: classification
+   * falls back to `"unknown"` when nothing is attributable, never null.
+   */
+  work_origin: WorkOrigin;
   /**
    * Role the subagent that owns this event's conversation was spawned with
    * (`researcher`, `builder`, `advisor`; a spawn that named no role records

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -1838,6 +1838,46 @@ describe("UsageTelemetryReporter", () => {
     });
   });
 
+  test("llm_usage bounds an out-of-contract conversation_source to null while classifying from the raw value", async () => {
+    // The persisted source column is unconstrained (import: and
+    // plugin-supplied sources are free-form) but the wire contract caps the
+    // field at 64 characters, and one out-of-contract value would fail wire
+    // validation for the whole event, losing the row when the watermark
+    // advances. The emitter nulls the field and still classifies work_origin
+    // from the raw value.
+    const longImportSource = `import:${"p".repeat(70)}`;
+    mockQueryUnreportedUsageEvents.mockReturnValue([
+      makeUsageEvent({
+        id: "evt-long-source",
+        conversationId: "conv-import",
+        conversationType: "standard",
+        conversationSource: longImportSource,
+        turnIndex: 1,
+      }),
+    ]);
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
+    );
+
+    const reporter = makeReporter();
+    await reporter.flush();
+
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    const event = (
+      body.events as Array<{
+        daemon_event_id: string;
+        conversation_source: string | null;
+        work_origin: string;
+      }>
+    ).find((e) => e.daemon_event_id === "evt-long-source");
+    expect(event).toMatchObject({
+      conversation_source: null,
+      work_origin: "user_interactive",
+    });
+  });
+
   test("flush is skipped and watermarks advanced when share_analytics consent is off", async () => {
     mockGetRawShareAnalytics.mockReturnValue(false);
     const events = [makeUsageEvent()];

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -198,13 +198,13 @@ import {
 import { getDb, getTelemetryDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { recordLifecycleEvent } from "../persistence/lifecycle-events-store.js";
+import type { UnreportedUsageEvent } from "../persistence/llm-usage-store.js";
 import {
   conversations,
   telemetryEvents,
   toolInvocations,
 } from "../persistence/schema/index.js";
 import { recordAuthFallbackCounts } from "../security/auth-fallback-events-store.js";
-import type { UsageEvent } from "../usage/types.js";
 import {
   ACTIVATION_FUNNEL_VERSION,
   buildActivationDaemonEventId,
@@ -250,24 +250,12 @@ await initializeDb();
 
 let eventIdCounter = 0;
 
-// The reporter consumes `UnreportedUsageEvent` (UsageEvent + the
-// conversation-level fields `conversationType`, `conversationSource`,
-// `turnIndex`, `parentConversationId`, and `parentTurnIndex`). Build that
-// shape directly so the mock matches `queryUnreportedUsageEvents`' return
-// type exactly.
-type UnreportedUsageEventFixture = UsageEvent & {
-  conversationType: string | null;
-  conversationSource: string | null;
-  turnIndex: number | null;
-  parentConversationId: string | null;
-  parentTurnIndex: number | null;
-  subagentRole: string | null;
-  subagentSpawnMode: string | null;
-};
-
+// The reporter consumes `UnreportedUsageEvent`, so the fixture is built as
+// that exact type and the mock matches `queryUnreportedUsageEvents`' return
+// type by construction.
 function makeUsageEvent(
-  overrides: Partial<UnreportedUsageEventFixture> = {},
-): UnreportedUsageEventFixture {
+  overrides: Partial<UnreportedUsageEvent> = {},
+): UnreportedUsageEvent {
   eventIdCounter += 1;
   return {
     id: `evt-${eventIdCounter}`,
@@ -1669,9 +1657,10 @@ describe("UsageTelemetryReporter", () => {
     expect("failure_code" in body.events[0]).toBe(false);
   });
 
-  test("llm_usage events carry conversation_id, conversation_type, turn_index, and parent linkage", async () => {
-    // Three LLM calls across the spectrum of the new fields:
+  test("llm_usage events carry conversation_id, conversation_type, turn_index, parent linkage, source, and work origin", async () => {
+    // Four LLM calls across the spectrum of the conversation-level fields:
     //  - tied to a conversation, mid-turn (typical foreground)
+    //  - tied to a standard conversation opened from a notification thread
     //  - tied to a background conversation spawned by a parent turn
     //    (subagent: parent linkage populated)
     //  - untied (memory consolidation: no conversation, no turn)
@@ -1680,12 +1669,21 @@ describe("UsageTelemetryReporter", () => {
         id: "evt-fg-call",
         conversationId: "conv-fg",
         conversationType: "standard",
+        conversationSource: "user",
         turnIndex: 4,
+      }),
+      makeUsageEvent({
+        id: "evt-notification-call",
+        conversationId: "conv-notification",
+        conversationType: "standard",
+        conversationSource: "notification",
+        turnIndex: 2,
       }),
       makeUsageEvent({
         id: "evt-bg-call",
         conversationId: "conv-bg",
         conversationType: "background",
+        conversationSource: "subagent",
         turnIndex: 1,
         parentConversationId: "conv-fg",
         parentTurnIndex: 4,
@@ -1694,11 +1692,12 @@ describe("UsageTelemetryReporter", () => {
         id: "evt-untied-call",
         conversationId: null,
         conversationType: null,
+        conversationSource: null,
         turnIndex: null,
       }),
     ]);
     mockFetch.mockImplementation(() =>
-      Promise.resolve(new Response('{"accepted":3}', { status: 200 })),
+      Promise.resolve(new Response('{"accepted":4}', { status: 200 })),
     );
 
     const reporter = makeReporter();
@@ -1715,6 +1714,8 @@ describe("UsageTelemetryReporter", () => {
         type: string;
         conversation_id: string | null;
         conversation_type: string | null;
+        conversation_source: string | null;
+        work_origin: string;
         turn_index: number | null;
         parent_conversation_id: string | null;
         parent_turn_index: number | null;
@@ -1725,6 +1726,8 @@ describe("UsageTelemetryReporter", () => {
       daemon_event_id: string;
       conversation_id: string | null;
       conversation_type: string | null;
+      conversation_source: string | null;
+      work_origin: string;
       turn_index: number | null;
       parent_conversation_id: string | null;
       parent_turn_index: number | null;
@@ -1736,29 +1739,102 @@ describe("UsageTelemetryReporter", () => {
       type: "llm_usage",
       conversation_id: "conv-fg",
       conversation_type: "standard",
+      conversation_source: "user",
+      // Standard user conversation, no parent, so the bucket is interactive.
+      work_origin: "user_interactive",
       turn_index: 4,
       parent_conversation_id: null,
       parent_turn_index: null,
+    });
+    // A standard conversation keeps its `notification` source when the user
+    // replies in it, so its turns are interactive spend.
+    expect(byId["evt-notification-call"]).toMatchObject({
+      type: "llm_usage",
+      conversation_type: "standard",
+      conversation_source: "notification",
+      work_origin: "user_interactive",
     });
     expect(byId["evt-bg-call"]).toMatchObject({
       type: "llm_usage",
       conversation_id: "conv-bg",
       conversation_type: "background",
+      conversation_source: "subagent",
+      // Parent linkage present, so the bucket is the delegated child whatever
+      // the type and source say.
+      work_origin: "delegated_child",
       turn_index: 1,
       parent_conversation_id: "conv-fg",
       parent_turn_index: 4,
     });
     // LLM calls without a parent conversation flush through with all
-    // conversation-level fields null — the serializer accepts
-    // allow_null and downstream SQL filters can `WHERE conversation_id
-    // IS NOT NULL` to scope to foreground analytics.
+    // conversation-level fields null (the serializer accepts allow_null and
+    // downstream SQL filters can `WHERE conversation_id IS NOT NULL` to scope
+    // to foreground analytics). `conversation_source` is null too, but
+    // `work_origin` is still classified (here there is no call site either,
+    // so `unknown`) and is never null on the wire.
     expect(byId["evt-untied-call"]).toMatchObject({
       type: "llm_usage",
       conversation_id: null,
       conversation_type: null,
+      conversation_source: null,
+      work_origin: "unknown",
       turn_index: null,
       parent_conversation_id: null,
       parent_turn_index: null,
+    });
+  });
+
+  test("llm_usage work_origin is classified from the call site when there is no joined conversation", async () => {
+    // A memory-consolidation call has no conversation (legacy rows and
+    // detached maintenance work): conversation_source is null, but the call
+    // site still classifies work_origin. Rows with neither survive as
+    // `unknown`, never a null work_origin.
+    mockQueryUnreportedUsageEvents.mockReturnValue([
+      makeUsageEvent({
+        id: "evt-consolidation",
+        conversationId: null,
+        conversationType: null,
+        conversationSource: null,
+        callSite: "memoryConsolidation",
+        turnIndex: null,
+      }),
+      makeUsageEvent({
+        id: "evt-legacy-untied",
+        conversationId: null,
+        conversationType: null,
+        conversationSource: null,
+        callSite: null,
+        turnIndex: null,
+      }),
+    ]);
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":2}', { status: 200 })),
+    );
+
+    const reporter = makeReporter();
+    await reporter.flush();
+
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    const byId: Record<
+      string,
+      { conversation_source: string | null; work_origin: string }
+    > = {};
+    for (const e of body.events as Array<{
+      daemon_event_id: string;
+      conversation_source: string | null;
+      work_origin: string;
+    }>) {
+      byId[e.daemon_event_id] = e;
+    }
+    expect(byId["evt-consolidation"]).toMatchObject({
+      conversation_source: null,
+      work_origin: "memory_maintenance",
+    });
+    expect(byId["evt-legacy-untied"]).toMatchObject({
+      conversation_source: null,
+      work_origin: "unknown",
     });
   });
 

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -1838,6 +1838,36 @@ describe("UsageTelemetryReporter", () => {
     });
   });
 
+  test("llm_usage classifies a wake-schedule firing by its cron run id", async () => {
+    // A wake or defer schedule can fire inside a conversation whose persisted
+    // type and source stay standard/user; the cron run id on the row is the
+    // only schedule signal.
+    mockQueryUnreportedUsageEvents.mockReturnValue([
+      makeUsageEvent({
+        id: "evt-wake-cron",
+        conversationId: "conv-waked",
+        conversationType: "standard",
+        conversationSource: "user",
+        cronRunId: "cron-run-123",
+        turnIndex: 2,
+      }),
+    ]);
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
+    );
+
+    const reporter = makeReporter();
+    await reporter.flush();
+
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    const event = (
+      body.events as Array<{ daemon_event_id: string; work_origin: string }>
+    ).find((e) => e.daemon_event_id === "evt-wake-cron");
+    expect(event?.work_origin).toBe("user_created_schedule");
+  });
+
   test("llm_usage bounds an out-of-contract conversation_source to null while classifying from the raw value", async () => {
     // The persisted source column is unconstrained (import: and
     // plugin-supplied sources are free-form) but the wire contract caps the


### PR DESCRIPTION
Part 3 of the work-origin cost-attribution stack (stacked on #40763; will be retargeted to `aaron/work-origin-attribution` as earlier parts merge; never targets main).

## What

The `llm_usage` telemetry event now carries two new fields:
- `conversation_source`: the raw record-time `conversations.source` value stamped on the usage row (part 2), null for calls with no conversation.
- `work_origin`: the coarse bucket from the part-1 classifier, derived from conversation type, source, call site, and parent linkage. Always present, never null; unattributable rows say `unknown` instead of disappearing.

## Wire-contract coupling (review focus)

`telemetry-wire.generated.ts` is platform-generated (source of truth: the platform repo's self-hosted-local serializers, auto-synced by its sync workflow). The matching serializer change is being made in the platform repo in parallel under a frozen contract (field names `work_origin` / `conversation_source`, plain strings, unknown values tolerated). This PR applies the exact shape regeneration should produce; the fields sit between `parent_turn_index` and `subagent_role`, and if the platform serializer orders them differently the sync PR will reorder lines without semantic change. Until the platform serializer lands, the ingest endpoint silently drops the two fields, which is safe: the daemon behavior is unchanged and no call can fail over them.

Both compile-time drift guards (`_llmUsageNarrows`, `_llmUsageKeysExist`) pass unchanged.

## Also

`usage-telemetry-reporter.test.ts` imports `UnreportedUsageEvent` from the store instead of keeping a hand-maintained structural copy that drifted on every new column.

## Verify

```
cd assistant
bun test src/telemetry/usage-telemetry-reporter.test.ts
bun test src/telemetry/types.test.ts
bun test src/telemetry/telemetry-wire-validation.test.ts
bun test src/__tests__/llm-usage-store.test.ts
bun run typecheck:fast && bun run lint
```

Part of the CAS-023 cost-attribution effort (Velcro case_c30f7ae1-bc36-47ea-ad9a-987ccdec2888).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40764" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->