### PR TITLE
feat(web): name the gallery row Photo Library

### DIFF
--- a/clients/web/src/domains/chat/components/chat-composer/add-to-chat-sheet.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/add-to-chat-sheet.test.tsx
@@ -82,7 +82,7 @@ describe("AddToChatSheet", () => {
     renderSheet();
 
     expect(screen.getByText("Camera")).toBeTruthy();
-    expect(screen.getByText("Find in Gallery")).toBeTruthy();
+    expect(screen.getByText("Photo Library")).toBeTruthy();
     expect(screen.getByText("Files")).toBeTruthy();
   });
 

--- a/clients/web/src/domains/chat/components/chat-composer/add-to-chat-sheet.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/add-to-chat-sheet.tsx
@@ -41,7 +41,7 @@ interface AddToChatSheetProps {
 }
 
 /**
- * Mobile "Add to chat" bottom sheet: Camera, Find in Gallery, and Files, each
+ * Mobile "Add to chat" bottom sheet: Camera, Photo Library, and Files, each
  * backed by its own hidden `<input type="file">`.
  *
  * The three inputs render as siblings of `BottomSheet.Root`, outside the

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -7,7 +7,7 @@
     "title": "Add to chat",
     "closeAriaLabel": "Close",
     "camera": "Camera",
-    "gallery": "Find in Gallery",
+    "gallery": "Photo Library",
     "files": "Files"
   },
   "allowOptionsMenu": {

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -7,7 +7,7 @@
     "title": "Añadir al chat",
     "closeAriaLabel": "Cerrar",
     "camera": "Cámara",
-    "gallery": "Buscar en la galería",
+    "gallery": "Fototeca",
     "files": "Archivos"
   },
   "allowOptionsMenu": {


### PR DESCRIPTION
Renames the add-to-chat sheet's middle row from "Find in Gallery" to "Photo Library".

The row opens the system photo picker, so it takes the name iOS gives that surface rather than describing the act of looking through it.

- `en`: `Find in Gallery` → `Photo Library`
- `es`: `Buscar en la galería` → `Fototeca` (Apple's own iOS Spanish term for the Photo Library)
- Sheet docblock and the test assertion follow the copy

The i18n key stays `addToChatSheet.gallery`: repo convention names keys for the row's role, not its copy, so renaming the key would be churn without meaning.

Copy-only. No behaviour change; the row still opens the same picker it did before. Note that on iOS that picker is currently WebKit's own action sheet rather than the Photo Library directly, which is a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)