### PR TITLE
fix(web): match the swipe layer to the surface a row sits on

### DIFF
--- a/clients/web/src/components/swipe-action-reveal.test.tsx
+++ b/clients/web/src/components/swipe-action-reveal.test.tsx
@@ -49,6 +49,21 @@ describe("SwipeActionReveal", () => {
     expect(html).toContain("Test");
   });
 
+  test("the content layer takes its opaque fill from the surface it sits on", () => {
+    const html = renderToStaticMarkup(
+      <SwipeActionReveal enabled={true} trailingActions={[noopAction]}>
+        <div>Row content</div>
+      </SwipeActionReveal>,
+    );
+    // The layer hides the actions until a swipe reveals them, so it can never
+    // be transparent. Reading `--swipe-reveal-bg` is what lets a host that
+    // rests its rows on something other than the panel surface (the sidebar's
+    // section card) hand down its own fill instead of banding every row.
+    expect(html).toContain(
+      "bg-[var(--swipe-reveal-bg,var(--surface-overlay))]",
+    );
+  });
+
   test("renders leading and trailing action buttons", () => {
     const leadingAction: SwipeAction = {
       id: "pin",

--- a/clients/web/src/components/swipe-action-reveal.tsx
+++ b/clients/web/src/components/swipe-action-reveal.tsx
@@ -197,10 +197,15 @@ export const SwipeActionReveal = forwardRef<
         </div>
       ) : null}
 
-      {/* Content layer — slides over the action layers */}
+      {/* Content layer, sliding over the action layers. Its fill has to be
+          opaque so the actions stay hidden until a swipe reveals them, and it
+          has to match whatever surface the row sits on or the row reads as a
+          differently-coloured band. `--swipe-reveal-bg` lets that surface name
+          itself (the sidebar's section card publishes its own), falling back
+          to the panel surface a row rests on elsewhere. */}
       <div
         className={cn(
-          "relative bg-[var(--surface-overlay)] transition-transform",
+          "relative bg-[var(--swipe-reveal-bg,var(--surface-overlay))] transition-transform",
           isDragging && "transition-none",
         )}
         style={{

--- a/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -1338,6 +1338,30 @@ describe("AssistantSideMenu · section spacing", () => {
   });
 });
 
+describe("AssistantSideMenu · section card surface", () => {
+  /* A conversation row rests transparent, so on touch the swipe layer wrapping
+     it is what actually paints behind the label. Left to its own default that
+     layer takes the panel surface, which is a different colour from the card,
+     and every row in the card reads as a sunken band. The card publishes its
+     own fill so the layer matches whatever the card is. */
+  test("every section card names the fill its swipeable rows sit on", () => {
+    const container = parse(
+      renderMenu({
+        conversations: LAYOUT_CONVERSATIONS,
+        conversationGroups: LAYOUT_GROUPS,
+      }),
+    );
+
+    const cards = sectionCards(container);
+    expect(cards).toHaveLength(4);
+    for (const card of cards) {
+      expect(card.className).toContain(
+        "[--swipe-reveal-bg:var(--surface-lift)]",
+      );
+    }
+  });
+});
+
 describe("AssistantSideMenu · default section order", () => {
   // The point of LUM-2909: groups are the deliberate organization layer, so
   // they lead rather than sitting under channel sections that come and go.

--- a/clients/web/src/domains/chat/components/sidebar-section-card.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-section-card.tsx
@@ -106,6 +106,12 @@ export function SidebarSectionCard({
       bordered={false}
       noPadding
       className={cn(
+        /* A swipeable row inside this card paints an opaque layer of its own
+           so its actions stay hidden until swiped, so the card names the
+           surface that layer has to match. Declared here rather than on the
+           row: the card is what owns the fill, and every swipeable thing it
+           holds inherits the one value. */
+        "[--swipe-reveal-bg:var(--surface-lift)]",
         /* No padding of its own: the header row is already a self-contained
            pill (its own height, its own 12px/6px inset) per Figma, and
            wrapping it in another layer of padding would inflate the pill
@@ -129,7 +135,9 @@ export function SidebarSectionCard({
            inset its header and row list sit flush inside (Figma 7842-83305);
            the rail keeps the radius that makes its 36px header read as fully
            round. */
-        overlayCards ? "rounded-[16px] pt-2.5 pr-3 pb-1.5 pl-2" : "rounded-[18px]",
+        overlayCards
+          ? "rounded-[16px] pt-2.5 pr-3 pb-1.5 pl-2"
+          : "rounded-[18px]",
         "has-[[data-state=open]]:w-full",
         /* `width` toggles between the measured `--section-collapsed-width`
            (a real length - see the `ResizeObserver` above) and a percentage,


### PR DESCRIPTION
## Problem

On iOS, every conversation row in the sidebar drawer renders as a darker band inside its section card:

| Region | Measured on device | Token |
|---|---|---|
| Card padding | `#24292E` | `--surface-lift` (matches the mock) |
| **Row strip** | `#1C2024` | `--surface-overlay` |
| Active row | `#282B2F` | `--surface-hover` over `#1C2024` |

Per [Figma 7842-83305](https://www.figma.com/design/cCGBcpVDbn22kj3OPU58W8/New-App?node-id=7842-83305) the rows carry no fill of their own; they should read as one uniform card.

## Cause

`PanelItem` rows rest `bg-transparent`, so the fill is not coming from the row. On a coarse pointer `ConversationRow` wraps each row in `SwipeActionReveal`, whose content layer must be opaque so the swipe actions stay hidden until revealed. That layer hardcoded `bg-[var(--surface-overlay)]`, which was correct while sidebar rows sat on the panel surface. They now sit inside a `--surface-lift` section card, so the two no longer agree. Card sections set `gap-0`, so the per-row layers tile into the continuous strip visible above.

The colour arithmetic confirms it: `--surface-hover` (6% white) over `#1C2024` gives `#282B2F`, the measured active row to within one unit per channel. Over the card it would be `#303439`.

## Fix

- `SwipeActionReveal`'s content layer reads `--swipe-reveal-bg`, falling back to `--surface-overlay` so every other caller is unchanged.
- `SidebarSectionCard` publishes `--swipe-reveal-bg: var(--surface-lift)`.

Declared on the card rather than the row because the card owns the fill: every swipeable thing inside inherits one value, and a custom workspace theme (which can remap `--surface-overlay` via `workspace-theme-tokens.ts`) cannot split the two apart.

## Scope

**Desktop web and Electron are unaffected.** `SwipeActionReveal` returns a passthrough before rendering the content layer when `isPointerCoarse()` is false, so the element carrying this class never exists there. No production call site overrides `enabled`. The card's declaration does emit everywhere, but a custom property paints nothing on its own and has exactly one reader.

The honest gate is *coarse pointer*, not platform, so a touchscreen laptop is also corrected. Light mode is fixed too (`#FDFDFC` on `#FFFFFF`), though the mismatch there is far subtler.

## Verification

- Diagnosed by sampling pixels from a device screenshot and by probing the resolved custom property in Storybook: inside a card it resolves to `rgb(36,41,46)`; outside one it still falls back to `#1C2024`.
- Two regression tests, both confirmed to **fail** with the fix reverted rather than passing vacuously.
- Typecheck, ESLint, Prettier clean; 9 + 69 + 5 tests pass.

**Not yet confirmed on hardware.** Playwright cannot emulate a coarse pointer, so the swipe layer never rendered during verification. What is proven is that the property resolves to the card's fill; that the layer reads it is a one-token class change plus a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
