### PR TITLE
feat(web): approve pending web-pairing requests from settings

### DIFF
--- a/clients/web/src/domains/settings/pair-device/pair-device-card.test.tsx
+++ b/clients/web/src/domains/settings/pair-device/pair-device-card.test.tsx
@@ -69,15 +69,41 @@ function challengeBody() {
   };
 }
 
+function pendingRequestBody() {
+  return {
+    requestId: "req-1",
+    userCode: "QRST-7890",
+    publicBaseUrl: PUBLIC_URL,
+    requestedAt: new Date(Date.now() - 2 * 60_000).toISOString(),
+    expiresAt: futureIso(),
+    requesterIp: "203.0.113.7",
+    requesterUserAgent: "Mozilla/5.0 (iPhone; like Mac OS X)",
+  };
+}
+
+interface FetchHandlers {
+  onVerification?: () => Response;
+  onPendingRequests?: () => Response | Promise<Response>;
+  onRequestAction?: () => Response | Promise<Response>;
+}
+
+function unexpectedMint(): Response {
+  throw new Error("unexpected challenge mint");
+}
+
 /** Install a fetch mock that records requests and answers per route. */
 function installFetch(
   onChallenge: () => Response,
-  onVerification: () => Response = () =>
-    jsonResponse({
-      status: "approved",
-      verificationUri: "https://foo.ts.net/assistant/pair",
-      expiresAt: futureIso(),
-    }),
+  {
+    onVerification = () =>
+      jsonResponse({
+        status: "approved",
+        verificationUri: "https://foo.ts.net/assistant/pair",
+        expiresAt: futureIso(),
+      }),
+    onPendingRequests = () => jsonResponse({ requests: [] }),
+    onRequestAction = () => jsonResponse({ status: "done" }),
+  }: FetchHandlers = {},
 ) {
   const fetchMock = mock(async (input: string | URL, init?: RequestInit) => {
     const url = typeof input === "string" ? input : input.toString();
@@ -91,10 +117,32 @@ function installFetch(
     if (url.endsWith("/v1/remote-web/pairing-verification")) {
       return onVerification();
     }
+    if (url.endsWith("/v1/remote-web/pairing-requests")) {
+      return onPendingRequests();
+    }
+    if (
+      url.endsWith("/v1/remote-web/pairing-requests/approve") ||
+      url.endsWith("/v1/remote-web/pairing-requests/deny")
+    ) {
+      return onRequestAction();
+    }
     throw new Error(`unexpected fetch: ${url}`);
   });
   globalThis.fetch = fetchMock as unknown as typeof fetch;
   return fetchMock;
+}
+
+function actionCalls(action: "approve" | "deny") {
+  return requests.filter((request) =>
+    request.url.endsWith(`/v1/remote-web/pairing-requests/${action}`),
+  );
+}
+
+/** The mint-flow calls (challenge + verification), without the section's list polls. */
+function mintCalls() {
+  return requests.filter(
+    (request) => !request.url.endsWith("/v1/remote-web/pairing-requests"),
+  );
 }
 
 function typeUrl(value: string) {
@@ -110,6 +158,9 @@ beforeEach(() => {
   selectedAssistant = { assistantId: "self", cloud: "local" };
   requests = [];
   localStorage.clear();
+  // A rendered card polls the pending-request list on mount, so every test
+  // needs the route answered; minting stays unexpected unless overridden.
+  installFetch(unexpectedMint);
 });
 
 afterEach(() => {
@@ -150,7 +201,7 @@ describe("PairDeviceCard", () => {
   });
 
   test("mints + approves, then shows the QR and pair URL", async () => {
-    const fetchMock = installFetch(() => jsonResponse(challengeBody()));
+    installFetch(() => jsonResponse(challengeBody()));
     render(<PairDeviceCard />);
     typeUrl(PUBLIC_URL);
     fireEvent.click(
@@ -162,15 +213,15 @@ describe("PairDeviceCard", () => {
     );
     expect(screen.getByTestId("pair-device-url").textContent).toBe(PAIR_URL);
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(requests[0]?.url).toContain(
+    expect(mintCalls()).toHaveLength(2);
+    expect(mintCalls()[0]?.url).toContain(
       "/assistant/__gateway/20100/v1/remote-web/pairing-challenge",
     );
-    expect(requests[0]?.body).toEqual({ publicBaseUrl: PUBLIC_URL });
-    expect(requests[1]?.url).toContain(
+    expect(mintCalls()[0]?.body).toEqual({ publicBaseUrl: PUBLIC_URL });
+    expect(mintCalls()[1]?.url).toContain(
       "/assistant/__gateway/20100/v1/remote-web/pairing-verification",
     );
-    expect(requests[1]?.body).toEqual({ userCode: "WXYZ-1234" });
+    expect(mintCalls()[1]?.body).toEqual({ userCode: "WXYZ-1234" });
   });
 
   test("surfaces the server's rejection message with a connectivity hint", async () => {
@@ -193,7 +244,7 @@ describe("PairDeviceCard", () => {
   });
 
   test("blocks a loopback URL client-side without a network call", () => {
-    const fetchMock = installFetch(() => jsonResponse(challengeBody()));
+    installFetch(() => jsonResponse(challengeBody()));
     render(<PairDeviceCard />);
     typeUrl("http://localhost:3000");
     fireEvent.click(
@@ -205,7 +256,7 @@ describe("PairDeviceCard", () => {
         "This is a loopback address other devices can't reach. Enter the assistant's public https URL.",
       ),
     ).toBeTruthy();
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mintCalls()).toHaveLength(0);
   });
 
   test("prefills the URL field from the assistant's recorded tunnel URL", () => {
@@ -237,7 +288,7 @@ describe("PairDeviceCard", () => {
   });
 
   test("rejects a tunnel-provider website URL (Tailscale admin invite) with a service-website message", () => {
-    const fetchMock = installFetch(() => jsonResponse(challengeBody()));
+    installFetch(() => jsonResponse(challengeBody()));
     render(<PairDeviceCard />);
     typeUrl("https://login.tailscale.com/admin/invite/abc123");
     fireEvent.click(
@@ -250,7 +301,7 @@ describe("PairDeviceCard", () => {
       ),
     ).toBeTruthy();
     // The bad URL is refused client-side — no challenge is ever minted.
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mintCalls()).toHaveLength(0);
   });
 
   test("names the assistant it pairs in the subtitle", () => {
@@ -276,5 +327,115 @@ describe("PairDeviceCard", () => {
         "Scan with another device's camera — or open the link on it — to use this assistant there.",
       ),
     ).toBeTruthy();
+  });
+});
+
+describe("PairDeviceCard: pending pairing requests", () => {
+  function installPendingFetch(handlers: FetchHandlers = {}) {
+    return installFetch(unexpectedMint, {
+      onPendingRequests: () =>
+        jsonResponse({ requests: [pendingRequestBody()] }),
+      ...handlers,
+    });
+  }
+
+  test("hides the approval section while no request is pending", async () => {
+    render(<PairDeviceCard />);
+
+    // The list was polled and came back empty.
+    await waitFor(() =>
+      expect(
+        requests.some((r) => r.url.endsWith("/v1/remote-web/pairing-requests")),
+      ).toBe(true),
+    );
+    expect(screen.queryByText("Pairing requests")).toBeNull();
+  });
+
+  test("renders a pending request's user code and requester metadata", async () => {
+    installPendingFetch();
+    render(<PairDeviceCard />);
+
+    await waitFor(() => expect(screen.getByText("QRST-7890")).toBeTruthy());
+    expect(screen.getByText("Pairing requests")).toBeTruthy();
+    // The anti-phishing binding: approval is tied to matching the code shown
+    // on the requesting device.
+    expect(
+      screen.getByText(/matches the one shown on the requesting device/),
+    ).toBeTruthy();
+    expect(screen.getByText(/203\.0\.113\.7/)).toBeTruthy();
+    expect(
+      screen.getByText("Mozilla/5.0 (iPhone; like Mac OS X)"),
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Approve" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Deny" })).toBeTruthy();
+  });
+
+  test("Approve posts the request id and removes the row", async () => {
+    installPendingFetch();
+    render(<PairDeviceCard />);
+    await waitFor(() => expect(screen.getByText("QRST-7890")).toBeTruthy());
+
+    fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+
+    await waitFor(() => expect(actionCalls("approve")).toHaveLength(1));
+    expect(actionCalls("approve")[0]?.body).toEqual({ requestId: "req-1" });
+    await waitFor(() => expect(screen.queryByText("QRST-7890")).toBeNull());
+    expect(actionCalls("deny")).toHaveLength(0);
+  });
+
+  test("Deny posts the request id and removes the row", async () => {
+    installPendingFetch();
+    render(<PairDeviceCard />);
+    await waitFor(() => expect(screen.getByText("QRST-7890")).toBeTruthy());
+
+    fireEvent.click(screen.getByRole("button", { name: "Deny" }));
+
+    await waitFor(() => expect(actionCalls("deny")).toHaveLength(1));
+    expect(actionCalls("deny")[0]?.body).toEqual({ requestId: "req-1" });
+    await waitFor(() => expect(screen.queryByText("QRST-7890")).toBeNull());
+    expect(actionCalls("approve")).toHaveLength(0);
+  });
+
+  test("action buttons disable while an action is in flight", async () => {
+    // An approve that never resolves keeps the action in flight.
+    installPendingFetch({
+      onRequestAction: () => new Promise<Response>(() => {}),
+    });
+    render(<PairDeviceCard />);
+    await waitFor(() => expect(screen.getByText("QRST-7890")).toBeTruthy());
+
+    fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+
+    await waitFor(() =>
+      expect(
+        (screen.getByRole("button", { name: "Approve" }) as HTMLButtonElement)
+          .disabled,
+      ).toBe(true),
+    );
+    expect(
+      (screen.getByRole("button", { name: "Deny" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+  });
+
+  test("stays hidden with the card when there is no local gateway", () => {
+    gatewayPath = undefined;
+    installPendingFetch();
+    const { container } = render(<PairDeviceCard />);
+
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByText("Pairing requests")).toBeNull();
+    // The gate keeps the poll from ever firing.
+    expect(requests).toHaveLength(0);
+  });
+
+  test("stays hidden with the card when web-remote-ingress is off", () => {
+    webRemoteIngressOn = false;
+    installPendingFetch();
+    const { container } = render(<PairDeviceCard />);
+
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByText("Pairing requests")).toBeNull();
+    expect(requests).toHaveLength(0);
   });
 });

--- a/clients/web/src/domains/settings/pair-device/pair-device-card.test.tsx
+++ b/clients/web/src/domains/settings/pair-device/pair-device-card.test.tsx
@@ -351,6 +351,23 @@ describe("PairDeviceCard: pending pairing requests", () => {
     expect(screen.queryByText("Pairing requests")).toBeNull();
   });
 
+  test("a failing list poll surfaces the error notice even with no rows", async () => {
+    installFetch(unexpectedMint, {
+      onPendingRequests: () =>
+        jsonResponse({ error: { message: "gateway unreachable" } }, 500),
+    });
+    render(<PairDeviceCard />);
+
+    await waitFor(() =>
+      expect(screen.getByText("gateway unreachable")).toBeTruthy(),
+    );
+    // The section shows with the error so an outage isn't mistaken for an
+    // empty queue, but no request rows or actions are offered.
+    expect(screen.getByText("Pairing requests")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Approve" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Deny" })).toBeNull();
+  });
+
   test("renders a pending request's user code and requester metadata", async () => {
     installPendingFetch();
     render(<PairDeviceCard />);
@@ -362,7 +379,10 @@ describe("PairDeviceCard: pending pairing requests", () => {
     expect(
       screen.getByText(/matches the one shown on the requesting device/),
     ).toBeTruthy();
-    expect(screen.getByText(/203\.0\.113\.7/)).toBeTruthy();
+    // The relative timestamp is locale-aware (en active in tests).
+    expect(
+      screen.getByText(/Requested 2 minutes ago from 203\.0\.113\.7/),
+    ).toBeTruthy();
     expect(
       screen.getByText("Mozilla/5.0 (iPhone; like Mac OS X)"),
     ).toBeTruthy();

--- a/clients/web/src/domains/settings/pair-device/pair-device-card.test.tsx
+++ b/clients/web/src/domains/settings/pair-device/pair-device-card.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -388,6 +389,41 @@ describe("PairDeviceCard: pending pairing requests", () => {
     ).toBeTruthy();
     expect(screen.getByRole("button", { name: "Approve" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Deny" })).toBeTruthy();
+  });
+
+  test("the relative request age advances while the request stays pending", async () => {
+    installPendingFetch();
+    // Bun has no fake timers: capture armed intervals by hand and drive the
+    // 30s age tick directly. `waitFor` needs real timers, so this test stubs
+    // per-test, flushes with `act`, and restores in `finally`.
+    const realSetInterval = globalThis.setInterval;
+    const realClearInterval = globalThis.clearInterval;
+    const realDateNow = Date.now;
+    const timers: Array<{ handler: () => void; delay: number }> = [];
+    globalThis.setInterval = ((handler: () => void, delay: number) => {
+      timers.push({ handler, delay });
+      return timers.length as unknown as ReturnType<typeof setInterval>;
+    }) as typeof globalThis.setInterval;
+    globalThis.clearInterval = (() => {}) as typeof globalThis.clearInterval;
+    try {
+      await act(async () => {
+        render(<PairDeviceCard />);
+      });
+      expect(screen.getByText(/Requested 2 minutes ago/)).toBeTruthy();
+
+      // Advance the clock 3 minutes and fire the age-refresh tick.
+      const now = realDateNow();
+      Date.now = () => now + 3 * 60_000;
+      const ageTick = timers.find((timer) => timer.delay === 30_000);
+      expect(ageTick).toBeTruthy();
+      act(() => ageTick?.handler());
+
+      expect(screen.getByText(/Requested 5 minutes ago/)).toBeTruthy();
+    } finally {
+      globalThis.setInterval = realSetInterval;
+      globalThis.clearInterval = realClearInterval;
+      Date.now = realDateNow;
+    }
   });
 
   test("Approve posts the request id and removes the row", async () => {

--- a/clients/web/src/domains/settings/pair-device/pair-device-card.tsx
+++ b/clients/web/src/domains/settings/pair-device/pair-device-card.tsx
@@ -9,6 +9,7 @@ import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 
 import { resolvePairDeviceTarget } from "./pair-device-client";
 import { PairDeviceReady } from "./pair-device-ready";
+import { PendingPairingRequests } from "./pending-pairing-requests";
 import { usePairDevice } from "./use-pair-device";
 
 /**
@@ -16,7 +17,9 @@ import { usePairDevice } from "./use-pair-device";
  * commands —
  * the UI equivalent of `vellum pair --qr`. It mints and auto-approves a
  * device-code challenge against the host's loopback gateway and renders the
- * https pair URL as a QR with a copyable link and expiry countdown.
+ * https pair URL as a QR with a copyable link and expiry countdown. It also
+ * hosts the approval list for pairing requests minted elsewhere
+ * ({@link PendingPairingRequests}).
  *
  * Rendered only in desktop/local mode against an on-machine gateway (the gate
  * lives in {@link resolvePairDeviceTarget}) whose assistant version serves the
@@ -112,6 +115,8 @@ export function PairDeviceCard() {
             onCopy={copy}
           />
         )}
+
+        <PendingPairingRequests base={target.base} />
       </div>
     </DetailCard>
   );

--- a/clients/web/src/domains/settings/pair-device/pending-pairing-requests.tsx
+++ b/clients/web/src/domains/settings/pair-device/pending-pairing-requests.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from "react";
+
 import { Button } from "@vellumai/design-library/components/button";
 import { Notice } from "@vellumai/design-library/components/notice";
 
@@ -9,6 +11,9 @@ interface PendingPairingRequestsProps {
   /** Absolute local-gateway base URL the requests are listed and acted on against. */
   base: string;
 }
+
+/** How often visible relative ages re-render; 30s suits minute phrasing. */
+const AGE_REFRESH_INTERVAL_MS = 30_000;
 
 const RELATIVE_UNITS: Array<{ unit: Intl.RelativeTimeFormatUnit; ms: number }> =
   [
@@ -48,6 +53,22 @@ export function PendingPairingRequests({ base }: PendingPairingRequestsProps) {
   const { t } = useTranslation("settings");
   const { requests, actingOn, error, approve, deny } =
     usePendingPairingRequests(base);
+
+  // The hook keeps a stable list reference while the pending set is unchanged,
+  // so nothing re-renders on its own and relative ages would freeze. Tick a
+  // render while any request is visible so `formatRequestedAt` stays current.
+  const hasRequests = requests.length > 0;
+  const [, setAgeTick] = useState(0);
+  useEffect(() => {
+    if (!hasRequests) {
+      return;
+    }
+    const intervalId = setInterval(
+      () => setAgeTick((tick) => tick + 1),
+      AGE_REFRESH_INTERVAL_MS,
+    );
+    return () => clearInterval(intervalId);
+  }, [hasRequests]);
 
   // An empty list with no error is the quiet normal state; a poll error must
   // still surface so an outage isn't mistaken for an empty queue.

--- a/clients/web/src/domains/settings/pair-device/pending-pairing-requests.tsx
+++ b/clients/web/src/domains/settings/pair-device/pending-pairing-requests.tsx
@@ -1,0 +1,89 @@
+import { Button } from "@vellumai/design-library/components/button";
+import { Notice } from "@vellumai/design-library/components/notice";
+
+import { useTranslation } from "@/i18n";
+import { formatRelativeDate } from "@/utils/format-date";
+
+import { usePendingPairingRequests } from "./use-pending-pairing-requests";
+
+interface PendingPairingRequestsProps {
+  /** Absolute local-gateway base URL the requests are listed and acted on against. */
+  base: string;
+}
+
+/**
+ * The approval half of the Pair Device card: pending pairing requests minted
+ * elsewhere (the public `/assistant/pair` page), each approvable or deniable
+ * by the host. Renders nothing while no request is pending. Each row shows its
+ * user code prominently so the approver can match it against the requesting
+ * device's screen: the device-flow anti-phishing binding.
+ */
+export function PendingPairingRequests({ base }: PendingPairingRequestsProps) {
+  const { t } = useTranslation("settings");
+  const { requests, actingOn, error, approve, deny } =
+    usePendingPairingRequests(base);
+
+  if (requests.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="flex flex-col gap-3 border-t border-[var(--border-element)] pt-4">
+      <div className="flex flex-col gap-1">
+        <h3 className="text-title-small text-[var(--content-emphasised)]">
+          {t("pendingPairingRequests.title")}
+        </h3>
+        <p className="text-body-small-default text-[var(--content-tertiary)]">
+          {t("pendingPairingRequests.instruction")}
+        </p>
+      </div>
+      {error && <Notice tone="error" title={error} />}
+      <ul className="flex flex-col gap-2">
+        {requests.map((request) => (
+          <li
+            key={request.requestId}
+            className="flex flex-col gap-2 rounded-lg border border-[var(--border-element)] p-3"
+          >
+            <code className="w-fit rounded-md bg-[var(--surface-active)] px-2.5 py-1.5 text-title-medium tracking-wide text-[var(--content-emphasised)]">
+              {request.userCode}
+            </code>
+            <div className="flex flex-col gap-0.5">
+              <p className="text-body-small-default text-[var(--content-tertiary)]">
+                {t("pendingPairingRequests.requestedMeta", {
+                  when: formatRelativeDate(request.requestedAt),
+                  ip: request.requesterIp,
+                })}
+              </p>
+              {request.requesterUserAgent && (
+                <p
+                  className="truncate text-body-small-default text-[var(--content-tertiary)]"
+                  title={request.requesterUserAgent}
+                >
+                  {request.requesterUserAgent}
+                </p>
+              )}
+            </div>
+            <div className="flex gap-2">
+              <Button
+                variant="primary"
+                size="compact"
+                disabled={actingOn !== null}
+                onClick={() => void approve(request.requestId)}
+              >
+                {t("pendingPairingRequests.approveButton")}
+              </Button>
+              <Button
+                variant="dangerOutline"
+                size="compact"
+                disabled={actingOn !== null}
+                onClick={() => void deny(request.requestId)}
+              >
+                {t("pendingPairingRequests.denyButton")}
+              </Button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/clients/web/src/domains/settings/pair-device/pending-pairing-requests.tsx
+++ b/clients/web/src/domains/settings/pair-device/pending-pairing-requests.tsx
@@ -1,8 +1,7 @@
 import { Button } from "@vellumai/design-library/components/button";
 import { Notice } from "@vellumai/design-library/components/notice";
 
-import { useTranslation } from "@/i18n";
-import { formatRelativeDate } from "@/utils/format-date";
+import { currentLocale, useTranslation } from "@/i18n";
 
 import { usePendingPairingRequests } from "./use-pending-pairing-requests";
 
@@ -11,19 +10,48 @@ interface PendingPairingRequestsProps {
   base: string;
 }
 
+const RELATIVE_UNITS: Array<{ unit: Intl.RelativeTimeFormatUnit; ms: number }> =
+  [
+    { unit: "day", ms: 86_400_000 },
+    { unit: "hour", ms: 3_600_000 },
+    { unit: "minute", ms: 60_000 },
+  ];
+
+/**
+ * Relative label for a request's timestamp in the active i18n locale.
+ * Pending requests are short-lived, so minutes/hours/days cover the range;
+ * anything under a minute reads as "now".
+ */
+function formatRequestedAt(iso: string): string {
+  const formatter = new Intl.RelativeTimeFormat(currentLocale(), {
+    numeric: "auto",
+  });
+  const diffMs = new Date(iso).getTime() - Date.now();
+  const absMs = Math.abs(diffMs);
+  for (const { unit, ms } of RELATIVE_UNITS) {
+    if (absMs >= ms) {
+      return formatter.format(Math.trunc(diffMs / ms), unit);
+    }
+  }
+  return formatter.format(0, "second");
+}
+
 /**
  * The approval half of the Pair Device card: pending pairing requests minted
  * elsewhere (the public `/assistant/pair` page), each approvable or deniable
- * by the host. Renders nothing while no request is pending. Each row shows its
- * user code prominently so the approver can match it against the requesting
- * device's screen: the device-flow anti-phishing binding.
+ * by the host. Renders nothing while no request is pending and the list poll
+ * is healthy. Each row shows its user code prominently so the approver can
+ * match it against the requesting device's screen: the device-flow
+ * anti-phishing binding.
  */
 export function PendingPairingRequests({ base }: PendingPairingRequestsProps) {
   const { t } = useTranslation("settings");
   const { requests, actingOn, error, approve, deny } =
     usePendingPairingRequests(base);
 
-  if (requests.length === 0) {
+  // An empty list with no error is the quiet normal state; a poll error must
+  // still surface so an outage isn't mistaken for an empty queue.
+  if (requests.length === 0 && !error) {
     return null;
   }
 
@@ -38,52 +66,54 @@ export function PendingPairingRequests({ base }: PendingPairingRequestsProps) {
         </p>
       </div>
       {error && <Notice tone="error" title={error} />}
-      <ul className="flex flex-col gap-2">
-        {requests.map((request) => (
-          <li
-            key={request.requestId}
-            className="flex flex-col gap-2 rounded-lg border border-[var(--border-element)] p-3"
-          >
-            <code className="w-fit rounded-md bg-[var(--surface-active)] px-2.5 py-1.5 text-title-medium tracking-wide text-[var(--content-emphasised)]">
-              {request.userCode}
-            </code>
-            <div className="flex flex-col gap-0.5">
-              <p className="text-body-small-default text-[var(--content-tertiary)]">
-                {t("pendingPairingRequests.requestedMeta", {
-                  when: formatRelativeDate(request.requestedAt),
-                  ip: request.requesterIp,
-                })}
-              </p>
-              {request.requesterUserAgent && (
-                <p
-                  className="truncate text-body-small-default text-[var(--content-tertiary)]"
-                  title={request.requesterUserAgent}
-                >
-                  {request.requesterUserAgent}
+      {requests.length > 0 && (
+        <ul className="flex flex-col gap-2">
+          {requests.map((request) => (
+            <li
+              key={request.requestId}
+              className="flex flex-col gap-2 rounded-lg border border-[var(--border-element)] p-3"
+            >
+              <code className="w-fit rounded-md bg-[var(--surface-active)] px-2.5 py-1.5 text-title-medium tracking-wide text-[var(--content-emphasised)]">
+                {request.userCode}
+              </code>
+              <div className="flex flex-col gap-0.5">
+                <p className="text-body-small-default text-[var(--content-tertiary)]">
+                  {t("pendingPairingRequests.requestedMeta", {
+                    when: formatRequestedAt(request.requestedAt),
+                    ip: request.requesterIp,
+                  })}
                 </p>
-              )}
-            </div>
-            <div className="flex gap-2">
-              <Button
-                variant="primary"
-                size="compact"
-                disabled={actingOn !== null}
-                onClick={() => void approve(request.requestId)}
-              >
-                {t("pendingPairingRequests.approveButton")}
-              </Button>
-              <Button
-                variant="dangerOutline"
-                size="compact"
-                disabled={actingOn !== null}
-                onClick={() => void deny(request.requestId)}
-              >
-                {t("pendingPairingRequests.denyButton")}
-              </Button>
-            </div>
-          </li>
-        ))}
-      </ul>
+                {request.requesterUserAgent && (
+                  <p
+                    className="truncate text-body-small-default text-[var(--content-tertiary)]"
+                    title={request.requesterUserAgent}
+                  >
+                    {request.requesterUserAgent}
+                  </p>
+                )}
+              </div>
+              <div className="flex gap-2">
+                <Button
+                  variant="primary"
+                  size="compact"
+                  disabled={actingOn !== null}
+                  onClick={() => void approve(request.requestId)}
+                >
+                  {t("pendingPairingRequests.approveButton")}
+                </Button>
+                <Button
+                  variant="dangerOutline"
+                  size="compact"
+                  disabled={actingOn !== null}
+                  onClick={() => void deny(request.requestId)}
+                >
+                  {t("pendingPairingRequests.denyButton")}
+                </Button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
     </section>
   );
 }

--- a/clients/web/src/domains/settings/pair-device/use-pending-pairing-requests.test.ts
+++ b/clients/web/src/domains/settings/pair-device/use-pending-pairing-requests.test.ts
@@ -351,6 +351,35 @@ describe("usePendingPairingRequests: approve/deny", () => {
     expect(result.current.error).toBeNull();
   });
 
+  test("a poll clears an action error once its request leaves the list", async () => {
+    serveList([pendingRequest("req-1")]);
+    installRoutedFetch({
+      [APPROVE_URL]: () =>
+        jsonResponse({ error: { message: "Approval failed." } }, 500),
+    });
+
+    let result!: ReturnType<typeof renderPendingRequests>["result"];
+    await act(async () => {
+      ({ result } = renderPendingRequests());
+    });
+
+    await act(async () => {
+      await result.current.approve("req-1");
+    });
+    expect(result.current.error).toBe("Approval failed.");
+
+    // While the request is still listed, the error survives polls.
+    await tickPoll();
+    expect(result.current.requests.map((r) => r.requestId)).toEqual(["req-1"]);
+    expect(result.current.error).toBe("Approval failed.");
+
+    // Handled elsewhere or expired: the next poll drops the row and the error.
+    serveList([]);
+    await tickPoll();
+    expect(result.current.requests).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+
   test("a base change clears rows and errors before the new base's poll resolves", async () => {
     serveList([pendingRequest("req-1")]);
     // The new base's list never resolves, so anything shown for it is stale.

--- a/clients/web/src/domains/settings/pair-device/use-pending-pairing-requests.ts
+++ b/clients/web/src/domains/settings/pair-device/use-pending-pairing-requests.ts
@@ -49,7 +49,8 @@ export interface PendingPairingRequestsController {
  * shouldn't flash the UI empty) and records a non-fatal error instead. A
  * 404/410 from approve/deny means the request expired or was handled elsewhere
  * (the CLI `--web-approve` path can race the UI), so the row is removed as if
- * the action succeeded.
+ * the action succeeded. An action error is dropped once a successful poll no
+ * longer lists its request; with the row gone there is nothing left to retry.
  *
  * A `base` change drops the previous gateway's rows and errors and aborts its
  * in-flight action, so stale requests are never shown against the new base.
@@ -65,7 +66,11 @@ export function usePendingPairingRequests(
     action: PendingPairingAction;
   } | null>(null);
   const [pollError, setPollError] = useState<string | null>(null);
-  const [actionError, setActionError] = useState<string | null>(null);
+  // Tagged with its request so a poll can drop it once the row disappears.
+  const [actionError, setActionError] = useState<{
+    requestId: string;
+    message: string;
+  } | null>(null);
 
   const pollAbortRef = useRef<AbortController | null>(null);
   const actionAbortRef = useRef<AbortController | null>(null);
@@ -109,6 +114,13 @@ export function usePendingPairingRequests(
           return;
         }
         setRequests((prev) => (sameRequestList(prev, next) ? prev : next));
+        // An action error whose request left the list is unactionable; drop it
+        // so it can't pin an empty section open forever.
+        setActionError((prev) =>
+          prev && !next.some((r) => r.requestId === prev.requestId)
+            ? null
+            : prev,
+        );
         setPollError(null);
       } catch (err) {
         if (controller.signal.aborted) {
@@ -167,13 +179,14 @@ export function usePendingPairingRequests(
             // Expired or already handled elsewhere; treat as removed.
             removeRequest();
           } else {
-            setActionError(err.message);
+            setActionError({ requestId, message: err.message });
           }
         } else {
           captureError(err, { context: "pair-device-pending-request-action" });
-          setActionError(
-            t("settings:usePendingPairingRequests.actionErrorFallback"),
-          );
+          setActionError({
+            requestId,
+            message: t("settings:usePendingPairingRequests.actionErrorFallback"),
+          });
         }
       } finally {
         // Only release the guard if it's still ours; a base change may have
@@ -201,7 +214,7 @@ export function usePendingPairingRequests(
   return {
     requests,
     actingOn,
-    error: actionError ?? pollError,
+    error: actionError?.message ?? pollError,
     approve,
     deny,
   };

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -200,6 +200,13 @@
     "searchPlaceholder": "Search actions…",
     "title": "Action Overrides"
   },
+  "pendingPairingRequests": {
+    "approveButton": "Approve",
+    "denyButton": "Deny",
+    "instruction": "A device is asking to use this assistant. Approve a request only after confirming its code matches the one shown on the requesting device.",
+    "requestedMeta": "Requested {when} from {ip}",
+    "title": "Pairing requests"
+  },
   "profileAdvancedParams": {
     "contextWindowLabel": "Context Window",
     "defaultValueLabel": "Default · {value}",

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -200,6 +200,13 @@
     "searchPlaceholder": "Buscar acciones…",
     "title": "Anulaciones de acciones"
   },
+  "pendingPairingRequests": {
+    "approveButton": "Aprobar",
+    "denyButton": "Denegar",
+    "instruction": "Un dispositivo está pidiendo usar este asistente. Aprueba una solicitud solo después de confirmar que su código coincide con el que muestra el dispositivo solicitante.",
+    "requestedMeta": "Solicitado {when} desde {ip}",
+    "title": "Solicitudes de vinculación"
+  },
   "profileAdvancedParams": {
     "contextWindowLabel": "Ventana de contexto",
     "defaultValueLabel": "Predeterminado · {value}",


### PR DESCRIPTION
## Summary
- Pending web-pairing requests now appear in the settings Pair Device card with Approve/Deny
- Each row shows the user code prominently so the approver can match it against the requesting device's screen, plus requester metadata
- Gating unchanged: desktop/local mode + version support + web-remote-ingress flag, inherited from PairDeviceCard

Part of plan: web-pair-approve.md (PR 6 of 6)