### PR TITLE
fix: harden vellum devices revoke --json contract

### DIFF
--- a/cli/src/__tests__/devices.test.ts
+++ b/cli/src/__tests__/devices.test.ts
@@ -287,7 +287,7 @@ describe("vellum devices", () => {
     expect(logs).not.toContain("Devices paired to");
   });
 
-  test("list --json with zero devices emits {\"devices\":[]}", async () => {
+  test('list --json with zero devices emits {"devices":[]}', async () => {
     seedLocal("json-empty-host");
     stubFetch(() => jsonResponse({ devices: [] }));
 
@@ -298,7 +298,7 @@ describe("vellum devices", () => {
     expect(logs).toBe('{"devices":[]}');
   });
 
-  test("revoke --json --yes emits { ok, hashedDeviceId } and no preamble", async () => {
+  test("revoke --json --yes emits one JSON line; identity preamble on stderr", async () => {
     seedLocal("json-revoke-host", "http://127.0.0.1:7836");
     stubFetch((url) =>
       url.endsWith("/v1/devices/revoke")
@@ -316,12 +316,40 @@ describe("vellum devices", () => {
       "--yes",
       "--json",
     ];
-    const { exited, logs } = await runDevices();
+    const { exited, logs, errors } = await runDevices();
 
     expect(exited).toBe(false);
+    // Stdout is exactly one JSON document, no prose.
     expect(logs).not.toContain("\n");
-    expect(JSON.parse(logs)).toEqual({ ok: true, hashedDeviceId: "hashAAA111" });
+    expect(JSON.parse(logs)).toEqual({
+      ok: true,
+      hashedDeviceId: "hashAAA111",
+      assistantId: "json-revoke-host",
+    });
     expect(logs).not.toContain("Device to revoke");
+    // Destructive-identity preamble still printed, on stderr (cli/AGENTS.md).
+    expect(errors).toContain("Device to revoke:");
+    expect(errors).toContain("hashAAA111");
+  });
+
+  test("revoke --json without --yes exits 1 with empty stdout", async () => {
+    seedLocal("json-noyes-host");
+
+    process.argv = [
+      "bun",
+      "vellum",
+      "devices",
+      "revoke",
+      "hashAAA111",
+      "json-noyes-host",
+      "--json",
+    ];
+    const { exited, logs, errors } = await runDevices();
+
+    expect(exited).toBe(true);
+    expect(logs).toBe("");
+    expect(errors).toContain("--json requires --yes");
+    expect(fetchCalls).toHaveLength(0);
   });
 
   test("list --json still exits 1 with stderr on a non-2xx gateway response", async () => {

--- a/cli/src/commands/devices.ts
+++ b/cli/src/commands/devices.ts
@@ -45,7 +45,7 @@ ARGUMENTS:
 
 OPTIONS:
     --yes              Skip the interactive confirmation prompt when revoking (for automation)
-    --json             Print machine-readable JSON on stdout
+    --json             Print machine-readable JSON on stdout (revoke requires --yes)
 
 Lists the devices paired to a local (host-side) assistant, or revokes one by its
 hashed id. Runs on the machine that hosts the assistant — paired connections
@@ -167,13 +167,20 @@ async function revokeDevice(
 ): Promise<void> {
   const displayName = getAssistantDisplayName(entry);
 
-  if (!jsonOutput) {
-    // Print the resolved identity before acting (cli/AGENTS.md).
-    console.log("Device to revoke:");
-    console.log(`  Assistant: ${formatAssistantReference(entry)}`);
-    console.log(`  Device:    ${hashedDeviceId}`);
-    console.log("");
+  if (jsonOutput && !yes) {
+    console.error(
+      "Error: --json requires --yes; the revoke confirmation prompt would corrupt JSON stdout.",
+    );
+    process.exit(1);
   }
+
+  // Print the resolved identity before acting (cli/AGENTS.md). In --json mode
+  // it goes to stderr so stdout stays a single JSON document.
+  const printIdentity = jsonOutput ? console.error : console.log;
+  printIdentity("Device to revoke:");
+  printIdentity(`  Assistant: ${formatAssistantReference(entry)}`);
+  printIdentity(`  Device:    ${hashedDeviceId}`);
+  printIdentity("");
 
   if (!yes) {
     if (!canPromptForConfirmation()) {
@@ -219,7 +226,13 @@ async function revokeDevice(
   }
 
   if (jsonOutput) {
-    console.log(JSON.stringify({ ok: true, hashedDeviceId }));
+    console.log(
+      JSON.stringify({
+        ok: true,
+        hashedDeviceId,
+        assistantId: entry.assistantId,
+      }),
+    );
     return;
   }
 


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for paired-devices-revoke.md.

**Gap:** --json revoke stdout purity + destructive-identity invariant
**What was expected:** --json stdout is exactly one JSON document; destructive commands print resolved identity before acting
**What was found:** interactive confirm prompt could pollute JSON stdout; identity preamble skipped in JSON mode