### PR TITLE
fix(companion): stop an abandoned drag bricking the surface (JARVIS-1539)

### DIFF
--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -17,8 +17,13 @@ mock.module("electron-store", () => ({
 
 // Dynamic, so the mock above is installed before the module graph loads:
 // static imports hoist above it.
-const { growthFor, callOnStart, callOnUpdate, shouldShowCompanionSurface } =
-  await import("./companion-window");
+const {
+  growthFor,
+  clampCanvasOrigin,
+  callOnStart,
+  callOnUpdate,
+  shouldShowCompanionSurface,
+} = await import("./companion-window");
 
 /** A session as the mirror publishes one, before main stamps its clock. */
 const START = {
@@ -89,6 +94,91 @@ describe("growthFor", () => {
  * about the elapsed clock, which is the one thing on the call pill that main
  * owns rather than passes through.
  */
+/**
+ * The clamp is the other half of that: growth decides which way the pill
+ * unfurls, and this decides whether the avatar it unfurls from is still
+ * somewhere the user can reach. A surface pushed off the display cannot be
+ * dragged back, because there is nothing left on screen to grab.
+ */
+
+// The canvas the avatar is centred in, from the constants the module derives
+// them from: 360 wide at most, a 44 avatar, 24 of shadow padding.
+const CANVAS_WIDTH = (360 - 44 / 2) * 2 + 24 * 2;
+const CANVAS_HEIGHT = (290 - 44 / 2 + 24) * 2;
+
+/** A 1440x900 display with the menu bar taken off the top. */
+const WORK_AREA = { x: 0, y: 25, width: 1440, height: 875 };
+
+/** The canvas origin that puts the avatar's centre exactly here. */
+const originFor = (centreX: number, centreY: number) => ({
+  x: centreX - CANVAS_WIDTH / 2,
+  y: centreY - CANVAS_HEIGHT / 2,
+});
+
+/** Where the avatar's centre ends up for a given canvas origin. */
+const centreOf = (origin: { x: number; y: number }) => ({
+  x: origin.x + CANVAS_WIDTH / 2,
+  y: origin.y + CANVAS_HEIGHT / 2,
+});
+
+describe("clampCanvasOrigin", () => {
+  test("leaves a position inside the work area alone", () => {
+    const origin = originFor(700, 500);
+    expect(clampCanvasOrigin(origin, WORK_AREA)).toEqual({
+      x: Math.round(origin.x),
+      y: Math.round(origin.y),
+    });
+  });
+
+  test("holds the avatar at the right edge rather than past it", () => {
+    const flung = originFor(9000, 500);
+    expect(centreOf(clampCanvasOrigin(flung, WORK_AREA)).x).toBe(1440 - 22);
+  });
+
+  test("holds the avatar at the left edge rather than past it", () => {
+    const flung = originFor(-9000, 500);
+    expect(centreOf(clampCanvasOrigin(flung, WORK_AREA)).x).toBe(22);
+  });
+
+  test("keeps the avatar below the menu bar", () => {
+    const flung = originFor(700, -9000);
+    expect(centreOf(clampCanvasOrigin(flung, WORK_AREA)).y).toBe(25 + 22);
+  });
+
+  test("holds the avatar at the bottom edge rather than past it", () => {
+    const flung = originFor(700, 9000);
+    expect(centreOf(clampCanvasOrigin(flung, WORK_AREA)).y).toBe(900 - 22);
+  });
+
+  /**
+   * The canvas is far wider than the avatar, so a clamp written against the
+   * canvas box would refuse to let the avatar anywhere near the edge. The
+   * corner is exactly where the surface is meant to rest.
+   */
+  test("lets the avatar reach the corner the surface opens in", () => {
+    const corner = originFor(1440 - 22, 900 - 22);
+    expect(centreOf(clampCanvasOrigin(corner, WORK_AREA))).toEqual({
+      x: 1440 - 22,
+      y: 900 - 22,
+    });
+  });
+
+  test("clamps against the display it is given, not the primary one", () => {
+    const secondary = { x: 1440, y: 0, width: 1920, height: 1080 };
+    const flung = originFor(99999, 500);
+    expect(centreOf(clampCanvasOrigin(flung, secondary)).x).toBe(
+      1440 + 1920 - 22,
+    );
+  });
+
+  test("stays inside a work area too small for the avatar", () => {
+    const tiny = { x: 0, y: 0, width: 10, height: 10 };
+    const centre = centreOf(clampCanvasOrigin(originFor(9000, 9000), tiny));
+    expect(centre.x).toBeLessThanOrEqual(10);
+    expect(centre.y).toBeLessThanOrEqual(10);
+  });
+});
+
 describe("the session main holds", () => {
   test("start stamps the clock", () => {
     expect(callOnStart(null, START, 1_000).startedAt).toBe(1_000);

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -270,6 +270,46 @@ export const growthFor = (
 };
 
 /**
+ * Keep the avatar on screen, whatever the drag asks for.
+ *
+ * A drag arrives as a delta and is applied blind, so nothing in the gesture
+ * itself stops the surface being pushed past the edge of the display. It has to
+ * be stopped here, because there is no way back: the canvas is transparent and
+ * mostly empty, so a surface pushed off screen leaves nothing to grab and
+ * nothing to see, and the position is not persisted, so the only recovery is
+ * relaunching the app.
+ *
+ * The avatar is what is kept inside the work area, not the canvas. The canvas
+ * reaches hundreds of points past the avatar in every direction to hold a pill
+ * that is usually not drawn, and clamping that box would fence the avatar into
+ * the middle of the display, unable to reach the corner it is meant to rest in.
+ *
+ * Exported for its tests, as {@link growthFor} is, and pure for the same
+ * reason: it is the rule that decides whether the surface can be lost.
+ */
+export const clampCanvasOrigin = (
+  origin: { x: number; y: number },
+  workArea: { x: number; y: number; width: number; height: number },
+): { x: number; y: number } => {
+  const centreX = origin.x + CANVAS_WIDTH / 2;
+  const centreY = origin.y + CANVAS_HEIGHT / 2;
+  // Half the avatar may hang past the edge, so the clamp is to its centre plus
+  // a half box. A work area smaller than the avatar would put the maximum below
+  // the minimum, which `Math.min` then resolves toward the top-left corner
+  // rather than producing a position outside the display.
+  const minCentreX = workArea.x + AVATAR_BOX / 2;
+  const maxCentreX = workArea.x + workArea.width - AVATAR_BOX / 2;
+  const minCentreY = workArea.y + AVATAR_BOX / 2;
+  const maxCentreY = workArea.y + workArea.height - AVATAR_BOX / 2;
+  const clampedX = Math.min(Math.max(centreX, minCentreX), maxCentreX);
+  const clampedY = Math.min(Math.max(centreY, minCentreY), maxCentreY);
+  return {
+    x: Math.round(clampedX - CANVAS_WIDTH / 2),
+    y: Math.round(clampedY - CANVAS_HEIGHT / 2),
+  };
+};
+
+/**
  * Where the surface opens with no remembered position: the bottom-right of the
  * display under the cursor, near where the Dock usually is and clear of the
  * window the user is working in.
@@ -381,6 +421,11 @@ export const installCompanionWindow = (): void => {
   // that knows where the window currently is. Moving fires `move`, which
   // recomputes the direction, so dragging toward a screen edge flips the growth
   // before the user gets there.
+  //
+  // The delta is clamped rather than trusted. A drag that outruns the window,
+  // or one whose release this window never saw, arrives here as a single huge
+  // jump, and unclamped that jump puts the surface somewhere the user cannot
+  // reach it. See `clampCanvasOrigin`.
   on(
     "vellum:companion:moveBy",
     z.tuple([z.number(), z.number()]),
@@ -390,7 +435,17 @@ export const installCompanionWindow = (): void => {
         return;
       }
       const [x, y] = win.getPosition();
-      win.setPosition(Math.round(x + dx), Math.round(y + dy));
+      const wanted = { x: x + dx, y: y + dy };
+      // Measured against the display the drag is heading for rather than the
+      // one it started on, so a surface dragged onto a second display is
+      // clamped to that display's edges instead of being held back at the
+      // first one's.
+      const { workArea } = screen.getDisplayNearestPoint({
+        x: Math.round(wanted.x + CANVAS_WIDTH / 2),
+        y: Math.round(wanted.y + CANVAS_HEIGHT / 2),
+      });
+      const next = clampCanvasOrigin(wanted, workArea);
+      win.setPosition(next.x, next.y);
     },
   );
 

--- a/clients/web/src/components/companion-surface-page.test.tsx
+++ b/clients/web/src/components/companion-surface-page.test.tsx
@@ -1,0 +1,205 @@
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import type { CompanionSurfaceState } from "@vellumai/ipc-contract";
+
+const moveByMock = mock((_dx: number, _dy: number) => undefined);
+const setInteractiveMock = mock((_interactive: boolean) => undefined);
+const activateMock = mock(() => undefined);
+
+const STATE: CompanionSurfaceState = {
+  growth: "right",
+  call: null,
+  assistantName: "Ziggy",
+  turns: [],
+};
+
+mock.module("@/runtime/companion-surface", () => ({
+  getCompanionState: async () => STATE,
+  subscribeCompanionState: () => () => undefined,
+  setCompanionInteractive: setInteractiveMock,
+  moveCompanionBy: moveByMock,
+  activateCompanionApp: activateMock,
+  startCompanionVoice: () => undefined,
+  submitCompanionMessage: () => undefined,
+  setCompanionComposing: () => undefined,
+  setCompanionContext: () => undefined,
+}));
+
+mock.module("@/runtime/desktop-voice-activity", () => ({
+  sendVoiceActivityControl: () => undefined,
+}));
+
+const { CompanionSurfacePage } = await import("./companion-surface-page");
+
+afterEach(() => {
+  cleanup();
+  moveByMock.mockClear();
+  setInteractiveMock.mockClear();
+  activateMock.mockClear();
+});
+
+/** The canvas the page fills, which is where the pointer handlers live. */
+const canvasOf = (container: HTMLElement): HTMLElement => {
+  const canvas = container.firstElementChild;
+  if (!(canvas instanceof HTMLElement)) {
+    throw new Error("Expected the canvas root to render");
+  }
+  return canvas;
+};
+
+/**
+ * The pill, pinned somewhere the hit-test can find it.
+ *
+ * The surface measures itself live, and nothing lays out in the test DOM, so
+ * every rect would otherwise be zero and the pointer would never be over the
+ * pill at all.
+ */
+const pinPill = async (container: HTMLElement): Promise<HTMLElement> => {
+  const pill = await waitFor(() => {
+    const found = container.querySelector<HTMLElement>(".cursor-grab");
+    if (!found) {
+      throw new Error("Expected the pill to render");
+    }
+    return found;
+  });
+  pill.getBoundingClientRect = () =>
+    ({
+      left: 100,
+      right: 144,
+      top: 100,
+      bottom: 144,
+      x: 100,
+      y: 100,
+      width: 44,
+      height: 44,
+      toJSON: () => ({}),
+    }) as DOMRect;
+  return pill;
+};
+
+/** The avatar inside the pill, which is what a press "goes back to Vellum". */
+const avatarOf = (container: HTMLElement): HTMLElement => {
+  const avatar = container.querySelector<HTMLElement>(".place-items-center");
+  if (!avatar) {
+    throw new Error("Expected the avatar to render");
+  }
+  return avatar;
+};
+
+describe("dragging the companion surface", () => {
+  test("moves the window by the pointer's travel", async () => {
+    const { container } = render(<CompanionSurfacePage />);
+    const pill = await pinPill(container);
+    const canvas = canvasOf(container);
+
+    fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
+    fireEvent.mouseDown(pill, { screenX: 500, screenY: 500 });
+    fireEvent.mouseMove(canvas, {
+      clientX: 120,
+      clientY: 120,
+      screenX: 530,
+      screenY: 520,
+      buttons: 1,
+    });
+
+    expect(moveByMock.mock.calls).toEqual([[30, 20]]);
+  });
+
+  /**
+   * The brick: a release this window never saw used to leave the press running
+   * forever, so the surface chased a pointer with no button held and the window
+   * stayed clickable across the whole canvas.
+   */
+  test("ends a drag whose release landed outside the window", async () => {
+    const { container } = render(<CompanionSurfacePage />);
+    const pill = await pinPill(container);
+    const canvas = canvasOf(container);
+
+    fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
+    fireEvent.mouseDown(pill, { screenX: 500, screenY: 500 });
+    fireEvent.mouseMove(canvas, {
+      clientX: 120,
+      clientY: 120,
+      screenX: 520,
+      screenY: 500,
+      buttons: 1,
+    });
+    moveByMock.mockClear();
+
+    // The button came up over another app, so no `mouseup` and no `mouseleave`
+    // ever reached this window. The pointer comes back a long way away.
+    fireEvent.mouseMove(canvas, {
+      clientX: 900,
+      clientY: 900,
+      screenX: 1300,
+      screenY: 1200,
+      buttons: 0,
+    });
+
+    expect(moveByMock).not.toHaveBeenCalled();
+  });
+
+  test("hit-tests again once the abandoned drag is dropped", async () => {
+    const { container } = render(<CompanionSurfacePage />);
+    const pill = await pinPill(container);
+    const canvas = canvasOf(container);
+
+    fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
+    expect(setInteractiveMock.mock.calls.at(-1)).toEqual([true]);
+    fireEvent.mouseDown(pill, { screenX: 500, screenY: 500 });
+    fireEvent.mouseMove(canvas, {
+      clientX: 120,
+      clientY: 120,
+      screenX: 520,
+      screenY: 500,
+      buttons: 1,
+    });
+
+    // Off the pill with the button already released: the window has to go back
+    // to click-through, or it swallows every press on this corner of the
+    // desktop until the app is relaunched.
+    fireEvent.mouseMove(canvas, {
+      clientX: 900,
+      clientY: 900,
+      screenX: 1300,
+      screenY: 1200,
+      buttons: 0,
+    });
+
+    expect(setInteractiveMock.mock.calls.at(-1)).toEqual([false]);
+  });
+
+  test("a press that travelled is not a click on the avatar", async () => {
+    const { container } = render(<CompanionSurfacePage />);
+    const pill = await pinPill(container);
+    const canvas = canvasOf(container);
+
+    fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
+    fireEvent.mouseDown(pill, { screenX: 500, screenY: 500 });
+    fireEvent.mouseMove(canvas, {
+      clientX: 120,
+      clientY: 120,
+      screenX: 540,
+      screenY: 500,
+      buttons: 1,
+    });
+    fireEvent.mouseUp(canvas);
+    fireEvent.click(avatarOf(container));
+
+    expect(activateMock).not.toHaveBeenCalled();
+  });
+
+  test("a press that held still still goes back to Vellum", async () => {
+    const { container } = render(<CompanionSurfacePage />);
+    const pill = await pinPill(container);
+    const canvas = canvasOf(container);
+
+    fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
+    fireEvent.mouseDown(pill, { screenX: 500, screenY: 500 });
+    fireEvent.mouseUp(canvas);
+    fireEvent.click(avatarOf(container));
+
+    expect(activateMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/web/src/components/companion-surface-page.tsx
+++ b/clients/web/src/components/companion-surface-page.tsx
@@ -177,6 +177,28 @@ export function CompanionSurfacePage() {
    * the moment it finished growing.
    */
   const onMouseMove = (event: MouseEvent<HTMLDivElement>) => {
+    // **A drag whose release this window never saw ends here.**
+    //
+    // The drag is ended by `mouseup` or by the pointer leaving the canvas, and
+    // both are events this window has to receive. Neither arrives when the
+    // button comes up over another app: the canvas is a bounded rectangle, a
+    // fast drag outruns a window that is moved a message at a time, and the
+    // release then lands somewhere this page is not.
+    //
+    // Left alone that press never ends. Every later move is read as a drag
+    // frame, so the surface follows a pointer with no button held and the first
+    // move after the pointer returns carries the whole distance travelled in
+    // between, flinging it across the desktop. Hit-testing never resumes
+    // either, so the window stays clickable across a canvas many times the size
+    // of the pill, swallowing presses meant for whatever is behind it. That is
+    // the state that reads as the surface being dead until the app is
+    // relaunched.
+    //
+    // No button held means the press is over, whatever this window saw of it,
+    // so the drag is dropped and this move goes on to hit-test normally.
+    if (dragRef.current !== null && event.buttons === 0) {
+      dragRef.current = null;
+    }
     // A drag owns the pointer until it is released. Hit-testing through it
     // would collapse the surface the moment the cursor left the pill, which is
     // most of any drag worth making.


### PR DESCRIPTION
Fixes JARVIS-1539.

## The premise that turned out to be wrong

Dragging by the avatar already works. The whole surface is the drag handle and controls opt out by stopping the press (`companion-surface.tsx:414`), so the avatar is grabbable today. No change was needed there; this PR adds tests to keep it that way, including the drag-vs-click distinction that decides whether a press goes back to Vellum.

## The brick

Not the `blur()` suspect the ticket listed. `dragRef` is cleared only by `mouseup` on the canvas or by the pointer leaving it, and both are events this window has to receive. Neither arrives when the button comes up over another app, which happens readily: the canvas is a bounded rectangle and a fast drag outruns a window moved one IPC message at a time, so the release lands somewhere the page is not.

Left running, that press never ends:

- every later move is read as a drag frame, so the surface chases a pointer with no button held, and the first move after the pointer returns carries the whole distance travelled in between;
- hit-testing never resumes, so the window stays clickable across a 724x584 transparent canvas and swallows presses meant for whatever is behind it.

Both read as the avatar going dead. The position is not persisted (`floating-window.ts` applies `defaultCanvasOrigin` on create), which is exactly why relaunching was the only way back.

## The fix

- **Renderer** — a move with no button held drops the drag and goes on to hit-test normally. Self-correcting from any missed release, whatever the cause.
- **Main** — the delta is clamped against the work area of the display the drag is heading for, so a jump that does get through can no longer put the avatar somewhere there is nothing left to grab. The clamp is on the avatar, not the canvas: the canvas reaches hundreds of points past the avatar to hold a pill that is usually not drawn, and clamping that box would fence the avatar out of the corner it is meant to rest in.

## Verification

- 5 new renderer tests, 8 new `clampCanvasOrigin` tests. All pass.
- Both brick regression tests were confirmed to **fail** with the guard removed and pass with it.
- `bun run typecheck` clean in `clients/web` and `clients/macos`; lint clean.
- The `clients/macos/src/main/` suite reports 202 failures when run as a whole directory. Identical on untouched `main` (the known cross-file `mock.module` leak), and this branch adds 8 passing tests with no new failures.

**Not verified in the running app.** The surface is behind the `companion-surface` flag, and this is a timing bug fixed by reasoning from the code rather than from a live reproduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)