### PR TITLE
i18n(web): move the chat domain's toast copy into the catalog

### DIFF
--- a/clients/web/src/domains/chat/components/composer-settings-menu.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.tsx
@@ -17,6 +17,7 @@ import {
   type ReactNode,
 } from "react";
 
+import { t } from "@/i18n";
 import { useSupportsCompleteProfileSnapshots } from "@/lib/backwards-compat/complete-profile-snapshots";
 import {
   profilePickerLabel,
@@ -564,7 +565,9 @@ export function ComposerSettingsMenu({
               // No cache write needed here — just autoselect the new profile.
               void handleProfileSelect(name).then((selected) => {
                 if (!selected) {
-                  toast.error("Profile created, but couldn't switch to it");
+                  toast.error(
+                    t("chat:composerSettingsMenu.profileSwitchFailed"),
+                  );
                 }
               });
             },

--- a/clients/web/src/domains/chat/components/composer-settings-menu.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.tsx
@@ -471,7 +471,7 @@ export function ComposerSettingsMenu({
           // would send the user round the same failing loop.
           toast.error(
             badRequestMessage(error) ??
-              "Failed to switch profile. Please try again.",
+              t("chat:composerSettingsMenu.profileSwitchFallback"),
           );
         }
         return false;

--- a/clients/web/src/domains/chat/components/conversation-asset-actions.tsx
+++ b/clients/web/src/domains/chat/components/conversation-asset-actions.tsx
@@ -93,11 +93,11 @@ export const AppAssetActions: FC<AppAssetActionsProps> = ({
     setIsSharing(true);
     try {
       await shareApp(assistantId, app.id, app.name);
-      toast.success(t("chat:conversationAssetActions.appExported"), {
+      toast.success(t("chat:appAssetActions.appExported"), {
         description: `${app.name}.vellum`,
       });
     } catch (err) {
-      toast.error(t("chat:conversationAssetActions.shareFailed"), {
+      toast.error(t("chat:appAssetActions.shareFailed"), {
         description: err instanceof Error ? err.message : undefined,
       });
     } finally {
@@ -150,7 +150,7 @@ export const DocumentAssetActions: FC<DocumentAssetActionsProps> = ({
       parseAs: "blob",
     });
     if (!response?.ok || !blob) {
-      toast.error(t("chat:conversationAssetActions.pdfDownloadFailed"));
+      toast.error(t("chat:documentAssetActions.pdfDownloadFailed"));
       return;
     }
     const url = URL.createObjectURL(blob);

--- a/clients/web/src/domains/chat/components/conversation-asset-actions.tsx
+++ b/clients/web/src/domains/chat/components/conversation-asset-actions.tsx
@@ -13,6 +13,7 @@ import type { FC, KeyboardEvent, MouseEvent, ReactNode } from "react";
 import { ActionMenu, Button, toast } from "@vellumai/design-library";
 
 import { documentsByIdPdfGet } from "@/generated/daemon/sdk.gen";
+import { t } from "@/i18n";
 import { usePinnedAppsStore } from "@/stores/pinned-apps-store";
 import type { AppSummary } from "@/types/app-types";
 import type { DocumentSummary } from "@/types/document-types";
@@ -92,9 +93,11 @@ export const AppAssetActions: FC<AppAssetActionsProps> = ({
     setIsSharing(true);
     try {
       await shareApp(assistantId, app.id, app.name);
-      toast.success("App exported", { description: `${app.name}.vellum` });
+      toast.success(t("chat:conversationAssetActions.appExported"), {
+        description: `${app.name}.vellum`,
+      });
     } catch (err) {
-      toast.error("Failed to share app", {
+      toast.error(t("chat:conversationAssetActions.shareFailed"), {
         description: err instanceof Error ? err.message : undefined,
       });
     } finally {
@@ -147,7 +150,7 @@ export const DocumentAssetActions: FC<DocumentAssetActionsProps> = ({
       parseAs: "blob",
     });
     if (!response?.ok || !blob) {
-      toast.error("Failed to download PDF");
+      toast.error(t("chat:conversationAssetActions.pdfDownloadFailed"));
       return;
     }
     const url = URL.createObjectURL(blob);

--- a/clients/web/src/domains/chat/components/local-file/local-file-embed.tsx
+++ b/clients/web/src/domains/chat/components/local-file/local-file-embed.tsx
@@ -20,6 +20,7 @@ import { localFileKindFromFilename } from "@/domains/chat/components/local-file/
 import { MAX_INLINE_MEDIA_BYTES } from "@/domains/chat/components/local-file/local-file-limits";
 import { LocalFileMenu } from "@/domains/chat/components/local-file/local-file-menu";
 import { resolveLocalFileTarget } from "@/domains/chat/components/local-file/local-file-target";
+import { t } from "@/i18n";
 import {
   useLocalFileInfo,
   useLocalFileObjectUrl,
@@ -100,7 +101,7 @@ export function LocalFileEmbed({
       await el.requestPictureInPicture();
     } catch {
       el.disablePictureInPicture = true;
-      toast.error("Picture in Picture isn't available");
+      toast.error(t("chat:localFileEmbed.pictureInPictureUnavailable"));
       return;
     }
     el.addEventListener(

--- a/clients/web/src/domains/chat/components/local-file/local-file-link.tsx
+++ b/clients/web/src/domains/chat/components/local-file/local-file-link.tsx
@@ -15,6 +15,7 @@ import {
 import { filenameFromHref } from "@/domains/chat/components/local-file/local-file-target";
 import { toggleLocalFile } from "@/domains/chat/components/local-file/open-local-file";
 import { workspaceBasenameOf } from "@/domains/chat/utils/workspace-path-links";
+import { t } from "@/i18n";
 import { useConversationStore } from "@/stores/conversation-store";
 
 export interface LocalFileLinkProps {
@@ -54,7 +55,7 @@ export function LocalFileLink({
       return;
     }
     if (workspacePath === null) {
-      toast.error("This file isn't available here");
+      toast.error(t("chat:localFileLink.unavailable"));
       return;
     }
     toggleLocalFile(workspacePath, filename, assistantId, conversationId);

--- a/clients/web/src/domains/chat/components/local-file/local-file-menu.tsx
+++ b/clients/web/src/domains/chat/components/local-file/local-file-menu.tsx
@@ -18,6 +18,7 @@ import type { KeyboardEvent, MouseEvent } from "react";
 
 import { Button, cn, Menu, toast } from "@vellumai/design-library";
 
+import { t } from "@/i18n";
 import { downloadWorkspaceFile } from "@/utils/download-workspace-file";
 import { openWorkspaceFile } from "@/utils/open-workspace-file";
 
@@ -64,7 +65,7 @@ export function LocalFileMenu({
         filename,
       });
     } catch {
-      toast.error("Failed to download file", { description: filename });
+      toast.error(t("chat:fileDownload.failed"), { description: filename });
     }
   }, [assistantId, filename, workspacePath]);
 

--- a/clients/web/src/domains/chat/components/local-file/preview/file-preview-container.tsx
+++ b/clients/web/src/domains/chat/components/local-file/preview/file-preview-container.tsx
@@ -32,6 +32,7 @@ import {
   useLocalFileInfo,
   workspaceFileBlobQuery,
 } from "@/domains/chat/components/local-file/use-local-file-info";
+import { t } from "@/i18n";
 import type { WorkspaceFilePreviewKind } from "@/stores/viewer-store";
 import { downloadWorkspaceFile } from "@/utils/download-workspace-file";
 import { openWorkspaceFile } from "@/utils/open-workspace-file";
@@ -146,7 +147,7 @@ export function FilePreviewContainer({
       path: workspacePath,
       filename: documentName,
     }).catch(() => {
-      toast.error("Failed to download file", { description: documentName });
+      toast.error(t("chat:fileDownload.failed"), { description: documentName });
     });
   }, [assistantId, documentName, workspacePath]);
 

--- a/clients/web/src/domains/chat/components/redacted-credential-chip.tsx
+++ b/clients/web/src/domains/chat/components/redacted-credential-chip.tsx
@@ -26,6 +26,7 @@ import { Check, Copy, Eye, EyeOff, KeyRound, Loader2 } from "lucide-react";
 import { useCallback, useRef, useState } from "react";
 
 import { credentialsRevealPost } from "@/generated/daemon/sdk.gen";
+import { t } from "@/i18n";
 import { copyToClipboard } from "@/lib/copy-to-clipboard";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { toast } from "@vellumai/design-library/components/toast";
@@ -125,7 +126,7 @@ export function RedactedCredentialChip({
       }
     } catch {
       if (revealVersionRef.current === myVersion) {
-        toast.error(`Couldn't reveal ${name}.`);
+        toast.error(t("chat:redactedCredentialChip.revealFailed", { name }));
       }
     } finally {
       if (revealVersionRef.current === myVersion) {

--- a/clients/web/src/domains/chat/hooks/use-conversation-loader.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-loader.ts
@@ -1,3 +1,4 @@
+import { t } from "@/i18n";
 import { captureError } from "@/lib/sentry/capture-error";
 import { useViewerStore } from "@/stores/viewer-store";
 
@@ -216,7 +217,7 @@ export function useConversationLoader({
       conversationListError instanceof ApiError &&
       conversationListError.status === 401
     ) {
-      toast.error("Failed to authenticate user.");
+      toast.error(t("chat:useConversationLoader.authFailed"));
     }
   }, [conversationListError]);
 

--- a/clients/web/src/domains/chat/hooks/use-conversation-secondary-actions.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-secondary-actions.ts
@@ -7,6 +7,7 @@
  * unarchive, pin, rename, mark read/unread) live in `useConversationActions`.
  */
 
+import { t } from "@/i18n";
 import { copyToClipboard } from "@/lib/copy-to-clipboard";
 import { captureError } from "@/lib/sentry/capture-error";
 import { useCallback, useEffect, useRef } from "react";
@@ -158,8 +159,8 @@ export function useConversationSecondaryActions({
         captureError(err, { context: "summarize_up_to_here" });
         toast.error(
           err instanceof ApiError && err.status === 409
-            ? "Your assistant is busy. Try again when it finishes replying."
-            : "Couldn't summarize the conversation",
+            ? t("chat:useConversationSecondaryActions.assistantBusy")
+            : t("chat:useConversationSecondaryActions.summarizeFailed"),
         );
       }
     },
@@ -189,8 +190,8 @@ export function useConversationSecondaryActions({
       captureError(err, { context: "retry_latest_turn" });
       toast.error(
         err instanceof ApiError && err.status === 409
-          ? "Your assistant is busy. Try again when it finishes replying."
-          : "Couldn't retry the response",
+          ? t("chat:useConversationSecondaryActions.assistantBusy")
+          : t("chat:useConversationSecondaryActions.retryFailed"),
       );
     }
   }, []);

--- a/clients/web/src/domains/chat/hooks/use-send-message.ts
+++ b/clients/web/src/domains/chat/hooks/use-send-message.ts
@@ -11,6 +11,7 @@
  * transforms from `send-message-utils`.
  */
 
+import { t } from "@/i18n";
 import { captureError } from "@/lib/sentry/capture-error";
 import { type MutableRefObject, useCallback, useRef } from "react";
 import { useQueryClient } from "@tanstack/react-query";
@@ -591,7 +592,7 @@ export function useSendMessage({
           throwOnError: false,
         });
         if (error || !data) {
-          toast.error("Couldn't run that command. Please try again.");
+          toast.error(t("chat:useSendMessage.commandFailed"));
           return;
         }
         useChatSessionStore.getState().addEphemeralMetaResult({
@@ -613,7 +614,7 @@ export function useSendMessage({
         }
       } catch (err) {
         captureError(err, { context: "run_local_meta_command" });
-        toast.error("Couldn't run that command. Please try again.");
+        toast.error(t("chat:useSendMessage.commandFailed"));
       }
     },
     [],
@@ -645,7 +646,7 @@ export function useSendMessage({
         // surface a notice rather than sending "/doctor …" as a normal turn.
         if (doctorGate === "gated") {
           useComposerStore.getState().setInput("");
-          toast.info("The Doctor isn't available on this assistant.");
+          toast.info(t("chat:useSendMessage.doctorUnavailable"));
           return;
         }
         if (doctorPrompt) {

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -505,7 +505,9 @@ export function TranscriptMessageBody({
       })();
     } else {
       toast.error(
-        `File not available for download${pending.isHost ? " (host file approval may have timed out)" : ""}`,
+        pending.isHost
+          ? t("chat:transcriptMessageBody.fileUnavailableHostTimeout")
+          : t("chat:transcriptMessageBody.fileUnavailable"),
         { description: pending.filename },
       );
     }

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -49,6 +49,7 @@ import { useCoarsePointerReveal } from "@/domains/chat/transcript/use-coarse-poi
 import { AssistantContentDisclosure } from "@/domains/chat/transcript/assistant-content-disclosure";
 import { parseInlineSurfaces } from "@/domains/chat/utils/parse-inline-surfaces";
 import { useSmoothStreamText } from "@/domains/chat/hooks/use-smooth-stream-text";
+import { t } from "@/i18n";
 import { useSupportsRedactedCredentialChips } from "@/lib/backwards-compat/use-supports-redacted-credential-chips";
 import { stopAcpRun } from "@/domains/chat/utils/acp-run-actions";
 import { stopBackgroundTask } from "@/domains/chat/utils/background-task-actions";
@@ -499,7 +500,7 @@ export function TranscriptMessageBody({
           }
           await saveFile(data, filename);
         } catch {
-          toast.error("Failed to download file", { description: filename });
+          toast.error(t("chat:fileDownload.failed"), { description: filename });
         }
       })();
     } else {

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -14,6 +14,10 @@
     "allowAndCreateRule": "Allow & Create Rule",
     "trigger": "More allow options"
   },
+  "appAssetActions": {
+    "appExported": "App exported",
+    "shareFailed": "Failed to share app"
+  },
   "assistantSideMenu": {
     "bulkActionMembersFailed": "Couldn't load every conversation in this section. Try again."
   },
@@ -172,11 +176,6 @@
     "closeAriaLabel": "Close",
     "title": "Conversation Actions"
   },
-  "conversationAssetActions": {
-    "appExported": "App exported",
-    "pdfDownloadFailed": "Failed to download PDF",
-    "shareFailed": "Failed to share app"
-  },
   "conversationAssets": {
     "ariaLabel": "Conversation assets, {count, plural, one {# item} other {# items}}",
     "ariaLabelUnseen": "Conversation assets, {count, plural, one {# item} other {# items}} (unseen changes)",
@@ -195,6 +194,9 @@
   },
   "detailPanelStopButton": {
     "tooltip": "Stop"
+  },
+  "documentAssetActions": {
+    "pdfDownloadFailed": "Failed to download PDF"
   },
   "exportProgressModal": {
     "cancel": "Cancel",

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -150,7 +150,8 @@
     "trigger": "Trigger"
   },
   "composerSettingsMenu": {
-    "profileSwitchFailed": "Profile created, but couldn't switch to it"
+    "profileSwitchFailed": "Profile created, but couldn't switch to it",
+    "profileSwitchFallback": "Failed to switch profile. Please try again."
   },
   "conversationActions": {
     "archive": "Archive",
@@ -577,6 +578,11 @@
   },
   "useConversationLoader": {
     "authFailed": "Failed to authenticate user."
+  },
+  "useConversationSecondaryActions": {
+    "assistantBusy": "Your assistant is busy. Try again when it finishes replying.",
+    "retryFailed": "Couldn't retry the response",
+    "summarizeFailed": "Couldn't summarize the conversation"
   },
   "useSendMessage": {
     "commandFailed": "Couldn't run that command. Please try again.",

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -531,6 +531,9 @@
     "responsePayload": "Response payload",
     "retry": "Retry"
   },
+  "redactedCredentialChip": {
+    "revealFailed": "Couldn't reveal {name}."
+  },
   "responseTab": {
     "argumentsPreview": "Arguments preview",
     "copySectionAria": "Copy section content",
@@ -575,6 +578,10 @@
     "noInputSchema": "No input schema - this tool takes no structured input.",
     "required": "required",
     "settings": "Settings"
+  },
+  "transcriptMessageBody": {
+    "fileUnavailable": "File not available for download",
+    "fileUnavailableHostTimeout": "File not available for download (host file approval may have timed out)"
   },
   "useConversationLoader": {
     "authFailed": "Failed to authenticate user."

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -145,6 +145,9 @@
     "tokenRangeWithReduction": "{before} → {after}  ({reduction})",
     "trigger": "Trigger"
   },
+  "composerSettingsMenu": {
+    "profileSwitchFailed": "Profile created, but couldn't switch to it"
+  },
   "conversationActions": {
     "archive": "Archive",
     "copyConversation": "Copy Full Conversation",
@@ -168,6 +171,11 @@
   "conversationActionsSheet": {
     "closeAriaLabel": "Close",
     "title": "Conversation Actions"
+  },
+  "conversationAssetActions": {
+    "appExported": "App exported",
+    "pdfDownloadFailed": "Failed to download PDF",
+    "shareFailed": "Failed to share app"
   },
   "conversationAssets": {
     "ariaLabel": "Conversation assets, {count, plural, one {# item} other {# items}}",
@@ -204,6 +212,9 @@
     "titleDone": "Export complete",
     "titleError": "Export failed",
     "titleRunning": "Exporting inspector data"
+  },
+  "fileDownload": {
+    "failed": "Failed to download file"
   },
   "inspectPage": {
     "accessDenied": "Inspector is available to Vellum staff, or when the settings-developer-nav developer flag is enabled.",
@@ -252,6 +263,12 @@
     "chipUpstreamType": "Upstream type",
     "noResponse": "The provider rejected this call and returned no response.",
     "title": "Call failed"
+  },
+  "localFileEmbed": {
+    "pictureInPictureUnavailable": "Picture in Picture isn't available"
+  },
+  "localFileLink": {
+    "unavailable": "This file isn't available here"
   },
   "memoryRouterPlaygroundPage": {
     "addOlderPairButton": "+ Add older pair",
@@ -555,5 +572,12 @@
     "noInputSchema": "No input schema - this tool takes no structured input.",
     "required": "required",
     "settings": "Settings"
+  },
+  "useConversationLoader": {
+    "authFailed": "Failed to authenticate user."
+  },
+  "useSendMessage": {
+    "commandFailed": "Couldn't run that command. Please try again.",
+    "doctorUnavailable": "The Doctor isn't available on this assistant."
   }
 }

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -531,6 +531,9 @@
     "responsePayload": "Carga de la respuesta",
     "retry": "Reintentar"
   },
+  "redactedCredentialChip": {
+    "revealFailed": "No se pudo revelar {name}."
+  },
   "responseTab": {
     "argumentsPreview": "Vista previa de argumentos",
     "copySectionAria": "Copiar contenido de la sección",
@@ -575,6 +578,10 @@
     "noInputSchema": "Sin esquema de entrada: esta herramienta no acepta entrada estructurada.",
     "required": "obligatorio",
     "settings": "Configuración"
+  },
+  "transcriptMessageBody": {
+    "fileUnavailable": "El archivo no está disponible para descargar",
+    "fileUnavailableHostTimeout": "El archivo no está disponible para descargar (puede que la aprobación del archivo en el host haya caducado)"
   },
   "useConversationLoader": {
     "authFailed": "No se pudo autenticar al usuario."

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -150,7 +150,8 @@
     "trigger": "Disparador"
   },
   "composerSettingsMenu": {
-    "profileSwitchFailed": "Perfil creado, pero no se pudo cambiar a él"
+    "profileSwitchFailed": "Perfil creado, pero no se pudo cambiar a él",
+    "profileSwitchFallback": "No se pudo cambiar de perfil. Inténtalo de nuevo."
   },
   "conversationActions": {
     "archive": "Archivar",
@@ -577,6 +578,11 @@
   },
   "useConversationLoader": {
     "authFailed": "No se pudo autenticar al usuario."
+  },
+  "useConversationSecondaryActions": {
+    "assistantBusy": "Tu asistente está ocupado. Inténtalo de nuevo cuando termine de responder.",
+    "retryFailed": "No se pudo reintentar la respuesta",
+    "summarizeFailed": "No se pudo resumir la conversación"
   },
   "useSendMessage": {
     "commandFailed": "No se pudo ejecutar ese comando. Inténtalo de nuevo.",

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -14,6 +14,10 @@
     "allowAndCreateRule": "Permitir y crear regla",
     "trigger": "Más opciones para permitir"
   },
+  "appAssetActions": {
+    "appExported": "Aplicación exportada",
+    "shareFailed": "No se pudo compartir la aplicación"
+  },
   "assistantSideMenu": {
     "bulkActionMembersFailed": "No se pudieron cargar todas las conversaciones de esta sección. Inténtalo de nuevo."
   },
@@ -172,11 +176,6 @@
     "closeAriaLabel": "Cerrar",
     "title": "Acciones de conversación"
   },
-  "conversationAssetActions": {
-    "appExported": "Aplicación exportada",
-    "pdfDownloadFailed": "No se pudo descargar el PDF",
-    "shareFailed": "No se pudo compartir la aplicación"
-  },
   "conversationAssets": {
     "ariaLabel": "Recursos de la conversación, {count, plural, one {# elemento} other {# elementos}}",
     "ariaLabelUnseen": "Recursos de la conversación, {count, plural, one {# elemento} other {# elementos}} (cambios sin ver)",
@@ -195,6 +194,9 @@
   },
   "detailPanelStopButton": {
     "tooltip": "Detener"
+  },
+  "documentAssetActions": {
+    "pdfDownloadFailed": "No se pudo descargar el PDF"
   },
   "exportProgressModal": {
     "cancel": "Cancelar",

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -145,6 +145,9 @@
     "tokenRangeWithReduction": "{before} → {after}  ({reduction})",
     "trigger": "Disparador"
   },
+  "composerSettingsMenu": {
+    "profileSwitchFailed": "Perfil creado, pero no se pudo cambiar a él"
+  },
   "conversationActions": {
     "archive": "Archivar",
     "copyConversation": "Copiar conversación completa",
@@ -168,6 +171,11 @@
   "conversationActionsSheet": {
     "closeAriaLabel": "Cerrar",
     "title": "Acciones de conversación"
+  },
+  "conversationAssetActions": {
+    "appExported": "Aplicación exportada",
+    "pdfDownloadFailed": "No se pudo descargar el PDF",
+    "shareFailed": "No se pudo compartir la aplicación"
   },
   "conversationAssets": {
     "ariaLabel": "Recursos de la conversación, {count, plural, one {# elemento} other {# elementos}}",
@@ -204,6 +212,9 @@
     "titleDone": "Exportación completa",
     "titleError": "Error al exportar",
     "titleRunning": "Exportando datos del inspector"
+  },
+  "fileDownload": {
+    "failed": "No se pudo descargar el archivo"
   },
   "inspectPage": {
     "accessDenied": "El inspector está disponible para el personal de Vellum o cuando la marca de desarrollador settings-developer-nav está habilitada.",
@@ -252,6 +263,12 @@
     "chipUpstreamType": "Tipo ascendente",
     "noResponse": "El proveedor rechazó esta llamada y no devolvió respuesta.",
     "title": "Llamada fallida"
+  },
+  "localFileEmbed": {
+    "pictureInPictureUnavailable": "Imagen sobre imagen no está disponible"
+  },
+  "localFileLink": {
+    "unavailable": "Este archivo no está disponible aquí"
   },
   "memoryRouterPlaygroundPage": {
     "addOlderPairButton": "+ Añadir par más antiguo",
@@ -555,5 +572,12 @@
     "noInputSchema": "Sin esquema de entrada: esta herramienta no acepta entrada estructurada.",
     "required": "obligatorio",
     "settings": "Configuración"
+  },
+  "useConversationLoader": {
+    "authFailed": "No se pudo autenticar al usuario."
+  },
+  "useSendMessage": {
+    "commandFailed": "No se pudo ejecutar ese comando. Inténtalo de nuevo.",
+    "doctorUnavailable": "El Doctor no está disponible en este asistente."
   }
 }


### PR DESCRIPTION
## TL;DR

Eighteen toasts in `domains/chat` rendered English literals. They now read from the `chat` catalog, in English and Spanish, through fourteen keys. Four of the sentences were written more than once, so this is a deduplication as much as a translation.

Follow-on from #40768, which converted the id-copy toasts and where Codex asked for exactly this.

## Why the lint rule never caught these

`local/no-untranslated-strings` reads JSX text and props. A string handed to `toast.error(...)` from a `catch` block is neither, and `docs/I18N.md` says so directly: *"copy that reaches the screen from somewhere else is invisible to it: string literals in `.ts` data modules, messages passed to `setError()` or returned by a helper."* A clean lint run over this domain was never evidence about this copy.

## Fourteen keys, eighteen sites

Four sentences were written in more than one place:

| Sentence | Was written in | Now |
| --- | --- | --- |
| "Failed to download file" | `transcript-message-body.tsx`, `local-file-menu.tsx`, `file-preview-container.tsx` | `chat:fileDownload.failed` |
| "Couldn't run that command. Please try again." | `use-send-message.ts`, twice | `chat:useSendMessage.commandFailed` |
| "Your assistant is busy. Try again when it finishes replying." | `use-conversation-secondary-actions.ts`, twice | `chat:useConversationSecondaryActions.assistantBusy` |

That is the Single Source of Truth rule as much as an i18n one: repeated copies of a user-facing sentence are repeated chances to reword one and not the others.

## Correction, and how the last four were found

The first commit claimed no literal `toast.*` copy remained in `domains/chat`. That was **false**, and the review caught it.

The sweep behind it matched `toast.<level>(` followed immediately by a quote, so it only saw calls whose first argument is a bare literal. Copy reached through an expression was invisible to it, which is the lint rule's own blind spot reproduced in the grep written to work around it. Two forms escaped:

- a `badRequestMessage(error) ?? "..."` fallback in `composer-settings-menu.tsx` (flagged by Vex), and
- two ternaries in `use-conversation-secondary-actions.ts` carrying three sentences. That file was untouched by the first commit, so it sat outside the review diff and no bot would have raised it.

The verification now matches every `toast.*` call and inspects its whole argument list rather than its first token, and reports none remaining.

## Two judgment calls worth reviewing

**`fileDownload` is a concern, not a component.** The catalog's convention is `<component>.<slot>`, and no component owns a string used by three of them. The alternative was three keys holding one identical sentence, which is the duplication this change removes. `copyIdToClipboard` is existing precedent for a non-component owner.

**Two strings stay duplicated across namespaces on purpose.** `library:libraryAppCard.exported` and `libraryAppCard.shareFailed` already carry "App exported" and "Failed to share app" verbatim. Namespace follows the owning directory, so `conversation-asset-actions.tsx` reads its own `chat:` keys rather than reaching into `library:` — a cross-namespace read would couple two domains the boundary rule keeps apart, and either may reword without the other. I reused the shipped Spanish for both so they do not start out disagreeing.

## Spanish

Follows wording the catalogs already ship for these sentences (`library` for the app strings, `account` and `workspace` for the failure register), and mirrors each English string's punctuation. It has not been reviewed by a native speaker; ten of the fourteen are my own translations rather than reused ones.

## Why it is safe

- Every site is an event handler or a `catch` block, so the bound `t` from `@/i18n` is correct. None is rendered output that must survive a language switch, which is the case that needs `useTranslation()`.
- The keys are validated by `tsc`: a misspelled key fails the build. I verified that rather than assuming it, by breaking a key deliberately and confirming the error and its suggestion.
- `bunx tsc --noEmit`, eslint (0 errors), and the pinned prettier all pass.

## Not included

`domains/chat` is **not** added to `i18nEnforcedPaths`. Converting the toasts does not clear the domain, which still has English in JSX and in other `.ts` modules, and `I18N.md` forbids adding a path that still has violations.

The guard here is `catalogs.test.ts`, which fails on any English key no call site references. Reverting one of these to a literal orphans its key and breaks the build.
