### PR TITLE
fix(android): residual self-review hardening

### DIFF
--- a/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
@@ -384,6 +384,12 @@ public class MainActivity extends BridgeActivity {
      * so no field needs resetting beyond the pending launch state.
      */
     void recreateForServerChange(String routePath) {
+        // A connect deep link may have planted a recreation while this call's
+        // runnable sat queued (recreate() flips neither isFinishing nor
+        // isDestroyed); the pairing navigation wins, so never discard it.
+        if (hasRecreationConnect()) {
+            return;
+        }
         // A live voice session does not survive an origin swap.
         VoiceLiveActivityPlugin.clearStatus(this);
         pendingConnect = null;
@@ -466,6 +472,10 @@ public class MainActivity extends BridgeActivity {
 
     private static synchronized void setRecreationConnect(ConnectDeepLink connect) {
         recreationConnect = connect;
+    }
+
+    private static synchronized boolean hasRecreationConnect() {
+        return recreationConnect != null;
     }
 
     private static final class SelfHostedWebViewClient extends BridgeWebViewClient {

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
@@ -138,6 +138,10 @@ final class SelfHostedServer {
                     }
                     String canonical = canonicalString(url);
                     if (indexOfUrl(entries, canonical) < 0) {
+                        // isNull guards platform org.json, whose optString
+                        // stringifies JSON null to "null"; the JVM test
+                        // artifact returns the default, so tests cannot
+                        // regression-protect this. Keep the guard.
                         String name = item.isNull("name") ? null : item.optString("name", null);
                         entries.add(new Entry(normalizedName(name), canonical));
                     }
@@ -274,6 +278,11 @@ final class SelfHostedServer {
             if ("..".equals(segment)) {
                 return null;
             }
+        }
+        // iOS splits the percent-decoded path, so %2e%2e reads as ".." there;
+        // reject the encoded spelling too or the route could climb the prefix.
+        if (containsEncodedDotSegment(pathPart)) {
+            return null;
         }
         String base = entryUrl;
         while (base.endsWith("/")) {

--- a/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
@@ -298,6 +298,8 @@ public class SelfHostedServerTest {
         assertNull(SelfHostedServer.appRoute("https://host/assistant", "https://evil.example/route"));
         assertNull(SelfHostedServer.appRoute("https://host/assistant", "pair#fragment"));
         assertNull(SelfHostedServer.appRoute("https://host/assistant", "a/../b"));
+        assertNull(SelfHostedServer.appRoute("https://host/assistant", "a/%2e%2e/b"));
+        assertNull(SelfHostedServer.appRoute("https://host/assistant", "a/.%2E/b"));
         assertNull(SelfHostedServer.appRoute("https://host/assistant", "   "));
     }
 


### PR DESCRIPTION
## Summary
Round-2 self-review residuals for android-assistant-parity.md:
- appRoute rejects encoded dot segments (%2e%2e class) matching iOS's decoded-path split
- recreateForServerChange no-ops when a connect recreation is already planted (the queued-runnable interleaving recreate() cannot guard via isFinishing)
- comment pins the isNull("name") guard, which JVM tests cannot regression-protect

🤖 Generated with [Claude Code](https://claude.com/claude-code)