### PR TITLE
fix: clean devices run-helper error extraction + review cleanups

### DIFF
--- a/clients/web/src/domains/settings/pair-device/paired-devices-section.test.tsx
+++ b/clients/web/src/domains/settings/pair-device/paired-devices-section.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -75,10 +76,11 @@ function setListResult(result: LocalListDevicesResult) {
 async function renderExpanded(devices: LocalPairedDeviceRecord[]) {
   setListResult({ ok: true, devices });
   render(<PairedDevicesSection />);
-  const trigger = await screen.findByRole("button", {
-    name: `Paired devices (${devices.length})`,
-  });
-  fireEvent.click(trigger);
+  // The list fetch is microtask-only; an awaited act drains it without timers.
+  await act(async () => {});
+  fireEvent.click(
+    screen.getByRole("button", { name: `Paired devices (${devices.length})` }),
+  );
 }
 
 function clickConfirm() {
@@ -174,8 +176,11 @@ describe("PairedDevicesSection", () => {
       });
 
     fireEvent.click(screen.getAllByRole("button", { name: "Revoke" })[0]!);
-    clickConfirm();
-    await waitFor(() => expect(listCalls.length).toBe(2));
+    // Drain the revoke and refetch kickoff; the refetch promise stays pending.
+    await act(async () => {
+      clickConfirm();
+    });
+    expect(listCalls.length).toBe(2);
 
     // Refetch in flight: the section (and its expanded rows) stays mounted.
     expect(screen.getByText("Ios")).toBeTruthy();
@@ -184,11 +189,13 @@ describe("PairedDevicesSection", () => {
       screen.getByRole("button", { name: "Paired devices (2)" }),
     ).toBeTruthy();
 
-    resolveRefetch({
-      ok: true,
-      devices: [device({ hashedDeviceId: HASH_B, platform: "android" })],
+    await act(async () => {
+      resolveRefetch({
+        ok: true,
+        devices: [device({ hashedDeviceId: HASH_B, platform: "android" })],
+      });
     });
-    await waitFor(() => expect(screen.queryByText("Ios")).toBeNull());
+    expect(screen.queryByText("Ios")).toBeNull();
     expect(
       screen.getByRole("button", { name: "Paired devices (1)" }),
     ).toBeTruthy();

--- a/clients/web/src/runtime/local-mode-host.ts
+++ b/clients/web/src/runtime/local-mode-host.ts
@@ -400,11 +400,8 @@ export async function listPairedDevicesHost(
 }
 
 /**
- * Revoke one paired device's tokens on a local assistant's gateway, the write
- * counterpart of {@link listPairedDevicesHost}. Same host-side-only rule (the
- * gateway's devices routes reject browser origins, so the trusted host drives
- * the CLI) and the same structured unsupported fallback on older Electron
- * hosts.
+ * Revoke one paired device's tokens; write counterpart of
+ * {@link listPairedDevicesHost} (same host-side-only rule and unsupported fallback).
  */
 export async function revokePairedDeviceHost(
   assistantId: string,

--- a/clients/web/vite-plugin-local-mode.ts
+++ b/clients/web/vite-plugin-local-mode.ts
@@ -773,23 +773,13 @@ function devicesMiddleware(baseDir: string): Connect.NextHandleFunction {
       if (revokeHash !== null) {
         void runDevicesRevoke(invocation, assistantId, revokeHash).then(
           (result) => {
-            respondJson(
-              res,
-              200,
-              result.ok ? { ok: true } : { ok: false, error: result.error },
-            );
+            respondJson(res, 200, result);
           },
         );
         return;
       }
       void runDevicesList(invocation, assistantId).then((result) => {
-        respondJson(
-          res,
-          200,
-          result.ok
-            ? { ok: true, devices: result.devices }
-            : { ok: false, error: result.error },
-        );
+        respondJson(res, 200, result);
       });
     });
   };

--- a/packages/electron-desktop/src/local-mode.ts
+++ b/packages/electron-desktop/src/local-mode.ts
@@ -330,19 +330,10 @@ const assistantRecord = z.record(z.string(), z.unknown());
 // optional on the wire and validated in the body.
 const assistantIdArgs = z.tuple([z.string().optional()]);
 
-// `connectImport` takes a pairing bundle plus an optional local name. Both are
-// optional on the wire (missing values resolve with structured errors, keeping
-// the never-reject contract); the shared `connectImport` op validates the
-// bundle, including the length cap that bounds what a hostile renderer can
-// make the main process buffer and decode.
-const connectImportArgs = z.tuple([
-  z.string().optional(),
-  z.string().optional(),
-]);
-
-// `revokeDevice` takes an assistant id plus the hashed device id to revoke.
-// Both optional on the wire, validated in the body (never-reject contract).
-const revokeDeviceArgs = z.tuple([
+// `connectImport` (pairing bundle + optional local name) and `revokeDevice`
+// (assistant id + hashed device id) each take two strings, optional on the
+// wire and validated in the body (never-reject contract).
+const twoOptionalStringArgs = z.tuple([
   z.string().optional(),
   z.string().optional(),
 ]);
@@ -479,7 +470,7 @@ export const installLocalMode = (): void => {
 
   ipc(
     "vellum:localMode:connectImport",
-    connectImportArgs,
+    twoOptionalStringArgs,
     ([bundle, name]): LocalConnectImportResult => {
       const result = connectImport(lockfilePaths, configDir, { bundle, name });
       if (!result.ok) {
@@ -510,7 +501,7 @@ export const installLocalMode = (): void => {
 
   ipc(
     "vellum:localMode:revokeDevice",
-    revokeDeviceArgs,
+    twoOptionalStringArgs,
     ([assistantId, hashedDeviceId]) => {
       if (!assistantId) {
         return { ok: false, error: "Missing assistantId" };

--- a/packages/local-mode/src/devices.test.ts
+++ b/packages/local-mode/src/devices.test.ts
@@ -201,4 +201,41 @@ describe("runDevicesRevoke", () => {
       error: "Failed to spawn CLI: EACCES",
     });
   });
+
+  test("multi-line stderr with a trailing Error: line surfaces just that message", async () => {
+    const pending = runDevicesRevoke(invocation, "asst-42", "hash-a");
+    lastChild.stderr.emit(
+      "data",
+      Buffer.from(
+        [
+          "Device to revoke:",
+          "  Platform: ios",
+          "  Issued:   2026-01-01",
+          "",
+          "Error: Gateway is unreachable",
+          "",
+        ].join("\n"),
+      ),
+    );
+    lastChild.emit("close", 1);
+
+    expect(await pending).toEqual({
+      ok: false,
+      error: "Gateway is unreachable",
+    });
+  });
+
+  test("stderr without an Error: line falls back to the whole stderr", async () => {
+    const pending = runDevicesRevoke(invocation, "asst-42", "hash-a");
+    lastChild.stderr.emit(
+      "data",
+      Buffer.from("Device to revoke:\n  Platform: ios\n"),
+    );
+    lastChild.emit("close", 1);
+
+    expect(await pending).toEqual({
+      ok: false,
+      error: "Device to revoke:\n  Platform: ios",
+    });
+  });
 });

--- a/packages/local-mode/src/devices.ts
+++ b/packages/local-mode/src/devices.ts
@@ -29,6 +29,20 @@ type CliRunResult =
   | { ok: true; stdout: string }
   | { ok: false; error: string };
 
+// The CLI prints an identity preamble before acting, so a failure transcript
+// is multi-line; surface only the final "Error:" line when one exists.
+function extractCliError(stderr: string, stdout: string): string {
+  const errorLines = stderr
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("Error:"));
+  const last = errorLines[errorLines.length - 1];
+  if (last) {
+    return last.slice("Error:".length).trim();
+  }
+  return (stderr || stdout).trim();
+}
+
 function runDevicesCli(
   invocation: CliInvocation,
   args: string[],
@@ -71,7 +85,7 @@ function runDevicesCli(
       if (code === 0) {
         finish({ ok: true, stdout });
       } else {
-        finish({ ok: false, error: stderr || stdout });
+        finish({ ok: false, error: extractCliError(stderr, stdout) });
       }
     });
 


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review round 2 for paired-devices-revoke.md.

**Gaps:** stderr identity preamble leaked verbatim into host revoke errors; no-op result re-wrap in the vite devices middleware; duplicate zod tuple in electron local-mode; redundant doc comment on revokePairedDeviceHost