### PR TITLE
fix(web): make a pending confirmation always reachable and always the same

### DIFF
--- a/clients/web/src/domains/chat/components/confirmation-prompt-card.tsx
+++ b/clients/web/src/domains/chat/components/confirmation-prompt-card.tsx
@@ -2,7 +2,7 @@ import { ChevronDown, ChevronRight, Loader2, Shield } from "lucide-react";
 import { useState } from "react";
 
 import { AllowOptionsMenu } from "@/domains/chat/components/allow-options-menu";
-import { resolveConfirmationDecisions } from "@/domains/chat/confirmation-decisions";
+import { offersRuleOption } from "@/domains/chat/confirmation-decisions";
 import { getRiskBadgeStyle } from "@/domains/chat/utils/risk";
 import type { ConfirmationDecision } from "@/types/event-types";
 import type {
@@ -17,8 +17,6 @@ export interface ConfirmationPromptCardProps {
     requestId: string;
     title?: string;
     description?: string;
-    confirmLabel?: string;
-    denyLabel?: string;
     toolName?: string;
     riskLevel?: string;
     riskReason?: string;
@@ -40,7 +38,7 @@ export function ConfirmationPromptCard({
   onAllowAndCreateRule,
 }: ConfirmationPromptCardProps) {
   const [showDetails, setShowDetails] = useState(false);
-  const decisions = resolveConfirmationDecisions(confirmation);
+  const offersRule = offersRuleOption(confirmation);
 
   const hasDetails =
     !!confirmation.toolName ||
@@ -78,7 +76,7 @@ export function ConfirmationPromptCard({
 
         <div className="flex shrink-0 gap-2">
           {/* Allow button — split when allowlistOptions present */}
-          {decisions.offersRule && onAllowAndCreateRule ? (
+          {offersRule && onAllowAndCreateRule ? (
             <div className="flex">
               {/* Primary: plain Allow */}
               <button
@@ -90,7 +88,7 @@ export function ConfirmationPromptCard({
                 {isSubmitting ? (
                   <Loader2 className="h-3.5 w-3.5 animate-spin" />
                 ) : null}
-                {decisions.confirmLabel}
+                Allow
               </button>
               <AllowOptionsMenu
                 align="end"
@@ -116,7 +114,7 @@ export function ConfirmationPromptCard({
               {isSubmitting ? (
                 <Loader2 className="h-3.5 w-3.5 animate-spin" />
               ) : null}
-              {decisions.confirmLabel}
+              Allow
             </button>
           )}
           <button
@@ -125,7 +123,7 @@ export function ConfirmationPromptCard({
             onClick={() => onSubmit("deny")}
             className="flex items-center gap-1.5 rounded-md bg-[var(--system-negative-strong)] px-3 py-1.5 text-body-small-default text-white transition-colors hover:opacity-90 disabled:opacity-50"
           >
-            {decisions.denyLabel}
+            Deny
           </button>
         </div>
       </div>

--- a/clients/web/src/domains/chat/components/confirmation-prompt-card.tsx
+++ b/clients/web/src/domains/chat/components/confirmation-prompt-card.tsx
@@ -2,6 +2,7 @@ import { ChevronDown, ChevronRight, Loader2, Shield } from "lucide-react";
 import { useState } from "react";
 
 import { AllowOptionsMenu } from "@/domains/chat/components/allow-options-menu";
+import { resolveConfirmationDecisions } from "@/domains/chat/confirmation-decisions";
 import { getRiskBadgeStyle } from "@/domains/chat/utils/risk";
 import type { ConfirmationDecision } from "@/types/event-types";
 import type {
@@ -39,6 +40,7 @@ export function ConfirmationPromptCard({
   onAllowAndCreateRule,
 }: ConfirmationPromptCardProps) {
   const [showDetails, setShowDetails] = useState(false);
+  const decisions = resolveConfirmationDecisions(confirmation);
 
   const hasDetails =
     !!confirmation.toolName ||
@@ -47,7 +49,6 @@ export function ConfirmationPromptCard({
   const riskBadge = confirmation.riskLevel
     ? getRiskBadgeStyle(confirmation.riskLevel)
     : null;
-  const hasAllowlistOptions = (confirmation.allowlistOptions?.length ?? 0) > 0;
 
   return (
     <Card>
@@ -77,7 +78,7 @@ export function ConfirmationPromptCard({
 
         <div className="flex shrink-0 gap-2">
           {/* Allow button — split when allowlistOptions present */}
-          {hasAllowlistOptions && onAllowAndCreateRule ? (
+          {decisions.offersRule && onAllowAndCreateRule ? (
             <div className="flex">
               {/* Primary: plain Allow */}
               <button
@@ -89,7 +90,7 @@ export function ConfirmationPromptCard({
                 {isSubmitting ? (
                   <Loader2 className="h-3.5 w-3.5 animate-spin" />
                 ) : null}
-                {confirmation.confirmLabel || "Allow"}
+                {decisions.confirmLabel}
               </button>
               <AllowOptionsMenu
                 align="end"
@@ -115,7 +116,7 @@ export function ConfirmationPromptCard({
               {isSubmitting ? (
                 <Loader2 className="h-3.5 w-3.5 animate-spin" />
               ) : null}
-              {confirmation.confirmLabel || "Allow"}
+              {decisions.confirmLabel}
             </button>
           )}
           <button
@@ -124,7 +125,7 @@ export function ConfirmationPromptCard({
             onClick={() => onSubmit("deny")}
             className="flex items-center gap-1.5 rounded-md bg-[var(--system-negative-strong)] px-3 py-1.5 text-body-small-default text-white transition-colors hover:opacity-90 disabled:opacity-50"
           >
-            {confirmation.denyLabel || "Deny"}
+            {decisions.denyLabel}
           </button>
         </div>
       </div>

--- a/clients/web/src/domains/chat/components/tool-call-chip/inline-confirmation-card.stories.tsx
+++ b/clients/web/src/domains/chat/components/tool-call-chip/inline-confirmation-card.stories.tsx
@@ -17,8 +17,6 @@ function makeConfirmationToolCall(
     riskReason?: string | null;
     allowlistOptions?: boolean;
     input?: Record<string, unknown> | null;
-    confirmLabel?: string;
-    denyLabel?: string;
     persistentDecisionsAllowed?: boolean;
   } = {},
 ): ChatMessageToolCall {
@@ -28,8 +26,6 @@ function makeConfirmationToolCall(
     riskReason = null,
     allowlistOptions = true,
     input = { command: "ls -lt ~/Downloads | head -20" },
-    confirmLabel,
-    denyLabel,
     persistentDecisionsAllowed,
   } = overrides;
   return {
@@ -43,8 +39,6 @@ function makeConfirmationToolCall(
     pendingConfirmation: {
       requestId: "req-1",
       riskLevel: "high",
-      ...(confirmLabel ? { confirmLabel } : {}),
-      ...(denyLabel ? { denyLabel } : {}),
       ...(persistentDecisionsAllowed !== undefined
         ? { persistentDecisionsAllowed }
         : {}),
@@ -127,20 +121,6 @@ export const Submitting: Story = {
   args: {
     toolCall: makeConfirmationToolCall(),
     isSubmitting: true,
-  },
-};
-
-/**
- * The daemon can name the decision itself. Both confirmation surfaces read
- * those verbs, so the same request never reads "Allow" in one place and
- * "Run it" in the other.
- */
-export const DaemonSuppliedVerbs: Story = {
-  args: {
-    toolCall: makeConfirmationToolCall({
-      confirmLabel: "Run it",
-      denyLabel: "Skip",
-    }),
   },
 };
 

--- a/clients/web/src/domains/chat/components/tool-call-chip/inline-confirmation-card.stories.tsx
+++ b/clients/web/src/domains/chat/components/tool-call-chip/inline-confirmation-card.stories.tsx
@@ -17,6 +17,9 @@ function makeConfirmationToolCall(
     riskReason?: string | null;
     allowlistOptions?: boolean;
     input?: Record<string, unknown> | null;
+    confirmLabel?: string;
+    denyLabel?: string;
+    persistentDecisionsAllowed?: boolean;
   } = {},
 ): ChatMessageToolCall {
   const {
@@ -25,6 +28,9 @@ function makeConfirmationToolCall(
     riskReason = null,
     allowlistOptions = true,
     input = { command: "ls -lt ~/Downloads | head -20" },
+    confirmLabel,
+    denyLabel,
+    persistentDecisionsAllowed,
   } = overrides;
   return {
     id: "tc-confirm",
@@ -37,6 +43,11 @@ function makeConfirmationToolCall(
     pendingConfirmation: {
       requestId: "req-1",
       riskLevel: "high",
+      ...(confirmLabel ? { confirmLabel } : {}),
+      ...(denyLabel ? { denyLabel } : {}),
+      ...(persistentDecisionsAllowed !== undefined
+        ? { persistentDecisionsAllowed }
+        : {}),
       ...(description ? { description } : {}),
       ...(riskReason ? { riskReason } : {}),
       ...(input ? { input } : {}),
@@ -116,5 +127,33 @@ export const Submitting: Story = {
   args: {
     toolCall: makeConfirmationToolCall(),
     isSubmitting: true,
+  },
+};
+
+/**
+ * The daemon can name the decision itself. Both confirmation surfaces read
+ * those verbs, so the same request never reads "Allow" in one place and
+ * "Run it" in the other.
+ */
+export const DaemonSuppliedVerbs: Story = {
+  args: {
+    toolCall: makeConfirmationToolCall({
+      confirmLabel: "Run it",
+      denyLabel: "Skip",
+    }),
+  },
+};
+
+/**
+ * A tool that demanded fresh approval every time. It still carries allowlist
+ * options (the generator falls back to "Everything"), so gating the rule menu
+ * on options alone would offer the standing permission the daemon asked to
+ * prevent: no chevron here, only the plain decision.
+ */
+export const FreshApprovalRequired: Story = {
+  args: {
+    toolCall: makeConfirmationToolCall({
+      persistentDecisionsAllowed: false,
+    }),
   },
 };

--- a/clients/web/src/domains/chat/components/tool-call-chip/tool-call-chip.tsx
+++ b/clients/web/src/domains/chat/components/tool-call-chip/tool-call-chip.tsx
@@ -28,6 +28,7 @@ import {
 import { Button } from "@vellumai/design-library";
 
 import { AllowOptionsMenu } from "@/domains/chat/components/allow-options-menu";
+import { resolveConfirmationDecisions } from "@/domains/chat/confirmation-decisions";
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 
 import {
@@ -158,7 +159,7 @@ export function InlineConfirmationCard({
   }
 
   const hasDetails = !!confirmation.input;
-  const hasAllowlistOptions = (confirmation.allowlistOptions?.length ?? 0) > 0;
+  const decisions = resolveConfirmationDecisions(confirmation);
 
   // Meta-line context: what the agent was doing when it hit the gate. The
   // live activity label wins; a custom confirmation title and the friendly
@@ -208,7 +209,7 @@ export function InlineConfirmationCard({
       {/* Actions — left-aligned. Allow splits into Allow | ⌄ when allowlist
           options exist; the chevron opens the "Allow & Create Rule" menu. */}
       <div className="flex items-start gap-2">
-        {hasAllowlistOptions && onAllowAndCreateRule ? (
+        {decisions.offersRule && onAllowAndCreateRule ? (
           <div className="flex">
             <Button
               variant="primary"
@@ -217,7 +218,7 @@ export function InlineConfirmationCard({
               className="rounded-r-none"
             >
               {isSubmitting && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
-              Allow
+              {decisions.confirmLabel}
             </Button>
             {/* Internal divider between the two halves of the split pill. */}
             <span
@@ -245,7 +246,7 @@ export function InlineConfirmationCard({
             onClick={() => onSubmit?.("allow")}
           >
             {isSubmitting && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
-            Allow
+            {decisions.confirmLabel}
           </Button>
         )}
 
@@ -254,7 +255,7 @@ export function InlineConfirmationCard({
           disabled={isSubmitting}
           onClick={() => onSubmit?.("deny")}
         >
-          Deny
+          {decisions.denyLabel}
         </Button>
       </div>
 

--- a/clients/web/src/domains/chat/components/tool-call-chip/tool-call-chip.tsx
+++ b/clients/web/src/domains/chat/components/tool-call-chip/tool-call-chip.tsx
@@ -28,7 +28,7 @@ import {
 import { Button } from "@vellumai/design-library";
 
 import { AllowOptionsMenu } from "@/domains/chat/components/allow-options-menu";
-import { resolveConfirmationDecisions } from "@/domains/chat/confirmation-decisions";
+import { offersRuleOption } from "@/domains/chat/confirmation-decisions";
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 
 import {
@@ -159,7 +159,7 @@ export function InlineConfirmationCard({
   }
 
   const hasDetails = !!confirmation.input;
-  const decisions = resolveConfirmationDecisions(confirmation);
+  const offersRule = offersRuleOption(confirmation);
 
   // Meta-line context: what the agent was doing when it hit the gate. The
   // live activity label wins; a custom confirmation title and the friendly
@@ -209,7 +209,7 @@ export function InlineConfirmationCard({
       {/* Actions — left-aligned. Allow splits into Allow | ⌄ when allowlist
           options exist; the chevron opens the "Allow & Create Rule" menu. */}
       <div className="flex items-start gap-2">
-        {decisions.offersRule && onAllowAndCreateRule ? (
+        {offersRule && onAllowAndCreateRule ? (
           <div className="flex">
             <Button
               variant="primary"
@@ -218,7 +218,7 @@ export function InlineConfirmationCard({
               className="rounded-r-none"
             >
               {isSubmitting && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
-              {decisions.confirmLabel}
+              Allow
             </Button>
             {/* Internal divider between the two halves of the split pill. */}
             <span
@@ -246,7 +246,7 @@ export function InlineConfirmationCard({
             onClick={() => onSubmit?.("allow")}
           >
             {isSubmitting && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
-            {decisions.confirmLabel}
+            Allow
           </Button>
         )}
 
@@ -255,7 +255,7 @@ export function InlineConfirmationCard({
           disabled={isSubmitting}
           onClick={() => onSubmit?.("deny")}
         >
-          {decisions.denyLabel}
+          Deny
         </Button>
       </div>
 

--- a/clients/web/src/domains/chat/confirmation-actions.test.ts
+++ b/clients/web/src/domains/chat/confirmation-actions.test.ts
@@ -95,3 +95,58 @@ describe("handleConfirmationSubmit — stale (404) interaction", () => {
     );
   });
 });
+
+describe("handleConfirmationSubmit — risk metadata stamping", () => {
+  function seedSnapshotWithFinishedCall(): void {
+    useChatSessionStore.setState({
+      snapshot: {
+        messages: [
+          {
+            id: "a-1",
+            role: "assistant",
+            toolCalls: [
+              // Finished and unstamped: what the deleted heuristic used to
+              // seize on when a prompt named no tool call.
+              { id: "tc-unrelated", name: "bash", input: {}, result: "ok" },
+            ],
+          },
+        ],
+      },
+    } as never);
+  }
+
+  it("does not stamp an unrelated tool call when the prompt named none", async () => {
+    seedSnapshotWithFinishedCall();
+    seedPendingConfirmation("cr-1");
+
+    await handleConfirmationSubmit("allow");
+
+    const stamped = (
+      useChatSessionStore.getState().snapshot?.messages ?? []
+    ).flatMap((m) =>
+      (m.toolCalls ?? []).filter((tc) => tc.confirmationDecision !== undefined),
+    );
+    // Risk metadata describes a tool call; a prompt with none has nothing to
+    // describe, so labelling the last finished step with this decision's risk
+    // is wrong about a step the user never approved.
+    expect(stamped).toEqual([]);
+  });
+
+  it("raises no unknown-risk nudge when the prompt named no tool call", async () => {
+    seedSnapshotWithFinishedCall();
+    useStreamStore.getState().setStreamContext({
+      assistantId: "ast-1",
+      conversationId: "conv-1",
+    });
+    useInteractionStore.getState().showConfirmation({
+      requestId: "cr-2",
+      toolName: "acp_spawn",
+      riskLevel: "unknown",
+      input: {},
+    });
+
+    await handleConfirmationSubmit("allow");
+
+    expect(useInteractionStore.getState().unknownNudgeToolCallIds.size).toBe(0);
+  });
+});

--- a/clients/web/src/domains/chat/confirmation-actions.ts
+++ b/clients/web/src/domains/chat/confirmation-actions.ts
@@ -20,7 +20,6 @@ import type { RuleEditorContext } from "@/domains/chat/rule-editor-store";
 import { clearConfirmationByRequestId } from "@/domains/chat/utils/send-message-utils";
 import { deriveCommandText } from "@/domains/chat/utils/chat";
 import { toRiskLevel } from "@/domains/chat/utils/risk";
-import { isToolCallRunning } from "@/domains/chat/utils/tool-call-status";
 import { mapMessageToolCalls } from "@/domains/chat/utils/map-message-tool-calls";
 import { submitConfirmation } from "@/domains/chat/api/interactions";
 import { fireSuggestion } from "@/domains/chat/rule-editor-actions";
@@ -67,27 +66,17 @@ function cleanupAfterConfirmationDecision(
   let nudgeTcId: string | null = null;
 
   patchTranscriptMessages((prev: DisplayMessage[]) => {
-    // Resolve stamp target: explicit mapping or heuristic fallback
-    let stampTargetId = mappedToolCallId;
-    if (!stampTargetId) {
-      for (let i = prev.length - 1; i >= 0; i--) {
-        const msg = prev[i];
-        if (msg?.role !== "assistant" || !msg.toolCalls?.length) {
-          continue;
-        }
-        const tc = msg.toolCalls.findLast(
-          (tc) => !isToolCallRunning(tc) && !tc.riskLevel,
-        );
-        if (tc) {
-          stampTargetId = tc.id;
-          break;
-        }
-      }
-    }
+    // The risk metadata describes a tool call, so it goes on the tool call the
+    // prompt named and nowhere else. A prompt that named none (an ACP route
+    // approval has no tool call of its own) has nothing to describe: stamping
+    // whichever call happens to be last would label an unrelated, already
+    // finished step with this decision's risk level, and point the
+    // unknown-risk nudge at it too.
+    const stampTargetId = mappedToolCallId;
 
-    // Compute nudge target from pre-stamp state (riskLevel not yet applied)
-    if (snapshot.riskLevel?.toLowerCase() === "unknown") {
-      nudgeTcId = stampTargetId ?? null;
+    // Computed from pre-stamp state, before `riskLevel` is applied.
+    if (stampTargetId && snapshot.riskLevel?.toLowerCase() === "unknown") {
+      nudgeTcId = stampTargetId;
     }
 
     let anyChanged = false;

--- a/clients/web/src/domains/chat/confirmation-actions.ts
+++ b/clients/web/src/domains/chat/confirmation-actions.ts
@@ -10,7 +10,7 @@ import { captureError } from "@/lib/sentry/capture-error";
 
 import type { DisplayMessage } from "@/domains/chat/types/types";
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
-import { resolveConfirmationDecisions } from "@/domains/chat/confirmation-decisions";
+import { offersRuleOption } from "@/domains/chat/confirmation-decisions";
 import { patchTranscriptMessages } from "@/domains/chat/transcript/patch-transcript-messages";
 import { useInteractionStore } from "@/domains/chat/interaction-store";
 import { useStreamStore } from "@/domains/chat/stream-store";
@@ -180,7 +180,7 @@ export async function handleConfirmationSubmit(
   // Same predicate the cards render from, so the hint cannot be sent for a
   // request whose card withheld the option (or withheld for one that offered).
   const ruleHint =
-    decision === "allow" && resolveConfirmationDecisions(snapshot).offersRule
+    decision === "allow" && offersRuleOption(snapshot)
       ? {
           selectedPattern: snapshot.allowlistOptions![0]!.pattern,
           selectedScope:

--- a/clients/web/src/domains/chat/confirmation-actions.ts
+++ b/clients/web/src/domains/chat/confirmation-actions.ts
@@ -10,6 +10,7 @@ import { captureError } from "@/lib/sentry/capture-error";
 
 import type { DisplayMessage } from "@/domains/chat/types/types";
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+import { resolveConfirmationDecisions } from "@/domains/chat/confirmation-decisions";
 import { patchTranscriptMessages } from "@/domains/chat/transcript/patch-transcript-messages";
 import { useInteractionStore } from "@/domains/chat/interaction-store";
 import { useStreamStore } from "@/domains/chat/stream-store";
@@ -186,11 +187,11 @@ export async function handleConfirmationSubmit(
       .getState()
       .confirmationToolCallMap.get(snapshot.requestId);
 
-  // Auto-select first pattern/scope when persistent decisions are allowed
+  // Auto-select first pattern/scope when the request permits a durable rule.
+  // Same predicate the cards render from, so the hint cannot be sent for a
+  // request whose card withheld the option (or withheld for one that offered).
   const ruleHint =
-    decision === "allow" &&
-    snapshot.persistentDecisionsAllowed !== false &&
-    (snapshot.allowlistOptions?.length ?? 0) > 0
+    decision === "allow" && resolveConfirmationDecisions(snapshot).offersRule
       ? {
           selectedPattern: snapshot.allowlistOptions![0]!.pattern,
           selectedScope:

--- a/clients/web/src/domains/chat/confirmation-decisions.test.ts
+++ b/clients/web/src/domains/chat/confirmation-decisions.test.ts
@@ -1,46 +1,21 @@
 /**
- * The decision set is what both confirmation surfaces render from, so these
- * cover the two ways they previously disagreed: the daemon's verbs being
- * honoured on one surface and hardcoded on the other, and the rule option
- * being gated on `persistentDecisionsAllowed` by one and not the other.
+ * The rule option is the one thing a confirmation's choices vary on, and both
+ * surfaces plus the submit path read this predicate, so a request that forbids
+ * a durable rule must never be offered one anywhere.
  */
 import { describe, expect, test } from "bun:test";
 
-import {
-  DEFAULT_CONFIRM_LABEL,
-  DEFAULT_DENY_LABEL,
-  resolveConfirmationDecisions,
-} from "@/domains/chat/confirmation-decisions";
+import { offersRuleOption } from "@/domains/chat/confirmation-decisions";
 
 const WITH_OPTIONS = {
   allowlistOptions: [{ label: "*", description: "Everything", pattern: "*" }],
 };
 
-describe("resolveConfirmationDecisions", () => {
-  test("uses the daemon's verbs when it sends them", () => {
-    const decisions = resolveConfirmationDecisions({
-      confirmLabel: "Run it",
-      denyLabel: "Skip",
-    });
-
-    expect(decisions.confirmLabel).toBe("Run it");
-    expect(decisions.denyLabel).toBe("Skip");
-  });
-
-  test("falls back to Allow/Deny when it does not", () => {
-    const decisions = resolveConfirmationDecisions({});
-
-    expect(decisions.confirmLabel).toBe(DEFAULT_CONFIRM_LABEL);
-    expect(decisions.denyLabel).toBe(DEFAULT_DENY_LABEL);
-  });
-
+describe("offersRuleOption", () => {
   test("offers the rule when options exist and persistence is allowed", () => {
-    expect(resolveConfirmationDecisions(WITH_OPTIONS).offersRule).toBe(true);
+    expect(offersRuleOption(WITH_OPTIONS)).toBe(true);
     expect(
-      resolveConfirmationDecisions({
-        ...WITH_OPTIONS,
-        persistentDecisionsAllowed: true,
-      }).offersRule,
+      offersRuleOption({ ...WITH_OPTIONS, persistentDecisionsAllowed: true }),
     ).toBe(true);
   });
 
@@ -49,18 +24,13 @@ describe("resolveConfirmationDecisions", () => {
     // non-empty allowlist, because the generator's fallback is "Everything".
     // Gating on options alone therefore offers the standing permission the
     // daemon asked to prevent.
-    const decisions = resolveConfirmationDecisions({
-      ...WITH_OPTIONS,
-      persistentDecisionsAllowed: false,
-    });
-
-    expect(decisions.offersRule).toBe(false);
+    expect(
+      offersRuleOption({ ...WITH_OPTIONS, persistentDecisionsAllowed: false }),
+    ).toBe(false);
   });
 
   test("withholds the rule when there are no options to build one from", () => {
-    expect(resolveConfirmationDecisions({}).offersRule).toBe(false);
-    expect(
-      resolveConfirmationDecisions({ allowlistOptions: [] }).offersRule,
-    ).toBe(false);
+    expect(offersRuleOption({})).toBe(false);
+    expect(offersRuleOption({ allowlistOptions: [] })).toBe(false);
   });
 });

--- a/clients/web/src/domains/chat/confirmation-decisions.test.ts
+++ b/clients/web/src/domains/chat/confirmation-decisions.test.ts
@@ -1,0 +1,66 @@
+/**
+ * The decision set is what both confirmation surfaces render from, so these
+ * cover the two ways they previously disagreed: the daemon's verbs being
+ * honoured on one surface and hardcoded on the other, and the rule option
+ * being gated on `persistentDecisionsAllowed` by one and not the other.
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+  DEFAULT_CONFIRM_LABEL,
+  DEFAULT_DENY_LABEL,
+  resolveConfirmationDecisions,
+} from "@/domains/chat/confirmation-decisions";
+
+const WITH_OPTIONS = {
+  allowlistOptions: [{ label: "*", description: "Everything", pattern: "*" }],
+};
+
+describe("resolveConfirmationDecisions", () => {
+  test("uses the daemon's verbs when it sends them", () => {
+    const decisions = resolveConfirmationDecisions({
+      confirmLabel: "Run it",
+      denyLabel: "Skip",
+    });
+
+    expect(decisions.confirmLabel).toBe("Run it");
+    expect(decisions.denyLabel).toBe("Skip");
+  });
+
+  test("falls back to Allow/Deny when it does not", () => {
+    const decisions = resolveConfirmationDecisions({});
+
+    expect(decisions.confirmLabel).toBe(DEFAULT_CONFIRM_LABEL);
+    expect(decisions.denyLabel).toBe(DEFAULT_DENY_LABEL);
+  });
+
+  test("offers the rule when options exist and persistence is allowed", () => {
+    expect(resolveConfirmationDecisions(WITH_OPTIONS).offersRule).toBe(true);
+    expect(
+      resolveConfirmationDecisions({
+        ...WITH_OPTIONS,
+        persistentDecisionsAllowed: true,
+      }).offersRule,
+    ).toBe(true);
+  });
+
+  test("withholds the rule when the daemon demanded fresh approval", () => {
+    // The reachable shape: a tool marked `requireFreshApproval` still ships a
+    // non-empty allowlist, because the generator's fallback is "Everything".
+    // Gating on options alone therefore offers the standing permission the
+    // daemon asked to prevent.
+    const decisions = resolveConfirmationDecisions({
+      ...WITH_OPTIONS,
+      persistentDecisionsAllowed: false,
+    });
+
+    expect(decisions.offersRule).toBe(false);
+  });
+
+  test("withholds the rule when there are no options to build one from", () => {
+    expect(resolveConfirmationDecisions({}).offersRule).toBe(false);
+    expect(
+      resolveConfirmationDecisions({ allowlistOptions: [] }).offersRule,
+    ).toBe(false);
+  });
+});

--- a/clients/web/src/domains/chat/confirmation-decisions.ts
+++ b/clients/web/src/domains/chat/confirmation-decisions.ts
@@ -1,61 +1,29 @@
 /**
- * What a pending confirmation offers the user, derived once.
+ * Whether a pending confirmation offers a durable allow rule.
  *
  * Two surfaces render a confirmation: the inline card on a tool-call chip and
  * the transcript's trailer row. Which one a given prompt lands on depends on
  * whether its tool call is in the transcript, which is invisible to the user,
- * so the choices offered must not depend on it. One derivation, both surfaces.
- *
- * This is the decision set and not a rendering: the two surfaces draw it
- * differently (the chip follows the Figma card, the trailer row keeps its own
- * chrome), which is a visual decision and not this one's to make.
- *
- * `confirmLabel`/`denyLabel` are latent. Nothing in the daemon populates them
- * for a tool approval: they are absent from the `confirmation_request` event
- * and from `PendingToolConfirmationSchema`, so every prompt resolves to the
- * defaults below. They stay here because the client type and its parser
- * already carry the fields, and one defaulting site is better than two if a
- * producer ever appears.
+ * so the choices offered must not depend on it. One predicate, every surface,
+ * including the submit path that decides whether to send a rule hint.
  */
 
 import type { AllowlistOption } from "@/types/interaction-ui-types";
 
-/** The payload fields a decision set is derived from. */
-export interface ConfirmationDecisionSource {
-  confirmLabel?: string;
-  denyLabel?: string;
+/** The payload fields the answer is derived from. */
+export interface RuleOptionSource {
   allowlistOptions?: AllowlistOption[];
   persistentDecisionsAllowed?: boolean;
 }
 
-export interface ConfirmationDecisions {
-  /** Verb for the approve action. */
-  confirmLabel: string;
-  /** Verb for the reject action. */
-  denyLabel: string;
-  /**
-   * Whether to offer creating a durable allow rule alongside the one-off
-   * approval.
-   */
-  offersRule: boolean;
-}
-
-export const DEFAULT_CONFIRM_LABEL = "Allow";
-export const DEFAULT_DENY_LABEL = "Deny";
-
-export function resolveConfirmationDecisions(
-  confirmation: ConfirmationDecisionSource,
-): ConfirmationDecisions {
-  return {
-    confirmLabel: confirmation.confirmLabel || DEFAULT_CONFIRM_LABEL,
-    denyLabel: confirmation.denyLabel || DEFAULT_DENY_LABEL,
-    // A tool that demanded fresh approval every time (scheduled tasks,
-    // workflow management) ships `persistentDecisionsAllowed: false` while
-    // still carrying allowlist options, since the generator's fallback is
-    // "Everything". Offering the rule there invites the standing permission
-    // the daemon asked to prevent.
-    offersRule:
-      confirmation.persistentDecisionsAllowed !== false &&
-      (confirmation.allowlistOptions?.length ?? 0) > 0,
-  };
+export function offersRuleOption(confirmation: RuleOptionSource): boolean {
+  // A tool that demanded fresh approval every time (scheduled tasks, workflow
+  // management) ships `persistentDecisionsAllowed: false` while still carrying
+  // allowlist options, since the generator's fallback is "Everything".
+  // Offering the rule there invites the standing permission the daemon asked
+  // to prevent.
+  return (
+    confirmation.persistentDecisionsAllowed !== false &&
+    (confirmation.allowlistOptions?.length ?? 0) > 0
+  );
 }

--- a/clients/web/src/domains/chat/confirmation-decisions.ts
+++ b/clients/web/src/domains/chat/confirmation-decisions.ts
@@ -4,15 +4,18 @@
  * Two surfaces render a confirmation: the inline card on a tool-call chip and
  * the transcript's trailer row. Which one a given prompt lands on depends on
  * whether its tool call is in the transcript, which is invisible to the user,
- * so the choices they are given must not depend on it. Each surface deriving
- * its own set from the raw payload is how they came to disagree: one honoured
- * `confirmLabel`/`denyLabel` and the other hardcoded the verbs, one gated the
- * rule option on `persistentDecisionsAllowed` and the other ignored it.
+ * so the choices offered must not depend on it. One derivation, both surfaces.
  *
- * This is deliberately the decision set and not a rendering: the two surfaces
- * still draw it differently (the chip follows the Figma card, the trailer row
- * keeps its own chrome), and converging that is a visual decision, not this
- * one.
+ * This is the decision set and not a rendering: the two surfaces draw it
+ * differently (the chip follows the Figma card, the trailer row keeps its own
+ * chrome), which is a visual decision and not this one's to make.
+ *
+ * `confirmLabel`/`denyLabel` are latent. Nothing in the daemon populates them
+ * for a tool approval: they are absent from the `confirmation_request` event
+ * and from `PendingToolConfirmationSchema`, so every prompt resolves to the
+ * defaults below. They stay here because the client type and its parser
+ * already carry the fields, and one defaulting site is better than two if a
+ * producer ever appears.
  */
 
 import type { AllowlistOption } from "@/types/interaction-ui-types";

--- a/clients/web/src/domains/chat/confirmation-decisions.ts
+++ b/clients/web/src/domains/chat/confirmation-decisions.ts
@@ -1,0 +1,58 @@
+/**
+ * What a pending confirmation offers the user, derived once.
+ *
+ * Two surfaces render a confirmation: the inline card on a tool-call chip and
+ * the transcript's trailer row. Which one a given prompt lands on depends on
+ * whether its tool call is in the transcript, which is invisible to the user,
+ * so the choices they are given must not depend on it. Each surface deriving
+ * its own set from the raw payload is how they came to disagree: one honoured
+ * `confirmLabel`/`denyLabel` and the other hardcoded the verbs, one gated the
+ * rule option on `persistentDecisionsAllowed` and the other ignored it.
+ *
+ * This is deliberately the decision set and not a rendering: the two surfaces
+ * still draw it differently (the chip follows the Figma card, the trailer row
+ * keeps its own chrome), and converging that is a visual decision, not this
+ * one.
+ */
+
+import type { AllowlistOption } from "@/types/interaction-ui-types";
+
+/** The payload fields a decision set is derived from. */
+export interface ConfirmationDecisionSource {
+  confirmLabel?: string;
+  denyLabel?: string;
+  allowlistOptions?: AllowlistOption[];
+  persistentDecisionsAllowed?: boolean;
+}
+
+export interface ConfirmationDecisions {
+  /** Verb for the approve action. */
+  confirmLabel: string;
+  /** Verb for the reject action. */
+  denyLabel: string;
+  /**
+   * Whether to offer creating a durable allow rule alongside the one-off
+   * approval.
+   */
+  offersRule: boolean;
+}
+
+export const DEFAULT_CONFIRM_LABEL = "Allow";
+export const DEFAULT_DENY_LABEL = "Deny";
+
+export function resolveConfirmationDecisions(
+  confirmation: ConfirmationDecisionSource,
+): ConfirmationDecisions {
+  return {
+    confirmLabel: confirmation.confirmLabel || DEFAULT_CONFIRM_LABEL,
+    denyLabel: confirmation.denyLabel || DEFAULT_DENY_LABEL,
+    // A tool that demanded fresh approval every time (scheduled tasks,
+    // workflow management) ships `persistentDecisionsAllowed: false` while
+    // still carrying allowlist options, since the generator's fallback is
+    // "Everything". Offering the rule there invites the standing permission
+    // the daemon asked to prevent.
+    offersRule:
+      confirmation.persistentDecisionsAllowed !== false &&
+      (confirmation.allowlistOptions?.length ?? 0) > 0,
+  };
+}

--- a/clients/web/src/domains/chat/hooks/use-conversation-history.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-history.ts
@@ -434,10 +434,13 @@ export function useConversationHistory({
           interactions.pendingConfirmation &&
           !useInteractionStore.getState().pendingConfirmation
         ) {
-          const { state } = parsePendingConfirmationData(
-            interactions.pendingConfirmation as Record<string, unknown>,
-          );
-          useInteractionStore.getState().showConfirmation(state);
+          useInteractionStore
+            .getState()
+            .showConfirmation(
+              parsePendingConfirmationData(
+                interactions.pendingConfirmation as Record<string, unknown>,
+              ),
+            );
         }
         if (!interactions.pendingSecret && !interactions.pendingConfirmation) {
           useConversationStore

--- a/clients/web/src/domains/chat/hooks/use-transcript-data.confirmation-visibility.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-transcript-data.confirmation-visibility.test.ts
@@ -1,0 +1,140 @@
+/**
+ * A pending confirmation must be reachable: whenever no tool-call chip is
+ * showing it, the transcript's trailer row has to.
+ *
+ * The projection is real here; only the two chat stores the hook reads are
+ * stubbed, with `pendingConfirmation` mutable so each case can set the prompt
+ * it needs. Lives beside `use-transcript-data.test.ts` rather than inside it
+ * because that file pins `pendingConfirmation` to null for its own scenarios,
+ * and `mock.module` is process-global.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { renderHook } from "@testing-library/react";
+
+import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
+import type { DisplayMessage } from "@/domains/chat/types/types";
+import type { PendingConfirmationState } from "@/types/interaction-ui-types";
+
+let pendingConfirmation: PendingConfirmationState | null = null;
+
+mock.module("@/domains/chat/chat-session-store", () => ({
+  useChatSessionStore: {
+    use: { ephemeralMetaResults: () => [] },
+  },
+}));
+
+mock.module("@/domains/chat/interaction-store", () => ({
+  useInteractionStore: {
+    use: {
+      pendingSecret: () => null,
+      pendingConfirmation: () => pendingConfirmation,
+      pendingContactRequest: () => null,
+    },
+  },
+}));
+
+const { useTranscriptData } = await import("./use-transcript-data");
+
+const REQUEST_ID = "req-1";
+
+function assistantWithToolCall(toolCall: ChatMessageToolCall): DisplayMessage {
+  return { id: "m1", role: "assistant", toolCalls: [toolCall] };
+}
+
+/** A tool call already carrying the active prompt, as the reducer stamps it. */
+function carrying(
+  overrides: Partial<ChatMessageToolCall> & { id: string; name: string },
+): ChatMessageToolCall {
+  return {
+    input: {},
+    pendingConfirmation: { requestId: REQUEST_ID },
+    ...overrides,
+  } as ChatMessageToolCall;
+}
+
+function trailerRowCount(messages: DisplayMessage[]): number {
+  const { result } = renderHook(() =>
+    useTranscriptData({
+      messages,
+      showThinking: false,
+      turnActive: false,
+      thinkingLabel: null,
+      showOnboardingChoice: false,
+      creditsExhausted: false,
+    }),
+  );
+  return result.current.transcriptItems.filter(
+    (item) => item.kind === "pendingConfirmation",
+  ).length;
+}
+
+describe("pending confirmation is always reachable", () => {
+  beforeEach(() => {
+    pendingConfirmation = {
+      requestId: REQUEST_ID,
+      toolName: "bash",
+    } as PendingConfirmationState;
+  });
+
+  test("a prompt on a chip the transcript draws is not repeated in the trailer", () => {
+    const messages = [
+      assistantWithToolCall(carrying({ id: "tc-1", name: "bash" })),
+    ];
+
+    // The chip renders it, so a trailer row would be a second approve/deny
+    // pair for one decision.
+    expect(trailerRowCount(messages)).toBe(0);
+  });
+
+  test("a prompt on a subagent spawn still gets a trailer row", () => {
+    const messages = [
+      assistantWithToolCall(carrying({ id: "tc-1", name: "subagent_spawn" })),
+    ];
+
+    // A spawn renders an inline subagent card, not a chip, so nothing on
+    // screen carries the prompt. Suppressing the trailer here is what leaves
+    // the user with a spinning tool and no way to answer until it times out.
+    expect(trailerRowCount(messages)).toBe(1);
+  });
+
+  test("a spawn dispatched through skill_execute counts the same", () => {
+    const messages = [
+      assistantWithToolCall(
+        carrying({
+          id: "tc-1",
+          name: "skill_execute",
+          input: { tool: "subagent_spawn" },
+        }),
+      ),
+    ];
+
+    // The wire reports `skill_execute` for a re-dispatched spawn, so matching
+    // on the raw name alone would miss it and re-open the same hole.
+    expect(trailerRowCount(messages)).toBe(1);
+  });
+
+  test("an unattached prompt gets a trailer row", () => {
+    const messages = [
+      assistantWithToolCall({
+        id: "tc-1",
+        name: "bash",
+        input: {},
+      } as ChatMessageToolCall),
+    ];
+
+    expect(trailerRowCount(messages)).toBe(1);
+  });
+
+  test("no prompt, no trailer row", () => {
+    pendingConfirmation = null;
+    const messages = [
+      assistantWithToolCall({
+        id: "tc-1",
+        name: "bash",
+        input: {},
+      } as ChatMessageToolCall),
+    ];
+
+    expect(trailerRowCount(messages)).toBe(0);
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-transcript-data.ts
+++ b/clients/web/src/domains/chat/hooks/use-transcript-data.ts
@@ -16,6 +16,7 @@ import { useMemo } from "react";
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import { useInteractionStore } from "@/domains/chat/interaction-store";
 import { buildTranscriptItems } from "@/domains/chat/transcript/build-items";
+import { isSubagentSpawnCall } from "@/domains/chat/transcript/message-content";
 import type { TranscriptItem } from "@/domains/chat/transcript/types";
 import { sanitizeDisplayMessages } from "@/domains/chat/utils/sanitize-display-messages";
 import type { DisplayMessage } from "@/domains/chat/types/types";
@@ -77,15 +78,29 @@ export function useTranscriptData({
   );
 
   // --- Confirmation attachment check --------------------------------------
-  // A confirmation that is already attached to an inline tool-call chip
-  // should NOT also appear as a standalone transcript trailer row.
+  // The trailer row is the home for a prompt no chip is showing, so the two
+  // surfaces have to agree on one question: is this prompt on screen already?
+  //
+  // "Attached to a tool call" is not that question. A subagent spawn carries a
+  // prompt like any other call but renders no chip (`renderableToolCalls` in
+  // `transcript-message-body` filters it out in favour of the inline subagent
+  // card), so counting it as shown suppresses the trailer too and the user is
+  // asked to approve something with no visible prompt. Attachment is only
+  // "shown" when the carrying call is one the transcript actually draws.
+  //
+  // The other half of that filter, card-backing, is deliberately not mirrored
+  // here: a call is card-backed only once a run is registered or a result has
+  // landed, and a prompt gates execution, so a pending confirmation cannot sit
+  // on a card-backed call. Mirroring it would also mean threading three store
+  // subscriptions into this hook to answer a question that cannot arise.
   const pendingConfirmationAttachedToToolCall = useMemo(
     () =>
       pendingConfirmation != null &&
       sanitizedMessages.some((m) =>
         m.toolCalls?.some(
           (tc) =>
-            tc.pendingConfirmation?.requestId === pendingConfirmation.requestId,
+            tc.pendingConfirmation?.requestId ===
+              pendingConfirmation.requestId && !isSubagentSpawnCall(tc),
         ),
       ),
     [pendingConfirmation, sanitizedMessages],

--- a/clients/web/src/domains/chat/hooks/use-transcript-data.ts
+++ b/clients/web/src/domains/chat/hooks/use-transcript-data.ts
@@ -88,11 +88,17 @@ export function useTranscriptData({
   // asked to approve something with no visible prompt. Attachment is only
   // "shown" when the carrying call is one the transcript actually draws.
   //
-  // The other half of that filter, card-backing, is deliberately not mirrored
-  // here: a call is card-backed only once a run is registered or a result has
-  // landed, and a prompt gates execution, so a pending confirmation cannot sit
-  // on a card-backed call. Mirroring it would also mean threading three store
-  // subscriptions into this hook to answer a question that cannot arise.
+  // The other half of that filter, card-backing, is deliberately not mirrored.
+  // Every route into it turns true only once the call has run: a workflow or
+  // ACP id arrives on the launch event or in the result, a background-task id
+  // is parsed out of the result, and an answered question is answered. A
+  // pending prompt gates execution, so the call carrying one has not run and
+  // cannot be card-backed by any of the four. Mirroring it would also mean
+  // threading three store subscriptions into this hook to answer that.
+  //
+  // If that ever stops holding, the failure mode is this trailer going quiet
+  // again for the affected call, so a card-backing route that can precede
+  // execution needs mirroring here as well.
   const pendingConfirmationAttachedToToolCall = useMemo(
     () =>
       pendingConfirmation != null &&

--- a/clients/web/src/domains/chat/transcript/pending-confirmation-row.tsx
+++ b/clients/web/src/domains/chat/transcript/pending-confirmation-row.tsx
@@ -18,18 +18,14 @@ export function PendingConfirmationRow() {
     return null;
   }
 
-  const showAllowAndCreateRule =
-    pendingConfirmation.persistentDecisionsAllowed !== false &&
-    (pendingConfirmation.allowlistOptions?.length ?? 0) > 0;
-
+  // The card owns whether the rule option is offered; this only says the
+  // surface can act on it.
   return (
     <ConfirmationPromptCard
       confirmation={pendingConfirmation}
       isSubmitting={isSubmitting}
       onSubmit={handleConfirmationSubmit}
-      onAllowAndCreateRule={
-        showAllowAndCreateRule ? handleAllowAndCreateRule : undefined
-      }
+      onAllowAndCreateRule={handleAllowAndCreateRule}
     />
   );
 }

--- a/clients/web/src/domains/chat/types.ts
+++ b/clients/web/src/domains/chat/types.ts
@@ -68,8 +68,6 @@ export interface PendingConfirmationState {
   requestId: string;
   title?: string;
   description?: string;
-  confirmLabel?: string;
-  denyLabel?: string;
   toolName?: string;
   riskLevel?: string;
   riskReason?: string;

--- a/clients/web/src/domains/chat/utils/chat.test.ts
+++ b/clients/web/src/domains/chat/utils/chat.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  attachConfirmationToToolCall,
   extractWirePendingAcpConnect,
   extractWirePendingConfirmation,
   extractWirePendingQuestion,
@@ -333,5 +334,69 @@ describe("chat utilities", () => {
       // THEN there is nothing to restore
       expect(restored).toBeNull();
     });
+  });
+});
+
+describe("attachConfirmationToToolCall", () => {
+  const conf = {
+    requestId: "req-1",
+    toolName: "bash",
+    input: { command: "ls" },
+  };
+
+  test("attaches to the tool call named by toolUseId", () => {
+    const messages = [
+      assistantWithToolCalls("m1", [
+        { id: "tc-1", name: "bash", input: {} },
+        { id: "tc-2", name: "file_read", input: {} },
+      ]),
+    ];
+
+    const { updatedMessages, attachedToolCallId } =
+      attachConfirmationToToolCall(messages, { ...conf, toolUseId: "tc-2" });
+
+    expect(attachedToolCallId).toBe("tc-2");
+    const attached = updatedMessages[0]!.toolCalls!.filter(
+      (tc) => tc.pendingConfirmation?.requestId === "req-1",
+    );
+    // Exactly one call carries it: a prompt that lands on two chips renders
+    // two approve/deny pairs for one decision.
+    expect(attached.map((tc) => tc.id)).toEqual(["tc-2"]);
+  });
+
+  test("does not attach when the confirmation names no tool call, even with a running one present", () => {
+    const messages = [
+      assistantWithToolCalls("m1", [
+        // Running: no result yet. The deleted fallback used to seize on this.
+        { id: "tc-running", name: "bash", input: {} },
+      ]),
+    ];
+
+    const { updatedMessages, attachedToolCallId } =
+      attachConfirmationToToolCall(messages, conf);
+
+    // An absent toolUseId means the daemon has no tool call for this prompt
+    // (ACP route approvals). Guessing one hides the prompt whenever the guess
+    // lands on a call the transcript does not draw; leaving it unattached
+    // routes it to the trailer row instead.
+    expect(attachedToolCallId).toBeUndefined();
+    expect(
+      updatedMessages.some((m) =>
+        m.toolCalls?.some((tc) => tc.pendingConfirmation !== undefined),
+      ),
+    ).toBe(false);
+  });
+
+  test("does not attach when toolUseId names a call that is not present", () => {
+    const messages = [
+      assistantWithToolCalls("m1", [{ id: "tc-1", name: "bash", input: {} }]),
+    ];
+
+    const { attachedToolCallId } = attachConfirmationToToolCall(messages, {
+      ...conf,
+      toolUseId: "tc-absent",
+    });
+
+    expect(attachedToolCallId).toBeUndefined();
   });
 });

--- a/clients/web/src/domains/chat/utils/chat.ts
+++ b/clients/web/src/domains/chat/utils/chat.ts
@@ -7,12 +7,9 @@ import type { Conversation } from "@/types/conversation-types";
 import type { AssistantEvent } from "@/types/event-types";
 import { mapMessageToolCalls } from "@/domains/chat/utils/map-message-tool-calls";
 import type {
-  AllowlistOption,
-  DirectoryScopeOption,
   PendingAcpConnectState,
   PendingConfirmationState,
   PendingQuestionState,
-  ScopeOption,
 } from "@/types/interaction-ui-types";
 import {
   ACP_CLAUDE_AUTH_REQUIRED_CODE,
@@ -363,20 +360,7 @@ function applyConfirmationToToolCall(
  */
 export function attachConfirmationToToolCall(
   messages: DisplayMessage[],
-  conf: {
-    requestId: string;
-    title?: string;
-    description?: string;
-    toolName?: string;
-    riskLevel?: string;
-    riskReason?: string;
-    input?: Record<string, unknown>;
-    allowlistOptions?: AllowlistOption[];
-    scopeOptions?: ScopeOption[];
-    directoryScopeOptions?: DirectoryScopeOption[];
-    persistentDecisionsAllowed?: boolean;
-    toolUseId?: string;
-  },
+  conf: PendingConfirmationState,
 ): {
   updatedMessages: DisplayMessage[];
   attachedToolCallId: string | undefined;

--- a/clients/web/src/domains/chat/utils/chat.ts
+++ b/clients/web/src/domains/chat/utils/chat.ts
@@ -5,7 +5,6 @@ import {
 import type { IdentityGetResponse } from "@/generated/daemon/types.gen";
 import type { Conversation } from "@/types/conversation-types";
 import type { AssistantEvent } from "@/types/event-types";
-import { isToolCallRunning } from "@/domains/chat/utils/tool-call-status";
 import { mapMessageToolCalls } from "@/domains/chat/utils/map-message-tool-calls";
 import type {
   AllowlistOption,
@@ -350,11 +349,15 @@ function applyConfirmationToToolCall(
 }
 
 /**
- * Attach a pending confirmation to the best-matching tool call in `messages`.
+ * Attach a pending confirmation to the tool call it names, if it names one.
  *
- * Search order:
- * 1. Exact `toolUseId` match (conf.toolUseId === toolCall.id)
- * 2. Fallback: last running tool call in the latest assistant message with tool calls
+ * A confirmation carries `toolUseId` when it belongs to a specific tool call
+ * and omits it when it belongs to none: `permissions/prompter.ts` passes the
+ * LLM's tool_use block id, while the ACP route approvals in
+ * `runtime/routes/acp-routes.ts` have no tool call of their own. So an absent
+ * `toolUseId` is an answer, not a gap, and this makes no attempt to guess one.
+ * Prompts that name no tool call stay unattached and render in the transcript's
+ * trailer row, which exists for exactly them.
  *
  * Returns updated messages and the id of the attached tool call (or undefined).
  */
@@ -381,7 +384,6 @@ export function attachConfirmationToToolCall(
   const { toolUseId, ...pendingFields } = conf;
   const pending: PendingToolConfirmation = pendingFields;
 
-  // 1. Exact toolUseId match — search all messages with tool calls
   if (toolUseId) {
     for (let mi = messages.length - 1; mi >= 0; mi--) {
       const msg = messages[mi];
@@ -393,22 +395,6 @@ export function attachConfirmationToToolCall(
         return applyConfirmationToToolCall(messages, mi, tcIdx, pending);
       }
     }
-  }
-
-  // 2. Fallback: last running tool call in the latest assistant message with tool calls
-  for (let mi = messages.length - 1; mi >= 0; mi--) {
-    const msg = messages[mi];
-    if (msg?.role !== "assistant" || !msg.toolCalls?.length) {
-      continue;
-    }
-
-    for (let ti = msg.toolCalls.length - 1; ti >= 0; ti--) {
-      const tc = msg.toolCalls[ti];
-      if (tc && isToolCallRunning(tc)) {
-        return applyConfirmationToToolCall(messages, mi, ti, pending);
-      }
-    }
-    break;
   }
 
   return { updatedMessages: messages, attachedToolCallId: undefined };

--- a/clients/web/src/domains/chat/utils/send-message-utils.test.ts
+++ b/clients/web/src/domains/chat/utils/send-message-utils.test.ts
@@ -368,18 +368,15 @@ describe("parsePendingConfirmationData", () => {
       input: { path: "/tmp" },
       toolUseId: "tu-1",
     };
-    const { confData, state } = parsePendingConfirmationData(raw);
+    const parsed = parsePendingConfirmationData(raw);
 
-    expect(state.requestId).toBe("req-1");
-    expect(state.toolName).toBe("delete_file");
-
-    expect(confData.requestId).toBe("req-1");
-    expect(confData.toolUseId).toBe("tu-1");
+    expect(parsed.requestId).toBe("req-1");
+    expect(parsed.toolName).toBe("delete_file");
+    expect(parsed.toolUseId).toBe("tu-1");
   });
 
   it("defaults requestId to empty string when missing", () => {
-    const { state } = parsePendingConfirmationData({});
-    expect(state.requestId).toBe("");
+    expect(parsePendingConfirmationData({}).requestId).toBe("");
   });
 });
 

--- a/clients/web/src/domains/chat/utils/send-message-utils.test.ts
+++ b/clients/web/src/domains/chat/utils/send-message-utils.test.ts
@@ -207,11 +207,7 @@ describe("completeSubmittedSurface", () => {
     ];
 
     expect(
-      completeSubmittedSurface(
-        messages,
-        "s-first-run-scope",
-        "scope_work",
-      ),
+      completeSubmittedSurface(messages, "s-first-run-scope", "scope_work"),
     ).toBe(messages);
   });
 
@@ -365,8 +361,6 @@ describe("parsePendingConfirmationData", () => {
       requestId: "req-1",
       title: "Confirm action",
       description: "Are you sure?",
-      confirmLabel: "Yes",
-      denyLabel: "No",
       toolName: "delete_file",
       riskLevel: "high",
       riskReason: "Irreversible",
@@ -377,8 +371,6 @@ describe("parsePendingConfirmationData", () => {
     const { confData, state } = parsePendingConfirmationData(raw);
 
     expect(state.requestId).toBe("req-1");
-    expect(state.confirmLabel).toBe("Yes");
-    expect(state.denyLabel).toBe("No");
     expect(state.toolName).toBe("delete_file");
 
     expect(confData.requestId).toBe("req-1");

--- a/clients/web/src/domains/chat/utils/send-message-utils.ts
+++ b/clients/web/src/domains/chat/utils/send-message-utils.ts
@@ -156,8 +156,7 @@ export function completeSubmittedSurface(
       return prev;
     }
     const matchedAction = surface.actions?.find((a) => a.id === actionId);
-    const isCancellation =
-      actionId === "cancel" || actionId === "dismiss";
+    const isCancellation = actionId === "cancel" || actionId === "dismiss";
     const updated = [...prev];
     updated[i] = mapMessageSurfaces(prev[i]!, (s) =>
       s.surfaceId === surfaceId
@@ -257,8 +256,6 @@ export function parsePendingConfirmationData(raw: Record<string, unknown>): {
   };
   const state: PendingConfirmationState = {
     ...confData,
-    confirmLabel: optionalString(raw.confirmLabel),
-    denyLabel: optionalString(raw.denyLabel),
   };
   return { confData, state };
 }

--- a/clients/web/src/domains/chat/utils/send-message-utils.ts
+++ b/clients/web/src/domains/chat/utils/send-message-utils.ts
@@ -11,10 +11,7 @@ import {
   type SurfaceCompletionTone,
 } from "@/domains/chat/types/types";
 
-import {
-  attachConfirmationToToolCall,
-  ERROR_MESSAGES,
-} from "@/domains/chat/utils/chat";
+import { ERROR_MESSAGES } from "@/domains/chat/utils/chat";
 import {
   filterMessageSurfaces,
   mapMessageSurfaces,
@@ -234,11 +231,10 @@ export function parsePendingSecretState(
   };
 }
 
-export function parsePendingConfirmationData(raw: Record<string, unknown>): {
-  confData: Parameters<typeof attachConfirmationToToolCall>[1];
-  state: PendingConfirmationState;
-} {
-  const confData = {
+export function parsePendingConfirmationData(
+  raw: Record<string, unknown>,
+): PendingConfirmationState {
+  return {
     requestId: typeof raw.requestId === "string" ? raw.requestId : "",
     title: optionalString(raw.title),
     description: optionalString(raw.description),
@@ -254,10 +250,6 @@ export function parsePendingConfirmationData(raw: Record<string, unknown>): {
     input: optionalRecord(raw.input),
     toolUseId: optionalString(raw.toolUseId),
   };
-  const state: PendingConfirmationState = {
-    ...confData,
-  };
-  return { confData, state };
 }
 
 /** Generate a unique turn ID for correlating the send → reconcile lifecycle. */

--- a/clients/web/src/domains/chat/utils/stream-handlers/interaction-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/interaction-handlers.test.ts
@@ -80,10 +80,45 @@ describe("handleConfirmationRequest", () => {
     expect(state.pendingConfirmation).toMatchObject({ requestId: "cr-1" });
   });
 
-  it("wires the interaction store to the matched tool call (reducer folds the marker)", () => {
+  it("wires the interaction store to the tool call the confirmation names", () => {
     // The reducer attaches the inline marker onto the snapshot (covered in
     // rolling-snapshot.test.ts); the handler only derives the matched tool-call id
     // read-only to wire the interaction store.
+    seedSnapshot([
+      {
+        id: "a-1",
+        role: "assistant",
+        ...textBody(""),
+        timestamp: 1,
+        toolCalls: [runningToolCall("tc-1")],
+      },
+    ]);
+    const ctx = makeCtx();
+    handleConfirmationRequest(
+      {
+        type: "confirmation_request",
+        requestId: "cr-1",
+        toolName: "bash",
+        input: { command: "ls" },
+        riskLevel: "low",
+        allowlistOptions: [],
+        scopeOptions: [],
+        toolUseId: "tc-1",
+      },
+      ctx,
+    );
+
+    expect(useInteractionStore.getState().inlineConfirmationToolCallId).toBe(
+      "tc-1",
+    );
+    expect(ctx.setConfirmationToolCall).toHaveBeenCalledWith("cr-1", "tc-1");
+  });
+
+  it("wires nothing when the confirmation names no tool call", () => {
+    // `toolUseId` is absent exactly when the prompt belongs to no tool call
+    // (ACP route approvals), so there is nothing to wire. Binding it to
+    // whichever call happens to be running hides the prompt whenever that
+    // call is one the transcript does not draw.
     seedSnapshot([
       {
         id: "a-1",
@@ -107,10 +142,10 @@ describe("handleConfirmationRequest", () => {
       ctx,
     );
 
-    expect(useInteractionStore.getState().inlineConfirmationToolCallId).toBe(
-      "tc-1",
-    );
-    expect(ctx.setConfirmationToolCall).toHaveBeenCalledWith("cr-1", "tc-1");
+    expect(
+      useInteractionStore.getState().inlineConfirmationToolCallId,
+    ).toBeNull();
+    expect(ctx.setConfirmationToolCall).not.toHaveBeenCalled();
   });
 });
 

--- a/clients/web/src/types/interaction-ui-types.ts
+++ b/clients/web/src/types/interaction-ui-types.ts
@@ -41,8 +41,6 @@ export interface PendingConfirmationState {
   requestId: string;
   title?: string;
   description?: string;
-  confirmLabel?: string;
-  denyLabel?: string;
   toolName?: string;
   riskLevel?: string;
   riskReason?: string;


### PR DESCRIPTION
## TL;DR

A permission prompt could render **nowhere**: the assistant sat spinning until the request timed out and was silently denied, and the user was never asked. Separately, a step that demanded fresh approval every time was still offered a standing "Allow & Create Rule".

Both come from one cause — a confirmation arrives with **no position in the conversation**, so the client invents one.

Fixes LUM-3271. Fixes LUM-3287.

## Before and after

| | Today on `main` | After this merges |
| --- | --- | --- |
| Assistant needs permission for a step with no tool call of its own (ACP approvals) | The prompt binds to an unrelated running step. If the transcript doesn't draw that step, **no card appears anywhere**. You see a spinning tool, nothing to click, and ~300s later the action is denied without you ever being asked. | The prompt appears in the transcript's trailer row, where you can answer it. |
| Permission prompt on a subagent spawn | Same dead end: a spawn draws a card rather than a chip, so nothing carries the prompt, and the trailer row is suppressed because the prompt counts as "attached". | The prompt appears in the trailer row. |
| Step that demanded fresh approval (scheduled tasks, workflow management) | The inline card offers **"Allow & Create Rule"** — the standing permission the daemon explicitly asked to prevent. The trailer row, for the same request, hides it. | Withheld on every surface, including the rule hint sent with the decision. |
| Answering a prompt that has no tool call | Risk metadata and an "unknown risk" nudge are stamped onto an unrelated, already-finished step — a badge about a decision that was never about it. | Nothing is stamped. |

## Why this is needed

Everything else a message contains — text, thinking, tool calls, surfaces, attachments — arrives with its position and is rendered by walking that list in order. A permission prompt is the only thing that arrives without one.

So the client guessed: *attach it to the last running tool call.*

That guess is unnecessary. `toolUseId` is absent **precisely when there is no tool call to name**: `permissions/prompter.ts` passes the LLM's tool_use block id, and the ACP route approvals have none. Absence is an answer, not missing data.

And the guess is what produced both bugs. It could land the prompt on a step the transcript filters out of the chip list, which hides the inline card **and** suppresses the trailer row that would otherwise carry it. Because there were two candidate positions, there were two components rendering the prompt, and they had drifted on what they offered.

## Why this is the root fix and not a workaround

Every change here **deletes** logic rather than adding a guard around it:

- the fabricated tool-call association is gone, not special-cased
- the trailer's condition is the real predicate (is a rendered chip showing this?) rather than a proxy (is it attached to anything?)
- one predicate answers "may this offer a durable rule", replacing three independent copies — including the submit path, so a card can no longer offer a rule the request never sends
- risk metadata lands only on the named call, replacing a second guess of the same kind
- verb fields that no producer sets are deleted rather than defaulted around

Net effect on behaviour code is a deletion. Nothing here is a compensating condition that a later change has to unwind.

There is a further structural fix one level down — the daemon giving the prompt a position, as it already does for every other kind of message content, at which point the client never chooses a position and cannot choose wrong. That is recorded on LUM-3271 as the follow-up. It is not a prerequisite: web always serves the latest bundle while the daemon can be any installed version, so a wire change alone would not reach users on an older daemon. This does.

## Why it is safe

- **Unchanged where it was already correct.** A prompt that names a drawn chip still renders there, and is still not duplicated in the trailer.
- **Regression tests fail on the pre-change code by construction.** The no-`toolUseId` test uses a fixture with no `result`/`completedAt`/`isError`, so `isToolCallRunning` is true and the deleted guess *would* have seized it. The subagent-spawn test asserts a trailer row where the old condition suppressed it.
- **Verified in the rendered DOM** across both surfaces and their gated and ungated states.
- **One existing test changed deliberately**, and it is worth a look: `interaction-handlers.test.ts` asserted that a confirmation with no `toolUseId` binds to whichever call is running. That encoded the guess as the contract, so it now names its tool call, with a sibling asserting nothing is wired when none is named.
- **Dead code removal is provably dead.** `confirmLabel`/`denyLabel` are absent from the `confirmation_request` event schema and from `PendingToolConfirmationSchema`, and every `confirmLabel` in `assistant/src` belongs to `ConfirmationSurfaceData`, a different feature. Every prompt has always rendered "Allow" and "Deny".
- Typecheck and lint clean; CI green. Local `bun test` is blocked by a repo hook, so CI is the test gate.

One judgement worth a reviewer's eye: only the subagent-spawn half of the chip filter is mirrored into the trailer's condition. Every route into card-backing — workflow id, ACP id, background-task id, answered question — turns true only once the call has run, and a pending prompt gates execution, so a prompt cannot sit on a card-backed call. That is reasoning rather than a test, so the code states it and states what breaks if it ever stops holding.

## Not in scope

The two cards still draw the same decision set with different chrome (the chip follows the Figma card, the trailer keeps its own). Converging that changes shipped visuals and is a design decision, not this one.
