### PR TITLE
fix: bind paired-device revoke to the fetch-time assistant context

### DIFF
--- a/clients/web/src/domains/settings/pair-device/paired-devices-section.test.tsx
+++ b/clients/web/src/domains/settings/pair-device/paired-devices-section.test.tsx
@@ -68,18 +68,12 @@ function device(
   };
 }
 
-/** Queue list responses; later calls replay the last entry. */
-function queueListResults(...results: LocalListDevicesResult[]) {
-  let index = 0;
-  listImpl = async () => {
-    const result = results[Math.min(index, results.length - 1)]!;
-    index += 1;
-    return result;
-  };
+function setListResult(result: LocalListDevicesResult) {
+  listImpl = async () => result;
 }
 
 async function renderExpanded(devices: LocalPairedDeviceRecord[]) {
-  queueListResults({ ok: true, devices }, { ok: true, devices });
+  setListResult({ ok: true, devices });
   render(<PairedDevicesSection />);
   const trigger = await screen.findByRole("button", {
     name: `Paired devices (${devices.length})`,
@@ -113,14 +107,14 @@ describe("PairedDevicesSection", () => {
   });
 
   test("renders nothing when the host refuses the list", async () => {
-    queueListResults({ ok: false, error: "unavailable" });
+    setListResult({ ok: false, error: "unavailable" });
     const { container } = render(<PairedDevicesSection />);
     await waitFor(() => expect(listCalls.length).toBe(1));
     expect(container.firstChild).toBeNull();
   });
 
   test("renders nothing when no devices are paired", async () => {
-    queueListResults({ ok: true, devices: [] });
+    setListResult({ ok: true, devices: [] });
     const { container } = render(<PairedDevicesSection />);
     await waitFor(() => expect(listCalls.length).toBe(1));
     expect(container.firstChild).toBeNull();
@@ -200,18 +194,21 @@ describe("PairedDevicesSection", () => {
     ).toBeTruthy();
   });
 
-  test("revokes against the currently selected assistant id read at call time", async () => {
+  test("revokes against the assistant the rendered list was fetched for, not the current selection", async () => {
     await renderExpanded([device()]);
 
+    // Selection moves to another assistant while the section stays mounted;
+    // the rendered rows (and the confirm target) still belong to "self".
     selectedAssistantId = "other";
     fireEvent.click(screen.getByRole("button", { name: "Revoke" }));
     clickConfirm();
 
     await waitFor(() =>
       expect(revokeCalls).toEqual([
-        { assistantId: "other", hashedDeviceId: HASH_A },
+        { assistantId: "self", hashedDeviceId: HASH_A },
       ]),
     );
+    // The post-revoke refresh re-reads the selection and fetches its list.
     await waitFor(() => expect(listCalls).toEqual(["self", "other"]));
   });
 

--- a/clients/web/src/domains/settings/pair-device/use-paired-devices.ts
+++ b/clients/web/src/domains/settings/pair-device/use-paired-devices.ts
@@ -13,9 +13,9 @@ function selectedAssistantId(): string | undefined {
 
 export interface PairedDevicesController {
   /**
-   * Paired devices for the selected assistant, or `null` when the list is
-   * not loaded or unavailable. A refresh keeps the previous list rendered
-   * until the new result lands.
+   * The most recently fetched paired-device list, or `null` when the list is
+   * not loaded or unavailable. A same-assistant refresh keeps the previous
+   * list rendered until the new result lands.
    */
   devices: LocalPairedDeviceRecord[] | null;
   /** Device awaiting revoke confirmation, or `null` when no dialog is open. */
@@ -32,19 +32,24 @@ export interface PairedDevicesController {
   confirmRevoke: () => void;
 }
 
+interface FetchedDeviceList {
+  /** Assistant the list was fetched for; revokes always target this id. */
+  assistantId: string;
+  devices: LocalPairedDeviceRecord[];
+}
+
 /**
  * Drives the "Paired devices" accordion: fetches the selected assistant's
  * paired devices through the host seam and runs the confirm-then-revoke flow.
  * Any `{ ok: false }` list result (older app shells, unavailable hosts,
  * transport failures) collapses `devices` to `null` so the section degrades
- * silently instead of showing a broken state. The assistant id is read at
- * call time so every fetch and revoke targets the currently selected
- * assistant.
+ * silently instead of showing a broken state. Each fetch reads the selected
+ * assistant, but a revoke always targets the assistant the rendered list was
+ * fetched for: device ids hash identically across assistants, so a fresh
+ * selection read could silently revoke the wrong assistant's pairing.
  */
 export function usePairedDevices(): PairedDevicesController {
-  const [devices, setDevices] = useState<LocalPairedDeviceRecord[] | null>(
-    null,
-  );
+  const [list, setList] = useState<FetchedDeviceList | null>(null);
   const [confirmTarget, setConfirmTarget] =
     useState<LocalPairedDeviceRecord | null>(null);
   const [isRevoking, setIsRevoking] = useState(false);
@@ -54,6 +59,10 @@ export function usePairedDevices(): PairedDevicesController {
   // out-of-order responses) with a mounted flag + request sequence.
   const mountedRef = useRef(true);
   const fetchSeqRef = useRef(0);
+  // Mirrors `list?.assistantId` so the stable `refresh` callback can detect a
+  // selection change without depending on state (which would refetch-loop the
+  // mount effect).
+  const listAssistantIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -67,12 +76,25 @@ export function usePairedDevices(): PairedDevicesController {
     if (!assistantId) {
       return;
     }
+    if (
+      listAssistantIdRef.current !== null &&
+      listAssistantIdRef.current !== assistantId
+    ) {
+      // The rendered rows belong to a different assistant: drop them and any
+      // pending confirmation instead of presenting them as the new
+      // selection's.
+      listAssistantIdRef.current = null;
+      setList(null);
+      setConfirmTarget(null);
+      setRevokeError(null);
+    }
     const seq = ++fetchSeqRef.current;
     void listPairedDevicesHost(assistantId).then((result) => {
       if (!mountedRef.current || seq !== fetchSeqRef.current) {
         return;
       }
-      setDevices(result.ok ? result.devices : null);
+      listAssistantIdRef.current = result.ok ? assistantId : null;
+      setList(result.ok ? { assistantId, devices: result.devices } : null);
     });
   }, []);
 
@@ -91,30 +113,30 @@ export function usePairedDevices(): PairedDevicesController {
   }, []);
 
   const confirmRevoke = useCallback(() => {
-    const assistantId = selectedAssistantId();
-    if (!assistantId || !confirmTarget || isRevoking) {
+    if (!list || !confirmTarget || isRevoking) {
       return;
     }
     setIsRevoking(true);
     setRevokeError(null);
-    void revokePairedDeviceHost(assistantId, confirmTarget.hashedDeviceId).then(
-      (result) => {
-        if (!mountedRef.current) {
-          return;
-        }
-        setIsRevoking(false);
-        if (result.ok) {
-          setConfirmTarget(null);
-          refresh();
-        } else {
-          setRevokeError(result.error);
-        }
-      },
-    );
-  }, [confirmTarget, isRevoking, refresh]);
+    void revokePairedDeviceHost(
+      list.assistantId,
+      confirmTarget.hashedDeviceId,
+    ).then((result) => {
+      if (!mountedRef.current) {
+        return;
+      }
+      setIsRevoking(false);
+      if (result.ok) {
+        setConfirmTarget(null);
+        refresh();
+      } else {
+        setRevokeError(result.error);
+      }
+    });
+  }, [list, confirmTarget, isRevoking, refresh]);
 
   return {
-    devices,
+    devices: list?.devices ?? null,
     confirmTarget,
     isRevoking,
     revokeError,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for paired-devices-revoke.md (Codex P1 on #40812 + integration review).

**Gap:** revoke read the selected assistant id at call time while the rendered list was fetched earlier - an in-place selection change could revoke against the wrong assistant (identical device hashes across assistants) or silently no-op with a success dialog (gateway revoke is idempotent)
**Fix:** the id sent to revokePairedDeviceHost is always the id the displayed list was fetched for; context changes close the confirm dialog