### PR TITLE
fix(android): self-review remediation for the self-hosted parity arc

### DIFF
--- a/clients/android/app/src/main/java/ai/vellum/assistant/ConnectDeepLink.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/ConnectDeepLink.java
@@ -68,7 +68,7 @@ final class ConnectDeepLink {
         if (pairPage == null) {
             return null;
         }
-        return new ConnectDeepLink(server, pairPage, normalizeName(query.get("name")));
+        return new ConnectDeepLink(server, pairPage, SelfHostedServer.normalizedName(query.get("name")));
     }
 
     URI server() {
@@ -81,14 +81,6 @@ final class ConnectDeepLink {
 
     String name() {
         return name;
-    }
-
-    private static String normalizeName(String value) {
-        if (value == null) {
-            return null;
-        }
-        String trimmed = value.trim();
-        return trimmed.isEmpty() ? null : trimmed;
     }
 
     private static URI parseUri(String raw) {

--- a/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
@@ -219,6 +219,8 @@ public class MainActivity extends BridgeActivity {
 
         if (effectiveServer == null || !effectiveServer.equals(connect.server())) {
             setRecreationConnect(connect);
+            // A stale switch route must not load over the pair page.
+            setRecreationRoutePath(null);
             setIntent(withoutData(intent));
             recreate();
             return;
@@ -334,8 +336,7 @@ public class MainActivity extends BridgeActivity {
         ) {
             return;
         }
-        SelfHostedServer.store(this, pendingConnect.server());
-        SelfHostedServer.append(this, pendingConnect.server(), pendingConnect.name());
+        SelfHostedServer.activate(this, pendingConnect.server(), pendingConnect.name());
         pendingConnect = null;
     }
 
@@ -373,19 +374,15 @@ public class MainActivity extends BridgeActivity {
     private void useVellumCloud() {
         SelfHostedServer.clear(this);
         effectiveServer = null;
-        recreateForServerChange();
-    }
-
-    /**
-     * Recreate onto whatever server slot {@link SelfHostedServer} now holds.
-     * The caller has already written the slot; onCreate re-reads everything,
-     * so no field needs resetting beyond the pending launch state.
-     */
-    void recreateForServerChange() {
         recreateForServerChange(null);
     }
 
-    /** Same, plus an initial in-app route to load once the new origin is up. */
+    /**
+     * Recreate onto whatever server slot {@link SelfHostedServer} now holds,
+     * plus an optional initial in-app route to load once the new origin is up.
+     * The caller has already written the slot; onCreate re-reads everything,
+     * so no field needs resetting beyond the pending launch state.
+     */
     void recreateForServerChange(String routePath) {
         // A live voice session does not survive an origin swap.
         VoiceLiveActivityPlugin.clearStatus(this);
@@ -441,7 +438,8 @@ public class MainActivity extends BridgeActivity {
      */
     private void deliverPendingRoute() {
         String path = takeRecreationRoutePath();
-        if (path == null || bridge == null || bridge.getServerUrl() == null) {
+        // Pair-page navigation wins over a stashed route.
+        if (path == null || pendingConnect != null || bridge == null || bridge.getServerUrl() == null) {
             return;
         }
         String route = SelfHostedServer.appRoute(bridge.getServerUrl(), path);

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
@@ -27,6 +27,9 @@ final class SelfHostedServer {
     private static final String SERVER_URL_KEY = "server_url";
     private static final String SERVERS_KEY = "servers";
 
+    /** Serializes every read-modify-write of the servers list. */
+    private static final Object listLock = new Object();
+
     interface Store {
         String read();
 
@@ -68,10 +71,6 @@ final class SelfHostedServer {
 
     static URI configured(Store store) {
         return validate(store.read());
-    }
-
-    static boolean store(Context context, URI server) {
-        return store(new PreferencesStore(context), server);
     }
 
     static boolean store(Store store, URI server) {
@@ -139,7 +138,8 @@ final class SelfHostedServer {
                     }
                     String canonical = canonicalString(url);
                     if (indexOfUrl(entries, canonical) < 0) {
-                        entries.add(new Entry(normalizedName(item.optString("name", null)), canonical));
+                        String name = item.isNull("name") ? null : item.optString("name", null);
+                        entries.add(new Entry(normalizedName(name), canonical));
                     }
                 }
             } catch (JSONException exception) {
@@ -165,16 +165,30 @@ final class SelfHostedServer {
      * updates the label; a nameless re-append keeps the existing one.
      */
     static void append(Store store, URI url, String name) {
-        List<Entry> entries = servers(store);
-        String canonical = canonicalString(url);
-        String label = normalizedName(name);
-        int index = indexOfUrl(entries, canonical);
-        if (index < 0) {
-            entries.add(new Entry(label, canonical));
-        } else if (label != null) {
-            entries.set(index, new Entry(label, canonical));
+        synchronized (listLock) {
+            List<Entry> entries = servers(store);
+            String canonical = canonicalString(url);
+            String label = normalizedName(name);
+            int index = indexOfUrl(entries, canonical);
+            if (index < 0) {
+                entries.add(new Entry(label, canonical));
+            } else if (label != null) {
+                entries.set(index, new Entry(label, canonical));
+            }
+            persist(store, entries);
         }
-        persist(store, entries);
+    }
+
+    static void activate(Context context, URI url, String name) {
+        activate(new PreferencesStore(context), url, name);
+    }
+
+    /** Write the active slot and remember the origin as one atomic mutation. */
+    static void activate(Store store, URI url, String name) {
+        synchronized (listLock) {
+            store(store, url);
+            append(store, url, name);
+        }
     }
 
     static boolean removeEntry(Context context, URI url) {
@@ -186,22 +200,20 @@ final class SelfHostedServer {
      * slot, the slot is cleared too; returns whether that happened.
      */
     static boolean removeEntry(Store store, URI url) {
-        List<Entry> entries = servers(store);
-        String canonical = canonicalString(url);
-        int index = indexOfUrl(entries, canonical);
-        if (index >= 0) {
-            entries.remove(index);
+        synchronized (listLock) {
+            List<Entry> entries = servers(store);
+            String canonical = canonicalString(url);
+            int index = indexOfUrl(entries, canonical);
+            if (index >= 0) {
+                entries.remove(index);
+            }
+            persist(store, entries);
+            if (isActive(store, url)) {
+                clear(store);
+                return true;
+            }
+            return false;
         }
-        persist(store, entries);
-        if (isActive(store, url)) {
-            clear(store);
-            return true;
-        }
-        return false;
-    }
-
-    static boolean isActive(Context context, URI url) {
-        return isActive(new PreferencesStore(context), url);
     }
 
     /** Whether a URL canonically matches the active slot. */
@@ -229,18 +241,36 @@ final class SelfHostedServer {
     }
 
     /**
+     * The shared shape guard for in-app route paths: non-blank, relative,
+     * scheme-less, fragment-free. Callers pass a trimmed path.
+     */
+    static boolean isRoutePathShape(String path) {
+        return path != null
+            && !path.isEmpty()
+            && !path.startsWith("/")
+            && !path.contains("://")
+            && !path.contains("#");
+    }
+
+    /**
      * A route under an entry URL: {@code <entry>/<path>}, the path's query
      * kept verbatim. Null (caller falls back to the entry) when the path is
      * unusable: blank, absolute, scheme-ful, fragment-carrying, or climbing.
      */
     static String appRoute(String entryUrl, String path) {
         String trimmed = path == null ? "" : path.trim();
-        if (trimmed.isEmpty() || trimmed.startsWith("/") || trimmed.contains("://") || trimmed.contains("#")) {
+        if (!isRoutePathShape(trimmed)) {
             return null;
         }
         int query = trimmed.indexOf('?');
         String pathPart = query < 0 ? trimmed : trimmed.substring(0, query);
-        for (String segment : pathPart.split("/", -1)) {
+        String[] segments = pathPart.split("/", -1);
+        // A colon in the first segment reads as a scheme (mailto:x,
+        // host:8080/x), matching the iOS URLComponents rejection.
+        if (segments[0].indexOf(':') >= 0) {
+            return null;
+        }
+        for (String segment : segments) {
             if ("..".equals(segment)) {
                 return null;
             }
@@ -300,7 +330,8 @@ final class SelfHostedServer {
         store.writeServers(array.toString());
     }
 
-    private static String normalizedName(String name) {
+    /** A user-facing label: trimmed, with blank collapsing to null. */
+    static String normalizedName(String name) {
         if (name == null) {
             return null;
         }
@@ -332,6 +363,11 @@ final class SelfHostedServer {
 
         String scheme = parsed.getScheme() == null ? "" : parsed.getScheme().toLowerCase(Locale.US);
         String host = parsed.getHost().toLowerCase(Locale.US);
+        // Unicode hosts canonicalize differently here (percent-encoding) than
+        // in the web chooser (punycode), so they are rejected outright.
+        if (!isAscii(host)) {
+            return null;
+        }
         if (!"https".equals(scheme) && !("http".equals(scheme) && isLocalDevelopmentHost(host))) {
             return null;
         }
@@ -528,6 +564,15 @@ final class SelfHostedServer {
     private static String formatAuthority(String host, int port) {
         String authorityHost = host.indexOf(':') >= 0 && !host.startsWith("[") ? "[" + host + "]" : host;
         return port >= 0 ? authorityHost + ":" + port : authorityHost;
+    }
+
+    private static boolean isAscii(String value) {
+        for (int index = 0; index < value.length(); index++) {
+            if (value.charAt(index) >= 0x80) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static boolean isLocalDevelopmentHost(String host) {

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServersPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServersPlugin.java
@@ -104,7 +104,7 @@ public class SelfHostedServersPlugin extends Plugin {
     public void switchToPath(PluginCall call) {
         String raw = call.getString("path");
         String path = raw == null ? "" : raw.trim();
-        if (path.isEmpty() || path.startsWith("/") || path.contains("://") || path.contains("#")) {
+        if (!SelfHostedServer.isRoutePathShape(path)) {
             call.reject("invalid path");
             return;
         }
@@ -132,15 +132,20 @@ public class SelfHostedServersPlugin extends Plugin {
             call.reject("invalid url");
             return false;
         }
-        SelfHostedServer.store(getContext(), url);
-        SelfHostedServer.append(getContext(), url, null);
+        SelfHostedServer.activate(getContext(), url, null);
         return true;
     }
 
     private void scheduleRecreate(String routePath) {
         Activity activity = getActivity();
         if (activity instanceof MainActivity mainActivity) {
-            activity.runOnUiThread(() -> mainActivity.recreateForServerChange(routePath));
+            activity.runOnUiThread(() -> {
+                // A superseded activity must not consume or plant recreation state.
+                if (mainActivity.isFinishing() || mainActivity.isDestroyed()) {
+                    return;
+                }
+                mainActivity.recreateForServerChange(routePath);
+            });
         }
     }
 

--- a/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
@@ -53,6 +53,13 @@ public class SelfHostedServerTest {
     }
 
     @Test
+    public void rejectsNonAsciiHostsButKeepsAsciiAndIpv6LiteralHosts() {
+        assertNull(SelfHostedServer.validate("https://münchen.example"));
+        assertEquals("https://example.com", SelfHostedServer.validate("https://example.com").toASCIIString());
+        assertEquals("https://[::1]:8443", SelfHostedServer.validate("https://[::1]:8443").toASCIIString());
+    }
+
+    @Test
     public void storesOnlyValidatedServerBasesAndCanReset() {
         FakeStore store = new FakeStore();
         URI server = SelfHostedServer.validate("https://example.com/assistant-123");
@@ -205,6 +212,30 @@ public class SelfHostedServerTest {
     }
 
     @Test
+    public void readsExplicitJsonNullNamesAsUnnamed() {
+        FakeStore store = new FakeStore();
+        store.servers = "[{\"name\":null,\"url\":\"https://example.com/assistant-123\"}]";
+
+        List<SelfHostedServer.Entry> servers = SelfHostedServer.servers(store);
+
+        assertEquals(1, servers.size());
+        assertEquals(new SelfHostedServer.Entry(null, "https://example.com/assistant-123"), servers.get(0));
+    }
+
+    @Test
+    public void activateWritesTheActiveSlotAndRemembersTheOrigin() {
+        FakeStore store = new FakeStore();
+        URI server = SelfHostedServer.validate("https://example.com:443/assistant-123/");
+
+        SelfHostedServer.activate(store, server, "Living Room");
+
+        assertTrue(SelfHostedServer.isActive(store, server));
+        List<SelfHostedServer.Entry> servers = SelfHostedServer.servers(store);
+        assertEquals(1, servers.size());
+        assertEquals(new SelfHostedServer.Entry("Living Room", "https://example.com/assistant-123"), servers.get(0));
+    }
+
+    @Test
     public void foldsInLegacyActiveUrlWithoutWritingBack() {
         FakeStore store = new FakeStore();
         SelfHostedServer.store(store, SelfHostedServer.validate("https://example.com:443/assistant-123"));
@@ -268,6 +299,16 @@ public class SelfHostedServerTest {
         assertNull(SelfHostedServer.appRoute("https://host/assistant", "pair#fragment"));
         assertNull(SelfHostedServer.appRoute("https://host/assistant", "a/../b"));
         assertNull(SelfHostedServer.appRoute("https://host/assistant", "   "));
+    }
+
+    @Test
+    public void appRouteRejectsColonsOnlyInTheFirstSegment() {
+        assertNull(SelfHostedServer.appRoute("https://host/assistant", "mailto:x"));
+        assertNull(SelfHostedServer.appRoute("https://host/assistant", "evil.example:8080/x"));
+        assertEquals(
+            "https://host/assistant/conversations/abc:def",
+            SelfHostedServer.appRoute("https://host/assistant", "conversations/abc:def")
+        );
     }
 
     @Test


### PR DESCRIPTION
## Summary
Fixes gaps identified during the plan self-review for android-assistant-parity.md:
- Recreation race guards: connect deep links clear a stashed switch route, pending routes yield to pair-page navigation, and a finishing activity's recreate runnable is skipped
- Servers-list mutations are synchronized (plugin thread vs UI thread read-modify-write)
- validate rejects non-ASCII hosts (Java/WHATWG canonicalization skew made them unremovable ghost chooser entries)
- appRoute rejects scheme-like relative paths (mailto:x class) matching iOS, and shares its shape predicate with switchToPath's precheck
- servers() reads an explicit JSON-null name as unnamed on platform org.json
- Consolidation: unused isActive(Context) overload removed, single recreateForServerChange(String), shared name normalization, atomic activate() for store+append