### PR TITLE
fix(schedule): load feature flag overrides in the schedule worker

### DIFF
--- a/assistant/src/schedule/__tests__/worker-feature-flags.test.ts
+++ b/assistant/src/schedule/__tests__/worker-feature-flags.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Guards over the schedule worker entrypoint's feature flag bootstrap.
+ *
+ * The override cache is process-local, so this worker has to populate its own.
+ * When it does not, every flag check inside it resolves to the registry default
+ * and ignores remote values and local overrides, and this is the process that
+ * decides at fire time whether a schedule runs. The entrypoint installs signal
+ * handlers and calls `process.exit`, so it cannot be imported into a test
+ * process; these assertions read its source the same way
+ * `src/__tests__/worker-entrypoint-guards.test.ts` does.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+const INIT_CALL = "await initFeatureFlagOverrides(";
+const REFRESH_CALL = "refreshOverridesFromGateway(";
+const REFRESH_INTERVAL = "FLAG_REFRESH_INTERVAL_MS";
+
+/** The worker's first call that can execute a schedule. */
+const WORK_START = "void tick()";
+
+function readWorkerSource(): string {
+  return readFileSync(join(process.cwd(), "src/schedule/worker.ts"), "utf8");
+}
+
+describe("schedule worker feature flags", () => {
+  test("loads flag overrides before the first schedule tick", () => {
+    const source = readWorkerSource();
+    const initAt = source.indexOf(INIT_CALL);
+    const workAt = source.indexOf(WORK_START);
+
+    expect(
+      initAt,
+      `The schedule worker must \`${INIT_CALL})\` at startup. Without it ` +
+        "its process-local override cache stays unset and fire-time flag " +
+        "checks fall back to registry defaults.",
+    ).toBeGreaterThanOrEqual(0);
+    expect(workAt).toBeGreaterThanOrEqual(0);
+    expect(
+      initAt < workAt,
+      "The flag load must complete before the first tick, so the schedules " +
+        "that tick fires are gated on real flag values.",
+    ).toBe(true);
+  });
+
+  test("re-reads the flag cache on a timer while running", () => {
+    const source = readWorkerSource();
+
+    expect(
+      source.includes(REFRESH_CALL) && source.includes(REFRESH_INTERVAL),
+      `This process outlives any single flag value, so it must call ` +
+        `${REFRESH_CALL}) on the ${REFRESH_INTERVAL} timer rather than ` +
+        "holding whatever was cached at startup.",
+    ).toBe(true);
+  });
+});

--- a/assistant/src/schedule/worker.ts
+++ b/assistant/src/schedule/worker.ts
@@ -58,8 +58,15 @@ async function main(): Promise<void> {
   // runs at all. Awaited so the first tick reads real values, and best-effort:
   // a gateway that never answers leaves the cache unset and the worker falls
   // back to registry defaults rather than failing to start.
+  // Bounded to one short attempt: a gateway that accepts the socket but never
+  // answers would otherwise hold the first tick for the full production retry
+  // schedule. A miss here leaves the cache unset (registry defaults) and the
+  // periodic refresh below converges to real values within a minute.
   try {
-    await initFeatureFlagOverrides();
+    await initFeatureFlagOverrides({
+      retryBackoffsMs: [],
+      callTimeoutMs: 2_000,
+    });
   } catch (err) {
     log.warn(
       { err },

--- a/assistant/src/schedule/worker.ts
+++ b/assistant/src/schedule/worker.ts
@@ -13,6 +13,10 @@
  */
 import { writeFileSync } from "node:fs";
 
+import {
+  initFeatureFlagOverrides,
+  refreshOverridesFromGateway,
+} from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
 import { rehydratePlatformCredentials } from "../config/platform-rehydration.js";
 import { resetDb } from "../persistence/db-connection.js";
@@ -32,6 +36,9 @@ const log = getLogger("schedule-worker-process");
 /** Same cadence as the daemon scheduler's tick. */
 const TICK_INTERVAL_MS = 15_000;
 
+/** How often this process re-reads flag overrides from the gateway. */
+const FLAG_REFRESH_INTERVAL_MS = 60_000;
+
 async function main(): Promise<void> {
   // Only the daemon stamps SSE seqs and writes the shared reservation file.
   disableStreamSeqStamping();
@@ -43,6 +50,22 @@ async function main(): Promise<void> {
   // Write PID file so `status` and `stop` can find us.
   writeFileSync(pidPath, String(process.pid), { flag: "w" });
   log.info({ pid: process.pid, pidPath }, "Schedule worker process started");
+
+  // The override cache is per-process, so this worker has to populate its own
+  // even though the daemon already populated the daemon's. Without it every
+  // flag check here resolves to its registry default and ignores both remote
+  // values and local overrides, which decides at fire time whether a schedule
+  // runs at all. Awaited so the first tick reads real values, and best-effort:
+  // a gateway that never answers leaves the cache unset and the worker falls
+  // back to registry defaults rather than failing to start.
+  try {
+    await initFeatureFlagOverrides();
+  } catch (err) {
+    log.warn(
+      { err },
+      "Failed to load feature flag overrides in schedule worker; continuing on registry defaults",
+    );
+  }
 
   // Rehydrate the platform base URL and IDs from the credential store before
   // the first tick. The daemon does this in initializeProvidersAndTools(); this
@@ -74,12 +97,16 @@ async function main(): Promise<void> {
   let stopped = false;
   let tickRunning = false;
   let timer: ReturnType<typeof setInterval> | null = null;
+  let flagRefreshTimer: ReturnType<typeof setInterval> | null = null;
   let disposePidGuard: (() => void) | null = null;
   const shutdown = (signal: string) => {
     log.info({ signal }, "Schedule worker process shutting down");
     stopped = true;
     if (timer != null) {
       clearInterval(timer);
+    }
+    if (flagRefreshTimer != null) {
+      clearInterval(flagRefreshTimer);
     }
     disposePidGuard?.();
     cleanupWorkerPidFile(pidPath);
@@ -127,6 +154,20 @@ async function main(): Promise<void> {
   }, TICK_INTERVAL_MS);
   void tick();
 
+  // This process outlives any single flag value, so poll the gateway instead of
+  // holding whatever was cached at startup. The daemon's gateway flag listener
+  // is not reusable here: it also reconciles managed profiles and broadcasts
+  // sync events, both of which belong to the daemon alone. The refresh swaps the
+  // cache atomically, so a tick reading a flag mid-refresh still sees the last
+  // known values. Unref'd so the tick interval above stays the one thing
+  // keeping this process alive.
+  flagRefreshTimer = setInterval(() => {
+    void refreshOverridesFromGateway().catch((err) => {
+      log.warn({ err }, "Failed to refresh feature flag overrides");
+    });
+  }, FLAG_REFRESH_INTERVAL_MS);
+  flagRefreshTimer.unref();
+
   process.on("SIGUSR1", () => {
     log.info("Received SIGUSR1 — refreshing database connections");
     resetDb();
@@ -154,6 +195,9 @@ async function main(): Promise<void> {
     stopped = true;
     if (timer != null) {
       clearInterval(timer);
+    }
+    if (flagRefreshTimer != null) {
+      clearInterval(flagRefreshTimer);
     }
     cleanupWorkerPidFile(getScheduleWorkerPidPath());
   });


### PR DESCRIPTION
## Summary
- The schedule worker now initializes feature flag overrides at startup and refreshes them while running, so fire-time flag checks see the same values as the daemon instead of falling back to registry defaults.