### PR TITLE
feat(prompts): remove the 01-delegate-subagents system-prompt section

### DIFF
--- a/assistant/src/prompts/templates/system-sections.ts
+++ b/assistant/src/prompts/templates/system-sections.ts
@@ -268,13 +268,6 @@ export const BUNDLED_SYSTEM_SECTIONS: readonly BundledSection[] = [
     enabled: "!excludeCustomPrefix",
   },
   {
-    id: "01-delegate-subagents",
-    body: `## Delegate independent work
-
-When part of a task can run on its own — a research sweep, a multi-file investigation, a build-and-test loop — hand it off instead of grinding through it inline: load the \`subagent\` skill, then \`subagent_spawn\` early and in parallel. Make delegating that kind of work your default, not a last resort; an unnecessary subagent is cheaper than serialized work, and a long inline dig floods your own context.
-`,
-  },
-  {
     id: "01-parallel-tool-calls",
     body: `<use_parallel_tool_calls>
 Batch independent tool calls into the same response. An extra LLM round trip costs orders of magnitude more than a few wasted tool calls — err on the side of parallelizing when calls are independent. Reading multiple files, \`glob\`/\`grep\`, \`ls\`, \`git status\`/\`diff\`/\`log\`, type-checks, and tests should be batched.


### PR DESCRIPTION
## Why

The `01-delegate-subagents` bundled section ships in every conversation's system prompt, including heartbeats and scheduled runs, and instructs the model to make delegation "your default, not a last resort" and that "an unnecessary subagent is cheaper than serialized work." That framing directly encourages excessive subagent spawning and token burn.

Reference points:
- Codex (openai/codex) ships **zero** subagent guidance in its main model prompts; delegation guidance lives only in its opt-in collab template, and even there it is restrained ("must be used wisely").
- Our own System Prompt Minimalism rule (AGENTS.md) says tool-routing guidance belongs in the tool description or SKILL.md, not the system prompt. The `subagent` skill is already discoverable via its catalog entry and activation hints.

## What

Deletes the section from `BUNDLED_SYSTEM_SECTIONS`. Registry consumers iterate generically; no test or doc references the section id.

Part of the subagent cost remediation tracked in [Velcro case CAS c30f7ae1](https://velcro.vellum.ai/cases/case_c30f7ae1-bc36-47ea-ad9a-987ccdec2888). Companion PRs retune the subagent skill's delegation triggers and advisor consult.

## Testing

- `bun test src/__tests__/workspace-policy.test.ts` (76 pass)
- `bunx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40765" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->