### PR TITLE
fix: consolidate duplicated devices middlewares in vite-plugin-local-mode

### DIFF
--- a/clients/web/vite-plugin-local-mode.test.ts
+++ b/clients/web/vite-plugin-local-mode.test.ts
@@ -260,7 +260,7 @@ describe("paired gateway proxy", () => {
   });
 });
 
-describe("devices middlewares", () => {
+describe("devices middleware", () => {
   beforeEach(() => {
     devicesListResult = { ok: true, devices: [] };
     devicesRevokeResult = { ok: true };

--- a/clients/web/vite-plugin-local-mode.ts
+++ b/clients/web/vite-plugin-local-mode.ts
@@ -104,8 +104,7 @@ export function localModePlugin(env: Record<string, string>): Plugin {
       );
       server.middlewares.use(sleepMiddleware(baseDir));
       server.middlewares.use(wakeMiddleware(baseDir));
-      server.middlewares.use(devicesListMiddleware(baseDir));
-      server.middlewares.use(devicesRevokeMiddleware(baseDir));
+      server.middlewares.use(devicesMiddleware(baseDir));
       const upgradingLocalAssistantIds = new Set<string>();
       server.middlewares.use(
         upgradeMiddleware(
@@ -715,9 +714,13 @@ function wakeMiddleware(baseDir: string): Connect.NextHandleFunction {
 // Paired-device management via the CLI (`vellum devices … --json`). POST-only
 // (the renderer's postLocalCommand always POSTs); run-helper results respond
 // 200 with `ok` discriminating success so all hosts share one wire shape.
-function devicesListMiddleware(baseDir: string): Connect.NextHandleFunction {
+function devicesMiddleware(baseDir: string): Connect.NextHandleFunction {
   return (req, res, next) => {
+    const isRevoke =
+      req.url === "/assistant/__local/devices-revoke" ||
+      req.url === "/__local/devices-revoke";
     if (
+      !isRevoke &&
       req.url !== "/assistant/__local/devices" &&
       req.url !== "/__local/devices"
     ) {
@@ -746,6 +749,16 @@ function devicesListMiddleware(baseDir: string): Connect.NextHandleFunction {
         return;
       }
 
+      let revokeHash: string | null = null;
+      if (isRevoke) {
+        const hashedDeviceId = body.hashedDeviceId;
+        if (typeof hashedDeviceId !== "string" || !hashedDeviceId) {
+          respondJson(res, 400, { ok: false, error: "Missing hashedDeviceId" });
+          return;
+        }
+        revokeHash = hashedDeviceId;
+      }
+
       let invocation: CliInvocation;
       try {
         invocation = resolveDevCliInvocation(baseDir, import.meta.url);
@@ -757,6 +770,18 @@ function devicesListMiddleware(baseDir: string): Connect.NextHandleFunction {
         return;
       }
 
+      if (revokeHash !== null) {
+        void runDevicesRevoke(invocation, assistantId, revokeHash).then(
+          (result) => {
+            respondJson(
+              res,
+              200,
+              result.ok ? { ok: true } : { ok: false, error: result.error },
+            );
+          },
+        );
+        return;
+      }
       void runDevicesList(invocation, assistantId).then((result) => {
         respondJson(
           res,
@@ -766,67 +791,6 @@ function devicesListMiddleware(baseDir: string): Connect.NextHandleFunction {
             : { ok: false, error: result.error },
         );
       });
-    });
-  };
-}
-
-function devicesRevokeMiddleware(baseDir: string): Connect.NextHandleFunction {
-  return (req, res, next) => {
-    if (
-      req.url !== "/assistant/__local/devices-revoke" &&
-      req.url !== "/__local/devices-revoke"
-    ) {
-      return next();
-    }
-
-    if (rejectUnlessLocalEndpointRequest(req, res)) {
-      return;
-    }
-
-    if (req.method !== "POST") {
-      res.statusCode = 405;
-      res.end();
-      return;
-    }
-
-    void readJsonBody(req).then((body) => {
-      if (!body) {
-        respondJson(res, 400, { ok: false, error: "Invalid JSON body" });
-        return;
-      }
-
-      const assistantId = body.assistantId;
-      if (typeof assistantId !== "string" || !assistantId) {
-        respondJson(res, 400, { ok: false, error: "Missing assistantId" });
-        return;
-      }
-
-      const hashedDeviceId = body.hashedDeviceId;
-      if (typeof hashedDeviceId !== "string" || !hashedDeviceId) {
-        respondJson(res, 400, { ok: false, error: "Missing hashedDeviceId" });
-        return;
-      }
-
-      let invocation: CliInvocation;
-      try {
-        invocation = resolveDevCliInvocation(baseDir, import.meta.url);
-      } catch (err) {
-        respondJson(res, 500, {
-          ok: false,
-          error: err instanceof Error ? err.message : String(err),
-        });
-        return;
-      }
-
-      void runDevicesRevoke(invocation, assistantId, hashedDeviceId).then(
-        (result) => {
-          respondJson(
-            res,
-            200,
-            result.ok ? { ok: true } : { ok: false, error: result.error },
-          );
-        },
-      );
     });
   };
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for paired-devices-revoke.md.

**Gap:** devicesListMiddleware/devicesRevokeMiddleware are ~60-line copies
**What was expected:** one handler for the devices route family, matching the vellum client host's combined shape
**What was found:** duplicated guards/validation/invocation across two middlewares