### PR TITLE
fix(plugins): tear a plugin down when it is disabled

### DIFF
--- a/assistant/src/__tests__/mtime-cache.test.ts
+++ b/assistant/src/__tests__/mtime-cache.test.ts
@@ -4,10 +4,10 @@
  *
  * Each test materializes a synthetic plugin directory under a per-file
  * tempdir. Changes are applied the way production applies them — the
- * install/uninstall/enable/disable routes call `reconcilePluginSourcesNow()`
- * after materializing files on disk. Dispatch-time hook and tool reads are
- * pure cache reads and must never activate anything; that invariant has its
- * own test below.
+ * install, uninstall, upgrade, enable and disable routes call
+ * `reconcilePluginSourcesNow()` after materializing files on disk.
+ * Dispatch-time hook and tool reads are pure cache reads and must never
+ * activate anything; that invariant has its own test below.
  */
 import {
   existsSync,
@@ -135,8 +135,8 @@ let touchSeq = 0;
 
 /**
  * Apply pending source changes exactly the way production does: the
- * imperative reconcile the install/uninstall/enable/disable routes call
- * after materializing a change on disk.
+ * imperative reconcile the install, uninstall, upgrade, enable and disable
+ * routes call after materializing a change on disk.
  */
 async function applySourceChangesNow(): Promise<void> {
   await reconcilePluginSourcesNow();
@@ -825,6 +825,41 @@ describe("plugin runtime activation", () => {
     // Disable keeps the directory, so `shutdown` is resolved from disk and runs
     // even though it was never pre-warmed.
     expect(existsSync(shutdownMarker)).toBe(true);
+  });
+
+  test("a disable/enable round trip runs shutdown then init and restores the tool", async () => {
+    const dir = freshPluginDir("round-trip-plugin");
+    writePackageJson(dir, { ...SIMPLE_PKG, name: "round-trip-plugin" });
+    writeTool(dir, "round-trip-tool", TOOL_SRC("round-trip-tool"));
+    // Both lifecycle hooks append to one marker, so the file records the order
+    // the two reconciles ran them in, not just that each fired.
+    const lifecycleMarker = join(ROOT, "round-trip-lifecycle.log");
+    writeMarkerHook(dir, "init", lifecycleMarker, "init");
+    writeMarkerHook(dir, "shutdown", lifecycleMarker, "shutdown");
+
+    await populateCacheAtBoot();
+    await loadPluginTools(); // boot pull (initializePlugins does this)
+    expect(getToolOwner("round-trip-tool")?.kind).toBe("plugin");
+
+    const sentinel = join(dir, ".disabled");
+    writeFileSync(sentinel, "");
+    await reconcileAndPull();
+    expect(getToolOwner("round-trip-tool")).toBeUndefined();
+
+    rmSync(sentinel, { force: true });
+    await reconcileAndPull();
+
+    // The plugin comes back up on the same directory, so the tool re-registers.
+    expect(getToolOwner("round-trip-tool")).toEqual({
+      kind: "plugin",
+      id: "round-trip-plugin",
+    });
+    // Boot init, the disable's shutdown, then the enable's init.
+    expect(readFileSync(lifecycleMarker, "utf8").trim().split("\n")).toEqual([
+      "init",
+      "shutdown",
+      "init",
+    ]);
   });
 });
 

--- a/assistant/src/plugins/mtime-cache.ts
+++ b/assistant/src/plugins/mtime-cache.ts
@@ -235,15 +235,16 @@ export function isPluginDirActivated(dir: string): boolean {
  * Imperatively reconcile the plugin caches against the current on-disk state
  * *now*.
  *
- * An install / uninstall / enable / disable materializes files on disk;
- * nothing else applies that change to the caches. Callers that just changed
- * the plugin set on disk (the install / uninstall routes, and the CLI's
- * best-effort post-install poke) call this to bring the change up
- * deterministically, so a freshly installed plugin's `init` fires as part of
- * the install rather than at the next daemon boot. Together with the boot
- * scan this is the only path that activates plugins — dispatch-time hook and
- * tool reads are pure cache reads — so activation only ever happens in the
- * main daemon, where these routes run.
+ * An install / uninstall / upgrade / enable / disable materializes files on
+ * disk; nothing else applies that change to the caches. Callers that just
+ * changed the plugin set on disk (the install, uninstall, upgrade, enable and
+ * disable routes, and the CLI's best-effort post-install poke) call this to
+ * bring the change up deterministically, so a freshly installed plugin's
+ * `init` fires as part of the install rather than at the next daemon boot,
+ * and a disabled plugin's `shutdown` fires as part of the disable rather than
+ * at daemon exit. Together with the boot scan this is the only path that
+ * activates plugins — dispatch-time hook and tool reads are pure cache reads —
+ * so activation only ever happens in the main daemon, where these routes run.
  *
  * Idempotent and safe to call redundantly: `applySourceVersions` only
  * redeploys directories whose fingerprint moved, and activation is guarded so
@@ -1070,9 +1071,10 @@ async function deactivatePlugin(
  *
  * Called by `loadUserPlugins()` during daemon startup. After boot, the same
  * `activatePlugin`/`deactivatePlugin` reconciliation runs only through the
- * imperative poke ({@link reconcilePluginSourcesNow}) the install/uninstall/
- * upgrade/enable routes call, so plugin lifecycle stays confined to the main
- * daemon — dispatch-time hook and tool reads never activate anything.
+ * imperative poke ({@link reconcilePluginSourcesNow}) the install, uninstall,
+ * upgrade, enable and disable routes call, so plugin lifecycle stays confined
+ * to the main daemon — dispatch-time hook and tool reads never activate
+ * anything.
  */
 export async function populateCacheAtBoot(
   opts: { importTimeoutMs?: number } = {},

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -2597,27 +2597,10 @@ async function invokeEnable(
   return (await enableHandler(args)) as { ok: boolean };
 }
 
-function invokeDisable(args: RouteHandlerArgs = {}): { ok: boolean } {
-  return disableHandler(args) as { ok: boolean };
-}
-
-/**
- * Wait for a toggle handler's fire-and-forget reconcile poke to land. The poke
- * runs off the microtask queue (the disable path also resolves a lazy
- * `import()` first), so the assertion cannot run on the handler's synchronous
- * return.
- */
-async function waitForReconcile(
-  spy: { mock: { calls: unknown[] } },
-  label: string,
-): Promise<void> {
-  for (let i = 0; i < 50; i++) {
-    if (spy.mock.calls.length > 0) {
-      return;
-    }
-    await new Promise((resolve) => setTimeout(resolve, 2));
-  }
-  throw new Error(`${label} was never triggered`);
+async function invokeDisable(
+  args: RouteHandlerArgs = {},
+): Promise<{ ok: boolean }> {
+  return (await disableHandler(args)) as { ok: boolean };
 }
 
 /** Assert the spy received exactly one sync_changed carrying `plugins:list`. */
@@ -2745,42 +2728,42 @@ describe("POST /v1/plugins/:name/disable", () => {
     reconcilePluginSourcesNowSpy.mockClear();
   });
 
-  test("reconciles plugin-declared schedules so the plugin's rows disarm now", async () => {
+  test("awaits the source reconcile so the plugin tears down before the route returns", async () => {
     disablePluginSpy.mockImplementation((name) =>
       toggleResult(name, "disable"),
     );
 
-    invokeDisable({ pathParams: { name: "simple-memory" } });
+    await invokeDisable({ pathParams: { name: "simple-memory" } });
 
-    // Without this poke the rows stay armed until the reconciler's next
-    // backstop sweep. Disable stays on the schedule poke: the sentinel filters
-    // the plugin out at read time, and a source reconcile here would run its
-    // shutdown hooks.
-    await waitForReconcile(
-      reconcilePluginSchedulesSpy,
-      "plugin schedule reconcile",
-    );
-    expect(reconcilePluginSourcesNowSpy).not.toHaveBeenCalled();
+    // Writing the sentinel only hides the plugin at read time; the source
+    // reconcile is what runs its shutdown hook and evicts its cached hooks and
+    // tools. The route awaits it, so by the time the response lands the plugin
+    // is down; the reconcile converges the schedules itself, so the route does
+    // not poke them separately.
+    expect(reconcilePluginSourcesNowSpy).toHaveBeenCalledTimes(1);
+    expect(reconcilePluginSchedulesSpy).not.toHaveBeenCalled();
   });
 
-  test("a failed toggle does not poke the schedule reconcile", async () => {
+  test("a failed toggle does not run the source reconcile", async () => {
     disablePluginSpy.mockImplementation((name) => {
       throw new PluginDirectoryNotFoundError(name);
     });
 
-    expect(() => invokeDisable({ pathParams: { name: "ghost" } })).toThrow(
-      NotFoundError,
-    );
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await expect(
+      invokeDisable({ pathParams: { name: "ghost" } }),
+    ).rejects.toThrow(NotFoundError);
+    expect(reconcilePluginSourcesNowSpy).not.toHaveBeenCalled();
     expect(reconcilePluginSchedulesSpy).not.toHaveBeenCalled();
   });
 
-  test("disables the plugin and broadcasts sync_changed(plugins:list)", () => {
+  test("disables the plugin and broadcasts sync_changed(plugins:list)", async () => {
     disablePluginSpy.mockImplementation((name) =>
       toggleResult(name, "disable"),
     );
 
-    const result = invokeDisable({ pathParams: { name: "simple-memory" } });
+    const result = await invokeDisable({
+      pathParams: { name: "simple-memory" },
+    });
 
     expect(result).toEqual({ ok: true });
     expect(disablePluginSpy.mock.calls[0]?.[0]).toBe("simple-memory");
@@ -2789,12 +2772,12 @@ describe("POST /v1/plugins/:name/disable", () => {
     expectPluginsListBroadcast();
   });
 
-  test("threads x-vellum-client-id into the published event's originClientId", () => {
+  test("threads x-vellum-client-id into the published event's originClientId", async () => {
     disablePluginSpy.mockImplementation((name) =>
       toggleResult(name, "disable"),
     );
 
-    invokeDisable({
+    await invokeDisable({
       pathParams: { name: "simple-memory" },
       headers: { "x-vellum-client-id": "client-xyz" },
     });
@@ -2806,35 +2789,52 @@ describe("POST /v1/plugins/:name/disable", () => {
     });
   });
 
-  test("PluginAlreadyInStateException → ConflictError (409), no broadcast", () => {
+  test("PluginAlreadyInStateException → ConflictError (409), no broadcast", async () => {
     disablePluginSpy.mockImplementation((name) => {
       throw new PluginAlreadyInStateException(name, "disable");
     });
 
-    expect(() =>
+    await expect(
       invokeDisable({ pathParams: { name: "simple-memory" } }),
-    ).toThrow(ConflictError);
+    ).rejects.toThrow(ConflictError);
+    // A no-op toggle must not fan out a spurious invalidation.
     expect(broadcastMessageSpy).not.toHaveBeenCalled();
   });
 
-  test("PluginDirectoryNotFoundError → NotFoundError (404)", () => {
+  test("PluginDirectoryNotFoundError → NotFoundError (404)", async () => {
     disablePluginSpy.mockImplementation((name) => {
       throw new PluginDirectoryNotFoundError(name);
     });
 
-    expect(() => invokeDisable({ pathParams: { name: "ghost" } })).toThrow(
-      NotFoundError,
-    );
+    await expect(
+      invokeDisable({ pathParams: { name: "ghost" } }),
+    ).rejects.toThrow(NotFoundError);
   });
 
-  test("InvalidPluginNameError → BadRequestError (400)", () => {
+  test("InvalidPluginNameError → BadRequestError (400)", async () => {
     disablePluginSpy.mockImplementation(() => {
       throw new ToggleInvalidPluginNameError("../escape");
     });
 
-    expect(() => invokeDisable({ pathParams: { name: "../escape" } })).toThrow(
-      BadRequestError,
+    await expect(
+      invokeDisable({ pathParams: { name: "../escape" } }),
+    ).rejects.toThrow(BadRequestError);
+  });
+
+  test("a disable then enable round trip reconciles the sources both times", async () => {
+    disablePluginSpy.mockImplementation((name) =>
+      toggleResult(name, "disable"),
     );
+    enablePluginSpy.mockImplementation((name) => toggleResult(name, "enable"));
+
+    await invokeDisable({ pathParams: { name: "simple-memory" } });
+    await invokeEnable({ pathParams: { name: "simple-memory" } });
+
+    // Each direction brings the caches back in line with the sentinel, so
+    // neither leaves the plugin half-torn-down. The teardown-then-init
+    // ordering is covered against a real plugin directory in mtime-cache.test.
+    expect(reconcilePluginSourcesNowSpy).toHaveBeenCalledTimes(2);
+    expect(broadcastMessageSpy.mock.calls).toHaveLength(2);
   });
 });
 

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -1642,29 +1642,6 @@ function mapTogglePluginError(err: unknown): RouteError {
 }
 
 /**
- * Converge plugin-declared schedules against the sentinel this route just
- * wrote, so a disabled plugin's rows disarm now rather than at the
- * reconciler's next backstop sweep.
- *
- * Fire-and-forget: the toggle itself already succeeded on disk, so a reconcile
- * failure must not turn it into a route error. Imported lazily, matching the
- * plugin source reconcile's own hook, to keep the schedule and notification
- * modules out of this route module's static graph. The scheduler applies the
- * sentinel at fire time as well, so a slow or failed pass here delays the row
- * bookkeeping without letting a disabled plugin run.
- */
-function reconcilePluginSchedulesInBackground(): void {
-  void import("../../schedule/plugin-schedule-reconciler.js")
-    .then(({ reconcilePluginSchedules }) => reconcilePluginSchedules())
-    .catch((err: unknown) => {
-      log.error(
-        { err },
-        "plugin schedule reconcile after a plugin toggle failed",
-      );
-    });
-}
-
-/**
  * Toggle a plugin's `.disabled` sentinel through the shared toggle-plugin lib,
  * then publish a generic `sync_changed(plugins:list)` so every client refetches
  * `GET /v1/plugins`. Enable and disable emit the SAME invalidation — the tag
@@ -1694,15 +1671,27 @@ async function handleEnablePlugin({
   return { ok: true };
 }
 
-function handleDisablePlugin({ pathParams = {}, headers }: RouteHandlerArgs) {
+async function handleDisablePlugin({
+  pathParams = {},
+  headers,
+}: RouteHandlerArgs) {
   try {
     disablePlugin(pathParams.name ?? "");
-    publishPluginsChanged(getOriginClientId(headers));
-    reconcilePluginSchedulesInBackground();
-    return { ok: true };
   } catch (err) {
     throw mapTogglePluginError(err);
   }
+  // Writing the sentinel only hides the plugin from read-time listings; its
+  // hooks and tools stay cached and whatever its `init` started keeps running.
+  // Run the same imperative source reconcile enable uses, which sees a
+  // present-but-disabled plugin, runs its `shutdown` hook, evicts its cached
+  // surfaces, and then converges its schedules and MCP servers. Awaited so a
+  // client that lists tools right after disabling sees the plugin down; the
+  // reconcile contains its own failures, so a broken shutdown cannot turn a
+  // successful disable into a route error. The invalidation publishes after it
+  // for the same reason: refetching clients should see the post-teardown state.
+  await reconcilePluginSourcesNow();
+  publishPluginsChanged(getOriginClientId(headers));
+  return { ok: true };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Disabling an installed plugin now runs the same awaited source reconcile as enable, so the plugin's shutdown hook runs and its cached hooks and tools are evicted instead of merely being hidden by the sentinel.
- Resources started by an installed plugin's init no longer outlive its disable. Default (bundled) plugins are unchanged here; their disable-side teardown is a follow-up on the bootstrap module.