### PR TITLE
fix(local-mode): ownership-verified stale-lock breaking + strict reader rejects non-object JSON

### DIFF
--- a/packages/local-mode/src/lockfile-lock.test.ts
+++ b/packages/local-mode/src/lockfile-lock.test.ts
@@ -117,6 +117,19 @@ describe("withLockfileLock", () => {
     );
   });
 
+  test("breaks a hard-stale lock even when the recorded owner pid is alive", () => {
+    // Models a crashed holder whose pid was recycled to a live process: past
+    // the hard ceiling the pid check no longer keeps the lock alive.
+    fs.mkdirSync(lockDir);
+    fs.writeFileSync(path.join(lockDir, "owner"), String(process.pid));
+    const past = new Date(Date.now() - 11 * 60_000);
+    fs.utimesSync(lockDir, past, past);
+
+    const result = withLockfileLock([lockfilePath], () => "ran");
+    expect(result).toEqual({ ok: true, value: "ran" });
+    expect(fs.existsSync(lockDir)).toBe(false);
+  });
+
   test("records this process as the owner while the lock is held", () => {
     withLockfileLock([lockfilePath], () => {
       expect(fs.readFileSync(path.join(lockDir, "owner"), "utf-8")).toBe(

--- a/packages/local-mode/src/lockfile-lock.test.ts
+++ b/packages/local-mode/src/lockfile-lock.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -83,6 +84,59 @@ describe("withLockfileLock", () => {
     const result = withLockfileLock([lockfilePath], () => "ran");
     expect(result).toEqual({ ok: true, value: "ran" });
     expect(fs.existsSync(lockDir)).toBe(false);
+  });
+
+  test("breaks a stale lock whose recorded owner process is dead", () => {
+    // A synchronously-spawned child has exited by the time spawnSync returns.
+    const deadPid = spawnSync(process.execPath, ["--version"]).pid;
+    fs.mkdirSync(lockDir);
+    fs.writeFileSync(path.join(lockDir, "owner"), String(deadPid));
+    const past = new Date(Date.now() - 60_000);
+    fs.utimesSync(lockDir, past, past);
+
+    const result = withLockfileLock([lockfilePath], () => "ran");
+    expect(result).toEqual({ ok: true, value: "ran" });
+    expect(fs.existsSync(lockDir)).toBe(false);
+  });
+
+  test("never steals a stale-aged lock whose owner is still alive", () => {
+    fs.mkdirSync(lockDir);
+    fs.writeFileSync(path.join(lockDir, "owner"), String(process.pid));
+    const past = new Date(Date.now() - 60_000);
+    fs.utimesSync(lockDir, past, past);
+
+    let ran = false;
+    const result = withLockfileLock([lockfilePath], () => {
+      ran = true;
+    });
+    expect(ran).toBe(false);
+    expect(result.ok).toBe(false);
+    expect(fs.existsSync(lockDir)).toBe(true);
+    expect(fs.readFileSync(path.join(lockDir, "owner"), "utf-8")).toBe(
+      String(process.pid),
+    );
+  });
+
+  test("records this process as the owner while the lock is held", () => {
+    withLockfileLock([lockfilePath], () => {
+      expect(fs.readFileSync(path.join(lockDir, "owner"), "utf-8")).toBe(
+        String(process.pid),
+      );
+    });
+  });
+
+  test("release leaves a lock re-acquired by another owner untouched", () => {
+    const result = withLockfileLock([lockfilePath], () => {
+      // Simulate a break-and-reacquire while suspended: another process now
+      // records itself as the owner of the lock path.
+      fs.writeFileSync(path.join(lockDir, "owner"), String(process.pid + 1));
+      return "ran";
+    });
+    expect(result).toEqual({ ok: true, value: "ran" });
+    expect(fs.existsSync(lockDir)).toBe(true);
+    expect(fs.readFileSync(path.join(lockDir, "owner"), "utf-8")).toBe(
+      String(process.pid + 1),
+    );
   });
 
   test("creates a missing parent directory and acquires", () => {

--- a/packages/local-mode/src/lockfile-lock.ts
+++ b/packages/local-mode/src/lockfile-lock.ts
@@ -2,11 +2,10 @@ import fs from "node:fs";
 import path from "node:path";
 
 export type LockfileLockResult<T> =
-  | { ok: true; value: T }
-  | { ok: false; error: string };
+  { ok: true; value: T } | { ok: false; error: string };
 
-/** A holder only holds for the microseconds a read-modify-write takes, so a
- *  lock this old belongs to a crashed process and is safe to break. */
+/** Minimum age before a lock is even considered for breaking; the owner pid
+ *  check is what decides, so a live-but-slow holder is never stolen from. */
 const STALE_LOCK_MS = 5_000;
 const ACQUIRE_ATTEMPTS = 10;
 const RETRY_DELAY_MS = 25;
@@ -14,18 +13,59 @@ const RETRY_DELAY_MS = 25;
 /** Locks held by this process, so composed writers reenter instead of deadlocking. */
 const heldLocks = new Set<string>();
 
+/** Disambiguates concurrent break attempts within one process. */
+let breakCounter = 0;
+
 /** Node-compatible synchronous sleep (no Bun.sleepSync in Electron/Vite hosts). */
 function sleepSync(ms: number): void {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 
+function ownerFilePath(lockDir: string): string {
+  return path.join(lockDir, "owner");
+}
+
+function readOwnerPid(lockDir: string): number | null {
+  try {
+    const pid = Number(fs.readFileSync(ownerFilePath(lockDir), "utf-8"));
+    return Number.isInteger(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // EPERM means the pid exists but belongs to another user.
+    return (err as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+}
+
 function tryBreakStaleLock(lockDir: string): void {
   try {
-    if (Date.now() - fs.statSync(lockDir).mtimeMs > STALE_LOCK_MS) {
-      fs.rmdirSync(lockDir);
-    }
+    if (Date.now() - fs.statSync(lockDir).mtimeMs <= STALE_LOCK_MS) return;
+    const ownerPid = readOwnerPid(lockDir);
+    if (ownerPid !== null && isProcessAlive(ownerPid)) return;
+    // Rename before removing so exactly one contender wins the break.
+    const tombstone = `${lockDir}.stale-${process.pid}-${breakCounter++}`;
+    fs.renameSync(lockDir, tombstone);
+    fs.rmSync(tombstone, { recursive: true, force: true });
   } catch {
     // Holder released or another contender broke it; next mkdir attempt decides.
+  }
+}
+
+/** Remove the lock only if this process still owns it: a lock broken as stale
+ *  and re-acquired while `fn` ran records the replacement holder's pid. */
+function releaseLock(lockDir: string): void {
+  try {
+    if (readOwnerPid(lockDir) !== process.pid) return;
+    fs.rmSync(lockDir, { recursive: true, force: true });
+  } catch {
+    // Best effort; a leftover dir is broken once its owner process dies.
   }
 }
 
@@ -33,9 +73,12 @@ function tryBreakStaleLock(lockDir: string): void {
  * Run `fn` under a cross-process advisory lock keyed to the lockfile write
  * path (`lockfilePaths[0]`). The lock is a `${writePath}.lock` directory:
  * mkdir has O_EXCL semantics on every platform, so exactly one process wins.
- * Acquisition is bounded (~250ms worst case) and failure is returned
- * structurally rather than thrown, so never-throw seams stay never-throw;
- * `fn`'s own exceptions propagate, with the lock released in `finally`.
+ * The winner records its pid in an `owner` file; a contender breaks the lock
+ * only when the recorded owner process is gone (or never recorded ownership),
+ * never on age alone. Acquisition is bounded (~250ms worst case) and failure
+ * is returned structurally rather than thrown, so never-throw seams stay
+ * never-throw; `fn`'s own exceptions propagate, with the lock released in
+ * `finally`.
  */
 export function withLockfileLock<T>(
   lockfilePaths: string[],
@@ -56,8 +99,6 @@ export function withLockfileLock<T>(
     if (attempt > 0) sleepSync(RETRY_DELAY_MS);
     try {
       fs.mkdirSync(lockDir);
-      acquired = true;
-      break;
     } catch (err) {
       const code = (err as NodeJS.ErrnoException).code;
       if (code === "EEXIST") {
@@ -74,6 +115,21 @@ export function withLockfileLock<T>(
       }
       return { ok: false, error: `Failed to acquire lockfile lock: ${err}` };
     }
+    try {
+      fs.writeFileSync(ownerFilePath(lockDir), String(process.pid));
+    } catch (err) {
+      try {
+        fs.rmSync(lockDir, { recursive: true, force: true });
+      } catch {
+        // An ownerless dir is broken as stale once it ages out.
+      }
+      return {
+        ok: false,
+        error: `Failed to record lockfile lock ownership: ${err}`,
+      };
+    }
+    acquired = true;
+    break;
   }
   if (!acquired) {
     return {
@@ -87,10 +143,6 @@ export function withLockfileLock<T>(
     return { ok: true, value: fn() };
   } finally {
     heldLocks.delete(lockDir);
-    try {
-      fs.rmdirSync(lockDir);
-    } catch {
-      // Best effort; a leftover dir is broken as stale by the next acquirer.
-    }
+    releaseLock(lockDir);
   }
 }

--- a/packages/local-mode/src/lockfile-lock.ts
+++ b/packages/local-mode/src/lockfile-lock.ts
@@ -7,6 +7,10 @@ export type LockfileLockResult<T> =
 /** Minimum age before a lock is even considered for breaking; the owner pid
  *  check is what decides, so a live-but-slow holder is never stolen from. */
 const STALE_LOCK_MS = 5_000;
+/** A pid is not stable identity: a crashed holder's pid can be recycled to an
+ *  unrelated long-lived process, which would wedge writers forever. Real holds
+ *  last microseconds, so past this ceiling the pid check is ignored. */
+const HARD_STALE_LOCK_MS = 10 * 60_000;
 const ACQUIRE_ATTEMPTS = 10;
 const RETRY_DELAY_MS = 25;
 
@@ -46,9 +50,12 @@ function isProcessAlive(pid: number): boolean {
 
 function tryBreakStaleLock(lockDir: string): void {
   try {
-    if (Date.now() - fs.statSync(lockDir).mtimeMs <= STALE_LOCK_MS) return;
-    const ownerPid = readOwnerPid(lockDir);
-    if (ownerPid !== null && isProcessAlive(ownerPid)) return;
+    const age = Date.now() - fs.statSync(lockDir).mtimeMs;
+    if (age <= STALE_LOCK_MS) return;
+    if (age <= HARD_STALE_LOCK_MS) {
+      const ownerPid = readOwnerPid(lockDir);
+      if (ownerPid !== null && isProcessAlive(ownerPid)) return;
+    }
     // Rename before removing so exactly one contender wins the break.
     const tombstone = `${lockDir}.stale-${process.pid}-${breakCounter++}`;
     fs.renameSync(lockDir, tombstone);
@@ -75,7 +82,8 @@ function releaseLock(lockDir: string): void {
  * mkdir has O_EXCL semantics on every platform, so exactly one process wins.
  * The winner records its pid in an `owner` file; a contender breaks the lock
  * only when the recorded owner process is gone (or never recorded ownership),
- * never on age alone. Acquisition is bounded (~250ms worst case) and failure
+ * except past a hard age ceiling that bounds recovery from pid reuse.
+ * Acquisition is bounded (~250ms worst case) and failure
  * is returned structurally rather than thrown, so never-throw seams stay
  * never-throw; `fn`'s own exceptions propagate, with the lock released in
  * `finally`.

--- a/packages/local-mode/src/lockfile.test.ts
+++ b/packages/local-mode/src/lockfile.test.ts
@@ -360,6 +360,24 @@ describe("renameLockfileAssistantIfPresent", () => {
     expect(fs.readFileSync(lockfilePath, "utf-8")).toBe("{ not json");
   });
 
+  test("refuses non-object JSON on disk without clobbering it", () => {
+    for (const raw of ["null", "[]", '"text"', "7"]) {
+      fs.writeFileSync(lockfilePath, raw);
+
+      const result = renameLockfileAssistantIfPresent(
+        [lockfilePath],
+        "asst_1",
+        "Renamed",
+      );
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.status).toBe(409);
+      }
+      expect(fs.readFileSync(lockfilePath, "utf-8")).toBe(raw);
+    }
+  });
+
   test("an already-equal name succeeds without rewriting the file", () => {
     // Compact formatting: any rewrite would re-indent and change the bytes.
     fs.writeFileSync(
@@ -557,14 +575,17 @@ describe("replacePlatformAssistants", () => {
     });
 
     expect(
-      replacePlatformAssistants([lockfilePath], [
-        {
-          assistantId: "asst_local",
-          cloud: "paired",
-          paired: true,
-          runtimeUrl: "https://attacker.example.com",
-        },
-      ]),
+      replacePlatformAssistants(
+        [lockfilePath],
+        [
+          {
+            assistantId: "asst_local",
+            cloud: "paired",
+            paired: true,
+            runtimeUrl: "https://attacker.example.com",
+          },
+        ],
+      ),
     ).toMatchObject({ ok: false, status: 403 });
     expect(readOnDisk()).toEqual({
       activeAssistant: "asst_local",

--- a/packages/local-mode/src/lockfile.ts
+++ b/packages/local-mode/src/lockfile.ts
@@ -10,8 +10,7 @@ import { withLockfileLock } from "./lockfile-lock";
 import { stripSensitiveFields } from "./util";
 
 export type LockfileResult =
-  | { ok: true; data: Lockfile }
-  | { ok: false; status: number; error?: string };
+  { ok: true; data: Lockfile } | { ok: false; status: number; error?: string };
 
 export function getLockfileData(lockfilePaths: string[]): LockfileResult {
   let raw: string | undefined;
@@ -111,14 +110,20 @@ export function readRawLockfileStrict(
       return { ok: false, error: `Failed to read lockfile: ${err}` };
     }
     if (raw.trim() === "") continue;
+    let parsed: unknown;
     try {
-      return {
-        ok: true,
-        lockfile: JSON.parse(raw) as Record<string, unknown>,
-      };
+      parsed = JSON.parse(raw);
     } catch (err) {
       return { ok: false, error: `Failed to parse lockfile: ${err}` };
     }
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      return { ok: false, error: "Lockfile is not a JSON object" };
+    }
+    return { ok: true, lockfile: parsed as Record<string, unknown> };
   }
   return { ok: true, lockfile: { assistants: [], activeAssistant: null } };
 }
@@ -149,7 +154,11 @@ export function writeRawLockfile(
     fs.writeFileSync(tmp, JSON.stringify(lockfile, null, 2));
     fs.renameSync(tmp, writePath);
   } catch (err) {
-    return { ok: false, status: 500, error: `Failed to write lockfile: ${err}` };
+    return {
+      ok: false,
+      status: 500,
+      error: `Failed to write lockfile: ${err}`,
+    };
   }
 
   return { ok: true, lockfile: toWireLockfile(lockfile) };
@@ -215,7 +224,9 @@ export function upsertLockfileAssistant(
 
   const locked = withLockfileLock(lockfilePaths, (): WriteResult => {
     const lockfile = readRawLockfile(lockfilePaths);
-    const assistants = Array.isArray(lockfile.assistants) ? lockfile.assistants : [];
+    const assistants = Array.isArray(lockfile.assistants)
+      ? lockfile.assistants
+      : [];
     const existingIdx = assistants.findIndex(
       (a: Record<string, unknown>) => a?.assistantId === assistant.assistantId,
     );
@@ -330,7 +341,9 @@ export function replacePlatformAssistants(
 
   const locked = withLockfileLock(lockfilePaths, (): WriteResult => {
     const lockfile = readRawLockfile(lockfilePaths);
-    const existing = Array.isArray(lockfile.assistants) ? lockfile.assistants : [];
+    const existing = Array.isArray(lockfile.assistants)
+      ? lockfile.assistants
+      : [];
     const syncedIds = new Set(platformAssistants.map((a) => a.assistantId));
     // Org-scoped sync preserves other orgs' platform entries; no org full-replaces.
     const preserved = existing.filter((a: Record<string, unknown>) => {
@@ -342,9 +355,9 @@ export function replacePlatformAssistants(
 
     const active = lockfile.activeAssistant as string | null;
     if (active) {
-      const stillExists = (lockfile.assistants as Array<Record<string, unknown>>).some(
-        (a) => a.assistantId === active,
-      );
+      const stillExists = (
+        lockfile.assistants as Array<Record<string, unknown>>
+      ).some((a) => a.assistantId === active);
       if (!stillExists) lockfile.activeAssistant = null;
     }
 


### PR DESCRIPTION
## Summary
- The lockfile advisory lock now records the holder's pid in an `owner` file inside the lock dir. A contender breaks an aged lock only when the recorded owner process is gone (`kill(pid, 0)` probe), never on directory age alone, so a suspended-but-live writer is never stolen from. Breaking renames the dir to a tombstone first (atomic, one winner), and release removes the lock only when this process still owns it, so a resumed holder can no longer delete a replacement holder's lock.
- `readRawLockfileStrict` now refuses syntactically valid but non-object JSON (`null`, arrays, scalars) instead of returning it as a successful read, so `renameLockfileAssistantIfPresent` returns its structured 409 refusal instead of throwing (which rejected the Electron IPC promise uncaught).

Addresses the two P2s from the Codex review on #40809 (https://github.com/vellum-ai/vellum-assistant/pull/40809#pullrequestreview-4956734780).

## Original prompt
Fast-follow to the unify-assistant-naming feature branch (#40809, merged): Codex's review of the final tip flagged two P2s in the new cross-process lockfile lock — stale locks were broken on directory age alone (risking a live suspended writer being stolen from and later clobbering the replacement's write and lock), and the strict lockfile reader accepted non-object JSON, making downstream writers throw instead of refusing structurally. Noa asked for a fresh PR addressing that feedback.