### PR TITLE
feat(web): add renameLockfileAssistant helper for persona-name lockfile writes

### DIFF
--- a/clients/web/src/lib/local-mode.test.ts
+++ b/clients/web/src/lib/local-mode.test.ts
@@ -19,7 +19,10 @@ const loadLockfileHost = mock(async (): Promise<localModeHost.Lockfile> => {
 });
 
 const saveLockfileAssistantHost = mock(
-  async (_assistant: Record<string, unknown>, _activeId?: string) => ({
+  async (
+    _assistant: Record<string, unknown>,
+    _activeId?: string,
+  ): Promise<localModeHost.LockfileWriteResult> => ({
     ok: true as const,
     lockfile: { assistants: [], activeAssistant: null },
   }),
@@ -79,6 +82,7 @@ import {
   reconcileSelectedAssistant,
   removePairedAssistantFromLockfile,
   removePlatformAssistantFromLockfile,
+  renameLockfileAssistant,
   saveManagedLockfileAssistant,
   syncPlatformAssistantsToLockfile,
   UnresolvedLocalGatewayError,
@@ -546,6 +550,102 @@ describe("saveManagedLockfileAssistant", () => {
     const [entry] = saveLockfileAssistantHost.mock.calls[0]!;
     expect(entry.organizationId).toBeUndefined();
     expect(entry.name).toBeUndefined();
+  });
+});
+
+describe("renameLockfileAssistant", () => {
+  const named: LockfileAssistant = {
+    assistantId: "local-a",
+    cloud: "local",
+    name: "Old Name",
+    resources: { gatewayPort: 7830 },
+  } as LockfileAssistant;
+
+  // A non-remote injected config marks the local-mode host as available.
+  function enableLocalHost(): void {
+    window.__VELLUM_CONFIG__ = {};
+  }
+
+  test("writes the partial payload without retargeting the active assistant, and commits", async () => {
+    enableLocalHost();
+    setLockfile({ assistants: [named], activeAssistant: "local-a" });
+    const resulting = {
+      assistants: [{ ...named, name: "Credence" }],
+      activeAssistant: "local-a",
+    };
+    saveLockfileAssistantHost.mockResolvedValueOnce({
+      ok: true as const,
+      lockfile: resulting,
+    });
+
+    await renameLockfileAssistant("local-a", "  Credence  ");
+
+    expect(saveLockfileAssistantHost).toHaveBeenCalledTimes(1);
+    expect(saveLockfileAssistantHost.mock.calls[0]).toEqual([
+      { assistantId: "local-a", name: "Credence" },
+      undefined,
+    ]);
+    expect(useLockfileStore.getState().lockfile).toEqual(resulting);
+    expect(useLockfileStore.getState().committed).toBe(true);
+  });
+
+  test("no-op when the lockfile has no entry for the id", async () => {
+    enableLocalHost();
+    setLockfile({ assistants: [named], activeAssistant: "local-a" });
+
+    await renameLockfileAssistant("nope", "Credence");
+
+    expect(saveLockfileAssistantHost).not.toHaveBeenCalled();
+  });
+
+  test("no-op when the entry already carries the trimmed name", async () => {
+    enableLocalHost();
+    setLockfile({ assistants: [named], activeAssistant: "local-a" });
+
+    await renameLockfileAssistant("local-a", "  Old Name  ");
+
+    expect(saveLockfileAssistantHost).not.toHaveBeenCalled();
+  });
+
+  test("no-op on an empty or whitespace-only name", async () => {
+    enableLocalHost();
+    setLockfile({ assistants: [named], activeAssistant: "local-a" });
+
+    await renameLockfileAssistant("local-a", "");
+    await renameLockfileAssistant("local-a", "   ");
+
+    expect(saveLockfileAssistantHost).not.toHaveBeenCalled();
+  });
+
+  test("no-op when no local-mode host backs this runtime", async () => {
+    // Default test env: no injected config, not Electron.
+    setLockfile({ assistants: [named], activeAssistant: "local-a" });
+
+    await renameLockfileAssistant("local-a", "Credence");
+
+    expect(saveLockfileAssistantHost).not.toHaveBeenCalled();
+  });
+
+  test("no-op in remote-gateway mode", async () => {
+    window.__VELLUM_CONFIG__ = { mode: "remote-gateway" };
+
+    await renameLockfileAssistant("self", "Credence");
+
+    expect(saveLockfileAssistantHost).not.toHaveBeenCalled();
+  });
+
+  test("does not commit on a host write failure", async () => {
+    enableLocalHost();
+    setLockfile({ assistants: [named], activeAssistant: "local-a" });
+    saveLockfileAssistantHost.mockResolvedValueOnce({
+      ok: false,
+      error: "disk unavailable",
+    });
+
+    await renameLockfileAssistant("local-a", "Credence");
+
+    expect(saveLockfileAssistantHost).toHaveBeenCalledTimes(1);
+    expect(useLockfileStore.getState().lockfile?.assistants).toEqual([named]);
   });
 });
 

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -27,6 +27,7 @@ import {
   connectImportHost,
   fetchGuardianTokenHost,
   GuardianTokenError,
+  isLocalModeHostAvailable,
   loadLockfileHost,
   parseLockfile,
   replacePlatformAssistantsHost,
@@ -290,6 +291,37 @@ export async function updateLockfileAssistant(
   assistant: LockfileAssistant,
 ): Promise<void> {
   const result = await saveLockfileAssistantHost({ ...assistant }, undefined);
+  if (result.ok) {
+    commitLockfile(result.lockfile);
+  }
+}
+
+/**
+ * Rename an existing assistant entry without touching its other fields or the
+ * active assistant pointer. The partial payload rides the host's shallow
+ * on-disk merge, so `resources`, secrets, and unknown fields survive.
+ */
+export async function renameLockfileAssistant(
+  assistantId: string,
+  name: string,
+): Promise<void> {
+  const trimmed = name.trim();
+  if (!trimmed) {
+    // Fresh assistants report "" — never write an empty name.
+    return;
+  }
+  if (isRemoteGatewayMode() || !isLocalModeHostAvailable()) {
+    return;
+  }
+  const entry = getLockfileAssistant(assistantId);
+  if (!entry || entry.name === trimmed) {
+    // Rename-only: never create an entry, never write redundantly.
+    return;
+  }
+  const result = await saveLockfileAssistantHost(
+    { assistantId, name: trimmed },
+    undefined,
+  );
   if (result.ok) {
     commitLockfile(result.lockfile);
   }

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -307,7 +307,7 @@ export async function renameLockfileAssistant(
 ): Promise<void> {
   const trimmed = name.trim();
   if (!trimmed) {
-    // Fresh assistants report "" — never write an empty name.
+    // Fresh assistants report "": never write an empty name.
     return;
   }
   if (isRemoteGatewayMode() || !isLocalModeHostAvailable()) {

--- a/packages/local-mode/src/lockfile.test.ts
+++ b/packages/local-mode/src/lockfile.test.ts
@@ -224,6 +224,33 @@ describe("upsertLockfileAssistant", () => {
     });
   });
 
+  test("a name-only payload preserves resources and on-disk secrets byte-for-byte", () => {
+    const entry = {
+      assistantId: "asst_1",
+      cloud: "local",
+      runtimeUrl: "http://a",
+      name: "Old Name",
+      resources: { gatewayPort: 7830, daemonPort: 7831, dataDir: "/tmp/x" },
+      signingKey: "sk-on-disk-secret",
+      bearerToken: "bt-on-disk-secret",
+      guardianBootstrapSecret: "gb-on-disk-secret",
+    };
+    writeOnDisk({ activeAssistant: "asst_1", assistants: [entry] });
+
+    const result = upsertLockfileAssistant(
+      [lockfilePath],
+      { assistantId: "asst_1", name: "Renamed" },
+      undefined,
+    );
+
+    expect(result.ok).toBe(true);
+    const assistants = readOnDisk().assistants as Array<
+      Record<string, unknown>
+    >;
+    expect(assistants).toHaveLength(1);
+    expect(assistants[0]).toEqual({ ...entry, name: "Renamed" });
+  });
+
   test("preserves activeAssistant when no active id is provided", () => {
     writeOnDisk({
       activeAssistant: "asst_active",


### PR DESCRIPTION
## Summary
- Adds a narrow renameLockfileAssistant helper that merges a partial {assistantId, name} into an existing lockfile entry without touching resources, secrets, or the active pointer
- Extends packages/local-mode merge tests to pin the preservation semantics the helper relies on

Part of plan: unify-assistant-naming.md (PR 1 of 4)