### PR TITLE
docs(plugins): schedule state convention, narrowed hash, and activation gating

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -888,17 +888,29 @@ startup pass in `daemon/lifecycle.ts` (after plugin init, before the
 scheduler starts), the end of `reconcilePluginSourcesNow()` in
 `plugins/mtime-cache.ts` (install/uninstall/upgrade and sentinel-driven
 changes), the plugin enable/disable routes, and a 60s backstop sweep
-registered with the HTTP server's background sweeps.
+registered with the HTTP server's background sweeps. The desired set is
+gated on activation as well as on what is on disk:
+`collectDesiredDeclarations` skips any plugin directory that
+`isPluginDirActivated` (`plugins/mtime-cache.ts`) does not report as brought
+up in this process, so a directory that merely exists under the plugins root
+never arms a row.
 
 Reconcile lag never lets a disabled plugin run. The disable path writes a
 `.disabled` sentinel that only a reconcile pass turns into disarmed rows, so
 the scheduler re-reads the sentinel at fire time and records a skipped run
 instead of executing a claimed row whose plugin is off. Run-now applies the
-same boundary through `declarationExistsOnDisk`, which also covers a plugin
+same boundary through `pluginScheduleSourceAvailable`
+(`schedule/plugin-schedule-availability.ts`), which composes the activation
+ledger with `declarationExistsOnDisk`. That disk probe also covers a plugin
 whose manifest no longer parses, a declaration directory that is gone, and a
 plugin root or declaration directory resolving outside the tree it belongs to
 (the same `isInsidePluginRoot` containment the loader applies before importing
-a plugin).
+a plugin). Fire time in the scheduler and the user re-enable path in
+`schedule-store.ts` deliberately use the disk probe on its own, because both
+can run outside the daemon process, where the activation ledger is empty and
+every plugin would read as unactivated. The reconciler's sweep disarms the
+rows of a plugin it has not activated within one pass, which bounds what
+those disk-only probes can let through.
 
 A declaration that stops parsing keeps its execute row armed on the message
 already stored in the row, but disarms its script rows: a script row fires its
@@ -911,7 +923,10 @@ timezone, message/script, retry policy, `definition_hash`); the execution
 engine owns runtime columns (`next_run_at`, `status`, `last_*`,
 `retry_count`) and its latches are never overridden; the user owns
 `user_enabled`, a sticky override consulted when computing effective
-`enabled`. Nothing ever writes to plugin files. Execution itself is
+`enabled`. `definition_hash` is a sha256 over the relPath and bytes of
+exactly two files, the declaration's `config.json` and its entrypoint, so
+nothing else under `schedules/<name>/` can produce a definition change.
+Nothing ever writes to plugin files. Execution itself is
 unchanged: declared rows fire through the same `claimDueSchedules` path as
 imperative ones.
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -167,7 +167,7 @@ import type { InitContext } from "@vellumai/plugin-api";
 export default async function init(ctx: InitContext): Promise<void> {
   // ctx.config            — your validated config (typed `unknown` for now)
   // ctx.logger            — pino child, bound to { plugin: <name> }
-  // ctx.pluginStorageDir  — writable dir at <workspace>/plugins-data/<name>/
+  // ctx.pluginStorageDir  — writable dir at <plugin dir>/data/
   // ctx.assistantVersion  — host semver string
 
   ctx.logger.info({ version: ctx.assistantVersion }, "init");
@@ -867,8 +867,10 @@ inside the stub, run under a stripped environment and a timeout.
 - **One contribution per file.** `hooks/init.ts` is one init hook.
   `tools/recall.ts` is one tool. No multi-export tricks.
 - **Persistence goes to `ctx.pluginStorageDir`.** The assistant allocates
-  `<workspace>/plugins-data/<plugin>/` per plugin and ensures it
-  exists before `init` runs.
+  `data/` inside each plugin's directory and ensures it exists before
+  `init` runs, migrating contents from the legacy
+  `<workspace>/plugins-data/<plugin>/` location when present. Standalone
+  workspace hooks still use `<workspace>/plugins-data/<name>/`.
 - **Logging through `ctx.logger`.** Don't roll your own pino instance
   — the runtime's child logger is bound to your plugin name.
 - **Cooperative cancellation.** Long-running tools should check

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -167,7 +167,7 @@ import type { InitContext } from "@vellumai/plugin-api";
 export default async function init(ctx: InitContext): Promise<void> {
   // ctx.config            — your validated config (typed `unknown` for now)
   // ctx.logger            — pino child, bound to { plugin: <name> }
-  // ctx.pluginStorageDir  — writable dir at <plugin dir>/data/
+  // ctx.pluginStorageDir  - writable dir at <plugin dir>/data/
   // ctx.assistantVersion  — host semver string
 
   ctx.logger.info({ version: ctx.assistantVersion }, "init");

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -624,10 +624,38 @@ while the error is surfaced as a notification.
 Lifecycle. The declaration directory is the source of truth: edits and
 upgrades update the schedule row in place, uninstalling or disabling the
 plugin pauses its schedules (runs and history are kept), and reinstalling
-re-links them. Users can enable/disable a declared schedule from the
-schedules UI; that override survives plugin upgrades. Rows are managed by
-the reconciler, so declared schedules cannot be edited or deleted
-imperatively: change the declaration instead.
+re-links them. What counts as an edit is narrow. The reconciler hashes
+`config.json` and the entrypoint and nothing else, so changing either one
+updates the row on the next reconcile pass while any other file in the
+declaration directory changes without producing a definition change. A
+helper script alongside the entrypoint still takes effect at the next
+fire, because a script schedule runs its entrypoint by path and reads
+whatever is on disk at that moment. Users can enable/disable a declared
+schedule from the schedules UI; that override survives plugin upgrades.
+Rows are managed by the reconciler, so declared schedules cannot be
+edited or deleted imperatively: change the declaration instead. A
+declared schedule that sits off says why in `assistant schedules` and in
+the schedules UI: turned off by you, plugin removed, plugin disabled,
+removed from plugin, or paused by plugin.
+
+Activation. A declared schedule arms only for a plugin the assistant has
+loaded. Installing or upgrading a plugin loads it as part of that
+operation, and a restart loads every plugin present, so a plugin
+directory copied into the plugins root by hand stays disarmed until one
+of those happens. The reconciler's sweep also disarms the rows of a
+plugin that is no longer loaded.
+
+State. A schedule runs with the workspace directory as its working
+directory. Keep whatever state the schedule accumulates in the plugin's
+own `data/` directory, the same directory hooks receive as
+`ctx.pluginStorageDir`. A script reaches it as `plugins/<plugin>/data/`
+and should `mkdir -p` it first, since a plugin with no `init` hook never
+has it created for it. That directory is the one part of the plugin tree
+the runtime leaves to the plugin. Everything else is source, so a file
+written under `schedules/<name>/` moves the plugin's live-reload
+fingerprint, which makes the next reconcile tear the plugin down and
+bring it back up, and the write reads as local drift the next time the
+plugin is upgraded.
 
 ---
 


### PR DESCRIPTION
## Summary
- Documents where plugin schedule scripts keep state (the plugin's data/ storage dir, never inside schedules/), that the definition hash covers config.json plus the entrypoint, and that declared schedules arm only for plugins the daemon has activated.