### PR TITLE
fix(web): paint the onboarding surface into the iOS safe-area strips

### DIFF
--- a/clients/web/src/domains/onboarding/components/onboarding-stage.test.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-stage.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * The onboarding stage hands its color to the app shell so the safe-area
+ * strips match the screen instead of leaving a pale band along the bottom
+ * edge on iOS. See `page-surface-store`.
+ */
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { OnboardingStage } from "@/domains/onboarding/components/onboarding-stage";
+import { ONBOARDING_DARK_SURFACE } from "@/domains/onboarding/onboarding-step-layout";
+import { usePageSurfaceStore } from "@/stores/page-surface-store";
+
+afterEach(() => {
+  cleanup();
+  usePageSurfaceStore.getState().setSurface(null);
+});
+
+describe("OnboardingStage", () => {
+  test("publishes the dark surface it themes itself with", () => {
+    render(<OnboardingStage>content</OnboardingStage>);
+
+    expect(usePageSurfaceStore.getState().surface).toBe(
+      ONBOARDING_DARK_SURFACE,
+    );
+  });
+
+  test("publishes a screen's own tint when it is given one", () => {
+    render(<OnboardingStage surface="#E5C100">content</OnboardingStage>);
+
+    expect(usePageSurfaceStore.getState().surface).toBe("#E5C100");
+  });
+
+  test("leaves the surface alone when a child layer owns the color", () => {
+    render(<OnboardingStage surface={null}>content</OnboardingStage>);
+
+    expect(usePageSurfaceStore.getState().surface).toBeNull();
+  });
+
+  test("releases the surface on unmount", () => {
+    const { unmount } = render(<OnboardingStage>content</OnboardingStage>);
+    unmount();
+
+    expect(usePageSurfaceStore.getState().surface).toBeNull();
+  });
+});

--- a/clients/web/src/domains/onboarding/components/onboarding-stage.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-stage.tsx
@@ -50,7 +50,12 @@ interface OnboardingStageProps {
    * strips in one frame.
    */
   surfaceTransition?: string;
-  children: ReactNode;
+  /**
+   * Optional: a screen waiting on its art renders the stage bare rather than
+   * standing up a plain div, which would publish no surface and leave the
+   * strips on the neutral canvas.
+   */
+  children?: ReactNode;
 }
 
 export function OnboardingStage({

--- a/clients/web/src/domains/onboarding/components/onboarding-stage.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-stage.tsx
@@ -43,17 +43,25 @@ interface OnboardingStageProps {
    * is owned and animated by a child layer (that layer publishes instead).
    */
   surface?: string | null;
+  /**
+   * How the strips should reach {@link OnboardingStageProps.surface}: the tail
+   * of a CSS `transition` shorthand, mirroring the screen's own motion timing
+   * when its canvas fades in rather than appearing at once. Omit to change the
+   * strips in one frame.
+   */
+  surfaceTransition?: string;
   children: ReactNode;
 }
 
 export function OnboardingStage({
   className,
   surface = ONBOARDING_DARK_SURFACE,
+  surfaceTransition,
   children,
 }: OnboardingStageProps) {
   const { ref, size } = useElementSize();
 
-  usePublishPageSurface(surface);
+  usePublishPageSurface(surface, surfaceTransition ?? null);
 
   return (
     <div

--- a/clients/web/src/domains/onboarding/components/onboarding-stage.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-stage.tsx
@@ -13,6 +13,12 @@
  * coordinate space than the content it is supposed to be pinned to. See
  * `use-element-size.ts` for the same hazard stated from the other side.
  *
+ * The stage is also the page's canvas, so it hands its color to the app shell
+ * (see `page-surface-store`): the safe-area strips are padding on the shell, so
+ * without this the home indicator sits on the shell's light `--surface-base`
+ * while the stage renders dark or avatar-tinted, leaving a pale band along the
+ * bottom edge on iOS.
+ *
  * This exists as a component rather than a snippet each screen repeats because
  * a story that mirrors the wrapper proves nothing about the real one: the two
  * drift, and the story keeps passing. Screens differ only in the surface they
@@ -22,17 +28,32 @@
 import { type ReactNode } from "react";
 
 import { OnboardingStageSizeProvider } from "@/domains/onboarding/hooks/use-onboarding-stage-size";
+import { ONBOARDING_DARK_SURFACE } from "@/domains/onboarding/onboarding-step-layout";
 import { useElementSize } from "@/hooks/use-element-size";
+import { usePublishPageSurface } from "@/stores/page-surface-store";
 import { cn } from "@/utils/misc";
 
 interface OnboardingStageProps {
   /** Surface classes for this screen (background, text colour). */
   className?: string;
+  /**
+   * The color the shell should paint into the safe-area strips. Defaults to the
+   * dark surface every screen inherits from the stage's own theme; pass the
+   * avatar color on a screen tinted with it, or `null` on a screen whose color
+   * is owned and animated by a child layer (that layer publishes instead).
+   */
+  surface?: string | null;
   children: ReactNode;
 }
 
-export function OnboardingStage({ className, children }: OnboardingStageProps) {
+export function OnboardingStage({
+  className,
+  surface = ONBOARDING_DARK_SURFACE,
+  children,
+}: OnboardingStageProps) {
   const { ref, size } = useElementSize();
+
+  usePublishPageSurface(surface);
 
   return (
     <div

--- a/clients/web/src/domains/onboarding/components/onboarding-toned-backdrop.test.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-toned-backdrop.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * The toned backdrop owns the canvas color on the tinted onboarding steps, so
+ * it is what hands that color to the app shell for the safe-area strips.
+ *
+ * What these pin is the timing rule it shares with its own `initial={false}`
+ * canvas: take the color outright on arrival, animate only when the target
+ * changes. Publishing the mount value with a transition would leave a journey
+ * resumed straight onto a toned step fading its strips up from the neutral
+ * canvas while the page was already tinted. See `page-surface-store`.
+ */
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("@/utils/use-bundled-avatar-components", () => ({
+  useBundledAvatarComponents: () => ({
+    colors: [
+      { id: "teal", hex: "#2AA79B" },
+      { id: "pink", hex: "#E86AA5" },
+      { id: "yellow", hex: "#E5C100" },
+    ],
+    bodyShapes: [],
+    eyeStyles: [],
+  }),
+}));
+
+// Decorative layers that measure and animate themselves; the surface handover
+// is what is under test.
+mock.module("@/domains/onboarding/components/onboarding-peeking-eyes", () => ({
+  OnboardingPeekingEyes: () => null,
+}));
+mock.module("@/components/avatar/animated-avatar", () => ({
+  AnimatedAvatar: () => null,
+}));
+
+const { OnboardingTonedBackdrop } =
+  await import("@/domains/onboarding/components/onboarding-toned-backdrop");
+const { useOnboardingAvatarPoolStore } =
+  await import("@/domains/onboarding/onboarding-avatar-pool-store");
+const { usePageSurfaceStore } = await import("@/stores/page-surface-store");
+const { ONBOARDING_DARK_SURFACE } =
+  await import("@/domains/onboarding/onboarding-step-layout");
+
+const TEAL = "#2AA79B";
+const CANVAS_FADE_CSS = "1s ease-in-out";
+
+beforeEach(() => {
+  useOnboardingAvatarPoolStore.setState({
+    characters: [{ bodyShape: "urchin", eyeStyle: "goofy", color: "teal" }],
+    selectedIndex: 0,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  usePageSurfaceStore.getState().setSurface(null);
+  useOnboardingAvatarPoolStore.setState({ characters: [], selectedIndex: 0 });
+});
+
+describe("OnboardingTonedBackdrop surface handover", () => {
+  test("takes the tint outright on arrival", () => {
+    const { unmount } = render(<OnboardingTonedBackdrop />);
+
+    expect(usePageSurfaceStore.getState().surface).toBe(TEAL);
+    expect(usePageSurfaceStore.getState().transition).toBeNull();
+    unmount();
+  });
+
+  test("crossfades to the post-calendar dark once mounted", () => {
+    const { rerender, unmount } = render(<OnboardingTonedBackdrop />);
+
+    rerender(<OnboardingTonedBackdrop darkBg />);
+
+    expect(usePageSurfaceStore.getState().surface).toBe(
+      ONBOARDING_DARK_SURFACE,
+    );
+    expect(usePageSurfaceStore.getState().transition).toBe(CANVAS_FADE_CSS);
+    unmount();
+  });
+
+  test("releases the surface on unmount", () => {
+    const { unmount } = render(<OnboardingTonedBackdrop />);
+    unmount();
+
+    expect(usePageSurfaceStore.getState().surface).toBeNull();
+  });
+});

--- a/clients/web/src/domains/onboarding/components/onboarding-toned-backdrop.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-toned-backdrop.tsx
@@ -116,6 +116,15 @@ const PEEKERS: {
   },
 ];
 
+/**
+ * The canvas crossfade, in the two forms it has to be stated in: motion's for
+ * the backdrop itself, CSS's for the safe-area strips the app shell paints (see
+ * `page-surface-store`). Keep them equal, or the strips will arrive on a
+ * different beat than the canvas. Motion's `easeInOut` is CSS `ease-in-out`.
+ */
+const CANVAS_FADE = { duration: 1, ease: "easeInOut" } as const;
+const CANVAS_FADE_CSS = "1s ease-in-out";
+
 /** The team that peeks in from the top, persisting once it forms. */
 const TOP_TEAM = [
   { bodyShape: "blob", eyeStyle: "gentle" },
@@ -183,8 +192,12 @@ export function OnboardingTonedBackdrop({
   }, [components, chosen]);
 
   // The backdrop, not the stage, owns this screen's canvas color, so it is what
-  // hands it to the app shell for the safe-area strips. See `page-surface-store`.
-  usePublishPageSurface(darkBg ? ONBOARDING_DARK_SURFACE : bg);
+  // hands it to the app shell for the safe-area strips, on the same crossfade
+  // timing so the two arrive together. See `page-surface-store`.
+  usePublishPageSurface(
+    darkBg ? ONBOARDING_DARK_SURFACE : bg,
+    reduce ? null : CANVAS_FADE_CSS,
+  );
 
   return (
     <>
@@ -192,9 +205,7 @@ export function OnboardingTonedBackdrop({
         className="absolute inset-0 z-0"
         initial={false}
         animate={{ backgroundColor: darkBg ? ONBOARDING_DARK_SURFACE : bg }}
-        transition={
-          reduce ? { duration: 0 } : { duration: 1, ease: "easeInOut" }
-        }
+        transition={reduce ? { duration: 0 } : CANVAS_FADE}
       />
 
       {/* The assistant's eyes peek up from the bottom (until they collapse into

--- a/clients/web/src/domains/onboarding/components/onboarding-toned-backdrop.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-toned-backdrop.tsx
@@ -21,6 +21,8 @@ import { OnboardingPeekingEyes } from "@/domains/onboarding/components/onboardin
 import { useOnboardingStageSize } from "@/domains/onboarding/hooks/use-onboarding-stage-size";
 import { pickOverlayColors } from "@/domains/onboarding/onboarding-avatar-colors";
 import { useOnboardingAvatarPoolStore } from "@/domains/onboarding/onboarding-avatar-pool-store";
+import { ONBOARDING_DARK_SURFACE } from "@/domains/onboarding/onboarding-step-layout";
+import { usePublishPageSurface } from "@/stores/page-surface-store";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 
 /**
@@ -114,8 +116,6 @@ const PEEKERS: {
   },
 ];
 
-const DARK_SURFACE = "#17191C";
-
 /** The team that peeks in from the top, persisting once it forms. */
 const TOP_TEAM = [
   { bodyShape: "blob", eyeStyle: "gentle" },
@@ -164,13 +164,16 @@ export function OnboardingTonedBackdrop({
   const chosen = characters.length > 0 ? characters[selectedIndex] : undefined;
 
   const { bg, peekColors } = useMemo(() => {
-    const fallback = { bg: "var(--surface-base)", peekColors: [] as string[] };
+    const fallback = {
+      bg: ONBOARDING_DARK_SURFACE,
+      peekColors: [] as string[],
+    };
     if (!components || !chosen) {
       return fallback;
     }
     const color = components.colors.find((c) => c.id === chosen.color);
     return {
-      bg: color?.hex ?? "var(--surface-base)",
+      bg: color?.hex ?? ONBOARDING_DARK_SURFACE,
       peekColors: pickOverlayColors(
         chosen.color,
         components.colors.map((c) => c.id),
@@ -179,12 +182,16 @@ export function OnboardingTonedBackdrop({
     };
   }, [components, chosen]);
 
+  // The backdrop, not the stage, owns this screen's canvas color, so it is what
+  // hands it to the app shell for the safe-area strips. See `page-surface-store`.
+  usePublishPageSurface(darkBg ? ONBOARDING_DARK_SURFACE : bg);
+
   return (
     <>
       <motion.div
         className="absolute inset-0 z-0"
         initial={false}
-        animate={{ backgroundColor: darkBg ? DARK_SURFACE : bg }}
+        animate={{ backgroundColor: darkBg ? ONBOARDING_DARK_SURFACE : bg }}
         transition={
           reduce ? { duration: 0 } : { duration: 1, ease: "easeInOut" }
         }

--- a/clients/web/src/domains/onboarding/components/onboarding-toned-backdrop.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-toned-backdrop.tsx
@@ -194,6 +194,8 @@ export function OnboardingTonedBackdrop({
   // The backdrop, not the stage, owns this screen's canvas color, so it is what
   // hands it to the app shell for the safe-area strips, on the same crossfade
   // timing so the two arrive together. See `page-surface-store`.
+  // The crossfade applies to changes of target only, never to the arrival, so
+  // this matches the `initial={false}` below on both counts.
   usePublishPageSurface(
     darkBg ? ONBOARDING_DARK_SURFACE : bg,
     reduce ? null : CANVAS_FADE_CSS,

--- a/clients/web/src/domains/onboarding/components/onboarding-toned-backdrop.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-toned-backdrop.tsx
@@ -22,7 +22,10 @@ import { useOnboardingStageSize } from "@/domains/onboarding/hooks/use-onboardin
 import { pickOverlayColors } from "@/domains/onboarding/onboarding-avatar-colors";
 import { useOnboardingAvatarPoolStore } from "@/domains/onboarding/onboarding-avatar-pool-store";
 import { ONBOARDING_DARK_SURFACE } from "@/domains/onboarding/onboarding-step-layout";
-import { usePublishPageSurface } from "@/stores/page-surface-store";
+import {
+  cssTransitionFor,
+  usePublishPageSurface,
+} from "@/stores/page-surface-store";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 
 /**
@@ -117,13 +120,12 @@ const PEEKERS: {
 ];
 
 /**
- * The canvas crossfade, in the two forms it has to be stated in: motion's for
- * the backdrop itself, CSS's for the safe-area strips the app shell paints (see
- * `page-surface-store`). Keep them equal, or the strips will arrive on a
- * different beat than the canvas. Motion's `easeInOut` is CSS `ease-in-out`.
+ * The canvas crossfade. Stated once for the backdrop itself and derived for the
+ * safe-area strips the app shell paints, so the two cannot drift apart. See
+ * `page-surface-store`.
  */
 const CANVAS_FADE = { duration: 1, ease: "easeInOut" } as const;
-const CANVAS_FADE_CSS = "1s ease-in-out";
+const CANVAS_FADE_CSS = cssTransitionFor(CANVAS_FADE);
 
 /** The team that peeks in from the top, persisting once it forms. */
 const TOP_TEAM = [

--- a/clients/web/src/domains/onboarding/onboarding-step-layout.ts
+++ b/clients/web/src/domains/onboarding/onboarding-step-layout.ts
@@ -18,3 +18,12 @@ export const ONBOARDING_STEP_CONTENT =
  * See LUM-2597.
  */
 export const MOBILE_INPUT_NO_ZOOM = "touch-mobile:text-[16px]";
+
+/**
+ * `--surface-base` resolved in the dark theme every onboarding screen forces on
+ * itself. The app shell paints the safe-area strips from outside that subtree,
+ * so what it publishes has to be the value, not the token. Otherwise the home
+ * indicator sits on the light canvas and leaves a pale band along the bottom
+ * edge on iOS. See `page-surface-store`.
+ */
+export const ONBOARDING_DARK_SURFACE = "#17191C";

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -1018,7 +1018,9 @@ export function ResearchOnboardingRoute() {
       ? edgeAvatars
       : 0;
     return withHatchError(
-      <OnboardingStage>
+      // The backdrop animates this screen's color, so it publishes the shell's
+      // safe-area surface itself rather than the stage pinning a static one.
+      <OnboardingStage surface={null}>
         <OnboardingTonedBackdrop
           eyesBumpNonce={eyesBump}
           peekLevel={peekLevel}

--- a/clients/web/src/domains/onboarding/screens/existing-assistant-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/existing-assistant-step.tsx
@@ -11,7 +11,11 @@ import { ArrowRight } from "lucide-react";
 import { Button } from "@vellumai/design-library/components/button";
 
 import { OnboardingTopBar } from "@/domains/onboarding/components/onboarding-top-bar";
-import { ONBOARDING_STEP_CONTENT } from "@/domains/onboarding/onboarding-step-layout";
+import {
+  ONBOARDING_DARK_SURFACE,
+  ONBOARDING_STEP_CONTENT,
+} from "@/domains/onboarding/onboarding-step-layout";
+import { usePublishPageSurface } from "@/stores/page-surface-store";
 import { useTranslation } from "@/i18n";
 
 interface ExistingAssistantStepProps {
@@ -31,6 +35,9 @@ export function ExistingAssistantStep({
   onBack,
 }: ExistingAssistantStepProps) {
   const { t } = useTranslation("onboarding");
+  // The screen owns the whole viewport, so the shell paints its safe-area
+  // strips to match. See `page-surface-store`.
+  usePublishPageSurface(ONBOARDING_DARK_SURFACE);
   const name = assistantName?.trim() || "";
   const hasName = name.length > 0;
 

--- a/clients/web/src/domains/onboarding/screens/introduction-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/screens/introduction-screen.test.tsx
@@ -18,17 +18,20 @@
 import { act, cleanup, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+/** Null while the bundled-art import is outstanding, or if it failed. */
+let bundledArt: unknown = {
+  colors: [{ id: "teal", hex: "#2AA79B" }],
+  bodyShapes: [
+    {
+      id: "urchin",
+      svgPath: "M0 0h10v10H0z",
+      viewBox: { width: 10, height: 10 },
+    },
+  ],
+};
+
 mock.module("@/utils/use-bundled-avatar-components", () => ({
-  useBundledAvatarComponents: () => ({
-    colors: [{ id: "teal", hex: "#2AA79B" }],
-    bodyShapes: [
-      {
-        id: "urchin",
-        svgPath: "M0 0h10v10H0z",
-        viewBox: { width: 10, height: 10 },
-      },
-    ],
-  }),
+  useBundledAvatarComponents: () => bundledArt,
 }));
 
 // Decorative, and it measures itself; the surface handover is what is under
@@ -77,6 +80,16 @@ function renderScreen() {
 }
 
 beforeEach(() => {
+  bundledArt = {
+    colors: [{ id: "teal", hex: "#2AA79B" }],
+    bodyShapes: [
+      {
+        id: "urchin",
+        svgPath: "M0 0h10v10H0z",
+        viewBox: { width: 10, height: 10 },
+      },
+    ],
+  };
   frames = [];
   globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) =>
     frames.push(callback)) as typeof globalThis.requestAnimationFrame;
@@ -139,6 +152,20 @@ describe("IntroductionScreen surface handover", () => {
       `${ONBOARDING_DARK_SURFACE}|null`,
       `${TEAL}|${TINT_FADE_CSS}`,
     ]);
+    unmount();
+  });
+
+  test("still darkens the strips while the art is missing", () => {
+    // The bundled art is a dynamic import: slow on a restored journey, and on
+    // a failed chunk load this screen is what the user sits on for good. A
+    // bare fallback would publish nothing and put the pale strip back.
+    bundledArt = null;
+
+    const { unmount } = renderScreen();
+
+    expect(usePageSurfaceStore.getState().surface).toBe(
+      ONBOARDING_DARK_SURFACE,
+    );
     unmount();
   });
 

--- a/clients/web/src/domains/onboarding/screens/introduction-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/screens/introduction-screen.test.tsx
@@ -1,16 +1,21 @@
 /**
  * The introduction screen opens on the picker's dark surface and fades the
  * avatar tint in over it, so the safe-area strips the app shell paints have to
- * start dark and follow rather than opening on the tint.
+ * start dark and follow.
  *
  * The regression this guards is the Back path from the pitch step, where the
- * toned backdrop has already published this same hex: publishing the tint on
- * mount is no color change at all, so nothing transitions and the strips sit
- * tinted through the whole fade. Asserted as a sequence, since the dark start
- * and the tint land in different commits. See `page-surface-store`.
+ * toned backdrop has already published this same hex. Two ways to get that
+ * wrong, and the tests cover both: publishing the tint on mount is no color
+ * change for the shell to transition, and publishing it from a passive effect
+ * is not a paint boundary either, so both writes coalesce into one style
+ * recalculation and the computed color never leaves the tint.
+ *
+ * Animation frames are therefore driven by hand here, so "the tint waits for a
+ * painted frame" is what the test actually asserts rather than something the
+ * environment happens to do. See `page-surface-store`.
  */
 
-import { cleanup, render } from "@testing-library/react";
+import { act, cleanup, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 mock.module("@/utils/use-bundled-avatar-components", () => ({
@@ -43,13 +48,20 @@ const { ONBOARDING_DARK_SURFACE } =
 const TEAL = "#2AA79B";
 const TINT_FADE_CSS = "0.6s ease-out 0.35s";
 
-/** Every surface the screen publishes, in order, as `color|transition`. */
-function recordPublishes(): { steps: string[]; stop: () => void } {
-  const steps: string[] = [];
-  const stop = usePageSurfaceStore.subscribe((state) => {
-    steps.push(`${state.surface}|${state.transition}`);
+/** Frames the component asked for, run only when a test says so. */
+let frames: FrameRequestCallback[] = [];
+const realRaf = globalThis.requestAnimationFrame;
+const realCancelRaf = globalThis.cancelAnimationFrame;
+
+/** Run every frame requested so far. Callbacks may request further frames. */
+function paintFrame() {
+  const due = frames;
+  frames = [];
+  act(() => {
+    for (const frame of due) {
+      frame(0);
+    }
   });
-  return { steps, stop };
 }
 
 function renderScreen() {
@@ -65,6 +77,10 @@ function renderScreen() {
 }
 
 beforeEach(() => {
+  frames = [];
+  globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) =>
+    frames.push(callback)) as typeof globalThis.requestAnimationFrame;
+  globalThis.cancelAnimationFrame = (() => {}) as typeof cancelAnimationFrame;
   useOnboardingAvatarPoolStore.setState({
     characters: [{ bodyShape: "urchin", eyeStyle: "goofy", color: "teal" }],
     selectedIndex: 0,
@@ -73,14 +89,50 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  globalThis.requestAnimationFrame = realRaf;
+  globalThis.cancelAnimationFrame = realCancelRaf;
   usePageSurfaceStore.getState().setSurface(null);
   useOnboardingAvatarPoolStore.setState({ characters: [], selectedIndex: 0 });
 });
 
 describe("IntroductionScreen surface handover", () => {
-  test("opens on the dark surface, then fades to the tint", () => {
-    const { steps, stop } = recordPublishes();
+  test("holds the dark surface until a frame has painted it", () => {
+    // The Back path from the pitch step: the strips already carry this hex, so
+    // publishing the tint before the dark one paints leaves the shell with no
+    // color change to transition.
+    usePageSurfaceStore.getState().setSurface(TEAL);
+
     const { unmount } = renderScreen();
+
+    expect(usePageSurfaceStore.getState().surface).toBe(
+      ONBOARDING_DARK_SURFACE,
+    );
+    expect(usePageSurfaceStore.getState().transition).toBeNull();
+
+    // The frame the dark value is painted in. Still too early: this callback
+    // runs before the browser's style and paint for it.
+    paintFrame();
+    expect(usePageSurfaceStore.getState().surface).toBe(
+      ONBOARDING_DARK_SURFACE,
+    );
+
+    // The next frame, which the dark value is now behind.
+    paintFrame();
+    expect(usePageSurfaceStore.getState().surface).toBe(TEAL);
+    expect(usePageSurfaceStore.getState().transition).toBe(TINT_FADE_CSS);
+
+    unmount();
+  });
+
+  test("publishes the tint exactly once, with its fade", () => {
+    const steps: string[] = [];
+    const stop = usePageSurfaceStore.subscribe((state) =>
+      steps.push(`${state.surface}|${state.transition}`),
+    );
+
+    const { unmount } = renderScreen();
+    paintFrame();
+    paintFrame();
     stop();
 
     expect(steps).toEqual([
@@ -90,18 +142,13 @@ describe("IntroductionScreen surface handover", () => {
     unmount();
   });
 
-  test("starts dark even when the strips already carry the tint", () => {
-    // The Back path from the pitch step: the backdrop left the strips on this
-    // same hex, so a mount that published the tint would be no change at all
-    // and the shell would have nothing to transition.
-    usePageSurfaceStore.getState().setSurface(TEAL);
-
-    const { steps, stop } = recordPublishes();
+  test("releases the surface on unmount", () => {
     const { unmount } = renderScreen();
-    stop();
+    paintFrame();
+    paintFrame();
 
-    expect(steps[0]).toBe(`${ONBOARDING_DARK_SURFACE}|null`);
-    expect(steps.at(-1)).toBe(`${TEAL}|${TINT_FADE_CSS}`);
     unmount();
+
+    expect(usePageSurfaceStore.getState().surface).toBeNull();
   });
 });

--- a/clients/web/src/domains/onboarding/screens/introduction-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/screens/introduction-screen.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * The introduction screen opens on the picker's dark surface and fades the
+ * avatar tint in over it, so the safe-area strips the app shell paints have to
+ * start dark and follow rather than opening on the tint.
+ *
+ * The regression this guards is the Back path from the pitch step, where the
+ * toned backdrop has already published this same hex: publishing the tint on
+ * mount is no color change at all, so nothing transitions and the strips sit
+ * tinted through the whole fade. Asserted as a sequence, since the dark start
+ * and the tint land in different commits. See `page-surface-store`.
+ */
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("@/utils/use-bundled-avatar-components", () => ({
+  useBundledAvatarComponents: () => ({
+    colors: [{ id: "teal", hex: "#2AA79B" }],
+    bodyShapes: [
+      {
+        id: "urchin",
+        svgPath: "M0 0h10v10H0z",
+        viewBox: { width: 10, height: 10 },
+      },
+    ],
+  }),
+}));
+
+// Decorative, and it measures itself; the surface handover is what is under
+// test here.
+mock.module("@/domains/onboarding/components/onboarding-peeking-eyes", () => ({
+  OnboardingPeekingEyes: () => null,
+}));
+
+const { IntroductionScreen } =
+  await import("@/domains/onboarding/screens/introduction-screen");
+const { useOnboardingAvatarPoolStore } =
+  await import("@/domains/onboarding/onboarding-avatar-pool-store");
+const { usePageSurfaceStore } = await import("@/stores/page-surface-store");
+const { ONBOARDING_DARK_SURFACE } =
+  await import("@/domains/onboarding/onboarding-step-layout");
+
+const TEAL = "#2AA79B";
+const TINT_FADE_CSS = "0.6s ease-out 0.35s";
+
+/** Every surface the screen publishes, in order, as `color|transition`. */
+function recordPublishes(): { steps: string[]; stop: () => void } {
+  const steps: string[] = [];
+  const stop = usePageSurfaceStore.subscribe((state) => {
+    steps.push(`${state.surface}|${state.transition}`);
+  });
+  return { steps, stop };
+}
+
+function renderScreen() {
+  return render(
+    <IntroductionScreen
+      firstName="Ada"
+      assistantName="Viper"
+      onContinue={() => {}}
+      onBack={() => {}}
+      onForward={() => {}}
+    />,
+  );
+}
+
+beforeEach(() => {
+  useOnboardingAvatarPoolStore.setState({
+    characters: [{ bodyShape: "urchin", eyeStyle: "goofy", color: "teal" }],
+    selectedIndex: 0,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  usePageSurfaceStore.getState().setSurface(null);
+  useOnboardingAvatarPoolStore.setState({ characters: [], selectedIndex: 0 });
+});
+
+describe("IntroductionScreen surface handover", () => {
+  test("opens on the dark surface, then fades to the tint", () => {
+    const { steps, stop } = recordPublishes();
+    const { unmount } = renderScreen();
+    stop();
+
+    expect(steps).toEqual([
+      `${ONBOARDING_DARK_SURFACE}|null`,
+      `${TEAL}|${TINT_FADE_CSS}`,
+    ]);
+    unmount();
+  });
+
+  test("starts dark even when the strips already carry the tint", () => {
+    // The Back path from the pitch step: the backdrop left the strips on this
+    // same hex, so a mount that published the tint would be no change at all
+    // and the shell would have nothing to transition.
+    usePageSurfaceStore.getState().setSurface(TEAL);
+
+    const { steps, stop } = recordPublishes();
+    const { unmount } = renderScreen();
+    stop();
+
+    expect(steps[0]).toBe(`${ONBOARDING_DARK_SURFACE}|null`);
+    expect(steps.at(-1)).toBe(`${TEAL}|${TINT_FADE_CSS}`);
+    unmount();
+  });
+});

--- a/clients/web/src/domains/onboarding/screens/introduction-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/introduction-screen.tsx
@@ -131,17 +131,33 @@ export function IntroductionScreen({
 
   // The stage paints the picker's dark surface at once and fades the tint in
   // over it, so the strips have to start dark and follow rather than open on
-  // the tint. Publishing the tint on mount cannot express that: arriving from
-  // the pitch step by Back, the backdrop has already published this same hex,
-  // so there is no color change for the shell to transition and the strips
-  // would sit tinted through the whole fade. Reduced motion has no fade to
-  // follow, so it takes the tint at once.
+  // the tint. Two things make that finicky. Arriving from the pitch step by
+  // Back, the backdrop has already published this same hex, so publishing the
+  // tint on mount is no color change at all and nothing transitions. And a
+  // transition only starts if the dark value went through a style change event
+  // first, which a passive effect does not guarantee: React schedules those on
+  // a macrotask that usually beats the browser's next rendering opportunity, so
+  // both writes would land in one style recalculation and coalesce back into
+  // tint-to-tint.
+  //
+  // Hence the dark surface in the mount commit and the tint two frames later:
+  // the first rAF still runs before this frame's style and paint, so the second
+  // is the earliest callback that the dark value is guaranteed to have been
+  // painted before. Reduced motion has no fade to follow and takes the tint at
+  // once.
   const [tintPublished, setTintPublished] = useState(false);
   useEffect(() => {
     if (!art || reduce) {
       return;
     }
-    setTintPublished(true);
+    let painted = 0;
+    const committed = requestAnimationFrame(() => {
+      painted = requestAnimationFrame(() => setTintPublished(true));
+    });
+    return () => {
+      cancelAnimationFrame(committed);
+      cancelAnimationFrame(painted);
+    };
   }, [art, reduce]);
   const stripTinted = Boolean(reduce) || tintPublished;
 

--- a/clients/web/src/domains/onboarding/screens/introduction-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/introduction-screen.tsx
@@ -145,6 +145,9 @@ export function IntroductionScreen({
   // is the earliest callback that the dark value is guaranteed to have been
   // painted before. Reduced motion has no fade to follow and takes the tint at
   // once.
+  //
+  // The color layer below waits on this same flip, so its delay and the strips'
+  // start together rather than the canvas leading them by the two frames.
   const [tintPublished, setTintPublished] = useState(false);
   useEffect(() => {
     if (!art || reduce) {
@@ -190,12 +193,13 @@ export function IntroductionScreen({
       surfaceTransition={tintPublished ? TINT_FADE_CSS : undefined}
     >
       {/* The avatar color fills in so coverage is end-to-end even where the
-          body shape has gaps/spikes. */}
+          body shape has gaps/spikes. Held at zero until the strips have their
+          dark starting color on screen, so the two fades share a start. */}
       <motion.div
         className="absolute inset-0 z-0"
         style={{ backgroundColor: art.color }}
         initial={reduce ? false : { opacity: 0 }}
-        animate={{ opacity: 1 }}
+        animate={{ opacity: stripTinted ? 1 : 0 }}
         transition={reduce ? { duration: 0 } : TINT_FADE}
       />
 

--- a/clients/web/src/domains/onboarding/screens/introduction-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/introduction-screen.tsx
@@ -173,13 +173,12 @@ export function IntroductionScreen({
     : t("introductionScreen.intro");
 
   if (!art) {
-    return (
-      <div
-        data-theme="dark"
-        className="h-full"
-        style={{ backgroundColor: "var(--surface-base)" }}
-      />
-    );
+    // The bundled avatar art is a dynamic import that can be slow on a restored
+    // journey and can fail outright, in which case this is what the user sits
+    // on. It goes through the stage rather than a bare div so the strips get
+    // the dark surface too: the stage is what publishes it, and the same stage
+    // instance carries on into the tinted render below once the art lands.
+    return <OnboardingStage className="bg-[var(--surface-base)]" />;
   }
 
   return (

--- a/clients/web/src/domains/onboarding/screens/introduction-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/introduction-screen.tsx
@@ -11,13 +11,16 @@
  * greeting bounces in with the Continue button.
  */
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { ArrowRight } from "lucide-react";
 import { motion, useReducedMotion } from "motion/react";
 import { Button } from "@vellumai/design-library/components/button";
 
 import { useTranslation } from "@/i18n";
-import { ONBOARDING_STEP_CONTENT } from "@/domains/onboarding/onboarding-step-layout";
+import {
+  ONBOARDING_DARK_SURFACE,
+  ONBOARDING_STEP_CONTENT,
+} from "@/domains/onboarding/onboarding-step-layout";
 import { OnboardingPeekingEyes } from "@/domains/onboarding/components/onboarding-peeking-eyes";
 import { OnboardingStage } from "@/domains/onboarding/components/onboarding-stage";
 import { OnboardingTopBar } from "@/domains/onboarding/components/onboarding-top-bar";
@@ -126,6 +129,22 @@ export function IntroductionScreen({
     return { body, color: color.hex };
   }, [components, chosen]);
 
+  // The stage paints the picker's dark surface at once and fades the tint in
+  // over it, so the strips have to start dark and follow rather than open on
+  // the tint. Publishing the tint on mount cannot express that: arriving from
+  // the pitch step by Back, the backdrop has already published this same hex,
+  // so there is no color change for the shell to transition and the strips
+  // would sit tinted through the whole fade. Reduced motion has no fade to
+  // follow, so it takes the tint at once.
+  const [tintPublished, setTintPublished] = useState(false);
+  useEffect(() => {
+    if (!art || reduce) {
+      return;
+    }
+    setTintPublished(true);
+  }, [art, reduce]);
+  const stripTinted = Boolean(reduce) || tintPublished;
+
   const trimmedFirstName = firstName.trim();
   const trimmedAssistantName = assistantName?.trim() ?? "";
   const greeting = trimmedFirstName
@@ -149,10 +168,10 @@ export function IntroductionScreen({
     // Starts on the picker's dark surface; the color layer below fades in.
     <OnboardingStage
       className="bg-[var(--surface-base)]"
-      surface={art.color}
+      surface={stripTinted ? art.color : ONBOARDING_DARK_SURFACE}
       // The strips fade on the color layer's own timing rather than jumping to
       // the tint while the stage is still dark.
-      surfaceTransition={reduce ? undefined : TINT_FADE_CSS}
+      surfaceTransition={tintPublished ? TINT_FADE_CSS : undefined}
     >
       {/* The avatar color fills in so coverage is end-to-end even where the
           body shape has gaps/spikes. */}

--- a/clients/web/src/domains/onboarding/screens/introduction-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/introduction-screen.tsx
@@ -137,7 +137,7 @@ export function IntroductionScreen({
 
   return (
     // Starts on the picker's dark surface; the color layer below fades in.
-    <OnboardingStage className="bg-[var(--surface-base)]">
+    <OnboardingStage className="bg-[var(--surface-base)]" surface={art.color}>
       {/* The avatar color fills in so coverage is end-to-end even where the
           body shape has gaps/spikes. */}
       <motion.div

--- a/clients/web/src/domains/onboarding/screens/introduction-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/introduction-screen.tsx
@@ -27,6 +27,7 @@ import { OnboardingTopBar } from "@/domains/onboarding/components/onboarding-top
 import { useOnboardingStageSize } from "@/domains/onboarding/hooks/use-onboarding-stage-size";
 import { useOnboardingTone } from "@/domains/onboarding/onboarding-tone";
 import { useOnboardingAvatarPoolStore } from "@/domains/onboarding/onboarding-avatar-pool-store";
+import { cssTransitionFor } from "@/stores/page-surface-store";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 
 interface IntroductionScreenProps {
@@ -92,14 +93,12 @@ function IntroductionBodyGrow({
 }
 
 /**
- * The tint layer's fade-in, in the two forms it has to be stated in: motion's
- * for the layer itself, CSS's for the safe-area strips the app shell paints
- * (see `page-surface-store`). Keep them equal, or the strips will arrive on a
- * different beat than the canvas. Motion's default tween ease is CSS
- * `ease-out`.
+ * The tint layer's fade-in. Stated once for the layer itself and derived for
+ * the safe-area strips the app shell paints, so the two cannot drift apart.
+ * See `page-surface-store`.
  */
-const TINT_FADE = { duration: 0.6, delay: 0.35 };
-const TINT_FADE_CSS = "0.6s ease-out 0.35s";
+const TINT_FADE = { duration: 0.6, delay: 0.35 } as const;
+const TINT_FADE_CSS = cssTransitionFor(TINT_FADE);
 
 export function IntroductionScreen({
   firstName,

--- a/clients/web/src/domains/onboarding/screens/introduction-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/introduction-screen.tsx
@@ -88,6 +88,16 @@ function IntroductionBodyGrow({
   );
 }
 
+/**
+ * The tint layer's fade-in, in the two forms it has to be stated in: motion's
+ * for the layer itself, CSS's for the safe-area strips the app shell paints
+ * (see `page-surface-store`). Keep them equal, or the strips will arrive on a
+ * different beat than the canvas. Motion's default tween ease is CSS
+ * `ease-out`.
+ */
+const TINT_FADE = { duration: 0.6, delay: 0.35 };
+const TINT_FADE_CSS = "0.6s ease-out 0.35s";
+
 export function IntroductionScreen({
   firstName,
   assistantName,
@@ -137,7 +147,13 @@ export function IntroductionScreen({
 
   return (
     // Starts on the picker's dark surface; the color layer below fades in.
-    <OnboardingStage className="bg-[var(--surface-base)]" surface={art.color}>
+    <OnboardingStage
+      className="bg-[var(--surface-base)]"
+      surface={art.color}
+      // The strips fade on the color layer's own timing rather than jumping to
+      // the tint while the stage is still dark.
+      surfaceTransition={reduce ? undefined : TINT_FADE_CSS}
+    >
       {/* The avatar color fills in so coverage is end-to-end even where the
           body shape has gaps/spikes. */}
       <motion.div
@@ -145,7 +161,7 @@ export function IntroductionScreen({
         style={{ backgroundColor: art.color }}
         initial={reduce ? false : { opacity: 0 }}
         animate={{ opacity: 1 }}
-        transition={reduce ? { duration: 0 } : { duration: 0.6, delay: 0.35 }}
+        transition={reduce ? { duration: 0 } : TINT_FADE}
       />
 
       {/* Body: grows from the picker size to cover the screen. */}

--- a/clients/web/src/domains/onboarding/screens/research-onboarding-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-onboarding-screen.tsx
@@ -18,7 +18,11 @@ import { HOBBY_SUGGESTIONS } from "@/domains/onboarding/onboarding-suggestions";
 import { Button } from "@vellumai/design-library/components/button";
 import { Input } from "@vellumai/design-library/components/input";
 
-import { MOBILE_INPUT_NO_ZOOM } from "@/domains/onboarding/onboarding-step-layout";
+import {
+  MOBILE_INPUT_NO_ZOOM,
+  ONBOARDING_DARK_SURFACE,
+} from "@/domains/onboarding/onboarding-step-layout";
+import { usePublishPageSurface } from "@/stores/page-surface-store";
 import { useTranslation } from "@/i18n";
 
 export interface ResearchOnboardingValues {
@@ -55,6 +59,9 @@ export function ResearchOnboardingScreen({
   onSubmit,
 }: ResearchOnboardingScreenProps) {
   const { t } = useTranslation("onboarding");
+  // The screen owns the whole viewport, so the shell paints its safe-area
+  // strips to match. See `page-surface-store`.
+  usePublishPageSurface(ONBOARDING_DARK_SURFACE);
   const [firstName, setFirstName] = useState(initialFirstName);
   const [lastName, setLastName] = useState(initialLastName);
   const [role, setRole] = useState("");

--- a/clients/web/src/root-layout.tsx
+++ b/clients/web/src/root-layout.tsx
@@ -67,6 +67,7 @@ import { isElectron } from "@/runtime/is-electron";
 import { isNativeMobile } from "@/runtime/platform-detection";
 import {
   resolveShellBackground,
+  resolveShellTransition,
   usePageSurfaceStore,
 } from "@/stores/page-surface-store";
 import { isPopoutWindow } from "@/runtime/popout-window";
@@ -450,6 +451,13 @@ export function RootLayout() {
   // desktop the neutral canvas is what makes a page read as a card on a page.
   const pageSurface = usePageSurfaceStore.use.surface();
   const shellBackground = resolveShellBackground(pageSurface, isNativeMobile());
+  // A page whose canvas animates hands over its timing too, so the strips move
+  // with it instead of snapping to the destination color a second early.
+  const pageSurfaceTransition = usePageSurfaceStore.use.transition();
+  const shellTransition = resolveShellTransition(
+    pageSurfaceTransition,
+    isNativeMobile(),
+  );
   const shellPaddingTop =
     keyboardOffsetTop > 0
       ? appShellOwnsTopInset
@@ -465,6 +473,7 @@ export function RootLayout() {
       className="app-shell"
       style={{
         background: shellBackground,
+        transition: shellTransition,
         height:
           keyboardOpen && visibleViewport
             ? `${visibleViewport.height + keyboardOffsetTop}px`

--- a/clients/web/src/stores/page-surface-store.test.tsx
+++ b/clients/web/src/stores/page-surface-store.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "bun:test";
 
 import {
+  cssTransitionFor,
   DEFAULT_SHELL_BACKGROUND,
   resolveShellBackground,
   resolveShellTransition,
@@ -12,6 +13,27 @@ import {
 afterEach(() => {
   cleanup();
   usePageSurfaceStore.getState().setSurface(null);
+});
+
+describe("cssTransitionFor", () => {
+  it("spells Motion's easing the CSS way", () => {
+    expect(cssTransitionFor({ duration: 1, ease: "easeInOut" })).toBe(
+      "1s ease-in-out",
+    );
+  });
+
+  it("defaults to Motion's own default tween easing", () => {
+    // Omitting `ease` means `easeOut` in Motion, so it has to here as well or
+    // the strips would run a different curve than the canvas.
+    expect(cssTransitionFor({ duration: 0.6 })).toBe("0.6s ease-out");
+  });
+
+  it("carries a delay when there is one, and omits it when there is not", () => {
+    expect(cssTransitionFor({ duration: 0.6, delay: 0.35 })).toBe(
+      "0.6s ease-out 0.35s",
+    );
+    expect(cssTransitionFor({ duration: 0.6, delay: 0 })).toBe("0.6s ease-out");
+  });
 });
 
 describe("resolveShellTransition", () => {
@@ -149,5 +171,17 @@ describe("usePublishPageSurface", () => {
     unmount();
 
     expect(usePageSurfaceStore.getState().surface).toBe("#17191C");
+  });
+
+  it("does the same when the two screens share a color", () => {
+    // Ownership is identity, not color: by value these two publishers are
+    // indistinguishable, and the outgoing one would clear a surface the
+    // incoming one is still showing.
+    const { unmount } = render(<Publisher surface="#E5C100" />);
+    render(<Publisher surface="#E5C100" />);
+
+    unmount();
+
+    expect(usePageSurfaceStore.getState().surface).toBe("#E5C100");
   });
 });

--- a/clients/web/src/stores/page-surface-store.test.tsx
+++ b/clients/web/src/stores/page-surface-store.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import {
   DEFAULT_SHELL_BACKGROUND,
   resolveShellBackground,
+  resolveShellTransition,
   usePageSurfaceStore,
   usePublishPageSurface,
 } from "@/stores/page-surface-store";
@@ -11,6 +12,22 @@ import {
 afterEach(() => {
   cleanup();
   usePageSurfaceStore.getState().setSurface(null);
+});
+
+describe("resolveShellTransition", () => {
+  it("scopes a published transition to the color", () => {
+    expect(resolveShellTransition("1s ease-in-out", true)).toBe(
+      "background-color 1s ease-in-out",
+    );
+  });
+
+  it("leaves the property off when nothing is animating", () => {
+    expect(resolveShellTransition(null, true)).toBeUndefined();
+  });
+
+  it("keeps the property off outside native mobile, where nothing is painted", () => {
+    expect(resolveShellTransition("1s ease-in-out", false)).toBeUndefined();
+  });
 });
 
 describe("resolveShellBackground", () => {
@@ -53,8 +70,14 @@ describe("usePageSurfaceStore", () => {
   });
 });
 
-function Publisher({ surface }: { surface: string | null }) {
-  usePublishPageSurface(surface);
+function Publisher({
+  surface,
+  transition,
+}: {
+  surface: string | null;
+  transition?: string;
+}) {
+  usePublishPageSurface(surface, transition ?? null);
   return null;
 }
 
@@ -65,6 +88,23 @@ describe("usePublishPageSurface", () => {
 
     unmount();
     expect(usePageSurfaceStore.getState().surface).toBeNull();
+  });
+
+  it("carries the page's timing so the strips animate with it", () => {
+    render(<Publisher surface="#E5C100" transition="0.6s ease-out 0.35s" />);
+
+    expect(usePageSurfaceStore.getState().transition).toBe(
+      "0.6s ease-out 0.35s",
+    );
+  });
+
+  it("clears the timing along with the surface", () => {
+    const { unmount } = render(
+      <Publisher surface="#E5C100" transition="1s ease-in-out" />,
+    );
+    unmount();
+
+    expect(usePageSurfaceStore.getState().transition).toBeNull();
   });
 
   it("opts out without touching what another publisher set", () => {

--- a/clients/web/src/stores/page-surface-store.test.tsx
+++ b/clients/web/src/stores/page-surface-store.test.tsx
@@ -107,6 +107,20 @@ describe("usePublishPageSurface", () => {
     expect(usePageSurfaceStore.getState().transition).toBeNull();
   });
 
+  it("changes color in one write, with no clear in between", () => {
+    const steps: (string | null)[] = [];
+    const stop = usePageSurfaceStore.subscribe((state) =>
+      steps.push(state.surface),
+    );
+
+    const { rerender, unmount } = render(<Publisher surface="#17191C" />);
+    rerender(<Publisher surface="#E5C100" transition="1s ease-in-out" />);
+    stop();
+
+    expect(steps).toEqual(["#17191C", "#E5C100"]);
+    unmount();
+  });
+
   it("opts out without touching what another publisher set", () => {
     usePageSurfaceStore.getState().setSurface("#E5C100");
 

--- a/clients/web/src/stores/page-surface-store.test.tsx
+++ b/clients/web/src/stores/page-surface-store.test.tsx
@@ -90,20 +90,30 @@ describe("usePublishPageSurface", () => {
     expect(usePageSurfaceStore.getState().surface).toBeNull();
   });
 
-  it("carries the page's timing so the strips animate with it", () => {
+  it("lands the first surface outright, whatever timing is offered", () => {
+    // A page takes its canvas color on arrival rather than fading into it, so
+    // the strips must not fade up from whatever the last page left behind.
     render(<Publisher surface="#E5C100" transition="0.6s ease-out 0.35s" />);
 
-    expect(usePageSurfaceStore.getState().transition).toBe(
-      "0.6s ease-out 0.35s",
-    );
+    expect(usePageSurfaceStore.getState().surface).toBe("#E5C100");
+    expect(usePageSurfaceStore.getState().transition).toBeNull();
+  });
+
+  it("carries the page's timing once the color changes", () => {
+    const { rerender } = render(<Publisher surface="#17191C" />);
+
+    rerender(<Publisher surface="#E5C100" transition="1s ease-in-out" />);
+
+    expect(usePageSurfaceStore.getState().transition).toBe("1s ease-in-out");
   });
 
   it("clears the timing along with the surface", () => {
-    const { unmount } = render(
-      <Publisher surface="#E5C100" transition="1s ease-in-out" />,
-    );
+    const { rerender, unmount } = render(<Publisher surface="#17191C" />);
+    rerender(<Publisher surface="#E5C100" transition="1s ease-in-out" />);
+
     unmount();
 
+    expect(usePageSurfaceStore.getState().surface).toBeNull();
     expect(usePageSurfaceStore.getState().transition).toBeNull();
   });
 
@@ -118,6 +128,7 @@ describe("usePublishPageSurface", () => {
     stop();
 
     expect(steps).toEqual(["#17191C", "#E5C100"]);
+    expect(usePageSurfaceStore.getState().transition).toBe("1s ease-in-out");
     unmount();
   });
 

--- a/clients/web/src/stores/page-surface-store.test.tsx
+++ b/clients/web/src/stores/page-surface-store.test.tsx
@@ -1,12 +1,15 @@
+import { cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "bun:test";
 
 import {
   DEFAULT_SHELL_BACKGROUND,
   resolveShellBackground,
   usePageSurfaceStore,
+  usePublishPageSurface,
 } from "@/stores/page-surface-store";
 
 afterEach(() => {
+  cleanup();
   usePageSurfaceStore.getState().setSurface(null);
 });
 
@@ -47,5 +50,39 @@ describe("usePageSurfaceStore", () => {
     usePageSurfaceStore.getState().setSurface("var(--surface-overlay)");
 
     expect(usePageSurfaceStore.getState()).toBe(before);
+  });
+});
+
+function Publisher({ surface }: { surface: string | null }) {
+  usePublishPageSurface(surface);
+  return null;
+}
+
+describe("usePublishPageSurface", () => {
+  it("publishes while mounted and clears on unmount", () => {
+    const { unmount } = render(<Publisher surface="#E5C100" />);
+    expect(usePageSurfaceStore.getState().surface).toBe("#E5C100");
+
+    unmount();
+    expect(usePageSurfaceStore.getState().surface).toBeNull();
+  });
+
+  it("opts out without touching what another publisher set", () => {
+    usePageSurfaceStore.getState().setSurface("#E5C100");
+
+    const { unmount } = render(<Publisher surface={null} />);
+    expect(usePageSurfaceStore.getState().surface).toBe("#E5C100");
+
+    unmount();
+    expect(usePageSurfaceStore.getState().surface).toBe("#E5C100");
+  });
+
+  it("leaves an incoming screen's surface alone when the outgoing one unmounts", () => {
+    const { unmount } = render(<Publisher surface="#E5C100" />);
+    render(<Publisher surface="#17191C" />);
+
+    unmount();
+
+    expect(usePageSurfaceStore.getState().surface).toBe("#17191C");
   });
 });

--- a/clients/web/src/stores/page-surface-store.ts
+++ b/clients/web/src/stores/page-surface-store.ts
@@ -29,17 +29,34 @@ interface PageSurfaceState {
    * back to the shell's neutral canvas.
    */
   surface: string | null;
+  /**
+   * How the strips should get to {@link surface}: the tail of a CSS
+   * `transition` shorthand (duration, easing, and optional delay), or null to
+   * change it in one frame.
+   *
+   * A page whose canvas animates has to say so, because the strips are painted
+   * by a different element than the page: publishing only the destination color
+   * snaps them there while the canvas is still crossfading, which is the same
+   * visible seam along the edge that publishing a surface at all is meant to
+   * remove. Mirror the page's own motion transition here.
+   */
+  transition: string | null;
 }
 
 interface PageSurfaceActions {
-  setSurface: (surface: string | null) => void;
+  setSurface: (surface: string | null, transition?: string | null) => void;
 }
 
 const usePageSurfaceStoreBase = create<PageSurfaceState & PageSurfaceActions>(
   (set) => ({
     surface: null,
-    setSurface: (surface) =>
-      set((state) => (state.surface === surface ? state : { surface })),
+    transition: null,
+    setSurface: (surface, transition = null) =>
+      set((state) =>
+        state.surface === surface && state.transition === transition
+          ? state
+          : { surface, transition },
+      ),
   }),
 );
 
@@ -63,28 +80,49 @@ export function resolveShellBackground(
 }
 
 /**
- * Publish `surface` as the shell canvas for as long as the caller is mounted.
+ * The app shell's `transition` for a published surface, scoped to the color so
+ * it never catches the height and padding the shell re-computes for the iOS
+ * keyboard. `undefined` (not `"none"`) when nothing is animating, so the shell
+ * leaves the property off entirely.
+ */
+export function resolveShellTransition(
+  pageTransition: string | null,
+  nativeMobile: boolean,
+): string | undefined {
+  return pageTransition && nativeMobile
+    ? `background-color ${pageTransition}`
+    : undefined;
+}
+
+/**
+ * Publish `surface` as the shell canvas for as long as the caller is mounted,
+ * reaching it over `transition` when the page's own canvas animates there.
  *
  * Layout effect, not passive: the page commits and can paint before a passive
  * effect runs, so the safe-area strips would trail the page by a frame both on
- * arrival and whenever the color resolves.
+ * arrival and whenever the color resolves. It also puts the strips' transition
+ * in the same frame the page starts its own, which is what keeps the two in
+ * step rather than merely equal in duration.
  *
  * Pass `null` to opt out (a screen whose color is owned by a child layer). The
  * cleanup only clears a surface this caller still owns, so a screen that mounts
  * before the outgoing one unmounts keeps its color instead of flashing the
  * neutral canvas.
  */
-export function usePublishPageSurface(surface: string | null): void {
+export function usePublishPageSurface(
+  surface: string | null,
+  transition: string | null = null,
+): void {
   const setSurface = usePageSurfaceStore.use.setSurface();
   useLayoutEffect(() => {
     if (surface === null) {
       return;
     }
-    setSurface(surface);
+    setSurface(surface, transition);
     return () => {
       if (usePageSurfaceStore.getState().surface === surface) {
         setSurface(null);
       }
     };
-  }, [surface, setSurface]);
+  }, [surface, transition, setSurface]);
 }

--- a/clients/web/src/stores/page-surface-store.ts
+++ b/clients/web/src/stores/page-surface-store.ts
@@ -14,10 +14,11 @@
  * Consumed only under `isNativeMobile()`: desktop web and Electron keep the
  * neutral canvas that makes `PageShell`'s card read as a card.
  *
- * Publishers register from a `useEffect` and clear on unmount, the same
- * convention as the header slots in `chat-layout-slots-store`.
+ * Publishers register through {@link usePublishPageSurface} and clear on
+ * unmount, the same convention as the header slots in `chat-layout-slots-store`.
  */
 
+import { useLayoutEffect } from "react";
 import { create } from "zustand";
 
 import { createSelectors } from "@/utils/create-selectors";
@@ -59,4 +60,31 @@ export function resolveShellBackground(
   nativeMobile: boolean,
 ): string {
   return pageSurface && nativeMobile ? pageSurface : DEFAULT_SHELL_BACKGROUND;
+}
+
+/**
+ * Publish `surface` as the shell canvas for as long as the caller is mounted.
+ *
+ * Layout effect, not passive: the page commits and can paint before a passive
+ * effect runs, so the safe-area strips would trail the page by a frame both on
+ * arrival and whenever the color resolves.
+ *
+ * Pass `null` to opt out (a screen whose color is owned by a child layer). The
+ * cleanup only clears a surface this caller still owns, so a screen that mounts
+ * before the outgoing one unmounts keeps its color instead of flashing the
+ * neutral canvas.
+ */
+export function usePublishPageSurface(surface: string | null): void {
+  const setSurface = usePageSurfaceStore.use.setSurface();
+  useLayoutEffect(() => {
+    if (surface === null) {
+      return;
+    }
+    setSurface(surface);
+    return () => {
+      if (usePageSurfaceStore.getState().surface === surface) {
+        setSurface(null);
+      }
+    };
+  }, [surface, setSurface]);
 }

--- a/clients/web/src/stores/page-surface-store.ts
+++ b/clients/web/src/stores/page-surface-store.ts
@@ -39,6 +39,9 @@ interface PageSurfaceState {
    * snaps them there while the canvas is still crossfading, which is the same
    * visible seam along the edge that publishing a surface at all is meant to
    * remove. Mirror the page's own motion transition here.
+   *
+   * Applies to a publisher's changes of color, never to its first: see
+   * {@link usePublishPageSurface}.
    */
   transition: string | null;
 }
@@ -98,6 +101,9 @@ export function resolveShellTransition(
  * Publish `surface` as the shell canvas for as long as the caller is mounted,
  * reaching it over `transition` when the page's own canvas animates there.
  *
+ * `transition` applies to this caller's changes of color, never to its first
+ * publish, which always lands outright.
+ *
  * Layout effect, not passive: the page commits and can paint before a passive
  * effect runs, so the safe-area strips would trail the page by a frame both on
  * arrival and whenever the color resolves. It also puts the strips' transition
@@ -120,8 +126,15 @@ export function usePublishPageSurface(
     if (surface === null) {
       return;
     }
+    // A transition is for a change of color, not an arrival. A page takes its
+    // canvas color outright when it mounts, so the strips do too, and only the
+    // publisher's later changes animate. Without this a page resumed straight
+    // onto a themed step would leave them fading up from the neutral canvas
+    // while the page itself was already there.
+    const changing =
+      published.current !== null && published.current !== surface;
     published.current = surface;
-    setSurface(surface, transition);
+    setSurface(surface, changing ? transition : null);
   }, [surface, transition, setSurface]);
 
   // Releasing is its own effect so that publishing a new color is one store

--- a/clients/web/src/stores/page-surface-store.ts
+++ b/clients/web/src/stores/page-surface-store.ts
@@ -18,7 +18,7 @@
  * unmount, the same convention as the header slots in `chat-layout-slots-store`.
  */
 
-import { useLayoutEffect, useRef } from "react";
+import { useId, useLayoutEffect, useRef } from "react";
 import { create } from "zustand";
 
 import { createSelectors } from "@/utils/create-selectors";
@@ -29,6 +29,14 @@ interface PageSurfaceState {
    * back to the shell's neutral canvas.
    */
   surface: string | null;
+  /**
+   * Which publisher {@link surface} belongs to, so an outgoing one can tell
+   * whether it is still the owner before clearing. Identity rather than color:
+   * two screens overlapping on the same color are indistinguishable by value,
+   * and the outgoing one would clear a surface the incoming one is still
+   * showing. Not read by the shell.
+   */
+  owner: string | null;
   /**
    * How the strips should get to {@link surface}: the tail of a CSS
    * `transition` shorthand (duration, easing, and optional delay), or null to
@@ -47,18 +55,25 @@ interface PageSurfaceState {
 }
 
 interface PageSurfaceActions {
-  setSurface: (surface: string | null, transition?: string | null) => void;
+  setSurface: (
+    surface: string | null,
+    transition?: string | null,
+    owner?: string | null,
+  ) => void;
 }
 
 const usePageSurfaceStoreBase = create<PageSurfaceState & PageSurfaceActions>(
   (set) => ({
     surface: null,
     transition: null,
-    setSurface: (surface, transition = null) =>
+    owner: null,
+    setSurface: (surface, transition = null, owner = null) =>
       set((state) =>
-        state.surface === surface && state.transition === transition
+        state.surface === surface &&
+        state.transition === transition &&
+        state.owner === owner
           ? state
-          : { surface, transition },
+          : { surface, transition, owner },
       ),
   }),
 );
@@ -98,6 +113,47 @@ export function resolveShellTransition(
 }
 
 /**
+ * Motion's named easings, in the CSS spelling of the same curves. Motion's
+ * `easeInOut` is `cubic-bezier(0.42, 0, 0.58, 1)` and CSS's `ease-in-out` is
+ * the same, and so on down the list, so a fade stated in one form runs on the
+ * identical curve in the other.
+ */
+const CSS_EASING = {
+  linear: "linear",
+  easeIn: "ease-in",
+  easeOut: "ease-out",
+  easeInOut: "ease-in-out",
+} as const;
+
+/**
+ * A page's own fade, in the subset of Motion's transition that has a CSS
+ * equivalent. Omitting `ease` means Motion's default for a tween, `easeOut`.
+ */
+export interface PageSurfaceFade {
+  duration: number;
+  delay?: number;
+  ease?: keyof typeof CSS_EASING;
+}
+
+/**
+ * The CSS form of a page's Motion fade, for {@link usePublishPageSurface}.
+ *
+ * The strips are painted by the shell and the canvas by the page, so the same
+ * fade has to be expressed twice, once for each engine. Deriving the second
+ * from the first is what keeps them equal: stated separately they are two
+ * literals whose agreement nothing enforces, and the seam this whole mechanism
+ * exists to remove comes back the moment one is edited alone.
+ */
+export function cssTransitionFor({
+  duration,
+  delay = 0,
+  ease = "easeOut",
+}: PageSurfaceFade): string {
+  const timing = `${duration}s ${CSS_EASING[ease]}`;
+  return delay > 0 ? `${timing} ${delay}s` : timing;
+}
+
+/**
  * Publish `surface` as the shell canvas for as long as the caller is mounted,
  * reaching it over `transition` when the page's own canvas animates there.
  *
@@ -113,13 +169,14 @@ export function resolveShellTransition(
  * Pass `null` to opt out (a screen whose color is owned by a child layer). The
  * cleanup only clears a surface this caller still owns, so a screen that mounts
  * before the outgoing one unmounts keeps its color instead of flashing the
- * neutral canvas.
+ * neutral canvas, whether or not the two happen to share a color.
  */
 export function usePublishPageSurface(
   surface: string | null,
   transition: string | null = null,
 ): void {
   const setSurface = usePageSurfaceStore.use.setSurface();
+  const owner = useId();
   const published = useRef<string | null>(null);
 
   useLayoutEffect(() => {
@@ -134,8 +191,8 @@ export function usePublishPageSurface(
     const changing =
       published.current !== null && published.current !== surface;
     published.current = surface;
-    setSurface(surface, changing ? transition : null);
-  }, [surface, transition, setSurface]);
+    setSurface(surface, changing ? transition : null, owner);
+  }, [surface, transition, owner, setSurface]);
 
   // Releasing is its own effect so that publishing a new color is one store
   // write rather than a clear followed by a set. The pair lands in a single
@@ -143,10 +200,10 @@ export function usePublishPageSurface(
   // the moment anything moved them apart.
   useLayoutEffect(
     () => () => {
-      if (usePageSurfaceStore.getState().surface === published.current) {
+      if (usePageSurfaceStore.getState().owner === owner) {
         setSurface(null);
       }
     },
-    [setSurface],
+    [owner, setSurface],
   );
 }

--- a/clients/web/src/stores/page-surface-store.ts
+++ b/clients/web/src/stores/page-surface-store.ts
@@ -18,7 +18,7 @@
  * unmount, the same convention as the header slots in `chat-layout-slots-store`.
  */
 
-import { useLayoutEffect } from "react";
+import { useLayoutEffect, useRef } from "react";
 import { create } from "zustand";
 
 import { createSelectors } from "@/utils/create-selectors";
@@ -114,15 +114,26 @@ export function usePublishPageSurface(
   transition: string | null = null,
 ): void {
   const setSurface = usePageSurfaceStore.use.setSurface();
+  const published = useRef<string | null>(null);
+
   useLayoutEffect(() => {
     if (surface === null) {
       return;
     }
+    published.current = surface;
     setSurface(surface, transition);
-    return () => {
-      if (usePageSurfaceStore.getState().surface === surface) {
+  }, [surface, transition, setSurface]);
+
+  // Releasing is its own effect so that publishing a new color is one store
+  // write rather than a clear followed by a set. The pair lands in a single
+  // commit either way, but the clear would be a frame of the neutral canvas
+  // the moment anything moved them apart.
+  useLayoutEffect(
+    () => () => {
+      if (usePageSurfaceStore.getState().surface === published.current) {
         setSurface(null);
       }
-    };
-  }, [surface, transition, setSurface]);
+    },
+    [setSurface],
+  );
 }


### PR DESCRIPTION
## The bug

A pale band across the bottom edge of every onboarding screen on iOS, under the home indicator.

## Root cause

Not an onboarding rendering bug. The app shell owns the home-indicator inset as `paddingBottom` on `.app-shell` (`root-layout.tsx`), so that element's own background is what paints the strip. Routes hand the shell a color through `page-surface-store`; anything that does not publish keeps `DEFAULT_SHELL_BACKGROUND` = `var(--surface-base)`, which resolves light (`#F6F5F4`) in the app theme.

Onboarding never published. Every onboarding screen re-declares `data-theme="dark"` on itself, and the pitch steps paint the avatar tint inside that subtree, so the page renders yellow while the shell keeps painting `#F6F5F4` under the home indicator. The top edge escaped only because onboarding is in `shouldSuppressRootStatusBanner`, which makes the shell skip `paddingTop` there; nothing skips the bottom.

This affected every onboarding screen, not just the pitch step in the report.

## The fix

`page-surface-store` gains `usePublishPageSurface(surface)` as its one publisher API: layout effect (the page can paint before a passive effect runs, so the strips would trail it by a frame), clears on unmount, and only clears a surface it still owns so a screen swap cannot flash the neutral canvas.

Publishers wired up:

- **`OnboardingStage`** takes a `surface` prop defaulting to `ONBOARDING_DARK_SURFACE` (`#17191C`, `--surface-base` resolved in the dark theme the stage forces on itself), so every screen using the stage is covered by default.
- **`OnboardingTonedBackdrop`** owns and animates this screen's color, so it publishes the live avatar tint (or the post-calendar dark) and the toned route passes `surface={null}` to defer to it. Its `var(--surface-base)` fallback became the literal: same color inside the dark stage, and interpolable by motion.
- **`IntroductionScreen`** publishes its avatar color.
- **`ResearchOnboardingScreen`** and **`ExistingAssistantStep`** are full-screen dark screens that live outside the stage, so they publish directly.
- **`AssistantStage`** drops its hand-rolled copy of the same effect for the shared hook, so the store's docstring has one convention to point at.

## Testing

- New `onboarding-stage.test.tsx` covers the default publish, an explicit tint, the `null` opt-out, and release on unmount.
- New `usePublishPageSurface` cases in `page-surface-store.test.tsx` (renamed from `.ts` for JSX) cover publish/clear, opting out without disturbing another publisher, and an outgoing screen not stealing the incoming screen's surface.
- `bunx tsc --noEmit`, eslint, and prettier clean; onboarding, stores, and intelligence suites pass isolated per file.

## Verification note

**Needs an iOS build to confirm visually.** `resolveShellBackground` gates on `isNativeMobile()`, which reads the real Capacitor runtime, so a desktop browser always takes the neutral-canvas branch and cannot exercise the change. Desktop web and Electron are unaffected by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
