### PR TITLE
feat(assistant): filter GET /v1/conversations to foreground rows (LUM-3323)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6608,6 +6608,20 @@ paths:
             predicate behind the unread count and the section index, so a client that keeps no complete conversation
             list can ask for exactly the rows its attention surfaces need. Composes with every other filter. Any value
             other than "true" is rejected. Omit to span every conversation.'
+        - name: foregroundOnly
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - "true"
+          description:
+            Pass "true" to return only user-facing foreground conversations, dropping the automated background and
+            scheduled runs the standard listing admits when they are filed in a custom group (a surfaced run stays).
+            This is the same predicate the unread count and the section index apply, so a client can ask for the newest
+            conversation a user can open in one row instead of paging past runs it would skip. Composes with every other
+            filter; a foreground-only first page never has pinned rows appended to it. Any value other than "true" is
+            rejected. Omit to keep every visible row.
       responses:
         "200":
           description: Successful response

--- a/assistant/src/persistence/conversation-queries.ts
+++ b/assistant/src/persistence/conversation-queries.ts
@@ -199,7 +199,8 @@ function surfacedVisibilitySql(alias = "conversations"): string {
  * explicitly surfaced. {@link standardListingVisibilitySql} already admits
  * such rows through its surfaced and custom-group arms, so a caller that
  * must distinguish "visible in the listing" from "user-facing foreground"
- * (unread counting) applies this on top.
+ * (unread counting, the section index, a `foregroundOnly` list read) applies
+ * this on top.
  *
  * The SQL twin of `isBackgroundConversation` in the web client's
  * `utils/conversation-predicates.ts`.
@@ -282,6 +283,16 @@ export interface ConversationListFilter {
    * the rows its attention surfaces need instead of scanning for them.
    */
   needsAttention?: true;
+  /**
+   * Restrict to user-facing foreground conversations: drop the automated
+   * background/scheduled rows the standard listing admits through its
+   * custom-group arm ({@link notBackgroundVisibilitySql}, the same predicate
+   * the unread count and the section index apply on top of visibility).
+   * Only `true` narrows; omit to keep every visible row. A client that
+   * needs the newest conversation a user can open can ask for it in one
+   * row instead of paging past runs it would skip.
+   */
+  foregroundOnly?: true;
 }
 
 export interface ConversationListQuery extends ConversationListFilter {
@@ -364,6 +375,7 @@ function conversationListWhere(filter: ConversationListFilter) {
     originChannel,
     groupId,
     needsAttention,
+    foregroundOnly,
   } = filter;
   return and(
     conversationTypeClause(conversationType),
@@ -371,6 +383,7 @@ function conversationListWhere(filter: ConversationListFilter) {
     originChannel ? originChannelClause(originChannel) : undefined,
     groupId ? groupIdClause(groupId) : undefined,
     ...(needsAttention ? unseenAttentionStateConditions() : []),
+    foregroundOnly ? sql.raw(notBackgroundVisibilitySql()) : undefined,
   );
 }
 

--- a/assistant/src/runtime/routes/__tests__/conversation-list-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-list-routes.test.ts
@@ -683,6 +683,139 @@ describe("GET /v1/conversations with needsAttention", () => {
   });
 });
 
+describe("GET /v1/conversations with foregroundOnly", () => {
+  function fileIntoGroup(conversationId: string, groupId: string): void {
+    rawRun(
+      "test:fileIntoGroup",
+      "UPDATE conversations SET group_id = ? WHERE id = ?",
+      groupId,
+      conversationId,
+    );
+  }
+
+  function surface(conversationId: string): void {
+    rawRun(
+      "test:surfaceConversation",
+      "UPDATE conversations SET surfaced_at = ? WHERE id = ?",
+      Date.now(),
+      conversationId,
+    );
+  }
+
+  beforeEach(() => {
+    clearConversations();
+  });
+
+  test("drops the automated runs the standard listing admits through a custom group", async () => {
+    /* The standard listing shows a background run filed in a custom group,
+       so a caller reading page one to find "the newest chat" can lead with
+       one; the filter is what lets that caller ask for chats alone. A
+       surfaced run is a chat for this purpose, exactly as the unread count
+       treats it. */
+    const group = createGroup("Work");
+    createConversation("plain-chat");
+    const bgInGroup = createConversation({
+      title: "bg-in-group",
+      conversationType: "background",
+    });
+    fileIntoGroup(bgInGroup.id, group.id);
+    const surfacedBg = createConversation({
+      title: "surfaced-bg",
+      conversationType: "background",
+    });
+    surface(surfacedBg.id);
+
+    const unfiltered = await invoke();
+    expect(unfiltered.conversations.map((c) => c.title).sort()).toEqual([
+      "bg-in-group",
+      "plain-chat",
+      "surfaced-bg",
+    ]);
+
+    const result = await invoke({ foregroundOnly: "true" });
+    expect(result.conversations.map((c) => c.title).sort()).toEqual([
+      "plain-chat",
+      "surfaced-bg",
+    ]);
+  });
+
+  test("hasMore and the total describe the filtered set, not the whole table", async () => {
+    /* The reason for the filter is a limit=1 read whose first row is the
+       answer; that read is only right if the page and its total come from
+       the same predicate. */
+    const group = createGroup("Work");
+    for (let i = 0; i < 3; i++) {
+      const bg = createConversation({
+        title: `bg-${i}`,
+        conversationType: "background",
+      });
+      fileIntoGroup(bg.id, group.id);
+    }
+    createConversation("the-only-chat");
+
+    const page = await invoke({ foregroundOnly: "true", limit: "1" });
+
+    expect(page.conversations.map((c) => c.title)).toEqual(["the-only-chat"]);
+    expect(page.hasMore).toBe(false);
+  });
+
+  test("a foreground-only first page has no pinned rows appended to it", async () => {
+    /* Same rule as the attention- and group-scoped pages: the injection is
+       for a client reading Pinned out of the unfiltered list, and a caller
+       that asked for the newest chat in one row is not that client. The
+       older pinned chat is a member of the filter, so only the injection
+       could put it on a limit=1 page. */
+    const older = createConversation("older-pinned-chat");
+    rawRun(
+      "test:pinConversation",
+      "UPDATE conversations SET is_pinned = 1, group_id = 'system:pinned', last_message_at = ? WHERE id = ?",
+      Date.now() - 60_000,
+      older.id,
+    );
+    const newer = createConversation("newest-chat");
+    rawRun(
+      "test:bumpRecency",
+      "UPDATE conversations SET last_message_at = ? WHERE id = ?",
+      Date.now(),
+      newer.id,
+    );
+
+    const unfiltered = await invoke({ limit: "1" });
+    expect(unfiltered.conversations.map((c) => c.title)).toEqual([
+      "newest-chat",
+      "older-pinned-chat",
+    ]);
+
+    const result = await invoke({ foregroundOnly: "true", limit: "1" });
+    expect(result.conversations.map((c) => c.title)).toEqual(["newest-chat"]);
+  });
+
+  test("composes with the other filters", async () => {
+    const group = createGroup("Work");
+    const chatInGroup = createConversation("chat-in-group");
+    fileIntoGroup(chatInGroup.id, group.id);
+    const bgInGroup = createConversation({
+      title: "bg-in-group",
+      conversationType: "background",
+    });
+    fileIntoGroup(bgInGroup.id, group.id);
+    createConversation("chat-outside");
+
+    const result = await invoke({
+      foregroundOnly: "true",
+      groupId: group.id,
+    });
+
+    expect(result.conversations.map((c) => c.title)).toEqual(["chat-in-group"]);
+  });
+
+  test('any value other than "true" is rejected with a 400', () => {
+    for (const bad of ["false", "1", "yes", "TRUE"]) {
+      expect(() => invoke({ foregroundOnly: bad })).toThrow(BadRequestError);
+    }
+  });
+});
+
 describe("GET /v1/conversations/unread-count", () => {
   const unreadCountHandler = findHandler(
     CONVERSATION_LIST_ROUTES,

--- a/assistant/src/runtime/routes/conversation-list-routes.ts
+++ b/assistant/src/runtime/routes/conversation-list-routes.ts
@@ -269,12 +269,18 @@ function handleListConversations({ queryParams = {} }: RouteHandlerArgs) {
       ? true
       : undefined;
 
+  const foregroundOnly =
+    parseEnumQueryParam(queryParams, "foregroundOnly", ["true"]) === "true"
+      ? true
+      : undefined;
+
   const filter: ConversationListFilter = {
     conversationType,
     archiveStatus,
     originChannel,
     groupId,
     needsAttention,
+    foregroundOnly,
   };
   let rows = listConversations({ ...filter, limit, offset });
   const totalCount = countConversations(filter);
@@ -289,19 +295,20 @@ function handleListConversations({ queryParams = {} }: RouteHandlerArgs) {
   // Skipped for group-scoped queries for the same reason: a caller asking
   // for one group gets that group, and a client that fetches the Pinned
   // section via `groupId=system:pinned` has no use for rows appended to
-  // some other group's page. Skipped for attention-scoped queries too: the
-  // caller asked for the unseen subset, and a seen pinned row appended to
-  // it would put a row outside the filter in the page while `hasMore` is
-  // computed from the filtered count. This is the compatibility shim for
-  // clients that still read Pinned out of the unfiltered list; it goes
-  // away once every section fetches its own group.
+  // some other group's page. Skipped for attention-scoped and
+  // foreground-only queries too: the caller asked for a subset, and a
+  // pinned row outside it appended to the page would sit there while
+  // `hasMore` is computed from the filtered count. This is the
+  // compatibility shim for clients that still read Pinned out of the
+  // unfiltered list; it goes away once every section fetches its own group.
   if (
     offset === 0 &&
     conversationType === "standard" &&
     archiveStatus === "active" &&
     originChannel === undefined &&
     groupId === undefined &&
-    needsAttention === undefined
+    needsAttention === undefined &&
+    foregroundOnly === undefined
   ) {
     const pinned = listPinnedConversations(archiveStatus);
     const seen = new Set(rows.map((c) => c.id));
@@ -609,6 +616,14 @@ export const ROUTES: RouteDefinition[] = [
         required: false,
         description:
           'Pass "true" to return only conversations whose latest assistant message the user has not seen: the same predicate behind the unread count and the section index, so a client that keeps no complete conversation list can ask for exactly the rows its attention surfaces need. Composes with every other filter. Any value other than "true" is rejected. Omit to span every conversation.',
+        schema: { type: "string", enum: ["true"] },
+      },
+      {
+        name: "foregroundOnly",
+        type: "string",
+        required: false,
+        description:
+          'Pass "true" to return only user-facing foreground conversations, dropping the automated background and scheduled runs the standard listing admits when they are filed in a custom group (a surfaced run stays). This is the same predicate the unread count and the section index apply, so a client can ask for the newest conversation a user can open in one row instead of paging past runs it would skip. Composes with every other filter; a foreground-only first page never has pinned rows appended to it. Any value other than "true" is rejected. Omit to keep every visible row.',
         schema: { type: "string", enum: ["true"] },
       },
     ],


### PR DESCRIPTION
Part of LUM-3323 (parent LUM-2443).

## TL;DR

`GET /v1/conversations` gains `foregroundOnly=true`: return only user-facing foreground conversations, dropping the automated background/scheduled runs the standard listing admits when they are filed in a custom group. It is the existing `notBackgroundVisibilitySql` predicate (the one the unread count and the section index already apply) exposed as a list filter, following the `needsAttention` pattern exactly.

## Why

The web client's cold-boot landing needs "the newest conversation the user can open". Today it fetches unfiltered pages, applies its own copy of the selectability rule, and reconstructs the daemon's ordering around the page-one pinned injection, walking up to four pages. With this filter it can ask for one row (`limit=1&foregroundOnly=true`) and take it; the client change is the follow-up PR under LUM-3323, gated by assistant version like the `groupId` filter was.

## What changed

- `ConversationListFilter.foregroundOnly?: true`; `conversationListWhere` adds `notBackgroundVisibilitySql()` when set, so the page and its count come from one predicate and `hasMore` describes the filtered set.
- Route parses it with `parseEnumQueryParam` (only `"true"`; anything else is a 400, same posture as `needsAttention`).
- The page-one pinned injection is skipped for a foreground-only request, as for every other scoped filter: the caller asked for the top of a subset, not the sidebar's Pinned reader.
- OpenAPI param declared; `assistant/openapi.yaml` regenerated (`bun run generate:openapi`).
- Route tests: filter semantics (bg-in-group dropped, surfaced kept), `hasMore` on the filtered set with `limit=1`, no pins appended, composes with `groupId`, rejects non-`"true"`.

## Before / after

| | Before | After |
| --- | --- | --- |
| `GET /v1/conversations` with no new param | unchanged | unchanged |
| `GET /v1/conversations?foregroundOnly=true` | param ignored, full standard listing | only rows the unread count calls foreground; no pinned rows appended on page one |
| `GET /v1/conversations?foregroundOnly=false` | ignored | 400 |
| Any user-visible behavior | none | none; no client sends the param yet |

## Why it is safe

Additive and opt-in: the parameter is optional, nothing sends it yet, and the unfiltered path is byte-for-byte what it was (the injection condition gains one `=== undefined` clause that holds for every existing caller). The predicate is not new: it is the same SQL the unread count and section index have used since they shipped, so "foreground" means one thing across the three readers.

Follow-up (same ticket): the web client gate + one-row landing read, floored on this PR's merged dev version per `clients/web/docs/BACKWARDS_COMPAT.md`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40852" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->