### PR TITLE
fix(gateway): edge requester ip + already-approved deny signal

### DIFF
--- a/cli/src/__tests__/nginx-ingress.test.ts
+++ b/cli/src/__tests__/nginx-ingress.test.ts
@@ -187,6 +187,27 @@ describe("buildIngressNginxConfig", () => {
     expect(conf).toContain("location / {");
     expect(conf).toContain("proxy_pass http://127.0.0.1:7830;");
     expect(conf).toContain('proxy_set_header X-Vellum-Edge-Forwarded "1";');
+    expect(conf).toContain(
+      "proxy_set_header X-Vellum-Client-Ip $vellum_edge_client_ip;",
+    );
+  });
+
+  test("stamps the edge-observed client ip from the rightmost X-Forwarded-For entry", () => {
+    for (const config of [conf, remoteConf]) {
+      // Falls back to the raw peer when the TLS-terminating front sets no
+      // X-Forwarded-For; the client cannot smuggle a value because
+      // proxy_set_header overwrites inbound headers.
+      expect(config).toContain(
+        "map $http_x_forwarded_for $vellum_edge_client_ip {",
+      );
+      expect(config).toContain("default $remote_addr;");
+      expect(config).toContain(
+        '"~,?\\s*(?<vellum_last_xff>[^,\\s]+)\\s*$" $vellum_last_xff;',
+      );
+      expect(config).toContain(
+        "proxy_set_header X-Vellum-Client-Ip $vellum_edge_client_ip;",
+      );
+    }
   });
 
   test("blocks local-only bootstrap helpers before the catch-all proxy", () => {
@@ -706,7 +727,7 @@ function spaConfigHash(assistantName?: string): string {
   return createHash("sha256")
     .update(
       JSON.stringify({
-        template: 2,
+        template: 3,
         config: {
           mode: "remote-gateway",
           apiBaseUrl: "/v1",

--- a/cli/src/lib/nginx-ingress.ts
+++ b/cli/src/lib/nginx-ingress.ts
@@ -90,6 +90,7 @@ function gatewayProxyBlock(gatewayPort: number): string {
       proxy_read_timeout 1h;
       proxy_set_header Host $host;
       proxy_set_header X-Vellum-Edge-Forwarded "1";
+      proxy_set_header X-Vellum-Client-Ip $vellum_edge_client_ip;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection $connection_upgrade;`;
 }
@@ -164,7 +165,7 @@ function remoteWebIngressConfig(
  * fingerprint matches, so this must change whenever the generated index or
  * nginx template does.
  */
-const EDGE_TEMPLATE_VERSION = 2;
+const EDGE_TEMPLATE_VERSION = 3;
 
 /**
  * Stable fingerprint of the SPA config injected into the served index and
@@ -278,6 +279,19 @@ http {
   map $http_upgrade $connection_upgrade {
     default upgrade;
     "" close;
+  }
+
+  # Edge-observed client address, stamped onto every proxied request as
+  # X-Vellum-Client-Ip. proxy_set_header overwrites any inbound value, so a
+  # remote client cannot smuggle one. Every caller reaches this loopback-only
+  # listener through the TLS-terminating front (tunnel agent), so the raw peer
+  # is always 127.0.0.1; the front records the real client as the RIGHTMOST
+  # X-Forwarded-For entry (ngrok/cloudflared append, tailscale serve sets it),
+  # which the remote client cannot control. Fall back to the raw peer when the
+  # front sets no X-Forwarded-For.
+  map $http_x_forwarded_for $vellum_edge_client_ip {
+    default $remote_addr;
+    "~,?\\s*(?<vellum_last_xff>[^,\\s]+)\\s*$" $vellum_last_xff;
   }
 
   server {

--- a/gateway/src/__tests__/helpers/remote-web-pairing-fixtures.ts
+++ b/gateway/src/__tests__/helpers/remote-web-pairing-fixtures.ts
@@ -1,0 +1,71 @@
+/** Shared constants and request factories for the remote-web pairing tests. */
+
+export const LOOPBACK_IP = "127.0.0.1";
+export const REMOTE_IP = "203.0.113.10";
+export const PUBLIC_BASE_URL = "https://paired.example.com";
+
+/** A request as sent by a local loopback client (host machine). */
+export function makeLocalRequest(
+  path: string,
+  init: {
+    method: string;
+    body?: BodyInit;
+    headers?: Record<string, string>;
+  },
+): Request {
+  return new Request(`http://localhost:7830${path}`, {
+    method: init.method,
+    headers: {
+      host: "localhost:7830",
+      "content-type": "application/json",
+      ...init.headers,
+    },
+    body: init.body,
+  });
+}
+
+/** A request as sent by a remote (non-loopback) caller. */
+export function makeRemoteRequest(
+  path: string,
+  init: { method: string; body?: BodyInit },
+): Request {
+  return new Request(`https://paired.example.com${path}`, {
+    method: init.method,
+    headers: {
+      host: "paired.example.com",
+      "content-type": "application/json",
+    },
+    body: init.body,
+  });
+}
+
+/** A mint request against the pairing-challenge route. */
+export function makePairingChallengeRequest(
+  overrides: {
+    publicBaseUrl?: string;
+    edgeForwarded?: boolean;
+    edgeClientIp?: string;
+    host?: string;
+    body?: BodyInit;
+    contentLength?: number;
+  } = {},
+): Request {
+  const headers: Record<string, string> = {};
+  if (overrides.host) headers.host = overrides.host;
+  if (overrides.edgeForwarded) headers["x-vellum-edge-forwarded"] = "1";
+  if (overrides.edgeClientIp) {
+    headers["x-vellum-client-ip"] = overrides.edgeClientIp;
+  }
+  if (overrides.contentLength != null) {
+    headers["content-length"] = String(overrides.contentLength);
+  }
+  return makeLocalRequest("/v1/remote-web/pairing-challenge", {
+    method: "POST",
+    headers,
+    body:
+      overrides.body ??
+      JSON.stringify({
+        publicBaseUrl: overrides.publicBaseUrl ?? PUBLIC_BASE_URL,
+      }),
+  });
+}

--- a/gateway/src/__tests__/remote-web-pairing-challenge.test.ts
+++ b/gateway/src/__tests__/remote-web-pairing-challenge.test.ts
@@ -16,39 +16,12 @@ const {
 const { resetRemoteWebPairingChallengeRateLimiterForTests } =
   await import("../remote-web/pairing-challenge-rate-limit-store.js");
 
-const LOOPBACK_IP = "127.0.0.1";
-const REMOTE_IP = "203.0.113.10";
-const PUBLIC_BASE_URL = "https://paired.example.com";
-
-function makeRequest(
-  overrides: {
-    publicBaseUrl?: string;
-    edgeForwarded?: boolean;
-    host?: string;
-    body?: BodyInit;
-    contentLength?: number;
-  } = {},
-): Request {
-  const headers: Record<string, string> = {
-    host: overrides.host ?? "localhost:7830",
-    "content-type": "application/json",
-  };
-  if (overrides.edgeForwarded) {
-    headers["x-vellum-edge-forwarded"] = "1";
-  }
-  if (overrides.contentLength != null) {
-    headers["content-length"] = String(overrides.contentLength);
-  }
-  return new Request("http://localhost:7830/v1/remote-web/pairing-challenge", {
-    method: "POST",
-    headers,
-    body:
-      overrides.body ??
-      JSON.stringify({
-        publicBaseUrl: overrides.publicBaseUrl ?? PUBLIC_BASE_URL,
-      }),
-  });
-}
+import {
+  LOOPBACK_IP,
+  makePairingChallengeRequest as makeRequest,
+  PUBLIC_BASE_URL,
+  REMOTE_IP,
+} from "./helpers/remote-web-pairing-fixtures.js";
 
 beforeEach(() => {
   resetRemoteWebPairingChallengesForTests();
@@ -269,8 +242,54 @@ describe("remote web pairing challenge", () => {
     const record = getRemoteWebPairingChallengeForTests(body.userCode);
     expect(record?.requesterIp).toBe(LOOPBACK_IP);
     expect(record?.requesterUserAgent).toBe("PairBrowser/1.0");
+    expect(record?.viaEdgeProxy).toBe(false);
     expect(record?.userCode).toBe(body.userCode);
     expect(record?.id).toBeTruthy();
+  });
+
+  test("records the edge-stamped client ip for tunneled mints", async () => {
+    const res = await handleCreateRemoteWebPairingChallenge(
+      makeRequest({
+        edgeForwarded: true,
+        edgeClientIp: REMOTE_IP,
+        host: "paired.example.com",
+      }),
+      LOOPBACK_IP,
+      LOOPBACK_IP,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { userCode: string };
+
+    const record = getRemoteWebPairingChallengeForTests(body.userCode);
+    expect(record?.requesterIp).toBe(REMOTE_IP);
+    expect(record?.viaEdgeProxy).toBe(true);
+  });
+
+  test("falls back to the peer ip when the edge stamps no client ip", async () => {
+    const res = await handleCreateRemoteWebPairingChallenge(
+      makeRequest({ edgeForwarded: true, host: "paired.example.com" }),
+      LOOPBACK_IP,
+      LOOPBACK_IP,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { userCode: string };
+
+    const record = getRemoteWebPairingChallengeForTests(body.userCode);
+    expect(record?.requesterIp).toBe(LOOPBACK_IP);
+    expect(record?.viaEdgeProxy).toBe(true);
+  });
+
+  test("ignores a forged client-ip header on direct loopback mints", async () => {
+    const res = await handleCreateRemoteWebPairingChallenge(
+      makeRequest({ edgeClientIp: "198.51.100.99" }),
+      LOOPBACK_IP,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { userCode: string };
+
+    const record = getRemoteWebPairingChallengeForTests(body.userCode);
+    expect(record?.requesterIp).toBe(LOOPBACK_IP);
+    expect(record?.viaEdgeProxy).toBe(false);
   });
 
   test("rejects oversized challenge request bodies", async () => {
@@ -290,7 +309,11 @@ describe("remote web pairing challenge", () => {
 });
 
 describe("remote web pairing request list/approve/deny", () => {
-  const REQUESTER = { ip: REMOTE_IP, userAgent: "PairBrowser/1.0" };
+  const REQUESTER = {
+    ip: REMOTE_IP,
+    userAgent: "PairBrowser/1.0",
+    viaEdgeProxy: true,
+  };
 
   test("lists only pending, non-expired challenges newest first with requester metadata", () => {
     let now = 1_000;
@@ -301,6 +324,7 @@ describe("remote web pairing request list/approve/deny", () => {
     const second = createRemoteWebPairingChallenge(PUBLIC_BASE_URL, {
       ip: "198.51.100.7",
       userAgent: null,
+      viaEdgeProxy: false,
     });
     now = 3_000;
     const approved = createRemoteWebPairingChallenge(
@@ -328,9 +352,11 @@ describe("remote web pairing request list/approve/deny", () => {
       expiresAt: new Date(2_000 + 600_000).toISOString(),
       requesterIp: "198.51.100.7",
       requesterUserAgent: null,
+      viaEdgeProxy: false,
     });
     expect(requests[1]?.requesterIp).toBe(REMOTE_IP);
     expect(requests[1]?.requesterUserAgent).toBe("PairBrowser/1.0");
+    expect(requests[1]?.viaEdgeProxy).toBe(true);
 
     now = 1_000 + 600_000;
     expect(
@@ -429,7 +455,7 @@ describe("remote web pairing request list/approve/deny", () => {
     expect(listPendingRemoteWebPairingChallenges()).toEqual([]);
   });
 
-  test("deny of a non-pending challenge returns invalid", () => {
+  test("deny of an approved challenge reports already_approved and keeps it", () => {
     setRemoteWebPairingChallengeNowForTests(() => 1_000);
     const challenge = createRemoteWebPairingChallenge(
       PUBLIC_BASE_URL,
@@ -441,11 +467,34 @@ describe("remote web pairing request list/approve/deny", () => {
     );
 
     expect(denyRemoteWebPairingChallengeById(record!.id)).toEqual({
-      status: "invalid",
+      status: "already_approved",
     });
     expect(
       claimRemoteWebPairingChallengeExchange(challenge.deviceCode).status,
     ).toBe("approved");
+  });
+
+  test("deny of exchanging and consumed challenges reports already_approved", () => {
+    setRemoteWebPairingChallengeNowForTests(() => 1_000);
+    const challenge = createRemoteWebPairingChallenge(
+      PUBLIC_BASE_URL,
+      REQUESTER,
+    );
+    const record = getRemoteWebPairingChallengeForTests(challenge.userCode);
+    expect(approveRemoteWebPairingChallengeById(record!.id).status).toBe(
+      "approved",
+    );
+    expect(
+      claimRemoteWebPairingChallengeExchange(challenge.deviceCode).status,
+    ).toBe("approved");
+    expect(denyRemoteWebPairingChallengeById(record!.id)).toEqual({
+      status: "already_approved",
+    });
+
+    completeRemoteWebPairingChallengeExchange(challenge.deviceCode);
+    expect(denyRemoteWebPairingChallengeById(record!.id)).toEqual({
+      status: "already_approved",
+    });
   });
 
   test("deny of an unknown id returns invalid", () => {

--- a/gateway/src/__tests__/remote-web-pairing-requests.test.ts
+++ b/gateway/src/__tests__/remote-web-pairing-requests.test.ts
@@ -13,45 +13,17 @@ const {
   setRemoteWebPairingChallengeNowForTests,
 } = await import("../remote-web/pairing-challenge-store.js");
 
-const CLIENT_IP = "203.0.113.10";
-const LOOPBACK_IP = "127.0.0.1";
-const PUBLIC_BASE_URL = "https://paired.example.com";
+import {
+  LOOPBACK_IP,
+  makeLocalRequest,
+  makeRemoteRequest,
+  PUBLIC_BASE_URL,
+  REMOTE_IP as CLIENT_IP,
+} from "./helpers/remote-web-pairing-fixtures.js";
+
 const LIST_PATH = "/v1/remote-web/pairing-requests";
 const APPROVE_PATH = "/v1/remote-web/pairing-requests/approve";
 const DENY_PATH = "/v1/remote-web/pairing-requests/deny";
-
-function makeLocalRequest(
-  path: string,
-  init: {
-    method: string;
-    body?: BodyInit;
-    headers?: Record<string, string>;
-  },
-): Request {
-  return new Request(`http://localhost:7830${path}`, {
-    method: init.method,
-    headers: {
-      host: "localhost:7830",
-      "content-type": "application/json",
-      ...init.headers,
-    },
-    body: init.body,
-  });
-}
-
-function makeRemoteRequest(
-  path: string,
-  init: { method: string; body?: BodyInit },
-): Request {
-  return new Request(`https://paired.example.com${path}`, {
-    method: init.method,
-    headers: {
-      host: "paired.example.com",
-      "content-type": "application/json",
-    },
-    body: init.body,
-  });
-}
 
 function makeActionRequest(path: string, body: unknown): Request {
   return makeLocalRequest(path, {
@@ -83,22 +55,21 @@ async function createChallenge(): Promise<{
   };
 }
 
-async function listRequests(): Promise<
-  {
-    requestId: string;
-    userCode: string;
-    publicBaseUrl: string;
-  }[]
-> {
+interface ListedRequest {
+  requestId: string;
+  userCode: string;
+  publicBaseUrl: string;
+  viaEdgeProxy: boolean;
+}
+
+async function listRequests(): Promise<ListedRequest[]> {
   const res = handleListRemoteWebPairingRequests(
     makeLocalRequest(LIST_PATH, { method: "GET" }),
     LOOPBACK_IP,
   );
   expect(res.status).toBe(200);
   expect(res.headers.get("Cache-Control")).toBe("no-store");
-  const body = (await res.json()) as {
-    requests: { requestId: string; userCode: string; publicBaseUrl: string }[];
-  };
+  const body = (await res.json()) as { requests: ListedRequest[] };
   return body.requests;
 }
 
@@ -171,6 +142,7 @@ describe("remote web pairing requests", () => {
     expect(requests).toHaveLength(1);
     expect(requests[0]?.userCode).toBe(challenge.userCode);
     expect(requests[0]?.publicBaseUrl).toBe(PUBLIC_BASE_URL);
+    expect(requests[0]?.viaEdgeProxy).toBe(false);
 
     const approveRes = await handleApproveRemoteWebPairingRequest(
       makeActionRequest(APPROVE_PATH, { requestId: requests[0]?.requestId }),
@@ -206,6 +178,34 @@ describe("remote web pairing requests", () => {
     expect(
       claimRemoteWebPairingChallengeExchange(challenge.deviceCode).status,
     ).toBe("invalid");
+  });
+
+  test("returns 409 ALREADY_APPROVED when denying an approved request", async () => {
+    const challenge = await createChallenge();
+    const requests = await listRequests();
+    expect(requests).toHaveLength(1);
+
+    const approveRes = await handleApproveRemoteWebPairingRequest(
+      makeActionRequest(APPROVE_PATH, { requestId: requests[0]?.requestId }),
+      LOOPBACK_IP,
+    );
+    expect(approveRes.status).toBe(200);
+
+    const denyRes = await handleDenyRemoteWebPairingRequest(
+      makeActionRequest(DENY_PATH, { requestId: requests[0]?.requestId }),
+      LOOPBACK_IP,
+    );
+    expect(denyRes.status).toBe(409);
+    expect(await denyRes.json()).toEqual({
+      error: {
+        code: "ALREADY_APPROVED",
+        message: "this pairing request was already approved on another surface",
+      },
+    });
+
+    expect(
+      claimRemoteWebPairingChallengeExchange(challenge.deviceCode).status,
+    ).toBe("approved");
   });
 
   test("returns 404 for unknown request ids", async () => {

--- a/gateway/src/__tests__/remote-web-pairing-token.test.ts
+++ b/gateway/src/__tests__/remote-web-pairing-token.test.ts
@@ -48,7 +48,11 @@ const {
 
 const GUARDIAN_ID = "guardian-001";
 const PUBLIC_BASE_URL = "https://paired.example.com";
-const TEST_REQUESTER = { ip: "203.0.113.10", userAgent: "test-agent" };
+const TEST_REQUESTER = {
+  ip: "203.0.113.10",
+  userAgent: "test-agent",
+  viaEdgeProxy: true,
+};
 
 let testRoot: string;
 

--- a/gateway/src/http/edge-forwarded-header.ts
+++ b/gateway/src/http/edge-forwarded-header.ts
@@ -29,6 +29,18 @@
 export const EDGE_FORWARDED_HEADER = "x-vellum-edge-forwarded" as const;
 
 /**
+ * Edge-observed client address, stamped by the same nginx edge on every
+ * proxied request (`proxy_set_header X-Vellum-Client-Ip ...`, which REPLACES
+ * any client-supplied value, so it cannot be smuggled). The edge derives it
+ * from the rightmost `X-Forwarded-For` entry written by the TLS-terminating
+ * front, falling back to its raw peer address when the front sets none.
+ *
+ * Only meaningful on requests that provably arrived via the trusted edge
+ * (edge marker present AND loopback raw peer); read it nowhere else.
+ */
+export const EDGE_CLIENT_IP_HEADER = "x-vellum-client-ip" as const;
+
+/**
  * True when the request carries the unspoofable edge-proxy marker, i.e. it was
  * forwarded by the self-hosted nginx edge rather than sent directly by a local
  * loopback client.

--- a/gateway/src/http/route-helpers.ts
+++ b/gateway/src/http/route-helpers.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared scaffolding for hand-rolled HTTP route handlers (the pairing family):
+ * the 405 method guard and the read-body-then-extract-one-string-field flow,
+ * so each route doesn't re-implement them with drifting error shapes.
+ */
+
+import { errorResponse } from "./loopback-guard.js";
+import { readLimitedBody } from "./read-limited-body.js";
+
+/** 405 response naming the allowed method. */
+export function methodNotAllowed(allow: string): Response {
+  return new Response("method not allowed", {
+    status: 405,
+    headers: { Allow: allow },
+  });
+}
+
+/**
+ * Read a JSON request body under a byte cap and extract one required string
+ * field. Returns the raw (untrimmed) field value, or the error `Response` to
+ * send: 413 for an oversized body, 400 for an unreadable body, invalid JSON,
+ * or a missing/blank field.
+ */
+export async function readJsonStringField(
+  req: Request,
+  maxBytes: number,
+  field: string,
+): Promise<string | Response> {
+  const rawBody = await readLimitedBody(req, maxBytes);
+  if (rawBody.status === "too_large") {
+    return errorResponse("PAYLOAD_TOO_LARGE", "request body too large", 413);
+  }
+  if (rawBody.status === "unreadable") {
+    return errorResponse("BAD_REQUEST", "failed to read request body", 400);
+  }
+
+  let value: string | null = null;
+  try {
+    const body = JSON.parse(rawBody.text) as Record<string, unknown>;
+    const raw = body[field];
+    value = typeof raw === "string" && raw.trim() ? raw : null;
+  } catch {
+    return errorResponse("BAD_REQUEST", "invalid JSON body", 400);
+  }
+
+  return value ?? errorResponse("BAD_REQUEST", `${field} is required`, 400);
+}

--- a/gateway/src/http/routes/remote-web-pairing-challenge.ts
+++ b/gateway/src/http/routes/remote-web-pairing-challenge.ts
@@ -8,14 +8,21 @@ import {
   type RemoteWebPairingChallengeRateLimit,
 } from "../../remote-web/pairing-challenge-rate-limit-store.js";
 import { isLoopbackAddress } from "../../util/is-loopback-address.js";
-import { requestArrivedViaEdgeProxy } from "../edge-forwarded-header.js";
-import { enforceLoopbackOnly, parseHostHeader } from "../loopback-guard.js";
-import { readLimitedBody } from "../read-limited-body.js";
+import {
+  EDGE_CLIENT_IP_HEADER,
+  requestArrivedViaEdgeProxy,
+} from "../edge-forwarded-header.js";
+import {
+  enforceLoopbackOnly,
+  errorResponse,
+  parseHostHeader,
+} from "../loopback-guard.js";
+import { methodNotAllowed, readJsonStringField } from "../route-helpers.js";
 
 const MAX_CHALLENGE_BODY_BYTES = 512;
 
-function parsePublicBaseUrl(value: unknown): string | null {
-  if (typeof value !== "string" || !value.trim()) return null;
+function parsePublicBaseUrl(value: string): string | null {
+  if (!value.trim()) return null;
   try {
     const url = new URL(value);
     if (url.protocol !== "https:" && url.protocol !== "http:") return null;
@@ -25,10 +32,6 @@ function parsePublicBaseUrl(value: unknown): string | null {
   } catch {
     return null;
   }
-}
-
-function jsonError(code: string, message: string, status: number): Response {
-  return Response.json({ error: { code, message } }, { status });
 }
 
 function rateLimitedResponse(
@@ -84,10 +87,7 @@ export async function handleCreateRemoteWebPairingChallenge(
   rawPeerIp = clientIp,
 ): Promise<Response> {
   if (req.method !== "POST") {
-    return new Response("method not allowed", {
-      status: 405,
-      headers: { Allow: "POST" },
-    });
+    return methodNotAllowed("POST");
   }
 
   const arrivedViaEdgeProxy = requestArrivedViaEdgeProxy(req);
@@ -102,31 +102,23 @@ export async function handleCreateRemoteWebPairingChallenge(
     if (guardError) return guardError;
   }
 
-  const rawBody = await readLimitedBody(req, MAX_CHALLENGE_BODY_BYTES);
-  if (rawBody.status === "too_large") {
-    return jsonError("PAYLOAD_TOO_LARGE", "request body too large", 413);
-  }
-  if (rawBody.status === "unreadable") {
-    return jsonError("BAD_REQUEST", "failed to read request body", 400);
-  }
+  const rawPublicBaseUrl = await readJsonStringField(
+    req,
+    MAX_CHALLENGE_BODY_BYTES,
+    "publicBaseUrl",
+  );
+  if (rawPublicBaseUrl instanceof Response) return rawPublicBaseUrl;
 
-  let publicBaseUrl: string | null = null;
-  try {
-    const body = JSON.parse(rawBody.text) as { publicBaseUrl?: unknown };
-    publicBaseUrl = parsePublicBaseUrl(body.publicBaseUrl);
-  } catch {
-    return jsonError("BAD_REQUEST", "invalid JSON body", 400);
-  }
-
+  const publicBaseUrl = parsePublicBaseUrl(rawPublicBaseUrl);
   if (!publicBaseUrl) {
-    return jsonError("BAD_REQUEST", "publicBaseUrl is required", 400);
+    return errorResponse("BAD_REQUEST", "publicBaseUrl is required", 400);
   }
 
   if (
     arrivedViaTrustedEdgeProxy &&
     !publicBaseUrlMatchesRequestHost(req, publicBaseUrl)
   ) {
-    return jsonError(
+    return errorResponse(
       "PUBLIC_BASE_URL_MISMATCH",
       "publicBaseUrl must match the request host",
       400,
@@ -139,9 +131,17 @@ export async function handleCreateRemoteWebPairingChallenge(
   const capacityLimited = checkRemoteWebPairingChallengeCapacity();
   if (capacityLimited) return capacityLimitedResponse(capacityLimited);
 
+  // The edge stamps the client address it observed via proxy_set_header
+  // (overwriting any inbound value), so it is trustworthy exactly when the
+  // trusted-edge check above passed. Direct local mints keep the raw peer.
+  const edgeClientIp = arrivedViaTrustedEdgeProxy
+    ? req.headers.get(EDGE_CLIENT_IP_HEADER)?.trim()
+    : undefined;
+
   const challenge = createRemoteWebPairingChallenge(publicBaseUrl, {
-    ip: clientIp,
+    ip: edgeClientIp || clientIp,
     userAgent: req.headers.get("user-agent"),
+    viaEdgeProxy: arrivedViaTrustedEdgeProxy,
   });
 
   return Response.json(challenge, {

--- a/gateway/src/http/routes/remote-web-pairing-requests.ts
+++ b/gateway/src/http/routes/remote-web-pairing-requests.ts
@@ -22,7 +22,7 @@ import {
   listPendingRemoteWebPairingChallenges,
 } from "../../remote-web/pairing-challenge-store.js";
 import { enforceLoopbackOnly, errorResponse } from "../loopback-guard.js";
-import { readLimitedBody } from "../read-limited-body.js";
+import { methodNotAllowed, readJsonStringField } from "../route-helpers.js";
 
 const MAX_ACTION_BODY_BYTES = 256;
 const AUDIT_TAG = "remote-web-pairing-requests";
@@ -32,10 +32,7 @@ export function handleListRemoteWebPairingRequests(
   clientIp: string,
 ): Response {
   if (req.method !== "GET") {
-    return new Response("method not allowed", {
-      status: 405,
-      headers: { Allow: "GET" },
-    });
+    return methodNotAllowed("GET");
   }
 
   const guardError = enforceLoopbackOnly(req, clientIp, AUDIT_TAG);
@@ -51,38 +48,11 @@ export function handleListRemoteWebPairingRequests(
 
 function guardPostLoopback(req: Request, clientIp: string): Response | null {
   if (req.method !== "POST") {
-    return new Response("method not allowed", {
-      status: 405,
-      headers: { Allow: "POST" },
-    });
+    return methodNotAllowed("POST");
   }
   return enforceLoopbackOnly(req, clientIp, AUDIT_TAG);
 }
 
-async function readRequestIdBody(req: Request): Promise<string | Response> {
-  const rawBody = await readLimitedBody(req, MAX_ACTION_BODY_BYTES);
-  if (rawBody.status === "too_large") {
-    return errorResponse("PAYLOAD_TOO_LARGE", "request body too large", 413);
-  }
-  if (rawBody.status === "unreadable") {
-    return errorResponse("BAD_REQUEST", "failed to read request body", 400);
-  }
-
-  let requestId: string | null = null;
-  try {
-    const body = JSON.parse(rawBody.text) as { requestId?: unknown };
-    requestId =
-      typeof body.requestId === "string" && body.requestId.trim()
-        ? body.requestId
-        : null;
-  } catch {
-    return errorResponse("BAD_REQUEST", "invalid JSON body", 400);
-  }
-
-  return (
-    requestId ?? errorResponse("BAD_REQUEST", "requestId is required", 400)
-  );
-}
 
 // No code-guess rate limiter on approve/deny: request ids are server-minted
 // opaque ids from the list route, not guessable secrets typed by users.
@@ -93,7 +63,11 @@ export async function handleApproveRemoteWebPairingRequest(
   const guardError = guardPostLoopback(req, clientIp);
   if (guardError) return guardError;
 
-  const requestId = await readRequestIdBody(req);
+  const requestId = await readJsonStringField(
+    req,
+    MAX_ACTION_BODY_BYTES,
+    "requestId",
+  );
   if (requestId instanceof Response) return requestId;
 
   const result = approveRemoteWebPairingChallengeById(requestId);
@@ -114,12 +88,23 @@ export async function handleDenyRemoteWebPairingRequest(
   const guardError = guardPostLoopback(req, clientIp);
   if (guardError) return guardError;
 
-  const requestId = await readRequestIdBody(req);
+  const requestId = await readJsonStringField(
+    req,
+    MAX_ACTION_BODY_BYTES,
+    "requestId",
+  );
   if (requestId instanceof Response) return requestId;
 
   const result = denyRemoteWebPairingChallengeById(requestId);
   if (result.status === "invalid") {
     return errorResponse("INVALID_REQUEST_ID", "unknown pairing request", 404);
+  }
+  if (result.status === "already_approved") {
+    return errorResponse(
+      "ALREADY_APPROVED",
+      "this pairing request was already approved on another surface",
+      409,
+    );
   }
 
   return Response.json(

--- a/gateway/src/http/routes/remote-web-pairing-verification.ts
+++ b/gateway/src/http/routes/remote-web-pairing-verification.ts
@@ -5,14 +5,10 @@ import {
   recordRemoteWebPairingVerificationFailure,
   type RemoteWebPairingVerificationRateLimit,
 } from "../../remote-web/pairing-verification-rate-limit-store.js";
-import { enforceLoopbackOnly } from "../loopback-guard.js";
-import { readLimitedBody } from "../read-limited-body.js";
+import { enforceLoopbackOnly, errorResponse } from "../loopback-guard.js";
+import { methodNotAllowed, readJsonStringField } from "../route-helpers.js";
 
 const MAX_VERIFICATION_BODY_BYTES = 256;
-
-function jsonError(code: string, message: string, status: number): Response {
-  return Response.json({ error: { code, message } }, { status });
-}
 
 function rateLimitedResponse(
   rateLimit: RemoteWebPairingVerificationRateLimit,
@@ -43,10 +39,7 @@ export async function handleVerifyRemoteWebPairingChallenge(
   clientIp: string,
 ): Promise<Response> {
   if (req.method !== "POST") {
-    return new Response("method not allowed", {
-      status: 405,
-      headers: { Allow: "POST" },
-    });
+    return methodNotAllowed("POST");
   }
 
   const guardError = enforceLoopbackOnly(
@@ -62,39 +55,15 @@ export async function handleVerifyRemoteWebPairingChallenge(
     return rateLimitedResponse(rateLimitedBeforeBodyRead);
   }
 
-  const rawBody = await readLimitedBody(req, MAX_VERIFICATION_BODY_BYTES);
-  if (rawBody.status === "too_large") {
-    return failedAttemptResponse(
-      clientIp,
-      jsonError("PAYLOAD_TOO_LARGE", "request body too large", 413),
-    );
-  }
-  if (rawBody.status === "unreadable") {
-    return failedAttemptResponse(
-      clientIp,
-      jsonError("BAD_REQUEST", "failed to read request body", 400),
-    );
-  }
-
-  let userCode: string | null = null;
-  try {
-    const body = JSON.parse(rawBody.text) as { userCode?: unknown };
-    userCode =
-      typeof body.userCode === "string" && body.userCode.trim()
-        ? body.userCode
-        : null;
-  } catch {
-    return failedAttemptResponse(
-      clientIp,
-      jsonError("BAD_REQUEST", "invalid JSON body", 400),
-    );
-  }
-
-  if (!userCode) {
-    return failedAttemptResponse(
-      clientIp,
-      jsonError("BAD_REQUEST", "userCode is required", 400),
-    );
+  // Body/JSON/field failures still count as failed attempts for the
+  // per-client rate limiter, exactly as before the shared helper.
+  const userCode = await readJsonStringField(
+    req,
+    MAX_VERIFICATION_BODY_BYTES,
+    "userCode",
+  );
+  if (userCode instanceof Response) {
+    return failedAttemptResponse(clientIp, userCode);
   }
 
   const rateLimitedBeforeCodeCheck =
@@ -107,13 +76,13 @@ export async function handleVerifyRemoteWebPairingChallenge(
   if (result.status === "invalid") {
     return failedAttemptResponse(
       clientIp,
-      jsonError("INVALID_USER_CODE", "invalid pairing code", 404),
+      errorResponse("INVALID_USER_CODE", "invalid pairing code", 404),
     );
   }
   if (result.status === "expired") {
     return failedAttemptResponse(
       clientIp,
-      jsonError("EXPIRED_USER_CODE", "pairing code expired", 410),
+      errorResponse("EXPIRED_USER_CODE", "pairing code expired", 410),
     );
   }
 

--- a/gateway/src/remote-web/pairing-challenge-store.ts
+++ b/gateway/src/remote-web/pairing-challenge-store.ts
@@ -29,6 +29,7 @@ export interface PendingRemoteWebPairingChallenge {
   expiresAtMs: number;
   requesterIp: string;
   requesterUserAgent: string | null;
+  viaEdgeProxy: boolean;
   approvedAtMs?: number;
   exchangeStartedAtMs?: number;
   consumedAtMs?: number;
@@ -119,7 +120,7 @@ export function checkRemoteWebPairingChallengeCapacity(): RemoteWebPairingChalle
 
 export function createRemoteWebPairingChallenge(
   publicBaseUrl: string,
-  requester: { ip: string; userAgent: string | null },
+  requester: { ip: string; userAgent: string | null; viaEdgeProxy: boolean },
 ): RemoteWebPairingChallengeResponse {
   cleanupExpiredChallenges();
 
@@ -147,6 +148,7 @@ export function createRemoteWebPairingChallenge(
     expiresAtMs,
     requesterIp: requester.ip,
     requesterUserAgent: requester.userAgent,
+    viaEdgeProxy: requester.viaEdgeProxy,
   };
   challengesByUserCodeHash.set(userCodeHash, challenge);
   challengesByDeviceCodeHash.set(deviceCodeHash, challenge);
@@ -216,6 +218,7 @@ export function listPendingRemoteWebPairingChallenges(): RemoteWebPairingRequest
     expiresAt: new Date(challenge.expiresAtMs).toISOString(),
     requesterIp: challenge.requesterIp,
     requesterUserAgent: challenge.requesterUserAgent,
+    viaEdgeProxy: challenge.viaEdgeProxy,
   }));
 }
 
@@ -227,12 +230,21 @@ export function approveRemoteWebPairingChallengeById(
   return approveChallenge(challenge);
 }
 
+export type DenyRemoteWebPairingChallengeResult =
+  | { status: "denied" }
+  | { status: "already_approved" }
+  | { status: "invalid" };
+
 export function denyRemoteWebPairingChallengeById(
   id: string,
-): { status: "denied" } | { status: "invalid" } {
+): DenyRemoteWebPairingChallengeResult {
   const challenge = findChallengeById(id);
-  if (!challenge || challenge.status !== "pending") {
-    return { status: "invalid" };
+  if (!challenge) return { status: "invalid" };
+  // Approved/exchanging/consumed: the remote device may already be pairing.
+  // Distinct from unknown-id so the route can surface it instead of a 404 the
+  // client would read as an already-handled row.
+  if (challenge.status !== "pending") {
+    return { status: "already_approved" };
   }
 
   deleteChallenge(challenge);

--- a/packages/service-contracts/src/remote-web-pairing.ts
+++ b/packages/service-contracts/src/remote-web-pairing.ts
@@ -94,10 +94,20 @@ export interface RemoteWebPairingRequestSummary {
   requestedAt: string;
   /** ISO-8601 instant the challenge expires. */
   expiresAt: string;
-  /** Client IP the mint request arrived from (edge-forwarded when tunneled). */
+  /**
+   * Client IP of the mint request: the loopback/host address when minted
+   * locally, or the edge-observed client address when the mint arrived
+   * through the nginx tunnel edge (which stamps it via `proxy_set_header`,
+   * so a remote client cannot smuggle a value).
+   */
   requesterIp: string;
   /** User-Agent header of the mint request, or null when absent. */
   requesterUserAgent: string | null;
+  /**
+   * Whether the mint arrived through the public tunnel edge rather than the
+   * host itself.
+   */
+  viaEdgeProxy: boolean;
 }
 
 /** `GET /v1/remote-web/pairing-requests` success response body (200). */


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for web-pair-approve.md.

- Requester IP now comes from an nginx-set header on edge-proxied mints (was always 127.0.0.1 through a tunnel); summaries carry viaEdgeProxy
- Deny of an already-approved request returns 409 ALREADY_APPROVED instead of a silent 404
- Shared readJsonStringField/methodNotAllowed helpers replace duplicated route scaffolding; gateway pairing test fixtures deduped