### PR TITLE
fix(web): keep New Chat focused and show the shortcut on hover

### DIFF
--- a/clients/web/src/domains/chat/components/assistant-nav-item.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-nav-item.test.tsx
@@ -106,3 +106,29 @@ describe("AssistantNavItem leading slot", () => {
     expect(html).toContain("<svg");
   });
 });
+
+describe("AssistantNavItem New Chat shortcut tooltip", () => {
+  function renderNewChat(collapsed = false): string {
+    return renderToStaticMarkup(
+      createElement(AssistantNavItem, {
+        assistantId: "a1",
+        label: "Haze II",
+        active: false,
+        collapsed,
+        onSelect: () => {},
+        onNewConversation: () => {},
+      }),
+    );
+  }
+
+  test("the expanded row keeps its New Chat label", () => {
+    const html = renderNewChat();
+    expect(html).toContain(">New Chat<");
+  });
+
+  test("the collapsed tile is named New Chat without a native title", () => {
+    const html = renderNewChat(true);
+    expect(html).toContain('aria-label="New Chat"');
+    expect(html).not.toContain('title="New Chat"');
+  });
+});

--- a/clients/web/src/domains/chat/components/assistant-nav-item.tsx
+++ b/clients/web/src/domains/chat/components/assistant-nav-item.tsx
@@ -30,7 +30,7 @@
 
 import { SIDEBAR_STACK_GAP } from "@/components/sidebar-nav-geometry";
 import { Brain, Plus } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type ReactElement } from "react";
 import { motion, useAnimationControls, useReducedMotion } from "motion/react";
 
 import {
@@ -38,6 +38,7 @@ import {
   PanelItem,
   panelItemWashStyle,
   SIDE_MENU_TILE_SIZE,
+  Tooltip,
   type CustomPropertyStyle,
 } from "@vellumai/design-library";
 
@@ -45,6 +46,7 @@ import {
   SIDEBAR_CHIP_GAP,
   SIDEBAR_CHIP_SIZE as CHIP_SIZE,
 } from "@/components/sidebar-nav-geometry";
+import { newChatShortcutHint } from "@/domains/chat/new-chat-shortcut";
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import { useInChatOnboardingStore } from "@/stores/in-chat-onboarding-store";
 import { eyeStyleBaseWidth } from "@/utils/assistant-eyes";
@@ -59,6 +61,29 @@ const sleep = (ms: number): Promise<void> =>
 
 const jitter = (base: number, spread: number): number =>
   base + Math.random() * spread;
+
+function NewChatTooltip({
+  children,
+  side,
+}: {
+  children: ReactElement;
+  side: "right" | "top";
+}) {
+  const hint = newChatShortcutHint();
+  return (
+    <Tooltip
+      content={
+        <span className="inline-flex items-center gap-1.5">
+          New Chat
+          <span className="opacity-80">{hint}</span>
+        </span>
+      }
+      side={side}
+    >
+      {children}
+    </Tooltip>
+  );
+}
 
 interface EyeArt {
   id: string;
@@ -219,47 +244,51 @@ export function AssistantNavItem({
         }
       : undefined;
   const newConversationRow = !showNewConversation ? null : collapsed ? (
-    <button
-      type="button"
-      onClick={onNewConversation}
-      title="New Chat"
-      data-tour-id="new-chat"
-      className={cn(
-        "group relative flex shrink-0 self-center cursor-pointer items-center justify-center overflow-hidden select-none",
-        "rounded-full",
-        "outline-none keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)]",
-        "transition-colors duration-150 active:scale-[0.98]",
-        "bg-[var(--panel-item-bg,var(--surface-lift))]",
-        "[@media(hover:hover)]:hover:bg-[var(--panel-item-hover,var(--surface-hover))]",
-      )}
-      style={{
-        ...newConversationTint,
-        width: SIDE_MENU_TILE_SIZE,
-        height: SIDE_MENU_TILE_SIZE,
-      }}
-    >
-      {/* 14px, not the section headers' 12px - the plus glyph carries less
-          ink than the pin/chat icons, so it needs the extra 2px to read at
-          the same weight beside them. Color matches the expanded pill's
-          plus: the assistant's own accent via `--panel-item-icon-fg`
-          (spread into this button's style from `newConversationTint`
-          above), falling back to the usual tertiary gray with no
-          character avatar to draw a hue from. */}
-      <Plus
-        aria-hidden="true"
-        className="h-3.5 w-3.5"
-        style={{ color: "var(--panel-item-icon-fg, var(--content-tertiary))" }}
-      />
-    </button>
+    <NewChatTooltip side="right">
+      <button
+        type="button"
+        onClick={onNewConversation}
+        aria-label="New Chat"
+        data-tour-id="new-chat"
+        className={cn(
+          "group relative flex shrink-0 self-center cursor-pointer items-center justify-center overflow-hidden select-none",
+          "rounded-full",
+          "outline-none keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)]",
+          "transition-colors duration-150 active:scale-[0.98]",
+          "bg-[var(--panel-item-bg,var(--surface-lift))]",
+          "[@media(hover:hover)]:hover:bg-[var(--panel-item-hover,var(--surface-hover))]",
+        )}
+        style={{
+          ...newConversationTint,
+          width: SIDE_MENU_TILE_SIZE,
+          height: SIDE_MENU_TILE_SIZE,
+        }}
+      >
+        {/* 14px, not the section headers' 12px - the plus glyph carries less
+            ink than the pin/chat icons, so it needs the extra 2px to read at
+            the same weight beside them. Color matches the expanded pill's
+            plus: the assistant's own accent via `--panel-item-icon-fg`
+            (spread into this button's style from `newConversationTint`
+            above), falling back to the usual tertiary gray with no
+            character avatar to draw a hue from. */}
+        <Plus
+          aria-hidden="true"
+          className="h-3.5 w-3.5"
+          style={{ color: "var(--panel-item-icon-fg, var(--content-tertiary))" }}
+        />
+      </button>
+    </NewChatTooltip>
   ) : (
-    <PanelItem
-      shape="pill"
-      icon={Plus}
-      label="New Chat"
-      onSelect={onNewConversation}
-      style={newConversationTint}
-      data-tour-id="new-chat"
-    />
+    <NewChatTooltip side="top">
+      <PanelItem
+        shape="pill"
+        icon={Plus}
+        label="New Chat"
+        onSelect={onNewConversation}
+        style={newConversationTint}
+        data-tour-id="new-chat"
+      />
+    </NewChatTooltip>
   );
 
   /* An uploaded image stands in for the character avatar this row otherwise

--- a/clients/web/src/domains/chat/components/chat-body.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.test.tsx
@@ -522,6 +522,20 @@ describe("ChatBody - plain empty state bottom-anchors while the keyboard is open
     expect(container.innerHTML).not.toContain("[justify-content:safe_center]");
   });
 
+  test("flipping docked/undocked keeps the composer DOM node mounted", () => {
+    keyboardOpen = false;
+    const { container, rerender } = render(<ChatBody {...withEmptyState()} />);
+    const composer = container.querySelector('[data-testid="composer"]');
+    expect(composer).not.toBeNull();
+
+    rerender(
+      <ChatBody
+        {...withEmptyState({ dockStartersToBottom: true, startersSlot })}
+      />,
+    );
+    expect(container.querySelector('[data-testid="composer"]')).toBe(composer);
+  });
+
   test("app-editing (non-docked with inline starters) stays centered with the keyboard open", () => {
     // Discriminates the gate: same non-docked empty state and open
     // keyboard, but with the inline startersSlot the app-editing branch

--- a/clients/web/src/domains/chat/components/chat-body.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.tsx
@@ -30,10 +30,10 @@ import { Notice, type NoticeTone } from "@vellumai/design-library";
  * single visual group — matching the original centered layout — while
  * the composer **stays at the same position in the React tree** so its
  * state (focus, draft text, attachments) is preserved across the
- * empty→active transition. `safe center` falls back to start-alignment
- * when the group overflows; while the soft keyboard is open the empty
- * state bottom-anchors the group instead so the composer docks to the
- * keyboard edge.
+ * empty→active and undocked→docked (starters arriving) transitions. `safe
+ * center` falls back to start-alignment when the group overflows; while
+ * the soft keyboard is open the empty state bottom-anchors the group
+ * instead so the composer docks to the keyboard edge.
  *
  * See [React — Preserving and Resetting State](https://react.dev/learn/preserving-and-resetting-state)
  * and [MDN — `justify-content: safe center`](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content).
@@ -245,21 +245,33 @@ export function ChatBody({
       : "[justify-content:safe_center]";
 
   // On the empty state the outer container is a plain scroll container.
-  // Group alignment lives on an inner `min-h-full` wrapper (the docked
-  // branch builds its own): alignment directly on the scroll container
-  // would make end-aligned content taller than the viewport overflow past
-  // the START edge, where scrolling cannot reach, leaving the greeting
-  // unreachable on short viewports while the keyboard is open.
+  // Group alignment lives on an inner `min-h-full` wrapper: alignment
+  // directly on the scroll container would make end-aligned content taller
+  // than the viewport overflow past the START edge, where scrolling cannot
+  // reach, leaving the greeting unreachable on short viewports while the
+  // keyboard is open.
   const outerClass = isEmptyState ? `${baseClass} overflow-y-auto` : baseClass;
 
-  // Inner wrapper for the non-docked layout. On the empty state it fills
-  // the first viewport (`min-h-full`) and carries the group alignment; on
-  // the active state it is a plain fill wrapper (`min-h-0 flex-1`) so the
-  // transcript keeps its height chain. It exists in both states so the
-  // composer keeps its tree position across the empty→active transition.
-  const nonDockedInnerClass = isEmptyState
-    ? `flex min-h-full flex-col ${nonDockedAlignmentClass}`
+  const isDockedEmpty = isEmptyState && dockStartersToBottom;
+
+  // The composer lives at outer > inner > group > stack in every branch, so
+  // flipping docked/undocked (starters arriving) or empty/active does not
+  // remount it and drop textarea focus. Empty + docked: inner is a
+  // min-h-full column and the group flexes + centers (or bottom-anchors
+  // while the keyboard is open). Empty + undocked: inner is the centered
+  // column and the group shrink-wraps. Active: both are flex-1 min-h-0 so
+  // the transcript still fills.
+  const innerClass = isEmptyState
+    ? isDockedEmpty
+      ? "flex min-h-full flex-col"
+      : `flex min-h-full flex-col ${nonDockedAlignmentClass}`
     : "flex min-h-0 flex-1 flex-col";
+
+  const groupClass = isDockedEmpty
+    ? `flex flex-1 flex-col ${keyboardOpen ? "justify-end" : "[justify-content:safe_center]"}`
+    : isEmptyState
+      ? "flex flex-col"
+      : "flex min-h-0 flex-1 flex-col";
 
   // Mirror the mounted banner — not the candidate slot — into the shared
   // store so tip surfaces stay mutually exclusive with nudge banners.
@@ -300,11 +312,12 @@ export function ChatBody({
     </div>
   );
 
-  // Composer stack — stays at the same tree position across the empty→active
-  // transition so React preserves its state (focus, draft text, attachments)
-  // and iOS Safari does not blur the input on first send (LUM-1506 / LUM-1516).
-  // `trailingStarters` lets the docked layout render the starters elsewhere
-  // (its own bottom dock) instead of directly below the composer.
+  // Composer stack stays at the same tree position across empty→active
+  // and undocked→docked so React preserves its state (focus, draft text,
+  // attachments) and iOS Safari does not blur the input on first send
+  // (LUM-1506 / LUM-1516). `trailingStarters` lets the docked layout
+  // render the starters elsewhere (its own bottom dock) instead of
+  // directly below the composer.
   const renderComposerStack = (trailingStarters: ReactNode) => (
     // The banner is a flow child here because it is an opaque full-width
     // card that always occupies its own height: the `flex-1` scroll area
@@ -375,43 +388,6 @@ export function ChatBody({
     </div>
   );
 
-  // Docked (suggestions-library) empty state: the first screen fills the
-  // viewport with the greeting + composer centered and the featured row
-  // pinned to its bottom; the categorized groups sit below the fold.
-  if (isEmptyState && dockStartersToBottom) {
-    return (
-      <div
-        className={outerClass}
-        style={bottomInset ? { paddingBottom: bottomInset } : undefined}
-        onDragEnter={dragHandlers.onDragEnter}
-        onDragOver={dragHandlers.onDragOver}
-        onDragLeave={dragHandlers.onDragLeave}
-        onDrop={dragHandlers.onDrop}
-      >
-        <div className="flex min-h-full flex-col">
-          {/* While the keyboard is open the group anchors to the bottom edge
-              (the shell bottom is the keyboard top), matching the transcript
-              layout; otherwise it centers in the first screen. */}
-          <div
-            className={`flex flex-1 flex-col ${keyboardOpen ? "justify-end" : "[justify-content:safe_center]"}`}
-          >
-            <ChatScrollArea {...scrollAreaProps} />
-            {renderComposerStack(null)}
-          </div>
-          {startersSlot &&
-            renderKeyboardCollapse(
-              "docked-starters",
-              <ChatColumn className="pb-3">{startersSlot}</ChatColumn>,
-            )}
-        </div>
-        {belowFoldSlot && (
-          <ChatColumn className="pt-2 pb-8">{belowFoldSlot}</ChatColumn>
-        )}
-        {dragOverlay}
-      </div>
-    );
-  }
-
   return (
     <div
       className={outerClass}
@@ -421,20 +397,31 @@ export function ChatBody({
       onDragLeave={dragHandlers.onDragLeave}
       onDrop={dragHandlers.onDrop}
     >
-      <div className={nonDockedInnerClass}>
-        <ChatScrollArea {...scrollAreaProps} />
+      <div className={innerClass}>
+        <div className={groupClass}>
+          <ChatScrollArea {...scrollAreaProps} />
 
-        {!isEmptyState && activeProcessOverlaysSlot && (
-          <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center gap-2 px-3 pt-2">
-            {/* Registry-driven row of active background-process overlays. The
-                caller owns which kinds it covers and their order; each overlay
-                self-gates on its own active ids. */}
-            {activeProcessOverlaysSlot}
-          </div>
-        )}
+          {!isEmptyState && activeProcessOverlaysSlot && (
+            <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center gap-2 px-3 pt-2">
+              {/* Registry-driven row of active background-process overlays. The
+                  caller owns which kinds it covers and their order; each overlay
+                  self-gates on its own active ids. */}
+              {activeProcessOverlaysSlot}
+            </div>
+          )}
 
-        {renderComposerStack(startersSlot)}
+          {renderComposerStack(isDockedEmpty ? null : startersSlot)}
+        </div>
+        {isDockedEmpty &&
+          startersSlot &&
+          renderKeyboardCollapse(
+            "docked-starters",
+            <ChatColumn className="pb-3">{startersSlot}</ChatColumn>,
+          )}
       </div>
+      {isDockedEmpty && belowFoldSlot ? (
+        <ChatColumn className="pt-2 pb-8">{belowFoldSlot}</ChatColumn>
+      ) : null}
       {dragOverlay}
     </div>
   );

--- a/clients/web/src/domains/chat/composer-focus.test.ts
+++ b/clients/web/src/domains/chat/composer-focus.test.ts
@@ -1,12 +1,8 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 
 import {
-  consumePendingComposerFocus,
   insertTextAtSelection,
-  isComposerFocusPending,
-  requestComposerFocus,
   shouldFocusComposerForTyping,
-  tryClaimComposerFocus,
 } from "@/domains/chat/composer-focus";
 
 const BASE_EVENT = {
@@ -68,55 +64,5 @@ describe("insertTextAtSelection", () => {
         selectionEnd: 99,
       }),
     ).toEqual({ value: "hell!", cursor: 5 });
-  });
-});
-
-describe("tryClaimComposerFocus", () => {
-  afterEach(() => {
-    consumePendingComposerFocus();
-    document.body.replaceChildren();
-  });
-
-  function mountTextarea(): HTMLTextAreaElement {
-    const el = document.createElement("textarea");
-    document.body.append(el);
-    return el;
-  }
-
-  test("focuses the textarea after a request", () => {
-    const el = mountTextarea();
-    requestComposerFocus();
-    tryClaimComposerFocus(el);
-    expect(document.activeElement).toBe(el);
-    expect(isComposerFocusPending()).toBe(true);
-  });
-
-  test("reclaims from the document after the original textarea unmounts", () => {
-    const first = mountTextarea();
-    requestComposerFocus();
-    tryClaimComposerFocus(first);
-    first.remove();
-
-    const second = mountTextarea();
-    tryClaimComposerFocus(second);
-    expect(document.activeElement).toBe(second);
-  });
-
-  test("stops reclaiming once the user moves to another text field", () => {
-    const el = mountTextarea();
-    const other = document.createElement("input");
-    document.body.append(other);
-    requestComposerFocus();
-    tryClaimComposerFocus(el);
-    other.focus();
-    tryClaimComposerFocus(el);
-    expect(document.activeElement).toBe(other);
-    expect(isComposerFocusPending()).toBe(false);
-  });
-
-  test("does not claim when nothing is pending", () => {
-    const el = mountTextarea();
-    tryClaimComposerFocus(el);
-    expect(document.activeElement).not.toBe(el);
   });
 });

--- a/clients/web/src/domains/chat/composer-focus.test.ts
+++ b/clients/web/src/domains/chat/composer-focus.test.ts
@@ -1,8 +1,12 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 
 import {
+  consumePendingComposerFocus,
   insertTextAtSelection,
+  isComposerFocusPending,
+  requestComposerFocus,
   shouldFocusComposerForTyping,
+  tryClaimComposerFocus,
 } from "@/domains/chat/composer-focus";
 
 const BASE_EVENT = {
@@ -64,5 +68,55 @@ describe("insertTextAtSelection", () => {
         selectionEnd: 99,
       }),
     ).toEqual({ value: "hell!", cursor: 5 });
+  });
+});
+
+describe("tryClaimComposerFocus", () => {
+  afterEach(() => {
+    consumePendingComposerFocus();
+    document.body.replaceChildren();
+  });
+
+  function mountTextarea(): HTMLTextAreaElement {
+    const el = document.createElement("textarea");
+    document.body.append(el);
+    return el;
+  }
+
+  test("focuses the textarea after a request", () => {
+    const el = mountTextarea();
+    requestComposerFocus();
+    tryClaimComposerFocus(el);
+    expect(document.activeElement).toBe(el);
+    expect(isComposerFocusPending()).toBe(true);
+  });
+
+  test("reclaims from the document after the original textarea unmounts", () => {
+    const first = mountTextarea();
+    requestComposerFocus();
+    tryClaimComposerFocus(first);
+    first.remove();
+
+    const second = mountTextarea();
+    tryClaimComposerFocus(second);
+    expect(document.activeElement).toBe(second);
+  });
+
+  test("stops reclaiming once the user moves to another text field", () => {
+    const el = mountTextarea();
+    const other = document.createElement("input");
+    document.body.append(other);
+    requestComposerFocus();
+    tryClaimComposerFocus(el);
+    other.focus();
+    tryClaimComposerFocus(el);
+    expect(document.activeElement).toBe(other);
+    expect(isComposerFocusPending()).toBe(false);
+  });
+
+  test("does not claim when nothing is pending", () => {
+    const el = mountTextarea();
+    tryClaimComposerFocus(el);
+    expect(document.activeElement).not.toBe(el);
   });
 });

--- a/clients/web/src/domains/chat/composer-focus.ts
+++ b/clients/web/src/domains/chat/composer-focus.ts
@@ -6,20 +6,39 @@
  *
  * - fires a window event consumed by `chat-page`'s mounted listener
  *   (for the same-route case), AND
- * - sets a one-shot pending flag that `chat-page` drains on its next
- *   mount (for the case where the caller navigated to the conversation
- *   route from elsewhere — `/assistant/home`, `/assistant/library`,
- *   etc. — and the listener doesn't exist yet at dispatch time).
+ * - sets a pending flag that `chat-page` drains on its next mount (for
+ *   the case where the caller navigated to the conversation route from
+ *   elsewhere: `/assistant/home`, `/assistant/library`, etc., and the
+ *   listener doesn't exist yet at dispatch time).
+ *
+ * Starting a new chat also remounts empty-state chrome around the
+ * composer (starters docking, greeting paint). A single `.focus()` on
+ * the pre-remount node lands, then the node is replaced and focus falls
+ * back to `<body>`. `tryClaimComposerFocus` keeps reclaiming the live
+ * textarea for {@link COMPOSER_FOCUS_CLAIM_MS} so the caret survives
+ * that layout churn, and stops if the user moves to another field or a
+ * modal in the meantime.
  *
  * Without the pending-flag drain, File > Current Conversation would no-op
  * when invoked from non-chat routes.
  */
 export const COMPOSER_FOCUS_EVENT = "vellum:focus-composer";
 
+/**
+ * How long a composer-focus request keeps reclaiming the textarea after
+ * layout churn. Long enough for the new-chat empty-state tree to settle,
+ * short enough that a later click elsewhere is not stolen.
+ */
+export const COMPOSER_FOCUS_CLAIM_MS = 800;
+
 let pending = false;
+let pendingUntil = 0;
+let claimed = false;
 
 export function requestComposerFocus(): void {
   pending = true;
+  claimed = false;
+  pendingUntil = Date.now() + COMPOSER_FOCUS_CLAIM_MS;
   if (typeof window !== "undefined") {
     window.dispatchEvent(new Event(COMPOSER_FOCUS_EVENT));
   }
@@ -29,7 +48,69 @@ export function requestComposerFocus(): void {
 export function consumePendingComposerFocus(): boolean {
   const wasPending = pending;
   pending = false;
+  claimed = false;
+  pendingUntil = 0;
   return wasPending;
+}
+
+/** True while a focus request is still allowed to claim the textarea. */
+export function isComposerFocusPending(): boolean {
+  if (!pending) {
+    return false;
+  }
+  if (Date.now() >= pendingUntil) {
+    pending = false;
+    claimed = false;
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Focus `element` if a composer-focus request is still live. Reclaims from
+ * `<body>` after a remount; yields if the user has moved to another text
+ * field, a modal, or (after the first successful claim) any other control.
+ */
+export function tryClaimComposerFocus(
+  element: HTMLTextAreaElement | null,
+): void {
+  if (!element || !isComposerFocusPending()) {
+    return;
+  }
+  if (element.disabled || element.readOnly) {
+    return;
+  }
+  if (
+    typeof document !== "undefined" &&
+    document.querySelector('[aria-modal="true"]')
+  ) {
+    consumePendingComposerFocus();
+    return;
+  }
+  const active =
+    typeof document === "undefined" ? null : document.activeElement;
+  if (active === element) {
+    claimed = true;
+    return;
+  }
+  if (isTextEntryElement(active) && active !== element) {
+    consumePendingComposerFocus();
+    return;
+  }
+  if (claimed) {
+    if (
+      active &&
+      active !== document.body &&
+      active !== document.documentElement
+    ) {
+      consumePendingComposerFocus();
+      return;
+    }
+  }
+  element.focus({ preventScroll: true });
+  if (typeof document !== "undefined" && document.activeElement === element) {
+    claimed = true;
+  }
 }
 
 type ComposerTypingKeyEvent = Pick<

--- a/clients/web/src/domains/chat/composer-focus.ts
+++ b/clients/web/src/domains/chat/composer-focus.ts
@@ -6,39 +6,24 @@
  *
  * - fires a window event consumed by `chat-page`'s mounted listener
  *   (for the same-route case), AND
- * - sets a pending flag that `chat-page` drains on its next mount (for
- *   the case where the caller navigated to the conversation route from
- *   elsewhere: `/assistant/home`, `/assistant/library`, etc., and the
- *   listener doesn't exist yet at dispatch time).
- *
- * Starting a new chat also remounts empty-state chrome around the
- * composer (starters docking, greeting paint). A single `.focus()` on
- * the pre-remount node lands, then the node is replaced and focus falls
- * back to `<body>`. `tryClaimComposerFocus` keeps reclaiming the live
- * textarea for {@link COMPOSER_FOCUS_CLAIM_MS} so the caret survives
- * that layout churn, and stops if the user moves to another field or a
- * modal in the meantime.
+ * - sets a one-shot pending flag that `chat-page` drains on its next
+ *   mount (for the case where the caller navigated to the conversation
+ *   route from elsewhere: `/assistant/home`, `/assistant/library`,
+ *   etc., and the listener doesn't exist yet at dispatch time).
  *
  * Without the pending-flag drain, File > Current Conversation would no-op
  * when invoked from non-chat routes.
+ *
+ * New Chat focus is kept by not remounting the composer: `ChatBody` uses
+ * one tree for docked and undocked empty states, so starters arriving
+ * cannot replace the focused textarea and drop the caret onto `<body>`.
  */
 export const COMPOSER_FOCUS_EVENT = "vellum:focus-composer";
 
-/**
- * How long a composer-focus request keeps reclaiming the textarea after
- * layout churn. Long enough for the new-chat empty-state tree to settle,
- * short enough that a later click elsewhere is not stolen.
- */
-export const COMPOSER_FOCUS_CLAIM_MS = 800;
-
 let pending = false;
-let pendingUntil = 0;
-let claimed = false;
 
 export function requestComposerFocus(): void {
   pending = true;
-  claimed = false;
-  pendingUntil = Date.now() + COMPOSER_FOCUS_CLAIM_MS;
   if (typeof window !== "undefined") {
     window.dispatchEvent(new Event(COMPOSER_FOCUS_EVENT));
   }
@@ -48,69 +33,7 @@ export function requestComposerFocus(): void {
 export function consumePendingComposerFocus(): boolean {
   const wasPending = pending;
   pending = false;
-  claimed = false;
-  pendingUntil = 0;
   return wasPending;
-}
-
-/** True while a focus request is still allowed to claim the textarea. */
-export function isComposerFocusPending(): boolean {
-  if (!pending) {
-    return false;
-  }
-  if (Date.now() >= pendingUntil) {
-    pending = false;
-    claimed = false;
-    return false;
-  }
-  return true;
-}
-
-/**
- * Focus `element` if a composer-focus request is still live. Reclaims from
- * `<body>` after a remount; yields if the user has moved to another text
- * field, a modal, or (after the first successful claim) any other control.
- */
-export function tryClaimComposerFocus(
-  element: HTMLTextAreaElement | null,
-): void {
-  if (!element || !isComposerFocusPending()) {
-    return;
-  }
-  if (element.disabled || element.readOnly) {
-    return;
-  }
-  if (
-    typeof document !== "undefined" &&
-    document.querySelector('[aria-modal="true"]')
-  ) {
-    consumePendingComposerFocus();
-    return;
-  }
-  const active =
-    typeof document === "undefined" ? null : document.activeElement;
-  if (active === element) {
-    claimed = true;
-    return;
-  }
-  if (isTextEntryElement(active) && active !== element) {
-    consumePendingComposerFocus();
-    return;
-  }
-  if (claimed) {
-    if (
-      active &&
-      active !== document.body &&
-      active !== document.documentElement
-    ) {
-      consumePendingComposerFocus();
-      return;
-    }
-  }
-  element.focus({ preventScroll: true });
-  if (typeof document !== "undefined" && document.activeElement === element) {
-    claimed = true;
-  }
 }
 
 type ComposerTypingKeyEvent = Pick<

--- a/clients/web/src/domains/chat/hooks/command-palette-utils.ts
+++ b/clients/web/src/domains/chat/hooks/command-palette-utils.ts
@@ -16,7 +16,7 @@ import {
 
 import type { CommandPaletteSection } from "@/components/command-palette/command-palette";
 import type { GlobalSearchResponse } from "@/domains/chat/api/global-search";
-import { isElectron } from "@/runtime/is-electron";
+import { newChatShortcutHint } from "@/domains/chat/new-chat-shortcut";
 
 /** Build the static "Actions" section with keyboard shortcuts. */
 export function buildActionsSection(
@@ -30,7 +30,7 @@ export function buildActionsSection(
         id: "action-new-conversation",
         icon: SquarePen,
         title: "New Conversation",
-        shortcutHint: isElectron() ? "⌘N" : "⌘⇧O",
+        shortcutHint: newChatShortcutHint(),
       },
       {
         id: "action-current-conversation",

--- a/clients/web/src/domains/chat/hooks/use-composer-keyboard.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-composer-keyboard.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * Tests for `useComposerKeyboard`'s host-focus claim loop: a new-chat
+ * request focuses the live textarea, and a remount of that node (empty-state
+ * chrome settling) must not leave the caret on `<body>`.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { useRef } from "react";
+import { act, cleanup, render } from "@testing-library/react";
+
+import {
+  consumePendingComposerFocus,
+  requestComposerFocus,
+} from "@/domains/chat/composer-focus";
+import { useComposerKeyboard } from "@/domains/chat/hooks/use-composer-keyboard";
+
+function Harness({ textareaKey }: { textareaKey: string }) {
+  const inputRef = useRef<HTMLTextAreaElement | null>(null);
+  useComposerKeyboard(inputRef);
+  return <textarea key={textareaKey} ref={inputRef} />;
+}
+
+function nextFrame(): Promise<void> {
+  return new Promise((resolve) => {
+    requestAnimationFrame(() => resolve());
+  });
+}
+
+afterEach(() => {
+  consumePendingComposerFocus();
+  cleanup();
+});
+
+describe("useComposerKeyboard host focus", () => {
+  test("focuses the composer textarea when a focus request fires", () => {
+    const { container } = render(<Harness textareaKey="a" />);
+    const textarea = container.querySelector("textarea");
+    expect(textarea).not.toBeNull();
+
+    act(() => {
+      requestComposerFocus();
+    });
+    expect(document.activeElement).toBe(textarea);
+  });
+
+  test("reclaims the remounted textarea while the claim window is open", async () => {
+    const { container, rerender } = render(<Harness textareaKey="a" />);
+    const first = container.querySelector("textarea");
+    expect(first).not.toBeNull();
+
+    act(() => {
+      requestComposerFocus();
+    });
+    expect(document.activeElement).toBe(first);
+
+    rerender(<Harness textareaKey="b" />);
+    const second = container.querySelector("textarea");
+    expect(second).not.toBeNull();
+    expect(second).not.toBe(first);
+
+    await act(async () => {
+      await nextFrame();
+      await nextFrame();
+    });
+    expect(document.activeElement).toBe(second);
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-composer-keyboard.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-composer-keyboard.test.tsx
@@ -1,7 +1,6 @@
 /**
- * Tests for `useComposerKeyboard`'s host-focus claim loop: a new-chat
- * request focuses the live textarea, and a remount of that node (empty-state
- * chrome settling) must not leave the caret on `<body>`.
+ * Tests for `useComposerKeyboard`'s host-focus relay: a New Chat / File
+ * menu request focuses the live composer textarea.
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
@@ -14,16 +13,10 @@ import {
 } from "@/domains/chat/composer-focus";
 import { useComposerKeyboard } from "@/domains/chat/hooks/use-composer-keyboard";
 
-function Harness({ textareaKey }: { textareaKey: string }) {
+function Harness() {
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   useComposerKeyboard(inputRef);
-  return <textarea key={textareaKey} ref={inputRef} />;
-}
-
-function nextFrame(): Promise<void> {
-  return new Promise((resolve) => {
-    requestAnimationFrame(() => resolve());
-  });
+  return <textarea ref={inputRef} />;
 }
 
 afterEach(() => {
@@ -33,7 +26,7 @@ afterEach(() => {
 
 describe("useComposerKeyboard host focus", () => {
   test("focuses the composer textarea when a focus request fires", () => {
-    const { container } = render(<Harness textareaKey="a" />);
+    const { container } = render(<Harness />);
     const textarea = container.querySelector("textarea");
     expect(textarea).not.toBeNull();
 
@@ -41,27 +34,5 @@ describe("useComposerKeyboard host focus", () => {
       requestComposerFocus();
     });
     expect(document.activeElement).toBe(textarea);
-  });
-
-  test("reclaims the remounted textarea while the claim window is open", async () => {
-    const { container, rerender } = render(<Harness textareaKey="a" />);
-    const first = container.querySelector("textarea");
-    expect(first).not.toBeNull();
-
-    act(() => {
-      requestComposerFocus();
-    });
-    expect(document.activeElement).toBe(first);
-
-    rerender(<Harness textareaKey="b" />);
-    const second = container.querySelector("textarea");
-    expect(second).not.toBeNull();
-    expect(second).not.toBe(first);
-
-    await act(async () => {
-      await nextFrame();
-      await nextFrame();
-    });
-    expect(document.activeElement).toBe(second);
   });
 });

--- a/clients/web/src/domains/chat/hooks/use-composer-keyboard.ts
+++ b/clients/web/src/domains/chat/hooks/use-composer-keyboard.ts
@@ -1,11 +1,13 @@
 /**
  * Consolidates keyboard-focus behaviors for the chat composer textarea:
  *
- * 1. **Electron host focus** — listens for `COMPOSER_FOCUS_EVENT` window
+ * 1. **Host focus relay** — listens for `COMPOSER_FOCUS_EVENT` window
  *    events dispatched by the `useVellumCommands` hook in `chat-layout.tsx`
- *    (File > Current Conversation menu). Also drains any pending focus
- *    request that fired before this component mounted (e.g. the command
- *    was invoked from `/assistant/home` and chat-layout navigated here).
+ *    (File > Current Conversation / New Chat). Also claims any pending
+ *    focus request that fired before this component mounted (e.g. the
+ *    command was invoked from `/assistant/home` and chat-layout navigated
+ *    here). Keeps reclaiming for a short window so a new-chat remount
+ *    cannot drop the caret back to `<body>`.
  *
  * 2. **Typing auto-focus** — when the user starts typing with no focused
  *    input and no modal open, captures the keypress and forwards it to
@@ -16,28 +18,45 @@ import { type MutableRefObject, useEffect } from "react";
 
 import {
   COMPOSER_FOCUS_EVENT,
-  consumePendingComposerFocus,
   insertTextAtSelection,
+  isComposerFocusPending,
   shouldFocusComposerForTyping,
+  tryClaimComposerFocus,
 } from "@/domains/chat/composer-focus";
 import { useComposerStore } from "@/domains/chat/composer-store";
 
 export function useComposerKeyboard(
   inputRef: MutableRefObject<HTMLTextAreaElement | null>,
 ): void {
-  // 1. Electron host focus relay + pending-focus drain.
+  // 1. Host focus relay + pending-focus claim loop.
   useEffect(() => {
-    const focusInput = () => inputRef.current?.focus();
-    const handleFocusRequest = () => {
-      consumePendingComposerFocus();
-      focusInput();
+    let raf = 0;
+    const claim = () => {
+      tryClaimComposerFocus(inputRef.current);
     };
-    window.addEventListener(COMPOSER_FOCUS_EVENT, handleFocusRequest);
-    if (consumePendingComposerFocus()) {
-      queueMicrotask(focusInput);
+    const tick = () => {
+      claim();
+      if (isComposerFocusPending()) {
+        raf = requestAnimationFrame(tick);
+      } else {
+        raf = 0;
+      }
+    };
+    const startClaimLoop = () => {
+      if (raf !== 0) {
+        return;
+      }
+      tick();
+    };
+
+    window.addEventListener(COMPOSER_FOCUS_EVENT, startClaimLoop);
+    if (isComposerFocusPending()) {
+      startClaimLoop();
     }
-    return () =>
-      window.removeEventListener(COMPOSER_FOCUS_EVENT, handleFocusRequest);
+    return () => {
+      window.removeEventListener(COMPOSER_FOCUS_EVENT, startClaimLoop);
+      cancelAnimationFrame(raf);
+    };
   }, [inputRef]);
 
   // 2. Typing auto-focus — redirect keypresses to the composer.

--- a/clients/web/src/domains/chat/hooks/use-composer-keyboard.ts
+++ b/clients/web/src/domains/chat/hooks/use-composer-keyboard.ts
@@ -1,15 +1,14 @@
 /**
  * Consolidates keyboard-focus behaviors for the chat composer textarea:
  *
- * 1. **Host focus relay** — listens for `COMPOSER_FOCUS_EVENT` window
- *    events dispatched by the `useVellumCommands` hook in `chat-layout.tsx`
- *    (File > Current Conversation / New Chat). Also claims any pending
+ * 1. Host focus relay: listens for `COMPOSER_FOCUS_EVENT` window events
+ *    dispatched by the `useVellumCommands` hook in `chat-layout.tsx`
+ *    (File > Current Conversation / New Chat). Also drains any pending
  *    focus request that fired before this component mounted (e.g. the
  *    command was invoked from `/assistant/home` and chat-layout navigated
- *    here). Keeps reclaiming for a short window so a new-chat remount
- *    cannot drop the caret back to `<body>`.
+ *    here).
  *
- * 2. **Typing auto-focus** — when the user starts typing with no focused
+ * 2. Typing auto-focus: when the user starts typing with no focused
  *    input and no modal open, captures the keypress and forwards it to
  *    the composer, focusing the textarea first.
  */
@@ -18,48 +17,31 @@ import { type MutableRefObject, useEffect } from "react";
 
 import {
   COMPOSER_FOCUS_EVENT,
+  consumePendingComposerFocus,
   insertTextAtSelection,
-  isComposerFocusPending,
   shouldFocusComposerForTyping,
-  tryClaimComposerFocus,
 } from "@/domains/chat/composer-focus";
 import { useComposerStore } from "@/domains/chat/composer-store";
 
 export function useComposerKeyboard(
   inputRef: MutableRefObject<HTMLTextAreaElement | null>,
 ): void {
-  // 1. Host focus relay + pending-focus claim loop.
+  // 1. Host focus relay + pending-focus drain.
   useEffect(() => {
-    let raf = 0;
-    const claim = () => {
-      tryClaimComposerFocus(inputRef.current);
+    const focusInput = () => inputRef.current?.focus();
+    const handleFocusRequest = () => {
+      consumePendingComposerFocus();
+      focusInput();
     };
-    const tick = () => {
-      claim();
-      if (isComposerFocusPending()) {
-        raf = requestAnimationFrame(tick);
-      } else {
-        raf = 0;
-      }
-    };
-    const startClaimLoop = () => {
-      if (raf !== 0) {
-        return;
-      }
-      tick();
-    };
-
-    window.addEventListener(COMPOSER_FOCUS_EVENT, startClaimLoop);
-    if (isComposerFocusPending()) {
-      startClaimLoop();
+    window.addEventListener(COMPOSER_FOCUS_EVENT, handleFocusRequest);
+    if (consumePendingComposerFocus()) {
+      queueMicrotask(focusInput);
     }
-    return () => {
-      window.removeEventListener(COMPOSER_FOCUS_EVENT, startClaimLoop);
-      cancelAnimationFrame(raf);
-    };
+    return () =>
+      window.removeEventListener(COMPOSER_FOCUS_EVENT, handleFocusRequest);
   }, [inputRef]);
 
-  // 2. Typing auto-focus — redirect keypresses to the composer.
+  // 2. Typing auto-focus: redirect keypresses to the composer.
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       const inputEl = inputRef.current;

--- a/clients/web/src/domains/chat/new-chat-shortcut.test.ts
+++ b/clients/web/src/domains/chat/new-chat-shortcut.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+let electron = false;
+
+mock.module("@/runtime/is-electron", () => ({
+  isElectron: () => electron,
+}));
+
+const { newChatAccelerator, newChatShortcutHint } = await import(
+  "@/domains/chat/new-chat-shortcut"
+);
+
+describe("newChatShortcutHint", () => {
+  afterEach(() => {
+    electron = false;
+  });
+
+  test("Electron hosts advertise Cmd/Ctrl+N", () => {
+    electron = true;
+    expect(newChatAccelerator()).toBe("CmdOrCtrl+N");
+    expect(newChatShortcutHint()).toBe("⌘N");
+  });
+
+  test("the web host advertises the in-app Cmd/Ctrl+Shift+O chord", () => {
+    electron = false;
+    expect(newChatAccelerator()).toBe("CmdOrCtrl+Shift+O");
+    expect(newChatShortcutHint()).toBe("⌘⇧O");
+  });
+});

--- a/clients/web/src/domains/chat/new-chat-shortcut.ts
+++ b/clients/web/src/domains/chat/new-chat-shortcut.ts
@@ -1,0 +1,28 @@
+import { parseAccelerator } from "@vellumai/design-library";
+
+import { isElectron } from "@/runtime/is-electron";
+
+/**
+ * Electron File menu accelerator for New Chat (`DEFAULT_ACCELERATORS.newConversation`).
+ * The native macOS/Windows app binds this as a menu shortcut.
+ */
+export const ELECTRON_NEW_CHAT_ACCELERATOR = "CmdOrCtrl+N";
+
+/**
+ * In-app web shortcut registered by `useChatLayoutShortcuts` (the ChatGPT /
+ * Claude convention). Used when the renderer is not inside Electron, where
+ * Cmd/Ctrl+N would create a browser window instead.
+ */
+export const WEB_NEW_CHAT_ACCELERATOR = "CmdOrCtrl+Shift+O";
+
+/** Electron accelerator string for the host this renderer is running in. */
+export function newChatAccelerator(): string {
+  return isElectron()
+    ? ELECTRON_NEW_CHAT_ACCELERATOR
+    : WEB_NEW_CHAT_ACCELERATOR;
+}
+
+/** Compact glyph form for tooltips and palette hints (`⌘N`, `⌘⇧O`). */
+export function newChatShortcutHint(): string {
+  return parseAccelerator(newChatAccelerator()).join("");
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan
Native macOS feedback: New Chat already has a hotkey, but it is not discoverable, and after starting a new chat the composer caret does not blink (focus lands on the textarea, then falls back to `<body>`).

Approach:
- Show the host shortcut on hover of the sidebar New Chat control (`⌘N` in Electron, `⌘⇧O` on the web).
- Keep the ChatBody tree identity stable when starters dock, so the composer does not remount and blur. That is the focus fix. No timed retry.

## Summary
- Hovering the rail New Chat button now tooltips the shortcut (`⌘N` in the macOS/Windows app, `⌘⇧O` on the web, where Cmd/Ctrl+N would open a browser window).
- Starting a new chat no longer remounts the composer when empty-state starters dock, so the caret stays on the textarea.
- Host focus is the original one-shot `requestComposerFocus()` drain. There is no 800ms claim loop.

## Test plan
- `bun test` on:
  - `clients/web/src/domains/chat/composer-focus.test.ts`
  - `clients/web/src/domains/chat/hooks/use-composer-keyboard.test.tsx`
  - `clients/web/src/domains/chat/new-chat-shortcut.test.ts`
  - `clients/web/src/domains/chat/components/chat-body.test.tsx`
  - `clients/web/src/domains/chat/components/assistant-nav-item.test.tsx`
  - `clients/web/src/domains/chat/hooks/use-command-palette-sections.test.ts`
  - `clients/web/src/hooks/use-global-deep-link-consumer.test.tsx`
  - `clients/web/src/domains/chat/hooks/use-deep-link-thread-send.test.tsx`
- Result: 114 pass, 0 fail.
- Manual: in the macOS app, hover New Chat and confirm `⌘N`; create a new chat and confirm the caret blinks in the composer without clicking.

## Risk
- Medium: ChatBody empty-state layout is unified so docked/undocked no longer remount the composer. Watch empty-state centering, keyboard-open bottom-anchor, and starter docking.
- Tooltip is rail-only (collapsed + expanded). Overlay mobile New Chat is unchanged.
- Shortcut hints use the shipped defaults, not per-user hotkey overrides (same as the command palette).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-00e5e60f-09f6-48f7-a441-696d00bd5248?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-00e5e60f-09f6-48f7-a441-696d00bd5248&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

