### PR TITLE
fix: paired-devices hook — stale-while-revalidate refresh, fresh assistant id, trim dead API

### DIFF
--- a/clients/web/src/domains/settings/pair-device/pair-device-card.tsx
+++ b/clients/web/src/domains/settings/pair-device/pair-device-card.tsx
@@ -114,7 +114,7 @@ export function PairDeviceCard() {
           />
         )}
 
-        <PairedDevicesSection enabled />
+        <PairedDevicesSection />
       </div>
     </DetailCard>
   );

--- a/clients/web/src/domains/settings/pair-device/paired-devices-section.test.tsx
+++ b/clients/web/src/domains/settings/pair-device/paired-devices-section.test.tsx
@@ -18,6 +18,7 @@ let listImpl: (assistantId: string) => Promise<LocalListDevicesResult>;
 let listCalls: string[] = [];
 let revokeResult: LocalRevokeDeviceResult = { ok: true };
 let revokeCalls: Array<{ assistantId: string; hashedDeviceId: string }> = [];
+let selectedAssistantId = "self";
 
 mock.module(
   "@/runtime/local-mode-host",
@@ -39,7 +40,10 @@ mock.module(
 mock.module(
   "@/lib/local-mode",
   (): Partial<typeof import("@/lib/local-mode")> => ({
-    getSelectedAssistant: () => ({ assistantId: "self", cloud: "local" }),
+    getSelectedAssistant: () => ({
+      assistantId: selectedAssistantId,
+      cloud: "local",
+    }),
     // Sibling test files in this suite mock the same module and share a
     // process; keep the export their modules import so relinking succeeds.
     getLocalGatewayUrl: () => undefined,
@@ -76,11 +80,17 @@ function queueListResults(...results: LocalListDevicesResult[]) {
 
 async function renderExpanded(devices: LocalPairedDeviceRecord[]) {
   queueListResults({ ok: true, devices }, { ok: true, devices });
-  render(<PairedDevicesSection enabled />);
+  render(<PairedDevicesSection />);
   const trigger = await screen.findByRole("button", {
     name: `Paired devices (${devices.length})`,
   });
   fireEvent.click(trigger);
+}
+
+function clickConfirm() {
+  fireEvent.click(
+    document.querySelector<HTMLButtonElement>("[data-confirm-dialog-confirm]")!,
+  );
 }
 
 beforeEach(() => {
@@ -88,6 +98,7 @@ beforeEach(() => {
   listCalls = [];
   revokeResult = { ok: true };
   revokeCalls = [];
+  selectedAssistantId = "self";
 });
 
 afterEach(() => {
@@ -97,20 +108,20 @@ afterEach(() => {
 describe("PairedDevicesSection", () => {
   test("renders nothing while the list is loading", () => {
     listImpl = () => new Promise(() => {});
-    const { container } = render(<PairedDevicesSection enabled />);
+    const { container } = render(<PairedDevicesSection />);
     expect(container.firstChild).toBeNull();
   });
 
   test("renders nothing when the host refuses the list", async () => {
     queueListResults({ ok: false, error: "unavailable" });
-    const { container } = render(<PairedDevicesSection enabled />);
+    const { container } = render(<PairedDevicesSection />);
     await waitFor(() => expect(listCalls.length).toBe(1));
     expect(container.firstChild).toBeNull();
   });
 
   test("renders nothing when no devices are paired", async () => {
     queueListResults({ ok: true, devices: [] });
-    const { container } = render(<PairedDevicesSection enabled />);
+    const { container } = render(<PairedDevicesSection />);
     await waitFor(() => expect(listCalls.length).toBe(1));
     expect(container.firstChild).toBeNull();
   });
@@ -145,11 +156,7 @@ describe("PairedDevicesSection", () => {
     await renderExpanded([device()]);
 
     fireEvent.click(screen.getByRole("button", { name: "Revoke" }));
-    fireEvent.click(
-      document.querySelector<HTMLButtonElement>(
-        "[data-confirm-dialog-confirm]",
-      )!,
-    );
+    clickConfirm();
 
     await waitFor(() => expect(listCalls.length).toBe(2));
     expect(revokeCalls).toEqual([
@@ -160,16 +167,60 @@ describe("PairedDevicesSection", () => {
     );
   });
 
+  test("keeps the previous list rendered while the post-revoke refetch is in flight", async () => {
+    await renderExpanded([
+      device(),
+      device({ hashedDeviceId: HASH_B, platform: "android" }),
+    ]);
+
+    let resolveRefetch!: (result: LocalListDevicesResult) => void;
+    listImpl = () =>
+      new Promise<LocalListDevicesResult>((resolve) => {
+        resolveRefetch = resolve;
+      });
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Revoke" })[0]!);
+    clickConfirm();
+    await waitFor(() => expect(listCalls.length).toBe(2));
+
+    // Refetch in flight: the section (and its expanded rows) stays mounted.
+    expect(screen.getByText("Ios")).toBeTruthy();
+    expect(screen.getByText("Android")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Paired devices (2)" }),
+    ).toBeTruthy();
+
+    resolveRefetch({
+      ok: true,
+      devices: [device({ hashedDeviceId: HASH_B, platform: "android" })],
+    });
+    await waitFor(() => expect(screen.queryByText("Ios")).toBeNull());
+    expect(
+      screen.getByRole("button", { name: "Paired devices (1)" }),
+    ).toBeTruthy();
+  });
+
+  test("revokes against the currently selected assistant id read at call time", async () => {
+    await renderExpanded([device()]);
+
+    selectedAssistantId = "other";
+    fireEvent.click(screen.getByRole("button", { name: "Revoke" }));
+    clickConfirm();
+
+    await waitFor(() =>
+      expect(revokeCalls).toEqual([
+        { assistantId: "other", hashedDeviceId: HASH_A },
+      ]),
+    );
+    await waitFor(() => expect(listCalls).toEqual(["self", "other"]));
+  });
+
   test("a failed revoke keeps the dialog open with the error", async () => {
     revokeResult = { ok: false, error: "Gateway is unreachable" };
     await renderExpanded([device()]);
 
     fireEvent.click(screen.getByRole("button", { name: "Revoke" }));
-    fireEvent.click(
-      document.querySelector<HTMLButtonElement>(
-        "[data-confirm-dialog-confirm]",
-      )!,
-    );
+    clickConfirm();
 
     await waitFor(() =>
       expect(screen.getByText("Gateway is unreachable")).toBeTruthy(),

--- a/clients/web/src/domains/settings/pair-device/paired-devices-section.tsx
+++ b/clients/web/src/domains/settings/pair-device/paired-devices-section.tsx
@@ -20,22 +20,17 @@ function formatDeviceDate(epochMs: number | null): string {
   return epochMs === null ? "unknown" : new Date(epochMs).toLocaleDateString();
 }
 
-export interface PairedDevicesSectionProps {
-  /** Mirrors the card's visibility gates so the hook only fetches when the card shows. */
-  enabled: boolean;
-}
-
 /**
  * Accordion listing the devices paired to the local assistant, with a
  * destructive per-device Revoke behind a confirm dialog. Renders nothing
  * unless the host reports one or more devices, so older app shells, host
  * failures, and empty lists leave the Pair a device card exactly as it is.
  */
-export function PairedDevicesSection({ enabled }: PairedDevicesSectionProps) {
-  const controller = usePairedDevices(enabled);
-  const { phase, confirmTarget } = controller;
+export function PairedDevicesSection() {
+  const controller = usePairedDevices();
+  const { devices, confirmTarget } = controller;
 
-  if (phase.kind !== "ready" || phase.devices.length === 0) {
+  if (devices === null || devices.length === 0) {
     return null;
   }
 
@@ -45,13 +40,13 @@ export function PairedDevicesSection({ enabled }: PairedDevicesSectionProps) {
         <Collapsible.Item value="paired-devices">
           <Collapsible.Trigger className="group flex w-full items-center justify-between gap-3">
             <span className="text-body-medium-default text-[var(--content-secondary)]">
-              {`Paired devices (${phase.devices.length})`}
+              {`Paired devices (${devices.length})`}
             </span>
             <ChevronDown className="h-4 w-4 shrink-0 text-[var(--content-tertiary)] transition-transform group-data-[state=open]:rotate-180" />
           </Collapsible.Trigger>
           <Collapsible.Content>
             <div className="mt-3 flex flex-col gap-3">
-              {phase.devices.map((device) => (
+              {devices.map((device) => (
                 <div
                   key={device.hashedDeviceId}
                   className="flex items-center justify-between gap-3"

--- a/clients/web/src/domains/settings/pair-device/use-paired-devices.ts
+++ b/clients/web/src/domains/settings/pair-device/use-paired-devices.ts
@@ -7,14 +7,17 @@ import {
   type LocalPairedDeviceRecord,
 } from "@/runtime/local-mode-host";
 
-export type PairedDevicesPhase =
-  | { kind: "idle" }
-  | { kind: "loading" }
-  | { kind: "ready"; devices: LocalPairedDeviceRecord[] }
-  | { kind: "unavailable" };
+function selectedAssistantId(): string | undefined {
+  return getSelectedAssistant()?.assistantId;
+}
 
 export interface PairedDevicesController {
-  phase: PairedDevicesPhase;
+  /**
+   * Paired devices for the selected assistant, or `null` when the list is
+   * not loaded or unavailable. A refresh keeps the previous list rendered
+   * until the new result lands.
+   */
+  devices: LocalPairedDeviceRecord[] | null;
   /** Device awaiting revoke confirmation, or `null` when no dialog is open. */
   confirmTarget: LocalPairedDeviceRecord | null;
   /** Whether a revoke request is in flight. */
@@ -27,22 +30,21 @@ export interface PairedDevicesController {
   cancelRevoke: () => void;
   /** Revoke {@link confirmTarget}'s tokens; refreshes the list on success. */
   confirmRevoke: () => void;
-  /** Re-fetch the device list from the host. */
-  refresh: () => void;
 }
 
 /**
  * Drives the "Paired devices" accordion: fetches the selected assistant's
  * paired devices through the host seam and runs the confirm-then-revoke flow.
  * Any `{ ok: false }` list result (older app shells, unavailable hosts,
- * transport failures) collapses to the `unavailable` phase so the section
- * degrades silently instead of showing a broken state.
+ * transport failures) collapses `devices` to `null` so the section degrades
+ * silently instead of showing a broken state. The assistant id is read at
+ * call time so every fetch and revoke targets the currently selected
+ * assistant.
  */
-export function usePairedDevices(enabled: boolean): PairedDevicesController {
-  const [assistantId] = useState(
-    () => getSelectedAssistant()?.assistantId ?? null,
+export function usePairedDevices(): PairedDevicesController {
+  const [devices, setDevices] = useState<LocalPairedDeviceRecord[] | null>(
+    null,
   );
-  const [phase, setPhase] = useState<PairedDevicesPhase>({ kind: "idle" });
   const [confirmTarget, setConfirmTarget] =
     useState<LocalPairedDeviceRecord | null>(null);
   const [isRevoking, setIsRevoking] = useState(false);
@@ -61,22 +63,18 @@ export function usePairedDevices(enabled: boolean): PairedDevicesController {
   }, []);
 
   const refresh = useCallback(() => {
-    if (!enabled || !assistantId) {
+    const assistantId = selectedAssistantId();
+    if (!assistantId) {
       return;
     }
     const seq = ++fetchSeqRef.current;
-    setPhase({ kind: "loading" });
     void listPairedDevicesHost(assistantId).then((result) => {
       if (!mountedRef.current || seq !== fetchSeqRef.current) {
         return;
       }
-      setPhase(
-        result.ok
-          ? { kind: "ready", devices: result.devices }
-          : { kind: "unavailable" },
-      );
+      setDevices(result.ok ? result.devices : null);
     });
-  }, [enabled, assistantId]);
+  }, []);
 
   useEffect(() => {
     refresh();
@@ -93,6 +91,7 @@ export function usePairedDevices(enabled: boolean): PairedDevicesController {
   }, []);
 
   const confirmRevoke = useCallback(() => {
+    const assistantId = selectedAssistantId();
     if (!assistantId || !confirmTarget || isRevoking) {
       return;
     }
@@ -112,16 +111,15 @@ export function usePairedDevices(enabled: boolean): PairedDevicesController {
         }
       },
     );
-  }, [assistantId, confirmTarget, isRevoking, refresh]);
+  }, [confirmTarget, isRevoking, refresh]);
 
   return {
-    phase,
+    devices,
     confirmTarget,
     isRevoking,
     revokeError,
     requestRevoke,
     cancelRevoke,
     confirmRevoke,
-    refresh,
   };
 }


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for paired-devices-revoke.md.

**Gap:** accordion collapses after every revoke; assistant id frozen at mount; dead enabled prop / public refresh
**What was expected:** revoke refreshes the list in place; destructive ops target the currently selected assistant
**What was found:** refresh() re-entered loading (section unmounts, Collapsible resets); useState snapshot of assistantId; unused API surface