### PR TITLE
feat(cli): add --json output to vellum devices list and revoke

### DIFF
--- a/cli/src/__tests__/devices.test.ts
+++ b/cli/src/__tests__/devices.test.ts
@@ -259,6 +259,83 @@ describe("vellum devices", () => {
     expect(fetchCalls).toHaveLength(0);
   });
 
+  test("list --json emits a single JSON document and no human text", async () => {
+    seedLocal("json-host", "http://127.0.0.1:7835");
+    const records = [
+      {
+        hashedDeviceId: "hashAAA111",
+        platform: "cli",
+        issuedAt: 1_700_000_000_000,
+        expiresAt: 1_800_000_000_000,
+        lastUsedAt: null,
+      },
+    ];
+    stubFetch((url) =>
+      url.endsWith("/v1/devices")
+        ? jsonResponse({ devices: records })
+        : jsonResponse({ error: "unexpected" }, 500),
+    );
+
+    process.argv = ["bun", "vellum", "devices", "json-host", "--json"];
+    const { exited, logs, errors } = await runDevices();
+
+    expect(exited).toBe(false);
+    expect(errors).toBe("");
+    // Exactly one line on stdout, parseable, and zero prose.
+    expect(logs).not.toContain("\n");
+    expect(JSON.parse(logs)).toEqual({ devices: records });
+    expect(logs).not.toContain("Devices paired to");
+  });
+
+  test("list --json with zero devices emits {\"devices\":[]}", async () => {
+    seedLocal("json-empty-host");
+    stubFetch(() => jsonResponse({ devices: [] }));
+
+    process.argv = ["bun", "vellum", "devices", "json-empty-host", "--json"];
+    const { exited, logs } = await runDevices();
+
+    expect(exited).toBe(false);
+    expect(logs).toBe('{"devices":[]}');
+  });
+
+  test("revoke --json --yes emits { ok, hashedDeviceId } and no preamble", async () => {
+    seedLocal("json-revoke-host", "http://127.0.0.1:7836");
+    stubFetch((url) =>
+      url.endsWith("/v1/devices/revoke")
+        ? jsonResponse({ revoked: true, hashedDeviceId: "hashAAA111" })
+        : jsonResponse({ error: "unexpected" }, 500),
+    );
+
+    process.argv = [
+      "bun",
+      "vellum",
+      "devices",
+      "revoke",
+      "hashAAA111",
+      "json-revoke-host",
+      "--yes",
+      "--json",
+    ];
+    const { exited, logs } = await runDevices();
+
+    expect(exited).toBe(false);
+    expect(logs).not.toContain("\n");
+    expect(JSON.parse(logs)).toEqual({ ok: true, hashedDeviceId: "hashAAA111" });
+    expect(logs).not.toContain("Device to revoke");
+  });
+
+  test("list --json still exits 1 with stderr on a non-2xx gateway response", async () => {
+    seedLocal("json-err-host");
+    stubFetch(() => jsonResponse({ error: { code: "FORBIDDEN" } }, 403));
+
+    process.argv = ["bun", "vellum", "devices", "json-err-host", "--json"];
+    const { exited, logs, errors } = await runDevices();
+
+    expect(exited).toBe(true);
+    expect(logs).toBe("");
+    expect(errors).toContain("403");
+  });
+
   test("surfaces a non-2xx gateway response on list", async () => {
     seedLocal("err-host");
     stubFetch(() => jsonResponse({ error: { code: "FORBIDDEN" } }, 403));

--- a/cli/src/commands/devices.ts
+++ b/cli/src/commands/devices.ts
@@ -13,6 +13,8 @@
  * that runs the assistant (server side).
  */
 
+import type { DeviceRecord } from "@vellumai/local-mode";
+
 import {
   type AssistantEntry,
   formatAssistantReference,
@@ -30,14 +32,6 @@ import {
 } from "../lib/confirm-action.js";
 import { loopbackSafeFetch } from "../lib/loopback-fetch.js";
 
-interface DeviceRecord {
-  hashedDeviceId: string;
-  platform: string;
-  issuedAt: number | null;
-  expiresAt: number | null;
-  lastUsedAt: number | null;
-}
-
 function printUsage(): void {
   console.log(`vellum devices [beta] - List and revoke devices paired to a local assistant
 
@@ -51,6 +45,7 @@ ARGUMENTS:
 
 OPTIONS:
     --yes              Skip the interactive confirmation prompt when revoking (for automation)
+    --json             Print machine-readable JSON on stdout
 
 Lists the devices paired to a local (host-side) assistant, or revokes one by its
 hashed id. Runs on the machine that hosts the assistant — paired connections
@@ -104,7 +99,11 @@ function formatTimestamp(ms: number | null, absent: string): string {
   return new Date(ms).toISOString();
 }
 
-async function listDevices(entry: AssistantEntry, base: string): Promise<void> {
+async function listDevices(
+  entry: AssistantEntry,
+  base: string,
+  jsonOutput: boolean,
+): Promise<void> {
   const displayName = getAssistantDisplayName(entry);
 
   let response: Response;
@@ -131,6 +130,11 @@ async function listDevices(entry: AssistantEntry, base: string): Promise<void> {
 
   const body = (await response.json()) as { devices?: DeviceRecord[] };
   const devices = body.devices ?? [];
+
+  if (jsonOutput) {
+    console.log(JSON.stringify({ devices }));
+    return;
+  }
 
   if (devices.length === 0) {
     console.log(`No devices are paired to ${displayName}.`);
@@ -159,14 +163,17 @@ async function revokeDevice(
   base: string,
   hashedDeviceId: string,
   yes: boolean,
+  jsonOutput: boolean,
 ): Promise<void> {
   const displayName = getAssistantDisplayName(entry);
 
-  // Print the resolved identity before acting (cli/AGENTS.md).
-  console.log("Device to revoke:");
-  console.log(`  Assistant: ${formatAssistantReference(entry)}`);
-  console.log(`  Device:    ${hashedDeviceId}`);
-  console.log("");
+  if (!jsonOutput) {
+    // Print the resolved identity before acting (cli/AGENTS.md).
+    console.log("Device to revoke:");
+    console.log(`  Assistant: ${formatAssistantReference(entry)}`);
+    console.log(`  Device:    ${hashedDeviceId}`);
+    console.log("");
+  }
 
   if (!yes) {
     if (!canPromptForConfirmation()) {
@@ -211,18 +218,26 @@ async function revokeDevice(
     process.exit(1);
   }
 
+  if (jsonOutput) {
+    console.log(JSON.stringify({ ok: true, hashedDeviceId }));
+    return;
+  }
+
   console.log(
     `Revoked device ${hashedDeviceId} from ${displayName}. Its tokens are invalidated; that machine must re-pair to reconnect.`,
   );
 }
 
 export async function devices(): Promise<void> {
-  const args = process.argv.slice(3);
+  const rawArgs = process.argv.slice(3);
 
-  if (args.includes("--help") || args.includes("-h")) {
+  if (rawArgs.includes("--help") || rawArgs.includes("-h")) {
     printUsage();
     return;
   }
+
+  const jsonOutput = rawArgs.includes("--json");
+  const args = rawArgs.filter((a) => a !== "--json");
 
   if (args[0] === "revoke") {
     const rest = args.slice(1);
@@ -237,12 +252,12 @@ export async function devices(): Promise<void> {
     const nameArg = positionals.slice(1).join(" ") || undefined;
     const entry = resolveTargetAssistant(nameArg);
     const base = resolveLoopbackBase(entry);
-    await revokeDevice(entry, base, hashedDeviceId, yes);
+    await revokeDevice(entry, base, hashedDeviceId, yes, jsonOutput);
     return;
   }
 
   const nameArg = parseAssistantTargetArg(args, []);
   const entry = resolveTargetAssistant(nameArg);
   const base = resolveLoopbackBase(entry);
-  await listDevices(entry, base);
+  await listDevices(entry, base, jsonOutput);
 }


### PR DESCRIPTION
## Summary
- Adds a --json flag to vellum devices (list) and vellum devices revoke for machine-readable stdout
- Adopts the canonical DeviceRecord type from @vellumai/local-mode
- Wire contract consumed by the runDevicesList/runDevicesRevoke host helpers

Part of plan: paired-devices-revoke.md (PR 2 of 6)