### PR TITLE
fix: drop dead status field from devices run-helper results

### DIFF
--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -751,21 +751,11 @@ async function handleLocalEndpoints(
     }
 
     if (revokeHash !== null) {
-      const result = await runDevicesRevoke(
-        invocation,
-        assistantId,
-        revokeHash,
-      );
       return Response.json(
-        result.ok ? { ok: true } : { ok: false, error: result.error },
+        await runDevicesRevoke(invocation, assistantId, revokeHash),
       );
     }
-    const result = await runDevicesList(invocation, assistantId);
-    return Response.json(
-      result.ok
-        ? { ok: true, devices: result.devices }
-        : { ok: false, error: result.error },
-    );
+    return Response.json(await runDevicesList(invocation, assistantId));
   }
 
   // Connect-import: register a pairing bundle from another machine (guardian

--- a/clients/web/vite-plugin-local-mode.test.ts
+++ b/clients/web/vite-plugin-local-mode.test.ts
@@ -337,7 +337,7 @@ describe("devices middlewares", () => {
     });
 
     test("run-helper failure yields ok:false with no status field", async () => {
-      devicesListResult = { ok: false, status: 500, error: "gateway offline" };
+      devicesListResult = { ok: false, error: "gateway offline" };
 
       const result = await dispatch(
         "/__local/devices",
@@ -433,7 +433,7 @@ describe("devices middlewares", () => {
     });
 
     test("run-helper failure yields ok:false with no status field", async () => {
-      devicesRevokeResult = { ok: false, status: 500, error: "revoke failed" };
+      devicesRevokeResult = { ok: false, error: "revoke failed" };
 
       const result = await dispatch(
         "/__local/devices-revoke",

--- a/packages/electron-desktop/src/local-mode.ts
+++ b/packages/electron-desktop/src/local-mode.ts
@@ -195,10 +195,7 @@ async function listDevices(
   } catch (err) {
     return { ok: false, error: (err as Error).message };
   }
-  const result = await runDevicesList(invocation, assistantId);
-  return result.ok
-    ? { ok: true, devices: result.devices }
-    : { ok: false, error: result.error };
+  return runDevicesList(invocation, assistantId);
 }
 
 /** Revoke one paired device's tokens. Mirrors `hatch`'s never-reject contract. */
@@ -212,12 +209,7 @@ async function revokeDevice(
   } catch (err) {
     return { ok: false, error: (err as Error).message };
   }
-  const result = await runDevicesRevoke(
-    invocation,
-    assistantId,
-    hashedDeviceId,
-  );
-  return result.ok ? { ok: true } : { ok: false, error: result.error };
+  return runDevicesRevoke(invocation, assistantId, hashedDeviceId);
 }
 
 /**

--- a/packages/local-mode/src/devices.test.ts
+++ b/packages/local-mode/src/devices.test.ts
@@ -123,7 +123,6 @@ describe("runDevicesList", () => {
 
     expect(await pending).toEqual({
       ok: false,
-      status: 500,
       error: "CLI returned unparseable devices output: not json",
     });
   });
@@ -150,7 +149,6 @@ describe("runDevicesList", () => {
 
     expect(await pending).toEqual({
       ok: false,
-      status: 500,
       error: "devices failed",
     });
   });
@@ -161,7 +159,6 @@ describe("runDevicesList", () => {
 
     expect(await pending).toEqual({
       ok: false,
-      status: 500,
       error: "Failed to spawn CLI: ENOENT",
     });
   });
@@ -191,7 +188,6 @@ describe("runDevicesRevoke", () => {
 
     expect(await pending).toEqual({
       ok: false,
-      status: 500,
       error: "revoke failed",
     });
   });
@@ -202,7 +198,6 @@ describe("runDevicesRevoke", () => {
 
     expect(await pending).toEqual({
       ok: false,
-      status: 500,
       error: "Failed to spawn CLI: EACCES",
     });
   });

--- a/packages/local-mode/src/devices.ts
+++ b/packages/local-mode/src/devices.ts
@@ -20,14 +20,14 @@ export interface DeviceRecord {
 
 export type DevicesListResult =
   | { ok: true; devices: DeviceRecord[] }
-  | { ok: false; status: number; error: string };
+  | { ok: false; error: string };
 
 export type DevicesRevokeResult =
-  { ok: true } | { ok: false; status: number; error: string };
+  { ok: true } | { ok: false; error: string };
 
 type CliRunResult =
   | { ok: true; stdout: string }
-  | { ok: false; status: number; error: string };
+  | { ok: false; error: string };
 
 function runDevicesCli(
   invocation: CliInvocation,
@@ -55,8 +55,7 @@ function runDevicesCli(
       child.kill("SIGTERM");
       finish({
         ok: false,
-        status: 500,
-        error: "Devices command timed out after 30 seconds",
+        error: `Devices command timed out after ${DEVICES_TIMEOUT_MS / 1000} seconds`,
       });
     }, DEVICES_TIMEOUT_MS);
 
@@ -72,14 +71,13 @@ function runDevicesCli(
       if (code === 0) {
         finish({ ok: true, stdout });
       } else {
-        finish({ ok: false, status: 500, error: stderr || stdout });
+        finish({ ok: false, error: stderr || stdout });
       }
     });
 
     child.on("error", (err) => {
       finish({
         ok: false,
-        status: 500,
         error: `Failed to spawn CLI: ${err.message}`,
       });
     });
@@ -143,7 +141,6 @@ export async function runDevicesList(
     const snippet = result.stdout.trim().slice(0, 200);
     return {
       ok: false,
-      status: 500,
       error: `CLI returned unparseable devices output: ${snippet}`,
     };
   }


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for paired-devices-revoke.md.

**Gap:** dead status field on DevicesListResult/DevicesRevokeResult; hardcoded timeout message
**What was expected:** result types carry only fields consumers read; timeout copy derives from DEVICES_TIMEOUT_MS
**What was found:** status: 500 stamped on every failure and discarded by all three hosts; '30 seconds' hardcoded