### PR TITLE
fix(gateway): round-2 review cleanups

### DIFF
--- a/gateway/src/__tests__/helpers/remote-web-pairing-fixtures.ts
+++ b/gateway/src/__tests__/helpers/remote-web-pairing-fixtures.ts
@@ -4,6 +4,13 @@ export const LOOPBACK_IP = "127.0.0.1";
 export const REMOTE_IP = "203.0.113.10";
 export const PUBLIC_BASE_URL = "https://paired.example.com";
 
+/** Requester metadata for challenges minted directly against the store. */
+export const TEST_REQUESTER = {
+  ip: REMOTE_IP,
+  userAgent: "PairBrowser/1.0",
+  viaEdgeProxy: true,
+};
+
 /** A request as sent by a local loopback client (host machine). */
 export function makeLocalRequest(
   path: string,
@@ -51,8 +58,12 @@ export function makePairingChallengeRequest(
   } = {},
 ): Request {
   const headers: Record<string, string> = {};
-  if (overrides.host) headers.host = overrides.host;
-  if (overrides.edgeForwarded) headers["x-vellum-edge-forwarded"] = "1";
+  if (overrides.host) {
+    headers.host = overrides.host;
+  }
+  if (overrides.edgeForwarded) {
+    headers["x-vellum-edge-forwarded"] = "1";
+  }
   if (overrides.edgeClientIp) {
     headers["x-vellum-client-ip"] = overrides.edgeClientIp;
   }

--- a/gateway/src/__tests__/remote-web-pairing-challenge.test.ts
+++ b/gateway/src/__tests__/remote-web-pairing-challenge.test.ts
@@ -21,6 +21,7 @@ import {
   makePairingChallengeRequest as makeRequest,
   PUBLIC_BASE_URL,
   REMOTE_IP,
+  TEST_REQUESTER,
 } from "./helpers/remote-web-pairing-fixtures.js";
 
 beforeEach(() => {
@@ -309,17 +310,14 @@ describe("remote web pairing challenge", () => {
 });
 
 describe("remote web pairing request list/approve/deny", () => {
-  const REQUESTER = {
-    ip: REMOTE_IP,
-    userAgent: "PairBrowser/1.0",
-    viaEdgeProxy: true,
-  };
-
   test("lists only pending, non-expired challenges newest first with requester metadata", () => {
     let now = 1_000;
     setRemoteWebPairingChallengeNowForTests(() => now);
 
-    const first = createRemoteWebPairingChallenge(PUBLIC_BASE_URL, REQUESTER);
+    const first = createRemoteWebPairingChallenge(
+      PUBLIC_BASE_URL,
+      TEST_REQUESTER,
+    );
     now = 2_000;
     const second = createRemoteWebPairingChallenge(PUBLIC_BASE_URL, {
       ip: "198.51.100.7",
@@ -329,7 +327,7 @@ describe("remote web pairing request list/approve/deny", () => {
     now = 3_000;
     const approved = createRemoteWebPairingChallenge(
       PUBLIC_BASE_URL,
-      REQUESTER,
+      TEST_REQUESTER,
     );
     const approvedRecord = getRemoteWebPairingChallengeForTests(
       approved.userCode,
@@ -368,7 +366,7 @@ describe("remote web pairing request list/approve/deny", () => {
     setRemoteWebPairingChallengeNowForTests(() => 1_000);
     const challenge = createRemoteWebPairingChallenge(
       PUBLIC_BASE_URL,
-      REQUESTER,
+      TEST_REQUESTER,
     );
     const record = getRemoteWebPairingChallengeForTests(challenge.userCode);
 
@@ -395,7 +393,7 @@ describe("remote web pairing request list/approve/deny", () => {
     setRemoteWebPairingChallengeNowForTests(() => now);
     const challenge = createRemoteWebPairingChallenge(
       PUBLIC_BASE_URL,
-      REQUESTER,
+      TEST_REQUESTER,
     );
     const record = getRemoteWebPairingChallengeForTests(challenge.userCode);
 
@@ -415,7 +413,7 @@ describe("remote web pairing request list/approve/deny", () => {
     setRemoteWebPairingChallengeNowForTests(() => 1_000);
     const challenge = createRemoteWebPairingChallenge(
       PUBLIC_BASE_URL,
-      REQUESTER,
+      TEST_REQUESTER,
     );
     const record = getRemoteWebPairingChallengeForTests(challenge.userCode);
 
@@ -439,7 +437,7 @@ describe("remote web pairing request list/approve/deny", () => {
     setRemoteWebPairingChallengeNowForTests(() => 1_000);
     const challenge = createRemoteWebPairingChallenge(
       PUBLIC_BASE_URL,
-      REQUESTER,
+      TEST_REQUESTER,
     );
     const record = getRemoteWebPairingChallengeForTests(challenge.userCode);
 
@@ -459,7 +457,7 @@ describe("remote web pairing request list/approve/deny", () => {
     setRemoteWebPairingChallengeNowForTests(() => 1_000);
     const challenge = createRemoteWebPairingChallenge(
       PUBLIC_BASE_URL,
-      REQUESTER,
+      TEST_REQUESTER,
     );
     const record = getRemoteWebPairingChallengeForTests(challenge.userCode);
     expect(approveRemoteWebPairingChallengeById(record!.id).status).toBe(
@@ -478,7 +476,7 @@ describe("remote web pairing request list/approve/deny", () => {
     setRemoteWebPairingChallengeNowForTests(() => 1_000);
     const challenge = createRemoteWebPairingChallenge(
       PUBLIC_BASE_URL,
-      REQUESTER,
+      TEST_REQUESTER,
     );
     const record = getRemoteWebPairingChallengeForTests(challenge.userCode);
     expect(approveRemoteWebPairingChallengeById(record!.id).status).toBe(

--- a/gateway/src/__tests__/remote-web-pairing-token.test.ts
+++ b/gateway/src/__tests__/remote-web-pairing-token.test.ts
@@ -7,6 +7,11 @@ import { eq } from "drizzle-orm";
 
 import { initSigningKey } from "../auth/token-service.js";
 
+import {
+  PUBLIC_BASE_URL,
+  TEST_REQUESTER,
+} from "./helpers/remote-web-pairing-fixtures.js";
+
 initSigningKey(Buffer.from("test-signing-key-at-least-32-bytes-long-xx"));
 
 const mockQuery = mock();
@@ -47,12 +52,6 @@ const {
 } = await import("../guardian-integrity-reporter.js");
 
 const GUARDIAN_ID = "guardian-001";
-const PUBLIC_BASE_URL = "https://paired.example.com";
-const TEST_REQUESTER = {
-  ip: "203.0.113.10",
-  userAgent: "test-agent",
-  viaEdgeProxy: true,
-};
 
 let testRoot: string;
 

--- a/gateway/src/http/routes/remote-web-pairing-challenge.ts
+++ b/gateway/src/http/routes/remote-web-pairing-challenge.ts
@@ -22,7 +22,9 @@ import { methodNotAllowed, readJsonStringField } from "../route-helpers.js";
 const MAX_CHALLENGE_BODY_BYTES = 512;
 
 function parsePublicBaseUrl(value: string): string | null {
-  if (!value.trim()) return null;
+  if (!value.trim()) {
+    return null;
+  }
   try {
     const url = new URL(value);
     if (url.protocol !== "https:" && url.protocol !== "http:") return null;
@@ -107,7 +109,9 @@ export async function handleCreateRemoteWebPairingChallenge(
     MAX_CHALLENGE_BODY_BYTES,
     "publicBaseUrl",
   );
-  if (rawPublicBaseUrl instanceof Response) return rawPublicBaseUrl;
+  if (rawPublicBaseUrl instanceof Response) {
+    return rawPublicBaseUrl;
+  }
 
   const publicBaseUrl = parsePublicBaseUrl(rawPublicBaseUrl);
   if (!publicBaseUrl) {

--- a/gateway/src/http/routes/remote-web-pairing-requests.ts
+++ b/gateway/src/http/routes/remote-web-pairing-requests.ts
@@ -36,7 +36,9 @@ export function handleListRemoteWebPairingRequests(
   }
 
   const guardError = enforceLoopbackOnly(req, clientIp, AUDIT_TAG);
-  if (guardError) return guardError;
+  if (guardError) {
+    return guardError;
+  }
 
   return Response.json(
     {
@@ -53,7 +55,6 @@ function guardPostLoopback(req: Request, clientIp: string): Response | null {
   return enforceLoopbackOnly(req, clientIp, AUDIT_TAG);
 }
 
-
 // No code-guess rate limiter on approve/deny: request ids are server-minted
 // opaque ids from the list route, not guessable secrets typed by users.
 export async function handleApproveRemoteWebPairingRequest(
@@ -61,14 +62,18 @@ export async function handleApproveRemoteWebPairingRequest(
   clientIp: string,
 ): Promise<Response> {
   const guardError = guardPostLoopback(req, clientIp);
-  if (guardError) return guardError;
+  if (guardError) {
+    return guardError;
+  }
 
   const requestId = await readJsonStringField(
     req,
     MAX_ACTION_BODY_BYTES,
     "requestId",
   );
-  if (requestId instanceof Response) return requestId;
+  if (requestId instanceof Response) {
+    return requestId;
+  }
 
   const result = approveRemoteWebPairingChallengeById(requestId);
   if (result.status === "invalid") {
@@ -86,14 +91,18 @@ export async function handleDenyRemoteWebPairingRequest(
   clientIp: string,
 ): Promise<Response> {
   const guardError = guardPostLoopback(req, clientIp);
-  if (guardError) return guardError;
+  if (guardError) {
+    return guardError;
+  }
 
   const requestId = await readJsonStringField(
     req,
     MAX_ACTION_BODY_BYTES,
     "requestId",
   );
-  if (requestId instanceof Response) return requestId;
+  if (requestId instanceof Response) {
+    return requestId;
+  }
 
   const result = denyRemoteWebPairingChallengeById(requestId);
   if (result.status === "invalid") {

--- a/gateway/src/http/routes/remote-web-pairing-token.ts
+++ b/gateway/src/http/routes/remote-web-pairing-token.ts
@@ -18,23 +18,25 @@ import {
   buildRemoteWebBrowserAuthCookies,
   remoteWebRefreshCookiePathForPublicBaseUrl,
 } from "../browser-auth-cookies.js";
-import { readLimitedBody } from "../read-limited-body.js";
+import { errorResponse } from "../loopback-guard.js";
+import { methodNotAllowed, readJsonStringField } from "../route-helpers.js";
 
 const MAX_TOKEN_BODY_BYTES = 512;
 const REMOTE_WEB_PLATFORM = "web";
 
-function jsonError(code: string, message: string, status: number): Response {
-  return Response.json(
-    { error: { code, message } },
-    { status, headers: { "Cache-Control": "no-store" } },
-  );
+/** Token-exchange JSON responses, errors included, are never cacheable. */
+function noStore(res: Response): Response {
+  res.headers.set("Cache-Control", "no-store");
+  return res;
 }
 
 function invalidDeviceCodeResponse(): Response {
-  return jsonError(
-    "INVALID_OR_EXPIRED_DEVICE_CODE",
-    "invalid or expired pairing device code",
-    401,
+  return noStore(
+    errorResponse(
+      "INVALID_OR_EXPIRED_DEVICE_CODE",
+      "invalid or expired pairing device code",
+      401,
+    ),
   );
 }
 
@@ -42,33 +44,16 @@ export async function handleRemoteWebPairingToken(
   req: Request,
 ): Promise<Response> {
   if (req.method !== "POST") {
-    return new Response("method not allowed", {
-      status: 405,
-      headers: { Allow: "POST" },
-    });
+    return methodNotAllowed("POST");
   }
 
-  const rawBody = await readLimitedBody(req, MAX_TOKEN_BODY_BYTES);
-  if (rawBody.status === "too_large") {
-    return jsonError("PAYLOAD_TOO_LARGE", "request body too large", 413);
-  }
-  if (rawBody.status === "unreadable") {
-    return jsonError("BAD_REQUEST", "failed to read request body", 400);
-  }
-
-  let deviceCode: string | null = null;
-  try {
-    const body = JSON.parse(rawBody.text) as { deviceCode?: unknown };
-    deviceCode =
-      typeof body.deviceCode === "string" && body.deviceCode.trim()
-        ? body.deviceCode
-        : null;
-  } catch {
-    return jsonError("BAD_REQUEST", "invalid JSON body", 400);
-  }
-
-  if (!deviceCode) {
-    return jsonError("BAD_REQUEST", "deviceCode is required", 400);
+  const deviceCode = await readJsonStringField(
+    req,
+    MAX_TOKEN_BODY_BYTES,
+    "deviceCode",
+  );
+  if (deviceCode instanceof Response) {
+    return noStore(deviceCode);
   }
 
   const challenge = claimRemoteWebPairingChallengeExchange(deviceCode);
@@ -114,10 +99,12 @@ export async function handleRemoteWebPairingToken(
       // Stays 503 (unlike /auth/token's repairable 401): 401 here means
       // invalid/expired device code, and the released code stays
       // exchangeable after guardian repair.
-      return jsonError(
-        "GUARDIAN_REPAIR_REQUIRED",
-        "gateway guardian binding is missing over evidence of prior onboarding — repair via guardian init, then retry pairing",
-        503,
+      return noStore(
+        errorResponse(
+          "GUARDIAN_REPAIR_REQUIRED",
+          "gateway guardian binding is missing over evidence of prior onboarding — repair via guardian init, then retry pairing",
+          503,
+        ),
       );
     }
     throw err;

--- a/gateway/src/http/routes/remote-web-pairing-verification.ts
+++ b/gateway/src/http/routes/remote-web-pairing-verification.ts
@@ -55,8 +55,8 @@ export async function handleVerifyRemoteWebPairingChallenge(
     return rateLimitedResponse(rateLimitedBeforeBodyRead);
   }
 
-  // Body/JSON/field failures still count as failed attempts for the
-  // per-client rate limiter, exactly as before the shared helper.
+  // Body/JSON/field failures count as failed attempts for the per-client
+  // rate limiter.
   const userCode = await readJsonStringField(
     req,
     MAX_VERIFICATION_BODY_BYTES,

--- a/gateway/src/remote-web/pairing-challenge-store.ts
+++ b/gateway/src/remote-web/pairing-challenge-store.ts
@@ -190,7 +190,9 @@ export function approveRemoteWebPairingChallenge(
 ): ApproveRemoteWebPairingChallengeResult {
   const userCodeHash = hashSecret(normalizeUserCode(userCode));
   const challenge = challengesByUserCodeHash.get(userCodeHash);
-  if (!challenge) return { status: "invalid" };
+  if (!challenge) {
+    return { status: "invalid" };
+  }
   return approveChallenge(challenge);
 }
 
@@ -198,7 +200,9 @@ function findChallengeById(
   id: string,
 ): PendingRemoteWebPairingChallenge | undefined {
   for (const challenge of challengesByUserCodeHash.values()) {
-    if (challenge.id === id) return challenge;
+    if (challenge.id === id) {
+      return challenge;
+    }
   }
   return undefined;
 }
@@ -226,7 +230,9 @@ export function approveRemoteWebPairingChallengeById(
   id: string,
 ): ApproveRemoteWebPairingChallengeResult {
   const challenge = findChallengeById(id);
-  if (!challenge) return { status: "invalid" };
+  if (!challenge) {
+    return { status: "invalid" };
+  }
   return approveChallenge(challenge);
 }
 
@@ -239,7 +245,9 @@ export function denyRemoteWebPairingChallengeById(
   id: string,
 ): DenyRemoteWebPairingChallengeResult {
   const challenge = findChallengeById(id);
-  if (!challenge) return { status: "invalid" };
+  if (!challenge) {
+    return { status: "invalid" };
+  }
   // Approved/exchanging/consumed: the remote device may already be pairing.
   // Distinct from unknown-id so the route can surface it instead of a 404 the
   // client would read as an already-handled row.


### PR DESCRIPTION
## Summary
Fixes round-2 self-review gaps for web-pair-approve.md.

- Reworded a refactor-history comment; braced the one-line guards added by the previous fix PR
- Migrated the pairing-token route onto the shared route helpers (wire behavior unchanged)
- Deduped requester/base-url constants into the shared pairing test fixtures