### PR TITLE
feat(web): paired-devices accordion with revoke in the Pair a device settings card

### DIFF
--- a/clients/web/src/domains/settings/pair-device/pair-device-card.test.tsx
+++ b/clients/web/src/domains/settings/pair-device/pair-device-card.test.tsx
@@ -8,6 +8,8 @@ import {
   waitFor,
 } from "@testing-library/react";
 
+import type { LocalListDevicesResult } from "@/runtime/local-mode-host";
+
 let gatewayPath: string | undefined = "/assistant/__gateway/20100";
 let supportsPairingRoutes = true;
 let webRemoteIngressOn = true;
@@ -38,6 +40,19 @@ mock.module("@/stores/client-feature-flag-store", () => ({
 mock.module("@/lib/sentry/capture-error", () => ({
   captureError: () => {},
 }));
+
+let listDevicesResult: LocalListDevicesResult = {
+  ok: false,
+  error: "unavailable",
+};
+
+mock.module(
+  "@/runtime/local-mode-host",
+  (): Partial<typeof import("@/runtime/local-mode-host")> => ({
+    listPairedDevicesHost: async () => listDevicesResult,
+    revokePairedDeviceHost: async () => ({ ok: true }),
+  }),
+);
 
 const { PairDeviceCard } = await import("./pair-device-card");
 
@@ -108,6 +123,7 @@ beforeEach(() => {
   supportsPairingRoutes = true;
   webRemoteIngressOn = true;
   selectedAssistant = { assistantId: "self", cloud: "local" };
+  listDevicesResult = { ok: false, error: "unavailable" };
   requests = [];
   localStorage.clear();
 });
@@ -265,6 +281,26 @@ describe("PairDeviceCard", () => {
       screen.getByText(
         "Scan with another device's camera — or open the link on it — to use My Assistant there.",
       ),
+    ).toBeTruthy();
+  });
+
+  test("shows the paired-devices section when the host reports a device", async () => {
+    listDevicesResult = {
+      ok: true,
+      devices: [
+        {
+          hashedDeviceId: "aaaabbbbccccdddd0000111122223333",
+          platform: "ios",
+          issuedAt: null,
+          expiresAt: null,
+          lastUsedAt: null,
+        },
+      ],
+    };
+    render(<PairDeviceCard />);
+
+    expect(
+      await screen.findByRole("button", { name: "Paired devices (1)" }),
     ).toBeTruthy();
   });
 

--- a/clients/web/src/domains/settings/pair-device/pair-device-card.tsx
+++ b/clients/web/src/domains/settings/pair-device/pair-device-card.tsx
@@ -9,6 +9,7 @@ import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 
 import { resolvePairDeviceTarget } from "./pair-device-client";
 import { PairDeviceReady } from "./pair-device-ready";
+import { PairedDevicesSection } from "./paired-devices-section";
 import { usePairDevice } from "./use-pair-device";
 
 /**
@@ -112,6 +113,8 @@ export function PairDeviceCard() {
             onCopy={copy}
           />
         )}
+
+        <PairedDevicesSection enabled />
       </div>
     </DetailCard>
   );

--- a/clients/web/src/domains/settings/pair-device/paired-devices-section.test.tsx
+++ b/clients/web/src/domains/settings/pair-device/paired-devices-section.test.tsx
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+
+import type {
+  LocalListDevicesResult,
+  LocalPairedDeviceRecord,
+  LocalRevokeDeviceResult,
+} from "@/runtime/local-mode-host";
+
+let listImpl: (assistantId: string) => Promise<LocalListDevicesResult>;
+let listCalls: string[] = [];
+let revokeResult: LocalRevokeDeviceResult = { ok: true };
+let revokeCalls: Array<{ assistantId: string; hashedDeviceId: string }> = [];
+
+mock.module(
+  "@/runtime/local-mode-host",
+  (): Partial<typeof import("@/runtime/local-mode-host")> => ({
+    listPairedDevicesHost: async (assistantId: string) => {
+      listCalls.push(assistantId);
+      return listImpl(assistantId);
+    },
+    revokePairedDeviceHost: async (
+      assistantId: string,
+      hashedDeviceId: string,
+    ) => {
+      revokeCalls.push({ assistantId, hashedDeviceId });
+      return revokeResult;
+    },
+  }),
+);
+
+mock.module(
+  "@/lib/local-mode",
+  (): Partial<typeof import("@/lib/local-mode")> => ({
+    getSelectedAssistant: () => ({ assistantId: "self", cloud: "local" }),
+    // Sibling test files in this suite mock the same module and share a
+    // process; keep the export their modules import so relinking succeeds.
+    getLocalGatewayUrl: () => undefined,
+  }),
+);
+
+const { PairedDevicesSection } = await import("./paired-devices-section");
+
+const HASH_A = "aaaabbbbccccdddd0000111122223333";
+const HASH_B = "eeeeffff00001111aaaabbbbccccdddd";
+
+function device(
+  overrides: Partial<LocalPairedDeviceRecord> = {},
+): LocalPairedDeviceRecord {
+  return {
+    hashedDeviceId: HASH_A,
+    platform: "ios",
+    issuedAt: Date.parse("2026-08-01T12:00:00Z"),
+    expiresAt: null,
+    lastUsedAt: Date.parse("2026-08-15T12:00:00Z"),
+    ...overrides,
+  };
+}
+
+/** Queue list responses; later calls replay the last entry. */
+function queueListResults(...results: LocalListDevicesResult[]) {
+  let index = 0;
+  listImpl = async () => {
+    const result = results[Math.min(index, results.length - 1)]!;
+    index += 1;
+    return result;
+  };
+}
+
+async function renderExpanded(devices: LocalPairedDeviceRecord[]) {
+  queueListResults({ ok: true, devices }, { ok: true, devices });
+  render(<PairedDevicesSection enabled />);
+  const trigger = await screen.findByRole("button", {
+    name: `Paired devices (${devices.length})`,
+  });
+  fireEvent.click(trigger);
+}
+
+beforeEach(() => {
+  listImpl = async () => ({ ok: false, error: "unset" });
+  listCalls = [];
+  revokeResult = { ok: true };
+  revokeCalls = [];
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("PairedDevicesSection", () => {
+  test("renders nothing while the list is loading", () => {
+    listImpl = () => new Promise(() => {});
+    const { container } = render(<PairedDevicesSection enabled />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("renders nothing when the host refuses the list", async () => {
+    queueListResults({ ok: false, error: "unavailable" });
+    const { container } = render(<PairedDevicesSection enabled />);
+    await waitFor(() => expect(listCalls.length).toBe(1));
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("renders nothing when no devices are paired", async () => {
+    queueListResults({ ok: true, devices: [] });
+    const { container } = render(<PairedDevicesSection enabled />);
+    await waitFor(() => expect(listCalls.length).toBe(1));
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("shows the count in the trigger and device rows when expanded", async () => {
+    await renderExpanded([
+      device(),
+      device({ hashedDeviceId: HASH_B, platform: "android" }),
+    ]);
+
+    expect(listCalls).toEqual(["self"]);
+    expect(screen.getByText("Ios")).toBeTruthy();
+    expect(screen.getByText("Android")).toBeTruthy();
+    const shortA = screen.getByText(HASH_A.slice(0, 12));
+    expect(shortA.getAttribute("title")).toBe(HASH_A);
+    expect(screen.getAllByRole("button", { name: "Revoke" })).toHaveLength(2);
+  });
+
+  test("clicking Revoke opens the confirmation naming the device", async () => {
+    await renderExpanded([device()]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Revoke" }));
+
+    expect(screen.getByText("Revoke this device?")).toBeTruthy();
+    expect(
+      screen.getByText(new RegExp(`Ios device ${HASH_A.slice(0, 12)}`)),
+    ).toBeTruthy();
+    expect(revokeCalls).toHaveLength(0);
+  });
+
+  test("confirming revokes the device and refetches the list", async () => {
+    await renderExpanded([device()]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Revoke" }));
+    fireEvent.click(
+      document.querySelector<HTMLButtonElement>(
+        "[data-confirm-dialog-confirm]",
+      )!,
+    );
+
+    await waitFor(() => expect(listCalls.length).toBe(2));
+    expect(revokeCalls).toEqual([
+      { assistantId: "self", hashedDeviceId: HASH_A },
+    ]);
+    await waitFor(() =>
+      expect(screen.queryByText("Revoke this device?")).toBeNull(),
+    );
+  });
+
+  test("a failed revoke keeps the dialog open with the error", async () => {
+    revokeResult = { ok: false, error: "Gateway is unreachable" };
+    await renderExpanded([device()]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Revoke" }));
+    fireEvent.click(
+      document.querySelector<HTMLButtonElement>(
+        "[data-confirm-dialog-confirm]",
+      )!,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText("Gateway is unreachable")).toBeTruthy(),
+    );
+    expect(screen.getByText("Revoke this device?")).toBeTruthy();
+    expect(listCalls).toHaveLength(1);
+  });
+});

--- a/clients/web/src/domains/settings/pair-device/paired-devices-section.tsx
+++ b/clients/web/src/domains/settings/pair-device/paired-devices-section.tsx
@@ -1,0 +1,113 @@
+import { ChevronDown } from "lucide-react";
+
+import { Button } from "@vellumai/design-library/components/button";
+import { Collapsible } from "@vellumai/design-library/components/collapsible";
+import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
+
+import { usePairedDevices } from "./use-paired-devices";
+
+function shortHash(hashedDeviceId: string): string {
+  return hashedDeviceId.slice(0, 12);
+}
+
+function platformLabel(platform: string): string {
+  return platform
+    ? platform.charAt(0).toUpperCase() + platform.slice(1)
+    : "Unknown";
+}
+
+function formatDeviceDate(epochMs: number | null): string {
+  return epochMs === null ? "unknown" : new Date(epochMs).toLocaleDateString();
+}
+
+export interface PairedDevicesSectionProps {
+  /** Mirrors the card's visibility gates so the hook only fetches when the card shows. */
+  enabled: boolean;
+}
+
+/**
+ * Accordion listing the devices paired to the local assistant, with a
+ * destructive per-device Revoke behind a confirm dialog. Renders nothing
+ * unless the host reports one or more devices, so older app shells, host
+ * failures, and empty lists leave the Pair a device card exactly as it is.
+ */
+export function PairedDevicesSection({ enabled }: PairedDevicesSectionProps) {
+  const controller = usePairedDevices(enabled);
+  const { phase, confirmTarget } = controller;
+
+  if (phase.kind !== "ready" || phase.devices.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <Collapsible.Root type="multiple">
+        <Collapsible.Item value="paired-devices">
+          <Collapsible.Trigger className="group flex w-full items-center justify-between gap-3">
+            <span className="text-body-medium-default text-[var(--content-secondary)]">
+              {`Paired devices (${phase.devices.length})`}
+            </span>
+            <ChevronDown className="h-4 w-4 shrink-0 text-[var(--content-tertiary)] transition-transform group-data-[state=open]:rotate-180" />
+          </Collapsible.Trigger>
+          <Collapsible.Content>
+            <div className="mt-3 flex flex-col gap-3">
+              {phase.devices.map((device) => (
+                <div
+                  key={device.hashedDeviceId}
+                  className="flex items-center justify-between gap-3"
+                >
+                  <div className="flex min-w-0 flex-col">
+                    <span className="text-body-medium-default text-[var(--content-secondary)]">
+                      {platformLabel(device.platform)}{" "}
+                      <span
+                        className="font-mono text-[var(--content-tertiary)]"
+                        title={device.hashedDeviceId}
+                      >
+                        {shortHash(device.hashedDeviceId)}
+                      </span>
+                    </span>
+                    <span className="text-body-medium-default text-[var(--content-tertiary)]">
+                      {`Paired ${formatDeviceDate(device.issuedAt)} · Last used ${formatDeviceDate(device.lastUsedAt)}`}
+                    </span>
+                  </div>
+                  <Button
+                    variant="dangerOutline"
+                    size="compact"
+                    className="shrink-0"
+                    onClick={() => controller.requestRevoke(device)}
+                  >
+                    Revoke
+                  </Button>
+                </div>
+              ))}
+            </div>
+          </Collapsible.Content>
+        </Collapsible.Item>
+      </Collapsible.Root>
+      <ConfirmDialog
+        open={confirmTarget !== null}
+        title="Revoke this device?"
+        message={
+          confirmTarget && (
+            <>
+              The {platformLabel(confirmTarget.platform)} device{" "}
+              {shortHash(confirmTarget.hashedDeviceId)} loses access to this
+              assistant. Its access tokens are invalidated immediately; that
+              device must be paired again from this machine to reconnect.
+              {controller.revokeError && (
+                <span className="mt-2 block text-[var(--system-negative-strong)]">
+                  {controller.revokeError}
+                </span>
+              )}
+            </>
+          )
+        }
+        confirmLabel="Revoke"
+        destructive
+        isPending={controller.isRevoking}
+        onConfirm={controller.confirmRevoke}
+        onCancel={controller.cancelRevoke}
+      />
+    </>
+  );
+}

--- a/clients/web/src/domains/settings/pair-device/use-paired-devices.ts
+++ b/clients/web/src/domains/settings/pair-device/use-paired-devices.ts
@@ -1,0 +1,127 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { getSelectedAssistant } from "@/lib/local-mode";
+import {
+  listPairedDevicesHost,
+  revokePairedDeviceHost,
+  type LocalPairedDeviceRecord,
+} from "@/runtime/local-mode-host";
+
+export type PairedDevicesPhase =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "ready"; devices: LocalPairedDeviceRecord[] }
+  | { kind: "unavailable" };
+
+export interface PairedDevicesController {
+  phase: PairedDevicesPhase;
+  /** Device awaiting revoke confirmation, or `null` when no dialog is open. */
+  confirmTarget: LocalPairedDeviceRecord | null;
+  /** Whether a revoke request is in flight. */
+  isRevoking: boolean;
+  /** Inline failure line for the confirm dialog, or `null`. */
+  revokeError: string | null;
+  /** Open the revoke confirmation for a device. */
+  requestRevoke: (device: LocalPairedDeviceRecord) => void;
+  /** Close the confirmation without revoking. */
+  cancelRevoke: () => void;
+  /** Revoke {@link confirmTarget}'s tokens; refreshes the list on success. */
+  confirmRevoke: () => void;
+  /** Re-fetch the device list from the host. */
+  refresh: () => void;
+}
+
+/**
+ * Drives the "Paired devices" accordion: fetches the selected assistant's
+ * paired devices through the host seam and runs the confirm-then-revoke flow.
+ * Any `{ ok: false }` list result (older app shells, unavailable hosts,
+ * transport failures) collapses to the `unavailable` phase so the section
+ * degrades silently instead of showing a broken state.
+ */
+export function usePairedDevices(enabled: boolean): PairedDevicesController {
+  const [assistantId] = useState(
+    () => getSelectedAssistant()?.assistantId ?? null,
+  );
+  const [phase, setPhase] = useState<PairedDevicesPhase>({ kind: "idle" });
+  const [confirmTarget, setConfirmTarget] =
+    useState<LocalPairedDeviceRecord | null>(null);
+  const [isRevoking, setIsRevoking] = useState(false);
+  const [revokeError, setRevokeError] = useState<string | null>(null);
+
+  // Host calls aren't abortable, so guard setState after unmount (and against
+  // out-of-order responses) with a mounted flag + request sequence.
+  const mountedRef = useRef(true);
+  const fetchSeqRef = useRef(0);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const refresh = useCallback(() => {
+    if (!enabled || !assistantId) {
+      return;
+    }
+    const seq = ++fetchSeqRef.current;
+    setPhase({ kind: "loading" });
+    void listPairedDevicesHost(assistantId).then((result) => {
+      if (!mountedRef.current || seq !== fetchSeqRef.current) {
+        return;
+      }
+      setPhase(
+        result.ok
+          ? { kind: "ready", devices: result.devices }
+          : { kind: "unavailable" },
+      );
+    });
+  }, [enabled, assistantId]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const requestRevoke = useCallback((device: LocalPairedDeviceRecord) => {
+    setRevokeError(null);
+    setConfirmTarget(device);
+  }, []);
+
+  const cancelRevoke = useCallback(() => {
+    setConfirmTarget(null);
+    setRevokeError(null);
+  }, []);
+
+  const confirmRevoke = useCallback(() => {
+    if (!assistantId || !confirmTarget || isRevoking) {
+      return;
+    }
+    setIsRevoking(true);
+    setRevokeError(null);
+    void revokePairedDeviceHost(assistantId, confirmTarget.hashedDeviceId).then(
+      (result) => {
+        if (!mountedRef.current) {
+          return;
+        }
+        setIsRevoking(false);
+        if (result.ok) {
+          setConfirmTarget(null);
+          refresh();
+        } else {
+          setRevokeError(result.error);
+        }
+      },
+    );
+  }, [assistantId, confirmTarget, isRevoking, refresh]);
+
+  return {
+    phase,
+    confirmTarget,
+    isRevoking,
+    revokeError,
+    requestRevoke,
+    cancelRevoke,
+    confirmRevoke,
+    refresh,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds a Paired devices accordion to the Pair a device settings card, listing devices paired to the local assistant
- Per-device destructive Revoke behind a confirm dialog; success refreshes the list, failure shows inline error
- Renders only when the host reports one or more devices; older shells and host failures degrade silently

Part of plan: paired-devices-revoke.md (PR 6 of 6)