### PR TITLE
fix(plugins): initialize a boot-disabled default plugin on enable

### DIFF
--- a/assistant/src/__tests__/plugin-bootstrap.test.ts
+++ b/assistant/src/__tests__/plugin-bootstrap.test.ts
@@ -9,6 +9,8 @@
  *   sees the malformed plugin).
  * - Plugins' `shutdown` hooks fire through the unified `runHook(HOOKS.SHUTDOWN)`
  *   pipeline; `.disabled` plugins are excluded from that dispatch.
+ * - `activateDefaultPluginNow` runs the `init` of a plugin the boot pass
+ *   skipped for its sentinel, and stays a no-op for one that is already up.
  *
  * `resetPluginRegistryForTests()` isolates registry state between cases.
  */
@@ -19,7 +21,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { beforeEach, describe, expect, test } from "bun:test";
 
-import { bootstrapPlugins } from "../daemon/external-plugins-bootstrap.js";
+import {
+  activateDefaultPluginNow,
+  bootstrapPlugins,
+} from "../daemon/external-plugins-bootstrap.js";
 import { HOOKS } from "../plugin-api/constants.js";
 import { registerDefaultPlugins } from "../plugins/defaults/index.js";
 import { runHook } from "../plugins/pipeline.js";
@@ -416,5 +421,83 @@ describe("plugin bootstrap", () => {
     expect(
       getRegisteredInjectors().some((i) => i.name === "workspace-context"),
     ).toBe(true);
+  });
+
+  // ── enabling a boot-disabled plugin ────────────────────────────────────
+  //
+  // Read-time filtering restores a re-enabled plugin's hooks and injectors,
+  // but its `init` never ran, so the handlers and workers those hooks depend
+  // on do not exist. `activateDefaultPluginNow` is the enable route's path to
+  // run that `init` in the live daemon.
+
+  test("activateDefaultPluginNow: init runs for a plugin the sentinel skipped at boot", async () => {
+    let initCount = 0;
+    registerPlugin(
+      buildPlugin("default-late", {
+        async init() {
+          initCount += 1;
+        },
+      }),
+    );
+
+    const sentinelDir = join(TEST_WORKSPACE_DIR, "plugins", "default-late");
+    const { mkdir, writeFile } = await import("node:fs/promises");
+    await mkdir(sentinelDir, { recursive: true });
+    await writeFile(join(sentinelDir, ".disabled"), "");
+
+    await bootstrapPlugins();
+    expect(initCount).toBe(0);
+
+    // Enable removes the sentinel, then the route activates the plugin.
+    await rm(sentinelDir, { recursive: true, force: true });
+    expect(await activateDefaultPluginNow("default-late")).toBe(true);
+    expect(initCount).toBe(1);
+  });
+
+  test("activateDefaultPluginNow: a plugin that already initialized is not initialized twice", async () => {
+    let initCount = 0;
+    registerPlugin(
+      buildPlugin("default-early", {
+        async init() {
+          initCount += 1;
+        },
+      }),
+    );
+
+    await bootstrapPlugins();
+    expect(initCount).toBe(1);
+
+    expect(await activateDefaultPluginNow("default-early")).toBe(false);
+    expect(initCount).toBe(1);
+  });
+
+  test("activateDefaultPluginNow: no-op while the sentinel is still on disk, and for an unknown name", async () => {
+    let initCount = 0;
+    registerPlugin(
+      buildPlugin("default-still-off", {
+        async init() {
+          initCount += 1;
+        },
+      }),
+    );
+
+    const sentinelDir = join(
+      TEST_WORKSPACE_DIR,
+      "plugins",
+      "default-still-off",
+    );
+    const { mkdir, writeFile } = await import("node:fs/promises");
+    await mkdir(sentinelDir, { recursive: true });
+    await writeFile(join(sentinelDir, ".disabled"), "");
+
+    await bootstrapPlugins();
+
+    expect(await activateDefaultPluginNow("default-still-off")).toBe(false);
+    expect(initCount).toBe(0);
+    // A workspace-installed plugin is activated by the source reconcile and is
+    // never in the registry, so it resolves to nothing here.
+    expect(await activateDefaultPluginNow("some-user-plugin")).toBe(false);
+
+    await rm(sentinelDir, { recursive: true, force: true });
   });
 });

--- a/assistant/src/daemon/external-plugins-bootstrap.ts
+++ b/assistant/src/daemon/external-plugins-bootstrap.ts
@@ -55,6 +55,7 @@ import {
   registerDefaultPluginInjectors,
   registerDefaultPlugins,
 } from "../plugins/defaults/index.js";
+import { isPluginDisabled } from "../plugins/disabled-state.js";
 import {
   registerPluginInjectors,
   unregisterPluginInjectors,
@@ -78,6 +79,14 @@ import { getWorkspaceDir, getWorkspacePluginsDir } from "../util/platform.js";
 import { APP_VERSION } from "../version.js";
 
 const log = getLogger("plugins-bootstrap");
+
+/**
+ * Names whose `init` completed in this process. {@link bootstrapPlugins}
+ * rebuilds the set on every run, and {@link activateDefaultPluginNow} reads it
+ * so enabling a plugin that is already up is a no-op instead of a second
+ * `init`.
+ */
+const initializedPlugins = new Set<string>();
 
 /**
  * Validate a plugin config block. If the manifest supplies a parser-like
@@ -173,6 +182,10 @@ export async function initializePlugins(): Promise<void> {
  * registered inline via {@link registerDefaultPlugins}.
  */
 export async function bootstrapPlugins(): Promise<void> {
+  // This run re-initializes every plugin it does not skip, so the record of
+  // what is already up is rebuilt from it.
+  initializedPlugins.clear();
+
   // Register first-party default plugins. Each default wraps one of the
   // assistant's canonical pipelines (`compaction`, `persistence`, ...) with a
   // passthrough so the pipeline shape is explicit at boot even when no
@@ -261,6 +274,52 @@ export async function bootstrapPlugins(): Promise<void> {
   }
 }
 
+/**
+ * Initialize a plugin the boot pass skipped for its `.disabled` sentinel, so
+ * enabling it takes effect in the running daemon rather than at the next start.
+ * The enable route calls this after clearing the sentinel: read-time filtering
+ * brings the plugin's hooks and injectors back on its own, but the job
+ * handlers, background workers, and storage handles that `init` sets up only
+ * exist once `init` has run.
+ *
+ * Eligibility is the set of plugins this module owns: the first-party defaults
+ * and anything registered through `registerPlugin`. Workspace-installed plugins
+ * are activated by the source reconcile in `plugins/mtime-cache.ts` and never
+ * enter the registry, so they resolve to nothing here.
+ *
+ * Idempotent. A plugin whose `init` already ran, a name no registered plugin
+ * claims, and a plugin whose sentinel is still on disk are all no-ops. An
+ * `init` failure is contained the way the boot pass contains it, dropping the
+ * plugin from the registry and logging, so a broken plugin never fails the
+ * caller. Returns whether `init` ran.
+ */
+export async function activateDefaultPluginNow(
+  pluginName: string,
+): Promise<boolean> {
+  if (initializedPlugins.has(pluginName) || isPluginDisabled(pluginName)) {
+    return false;
+  }
+
+  const plugin = getRegisteredPlugins().find(
+    (p) => p.manifest.name === pluginName,
+  );
+  if (!plugin) {
+    return false;
+  }
+
+  try {
+    await initializePlugin(plugin, getConfig());
+    return true;
+  } catch (err) {
+    unregisterPlugin(pluginName);
+    log.warn(
+      { err, plugin: pluginName },
+      `plugin ${pluginName} failed to initialize on enable`,
+    );
+    return false;
+  }
+}
+
 async function initializePlugin(
   plugin: Plugin,
   assistantConfig: AssistantConfig,
@@ -336,9 +395,11 @@ async function initializePlugin(
       }
     }
     initCompleted = true;
+    initializedPlugins.add(name);
 
     log.info({ plugin: name }, "plugin initialized");
   } catch (err) {
+    initializedPlugins.delete(name);
     if (initCompleted) {
       await teardownPlugin(plugin, {
         assistantVersion: APP_VERSION,

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -41,6 +41,8 @@
  *   - Enable pokes the imperative plugin source reconcile, which activates a
  *     plugin the boot scan skipped for its sentinel and converges its
  *     schedules and MCP servers
+ *   - Enable also activates a default plugin, which the source reconcile does
+ *     not cover, so its `init` runs instead of waiting for the next daemon start
  *   - Disable pokes the plugin-declared schedule reconcile on a successful
  *     toggle (and not on a failed one), so the plugin's rows disarm
  *     immediately instead of at the reconciler's next backstop sweep
@@ -341,6 +343,17 @@ const actualMtimeCache: typeof import("../../../plugins/mtime-cache.js") =
 mock.module("../../../plugins/mtime-cache.js", () => ({
   ...actualMtimeCache,
   reconcilePluginSourcesNow: reconcilePluginSourcesNowSpy,
+}));
+
+// Spy on the default-plugin activation the enable route runs after the source
+// reconcile, which only covers installed plugin directories. Stubbed so the
+// assertion does not pull the daemon's plugin bootstrap into the test.
+const activateDefaultPluginNowSpy = mock((_name: string) =>
+  Promise.resolve(true),
+);
+
+mock.module("../../../daemon/external-plugins-bootstrap.js", () => ({
+  activateDefaultPluginNow: activateDefaultPluginNowSpy,
 }));
 
 // Spy on broadcastMessage so we can assert the sync_changed invalidation the
@@ -2634,6 +2647,32 @@ describe("POST /v1/plugins/:name/enable", () => {
     broadcastMessageSpy.mockReset();
     reconcilePluginSchedulesSpy.mockClear();
     reconcilePluginSourcesNowSpy.mockClear();
+    activateDefaultPluginNowSpy.mockClear();
+  });
+
+  test("activates a default plugin the boot pass left uninitialized", async () => {
+    enablePluginSpy.mockImplementation((name) => toggleResult(name, "enable"));
+
+    await invokeEnable({ pathParams: { name: "default-memory" } });
+
+    // The source reconcile walks installed plugin directories, so it never
+    // reaches a default plugin. Without this the re-enabled plugin's hooks come
+    // back through read-time filtering while the handlers and workers its
+    // `init` sets up are still missing.
+    expect(activateDefaultPluginNowSpy.mock.calls[0]?.[0]).toBe(
+      "default-memory",
+    );
+  });
+
+  test("a failed toggle does not activate a default plugin", async () => {
+    enablePluginSpy.mockImplementation((name) => {
+      throw new PluginAlreadyInStateException(name, "enable");
+    });
+
+    await expect(
+      invokeEnable({ pathParams: { name: "default-memory" } }),
+    ).rejects.toThrow(ConflictError);
+    expect(activateDefaultPluginNowSpy).not.toHaveBeenCalled();
   });
 
   test("awaits the source reconcile so a boot-disabled plugin activates before the route returns", async () => {

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -90,6 +90,7 @@ import {
   upgradePlugin,
 } from "../../cli/lib/upgrade-plugin.js";
 import { getPlatformBaseUrl } from "../../config/env.js";
+import { activateDefaultPluginNow } from "../../daemon/external-plugins-bootstrap.js";
 import { isPluginDisabled } from "../../plugins/disabled-state.js";
 import { ensurePluginApiShim } from "../../plugins/ensure-plugin-api-shim.js";
 import {
@@ -1675,8 +1676,9 @@ async function handleEnablePlugin({
   pathParams = {},
   headers,
 }: RouteHandlerArgs) {
+  let name: string;
   try {
-    enablePlugin(pathParams.name ?? "");
+    name = enablePlugin(pathParams.name ?? "").name;
   } catch (err) {
     throw mapTogglePluginError(err);
   }
@@ -1690,6 +1692,13 @@ async function handleEnablePlugin({
   // enable into a route error. The invalidation publishes after it for the
   // same reason: refetching clients should see the post-activation state.
   await reconcilePluginSourcesNow();
+  // That reconcile walks installed plugin directories, so it never reaches a
+  // default plugin, which the daemon initializes from its own bootstrap. One
+  // that was disabled at boot had its `init` skipped there, leaving it without
+  // the job handlers, workers, and storage handles its hooks rely on. Bring it
+  // up here. Contained and idempotent, so an already-running default plugin and
+  // a failing one both leave the enable successful.
+  await activateDefaultPluginNow(name);
   publishPluginsChanged(getOriginClientId(headers));
   return { ok: true };
 }


### PR DESCRIPTION
## Summary
- Enabling a default plugin that was disabled at daemon boot now runs its initialization, so its hooks no longer surface without the handlers and workers its init sets up.