### PR TITLE
feat(daemon): needsAttention filter on GET /v1/conversations (JARVIS-1541)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6596,6 +6596,18 @@ paths:
             "system:all" for conversations in no group, "system:pinned" for the Pinned section, or a custom group id. A
             group-scoped request is recency-ordered like every list read (COALESCE(last_message_at, updated_at)
             descending) and never has pinned rows appended to it. Omit to span every group.
+        - name: needsAttention
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - "true"
+          description:
+            'Pass "true" to return only conversations whose latest assistant message the user has not seen: the same
+            predicate behind the unread count and the section index, so a client that keeps no complete conversation
+            list can ask for exactly the rows its attention surfaces need. Composes with every other filter. Any value
+            other than "true" is rejected. Omit to span every conversation.'
       responses:
         "200":
           description: Successful response

--- a/assistant/src/persistence/conversation-queries.ts
+++ b/assistant/src/persistence/conversation-queries.ts
@@ -346,6 +346,17 @@ function originChannelClause(originChannel: string) {
   return eq(conversations.originChannel, originChannel);
 }
 
+/**
+ * The join between a conversation and its attention projection, one row per
+ * conversation in `conversation_assistant_attention_state`. Every reader of
+ * "unseen" joins on this: the list and count filters, the unread count, and
+ * the section index.
+ */
+const attentionJoin = eq(
+  conversationAssistantAttentionState.conversationId,
+  conversations.id,
+);
+
 function conversationListWhere(filter: ConversationListFilter) {
   const {
     conversationType = "standard",
@@ -365,9 +376,9 @@ function conversationListWhere(filter: ConversationListFilter) {
 
 /**
  * The joins {@link conversationListWhere}'s predicates need, applied to a
- * list or count query over `conversations`. Today that is one: the attention
- * predicate lives on `conversation_assistant_attention_state`, so
- * `needsAttention` joins it. Inner, not left: a conversation with no
+ * list or count query over `conversations`. The attention predicate lives on
+ * `conversation_assistant_attention_state`, so `needsAttention` joins it.
+ * Inner, not left: a conversation with no
  * attention row has no unseen message by definition. Joined only when the
  * filter asks, so a query without the filter runs without the join and
  * lists every conversation the predicates admit. One place for both
@@ -381,10 +392,7 @@ function withListFilterJoins<T extends SQLiteSelect>(
   if (!filter.needsAttention) {
     return query;
   }
-  return query.innerJoin(
-    conversationAssistantAttentionState,
-    eq(conversationAssistantAttentionState.conversationId, conversations.id),
-  );
+  return query.innerJoin(conversationAssistantAttentionState, attentionJoin);
 }
 
 export function listConversations(
@@ -632,10 +640,7 @@ export function countUnreadConversations(): number {
   const [{ total }] = db
     .select({ total: count() })
     .from(conversations)
-    .innerJoin(
-      conversationAssistantAttentionState,
-      eq(conversationAssistantAttentionState.conversationId, conversations.id),
-    )
+    .innerJoin(conversationAssistantAttentionState, attentionJoin)
     .where(
       and(
         conversationTypeClause("standard"),
@@ -696,11 +701,6 @@ export function countConversationSections(): ConversationSectionCounts {
     sql.raw(notBackgroundVisibilitySql()),
     ...unseenAttentionStateConditions(),
   )} THEN 1 ELSE 0 END)`;
-
-  const attentionJoin = eq(
-    conversationAssistantAttentionState.conversationId,
-    conversations.id,
-  );
 
   const groups = db
     .select({

--- a/assistant/src/persistence/conversation-queries.ts
+++ b/assistant/src/persistence/conversation-queries.ts
@@ -1,4 +1,14 @@
-import { and, count, desc, eq, isNull, lt, sql } from "drizzle-orm";
+import {
+  and,
+  count,
+  desc,
+  eq,
+  getTableColumns,
+  isNull,
+  lt,
+  sql,
+} from "drizzle-orm";
+import type { SQLiteSelect } from "drizzle-orm/sqlite-core";
 
 import {
   parseExternalContentEnvelope,
@@ -263,6 +273,15 @@ export interface ConversationListFilter {
    * section, and a UUID one custom group. Omit to span every group.
    */
   groupId?: string;
+  /**
+   * Restrict to conversations whose latest assistant message the user has
+   * not seen: the same "unseen" predicate the unread count and the section
+   * index apply ({@link unseenAttentionStateConditions}), so every reader
+   * of "needs attention" agrees. Only `true` narrows; omit to span every
+   * conversation. A client that keeps no complete list can ask for exactly
+   * the rows its attention surfaces need instead of scanning for them.
+   */
+  needsAttention?: true;
 }
 
 export interface ConversationListQuery extends ConversationListFilter {
@@ -333,12 +352,38 @@ function conversationListWhere(filter: ConversationListFilter) {
     archiveStatus = "active",
     originChannel,
     groupId,
+    needsAttention,
   } = filter;
   return and(
     conversationTypeClause(conversationType),
     archiveStatusClause(archiveStatus) ?? undefined,
     originChannel ? originChannelClause(originChannel) : undefined,
     groupId ? groupIdClause(groupId) : undefined,
+    ...(needsAttention ? unseenAttentionStateConditions() : []),
+  );
+}
+
+/**
+ * The joins {@link conversationListWhere}'s predicates need, applied to a
+ * list or count query over `conversations`. Today that is one: the attention
+ * predicate lives on `conversation_assistant_attention_state`, so
+ * `needsAttention` joins it. Inner, not left: a conversation with no
+ * attention row has no unseen message by definition. Joined only when the
+ * filter asks, so every other query stays exactly as it was, no join and no
+ * row it did not have before. One place for both {@link listConversations}
+ * and {@link countConversations}, so a page and its total always describe
+ * the same set.
+ */
+function withListFilterJoins<T extends SQLiteSelect>(
+  query: T,
+  filter: ConversationListFilter,
+) {
+  if (!filter.needsAttention) {
+    return query;
+  }
+  return query.innerJoin(
+    conversationAssistantAttentionState,
+    eq(conversationAssistantAttentionState.conversationId, conversations.id),
   );
 }
 
@@ -362,9 +407,13 @@ export function listConversations(
   // distinguish a total order from a lucky one. The guarantee becomes
   // observable, and gets its test, with the keyset pagination work.
   const tiebreak = desc(conversations.id);
-  return db
-    .select()
-    .from(conversations)
+  // Selecting the conversation columns explicitly keeps the row shape
+  // `parseConversation` maps identical whether or not the attention join is
+  // present.
+  return withListFilterJoins(
+    db.select(getTableColumns(conversations)).from(conversations).$dynamic(),
+    filter,
+  )
     .where(conversationListWhere(filter))
     .orderBy(recency, tiebreak)
     .limit(limit ?? 100)
@@ -542,9 +591,10 @@ export function countConversations(
 ): number {
   ensureGroupMigration();
   const db = getDb();
-  const [{ total }] = db
-    .select({ total: count() })
-    .from(conversations)
+  const [{ total }] = withListFilterJoins(
+    db.select({ total: count() }).from(conversations).$dynamic(),
+    filter,
+  )
     .where(conversationListWhere(filter))
     .all();
   return total;

--- a/assistant/src/persistence/conversation-queries.ts
+++ b/assistant/src/persistence/conversation-queries.ts
@@ -369,10 +369,10 @@ function conversationListWhere(filter: ConversationListFilter) {
  * predicate lives on `conversation_assistant_attention_state`, so
  * `needsAttention` joins it. Inner, not left: a conversation with no
  * attention row has no unseen message by definition. Joined only when the
- * filter asks, so every other query stays exactly as it was, no join and no
- * row it did not have before. One place for both {@link listConversations}
- * and {@link countConversations}, so a page and its total always describe
- * the same set.
+ * filter asks, so a query without the filter runs without the join and
+ * lists every conversation the predicates admit. One place for both
+ * {@link listConversations} and {@link countConversations}, so a page and
+ * its total always describe the same set.
  */
 function withListFilterJoins<T extends SQLiteSelect>(
   query: T,

--- a/assistant/src/runtime/routes/__tests__/conversation-list-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-list-routes.test.ts
@@ -597,6 +597,26 @@ describe("GET /v1/conversations with needsAttention", () => {
     expect(rest.hasMore).toBe(false);
   });
 
+  test("an attention-scoped first page has no pinned rows appended to it", async () => {
+    /* Same rule as the group-scoped page: the pinned injection exists for
+       a client reading Pinned out of the unfiltered list, and a caller
+       that asked for the unseen subset is not that client. A seen pinned
+       row appended here would be a row outside the filter, on a page whose
+       hasMore was computed from the filtered count. */
+    const unseen = createConversation("unseen-only");
+    seedUnseen(unseen.id);
+    const pinnedSeen = createConversation("pinned-and-seen");
+    rawRun(
+      "test:pinConversation",
+      "UPDATE conversations SET is_pinned = 1, group_id = 'system:pinned' WHERE id = ?",
+      pinnedSeen.id,
+    );
+
+    const result = await invoke({ needsAttention: "true" });
+
+    expect(result.conversations.map((c) => c.title)).toEqual(["unseen-only"]);
+  });
+
   test("composes with the other filters", async () => {
     const group = createGroup("Work");
     const inGroupUnseen = createConversation("in-group-unseen");

--- a/assistant/src/runtime/routes/__tests__/conversation-list-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-list-routes.test.ts
@@ -514,6 +514,119 @@ describe("GET /v1/conversations with groupId", () => {
   });
 });
 
+describe("GET /v1/conversations with needsAttention", () => {
+  function seedUnseen(conversationId: string): void {
+    projectAssistantMessage({
+      conversationId,
+      messageId: `msg-${conversationId}`,
+      messageAt: Date.now(),
+    });
+  }
+
+  function markSeen(conversationId: string): void {
+    recordConversationSeenSignal({
+      conversationId,
+      sourceChannel: "vellum",
+      signalType: "macos_conversation_opened",
+      confidence: "explicit",
+      source: "test",
+    });
+  }
+
+  beforeEach(() => {
+    getDb().delete(conversationAttentionEvents).run();
+    getDb().delete(conversationAssistantAttentionState).run();
+    clearConversations();
+  });
+
+  test("returns only conversations with an unseen latest assistant message", async () => {
+    const unseen = createConversation("needs-attention");
+    seedUnseen(unseen.id);
+    const seen = createConversation("already-seen");
+    seedUnseen(seen.id);
+    markSeen(seen.id);
+    // No attention projection at all: not unseen, so not returned. The
+    // filter's inner join is what excludes it; a left join would leak it.
+    createConversation("never-projected");
+
+    const result = await invoke({ needsAttention: "true" });
+
+    expect(result.conversations.map((c) => c.title)).toEqual([
+      "needs-attention",
+    ]);
+  });
+
+  test("omitting the filter leaves every list unchanged, join and all", async () => {
+    /* The sensitivity check for the conditional join: with the filter off,
+       rows with no attention row must still be listed. If the join were
+       applied unconditionally, "never-projected" would vanish from the
+       plain list, which is every list the app has today. */
+    const unseen = createConversation("has-attention-row");
+    seedUnseen(unseen.id);
+    createConversation("never-projected");
+
+    const result = await invoke();
+
+    expect(result.conversations.map((c) => c.title).sort()).toEqual([
+      "has-attention-row",
+      "never-projected",
+    ]);
+  });
+
+  test("hasMore and the total describe the filtered set, not the whole table", async () => {
+    /* countConversations reads through the same where AND the same join;
+       a page and its total have to agree or the client's hasMore lies. */
+    for (let i = 0; i < 3; i++) {
+      const c = createConversation(`unseen-${i}`);
+      seedUnseen(c.id);
+    }
+    for (let i = 0; i < 5; i++) {
+      createConversation(`quiet-${i}`);
+    }
+
+    const page = await invoke({ needsAttention: "true", limit: "2" });
+
+    expect(page.conversations).toHaveLength(2);
+    expect(page.hasMore).toBe(true);
+    const rest = await invoke({
+      needsAttention: "true",
+      limit: "2",
+      offset: "2",
+    });
+    expect(rest.conversations).toHaveLength(1);
+    expect(rest.hasMore).toBe(false);
+  });
+
+  test("composes with the other filters", async () => {
+    const group = createGroup("Work");
+    const inGroupUnseen = createConversation("in-group-unseen");
+    seedUnseen(inGroupUnseen.id);
+    rawRun(
+      "test:fileInGroup",
+      "UPDATE conversations SET group_id = ? WHERE id = ?",
+      group.id,
+      inGroupUnseen.id,
+    );
+    const outOfGroupUnseen = createConversation("out-of-group-unseen");
+    seedUnseen(outOfGroupUnseen.id);
+
+    const result = await invoke({ needsAttention: "true", groupId: group.id });
+
+    expect(result.conversations.map((c) => c.title)).toEqual([
+      "in-group-unseen",
+    ]);
+  });
+
+  test('any value other than "true" is rejected with a 400', () => {
+    /* Same posture as conversationType: silently reading a typo or a newer
+       client's value as "no filter" would hand back the full list where a
+       subset was asked for, and that skew is invisible to the client. */
+    for (const bad of ["false", "1", "yes", "TRUE"]) {
+      expect(() => invoke({ needsAttention: bad })).toThrow(BadRequestError);
+    }
+  });
+});
+
 describe("GET /v1/conversations/unread-count", () => {
   const unreadCountHandler = findHandler(
     CONVERSATION_LIST_ROUTES,

--- a/assistant/src/runtime/routes/conversation-list-routes.ts
+++ b/assistant/src/runtime/routes/conversation-list-routes.ts
@@ -251,11 +251,28 @@ function handleListConversations({ queryParams = {} }: RouteHandlerArgs) {
       ? queryParams.groupId
       : undefined;
 
+  // Only the literal "true" narrows. Anything else is a 400 for the same
+  // reason an unknown conversationType is: silently reading a typo or a
+  // newer client's value as "no filter" would return the full list where the
+  // client asked for a subset, and that skew is invisible.
+  const rawNeedsAttention = queryParams.needsAttention;
+  let needsAttention: true | undefined;
+  if (rawNeedsAttention !== undefined && rawNeedsAttention !== "") {
+    if (rawNeedsAttention === "true") {
+      needsAttention = true;
+    } else {
+      throw new BadRequestError(
+        `Unknown needsAttention "${rawNeedsAttention}"; expected "true" or omit.`,
+      );
+    }
+  }
+
   const filter: ConversationListFilter = {
     conversationType,
     archiveStatus,
     originChannel,
     groupId,
+    needsAttention,
   };
   let rows = listConversations({ ...filter, limit, offset });
   const totalCount = countConversations(filter);
@@ -579,6 +596,14 @@ export const ROUTES: RouteDefinition[] = [
         required: false,
         description:
           'Filter to a single group, so each sidebar section can load independently of the paginated list. Pass "system:all" for conversations in no group, "system:pinned" for the Pinned section, or a custom group id. A group-scoped request is recency-ordered like every list read (COALESCE(last_message_at, updated_at) descending) and never has pinned rows appended to it. Omit to span every group.',
+      },
+      {
+        name: "needsAttention",
+        type: "string",
+        required: false,
+        description:
+          'Pass "true" to return only conversations whose latest assistant message the user has not seen: the same predicate behind the unread count and the section index, so a client that keeps no complete conversation list can ask for exactly the rows its attention surfaces need. Composes with every other filter. Any value other than "true" is rejected. Omit to span every conversation.',
+        schema: { type: "string", enum: ["true"] },
       },
     ],
     responseBody: listConversationsResponseSchema,

--- a/assistant/src/runtime/routes/conversation-list-routes.ts
+++ b/assistant/src/runtime/routes/conversation-list-routes.ts
@@ -287,15 +287,19 @@ function handleListConversations({ queryParams = {} }: RouteHandlerArgs) {
   // Skipped for group-scoped queries for the same reason: a caller asking
   // for one group gets that group, and a client that fetches the Pinned
   // section via `groupId=system:pinned` has no use for rows appended to
-  // some other group's page. This is the compatibility shim for clients
-  // that still read Pinned out of the unfiltered list; it goes away once
-  // every section fetches its own group.
+  // some other group's page. Skipped for attention-scoped queries too: the
+  // caller asked for the unseen subset, and a seen pinned row appended to
+  // it would put a row outside the filter in the page while `hasMore` is
+  // computed from the filtered count. This is the compatibility shim for
+  // clients that still read Pinned out of the unfiltered list; it goes
+  // away once every section fetches its own group.
   if (
     offset === 0 &&
     conversationType === "standard" &&
     archiveStatus === "active" &&
     originChannel === undefined &&
-    groupId === undefined
+    groupId === undefined &&
+    needsAttention === undefined
   ) {
     const pinned = listPinnedConversations(archiveStatus);
     const seen = new Set(rows.map((c) => c.id));

--- a/assistant/src/runtime/routes/conversation-list-routes.ts
+++ b/assistant/src/runtime/routes/conversation-list-routes.ts
@@ -209,28 +209,41 @@ function resolveOrThrow(rawId: string): string {
 // Handlers
 // ---------------------------------------------------------------------------
 
+/**
+ * Read a query parameter that admits a closed set of values. Absent or empty
+ * reads as `undefined`; anything outside `accepted` is a 400. The strictness
+ * is the point: silently coercing a typo or a newer client's value to "no
+ * filter" would hand back the full list where a subset was asked for, and
+ * that skew is invisible to the client (it masks version skew too).
+ */
+function parseEnumQueryParam<const T extends readonly string[]>(
+  queryParams: Record<string, string | undefined>,
+  name: string,
+  accepted: T,
+): T[number] | undefined {
+  const raw = queryParams[name];
+  if (raw === undefined || raw === "") {
+    return undefined;
+  }
+  if ((accepted as readonly string[]).includes(raw)) {
+    return raw as T[number];
+  }
+  throw new BadRequestError(
+    `Unknown ${name} "${raw}"; expected ${accepted.map((v) => `"${v}"`).join(" or ")}.`,
+  );
+}
+
 function handleListConversations({ queryParams = {} }: RouteHandlerArgs) {
   const limit = Number(queryParams.limit ?? 50);
   const offset = Number(queryParams.offset ?? 0);
   // "background" is the back-compat umbrella (background + scheduled); newer
   // clients can pass "scheduled" to load only the Scheduled section. Absent
-  // defaults to the standard foreground list. Any other value is rejected so
-  // an unrecognized type surfaces as a 400 rather than being silently coerced
-  // to the foreground list (which would mask client/daemon version skew).
-  const rawConversationType = queryParams.conversationType;
-  let conversationType: ConversationType = "standard";
-  if (rawConversationType !== undefined && rawConversationType !== "") {
-    if (
-      rawConversationType === "background" ||
-      rawConversationType === "scheduled"
-    ) {
-      conversationType = rawConversationType;
-    } else {
-      throw new BadRequestError(
-        `Unknown conversationType "${rawConversationType}"; expected "background" or "scheduled".`,
-      );
-    }
-  }
+  // defaults to the standard foreground list.
+  const conversationType: ConversationType =
+    parseEnumQueryParam(queryParams, "conversationType", [
+      "background",
+      "scheduled",
+    ]) ?? "standard";
   // Defaults to `active` so sidebar restores no longer pull archived rows.
   // The Archive page opts into `archived` to render only archived rows
   // without dragging the entire live history through pagination first.
@@ -251,21 +264,10 @@ function handleListConversations({ queryParams = {} }: RouteHandlerArgs) {
       ? queryParams.groupId
       : undefined;
 
-  // Only the literal "true" narrows. Anything else is a 400 for the same
-  // reason an unknown conversationType is: silently reading a typo or a
-  // newer client's value as "no filter" would return the full list where the
-  // client asked for a subset, and that skew is invisible.
-  const rawNeedsAttention = queryParams.needsAttention;
-  let needsAttention: true | undefined;
-  if (rawNeedsAttention !== undefined && rawNeedsAttention !== "") {
-    if (rawNeedsAttention === "true") {
-      needsAttention = true;
-    } else {
-      throw new BadRequestError(
-        `Unknown needsAttention "${rawNeedsAttention}"; expected "true" or omit.`,
-      );
-    }
-  }
+  const needsAttention =
+    parseEnumQueryParam(queryParams, "needsAttention", ["true"]) === "true"
+      ? true
+      : undefined;
 
   const filter: ConversationListFilter = {
     conversationType,


### PR DESCRIPTION
## TL;DR

`GET /v1/conversations?needsAttention=true` returns only conversations whose latest assistant message the user has not seen, composing with every other list filter. Daemon-only; the web consumers move onto it in the next PR.

Fixes JARVIS-1541. Part of LUM-2409.

## What changes for the user

Nothing yet, by design. This is the server half of removing the web client's complete conversation-list copy (LUM-2409 Phase 3): the bell and attention tracking currently scan that copy for rows needing attention, and under windowed section caches (#40633) a client-side scan sees only what is loaded. This filter is the root answer; the client PR that follows swaps those consumers onto it.

## Design

**One predicate, one more reader.** The filter applies `unseenAttentionStateConditions`, the exact SQL twin the unread count and the section index already use, so "needs attention" cannot drift between readers. That predicate lives on `conversation_assistant_attention_state`, so the filter joins it: inner (a conversation with no attention row has no unseen message by definition) and only when asked, through one `withListFilterJoins` helper shared by `listConversations` and `countConversations`. Two consequences worth stating: a page and its `hasMore` describe the same set, and every existing list query is byte-identical when the param is absent, no join and no row it did not have before. Both are pinned by tests, the second as a sensitivity check (a conversation with no attention row must still appear in the plain list).

**Strict value.** Only the literal `"true"` narrows; anything else is a 400, the same posture the route already takes for an unknown `conversationType`, because silently reading a typo or a newer client's value as "no filter" would return the full list where a subset was asked for, and that skew is invisible.

**Drizzle shape.** The conditional join uses the documented dynamic-query-building pattern (`$dynamic()` at the call sites, `T extends SQLiteSelect` in the helper, inferred return), verified against orm.drizzle.team, no casts.

## Why it's safe

- Additive, optional param; absent means unchanged behavior, and the "unchanged" claim is tested, not assumed.
- Read-only route; no schema, migration, or write-path change.
- The join is scoped to the one filter that needs it, so no other list read pays it or changes shape (`getTableColumns(conversations)` keeps `parseConversation`'s input identical either way).
- `openapi.yaml` regenerated (`bun run generate:openapi`); the diff is exactly the one new param.

## Deferred, and why

- **The client consumers** (bell, attention initial sweep) are the next PR: keeping this daemon-only makes it small and independently reviewable, and the client change depends on this being deployed.
- **Version gating on the client** will be decided in that PR: an old daemon ignores the unknown param and returns the unfiltered list, which for a *filter* degrades to today's behavior (the client keeps scanning); whether that is acceptable feature-off or needs a gate is a client-side call, per `clients/web/docs/BACKWARDS_COMPAT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40775" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->