### PR TITLE
feat(image-studio): save generated images to the workspace and guide inline embedding

### DIFF
--- a/assistant/src/__tests__/media-generate-image.test.ts
+++ b/assistant/src/__tests__/media-generate-image.test.ts
@@ -1,6 +1,13 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import {
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "fs";
 import { tmpdir } from "os";
 import { dirname, join } from "path";
 
@@ -527,6 +534,19 @@ describe("image-studio skill script wrapper", () => {
 
     const second = await run({ prompt: "a fox" }, fakeContext);
     expect(second.content).toContain("Saved to media/generated/a-fox-2.png");
+  });
+
+  test("refuses to write through a symlink that escapes the workspace", async () => {
+    const outside = mkdtempSync(join(tmpdir(), "media-gen-outside-"));
+    tempWorkingDirs.push(outside);
+    symlinkSync(outside, join(fakeContext.workingDir, "media"));
+
+    const result = await run({ prompt: "a cat" }, fakeContext);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Could not save to the workspace");
+    expect(result.content).not.toContain("vellum://workspace/");
+    expect(readdirSync(outside)).toEqual([]);
   });
 
   test("falls back to inline-only when the workspace write fails", async () => {

--- a/assistant/src/__tests__/media-generate-image.test.ts
+++ b/assistant/src/__tests__/media-generate-image.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import { readFileSync } from "fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
 import { dirname, join } from "path";
 
 import { __resetRegistryForTesting, getTool } from "../tools/registry.js";
@@ -97,7 +98,22 @@ import { run } from "../config/bundled-skills/image-studio/tools/media-generate-
 // Clean up after this file to prevent contamination of later test files.
 afterAll(() => {
   __resetRegistryForTesting();
+  for (const dir of tempWorkingDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
+
+const tempWorkingDirs: string[] = [];
+
+/** Build a ToolContext with a fresh temp working directory. */
+function makeContext(): ToolContext {
+  const workingDir = mkdtempSync(join(tmpdir(), "media-gen-test-"));
+  tempWorkingDirs.push(workingDir);
+  return {
+    conversationId: "conv-123",
+    workingDir,
+  } as unknown as ToolContext;
+}
 
 const CONFIG_DIR = join(
   dirname(import.meta.dirname!),
@@ -128,12 +144,10 @@ beforeEach(() => {
     platformBaseUrl: "",
     assistantApiKey: "",
   };
+  fakeContext = makeContext();
 });
 
-const fakeContext = {
-  conversationId: "conv-123",
-  workingDir: "/tmp",
-} as unknown as ToolContext;
+let fakeContext: ToolContext;
 
 describe("image-studio skill script wrapper", () => {
   test("exports a run function without registering media_generate_image in the tool registry", async () => {
@@ -431,28 +445,104 @@ describe("image-studio skill script wrapper", () => {
   });
 
   test("reads source images from file paths on disk", async () => {
-    // Write a temp image file inside the workspace (fakeContext.workingDir = /tmp)
-    const tmpPath = join("/tmp", "test-source-image.png");
+    // Write a temp image file inside the workspace
+    const tmpPath = join(fakeContext.workingDir, "test-source-image.png");
     const pngBytes = Buffer.from(
       "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==",
       "base64",
     );
     await Bun.write(tmpPath, pngBytes);
 
-    try {
-      const result = await run(
-        { prompt: "edit this", mode: "edit", source_paths: [tmpPath] },
-        fakeContext,
-      );
+    const result = await run(
+      { prompt: "edit this", mode: "edit", source_paths: [tmpPath] },
+      fakeContext,
+    );
 
-      expect(result.isError).toBe(false);
-      expect(result.content).toContain("Generated 1 image");
-    } finally {
-      const { unlink } = await import("fs/promises");
-      if (await Bun.file(tmpPath).exists()) {
-        await unlink(tmpPath);
-      }
-    }
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Generated 1 image");
+  });
+
+  test("saves the image into media/generated and returns the embed instruction", async () => {
+    const result = await run({ prompt: "a sunset" }, fakeContext);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Saved to media/generated/a-sunset.png");
+    expect(result.content).toContain(
+      "![description](vellum://workspace/media/generated/a-sunset.png)",
+    );
+    const saved = Bun.file(
+      join(fakeContext.workingDir, "media/generated/a-sunset.png"),
+    );
+    expect(await saved.exists()).toBe(true);
+    const bytes = Buffer.from(await saved.arrayBuffer());
+    expect(bytes.equals(Buffer.from("generated-data", "base64"))).toBe(true);
+  });
+
+  test("uses the image title for the filename when present", async () => {
+    mockGenerateResult = {
+      images: [
+        {
+          mimeType: "image/png",
+          dataBase64: "img1",
+          title: "Twilight Gremlin!",
+        } as never,
+      ],
+      text: "",
+      resolvedModel: "gemini-3.1-flash-image-preview",
+    };
+
+    const result = await run({ prompt: "a pond creature" }, fakeContext);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain(
+      "Saved to media/generated/twilight-gremlin.png",
+    );
+  });
+
+  test("gives each variant a distinct filename", async () => {
+    mockGenerateResult = {
+      images: [
+        { mimeType: "image/png", dataBase64: "img1" },
+        { mimeType: "image/png", dataBase64: "img2" },
+      ],
+      text: undefined as unknown as string,
+      resolvedModel: "gemini-3.1-flash-image-preview",
+    };
+
+    const result = await run({ prompt: "a robot", variants: 2 }, fakeContext);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("- media/generated/a-robot.png");
+    expect(result.content).toContain("- media/generated/a-robot-2.png");
+    expect(
+      await Bun.file(
+        join(fakeContext.workingDir, "media/generated/a-robot-2.png"),
+      ).exists(),
+    ).toBe(true);
+  });
+
+  test("suffixes the filename when a previous generation already used it", async () => {
+    const first = await run({ prompt: "a fox" }, fakeContext);
+    expect(first.content).toContain("Saved to media/generated/a-fox.png");
+
+    const second = await run({ prompt: "a fox" }, fakeContext);
+    expect(second.content).toContain("Saved to media/generated/a-fox-2.png");
+  });
+
+  test("falls back to inline-only when the workspace write fails", async () => {
+    // Occupy the media path with a regular file so the directory creation
+    // under it fails.
+    writeFileSync(join(fakeContext.workingDir, "media"), "not a directory");
+
+    const result = await run({ prompt: "a cat" }, fakeContext);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Could not save to the workspace");
+    expect(result.content).toContain(
+      "will be attached to your reply automatically",
+    );
+    expect(result.content).not.toContain("vellum://workspace/");
+    expect(result.contentBlocks).toHaveLength(1);
   });
 
   test("returns error when all source_paths are invalid", async () => {

--- a/assistant/src/config/bundled-skills/image-studio/SKILL.md
+++ b/assistant/src/config/bundled-skills/image-studio/SKILL.md
@@ -69,10 +69,11 @@ Edits on large photos are slow (1 to 2 minutes). If the tool reports a timeout (
 
 ## Output handling
 
-Images return as inline content blocks in the tool result; they are not written to disk automatically.
+Each generated image is saved into the workspace under `media/generated/` and the tool result lists the saved paths. The images also come back as inline content blocks so you can judge the result before presenting it.
 
-- If the user just wants to see the image, the inline result is enough.
-- If the user wants a file or you need to iterate on the result, save it to disk and deliver it through the conversation's attachment mechanism.
+- Present an image to the user by embedding its saved path in your reply: `![short description](vellum://workspace/media/generated/<file>.png)`. The app renders it inline where your text refers to it, and chat channels (Slack, Telegram, WhatsApp) deliver it as a native image upload.
+- If you do not embed it, the image is still auto-attached to your reply as a file, so it is never lost. Prefer embedding: an attachment chip at the end of the message is a worse presentation than the image inline.
+- To iterate on a result, pass its saved path via `source_paths` with `mode: "edit"`.
 
 ## Error handling
 
@@ -88,4 +89,4 @@ Do NOT rephrase the prompt and retry on the same model, even if the error sugges
 
 ## Complete when
 
-The tool has returned at least one image and the user can see it: either the inline result in chat or an attached saved file. An error report counts as complete only after the retry path in Error handling has been exhausted.
+The tool has returned at least one image and your reply presents it to the user, preferably as an inline `![description](vellum://workspace/...)` embed of the saved path. An error report counts as complete only after the retry path in Error handling has been exhausted.

--- a/assistant/src/config/bundled-skills/image-studio/TOOLS.json
+++ b/assistant/src/config/bundled-skills/image-studio/TOOLS.json
@@ -3,7 +3,7 @@
   "tools": [
     {
       "name": "media_generate_image",
-      "description": "Generate or edit images using AI. Supports text-to-image generation and image editing with source images.",
+      "description": "Generate or edit images using AI. Supports text-to-image generation and image editing with source images. Saves results into the workspace and returns their file paths; present a result to the user by embedding its path in your reply as ![description](vellum://workspace/<path>).",
       "category": "media",
       "risk": "low",
       "input_schema": {

--- a/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
+++ b/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
@@ -1,3 +1,5 @@
+import { join } from "path";
+
 import {
   resolveImageGenCredentials,
   resolveImageGenRouting,
@@ -18,6 +20,58 @@ import type {
   ToolExecutionResult,
 } from "../../../../tools/types.js";
 import { getConfig } from "../../../loader.js";
+
+/** Workspace-relative directory where generated images are saved. */
+const GENERATED_MEDIA_DIR = "media/generated";
+
+/**
+ * Derive a filesystem-safe base name for a generated image from its title
+ * (when the provider returns one) or the generation prompt.
+ */
+function imageFileSlug(title: string | undefined, prompt: string): string {
+  const base = (title?.trim() || prompt)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+/, "")
+    .slice(0, 48)
+    .replace(/-+$/, "");
+  return base || "image";
+}
+
+/**
+ * Save generated images under `media/generated/` in the workspace so the
+ * model can reference them by path (inline embeds, edit-mode iteration).
+ * Returns workspace-relative paths for the images written before any
+ * failure; a failure stops the loop and is reported, not thrown, so the
+ * inline content blocks still reach the model.
+ */
+async function saveGeneratedImages(
+  images: Array<{ mimeType: string; dataBase64: string; title?: string }>,
+  prompt: string,
+  workingDir: string,
+): Promise<{ savedPaths: string[]; saveError?: string }> {
+  const savedPaths: string[] = [];
+  try {
+    for (const img of images) {
+      const ext = img.mimeType.split("/")[1] ?? "png";
+      const slug = imageFileSlug(img.title, prompt);
+      let relPath = `${GENERATED_MEDIA_DIR}/${slug}.${ext}`;
+      let suffix = 2;
+      while (await Bun.file(join(workingDir, relPath)).exists()) {
+        relPath = `${GENERATED_MEDIA_DIR}/${slug}-${suffix}.${ext}`;
+        suffix++;
+      }
+      await Bun.write(
+        join(workingDir, relPath),
+        Buffer.from(img.dataBase64, "base64"),
+      );
+      savedPaths.push(relPath);
+    }
+  } catch (error) {
+    return { savedPaths, saveError: (error as Error).message };
+  }
+  return { savedPaths };
+}
 
 export async function run(
   input: Record<string, unknown>,
@@ -127,7 +181,24 @@ export async function run(
     });
 
     const imageCount = result.images.length;
+    const { savedPaths, saveError } = await saveGeneratedImages(
+      result.images,
+      prompt,
+      context.workingDir,
+    );
+
     let content = `Generated ${imageCount} image${imageCount !== 1 ? "s" : ""} using ${result.resolvedModel}.`;
+    if (savedPaths.length === 1) {
+      content += ` Saved to ${savedPaths[0]}.`;
+    } else if (savedPaths.length > 1) {
+      content += ` Saved to:\n${savedPaths.map((p) => `- ${p}`).join("\n")}`;
+    }
+    if (savedPaths.length > 0) {
+      content += `\n\nShow the user an image by embedding it in your reply: ![description](vellum://workspace/${savedPaths[0]}). To iterate on a result, pass its saved path via source_paths with mode "edit".`;
+    }
+    if (saveError) {
+      content += `\n\nCould not save to the workspace (${saveError}); the image${imageCount !== 1 ? "s" : ""} will be attached to your reply automatically instead.`;
+    }
     if (result.text) {
       content += `\n\n${result.text}`;
     }

--- a/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
+++ b/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
@@ -1,4 +1,5 @@
-import { join } from "path";
+import { mkdirSync, writeFileSync } from "fs";
+import { dirname, join } from "path";
 
 import {
   resolveImageGenCredentials,
@@ -38,34 +39,63 @@ function imageFileSlug(title: string | undefined, prompt: string): string {
   return base || "image";
 }
 
+/** Upper bound on filename-collision retries per image. */
+const MAX_FILENAME_ATTEMPTS = 1000;
+
 /**
  * Save generated images under `media/generated/` in the workspace so the
  * model can reference them by path (inline embeds, edit-mode iteration).
- * Returns workspace-relative paths for the images written before any
- * failure; a failure stops the loop and is reported, not thrown, so the
- * inline content blocks still reach the model.
+ * Each target path is validated through `sandboxPolicy` so a symlinked
+ * directory cannot redirect the write outside the workspace, and files are
+ * created exclusively (`wx`) so concurrent generations cannot claim the
+ * same filename. Returns workspace-relative paths for the images written
+ * before any failure; a failure stops the loop and is reported, not
+ * thrown, so the inline content blocks still reach the model.
  */
-async function saveGeneratedImages(
+function saveGeneratedImages(
   images: Array<{ mimeType: string; dataBase64: string; title?: string }>,
   prompt: string,
   workingDir: string,
-): Promise<{ savedPaths: string[]; saveError?: string }> {
+): { savedPaths: string[]; saveError?: string } {
   const savedPaths: string[] = [];
   try {
     for (const img of images) {
       const ext = img.mimeType.split("/")[1] ?? "png";
       const slug = imageFileSlug(img.title, prompt);
-      let relPath = `${GENERATED_MEDIA_DIR}/${slug}.${ext}`;
-      let suffix = 2;
-      while (await Bun.file(join(workingDir, relPath)).exists()) {
-        relPath = `${GENERATED_MEDIA_DIR}/${slug}-${suffix}.${ext}`;
-        suffix++;
+      let written = false;
+      for (let attempt = 1; attempt <= MAX_FILENAME_ATTEMPTS; attempt++) {
+        const relPath =
+          attempt === 1
+            ? `${GENERATED_MEDIA_DIR}/${slug}.${ext}`
+            : `${GENERATED_MEDIA_DIR}/${slug}-${attempt}.${ext}`;
+        const pathCheck = sandboxPolicy(join(workingDir, relPath), workingDir, {
+          mustExist: false,
+        });
+        if (!pathCheck.ok) {
+          throw new Error(pathCheck.error);
+        }
+        mkdirSync(dirname(pathCheck.resolved), { recursive: true });
+        try {
+          writeFileSync(
+            pathCheck.resolved,
+            Buffer.from(img.dataBase64, "base64"),
+            { flag: "wx" },
+          );
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+            continue;
+          }
+          throw error;
+        }
+        savedPaths.push(relPath);
+        written = true;
+        break;
       }
-      await Bun.write(
-        join(workingDir, relPath),
-        Buffer.from(img.dataBase64, "base64"),
-      );
-      savedPaths.push(relPath);
+      if (!written) {
+        throw new Error(
+          `Could not find a free filename for "${slug}.${ext}" after ${MAX_FILENAME_ATTEMPTS} attempts.`,
+        );
+      }
     }
   } catch (error) {
     return { savedPaths, saveError: (error as Error).message };
@@ -181,7 +211,7 @@ export async function run(
     });
 
     const imageCount = result.images.length;
-    const { savedPaths, saveError } = await saveGeneratedImages(
+    const { savedPaths, saveError } = saveGeneratedImages(
       result.images,
       prompt,
       context.workingDir,

--- a/clients/docs/src/app/docs/_components/skills-reference-image-studio-content.tsx
+++ b/clients/docs/src/app/docs/_components/skills-reference-image-studio-content.tsx
@@ -156,9 +156,10 @@ A Gemini API key is required. If one isn&apos;t configured, your assistant will
               a preference.
             </li>
             <li>
-              <strong>File delivery:</strong> Generated images are delivered as attachments in chat.
-              You can also ask your assistant to save them to a specific folder on your machine
-              (requires file access permission).
+              <strong>File delivery:</strong> Generated images appear inline in your assistant&rsquo;s
+              reply and are saved in its workspace, so you can refer back to them or ask for edits
+              later. You can also ask your assistant to save them to a specific folder on your
+              machine (requires file access permission).
             </li>
           </ul>
         </section>

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -27,7 +27,7 @@
     },
     "image-studio": {
       "docsSlug": "image-studio",
-      "sha256": "7a122d409ca7146fcaac4452d8f8dcd11b4f1e702f5079cd0472da992211a1c5"
+      "sha256": "53a3c4669dda0ed8a2d0080c2ca52200429db0bd33a570581915cc5804feb51a"
     },
     "media-processing": {
       "docsSlug": "media-processing",


### PR DESCRIPTION
## Why

Generated images always surface as a detached attachment chip at the end of the assistant's reply. The model cannot present them inline with `![description](vellum://workspace/...)` because `media_generate_image` returns only base64 content blocks with no file path, so there is no path to embed. Worse, the image-studio SKILL.md claims images "are not written to disk automatically", which is false: the daemon persists them into the conversation's attachments directory, and assistants repeat that false claim to users when asked.

## What

1. **Executor** (`media-generate-image.ts`): saves each generated image under `media/generated/` in the workspace (slug from the provider title or the prompt, collision-suffixed), and the tool result now lists the saved paths plus an explicit instruction to present the image with `![description](vellum://workspace/<path>)` and to iterate via `source_paths`. A workspace write failure degrades to the previous inline-only behavior instead of failing the tool.
2. **SKILL.md**: replaces the incorrect output-handling section with the real contract (saved paths, inline embed preferred, auto-attach as fallback) and updates the completion criterion.
3. **TOOLS.json**: tool description now mentions the returned paths and the embed syntax.

The end-of-turn auto-attach of tool-result media is intentionally unchanged: it remains the safety net when the model does not embed. `deduplicateDrafts` already collapses the embedded copy and the tool-block copy by content hash, so nothing attaches twice.

Downstream this composes with existing channel delivery: `vellum://` embeds are extracted into attachments and delivered as native uploads on Slack/Telegram/WhatsApp/Discord, with `stripVellumLinks` removing the markdown from the channel text.

## Testing

- `bun test src/__tests__/media-generate-image.test.ts`: 36 pass, including new coverage for the saved path + embed instruction in the result, title-derived and collision-suffixed filenames, per-variant filenames, byte-exact file content, and the write-failure fallback.
- `bun run typecheck:fast` and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40770" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->