### PR TITLE
fix(web): pairing card round-2 review gaps

### DIFF
--- a/clients/web/src/domains/settings/pair-device/pair-device-card.test.tsx
+++ b/clients/web/src/domains/settings/pair-device/pair-device-card.test.tsx
@@ -79,6 +79,8 @@ function pendingRequestBody(
     requestedAt: new Date(Date.now() - 2 * 60_000).toISOString(),
     expiresAt: futureIso(),
     requesterUserAgent: "Mozilla/5.0 (iPhone; like Mac OS X)",
+    // Default rows carry a public requester IP, so they read as edge mints.
+    viaEdgeProxy: true,
     ...overrides,
   });
 }

--- a/clients/web/src/domains/settings/pair-device/pair-device-client.test.ts
+++ b/clients/web/src/domains/settings/pair-device/pair-device-client.test.ts
@@ -397,15 +397,27 @@ describe("mintDevicePairing", () => {
     ]);
   });
 
-  test("skips cleanup when the caller aborts during verification", async () => {
+  test("fires cleanup without awaiting it when the caller aborts during verification", async () => {
+    let resolveList!: (response: Response) => void;
     installFetch((url) => {
-      if (url === CHALLENGE_URL) {
-        return challengeResponse();
+      switch (url) {
+        case CHALLENGE_URL:
+          return challengeResponse();
+        case VERIFICATION_URL:
+          throw new DOMException("Aborted", "AbortError");
+        case LIST_URL:
+          return new Promise<Response>((resolve) => {
+            resolveList = resolve;
+          });
+        case DENY_URL:
+          return jsonResponse({ status: "denied" });
+        default:
+          throw new Error(`unexpected fetch: ${url}`);
       }
-      throw new DOMException("Aborted", "AbortError");
     });
     const controller = new AbortController();
 
+    // The AbortError rethrows while the cleanup list is still in flight.
     await expect(
       mintDevicePairing({ ...MINT_ARGS, signal: controller.signal }),
     ).rejects.toMatchObject({ name: "AbortError" });
@@ -413,6 +425,28 @@ describe("mintDevicePairing", () => {
     expect(fetchLog.map((r) => r.url)).toEqual([
       CHALLENGE_URL,
       VERIFICATION_URL,
+      LIST_URL,
     ]);
+    // Cleanup runs on its own timeout signal, never the caller's.
+    const listSignal = fetchLog[2]?.init?.signal;
+    expect(listSignal).not.toBe(controller.signal);
+    expect(listSignal?.aborted).toBe(false);
+
+    resolveList(
+      jsonResponse({
+        requests: [
+          pendingRequest({ requestId: "req-orphan", userCode: "WXYZ-1234" }),
+        ],
+      }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(fetchLog.map((r) => r.url)).toEqual([
+      CHALLENGE_URL,
+      VERIFICATION_URL,
+      LIST_URL,
+      DENY_URL,
+    ]);
+    expect(requestBody(fetchLog[3])).toEqual({ requestId: "req-orphan" });
   });
 });

--- a/clients/web/src/domains/settings/pair-device/pair-device-client.ts
+++ b/clients/web/src/domains/settings/pair-device/pair-device-client.ts
@@ -73,15 +73,8 @@ export class PairDeviceError extends Error {
 /** Error code the deny route returns when the request was approved first. */
 export const ALREADY_APPROVED_ERROR_CODE = "ALREADY_APPROVED";
 
-/**
- * A pending request row as this branch reads it. `viaEdgeProxy` (`true` when
- * the challenge was minted through the public tunnel edge, `false` when it was
- * minted from the host itself) lands with the gateway contracts change;
- * optional here so older gateways that omit it stay compatible.
- */
-export type PendingPairingRequestSummary = RemoteWebPairingRequestSummary & {
-  viaEdgeProxy?: boolean;
-};
+/** Bounds the best-effort orphan cleanup so it can't wedge a failed mint. */
+const ORPHAN_CLEANUP_TIMEOUT_MS = 5000;
 
 export interface DevicePairing {
   /** The scannable https pair URL (verification URI + `#device_code=…`). */
@@ -228,8 +221,17 @@ export async function mintDevicePairing(args: {
   } catch (err) {
     // The minted challenge would otherwise stay pending for its TTL and show
     // up in the sibling approval list as a foreign request.
-    if (!(err instanceof DOMException && err.name === "AbortError")) {
-      await denyOrphanedChallenge(base, challenge.userCode, signal);
+    const cleanupTimeout = AbortSignal.timeout(ORPHAN_CLEANUP_TIMEOUT_MS);
+    if (err instanceof DOMException && err.name === "AbortError") {
+      // The caller's signal is dead; run cleanup fire-and-forget on its own
+      // timeout so the orphan still gets denied.
+      void denyOrphanedChallenge(base, challenge.userCode, cleanupTimeout);
+    } else {
+      await denyOrphanedChallenge(
+        base,
+        challenge.userCode,
+        signal ? AbortSignal.any([signal, cleanupTimeout]) : cleanupTimeout,
+      );
     }
     throw err;
   }
@@ -248,7 +250,7 @@ export async function mintDevicePairing(args: {
 async function denyOrphanedChallenge(
   base: string,
   userCode: string,
-  signal: AbortSignal | undefined,
+  signal: AbortSignal,
 ): Promise<void> {
   try {
     const pending = await listPendingPairingRequests({ base, signal });
@@ -275,7 +277,7 @@ async function denyOrphanedChallenge(
 export async function listPendingPairingRequests(args: {
   base: string;
   signal?: AbortSignal;
-}): Promise<PendingPairingRequestSummary[]> {
+}): Promise<RemoteWebPairingRequestSummary[]> {
   const payload =
     await pairingRouteRequest<RemoteWebPairingRequestListResponse>(
       `${args.base}${PAIRING_REQUESTS_PATH}`,

--- a/clients/web/src/domains/settings/pair-device/pair-device-test-helpers.ts
+++ b/clients/web/src/domains/settings/pair-device/pair-device-test-helpers.ts
@@ -7,7 +7,7 @@
 
 import { mock } from "bun:test";
 
-import type { PendingPairingRequestSummary } from "./pair-device-client";
+import type { RemoteWebPairingRequestSummary } from "@vellumai/service-contracts/remote-web-pairing";
 
 /** Local-gateway base URL used across the pair-device tests. */
 export const TEST_GATEWAY_BASE =
@@ -21,8 +21,8 @@ export function jsonResponse(body: unknown, status = 200): Response {
 }
 
 export function pendingRequest(
-  overrides: Partial<PendingPairingRequestSummary> = {},
-): PendingPairingRequestSummary {
+  overrides: Partial<RemoteWebPairingRequestSummary> = {},
+): RemoteWebPairingRequestSummary {
   return {
     requestId: "req-1",
     userCode: "WXYZ-1234",
@@ -31,6 +31,7 @@ export function pendingRequest(
     expiresAt: "2026-08-17T10:10:00.000Z",
     requesterIp: "203.0.113.7",
     requesterUserAgent: "Mozilla/5.0",
+    viaEdgeProxy: false,
     ...overrides,
   };
 }

--- a/clients/web/src/domains/settings/pair-device/use-pending-pairing-requests.test.ts
+++ b/clients/web/src/domains/settings/pair-device/use-pending-pairing-requests.test.ts
@@ -13,7 +13,8 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { act, cleanup, renderHook } from "@testing-library/react";
 
-import type { PendingPairingRequestSummary } from "./pair-device-client";
+import type { RemoteWebPairingRequestSummary } from "@vellumai/service-contracts/remote-web-pairing";
+
 import {
   createTimerHarness,
   fetchLog,
@@ -50,7 +51,7 @@ function listCalls() {
 /** Serve the list route with `summaries`; reassignable between polls. */
 let listResponder: () => Response | Promise<Response>;
 
-function serveList(summaries: PendingPairingRequestSummary[]) {
+function serveList(summaries: RemoteWebPairingRequestSummary[]) {
   listResponder = () => jsonResponse({ requests: summaries });
 }
 
@@ -85,14 +86,14 @@ async function tickPoll() {
   });
 }
 
-function renderPendingRequests(base: string | null = BASE) {
+function renderPendingRequests(base: string = BASE) {
   return renderHook(
-    (props: { base: string | null }) => usePendingPairingRequests(props.base),
+    (props: { base: string }) => usePendingPairingRequests(props.base),
     { initialProps: { base } },
   );
 }
 
-async function renderWithList(summaries: PendingPairingRequestSummary[]) {
+async function renderWithList(summaries: RemoteWebPairingRequestSummary[]) {
   serveList(summaries);
   installRoutedFetch();
   let rendered!: ReturnType<typeof renderPendingRequests>;
@@ -146,20 +147,6 @@ describe("usePendingPairingRequests: polling", () => {
 
     expect(listCalls()).toHaveLength(2);
     expect(result.current.requests).toBe(initial);
-  });
-
-  test("does nothing when base is null", async () => {
-    installRoutedFetch();
-
-    let result!: ReturnType<typeof renderPendingRequests>["result"];
-    await act(async () => {
-      ({ result } = renderPendingRequests(null));
-    });
-
-    expect(fetchLog).toHaveLength(0);
-    expect(pollTimers()).toHaveLength(0);
-    expect(result.current.requests).toEqual([]);
-    expect(result.current.error).toBeNull();
   });
 
   test("unmount clears the interval and aborts the in-flight poll", async () => {
@@ -416,21 +403,6 @@ describe("usePendingPairingRequests: approve/deny", () => {
     expect(result.current.error).toBeNull();
   });
 
-  test("actions are ignored while base is null", async () => {
-    installRoutedFetch();
-
-    let result!: ReturnType<typeof renderPendingRequests>["result"];
-    await act(async () => {
-      ({ result } = renderPendingRequests(null));
-    });
-
-    await act(async () => {
-      await result.current.approve("req-1");
-    });
-
-    expect(fetchLog).toHaveLength(0);
-    expect(result.current.actingOn).toBeNull();
-  });
 });
 
 describe("usePendingPairingRequests: deny racing an approve", () => {

--- a/clients/web/src/domains/settings/pair-device/use-pending-pairing-requests.ts
+++ b/clients/web/src/domains/settings/pair-device/use-pending-pairing-requests.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import type { RemoteWebPairingRequestSummary } from "@vellumai/service-contracts/remote-web-pairing";
+
 import { t } from "@/i18n";
 import { captureError } from "@/lib/sentry/capture-error";
 
@@ -9,7 +11,6 @@ import {
   denyPairingRequest,
   listPendingPairingRequests,
   PairDeviceError,
-  type PendingPairingRequestSummary,
 } from "./pair-device-client";
 
 /** Matches the gateway store's recommended poll interval for pending requests. */
@@ -19,8 +20,8 @@ export type PendingPairingAction = "approve" | "deny";
 
 /** Summaries are immutable per id, so id-sequence equality means unchanged. */
 function sameRequestList(
-  prev: PendingPairingRequestSummary[],
-  next: PendingPairingRequestSummary[],
+  prev: RemoteWebPairingRequestSummary[],
+  next: RemoteWebPairingRequestSummary[],
 ): boolean {
   return (
     prev.length === next.length &&
@@ -30,7 +31,7 @@ function sameRequestList(
 
 export interface PendingPairingRequestsController {
   /** The pending pairing requests, as last fetched from the host gateway. */
-  requests: PendingPairingRequestSummary[];
+  requests: RemoteWebPairingRequestSummary[];
   /** The request an approve/deny is currently in flight for, or `null`. */
   actingOn: { requestId: string; action: PendingPairingAction } | null;
   /** Non-fatal error message the card may surface, or `null`. */
@@ -42,8 +43,7 @@ export interface PendingPairingRequestsController {
 /**
  * Polls the host gateway's loopback-only pending pairing-request list while
  * mounted and exposes approve/deny actions on the rows. `base` is the resolved
- * local-gateway base URL, or `null` when request approval isn't available from
- * here (outside desktop/local mode); the hook is then inert.
+ * local-gateway base URL; the caller gates mounting on its availability.
  *
  * A failed poll keeps the previous list (a transient loopback-proxy hiccup
  * shouldn't flash the UI empty) and records a non-fatal error instead. A
@@ -59,9 +59,9 @@ export interface PendingPairingRequestsController {
  * in-flight action, so stale requests are never shown against the new base.
  */
 export function usePendingPairingRequests(
-  base: string | null,
+  base: string,
 ): PendingPairingRequestsController {
-  const [requests, setRequests] = useState<PendingPairingRequestSummary[]>(
+  const [requests, setRequests] = useState<RemoteWebPairingRequestSummary[]>(
     [],
   );
   const [actingOn, setActingOn] = useState<{
@@ -102,10 +102,6 @@ export function usePendingPairingRequests(
   }, [base]);
 
   useEffect(() => {
-    if (!base) {
-      return;
-    }
-
     const poll = async () => {
       pollAbortRef.current?.abort();
       const controller = new AbortController();
@@ -153,7 +149,7 @@ export function usePendingPairingRequests(
 
   const runAction = useCallback(
     async (requestId: string, action: PendingPairingAction) => {
-      if (!base || actionAbortRef.current) {
+      if (actionAbortRef.current) {
         return;
       }
       const controller = new AbortController();


### PR DESCRIPTION
## Summary
Fixes round-2 self-review gaps for web-pair-approve.md.

- Adds viaEdgeProxy to the shared fixture and drops the no-op intersection type (repairs the cross-PR typecheck break)
- Orphan-mint cleanup is timeout-bounded and now also runs fire-and-forget when the mint is aborted
- usePendingPairingRequests narrowed to a required base (dead null-mode removed)