### PR TITLE
feat(web): pair-device client functions for pending pairing requests

### DIFF
--- a/clients/web/src/domains/settings/pair-device/pair-device-client.test.ts
+++ b/clients/web/src/domains/settings/pair-device/pair-device-client.test.ts
@@ -4,6 +4,8 @@ import {
   approvePairingRequest,
   denyPairingRequest,
   listPendingPairingRequests,
+  mintDevicePairing,
+  PAIRING_CONNECTIVITY_HINT,
   PairDeviceError,
 } from "./pair-device-client";
 
@@ -39,6 +41,18 @@ function pendingRequest() {
     requesterIp: "203.0.113.7",
     requesterUserAgent: "Mozilla/5.0",
   };
+}
+
+async function capturePairDeviceError(
+  promise: Promise<unknown>,
+): Promise<PairDeviceError> {
+  try {
+    await promise;
+  } catch (err) {
+    expect(err).toBeInstanceOf(PairDeviceError);
+    return err as PairDeviceError;
+  }
+  throw new Error("expected the promise to reject");
 }
 
 beforeEach(() => {
@@ -77,14 +91,16 @@ describe("listPendingPairingRequests", () => {
     expect(await listPendingPairingRequests({ base: BASE })).toEqual([]);
   });
 
-  test("throws PairDeviceError with the server's message on a non-OK response", async () => {
+  test("throws PairDeviceError with the server's message and no hint on a non-OK response", async () => {
     installFetch(() =>
       jsonResponse({ error: { message: "Not available." } }, 503),
     );
 
-    await expect(listPendingPairingRequests({ base: BASE })).rejects.toThrow(
-      new PairDeviceError("Not available."),
+    const err = await capturePairDeviceError(
+      listPendingPairingRequests({ base: BASE }),
     );
+    expect(err.message).toBe("Not available.");
+    expect(err.hint).toBeUndefined();
   });
 
   test("falls back to a status message when the error body is not JSON", async () => {
@@ -151,14 +167,16 @@ describe("approvePairingRequest", () => {
     expect(headers.get("Authorization")).toBeNull();
   });
 
-  test("throws PairDeviceError with the server's message on a non-OK response", async () => {
+  test("throws PairDeviceError with the server's message and no hint on a non-OK response", async () => {
     installFetch(() =>
       jsonResponse({ error: { message: "Unknown request." } }, 404),
     );
 
-    await expect(
+    const err = await capturePairDeviceError(
       approvePairingRequest({ base: BASE, requestId: "req-x" }),
-    ).rejects.toThrow(new PairDeviceError("Unknown request."));
+    );
+    expect(err.message).toBe("Unknown request.");
+    expect(err.hint).toBeUndefined();
   });
 
   test("maps a network failure to PairDeviceError", async () => {
@@ -212,14 +230,16 @@ describe("denyPairingRequest", () => {
     ).toBeNull();
   });
 
-  test("throws PairDeviceError with the server's message on a non-OK response", async () => {
+  test("throws PairDeviceError with the server's message and no hint on a non-OK response", async () => {
     installFetch(() =>
       jsonResponse({ error: { message: "Request expired." } }, 410),
     );
 
-    await expect(
+    const err = await capturePairDeviceError(
       denyPairingRequest({ base: BASE, requestId: "req-1" }),
-    ).rejects.toThrow(new PairDeviceError("Request expired."));
+    );
+    expect(err.message).toBe("Request expired.");
+    expect(err.hint).toBeUndefined();
   });
 
   test("rethrows AbortError when the caller cancels", async () => {
@@ -235,5 +255,36 @@ describe("denyPairingRequest", () => {
         signal: controller.signal,
       }),
     ).rejects.toMatchObject({ name: "AbortError" });
+  });
+});
+
+describe("mintDevicePairing", () => {
+  const MINT_ARGS = { base: BASE, publicBaseUrl: "https://foo.ts.net" };
+
+  test("attaches the connectivity hint when the challenge mint is rejected", async () => {
+    installFetch(() =>
+      jsonResponse({ error: { message: "Mint refused." } }, 403),
+    );
+
+    const err = await capturePairDeviceError(mintDevicePairing(MINT_ARGS));
+    expect(err.message).toBe("Mint refused.");
+    expect(err.hint).toBe(PAIRING_CONNECTIVITY_HINT);
+  });
+
+  test("attaches the connectivity hint when the verification step is rejected", async () => {
+    installFetch((url) =>
+      url.endsWith("/v1/remote-web/pairing-challenge")
+        ? jsonResponse({
+            userCode: "WXYZ-1234",
+            deviceCode: "device-code-1",
+            verificationUri: "https://foo.ts.net/assistant/pair",
+            expiresAt: "2026-08-17T10:10:00.000Z",
+          })
+        : jsonResponse({ error: { message: "Verification failed." } }, 400),
+    );
+
+    const err = await capturePairDeviceError(mintDevicePairing(MINT_ARGS));
+    expect(err.message).toBe("Verification failed.");
+    expect(err.hint).toBe(PAIRING_CONNECTIVITY_HINT);
   });
 });

--- a/clients/web/src/domains/settings/pair-device/pair-device-client.test.ts
+++ b/clients/web/src/domains/settings/pair-device/pair-device-client.test.ts
@@ -1,0 +1,239 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import {
+  approvePairingRequest,
+  denyPairingRequest,
+  listPendingPairingRequests,
+  PairDeviceError,
+} from "./pair-device-client";
+
+const BASE = "http://localhost:3000/assistant/__gateway/20100";
+
+const originalFetch = globalThis.fetch;
+let requests: Array<{ url: string; init: RequestInit | undefined }> = [];
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function installFetch(respond: (url: string) => Response | Promise<Response>) {
+  const fetchMock = mock(async (input: string | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    requests.push({ url, init });
+    return respond(url);
+  });
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  return fetchMock;
+}
+
+function pendingRequest() {
+  return {
+    requestId: "req-1",
+    userCode: "WXYZ-1234",
+    publicBaseUrl: "https://foo.ts.net",
+    requestedAt: "2026-08-17T10:00:00.000Z",
+    expiresAt: "2026-08-17T10:10:00.000Z",
+    requesterIp: "203.0.113.7",
+    requesterUserAgent: "Mozilla/5.0",
+  };
+}
+
+beforeEach(() => {
+  requests = [];
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("listPendingPairingRequests", () => {
+  test("GETs the list route with no auth header and returns the requests", async () => {
+    installFetch(() => jsonResponse({ requests: [pendingRequest()] }));
+
+    const result = await listPendingPairingRequests({ base: BASE });
+
+    await expect(result).toEqual([pendingRequest()]);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.url).toBe(`${BASE}/v1/remote-web/pairing-requests`);
+    expect(requests[0]?.init?.method).toBe("GET");
+    expect(requests[0]?.init?.body).toBeUndefined();
+    expect(
+      new Headers(requests[0]?.init?.headers).get("Authorization"),
+    ).toBeNull();
+  });
+
+  test("returns [] when the requests field is missing", async () => {
+    installFetch(() => jsonResponse({}));
+
+    expect(await listPendingPairingRequests({ base: BASE })).toEqual([]);
+  });
+
+  test("returns [] when the requests field is not an array", async () => {
+    installFetch(() => jsonResponse({ requests: "nope" }));
+
+    expect(await listPendingPairingRequests({ base: BASE })).toEqual([]);
+  });
+
+  test("throws PairDeviceError with the server's message on a non-OK response", async () => {
+    installFetch(() =>
+      jsonResponse({ error: { message: "Not available." } }, 503),
+    );
+
+    await expect(listPendingPairingRequests({ base: BASE })).rejects.toThrow(
+      new PairDeviceError("Not available."),
+    );
+  });
+
+  test("falls back to a status message when the error body is not JSON", async () => {
+    installFetch(() => new Response("<html>oops</html>", { status: 500 }));
+
+    await expect(listPendingPairingRequests({ base: BASE })).rejects.toThrow(
+      "Pairing failed (HTTP 500).",
+    );
+  });
+
+  test("maps a network failure to PairDeviceError", async () => {
+    installFetch(() => {
+      throw new TypeError("Failed to fetch");
+    });
+
+    await expect(listPendingPairingRequests({ base: BASE })).rejects.toThrow(
+      "Couldn't reach the assistant. Make sure it's running and try again.",
+    );
+  });
+
+  test("rethrows AbortError when the caller cancels", async () => {
+    installFetch(() => {
+      throw new DOMException("Aborted", "AbortError");
+    });
+    const controller = new AbortController();
+
+    await expect(
+      listPendingPairingRequests({ base: BASE, signal: controller.signal }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  test("passes the abort signal through to fetch", async () => {
+    installFetch(() => jsonResponse({ requests: [] }));
+    const controller = new AbortController();
+
+    await listPendingPairingRequests({ base: BASE, signal: controller.signal });
+
+    await expect(requests[0]?.init?.signal).toBe(controller.signal);
+  });
+});
+
+describe("approvePairingRequest", () => {
+  test("POSTs the requestId to the approve route with no auth header", async () => {
+    installFetch(() =>
+      jsonResponse({
+        status: "approved",
+        verificationUri: "https://foo.ts.net/assistant/pair",
+        expiresAt: "2026-08-17T10:10:00.000Z",
+      }),
+    );
+
+    await approvePairingRequest({ base: BASE, requestId: "req-1" });
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.url).toBe(
+      `${BASE}/v1/remote-web/pairing-requests/approve`,
+    );
+    expect(requests[0]?.init?.method).toBe("POST");
+    expect(JSON.parse(requests[0]?.init?.body as string)).toEqual({
+      requestId: "req-1",
+    });
+    const headers = new Headers(requests[0]?.init?.headers);
+    expect(headers.get("Content-Type")).toBe("application/json");
+    expect(headers.get("Authorization")).toBeNull();
+  });
+
+  test("throws PairDeviceError with the server's message on a non-OK response", async () => {
+    installFetch(() =>
+      jsonResponse({ error: { message: "Unknown request." } }, 404),
+    );
+
+    await expect(
+      approvePairingRequest({ base: BASE, requestId: "req-x" }),
+    ).rejects.toThrow(new PairDeviceError("Unknown request."));
+  });
+
+  test("maps a network failure to PairDeviceError", async () => {
+    installFetch(() => {
+      throw new TypeError("Failed to fetch");
+    });
+
+    await expect(
+      approvePairingRequest({ base: BASE, requestId: "req-1" }),
+    ).rejects.toThrow(
+      "Couldn't reach the assistant. Make sure it's running and try again.",
+    );
+  });
+
+  test("passes the abort signal through to fetch", async () => {
+    installFetch(() =>
+      jsonResponse({
+        status: "approved",
+        verificationUri: "https://foo.ts.net/assistant/pair",
+        expiresAt: "2026-08-17T10:10:00.000Z",
+      }),
+    );
+    const controller = new AbortController();
+
+    await approvePairingRequest({
+      base: BASE,
+      requestId: "req-1",
+      signal: controller.signal,
+    });
+
+    await expect(requests[0]?.init?.signal).toBe(controller.signal);
+  });
+});
+
+describe("denyPairingRequest", () => {
+  test("POSTs the requestId to the deny route with no auth header", async () => {
+    installFetch(() => jsonResponse({ status: "denied" }));
+
+    await denyPairingRequest({ base: BASE, requestId: "req-1" });
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.url).toBe(
+      `${BASE}/v1/remote-web/pairing-requests/deny`,
+    );
+    expect(requests[0]?.init?.method).toBe("POST");
+    expect(JSON.parse(requests[0]?.init?.body as string)).toEqual({
+      requestId: "req-1",
+    });
+    expect(
+      new Headers(requests[0]?.init?.headers).get("Authorization"),
+    ).toBeNull();
+  });
+
+  test("throws PairDeviceError with the server's message on a non-OK response", async () => {
+    installFetch(() =>
+      jsonResponse({ error: { message: "Request expired." } }, 410),
+    );
+
+    await expect(
+      denyPairingRequest({ base: BASE, requestId: "req-1" }),
+    ).rejects.toThrow(new PairDeviceError("Request expired."));
+  });
+
+  test("rethrows AbortError when the caller cancels", async () => {
+    installFetch(() => {
+      throw new DOMException("Aborted", "AbortError");
+    });
+    const controller = new AbortController();
+
+    await expect(
+      denyPairingRequest({
+        base: BASE,
+        requestId: "req-1",
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+  });
+});

--- a/clients/web/src/domains/settings/pair-device/pair-device-client.ts
+++ b/clients/web/src/domains/settings/pair-device/pair-device-client.ts
@@ -114,6 +114,7 @@ async function pairingRouteRequest<T>(
   url: string,
   init: RequestInit,
   signal: AbortSignal | undefined,
+  rejectionHint?: string,
 ): Promise<T> {
   let response: Response;
   try {
@@ -135,7 +136,7 @@ async function pairingRouteRequest<T>(
     throw new PairDeviceError(
       serverErrorMessage(payload) ??
         `Pairing failed (HTTP ${response.status}).`,
-      PAIRING_CONNECTIVITY_HINT,
+      rejectionHint,
     );
   }
 
@@ -149,6 +150,7 @@ function postPairingRoute<T>(
   url: string,
   body: unknown,
   signal: AbortSignal | undefined,
+  rejectionHint?: string,
 ): Promise<T> {
   return pairingRouteRequest<T>(
     url,
@@ -158,6 +160,7 @@ function postPairingRoute<T>(
       body: JSON.stringify(body),
     },
     signal,
+    rejectionHint,
   );
 }
 
@@ -178,6 +181,7 @@ export async function mintDevicePairing(args: {
     `${base}${PAIRING_CHALLENGE_PATH}`,
     { publicBaseUrl } satisfies RemoteWebPairingChallengeRequest,
     signal,
+    PAIRING_CONNECTIVITY_HINT,
   );
 
   await postPairingRoute(
@@ -186,6 +190,7 @@ export async function mintDevicePairing(args: {
       userCode: challenge.userCode,
     } satisfies RemoteWebPairingVerificationRequest,
     signal,
+    PAIRING_CONNECTIVITY_HINT,
   );
 
   return {

--- a/clients/web/src/domains/settings/pair-device/pair-device-client.ts
+++ b/clients/web/src/domains/settings/pair-device/pair-device-client.ts
@@ -8,16 +8,26 @@
  *      code. Running on the host IS the authorization, so the scan alone
  *      completes pairing.
  *
- * Both routes are loopback-gated and unauthenticated (they refuse any
- * non-loopback origin server-side), so no token is attached — the loopback
- * proxy is the trust boundary. Minting is possible only from the host; a remote
- * paired session can never reach these routes, which is why the UI is hidden
- * outside local mode rather than relying on a client-side check.
+ * It also drives the request-approval routes behind the settings surface that
+ * lists pairing requests minted elsewhere (e.g. the public `/assistant/pair`
+ * page) so the host can approve or deny them by request id:
+ *   3. `GET  /v1/remote-web/pairing-requests`: list pending requests.
+ *   4. `POST /v1/remote-web/pairing-requests/approve`: approve one.
+ *   5. `POST /v1/remote-web/pairing-requests/deny`: deny one.
+ *
+ * All these routes are loopback-gated and unauthenticated (they refuse any
+ * non-loopback origin server-side), so no token is attached: the loopback
+ * proxy is the trust boundary. Minting and approval are possible only from the
+ * host; a remote paired session can never reach these routes, which is why the
+ * UI is hidden outside local mode rather than relying on a client-side check.
  */
 
 import type {
   RemoteWebPairingChallengeRequest,
   RemoteWebPairingChallengeResponse,
+  RemoteWebPairingRequestActionRequest,
+  RemoteWebPairingRequestListResponse,
+  RemoteWebPairingRequestSummary,
   RemoteWebPairingVerificationRequest,
 } from "@vellumai/service-contracts/remote-web-pairing";
 
@@ -27,6 +37,9 @@ import { buildRemoteWebPairingUrl } from "./pair-device-url";
 
 const PAIRING_CHALLENGE_PATH = "/v1/remote-web/pairing-challenge";
 const PAIRING_VERIFICATION_PATH = "/v1/remote-web/pairing-verification";
+const PAIRING_REQUESTS_PATH = "/v1/remote-web/pairing-requests";
+const PAIRING_REQUEST_APPROVE_PATH = `${PAIRING_REQUESTS_PATH}/approve`;
+const PAIRING_REQUEST_DENY_PATH = `${PAIRING_REQUESTS_PATH}/deny`;
 
 /**
  * Guidance appended when the host rejects the mint. The routes themselves only
@@ -97,19 +110,14 @@ function serverErrorMessage(payload: unknown): string | null {
   return typeof message === "string" && message.trim() ? message : null;
 }
 
-async function postPairingRoute<T>(
+async function pairingRouteRequest<T>(
   url: string,
-  body: unknown,
+  init: RequestInit,
   signal: AbortSignal | undefined,
 ): Promise<T> {
   let response: Response;
   try {
-    response = await fetch(url, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-      signal,
-    });
+    response = await fetch(url, { ...init, signal });
   } catch (err) {
     if (err instanceof DOMException && err.name === "AbortError") {
       throw err;
@@ -135,6 +143,22 @@ async function postPairingRoute<T>(
     throw new PairDeviceError("The assistant returned an unexpected response.");
   }
   return payload as T;
+}
+
+function postPairingRoute<T>(
+  url: string,
+  body: unknown,
+  signal: AbortSignal | undefined,
+): Promise<T> {
+  return pairingRouteRequest<T>(
+    url,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+    signal,
+  );
 }
 
 /**
@@ -168,4 +192,63 @@ export async function mintDevicePairing(args: {
     pairUrl: buildRemoteWebPairingUrl(challenge),
     expiresAt: challenge.expiresAt,
   };
+}
+
+/**
+ * List the pending pairing requests awaiting host approval. Throws
+ * {@link PairDeviceError} on rejection or an unreachable gateway; rethrows an
+ * `AbortError` when the caller cancels.
+ */
+export async function listPendingPairingRequests(args: {
+  base: string;
+  signal?: AbortSignal;
+}): Promise<RemoteWebPairingRequestSummary[]> {
+  const payload =
+    await pairingRouteRequest<RemoteWebPairingRequestListResponse>(
+      `${args.base}${PAIRING_REQUESTS_PATH}`,
+      { method: "GET" },
+      args.signal,
+    );
+  return Array.isArray(payload.requests) ? payload.requests : [];
+}
+
+interface PairingRequestActionArgs {
+  base: string;
+  requestId: string;
+  signal?: AbortSignal;
+}
+
+async function postPairingRequestAction(
+  path: string,
+  args: PairingRequestActionArgs,
+): Promise<void> {
+  await postPairingRoute(
+    `${args.base}${path}`,
+    {
+      requestId: args.requestId,
+    } satisfies RemoteWebPairingRequestActionRequest,
+    args.signal,
+  );
+}
+
+/**
+ * Approve one pending pairing request by id. Throws {@link PairDeviceError} on
+ * rejection (e.g. an unknown or expired request id) or an unreachable gateway;
+ * rethrows an `AbortError` when the caller cancels.
+ */
+export function approvePairingRequest(
+  args: PairingRequestActionArgs,
+): Promise<void> {
+  return postPairingRequestAction(PAIRING_REQUEST_APPROVE_PATH, args);
+}
+
+/**
+ * Deny (delete) one pending pairing request by id. Throws
+ * {@link PairDeviceError} on rejection or an unreachable gateway; rethrows an
+ * `AbortError` when the caller cancels.
+ */
+export function denyPairingRequest(
+  args: PairingRequestActionArgs,
+): Promise<void> {
+  return postPairingRequestAction(PAIRING_REQUEST_DENY_PATH, args);
 }


### PR DESCRIPTION
## Summary
- Adds listPendingPairingRequests, approvePairingRequest, denyPairingRequest against the new loopback-only gateway routes
- Generalizes the pairing route fetch helper to support GET while keeping PairDeviceError semantics
- New unit tests for the client functions

Part of plan: web-pair-approve.md (PR 4 of 6)