### PR TITLE
feat(web): stand the composer settings pills up in the app shells

### DIFF
--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -59,8 +59,13 @@ mock.module("@/runtime/is-electron", () => ({
 // requests — see the composer's `handleLiveVoiceStart` note), so setting this to
 // iOS must NOT suppress the card. Defaults to non-iOS (web).
 let mockIsNativeIOS = false;
+// The Capacitor shells (iOS and Android), where the settings pills stand for
+// the whole session instead of following focus. Defaults to the browser, so
+// every case that does not set it exercises the focus-driven reveal.
+let mockIsNativeMobile = false;
 mock.module("@/runtime/platform-detection", () => ({
   isNativeIOS: () => mockIsNativeIOS,
+  useIsNativeMobile: () => mockIsNativeMobile,
 }));
 
 // The native shell, which is the only place dictation's inline preview takes
@@ -283,6 +288,7 @@ function resetLiveVoiceMocks() {
   mockSupportsLiveVoice = true;
   mockIsElectron = false;
   mockIsNativeIOS = false;
+  mockIsNativeMobile = false;
   mockIsNativePlatform = false;
   mockVoicePhase = "idle";
   mockPreflightVerdict = { status: "ready" };
@@ -1261,6 +1267,36 @@ describe("ChatComposer: mobile settings pills row", () => {
     // AND the action row does not carry the pickers either: mobile moves them
     // out of the card entirely
     expect(container.querySelector("form")?.innerHTML).not.toContain(">THR<");
+  });
+
+  test("an app shell keeps the row standing before anyone taps in", () => {
+    // GIVEN the same untouched phone composer, in a Capacitor shell
+    mockIsNativeMobile = true;
+    const { container } = renderPhoneComposer(SETTINGS_SLOTS);
+
+    // THEN the row is up already: on a phone these pills are the only place
+    // the access and profile pickers live, so a row that waited for focus put
+    // both behind a tap for as long as the composer rested
+    const row = pillsRow(container);
+    expect(row?.textContent).toBe("THRPROFILE");
+    expect(row?.hasAttribute("hidden")).toBe(false);
+
+    // AND it carries no entrance: the animation exists because the row
+    // arrives with the keyboard, and standing permanently it would instead
+    // replay on every mount, settling the composer on each navigation
+    expect(row?.className).not.toContain("animate-");
+    expect(row?.className).toContain("flex");
+  });
+
+  test("an app shell still rests the caption under the card", () => {
+    // GIVEN an untouched phone composer in a Capacitor shell
+    mockIsNativeMobile = true;
+    const { container } = renderPhoneComposer(SETTINGS_SLOTS);
+
+    // THEN the caption keeps its own at-rest rule rather than trading places
+    // with the row: the two now share the resting composer
+    expect(disclaimer(container)?.hasAttribute("hidden")).toBe(false);
+    expect(pillsRow(container)?.hasAttribute("hidden")).toBe(false);
   });
 
   test("focusing the composer raises the row above the card, access first", () => {

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -1293,8 +1293,9 @@ describe("ChatComposer: mobile settings pills row", () => {
     mockIsNativeMobile = true;
     const { container } = renderPhoneComposer(SETTINGS_SLOTS);
 
-    // THEN the caption keeps its own at-rest rule rather than trading places
-    // with the row: the two now share the resting composer
+    // THEN both stand: the caption keeps its own at-rest rule, so a resting
+    // composer in a shell carries the row above the card and the caption below
+    // it at the same time
     expect(disclaimer(container)?.hasAttribute("hidden")).toBe(false);
     expect(pillsRow(container)?.hasAttribute("hidden")).toBe(false);
   });

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -73,7 +73,7 @@ import { useIsMobile } from "@/hooks/use-is-mobile";
 import { isElectron } from "@/runtime/is-electron";
 import { isPopoutWindowLifetime } from "@/runtime/popout-window";
 import { useIsNativePlatform } from "@/runtime/native-auth";
-import { isNativeIOS } from "@/runtime/platform-detection";
+import { isNativeIOS, useIsNativeMobile } from "@/runtime/platform-detection";
 import { isPointerCoarse, usePointerCoarse } from "@/utils/pointer";
 import { routes } from "@/utils/routes";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
@@ -772,11 +772,31 @@ export function ChatComposer({
   // sheet rises and the card would shift down under the scrim.
   const composerInUse =
     composerFocusWithin || settingsSheetOpen || addSheetOpen;
-  const settingsPillsVisible = isMobileMainComposer && composerInUse;
+  // The app shells hold the row up for the whole session. On a phone these
+  // pills are the only place the access and profile pickers live, and a row
+  // that comes and goes with the keyboard puts both a tap out of reach for as
+  // long as the composer is at rest. A mobile browser keeps the focus-driven
+  // reveal, where the row is competing with the page's own chrome for the
+  // bottom of the screen.
+  const isNativeMobileShell = useIsNativeMobile();
+  const settingsPillsVisible =
+    isMobileMainComposer && (isNativeMobileShell || composerInUse);
   // The caption is the row's opposite number: it stands under the card at rest
   // and steps aside the moment anything takes the bottom of the screen, which
-  // is where the keyboard and every sheet cover it anyway.
+  // is where the keyboard and every sheet cover it anyway. Unchanged by the
+  // row standing permanently, so in the shells the two share the resting
+  // composer rather than trading places.
   const disclaimerVisible = isMobileMainComposer && !composerInUse;
+  // The entrance exists because the row arrives with the keyboard. Standing
+  // permanently there is no arrival, and the same animation would instead
+  // replay on every mount, settling the composer on each navigation.
+  const settingsPillsClassName = settingsPillsVisible
+    ? `mb-3 flex justify-end gap-1.5 pr-1.5${
+        isNativeMobileShell
+          ? ""
+          : " animate-[fadeInUp_var(--anim-fast)_var(--anim-ease-out)_backwards] motion-reduce:animate-none"
+      }`
+    : undefined;
 
   // A pill at mobile widths (half the card's 52px collapsed height), the 10px
   // panel elsewhere, both from the live-voice bar's module: the bar stacks on
@@ -1324,13 +1344,13 @@ export function ChatComposer({
             // Mounted for as long as the composer is, because each pill gates
             // itself on server state its own menu loads (access waits on the
             // global-threshold fetch), and a row that mounted on first focus
-            // would rise with that pill still missing. Only its visibility
-            // follows focus: `hidden` is `display: none`, which keeps the resting
-            // row out of the layout, the tab order and the accessibility tree,
-            // and lets the entrance animation run again on every reveal.
+            // would rise with that pill still missing.
             //
-            // The row rises into place rather than appearing, since it arrives
-            // with the keyboard; reduced motion keeps the placement and drops the
+            // In the app shells it then stays visible. In a mobile browser its
+            // visibility follows focus, and `hidden` is `display: none`, which
+            // keeps the resting row out of the layout, the tab order and the
+            // accessibility tree, and lets the entrance run again on every
+            // reveal. Reduced motion keeps the placement and drops the
             // movement.
             <div
               data-slot="composer-settings-pills"
@@ -1338,11 +1358,7 @@ export function ChatComposer({
               // The right inset lands the last pill's edge over the send
               // circle's, so the row reads as hung off the card rather than
               // floated past it.
-              className={
-                settingsPillsVisible
-                  ? "mb-3 flex animate-[fadeInUp_var(--anim-fast)_var(--anim-ease-out)_backwards] justify-end gap-1.5 pr-1.5 motion-reduce:animate-none"
-                  : undefined
-              }
+              className={settingsPillsClassName}
             >
               {thresholdPickerSlot}
               {modelPickerSlot}

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -783,13 +783,13 @@ export function ChatComposer({
     isMobileMainComposer && (isNativeMobileShell || composerInUse);
   // The caption is the row's opposite number: it stands under the card at rest
   // and steps aside the moment anything takes the bottom of the screen, which
-  // is where the keyboard and every sheet cover it anyway. Unchanged by the
-  // row standing permanently, so in the shells the two share the resting
-  // composer rather than trading places.
+  // is where the keyboard and every sheet cover it anyway. In the shells,
+  // where the pills row stands throughout, the two share the resting composer
+  // rather than trading places.
   const disclaimerVisible = isMobileMainComposer && !composerInUse;
-  // The entrance exists because the row arrives with the keyboard. Standing
-  // permanently there is no arrival, and the same animation would instead
-  // replay on every mount, settling the composer on each navigation.
+  // The entrance belongs to the row that arrives with the keyboard. A row that
+  // stands throughout has no arrival to animate, and the same animation there
+  // replays on every mount, settling the composer on each navigation.
   const settingsPillsClassName = settingsPillsVisible
     ? `mb-3 flex justify-end gap-1.5 pr-1.5${
         isNativeMobileShell


### PR DESCRIPTION
## What

The mobile composer's settings pills (assistant access, model profile) stay visible for the whole session in the Capacitor shells instead of appearing on focus.

```ts
const settingsPillsVisible =
  isMobileMainComposer && (isNativeMobileShell || composerInUse);
```

`useIsNativeMobile()` already existed in `platform-detection.ts`, so no new helper. Scope is both app shells (iOS + Android) so the two builds stay consistent; a mobile browser keeps the focus-driven reveal, where the row competes with the page's own chrome for the bottom of the screen.

## Two things that came with it

**The caption keeps its own rule.** The pills row and the "Vellum uses external AI models and can make mistakes" caption were mutually exclusive: the caption stood at rest and the pills replaced it on focus. `disclaimerVisible` is unchanged, so in the shells the two now share the resting composer rather than trading places. That costs a row of vertical space at rest, which is the deliberate trade for keeping both pickers one tap away.

**The entrance animation is dropped on the always-on path.** `fadeInUp` exists because the row arrives with the keyboard. Standing permanently there is no arrival, and the same animation would instead replay on every mount, visibly settling the composer on each navigation. The focus-driven path keeps it.

## Tests

The existing "an unfocused phone composer keeps the row mounted but hidden" case is untouched and still passes, which is what pins the mobile-web path. Two new cases cover the shell, and I confirmed both **fail** with the predicate reverted (2 fail) rather than passing vacuously.

`useIsNativeMobile` is now explicitly mocked beside `isNativeIOS` and reset with the other platform mocks, rather than relying on unclear `mock.module` merge semantics for an export the factory did not list.

139 pass, 0 fail. Typecheck, ESLint, Prettier clean.

## Worth a look

`composer-peek` measures the composer box and the empty-state layout keys off it. The resting composer is now one row taller in the shells. The peek observes size rather than assuming it, so this should adapt, but it is the thing I would check first on device.

Not verified on hardware: `useIsNativeMobile()` is false outside a Capacitor shell, so this path cannot be exercised in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)