### PR TITLE
ci(design-library): run the Storybook browser tests on main, not only on PRs

### DIFF
--- a/.github/workflows/ci-main-design-library.yaml
+++ b/.github/workflows/ci-main-design-library.yaml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   checks:
-    name: Type Check & Unit Test
+    name: Type Check & Test
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -40,8 +40,16 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile --filter=@vellumai/design-library
 
+      - name: Install Playwright browsers
+        run: bunx playwright install chromium --with-deps
+
       - name: Type check
         run: bun run typecheck
 
+      # `bun run test` is vitest, whose config covers only the Storybook
+      # browser project; this step runs the package's bun:test unit files.
       - name: Unit tests
         run: bun run test:unit
+
+      - name: Test
+        run: bun run test


### PR DESCRIPTION
## TL;DR

The PR workflow runs the vitest project that executes every story as a browser test under Playwright chromium. The main-branch workflow did not, so those assertions gated pull requests and nothing else. One step added, plus the Playwright install it needs.

## Why it matters

The main workflow's own header comment says it exists to "catch breakage that lands without touching the package's PR path filters (dependency bumps, direct pushes)". Story assertions were exactly the class of check it was missing: a story asserting real behaviour could regress on `main` and stay green until the next design-library PR happened to run.

Not hypothetical for long: #40719 lands a `play` function asserting that a tap leaves no tooltip stranded, in both the Chromium and Safari event orderings. Under the old workflow that contract was unenforced on `main`.

## What changed

| Before | After |
| --- | --- |
| Type check, unit tests | Type check, unit tests, and the Storybook browser project |
| No Playwright install | `bunx playwright install chromium --with-deps`, matching the PR workflow |
| Job named "Type Check & Unit Test" | "Type Check & Test", matching what it runs |

## Why this is safe

- Mirrors `pr-design-library.yaml` step for step, so it runs the same suite that already passes on every design-library PR.
- Main-branch workflow only: no effect on PR gating.
- The two steps cover disjoint sets. The comment carried over from the PR workflow says so: vitest's config covers only the Storybook browser project, while the unit step runs the package's `bun:test` files.
- The one cost is runtime: the Playwright install and browser run add a few minutes to a workflow that currently takes about one.

## Not doing

A lint or format gate for this package was considered and rejected. It would have enforced a proxy (args-first stories) rather than a defect, and a dead Controls panel harms no user. This PR only makes existing assertions run in one more place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40774" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->