### PR TITLE
Require an edit to the Doctor not-resolved feedback prefill before Send

### DIFF
--- a/clients/web/src/components/share-feedback-modal.test.tsx
+++ b/clients/web/src/components/share-feedback-modal.test.tsx
@@ -104,6 +104,42 @@ describe("ShareFeedbackModal", () => {
     ).toBe("The app colors are ugly.");
   });
 
+  test("requireMessageEdit blocks Submit until the prefill is edited", async () => {
+    const client = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    });
+
+    render(
+      <QueryClientProvider client={client}>
+        <ShareFeedbackModal
+          open
+          onClose={() => {}}
+          initialReason="bug_report"
+          initialMessage="The Doctor wasn't able to solve my problem:"
+          requireMessageEdit
+        />
+      </QueryClientProvider>,
+    );
+
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText("Email"), "user@example.com");
+    const submit = screen.getByRole("button", { name: "Submit" });
+    expect((submit as HTMLButtonElement).disabled).toBe(true);
+
+    await user.type(
+      screen.getByLabelText("What went wrong?"),
+      " it keeps crashing",
+    );
+    expect((submit as HTMLButtonElement).disabled).toBe(false);
+
+    await user.click(submit);
+    await waitFor(() => expect(feedbackRequests).toHaveLength(1));
+    const request = feedbackRequests[0] as { body: { message?: string } };
+    expect(request.body.message).toBe(
+      "The Doctor wasn't able to solve my problem: it keeps crashing",
+    );
+  });
+
   test("reports Android shell feedback as android", async () => {
     capacitorPlatform = "android";
     const client = new QueryClient({

--- a/clients/web/src/components/share-feedback-modal.tsx
+++ b/clients/web/src/components/share-feedback-modal.tsx
@@ -648,6 +648,8 @@ export interface ShareFeedbackModalProps {
   onClose: () => void;
   initialReason?: FeedbackReason;
   initialMessage?: string;
+  /** Treat `initialMessage` as a scaffold: block Send until the user edits it. */
+  requireMessageEdit?: boolean;
   onSubmitted?: () => void;
   assistantId?: string | null;
   assistantVersion?: string | null;
@@ -662,6 +664,7 @@ export function ShareFeedbackModal({
   onClose,
   initialReason,
   initialMessage,
+  requireMessageEdit,
   onSubmitted,
   assistantId,
   assistantVersion,
@@ -704,8 +707,11 @@ export function ShareFeedbackModal({
 
   const shouldShowEmail = !authEmail;
   const canSend = useMemo(
-    () => message.trim().length > 0 && email.trim().length > 0,
-    [message, email],
+    () =>
+      message.trim().length > 0 &&
+      email.trim().length > 0 &&
+      (!requireMessageEdit || message.trim() !== (initialMessage ?? "").trim()),
+    [message, email, requireMessageEdit, initialMessage],
   );
 
   useEffect(() => {

--- a/clients/web/src/domains/settings/components/panels/doctor-panel.tsx
+++ b/clients/web/src/domains/settings/components/panels/doctor-panel.tsx
@@ -168,6 +168,7 @@ export function DoctorPanel() {
   const [feedbackDraft, setFeedbackDraft] = useState<{
     message?: string;
     reason?: FeedbackReason;
+    requireEdit?: boolean;
   } | null>(null);
 
   const platformGate = usePlatformGate();
@@ -411,9 +412,17 @@ export function DoctorPanel() {
   };
 
   const handleOpenFeedback = useCallback(
-    (draft?: { message?: string; reason?: FeedbackReason }) => {
+    (draft?: {
+      message?: string;
+      reason?: FeedbackReason;
+      requireEdit?: boolean;
+    }) => {
       const initialMessage = draft?.message?.trim() || undefined;
-      setFeedbackDraft({ message: initialMessage, reason: draft?.reason });
+      setFeedbackDraft({
+        message: initialMessage,
+        reason: draft?.reason,
+        requireEdit: draft?.requireEdit,
+      });
       setFeedbackOpen(true);
     },
     [],
@@ -481,8 +490,11 @@ export function DoctorPanel() {
         }
       });
       if (!resolved) {
+        // Scaffold only — Send stays disabled until the user adds their own
+        // words, so we don't file content-free "[Doctor] ..." Linear tickets.
         handleOpenFeedback({
           message: "The Doctor wasn't able to solve my problem: ",
+          requireEdit: true,
         });
       }
     },
@@ -1018,6 +1030,7 @@ export function DoctorPanel() {
         onClose={handleCloseFeedback}
         initialReason={feedbackDraft?.reason}
         initialMessage={feedbackDraft?.message}
+        requireMessageEdit={feedbackDraft?.requireEdit}
         assistantId={assistantId}
         doctorSessionId={visibleDoctorSessionId}
         doctorSessionLog={doctorSessionLog}


### PR DESCRIPTION
## Problem

Answering **No** to the Doctor's "Did the Doctor solve your problem?" prompt opens the Share Feedback modal prefilled with `"The Doctor wasn't able to solve my problem: "`. The prefill alone satisfies the non-empty message check, so users can hit Send without typing anything — which files content-free Linear tickets in the Self-Service KPI project titled `[Doctor] Bug Report: The Doctor wasn't able to solve my problem:` (e.g. ATL-1279, ATL-1285).

## Change

- `ShareFeedbackModal` gains an opt-in `requireMessageEdit` prop: when set, Send stays disabled until the trimmed message differs from the trimmed `initialMessage`.
- The Doctor panel sets it only on the not-resolved prefill flow.
- The Doctor-drafted `feedback_prompt` flow is untouched — those prefills are complete messages meant to be submittable as-is, so no blanket gate.

No behavior change for any caller that doesn't pass the new prop.

## Testing

- New test: Submit disabled with the untouched prefill, enabled after typing, and the submitted message includes prefix + user text.
- `bun test src/components/share-feedback-modal.test.tsx` — 16 pass.
- `bun run typecheck` clean; lint shows one pre-existing `exhaustive-deps` warning on the open-reset effect (untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hDRMbQPccyzEQPKVPzsYV
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40800" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->