### PR TITLE
feat(providers): send billing-origin headers on managed inference calls

### DIFF
--- a/assistant/src/__tests__/btw-routes.test.ts
+++ b/assistant/src/__tests__/btw-routes.test.ts
@@ -156,6 +156,7 @@ function makeMockSession(
 ) {
   const provider = providerOverride ?? makeMockProvider();
   return {
+    conversationId: "conv-test-123",
     provider,
     systemPrompt: "You are a helpful assistant.",
     processing: false,
@@ -333,6 +334,39 @@ describe("POST /v1/btw", () => {
     expect(options!.config!.tool_choice).toEqual({ type: "none" });
     expect(options!.config!.callSite).toBe("identityIntro");
     expect(options!.config!.modelIntent).toBeUndefined();
+  });
+
+  // A keyed request runs against a persisted conversation, so its spend joins
+  // that conversation's; without the id the call bills as conversationless.
+  test("mapped keys pass the resolved conversation id on the send config", async () => {
+    const provider = makeMockProvider();
+    const session = makeMockSession(provider);
+    mockGetOrCreateConversation.mockImplementationOnce(async () => session);
+
+    const { result } = await callHandler({
+      conversationKey: "key",
+      content: "hello",
+    });
+    await readStream(result as ReadableStream<Uint8Array>);
+
+    const [, options] = provider.sendMessage.mock.calls[0];
+    expect(options!.config!.conversationId).toBe("conv-test-123");
+  });
+
+  test("unmapped keys stay conversationless", async () => {
+    mockGetConversationByKey.mockImplementationOnce(() => null);
+    const provider = makeMockProvider();
+    const session = makeMockSession(provider);
+    mockGetOrCreateConversation.mockImplementationOnce(async () => session);
+
+    const { result } = await callHandler({
+      conversationKey: "profile-intro",
+      content: "Generate an intro",
+    });
+    await readStream(result as ReadableStream<Uint8Array>);
+
+    const [, options] = provider.sendMessage.mock.calls[0];
+    expect(options!.config!.conversationId).toBeUndefined();
   });
 
   test("greeting requests pass callSite: 'emptyStateGreeting'", async () => {

--- a/assistant/src/__tests__/compaction-events.test.ts
+++ b/assistant/src/__tests__/compaction-events.test.ts
@@ -157,7 +157,7 @@ let mockCompactResult: ContextWindowResult = {
 // before delegating to the manager.
 const updateConfigCalls: Array<{ maxInputTokens?: number }> = [];
 
-// Options the manager's `maybeCompact` received — the compaction pipeline
+// Options the manager's `maybeCompact` received: the compaction pipeline
 // forwards the caller's billing origin through them onto the summary call.
 const managerCompactOptions: Array<{ usageOriginSnapshot?: unknown }> = [];
 
@@ -194,7 +194,7 @@ mock.module("../plugins/defaults/compaction/window-manager.js", () => ({
   getSummaryFromContextMessage: () => null,
 }));
 
-// Ledger rows written for the compaction summary call — the cron run id on
+// Ledger rows written for the compaction summary call: the cron run id on
 // them is what attributes a scheduled wake's compaction to its firing.
 const recordedUsageEvents: Array<{
   actor: string;

--- a/assistant/src/__tests__/compaction-events.test.ts
+++ b/assistant/src/__tests__/compaction-events.test.ts
@@ -157,6 +157,10 @@ let mockCompactResult: ContextWindowResult = {
 // before delegating to the manager.
 const updateConfigCalls: Array<{ maxInputTokens?: number }> = [];
 
+// Options the manager's `maybeCompact` received — the compaction pipeline
+// forwards the caller's billing origin through them onto the summary call.
+const managerCompactOptions: Array<{ usageOriginSnapshot?: unknown }> = [];
+
 mock.module("../plugins/defaults/compaction/window-manager.js", () => ({
   ContextWindowManager: class {
     estimateInputTokens() {
@@ -173,7 +177,12 @@ mock.module("../plugins/defaults/compaction/window-manager.js", () => ({
     shouldCompact() {
       return { needed: false, estimatedTokens: 0 };
     }
-    async maybeCompact(): Promise<ContextWindowResult> {
+    async maybeCompact(
+      _messages: Message[],
+      _signal?: AbortSignal,
+      options?: { usageOriginSnapshot?: unknown },
+    ): Promise<ContextWindowResult> {
+      managerCompactOptions.push(options ?? {});
       return mockCompactResult;
     }
     resetOverflowRecovery() {}
@@ -185,8 +194,18 @@ mock.module("../plugins/defaults/compaction/window-manager.js", () => ({
   getSummaryFromContextMessage: () => null,
 }));
 
+// Ledger rows written for the compaction summary call — the cron run id on
+// them is what attributes a scheduled wake's compaction to its firing.
+const recordedUsageEvents: Array<{
+  actor: string;
+  cronRunId: string | null;
+}> = [];
+
 mock.module("../persistence/llm-usage-store.js", () => ({
-  recordUsageEvent: () => ({ id: "mock-id", createdAt: Date.now() }),
+  recordUsageEvent: (event: { actor: string; cronRunId: string | null }) => {
+    recordedUsageEvents.push(event);
+    return { id: "mock-id", createdAt: Date.now() };
+  },
   listUsageEvents: () => [],
 }));
 
@@ -217,6 +236,7 @@ mock.module("../agent/loop.js", () => ({
 // ---------------------------------------------------------------------------
 
 import { Conversation } from "../daemon/conversation.js";
+import { buildUsageOriginSnapshot } from "../usage/work-origin.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -550,6 +570,65 @@ describe("maybeCompact gate sizing", () => {
     expect(updateConfigCalls.map((cfg) => cfg.maxInputTokens)).toEqual([
       100000, 50000,
     ]);
+  });
+
+  // A wake fired by a schedule compacts before its run, and the conversation
+  // it fires in stays standard/user, so the firing on the turn's snapshot is
+  // the only thing that keeps the summary call's spend attributed to the
+  // schedule.
+  test("forwards the caller's billing origin to the summary call and the usage row", async () => {
+    mockCompactResult = {
+      messages: [],
+      compacted: true,
+      previousEstimatedInputTokens: 150_000,
+      estimatedInputTokens: 80_000,
+      maxInputTokens: 200_000,
+      thresholdTokens: 160_000,
+      compactedMessages: 10,
+      compactedPersistedMessages: 5,
+      summaryCalls: 1,
+      summaryInputTokens: 500,
+      summaryOutputTokens: 200,
+      summaryModel: "test-model",
+      summaryText: "summary text",
+    };
+    const snapshot = buildUsageOriginSnapshot({
+      conversationType: "standard",
+      conversationSource: "user",
+      callSite: "mainAgent",
+      conversationId: "conv-compact-origin",
+      turnIndex: 3,
+      parentConversationId: null,
+      parentTurnIndex: null,
+      cronRunId: "cron-run-1",
+    });
+    const conversation = makeConversation([], "conv-compact-origin");
+
+    managerCompactOptions.length = 0;
+    recordedUsageEvents.length = 0;
+    await conversation.maybeCompact({ callSite: "mainAgent" }, snapshot);
+
+    expect(managerCompactOptions).toHaveLength(1);
+    expect(managerCompactOptions[0]!.usageOriginSnapshot).toBe(snapshot);
+    const compactorRows = recordedUsageEvents.filter(
+      (event) => event.actor === "context_compactor",
+    );
+    expect(compactorRows).toHaveLength(1);
+    expect(compactorRows[0]!.cronRunId).toBe("cron-run-1");
+  });
+
+  test("records no firing on a compaction with no billing origin", async () => {
+    mockCompactResult = { ...mockCompactResult, compacted: true };
+    const conversation = makeConversation([], "conv-compact-origin-absent");
+
+    recordedUsageEvents.length = 0;
+    await conversation.maybeCompact();
+
+    const compactorRows = recordedUsageEvents.filter(
+      (event) => event.actor === "context_compactor",
+    );
+    expect(compactorRows).toHaveLength(1);
+    expect(compactorRows[0]!.cronRunId).toBeNull();
   });
 
   test("forceCompact keeps mainAgent sizing", async () => {

--- a/assistant/src/__tests__/compactor-call-site-logging.test.ts
+++ b/assistant/src/__tests__/compactor-call-site-logging.test.ts
@@ -56,6 +56,7 @@ import type {
   Provider,
   SendMessageOptions,
 } from "../providers/types.js";
+import { buildUsageOriginSnapshot } from "../usage/work-origin.js";
 
 const TAIL_TIMESTAMP =
   "2026-05-21 (Thursday) 10:00:00 -05:00 (America/Chicago)";
@@ -181,6 +182,43 @@ describe("compactor records llm_request_logs with call_site=compactionAgent", ()
     expect(recordRequestLogCalls[0]!.responsePayload).toBe(
       JSON.stringify(RAW_RESPONSE),
     );
+  });
+
+  test("carries the turn's usage-origin snapshot onto the summary call", async () => {
+    // A wake or defer firing inside a standard user conversation shows up
+    // only as a cron run id, so the turn snapshot is what makes a mid-turn
+    // compaction bill as schedule-driven rather than interactive work.
+    const snapshot = buildUsageOriginSnapshot({
+      conversationType: "standard",
+      conversationSource: "user",
+      callSite: "mainAgent",
+      conversationId: "conv-compaction-log-1",
+      turnIndex: 2,
+      parentConversationId: null,
+      parentTurnIndex: null,
+      cronRunId: "cron-run-1",
+    });
+
+    await runAssistantDrivenCompaction({
+      ...args(makeProvider()),
+      usageOriginSnapshot: snapshot,
+    });
+
+    expect(lastSendOptions?.config?.usageOriginSnapshot).toBe(snapshot);
+    expect(lastSendOptions?.config?.usageOriginSnapshot?.workOrigin).toBe(
+      "user_created_schedule",
+    );
+    // The conversation id still rides alongside for the standalone paths that
+    // have no snapshot.
+    expect(lastSendOptions?.config?.conversationId).toBe(
+      "conv-compaction-log-1",
+    );
+  });
+
+  test("omits the snapshot key when the caller supplies none", async () => {
+    await runAssistantDrivenCompaction(args(makeProvider()));
+
+    expect(lastSendOptions?.config?.usageOriginSnapshot).toBeUndefined();
   });
 
   test("skips persistence when provider returns no rawRequest/rawResponse", async () => {

--- a/assistant/src/__tests__/compactor-call-site-logging.test.ts
+++ b/assistant/src/__tests__/compactor-call-site-logging.test.ts
@@ -51,7 +51,11 @@ mock.module("../persistence/llm-request-log-store.js", () => ({
 }));
 
 import { runAssistantDrivenCompaction } from "../context/compactor.js";
-import type { Message, Provider } from "../providers/types.js";
+import type {
+  Message,
+  Provider,
+  SendMessageOptions,
+} from "../providers/types.js";
 
 const TAIL_TIMESTAMP =
   "2026-05-21 (Thursday) 10:00:00 -05:00 (America/Chicago)";
@@ -73,18 +77,24 @@ Earlier turns summarized here.
 const RAW_REQUEST = { model: "mock-model", messages: [] };
 const RAW_RESPONSE = { id: "resp-1", content: compactionResponse };
 
+/** Options the most recent makeProvider sendMessage call received. */
+let lastSendOptions: SendMessageOptions | undefined;
+
 function makeProvider(): Provider {
   return {
     name: "mock-provider",
-    sendMessage: async () => ({
-      content: [{ type: "text", text: compactionResponse }],
-      model: "mock-model",
-      actualProvider: "actual-mock-provider",
-      usage: { inputTokens: 100, outputTokens: 50 },
-      stopReason: "end_turn",
-      rawRequest: RAW_REQUEST,
-      rawResponse: RAW_RESPONSE,
-    }),
+    sendMessage: async (_messages, options) => {
+      lastSendOptions = options;
+      return {
+        content: [{ type: "text", text: compactionResponse }],
+        model: "mock-model",
+        actualProvider: "actual-mock-provider",
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: "end_turn",
+        rawRequest: RAW_REQUEST,
+        rawResponse: RAW_RESPONSE,
+      };
+    },
   };
 }
 
@@ -151,6 +161,12 @@ describe("compactor records llm_request_logs with call_site=compactionAgent", ()
   test("successful compaction call stamps call_site = compactionAgent", async () => {
     await runAssistantDrivenCompaction(args(makeProvider()));
 
+    // The send config carries the conversation id so the billing-origin
+    // fallback attributes the call to the same conversation the manual
+    // usage recording does.
+    expect(lastSendOptions?.config?.conversationId).toBe(
+      "conv-compaction-log-1",
+    );
     expect(recordRequestLogCalls.length).toBe(1);
     expect(recordRequestLogCalls[0]!.callSite).toBe("compactionAgent");
     expect(recordRequestLogCalls[0]!.conversationId).toBe(

--- a/assistant/src/__tests__/conversation-lifecycle.test.ts
+++ b/assistant/src/__tests__/conversation-lifecycle.test.ts
@@ -135,6 +135,50 @@ function defaultConv() {
   };
 }
 
+// Cache warming is a managed LLM call like any other. Without the conversation
+// on its config the provider layer derives conversationless `other_system`
+// billing origin for spend caused by a specific conversation.
+describe("Conversation prompt cache warming", () => {
+  test("attributes the warming call to its own conversation", async () => {
+    const sentConfigs: Array<Record<string, unknown>> = [];
+    const provider = {
+      name: "mock",
+      sendMessage: async (
+        _messages: unknown,
+        options?: { config?: Record<string, unknown> },
+      ) => {
+        if (options?.config) {
+          sentConfigs.push(options.config);
+        }
+        return {
+          content: [],
+          model: "mock",
+          usage: { inputTokens: 0, outputTokens: 0 },
+          stopReason: "end_turn" as const,
+        };
+      },
+    };
+    const conv = new Conversation(
+      "conv-warm",
+      provider,
+      "system prompt",
+      () => {},
+      "/tmp",
+      { maxTokens: 4096 },
+    );
+
+    conv.warmPromptCache();
+    await Promise.resolve();
+
+    expect(sentConfigs).toHaveLength(1);
+    expect(sentConfigs[0]).toMatchObject({
+      callSite: "mainAgent",
+      usageTracking: "manual",
+      conversationId: "conv-warm",
+    });
+  });
+});
+
 describe("Conversation — subagent identity", () => {
   test("is not a subagent by default", () => {
     const conv = makeConversation();
@@ -153,9 +197,10 @@ describe("Conversation — subagent identity", () => {
 
   // A conversation rehydrated after eviction or a daemon restart is
   // constructed without a parent, so the row is the only place its spawn
-  // linkage survives. Losing it costs the billing-origin snapshot its
-  // parent-linkage headers while telemetry still resolves the parent.
-  test("loadFromDb hydrates the parent from the row and the snapshot carries it", async () => {
+  // linkage survives. The billing-origin snapshot reads the conversation's own
+  // metadata off the live object, so a rehydrated child still classifies as
+  // delegated work.
+  test("loadFromDb hydrates the parent and the source the snapshot classifies from", async () => {
     mockConversation = {
       ...defaultConv(),
       conversationType: "background",
@@ -171,8 +216,7 @@ describe("Conversation — subagent identity", () => {
     expect(conv.parentConversationId).toBe("parent-row");
     expect(conv.isSubagent).toBe(true);
 
-    const snapshot = buildTurnUsageOriginSnapshot(conv, "subagentSpawn");
-    expect(snapshot.parentConversationId).toBe("parent-row");
+    const snapshot = buildTurnUsageOriginSnapshot(conv, "subagentSpawn", null);
     expect(snapshot.conversationSource).toBe("subagent");
     expect(snapshot.workOrigin).toBe("delegated_child");
   });

--- a/assistant/src/__tests__/conversation-lifecycle.test.ts
+++ b/assistant/src/__tests__/conversation-lifecycle.test.ts
@@ -88,6 +88,7 @@ import {
   Conversation,
   type ConversationConstructorOptions,
 } from "../daemon/conversation.js";
+import { buildTurnUsageOriginSnapshot } from "../usage/usage-origin-snapshot.js";
 
 beforeEach(() => {
   lifecycleStoreMockActive = true;
@@ -148,6 +149,45 @@ describe("Conversation — subagent identity", () => {
     });
     expect(conv.parentConversationId).toBe("parent-1");
     expect(conv.isSubagent).toBe(true);
+  });
+
+  // A conversation rehydrated after eviction or a daemon restart is
+  // constructed without a parent, so the row is the only place its spawn
+  // linkage survives. Losing it costs the billing-origin snapshot its
+  // parent-linkage headers while telemetry still resolves the parent.
+  test("loadFromDb hydrates the parent from the row and the snapshot carries it", async () => {
+    mockConversation = {
+      ...defaultConv(),
+      conversationType: "background",
+      source: "subagent",
+      parentConversationId: "parent-row",
+    };
+    mockDbMessages = [];
+
+    const conv = makeConversation();
+    expect(conv.parentConversationId).toBeUndefined();
+    await conv.loadFromDb();
+
+    expect(conv.parentConversationId).toBe("parent-row");
+    expect(conv.isSubagent).toBe(true);
+
+    const snapshot = buildTurnUsageOriginSnapshot(conv, "subagentSpawn");
+    expect(snapshot.parentConversationId).toBe("parent-row");
+    expect(snapshot.conversationSource).toBe("subagent");
+    expect(snapshot.workOrigin).toBe("delegated_child");
+  });
+
+  test("loadFromDb leaves a construction-supplied parent in place", async () => {
+    mockConversation = { ...defaultConv(), parentConversationId: null };
+    mockDbMessages = [];
+
+    const conv = makeConversation({
+      maxTokens: 4096,
+      parentConversationId: "parent-live",
+    });
+    await conv.loadFromDb();
+
+    expect(conv.parentConversationId).toBe("parent-live");
   });
 });
 

--- a/assistant/src/__tests__/conversation-tool-setup-attribution.test.ts
+++ b/assistant/src/__tests__/conversation-tool-setup-attribution.test.ts
@@ -70,6 +70,7 @@ import {
   createToolExecutor,
   resolveConversationAttribution,
 } from "../daemon/conversation-tool-setup.js";
+import { buildUsageOriginSnapshot } from "../usage/work-origin.js";
 import { asConversation } from "./helpers/mock-conversation.js";
 import { setConfig } from "./helpers/set-config.js";
 
@@ -288,6 +289,32 @@ describe("createToolExecutor attribution threading", () => {
       appliedProfile: "active",
       profileSource: "active",
     });
+  });
+
+  // Tools that make their own LLM call (style analysis) stamp this onto their
+  // send config. Without it their spend is classified from the conversation
+  // row, which shows a scheduled turn as ordinary interactive work.
+  test("stamps the turn's billing origin onto the ToolContext", async () => {
+    const snapshot = buildUsageOriginSnapshot({
+      conversationType: "standard",
+      conversationSource: "user",
+      callSite: "mainAgent",
+      conversationId: "conv-test",
+      turnIndex: 2,
+      parentConversationId: null,
+      parentTurnIndex: null,
+      cronRunId: "cron-run-1",
+    });
+    const { executor, calls } = makeCapturingExecutor();
+    const toolFn = makeToolFn(
+      executor,
+      makeCtx({ currentTurnUsageOriginSnapshot: snapshot }),
+    );
+
+    await toolFn("file_read", { path: "/tmp/a" });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].context.usageOriginSnapshot).toBe(snapshot);
   });
 
   test("attribution resolution failure yields null and does not break tool execution", async () => {

--- a/assistant/src/__tests__/llm-usage-store.test.ts
+++ b/assistant/src/__tests__/llm-usage-store.test.ts
@@ -13,6 +13,7 @@ import {
   listUsageEvents,
   queryUnreportedUsageEvents,
   recordUsageEvent,
+  resolveSpawnAttribution,
 } from "../persistence/llm-usage-store.js";
 import type { PricingResult, UsageEventInput } from "../usage/types.js";
 
@@ -1761,6 +1762,90 @@ describe("countRealUserTurns", () => {
     expect(countRealUserTurns("conv-tr2")).toBe(1);
     const events = queryUnreportedUsageEvents(0, undefined, 100);
     expect(events[0].turnIndex).toBe(1);
+  });
+});
+
+// `resolveSpawnAttribution` and the flush query's `parent_conversation_id`
+// column are the same SQL expression, so the live billing-origin snapshot and
+// the telemetry row cannot disagree about who spawned a conversation.
+describe("resolveSpawnAttribution", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run(`DELETE FROM llm_usage_events`);
+    db.run(`DELETE FROM messages`);
+    db.run(`DELETE FROM conversations`);
+  });
+
+  /** Resolve the same conversation through the telemetry flush query. */
+  function telemetryParentFor(conversationId: string): string | null {
+    insertEventAt(9000, { conversationId });
+    const events = queryUnreportedUsageEvents(0, undefined, 100);
+    expect(events).toHaveLength(1);
+    return events[0].parentConversationId;
+  }
+
+  test("a subagent parent wins over a fork parent", () => {
+    getDb().run(
+      `INSERT INTO conversations (id, conversation_type, created_at, updated_at, parent_conversation_id, fork_parent_conversation_id)
+       VALUES ('child-1', 'background', 3000, 3000, 'parent-1', 'source-1')`,
+    );
+
+    expect(resolveSpawnAttribution("child-1").spawnParentConversationId).toBe(
+      "parent-1",
+    );
+    expect(telemetryParentFor("child-1")).toBe("parent-1");
+  });
+
+  test("a background fork falls back to the fork parent", () => {
+    getDb().run(
+      `INSERT INTO conversations (id, conversation_type, created_at, updated_at, fork_parent_conversation_id)
+       VALUES ('retro-1', 'background', 3000, 3000, 'source-1')`,
+    );
+
+    expect(resolveSpawnAttribution("retro-1").spawnParentConversationId).toBe(
+      "source-1",
+    );
+    expect(telemetryParentFor("retro-1")).toBe("source-1");
+  });
+
+  test("a standard (user-initiated) fork resolves no spawn parent", () => {
+    getDb().run(
+      `INSERT INTO conversations (id, conversation_type, created_at, updated_at, fork_parent_conversation_id)
+       VALUES ('user-fork', 'standard', 3000, 3000, 'source-1')`,
+    );
+
+    expect(
+      resolveSpawnAttribution("user-fork").spawnParentConversationId,
+    ).toBeNull();
+    expect(telemetryParentFor("user-fork")).toBeNull();
+  });
+
+  test("a missing conversation resolves to no parent and no cutoff", () => {
+    expect(resolveSpawnAttribution("conv-absent")).toEqual({
+      spawnParentConversationId: null,
+      cutoffCreatedAt: undefined,
+    });
+  });
+
+  test("the cutoff is child creation for a spawn and the fork boundary for a fork", () => {
+    const db = getDb();
+    db.run(
+      `INSERT INTO conversations (id, conversation_type, created_at, updated_at) VALUES ('source-2', 'standard', 500, 500)`,
+    );
+    db.run(
+      `INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES ('b1', 'source-2', 'user', 'boundary', 1200)`,
+    );
+    db.run(
+      `INSERT INTO conversations (id, conversation_type, created_at, updated_at, parent_conversation_id)
+       VALUES ('child-2', 'background', 3000, 3000, 'parent-2')`,
+    );
+    db.run(
+      `INSERT INTO conversations (id, conversation_type, created_at, updated_at, fork_parent_conversation_id, fork_parent_message_id)
+       VALUES ('retro-2', 'background', 4000, 4000, 'source-2', 'b1')`,
+    );
+
+    expect(resolveSpawnAttribution("child-2").cutoffCreatedAt).toBe(3000);
+    expect(resolveSpawnAttribution("retro-2").cutoffCreatedAt).toBe(1200);
   });
 });
 

--- a/assistant/src/__tests__/llm-usage-store.test.ts
+++ b/assistant/src/__tests__/llm-usage-store.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, test } from "bun:test";
 import { getDb, getSqlite } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import {
+  countRealUserTurns,
   getUsageDayBuckets,
   getUsageGroupBreakdown,
   getUsageGroupedSeries,
@@ -1672,6 +1673,96 @@ describe("getUsageGroupedSeries", () => {
 // ---------------------------------------------------------------------------
 // queryUnreportedUsageEvents tests
 // ---------------------------------------------------------------------------
+
+describe("countRealUserTurns", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run(`DELETE FROM llm_usage_events`);
+    db.run(`DELETE FROM messages`);
+    db.run(`DELETE FROM conversations`);
+  });
+
+  test("returns 0 for a conversation with no real user turns", () => {
+    expect(countRealUserTurns("conv-empty")).toBe(0);
+  });
+
+  // The billing-origin snapshot stamps `turnIndex = countRealUserTurns(...)` at
+  // agent-loop start, when a coalesced batch has already persisted all N user
+  // messages. It must equal the `turn_index` the telemetry read path computes
+  // for an LLM call fired during the same run: both count real user turns via
+  // `realUserTurnContentFilter`, so a batch of 3 reads 3 on both paths.
+  test("a batch of 3 user messages counts 3, matching telemetry's turn_index", () => {
+    const db = getDb();
+    const now = Date.now();
+    db.run(
+      `INSERT INTO conversations (id, conversation_type, created_at, updated_at) VALUES ('conv-batch', 'standard', ${now}, ${now})`,
+    );
+    // The coalesced batch: three real user messages persisted before the
+    // single agent-loop run's first LLM call.
+    db.run(
+      `INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES ('b1', 'conv-batch', 'user', 'one', 1000)`,
+    );
+    db.run(
+      `INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES ('b2', 'conv-batch', 'user', 'two', 1001)`,
+    );
+    db.run(
+      `INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES ('b3', 'conv-batch', 'user', 'three', 1002)`,
+    );
+    // The run's LLM call lands after the whole batch is persisted.
+    insertEventAt(2000, { conversationId: "conv-batch" });
+
+    expect(countRealUserTurns("conv-batch")).toBe(3);
+
+    const events = queryUnreportedUsageEvents(0, undefined, 100);
+    expect(events).toHaveLength(1);
+    // Snapshot turnIndex (countRealUserTurns) agrees with the telemetry row.
+    expect(events[0].turnIndex).toBe(3);
+    expect(events[0].turnIndex).toBe(countRealUserTurns("conv-batch"));
+  });
+
+  test("prior single turns plus a batch of 2 count as 3, matching telemetry", () => {
+    const db = getDb();
+    const now = Date.now();
+    db.run(
+      `INSERT INTO conversations (id, conversation_type, created_at, updated_at) VALUES ('conv-mix', 'standard', ${now}, ${now})`,
+    );
+    // One prior completed turn, then a 2-message batch.
+    db.run(
+      `INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES ('p1', 'conv-mix', 'user', 'prior', 1000)`,
+    );
+    db.run(
+      `INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES ('c1', 'conv-mix', 'user', 'batch a', 2000)`,
+    );
+    db.run(
+      `INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES ('c2', 'conv-mix', 'user', 'batch b', 2001)`,
+    );
+    insertEventAt(3000, { conversationId: "conv-mix" });
+
+    expect(countRealUserTurns("conv-mix")).toBe(3);
+    const events = queryUnreportedUsageEvents(0, undefined, 100);
+    expect(events[0].turnIndex).toBe(3);
+  });
+
+  test("skips tool_result continuation rows, matching telemetry", () => {
+    const db = getDb();
+    const now = Date.now();
+    db.run(
+      `INSERT INTO conversations (id, conversation_type, created_at, updated_at) VALUES ('conv-tr2', 'standard', ${now}, ${now})`,
+    );
+    db.run(
+      `INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES ('r1', 'conv-tr2', 'user', 'real text', 1000)`,
+    );
+    // Tool-result row persisted with role='user': a continuation, not a turn.
+    db.run(
+      `INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES ('t1', 'conv-tr2', 'user', '[{"type":"tool_result","tool_use_id":"x","content":""}]', 1500)`,
+    );
+    insertEventAt(2000, { conversationId: "conv-tr2" });
+
+    expect(countRealUserTurns("conv-tr2")).toBe(1);
+    const events = queryUnreportedUsageEvents(0, undefined, 100);
+    expect(events[0].turnIndex).toBe(1);
+  });
+});
 
 describe("queryUnreportedUsageEvents", () => {
   beforeEach(() => {

--- a/assistant/src/__tests__/provider-usage-tracking.test.ts
+++ b/assistant/src/__tests__/provider-usage-tracking.test.ts
@@ -6,6 +6,7 @@ import { listUsageEvents } from "../persistence/llm-usage-store.js";
 import { CallSiteConfiguredProvider } from "../providers/provider-send-message.js";
 import type { Provider, ProviderResponse } from "../providers/types.js";
 import { UsageTrackingProvider } from "../providers/usage-tracking.js";
+import { buildUsageOriginSnapshot } from "../usage/work-origin.js";
 import { setConfig } from "./helpers/set-config.js";
 
 await initializeDb();
@@ -120,6 +121,74 @@ describe("UsageTrackingProvider", () => {
       callSite: "conversationTitle",
       conversationId: "conv-123",
     });
+  });
+
+  // The turn's origin snapshot carries the schedule firing behind the call. A
+  // wake or defer schedule fires inside a conversation whose type and source
+  // stay standard, so the run id on the row is what makes the auto-recorded
+  // usage classify as schedule-driven, exactly as the billing headers do.
+  test("stamps the origin snapshot's cron run id on the recorded row", async () => {
+    const provider = new UsageTrackingProvider(
+      makeProvider({
+        content: [{ type: "text", text: "ok" }],
+        model: "gpt-5.4-mini",
+        usage: {
+          inputTokens: 1_000,
+          outputTokens: 2_000,
+        },
+        stopReason: "end_turn",
+      }),
+    );
+
+    await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Do the thing" }] }],
+      {
+        config: {
+          callSite: "conversationTitle",
+          conversationId: "conv-123",
+          usageOriginSnapshot: buildUsageOriginSnapshot({
+            conversationType: "standard",
+            conversationSource: "user",
+            callSite: "conversationTitle",
+            conversationId: "conv-123",
+            turnIndex: 1,
+            parentConversationId: null,
+            parentTurnIndex: null,
+            cronRunId: "cron-run-1",
+          }),
+        },
+      },
+    );
+
+    const events = listUsageEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      conversationId: "conv-123",
+      cronRunId: "cron-run-1",
+    });
+  });
+
+  test("records a null cron run id when the call carries no origin snapshot", async () => {
+    const provider = new UsageTrackingProvider(
+      makeProvider({
+        content: [{ type: "text", text: "ok" }],
+        model: "gpt-5.4-mini",
+        usage: {
+          inputTokens: 10,
+          outputTokens: 5,
+        },
+        stopReason: "end_turn",
+      }),
+    );
+
+    await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Summarize" }] }],
+      { config: { callSite: "conversationTitle" } },
+    );
+
+    const events = listUsageEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0].cronRunId).toBeNull();
   });
 
   test("uses the transport provider when resolved attribution points elsewhere", async () => {

--- a/assistant/src/__tests__/style-analyzer-usage-origin.test.ts
+++ b/assistant/src/__tests__/style-analyzer-usage-origin.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Pins that the style analyzer's LLM call carries the assistant conversation
+ * it runs under. `normalizeSendMessageOptions` derives billing-origin headers
+ * from `config.conversationId` when no explicit snapshot is stamped, so a send
+ * without it loses all conversation provenance.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+import type { SendMessageOptions } from "../providers/types.js";
+
+/** Options the stubbed provider's most recent sendMessage call received. */
+let lastSendOptions: SendMessageOptions | undefined;
+
+const analysisResponse = {
+  content: [
+    {
+      type: "tool_use",
+      id: "toolu_style",
+      name: "store_style_analysis",
+      input: {
+        style_patterns: [
+          { aspect: "tone", summary: "Warm and direct.", importance: 0.7 },
+        ],
+      },
+    },
+  ],
+  model: "test-model",
+  usage: { inputTokens: 10, outputTokens: 5 },
+  stopReason: "tool_use",
+};
+
+mock.module("../providers/provider-send-message.js", () => ({
+  getConfiguredProvider: async () => ({
+    name: "test-provider",
+    // `any` keeps the stub assignable to Provider without restating its shape.
+    sendMessage: async (_messages: any, options: any) => {
+      lastSendOptions = options;
+      return analysisResponse;
+    },
+  }),
+}));
+
+import type { Message as ProviderMessage } from "../messaging/provider-types.js";
+import { extractStylePatterns } from "../messaging/style-analyzer.js";
+
+function sentMessage(text: string): ProviderMessage {
+  return {
+    id: "msg-1",
+    conversationId: "thread-1",
+    sender: { id: "user-123", name: "Alice" },
+    text,
+    timestamp: 0,
+    platform: "gmail",
+  };
+}
+
+describe("extractStylePatterns billing origin", () => {
+  test("forwards the assistant conversation id on the send config", async () => {
+    await extractStylePatterns([sentMessage("Hi Bob, sounds good.")], {
+      conversationId: "conv-xyz",
+    });
+
+    expect(lastSendOptions?.config?.callSite).toBe("styleAnalyzer");
+    expect(lastSendOptions?.config?.conversationId).toBe("conv-xyz");
+  });
+});

--- a/assistant/src/__tests__/style-analyzer-usage-origin.test.ts
+++ b/assistant/src/__tests__/style-analyzer-usage-origin.test.ts
@@ -42,6 +42,7 @@ mock.module("../providers/provider-send-message.js", () => ({
 
 import type { Message as ProviderMessage } from "../messaging/provider-types.js";
 import { extractStylePatterns } from "../messaging/style-analyzer.js";
+import { buildUsageOriginSnapshot } from "../usage/work-origin.js";
 
 function sentMessage(text: string): ProviderMessage {
   return {
@@ -62,5 +63,42 @@ describe("extractStylePatterns billing origin", () => {
 
     expect(lastSendOptions?.config?.callSite).toBe("styleAnalyzer");
     expect(lastSendOptions?.config?.conversationId).toBe("conv-xyz");
+  });
+
+  // A schedule firing inside a conversation whose type and source stay
+  // standard/user is invisible to a row-derived classification, so the turn's
+  // snapshot is what keeps a scheduled analysis out of interactive spend.
+  test("carries the turn's origin when the analysis runs inside a scheduled turn", async () => {
+    const snapshot = buildUsageOriginSnapshot({
+      conversationType: "standard",
+      conversationSource: "user",
+      callSite: "mainAgent",
+      conversationId: "conv-xyz",
+      turnIndex: 4,
+      parentConversationId: null,
+      parentTurnIndex: null,
+      cronRunId: "cron-run-1",
+    });
+
+    await extractStylePatterns([sentMessage("Hi Bob, sounds good.")], {
+      conversationId: "conv-xyz",
+      usageOriginSnapshot: snapshot,
+    });
+
+    expect(lastSendOptions?.config?.usageOriginSnapshot).toBe(snapshot);
+    expect(lastSendOptions?.config?.usageOriginSnapshot?.workOrigin).toBe(
+      "user_created_schedule",
+    );
+    // The conversation id still rides alongside for callers running outside a
+    // turn, whose sends have no snapshot to classify from.
+    expect(lastSendOptions?.config?.conversationId).toBe("conv-xyz");
+  });
+
+  test("omits the snapshot key when the caller has no turn origin", async () => {
+    await extractStylePatterns([sentMessage("Hi Bob, sounds good.")], {
+      conversationId: "conv-xyz",
+    });
+
+    expect(lastSendOptions?.config?.usageOriginSnapshot).toBeUndefined();
   });
 });

--- a/assistant/src/__tests__/subagent-spawn-and-await.test.ts
+++ b/assistant/src/__tests__/subagent-spawn-and-await.test.ts
@@ -64,6 +64,21 @@ let lastTrustContext: unknown;
 /** Options the most recent `bootstrapConversation` call received. */
 let lastBootstrapOptions: Record<string, unknown> | undefined;
 
+/** The most recent FakeConversation the manager constructed. */
+let lastConversation: FakeConversation | undefined;
+
+function recordConversation(conversation: FakeConversation): void {
+  lastConversation = conversation;
+}
+
+/** Reads {@link lastConversation}, asserting the manager built one. */
+function takeLastConversation(): FakeConversation {
+  if (lastConversation === undefined) {
+    throw new Error("no conversation was constructed");
+  }
+  return lastConversation;
+}
+
 class FakeConversation {
   messages: Message[];
   usageStats = { inputTokens: 10, outputTokens: 5, estimatedCost: 0.001 };
@@ -74,6 +89,12 @@ class FakeConversation {
     filesWritten: new Set<string>(),
   };
   conversationType = "background";
+  /**
+   * Undefined until the manager caches it, mirroring the real `Conversation`,
+   * which fills `source` only in `loadFromDb` (never called for a subagent).
+   */
+  source?: string;
+  readonly conversationId: string;
   hasSystemPromptOverride = false;
 
   private sendToClient: (msg: AssistantEvent) => void;
@@ -82,16 +103,18 @@ class FakeConversation {
   private resolveAbort?: () => void;
 
   constructor(
-    _id: string,
+    id: string,
     _provider: unknown,
     _systemPrompt: string,
     sendToClient: (msg: AssistantEvent) => void,
     _workingDir: string,
     _options?: unknown,
   ) {
+    this.conversationId = id;
     this.sendToClient = sendToClient;
     this.cfg = nextConversationConfig;
     this.messages = this.cfg.messages ?? [];
+    recordConversation(this);
   }
 
   updateClient(sendToClient: (msg: AssistantEvent) => void) {
@@ -207,6 +230,10 @@ import {
   setConversation,
 } from "../daemon/conversation-registry.js";
 import { SubagentAbortedError, SubagentManager } from "../subagent/manager.js";
+import {
+  buildTurnUsageOriginSnapshot,
+  type ConversationUsageOriginContext,
+} from "../usage/usage-origin-snapshot.js";
 import { asConversation } from "./helpers/mock-conversation.js";
 
 function makeConfig(overrides: Record<string, unknown> = {}) {
@@ -654,6 +681,34 @@ describe("SubagentManager.spawn (fire-and-forget) — unaffected", () => {
 
     expect(typeof id).toBe("string");
     expect(id.length).toBeGreaterThan(0);
+  });
+
+  // The manager never calls `loadFromDb`, so anything the billing-origin
+  // snapshot reads off live state has to be cached at spawn. Without the
+  // cached source every managed subagent call omitted
+  // `X-Vellum-Conversation-Source` while its usage row reported "subagent".
+  test("spawn caches the persisted conversation source on the live conversation", async () => {
+    lastConversation = undefined;
+    nextConversationConfig = {
+      messages: [
+        { role: "assistant", content: [{ type: "text", text: "ok" }] },
+      ],
+    };
+
+    const manager = new SubagentManager();
+    await manager.spawn(makeConfig(), () => {});
+
+    const conversation = takeLastConversation();
+    expect(conversation.source).toBe("subagent");
+    // The live copy and the persisted row report one source.
+    expect(lastBootstrapOptions?.source).toBe(conversation.source);
+
+    const snapshot = buildTurnUsageOriginSnapshot(
+      conversation as ConversationUsageOriginContext,
+      "subagentSpawn",
+    );
+    expect(snapshot.conversationSource).toBe("subagent");
+    expect(snapshot.workOrigin).toBe("delegated_child");
   });
 
   test("spawn still injects a terminal notification into the parent", async () => {

--- a/assistant/src/__tests__/subagent-spawn-and-await.test.ts
+++ b/assistant/src/__tests__/subagent-spawn-and-await.test.ts
@@ -706,6 +706,7 @@ describe("SubagentManager.spawn (fire-and-forget) — unaffected", () => {
     const snapshot = buildTurnUsageOriginSnapshot(
       conversation as ConversationUsageOriginContext,
       "subagentSpawn",
+      null,
     );
     expect(snapshot.conversationSource).toBe("subagent");
     expect(snapshot.workOrigin).toBe("delegated_child");

--- a/assistant/src/__tests__/usage-origin-snapshot.test.ts
+++ b/assistant/src/__tests__/usage-origin-snapshot.test.ts
@@ -78,10 +78,9 @@ describe("buildTurnUsageOriginSnapshot", () => {
         conversationId: "conv-user",
         conversationType: "standard",
         source: "user",
-        parentConversationId: null,
-        forkParentConversationId: null,
       },
       "mainAgent",
+      null,
     );
 
     expect(snapshot.turnIndex).toBe(2);
@@ -111,10 +110,9 @@ describe("buildTurnUsageOriginSnapshot", () => {
         conversationId: "child-1",
         conversationType: "background",
         source: "subagent",
-        parentConversationId: "parent-1",
-        forkParentConversationId: null,
       },
       "subagentSpawn",
+      null,
     );
 
     expect(snapshot.parentConversationId).toBe("parent-1");
@@ -148,10 +146,9 @@ describe("buildTurnUsageOriginSnapshot", () => {
         conversationId: "retro-1",
         conversationType: "background",
         source: "memory-retrospective-fork",
-        parentConversationId: null,
-        forkParentConversationId: "source-1",
       },
       "memoryRetrospective",
+      null,
     );
 
     expect(snapshot.parentConversationId).toBe("source-1");
@@ -187,10 +184,9 @@ describe("buildTurnUsageOriginSnapshot", () => {
         conversationId: "retro-2",
         conversationType: "background",
         source: "memory-retrospective-fork",
-        parentConversationId: null,
-        forkParentConversationId: "source-3",
       },
       "memoryRetrospective",
+      null,
     );
 
     expect(snapshot.parentConversationId).toBe("source-3");
@@ -203,8 +199,13 @@ describe("buildTurnUsageOriginSnapshot", () => {
   });
 
   test("user-initiated (standard) fork does not inherit fork-parent attribution", () => {
+    const db = getDb();
     insertConversation("source-2");
-    insertConversation("user-fork");
+    // A user-initiated fork stamps the same fork lineage a retrospective does,
+    // but stays a first-class standard conversation whose spend is its own.
+    db.run(
+      `INSERT INTO conversations (id, conversation_type, created_at, updated_at, fork_parent_conversation_id) VALUES ('user-fork', 'standard', 2000, 2000, 'source-2')`,
+    );
     insertUserMessage("s1", "source-2", 1000);
     insertUserMessage("f1", "user-fork", 2000);
 
@@ -213,14 +214,37 @@ describe("buildTurnUsageOriginSnapshot", () => {
         conversationId: "user-fork",
         conversationType: "standard",
         source: "user",
-        parentConversationId: null,
-        forkParentConversationId: "source-2",
       },
       "mainAgent",
+      null,
     );
 
     expect(snapshot.parentConversationId).toBeNull();
     expect(snapshot.parentTurnIndex).toBeNull();
     expect(snapshot.workOrigin).toBe("user_interactive");
+  });
+
+  // A wake or defer schedule fires inside a conversation whose persisted type
+  // and source stay standard/user, so the firing's run id is the only signal
+  // that the turn is schedule-driven. Both the billing headers and the
+  // auto-recorded usage row must see it.
+  test("a schedule firing classifies a standard conversation as user_created_schedule", () => {
+    insertConversation("conv-wake");
+    insertUserMessage("w1", "conv-wake", 1000);
+
+    const snapshot = buildTurnUsageOriginSnapshot(
+      {
+        conversationId: "conv-wake",
+        conversationType: "standard",
+        source: "user",
+      },
+      "mainAgent",
+      "cron-run-1",
+    );
+
+    expect(snapshot.cronRunId).toBe("cron-run-1");
+    expect(snapshot.workOrigin).toBe("user_created_schedule");
+    expect(snapshot.conversationType).toBe("standard");
+    expect(snapshot.conversationSource).toBe("user");
   });
 });

--- a/assistant/src/__tests__/usage-origin-snapshot.test.ts
+++ b/assistant/src/__tests__/usage-origin-snapshot.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { getDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import {
+  queryUnreportedUsageEvents,
+  recordUsageEvent,
+} from "../persistence/llm-usage-store.js";
+import type { PricingResult, UsageEventInput } from "../usage/types.js";
+import { buildTurnUsageOriginSnapshot } from "../usage/usage-origin-snapshot.js";
+
+await initializeDb();
+
+const priced: PricingResult = {
+  estimatedCostUsd: 0.001,
+  pricingStatus: "priced",
+};
+
+function makeInput(conversationId: string): UsageEventInput {
+  return {
+    provider: "anthropic",
+    model: "claude-sonnet-4-20250514",
+    inputTokens: 100,
+    outputTokens: 50,
+    cacheCreationInputTokens: null,
+    cacheReadInputTokens: null,
+    rawUsage: null,
+    actor: "main_agent",
+    conversationId,
+    runId: null,
+    requestId: null,
+  };
+}
+
+/** Record one usage event on a conversation at a specific created_at. */
+function insertEventAt(timestamp: number, conversationId: string): void {
+  const event = recordUsageEvent(makeInput(conversationId), priced);
+  getDb().run(
+    `UPDATE llm_usage_events SET created_at = ${timestamp} WHERE id = '${event.id}'`,
+  );
+}
+
+function insertConversation(
+  id: string,
+  conversationType = "standard",
+  createdAt = 0,
+): void {
+  getDb().run(
+    `INSERT OR IGNORE INTO conversations (id, conversation_type, created_at, updated_at) VALUES ('${id}', '${conversationType}', ${createdAt}, ${createdAt})`,
+  );
+}
+
+function insertUserMessage(
+  id: string,
+  conversationId: string,
+  createdAt: number,
+): void {
+  getDb().run(
+    `INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES ('${id}', '${conversationId}', 'user', 'text', ${createdAt})`,
+  );
+}
+
+describe("buildTurnUsageOriginSnapshot", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run(`DELETE FROM llm_usage_events`);
+    db.run(`DELETE FROM messages`);
+    db.run(`DELETE FROM conversations`);
+  });
+
+  test("top-level user conversation: turnIndex counted, parentTurnIndex null", () => {
+    insertConversation("conv-user");
+    insertUserMessage("u1", "conv-user", 1000);
+    insertUserMessage("u2", "conv-user", 2000);
+
+    const snapshot = buildTurnUsageOriginSnapshot(
+      {
+        conversationId: "conv-user",
+        conversationType: "standard",
+        source: "user",
+        parentConversationId: null,
+        forkParentConversationId: null,
+      },
+      "mainAgent",
+    );
+
+    expect(snapshot.turnIndex).toBe(2);
+    expect(snapshot.parentConversationId).toBeNull();
+    expect(snapshot.parentTurnIndex).toBeNull();
+    expect(snapshot.workOrigin).toBe("user_interactive");
+  });
+
+  // A subagent's background conversation carries the live subagent parent. Its
+  // parentTurnIndex counts the PARENT conversation's real user turns, matching
+  // the telemetry read path, which counts the same population up to the child's
+  // creation. At snapshot time the parent's turns already exist, so counting
+  // them all equals telemetry's cutoff count.
+  test("subagent child: parentTurnIndex counts the parent's turns and agrees with telemetry", () => {
+    const db = getDb();
+    insertConversation("parent-1");
+    insertUserMessage("p1", "parent-1", 1000);
+    insertUserMessage("p2", "parent-1", 2000);
+    db.run(
+      `INSERT INTO conversations (id, conversation_type, created_at, updated_at, parent_conversation_id) VALUES ('child-1', 'background', 3000, 3000, 'parent-1')`,
+    );
+    insertUserMessage("c1", "child-1", 3100);
+    insertEventAt(4000, "child-1");
+
+    const snapshot = buildTurnUsageOriginSnapshot(
+      {
+        conversationId: "child-1",
+        conversationType: "background",
+        source: "subagent",
+        parentConversationId: "parent-1",
+        forkParentConversationId: null,
+      },
+      "subagentSpawn",
+    );
+
+    expect(snapshot.parentConversationId).toBe("parent-1");
+    expect(snapshot.turnIndex).toBe(1);
+    expect(snapshot.parentTurnIndex).toBe(2);
+    expect(snapshot.workOrigin).toBe("delegated_child");
+
+    // Telemetry resolves the same parent and counts the same population.
+    const events = queryUnreportedUsageEvents(0, undefined, 100);
+    expect(events).toHaveLength(1);
+    expect(events[0].parentConversationId).toBe("parent-1");
+    expect(events[0].parentTurnIndex).toBe(snapshot.parentTurnIndex);
+  });
+
+  // A retrospective fork is a background conversation with no live subagent
+  // parent; its spawn parent is the source via fork_parent_conversation_id. The
+  // parentTurnIndex counts the SOURCE's real user turns.
+  test("retrospective fork: resolves the fork parent and counts its turns", () => {
+    const db = getDb();
+    insertConversation("source-1");
+    insertUserMessage("s1", "source-1", 1000);
+    insertUserMessage("s2", "source-1", 2000);
+    // Fork through the latest source message (s2), as real retrospectives do.
+    db.run(
+      `INSERT INTO conversations (id, conversation_type, created_at, updated_at, fork_parent_conversation_id, fork_parent_message_id) VALUES ('retro-1', 'background', 3000, 3000, 'source-1', 's2')`,
+    );
+    insertEventAt(4000, "retro-1");
+
+    const snapshot = buildTurnUsageOriginSnapshot(
+      {
+        conversationId: "retro-1",
+        conversationType: "background",
+        source: "memory-retrospective-fork",
+        parentConversationId: null,
+        forkParentConversationId: "source-1",
+      },
+      "memoryRetrospective",
+    );
+
+    expect(snapshot.parentConversationId).toBe("source-1");
+    expect(snapshot.parentTurnIndex).toBe(2);
+    expect(snapshot.workOrigin).toBe("delegated_child");
+
+    const events = queryUnreportedUsageEvents(0, undefined, 100);
+    expect(events[0].parentConversationId).toBe("source-1");
+    expect(events[0].parentTurnIndex).toBe(snapshot.parentTurnIndex);
+  });
+
+  test("user-initiated (standard) fork does not inherit fork-parent attribution", () => {
+    insertConversation("source-2");
+    insertConversation("user-fork");
+    insertUserMessage("s1", "source-2", 1000);
+    insertUserMessage("f1", "user-fork", 2000);
+
+    const snapshot = buildTurnUsageOriginSnapshot(
+      {
+        conversationId: "user-fork",
+        conversationType: "standard",
+        source: "user",
+        parentConversationId: null,
+        forkParentConversationId: "source-2",
+      },
+      "mainAgent",
+    );
+
+    expect(snapshot.parentConversationId).toBeNull();
+    expect(snapshot.parentTurnIndex).toBeNull();
+    expect(snapshot.workOrigin).toBe("user_interactive");
+  });
+});

--- a/assistant/src/__tests__/usage-origin-snapshot.test.ts
+++ b/assistant/src/__tests__/usage-origin-snapshot.test.ts
@@ -163,6 +163,45 @@ describe("buildTurnUsageOriginSnapshot", () => {
     expect(events[0].parentTurnIndex).toBe(snapshot.parentTurnIndex);
   });
 
+  // A retrospective fork branches through a boundary message captured before
+  // the fork runs, and the source conversation keeps taking user turns in the
+  // meantime. Both surfaces must name the turn the fork branched from, so the
+  // count stops at the boundary message rather than at the source's turns to
+  // date.
+  test("retrospective fork: parentTurnIndex stops at the fork boundary, not the source's later turns", () => {
+    const db = getDb();
+    insertConversation("source-3");
+    insertUserMessage("e1", "source-3", 1000);
+    insertUserMessage("e2", "source-3", 2000);
+    // The fork branches through e2, then the source gains two more real user
+    // turns before the fork's wake records usage.
+    db.run(
+      `INSERT INTO conversations (id, conversation_type, created_at, updated_at, fork_parent_conversation_id, fork_parent_message_id) VALUES ('retro-2', 'background', 3000, 3000, 'source-3', 'e2')`,
+    );
+    insertUserMessage("e3", "source-3", 4000);
+    insertUserMessage("e4", "source-3", 5000);
+    insertEventAt(6000, "retro-2");
+
+    const snapshot = buildTurnUsageOriginSnapshot(
+      {
+        conversationId: "retro-2",
+        conversationType: "background",
+        source: "memory-retrospective-fork",
+        parentConversationId: null,
+        forkParentConversationId: "source-3",
+      },
+      "memoryRetrospective",
+    );
+
+    expect(snapshot.parentConversationId).toBe("source-3");
+    // Two turns existed at the boundary; the source now has four.
+    expect(snapshot.parentTurnIndex).toBe(2);
+
+    const events = queryUnreportedUsageEvents(0, undefined, 100);
+    expect(events).toHaveLength(1);
+    expect(events[0].parentTurnIndex).toBe(snapshot.parentTurnIndex);
+  });
+
   test("user-initiated (standard) fork does not inherit fork-parent attribution", () => {
     insertConversation("source-2");
     insertConversation("user-fork");

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -906,6 +906,7 @@ export class AgentLoop {
     overrideProfile: string | null,
     isNonInteractive: boolean,
     modelProfileKey: string,
+    usageOriginSnapshot: UsageOriginSnapshot | undefined,
     overflowSignal?: { actualTokens: number | null; isInteractive: boolean },
   ): Promise<CompactionAttempt> {
     const compactionId = crypto.randomUUID();
@@ -931,8 +932,11 @@ export class AgentLoop {
     // from the turn's trust snapshot (the actor whose turn triggered
     // compaction) so the compactor's image manifest excludes guardian-only
     // attachments for untrusted actors. `overrideProfile` is the turn's
-    // resolved inference-profile override for the summary call. `overflowSignal`
-    // routes the request through the reduction ladder when present.
+    // resolved inference-profile override for the summary call.
+    // `usageOriginSnapshot` is the turn's billing origin, so a mid-turn
+    // compaction bills against the work that triggered it rather than being
+    // classified from the conversation row alone. `overflowSignal` routes the
+    // request through the reduction ladder when present.
     const compactResult = await defaultCompact({
       conversationId: this.conversationId,
       messages: history,
@@ -940,6 +944,7 @@ export class AgentLoop {
       force: true,
       actorTrustClass: trust.trustClass,
       overrideProfile,
+      usageOriginSnapshot,
       overflowSignal,
     });
     // `force: true` bypasses the auto-threshold gate, but early returns
@@ -1316,6 +1321,7 @@ export class AgentLoop {
                   resolveEffectiveOverrideProfile() ?? null,
                   isNonInteractive,
                   options.modelProfileKey,
+                  usageOriginSnapshot,
                   overflowSignal ?? undefined,
                 );
                 if (attempt.history) {

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -49,6 +49,7 @@ import {
   applyStreamingSubstitution,
   applySubstitutions,
 } from "../tools/sensitive-output-placeholders.js";
+import type { UsageOriginSnapshot } from "../usage/work-origin.js";
 import { ProviderError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import { CompactionCircuit } from "./compaction-circuit.js";
@@ -629,6 +630,14 @@ interface AgentLoopRunOptionsBase {
     mark(name: string): void;
     markFirstToken(kind: "thinking" | "text"): void;
   };
+  /**
+   * Immutable record-time usage attribution for every LLM call this run emits,
+   * built once by the conversation orchestrator from the turn's conversation
+   * metadata and call site. Threaded onto each send's `SendMessageConfig` so
+   * `RetryProvider` can forward it as billing-origin headers on the managed
+   * proxy. Absent for standalone loop runs with no conversation attribution.
+   */
+  usageOriginSnapshot?: UsageOriginSnapshot;
 }
 
 interface AgentLoopRunOptionsWithContextWindow extends AgentLoopRunOptionsBase {
@@ -1011,6 +1020,7 @@ export class AgentLoop {
       isNonInteractive = false,
       model: runModel,
       latencyTracker,
+      usageOriginSnapshot,
     } = options;
     // Snapshot the system prompt once per run. The instance field is mutable
     // (the conversation may update it between turns), but a single run must
@@ -1476,6 +1486,15 @@ export class AgentLoop {
             providerConfig.selectionSeed = this.conversationId;
             providerConfig.conversationId = this.conversationId;
           }
+        }
+
+        // Immutable record-time usage attribution, riding the same per-call
+        // config as `callSite` and `selectionSeed`. `RetryProvider` maps it to
+        // the billing-origin headers on the managed-proxy path and strips it
+        // before the wire request; it is stripped (and harmless) on every other
+        // transport.
+        if (usageOriginSnapshot) {
+          providerConfig.usageOriginSnapshot = usageOriginSnapshot;
         }
 
         // Per-call inference-profile override. The resolver layers

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-analyze-style.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-analyze-style.ts
@@ -95,7 +95,7 @@ function upsertMemoryItem(opts: {
 
 export async function run(
   input: Record<string, unknown>,
-  _context: ToolContext,
+  context: ToolContext,
 ): Promise<ToolExecutionResult> {
   const platform = input.platform as string | undefined;
   const maxMessages = Math.min(
@@ -121,7 +121,9 @@ export async function run(
       );
     }
 
-    const result = await extractStylePatterns(searchResult.messages);
+    const result = await extractStylePatterns(searchResult.messages, {
+      conversationId: context.conversationId,
+    });
 
     if (result.stylePatterns.length === 0) {
       return err("No style patterns were extracted. Try with more messages.");

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-analyze-style.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-analyze-style.ts
@@ -123,6 +123,7 @@ export async function run(
 
     const result = await extractStylePatterns(searchResult.messages, {
       conversationId: context.conversationId,
+      usageOriginSnapshot: context.usageOriginSnapshot,
     });
 
     if (result.stylePatterns.length === 0) {

--- a/assistant/src/context/compactor.ts
+++ b/assistant/src/context/compactor.ts
@@ -1273,6 +1273,10 @@ export async function runAssistantDrivenCompaction(
       signal: args.signal,
       config: {
         callSite: COMPACTION_CALL_SITE,
+        // Billing-origin attribution: the fallback in `RetryProvider` derives
+        // origin headers from this id, matching the conversation the manual
+        // usage recording below attributes the call to.
+        conversationId: args.conversationId,
         usageTracking: "manual",
         tool_choice: { type: "none" },
         ...(args.overrideProfile
@@ -1743,6 +1747,8 @@ export async function runEmergencyCompaction(
       signal: args.signal,
       config: {
         callSite: COMPACTION_CALL_SITE,
+        // Billing-origin attribution, matching the assistant-driven path.
+        conversationId: args.conversationId,
         usageTracking: "manual",
         tool_choice: { type: "none" },
         ...(args.overrideProfile

--- a/assistant/src/context/compactor.ts
+++ b/assistant/src/context/compactor.ts
@@ -39,6 +39,7 @@ import type {
 } from "../providers/types.js";
 import { type TrustClass } from "../runtime/actor-trust-resolver.js";
 import { resolveCapabilities } from "../runtime/capabilities.js";
+import type { UsageOriginSnapshot } from "../usage/work-origin.js";
 import { getLogger } from "../util/logger.js";
 import { preModelCallSanitize } from "./outbound-sanitize.js";
 import { stripInjectionsForCompaction } from "./strip-injections.js";
@@ -263,6 +264,16 @@ export interface CompactionRunArgs {
   force?: boolean;
   signal?: AbortSignal;
   overrideProfile?: string | null;
+  /**
+   * Billing-origin attribution for the turn compaction runs inside, forwarded
+   * onto the summary call's provider config. A compaction that fires mid-turn
+   * inherits the turn's own origin, including the schedule firing behind a
+   * wake or defer whose conversation type and source stay standard/user and
+   * would otherwise classify as interactive work. Absent on standalone
+   * compaction (`/compact`, lifecycle paths) that runs outside a turn, where
+   * the conversation id alone drives the row-derived fallback.
+   */
+  usageOriginSnapshot?: UsageOriginSnapshot;
   /**
    * Trust class of the actor whose turn triggered compaction. When the
    * actor is untrusted, the image manifest is filtered to exclude
@@ -1273,10 +1284,15 @@ export async function runAssistantDrivenCompaction(
       signal: args.signal,
       config: {
         callSite: COMPACTION_CALL_SITE,
-        // Billing-origin attribution: the fallback in `RetryProvider` derives
-        // origin headers from this id, matching the conversation the manual
-        // usage recording below attributes the call to.
+        // Billing-origin attribution. The turn's snapshot wins when compaction
+        // runs inside one, carrying its turn indexes and schedule provenance.
+        // Without it the fallback in `RetryProvider` derives origin headers
+        // from this id, matching the conversation the manual usage recording
+        // below attributes the call to.
         conversationId: args.conversationId,
+        ...(args.usageOriginSnapshot
+          ? { usageOriginSnapshot: args.usageOriginSnapshot }
+          : {}),
         usageTracking: "manual",
         tool_choice: { type: "none" },
         ...(args.overrideProfile
@@ -1749,6 +1765,9 @@ export async function runEmergencyCompaction(
         callSite: COMPACTION_CALL_SITE,
         // Billing-origin attribution, matching the assistant-driven path.
         conversationId: args.conversationId,
+        ...(args.usageOriginSnapshot
+          ? { usageOriginSnapshot: args.usageOriginSnapshot }
+          : {}),
         usageTracking: "manual",
         tool_choice: { type: "none" },
         ...(args.overrideProfile

--- a/assistant/src/daemon/__tests__/turn-tail-deleted-conversation.test.ts
+++ b/assistant/src/daemon/__tests__/turn-tail-deleted-conversation.test.ts
@@ -53,6 +53,7 @@ function makeConversation(): ConversationRow {
     source: "user",
     originChannel: null,
     originInterface: null,
+    parentConversationId: null,
     forkParentConversationId: null,
     forkParentMessageId: null,
     forkStrategy: null,

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -469,16 +469,6 @@ export async function runAgentLoopImpl(
   // injection assembly self-resolves it for the turn's plugin contexts.
   ctx.currentCallSite = turnCallSite;
 
-  // Immutable record-time usage attribution for every LLM call this turn emits,
-  // carrying the same work-origin classification the `llm_usage` telemetry
-  // derives, so managed billing rows and usage telemetry share one vocabulary.
-  // Both turn indexes count the same real-user-turn population the telemetry
-  // read path counts, and the spawn-parent precedence matches the telemetry
-  // `parentIdSql`, so a retrospective fork classifies as `delegated_child` and
-  // carries its parent turn index on both paths. The wake path builds the
-  // identical snapshot through the same helper.
-  const usageOriginSnapshot = buildTurnUsageOriginSnapshot(ctx, turnCallSite);
-
   // Expose the turn's request origin (e.g. "memory_consolidation") on the live
   // conversation so the tool context — and through it `buildPolicyContext` —
   // can scope narrow non-interactive permission auto-grants to a specific
@@ -489,6 +479,22 @@ export async function runAgentLoopImpl(
   // conversation) so a reused conversation attributes each turn to its own
   // firing.
   const turnCronRunId = options?.cronRunId ?? null;
+
+  // Immutable record-time usage attribution for every LLM call this turn emits,
+  // carrying the same work-origin classification the `llm_usage` telemetry
+  // derives, so managed billing rows and usage telemetry share one vocabulary.
+  // Both turn indexes count the same real-user-turn population the telemetry
+  // read path counts, and the spawn parent comes from the same expression the
+  // telemetry read path reads, so a retrospective fork classifies as
+  // `delegated_child` and carries its parent turn index on both paths. The
+  // firing's run id classifies a wake or defer schedule that fired inside an
+  // ordinary conversation. The wake path builds the identical snapshot through
+  // the same helper.
+  const usageOriginSnapshot = buildTurnUsageOriginSnapshot(
+    ctx,
+    turnCallSite,
+    turnCronRunId,
+  );
 
   // Optional per-turn inference-profile override. Plumbed through to every
   // LLM call the loop emits and inherited by any subagents spawned during

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -80,6 +80,7 @@ import {
   startToolProfilingRequest,
 } from "../tools/tool-profiler.js";
 import type { UsageActor } from "../usage/actors.js";
+import { buildTurnUsageOriginSnapshot } from "../usage/usage-origin-snapshot.js";
 import { getLogger } from "../util/logger.js";
 import { timeAgo } from "../util/time.js";
 import { getWorkspaceGitService } from "../workspace/git-service.js";
@@ -467,6 +468,16 @@ export async function runAgentLoopImpl(
   // Expose the turn's call site on the live conversation so the runtime
   // injection assembly self-resolves it for the turn's plugin contexts.
   ctx.currentCallSite = turnCallSite;
+
+  // Immutable record-time usage attribution for every LLM call this turn emits,
+  // carrying the same work-origin classification the `llm_usage` telemetry
+  // derives, so managed billing rows and usage telemetry share one vocabulary.
+  // Both turn indexes count the same real-user-turn population the telemetry
+  // read path counts, and the spawn-parent precedence matches the telemetry
+  // `parentIdSql`, so a retrospective fork classifies as `delegated_child` and
+  // carries its parent turn index on both paths. The wake path builds the
+  // identical snapshot through the same helper.
+  const usageOriginSnapshot = buildTurnUsageOriginSnapshot(ctx, turnCallSite);
 
   // Expose the turn's request origin (e.g. "memory_consolidation") on the live
   // conversation so the tool context — and through it `buildPolicyContext` —
@@ -1327,6 +1338,7 @@ export async function runAgentLoopImpl(
           isNonInteractive,
           modelProfileKey,
           latencyTracker,
+          usageOriginSnapshot,
           ...(ctx.modelOverride ? { model: ctx.modelOverride } : {}),
         }),
         abortController.signal,

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -665,6 +665,12 @@ export async function runAgentLoopImpl(
   // or message) stamps the delegated usage with this firing.
   ctx.currentTurnCronRunId = turnCronRunId;
 
+  // Mirrored for the same reason as the firing above, one level up: a tool that
+  // makes its own LLM call (style analysis) reads the turn's whole origin off
+  // the tool context, so its send carries this turn's work origin instead of a
+  // classification derived from the conversation row.
+  ctx.currentTurnUsageOriginSnapshot = usageOriginSnapshot;
+
   // Capture the turn channel context *before* any awaits so a second
   // message from a different channel can't overwrite it mid-flight.
   // When context is unavailable (e.g. regenerate after daemon restart),
@@ -818,6 +824,7 @@ export async function runAgentLoopImpl(
     ctx.preactivatedSkillIds = undefined;
     ctx.currentTurnOverrideProfile = undefined;
     ctx.currentTurnCronRunId = undefined;
+    ctx.currentTurnUsageOriginSnapshot = undefined;
     ctx.currentTurnModelProfileNoticeKey = undefined;
     // Turn-scoped interactivity. Clear it so paths that bypass this loop
     // (e.g. opportunity wakes calling `agentLoop.run` directly) don't inherit

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -432,6 +432,7 @@ export function createToolExecutor(
       transportInterface: ctx.transportInterface,
       overrideProfile: ctx.currentTurnOverrideProfile,
       cronRunId: ctx.currentTurnCronRunId,
+      usageOriginSnapshot: ctx.currentTurnUsageOriginSnapshot,
       invokingCallSite: ctx.currentCallSite ?? "mainAgent",
       attribution: resolveConversationAttribution(ctx),
       enabledPluginSet: effectiveEnabledPluginSet,

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -462,15 +462,29 @@ export class Conversation {
     return this.currentTurnIsNonInteractive ?? true;
   }
   /**
-   * For subagent conversations, the id of the parent that spawned this one; set
-   * once at construction and never reassigned. `undefined` for top-level
-   * conversations. It is the single source of truth for {@link isSubagent} and
-   * the authoritative (non-writable) routing target for child → parent
-   * notifications — as opposed to the durable subagent record, which lives under
-   * the sandbox workspace and could be tampered with by a sandbox-tool subagent.
+   * For subagent conversations, the id of the parent that spawned this one.
+   * `undefined` for top-level conversations. It is the single source of truth
+   * for {@link isSubagent} and the authoritative (non-writable) routing target
+   * for child to parent notifications, as opposed to the durable subagent
+   * record, which lives under the sandbox workspace and could be tampered with
+   * by a sandbox-tool subagent.
+   *
+   * A live spawn supplies it at construction. A conversation rehydrated after
+   * eviction or a daemon restart takes it from
+   * `conversations.parent_conversation_id` in {@link loadFromDb}, so its
+   * billing-origin snapshot keeps the parent linkage the row records. The
+   * construction value wins when both are present: the spawning process is the
+   * authority on the parent it just passed, and it is the same value it wrote
+   * to the row.
+   *
+   * Read-only to callers: the accessor has no setter, so the two writes above
+   * remain the only ones.
    * @internal
    */
-  readonly parentConversationId?: string;
+  get parentConversationId(): string | undefined {
+    return this.parentConversationIdValue;
+  }
+  private parentConversationIdValue?: string;
   /** @internal */ headlessLock = false;
   /** @internal */ taskRunId?: string;
   /** @internal */ callSessionId?: string;
@@ -785,7 +799,7 @@ export class Conversation {
     const { maxTokens, speedOverride, cacheTtl, modelOverride } = options ?? {};
     const enableNativeWebSearch = options?.enableNativeWebSearch ?? false;
     this.conversationId = conversationId;
-    this.parentConversationId = options?.parentConversationId;
+    this.parentConversationIdValue = options?.parentConversationId;
     this.systemPrompt = systemPrompt;
     this.provider = provider;
     this.workingDir = workingDir;
@@ -1084,6 +1098,7 @@ export class Conversation {
     this.originInterface = parseInterfaceId(conv?.originInterface) ?? undefined;
     this.originChannel = parseChannelId(conv?.originChannel) ?? undefined;
     this.source = conv?.source ?? undefined;
+    this.parentConversationIdValue ??= conv?.parentConversationId ?? undefined;
     this.forkParentConversationId = conv?.forkParentConversationId ?? undefined;
     this.contextSummary = conv?.contextSummary ?? null;
     this.slackContextCompactionWatermarkTs =

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -1052,6 +1052,11 @@ export class Conversation {
           max_tokens: 1,
           callSite: "mainAgent",
           usageTracking: "manual",
+          // Attribution only: the managed transport derives this call's
+          // billing-origin headers from the conversation it warms the cache
+          // for, so the warming spend lands on that conversation rather than
+          // reading as conversationless system work.
+          conversationId: this.conversationId,
         },
         signal: abort.signal,
       })

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -571,6 +571,15 @@ export class Conversation {
    * @internal
    */
   source?: string;
+  /**
+   * The source conversation this one was forked from
+   * (`conversations.fork_parent_conversation_id`), cached on load so the
+   * usage-attribution snapshot can resolve a background fork's spawn parent
+   * (retrospective forks) without a per-turn DB row read. Undefined when the
+   * conversation is not a fork.
+   * @internal
+   */
+  forkParentConversationId?: string;
   /** @internal */ assistantId?: string;
   /** @internal */ commandIntent?: {
     type: string;
@@ -1075,6 +1084,7 @@ export class Conversation {
     this.originInterface = parseInterfaceId(conv?.originInterface) ?? undefined;
     this.originChannel = parseChannelId(conv?.originChannel) ?? undefined;
     this.source = conv?.source ?? undefined;
+    this.forkParentConversationId = conv?.forkParentConversationId ?? undefined;
     this.contextSummary = conv?.contextSummary ?? null;
     this.slackContextCompactionWatermarkTs =
       conv?.slackContextCompactionWatermarkTs ?? null;

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -93,6 +93,7 @@ import type { SubagentState } from "../subagent/types.js";
 import { ToolExecutor } from "../tools/executor.js";
 import { getAllToolDefinitions } from "../tools/registry.js";
 import type { OnboardingContext } from "../types/onboarding-context.js";
+import type { UsageOriginSnapshot } from "../usage/work-origin.js";
 import type { AbortReason } from "../util/abort-reasons.js";
 import { UserError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
@@ -543,6 +544,15 @@ export class Conversation {
    * @internal
    */
   currentTurnCronRunId?: string | null;
+  /**
+   * Immutable billing-origin attribution of the turn currently running, as
+   * built by `buildTurnUsageOriginSnapshot`. Exposed on the live
+   * conversation so the tool context can forward it to LLM calls a tool makes
+   * on its own (style analysis and the like), which then carry the turn's own
+   * work origin instead of a classification derived from the conversation row.
+   * @internal
+   */
+  currentTurnUsageOriginSnapshot?: UsageOriginSnapshot;
   /** @internal */ currentTurnIsNonInteractive?: boolean;
   /** @internal */ currentTurnModelProfileNoticeKey?: string;
   /** @internal */ currentTurnRequestOrigin?: string;
@@ -2336,14 +2346,20 @@ export class Conversation {
    * `sizing` lets a wake thread its own call-site/profile resolution into
    * the gate's context-window sizing — see {@link CompactionSizing}. Absent,
    * the gate sizes against `mainAgent` (the live-turn behavior).
+   *
+   * `usageOriginSnapshot` is the billing origin of the turn this gate runs
+   * ahead of. The summary call and the compaction usage row both carry it, so
+   * a scheduled wake's compaction attributes to the firing rather than
+   * classifying from the conversation row as ordinary interactive spend.
    */
   async maybeCompact(
     sizing?: CompactionSizing,
+    usageOriginSnapshot?: UsageOriginSnapshot,
   ): Promise<ContextWindowResult | null> {
     if (await this.agentLoop.compactionCircuit.isOpen()) {
       return null;
     }
-    return this.runCompaction(false, sizing);
+    return this.runCompaction(false, sizing, { usageOriginSnapshot });
   }
 
   /**
@@ -2360,6 +2376,9 @@ export class Conversation {
    * this pipeline derives row-exact persisted and Slack watermarks against
    * the cut the compactor actually used (the requested cut may retreat to
    * keep tool_use/tool_result pairs together).
+   * `opts.usageOriginSnapshot` is the billing origin of the turn compaction
+   * runs inside, forwarded to the summary call and stamped onto the
+   * compaction usage row.
    */
   private async runCompaction(
     force: boolean,
@@ -2371,6 +2390,7 @@ export class Conversation {
         rows: MessageRow[];
         firstRowByHistoryIndex: (number | null)[];
       };
+      usageOriginSnapshot?: UsageOriginSnapshot;
     },
   ): Promise<ContextWindowResult> {
     const overrideProfile = resolveOverrideProfile(this) ?? null;
@@ -2433,6 +2453,7 @@ export class Conversation {
       actorTrustClass: this.trustContext?.trustClass,
       fixedTailStartIndex: opts?.fixedTailStartIndex,
       fixedBoundaryRowIndex: opts?.fixedBoundaryRowIndex,
+      usageOriginSnapshot: opts?.usageOriginSnapshot,
     });
     // Row-exact watermark accounting for a caller-fixed boundary, derived
     // from the cut the compactor ACTUALLY used (`result.compactedMessages`
@@ -2491,6 +2512,7 @@ export class Conversation {
     }
     if (result.compacted) {
       await applyCompactionResult(this, result, this.emit, null, {
+        cronRunId: opts?.usageOriginSnapshot?.cronRunId ?? null,
         slackContextCompactionWatermarkTs:
           fixedBoundarySlackWatermarkTs ??
           getSlackCompactionWatermarkForPrefix(

--- a/assistant/src/messaging/style-analyzer.ts
+++ b/assistant/src/messaging/style-analyzer.ts
@@ -115,10 +115,15 @@ function buildCorpus(messages: ProviderMessage[]): string[] {
 
 /**
  * Extract writing style patterns from a corpus of messages using an LLM.
- * Platform-agnostic — works with messages from any messaging provider.
+ * Platform-agnostic: works with messages from any messaging provider.
+ *
+ * `options.conversationId` is the assistant conversation the analysis runs
+ * under. It rides the send config so the call carries the same billing-origin
+ * attribution as the rest of that conversation's spend.
  */
 export async function extractStylePatterns(
   messages: ProviderMessage[],
+  options?: { conversationId?: string | null },
 ): Promise<StyleAnalysisResult> {
   const corpusEntries = buildCorpus(messages);
   if (corpusEntries.length === 0) {
@@ -145,11 +150,15 @@ export async function extractStylePatterns(
     },
   ];
 
+  const conversationId = options?.conversationId;
   const response = await provider.sendMessage(promptMessages, {
     tools: [storeStyleAnalysisTool],
     systemPrompt: STYLE_EXTRACTION_SYSTEM_PROMPT,
     signal: AbortSignal.timeout(30_000),
-    config: { callSite: "styleAnalyzer" },
+    config: {
+      callSite: "styleAnalyzer",
+      ...(conversationId ? { conversationId } : {}),
+    },
   });
 
   const toolBlock = response.content.find((b) => b.type === "tool_use");

--- a/assistant/src/messaging/style-analyzer.ts
+++ b/assistant/src/messaging/style-analyzer.ts
@@ -8,6 +8,7 @@
 
 import { getConfiguredProvider } from "../providers/provider-send-message.js";
 import type { Message, ToolDefinition } from "../providers/types.js";
+import type { UsageOriginSnapshot } from "../usage/work-origin.js";
 import { truncate } from "../util/truncate.js";
 import type { Message as ProviderMessage } from "./provider-types.js";
 
@@ -120,10 +121,19 @@ function buildCorpus(messages: ProviderMessage[]): string[] {
  * `options.conversationId` is the assistant conversation the analysis runs
  * under. It rides the send config so the call carries the same billing-origin
  * attribution as the rest of that conversation's spend.
+ *
+ * `options.usageOriginSnapshot` is the origin of the turn that asked for the
+ * analysis, when there is one. It states the work origin outright, so a
+ * schedule-driven turn's analysis attributes to the firing instead of being
+ * classified from the conversation row as interactive spend. The conversation
+ * id stays the fallback for callers running outside a turn.
  */
 export async function extractStylePatterns(
   messages: ProviderMessage[],
-  options?: { conversationId?: string | null },
+  options?: {
+    conversationId?: string | null;
+    usageOriginSnapshot?: UsageOriginSnapshot;
+  },
 ): Promise<StyleAnalysisResult> {
   const corpusEntries = buildCorpus(messages);
   if (corpusEntries.length === 0) {
@@ -151,6 +161,7 @@ export async function extractStylePatterns(
   ];
 
   const conversationId = options?.conversationId;
+  const usageOriginSnapshot = options?.usageOriginSnapshot;
   const response = await provider.sendMessage(promptMessages, {
     tools: [storeStyleAnalysisTool],
     systemPrompt: STYLE_EXTRACTION_SYSTEM_PROMPT,
@@ -158,6 +169,7 @@ export async function extractStylePatterns(
     config: {
       callSite: "styleAnalyzer",
       ...(conversationId ? { conversationId } : {}),
+      ...(usageOriginSnapshot ? { usageOriginSnapshot } : {}),
     },
   });
 

--- a/assistant/src/notifications/__tests__/assistant-reply-producer.test.ts
+++ b/assistant/src/notifications/__tests__/assistant-reply-producer.test.ts
@@ -133,6 +133,7 @@ function makeConversation(
     source: "user",
     originChannel: null,
     originInterface: null,
+    parentConversationId: null,
     forkParentConversationId: null,
     forkParentMessageId: null,
     forkStrategy: null,

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -618,6 +618,8 @@ export interface ConversationRow {
   source: string;
   originChannel: string | null;
   originInterface: string | null;
+  /** Spawning conversation for a subagent child; null for every other conversation. */
+  parentConversationId: string | null;
   forkParentConversationId: string | null;
   forkParentMessageId: string | null;
   /** `"reference"` on referential forks; `"cloning"` or null on copied ones. */
@@ -660,6 +662,7 @@ export const parseConversation = createRowMapper<
   source: "source",
   originChannel: "originChannel",
   originInterface: "originInterface",
+  parentConversationId: "parentConversationId",
   forkParentConversationId: "forkParentConversationId",
   forkParentMessageId: "forkParentMessageId",
   forkStrategy: "forkStrategy",

--- a/assistant/src/persistence/llm-usage-store.ts
+++ b/assistant/src/persistence/llm-usage-store.ts
@@ -21,7 +21,7 @@ import {
   type ScheduleAttributionFilter,
   type ScheduleAttributionSqlParam,
 } from "./schedule-attribution-sql.js";
-import { conversations, llmUsageEvents } from "./schema/index.js";
+import { conversations, llmUsageEvents, messages } from "./schema/index.js";
 import {
   bucketEventsByDay,
   bucketEventsByHour,
@@ -133,6 +133,44 @@ export function recordUsageEvent(
     })
     .run();
   return event;
+}
+
+/**
+ * Count a conversation's real user turns: `role='user'` rows that survive
+ * {@link realUserTurnContentFilter}, so tool-result continuations persisted
+ * under the user role are excluded.
+ *
+ * This is the same population the `turn_index` and `parent_turn_index`
+ * correlated subqueries in {@link queryUnreportedUsageEvents} count, shared
+ * through that one filter. The live billing-origin snapshot stamps its
+ * `turnIndex` from here at agent-loop start, so it agrees with the `turn_index`
+ * the telemetry read path later derives for the same call: a coalesced batch of
+ * N user messages persists all N rows before the single agent-loop run, and the
+ * processing lock keeps a further real user turn from landing until that run
+ * finishes.
+ *
+ * Best-effort, like {@link lookupConversationAttribution}: a query failure
+ * degrades to 0 rather than throwing, so a billing-attribution detail can never
+ * abort the user's turn. Returns 0 for a conversation with no real user turn
+ * yet.
+ */
+export function countRealUserTurns(conversationId: string): number {
+  try {
+    const row = getDb()
+      .select({ count: sql<number>`COUNT(*)` })
+      .from(messages)
+      .where(
+        and(
+          eq(messages.conversationId, conversationId),
+          eq(messages.role, "user"),
+          realUserTurnContentFilter("messages"),
+        ),
+      )
+      .get();
+    return row?.count ? Number(row.count) : 0;
+  } catch {
+    return 0;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -312,6 +350,12 @@ export function queryUnreportedUsageEvents(
   // conversations whose usage belongs to themselves, not the source turn.
   // Null when the LEFT JOIN below misses or the conversation has no
   // parent.
+  //
+  // Agreement contract: `resolveSpawnParentConversationId`
+  // (`usage/work-origin.ts`) implements this exact precedence for the live
+  // billing-origin snapshot, so the managed billing headers and this telemetry
+  // row name the same spawn parent for the same conversation. Change one and
+  // change the other.
   const parentIdSql = sql<string | null>`COALESCE(
     ${conversations.parentConversationId},
     CASE WHEN ${conversations.conversationType} = 'background'

--- a/assistant/src/persistence/llm-usage-store.ts
+++ b/assistant/src/persistence/llm-usage-store.ts
@@ -192,7 +192,7 @@ export function countRealUserTurns(
  * child creation is the fallback when the boundary message is absent.
  *
  * One definition, two readers: the `parent_turn_index` subquery in
- * {@link queryUnreportedUsageEvents} and {@link resolveParentTurnCutoff}, which
+ * {@link queryUnreportedUsageEvents} and {@link resolveSpawnAttribution}, which
  * serves the live billing-origin snapshot. Both name the same cutoff for the
  * same conversation, so the managed billing header and the telemetry row report
  * the same parent turn for one call.
@@ -207,24 +207,76 @@ const PARENT_TURN_CUTOFF_SQL = sql<number>`CASE
 END`;
 
 /**
- * Resolve the {@link PARENT_TURN_CUTOFF_SQL} cutoff for one child conversation,
- * for bounding a live {@link countRealUserTurns} of its spawn parent.
+ * Id of the conversation that spawned this one, as a `conversations`
+ * expression.
  *
- * Best-effort: a missing row or a failed read returns undefined, which leaves
- * the caller counting the parent's turns to date rather than failing the call.
+ * Precedence, highest first:
+ *   1. `parent_conversation_id`, the subagent-spawn parent,
+ *   2. `fork_parent_conversation_id`, but only for a `background` conversation
+ *      (retrospective forks), so a fork's spend is attributed to the delegating
+ *      turn,
+ *   3. null, meaning the conversation was not spawned by another.
+ *
+ * The `background` gate on rule 2 matters: user-initiated forks also stamp
+ * `fork_parent_conversation_id`, but they are first-class `standard`
+ * conversations whose spend belongs to themselves.
+ *
+ * One definition, two readers: the `parent_conversation_id` column of
+ * {@link queryUnreportedUsageEvents} and {@link resolveSpawnAttribution}, which
+ * serves the live billing-origin snapshot. Both name the same spawn parent for
+ * the same conversation, so the managed billing headers and the telemetry row
+ * agree about who owns the cost.
  */
-export function resolveParentTurnCutoff(
+const SPAWN_PARENT_ID_SQL = sql<string | null>`COALESCE(
+  ${conversations.parentConversationId},
+  CASE WHEN ${conversations.conversationType} = 'background'
+    THEN ${conversations.forkParentConversationId}
+  END
+)`;
+
+/** Spawn lineage of one child conversation, as the snapshot path needs it. */
+export interface SpawnAttribution {
+  /** {@link SPAWN_PARENT_ID_SQL} for this conversation. */
+  spawnParentConversationId: string | null;
+  /**
+   * {@link PARENT_TURN_CUTOFF_SQL} for this conversation, for bounding a
+   * {@link countRealUserTurns} of the spawn parent. Undefined when unresolvable,
+   * which counts the parent's turns to date.
+   */
+  cutoffCreatedAt: number | undefined;
+}
+
+/**
+ * Resolve one child conversation's spawn lineage from its `conversations` row:
+ * the spawn parent and the cutoff that bounds the parent's turn count.
+ *
+ * Both columns behind this are stamped when the conversation is created
+ * (`bootstrapConversation`), before any turn of it runs, so a live turn's
+ * snapshot reads the same values the telemetry read path later resolves for the
+ * same conversation.
+ *
+ * Best-effort: a missing row or a failed read resolves to no parent and no
+ * cutoff, degrading the snapshot to no parent linkage rather than failing the
+ * call.
+ */
+export function resolveSpawnAttribution(
   childConversationId: string,
-): number | undefined {
+): SpawnAttribution {
   try {
     const row = getDb()
-      .select({ cutoff: PARENT_TURN_CUTOFF_SQL })
+      .select({
+        spawnParentConversationId: SPAWN_PARENT_ID_SQL,
+        cutoff: PARENT_TURN_CUTOFF_SQL,
+      })
       .from(conversations)
       .where(eq(conversations.id, childConversationId))
       .get();
-    return row?.cutoff == null ? undefined : Number(row.cutoff);
+    return {
+      spawnParentConversationId: row?.spawnParentConversationId ?? null,
+      cutoffCreatedAt: row?.cutoff == null ? undefined : Number(row.cutoff),
+    };
   } catch {
-    return undefined;
+    return { spawnParentConversationId: null, cutoffCreatedAt: undefined };
   }
 }
 
@@ -397,26 +449,8 @@ export function queryUnreportedUsageEvents(
   limit: number,
 ): UnreportedUsageEvent[] {
   const db = getTelemetryMainDb();
-  // Spawn linkage: `parent_conversation_id` (subagent spawns) with a
-  // fallback to `fork_parent_conversation_id` (retrospective forks — one
-  // hop up the fork chain is the intended attribution). The fallback is
-  // gated to background conversations: user-initiated forks also stamp
-  // `fork_parent_conversation_id` but are first-class standard
-  // conversations whose usage belongs to themselves, not the source turn.
-  // Null when the LEFT JOIN below misses or the conversation has no
-  // parent.
-  //
-  // Agreement contract: `resolveSpawnParentConversationId`
-  // (`usage/work-origin.ts`) implements this exact precedence for the live
-  // billing-origin snapshot, so the managed billing headers and this telemetry
-  // row name the same spawn parent for the same conversation. Change one and
-  // change the other.
-  const parentIdSql = sql<string | null>`COALESCE(
-    ${conversations.parentConversationId},
-    CASE WHEN ${conversations.conversationType} = 'background'
-      THEN ${conversations.forkParentConversationId}
-    END
-  )`;
+  // Spawn linkage comes from the shared `SPAWN_PARENT_ID_SQL` expression, and
+  // is null when the LEFT JOIN below misses or the conversation has no parent.
   // The turn-index subqueries below count user-role rows only. User rows are
   // always written finalized (only assistant turns stream), so no completeness
   // predicate is needed; do not copy this shape for assistant-row counts.
@@ -486,7 +520,7 @@ export function queryUnreportedUsageEvents(
         )
         END
       )`.as("turn_index"),
-      parentConversationId: parentIdSql.as("parent_conversation_id"),
+      parentConversationId: SPAWN_PARENT_ID_SQL.as("parent_conversation_id"),
       // The parent turn this child conversation branched from: count of
       // the PARENT conversation's real user turns with `created_at <=`
       // the cutoff (child creation for subagent spawns, fork boundary
@@ -498,10 +532,10 @@ export function queryUnreportedUsageEvents(
       subagentRole: conversations.subagentRole,
       subagentSpawnMode: conversations.subagentSpawnMode,
       parentTurnIndex: sql<number | null>`(
-        CASE WHEN ${parentIdSql} IS NULL THEN NULL
+        CASE WHEN ${SPAWN_PARENT_ID_SQL} IS NULL THEN NULL
         ELSE (
           SELECT COUNT(*) FROM messages AS m3
-          WHERE m3.conversation_id = ${parentIdSql}
+          WHERE m3.conversation_id = ${SPAWN_PARENT_ID_SQL}
             AND m3.role = 'user'
             AND ${realUserTurnContentFilter("m3")}
             AND m3.created_at <= ${PARENT_TURN_CUTOFF_SQL}

--- a/assistant/src/persistence/llm-usage-store.ts
+++ b/assistant/src/persistence/llm-usage-store.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gt, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, lte, or, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getTelemetryMainDb } from "../telemetry/telemetry-main-db.js";
@@ -149,12 +149,20 @@ export function recordUsageEvent(
  * processing lock keeps a further real user turn from landing until that run
  * finishes.
  *
+ * `cutoffCreatedAt`, when given, bounds the count to turns with
+ * `created_at <=` that timestamp, the same bound the `parent_turn_index`
+ * subquery applies via {@link PARENT_TURN_CUTOFF_SQL}. Omit it to count the
+ * conversation's turns to date.
+ *
  * Best-effort, like {@link lookupConversationAttribution}: a query failure
  * degrades to 0 rather than throwing, so a billing-attribution detail can never
  * abort the user's turn. Returns 0 for a conversation with no real user turn
  * yet.
  */
-export function countRealUserTurns(conversationId: string): number {
+export function countRealUserTurns(
+  conversationId: string,
+  cutoffCreatedAt?: number,
+): number {
   try {
     const row = getDb()
       .select({ count: sql<number>`COUNT(*)` })
@@ -164,12 +172,59 @@ export function countRealUserTurns(conversationId: string): number {
           eq(messages.conversationId, conversationId),
           eq(messages.role, "user"),
           realUserTurnContentFilter("messages"),
+          ...(cutoffCreatedAt === undefined
+            ? []
+            : [lte(messages.createdAt, cutoffCreatedAt)]),
         ),
       )
       .get();
     return row?.count ? Number(row.count) : 0;
   } catch {
     return 0;
+  }
+}
+
+/**
+ * Cutoff for a child conversation's parent-turn count, as a `conversations`
+ * expression. Subagent spawns attribute to the parent turn in flight at child
+ * creation. Retrospective forks can branch from a turn far earlier than the
+ * fork's creation time, so they anchor on the fork boundary message instead;
+ * child creation is the fallback when the boundary message is absent.
+ *
+ * One definition, two readers: the `parent_turn_index` subquery in
+ * {@link queryUnreportedUsageEvents} and {@link resolveParentTurnCutoff}, which
+ * serves the live billing-origin snapshot. Both name the same cutoff for the
+ * same conversation, so the managed billing header and the telemetry row report
+ * the same parent turn for one call.
+ */
+const PARENT_TURN_CUTOFF_SQL = sql<number>`CASE
+  WHEN ${conversations.parentConversationId} IS NOT NULL THEN ${conversations.createdAt}
+  ELSE COALESCE(
+    (SELECT mb.created_at FROM messages AS mb
+      WHERE mb.id = ${conversations.forkParentMessageId}),
+    ${conversations.createdAt}
+  )
+END`;
+
+/**
+ * Resolve the {@link PARENT_TURN_CUTOFF_SQL} cutoff for one child conversation,
+ * for bounding a live {@link countRealUserTurns} of its spawn parent.
+ *
+ * Best-effort: a missing row or a failed read returns undefined, which leaves
+ * the caller counting the parent's turns to date rather than failing the call.
+ */
+export function resolveParentTurnCutoff(
+  childConversationId: string,
+): number | undefined {
+  try {
+    const row = getDb()
+      .select({ cutoff: PARENT_TURN_CUTOFF_SQL })
+      .from(conversations)
+      .where(eq(conversations.id, childConversationId))
+      .get();
+    return row?.cutoff == null ? undefined : Number(row.cutoff);
+  } catch {
+    return undefined;
   }
 }
 
@@ -362,22 +417,9 @@ export function queryUnreportedUsageEvents(
       THEN ${conversations.forkParentConversationId}
     END
   )`;
-  // Cutoff for the parent-turn count. Subagent spawns attribute to the
-  // parent turn in flight at child creation. Retrospective forks can
-  // branch from a turn far earlier than the fork's creation time, so
-  // they anchor on the fork boundary message instead; child creation is
-  // the fallback when the boundary message is absent.
   // The turn-index subqueries below count user-role rows only. User rows are
   // always written finalized (only assistant turns stream), so no completeness
   // predicate is needed; do not copy this shape for assistant-row counts.
-  const parentTurnCutoffSql = sql<number>`CASE
-    WHEN ${conversations.parentConversationId} IS NOT NULL THEN ${conversations.createdAt}
-    ELSE COALESCE(
-      (SELECT mb.created_at FROM messages AS mb
-        WHERE mb.id = ${conversations.forkParentMessageId}),
-      ${conversations.createdAt}
-    )
-  END`;
   // `conversationType` prefers the value stamped on the row at record
   // time (migration 353) — the parent conversation may have been deleted
   // before this flush (retrospective fork GC, user deletion) — and falls
@@ -462,7 +504,7 @@ export function queryUnreportedUsageEvents(
           WHERE m3.conversation_id = ${parentIdSql}
             AND m3.role = 'user'
             AND ${realUserTurnContentFilter("m3")}
-            AND m3.created_at <= ${parentTurnCutoffSql}
+            AND m3.created_at <= ${PARENT_TURN_CUTOFF_SQL}
         )
         END
       )`.as("parent_turn_index"),

--- a/assistant/src/plugins/defaults/compaction/compact.ts
+++ b/assistant/src/plugins/defaults/compaction/compact.ts
@@ -13,6 +13,7 @@
 import type { Message } from "@vellumai/plugin-api";
 
 import type { TrustClass } from "../../../runtime/actor-trust-resolver.js";
+import type { UsageOriginSnapshot } from "../../../usage/work-origin.js";
 import { PluginExecutionError } from "../../types.js";
 import { getContextWindowManager } from "./manager-store.js";
 import type {
@@ -44,6 +45,12 @@ export interface CompactionContext {
   force?: boolean;
   /** Per-conversation inference-profile override for the summary call. */
   overrideProfile?: string | null;
+  /**
+   * Billing-origin attribution for the turn compaction runs inside, forwarded
+   * to the summary call so a mid-turn pass inherits the turn's own origin
+   * rather than being classified from the conversation row alone.
+   */
+  usageOriginSnapshot?: UsageOriginSnapshot;
   /** Pre-computed token estimate from a prior `shouldCompact()` call. */
   precomputedEstimate?: number;
   /** Legacy keep-boundary hint forwarded to the compactor. */
@@ -108,6 +115,7 @@ export async function defaultCompact(
         actualTokens: overflowSignal.actualTokens,
         isInteractive: overflowSignal.isInteractive,
         overrideProfile: options.overrideProfile,
+        usageOriginSnapshot: options.usageOriginSnapshot,
         actorTrustClass: options.actorTrustClass,
       },
       signal,

--- a/assistant/src/plugins/defaults/compaction/context-overflow-reducer.ts
+++ b/assistant/src/plugins/defaults/compaction/context-overflow-reducer.ts
@@ -40,6 +40,7 @@ import {
 } from "../../../daemon/conversation-media-retry.js";
 import type { InjectionMode } from "../../../daemon/conversation-runtime-assembly.js";
 import type { TrustClass } from "../../../runtime/actor-trust-resolver.js";
+import type { UsageOriginSnapshot } from "../../../usage/work-origin.js";
 import { getLogger } from "../../../util/logger.js";
 import { defaultCompact, defaultEmergencyCompact } from "./compact.js";
 import type {
@@ -130,6 +131,11 @@ export interface ReducerConfig {
   conversationId: string;
   /** Per-conversation inference-profile override for the summary call. */
   overrideProfile?: string | null;
+  /**
+   * Billing-origin attribution for the turn the overflow occurred in,
+   * forwarded to every summary call the ladder makes.
+   */
+  usageOriginSnapshot?: UsageOriginSnapshot;
   /** Trust class of the actor whose turn triggered overflow recovery. */
   actorTrustClass?: TrustClass;
   /**
@@ -284,6 +290,7 @@ async function applyEmergencyCompaction(
       messages,
       previousEstimatedInputTokens: config.previousEstimatedInputTokens,
       overrideProfile: config.overrideProfile ?? null,
+      usageOriginSnapshot: config.usageOriginSnapshot,
       signal,
     });
   } catch (err) {
@@ -337,6 +344,7 @@ async function applyForcedCompaction(
     signal,
     ...compactionOptions,
     overrideProfile: config.overrideProfile ?? null,
+    usageOriginSnapshot: config.usageOriginSnapshot,
     actorTrustClass: config.actorTrustClass,
   });
   const nextMessages = result.compacted ? result.messages : messages;
@@ -528,6 +536,7 @@ async function applyAutoCompressLatestTurn(
     signal,
     ...compactionOptions,
     overrideProfile: config.overrideProfile ?? null,
+    usageOriginSnapshot: config.usageOriginSnapshot,
     actorTrustClass: config.actorTrustClass,
   });
   const nextMessages = result.compacted ? result.messages : messages;

--- a/assistant/src/plugins/defaults/compaction/window-manager.ts
+++ b/assistant/src/plugins/defaults/compaction/window-manager.ts
@@ -42,6 +42,7 @@ import { findConversationOrSubagent } from "../../../daemon/conversation-registr
 import type { InjectionMode } from "../../../daemon/conversation-runtime-assembly.js";
 import type { ToolDefinition } from "../../../providers/types.js";
 import type { TrustClass } from "../../../runtime/actor-trust-resolver.js";
+import type { UsageOriginSnapshot } from "../../../usage/work-origin.js";
 import { getLogger } from "../../../util/logger.js";
 import {
   createInitialReducerState,
@@ -157,6 +158,12 @@ export interface ContextWindowCompactOptions {
    */
   minKeepRecentUserTurns?: number;
   /**
+   * Billing-origin attribution for the turn compaction runs inside, forwarded
+   * to the compactor's summary call. See
+   * {@link CompactionRunArgs.usageOriginSnapshot}.
+   */
+  usageOriginSnapshot?: UsageOriginSnapshot;
+  /**
    * Trust class of the actor whose turn triggered compaction. Forwarded to
    * the compactor so the image manifest excludes guardian-only attachments
    * for untrusted actors.
@@ -192,6 +199,12 @@ export interface EmergencyCompactOptions {
    * call.
    */
   overrideProfile?: string | null;
+  /**
+   * Billing-origin attribution for the turn the overflow occurred in,
+   * forwarded to the summary call. See
+   * {@link CompactionRunArgs.usageOriginSnapshot}.
+   */
+  usageOriginSnapshot?: UsageOriginSnapshot;
 }
 
 /**
@@ -217,6 +230,11 @@ export interface OverflowRecoveryRungOptions {
   allowAutoCompressLatestTurn: boolean;
   /** Per-conversation inference-profile override for the summary call. */
   overrideProfile?: string | null;
+  /**
+   * Billing-origin attribution for the turn the overflow occurred in,
+   * forwarded to every summary call the ladder makes.
+   */
+  usageOriginSnapshot?: UsageOriginSnapshot;
   /** Trust class of the actor whose turn triggered overflow recovery. */
   actorTrustClass?: TrustClass;
 }
@@ -236,6 +254,11 @@ export interface OverflowRecoveryOptions {
   isInteractive: boolean;
   /** Per-conversation inference-profile override for the summary call. */
   overrideProfile?: string | null;
+  /**
+   * Billing-origin attribution for the turn the overflow occurred in,
+   * forwarded to every summary call the ladder makes.
+   */
+  usageOriginSnapshot?: UsageOriginSnapshot;
   /** Trust class of the actor whose turn triggered overflow recovery. */
   actorTrustClass?: TrustClass;
 }
@@ -547,6 +570,7 @@ export class ContextWindowManager {
         actualTokens: options.actualTokens,
         allowAutoCompressLatestTurn,
         overrideProfile: options.overrideProfile,
+        usageOriginSnapshot: options.usageOriginSnapshot,
         actorTrustClass: options.actorTrustClass,
       },
       signal,
@@ -619,6 +643,7 @@ export class ContextWindowManager {
       toolTokenBudget: this.resolveTurnToolTokenBudget(),
       conversationId: this.conversationId,
       overrideProfile: options.overrideProfile ?? null,
+      usageOriginSnapshot: options.usageOriginSnapshot,
       actorTrustClass: options.actorTrustClass,
       previousEstimatedInputTokens: estimatedInputTokens,
       maxMiddleTierAttempts: this.config.overflowRecovery.maxAttempts,
@@ -778,6 +803,7 @@ export class ContextWindowManager {
       force: options?.force,
       signal,
       overrideProfile: options?.overrideProfile ?? null,
+      usageOriginSnapshot: options?.usageOriginSnapshot,
       actorTrustClass: options?.actorTrustClass,
       nonPersistedPrefixCount: this.resolveNonPersistedPrefixCount(messages),
     });
@@ -925,6 +951,7 @@ export class ContextWindowManager {
       force: true,
       signal,
       overrideProfile: options.overrideProfile ?? null,
+      usageOriginSnapshot: options.usageOriginSnapshot,
       nonPersistedPrefixCount: this.resolveNonPersistedPrefixCount(messages),
     });
     // A productive emergency pass rebuilds the history front just like the

--- a/assistant/src/providers/__tests__/retry-callsite.test.ts
+++ b/assistant/src/providers/__tests__/retry-callsite.test.ts
@@ -36,6 +36,7 @@ import {
   classifyWorkOrigin,
   type UsageOriginSnapshot,
 } from "../../usage/work-origin.js";
+import { ProviderError } from "../../util/errors.js";
 import { RetryProvider } from "../retry.js";
 import type {
   Message,
@@ -1157,6 +1158,63 @@ describe("RetryProvider: billing-origin headers", () => {
     expect(headers["X-Vellum-Turn-Index"]).toBe("4");
   });
 
+  test("a scheduled turn's compaction send bills as user_created_schedule", async () => {
+    // The conversation row stays standard/user for a wake or defer firing, so
+    // the row-derived fallback classifies its compaction as interactive. The
+    // turn snapshot the agent loop threads through carries the cron run id
+    // that makes the same send bill as schedule-driven work.
+    await initializeDb();
+    resetFallbackUsageOriginCacheForTests();
+    getDb().run(
+      `INSERT INTO conversations (id, conversation_type, source, created_at, updated_at)
+       VALUES ('conv-retry-compaction', 'standard', 'user', 1000, 1000)`,
+    );
+    setLlmConfig({
+      callSites: {
+        compactionAgent: { provider: "anthropic", model: "claude-x" },
+      },
+    });
+
+    const send = async (
+      snapshot?: UsageOriginSnapshot,
+    ): Promise<Record<string, string>> => {
+      let seen: SendMessageOptions | undefined;
+      const wrapped = new RetryProvider(
+        makeProvider("anthropic", (options) => {
+          seen = options;
+        }),
+        { forwardUsageAttributionHeaders: true },
+      );
+      await wrapped.sendMessage(DUMMY_MESSAGES, {
+        config: {
+          callSite: "compactionAgent",
+          conversationId: "conv-retry-compaction",
+          ...(snapshot ? { usageOriginSnapshot: snapshot } : {}),
+        },
+      });
+      return (seen?.config as Record<string, unknown>)
+        .usageAttributionHeaders as Record<string, string>;
+    };
+
+    expect((await send())["X-Vellum-Work-Origin"]).toBe("user_interactive");
+
+    const scheduled = await send(
+      buildUsageOriginSnapshot({
+        conversationType: "standard",
+        conversationSource: "user",
+        callSite: "mainAgent",
+        conversationId: "conv-retry-compaction",
+        turnIndex: 2,
+        parentConversationId: null,
+        parentTurnIndex: null,
+        cronRunId: "cron-run-1",
+      }),
+    );
+    expect(scheduled["X-Vellum-Work-Origin"]).toBe("user_created_schedule");
+    expect(scheduled["X-Vellum-Turn-Index"]).toBe("2");
+    expect(scheduled["X-Vellum-LLM-Call-Site"]).toBe("compactionAgent");
+  });
+
   test("direct transports get no row-derived origin headers either", async () => {
     await initializeDb();
     resetFallbackUsageOriginCacheForTests();
@@ -1186,6 +1244,65 @@ describe("RetryProvider: billing-origin headers", () => {
 
     const config = seen?.config as Record<string, unknown>;
     expect(config.usageAttributionHeaders).toBeUndefined();
+  });
+
+  test("a credential-refresh retry carries the same attribution headers", async () => {
+    // Options are normalized once, before the retry loop, and every attempt
+    // sends that one object. A refreshed managed credential swaps the inner
+    // adapter, so the second attempt must reach billing with the headers the
+    // first one carried. The refresher hands back a raw adapter, which is what
+    // keeps the already-normalized options from being normalized a second time
+    // and losing the snapshot the first pass stripped.
+    setLlmConfig({
+      callSites: { mainAgent: { provider: "anthropic", model: "claude-x" } },
+    });
+
+    const seen: Array<SendMessageOptions | undefined> = [];
+    const expired: Provider = {
+      name: "anthropic",
+      async sendMessage(_messages, options) {
+        seen.push(options);
+        throw new ProviderError("assistant key expired", "anthropic", 401, {
+          reason: "invalid_credentials",
+        });
+      },
+    };
+    const refreshed = makeProvider("anthropic", (options) => {
+      seen.push(options);
+    });
+
+    const wrapped = new RetryProvider(expired, {
+      forwardUsageAttributionHeaders: true,
+      credentialSource: "vellum-managed",
+      connectionName: "vellum",
+      refreshCredentialProvider: async () => refreshed,
+    });
+
+    await wrapped.sendMessage(DUMMY_MESSAGES, {
+      config: {
+        callSite: "mainAgent",
+        conversationId: "conv-refresh",
+        usageOriginSnapshot: makeSnapshot({
+          conversationType: "scheduled",
+          conversationSource: "schedule",
+          workOrigin: "user_created_schedule",
+          conversationId: "conv-refresh",
+          turnIndex: 1,
+          cronRunId: "cron-run-1",
+        }),
+      },
+    });
+
+    expect(seen.length).toBe(2);
+    const headersOf = (options: SendMessageOptions | undefined) =>
+      (options?.config as Record<string, unknown>)
+        .usageAttributionHeaders as Record<string, string>;
+    expect(headersOf(seen[1])).toEqual(headersOf(seen[0]));
+    expect(headersOf(seen[1])["X-Vellum-Work-Origin"]).toBe(
+      "user_created_schedule",
+    );
+    expect(headersOf(seen[1])["X-Vellum-Conversation-Id"]).toBe("conv-refresh");
+    expect(headersOf(seen[1])["X-Vellum-LLM-Call-Site"]).toBe("mainAgent");
   });
 
   test("user-key / direct provider transports receive NO billing-origin headers", async () => {

--- a/assistant/src/providers/__tests__/retry-callsite.test.ts
+++ b/assistant/src/providers/__tests__/retry-callsite.test.ts
@@ -32,6 +32,7 @@ import { initializeDb } from "../../persistence/db-init.js";
 import { resetFallbackUsageOriginCacheForTests } from "../../usage/fallback-usage-origin.js";
 import { resetSubagentAttributionCacheForTests } from "../../usage/subagent-attribution.js";
 import {
+  buildUsageOriginSnapshot,
   classifyWorkOrigin,
   type UsageOriginSnapshot,
 } from "../../usage/work-origin.js";
@@ -98,6 +99,7 @@ function makeSnapshot(
     turnIndex: null,
     parentConversationId: null,
     parentTurnIndex: null,
+    cronRunId: null,
     ...overrides,
   };
 }
@@ -976,6 +978,32 @@ describe("RetryProvider: billing-origin headers", () => {
     expect(headers["X-Vellum-Parent-Conversation-Id"]).toBe("conv-root");
     expect(headers["X-Vellum-Parent-Turn-Index"]).toBe("5");
     expect(headers["X-Vellum-Work-Origin"]).toBe("delegated_child");
+  });
+
+  // A wake or defer schedule fires inside a conversation whose type and source
+  // stay standard/user. The firing's run id is carried on the snapshot, never
+  // as its own header: `X-Vellum-Work-Origin` is the billing signal.
+  test("a snapshot carrying a cron run id bills as user_created_schedule", async () => {
+    const config = await sendWithSnapshot(
+      buildUsageOriginSnapshot({
+        conversationType: "standard",
+        conversationSource: "user",
+        callSite: "mainAgent",
+        conversationId: "conv-wake",
+        turnIndex: 2,
+        parentConversationId: null,
+        parentTurnIndex: null,
+        cronRunId: "cron-run-1",
+      }),
+    );
+    const headers = config.usageAttributionHeaders as Record<string, string>;
+    expect(headers["X-Vellum-Work-Origin"]).toBe("user_created_schedule");
+    expect(headers["X-Vellum-Conversation-Type"]).toBe("standard");
+    expect(headers["X-Vellum-Conversation-Id"]).toBe("conv-wake");
+    // The run id itself is not a wire header.
+    expect(Object.keys(headers).some((name) => name.includes("Cron"))).toBe(
+      false,
+    );
   });
 
   test("turn index 0 is a valid non-negative integer and is emitted", async () => {

--- a/assistant/src/providers/__tests__/retry-callsite.test.ts
+++ b/assistant/src/providers/__tests__/retry-callsite.test.ts
@@ -30,6 +30,7 @@ import { CODE_DEFAULT_PROFILE_ENTRIES } from "../../config/default-profile-catal
 import { getDb } from "../../persistence/db-connection.js";
 import { initializeDb } from "../../persistence/db-init.js";
 import { resetSubagentAttributionCacheForTests } from "../../usage/subagent-attribution.js";
+import type { UsageOriginSnapshot } from "../../usage/work-origin.js";
 import { RetryProvider } from "../retry.js";
 import type {
   Message,
@@ -80,6 +81,21 @@ function setLlmConfig(raw: unknown): void {
   // Seed the raw fixture; the real loader schema-merges it over defaults, the
   // same cascade `getConfig().llm` produces in production.
   setConfig("llm", raw);
+}
+
+function makeSnapshot(
+  overrides: Partial<UsageOriginSnapshot> = {},
+): UsageOriginSnapshot {
+  return {
+    conversationType: null,
+    conversationSource: null,
+    workOrigin: null,
+    conversationId: null,
+    turnIndex: null,
+    parentConversationId: null,
+    parentTurnIndex: null,
+    ...overrides,
+  };
 }
 
 beforeEach(() => {
@@ -840,6 +856,169 @@ describe("RetryProvider — callSite resolution", () => {
 
     const config = seen?.config as Record<string, unknown>;
     expect(config.model).toBe("explicit-override");
+  });
+});
+
+// ── RetryProvider: billing-origin (X-Vellum-*) headers ─────────────────────
+//
+// `usageOriginSnapshot` rides the per-call config from conversation-aware call
+// sites. On the managed-proxy transport (`forwardUsageAttributionHeaders:
+// true`) `RetryProvider` maps it to the seven billing-origin headers, merges
+// them into `usageAttributionHeaders`, and strips the snapshot from the wire
+// config. Direct/user-key transports must receive neither.
+
+describe("RetryProvider: billing-origin headers", () => {
+  async function sendWithSnapshot(
+    snapshot: UsageOriginSnapshot,
+    opts: { forward: boolean } = { forward: true },
+  ): Promise<Record<string, unknown>> {
+    setLlmConfig({
+      callSites: {
+        mainAgent: { provider: "anthropic", model: "claude-x" },
+      },
+    });
+    let seen: SendMessageOptions | undefined;
+    const wrapped = new RetryProvider(
+      makeProvider("anthropic", (options) => {
+        seen = options;
+      }),
+      opts.forward ? { forwardUsageAttributionHeaders: true } : {},
+    );
+    await wrapped.sendMessage(DUMMY_MESSAGES, {
+      config: { callSite: "mainAgent", usageOriginSnapshot: snapshot },
+    });
+    return seen?.config as Record<string, unknown>;
+  }
+
+  test("forwards the full snapshot as merged X-Vellum-* headers and strips the snapshot", async () => {
+    const config = await sendWithSnapshot(
+      makeSnapshot({
+        conversationType: "standard",
+        conversationSource: "user",
+        workOrigin: "delegated_child",
+        conversationId: "conv-123",
+        turnIndex: 3,
+        parentConversationId: "conv-parent",
+        parentTurnIndex: 2,
+      }),
+    );
+    const headers = config.usageAttributionHeaders as Record<string, string>;
+    expect(headers["X-Vellum-Conversation-Type"]).toBe("standard");
+    expect(headers["X-Vellum-Conversation-Source"]).toBe("user");
+    expect(headers["X-Vellum-Work-Origin"]).toBe("delegated_child");
+    expect(headers["X-Vellum-Conversation-Id"]).toBe("conv-123");
+    expect(headers["X-Vellum-Turn-Index"]).toBe("3");
+    expect(headers["X-Vellum-Parent-Conversation-Id"]).toBe("conv-parent");
+    expect(headers["X-Vellum-Parent-Turn-Index"]).toBe("2");
+    // Merged alongside the call-site attribution headers, not replacing them.
+    expect(headers["X-Vellum-LLM-Call-Site"]).toBe("mainAgent");
+    expect(headers["X-Vellum-Resolved-Provider"]).toBe("anthropic");
+    expect(headers["X-Vellum-Resolved-Model"]).toBe("claude-x");
+    // The snapshot itself is a routing concern and must never reach the wire.
+    expect(config.usageOriginSnapshot).toBeUndefined();
+  });
+
+  test("omits null fields from a partial snapshot", async () => {
+    const config = await sendWithSnapshot(
+      makeSnapshot({
+        conversationType: "background",
+        conversationSource: "subagent",
+        workOrigin: "user_created_background",
+        conversationId: "conv-partial",
+        // turnIndex and parent linkage unresolved at send time.
+      }),
+    );
+    const headers = config.usageAttributionHeaders as Record<string, string>;
+    expect(headers["X-Vellum-Conversation-Type"]).toBe("background");
+    expect(headers["X-Vellum-Conversation-Source"]).toBe("subagent");
+    expect(headers["X-Vellum-Work-Origin"]).toBe("user_created_background");
+    expect(headers["X-Vellum-Conversation-Id"]).toBe("conv-partial");
+    expect("X-Vellum-Turn-Index" in headers).toBe(false);
+    expect("X-Vellum-Parent-Conversation-Id" in headers).toBe(false);
+    expect("X-Vellum-Parent-Turn-Index" in headers).toBe(false);
+  });
+
+  test("auxiliary (no conversation) snapshot emits only the work-origin billing header", async () => {
+    const config = await sendWithSnapshot(
+      makeSnapshot({ workOrigin: "memory_maintenance" }),
+    );
+    const headers = config.usageAttributionHeaders as Record<string, string>;
+    // Work origin is the only non-null billing-origin field; the conversation
+    // ids/type/source headers are all omitted.
+    expect(headers["X-Vellum-Work-Origin"]).toBe("memory_maintenance");
+    expect("X-Vellum-Conversation-Type" in headers).toBe(false);
+    expect("X-Vellum-Conversation-Source" in headers).toBe(false);
+    expect("X-Vellum-Conversation-Id" in headers).toBe(false);
+    expect("X-Vellum-Turn-Index" in headers).toBe(false);
+    expect("X-Vellum-Parent-Conversation-Id" in headers).toBe(false);
+    expect("X-Vellum-Parent-Turn-Index" in headers).toBe(false);
+  });
+
+  test("parent-linked snapshot carries the parent conversation/turn headers", async () => {
+    const config = await sendWithSnapshot(
+      makeSnapshot({
+        conversationType: "background",
+        conversationSource: "subagent",
+        workOrigin: "delegated_child",
+        conversationId: "conv-child",
+        parentConversationId: "conv-root",
+        parentTurnIndex: 5,
+      }),
+    );
+    const headers = config.usageAttributionHeaders as Record<string, string>;
+    expect(headers["X-Vellum-Parent-Conversation-Id"]).toBe("conv-root");
+    expect(headers["X-Vellum-Parent-Turn-Index"]).toBe("5");
+    expect(headers["X-Vellum-Work-Origin"]).toBe("delegated_child");
+  });
+
+  test("turn index 0 is a valid non-negative integer and is emitted", async () => {
+    const config = await sendWithSnapshot(
+      makeSnapshot({ conversationId: "conv-zero", turnIndex: 0 }),
+    );
+    const headers = config.usageAttributionHeaders as Record<string, string>;
+    expect(headers["X-Vellum-Turn-Index"]).toBe("0");
+  });
+
+  test("omits values that violate the platform charset / integer contract", async () => {
+    const config = await sendWithSnapshot(
+      makeSnapshot({
+        // Space is outside `^[A-Za-z0-9._:@/-]+$`, so omit the whole value
+        // rather than send a value the platform sanitizer would reject.
+        conversationId: "conv 123",
+        conversationType: "standard",
+        workOrigin: "user_interactive",
+        // Negative and non-integer indexes are not decimal turn indexes.
+        turnIndex: -1,
+        parentConversationId: "conv-ok",
+        parentTurnIndex: 2.5,
+      }),
+    );
+    const headers = config.usageAttributionHeaders as Record<string, string>;
+    expect("X-Vellum-Conversation-Id" in headers).toBe(false);
+    expect("X-Vellum-Turn-Index" in headers).toBe(false);
+    expect("X-Vellum-Parent-Turn-Index" in headers).toBe(false);
+    // Valid siblings still flow.
+    expect(headers["X-Vellum-Conversation-Type"]).toBe("standard");
+    expect(headers["X-Vellum-Work-Origin"]).toBe("user_interactive");
+    expect(headers["X-Vellum-Parent-Conversation-Id"]).toBe("conv-ok");
+  });
+
+  test("user-key / direct provider transports receive NO billing-origin headers", async () => {
+    const config = await sendWithSnapshot(
+      makeSnapshot({
+        conversationType: "standard",
+        conversationSource: "user",
+        workOrigin: "user_interactive",
+        conversationId: "conv-123",
+        turnIndex: 1,
+      }),
+      { forward: false },
+    );
+    // No managed proxy means no attribution headers at all (billing or
+    // call-site).
+    expect(config.usageAttributionHeaders).toBeUndefined();
+    // The snapshot is still stripped from the wire config on every transport.
+    expect(config.usageOriginSnapshot).toBeUndefined();
   });
 });
 

--- a/assistant/src/providers/__tests__/retry-callsite.test.ts
+++ b/assistant/src/providers/__tests__/retry-callsite.test.ts
@@ -29,8 +29,12 @@ mock.module("../registry.js", () => ({
 import { CODE_DEFAULT_PROFILE_ENTRIES } from "../../config/default-profile-catalog.js";
 import { getDb } from "../../persistence/db-connection.js";
 import { initializeDb } from "../../persistence/db-init.js";
+import { resetFallbackUsageOriginCacheForTests } from "../../usage/fallback-usage-origin.js";
 import { resetSubagentAttributionCacheForTests } from "../../usage/subagent-attribution.js";
-import type { UsageOriginSnapshot } from "../../usage/work-origin.js";
+import {
+  classifyWorkOrigin,
+  type UsageOriginSnapshot,
+} from "../../usage/work-origin.js";
 import { RetryProvider } from "../retry.js";
 import type {
   Message,
@@ -199,6 +203,8 @@ describe("RetryProvider — callSite resolution", () => {
       "X-Vellum-Inference-Profile-Source": "conversation",
       "X-Vellum-Resolved-Provider": "openai",
       "X-Vellum-Resolved-Model": "claude-profile",
+      // A conversationless managed call still classifies from its call site.
+      "X-Vellum-Work-Origin": "memory_maintenance",
     });
     expect(
       (config.usageAttributionHeaders as Record<string, string>)[
@@ -327,6 +333,7 @@ describe("RetryProvider — callSite resolution", () => {
       "X-Vellum-LLM-Call-Site": "vision",
       "X-Vellum-Resolved-Provider": "openai",
       "X-Vellum-Resolved-Model": "gpt-default",
+      "X-Vellum-Work-Origin": "other_system",
     });
   });
 
@@ -1001,6 +1008,156 @@ describe("RetryProvider: billing-origin headers", () => {
     expect(headers["X-Vellum-Conversation-Type"]).toBe("standard");
     expect(headers["X-Vellum-Work-Origin"]).toBe("user_interactive");
     expect(headers["X-Vellum-Parent-Conversation-Id"]).toBe("conv-ok");
+  });
+
+  // Most managed calls stamp no snapshot: compaction, workflow leaves,
+  // conversation titles, and every other direct `sendMessage` site pass a
+  // `callSite` alone. Their billing rows still need origin attribution, so the
+  // provider layer derives one from the conversation row.
+  test("derives origin headers from the conversation row when no snapshot is supplied", async () => {
+    await initializeDb();
+    resetFallbackUsageOriginCacheForTests();
+    getDb().run(
+      `INSERT INTO conversations (id, conversation_type, source, created_at, updated_at)
+       VALUES ('conv-retry-fallback', 'standard', 'user', 1000, 1000)`,
+    );
+    setLlmConfig({
+      callSites: {
+        compactionAgent: { provider: "anthropic", model: "claude-x" },
+      },
+    });
+
+    let seen: SendMessageOptions | undefined;
+    const wrapped = new RetryProvider(
+      makeProvider("anthropic", (options) => {
+        seen = options;
+      }),
+      { forwardUsageAttributionHeaders: true },
+    );
+
+    await wrapped.sendMessage(DUMMY_MESSAGES, {
+      config: {
+        callSite: "compactionAgent",
+        conversationId: "conv-retry-fallback",
+      },
+    });
+
+    const headers = (seen?.config as Record<string, unknown>)
+      .usageAttributionHeaders as Record<string, string>;
+    expect(headers["X-Vellum-Conversation-Id"]).toBe("conv-retry-fallback");
+    expect(headers["X-Vellum-Conversation-Type"]).toBe("standard");
+    expect(headers["X-Vellum-Conversation-Source"]).toBe("user");
+    // The telemetry classifier reaches the same bucket for this row.
+    expect(headers["X-Vellum-Work-Origin"]).toBe(
+      classifyWorkOrigin({
+        conversationType: "standard",
+        conversationSource: "user",
+        callSite: "compactionAgent",
+        parentConversationId: null,
+      }),
+    );
+    // Turn linkage belongs to the per-turn path, which knows the turn.
+    expect("X-Vellum-Turn-Index" in headers).toBe(false);
+    expect("X-Vellum-Parent-Turn-Index" in headers).toBe(false);
+  });
+
+  test("conversationless workflow leaf carries the call-site work origin only", async () => {
+    setLlmConfig({
+      callSites: { workflowLeaf: { provider: "anthropic", model: "claude-x" } },
+    });
+
+    let seen: SendMessageOptions | undefined;
+    const wrapped = new RetryProvider(
+      makeProvider("anthropic", (options) => {
+        seen = options;
+      }),
+      { forwardUsageAttributionHeaders: true },
+    );
+
+    await wrapped.sendMessage(DUMMY_MESSAGES, {
+      config: { callSite: "workflowLeaf" },
+    });
+
+    const headers = (seen?.config as Record<string, unknown>)
+      .usageAttributionHeaders as Record<string, string>;
+    expect(headers["X-Vellum-Work-Origin"]).toBe("user_created_background");
+    expect("X-Vellum-Conversation-Id" in headers).toBe(false);
+    expect("X-Vellum-Conversation-Type" in headers).toBe(false);
+    expect("X-Vellum-Turn-Index" in headers).toBe(false);
+    expect("X-Vellum-Parent-Turn-Index" in headers).toBe(false);
+  });
+
+  test("an explicit snapshot wins over the row-derived fallback", async () => {
+    await initializeDb();
+    resetFallbackUsageOriginCacheForTests();
+    getDb().run(
+      `INSERT INTO conversations (id, conversation_type, source, created_at, updated_at)
+       VALUES ('conv-retry-explicit', 'standard', 'user', 1000, 1000)`,
+    );
+    setLlmConfig({
+      callSites: { mainAgent: { provider: "anthropic", model: "claude-x" } },
+    });
+
+    let seen: SendMessageOptions | undefined;
+    const wrapped = new RetryProvider(
+      makeProvider("anthropic", (options) => {
+        seen = options;
+      }),
+      { forwardUsageAttributionHeaders: true },
+    );
+
+    await wrapped.sendMessage(DUMMY_MESSAGES, {
+      config: {
+        callSite: "mainAgent",
+        conversationId: "conv-retry-explicit",
+        usageOriginSnapshot: makeSnapshot({
+          conversationType: "background",
+          conversationSource: "subagent",
+          workOrigin: "delegated_child",
+          conversationId: "conv-retry-explicit",
+          turnIndex: 4,
+        }),
+      },
+    });
+
+    const headers = (seen?.config as Record<string, unknown>)
+      .usageAttributionHeaders as Record<string, string>;
+    // The explicit snapshot is taken whole; no row-derived field is merged in.
+    expect(headers["X-Vellum-Conversation-Type"]).toBe("background");
+    expect(headers["X-Vellum-Conversation-Source"]).toBe("subagent");
+    expect(headers["X-Vellum-Work-Origin"]).toBe("delegated_child");
+    expect(headers["X-Vellum-Turn-Index"]).toBe("4");
+  });
+
+  test("direct transports get no row-derived origin headers either", async () => {
+    await initializeDb();
+    resetFallbackUsageOriginCacheForTests();
+    getDb().run(
+      `INSERT INTO conversations (id, conversation_type, source, created_at, updated_at)
+       VALUES ('conv-retry-direct', 'standard', 'user', 1000, 1000)`,
+    );
+    setLlmConfig({
+      callSites: {
+        compactionAgent: { provider: "anthropic", model: "claude-x" },
+      },
+    });
+
+    let seen: SendMessageOptions | undefined;
+    const wrapped = new RetryProvider(
+      makeProvider("anthropic", (options) => {
+        seen = options;
+      }),
+    );
+
+    await wrapped.sendMessage(DUMMY_MESSAGES, {
+      config: {
+        callSite: "compactionAgent",
+        conversationId: "conv-retry-direct",
+      },
+    });
+
+    const config = seen?.config as Record<string, unknown>;
+    expect(config.usageAttributionHeaders).toBeUndefined();
   });
 
   test("user-key / direct provider transports receive NO billing-origin headers", async () => {

--- a/assistant/src/providers/inference/adapter-factory.ts
+++ b/assistant/src/providers/inference/adapter-factory.ts
@@ -242,6 +242,15 @@ export function createAdapterFromConnection(
    * that just failed — otherwise a proxy 401 from any other cause (platform
    * auth degraded, revoked account) would make every request pay a second
    * doomed upstream call forever.
+   *
+   * The replacement is a bare adapter, never a wrapped chain. `RetryProvider`
+   * normalizes the send options once, before its attempt loop, and hands the
+   * same object to whichever inner provider it holds; a wrapped replacement
+   * would normalize them a second time, and since normalization derives
+   * attribution headers from routing fields it has already stripped, the
+   * refreshed request would reach billing with none. A bare adapter also keeps
+   * usage recording to the single `UsageTrackingProvider` wrapping this whole
+   * chain, so a rotation cannot double-count a call.
    */
   function makeCredentialRefresher(): () => Promise<Provider | null> {
     let lastAuth = JSON.stringify(resolvedAuth);

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -5,6 +5,7 @@ import {
   sanitizeUsageMetadataValue,
 } from "../usage/attribution.js";
 import { resolveSubagentAttribution } from "../usage/subagent-attribution.js";
+import type { UsageOriginSnapshot } from "../usage/work-origin.js";
 import {
   type ProviderCredentialSource,
   ProviderError,
@@ -57,6 +58,27 @@ const USAGE_ATTRIBUTION_HEADER_NAMES = {
   subagentRole: "X-Vellum-Subagent-Role",
   subagentSpawnMode: "X-Vellum-Subagent-Spawn-Mode",
 } as const;
+
+/** Billing-origin attribution headers derived from a
+ *  {@link UsageOriginSnapshot}, forwarded only on the managed-proxy transport
+ *  path so the billing backend can key rows by the same work-origin vocabulary
+ *  the `llm_usage` telemetry uses. */
+const USAGE_ORIGIN_HEADER_NAMES = {
+  conversationType: "X-Vellum-Conversation-Type",
+  conversationSource: "X-Vellum-Conversation-Source",
+  workOrigin: "X-Vellum-Work-Origin",
+  conversationId: "X-Vellum-Conversation-Id",
+  turnIndex: "X-Vellum-Turn-Index",
+  parentConversationId: "X-Vellum-Parent-Conversation-Id",
+  parentTurnIndex: "X-Vellum-Parent-Turn-Index",
+} as const;
+
+/** Platform header-sanitizer contract: accepted values match this charset and
+ *  cap at {@link MAX_ORIGIN_HEADER_VALUE_LENGTH} characters. Values outside the
+ *  contract are omitted rather than truncated or rewritten, because a corrupted
+ *  billing identifier is worse than an absent one. */
+const ORIGIN_HEADER_VALUE_PATTERN = /^[A-Za-z0-9._:@/-]+$/;
+const MAX_ORIGIN_HEADER_VALUE_LENGTH = 256;
 
 /** Providers whose transports consume `promptCacheKey` (OpenAI Responses
  *  `prompt_cache_key`); `RetryProvider` derives it from `selectionSeed` for
@@ -406,6 +428,10 @@ function normalizeSendMessageOptions(
   delete nextConfig.forceOverrideProfile;
   delete nextConfig.selectionSeed;
   delete nextConfig.conversationId;
+  // Attribution-only: mapped to billing-origin headers below (managed-proxy
+  // path) and never a wire-format field. Strip unconditionally so it cannot
+  // leak into a provider request body.
+  delete nextConfig.usageOriginSnapshot;
 
   if (config.callSite !== undefined) {
     const resolved = resolveCallSiteConfig(config.callSite, getConfig().llm, {
@@ -535,6 +561,27 @@ function normalizeSendMessageOptions(
     // leaks unknown fields into provider request bodies — Anthropic (and other
     // strict-schema clients) reject the request with
     // "Extra inputs are not permitted".
+  }
+
+  // Billing-origin attribution headers share the managed-proxy-only forwarding
+  // gate with the call-site attribution headers above, but derive from the
+  // immutable `usageOriginSnapshot` a conversation-aware call site stamped
+  // rather than from call-site resolution, so they flow even for a snapshot
+  // carried without a `callSite`. Sanitized to the platform header contract and
+  // merged into the same header map the transport forwards; null snapshot
+  // fields are omitted entirely.
+  if (
+    normalizeOptions.forwardUsageAttributionHeaders === true &&
+    config.usageOriginSnapshot
+  ) {
+    const originHeaders = buildUsageOriginHeaders(config.usageOriginSnapshot);
+    if (Object.keys(originHeaders).length > 0) {
+      const existing =
+        (nextConfig.usageAttributionHeaders as
+          | Record<string, string>
+          | undefined) ?? {};
+      nextConfig.usageAttributionHeaders = { ...existing, ...originHeaders };
+    }
   }
 
   // Convert schema-shape `{ enabled, streamThinking }` into Anthropic's
@@ -840,6 +887,103 @@ function addSanitizedHeader(
   if (sanitized != null) {
     headers[name] = sanitized;
   }
+}
+
+/**
+ * Map a {@link UsageOriginSnapshot} to the seven `X-Vellum-*` billing-origin
+ * headers, sanitizing each value to the platform header-sanitizer contract and
+ * omitting any null or invalid field entirely. Ids and vocabulary values go
+ * through the string charset gate; turn indexes serialize only as non-negative
+ * decimal integers.
+ */
+function buildUsageOriginHeaders(
+  snapshot: UsageOriginSnapshot,
+): Record<string, string> {
+  const headers: Record<string, string> = {};
+  addOriginStringHeader(
+    headers,
+    USAGE_ORIGIN_HEADER_NAMES.conversationType,
+    snapshot.conversationType,
+  );
+  addOriginStringHeader(
+    headers,
+    USAGE_ORIGIN_HEADER_NAMES.conversationSource,
+    snapshot.conversationSource,
+  );
+  addOriginStringHeader(
+    headers,
+    USAGE_ORIGIN_HEADER_NAMES.workOrigin,
+    snapshot.workOrigin,
+  );
+  addOriginStringHeader(
+    headers,
+    USAGE_ORIGIN_HEADER_NAMES.conversationId,
+    snapshot.conversationId,
+  );
+  addOriginStringHeader(
+    headers,
+    USAGE_ORIGIN_HEADER_NAMES.parentConversationId,
+    snapshot.parentConversationId,
+  );
+  addOriginTurnIndexHeader(
+    headers,
+    USAGE_ORIGIN_HEADER_NAMES.turnIndex,
+    snapshot.turnIndex,
+  );
+  addOriginTurnIndexHeader(
+    headers,
+    USAGE_ORIGIN_HEADER_NAMES.parentTurnIndex,
+    snapshot.parentTurnIndex,
+  );
+  return headers;
+}
+
+function addOriginStringHeader(
+  headers: Record<string, string>,
+  name: string,
+  value: string | null,
+): void {
+  const sanitized = sanitizeOriginHeaderValue(value);
+  if (sanitized != null) {
+    headers[name] = sanitized;
+  }
+}
+
+function addOriginTurnIndexHeader(
+  headers: Record<string, string>,
+  name: string,
+  value: number | null,
+): void {
+  const sanitized = sanitizeOriginTurnIndex(value);
+  if (sanitized != null) {
+    headers[name] = sanitized;
+  }
+}
+
+/** Enforce the platform charset and length contract, omitting (returning null)
+ *  any value that violates it rather than rewriting it. */
+function sanitizeOriginHeaderValue(value: string | null): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (
+    trimmed.length === 0 ||
+    trimmed.length > MAX_ORIGIN_HEADER_VALUE_LENGTH ||
+    !ORIGIN_HEADER_VALUE_PATTERN.test(trimmed)
+  ) {
+    return null;
+  }
+  return trimmed;
+}
+
+/** Serialize a turn index as a non-negative decimal integer; omit anything
+ *  else (null, non-integer, negative). */
+function sanitizeOriginTurnIndex(value: number | null): string | null {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    return null;
+  }
+  return String(value);
 }
 
 /**

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -4,6 +4,7 @@ import {
   resolveUsageAttribution,
   sanitizeUsageMetadataValue,
 } from "../usage/attribution.js";
+import { resolveFallbackUsageOrigin } from "../usage/fallback-usage-origin.js";
 import { resolveSubagentAttribution } from "../usage/subagent-attribution.js";
 import type { UsageOriginSnapshot } from "../usage/work-origin.js";
 import {
@@ -570,17 +571,32 @@ function normalizeSendMessageOptions(
   // carried without a `callSite`. Sanitized to the platform header contract and
   // merged into the same header map the transport forwards; null snapshot
   // fields are omitted entirely.
-  if (
-    normalizeOptions.forwardUsageAttributionHeaders === true &&
-    config.usageOriginSnapshot
-  ) {
-    const originHeaders = buildUsageOriginHeaders(config.usageOriginSnapshot);
-    if (Object.keys(originHeaders).length > 0) {
-      const existing =
-        (nextConfig.usageAttributionHeaders as
-          | Record<string, string>
-          | undefined) ?? {};
-      nextConfig.usageAttributionHeaders = { ...existing, ...originHeaders };
+  //
+  // A managed call without a snapshot (compaction, workflow leaves,
+  // conversation titles, every other direct `sendMessage` site) falls back to
+  // one derived from its conversation row and call site, so those rows carry
+  // origin attribution too. The explicit snapshot wins whole: the two are
+  // never merged, because a per-turn snapshot already states everything its
+  // caller knows and a row-derived field cannot improve on it.
+  //
+  // `config` is the caller's object; the strips above mutate only `nextConfig`,
+  // so `conversationId` and `callSite` are still readable here.
+  if (normalizeOptions.forwardUsageAttributionHeaders === true) {
+    const originSnapshot =
+      config.usageOriginSnapshot ??
+      resolveFallbackUsageOrigin(
+        config.conversationId ?? null,
+        config.callSite ?? null,
+      );
+    if (originSnapshot) {
+      const originHeaders = buildUsageOriginHeaders(originSnapshot);
+      if (Object.keys(originHeaders).length > 0) {
+        const existing =
+          (nextConfig.usageAttributionHeaders as
+            | Record<string, string>
+            | undefined) ?? {};
+        nextConfig.usageAttributionHeaders = { ...existing, ...originHeaders };
+      }
     }
   }
 

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -2,6 +2,7 @@ import type { ToolDefinition } from "../tools/tool-types.js";
 export type { ToolDefinition };
 
 import type { LLMCallSite } from "../config/schemas/llm.js";
+import type { UsageOriginSnapshot } from "../usage/work-origin.js";
 import {
   ProviderError,
   type ProviderErrorReason,
@@ -316,6 +317,17 @@ export interface SendMessageConfig {
    * JSON request bodies.
    */
   usageAttributionHeaders?: Record<string, string>;
+  /**
+   * Immutable record-time attribution of why this LLM call happened, populated
+   * by conversation-aware call sites. `RetryProvider` maps it to the seven
+   * `X-Vellum-*` billing-origin headers (conversation type and source, work
+   * origin, conversation id and turn index, parent conversation id and turn
+   * index) and merges them into {@link usageAttributionHeaders}, but only on
+   * the managed-proxy transport path. A resolution and routing concern only:
+   * stripped before any provider wire request so it never leaks into a JSON
+   * request body.
+   */
+  usageOriginSnapshot?: UsageOriginSnapshot;
   /**
    * Controls local usage-ledger writes for attributed provider calls.
    * Defaults to `auto`; conversation paths that aggregate usage separately

--- a/assistant/src/providers/usage-tracking.ts
+++ b/assistant/src/providers/usage-tracking.ts
@@ -93,6 +93,11 @@ export class UsageTrackingProvider implements Provider {
           rawUsage: extractRawUsage(response.rawResponse),
           conversationId: config.conversationId ?? null,
           runId: null,
+          // The schedule firing behind the call, from the turn's immutable
+          // origin snapshot. A wake or defer schedule fires inside a
+          // conversation whose type and source stay standard, so this is what
+          // classifies the row as schedule-driven work.
+          cronRunId: config.usageOriginSnapshot?.cronRunId ?? null,
           requestId: null,
           callSite: attribution.callSite,
           inferenceProfile: attribution.appliedProfile,

--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -124,7 +124,7 @@ interface WakeConversationProbe {
   maybeCompactSizings: unknown[];
   /**
    * The billing-origin snapshot passed to each `conversation.maybeCompact()`
-   * call — the gate's summary call bills against the wake's own origin, not a
+   * call: the gate's summary call bills against the wake's own origin, not a
    * classification derived from the conversation row.
    */
   maybeCompactSnapshots: unknown[];

--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -123,6 +123,12 @@ interface WakeConversationProbe {
    */
   maybeCompactSizings: unknown[];
   /**
+   * The billing-origin snapshot passed to each `conversation.maybeCompact()`
+   * call — the gate's summary call bills against the wake's own origin, not a
+   * classification derived from the conversation row.
+   */
+  maybeCompactSnapshots: unknown[];
+  /**
    * Options passed to each `conversation.waitForIdle()` call — the wake's
    * pre-run busy gate. Lets tests pin the wait budget the wake hands to the
    * conversation's event-driven wait.
@@ -466,6 +472,7 @@ function makeWakeConversation(options: {
     persistedAtEachEmit: [],
     maybeCompactOrders: [],
     maybeCompactSizings: [],
+    maybeCompactSnapshots: [],
     waitForIdleCalls: [],
     processingLockStomps: 0,
   };
@@ -618,9 +625,10 @@ function makeWakeConversation(options: {
     // Pre-run auto-compaction gate. The double only records the call (and
     // the sizing argument) — compaction side effects are exercised in the
     // Conversation tests.
-    maybeCompact: async (sizing?: unknown) => {
+    maybeCompact: async (sizing?: unknown, usageOriginSnapshot?: unknown) => {
       probe.maybeCompactOrders.push(order++);
       probe.maybeCompactSizings.push(sizing);
+      probe.maybeCompactSnapshots.push(usageOriginSnapshot);
       probe.callSequence.push("maybeCompact");
       return null;
     },
@@ -751,6 +759,43 @@ describe("wakeAgentForOpportunity", () => {
         conversationId: "wake-scheduled-1",
         callSite: "mainAgent",
         cronRunId: "cron-run-1",
+      },
+    ]);
+  });
+
+  // The pre-run compaction gate runs before the agent loop, so its summary
+  // call is the wake's first LLM spend. Without the wake's own snapshot it
+  // would fall back to a row-derived origin and label a scheduled wake's
+  // compaction as interactive user spend.
+  test("hands the pre-run compaction gate the same snapshot the run gets", async () => {
+    const conversation = makeWakeConversation({
+      conversationId: "wake-compact-origin-1",
+      scriptedAssistant: null,
+    });
+
+    await wakeAgentForOpportunity(
+      {
+        conversationId: conversation.conversationId,
+        hint: "scheduled",
+        source: "schedule",
+        cronRunId: "cron-run-2",
+      },
+      { resolveTarget: async () => conversation },
+    );
+
+    expect(conversation.maybeCompactSnapshots).toEqual([
+      SENTINEL_USAGE_ORIGIN_SNAPSHOT,
+    ]);
+    expect(conversation.runCalls[0]!.usageOriginSnapshot).toBe(
+      SENTINEL_USAGE_ORIGIN_SNAPSHOT,
+    );
+    // One assembly per wake: it counts turns and resolves spawn lineage from
+    // the DB, and both consumers describe the same turn.
+    expect(buildTurnUsageOriginSnapshotCalls).toEqual([
+      {
+        conversationId: "wake-compact-origin-1",
+        callSite: "mainAgent",
+        cronRunId: "cron-run-2",
       },
     ]);
   });

--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -350,6 +350,7 @@ mock.module("../../persistence/llm-request-log-store.js", () => ({
 const buildTurnUsageOriginSnapshotCalls: Array<{
   conversationId: string;
   callSite: string | null;
+  cronRunId: string | null;
 }> = [];
 const SENTINEL_USAGE_ORIGIN_SNAPSHOT = {
   conversationType: "background",
@@ -359,15 +360,18 @@ const SENTINEL_USAGE_ORIGIN_SNAPSHOT = {
   turnIndex: 2,
   parentConversationId: "sentinel-parent",
   parentTurnIndex: 5,
+  cronRunId: null,
 };
 mock.module("../../usage/usage-origin-snapshot.js", () => ({
   buildTurnUsageOriginSnapshot: (
     conversation: { conversationId: string },
     callSite: string | null,
+    cronRunId: string | null,
   ) => {
     buildTurnUsageOriginSnapshotCalls.push({
       conversationId: conversation.conversationId,
       callSite,
+      cronRunId,
     });
     return SENTINEL_USAGE_ORIGIN_SNAPSHOT;
   },
@@ -712,11 +716,43 @@ describe("wakeAgentForOpportunity", () => {
     // site, then forwarded the exact snapshot onto the run config, so the
     // managed proxy sends the same X-Vellum-* headers a normal turn would.
     expect(buildTurnUsageOriginSnapshotCalls).toEqual([
-      { conversationId: "retro-fork-1", callSite: "memoryRetrospective" },
+      {
+        conversationId: "retro-fork-1",
+        callSite: "memoryRetrospective",
+        cronRunId: null,
+      },
     ]);
     expect(conversation.runCalls[0]!.usageOriginSnapshot).toBe(
       SENTINEL_USAGE_ORIGIN_SNAPSHOT,
     );
+  });
+
+  // A wake fired by a schedule runs in a conversation whose type and source
+  // stay standard, so the firing's run id is the only signal the spend is
+  // schedule-driven. It has to reach the snapshot the wake stamps.
+  test("passes the wake's cron run id into the billing-origin snapshot", async () => {
+    const conversation = makeWakeConversation({
+      conversationId: "wake-scheduled-1",
+      scriptedAssistant: null,
+    });
+
+    await wakeAgentForOpportunity(
+      {
+        conversationId: conversation.conversationId,
+        hint: "scheduled",
+        source: "schedule",
+        cronRunId: "cron-run-1",
+      },
+      { resolveTarget: async () => conversation },
+    );
+
+    expect(buildTurnUsageOriginSnapshotCalls).toEqual([
+      {
+        conversationId: "wake-scheduled-1",
+        callSite: "mainAgent",
+        cronRunId: "cron-run-1",
+      },
+    ]);
   });
 
   test("blocks background wakes during disk pressure before marking processing", async () => {

--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -56,6 +56,13 @@ interface WakeConversationProbe {
      * system prompt before `agentLoop.run()`.
      */
     personaOverride?: unknown;
+    /**
+     * The immutable billing-origin `usageOriginSnapshot` forwarded on the run
+     * config. The wake path builds it from the live conversation (via
+     * `buildTurnUsageOriginSnapshot`) so scheduled, retrospective, and
+     * background wakes send the same `X-Vellum-*` headers a normal turn does.
+     */
+    usageOriginSnapshot?: unknown;
     order: number;
   }>;
   /** Every `setProcessing` value, in call order. */
@@ -335,6 +342,37 @@ mock.module("../../persistence/llm-request-log-store.js", () => ({
   backfillMessageIdOnLogs: () => {},
 }));
 
+// Stub the DB-backed billing-origin snapshot assembly (it counts real user
+// turns via `countRealUserTurns`, which needs a live SQLite DB these unit
+// tests don't set up). Records its call args and returns a fixed sentinel so
+// tests can assert the wake builds the snapshot from the live conversation and
+// forwards it verbatim onto `agentLoop.run`.
+const buildTurnUsageOriginSnapshotCalls: Array<{
+  conversationId: string;
+  callSite: string | null;
+}> = [];
+const SENTINEL_USAGE_ORIGIN_SNAPSHOT = {
+  conversationType: "background",
+  conversationSource: "memory-retrospective",
+  workOrigin: "delegated_child",
+  conversationId: "sentinel-conv",
+  turnIndex: 2,
+  parentConversationId: "sentinel-parent",
+  parentTurnIndex: 5,
+};
+mock.module("../../usage/usage-origin-snapshot.js", () => ({
+  buildTurnUsageOriginSnapshot: (
+    conversation: { conversationId: string },
+    callSite: string | null,
+  ) => {
+    buildTurnUsageOriginSnapshotCalls.push({
+      conversationId: conversation.conversationId,
+      callSite,
+    });
+    return SENTINEL_USAGE_ORIGIN_SNAPSHOT;
+  },
+}));
+
 import type {
   AgentEvent,
   AgentLoopRunOptions,
@@ -514,6 +552,7 @@ function makeWakeConversation(options: {
           trust: options.trust,
           allowedTools: snapshotAllowedTools(),
           personaOverride: wakePersonaOverride,
+          usageOriginSnapshot: options.usageOriginSnapshot,
           order: order++,
         });
         return runBody(input, onEvent, options);
@@ -608,6 +647,7 @@ beforeEach(() => {
   wakeConvRegistry.clear();
   recordRequestLogCalls.length = 0;
   recordUsageCalls.length = 0;
+  buildTurnUsageOriginSnapshotCalls.length = 0;
   publishMessagesChangedCalls.length = 0;
   mockGetOrCreateConversationCalls.length = 0;
   mockResolverTarget = null;
@@ -648,6 +688,35 @@ describe("wakeAgentForOpportunity", () => {
 
     expect(result).toEqual({ invoked: true, producedToolCalls: false });
     expect(conversation.runCalls).toHaveLength(1);
+  });
+
+  test("forwards a billing-origin usageOriginSnapshot built from the live conversation onto agentLoop.run", async () => {
+    const conversation = makeWakeConversation({
+      conversationId: "retro-fork-1",
+      scriptedAssistant: null,
+    });
+
+    const result = await wakeAgentForOpportunity(
+      {
+        conversationId: conversation.conversationId,
+        hint: "retrospective",
+        source: "memory-retrospective",
+        callSite: "memoryRetrospective",
+      },
+      { resolveTarget: async () => conversation },
+    );
+
+    expect(result).toEqual({ invoked: true, producedToolCalls: false });
+    expect(conversation.runCalls).toHaveLength(1);
+    // The wake built the snapshot from THIS conversation and the resolved call
+    // site, then forwarded the exact snapshot onto the run config, so the
+    // managed proxy sends the same X-Vellum-* headers a normal turn would.
+    expect(buildTurnUsageOriginSnapshotCalls).toEqual([
+      { conversationId: "retro-fork-1", callSite: "memoryRetrospective" },
+    ]);
+    expect(conversation.runCalls[0]!.usageOriginSnapshot).toBe(
+      SENTINEL_USAGE_ORIGIN_SNAPSHOT,
+    );
   });
 
   test("blocks background wakes during disk pressure before marking processing", async () => {

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -883,6 +883,22 @@ export async function wakeAgentForOpportunity(
     // the lock cannot change hands in between.
     conversation.setProcessing(true);
 
+    // Immutable record-time usage attribution for every LLM call this wake
+    // emits, the pre-run compaction summary below included. Built from the same
+    // helper `runAgentLoopImpl` uses, so a scheduled, retrospective, or
+    // background wake carries the same work-origin classification, turn
+    // indexes, spawn-parent linkage, and schedule firing as a normal turn.
+    // Built before the compaction gate so a compaction send never falls back
+    // to a row-derived origin (which would label a scheduled wake's summary
+    // call user-interactive). A wake that persists its trigger row rebuilds
+    // the run's snapshot after the persist, so each consumer's turn index
+    // matches the rows the telemetry read path counts for its calls.
+    let usageOriginSnapshot = buildTurnUsageOriginSnapshot(
+      conversation,
+      callSite,
+      opts.cronRunId ?? null,
+    );
+
     // ── Pre-run auto-compaction gate ──────────────────────────────────
     // The wake invokes `conversation.agentLoop.run()` with the loop's
     // in-loop budget gate disabled (see `resolveContextWindow` below), so
@@ -900,11 +916,14 @@ export async function wakeAgentForOpportunity(
     // window (and then overflow at the provider).
     if (!suppressAutoCompaction) {
       try {
-        await conversation.maybeCompact({
-          callSite,
-          overrideProfile,
-          forceOverrideProfile,
-        });
+        await conversation.maybeCompact(
+          {
+            callSite,
+            overrideProfile,
+            forceOverrideProfile,
+          },
+          usageOriginSnapshot,
+        );
       } catch (err) {
         log.warn(
           { conversationId, source, err },
@@ -954,6 +973,16 @@ export async function wakeAgentForOpportunity(
           "agent-wake: failed to persist wake trigger message; continuing",
         );
       }
+      // The persisted trigger row is a real user turn, so the run's
+      // attribution is rebuilt to include it: the telemetry read path counts
+      // rows persisted before each call, and the run's calls all follow the
+      // trigger. The compaction gate above keeps the pre-trigger build, whose
+      // calls precede the row.
+      usageOriginSnapshot = buildTurnUsageOriginSnapshot(
+        conversation,
+        callSite,
+        opts.cronRunId ?? null,
+      );
     }
 
     const baseline = conversation.getMessages();
@@ -1455,6 +1484,8 @@ export async function wakeAgentForOpportunity(
       const priorCallSite = conversation.currentCallSite;
       const priorTurnOverrideProfile = conversation.currentTurnOverrideProfile;
       const priorTurnCronRunId = conversation.currentTurnCronRunId;
+      const priorTurnUsageOriginSnapshot =
+        conversation.currentTurnUsageOriginSnapshot;
       const priorTurnIsNonInteractive =
         conversation.currentTurnIsNonInteractive;
       const priorTurnTrust = conversation.currentTurnTrustContext;
@@ -1463,6 +1494,8 @@ export async function wakeAgentForOpportunity(
       // Same reason as the stamps above: a wake triggered by a schedule firing
       // delegates work to subagents whose usage must attribute to that firing.
       conversation.currentTurnCronRunId = opts.cronRunId ?? null;
+      // The turn's own origin, for tools that emit their own LLM calls.
+      conversation.currentTurnUsageOriginSnapshot = usageOriginSnapshot;
       if (opts.clientless) {
         // Presence is per-turn state; a clientless wake declares no human is
         // present for the duration of its dispatch.
@@ -1473,17 +1506,6 @@ export async function wakeAgentForOpportunity(
       if (opts.trustContext) {
         conversation.currentTurnTrustContext = opts.trustContext;
       }
-
-      // Immutable record-time usage attribution for every LLM call this wake
-      // emits. Built from the same helper `runAgentLoopImpl` uses, so a
-      // scheduled, retrospective, or background wake carries the same
-      // work-origin classification, turn indexes, spawn-parent linkage, and
-      // schedule firing as a normal turn.
-      const usageOriginSnapshot = buildTurnUsageOriginSnapshot(
-        conversation,
-        callSite,
-        opts.cronRunId ?? null,
-      );
 
       let updatedHistory: Message[];
       try {
@@ -1566,6 +1588,8 @@ export async function wakeAgentForOpportunity(
         conversation.currentCallSite = priorCallSite;
         conversation.currentTurnOverrideProfile = priorTurnOverrideProfile;
         conversation.currentTurnCronRunId = priorTurnCronRunId;
+        conversation.currentTurnUsageOriginSnapshot =
+          priorTurnUsageOriginSnapshot;
         conversation.currentTurnIsNonInteractive = priorTurnIsNonInteractive;
         conversation.currentTurnTrustContext = priorTurnTrust;
       }

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -124,6 +124,7 @@ import {
   wrapUntrustedContent,
 } from "../security/untrusted-content.js";
 import type { CompletedBackgroundTool } from "../tools/background-tool-registry.js";
+import { buildTurnUsageOriginSnapshot } from "../usage/usage-origin-snapshot.js";
 import { getLogger } from "../util/logger.js";
 import { createKeyedSingleFlight } from "../util/single-flight.js";
 
@@ -1473,6 +1474,16 @@ export async function wakeAgentForOpportunity(
         conversation.currentTurnTrustContext = opts.trustContext;
       }
 
+      // Immutable record-time usage attribution for every LLM call this wake
+      // emits. Built from the same helper `runAgentLoopImpl` uses, so a
+      // scheduled, retrospective, or background wake carries the same
+      // work-origin classification, turn indexes, and spawn-parent linkage as a
+      // normal turn.
+      const usageOriginSnapshot = buildTurnUsageOriginSnapshot(
+        conversation,
+        callSite,
+      );
+
       let updatedHistory: Message[];
       try {
         ({ history: updatedHistory } = await conversation.agentLoop.run({
@@ -1480,6 +1491,7 @@ export async function wakeAgentForOpportunity(
           onEvent,
           requestId: `wake:${source}`,
           onCheckpoint,
+          usageOriginSnapshot,
           // Route through the caller-supplied call site (defaults to
           // `mainAgent` so a normal user-turn wake shares the user's chat
           // selection). Without an explicit callSite, the resolver in

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -1477,11 +1477,12 @@ export async function wakeAgentForOpportunity(
       // Immutable record-time usage attribution for every LLM call this wake
       // emits. Built from the same helper `runAgentLoopImpl` uses, so a
       // scheduled, retrospective, or background wake carries the same
-      // work-origin classification, turn indexes, and spawn-parent linkage as a
-      // normal turn.
+      // work-origin classification, turn indexes, spawn-parent linkage, and
+      // schedule firing as a normal turn.
       const usageOriginSnapshot = buildTurnUsageOriginSnapshot(
         conversation,
         callSite,
+        opts.cronRunId ?? null,
       );
 
       let updatedHistory: Message[];

--- a/assistant/src/runtime/btw-sidechain.ts
+++ b/assistant/src/runtime/btw-sidechain.ts
@@ -18,6 +18,13 @@ export interface BtwSidechainConversationLike {
   systemPrompt: string;
   hasSystemPromptOverride?: boolean;
   getMessages(): Message[];
+  /**
+   * Persisted conversation the side-chain runs against, when it has one. It
+   * rides the send config so the call's spend attributes to that conversation
+   * instead of classifying as conversationless. Absent for a side-chain on an
+   * ephemeral conversation, whose id names no row.
+   */
+  conversationId?: string;
 }
 
 export interface RunBtwSidechainParams {
@@ -86,6 +93,7 @@ export async function runBtwSidechain(
 
   let collectedText = "";
   let hadTextDeltas = false;
+  const conversationId = params.conversation?.conversationId;
 
   try {
     const response = await provider.sendMessage(messages, {
@@ -95,6 +103,7 @@ export async function runBtwSidechain(
         max_tokens: params.maxTokens ?? 1024,
         tool_choice: { type: "none" },
         callSite: params.callSite ?? ("identityIntro" as LLMCallSite),
+        ...(conversationId ? { conversationId } : {}),
       },
       onEvent: (event) => {
         if (event.type === "text_delta") {

--- a/assistant/src/runtime/routes/btw-routes.ts
+++ b/assistant/src/runtime/routes/btw-routes.ts
@@ -26,6 +26,7 @@ import { getConversationByKey } from "../../persistence/conversation-key-store.j
 import { getAllToolDefinitions } from "../../tools/registry.js";
 import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import type { BtwSidechainConversationLike } from "../btw-sidechain.js";
 import { runBtwSidechain } from "../btw-sidechain.js";
 import {
   getCachedEmptyStateGreeting,
@@ -137,6 +138,19 @@ async function handleBtw({
     throw new ServiceUnavailableError("Message processing is not available");
   }
 
+  // The side-chain attributes its call to the conversation id it is handed. A
+  // mapped key resolves to a persisted conversation, so the call joins that
+  // conversation's spend; the ephemeral instance an unmapped key runs on has no
+  // row, so it is handed no id and classifies from its call site alone.
+  const sidechainConversation: BtwSidechainConversationLike = mapping
+    ? conversation
+    : {
+        provider: conversation.provider,
+        systemPrompt: conversation.systemPrompt,
+        hasSystemPromptOverride: conversation.hasSystemPromptOverride,
+        getMessages: () => conversation.getMessages(),
+      };
+
   return new ReadableStream({
     start(controller) {
       (async () => {
@@ -144,7 +158,7 @@ async function handleBtw({
           const isGreeting = conversationKey === GREETING_KEY;
           const result = await runBtwSidechain({
             content: effectiveContent,
-            conversation,
+            conversation: sidechainConversation,
             tools: getAllToolDefinitions(),
             signal: abortSignal,
             ...(isGreeting ? { callSite: "emptyStateGreeting" as const } : {}),

--- a/assistant/src/runtime/services/__tests__/conversation-serializer.test.ts
+++ b/assistant/src/runtime/services/__tests__/conversation-serializer.test.ts
@@ -36,6 +36,7 @@ function makeConversationRow(
     source: "task",
     originChannel: null,
     originInterface: null,
+    parentConversationId: null,
     forkParentConversationId: null,
     forkParentMessageId: null,
     forkStrategy: null,

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -61,6 +61,13 @@ import {
 
 const log = getLogger("subagent-manager");
 
+/**
+ * `conversations.source` for a spawned subagent. One literal for the persisted
+ * row and the live conversation's cached copy, so the durable row and the
+ * billing-origin snapshot report the same source.
+ */
+const SUBAGENT_CONVERSATION_SOURCE = "subagent";
+
 /** How long to keep terminal subagent metadata after the live conversation is released (ms). */
 const TERMINAL_RETENTION_MS = 30 * 60 * 1000; // 30 minutes
 /** How often to sweep expired terminal entries (ms). */
@@ -534,7 +541,7 @@ export class SubagentManager {
     // far behind. See migration 362.
     const conversationRecord = await bootstrapConversation({
       conversationType: "background",
-      source: "subagent",
+      source: SUBAGENT_CONVERSATION_SOURCE,
       origin: "subagent",
       systemHint: `Subagent: ${config.label}`,
       parentConversationId: config.parentConversationId,
@@ -691,8 +698,11 @@ export class SubagentManager {
     // interactive prompts (host attachment reads) fail fast.
     // Subagents are created as background conversations (see the
     // `bootstrapConversation` call above) and never call `loadFromDb`, so cache
-    // the type on the live conversation directly for the runtime-assembly path.
+    // the type on the live conversation directly for the runtime-assembly path,
+    // and the source for the billing-origin snapshot, which reads both from
+    // live state.
     conversation.conversationType = "background";
+    conversation.source = SUBAGENT_CONVERSATION_SOURCE;
 
     // Subagents execute as background child conversations, but their tool
     // permissions must still be scoped to the actor that spawned them. Without

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -8,6 +8,7 @@ import type { SecretPromptResult } from "../permissions/secret-prompt-types.js";
 import type { ContentBlock } from "../providers/types.js";
 import type { TrustClass } from "../runtime/trust-class.js";
 import type { UsageAttributionSnapshot } from "../usage/attribution.js";
+import type { UsageOriginSnapshot } from "../usage/work-origin.js";
 import type {
   DiffInfo,
   ProxyApprovalCallback,
@@ -424,6 +425,15 @@ export interface ToolContext {
    * cost reporting.
    */
   cronRunId?: string | null;
+  /**
+   * Immutable billing-origin attribution of the turn executing this tool: work
+   * origin, conversation type and source, turn indexes, spawn lineage, and the
+   * schedule firing behind it. Tools that make their own LLM call stamp it on
+   * the send config so the managed billing headers and the recorded usage row
+   * describe the turn the call ran inside, rather than being classified from
+   * the conversation row alone. Undefined outside a live turn.
+   */
+  usageOriginSnapshot?: UsageOriginSnapshot;
   /**
    * The LLM call site of the turn currently executing this tool (`mainAgent`,
    * `heartbeatAgent`, scheduled work, etc.). `subagent_spawn` reads it to

--- a/assistant/src/usage/fallback-usage-origin.ts
+++ b/assistant/src/usage/fallback-usage-origin.ts
@@ -1,3 +1,4 @@
+import { resolveSpawnAttribution } from "../persistence/llm-usage-store.js";
 import { rawGet } from "../persistence/raw-query.js";
 import { getLogger } from "../util/logger.js";
 import {
@@ -15,12 +16,20 @@ const log = getLogger("fallback-usage-origin");
 interface ConversationOriginRow {
   conversation_type: string | null;
   source: string | null;
-  parent_conversation_id: string | null;
-  fork_parent_conversation_id: string | null;
 }
 
 /**
- * Bound on the memo below. All four columns are stamped at conversation
+ * The per-conversation attribution a fallback snapshot is built from: the
+ * conversation's own metadata plus its resolved spawn parent.
+ */
+interface ConversationOrigin {
+  conversationType: string | null;
+  conversationSource: string | null;
+  spawnParentConversationId: string | null;
+}
+
+/**
+ * Bound on the memo below. Every field behind it is stamped at conversation
  * creation and never updated, so a hit is always correct and the only cost of
  * a bounded cache is an occasional re-read. Sized to comfortably cover the
  * conversations resident in one process without becoming a memory concern.
@@ -30,9 +39,9 @@ const MAX_CACHED_CONVERSATIONS = 2048;
 /**
  * Insertion-ordered memo. `Map` iteration order is insertion order, so
  * dropping the first key evicts the oldest entry, sufficient for a lookup
- * whose values are immutable and whose miss cost is a single primary-key read.
+ * whose values are immutable and whose miss cost is a pair of primary-key reads.
  */
-const cache = new Map<string, ConversationOriginRow>();
+const cache = new Map<string, ConversationOrigin>();
 
 /**
  * Build a best-effort {@link UsageOriginSnapshot} for a managed call whose
@@ -42,11 +51,15 @@ const cache = new Map<string, ConversationOriginRow>();
  * backend with no origin headers at all.
  *
  * The conversation's own metadata drives the classification when there is a
- * conversation: its type, source, and spawn lineage resolve exactly as
- * {@link buildUsageOriginSnapshot} resolves them for the per-turn path. With no
- * conversation the call site alone classifies it, so a conversationless
- * `workflowLeaf` call still carries `user_created_background` and agrees with
- * the telemetry row for the same call.
+ * conversation: its type and source come from the conversation row, and its
+ * spawn parent from the same {@link resolveSpawnAttribution} the per-turn path
+ * reads. With no conversation the call site alone classifies it, so a
+ * conversationless `workflowLeaf` call still carries `user_created_background`
+ * and agrees with the telemetry row for the same call.
+ *
+ * `cronRunId` is always null here: a direct call site send carries no schedule
+ * provenance, and the firing a schedule-driven turn runs under is known only on
+ * the per-turn path.
  *
  * Turn linkage is absent by construction: `turnIndex` and `parentTurnIndex`
  * are computed only on the explicit per-turn path
@@ -77,30 +90,30 @@ export function resolveFallbackUsageOrigin(
       conversationId: null,
       turnIndex: null,
       parentConversationId: null,
-      forkParentConversationId: null,
       parentTurnIndex: null,
+      cronRunId: null,
     });
   }
 
-  const row = readRow(conversationId);
+  const origin = readOrigin(conversationId);
   return buildUsageOriginSnapshot({
-    conversationType: row?.conversation_type ?? null,
-    conversationSource: row?.source ?? null,
+    conversationType: origin?.conversationType ?? null,
+    conversationSource: origin?.conversationSource ?? null,
     callSite,
     conversationId,
     turnIndex: null,
-    parentConversationId: row?.parent_conversation_id ?? null,
-    forkParentConversationId: row?.fork_parent_conversation_id ?? null,
+    parentConversationId: origin?.spawnParentConversationId ?? null,
     parentTurnIndex: null,
+    cronRunId: null,
   });
 }
 
 /**
- * Read the conversation's origin columns, or `null` when the conversation has
+ * Read the conversation's origin metadata, or `null` when the conversation has
  * no row or the read fails. Failure covers a DB-unavailable context, such as a
  * unit test exercising the provider stack alone.
  */
-function readRow(conversationId: string): ConversationOriginRow | null {
+function readOrigin(conversationId: string): ConversationOrigin | null {
   const cached = cache.get(conversationId);
   if (cached !== undefined) {
     return cached;
@@ -109,8 +122,7 @@ function readRow(conversationId: string): ConversationOriginRow | null {
   try {
     row = rawGet<ConversationOriginRow>(
       "usage:fallbackOrigin",
-      `SELECT conversation_type, source, parent_conversation_id, fork_parent_conversation_id
-         FROM conversations WHERE id = ?`,
+      `SELECT conversation_type, source FROM conversations WHERE id = ?`,
       conversationId,
     );
   } catch (err) {
@@ -122,14 +134,20 @@ function readRow(conversationId: string): ConversationOriginRow | null {
     // conversation whose row lands moments later.
     return null;
   }
+  const origin: ConversationOrigin = {
+    conversationType: row.conversation_type,
+    conversationSource: row.source,
+    spawnParentConversationId:
+      resolveSpawnAttribution(conversationId).spawnParentConversationId,
+  };
   if (cache.size >= MAX_CACHED_CONVERSATIONS) {
     const oldest = cache.keys().next();
     if (!oldest.done) {
       cache.delete(oldest.value);
     }
   }
-  cache.set(conversationId, row);
-  return row;
+  cache.set(conversationId, origin);
+  return origin;
 }
 
 /** Test seam: drops every memoized entry. */

--- a/assistant/src/usage/fallback-usage-origin.ts
+++ b/assistant/src/usage/fallback-usage-origin.ts
@@ -1,0 +1,138 @@
+import { rawGet } from "../persistence/raw-query.js";
+import { getLogger } from "../util/logger.js";
+import {
+  buildUsageOriginSnapshot,
+  type UsageOriginSnapshot,
+} from "./work-origin.js";
+
+const log = getLogger("fallback-usage-origin");
+
+/**
+ * The conversation columns a fallback snapshot classifies from. Mirrors the
+ * record-time metadata the `llm_usage` telemetry read path resolves for the
+ * same conversation.
+ */
+interface ConversationOriginRow {
+  conversation_type: string | null;
+  source: string | null;
+  parent_conversation_id: string | null;
+  fork_parent_conversation_id: string | null;
+}
+
+/**
+ * Bound on the memo below. All four columns are stamped at conversation
+ * creation and never updated, so a hit is always correct and the only cost of
+ * a bounded cache is an occasional re-read. Sized to comfortably cover the
+ * conversations resident in one process without becoming a memory concern.
+ */
+const MAX_CACHED_CONVERSATIONS = 2048;
+
+/**
+ * Insertion-ordered memo. `Map` iteration order is insertion order, so
+ * dropping the first key evicts the oldest entry, sufficient for a lookup
+ * whose values are immutable and whose miss cost is a single primary-key read.
+ */
+const cache = new Map<string, ConversationOriginRow>();
+
+/**
+ * Build a best-effort {@link UsageOriginSnapshot} for a managed call whose
+ * caller stamped no explicit snapshot: compaction, workflow leaves,
+ * conversation titles, and every other direct `provider.sendMessage` site.
+ * Without this those calls, a large share of real spend, reach the billing
+ * backend with no origin headers at all.
+ *
+ * The conversation's own metadata drives the classification when there is a
+ * conversation: its type, source, and spawn lineage resolve exactly as
+ * {@link buildUsageOriginSnapshot} resolves them for the per-turn path. With no
+ * conversation the call site alone classifies it, so a conversationless
+ * `workflowLeaf` call still carries `user_created_background` and agrees with
+ * the telemetry row for the same call.
+ *
+ * Turn linkage is absent by construction: `turnIndex` and `parentTurnIndex`
+ * are computed only on the explicit per-turn path
+ * (`buildTurnUsageOriginSnapshot`), which knows which turn it is running. A
+ * count taken here would name whichever turn happened to be persisted when an
+ * auxiliary call fired, so both stay null and the platform sees no turn header
+ * rather than a wrong one.
+ *
+ * Never throws. This runs on the provider dispatch hot path and attribution
+ * must never be able to take a model request down: a failed or missing row
+ * degrades to a call-site-only classification.
+ *
+ * Returns null for a call carrying neither a conversation nor a call site,
+ * which has nothing to attribute.
+ */
+export function resolveFallbackUsageOrigin(
+  conversationId: string | null,
+  callSite: string | null,
+): UsageOriginSnapshot | null {
+  if (conversationId === null || conversationId.length === 0) {
+    if (callSite === null) {
+      return null;
+    }
+    return buildUsageOriginSnapshot({
+      conversationType: null,
+      conversationSource: null,
+      callSite,
+      conversationId: null,
+      turnIndex: null,
+      parentConversationId: null,
+      forkParentConversationId: null,
+      parentTurnIndex: null,
+    });
+  }
+
+  const row = readRow(conversationId);
+  return buildUsageOriginSnapshot({
+    conversationType: row?.conversation_type ?? null,
+    conversationSource: row?.source ?? null,
+    callSite,
+    conversationId,
+    turnIndex: null,
+    parentConversationId: row?.parent_conversation_id ?? null,
+    forkParentConversationId: row?.fork_parent_conversation_id ?? null,
+    parentTurnIndex: null,
+  });
+}
+
+/**
+ * Read the conversation's origin columns, or `null` when the conversation has
+ * no row or the read fails. Failure covers a DB-unavailable context, such as a
+ * unit test exercising the provider stack alone.
+ */
+function readRow(conversationId: string): ConversationOriginRow | null {
+  const cached = cache.get(conversationId);
+  if (cached !== undefined) {
+    return cached;
+  }
+  let row: ConversationOriginRow | null;
+  try {
+    row = rawGet<ConversationOriginRow>(
+      "usage:fallbackOrigin",
+      `SELECT conversation_type, source, parent_conversation_id, fork_parent_conversation_id
+         FROM conversations WHERE id = ?`,
+      conversationId,
+    );
+  } catch (err) {
+    log.debug({ err, conversationId }, "Fallback origin lookup failed");
+    return null;
+  }
+  if (!row) {
+    // Deliberately NOT cached: caching a miss would pin an empty result for a
+    // conversation whose row lands moments later.
+    return null;
+  }
+  if (cache.size >= MAX_CACHED_CONVERSATIONS) {
+    const oldest = cache.keys().next();
+    if (!oldest.done) {
+      cache.delete(oldest.value);
+    }
+  }
+  cache.set(conversationId, row);
+  return row;
+}
+
+/** Test seam: drops every memoized entry. */
+export function resetFallbackUsageOriginCacheForTests(): void {
+  cache.clear();
+}

--- a/assistant/src/usage/usage-origin-snapshot.ts
+++ b/assistant/src/usage/usage-origin-snapshot.ts
@@ -1,10 +1,9 @@
 import {
   countRealUserTurns,
-  resolveParentTurnCutoff,
+  resolveSpawnAttribution,
 } from "../persistence/llm-usage-store.js";
 import {
   buildUsageOriginSnapshot,
-  resolveSpawnParentConversationId,
   type UsageOriginSnapshot,
 } from "./work-origin.js";
 
@@ -19,8 +18,6 @@ export interface ConversationUsageOriginContext {
   conversationId: string;
   conversationType?: string | null;
   source?: string | null;
-  parentConversationId?: string | null;
-  forkParentConversationId?: string | null;
 }
 
 /**
@@ -36,14 +33,22 @@ export interface ConversationUsageOriginContext {
  * - `turnIndex` counts this conversation's own real user turns, evaluated once
  *   the turn's user message or messages are persisted.
  * - `parentTurnIndex` counts the spawning conversation's real user turns up to
- *   the spawn cutoff ({@link resolveParentTurnCutoff}: child creation for a
- *   subagent spawn, the fork boundary message for a background fork), and is
- *   null when this conversation was not spawned by another. Counting to the
- *   cutoff rather than to date is what keeps a retrospective fork, whose source
- *   conversation can gain turns between the boundary and the fork's wake,
- *   pointing at the turn it branched from. The spawn parent comes from
- *   {@link resolveSpawnParentConversationId}, which mirrors the telemetry read
- *   path's `parentIdSql` precedence.
+ *   the spawn cutoff (child creation for a subagent spawn, the fork boundary
+ *   message for a background fork), and is null when this conversation was not
+ *   spawned by another. Counting to the cutoff rather than to date is what keeps
+ *   a retrospective fork, whose source conversation can gain turns between the
+ *   boundary and the fork's wake, pointing at the turn it branched from.
+ *
+ * The spawn parent and that cutoff both come from
+ * {@link resolveSpawnAttribution}, the one expression the telemetry read path
+ * also reads, so the two surfaces name the same parent and the same parent turn.
+ * The lineage is read from the conversation row rather than from the live
+ * object: the row is written at creation (`bootstrapConversation`), before any
+ * turn of the conversation runs, so it holds the same lineage a live turn knows.
+ *
+ * `cronRunId` is the schedule firing driving this turn, or null. A wake or defer
+ * schedule can fire inside a conversation whose type and source stay
+ * `standard`/`user`, where it is the only signal the spend is schedule-driven.
  *
  * Everything here is best-effort. Attribution must never fail or block a
  * provider call, so a failed turn count degrades to 0 and an unresolvable
@@ -52,30 +57,21 @@ export interface ConversationUsageOriginContext {
 export function buildTurnUsageOriginSnapshot(
   conversation: ConversationUsageOriginContext,
   callSite: string | null,
+  cronRunId: string | null,
 ): UsageOriginSnapshot {
-  const parentConversationId = conversation.parentConversationId ?? null;
-  const forkParentConversationId =
-    conversation.forkParentConversationId ?? null;
-  const conversationType = conversation.conversationType ?? null;
-  const spawnParentConversationId = resolveSpawnParentConversationId({
-    parentConversationId,
-    conversationType,
-    forkParentConversationId,
-  });
+  const { spawnParentConversationId, cutoffCreatedAt } =
+    resolveSpawnAttribution(conversation.conversationId);
   return buildUsageOriginSnapshot({
-    conversationType,
+    conversationType: conversation.conversationType ?? null,
     conversationSource: conversation.source ?? null,
     callSite,
     conversationId: conversation.conversationId,
     turnIndex: countRealUserTurns(conversation.conversationId),
-    parentConversationId,
-    forkParentConversationId,
+    parentConversationId: spawnParentConversationId,
     parentTurnIndex:
       spawnParentConversationId !== null
-        ? countRealUserTurns(
-            spawnParentConversationId,
-            resolveParentTurnCutoff(conversation.conversationId),
-          )
+        ? countRealUserTurns(spawnParentConversationId, cutoffCreatedAt)
         : null,
+    cronRunId,
   });
 }

--- a/assistant/src/usage/usage-origin-snapshot.ts
+++ b/assistant/src/usage/usage-origin-snapshot.ts
@@ -1,0 +1,70 @@
+import { countRealUserTurns } from "../persistence/llm-usage-store.js";
+import {
+  buildUsageOriginSnapshot,
+  resolveSpawnParentConversationId,
+  type UsageOriginSnapshot,
+} from "./work-origin.js";
+
+/**
+ * The conversation-level fields a per-turn {@link UsageOriginSnapshot} is
+ * assembled from. A structural subset of `Conversation`, so both the normal
+ * agent-loop wrapper (`runAgentLoopImpl`) and the background wake path
+ * (`wakeAgentForOpportunity`) can build the snapshot from their live
+ * conversation without depending on the class.
+ */
+export interface ConversationUsageOriginContext {
+  conversationId: string;
+  conversationType?: string | null;
+  source?: string | null;
+  parentConversationId?: string | null;
+  forkParentConversationId?: string | null;
+}
+
+/**
+ * Assemble the immutable per-turn {@link UsageOriginSnapshot} for a live
+ * conversation turn. This is the single assembly point shared by every path
+ * that drives the agent loop: `runAgentLoopImpl` for user and subagent turns,
+ * `wakeAgentForOpportunity` for scheduled, retrospective, and background wakes.
+ *
+ * Both turn indexes count the same real-user-turn population the `llm_usage`
+ * telemetry read path counts, via {@link countRealUserTurns}, so the managed
+ * billing-origin headers and usage telemetry agree:
+ *
+ * - `turnIndex` counts this conversation's own real user turns, evaluated once
+ *   the turn's user message or messages are persisted.
+ * - `parentTurnIndex` counts the spawning conversation's real user turns, and
+ *   is null when this conversation was not spawned by another. The spawn parent
+ *   comes from {@link resolveSpawnParentConversationId}, which mirrors the
+ *   telemetry read path's `parentIdSql` precedence.
+ *
+ * Everything here is best-effort. Attribution must never fail or block a
+ * provider call, so a failed turn count degrades to 0 and an unresolvable
+ * lineage field degrades to null.
+ */
+export function buildTurnUsageOriginSnapshot(
+  conversation: ConversationUsageOriginContext,
+  callSite: string | null,
+): UsageOriginSnapshot {
+  const parentConversationId = conversation.parentConversationId ?? null;
+  const forkParentConversationId =
+    conversation.forkParentConversationId ?? null;
+  const conversationType = conversation.conversationType ?? null;
+  const spawnParentConversationId = resolveSpawnParentConversationId({
+    parentConversationId,
+    conversationType,
+    forkParentConversationId,
+  });
+  return buildUsageOriginSnapshot({
+    conversationType,
+    conversationSource: conversation.source ?? null,
+    callSite,
+    conversationId: conversation.conversationId,
+    turnIndex: countRealUserTurns(conversation.conversationId),
+    parentConversationId,
+    forkParentConversationId,
+    parentTurnIndex:
+      spawnParentConversationId !== null
+        ? countRealUserTurns(spawnParentConversationId)
+        : null,
+  });
+}

--- a/assistant/src/usage/usage-origin-snapshot.ts
+++ b/assistant/src/usage/usage-origin-snapshot.ts
@@ -1,4 +1,7 @@
-import { countRealUserTurns } from "../persistence/llm-usage-store.js";
+import {
+  countRealUserTurns,
+  resolveParentTurnCutoff,
+} from "../persistence/llm-usage-store.js";
 import {
   buildUsageOriginSnapshot,
   resolveSpawnParentConversationId,
@@ -32,10 +35,15 @@ export interface ConversationUsageOriginContext {
  *
  * - `turnIndex` counts this conversation's own real user turns, evaluated once
  *   the turn's user message or messages are persisted.
- * - `parentTurnIndex` counts the spawning conversation's real user turns, and
- *   is null when this conversation was not spawned by another. The spawn parent
- *   comes from {@link resolveSpawnParentConversationId}, which mirrors the
- *   telemetry read path's `parentIdSql` precedence.
+ * - `parentTurnIndex` counts the spawning conversation's real user turns up to
+ *   the spawn cutoff ({@link resolveParentTurnCutoff}: child creation for a
+ *   subagent spawn, the fork boundary message for a background fork), and is
+ *   null when this conversation was not spawned by another. Counting to the
+ *   cutoff rather than to date is what keeps a retrospective fork, whose source
+ *   conversation can gain turns between the boundary and the fork's wake,
+ *   pointing at the turn it branched from. The spawn parent comes from
+ *   {@link resolveSpawnParentConversationId}, which mirrors the telemetry read
+ *   path's `parentIdSql` precedence.
  *
  * Everything here is best-effort. Attribution must never fail or block a
  * provider call, so a failed turn count degrades to 0 and an unresolvable
@@ -64,7 +72,10 @@ export function buildTurnUsageOriginSnapshot(
     forkParentConversationId,
     parentTurnIndex:
       spawnParentConversationId !== null
-        ? countRealUserTurns(spawnParentConversationId)
+        ? countRealUserTurns(
+            spawnParentConversationId,
+            resolveParentTurnCutoff(conversation.conversationId),
+          )
         : null,
   });
 }

--- a/assistant/src/usage/work-origin.test.ts
+++ b/assistant/src/usage/work-origin.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  buildUsageOriginSnapshot,
   classifyWorkOrigin,
+  resolveSpawnParentConversationId,
   type WorkOrigin,
   type WorkOriginInput,
 } from "./work-origin.js";
@@ -480,4 +482,112 @@ describe("classifyWorkOrigin residual-bucket guard: unrecognized combinations st
       expect(classifyWorkOrigin(c.input)).toBe("unknown");
     });
   }
+});
+
+describe("resolveSpawnParentConversationId", () => {
+  test("subagent parent wins over a fork parent", () => {
+    expect(
+      resolveSpawnParentConversationId({
+        parentConversationId: "parent-1",
+        conversationType: "background",
+        forkParentConversationId: "source-1",
+      }),
+    ).toBe("parent-1");
+  });
+
+  test("background fork falls back to the fork parent", () => {
+    expect(
+      resolveSpawnParentConversationId({
+        parentConversationId: null,
+        conversationType: "background",
+        forkParentConversationId: "source-1",
+      }),
+    ).toBe("source-1");
+  });
+
+  test("standard (user-initiated) fork does NOT resolve the fork parent", () => {
+    expect(
+      resolveSpawnParentConversationId({
+        parentConversationId: null,
+        conversationType: "standard",
+        forkParentConversationId: "source-1",
+      }),
+    ).toBeNull();
+  });
+
+  test("no parent and no fork resolves to null", () => {
+    expect(
+      resolveSpawnParentConversationId({
+        parentConversationId: null,
+        conversationType: "standard",
+        forkParentConversationId: null,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("buildUsageOriginSnapshot spawn-parent resolution", () => {
+  // A retrospective-fork background conversation: no live subagent parent, but
+  // its `fork_parent_conversation_id` points back at the source. The snapshot
+  // resolves the fork parent and classifies `delegated_child`, matching the
+  // telemetry read path's `parentIdSql` fallback plus `classifyWorkOrigin` for
+  // the same conversation.
+  test("retrospective fork carries the fork parent and classifies delegated_child", () => {
+    const snapshot = buildUsageOriginSnapshot({
+      conversationType: "background",
+      conversationSource: "memory-retrospective",
+      callSite: "memoryRetrospective",
+      conversationId: "retro-1",
+      turnIndex: 1,
+      parentConversationId: null,
+      forkParentConversationId: "source-1",
+      parentTurnIndex: null,
+    });
+    expect(snapshot.parentConversationId).toBe("source-1");
+    expect(snapshot.workOrigin).toBe("delegated_child");
+    // Telemetry resolves the identical parent for the same row and runs the
+    // same classifier, so the two agree.
+    expect(
+      classifyWorkOrigin({
+        conversationType: "background",
+        conversationSource: "memory-retrospective",
+        callSite: "memoryRetrospective",
+        parentConversationId: resolveSpawnParentConversationId({
+          parentConversationId: null,
+          conversationType: "background",
+          forkParentConversationId: "source-1",
+        }),
+      }),
+    ).toBe("delegated_child");
+  });
+
+  test("subagent spawn keeps the live parent (fork parent unset)", () => {
+    const snapshot = buildUsageOriginSnapshot({
+      conversationType: "background",
+      conversationSource: "subagent",
+      callSite: "subagentSpawn",
+      conversationId: "child-1",
+      turnIndex: 1,
+      parentConversationId: "parent-1",
+      forkParentConversationId: null,
+      parentTurnIndex: null,
+    });
+    expect(snapshot.parentConversationId).toBe("parent-1");
+    expect(snapshot.workOrigin).toBe("delegated_child");
+  });
+
+  test("standard user fork keeps itself (no delegated attribution)", () => {
+    const snapshot = buildUsageOriginSnapshot({
+      conversationType: "standard",
+      conversationSource: "user",
+      callSite: "mainAgent",
+      conversationId: "user-fork-1",
+      turnIndex: 2,
+      parentConversationId: null,
+      forkParentConversationId: "source-1",
+      parentTurnIndex: null,
+    });
+    expect(snapshot.parentConversationId).toBeNull();
+    expect(snapshot.workOrigin).toBe("user_interactive");
+  });
 });

--- a/assistant/src/usage/work-origin.test.ts
+++ b/assistant/src/usage/work-origin.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, test } from "bun:test";
 import {
   buildUsageOriginSnapshot,
   classifyWorkOrigin,
-  resolveSpawnParentConversationId,
   type WorkOrigin,
   type WorkOriginInput,
 } from "./work-origin.js";
@@ -484,99 +483,37 @@ describe("classifyWorkOrigin residual-bucket guard: unrecognized combinations st
   }
 });
 
-describe("resolveSpawnParentConversationId", () => {
-  test("subagent parent wins over a fork parent", () => {
-    expect(
-      resolveSpawnParentConversationId({
-        parentConversationId: "parent-1",
-        conversationType: "background",
-        forkParentConversationId: "source-1",
-      }),
-    ).toBe("parent-1");
-  });
-
-  test("background fork falls back to the fork parent", () => {
-    expect(
-      resolveSpawnParentConversationId({
-        parentConversationId: null,
-        conversationType: "background",
-        forkParentConversationId: "source-1",
-      }),
-    ).toBe("source-1");
-  });
-
-  test("standard (user-initiated) fork does NOT resolve the fork parent", () => {
-    expect(
-      resolveSpawnParentConversationId({
-        parentConversationId: null,
-        conversationType: "standard",
-        forkParentConversationId: "source-1",
-      }),
-    ).toBeNull();
-  });
-
-  test("no parent and no fork resolves to null", () => {
-    expect(
-      resolveSpawnParentConversationId({
-        parentConversationId: null,
-        conversationType: "standard",
-        forkParentConversationId: null,
-      }),
-    ).toBeNull();
-  });
-});
-
-describe("buildUsageOriginSnapshot spawn-parent resolution", () => {
-  // A retrospective-fork background conversation: no live subagent parent, but
-  // its `fork_parent_conversation_id` points back at the source. The snapshot
-  // resolves the fork parent and classifies `delegated_child`, matching the
-  // telemetry read path's `parentIdSql` fallback plus `classifyWorkOrigin` for
-  // the same conversation.
-  test("retrospective fork carries the fork parent and classifies delegated_child", () => {
+describe("buildUsageOriginSnapshot", () => {
+  // The spawn parent reaches the snapshot already resolved, by
+  // `resolveSpawnAttribution` on the store: the same expression the telemetry
+  // read path reads. A resolved parent classifies the call as delegated work
+  // whatever the conversation's own source says.
+  test("a resolved spawn parent carries through and classifies delegated_child", () => {
     const snapshot = buildUsageOriginSnapshot({
       conversationType: "background",
       conversationSource: "memory-retrospective",
       callSite: "memoryRetrospective",
       conversationId: "retro-1",
       turnIndex: 1,
-      parentConversationId: null,
-      forkParentConversationId: "source-1",
+      parentConversationId: "source-1",
       parentTurnIndex: null,
+      cronRunId: null,
     });
     expect(snapshot.parentConversationId).toBe("source-1");
     expect(snapshot.workOrigin).toBe("delegated_child");
-    // Telemetry resolves the identical parent for the same row and runs the
-    // same classifier, so the two agree.
+    // Telemetry runs the same classifier over the same resolved parent, so the
+    // two surfaces agree.
     expect(
       classifyWorkOrigin({
         conversationType: "background",
         conversationSource: "memory-retrospective",
         callSite: "memoryRetrospective",
-        parentConversationId: resolveSpawnParentConversationId({
-          parentConversationId: null,
-          conversationType: "background",
-          forkParentConversationId: "source-1",
-        }),
+        parentConversationId: "source-1",
       }),
     ).toBe("delegated_child");
   });
 
-  test("subagent spawn keeps the live parent (fork parent unset)", () => {
-    const snapshot = buildUsageOriginSnapshot({
-      conversationType: "background",
-      conversationSource: "subagent",
-      callSite: "subagentSpawn",
-      conversationId: "child-1",
-      turnIndex: 1,
-      parentConversationId: "parent-1",
-      forkParentConversationId: null,
-      parentTurnIndex: null,
-    });
-    expect(snapshot.parentConversationId).toBe("parent-1");
-    expect(snapshot.workOrigin).toBe("delegated_child");
-  });
-
-  test("standard user fork keeps itself (no delegated attribution)", () => {
+  test("no spawn parent keeps the conversation's own attribution", () => {
     const snapshot = buildUsageOriginSnapshot({
       conversationType: "standard",
       conversationSource: "user",
@@ -584,10 +521,29 @@ describe("buildUsageOriginSnapshot spawn-parent resolution", () => {
       conversationId: "user-fork-1",
       turnIndex: 2,
       parentConversationId: null,
-      forkParentConversationId: "source-1",
       parentTurnIndex: null,
+      cronRunId: null,
     });
     expect(snapshot.parentConversationId).toBeNull();
     expect(snapshot.workOrigin).toBe("user_interactive");
+  });
+
+  // A wake or defer schedule fires inside an ordinary conversation whose type
+  // and source stay standard/user, so the firing's run id is the only signal
+  // that the spend is schedule-driven. It rides the snapshot for both the
+  // billing headers and the auto-recorded usage row.
+  test("a cron run id classifies a standard conversation as user_created_schedule", () => {
+    const snapshot = buildUsageOriginSnapshot({
+      conversationType: "standard",
+      conversationSource: "user",
+      callSite: "mainAgent",
+      conversationId: "conv-123",
+      turnIndex: 3,
+      parentConversationId: null,
+      parentTurnIndex: null,
+      cronRunId: "cron-run-1",
+    });
+    expect(snapshot.cronRunId).toBe("cron-run-1");
+    expect(snapshot.workOrigin).toBe("user_created_schedule");
   });
 });

--- a/assistant/src/usage/work-origin.ts
+++ b/assistant/src/usage/work-origin.ts
@@ -338,3 +338,114 @@ export function classifyWorkOrigin(input: WorkOriginInput): WorkOrigin {
   }
   return "unknown";
 }
+
+/**
+ * Resolve the id of the conversation that spawned this one.
+ *
+ * Precedence, highest first:
+ *   1. `conversations.parent_conversation_id`, the live subagent-spawn parent,
+ *   2. `conversations.fork_parent_conversation_id`, but only when the
+ *      conversation's type is `background` (retrospective forks), so a fork's
+ *      spend is attributed to the delegating turn,
+ *   3. null, meaning the conversation was not spawned by another.
+ *
+ * The `background` gate on rule 2 matters: user-initiated forks also stamp
+ * `fork_parent_conversation_id`, but they are first-class `standard`
+ * conversations whose spend belongs to themselves.
+ *
+ * **Agreement contract.** This is the same precedence the `llm_usage`
+ * telemetry read path encodes as `parentIdSql` in `queryUnreportedUsageEvents`
+ * (`persistence/llm-usage-store.ts`). The live billing-origin snapshot and the
+ * telemetry row must resolve the same spawn parent for the same conversation,
+ * or the two attribution surfaces disagree about who owns the cost. Change one
+ * and change the other.
+ */
+export function resolveSpawnParentConversationId(input: {
+  parentConversationId: string | null;
+  conversationType: string | null;
+  forkParentConversationId: string | null;
+}): string | null {
+  if (input.parentConversationId !== null) {
+    return input.parentConversationId;
+  }
+  if (input.conversationType === "background") {
+    return input.forkParentConversationId;
+  }
+  return null;
+}
+
+/**
+ * An immutable, record-time attribution of an in-flight LLM call, carried on
+ * the provider send config so the managed-proxy transport can forward it to
+ * the billing backend as `X-Vellum-*` headers. Every field is explicitly
+ * nullable so a non-conversation auxiliary call stays distinguishable from a
+ * conversation-scoped one (null is not an "unattributed default").
+ * {@link workOrigin} is the same bucket the `llm_usage` telemetry derives via
+ * {@link classifyWorkOrigin}, so managed billing rows and usage telemetry share
+ * one classifier and one vocabulary.
+ *
+ * `turnIndex` is the position of the user turn the call belongs to, counting
+ * real user turns, matching the `llm_usage` read-path convention.
+ * `parentConversationId` is the resolved spawn parent
+ * ({@link resolveSpawnParentConversationId}): the subagent-spawn parent, or a
+ * background fork's source conversation. `parentTurnIndex` counts that
+ * conversation's real user turns. Both are null when the conversation was not
+ * spawned by another.
+ *
+ * Every field is best-effort. Attribution never fails or blocks a provider
+ * call: an unresolvable field degrades to null (or, for a failed turn count, to
+ * 0) and the call proceeds without that header.
+ */
+export interface UsageOriginSnapshot {
+  conversationType: string | null;
+  conversationSource: string | null;
+  workOrigin: WorkOrigin | null;
+  conversationId: string | null;
+  turnIndex: number | null;
+  parentConversationId: string | null;
+  parentTurnIndex: number | null;
+}
+
+/**
+ * Build a {@link UsageOriginSnapshot}, deriving
+ * {@link UsageOriginSnapshot.workOrigin} from the same {@link classifyWorkOrigin}
+ * the usage telemetry uses. Callers pass the record-time conversation metadata
+ * and call site; nulls are preserved verbatim so auxiliary (no-conversation)
+ * calls stay distinguishable.
+ *
+ * The spawn parent is resolved via {@link resolveSpawnParentConversationId} and
+ * is what the classifier sees as `parentConversationId`, so a background fork
+ * classifies as `delegated_child` here exactly as it does on the telemetry read
+ * path. Callers pass the raw fork lineage rather than a pre-resolved parent, so
+ * the precedence stays in one place.
+ */
+export function buildUsageOriginSnapshot(input: {
+  conversationType: string | null;
+  conversationSource: string | null;
+  callSite: string | null;
+  conversationId: string | null;
+  turnIndex: number | null;
+  parentConversationId: string | null;
+  forkParentConversationId: string | null;
+  parentTurnIndex: number | null;
+}): UsageOriginSnapshot {
+  const spawnParentConversationId = resolveSpawnParentConversationId({
+    parentConversationId: input.parentConversationId,
+    conversationType: input.conversationType,
+    forkParentConversationId: input.forkParentConversationId,
+  });
+  return {
+    conversationType: input.conversationType,
+    conversationSource: input.conversationSource,
+    workOrigin: classifyWorkOrigin({
+      conversationType: input.conversationType,
+      conversationSource: input.conversationSource,
+      callSite: input.callSite,
+      parentConversationId: spawnParentConversationId,
+    }),
+    conversationId: input.conversationId,
+    turnIndex: input.turnIndex,
+    parentConversationId: spawnParentConversationId,
+    parentTurnIndex: input.parentTurnIndex,
+  };
+}

--- a/assistant/src/usage/work-origin.ts
+++ b/assistant/src/usage/work-origin.ts
@@ -340,41 +340,6 @@ export function classifyWorkOrigin(input: WorkOriginInput): WorkOrigin {
 }
 
 /**
- * Resolve the id of the conversation that spawned this one.
- *
- * Precedence, highest first:
- *   1. `conversations.parent_conversation_id`, the live subagent-spawn parent,
- *   2. `conversations.fork_parent_conversation_id`, but only when the
- *      conversation's type is `background` (retrospective forks), so a fork's
- *      spend is attributed to the delegating turn,
- *   3. null, meaning the conversation was not spawned by another.
- *
- * The `background` gate on rule 2 matters: user-initiated forks also stamp
- * `fork_parent_conversation_id`, but they are first-class `standard`
- * conversations whose spend belongs to themselves.
- *
- * **Agreement contract.** This is the same precedence the `llm_usage`
- * telemetry read path encodes as `parentIdSql` in `queryUnreportedUsageEvents`
- * (`persistence/llm-usage-store.ts`). The live billing-origin snapshot and the
- * telemetry row must resolve the same spawn parent for the same conversation,
- * or the two attribution surfaces disagree about who owns the cost. Change one
- * and change the other.
- */
-export function resolveSpawnParentConversationId(input: {
-  parentConversationId: string | null;
-  conversationType: string | null;
-  forkParentConversationId: string | null;
-}): string | null {
-  if (input.parentConversationId !== null) {
-    return input.parentConversationId;
-  }
-  if (input.conversationType === "background") {
-    return input.forkParentConversationId;
-  }
-  return null;
-}
-
-/**
  * An immutable, record-time attribution of an in-flight LLM call, carried on
  * the provider send config so the managed-proxy transport can forward it to
  * the billing backend as `X-Vellum-*` headers. Every field is explicitly
@@ -386,11 +351,15 @@ export function resolveSpawnParentConversationId(input: {
  *
  * `turnIndex` is the position of the user turn the call belongs to, counting
  * real user turns, matching the `llm_usage` read-path convention.
- * `parentConversationId` is the resolved spawn parent
- * ({@link resolveSpawnParentConversationId}): the subagent-spawn parent, or a
- * background fork's source conversation. `parentTurnIndex` counts that
- * conversation's real user turns. Both are null when the conversation was not
- * spawned by another.
+ * `parentConversationId` is the resolved spawn parent (`SPAWN_PARENT_ID_SQL` in
+ * `persistence/llm-usage-store.ts`): the subagent-spawn parent, or a background
+ * fork's source conversation. `parentTurnIndex` counts that conversation's real
+ * user turns. Both are null when the conversation was not spawned by another.
+ *
+ * `cronRunId` is the schedule firing behind the call, carried so the classifier
+ * sees a wake or defer schedule that fired inside an otherwise standard
+ * conversation, and so the auto-recorded `llm_usage` row can stamp the same
+ * firing.
  *
  * Every field is best-effort. Attribution never fails or blocks a provider
  * call: an unresolvable field degrades to null (or, for a failed turn count, to
@@ -404,20 +373,15 @@ export interface UsageOriginSnapshot {
   turnIndex: number | null;
   parentConversationId: string | null;
   parentTurnIndex: number | null;
+  cronRunId: string | null;
 }
 
 /**
  * Build a {@link UsageOriginSnapshot}, deriving
  * {@link UsageOriginSnapshot.workOrigin} from the same {@link classifyWorkOrigin}
- * the usage telemetry uses. Callers pass the record-time conversation metadata
- * and call site; nulls are preserved verbatim so auxiliary (no-conversation)
- * calls stay distinguishable.
- *
- * The spawn parent is resolved via {@link resolveSpawnParentConversationId} and
- * is what the classifier sees as `parentConversationId`, so a background fork
- * classifies as `delegated_child` here exactly as it does on the telemetry read
- * path. Callers pass the raw fork lineage rather than a pre-resolved parent, so
- * the precedence stays in one place.
+ * the usage telemetry uses. Callers pass the record-time conversation metadata,
+ * call site, and already-resolved spawn parent; nulls are preserved verbatim so
+ * auxiliary (no-conversation) calls stay distinguishable.
  */
 export function buildUsageOriginSnapshot(input: {
   conversationType: string | null;
@@ -426,14 +390,9 @@ export function buildUsageOriginSnapshot(input: {
   conversationId: string | null;
   turnIndex: number | null;
   parentConversationId: string | null;
-  forkParentConversationId: string | null;
   parentTurnIndex: number | null;
+  cronRunId: string | null;
 }): UsageOriginSnapshot {
-  const spawnParentConversationId = resolveSpawnParentConversationId({
-    parentConversationId: input.parentConversationId,
-    conversationType: input.conversationType,
-    forkParentConversationId: input.forkParentConversationId,
-  });
   return {
     conversationType: input.conversationType,
     conversationSource: input.conversationSource,
@@ -441,11 +400,13 @@ export function buildUsageOriginSnapshot(input: {
       conversationType: input.conversationType,
       conversationSource: input.conversationSource,
       callSite: input.callSite,
-      parentConversationId: spawnParentConversationId,
+      parentConversationId: input.parentConversationId,
+      cronRunId: input.cronRunId,
     }),
     conversationId: input.conversationId,
     turnIndex: input.turnIndex,
-    parentConversationId: spawnParentConversationId,
+    parentConversationId: input.parentConversationId,
     parentTurnIndex: input.parentTurnIndex,
+    cronRunId: input.cronRunId,
   };
 }


### PR DESCRIPTION
Part 4 (final implementation chunk) of the work-origin cost-attribution stack (stacked on #40764; will be retargeted to `aaron/work-origin-attribution` as earlier parts merge; never targets main).

## What

Managed inference calls now carry work-origin and turn linkage so the billing backend can key rows by the same vocabulary the `llm_usage` telemetry uses:

- `buildTurnUsageOriginSnapshot` assembles an immutable per-turn `UsageOriginSnapshot` (work origin, conversation id/type/source, real-user-turn index, spawn-parent id and its turn index) at agent-loop start (`runAgentLoopImpl`) and on background wakes (`wakeAgentForOpportunity`), from one shared helper.
- The snapshot rides the per-call provider config; `RetryProvider` maps it to seven headers on the managed-proxy transport only (`forwardUsageAttributionHeaders` gate): `X-Vellum-Conversation-Type`, `X-Vellum-Conversation-Source`, `X-Vellum-Work-Origin`, `X-Vellum-Conversation-Id`, `X-Vellum-Turn-Index`, `X-Vellum-Parent-Conversation-Id`, `X-Vellum-Parent-Turn-Index`.
- Values are sanitized to the platform header contract (charset `[A-Za-z0-9._:@/-]`, max 256 chars; turn indexes as non-negative decimal integers); invalid values are omitted, never rewritten. The snapshot itself is stripped from the wire config unconditionally so it cannot reach a provider request body.

## Consistency contracts (review focus)

- `resolveSpawnParentConversationId` implements the same precedence as the flush-time `parentIdSql` in `queryUnreportedUsageEvents` (parent id wins; fork parent only for `background` conversations), documented at both sites, so live billing headers and batched telemetry attribute a retrospective fork identically.
- Turn indexes count the same real-user-turn population as the telemetry read path (`countRealUserTurns` shares `realUserTurnContentFilter`).
- All lookups are best-effort and degrade to null/0: attribution can never fail or block a provider call.

## Verify

```
cd assistant
bun test src/__tests__/usage-origin-snapshot.test.ts
bun test src/__tests__/llm-usage-store.test.ts
bun test src/providers/__tests__/retry-callsite.test.ts
bun test src/runtime/__tests__/agent-wake.test.ts
bun run typecheck:fast && bun run lint
```

Part of the CAS-023 cost-attribution effort (Velcro case_c30f7ae1-bc36-47ea-ad9a-987ccdec2888).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40771" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->