### PR TITLE
feat(flags): enable plugin-schedules by default

### DIFF
--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -362,7 +362,7 @@
       "key": "plugin-schedules",
       "label": "Plugin Schedules",
       "description": "Plugins declare recurring schedules as files that register and run automatically",
-      "defaultEnabled": false
+      "defaultEnabled": true
     },
     {
       "id": "experiment-balanced-model-2026-08-06",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -362,7 +362,7 @@
       "key": "plugin-schedules",
       "label": "Plugin Schedules",
       "description": "Plugins declare recurring schedules as files that register and run automatically",
-      "defaultEnabled": false
+      "defaultEnabled": true
     },
     {
       "id": "experiment-balanced-model-2026-08-06",


### PR DESCRIPTION
## Summary
- Flips the plugin-schedules registry default to enabled so assistants without a platform flag snapshot (offline and local-mode) get plugin-declared schedules.
- Note: per the gateway's GA normalization, merging this removes the platform's ability to remotely disable the flag for connected assistants (remote false for a defaultEnabled:true flag is rewritten to true). Hold until the LaunchDarkly rollout has baked.