### PR TITLE
feat(web): use-pending-pairing-requests polling hook

### DIFF
--- a/clients/web/src/domains/settings/pair-device/pair-device-client.test.ts
+++ b/clients/web/src/domains/settings/pair-device/pair-device-client.test.ts
@@ -111,14 +111,18 @@ describe("listPendingPairingRequests", () => {
     );
   });
 
-  test("maps a network failure to PairDeviceError", async () => {
+  test("maps a network failure to a PairDeviceError with no status", async () => {
     installFetch(() => {
       throw new TypeError("Failed to fetch");
     });
 
-    await expect(listPendingPairingRequests({ base: BASE })).rejects.toThrow(
+    const err = await capturePairDeviceError(
+      listPendingPairingRequests({ base: BASE }),
+    );
+    expect(err.message).toBe(
       "Couldn't reach the assistant. Make sure it's running and try again.",
     );
+    expect(err.status).toBeUndefined();
   });
 
   test("rethrows AbortError when the caller cancels", async () => {
@@ -177,6 +181,7 @@ describe("approvePairingRequest", () => {
     );
     expect(err.message).toBe("Unknown request.");
     expect(err.hint).toBeUndefined();
+    expect(err.status).toBe(404);
   });
 
   test("maps a network failure to PairDeviceError", async () => {
@@ -240,6 +245,7 @@ describe("denyPairingRequest", () => {
     );
     expect(err.message).toBe("Request expired.");
     expect(err.hint).toBeUndefined();
+    expect(err.status).toBe(410);
   });
 
   test("rethrows AbortError when the caller cancels", async () => {

--- a/clients/web/src/domains/settings/pair-device/pair-device-client.ts
+++ b/clients/web/src/domains/settings/pair-device/pair-device-client.ts
@@ -49,14 +49,17 @@ const PAIRING_REQUEST_DENY_PATH = `${PAIRING_REQUESTS_PATH}/deny`;
 export const PAIRING_CONNECTIVITY_HINT =
   "If a scan can't connect, make sure a tunnel is running on the host (`vellum tunnel`) and the public URL points at it, then generate a new code.";
 
-/** A pairing mint that failed, carrying an optional actionable hint. */
+/** A pairing request that failed, carrying an optional actionable hint. */
 export class PairDeviceError extends Error {
   readonly hint?: string;
+  /** HTTP status of the rejecting response; unset for network failures. */
+  readonly status?: number;
 
-  constructor(message: string, hint?: string) {
+  constructor(message: string, hint?: string, status?: number) {
     super(message);
     this.name = "PairDeviceError";
     this.hint = hint;
+    this.status = status;
   }
 }
 
@@ -137,6 +140,7 @@ async function pairingRouteRequest<T>(
       serverErrorMessage(payload) ??
         `Pairing failed (HTTP ${response.status}).`,
       rejectionHint,
+      response.status,
     );
   }
 

--- a/clients/web/src/domains/settings/pair-device/use-pending-pairing-requests.test.ts
+++ b/clients/web/src/domains/settings/pair-device/use-pending-pairing-requests.test.ts
@@ -1,0 +1,363 @@
+/**
+ * Tests for `usePendingPairingRequests`.
+ *
+ * `globalThis.fetch` is stubbed per-test (restored in `afterEach`) so the hook
+ * runs through the real client module; `mock.module` is avoided because it
+ * leaks across the other pair-device test files in a single-process run.
+ * `setInterval`/`clearInterval` are stubbed with an armed-timer capture (bun's
+ * test runner has no fake timers) so interval refreshes are driven by hand;
+ * because the timer globals are stubbed, tests flush with `act` instead of
+ * `waitFor` (which schedules real timers).
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+
+import type { RemoteWebPairingRequestSummary } from "@vellumai/service-contracts/remote-web-pairing";
+
+import { usePendingPairingRequests } from "./use-pending-pairing-requests";
+
+const BASE = "http://localhost:3000/assistant/__gateway/20100";
+const LIST_URL = `${BASE}/v1/remote-web/pairing-requests`;
+const APPROVE_URL = `${LIST_URL}/approve`;
+const DENY_URL = `${LIST_URL}/deny`;
+const POLL_INTERVAL_MS = 5000;
+
+function pendingRequest(requestId = "req-1"): RemoteWebPairingRequestSummary {
+  return {
+    requestId,
+    userCode: "WXYZ-1234",
+    publicBaseUrl: "https://foo.ts.net",
+    requestedAt: "2026-08-17T10:00:00.000Z",
+    expiresAt: "2026-08-17T10:10:00.000Z",
+    requesterIp: "203.0.113.7",
+    requesterUserAgent: "Mozilla/5.0",
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function approvedResponse(): Response {
+  return jsonResponse({
+    status: "approved",
+    verificationUri: "https://foo.ts.net/assistant/pair",
+    expiresAt: "2026-08-17T10:10:00.000Z",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// fetch stub: per-URL responders plus a captured request log.
+// ---------------------------------------------------------------------------
+
+const originalFetch = globalThis.fetch;
+let requests: Array<{ url: string; init: RequestInit | undefined }> = [];
+
+function installFetch(respond: (url: string) => Response | Promise<Response>) {
+  const fetchMock = mock(async (input: string | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    requests.push({ url, init });
+    return respond(url);
+  });
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  return fetchMock;
+}
+
+function listCalls() {
+  return requests.filter((request) => request.url === LIST_URL);
+}
+
+/** Serve the list route with `summaries`; reassignable between polls. */
+let listResponder: () => Response | Promise<Response>;
+
+function serveList(summaries: RemoteWebPairingRequestSummary[]) {
+  listResponder = () => jsonResponse({ requests: summaries });
+}
+
+function installRoutedFetch(
+  actions: Partial<Record<string, () => Response | Promise<Response>>> = {},
+) {
+  installFetch((url) => {
+    const respond = url === LIST_URL ? listResponder : actions[url];
+    if (!respond) {
+      throw new Error(`unexpected fetch: ${url}`);
+    }
+    return respond();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Armed-timer capture standing in for fake timers.
+// ---------------------------------------------------------------------------
+
+interface ArmedTimer {
+  handler: () => void;
+  delay: number;
+  cleared: boolean;
+}
+
+let armedTimers: ArmedTimer[] = [];
+const realSetInterval = globalThis.setInterval;
+const realClearInterval = globalThis.clearInterval;
+
+function pollTimers(): ArmedTimer[] {
+  return armedTimers.filter((timer) => timer.delay === POLL_INTERVAL_MS);
+}
+
+/** Fire the (single) live poll interval once and flush the resulting poll. */
+async function tickPoll() {
+  const live = pollTimers().filter((timer) => !timer.cleared);
+  expect(live).toHaveLength(1);
+  await act(async () => {
+    live[0]?.handler();
+  });
+}
+
+function renderPendingRequests(base: string | null = BASE) {
+  return renderHook(() => usePendingPairingRequests(base));
+}
+
+async function renderWithList(summaries: RemoteWebPairingRequestSummary[]) {
+  serveList(summaries);
+  installRoutedFetch();
+  let rendered!: ReturnType<typeof renderPendingRequests>;
+  await act(async () => {
+    rendered = renderPendingRequests();
+  });
+  return rendered;
+}
+
+beforeEach(() => {
+  requests = [];
+  serveList([]);
+
+  globalThis.setInterval = ((handler: () => void, delay: number) => {
+    armedTimers.push({ handler, delay, cleared: false });
+    return armedTimers.length as unknown as ReturnType<typeof setInterval>;
+  }) as typeof globalThis.setInterval;
+  globalThis.clearInterval = ((id: number) => {
+    const timer = armedTimers[id - 1];
+    if (timer) {
+      timer.cleared = true;
+    }
+  }) as typeof globalThis.clearInterval;
+});
+
+afterEach(() => {
+  cleanup();
+  armedTimers = [];
+  globalThis.setInterval = realSetInterval;
+  globalThis.clearInterval = realClearInterval;
+  globalThis.fetch = originalFetch;
+});
+
+describe("usePendingPairingRequests: polling", () => {
+  test("fetches immediately on mount and arms a 5s interval", async () => {
+    const { result } = await renderWithList([pendingRequest()]);
+
+    expect(listCalls()).toHaveLength(1);
+    expect(listCalls()[0]?.init?.method).toBe("GET");
+    expect(result.current.requests).toEqual([pendingRequest()]);
+    expect(result.current.error).toBeNull();
+    expect(pollTimers()).toHaveLength(1);
+  });
+
+  test("an interval tick replaces the list", async () => {
+    const { result } = await renderWithList([pendingRequest("req-1")]);
+
+    serveList([pendingRequest("req-1"), pendingRequest("req-2")]);
+    await tickPoll();
+
+    expect(listCalls()).toHaveLength(2);
+    expect(result.current.requests.map((r) => r.requestId)).toEqual([
+      "req-1",
+      "req-2",
+    ]);
+  });
+
+  test("an unchanged poll keeps the same list reference", async () => {
+    const { result } = await renderWithList([pendingRequest("req-1")]);
+    const initial = result.current.requests;
+
+    await tickPoll();
+
+    expect(listCalls()).toHaveLength(2);
+    expect(result.current.requests).toBe(initial);
+  });
+
+  test("does nothing when base is null", async () => {
+    installRoutedFetch();
+
+    let result!: ReturnType<typeof renderPendingRequests>["result"];
+    await act(async () => {
+      ({ result } = renderPendingRequests(null));
+    });
+
+    expect(requests).toHaveLength(0);
+    expect(pollTimers()).toHaveLength(0);
+    expect(result.current.requests).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+
+  test("unmount clears the interval and aborts the in-flight poll", async () => {
+    // A list response that never resolves, so the poll stays in flight.
+    listResponder = () => new Promise<Response>(() => {});
+    installRoutedFetch();
+
+    let unmount!: () => void;
+    await act(async () => {
+      ({ unmount } = renderPendingRequests());
+    });
+    expect(listCalls()).toHaveLength(1);
+
+    unmount();
+
+    expect(pollTimers()[0]?.cleared).toBe(true);
+    expect(listCalls()[0]?.init?.signal?.aborted).toBe(true);
+    expect(listCalls()).toHaveLength(1);
+  });
+
+  test("a failed poll keeps the previous list and records the error", async () => {
+    const { result } = await renderWithList([pendingRequest()]);
+
+    listResponder = () =>
+      jsonResponse({ error: { message: "Not available." } }, 503);
+    await tickPoll();
+
+    expect(result.current.requests).toEqual([pendingRequest()]);
+    expect(result.current.error).toBe("Not available.");
+
+    // The next successful poll clears the error again.
+    serveList([pendingRequest()]);
+    await tickPoll();
+    expect(result.current.error).toBeNull();
+  });
+});
+
+describe("usePendingPairingRequests: approve/deny", () => {
+  test("approve tracks the in-flight action and removes the row on success", async () => {
+    serveList([pendingRequest("req-1"), pendingRequest("req-2")]);
+    let resolveApprove!: (response: Response) => void;
+    installRoutedFetch({
+      [APPROVE_URL]: () =>
+        new Promise<Response>((resolve) => {
+          resolveApprove = resolve;
+        }),
+    });
+
+    let result!: ReturnType<typeof renderPendingRequests>["result"];
+    await act(async () => {
+      ({ result } = renderPendingRequests());
+    });
+
+    await act(async () => {
+      void result.current.approve("req-1");
+    });
+    expect(result.current.actingOn).toEqual({
+      requestId: "req-1",
+      action: "approve",
+    });
+
+    await act(async () => {
+      resolveApprove(approvedResponse());
+    });
+
+    const approveCalls = requests.filter((r) => r.url === APPROVE_URL);
+    expect(approveCalls).toHaveLength(1);
+    expect(JSON.parse(approveCalls[0]?.init?.body as string)).toEqual({
+      requestId: "req-1",
+    });
+    expect(result.current.actingOn).toBeNull();
+    expect(result.current.requests.map((r) => r.requestId)).toEqual(["req-2"]);
+    expect(result.current.error).toBeNull();
+  });
+
+  test("deny removes the row and clears the in-flight marker", async () => {
+    serveList([pendingRequest("req-1")]);
+    installRoutedFetch({
+      [DENY_URL]: () => jsonResponse({ status: "denied" }),
+    });
+
+    let result!: ReturnType<typeof renderPendingRequests>["result"];
+    await act(async () => {
+      ({ result } = renderPendingRequests());
+    });
+
+    await act(async () => {
+      await result.current.deny("req-1");
+    });
+
+    expect(requests.filter((r) => r.url === DENY_URL)).toHaveLength(1);
+    expect(result.current.actingOn).toBeNull();
+    expect(result.current.requests).toEqual([]);
+  });
+
+  test("a 404 from approve is treated as removal, not an error", async () => {
+    serveList([pendingRequest("req-1")]);
+    installRoutedFetch({
+      [APPROVE_URL]: () =>
+        jsonResponse({ error: { message: "Unknown request." } }, 404),
+    });
+
+    let result!: ReturnType<typeof renderPendingRequests>["result"];
+    await act(async () => {
+      ({ result } = renderPendingRequests());
+    });
+
+    await act(async () => {
+      await result.current.approve("req-1");
+    });
+
+    expect(result.current.requests).toEqual([]);
+    expect(result.current.actingOn).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  test("a non-404 failure keeps the row and surfaces the message", async () => {
+    serveList([pendingRequest("req-1")]);
+    let approveResponder = () =>
+      jsonResponse({ error: { message: "Approval failed." } }, 500);
+    installRoutedFetch({ [APPROVE_URL]: () => approveResponder() });
+
+    let result!: ReturnType<typeof renderPendingRequests>["result"];
+    await act(async () => {
+      ({ result } = renderPendingRequests());
+    });
+
+    await act(async () => {
+      await result.current.approve("req-1");
+    });
+
+    expect(result.current.requests).toEqual([pendingRequest("req-1")]);
+    expect(result.current.actingOn).toBeNull();
+    expect(result.current.error).toBe("Approval failed.");
+
+    // Retrying clears the stale message before the new outcome lands.
+    approveResponder = approvedResponse;
+    await act(async () => {
+      await result.current.approve("req-1");
+    });
+    expect(result.current.requests).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+
+  test("actions are ignored while base is null", async () => {
+    installRoutedFetch();
+
+    let result!: ReturnType<typeof renderPendingRequests>["result"];
+    await act(async () => {
+      ({ result } = renderPendingRequests(null));
+    });
+
+    await act(async () => {
+      await result.current.approve("req-1");
+    });
+
+    expect(requests).toHaveLength(0);
+    expect(result.current.actingOn).toBeNull();
+  });
+});

--- a/clients/web/src/domains/settings/pair-device/use-pending-pairing-requests.test.ts
+++ b/clients/web/src/domains/settings/pair-device/use-pending-pairing-requests.test.ts
@@ -21,6 +21,9 @@ const BASE = "http://localhost:3000/assistant/__gateway/20100";
 const LIST_URL = `${BASE}/v1/remote-web/pairing-requests`;
 const APPROVE_URL = `${LIST_URL}/approve`;
 const DENY_URL = `${LIST_URL}/deny`;
+const OTHER_BASE = "http://localhost:3000/assistant/__gateway/20200";
+const OTHER_LIST_URL = `${OTHER_BASE}/v1/remote-web/pairing-requests`;
+const OTHER_APPROVE_URL = `${OTHER_LIST_URL}/approve`;
 const POLL_INTERVAL_MS = 5000;
 
 function pendingRequest(requestId = "req-1"): RemoteWebPairingRequestSummary {
@@ -118,7 +121,10 @@ async function tickPoll() {
 }
 
 function renderPendingRequests(base: string | null = BASE) {
-  return renderHook(() => usePendingPairingRequests(base));
+  return renderHook(
+    (props: { base: string | null }) => usePendingPairingRequests(props.base),
+    { initialProps: { base } },
+  );
 }
 
 async function renderWithList(summaries: RemoteWebPairingRequestSummary[]) {
@@ -341,6 +347,89 @@ describe("usePendingPairingRequests: approve/deny", () => {
     await act(async () => {
       await result.current.approve("req-1");
     });
+    expect(result.current.requests).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+
+  test("a base change clears rows and errors before the new base's poll resolves", async () => {
+    serveList([pendingRequest("req-1")]);
+    // The new base's list never resolves, so anything shown for it is stale.
+    installRoutedFetch({
+      [OTHER_LIST_URL]: () => new Promise<Response>(() => {}),
+    });
+
+    let result!: ReturnType<typeof renderPendingRequests>["result"];
+    let rerender!: ReturnType<typeof renderPendingRequests>["rerender"];
+    await act(async () => {
+      ({ result, rerender } = renderPendingRequests());
+    });
+    expect(result.current.requests).toHaveLength(1);
+
+    // Put both error channels in a non-null state first.
+    listResponder = () =>
+      jsonResponse({ error: { message: "Not available." } }, 503);
+    await tickPoll();
+    expect(result.current.error).toBe("Not available.");
+
+    await act(async () => {
+      rerender({ base: OTHER_BASE });
+    });
+
+    expect(result.current.requests).toEqual([]);
+    expect(result.current.error).toBeNull();
+    // The new base was polled, but its hung response left the list empty.
+    const otherListCalls = requests.filter((r) => r.url === OTHER_LIST_URL);
+    expect(otherListCalls).toHaveLength(1);
+  });
+
+  test("a base change aborts the pending action and frees the guard for the new base", async () => {
+    serveList([pendingRequest("req-1")]);
+    let resolveOldApprove!: (response: Response) => void;
+    installRoutedFetch({
+      [APPROVE_URL]: () =>
+        new Promise<Response>((resolve) => {
+          resolveOldApprove = resolve;
+        }),
+      [OTHER_LIST_URL]: () =>
+        jsonResponse({ requests: [pendingRequest("req-9")] }),
+      [OTHER_APPROVE_URL]: approvedResponse,
+    });
+
+    let result!: ReturnType<typeof renderPendingRequests>["result"];
+    let rerender!: ReturnType<typeof renderPendingRequests>["rerender"];
+    await act(async () => {
+      ({ result, rerender } = renderPendingRequests());
+    });
+
+    await act(async () => {
+      void result.current.approve("req-1");
+    });
+    expect(result.current.actingOn).toEqual({
+      requestId: "req-1",
+      action: "approve",
+    });
+
+    await act(async () => {
+      rerender({ base: OTHER_BASE });
+    });
+
+    // The old action was aborted and its marker cleared.
+    const oldApprove = requests.filter((r) => r.url === APPROVE_URL);
+    expect(oldApprove[0]?.init?.signal?.aborted).toBe(true);
+    expect(result.current.actingOn).toBeNull();
+    expect(result.current.requests.map((r) => r.requestId)).toEqual(["req-9"]);
+
+    // A late success from the old base must not touch the new base's list.
+    await act(async () => {
+      resolveOldApprove(approvedResponse());
+    });
+    expect(result.current.requests.map((r) => r.requestId)).toEqual(["req-9"]);
+
+    // The guard is free: an action against the new base goes through.
+    await act(async () => {
+      await result.current.approve("req-9");
+    });
+    expect(requests.filter((r) => r.url === OTHER_APPROVE_URL)).toHaveLength(1);
     expect(result.current.requests).toEqual([]);
     expect(result.current.error).toBeNull();
   });

--- a/clients/web/src/domains/settings/pair-device/use-pending-pairing-requests.ts
+++ b/clients/web/src/domains/settings/pair-device/use-pending-pairing-requests.ts
@@ -1,0 +1,179 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { RemoteWebPairingRequestSummary } from "@vellumai/service-contracts/remote-web-pairing";
+
+import { captureError } from "@/lib/sentry/capture-error";
+
+import {
+  approvePairingRequest,
+  denyPairingRequest,
+  listPendingPairingRequests,
+  PairDeviceError,
+} from "./pair-device-client";
+
+/** Matches the gateway store's recommended poll interval for pending requests. */
+const POLL_INTERVAL_MS = 5000;
+
+export type PendingPairingAction = "approve" | "deny";
+
+/** Summaries are immutable per id, so id-sequence equality means unchanged. */
+function sameRequestList(
+  prev: RemoteWebPairingRequestSummary[],
+  next: RemoteWebPairingRequestSummary[],
+): boolean {
+  return (
+    prev.length === next.length &&
+    next.every((request, i) => prev[i]?.requestId === request.requestId)
+  );
+}
+
+export interface PendingPairingRequestsController {
+  /** The pending pairing requests, as last fetched from the host gateway. */
+  requests: RemoteWebPairingRequestSummary[];
+  /** The request an approve/deny is currently in flight for, or `null`. */
+  actingOn: { requestId: string; action: PendingPairingAction } | null;
+  /** Non-fatal error message the card may surface, or `null`. */
+  error: string | null;
+  approve: (requestId: string) => Promise<void>;
+  deny: (requestId: string) => Promise<void>;
+}
+
+/**
+ * Polls the host gateway's loopback-only pending pairing-request list while
+ * mounted and exposes approve/deny actions on the rows. `base` is the resolved
+ * local-gateway base URL, or `null` when request approval isn't available from
+ * here (outside desktop/local mode); the hook is then inert.
+ *
+ * A failed poll keeps the previous list (a transient loopback-proxy hiccup
+ * shouldn't flash the UI empty) and records a non-fatal error instead. A
+ * 404/410 from approve/deny means the request expired or was handled elsewhere
+ * (the CLI `--web-approve` path can race the UI), so the row is removed as if
+ * the action succeeded.
+ */
+export function usePendingPairingRequests(
+  base: string | null,
+): PendingPairingRequestsController {
+  const [requests, setRequests] = useState<RemoteWebPairingRequestSummary[]>(
+    [],
+  );
+  const [actingOn, setActingOn] = useState<{
+    requestId: string;
+    action: PendingPairingAction;
+  } | null>(null);
+  const [pollError, setPollError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const pollAbortRef = useRef<AbortController | null>(null);
+  const actionAbortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    return () => actionAbortRef.current?.abort();
+  }, []);
+
+  useEffect(() => {
+    if (!base) {
+      return;
+    }
+
+    const poll = async () => {
+      pollAbortRef.current?.abort();
+      const controller = new AbortController();
+      pollAbortRef.current = controller;
+      try {
+        const next = await listPendingPairingRequests({
+          base,
+          signal: controller.signal,
+        });
+        if (controller.signal.aborted) {
+          return;
+        }
+        setRequests((prev) => (sameRequestList(prev, next) ? prev : next));
+        setPollError(null);
+      } catch (err) {
+        if (controller.signal.aborted) {
+          return;
+        }
+        if (err instanceof PairDeviceError) {
+          setPollError(err.message);
+          return;
+        }
+        captureError(err, { context: "pair-device-pending-requests-poll" });
+        setPollError(
+          "Something went wrong while checking for pairing requests.",
+        );
+      }
+    };
+
+    void poll();
+    const intervalId = setInterval(() => void poll(), POLL_INTERVAL_MS);
+    return () => {
+      clearInterval(intervalId);
+      pollAbortRef.current?.abort();
+    };
+  }, [base]);
+
+  const runAction = useCallback(
+    async (requestId: string, action: PendingPairingAction) => {
+      if (!base || actionAbortRef.current) {
+        return;
+      }
+      const controller = new AbortController();
+      actionAbortRef.current = controller;
+      setActingOn({ requestId, action });
+      setActionError(null);
+
+      const removeRequest = () => {
+        // Abort any in-flight poll so a stale response can't resurrect the row.
+        pollAbortRef.current?.abort();
+        setRequests((prev) =>
+          prev.filter((request) => request.requestId !== requestId),
+        );
+      };
+
+      try {
+        const perform =
+          action === "approve" ? approvePairingRequest : denyPairingRequest;
+        await perform({ base, requestId, signal: controller.signal });
+        removeRequest();
+      } catch (err) {
+        if (controller.signal.aborted) {
+          return;
+        }
+        if (err instanceof PairDeviceError) {
+          if (err.status === 404 || err.status === 410) {
+            // Expired or already handled elsewhere; treat as removed.
+            removeRequest();
+          } else {
+            setActionError(err.message);
+          }
+        } else {
+          captureError(err, { context: "pair-device-pending-request-action" });
+          setActionError("Something went wrong. Try again.");
+        }
+      } finally {
+        actionAbortRef.current = null;
+        if (!controller.signal.aborted) {
+          setActingOn(null);
+        }
+      }
+    },
+    [base],
+  );
+
+  const approve = useCallback(
+    (requestId: string) => runAction(requestId, "approve"),
+    [runAction],
+  );
+  const deny = useCallback(
+    (requestId: string) => runAction(requestId, "deny"),
+    [runAction],
+  );
+
+  return {
+    requests,
+    actingOn,
+    error: actionError ?? pollError,
+    approve,
+    deny,
+  };
+}

--- a/clients/web/src/domains/settings/pair-device/use-pending-pairing-requests.ts
+++ b/clients/web/src/domains/settings/pair-device/use-pending-pairing-requests.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { RemoteWebPairingRequestSummary } from "@vellumai/service-contracts/remote-web-pairing";
 
+import { t } from "@/i18n";
 import { captureError } from "@/lib/sentry/capture-error";
 
 import {
@@ -49,6 +50,9 @@ export interface PendingPairingRequestsController {
  * 404/410 from approve/deny means the request expired or was handled elsewhere
  * (the CLI `--web-approve` path can race the UI), so the row is removed as if
  * the action succeeded.
+ *
+ * A `base` change drops the previous gateway's rows and errors and aborts its
+ * in-flight action, so stale requests are never shown against the new base.
  */
 export function usePendingPairingRequests(
   base: string | null,
@@ -66,9 +70,26 @@ export function usePendingPairingRequests(
   const pollAbortRef = useRef<AbortController | null>(null);
   const actionAbortRef = useRef<AbortController | null>(null);
 
+  // Requests and errors belong to the gateway they came from. When `base`
+  // changes, drop them during render so the old assistant's rows can never be
+  // shown against (or acted on toward) the new one.
+  const [lastBase, setLastBase] = useState(base);
+  if (base !== lastBase) {
+    setLastBase(base);
+    setRequests([]);
+    setActingOn(null);
+    setPollError(null);
+    setActionError(null);
+  }
+
+  // Abort any in-flight approve/deny on base change and unmount, and release
+  // the single-action guard so the new base's actions aren't blocked.
   useEffect(() => {
-    return () => actionAbortRef.current?.abort();
-  }, []);
+    return () => {
+      actionAbortRef.current?.abort();
+      actionAbortRef.current = null;
+    };
+  }, [base]);
 
   useEffect(() => {
     if (!base) {
@@ -98,9 +119,7 @@ export function usePendingPairingRequests(
           return;
         }
         captureError(err, { context: "pair-device-pending-requests-poll" });
-        setPollError(
-          "Something went wrong while checking for pairing requests.",
-        );
+        setPollError(t("settings:usePendingPairingRequests.pollErrorFallback"));
       }
     };
 
@@ -134,6 +153,10 @@ export function usePendingPairingRequests(
         const perform =
           action === "approve" ? approvePairingRequest : denyPairingRequest;
         await perform({ base, requestId, signal: controller.signal });
+        if (controller.signal.aborted) {
+          // Aborted by a base change; the row no longer belongs to this list.
+          return;
+        }
         removeRequest();
       } catch (err) {
         if (controller.signal.aborted) {
@@ -148,10 +171,16 @@ export function usePendingPairingRequests(
           }
         } else {
           captureError(err, { context: "pair-device-pending-request-action" });
-          setActionError("Something went wrong. Try again.");
+          setActionError(
+            t("settings:usePendingPairingRequests.actionErrorFallback"),
+          );
         }
       } finally {
-        actionAbortRef.current = null;
+        // Only release the guard if it's still ours; a base change may have
+        // cleared it and a new base's action may already hold it.
+        if (actionAbortRef.current === controller) {
+          actionAbortRef.current = null;
+        }
         if (!controller.signal.aborted) {
           setActingOn(null);
         }

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -417,6 +417,10 @@
     "assistantNotReadyToast": "Assistant not ready. Please try again.",
     "saveApiKeyFailedToast": "Failed to save {providerName} API key. Please try again."
   },
+  "usePendingPairingRequests": {
+    "actionErrorFallback": "Something went wrong. Try again.",
+    "pollErrorFallback": "Something went wrong while checking for pairing requests."
+  },
   "useProfileSave": {
     "createdToast": "Profile \"{name}\" created"
   },

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -417,6 +417,10 @@
     "assistantNotReadyToast": "El asistente no está listo. Inténtalo de nuevo.",
     "saveApiKeyFailedToast": "No se pudo guardar la clave de API de {providerName}. Inténtalo de nuevo."
   },
+  "usePendingPairingRequests": {
+    "actionErrorFallback": "Algo salió mal. Inténtalo de nuevo.",
+    "pollErrorFallback": "Algo salió mal al comprobar las solicitudes de vinculación."
+  },
   "useProfileSave": {
     "createdToast": "Perfil \"{name}\" creado"
   },


### PR DESCRIPTION
## Summary
- Polls the loopback-only pairing-requests list every 5s while the pair-device surface is mounted
- approve/deny callbacks with per-request in-flight tracking; 404/410 treated as already-handled removal
- Failed polls retain the previous list; tests with fake timers

Part of plan: web-pair-approve.md (PR 5 of 6)