### PR TITLE
refactor(web): re-key the conversation list caches onto the generated conversationsGet key (LUM-2447)

### DIFF
--- a/clients/web/docs/CONVENTIONS.md
+++ b/clients/web/docs/CONVENTIONS.md
@@ -276,6 +276,8 @@ src/
   utils/                           # cross-domain shared utilities
     conversation-cache.ts          #   low-level read/write over conversation caches
     conversation-cache-mutations.ts #  domain-level cache mutation helpers
+    conversation-list-keys.ts      #   generated conversationsGet keys + filter for every list cache
+    conversation-list-options.ts   #   the one queryOptions factory behind every list cache
     conversation-list-fetchers.ts  #   pure async fetch functions for conversation lists
     conversation-transforms.ts     #   daemon → client field mapping
     format-date.ts

--- a/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -81,9 +81,9 @@ mock.module(
     useSidebarSectionsQuery: () => null,
     useSectionConversationListQuery: (
       _assistantId: string | null,
-      filter: ConversationListFilter,
+      filter: ConversationListFilter | null,
     ): ConversationQueries.ConversationListQueryResult => ({
-      conversations: rowsMatching(filter),
+      conversations: filter === null ? [] : rowsMatching(filter),
       isLoading: false,
       isPending: false,
       isError: false,

--- a/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -48,10 +48,7 @@ function setSectionRows(conversations: Conversation[]) {
  * for "no group claimed it" AND its own `origin_channel`. Honoring only the
  * group would hand every channel card the whole ungrouped bucket.
  */
-function rowsMatching(filter: {
-  groupId?: string;
-  originChannel?: string;
-}): Conversation[] {
+function rowsMatching(filter: ConversationListFilter): Conversation[] {
   if (filter.groupId === "system:pinned") {
     return sectionSource.filter((c) => c.isPinned);
   }
@@ -84,12 +81,13 @@ mock.module(
     useSidebarSectionsQuery: () => null,
     useSectionConversationListQuery: (
       _assistantId: string | null,
-      filter: { groupId?: string; originChannel?: string },
-    ) => ({
+      filter: ConversationListFilter,
+    ): ConversationQueries.ConversationListQueryResult => ({
       conversations: rowsMatching(filter),
       isLoading: false,
       isPending: false,
       isError: false,
+      error: null,
       // A resolved query. Omitting this reads as falsy, which would send every
       // section back to its derived rows and pass these tests for the wrong
       // reason: green because nothing is filtered, not because it is.
@@ -98,6 +96,7 @@ mock.module(
       // load-more path, and a stub window would mount sentinels under every
       // section.
       hasMore: false,
+      refetch: () => {},
     }),
   }),
 );
@@ -132,6 +131,7 @@ import type {
   Conversation,
   ConversationGroup,
 } from "@/types/conversation-types";
+import type { ConversationListFilter } from "@/utils/conversation-list-keys";
 import { AssistantSideMenu } from "@/domains/chat/components/assistant-side-menu";
 import { CONVERSATION_LIST_VIRTUALIZE_THRESHOLD } from "@/domains/chat/components/conversation-nav-section";
 import { useSidebarLayoutStore } from "@/domains/chat/sidebar-layout-store";

--- a/clients/web/src/domains/chat/components/load-more-sentinel.tsx
+++ b/clients/web/src/domains/chat/components/load-more-sentinel.tsx
@@ -13,7 +13,7 @@
  * full page.
  *
  * Fires on every entry into view, not once: the callback is expected to be
- * idempotent while a load is in flight (`loadMoreSectionConversations`
+ * idempotent while a load is in flight (`loadMoreConversations`
  * guards per section), and re-firing after rows arrive is what pages in the
  * next window when the user keeps scrolling.
  */

--- a/clients/web/src/domains/chat/hooks/use-conversation-actions-archive-optimistic.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-actions-archive-optimistic.test.tsx
@@ -34,9 +34,9 @@ import * as sdkGen from "@/generated/daemon/sdk.gen";
 import type { Conversation } from "@/types/conversation-types";
 import type { ConversationListPage } from "@/utils/conversation-list-fetchers";
 import {
-  archivedConversationsQueryKey,
-  conversationsQueryKey,
-} from "@/utils/conversation-list-fetchers";
+  ARCHIVED_FILTER,
+  conversationListQueryKey,
+} from "@/utils/conversation-list-keys";
 import { listPage } from "@/utils/conversation-list.test-helper";
 
 // ---------------------------------------------------------------------------
@@ -104,7 +104,7 @@ function seedClient(conversations: Conversation[]): QueryClient {
     defaultOptions: { queries: { retry: false } },
   });
   client.setQueryData(
-    conversationsQueryKey(ASSISTANT_ID),
+    conversationListQueryKey(ASSISTANT_ID),
     listPage(conversations),
   );
   return client;
@@ -151,7 +151,7 @@ function readArchived(
   conversationId: string,
 ): number | undefined {
   const list = client.getQueryData<ConversationListPage>(
-    conversationsQueryKey(ASSISTANT_ID),
+    conversationListQueryKey(ASSISTANT_ID),
   )?.conversations;
   return list?.find((c) => c.conversationId === conversationId)?.archivedAt;
 }
@@ -249,11 +249,11 @@ describe("handleArchiveConversation — optimistic update", () => {
 
     // Seed the archived cache — onSettled should invalidate it.
     client.setQueryData(
-      archivedConversationsQueryKey(ASSISTANT_ID),
+      conversationListQueryKey(ASSISTANT_ID, ARCHIVED_FILTER),
       listPage([]),
     );
     const beforeState = client.getQueryState(
-      archivedConversationsQueryKey(ASSISTANT_ID),
+      conversationListQueryKey(ASSISTANT_ID, ARCHIVED_FILTER),
     );
     expect(beforeState?.isInvalidated).toBe(false);
 
@@ -263,7 +263,7 @@ describe("handleArchiveConversation — optimistic update", () => {
 
     await waitFor(() => {
       const afterState = client.getQueryState(
-        archivedConversationsQueryKey(ASSISTANT_ID),
+        conversationListQueryKey(ASSISTANT_ID, ARCHIVED_FILTER),
       );
       expect(afterState?.isInvalidated).toBe(true);
     });
@@ -274,7 +274,7 @@ describe("handleArchiveConversation — optimistic update", () => {
     const { result, client } = setupHook({ conversations: [conv] });
 
     client.setQueryData(
-      archivedConversationsQueryKey(ASSISTANT_ID),
+      conversationListQueryKey(ASSISTANT_ID, ARCHIVED_FILTER),
       listPage([]),
     );
 
@@ -290,7 +290,7 @@ describe("handleArchiveConversation — optimistic update", () => {
     // TanStack Query refetches the server-authoritative state.
     await waitFor(() => {
       const afterState = client.getQueryState(
-        archivedConversationsQueryKey(ASSISTANT_ID),
+        conversationListQueryKey(ASSISTANT_ID, ARCHIVED_FILTER),
       );
       expect(afterState?.isInvalidated).toBe(true);
     });
@@ -356,11 +356,11 @@ describe("handleUnarchiveConversation — optimistic update", () => {
     const { result, client } = setupHook({ conversations: [conv] });
 
     client.setQueryData(
-      archivedConversationsQueryKey(ASSISTANT_ID),
+      conversationListQueryKey(ASSISTANT_ID, ARCHIVED_FILTER),
       listPage([conv]),
     );
     const beforeState = client.getQueryState(
-      archivedConversationsQueryKey(ASSISTANT_ID),
+      conversationListQueryKey(ASSISTANT_ID, ARCHIVED_FILTER),
     );
     expect(beforeState?.isInvalidated).toBe(false);
 
@@ -370,7 +370,7 @@ describe("handleUnarchiveConversation — optimistic update", () => {
 
     await waitFor(() => {
       const afterState = client.getQueryState(
-        archivedConversationsQueryKey(ASSISTANT_ID),
+        conversationListQueryKey(ASSISTANT_ID, ARCHIVED_FILTER),
       );
       expect(afterState?.isInvalidated).toBe(true);
     });
@@ -384,7 +384,7 @@ describe("handleUnarchiveConversation — optimistic update", () => {
     const { result, client } = setupHook({ conversations: [conv] });
 
     client.setQueryData(
-      archivedConversationsQueryKey(ASSISTANT_ID),
+      conversationListQueryKey(ASSISTANT_ID, ARCHIVED_FILTER),
       listPage([conv]),
     );
 
@@ -398,7 +398,7 @@ describe("handleUnarchiveConversation — optimistic update", () => {
 
     await waitFor(() => {
       const afterState = client.getQueryState(
-        archivedConversationsQueryKey(ASSISTANT_ID),
+        conversationListQueryKey(ASSISTANT_ID, ARCHIVED_FILTER),
       );
       expect(afterState?.isInvalidated).toBe(true);
     });

--- a/clients/web/src/domains/chat/hooks/use-conversation-actions-placement.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-actions-placement.test.tsx
@@ -22,12 +22,11 @@ import { createElement, type ReactNode } from "react";
 
 import * as sdkGen from "@/generated/daemon/sdk.gen";
 import type { Conversation } from "@/types/conversation-types";
+import type { ConversationListPage } from "@/utils/conversation-list-fetchers";
 import {
-  conversationsQueryKey,
-  sectionConversationsQueryKey,
-  type ConversationListPage,
-  type SectionConversationFilter,
-} from "@/utils/conversation-list-fetchers";
+  conversationListQueryKey,
+  type ConversationListFilter,
+} from "@/utils/conversation-list-keys";
 import { listPage } from "@/utils/conversation-list.test-helper";
 
 type ReorderImpl = (opts: unknown) => Promise<{
@@ -63,8 +62,8 @@ const { useConversationActions } =
 // ---------------------------------------------------------------------------
 
 const ASSISTANT_ID = "asst-1";
-const PINNED: SectionConversationFilter = { groupId: "system:pinned" };
-const SLACK: SectionConversationFilter = {
+const PINNED: ConversationListFilter = { groupId: "system:pinned" };
+const SLACK: ConversationListFilter = {
   groupId: "system:all",
   originChannel: "slack",
 };
@@ -75,17 +74,17 @@ const SLACK_ROW: Conversation = {
   lastMessageAt: 1_000,
 };
 
-function setup(sections: Array<[SectionConversationFilter, Conversation[]]>) {
+function setup(sections: Array<[ConversationListFilter, Conversation[]]>) {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
   client.setQueryData<ConversationListPage>(
-    conversationsQueryKey(ASSISTANT_ID),
+    conversationListQueryKey(ASSISTANT_ID),
     listPage([SLACK_ROW]),
   );
   for (const [filter, rows] of sections) {
     client.setQueryData(
-      sectionConversationsQueryKey(ASSISTANT_ID, filter),
+      conversationListQueryKey(ASSISTANT_ID, filter),
       listPage(rows),
     );
   }
@@ -109,14 +108,11 @@ function setup(sections: Array<[SectionConversationFilter, Conversation[]]>) {
   return { result, client };
 }
 
-function idsIn(
-  client: QueryClient,
-  filter: SectionConversationFilter,
-): string[] {
+function idsIn(client: QueryClient, filter: ConversationListFilter): string[] {
   return (
     client
       .getQueryData<ConversationListPage>(
-        sectionConversationsQueryKey(ASSISTANT_ID, filter),
+        conversationListQueryKey(ASSISTANT_ID, filter),
       )
       ?.conversations.map((c) => c.conversationId) ?? []
   );
@@ -321,7 +317,7 @@ describe("pin/unpin placement", () => {
       [SLACK, [SLACK_ROW]],
       [PINNED, []],
     ]);
-    const pinnedKey = sectionConversationsQueryKey(ASSISTANT_ID, PINNED);
+    const pinnedKey = conversationListQueryKey(ASSISTANT_ID, PINNED);
 
     // A: pin. Its request resolves, but B starts before A settles.
     await act(async () => {
@@ -386,12 +382,13 @@ describe("pin/unpin placement", () => {
 
     await waitFor(() => {
       expect(
-        client.getQueryState(sectionConversationsQueryKey(ASSISTANT_ID, PINNED))
+        client.getQueryState(conversationListQueryKey(ASSISTANT_ID, PINNED))
           ?.isInvalidated,
       ).toBe(true);
     });
     expect(
-      client.getQueryState(conversationsQueryKey(ASSISTANT_ID))?.isInvalidated,
+      client.getQueryState(conversationListQueryKey(ASSISTANT_ID))
+        ?.isInvalidated,
     ).toBe(false);
   });
 });

--- a/clients/web/src/domains/chat/hooks/use-conversation-actions-unread-count.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-actions-unread-count.test.tsx
@@ -24,10 +24,8 @@ import { createElement, type ReactNode } from "react";
 
 import * as sdkGen from "@/generated/daemon/sdk.gen";
 import type { Conversation } from "@/types/conversation-types";
-import {
-  conversationsQueryKey,
-  unreadConversationCountQueryKey,
-} from "@/utils/conversation-list-fetchers";
+import { unreadConversationCountQueryKey } from "@/utils/conversation-list-fetchers";
+import { conversationListQueryKey } from "@/utils/conversation-list-keys";
 import { listPage } from "@/utils/conversation-list.test-helper";
 
 // ---------------------------------------------------------------------------
@@ -87,7 +85,7 @@ function setupHook(opts: {
     defaultOptions: { queries: { retry: false } },
   });
   client.setQueryData(
-    conversationsQueryKey(ASSISTANT_ID),
+    conversationListQueryKey(ASSISTANT_ID),
     listPage(opts.conversations),
   );
   if (opts.unreadCount !== undefined) {

--- a/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
@@ -1,5 +1,6 @@
 import { type MutableRefObject, useCallback, useRef } from "react";
 import {
+  hashKey,
   useMutation,
   useQueryClient,
   type QueryClient,
@@ -154,10 +155,13 @@ function reconcilePlacement(
       ),
     ]);
   }
+  /* Exact: a section key used as a partial filter would also match every
+     section whose filter extends it (Chats matches each channel card), and
+     that would refetch caches the move never touched. */
   return Promise.all([
     refreshIndex,
     ...sectionKeys.map((queryKey) =>
-      queryClient.invalidateQueries({ queryKey }),
+      queryClient.invalidateQueries({ queryKey, exact: true }),
     ),
   ]);
 }
@@ -411,7 +415,7 @@ export function useConversationActions({
         placementsRef.current.get(conversationId)?.sectionKeys ??
         new Map<string, readonly unknown[]>();
       for (const queryKey of sectionKeys) {
-        inherited.set(JSON.stringify(queryKey), queryKey);
+        inherited.set(hashKey(queryKey), queryKey);
       }
       placementsRef.current.set(conversationId, {
         token,

--- a/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
@@ -18,9 +18,7 @@ import {
   adjustSectionUnreadCache,
   adjustUnreadCountCache,
 } from "@/utils/conversation-cache-mutations";
-import {
-  sidebarSectionsQueryKey,
-} from "@/utils/conversation-list-fetchers";
+import { sidebarSectionsQueryKey } from "@/utils/conversation-list-fetchers";
 import {
   conversationListQueryFilter,
   isSectionFilter,

--- a/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
@@ -19,9 +19,12 @@ import {
   adjustUnreadCountCache,
 } from "@/utils/conversation-cache-mutations";
 import {
-  sectionListPrefix,
   sidebarSectionsQueryKey,
 } from "@/utils/conversation-list-fetchers";
+import {
+  conversationListQueryFilter,
+  isSectionFilter,
+} from "@/utils/conversation-list-keys";
 import { contributesToUnreadCount } from "@/utils/conversation-predicates";
 import { executeBulkWithFallback } from "@/utils/bulk-with-fallback";
 import {
@@ -148,9 +151,9 @@ function reconcilePlacement(
   if (!sectionKeys?.length) {
     return Promise.all([
       refreshIndex,
-      queryClient.invalidateQueries({
-        queryKey: sectionListPrefix(assistantId),
-      }),
+      queryClient.invalidateQueries(
+        conversationListQueryFilter(assistantId, isSectionFilter),
+      ),
     ]);
   }
   return Promise.all([

--- a/clients/web/src/domains/chat/hooks/use-conversation-loader.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-loader.ts
@@ -122,7 +122,7 @@ export function useConversationLoader({
   // refreshConversations -- invalidate the cached conversation list + groups
   // so subscribed query consumers refetch. The active list query is mounted
   // by `ChatLayout` and `ChatPage`, so invalidation triggers a background
-  // refetch through the same `listConversations` queryFn used at boot.
+  // refetch through the same `conversationListOptions` queryFn used at boot.
   // -------------------------------------------------------------------------
   const refreshConversations = useCallback(async () => {
     if (!assistantId) {
@@ -151,8 +151,8 @@ export function useConversationLoader({
   // `useBackgroundConversationListQuery`, gated on the sidebar revealing
   // those sections, so a large background backlog never blocks the initial
   // render. Sibling consumers in `ChatLayout` and `ChatPage` mount the same
-  // foreground query — they all share one cache entry under
-  // `conversationsQueryKey(assistantId)`, so dedupe and structural-sharing
+  // foreground query; they all share one cache entry under
+  // `conversationListQueryKey(assistantId)`, so dedupe and structural-sharing
   // are automatic.
   //
   // The query owns:

--- a/clients/web/src/domains/chat/hooks/use-mark-seen-on-open.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-mark-seen-on-open.test.tsx
@@ -16,10 +16,8 @@ import { createElement, type ReactNode } from "react";
 import * as sdkGen from "@/generated/daemon/sdk.gen";
 import type { Conversation } from "@/types/conversation-types";
 import type { ConversationListPage } from "@/utils/conversation-list-fetchers";
-import {
-  conversationsQueryKey,
-  unreadConversationCountQueryKey,
-} from "@/utils/conversation-list-fetchers";
+import { unreadConversationCountQueryKey } from "@/utils/conversation-list-fetchers";
+import { conversationListQueryKey } from "@/utils/conversation-list-keys";
 import { listPage } from "@/utils/conversation-list.test-helper";
 
 const seenCalls: Array<{ conversationId: string }> = [];
@@ -59,7 +57,7 @@ function setup(conversation: Conversation | undefined, unreadCount: number) {
     defaultOptions: { queries: { retry: false } },
   });
   client.setQueryData(
-    conversationsQueryKey(ASSISTANT_ID),
+    conversationListQueryKey(ASSISTANT_ID),
     listPage(conversation ? [conversation] : []),
   );
   client.setQueryData(
@@ -92,7 +90,7 @@ function readCount(client: QueryClient): number | null | undefined {
 
 function readUnseen(client: QueryClient): boolean | undefined {
   return client
-    .getQueryData<ConversationListPage>(conversationsQueryKey(ASSISTANT_ID))
+    .getQueryData<ConversationListPage>(conversationListQueryKey(ASSISTANT_ID))
     ?.conversations.find((c) => c.conversationId === "conv-1")
     ?.hasUnseenLatestAssistantMessage;
 }

--- a/clients/web/src/domains/chat/hooks/use-surface-on-open.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-surface-on-open.test.tsx
@@ -18,7 +18,7 @@ import { createElement, type ReactNode } from "react";
 import type * as ConversationsApi from "@/domains/chat/api/conversations";
 import type { Conversation } from "@/types/conversation-types";
 import type { ConversationListPage } from "@/utils/conversation-list-fetchers";
-import { conversationsQueryKey } from "@/utils/conversation-list-fetchers";
+import { conversationListQueryKey } from "@/utils/conversation-list-keys";
 import { listPage } from "@/utils/conversation-list.test-helper";
 
 const surfaceCalls: Array<{ assistantId: string; conversationId: string }> = [];
@@ -86,7 +86,7 @@ describe("useSurfaceOnOpen", () => {
     const client = new QueryClient();
     const bg = conversation({ conversationType: "background" });
     client.setQueryData<ConversationListPage>(
-      conversationsQueryKey(ASSISTANT_ID),
+      conversationListQueryKey(ASSISTANT_ID),
       listPage([]),
     );
 
@@ -101,7 +101,7 @@ describe("useSurfaceOnOpen", () => {
       expect(
         client
           .getQueryData<ConversationListPage>(
-            conversationsQueryKey(ASSISTANT_ID),
+            conversationListQueryKey(ASSISTANT_ID),
           )
           ?.conversations.map((c) => c.surfacedAt),
       ).toEqual([4242]);
@@ -160,7 +160,7 @@ describe("useSurfaceOnOpen", () => {
   test("a failed surface leaves caches untouched and retries on the next open", async () => {
     const client = new QueryClient();
     client.setQueryData<ConversationListPage>(
-      conversationsQueryKey(ASSISTANT_ID),
+      conversationListQueryKey(ASSISTANT_ID),
       listPage([]),
     );
     surfaceImpl = async () => {
@@ -174,7 +174,7 @@ describe("useSurfaceOnOpen", () => {
     });
     expect(
       client.getQueryData<ConversationListPage>(
-        conversationsQueryKey(ASSISTANT_ID),
+        conversationListQueryKey(ASSISTANT_ID),
       ),
     ).toEqual(listPage([]));
 
@@ -196,7 +196,7 @@ describe("useSurfaceOnOpen", () => {
        fire a duplicate promotion for a run already being promoted. */
     const client = new QueryClient();
     client.setQueryData<ConversationListPage>(
-      conversationsQueryKey(ASSISTANT_ID),
+      conversationListQueryKey(ASSISTANT_ID),
       listPage([]),
     );
     const resolvers = new Map<string, (at: number) => void>();
@@ -246,7 +246,7 @@ describe("useSurfaceOnOpen", () => {
   test("a pending request blocks a duplicate while prop identity churns", async () => {
     const client = new QueryClient();
     client.setQueryData<ConversationListPage>(
-      conversationsQueryKey(ASSISTANT_ID),
+      conversationListQueryKey(ASSISTANT_ID),
       listPage([]),
     );
     let resolveSurface!: (at: number) => void;

--- a/clients/web/src/domains/chat/use-section-conversations.test.tsx
+++ b/clients/web/src/domains/chat/use-section-conversations.test.tsx
@@ -16,6 +16,7 @@ import type * as ListFetchers from "@/utils/conversation-list-fetchers";
 import type { SidebarSection } from "@/domains/chat/use-sidebar-state";
 import type { Conversation } from "@/types/conversation-types";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+import { conversationListQueryKey } from "@/utils/conversation-list-keys";
 import { listPage } from "@/utils/conversation-list.test-helper";
 
 /** What the section query answers with, per test. */
@@ -54,8 +55,10 @@ mock.module(
         isLoading: serverPending,
         isPending: serverPending,
         isError: serverErrored,
+        error: serverErrored ? new Error("section query failed") : null,
         hasData: enabled && serverHasData && !serverPending,
         hasMore: enabled && serverHasData ? serverHasMore : false,
+        refetch: () => {},
       };
     },
   }),
@@ -64,7 +67,7 @@ mock.module(
 const actualFetchers = await import("@/utils/conversation-list-fetchers");
 mock.module("@/utils/conversation-list-fetchers", (): typeof ListFetchers => ({
   ...actualFetchers,
-  drainSectionConversations: async (_assistantId, filter) => {
+  drainConversationList: async (_assistantId, filter = {}) => {
     drainCalls.push(filter);
     return drainRows;
   },
@@ -406,9 +409,7 @@ describe("useSectionConversations", () => {
 
     const { result } = renderSection(pinnedSection());
     queryClient.setQueryData(
-      actualFetchers.sectionConversationsQueryKey("asst-1", {
-        groupId: "system:pinned",
-      }),
+      conversationListQueryKey("asst-1", { groupId: "system:pinned" }),
       listPage(FROM_SERVER),
     );
 
@@ -427,9 +428,7 @@ describe("useSectionConversations", () => {
 
     const { result } = renderSection(pinnedSection());
     queryClient.setQueryData(
-      actualFetchers.sectionConversationsQueryKey("asst-1", {
-        groupId: "system:pinned",
-      }),
+      conversationListQueryKey("asst-1", { groupId: "system:pinned" }),
       listPage(FROM_SERVER, true),
     );
 

--- a/clients/web/src/domains/chat/use-section-conversations.test.tsx
+++ b/clients/web/src/domains/chat/use-section-conversations.test.tsx
@@ -16,7 +16,10 @@ import type * as ListFetchers from "@/utils/conversation-list-fetchers";
 import type { SidebarSection } from "@/domains/chat/use-sidebar-state";
 import type { Conversation } from "@/types/conversation-types";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
-import { conversationListQueryKey } from "@/utils/conversation-list-keys";
+import {
+  type ConversationListFilter,
+  conversationListQueryKey,
+} from "@/utils/conversation-list-keys";
 import { listPage } from "@/utils/conversation-list.test-helper";
 
 /** What the section query answers with, per test. */
@@ -32,7 +35,7 @@ let serverHasData = true;
 /** Whether the query reports rows past the window (LUM-2444). */
 let serverHasMore = false;
 /** Filters the hook actually sent, so tests can assert the query is scoped. */
-let sentFilters: Array<{ groupId?: string; originChannel?: string }> = [];
+let sentFilters: Array<ConversationListFilter | null> = [];
 /** Whether the query was enabled, so a closed gate is distinguishable. */
 let lastEnabled = false;
 /** Filters the bulk-path drain was asked for, and what it answers. */
@@ -369,6 +372,8 @@ describe("useSectionConversations", () => {
     expect(result.current.conversations.map((c) => c.conversationId)).toEqual([
       "derived-1",
     ]);
+    /* No filter means no query: nothing to key on, so nothing observed. */
+    expect(sentFilters.at(-1)).toBeNull();
     expect(lastEnabled).toBe(false);
   });
 

--- a/clients/web/src/domains/chat/use-section-conversations.ts
+++ b/clients/web/src/domains/chat/use-section-conversations.ts
@@ -45,9 +45,11 @@ import {
 } from "@/utils/conversation-list-keys";
 
 /**
- * Stable placeholder for a section with no filter of its own. The query is
- * disabled in that case, so this is never sent; it exists only because the
- * query hook takes a filter unconditionally.
+ * Stable placeholder for a section with no filter of its own, because the
+ * query hook takes a filter unconditionally. It keys onto the foreground
+ * cache (the empty filter IS the foreground list), so it must only ever be
+ * passed with `enabled: false`; the disabled observer sends nothing, and
+ * `live` keeps its data out of the render.
  */
 const NO_FILTER: ConversationListFilter = {};
 

--- a/clients/web/src/domains/chat/use-section-conversations.ts
+++ b/clients/web/src/domains/chat/use-section-conversations.ts
@@ -29,25 +29,27 @@ import { useSupportsGroupFilter } from "@/lib/backwards-compat/use-supports-grou
 import { useSupportsNativeOriginFilter } from "@/lib/backwards-compat/use-supports-native-origin-filter";
 import type { Conversation } from "@/types/conversation-types";
 import { captureError } from "@/lib/sentry/capture-error";
-import { loadMoreSectionConversations } from "@/utils/conversation-cache-mutations";
+import { loadMoreConversations } from "@/utils/conversation-cache-mutations";
 import {
   NATIVE_ORIGIN_CHANNEL,
   ORIGIN_CHANNELS,
   SYSTEM_ALL_GROUP_ID,
   SYSTEM_PINNED_GROUP_ID,
-  drainSectionConversations,
-  sectionConversationsQueryKey,
+  drainConversationList,
   type ConversationListPage,
   type OriginChannel,
-  type SectionConversationFilter,
 } from "@/utils/conversation-list-fetchers";
+import {
+  type ConversationListFilter,
+  conversationListQueryKey,
+} from "@/utils/conversation-list-keys";
 
 /**
  * Stable placeholder for a section with no filter of its own. The query is
  * disabled in that case, so this is never sent; it exists only because the
  * query hook takes a filter unconditionally.
  */
-const NO_FILTER: SectionConversationFilter = {};
+const NO_FILTER: ConversationListFilter = {};
 
 /**
  * What this section asks the server for, or `null` when it has no filter yet.
@@ -86,7 +88,7 @@ const NO_FILTER: SectionConversationFilter = {};
 function sectionFilter(
   section: SidebarSection,
   supportsNativeOrigin: boolean,
-): SectionConversationFilter | null {
+): ConversationListFilter | null {
   switch (section.type) {
     case "pinned":
       return { groupId: SYSTEM_PINNED_GROUP_ID };
@@ -219,7 +221,7 @@ export function useSectionConversations(
     if (!assistantId || filter === null) {
       return;
     }
-    loadMoreSectionConversations(queryClient, assistantId, filter).catch(
+    loadMoreConversations(queryClient, assistantId, filter).catch(
       (error: unknown) => {
         /* Best-effort: the sentinel re-fires on the next intersection, so
            daemon transients filter out and only unexpected failures reach
@@ -240,12 +242,12 @@ export function useSectionConversations(
       return sectionAll;
     }
     const page = queryClient.getQueryData<ConversationListPage>(
-      sectionConversationsQueryKey(assistantId, filter),
+      conversationListQueryKey(assistantId, filter),
     );
     if (page && !page.hasMore) {
       return page.conversations;
     }
-    return drainSectionConversations(assistantId, filter);
+    return drainConversationList(assistantId, filter);
   }, [assistantId, filter, live, queryClient, sectionAll]);
 
   /* `hasData`, not `!isPending`, and not `!isError` either.

--- a/clients/web/src/domains/chat/use-section-conversations.ts
+++ b/clients/web/src/domains/chat/use-section-conversations.ts
@@ -45,15 +45,6 @@ import {
 } from "@/utils/conversation-list-keys";
 
 /**
- * Stable placeholder for a section with no filter of its own, because the
- * query hook takes a filter unconditionally. It keys onto the foreground
- * cache (the empty filter IS the foreground list), so it must only ever be
- * passed with `enabled: false`; the disabled observer sends nothing, and
- * `live` keeps its data out of the render.
- */
-const NO_FILTER: ConversationListFilter = {};
-
-/**
  * What this section asks the server for, or `null` when it has no filter yet.
  *
  * Pinned and the custom groups are answered by `groupId` alone, because
@@ -214,7 +205,7 @@ export function useSectionConversations(
   const enabled = filter !== null && isAssistantActive && supportsGroupFilter;
   const { conversations, hasData, hasMore } = useSectionConversationListQuery(
     assistantId,
-    filter ?? NO_FILTER,
+    filter,
     enabled,
   );
   const live = enabled && hasData;

--- a/clients/web/src/domains/chat/utils/stream-handlers/message-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/message-handlers.test.ts
@@ -16,7 +16,7 @@ import {
 import { useSubagentStore } from "@/domains/chat/subagent-store";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useInteractionStore } from "@/domains/chat/interaction-store";
-import { conversationsQueryKey } from "@/utils/conversation-list-fetchers";
+import { conversationListQueryKey } from "@/utils/conversation-list-keys";
 import { listPage } from "@/utils/conversation-list.test-helper";
 import { findConversation } from "@/utils/conversation-cache";
 import type { DisplayMessage } from "@/domains/chat/types/types";
@@ -35,7 +35,7 @@ describe("handleAssistantTurnStart", () => {
     // GIVEN a cached conversation row the daemon last reported as idle
     const ctx = makeCtx();
     ctx.queryClient.setQueryData(
-      conversationsQueryKey("ast-1"),
+      conversationListQueryKey("ast-1"),
       listPage([{ conversationId: "conv-1", isProcessing: false }]),
     );
 
@@ -70,7 +70,7 @@ describe("handleAssistantTextDelta", () => {
     // (e.g. the start event was dropped on a reconnect)
     const ctx = makeCtx();
     ctx.queryClient.setQueryData(
-      conversationsQueryKey("ast-1"),
+      conversationListQueryKey("ast-1"),
       listPage([{ conversationId: "conv-1", isProcessing: false }]),
     );
 

--- a/clients/web/src/hooks/conversation-queries-gating.test.tsx
+++ b/clients/web/src/hooks/conversation-queries-gating.test.tsx
@@ -47,17 +47,34 @@ mock.module("@/hooks/use-is-org-ready", () => ({
   useIsOrgReady: () => orgIsReady,
 }));
 
-const { useConversationListQuery } = await import(
-  "@/hooks/conversation-queries"
-);
+const { useConversationListQuery, useSectionConversationListQuery } =
+  await import("@/hooks/conversation-queries");
+const { conversationListQueryKey } =
+  await import("@/utils/conversation-list-keys");
 
 const ASSISTANT_ID = "asst-1";
 
+function makeQueryClient(): QueryClient {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
 function wrapper({ children }: { children: ReactNode }) {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
-  return createElement(QueryClientProvider, { client: queryClient }, children);
+  return createElement(
+    QueryClientProvider,
+    { client: makeQueryClient() },
+    children,
+  );
+}
+
+/** A wrapper over one client the test can inspect afterwards. */
+function wrapperFor(queryClient: QueryClient) {
+  return function InspectableWrapper({ children }: { children: ReactNode }) {
+    return createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children,
+    );
+  };
 }
 
 async function settle() {
@@ -137,5 +154,58 @@ describe("conversation queries · daemon gate", () => {
     await settle();
 
     expect(conversationsGetMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("section list query · no filter, no query", () => {
+  test("a null filter mounts nothing: no cache entry, no request", async () => {
+    /* Every filter names a real cache under the generated key, the empty
+       filter included, so the only honest answer for a section with no
+       server filter is to observe nothing at all. In particular nothing may
+       sit on the foreground list's key. */
+    const queryClient = makeQueryClient();
+    renderHook(() => useSectionConversationListQuery(ASSISTANT_ID, null), {
+      wrapper: wrapperFor(queryClient),
+    });
+    await settle();
+
+    expect(queryClient.getQueryCache().getAll()).toHaveLength(0);
+    expect(
+      queryClient.getQueryCache().find({
+        queryKey: conversationListQueryKey(ASSISTANT_ID),
+        exact: true,
+      }),
+    ).toBeUndefined();
+    expect(conversationsGetMock).not.toHaveBeenCalled();
+  });
+
+  test("a null filter reads as nothing to show", async () => {
+    const { result } = renderHook(
+      () => useSectionConversationListQuery(ASSISTANT_ID, null),
+      { wrapper },
+    );
+    await settle();
+
+    expect(result.current.conversations).toEqual([]);
+    expect(result.current.hasData).toBe(false);
+    expect(result.current.hasMore).toBe(false);
+    expect(result.current.isError).toBe(false);
+  });
+
+  test("a filter mounts exactly its own query", async () => {
+    const queryClient = makeQueryClient();
+    const filter = { groupId: "system:pinned" };
+    renderHook(() => useSectionConversationListQuery(ASSISTANT_ID, filter), {
+      wrapper: wrapperFor(queryClient),
+    });
+    await waitFor(() => {
+      expect(conversationsGetMock).toHaveBeenCalledTimes(1);
+    });
+
+    const keys = queryClient
+      .getQueryCache()
+      .getAll()
+      .map((query) => query.queryKey);
+    expect(keys).toEqual([conversationListQueryKey(ASSISTANT_ID, filter)]);
   });
 });

--- a/clients/web/src/hooks/conversation-queries.test.ts
+++ b/clients/web/src/hooks/conversation-queries.test.ts
@@ -13,12 +13,12 @@ import {
   replaceOptimisticGroup,
   resolveDraftKey,
 } from "@/utils/conversation-cache-mutations";
+import type { ConversationListPage } from "@/utils/conversation-list-fetchers";
 import {
-  backgroundConversationsQueryKey,
-  conversationsQueryKey,
-  scheduledConversationsQueryKey,
-  type ConversationListPage,
-} from "@/utils/conversation-list-fetchers";
+  BACKGROUND_FILTER,
+  conversationListQueryKey,
+  SCHEDULED_FILTER,
+} from "@/utils/conversation-list-keys";
 import { listPage } from "@/utils/conversation-list.test-helper";
 import { groupsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
 import { patchConversation } from "@/utils/conversation-cache";
@@ -57,15 +57,16 @@ function seedConversations(
   conversations: Conversation[],
 ): void {
   qc.setQueryData<ConversationListPage>(
-    conversationsQueryKey(ASSISTANT_ID),
+    conversationListQueryKey(ASSISTANT_ID),
     listPage(conversations),
   );
 }
 
 function getConversations(qc: QueryClient): Conversation[] {
   return (
-    qc.getQueryData<ConversationListPage>(conversationsQueryKey(ASSISTANT_ID))
-      ?.conversations ?? []
+    qc.getQueryData<ConversationListPage>(
+      conversationListQueryKey(ASSISTANT_ID),
+    )?.conversations ?? []
   );
 }
 
@@ -74,7 +75,7 @@ function seedBackgroundConversations(
   conversations: Conversation[],
 ): void {
   qc.setQueryData<ConversationListPage>(
-    backgroundConversationsQueryKey(ASSISTANT_ID),
+    conversationListQueryKey(ASSISTANT_ID, BACKGROUND_FILTER),
     listPage(conversations),
   );
 }
@@ -82,7 +83,7 @@ function seedBackgroundConversations(
 function getBackgroundConversations(qc: QueryClient): Conversation[] {
   return (
     qc.getQueryData<ConversationListPage>(
-      backgroundConversationsQueryKey(ASSISTANT_ID),
+      conversationListQueryKey(ASSISTANT_ID, BACKGROUND_FILTER),
     )?.conversations ?? []
   );
 }
@@ -92,7 +93,7 @@ function seedScheduledConversations(
   conversations: Conversation[],
 ): void {
   qc.setQueryData<ConversationListPage>(
-    scheduledConversationsQueryKey(ASSISTANT_ID),
+    conversationListQueryKey(ASSISTANT_ID, SCHEDULED_FILTER),
     listPage(conversations),
   );
 }
@@ -100,7 +101,7 @@ function seedScheduledConversations(
 function getScheduledConversations(qc: QueryClient): Conversation[] {
   return (
     qc.getQueryData<ConversationListPage>(
-      scheduledConversationsQueryKey(ASSISTANT_ID),
+      conversationListQueryKey(ASSISTANT_ID, SCHEDULED_FILTER),
     )?.conversations ?? []
   );
 }
@@ -140,7 +141,7 @@ describe("patchConversation", () => {
     patchConversation(qc, ASSISTANT_ID, "a", { title: "x" });
     expect(
       qc.getQueryData<ConversationListPage>(
-        conversationsQueryKey(ASSISTANT_ID),
+        conversationListQueryKey(ASSISTANT_ID),
       ),
     ).toBeUndefined();
   });

--- a/clients/web/src/hooks/conversation-queries.ts
+++ b/clients/web/src/hooks/conversation-queries.ts
@@ -27,7 +27,11 @@
  */
 
 import { useMemo } from "react";
-import { useQuery } from "@tanstack/react-query";
+import {
+  useQueries,
+  useQuery,
+  type UseQueryResult,
+} from "@tanstack/react-query";
 
 import { groupsGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
 import type { Options } from "@/generated/daemon/sdk.gen";
@@ -43,7 +47,10 @@ import {
   sidebarSectionsOptions,
   unreadConversationCountOptions,
 } from "@/utils/conversation-list-fetchers";
-import type { SidebarIndexSection } from "@/utils/conversation-list-fetchers";
+import type {
+  ConversationListPage,
+  SidebarIndexSection,
+} from "@/utils/conversation-list-fetchers";
 import {
   ARCHIVED_BACKGROUND_FILTER,
   ARCHIVED_FILTER,
@@ -113,8 +120,35 @@ export interface ConversationListQueryResult {
   refetch: () => void;
 }
 
+type ListQueryOptions = ReturnType<typeof conversationListOptions> & {
+  enabled: boolean;
+};
+
 /**
- * Subscribe to the list cache `filter` names.
+ * What a list hook returns when it has no query to observe: the same shape a
+ * never-enabled query reports (pending, not loading, nothing to show), so a
+ * consumer branches the same way in both cases.
+ */
+const NO_QUERY: ConversationListQueryResult = {
+  conversations: EMPTY_CONVERSATIONS,
+  isLoading: false,
+  isPending: true,
+  isError: false,
+  error: null,
+  hasData: false,
+  hasMore: false,
+  refetch: () => {},
+};
+
+/**
+ * Subscribe to the list cache `filter` names, or to nothing when `filter` is
+ * `null`.
+ *
+ * `null` mounts no query at all (`useQueries` with an empty list), which is
+ * what a section without a server filter needs: every filter names a real
+ * cache under the generated key, the empty filter included, so there is no
+ * placeholder key a disabled observer could sit on without subscribing to
+ * someone's data.
  *
  * `enabled` gates the network fetch; passing `false` keeps the observer
  * subscribed to cache updates without firing a request (attention tracking
@@ -129,14 +163,27 @@ export interface ConversationListQueryResult {
  */
 function useListQuery(
   assistantId: string | null,
-  filter: ConversationListFilter,
+  filter: ConversationListFilter | null,
   enabled: boolean,
 ): ConversationListQueryResult {
   const canQuery = useCanQueryDaemon(assistantId);
-  const query = useQuery({
-    ...conversationListOptions(assistantId ?? "", filter),
-    enabled: enabled && Boolean(assistantId) && canQuery,
-  });
+  /* An array, not a tuple, so `useQueries` types the results as a list of
+     one query kind whether it holds zero entries or one. */
+  const queries: ListQueryOptions[] =
+    filter === null
+      ? []
+      : [
+          {
+            ...conversationListOptions(assistantId ?? "", filter),
+            enabled: enabled && Boolean(assistantId) && canQuery,
+          },
+        ];
+  const query: UseQueryResult<ConversationListPage> | undefined = useQueries({
+    queries,
+  })[0];
+  if (query === undefined) {
+    return NO_QUERY;
+  }
   return {
     conversations: query.data?.conversations ?? EMPTY_CONVERSATIONS,
     isLoading: query.isLoading,
@@ -185,7 +232,9 @@ export function useScheduledConversationListQuery(
 }
 
 /**
- * One sidebar section's conversations (a group and/or channel filter).
+ * One sidebar section's conversations (a group and/or channel filter), or
+ * nothing for a section that has no server filter (`null`: a channel this
+ * client's schema does not carry, or Chats below the native-origin gate).
  *
  * Each section mounts its own instance, so its contents come from the server
  * rather than from filtering another section's list. That is what lets a
@@ -194,7 +243,7 @@ export function useScheduledConversationListQuery(
  */
 export function useSectionConversationListQuery(
   assistantId: string | null,
-  filter: ConversationListFilter,
+  filter: ConversationListFilter | null,
   enabled: boolean = true,
 ): ConversationListQueryResult {
   return useListQuery(assistantId, filter, enabled);

--- a/clients/web/src/hooks/conversation-queries.ts
+++ b/clients/web/src/hooks/conversation-queries.ts
@@ -6,11 +6,17 @@
  * companion `conversation-store.ts` keeps only the client-side slice —
  * active/editing key, processing/attention sets, and snapshots.
  *
- * Each hook spreads a `queryOptions` factory from
- * `utils/conversation-list-fetchers.ts` and adds runtime concerns
+ * Each hook spreads a `queryOptions` factory (`conversationListOptions` in
+ * `utils/conversation-list-options.ts` for the list caches; the fetchers
+ * module for the sidebar's other reads) and adds runtime concerns
  * (`enabled` gating via `useCanQueryDaemon()`, `select` transforms). This
  * co-locates `queryKey` + `queryFn` + `staleTime` in one place so they
  * can be reused across hooks, prefetches, and imperative cache reads.
+ *
+ * The list hooks are one hook, {@link useListQuery}, under the names the
+ * consumers read: every list cache is `conversationListOptions` with a
+ * different filter, and the named hooks exist for the consumers that still
+ * read the four buckets rather than a section. They go with those consumers.
  *
  * Cache mutation helpers live in `utils/conversation-cache-mutations.ts`.
  *
@@ -32,20 +38,23 @@ import type {
   Conversation,
   ConversationGroup,
 } from "@/types/conversation-types";
-import { countUnreadConversationsInList } from "@/utils/conversation-predicates";
+import { mergeConversationLists } from "@/utils/conversation-cache";
 import {
-  archivedConversationListOptions,
-  backgroundConversationListOptions,
-  conversationListOptions,
-  sectionConversationListOptions,
-  scheduledConversationListOptions,
   sidebarSectionsOptions,
   unreadConversationCountOptions,
 } from "@/utils/conversation-list-fetchers";
-import type {
-  SectionConversationFilter,
-  SidebarIndexSection,
-} from "@/utils/conversation-list-fetchers";
+import type { SidebarIndexSection } from "@/utils/conversation-list-fetchers";
+import {
+  ARCHIVED_BACKGROUND_FILTER,
+  ARCHIVED_FILTER,
+  BACKGROUND_FILTER,
+  type ConversationListFilter,
+  FOREGROUND_FILTER,
+  SCHEDULED_FILTER,
+} from "@/utils/conversation-list-keys";
+import { conversationListOptions } from "@/utils/conversation-list-options";
+import { byTimestampDesc } from "@/utils/conversation-order";
+import { countUnreadConversationsInList } from "@/utils/conversation-predicates";
 
 // ---------------------------------------------------------------------------
 // Queries
@@ -77,39 +86,55 @@ function useCanQueryDaemon(assistantId: string | null): boolean {
   return isOrgReady && isServing;
 }
 
-/**
- * Subscribe to the foreground conversation list for the given assistant.
- *
- * Fetches foreground conversations via `listConversations()` and stores a
- * `ConversationListPage` under `conversationsQueryKey`. Background and
- * scheduled jobs are deliberately excluded — they load through
- * `useBackgroundConversationListQuery` only when the user reveals them — so
- * the initial chat render is never blocked on a large background backlog.
- *
- * Returns an empty array until the query resolves so consumers can render
- * an empty sidebar without null-checking. Cache writes from mutations and
- * SSE handlers feed through here automatically.
- *
- * `isError`, `error`, and `refetch` are exposed so chat-surface consumers
- * can surface a visible error state when the conversation list fails —
- * most notably for self-hosted assistants, where a missing actor-token
- * JWT surfaces as a gateway 401 that has to terminate the loading spinner
- * with an actionable retry instead of silently keeping the sidebar empty.
- */
-export function useConversationListQuery(
-  assistantId: string | null,
-  enabled: boolean = true,
-): {
+/** What every list hook returns. */
+export interface ConversationListQueryResult {
+  /** Empty until the query resolves, so consumers render without null checks. */
   conversations: Conversation[];
   isLoading: boolean;
   isPending: boolean;
   isError: boolean;
   error: Error | null;
+  /**
+   * Whether the query has ever resolved; survives a failed refetch. What a
+   * consumer branches on to decide whether to trust `conversations`:
+   * `isError` is not its complement, since React Query keeps the last
+   * successful data when a later refetch fails, and treating an errored
+   * query as unusable would swap real rows for a worse list. `hasData` is
+   * false in exactly the cases with nothing to show: never fetched, still
+   * pending, or failed before it ever succeeded.
+   */
+  hasData: boolean;
+  /**
+   * Whether the server holds rows past this window (LUM-2444). `false`
+   * until the query resolves, so nothing offers a load-more for a list that
+   * has not answered once, and always `false` for a drained bucket.
+   */
+  hasMore: boolean;
   refetch: () => void;
-} {
+}
+
+/**
+ * Subscribe to the list cache `filter` names.
+ *
+ * `enabled` gates the network fetch; passing `false` keeps the observer
+ * subscribed to cache updates without firing a request (attention tracking
+ * reads the background and scheduled buckets that way: it reflects their
+ * rows once the sidebar loads them, but never triggers the fetch itself).
+ *
+ * `isError`, `error`, and `refetch` let a chat surface render a visible
+ * error state when the list fails, most notably for self-hosted assistants,
+ * where a missing actor-token JWT surfaces as a gateway 401 that has to
+ * terminate the loading spinner with an actionable retry instead of
+ * silently keeping the sidebar empty.
+ */
+function useListQuery(
+  assistantId: string | null,
+  filter: ConversationListFilter,
+  enabled: boolean,
+): ConversationListQueryResult {
   const canQuery = useCanQueryDaemon(assistantId);
   const query = useQuery({
-    ...conversationListOptions(assistantId!),
+    ...conversationListOptions(assistantId ?? "", filter),
     enabled: enabled && Boolean(assistantId) && canQuery,
   });
   return {
@@ -118,6 +143,8 @@ export function useConversationListQuery(
     isPending: query.isPending,
     isError: query.isError,
     error: query.error,
+    hasData: query.data !== undefined,
+    hasMore: query.data?.hasMore ?? false,
     refetch: () => {
       void query.refetch();
     },
@@ -125,129 +152,94 @@ export function useConversationListQuery(
 }
 
 /**
- * Subscribe to the background conversation list for the given assistant.
- * Cached separately from the foreground list under
- * `backgroundConversationsQueryKey`.
- *
- * `enabled` gates the network fetch on whether the user has revealed the
- * Background sidebar section. Passing `enabled: false` keeps the observer
- * subscribed to cache updates without firing a request — used by attention
- * tracking so it reflects background rows once the sidebar has loaded them,
- * but never triggers the fetch itself.
+ * The foreground conversation list: the primary list that gates the initial
+ * chat render. Background and scheduled jobs are excluded on purpose; they
+ * load through their own hooks only when the user reveals them, so the
+ * initial render is never blocked on a large background backlog.
  */
+export function useConversationListQuery(
+  assistantId: string | null,
+  enabled: boolean = true,
+): ConversationListQueryResult {
+  return useListQuery(assistantId, FOREGROUND_FILTER, enabled);
+}
+
+/** The background conversation list, its own cache from the foreground list. */
 export function useBackgroundConversationListQuery(
   assistantId: string | null,
   enabled: boolean = true,
-): {
-  conversations: Conversation[];
-  isLoading: boolean;
-  isPending: boolean;
-  isError: boolean;
-  refetch: () => void;
-} {
-  const canQuery = useCanQueryDaemon(assistantId);
-  const query = useQuery({
-    ...backgroundConversationListOptions(assistantId!),
-    enabled: enabled && Boolean(assistantId) && canQuery,
-  });
-  return {
-    conversations: query.data?.conversations ?? EMPTY_CONVERSATIONS,
-    isLoading: query.isLoading,
-    isPending: query.isPending,
-    isError: query.isError,
-    refetch: () => {
-      void query.refetch();
-    },
-  };
+): ConversationListQueryResult {
+  return useListQuery(assistantId, BACKGROUND_FILTER, enabled);
 }
 
 /**
- * Subscribe to the scheduled conversation list for the given assistant.
- * Cached separately under `scheduledConversationsQueryKey` so revealing the
- * Scheduled section fetches only scheduled jobs, independently of the
- * background backlog.
- *
- * `enabled` gates the network fetch on whether the user has revealed the
- * Scheduled sidebar section. Passing `enabled: false` keeps the observer
- * subscribed to cache updates without firing a request — mirroring the
- * background hook so attention tracking reflects scheduled rows once loaded
- * without triggering the fetch itself.
+ * The scheduled conversation list, its own cache so revealing the Scheduled
+ * section fetches only scheduled jobs, independently of the background
+ * backlog.
  */
 export function useScheduledConversationListQuery(
   assistantId: string | null,
   enabled: boolean = true,
-): {
-  conversations: Conversation[];
-  isLoading: boolean;
-  isPending: boolean;
-  isError: boolean;
-  refetch: () => void;
-} {
-  const canQuery = useCanQueryDaemon(assistantId);
-  const query = useQuery({
-    ...scheduledConversationListOptions(assistantId!),
-    enabled: enabled && Boolean(assistantId) && canQuery,
-  });
-  return {
-    conversations: query.data?.conversations ?? EMPTY_CONVERSATIONS,
-    isLoading: query.isLoading,
-    isPending: query.isPending,
-    isError: query.isError,
-    refetch: () => {
-      void query.refetch();
-    },
-  };
+): ConversationListQueryResult {
+  return useListQuery(assistantId, SCHEDULED_FILTER, enabled);
 }
 
 /**
- * Subscribe to one sidebar section's conversations.
+ * One sidebar section's conversations (a group and/or channel filter).
  *
  * Each section mounts its own instance, so its contents come from the server
  * rather than from filtering another section's list. That is what lets a
  * pinned conversation appear in Pinned even when it sorts many pages deep in
  * the full list.
- *
- * `enabled` gates the network fetch; passing `false` keeps the observer
- * subscribed to cache updates without firing a request.
- *
- * `hasData` rather than `isError` is what a section should branch on when
- * deciding whether to trust this result. The two are not complements: React
- * Query keeps the last successful data when a later refetch fails, so an
- * errored query can still be holding the section's real rows, and treating
- * `isError` as "unusable" would swap them for a worse list. `hasData` is
- * false in exactly the cases with nothing to show - never fetched, still
- * pending, or failed before it ever succeeded.
  */
 export function useSectionConversationListQuery(
   assistantId: string | null,
-  filter: SectionConversationFilter,
+  filter: ConversationListFilter,
   enabled: boolean = true,
-): {
-  conversations: Conversation[];
-  isLoading: boolean;
-  isPending: boolean;
-  isError: boolean;
-  /** Whether the query has ever resolved; survives a failed refetch. */
-  hasData: boolean;
-  /**
-   * Whether the server holds rows past this window (LUM-2444). `false`
-   * until the query resolves, so nothing offers a load-more for a section
-   * that has not answered once.
-   */
-  hasMore: boolean;
-} {
-  const canQuery = useCanQueryDaemon(assistantId);
-  const query = useQuery({
-    ...sectionConversationListOptions(assistantId!, filter),
-    enabled: enabled && Boolean(assistantId) && canQuery,
-  });
+): ConversationListQueryResult {
+  return useListQuery(assistantId, filter, enabled);
+}
+
+/**
+ * The archived conversations of every type, newest-archived first.
+ *
+ * Two caches, merged here: the daemon's `conversationType` defaults to
+ * standard and has no "all", so archived background rows are a second read
+ * ({@link ARCHIVED_BACKGROUND_FILTER}). Either failing is the whole list
+ * failing: this is presented as the complete set, and an archived row that
+ * looks gone is worse than an error with a retry.
+ */
+export function useArchivedConversationListQuery(
+  assistantId: string | null,
+  enabled: boolean = true,
+): ConversationListQueryResult {
+  const foreground = useListQuery(assistantId, ARCHIVED_FILTER, enabled);
+  const background = useListQuery(
+    assistantId,
+    ARCHIVED_BACKGROUND_FILTER,
+    enabled,
+  );
+  const conversations = useMemo(() => {
+    const merged = mergeConversationLists(
+      foreground.conversations,
+      background.conversations,
+    );
+    return merged === foreground.conversations
+      ? merged
+      : [...merged].sort(byTimestampDesc("archivedAt"));
+  }, [foreground.conversations, background.conversations]);
   return {
-    conversations: query.data?.conversations ?? EMPTY_CONVERSATIONS,
-    isLoading: query.isLoading,
-    isPending: query.isPending,
-    isError: query.isError,
-    hasData: query.data !== undefined,
-    hasMore: query.data?.hasMore ?? false,
+    conversations,
+    isLoading: foreground.isLoading || background.isLoading,
+    isPending: foreground.isPending || background.isPending,
+    isError: foreground.isError || background.isError,
+    error: foreground.error ?? background.error,
+    hasData: foreground.hasData && background.hasData,
+    hasMore: false,
+    refetch: () => {
+      foreground.refetch();
+      background.refetch();
+    },
   };
 }
 
@@ -335,43 +327,6 @@ export function useUnreadConversationCount(
     [fallbackConversations],
   );
   return Math.max(0, serverCount ?? derivedCount);
-}
-
-/**
- * Subscribe to the archived conversation list for the given assistant. The
- * cache lives under a separate query key (`archivedConversationsQueryKey`)
- * so that mutations to the active list don't refetch the archive view and
- * vice versa.
- *
- * Returns an empty array until the query resolves so consumers can render
- * an empty state without null-checking.
- */
-export function useArchivedConversationListQuery(
-  assistantId: string | null,
-  enabled: boolean = true,
-): {
-  conversations: Conversation[];
-  isLoading: boolean;
-  isPending: boolean;
-  isError: boolean;
-  error: Error | null;
-  refetch: () => void;
-} {
-  const canQuery = useCanQueryDaemon(assistantId);
-  const query = useQuery({
-    ...archivedConversationListOptions(assistantId!),
-    enabled: enabled && Boolean(assistantId) && canQuery,
-  });
-  return {
-    conversations: query.data?.conversations ?? EMPTY_CONVERSATIONS,
-    isLoading: query.isLoading,
-    isPending: query.isPending,
-    isError: query.isError,
-    error: query.error,
-    refetch: () => {
-      void query.refetch();
-    },
-  };
 }
 
 /**

--- a/clients/web/src/hooks/use-conversation-sync.test.tsx
+++ b/clients/web/src/hooks/use-conversation-sync.test.tsx
@@ -2,8 +2,10 @@ import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
   hashKey,
+  matchQuery,
   QueryClient,
   QueryClientProvider,
+  type QueryFilters,
 } from "@tanstack/react-query";
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
 
@@ -15,6 +17,7 @@ import {
   type ConversationListPage,
 } from "@/utils/conversation-list-fetchers";
 import {
+  ARCHIVED_FILTER,
   conversationListQueryKey,
   isConversationListKey,
   isSectionFilter,
@@ -405,12 +408,23 @@ describe("useConversationSync", () => {
         return key?._id === (expectedGroupsKey as Record<string, unknown>)._id;
       },
     );
-    const archivedCalls = (
-      spy.mock.calls as unknown as Array<[unknown]>
-    ).filter((call) => {
-      const arg = call[0] as { queryKey: readonly unknown[] } | undefined;
-      return arg?.queryKey?.[2] === "archived";
+    /* The archived lists are invalidated through a prefix + predicate
+       filter, so the assertion runs TanStack's real matcher against a real
+       archived query and a real foreground query. */
+    const archivedQuery = queryClient.getQueryCache().build(queryClient, {
+      queryKey: conversationListQueryKey("asst-1", ARCHIVED_FILTER),
     });
+    const foregroundQuery = queryClient
+      .getQueryCache()
+      .build(queryClient, { queryKey: conversationListQueryKey("asst-1") });
+    const archivedCalls = (
+      spy.mock.calls as unknown as Array<[QueryFilters | undefined]>
+    ).filter(
+      (call) =>
+        call[0] !== undefined &&
+        matchQuery(call[0], archivedQuery) &&
+        !matchQuery(call[0], foregroundQuery),
+    );
     expect(groupsCalls.length).toBe(1);
     expect(archivedCalls.length).toBe(1);
   });

--- a/clients/web/src/hooks/use-conversation-sync.test.tsx
+++ b/clients/web/src/hooks/use-conversation-sync.test.tsx
@@ -23,7 +23,7 @@ import {
   isSectionFilter,
   type ConversationListFilter,
 } from "@/utils/conversation-list-keys";
-import { listPage } from "@/utils/conversation-list.test-helper";
+import { listPage, queryFor } from "@/utils/conversation-list.test-helper";
 import { SYNC_TAGS, type SyncChangedEvent } from "@/lib/sync/types";
 import { __resetForTesting, publish } from "@/lib/event-bus";
 
@@ -411,12 +411,14 @@ describe("useConversationSync", () => {
     /* The archived lists are invalidated through a prefix + predicate
        filter, so the assertion runs TanStack's real matcher against a real
        archived query and a real foreground query. */
-    const archivedQuery = queryClient.getQueryCache().build(queryClient, {
-      queryKey: conversationListQueryKey("asst-1", ARCHIVED_FILTER),
-    });
-    const foregroundQuery = queryClient
-      .getQueryCache()
-      .build(queryClient, { queryKey: conversationListQueryKey("asst-1") });
+    const archivedQuery = queryFor(
+      conversationListQueryKey("asst-1", ARCHIVED_FILTER),
+      queryClient,
+    );
+    const foregroundQuery = queryFor(
+      conversationListQueryKey("asst-1"),
+      queryClient,
+    );
     const archivedCalls = (
       spy.mock.calls as unknown as Array<[QueryFilters | undefined]>
     ).filter(

--- a/clients/web/src/hooks/use-conversation-sync.test.tsx
+++ b/clients/web/src/hooks/use-conversation-sync.test.tsx
@@ -1,16 +1,25 @@
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  hashKey,
+  QueryClient,
+  QueryClientProvider,
+} from "@tanstack/react-query";
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
 
 import type { AssistantEventEnvelope } from "@vellumai/assistant-api";
 import type { Conversation } from "@/types/conversation-types";
 import { groupsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
 import {
-  conversationsQueryKey,
   unreadConversationCountQueryKey,
   type ConversationListPage,
 } from "@/utils/conversation-list-fetchers";
+import {
+  conversationListQueryKey,
+  isConversationListKey,
+  isSectionFilter,
+  type ConversationListFilter,
+} from "@/utils/conversation-list-keys";
 import { listPage } from "@/utils/conversation-list.test-helper";
 import { SYNC_TAGS, type SyncChangedEvent } from "@/lib/sync/types";
 import { __resetForTesting, publish } from "@/lib/event-bus";
@@ -70,18 +79,23 @@ let listFirstPageImpl: (
 });
 const listFirstPageCalls: Array<{ bucket: string; assistantId: string }> = [];
 
-function recordFirstPage(bucket: string) {
-  return (assistantId: string) => {
-    listFirstPageCalls.push({ bucket, assistantId });
-    return listFirstPageImpl(bucket, assistantId);
-  };
+/** The bucket a list filter names, so the call log stays readable. */
+function bucketOf(filter: ConversationListFilter): string {
+  return isSectionFilter(filter)
+    ? "section"
+    : (filter.conversationType ?? "foreground");
 }
 
 mock.module("@/utils/conversation-list-fetchers", () => ({
   ...realListFetchersModule,
-  listConversationsFirstPage: recordFirstPage("foreground"),
-  listBackgroundConversationsFirstPage: recordFirstPage("background"),
-  listScheduledConversationsFirstPage: recordFirstPage("scheduled"),
+  listConversationsFirstPage: (
+    assistantId: string,
+    filter: ConversationListFilter = {},
+  ) => {
+    const bucket = bucketOf(filter);
+    listFirstPageCalls.push({ bucket, assistantId });
+    return listFirstPageImpl(bucket, assistantId);
+  },
 }));
 
 const { useConversationSync } = await import("@/hooks/use-conversation-sync");
@@ -162,7 +176,7 @@ describe("useConversationSync", () => {
 
   test("debounces conversations:list signals into one first-page window refresh", async () => {
     const queryClient = freshQueryClient();
-    queryClient.setQueryData(conversationsQueryKey("asst-1"), listPage([]));
+    queryClient.setQueryData(conversationListQueryKey("asst-1"), listPage([]));
     const spy = mock(() => Promise.resolve());
     queryClient.invalidateQueries = spy as never;
     renderHook(() => useConversationSync("asst-1", true), {
@@ -185,7 +199,10 @@ describe("useConversationSync", () => {
       spy.mock.calls as unknown as Array<[unknown]>
     ).filter((call) => {
       const arg = call[0] as { queryKey: readonly unknown[] } | undefined;
-      return arg?.queryKey?.[2] === "foreground";
+      return (
+        arg?.queryKey !== undefined &&
+        hashKey(arg.queryKey) === hashKey(conversationListQueryKey("asst-1"))
+      );
     });
     expect(foregroundCalls.length).toBe(0);
   });
@@ -193,7 +210,7 @@ describe("useConversationSync", () => {
   test("merges the fetched first page into the cached foreground window", async () => {
     const queryClient = freshQueryClient();
     queryClient.setQueryData(
-      conversationsQueryKey("asst-1"),
+      conversationListQueryKey("asst-1"),
       listPage([
         { conversationId: "conv-new", title: "Recent", lastMessageAt: 5000 },
         // Inside the fresh window (>= its oldest row) but missing from the
@@ -233,7 +250,7 @@ describe("useConversationSync", () => {
     emit(syncEvent([SYNC_TAGS.conversationsList]));
     await waitFor(() => {
       const list = queryClient.getQueryData<ConversationListPage>(
-        conversationsQueryKey("asst-1"),
+        conversationListQueryKey("asst-1"),
       )!.conversations;
       expect(list.map((c) => c.conversationId)).toEqual([
         "conv-new",
@@ -247,7 +264,7 @@ describe("useConversationSync", () => {
   test("per-conversation metadata tags GET-and-patch the cached row (no list refetch)", async () => {
     const queryClient = freshQueryClient();
     queryClient.setQueryData(
-      conversationsQueryKey("asst-1"),
+      conversationListQueryKey("asst-1"),
       listPage([
         {
           conversationId: "conv-1",
@@ -282,7 +299,7 @@ describe("useConversationSync", () => {
 
     await waitFor(() => {
       const list = queryClient.getQueryData<ConversationListPage>(
-        conversationsQueryKey("asst-1"),
+        conversationListQueryKey("asst-1"),
       )!.conversations;
       const conv1 = list.find((c) => c.conversationId === "conv-1");
       expect(conv1?.hasUnseenLatestAssistantMessage).toBe(false);
@@ -296,7 +313,7 @@ describe("useConversationSync", () => {
 
     // Untouched row stays untouched.
     const listAfter = queryClient.getQueryData<ConversationListPage>(
-      conversationsQueryKey("asst-1"),
+      conversationListQueryKey("asst-1"),
     )!.conversations;
     const conv2 = listAfter.find((c) => c.conversationId === "conv-2");
     expect(conv2?.hasUnseenLatestAssistantMessage).toBe(true);
@@ -306,7 +323,10 @@ describe("useConversationSync", () => {
       invalidateSpy.mock.calls as unknown as Array<[unknown]>
     ).filter((call) => {
       const arg = call[0] as { queryKey: readonly unknown[] } | undefined;
-      return arg?.queryKey?.[0] === conversationsQueryKey("asst-1")[0];
+      return (
+        arg?.queryKey !== undefined &&
+        isConversationListKey(arg.queryKey, "asst-1")
+      );
     });
     expect(listCalls.length).toBe(0);
   });
@@ -314,7 +334,7 @@ describe("useConversationSync", () => {
   test("per-conversation metadata tag handles a 404 (deleted-by-other-client) by removing the row", async () => {
     const queryClient = freshQueryClient();
     queryClient.setQueryData(
-      conversationsQueryKey("asst-1"),
+      conversationListQueryKey("asst-1"),
       listPage([
         { conversationId: "conv-1", title: "Tombstone" },
         { conversationId: "conv-2", title: "Survivor" },
@@ -331,7 +351,7 @@ describe("useConversationSync", () => {
 
     await waitFor(() => {
       const list = queryClient.getQueryData<ConversationListPage>(
-        conversationsQueryKey("asst-1"),
+        conversationListQueryKey("asst-1"),
       )!.conversations;
       expect(list.some((c) => c.conversationId === "conv-1")).toBe(false);
       expect(list.some((c) => c.conversationId === "conv-2")).toBe(true);
@@ -352,7 +372,10 @@ describe("useConversationSync", () => {
     const listCalls = (spy.mock.calls as unknown as Array<[unknown]>).filter(
       (call) => {
         const arg = call[0] as { queryKey: readonly unknown[] } | undefined;
-        return arg?.queryKey?.[0] === conversationsQueryKey("asst-1")[0];
+        return (
+          arg?.queryKey !== undefined &&
+          isConversationListKey(arg.queryKey, "asst-1")
+        );
       },
     );
     expect(listCalls.length).toBe(0);
@@ -360,7 +383,7 @@ describe("useConversationSync", () => {
 
   test("refreshes the list window on sse.opened reconnect (debounced)", async () => {
     const queryClient = freshQueryClient();
-    queryClient.setQueryData(conversationsQueryKey("asst-1"), listPage([]));
+    queryClient.setQueryData(conversationListQueryKey("asst-1"), listPage([]));
     const spy = mock(() => Promise.resolve());
     queryClient.invalidateQueries = spy as never;
     renderHook(() => useConversationSync("asst-1", true), {
@@ -394,7 +417,7 @@ describe("useConversationSync", () => {
 
   test("does NOT refresh on sse.opened (cause=fresh)", async () => {
     const queryClient = freshQueryClient();
-    queryClient.setQueryData(conversationsQueryKey("asst-1"), listPage([]));
+    queryClient.setQueryData(conversationListQueryKey("asst-1"), listPage([]));
     const spy = mock(() => Promise.resolve());
     queryClient.invalidateQueries = spy as never;
     renderHook(() => useConversationSync("asst-1", true), {
@@ -465,7 +488,7 @@ describe("useConversationSync", () => {
   test("patches conversation title in cache on conversation_title_updated", async () => {
     const queryClient = freshQueryClient();
     queryClient.setQueryData<ConversationListPage>(
-      conversationsQueryKey("asst-1"),
+      conversationListQueryKey("asst-1"),
       listPage([
         { conversationId: "conv-1", title: "Old Title" } as Conversation,
       ]),
@@ -485,7 +508,7 @@ describe("useConversationSync", () => {
     } as AssistantEventEnvelope);
     await waitFor(() => {
       const cached = queryClient.getQueryData<ConversationListPage>(
-        conversationsQueryKey("asst-1"),
+        conversationListQueryKey("asst-1"),
       )?.conversations;
       const conv = cached?.find((c) => c.conversationId === "conv-1");
       expect(conv?.title).toBe("New Title");

--- a/clients/web/src/hooks/use-conversation-sync.ts
+++ b/clients/web/src/hooks/use-conversation-sync.ts
@@ -35,10 +35,10 @@ import { createConcurrencyLimiter } from "@/utils/concurrency-limiter";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { groupsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
 import {
-  archivedConversationsQueryKey,
   sidebarSectionsQueryKey,
   unreadConversationCountQueryKey,
 } from "@/utils/conversation-list-fetchers";
+import { conversationListQueryFilter } from "@/utils/conversation-list-keys";
 import { getClientId } from "@/lib/telemetry/client-identity";
 import {
   parseConversationSyncTag,
@@ -206,13 +206,16 @@ function scheduleConversationListRefetch(
         });
       },
     );
-    // The archive list stays on plain invalidation: it also drains, but
-    // its query is mounted only while the archive view is open, and
-    // invalidation refetches active queries alone. Groups are a single
-    // unpaginated GET.
-    void queryClient.invalidateQueries({
-      queryKey: archivedConversationsQueryKey(assistantId),
-    });
+    // The archived lists stay on plain invalidation: they order by
+    // `archivedAt` while the window refresh merges on a recency axis, and
+    // they are mounted only while the archive view is open, so invalidation
+    // refetches nothing until then. Groups are a single unpaginated GET.
+    void queryClient.invalidateQueries(
+      conversationListQueryFilter(
+        assistantId,
+        (filter) => filter.archiveStatus === "archived",
+      ),
+    );
     void queryClient.invalidateQueries({
       queryKey: groupsGetQueryKey({
         path: { assistant_id: assistantId ?? "" },

--- a/clients/web/src/hooks/use-conversation-sync.ts
+++ b/clients/web/src/hooks/use-conversation-sync.ts
@@ -38,7 +38,10 @@ import {
   sidebarSectionsQueryKey,
   unreadConversationCountQueryKey,
 } from "@/utils/conversation-list-fetchers";
-import { conversationListQueryFilter } from "@/utils/conversation-list-keys";
+import {
+  conversationListQueryFilter,
+  isArchivedFilter,
+} from "@/utils/conversation-list-keys";
 import { getClientId } from "@/lib/telemetry/client-identity";
 import {
   parseConversationSyncTag,
@@ -211,10 +214,7 @@ function scheduleConversationListRefetch(
     // they are mounted only while the archive view is open, so invalidation
     // refetches nothing until then. Groups are a single unpaginated GET.
     void queryClient.invalidateQueries(
-      conversationListQueryFilter(
-        assistantId,
-        (filter) => filter.archiveStatus === "archived",
-      ),
+      conversationListQueryFilter(assistantId, isArchivedFilter),
     );
     void queryClient.invalidateQueries({
       queryKey: groupsGetQueryKey({

--- a/clients/web/src/lib/backwards-compat/conversation-processing-state.test.ts
+++ b/clients/web/src/lib/backwards-compat/conversation-processing-state.test.ts
@@ -4,7 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, cleanup, renderHook } from "@testing-library/react";
 
 import { useActiveConversationIsProcessing } from "@/lib/backwards-compat/conversation-processing-state";
-import { conversationsQueryKey } from "@/utils/conversation-list-fetchers";
+import { conversationListQueryKey } from "@/utils/conversation-list-keys";
 import { listPage } from "@/utils/conversation-list.test-helper";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { useConversationStore } from "@/stores/conversation-store";
@@ -48,7 +48,7 @@ async function isProcessing(inputs: {
     defaultOptions: { queries: { retry: false } },
   });
   queryClient.setQueryData(
-    conversationsQueryKey(ASSISTANT_ID),
+    conversationListQueryKey(ASSISTANT_ID),
     listPage([
       {
         conversationId: CONVERSATION_ID,

--- a/clients/web/src/utils/conversation-cache-mutations.test.ts
+++ b/clients/web/src/utils/conversation-cache-mutations.test.ts
@@ -7,14 +7,16 @@ import type {
 } from "@/types/conversation-types";
 import type { GroupsGetResponse } from "@/generated/daemon/types.gen";
 import {
-  conversationsQueryKey,
-  backgroundConversationsQueryKey,
-  scheduledConversationsQueryKey,
-  archivedConversationsQueryKey,
   sidebarSectionsQueryKey,
   type ConversationListPage,
   type SidebarIndexSection,
 } from "@/utils/conversation-list-fetchers";
+import {
+  ARCHIVED_FILTER,
+  BACKGROUND_FILTER,
+  conversationListQueryKey,
+  SCHEDULED_FILTER,
+} from "@/utils/conversation-list-keys";
 import { listPage } from "@/utils/conversation-list.test-helper";
 import { groupsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
 
@@ -63,26 +65,29 @@ function makeGroup(
 }
 
 function seedForeground(qc: QueryClient, conversations: Conversation[]) {
-  qc.setQueryData(conversationsQueryKey(ASSISTANT_ID), listPage(conversations));
+  qc.setQueryData(
+    conversationListQueryKey(ASSISTANT_ID),
+    listPage(conversations),
+  );
 }
 
 function seedBackground(qc: QueryClient, conversations: Conversation[]) {
   qc.setQueryData(
-    backgroundConversationsQueryKey(ASSISTANT_ID),
+    conversationListQueryKey(ASSISTANT_ID, BACKGROUND_FILTER),
     listPage(conversations),
   );
 }
 
 function seedScheduled(qc: QueryClient, conversations: Conversation[]) {
   qc.setQueryData(
-    scheduledConversationsQueryKey(ASSISTANT_ID),
+    conversationListQueryKey(ASSISTANT_ID, SCHEDULED_FILTER),
     listPage(conversations),
   );
 }
 
 function seedArchived(qc: QueryClient, conversations: Conversation[]) {
   qc.setQueryData(
-    archivedConversationsQueryKey(ASSISTANT_ID),
+    conversationListQueryKey(ASSISTANT_ID, ARCHIVED_FILTER),
     listPage(conversations),
   );
 }
@@ -96,15 +101,16 @@ function seedGroups(qc: QueryClient, groups: ConversationGroup[]) {
 
 function getForeground(qc: QueryClient): Conversation[] {
   return (
-    qc.getQueryData<ConversationListPage>(conversationsQueryKey(ASSISTANT_ID))
-      ?.conversations ?? []
+    qc.getQueryData<ConversationListPage>(
+      conversationListQueryKey(ASSISTANT_ID),
+    )?.conversations ?? []
   );
 }
 
 function getBackground(qc: QueryClient): Conversation[] {
   return (
     qc.getQueryData<ConversationListPage>(
-      backgroundConversationsQueryKey(ASSISTANT_ID),
+      conversationListQueryKey(ASSISTANT_ID, BACKGROUND_FILTER),
     )?.conversations ?? []
   );
 }
@@ -112,7 +118,7 @@ function getBackground(qc: QueryClient): Conversation[] {
 function getScheduled(qc: QueryClient): Conversation[] {
   return (
     qc.getQueryData<ConversationListPage>(
-      scheduledConversationsQueryKey(ASSISTANT_ID),
+      conversationListQueryKey(ASSISTANT_ID, SCHEDULED_FILTER),
     )?.conversations ?? []
   );
 }
@@ -120,7 +126,7 @@ function getScheduled(qc: QueryClient): Conversation[] {
 function getArchived(qc: QueryClient): Conversation[] {
   return (
     qc.getQueryData<ConversationListPage>(
-      archivedConversationsQueryKey(ASSISTANT_ID),
+      conversationListQueryKey(ASSISTANT_ID, ARCHIVED_FILTER),
     )?.conversations ?? []
   );
 }
@@ -1089,14 +1095,11 @@ describe("applySurfacedConversation", () => {
       conversationType: "background",
     });
     seedBackground(qc, [bg]);
-    // Chats section contents cache: {groupId: system:all, no channel}.
-    const chatsKey = [
-      "conversation-list",
-      ASSISTANT_ID,
-      "section",
-      "system:all",
-      "vellum",
-    ] as const;
+    // Chats section contents cache: {groupId: system:all, channel: vellum}.
+    const chatsKey = conversationListQueryKey(ASSISTANT_ID, {
+      groupId: "system:all",
+      originChannel: "vellum",
+    });
     qc.setQueryData(chatsKey, listPage([]));
 
     applySurfacedConversation(qc, ASSISTANT_ID, bg, 4242);

--- a/clients/web/src/utils/conversation-cache-mutations.ts
+++ b/clients/web/src/utils/conversation-cache-mutations.ts
@@ -2,7 +2,7 @@
  * Domain-level cache mutation helpers for conversations and groups.
  *
  * Each function is a thin `queryClient.setQueryData` wrapper so call sites
- * stay declarative. Low-level cache primitives (`updateConversationsCache`,
+ * stay declarative. Low-level cache primitives (`updateConversationListCache`,
  * `findConversation`, `patchConversation`) live in `@/utils/conversation-cache`.
  *
  * References:
@@ -31,30 +31,26 @@ import {
   findConversation,
   patchConversation,
   updateAllConversationCaches,
-  updateBackgroundConversationsCache,
-  updateConversationsCache,
-  updateScheduledConversationsCache,
+  updateConversationListCache,
 } from "@/utils/conversation-cache";
 import {
-  backgroundConversationsQueryKey,
-  conversationsQueryKey,
-  parseSectionConversationsQueryKey,
-  scheduledConversationsQueryKey,
-  sectionListPrefix,
+  type ConversationListPage,
+  type SidebarIndexSection,
+  listConversationsFirstPage,
+  listConversationsPage,
   sidebarSectionsQueryKey,
   unreadConversationCountQueryKey,
-  type SidebarIndexSection,
 } from "@/utils/conversation-list-fetchers";
 import {
-  type ConversationListPage,
-  type SectionConversationFilter,
-  listBackgroundConversationsFirstPage,
-  listConversationsFirstPage,
-  listScheduledConversationsFirstPage,
-  listSectionConversationsFirstPage,
-  listSectionConversationsPage,
-  sectionConversationsQueryKey,
-} from "@/utils/conversation-list-fetchers";
+  BACKGROUND_FILTER,
+  type ConversationListFilter,
+  conversationListFilterOf,
+  conversationListPrefix,
+  conversationListQueryKey,
+  FOREGROUND_FILTER,
+  isPinnedInjectedFilter,
+  SCHEDULED_FILTER,
+} from "@/utils/conversation-list-keys";
 import {
   ConversationNotFoundError,
   fetchConversationDetail,
@@ -179,7 +175,7 @@ export function prependConversation(
   assistantId: string | null,
   conversation: Conversation,
 ): void {
-  updateConversationsCache(queryClient, assistantId, (conversations) => [
+  updateConversationListCache(queryClient, assistantId, FOREGROUND_FILTER, (conversations) => [
     conversation,
     ...conversations,
   ]);
@@ -257,7 +253,7 @@ export function applySurfacedConversation(
     findConversation(queryClient, assistantId, conversation.conversationId) ??
     conversation;
   const surfaced: Conversation = { ...latest, surfacedAt };
-  updateConversationsCache(queryClient, assistantId, (conversations) =>
+  updateConversationListCache(queryClient, assistantId, FOREGROUND_FILTER, (conversations) =>
     conversations.some((c) => c.conversationId === conversation.conversationId)
       ? conversations
       : insertByRecency(conversations, surfaced),
@@ -293,7 +289,7 @@ export function surfaceConversationInCaches(
     return changed ? next : conversations;
   });
 
-  updateConversationsCache(queryClient, assistantId, (conversations) => [
+  updateConversationListCache(queryClient, assistantId, FOREGROUND_FILTER, (conversations) => [
     surfacedConversation,
     ...conversations.filter(
       (c) => c.conversationId !== conversation.conversationId,
@@ -371,53 +367,46 @@ export async function refreshConversationRow(
   }
 
   if (isScheduledConversation(result)) {
-    updateScheduledConversationsCache(
+    updateConversationListCache(
       queryClient,
       assistantId,
+      SCHEDULED_FILTER,
       (conversations) => [...conversations, result],
     );
     return;
   }
   if (isBackgroundConversation(result)) {
-    updateBackgroundConversationsCache(
+    updateConversationListCache(
       queryClient,
       assistantId,
+      BACKGROUND_FILTER,
       (conversations) => [...conversations, result],
     );
     return;
   }
-  updateConversationsCache(queryClient, assistantId, (conversations) => [
+  updateConversationListCache(queryClient, assistantId, FOREGROUND_FILTER, (conversations) => [
     ...conversations,
     result,
   ]);
 }
 
-const LIST_WINDOW_BUCKETS = [
-  {
-    queryKey: conversationsQueryKey,
-    fetchFirstPage: listConversationsFirstPage,
-  },
-  {
-    queryKey: backgroundConversationsQueryKey,
-    fetchFirstPage: listBackgroundConversationsFirstPage,
-  },
-  {
-    queryKey: scheduledConversationsQueryKey,
-    fetchFirstPage: listScheduledConversationsFirstPage,
-  },
-] as const;
-
 /**
  * Refresh the top window of every populated conversation-list cache with a
  * single first-page GET per cache, merging via {@link mergeListFirstPage}.
  *
- * Covers the three static buckets AND every populated per-section cache,
- * discovered through the section key prefix and decoded back to the filter
- * each was fetched with. A section cache is a *window* (LUM-2444): its
- * plain refetch is one first-page GET, but that refetch would also replace
- * the whole window with page one, throwing away every load-more page the
- * user scrolled in. Merging here keeps the loaded window and refreshes its
- * top, so a signal costs one request per cache and loses nothing.
+ * Covers every tracked list cache, bucket or section, discovered through
+ * the list prefix and read back to the filter each was fetched with (the
+ * filter is the key's `query`). A section cache is a *window* (LUM-2444):
+ * its plain refetch is one first-page GET, but that refetch would also
+ * replace the whole window with page one, throwing away every load-more
+ * page the user scrolled in. Merging here keeps the loaded window and
+ * refreshes its top, so a signal costs one request per cache and loses
+ * nothing.
+ *
+ * The archived caches are the exception and stay on plain invalidation
+ * (`use-conversation-sync.ts`): they are ordered by `archivedAt`, while
+ * every daemon page is recency-ordered and the merge's window cutoff is a
+ * recency axis, so a merged archived list would come out mis-ordered.
  *
  * Drives the `conversationsList` sync-tag and SSE-reconnect handlers in
  * `use-conversation-sync.ts`. The full list query drains every page
@@ -488,39 +477,23 @@ export async function refreshConversationListWindows(
     );
   };
 
-  const bucketRefreshes = LIST_WINDOW_BUCKETS.map(async (bucket) => {
-    const queryKey = bucket.queryKey(assistantId);
-    const state = queryClient.getQueryState<ConversationListPage>(queryKey);
-    if (!state) {
-      return;
-    }
-    await refresh(
-      queryKey,
-      state.fetchStatus,
-      () => bucket.fetchFirstPage(assistantId),
-      /* The one request the daemon appends pinned rows to is the unfiltered
-         foreground list; see mergeListFirstPage. */
-      bucket.queryKey === conversationsQueryKey,
-    );
-  });
-
-  const sectionRefreshes = queryClient
+  const refreshes = queryClient
     .getQueryCache()
-    .findAll({ queryKey: sectionListPrefix(assistantId) })
+    .findAll({ queryKey: conversationListPrefix(assistantId) })
     .map(async (query) => {
-      const filter = parseSectionConversationsQueryKey(query.queryKey);
-      if (!filter) {
+      const filter = conversationListFilterOf(query.queryKey);
+      if (!filter || filter.archiveStatus === "archived") {
         return;
       }
       await refresh(
         query.queryKey,
         query.state.fetchStatus,
-        () => listSectionConversationsFirstPage(assistantId, filter),
-        false,
+        () => listConversationsFirstPage(assistantId, filter),
+        isPinnedInjectedFilter(filter),
       );
     });
 
-  await Promise.all([...bucketRefreshes, ...sectionRefreshes]);
+  await Promise.all(refreshes);
 }
 
 export function resolveDraftKey(
@@ -529,7 +502,7 @@ export function resolveDraftKey(
   oldKey: string,
   newKey: string,
 ): void {
-  updateConversationsCache(queryClient, assistantId, (conversations) => {
+  updateConversationListCache(queryClient, assistantId, FOREGROUND_FILTER, (conversations) => {
     let changed = false;
     const next = conversations.map((c) => {
       if (c.conversationId !== oldKey) {
@@ -662,10 +635,10 @@ export function deleteGroupAndResetConversations(
  * would need a per-offset query key for a page that is appended into
  * another key's cache rather than owned by its own.
  */
-const sectionLoadsInFlight = new Set<string>();
+const loadsInFlight = new Set<string>();
 
 /**
- * Extend a windowed section cache by one page.
+ * Extend a windowed list cache by one page.
  *
  * The offset is the cache's current row count at request time, not a stored
  * cursor: optimistic writes add and remove rows, and a frozen cursor would
@@ -682,23 +655,23 @@ const sectionLoadsInFlight = new Set<string>();
  *
  * No-op when the cache is absent (nothing to extend) or already complete.
  */
-export async function loadMoreSectionConversations(
+export async function loadMoreConversations(
   queryClient: QueryClient,
   assistantId: string,
-  filter: SectionConversationFilter,
+  filter: ConversationListFilter,
 ): Promise<void> {
-  const queryKey = sectionConversationsQueryKey(assistantId, filter);
+  const queryKey = conversationListQueryKey(assistantId, filter);
   const guardKey = hashKey(queryKey);
-  if (sectionLoadsInFlight.has(guardKey)) {
+  if (loadsInFlight.has(guardKey)) {
     return;
   }
   const before = queryClient.getQueryData<ConversationListPage>(queryKey);
   if (!before || !before.hasMore) {
     return;
   }
-  sectionLoadsInFlight.add(guardKey);
+  loadsInFlight.add(guardKey);
   try {
-    const page = await listSectionConversationsPage(
+    const page = await listConversationsPage(
       assistantId,
       filter,
       before.conversations.length,
@@ -713,6 +686,6 @@ export async function loadMoreSectionConversations(
       hasMore: page.hasMore,
     });
   } finally {
-    sectionLoadsInFlight.delete(guardKey);
+    loadsInFlight.delete(guardKey);
   }
 }

--- a/clients/web/src/utils/conversation-cache-mutations.ts
+++ b/clients/web/src/utils/conversation-cache-mutations.ts
@@ -48,6 +48,7 @@ import {
   conversationListPrefix,
   conversationListQueryKey,
   FOREGROUND_FILTER,
+  isArchivedFilter,
   isPinnedInjectedFilter,
   SCHEDULED_FILTER,
 } from "@/utils/conversation-list-keys";
@@ -175,10 +176,12 @@ export function prependConversation(
   assistantId: string | null,
   conversation: Conversation,
 ): void {
-  updateConversationListCache(queryClient, assistantId, FOREGROUND_FILTER, (conversations) => [
-    conversation,
-    ...conversations,
-  ]);
+  updateConversationListCache(
+    queryClient,
+    assistantId,
+    FOREGROUND_FILTER,
+    (conversations) => [conversation, ...conversations],
+  );
 }
 
 export function removeConversation(
@@ -253,10 +256,16 @@ export function applySurfacedConversation(
     findConversation(queryClient, assistantId, conversation.conversationId) ??
     conversation;
   const surfaced: Conversation = { ...latest, surfacedAt };
-  updateConversationListCache(queryClient, assistantId, FOREGROUND_FILTER, (conversations) =>
-    conversations.some((c) => c.conversationId === conversation.conversationId)
-      ? conversations
-      : insertByRecency(conversations, surfaced),
+  updateConversationListCache(
+    queryClient,
+    assistantId,
+    FOREGROUND_FILTER,
+    (conversations) =>
+      conversations.some(
+        (c) => c.conversationId === conversation.conversationId,
+      )
+        ? conversations
+        : insertByRecency(conversations, surfaced),
   );
   patchConversation(queryClient, assistantId, conversation.conversationId, {
     surfacedAt,
@@ -289,12 +298,17 @@ export function surfaceConversationInCaches(
     return changed ? next : conversations;
   });
 
-  updateConversationListCache(queryClient, assistantId, FOREGROUND_FILTER, (conversations) => [
-    surfacedConversation,
-    ...conversations.filter(
-      (c) => c.conversationId !== conversation.conversationId,
-    ),
-  ]);
+  updateConversationListCache(
+    queryClient,
+    assistantId,
+    FOREGROUND_FILTER,
+    (conversations) => [
+      surfacedConversation,
+      ...conversations.filter(
+        (c) => c.conversationId !== conversation.conversationId,
+      ),
+    ],
+  );
 }
 
 /**
@@ -384,10 +398,12 @@ export async function refreshConversationRow(
     );
     return;
   }
-  updateConversationListCache(queryClient, assistantId, FOREGROUND_FILTER, (conversations) => [
-    ...conversations,
-    result,
-  ]);
+  updateConversationListCache(
+    queryClient,
+    assistantId,
+    FOREGROUND_FILTER,
+    (conversations) => [...conversations, result],
+  );
 }
 
 /**
@@ -482,7 +498,7 @@ export async function refreshConversationListWindows(
     .findAll({ queryKey: conversationListPrefix(assistantId) })
     .map(async (query) => {
       const filter = conversationListFilterOf(query.queryKey);
-      if (!filter || filter.archiveStatus === "archived") {
+      if (!filter || isArchivedFilter(filter)) {
         return;
       }
       await refresh(
@@ -502,17 +518,22 @@ export function resolveDraftKey(
   oldKey: string,
   newKey: string,
 ): void {
-  updateConversationListCache(queryClient, assistantId, FOREGROUND_FILTER, (conversations) => {
-    let changed = false;
-    const next = conversations.map((c) => {
-      if (c.conversationId !== oldKey) {
-        return c;
-      }
-      changed = true;
-      return { ...c, conversationId: newKey, draft: false };
-    });
-    return changed ? next : conversations;
-  });
+  updateConversationListCache(
+    queryClient,
+    assistantId,
+    FOREGROUND_FILTER,
+    (conversations) => {
+      let changed = false;
+      const next = conversations.map((c) => {
+        if (c.conversationId !== oldKey) {
+          return c;
+        }
+        changed = true;
+        return { ...c, conversationId: newKey, draft: false };
+      });
+      return changed ? next : conversations;
+    },
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/clients/web/src/utils/conversation-cache-mutations.ts
+++ b/clients/web/src/utils/conversation-cache-mutations.ts
@@ -464,7 +464,9 @@ export async function refreshConversationListWindows(
     const before = queryClient.getQueryData<ConversationListPage>(queryKey);
     if (before === undefined) {
       if (fetchStatus === "idle") {
-        await queryClient.invalidateQueries({ queryKey });
+        /* Exact: this cache alone. As a partial filter the foreground key
+           (`query: {}`) would match every list cache. */
+        await queryClient.invalidateQueries({ queryKey, exact: true });
       }
       return;
     }

--- a/clients/web/src/utils/conversation-cache-mutations.window-refresh.test.ts
+++ b/clients/web/src/utils/conversation-cache-mutations.window-refresh.test.ts
@@ -1,6 +1,6 @@
 /**
  * Tests for `refreshConversationListWindows` covering the per-section caches,
- * and for `loadMoreSectionConversations`, the windowed caches' append path.
+ * and for `loadMoreConversations`, the windowed caches' append path.
  *
  * A section cache is a window (LUM-2444): the sync path window-refreshes it
  * (one first-page GET per populated cache, merged so load-more pages
@@ -71,7 +71,7 @@ mock.module("@/utils/conversation-list-fetchers", (): typeof fetchers => ({
   },
 }));
 
-const { loadMoreSectionConversations, refreshConversationListWindows } =
+const { loadMoreConversations, refreshConversationListWindows } =
   await import("@/utils/conversation-cache-mutations");
 
 const ASSISTANT_ID = "ast-test";
@@ -354,7 +354,7 @@ describe("refreshConversationListWindows and sections", () => {
   });
 });
 
-describe("loadMoreSectionConversations", () => {
+describe("loadMoreConversations", () => {
   test("appends the next page at the cache's current row count", async () => {
     const client = reset();
     const slackKey = sectionConversationsQueryKey(ASSISTANT_ID, SLACK);
@@ -375,7 +375,7 @@ describe("loadMoreSectionConversations", () => {
       hasMore: false,
     });
 
-    await loadMoreSectionConversations(client, ASSISTANT_ID, SLACK);
+    await loadMoreConversations(client, ASSISTANT_ID, SLACK);
 
     expect(loadMoreCalls).toEqual([{ filter: SLACK, offset: 2 }]);
     expect(rowsIn(client, SLACK)).toEqual(["s1", "s2", "s3"]);
@@ -400,7 +400,7 @@ describe("loadMoreSectionConversations", () => {
       hasMore: true,
     });
 
-    await loadMoreSectionConversations(client, ASSISTANT_ID, SLACK);
+    await loadMoreConversations(client, ASSISTANT_ID, SLACK);
 
     expect(rowsIn(client, SLACK)).toEqual(["s1", "s2"]);
   });
@@ -412,8 +412,8 @@ describe("loadMoreSectionConversations", () => {
       listPage([conversation({ conversationId: "s1" })]),
     );
 
-    await loadMoreSectionConversations(client, ASSISTANT_ID, SLACK);
-    await loadMoreSectionConversations(client, ASSISTANT_ID, PINNED);
+    await loadMoreConversations(client, ASSISTANT_ID, SLACK);
+    await loadMoreConversations(client, ASSISTANT_ID, PINNED);
 
     expect(loadMoreCalls).toEqual([]);
   });
@@ -430,9 +430,9 @@ describe("loadMoreSectionConversations", () => {
         resolvePage = resolve;
       });
 
-    const first = loadMoreSectionConversations(client, ASSISTANT_ID, SLACK);
+    const first = loadMoreConversations(client, ASSISTANT_ID, SLACK);
     // The sentinel re-fires while the request is out; the guard holds.
-    const second = loadMoreSectionConversations(client, ASSISTANT_ID, SLACK);
+    const second = loadMoreConversations(client, ASSISTANT_ID, SLACK);
     resolvePage({
       conversations: [conversation({ conversationId: "s2" })],
       hasMore: false,
@@ -460,7 +460,7 @@ describe("loadMoreSectionConversations", () => {
         resolvePage = resolve;
       });
 
-    const inFlight = loadMoreSectionConversations(client, ASSISTANT_ID, SLACK);
+    const inFlight = loadMoreConversations(client, ASSISTANT_ID, SLACK);
     client.setQueryData(
       slackKey,
       listPage([conversation({ conversationId: "s2" })], true),
@@ -485,14 +485,14 @@ describe("loadMoreSectionConversations", () => {
     loadMorePages = () => Promise.reject(new Error("network down"));
 
     await expect(
-      loadMoreSectionConversations(client, ASSISTANT_ID, SLACK),
+      loadMoreConversations(client, ASSISTANT_ID, SLACK),
     ).rejects.toThrow("network down");
 
     loadMorePages = () => ({
       conversations: [conversation({ conversationId: "s2" })],
       hasMore: false,
     });
-    await loadMoreSectionConversations(client, ASSISTANT_ID, SLACK);
+    await loadMoreConversations(client, ASSISTANT_ID, SLACK);
 
     expect(rowsIn(client, SLACK)).toEqual(["s1", "s2"]);
   });

--- a/clients/web/src/utils/conversation-cache-mutations.window-refresh.test.ts
+++ b/clients/web/src/utils/conversation-cache-mutations.window-refresh.test.ts
@@ -339,6 +339,41 @@ describe("refreshConversationListWindows and sections", () => {
     expect(foregroundCalls).toBe(0);
   });
 
+  test("a failed bucket's retry invalidates that bucket alone", async () => {
+    /* The foreground key's filter is the empty object, and a key used as a
+       partial filter matches every key whose query extends it, so an inexact
+       invalidation here would refetch every section and re-drain every other
+       bucket on each sync signal while the foreground list is errored. */
+    const client = reset();
+    const foregroundKey = conversationListQueryKey(ASSISTANT_ID);
+    await client
+      .prefetchQuery({
+        queryKey: foregroundKey,
+        queryFn: () => Promise.reject(new Error("first fetch failed")),
+        retry: false,
+      })
+      .catch(() => {});
+    const pinnedKey = conversationListQueryKey(ASSISTANT_ID, PINNED);
+    client.setQueryData(
+      pinnedKey,
+      listPage([conversation({ conversationId: "p1", isPinned: true })]),
+    );
+    const backgroundKey = conversationListQueryKey(
+      ASSISTANT_ID,
+      BACKGROUND_FILTER,
+    );
+    client.setQueryData(
+      backgroundKey,
+      listPage([conversation({ conversationId: "b1" })]),
+    );
+
+    await refreshConversationListWindows(client, ASSISTANT_ID);
+
+    expect(client.getQueryState(foregroundKey)?.isInvalidated).toBe(true);
+    expect(client.getQueryState(pinnedKey)?.isInvalidated).toBe(false);
+    expect(client.getQueryState(backgroundKey)?.isInvalidated).toBe(false);
+  });
+
   test("an unpopulated bucket is skipped", async () => {
     const client = reset();
     client.setQueryData(

--- a/clients/web/src/utils/conversation-cache-mutations.window-refresh.test.ts
+++ b/clients/web/src/utils/conversation-cache-mutations.window-refresh.test.ts
@@ -20,27 +20,28 @@ import * as fetchers from "@/utils/conversation-list-fetchers";
 import type { Conversation } from "@/types/conversation-types";
 import { listPage } from "@/utils/conversation-list.test-helper";
 import {
-  backgroundConversationsQueryKey,
-  conversationsQueryKey,
-  sectionConversationsQueryKey,
-  type SectionConversationFilter,
-} from "@/utils/conversation-list-fetchers";
+  BACKGROUND_FILTER,
+  conversationListQueryKey,
+  isPinnedInjectedFilter,
+  isSectionFilter,
+  type ConversationListFilter,
+} from "@/utils/conversation-list-keys";
 
 type Page = { conversations: Conversation[]; hasMore: boolean };
 
 /** One safe no-op page: empty window, so the merge keeps the cache as-is. */
 const NOOP_PAGE: Page = { conversations: [], hasMore: true };
 
-const sectionCalls: SectionConversationFilter[] = [];
+const sectionCalls: ConversationListFilter[] = [];
 let sectionPages: (
-  filter: SectionConversationFilter,
+  filter: ConversationListFilter,
 ) => Page | Promise<Page> = () => NOOP_PAGE;
 const loadMoreCalls: Array<{
-  filter: SectionConversationFilter;
+  filter: ConversationListFilter;
   offset: number;
 }> = [];
 let loadMorePages: (
-  filter: SectionConversationFilter,
+  filter: ConversationListFilter,
   offset: number,
 ) => Page | Promise<Page> = () => NOOP_PAGE;
 let foregroundCalls = 0;
@@ -48,22 +49,23 @@ let foregroundPage: Page = NOOP_PAGE;
 
 mock.module("@/utils/conversation-list-fetchers", (): typeof fetchers => ({
   ...fetchers,
-  listConversationsFirstPage: async (): Promise<Page> => {
-    foregroundCalls += 1;
-    return foregroundPage;
-  },
-  listBackgroundConversationsFirstPage: async (): Promise<Page> => NOOP_PAGE,
-  listScheduledConversationsFirstPage: async (): Promise<Page> => NOOP_PAGE,
-  listSectionConversationsFirstPage: async (
+  listConversationsFirstPage: async (
     _assistantId: string,
-    filter: SectionConversationFilter,
+    filter: ConversationListFilter = {},
   ): Promise<Page> => {
-    sectionCalls.push(filter);
-    return sectionPages(filter);
+    if (isSectionFilter(filter)) {
+      sectionCalls.push(filter);
+      return sectionPages(filter);
+    }
+    if (isPinnedInjectedFilter(filter)) {
+      foregroundCalls += 1;
+      return foregroundPage;
+    }
+    return NOOP_PAGE;
   },
-  listSectionConversationsPage: async (
+  listConversationsPage: async (
     _assistantId: string,
-    filter: SectionConversationFilter,
+    filter: ConversationListFilter,
     offset: number,
   ): Promise<Page> => {
     loadMoreCalls.push({ filter, offset });
@@ -75,8 +77,8 @@ const { loadMoreConversations, refreshConversationListWindows } =
   await import("@/utils/conversation-cache-mutations");
 
 const ASSISTANT_ID = "ast-test";
-const PINNED: SectionConversationFilter = { groupId: "system:pinned" };
-const SLACK: SectionConversationFilter = {
+const PINNED: ConversationListFilter = { groupId: "system:pinned" };
+const SLACK: ConversationListFilter = {
   groupId: "system:all",
   originChannel: "slack",
 };
@@ -97,13 +99,10 @@ function reset(): QueryClient {
   return new QueryClient({ defaultOptions: { queries: { retry: false } } });
 }
 
-function rowsIn(
-  client: QueryClient,
-  filter: SectionConversationFilter,
-): string[] {
+function rowsIn(client: QueryClient, filter: ConversationListFilter): string[] {
   return (
     client
-      .getQueryData<Page>(sectionConversationsQueryKey(ASSISTANT_ID, filter))
+      .getQueryData<Page>(conversationListQueryKey(ASSISTANT_ID, filter))
       ?.conversations.map((c) => c.conversationId) ?? []
   );
 }
@@ -112,11 +111,11 @@ describe("refreshConversationListWindows and sections", () => {
   test("each populated section cache gets one first-page fetch with its own filter", async () => {
     const client = reset();
     client.setQueryData(
-      sectionConversationsQueryKey(ASSISTANT_ID, PINNED),
+      conversationListQueryKey(ASSISTANT_ID, PINNED),
       listPage([conversation({ conversationId: "p1", isPinned: true })]),
     );
     client.setQueryData(
-      sectionConversationsQueryKey(ASSISTANT_ID, SLACK),
+      conversationListQueryKey(ASSISTANT_ID, SLACK),
       listPage([
         conversation({ conversationId: "s1", originChannel: "slack" }),
       ]),
@@ -132,7 +131,7 @@ describe("refreshConversationListWindows and sections", () => {
   test("a section that was never fetched is not fetched by a sync signal", async () => {
     const client = reset();
     client.setQueryData(
-      sectionConversationsQueryKey(ASSISTANT_ID, SLACK),
+      conversationListQueryKey(ASSISTANT_ID, SLACK),
       listPage([conversation({ conversationId: "s1" })]),
     );
 
@@ -144,7 +143,7 @@ describe("refreshConversationListWindows and sections", () => {
   test("the Pinned section merges its page even though every row is pinned", async () => {
     const client = reset();
     client.setQueryData(
-      sectionConversationsQueryKey(ASSISTANT_ID, PINNED),
+      conversationListQueryKey(ASSISTANT_ID, PINNED),
       listPage([
         // Inside the page's window (between 3000 and 5000) but missing from
         // the page: no longer pinned, must be dropped.
@@ -180,7 +179,7 @@ describe("refreshConversationListWindows and sections", () => {
   test("a complete section page replaces the cache", async () => {
     const client = reset();
     client.setQueryData(
-      sectionConversationsQueryKey(ASSISTANT_ID, SLACK),
+      conversationListQueryKey(ASSISTANT_ID, SLACK),
       listPage([conversation({ conversationId: "s-gone" })]),
     );
     sectionPages = () => ({
@@ -196,11 +195,11 @@ describe("refreshConversationListWindows and sections", () => {
   test("static buckets are still refreshed alongside the sections", async () => {
     const client = reset();
     client.setQueryData(
-      conversationsQueryKey(ASSISTANT_ID),
+      conversationListQueryKey(ASSISTANT_ID),
       listPage([conversation({ conversationId: "f1" })]),
     );
     client.setQueryData(
-      sectionConversationsQueryKey(ASSISTANT_ID, SLACK),
+      conversationListQueryKey(ASSISTANT_ID, SLACK),
       listPage([conversation({ conversationId: "s1" })]),
     );
 
@@ -216,7 +215,7 @@ describe("refreshConversationListWindows and sections", () => {
        after it would resurrect the old placement; the guard drops any
        response the cache was written past. */
     const client = reset();
-    const slackKey = sectionConversationsQueryKey(ASSISTANT_ID, SLACK);
+    const slackKey = conversationListQueryKey(ASSISTANT_ID, SLACK);
     client.setQueryData(
       slackKey,
       listPage([conversation({ conversationId: "s1" })]),
@@ -247,7 +246,7 @@ describe("refreshConversationListWindows and sections", () => {
 
   test("a slower refresh cannot overwrite a faster newer one", async () => {
     const client = reset();
-    const slackKey = sectionConversationsQueryKey(ASSISTANT_ID, SLACK);
+    const slackKey = conversationListQueryKey(ASSISTANT_ID, SLACK);
     client.setQueryData(
       slackKey,
       listPage([conversation({ conversationId: "s-old" })]),
@@ -284,7 +283,7 @@ describe("refreshConversationListWindows and sections", () => {
        strands the section on its derived fallback forever: the sync signal
        is its only retry path now that the prefix invalidation is gone. */
     const client = reset();
-    const failedKey = sectionConversationsQueryKey(ASSISTANT_ID, PINNED);
+    const failedKey = conversationListQueryKey(ASSISTANT_ID, PINNED);
     await client
       .prefetchQuery({
         queryKey: failedKey,
@@ -307,7 +306,7 @@ describe("refreshConversationListWindows and sections", () => {
        of sync signals arriving faster than a first load completes would
        keep that load from ever finishing. */
     const client = reset();
-    const pendingKey = sectionConversationsQueryKey(ASSISTANT_ID, SLACK);
+    const pendingKey = conversationListQueryKey(ASSISTANT_ID, SLACK);
     void client
       .prefetchQuery({
         queryKey: pendingKey,
@@ -325,7 +324,7 @@ describe("refreshConversationListWindows and sections", () => {
     // Same recovery contract as the sections; the bucket path had the same
     // hole (a failed first fetch was skipped, not retried).
     const client = reset();
-    const foregroundKey = conversationsQueryKey(ASSISTANT_ID);
+    const foregroundKey = conversationListQueryKey(ASSISTANT_ID);
     await client
       .prefetchQuery({
         queryKey: foregroundKey,
@@ -343,7 +342,7 @@ describe("refreshConversationListWindows and sections", () => {
   test("an unpopulated bucket is skipped", async () => {
     const client = reset();
     client.setQueryData(
-      backgroundConversationsQueryKey(ASSISTANT_ID),
+      conversationListQueryKey(ASSISTANT_ID, BACKGROUND_FILTER),
       listPage([conversation({ conversationId: "b1" })]),
     );
 
@@ -357,7 +356,7 @@ describe("refreshConversationListWindows and sections", () => {
 describe("loadMoreConversations", () => {
   test("appends the next page at the cache's current row count", async () => {
     const client = reset();
-    const slackKey = sectionConversationsQueryKey(ASSISTANT_ID, SLACK);
+    const slackKey = conversationListQueryKey(ASSISTANT_ID, SLACK);
     client.setQueryData(
       slackKey,
       listPage(
@@ -387,7 +386,7 @@ describe("loadMoreConversations", () => {
        a row from the previous page; appending it again would render the
        conversation twice in one section. */
     const client = reset();
-    const slackKey = sectionConversationsQueryKey(ASSISTANT_ID, SLACK);
+    const slackKey = conversationListQueryKey(ASSISTANT_ID, SLACK);
     client.setQueryData(
       slackKey,
       listPage([conversation({ conversationId: "s1" })], true),
@@ -408,7 +407,7 @@ describe("loadMoreConversations", () => {
   test("a complete or unfetched cache is a no-op without a request", async () => {
     const client = reset();
     client.setQueryData(
-      sectionConversationsQueryKey(ASSISTANT_ID, SLACK),
+      conversationListQueryKey(ASSISTANT_ID, SLACK),
       listPage([conversation({ conversationId: "s1" })]),
     );
 
@@ -421,7 +420,7 @@ describe("loadMoreConversations", () => {
   test("one request per section while in flight", async () => {
     const client = reset();
     client.setQueryData(
-      sectionConversationsQueryKey(ASSISTANT_ID, SLACK),
+      conversationListQueryKey(ASSISTANT_ID, SLACK),
       listPage([conversation({ conversationId: "s1" })], true),
     );
     let resolvePage!: (page: Page) => void;
@@ -449,7 +448,7 @@ describe("loadMoreConversations", () => {
        page. The sentinel is still visible and re-fires against the new
        cache. */
     const client = reset();
-    const slackKey = sectionConversationsQueryKey(ASSISTANT_ID, SLACK);
+    const slackKey = conversationListQueryKey(ASSISTANT_ID, SLACK);
     client.setQueryData(
       slackKey,
       listPage([conversation({ conversationId: "s1" })], true),
@@ -479,7 +478,7 @@ describe("loadMoreConversations", () => {
   test("the guard clears after a failed fetch so the next attempt retries", async () => {
     const client = reset();
     client.setQueryData(
-      sectionConversationsQueryKey(ASSISTANT_ID, SLACK),
+      conversationListQueryKey(ASSISTANT_ID, SLACK),
       listPage([conversation({ conversationId: "s1" })], true),
     );
     loadMorePages = () => Promise.reject(new Error("network down"));

--- a/clients/web/src/utils/conversation-cache.test.ts
+++ b/clients/web/src/utils/conversation-cache.test.ts
@@ -2,13 +2,14 @@ import { beforeEach, describe, expect, test } from "bun:test";
 import { QueryClient } from "@tanstack/react-query";
 
 import type { Conversation } from "@/types/conversation-types";
+import type { ConversationListPage } from "@/utils/conversation-list-fetchers";
 import {
-  conversationsQueryKey,
-  backgroundConversationsQueryKey,
-  scheduledConversationsQueryKey,
-  archivedConversationsQueryKey,
-  type ConversationListPage,
-} from "@/utils/conversation-list-fetchers";
+  ARCHIVED_FILTER,
+  BACKGROUND_FILTER,
+  conversationListQueryKey,
+  FOREGROUND_FILTER,
+  SCHEDULED_FILTER,
+} from "@/utils/conversation-list-keys";
 import { listPage } from "@/utils/conversation-list.test-helper";
 
 import {
@@ -16,10 +17,7 @@ import {
   snapshotConversationCaches,
   restoreConversationCaches,
   invalidateConversationQueries,
-  updateConversationsCache,
-  updateBackgroundConversationsCache,
-  updateScheduledConversationsCache,
-  updateArchivedConversationsCache,
+  updateConversationListCache,
   updateAllConversationCaches,
   findConversation,
   mergeConversationLists,
@@ -45,41 +43,45 @@ function makeConversation(
 }
 
 function seedForeground(qc: QueryClient, conversations: Conversation[]) {
-  qc.setQueryData(conversationsQueryKey(ASSISTANT_ID), listPage(conversations));
+  qc.setQueryData(
+    conversationListQueryKey(ASSISTANT_ID),
+    listPage(conversations),
+  );
 }
 
 function seedBackground(qc: QueryClient, conversations: Conversation[]) {
   qc.setQueryData(
-    backgroundConversationsQueryKey(ASSISTANT_ID),
+    conversationListQueryKey(ASSISTANT_ID, BACKGROUND_FILTER),
     listPage(conversations),
   );
 }
 
 function seedScheduled(qc: QueryClient, conversations: Conversation[]) {
   qc.setQueryData(
-    scheduledConversationsQueryKey(ASSISTANT_ID),
+    conversationListQueryKey(ASSISTANT_ID, SCHEDULED_FILTER),
     listPage(conversations),
   );
 }
 
 function seedArchived(qc: QueryClient, conversations: Conversation[]) {
   qc.setQueryData(
-    archivedConversationsQueryKey(ASSISTANT_ID),
+    conversationListQueryKey(ASSISTANT_ID, ARCHIVED_FILTER),
     listPage(conversations),
   );
 }
 
 function getForeground(qc: QueryClient): Conversation[] {
   return (
-    qc.getQueryData<ConversationListPage>(conversationsQueryKey(ASSISTANT_ID))
-      ?.conversations ?? []
+    qc.getQueryData<ConversationListPage>(
+      conversationListQueryKey(ASSISTANT_ID),
+    )?.conversations ?? []
   );
 }
 
 function getBackground(qc: QueryClient): Conversation[] {
   return (
     qc.getQueryData<ConversationListPage>(
-      backgroundConversationsQueryKey(ASSISTANT_ID),
+      conversationListQueryKey(ASSISTANT_ID, BACKGROUND_FILTER),
     )?.conversations ?? []
   );
 }
@@ -87,7 +89,7 @@ function getBackground(qc: QueryClient): Conversation[] {
 function getScheduled(qc: QueryClient): Conversation[] {
   return (
     qc.getQueryData<ConversationListPage>(
-      scheduledConversationsQueryKey(ASSISTANT_ID),
+      conversationListQueryKey(ASSISTANT_ID, SCHEDULED_FILTER),
     )?.conversations ?? []
   );
 }
@@ -95,7 +97,7 @@ function getScheduled(qc: QueryClient): Conversation[] {
 function getArchived(qc: QueryClient): Conversation[] {
   return (
     qc.getQueryData<ConversationListPage>(
-      archivedConversationsQueryKey(ASSISTANT_ID),
+      conversationListQueryKey(ASSISTANT_ID, ARCHIVED_FILTER),
     )?.conversations ?? []
   );
 }
@@ -159,14 +161,14 @@ describe("snapshotConversationCaches + restoreConversationCaches", () => {
 });
 
 // ---------------------------------------------------------------------------
-// updateConversationsCache
+// updateConversationListCache
 // ---------------------------------------------------------------------------
 
-describe("updateConversationsCache", () => {
+describe("updateConversationListCache with FOREGROUND_FILTER", () => {
   test("applies updater to foreground cache", () => {
     seedForeground(qc, [makeConversation({ conversationId: "c1" })]);
 
-    updateConversationsCache(qc, ASSISTANT_ID, (list) => [
+    updateConversationListCache(qc, ASSISTANT_ID, FOREGROUND_FILTER, (list) => [
       ...list,
       makeConversation({ conversationId: "c2" }),
     ]);
@@ -178,13 +180,18 @@ describe("updateConversationsCache", () => {
     const original = [makeConversation({ conversationId: "c1" })];
     seedForeground(qc, original);
 
-    updateConversationsCache(qc, ASSISTANT_ID, (list) => list);
+    updateConversationListCache(
+      qc,
+      ASSISTANT_ID,
+      FOREGROUND_FILTER,
+      (list) => list,
+    );
 
     expect(getForeground(qc)).toBe(original);
   });
 
   test("initializes from empty when cache is unset", () => {
-    updateConversationsCache(qc, ASSISTANT_ID, (list) => {
+    updateConversationListCache(qc, ASSISTANT_ID, FOREGROUND_FILTER, (list) => {
       expect(list).toEqual([]);
       return [makeConversation({ conversationId: "c1" })];
     });
@@ -194,15 +201,15 @@ describe("updateConversationsCache", () => {
 });
 
 // ---------------------------------------------------------------------------
-// updateBackgroundConversationsCache / updateScheduledConversationsCache
+// updateConversationListCache with the typed bucket filters
 // ---------------------------------------------------------------------------
 
-describe("updateBackgroundConversationsCache", () => {
+describe("updateConversationListCache with BACKGROUND_FILTER", () => {
   test("applies updater to background cache only", () => {
     seedForeground(qc, [makeConversation({ conversationId: "c1" })]);
     seedBackground(qc, []);
 
-    updateBackgroundConversationsCache(qc, ASSISTANT_ID, () => [
+    updateConversationListCache(qc, ASSISTANT_ID, BACKGROUND_FILTER, () => [
       makeConversation({ conversationId: "bg1" }),
     ]);
 
@@ -211,12 +218,12 @@ describe("updateBackgroundConversationsCache", () => {
   });
 });
 
-describe("updateScheduledConversationsCache", () => {
+describe("updateConversationListCache with SCHEDULED_FILTER", () => {
   test("applies updater to scheduled cache only", () => {
     seedForeground(qc, [makeConversation({ conversationId: "c1" })]);
     seedScheduled(qc, []);
 
-    updateScheduledConversationsCache(qc, ASSISTANT_ID, () => [
+    updateConversationListCache(qc, ASSISTANT_ID, SCHEDULED_FILTER, () => [
       makeConversation({ conversationId: "s1" }),
     ]);
 
@@ -229,12 +236,12 @@ describe("updateScheduledConversationsCache", () => {
 // updateAllConversationCaches
 // ---------------------------------------------------------------------------
 
-describe("updateArchivedConversationsCache", () => {
+describe("updateConversationListCache with ARCHIVED_FILTER", () => {
   test("applies updater to archived cache only", () => {
     seedForeground(qc, [makeConversation({ conversationId: "c1" })]);
     seedArchived(qc, []);
 
-    updateArchivedConversationsCache(qc, ASSISTANT_ID, () => [
+    updateConversationListCache(qc, ASSISTANT_ID, ARCHIVED_FILTER, () => [
       makeConversation({ conversationId: "a1" }),
     ]);
 
@@ -248,7 +255,7 @@ describe("updateAllConversationCaches", () => {
     // A windowed cache (hasMore: true) stays a window when a row inside it
     // changes; flipping the flag would silently retire the load-more path.
     qc.setQueryData(
-      conversationsQueryKey(ASSISTANT_ID),
+      conversationListQueryKey(ASSISTANT_ID),
       listPage(
         [makeConversation({ conversationId: "c1", title: "old" })],
         true,
@@ -260,7 +267,7 @@ describe("updateAllConversationCaches", () => {
     );
 
     const page = qc.getQueryData<ConversationListPage>(
-      conversationsQueryKey(ASSISTANT_ID),
+      conversationListQueryKey(ASSISTANT_ID),
     );
     expect(page?.conversations[0]?.title).toBe("new");
     expect(page?.hasMore).toBe(true);

--- a/clients/web/src/utils/conversation-cache.ts
+++ b/clients/web/src/utils/conversation-cache.ts
@@ -1,35 +1,34 @@
 /**
  * Low-level read/write helpers over the conversation query caches.
  *
- * Conversations are split across multiple `ConversationListPage` caches
- * (`{conversations, hasMore}`), each identified by a query key under the
- * shared prefix `["conversation-list", assistantId, ...discriminator]`.
- * `hasMore` marks a cache as a *window*, a prefix of the true list whose
- * older rows load on demand; a drained list is a page with nothing beyond
- * it. One shape for both is what keeps every helper here shape-blind:
- * updaters operate on the rows and the window flag rides along.
+ * Every conversation list cache is one `GET /v1/conversations` read scoped
+ * by a {@link ConversationListFilter} and keyed by the generated key for
+ * that request (`conversation-list-keys.ts`); the cached value is a
+ * `ConversationListPage` (`{conversations, hasMore}`). `hasMore` marks a
+ * cache as a *window*, a prefix of the true list whose older rows load on
+ * demand; a drained list is a page with nothing beyond it. One shape for
+ * both is what keeps every helper here shape-blind: updaters operate on the
+ * rows and the window flag rides along.
  *
- * - **Foreground** (`"foreground"`) — the primary list that gates the
- *   initial chat render. Always fetched.
- * - **Background** (`"background"`) — background jobs only. Fetched
- *   lazily when the user reveals the Background sidebar section.
- * - **Scheduled** (`"scheduled"`) — scheduled jobs only. Fetched lazily
- *   when the user reveals the Scheduled sidebar section.
- * - **Archived** (`"archived"`) — archived conversations. Fetched
- *   lazily when the user opens the archive view.
- * - **Section** (`"section", groupId, originChannel`): one sidebar section's
- *   rows, fetched through the server filter that defines the section. Pinned,
- *   each custom group, each channel, and Chats each key their own entry.
- *   Membership here is the server's answer, not a client-side filter, so a
- *   local change to the fields that filter reads has to move the row between
- *   these caches. See `utils/section-membership.ts`.
+ * The caches that exist at any moment are whatever filters are mounted:
+ *
+ * - The four **buckets** (foreground `{}`, background, scheduled, archived)
+ *   that predate the per-section queries. Foreground gates the initial chat
+ *   render; the others mount when their sidebar section or the archive view
+ *   is revealed.
+ * - One **section** cache per sidebar section (a group and/or channel
+ *   filter): Pinned, each custom group, each channel, and Chats each key
+ *   their own entry. Membership here is the server's answer, not a
+ *   client-side filter, so a local change to the fields that filter reads
+ *   has to move the row between these caches. See
+ *   `utils/section-membership.ts`.
  *
  * A conversation lives in exactly one cache, so the cross-cache helpers
  * (`findConversation`, `getConversations`, `patchConversation`,
  * `updateAllConversationCaches`) discover and operate on every active
- * cache via TanStack Query's prefix matching — no manual registry.
- * Adding a new cache type automatically participates in all cross-cache
- * operations.
+ * cache via TanStack Query's partial key matching against the list prefix
+ * (`conversationListPrefix`), never a registry. A new filter participates
+ * in every cross-cache operation by construction.
  *
  * References:
  * - https://tanstack.com/query/latest/docs/framework/react/guides/updates-from-mutation-responses
@@ -39,14 +38,14 @@
 import type { QueryClient } from "@tanstack/react-query";
 
 import {
-  archivedConversationsQueryKey,
-  backgroundConversationsQueryKey,
-  conversationListPrefix,
-  conversationsQueryKey,
-  scheduledConversationsQueryKey,
   sidebarSectionsQueryKey,
   unreadConversationCountQueryKey,
 } from "@/utils/conversation-list-fetchers";
+import {
+  type ConversationListFilter,
+  conversationListPrefix,
+  conversationListQueryKey,
+} from "@/utils/conversation-list-keys";
 import {
   ensureSectionInIndex,
   patchAffectsMembership,
@@ -197,63 +196,27 @@ function updateCache(
 }
 
 /**
- * Apply `updater` to the foreground conversation cache. Used for writes
- * that only ever target foreground rows (draft creation, new-conversation
- * insertion).
+ * Apply `updater` to the one list cache `filter` names. For writes that
+ * target a known bucket (draft creation and new-conversation insertion go
+ * to the foreground list; a scheduled or background run to its own).
  */
-export function updateConversationsCache(
+export function updateConversationListCache(
   queryClient: QueryClient,
   assistantId: string | null,
-  updater: ConversationUpdater,
-): void {
-  updateCache(queryClient, conversationsQueryKey(assistantId), updater);
-}
-
-/**
- * Apply `updater` to the background conversation cache.
- */
-export function updateBackgroundConversationsCache(
-  queryClient: QueryClient,
-  assistantId: string | null,
+  filter: ConversationListFilter,
   updater: ConversationUpdater,
 ): void {
   updateCache(
     queryClient,
-    backgroundConversationsQueryKey(assistantId),
+    conversationListQueryKey(assistantId, filter),
     updater,
   );
-}
-
-/**
- * Apply `updater` to the scheduled conversation cache.
- */
-export function updateScheduledConversationsCache(
-  queryClient: QueryClient,
-  assistantId: string | null,
-  updater: ConversationUpdater,
-): void {
-  updateCache(
-    queryClient,
-    scheduledConversationsQueryKey(assistantId),
-    updater,
-  );
-}
-
-/**
- * Apply `updater` to the archived conversation cache.
- */
-export function updateArchivedConversationsCache(
-  queryClient: QueryClient,
-  assistantId: string | null,
-  updater: ConversationUpdater,
-): void {
-  updateCache(queryClient, archivedConversationsQueryKey(assistantId), updater);
 }
 
 /**
  * Apply `updater` to ALL active conversation caches for the given
  * assistant. Uses TanStack Query's prefix matching to dynamically
- * discover which caches exist — no static enumeration. Only caches that
+ * discover which caches exist, never a static enumeration. Only caches that
  * TanStack Query is actively tracking are patched; unmounted queries
  * refetch fresh data when they re-mount.
  *

--- a/clients/web/src/utils/conversation-cache.ts
+++ b/clients/web/src/utils/conversation-cache.ts
@@ -12,10 +12,10 @@
  *
  * The caches that exist at any moment are whatever filters are mounted:
  *
- * - The four **buckets** (foreground `{}`, background, scheduled, archived)
- *   that predate the per-section queries. Foreground gates the initial chat
- *   render; the others mount when their sidebar section or the archive view
- *   is revealed.
+ * - The four **buckets** (foreground `{}`, background, scheduled, archived):
+ *   whole-list reads for the surfaces that need every row of a type.
+ *   Foreground gates the initial chat render; the others mount when their
+ *   sidebar section or the archive view is revealed.
  * - One **section** cache per sidebar section (a group and/or channel
  *   filter): Pinned, each custom group, each channel, and Chats each key
  *   their own entry. Membership here is the server's answer, not a

--- a/clients/web/src/utils/conversation-list-fetchers.test.ts
+++ b/clients/web/src/utils/conversation-list-fetchers.test.ts
@@ -9,12 +9,16 @@
  */
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { QueryClient } from "@tanstack/react-query";
 
 import { client as daemonClient } from "@/generated/daemon/client.gen";
-import { listPage } from "@/utils/conversation-list.test-helper";
 import { getDiagnosticsEvents, type DiagnosticsEvent } from "@/lib/diagnostics";
 import { ApiError } from "@/utils/api-errors";
+import {
+  ARCHIVED_BACKGROUND_FILTER,
+  ARCHIVED_FILTER,
+  BACKGROUND_FILTER,
+  SCHEDULED_FILTER,
+} from "@/utils/conversation-list-keys";
 import type { RawConversationSummary } from "@/utils/conversation-transforms";
 
 const emitClientPerfEventMock = mock(
@@ -30,20 +34,19 @@ mock.module("@/lib/telemetry/client-perf", () => ({
 }));
 
 const {
+  drainConversationList,
   hasAnyActiveConversation,
-  listArchivedConversations,
-  listBackgroundConversations,
-  listBackgroundConversationsFirstPage,
-  listConversations,
   listConversationsFirstPage,
-  drainSectionConversations,
-  listSectionConversationsFirstPage,
-  listSectionConversationsPage,
-  sectionConversationListOptions,
-  sectionConversationsQueryKey,
-  listScheduledConversations,
-  listScheduledConversationsFirstPage,
+  listConversationsPage,
 } = await import("@/utils/conversation-list-fetchers");
+
+/** The archive view's two drains, as its hook issues them. */
+function drainArchived(): Promise<unknown> {
+  return Promise.all([
+    drainConversationList(ASSISTANT_ID, ARCHIVED_FILTER),
+    drainConversationList(ASSISTANT_ID, ARCHIVED_BACKGROUND_FILTER),
+  ]);
+}
 
 const ASSISTANT_ID = "assistant-1";
 
@@ -151,7 +154,7 @@ describe("conversation list drain diagnostics", () => {
     ]);
 
     const { result: conversations, events } = await diagnosticsDuring(() =>
-      listConversations(ASSISTANT_ID),
+      drainConversationList(ASSISTANT_ID),
     );
 
     expect(offsets).toEqual([0, 50, 100]);
@@ -194,7 +197,7 @@ describe("conversation list drain diagnostics", () => {
 
     let thrown: unknown;
     const { events } = await diagnosticsDuring(() =>
-      listConversations(ASSISTANT_ID).catch((error: unknown) => {
+      drainConversationList(ASSISTANT_ID).catch((error: unknown) => {
         thrown = error;
       }),
     );
@@ -233,7 +236,7 @@ describe("conversation list drain diagnostics", () => {
     stubPages([{ ids: [], hasMore: false, status: 500, contentLength: "77" }]);
 
     const { events } = await diagnosticsDuring(() =>
-      listConversations(ASSISTANT_ID).catch(() => undefined),
+      drainConversationList(ASSISTANT_ID).catch(() => undefined),
     );
 
     const errorEntry = events.find(
@@ -246,7 +249,9 @@ describe("conversation list drain diagnostics", () => {
     stubPages([{ ids: [], hasMore: false, status: 500 }]);
 
     const { events } = await diagnosticsDuring(() =>
-      listBackgroundConversations(ASSISTANT_ID).catch(() => undefined),
+      drainConversationList(ASSISTANT_ID, BACKGROUND_FILTER).catch(
+        () => undefined,
+      ),
     );
 
     const errorEntry = events.find(
@@ -280,16 +285,14 @@ describe("conversation list drain diagnostics", () => {
   });
 
   test("both archive-page drain summaries are labeled archived", async () => {
-    // The archive page drains the foreground and background buckets, so one
-    // call produces two summaries, and both are archive-page cost.
+    // The archive view reads two lists (archived, archived background), so
+    // it produces two summaries, and both are archive-page cost.
     stubPages([
       { ids: ["c-0"], hasMore: false, contentLength: "10" },
       { ids: ["c-1"], hasMore: false, contentLength: "20" },
     ]);
 
-    const { events } = await diagnosticsDuring(() =>
-      listArchivedConversations(ASSISTANT_ID),
-    );
+    const { events } = await diagnosticsDuring(() => drainArchived());
     const summaries = events.filter(
       (event) => event.kind === "conversation_list_drain",
     );
@@ -304,7 +307,7 @@ describe("conversation list drain diagnostics", () => {
   test("page-0 entries carry the drain's list kind and a drain source", async () => {
     stubPages([{ ids: ["c-0"], hasMore: false, contentLength: "10" }]);
     const background = await diagnosticsDuring(() =>
-      listBackgroundConversations(ASSISTANT_ID),
+      drainConversationList(ASSISTANT_ID, BACKGROUND_FILTER),
     );
 
     expect(background.events[0]?.details).toMatchObject({
@@ -315,7 +318,7 @@ describe("conversation list drain diagnostics", () => {
 
     stubPages([{ ids: ["c-0"], hasMore: false, contentLength: "10" }]);
     const channel = await diagnosticsDuring(() =>
-      drainSectionConversations(ASSISTANT_ID, { originChannel: "slack" }),
+      drainConversationList(ASSISTANT_ID, { originChannel: "slack" }),
     );
 
     expect(channel.events[0]?.details).toMatchObject({
@@ -324,15 +327,13 @@ describe("conversation list drain diagnostics", () => {
       source: "drain",
     });
 
-    // The archive page drains the foreground and background buckets, so both
-    // of its page-0 entries are archive-page cost.
+    // The archive view reads two lists (archived, archived background), so
+    // both of its page-0 entries are archive-page cost.
     stubPages([
       { ids: ["c-0"], hasMore: false, contentLength: "10" },
       { ids: ["c-1"], hasMore: false, contentLength: "20" },
     ]);
-    const archived = await diagnosticsDuring(() =>
-      listArchivedConversations(ASSISTANT_ID),
-    );
+    const archived = await diagnosticsDuring(() => drainArchived());
     const pageEntries = archived.events.filter(
       (event) => event.kind === "conversation_list_page_fetch",
     );
@@ -349,7 +350,7 @@ describe("conversation list drain diagnostics", () => {
   test("bytes is null when content-length is absent and numeric when present", async () => {
     stubPages([{ ids: ["c-0"], hasMore: false }]);
     const withoutHeader = await diagnosticsDuring(() =>
-      listConversations(ASSISTANT_ID),
+      drainConversationList(ASSISTANT_ID),
     );
 
     expect(withoutHeader.events[0]?.details.bytes).toBeNull();
@@ -357,7 +358,7 @@ describe("conversation list drain diagnostics", () => {
 
     stubPages([{ ids: ["c-0"], hasMore: false, contentLength: "4096" }]);
     const withHeader = await diagnosticsDuring(() =>
-      listConversations(ASSISTANT_ID),
+      drainConversationList(ASSISTANT_ID),
     );
 
     expect(withHeader.events[0]?.details.bytes).toBe(4096);
@@ -369,7 +370,7 @@ describe("conversation list drain diagnostics", () => {
       { ids: ["c-0"], hasMore: false, contentLength: "not-a-number" },
     ]);
     const malformed = await diagnosticsDuring(() =>
-      listConversations(ASSISTANT_ID),
+      drainConversationList(ASSISTANT_ID),
     );
 
     expect(malformed.events[0]?.details.bytes).toBeNull();
@@ -377,7 +378,7 @@ describe("conversation list drain diagnostics", () => {
 
     stubPages([{ ids: ["c-0"], hasMore: false, contentLength: "" }]);
     const blank = await diagnosticsDuring(() =>
-      listConversations(ASSISTANT_ID),
+      drainConversationList(ASSISTANT_ID),
     );
 
     expect(blank.events[0]?.details.bytes).toBeNull();
@@ -388,7 +389,7 @@ describe("conversation list drain diagnostics", () => {
     stubPages([{ ids: ["c-0"], hasMore: false, contentLength: "10" }]);
 
     const { events } = await diagnosticsDuring(() =>
-      listConversations(ASSISTANT_ID),
+      drainConversationList(ASSISTANT_ID),
     );
 
     expect(events).toHaveLength(2);
@@ -435,7 +436,7 @@ describe("first-page fetch diagnostics", () => {
     stubPages([{ ids: ["c-0"], hasMore: false, contentLength: "12" }]);
 
     const { events } = await diagnosticsDuring(() =>
-      listBackgroundConversationsFirstPage(ASSISTANT_ID),
+      listConversationsFirstPage(ASSISTANT_ID, BACKGROUND_FILTER),
     );
 
     expect(events[0]?.details).toMatchObject({
@@ -451,7 +452,7 @@ describe("first-page fetch diagnostics", () => {
     stubPages([{ ids: ["c-0"], hasMore: false, contentLength: "12" }]);
 
     const { events } = await diagnosticsDuring(() =>
-      listScheduledConversationsFirstPage(ASSISTANT_ID),
+      listConversationsFirstPage(ASSISTANT_ID, SCHEDULED_FILTER),
     );
 
     expect(events[0]?.details).toMatchObject({
@@ -490,7 +491,7 @@ describe("conversation list drain telemetry", () => {
       { ids: ["c-2"], hasMore: false, contentLength: "50" },
     ]);
 
-    await listConversations(ASSISTANT_ID);
+    await drainConversationList(ASSISTANT_ID);
 
     expect(emitClientPerfEventMock.mock.calls).toHaveLength(1);
     const emits = drainEmits();
@@ -509,7 +510,7 @@ describe("conversation list drain telemetry", () => {
   test("a background drain reports its own list_kind", async () => {
     stubPages([{ ids: ["c-0"], hasMore: false, contentLength: "10" }]);
 
-    await listBackgroundConversations(ASSISTANT_ID);
+    await drainConversationList(ASSISTANT_ID, BACKGROUND_FILTER);
 
     const emits = drainEmits();
     expect(emits).toHaveLength(1);
@@ -523,7 +524,7 @@ describe("conversation list drain telemetry", () => {
   test("a scheduled drain reports its own list_kind", async () => {
     stubPages([{ ids: ["c-0"], hasMore: false, contentLength: "10" }]);
 
-    await listScheduledConversations(ASSISTANT_ID);
+    await drainConversationList(ASSISTANT_ID, SCHEDULED_FILTER);
 
     const emits = drainEmits();
     expect(emits).toHaveLength(1);
@@ -533,7 +534,7 @@ describe("conversation list drain telemetry", () => {
   test("an origin-channel drain is labeled origin_channel, not foreground", async () => {
     stubPages([{ ids: ["c-0"], hasMore: false, contentLength: "10" }]);
 
-    await drainSectionConversations(ASSISTANT_ID, { originChannel: "slack" });
+    await drainConversationList(ASSISTANT_ID, { originChannel: "slack" });
 
     const emits = drainEmits();
     expect(emits).toHaveLength(1);
@@ -545,14 +546,14 @@ describe("conversation list drain telemetry", () => {
   });
 
   test("both archive-page drains are labeled archived, not foreground or background", async () => {
-    // The archive page drains the foreground and background buckets in
-    // parallel, so one call produces two emits.
+    // The archive view reads two lists (archived, archived background) in
+    // parallel, so it produces two emits.
     stubPages([
       { ids: ["c-0"], hasMore: false, contentLength: "10" },
       { ids: ["c-1"], hasMore: false, contentLength: "20" },
     ]);
 
-    await listArchivedConversations(ASSISTANT_ID);
+    await drainArchived();
 
     const emits = drainEmits();
     expect(emits).toHaveLength(2);
@@ -565,7 +566,7 @@ describe("conversation list drain telemetry", () => {
   test("the detail bag carries no assistant id, and null bytes when content-length is absent", async () => {
     stubPages([{ ids: ["c-0"], hasMore: false }]);
 
-    await listConversations(ASSISTANT_ID);
+    await drainConversationList(ASSISTANT_ID);
 
     const emits = drainEmits();
     expect(emits).toHaveLength(1);
@@ -580,7 +581,7 @@ describe("conversation list drain telemetry", () => {
   test("the numeric detail fields ride as raw numbers, not strings", async () => {
     stubPages([{ ids: ["c-0"], hasMore: false, contentLength: "64" }]);
 
-    await listConversations(ASSISTANT_ID);
+    await drainConversationList(ASSISTANT_ID);
 
     const detail = drainEmits()[0]!.detail;
     for (const key of ["pages", "rows", "max_page_ms", "total_bytes"]) {
@@ -595,7 +596,7 @@ describe("conversation list drain telemetry", () => {
     ]);
 
     let thrown: unknown;
-    await listConversations(ASSISTANT_ID).catch((error: unknown) => {
+    await drainConversationList(ASSISTANT_ID).catch((error: unknown) => {
       thrown = error;
     });
 
@@ -625,7 +626,7 @@ describe("section list filters", () => {
       { ids: ["c-1"], hasMore: false },
     ]);
 
-    await drainSectionConversations(ASSISTANT_ID, {
+    await drainConversationList(ASSISTANT_ID, {
       groupId: "system:pinned",
     });
 
@@ -641,7 +642,7 @@ describe("section list filters", () => {
     // custom group would render in that group AND in its channel.
     const { queries } = stubPages([{ ids: ["c-0"], hasMore: false }]);
 
-    await drainSectionConversations(ASSISTANT_ID, {
+    await drainConversationList(ASSISTANT_ID, {
       groupId: "system:all",
       originChannel: "slack",
     });
@@ -655,7 +656,7 @@ describe("section list filters", () => {
   test("omits the filters it was not given rather than sending empties", async () => {
     const { queries } = stubPages([{ ids: ["c-0"], hasMore: false }]);
 
-    await drainSectionConversations(ASSISTANT_ID, { groupId: "grp-a" });
+    await drainConversationList(ASSISTANT_ID, { groupId: "grp-a" });
 
     expect(queries[0]).not.toHaveProperty("originChannel");
   });
@@ -665,7 +666,7 @@ describe("section list filters", () => {
     // superset.
     const { queries } = stubPages([{ ids: ["c-0"], hasMore: true }]);
 
-    const page = await listSectionConversationsFirstPage(ASSISTANT_ID, {
+    const page = await listConversationsFirstPage(ASSISTANT_ID, {
       groupId: "system:all",
       originChannel: "slack",
     });
@@ -679,58 +680,10 @@ describe("section list filters", () => {
     expect(page.hasMore).toBe(true);
   });
 
-  test("a plain refetch keeps the scrolled-in window", async () => {
-    /* The queryFn merges the fresh first page over the cached window. A
-       bare page-one return here would mean every focus refetch and every
-       settle invalidation truncated a scrolled window back to 50 rows
-       under the user's scrollbar. */
-    const client = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    const filter = { groupId: "grp-a" };
-    client.setQueryData(
-      sectionConversationsQueryKey(ASSISTANT_ID, filter),
-      listPage(
-        [
-          {
-            conversationId: "c-top",
-            title: "",
-            createdAt: 0,
-            lastMessageAt: 5000,
-          },
-          {
-            conversationId: "c-scrolled-in",
-            title: "",
-            createdAt: 0,
-            lastMessageAt: 100,
-          },
-        ],
-        true,
-      ),
-    );
-    // The fresh page holds only the window top; the scrolled-in row sorts
-    // below the page's cutoff, so the merge must keep it.
-    stubPages([{ ids: [["c-top", 5000]], hasMore: true }]);
-
-    // staleTime 0: the seeded cache is seconds old, and fetchQuery serves
-    // fresh data without running the queryFn, which would pass this test
-    // without exercising the merge at all.
-    const result = await client.fetchQuery({
-      ...sectionConversationListOptions(ASSISTANT_ID, filter),
-      staleTime: 0,
-    });
-
-    expect(result.conversations.map((c) => c.conversationId)).toEqual([
-      "c-top",
-      "c-scrolled-in",
-    ]);
-    expect(result.hasMore).toBe(true);
-  });
-
   test("a load-more page carries the filter and its offset", async () => {
     const { queries } = stubPages([{ ids: ["c-50"], hasMore: false }]);
 
-    const page = await listSectionConversationsPage(
+    const page = await listConversationsPage(
       ASSISTANT_ID,
       { groupId: "grp-a" },
       50,
@@ -744,7 +697,7 @@ describe("section list filters", () => {
   test("labels a group-only drain 'section', keeping it distinct from a channel", async () => {
     stubPages([{ ids: ["c-0"], hasMore: false, contentLength: "10" }]);
     const group = await diagnosticsDuring(() =>
-      drainSectionConversations(ASSISTANT_ID, { groupId: "system:pinned" }),
+      drainConversationList(ASSISTANT_ID, { groupId: "system:pinned" }),
     );
 
     expect(group.events[0]?.details).toMatchObject({
@@ -756,7 +709,7 @@ describe("section list filters", () => {
     // so the bounded per-channel budget stays readable.
     stubPages([{ ids: ["c-0"], hasMore: false, contentLength: "10" }]);
     const channel = await diagnosticsDuring(() =>
-      drainSectionConversations(ASSISTANT_ID, {
+      drainConversationList(ASSISTANT_ID, {
         groupId: "system:all",
         originChannel: "slack",
       }),

--- a/clients/web/src/utils/conversation-list-fetchers.ts
+++ b/clients/web/src/utils/conversation-list-fetchers.ts
@@ -1,17 +1,18 @@
 /**
- * Fetch functions and `queryOptions` factories for conversation lists
- * (foreground, background, scheduled, archived).
+ * Fetch functions for the conversation list caches, plus the sidebar's two
+ * non-list reads (unread count, section index).
  *
- * Each fetcher returns a sorted `Conversation[]` from the daemon's paginated
- * `conversationsGet()` endpoint. The `queryOptions` factories co-locate
- * `queryKey` + `queryFn` + `staleTime` so consumers can spread them into
- * `useQuery()`, pass them to `queryClient.prefetchQuery()`, or destructure
- * `.queryKey` for imperative cache operations — all with full type safety.
+ * Every list read is the daemon's paginated `conversationsGet()` scoped by a
+ * {@link ConversationListFilter}; three primitives cover them all: a drain
+ * ({@link drainConversationList}), the newest page
+ * ({@link listConversationsFirstPage}), and a page at an offset
+ * ({@link listConversationsPage}). Rows come back as `Conversation`
+ * (`toConversation` runs here, in the fetch), shaped per bucket by
+ * {@link shapeListRows}. Keys live in `conversation-list-keys.ts` and the
+ * list `queryOptions` in `conversation-list-options.ts`.
  *
  * References:
- * - https://tanstack.com/query/latest/docs/framework/react/guides/query-options
  * - https://tanstack.com/query/latest/docs/framework/react/guides/query-functions
- * - https://tanstack.com/query/latest/docs/eslint/prefer-query-options
  */
 
 import { queryOptions } from "@tanstack/react-query";
@@ -39,106 +40,12 @@ import { emitClientPerfEvent } from "@/lib/telemetry/client-perf";
 import type { Conversation } from "@/types/conversation-types";
 import { readContentLength } from "@/utils/content-length";
 import {
-  byTimestampDesc,
-  mergeListFirstPage,
-} from "@/utils/conversation-order";
+  type ConversationListFilter,
+  isSectionFilter,
+} from "@/utils/conversation-list-keys";
+import { byTimestampDesc } from "@/utils/conversation-order";
 import { isScheduledConversation } from "@/utils/conversation-predicates";
 import { toConversation } from "@/utils/conversation-transforms";
-
-// ---------------------------------------------------------------------------
-// Conversation list query keys
-//
-// All conversation list caches share a common prefix:
-//   ["conversation-list", assistantId, ...discriminator]
-//
-// This enables TanStack Query's prefix matching to operate on ALL
-// conversation caches simultaneously (cancel, invalidate, snapshot, patch)
-// without maintaining a static registry.
-// ---------------------------------------------------------------------------
-
-export const CONVERSATION_LIST_PREFIX = "conversation-list" as const;
-
-/** Prefix key matching ALL conversation list caches for the given assistant. */
-export function conversationListPrefix(assistantId: string | null) {
-  return [CONVERSATION_LIST_PREFIX, assistantId ?? ""] as const;
-}
-
-export function conversationsQueryKey(assistantId: string | null) {
-  return [CONVERSATION_LIST_PREFIX, assistantId ?? "", "foreground"] as const;
-}
-
-export function archivedConversationsQueryKey(assistantId: string | null) {
-  return [CONVERSATION_LIST_PREFIX, assistantId ?? "", "archived"] as const;
-}
-
-export function backgroundConversationsQueryKey(assistantId: string | null) {
-  return [CONVERSATION_LIST_PREFIX, assistantId ?? "", "background"] as const;
-}
-
-export function scheduledConversationsQueryKey(assistantId: string | null) {
-  return [CONVERSATION_LIST_PREFIX, assistantId ?? "", "scheduled"] as const;
-}
-
-/** Prefix key matching every per-section conversation cache. */
-export function sectionListPrefix(assistantId: string | null) {
-  return [CONVERSATION_LIST_PREFIX, assistantId ?? "", "section"] as const;
-}
-
-/**
- * Key for one section's conversation cache, a child of
- * {@link sectionListPrefix} so prefix-match invalidation reaches every
- * section at once.
- *
- * Both filter axes are in the key because both can be set at once, and two
- * sections differing only in channel must not share a cache entry.
- */
-export function sectionConversationsQueryKey(
-  assistantId: string | null,
-  filter: SectionConversationFilter,
-) {
-  return [
-    CONVERSATION_LIST_PREFIX,
-    assistantId ?? "",
-    "section",
-    filter.groupId ?? "",
-    filter.originChannel ?? "",
-  ] as const;
-}
-
-/**
- * Recover the filter a section cache was keyed by, or `null` when the key
- * is not a section key.
- *
- * The decoder to {@link sectionConversationsQueryKey}'s encoder, and it lives
- * beside it so the two cannot drift. It exists because a local write has to
- * answer "does this row belong in *this* cache", and the only statement of
- * what a cache holds is its own key: TanStack's `setQueriesData` hands its
- * updater the data alone, never the key it came from, so a membership-aware
- * write has to walk `getQueriesData` and decode each key itself.
- *
- * @see {@link https://tanstack.com/query/latest/docs/reference/QueryClient#queryclientsetqueriesdata}
- */
-export function parseSectionConversationsQueryKey(
-  queryKey: readonly unknown[],
-): SectionConversationFilter | null {
-  const [prefix, , discriminator, groupId, originChannel] = queryKey;
-  if (
-    prefix !== CONVERSATION_LIST_PREFIX ||
-    discriminator !== "section" ||
-    typeof groupId !== "string" ||
-    typeof originChannel !== "string"
-  ) {
-    return null;
-  }
-  /* The encoder writes "" for an absent axis, so "" decodes back to absent
-     rather than to a filter on the empty string. */
-  return {
-    ...(groupId === "" ? {} : { groupId: groupId as ConversationGroupId }),
-    ...(originChannel === ""
-      ? {}
-      : { originChannel: originChannel as OriginChannel }),
-  };
-}
 
 /**
  * Key for the server-side unread conversation count
@@ -146,9 +53,10 @@ export function parseSectionConversationsQueryKey(
  * (see {@link fetchUnreadConversationCount}).
  *
  * Deliberately the generated key, NOT a child of
- * {@link conversationListPrefix}: the prefix-wide helpers in
- * `conversation-cache.ts` treat every entry under the prefix as a
- * `Conversation[]`, and this cache holds a scalar.
+ * the list prefix (`conversationListPrefix` in `conversation-list-keys.ts`):
+ * the prefix-wide helpers in `conversation-cache.ts` treat every entry
+ * under it as a {@link ConversationListPage}, and this cache holds a scalar.
+ * The generated key's `_id` keeps the two apart.
  */
 export function unreadConversationCountQueryKey(assistantId: string | null) {
   return conversationsUnreadcountGetQueryKey({
@@ -205,43 +113,16 @@ type _Exhaustive =
 export type ConversationGroupId = ConversationListQuery["groupId"];
 
 /**
- * What one sidebar section asks the server for.
- *
- * Both axes together, because a section can need both: a channel card is
- * that channel *and* ungrouped, since `origin_channel` is a separate column
- * from `group_id` and a Slack conversation filed into a custom group would
- * otherwise render in two cards.
+ * A list read's filter is the route's query parameters minus pagination,
+ * defined once in `conversation-list-keys.ts` from the generated request
+ * type. A section is a filter on the group and/or channel axis (both at
+ * once for a channel card: that channel *and* ungrouped, since
+ * `origin_channel` is a separate column from `group_id`); the buckets are
+ * filters on type and archive status. Re-exported here while callers
+ * migrate; the canonical home is the key module.
  */
-export interface SectionConversationFilter {
-  groupId?: ConversationGroupId;
-  originChannel?: OriginChannel;
-}
+export type { ConversationListFilter } from "@/utils/conversation-list-keys";
 
-type FetchConversationListOptions = {
-  conversationType?: "background" | "scheduled";
-  /**
-   * Filter by archive state. Defaults to `"active"` on the daemon side, so
-   * omitting this returns non-archived rows only — matching how the sidebar
-   * wants to read the list. The Archive page passes `"archived"`.
-   */
-  archiveStatus?: "active" | "archived" | "all";
-  /**
-   * Filter by origin channel. When provided, only conversations with this
-   * exact `origin_channel` value are returned.
-   */
-  originChannel?: OriginChannel;
-  /**
-   * Filter to one group: {@link SYSTEM_PINNED_GROUP_ID} for Pinned,
-   * {@link SYSTEM_ALL_GROUP_ID} for what no group claimed, or a custom
-   * group's id.
-   *
-   * A conversation carries exactly one `group_id`, so group-scoped lists are
-   * disjoint by construction and no section needs to subtract another's rows.
-   * The server orders a group-scoped request by the user's own arrangement
-   * (display order, then recency) and never appends pinned rows to it.
-   */
-  groupId?: ConversationGroupId;
-};
 
 /**
  * Closed set of list labels carried by the `client_list.drain` watchdog event
@@ -264,7 +145,7 @@ type DrainListKind =
  * channel collapses to one `"origin_channel"` label so the set stays bounded
  * as channels are added.
  */
-function drainListKind(options: FetchConversationListOptions): DrainListKind {
+function drainListKind(options: ConversationListFilter): DrainListKind {
   if (options.archiveStatus === "archived") {
     return "archived";
   }
@@ -285,6 +166,35 @@ export type ConversationListPage = {
   conversations: Conversation[];
   hasMore: boolean;
 };
+
+/**
+ * Per-bucket shaping applied to every list read before it is cached, as
+ * data on the filter so there is one fetch path.
+ *
+ * A section (a group or channel filter) keeps server order: it renders the
+ * server's recency order as-is (LUM-3108), and a client sort could disagree
+ * with it on ties. The archived bucket sorts by `archivedAt`, the other
+ * buckets by `lastMessageAt`; the background bucket drops scheduled rows,
+ * because the daemon's `background` value is the back-compat umbrella that
+ * includes them and the sidebar keeps one conversation in one cache.
+ */
+function shapeListRows(
+  filter: ConversationListFilter,
+  rows: Conversation[],
+): Conversation[] {
+  if (isSectionFilter(filter)) {
+    return rows;
+  }
+  const kept =
+    filter.conversationType === "background"
+      ? rows.filter((c) => !isScheduledConversation(c))
+      : rows;
+  return [...kept].sort(
+    byTimestampDesc(
+      filter.archiveStatus === "archived" ? "archivedAt" : "lastMessageAt",
+    ),
+  );
+}
 
 /**
  * A page plus what it cost to fetch. Module-private, and every exported
@@ -347,20 +257,12 @@ async function fetchConversationListPage(
   assistantId: string,
   offset: number,
   source: ListFetchSource,
-  options: FetchConversationListOptions = {},
+  filter: ConversationListFilter = {},
 ): Promise<TimedConversationListPage> {
-  const { conversationType, archiveStatus, originChannel, groupId } = options;
   const startedAt = performance.now();
   const { data, error, response } = await conversationsGet({
     path: { assistant_id: assistantId },
-    query: {
-      limit: CONVERSATION_LIST_PAGE_SIZE,
-      offset,
-      ...(conversationType ? { conversationType } : {}),
-      ...(archiveStatus ? { archiveStatus } : {}),
-      ...(originChannel ? { originChannel } : {}),
-      ...(groupId ? { groupId } : {}),
-    },
+    query: { ...filter, limit: CONVERSATION_LIST_PAGE_SIZE, offset },
     throwOnError: false,
   });
   assertHasResponse(response, error, "Failed to list conversations.");
@@ -372,7 +274,7 @@ async function fetchConversationListPage(
       status: response.status,
       durationMs,
       bytes: readContentLength(response),
-      listKind: drainListKind(options),
+      listKind: drainListKind(filter),
       source,
     });
     const msg = extractErrorMessage(
@@ -392,9 +294,23 @@ async function fetchConversationListPage(
   };
 }
 
-async function fetchConversationList(
+/**
+ * Every row matching `filter`, drained page by page and shaped for its
+ * bucket ({@link shapeListRows}).
+ *
+ * The four bucket caches (foreground, background, scheduled, archived)
+ * still drain because their remaining readers assume a complete list; a
+ * section drains only for the bulk-action path (`getAllRows` in
+ * `use-section-conversations.ts`), which must cover a section's full
+ * membership while its rendered cache is a window. Bulk archive and
+ * mark-all-read send explicit id lists, so their completeness is exactly
+ * this list's completeness; a server-side group-scoped bulk operation
+ * replaces that drain. Do not reach for a drain anywhere new: a windowed
+ * cache plus load-more is the shape everything else uses.
+ */
+export async function drainConversationList(
   assistantId: string,
-  options: FetchConversationListOptions = {},
+  filter: ConversationListFilter = {},
 ): Promise<Conversation[]> {
   const all: Conversation[] = [];
   const seen = new Set<string>();
@@ -416,7 +332,7 @@ async function fetchConversationList(
       totalMs,
       maxPageMs,
       totalBytes,
-      listKind: drainListKind(options),
+      listKind: drainListKind(filter),
     });
     // The ring keeps `assistantId` for feedback bundles; the telemetry rail is
     // metadata only.
@@ -426,7 +342,7 @@ async function fetchConversationList(
       rows: all.length,
       max_page_ms: maxPageMs,
       total_bytes: totalBytes,
-      list_kind: drainListKind(options),
+      list_kind: drainListKind(filter),
     });
   };
 
@@ -437,7 +353,7 @@ async function fetchConversationList(
         assistantId,
         offset,
         "drain",
-        options,
+        filter,
       );
       pages++;
       maxPageMs = Math.max(maxPageMs, result.durationMs);
@@ -448,7 +364,7 @@ async function fetchConversationList(
         recordFirstPageFetch(
           assistantId,
           result,
-          drainListKind(options),
+          drainListKind(filter),
           "drain",
         );
       }
@@ -473,88 +389,12 @@ async function fetchConversationList(
   }
 
   recordDrain("ok");
-  return all;
-}
-
-// ---------------------------------------------------------------------------
-// Merged list (foreground + background, deduplicated)
-// ---------------------------------------------------------------------------
-
-/**
- * Fetch active or archived conversations for an assistant — foreground and
- * background buckets fetched in parallel, deduplicated by `conversationId`,
- * and sorted. Used by the Conversations browser, which lists every
- * conversation type together.
- *
- * Either bucket failing rejects the whole list. The caller presents this as
- * the complete set, so silently dropping the background rows would read as
- * "these don't exist" rather than "these didn't load" — and an archived row
- * that looks gone is worse than an error with a retry.
- *
- * @param archiveStatus — `"active"` or `"archived"` (archive page)
- * @param sortKey — which timestamp to sort descending by (default: `lastMessageAt`)
- */
-async function fetchMergedConversationList(
-  assistantId: string,
-  archiveStatus: "active" | "archived" = "active",
-  sortKey: "lastMessageAt" | "archivedAt" = "lastMessageAt",
-): Promise<Conversation[]> {
-  const opts: FetchConversationListOptions =
-    archiveStatus === "active" ? {} : { archiveStatus };
-  const bgOpts: FetchConversationListOptions = {
-    ...opts,
-    conversationType: "background",
-  };
-
-  const [foregroundResult, backgroundResult] = await Promise.allSettled([
-    fetchConversationList(assistantId, opts),
-    fetchConversationList(assistantId, bgOpts),
-  ]);
-
-  if (foregroundResult.status === "rejected") {
-    throw foregroundResult.reason;
-  }
-  if (backgroundResult.status === "rejected") {
-    throw backgroundResult.reason;
-  }
-
-  const foreground = foregroundResult.value;
-  const background = backgroundResult.value;
-
-  const seen = new Set<string>();
-  const conversations: Conversation[] = [];
-  for (const conversation of [...foreground, ...background]) {
-    if (seen.has(conversation.conversationId)) {
-      continue;
-    }
-    seen.add(conversation.conversationId);
-    conversations.push(conversation);
-  }
-
-  conversations.sort(byTimestampDesc(sortKey));
-  return conversations;
+  return shapeListRows(filter, all);
 }
 
 // ---------------------------------------------------------------------------
 // Public fetchers
 // ---------------------------------------------------------------------------
-
-/**
- * Fetch all active (non-archived) foreground conversations for a given
- * assistant, sorted newest-first.
- *
- * Background and scheduled jobs are intentionally excluded — they load
- * through `listBackgroundConversations` / `listScheduledConversations` only
- * once the user expands the Background/Scheduled sidebar sections, so a large
- * background backlog never blocks the initial chat render (the conversation
- * the user actually opened).
- */
-export async function listConversations(
-  assistantId: string,
-): Promise<Conversation[]> {
-  const foreground = await fetchConversationList(assistantId);
-  return [...foreground].sort(byTimestampDesc("lastMessageAt"));
-}
 
 /**
  * Whether the assistant has ANY active (non-archived) foreground conversation.
@@ -575,50 +415,6 @@ export async function hasAnyActiveConversation(
 }
 
 /**
- * Fetch all active (non-archived) background conversations for a given
- * assistant, sorted newest-first.
- *
- * The daemon's `conversationType=background` filter is the back-compat
- * umbrella that also returns scheduled rows, so those are filtered out here
- * to keep the background cache disjoint from the scheduled cache (one
- * conversation, one cache). Scheduled jobs load through
- * `listScheduledConversations` instead.
- *
- * Mounted lazily by the sidebar — only enabled once the user reveals the
- * Background section — so this never runs on the initial load path. Cached
- * separately from the foreground list under `backgroundConversationsQueryKey`.
- */
-export async function listBackgroundConversations(
-  assistantId: string,
-): Promise<Conversation[]> {
-  const background = await fetchConversationList(assistantId, {
-    conversationType: "background",
-  });
-  return background
-    .filter((c) => !isScheduledConversation(c))
-    .sort(byTimestampDesc("lastMessageAt"));
-}
-
-/**
- * Fetch all active (non-archived) scheduled conversations for a given
- * assistant, sorted newest-first.
- *
- * Uses the daemon's dedicated `conversationType=scheduled` filter so the
- * Scheduled sidebar section can load independently of the background
- * backlog. Mounted lazily — only enabled once the user reveals the
- * Scheduled section — so this never runs on the initial load path. Cached
- * separately under `scheduledConversationsQueryKey`.
- */
-export async function listScheduledConversations(
-  assistantId: string,
-): Promise<Conversation[]> {
-  const scheduled = await fetchConversationList(assistantId, {
-    conversationType: "scheduled",
-  });
-  return [...scheduled].sort(byTimestampDesc("lastMessageAt"));
-}
-
-/**
  * The two group ids the daemon owns. Pinning is stored as group membership,
  * and `system:all` is what no group claimed, so a conversation belongs to
  * exactly one group and group-scoped lists never overlap.
@@ -635,16 +431,6 @@ export const SYSTEM_ALL_GROUP_ID = "system:all";
  * the build here rather than sending a value the daemon rejects.
  */
 export const NATIVE_ORIGIN_CHANNEL: NonNullable<OriginChannel> = "vellum";
-
-/**
- * Fetch all archived conversations for the archive page.
- * Sorted by `archivedAt` descending (most recently archived first).
- */
-export async function listArchivedConversations(
-  assistantId: string,
-): Promise<Conversation[]> {
-  return fetchMergedConversationList(assistantId, "archived", "archivedAt");
-}
 
 /**
  * Read the server-side unread conversation count, mapping a 404 to `null`.
@@ -689,10 +475,10 @@ export type SidebarIndexSection =
  * cache holds `SidebarIndexSection[] | null` (see
  * {@link fetchSidebarSections}).
  *
- * The generated key, NOT a child of {@link conversationListPrefix}, for the
- * same reason as the unread count: the prefix-wide helpers in
- * `conversation-cache.ts` treat every entry under the prefix as a
- * `Conversation[]`, and this cache holds section rows.
+ * Not a list cache, for the same reason as the unread count: the
+ * prefix-wide helpers in `conversation-cache.ts` treat every entry under
+ * the list prefix as a {@link ConversationListPage}, and this cache holds
+ * section rows.
  */
 export function sidebarSectionsQueryKey(assistantId: string | null) {
   return conversationsSectionsGetQueryKey({
@@ -731,84 +517,23 @@ export async function fetchSidebarSections(
 }
 
 // ---------------------------------------------------------------------------
-// First-page fetchers
+// Page fetchers
 //
-// Single-request variants of the list fetchers above, used by the
-// sync_changed consumer to refresh the top of a cached list without
-// re-draining every page. At thousands of conversations the full drain is
-// hundreds of sequential GETs, which exhausts the daemon's per-client
-// rate-limit budget when sync events arrive continuously during an active
-// turn. Each returns the bucket's newest rows (one page, already filtered
-// and sorted with the same semantics as its full-list counterpart) plus
-// `hasMore` so callers can tell a complete list from a window.
+// Single-request reads. The first-page read refreshes the top of a cached
+// list without re-draining every page (at thousands of conversations a
+// drain is hundreds of sequential GETs, which exhausts the daemon's
+// per-client rate-limit budget when sync events arrive continuously during
+// an active turn), and it is the whole cold read for a windowed section.
+// Both return `hasMore` so callers can tell a complete list from a window.
 // ---------------------------------------------------------------------------
 
-/** First page of {@link listConversations} (foreground bucket). */
+/**
+ * The newest page of the list `filter` names, shaped for its bucket
+ * ({@link shapeListRows}).
+ */
 export async function listConversationsFirstPage(
   assistantId: string,
-): Promise<ConversationListPage> {
-  const page = await fetchConversationListPage(
-    assistantId,
-    0,
-    "first_page_refresh",
-  );
-  recordFirstPageFetch(assistantId, page, "foreground", "first_page_refresh");
-  return {
-    conversations: [...page.conversations].sort(
-      byTimestampDesc("lastMessageAt"),
-    ),
-    hasMore: page.hasMore,
-  };
-}
-
-/** First page of {@link listBackgroundConversations} (background bucket). */
-export async function listBackgroundConversationsFirstPage(
-  assistantId: string,
-): Promise<ConversationListPage> {
-  const page = await fetchConversationListPage(
-    assistantId,
-    0,
-    "first_page_refresh",
-    { conversationType: "background" },
-  );
-  recordFirstPageFetch(assistantId, page, "background", "first_page_refresh");
-  return {
-    conversations: page.conversations
-      .filter((c) => !isScheduledConversation(c))
-      .sort(byTimestampDesc("lastMessageAt")),
-    hasMore: page.hasMore,
-  };
-}
-
-/** First page of {@link listScheduledConversations} (scheduled bucket). */
-export async function listScheduledConversationsFirstPage(
-  assistantId: string,
-): Promise<ConversationListPage> {
-  const page = await fetchConversationListPage(
-    assistantId,
-    0,
-    "first_page_refresh",
-    { conversationType: "scheduled" },
-  );
-  recordFirstPageFetch(assistantId, page, "scheduled", "first_page_refresh");
-  return {
-    conversations: [...page.conversations].sort(
-      byTimestampDesc("lastMessageAt"),
-    ),
-    hasMore: page.hasMore,
-  };
-}
-
-/**
- * First page of one sidebar section's conversations.
- *
- * Server order is preserved rather than re-sorted: a section renders the
- * server's order as-is (recency, LUM-3108), and a client-side sort here
- * could disagree with it on ties.
- */
-export async function listSectionConversationsFirstPage(
-  assistantId: string,
-  filter: SectionConversationFilter,
+  filter: ConversationListFilter = {},
 ): Promise<ConversationListPage> {
   const page = await fetchConversationListPage(
     assistantId,
@@ -822,32 +547,16 @@ export async function listSectionConversationsFirstPage(
     drainListKind(filter),
     "first_page_refresh",
   );
-  return { conversations: page.conversations, hasMore: page.hasMore };
+  return {
+    conversations: shapeListRows(filter, page.conversations),
+    hasMore: page.hasMore,
+  };
 }
 
 /**
- * Every row of one section, drained page by page.
- *
- * Transitional, and deliberately narrow: the only caller is the bulk-action
- * path (`getAllRows` in `use-section-conversations.ts`), which must cover a
- * section's full membership while the rendered cache is a window
- * (LUM-2444). Bulk archive / mark-all-read send explicit id lists, so their
- * completeness is exactly this list's completeness. The better shape is a
- * server-side group-scoped bulk operation (one filter parameter instead of
- * an id list); when that exists, this drain goes with it. Do not reach for
- * this anywhere new - a windowed cache plus load-more is the shape
- * everything else uses.
- */
-export async function drainSectionConversations(
-  assistantId: string,
-  filter: SectionConversationFilter,
-): Promise<Conversation[]> {
-  return fetchConversationList(assistantId, filter);
-}
-
-/**
- * One page of a section's conversations at an arbitrary offset, for
- * extending a windowed cache (`loadMoreSectionConversations`).
+ * One page at an arbitrary offset, for extending a windowed cache
+ * (`loadMoreConversations`). Server order, unshaped: a load-more appends
+ * below rows already on screen.
  *
  * The offset is the caller's cached row count, not a stored page cursor:
  * optimistic writes add and remove rows, so a cursor recorded at fetch time
@@ -856,9 +565,9 @@ export async function drainSectionConversations(
  * id at the append, and a skipped row surfaces on the next first-page merge
  * or deeper load.
  */
-export async function listSectionConversationsPage(
+export async function listConversationsPage(
   assistantId: string,
-  filter: SectionConversationFilter,
+  filter: ConversationListFilter,
   offset: number,
 ): Promise<ConversationListPage> {
   const page = await fetchConversationListPage(
@@ -873,8 +582,10 @@ export async function listSectionConversationsPage(
 // ---------------------------------------------------------------------------
 // queryOptions factories
 //
-// Co-locate queryKey + queryFn + staleTime so hooks can spread them into
-// useQuery() and imperative callers can use .queryKey for cache operations.
+// The list caches' options live in `conversation-list-options.ts`; these
+// two are the sidebar's other reads. Co-locate queryKey + queryFn +
+// staleTime so hooks can spread them into useQuery() and imperative callers
+// can use .queryKey for cache operations.
 //
 // References:
 // - https://tanstack.com/query/latest/docs/framework/react/guides/query-options
@@ -882,107 +593,6 @@ export async function listSectionConversationsPage(
 // ---------------------------------------------------------------------------
 
 const QUERY_STALE_TIME_MS = 30_000;
-
-/**
- * A fully drained list as a {@link ConversationListPage}. Every list cache
- * holds the page shape, windowed or not, so the cross-cache helpers in
- * `conversation-cache.ts` never branch on shape; a drained list is simply a
- * page the server has nothing beyond.
- */
-async function drainedPage(
-  fetchAll: Promise<Conversation[]>,
-): Promise<ConversationListPage> {
-  return { conversations: await fetchAll, hasMore: false };
-}
-
-/**
- * Query options for the foreground conversation list. Spread into
- * `useQuery()` and override `enabled` at the hook level.
- */
-export function conversationListOptions(assistantId: string) {
-  return queryOptions({
-    queryKey: conversationsQueryKey(assistantId),
-    queryFn: () => drainedPage(listConversations(assistantId)),
-    staleTime: QUERY_STALE_TIME_MS,
-  });
-}
-
-/**
- * Query options for the background conversation list.
- */
-export function backgroundConversationListOptions(assistantId: string) {
-  return queryOptions({
-    queryKey: backgroundConversationsQueryKey(assistantId),
-    queryFn: () => drainedPage(listBackgroundConversations(assistantId)),
-    staleTime: QUERY_STALE_TIME_MS,
-  });
-}
-
-/**
- * Query options for the scheduled conversation list.
- */
-export function scheduledConversationListOptions(assistantId: string) {
-  return queryOptions({
-    queryKey: scheduledConversationsQueryKey(assistantId),
-    queryFn: () => drainedPage(listScheduledConversations(assistantId)),
-    staleTime: QUERY_STALE_TIME_MS,
-  });
-}
-
-/**
- * Query options for the archived conversation list.
- */
-export function archivedConversationListOptions(assistantId: string) {
-  return queryOptions({
-    queryKey: archivedConversationsQueryKey(assistantId),
-    queryFn: () => drainedPage(listArchivedConversations(assistantId)),
-    staleTime: QUERY_STALE_TIME_MS,
-  });
-}
-
-/**
- * Query options for one sidebar section's conversations.
- *
- * One factory for every section, parameterized by the filter rather than one
- * factory per filter axis: a section can constrain both at once, which a
- * per-axis factory cannot express. Caches independently per
- * `(assistantId, groupId, originChannel)`.
- *
- * The fetch is one page, not a drain (LUM-2444): a cold section costs a
- * single GET, `hasMore` marks the cache as a window, and older rows arrive
- * through `loadMoreSectionConversations` as the user scrolls.
- *
- * The queryFn is *window-preserving*: a windowed cache holds every page the
- * user scrolled in, and a plain refetch (focus past staleTime, the settle
- * invalidation after every placement) that returned page one bare would
- * truncate the window back to 50 rows under the user's scrollbar. Merging
- * the fresh page over the cached window (`mergeListFirstPage`, the same
- * rule the sync refresh uses) makes every refresh path "refresh the top,
- * keep the window". The cache is read through the query function's own
- * context, so the factory stays keyed by request identity alone like its
- * siblings; the read happens after the response so it merges against the
- * freshest rows, and a mutation that lands mid-fetch cancels this query
- * outright (`cancelConversationQueries`), so the merge cannot land on top
- * of an optimistic write.
- */
-export function sectionConversationListOptions(
-  assistantId: string,
-  filter: SectionConversationFilter,
-) {
-  return queryOptions({
-    queryKey: sectionConversationsQueryKey(assistantId, filter),
-    queryFn: async ({ client, queryKey }) => {
-      const page = await listSectionConversationsFirstPage(assistantId, filter);
-      const prev = client.getQueryData<ConversationListPage>(queryKey);
-      /* A section page has no daemon pinned-row injection; see
-         mergeListFirstPage. */
-      return prev
-        ? mergeListFirstPage(prev, page, { pinnedInjected: false })
-        : page;
-    },
-    staleTime: QUERY_STALE_TIME_MS,
-  });
-}
 
 /**
  * Query options for the server-side unread conversation count. The cache

--- a/clients/web/src/utils/conversation-list-fetchers.ts
+++ b/clients/web/src/utils/conversation-list-fetchers.ts
@@ -162,10 +162,13 @@ export type ConversationListPage = {
  *
  * A section (a group or channel filter) keeps server order: it renders the
  * server's recency order as-is (LUM-3108), and a client sort could disagree
- * with it on ties. The archived bucket sorts by `archivedAt`, the other
- * buckets by `lastMessageAt`; the background bucket drops scheduled rows,
- * because the daemon's `background` value is the back-compat umbrella that
- * includes them and the sidebar keeps one conversation in one cache.
+ * with it on ties. The archived reads sort by `archivedAt`, the other
+ * buckets by `lastMessageAt`. The active background bucket drops scheduled
+ * rows: the daemon's `background` value is the back-compat umbrella that
+ * includes them, and the sidebar keeps one conversation in one cache, with
+ * scheduled runs in their own bucket. The archived background read keeps
+ * them, because the archive view shows every type and there is no
+ * archived-scheduled cache to hold them.
  */
 function shapeListRows(
   filter: ConversationListFilter,
@@ -175,7 +178,7 @@ function shapeListRows(
     return rows;
   }
   const kept =
-    filter.conversationType === "background"
+    filter.conversationType === "background" && !isArchivedFilter(filter)
       ? rows.filter((c) => !isScheduledConversation(c))
       : rows;
   return [...kept].sort(

--- a/clients/web/src/utils/conversation-list-fetchers.ts
+++ b/clients/web/src/utils/conversation-list-fetchers.ts
@@ -41,6 +41,7 @@ import type { Conversation } from "@/types/conversation-types";
 import { readContentLength } from "@/utils/content-length";
 import {
   type ConversationListFilter,
+  isArchivedFilter,
   isSectionFilter,
 } from "@/utils/conversation-list-keys";
 import { byTimestampDesc } from "@/utils/conversation-order";
@@ -113,18 +114,6 @@ type _Exhaustive =
 export type ConversationGroupId = ConversationListQuery["groupId"];
 
 /**
- * A list read's filter is the route's query parameters minus pagination,
- * defined once in `conversation-list-keys.ts` from the generated request
- * type. A section is a filter on the group and/or channel axis (both at
- * once for a channel card: that channel *and* ungrouped, since
- * `origin_channel` is a separate column from `group_id`); the buckets are
- * filters on type and archive status. Re-exported here while callers
- * migrate; the canonical home is the key module.
- */
-export type { ConversationListFilter } from "@/utils/conversation-list-keys";
-
-
-/**
  * Closed set of list labels carried by the `client_list.drain` watchdog event
  * and by every conversation-list ring entry. One label per real caller, so the
  * archive page and the channel sections stay distinguishable from the sidebar's
@@ -146,7 +135,7 @@ type DrainListKind =
  * as channels are added.
  */
 function drainListKind(options: ConversationListFilter): DrainListKind {
-  if (options.archiveStatus === "archived") {
+  if (isArchivedFilter(options)) {
     return "archived";
   }
   if (options.conversationType !== undefined) {
@@ -190,9 +179,7 @@ function shapeListRows(
       ? rows.filter((c) => !isScheduledConversation(c))
       : rows;
   return [...kept].sort(
-    byTimestampDesc(
-      filter.archiveStatus === "archived" ? "archivedAt" : "lastMessageAt",
-    ),
+    byTimestampDesc(isArchivedFilter(filter) ? "archivedAt" : "lastMessageAt"),
   );
 }
 

--- a/clients/web/src/utils/conversation-list-fetchers.ts
+++ b/clients/web/src/utils/conversation-list-fetchers.ts
@@ -286,8 +286,8 @@ async function fetchConversationListPage(
  * bucket ({@link shapeListRows}).
  *
  * The four bucket caches (foreground, background, scheduled, archived)
- * still drain because their remaining readers assume a complete list; a
- * section drains only for the bulk-action path (`getAllRows` in
+ * drain because their readers assume a complete list; a section drains
+ * only for the bulk-action path (`getAllRows` in
  * `use-section-conversations.ts`), which must cover a section's full
  * membership while its rendered cache is a window. Bulk archive and
  * mark-all-read send explicit id lists, so their completeness is exactly

--- a/clients/web/src/utils/conversation-list-keys.test.ts
+++ b/clients/web/src/utils/conversation-list-keys.test.ts
@@ -6,6 +6,12 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import {
+  matchQuery,
+  partialMatchKey,
+  QueryClient,
+  type Query,
+} from "@tanstack/react-query";
 
 import {
   conversationsByIdGetQueryKey,
@@ -21,6 +27,13 @@ import {
 } from "./conversation-list-keys";
 
 const ASSISTANT_ID = "asst-1";
+
+/** A real `Query` for `queryKey`, so `matchQuery` runs against the real thing. */
+function queryFor(queryKey: readonly unknown[]): Query {
+  return new QueryClient().getQueryCache().build(new QueryClient(), {
+    queryKey,
+  });
+}
 
 describe("conversationListPrefix", () => {
   test("matches every list cache for the assistant, whatever its filter", () => {
@@ -84,21 +97,41 @@ describe("conversationListPrefix", () => {
   });
 });
 
+describe("a cache key as a queryClient filter", () => {
+  test("partial-matches every list whose query it is a subset of; exact does not", () => {
+    /* Fact 3 in the module doc. The foreground key's `query: {}` is a
+       subset of every filter, so as a non-exact filter it is the prefix. */
+    const foreground = conversationListQueryKey(ASSISTANT_ID, {});
+    const section = conversationListQueryKey(ASSISTANT_ID, {
+      groupId: "system:pinned",
+    });
+    expect(partialMatchKey(section, foreground)).toBe(true);
+    expect(
+      matchQuery({ queryKey: foreground, exact: true }, queryFor(section)),
+    ).toBe(false);
+    expect(
+      matchQuery({ queryKey: foreground, exact: true }, queryFor(foreground)),
+    ).toBe(true);
+  });
+});
+
 describe("conversationListFilterOf", () => {
   test("reads the filter straight off a list key", () => {
     const filter = { groupId: "system:all", originChannel: "slack" as const };
     expect(
       conversationListFilterOf(conversationListQueryKey(ASSISTANT_ID, filter)),
     ).toEqual(filter);
-    expect(conversationListFilterOf(conversationListQueryKey(ASSISTANT_ID))).toEqual(
-      {},
-    );
+    expect(
+      conversationListFilterOf(conversationListQueryKey(ASSISTANT_ID)),
+    ).toEqual({});
   });
 
   test("is undefined for a non-list key", () => {
     expect(
       conversationListFilterOf(
-        conversationsSectionsGetQueryKey({ path: { assistant_id: ASSISTANT_ID } }),
+        conversationsSectionsGetQueryKey({
+          path: { assistant_id: ASSISTANT_ID },
+        }),
       ),
     ).toBeUndefined();
     expect(conversationListFilterOf(["something", "else"])).toBeUndefined();

--- a/clients/web/src/utils/conversation-list-keys.test.ts
+++ b/clients/web/src/utils/conversation-list-keys.test.ts
@@ -6,12 +6,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import {
-  matchQuery,
-  partialMatchKey,
-  QueryClient,
-  type Query,
-} from "@tanstack/react-query";
+import { matchQuery, partialMatchKey } from "@tanstack/react-query";
 
 import {
   conversationsByIdGetQueryKey,
@@ -25,15 +20,9 @@ import {
   isConversationListKey,
   isSectionFilter,
 } from "./conversation-list-keys";
+import { queryFor } from "./conversation-list.test-helper";
 
 const ASSISTANT_ID = "asst-1";
-
-/** A real `Query` for `queryKey`, so `matchQuery` runs against the real thing. */
-function queryFor(queryKey: readonly unknown[]): Query {
-  return new QueryClient().getQueryCache().build(new QueryClient(), {
-    queryKey,
-  });
-}
 
 describe("conversationListPrefix", () => {
   test("matches every list cache for the assistant, whatever its filter", () => {

--- a/clients/web/src/utils/conversation-list-keys.test.ts
+++ b/clients/web/src/utils/conversation-list-keys.test.ts
@@ -1,0 +1,116 @@
+/**
+ * The two facts about the generated key shape that the whole cache layer
+ * stands on (see the module doc). Pinned against the real generated
+ * functions and TanStack's real `partialMatchKey`, so a codegen or library
+ * change that alters either shape fails here first.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  conversationsByIdGetQueryKey,
+  conversationsSectionsGetQueryKey,
+  conversationsUnreadcountGetQueryKey,
+} from "@/generated/daemon/@tanstack/react-query.gen";
+import {
+  conversationListFilterOf,
+  conversationListPrefix,
+  conversationListQueryKey,
+  isConversationListKey,
+  isSectionFilter,
+} from "./conversation-list-keys";
+
+const ASSISTANT_ID = "asst-1";
+
+describe("conversationListPrefix", () => {
+  test("matches every list cache for the assistant, whatever its filter", () => {
+    for (const filter of [
+      {},
+      { conversationType: "background" as const },
+      { archiveStatus: "archived" as const },
+      { groupId: "system:pinned" },
+      { groupId: "system:all", originChannel: "slack" as const },
+      { needsAttention: "true" as const },
+    ]) {
+      expect(
+        isConversationListKey(
+          conversationListQueryKey(ASSISTANT_ID, filter),
+          ASSISTANT_ID,
+        ),
+      ).toBe(true);
+    }
+  });
+
+  test("rejects the other reads that share the assistant path", () => {
+    const path = { assistant_id: ASSISTANT_ID };
+    expect(
+      isConversationListKey(
+        conversationsByIdGetQueryKey({ path: { ...path, id: "c1" } }),
+        ASSISTANT_ID,
+      ),
+    ).toBe(false);
+    expect(
+      isConversationListKey(
+        conversationsSectionsGetQueryKey({ path }),
+        ASSISTANT_ID,
+      ),
+    ).toBe(false);
+    expect(
+      isConversationListKey(
+        conversationsUnreadcountGetQueryKey({ path }),
+        ASSISTANT_ID,
+      ),
+    ).toBe(false);
+  });
+
+  test("rejects another assistant's list caches", () => {
+    expect(
+      isConversationListKey(
+        conversationListQueryKey("asst-2", { groupId: "system:pinned" }),
+        ASSISTANT_ID,
+      ),
+    ).toBe(false);
+  });
+
+  test("a cache key is a member of the prefix, never equal to it", () => {
+    /* Fact 2 in the module doc. If the foreground key were the bare prefix,
+       a prefix scan would find it as a phantom list. */
+    expect(conversationListQueryKey(ASSISTANT_ID, {})).not.toEqual(
+      conversationListPrefix(ASSISTANT_ID),
+    );
+    expect(conversationListFilterOf(conversationListPrefix(ASSISTANT_ID))).toBe(
+      undefined,
+    );
+  });
+});
+
+describe("conversationListFilterOf", () => {
+  test("reads the filter straight off a list key", () => {
+    const filter = { groupId: "system:all", originChannel: "slack" as const };
+    expect(
+      conversationListFilterOf(conversationListQueryKey(ASSISTANT_ID, filter)),
+    ).toEqual(filter);
+    expect(conversationListFilterOf(conversationListQueryKey(ASSISTANT_ID))).toEqual(
+      {},
+    );
+  });
+
+  test("is undefined for a non-list key", () => {
+    expect(
+      conversationListFilterOf(
+        conversationsSectionsGetQueryKey({ path: { assistant_id: ASSISTANT_ID } }),
+      ),
+    ).toBeUndefined();
+    expect(conversationListFilterOf(["something", "else"])).toBeUndefined();
+  });
+});
+
+describe("isSectionFilter", () => {
+  test("a group or channel constraint is a section; a bare bucket is not", () => {
+    expect(isSectionFilter({ groupId: "system:pinned" })).toBe(true);
+    expect(isSectionFilter({ originChannel: "slack" })).toBe(true);
+    expect(isSectionFilter({})).toBe(false);
+    expect(isSectionFilter({ conversationType: "background" })).toBe(false);
+    expect(isSectionFilter({ archiveStatus: "archived" })).toBe(false);
+  });
+});

--- a/clients/web/src/utils/conversation-list-keys.ts
+++ b/clients/web/src/utils/conversation-list-keys.ts
@@ -26,6 +26,13 @@
  *    prefix, a prefix scan would find that entry as a phantom list. So
  *    {@link conversationListQueryKey} always writes a `query` object, and
  *    {@link conversationListPrefix} never does.
+ * 3. **The same partial matching cuts the other way.** A cache key used as
+ *    a `queryClient` *filter* (`invalidateQueries`, `cancelQueries`) matches
+ *    every key its `query` is a subset of, so the foreground key
+ *    `{ query: {} }` would match every list cache. Read and write one cache
+ *    by its key (`getQueryData`, `setQueryData`, exact by construction);
+ *    to filter to one cache pass `exact: true`; to filter to a subset use
+ *    {@link conversationListQueryFilter}.
  *
  * `limit` and `offset` are deliberately not part of the key. The key names
  * the filter; pagination lives inside the cached page (`hasMore` and the
@@ -78,6 +85,11 @@ export const ARCHIVED_BACKGROUND_FILTER: ConversationListFilter = {
   conversationType: "background",
 };
 
+/** The `_id` the generated key stamps on every list read, read off the key itself. */
+const LIST_OPERATION_ID = conversationsGetQueryKey({
+  path: { assistant_id: "" },
+})[0]._id;
+
 /** The generated key type for one list cache; what `partialMatchKey` walks. */
 export type ConversationListQueryKey = ReturnType<
   typeof conversationsGetQueryKey
@@ -106,7 +118,9 @@ export function conversationListQueryKey(
 export function conversationListPrefix(
   assistantId: string | null,
 ): ConversationListQueryKey {
-  return conversationsGetQueryKey({ path: { assistant_id: assistantId ?? "" } });
+  return conversationsGetQueryKey({
+    path: { assistant_id: assistantId ?? "" },
+  });
 }
 
 /**
@@ -139,7 +153,7 @@ export function conversationListFilterOf(
   if (
     typeof head !== "object" ||
     head === null ||
-    (head as { _id?: unknown })._id !== "conversationsGet"
+    (head as { _id?: unknown })._id !== LIST_OPERATION_ID
   ) {
     return undefined;
   }
@@ -182,6 +196,11 @@ export function isSectionFilter(filter: ConversationListFilter): boolean {
   return filter.groupId !== undefined || filter.originChannel !== undefined;
 }
 
+/** Whether a list filter names an archived list (the archive view's reads). */
+export function isArchivedFilter(filter: ConversationListFilter): boolean {
+  return filter.archiveStatus === "archived";
+}
+
 /**
  * Whether the daemon appends every pinned row to this filter's first page.
  * True for exactly one read, the fully unfiltered foreground list (every
@@ -191,7 +210,9 @@ export function isSectionFilter(filter: ConversationListFilter): boolean {
  * unfiltered list, and matters to `mergeListFirstPage`, which must keep the
  * injected rows out of its window cutoff.
  */
-export function isPinnedInjectedFilter(filter: ConversationListFilter): boolean {
+export function isPinnedInjectedFilter(
+  filter: ConversationListFilter,
+): boolean {
   return (
     filter.conversationType === undefined &&
     (filter.archiveStatus === undefined || filter.archiveStatus === "active") &&

--- a/clients/web/src/utils/conversation-list-keys.ts
+++ b/clients/web/src/utils/conversation-list-keys.ts
@@ -5,9 +5,9 @@
  * Every conversation list cache is a `GET /v1/conversations` read scoped by
  * its filter, so its key is the generated key for that request:
  * `[{ _id: "conversationsGet", path: { assistant_id }, query: <filter> }]`.
- * The four caches the app used to name (foreground, background, scheduled,
- * archived) and the per-section caches are all this one key with different
- * `query` values; there is no second key scheme.
+ * The four bucket caches (foreground, background, scheduled, archived) and
+ * the per-section caches are all this one key with different `query`
+ * values; there is no second key scheme.
  *
  * Two facts about the generated key shape decide how it is used, both
  * verified by executing `partialMatchKey` against the generated functions
@@ -59,9 +59,10 @@ export type ConversationListFilter = Omit<
 >;
 
 /**
- * Filters for the four bucket reads that predate the per-section queries.
- * Named so callers spread the same object and get the same key; every one
- * of them is still one `conversationsGet` request scoped by these params.
+ * Filters for the four bucket reads: whole-list reads for the surfaces that
+ * need every row of a type. Named so callers spread the same object and get
+ * the same key; each is one `conversationsGet` request scoped by these
+ * params.
  */
 export const FOREGROUND_FILTER: ConversationListFilter = {};
 export const BACKGROUND_FILTER: ConversationListFilter = {
@@ -206,8 +207,8 @@ export function isArchivedFilter(filter: ConversationListFilter): boolean {
  * True for exactly one read, the fully unfiltered foreground list (every
  * axis at its default); every scoped read gets the filtered page alone.
  * Mirrors the guard in the daemon's `handleListConversations`, the
- * compatibility shim for clients that still read Pinned out of the
- * unfiltered list, and matters to `mergeListFirstPage`, which must keep the
+ * compatibility shim for clients that read Pinned out of the unfiltered
+ * list, and matters to `mergeListFirstPage`, which must keep the
  * injected rows out of its window cutoff.
  */
 export function isPinnedInjectedFilter(

--- a/clients/web/src/utils/conversation-list-keys.ts
+++ b/clients/web/src/utils/conversation-list-keys.ts
@@ -36,7 +36,7 @@
  * documented on the options factories, not here.
  */
 
-import { partialMatchKey } from "@tanstack/react-query";
+import { partialMatchKey, type QueryFilters } from "@tanstack/react-query";
 
 import { conversationsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
 import type { ConversationsGetData } from "@/generated/daemon/types.gen";
@@ -50,6 +50,33 @@ export type ConversationListFilter = Omit<
   NonNullable<ConversationsGetData["query"]>,
   "limit" | "offset"
 >;
+
+/**
+ * Filters for the four bucket reads that predate the per-section queries.
+ * Named so callers spread the same object and get the same key; every one
+ * of them is still one `conversationsGet` request scoped by these params.
+ */
+export const FOREGROUND_FILTER: ConversationListFilter = {};
+export const BACKGROUND_FILTER: ConversationListFilter = {
+  conversationType: "background",
+};
+export const SCHEDULED_FILTER: ConversationListFilter = {
+  conversationType: "scheduled",
+};
+export const ARCHIVED_FILTER: ConversationListFilter = {
+  archiveStatus: "archived",
+};
+/**
+ * The archived view shows archived rows of every type, and the route's
+ * `conversationType` defaults to standard with no "all" value, so archived
+ * background rows are a second request. It is its own cache, keyed by its
+ * own filter, and the archive page merges the two at the consumer; there is
+ * no honest single key for a client-side union of two requests.
+ */
+export const ARCHIVED_BACKGROUND_FILTER: ConversationListFilter = {
+  archiveStatus: "archived",
+  conversationType: "background",
+};
 
 /** The generated key type for one list cache; what `partialMatchKey` walks. */
 export type ConversationListQueryKey = ReturnType<
@@ -125,10 +152,51 @@ export function conversationListFilterOf(
 }
 
 /**
+ * A `queryClient` filter selecting the subset of one assistant's list
+ * caches whose filter satisfies `matches`: the prefix narrows to list
+ * caches and the predicate reads each key's filter, and TanStack applies
+ * both. For "invalidate every section" or "every archived list" without
+ * enumerating keys.
+ *
+ * @see {@link https://tanstack.com/query/latest/docs/framework/react/guides/filters#query-filters}
+ */
+export function conversationListQueryFilter(
+  assistantId: string | null,
+  matches: (filter: ConversationListFilter) => boolean,
+): QueryFilters {
+  return {
+    queryKey: conversationListPrefix(assistantId),
+    predicate: (query) => {
+      const filter = conversationListFilterOf(query.queryKey);
+      return filter !== undefined && matches(filter);
+    },
+  };
+}
+
+/**
  * Whether a list filter names a sidebar section (as opposed to a whole
  * bucket): any filter constrained on the group or channel axis. The
  * placement seam moves rows between section caches only.
  */
 export function isSectionFilter(filter: ConversationListFilter): boolean {
   return filter.groupId !== undefined || filter.originChannel !== undefined;
+}
+
+/**
+ * Whether the daemon appends every pinned row to this filter's first page.
+ * True for exactly one read, the fully unfiltered foreground list (every
+ * axis at its default); every scoped read gets the filtered page alone.
+ * Mirrors the guard in the daemon's `handleListConversations`, the
+ * compatibility shim for clients that still read Pinned out of the
+ * unfiltered list, and matters to `mergeListFirstPage`, which must keep the
+ * injected rows out of its window cutoff.
+ */
+export function isPinnedInjectedFilter(filter: ConversationListFilter): boolean {
+  return (
+    filter.conversationType === undefined &&
+    (filter.archiveStatus === undefined || filter.archiveStatus === "active") &&
+    filter.originChannel === undefined &&
+    filter.groupId === undefined &&
+    filter.needsAttention === undefined
+  );
 }

--- a/clients/web/src/utils/conversation-list-keys.ts
+++ b/clients/web/src/utils/conversation-list-keys.ts
@@ -1,0 +1,134 @@
+/**
+ * Query keys for the conversation list caches: the generated
+ * `conversationsGetQueryKey`, and nothing else.
+ *
+ * Every conversation list cache is a `GET /v1/conversations` read scoped by
+ * its filter, so its key is the generated key for that request:
+ * `[{ _id: "conversationsGet", path: { assistant_id }, query: <filter> }]`.
+ * The four caches the app used to name (foreground, background, scheduled,
+ * archived) and the per-section caches are all this one key with different
+ * `query` values; there is no second key scheme.
+ *
+ * Two facts about the generated key shape decide how it is used, both
+ * verified by executing `partialMatchKey` against the generated functions
+ * rather than by reading about them:
+ *
+ * 1. **The key without `query` is the prefix.** `partialMatchKey` matches
+ *    an object key when every property of the filter is deep-equal in the
+ *    candidate, so `{ _id, path }` matches every list read for that
+ *    assistant and rejects the by-id detail (`conversationsByIdGet`), the
+ *    section index, the unread count, and every other assistant. That is
+ *    the whole "prefix scan" the cross-cache helpers depend on, provided by
+ *    TanStack rather than by a hand-rolled key layout.
+ * 2. **A cache's own key must carry `query`, even when empty.** The prefix
+ *    `{ _id, path }` and the foreground list's key `{ _id, path, query: {} }`
+ *    are different keys. If the foreground list were keyed by the bare
+ *    prefix, a prefix scan would find that entry as a phantom list. So
+ *    {@link conversationListQueryKey} always writes a `query` object, and
+ *    {@link conversationListPrefix} never does.
+ *
+ * `limit` and `offset` are deliberately not part of the key. The key names
+ * the filter; pagination lives inside the cached page (`hasMore` and the
+ * rows loaded so far), so a load-more extends one cache entry rather than
+ * minting one per page.
+ *
+ * `select`-side transforms and the page shape the cache holds are
+ * documented on the options factories, not here.
+ */
+
+import { partialMatchKey } from "@tanstack/react-query";
+
+import { conversationsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
+import type { ConversationsGetData } from "@/generated/daemon/types.gen";
+
+/**
+ * The filter a conversation list cache is keyed by: the route's query
+ * parameters minus pagination. Absent means "no constraint on that axis",
+ * exactly as the route reads it, so the foreground list is `{}`.
+ */
+export type ConversationListFilter = Omit<
+  NonNullable<ConversationsGetData["query"]>,
+  "limit" | "offset"
+>;
+
+/** The generated key type for one list cache; what `partialMatchKey` walks. */
+export type ConversationListQueryKey = ReturnType<
+  typeof conversationsGetQueryKey
+>;
+
+/**
+ * Key for one conversation list cache. Always carries `query`, so it is a
+ * member of the prefix and never equal to it (see the module doc, fact 2).
+ */
+export function conversationListQueryKey(
+  assistantId: string | null,
+  filter: ConversationListFilter = {},
+): ConversationListQueryKey {
+  return conversationsGetQueryKey({
+    path: { assistant_id: assistantId ?? "" },
+    query: filter,
+  });
+}
+
+/**
+ * Prefix matching every conversation list cache for one assistant, and
+ * nothing else that shares its `assistant_id` path. Pass to `queryClient`
+ * filters (`getQueriesData`, `cancelQueries`, `invalidateQueries`) and to
+ * {@link isConversationListKey}.
+ */
+export function conversationListPrefix(
+  assistantId: string | null,
+): ConversationListQueryKey {
+  return conversationsGetQueryKey({ path: { assistant_id: assistantId ?? "" } });
+}
+
+/**
+ * Whether `queryKey` is one assistant's conversation list cache. The
+ * predicate a query-cache subscriber uses to ignore unrelated traffic.
+ */
+export function isConversationListKey(
+  queryKey: readonly unknown[],
+  assistantId: string | null,
+): boolean {
+  return partialMatchKey(queryKey, conversationListPrefix(assistantId));
+}
+
+/**
+ * The filter a conversation list cache was keyed by, read straight off the
+ * generated key. `undefined` when the key is not a list key.
+ *
+ * Exists because a membership-aware write has to answer "does this row
+ * belong in *this* cache", and the only statement of what a cache holds is
+ * its key: TanStack's `setQueriesData` hands an updater the data alone, so
+ * the write walks `getQueriesData` and reads each key. With the generated
+ * key that read is a property access, not a positional decode.
+ *
+ * @see {@link https://tanstack.com/query/latest/docs/reference/QueryClient#queryclientsetqueriesdata}
+ */
+export function conversationListFilterOf(
+  queryKey: readonly unknown[],
+): ConversationListFilter | undefined {
+  const head = queryKey[0];
+  if (
+    typeof head !== "object" ||
+    head === null ||
+    (head as { _id?: unknown })._id !== "conversationsGet"
+  ) {
+    return undefined;
+  }
+  const query = (head as { query?: unknown }).query;
+  /* A key with no `query` is the prefix, not a cache (module doc, fact 2). */
+  if (typeof query !== "object" || query === null) {
+    return undefined;
+  }
+  return query as ConversationListFilter;
+}
+
+/**
+ * Whether a list filter names a sidebar section (as opposed to a whole
+ * bucket): any filter constrained on the group or channel axis. The
+ * placement seam moves rows between section caches only.
+ */
+export function isSectionFilter(filter: ConversationListFilter): boolean {
+  return filter.groupId !== undefined || filter.originChannel !== undefined;
+}

--- a/clients/web/src/utils/conversation-list-options.test.ts
+++ b/clients/web/src/utils/conversation-list-options.test.ts
@@ -1,0 +1,222 @@
+/**
+ * The one options factory behind every conversation list cache: which
+ * filters are windowed and which drain, what a drained cache looks like at
+ * rest, and that a windowed refetch keeps the scrolled-in window. Run
+ * against a real `QueryClient` and the real generated key, with only the
+ * daemon transport stubbed, so the queryFn's use of its own context
+ * (`client`, `queryKey`) is exercised rather than mocked.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient } from "@tanstack/react-query";
+
+import { client as daemonClient } from "@/generated/daemon/client.gen";
+import {
+  ARCHIVED_FILTER,
+  BACKGROUND_FILTER,
+  conversationListQueryKey,
+  FOREGROUND_FILTER,
+} from "@/utils/conversation-list-keys";
+import { conversationListOptions } from "@/utils/conversation-list-options";
+import { listPage } from "@/utils/conversation-list.test-helper";
+import type { RawConversationSummary } from "@/utils/conversation-transforms";
+
+const ASSISTANT_ID = "assistant-1";
+
+type RawFixture = Partial<RawConversationSummary> & { id: string };
+
+function makeRaw(fixture: RawFixture): RawConversationSummary {
+  return {
+    title: "",
+    createdAt: 0,
+    updatedAt: 0,
+    lastMessageAt: 0,
+    conversationType: "standard",
+    source: "vellum",
+    groupId: "",
+    isProcessing: false,
+    ...fixture,
+  } as RawConversationSummary;
+}
+
+/**
+ * Stub the daemon transport so each list GET resolves the next fixture in
+ * order. Returns the captured queries so tests can assert what was sent.
+ */
+function stubPages(
+  fixtures: Array<{ rows: RawFixture[]; hasMore: boolean }>,
+): Record<string, unknown>[] {
+  const queries: Record<string, unknown>[] = [];
+  daemonClient.get = mock(
+    async (options: { query?: Record<string, unknown> }) => {
+      const index = queries.length;
+      queries.push({ ...(options.query ?? {}) });
+      const fixture = fixtures[index];
+      if (!fixture) {
+        throw new Error(`test setup has no fixture for request ${index}`);
+      }
+      const body = {
+        conversations: fixture.rows.map(makeRaw),
+        hasMore: fixture.hasMore,
+      };
+      return {
+        data: body,
+        error: null,
+        response: new Response(JSON.stringify(body), { status: 200 }),
+      };
+    },
+  ) as typeof daemonClient.get;
+  return queries;
+}
+
+function freshClient(): QueryClient {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+const originalGet = daemonClient.get;
+
+afterEach(() => {
+  daemonClient.get = originalGet;
+});
+
+describe("conversationListOptions", () => {
+  test("is keyed by the generated key for its filter", () => {
+    const filter = { groupId: "grp-a" };
+    expect(conversationListQueryKey(ASSISTANT_ID, filter)).toEqual(
+      conversationListOptions(ASSISTANT_ID, filter).queryKey,
+    );
+    expect(conversationListQueryKey(ASSISTANT_ID, FOREGROUND_FILTER)).toEqual(
+      conversationListOptions(ASSISTANT_ID).queryKey,
+    );
+  });
+
+  test("a bucket drains every page and rests with hasMore false", async () => {
+    const queries = stubPages([
+      { rows: [{ id: "c-0", lastMessageAt: 10 }], hasMore: true },
+      { rows: [{ id: "c-1", lastMessageAt: 20 }], hasMore: false },
+    ]);
+
+    const result = await freshClient().fetchQuery(
+      conversationListOptions(ASSISTANT_ID, FOREGROUND_FILTER),
+    );
+
+    expect(queries.map((q) => q.offset)).toEqual([0, 50]);
+    /* Newest first, whatever order the pages arrived in. */
+    expect(result.conversations.map((c) => c.conversationId)).toEqual([
+      "c-1",
+      "c-0",
+    ]);
+    expect(result.hasMore).toBe(false);
+  });
+
+  test("the background bucket drops scheduled rows the umbrella filter returns", async () => {
+    stubPages([
+      {
+        rows: [
+          { id: "bg", conversationType: "background", lastMessageAt: 10 },
+          { id: "sched", conversationType: "scheduled", lastMessageAt: 20 },
+        ],
+        hasMore: false,
+      },
+    ]);
+
+    const result = await freshClient().fetchQuery(
+      conversationListOptions(ASSISTANT_ID, BACKGROUND_FILTER),
+    );
+
+    expect(result.conversations.map((c) => c.conversationId)).toEqual(["bg"]);
+  });
+
+  test("the archived bucket orders by archivedAt, not recency", async () => {
+    stubPages([
+      {
+        rows: [
+          { id: "recent-msg", lastMessageAt: 900, archivedAt: 10 },
+          { id: "recent-archive", lastMessageAt: 100, archivedAt: 20 },
+        ],
+        hasMore: false,
+      },
+    ]);
+
+    const result = await freshClient().fetchQuery(
+      conversationListOptions(ASSISTANT_ID, ARCHIVED_FILTER),
+    );
+
+    expect(result.conversations.map((c) => c.conversationId)).toEqual([
+      "recent-archive",
+      "recent-msg",
+    ]);
+  });
+
+  test("a section fetches one page and keeps server order", async () => {
+    const queries = stubPages([
+      {
+        rows: [
+          { id: "older", lastMessageAt: 10 },
+          { id: "newer", lastMessageAt: 20 },
+        ],
+        hasMore: true,
+      },
+    ]);
+
+    const result = await freshClient().fetchQuery(
+      conversationListOptions(ASSISTANT_ID, { groupId: "grp-a" }),
+    );
+
+    expect(queries).toHaveLength(1);
+    expect(queries[0]).toMatchObject({ groupId: "grp-a", offset: 0 });
+    expect(result.conversations.map((c) => c.conversationId)).toEqual([
+      "older",
+      "newer",
+    ]);
+    expect(result.hasMore).toBe(true);
+  });
+
+  test("a plain refetch of a section keeps the scrolled-in window", async () => {
+    /* The queryFn merges the fresh first page over the cached window. A
+       bare page-one return here would mean every focus refetch and every
+       settle invalidation truncated a scrolled window back to 50 rows
+       under the user's scrollbar. */
+    const client = freshClient();
+    const filter = { groupId: "grp-a" };
+    client.setQueryData(
+      conversationListQueryKey(ASSISTANT_ID, filter),
+      listPage(
+        [
+          {
+            conversationId: "c-top",
+            title: "",
+            createdAt: 0,
+            lastMessageAt: 5000,
+          },
+          {
+            conversationId: "c-scrolled-in",
+            title: "",
+            createdAt: 0,
+            lastMessageAt: 100,
+          },
+        ],
+        true,
+      ),
+    );
+    // The fresh page holds only the window top; the scrolled-in row sorts
+    // below the page's cutoff, so the merge must keep it.
+    stubPages([
+      { rows: [{ id: "c-top", lastMessageAt: 5000 }], hasMore: true },
+    ]);
+
+    // staleTime 0: the seeded cache is seconds old, and fetchQuery serves
+    // fresh data without running the queryFn, which would pass this test
+    // without exercising the merge at all.
+    const result = await client.fetchQuery({
+      ...conversationListOptions(ASSISTANT_ID, filter),
+      staleTime: 0,
+    });
+
+    expect(result.conversations.map((c) => c.conversationId)).toEqual([
+      "c-top",
+      "c-scrolled-in",
+    ]);
+    expect(result.hasMore).toBe(true);
+  });
+});

--- a/clients/web/src/utils/conversation-list-options.test.ts
+++ b/clients/web/src/utils/conversation-list-options.test.ts
@@ -12,6 +12,7 @@ import { QueryClient } from "@tanstack/react-query";
 
 import { client as daemonClient } from "@/generated/daemon/client.gen";
 import {
+  ARCHIVED_BACKGROUND_FILTER,
   ARCHIVED_FILTER,
   BACKGROUND_FILTER,
   conversationListQueryKey,
@@ -125,6 +126,39 @@ describe("conversationListOptions", () => {
     );
 
     expect(result.conversations.map((c) => c.conversationId)).toEqual(["bg"]);
+  });
+
+  test("the archived background read keeps scheduled rows", async () => {
+    /* The archive view has no archived-scheduled cache; this read is the
+       only one that returns archived scheduled runs. */
+    stubPages([
+      {
+        rows: [
+          {
+            id: "bg",
+            conversationType: "background",
+            lastMessageAt: 10,
+            archivedAt: 10,
+          },
+          {
+            id: "sched",
+            conversationType: "scheduled",
+            lastMessageAt: 20,
+            archivedAt: 20,
+          },
+        ],
+        hasMore: false,
+      },
+    ]);
+
+    const result = await freshClient().fetchQuery(
+      conversationListOptions(ASSISTANT_ID, ARCHIVED_BACKGROUND_FILTER),
+    );
+
+    expect(result.conversations.map((c) => c.conversationId)).toEqual([
+      "sched",
+      "bg",
+    ]);
   });
 
   test("the archived bucket orders by archivedAt, not recency", async () => {

--- a/clients/web/src/utils/conversation-list-options.ts
+++ b/clients/web/src/utils/conversation-list-options.ts
@@ -1,0 +1,97 @@
+/**
+ * Query options for the conversation list caches: one factory over the
+ * generated `conversationsGet` request, keyed by the generated key.
+ *
+ * A conversation list cache is a `GET /v1/conversations` read scoped by a
+ * filter, so its options are the generated request with two additions the
+ * app needs and the codegen cannot know: the rows are `Conversation` (the
+ * wire row through `toConversation`), and the cached value is a
+ * {@link ConversationListPage} whose `hasMore` says whether the cache is a
+ * window onto a longer list. That value shape is what the placement seam
+ * writes and every reader expects; keeping it here means one factory
+ * serves every list read.
+ *
+ * Two loading modes, and which one a filter gets is decided here rather
+ * than by the caller:
+ *
+ * - **Windowed**: one page on mount, more on scroll
+ *   (`loadMoreConversations`), sync and settle refreshes merge a
+ *   fresh first page over the window (`mergeListFirstPage`). Every
+ *   section (a filter on the group or channel axis) is windowed.
+ * - **Drained**: every page fetched serially, `hasMore: false` at rest.
+ *   The four bucket reads (foreground, background, scheduled, archived)
+ *   still drain because their remaining readers assume a complete list;
+ *   they stop draining as those readers move to server answers, not as a
+ *   side effect of a key change.
+ *
+ * The transform runs in the queryFn, so the cache holds `Conversation` and
+ * not the wire shape. That is a documented TanStack option with a named
+ * cost: the raw response is not available from the cache, so the generated
+ * `SetQueryData` helpers for this route do not apply. It is kept for now
+ * because the placement seam mints rows optimistically (`prependConversation`,
+ * `surfaceConversationInCaches`) and there is no `Conversation` -> wire
+ * inverse; once mutation responses carry the row's post-state the seam
+ * applies server rows and the transform moves to `select`.
+ *
+ * @see {@link https://tanstack.com/query/latest/docs/framework/react/guides/query-options}
+ * @see {@link https://tkdodo.eu/blog/react-query-data-transformations}
+ */
+
+import { queryOptions } from "@tanstack/react-query";
+
+import {
+  type ConversationListFilter,
+  conversationListQueryKey,
+  FOREGROUND_FILTER,
+  isSectionFilter,
+} from "@/utils/conversation-list-keys";
+import {
+  type ConversationListPage,
+  drainConversationList,
+  listConversationsFirstPage,
+} from "@/utils/conversation-list-fetchers";
+import { mergeListFirstPage } from "@/utils/conversation-order";
+
+const QUERY_STALE_TIME_MS = 30_000;
+
+/**
+ * Query options for one conversation list cache.
+ *
+ * Spread into `useQuery()` and set `enabled` at the hook. Sections
+ * (group/channel filters) are windowed; the buckets drain. The windowed
+ * queryFn is *window-preserving*: a plain refetch (focus past staleTime,
+ * a settle invalidation) merges the fresh first page over the cached
+ * window rather than replacing it, so a scrolled-in window is never
+ * truncated to page one under the user's scrollbar. The cache is read
+ * through the query function's own context (`client`, `queryKey`), so the
+ * factory is keyed by request identity alone.
+ */
+export function conversationListOptions(
+  assistantId: string,
+  filter: ConversationListFilter = FOREGROUND_FILTER,
+) {
+  const queryKey = conversationListQueryKey(assistantId, filter);
+  if (isSectionFilter(filter)) {
+    return queryOptions({
+      queryKey,
+      queryFn: async ({ client }) => {
+        const page = await listConversationsFirstPage(assistantId, filter);
+        const prev = client.getQueryData<ConversationListPage>(queryKey);
+        /* A section page has no daemon pinned-row injection; see
+           mergeListFirstPage. */
+        return prev
+          ? mergeListFirstPage(prev, page, { pinnedInjected: false })
+          : page;
+      },
+      staleTime: QUERY_STALE_TIME_MS,
+    });
+  }
+  return queryOptions({
+    queryKey,
+    queryFn: async (): Promise<ConversationListPage> => ({
+      conversations: await drainConversationList(assistantId, filter),
+      hasMore: false,
+    }),
+    staleTime: QUERY_STALE_TIME_MS,
+  });
+}

--- a/clients/web/src/utils/conversation-list-options.ts
+++ b/clients/web/src/utils/conversation-list-options.ts
@@ -20,18 +20,19 @@
  *   section (a filter on the group or channel axis) is windowed.
  * - **Drained**: every page fetched serially, `hasMore: false` at rest.
  *   The four bucket reads (foreground, background, scheduled, archived)
- *   still drain because their remaining readers assume a complete list;
- *   they stop draining as those readers move to server answers, not as a
- *   side effect of a key change.
+ *   drain because their readers assume a complete list; a bucket becomes
+ *   windowed only when its readers stop needing every row, never as a side
+ *   effect of the key.
  *
  * The transform runs in the queryFn, so the cache holds `Conversation` and
  * not the wire shape. That is a documented TanStack option with a named
  * cost: the raw response is not available from the cache, so the generated
- * `SetQueryData` helpers for this route do not apply. It is kept for now
- * because the placement seam mints rows optimistically (`prependConversation`,
- * `surfaceConversationInCaches`) and there is no `Conversation` -> wire
- * inverse; once mutation responses carry the row's post-state the seam
- * applies server rows and the transform moves to `select`.
+ * `SetQueryData` helpers for this route do not apply. The constraint that
+ * forces it is the placement seam: it mints rows optimistically
+ * (`prependConversation`, `surfaceConversationInCaches`) and there is no
+ * `Conversation` -> wire inverse, so the cache cannot hold the wire shape
+ * while the client authors rows. A seam that applies server-returned rows
+ * lets the transform move to `select`.
  *
  * @see {@link https://tanstack.com/query/latest/docs/framework/react/guides/query-options}
  * @see {@link https://tkdodo.eu/blog/react-query-data-transformations}

--- a/clients/web/src/utils/conversation-list-options.ts
+++ b/clients/web/src/utils/conversation-list-options.ts
@@ -43,6 +43,7 @@ import {
   type ConversationListFilter,
   conversationListQueryKey,
   FOREGROUND_FILTER,
+  isPinnedInjectedFilter,
   isSectionFilter,
 } from "@/utils/conversation-list-keys";
 import {
@@ -77,10 +78,10 @@ export function conversationListOptions(
       queryFn: async ({ client }) => {
         const page = await listConversationsFirstPage(assistantId, filter);
         const prev = client.getQueryData<ConversationListPage>(queryKey);
-        /* A section page has no daemon pinned-row injection; see
-           mergeListFirstPage. */
         return prev
-          ? mergeListFirstPage(prev, page, { pinnedInjected: false })
+          ? mergeListFirstPage(prev, page, {
+              pinnedInjected: isPinnedInjectedFilter(filter),
+            })
           : page;
       },
       staleTime: QUERY_STALE_TIME_MS,

--- a/clients/web/src/utils/conversation-list-options.ts
+++ b/clients/web/src/utils/conversation-list-options.ts
@@ -40,9 +40,10 @@
 
 import { queryOptions } from "@tanstack/react-query";
 
+import { conversationsGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
 import {
   type ConversationListFilter,
-  conversationListQueryKey,
+  type ConversationListQueryKey,
   FOREGROUND_FILTER,
   isPinnedInjectedFilter,
   isSectionFilter,
@@ -72,7 +73,17 @@ export function conversationListOptions(
   assistantId: string,
   filter: ConversationListFilter = FOREGROUND_FILTER,
 ) {
-  const queryKey = conversationListQueryKey(assistantId, filter);
+  /* The generated factory is the route contract, and its key is what this
+     cache is filed under. Its `queryFn` is not reused: it returns the wire
+     page for one offset, typed as `ConversationsGetResponse` through every
+     TanStack option slot (`select`, `initialData`, `placeholderData`), so
+     the object cannot be spread under a `queryFn` that returns
+     `ConversationListPage`; the key is taken from it and the query function
+     is this module's. */
+  const queryKey: ConversationListQueryKey = conversationsGetOptions({
+    path: { assistant_id: assistantId },
+    query: filter,
+  }).queryKey;
   if (isSectionFilter(filter)) {
     return queryOptions({
       queryKey,

--- a/clients/web/src/utils/conversation-list.test-helper.ts
+++ b/clients/web/src/utils/conversation-list.test-helper.ts
@@ -9,6 +9,8 @@
  * explicitly.
  */
 
+import { QueryClient, type Query } from "@tanstack/react-query";
+
 import type { Conversation } from "@/types/conversation-types";
 import type { ConversationListPage } from "@/utils/conversation-list-fetchers";
 
@@ -17,4 +19,16 @@ export function listPage(
   hasMore = false,
 ): ConversationListPage {
   return { conversations, hasMore };
+}
+
+/**
+ * A real `Query` for `queryKey`, so a test can run TanStack's own
+ * `matchQuery` against a `queryClient` filter instead of reading key slots.
+ * Built in `client` when given, so it is the same object the client holds.
+ */
+export function queryFor(
+  queryKey: readonly unknown[],
+  client: QueryClient = new QueryClient(),
+): Query {
+  return client.getQueryCache().build(client, { queryKey });
 }

--- a/clients/web/src/utils/conversation-transforms-list.test.ts
+++ b/clients/web/src/utils/conversation-transforms-list.test.ts
@@ -2,10 +2,13 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 
 import { client as daemonClient } from "@/generated/daemon/client.gen";
 import {
+  drainConversationList,
   hasAnyActiveConversation,
-  listBackgroundConversations,
-  listConversations,
 } from "@/utils/conversation-list-fetchers";
+import {
+  BACKGROUND_FILTER,
+  FOREGROUND_FILTER,
+} from "@/utils/conversation-list-keys";
 import {
   toConversation,
   type RawConversationSummary,
@@ -275,10 +278,10 @@ describe("toConversation — Slack channel binding", () => {
 });
 
 // ---------------------------------------------------------------------------
-// listConversations — pagination
+// drainConversationList (foreground) pagination
 // ---------------------------------------------------------------------------
 
-describe("listConversations — pagination", () => {
+describe("drainConversationList (foreground) pagination", () => {
   const originalGet = daemonClient.get;
   type GetOptions = {
     query?: Record<string, unknown>;
@@ -355,7 +358,10 @@ describe("listConversations — pagination", () => {
       ],
     });
 
-    const result = await listConversations("assistant-1");
+    const result = await drainConversationList(
+      "assistant-1",
+      FOREGROUND_FILTER,
+    );
 
     expect(result).toHaveLength(80);
     expect(result.at(0)?.conversationId).toBe("foreground-0");
@@ -380,7 +386,10 @@ describe("listConversations — pagination", () => {
       foreground: [{ conversations: [makeConversationRow("only-one")] }],
     });
 
-    const result = await listConversations("assistant-1");
+    const result = await drainConversationList(
+      "assistant-1",
+      FOREGROUND_FILTER,
+    );
 
     expect(result).toHaveLength(1);
     // Foreground only — a single page, no background fetch.
@@ -395,7 +404,10 @@ describe("listConversations — pagination", () => {
       ],
     });
 
-    const result = await listConversations("assistant-1");
+    const result = await drainConversationList(
+      "assistant-1",
+      FOREGROUND_FILTER,
+    );
 
     expect(result).toHaveLength(1);
     expect(calls).toHaveLength(2); // 2 foreground pages, no background
@@ -403,10 +415,10 @@ describe("listConversations — pagination", () => {
 });
 
 // ---------------------------------------------------------------------------
-// listBackgroundConversations — pagination
+// drainConversationList (background) pagination
 // ---------------------------------------------------------------------------
 
-describe("listBackgroundConversations — pagination", () => {
+describe("drainConversationList (background) pagination", () => {
   const originalGet = daemonClient.get;
   type GetOptions = {
     query?: Record<string, unknown>;
@@ -466,7 +478,10 @@ describe("listBackgroundConversations — pagination", () => {
     }) as typeof daemonClient.get;
 
     // WHEN we list background conversations
-    const result = await listBackgroundConversations("assistant-1");
+    const result = await drainConversationList(
+      "assistant-1",
+      BACKGROUND_FILTER,
+    );
 
     // THEN both pages are returned
     expect(result.map((c) => c.conversationId)).toEqual(["bg-0", "bg-1"]);

--- a/clients/web/src/utils/section-membership.test.ts
+++ b/clients/web/src/utils/section-membership.test.ts
@@ -22,13 +22,14 @@ import { QueryClient } from "@tanstack/react-query";
 
 import type { Conversation } from "@/types/conversation-types";
 import {
-  conversationsQueryKey,
-  sectionConversationsQueryKey,
   sidebarSectionsQueryKey,
-  type SectionConversationFilter,
   type SidebarIndexSection,
   type ConversationListPage,
 } from "@/utils/conversation-list-fetchers";
+import {
+  conversationListQueryKey,
+  type ConversationListFilter,
+} from "@/utils/conversation-list-keys";
 import { listPage } from "@/utils/conversation-list.test-helper";
 import { groupsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
 import {
@@ -40,17 +41,17 @@ import {
 
 const ASSISTANT_ID = "asst-1";
 
-const PINNED: SectionConversationFilter = { groupId: "system:pinned" };
-const CHATS: SectionConversationFilter = { groupId: "system:all" };
-const SLACK: SectionConversationFilter = {
+const PINNED: ConversationListFilter = { groupId: "system:pinned" };
+const CHATS: ConversationListFilter = { groupId: "system:all" };
+const SLACK: ConversationListFilter = {
   groupId: "system:all",
   originChannel: "slack",
 };
-const NATIVE_CHATS: SectionConversationFilter = {
+const NATIVE_CHATS: ConversationListFilter = {
   groupId: "system:all",
   originChannel: "vellum",
 };
-const CUSTOM: SectionConversationFilter = { groupId: "group-uuid" };
+const CUSTOM: ConversationListFilter = { groupId: "group-uuid" };
 
 function conversation(overrides: Partial<Conversation> = {}): Conversation {
   return { conversationId: "conv-1", lastMessageAt: 1_000, ...overrides };
@@ -236,14 +237,14 @@ describe("patchAffectsMembership", () => {
 // ---------------------------------------------------------------------------
 
 function seed(
-  sections: Array<[SectionConversationFilter, Conversation[], boolean?]>,
+  sections: Array<[ConversationListFilter, Conversation[], boolean?]>,
 ): QueryClient {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
   for (const [filter, rows, hasMore] of sections) {
     client.setQueryData(
-      sectionConversationsQueryKey(ASSISTANT_ID, filter),
+      conversationListQueryKey(ASSISTANT_ID, filter),
       listPage(rows, hasMore),
     );
   }
@@ -252,11 +253,11 @@ function seed(
 
 function rowsIn(
   client: QueryClient,
-  filter: SectionConversationFilter,
+  filter: ConversationListFilter,
 ): Conversation[] {
   return (
     client.getQueryData<ConversationListPage>(
-      sectionConversationsQueryKey(ASSISTANT_ID, filter),
+      conversationListQueryKey(ASSISTANT_ID, filter),
     )?.conversations ?? []
   );
 }
@@ -264,7 +265,7 @@ function rowsIn(
 /** How many sections hold `conversationId`, counting duplicates within one. */
 function copiesAcrossSections(
   client: QueryClient,
-  filters: SectionConversationFilter[],
+  filters: ConversationListFilter[],
   conversationId: string,
 ): number {
   return filters.reduce(
@@ -508,7 +509,7 @@ describe("reconcileSectionMembership", () => {
     });
 
     const page = client.getQueryData<ConversationListPage>(
-      sectionConversationsQueryKey(ASSISTANT_ID, SLACK),
+      conversationListQueryKey(ASSISTANT_ID, SLACK),
     );
     expect(page?.conversations).toEqual([]);
     expect(page?.hasMore).toBe(true);
@@ -527,7 +528,7 @@ describe("reconcileSectionMembership", () => {
     });
 
     expect(
-      client.getQueryData(sectionConversationsQueryKey(ASSISTANT_ID, PINNED)),
+      client.getQueryData(conversationListQueryKey(ASSISTANT_ID, PINNED)),
     ).toBeUndefined();
     expect(rowsIn(client, CHATS)).toEqual([]);
   });
@@ -541,10 +542,10 @@ describe("reconcileSectionMembership", () => {
       defaultOptions: { queries: { retry: false } },
     });
     client.setQueryData(
-      sectionConversationsQueryKey(ASSISTANT_ID, CHATS),
+      conversationListQueryKey(ASSISTANT_ID, CHATS),
       listPage([conversation({ conversationId: "c1" })]),
     );
-    const pinnedKey = sectionConversationsQueryKey(ASSISTANT_ID, PINNED);
+    const pinnedKey = conversationListQueryKey(ASSISTANT_ID, PINNED);
     void client
       .prefetchQuery({
         queryKey: pinnedKey,
@@ -585,7 +586,10 @@ describe("reconcileSectionMembership", () => {
        it for Pinned to appear in the first place. */
     const row = conversation({ conversationId: "c1" });
     const client = seed([[CHATS, [row]]]);
-    client.setQueryData(conversationsQueryKey(ASSISTANT_ID), listPage([row]));
+    client.setQueryData(
+      conversationListQueryKey(ASSISTANT_ID),
+      listPage([row]),
+    );
 
     reconcileSectionMembership(client, ASSISTANT_ID, {
       ...row,
@@ -595,7 +599,9 @@ describe("reconcileSectionMembership", () => {
 
     expect(
       client
-        .getQueryData<ConversationListPage>(conversationsQueryKey(ASSISTANT_ID))
+        .getQueryData<ConversationListPage>(
+          conversationListQueryKey(ASSISTANT_ID),
+        )
         ?.conversations.map((c) => c.conversationId),
     ).toEqual(["c1"]);
   });

--- a/clients/web/src/utils/section-membership.ts
+++ b/clients/web/src/utils/section-membership.ts
@@ -27,13 +27,16 @@ import {
   NATIVE_ORIGIN_CHANNEL,
   SYSTEM_ALL_GROUP_ID,
   SYSTEM_PINNED_GROUP_ID,
-  parseSectionConversationsQueryKey,
-  sectionListPrefix,
   sidebarSectionsQueryKey,
   type ConversationListPage,
-  type SectionConversationFilter,
   type SidebarIndexSection,
 } from "@/utils/conversation-list-fetchers";
+import {
+  type ConversationListFilter,
+  conversationListFilterOf,
+  conversationListPrefix,
+  isSectionFilter,
+} from "@/utils/conversation-list-keys";
 import { insertIntoWindow } from "@/utils/conversation-order";
 import {
   isConversationPinned,
@@ -138,7 +141,7 @@ function isSidebarVisible(conversation: Conversation): boolean {
  */
 export function matchesSectionFilter(
   conversation: Conversation,
-  filter: SectionConversationFilter,
+  filter: ConversationListFilter,
 ): boolean {
   if (!isSidebarVisible(conversation)) {
     return false;
@@ -323,12 +326,13 @@ export function reconcileSectionMembership(
   }
   const needsRefetch: (readonly unknown[])[] = [];
   const entries = queryClient.getQueriesData<ConversationListPage>({
-    queryKey: sectionListPrefix(assistantId),
+    queryKey: conversationListPrefix(assistantId),
   });
 
   for (const [queryKey, page] of entries) {
-    const filter = parseSectionConversationsQueryKey(queryKey);
-    if (!filter) {
+    /* Only the section caches; the buckets are not membership caches. */
+    const filter = conversationListFilterOf(queryKey);
+    if (!filter || !isSectionFilter(filter)) {
       continue;
     }
     if (!page) {


### PR DESCRIPTION
## TL;DR

Every conversation list cache is now keyed by the generated HeyAPI key for its request, `conversationsGetQueryKey({ path, query: filter })`, and the hand-rolled key layer that every list read, cache write, and sync path went through is deleted. One key scheme, one options factory, one list hook, three filter-parameterized fetch primitives. No user-visible behavior change is intended, with two small exceptions in the table below.

Fixes LUM-2447.

## Why

The web list layer had its own key scheme (`CONVERSATION_LIST_PREFIX`, `conversationsQueryKey`, `backgroundConversationsQueryKey`, `scheduledConversationsQueryKey`, `archivedConversationsQueryKey`, `sectionConversationsQueryKey` + a positional encoder/decoder), per-bucket fetchers, per-bucket options factories, per-bucket hooks, per-bucket cache updaters, and two hand-copied subsets of the generated request's query type. The generated client (`src/generated/daemon/@tanstack/react-query.gen.ts`) already exports `conversationsGetQueryKey` and `conversationsGetOptions` for this exact route, and `clients/web/docs/CONVENTIONS.md` says to spread the generated factories. Nothing in the layer referenced them.

Two facts, verified by executing TanStack's real `partialMatchKey` against the real generated functions (pinned in `conversation-list-keys.test.ts`), make the generated key a drop-in for everything the hand-rolled prefix did:

1. The generated key **without** `query` (`{ _id: "conversationsGet", path: { assistant_id } }`) prefix-matches every list read for the assistant and rejects the by-id detail, the section index, the unread count, and other assistants. That is the whole cross-cache "prefix scan" the seam depends on (`findConversation`, `patchConversation`, `snapshot/restore`, `reconcileSectionMembership`, `refreshConversationListWindows`), provided by TanStack rather than by a key layout.
2. A cache's own key must always carry `query`, even `{}`: the prefix and the foreground list's key are different keys, so `conversationListQueryKey` always writes `query` and `conversationListPrefix` never does.

Because the filter **is** the key's `query`, "which cache is this" is a property read (`conversationListFilterOf(key)`), not a positional decode.

## What changed

**New**

- `utils/conversation-list-keys.ts`: `ConversationListFilter` (the generated `ConversationsGetData["query"]` minus pagination; the one filter type), `conversationListQueryKey`, `conversationListPrefix`, `isConversationListKey`, `conversationListFilterOf`, `conversationListQueryFilter` (prefix + predicate, for "every section" / "every archived list" without enumerating keys), `isSectionFilter`, `isPinnedInjectedFilter` (mirrors the daemon's injection guard), and the four bucket filter constants.
- `utils/conversation-list-options.ts`: `conversationListOptions(assistantId, filter)`. Sections (group/channel filters) are windowed with the window-preserving queryFn; the buckets still drain (their remaining readers assume a complete list; that changes when those readers do, not as a side effect of a key change).

**Collapsed**

- Fetchers: 10 per-bucket/per-section functions -> `drainConversationList`, `listConversationsFirstPage`, `listConversationsPage`, all taking a filter. Per-bucket shaping (archived sorts by `archivedAt`, background drops the umbrella's scheduled rows, sections keep server order) is one function on the filter.
- Hooks: five copy-paste list hooks with divergent return shapes -> one private `useListQuery` returning `ConversationListQueryResult`; the exported names are unchanged so no consumer moves.
- Cache: four per-bucket updaters -> `updateConversationListCache(qc, assistantId, filter, updater)`.
- `refreshConversationListWindows` discovers every tracked list cache through the prefix instead of a static bucket table plus a section scan; `loadMoreSectionConversations` -> `loadMoreConversations` (nothing about it was section-specific).
- `SectionConversationFilter` and `FetchConversationListOptions` (both hand-copied subsets of the generated query type) -> `ConversationListFilter`.

**Deleted**: the whole "Conversation list query keys" section of the fetchers module, `fetchMergedConversationList`, and every name above. `grep CONVERSATION_LIST_PREFIX` is zero.

## Before / after for the user

| | Before | After |
|---|---|---|
| Sidebar, archive page, palette, bell, attention tracking | work | same |
| Archive page data | one client-side union of two requests under a synthetic key | two generated queries (`archived`, `archived+background`) merged at the hook; same rows, same order |
| `needsAttention` list filter (added in #40775) | silently dropped by the hand-picked query builder before reaching the wire | reaches the wire (the filter is spread whole) |
| Cross-client sync of archived lists | one invalidation | same, via prefix + predicate |

## Why this is safe

- Non-test code has zero references to any deleted name; the seam's logic (`patchConversation`, `reconcileSectionMembership`, `mergeListFirstPage`, ownership tokens, the identity guards) is untouched, only its key plumbing changed.
- The two key facts the whole layer stands on are pinned by tests against the real generated functions and TanStack's real matcher, not against a description of them.
- A cache key used as a *partial* `queryClient` filter matches every key whose `query` extends it (the foreground key's `query: {}` is a subset of all), so the two places that invalidate a single list cache by its own key (the failed-first-fetch retry in the window refresh, the per-section settle after a placement) pass `exact: true`; the keys suite pins the matcher semantics and the window-refresh suite pins that a failed foreground retry touches the foreground cache alone.
- The archived lists deliberately stay out of the window refresh (they order by `archivedAt`; the merge cutoff is a recency axis) and stay on plain invalidation, exactly as before.
- Every existing test that seeded a hand-rolled key now seeds the generated key for the same filter; assertions unchanged. The window-preservation test moved to the options module's own suite alongside new tests for the drain/window split and per-bucket shaping.

## Decision record: why the cache still holds `Conversation`, not the wire row

The transform (`toConversation`) runs in the queryFn, so the cache holds app rows and the generated `SetQueryData` helpers for this route do not apply. That is a documented TanStack option with a named cost (TkDodo, "React Query Data Transformations"). It is kept in this PR because the placement seam mints rows optimistically and there is no `Conversation` -> wire inverse. Once mutation responses carry the row's post-state (the next PR), the seam applies server rows and the transform moves to `select`. LUM-2406 named this in June and was closed Won't Do; the comment there is the record.

## Deferred (next PRs, each small)

1. Authoritative mutation responses: the daemon returns each mutated row's post-state; the client twins of the SQL filters (`matchesSectionFilter`, `isSidebarVisible`, `matchesIndexBucket`) collapse to "apply".
2. Cache -> wire shape + `select(toConversation)`; the generated `SetQueryData` helpers become usable.
3. Sections onto `conversationsGetInfiniteOptions`; the hand-rolled load-more (in-flight Set + identity guard) goes with it. Blocked until 1 because the seam moves rows across page boundaries.
4. Consumer teardown of the four bucket reads (the named hooks go with their consumers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
