### PR TITLE
feat(gateway): pairing challenge store supports listing, approve-by-id, and deny

### DIFF
--- a/gateway/src/__tests__/remote-web-pairing-challenge.test.ts
+++ b/gateway/src/__tests__/remote-web-pairing-challenge.test.ts
@@ -3,7 +3,13 @@ import { beforeEach, describe, expect, test } from "bun:test";
 const { handleCreateRemoteWebPairingChallenge } =
   await import("../http/routes/remote-web-pairing-challenge.js");
 const {
+  approveRemoteWebPairingChallengeById,
+  claimRemoteWebPairingChallengeExchange,
+  completeRemoteWebPairingChallengeExchange,
+  createRemoteWebPairingChallenge,
+  denyRemoteWebPairingChallengeById,
   getRemoteWebPairingChallengeForTests,
+  listPendingRemoteWebPairingChallenges,
   resetRemoteWebPairingChallengesForTests,
   setRemoteWebPairingChallengeNowForTests,
 } = await import("../remote-web/pairing-challenge-store.js");
@@ -254,6 +260,19 @@ describe("remote web pairing challenge", () => {
     });
   });
 
+  test("records requester metadata from the mint request", async () => {
+    const req = makeRequest();
+    req.headers.set("user-agent", "PairBrowser/1.0");
+    const res = await handleCreateRemoteWebPairingChallenge(req, LOOPBACK_IP);
+    const body = (await res.json()) as { userCode: string };
+
+    const record = getRemoteWebPairingChallengeForTests(body.userCode);
+    expect(record?.requesterIp).toBe(LOOPBACK_IP);
+    expect(record?.requesterUserAgent).toBe("PairBrowser/1.0");
+    expect(record?.userCode).toBe(body.userCode);
+    expect(record?.id).toBeTruthy();
+  });
+
   test("rejects oversized challenge request bodies", async () => {
     const body = JSON.stringify({ publicBaseUrl: "A".repeat(1024) });
     const res = await handleCreateRemoteWebPairingChallenge(
@@ -267,5 +286,171 @@ describe("remote web pairing challenge", () => {
     );
 
     expect(res.status).toBe(413);
+  });
+});
+
+describe("remote web pairing request list/approve/deny", () => {
+  const REQUESTER = { ip: REMOTE_IP, userAgent: "PairBrowser/1.0" };
+
+  test("lists only pending, non-expired challenges newest first with requester metadata", () => {
+    let now = 1_000;
+    setRemoteWebPairingChallengeNowForTests(() => now);
+
+    const first = createRemoteWebPairingChallenge(PUBLIC_BASE_URL, REQUESTER);
+    now = 2_000;
+    const second = createRemoteWebPairingChallenge(PUBLIC_BASE_URL, {
+      ip: "198.51.100.7",
+      userAgent: null,
+    });
+    now = 3_000;
+    const approved = createRemoteWebPairingChallenge(
+      PUBLIC_BASE_URL,
+      REQUESTER,
+    );
+    const approvedRecord = getRemoteWebPairingChallengeForTests(
+      approved.userCode,
+    );
+    expect(
+      approveRemoteWebPairingChallengeById(approvedRecord!.id).status,
+    ).toBe("approved");
+
+    const requests = listPendingRemoteWebPairingChallenges();
+
+    expect(requests.map((r) => r.userCode)).toEqual([
+      second.userCode,
+      first.userCode,
+    ]);
+    expect(requests[0]).toEqual({
+      requestId: getRemoteWebPairingChallengeForTests(second.userCode)!.id,
+      userCode: second.userCode,
+      publicBaseUrl: PUBLIC_BASE_URL,
+      requestedAt: new Date(2_000).toISOString(),
+      expiresAt: new Date(2_000 + 600_000).toISOString(),
+      requesterIp: "198.51.100.7",
+      requesterUserAgent: null,
+    });
+    expect(requests[1]?.requesterIp).toBe(REMOTE_IP);
+    expect(requests[1]?.requesterUserAgent).toBe("PairBrowser/1.0");
+
+    now = 1_000 + 600_000;
+    expect(
+      listPendingRemoteWebPairingChallenges().map((r) => r.userCode),
+    ).toEqual([second.userCode]);
+  });
+
+  test("approve-by-id transitions pending to approved and the exchange succeeds", () => {
+    setRemoteWebPairingChallengeNowForTests(() => 1_000);
+    const challenge = createRemoteWebPairingChallenge(
+      PUBLIC_BASE_URL,
+      REQUESTER,
+    );
+    const record = getRemoteWebPairingChallengeForTests(challenge.userCode);
+
+    const result = approveRemoteWebPairingChallengeById(record!.id);
+
+    expect(result).toEqual({
+      status: "approved",
+      verificationUri: `${PUBLIC_BASE_URL}/assistant/pair`,
+      expiresAt: new Date(1_000 + 600_000).toISOString(),
+    });
+    expect(
+      claimRemoteWebPairingChallengeExchange(challenge.deviceCode).status,
+    ).toBe("approved");
+  });
+
+  test("approve-by-id returns invalid for unknown ids", () => {
+    expect(approveRemoteWebPairingChallengeById("missing-id")).toEqual({
+      status: "invalid",
+    });
+  });
+
+  test("approve-by-id on an expired challenge returns expired and evicts it", () => {
+    let now = 1_000;
+    setRemoteWebPairingChallengeNowForTests(() => now);
+    const challenge = createRemoteWebPairingChallenge(
+      PUBLIC_BASE_URL,
+      REQUESTER,
+    );
+    const record = getRemoteWebPairingChallengeForTests(challenge.userCode);
+
+    now = 1_000 + 600_000;
+    expect(approveRemoteWebPairingChallengeById(record!.id)).toEqual({
+      status: "expired",
+    });
+    expect(
+      getRemoteWebPairingChallengeForTests(challenge.userCode),
+    ).toBeUndefined();
+    expect(
+      claimRemoteWebPairingChallengeExchange(challenge.deviceCode).status,
+    ).toBe("invalid");
+  });
+
+  test("approve-by-id on exchanging and consumed challenges returns invalid", () => {
+    setRemoteWebPairingChallengeNowForTests(() => 1_000);
+    const challenge = createRemoteWebPairingChallenge(
+      PUBLIC_BASE_URL,
+      REQUESTER,
+    );
+    const record = getRemoteWebPairingChallengeForTests(challenge.userCode);
+
+    expect(approveRemoteWebPairingChallengeById(record!.id).status).toBe(
+      "approved",
+    );
+    expect(
+      claimRemoteWebPairingChallengeExchange(challenge.deviceCode).status,
+    ).toBe("approved");
+    expect(approveRemoteWebPairingChallengeById(record!.id)).toEqual({
+      status: "invalid",
+    });
+
+    completeRemoteWebPairingChallengeExchange(challenge.deviceCode);
+    expect(approveRemoteWebPairingChallengeById(record!.id)).toEqual({
+      status: "invalid",
+    });
+  });
+
+  test("deny removes the challenge from both lookup maps", () => {
+    setRemoteWebPairingChallengeNowForTests(() => 1_000);
+    const challenge = createRemoteWebPairingChallenge(
+      PUBLIC_BASE_URL,
+      REQUESTER,
+    );
+    const record = getRemoteWebPairingChallengeForTests(challenge.userCode);
+
+    expect(denyRemoteWebPairingChallengeById(record!.id)).toEqual({
+      status: "denied",
+    });
+    expect(
+      getRemoteWebPairingChallengeForTests(challenge.userCode),
+    ).toBeUndefined();
+    expect(
+      claimRemoteWebPairingChallengeExchange(challenge.deviceCode).status,
+    ).toBe("invalid");
+    expect(listPendingRemoteWebPairingChallenges()).toEqual([]);
+  });
+
+  test("deny of a non-pending challenge returns invalid", () => {
+    setRemoteWebPairingChallengeNowForTests(() => 1_000);
+    const challenge = createRemoteWebPairingChallenge(
+      PUBLIC_BASE_URL,
+      REQUESTER,
+    );
+    const record = getRemoteWebPairingChallengeForTests(challenge.userCode);
+    expect(approveRemoteWebPairingChallengeById(record!.id).status).toBe(
+      "approved",
+    );
+
+    expect(denyRemoteWebPairingChallengeById(record!.id)).toEqual({
+      status: "invalid",
+    });
+    expect(
+      claimRemoteWebPairingChallengeExchange(challenge.deviceCode).status,
+    ).toBe("approved");
+  });
+
+  test("deny of an unknown id returns invalid", () => {
+    expect(denyRemoteWebPairingChallengeById("missing-id")).toEqual({
+      status: "invalid",
+    });
   });
 });

--- a/gateway/src/__tests__/remote-web-pairing-token.test.ts
+++ b/gateway/src/__tests__/remote-web-pairing-token.test.ts
@@ -48,6 +48,7 @@ const {
 
 const GUARDIAN_ID = "guardian-001";
 const PUBLIC_BASE_URL = "https://paired.example.com";
+const TEST_REQUESTER = { ip: "203.0.113.10", userAgent: "test-agent" };
 
 let testRoot: string;
 
@@ -203,7 +204,10 @@ afterEach(() => {
 describe("remote web pairing token exchange", () => {
   test("returns pending before the user approves the code", async () => {
     setRemoteWebPairingChallengeNowForTests(() => 1_000);
-    const challenge = createRemoteWebPairingChallenge(PUBLIC_BASE_URL);
+    const challenge = createRemoteWebPairingChallenge(
+      PUBLIC_BASE_URL,
+      TEST_REQUESTER,
+    );
 
     const res = await handleRemoteWebPairingToken(
       makeTokenRequest({ deviceCode: challenge.deviceCode }),
@@ -220,7 +224,10 @@ describe("remote web pairing token exchange", () => {
   });
 
   test("approved device code mints access token and HttpOnly refresh cookies once", async () => {
-    const challenge = createRemoteWebPairingChallenge(PUBLIC_BASE_URL);
+    const challenge = createRemoteWebPairingChallenge(
+      PUBLIC_BASE_URL,
+      TEST_REQUESTER,
+    );
     expect(approveRemoteWebPairingChallenge(challenge.userCode).status).toBe(
       "approved",
     );
@@ -268,7 +275,10 @@ describe("remote web pairing token exchange", () => {
   });
 
   test("browser refresh rotates using only the HttpOnly refresh cookie", async () => {
-    const challenge = createRemoteWebPairingChallenge(PUBLIC_BASE_URL);
+    const challenge = createRemoteWebPairingChallenge(
+      PUBLIC_BASE_URL,
+      TEST_REQUESTER,
+    );
     expect(approveRemoteWebPairingChallenge(challenge.userCode).status).toBe(
       "approved",
     );
@@ -317,7 +327,10 @@ describe("remote web pairing token exchange", () => {
   });
 
   test("browser refresh rejects non-same-origin fetch metadata", async () => {
-    const challenge = createRemoteWebPairingChallenge(PUBLIC_BASE_URL);
+    const challenge = createRemoteWebPairingChallenge(
+      PUBLIC_BASE_URL,
+      TEST_REQUESTER,
+    );
     expect(approveRemoteWebPairingChallenge(challenge.userCode).status).toBe(
       "approved",
     );
@@ -355,7 +368,10 @@ describe("remote web pairing token exchange", () => {
   });
 
   test("browser refresh falls back to same-origin request headers when fetch metadata is missing", async () => {
-    const challenge = createRemoteWebPairingChallenge(PUBLIC_BASE_URL);
+    const challenge = createRemoteWebPairingChallenge(
+      PUBLIC_BASE_URL,
+      TEST_REQUESTER,
+    );
     expect(approveRemoteWebPairingChallenge(challenge.userCode).status).toBe(
       "approved",
     );
@@ -381,7 +397,10 @@ describe("remote web pairing token exchange", () => {
       cookieValue(setCookies(originRefresh), "vellum_web_refresh"),
     ).not.toBe(originRefreshToken);
 
-    const refererChallenge = createRemoteWebPairingChallenge(PUBLIC_BASE_URL);
+    const refererChallenge = createRemoteWebPairingChallenge(
+      PUBLIC_BASE_URL,
+      TEST_REQUESTER,
+    );
     expect(
       approveRemoteWebPairingChallenge(refererChallenge.userCode).status,
     ).toBe("approved");
@@ -407,7 +426,10 @@ describe("remote web pairing token exchange", () => {
   });
 
   test("browser refresh rejects missing fetch metadata without a same-origin fallback", async () => {
-    const challenge = createRemoteWebPairingChallenge(PUBLIC_BASE_URL);
+    const challenge = createRemoteWebPairingChallenge(
+      PUBLIC_BASE_URL,
+      TEST_REQUESTER,
+    );
     expect(approveRemoteWebPairingChallenge(challenge.userCode).status).toBe(
       "approved",
     );
@@ -476,7 +498,10 @@ describe("remote web pairing token exchange", () => {
   test("path-prefixed public base URLs keep refresh cookies on the public refresh path", async () => {
     const publicBaseUrl = `${PUBLIC_BASE_URL}/assistant-123`;
     const expectedCookiePath = "/assistant-123/v1/guardian/refresh";
-    const challenge = createRemoteWebPairingChallenge(publicBaseUrl);
+    const challenge = createRemoteWebPairingChallenge(
+      publicBaseUrl,
+      TEST_REQUESTER,
+    );
     expect(approveRemoteWebPairingChallenge(challenge.userCode).status).toBe(
       "approved",
     );
@@ -529,7 +554,10 @@ describe("remote web pairing token exchange", () => {
   });
 
   test("assistant mirror failure does not fail the gateway-committed binding", async () => {
-    const challenge = createRemoteWebPairingChallenge(PUBLIC_BASE_URL);
+    const challenge = createRemoteWebPairingChallenge(
+      PUBLIC_BASE_URL,
+      TEST_REQUESTER,
+    );
     expect(approveRemoteWebPairingChallenge(challenge.userCode).status).toBe(
       "approved",
     );
@@ -561,7 +589,10 @@ describe("remote web pairing token exchange", () => {
   });
 
   test("gateway binding write failure fails the mint and leaves the code retryable", async () => {
-    const challenge = createRemoteWebPairingChallenge(PUBLIC_BASE_URL);
+    const challenge = createRemoteWebPairingChallenge(
+      PUBLIC_BASE_URL,
+      TEST_REQUESTER,
+    );
     expect(approveRemoteWebPairingChallenge(challenge.userCode).status).toBe(
       "approved",
     );
@@ -612,7 +643,10 @@ describe("remote web pairing token exchange", () => {
   });
 
   test("guardian mint refusal fails closed with 503 and releases the approved code", async () => {
-    const challenge = createRemoteWebPairingChallenge(PUBLIC_BASE_URL);
+    const challenge = createRemoteWebPairingChallenge(
+      PUBLIC_BASE_URL,
+      TEST_REQUESTER,
+    );
     expect(approveRemoteWebPairingChallenge(challenge.userCode).status).toBe(
       "approved",
     );
@@ -684,7 +718,10 @@ describe("remote web pairing token exchange", () => {
 
   test("expired device code does not mint credentials", async () => {
     setRemoteWebPairingChallengeNowForTests(() => 1_000);
-    const challenge = createRemoteWebPairingChallenge(PUBLIC_BASE_URL);
+    const challenge = createRemoteWebPairingChallenge(
+      PUBLIC_BASE_URL,
+      TEST_REQUESTER,
+    );
     expect(approveRemoteWebPairingChallenge(challenge.userCode).status).toBe(
       "approved",
     );

--- a/gateway/src/http/routes/remote-web-pairing-challenge.ts
+++ b/gateway/src/http/routes/remote-web-pairing-challenge.ts
@@ -139,7 +139,10 @@ export async function handleCreateRemoteWebPairingChallenge(
   const capacityLimited = checkRemoteWebPairingChallengeCapacity();
   if (capacityLimited) return capacityLimitedResponse(capacityLimited);
 
-  const challenge = createRemoteWebPairingChallenge(publicBaseUrl);
+  const challenge = createRemoteWebPairingChallenge(publicBaseUrl, {
+    ip: clientIp,
+    userAgent: req.headers.get("user-agent"),
+  });
 
   return Response.json(challenge, {
     headers: { "Cache-Control": "no-store" },

--- a/gateway/src/remote-web/pairing-challenge-store.ts
+++ b/gateway/src/remote-web/pairing-challenge-store.ts
@@ -3,6 +3,7 @@ import { createHash, randomBytes, randomInt } from "node:crypto";
 import {
   REMOTE_WEB_PAIRING_CODE_TTL_MS,
   type RemoteWebPairingChallengeResponse,
+  type RemoteWebPairingRequestSummary,
   type RemoteWebPairingTokenPendingResponse,
   type RemoteWebPairingVerificationResponse,
 } from "@vellumai/service-contracts/remote-web-pairing";
@@ -15,12 +16,19 @@ const DEVICE_CODE_BYTES = 32;
 const POLL_INTERVAL_SECONDS = 5;
 
 export interface PendingRemoteWebPairingChallenge {
+  id: string;
   deviceCodeHash: string;
   userCodeHash: string;
+  // Deliberately plaintext: the loopback-gated list route shows it to the
+  // host approver. The hash fields remain the lookup keys.
+  userCode: string;
   publicBaseUrl: string;
   verificationUri: string;
   status: "pending" | "approved" | "exchanging" | "consumed";
+  createdAtMs: number;
   expiresAtMs: number;
+  requesterIp: string;
+  requesterUserAgent: string | null;
   approvedAtMs?: number;
   exchangeStartedAtMs?: number;
   consumedAtMs?: number;
@@ -77,11 +85,15 @@ function normalizeUserCode(code: string): string {
   return code.replace(/[^A-Z0-9]/gi, "").toUpperCase();
 }
 
+function deleteChallenge(challenge: PendingRemoteWebPairingChallenge): void {
+  challengesByUserCodeHash.delete(challenge.userCodeHash);
+  challengesByDeviceCodeHash.delete(challenge.deviceCodeHash);
+}
+
 function cleanupExpiredChallenges(now = nowMs()): void {
-  for (const [hash, challenge] of challengesByUserCodeHash) {
+  for (const challenge of challengesByUserCodeHash.values()) {
     if (challenge.expiresAtMs <= now) {
-      challengesByUserCodeHash.delete(hash);
-      challengesByDeviceCodeHash.delete(challenge.deviceCodeHash);
+      deleteChallenge(challenge);
     }
   }
 }
@@ -107,6 +119,7 @@ export function checkRemoteWebPairingChallengeCapacity(): RemoteWebPairingChalle
 
 export function createRemoteWebPairingChallenge(
   publicBaseUrl: string,
+  requester: { ip: string; userAgent: string | null },
 ): RemoteWebPairingChallengeResponse {
   cleanupExpiredChallenges();
 
@@ -120,14 +133,20 @@ export function createRemoteWebPairingChallenge(
   }
 
   const verificationUri = `${publicBaseUrl}/assistant/pair`;
-  const expiresAtMs = nowMs() + CODE_TTL_MS;
+  const createdAtMs = nowMs();
+  const expiresAtMs = createdAtMs + CODE_TTL_MS;
   const challenge: PendingRemoteWebPairingChallenge = {
+    id: randomBytes(16).toString("base64url"),
     deviceCodeHash,
     userCodeHash,
+    userCode,
     publicBaseUrl,
     verificationUri,
     status: "pending",
+    createdAtMs,
     expiresAtMs,
+    requesterIp: requester.ip,
+    requesterUserAgent: requester.userAgent,
   };
   challengesByUserCodeHash.set(userCodeHash, challenge);
   challengesByDeviceCodeHash.set(deviceCodeHash, challenge);
@@ -142,20 +161,16 @@ export function createRemoteWebPairingChallenge(
   };
 }
 
-export function approveRemoteWebPairingChallenge(
-  userCode: string,
+function approveChallenge(
+  challenge: PendingRemoteWebPairingChallenge,
 ): ApproveRemoteWebPairingChallengeResult {
-  const userCodeHash = hashSecret(normalizeUserCode(userCode));
-  const challenge = challengesByUserCodeHash.get(userCodeHash);
-  if (!challenge) return { status: "invalid" };
   if (challenge.status === "exchanging" || challenge.status === "consumed") {
     return { status: "invalid" };
   }
 
   const now = nowMs();
   if (challenge.expiresAtMs <= now) {
-    challengesByUserCodeHash.delete(userCodeHash);
-    challengesByDeviceCodeHash.delete(challenge.deviceCodeHash);
+    deleteChallenge(challenge);
     return { status: "expired" };
   }
 
@@ -168,6 +183,62 @@ export function approveRemoteWebPairingChallenge(
   };
 }
 
+export function approveRemoteWebPairingChallenge(
+  userCode: string,
+): ApproveRemoteWebPairingChallengeResult {
+  const userCodeHash = hashSecret(normalizeUserCode(userCode));
+  const challenge = challengesByUserCodeHash.get(userCodeHash);
+  if (!challenge) return { status: "invalid" };
+  return approveChallenge(challenge);
+}
+
+function findChallengeById(
+  id: string,
+): PendingRemoteWebPairingChallenge | undefined {
+  for (const challenge of challengesByUserCodeHash.values()) {
+    if (challenge.id === id) return challenge;
+  }
+  return undefined;
+}
+
+export function listPendingRemoteWebPairingChallenges(): RemoteWebPairingRequestSummary[] {
+  cleanupExpiredChallenges();
+
+  const pending = [...challengesByUserCodeHash.values()]
+    .filter((challenge) => challenge.status === "pending")
+    .sort((a, b) => b.createdAtMs - a.createdAtMs);
+
+  return pending.map((challenge) => ({
+    requestId: challenge.id,
+    userCode: challenge.userCode,
+    publicBaseUrl: challenge.publicBaseUrl,
+    requestedAt: new Date(challenge.createdAtMs).toISOString(),
+    expiresAt: new Date(challenge.expiresAtMs).toISOString(),
+    requesterIp: challenge.requesterIp,
+    requesterUserAgent: challenge.requesterUserAgent,
+  }));
+}
+
+export function approveRemoteWebPairingChallengeById(
+  id: string,
+): ApproveRemoteWebPairingChallengeResult {
+  const challenge = findChallengeById(id);
+  if (!challenge) return { status: "invalid" };
+  return approveChallenge(challenge);
+}
+
+export function denyRemoteWebPairingChallengeById(
+  id: string,
+): { status: "denied" } | { status: "invalid" } {
+  const challenge = findChallengeById(id);
+  if (!challenge || challenge.status !== "pending") {
+    return { status: "invalid" };
+  }
+
+  deleteChallenge(challenge);
+  return { status: "denied" };
+}
+
 export function claimRemoteWebPairingChallengeExchange(
   deviceCode: string,
 ): ClaimRemoteWebPairingChallengeExchangeResult {
@@ -177,8 +248,7 @@ export function claimRemoteWebPairingChallengeExchange(
 
   const now = nowMs();
   if (challenge.expiresAtMs <= now) {
-    challengesByDeviceCodeHash.delete(deviceCodeHash);
-    challengesByUserCodeHash.delete(challenge.userCodeHash);
+    deleteChallenge(challenge);
     return { status: "expired" };
   }
 


### PR DESCRIPTION
## Summary
- Challenge records gain an opaque id, plaintext display code, created-at, and requester metadata captured at mint
- New store functions: listPendingRemoteWebPairingChallenges, approveRemoteWebPairingChallengeById, denyRemoteWebPairingChallengeById
- Approve-by-code semantics unchanged (shared helper)

Part of plan: web-pair-approve.md (PR 2 of 6)