### PR TITLE
feat(local-mode): add runDevicesList/runDevicesRevoke CLI run helpers and DeviceRecord contract

### DIFF
--- a/packages/local-mode/src/devices.test.ts
+++ b/packages/local-mode/src/devices.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
+import { EventEmitter } from "node:events";
+
+import type { CliInvocation } from "./util";
+
+class FakeChild extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  kill = mock(() => true);
+}
+
+let lastChild: FakeChild;
+const spawnArgs: Array<[string, string[], { stdio?: unknown }]> = [];
+const spawnMock = mock(
+  (command: string, args: string[], options: { stdio?: unknown }) => {
+    spawnArgs.push([command, args, options]);
+    lastChild = new FakeChild();
+    return lastChild;
+  },
+);
+
+mock.module("node:child_process", () => ({ spawn: spawnMock }));
+
+let runDevicesList: typeof import("./devices").runDevicesList;
+let runDevicesRevoke: typeof import("./devices").runDevicesRevoke;
+
+beforeAll(async () => {
+  ({ runDevicesList, runDevicesRevoke } = await import("./devices"));
+});
+
+afterEach(() => {
+  spawnArgs.length = 0;
+  spawnMock.mockClear();
+});
+
+const invocation: CliInvocation = { command: "bun", baseArgs: ["run", "cli"] };
+
+describe("runDevicesList", () => {
+  test("spawns the CLI devices command and parses the JSON document", async () => {
+    const pending = runDevicesList(invocation, "asst-42");
+    lastChild.stdout.emit(
+      "data",
+      Buffer.from(
+        JSON.stringify({
+          devices: [
+            {
+              hashedDeviceId: "hash-a",
+              platform: "ios",
+              issuedAt: 1000,
+              expiresAt: 2000,
+              lastUsedAt: 1500,
+            },
+          ],
+        }),
+      ),
+    );
+    lastChild.emit("close", 0);
+
+    expect(await pending).toEqual({
+      ok: true,
+      devices: [
+        {
+          hashedDeviceId: "hash-a",
+          platform: "ios",
+          issuedAt: 1000,
+          expiresAt: 2000,
+          lastUsedAt: 1500,
+        },
+      ],
+    });
+    expect(spawnArgs[0]).toEqual([
+      "bun",
+      ["run", "cli", "devices", "asst-42", "--json"],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    ]);
+  });
+
+  test("tolerates null and non-numeric timestamps", async () => {
+    const pending = runDevicesList(invocation, "asst-42");
+    lastChild.stdout.emit(
+      "data",
+      Buffer.from(
+        JSON.stringify({
+          devices: [
+            {
+              hashedDeviceId: "hash-b",
+              platform: "web",
+              issuedAt: null,
+              expiresAt: "soon",
+            },
+          ],
+        }),
+      ),
+    );
+    lastChild.emit("close", 0);
+
+    expect(await pending).toEqual({
+      ok: true,
+      devices: [
+        {
+          hashedDeviceId: "hash-b",
+          platform: "web",
+          issuedAt: null,
+          expiresAt: null,
+          lastUsedAt: null,
+        },
+      ],
+    });
+  });
+
+  test("an empty device list parses to no records", async () => {
+    const pending = runDevicesList(invocation, "asst-42");
+    lastChild.stdout.emit("data", Buffer.from('{ "devices": [] }'));
+    lastChild.emit("close", 0);
+
+    expect(await pending).toEqual({ ok: true, devices: [] });
+  });
+
+  test("malformed stdout resolves to a failure with a snippet", async () => {
+    const pending = runDevicesList(invocation, "asst-42");
+    lastChild.stdout.emit("data", Buffer.from("not json"));
+    lastChild.emit("close", 0);
+
+    expect(await pending).toEqual({
+      ok: false,
+      status: 500,
+      error: "CLI returned unparseable devices output: not json",
+    });
+  });
+
+  test("a record missing hashedDeviceId resolves to a failure", async () => {
+    const pending = runDevicesList(invocation, "asst-42");
+    lastChild.stdout.emit(
+      "data",
+      Buffer.from(JSON.stringify({ devices: [{ platform: "ios" }] })),
+    );
+    lastChild.emit("close", 0);
+
+    const result = await pending;
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toStartWith("CLI returned unparseable devices output");
+    }
+  });
+
+  test("a non-zero exit resolves to a failure carrying stderr", async () => {
+    const pending = runDevicesList(invocation, "asst-42");
+    lastChild.stderr.emit("data", Buffer.from("devices failed"));
+    lastChild.emit("close", 1);
+
+    expect(await pending).toEqual({
+      ok: false,
+      status: 500,
+      error: "devices failed",
+    });
+  });
+
+  test("a spawn error resolves to a failure", async () => {
+    const pending = runDevicesList(invocation, "asst-42");
+    lastChild.emit("error", new Error("ENOENT"));
+
+    expect(await pending).toEqual({
+      ok: false,
+      status: 500,
+      error: "Failed to spawn CLI: ENOENT",
+    });
+  });
+});
+
+describe("runDevicesRevoke", () => {
+  test("spawns the CLI revoke command and succeeds on exit 0", async () => {
+    const pending = runDevicesRevoke(invocation, "asst-42", "hash-a");
+    lastChild.stdout.emit(
+      "data",
+      Buffer.from('{ "ok": true, "hashedDeviceId": "hash-a" }'),
+    );
+    lastChild.emit("close", 0);
+
+    expect(await pending).toEqual({ ok: true });
+    expect(spawnArgs[0]).toEqual([
+      "bun",
+      ["run", "cli", "devices", "revoke", "hash-a", "asst-42", "--yes", "--json"],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    ]);
+  });
+
+  test("a non-zero exit resolves to a failure carrying stderr", async () => {
+    const pending = runDevicesRevoke(invocation, "asst-42", "hash-a");
+    lastChild.stderr.emit("data", Buffer.from("revoke failed"));
+    lastChild.emit("close", 1);
+
+    expect(await pending).toEqual({
+      ok: false,
+      status: 500,
+      error: "revoke failed",
+    });
+  });
+
+  test("a spawn error resolves to a failure", async () => {
+    const pending = runDevicesRevoke(invocation, "asst-42", "hash-a");
+    lastChild.emit("error", new Error("EACCES"));
+
+    expect(await pending).toEqual({
+      ok: false,
+      status: 500,
+      error: "Failed to spawn CLI: EACCES",
+    });
+  });
+});

--- a/packages/local-mode/src/devices.ts
+++ b/packages/local-mode/src/devices.ts
@@ -1,0 +1,167 @@
+import { spawn } from "node:child_process";
+
+import type { CliInvocation } from "./util";
+
+// Fast loopback HTTP calls; well under the lifecycle-op timeouts.
+const DEVICES_TIMEOUT_MS = 30_000;
+
+/**
+ * Mirrors one row of the gateway's `GET /v1/devices` response. The gateway
+ * stores only the HASHED device id, so `hashedDeviceId` is both the display
+ * identifier and the revocation key.
+ */
+export interface DeviceRecord {
+  hashedDeviceId: string;
+  platform: string;
+  issuedAt: number | null;
+  expiresAt: number | null;
+  lastUsedAt: number | null;
+}
+
+export type DevicesListResult =
+  | { ok: true; devices: DeviceRecord[] }
+  | { ok: false; status: number; error: string };
+
+export type DevicesRevokeResult =
+  { ok: true } | { ok: false; status: number; error: string };
+
+type CliRunResult =
+  | { ok: true; stdout: string }
+  | { ok: false; status: number; error: string };
+
+function runDevicesCli(
+  invocation: CliInvocation,
+  args: string[],
+): Promise<CliRunResult> {
+  return new Promise((resolve) => {
+    const child = spawn(
+      invocation.command,
+      [...invocation.baseArgs, ...args],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+
+    let stdout = "";
+    let stderr = "";
+    let done = false;
+
+    const finish = (result: CliRunResult) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timeout);
+      resolve(result);
+    };
+
+    const timeout = setTimeout(() => {
+      child.kill("SIGTERM");
+      finish({
+        ok: false,
+        status: 500,
+        error: "Devices command timed out after 30 seconds",
+      });
+    }, DEVICES_TIMEOUT_MS);
+
+    child.stdout.on("data", (data: Buffer) => {
+      stdout += data.toString();
+    });
+
+    child.stderr.on("data", (data: Buffer) => {
+      stderr += data.toString();
+    });
+
+    child.on("close", (code) => {
+      if (code === 0) {
+        finish({ ok: true, stdout });
+      } else {
+        finish({ ok: false, status: 500, error: stderr || stdout });
+      }
+    });
+
+    child.on("error", (err) => {
+      finish({
+        ok: false,
+        status: 500,
+        error: `Failed to spawn CLI: ${err.message}`,
+      });
+    });
+  });
+}
+
+function toTimestamp(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function parseDeviceRecords(stdout: string): DeviceRecord[] | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    return null;
+  }
+  const devices = (parsed as { devices?: unknown }).devices;
+  if (!Array.isArray(devices)) {
+    return null;
+  }
+
+  const records: DeviceRecord[] = [];
+  for (const entry of devices) {
+    if (typeof entry !== "object" || entry === null) {
+      return null;
+    }
+    const { hashedDeviceId, platform, issuedAt, expiresAt, lastUsedAt } =
+      entry as Record<string, unknown>;
+    if (typeof hashedDeviceId !== "string" || typeof platform !== "string") {
+      return null;
+    }
+    records.push({
+      hashedDeviceId,
+      platform,
+      issuedAt: toTimestamp(issuedAt),
+      expiresAt: toTimestamp(expiresAt),
+      lastUsedAt: toTimestamp(lastUsedAt),
+    });
+  }
+  return records;
+}
+
+export async function runDevicesList(
+  invocation: CliInvocation,
+  assistantId: string,
+): Promise<DevicesListResult> {
+  const result = await runDevicesCli(invocation, [
+    "devices",
+    assistantId,
+    "--json",
+  ]);
+  if (!result.ok) {
+    return result;
+  }
+  const devices = parseDeviceRecords(result.stdout);
+  if (!devices) {
+    const snippet = result.stdout.trim().slice(0, 200);
+    return {
+      ok: false,
+      status: 500,
+      error: `CLI returned unparseable devices output: ${snippet}`,
+    };
+  }
+  return { ok: true, devices };
+}
+
+export async function runDevicesRevoke(
+  invocation: CliInvocation,
+  assistantId: string,
+  hashedDeviceId: string,
+): Promise<DevicesRevokeResult> {
+  const result = await runDevicesCli(invocation, [
+    "devices",
+    "revoke",
+    hashedDeviceId,
+    assistantId,
+    "--yes",
+    "--json",
+  ]);
+  return result.ok ? { ok: true } : result;
+}

--- a/packages/local-mode/src/index.ts
+++ b/packages/local-mode/src/index.ts
@@ -61,6 +61,12 @@ export { runSleep } from "./sleep";
 export type { SleepResult } from "./sleep";
 export { runWake } from "./wake";
 export type { WakeOptions, WakeResult } from "./wake";
+export { runDevicesList, runDevicesRevoke } from "./devices";
+export type {
+  DeviceRecord,
+  DevicesListResult,
+  DevicesRevokeResult,
+} from "./devices";
 export { runUpgrade, isValidReleaseVersion } from "./upgrade";
 export type { UpgradeOptions, UpgradeResult } from "./upgrade";
 export { getLocalAssistantStatus } from "./status";


### PR DESCRIPTION
## Summary
- Adds runDevicesList/runDevicesRevoke spawn helpers to @vellumai/local-mode, wrapping vellum devices --json
- Introduces the canonical DeviceRecord contract shared by the CLI and hosts in later PRs
- Never-reject result unions matching the retire/sleep/wake helper contract

Part of plan: paired-devices-revoke.md (PR 1 of 6)