### PR TITLE
fix(web): pairing approval card review gaps

### DIFF
--- a/clients/web/src/domains/intelligence/memories/format.ts
+++ b/clients/web/src/domains/intelligence/memories/format.ts
@@ -1,36 +1,11 @@
 import { t } from "@/i18n";
-
-const RELATIVE_FORMATTER =
-  typeof Intl !== "undefined" && "RelativeTimeFormat" in Intl
-    ? new Intl.RelativeTimeFormat(undefined, { style: "long", numeric: "auto" })
-    : null;
-
-const UNITS: Array<{ unit: Intl.RelativeTimeFormatUnit; ms: number }> = [
-  { unit: "year", ms: 365 * 24 * 60 * 60 * 1000 },
-  { unit: "month", ms: 30 * 24 * 60 * 60 * 1000 },
-  { unit: "week", ms: 7 * 24 * 60 * 60 * 1000 },
-  { unit: "day", ms: 24 * 60 * 60 * 1000 },
-  { unit: "hour", ms: 60 * 60 * 1000 },
-  { unit: "minute", ms: 60 * 1000 },
-  { unit: "second", ms: 1000 },
-];
+import { formatRelativeTime as formatRelativeTimeFromNow } from "@/lib/relative-time";
 
 export function formatRelativeTime(epochMs: number): string {
-  const diff = epochMs - Date.now();
-  const absDiff = Math.abs(diff);
-  if (absDiff < 30_000) {
+  if (Math.abs(epochMs - Date.now()) < 30_000) {
     return t("memoryFormat.justNow", { ns: "intelligence" });
   }
-  if (!RELATIVE_FORMATTER) {
-    return new Date(epochMs).toLocaleString();
-  }
-  for (const { unit, ms } of UNITS) {
-    if (absDiff >= ms || unit === "second") {
-      const value = Math.round(diff / ms);
-      return RELATIVE_FORMATTER.format(value, unit);
-    }
-  }
-  return RELATIVE_FORMATTER.format(Math.round(diff / 1000), "second");
+  return formatRelativeTimeFromNow(epochMs);
 }
 
 export function formatAbsoluteDate(epochMs: number): string {

--- a/clients/web/src/domains/settings/pair-device/pair-device-card.test.tsx
+++ b/clients/web/src/domains/settings/pair-device/pair-device-card.test.tsx
@@ -41,22 +41,22 @@ mock.module("@/lib/sentry/capture-error", () => ({
 }));
 
 const { PairDeviceCard } = await import("./pair-device-card");
+const {
+  createTimerHarness,
+  fetchLog,
+  installFetch: installRecordingFetch,
+  jsonResponse,
+  pendingRequest,
+  requestBody,
+  resetFetchLog,
+  restoreFetch,
+} = await import("./pair-device-test-helpers");
 
 const PUBLIC_URL = "https://foo.ts.net";
 const PAIR_URL = "https://foo.ts.net/assistant/pair#device_code=DEV-123";
 
-const originalFetch = globalThis.fetch;
-let requests: Array<{ url: string; body: unknown }> = [];
-
 function futureIso(): string {
   return new Date(Date.now() + 10 * 60_000).toISOString();
-}
-
-function jsonResponse(body: unknown, status = 200): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "Content-Type": "application/json" },
-  });
 }
 
 function challengeBody() {
@@ -70,16 +70,17 @@ function challengeBody() {
   };
 }
 
-function pendingRequestBody() {
-  return {
-    requestId: "req-1",
+function pendingRequestBody(
+  overrides: Parameters<typeof pendingRequest>[0] = {},
+) {
+  return pendingRequest({
     userCode: "QRST-7890",
     publicBaseUrl: PUBLIC_URL,
     requestedAt: new Date(Date.now() - 2 * 60_000).toISOString(),
     expiresAt: futureIso(),
-    requesterIp: "203.0.113.7",
     requesterUserAgent: "Mozilla/5.0 (iPhone; like Mac OS X)",
-  };
+    ...overrides,
+  });
 }
 
 interface FetchHandlers {
@@ -106,12 +107,7 @@ function installFetch(
     onRequestAction = () => jsonResponse({ status: "done" }),
   }: FetchHandlers = {},
 ) {
-  const fetchMock = mock(async (input: string | URL, init?: RequestInit) => {
-    const url = typeof input === "string" ? input : input.toString();
-    requests.push({
-      url,
-      body: typeof init?.body === "string" ? JSON.parse(init.body) : null,
-    });
+  return installRecordingFetch((url) => {
     if (url.endsWith("/v1/remote-web/pairing-challenge")) {
       return onChallenge();
     }
@@ -129,19 +125,17 @@ function installFetch(
     }
     throw new Error(`unexpected fetch: ${url}`);
   });
-  globalThis.fetch = fetchMock as unknown as typeof fetch;
-  return fetchMock;
 }
 
 function actionCalls(action: "approve" | "deny") {
-  return requests.filter((request) =>
+  return fetchLog.filter((request) =>
     request.url.endsWith(`/v1/remote-web/pairing-requests/${action}`),
   );
 }
 
 /** The mint-flow calls (challenge + verification), without the section's list polls. */
 function mintCalls() {
-  return requests.filter(
+  return fetchLog.filter(
     (request) => !request.url.endsWith("/v1/remote-web/pairing-requests"),
   );
 }
@@ -157,7 +151,7 @@ beforeEach(() => {
   supportsPairingRoutes = true;
   webRemoteIngressOn = true;
   selectedAssistant = { assistantId: "self", cloud: "local" };
-  requests = [];
+  resetFetchLog();
   localStorage.clear();
   // A rendered card polls the pending-request list on mount, so every test
   // needs the route answered; minting stays unexpected unless overridden.
@@ -166,7 +160,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
-  globalThis.fetch = originalFetch;
+  restoreFetch();
 });
 
 describe("PairDeviceCard", () => {
@@ -218,11 +212,11 @@ describe("PairDeviceCard", () => {
     expect(mintCalls()[0]?.url).toContain(
       "/assistant/__gateway/20100/v1/remote-web/pairing-challenge",
     );
-    expect(mintCalls()[0]?.body).toEqual({ publicBaseUrl: PUBLIC_URL });
+    expect(requestBody(mintCalls()[0])).toEqual({ publicBaseUrl: PUBLIC_URL });
     expect(mintCalls()[1]?.url).toContain(
       "/assistant/__gateway/20100/v1/remote-web/pairing-verification",
     );
-    expect(mintCalls()[1]?.body).toEqual({ userCode: "WXYZ-1234" });
+    expect(requestBody(mintCalls()[1])).toEqual({ userCode: "WXYZ-1234" });
   });
 
   test("surfaces the server's rejection message with a connectivity hint", async () => {
@@ -346,7 +340,7 @@ describe("PairDeviceCard: pending pairing requests", () => {
     // The list was polled and came back empty.
     await waitFor(() =>
       expect(
-        requests.some((r) => r.url.endsWith("/v1/remote-web/pairing-requests")),
+        fetchLog.some((r) => r.url.endsWith("/v1/remote-web/pairing-requests")),
       ).toBe(true),
     );
     expect(screen.queryByText("Pairing requests")).toBeNull();
@@ -393,18 +387,11 @@ describe("PairDeviceCard: pending pairing requests", () => {
 
   test("the relative request age advances while the request stays pending", async () => {
     installPendingFetch();
-    // Bun has no fake timers: capture armed intervals by hand and drive the
-    // 30s age tick directly. `waitFor` needs real timers, so this test stubs
-    // per-test, flushes with `act`, and restores in `finally`.
-    const realSetInterval = globalThis.setInterval;
-    const realClearInterval = globalThis.clearInterval;
+    // Timer harness instead of fake timers (bun has none): `waitFor` needs
+    // real timers, so this test flushes with `act` and restores in `finally`.
+    const timerHarness = createTimerHarness();
     const realDateNow = Date.now;
-    const timers: Array<{ handler: () => void; delay: number }> = [];
-    globalThis.setInterval = ((handler: () => void, delay: number) => {
-      timers.push({ handler, delay });
-      return timers.length as unknown as ReturnType<typeof setInterval>;
-    }) as typeof globalThis.setInterval;
-    globalThis.clearInterval = (() => {}) as typeof globalThis.clearInterval;
+    timerHarness.install();
     try {
       await act(async () => {
         render(<PairDeviceCard />);
@@ -414,14 +401,15 @@ describe("PairDeviceCard: pending pairing requests", () => {
       // Advance the clock 3 minutes and fire the age-refresh tick.
       const now = realDateNow();
       Date.now = () => now + 3 * 60_000;
-      const ageTick = timers.find((timer) => timer.delay === 30_000);
+      const ageTick = timerHarness.timers.find(
+        (timer) => timer.delay === 30_000,
+      );
       expect(ageTick).toBeTruthy();
       act(() => ageTick?.handler());
 
       expect(screen.getByText(/Requested 5 minutes ago/)).toBeTruthy();
     } finally {
-      globalThis.setInterval = realSetInterval;
-      globalThis.clearInterval = realClearInterval;
+      timerHarness.restore();
       Date.now = realDateNow;
     }
   });
@@ -434,7 +422,7 @@ describe("PairDeviceCard: pending pairing requests", () => {
     fireEvent.click(screen.getByRole("button", { name: "Approve" }));
 
     await waitFor(() => expect(actionCalls("approve")).toHaveLength(1));
-    expect(actionCalls("approve")[0]?.body).toEqual({ requestId: "req-1" });
+    expect(requestBody(actionCalls("approve")[0])).toEqual({ requestId: "req-1" });
     await waitFor(() => expect(screen.queryByText("QRST-7890")).toBeNull());
     expect(actionCalls("deny")).toHaveLength(0);
   });
@@ -447,12 +435,12 @@ describe("PairDeviceCard: pending pairing requests", () => {
     fireEvent.click(screen.getByRole("button", { name: "Deny" }));
 
     await waitFor(() => expect(actionCalls("deny")).toHaveLength(1));
-    expect(actionCalls("deny")[0]?.body).toEqual({ requestId: "req-1" });
+    expect(requestBody(actionCalls("deny")[0])).toEqual({ requestId: "req-1" });
     await waitFor(() => expect(screen.queryByText("QRST-7890")).toBeNull());
     expect(actionCalls("approve")).toHaveLength(0);
   });
 
-  test("action buttons disable while an action is in flight", async () => {
+  test("action buttons disable and the acted button shows busy while an action is in flight", async () => {
     // An approve that never resolves keeps the action in flight.
     installPendingFetch({
       onRequestAction: () => new Promise<Response>(() => {}),
@@ -472,6 +460,45 @@ describe("PairDeviceCard: pending pairing requests", () => {
       (screen.getByRole("button", { name: "Deny" }) as HTMLButtonElement)
         .disabled,
     ).toBe(true);
+
+    // Only the acted button carries the busy state.
+    const approveButton = screen.getByRole("button", { name: "Approve" });
+    expect(approveButton.getAttribute("aria-busy")).toBe("true");
+    expect(approveButton.querySelector(".animate-spin")).toBeTruthy();
+    const denyButton = screen.getByRole("button", { name: "Deny" });
+    expect(denyButton.getAttribute("aria-busy")).toBeNull();
+    expect(denyButton.querySelector(".animate-spin")).toBeNull();
+  });
+
+  test("a host-originated request says 'from this computer' instead of a loopback IP", async () => {
+    installPendingFetch({
+      onPendingRequests: () =>
+        jsonResponse({
+          requests: [
+            pendingRequestBody({ requesterIp: "127.0.0.1", viaEdgeProxy: false }),
+          ],
+        }),
+    });
+    render(<PairDeviceCard />);
+
+    await waitFor(() => expect(screen.getByText("QRST-7890")).toBeTruthy());
+    expect(
+      screen.getByText(/Requested 2 minutes ago from this computer/),
+    ).toBeTruthy();
+    expect(screen.queryByText(/127\.0\.0\.1/)).toBeNull();
+  });
+
+  test("a tunnel-edge request keeps showing the requester IP", async () => {
+    installPendingFetch({
+      onPendingRequests: () =>
+        jsonResponse({ requests: [pendingRequestBody({ viaEdgeProxy: true })] }),
+    });
+    render(<PairDeviceCard />);
+
+    await waitFor(() => expect(screen.getByText("QRST-7890")).toBeTruthy());
+    expect(
+      screen.getByText(/Requested 2 minutes ago from 203\.0\.113\.7/),
+    ).toBeTruthy();
   });
 
   test("stays hidden with the card when there is no local gateway", () => {
@@ -482,7 +509,7 @@ describe("PairDeviceCard: pending pairing requests", () => {
     expect(container.firstChild).toBeNull();
     expect(screen.queryByText("Pairing requests")).toBeNull();
     // The gate keeps the poll from ever firing.
-    expect(requests).toHaveLength(0);
+    expect(fetchLog).toHaveLength(0);
   });
 
   test("stays hidden with the card when web-remote-ingress is off", () => {
@@ -492,6 +519,6 @@ describe("PairDeviceCard: pending pairing requests", () => {
 
     expect(container.firstChild).toBeNull();
     expect(screen.queryByText("Pairing requests")).toBeNull();
-    expect(requests).toHaveLength(0);
+    expect(fetchLog).toHaveLength(0);
   });
 });

--- a/clients/web/src/domains/settings/pair-device/pair-device-client.test.ts
+++ b/clients/web/src/domains/settings/pair-device/pair-device-client.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import {
   approvePairingRequest,
@@ -8,40 +8,16 @@ import {
   PAIRING_CONNECTIVITY_HINT,
   PairDeviceError,
 } from "./pair-device-client";
-
-const BASE = "http://localhost:3000/assistant/__gateway/20100";
-
-const originalFetch = globalThis.fetch;
-let requests: Array<{ url: string; init: RequestInit | undefined }> = [];
-
-function jsonResponse(body: unknown, status = 200): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "Content-Type": "application/json" },
-  });
-}
-
-function installFetch(respond: (url: string) => Response | Promise<Response>) {
-  const fetchMock = mock(async (input: string | URL, init?: RequestInit) => {
-    const url = typeof input === "string" ? input : input.toString();
-    requests.push({ url, init });
-    return respond(url);
-  });
-  globalThis.fetch = fetchMock as unknown as typeof fetch;
-  return fetchMock;
-}
-
-function pendingRequest() {
-  return {
-    requestId: "req-1",
-    userCode: "WXYZ-1234",
-    publicBaseUrl: "https://foo.ts.net",
-    requestedAt: "2026-08-17T10:00:00.000Z",
-    expiresAt: "2026-08-17T10:10:00.000Z",
-    requesterIp: "203.0.113.7",
-    requesterUserAgent: "Mozilla/5.0",
-  };
-}
+import {
+  fetchLog,
+  installFetch,
+  jsonResponse,
+  pendingRequest,
+  requestBody,
+  resetFetchLog,
+  restoreFetch,
+  TEST_GATEWAY_BASE as BASE,
+} from "./pair-device-test-helpers";
 
 async function capturePairDeviceError(
   promise: Promise<unknown>,
@@ -56,11 +32,11 @@ async function capturePairDeviceError(
 }
 
 beforeEach(() => {
-  requests = [];
+  resetFetchLog();
 });
 
 afterEach(() => {
-  globalThis.fetch = originalFetch;
+  restoreFetch();
 });
 
 describe("listPendingPairingRequests", () => {
@@ -70,12 +46,12 @@ describe("listPendingPairingRequests", () => {
     const result = await listPendingPairingRequests({ base: BASE });
 
     await expect(result).toEqual([pendingRequest()]);
-    expect(requests).toHaveLength(1);
-    expect(requests[0]?.url).toBe(`${BASE}/v1/remote-web/pairing-requests`);
-    expect(requests[0]?.init?.method).toBe("GET");
-    expect(requests[0]?.init?.body).toBeUndefined();
+    expect(fetchLog).toHaveLength(1);
+    expect(fetchLog[0]?.url).toBe(`${BASE}/v1/remote-web/pairing-requests`);
+    expect(fetchLog[0]?.init?.method).toBe("GET");
+    expect(fetchLog[0]?.init?.body).toBeUndefined();
     expect(
-      new Headers(requests[0]?.init?.headers).get("Authorization"),
+      new Headers(fetchLog[0]?.init?.headers).get("Authorization"),
     ).toBeNull();
   });
 
@@ -142,7 +118,7 @@ describe("listPendingPairingRequests", () => {
 
     await listPendingPairingRequests({ base: BASE, signal: controller.signal });
 
-    await expect(requests[0]?.init?.signal).toBe(controller.signal);
+    await expect(fetchLog[0]?.init?.signal).toBe(controller.signal);
   });
 });
 
@@ -158,15 +134,13 @@ describe("approvePairingRequest", () => {
 
     await approvePairingRequest({ base: BASE, requestId: "req-1" });
 
-    expect(requests).toHaveLength(1);
-    expect(requests[0]?.url).toBe(
+    expect(fetchLog).toHaveLength(1);
+    expect(fetchLog[0]?.url).toBe(
       `${BASE}/v1/remote-web/pairing-requests/approve`,
     );
-    expect(requests[0]?.init?.method).toBe("POST");
-    expect(JSON.parse(requests[0]?.init?.body as string)).toEqual({
-      requestId: "req-1",
-    });
-    const headers = new Headers(requests[0]?.init?.headers);
+    expect(fetchLog[0]?.init?.method).toBe("POST");
+    expect(requestBody(fetchLog[0])).toEqual({ requestId: "req-1" });
+    const headers = new Headers(fetchLog[0]?.init?.headers);
     expect(headers.get("Content-Type")).toBe("application/json");
     expect(headers.get("Authorization")).toBeNull();
   });
@@ -212,7 +186,7 @@ describe("approvePairingRequest", () => {
       signal: controller.signal,
     });
 
-    await expect(requests[0]?.init?.signal).toBe(controller.signal);
+    await expect(fetchLog[0]?.init?.signal).toBe(controller.signal);
   });
 });
 
@@ -222,16 +196,14 @@ describe("denyPairingRequest", () => {
 
     await denyPairingRequest({ base: BASE, requestId: "req-1" });
 
-    expect(requests).toHaveLength(1);
-    expect(requests[0]?.url).toBe(
+    expect(fetchLog).toHaveLength(1);
+    expect(fetchLog[0]?.url).toBe(
       `${BASE}/v1/remote-web/pairing-requests/deny`,
     );
-    expect(requests[0]?.init?.method).toBe("POST");
-    expect(JSON.parse(requests[0]?.init?.body as string)).toEqual({
-      requestId: "req-1",
-    });
+    expect(fetchLog[0]?.init?.method).toBe("POST");
+    expect(requestBody(fetchLog[0])).toEqual({ requestId: "req-1" });
     expect(
-      new Headers(requests[0]?.init?.headers).get("Authorization"),
+      new Headers(fetchLog[0]?.init?.headers).get("Authorization"),
     ).toBeNull();
   });
 
@@ -246,6 +218,26 @@ describe("denyPairingRequest", () => {
     expect(err.message).toBe("Request expired.");
     expect(err.hint).toBeUndefined();
     expect(err.status).toBe(410);
+  });
+
+  test("carries the server's error code for conflict handling", async () => {
+    installFetch(() =>
+      jsonResponse(
+        {
+          error: {
+            code: "ALREADY_APPROVED",
+            message: "Request already approved on another surface.",
+          },
+        },
+        409,
+      ),
+    );
+
+    const err = await capturePairDeviceError(
+      denyPairingRequest({ base: BASE, requestId: "req-1" }),
+    );
+    expect(err.status).toBe(409);
+    expect(err.code).toBe("ALREADY_APPROVED");
   });
 
   test("rethrows AbortError when the caller cancels", async () => {
@@ -266,6 +258,19 @@ describe("denyPairingRequest", () => {
 
 describe("mintDevicePairing", () => {
   const MINT_ARGS = { base: BASE, publicBaseUrl: "https://foo.ts.net" };
+  const CHALLENGE_URL = `${BASE}/v1/remote-web/pairing-challenge`;
+  const VERIFICATION_URL = `${BASE}/v1/remote-web/pairing-verification`;
+  const LIST_URL = `${BASE}/v1/remote-web/pairing-requests`;
+  const DENY_URL = `${LIST_URL}/deny`;
+
+  function challengeResponse(): Response {
+    return jsonResponse({
+      userCode: "WXYZ-1234",
+      deviceCode: "device-code-1",
+      verificationUri: "https://foo.ts.net/assistant/pair",
+      expiresAt: "2026-08-17T10:10:00.000Z",
+    });
+  }
 
   test("attaches the connectivity hint when the challenge mint is rejected", async () => {
     installFetch(() =>
@@ -275,22 +280,139 @@ describe("mintDevicePairing", () => {
     const err = await capturePairDeviceError(mintDevicePairing(MINT_ARGS));
     expect(err.message).toBe("Mint refused.");
     expect(err.hint).toBe(PAIRING_CONNECTIVITY_HINT);
+    // The challenge never minted, so there is no orphan to clean up.
+    expect(fetchLog.map((r) => r.url)).toEqual([CHALLENGE_URL]);
   });
 
   test("attaches the connectivity hint when the verification step is rejected", async () => {
     installFetch((url) =>
-      url.endsWith("/v1/remote-web/pairing-challenge")
-        ? jsonResponse({
-            userCode: "WXYZ-1234",
-            deviceCode: "device-code-1",
-            verificationUri: "https://foo.ts.net/assistant/pair",
-            expiresAt: "2026-08-17T10:10:00.000Z",
-          })
+      url === CHALLENGE_URL
+        ? challengeResponse()
         : jsonResponse({ error: { message: "Verification failed." } }, 400),
     );
 
     const err = await capturePairDeviceError(mintDevicePairing(MINT_ARGS));
     expect(err.message).toBe("Verification failed.");
     expect(err.hint).toBe(PAIRING_CONNECTIVITY_HINT);
+  });
+
+  test("denies its orphaned challenge when the verification step fails", async () => {
+    installFetch((url) => {
+      switch (url) {
+        case CHALLENGE_URL:
+          return challengeResponse();
+        case VERIFICATION_URL:
+          return jsonResponse(
+            { error: { message: "Verification failed." } },
+            400,
+          );
+        case LIST_URL:
+          return jsonResponse({
+            requests: [
+              pendingRequest({ requestId: "req-other", userCode: "AAAA-0000" }),
+              pendingRequest({
+                requestId: "req-orphan",
+                userCode: "WXYZ-1234",
+              }),
+            ],
+          });
+        case DENY_URL:
+          return jsonResponse({ status: "denied" });
+        default:
+          throw new Error(`unexpected fetch: ${url}`);
+      }
+    });
+
+    const err = await capturePairDeviceError(mintDevicePairing(MINT_ARGS));
+
+    // The original mint error propagates unchanged.
+    expect(err.message).toBe("Verification failed.");
+    expect(err.hint).toBe(PAIRING_CONNECTIVITY_HINT);
+    // Cleanup listed the pending requests and denied the matching userCode.
+    expect(fetchLog.map((r) => r.url)).toEqual([
+      CHALLENGE_URL,
+      VERIFICATION_URL,
+      LIST_URL,
+      DENY_URL,
+    ]);
+    expect(requestBody(fetchLog[3])).toEqual({ requestId: "req-orphan" });
+  });
+
+  test("skips the deny when no pending row matches the minted userCode", async () => {
+    installFetch((url) => {
+      switch (url) {
+        case CHALLENGE_URL:
+          return challengeResponse();
+        case VERIFICATION_URL:
+          return jsonResponse(
+            { error: { message: "Verification failed." } },
+            400,
+          );
+        case LIST_URL:
+          return jsonResponse({
+            requests: [
+              pendingRequest({ requestId: "req-other", userCode: "AAAA-0000" }),
+            ],
+          });
+        default:
+          throw new Error(`unexpected fetch: ${url}`);
+      }
+    });
+
+    const err = await capturePairDeviceError(mintDevicePairing(MINT_ARGS));
+
+    expect(err.message).toBe("Verification failed.");
+    expect(fetchLog.map((r) => r.url)).toEqual([
+      CHALLENGE_URL,
+      VERIFICATION_URL,
+      LIST_URL,
+    ]);
+  });
+
+  test("a cleanup failure does not mask the original mint error", async () => {
+    installFetch((url) => {
+      switch (url) {
+        case CHALLENGE_URL:
+          return challengeResponse();
+        case VERIFICATION_URL:
+          return jsonResponse(
+            { error: { message: "Verification failed." } },
+            400,
+          );
+        case LIST_URL:
+          return jsonResponse({ error: { message: "List broken." } }, 500);
+        default:
+          throw new Error(`unexpected fetch: ${url}`);
+      }
+    });
+
+    const err = await capturePairDeviceError(mintDevicePairing(MINT_ARGS));
+
+    expect(err.message).toBe("Verification failed.");
+    expect(err.hint).toBe(PAIRING_CONNECTIVITY_HINT);
+    expect(fetchLog.map((r) => r.url)).toEqual([
+      CHALLENGE_URL,
+      VERIFICATION_URL,
+      LIST_URL,
+    ]);
+  });
+
+  test("skips cleanup when the caller aborts during verification", async () => {
+    installFetch((url) => {
+      if (url === CHALLENGE_URL) {
+        return challengeResponse();
+      }
+      throw new DOMException("Aborted", "AbortError");
+    });
+    const controller = new AbortController();
+
+    await expect(
+      mintDevicePairing({ ...MINT_ARGS, signal: controller.signal }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+
+    expect(fetchLog.map((r) => r.url)).toEqual([
+      CHALLENGE_URL,
+      VERIFICATION_URL,
+    ]);
   });
 });

--- a/clients/web/src/domains/settings/pair-device/pair-device-client.ts
+++ b/clients/web/src/domains/settings/pair-device/pair-device-client.ts
@@ -32,6 +32,7 @@ import type {
 } from "@vellumai/service-contracts/remote-web-pairing";
 
 import { getLocalGatewayUrl, getSelectedAssistant } from "@/lib/local-mode";
+import { captureError } from "@/lib/sentry/capture-error";
 
 import { buildRemoteWebPairingUrl } from "./pair-device-url";
 
@@ -54,14 +55,33 @@ export class PairDeviceError extends Error {
   readonly hint?: string;
   /** HTTP status of the rejecting response; unset for network failures. */
   readonly status?: number;
+  /** Machine-readable error code from the response body, when present. */
+  readonly code?: string;
 
-  constructor(message: string, hint?: string, status?: number) {
+  constructor(
+    message: string,
+    options: { hint?: string; status?: number; code?: string } = {},
+  ) {
     super(message);
     this.name = "PairDeviceError";
-    this.hint = hint;
-    this.status = status;
+    this.hint = options.hint;
+    this.status = options.status;
+    this.code = options.code;
   }
 }
+
+/** Error code the deny route returns when the request was approved first. */
+export const ALREADY_APPROVED_ERROR_CODE = "ALREADY_APPROVED";
+
+/**
+ * A pending request row as this branch reads it. `viaEdgeProxy` (`true` when
+ * the challenge was minted through the public tunnel edge, `false` when it was
+ * minted from the host itself) lands with the gateway contracts change;
+ * optional here so older gateways that omit it stay compatible.
+ */
+export type PendingPairingRequestSummary = RemoteWebPairingRequestSummary & {
+  viaEdgeProxy?: boolean;
+};
 
 export interface DevicePairing {
   /** The scannable https pair URL (verification URI + `#device_code=…`). */
@@ -113,6 +133,11 @@ function serverErrorMessage(payload: unknown): string | null {
   return typeof message === "string" && message.trim() ? message : null;
 }
 
+function serverErrorCode(payload: unknown): string | undefined {
+  const code = (payload as { error?: { code?: unknown } } | null)?.error?.code;
+  return typeof code === "string" && code ? code : undefined;
+}
+
 async function pairingRouteRequest<T>(
   url: string,
   init: RequestInit,
@@ -139,8 +164,11 @@ async function pairingRouteRequest<T>(
     throw new PairDeviceError(
       serverErrorMessage(payload) ??
         `Pairing failed (HTTP ${response.status}).`,
-      rejectionHint,
-      response.status,
+      {
+        hint: rejectionHint,
+        status: response.status,
+        code: serverErrorCode(payload),
+      },
     );
   }
 
@@ -188,19 +216,55 @@ export async function mintDevicePairing(args: {
     PAIRING_CONNECTIVITY_HINT,
   );
 
-  await postPairingRoute(
-    `${base}${PAIRING_VERIFICATION_PATH}`,
-    {
-      userCode: challenge.userCode,
-    } satisfies RemoteWebPairingVerificationRequest,
-    signal,
-    PAIRING_CONNECTIVITY_HINT,
-  );
+  try {
+    await postPairingRoute(
+      `${base}${PAIRING_VERIFICATION_PATH}`,
+      {
+        userCode: challenge.userCode,
+      } satisfies RemoteWebPairingVerificationRequest,
+      signal,
+      PAIRING_CONNECTIVITY_HINT,
+    );
+  } catch (err) {
+    // The minted challenge would otherwise stay pending for its TTL and show
+    // up in the sibling approval list as a foreign request.
+    if (!(err instanceof DOMException && err.name === "AbortError")) {
+      await denyOrphanedChallenge(base, challenge.userCode, signal);
+    }
+    throw err;
+  }
 
   return {
     pairUrl: buildRemoteWebPairingUrl(challenge),
     expiresAt: challenge.expiresAt,
   };
+}
+
+/**
+ * Best-effort removal of a freshly minted challenge whose verification step
+ * failed. Swallows every cleanup error (the mint failure is what the caller
+ * must see); the challenge's TTL bounds the damage when cleanup also fails.
+ */
+async function denyOrphanedChallenge(
+  base: string,
+  userCode: string,
+  signal: AbortSignal | undefined,
+): Promise<void> {
+  try {
+    const pending = await listPendingPairingRequests({ base, signal });
+    const orphan = pending.find((request) => request.userCode === userCode);
+    if (orphan) {
+      await denyPairingRequest({ base, requestId: orphan.requestId, signal });
+    }
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "AbortError") {
+      return;
+    }
+    captureError(err, {
+      context: "pair-device-orphan-cleanup",
+      bestEffort: true,
+    });
+  }
 }
 
 /**
@@ -211,7 +275,7 @@ export async function mintDevicePairing(args: {
 export async function listPendingPairingRequests(args: {
   base: string;
   signal?: AbortSignal;
-}): Promise<RemoteWebPairingRequestSummary[]> {
+}): Promise<PendingPairingRequestSummary[]> {
   const payload =
     await pairingRouteRequest<RemoteWebPairingRequestListResponse>(
       `${args.base}${PAIRING_REQUESTS_PATH}`,

--- a/clients/web/src/domains/settings/pair-device/pair-device-test-helpers.ts
+++ b/clients/web/src/domains/settings/pair-device/pair-device-test-helpers.ts
@@ -1,0 +1,122 @@
+/**
+ * Shared scaffolding for the pair-device test files: the fetch stub with its
+ * request log, JSON response builders, the pending-request fixture, and the
+ * armed-timer capture harness standing in for fake timers (bun's test runner
+ * has none). Test semantics stay in the test files; only plumbing lives here.
+ */
+
+import { mock } from "bun:test";
+
+import type { PendingPairingRequestSummary } from "./pair-device-client";
+
+/** Local-gateway base URL used across the pair-device tests. */
+export const TEST_GATEWAY_BASE =
+  "http://localhost:3000/assistant/__gateway/20100";
+
+export function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export function pendingRequest(
+  overrides: Partial<PendingPairingRequestSummary> = {},
+): PendingPairingRequestSummary {
+  return {
+    requestId: "req-1",
+    userCode: "WXYZ-1234",
+    publicBaseUrl: "https://foo.ts.net",
+    requestedAt: "2026-08-17T10:00:00.000Z",
+    expiresAt: "2026-08-17T10:10:00.000Z",
+    requesterIp: "203.0.113.7",
+    requesterUserAgent: "Mozilla/5.0",
+    ...overrides,
+  };
+}
+
+export interface RecordedFetch {
+  url: string;
+  init: RequestInit | undefined;
+}
+
+/** The recorded fetch's parsed JSON body, or `null` when it had none. */
+export function requestBody(recorded: RecordedFetch | undefined): unknown {
+  return typeof recorded?.init?.body === "string"
+    ? JSON.parse(recorded.init.body)
+    : null;
+}
+
+const originalFetch = globalThis.fetch;
+
+/** Requests recorded by {@link installFetch}, oldest first. */
+export const fetchLog: RecordedFetch[] = [];
+
+/**
+ * Replace `globalThis.fetch` with a recording stub answering via `respond`.
+ * Pair with {@link resetFetchLog} in `beforeEach` and {@link restoreFetch} in
+ * `afterEach`.
+ */
+export function installFetch(
+  respond: (url: string) => Response | Promise<Response>,
+) {
+  const fetchMock = mock(async (input: string | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    fetchLog.push({ url, init });
+    return respond(url);
+  });
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  return fetchMock;
+}
+
+export function resetFetchLog() {
+  fetchLog.length = 0;
+}
+
+export function restoreFetch() {
+  globalThis.fetch = originalFetch;
+}
+
+export interface ArmedTimer {
+  handler: () => void;
+  delay: number;
+  cleared: boolean;
+}
+
+export interface TimerHarness {
+  /** Every interval armed since {@link TimerHarness.install}, oldest first. */
+  timers: ArmedTimer[];
+  install: () => void;
+  restore: () => void;
+}
+
+/**
+ * Capture `setInterval` arms instead of scheduling them, so tests fire ticks
+ * by hand. While installed, `waitFor` (which needs real timers) cannot be
+ * used; flush with `act` instead.
+ */
+export function createTimerHarness(): TimerHarness {
+  const timers: ArmedTimer[] = [];
+  const realSetInterval = globalThis.setInterval;
+  const realClearInterval = globalThis.clearInterval;
+  return {
+    timers,
+    install() {
+      globalThis.setInterval = ((handler: () => void, delay: number) => {
+        timers.push({ handler, delay, cleared: false });
+        return timers.length as unknown as ReturnType<typeof setInterval>;
+      }) as typeof globalThis.setInterval;
+      globalThis.clearInterval = ((id: number) => {
+        const timer = timers[id - 1];
+        if (timer) {
+          timer.cleared = true;
+        }
+      }) as typeof globalThis.clearInterval;
+    },
+    restore() {
+      globalThis.setInterval = realSetInterval;
+      globalThis.clearInterval = realClearInterval;
+      timers.length = 0;
+    },
+  };
+}

--- a/clients/web/src/domains/settings/pair-device/pending-pairing-requests.tsx
+++ b/clients/web/src/domains/settings/pair-device/pending-pairing-requests.tsx
@@ -2,8 +2,10 @@ import { useEffect, useState } from "react";
 
 import { Button } from "@vellumai/design-library/components/button";
 import { Notice } from "@vellumai/design-library/components/notice";
+import { Loader2 } from "lucide-react";
 
 import { currentLocale, useTranslation } from "@/i18n";
+import { formatRelativeTime } from "@/lib/relative-time";
 
 import { usePendingPairingRequests } from "./use-pending-pairing-requests";
 
@@ -15,30 +17,16 @@ interface PendingPairingRequestsProps {
 /** How often visible relative ages re-render; 30s suits minute phrasing. */
 const AGE_REFRESH_INTERVAL_MS = 30_000;
 
-const RELATIVE_UNITS: Array<{ unit: Intl.RelativeTimeFormatUnit; ms: number }> =
-  [
-    { unit: "day", ms: 86_400_000 },
-    { unit: "hour", ms: 3_600_000 },
-    { unit: "minute", ms: 60_000 },
-  ];
-
 /**
  * Relative label for a request's timestamp in the active i18n locale.
- * Pending requests are short-lived, so minutes/hours/days cover the range;
+ * Pending requests are short-lived, so minute granularity is enough;
  * anything under a minute reads as "now".
  */
 function formatRequestedAt(iso: string): string {
-  const formatter = new Intl.RelativeTimeFormat(currentLocale(), {
-    numeric: "auto",
+  return formatRelativeTime(new Date(iso).getTime(), {
+    locale: currentLocale(),
+    minimumUnit: "minute",
   });
-  const diffMs = new Date(iso).getTime() - Date.now();
-  const absMs = Math.abs(diffMs);
-  for (const { unit, ms } of RELATIVE_UNITS) {
-    if (absMs >= ms) {
-      return formatter.format(Math.trunc(diffMs / ms), unit);
-    }
-  }
-  return formatter.format(0, "second");
 }
 
 /**
@@ -89,50 +77,72 @@ export function PendingPairingRequests({ base }: PendingPairingRequestsProps) {
       {error && <Notice tone="error" title={error} />}
       {requests.length > 0 && (
         <ul className="flex flex-col gap-2">
-          {requests.map((request) => (
-            <li
-              key={request.requestId}
-              className="flex flex-col gap-2 rounded-lg border border-[var(--border-element)] p-3"
-            >
-              <code className="w-fit rounded-md bg-[var(--surface-active)] px-2.5 py-1.5 text-title-medium tracking-wide text-[var(--content-emphasised)]">
-                {request.userCode}
-              </code>
-              <div className="flex flex-col gap-0.5">
-                <p className="text-body-small-default text-[var(--content-tertiary)]">
-                  {t("pendingPairingRequests.requestedMeta", {
-                    when: formatRequestedAt(request.requestedAt),
-                    ip: request.requesterIp,
-                  })}
-                </p>
-                {request.requesterUserAgent && (
-                  <p
-                    className="truncate text-body-small-default text-[var(--content-tertiary)]"
-                    title={request.requesterUserAgent}
-                  >
-                    {request.requesterUserAgent}
+          {requests.map((request) => {
+            const rowAction =
+              actingOn !== null && actingOn.requestId === request.requestId
+                ? actingOn.action
+                : null;
+            const approving = rowAction === "approve";
+            const denying = rowAction === "deny";
+            return (
+              <li
+                key={request.requestId}
+                className="flex flex-col gap-2 rounded-lg border border-[var(--border-element)] p-3"
+              >
+                <code className="w-fit rounded-md bg-[var(--surface-active)] px-2.5 py-1.5 text-title-medium tracking-wide text-[var(--content-emphasised)]">
+                  {request.userCode}
+                </code>
+                <div className="flex flex-col gap-0.5">
+                  <p className="text-body-small-default text-[var(--content-tertiary)]">
+                    {request.viaEdgeProxy === false
+                      ? // Host-originated mint: the requester IP is a loopback
+                        // address, so naming this computer is the honest label.
+                        t("pendingPairingRequests.requestedMetaHost", {
+                          when: formatRequestedAt(request.requestedAt),
+                        })
+                      : t("pendingPairingRequests.requestedMeta", {
+                          when: formatRequestedAt(request.requestedAt),
+                          ip: request.requesterIp,
+                        })}
                   </p>
-                )}
-              </div>
-              <div className="flex gap-2">
-                <Button
-                  variant="primary"
-                  size="compact"
-                  disabled={actingOn !== null}
-                  onClick={() => void approve(request.requestId)}
-                >
-                  {t("pendingPairingRequests.approveButton")}
-                </Button>
-                <Button
-                  variant="dangerOutline"
-                  size="compact"
-                  disabled={actingOn !== null}
-                  onClick={() => void deny(request.requestId)}
-                >
-                  {t("pendingPairingRequests.denyButton")}
-                </Button>
-              </div>
-            </li>
-          ))}
+                  {request.requesterUserAgent && (
+                    <p
+                      className="truncate text-body-small-default text-[var(--content-tertiary)]"
+                      title={request.requesterUserAgent}
+                    >
+                      {request.requesterUserAgent}
+                    </p>
+                  )}
+                </div>
+                <div className="flex gap-2">
+                  <Button
+                    variant="primary"
+                    size="compact"
+                    disabled={actingOn !== null}
+                    aria-busy={approving || undefined}
+                    leftIcon={
+                      approving ? <Loader2 className="animate-spin" /> : undefined
+                    }
+                    onClick={() => void approve(request.requestId)}
+                  >
+                    {t("pendingPairingRequests.approveButton")}
+                  </Button>
+                  <Button
+                    variant="dangerOutline"
+                    size="compact"
+                    disabled={actingOn !== null}
+                    aria-busy={denying || undefined}
+                    leftIcon={
+                      denying ? <Loader2 className="animate-spin" /> : undefined
+                    }
+                    onClick={() => void deny(request.requestId)}
+                  >
+                    {t("pendingPairingRequests.denyButton")}
+                  </Button>
+                </div>
+              </li>
+            );
+          })}
         </ul>
       )}
     </section>

--- a/clients/web/src/domains/settings/pair-device/use-pending-pairing-requests.test.ts
+++ b/clients/web/src/domains/settings/pair-device/use-pending-pairing-requests.test.ts
@@ -10,14 +10,23 @@
  * `waitFor` (which schedules real timers).
  */
 
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { act, cleanup, renderHook } from "@testing-library/react";
 
-import type { RemoteWebPairingRequestSummary } from "@vellumai/service-contracts/remote-web-pairing";
-
+import type { PendingPairingRequestSummary } from "./pair-device-client";
+import {
+  createTimerHarness,
+  fetchLog,
+  installFetch,
+  jsonResponse,
+  pendingRequest,
+  resetFetchLog,
+  restoreFetch,
+  TEST_GATEWAY_BASE as BASE,
+  type ArmedTimer,
+} from "./pair-device-test-helpers";
 import { usePendingPairingRequests } from "./use-pending-pairing-requests";
 
-const BASE = "http://localhost:3000/assistant/__gateway/20100";
 const LIST_URL = `${BASE}/v1/remote-web/pairing-requests`;
 const APPROVE_URL = `${LIST_URL}/approve`;
 const DENY_URL = `${LIST_URL}/deny`;
@@ -25,25 +34,6 @@ const OTHER_BASE = "http://localhost:3000/assistant/__gateway/20200";
 const OTHER_LIST_URL = `${OTHER_BASE}/v1/remote-web/pairing-requests`;
 const OTHER_APPROVE_URL = `${OTHER_LIST_URL}/approve`;
 const POLL_INTERVAL_MS = 5000;
-
-function pendingRequest(requestId = "req-1"): RemoteWebPairingRequestSummary {
-  return {
-    requestId,
-    userCode: "WXYZ-1234",
-    publicBaseUrl: "https://foo.ts.net",
-    requestedAt: "2026-08-17T10:00:00.000Z",
-    expiresAt: "2026-08-17T10:10:00.000Z",
-    requesterIp: "203.0.113.7",
-    requesterUserAgent: "Mozilla/5.0",
-  };
-}
-
-function jsonResponse(body: unknown, status = 200): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "Content-Type": "application/json" },
-  });
-}
 
 function approvedResponse(): Response {
   return jsonResponse({
@@ -53,31 +43,14 @@ function approvedResponse(): Response {
   });
 }
 
-// ---------------------------------------------------------------------------
-// fetch stub: per-URL responders plus a captured request log.
-// ---------------------------------------------------------------------------
-
-const originalFetch = globalThis.fetch;
-let requests: Array<{ url: string; init: RequestInit | undefined }> = [];
-
-function installFetch(respond: (url: string) => Response | Promise<Response>) {
-  const fetchMock = mock(async (input: string | URL, init?: RequestInit) => {
-    const url = typeof input === "string" ? input : input.toString();
-    requests.push({ url, init });
-    return respond(url);
-  });
-  globalThis.fetch = fetchMock as unknown as typeof fetch;
-  return fetchMock;
-}
-
 function listCalls() {
-  return requests.filter((request) => request.url === LIST_URL);
+  return fetchLog.filter((request) => request.url === LIST_URL);
 }
 
 /** Serve the list route with `summaries`; reassignable between polls. */
 let listResponder: () => Response | Promise<Response>;
 
-function serveList(summaries: RemoteWebPairingRequestSummary[]) {
+function serveList(summaries: PendingPairingRequestSummary[]) {
   listResponder = () => jsonResponse({ requests: summaries });
 }
 
@@ -93,22 +66,14 @@ function installRoutedFetch(
   });
 }
 
-// ---------------------------------------------------------------------------
-// Armed-timer capture standing in for fake timers.
-// ---------------------------------------------------------------------------
-
-interface ArmedTimer {
-  handler: () => void;
-  delay: number;
-  cleared: boolean;
-}
-
-let armedTimers: ArmedTimer[] = [];
-const realSetInterval = globalThis.setInterval;
-const realClearInterval = globalThis.clearInterval;
+// Armed-timer capture standing in for fake timers (bun has none); interval
+// refreshes are driven by hand and flushed with `act` instead of `waitFor`.
+const timerHarness = createTimerHarness();
 
 function pollTimers(): ArmedTimer[] {
-  return armedTimers.filter((timer) => timer.delay === POLL_INTERVAL_MS);
+  return timerHarness.timers.filter(
+    (timer) => timer.delay === POLL_INTERVAL_MS,
+  );
 }
 
 /** Fire the (single) live poll interval once and flush the resulting poll. */
@@ -127,7 +92,7 @@ function renderPendingRequests(base: string | null = BASE) {
   );
 }
 
-async function renderWithList(summaries: RemoteWebPairingRequestSummary[]) {
+async function renderWithList(summaries: PendingPairingRequestSummary[]) {
   serveList(summaries);
   installRoutedFetch();
   let rendered!: ReturnType<typeof renderPendingRequests>;
@@ -138,27 +103,15 @@ async function renderWithList(summaries: RemoteWebPairingRequestSummary[]) {
 }
 
 beforeEach(() => {
-  requests = [];
+  resetFetchLog();
   serveList([]);
-
-  globalThis.setInterval = ((handler: () => void, delay: number) => {
-    armedTimers.push({ handler, delay, cleared: false });
-    return armedTimers.length as unknown as ReturnType<typeof setInterval>;
-  }) as typeof globalThis.setInterval;
-  globalThis.clearInterval = ((id: number) => {
-    const timer = armedTimers[id - 1];
-    if (timer) {
-      timer.cleared = true;
-    }
-  }) as typeof globalThis.clearInterval;
+  timerHarness.install();
 });
 
 afterEach(() => {
   cleanup();
-  armedTimers = [];
-  globalThis.setInterval = realSetInterval;
-  globalThis.clearInterval = realClearInterval;
-  globalThis.fetch = originalFetch;
+  timerHarness.restore();
+  restoreFetch();
 });
 
 describe("usePendingPairingRequests: polling", () => {
@@ -173,9 +126,9 @@ describe("usePendingPairingRequests: polling", () => {
   });
 
   test("an interval tick replaces the list", async () => {
-    const { result } = await renderWithList([pendingRequest("req-1")]);
+    const { result } = await renderWithList([pendingRequest({ requestId: "req-1" })]);
 
-    serveList([pendingRequest("req-1"), pendingRequest("req-2")]);
+    serveList([pendingRequest({ requestId: "req-1" }), pendingRequest({ requestId: "req-2" })]);
     await tickPoll();
 
     expect(listCalls()).toHaveLength(2);
@@ -186,7 +139,7 @@ describe("usePendingPairingRequests: polling", () => {
   });
 
   test("an unchanged poll keeps the same list reference", async () => {
-    const { result } = await renderWithList([pendingRequest("req-1")]);
+    const { result } = await renderWithList([pendingRequest({ requestId: "req-1" })]);
     const initial = result.current.requests;
 
     await tickPoll();
@@ -203,7 +156,7 @@ describe("usePendingPairingRequests: polling", () => {
       ({ result } = renderPendingRequests(null));
     });
 
-    expect(requests).toHaveLength(0);
+    expect(fetchLog).toHaveLength(0);
     expect(pollTimers()).toHaveLength(0);
     expect(result.current.requests).toEqual([]);
     expect(result.current.error).toBeNull();
@@ -246,7 +199,7 @@ describe("usePendingPairingRequests: polling", () => {
 
 describe("usePendingPairingRequests: approve/deny", () => {
   test("approve tracks the in-flight action and removes the row on success", async () => {
-    serveList([pendingRequest("req-1"), pendingRequest("req-2")]);
+    serveList([pendingRequest({ requestId: "req-1" }), pendingRequest({ requestId: "req-2" })]);
     let resolveApprove!: (response: Response) => void;
     installRoutedFetch({
       [APPROVE_URL]: () =>
@@ -272,7 +225,7 @@ describe("usePendingPairingRequests: approve/deny", () => {
       resolveApprove(approvedResponse());
     });
 
-    const approveCalls = requests.filter((r) => r.url === APPROVE_URL);
+    const approveCalls = fetchLog.filter((r) => r.url === APPROVE_URL);
     expect(approveCalls).toHaveLength(1);
     expect(JSON.parse(approveCalls[0]?.init?.body as string)).toEqual({
       requestId: "req-1",
@@ -283,7 +236,7 @@ describe("usePendingPairingRequests: approve/deny", () => {
   });
 
   test("deny removes the row and clears the in-flight marker", async () => {
-    serveList([pendingRequest("req-1")]);
+    serveList([pendingRequest({ requestId: "req-1" })]);
     installRoutedFetch({
       [DENY_URL]: () => jsonResponse({ status: "denied" }),
     });
@@ -297,13 +250,13 @@ describe("usePendingPairingRequests: approve/deny", () => {
       await result.current.deny("req-1");
     });
 
-    expect(requests.filter((r) => r.url === DENY_URL)).toHaveLength(1);
+    expect(fetchLog.filter((r) => r.url === DENY_URL)).toHaveLength(1);
     expect(result.current.actingOn).toBeNull();
     expect(result.current.requests).toEqual([]);
   });
 
   test("a 404 from approve is treated as removal, not an error", async () => {
-    serveList([pendingRequest("req-1")]);
+    serveList([pendingRequest({ requestId: "req-1" })]);
     installRoutedFetch({
       [APPROVE_URL]: () =>
         jsonResponse({ error: { message: "Unknown request." } }, 404),
@@ -324,7 +277,7 @@ describe("usePendingPairingRequests: approve/deny", () => {
   });
 
   test("a non-404 failure keeps the row and surfaces the message", async () => {
-    serveList([pendingRequest("req-1")]);
+    serveList([pendingRequest({ requestId: "req-1" })]);
     let approveResponder = () =>
       jsonResponse({ error: { message: "Approval failed." } }, 500);
     installRoutedFetch({ [APPROVE_URL]: () => approveResponder() });
@@ -338,7 +291,7 @@ describe("usePendingPairingRequests: approve/deny", () => {
       await result.current.approve("req-1");
     });
 
-    expect(result.current.requests).toEqual([pendingRequest("req-1")]);
+    expect(result.current.requests).toEqual([pendingRequest({ requestId: "req-1" })]);
     expect(result.current.actingOn).toBeNull();
     expect(result.current.error).toBe("Approval failed.");
 
@@ -352,7 +305,7 @@ describe("usePendingPairingRequests: approve/deny", () => {
   });
 
   test("a poll clears an action error once its request leaves the list", async () => {
-    serveList([pendingRequest("req-1")]);
+    serveList([pendingRequest({ requestId: "req-1" })]);
     installRoutedFetch({
       [APPROVE_URL]: () =>
         jsonResponse({ error: { message: "Approval failed." } }, 500),
@@ -381,7 +334,7 @@ describe("usePendingPairingRequests: approve/deny", () => {
   });
 
   test("a base change clears rows and errors before the new base's poll resolves", async () => {
-    serveList([pendingRequest("req-1")]);
+    serveList([pendingRequest({ requestId: "req-1" })]);
     // The new base's list never resolves, so anything shown for it is stale.
     installRoutedFetch({
       [OTHER_LIST_URL]: () => new Promise<Response>(() => {}),
@@ -407,12 +360,12 @@ describe("usePendingPairingRequests: approve/deny", () => {
     expect(result.current.requests).toEqual([]);
     expect(result.current.error).toBeNull();
     // The new base was polled, but its hung response left the list empty.
-    const otherListCalls = requests.filter((r) => r.url === OTHER_LIST_URL);
+    const otherListCalls = fetchLog.filter((r) => r.url === OTHER_LIST_URL);
     expect(otherListCalls).toHaveLength(1);
   });
 
   test("a base change aborts the pending action and frees the guard for the new base", async () => {
-    serveList([pendingRequest("req-1")]);
+    serveList([pendingRequest({ requestId: "req-1" })]);
     let resolveOldApprove!: (response: Response) => void;
     installRoutedFetch({
       [APPROVE_URL]: () =>
@@ -420,7 +373,7 @@ describe("usePendingPairingRequests: approve/deny", () => {
           resolveOldApprove = resolve;
         }),
       [OTHER_LIST_URL]: () =>
-        jsonResponse({ requests: [pendingRequest("req-9")] }),
+        jsonResponse({ requests: [pendingRequest({ requestId: "req-9" })] }),
       [OTHER_APPROVE_URL]: approvedResponse,
     });
 
@@ -443,7 +396,7 @@ describe("usePendingPairingRequests: approve/deny", () => {
     });
 
     // The old action was aborted and its marker cleared.
-    const oldApprove = requests.filter((r) => r.url === APPROVE_URL);
+    const oldApprove = fetchLog.filter((r) => r.url === APPROVE_URL);
     expect(oldApprove[0]?.init?.signal?.aborted).toBe(true);
     expect(result.current.actingOn).toBeNull();
     expect(result.current.requests.map((r) => r.requestId)).toEqual(["req-9"]);
@@ -458,7 +411,7 @@ describe("usePendingPairingRequests: approve/deny", () => {
     await act(async () => {
       await result.current.approve("req-9");
     });
-    expect(requests.filter((r) => r.url === OTHER_APPROVE_URL)).toHaveLength(1);
+    expect(fetchLog.filter((r) => r.url === OTHER_APPROVE_URL)).toHaveLength(1);
     expect(result.current.requests).toEqual([]);
     expect(result.current.error).toBeNull();
   });
@@ -475,7 +428,115 @@ describe("usePendingPairingRequests: approve/deny", () => {
       await result.current.approve("req-1");
     });
 
-    expect(requests).toHaveLength(0);
+    expect(fetchLog).toHaveLength(0);
     expect(result.current.actingOn).toBeNull();
+  });
+});
+
+describe("usePendingPairingRequests: deny racing an approve", () => {
+  const ALREADY_APPROVED_CONFLICT = () =>
+    jsonResponse(
+      {
+        error: {
+          code: "ALREADY_APPROVED",
+          message: "Request already approved on another surface.",
+        },
+      },
+      409,
+    );
+
+  test("a deny rejected with 409 ALREADY_APPROVED removes the row but surfaces the notice", async () => {
+    serveList([pendingRequest({ requestId: "req-1" })]);
+    installRoutedFetch({ [DENY_URL]: ALREADY_APPROVED_CONFLICT });
+
+    let result!: ReturnType<typeof renderPendingRequests>["result"];
+    await act(async () => {
+      ({ result } = renderPendingRequests());
+    });
+
+    await act(async () => {
+      await result.current.deny("req-1");
+    });
+
+    // The row is gone (it is no longer pending), but the user must learn the
+    // deny never took effect and the device is now paired.
+    expect(result.current.requests).toEqual([]);
+    expect(result.current.actingOn).toBeNull();
+    expect(result.current.error).toBe(
+      "This request was already approved somewhere else, so the deny didn't take effect and the device is now paired.",
+    );
+  });
+
+  test("the already-approved notice survives polls, then clears on the next action", async () => {
+    serveList([pendingRequest({ requestId: "req-1" })]);
+    installRoutedFetch({
+      [DENY_URL]: ALREADY_APPROVED_CONFLICT,
+      [APPROVE_URL]: approvedResponse,
+    });
+
+    let result!: ReturnType<typeof renderPendingRequests>["result"];
+    await act(async () => {
+      ({ result } = renderPendingRequests());
+    });
+    await act(async () => {
+      await result.current.deny("req-1");
+    });
+
+    // Unlike ordinary action errors, the notice is not dropped when a poll no
+    // longer lists the request; it would otherwise flash away within 5s.
+    serveList([]);
+    await tickPoll();
+    expect(result.current.requests).toEqual([]);
+    expect(result.current.error).toBe(
+      "This request was already approved somewhere else, so the deny didn't take effect and the device is now paired.",
+    );
+
+    // A later request showing up and being acted on clears the stale notice.
+    serveList([pendingRequest({ requestId: "req-2" })]);
+    await tickPoll();
+    await act(async () => {
+      await result.current.approve("req-2");
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  test("a 409 on approve is not treated as handled elsewhere", async () => {
+    serveList([pendingRequest({ requestId: "req-1" })]);
+    installRoutedFetch({ [APPROVE_URL]: ALREADY_APPROVED_CONFLICT });
+
+    let result!: ReturnType<typeof renderPendingRequests>["result"];
+    await act(async () => {
+      ({ result } = renderPendingRequests());
+    });
+
+    await act(async () => {
+      await result.current.approve("req-1");
+    });
+
+    // The row stays with the server's message; the next poll reconciles it.
+    expect(result.current.requests.map((r) => r.requestId)).toEqual(["req-1"]);
+    expect(result.current.error).toBe(
+      "Request already approved on another surface.",
+    );
+  });
+
+  test("a deny rejected with a plain 409 (no code) keeps the row and shows the message", async () => {
+    serveList([pendingRequest({ requestId: "req-1" })]);
+    installRoutedFetch({
+      [DENY_URL]: () =>
+        jsonResponse({ error: { message: "Conflicting request." } }, 409),
+    });
+
+    let result!: ReturnType<typeof renderPendingRequests>["result"];
+    await act(async () => {
+      ({ result } = renderPendingRequests());
+    });
+
+    await act(async () => {
+      await result.current.deny("req-1");
+    });
+
+    expect(result.current.requests.map((r) => r.requestId)).toEqual(["req-1"]);
+    expect(result.current.error).toBe("Conflicting request.");
   });
 });

--- a/clients/web/src/domains/settings/pair-device/use-pending-pairing-requests.ts
+++ b/clients/web/src/domains/settings/pair-device/use-pending-pairing-requests.ts
@@ -1,15 +1,15 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import type { RemoteWebPairingRequestSummary } from "@vellumai/service-contracts/remote-web-pairing";
-
 import { t } from "@/i18n";
 import { captureError } from "@/lib/sentry/capture-error";
 
 import {
+  ALREADY_APPROVED_ERROR_CODE,
   approvePairingRequest,
   denyPairingRequest,
   listPendingPairingRequests,
   PairDeviceError,
+  type PendingPairingRequestSummary,
 } from "./pair-device-client";
 
 /** Matches the gateway store's recommended poll interval for pending requests. */
@@ -19,8 +19,8 @@ export type PendingPairingAction = "approve" | "deny";
 
 /** Summaries are immutable per id, so id-sequence equality means unchanged. */
 function sameRequestList(
-  prev: RemoteWebPairingRequestSummary[],
-  next: RemoteWebPairingRequestSummary[],
+  prev: PendingPairingRequestSummary[],
+  next: PendingPairingRequestSummary[],
 ): boolean {
   return (
     prev.length === next.length &&
@@ -30,7 +30,7 @@ function sameRequestList(
 
 export interface PendingPairingRequestsController {
   /** The pending pairing requests, as last fetched from the host gateway. */
-  requests: RemoteWebPairingRequestSummary[];
+  requests: PendingPairingRequestSummary[];
   /** The request an approve/deny is currently in flight for, or `null`. */
   actingOn: { requestId: string; action: PendingPairingAction } | null;
   /** Non-fatal error message the card may surface, or `null`. */
@@ -49,8 +49,11 @@ export interface PendingPairingRequestsController {
  * shouldn't flash the UI empty) and records a non-fatal error instead. A
  * 404/410 from approve/deny means the request expired or was handled elsewhere
  * (the CLI `--web-approve` path can race the UI), so the row is removed as if
- * the action succeeded. An action error is dropped once a successful poll no
- * longer lists its request; with the row gone there is nothing left to retry.
+ * the action succeeded. A deny rejected with 409 ALREADY_APPROVED also removes
+ * the row (it is no longer pending) but keeps a sticky notice up: the deny
+ * never took effect and the device is now paired. Other action errors are
+ * dropped once a successful poll no longer lists their request; with the row
+ * gone there is nothing left to retry.
  *
  * A `base` change drops the previous gateway's rows and errors and aborts its
  * in-flight action, so stale requests are never shown against the new base.
@@ -58,7 +61,7 @@ export interface PendingPairingRequestsController {
 export function usePendingPairingRequests(
   base: string | null,
 ): PendingPairingRequestsController {
-  const [requests, setRequests] = useState<RemoteWebPairingRequestSummary[]>(
+  const [requests, setRequests] = useState<PendingPairingRequestSummary[]>(
     [],
   );
   const [actingOn, setActingOn] = useState<{
@@ -70,6 +73,8 @@ export function usePendingPairingRequests(
   const [actionError, setActionError] = useState<{
     requestId: string;
     message: string;
+    /** Survives the row leaving the list (deny lost the race to an approve). */
+    sticky?: boolean;
   } | null>(null);
 
   const pollAbortRef = useRef<AbortController | null>(null);
@@ -115,9 +120,12 @@ export function usePendingPairingRequests(
         }
         setRequests((prev) => (sameRequestList(prev, next) ? prev : next));
         // An action error whose request left the list is unactionable; drop it
-        // so it can't pin an empty section open forever.
+        // so it can't pin an empty section open forever. Sticky notices stay:
+        // the user must still learn a deny never took effect.
         setActionError((prev) =>
-          prev && !next.some((r) => r.requestId === prev.requestId)
+          prev &&
+          !prev.sticky &&
+          !next.some((r) => r.requestId === prev.requestId)
             ? null
             : prev,
         );
@@ -175,7 +183,23 @@ export function usePendingPairingRequests(
           return;
         }
         if (err instanceof PairDeviceError) {
-          if (err.status === 404 || err.status === 410) {
+          if (
+            action === "deny" &&
+            err.status === 409 &&
+            err.code === ALREADY_APPROVED_ERROR_CODE
+          ) {
+            // The deny lost a race to an approve on another surface: the row
+            // is no longer pending, but the deny did NOT take effect, and the
+            // user must learn a device they tried to reject is now paired.
+            removeRequest();
+            setActionError({
+              requestId,
+              message: t(
+                "settings:usePendingPairingRequests.denyAlreadyApproved",
+              ),
+              sticky: true,
+            });
+          } else if (err.status === 404 || err.status === 410) {
             // Expired or already handled elsewhere; treat as removed.
             removeRequest();
           } else {

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -205,6 +205,7 @@
     "denyButton": "Deny",
     "instruction": "A device is asking to use this assistant. Approve a request only after confirming its code matches the one shown on the requesting device.",
     "requestedMeta": "Requested {when} from {ip}",
+    "requestedMetaHost": "Requested {when} from this computer",
     "title": "Pairing requests"
   },
   "profileAdvancedParams": {
@@ -426,6 +427,7 @@
   },
   "usePendingPairingRequests": {
     "actionErrorFallback": "Something went wrong. Try again.",
+    "denyAlreadyApproved": "This request was already approved somewhere else, so the deny didn't take effect and the device is now paired.",
     "pollErrorFallback": "Something went wrong while checking for pairing requests."
   },
   "useProfileSave": {

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -205,6 +205,7 @@
     "denyButton": "Denegar",
     "instruction": "Un dispositivo está pidiendo usar este asistente. Aprueba una solicitud solo después de confirmar que su código coincide con el que muestra el dispositivo solicitante.",
     "requestedMeta": "Solicitado {when} desde {ip}",
+    "requestedMetaHost": "Solicitado {when} desde este equipo",
     "title": "Solicitudes de vinculación"
   },
   "profileAdvancedParams": {
@@ -426,6 +427,7 @@
   },
   "usePendingPairingRequests": {
     "actionErrorFallback": "Algo salió mal. Inténtalo de nuevo.",
+    "denyAlreadyApproved": "Esta solicitud ya se había aprobado en otro lugar, así que la denegación no tuvo efecto y el dispositivo ya está vinculado.",
     "pollErrorFallback": "Algo salió mal al comprobar las solicitudes de vinculación."
   },
   "useProfileSave": {

--- a/clients/web/src/lib/relative-time.test.ts
+++ b/clients/web/src/lib/relative-time.test.ts
@@ -1,0 +1,47 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+
+import { formatRelativeTime } from "./relative-time";
+
+const realDateNow = Date.now;
+const NOW = new Date("2026-08-17T12:00:00.000Z").getTime();
+
+beforeEach(() => {
+  Date.now = () => NOW;
+});
+
+afterAll(() => {
+  Date.now = realDateNow;
+});
+
+describe("formatRelativeTime", () => {
+  test("picks the largest fitting unit, past and future", () => {
+    expect(formatRelativeTime(NOW - 2 * 60_000, { locale: "en" })).toBe("2 minutes ago");
+    expect(formatRelativeTime(NOW + 3 * 60 * 60_000, { locale: "en" })).toBe("in 3 hours");
+    // numeric: "auto" phrases single units idiomatically.
+    expect(
+      formatRelativeTime(NOW - 8 * 24 * 60 * 60_000, { locale: "en" }),
+    ).toBe("last week");
+  });
+
+  test("rounds within the chosen unit (Math.round semantics)", () => {
+    expect(formatRelativeTime(NOW - 90_000, { locale: "en" })).toBe(
+      "1 minute ago",
+    );
+    expect(formatRelativeTime(NOW - 91_000, { locale: "en" })).toBe(
+      "2 minutes ago",
+    );
+  });
+
+  test("phrases sub-minimum-unit differences as now", () => {
+    expect(formatRelativeTime(NOW - 45_000, { locale: "en", minimumUnit: "minute" })).toBe(
+      "now",
+    );
+    expect(formatRelativeTime(NOW - 45_000, { locale: "en" })).toBe("45 seconds ago");
+  });
+
+  test("formats in the requested locale", () => {
+    expect(formatRelativeTime(NOW - 2 * 60_000, { locale: "es" })).toBe(
+      "hace 2 minutos",
+    );
+  });
+});

--- a/clients/web/src/lib/relative-time.ts
+++ b/clients/web/src/lib/relative-time.ts
@@ -1,0 +1,75 @@
+/**
+ * Locale-aware relative-time formatting over a shared, per-locale-cached
+ * `Intl.RelativeTimeFormat` (construction is expensive; reuse is the
+ * documented pattern). Callers own any domain-specific phrasing around it,
+ * e.g. a "just now" cutoff.
+ *
+ * Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat
+ */
+
+const UNITS: Array<{ unit: Intl.RelativeTimeFormatUnit; ms: number }> = [
+  { unit: "year", ms: 365 * 24 * 60 * 60 * 1000 },
+  { unit: "month", ms: 30 * 24 * 60 * 60 * 1000 },
+  { unit: "week", ms: 7 * 24 * 60 * 60 * 1000 },
+  { unit: "day", ms: 24 * 60 * 60 * 1000 },
+  { unit: "hour", ms: 60 * 60 * 1000 },
+  { unit: "minute", ms: 60 * 1000 },
+  { unit: "second", ms: 1000 },
+];
+
+/** Units a caller may clamp the phrasing at (largest-to-smallest granularity). */
+export type RelativeTimeMinimumUnit = (typeof UNITS)[number]["unit"];
+
+const formatters = new Map<string, Intl.RelativeTimeFormat | null>();
+
+function getFormatter(locale: string | undefined): Intl.RelativeTimeFormat | null {
+  const key = locale ?? "";
+  let formatter = formatters.get(key);
+  if (formatter === undefined) {
+    formatter =
+      typeof Intl !== "undefined" && "RelativeTimeFormat" in Intl
+        ? new Intl.RelativeTimeFormat(locale, {
+            style: "long",
+            numeric: "auto",
+          })
+        : null;
+    formatters.set(key, formatter);
+  }
+  return formatter;
+}
+
+export interface FormatRelativeTimeOptions {
+  /** BCP 47 locale tag; defaults to the host environment's locale. */
+  locale?: string;
+  /**
+   * Smallest unit to phrase in; a difference below it reads as "now"
+   * (`format(0, "second")` under `numeric: "auto"`). Defaults to `"second"`.
+   */
+  minimumUnit?: RelativeTimeMinimumUnit;
+}
+
+/**
+ * Relative label for an instant against the current time, e.g. "2 minutes
+ * ago" / "in 3 days". Falls back to an absolute `toLocaleString()` where
+ * `Intl.RelativeTimeFormat` is unavailable.
+ */
+export function formatRelativeTime(
+  epochMs: number,
+  options: FormatRelativeTimeOptions = {},
+): string {
+  const formatter = getFormatter(options.locale);
+  if (!formatter) {
+    return new Date(epochMs).toLocaleString();
+  }
+  const diff = epochMs - Date.now();
+  const absDiff = Math.abs(diff);
+  const minIndex = UNITS.findIndex(
+    ({ unit }) => unit === (options.minimumUnit ?? "second"),
+  );
+  for (const { unit, ms } of UNITS.slice(0, minIndex + 1)) {
+    if (absDiff >= ms) {
+      return formatter.format(Math.round(diff / ms), unit);
+    }
+  }
+  return formatter.format(0, "second");
+}


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for web-pair-approve.md.

- Deny that races an approve now surfaces an already-approved notice (409 ALREADY_APPROVED) instead of silently looking successful
- Failed QR mints best-effort deny their orphaned challenge so the card's own mint never appears as a foreign request
- Acted row shows a busy state via actingOn; host-originated rows say 'from this computer' instead of a loopback IP
- Shared cached relative-time helper replaces duplicated formatter; pair-device test scaffolding deduped