### PR TITLE
feat(web): listPairedDevicesHost/revokePairedDeviceHost local-mode host wrappers

### DIFF
--- a/clients/web/src/runtime/is-electron.ts
+++ b/clients/web/src/runtime/is-electron.ts
@@ -39,6 +39,8 @@ import type {
   HotkeyScope,
   LocalAssistantStatusResult,
   LocalConnectImportResult,
+  LocalListDevicesResult,
+  LocalRevokeDeviceResult,
   LocalUpgradeOptions,
   LocalWakeOptions,
   NotificationActionEvent,
@@ -207,6 +209,7 @@ declare global {
           assistantId?: string;
           error?: string;
         }>;
+        listDevices?(assistantId: string): Promise<LocalListDevicesResult>;
         readLockfile(): Promise<Lockfile>;
         saveLockfileAssistant(
           assistant: Record<string, unknown>,
@@ -217,6 +220,10 @@ declare global {
           organizationId?: string,
         ): Promise<LockfileWriteResult>;
         retire(assistantId: string): Promise<{ ok: boolean; error?: string }>;
+        revokeDevice?(
+          assistantId: string,
+          hashedDeviceId: string,
+        ): Promise<LocalRevokeDeviceResult>;
         unpair?(assistantId: string): Promise<LockfileWriteResult>;
         connectImport?(
           bundle: string,

--- a/clients/web/src/runtime/local-mode-host.test.ts
+++ b/clients/web/src/runtime/local-mode-host.test.ts
@@ -15,6 +15,8 @@ const {
   retireLocalAssistantHost,
   unpairAssistantHost,
   connectImportHost,
+  listPairedDevicesHost,
+  revokePairedDeviceHost,
   upgradeLocalAssistantHost,
   wakeLocalAssistantHost,
   getLocalAssistantStatusHost,
@@ -417,6 +419,119 @@ describe("connectImportHost", () => {
       ok: false,
       error:
         "Connecting a paired assistant is not supported by this app version",
+    });
+  });
+});
+
+describe("listPairedDevicesHost", () => {
+  const devices = [
+    {
+      hashedDeviceId: "hash-1",
+      platform: "ios",
+      issuedAt: 1,
+      expiresAt: 2,
+      lastUsedAt: null,
+    },
+  ];
+
+  test("web/dev host POSTs the assistant id to the devices middleware", async () => {
+    const fetchMock = mock(async () => ({
+      json: async () => ({ ok: true, devices }),
+    }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    expect(await listPairedDevicesHost("a-1")).toEqual({ ok: true, devices });
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
+    expect(url).toBe("/assistant/__local/devices");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({ assistantId: "a-1" });
+  });
+
+  test("web/dev host surfaces the host's structured refusal", async () => {
+    globalThis.fetch = mock(async () => ({
+      json: async () => ({ ok: false, error: "No such assistant" }),
+    })) as unknown as typeof fetch;
+
+    expect(await listPairedDevicesHost("a-1")).toEqual({
+      ok: false,
+      error: "No such assistant",
+    });
+  });
+
+  test("Electron host lists through the bridge and never touches fetch", async () => {
+    const listDevices = mock(async () => ({ ok: true, devices }));
+    const fetchMock = mock(async () => {
+      throw new Error("fetch must not run on the Electron branch");
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    setElectronBridge({ listDevices });
+
+    expect(await listPairedDevicesHost("a-1")).toEqual({ ok: true, devices });
+    expect(listDevices).toHaveBeenCalledWith("a-1");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("older Electron shell without the listDevices channel reports an unsupported failure", async () => {
+    setElectronBridge({});
+
+    expect(await listPairedDevicesHost("a-1")).toEqual({
+      ok: false,
+      error: "Device management is not supported by this app version",
+    });
+  });
+});
+
+describe("revokePairedDeviceHost", () => {
+  test("web/dev host POSTs the assistant and hashed device ids to the devices-revoke middleware", async () => {
+    const fetchMock = mock(async () => ({ json: async () => ({ ok: true }) }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    expect(await revokePairedDeviceHost("a-1", "hash-1")).toEqual({ ok: true });
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
+    expect(url).toBe("/assistant/__local/devices-revoke");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({
+      assistantId: "a-1",
+      hashedDeviceId: "hash-1",
+    });
+  });
+
+  test("web/dev host surfaces the host's structured refusal", async () => {
+    globalThis.fetch = mock(async () => ({
+      json: async () => ({ ok: false, error: "Device not found" }),
+    })) as unknown as typeof fetch;
+
+    expect(await revokePairedDeviceHost("a-1", "hash-1")).toEqual({
+      ok: false,
+      error: "Device not found",
+    });
+  });
+
+  test("Electron host revokes through the bridge and never touches fetch", async () => {
+    const revokeDevice = mock(async () => ({ ok: true }));
+    const fetchMock = mock(async () => {
+      throw new Error("fetch must not run on the Electron branch");
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    setElectronBridge({ revokeDevice });
+
+    expect(await revokePairedDeviceHost("a-1", "hash-1")).toEqual({ ok: true });
+    expect(revokeDevice).toHaveBeenCalledWith("a-1", "hash-1");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("older Electron shell without the revokeDevice channel reports an unsupported failure", async () => {
+    setElectronBridge({});
+
+    expect(await revokePairedDeviceHost("a-1", "hash-1")).toEqual({
+      ok: false,
+      error: "Device management is not supported by this app version",
     });
   });
 });

--- a/clients/web/src/runtime/local-mode-host.ts
+++ b/clients/web/src/runtime/local-mode-host.ts
@@ -1,6 +1,9 @@
 import type {
   LocalAssistantStatusResult,
   LocalConnectImportResult,
+  LocalListDevicesResult,
+  LocalPairedDeviceRecord,
+  LocalRevokeDeviceResult,
   LocalUpgradeOptions,
   LocalWakeOptions,
 } from "@vellumai/ipc-contract";
@@ -86,6 +89,9 @@ export interface LocalUpgradeResult {
 
 export type { LocalAssistantStatusResult };
 export type { LocalConnectImportResult };
+export type { LocalListDevicesResult };
+export type { LocalPairedDeviceRecord };
+export type { LocalRevokeDeviceResult };
 export type { LocalUpgradeOptions };
 
 /**
@@ -358,6 +364,63 @@ export async function connectImportHost(
   return postLocalCommand<LocalConnectImportResult>(
     "/assistant/__local/connect-import",
     { bundle, name },
+    LOCAL_HOST_UNAVAILABLE_ERROR,
+  );
+}
+
+/** Shared fallback for Electron preloads that predate the devices channels. */
+const DEVICE_MANAGEMENT_UNSUPPORTED_ERROR =
+  "Device management is not supported by this app version";
+
+/**
+ * List the devices holding pairing tokens for a local assistant. Device
+ * management is host-side only: the gateway's devices routes reject browser
+ * origins by design, so the trusted host (Electron main, the Vite dev
+ * middleware, or the `vellum client` server) spawns the CLI's `devices
+ * --json` and returns its result over this seam. Older Electron hosts that
+ * predate the IPC channel degrade to a structured unsupported error, which
+ * doubles as the UI's visibility gate on those app shells.
+ */
+export async function listPairedDevicesHost(
+  assistantId: string,
+): Promise<LocalListDevicesResult> {
+  if (isElectron()) {
+    const listDevices = window.vellum!.localMode.listDevices;
+    if (!listDevices) {
+      return { ok: false, error: DEVICE_MANAGEMENT_UNSUPPORTED_ERROR };
+    }
+    return listDevices(assistantId);
+  }
+
+  return postLocalCommand<LocalListDevicesResult>(
+    "/assistant/__local/devices",
+    { assistantId },
+    LOCAL_HOST_UNAVAILABLE_ERROR,
+  );
+}
+
+/**
+ * Revoke one paired device's tokens on a local assistant's gateway, the write
+ * counterpart of {@link listPairedDevicesHost}. Same host-side-only rule (the
+ * gateway's devices routes reject browser origins, so the trusted host drives
+ * the CLI) and the same structured unsupported fallback on older Electron
+ * hosts.
+ */
+export async function revokePairedDeviceHost(
+  assistantId: string,
+  hashedDeviceId: string,
+): Promise<LocalRevokeDeviceResult> {
+  if (isElectron()) {
+    const revokeDevice = window.vellum!.localMode.revokeDevice;
+    if (!revokeDevice) {
+      return { ok: false, error: DEVICE_MANAGEMENT_UNSUPPORTED_ERROR };
+    }
+    return revokeDevice(assistantId, hashedDeviceId);
+  }
+
+  return postLocalCommand<LocalRevokeDeviceResult>(
+    "/assistant/__local/devices-revoke",
+    { assistantId, hashedDeviceId },
     LOCAL_HOST_UNAVAILABLE_ERROR,
   );
 }


### PR DESCRIPTION
## Summary
- Adds listPairedDevicesHost/revokePairedDeviceHost renderer wrappers with the standard Electron/dev-server split
- Optional bridge methods in the renderer's defensive global declaration; 'not supported' fallback doubles as the UI visibility gate on older shells
- Re-exports the device contract types from the host module boundary

Part of plan: paired-devices-revoke.md (PR 5 of 6)