### PR TITLE
fix(plugins): activate a plugin when it is enabled

### DIFF
--- a/assistant/src/plugins/mtime-cache.ts
+++ b/assistant/src/plugins/mtime-cache.ts
@@ -1071,7 +1071,7 @@ async function deactivatePlugin(
  * Called by `loadUserPlugins()` during daemon startup. After boot, the same
  * `activatePlugin`/`deactivatePlugin` reconciliation runs only through the
  * imperative poke ({@link reconcilePluginSourcesNow}) the install/uninstall/
- * enable/disable routes call, so plugin lifecycle stays confined to the main
+ * upgrade/enable routes call, so plugin lifecycle stays confined to the main
  * daemon — dispatch-time hook and tool reads never activate anything.
  */
 export async function populateCacheAtBoot(

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -2591,8 +2591,10 @@ function toggleResult(
   };
 }
 
-function invokeEnable(args: RouteHandlerArgs = {}): { ok: boolean } {
-  return enableHandler(args) as { ok: boolean };
+async function invokeEnable(
+  args: RouteHandlerArgs = {},
+): Promise<{ ok: boolean }> {
+  return (await enableHandler(args)) as { ok: boolean };
 }
 
 function invokeDisable(args: RouteHandlerArgs = {}): { ok: boolean } {
@@ -2634,49 +2636,47 @@ describe("POST /v1/plugins/:name/enable", () => {
     reconcilePluginSourcesNowSpy.mockClear();
   });
 
-  test("pokes the source reconcile so a boot-disabled plugin activates now", async () => {
+  test("awaits the source reconcile so a boot-disabled plugin activates before the route returns", async () => {
     enablePluginSpy.mockImplementation((name) => toggleResult(name, "enable"));
 
-    invokeEnable({ pathParams: { name: "simple-memory" } });
+    await invokeEnable({ pathParams: { name: "simple-memory" } });
 
     // The boot scan skipped this plugin for its sentinel, so clearing the
     // sentinel only brings its hooks, tools, MCP servers and schedules up if
-    // the source reconcile runs. The reconcile converges the schedules itself,
-    // so the route does not poke them separately.
-    await waitForReconcile(
-      reconcilePluginSourcesNowSpy,
-      "plugin source reconcile",
-    );
+    // the source reconcile runs. The route awaits it, so by the time the
+    // response lands the reconcile has completed; it converges the schedules
+    // itself, so the route does not poke them separately.
     expect(reconcilePluginSourcesNowSpy).toHaveBeenCalledTimes(1);
     expect(reconcilePluginSchedulesSpy).not.toHaveBeenCalled();
   });
 
-  test("a failed toggle does not poke the source reconcile", async () => {
+  test("a failed toggle does not run the source reconcile", async () => {
     enablePluginSpy.mockImplementation((name) => {
       throw new PluginDirectoryNotFoundError(name);
     });
 
-    expect(() => invokeEnable({ pathParams: { name: "ghost" } })).toThrow(
-      NotFoundError,
-    );
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await expect(
+      invokeEnable({ pathParams: { name: "ghost" } }),
+    ).rejects.toThrow(NotFoundError);
     expect(reconcilePluginSourcesNowSpy).not.toHaveBeenCalled();
   });
 
-  test("enables the plugin and broadcasts sync_changed(plugins:list)", () => {
+  test("enables the plugin and broadcasts sync_changed(plugins:list)", async () => {
     enablePluginSpy.mockImplementation((name) => toggleResult(name, "enable"));
 
-    const result = invokeEnable({ pathParams: { name: "simple-memory" } });
+    const result = await invokeEnable({
+      pathParams: { name: "simple-memory" },
+    });
 
     expect(result).toEqual({ ok: true });
     expect(enablePluginSpy.mock.calls[0]?.[0]).toBe("simple-memory");
     expectPluginsListBroadcast();
   });
 
-  test("threads x-vellum-client-id into the published event's originClientId", () => {
+  test("threads x-vellum-client-id into the published event's originClientId", async () => {
     enablePluginSpy.mockImplementation((name) => toggleResult(name, "enable"));
 
-    invokeEnable({
+    await invokeEnable({
       pathParams: { name: "simple-memory" },
       headers: { "x-vellum-client-id": "client-abc" },
     });
@@ -2690,7 +2690,7 @@ describe("POST /v1/plugins/:name/enable", () => {
     });
   });
 
-  test("a broadcast failure does not fail a successful toggle", () => {
+  test("a broadcast failure does not fail a successful toggle", async () => {
     enablePluginSpy.mockImplementation((name) => toggleResult(name, "enable"));
     // The sentinel was already flipped; a hub throw AFTER that must not surface
     // as a 500 — the canonical publisher swallows broadcast errors.
@@ -2698,40 +2698,42 @@ describe("POST /v1/plugins/:name/enable", () => {
       throw new Error("hub unavailable");
     });
 
-    const result = invokeEnable({ pathParams: { name: "simple-memory" } });
+    const result = await invokeEnable({
+      pathParams: { name: "simple-memory" },
+    });
     expect(result).toEqual({ ok: true });
   });
 
-  test("PluginAlreadyInStateException → ConflictError (409), no broadcast", () => {
+  test("PluginAlreadyInStateException → ConflictError (409), no broadcast", async () => {
     enablePluginSpy.mockImplementation((name) => {
       throw new PluginAlreadyInStateException(name, "enable");
     });
 
-    expect(() =>
+    await expect(
       invokeEnable({ pathParams: { name: "simple-memory" } }),
-    ).toThrow(ConflictError);
+    ).rejects.toThrow(ConflictError);
     // A no-op toggle must not fan out a spurious invalidation.
     expect(broadcastMessageSpy).not.toHaveBeenCalled();
   });
 
-  test("PluginDirectoryNotFoundError → NotFoundError (404)", () => {
+  test("PluginDirectoryNotFoundError → NotFoundError (404)", async () => {
     enablePluginSpy.mockImplementation((name) => {
       throw new PluginDirectoryNotFoundError(name);
     });
 
-    expect(() => invokeEnable({ pathParams: { name: "ghost" } })).toThrow(
-      NotFoundError,
-    );
+    await expect(
+      invokeEnable({ pathParams: { name: "ghost" } }),
+    ).rejects.toThrow(NotFoundError);
   });
 
-  test("InvalidPluginNameError → BadRequestError (400)", () => {
+  test("InvalidPluginNameError → BadRequestError (400)", async () => {
     enablePluginSpy.mockImplementation(() => {
       throw new ToggleInvalidPluginNameError("../escape");
     });
 
-    expect(() => invokeEnable({ pathParams: { name: "../escape" } })).toThrow(
-      BadRequestError,
-    );
+    await expect(
+      invokeEnable({ pathParams: { name: "../escape" } }),
+    ).rejects.toThrow(BadRequestError);
   });
 });
 

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -38,9 +38,12 @@
  *     `plugins:list` tag via the canonical resource-sync publisher (enable and
  *     disable emit the SAME invalidation)
  *   - Threads `x-vellum-client-id` into the published event's `originClientId`
- *   - Pokes the plugin-declared schedule reconcile on a successful toggle (and
- *     not on a failed one), so the plugin's rows disarm / re-arm immediately
- *     instead of at the reconciler's next backstop sweep
+ *   - Enable pokes the imperative plugin source reconcile, which activates a
+ *     plugin the boot scan skipped for its sentinel and converges its
+ *     schedules and MCP servers
+ *   - Disable pokes the plugin-declared schedule reconcile on a successful
+ *     toggle (and not on a failed one), so the plugin's rows disarm
+ *     immediately instead of at the reconciler's next backstop sweep
  *   - A broadcast failure does not fail a successful toggle (the publisher
  *     swallows hub errors)
  *   - Maps `InvalidPluginNameError` → BadRequestError (400)
@@ -316,13 +319,28 @@ mock.module("../../../cli/lib/toggle-plugin.js", () => ({
   enablePlugin: enablePluginSpy,
 }));
 
-// Spy on the plugin-schedule reconcile the toggle handlers poke. The handlers
-// import it lazily at call time, so this mock intercepts the dynamic import
+// Spy on the plugin-schedule reconcile the disable handler pokes. The handler
+// imports it lazily at call time, so this mock intercepts the dynamic import
 // and keeps the reconciler's persistence graph out of the test.
 const reconcilePluginSchedulesSpy = mock(() => Promise.resolve());
 
 mock.module("../../../schedule/plugin-schedule-reconciler.js", () => ({
   reconcilePluginSchedules: reconcilePluginSchedulesSpy,
+}));
+
+// Spy on the imperative plugin source reconcile so the enable route's
+// activation poke is assertable without scanning a real plugins tree. Only
+// that one export is swapped; the rest of the module passes through real,
+// because other modules in this route's graph import their own bindings from
+// it.
+const reconcilePluginSourcesNowSpy = mock(() => Promise.resolve());
+
+const actualMtimeCache: typeof import("../../../plugins/mtime-cache.js") =
+  await import("../../../plugins/mtime-cache.js");
+
+mock.module("../../../plugins/mtime-cache.js", () => ({
+  ...actualMtimeCache,
+  reconcilePluginSourcesNow: reconcilePluginSourcesNowSpy,
 }));
 
 // Spy on broadcastMessage so we can assert the sync_changed invalidation the
@@ -2582,18 +2600,22 @@ function invokeDisable(args: RouteHandlerArgs = {}): { ok: boolean } {
 }
 
 /**
- * Wait for the toggle handlers' fire-and-forget reconcile poke to land. The
- * lazy `import()` resolves off the microtask queue, so the assertion cannot
- * run on the handler's synchronous return.
+ * Wait for a toggle handler's fire-and-forget reconcile poke to land. The poke
+ * runs off the microtask queue (the disable path also resolves a lazy
+ * `import()` first), so the assertion cannot run on the handler's synchronous
+ * return.
  */
-async function waitForScheduleReconcile(): Promise<void> {
+async function waitForReconcile(
+  spy: { mock: { calls: unknown[] } },
+  label: string,
+): Promise<void> {
   for (let i = 0; i < 50; i++) {
-    if (reconcilePluginSchedulesSpy.mock.calls.length > 0) {
+    if (spy.mock.calls.length > 0) {
       return;
     }
     await new Promise((resolve) => setTimeout(resolve, 2));
   }
-  throw new Error("plugin schedule reconcile was never triggered");
+  throw new Error(`${label} was never triggered`);
 }
 
 /** Assert the spy received exactly one sync_changed carrying `plugins:list`. */
@@ -2609,14 +2631,36 @@ describe("POST /v1/plugins/:name/enable", () => {
     enablePluginSpy.mockReset();
     broadcastMessageSpy.mockReset();
     reconcilePluginSchedulesSpy.mockClear();
+    reconcilePluginSourcesNowSpy.mockClear();
   });
 
-  test("reconciles plugin-declared schedules so the plugin's rows re-arm now", async () => {
+  test("pokes the source reconcile so a boot-disabled plugin activates now", async () => {
     enablePluginSpy.mockImplementation((name) => toggleResult(name, "enable"));
 
     invokeEnable({ pathParams: { name: "simple-memory" } });
 
-    await waitForScheduleReconcile();
+    // The boot scan skipped this plugin for its sentinel, so clearing the
+    // sentinel only brings its hooks, tools, MCP servers and schedules up if
+    // the source reconcile runs. The reconcile converges the schedules itself,
+    // so the route does not poke them separately.
+    await waitForReconcile(
+      reconcilePluginSourcesNowSpy,
+      "plugin source reconcile",
+    );
+    expect(reconcilePluginSourcesNowSpy).toHaveBeenCalledTimes(1);
+    expect(reconcilePluginSchedulesSpy).not.toHaveBeenCalled();
+  });
+
+  test("a failed toggle does not poke the source reconcile", async () => {
+    enablePluginSpy.mockImplementation((name) => {
+      throw new PluginDirectoryNotFoundError(name);
+    });
+
+    expect(() => invokeEnable({ pathParams: { name: "ghost" } })).toThrow(
+      NotFoundError,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(reconcilePluginSourcesNowSpy).not.toHaveBeenCalled();
   });
 
   test("enables the plugin and broadcasts sync_changed(plugins:list)", () => {
@@ -2696,6 +2740,7 @@ describe("POST /v1/plugins/:name/disable", () => {
     disablePluginSpy.mockReset();
     broadcastMessageSpy.mockReset();
     reconcilePluginSchedulesSpy.mockClear();
+    reconcilePluginSourcesNowSpy.mockClear();
   });
 
   test("reconciles plugin-declared schedules so the plugin's rows disarm now", async () => {
@@ -2706,8 +2751,14 @@ describe("POST /v1/plugins/:name/disable", () => {
     invokeDisable({ pathParams: { name: "simple-memory" } });
 
     // Without this poke the rows stay armed until the reconciler's next
-    // backstop sweep.
-    await waitForScheduleReconcile();
+    // backstop sweep. Disable stays on the schedule poke: the sentinel filters
+    // the plugin out at read time, and a source reconcile here would run its
+    // shutdown hooks.
+    await waitForReconcile(
+      reconcilePluginSchedulesSpy,
+      "plugin schedule reconcile",
+    );
+    expect(reconcilePluginSourcesNowSpy).not.toHaveBeenCalled();
   });
 
   test("a failed toggle does not poke the schedule reconcile", async () => {

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -1671,27 +1671,27 @@ function reconcilePluginSchedulesInBackground(): void {
  * names WHICH resource is stale, not the new value. The origin client id is
  * threaded through for self-echo suppression.
  */
-function handleEnablePlugin({ pathParams = {}, headers }: RouteHandlerArgs) {
+async function handleEnablePlugin({
+  pathParams = {},
+  headers,
+}: RouteHandlerArgs) {
   try {
     enablePlugin(pathParams.name ?? "");
-    publishPluginsChanged(getOriginClientId(headers));
-    // A plugin the boot scan skipped for its sentinel has no hooks, tools or
-    // MCP servers in the caches, so clearing the sentinel is not enough to
-    // bring it up. Run the same imperative source reconcile the install and
-    // upgrade routes use, which activates the plugin and then converges its
-    // schedules and MCP servers. Fire-and-forget: the sentinel is already off
-    // disk, so a reconcile failure must not turn a successful enable into a
-    // route error.
-    void reconcilePluginSourcesNow().catch((err: unknown) => {
-      log.error(
-        { err },
-        "plugin source reconcile after a plugin enable failed",
-      );
-    });
-    return { ok: true };
   } catch (err) {
     throw mapTogglePluginError(err);
   }
+  // A plugin the boot scan skipped for its sentinel has no hooks, tools or
+  // MCP servers in the caches, so clearing the sentinel is not enough to
+  // bring it up. Run the same imperative source reconcile the install and
+  // upgrade routes use, which activates the plugin and then converges its
+  // schedules and MCP servers. Awaited, like the install route, so a client
+  // that lists tools right after enabling sees the plugin up; the reconcile
+  // contains its own failures, so a broken plugin cannot turn a successful
+  // enable into a route error. The invalidation publishes after it for the
+  // same reason: refetching clients should see the post-activation state.
+  await reconcilePluginSourcesNow();
+  publishPluginsChanged(getOriginClientId(headers));
+  return { ok: true };
 }
 
 function handleDisablePlugin({ pathParams = {}, headers }: RouteHandlerArgs) {

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -1643,7 +1643,7 @@ function mapTogglePluginError(err: unknown): RouteError {
 
 /**
  * Converge plugin-declared schedules against the sentinel this route just
- * wrote, so a toggled plugin's rows disarm or re-arm now rather than at the
+ * wrote, so a disabled plugin's rows disarm now rather than at the
  * reconciler's next backstop sweep.
  *
  * Fire-and-forget: the toggle itself already succeeded on disk, so a reconcile
@@ -1675,7 +1675,19 @@ function handleEnablePlugin({ pathParams = {}, headers }: RouteHandlerArgs) {
   try {
     enablePlugin(pathParams.name ?? "");
     publishPluginsChanged(getOriginClientId(headers));
-    reconcilePluginSchedulesInBackground();
+    // A plugin the boot scan skipped for its sentinel has no hooks, tools or
+    // MCP servers in the caches, so clearing the sentinel is not enough to
+    // bring it up. Run the same imperative source reconcile the install and
+    // upgrade routes use, which activates the plugin and then converges its
+    // schedules and MCP servers. Fire-and-forget: the sentinel is already off
+    // disk, so a reconcile failure must not turn a successful enable into a
+    // route error.
+    void reconcilePluginSourcesNow().catch((err: unknown) => {
+      log.error(
+        { err },
+        "plugin source reconcile after a plugin enable failed",
+      );
+    });
     return { ok: true };
   } catch (err) {
     throw mapTogglePluginError(err);


### PR DESCRIPTION
## Summary
- Enabling an installed plugin now runs the same imperative source reconcile the install and upgrade routes use, awaited before the route returns, so a plugin that was disabled at daemon boot comes up on enable: hooks, tools, MCP servers, and declared schedules, without waiting for a restart.
- Disable is unchanged and still works through the .disabled sentinel's read-time filtering. Default (bundled) plugins keep their existing enable behavior; their lifecycle is owned by the defaults bootstrap, not the workspace source reconcile.