### PR TITLE
fix(web): stand the avatar and settings row down under a chat banner

### DIFF
--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -830,6 +830,11 @@ function disclaimer(container: HTMLElement) {
   return container.querySelector('[data-slot="composer-disclaimer"]');
 }
 
+/** The wrapper around the card, which publishes the banner flag. */
+function composerShell(container: HTMLElement) {
+  return container.querySelector('[data-slot="chat-composer-shell"]');
+}
+
 function addSheet(container: HTMLElement) {
   return container.querySelector('[data-testid="add-to-chat-sheet"]');
 }
@@ -1410,6 +1415,104 @@ describe("ChatComposer: mobile settings pills row", () => {
 
     // THEN there is nothing to float, so no row is rendered
     expect(pillsRow(container)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Banners standing over the card, and what gives way to them
+// ---------------------------------------------------------------------------
+
+describe("ChatComposer: a banner standing over the card", () => {
+  test("an empty banner stack leaves the row up and publishes nothing", () => {
+    // GIVEN a resting phone composer in an app shell, with nothing above it
+    mockIsNativeMobile = true;
+    const { container } = renderPhoneComposer(SETTINGS_SLOTS);
+
+    // THEN the row stands, and the shell carries no flag for the avatar peek
+    // that reads this off it
+    expect(pillsRow(container)?.hasAttribute("hidden")).toBe(false);
+    expect(composerShell(container)?.hasAttribute("data-banner-above")).toBe(
+      false,
+    );
+  });
+
+  test("a banner mounted with the composer takes the row down", () => {
+    // GIVEN the same shell composer, with a banner in the stack above the card
+    mockIsNativeMobile = true;
+    const { container } = renderPhoneComposer({
+      ...SETTINGS_SLOTS,
+      noticesAboveFormSlot: <div>BANNER</div>,
+    });
+
+    // THEN the row stands down: the banner docks to the card's top edge and
+    // takes the strip the row floats in
+    expect(pillsRow(container)?.hasAttribute("hidden")).toBe(true);
+
+    // AND the shell publishes the banner, which is how `ComposerPeek` knows to
+    // hold its avatar down behind that same edge
+    expect(composerShell(container)?.hasAttribute("data-banner-above")).toBe(
+      true,
+    );
+  });
+
+  test("focus does not buy the row back from a banner", () => {
+    // GIVEN a browser phone composer under a banner, where focus is normally
+    // what raises the row
+    const { container } = renderPhoneComposer({
+      ...SETTINGS_SLOTS,
+      noticesAboveFormSlot: <div>BANNER</div>,
+    });
+
+    // WHEN the user taps into it
+    fireEvent.focusIn(textareaOf(container));
+
+    // THEN the banner still wins
+    expect(pillsRow(container)?.hasAttribute("hidden")).toBe(true);
+  });
+
+  test("a banner arriving after mount takes the row down with it", async () => {
+    // GIVEN a standing row in an app shell
+    mockIsNativeMobile = true;
+    const { container, rerender } = renderPhoneComposer(SETTINGS_SLOTS);
+    expect(pillsRow(container)?.hasAttribute("hidden")).toBe(false);
+
+    // WHEN a banner arrives mid-session, the way a low credit balance does
+    await act(async () => {
+      rerender(
+        composerElement({
+          ...SETTINGS_SLOTS,
+          noticesAboveFormSlot: <div>BANNER</div>,
+        }),
+      );
+    });
+
+    // THEN the row follows it down. The stack is watched rather than derived
+    // from props, so notices that source their own state take it down too
+    expect(pillsRow(container)?.hasAttribute("hidden")).toBe(true);
+    expect(composerShell(container)?.hasAttribute("data-banner-above")).toBe(
+      true,
+    );
+  });
+
+  test("a banner leaving gives the row back", async () => {
+    // GIVEN a shell composer whose row is down under a banner
+    mockIsNativeMobile = true;
+    const { container, rerender } = renderPhoneComposer({
+      ...SETTINGS_SLOTS,
+      noticesAboveFormSlot: <div>BANNER</div>,
+    });
+    expect(pillsRow(container)?.hasAttribute("hidden")).toBe(true);
+
+    // WHEN the banner is dismissed
+    await act(async () => {
+      rerender(composerElement(SETTINGS_SLOTS));
+    });
+
+    // THEN the strip is free again and the row comes back up with it
+    expect(pillsRow(container)?.hasAttribute("hidden")).toBe(false);
+    expect(composerShell(container)?.hasAttribute("data-banner-above")).toBe(
+      false,
+    );
   });
 });
 

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -813,6 +813,39 @@ export function ChatComposer({
   // sheet rises and the card would shift down under the scrim.
   const composerInUse =
     composerFocusWithin || settingsSheetOpen || addSheetOpen;
+  // Whether a banner is standing over the card. Read off the box rather than
+  // derived from props: most of that stack arrives through
+  // `noticesAboveFormSlot`, an opaque node, and the composer-owned notices in
+  // it source their own state, so what the box holds is the one answer that
+  // covers all of them at once.
+  const bannerStackRef = useRef<HTMLDivElement>(null);
+  const [hasBannerAboveCard, setHasBannerAboveCard] = useState(false);
+  const readBannerStack = useCallback(() => {
+    const node = bannerStackRef.current;
+    if (node) {
+      setHasBannerAboveCard(node.childElementCount > 0);
+    }
+  }, []);
+  // On every commit, so a banner that arrives with a render of this composer
+  // (the slot above, or a notice keyed on state it already subscribes to)
+  // settles in that same commit rather than a frame later.
+  useLayoutEffect(readBannerStack);
+  // The backstop for the rest: `ComposerDraftNotices` sources its own state,
+  // and its restored-draft notice comes and goes without this composer
+  // rendering at all. `childList` alone, since every notice in there is an
+  // element of its own.
+  useLayoutEffect(() => {
+    const node = bannerStackRef.current;
+    if (!node) {
+      return;
+    }
+    const observer = new MutationObserver(readBannerStack);
+    observer.observe(node, { childList: true });
+    return () => {
+      observer.disconnect();
+    };
+  }, [readBannerStack]);
+
   // The app shells hold the row up for the whole session. On a phone these
   // pills are the only place the access and profile pickers live, and a row
   // that comes and goes with the keyboard puts both a tap out of reach for as
@@ -820,8 +853,13 @@ export function ChatComposer({
   // reveal, where the row is competing with the page's own chrome for the
   // bottom of the screen.
   const isNativeMobileShell = useIsNativeMobile();
+  // A banner docks to the card's top edge and takes the strip this row floats
+  // in, so the row stands down while one is up rather than crowding it. The
+  // avatar peeking over that same edge stands down with it (`ComposerPeek`).
   const settingsPillsVisible =
-    isMobileMainComposer && (isNativeMobileShell || composerInUse);
+    isMobileMainComposer &&
+    !hasBannerAboveCard &&
+    (isNativeMobileShell || composerInUse);
   // The caption is the row's opposite number: it stands under the card at rest
   // and steps aside the moment anything takes the bottom of the screen, which
   // is where the keyboard and every sheet cover it anyway. In the shells,
@@ -1316,49 +1354,55 @@ export function ChatComposer({
           nonDismissible={isNativeIOS()}
         />
       )}
-      {/* Composer-owned draft/attachment notices (self-sourced), above the
-          orchestration banner stack. */}
-      <ComposerDraftNotices />
-      {/* Live-voice failure notice — surfaced by the voice-enabled composer
-          the user is looking at, mirroring the dictation `voiceError` Notice
-          rendered by `ComposerNotices` in the orchestration stack below.
-          Keyed on the session state (not entry eligibility) for the same
-          reason as `isLiveVoiceActive`: a session that fails right after an
-          eligibility drop must still surface its error. */}
-      {showVoiceInput && liveVoiceState === "failed" && liveVoiceError && (
-        <div className="mb-2">
-          <Notice tone="error" onDismiss={dismissLiveVoiceFailure}>
-            {liveVoiceError}
-          </Notice>
-        </div>
-      )}
-      {/* Pre-open "configure voice" prompt — surfaced when the readiness
-          preflight returns `not-ready` (no usable STT/TTS provider that
-          couldn't be auto-configured). The room stays closed; the action
-          deep-links to voice settings so the user can wire a provider. */}
-      {showVoiceInput && voiceConfigNotice && (
-        <div className="mb-2">
-          <Notice
-            tone="warning"
-            onDismiss={() => setVoiceConfigNotice(null)}
-            actions={
-              <Button
-                variant="outlined"
-                size="compact"
-                onClick={() => {
-                  setVoiceConfigNotice(null);
-                  navigate(routes.settings.voice);
-                }}
-              >
-                Configure voice
-              </Button>
-            }
-          >
-            {voiceConfigNotice}
-          </Notice>
-        </div>
-      )}
-      {noticesAboveFormSlot}
+      {/* Every banner that stands over the card, in one watched box. While
+          anything is in it the strip between the banner and the card is
+          spoken for, and the two things that float in that strip (the mobile
+          settings row below, and `ComposerPeek`'s avatar) stand down. */}
+      <div ref={bannerStackRef} data-slot="composer-banner-stack">
+        {/* Composer-owned draft/attachment notices (self-sourced), above the
+            orchestration banner stack. */}
+        <ComposerDraftNotices />
+        {/* Live-voice failure notice, surfaced by the voice-enabled composer
+            the user is looking at, mirroring the dictation `voiceError` Notice
+            rendered by `ComposerNotices` in the orchestration stack below.
+            Keyed on the session state (not entry eligibility) for the same
+            reason as `isLiveVoiceActive`: a session that fails right after an
+            eligibility drop must still surface its error. */}
+        {showVoiceInput && liveVoiceState === "failed" && liveVoiceError && (
+          <div className="mb-2">
+            <Notice tone="error" onDismiss={dismissLiveVoiceFailure}>
+              {liveVoiceError}
+            </Notice>
+          </div>
+        )}
+        {/* Pre-open "configure voice" prompt, surfaced when the readiness
+            preflight returns `not-ready` (no usable STT/TTS provider that
+            couldn't be auto-configured). The room stays closed; the action
+            deep-links to voice settings so the user can wire a provider. */}
+        {showVoiceInput && voiceConfigNotice && (
+          <div className="mb-2">
+            <Notice
+              tone="warning"
+              onDismiss={() => setVoiceConfigNotice(null)}
+              actions={
+                <Button
+                  variant="outlined"
+                  size="compact"
+                  onClick={() => {
+                    setVoiceConfigNotice(null);
+                    navigate(routes.settings.voice);
+                  }}
+                >
+                  Configure voice
+                </Button>
+              }
+            >
+              {voiceConfigNotice}
+            </Notice>
+          </div>
+        )}
+        {noticesAboveFormSlot}
+      </div>
       {isLiveVoiceActive && (
         // The minimized session surface, directly above the composer card
         // rather than in place of it: the session gets a bar, the user keeps a
@@ -1382,7 +1426,14 @@ export function ChatComposer({
           />
         </div>
       )}
-      <div ref={composerShellRef} data-slot="chat-composer-shell">
+      {/* `data-banner-above` is published for `ComposerPeek`, which reads the
+          flag off this shell rather than watching the same stack a second
+          time on its own clock. */}
+      <div
+        ref={composerShellRef}
+        data-slot="chat-composer-shell"
+        data-banner-above={hasBannerAboveCard ? "" : undefined}
+      >
         {/* Above every slot placement, the pills row included: what a control
             does when the card runs narrow is the control's own business, and
             must not depend on which row it happens to be sitting in. */}

--- a/clients/web/src/domains/chat/components/composer-peek.tsx
+++ b/clients/web/src/domains/chat/components/composer-peek.tsx
@@ -21,6 +21,12 @@
  *   and the card. In the browser the top dude retreats up off screen as
  *   it rises.
  *
+ * On phone-sized windows the focus peek gives way to any banner docked
+ * over the input's top edge (billing, setup, a draft notice): the banner
+ * owns that strip, and an avatar rising into it would surface behind the
+ * banner with its eyes cut off. The composer's mobile settings row stands
+ * down on the same signal, which it publishes on the shell.
+ *
  * The composer card is located by its `data-slot="chat-composer"` anchor
  * and its rect tracked per-frame, so the overlays stay glued through
  * reflows and composer remounts. Focus, though, is judged against the
@@ -36,6 +42,7 @@ import { createPortal } from "react-dom";
 import { motion, useReducedMotion } from "motion/react";
 
 import { AnimatedAvatar } from "@/components/avatar/animated-avatar";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import { recordUpdate } from "@/lib/commit-pressure";
 import { useIsNativeMobile } from "@/runtime/platform-detection";
 import { useInChatOnboardingStore } from "@/stores/in-chat-onboarding-store";
@@ -55,6 +62,8 @@ interface TargetRect {
    *  clears the settings pills floating there. Zero whenever no row is up, or
    *  whenever the row hangs clear of the avatar's own column. */
   pillsClearance: number;
+  /** True while a banner is docked over the card's top edge. */
+  bannerAbove: boolean;
 }
 
 /** The composer card itself, which the overlays are measured against. */
@@ -66,6 +75,11 @@ const COMPOSER_SHELL_SELECTOR = '[data-slot="chat-composer-shell"]';
  *  the `hidden` attribute is what separates the two. */
 const COMPOSER_PILLS_SELECTOR =
   '[data-slot="composer-settings-pills"]:not([hidden])';
+/** Marks a shell whose card currently has a banner standing over it.
+ *  `ChatComposer` watches that stack for its own settings row and publishes
+ *  the answer here, so this overlay reads one flag instead of keeping a
+ *  second read of the same boxes on a different clock. */
+const BANNER_ABOVE_ATTRIBUTE = "data-banner-above";
 
 /**
  * Whether a focus target belongs to the composer. The shell is the
@@ -173,6 +187,10 @@ export function ComposerPeek({
   // Native shells can place the system status area over the top perch.
   // Browsers keep it; native mobile gets the bottom-edge hello instead.
   const nativeMobile = useIsNativeMobile();
+  // The window-size axis, for the banner rule below: it is a question of the
+  // room left over the card, and the settings row that competes for the same
+  // strip is gated the same way. See `docs/PLATFORM_ADAPTATION.md`.
+  const isMobile = useIsMobile();
   const [rect, setRect] = useState<TargetRect | null>(null);
   const [mode, setMode] = useState<Mode>("rest");
   const [introRisen, setIntroRisen] = useState(false);
@@ -250,9 +268,8 @@ export function ComposerPeek({
       // The row hangs its pills off the card's right edge while this avatar
       // rises on the left, so a short row leaves the rim clear and the peek
       // stays on it, rather than floating a body height above nothing.
-      const pills = element
-        .closest(COMPOSER_SHELL_SELECTOR)
-        ?.querySelector<HTMLElement>(COMPOSER_PILLS_SELECTOR);
+      const shell = element.closest<HTMLElement>(COMPOSER_SHELL_SELECTOR);
+      const pills = shell?.querySelector<HTMLElement>(COMPOSER_PILLS_SELECTOR);
       // Height comes from layout, not from a rect: the row rises into place on
       // a transform, and a rect's top would move with it and put a `setRect` in
       // every frame of that animation. The same animation is translateY-only,
@@ -282,6 +299,7 @@ export function ComposerPeek({
         height: r.height,
         radius,
         pillsClearance,
+        bannerAbove: shell?.hasAttribute(BANNER_ABOVE_ATTRIBUTE) ?? false,
       };
     };
     const enter = () => {
@@ -337,7 +355,8 @@ export function ComposerPeek({
           next.width !== last.width ||
           next.height !== last.height ||
           next.radius !== last.radius ||
-          next.pillsClearance !== last.pillsClearance)
+          next.pillsClearance !== last.pillsClearance ||
+          next.bannerAbove !== last.bannerAbove)
       ) {
         last = next;
         recordUpdate("composer-peek");
@@ -398,6 +417,12 @@ export function ComposerPeek({
   }
 
   const focused = mode === "focus";
+  // A banner docks to the card's top edge and takes the strip this peek rises
+  // into, so the avatar would surface behind it with its eyes cut off. Held
+  // down rather than unmounted, so a banner that arrives mid-focus sends it
+  // back the way a blur does. Phone-sized windows only, which is the shape
+  // this was reported on and the one the settings row is already gated to.
+  const peekRisen = focused && !(isMobile && rect.bannerAbove);
   // The hello owns the avatar until it has ducked away, so the focus peek
   // stays out of the way rather than putting a second one on screen.
   const introActive = nativeMobile && !introDone;
@@ -554,9 +579,9 @@ export function ComposerPeek({
               top: clipHeight - peekExposedPx,
             }}
             initial={{ y: risePx }}
-            animate={focused ? { y: 0 } : { y: risePx }}
+            animate={peekRisen ? { y: 0 } : { y: risePx }}
             transition={
-              focused
+              peekRisen
                 ? {
                     type: "spring",
                     stiffness: 280,
@@ -589,7 +614,7 @@ export function ComposerPeek({
           boxShadow: PEEK_SHADOW,
         }}
         initial={{ opacity: 0 }}
-        animate={{ opacity: (introActive ? introRisen : focused) ? 1 : 0 }}
+        animate={{ opacity: (introActive ? introRisen : peekRisen) ? 1 : 0 }}
         transition={{ duration: 0.2 }}
       />
     </div>,


### PR DESCRIPTION
## Problem

On a phone, a banner docked to the composer's top edge shares that strip with two things that float there: the mobile access/profile pills, and the avatar peeking over the card's rim. All three land on top of each other. The avatar comes up *behind* the banner with its eyes cut off, and the pills sit flush against the banner's bottom edge.

Reported on iOS with the low-balance banner, but the same strip is shared by every banner above the card: daily limit, provider billing, missing API key, maintenance, compaction circuit, disk pressure, the live-voice/dictation errors, and the composer's own draft/attachment notices.

## Change

**`ChatComposer`** keeps its whole banner stack in one box (`data-slot="composer-banner-stack"`) and watches what is in it:

- a read on every commit, so a banner that arrives with a render of the composer settles in that same commit;
- a `childList` `MutationObserver` as the backstop, for the composer-owned notices that source their own state (the restored-draft notice comes and goes without the composer rendering at all).

Read off the box rather than derived from props because most of the stack arrives through `noticesAboveFormSlot`, an opaque `ReactNode`, so no single prop can answer for all of it.

While the box holds anything, the settings row stays down and the shell publishes `data-banner-above`.

**`ComposerPeek`** reads that flag off the shell inside the per-frame rect it already takes, and holds the focus peek down rather than unmounting it, so a banner arriving mid-focus sends the avatar back the way a blur does. The shadow the card casts over the avatar follows it down.

## Scope

Phone-sized windows only (`useIsMobile()`), as requested. That is the shape this was reported on, and the one the settings row is already gated to. The same collision exists on desktop and is left alone here.

The live-voice bar also stands in that strip during a session. It is not a banner and is not part of the box, so its behaviour is unchanged.

## Verification

- `bun test src/domains/chat/components/chat-composer/chat-composer.test.tsx` — 152 pass, including 5 new cases: no banner leaves the row up and publishes nothing; a banner mounted with the composer takes the row down; focus does not buy the row back; a banner arriving after mount takes the row down with it; a banner leaving gives it back.
- `bun test` on `chat-route-content`, `chat-body`, `composer-draft-notices`, `low-balance-banner`, `daily-limit-banner` — all pass.
- `bunx tsc --noEmit` clean; `bunx eslint` clean on the changed files (one pre-existing warning at `chat-composer.tsx:670`).

**Outstanding:** not yet checked on a device. The screenshot case (iOS, low-balance banner, keyboard up) is worth a look before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)