### PR TITLE
feat(web-hosts): __local/devices list + revoke endpoints in vite dev middleware and vellum client

### DIFF
--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -34,6 +34,8 @@ import {
   isActiveAssistant,
   isPairedLockfileEntry,
   PAIRED_GUARDIAN_TOKEN_HOST_ONLY_ERROR,
+  runDevicesList,
+  runDevicesRevoke,
   runHatch,
   runRetire,
   connectImport,
@@ -426,6 +428,8 @@ const LOCKFILE_PATTERN = /^(?:\/assistant)?\/__local\/lockfile$/;
 const HATCH_PATTERN = /^(?:\/assistant)?\/__local\/hatch$/;
 const RETIRE_PATTERN = /^(?:\/assistant)?\/__local\/retire$/;
 const UNPAIR_PATTERN = /^(?:\/assistant)?\/__local\/unpair$/;
+const DEVICES_PATTERN = /^(?:\/assistant)?\/__local\/devices$/;
+const DEVICES_REVOKE_PATTERN = /^(?:\/assistant)?\/__local\/devices-revoke$/;
 const CONNECT_IMPORT_PATTERN = /^(?:\/assistant)?\/__local\/connect-import$/;
 const GUARDIAN_TOKEN_PATTERN =
   /^(?:\/assistant)?\/__local\/guardian-token\/([^/]+)$/;
@@ -482,6 +486,8 @@ async function handleLocalEndpoints(
     HATCH_PATTERN.test(pathname) ||
     RETIRE_PATTERN.test(pathname) ||
     UNPAIR_PATTERN.test(pathname) ||
+    DEVICES_PATTERN.test(pathname) ||
+    DEVICES_REVOKE_PATTERN.test(pathname) ||
     CONNECT_IMPORT_PATTERN.test(pathname) ||
     GUARDIAN_TOKEN_PATTERN.test(pathname) ||
     PLATFORM_SESSION_PATTERN.test(pathname) ||
@@ -695,6 +701,70 @@ async function handleLocalEndpoints(
     return Response.json(
       { ok: false, error: result.error },
       { status: result.status },
+    );
+  }
+
+  // Paired devices: list and revoke via the CLI (`vellum devices … --json`).
+  // Always 200 with `ok` discriminating success, matching the other hosts.
+  const isDevicesRevoke = DEVICES_REVOKE_PATTERN.test(pathname);
+  if (DEVICES_PATTERN.test(pathname) || isDevicesRevoke) {
+    if (req.method !== "POST") {
+      return new Response(null, { status: 405 });
+    }
+
+    let body: { assistantId?: unknown; hashedDeviceId?: unknown };
+    try {
+      body = (await req.json()) as typeof body;
+    } catch {
+      return Response.json(
+        { ok: false, error: "Invalid JSON body" },
+        { status: 400 },
+      );
+    }
+
+    const { assistantId, hashedDeviceId } = body;
+    if (typeof assistantId !== "string" || !assistantId) {
+      return Response.json(
+        { ok: false, error: "Missing assistantId" },
+        { status: 400 },
+      );
+    }
+    let revokeHash: string | null = null;
+    if (isDevicesRevoke) {
+      if (typeof hashedDeviceId !== "string" || !hashedDeviceId) {
+        return Response.json(
+          { ok: false, error: "Missing hashedDeviceId" },
+          { status: 400 },
+        );
+      }
+      revokeHash = hashedDeviceId;
+    }
+
+    let invocation: CliInvocation;
+    try {
+      invocation = resolveDevCliInvocation(_baseDir);
+    } catch (err) {
+      return Response.json(
+        { ok: false, error: err instanceof Error ? err.message : String(err) },
+        { status: 500 },
+      );
+    }
+
+    if (revokeHash !== null) {
+      const result = await runDevicesRevoke(
+        invocation,
+        assistantId,
+        revokeHash,
+      );
+      return Response.json(
+        result.ok ? { ok: true } : { ok: false, error: result.error },
+      );
+    }
+    const result = await runDevicesList(invocation, assistantId);
+    return Response.json(
+      result.ok
+        ? { ok: true, devices: result.devices }
+        : { ok: false, error: result.error },
     );
   }
 

--- a/clients/web/vite-plugin-local-mode.test.ts
+++ b/clients/web/vite-plugin-local-mode.test.ts
@@ -3,14 +3,41 @@
  * support the renderer's loopback token exchange, while paired credentials
  * stay inside the trusted host proxy.
  */
-import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { ViteDevServer, Connect } from "vite";
 
-import { guardianTokenPath } from "@vellumai/local-mode";
+import * as actualLocalMode from "@vellumai/local-mode";
+import {
+  guardianTokenPath,
+  type DevicesListResult,
+  type DevicesRevokeResult,
+} from "@vellumai/local-mode";
+
+// Per-test stubs for the CLI-spawning device helpers. The rest of the module
+// stays real so the other middlewares under test keep their behavior.
+let devicesListResult: DevicesListResult = { ok: true, devices: [] };
+let devicesRevokeResult: DevicesRevokeResult = { ok: true };
+const runDevicesListMock = mock((_invocation: unknown, _assistantId: string) =>
+  Promise.resolve(devicesListResult),
+);
+const runDevicesRevokeMock = mock(
+  (_invocation: unknown, _assistantId: string, _hashedDeviceId: string) =>
+    Promise.resolve(devicesRevokeResult),
+);
+
+mock.module("@vellumai/local-mode", () => {
+  const mocked: Partial<typeof import("@vellumai/local-mode")> = {
+    ...actualLocalMode,
+    resolveDevCliInvocation: () => ({ command: "vellum", baseArgs: [] }),
+    runDevicesList: runDevicesListMock,
+    runDevicesRevoke: runDevicesRevokeMock,
+  };
+  return mocked;
+});
 
 import { localModePlugin } from "./vite-plugin-local-mode";
 
@@ -46,17 +73,20 @@ interface DispatchResult {
   body: string;
 }
 
-/** Drive a loopback GET through the captured connect chain. */
+/** Drive a request through the captured connect chain (loopback by default). */
 function dispatch(
   url: string,
   headers: Record<string, string> = {},
+  options: { method?: string; body?: unknown; remoteAddress?: string } = {},
 ): Promise<DispatchResult> {
+  const { method = "GET", body, remoteAddress = "127.0.0.1" } = options;
   return new Promise((resolve, reject) => {
-    const req = Object.assign(new EventEmitter(), {
+    const emitter = new EventEmitter();
+    const req = Object.assign(emitter, {
       url,
-      method: "GET",
+      method,
       headers: { host: "127.0.0.1:5173", ...headers },
-      socket: { remoteAddress: "127.0.0.1" },
+      socket: { remoteAddress },
     }) as unknown as Connect.IncomingMessage;
     const res = {
       statusCode: 200,
@@ -79,6 +109,16 @@ function dispatch(
       middleware(req, res as unknown as Parameters<typeof middleware>[1], next);
     };
     next();
+    if (method === "POST") {
+      // Body listeners are registered synchronously by the matched middleware;
+      // feed the stream on the next tick.
+      setImmediate(() => {
+        if (body !== undefined) {
+          emitter.emit("data", Buffer.from(JSON.stringify(body)));
+        }
+        emitter.emit("end");
+      });
+    }
   });
 }
 
@@ -217,5 +257,198 @@ describe("paired gateway proxy", () => {
     });
 
     expect(result).toEqual({ status: 403, body: "Forbidden" });
+  });
+});
+
+describe("devices middlewares", () => {
+  beforeEach(() => {
+    devicesListResult = { ok: true, devices: [] };
+    devicesRevokeResult = { ok: true };
+    runDevicesListMock.mockClear();
+    runDevicesRevokeMock.mockClear();
+  });
+
+  const DEVICE = {
+    hashedDeviceId: "hash-a",
+    platform: "ios",
+    issuedAt: 1700000000000,
+    expiresAt: null,
+    lastUsedAt: null,
+  };
+
+  describe("list endpoint", () => {
+    test("rejects non-loopback callers", async () => {
+      const result = await dispatch(
+        "/__local/devices",
+        {},
+        {
+          method: "POST",
+          body: { assistantId: "asst-1" },
+          remoteAddress: "192.168.1.20",
+        },
+      );
+
+      expect(result.status).toBe(403);
+      expect(runDevicesListMock).not.toHaveBeenCalled();
+    });
+
+    test("rejects non-POST methods", async () => {
+      const result = await dispatch("/__local/devices");
+
+      expect(result.status).toBe(405);
+      expect(runDevicesListMock).not.toHaveBeenCalled();
+    });
+
+    test("400 when assistantId is missing", async () => {
+      const result = await dispatch(
+        "/__local/devices",
+        {},
+        {
+          method: "POST",
+          body: {},
+        },
+      );
+
+      expect(result.status).toBe(400);
+      expect(JSON.parse(result.body)).toEqual({
+        ok: false,
+        error: "Missing assistantId",
+      });
+    });
+
+    test("passes the device list through on the SPA-prefixed route", async () => {
+      devicesListResult = { ok: true, devices: [DEVICE] };
+
+      const result = await dispatch(
+        "/assistant/__local/devices",
+        {},
+        {
+          method: "POST",
+          body: { assistantId: "asst-1" },
+        },
+      );
+
+      expect(result.status).toBe(200);
+      expect(JSON.parse(result.body)).toEqual({ ok: true, devices: [DEVICE] });
+      expect(runDevicesListMock).toHaveBeenCalledWith(
+        { command: "vellum", baseArgs: [] },
+        "asst-1",
+      );
+    });
+
+    test("run-helper failure yields ok:false with no status field", async () => {
+      devicesListResult = { ok: false, status: 500, error: "gateway offline" };
+
+      const result = await dispatch(
+        "/__local/devices",
+        {},
+        {
+          method: "POST",
+          body: { assistantId: "asst-1" },
+        },
+      );
+
+      expect(result.status).toBe(200);
+      expect(JSON.parse(result.body)).toEqual({
+        ok: false,
+        error: "gateway offline",
+      });
+    });
+  });
+
+  describe("revoke endpoint", () => {
+    test("rejects non-loopback callers", async () => {
+      const result = await dispatch(
+        "/__local/devices-revoke",
+        {},
+        {
+          method: "POST",
+          body: { assistantId: "asst-1", hashedDeviceId: "hash-a" },
+          remoteAddress: "192.168.1.20",
+        },
+      );
+
+      expect(result.status).toBe(403);
+      expect(runDevicesRevokeMock).not.toHaveBeenCalled();
+    });
+
+    test("rejects non-POST methods", async () => {
+      const result = await dispatch("/__local/devices-revoke");
+
+      expect(result.status).toBe(405);
+      expect(runDevicesRevokeMock).not.toHaveBeenCalled();
+    });
+
+    test("400 when assistantId is missing", async () => {
+      const result = await dispatch(
+        "/__local/devices-revoke",
+        {},
+        {
+          method: "POST",
+          body: { hashedDeviceId: "hash-a" },
+        },
+      );
+
+      expect(result.status).toBe(400);
+      expect(JSON.parse(result.body)).toEqual({
+        ok: false,
+        error: "Missing assistantId",
+      });
+    });
+
+    test("400 when hashedDeviceId is missing", async () => {
+      const result = await dispatch(
+        "/__local/devices-revoke",
+        {},
+        {
+          method: "POST",
+          body: { assistantId: "asst-1" },
+        },
+      );
+
+      expect(result.status).toBe(400);
+      expect(JSON.parse(result.body)).toEqual({
+        ok: false,
+        error: "Missing hashedDeviceId",
+      });
+    });
+
+    test("passes a successful revoke through", async () => {
+      const result = await dispatch(
+        "/assistant/__local/devices-revoke",
+        {},
+        {
+          method: "POST",
+          body: { assistantId: "asst-1", hashedDeviceId: "hash-a" },
+        },
+      );
+
+      expect(result.status).toBe(200);
+      expect(JSON.parse(result.body)).toEqual({ ok: true });
+      expect(runDevicesRevokeMock).toHaveBeenCalledWith(
+        { command: "vellum", baseArgs: [] },
+        "asst-1",
+        "hash-a",
+      );
+    });
+
+    test("run-helper failure yields ok:false with no status field", async () => {
+      devicesRevokeResult = { ok: false, status: 500, error: "revoke failed" };
+
+      const result = await dispatch(
+        "/__local/devices-revoke",
+        {},
+        {
+          method: "POST",
+          body: { assistantId: "asst-1", hashedDeviceId: "hash-a" },
+        },
+      );
+
+      expect(result.status).toBe(200);
+      expect(JSON.parse(result.body)).toEqual({
+        ok: false,
+        error: "revoke failed",
+      });
+    });
   });
 });

--- a/clients/web/vite-plugin-local-mode.ts
+++ b/clients/web/vite-plugin-local-mode.ts
@@ -19,6 +19,8 @@ import {
   isActiveAssistant,
   isPairedLockfileEntry,
   PAIRED_GUARDIAN_TOKEN_HOST_ONLY_ERROR,
+  runDevicesList,
+  runDevicesRevoke,
   runHatch,
   runRetire,
   runSleep,
@@ -102,6 +104,8 @@ export function localModePlugin(env: Record<string, string>): Plugin {
       );
       server.middlewares.use(sleepMiddleware(baseDir));
       server.middlewares.use(wakeMiddleware(baseDir));
+      server.middlewares.use(devicesListMiddleware(baseDir));
+      server.middlewares.use(devicesRevokeMiddleware(baseDir));
       const upgradingLocalAssistantIds = new Set<string>();
       server.middlewares.use(
         upgradeMiddleware(
@@ -700,6 +704,125 @@ function wakeMiddleware(baseDir: string): Connect.NextHandleFunction {
           respondJson(
             res,
             result.ok ? 200 : result.status,
+            result.ok ? { ok: true } : { ok: false, error: result.error },
+          );
+        },
+      );
+    });
+  };
+}
+
+// Paired-device management via the CLI (`vellum devices … --json`). POST-only
+// (the renderer's postLocalCommand always POSTs); run-helper results respond
+// 200 with `ok` discriminating success so all hosts share one wire shape.
+function devicesListMiddleware(baseDir: string): Connect.NextHandleFunction {
+  return (req, res, next) => {
+    if (
+      req.url !== "/assistant/__local/devices" &&
+      req.url !== "/__local/devices"
+    ) {
+      return next();
+    }
+
+    if (rejectUnlessLocalEndpointRequest(req, res)) {
+      return;
+    }
+
+    if (req.method !== "POST") {
+      res.statusCode = 405;
+      res.end();
+      return;
+    }
+
+    void readJsonBody(req).then((body) => {
+      if (!body) {
+        respondJson(res, 400, { ok: false, error: "Invalid JSON body" });
+        return;
+      }
+
+      const assistantId = body.assistantId;
+      if (typeof assistantId !== "string" || !assistantId) {
+        respondJson(res, 400, { ok: false, error: "Missing assistantId" });
+        return;
+      }
+
+      let invocation: CliInvocation;
+      try {
+        invocation = resolveDevCliInvocation(baseDir, import.meta.url);
+      } catch (err) {
+        respondJson(res, 500, {
+          ok: false,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return;
+      }
+
+      void runDevicesList(invocation, assistantId).then((result) => {
+        respondJson(
+          res,
+          200,
+          result.ok
+            ? { ok: true, devices: result.devices }
+            : { ok: false, error: result.error },
+        );
+      });
+    });
+  };
+}
+
+function devicesRevokeMiddleware(baseDir: string): Connect.NextHandleFunction {
+  return (req, res, next) => {
+    if (
+      req.url !== "/assistant/__local/devices-revoke" &&
+      req.url !== "/__local/devices-revoke"
+    ) {
+      return next();
+    }
+
+    if (rejectUnlessLocalEndpointRequest(req, res)) {
+      return;
+    }
+
+    if (req.method !== "POST") {
+      res.statusCode = 405;
+      res.end();
+      return;
+    }
+
+    void readJsonBody(req).then((body) => {
+      if (!body) {
+        respondJson(res, 400, { ok: false, error: "Invalid JSON body" });
+        return;
+      }
+
+      const assistantId = body.assistantId;
+      if (typeof assistantId !== "string" || !assistantId) {
+        respondJson(res, 400, { ok: false, error: "Missing assistantId" });
+        return;
+      }
+
+      const hashedDeviceId = body.hashedDeviceId;
+      if (typeof hashedDeviceId !== "string" || !hashedDeviceId) {
+        respondJson(res, 400, { ok: false, error: "Missing hashedDeviceId" });
+        return;
+      }
+
+      let invocation: CliInvocation;
+      try {
+        invocation = resolveDevCliInvocation(baseDir, import.meta.url);
+      } catch (err) {
+        respondJson(res, 500, {
+          ok: false,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return;
+      }
+
+      void runDevicesRevoke(invocation, assistantId, hashedDeviceId).then(
+        (result) => {
+          respondJson(
+            res,
+            200,
             result.ok ? { ok: true } : { ok: false, error: result.error },
           );
         },


### PR DESCRIPTION
## Summary
- Adds POST /assistant/__local/devices and /assistant/__local/devices-revoke to the Vite dev middleware, spawning the CLI via runDevicesList/runDevicesRevoke
- Mirrors the same routes in the vellum client loopback server so all three hosts are wire-identical
- Middleware tests for guards, validation, and passthrough shapes

Part of plan: paired-devices-revoke.md (PR 4 of 6)