### PR TITLE
refactor(web): resolve the active conversation by id, not by scanning the conversation list (LUM-3306)

### DIFF
--- a/clients/web/src/domains/chat/active-chat-view.tsx
+++ b/clients/web/src/domains/chat/active-chat-view.tsx
@@ -300,7 +300,6 @@ export function ActiveChatView() {
   // existence verdict and `sendMessage`, hence this placement.
   useDeepLinkThreadSend({
     assistantId,
-    isAssistantActive: assistantState.kind === "active",
     activeConversationId,
     conversationExistsOnServer,
     activeConversationArchived: activeConversation?.archivedAt != null,

--- a/clients/web/src/domains/chat/active-chat-view.tsx
+++ b/clients/web/src/domains/chat/active-chat-view.tsx
@@ -303,6 +303,7 @@ export function ActiveChatView() {
     isAssistantActive: assistantState.kind === "active",
     activeConversationId,
     conversationExistsOnServer,
+    activeConversationArchived: activeConversation?.archivedAt != null,
     sendMessage,
   });
 

--- a/clients/web/src/domains/chat/hooks/use-active-conversation.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-active-conversation.test.tsx
@@ -1,8 +1,11 @@
 /**
  * `useActiveConversation` resolves the open conversation's metadata row from
- * either list cache, and fetches the single row on demand when an open
- * background/scheduled thread is in neither — without loading the whole
- * background backlog.
+ * whichever list cache holds it, and fetches the single row on demand when
+ * no cache does, without loading any list onto the render path.
+ *
+ * The list caches are real here (a seeded QueryClient), not stubbed: the
+ * property under test is that the row is found wherever it lives, which a
+ * stub of the lookup could only assert about itself.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -12,23 +15,20 @@ import type { ReactNode } from "react";
 import { createElement } from "react";
 
 import type { Conversation } from "@/types/conversation-types";
+import {
+  archivedConversationsQueryKey,
+  backgroundConversationsQueryKey,
+  conversationsQueryKey,
+  scheduledConversationsQueryKey,
+  sectionConversationsQueryKey,
+} from "@/utils/conversation-list-fetchers";
+import { listPage } from "@/utils/conversation-list.test-helper";
 
-let foregroundImpl: Conversation[] = [];
-let backgroundImpl: Conversation[] = [];
-let scheduledImpl: Conversation[] = [];
-let archivedImpl: Conversation[] = [];
 let isOrgReadyImpl = true;
 const refreshConversationRowCalls: Array<{
   assistantId: string | null;
   conversationId: string;
 }> = [];
-
-mock.module("@/hooks/conversation-queries", () => ({
-  useConversationListQuery: () => ({ conversations: foregroundImpl }),
-  useBackgroundConversationListQuery: () => ({ conversations: backgroundImpl }),
-  useScheduledConversationListQuery: () => ({ conversations: scheduledImpl }),
-  useArchivedConversationListQuery: () => ({ conversations: archivedImpl }),
-}));
 
 mock.module("@/hooks/use-is-org-ready", () => ({
   useIsOrgReady: () => isOrgReadyImpl,
@@ -55,17 +55,21 @@ function makeConversation(conversationId: string): Conversation {
   return { conversationId } as Conversation;
 }
 
+const ASSISTANT_ID = "asst-1";
+let client: QueryClient;
+
+function seed(queryKey: readonly unknown[], rows: Conversation[]): void {
+  client.setQueryData(queryKey, listPage(rows));
+}
+
 function wrapper({ children }: { children: ReactNode }) {
-  const client = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: 0 } },
-  });
   return createElement(QueryClientProvider, { client }, children);
 }
 
 beforeEach(() => {
-  foregroundImpl = [];
-  backgroundImpl = [];
-  scheduledImpl = [];
+  client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
   isOrgReadyImpl = true;
   refreshConversationRowCalls.length = 0;
 });
@@ -77,11 +81,11 @@ afterEach(() => {
 describe("useActiveConversation", () => {
   test("returns the foreground row without fetching", () => {
     // GIVEN the active conversation is already in the foreground list
-    foregroundImpl = [makeConversation("fg-1")];
+    seed(conversationsQueryKey(ASSISTANT_ID), [makeConversation("fg-1")]);
 
     // WHEN the hook resolves the active conversation
     const { result } = renderHook(
-      () => useActiveConversation("asst-1", "fg-1", true),
+      () => useActiveConversation(ASSISTANT_ID, "fg-1", true),
       { wrapper },
     );
 
@@ -92,11 +96,13 @@ describe("useActiveConversation", () => {
 
   test("returns a background-cache row without fetching", () => {
     // GIVEN the active conversation is only in the background cache
-    backgroundImpl = [makeConversation("bg-1")];
+    seed(backgroundConversationsQueryKey(ASSISTANT_ID), [
+      makeConversation("bg-1"),
+    ]);
 
     // WHEN the hook resolves the active conversation
     const { result } = renderHook(
-      () => useActiveConversation("asst-1", "bg-1", true),
+      () => useActiveConversation(ASSISTANT_ID, "bg-1", true),
       { wrapper },
     );
 
@@ -107,11 +113,13 @@ describe("useActiveConversation", () => {
 
   test("returns a scheduled-cache row without fetching", () => {
     // GIVEN the active conversation is only in the scheduled cache
-    scheduledImpl = [makeConversation("sch-1")];
+    seed(scheduledConversationsQueryKey(ASSISTANT_ID), [
+      makeConversation("sch-1"),
+    ]);
 
     // WHEN the hook resolves the active conversation
     const { result } = renderHook(
-      () => useActiveConversation("asst-1", "sch-1", true),
+      () => useActiveConversation(ASSISTANT_ID, "sch-1", true),
       { wrapper },
     );
 
@@ -122,11 +130,13 @@ describe("useActiveConversation", () => {
 
   test("returns an archived-cache row without fetching", () => {
     // GIVEN the active conversation is only in the archived cache
-    archivedImpl = [makeConversation("arc-1")];
+    seed(archivedConversationsQueryKey(ASSISTANT_ID), [
+      makeConversation("arc-1"),
+    ]);
 
     // WHEN the hook resolves the active conversation
     const { result } = renderHook(
-      () => useActiveConversation("asst-1", "arc-1", true),
+      () => useActiveConversation(ASSISTANT_ID, "arc-1", true),
       { wrapper },
     );
 
@@ -135,14 +145,31 @@ describe("useActiveConversation", () => {
     expect(refreshConversationRowCalls).toHaveLength(0);
   });
 
-  test("fetches the single row when the active thread is in neither list", async () => {
-    // GIVEN neither list holds the open background/scheduled thread
-    foregroundImpl = [makeConversation("fg-1")];
-    backgroundImpl = [];
+  test("returns a row that lives only in a section cache without fetching", () => {
+    // GIVEN the row is in a pinned-section window and no drained list. The
+    // four-list scan this hook replaced could not see it and would have
+    // fetched a row it already had.
+    seed(
+      sectionConversationsQueryKey(ASSISTANT_ID, { groupId: "system:pinned" }),
+      [makeConversation("pin-1")],
+    );
+
+    const { result } = renderHook(
+      () => useActiveConversation(ASSISTANT_ID, "pin-1", true),
+      { wrapper },
+    );
+
+    expect(result.current?.conversationId).toBe("pin-1");
+    expect(refreshConversationRowCalls).toHaveLength(0);
+  });
+
+  test("fetches the single row when the active thread is in no list", async () => {
+    // GIVEN no list holds the open background/scheduled thread
+    seed(conversationsQueryKey(ASSISTANT_ID), [makeConversation("fg-1")]);
 
     // WHEN the hook resolves an active conversation absent from both lists
     const { result } = renderHook(
-      () => useActiveConversation("asst-1", "bg-unloaded", true),
+      () => useActiveConversation(ASSISTANT_ID, "bg-unloaded", true),
       { wrapper },
     );
 
@@ -156,14 +183,15 @@ describe("useActiveConversation", () => {
   });
 
   test("does not fetch when disabled", async () => {
-    // GIVEN the active thread is in neither list AND the hook is disabled
-    foregroundImpl = [];
-    backgroundImpl = [];
+    // GIVEN the active thread is in no list AND the hook is disabled
 
     // WHEN the hook runs with `enabled: false`
-    renderHook(() => useActiveConversation("asst-1", "bg-unloaded", false), {
-      wrapper,
-    });
+    renderHook(
+      () => useActiveConversation(ASSISTANT_ID, "bg-unloaded", false),
+      {
+        wrapper,
+      },
+    );
 
     // THEN no single-row fetch is issued
     await Promise.resolve();
@@ -173,11 +201,9 @@ describe("useActiveConversation", () => {
   test("does not fetch when org is not ready", async () => {
     // GIVEN the org store has not hydrated yet
     isOrgReadyImpl = false;
-    foregroundImpl = [];
-    backgroundImpl = [];
 
     // WHEN the hook runs with org not ready
-    renderHook(() => useActiveConversation("asst-1", "bg-unloaded", true), {
+    renderHook(() => useActiveConversation(ASSISTANT_ID, "bg-unloaded", true), {
       wrapper,
     });
 

--- a/clients/web/src/domains/chat/hooks/use-active-conversation.ts
+++ b/clients/web/src/domains/chat/hooks/use-active-conversation.ts
@@ -1,21 +1,22 @@
 /**
  * Resolve the metadata row for the currently-open conversation.
  *
- * The foreground list query holds only foreground conversations, while the
- * Background and Scheduled lists load lazily through separate queries — only
- * once the user reveals their sidebar sections. A background or scheduled
- * thread opened directly (by URL or a deep link) is therefore absent from
- * every loaded list, which would leave the chat header, action menu,
- * read-state, and the SSE subscription (gated on `conversationExistsOnServer`)
- * without a row to work from.
+ * The row lives in exactly one list cache, and which one depends on the
+ * conversation (foreground, background, scheduled, archived, or a section
+ * window) and moves as it is pinned, filed, archived, or surfaced. A thread
+ * opened directly (by URL or a deep link) may be in none of them yet, which
+ * would leave the chat header, action menu, read-state, and the SSE
+ * subscription (gated on `conversationExistsOnServer`) without a row.
  *
- * This hook reads the row from whichever list cache already holds it and,
- * when it is in none, fetches that single row into the cache. Fetching one
- * row keeps the active thread fully functional without pulling the entire
- * background or scheduled backlog onto the initial-render path.
+ * This hook follows the row wherever it lives (`useConversationRow`) and,
+ * when no cache holds it, fetches that single row into its home cache.
+ * Fetching one row keeps the active thread fully functional without
+ * pulling any list onto the initial-render path, and reading it from the
+ * list caches keeps one owner for the row: a placement or seen-state write
+ * reaches this consumer the same way it reaches the sidebar.
  */
 
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { captureError } from "@/lib/sentry/capture-error";
 import { useQueryClient } from "@tanstack/react-query";
 
@@ -23,12 +24,7 @@ import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 
 import type { Conversation } from "@/types/conversation-types";
 
-import {
-  useArchivedConversationListQuery,
-  useBackgroundConversationListQuery,
-  useConversationListQuery,
-  useScheduledConversationListQuery,
-} from "@/hooks/conversation-queries";
+import { useConversationRow } from "@/hooks/conversation-queries";
 import { refreshConversationRow } from "@/utils/conversation-cache-mutations";
 
 export function useActiveConversation(
@@ -38,37 +34,7 @@ export function useActiveConversation(
 ): Conversation | undefined {
   const queryClient = useQueryClient();
   const isOrgReady = useIsOrgReady();
-  const { conversations: foreground } = useConversationListQuery(
-    assistantId,
-    enabled,
-  );
-  // Read-only subscriptions (`enabled: false`): reflect background, scheduled,
-  // and archived rows already in cache — including the single row fetched below
-  // — without triggering any lazy list fetch.
-  const { conversations: background } = useBackgroundConversationListQuery(
-    assistantId,
-    false,
-  );
-  const { conversations: scheduled } = useScheduledConversationListQuery(
-    assistantId,
-    false,
-  );
-  const { conversations: archived } = useArchivedConversationListQuery(
-    assistantId,
-    false,
-  );
-
-  const activeConversation = useMemo(() => {
-    if (!conversationId) {
-      return undefined;
-    }
-    return (
-      foreground.find((c) => c.conversationId === conversationId) ??
-      background.find((c) => c.conversationId === conversationId) ??
-      scheduled.find((c) => c.conversationId === conversationId) ??
-      archived.find((c) => c.conversationId === conversationId)
-    );
-  }, [foreground, background, scheduled, archived, conversationId]);
+  const activeConversation = useConversationRow(assistantId, conversationId);
 
   const fetchedConversationIdRef = useRef<string | null>(null);
   useEffect(() => {

--- a/clients/web/src/domains/chat/hooks/use-attention-tracking-interaction-resolved.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-attention-tracking-interaction-resolved.test.tsx
@@ -13,12 +13,14 @@ import { createElement } from "react";
 import * as sdkGen from "@/generated/daemon/sdk.gen";
 import * as conversationCache from "@/utils/conversation-cache";
 import * as cacheMutations from "@/utils/conversation-cache-mutations";
+import * as conversationQueries from "@/hooks/conversation-queries";
 import { useConversationStore } from "@/stores/conversation-store";
 import { __resetForTesting, publish } from "@/lib/event-bus";
 
 // The hook fetches the conversation list and runs an initial sweep; stub
 // both so renderHook does not try to hit a real backend.
 mock.module("@/hooks/conversation-queries", () => ({
+  ...conversationQueries,
   useConversationListQuery: () => ({ conversations: [] }),
   useBackgroundConversationListQuery: () => ({ conversations: [] }),
   useScheduledConversationListQuery: () => ({ conversations: [] }),
@@ -56,9 +58,8 @@ mock.module("@/domains/chat/api/interactions", () => ({
   listConversationIdsWithPendingInteractions: async () => new Set<string>(),
 }));
 
-const { useAttentionTracking } = await import(
-  "@/domains/chat/hooks/use-attention-tracking"
-);
+const { useAttentionTracking } =
+  await import("@/domains/chat/hooks/use-attention-tracking");
 
 function wrapper({ children }: { children: ReactNode }) {
   const client = new QueryClient({

--- a/clients/web/src/domains/chat/hooks/use-attention-tracking-mark-seen.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-attention-tracking-mark-seen.test.tsx
@@ -13,6 +13,7 @@ import { createElement } from "react";
 import * as sdkGen from "@/generated/daemon/sdk.gen";
 import * as conversationCache from "@/utils/conversation-cache";
 import * as cacheMutations from "@/utils/conversation-cache-mutations";
+import * as conversationQueries from "@/hooks/conversation-queries";
 import { useConversationStore } from "@/stores/conversation-store";
 import { __resetForTesting } from "@/lib/event-bus";
 
@@ -34,6 +35,7 @@ const markConversationSeenCalls: Array<{
 let markConversationSeenImpl: () => Promise<void> = async () => {};
 
 mock.module("@/hooks/conversation-queries", () => ({
+  ...conversationQueries,
   useConversationListQuery: () => ({ conversations: conversationsImpl }),
   useBackgroundConversationListQuery: () => ({ conversations: [] }),
   useScheduledConversationListQuery: () => ({ conversations: [] }),
@@ -80,9 +82,8 @@ mock.module("@/domains/chat/api/interactions", () => ({
   listConversationIdsWithPendingInteractions: async () => new Set<string>(),
 }));
 
-const { useAttentionTracking } = await import(
-  "@/domains/chat/hooks/use-attention-tracking"
-);
+const { useAttentionTracking } =
+  await import("@/domains/chat/hooks/use-attention-tracking");
 
 function wrapper({ children }: { children: ReactNode }) {
   const client = new QueryClient({

--- a/clients/web/src/domains/chat/hooks/use-attention-tracking-reconnect-sweep.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-attention-tracking-reconnect-sweep.test.tsx
@@ -16,12 +16,14 @@ import { createElement } from "react";
 import * as sdkGen from "@/generated/daemon/sdk.gen";
 import * as conversationCache from "@/utils/conversation-cache";
 import * as cacheMutations from "@/utils/conversation-cache-mutations";
+import * as conversationQueries from "@/hooks/conversation-queries";
 import { useConversationStore } from "@/stores/conversation-store";
 import { __resetForTesting, publish } from "@/lib/event-bus";
 
 // Stub the conversation-list query and the mark-seen endpoint so the
 // hook does not try to hit a real backend during renderHook.
 mock.module("@/hooks/conversation-queries", () => ({
+  ...conversationQueries,
   useConversationListQuery: () => ({ conversations: [] }),
   useBackgroundConversationListQuery: () => ({ conversations: [] }),
   useScheduledConversationListQuery: () => ({ conversations: [] }),
@@ -85,9 +87,8 @@ mock.module("@/domains/chat/api/interactions", () => ({
   submitQuestionResponse: stubFromOtherTest("submitQuestionResponse"),
 }));
 
-const { useAttentionTracking } = await import(
-  "@/domains/chat/hooks/use-attention-tracking"
-);
+const { useAttentionTracking } =
+  await import("@/domains/chat/hooks/use-attention-tracking");
 
 function wrapper({ children }: { children: ReactNode }) {
   const client = new QueryClient({

--- a/clients/web/src/domains/chat/hooks/use-deep-link-thread-send.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-deep-link-thread-send.test.tsx
@@ -10,26 +10,13 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { createElement, type ReactNode } from "react";
 
 import { cleanup, renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
-import type { Conversation } from "@/types/conversation-types";
-
-// The hook observes the foreground list to decide "definitively absent".
-// Full module surface: `mock.module` is process-global in bun.
-let listState: {
-  conversations: Conversation[];
-  isPending: boolean;
-  isError: boolean;
-} = { conversations: [], isPending: true, isError: false };
-mock.module("@/hooks/conversation-queries", () => ({
-  useConversationListQuery: () => ({
-    ...listState,
-    isLoading: listState.isPending,
-    error: null,
-    refetch: () => {},
-  }),
-}));
+import { conversationsByIdGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
+import { ConversationNotFoundError } from "@/utils/fetch-conversation-detail";
 
 const sentryBreadcrumbMock = mock((_args: unknown) => undefined);
 mock.module("@sentry/react", () => ({
@@ -48,14 +35,49 @@ import {
   usePendingDeepLinkStore,
 } from "@/stores/pending-deep-link-store";
 
-const conversation = (id: string): Conversation => ({
-  conversationId: id,
-  title: id,
-});
-
 interface Props {
   activeConversationId: string | null;
   conversationExistsOnServer: boolean;
+  activeConversationArchived?: boolean;
+}
+
+/* The hook reads the target's single-row fetch outcome straight from the
+   query cache (the same key `fetchConversationDetail` populates), so each
+   test gets a real client and seeds that key: absent (never fetched), or
+   settled into the error the real fetch leaves on a 404. */
+let queryClient: QueryClient;
+
+function rowKey(conversationId: string) {
+  return conversationsByIdGetOptions({
+    path: { assistant_id: "assistant-1", id: conversationId },
+  }).queryKey;
+}
+
+/** Settle the target's row query into the state a 404 leaves behind. */
+async function seedRowNotFound(conversationId: string): Promise<void> {
+  await queryClient
+    .prefetchQuery({
+      queryKey: rowKey(conversationId),
+      queryFn: () =>
+        Promise.reject(new ConversationNotFoundError(conversationId)),
+      retry: false,
+    })
+    .catch(() => {});
+}
+
+/** Settle the target's row query into a transient (non-404) failure. */
+async function seedRowTransientError(conversationId: string): Promise<void> {
+  await queryClient
+    .prefetchQuery({
+      queryKey: rowKey(conversationId),
+      queryFn: () => Promise.reject(new Error("network down")),
+      retry: false,
+    })
+    .catch(() => {});
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  return createElement(QueryClientProvider, { client: queryClient }, children);
 }
 
 function renderSend(initial: Props) {
@@ -67,9 +89,10 @@ function renderSend(initial: Props) {
         isAssistantActive: true,
         activeConversationId: p.activeConversationId,
         conversationExistsOnServer: p.conversationExistsOnServer,
+        activeConversationArchived: p.activeConversationArchived ?? false,
         sendMessage,
       }),
-    { initialProps: initial },
+    { initialProps: initial, wrapper },
   );
   return { ...result, sendMessage };
 }
@@ -78,7 +101,9 @@ beforeEach(() => {
   __resetPendingDeepLinkForTesting();
   consumePendingComposerFocus();
   sentryBreadcrumbMock.mockClear();
-  listState = { conversations: [], isPending: true, isError: false };
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
   const composer = useComposerStore.getState();
   composer.setInput("");
   composer.clearDraft("abc-123");
@@ -137,11 +162,6 @@ describe("useDeepLinkThreadSend", () => {
     usePendingDeepLinkStore
       .getState()
       .setPendingThreadSend("abc-123", "gym done");
-    listState = {
-      conversations: [conversation("other")],
-      isPending: false,
-      isError: false,
-    };
     const { sendMessage } = renderSend({
       activeConversationId: "other",
       conversationExistsOnServer: true,
@@ -165,15 +185,14 @@ describe("useDeepLinkThreadSend", () => {
     expect(sentryBreadcrumbMock).toHaveBeenCalledTimes(1);
   });
 
-  it("demotes to a pre-fill when the loaded foreground list does not contain the target", () => {
+  it("demotes to a pre-fill when the server reports the target does not exist", async () => {
     usePendingDeepLinkStore
       .getState()
       .setPendingThreadSend("abc-123", "gym done");
-    listState = {
-      conversations: [conversation("something-else")],
-      isPending: false,
-      isError: false,
-    };
+    // The active-conversation path fetched the row and the daemon 404ed:
+    // the one definitive "not there". A list scan could not say this, since
+    // a windowed list is missing every row past its loaded page.
+    await seedRowNotFound("abc-123");
     const { sendMessage } = renderSend({
       activeConversationId: "abc-123",
       conversationExistsOnServer: false,
@@ -190,22 +209,45 @@ describe("useDeepLinkThreadSend", () => {
     expect(sentryBreadcrumbMock).toHaveBeenCalledTimes(1);
   });
 
-  it("does not treat an errored list as proof of absence", () => {
+  it("does not treat a transient row-fetch failure as proof of absence", async () => {
     usePendingDeepLinkStore
       .getState()
       .setPendingThreadSend("abc-123", "gym done");
-    listState = { conversations: [], isPending: false, isError: true };
+    // A network failure on the single-row fetch says nothing about the
+    // target; only the daemon's 404 does. Keep waiting rather than demote
+    // on a guess (the TTL bounds the wait).
+    await seedRowTransientError("abc-123");
     const { sendMessage } = renderSend({
       activeConversationId: "abc-123",
       conversationExistsOnServer: false,
     });
-    // An errored list served the [] fallback; that says nothing about the
-    // target. Keep waiting rather than demote on a guess.
     expect(sendMessage).not.toHaveBeenCalled();
     expect(usePendingDeepLinkStore.getState().pendingThreadSend).not.toBeNull();
     expect(
       usePendingDeepLinkStore.getState().pendingComposerMessage,
     ).toBeNull();
+  });
+
+  it("demotes when the target exists but is archived", () => {
+    /* The picker offers live conversations, and the daemon does not revive
+       an archived thread on send; a target archived after the picker synced
+       is found on the server yet must not be sent into. Kept as the
+       conservative direction: the text is staged, not dropped. */
+    usePendingDeepLinkStore
+      .getState()
+      .setPendingThreadSend("abc-123", "gym done");
+    const { sendMessage } = renderSend({
+      activeConversationId: "abc-123",
+      conversationExistsOnServer: true,
+      activeConversationArchived: true,
+    });
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(usePendingDeepLinkStore.getState().pendingThreadSend).toBeNull();
+    expect(usePendingDeepLinkStore.getState().pendingComposerMessage).toBe(
+      "gym done",
+    );
+    expect(consumePendingComposerFocus()).toBe(true);
   });
 
   it("demotes an expired park instead of sending, even when the target exists", () => {

--- a/clients/web/src/domains/chat/hooks/use-deep-link-thread-send.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-deep-link-thread-send.test.tsx
@@ -86,7 +86,6 @@ function renderSend(initial: Props) {
     (p: Props) =>
       useDeepLinkThreadSend({
         assistantId: "assistant-1",
-        isAssistantActive: true,
         activeConversationId: p.activeConversationId,
         conversationExistsOnServer: p.conversationExistsOnServer,
         activeConversationArchived: p.activeConversationArchived ?? false,

--- a/clients/web/src/domains/chat/hooks/use-deep-link-thread-send.ts
+++ b/clients/web/src/domains/chat/hooks/use-deep-link-thread-send.ts
@@ -19,7 +19,6 @@ export const PENDING_THREAD_SEND_TTL_MS = 60_000;
 
 export interface UseDeepLinkThreadSendOptions {
   assistantId: string | null;
-  isAssistantActive: boolean;
   activeConversationId: string | null;
   /**
    * The active conversation is a confirmed server row (from any list cache
@@ -86,7 +85,6 @@ export interface UseDeepLinkThreadSendOptions {
  */
 export function useDeepLinkThreadSend({
   assistantId,
-  isAssistantActive,
   activeConversationId,
   conversationExistsOnServer,
   activeConversationArchived,
@@ -107,8 +105,7 @@ export function useDeepLinkThreadSend({
     }),
     enabled: false,
   });
-  const targetConfirmedAbsent =
-    isAssistantActive && rowError instanceof ConversationNotFoundError;
+  const targetConfirmedAbsent = rowError instanceof ConversationNotFoundError;
 
   useEffect(() => {
     if (pending === null || activeConversationId === null) {

--- a/clients/web/src/domains/chat/hooks/use-deep-link-thread-send.ts
+++ b/clients/web/src/domains/chat/hooks/use-deep-link-thread-send.ts
@@ -1,10 +1,12 @@
 import { useEffect } from "react";
 import * as Sentry from "@sentry/react";
+import { useQuery } from "@tanstack/react-query";
 
 import { requestComposerFocus } from "@/domains/chat/composer-focus";
 import { useComposerStore } from "@/domains/chat/composer-store";
-import { useConversationListQuery } from "@/hooks/conversation-queries";
+import { conversationsByIdGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
 import { usePendingDeepLinkStore } from "@/stores/pending-deep-link-store";
+import { ConversationNotFoundError } from "@/utils/fetch-conversation-detail";
 
 /**
  * How long a parked send-into-thread request may wait for its target to
@@ -25,6 +27,13 @@ export interface UseDeepLinkThreadSendOptions {
    * `conversationExistsOnServer`.
    */
   conversationExistsOnServer: boolean;
+  /**
+   * The confirmed row is archived. The picker only offers live
+   * conversations, so a target archived after it synced is not what the
+   * user chose to send into; the daemon does not revive an archived thread
+   * on send, so the message would land in a thread the user put away.
+   */
+  activeConversationArchived: boolean;
   sendMessage: (content: string) => Promise<void>;
 }
 
@@ -43,13 +52,17 @@ export interface UseDeepLinkThreadSendOptions {
  *   `conversationExistsOnServer` is true;
  * - **degrades to a pre-fill in the target's composer** (the unproven-link
  *   contract: text staged, focus requested, nothing sent) when, on the
- *   target thread, the foreground list has loaded and does not contain it,
- *   or the park has aged past {@link PENDING_THREAD_SEND_TTL_MS}. The
- *   picker only ever offers foreground conversations, so absence from a
- *   loaded foreground list is definitive for anything an intent can name.
- *   (A target archived *after* the picker synced is absent too and also
- *   demotes, deliberately: reviving an archived chat is worth a look before
- *   the send, and the conservative direction is the safe one.)
+ *   target thread, the server has answered that the conversation does not
+ *   exist, or the park has aged past {@link PENDING_THREAD_SEND_TTL_MS}.
+ *   "Does not exist" is the single-row fetch's 404: `useActiveConversation`
+ *   asks for any row no list cache holds, and a miss leaves that query
+ *   errored with `ConversationNotFoundError`, which this hook reads. That is
+ *   definitive in a way no list scan is: a list is a window, and a row
+ *   absent from it may simply be past the loaded page. A target archived
+ *   *after* the picker synced is found but demotes too, deliberately: the
+ *   daemon does not revive an archived thread on send, so reviving it is
+ *   worth a look before the message lands, and the conservative direction
+ *   is the safe one.
  * - **degrades to the target's persisted draft** when the user has moved to
  *   a different thread while the request was still resolving. The active id
  *   is set synchronously in the same bus callback that parks the request,
@@ -59,8 +72,8 @@ export interface UseDeepLinkThreadSendOptions {
  *   surfaces in that composer whenever they open it, and never into the
  *   composer they happen to be in, which would stage it one tap from the
  *   wrong conversation.
- * - **waits** otherwise (list still loading, single-row fetch in flight).
- *   The effect re-runs as those settle.
+ * - **waits** otherwise (the single-row fetch is still in flight, or has not
+ *   started). The effect re-runs as it settles.
  *
  * Between them the three demotions guarantee the text is never dropped:
  * every exit from the parked state either sends it or leaves it in the
@@ -76,16 +89,26 @@ export function useDeepLinkThreadSend({
   isAssistantActive,
   activeConversationId,
   conversationExistsOnServer,
+  activeConversationArchived,
   sendMessage,
 }: UseDeepLinkThreadSendOptions): void {
   const pending = usePendingDeepLinkStore.use.pendingThreadSend();
-  // Observing the foreground list is what lets "not there" be a decision
-  // rather than a guess; TanStack dedupes this with ChatLayout's subscription.
-  const {
-    conversations,
-    isPending: listPending,
-    isError: listErrored,
-  } = useConversationListQuery(assistantId, isAssistantActive);
+  // Read-only view of the target's single-row fetch (`fetchConversationDetail`
+  // runs it through this same key). Disabled, so this never fetches; it only
+  // reflects the outcome the active-conversation path already produced. An
+  // errored query holding ConversationNotFoundError is the server saying the
+  // target does not exist, which is what lets "not there" be a decision.
+  const { error: rowError } = useQuery({
+    ...conversationsByIdGetOptions({
+      path: {
+        assistant_id: assistantId ?? "",
+        id: pending?.threadId ?? "",
+      },
+    }),
+    enabled: false,
+  });
+  const targetConfirmedAbsent =
+    isAssistantActive && rowError instanceof ConversationNotFoundError;
 
   useEffect(() => {
     if (pending === null || activeConversationId === null) {
@@ -125,27 +148,26 @@ export function useDeepLinkThreadSend({
       return;
     }
     if (conversationExistsOnServer) {
+      if (activeConversationArchived) {
+        demote("target conversation is archived");
+        return;
+      }
       const parked = store.consumePendingThreadSend();
       if (parked !== null) {
         void sendMessage(parked.message);
       }
       return;
     }
-    const listLoaded = !listPending && !listErrored;
-    if (
-      listLoaded &&
-      !conversations.some((c) => c.conversationId === pending.threadId)
-    ) {
-      demote("target absent from the loaded conversation list");
+    if (targetConfirmedAbsent) {
+      demote("server reports the target conversation does not exist");
     }
     // Otherwise the target is still resolving; wait for the next change.
   }, [
     pending,
     activeConversationId,
     conversationExistsOnServer,
-    conversations,
-    listPending,
-    listErrored,
+    activeConversationArchived,
+    targetConfirmedAbsent,
     sendMessage,
   ]);
 }

--- a/clients/web/src/hooks/conversation-queries.ts
+++ b/clients/web/src/hooks/conversation-queries.ts
@@ -402,6 +402,18 @@ export function useArchivedConversationListQuery(
  * Reads only. It never fetches; a consumer that needs the row present when
  * no cache holds it (a deep-linked open) fetches it into its home cache
  * first (`refreshConversationRow`) and this subscription picks it up.
+ *
+ * Transitional. TanStack has no hook for "the row with id X in whichever
+ * list holds it"; its idiom is a detail query per entity that the writers
+ * keep in sync with the lists (`fetchConversationDetail` already runs the
+ * single-row fetch through `conversationsByIdGetOptions`). Today the
+ * placement and seen-state writers write only into the list caches, so a
+ * detail query would go stale on every optimistic write; once they also
+ * write the row into its detail key, `useActiveConversation` becomes a
+ * plain `useQuery` on that key and this subscription is deleted. Until
+ * then this is the one correct way to follow a row across an open set of
+ * caches, and it is cheaper than the four-list scan it replaced. Do not
+ * add new consumers; reach for the detail query when it lands.
  */
 export function useConversationRow(
   assistantId: string | null,

--- a/clients/web/src/hooks/conversation-queries.ts
+++ b/clients/web/src/hooks/conversation-queries.ts
@@ -403,17 +403,18 @@ export function useArchivedConversationListQuery(
  * no cache holds it (a deep-linked open) fetches it into its home cache
  * first (`refreshConversationRow`) and this subscription picks it up.
  *
- * Transitional. TanStack has no hook for "the row with id X in whichever
- * list holds it"; its idiom is a detail query per entity that the writers
- * keep in sync with the lists (`fetchConversationDetail` already runs the
- * single-row fetch through `conversationsByIdGetOptions`). Today the
- * placement and seen-state writers write only into the list caches, so a
- * detail query would go stale on every optimistic write; once they also
- * write the row into its detail key, `useActiveConversation` becomes a
- * plain `useQuery` on that key and this subscription is deleted. Until
- * then this is the one correct way to follow a row across an open set of
- * caches, and it is cheaper than the four-list scan it replaced. Do not
- * add new consumers; reach for the detail query when it lands.
+ * Why a cache subscription and not a query hook. TanStack has no hook for
+ * "the list row with id X in whichever list holds it", and the two hooks
+ * that look close both fail here: `useQueries` needs the caches enumerated
+ * at render time, and the section caches are an open set created as
+ * sections mount; a per-row `useQuery` would make the row live in two
+ * places, its own query and a list, and every optimistic write (placement,
+ * seen-state) updates the list and not the copy. The detail query
+ * (`conversationsByIdGetOptions`) is a different resource, the full record
+ * with fields no list row carries, read as such by its own consumers; it is
+ * not this row's home. So the row stays in its list cache, one owner, and
+ * this follows it. The same primitive serves the same need in
+ * `use-pro-provisioning.ts`.
  */
 export function useConversationRow(
   assistantId: string | null,

--- a/clients/web/src/hooks/conversation-queries.ts
+++ b/clients/web/src/hooks/conversation-queries.ts
@@ -20,8 +20,12 @@
  * - https://tanstack.com/query/latest/docs/framework/react/guides/updates-from-mutation-responses
  */
 
-import { useMemo } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useCallback, useMemo, useSyncExternalStore } from "react";
+import {
+  partialMatchKey,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 
 import { groupsGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
 import type { Options } from "@/generated/daemon/sdk.gen";
@@ -32,8 +36,10 @@ import type {
   Conversation,
   ConversationGroup,
 } from "@/types/conversation-types";
+import { findConversation } from "@/utils/conversation-cache";
 import { countUnreadConversationsInList } from "@/utils/conversation-predicates";
 import {
+  conversationListPrefix,
   archivedConversationListOptions,
   backgroundConversationListOptions,
   conversationListOptions,
@@ -372,6 +378,58 @@ export function useArchivedConversationListQuery(
       void query.refetch();
     },
   };
+}
+
+/**
+ * Subscribe to one conversation's row, wherever it lives among the list
+ * caches, by id.
+ *
+ * A row has exactly one home under the `conversation-list` prefix
+ * (foreground, background, scheduled, archived, or a section window), and
+ * which home moves as the row is pinned, filed, archived, or surfaced. A
+ * consumer that wants the row therefore cannot subscribe to a fixed list;
+ * it has to follow the row. This is the subscribing twin of
+ * `findConversation`: the same prefix-wide lookup, re-read whenever any
+ * cache under the prefix changes.
+ *
+ * Every optimistic write and every fetch lands through `setQueryData` or a
+ * query resolving, both of which notify the query cache, so a global cache
+ * subscription filtered to the prefix sees exactly the changes that could
+ * move or alter the row and nothing else. `useSyncExternalStore` then reads
+ * the row by identity: an event that touched a different row leaves the
+ * same object reference in place and causes no re-render.
+ *
+ * Reads only. It never fetches; a consumer that needs the row present when
+ * no cache holds it (a deep-linked open) fetches it into its home cache
+ * first (`refreshConversationRow`) and this subscription picks it up.
+ */
+export function useConversationRow(
+  assistantId: string | null,
+  conversationId: string | null | undefined,
+): Conversation | undefined {
+  const queryClient = useQueryClient();
+  const subscribe = useCallback(
+    (onChange: () => void) => {
+      if (!assistantId) {
+        return () => {};
+      }
+      const prefix = conversationListPrefix(assistantId);
+      return queryClient.getQueryCache().subscribe((event) => {
+        if (partialMatchKey(event.query.queryKey, prefix)) {
+          onChange();
+        }
+      });
+    },
+    [queryClient, assistantId],
+  );
+  const getSnapshot = useCallback(
+    () =>
+      conversationId
+        ? findConversation(queryClient, assistantId, conversationId)
+        : undefined,
+    [queryClient, assistantId, conversationId],
+  );
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }
 
 /**

--- a/clients/web/src/hooks/use-conversation-row.test.tsx
+++ b/clients/web/src/hooks/use-conversation-row.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * `useConversationRow` follows one conversation by id across every list
+ * cache under the `conversation-list` prefix. Two properties are what it
+ * exists for, and both are pinned here at the render level: it sees the row
+ * wherever it lives (and keeps seeing it as it moves), and a write to some
+ * other row leaves the returned reference alone, so consumers of the active
+ * row are not re-rendered by unrelated sidebar traffic.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { createElement, type ReactNode } from "react";
+
+import { act, renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { useConversationRow } from "@/hooks/conversation-queries";
+import type { Conversation } from "@/types/conversation-types";
+import { patchConversation } from "@/utils/conversation-cache";
+import {
+  conversationsQueryKey,
+  sectionConversationsQueryKey,
+} from "@/utils/conversation-list-fetchers";
+import { listPage } from "@/utils/conversation-list.test-helper";
+
+const ASSISTANT_ID = "asst-1";
+
+function row(conversationId: string, title = conversationId): Conversation {
+  return { conversationId, title, createdAt: 1, lastMessageAt: 1 };
+}
+
+function setup() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return { queryClient, wrapper };
+}
+
+describe("useConversationRow", () => {
+  it("returns undefined when no cache holds the row, then the row once one does", () => {
+    const { queryClient, wrapper } = setup();
+    const { result } = renderHook(
+      () => useConversationRow(ASSISTANT_ID, "c1"),
+      { wrapper },
+    );
+    expect(result.current).toBeUndefined();
+
+    act(() => {
+      queryClient.setQueryData(
+        conversationsQueryKey(ASSISTANT_ID),
+        listPage([row("c1", "found")]),
+      );
+    });
+    expect(result.current?.title).toBe("found");
+  });
+
+  it("follows the row into a section cache, not only the foreground list", () => {
+    /* The row's home moves as it is pinned or filed. A subscription pinned
+       to the foreground list would lose it the moment it lived only in a
+       section window; this one is keyed by prefix, so it does not. */
+    const { queryClient, wrapper } = setup();
+    queryClient.setQueryData(
+      sectionConversationsQueryKey(ASSISTANT_ID, { groupId: "system:pinned" }),
+      listPage([row("c1", "pinned-row")], true),
+    );
+    const { result } = renderHook(
+      () => useConversationRow(ASSISTANT_ID, "c1"),
+      { wrapper },
+    );
+    expect(result.current?.title).toBe("pinned-row");
+  });
+
+  it("re-renders with the patched row when that row changes", () => {
+    const { queryClient, wrapper } = setup();
+    queryClient.setQueryData(
+      conversationsQueryKey(ASSISTANT_ID),
+      listPage([row("c1", "before")]),
+    );
+    const { result } = renderHook(
+      () => useConversationRow(ASSISTANT_ID, "c1"),
+      { wrapper },
+    );
+    expect(result.current?.title).toBe("before");
+
+    act(() => {
+      patchConversation(queryClient, ASSISTANT_ID, "c1", { title: "after" });
+    });
+    expect(result.current?.title).toBe("after");
+  });
+
+  it("keeps the same reference when a different row is written", () => {
+    /* The point of subscribing by id rather than to a whole list: a
+       placement or seen-state write elsewhere in the sidebar must not
+       re-render every consumer of the active row. patchConversation keeps
+       untouched rows' identity, and useSyncExternalStore compares by it. */
+    const { queryClient, wrapper } = setup();
+    queryClient.setQueryData(
+      conversationsQueryKey(ASSISTANT_ID),
+      listPage([row("c1"), row("c2")]),
+    );
+    const { result } = renderHook(
+      () => useConversationRow(ASSISTANT_ID, "c1"),
+      { wrapper },
+    );
+    const before = result.current;
+    expect(before).toBeDefined();
+
+    act(() => {
+      patchConversation(queryClient, ASSISTANT_ID, "c2", { title: "moved" });
+    });
+    expect(result.current).toBe(before);
+  });
+
+  it("returns undefined for a null id or assistant without subscribing", () => {
+    const { wrapper } = setup();
+    const { result: noId } = renderHook(
+      () => useConversationRow(ASSISTANT_ID, null),
+      { wrapper },
+    );
+    expect(noId.current).toBeUndefined();
+    const { result: noAssistant } = renderHook(
+      () => useConversationRow(null, "c1"),
+      { wrapper },
+    );
+    expect(noAssistant.current).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## TL;DR

Two consumers of the full foreground conversation list stop reading it. `useActiveConversation` (six callers) follows the active row by id across every list cache through a new `useConversationRow` subscription instead of scanning four whole lists; `useDeepLinkThreadSend` decides "the target does not exist" from the target's single-row fetch outcome instead of its absence from the loaded list. No signature changes for callers.

Fixes LUM-3306. Part of LUM-2409 (Phase 3: retire the client's complete list copy).

## What changes for the user

| Before | After |
| --- | --- |
| Opening a conversation that lives only in a section window (pinned/filed row deep past the foreground page) could leave the header, actions, and read-state without a row, since the four-list scan never looked in section caches | The active row is found wherever it lives |
| A deep-linked send into a thread absent from the *loaded* list demoted to a pre-fill, even when the thread existed past the loaded page | Demotes only when the daemon says the thread does not exist (404); waits on a transient failure; still demotes on an archived target |
| Six active-row consumers re-rendered on any write to any of four list caches | They re-render only when *their* row's reference changes |

## Design

**Why not a per-row `useQuery`.** The tempting "root fix" is to give the active row its own query. That would break the arc's one invariant, one owner per row: the row would exist in its own query *and* in a list cache, and every optimistic write (placement, seen-state) would update one and not the other. That is the double-sourcing `STATE_MANAGEMENT.md` forbids. So the row stays in its list cache and the hook subscribes to *whichever cache holds it*: a `QueryCache` subscription filtered to the `conversation-list` prefix (with TanStack's own `partialMatchKey`, argument order verified against `matchQuery`), read through `useSyncExternalStore` by identity. Structural sharing keeps an untouched row's reference across writes to its neighbours (verified in `replaceEqualDeep`), so unrelated traffic causes no re-render; that property has a test.

**Why the deep-link change is safe, and one behavior deliberately kept.** The single-row fetch already runs through `queryClient.fetchQuery` on the generated `conversationsByIdGetOptions` key, so a 404 leaves that query errored with `ConversationNotFoundError`. A disabled `useQuery` on the same key reads that state (verified in `QueryObserver.createResult`: `enabled` gates fetching, not what state is reported). One behavior I nearly regressed and then preserved on purpose: an *archived* target used to demote (absent from the foreground list); the row fetch finds it, so it would have sent. The daemon does not revive an archived thread on send (only the explicit unarchive route clears `archived_at`), so sending would land the message in a thread the user put away. It stays a demotion, now on an explicit `activeConversationArchived` input from the resolved row, with its own test.

**Fetch timing is unchanged.** `useActiveConversation` was one of several *active* subscribers to the foreground list; removing it does not change when that list loads (`ChatLayout` and `ChatRouteContent` drive it under the same gate). Verified by enumerating every enabled subscriber.

## Why it's safe

- Six callers keep the same signature and receive the same row object they did before; the difference is how it is found.
- The row's ownership does not change; the sync/placement seams need no edits.
- New behavior is pinned at the render level (`use-conversation-row.test.tsx`: found across caches, updates on its own patch, stable on a neighbour's) and the deep-link suite runs against a real `QueryClient` with the row query settled into the exact states the real fetch leaves, no stub of the hook's data source.
- Only two files under active PRs are touched (`active-chat-view.tsx` one line, `conversation-queries.ts` additive); `chat-layout.tsx` and `chat-route-content.tsx`, which are contested by four open PRs, are deliberately left for the next step.

## Deferred, and why

- **`chat-layout.tsx` next/prev navigation and `chat-route-content.tsx`**: contested by #40759, #40756, #40584, #39921, #39089; they follow once those land, and their replacement (section-owned neighbours) needs the section caches, not the row hook.
- **Bell and attention tracking**: need the daemon `needsAttention` filter (#40775, merged today) deployed; next PR, where the client gating decision gets made with handler evidence.
- **Command palette** onto daemon `searchConversations`: its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40785" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->