### PR TITLE
fix(gateway): drop em dashes from the guardian-repair pairing error

### DIFF
--- a/gateway/src/__tests__/remote-web-pairing-token.test.ts
+++ b/gateway/src/__tests__/remote-web-pairing-token.test.ts
@@ -655,7 +655,7 @@ describe("remote web pairing token exchange", () => {
     );
 
     // Guardian rows lost, but a residual non-guardian contact is evidence of
-    // prior onboarding — the fallback mint must refuse rather than diverge.
+    // prior onboarding: the fallback mint must refuse rather than diverge.
     clearGatewayGuardian();
     const now = Date.now();
     getGatewayDb()
@@ -687,7 +687,7 @@ describe("remote web pairing token exchange", () => {
         error: {
           code: "GUARDIAN_REPAIR_REQUIRED",
           message:
-            "gateway guardian binding is missing over evidence of prior onboarding — repair via guardian init, then retry pairing",
+            "gateway guardian binding is missing over evidence of prior onboarding; repair via guardian init, then retry pairing",
         },
       });
       expect(setCookies(res)).toHaveLength(0);

--- a/gateway/src/http/routes/remote-web-pairing-token.ts
+++ b/gateway/src/http/routes/remote-web-pairing-token.ts
@@ -102,7 +102,7 @@ export async function handleRemoteWebPairingToken(
       return noStore(
         errorResponse(
           "GUARDIAN_REPAIR_REQUIRED",
-          "gateway guardian binding is missing over evidence of prior onboarding — repair via guardian init, then retry pairing",
+          "gateway guardian binding is missing over evidence of prior onboarding; repair via guardian init, then retry pairing",
           503,
         ),
       );


### PR DESCRIPTION
## Summary
Fixes the round-3 review gap for web-pair-approve.md: replaces the em dash in the user-facing GUARDIAN_REPAIR_REQUIRED message (and the matching test assertion plus a ride-along comment) per the AGENTS.md punctuation rule.