### PR TITLE
fix(windows): run local web against dev platform

### DIFF
--- a/clients/windows/README.md
+++ b/clients/windows/README.md
@@ -24,10 +24,10 @@ it serves a bundled `resources/web-dist` over a privileged `app://` protocol.
   attention state appear on the Windows taskbar.
 - Persisted main-window geometry and maximized state, load/show readiness,
   dynamic assistant titles, and frameless title-bar overlay controls.
-- Packaged static serving of the renderer from `src/main/index.ts`, with
+- Static serving of the renderer from `src/main/index.ts`, with
   path-traversal protection from `@vellumai/electron-utils/app-protocol`,
-  single-instance lock, per-environment `userData` separation, and
-  `electron-log` file logging.
+  platform API forwarding, single-instance lock, per-environment `userData`
+  separation, and `electron-log` file logging.
 - `electron-builder` NSIS installer target (`bun run pack`).
 
 ## Packaged CLI provisioning
@@ -59,10 +59,8 @@ use the existing POSIX archive process.
 
 ## Not ported yet (see `clients/macos/src/main/` for reference implementations)
 
-- Gateway (`/assistant/__gateway/{port}/*`) and platform (`/v1/*`,
-  `/_allauth/*`, `/accounts/*`) request forwarding. Packaged builds can't
-  reach local gateways or the cloud platform until this lands; dev runs are
-  unaffected because the Vite dev server proxies both.
+- Gateway (`/assistant/__gateway/{port}/*`) request forwarding. Packaged
+  builds cannot reach local gateways until this lands.
 - Native auth / OAuth sign-in chain, notifications, auto-update, CSP, hotkeys,
   local-mode IPC (hatch/wake/retire), and device id.
 
@@ -75,6 +73,18 @@ bun run dev
 Probes for `vel up` at `localhost:3000` and attaches to it, or falls back to
 standalone mode (spawns `clients/web`'s Vite on :5173, shell only, no
 backends). Scripts assume a POSIX shell; on Windows use Git Bash (or WSL).
+
+To test local web changes against the deployed dev platform without starting
+Vite or opening a local development port, run this from PowerShell:
+
+```powershell
+$env:VELLUM_ENVIRONMENT="dev"
+$env:VELLUM_DEV_URL="https://dev-assistant.vellum.ai/assistant"
+bun run dev:electron-local-web
+```
+
+This builds the local `clients/web` source, serves it from Electron's
+`app://` origin, and forwards platform API requests to `dev-assistant`.
 
 ## Packaging
 

--- a/clients/windows/package.json
+++ b/clients/windows/package.json
@@ -9,6 +9,7 @@
     "dev": "bun run install:all && bun scripts/dev.ts",
     "dev:standalone": "bun run install:all && concurrently --kill-others --names web,electron --prefix-colors blue,green \"bun run dev:web\" \"bun run dev:electron\"",
     "dev:electron-only": "bun run install:all && electron-vite dev",
+    "dev:electron-local-web": "bun scripts/dev-electron-local-web.ts",
     "install:all": "bun install && bun run setup && bun run build:native-helper",
     "dev:web": "cd ../web && bun run dev -- --port 5173 --strictPort",
     "dev:electron": "wait-on --timeout 30000 http://localhost:5173 && electron-vite dev",

--- a/clients/windows/scripts/dev-electron-local-web.test.ts
+++ b/clients/windows/scripts/dev-electron-local-web.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+
+import { platformOriginFromDevUrl } from "./dev-electron-local-web";
+
+describe("platformOriginFromDevUrl", () => {
+  test("uses the remote origin without the renderer path", () => {
+    expect(
+      platformOriginFromDevUrl("https://dev-assistant.vellum.ai/assistant"),
+    ).toBe("https://dev-assistant.vellum.ai");
+  });
+
+  test("rejects URLs that cannot serve the platform API", () => {
+    expect(() => platformOriginFromDevUrl("file:///tmp/assistant")).toThrow(
+      "VELLUM_DEV_URL must use http or https",
+    );
+  });
+});

--- a/clients/windows/scripts/dev-electron-local-web.ts
+++ b/clients/windows/scripts/dev-electron-local-web.ts
@@ -1,0 +1,56 @@
+import path from "node:path";
+
+const packageDir = path.resolve(import.meta.dir, "..");
+
+export const platformOriginFromDevUrl = (value: string): string => {
+  const url = new URL(value);
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("VELLUM_DEV_URL must use http or https");
+  }
+  return url.origin;
+};
+
+const run = async (
+  args: string[],
+  env: Record<string, string | undefined>,
+): Promise<number> => {
+  const child = Bun.spawn([process.execPath, ...args], {
+    cwd: packageDir,
+    env,
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  return child.exited;
+};
+
+const main = async (): Promise<void> => {
+  const remoteUrl = process.env.VELLUM_DEV_URL;
+  if (!remoteUrl) {
+    throw new Error(
+      "Set VELLUM_DEV_URL to the remote platform URL, for example https://dev-assistant.vellum.ai/assistant",
+    );
+  }
+
+  const platformOrigin = platformOriginFromDevUrl(remoteUrl);
+  const buildExitCode = await run(["run", "build:web"], {
+    ...process.env,
+    VITE_PLATFORM_MODE: "true",
+  });
+  if (buildExitCode !== 0) {
+    process.exit(buildExitCode);
+  }
+
+  process.exit(
+    await run(["run", "dev:electron-only"], {
+      ...process.env,
+      VELLUM_LOCAL_RENDERER: "true",
+      VELLUM_PLATFORM_URL: platformOrigin,
+      VELLUM_WEB_URL: platformOrigin,
+    }),
+  );
+};
+
+if (import.meta.main) {
+  await main();
+}

--- a/clients/windows/src/main/app-config.ts
+++ b/clients/windows/src/main/app-config.ts
@@ -11,6 +11,8 @@
  * path is honored from `VELLUM_DEV_URL` (vel's edge proxy, or the
  * local Vite default at port 5173). Both end at the `/assistant`
  * suffix that `clients/web/vite.config.ts`'s `base` setting requires.
+ * `VELLUM_LOCAL_RENDERER` opts development into serving the locally built
+ * renderer through the app protocol, while keeping platform traffic remote.
  */
 
 export const APP_PROTOCOL = "app";
@@ -45,6 +47,10 @@ export const RENDERER_BASE_PROD = `${APP_PROTOCOL}://${APP_HOST}/assistant`;
 export const getDevRendererBase = (): string =>
   (process.env.VELLUM_DEV_URL ?? DEV_SERVER_FALLBACK_URL).replace(/\/+$/, "");
 
+/** Whether this process loads the renderer through the app protocol. */
+export const usesAppProtocolRenderer = (isPackaged: boolean): boolean =>
+  isPackaged || process.env.VELLUM_LOCAL_RENDERER === "true";
+
 /**
  * SPA-root URL the main BrowserWindow loads.
  *
@@ -58,4 +64,6 @@ export const getDevRendererBase = (): string =>
  * land on the `/assistant/*` NotFound route).
  */
 export const getRendererRootUrl = (isPackaged: boolean): string =>
-  isPackaged ? RENDERER_BASE_PROD : `${getDevRendererBase()}/`;
+  usesAppProtocolRenderer(isPackaged)
+    ? RENDERER_BASE_PROD
+    : `${getDevRendererBase()}/`;

--- a/clients/windows/src/main/app-origin.client.ts
+++ b/clients/windows/src/main/app-origin.client.ts
@@ -6,7 +6,12 @@ import {
   type AllowedOrigin,
 } from "@vellumai/electron-desktop/app-origin";
 
-import { APP_HOST, APP_PROTOCOL, getDevRendererBase } from "./app-config";
+import {
+  APP_HOST,
+  APP_PROTOCOL,
+  getDevRendererBase,
+  usesAppProtocolRenderer,
+} from "./app-config";
 
 export type { AllowedOrigin };
 export { isAllowedOrigin };
@@ -15,5 +20,5 @@ export const resolveAllowedOrigin = createAllowedOriginResolver({
   appHost: APP_HOST,
   appProtocol: APP_PROTOCOL,
   getDevRendererBase,
-  isPackaged: () => app.isPackaged,
+  isPackaged: () => usesAppProtocolRenderer(app.isPackaged),
 });

--- a/clients/windows/src/main/index.ts
+++ b/clients/windows/src/main/index.ts
@@ -8,9 +8,18 @@ import path from "node:path";
 import { resolveAppProtocolPath } from "@vellumai/electron-utils/app-protocol";
 import { VELLUMAPP_PROTOCOL } from "@vellumai/electron-desktop/bundle-platform";
 import { getDeviceId } from "@vellumai/electron-desktop/device-id";
+import {
+  executePlatformForwardPlan,
+  planPlatformForward,
+} from "@vellumai/electron-desktop/platform-forward";
 import { resolveLocalConfigFromEnv } from "@vellumai/local-mode";
 
-import { APP_PROTOCOL, WINDOWS_RELEASE_INFO } from "./app-config";
+import {
+  APP_PROTOCOL,
+  WINDOWS_RELEASE_INFO,
+  usesAppProtocolRenderer,
+} from "./app-config";
+import { resolveAllowedOrigin } from "./app-origin.client";
 import { provisionCliForCurrentUser } from "./cli-path-flow";
 import { installMainFeatures } from "./features";
 import { handleSync } from "./ipc.client";
@@ -29,8 +38,8 @@ import { installWebContentsSecurity } from "./windows.client";
  * partial preload bridge degrades to web behavior everywhere else.
  *
  * Not ported from the macOS client yet (see `clients/macos/src/main/` for the
- * reference implementations): gateway/platform request forwarding for
- * packaged builds, auto-update, CSP, notifications, and hotkeys.
+ * reference implementations): gateway request forwarding, auto-update, CSP,
+ * notifications, and hotkeys.
  */
 
 // Dev-only: override the package `name` (`@vellumai/windows`) so
@@ -42,7 +51,6 @@ import { installWebContentsSecurity } from "./windows.client";
 if (!app.isPackaged) {
   app.setName("Vellum Electron Windows");
 }
-const isDev = !app.isPackaged;
 
 // Packaged builds all share the same package.json `name`, so Electron
 // resolves `app.getPath("userData")` to the same directory for every
@@ -101,11 +109,6 @@ protocol.registerSchemesAsPrivileged([
 // live directly under `rendererRoot`; the mount prefix is stripped before
 // path resolution.
 //
-// TODO(windows): port the gateway (`/assistant/__gateway/{port}/*`) and
-// platform (`/v1/*`, `/_allauth/*`, `/accounts/*`) request forwarding from
-// `clients/macos/src/main/index.ts` so packaged builds can reach local
-// gateways and the cloud platform. Until then only dev runs (where the Vite
-// dev server proxies both) are fully functional.
 const RENDERER_MOUNT = "/assistant";
 
 const resolveRendererRoot = (): string => {
@@ -122,6 +125,14 @@ const registerAppProtocol = (): void => {
   const indexHtml = path.join(rendererRoot, "index.html");
 
   protocol.handle(APP_PROTOCOL, async (request) => {
+    const platformProxied = await forwardPlatformRequest(
+      request,
+      resolvedConfig.platformUrl,
+    );
+    if (platformProxied) {
+      return platformProxied;
+    }
+
     const result = resolveAppProtocolPath(
       rendererRoot,
       request.url,
@@ -164,6 +175,29 @@ handleSync("vellum:config:get", () => ({
   deviceId: getDeviceId(),
 }));
 
+const forwardPlatformRequest = async (
+  request: GlobalRequest,
+  platformUrl: string,
+): Promise<Response | null> => {
+  const plan = planPlatformForward(request, platformUrl, {
+    allowedOrigin: resolveAllowedOrigin(),
+  });
+  const target = plan.kind === "forward" ? `${plan.method} ${plan.url}` : "";
+  return executePlatformForwardPlan(
+    plan,
+    request,
+    (url, init) => net.fetch(url, init),
+    {
+      onError: (error, attempt) => {
+        log.error(
+          `[platform-forward] net.fetch failed (attempt ${attempt + 1}) for ${target}:`,
+          error,
+        );
+      },
+    },
+  );
+};
+
 // ---------------------------------------------------------------------------
 // App lifecycle
 // ---------------------------------------------------------------------------
@@ -171,7 +205,7 @@ handleSync("vellum:config:get", () => ({
 app
   .whenReady()
   .then(() => {
-    if (!isDev) {
+    if (usesAppProtocolRenderer(app.isPackaged)) {
       registerAppProtocol();
     }
     if (app.isPackaged && process.platform === "win32") {


### PR DESCRIPTION
## Summary
- add an Electron-only local renderer mode with no Vite server
- forward the local app protocol platform requests to the configured dev platform
- document the Windows PowerShell command

## Testing
- bun test scripts/dev-electron-local-web.test.ts
- bun test ../../packages/electron-desktop/src/platform-forward.test.ts
- bun run typecheck
- VITE_PLATFORM_MODE=true bun run build:web
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40803" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->