### PR TITLE
chore(plugins): bump level-up marketplace pin to 4357028 (LUM-3295)

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -232,7 +232,7 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/level-up",
-        "ref": "d3cbb50f8aba1f8320cd2d59ea3a85d0a4e9210b"
+        "ref": "4357028acc339c6d6f718d5d6ab279ebf198673b"
       },
       "description": "Surfaces a first-class \"Level Up\" diff card whenever the assistant edits its own skills or plugins, so you can see how it improved itself after the fact.",
       "category": "developer",


### PR DESCRIPTION
Part of LUM-3295. Companion to #40748.

## TL;DR

Repins `level-up` from `d3cbb50f` (Jun 15) to `4357028a`, the merge of vellum-ai/level-up#7 (also picks up #6, the workspace-root derivation fix).

## What changes for the user

| Before | After |
|---|---|
| The Level Up card's link row pointed at the Level Up library app, in a titleless section the host drops, so the plugin-built card showed no link row | A "History" section: each changed skill links to `/assistant/skills/<name>?tab=history` (clickable and landing on the History tab once #40748 ships); plugin edits and deleted skills get one "Open Level Up" row |

## Why this is safe

- Pin-only change; `bun run meta/sync-bundled-copies.ts --check` passes. Plugin icon is an emoji, so no asset regen.
- Independent of #40748's merge order: before it, the new row renders as an unlinked row (as today); after it, the row is a link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40776" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->