### PR TITLE
feat(web): sync persona name into the lockfile on identity changes

### DIFF
--- a/clients/web/src/hooks/use-lockfile-identity-sync.test.tsx
+++ b/clients/web/src/hooks/use-lockfile-identity-sync.test.tsx
@@ -1,0 +1,87 @@
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
+
+const renameLockfileAssistantMock = mock(async (): Promise<void> => {});
+mock.module("@/lib/local-mode", () => ({
+  renameLockfileAssistant: renameLockfileAssistantMock,
+}));
+
+const { useLockfileIdentitySync } = await import(
+  "@/hooks/use-lockfile-identity-sync"
+);
+const { useAssistantIdentityStore } = await import(
+  "@/stores/assistant-identity-store"
+);
+
+beforeEach(() => {
+  renameLockfileAssistantMock.mockClear();
+  useAssistantIdentityStore.getState().clearIdentity();
+});
+
+afterEach(() => {
+  cleanup();
+  useAssistantIdentityStore.getState().clearIdentity();
+});
+
+describe("useLockfileIdentitySync", () => {
+  test("renames the lockfile entry with the store's assistantId and name", () => {
+    renderHook(() => useLockfileIdentitySync());
+    expect(renameLockfileAssistantMock).not.toHaveBeenCalled();
+
+    act(() => {
+      useAssistantIdentityStore
+        .getState()
+        .setIdentity("Aria", "1.2.3", "assistant-1");
+    });
+
+    expect(renameLockfileAssistantMock).toHaveBeenCalledTimes(1);
+    expect(renameLockfileAssistantMock).toHaveBeenCalledWith(
+      "assistant-1",
+      "Aria",
+    );
+  });
+
+  test("does not fire while the name is null", () => {
+    renderHook(() => useLockfileIdentitySync());
+
+    act(() => {
+      useAssistantIdentityStore
+        .getState()
+        .setIdentity(null, "1.2.3", "assistant-1");
+    });
+
+    expect(renameLockfileAssistantMock).not.toHaveBeenCalled();
+  });
+
+  test("does not fire while the assistantId is null", () => {
+    renderHook(() => useLockfileIdentitySync());
+
+    act(() => {
+      useAssistantIdentityStore.getState().setIdentity("Aria", "1.2.3");
+    });
+
+    expect(renameLockfileAssistantMock).not.toHaveBeenCalled();
+  });
+
+  test("re-fires when the store switches to a different named assistant", () => {
+    renderHook(() => useLockfileIdentitySync());
+
+    act(() => {
+      useAssistantIdentityStore
+        .getState()
+        .setIdentity("Aria", "1.2.3", "assistant-1");
+    });
+    act(() => {
+      useAssistantIdentityStore
+        .getState()
+        .setIdentity("Bela", "1.2.3", "assistant-2");
+    });
+
+    expect(renameLockfileAssistantMock).toHaveBeenCalledTimes(2);
+    expect(renameLockfileAssistantMock).toHaveBeenLastCalledWith(
+      "assistant-2",
+      "Bela",
+    );
+  });
+});

--- a/clients/web/src/hooks/use-lockfile-identity-sync.test.tsx
+++ b/clients/web/src/hooks/use-lockfile-identity-sync.test.tsx
@@ -2,8 +2,15 @@ import { act } from "react";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, renderHook } from "@testing-library/react";
 
-const renameLockfileAssistantMock = mock(async (): Promise<void> => {});
+import type { LockfileAssistant } from "@/runtime/local-mode-host";
+
+// Real module first, so the mock can pass through useLockfileAssistantName
+// and only stub the write helper.
+const actualLocalMode = await import("@/lib/local-mode");
+
+const renameLockfileAssistantMock = mock(async (): Promise<boolean> => true);
 mock.module("@/lib/local-mode", () => ({
+  ...actualLocalMode,
   renameLockfileAssistant: renameLockfileAssistantMock,
 }));
 
@@ -13,15 +20,30 @@ const { useLockfileIdentitySync } = await import(
 const { useAssistantIdentityStore } = await import(
   "@/stores/assistant-identity-store"
 );
+const { useLockfileStore } = await import("@/stores/lockfile-store");
 
-beforeEach(() => {
+/** bun:test has no fake timers, so retry tests run on a real short delay. */
+const TEST_RETRY_DELAY_MS = 25;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function lockfileEntry(assistantId: string, name: string): LockfileAssistant {
+  return { assistantId, cloud: "local", name } as LockfileAssistant;
+}
+
+function resetStores(): void {
   renameLockfileAssistantMock.mockClear();
   useAssistantIdentityStore.getState().clearIdentity();
-});
+  useLockfileStore.setState({ lockfile: null, committed: false });
+}
+
+beforeEach(resetStores);
 
 afterEach(() => {
   cleanup();
-  useAssistantIdentityStore.getState().clearIdentity();
+  resetStores();
 });
 
 describe("useLockfileIdentitySync", () => {
@@ -83,5 +105,89 @@ describe("useLockfileIdentitySync", () => {
       "assistant-2",
       "Bela",
     );
+  });
+
+  test("re-fires when the lockfile entry hydrates after the identity store", () => {
+    renderHook(() => useLockfileIdentitySync());
+
+    act(() => {
+      useAssistantIdentityStore
+        .getState()
+        .setIdentity("Aria", "1.2.3", "assistant-1");
+    });
+    // First attempt ran against an unhydrated lockfile (helper no-ops on a
+    // missing entry).
+    expect(renameLockfileAssistantMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      useLockfileStore.getState().setLockfile({
+        assistants: [lockfileEntry("assistant-1", "Stale Name")],
+        activeAssistant: "assistant-1",
+      });
+    });
+
+    expect(renameLockfileAssistantMock).toHaveBeenCalledTimes(2);
+    expect(renameLockfileAssistantMock).toHaveBeenLastCalledWith(
+      "assistant-1",
+      "Aria",
+    );
+  });
+
+  test("retries once after a delay when the write fails", async () => {
+    renameLockfileAssistantMock.mockResolvedValueOnce(false);
+    renderHook(() => useLockfileIdentitySync(TEST_RETRY_DELAY_MS));
+
+    act(() => {
+      useAssistantIdentityStore
+        .getState()
+        .setIdentity("Aria", "1.2.3", "assistant-1");
+    });
+    expect(renameLockfileAssistantMock).toHaveBeenCalledTimes(1);
+
+    await sleep(TEST_RETRY_DELAY_MS * 3);
+
+    expect(renameLockfileAssistantMock).toHaveBeenCalledTimes(2);
+    expect(renameLockfileAssistantMock).toHaveBeenLastCalledWith(
+      "assistant-1",
+      "Aria",
+    );
+
+    // The retry resolved true (mock default), so no further attempts.
+    await sleep(TEST_RETRY_DELAY_MS * 3);
+    expect(renameLockfileAssistantMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("does not retry when the helper resolves true", async () => {
+    renderHook(() => useLockfileIdentitySync(TEST_RETRY_DELAY_MS));
+
+    act(() => {
+      useAssistantIdentityStore
+        .getState()
+        .setIdentity("Aria", "1.2.3", "assistant-1");
+    });
+
+    await sleep(TEST_RETRY_DELAY_MS * 3);
+    expect(renameLockfileAssistantMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("unmounting cancels a pending failed-write retry", async () => {
+    renameLockfileAssistantMock.mockResolvedValueOnce(false);
+    const { unmount } = renderHook(() =>
+      useLockfileIdentitySync(TEST_RETRY_DELAY_MS),
+    );
+
+    act(() => {
+      useAssistantIdentityStore
+        .getState()
+        .setIdentity("Aria", "1.2.3", "assistant-1");
+    });
+    expect(renameLockfileAssistantMock).toHaveBeenCalledTimes(1);
+
+    // Let the rejection settle so the retry timer gets scheduled, then unmount.
+    await sleep(1);
+    unmount();
+
+    await sleep(TEST_RETRY_DELAY_MS * 3);
+    expect(renameLockfileAssistantMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/clients/web/src/hooks/use-lockfile-identity-sync.ts
+++ b/clients/web/src/hooks/use-lockfile-identity-sync.ts
@@ -1,7 +1,12 @@
 import { useEffect } from "react";
 
-import { renameLockfileAssistant } from "@/lib/local-mode";
+import {
+  renameLockfileAssistant,
+  useLockfileAssistantName,
+} from "@/lib/local-mode";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+
+const RETRY_DELAY_MS = 2_000;
 
 /**
  * Mirror the active assistant's persona name into its lockfile entry so
@@ -13,17 +18,40 @@ import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
  * name with a new id mid-switch (unlike pairing the name with
  * `activeAssistantId` from the resolved-assistants store).
  *
+ * Also subscribes to the lockfile entry's own name, so the sync re-fires when
+ * the lockfile hydrates after the identity store on boot (the helper no-ops
+ * on a missing entry) or the entry's name changes externally. A failed host
+ * write gets one delayed retry per effect run; convergence otherwise rides
+ * the next dep change.
+ *
  * All skip logic (empty name, missing lockfile entry, unchanged name, host
  * unavailable, remote-gateway mode) lives in `renameLockfileAssistant`, so
  * this hook is safe to mount unconditionally in `RootLayout`.
  */
-export function useLockfileIdentitySync(): void {
+export function useLockfileIdentitySync(retryDelayMs = RETRY_DELAY_MS): void {
   const name = useAssistantIdentityStore.use.name();
   const assistantId = useAssistantIdentityStore.use.assistantId();
+  const lockfileName = useLockfileAssistantName(assistantId);
 
   useEffect(() => {
-    if (name !== null && assistantId !== null) {
-      void renameLockfileAssistant(assistantId, name);
+    if (name === null || assistantId === null) {
+      return;
     }
-  }, [name, assistantId]);
+    let disposed = false;
+    let retryTimer: ReturnType<typeof setTimeout> | undefined;
+    void renameLockfileAssistant(assistantId, name).then((converged) => {
+      if (converged || disposed) {
+        return;
+      }
+      retryTimer = setTimeout(() => {
+        void renameLockfileAssistant(assistantId, name);
+      }, retryDelayMs);
+    });
+    return () => {
+      disposed = true;
+      if (retryTimer !== undefined) {
+        clearTimeout(retryTimer);
+      }
+    };
+  }, [name, assistantId, lockfileName, retryDelayMs]);
 }

--- a/clients/web/src/hooks/use-lockfile-identity-sync.ts
+++ b/clients/web/src/hooks/use-lockfile-identity-sync.ts
@@ -1,0 +1,29 @@
+import { useEffect } from "react";
+
+import { renameLockfileAssistant } from "@/lib/local-mode";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+
+/**
+ * Mirror the active assistant's persona name into its lockfile entry so
+ * lockfile consumers (assistant chooser, Electron tray, `vellum pair`) show
+ * the live name instead of a stale snapshot.
+ *
+ * Reads both `name` and `assistantId` from `useAssistantIdentityStore`: the
+ * store writes them in one `set()`, so this pairing can never mix a stale
+ * name with a new id mid-switch (unlike pairing the name with
+ * `activeAssistantId` from the resolved-assistants store).
+ *
+ * All skip logic (empty name, missing lockfile entry, unchanged name, host
+ * unavailable, remote-gateway mode) lives in `renameLockfileAssistant`, so
+ * this hook is safe to mount unconditionally in `RootLayout`.
+ */
+export function useLockfileIdentitySync(): void {
+  const name = useAssistantIdentityStore.use.name();
+  const assistantId = useAssistantIdentityStore.use.assistantId();
+
+  useEffect(() => {
+    if (name !== null && assistantId !== null) {
+      void renameLockfileAssistant(assistantId, name);
+    }
+  }, [name, assistantId]);
+}

--- a/clients/web/src/lib/local-mode.test.ts
+++ b/clients/web/src/lib/local-mode.test.ts
@@ -609,7 +609,9 @@ describe("renameLockfileAssistant", () => {
       lockfile: resulting,
     });
 
-    await renameLockfileAssistant("local-a", "  Credence  ");
+    await expect(
+      renameLockfileAssistant("local-a", "  Credence  "),
+    ).resolves.toBe(true);
 
     expect(saveLockfileAssistantHost).toHaveBeenCalledTimes(1);
     expect(saveLockfileAssistantHost.mock.calls[0]).toEqual([
@@ -620,52 +622,60 @@ describe("renameLockfileAssistant", () => {
     expect(useLockfileStore.getState().committed).toBe(true);
   });
 
-  test("no-op when the lockfile has no entry for the id", async () => {
+  test("no-op (true) when the lockfile has no entry for the id", async () => {
     enableLocalHost();
     setLockfile({ assistants: [named], activeAssistant: "local-a" });
 
-    await renameLockfileAssistant("nope", "Credence");
+    await expect(renameLockfileAssistant("nope", "Credence")).resolves.toBe(
+      true,
+    );
 
     expect(saveLockfileAssistantHost).not.toHaveBeenCalled();
   });
 
-  test("no-op when the entry already carries the trimmed name", async () => {
+  test("no-op (true) when the entry already carries the trimmed name", async () => {
     enableLocalHost();
     setLockfile({ assistants: [named], activeAssistant: "local-a" });
 
-    await renameLockfileAssistant("local-a", "  Old Name  ");
+    await expect(
+      renameLockfileAssistant("local-a", "  Old Name  "),
+    ).resolves.toBe(true);
 
     expect(saveLockfileAssistantHost).not.toHaveBeenCalled();
   });
 
-  test("no-op on an empty or whitespace-only name", async () => {
+  test("no-op (true) on an empty or whitespace-only name", async () => {
     enableLocalHost();
     setLockfile({ assistants: [named], activeAssistant: "local-a" });
 
-    await renameLockfileAssistant("local-a", "");
-    await renameLockfileAssistant("local-a", "   ");
+    await expect(renameLockfileAssistant("local-a", "")).resolves.toBe(true);
+    await expect(renameLockfileAssistant("local-a", "   ")).resolves.toBe(true);
 
     expect(saveLockfileAssistantHost).not.toHaveBeenCalled();
   });
 
-  test("no-op when no local-mode host backs this runtime", async () => {
+  test("no-op (true) when no local-mode host backs this runtime", async () => {
     // Default test env: no injected config, not Electron.
     setLockfile({ assistants: [named], activeAssistant: "local-a" });
 
-    await renameLockfileAssistant("local-a", "Credence");
+    await expect(renameLockfileAssistant("local-a", "Credence")).resolves.toBe(
+      true,
+    );
 
     expect(saveLockfileAssistantHost).not.toHaveBeenCalled();
   });
 
-  test("no-op in remote-gateway mode", async () => {
+  test("no-op (true) in remote-gateway mode", async () => {
     window.__VELLUM_CONFIG__ = { mode: "remote-gateway" };
 
-    await renameLockfileAssistant("self", "Credence");
+    await expect(renameLockfileAssistant("self", "Credence")).resolves.toBe(
+      true,
+    );
 
     expect(saveLockfileAssistantHost).not.toHaveBeenCalled();
   });
 
-  test("does not commit on a host write failure", async () => {
+  test("resolves false without committing on a host write failure", async () => {
     enableLocalHost();
     setLockfile({ assistants: [named], activeAssistant: "local-a" });
     saveLockfileAssistantHost.mockResolvedValueOnce({
@@ -673,7 +683,9 @@ describe("renameLockfileAssistant", () => {
       error: "disk unavailable",
     });
 
-    await renameLockfileAssistant("local-a", "Credence");
+    await expect(renameLockfileAssistant("local-a", "Credence")).resolves.toBe(
+      false,
+    );
 
     expect(saveLockfileAssistantHost).toHaveBeenCalledTimes(1);
     expect(useLockfileStore.getState().lockfile?.assistants).toEqual([named]);

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -307,23 +307,27 @@ export async function updateLockfileAssistant(
  * Rename an existing assistant entry without touching its other fields or the
  * active assistant pointer. The partial payload rides the host's shallow
  * on-disk merge, so `resources`, secrets, and unknown fields survive.
+ *
+ * Resolves `true` when there is nothing left to do (converged, no-op guard,
+ * or a successful write); `false` only when a host write was attempted and
+ * failed, so callers can retry.
  */
 export async function renameLockfileAssistant(
   assistantId: string,
   name: string,
-): Promise<void> {
+): Promise<boolean> {
   const trimmed = name.trim();
   if (!trimmed) {
     // Fresh assistants report "": never write an empty name.
-    return;
+    return true;
   }
   if (isRemoteGatewayMode() || !isLocalModeHostAvailable()) {
-    return;
+    return true;
   }
   const entry = getLockfileAssistant(assistantId);
   if (!entry || entry.name === trimmed) {
     // Rename-only: never create an entry, never write redundantly.
-    return;
+    return true;
   }
   const result = await saveLockfileAssistantHost(
     { assistantId, name: trimmed },
@@ -331,7 +335,9 @@ export async function renameLockfileAssistant(
   );
   if (result.ok) {
     commitLockfile(result.lockfile);
+    return true;
   }
+  return false;
 }
 
 /**
@@ -668,6 +674,22 @@ export function getLockfileAssistant(
   assistantId: string,
 ): LockfileAssistant | undefined {
   return getLockfile().assistants.find((a) => a.assistantId === assistantId);
+}
+
+/**
+ * React subscription to one lockfile entry's `name`. `undefined` while the
+ * lockfile hasn't hydrated or the id has no entry, so effects depending on it
+ * re-fire once the entry appears. Narrow on purpose: the lockfile store stays
+ * internal to this module.
+ */
+export function useLockfileAssistantName(
+  assistantId: string | null,
+): string | undefined {
+  return useLockfileStore((s) =>
+    assistantId === null
+      ? undefined
+      : s.lockfile?.assistants.find((a) => a.assistantId === assistantId)?.name,
+  );
 }
 
 /**

--- a/clients/web/src/root-layout.tsx
+++ b/clients/web/src/root-layout.tsx
@@ -59,6 +59,7 @@ import { useCompanionMirror } from "@/domains/chat/hooks/use-companion-mirror";
 import { useElectronIconSync } from "@/hooks/use-electron-icon-sync";
 import { useIslandAvatarSource } from "@/hooks/use-island-avatar-source";
 import { useElectronIdentitySync } from "@/hooks/use-electron-identity-sync";
+import { useLockfileIdentitySync } from "@/hooks/use-lockfile-identity-sync";
 import { useElectronStatusSync } from "@/hooks/use-electron-status-sync";
 import { useElectronFeatureFlagBridge } from "@/runtime/electron-feature-flags";
 import { subscribeAndroidBackButtonSource } from "@/runtime/event-sources/android-back-button";
@@ -186,6 +187,7 @@ export function RootLayout() {
   useElectronIconSync(avatar.customImageUrl, avatar.components, avatar.traits);
   useElectronStatusSync();
   useElectronIdentitySync();
+  useLockfileIdentitySync();
   useElectronFeatureFlagBridge();
 
   // Size the Electron main window to the onboarding layout (440×630


### PR DESCRIPTION
## Summary
- New use-lockfile-identity-sync hook mounted in RootLayout: writes the live persona name into the matching lockfile entry via renameLockfileAssistant (partial merge; resources, secrets, and the active pointer untouched)
- Completes the liveness chain: IDENTITY.md change -> identity_changed SSE -> identity query refetch -> identity store -> lockfile -> chooser/tray via the lockfile watcher
- Gives the PR-1 helper its production caller

Part of plan: unify-assistant-naming.md (PR 2 of 4)