### PR TITLE
fix: lockfile name selector presence semantics + remote-gateway entry name

### DIFF
--- a/clients/web/src/hooks/use-lockfile-identity-sync.test.tsx
+++ b/clients/web/src/hooks/use-lockfile-identity-sync.test.tsx
@@ -29,7 +29,7 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function lockfileEntry(assistantId: string, name: string): LockfileAssistant {
+function lockfileEntry(assistantId: string, name?: string): LockfileAssistant {
   return { assistantId, cloud: "local", name } as LockfileAssistant;
 }
 
@@ -122,6 +122,32 @@ describe("useLockfileIdentitySync", () => {
     act(() => {
       useLockfileStore.getState().setLockfile({
         assistants: [lockfileEntry("assistant-1", "Stale Name")],
+        activeAssistant: "assistant-1",
+      });
+    });
+
+    expect(renameLockfileAssistantMock).toHaveBeenCalledTimes(2);
+    expect(renameLockfileAssistantMock).toHaveBeenLastCalledWith(
+      "assistant-1",
+      "Aria",
+    );
+  });
+
+  test("re-fires when an unnamed lockfile entry hydrates after the identity store", () => {
+    renderHook(() => useLockfileIdentitySync());
+
+    act(() => {
+      useAssistantIdentityStore
+        .getState()
+        .setIdentity("Aria", "1.2.3", "assistant-1");
+    });
+    // First attempt ran against an unhydrated lockfile (helper no-ops on a
+    // missing entry).
+    expect(renameLockfileAssistantMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      useLockfileStore.getState().setLockfile({
+        assistants: [lockfileEntry("assistant-1")],
         activeAssistant: "assistant-1",
       });
     });

--- a/clients/web/src/lib/local-mode.test.ts
+++ b/clients/web/src/lib/local-mode.test.ts
@@ -184,6 +184,22 @@ describe("remote gateway mode", () => {
     expect(getLocalGatewayUrl()).toBeUndefined();
     expect(useLockfileStore.getState().committed).toBe(true);
   });
+
+  test("names the synthetic assistant from the injected config when present", async () => {
+    window.__VELLUM_CONFIG__ = {
+      mode: "remote-gateway",
+      assistantName: "vellum-deep-hare-ww1iw1",
+    };
+
+    const lockfile = await loadLockfile();
+
+    expect(lockfile.assistants).toEqual([
+      expect.objectContaining({
+        assistantId: "self",
+        name: "vellum-deep-hare-ww1iw1",
+      }),
+    ]);
+  });
 });
 
 describe("getRemoteAssistantDisplayName", () => {

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -135,7 +135,7 @@ function getRemoteGatewayLockfile(): Lockfile {
     assistants: [
       {
         assistantId: "self",
-        name: "Local Assistant",
+        name: getRemoteGatewayAssistantName() ?? "Local Assistant",
         cloud: "local",
         runtimeUrl: window.location.origin,
         hatchedAt: "1970-01-01T00:00:00.000Z",
@@ -677,19 +677,24 @@ export function getLockfileAssistant(
 }
 
 /**
- * React subscription to one lockfile entry's `name`. `undefined` while the
- * lockfile hasn't hydrated or the id has no entry, so effects depending on it
- * re-fire once the entry appears. Narrow on purpose: the lockfile store stays
- * internal to this module.
+ * React subscription to one lockfile entry's `name`: `undefined` while the
+ * lockfile hasn't hydrated or the id has no entry, `null` when the entry
+ * exists but is unnamed. Distinguishing absence from an unnamed entry lets
+ * effects depending on this value re-fire even when the appearing entry
+ * carries no name.
  */
 export function useLockfileAssistantName(
   assistantId: string | null,
-): string | undefined {
-  return useLockfileStore((s) =>
-    assistantId === null
-      ? undefined
-      : s.lockfile?.assistants.find((a) => a.assistantId === assistantId)?.name,
-  );
+): string | null | undefined {
+  return useLockfileStore((s) => {
+    if (assistantId === null) {
+      return undefined;
+    }
+    const entry = s.lockfile?.assistants.find(
+      (a) => a.assistantId === assistantId,
+    );
+    return entry === undefined ? undefined : (entry.name ?? null);
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for unify-assistant-naming.md.

**Gap A:** useLockfileAssistantName collapsed 'entry absent' and 'entry present, unnamed' into undefined, so an unnamed entry hydrating late never re-fired the sync (also Codex P2 on #40799). Selector now returns null for present-but-unnamed vs undefined for absent.
**Gap B:** getRemoteGatewayLockfile hardcoded 'Local Assistant' despite the injected config carrying the real name.