### PR TITLE
Unify assistant naming in the chooser

### DIFF
--- a/cli/src/__tests__/assistant-config.test.ts
+++ b/cli/src/__tests__/assistant-config.test.ts
@@ -8,10 +8,12 @@ import {
   spyOn,
 } from "bun:test";
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
+  utimesSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -95,6 +97,39 @@ describe("assistant-config", () => {
     const all = loadAllAssistants();
     expect(all).toHaveLength(1);
     expect(all[0].assistantId).toBe("test-1");
+  });
+
+  test("saveAssistantEntry writes under the advisory lock and cleans it up", () => {
+    saveAssistantEntry(makeEntry("locked-1"));
+    expect(loadAllAssistants()).toHaveLength(1);
+    // The shared `${lockfilePath}.lock` key hosts contend on is released.
+    expect(existsSync(join(testDir, ".vellum.lock.json.lock"))).toBe(false);
+  });
+
+  test("saveAssistantEntry breaks a stale lock and still lands the write", () => {
+    const lockDir = join(testDir, ".vellum.lock.json.lock");
+    mkdirSync(lockDir);
+    const past = new Date(Date.now() - 60_000);
+    utimesSync(lockDir, past, past);
+
+    saveAssistantEntry(makeEntry("stale-lock-1"));
+    expect(loadAllAssistants()).toHaveLength(1);
+    expect(existsSync(lockDir)).toBe(false);
+  });
+
+  test("saveAssistantEntry fails fast without writing when another holder is fresh", () => {
+    const lockDir = join(testDir, ".vellum.lock.json.lock");
+    mkdirSync(lockDir);
+    try {
+      const start = Date.now();
+      expect(() => saveAssistantEntry(makeEntry("contended-1"))).toThrow(
+        /Timed out acquiring lockfile lock/,
+      );
+      expect(Date.now() - start).toBeLessThan(2_000);
+      expect(loadAllAssistants()).toEqual([]);
+    } finally {
+      rmSync(lockDir, { recursive: true, force: true });
+    }
   });
 
   test("findAssistantByName returns matching entry", () => {

--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -29,6 +29,7 @@ import {
 } from "../lib/client-identity";
 import {
   getLockfileData,
+  renameLockfileAssistantIfPresent,
   upsertRendererLockfileAssistant,
   replacePlatformAssistants,
   isActiveAssistant,
@@ -555,6 +556,13 @@ async function handleLocalEndpoints(
           lockfilePaths,
           body.platformAssistants as Array<Record<string, unknown>>,
           body.organizationId as string | undefined,
+        );
+      } else if (body.rename && typeof body.rename === "object") {
+        const rename = body.rename as Record<string, unknown>;
+        result = renameLockfileAssistantIfPresent(
+          lockfilePaths,
+          rename.assistantId as string,
+          rename.name as string,
         );
       } else {
         result = upsertRendererLockfileAssistant(

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -219,10 +219,6 @@ function withCliLockfileLock<T>(fn: () => T): T {
   return locked.value;
 }
 
-function writeLockfile(data: LockfileData): void {
-  withCliLockfileLock(() => writeLockfileUnlocked(data));
-}
-
 /**
  * Try to extract a port number from a URL string (e.g. `http://localhost:7830`).
  * Returns undefined if the URL is malformed or has no explicit port.

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -11,6 +11,7 @@ import { homedir } from "os";
 import { dirname, join } from "path";
 
 import { SEEDS, type EnvironmentDefinition } from "@vellumai/environments";
+import { withLockfileLock } from "@vellumai/local-mode";
 import {
   resolveCloud,
   type LocalAssistantResources,
@@ -186,7 +187,7 @@ function readLockfile(): LockfileData {
   return {};
 }
 
-function writeLockfile(data: LockfileData): void {
+function writeLockfileUnlocked(data: LockfileData): void {
   const lockfilePath = getLockfilePath(getCurrentEnvironment());
   mkdirSync(dirname(lockfilePath), { recursive: true });
   const tmpPath = `${lockfilePath}.${randomBytes(4).toString("hex")}.tmp`;
@@ -199,6 +200,27 @@ function writeLockfile(data: LockfileData): void {
     } catch {}
     throw err;
   }
+}
+
+/**
+ * Run `fn` under the same cross-process advisory lock the local-mode hosts
+ * use, keyed to this environment's write-path lockfile, so CLI writers and
+ * package-side writers (Electron main, Vite plugin, `vellum client`) never
+ * interleave read-modify-write cycles. Reentrant, so wrapped units may call
+ * the locked write helpers. Throws on lock timeout, matching the fs-error
+ * contract of the write path.
+ */
+function withCliLockfileLock<T>(fn: () => T): T {
+  const locked = withLockfileLock(
+    [getLockfilePath(getCurrentEnvironment())],
+    fn,
+  );
+  if (!locked.ok) throw new Error(locked.error);
+  return locked.value;
+}
+
+function writeLockfile(data: LockfileData): void {
+  withCliLockfileLock(() => writeLockfileUnlocked(data));
 }
 
 /**
@@ -322,7 +344,18 @@ function readAssistants(): AssistantEntry[] {
   }
 
   if (migrated) {
-    writeLockfile(data);
+    // Persist the backfill against a fresh read under the lock so this
+    // snapshot cannot clobber a concurrent writer; skip on contention (the
+    // in-memory result below is already migrated).
+    withLockfileLock([getLockfilePath(getCurrentEnvironment())], () => {
+      const fresh = readLockfile();
+      if (!Array.isArray(fresh.assistants)) return;
+      let freshMigrated = false;
+      for (const entry of fresh.assistants) {
+        if (migrateLegacyEntry(entry)) freshMigrated = true;
+      }
+      if (freshMigrated) writeLockfileUnlocked(fresh);
+    });
   }
 
   const result: AssistantEntry[] = [];
@@ -342,9 +375,11 @@ function readAssistants(): AssistantEntry[] {
 }
 
 function writeAssistants(entries: AssistantEntry[]): void {
-  const data = readLockfile();
-  data.assistants = entries;
-  writeLockfile(data);
+  withCliLockfileLock(() => {
+    const data = readLockfile();
+    data.assistants = entries;
+    writeLockfileUnlocked(data);
+  });
 }
 
 export function loadLatestAssistant(): AssistantEntry | null {
@@ -428,21 +463,23 @@ export function formatAssistantLookupError(
 }
 
 export function removeAssistantEntry(assistantId: string): void {
-  const data = readLockfile();
-  const entries = (data.assistants ?? []).filter(
-    (e) => e.assistantId !== assistantId,
-  );
-  data.assistants = entries;
-  // Reassign active assistant if it matches the removed entry
-  if (data.activeAssistant === assistantId) {
-    const remaining = entries[0];
-    if (remaining) {
-      data.activeAssistant = String(remaining.assistantId);
-    } else {
-      delete data.activeAssistant;
+  withCliLockfileLock(() => {
+    const data = readLockfile();
+    const entries = (data.assistants ?? []).filter(
+      (e) => e.assistantId !== assistantId,
+    );
+    data.assistants = entries;
+    // Reassign active assistant if it matches the removed entry
+    if (data.activeAssistant === assistantId) {
+      const remaining = entries[0];
+      if (remaining) {
+        data.activeAssistant = String(remaining.assistantId);
+      } else {
+        delete data.activeAssistant;
+      }
     }
-  }
-  writeLockfile(data);
+    writeLockfileUnlocked(data);
+  });
 }
 
 export function loadAllAssistants(): AssistantEntry[] {
@@ -519,9 +556,11 @@ export function getActiveAssistant(): string | null {
 }
 
 export function setActiveAssistant(assistantId: string): void {
-  const data = readLockfile();
-  data.activeAssistant = assistantId;
-  writeLockfile(data);
+  withCliLockfileLock(() => {
+    const data = readLockfile();
+    data.activeAssistant = assistantId;
+    writeLockfileUnlocked(data);
+  });
 }
 
 /**
@@ -607,11 +646,13 @@ export function extractHostFromUrl(url: string): string {
 }
 
 export function saveAssistantEntry(entry: AssistantEntry): void {
-  const entries = readAssistants().filter(
-    (e) => e.assistantId !== entry.assistantId,
-  );
-  entries.unshift(entry);
-  writeAssistants(entries);
+  withCliLockfileLock(() => {
+    const entries = readAssistants().filter(
+      (e) => e.assistantId !== entry.assistantId,
+    );
+    entries.unshift(entry);
+    writeAssistants(entries);
+  });
 }
 
 /**

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
@@ -404,7 +404,6 @@ const { SelectAssistantScreen } = await import(
 
 const PAIRED_ID = "paired-1";
 const PLATFORM_ID = "platform-1";
-/** Local ids are friendly generated instance names, not UUIDs. */
 const LOCAL_ID = "vellum-deep-hare-ww1iw1";
 
 function makePairedAssistant(
@@ -1745,6 +1744,30 @@ describe("SelectAssistantScreen assistant labels", () => {
     expect(screen.getByText(LOCAL_ID)).toBeTruthy();
     expect(screen.getByText(SECOND_LOCAL_ID)).toBeTruthy();
     expect(screen.queryByText("Local Assistant")).toBeNull();
+  });
+
+  test("an unnamed hub local registration keeps the generic fallback, not its UUID", () => {
+    // API-sourced hub row: no lockfile entry behind it, so no `cloud`, and
+    // its id is the platform assistant record's UUID.
+    const HUB_LOCAL_UUID = "3f8a1c2e-9b4d-4e6f-8a70-1d2c3b4a5e6f";
+    assistantsValue = [
+      makeLocalAssistant({ name: undefined }),
+      {
+        id: HUB_LOCAL_UUID,
+        name: undefined,
+        isLocal: true,
+        isPlatformHosted: false,
+        isPaired: false,
+        ingressUrl: "https://mac.example.com",
+      },
+    ];
+
+    render(<SelectAssistantScreen />);
+
+    expect(screen.getByText("Local Assistant")).toBeTruthy();
+    expect(screen.queryByText(HUB_LOCAL_UUID)).toBeNull();
+    // The lockfile-sourced entry still shows its friendly instance id.
+    expect(screen.getByText(LOCAL_ID)).toBeTruthy();
   });
 
   test("an unnamed cloud entry keeps the generic Cloud Assistant fallback", () => {

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
@@ -404,6 +404,8 @@ const { SelectAssistantScreen } = await import(
 
 const PAIRED_ID = "paired-1";
 const PLATFORM_ID = "platform-1";
+/** Local ids are friendly generated instance names, not UUIDs. */
+const LOCAL_ID = "vellum-deep-hare-ww1iw1";
 
 function makePairedAssistant(
   overrides: Partial<ResolvedAssistant> = {},
@@ -428,6 +430,21 @@ function makePlatformAssistant(
     cloud: "vellum",
     isLocal: false,
     isPlatformHosted: true,
+    isPaired: false,
+    ...overrides,
+  };
+}
+
+/** A lockfile-backed local entry as a local client sees it. */
+function makeLocalAssistant(
+  overrides: Partial<ResolvedAssistant> = {},
+): ResolvedAssistant {
+  return {
+    id: LOCAL_ID,
+    name: "Desk Helper",
+    cloud: "local",
+    isLocal: true,
+    isPlatformHosted: false,
     isPaired: false,
     ...overrides,
   };
@@ -1694,5 +1711,48 @@ describe("SelectAssistantScreen local registrations on the platform hub", () => 
     await waitFor(() =>
       expect(refreshPlatformAssistantsIfStaleMock).toHaveBeenCalledTimes(1),
     );
+  });
+});
+
+describe("SelectAssistantScreen assistant labels", () => {
+  // Two entries per case: a sole accessible local entry auto-connects
+  // instead of rendering the chooser.
+  const SECOND_LOCAL_ID = "vellum-calm-otter-ab2cd3";
+
+  test("a named local entry shows its persona name", () => {
+    assistantsValue = [
+      makeLocalAssistant(),
+      makeLocalAssistant({ id: SECOND_LOCAL_ID, name: undefined }),
+    ];
+
+    render(<SelectAssistantScreen />);
+
+    const named = screen
+      .getAllByRole("radio")
+      .find((r) => r.textContent?.includes("Desk Helper"));
+    expect(named).toBeTruthy();
+    expect(named!.textContent).not.toContain(LOCAL_ID);
+  });
+
+  test("unnamed local entries fall back to their instance ids", () => {
+    assistantsValue = [
+      makeLocalAssistant({ name: undefined }),
+      makeLocalAssistant({ id: SECOND_LOCAL_ID, name: undefined }),
+    ];
+
+    render(<SelectAssistantScreen />);
+
+    expect(screen.getByText(LOCAL_ID)).toBeTruthy();
+    expect(screen.getByText(SECOND_LOCAL_ID)).toBeTruthy();
+    expect(screen.queryByText("Local Assistant")).toBeNull();
+  });
+
+  test("an unnamed cloud entry keeps the generic Cloud Assistant fallback", () => {
+    assistantsValue = [makePlatformAssistant({ name: undefined })];
+
+    render(<SelectAssistantScreen />);
+
+    expect(screen.getByText("Cloud Assistant")).toBeTruthy();
+    expect(screen.queryByText(PLATFORM_ID)).toBeNull();
   });
 });

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -73,9 +73,13 @@ function assistantLabel(a: ResolvedAssistant): string {
   if (a.isPaired) {
     return "Paired Assistant";
   }
-  if (a.isLocal) {
-    // Local ids are friendly generated instance names; cloud ids are UUIDs.
+  if (a.isLocal && a.cloud === "local") {
+    // Lockfile-sourced local ids are friendly generated instance names;
+    // API-sourced hub registrations carry platform UUIDs instead.
     return a.id;
+  }
+  if (a.isLocal) {
+    return "Local Assistant";
   }
   return "Cloud Assistant";
 }

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -73,7 +73,11 @@ function assistantLabel(a: ResolvedAssistant): string {
   if (a.isPaired) {
     return "Paired Assistant";
   }
-  return a.isLocal ? "Local Assistant" : "Cloud Assistant";
+  if (a.isLocal) {
+    // Local ids are friendly generated instance names; cloud ids are UUIDs.
+    return a.id;
+  }
+  return "Cloud Assistant";
 }
 
 /** A hub-listed self-hosted entry lives on another machine; name its host. */

--- a/clients/web/src/domains/settings/pages/general-page.tsx
+++ b/clients/web/src/domains/settings/pages/general-page.tsx
@@ -38,7 +38,7 @@ import {
 } from "@/hooks/use-platform-gate";
 import { remoteGatewayPublicBaseUrl } from "@/lib/auth/remote-gateway-session";
 import {
-  getRemoteGatewayAssistantName,
+  getRemoteAssistantDisplayName,
   getRemoteGatewayHubUrl,
   getSelectedAssistant,
   isLocalAssistant,
@@ -156,7 +156,7 @@ export function GeneralPage() {
       const params = new URLSearchParams({
         register: remoteGatewayPublicBaseUrl(),
       });
-      const assistantName = getRemoteGatewayAssistantName();
+      const assistantName = getRemoteAssistantDisplayName();
       if (assistantName) {
         params.set("name", assistantName);
       }

--- a/clients/web/src/hooks/use-lockfile-identity-sync.test.tsx
+++ b/clients/web/src/hooks/use-lockfile-identity-sync.test.tsx
@@ -1,0 +1,193 @@
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
+
+import type { LockfileAssistant } from "@/runtime/local-mode-host";
+
+// Real module first, so the mock can pass through useLockfileAssistantName
+// and only stub the write helper.
+const actualLocalMode = await import("@/lib/local-mode");
+
+const renameLockfileAssistantMock = mock(async (): Promise<boolean> => true);
+mock.module("@/lib/local-mode", () => ({
+  ...actualLocalMode,
+  renameLockfileAssistant: renameLockfileAssistantMock,
+}));
+
+const { useLockfileIdentitySync } = await import(
+  "@/hooks/use-lockfile-identity-sync"
+);
+const { useAssistantIdentityStore } = await import(
+  "@/stores/assistant-identity-store"
+);
+const { useLockfileStore } = await import("@/stores/lockfile-store");
+
+/** bun:test has no fake timers, so retry tests run on a real short delay. */
+const TEST_RETRY_DELAY_MS = 25;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function lockfileEntry(assistantId: string, name: string): LockfileAssistant {
+  return { assistantId, cloud: "local", name } as LockfileAssistant;
+}
+
+function resetStores(): void {
+  renameLockfileAssistantMock.mockClear();
+  useAssistantIdentityStore.getState().clearIdentity();
+  useLockfileStore.setState({ lockfile: null, committed: false });
+}
+
+beforeEach(resetStores);
+
+afterEach(() => {
+  cleanup();
+  resetStores();
+});
+
+describe("useLockfileIdentitySync", () => {
+  test("renames the lockfile entry with the store's assistantId and name", () => {
+    renderHook(() => useLockfileIdentitySync());
+    expect(renameLockfileAssistantMock).not.toHaveBeenCalled();
+
+    act(() => {
+      useAssistantIdentityStore
+        .getState()
+        .setIdentity("Aria", "1.2.3", "assistant-1");
+    });
+
+    expect(renameLockfileAssistantMock).toHaveBeenCalledTimes(1);
+    expect(renameLockfileAssistantMock).toHaveBeenCalledWith(
+      "assistant-1",
+      "Aria",
+    );
+  });
+
+  test("does not fire while the name is null", () => {
+    renderHook(() => useLockfileIdentitySync());
+
+    act(() => {
+      useAssistantIdentityStore
+        .getState()
+        .setIdentity(null, "1.2.3", "assistant-1");
+    });
+
+    expect(renameLockfileAssistantMock).not.toHaveBeenCalled();
+  });
+
+  test("does not fire while the assistantId is null", () => {
+    renderHook(() => useLockfileIdentitySync());
+
+    act(() => {
+      useAssistantIdentityStore.getState().setIdentity("Aria", "1.2.3");
+    });
+
+    expect(renameLockfileAssistantMock).not.toHaveBeenCalled();
+  });
+
+  test("re-fires when the store switches to a different named assistant", () => {
+    renderHook(() => useLockfileIdentitySync());
+
+    act(() => {
+      useAssistantIdentityStore
+        .getState()
+        .setIdentity("Aria", "1.2.3", "assistant-1");
+    });
+    act(() => {
+      useAssistantIdentityStore
+        .getState()
+        .setIdentity("Bela", "1.2.3", "assistant-2");
+    });
+
+    expect(renameLockfileAssistantMock).toHaveBeenCalledTimes(2);
+    expect(renameLockfileAssistantMock).toHaveBeenLastCalledWith(
+      "assistant-2",
+      "Bela",
+    );
+  });
+
+  test("re-fires when the lockfile entry hydrates after the identity store", () => {
+    renderHook(() => useLockfileIdentitySync());
+
+    act(() => {
+      useAssistantIdentityStore
+        .getState()
+        .setIdentity("Aria", "1.2.3", "assistant-1");
+    });
+    // First attempt ran against an unhydrated lockfile (helper no-ops on a
+    // missing entry).
+    expect(renameLockfileAssistantMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      useLockfileStore.getState().setLockfile({
+        assistants: [lockfileEntry("assistant-1", "Stale Name")],
+        activeAssistant: "assistant-1",
+      });
+    });
+
+    expect(renameLockfileAssistantMock).toHaveBeenCalledTimes(2);
+    expect(renameLockfileAssistantMock).toHaveBeenLastCalledWith(
+      "assistant-1",
+      "Aria",
+    );
+  });
+
+  test("retries once after a delay when the write fails", async () => {
+    renameLockfileAssistantMock.mockResolvedValueOnce(false);
+    renderHook(() => useLockfileIdentitySync(TEST_RETRY_DELAY_MS));
+
+    act(() => {
+      useAssistantIdentityStore
+        .getState()
+        .setIdentity("Aria", "1.2.3", "assistant-1");
+    });
+    expect(renameLockfileAssistantMock).toHaveBeenCalledTimes(1);
+
+    await sleep(TEST_RETRY_DELAY_MS * 3);
+
+    expect(renameLockfileAssistantMock).toHaveBeenCalledTimes(2);
+    expect(renameLockfileAssistantMock).toHaveBeenLastCalledWith(
+      "assistant-1",
+      "Aria",
+    );
+
+    // The retry resolved true (mock default), so no further attempts.
+    await sleep(TEST_RETRY_DELAY_MS * 3);
+    expect(renameLockfileAssistantMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("does not retry when the helper resolves true", async () => {
+    renderHook(() => useLockfileIdentitySync(TEST_RETRY_DELAY_MS));
+
+    act(() => {
+      useAssistantIdentityStore
+        .getState()
+        .setIdentity("Aria", "1.2.3", "assistant-1");
+    });
+
+    await sleep(TEST_RETRY_DELAY_MS * 3);
+    expect(renameLockfileAssistantMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("unmounting cancels a pending failed-write retry", async () => {
+    renameLockfileAssistantMock.mockResolvedValueOnce(false);
+    const { unmount } = renderHook(() =>
+      useLockfileIdentitySync(TEST_RETRY_DELAY_MS),
+    );
+
+    act(() => {
+      useAssistantIdentityStore
+        .getState()
+        .setIdentity("Aria", "1.2.3", "assistant-1");
+    });
+    expect(renameLockfileAssistantMock).toHaveBeenCalledTimes(1);
+
+    // Let the rejection settle so the retry timer gets scheduled, then unmount.
+    await sleep(1);
+    unmount();
+
+    await sleep(TEST_RETRY_DELAY_MS * 3);
+    expect(renameLockfileAssistantMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/web/src/hooks/use-lockfile-identity-sync.test.tsx
+++ b/clients/web/src/hooks/use-lockfile-identity-sync.test.tsx
@@ -29,7 +29,7 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function lockfileEntry(assistantId: string, name: string): LockfileAssistant {
+function lockfileEntry(assistantId: string, name?: string): LockfileAssistant {
   return { assistantId, cloud: "local", name } as LockfileAssistant;
 }
 
@@ -122,6 +122,32 @@ describe("useLockfileIdentitySync", () => {
     act(() => {
       useLockfileStore.getState().setLockfile({
         assistants: [lockfileEntry("assistant-1", "Stale Name")],
+        activeAssistant: "assistant-1",
+      });
+    });
+
+    expect(renameLockfileAssistantMock).toHaveBeenCalledTimes(2);
+    expect(renameLockfileAssistantMock).toHaveBeenLastCalledWith(
+      "assistant-1",
+      "Aria",
+    );
+  });
+
+  test("re-fires when an unnamed lockfile entry hydrates after the identity store", () => {
+    renderHook(() => useLockfileIdentitySync());
+
+    act(() => {
+      useAssistantIdentityStore
+        .getState()
+        .setIdentity("Aria", "1.2.3", "assistant-1");
+    });
+    // First attempt ran against an unhydrated lockfile (helper no-ops on a
+    // missing entry).
+    expect(renameLockfileAssistantMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      useLockfileStore.getState().setLockfile({
+        assistants: [lockfileEntry("assistant-1")],
         activeAssistant: "assistant-1",
       });
     });

--- a/clients/web/src/hooks/use-lockfile-identity-sync.ts
+++ b/clients/web/src/hooks/use-lockfile-identity-sync.ts
@@ -1,0 +1,57 @@
+import { useEffect } from "react";
+
+import {
+  renameLockfileAssistant,
+  useLockfileAssistantName,
+} from "@/lib/local-mode";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+
+const RETRY_DELAY_MS = 2_000;
+
+/**
+ * Mirror the active assistant's persona name into its lockfile entry so
+ * lockfile consumers (assistant chooser, Electron tray, `vellum pair`) show
+ * the live name instead of a stale snapshot.
+ *
+ * Reads both `name` and `assistantId` from `useAssistantIdentityStore`: the
+ * store writes them in one `set()`, so this pairing can never mix a stale
+ * name with a new id mid-switch (unlike pairing the name with
+ * `activeAssistantId` from the resolved-assistants store).
+ *
+ * Also subscribes to the lockfile entry's own name, so the sync re-fires when
+ * the lockfile hydrates after the identity store on boot (the helper no-ops
+ * on a missing entry) or the entry's name changes externally. A failed host
+ * write gets one delayed retry per effect run; convergence otherwise rides
+ * the next dep change.
+ *
+ * All skip logic (empty name, missing lockfile entry, unchanged name, host
+ * unavailable, remote-gateway mode) lives in `renameLockfileAssistant`, so
+ * this hook is safe to mount unconditionally in `RootLayout`.
+ */
+export function useLockfileIdentitySync(retryDelayMs = RETRY_DELAY_MS): void {
+  const name = useAssistantIdentityStore.use.name();
+  const assistantId = useAssistantIdentityStore.use.assistantId();
+  const lockfileName = useLockfileAssistantName(assistantId);
+
+  useEffect(() => {
+    if (name === null || assistantId === null) {
+      return;
+    }
+    let disposed = false;
+    let retryTimer: ReturnType<typeof setTimeout> | undefined;
+    void renameLockfileAssistant(assistantId, name).then((converged) => {
+      if (converged || disposed) {
+        return;
+      }
+      retryTimer = setTimeout(() => {
+        void renameLockfileAssistant(assistantId, name);
+      }, retryDelayMs);
+    });
+    return () => {
+      disposed = true;
+      if (retryTimer !== undefined) {
+        clearTimeout(retryTimer);
+      }
+    };
+  }, [name, assistantId, lockfileName, retryDelayMs]);
+}

--- a/clients/web/src/lib/local-mode.test.ts
+++ b/clients/web/src/lib/local-mode.test.ts
@@ -19,7 +19,10 @@ const loadLockfileHost = mock(async (): Promise<localModeHost.Lockfile> => {
 });
 
 const saveLockfileAssistantHost = mock(
-  async (_assistant: Record<string, unknown>, _activeId?: string) => ({
+  async (
+    _assistant: Record<string, unknown>,
+    _activeId?: string,
+  ): Promise<localModeHost.LockfileWriteResult> => ({
     ok: true as const,
     lockfile: { assistants: [], activeAssistant: null },
   }),
@@ -79,6 +82,7 @@ import {
   reconcileSelectedAssistant,
   removePairedAssistantFromLockfile,
   removePlatformAssistantFromLockfile,
+  renameLockfileAssistant,
   saveManagedLockfileAssistant,
   syncPlatformAssistantsToLockfile,
   UnresolvedLocalGatewayError,
@@ -546,6 +550,102 @@ describe("saveManagedLockfileAssistant", () => {
     const [entry] = saveLockfileAssistantHost.mock.calls[0]!;
     expect(entry.organizationId).toBeUndefined();
     expect(entry.name).toBeUndefined();
+  });
+});
+
+describe("renameLockfileAssistant", () => {
+  const named: LockfileAssistant = {
+    assistantId: "local-a",
+    cloud: "local",
+    name: "Old Name",
+    resources: { gatewayPort: 7830 },
+  } as LockfileAssistant;
+
+  // A non-remote injected config marks the local-mode host as available.
+  function enableLocalHost(): void {
+    window.__VELLUM_CONFIG__ = {};
+  }
+
+  test("writes the partial payload without retargeting the active assistant, and commits", async () => {
+    enableLocalHost();
+    setLockfile({ assistants: [named], activeAssistant: "local-a" });
+    const resulting = {
+      assistants: [{ ...named, name: "Credence" }],
+      activeAssistant: "local-a",
+    };
+    saveLockfileAssistantHost.mockResolvedValueOnce({
+      ok: true as const,
+      lockfile: resulting,
+    });
+
+    await renameLockfileAssistant("local-a", "  Credence  ");
+
+    expect(saveLockfileAssistantHost).toHaveBeenCalledTimes(1);
+    expect(saveLockfileAssistantHost.mock.calls[0]).toEqual([
+      { assistantId: "local-a", name: "Credence" },
+      undefined,
+    ]);
+    expect(useLockfileStore.getState().lockfile).toEqual(resulting);
+    expect(useLockfileStore.getState().committed).toBe(true);
+  });
+
+  test("no-op when the lockfile has no entry for the id", async () => {
+    enableLocalHost();
+    setLockfile({ assistants: [named], activeAssistant: "local-a" });
+
+    await renameLockfileAssistant("nope", "Credence");
+
+    expect(saveLockfileAssistantHost).not.toHaveBeenCalled();
+  });
+
+  test("no-op when the entry already carries the trimmed name", async () => {
+    enableLocalHost();
+    setLockfile({ assistants: [named], activeAssistant: "local-a" });
+
+    await renameLockfileAssistant("local-a", "  Old Name  ");
+
+    expect(saveLockfileAssistantHost).not.toHaveBeenCalled();
+  });
+
+  test("no-op on an empty or whitespace-only name", async () => {
+    enableLocalHost();
+    setLockfile({ assistants: [named], activeAssistant: "local-a" });
+
+    await renameLockfileAssistant("local-a", "");
+    await renameLockfileAssistant("local-a", "   ");
+
+    expect(saveLockfileAssistantHost).not.toHaveBeenCalled();
+  });
+
+  test("no-op when no local-mode host backs this runtime", async () => {
+    // Default test env: no injected config, not Electron.
+    setLockfile({ assistants: [named], activeAssistant: "local-a" });
+
+    await renameLockfileAssistant("local-a", "Credence");
+
+    expect(saveLockfileAssistantHost).not.toHaveBeenCalled();
+  });
+
+  test("no-op in remote-gateway mode", async () => {
+    window.__VELLUM_CONFIG__ = { mode: "remote-gateway" };
+
+    await renameLockfileAssistant("self", "Credence");
+
+    expect(saveLockfileAssistantHost).not.toHaveBeenCalled();
+  });
+
+  test("does not commit on a host write failure", async () => {
+    enableLocalHost();
+    setLockfile({ assistants: [named], activeAssistant: "local-a" });
+    saveLockfileAssistantHost.mockResolvedValueOnce({
+      ok: false,
+      error: "disk unavailable",
+    });
+
+    await renameLockfileAssistant("local-a", "Credence");
+
+    expect(saveLockfileAssistantHost).toHaveBeenCalledTimes(1);
+    expect(useLockfileStore.getState().lockfile?.assistants).toEqual([named]);
   });
 });
 

--- a/clients/web/src/lib/local-mode.test.ts
+++ b/clients/web/src/lib/local-mode.test.ts
@@ -184,6 +184,22 @@ describe("remote gateway mode", () => {
     expect(getLocalGatewayUrl()).toBeUndefined();
     expect(useLockfileStore.getState().committed).toBe(true);
   });
+
+  test("names the synthetic assistant from the injected config when present", async () => {
+    window.__VELLUM_CONFIG__ = {
+      mode: "remote-gateway",
+      assistantName: "vellum-deep-hare-ww1iw1",
+    };
+
+    const lockfile = await loadLockfile();
+
+    expect(lockfile.assistants).toEqual([
+      expect.objectContaining({
+        assistantId: "self",
+        name: "vellum-deep-hare-ww1iw1",
+      }),
+    ]);
+  });
 });
 
 describe("getRemoteAssistantDisplayName", () => {

--- a/clients/web/src/lib/local-mode.test.ts
+++ b/clients/web/src/lib/local-mode.test.ts
@@ -28,6 +28,16 @@ const saveLockfileAssistantHost = mock(
   }),
 );
 
+const renameLockfileAssistantHost = mock(
+  async (
+    _assistantId: string,
+    _name: string,
+  ): Promise<localModeHost.LockfileWriteResult> => ({
+    ok: true as const,
+    lockfile: { assistants: [], activeAssistant: null },
+  }),
+);
+
 const fetchGuardianTokenHost = mock(async (_id: string) => "guardian-tok");
 
 const unpairAssistantHost = mock(
@@ -52,6 +62,7 @@ mock.module("@/runtime/local-mode-host", () => ({
   ...localModeHost,
   replacePlatformAssistantsHost,
   loadLockfileHost,
+  renameLockfileAssistantHost,
   saveLockfileAssistantHost,
   fetchGuardianTokenHost,
   unpairAssistantHost,
@@ -154,6 +165,7 @@ afterEach(() => {
   localStorage.removeItem(SELECTED_ASSISTANT_STORAGE_KEY);
   replacePlatformAssistantsHost.mockClear();
   loadLockfileHost.mockClear();
+  renameLockfileAssistantHost.mockClear();
   saveLockfileAssistantHost.mockClear();
   fetchGuardianTokenHost.mockClear();
   unpairAssistantHost.mockClear();
@@ -613,14 +625,14 @@ describe("renameLockfileAssistant", () => {
     window.__VELLUM_CONFIG__ = {};
   }
 
-  test("writes the partial payload without retargeting the active assistant, and commits", async () => {
+  test("routes the trimmed rename through the host rename op and commits", async () => {
     enableLocalHost();
     setLockfile({ assistants: [named], activeAssistant: "local-a" });
     const resulting = {
       assistants: [{ ...named, name: "Credence" }],
       activeAssistant: "local-a",
     };
-    saveLockfileAssistantHost.mockResolvedValueOnce({
+    renameLockfileAssistantHost.mockResolvedValueOnce({
       ok: true as const,
       lockfile: resulting,
     });
@@ -629,11 +641,13 @@ describe("renameLockfileAssistant", () => {
       renameLockfileAssistant("local-a", "  Credence  "),
     ).resolves.toBe(true);
 
-    expect(saveLockfileAssistantHost).toHaveBeenCalledTimes(1);
-    expect(saveLockfileAssistantHost.mock.calls[0]).toEqual([
-      { assistantId: "local-a", name: "Credence" },
-      undefined,
+    expect(renameLockfileAssistantHost).toHaveBeenCalledTimes(1);
+    expect(renameLockfileAssistantHost.mock.calls[0]).toEqual([
+      "local-a",
+      "Credence",
     ]);
+    // Never the upsert path: a stale cache must not re-create an entry.
+    expect(saveLockfileAssistantHost).not.toHaveBeenCalled();
     expect(useLockfileStore.getState().lockfile).toEqual(resulting);
     expect(useLockfileStore.getState().committed).toBe(true);
   });
@@ -646,7 +660,7 @@ describe("renameLockfileAssistant", () => {
       true,
     );
 
-    expect(saveLockfileAssistantHost).not.toHaveBeenCalled();
+    expect(renameLockfileAssistantHost).not.toHaveBeenCalled();
   });
 
   test("no-op (true) when the entry already carries the trimmed name", async () => {
@@ -657,7 +671,7 @@ describe("renameLockfileAssistant", () => {
       renameLockfileAssistant("local-a", "  Old Name  "),
     ).resolves.toBe(true);
 
-    expect(saveLockfileAssistantHost).not.toHaveBeenCalled();
+    expect(renameLockfileAssistantHost).not.toHaveBeenCalled();
   });
 
   test("no-op (true) on an empty or whitespace-only name", async () => {
@@ -667,7 +681,7 @@ describe("renameLockfileAssistant", () => {
     await expect(renameLockfileAssistant("local-a", "")).resolves.toBe(true);
     await expect(renameLockfileAssistant("local-a", "   ")).resolves.toBe(true);
 
-    expect(saveLockfileAssistantHost).not.toHaveBeenCalled();
+    expect(renameLockfileAssistantHost).not.toHaveBeenCalled();
   });
 
   test("no-op (true) when no local-mode host backs this runtime", async () => {
@@ -678,7 +692,7 @@ describe("renameLockfileAssistant", () => {
       true,
     );
 
-    expect(saveLockfileAssistantHost).not.toHaveBeenCalled();
+    expect(renameLockfileAssistantHost).not.toHaveBeenCalled();
   });
 
   test("no-op (true) in remote-gateway mode", async () => {
@@ -688,22 +702,22 @@ describe("renameLockfileAssistant", () => {
       true,
     );
 
-    expect(saveLockfileAssistantHost).not.toHaveBeenCalled();
+    expect(renameLockfileAssistantHost).not.toHaveBeenCalled();
   });
 
-  test("resolves false without committing on a host write failure", async () => {
+  test("resolves false without committing on a host refusal or write failure", async () => {
     enableLocalHost();
     setLockfile({ assistants: [named], activeAssistant: "local-a" });
-    saveLockfileAssistantHost.mockResolvedValueOnce({
+    renameLockfileAssistantHost.mockResolvedValueOnce({
       ok: false,
-      error: "disk unavailable",
+      error: "No lockfile entry for this assistant",
     });
 
     await expect(renameLockfileAssistant("local-a", "Credence")).resolves.toBe(
       false,
     );
 
-    expect(saveLockfileAssistantHost).toHaveBeenCalledTimes(1);
+    expect(renameLockfileAssistantHost).toHaveBeenCalledTimes(1);
     expect(useLockfileStore.getState().lockfile?.assistants).toEqual([named]);
   });
 });

--- a/clients/web/src/lib/local-mode.test.ts
+++ b/clients/web/src/lib/local-mode.test.ts
@@ -67,6 +67,7 @@ import {
   getPairedGatewayUrl,
   getPlatformAssistants,
   getPlatformRuntimeUrl,
+  getRemoteAssistantDisplayName,
   getSelectedAssistant,
   importPairedAssistantBundle,
   isCliWakeableAssistant,
@@ -101,6 +102,7 @@ import {
 } from "@/lib/self-hosted/connection";
 import { SELECTED_ASSISTANT_STORAGE_KEY } from "@/assistant/selected-assistant-storage";
 import type { Lockfile, LockfileAssistant } from "@/runtime/local-mode-host";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { useLockfileStore } from "@/stores/lockfile-store";
 
 const LOCKFILE_STORAGE_KEY = "vellum:local:lockfile";
@@ -158,6 +160,7 @@ afterEach(() => {
   connectImportHost.mockClear();
   clearGatewayToken();
   setSelfHostedConnection(null);
+  useAssistantIdentityStore.getState().clearIdentity();
 });
 
 describe("remote gateway mode", () => {
@@ -180,6 +183,34 @@ describe("remote gateway mode", () => {
     expect(getLocalAssistants().map((a) => a.assistantId)).toEqual(["self"]);
     expect(getLocalGatewayUrl()).toBeUndefined();
     expect(useLockfileStore.getState().committed).toBe(true);
+  });
+});
+
+describe("getRemoteAssistantDisplayName", () => {
+  test("prefers the live identity-store name over the injected config", () => {
+    window.__VELLUM_CONFIG__ = {
+      mode: "remote-gateway",
+      assistantName: "vellum-deep-hare-ww1iw1",
+    };
+    useAssistantIdentityStore.getState().setIdentity("Credence", "1.0.0");
+
+    expect(getRemoteAssistantDisplayName()).toBe("Credence");
+  });
+
+  test("falls back to the injected config for a whitespace-only live name", () => {
+    window.__VELLUM_CONFIG__ = {
+      mode: "remote-gateway",
+      assistantName: "vellum-deep-hare-ww1iw1",
+    };
+    useAssistantIdentityStore.getState().setIdentity("   ", "1.0.0");
+
+    expect(getRemoteAssistantDisplayName()).toBe("vellum-deep-hare-ww1iw1");
+  });
+
+  test("is undefined when neither source carries a name", () => {
+    window.__VELLUM_CONFIG__ = { mode: "remote-gateway" };
+
+    expect(getRemoteAssistantDisplayName()).toBeUndefined();
   });
 });
 

--- a/clients/web/src/lib/local-mode.test.ts
+++ b/clients/web/src/lib/local-mode.test.ts
@@ -609,7 +609,9 @@ describe("renameLockfileAssistant", () => {
       lockfile: resulting,
     });
 
-    await renameLockfileAssistant("local-a", "  Credence  ");
+    await expect(
+      renameLockfileAssistant("local-a", "  Credence  "),
+    ).resolves.toBe(true);
 
     expect(saveLockfileAssistantHost).toHaveBeenCalledTimes(1);
     expect(saveLockfileAssistantHost.mock.calls[0]).toEqual([
@@ -620,52 +622,60 @@ describe("renameLockfileAssistant", () => {
     expect(useLockfileStore.getState().committed).toBe(true);
   });
 
-  test("no-op when the lockfile has no entry for the id", async () => {
+  test("no-op (true) when the lockfile has no entry for the id", async () => {
     enableLocalHost();
     setLockfile({ assistants: [named], activeAssistant: "local-a" });
 
-    await renameLockfileAssistant("nope", "Credence");
+    await expect(renameLockfileAssistant("nope", "Credence")).resolves.toBe(
+      true,
+    );
 
     expect(saveLockfileAssistantHost).not.toHaveBeenCalled();
   });
 
-  test("no-op when the entry already carries the trimmed name", async () => {
+  test("no-op (true) when the entry already carries the trimmed name", async () => {
     enableLocalHost();
     setLockfile({ assistants: [named], activeAssistant: "local-a" });
 
-    await renameLockfileAssistant("local-a", "  Old Name  ");
+    await expect(
+      renameLockfileAssistant("local-a", "  Old Name  "),
+    ).resolves.toBe(true);
 
     expect(saveLockfileAssistantHost).not.toHaveBeenCalled();
   });
 
-  test("no-op on an empty or whitespace-only name", async () => {
+  test("no-op (true) on an empty or whitespace-only name", async () => {
     enableLocalHost();
     setLockfile({ assistants: [named], activeAssistant: "local-a" });
 
-    await renameLockfileAssistant("local-a", "");
-    await renameLockfileAssistant("local-a", "   ");
+    await expect(renameLockfileAssistant("local-a", "")).resolves.toBe(true);
+    await expect(renameLockfileAssistant("local-a", "   ")).resolves.toBe(true);
 
     expect(saveLockfileAssistantHost).not.toHaveBeenCalled();
   });
 
-  test("no-op when no local-mode host backs this runtime", async () => {
+  test("no-op (true) when no local-mode host backs this runtime", async () => {
     // Default test env: no injected config, not Electron.
     setLockfile({ assistants: [named], activeAssistant: "local-a" });
 
-    await renameLockfileAssistant("local-a", "Credence");
+    await expect(renameLockfileAssistant("local-a", "Credence")).resolves.toBe(
+      true,
+    );
 
     expect(saveLockfileAssistantHost).not.toHaveBeenCalled();
   });
 
-  test("no-op in remote-gateway mode", async () => {
+  test("no-op (true) in remote-gateway mode", async () => {
     window.__VELLUM_CONFIG__ = { mode: "remote-gateway" };
 
-    await renameLockfileAssistant("self", "Credence");
+    await expect(renameLockfileAssistant("self", "Credence")).resolves.toBe(
+      true,
+    );
 
     expect(saveLockfileAssistantHost).not.toHaveBeenCalled();
   });
 
-  test("does not commit on a host write failure", async () => {
+  test("resolves false without committing on a host write failure", async () => {
     enableLocalHost();
     setLockfile({ assistants: [named], activeAssistant: "local-a" });
     saveLockfileAssistantHost.mockResolvedValueOnce({
@@ -673,7 +683,9 @@ describe("renameLockfileAssistant", () => {
       error: "disk unavailable",
     });
 
-    await renameLockfileAssistant("local-a", "Credence");
+    await expect(renameLockfileAssistant("local-a", "Credence")).resolves.toBe(
+      false,
+    );
 
     expect(saveLockfileAssistantHost).toHaveBeenCalledTimes(1);
     expect(useLockfileStore.getState().lockfile?.assistants).toEqual([named]);

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -135,7 +135,7 @@ function getRemoteGatewayLockfile(): Lockfile {
     assistants: [
       {
         assistantId: "self",
-        name: "Local Assistant",
+        name: getRemoteGatewayAssistantName() ?? "Local Assistant",
         cloud: "local",
         runtimeUrl: window.location.origin,
         hatchedAt: "1970-01-01T00:00:00.000Z",
@@ -677,19 +677,24 @@ export function getLockfileAssistant(
 }
 
 /**
- * React subscription to one lockfile entry's `name`. `undefined` while the
- * lockfile hasn't hydrated or the id has no entry, so effects depending on it
- * re-fire once the entry appears. Narrow on purpose: the lockfile store stays
- * internal to this module.
+ * React subscription to one lockfile entry's `name`: `undefined` while the
+ * lockfile hasn't hydrated or the id has no entry, `null` when the entry
+ * exists but is unnamed. Distinguishing absence from an unnamed entry lets
+ * effects depending on this value re-fire even when the appearing entry
+ * carries no name.
  */
 export function useLockfileAssistantName(
   assistantId: string | null,
-): string | undefined {
-  return useLockfileStore((s) =>
-    assistantId === null
-      ? undefined
-      : s.lockfile?.assistants.find((a) => a.assistantId === assistantId)?.name,
-  );
+): string | null | undefined {
+  return useLockfileStore((s) => {
+    if (assistantId === null) {
+      return undefined;
+    }
+    const entry = s.lockfile?.assistants.find(
+      (a) => a.assistantId === assistantId,
+    );
+    return entry === undefined ? undefined : (entry.name ?? null);
+  });
 }
 
 /**

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -27,6 +27,7 @@ import {
   connectImportHost,
   fetchGuardianTokenHost,
   GuardianTokenError,
+  isLocalModeHostAvailable,
   loadLockfileHost,
   parseLockfile,
   replacePlatformAssistantsHost,
@@ -290,6 +291,37 @@ export async function updateLockfileAssistant(
   assistant: LockfileAssistant,
 ): Promise<void> {
   const result = await saveLockfileAssistantHost({ ...assistant }, undefined);
+  if (result.ok) {
+    commitLockfile(result.lockfile);
+  }
+}
+
+/**
+ * Rename an existing assistant entry without touching its other fields or the
+ * active assistant pointer. The partial payload rides the host's shallow
+ * on-disk merge, so `resources`, secrets, and unknown fields survive.
+ */
+export async function renameLockfileAssistant(
+  assistantId: string,
+  name: string,
+): Promise<void> {
+  const trimmed = name.trim();
+  if (!trimmed) {
+    // Fresh assistants report "": never write an empty name.
+    return;
+  }
+  if (isRemoteGatewayMode() || !isLocalModeHostAvailable()) {
+    return;
+  }
+  const entry = getLockfileAssistant(assistantId);
+  if (!entry || entry.name === trimmed) {
+    // Rename-only: never create an entry, never write redundantly.
+    return;
+  }
+  const result = await saveLockfileAssistantHost(
+    { assistantId, name: trimmed },
+    undefined,
+  );
   if (result.ok) {
     commitLockfile(result.lockfile);
   }

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -33,6 +33,7 @@ import {
   parseLockfile,
   replacePlatformAssistantsHost,
   retireLocalAssistantHost,
+  renameLockfileAssistantHost,
   saveLockfileAssistantHost,
   unpairAssistantHost,
   wakeLocalAssistantHost,
@@ -305,12 +306,15 @@ export async function updateLockfileAssistant(
 
 /**
  * Rename an existing assistant entry without touching its other fields or the
- * active assistant pointer. The partial payload rides the host's shallow
- * on-disk merge, so `resources`, secrets, and unknown fields survive.
+ * active assistant pointer. Runs through the host's rename-if-present
+ * operation, which decides against the on-disk registry and refuses missing
+ * entries and unreadable files instead of upserting, so a stale renderer
+ * cache can never resurrect a retired assistant. The renderer-side guards
+ * below are cheap early-outs, not the safety boundary.
  *
  * Resolves `true` when there is nothing left to do (converged, no-op guard,
- * or a successful write); `false` only when a host write was attempted and
- * failed, so callers can retry.
+ * or a successful write); `false` when the host write failed or refused, so
+ * callers can retry.
  */
 export async function renameLockfileAssistant(
   assistantId: string,
@@ -329,10 +333,7 @@ export async function renameLockfileAssistant(
     // Rename-only: never create an entry, never write redundantly.
     return true;
   }
-  const result = await saveLockfileAssistantHost(
-    { assistantId, name: trimmed },
-    undefined,
-  );
+  const result = await renameLockfileAssistantHost(assistantId, trimmed);
   if (result.ok) {
     commitLockfile(result.lockfile);
     return true;

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -307,23 +307,27 @@ export async function updateLockfileAssistant(
  * Rename an existing assistant entry without touching its other fields or the
  * active assistant pointer. The partial payload rides the host's shallow
  * on-disk merge, so `resources`, secrets, and unknown fields survive.
+ *
+ * Resolves `true` when there is nothing left to do (converged, no-op guard,
+ * or a successful write); `false` only when a host write was attempted and
+ * failed, so callers can retry.
  */
 export async function renameLockfileAssistant(
   assistantId: string,
   name: string,
-): Promise<void> {
+): Promise<boolean> {
   const trimmed = name.trim();
   if (!trimmed) {
     // Fresh assistants report "": never write an empty name.
-    return;
+    return true;
   }
   if (isRemoteGatewayMode() || !isLocalModeHostAvailable()) {
-    return;
+    return true;
   }
   const entry = getLockfileAssistant(assistantId);
   if (!entry || entry.name === trimmed) {
     // Rename-only: never create an entry, never write redundantly.
-    return;
+    return true;
   }
   const result = await saveLockfileAssistantHost(
     { assistantId, name: trimmed },
@@ -331,7 +335,9 @@ export async function renameLockfileAssistant(
   );
   if (result.ok) {
     commitLockfile(result.lockfile);
+    return true;
   }
+  return false;
 }
 
 /**
@@ -668,6 +674,22 @@ export function getLockfileAssistant(
   assistantId: string,
 ): LockfileAssistant | undefined {
   return getLockfile().assistants.find((a) => a.assistantId === assistantId);
+}
+
+/**
+ * React subscription to one lockfile entry's `name`. `undefined` while the
+ * lockfile hasn't hydrated or the id has no entry, so effects depending on it
+ * re-fire once the entry appears. Narrow on purpose: the lockfile store stays
+ * internal to this module.
+ */
+export function useLockfileAssistantName(
+  assistantId: string | null,
+): string | undefined {
+  return useLockfileStore((s) =>
+    assistantId === null
+      ? undefined
+      : s.lockfile?.assistants.find((a) => a.assistantId === assistantId)?.name,
+  );
 }
 
 /**

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -22,6 +22,7 @@ import {
   getSelfHostedIngressUrl,
   setSelfHostedConnection,
 } from "@/lib/self-hosted/connection";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { useLockfileStore } from "@/stores/lockfile-store";
 import {
   connectImportHost,
@@ -112,6 +113,12 @@ function nonEmptyString(value: string | undefined): string | undefined {
  */
 export function getRemoteGatewayAssistantName(): string | undefined {
   return nonEmptyString(getInjectedConfig().assistantName);
+}
+
+/** Live persona name when hydrated, else the (possibly stale) name the edge injected at tunnel start. */
+export function getRemoteAssistantDisplayName(): string | undefined {
+  const live = useAssistantIdentityStore.getState().name?.trim();
+  return live || getRemoteGatewayAssistantName();
 }
 
 /**

--- a/clients/web/src/root-layout.tsx
+++ b/clients/web/src/root-layout.tsx
@@ -59,6 +59,7 @@ import { useCompanionMirror } from "@/domains/chat/hooks/use-companion-mirror";
 import { useElectronIconSync } from "@/hooks/use-electron-icon-sync";
 import { useIslandAvatarSource } from "@/hooks/use-island-avatar-source";
 import { useElectronIdentitySync } from "@/hooks/use-electron-identity-sync";
+import { useLockfileIdentitySync } from "@/hooks/use-lockfile-identity-sync";
 import { useElectronStatusSync } from "@/hooks/use-electron-status-sync";
 import { useElectronFeatureFlagBridge } from "@/runtime/electron-feature-flags";
 import { subscribeAndroidBackButtonSource } from "@/runtime/event-sources/android-back-button";
@@ -186,6 +187,7 @@ export function RootLayout() {
   useElectronIconSync(avatar.customImageUrl, avatar.components, avatar.traits);
   useElectronStatusSync();
   useElectronIdentitySync();
+  useLockfileIdentitySync();
   useElectronFeatureFlagBridge();
 
   // Size the Electron main window to the onboarding layout (440×630

--- a/clients/web/src/runtime/is-electron.ts
+++ b/clients/web/src/runtime/is-electron.ts
@@ -212,6 +212,10 @@ declare global {
           assistant: Record<string, unknown>,
           activeAssistant?: string,
         ): Promise<LockfileWriteResult>;
+        renameLockfileAssistant?(
+          assistantId: string,
+          name: string,
+        ): Promise<LockfileWriteResult>;
         replacePlatformAssistants(
           platformAssistants: Array<Record<string, unknown>>,
           organizationId?: string,

--- a/clients/web/src/runtime/local-mode-host.test.ts
+++ b/clients/web/src/runtime/local-mode-host.test.ts
@@ -10,6 +10,7 @@ const {
   GuardianTokenError,
   hatchLocalAssistant,
   loadLockfileHost,
+  renameLockfileAssistantHost,
   saveLockfileAssistantHost,
   replacePlatformAssistantsHost,
   retireLocalAssistantHost,
@@ -216,6 +217,77 @@ describe("saveLockfileAssistantHost", () => {
       { assistantId: "a-1" },
       "a-1",
     );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("renameLockfileAssistantHost", () => {
+  test("web/dev host POSTs the rename body shape to the lockfile middleware", async () => {
+    const lockfile = { assistants: [], activeAssistant: null };
+    const fetchMock = mock(async () => ({
+      json: async () => ({ ok: true, lockfile }),
+    }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await renameLockfileAssistantHost("a-1", "Credence");
+
+    expect(result).toEqual({ ok: true, lockfile });
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
+    expect(url).toBe("/assistant/__local/lockfile");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({
+      rename: { assistantId: "a-1", name: "Credence" },
+    });
+  });
+
+  test("web/dev host surfaces the host's structured refusal", async () => {
+    globalThis.fetch = mock(async () => ({
+      json: async () => ({ ok: false, error: "No lockfile entry" }),
+    })) as unknown as typeof fetch;
+
+    const result = await renameLockfileAssistantHost("gone", "Credence");
+
+    expect(result).toEqual({ ok: false, error: "No lockfile entry" });
+  });
+
+  test("Electron host renames through the bridge and never touches fetch", async () => {
+    const renameLockfileAssistant = mock(async () => ({
+      ok: true,
+      lockfile: {},
+    }));
+    const fetchMock = mock(async () => {
+      throw new Error("fetch must not run on the Electron branch");
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    setElectronBridge({ renameLockfileAssistant });
+
+    await renameLockfileAssistantHost("a-1", "Credence");
+
+    expect(renameLockfileAssistant).toHaveBeenCalledWith("a-1", "Credence");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("older Electron shell without the channel refuses without falling back to the upsert", async () => {
+    const saveLockfileAssistant = mock(async () => ({
+      ok: true,
+      lockfile: {},
+    }));
+    const fetchMock = mock(async () => {
+      throw new Error("fetch must not run on the Electron branch");
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    setElectronBridge({ saveLockfileAssistant });
+
+    const result = await renameLockfileAssistantHost("a-1", "Credence");
+
+    expect(result).toEqual({
+      ok: false,
+      error: "Renaming is not supported by this app version",
+    });
+    expect(saveLockfileAssistant).not.toHaveBeenCalled();
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/runtime/local-mode-host.ts
+++ b/clients/web/src/runtime/local-mode-host.ts
@@ -257,6 +257,38 @@ export async function saveLockfileAssistantHost(
 }
 
 /**
+ * Rename an existing lockfile entry through the host's rename-if-present
+ * operation. Unlike {@link saveLockfileAssistantHost}'s upsert, the host
+ * decides against its current on-disk registry and refuses when the entry is
+ * missing or the file is unreadable, so a stale renderer cache can never
+ * resurrect a retired assistant or replace a registry the host could not
+ * read. Older Electron hosts that predate the IPC channel degrade to a
+ * structured failure rather than falling back to the upsert (which would
+ * reintroduce the hazard); the name sync simply waits for the app update.
+ */
+export async function renameLockfileAssistantHost(
+  assistantId: string,
+  name: string,
+): Promise<LockfileWriteResult> {
+  if (isElectron()) {
+    const rename = window.vellum!.localMode.renameLockfileAssistant;
+    if (!rename) {
+      return {
+        ok: false,
+        error: "Renaming is not supported by this app version",
+      };
+    }
+    return rename(assistantId, name);
+  }
+
+  return postLocalCommand<LockfileWriteResult>(
+    "/assistant/__local/lockfile",
+    { rename: { assistantId, name } },
+    LOCAL_HOST_UNAVAILABLE_ERROR,
+  );
+}
+
+/**
  * Replace the platform (`cloud === "vellum"`) assistants in the lockfile with
  * the provided set, preserving local assistants. When `organizationId` is
  * given, only that org's platform entries are replaced — other orgs' entries

--- a/clients/web/vite-plugin-local-mode.ts
+++ b/clients/web/vite-plugin-local-mode.ts
@@ -14,6 +14,7 @@ import {
   connectImport,
   getLockfileData,
   getLocalAssistantStatus,
+  renameLockfileAssistantIfPresent,
   upsertRendererLockfileAssistant,
   replacePlatformAssistants,
   isActiveAssistant,
@@ -348,6 +349,13 @@ function lockfileMiddleware(
             lockfilePaths,
             body.platformAssistants as Array<Record<string, unknown>>,
             body.organizationId as string | undefined,
+          );
+        } else if (body.rename && typeof body.rename === "object") {
+          const rename = body.rename as Record<string, unknown>;
+          result = renameLockfileAssistantIfPresent(
+            lockfilePaths,
+            rename.assistantId as string,
+            rename.name as string,
           );
         } else {
           result = upsertRendererLockfileAssistant(

--- a/packages/electron-desktop/src/local-mode-bridge.ts
+++ b/packages/electron-desktop/src/local-mode-bridge.ts
@@ -14,6 +14,8 @@ export const createLocalModeBridge = (
   hatch: (species, remote) =>
     ipc.invoke("vellum:localMode:hatch", species, remote),
   readLockfile: () => ipc.invoke("vellum:localMode:readLockfile"),
+  renameLockfileAssistant: (assistantId, name) =>
+    ipc.invoke("vellum:localMode:renameLockfileAssistant", assistantId, name),
   replacePlatformAssistants: (assistants, organizationId) =>
     ipc.invoke(
       "vellum:localMode:replacePlatformAssistants",

--- a/packages/electron-desktop/src/local-mode.test.ts
+++ b/packages/electron-desktop/src/local-mode.test.ts
@@ -368,6 +368,15 @@ const saveLockfileAssistant = (
     assistant,
     activeAssistant,
   ) as WriteResult;
+const renameLockfileAssistant = (
+  assistantId?: unknown,
+  name?: unknown,
+): WriteResult =>
+  handlers["vellum:localMode:renameLockfileAssistant"](
+    allowedEvent,
+    assistantId,
+    name,
+  ) as WriteResult;
 const writePairedLockfileAssistant = (assistantId: string): void => {
   fs.writeFileSync(
     lockfilePath,
@@ -516,6 +525,71 @@ describe("lockfile IPC handlers", () => {
         runtimeUrl: "https://h",
       },
     ]);
+  });
+
+  test("renameLockfileAssistant persists the rename and refreshes the watcher", () => {
+    saveLockfileAssistant(
+      {
+        assistantId: "asst-1",
+        cloud: "local",
+        runtimeUrl: "http://127.0.0.1:1",
+        name: "Old Name",
+      },
+      "asst-1",
+    );
+    refreshLockfileNowMock.mockClear();
+
+    const result = renameLockfileAssistant("asst-1", "Credence");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.lockfile.assistants).toEqual([
+      {
+        assistantId: "asst-1",
+        cloud: "local",
+        runtimeUrl: "http://127.0.0.1:1",
+        name: "Credence",
+      },
+    ]);
+    expect(result.lockfile.activeAssistant).toBe("asst-1");
+    expect(refreshLockfileNowMock).toHaveBeenCalledTimes(1);
+
+    const onDisk = JSON.parse(fs.readFileSync(lockfilePath, "utf-8")) as {
+      assistants: Array<Record<string, unknown>>;
+    };
+    expect(onDisk.assistants[0]?.name).toBe("Credence");
+  });
+
+  test("renameLockfileAssistant refuses a missing entry without creating the file", () => {
+    const result = renameLockfileAssistant("asst-gone", "Credence");
+
+    expect(result.ok).toBe(false);
+    expect(fs.existsSync(lockfilePath)).toBe(false);
+    expect(refreshLockfileNowMock).not.toHaveBeenCalled();
+  });
+
+  test("renameLockfileAssistant refuses a corrupt file without clobbering it", () => {
+    fs.writeFileSync(lockfilePath, "{ not json");
+
+    const result = renameLockfileAssistant("asst-1", "Credence");
+
+    expect(result.ok).toBe(false);
+    expect(fs.readFileSync(lockfilePath, "utf-8")).toBe("{ not json");
+    expect(refreshLockfileNowMock).not.toHaveBeenCalled();
+  });
+
+  test("renameLockfileAssistant rejects a missing id or name with a structured error", () => {
+    expect(renameLockfileAssistant(undefined, "Credence")).toEqual({
+      ok: false,
+      error: "Missing assistantId or name",
+    });
+    expect(renameLockfileAssistant("asst-1", undefined)).toEqual({
+      ok: false,
+      error: "Missing assistantId or name",
+    });
+    expect(fs.existsSync(lockfilePath)).toBe(false);
   });
 
   test("replacePlatformAssistants swaps platform entries while preserving local ones", () => {

--- a/packages/electron-desktop/src/local-mode.ts
+++ b/packages/electron-desktop/src/local-mode.ts
@@ -6,6 +6,7 @@ import {
   getPairedGuardianAccessToken as getStoredPairedGuardianAccessToken,
   isActiveAssistant,
   isPairedLockfileEntry,
+  renameLockfileAssistantIfPresent,
   PAIRED_GUARDIAN_TOKEN_HOST_ONLY_ERROR,
   getLockfileData,
   getLocalAssistantStatus,
@@ -393,6 +394,31 @@ export const installLocalMode = (): void => {
       return result.ok
         ? { ok: true, lockfile: result.lockfile }
         : { ok: false, error: result.error };
+    },
+  );
+
+  // Rename-if-present: refuses missing entries and unreadable files instead
+  // of upserting, so a stale renderer cache never re-creates an entry. Both
+  // args stay optional on the wire, keeping the never-reject contract.
+  ipc(
+    "vellum:localMode:renameLockfileAssistant",
+    z.tuple([z.string().optional(), z.string().optional()]),
+    ([assistantId, name]): LockfileWriteResult => {
+      if (!assistantId || !name) {
+        return { ok: false, error: "Missing assistantId or name" };
+      }
+      const result = renameLockfileAssistantIfPresent(
+        lockfilePaths,
+        assistantId,
+        name,
+      );
+      if (!result.ok) {
+        return { ok: false, error: result.error };
+      }
+      // Refresh the watcher so lockfile-driven surfaces pick up the new name
+      // in the same tick instead of after the next poll.
+      refreshLockfile();
+      return { ok: true, lockfile: result.lockfile };
     },
   );
 

--- a/packages/ipc-contract/src/bridge.ts
+++ b/packages/ipc-contract/src/bridge.ts
@@ -192,6 +192,16 @@ export interface VellumBridge {
       assistant: Record<string, unknown>,
       activeAssistant?: string,
     ): Promise<LockfileWriteResult>;
+    /**
+     * Rename an existing lockfile entry. Unlike `saveLockfileAssistant`'s
+     * upsert, the host refuses when the entry is missing or the on-disk
+     * file is unreadable, so a stale renderer cache can never re-create a
+     * retired assistant. Never touches the active assistant.
+     */
+    renameLockfileAssistant(
+      assistantId: string,
+      name: string,
+    ): Promise<LockfileWriteResult>;
     replacePlatformAssistants(
       platformAssistants: Array<Record<string, unknown>>,
       organizationId?: string,

--- a/packages/local-mode/src/__tests__/unpair.test.ts
+++ b/packages/local-mode/src/__tests__/unpair.test.ts
@@ -229,4 +229,37 @@ describe("unpairAssistant", () => {
     }
     expect(result.status).toBe(400);
   });
+
+  test("refuses with 423 under a held write lock, leaving entry and token alone", () => {
+    writeLockfile({
+      assistants: [{ assistantId: "paired-1", cloud: "paired" }],
+      activeAssistant: "paired-1",
+    });
+    const tokenPath = seedGuardianToken("paired-1");
+    fs.mkdirSync(`${lockfilePath}.lock`);
+    try {
+      const result = unpairAssistant([lockfilePath], configDir, "paired-1");
+
+      expect(result).toMatchObject({ ok: false, status: 423 });
+      expect(fs.existsSync(tokenPath)).toBe(true);
+      expect(readLockfileFromDisk().assistants).toEqual([
+        { assistantId: "paired-1", cloud: "paired" },
+      ]);
+    } finally {
+      fs.rmdirSync(`${lockfilePath}.lock`);
+    }
+  });
+
+  test("a successful unpair leaves no lock dir behind", () => {
+    writeLockfile({
+      assistants: [{ assistantId: "paired-1", cloud: "paired" }],
+      activeAssistant: "paired-1",
+    });
+    seedGuardianToken("paired-1");
+
+    const result = unpairAssistant([lockfilePath], configDir, "paired-1");
+
+    expect(result.ok).toBe(true);
+    expect(fs.existsSync(`${lockfilePath}.lock`)).toBe(false);
+  });
 });

--- a/packages/local-mode/src/index.ts
+++ b/packages/local-mode/src/index.ts
@@ -45,6 +45,8 @@ export {
   isPairedLockfileEntry,
 } from "./lockfile";
 export type { LockfileResult, WriteResult } from "./lockfile";
+export { withLockfileLock } from "./lockfile-lock";
+export type { LockfileLockResult } from "./lockfile-lock";
 export { parseLockfile } from "./lockfile-contract";
 export type {
   Lockfile,

--- a/packages/local-mode/src/index.ts
+++ b/packages/local-mode/src/index.ts
@@ -37,6 +37,7 @@ export {
 } from "./environment";
 export {
   getLockfileData,
+  renameLockfileAssistantIfPresent,
   upsertLockfileAssistant,
   upsertRendererLockfileAssistant,
   replacePlatformAssistants,

--- a/packages/local-mode/src/lockfile-lock.test.ts
+++ b/packages/local-mode/src/lockfile-lock.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { withLockfileLock } from "./lockfile-lock";
+
+let dir: string;
+let lockfilePath: string;
+let lockDir: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "lockfile-lock-test-"));
+  lockfilePath = path.join(dir, "lockfile.json");
+  lockDir = `${lockfilePath}.lock`;
+});
+
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe("withLockfileLock", () => {
+  test("runs fn, propagates its result, and removes the lock dir", () => {
+    const result = withLockfileLock([lockfilePath], () => {
+      expect(fs.existsSync(lockDir)).toBe(true);
+      return 42;
+    });
+    expect(result).toEqual({ ok: true, value: 42 });
+    expect(fs.existsSync(lockDir)).toBe(false);
+  });
+
+  test("keys the lock to the write path, ignoring fallback paths", () => {
+    const fallback = path.join(dir, "legacy.json");
+    withLockfileLock([lockfilePath, fallback], () => {
+      expect(fs.existsSync(lockDir)).toBe(true);
+      expect(fs.existsSync(`${fallback}.lock`)).toBe(false);
+    });
+  });
+
+  test("releases the lock when fn throws, rethrowing", () => {
+    expect(() =>
+      withLockfileLock([lockfilePath], () => {
+        throw new Error("boom");
+      }),
+    ).toThrow("boom");
+    expect(fs.existsSync(lockDir)).toBe(false);
+  });
+
+  test("is reentrant within the process", () => {
+    const result = withLockfileLock([lockfilePath], () => {
+      const inner = withLockfileLock([lockfilePath], () => "inner");
+      expect(inner).toEqual({ ok: true, value: "inner" });
+      // Inner exit must not release the outer hold.
+      expect(fs.existsSync(lockDir)).toBe(true);
+      return "outer";
+    });
+    expect(result).toEqual({ ok: true, value: "outer" });
+    expect(fs.existsSync(lockDir)).toBe(false);
+  });
+
+  test("fails cleanly within budget when another holder is fresh", () => {
+    fs.mkdirSync(lockDir);
+    let ran = false;
+    const start = Date.now();
+    const result = withLockfileLock([lockfilePath], () => {
+      ran = true;
+    });
+    expect(Date.now() - start).toBeLessThan(2_000);
+    expect(ran).toBe(false);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("Timed out acquiring lockfile lock");
+    }
+    // The other holder's lock is untouched.
+    expect(fs.existsSync(lockDir)).toBe(true);
+  });
+
+  test("breaks a stale lock left by a crashed holder", () => {
+    fs.mkdirSync(lockDir);
+    const past = new Date(Date.now() - 60_000);
+    fs.utimesSync(lockDir, past, past);
+
+    const result = withLockfileLock([lockfilePath], () => "ran");
+    expect(result).toEqual({ ok: true, value: "ran" });
+    expect(fs.existsSync(lockDir)).toBe(false);
+  });
+
+  test("creates a missing parent directory and acquires", () => {
+    const nested = path.join(dir, "a", "b", "lockfile.json");
+    const result = withLockfileLock([nested], () => "ran");
+    expect(result).toEqual({ ok: true, value: "ran" });
+    expect(fs.existsSync(`${nested}.lock`)).toBe(false);
+  });
+
+  test("refuses an empty path list", () => {
+    expect(withLockfileLock([], () => "never").ok).toBe(false);
+  });
+});

--- a/packages/local-mode/src/lockfile-lock.ts
+++ b/packages/local-mode/src/lockfile-lock.ts
@@ -1,0 +1,96 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export type LockfileLockResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: string };
+
+/** A holder only holds for the microseconds a read-modify-write takes, so a
+ *  lock this old belongs to a crashed process and is safe to break. */
+const STALE_LOCK_MS = 5_000;
+const ACQUIRE_ATTEMPTS = 10;
+const RETRY_DELAY_MS = 25;
+
+/** Locks held by this process, so composed writers reenter instead of deadlocking. */
+const heldLocks = new Set<string>();
+
+/** Node-compatible synchronous sleep (no Bun.sleepSync in Electron/Vite hosts). */
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function tryBreakStaleLock(lockDir: string): void {
+  try {
+    if (Date.now() - fs.statSync(lockDir).mtimeMs > STALE_LOCK_MS) {
+      fs.rmdirSync(lockDir);
+    }
+  } catch {
+    // Holder released or another contender broke it; next mkdir attempt decides.
+  }
+}
+
+/**
+ * Run `fn` under a cross-process advisory lock keyed to the lockfile write
+ * path (`lockfilePaths[0]`). The lock is a `${writePath}.lock` directory:
+ * mkdir has O_EXCL semantics on every platform, so exactly one process wins.
+ * Acquisition is bounded (~250ms worst case) and failure is returned
+ * structurally rather than thrown, so never-throw seams stay never-throw;
+ * `fn`'s own exceptions propagate, with the lock released in `finally`.
+ */
+export function withLockfileLock<T>(
+  lockfilePaths: string[],
+  fn: () => T,
+): LockfileLockResult<T> {
+  const writePath = lockfilePaths[0];
+  if (!writePath) {
+    return { ok: false, error: "No lockfile path to lock" };
+  }
+  const lockDir = `${writePath}.lock`;
+
+  if (heldLocks.has(lockDir)) {
+    return { ok: true, value: fn() };
+  }
+
+  let acquired = false;
+  for (let attempt = 0; attempt < ACQUIRE_ATTEMPTS; attempt++) {
+    if (attempt > 0) sleepSync(RETRY_DELAY_MS);
+    try {
+      fs.mkdirSync(lockDir);
+      acquired = true;
+      break;
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "EEXIST") {
+        tryBreakStaleLock(lockDir);
+        continue;
+      }
+      if (code === "ENOENT") {
+        try {
+          fs.mkdirSync(path.dirname(lockDir), { recursive: true });
+        } catch {
+          // Surfaced by the next mkdir attempt.
+        }
+        continue;
+      }
+      return { ok: false, error: `Failed to acquire lockfile lock: ${err}` };
+    }
+  }
+  if (!acquired) {
+    return {
+      ok: false,
+      error: `Timed out acquiring lockfile lock at ${lockDir}`,
+    };
+  }
+
+  heldLocks.add(lockDir);
+  try {
+    return { ok: true, value: fn() };
+  } finally {
+    heldLocks.delete(lockDir);
+    try {
+      fs.rmdirSync(lockDir);
+    } catch {
+      // Best effort; a leftover dir is broken as stale by the next acquirer.
+    }
+  }
+}

--- a/packages/local-mode/src/lockfile.test.ts
+++ b/packages/local-mode/src/lockfile.test.ts
@@ -224,6 +224,33 @@ describe("upsertLockfileAssistant", () => {
     });
   });
 
+  test("a name-only payload preserves resources and on-disk secrets byte-for-byte", () => {
+    const entry = {
+      assistantId: "asst_1",
+      cloud: "local",
+      runtimeUrl: "http://a",
+      name: "Old Name",
+      resources: { gatewayPort: 7830, daemonPort: 7831, dataDir: "/tmp/x" },
+      signingKey: "sk-on-disk-secret",
+      bearerToken: "bt-on-disk-secret",
+      guardianBootstrapSecret: "gb-on-disk-secret",
+    };
+    writeOnDisk({ activeAssistant: "asst_1", assistants: [entry] });
+
+    const result = upsertLockfileAssistant(
+      [lockfilePath],
+      { assistantId: "asst_1", name: "Renamed" },
+      undefined,
+    );
+
+    expect(result.ok).toBe(true);
+    const assistants = readOnDisk().assistants as Array<
+      Record<string, unknown>
+    >;
+    expect(assistants).toHaveLength(1);
+    expect(assistants[0]).toEqual({ ...entry, name: "Renamed" });
+  });
+
   test("preserves activeAssistant when no active id is provided", () => {
     writeOnDisk({
       activeAssistant: "asst_active",

--- a/packages/local-mode/src/lockfile.test.ts
+++ b/packages/local-mode/src/lockfile.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import {
   getLockfileData,
   isPairedLockfileEntry,
+  renameLockfileAssistantIfPresent,
   replacePlatformAssistants,
   upsertLockfileAssistant,
   upsertRendererLockfileAssistant,
@@ -275,6 +276,123 @@ describe("upsertLockfileAssistant", () => {
     if (result.ok) {
       expect(result.lockfile.activeAssistant).toBe("asst_active");
     }
+  });
+});
+
+describe("renameLockfileAssistantIfPresent", () => {
+  const entry = {
+    assistantId: "asst_1",
+    cloud: "local",
+    runtimeUrl: "http://a",
+    name: "Old Name",
+    resources: { gatewayPort: 7830, daemonPort: 7831, dataDir: "/tmp/x" },
+    signingKey: "sk-on-disk-secret",
+    bearerToken: "bt-on-disk-secret",
+  };
+
+  test("renames the entry preserving resources, secrets, and activeAssistant", () => {
+    writeOnDisk({
+      activeAssistant: "asst_other",
+      assistants: [entry, { assistantId: "asst_other", cloud: "local" }],
+    });
+
+    const result = renameLockfileAssistantIfPresent(
+      [lockfilePath],
+      "asst_1",
+      "Renamed",
+    );
+
+    expect(result.ok).toBe(true);
+    const onDisk = readOnDisk();
+    expect(onDisk.activeAssistant).toBe("asst_other");
+    const assistants = onDisk.assistants as Array<Record<string, unknown>>;
+    expect(assistants).toEqual([
+      { ...entry, name: "Renamed" },
+      { assistantId: "asst_other", cloud: "local" },
+    ]);
+  });
+
+  test("refuses a missing entry without writing the file", () => {
+    const result = renameLockfileAssistantIfPresent(
+      [lockfilePath],
+      "asst_gone",
+      "Renamed",
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      status: 404,
+      error: "No lockfile entry for this assistant",
+    });
+    expect(fs.existsSync(lockfilePath)).toBe(false);
+  });
+
+  test("refuses when the id names another process's retired entry", () => {
+    writeOnDisk({ activeAssistant: null, assistants: [entry] });
+    const before = fs.readFileSync(lockfilePath, "utf-8");
+
+    const result = renameLockfileAssistantIfPresent(
+      [lockfilePath],
+      "asst_retired",
+      "Renamed",
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(404);
+    }
+    expect(fs.readFileSync(lockfilePath, "utf-8")).toBe(before);
+  });
+
+  test("refuses a corrupt on-disk file without clobbering it", () => {
+    fs.writeFileSync(lockfilePath, "{ not json");
+
+    const result = renameLockfileAssistantIfPresent(
+      [lockfilePath],
+      "asst_1",
+      "Renamed",
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(409);
+    }
+    expect(fs.readFileSync(lockfilePath, "utf-8")).toBe("{ not json");
+  });
+
+  test("an already-equal name succeeds without rewriting the file", () => {
+    // Compact formatting: any rewrite would re-indent and change the bytes.
+    fs.writeFileSync(
+      lockfilePath,
+      JSON.stringify({ activeAssistant: null, assistants: [entry] }),
+    );
+    const before = fs.readFileSync(lockfilePath, "utf-8");
+
+    const result = renameLockfileAssistantIfPresent(
+      [lockfilePath],
+      "asst_1",
+      "Old Name",
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.lockfile.assistants[0]?.name).toBe("Old Name");
+      expect(result.lockfile.assistants[0]).not.toHaveProperty("signingKey");
+    }
+    expect(fs.readFileSync(lockfilePath, "utf-8")).toBe(before);
+  });
+
+  test("rejects a missing id or name without touching disk", () => {
+    writeOnDisk({ activeAssistant: null, assistants: [entry] });
+    const before = fs.readFileSync(lockfilePath, "utf-8");
+
+    expect(renameLockfileAssistantIfPresent([lockfilePath], "", "N").ok).toBe(
+      false,
+    );
+    expect(
+      renameLockfileAssistantIfPresent([lockfilePath], "asst_1", "").ok,
+    ).toBe(false);
+    expect(fs.readFileSync(lockfilePath, "utf-8")).toBe(before);
   });
 });
 

--- a/packages/local-mode/src/lockfile.test.ts
+++ b/packages/local-mode/src/lockfile.test.ts
@@ -396,6 +396,81 @@ describe("renameLockfileAssistantIfPresent", () => {
   });
 });
 
+describe("lockfile writers under lock contention", () => {
+  const entry = {
+    assistantId: "asst_1",
+    cloud: "local",
+    runtimeUrl: "http://a",
+    name: "Old Name",
+  };
+
+  function holdLock(): string {
+    const lockDir = `${lockfilePath}.lock`;
+    fs.mkdirSync(lockDir);
+    return lockDir;
+  }
+
+  test("rename refuses with 423 and leaves the file untouched", () => {
+    writeOnDisk({ activeAssistant: null, assistants: [entry] });
+    const before = fs.readFileSync(lockfilePath, "utf-8");
+    holdLock();
+
+    const result = renameLockfileAssistantIfPresent(
+      [lockfilePath],
+      "asst_1",
+      "Renamed",
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(423);
+    }
+    expect(fs.readFileSync(lockfilePath, "utf-8")).toBe(before);
+  });
+
+  test("upsert refuses with 423 and leaves the file untouched", () => {
+    writeOnDisk({ activeAssistant: null, assistants: [entry] });
+    const before = fs.readFileSync(lockfilePath, "utf-8");
+    holdLock();
+
+    const result = upsertLockfileAssistant(
+      [lockfilePath],
+      { assistantId: "asst_2", cloud: "local" },
+      undefined,
+    );
+
+    expect(result).toMatchObject({ ok: false, status: 423 });
+    expect(fs.readFileSync(lockfilePath, "utf-8")).toBe(before);
+  });
+
+  test("platform replace refuses with 423 and leaves the file untouched", () => {
+    writeOnDisk({ activeAssistant: null, assistants: [entry] });
+    const before = fs.readFileSync(lockfilePath, "utf-8");
+    holdLock();
+
+    const result = replacePlatformAssistants(
+      [lockfilePath],
+      [{ assistantId: "asst_p", cloud: "vellum", runtimeUrl: "http://p" }],
+    );
+
+    expect(result).toMatchObject({ ok: false, status: 423 });
+    expect(fs.readFileSync(lockfilePath, "utf-8")).toBe(before);
+  });
+
+  test("a successful rename leaves no lock dir behind", () => {
+    writeOnDisk({ activeAssistant: null, assistants: [entry] });
+
+    const result = renameLockfileAssistantIfPresent(
+      [lockfilePath],
+      "asst_1",
+      "Renamed",
+    );
+
+    expect(result.ok).toBe(true);
+    expect(fs.existsSync(`${lockfilePath}.lock`)).toBe(false);
+  });
+});
+
 describe("upsertRendererLockfileAssistant", () => {
   const paired = {
     assistantId: "paired-1",

--- a/packages/local-mode/src/lockfile.ts
+++ b/packages/local-mode/src/lockfile.ts
@@ -83,6 +83,50 @@ export function readRawLockfile(
   return { assistants: [], activeAssistant: null };
 }
 
+export type RawLockfileReadResult =
+  | { ok: true; lockfile: Record<string, unknown> }
+  | { ok: false; error: string };
+
+/**
+ * Like {@link readRawLockfile}, but a file that exists and cannot be read or
+ * parsed refuses instead of degrading to the empty registry. Missing or empty
+ * files still yield the empty registry. Use for writes that must never
+ * replace a registry they could not actually read.
+ */
+export function readRawLockfileStrict(
+  lockfilePaths: string[],
+): RawLockfileReadResult {
+  for (const candidate of lockfilePaths) {
+    let raw: string;
+    try {
+      raw = fs.readFileSync(candidate, "utf-8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") continue;
+      return { ok: false, error: `Failed to read lockfile: ${err}` };
+    }
+    if (raw.trim() === "") continue;
+    try {
+      return {
+        ok: true,
+        lockfile: JSON.parse(raw) as Record<string, unknown>,
+      };
+    } catch (err) {
+      return { ok: false, error: `Failed to parse lockfile: ${err}` };
+    }
+  }
+  return { ok: true, lockfile: { assistants: [], activeAssistant: null } };
+}
+
+/** The validated, sensitive-field-stripped wire view of a raw lockfile. */
+function toWireLockfile(lockfile: Record<string, unknown>): Lockfile {
+  const stripped = JSON.parse(JSON.stringify(lockfile)) as Record<
+    string,
+    unknown
+  >;
+  stripSensitiveFields(stripped);
+  return parseLockfile(stripped);
+}
+
 /**
  * Atomically persist a raw lockfile (write-to-temp + rename) and return the
  * validated, sensitive-field-stripped view of what was written.
@@ -102,12 +146,50 @@ export function writeRawLockfile(
     return { ok: false, status: 500, error: `Failed to write lockfile: ${err}` };
   }
 
-  const stripped = JSON.parse(JSON.stringify(lockfile)) as Record<
-    string,
-    unknown
-  >;
-  stripSensitiveFields(stripped);
-  return { ok: true, lockfile: parseLockfile(stripped) };
+  return { ok: true, lockfile: toWireLockfile(lockfile) };
+}
+
+/**
+ * Rename an existing assistant entry, never creating one. Unlike the upserts,
+ * a missing entry refuses (404) and an unreadable on-disk file refuses (409)
+ * instead of being treated as an empty registry, so a stale renderer cache
+ * can neither resurrect a retired assistant nor replace a registry it could
+ * not read with a skeleton row. Never touches `activeAssistant`.
+ */
+export function renameLockfileAssistantIfPresent(
+  lockfilePaths: string[],
+  assistantId: string,
+  name: string,
+): WriteResult {
+  if (typeof assistantId !== "string" || assistantId === "") {
+    return { ok: false, status: 400, error: "Missing assistantId" };
+  }
+  if (typeof name !== "string" || name === "") {
+    return { ok: false, status: 400, error: "Missing name" };
+  }
+
+  const read = readRawLockfileStrict(lockfilePaths);
+  if (!read.ok) {
+    return { ok: false, status: 409, error: read.error };
+  }
+  const lockfile = read.lockfile;
+  const assistants = Array.isArray(lockfile.assistants)
+    ? (lockfile.assistants as Array<Record<string, unknown>>)
+    : [];
+  const idx = assistants.findIndex((a) => a?.assistantId === assistantId);
+  if (idx < 0) {
+    return {
+      ok: false,
+      status: 404,
+      error: "No lockfile entry for this assistant",
+    };
+  }
+  if (assistants[idx]!.name === name) {
+    return { ok: true, lockfile: toWireLockfile(lockfile) };
+  }
+  assistants[idx] = { ...assistants[idx], name };
+  lockfile.assistants = assistants;
+  return writeRawLockfile(lockfilePaths, lockfile);
 }
 
 export function upsertLockfileAssistant(

--- a/packages/local-mode/src/lockfile.ts
+++ b/packages/local-mode/src/lockfile.ts
@@ -6,6 +6,7 @@ import {
   resolveCloud,
   type Lockfile,
 } from "./lockfile-contract";
+import { withLockfileLock } from "./lockfile-lock";
 import { stripSensitiveFields } from "./util";
 
 export type LockfileResult =
@@ -62,6 +63,11 @@ export function isPairedLockfileEntry(
 export type WriteResult =
   | { ok: true; lockfile: Lockfile }
   | { ok: false; status: number; error: string };
+
+/** 423 Locked: the cross-process advisory lock could not be acquired. */
+function lockFailure(error: string): WriteResult {
+  return { ok: false, status: 423, error };
+}
 
 /**
  * Read the first parseable lockfile as raw JSON (unknown fields intact) for a
@@ -154,7 +160,10 @@ export function writeRawLockfile(
  * a missing entry refuses (404) and an unreadable on-disk file refuses (409)
  * instead of being treated as an empty registry, so a stale renderer cache
  * can neither resurrect a retired assistant nor replace a registry it could
- * not read with a skeleton row. Never touches `activeAssistant`.
+ * not read with a skeleton row. Never touches `activeAssistant`. The whole
+ * read-check-write runs under the shared advisory lock so a concurrent writer
+ * (e.g. a CLI retire) cannot be clobbered by this snapshot; lock contention
+ * refuses (423) without writing.
  */
 export function renameLockfileAssistantIfPresent(
   lockfilePaths: string[],
@@ -168,28 +177,31 @@ export function renameLockfileAssistantIfPresent(
     return { ok: false, status: 400, error: "Missing name" };
   }
 
-  const read = readRawLockfileStrict(lockfilePaths);
-  if (!read.ok) {
-    return { ok: false, status: 409, error: read.error };
-  }
-  const lockfile = read.lockfile;
-  const assistants = Array.isArray(lockfile.assistants)
-    ? (lockfile.assistants as Array<Record<string, unknown>>)
-    : [];
-  const idx = assistants.findIndex((a) => a?.assistantId === assistantId);
-  if (idx < 0) {
-    return {
-      ok: false,
-      status: 404,
-      error: "No lockfile entry for this assistant",
-    };
-  }
-  if (assistants[idx]!.name === name) {
-    return { ok: true, lockfile: toWireLockfile(lockfile) };
-  }
-  assistants[idx] = { ...assistants[idx], name };
-  lockfile.assistants = assistants;
-  return writeRawLockfile(lockfilePaths, lockfile);
+  const locked = withLockfileLock(lockfilePaths, (): WriteResult => {
+    const read = readRawLockfileStrict(lockfilePaths);
+    if (!read.ok) {
+      return { ok: false, status: 409, error: read.error };
+    }
+    const lockfile = read.lockfile;
+    const assistants = Array.isArray(lockfile.assistants)
+      ? (lockfile.assistants as Array<Record<string, unknown>>)
+      : [];
+    const idx = assistants.findIndex((a) => a?.assistantId === assistantId);
+    if (idx < 0) {
+      return {
+        ok: false,
+        status: 404,
+        error: "No lockfile entry for this assistant",
+      };
+    }
+    if (assistants[idx]!.name === name) {
+      return { ok: true, lockfile: toWireLockfile(lockfile) };
+    }
+    assistants[idx] = { ...assistants[idx], name };
+    lockfile.assistants = assistants;
+    return writeRawLockfile(lockfilePaths, lockfile);
+  });
+  return locked.ok ? locked.value : lockFailure(locked.error);
 }
 
 export function upsertLockfileAssistant(
@@ -201,22 +213,25 @@ export function upsertLockfileAssistant(
     return { ok: false, status: 400, error: "Missing assistant.assistantId" };
   }
 
-  const lockfile = readRawLockfile(lockfilePaths);
-  const assistants = Array.isArray(lockfile.assistants) ? lockfile.assistants : [];
-  const existingIdx = assistants.findIndex(
-    (a: Record<string, unknown>) => a?.assistantId === assistant.assistantId,
-  );
-  if (existingIdx >= 0) {
-    assistants[existingIdx] = { ...assistants[existingIdx], ...assistant };
-  } else {
-    assistants.push(assistant);
-  }
-  lockfile.assistants = assistants;
-  if (activeAssistant !== undefined) {
-    lockfile.activeAssistant = activeAssistant;
-  }
+  const locked = withLockfileLock(lockfilePaths, (): WriteResult => {
+    const lockfile = readRawLockfile(lockfilePaths);
+    const assistants = Array.isArray(lockfile.assistants) ? lockfile.assistants : [];
+    const existingIdx = assistants.findIndex(
+      (a: Record<string, unknown>) => a?.assistantId === assistant.assistantId,
+    );
+    if (existingIdx >= 0) {
+      assistants[existingIdx] = { ...assistants[existingIdx], ...assistant };
+    } else {
+      assistants.push(assistant);
+    }
+    lockfile.assistants = assistants;
+    if (activeAssistant !== undefined) {
+      lockfile.activeAssistant = activeAssistant;
+    }
 
-  return writeRawLockfile(lockfilePaths, lockfile);
+    return writeRawLockfile(lockfilePaths, lockfile);
+  });
+  return locked.ok ? locked.value : lockFailure(locked.error);
 }
 
 const PAIRED_LOCKFILE_WRITE_ERROR =
@@ -236,33 +251,38 @@ export function upsertRendererLockfileAssistant(
     return { ok: false, status: 400, error: "Missing assistant.assistantId" };
   }
 
-  const lockfile = readRawLockfile(lockfilePaths);
-  const assistants = Array.isArray(lockfile.assistants)
-    ? (lockfile.assistants as Array<Record<string, unknown>>)
-    : [];
-  const existing = assistants.find(
-    (entry) => entry?.assistantId === assistant.assistantId,
-  );
-  const merged = { ...existing, ...assistant };
-  const existingIsPaired =
-    existing != null &&
-    (resolveCloud(existing) === "paired" || existing.paired === true);
-  const mergedIsPaired =
-    resolveCloud(merged) === "paired" || merged.paired === true;
+  // Lock spans the paired-guard read and the upsert (which reenters) so the
+  // guard cannot be judged against a snapshot another writer replaces.
+  const locked = withLockfileLock(lockfilePaths, (): WriteResult => {
+    const lockfile = readRawLockfile(lockfilePaths);
+    const assistants = Array.isArray(lockfile.assistants)
+      ? (lockfile.assistants as Array<Record<string, unknown>>)
+      : [];
+    const existing = assistants.find(
+      (entry) => entry?.assistantId === assistant.assistantId,
+    );
+    const merged = { ...existing, ...assistant };
+    const existingIsPaired =
+      existing != null &&
+      (resolveCloud(existing) === "paired" || existing.paired === true);
+    const mergedIsPaired =
+      resolveCloud(merged) === "paired" || merged.paired === true;
 
-  if (!existingIsPaired && mergedIsPaired) {
-    return { ok: false, status: 403, error: PAIRED_LOCKFILE_WRITE_ERROR };
-  }
-  if (
-    existingIsPaired &&
-    (resolveCloud(merged) !== "paired" ||
-      merged.runtimeUrl !== existing.runtimeUrl ||
-      merged.paired !== existing.paired)
-  ) {
-    return { ok: false, status: 403, error: PAIRED_LOCKFILE_WRITE_ERROR };
-  }
+    if (!existingIsPaired && mergedIsPaired) {
+      return { ok: false, status: 403, error: PAIRED_LOCKFILE_WRITE_ERROR };
+    }
+    if (
+      existingIsPaired &&
+      (resolveCloud(merged) !== "paired" ||
+        merged.runtimeUrl !== existing.runtimeUrl ||
+        merged.paired !== existing.paired)
+    ) {
+      return { ok: false, status: 403, error: PAIRED_LOCKFILE_WRITE_ERROR };
+    }
 
-  return upsertLockfileAssistant(lockfilePaths, assistant, activeAssistant);
+    return upsertLockfileAssistant(lockfilePaths, assistant, activeAssistant);
+  });
+  return locked.ok ? locked.value : lockFailure(locked.error);
 }
 
 export function isActiveAssistant(
@@ -308,24 +328,27 @@ export function replacePlatformAssistants(
     };
   }
 
-  const lockfile = readRawLockfile(lockfilePaths);
-  const existing = Array.isArray(lockfile.assistants) ? lockfile.assistants : [];
-  const syncedIds = new Set(platformAssistants.map((a) => a.assistantId));
-  // Org-scoped sync preserves other orgs' platform entries; no org full-replaces.
-  const preserved = existing.filter((a: Record<string, unknown>) => {
-    if (a?.cloud !== "vellum") return true;
-    if (syncedIds.has(a.assistantId)) return false;
-    return organizationId != null && a.organizationId !== organizationId;
+  const locked = withLockfileLock(lockfilePaths, (): WriteResult => {
+    const lockfile = readRawLockfile(lockfilePaths);
+    const existing = Array.isArray(lockfile.assistants) ? lockfile.assistants : [];
+    const syncedIds = new Set(platformAssistants.map((a) => a.assistantId));
+    // Org-scoped sync preserves other orgs' platform entries; no org full-replaces.
+    const preserved = existing.filter((a: Record<string, unknown>) => {
+      if (a?.cloud !== "vellum") return true;
+      if (syncedIds.has(a.assistantId)) return false;
+      return organizationId != null && a.organizationId !== organizationId;
+    });
+    lockfile.assistants = [...preserved, ...platformAssistants];
+
+    const active = lockfile.activeAssistant as string | null;
+    if (active) {
+      const stillExists = (lockfile.assistants as Array<Record<string, unknown>>).some(
+        (a) => a.assistantId === active,
+      );
+      if (!stillExists) lockfile.activeAssistant = null;
+    }
+
+    return writeRawLockfile(lockfilePaths, lockfile);
   });
-  lockfile.assistants = [...preserved, ...platformAssistants];
-
-  const active = lockfile.activeAssistant as string | null;
-  if (active) {
-    const stillExists = (lockfile.assistants as Array<Record<string, unknown>>).some(
-      (a) => a.assistantId === active,
-    );
-    if (!stillExists) lockfile.activeAssistant = null;
-  }
-
-  return writeRawLockfile(lockfilePaths, lockfile);
+  return locked.ok ? locked.value : lockFailure(locked.error);
 }

--- a/packages/local-mode/src/unpair.ts
+++ b/packages/local-mode/src/unpair.ts
@@ -8,6 +8,7 @@ import {
   type WriteResult,
 } from "./lockfile";
 import { resolveCloud } from "./lockfile-contract";
+import { withLockfileLock } from "./lockfile-lock";
 
 /**
  * Forget a paired assistant on this machine: remove its lockfile entry and
@@ -18,6 +19,23 @@ import { resolveCloud } from "./lockfile-contract";
  * way; local and managed assistants go through retire.
  */
 export function unpairAssistant(
+  lockfilePaths: string[],
+  configDir: string,
+  assistantId: string,
+): WriteResult {
+  // The whole transaction holds the shared write lock so a concurrent
+  // read-modify-write (e.g. a persona-name rename) cannot restore the entry
+  // after its credential is deleted.
+  const locked = withLockfileLock(lockfilePaths, (): WriteResult =>
+    unpairAssistantLocked(lockfilePaths, configDir, assistantId),
+  );
+  if (!locked.ok) {
+    return { ok: false, status: 423, error: locked.error };
+  }
+  return locked.value;
+}
+
+function unpairAssistantLocked(
   lockfilePaths: string[],
   configDir: string,
   assistantId: string,


### PR DESCRIPTION
## Summary
Makes chooser rows follow the cloud naming pattern (persona name like "Credence") instead of raw instance ids: the assistant's IDENTITY.md name now syncs into the lockfile (chooser + tray + CLI pick it up), the remote `?register` handoff carries the live persona name so the hub's remembered-origin label converges, and unnamed local rows fall back to their friendly instance id instead of an indistinguishable generic label. Companion platform-repo plan (drop the server-minted "Local: " prefix) ships separately.

## Self-review result
GAPS FOUND — 3 gaps fixed across 2 fix PRs (round 2 re-review: PASS on all four passes)

## PRs merged into feature branch
- #40783: feat(web): add renameLockfileAssistant helper for persona-name lockfile writes
- #40782: feat(web): chooser shows instance id for unnamed local assistants
- #40784: feat(web): remote assistant handoff carries the live persona name
- #40799: feat(web): sync persona name into the lockfile on identity changes

### Fix PRs
- #40804: fix: chooser id fallback excludes API-sourced hub local registrations
- #40806: fix: lockfile name selector presence semantics + remote-gateway entry name

Part of plan: unify-assistant-naming.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)