### PR TITLE
fix(local-mode): treat a down gateway as unavailable, not a spent token

### DIFF
--- a/cli/src/__tests__/guardian-token.test.ts
+++ b/cli/src/__tests__/guardian-token.test.ts
@@ -428,11 +428,11 @@ describe("refreshGuardianToken", () => {
 
   test("an unreachable gateway is a 503, not a 401", async () => {
     seed(future());
-    globalThis.fetch = (async () => {
+    globalThis.fetch = (async (_url: unknown, _init?: RequestInit) => {
       throw Object.assign(new TypeError("fetch failed"), {
         cause: { code: "ECONNREFUSED" },
       });
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const result = await refreshGuardianTokenResult(
       "http://127.0.0.1:59999",
@@ -451,7 +451,7 @@ describe("refreshGuardianToken", () => {
 
   test("an HTTP 401 from the gateway is a spent credential", async () => {
     seed(future());
-    globalThis.fetch = (async () =>
+    globalThis.fetch = (async (_url: unknown, _init?: RequestInit) =>
       new Response("", { status: 401 })) as typeof fetch;
 
     expect(
@@ -465,7 +465,7 @@ describe("refreshGuardianToken", () => {
 
   test("an HTTP 503 from a still-starting gateway is retryable", async () => {
     seed(future());
-    globalThis.fetch = (async () =>
+    globalThis.fetch = (async (_url: unknown, _init?: RequestInit) =>
       new Response("", { status: 503 })) as typeof fetch;
 
     const result = await refreshGuardianTokenResult(

--- a/cli/src/__tests__/guardian-token.test.ts
+++ b/cli/src/__tests__/guardian-token.test.ts
@@ -18,6 +18,7 @@ import {
   guardianTokenDueForRenewal,
   loadGuardianToken,
   refreshGuardianToken,
+  refreshGuardianTokenResult,
   saveGuardianToken,
   seedGuardianTokenFromSiblingEnv,
   type GuardianTokenData,
@@ -423,6 +424,58 @@ describe("refreshGuardianToken", () => {
       console.warn = origWarn;
     }
     expect(called).toBe(false);
+  });
+
+  test("an unreachable gateway is a 503, not a 401", async () => {
+    seed(future());
+    globalThis.fetch = (async () => {
+      throw Object.assign(new TypeError("fetch failed"), {
+        cause: { code: "ECONNREFUSED" },
+      });
+    }) as typeof fetch;
+
+    const result = await refreshGuardianTokenResult(
+      "http://127.0.0.1:59999",
+      "px",
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      status: 503,
+      error: "Assistant gateway is unreachable",
+    });
+    expect(
+      await refreshGuardianToken("http://127.0.0.1:59999", "px"),
+    ).toBeNull();
+  });
+
+  test("an HTTP 401 from the gateway is a spent credential", async () => {
+    seed(future());
+    globalThis.fetch = (async () =>
+      new Response("", { status: 401 })) as typeof fetch;
+
+    expect(
+      await refreshGuardianTokenResult("https://gw.example.com", "px"),
+    ).toEqual({
+      ok: false,
+      status: 401,
+      error: "Failed to refresh guardian token",
+    });
+  });
+
+  test("an HTTP 503 from a still-starting gateway is retryable", async () => {
+    seed(future());
+    globalThis.fetch = (async () =>
+      new Response("", { status: 503 })) as typeof fetch;
+
+    const result = await refreshGuardianTokenResult(
+      "https://gw.example.com",
+      "px",
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(503);
+    }
   });
 });
 

--- a/cli/src/__tests__/guardian-token.test.ts
+++ b/cli/src/__tests__/guardian-token.test.ts
@@ -463,6 +463,44 @@ describe("refreshGuardianToken", () => {
     });
   });
 
+  test("an HTTP 403 from the refresh route is a spent credential, not a loopback refusal", async () => {
+    seed(future());
+    globalThis.fetch = (async (_url: unknown, _init?: RequestInit) =>
+      new Response("", { status: 403 })) as typeof fetch;
+
+    expect(
+      await refreshGuardianTokenResult("https://gw.example.com", "px"),
+    ).toEqual({
+      ok: false,
+      status: 401,
+      error: "Failed to refresh guardian token",
+    });
+  });
+
+  test("an insecure gateway URL is a local 403, not a spent credential", async () => {
+    seed(future());
+    let called = false;
+    globalThis.fetch = (async (_url: unknown, _init?: RequestInit) => {
+      called = true;
+      return new Response("", { status: 200 });
+    }) as typeof fetch;
+
+    const origWarn = console.warn;
+    console.warn = () => {};
+    try {
+      expect(
+        await refreshGuardianTokenResult("http://10.0.0.5:7830", "px"),
+      ).toEqual({
+        ok: false,
+        status: 403,
+        error: "Refusing to refresh the guardian token over an insecure URL",
+      });
+    } finally {
+      console.warn = origWarn;
+    }
+    expect(called).toBe(false);
+  });
+
   test("an HTTP 503 from a still-starting gateway is retryable", async () => {
     seed(future());
     globalThis.fetch = (async (_url: unknown, _init?: RequestInit) =>

--- a/cli/src/commands/gateway/token.ts
+++ b/cli/src/commands/gateway/token.ts
@@ -1,10 +1,12 @@
+import { formatGuardianRefreshCliFailure } from "@vellumai/local-mode";
+
 import {
   lookupAssistantByIdentifier,
   formatAssistantLookupError,
 } from "../../lib/assistant-config.js";
 import {
   loadGuardianToken,
-  refreshGuardianToken,
+  refreshGuardianTokenResult,
 } from "../../lib/guardian-token.js";
 
 function printUsage(): void {
@@ -63,11 +65,17 @@ export async function gatewayToken(): Promise<void> {
     process.exit(1);
   }
 
-  const refreshed = await refreshGuardianToken(gatewayUrl, entry.assistantId);
-  if (!refreshed) {
-    console.error("Failed to refresh guardian token.");
+  const refreshed = await refreshGuardianTokenResult(
+    gatewayUrl,
+    entry.assistantId,
+  );
+  if (!refreshed.ok) {
+    console.error(refreshed.error);
+    console.error(
+      formatGuardianRefreshCliFailure(refreshed.status, refreshed.error),
+    );
     process.exit(1);
   }
 
-  console.log(refreshed.accessToken);
+  console.log(refreshed.token.accessToken);
 }

--- a/cli/src/lib/guardian-token.ts
+++ b/cli/src/lib/guardian-token.ts
@@ -339,18 +339,14 @@ function classifyRefreshThrownError(error: unknown): GuardianTokenRefreshResult 
 }
 
 function classifyRefreshHttpStatus(status: number): GuardianTokenRefreshResult {
-  if (status === 401) {
+  // The guardian refresh route uses 403 for revoked, reused, or
+  // device-mismatched tokens. That is a spent credential, not a
+  // loopback-boundary refusal, so hosts treat it as 401.
+  if (status === 401 || status === 403) {
     return {
       ok: false,
       status: 401,
       error: "Failed to refresh guardian token",
-    };
-  }
-  if (status === 403) {
-    return {
-      ok: false,
-      status: 403,
-      error: "Assistant gateway refused the token refresh",
     };
   }
   if (status >= 500) {
@@ -370,8 +366,12 @@ function classifyRefreshHttpStatus(status: number): GuardianTokenRefreshResult {
 /**
  * Call POST /v1/guardian/refresh on the remote gateway to obtain a new
  * access token using an existing (possibly expired) access token for auth.
- * Returns a structured result so hosts can tell a spent credential (401)
- * from an unreachable gateway (503) instead of collapsing both to null.
+ * Returns a structured result so hosts can tell a spent credential (401,
+ * including a refresh-endpoint 403 for revoked/reused/device-mismatched
+ * tokens) from an unreachable gateway (503) instead of collapsing both
+ * to null. 403 is reserved for a local confidentiality refusal (insecure
+ * URL). Loopback and paired-token refusals are also 403, and they are
+ * decided on the host before this refresh runs.
  *
  * Concurrency-safe: the gateway rotates refresh tokens and treats reuse of an
  * already-rotated token as replay (revoking the whole token family), so two

--- a/cli/src/lib/guardian-token.ts
+++ b/cli/src/lib/guardian-token.ts
@@ -233,10 +233,145 @@ function releaseRefreshLock(lockPath: string): void {
 }
 
 /**
+ * True when a stored guardian token has reached its renewal point: now is
+ * at/after `refreshAfter` (preferred) or `accessTokenExpiresAt`. Used to gate
+ * refresh so a forged/synthetic 401 on a still-valid token can't coax out the
+ * long-lived refresh credential. Unparseable timestamps → not due.
+ */
+export function guardianTokenDueForRenewal(token: GuardianTokenData): boolean {
+  const raw = token.refreshAfter || token.accessTokenExpiresAt;
+  const at = new Date(raw).getTime();
+  if (!Number.isFinite(at)) {
+    return false;
+  }
+  return at <= Date.now();
+}
+
+export type GuardianTokenRefreshResult =
+  | { ok: true; token: GuardianTokenData }
+  | { ok: false; status: number; error: string };
+
+function failureChainText(error: unknown): string {
+  const parts: string[] = [];
+  let current: unknown = error;
+  for (let i = 0; i < 4 && current; i++) {
+    if (current instanceof Error) {
+      parts.push(current.name, current.message);
+      if ("code" in current && current.code != null) {
+        parts.push(String(current.code));
+      }
+      current = current.cause;
+      continue;
+    }
+    if (current && typeof current === "object") {
+      const record = current as {
+        code?: unknown;
+        message?: unknown;
+        cause?: unknown;
+        name?: unknown;
+      };
+      if (record.name != null) {
+        parts.push(String(record.name));
+      }
+      if (record.message != null) {
+        parts.push(String(record.message));
+      }
+      if (record.code != null) {
+        parts.push(String(record.code));
+      }
+      current = record.cause;
+      continue;
+    }
+    break;
+  }
+  return parts.join(" ").toLowerCase();
+}
+
+function isTimeoutLikeError(error: unknown): boolean {
+  if (error instanceof Error) {
+    if (error.name === "TimeoutError" || error.name === "AbortError") {
+      return true;
+    }
+  }
+  const haystack = failureChainText(error);
+  return (
+    haystack.includes("timeout") ||
+    haystack.includes("etimedout") ||
+    haystack.includes("und_err_connect_timeout")
+  );
+}
+
+function isUnreachableGatewayError(error: unknown): boolean {
+  const haystack = failureChainText(error);
+  return (
+    haystack.includes("econnrefused") ||
+    haystack.includes("econnreset") ||
+    haystack.includes("enotfound") ||
+    haystack.includes("ehostunreach") ||
+    haystack.includes("enetunreach") ||
+    haystack.includes("und_err_socket") ||
+    haystack.includes("fetch failed") ||
+    haystack.includes("unable to connect") ||
+    haystack.includes("failed to connect")
+  );
+}
+
+function classifyRefreshThrownError(error: unknown): GuardianTokenRefreshResult {
+  if (isTimeoutLikeError(error)) {
+    return {
+      ok: false,
+      status: 504,
+      error: "Guardian token refresh timed out",
+    };
+  }
+  if (isUnreachableGatewayError(error)) {
+    return {
+      ok: false,
+      status: 503,
+      error: "Assistant gateway is unreachable",
+    };
+  }
+  return {
+    ok: false,
+    status: 500,
+    error: "Failed to refresh guardian token",
+  };
+}
+
+function classifyRefreshHttpStatus(status: number): GuardianTokenRefreshResult {
+  if (status === 401) {
+    return {
+      ok: false,
+      status: 401,
+      error: "Failed to refresh guardian token",
+    };
+  }
+  if (status === 403) {
+    return {
+      ok: false,
+      status: 403,
+      error: "Assistant gateway refused the token refresh",
+    };
+  }
+  if (status >= 500) {
+    return {
+      ok: false,
+      status,
+      error: `Assistant gateway rejected the token refresh (${status})`,
+    };
+  }
+  return {
+    ok: false,
+    status,
+    error: `Assistant gateway rejected the token refresh (${status})`,
+  };
+}
+
+/**
  * Call POST /v1/guardian/refresh on the remote gateway to obtain a new
  * access token using an existing (possibly expired) access token for auth.
- * Returns the refreshed token data (persisted locally), or null if the
- * refresh fails (e.g. no stored token, or refresh token itself is expired).
+ * Returns a structured result so hosts can tell a spent credential (401)
+ * from an unreachable gateway (503) instead of collapsing both to null.
  *
  * Concurrency-safe: the gateway rotates refresh tokens and treats reuse of an
  * already-rotated token as replay (revoking the whole token family), so two
@@ -246,60 +381,68 @@ function releaseRefreshLock(lockPath: string): void {
  * process already rotated it while we waited, we return that fresh token
  * instead of replaying our now-stale refresh token.
  */
-/**
- * True when a stored guardian token has reached its renewal point — now is
- * at/after `refreshAfter` (preferred) or `accessTokenExpiresAt`. Used to gate
- * refresh so a forged/synthetic 401 on a still-valid token can't coax out the
- * long-lived refresh credential. Unparseable timestamps → not due.
- */
-export function guardianTokenDueForRenewal(token: GuardianTokenData): boolean {
-  const raw = token.refreshAfter || token.accessTokenExpiresAt;
-  const at = new Date(raw).getTime();
-  if (!Number.isFinite(at)) return false;
-  return at <= Date.now();
-}
-
-export async function refreshGuardianToken(
+export async function refreshGuardianTokenResult(
   gatewayUrl: string,
   assistantId: string,
-): Promise<GuardianTokenData | null> {
+): Promise<GuardianTokenRefreshResult> {
   // Never send the long-lived refresh token over a non-loopback plaintext URL.
   if (!isConfidentialRefreshUrl(gatewayUrl)) {
     console.warn(
       `Refusing to refresh the guardian token over an insecure URL (${gatewayUrl}). ` +
-        "The refresh token is only sent over https or a loopback address — " +
+        "The refresh token is only sent over https or a loopback address: " +
         "use an https URL (e.g. a tunnel) or connect over loopback.",
     );
-    return null;
+    return {
+      ok: false,
+      status: 403,
+      error: "Refusing to refresh the guardian token over an insecure URL",
+    };
   }
 
   const before = loadGuardianToken(assistantId);
-  if (!before) return null;
+  if (!before) {
+    return {
+      ok: false,
+      status: 404,
+      error: "Guardian token not found",
+    };
+  }
 
   // Gateway persists expiresAt as epoch-ms numbers; Date.parse("1234567890000")
   // returns NaN. new Date() accepts both ISO strings and epoch-ms numbers.
   const refreshExpiry = new Date(before.refreshTokenExpiresAt).getTime();
-  if (!Number.isFinite(refreshExpiry) || refreshExpiry <= Date.now())
-    return null;
+  if (!Number.isFinite(refreshExpiry) || refreshExpiry <= Date.now()) {
+    return {
+      ok: false,
+      status: 401,
+      error: "Guardian token expired. Re-run `vellum hatch` or `vellum wake`.",
+    };
+  }
 
   const lockPath = getRefreshLockPath(assistantId);
   const locked = await acquireRefreshLock(lockPath);
   try {
     // Re-read under the lock: a concurrent process may have rotated the token
     // while we waited. If the stored refresh token changed, ours is now stale
-    // (replaying it would trip reuse-detection) — use the fresh token instead.
+    // (replaying it would trip reuse-detection). Use the fresh token instead.
     const current = loadGuardianToken(assistantId);
     if (current && current.refreshToken !== before.refreshToken) {
-      return current;
+      return { ok: true, token: current };
     }
 
     // We did NOT acquire the lock (another process is likely mid-refresh) and
     // the stored token hasn't been rotated yet. Do NOT call the gateway: our
     // refresh token may be the one the winner is rotating right now, and
     // replaying a rotated token revokes the whole family (forcing re-pair).
-    // Give up — the caller surfaces the original 401, and the next attempt
-    // picks up the winner's persisted token.
-    if (!locked) return null;
+    // Surface a retryable failure so the next attempt can pick up the
+    // winner's persisted token.
+    if (!locked) {
+      return {
+        ok: false,
+        status: 503,
+        error: "Guardian token refresh is already in progress",
+      };
+    }
 
     const tokenData = current ?? before;
 
@@ -321,7 +464,9 @@ export async function refreshGuardianToken(
         signal: AbortSignal.timeout(REFRESH_FETCH_TIMEOUT_MS),
       },
     );
-    if (!response.ok) return null;
+    if (!response.ok) {
+      return classifyRefreshHttpStatus(response.status);
+    }
 
     const json = (await response.json()) as Record<string, unknown>;
     const refreshed: GuardianTokenData = {
@@ -342,12 +487,23 @@ export async function refreshGuardianToken(
       pairedGatewayUrl: tokenData.pairedGatewayUrl,
     };
     saveGuardianToken(assistantId, refreshed);
-    return refreshed;
-  } catch {
-    return null;
+    return { ok: true, token: refreshed };
+  } catch (error) {
+    return classifyRefreshThrownError(error);
   } finally {
-    if (locked) releaseRefreshLock(lockPath);
+    if (locked) {
+      releaseRefreshLock(lockPath);
+    }
   }
+}
+
+/** Convenience wrapper around {@link refreshGuardianTokenResult}. */
+export async function refreshGuardianToken(
+  gatewayUrl: string,
+  assistantId: string,
+): Promise<GuardianTokenData | null> {
+  const result = await refreshGuardianTokenResult(gatewayUrl, assistantId);
+  return result.ok ? result.token : null;
 }
 
 /**

--- a/clients/web/src/lib/local-mode-repair.test.ts
+++ b/clients/web/src/lib/local-mode-repair.test.ts
@@ -262,6 +262,43 @@ describe("primeLocalGatewayConnectionWithRepair", () => {
     expect((err as InstanceType<typeof GatewayTokenError>).status).toBe(503);
     expect(wakeLocalAssistantHost).toHaveBeenCalledTimes(1);
   });
+
+  test("rides out a post-wake guardian refresh 503, then reconnects", async () => {
+    // The reopen-the-app symptom: with the gateway down, refresh reports 503.
+    // Wake restarts the gateway, but the refresh that follows can still land
+    // before it answers. Riding that 5xx out keeps a plain reopen from
+    // dead-ending on the recovery dialog.
+    let fetches = 0;
+    fetchGuardianTokenHost = mock(async (_id: string) => {
+      fetches++;
+      if (fetches <= 2) {
+        throw new GuardianTokenError(503, "Assistant gateway is unreachable");
+      }
+      return "tok";
+    });
+
+    await primeLocalGatewayConnectionWithRepair();
+
+    expect(wakeLocalAssistantHost).toHaveBeenCalledTimes(1);
+    // One pre-wake fetch, one post-wake fetch ridden out, then the success.
+    expect(fetches).toBe(3);
+  });
+
+  test("a post-wake guardian 401 surfaces immediately as a spent credential", async () => {
+    fetchGuardianTokenHost = mock(async () => {
+      throw new GuardianTokenError(401, "Failed to refresh guardian token");
+    });
+
+    const err = await primeLocalGatewayConnectionWithRepair().catch(
+      (e: unknown) => e,
+    );
+
+    expect(err).toBeInstanceOf(GuardianTokenError);
+    expect((err as InstanceType<typeof GuardianTokenError>).status).toBe(401);
+    expect(wakeLocalAssistantHost).toHaveBeenCalledTimes(1);
+    // One pre-wake fetch plus one terminal post-wake fetch.
+    expect(fetchGuardianTokenHost).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("primeLocalGatewayConnectionWithStartupRetry", () => {

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -1024,14 +1024,17 @@ function isGatewayStillStarting(error: unknown): boolean {
 /**
  * A `wake`-restarted gateway that hasn't finished coming back up: it refuses
  * connections (a thrown transport error), answers `503`/`5xx`, or rejects the
- * mint with a repairable `401` while it re-provisions its guardian binding. A
- * `403` loopback-boundary refusal is terminal, and a missing/expired guardian
- * token or an unresolved gateway won't heal by waiting (the just-run `wake`
- * already re-seeded the token and recorded the port), so those fall through.
+ * mint with a repairable `401` while it re-provisions its guardian binding.
+ * A guardian refresh `5xx` is the same window: the host shells out to
+ * `vellum gateway token refresh`, which cannot reach a gateway that is still
+ * binding its port. A `403` loopback-boundary refusal is terminal, and a
+ * missing (`404`) or rejected (`401`) guardian token will not heal by
+ * waiting (the just-run `wake` already re-seeded the token and recorded the
+ * port), so those fall through.
  */
 function isGatewayRestartTransient(error: unknown): boolean {
   if (error instanceof GuardianTokenError) {
-    return false;
+    return error.status >= 500;
   }
   if (error instanceof UnresolvedLocalGatewayError) {
     return false;

--- a/clients/web/src/runtime/local-mode-host.test.ts
+++ b/clients/web/src/runtime/local-mode-host.test.ts
@@ -21,6 +21,7 @@ const {
   getLocalAssistantStatusHost,
   fetchGuardianTokenHost,
   isLocalModeHostAvailable,
+  requiresGuardianReprovision,
 } = await import("./local-mode-host");
 
 const realFetch = globalThis.fetch;
@@ -696,6 +697,30 @@ describe("fetchGuardianTokenHost", () => {
     expect(err).toBeInstanceOf(GuardianTokenError);
     expect((err as InstanceType<typeof GuardianTokenError>).status).toBe(500);
     expect((err as Error).message).toBe("refresh failed");
+  });
+});
+
+describe("requiresGuardianReprovision", () => {
+  test("true only for a missing (404) or spent (401) guardian token", () => {
+    expect(requiresGuardianReprovision(new GuardianTokenError(401, "x"))).toBe(
+      true,
+    );
+    expect(requiresGuardianReprovision(new GuardianTokenError(404, "x"))).toBe(
+      true,
+    );
+  });
+
+  test("false for an unreachable gateway or a loopback-boundary refusal", () => {
+    expect(requiresGuardianReprovision(new GuardianTokenError(503, "x"))).toBe(
+      false,
+    );
+    expect(requiresGuardianReprovision(new GuardianTokenError(500, "x"))).toBe(
+      false,
+    );
+    expect(requiresGuardianReprovision(new GuardianTokenError(403, "x"))).toBe(
+      false,
+    );
+    expect(requiresGuardianReprovision(new Error("x"))).toBe(false);
   });
 });
 

--- a/packages/electron-desktop/src/local-mode.test.ts
+++ b/packages/electron-desktop/src/local-mode.test.ts
@@ -1082,6 +1082,44 @@ describe("vellum:localMode:guardianToken handler", () => {
     expect(await pending).toEqual({ ok: true, accessToken: "refreshed-token" });
   });
 
+  test("a labeled CLI refresh 503 is an unreachable gateway, not a spent token", async () => {
+    writeToken("asst-g", { accessTokenExpiresAt: PAST });
+
+    const pending = guardianToken("asst-g");
+    await tick();
+    lastChild.stderr.emit(
+      "data",
+      Buffer.from(
+        `VELLUM_REFRESH_ERROR=${JSON.stringify({ status: 503, error: "Assistant gateway is unreachable" })}\n`,
+      ),
+    );
+    lastChild.emit("close", 1);
+
+    expect(await pending).toEqual({
+      ok: false,
+      status: 503,
+      error: "Assistant gateway is unreachable",
+    });
+  });
+
+  test("an unlabeled CLI refresh failure is a 503, not a 401", async () => {
+    writeToken("asst-g", { accessTokenExpiresAt: PAST });
+
+    const pending = guardianToken("asst-g");
+    await tick();
+    lastChild.stderr.emit(
+      "data",
+      Buffer.from("Failed to refresh guardian token.\n"),
+    );
+    lastChild.emit("close", 1);
+
+    expect(await pending).toEqual({
+      ok: false,
+      status: 503,
+      error: "Failed to refresh guardian token",
+    });
+  });
+
   test("deduplicates concurrent refreshes for the same credential", async () => {
     writeToken("asst-g", { accessTokenExpiresAt: PAST });
 

--- a/packages/local-mode/src/__tests__/guardian-token-refresh.test.ts
+++ b/packages/local-mode/src/__tests__/guardian-token-refresh.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type { CliInvocation } from "../util";
+import type { GuardianTokenData } from "../guardian-token";
+
+class FakeChild extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  kill = mock(() => true);
+}
+
+let lastChild: FakeChild;
+const spawnMock = mock((_command: string, _args: string[]) => {
+  lastChild = new FakeChild();
+  return lastChild;
+});
+
+mock.module("node:child_process", () => ({ spawn: spawnMock }));
+
+let getGuardianAccessToken: typeof import("../guardian-token").getGuardianAccessToken;
+let saveGuardianToken: typeof import("../guardian-token").saveGuardianToken;
+let formatGuardianRefreshCliFailure: typeof import("../guardian-token").formatGuardianRefreshCliFailure;
+
+beforeAll(async () => {
+  ({
+    getGuardianAccessToken,
+    saveGuardianToken,
+    formatGuardianRefreshCliFailure,
+  } = await import("../guardian-token"));
+});
+
+afterEach(() => {
+  spawnMock.mockClear();
+});
+
+const invocation: CliInvocation = { command: "bun", baseArgs: ["run", "cli"] };
+const FUTURE = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+const PAST = new Date(Date.now() - 60_000).toISOString();
+const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+function makeTokenData(over: Partial<GuardianTokenData>): GuardianTokenData {
+  return {
+    guardianPrincipalId: "principal",
+    accessToken: "access",
+    accessTokenExpiresAt: PAST,
+    refreshToken: "refresh",
+    refreshTokenExpiresAt: FUTURE,
+    refreshAfter: FUTURE,
+    isNew: false,
+    deviceId: "device",
+    leasedAt: new Date().toISOString(),
+    ...over,
+  };
+}
+
+describe("getGuardianAccessToken refresh spawn", () => {
+  let configDir: string;
+
+  beforeEach(() => {
+    configDir = fs.mkdtempSync(path.join(os.tmpdir(), "guardian-refresh-"));
+    saveGuardianToken(configDir, "asst-1", makeTokenData({}));
+  });
+
+  afterEach(() => {
+    fs.rmSync(configDir, { recursive: true, force: true });
+  });
+
+  test("a labeled CLI 503 is an unreachable gateway, not a spent token", async () => {
+    const pending = getGuardianAccessToken(
+      "asst-1",
+      configDir,
+      invocation,
+      true,
+    );
+    await tick();
+    lastChild.stderr.emit(
+      "data",
+      Buffer.from(
+        `${formatGuardianRefreshCliFailure(503, "Assistant gateway is unreachable")}\n`,
+      ),
+    );
+    lastChild.emit("close", 1);
+
+    expect(await pending).toEqual({
+      ok: false,
+      status: 503,
+      error: "Assistant gateway is unreachable",
+    });
+  });
+
+  test("a labeled CLI 401 is a spent credential", async () => {
+    const pending = getGuardianAccessToken(
+      "asst-1",
+      configDir,
+      invocation,
+      true,
+    );
+    await tick();
+    lastChild.stderr.emit(
+      "data",
+      Buffer.from(
+        `${formatGuardianRefreshCliFailure(401, "Failed to refresh guardian token")}\n`,
+      ),
+    );
+    lastChild.emit("close", 1);
+
+    expect(await pending).toEqual({
+      ok: false,
+      status: 401,
+      error: "Failed to refresh guardian token",
+    });
+  });
+
+  test("an unlabeled non-zero CLI exit is a 503, not a 401", async () => {
+    const pending = getGuardianAccessToken(
+      "asst-1",
+      configDir,
+      invocation,
+      true,
+    );
+    await tick();
+    lastChild.stderr.emit(
+      "data",
+      Buffer.from("Failed to refresh guardian token.\n"),
+    );
+    lastChild.emit("close", 1);
+
+    expect(await pending).toEqual({
+      ok: false,
+      status: 503,
+      error: "Failed to refresh guardian token",
+    });
+  });
+});

--- a/packages/local-mode/src/__tests__/guardian-token-refresh.test.ts
+++ b/packages/local-mode/src/__tests__/guardian-token-refresh.test.ts
@@ -115,6 +115,29 @@ describe("getGuardianAccessToken refresh spawn", () => {
     });
   });
 
+  test("a labeled CLI 403 is a local confidentiality refusal, not a spent credential", async () => {
+    const pending = getGuardianAccessToken(
+      "asst-1",
+      configDir,
+      invocation,
+      true,
+    );
+    await tick();
+    lastChild.stderr.emit(
+      "data",
+      Buffer.from(
+        `${formatGuardianRefreshCliFailure(403, "Refusing to refresh the guardian token over an insecure URL")}\n`,
+      ),
+    );
+    lastChild.emit("close", 1);
+
+    expect(await pending).toEqual({
+      ok: false,
+      status: 403,
+      error: "Refusing to refresh the guardian token over an insecure URL",
+    });
+  });
+
   test("an unlabeled non-zero CLI exit is a 503, not a 401", async () => {
     const pending = getGuardianAccessToken(
       "asst-1",

--- a/packages/local-mode/src/__tests__/guardian-token.test.ts
+++ b/packages/local-mode/src/__tests__/guardian-token.test.ts
@@ -3,11 +3,6 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-
 import {
   getGuardianAccessToken,
   formatGuardianRefreshCliFailure,
@@ -17,7 +12,6 @@ import {
   saveGuardianToken,
   type GuardianTokenData,
 } from "../guardian-token";
-import type { CliInvocation } from "../util";
 import type { CliInvocation } from "../util";
 
 // An invocation that would fail loudly if any tested branch spawned the CLI.

--- a/packages/local-mode/src/__tests__/guardian-token.test.ts
+++ b/packages/local-mode/src/__tests__/guardian-token.test.ts
@@ -3,13 +3,21 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
 import {
   getGuardianAccessToken,
+  formatGuardianRefreshCliFailure,
+  parseGuardianRefreshCliFailure,
   PAIRED_GUARDIAN_TARGET_MISMATCH_ERROR,
   PAIRED_GUARDIAN_TOKEN_HOST_ONLY_ERROR,
   saveGuardianToken,
   type GuardianTokenData,
 } from "../guardian-token";
+import type { CliInvocation } from "../util";
 import type { CliInvocation } from "../util";
 
 // An invocation that would fail loudly if any tested branch spawned the CLI.
@@ -199,5 +207,43 @@ describe("getGuardianAccessToken", () => {
       ),
     ) as GuardianTokenData;
     expect(stored.pairedGatewayUrl).toBe("https://gateway.example.com");
+  });
+});
+
+describe("parseGuardianRefreshCliFailure", () => {
+  test("reads a labeled 401 from stderr", () => {
+    expect(
+      parseGuardianRefreshCliFailure(
+        "",
+        `Failed to refresh guardian token.\n${formatGuardianRefreshCliFailure(401, "Failed to refresh guardian token")}\n`,
+      ),
+    ).toEqual({
+      ok: false,
+      status: 401,
+      error: "Failed to refresh guardian token",
+    });
+  });
+
+  test("reads a labeled 503 from stderr", () => {
+    expect(
+      parseGuardianRefreshCliFailure(
+        "",
+        formatGuardianRefreshCliFailure(503, "Assistant gateway is unreachable"),
+      ),
+    ).toEqual({
+      ok: false,
+      status: 503,
+      error: "Assistant gateway is unreachable",
+    });
+  });
+
+  test("an unlabeled non-zero CLI exit is a 503, not a 401", () => {
+    expect(
+      parseGuardianRefreshCliFailure("", "Failed to refresh guardian token."),
+    ).toEqual({
+      ok: false,
+      status: 503,
+      error: "Failed to refresh guardian token",
+    });
   });
 });

--- a/packages/local-mode/src/guardian-token.ts
+++ b/packages/local-mode/src/guardian-token.ts
@@ -117,6 +117,71 @@ export type TokenResult =
   | { ok: true; accessToken: string }
   | { ok: false; status: number; error: string };
 
+/**
+ * Prefix of the machine-readable line `vellum gateway token refresh` writes
+ * to stderr on failure so hosts can distinguish a spent credential (401)
+ * from an unreachable gateway (503) without scraping the human message.
+ */
+export const GUARDIAN_REFRESH_ERROR_PREFIX = "VELLUM_REFRESH_ERROR=";
+
+/** Encode a structured refresh failure for the CLI's stderr. */
+export function formatGuardianRefreshCliFailure(
+  status: number,
+  error: string,
+): string {
+  return `${GUARDIAN_REFRESH_ERROR_PREFIX}${JSON.stringify({ status, error })}`;
+}
+
+/**
+ * Read the structured status out of a failed `vellum gateway token refresh`.
+ * An unlabeled non-zero exit defaults to 503: this spawn only runs when the
+ * on-disk refresh token is still unexpired, so a bare CLI failure is an
+ * unreachable or still-starting gateway, not a spent credential.
+ */
+export function parseGuardianRefreshCliFailure(
+  stdout: string,
+  stderr: string,
+): TokenResult {
+  const blob = `${stderr}\n${stdout}`;
+  for (const line of blob.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith(GUARDIAN_REFRESH_ERROR_PREFIX)) {
+      continue;
+    }
+    try {
+      const parsed: unknown = JSON.parse(
+        trimmed.slice(GUARDIAN_REFRESH_ERROR_PREFIX.length),
+      );
+      if (
+        parsed === null ||
+        typeof parsed !== "object" ||
+        !("status" in parsed) ||
+        typeof (parsed as { status: unknown }).status !== "number"
+      ) {
+        continue;
+      }
+      const status = (parsed as { status: number }).status;
+      if (status < 400 || status > 599) {
+        continue;
+      }
+      const errorText =
+        "error" in parsed &&
+        typeof (parsed as { error: unknown }).error === "string" &&
+        (parsed as { error: string }).error.trim() !== ""
+          ? (parsed as { error: string }).error
+          : "Failed to refresh guardian token";
+      return { ok: false, status, error: errorText };
+    } catch {
+      // Keep scanning; a later well-formed line still wins.
+    }
+  }
+  return {
+    ok: false,
+    status: 503,
+    error: "Failed to refresh guardian token",
+  };
+}
+
 export interface GuardianTokenOptions {
   /**
    * True when the entry was imported from another machine via `vellum pair`.
@@ -281,10 +346,13 @@ function refreshToken(
     );
 
     let stdout = "";
+    let stderr = "";
     let done = false;
 
     const finish = (result: TokenResult) => {
-      if (done) return;
+      if (done) {
+        return;
+      }
       done = true;
       clearTimeout(timeout);
       resolve(result);
@@ -303,6 +371,10 @@ function refreshToken(
       stdout += chunk.toString();
     });
 
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
     child.on("close", (code) => {
       if (code === 0) {
         const accessToken = stdout.trim();
@@ -312,11 +384,11 @@ function refreshToken(
           finish({ ok: false, status: 500, error: "CLI returned empty token" });
         }
       } else {
-        finish({
-          ok: false,
-          status: 401,
-          error: "Failed to refresh guardian token",
-        });
+        // This spawn only runs when the on-disk refresh token is still
+        // unexpired. A non-zero CLI exit is therefore a transport or
+        // gateway-availability failure unless the CLI labels a real HTTP
+        // rejection (401/403) via the machine-readable stderr line.
+        finish(parseGuardianRefreshCliFailure(stdout, stderr));
       }
     });
 

--- a/packages/local-mode/src/guardian-token.ts
+++ b/packages/local-mode/src/guardian-token.ts
@@ -386,8 +386,8 @@ function refreshToken(
       } else {
         // This spawn only runs when the on-disk refresh token is still
         // unexpired. A non-zero CLI exit is therefore a transport or
-        // gateway-availability failure unless the CLI labels a real HTTP
-        // rejection (401/403) via the machine-readable stderr line.
+        // gateway-availability failure unless the CLI labels a spent
+        // credential (401) or a local confidentiality refusal (403).
         finish(parseGuardianRefreshCliFailure(stdout, stderr));
       }
     });

--- a/packages/local-mode/src/index.ts
+++ b/packages/local-mode/src/index.ts
@@ -75,8 +75,11 @@ export {
   getGuardianAccessToken,
   getPairedGuardianAccessToken,
   isConfidentialRefreshUrl,
+  formatGuardianRefreshCliFailure,
+  parseGuardianRefreshCliFailure,
   PAIRED_GUARDIAN_TOKEN_HOST_ONLY_ERROR,
   PAIRED_GUARDIAN_TARGET_MISMATCH_ERROR,
+  GUARDIAN_REFRESH_ERROR_PREFIX,
   saveGuardianToken,
 } from "./guardian-token";
 export type {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

Closed PR #40611 treated the customer report as a recovery-dialog UX problem (one-click Repair, move Retire). The actual failure is upstream of that dialog.

After a full quit, the local gateway is down. The host still tries `vellum gateway token refresh` because the access token has expired, and `refreshToken` mapped **any** non-zero CLI exit to `401`. The chooser then classified that as `requiresGuardianReprovision` and offered Wake & Repair (`wake --repair-guardian`), which re-leases the token and signs other devices out. A stopped assistant only needed a plain `wake`.

This PR fixes the misclassification:

- `refreshGuardianTokenResult` reports connection-refused / timeout / 5xx as `503`/`504`, and a real HTTP `401` as `401`.
- The guardian refresh route also returns `403` for revoked, reused, or device-mismatched tokens. Those are spent credentials, so the CLI maps that HTTP `403` to `401`. Local `403` stays a confidentiality refusal (insecure URL) or a host-seam loopback/paired-token refusal.
- `vellum gateway token refresh` writes a machine-readable `VELLUM_REFRESH_ERROR=` line so hosts can tell those apart. An unlabeled non-zero exit also defaults to `503`, because this spawn only runs when the on-disk refresh token is still unexpired.
- Connect-with-repair rides out post-wake guardian `5xx` (the restarted gateway may not answer the first refresh) and still treats a post-wake `401` as terminal, so a genuinely spent credential still reaches the recovery dialog.

The recovery dialog itself is unchanged. Repair stays behind confirmation because it is still destructive.

Supersedes #40611.

## Test plan

Verified:

- `cd cli && bun test src/__tests__/guardian-token.test.ts` (30 pass)
- `cd packages/local-mode && bun test src/__tests__/guardian-token-refresh.test.ts` (4 pass)
- `cd packages/local-mode && bun test src/__tests__/guardian-token.test.ts`
- `cd cli && bun test src/__tests__/assistant-client-refresh.test.ts` (6 pass)
- `cd clients/web && bun test src/lib/local-mode-repair.test.ts` (15 pass)
- `cd clients/web && bun test src/runtime/local-mode-host.test.ts` (51 pass)
- `cd packages/electron-desktop && bun test src/local-mode.test.ts` (55 pass)
- `bunx tsc --noEmit` clean in `packages/local-mode` and `cli`

Not manually exercised on macOS: reproducing it needs a packaged app and a stopped local assistant. The failure mode if the status line is missing is a `503` (plain wake) rather than a false `401` (destructive repair).

## Risk

- Hosts that still treat every guardian `401` as "re-provision" are unchanged for a real spent refresh token.
- A revoked, reused, or device-mismatched refresh token that the gateway rejects with `403` now reaches Wake & Repair, matching a gateway `401`.
- An insecure (non-loopback plaintext) refresh URL still surfaces as `403` and does not open the recovery dialog.
- Older CLI binaries that do not print `VELLUM_REFRESH_ERROR=` are treated as `503` on failure, which is the intended default for this spawn.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c246d4fc-5b79-4a07-9a47-f522eee4f75d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c246d4fc-5b79-4a07-9a47-f522eee4f75d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

