### PR TITLE
feat(electron): listDevices/revokeDevice local-mode IPC channels and bridge

### DIFF
--- a/packages/electron-desktop/src/local-mode-bridge.test.ts
+++ b/packages/electron-desktop/src/local-mode-bridge.test.ts
@@ -21,9 +21,16 @@ test("forwards the complete local-mode namespace through IPC", async () => {
   await bridge.unpair("assistant-1");
   await bridge.connectImport("bundle", "Assistant 1");
   await bridge.guardianToken("assistant-1");
+  await bridge.listDevices("assistant-1");
+  await bridge.revokeDevice("assistant-1", "hash-1");
 
-  expect(invoke).toHaveBeenCalledTimes(12);
+  expect(invoke).toHaveBeenCalledTimes(14);
   expect(invoke).toHaveBeenCalledWith("vellum:localMode:wake", "assistant-1", {
     repairGuardian: true,
   });
+  expect(invoke).toHaveBeenCalledWith(
+    "vellum:localMode:revokeDevice",
+    "assistant-1",
+    "hash-1",
+  );
 });

--- a/packages/electron-desktop/src/local-mode-bridge.ts
+++ b/packages/electron-desktop/src/local-mode-bridge.ts
@@ -13,6 +13,8 @@ export const createLocalModeBridge = (
     ipc.invoke("vellum:localMode:guardianToken", assistantId),
   hatch: (species, remote) =>
     ipc.invoke("vellum:localMode:hatch", species, remote),
+  listDevices: (assistantId) =>
+    ipc.invoke("vellum:localMode:listDevices", assistantId),
   readLockfile: () => ipc.invoke("vellum:localMode:readLockfile"),
   replacePlatformAssistants: (assistants, organizationId) =>
     ipc.invoke(
@@ -21,6 +23,8 @@ export const createLocalModeBridge = (
       organizationId,
     ),
   retire: (assistantId) => ipc.invoke("vellum:localMode:retire", assistantId),
+  revokeDevice: (assistantId, hashedDeviceId) =>
+    ipc.invoke("vellum:localMode:revokeDevice", assistantId, hashedDeviceId),
   saveLockfileAssistant: (assistant, activeAssistant) =>
     ipc.invoke(
       "vellum:localMode:saveLockfileAssistant",

--- a/packages/electron-desktop/src/local-mode-unavailable.test.ts
+++ b/packages/electron-desktop/src/local-mode-unavailable.test.ts
@@ -15,6 +15,14 @@ test("the unavailable runtime preserves the structured bridge contract", async (
   const invoke = (name: string, ...args: unknown[]) =>
     handlers[`vellum:localMode:${name}`]!(...args);
   expect(await invoke("hatch", "vellum")).toEqual({ ok: false, error });
+  expect(await invoke("listDevices", "assistant-1")).toEqual({
+    ok: false,
+    error,
+  });
+  expect(await invoke("revokeDevice", "assistant-1", "hash-1")).toEqual({
+    ok: false,
+    error,
+  });
   const status = await invoke("status", "assistant-1");
   expect(status).toMatchObject({ ok: false, status: 501 });
   expect(() => invoke("readLockfile")).toThrow(error);

--- a/packages/electron-desktop/src/local-mode.test.ts
+++ b/packages/electron-desktop/src/local-mode.test.ts
@@ -413,6 +413,20 @@ const guardianToken = (assistantId?: unknown): Promise<unknown> =>
     allowedEvent,
     assistantId,
   ) as Promise<unknown>;
+const listDevices = (assistantId?: unknown): Promise<unknown> =>
+  handlers["vellum:localMode:listDevices"](
+    allowedEvent,
+    assistantId,
+  ) as Promise<unknown>;
+const revokeDevice = (
+  assistantId?: unknown,
+  hashedDeviceId?: unknown,
+): Promise<unknown> =>
+  handlers["vellum:localMode:revokeDevice"](
+    allowedEvent,
+    assistantId,
+    hashedDeviceId,
+  ) as Promise<unknown>;
 
 describe("lockfile IPC handlers", () => {
   beforeEach(() => {
@@ -667,6 +681,92 @@ describe("vellum:localMode:retire handler", () => {
     const result = (await retire("asst-1")) as { ok: boolean; error: string };
     expect(result.ok).toBe(false);
     expect(result.error).toBe("disk full");
+    expect(spawnArgs).toHaveLength(0);
+  });
+});
+
+describe("vellum:localMode:listDevices handler", () => {
+  test("dev: spawns `... devices <id> --json` and returns the parsed devices without a status field", async () => {
+    const pending = listDevices("asst-1");
+    await tick();
+    expect(spawnArgs[0]).toEqual([
+      "bun",
+      ["run", devCliEntry, "devices", "asst-1", "--json"],
+    ]);
+    const device = {
+      hashedDeviceId: "hash-1",
+      platform: "ios",
+      issuedAt: 1_000,
+      expiresAt: 2_000,
+      lastUsedAt: 1_500,
+    };
+    lastChild.stdout.emit(
+      "data",
+      Buffer.from(JSON.stringify({ devices: [device] })),
+    );
+    lastChild.emit("close", 0);
+    expect(await pending).toEqual({ ok: true, devices: [device] });
+  });
+
+  test("a non-zero exit resolves to a failure carrying the CLI's stderr", async () => {
+    const pending = listDevices("asst-1");
+    await tick();
+    lastChild.stderr.emit("data", Buffer.from("gateway offline"));
+    lastChild.emit("close", 1);
+    expect(await pending).toEqual({ ok: false, error: "gateway offline" });
+  });
+
+  test("rejects a missing assistant id without spawning", async () => {
+    expect(await listDevices("")).toEqual({
+      ok: false,
+      error: "Missing assistantId",
+    });
+    expect(await listDevices(undefined)).toEqual({
+      ok: false,
+      error: "Missing assistantId",
+    });
+    expect(spawnArgs).toHaveLength(0);
+  });
+});
+
+describe("vellum:localMode:revokeDevice handler", () => {
+  test("dev: spawns `... devices revoke <hash> <id> --yes --json` and reports success on a zero exit", async () => {
+    const pending = revokeDevice("asst-1", "hash-1");
+    await tick();
+    expect(spawnArgs[0]).toEqual([
+      "bun",
+      [
+        "run",
+        devCliEntry,
+        "devices",
+        "revoke",
+        "hash-1",
+        "asst-1",
+        "--yes",
+        "--json",
+      ],
+    ]);
+    lastChild.emit("close", 0);
+    expect(await pending).toEqual({ ok: true });
+  });
+
+  test("a non-zero exit resolves to a failure carrying the CLI's stderr", async () => {
+    const pending = revokeDevice("asst-1", "hash-1");
+    await tick();
+    lastChild.stderr.emit("data", Buffer.from("no such device"));
+    lastChild.emit("close", 1);
+    expect(await pending).toEqual({ ok: false, error: "no such device" });
+  });
+
+  test("rejects missing arguments without spawning", async () => {
+    expect(await revokeDevice(undefined, "hash-1")).toEqual({
+      ok: false,
+      error: "Missing assistantId",
+    });
+    expect(await revokeDevice("asst-1", undefined)).toEqual({
+      ok: false,
+      error: "Missing hashedDeviceId",
+    });
     expect(spawnArgs).toHaveLength(0);
   });
 });

--- a/packages/electron-desktop/src/local-mode.ts
+++ b/packages/electron-desktop/src/local-mode.ts
@@ -10,6 +10,8 @@ import {
   getLockfileData,
   getLocalAssistantStatus,
   replacePlatformAssistants,
+  runDevicesList,
+  runDevicesRevoke,
   runHatch,
   runRetire,
   runSleep,
@@ -24,7 +26,11 @@ import {
   type UpgradeOptions,
   type WakeOptions,
 } from "@vellumai/local-mode";
-import type { LocalConnectImportResult } from "@vellumai/ipc-contract";
+import type {
+  LocalConnectImportResult,
+  LocalListDevicesResult,
+  LocalRevokeDeviceResult,
+} from "@vellumai/ipc-contract";
 import { capabilityToken } from "./capability-registry";
 import type { IpcHandle } from "./ipc";
 
@@ -179,6 +185,41 @@ async function sleep(assistantId: string): Promise<SleepResult> {
   return result.ok ? { ok: true } : { ok: false, error: result.error };
 }
 
+/** List a local assistant's paired devices. Mirrors `hatch`'s never-reject contract. */
+async function listDevices(
+  assistantId: string,
+): Promise<LocalListDevicesResult> {
+  let invocation: CliInvocation;
+  try {
+    invocation = await requireRuntime().cli.resolveInvocation();
+  } catch (err) {
+    return { ok: false, error: (err as Error).message };
+  }
+  const result = await runDevicesList(invocation, assistantId);
+  return result.ok
+    ? { ok: true, devices: result.devices }
+    : { ok: false, error: result.error };
+}
+
+/** Revoke one paired device's tokens. Mirrors `hatch`'s never-reject contract. */
+async function revokeDevice(
+  assistantId: string,
+  hashedDeviceId: string,
+): Promise<LocalRevokeDeviceResult> {
+  let invocation: CliInvocation;
+  try {
+    invocation = await requireRuntime().cli.resolveInvocation();
+  } catch (err) {
+    return { ok: false, error: (err as Error).message };
+  }
+  const result = await runDevicesRevoke(
+    invocation,
+    assistantId,
+    hashedDeviceId,
+  );
+  return result.ok ? { ok: true } : { ok: false, error: result.error };
+}
+
 /**
  * Wake (start) a local assistant's daemon and gateway, re-seeding its
  * guardian token. The non-destructive repair primitive. Mirrors `hatch`'s
@@ -303,6 +344,13 @@ const assistantIdArgs = z.tuple([z.string().optional()]);
 // bundle, including the length cap that bounds what a hostile renderer can
 // make the main process buffer and decode.
 const connectImportArgs = z.tuple([
+  z.string().optional(),
+  z.string().optional(),
+]);
+
+// `revokeDevice` takes an assistant id plus the hashed device id to revoke.
+// Both optional on the wire, validated in the body (never-reject contract).
+const revokeDeviceArgs = z.tuple([
   z.string().optional(),
   z.string().optional(),
 ]);
@@ -460,6 +508,27 @@ export const installLocalMode = (): void => {
     }
     return sleep(assistantId);
   });
+
+  ipc("vellum:localMode:listDevices", assistantIdArgs, ([assistantId]) => {
+    if (!assistantId) {
+      return { ok: false, error: "Missing assistantId" };
+    }
+    return listDevices(assistantId);
+  });
+
+  ipc(
+    "vellum:localMode:revokeDevice",
+    revokeDeviceArgs,
+    ([assistantId, hashedDeviceId]) => {
+      if (!assistantId) {
+        return { ok: false, error: "Missing assistantId" };
+      }
+      if (!hashedDeviceId) {
+        return { ok: false, error: "Missing hashedDeviceId" };
+      }
+      return revokeDevice(assistantId, hashedDeviceId);
+    },
+  );
 
   ipc("vellum:localMode:wake", wakeArgs, ([assistantId, options]) => {
     if (!assistantId) {

--- a/packages/ipc-contract/src/bridge.ts
+++ b/packages/ipc-contract/src/bridge.ts
@@ -76,6 +76,30 @@ export type LocalConnectImportResult =
   | { ok: true; assistantId: string; accessOnly: boolean }
   | { ok: false; error: string };
 
+/**
+ * One paired-device row as returned by `localMode.listDevices`. Structural
+ * duplicate of `@vellumai/local-mode`'s `DeviceRecord`, declared here so this
+ * package has no `file:` dependency on local-mode (which carries a transitive
+ * `file:` chain that breaks lockfile resolution in consumer packages; see the
+ * lockfile types in `./types.ts`). The gateway stores only the HASHED device
+ * id, so `hashedDeviceId` is both the display identifier and the revocation
+ * key.
+ */
+export interface LocalPairedDeviceRecord {
+  hashedDeviceId: string;
+  platform: string;
+  issuedAt: number | null;
+  expiresAt: number | null;
+  lastUsedAt: number | null;
+}
+
+export type LocalListDevicesResult =
+  | { ok: true; devices: LocalPairedDeviceRecord[] }
+  | { ok: false; error: string };
+
+export type LocalRevokeDeviceResult =
+  { ok: true } | { ok: false; error: string };
+
 export interface VellumBridge {
   platform: "electron";
   hostOS?: ElectronHostOS;
@@ -187,6 +211,8 @@ export interface VellumBridge {
       species: string,
       remote?: string,
     ): Promise<{ ok: boolean; assistantId?: string; error?: string }>;
+    /** List the devices holding pairing tokens for a local assistant. */
+    listDevices(assistantId: string): Promise<LocalListDevicesResult>;
     readLockfile(): Promise<Lockfile>;
     saveLockfileAssistant(
       assistant: Record<string, unknown>,
@@ -197,6 +223,14 @@ export interface VellumBridge {
       organizationId?: string,
     ): Promise<LockfileWriteResult>;
     retire(assistantId: string): Promise<{ ok: boolean; error?: string }>;
+    /**
+     * Revoke one paired device's tokens on a local assistant's gateway.
+     * Server-side: the device's next request is rejected.
+     */
+    revokeDevice(
+      assistantId: string,
+      hashedDeviceId: string,
+    ): Promise<LocalRevokeDeviceResult>;
     /**
      * Forget a paired assistant (`cloud: "paired"`): remove its lockfile
      * entry and stored guardian token on this machine. Client-side only:

--- a/packages/ipc-contract/src/index.ts
+++ b/packages/ipc-contract/src/index.ts
@@ -14,6 +14,9 @@ export * from "./schemas";
 export {
   type ElectronHostOS,
   type LocalConnectImportResult,
+  type LocalListDevicesResult,
+  type LocalPairedDeviceRecord,
+  type LocalRevokeDeviceResult,
   type LocalUpgradeOptions,
   type LocalWakeOptions,
   type VellumBridge,


### PR DESCRIPTION
## Summary
- Adds LocalPairedDeviceRecord + list/revoke result types and required VellumBridge methods to @vellumai/ipc-contract
- Electron main handlers spawn the CLI via runDevicesList/runDevicesRevoke (same pattern as retire/sleep)
- Preload bridge one-liners + tests; unavailable-runtime path returns structured errors

Part of plan: paired-devices-revoke.md (PR 3 of 6)