### PR TITLE
feat(web): translate settings pages

### DIFF
--- a/clients/web/eslint.config.mjs
+++ b/clients/web/eslint.config.mjs
@@ -214,6 +214,7 @@ const i18nEnforcedPaths = [
   "src/domains/settings/ai/**/*.{ts,tsx}",
   "src/domains/chat/inspector/**/*.{ts,tsx}",
   "src/domains/settings/billing/**/*.{ts,tsx}",
+  "src/domains/settings/pages/**/*.{ts,tsx}",
 ];
 
 const eslintConfig = defineConfig([

--- a/clients/web/src/domains/settings/pages/bookmarks-page.tsx
+++ b/clients/web/src/domains/settings/pages/bookmarks-page.tsx
@@ -6,9 +6,12 @@ import {
   useBookmarks,
   useBookmarkToggle,
 } from "@/hooks/use-bookmarks";
+import { useTranslation } from "@/i18n";
 import { navigateToConversation } from "@/utils/conversation-navigation";
 import { Button } from "@vellumai/design-library/components/button";
 import { Card } from "@vellumai/design-library/components/card";
+
+type SettingsTranslate = ReturnType<typeof useTranslation<"settings">>["t"];
 
 function formatBookmarkDate(timestamp: number | undefined): string {
   if (timestamp == null) {
@@ -28,7 +31,7 @@ function formatBookmarkDate(timestamp: number | undefined): string {
   });
 }
 
-function EmptyState() {
+function EmptyState({ t }: { t: SettingsTranslate }) {
   return (
     <Card>
       <div className="flex min-h-[400px] flex-col items-center justify-center px-6 py-16 text-center">
@@ -36,10 +39,10 @@ function EmptyState() {
           <Bookmark className="h-6 w-6 text-[var(--content-disabled)] dark:text-[var(--content-default)]" />
         </div>
         <h2 className="mt-4 text-title-small text-[var(--content-default)]">
-          No bookmarks
+          {t("bookmarksPage.emptyTitle")}
         </h2>
         <p className="mt-1 text-body-medium-lighter text-[var(--content-tertiary)]">
-          Hover any message and click the bookmark icon to save it here.
+          {t("bookmarksPage.emptyDescription")}
         </p>
       </div>
     </Card>
@@ -51,16 +54,18 @@ function BookmarkRow({
   isFirst,
   onOpen,
   onRemove,
+  t,
 }: {
   bookmark: BookmarkSummary;
   isFirst: boolean;
   onOpen: () => void;
   onRemove: () => void;
+  t: SettingsTranslate;
 }) {
   const title =
     bookmark.conversationTitle && bookmark.conversationTitle.trim().length > 0
       ? bookmark.conversationTitle
-      : "Untitled conversation";
+      : t("bookmarksPage.untitledConversation");
   // Accent the source: assistant replies read stronger than the user's own
   // lines, matching the legacy macOS Bookmarks tab.
   const isAssistant = bookmark.messageRole !== "user";
@@ -100,13 +105,13 @@ function BookmarkRow({
       </div>
       <div className="flex shrink-0 items-center gap-2">
         <Button variant="outlined" onClick={onOpen}>
-          Open
+          {t("bookmarksPage.open")}
         </Button>
         <button
           type="button"
           onClick={onRemove}
-          title="Remove bookmark"
-          aria-label="Remove bookmark"
+          title={t("bookmarksPage.removeBookmark")}
+          aria-label={t("bookmarksPage.removeBookmark")}
           className="flex h-8 w-8 cursor-pointer items-center justify-center rounded-md text-[var(--content-tertiary)] transition-colors hover:bg-[var(--surface-active)] hover:text-[var(--content-default)]"
         >
           <X className="h-4 w-4" />
@@ -117,6 +122,7 @@ function BookmarkRow({
 }
 
 export function BookmarksPage() {
+  const { t } = useTranslation("settings");
   const navigate = useNavigate();
   const { bookmarks, isLoading, isError, refetch } = useBookmarks();
   const toggleBookmark = useBookmarkToggle();
@@ -140,14 +146,14 @@ export function BookmarksPage() {
               <AlertTriangle className="h-6 w-6 text-[var(--system-error-default)]" />
             </div>
             <h2 className="mt-4 text-title-small text-[var(--content-default)]">
-              Failed to load bookmarks
+              {t("bookmarksPage.errorTitle")}
             </h2>
             <p className="mt-1 text-body-medium-lighter text-[var(--content-tertiary)]">
-              Something went wrong. Please try again.
+              {t("bookmarksPage.errorDescription")}
             </p>
             <Button variant="outlined" onClick={refetch} className="mt-4">
               <RotateCcw className="h-4 w-4" />
-              Retry
+              {t("bookmarksPage.retry")}
             </Button>
           </div>
         </Card>
@@ -158,7 +164,7 @@ export function BookmarksPage() {
   if (bookmarks.length === 0) {
     return (
       <div className="w-full">
-        <EmptyState />
+        <EmptyState t={t} />
       </div>
     );
   }
@@ -183,6 +189,7 @@ export function BookmarksPage() {
                 true,
               );
             }}
+            t={t}
           />
         ))}
       </Card>

--- a/clients/web/src/domains/settings/pages/community-page.tsx
+++ b/clients/web/src/domains/settings/pages/community-page.tsx
@@ -18,12 +18,15 @@ import { XLogo } from "@/components/icons/x-logo";
 import { YouTubeLogo } from "@/components/icons/youtube-logo";
 import { joinDiscord } from "@/hooks/use-discord-nudge";
 import { GITHUB_REPO_URL, useGitHubNudgeState } from "@/hooks/use-github-nudge";
+import { useTranslation } from "@/i18n";
 import { VELLUM_COMMUNITY_URL } from "@/utils/external-urls";
 import { Button } from "@vellumai/design-library/components/button";
 import { Card } from "@vellumai/design-library/components/card";
 import { Tag } from "@vellumai/design-library/components/tag";
 
-function HeroBanner() {
+type SettingsTranslate = ReturnType<typeof useTranslation<"settings">>["t"];
+
+function HeroBanner({ t }: { t: SettingsTranslate }) {
   return (
     <Card padding="lg" className="bg-[var(--surface-lift)]">
       <div className="relative">
@@ -38,14 +41,13 @@ function HeroBanner() {
         <div className="relative flex flex-col items-start gap-3">
           <Tag tone="neutral">
             <Play className="h-3.5 w-3.5" />
-            Community
+            {t("communityPage.heroTag")}
           </Tag>
           <h1 className="text-[28px] font-semibold leading-tight tracking-tight text-[var(--content-emphasised)]">
-            Build with us, in the open.
+            {t("communityPage.heroTitle")}
           </h1>
           <p className="max-w-xl text-body-medium-default text-[color:var(--content-tertiary)]">
-            Vellum is built in the open with a growing community of developers,
-            designers, and tinkerers. Here&apos;s how to get involved.
+            {t("communityPage.heroDescription")}
           </p>
         </div>
       </div>
@@ -212,58 +214,68 @@ function ResourceCard({
 }
 
 export function CommunityPage() {
+  const { t } = useTranslation("settings");
   const { handleStar } = useGitHubNudgeState();
 
   return (
     <div className="space-y-6">
-      <HeroBanner />
+      <HeroBanner t={t} />
 
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
         <FeatureCard
           accentColor="var(--content-emphasised)"
           iconColor="var(--surface-base)"
-          label="Open Source"
+          label={t("communityPage.openSourceLabel")}
           icon={<GitHubLogo size={20} />}
-          title="Vellum is open source"
-          subtitle="Read the source, star the repo, and contribute fixes and features on GitHub."
+          title={t("communityPage.openSourceTitle")}
+          subtitle={t("communityPage.openSourceSubtitle")}
           benefits={[
-            { icon: Star, text: "Star the repo to follow updates" },
-            { icon: Bug, text: "Open issues and report bugs" },
+            {
+              icon: Star,
+              text: t("communityPage.openSourceBenefitStar"),
+            },
+            {
+              icon: Bug,
+              text: t("communityPage.openSourceBenefitIssues"),
+            },
             {
               icon: GitPullRequest,
-              text: "Contribute fixes and new features",
+              text: t("communityPage.openSourceBenefitContribute"),
             },
           ]}
           primaryAction={{
-            label: "Star on GitHub",
+            label: t("communityPage.starOnGitHub"),
             icon: <Star size={16} />,
             onClick: handleStar,
           }}
           secondaryAction={{
-            label: "View source",
+            label: t("communityPage.viewSource"),
             href: GITHUB_REPO_URL,
           }}
         />
 
         <FeatureCard
           accentColor="#5865F2"
-          label="Discord"
+          label={t("communityPage.discordLabel")}
           icon={<DiscordLogo size={20} />}
-          title="Join our community"
-          subtitle="Talk to the team, share feedback, request features, and get answers faster."
+          title={t("communityPage.discordTitle")}
+          subtitle={t("communityPage.discordSubtitle")}
           benefits={[
-            { icon: Heart, text: "Talk directly with the team" },
+            {
+              icon: Heart,
+              text: t("communityPage.discordBenefitTeam"),
+            },
             {
               icon: Sparkles,
-              text: "Share feedback and request features",
+              text: t("communityPage.discordBenefitFeedback"),
             },
             {
               icon: Users,
-              text: "Get answers faster from the community",
+              text: t("communityPage.discordBenefitAnswers"),
             },
           ]}
           primaryAction={{
-            label: "Join Discord",
+            label: t("communityPage.joinDiscord"),
             icon: <DiscordLogo size={16} style={{ color: "currentColor" }} />,
             onClick: joinDiscord,
           }}
@@ -272,29 +284,29 @@ export function CommunityPage() {
 
       <div className="flex flex-col gap-4">
         <h2 className="text-label-medium-default uppercase tracking-wider text-[color:var(--content-tertiary)]">
-          More from Vellum
+          {t("communityPage.moreFromVellum")}
         </h2>
         <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
           <ResourceCard
             icon={<Globe size={20} />}
             iconBg="#22c55e"
-            title="Community Hub"
-            description="Showcases, guides, and projects shared by the community."
+            title={t("communityPage.communityHubTitle")}
+            description={t("communityPage.communityHubDescription")}
             href={VELLUM_COMMUNITY_URL}
           />
           <ResourceCard
             icon={<XLogo size={20} />}
             iconBg="var(--content-default)"
             iconColor="var(--surface-base)"
-            title="Follow on X"
-            description="Product updates, releases, and behind-the-scenes."
+            title={t("communityPage.followOnXTitle")}
+            description={t("communityPage.followOnXDescription")}
             href="https://x.com/vellum_ai"
           />
           <ResourceCard
             icon={<YouTubeLogo size={20} />}
             iconBg="#ef4444"
-            title="YouTube channel"
-            description="Walkthroughs, tutorials, and product deep-dives."
+            title={t("communityPage.youtubeChannelTitle")}
+            description={t("communityPage.youtubeChannelDescription")}
             href="https://www.youtube.com/@Vellum_AI"
           />
         </div>

--- a/clients/web/src/domains/settings/pages/developer-page.tsx
+++ b/clients/web/src/domains/settings/pages/developer-page.tsx
@@ -7,14 +7,15 @@ import { AssistantLifecyclePanel } from "@/domains/settings/components/panels/as
 import { EnvironmentConfigPanel } from "@/domains/settings/components/panels/environment-config-panel";
 import { FeatureFlagsPanel } from "@/domains/settings/components/panels/feature-flags-panel";
 import { SentryTestingPanel } from "@/domains/settings/components/panels/sentry-testing-panel";
+import { useTranslation } from "@/i18n";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { routes } from "@/utils/routes";
 
 const ALL_TABS = [
-  { id: "feature-flags", label: "Feature Flags" },
-  { id: "lifecycle", label: "Assistant Lifecycle" },
-  { id: "sentry", label: "Sentry Testing" },
-  { id: "memory", label: "Memory" },
+  { id: "feature-flags", labelKey: "developerPage.tabFeatureFlags" },
+  { id: "lifecycle", labelKey: "developerPage.tabLifecycle" },
+  { id: "sentry", labelKey: "developerPage.tabSentry" },
+  { id: "memory", labelKey: "developerPage.tabMemory" },
 ] as const;
 
 type DeveloperTabId = (typeof ALL_TABS)[number]["id"];
@@ -26,6 +27,7 @@ type DeveloperTabId = (typeof ALL_TABS)[number]["id"];
 const PANEL_CLASS = "flex min-h-0 flex-1 flex-col pt-6";
 
 export function DeveloperPage() {
+  const { t } = useTranslation("settings");
   const [searchParams, setSearchParams] = useSearchParams();
   const settingsDeveloperNav =
     useAssistantFeatureFlagStore.use.settingsDeveloperNav();
@@ -60,10 +62,13 @@ export function DeveloperPage() {
         onValueChange={setActiveTab}
         className="flex min-h-0 flex-1 flex-col"
       >
-        <Tabs.List className="shrink-0" aria-label="Developer sections">
+        <Tabs.List
+          className="shrink-0"
+          aria-label={t("developerPage.sectionsAriaLabel")}
+        >
           {ALL_TABS.map((tab) => (
             <Tabs.Trigger key={tab.id} value={tab.id}>
-              {tab.label}
+              {t(tab.labelKey)}
             </Tabs.Trigger>
           ))}
         </Tabs.List>

--- a/clients/web/src/domains/settings/pages/general-page.tsx
+++ b/clients/web/src/domains/settings/pages/general-page.tsx
@@ -53,9 +53,11 @@ import {
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { useIsAuthenticated } from "@/stores/auth-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+import { useTranslation } from "@/i18n";
 import { routes } from "@/utils/routes";
 
 export function GeneralPage() {
+  const { t } = useTranslation("settings");
   const {
     assistant,
     healthz,
@@ -207,16 +209,15 @@ export function GeneralPage() {
             <div className="border-t border-[var(--border-subtle)]" />
             <section className="flex flex-col gap-2">
               <h3 className="text-title-small text-[var(--content-emphasised)]">
-                Two-Factor Authentication
+                {t("generalPage.twoFactorTitle")}
               </h3>
               <p className="text-body-medium-default text-[var(--content-tertiary)]">
-                Require a code from an authenticator app when you sign in.
+                {t("generalPage.twoFactorDescription")}
               </p>
               <div className="mt-1">
                 {platformGate === "disabled" ? (
                   <PlatformLoginNotice>
-                    Log in to the Vellum platform to manage two-factor
-                    authentication.
+                    {t("generalPage.twoFactorLoginNotice")}
                   </PlatformLoginNotice>
                 ) : (
                   <TwoFactorSection />
@@ -228,15 +229,15 @@ export function GeneralPage() {
       </ProfileCard>
 
       <DetailCard
-        title="Version"
-        subtitle="Manage your assistant's software version and updates."
+        title={t("generalPage.versionTitle")}
+        subtitle={t("generalPage.versionSubtitle")}
         accessory={
           infraGate === "full" && platformAssistant ? (
             <Button
               variant="outlined"
               onClick={() => setUpdateWindowOpen(true)}
             >
-              Update Window
+              {t("generalPage.updateWindow")}
             </Button>
           ) : undefined
         }
@@ -272,7 +273,7 @@ export function GeneralPage() {
           {!showsUpgradePanel && assistant && (
             <div className="grid grid-cols-[140px_minmax(0,1fr)] gap-y-3">
               <span className="text-body-medium-default text-[var(--content-tertiary)]">
-                Current
+                {t("generalPage.current")}
               </span>
               <DevModeVersionUnlock
                 version={versionValue}
@@ -283,7 +284,7 @@ export function GeneralPage() {
           )}
           {infraGate === "disabled" && !canUpgradeLocally && (
             <PlatformLoginNotice>
-              Log in to the Vellum platform to manage software updates.
+              {t("generalPage.updatesLoginNotice")}
             </PlatformLoginNotice>
           )}
         </div>
@@ -309,21 +310,21 @@ export function GeneralPage() {
       {infraGate === "disabled" && (
         <DetailCard
           id="storage-resources"
-          title="Compute & Resources"
-          subtitle="Monitor resource usage and manage your assistant's compute profile."
+          title={t("generalPage.computeResourcesTitle")}
+          subtitle={t("generalPage.computeResourcesSubtitle")}
         >
           <PlatformLoginNotice>
-            Log in to the Vellum platform to manage compute resources.
+            {t("generalPage.computeResourcesLoginNotice")}
           </PlatformLoginNotice>
         </DetailCard>
       )}
 
       <DetailCard
-        title="Preferences"
-        subtitle="Customize how Vellum looks and behaves on this device."
+        title={t("generalPage.preferencesTitle")}
+        subtitle={t("generalPage.preferencesSubtitle")}
         accessory={
           <Button variant="outlined" onClick={() => setPreferencesOpen(true)}>
-            Customize
+            {t("generalPage.customize")}
           </Button>
         }
       >
@@ -346,19 +347,19 @@ export function GeneralPage() {
 
       {infraGate === "full" && platformAssistant && settingsSleepPolicy && (
         <DetailCard
-          title="Sleep Policy"
-          subtitle="Control how long this assistant stays awake when idle."
+          title={t("generalPage.sleepPolicyTitle")}
+          subtitle={t("generalPage.sleepPolicySubtitle")}
         >
           <AssistantSleepPolicy assistantId={platformAssistant.id} />
         </DetailCard>
       )}
       {infraGate === "disabled" && settingsSleepPolicy && (
         <DetailCard
-          title="Sleep Policy"
-          subtitle="Control how long this assistant stays awake when idle."
+          title={t("generalPage.sleepPolicyTitle")}
+          subtitle={t("generalPage.sleepPolicySubtitle")}
         >
           <PlatformLoginNotice>
-            Log in to the Vellum platform to manage sleep policy.
+            {t("generalPage.sleepPolicyLoginNotice")}
           </PlatformLoginNotice>
         </DetailCard>
       )}
@@ -369,27 +370,26 @@ export function GeneralPage() {
 
       {showAssistantSwitcherCard && (
         <DetailCard
-          title="Switch Assistant"
-          subtitle="Choose which assistant this device is connected to."
+          title={t("generalPage.switchAssistantTitle")}
+          subtitle={t("generalPage.switchAssistantSubtitle")}
           accessory={
             <Button variant="outlined" onClick={openAssistantChooser}>
-              Choose Assistant
+              {t("generalPage.chooseAssistant")}
             </Button>
           }
         />
       )}
 
       {(showRetire || showDeleteAccount) && (
-        <DetailCard variant="danger" title="Danger Zone">
+        <DetailCard variant="danger" title={t("generalPage.dangerZoneTitle")}>
           <div className="flex flex-col gap-6">
             {showRetire && (
               <section className="flex flex-col gap-2">
                 <h3 className="text-title-small text-[var(--content-emphasised)]">
-                  Retire Assistant
+                  {t("generalPage.retireAssistantTitle")}
                 </h3>
                 <p className="text-body-medium-default text-[var(--content-tertiary)]">
-                  Permanently retire this assistant and delete all associated
-                  data.
+                  {t("generalPage.retireAssistantDescription")}
                 </p>
                 <div className="mt-1">
                   {(platformGate === "full" || canRetireLocally) &&
@@ -397,7 +397,7 @@ export function GeneralPage() {
                     <RetireAssistant assistantId={platformAssistant.id} />
                   ) : (
                     <PlatformLoginNotice>
-                      Log in to the Vellum platform to retire this assistant.
+                      {t("generalPage.retireAssistantLoginNotice")}
                     </PlatformLoginNotice>
                   )}
                 </div>

--- a/clients/web/src/domains/settings/pages/integrations-page.tsx
+++ b/clients/web/src/domains/settings/pages/integrations-page.tsx
@@ -21,7 +21,7 @@ import { oauthProvidersGetOptions } from "@/generated/daemon/@tanstack/react-que
 import { usePlatformAssistantId } from "@/hooks/use-platform-assistant-id";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
 import { captureError } from "@/lib/sentry/capture-error";
-import { useTranslation } from "@/i18n";
+import { Trans, useTranslation } from "@/i18n";
 import { getLocalSetting, setLocalSetting } from "@/utils/local-settings";
 import { routes } from "@/utils/routes";
 
@@ -29,6 +29,60 @@ const BANNER_STORAGE_KEY = "vellum:integrations:bannerDismissed";
 
 type IntegrationFilter = "all" | "enabled" | "not-enabled";
 type IntegrationsTab = "oauth" | "mcp";
+
+type SettingsTranslate = ReturnType<typeof useTranslation<"settings">>["t"];
+
+function oauthErrorMessage(
+  t: SettingsTranslate,
+  code: string,
+): string | undefined {
+  const messages: Record<string, string> = {
+    denied: t("integrationsPage.oauthErrorDenied"),
+    state_invalid: t("integrationsPage.oauthErrorStateInvalid"),
+    state_expired: t("integrationsPage.oauthErrorStateExpired"),
+    exchange_failed: t("integrationsPage.oauthErrorExchangeFailed"),
+    identity_failed: t("integrationsPage.oauthErrorIdentityFailed"),
+  };
+  return messages[code];
+}
+
+function emptyStateTitle(
+  t: SettingsTranslate,
+  searchText: string,
+  selectedFilter: IntegrationFilter,
+): string {
+  if (searchText.trim()) {
+    return t("integrationsPage.emptySearchTitle");
+  }
+  switch (selectedFilter) {
+    case "enabled":
+      return t("integrationsPage.emptyEnabledTitle");
+    case "not-enabled":
+      return t("integrationsPage.emptyAllEnabledTitle");
+    default:
+      return t("integrationsPage.emptyDefaultTitle");
+  }
+}
+
+function emptyStateSubtitle(
+  t: SettingsTranslate,
+  searchText: string,
+  selectedFilter: IntegrationFilter,
+): string {
+  if (searchText.trim()) {
+    return t("integrationsPage.emptySearchSubtitle", {
+      query: searchText.trim(),
+    });
+  }
+  switch (selectedFilter) {
+    case "enabled":
+      return t("integrationsPage.emptyEnabledSubtitle");
+    case "not-enabled":
+      return t("integrationsPage.emptyNotEnabledSubtitle");
+    default:
+      return t("integrationsPage.emptyDefaultSubtitle");
+  }
+}
 
 /** Filter values in display order, each with the catalog key for its label. */
 const FILTER_OPTION_KEYS = [
@@ -137,28 +191,21 @@ function IntegrationsPanelInner() {
     if (oauthStatus === "connected") {
       toast.success(
         providerLabel
-          ? `${providerLabel} account connected successfully.`
-          : "Account connected successfully.",
+          ? t("integrationsPage.accountConnectedToast", { providerLabel })
+          : t("integrationsPage.accountConnectedToastGeneric"),
       );
     } else if (oauthStatus === "error") {
       const code = searchParams.get("oauth_code") ?? "unknown";
-      const messages: Record<string, string> = {
-        denied: "Authorization was denied. Please try again.",
-        state_invalid: "Authorization state was invalid. Please try again.",
-        state_expired: "Authorization expired. Please try again.",
-        exchange_failed: "Failed to complete authorization. Please try again.",
-        identity_failed: "Failed to verify account identity. Please try again.",
-      };
       toast.error(
-        messages[code] ??
+        oauthErrorMessage(t, code) ??
           (providerLabel
-            ? `Failed to connect ${providerLabel}.`
-            : "Failed to connect. Please try again."),
+            ? t("integrationsPage.connectFailedToast", { providerLabel })
+            : t("integrationsPage.connectFailedToastGeneric")),
       );
     }
 
     navigate(routes.settings.integrations, { replace: true });
-  }, [searchParams, navigate]);
+  }, [searchParams, navigate, t]);
 
   const managedProviders = useMemo(
     () => providers?.filter((p) => p.supports_managed_mode) ?? [],
@@ -212,33 +259,8 @@ function IntegrationsPanelInner() {
     connectionsLoading ||
     platformAssistantIdLoading;
 
-  const emptyStateTitle = (() => {
-    if (searchText.trim()) {
-      return "No integrations matched";
-    }
-    switch (selectedFilter) {
-      case "enabled":
-        return "No Enabled Integrations";
-      case "not-enabled":
-        return "All Integrations Are Enabled";
-      default:
-        return "No Integrations Available";
-    }
-  })();
-
-  const emptyStateSubtitle = (() => {
-    if (searchText.trim()) {
-      return `No integrations matched "${searchText.trim()}"`;
-    }
-    switch (selectedFilter) {
-      case "enabled":
-        return "Connect an integration to get started.";
-      case "not-enabled":
-        return "All available integrations have been connected.";
-      default:
-        return "Check your connection and try again.";
-    }
-  })();
+  const emptyTitle = emptyStateTitle(t, searchText, selectedFilter);
+  const emptySubtitle = emptyStateSubtitle(t, searchText, selectedFilter);
 
   const selectedProvider = useMemo(
     () =>
@@ -264,8 +286,13 @@ function IntegrationsPanelInner() {
           icon={<Sparkles className="h-3.5 w-3.5" />}
           onDismiss={dismissBanner}
         >
-          <span className="text-body-medium-default">Tip:</span> You can enable
-          integrations by mentioning them in chat.
+          <Trans
+            ns="settings"
+            i18nKey="integrationsPage.tipBanner"
+            components={{
+              tip: <span className="text-body-medium-default" />,
+            }}
+          />
         </Notice>
       )}
 
@@ -274,8 +301,8 @@ function IntegrationsPanelInner() {
           type="text"
           value={searchText}
           onChange={(e) => setSearchText(e.target.value)}
-          placeholder="Search Integrations"
-          aria-label="Search integrations"
+          placeholder={t("integrationsPage.searchPlaceholder")}
+          aria-label={t("integrationsPage.searchAriaLabel")}
           leftIcon={<Search className="h-3.5 w-3.5" aria-hidden />}
           fullWidth
           wrapperClassName="flex-1"
@@ -294,24 +321,24 @@ function IntegrationsPanelInner() {
         {loading ? (
           <div className="flex items-center gap-2 py-6 text-body-medium-lighter text-[var(--content-tertiary)]">
             <Loader2 className="h-4 w-4 animate-spin" />
-            <span>Loading...</span>
+            <span>{t("integrationsPage.loading")}</span>
           </div>
         ) : providersError ? (
           <p className="text-body-medium-lighter text-[var(--content-tertiary)]">
-            Failed to load integrations. Please try again.
+            {t("integrationsPage.loadFailed")}
           </p>
         ) : !assistant ? (
           <p className="text-body-medium-lighter text-[var(--content-tertiary)]">
-            No assistant found. Hatch an assistant to connect integrations.
+            {t("integrationsPage.noAssistant")}
           </p>
         ) : filteredProviders.length === 0 ? (
           <div className="flex flex-col items-center gap-2 rounded-lg border border-dashed border-[var(--border-element)] px-4 py-12 text-center">
             <Search className="h-6 w-6 text-[var(--content-disabled)]" />
             <p className="text-body-medium-default text-[var(--content-default)]">
-              {emptyStateTitle}
+              {emptyTitle}
             </p>
             <p className="text-body-small-default text-[var(--content-tertiary)]">
-              {emptyStateSubtitle}
+              {emptySubtitle}
             </p>
           </div>
         ) : (
@@ -357,6 +384,7 @@ function IntegrationsPanelInner() {
 }
 
 export function IntegrationsPage() {
+  const { t } = useTranslation("settings");
   const [searchParams, setSearchParams] = useSearchParams();
   const activeTab = parseIntegrationsTab(searchParams.get("tab"));
 
@@ -375,8 +403,10 @@ export function IntegrationsPage() {
     <div className="space-y-6">
       <Tabs.Root value={activeTab} onValueChange={handleTabChange}>
         <Tabs.List>
-          <Tabs.Trigger value="oauth">OAuth</Tabs.Trigger>
-          <Tabs.Trigger value="mcp">MCP</Tabs.Trigger>
+          <Tabs.Trigger value="oauth">
+            {t("integrationsPage.tabOAuth")}
+          </Tabs.Trigger>
+          <Tabs.Trigger value="mcp">{t("integrationsPage.tabMcp")}</Tabs.Trigger>
         </Tabs.List>
         <Tabs.Panel value="oauth" className="pt-4">
           <Suspense>

--- a/clients/web/src/domains/settings/pages/listening-language-card.tsx
+++ b/clients/web/src/domains/settings/pages/listening-language-card.tsx
@@ -32,8 +32,10 @@ import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { SttLanguagePickerModal } from "@/components/speech/stt-language-picker-modal";
 import { useSttLanguageSelection } from "@/components/speech/use-stt-language-selection";
 import { sttLanguageLabelForCode } from "@/lib/stt/language-catalog";
+import { useTranslation } from "@/i18n";
 
 export function ListeningLanguageCard() {
+  const { t } = useTranslation("settings");
   const assistantId = useActiveAssistantId();
   const {
     available,
@@ -50,11 +52,11 @@ export function ListeningLanguageCard() {
 
   return (
     <DetailCard
-      title="Listening language"
+      title={t("listeningLanguageCard.title")}
       // Named for what it governs rather than for the setting's key: people
       // arrive here having noticed the assistant mishearing them, not having
       // gone looking for a speech-recognition parameter.
-      subtitle="The language you speak to your assistant. Applies from your next spoken turn."
+      subtitle={t("listeningLanguageCard.subtitle")}
     >
       <div className="flex items-center gap-3">
         <span className="min-w-0 text-body-medium-lighter text-[var(--content-default)]">
@@ -65,13 +67,13 @@ export function ListeningLanguageCard() {
           onClick={() => setPickerOpen(true)}
           className="shrink-0"
         >
-          Change
+          {t("listeningLanguageCard.change")}
         </Button>
       </div>
       <SttLanguagePickerModal
         open={pickerOpen}
         onOpenChange={setPickerOpen}
-        title="Listening language"
+        title={t("listeningLanguageCard.title")}
         currentCode={currentCode}
         configuredProviderId={configuredProviderId}
         selectLanguage={selectLanguage}

--- a/clients/web/src/domains/settings/pages/notifications-page.tsx
+++ b/clients/web/src/domains/settings/pages/notifications-page.tsx
@@ -2,10 +2,12 @@ import { BellRing } from "lucide-react";
 import { Navigate } from "react-router";
 
 import { AndroidNotificationSettingsCard } from "@/domains/settings/components/android-notification-settings-card";
+import { useTranslation } from "@/i18n";
 import { useIsNativeAndroid } from "@/runtime/platform-detection";
 import { routes } from "@/utils/routes";
 
 export function NotificationsPage() {
+  const { t } = useTranslation("settings");
   const isNativeAndroid = useIsNativeAndroid();
 
   if (!isNativeAndroid) {
@@ -20,10 +22,10 @@ export function NotificationsPage() {
         </span>
         <div className="min-w-0">
           <h1 className="text-title-medium text-[var(--content-emphasised)]">
-            Notifications
+            {t("notificationsPage.title")}
           </h1>
           <p className="mt-1 text-body-medium-lighter text-[var(--content-secondary)]">
-            Manage how Vellum notifies you on this Android device.
+            {t("notificationsPage.description")}
           </p>
         </div>
       </div>

--- a/clients/web/src/domains/settings/pages/privacy-page.tsx
+++ b/clients/web/src/domains/settings/pages/privacy-page.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import { DetailCard } from "@/components/detail-card";
 import { SettingRow } from "@/components/setting-row";
@@ -13,6 +13,7 @@ import { MediaEmbedsCard } from "@/domains/settings/components/media-embeds-card
 import { RiskToleranceSettings } from "@/domains/settings/components/risk-tolerance-settings";
 import { TrustRules } from "@/domains/settings/components/trust-rules/trust-rules";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
+import { Trans, useTranslation } from "@/i18n";
 import {
   useAuthStore,
   useHasConfirmedPlatformSession,
@@ -22,15 +23,15 @@ import { savePreferenceToggle } from "@/lib/consent/consent-persistence";
 import { legalUrl, routes } from "@/utils/routes";
 import { Select } from "@vellumai/design-library/components/select";
 
-const RETENTION_OPTIONS: { value: string; label: string }[] = [
-  { value: "dontRetain", label: "Don't retain" },
-  { value: "oneHour", label: "1 hour" },
-  { value: "oneDay", label: "1 day" },
-  { value: "sevenDays", label: "7 days" },
-  { value: "thirtyDays", label: "30 days" },
-  { value: "ninetyDays", label: "90 days" },
-  { value: "keepForever", label: "Keep forever" },
-];
+const RETENTION_OPTIONS = [
+  { value: "dontRetain", labelKey: "privacyPage.retentionDontRetain" },
+  { value: "oneHour", labelKey: "privacyPage.retentionOneHour" },
+  { value: "oneDay", labelKey: "privacyPage.retentionOneDay" },
+  { value: "sevenDays", labelKey: "privacyPage.retentionSevenDays" },
+  { value: "thirtyDays", labelKey: "privacyPage.retentionThirtyDays" },
+  { value: "ninetyDays", labelKey: "privacyPage.retentionNinetyDays" },
+  { value: "keepForever", labelKey: "privacyPage.retentionKeepForever" },
+] as const;
 
 const DEFAULT_RETENTION_ID = "thirtyDays";
 
@@ -41,6 +42,7 @@ function Divider() {
 }
 
 export function PrivacyPage() {
+  const { t } = useTranslation("settings");
   // platformHostedOnly so the divider visibility matches the gate inside
   // `AccessConsentSetting` exactly.
   const platformGate = usePlatformGate({ platformHostedOnly: true });
@@ -61,6 +63,15 @@ export function PrivacyPage() {
   const shareDiagnosticsChecked = shareDiagnostics ?? true;
   const [retentionId, setRetentionId] = useState(() =>
     getDeviceSetting("llmLogRetention", DEFAULT_RETENTION_ID),
+  );
+
+  const retentionOptions = useMemo(
+    () =>
+      RETENTION_OPTIONS.map((option) => ({
+        value: option.value,
+        label: t(option.labelKey),
+      })),
+    [t],
   );
 
   const handleAnalyticsToggle = () => {
@@ -90,21 +101,23 @@ export function PrivacyPage() {
       <RiskToleranceSettings />
       <MediaEmbedsCard />
       <DetailCard
-        title="Privacy"
+        title={t("privacyPage.title")}
         subtitle={
           hasPlatformSession ? (
-            <>
-              View details about what data we collect and how it's used in our{" "}
-              <a
-                href={legalUrl(routes.docs.legal.privacyPolicy)}
-                target="_blank"
-                rel="noreferrer"
-                className="underline"
-              >
-                privacy policy
-              </a>
-              .
-            </>
+            <Trans
+              ns="settings"
+              i18nKey="privacyPage.subtitleWithPolicy"
+              components={{
+                policyLink: (
+                  <a
+                    href={legalUrl(routes.docs.legal.privacyPolicy)}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="underline"
+                  />
+                ),
+              }}
+            />
           ) : undefined
         }
       >
@@ -112,16 +125,16 @@ export function PrivacyPage() {
           {showShareConsent && (
             <>
               <SettingRow
-                label="Share Analytics"
-                helperText="Send aggregated product usage data"
+                label={t("privacyPage.shareAnalyticsLabel")}
+                helperText={t("privacyPage.shareAnalyticsHelper")}
                 checked={shareAnalyticsChecked}
                 onChange={handleAnalyticsToggle}
                 variant="toggle-trailing"
               />
               <Divider />
               <SettingRow
-                label="Share Diagnostics"
-                helperText="Send crash reports, conversation traces, and session replay data"
+                label={t("privacyPage.shareDiagnosticsLabel")}
+                helperText={t("privacyPage.shareDiagnosticsHelper")}
                 checked={shareDiagnosticsChecked}
                 onChange={handleDiagnosticsToggle}
                 variant="toggle-trailing"
@@ -141,20 +154,17 @@ export function PrivacyPage() {
               htmlFor="llm-log-retention"
               className="block text-body-medium-default text-[var(--content-default)]"
             >
-              LLM Request Log Retention
+              {t("privacyPage.llmLogRetentionLabel")}
             </label>
             <div className="mt-2" style={{ maxWidth: 280 }}>
               <Select
                 value={retentionId}
                 onChange={handleRetentionChange}
-                options={RETENTION_OPTIONS}
+                options={retentionOptions}
               />
             </div>
             <p className="mt-2 text-body-small-default text-[var(--content-tertiary)]">
-              How long to keep LLM request and response logs on this device.
-              These logs record the prompts and completions sent to model
-              providers and are used for debugging. Shorter retention improves
-              privacy; longer retention helps troubleshoot issues.
+              {t("privacyPage.llmLogRetentionDescription")}
             </p>
           </div>
         </div>

--- a/clients/web/src/domains/settings/pages/sounds-sections.tsx
+++ b/clients/web/src/domains/settings/pages/sounds-sections.tsx
@@ -7,7 +7,6 @@ import type { AvailableSound } from "@/lib/sounds/api";
 import {
   defaultSoundsConfig,
   displayLabelForFilename,
-  SOUND_EVENT_DISPLAY_NAMES,
   SOUND_EVENT_IDS,
   type SoundEventConfig,
   type SoundEventId,
@@ -21,10 +20,38 @@ import {
   soundsConfigPutMutation,
 } from "@/generated/daemon/@tanstack/react-query.gen";
 import type { SoundsConfigGetResponse } from "@/generated/daemon/types.gen";
+import { useTranslation } from "@/i18n";
 import { Card } from "@vellumai/design-library/components/card";
 import { Toggle } from "@vellumai/design-library/components/toggle";
 
 type SoundsConfig = SoundsConfigGetResponse;
+
+type SettingsTranslate = ReturnType<typeof useTranslation<"settings">>["t"];
+
+const SOUND_EVENT_LABEL_KEYS = {
+  task_complete: "soundsSections.soundEventTaskComplete",
+  needs_input: "soundsSections.soundEventNeedsInput",
+  task_failed: "soundsSections.soundEventTaskFailed",
+  notification: "soundsSections.soundEventNotification",
+  new_conversation: "soundsSections.soundEventNewConversation",
+  message_sent: "soundsSections.soundEventMessageSent",
+  character_poke: "soundsSections.soundEventCharacterPoke",
+  random: "soundsSections.soundEventRandom",
+} as const satisfies Record<
+  SoundEventId,
+  | "soundsSections.soundEventTaskComplete"
+  | "soundsSections.soundEventNeedsInput"
+  | "soundsSections.soundEventTaskFailed"
+  | "soundsSections.soundEventNotification"
+  | "soundsSections.soundEventNewConversation"
+  | "soundsSections.soundEventMessageSent"
+  | "soundsSections.soundEventCharacterPoke"
+  | "soundsSections.soundEventRandom"
+>;
+
+function soundEventDisplayName(event: SoundEventId, t: SettingsTranslate): string {
+  return t(SOUND_EVENT_LABEL_KEYS[event]);
+}
 
 function ToggleRow({
   label,
@@ -74,6 +101,7 @@ function SoundEventRow({
   onAddSound,
   onRemoveSound,
   onPreview,
+  t,
 }: {
   event: SoundEventId;
   eventConfig: SoundEventConfig;
@@ -83,8 +111,10 @@ function SoundEventRow({
   onAddSound: (filename: string) => void;
   onRemoveSound: (filename: string) => void;
   onPreview: (filename: string) => void;
+  t: SettingsTranslate;
 }) {
   const [pickerOpen, setPickerOpen] = useState(false);
+  const eventName = soundEventDisplayName(event, t);
 
   const remaining = availableSounds.filter(
     (s) => !eventConfig.sounds.includes(s.filename),
@@ -95,13 +125,13 @@ function SoundEventRow({
     <div className="py-3">
       <div className="flex items-center justify-between gap-3">
         <span className="text-body-medium-lighter text-[var(--content-default)]">
-          {SOUND_EVENT_DISPLAY_NAMES[event]}
+          {eventName}
         </span>
         <Toggle
           checked={eventConfig.enabled}
           disabled={!globalEnabled}
           onChange={onToggle}
-          label={`Enable ${SOUND_EVENT_DISPLAY_NAMES[event]}`}
+          label={t("soundsSections.enableEvent", { eventName })}
         />
       </div>
 
@@ -109,7 +139,7 @@ function SoundEventRow({
         <div className="mt-2 space-y-1 pl-2">
           {eventConfig.sounds.length === 0 ? (
             <p className="text-body-small-default text-[var(--content-tertiary)]">
-              Default Blip
+              {t("soundsSections.defaultBlip")}
             </p>
           ) : (
             eventConfig.sounds.map((filename) => (
@@ -128,7 +158,9 @@ function SoundEventRow({
                     type="button"
                     onClick={() => onPreview(filename)}
                     className="inline-flex items-center rounded-md px-1.5 py-0.5 text-body-small-default text-[var(--content-tertiary)] hover:bg-[var(--surface-base)] dark:text-[var(--content-disabled)] dark:hover:bg-[var(--ghost-hover)]"
-                    aria-label={`Preview ${filename}`}
+                    aria-label={t("soundsSections.previewSoundAriaLabel", {
+                      filename,
+                    })}
                   >
                     <Play className="h-3 w-3" />
                   </button>
@@ -136,7 +168,9 @@ function SoundEventRow({
                     type="button"
                     onClick={() => onRemoveSound(filename)}
                     className="inline-flex items-center rounded-md px-1.5 py-0.5 text-body-small-default text-[var(--content-tertiary)] hover:bg-[var(--surface-base)] dark:text-[var(--content-disabled)] dark:hover:bg-[var(--ghost-hover)]"
-                    aria-label={`Remove ${filename}`}
+                    aria-label={t("soundsSections.removeSoundAriaLabel", {
+                      filename,
+                    })}
                   >
                     <Trash2 className="h-3 w-3" />
                   </button>
@@ -147,8 +181,7 @@ function SoundEventRow({
 
           {availableSounds.length === 0 ? (
             <p className="text-body-small-default italic text-[var(--content-disabled)]">
-              No sound files yet. Drop audio files into data/sounds/ in your
-              workspace.
+              {t("soundsSections.noSoundFiles")}
             </p>
           ) : allAdded ? (
             <button
@@ -156,7 +189,7 @@ function SoundEventRow({
               disabled
               className="inline-flex items-center gap-1 rounded-md border border-[var(--border-base)] bg-white px-2 py-1 text-body-small-default text-[var(--content-disabled)] disabled:cursor-not-allowed dark:bg-[var(--surface-lift)] dark:text-[var(--content-tertiary)]"
             >
-              All sounds added
+              {t("soundsSections.allSoundsAdded")}
             </button>
           ) : (
             <div className="relative inline-block">
@@ -165,7 +198,7 @@ function SoundEventRow({
                 onClick={() => setPickerOpen((v) => !v)}
                 className="inline-flex items-center gap-1 rounded-md border border-[var(--border-base)] bg-white px-2 py-1 text-body-small-default text-[var(--content-default)] hover:bg-[var(--surface-base)] dark:bg-[var(--surface-lift)] dark:hover:bg-[var(--ghost-hover)]"
               >
-                Add sound
+                {t("soundsSections.addSound")}
                 <ChevronDown className="h-3 w-3" />
               </button>
               {pickerOpen && (
@@ -198,6 +231,7 @@ function SoundEventRow({
 }
 
 export function SoundsSections() {
+  const { t } = useTranslation("settings");
   const queryClient = useQueryClient();
   const assistantId = useActiveAssistantId();
 
@@ -323,15 +357,15 @@ export function SoundsSections() {
     <div className="space-y-6">
       <Card>
         <ToggleRow
-          label="Enable sound effects"
-          description="Master switch for every event-driven sound."
+          label={t("soundsSections.enableSoundEffects")}
+          description={t("soundsSections.enableSoundEffectsDescription")}
           checked={config.globalEnabled}
           onChange={setGlobalEnabled}
         />
         <Divider />
         <div className="flex items-center gap-3 py-3">
           <span className="text-body-medium-lighter text-[var(--content-default)]">
-            Volume
+            {t("soundsSections.volume")}
           </span>
           <input
             type="range"
@@ -363,7 +397,7 @@ export function SoundsSections() {
             }}
             className="h-1 w-48 cursor-pointer"
             disabled={!config.globalEnabled}
-            aria-label="Sound effect volume"
+            aria-label={t("soundsSections.volumeAriaLabel")}
           />
           <span className="tabular-nums text-body-small-default text-[var(--content-tertiary)]">
             {Math.round(displayVolume * 100)}%
@@ -372,7 +406,7 @@ export function SoundsSections() {
         <Divider />
         <div className="flex items-center justify-between py-3">
           <span className="text-body-medium-lighter text-[var(--content-default)]">
-            Preview default blip
+            {t("soundsSections.previewDefaultBlip")}
           </span>
           <button
             type="button"
@@ -381,7 +415,7 @@ export function SoundsSections() {
             className="inline-flex items-center gap-1.5 rounded-md border border-[var(--border-base)] bg-white px-3 py-1.5 text-body-medium-lighter text-[var(--content-default)] hover:bg-[var(--surface-base)] disabled:cursor-not-allowed disabled:opacity-50 dark:bg-[var(--surface-lift)] dark:hover:bg-[var(--ghost-hover)]"
           >
             <Play className="h-3.5 w-3.5" />
-            Preview
+            {t("soundsSections.preview")}
           </button>
         </div>
       </Card>
@@ -389,11 +423,10 @@ export function SoundsSections() {
       <Card>
         <div className="pb-2">
           <h3 className="text-title-small text-[var(--content-default)]">
-            Sound Events
+            {t("soundsSections.soundEventsTitle")}
           </h3>
           <p className="text-body-small-default text-[var(--content-tertiary)]">
-            Add one or more sounds per event. When multiple are configured, one
-            plays at random.
+            {t("soundsSections.soundEventsDescription")}
           </p>
         </div>
         <div className="divide-y divide-[var(--border-base)]">
@@ -412,6 +445,7 @@ export function SoundsSections() {
                 removeSoundFromEvent(event, filename)
               }
               onPreview={(filename) => previewFile(filename)}
+              t={t}
             />
           ))}
         </div>

--- a/clients/web/src/domains/settings/pages/voice-page.tsx
+++ b/clients/web/src/domains/settings/pages/voice-page.tsx
@@ -23,6 +23,7 @@ import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { useManagedVoiceSelection } from "@/components/speech/use-managed-voice-selection";
 
 import { DetailCard } from "@/components/detail-card";
+import { useTranslation } from "@/i18n";
 import {
   DEFAULT_INTERRUPT_SENSITIVITY,
   DEFAULT_PAUSE_BEFORE_REPLY_MS,
@@ -113,16 +114,21 @@ export function VoicePage() {
 }
 
 export function VoiceSections() {
+  const { t } = useTranslation("settings");
+
   return (
     <div className="flex flex-col gap-8">
-      <VoiceSection heading="Output" description="How your assistant sounds.">
+      <VoiceSection
+        heading={t("voicePage.sectionOutputHeading")}
+        description={t("voicePage.sectionOutputDescription")}
+      >
         <VoicePickerCard />
         <SpeechServicesBanner />
       </VoiceSection>
 
       <VoiceSection
-        heading="Input"
-        description="How you talk to your assistant."
+        heading={t("voicePage.sectionInputHeading")}
+        description={t("voicePage.sectionInputDescription")}
       >
         <MicrophoneCard />
         <ListeningLanguageCard />
@@ -130,7 +136,7 @@ export function VoiceSections() {
         <ConversationTuningCard />
       </VoiceSection>
 
-      <VoiceSection heading="Captions">
+      <VoiceSection heading={t("voicePage.sectionCaptionsHeading")}>
         <CaptionsCard />
       </VoiceSection>
     </div>
@@ -148,6 +154,7 @@ export function VoiceSections() {
  * to offer — a second copy of the sentence directly beneath it just repeats.
  */
 function SpeechServicesBanner() {
+  const { t } = useTranslation("settings");
   const { available } = useManagedVoiceSelection(useActiveAssistantId());
 
   if (!available) {
@@ -157,14 +164,12 @@ function SpeechServicesBanner() {
   return (
     <div className="flex flex-wrap items-center gap-1.5 px-1 text-body-small-default text-[var(--content-tertiary)]">
       <Info className="h-3.5 w-3.5 shrink-0 text-[var(--content-quiet)]" />
-      <span>
-        Want to use your own API key for STT or TTS, or set a custom voice?
-      </span>
+      <span>{t("voicePage.speechServicesBannerPrompt")}</span>
       <Link
         to={`${routes.settings.ai}#text-to-speech`}
         className="inline-flex items-center gap-1 text-[var(--content-secondary)] underline decoration-[var(--border-element)] underline-offset-2 hover:text-[var(--content-default)]"
       >
-        Set it up in Models &amp; Services
+        {t("voicePage.speechServicesBannerLink")}
         <ArrowUpRight className="h-3 w-3" />
       </Link>
     </div>
@@ -198,12 +203,14 @@ function VoiceSection({
 }
 
 function CaptionsCard() {
+  const { t } = useTranslation("settings");
+
   return (
     <DetailCard
-      title="Captions"
+      title={t("voicePage.captionsTitle")}
       // Named to match the voice room's own "Captions" toggle — same two prefs,
       // so calling it "Transcription" here sent people hunting.
-      subtitle="Show live text of what you and the assistant say during a voice conversation."
+      subtitle={t("voicePage.captionsSubtitle")}
     >
       <div className="flex flex-col gap-2">
         <VoiceTranscriptToggles showDescription />
@@ -223,6 +230,7 @@ function CaptionsCard() {
 const SYSTEM_DEFAULT_DEVICE = "";
 
 function MicrophoneCard() {
+  const { t } = useTranslation("settings");
   const [devices, setDevices] = useState<MediaDeviceInfo[]>([]);
   const [needsPermission, setNeedsPermission] = useState(false);
   // Whether the browser has given us a list we can draw conclusions from.
@@ -297,7 +305,9 @@ function MicrophoneCard() {
   const options = useMemo(() => {
     const live = devices.map((device, index) => ({
       value: device.deviceId,
-      label: device.label || `Microphone ${index + 1}`,
+      label:
+        device.label ||
+        t("voicePage.microphoneFallbackLabel", { index: index + 1 }),
     }));
     // A saved device absent from the list keeps its own row rather than being
     // displayed as System Default: capture already falls back, so the
@@ -311,20 +321,20 @@ function MicrophoneCard() {
       deviceId !== SYSTEM_DEFAULT_DEVICE &&
       !live.some((option) => option.value === deviceId);
     return [
-      { value: null, label: "System Default" },
+      { value: null, label: t("voicePage.systemDefault") },
       ...live,
       ...(savedIsAbsent
         ? [
             {
               value: deviceId,
               label: deviceListIsKnown
-                ? "Saved microphone (not connected)"
-                : "Saved microphone",
+                ? t("voicePage.savedMicrophoneNotConnected")
+                : t("voicePage.savedMicrophone"),
             },
           ]
         : []),
     ];
-  }, [devices, deviceId, deviceListIsKnown]);
+  }, [devices, deviceId, deviceListIsKnown, t]);
 
   const handleChange = useCallback((next: string) => {
     setDeviceId(next);
@@ -339,8 +349,8 @@ function MicrophoneCard() {
 
   return (
     <DetailCard
-      title="Microphone"
-      subtitle="Which input device is used for dictation and voice conversations."
+      title={t("voicePage.microphoneTitle")}
+      subtitle={t("voicePage.microphoneSubtitle")}
     >
       <div className="flex flex-col gap-3">
         <div className="max-w-xs">
@@ -349,16 +359,16 @@ function MicrophoneCard() {
             value={selectedValue}
             onChange={handleChange}
             onSelectNone={() => handleChange(SYSTEM_DEFAULT_DEVICE)}
-            aria-label="Microphone"
+            aria-label={t("voicePage.microphoneAriaLabel")}
           />
         </div>
         {needsPermission && (
           <div className="flex flex-wrap items-center gap-2">
             <Button variant="outlined" onClick={requestMicAccess}>
-              Allow Microphone Access
+              {t("voicePage.allowMicrophoneAccess")}
             </Button>
             <span className={labelClasses}>
-              Grant microphone access to list your available input devices.
+              {t("voicePage.grantMicrophoneAccessHint")}
             </span>
           </div>
         )}
@@ -368,6 +378,7 @@ function MicrophoneCard() {
 }
 
 function PushToTalkCard() {
+  const { t } = useTranslation("settings");
   const fnPushToTalkConfigurable = canConfigureFnPushToTalk();
   const [activator, setActivator] = useState<PTTActivator>(() => {
     const raw = getLocalSetting(LS_PTT_ACTIVATION_KEY, "");
@@ -532,8 +543,8 @@ function PushToTalkCard() {
 
   return (
     <DetailCard
-      title="Push to Talk"
-      subtitle="Hold the activation key to dictate text or start a voice conversation."
+      title={t("voicePage.pushToTalkTitle")}
+      subtitle={t("voicePage.pushToTalkSubtitle")}
     >
       <div className="flex flex-col gap-4">
         <Toggle
@@ -551,12 +562,14 @@ function PushToTalkCard() {
               selectActivator({ kind: "off" });
             }
           }}
-          label="Enable Push to Talk"
+          label={t("voicePage.enablePushToTalk")}
         />
 
         {pttEnabled && (
           <div className="flex flex-col gap-2">
-            <span className={labelClasses}>Activation Key:</span>
+            <span className={labelClasses}>
+              {t("voicePage.activationKeyLabel")}
+            </span>
             <div
               ref={recordingZoneRef}
               tabIndex={isRecording ? 0 : -1}
@@ -580,7 +593,7 @@ function PushToTalkCard() {
                   label={
                     pendingModifiers.length > 0
                       ? modifierLabel(pendingModifiers)
-                      : "Press any key…"
+                      : t("voicePage.pressAnyKey")
                   }
                   selected
                   recording
@@ -588,7 +601,11 @@ function PushToTalkCard() {
                 />
               ) : (
                 <ActivationKeyOption
-                  label={isCustom ? activatorDisplayName(activator) : "Custom"}
+                  label={
+                    isCustom
+                      ? activatorDisplayName(activator)
+                      : t("voicePage.customKey")
+                  }
                   selected={isCustom}
                   onClick={beginRecording}
                 />
@@ -598,12 +615,7 @@ function PushToTalkCard() {
             {showFocusedTabNote && (
               <div className="flex items-start gap-1 pt-1 text-body-small-default text-[var(--content-quiet)]">
                 <Info className="mt-0.5 h-3 w-3 shrink-0" />
-                <span>
-                  Push-to-Talk only works while this tab is focused, and
-                  browsers may intercept some shortcuts (e.g. Ctrl+T) before the
-                  page can see them. For always-on PTT, use the Vellum desktop
-                  app.
-                </span>
+                <span>{t("voicePage.focusedTabNote")}</span>
               </div>
             )}
           </div>
@@ -650,14 +662,6 @@ function ActivationKeyOption({
   );
 }
 
-const INTERRUPT_SENSITIVITY_ITEMS: {
-  value: InterruptSensitivity;
-  label: string;
-}[] = [
-  { value: "low", label: "Low" },
-  { value: "medium", label: "Medium" },
-  { value: "high", label: "High" },
-];
 
 /**
  * The two turn-taking dials, in one card because they're one idea — where the
@@ -670,22 +674,35 @@ const INTERRUPT_SENSITIVITY_ITEMS: {
  * per-row "Default" state and the Reset affordance.
  */
 function ConversationTuningCard() {
+  const { t } = useTranslation("settings");
   const pauseMs = useVoicePrefsStore.use.pauseBeforeReplyMs();
   const setPauseMs = useVoicePrefsStore.use.setPauseBeforeReplyMs();
   const sensitivity = useVoicePrefsStore.use.interruptSensitivity();
   const setSensitivity = useVoicePrefsStore.use.setInterruptSensitivity();
 
+  const interruptSensitivityItems = useMemo(
+    () => [
+      { value: "low" as const, label: t("voicePage.interruptSensitivityLow") },
+      {
+        value: "medium" as const,
+        label: t("voicePage.interruptSensitivityMedium"),
+      },
+      { value: "high" as const, label: t("voicePage.interruptSensitivityHigh") },
+    ],
+    [t],
+  );
+
   const anySet = pauseMs !== null || sensitivity !== null;
 
   return (
     <DetailCard
-      title="Turn taking"
-      subtitle="Where your turn ends and the assistant's begins. Applies to hands-free conversations — under push to talk, the key decides."
+      title={t("voicePage.turnTakingTitle")}
+      subtitle={t("voicePage.turnTakingSubtitle")}
     >
       <div className="flex flex-col gap-5">
         <TuningRow
-          label="Pause before reply"
-          description="How long the assistant waits after you stop speaking before it replies. A longer pause lets you gather your thoughts mid-sentence without being cut off."
+          label={t("voicePage.pauseBeforeReplyLabel")}
+          description={t("voicePage.pauseBeforeReplyDescription")}
           isDefault={pauseMs === null}
         >
           <div className="max-w-xs">
@@ -703,22 +720,22 @@ function ConversationTuningCard() {
               formatValue={(value) =>
                 `${(typeof value === "number" ? value : value[0]).toFixed(1)}s`
               }
-              aria-label="Pause before reply"
+              aria-label={t("voicePage.pauseBeforeReplyAriaLabel")}
             />
           </div>
         </TuningRow>
 
         <TuningRow
-          label="Interrupt sensitivity"
-          description="How easily talking over the assistant interrupts it. Lower it if the assistant cuts itself off on background noise or filler words; raise it to interrupt more quickly."
+          label={t("voicePage.interruptSensitivityLabel")}
+          description={t("voicePage.interruptSensitivityDescription")}
           isDefault={sensitivity === null}
         >
           <div className="max-w-xs">
             <SegmentControl<InterruptSensitivity>
-              items={INTERRUPT_SENSITIVITY_ITEMS}
+              items={interruptSensitivityItems}
               value={sensitivity ?? DEFAULT_INTERRUPT_SENSITIVITY}
               onChange={setSensitivity}
-              ariaLabel="Interrupt sensitivity"
+              ariaLabel={t("voicePage.interruptSensitivityAriaLabel")}
             />
           </div>
         </TuningRow>
@@ -732,7 +749,7 @@ function ConversationTuningCard() {
                 setSensitivity(null);
               }}
             >
-              Reset to defaults
+              {t("voicePage.resetToDefaults")}
             </Button>
           </div>
         )}
@@ -752,6 +769,8 @@ function TuningRow({
   isDefault: boolean;
   children: ReactNode;
 }) {
+  const { t } = useTranslation("settings");
+
   return (
     <div className="flex flex-col gap-2">
       <div className="flex items-center gap-2">
@@ -760,7 +779,7 @@ function TuningRow({
         </span>
         {isDefault && (
           <span className="shrink-0 rounded-full bg-[var(--surface-active)] px-2 py-0.5 text-body-small-default text-[var(--content-tertiary)]">
-            Default
+            {t("voicePage.defaultBadge")}
           </span>
         )}
       </div>

--- a/clients/web/src/domains/settings/pages/voice-picker-card.tsx
+++ b/clients/web/src/domains/settings/pages/voice-picker-card.tsx
@@ -21,12 +21,13 @@ import { DetailCard } from "@/components/detail-card";
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { ByoVoiceNote } from "@/components/speech/byo-voice-note";
 import { useManagedVoiceSelection } from "@/components/speech/use-managed-voice-selection";
-import { MANAGED_VOICE_CREDITS_NOTE } from "@/lib/tts/managed-voice-catalog";
 import { VoiceLabel } from "@/components/speech/voice-list";
 import { VoicePickerModal } from "@/components/speech/voice-picker-modal";
+import { useTranslation } from "@/i18n";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 
 export function VoicePickerCard() {
+  const { t } = useTranslation("settings");
   const assistantId = useActiveAssistantId();
   const { available, voices, currentModel } =
     useManagedVoiceSelection(assistantId);
@@ -37,11 +38,16 @@ export function VoicePickerCard() {
   // input cards below stay plain — those are yours). Falls back to a bare
   // "Voice" when the assistant has no name yet, never "'s Voice".
   const assistantName = useAssistantIdentityStore.use.name();
-  const voiceTitle = assistantName ? `${assistantName}’s Voice` : "Voice";
+  const voiceTitle = assistantName
+    ? t("voicePickerCard.titleWithName", { name: assistantName })
+    : t("voicePickerCard.title");
 
   if (available && current) {
     return (
-      <DetailCard title={voiceTitle} subtitle={MANAGED_VOICE_CREDITS_NOTE}>
+      <DetailCard
+        title={voiceTitle}
+        subtitle={t("voicePickerCard.creditsNote")}
+      >
         <div className="flex items-center gap-3">
           <VoiceLabel
             description={current.description}
@@ -56,7 +62,7 @@ export function VoicePickerCard() {
             onClick={() => setPickerOpen(true)}
             className="shrink-0"
           >
-            Change
+            {t("voicePickerCard.changeButton")}
           </Button>
         </div>
         <VoicePickerModal

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -27,6 +27,16 @@
     "topUpCancelToast": "Checkout was cancelled. No credits were added.",
     "upgradeCancelToast": "Upgrade canceled. No changes to your plan."
   },
+  "bookmarksPage": {
+    "emptyDescription": "Hover any message and click the bookmark icon to save it here.",
+    "emptyTitle": "No bookmarks",
+    "errorDescription": "Something went wrong. Please try again.",
+    "errorTitle": "Failed to load bookmarks",
+    "open": "Open",
+    "removeBookmark": "Remove bookmark",
+    "retry": "Retry",
+    "untitledConversation": "Untitled conversation"
+  },
   "bulkOverrideSwapModal": {
     "affectedSummary": "{count, plural, one {# action currently uses {profile}} other {# actions currently use {profile}}}",
     "applyTo": "{count, plural, one {Apply to # action} other {Apply to # actions}}",
@@ -94,6 +104,33 @@
     "tryAgain": "Try again",
     "viewPlans": "View plans"
   },
+  "communityPage": {
+    "communityHubDescription": "Showcases, guides, and projects shared by the community.",
+    "communityHubTitle": "Community Hub",
+    "discordBenefitAnswers": "Get answers faster from the community",
+    "discordBenefitFeedback": "Share feedback and request features",
+    "discordBenefitTeam": "Talk directly with the team",
+    "discordLabel": "Discord",
+    "discordSubtitle": "Talk to the team, share feedback, request features, and get answers faster.",
+    "discordTitle": "Join our community",
+    "followOnXDescription": "Product updates, releases, and behind-the-scenes.",
+    "followOnXTitle": "Follow on X",
+    "heroDescription": "Vellum is built in the open with a growing community of developers, designers, and tinkerers. Here's how to get involved.",
+    "heroTag": "Community",
+    "heroTitle": "Build with us, in the open.",
+    "joinDiscord": "Join Discord",
+    "moreFromVellum": "More from Vellum",
+    "openSourceBenefitContribute": "Contribute fixes and new features",
+    "openSourceBenefitIssues": "Open issues and report bugs",
+    "openSourceBenefitStar": "Star the repo to follow updates",
+    "openSourceLabel": "Open Source",
+    "openSourceSubtitle": "Read the source, star the repo, and contribute fixes and features on GitHub.",
+    "openSourceTitle": "Vellum is open source",
+    "starOnGitHub": "Star on GitHub",
+    "viewSource": "View source",
+    "youtubeChannelDescription": "Walkthroughs, tutorials, and product deep-dives.",
+    "youtubeChannelTitle": "YouTube channel"
+  },
   "completeState": {
     "assistantFallbackName": "your assistant",
     "returnTo": "Return to {assistantName}",
@@ -128,6 +165,13 @@
     "genericDescriptor": "Select custom CPU power, Ram and Storage. Or just throw in some tokens.",
     "prompt": "Need something more tailored to your needs?",
     "title": "Custom Plan"
+  },
+  "developerPage": {
+    "sectionsAriaLabel": "Developer sections",
+    "tabFeatureFlags": "Feature Flags",
+    "tabLifecycle": "Assistant Lifecycle",
+    "tabMemory": "Memory",
+    "tabSentry": "Sentry Testing"
   },
   "domainStep": {
     "continue": "Continue",
@@ -210,6 +254,32 @@
     "confirm": "Downgrade to Base",
     "title": "Downgrade to Base?"
   },
+  "generalPage": {
+    "chooseAssistant": "Choose Assistant",
+    "computeResourcesLoginNotice": "Log in to the Vellum platform to manage compute resources.",
+    "computeResourcesSubtitle": "Monitor resource usage and manage your assistant's compute profile.",
+    "computeResourcesTitle": "Compute & Resources",
+    "current": "Current",
+    "customize": "Customize",
+    "dangerZoneTitle": "Danger Zone",
+    "preferencesSubtitle": "Customize how Vellum looks and behaves on this device.",
+    "preferencesTitle": "Preferences",
+    "retireAssistantDescription": "Permanently retire this assistant and delete all associated data.",
+    "retireAssistantLoginNotice": "Log in to the Vellum platform to retire this assistant.",
+    "retireAssistantTitle": "Retire Assistant",
+    "sleepPolicyLoginNotice": "Log in to the Vellum platform to manage sleep policy.",
+    "sleepPolicySubtitle": "Control how long this assistant stays awake when idle.",
+    "sleepPolicyTitle": "Sleep Policy",
+    "switchAssistantSubtitle": "Choose which assistant this device is connected to.",
+    "switchAssistantTitle": "Switch Assistant",
+    "twoFactorDescription": "Require a code from an authenticator app when you sign in.",
+    "twoFactorLoginNotice": "Log in to the Vellum platform to manage two-factor authentication.",
+    "twoFactorTitle": "Two-Factor Authentication",
+    "updateWindow": "Update Window",
+    "updatesLoginNotice": "Log in to the Vellum platform to manage software updates.",
+    "versionSubtitle": "Manage your assistant's software version and updates.",
+    "versionTitle": "Version"
+  },
   "imageGenerationCard": {
     "activeModelLabel": "Active Model",
     "apiKeyLabel": "API Key",
@@ -227,10 +297,35 @@
     "vellumNote": "Image generation runs through your Vellum account."
   },
   "integrationsPage": {
-    "filterAriaLabel": "Filter integrations",
+    "accountConnectedToast": "{providerLabel} account connected successfully.",
+    "accountConnectedToastGeneric": "Account connected successfully.",
+    "connectFailedToast": "Failed to connect {providerLabel}.",
+    "connectFailedToastGeneric": "Failed to connect. Please try again.",
+    "emptyAllEnabledTitle": "All Integrations Are Enabled",
+    "emptyDefaultSubtitle": "Check your connection and try again.",
+    "emptyDefaultTitle": "No Integrations Available",
+    "emptyEnabledSubtitle": "Connect an integration to get started.",
+    "emptyEnabledTitle": "No Enabled Integrations",
+    "emptyNotEnabledSubtitle": "All available integrations have been connected.",
+    "emptySearchSubtitle": "No integrations matched \"{query}\"",
+    "emptySearchTitle": "No integrations matched",
     "filterAll": "All",
+    "filterAriaLabel": "Filter integrations",
     "filterEnabled": "Enabled",
-    "filterNotEnabled": "Not Enabled"
+    "filterNotEnabled": "Not Enabled",
+    "loadFailed": "Failed to load integrations. Please try again.",
+    "loading": "Loading...",
+    "noAssistant": "No assistant found. Hatch an assistant to connect integrations.",
+    "oauthErrorDenied": "Authorization was denied. Please try again.",
+    "oauthErrorExchangeFailed": "Failed to complete authorization. Please try again.",
+    "oauthErrorIdentityFailed": "Failed to verify account identity. Please try again.",
+    "oauthErrorStateExpired": "Authorization expired. Please try again.",
+    "oauthErrorStateInvalid": "Authorization state was invalid. Please try again.",
+    "searchAriaLabel": "Search integrations",
+    "searchPlaceholder": "Search Integrations",
+    "tabMcp": "MCP",
+    "tabOAuth": "OAuth",
+    "tipBanner": "<tip>Tip:</tip> You can enable integrations by mentioning them in chat."
   },
   "languageModelCard": {
     "defaultProviderUnavailable": "Your default provider is not available.",
@@ -238,6 +333,11 @@
     "overridesTitle": "Overrides",
     "subtitle": "Profiles choose which model answers. Providers supply access to it",
     "title": "Language Model"
+  },
+  "listeningLanguageCard": {
+    "change": "Change",
+    "subtitle": "The language you speak to your assistant. Applies from your next spoken turn.",
+    "title": "Listening language"
   },
   "manageProfilesBlockedDeleteModal": {
     "actionOverridesTitle": "Action overrides",
@@ -260,6 +360,10 @@
     "summaryThreeClauses": "\"{display}\" {clause1}, {clause2}, and {clause3}. Pick a replacement below and those references move to it, then \"{display}\" is deleted.",
     "summaryTwoClauses": "\"{display}\" {clause1} and {clause2}. Pick a replacement below and those references move to it, then \"{display}\" is deleted.",
     "title": "Choose a Replacement Profile"
+  },
+  "notificationsPage": {
+    "description": "Manage how Vellum notifies you on this Android device.",
+    "title": "Notifications"
   },
   "overridesCallSiteList": {
     "emptySearch": "No actions match your search."
@@ -313,6 +417,23 @@
     "planUpdatedToast": "Plan updated.",
     "startFreeCta": "Start Free",
     "subheading": "Choose the level that matches how much you want it to take on."
+  },
+  "privacyPage": {
+    "llmLogRetentionDescription": "How long to keep LLM request and response logs on this device. These logs record the prompts and completions sent to model providers and are used for debugging. Shorter retention improves privacy; longer retention helps troubleshoot issues.",
+    "llmLogRetentionLabel": "LLM Request Log Retention",
+    "retentionDontRetain": "Don't retain",
+    "retentionKeepForever": "Keep forever",
+    "retentionNinetyDays": "90 days",
+    "retentionOneDay": "1 day",
+    "retentionOneHour": "1 hour",
+    "retentionSevenDays": "7 days",
+    "retentionThirtyDays": "30 days",
+    "shareAnalyticsHelper": "Send aggregated product usage data",
+    "shareAnalyticsLabel": "Share Analytics",
+    "shareDiagnosticsHelper": "Send crash reports, conversation traces, and session replay data",
+    "shareDiagnosticsLabel": "Share Diagnostics",
+    "subtitleWithPolicy": "View details about what data we collect and how it's used in our <policyLink>privacy policy</policyLink>.",
+    "title": "Privacy"
   },
   "profileAdvancedParams": {
     "contextWindowLabel": "Context Window",
@@ -540,6 +661,31 @@
     "verifyingTitle": "DNS records have been provisioned. Waiting for the email provider to verify them - this usually takes a few minutes.",
     "yourOwnLabel": "Your Own"
   },
+  "soundsSections": {
+    "addSound": "Add sound",
+    "allSoundsAdded": "All sounds added",
+    "defaultBlip": "Default Blip",
+    "enableEvent": "Enable {eventName}",
+    "enableSoundEffects": "Enable sound effects",
+    "enableSoundEffectsDescription": "Master switch for every event-driven sound.",
+    "noSoundFiles": "No sound files yet. Drop audio files into data/sounds/ in your workspace.",
+    "preview": "Preview",
+    "previewDefaultBlip": "Preview default blip",
+    "previewSoundAriaLabel": "Preview {filename}",
+    "removeSoundAriaLabel": "Remove {filename}",
+    "soundEventCharacterPoke": "Character Poke",
+    "soundEventMessageSent": "Message Sent",
+    "soundEventNeedsInput": "Needs Input",
+    "soundEventNewConversation": "New Conversation",
+    "soundEventNotification": "Notification",
+    "soundEventRandom": "Random",
+    "soundEventTaskComplete": "Task Complete",
+    "soundEventTaskFailed": "Task Failed",
+    "soundEventsDescription": "Add one or more sounds per event. When multiple are configured, one plays at random.",
+    "soundEventsTitle": "Sound Events",
+    "volume": "Volume",
+    "volumeAriaLabel": "Sound effect volume"
+  },
   "speechToTextCard": {
     "subtitle": "Configure how your assistant transcribes speech",
     "title": "Speech-to-Text"
@@ -626,6 +772,52 @@
     "deleteFailedToast": "Failed to delete the provider. Please try again.",
     "deleteInUseToast": "This provider is in use by a profile or as the default provider. Update those settings before deleting it.",
     "setDefaultFailedToast": "Failed to set the default provider. Please try again."
+  },
+  "voicePage": {
+    "activationKeyLabel": "Activation Key:",
+    "allowMicrophoneAccess": "Allow Microphone Access",
+    "captionsSubtitle": "Show live text of what you and the assistant say during a voice conversation.",
+    "captionsTitle": "Captions",
+    "customKey": "Custom",
+    "defaultBadge": "Default",
+    "enablePushToTalk": "Enable Push to Talk",
+    "focusedTabNote": "Push-to-Talk only works while this tab is focused, and browsers may intercept some shortcuts (e.g. Ctrl+T) before the page can see them. For always-on PTT, use the Vellum desktop app.",
+    "grantMicrophoneAccessHint": "Grant microphone access to list your available input devices.",
+    "interruptSensitivityAriaLabel": "Interrupt sensitivity",
+    "interruptSensitivityDescription": "How easily talking over the assistant interrupts it. Lower it if the assistant cuts itself off on background noise or filler words; raise it to interrupt more quickly.",
+    "interruptSensitivityHigh": "High",
+    "interruptSensitivityLabel": "Interrupt sensitivity",
+    "interruptSensitivityLow": "Low",
+    "interruptSensitivityMedium": "Medium",
+    "microphoneAriaLabel": "Microphone",
+    "microphoneFallbackLabel": "Microphone {index}",
+    "microphoneSubtitle": "Which input device is used for dictation and voice conversations.",
+    "microphoneTitle": "Microphone",
+    "pauseBeforeReplyAriaLabel": "Pause before reply",
+    "pauseBeforeReplyDescription": "How long the assistant waits after you stop speaking before it replies. A longer pause lets you gather your thoughts mid-sentence without being cut off.",
+    "pauseBeforeReplyLabel": "Pause before reply",
+    "pressAnyKey": "Press any key…",
+    "pushToTalkSubtitle": "Hold the activation key to dictate text or start a voice conversation.",
+    "pushToTalkTitle": "Push to Talk",
+    "resetToDefaults": "Reset to defaults",
+    "savedMicrophone": "Saved microphone",
+    "savedMicrophoneNotConnected": "Saved microphone (not connected)",
+    "sectionCaptionsHeading": "Captions",
+    "sectionInputDescription": "How you talk to your assistant.",
+    "sectionInputHeading": "Input",
+    "sectionOutputDescription": "How your assistant sounds.",
+    "sectionOutputHeading": "Output",
+    "speechServicesBannerLink": "Set it up in Models & Services",
+    "speechServicesBannerPrompt": "Want to use your own API key for STT or TTS, or set a custom voice?",
+    "systemDefault": "System Default",
+    "turnTakingSubtitle": "Where your turn ends and the assistant's begins. Applies to hands-free conversations. Under push to talk, the key decides.",
+    "turnTakingTitle": "Turn taking"
+  },
+  "voicePickerCard": {
+    "changeButton": "Change",
+    "creditsNote": "Uses Vellum credits, through providers like ElevenLabs and Deepgram.",
+    "title": "Voice",
+    "titleWithName": "{name}'s Voice"
   },
   "webFetchCard": {
     "apiKeyLabel": "API Key",

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -27,6 +27,16 @@
     "topUpCancelToast": "Se canceló el pago. No se añadieron créditos.",
     "upgradeCancelToast": "Mejora cancelada. No hay cambios en tu plan."
   },
+  "bookmarksPage": {
+    "emptyDescription": "Pasa el cursor sobre cualquier mensaje y haz clic en el icono de marcador para guardarlo aquí.",
+    "emptyTitle": "Sin marcadores",
+    "errorDescription": "Algo salió mal. Inténtalo de nuevo.",
+    "errorTitle": "No se pudieron cargar los marcadores",
+    "open": "Abrir",
+    "removeBookmark": "Eliminar marcador",
+    "retry": "Reintentar",
+    "untitledConversation": "Conversación sin título"
+  },
   "bulkOverrideSwapModal": {
     "affectedSummary": "{count, plural, one {# acción usa actualmente {profile}} other {# acciones usan actualmente {profile}}}",
     "applyTo": "{count, plural, one {Aplicar a # acción} other {Aplicar a # acciones}}",
@@ -94,6 +104,33 @@
     "tryAgain": "Intentar de nuevo",
     "viewPlans": "Ver planes"
   },
+  "communityPage": {
+    "communityHubDescription": "Muestras, guías y proyectos compartidos por la comunidad.",
+    "communityHubTitle": "Centro de la comunidad",
+    "discordBenefitAnswers": "Obtén respuestas más rápido de la comunidad",
+    "discordBenefitFeedback": "Comparte comentarios y solicita funciones",
+    "discordBenefitTeam": "Habla directamente con el equipo",
+    "discordLabel": "Discord",
+    "discordSubtitle": "Habla con el equipo, comparte comentarios, solicita funciones y obtén respuestas más rápido.",
+    "discordTitle": "Únete a nuestra comunidad",
+    "followOnXDescription": "Actualizaciones del producto, lanzamientos y detrás de escena.",
+    "followOnXTitle": "Seguir en X",
+    "heroDescription": "Vellum se construye en abierto con una comunidad creciente de desarrolladores, diseñadores y experimentadores. Así puedes participar.",
+    "heroTag": "Comunidad",
+    "heroTitle": "Construye con nosotros, en abierto.",
+    "joinDiscord": "Unirse a Discord",
+    "moreFromVellum": "Más de Vellum",
+    "openSourceBenefitContribute": "Contribuye con correcciones y nuevas funciones",
+    "openSourceBenefitIssues": "Abre incidencias y reporta errores",
+    "openSourceBenefitStar": "Marca el repositorio para seguir las actualizaciones",
+    "openSourceLabel": "Código abierto",
+    "openSourceSubtitle": "Lee el código fuente, marca el repositorio y contribuye con correcciones y funciones en GitHub.",
+    "openSourceTitle": "Vellum es de código abierto",
+    "starOnGitHub": "Marcar en GitHub",
+    "viewSource": "Ver código fuente",
+    "youtubeChannelDescription": "Recorridos, tutoriales y análisis profundos del producto.",
+    "youtubeChannelTitle": "Canal de YouTube"
+  },
   "completeState": {
     "assistantFallbackName": "tu asistente",
     "returnTo": "Volver a {assistantName}",
@@ -128,6 +165,13 @@
     "genericDescriptor": "Selecciona potencia de CPU, RAM y almacenamiento personalizados. O añade algunos tokens.",
     "prompt": "¿Necesitas algo más adaptado a tus necesidades?",
     "title": "Plan personalizado"
+  },
+  "developerPage": {
+    "sectionsAriaLabel": "Secciones de desarrollador",
+    "tabFeatureFlags": "Indicadores de funciones",
+    "tabLifecycle": "Ciclo de vida del asistente",
+    "tabMemory": "Memoria",
+    "tabSentry": "Pruebas de Sentry"
   },
   "domainStep": {
     "continue": "Continuar",
@@ -210,6 +254,32 @@
     "confirm": "Bajar a Base",
     "title": "¿Bajar a Base?"
   },
+  "generalPage": {
+    "chooseAssistant": "Elegir asistente",
+    "computeResourcesLoginNotice": "Inicia sesión en la plataforma Vellum para administrar los recursos de cómputo.",
+    "computeResourcesSubtitle": "Supervisa el uso de recursos y administra el perfil de cómputo de tu asistente.",
+    "computeResourcesTitle": "Cómputo y recursos",
+    "current": "Actual",
+    "customize": "Personalizar",
+    "dangerZoneTitle": "Zona de peligro",
+    "preferencesSubtitle": "Personaliza cómo se ve y se comporta Vellum en este dispositivo.",
+    "preferencesTitle": "Preferencias",
+    "retireAssistantDescription": "Retira permanentemente este asistente y elimina todos los datos asociados.",
+    "retireAssistantLoginNotice": "Inicia sesión en la plataforma Vellum para retirar este asistente.",
+    "retireAssistantTitle": "Retirar asistente",
+    "sleepPolicyLoginNotice": "Inicia sesión en la plataforma Vellum para administrar la política de suspensión.",
+    "sleepPolicySubtitle": "Controla cuánto tiempo permanece activo este asistente cuando está inactivo.",
+    "sleepPolicyTitle": "Política de suspensión",
+    "switchAssistantSubtitle": "Elige a qué asistente está conectado este dispositivo.",
+    "switchAssistantTitle": "Cambiar asistente",
+    "twoFactorDescription": "Requiere un código de una aplicación de autenticación cuando inicias sesión.",
+    "twoFactorLoginNotice": "Inicia sesión en la plataforma Vellum para administrar la autenticación de dos factores.",
+    "twoFactorTitle": "Autenticación de dos factores",
+    "updateWindow": "Ventana de actualización",
+    "updatesLoginNotice": "Inicia sesión en la plataforma Vellum para administrar las actualizaciones de software.",
+    "versionSubtitle": "Administra la versión de software de tu asistente y las actualizaciones.",
+    "versionTitle": "Versión"
+  },
   "imageGenerationCard": {
     "activeModelLabel": "Modelo activo",
     "apiKeyLabel": "Clave de API",
@@ -227,10 +297,35 @@
     "vellumNote": "La generación de imágenes se ejecuta a través de tu cuenta de Vellum."
   },
   "integrationsPage": {
-    "filterAriaLabel": "Filtrar integraciones",
+    "accountConnectedToast": "Cuenta de {providerLabel} conectada correctamente.",
+    "accountConnectedToastGeneric": "Cuenta conectada correctamente.",
+    "connectFailedToast": "No se pudo conectar {providerLabel}.",
+    "connectFailedToastGeneric": "No se pudo conectar. Inténtalo de nuevo.",
+    "emptyAllEnabledTitle": "Todas las integraciones están habilitadas",
+    "emptyDefaultSubtitle": "Comprueba tu conexión e inténtalo de nuevo.",
+    "emptyDefaultTitle": "No hay integraciones disponibles",
+    "emptyEnabledSubtitle": "Conecta una integración para comenzar.",
+    "emptyEnabledTitle": "No hay integraciones habilitadas",
+    "emptyNotEnabledSubtitle": "Todas las integraciones disponibles han sido conectadas.",
+    "emptySearchSubtitle": "Ninguna integración coincide con \"{query}\"",
+    "emptySearchTitle": "Ninguna integración coincide",
     "filterAll": "Todas",
+    "filterAriaLabel": "Filtrar integraciones",
     "filterEnabled": "Habilitadas",
-    "filterNotEnabled": "No habilitadas"
+    "filterNotEnabled": "No habilitadas",
+    "loadFailed": "No se pudieron cargar las integraciones. Inténtalo de nuevo.",
+    "loading": "Cargando...",
+    "noAssistant": "No se encontró ningún asistente. Crea un asistente para conectar integraciones.",
+    "oauthErrorDenied": "Se denegó la autorización. Inténtalo de nuevo.",
+    "oauthErrorExchangeFailed": "No se pudo completar la autorización. Inténtalo de nuevo.",
+    "oauthErrorIdentityFailed": "No se pudo verificar la identidad de la cuenta. Inténtalo de nuevo.",
+    "oauthErrorStateExpired": "La autorización expiró. Inténtalo de nuevo.",
+    "oauthErrorStateInvalid": "El estado de autorización no era válido. Inténtalo de nuevo.",
+    "searchAriaLabel": "Buscar integraciones",
+    "searchPlaceholder": "Buscar integraciones",
+    "tabMcp": "MCP",
+    "tabOAuth": "OAuth",
+    "tipBanner": "<tip>Consejo:</tip> Puedes habilitar integraciones mencionándolas en el chat."
   },
   "languageModelCard": {
     "defaultProviderUnavailable": "Tu proveedor predeterminado no está disponible.",
@@ -238,6 +333,11 @@
     "overridesTitle": "Anulaciones",
     "subtitle": "Los perfiles eligen qué modelo responde. Los proveedores dan acceso a él",
     "title": "Modelo de lenguaje"
+  },
+  "listeningLanguageCard": {
+    "change": "Cambiar",
+    "subtitle": "El idioma en el que hablas con tu asistente. Se aplica a partir de tu próximo turno hablado.",
+    "title": "Idioma de escucha"
   },
   "manageProfilesBlockedDeleteModal": {
     "actionOverridesTitle": "Anulaciones de acciones",
@@ -260,6 +360,10 @@
     "summaryThreeClauses": "\"{display}\" {clause1}, {clause2} y {clause3}. Elige un reemplazo abajo y esas referencias se moverán a él; después se eliminará \"{display}\".",
     "summaryTwoClauses": "\"{display}\" {clause1} y {clause2}. Elige un reemplazo abajo y esas referencias se moverán a él; después se eliminará \"{display}\".",
     "title": "Elige un perfil de reemplazo"
+  },
+  "notificationsPage": {
+    "description": "Administra cómo Vellum te notifica en este dispositivo Android.",
+    "title": "Notificaciones"
   },
   "overridesCallSiteList": {
     "emptySearch": "Ninguna acción coincide con tu búsqueda."
@@ -313,6 +417,23 @@
     "planUpdatedToast": "Plan actualizado.",
     "startFreeCta": "Empezar gratis",
     "subheading": "Elige el nivel que se ajuste a cuánto quieres que se encargue."
+  },
+  "privacyPage": {
+    "llmLogRetentionDescription": "Cuánto tiempo conservar los registros de solicitudes y respuestas LLM en este dispositivo. Estos registros documentan las solicitudes y completaciones enviadas a los proveedores de modelos y se usan para depuración. Una retención más corta mejora la privacidad; una retención más larga ayuda a solucionar problemas.",
+    "llmLogRetentionLabel": "Retención de registros de solicitudes LLM",
+    "retentionDontRetain": "No conservar",
+    "retentionKeepForever": "Conservar para siempre",
+    "retentionNinetyDays": "90 días",
+    "retentionOneDay": "1 día",
+    "retentionOneHour": "1 hora",
+    "retentionSevenDays": "7 días",
+    "retentionThirtyDays": "30 días",
+    "shareAnalyticsHelper": "Enviar datos agregados de uso del producto",
+    "shareAnalyticsLabel": "Compartir analíticas",
+    "shareDiagnosticsHelper": "Enviar informes de fallos, trazas de conversación y datos de reproducción de sesión",
+    "shareDiagnosticsLabel": "Compartir diagnósticos",
+    "subtitleWithPolicy": "Consulta detalles sobre qué datos recopilamos y cómo se usan en nuestra <policyLink>política de privacidad</policyLink>.",
+    "title": "Privacidad"
   },
   "profileAdvancedParams": {
     "contextWindowLabel": "Ventana de contexto",
@@ -540,6 +661,31 @@
     "verifyingTitle": "Los registros DNS se han aprovisionado. Esperando a que el proveedor de correo los verifique; esto suele tardar unos minutos.",
     "yourOwnLabel": "Propio"
   },
+  "soundsSections": {
+    "addSound": "Agregar sonido",
+    "allSoundsAdded": "Todos los sonidos agregados",
+    "defaultBlip": "Blip predeterminado",
+    "enableEvent": "Activar {eventName}",
+    "enableSoundEffects": "Activar efectos de sonido",
+    "enableSoundEffectsDescription": "Interruptor principal para cada sonido basado en eventos.",
+    "noSoundFiles": "Aún no hay archivos de sonido. Coloca archivos de audio en data/sounds/ en tu espacio de trabajo.",
+    "preview": "Vista previa",
+    "previewDefaultBlip": "Vista previa del blip predeterminado",
+    "previewSoundAriaLabel": "Vista previa de {filename}",
+    "removeSoundAriaLabel": "Eliminar {filename}",
+    "soundEventCharacterPoke": "Toque de personaje",
+    "soundEventMessageSent": "Mensaje enviado",
+    "soundEventNeedsInput": "Requiere entrada",
+    "soundEventNewConversation": "Nueva conversación",
+    "soundEventNotification": "Notificación",
+    "soundEventRandom": "Aleatorio",
+    "soundEventTaskComplete": "Tarea completada",
+    "soundEventTaskFailed": "Tarea fallida",
+    "soundEventsDescription": "Agrega uno o más sonidos por evento. Cuando hay varios configurados, uno se reproduce al azar.",
+    "soundEventsTitle": "Eventos de sonido",
+    "volume": "Volumen",
+    "volumeAriaLabel": "Volumen de efectos de sonido"
+  },
   "speechToTextCard": {
     "subtitle": "Configura cómo tu asistente transcribe el habla",
     "title": "Voz a texto"
@@ -626,6 +772,52 @@
     "deleteFailedToast": "No se pudo eliminar el proveedor. Inténtalo de nuevo.",
     "deleteInUseToast": "Este proveedor está en uso en un perfil o como proveedor predeterminado. Actualiza esas configuraciones antes de eliminarlo.",
     "setDefaultFailedToast": "No se pudo establecer el proveedor predeterminado. Inténtalo de nuevo."
+  },
+  "voicePage": {
+    "activationKeyLabel": "Tecla de activación:",
+    "allowMicrophoneAccess": "Permitir acceso al micrófono",
+    "captionsSubtitle": "Muestra texto en vivo de lo que tú y el asistente dicen durante una conversación de voz.",
+    "captionsTitle": "Subtítulos",
+    "customKey": "Personalizada",
+    "defaultBadge": "Predeterminado",
+    "enablePushToTalk": "Activar pulsar para hablar",
+    "focusedTabNote": "Pulsar para hablar solo funciona mientras esta pestaña está enfocada, y los navegadores pueden interceptar algunos atajos (p. ej., Ctrl+T) antes de que la página los detecte. Para PTT siempre activo, usa la aplicación de escritorio de Vellum.",
+    "grantMicrophoneAccessHint": "Concede acceso al micrófono para enumerar tus dispositivos de entrada disponibles.",
+    "interruptSensitivityAriaLabel": "Sensibilidad a interrupciones",
+    "interruptSensitivityDescription": "Qué tan fácilmente hablar por encima del asistente lo interrumpe. Redúcela si el asistente se corta a sí mismo por ruido de fondo o muletillas; aumenta la sensibilidad para interrumpir más rápido.",
+    "interruptSensitivityHigh": "Alta",
+    "interruptSensitivityLabel": "Sensibilidad a interrupciones",
+    "interruptSensitivityLow": "Baja",
+    "interruptSensitivityMedium": "Media",
+    "microphoneAriaLabel": "Micrófono",
+    "microphoneFallbackLabel": "Micrófono {index}",
+    "microphoneSubtitle": "Qué dispositivo de entrada se usa para dictado y conversaciones de voz.",
+    "microphoneTitle": "Micrófono",
+    "pauseBeforeReplyAriaLabel": "Pausa antes de responder",
+    "pauseBeforeReplyDescription": "Cuánto espera el asistente después de que dejas de hablar antes de responder. Una pausa más larga te permite reunir tus ideas a mitad de frase sin ser interrumpido.",
+    "pauseBeforeReplyLabel": "Pausa antes de responder",
+    "pressAnyKey": "Pulsa cualquier tecla…",
+    "pushToTalkSubtitle": "Mantén pulsada la tecla de activación para dictar texto o iniciar una conversación de voz.",
+    "pushToTalkTitle": "Pulsar para hablar",
+    "resetToDefaults": "Restablecer valores predeterminados",
+    "savedMicrophone": "Micrófono guardado",
+    "savedMicrophoneNotConnected": "Micrófono guardado (no conectado)",
+    "sectionCaptionsHeading": "Subtítulos",
+    "sectionInputDescription": "Cómo hablas con tu asistente.",
+    "sectionInputHeading": "Entrada",
+    "sectionOutputDescription": "Cómo suena tu asistente.",
+    "sectionOutputHeading": "Salida",
+    "speechServicesBannerLink": "Configúralo en Modelos y servicios",
+    "speechServicesBannerPrompt": "¿Quieres usar tu propia clave API para STT o TTS, o configurar una voz personalizada?",
+    "systemDefault": "Predeterminado del sistema",
+    "turnTakingSubtitle": "Dónde termina tu turno y comienza el del asistente. Se aplica a conversaciones manos libres. Con pulsar para hablar, lo decide la tecla.",
+    "turnTakingTitle": "Turnos de conversación"
+  },
+  "voicePickerCard": {
+    "changeButton": "Cambiar",
+    "creditsNote": "Usa créditos de Vellum, a través de proveedores como ElevenLabs y Deepgram.",
+    "title": "Voz",
+    "titleWithName": "Voz de {name}"
   },
   "webFetchCard": {
     "apiKeyLabel": "Clave de API",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan
Continue the web i18n cutover after settings billing (#40680). Next mid-sized slice: translate `clients/web/src/domains/settings/pages/**` into the existing `settings` namespace, then ratchet `local/no-untranslated-strings`.

## Summary
- Move user-facing copy in `src/domains/settings/pages/**` into `settings` catalogs (en + es), read through `t()` / `<Trans>` from `@/i18n`.
- Cover general, voice, sounds, privacy, community, bookmarks, notifications, developer, integrations, and listening-language / voice-picker cards.
- Ratchet enforcement to `src/domains/settings/pages/**/*.{ts,tsx}`.

## Test plan
- [x] `bunx eslint "src/domains/settings/pages/**/*.{ts,tsx}"` — 0 `no-untranslated-strings` errors
- [x] `bun test src/i18n/catalogs.test.ts`
- [x] `bun test src/domains/settings/pages` — 8 pass
- [x] `bun run lint` — 0 errors (existing warnings only)
- [x] `bunx tsc --noEmit` — no settings/pages errors

## Risk
Low. Catalog cutover plus call-site wiring; no API or persistence changes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7f2993b-c41a-4c7d-8427-a880d12f5a8a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7f2993b-c41a-4c7d-8427-a880d12f5a8a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

