### PR TITLE
Android parity: self-hosted assistant pairing + switching

### DIFF
--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -112,15 +112,38 @@ vellum-assistant-dev://connect?url=https%3A%2F%2Fassistant.example.com&code=devi
 ```
 
 The production and staging builds use their matching auth schemes from the
-Build Variants table. Scanning a connect link switches the native shell to the
-validated server, opens `<server>/assistant/pair`, and keeps an existing server
-path prefix intact. Cold and warm app launches use the same route.
+Build Variants table. An optional `name=<label>` parameter supplies a
+user-facing label; the value is trimmed and a blank label is treated as
+absent. Scanning a connect link switches the native shell to the validated
+server, opens `<server>/assistant/pair`, and keeps an existing server path
+prefix intact. Cold and warm app launches use the same route.
 
-Only the validated server base is saved after the pairing page loads. The
-one-time device code is kept out of app preferences and the generated
-Capacitor configuration. HTTPS is required except for `localhost`, `127.0.0.1`,
-and the Android emulator host alias `10.0.2.2`. Use `adb reverse` when a physical
-development device needs to reach a service through `localhost`.
+Only the validated server base is saved after the pairing page loads; the
+same deferred write appends the server, with its label, to the remembered
+list. The one-time device code is kept out of app preferences and the
+generated Capacitor configuration. HTTPS is required except for `localhost`,
+`127.0.0.1`, and the Android emulator host alias `10.0.2.2`. Use `adb reverse`
+when a physical development device needs to reach a service through
+`localhost`.
+
+Paired servers accumulate in a remembered list, stored as JSON `{name?, url}`
+entries in the same `self_hosted_server` SharedPreferences file as the active
+server. Entries are keyed by the canonical URL the web chooser's
+`normalizeOriginUrl` also computes (scheme-default ports collapse, trailing
+slashes are stripped, and percent-escape casing and interior duplicate
+separators are preserved), so both sides agree on which strings mean the same
+HTTPS server. The cleartext development hosts are the exception: the web
+normalizer rejects every non-HTTPS URL, so an `http://localhost`-style server
+stays in the native list and remains switchable through a connect link, but
+never surfaces as a chooser card.
+
+The web assistant chooser is the management surface. The `SelfHostedServers`
+Capacitor plugin exposes the list to it and handles switch and forget
+(`list`/`add`/`remove`/`switchTo`/`switchToPath`). Switching recreates the
+activity so Capacitor starts on a configuration rebuilt around the new
+`server.url`; that configuration loads `<base>/assistant`, so a hosting path
+prefix survives the ingress redirect that would otherwise drop it. Forgetting
+the active server returns the shell to Vellum Cloud the same way.
 
 If Android terminates the app before the pairing page loads, scan the connect
 link again. The shell intentionally does not save the one-time code for process
@@ -215,6 +238,7 @@ clients/
     │       │   ├── NativeLaunchScreenPlugin.java
     │       │   ├── BiometricTokenStore.java
     │       │   ├── SelfHostedServer.java
+    │       │   ├── SelfHostedServersPlugin.java
     │       │   ├── VoiceAudioSessionPlugin.java
     │       │   ├── VoiceDeepLink.java
     │       │   ├── VoiceLiveActivityPlugin.java

--- a/clients/android/app/build.gradle
+++ b/clients/android/app/build.gradle
@@ -152,7 +152,9 @@ dependencies {
     implementation "com.google.firebase:firebase-messaging:$firebaseMessagingVersion"
     implementation project(':capacitor-android')
     testImplementation "junit:junit:$junitVersion"
-    testImplementation "org.json:json:20240303"
+    // AOSP-derived org.json for JVM tests (Apache-2.0), matching platform
+    // semantics the mockable android.jar stubs out.
+    testImplementation "com.vaadin.external.google:android-json:0.0.20131108.vaadin1"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
     implementation project(':capacitor-cordova-android-plugins')

--- a/clients/android/app/build.gradle
+++ b/clients/android/app/build.gradle
@@ -152,6 +152,7 @@ dependencies {
     implementation "com.google.firebase:firebase-messaging:$firebaseMessagingVersion"
     implementation project(':capacitor-android')
     testImplementation "junit:junit:$junitVersion"
+    testImplementation "org.json:json:20240303"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
     implementation project(':capacitor-cordova-android-plugins')

--- a/clients/android/app/src/main/java/ai/vellum/assistant/ConnectDeepLink.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/ConnectDeepLink.java
@@ -68,7 +68,7 @@ final class ConnectDeepLink {
         if (pairPage == null) {
             return null;
         }
-        return new ConnectDeepLink(server, pairPage, normalizeName(query.get("name")));
+        return new ConnectDeepLink(server, pairPage, SelfHostedServer.normalizedName(query.get("name")));
     }
 
     URI server() {
@@ -81,14 +81,6 @@ final class ConnectDeepLink {
 
     String name() {
         return name;
-    }
-
-    private static String normalizeName(String value) {
-        if (value == null) {
-            return null;
-        }
-        String trimmed = value.trim();
-        return trimmed.isEmpty() ? null : trimmed;
     }
 
     private static URI parseUri(String raw) {

--- a/clients/android/app/src/main/java/ai/vellum/assistant/ConnectDeepLink.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/ConnectDeepLink.java
@@ -14,10 +14,12 @@ final class ConnectDeepLink {
 
     private final URI server;
     private final URI pairPage;
+    private final String name;
 
-    private ConnectDeepLink(URI server, URI pairPage) {
+    private ConnectDeepLink(URI server, URI pairPage, String name) {
         this.server = server;
         this.pairPage = pairPage;
+        this.name = name;
     }
 
     static boolean handles(String raw, String expectedScheme) {
@@ -66,7 +68,7 @@ final class ConnectDeepLink {
         if (pairPage == null) {
             return null;
         }
-        return new ConnectDeepLink(server, pairPage);
+        return new ConnectDeepLink(server, pairPage, normalizeName(query.get("name")));
     }
 
     URI server() {
@@ -75,6 +77,18 @@ final class ConnectDeepLink {
 
     URI pairPage() {
         return pairPage;
+    }
+
+    String name() {
+        return name;
+    }
+
+    private static String normalizeName(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
     }
 
     private static URI parseUri(String raw) {

--- a/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
@@ -219,6 +219,8 @@ public class MainActivity extends BridgeActivity {
 
         if (effectiveServer == null || !effectiveServer.equals(connect.server())) {
             setRecreationConnect(connect);
+            // A stale switch route must not load over the pair page.
+            setRecreationRoutePath(null);
             setIntent(withoutData(intent));
             recreate();
             return;
@@ -334,8 +336,7 @@ public class MainActivity extends BridgeActivity {
         ) {
             return;
         }
-        SelfHostedServer.store(this, pendingConnect.server());
-        SelfHostedServer.append(this, pendingConnect.server(), pendingConnect.name());
+        SelfHostedServer.activate(this, pendingConnect.server(), pendingConnect.name());
         pendingConnect = null;
     }
 
@@ -373,19 +374,15 @@ public class MainActivity extends BridgeActivity {
     private void useVellumCloud() {
         SelfHostedServer.clear(this);
         effectiveServer = null;
-        recreateForServerChange();
-    }
-
-    /**
-     * Recreate onto whatever server slot {@link SelfHostedServer} now holds.
-     * The caller has already written the slot; onCreate re-reads everything,
-     * so no field needs resetting beyond the pending launch state.
-     */
-    void recreateForServerChange() {
         recreateForServerChange(null);
     }
 
-    /** Same, plus an initial in-app route to load once the new origin is up. */
+    /**
+     * Recreate onto whatever server slot {@link SelfHostedServer} now holds,
+     * plus an optional initial in-app route to load once the new origin is up.
+     * The caller has already written the slot; onCreate re-reads everything,
+     * so no field needs resetting beyond the pending launch state.
+     */
     void recreateForServerChange(String routePath) {
         // A live voice session does not survive an origin swap.
         VoiceLiveActivityPlugin.clearStatus(this);
@@ -441,7 +438,8 @@ public class MainActivity extends BridgeActivity {
      */
     private void deliverPendingRoute() {
         String path = takeRecreationRoutePath();
-        if (path == null || bridge == null || bridge.getServerUrl() == null) {
+        // Pair-page navigation wins over a stashed route.
+        if (path == null || pendingConnect != null || bridge == null || bridge.getServerUrl() == null) {
             return;
         }
         String route = SelfHostedServer.appRoute(bridge.getServerUrl(), path);

--- a/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
@@ -32,6 +32,7 @@ public class MainActivity extends BridgeActivity {
     private static final long LAUNCH_SCREEN_LOAD_FALLBACK_MS = 2_000;
     private static final long LAUNCH_SCREEN_TIMEOUT_MS = 15_000;
     private static ConnectDeepLink recreationConnect;
+    private static String recreationRoutePath;
 
     private final Handler launchScreenHandler = new Handler(Looper.getMainLooper());
     private AlertDialog unreachableDialog;
@@ -104,6 +105,7 @@ public class MainActivity extends BridgeActivity {
         NativeFailureGuard.run("Unable to deliver the Android app link", this::deliverPendingAppLink);
         NativeFailureGuard.run("Unable to deliver the Android connect launch", this::deliverPendingConnect);
         NativeFailureGuard.run("Unable to deliver the Android new chat launch", this::deliverPendingNewChat);
+        NativeFailureGuard.run("Unable to deliver the Android route launch", this::deliverPendingRoute);
     }
 
     @Override
@@ -126,6 +128,7 @@ public class MainActivity extends BridgeActivity {
         registerPlugin(AndroidPushRegistrationPlugin.class);
         registerPlugin(VoiceAudioSessionPlugin.class);
         registerPlugin(VoiceLiveActivityPlugin.class);
+        registerPlugin(SelfHostedServersPlugin.class);
         registerPlugin(SafePushNotificationsPlugin.class);
         super.load();
     }
@@ -362,18 +365,34 @@ public class MainActivity extends BridgeActivity {
             return;
         }
         String destination = pendingConnect == null
-            ? effectiveServer.toASCIIString()
+            ? SelfHostedServer.appEntryUrl(effectiveServer).toASCIIString()
             : pendingConnect.pairPage().toASCIIString();
         bridge.getWebView().loadUrl(destination);
     }
 
     private void useVellumCloud() {
-        VoiceLiveActivityPlugin.clearStatus(this);
         SelfHostedServer.clear(this);
+        effectiveServer = null;
+        recreateForServerChange();
+    }
+
+    /**
+     * Recreate onto whatever server slot {@link SelfHostedServer} now holds.
+     * The caller has already written the slot; onCreate re-reads everything,
+     * so no field needs resetting beyond the pending launch state.
+     */
+    void recreateForServerChange() {
+        recreateForServerChange(null);
+    }
+
+    /** Same, plus an initial in-app route to load once the new origin is up. */
+    void recreateForServerChange(String routePath) {
+        // A live voice session does not survive an origin swap.
+        VoiceLiveActivityPlugin.clearStatus(this);
         pendingConnect = null;
         pendingNewChat = false;
         setRecreationConnect(null);
-        effectiveServer = null;
+        setRecreationRoutePath(routePath);
         setIntent(withoutData(getIntent()));
         recreate();
     }
@@ -413,6 +432,32 @@ public class MainActivity extends BridgeActivity {
         }
         pendingNewChat = false;
         bridge.getWebView().loadUrl(bridge.getServerUrl());
+    }
+
+    /**
+     * Load a route stashed by {@link #recreateForServerChange(String)}.
+     * bridge.getServerUrl() is already the app entry URL (override or baked);
+     * an unusable route silently falls back to the default entry load.
+     */
+    private void deliverPendingRoute() {
+        String path = takeRecreationRoutePath();
+        if (path == null || bridge == null || bridge.getServerUrl() == null) {
+            return;
+        }
+        String route = SelfHostedServer.appRoute(bridge.getServerUrl(), path);
+        if (route != null) {
+            bridge.getWebView().loadUrl(route);
+        }
+    }
+
+    private static synchronized String takeRecreationRoutePath() {
+        String path = recreationRoutePath;
+        recreationRoutePath = null;
+        return path;
+    }
+
+    private static synchronized void setRecreationRoutePath(String path) {
+        recreationRoutePath = path;
     }
 
     private static synchronized ConnectDeepLink takeRecreationConnect() {

--- a/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
@@ -384,6 +384,12 @@ public class MainActivity extends BridgeActivity {
      * so no field needs resetting beyond the pending launch state.
      */
     void recreateForServerChange(String routePath) {
+        // A connect deep link may have planted a recreation while this call's
+        // runnable sat queued (recreate() flips neither isFinishing nor
+        // isDestroyed); the pairing navigation wins, so never discard it.
+        if (hasRecreationConnect()) {
+            return;
+        }
         // A live voice session does not survive an origin swap.
         VoiceLiveActivityPlugin.clearStatus(this);
         pendingConnect = null;
@@ -466,6 +472,10 @@ public class MainActivity extends BridgeActivity {
 
     private static synchronized void setRecreationConnect(ConnectDeepLink connect) {
         recreationConnect = connect;
+    }
+
+    private static synchronized boolean hasRecreationConnect() {
+        return recreationConnect != null;
     }
 
     private static final class SelfHostedWebViewClient extends BridgeWebViewClient {

--- a/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
@@ -332,6 +332,7 @@ public class MainActivity extends BridgeActivity {
             return;
         }
         SelfHostedServer.store(this, pendingConnect.server());
+        SelfHostedServer.append(this, pendingConnect.server(), pendingConnect.name());
         pendingConnect = null;
     }
 

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
@@ -12,7 +12,11 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -21,6 +25,7 @@ final class SelfHostedServer {
     private static final String CONFIG_FILE = "capacitor.config.json";
     private static final String PREFERENCES_NAME = "self_hosted_server";
     private static final String SERVER_URL_KEY = "server_url";
+    private static final String SERVERS_KEY = "servers";
 
     interface Store {
         String read();
@@ -28,6 +33,31 @@ final class SelfHostedServer {
         boolean write(String value);
 
         void clear();
+
+        String readServers();
+
+        void writeServers(String json);
+    }
+
+    /** A remembered self-hosted server: a canonical url plus an optional user-facing label. */
+    static final class Entry {
+        final String name;
+        final String url;
+
+        Entry(String name, String url) {
+            this.name = name;
+            this.url = url;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof Entry entry && Objects.equals(name, entry.name) && Objects.equals(url, entry.url);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name, url);
+        }
     }
 
     private SelfHostedServer() {}
@@ -58,6 +88,182 @@ final class SelfHostedServer {
 
     static void clear(Store store) {
         store.clear();
+    }
+
+    /**
+     * Canonical identity of a validated server URL, shared with the web chooser's
+     * remembered-origins store (normalizeOriginUrl) and iOS: the scheme-default
+     * port is collapsed, everything else is already normalized by validate.
+     */
+    static URI canonicalize(URI validated) {
+        int port = validated.getPort();
+        String scheme = validated.getScheme();
+        boolean schemeDefaultPort = ("https".equals(scheme) && port == 443) || ("http".equals(scheme) && port == 80);
+        if (!schemeDefaultPort) {
+            return validated;
+        }
+        try {
+            return new URI(scheme + "://" + validated.getHost() + normalizePath(validated.getRawPath()));
+        } catch (URISyntaxException exception) {
+            return validated;
+        }
+    }
+
+    /** canonicalize as the string used for list entries and equality. */
+    static String canonicalString(URI validated) {
+        return canonicalize(validated).toASCIIString();
+    }
+
+    static List<Entry> servers(Context context) {
+        return servers(new PreferencesStore(context));
+    }
+
+    /**
+     * The remembered server list, entries keyed by canonical URL. Entries failing
+     * validate are dropped, stored urls re-canonicalize on read (deduping any
+     * pre-canonical duplicates, first entry wins), and a legacy active URL absent
+     * from the stored list is included (name null) without writing back until the
+     * next mutation.
+     */
+    static List<Entry> servers(Store store) {
+        List<Entry> entries = new ArrayList<>();
+        String raw = store.readServers();
+        if (raw != null) {
+            try {
+                JSONArray stored = new JSONArray(raw);
+                for (int index = 0; index < stored.length(); index++) {
+                    JSONObject item = stored.optJSONObject(index);
+                    URI url = item == null ? null : validate(item.optString("url", null));
+                    if (url == null) {
+                        continue;
+                    }
+                    String canonical = canonicalString(url);
+                    if (indexOfUrl(entries, canonical) < 0) {
+                        entries.add(new Entry(normalizedName(item.optString("name", null)), canonical));
+                    }
+                }
+            } catch (JSONException exception) {
+                // A corrupt list reads as empty; the active slot below still surfaces.
+            }
+        }
+        URI active = configured(store);
+        if (active != null) {
+            String canonical = canonicalString(active);
+            if (indexOfUrl(entries, canonical) < 0) {
+                entries.add(new Entry(null, canonical));
+            }
+        }
+        return entries;
+    }
+
+    static void append(Context context, URI url, String name) {
+        append(new PreferencesStore(context), url, name);
+    }
+
+    /**
+     * Remember an origin, deduped by canonical URL. A re-append with a name
+     * updates the label; a nameless re-append keeps the existing one.
+     */
+    static void append(Store store, URI url, String name) {
+        List<Entry> entries = servers(store);
+        String canonical = canonicalString(url);
+        String label = normalizedName(name);
+        int index = indexOfUrl(entries, canonical);
+        if (index < 0) {
+            entries.add(new Entry(label, canonical));
+        } else if (label != null) {
+            entries.set(index, new Entry(label, canonical));
+        }
+        persist(store, entries);
+    }
+
+    static boolean removeEntry(Context context, URI url) {
+        return removeEntry(new PreferencesStore(context), url);
+    }
+
+    /**
+     * Forget an origin, matched by canonical URL. When it is also the active
+     * slot, the slot is cleared too; returns whether that happened.
+     */
+    static boolean removeEntry(Store store, URI url) {
+        List<Entry> entries = servers(store);
+        String canonical = canonicalString(url);
+        int index = indexOfUrl(entries, canonical);
+        if (index >= 0) {
+            entries.remove(index);
+        }
+        persist(store, entries);
+        if (isActive(store, url)) {
+            clear(store);
+            return true;
+        }
+        return false;
+    }
+
+    static boolean isActive(Context context, URI url) {
+        return isActive(new PreferencesStore(context), url);
+    }
+
+    /** Whether a URL canonically matches the active slot. */
+    static boolean isActive(Store store, URI url) {
+        URI active = configured(store);
+        return active != null && url != null && canonicalString(active).equals(canonicalString(url));
+    }
+
+    /** The baked server.url from the bundled Capacitor config, or null when unreadable. */
+    static String bakedServerUrl(Context context) {
+        try {
+            return parseBakedServerUrl(readAsset(context, CONFIG_FILE));
+        } catch (Exception exception) {
+            return null;
+        }
+    }
+
+    static String parseBakedServerUrl(String configJson) {
+        if (configJson == null) {
+            return null;
+        }
+        try {
+            JSONObject server = new JSONObject(configJson).optJSONObject("server");
+            String url = server == null ? null : server.optString("url", null);
+            return url == null || url.trim().isEmpty() ? null : url;
+        } catch (JSONException exception) {
+            return null;
+        }
+    }
+
+    private static int indexOfUrl(List<Entry> entries, String canonicalUrl) {
+        for (int index = 0; index < entries.size(); index++) {
+            if (entries.get(index).url.equals(canonicalUrl)) {
+                return index;
+            }
+        }
+        return -1;
+    }
+
+    private static void persist(Store store, List<Entry> entries) {
+        JSONArray array = new JSONArray();
+        try {
+            for (Entry entry : entries) {
+                JSONObject item = new JSONObject();
+                if (entry.name != null) {
+                    item.put("name", entry.name);
+                }
+                item.put("url", entry.url);
+                array.put(item);
+            }
+        } catch (JSONException exception) {
+            return;
+        }
+        store.writeServers(array.toString());
+    }
+
+    private static String normalizedName(String name) {
+        if (name == null) {
+            return null;
+        }
+        String trimmed = name.trim();
+        return trimmed.isEmpty() ? null : trimmed;
     }
 
     static URI validate(String raw) {
@@ -91,11 +297,11 @@ final class SelfHostedServer {
         if (containsEncodedDotSegment(parsed.getRawPath())) {
             return null;
         }
-        URI normalized = parsed.normalize();
-        if (containsDotSegment(normalized.getRawPath())) {
+        String resolved = resolveDotSegments(parsed.getRawPath());
+        if (resolved == null) {
             return null;
         }
-        String path = normalizePath(normalized.getRawPath());
+        String path = normalizePath(resolved);
         try {
             return new URI(scheme + "://" + formatAuthority(host, parsed.getPort()) + path);
         } catch (URISyntaxException exception) {
@@ -118,8 +324,8 @@ final class SelfHostedServer {
             return false;
         }
 
-        String basePath = normalizePath(server.getRawPath());
-        String candidatePath = normalizePath(candidate.getRawPath());
+        String basePath = foldEscapeCase(normalizePath(server.getRawPath()));
+        String candidatePath = foldEscapeCase(normalizePath(candidate.getRawPath()));
         if (basePath.isEmpty()) {
             return true;
         }
@@ -134,7 +340,8 @@ final class SelfHostedServer {
             && expected.getScheme().equalsIgnoreCase(actual.getScheme())
             && expected.getHost().equalsIgnoreCase(actual.getHost())
             && effectivePort(expected) == effectivePort(actual)
-            && normalizePath(expected.getRawPath()).equals(normalizePath(actual.getRawPath()));
+            && foldEscapeCase(normalizePath(expected.getRawPath()))
+                .equals(foldEscapeCase(normalizePath(actual.getRawPath())));
     }
 
     static CapConfig overrideCapacitorConfig(Context context, URI server) throws IOException, JSONException {
@@ -188,20 +395,31 @@ final class SelfHostedServer {
         if (rawPath == null || rawPath.isEmpty() || "/".equals(rawPath)) {
             return "";
         }
+        // Percent-escape casing is preserved, matching the iOS canonicalizer
+        // and the web normalizeOriginUrl.
         String normalized = rawPath;
-        while (normalized.endsWith("/") && normalized.length() > 1) {
+        while (normalized.endsWith("/")) {
             normalized = normalized.substring(0, normalized.length() - 1);
         }
-        StringBuilder canonical = new StringBuilder(normalized.length());
-        for (int index = 0; index < normalized.length(); index++) {
-            char item = normalized.charAt(index);
-            canonical.append(item);
-            if (item == '%' && index + 2 < normalized.length()) {
-                canonical.append(Character.toUpperCase(normalized.charAt(++index)));
-                canonical.append(Character.toUpperCase(normalized.charAt(++index)));
+        return normalized;
+    }
+
+    /**
+     * Uppercase percent-escape hex for comparison only: escape hex digits are
+     * case-insensitive per RFC 3986, so navigation checks must match `%2f`
+     * against `%2F`, while canonical list identity keeps the original casing.
+     */
+    private static String foldEscapeCase(String path) {
+        StringBuilder folded = new StringBuilder(path.length());
+        for (int index = 0; index < path.length(); index++) {
+            char item = path.charAt(index);
+            folded.append(item);
+            if (item == '%' && index + 2 < path.length()) {
+                folded.append(Character.toUpperCase(path.charAt(++index)));
+                folded.append(Character.toUpperCase(path.charAt(++index)));
             }
         }
-        return canonical.toString();
+        return folded.toString();
     }
 
     private static boolean containsEncodedDotSegment(String rawPath) {
@@ -232,16 +450,37 @@ final class SelfHostedServer {
         return false;
     }
 
-    private static boolean containsDotSegment(String rawPath) {
-        if (rawPath == null) {
-            return false;
+    /**
+     * RFC 3986 §5.2.4 dot-segment removal that preserves empty segments, which
+     * {@code URI.normalize()} collapses; iOS and the web canonicalizer keep
+     * interior duplicate separators as distinct route characters. Returns null
+     * when a {@code ..} would climb above the root.
+     */
+    private static String resolveDotSegments(String rawPath) {
+        if (rawPath == null || rawPath.isEmpty()) {
+            return "";
         }
-        for (String segment : rawPath.split("/", -1)) {
-            if (".".equals(segment) || "..".equals(segment)) {
-                return true;
+        String[] parts = rawPath.split("/", -1);
+        List<String> segments = new ArrayList<>();
+        for (int index = 1; index < parts.length; index++) {
+            String segment = parts[index];
+            if (".".equals(segment)) {
+                continue;
+            }
+            if ("..".equals(segment)) {
+                if (segments.isEmpty()) {
+                    return null;
+                }
+                segments.remove(segments.size() - 1);
+            } else {
+                segments.add(segment);
             }
         }
-        return false;
+        StringBuilder resolved = new StringBuilder();
+        for (String segment : segments) {
+            resolved.append('/').append(segment);
+        }
+        return resolved.toString();
     }
 
     private static String formatAuthority(String host, int port) {
@@ -284,6 +523,16 @@ final class SelfHostedServer {
         @Override
         public void clear() {
             preferences.edit().remove(SERVER_URL_KEY).commit();
+        }
+
+        @Override
+        public String readServers() {
+            return preferences.getString(SERVERS_KEY, null);
+        }
+
+        @Override
+        public void writeServers(String json) {
+            preferences.edit().putString(SERVERS_KEY, json).commit();
         }
     }
 }

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
@@ -210,6 +210,48 @@ final class SelfHostedServer {
         return active != null && url != null && canonicalString(active).equals(canonicalString(url));
     }
 
+    /**
+     * The SPA entry point for a server base, {@code <base>/assistant}. The
+     * ingress redirects a bare base to a prefixless {@code /assistant/},
+     * dropping a hosting prefix, so the segment is appended here instead,
+     * mirroring iOS {@code appEntryURL}. Stored identity keeps the bare base.
+     */
+    static URI appEntryUrl(URI base) {
+        String path = base.getRawPath();
+        if (path != null && path.endsWith("/assistant")) {
+            return base;
+        }
+        try {
+            return new URI(base.toASCIIString() + "/assistant");
+        } catch (URISyntaxException exception) {
+            return base;
+        }
+    }
+
+    /**
+     * A route under an entry URL: {@code <entry>/<path>}, the path's query
+     * kept verbatim. Null (caller falls back to the entry) when the path is
+     * unusable: blank, absolute, scheme-ful, fragment-carrying, or climbing.
+     */
+    static String appRoute(String entryUrl, String path) {
+        String trimmed = path == null ? "" : path.trim();
+        if (trimmed.isEmpty() || trimmed.startsWith("/") || trimmed.contains("://") || trimmed.contains("#")) {
+            return null;
+        }
+        int query = trimmed.indexOf('?');
+        String pathPart = query < 0 ? trimmed : trimmed.substring(0, query);
+        for (String segment : pathPart.split("/", -1)) {
+            if ("..".equals(segment)) {
+                return null;
+            }
+        }
+        String base = entryUrl;
+        while (base.endsWith("/")) {
+            base = base.substring(0, base.length() - 1);
+        }
+        return base + "/" + trimmed;
+    }
+
     /** The baked server.url from the bundled Capacitor config, or null when unreadable. */
     static String bakedServerUrl(Context context) {
         try {
@@ -348,7 +390,7 @@ final class SelfHostedServer {
         String source = readAsset(context, CONFIG_FILE);
         JSONObject root = new JSONObject(source);
         JSONObject serverConfig = root.getJSONObject("server");
-        serverConfig.put("url", server.toASCIIString());
+        serverConfig.put("url", appEntryUrl(server).toASCIIString());
 
         File directory = new File(context.getCacheDir(), CONFIG_DIRECTORY);
         if (!directory.exists() && !directory.mkdirs()) {

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
@@ -268,6 +268,11 @@ final class SelfHostedServer {
         }
         int query = trimmed.indexOf('?');
         String pathPart = query < 0 ? trimmed : trimmed.substring(0, query);
+        // Query-only input has an empty path component; iOS appRouteURL
+        // rejects it, so fall back to the entry URL here too.
+        if (pathPart.isEmpty()) {
+            return null;
+        }
         String[] segments = pathPart.split("/", -1);
         // A colon in the first segment reads as a scheme (mailto:x,
         // host:8080/x), matching the iOS URLComponents rejection.

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
@@ -138,6 +138,10 @@ final class SelfHostedServer {
                     }
                     String canonical = canonicalString(url);
                     if (indexOfUrl(entries, canonical) < 0) {
+                        // isNull guards platform org.json, whose optString
+                        // stringifies JSON null to "null"; the JVM test
+                        // artifact returns the default, so tests cannot
+                        // regression-protect this. Keep the guard.
                         String name = item.isNull("name") ? null : item.optString("name", null);
                         entries.add(new Entry(normalizedName(name), canonical));
                     }
@@ -274,6 +278,11 @@ final class SelfHostedServer {
             if ("..".equals(segment)) {
                 return null;
             }
+        }
+        // iOS splits the percent-decoded path, so %2e%2e reads as ".." there;
+        // reject the encoded spelling too or the route could climb the prefix.
+        if (containsEncodedDotSegment(pathPart)) {
+            return null;
         }
         String base = entryUrl;
         while (base.endsWith("/")) {

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
@@ -27,6 +27,9 @@ final class SelfHostedServer {
     private static final String SERVER_URL_KEY = "server_url";
     private static final String SERVERS_KEY = "servers";
 
+    /** Serializes every read-modify-write of the servers list. */
+    private static final Object listLock = new Object();
+
     interface Store {
         String read();
 
@@ -68,10 +71,6 @@ final class SelfHostedServer {
 
     static URI configured(Store store) {
         return validate(store.read());
-    }
-
-    static boolean store(Context context, URI server) {
-        return store(new PreferencesStore(context), server);
     }
 
     static boolean store(Store store, URI server) {
@@ -139,7 +138,8 @@ final class SelfHostedServer {
                     }
                     String canonical = canonicalString(url);
                     if (indexOfUrl(entries, canonical) < 0) {
-                        entries.add(new Entry(normalizedName(item.optString("name", null)), canonical));
+                        String name = item.isNull("name") ? null : item.optString("name", null);
+                        entries.add(new Entry(normalizedName(name), canonical));
                     }
                 }
             } catch (JSONException exception) {
@@ -165,16 +165,30 @@ final class SelfHostedServer {
      * updates the label; a nameless re-append keeps the existing one.
      */
     static void append(Store store, URI url, String name) {
-        List<Entry> entries = servers(store);
-        String canonical = canonicalString(url);
-        String label = normalizedName(name);
-        int index = indexOfUrl(entries, canonical);
-        if (index < 0) {
-            entries.add(new Entry(label, canonical));
-        } else if (label != null) {
-            entries.set(index, new Entry(label, canonical));
+        synchronized (listLock) {
+            List<Entry> entries = servers(store);
+            String canonical = canonicalString(url);
+            String label = normalizedName(name);
+            int index = indexOfUrl(entries, canonical);
+            if (index < 0) {
+                entries.add(new Entry(label, canonical));
+            } else if (label != null) {
+                entries.set(index, new Entry(label, canonical));
+            }
+            persist(store, entries);
         }
-        persist(store, entries);
+    }
+
+    static void activate(Context context, URI url, String name) {
+        activate(new PreferencesStore(context), url, name);
+    }
+
+    /** Write the active slot and remember the origin as one atomic mutation. */
+    static void activate(Store store, URI url, String name) {
+        synchronized (listLock) {
+            store(store, url);
+            append(store, url, name);
+        }
     }
 
     static boolean removeEntry(Context context, URI url) {
@@ -186,22 +200,20 @@ final class SelfHostedServer {
      * slot, the slot is cleared too; returns whether that happened.
      */
     static boolean removeEntry(Store store, URI url) {
-        List<Entry> entries = servers(store);
-        String canonical = canonicalString(url);
-        int index = indexOfUrl(entries, canonical);
-        if (index >= 0) {
-            entries.remove(index);
+        synchronized (listLock) {
+            List<Entry> entries = servers(store);
+            String canonical = canonicalString(url);
+            int index = indexOfUrl(entries, canonical);
+            if (index >= 0) {
+                entries.remove(index);
+            }
+            persist(store, entries);
+            if (isActive(store, url)) {
+                clear(store);
+                return true;
+            }
+            return false;
         }
-        persist(store, entries);
-        if (isActive(store, url)) {
-            clear(store);
-            return true;
-        }
-        return false;
-    }
-
-    static boolean isActive(Context context, URI url) {
-        return isActive(new PreferencesStore(context), url);
     }
 
     /** Whether a URL canonically matches the active slot. */
@@ -229,18 +241,36 @@ final class SelfHostedServer {
     }
 
     /**
+     * The shared shape guard for in-app route paths: non-blank, relative,
+     * scheme-less, fragment-free. Callers pass a trimmed path.
+     */
+    static boolean isRoutePathShape(String path) {
+        return path != null
+            && !path.isEmpty()
+            && !path.startsWith("/")
+            && !path.contains("://")
+            && !path.contains("#");
+    }
+
+    /**
      * A route under an entry URL: {@code <entry>/<path>}, the path's query
      * kept verbatim. Null (caller falls back to the entry) when the path is
      * unusable: blank, absolute, scheme-ful, fragment-carrying, or climbing.
      */
     static String appRoute(String entryUrl, String path) {
         String trimmed = path == null ? "" : path.trim();
-        if (trimmed.isEmpty() || trimmed.startsWith("/") || trimmed.contains("://") || trimmed.contains("#")) {
+        if (!isRoutePathShape(trimmed)) {
             return null;
         }
         int query = trimmed.indexOf('?');
         String pathPart = query < 0 ? trimmed : trimmed.substring(0, query);
-        for (String segment : pathPart.split("/", -1)) {
+        String[] segments = pathPart.split("/", -1);
+        // A colon in the first segment reads as a scheme (mailto:x,
+        // host:8080/x), matching the iOS URLComponents rejection.
+        if (segments[0].indexOf(':') >= 0) {
+            return null;
+        }
+        for (String segment : segments) {
             if ("..".equals(segment)) {
                 return null;
             }
@@ -300,7 +330,8 @@ final class SelfHostedServer {
         store.writeServers(array.toString());
     }
 
-    private static String normalizedName(String name) {
+    /** A user-facing label: trimmed, with blank collapsing to null. */
+    static String normalizedName(String name) {
         if (name == null) {
             return null;
         }
@@ -332,6 +363,11 @@ final class SelfHostedServer {
 
         String scheme = parsed.getScheme() == null ? "" : parsed.getScheme().toLowerCase(Locale.US);
         String host = parsed.getHost().toLowerCase(Locale.US);
+        // Unicode hosts canonicalize differently here (percent-encoding) than
+        // in the web chooser (punycode), so they are rejected outright.
+        if (!isAscii(host)) {
+            return null;
+        }
         if (!"https".equals(scheme) && !("http".equals(scheme) && isLocalDevelopmentHost(host))) {
             return null;
         }
@@ -528,6 +564,15 @@ final class SelfHostedServer {
     private static String formatAuthority(String host, int port) {
         String authorityHost = host.indexOf(':') >= 0 && !host.startsWith("[") ? "[" + host + "]" : host;
         return port >= 0 ? authorityHost + ":" + port : authorityHost;
+    }
+
+    private static boolean isAscii(String value) {
+        for (int index = 0; index < value.length(); index++) {
+            if (value.charAt(index) >= 0x80) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static boolean isLocalDevelopmentHost(String host) {

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
@@ -139,9 +139,9 @@ final class SelfHostedServer {
                     String canonical = canonicalString(url);
                     if (indexOfUrl(entries, canonical) < 0) {
                         // isNull guards platform org.json, whose optString
-                        // stringifies JSON null to "null"; the JVM test
-                        // artifact returns the default, so tests cannot
-                        // regression-protect this. Keep the guard.
+                        // stringifies JSON null to "null". The AOSP-derived
+                        // test artifact shares that behavior, so the unnamed
+                        // read is test-covered.
                         String name = item.isNull("name") ? null : item.optString("name", null);
                         entries.add(new Entry(normalizedName(name), canonical));
                     }

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServersPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServersPlugin.java
@@ -1,0 +1,150 @@
+package ai.vellum.assistant;
+
+import android.app.Activity;
+import com.getcapacitor.JSArray;
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+import java.net.URI;
+import java.util.List;
+
+/**
+ * Exposes the remembered self-hosted server list to the web chooser,
+ * mirroring iOS's {@code SelfHostedServersPlugin.swift}. Per the skew rule in
+ * {@code clients/web/docs/CAPACITOR.md}, one result shape encodes every
+ * state: empty state resolves with an empty list and nulls; only an
+ * {@code add}/{@code switchTo}/{@code switchToPath} url failing
+ * {@link SelfHostedServer#validate} (or a malformed switchToPath path)
+ * rejects.
+ */
+@CapacitorPlugin(name = "SelfHostedServers")
+public class SelfHostedServersPlugin extends Plugin {
+
+    @PluginMethod
+    public void list(PluginCall call) {
+        URI active = SelfHostedServer.configured(getContext());
+        call.resolve(
+            listPayload(
+                SelfHostedServer.servers(getContext()),
+                active == null ? null : active.toASCIIString(),
+                SelfHostedServer.bakedServerUrl(getContext())
+            )
+        );
+    }
+
+    static JSObject listPayload(List<SelfHostedServer.Entry> servers, String activeUrl, String bakedUrl) {
+        JSArray items = new JSArray();
+        for (SelfHostedServer.Entry entry : servers) {
+            JSObject item = new JSObject();
+            if (entry.name != null) {
+                item.put("name", entry.name);
+            }
+            item.put("url", entry.url);
+            items.put(item);
+        }
+        JSObject payload = new JSObject();
+        payload.put("servers", items);
+        payload.put("activeUrl", activeUrl == null ? JSObject.NULL : activeUrl);
+        payload.put("bakedUrl", bakedUrl == null ? JSObject.NULL : bakedUrl);
+        return payload;
+    }
+
+    @PluginMethod
+    public void add(PluginCall call) {
+        URI url = SelfHostedServer.validate(call.getString("url"));
+        if (url == null) {
+            call.reject("invalid url");
+            return;
+        }
+        SelfHostedServer.append(getContext(), url, call.getString("name"));
+        call.resolve(okResult());
+    }
+
+    /**
+     * Forgetting a url that is not (or cannot be) in the list is a no-op, so
+     * this never rejects. Removing the active server clears the active slot,
+     * so the shell recreates back to the baked origin like {@code switchTo({})}.
+     */
+    @PluginMethod
+    public void remove(PluginCall call) {
+        URI url = SelfHostedServer.validate(call.getString("url"));
+        boolean removedActive = url != null && SelfHostedServer.removeEntry(getContext(), url);
+        // Resolve before scheduling the recreate: recreation tears the bridge
+        // down, so a web caller awaiting this call would otherwise never settle.
+        call.resolve(okResult());
+        if (removedActive) {
+            scheduleRecreate(null);
+        }
+    }
+
+    /**
+     * Switching to a url implies remembering it, so the target is appended to
+     * the list alongside the active-slot write (nameless, keeping any stored
+     * label). An absent or empty url returns to the baked origin. Always
+     * recreates, even onto the same origin, matching iOS's unconditional
+     * reload.
+     */
+    @PluginMethod
+    public void switchTo(PluginCall call) {
+        if (!applySwitchUrl(call)) {
+            return;
+        }
+        // Same ordering constraint as remove: settle the call, then recreate.
+        call.resolve(okResult());
+        scheduleRecreate(null);
+    }
+
+    /**
+     * switchTo plus an initial in-app route under the destination's entry
+     * URL, mirroring iOS. An invalid path rejects before any state changes.
+     */
+    @PluginMethod
+    public void switchToPath(PluginCall call) {
+        String raw = call.getString("path");
+        String path = raw == null ? "" : raw.trim();
+        if (path.isEmpty() || path.startsWith("/") || path.contains("://") || path.contains("#")) {
+            call.reject("invalid path");
+            return;
+        }
+        if (!applySwitchUrl(call)) {
+            return;
+        }
+        call.resolve(okResult());
+        scheduleRecreate(path);
+    }
+
+    /**
+     * Shared switchTo/switchToPath url handling: absent or empty returns to
+     * the baked origin; a valid url is stored and remembered nameless,
+     * keeping any stored label; invalid rejects and returns false.
+     */
+    private boolean applySwitchUrl(PluginCall call) {
+        String raw = call.getString("url");
+        String trimmed = raw == null ? "" : raw.trim();
+        if (trimmed.isEmpty()) {
+            SelfHostedServer.clear(getContext());
+            return true;
+        }
+        URI url = SelfHostedServer.validate(trimmed);
+        if (url == null) {
+            call.reject("invalid url");
+            return false;
+        }
+        SelfHostedServer.store(getContext(), url);
+        SelfHostedServer.append(getContext(), url, null);
+        return true;
+    }
+
+    private void scheduleRecreate(String routePath) {
+        Activity activity = getActivity();
+        if (activity instanceof MainActivity mainActivity) {
+            activity.runOnUiThread(() -> mainActivity.recreateForServerChange(routePath));
+        }
+    }
+
+    private static JSObject okResult() {
+        return new JSObject().put("ok", true);
+    }
+}

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServersPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServersPlugin.java
@@ -104,7 +104,7 @@ public class SelfHostedServersPlugin extends Plugin {
     public void switchToPath(PluginCall call) {
         String raw = call.getString("path");
         String path = raw == null ? "" : raw.trim();
-        if (path.isEmpty() || path.startsWith("/") || path.contains("://") || path.contains("#")) {
+        if (!SelfHostedServer.isRoutePathShape(path)) {
             call.reject("invalid path");
             return;
         }
@@ -132,15 +132,20 @@ public class SelfHostedServersPlugin extends Plugin {
             call.reject("invalid url");
             return false;
         }
-        SelfHostedServer.store(getContext(), url);
-        SelfHostedServer.append(getContext(), url, null);
+        SelfHostedServer.activate(getContext(), url, null);
         return true;
     }
 
     private void scheduleRecreate(String routePath) {
         Activity activity = getActivity();
         if (activity instanceof MainActivity mainActivity) {
-            activity.runOnUiThread(() -> mainActivity.recreateForServerChange(routePath));
+            activity.runOnUiThread(() -> {
+                // A superseded activity must not consume or plant recreation state.
+                if (mainActivity.isFinishing() || mainActivity.isDestroyed()) {
+                    return;
+                }
+                mainActivity.recreateForServerChange(routePath);
+            });
         }
     }
 

--- a/clients/android/app/src/test/java/ai/vellum/assistant/ConnectDeepLinkTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/ConnectDeepLinkTest.java
@@ -53,6 +53,42 @@ public class ConnectDeepLinkTest {
     }
 
     @Test
+    public void decodesAndTrimsTheOptionalNameLabel() {
+        ConnectDeepLink connect = ConnectDeepLink.parse(
+            SCHEME + "://connect?url=https%3A%2F%2Fexample.com&code=device-code&name=Living+Room",
+            SCHEME
+        );
+
+        assertEquals("Living Room", connect.name());
+    }
+
+    @Test
+    public void preservesEscapedPlusSignsInNameLabels() {
+        ConnectDeepLink connect = ConnectDeepLink.parse(
+            SCHEME + "://connect?url=https%3A%2F%2Fexample.com&code=device-code&name=A%2BB",
+            SCHEME
+        );
+
+        assertEquals("A+B", connect.name());
+    }
+
+    @Test
+    public void collapsesMissingOrBlankNameLabelsToNull() {
+        ConnectDeepLink withoutName = ConnectDeepLink.parse(
+            SCHEME + "://connect?url=https%3A%2F%2Fexample.com&code=device-code",
+            SCHEME
+        );
+        ConnectDeepLink blankName = ConnectDeepLink.parse(
+            SCHEME + "://connect?url=https%3A%2F%2Fexample.com&code=device-code&name=",
+            SCHEME
+        );
+
+        assertNull(withoutName.name());
+        assertEquals("https://example.com", blankName.server().toASCIIString());
+        assertNull(blankName.name());
+    }
+
+    @Test
     public void ownsConnectLinksThatStrictUriParsingRejects() {
         String raw = SCHEME + "://connect?url=https%3A%2F%2Fexample.com&code=bare value%";
 

--- a/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.net.URI;
+import java.util.List;
 import org.junit.Test;
 
 public class SelfHostedServerTest {
@@ -18,9 +19,11 @@ public class SelfHostedServerTest {
 
     @Test
     public void preservesEscapedReservedCharacters() {
-        URI server = SelfHostedServer.validate("https://example.com/tenant%2fabc/");
+        URI lower = SelfHostedServer.validate("https://example.com/tenant%2fabc/");
+        URI upper = SelfHostedServer.validate("https://example.com/tenant%2Fabc/");
 
-        assertEquals("https://example.com/tenant%2Fabc", server.toASCIIString());
+        assertEquals("https://example.com/tenant%2fabc", lower.toASCIIString());
+        assertEquals("https://example.com/tenant%2Fabc", upper.toASCIIString());
     }
 
     @Test
@@ -85,7 +88,7 @@ public class SelfHostedServerTest {
     public void keepsEscapedSeparatorsDistinctWhenMatchingPrefixes() {
         URI server = SelfHostedServer.validate("https://example.com/tenant%2Fabc");
 
-        assertTrue(SelfHostedServer.contains(server, "https://example.com/tenant%2fabc/assistant/pair"));
+        assertTrue(SelfHostedServer.contains(server, "https://example.com/tenant%2Fabc/assistant/pair"));
         assertFalse(SelfHostedServer.contains(server, "https://example.com/tenant/abc/assistant/pair"));
     }
 
@@ -102,8 +105,148 @@ public class SelfHostedServerTest {
         assertFalse(SelfHostedServer.samePage(pairPage, "https://example.com/other/assistant/pair"));
     }
 
+    @Test
+    public void canonicalizationCollapsesSchemeDefaultPortsOnly() {
+        assertEquals(
+            "https://example.com/assistant-123",
+            SelfHostedServer.canonicalString(SelfHostedServer.validate("https://example.com:443/assistant-123/"))
+        );
+        assertEquals(
+            "https://example.com:8443/assistant-123",
+            SelfHostedServer.canonicalString(SelfHostedServer.validate("https://example.com:8443/assistant-123"))
+        );
+        assertEquals(
+            "http://localhost:8787",
+            SelfHostedServer.canonicalString(SelfHostedServer.validate("http://localhost:8787"))
+        );
+        assertEquals(
+            "http://localhost",
+            SelfHostedServer.canonicalString(SelfHostedServer.validate("http://localhost:80"))
+        );
+    }
+
+    @Test
+    public void preservesInteriorDuplicateSeparators() {
+        assertEquals(
+            "https://example.com/tenant//assistant",
+            SelfHostedServer.validate("https://example.com/tenant//assistant").toASCIIString()
+        );
+        assertEquals(
+            "https://example.com/tenant//assistant",
+            SelfHostedServer.canonicalString(SelfHostedServer.validate("https://example.com/tenant//assistant"))
+        );
+    }
+
+    @Test
+    public void navigationChecksMatchPercentEscapesCaseInsensitively() {
+        assertTrue(
+            SelfHostedServer.samePage(
+                "https://example.com/tenant%2fabc/assistant/pair",
+                "https://example.com/tenant%2Fabc/assistant/pair"
+            )
+        );
+        assertTrue(
+            SelfHostedServer.contains(
+                SelfHostedServer.validate("https://example.com/tenant%2fabc"),
+                "https://example.com/tenant%2Fabc/conversations"
+            )
+        );
+        assertFalse(
+            SelfHostedServer.contains(
+                SelfHostedServer.validate("https://example.com/tenant%2fabc"),
+                "https://example.com/tenant/abc/conversations"
+            )
+        );
+    }
+
+    @Test
+    public void stripsEveryTrailingSlashLikeIosAndWebCanonicalizers() {
+        assertEquals("https://example.com", SelfHostedServer.validate("https://example.com//").toASCIIString());
+        assertEquals(
+            "https://example.com",
+            SelfHostedServer.canonicalString(SelfHostedServer.validate("https://example.com:443///"))
+        );
+        assertEquals(
+            "https://example.com/assistant-123",
+            SelfHostedServer.canonicalString(SelfHostedServer.validate("https://example.com/assistant-123//"))
+        );
+    }
+
+    @Test
+    public void appendDedupesByCanonicalUrlAndKeepsLabelsAcrossNamelessReappends() {
+        FakeStore store = new FakeStore();
+        URI server = SelfHostedServer.validate("https://example.com:443/assistant-123/");
+
+        SelfHostedServer.append(store, server, "  Living Room  ");
+        SelfHostedServer.append(store, SelfHostedServer.validate("https://example.com/assistant-123"), null);
+
+        List<SelfHostedServer.Entry> servers = SelfHostedServer.servers(store);
+        assertEquals(1, servers.size());
+        assertEquals(new SelfHostedServer.Entry("Living Room", "https://example.com/assistant-123"), servers.get(0));
+
+        SelfHostedServer.append(store, server, "Kitchen");
+        assertEquals("Kitchen", SelfHostedServer.servers(store).get(0).name);
+    }
+
+    @Test
+    public void readingDropsInvalidEntriesAndDedupesPreCanonicalDuplicates() {
+        FakeStore store = new FakeStore();
+        store.servers =
+            "[{\"url\":\"http://example.com\"},"
+                + "{\"name\":\"First\",\"url\":\"https://example.com:443/assistant-123\"},"
+                + "{\"name\":\"Second\",\"url\":\"https://example.com/assistant-123/\"},"
+                + "{\"name\":\"\",\"url\":\"https://other.example.com/assistant-456\"}]";
+
+        List<SelfHostedServer.Entry> servers = SelfHostedServer.servers(store);
+
+        assertEquals(2, servers.size());
+        assertEquals(new SelfHostedServer.Entry("First", "https://example.com/assistant-123"), servers.get(0));
+        assertEquals(new SelfHostedServer.Entry(null, "https://other.example.com/assistant-456"), servers.get(1));
+    }
+
+    @Test
+    public void foldsInLegacyActiveUrlWithoutWritingBack() {
+        FakeStore store = new FakeStore();
+        SelfHostedServer.store(store, SelfHostedServer.validate("https://example.com:443/assistant-123"));
+
+        List<SelfHostedServer.Entry> servers = SelfHostedServer.servers(store);
+
+        assertEquals(1, servers.size());
+        assertEquals(new SelfHostedServer.Entry(null, "https://example.com/assistant-123"), servers.get(0));
+        assertNull(store.servers);
+    }
+
+    @Test
+    public void removingTheActiveEntryClearsTheActiveSlot() {
+        FakeStore store = new FakeStore();
+        URI active = SelfHostedServer.validate("https://example.com/assistant-123");
+        URI other = SelfHostedServer.validate("https://other.example.com/assistant-456");
+        SelfHostedServer.append(store, active, "Active");
+        SelfHostedServer.append(store, other, "Other");
+        SelfHostedServer.store(store, active);
+
+        assertFalse(SelfHostedServer.removeEntry(store, other));
+        assertTrue(SelfHostedServer.isActive(store, active));
+
+        assertTrue(SelfHostedServer.removeEntry(store, SelfHostedServer.validate("https://example.com:443/assistant-123")));
+        assertNull(SelfHostedServer.configured(store));
+        assertTrue(SelfHostedServer.servers(store).isEmpty());
+    }
+
+    @Test
+    public void parsesBakedServerUrlFromCapacitorConfig() {
+        assertEquals(
+            "https://www.vellum.ai/assistant",
+            SelfHostedServer.parseBakedServerUrl("{\"server\":{\"url\":\"https://www.vellum.ai/assistant\"}}")
+        );
+        assertNull(SelfHostedServer.parseBakedServerUrl("not json"));
+        assertNull(SelfHostedServer.parseBakedServerUrl("{\"server\":{}}"));
+        assertNull(SelfHostedServer.parseBakedServerUrl(null));
+    }
+
     private static final class FakeStore implements SelfHostedServer.Store {
         private String value;
+        private String servers;
 
         @Override
         public String read() {
@@ -119,6 +262,16 @@ public class SelfHostedServerTest {
         @Override
         public void clear() {
             value = null;
+        }
+
+        @Override
+        public String readServers() {
+            return servers;
+        }
+
+        @Override
+        public void writeServers(String json) {
+            servers = json;
         }
     }
 }

--- a/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
@@ -298,6 +298,8 @@ public class SelfHostedServerTest {
         assertNull(SelfHostedServer.appRoute("https://host/assistant", "https://evil.example/route"));
         assertNull(SelfHostedServer.appRoute("https://host/assistant", "pair#fragment"));
         assertNull(SelfHostedServer.appRoute("https://host/assistant", "a/../b"));
+        assertNull(SelfHostedServer.appRoute("https://host/assistant", "a/%2e%2e/b"));
+        assertNull(SelfHostedServer.appRoute("https://host/assistant", "a/.%2E/b"));
         assertNull(SelfHostedServer.appRoute("https://host/assistant", "   "));
     }
 

--- a/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
@@ -234,6 +234,43 @@ public class SelfHostedServerTest {
     }
 
     @Test
+    public void appEntryUrlAppendsTheAssistantSegmentPreservingPrefixes() {
+        assertEquals(
+            "https://example.com/assistant-123/assistant",
+            SelfHostedServer.appEntryUrl(SelfHostedServer.validate("https://example.com/assistant-123")).toASCIIString()
+        );
+        assertEquals(
+            "https://example.com/assistant",
+            SelfHostedServer.appEntryUrl(SelfHostedServer.validate("https://example.com")).toASCIIString()
+        );
+        assertEquals(
+            "https://example.com/assistant",
+            SelfHostedServer.appEntryUrl(SelfHostedServer.validate("https://example.com/assistant")).toASCIIString()
+        );
+    }
+
+    @Test
+    public void appRouteJoinsRelativePathsKeepingQueries() {
+        assertEquals(
+            "https://host/assistant-123/assistant/select-assistant?noAutoSkip=1",
+            SelfHostedServer.appRoute("https://host/assistant-123/assistant", "select-assistant?noAutoSkip=1")
+        );
+        assertEquals(
+            "https://host/assistant/pair",
+            SelfHostedServer.appRoute("https://host/assistant/", "pair")
+        );
+    }
+
+    @Test
+    public void appRouteRejectsAbsoluteSchemefulFragmentClimbingAndBlankPaths() {
+        assertNull(SelfHostedServer.appRoute("https://host/assistant", "/absolute"));
+        assertNull(SelfHostedServer.appRoute("https://host/assistant", "https://evil.example/route"));
+        assertNull(SelfHostedServer.appRoute("https://host/assistant", "pair#fragment"));
+        assertNull(SelfHostedServer.appRoute("https://host/assistant", "a/../b"));
+        assertNull(SelfHostedServer.appRoute("https://host/assistant", "   "));
+    }
+
+    @Test
     public void parsesBakedServerUrlFromCapacitorConfig() {
         assertEquals(
             "https://www.vellum.ai/assistant",

--- a/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
@@ -299,6 +299,7 @@ public class SelfHostedServerTest {
         assertNull(SelfHostedServer.appRoute("https://host/assistant", "pair#fragment"));
         assertNull(SelfHostedServer.appRoute("https://host/assistant", "a/../b"));
         assertNull(SelfHostedServer.appRoute("https://host/assistant", "a/%2e%2e/b"));
+        assertNull(SelfHostedServer.appRoute("https://host/assistant", "?noAutoSkip=1"));
         assertNull(SelfHostedServer.appRoute("https://host/assistant", "a/.%2E/b"));
         assertNull(SelfHostedServer.appRoute("https://host/assistant", "   "));
     }

--- a/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
@@ -53,6 +53,13 @@ public class SelfHostedServerTest {
     }
 
     @Test
+    public void rejectsNonAsciiHostsButKeepsAsciiAndIpv6LiteralHosts() {
+        assertNull(SelfHostedServer.validate("https://münchen.example"));
+        assertEquals("https://example.com", SelfHostedServer.validate("https://example.com").toASCIIString());
+        assertEquals("https://[::1]:8443", SelfHostedServer.validate("https://[::1]:8443").toASCIIString());
+    }
+
+    @Test
     public void storesOnlyValidatedServerBasesAndCanReset() {
         FakeStore store = new FakeStore();
         URI server = SelfHostedServer.validate("https://example.com/assistant-123");
@@ -205,6 +212,30 @@ public class SelfHostedServerTest {
     }
 
     @Test
+    public void readsExplicitJsonNullNamesAsUnnamed() {
+        FakeStore store = new FakeStore();
+        store.servers = "[{\"name\":null,\"url\":\"https://example.com/assistant-123\"}]";
+
+        List<SelfHostedServer.Entry> servers = SelfHostedServer.servers(store);
+
+        assertEquals(1, servers.size());
+        assertEquals(new SelfHostedServer.Entry(null, "https://example.com/assistant-123"), servers.get(0));
+    }
+
+    @Test
+    public void activateWritesTheActiveSlotAndRemembersTheOrigin() {
+        FakeStore store = new FakeStore();
+        URI server = SelfHostedServer.validate("https://example.com:443/assistant-123/");
+
+        SelfHostedServer.activate(store, server, "Living Room");
+
+        assertTrue(SelfHostedServer.isActive(store, server));
+        List<SelfHostedServer.Entry> servers = SelfHostedServer.servers(store);
+        assertEquals(1, servers.size());
+        assertEquals(new SelfHostedServer.Entry("Living Room", "https://example.com/assistant-123"), servers.get(0));
+    }
+
+    @Test
     public void foldsInLegacyActiveUrlWithoutWritingBack() {
         FakeStore store = new FakeStore();
         SelfHostedServer.store(store, SelfHostedServer.validate("https://example.com:443/assistant-123"));
@@ -268,6 +299,16 @@ public class SelfHostedServerTest {
         assertNull(SelfHostedServer.appRoute("https://host/assistant", "pair#fragment"));
         assertNull(SelfHostedServer.appRoute("https://host/assistant", "a/../b"));
         assertNull(SelfHostedServer.appRoute("https://host/assistant", "   "));
+    }
+
+    @Test
+    public void appRouteRejectsColonsOnlyInTheFirstSegment() {
+        assertNull(SelfHostedServer.appRoute("https://host/assistant", "mailto:x"));
+        assertNull(SelfHostedServer.appRoute("https://host/assistant", "evil.example:8080/x"));
+        assertEquals(
+            "https://host/assistant/conversations/abc:def",
+            SelfHostedServer.appRoute("https://host/assistant", "conversations/abc:def")
+        );
     }
 
     @Test

--- a/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServersPluginTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServersPluginTest.java
@@ -1,0 +1,69 @@
+package ai.vellum.assistant;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import com.getcapacitor.JSObject;
+import java.util.Arrays;
+import java.util.Collections;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Test;
+
+public class SelfHostedServersPluginTest {
+    @Test
+    public void emptyStateResolvesEmptyListAndJsonNulls() throws JSONException {
+        JSObject payload = SelfHostedServersPlugin.listPayload(Collections.emptyList(), null, null);
+
+        assertEquals(0, payload.getJSONArray("servers").length());
+        assertTrue(payload.has("activeUrl"));
+        assertTrue(payload.isNull("activeUrl"));
+        assertSame(JSONObject.NULL, payload.get("activeUrl"));
+        assertTrue(payload.has("bakedUrl"));
+        assertTrue(payload.isNull("bakedUrl"));
+        assertSame(JSONObject.NULL, payload.get("bakedUrl"));
+    }
+
+    @Test
+    public void namedEntriesCarryTheNameKey() throws JSONException {
+        JSObject payload = SelfHostedServersPlugin.listPayload(
+            Collections.singletonList(new SelfHostedServer.Entry("Work", "https://work.example.com")),
+            "https://work.example.com",
+            "https://app.vellum.ai"
+        );
+
+        JSONArray servers = payload.getJSONArray("servers");
+        assertEquals(1, servers.length());
+        JSONObject entry = servers.getJSONObject(0);
+        assertEquals("Work", entry.getString("name"));
+        assertEquals("https://work.example.com", entry.getString("url"));
+        assertEquals("https://work.example.com", payload.getString("activeUrl"));
+        assertEquals("https://app.vellum.ai", payload.getString("bakedUrl"));
+    }
+
+    @Test
+    public void unnamedEntriesOmitTheNameKeyEntirely() throws JSONException {
+        JSObject payload = SelfHostedServersPlugin.listPayload(
+            Arrays.asList(
+                new SelfHostedServer.Entry(null, "https://one.example.com"),
+                new SelfHostedServer.Entry("Two", "https://two.example.com/base")
+            ),
+            null,
+            "https://app.vellum.ai"
+        );
+
+        JSONArray servers = payload.getJSONArray("servers");
+        assertEquals(2, servers.length());
+        JSONObject unnamed = servers.getJSONObject(0);
+        assertFalse(unnamed.has("name"));
+        assertEquals("https://one.example.com", unnamed.getString("url"));
+        JSONObject named = servers.getJSONObject(1);
+        assertEquals("Two", named.getString("name"));
+        assertEquals("https://two.example.com/base", named.getString("url"));
+        assertTrue(payload.isNull("activeUrl"));
+        assertEquals("https://app.vellum.ai", payload.getString("bakedUrl"));
+    }
+}

--- a/clients/web/docs/CAPACITOR.md
+++ b/clients/web/docs/CAPACITOR.md
@@ -178,7 +178,7 @@ The shell registers **seven app-local** Capacitor plugins in [`MyViewController.
 | `VoiceAudioSession` | [`src/runtime/native-audio-session.ts`](../src/runtime/native-audio-session.ts) | iOS interruption events and Android audio-focus and microphone-service lifecycle. See the background-audio contract below |
 | `VoiceLiveActivity` | [`src/runtime/native-live-activity.ts`](../src/runtime/native-live-activity.ts) | One ActivityKit activity on iOS or ongoing notification on Android |
 | `ApnsEnvironment` | [`src/runtime/apns-environment.ts`](../src/runtime/apns-environment.ts) | The build's real APNs entitlement environment (`development` / `production` / `unknown`), read from the embedded provisioning profile |
-| `SelfHostedServers` | [`src/runtime/self-hosted-servers.ts`](../src/runtime/self-hosted-servers.ts) | List, add, remove, and switch between self-hosted server origins; `switchTo` swaps the shell's configured origin and reloads in place. See the section below |
+| `SelfHostedServers` | [`src/runtime/self-hosted-servers.ts`](../src/runtime/self-hosted-servers.ts) | List, add, remove, and switch between self-hosted server origins; `switchTo` swaps the shell's configured origin and reloads without leaving the app. See the section below |
 | `RecentChats` | [`src/runtime/recent-chats.ts`](../src/runtime/recent-chats.ts) | Mirrors the sidebar conversation list (ids + titles) into a UserDefaults cache that backs the Shortcuts app's chat picker (`ChatEntityQuery`); synced from `ChatLayout` once the list query has resolved |
 
 The two voice plugins are consumed only through `use-live-voice-session-controller.ts` (audio session) and `use-live-activity-mirror.ts` (Live Activity), both mounted at `ChatLayout` scope so their lifetime is exactly the session's.
@@ -259,13 +259,18 @@ References:
 
 The assistant chooser offers every origin this device knows about. On a native
 mobile shell those origins live natively, not in web storage, because the shell
-is the only thing that can point its `WKWebView` somewhere else without leaving
-the app, and because the same list is written by the native Settings pane and
-the `<scheme>://connect` deep link. The web side is
+is the only thing that can point its web view somewhere else without leaving
+the app, and because the same list is written by the `<scheme>://connect` deep
+link (and, on iOS, the native Settings pane). The web side is
 [`src/runtime/self-hosted-servers.ts`](../src/runtime/self-hosted-servers.ts);
 the native side is
 [`SelfHostedServersPlugin.swift`](../../../clients/ios/App/App/SelfHostedServersPlugin.swift)
-over [`SelfHostedServer.swift`](../../../clients/ios/App/App/SelfHostedServer.swift).
+over [`SelfHostedServer.swift`](../../../clients/ios/App/App/SelfHostedServer.swift)
+on iOS, and
+[`SelfHostedServersPlugin.java`](../../../clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServersPlugin.java)
+over
+[`SelfHostedServer.java`](../../../clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java)
+on Android.
 
 The bridge contract:
 
@@ -274,17 +279,22 @@ The bridge contract:
 | `list()` | `{ servers: [{name?, url}], activeUrl, bakedUrl }` | `activeUrl` is the configured self-hosted slot (`null` means the shell serves its baked origin); `bakedUrl` is the Vellum Cloud origin the build ships with |
 | `add({url, name?})` | `{ ok }` | Deduped by canonical url. A nameless re-add keeps the stored label |
 | `remove({url})` | `{ ok }` | Forgetting the active url also clears the active slot, so the shell returns to the baked origin |
-| `switchTo({url?})` | `{ ok }` | Swaps the active slot and reloads in place. An absent or empty `url` returns to the baked origin |
+| `switchTo({url?})` | `{ ok }` | Swaps the active slot and reloads the shell onto it (see the per-surface list below). An absent or empty `url` returns to the baked origin |
+| `switchToPath({url?, path})` | `{ ok }` | `switchTo` plus an initial in-app route loaded relative to the destination's app entry URL. A malformed `path` (empty, absolute, containing `://`, or carrying a fragment) rejects up front; a path that passes those checks but fails route building still switches and falls back to the app entry URL |
 
-Only genuinely invalid caller input rejects (an `add` or `switchTo` url that
-fails `SelfHostedServer.validate`). Empty state resolves with an empty list and
-nulls, so there is no "not configured" error branch to write.
+Only genuinely invalid caller input rejects (an `add`/`switchTo`/`switchToPath`
+url that fails `SelfHostedServer.validate`, or a malformed `switchToPath`
+path). Empty state resolves with an empty list and nulls, so there is no "not
+configured" error branch to write.
 
 Urls cross the bridge in one canonical form: `SelfHostedServer.canonicalize` and
 the store's `normalizeOriginUrl` implement the same rules (lowercase scheme and
 host, userinfo dropped, trailing slashes stripped, query and fragment dropped,
 path and port preserved), so both sides agree on which strings mean the same
-server. Changing one means changing the other.
+HTTPS server. Changing one means changing the others. The one divergence is
+deliberate: the Android shell also accepts cleartext development hosts
+(`http://localhost` and friends) that `normalizeOriginUrl` rejects, so those
+entries live in the native list but never surface as chooser cards.
 
 **Switching is per surface, and every surface has a working answer.**
 
@@ -296,8 +306,10 @@ server. Changing one means changing the other.
   ([`main-window.ts`](../../macos/src/main/main-window.ts)) sends any
   cross-origin https target to the system browser, so the origin opens there.
 - Native mobile with the plugin: `nativeSwitchToOrigin` hands the url to the
-  shell, which reloads the web view in place. The user never leaves the app,
-  and a "Vellum Cloud" card sourced from `list().bakedUrl` is the way back.
+  shell. iOS reloads the `WKWebView` in place; Android recreates the activity
+  onto a rebuilt Capacitor config, so a brief relaunch flash is expected.
+  Either way the user never leaves the app, and a "Vellum Cloud" card sourced
+  from `list().bakedUrl` is the way back.
 - Native mobile without the plugin: the same navigation the browser takes. That
   leaves the app for the system browser, which is degraded but is exactly what
   the pair-page path already does there.


### PR DESCRIPTION
## Summary
Brings the Android Capacitor shell to parity with iOS for self-hosted assistants: a natively remembered `{name?, url}` server list with canonical URL identity shared with the web chooser, the full five-method `SelfHostedServers` Capacitor plugin (`list`/`add`/`remove`/`switchTo`/`switchToPath`), in-app origin switching via activity recreation with entry-URL prefix preservation, connect-link `name` labels, and docs. No web files changed; the existing web chooser, localStorage migration, and Vellum Cloud card light up on Android automatically.

## Self-review result
GAPS FOUND then fixed: 4 fresh-eyes passes (external feedback, plan faithfulness, repo integration, slop audit) plus 2 remediation rounds and a final scoped verification (PASS, no gaps). 12 unique findings: 9 fixed across 2 fix PRs, 3 declined with rationale (test-ergonomics equals/hashCode, iOS-parity appEntryUrl guard, JVM-unreachable test caveat documented in-code).

## PRs merged into feature branch
- #40722: feat(android): parse the optional name label from connect deep links
- #40723: feat(android): remembered self-hosted server list with canonical URL identity
- #40734: feat(android): append paired self-hosted servers to the remembered list
- #40736: feat(android): SelfHostedServers plugin with in-app origin switching
- #40745: docs: document Android self-hosted server list and switching

### Fix PRs
- #40780: fix(android): close recreation races, lock list writes, tighten host and route validation
- #40781: fix(android): residual self-review hardening

## Manual QA before release (from the plan)
With the `vellum:ff:assistant-switcher` flag override on an Android dev build: pair two self-hosted assistants via QR connect links (one with `name=`), switch between them and Vellum Cloud from the chooser, forget the active one, verify the localStorage-to-native migration, and confirm a path-prefixed base lands on the SPA after switchTo. Also verify PR #40721's platform-hub mechanic composes: ingress-less local registrations hidden, ingress'd ones connect in-SPA without an origin switch.

Part of plan: android-assistant-parity.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)