### PR TITLE
feat(web): chooser shows instance id for unnamed local assistants

### DIFF
--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
@@ -404,6 +404,8 @@ const { SelectAssistantScreen } = await import(
 
 const PAIRED_ID = "paired-1";
 const PLATFORM_ID = "platform-1";
+/** Local ids are friendly generated instance names, not UUIDs. */
+const LOCAL_ID = "vellum-deep-hare-ww1iw1";
 
 function makePairedAssistant(
   overrides: Partial<ResolvedAssistant> = {},
@@ -428,6 +430,21 @@ function makePlatformAssistant(
     cloud: "vellum",
     isLocal: false,
     isPlatformHosted: true,
+    isPaired: false,
+    ...overrides,
+  };
+}
+
+/** A lockfile-backed local entry as a local client sees it. */
+function makeLocalAssistant(
+  overrides: Partial<ResolvedAssistant> = {},
+): ResolvedAssistant {
+  return {
+    id: LOCAL_ID,
+    name: "Desk Helper",
+    cloud: "local",
+    isLocal: true,
+    isPlatformHosted: false,
     isPaired: false,
     ...overrides,
   };
@@ -1694,5 +1711,48 @@ describe("SelectAssistantScreen local registrations on the platform hub", () => 
     await waitFor(() =>
       expect(refreshPlatformAssistantsIfStaleMock).toHaveBeenCalledTimes(1),
     );
+  });
+});
+
+describe("SelectAssistantScreen assistant labels", () => {
+  // Two entries per case: a sole accessible local entry auto-connects
+  // instead of rendering the chooser.
+  const SECOND_LOCAL_ID = "vellum-calm-otter-ab2cd3";
+
+  test("a named local entry shows its persona name", () => {
+    assistantsValue = [
+      makeLocalAssistant(),
+      makeLocalAssistant({ id: SECOND_LOCAL_ID, name: undefined }),
+    ];
+
+    render(<SelectAssistantScreen />);
+
+    const named = screen
+      .getAllByRole("radio")
+      .find((r) => r.textContent?.includes("Desk Helper"));
+    expect(named).toBeTruthy();
+    expect(named!.textContent).not.toContain(LOCAL_ID);
+  });
+
+  test("unnamed local entries fall back to their instance ids", () => {
+    assistantsValue = [
+      makeLocalAssistant({ name: undefined }),
+      makeLocalAssistant({ id: SECOND_LOCAL_ID, name: undefined }),
+    ];
+
+    render(<SelectAssistantScreen />);
+
+    expect(screen.getByText(LOCAL_ID)).toBeTruthy();
+    expect(screen.getByText(SECOND_LOCAL_ID)).toBeTruthy();
+    expect(screen.queryByText("Local Assistant")).toBeNull();
+  });
+
+  test("an unnamed cloud entry keeps the generic Cloud Assistant fallback", () => {
+    assistantsValue = [makePlatformAssistant({ name: undefined })];
+
+    render(<SelectAssistantScreen />);
+
+    expect(screen.getByText("Cloud Assistant")).toBeTruthy();
+    expect(screen.queryByText(PLATFORM_ID)).toBeNull();
   });
 });

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -73,7 +73,11 @@ function assistantLabel(a: ResolvedAssistant): string {
   if (a.isPaired) {
     return "Paired Assistant";
   }
-  return a.isLocal ? "Local Assistant" : "Cloud Assistant";
+  if (a.isLocal) {
+    // Local ids are friendly generated instance names; cloud ids are UUIDs.
+    return a.id;
+  }
+  return "Cloud Assistant";
 }
 
 /** A hub-listed self-hosted entry lives on another machine; name its host. */


### PR DESCRIPTION
## Summary
- assistantLabel now falls back to the friendly instance id for unnamed local entries instead of an indistinguishable generic "Local Assistant" label
- Adds chooser test coverage for local named/unnamed fallback cases

Part of plan: unify-assistant-naming.md (PR 3 of 4)