### PR TITLE
feat(web): cold-boot landing asks the daemon for its one selectable row (LUM-3323)

### DIFF
--- a/clients/web/docs/BACKWARDS_COMPAT.md
+++ b/clients/web/docs/BACKWARDS_COMPAT.md
@@ -254,6 +254,18 @@ with the code they protect:
   pre-0.8.8 positional arrays (`textSegments`, `thinkingSegments`,
   `toolCalls`, `surfaces`, `attachments`, `contentOrder`) when an assistant
   omits `contentBlocks`, so the renderer only ever deals with one shape.
+- **Cold-boot landing's one-row read**:
+  `src/domains/chat/utils/landing-conversation.ts` asks
+  `GET /v1/conversations?foregroundOnly=true&limit=1` for the newest
+  conversation the user can open. An assistant that predates the parameter
+  ignores it and answers 200 with the newest row of the unfiltered listing,
+  the "silent superset" that normally forces a version gate. Here the client
+  can tell: it asked for a foreground row, so a returned row that fails
+  `isStoredConversationSelectable` proves the filter was not applied, and the
+  landing falls back to paging the unfiltered list itself. A gate would also
+  be read before the identity fetch hydrates the version on most cold boots
+  and send them all down the paged path. The paged fallback is the legacy
+  branch: delete it once no supported assistant predates the parameter.
 - **Electron / Capacitor bridge** — `src/runtime/is-electron.ts` declares
   `window.vellum` with **optional capability groups** (`helper?`,
   `featureFlags?`, `diagnostics?`, …). Consumers guard on presence

--- a/clients/web/src/domains/chat/hooks/use-conversation-loader-cold-boot.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-loader-cold-boot.test.tsx
@@ -5,6 +5,11 @@
  * from two single-row reads while the drained conversation list is still
  * pending. The list query is stubbed permanently pending here so a landing
  * that waited on it would never happen and every test would time out.
+ *
+ * The newest-row read asks the daemon to filter to foreground rows itself.
+ * The tests under "an assistant that predates foregroundOnly" flip the stub
+ * to ignore the parameter, which is what an older assistant does, and cover
+ * the paged search the loader falls back to when the answer proves that.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -98,12 +103,28 @@ const { useConversationLoader } =
 
 /** Requests the loader made, by URL, so a test can assert what it asked. */
 let requests: string[] = [];
+/** The query of every list request, in order, so a test can assert the ask. */
+let listQueries: Record<string, unknown>[] = [];
 let byIdRow: RawConversationFixture | null = null;
 let listRows: RawConversationFixture[] = [];
 /** Rows the daemon appends to an unfiltered page one beyond the limit. */
 let pinnedExtras: RawConversationFixture[] = [];
 /** How many upcoming requests answer 503 before the stub recovers. */
 let failNextRequests = 0;
+/**
+ * Whether the stub honors `foregroundOnly`. `false` plays an assistant that
+ * predates the parameter: it ignores it and answers with the unfiltered
+ * listing, appended pins and all.
+ */
+let daemonFiltersForeground = true;
+
+/** The stub's foreground rule: the run types the daemon's filter drops. */
+function isForegroundFixture(row: RawConversationFixture): boolean {
+  return (
+    row.conversationType !== "background" &&
+    row.conversationType !== "scheduled"
+  );
+}
 
 function stubDaemon() {
   daemonClient.get = mock(
@@ -138,14 +159,20 @@ function stubDaemon() {
         };
       }
       if (url.endsWith("/conversations")) {
+        listQueries.push(options.query ?? {});
         const limit = Number(options.query?.limit ?? 50);
         const offset = Number(options.query?.offset ?? 0);
+        const filtered =
+          daemonFiltersForeground && options.query?.foregroundOnly === "true";
+        const source = filtered
+          ? listRows.filter(isForegroundFixture)
+          : listRows;
         const body = {
           conversations: [
-            ...listRows.slice(offset, offset + limit),
-            ...(offset === 0 ? pinnedExtras : []),
+            ...source.slice(offset, offset + limit),
+            ...(offset === 0 && !filtered ? pinnedExtras : []),
           ].map(rawConversation),
-          hasMore: listRows.length > offset + limit,
+          hasMore: source.length > offset + limit,
         };
         return {
           data: body,
@@ -195,10 +222,12 @@ async function landedOn(): Promise<string> {
 
 beforeEach(() => {
   requests = [];
+  listQueries = [];
   byIdRow = null;
   listRows = [];
   pinnedExtras = [];
   failNextRequests = 0;
+  daemonFiltersForeground = true;
   podIsServing = true;
   orgIsReady = true;
   navigateMock.mockClear();
@@ -241,6 +270,11 @@ describe("useConversationLoader cold-boot landing", () => {
       "/v1/assistants/{assistant_id}/conversations/{id}",
       "/v1/assistants/{assistant_id}/conversations",
     ]);
+    /* One row, filtered by the daemon: the client neither pages nor
+       re-derives which rows are foreground. */
+    expect(listQueries).toEqual([
+      { foregroundOnly: "true", limit: 1, offset: 0 },
+    ]);
   });
 
   test("does not implicitly resume a stored background run", async () => {
@@ -253,7 +287,7 @@ describe("useConversationLoader cold-boot landing", () => {
     expect(await landedOn()).toContain("newest");
   });
 
-  test("with nothing stored, reads page one of the foreground list and caches nothing under the list prefix", async () => {
+  test("with nothing stored, reads the newest foreground row and caches nothing under the list prefix", async () => {
     listRows = [{ id: "newest" }, { id: "older" }, { id: "oldest" }];
     const queryClient = new QueryClient();
 
@@ -270,43 +304,10 @@ describe("useConversationLoader cold-boot landing", () => {
     ).toEqual([]);
   });
 
-  test("skips an unselectable newest row and lands on the first chat", async () => {
+  test("lands on the first chat past any number of unselectable rows, in one request", async () => {
     /* The standard listing admits background runs filed in custom groups,
-       so page one can lead with one. */
-    listRows = [
-      { id: "bg-in-group", conversationType: "background", groupId: "grp-1" },
-      { id: "first-chat" },
-    ];
-
-    renderColdBoot(new QueryClient());
-
-    expect(await landedOn()).toContain("first-chat");
-  });
-
-  test("keeps looking past page one when it has no chat, and stops after the 200 newest rows", async () => {
-    /* 60 background runs in a custom group lead the list; the first chat sits
-       on page two. The stub pages by the server's own offset arithmetic. */
-    listRows = [
-      ...Array.from({ length: 60 }, (_, i) => ({
-        id: `bg-${i}`,
-        conversationType: "background" as const,
-        groupId: "grp-1",
-      })),
-      { id: "first-chat" },
-    ];
-    renderColdBoot(new QueryClient());
-    expect(await landedOn()).toContain("first-chat");
-    expect(requests.filter((u) => u.endsWith("/conversations"))).toHaveLength(
-      2,
-    );
-
-    cleanup();
-    navigateMock.mockClear();
-    requests = [];
-    useConversationStore.setState({ activeConversationId: null });
-
-    /* 300 unselectable rows before the first chat: the search stops after
-       four pages and lands on the assistant itself rather than scanning on. */
+       so its newest rows can all be runs; the daemon's filter skips them, so
+       the first chat is one row away however deep it sits. */
     listRows = [
       ...Array.from({ length: 300 }, (_, i) => ({
         id: `bg-${i}`,
@@ -315,71 +316,152 @@ describe("useConversationLoader cold-boot landing", () => {
       })),
       { id: "deep-chat" },
     ];
+
     renderColdBoot(new QueryClient());
-    const landing = await landedOn();
-    expect(landing).toContain(ASSISTANT_ID);
-    expect(landing).not.toContain("deep-chat");
+
+    expect(await landedOn()).toContain("deep-chat");
     expect(requests.filter((u) => u.endsWith("/conversations"))).toHaveLength(
-      4,
+      1,
     );
   });
 
-  test("pages by the server's page size, not by rows received, so appended pinned rows skip nothing", async () => {
-    /* Page one is 50 rows plus 2 appended pinned rows, all unselectable; the
-       first chat is row 51 in server order, so an offset advanced by rows
-       received (52) would skip it. */
-    pinnedExtras = [
-      { id: "pin-a", conversationType: "background", groupId: "grp-1" },
-      { id: "pin-b", conversationType: "background", groupId: "grp-1" },
-    ];
-    listRows = [
-      ...Array.from({ length: 50 }, (_, i) => ({
-        id: `bg-${i}`,
-        conversationType: "background" as const,
-        groupId: "grp-1",
-      })),
-      { id: "row-51-chat" },
-    ];
-    renderColdBoot(new QueryClient());
-    expect(await landedOn()).toContain("row-51-chat");
-  });
+  describe("an assistant that predates foregroundOnly", () => {
+    /* Such an assistant ignores the parameter and answers with the newest
+       row of the unfiltered listing. When that row is a chat it is the same
+       answer a filtering assistant gives; when it is not, the loader knows
+       the filter was not applied and pages through the list itself. */
+    beforeEach(() => {
+      daemonFiltersForeground = false;
+    });
 
-  test("an appended pin older than the window does not pre-empt a newer chat on page two", async () => {
-    /* The window's 50 newest rows are all unselectable; the daemon appends
-       an old pinned chat beyond the window; a newer (still selectable) chat
-       leads page two. Recency order: bg rows (100..51), the page-two chat
-       (30), the appended pin (1). */
-    pinnedExtras = [{ id: "old-pin", isPinned: true, lastMessageAt: 1 }];
-    listRows = [
-      ...Array.from({ length: 50 }, (_, i) => ({
-        id: `bg-${i}`,
-        conversationType: "background" as const,
-        groupId: "grp-1",
-        lastMessageAt: 100 - i,
-      })),
-      { id: "page-two-chat", lastMessageAt: 30 },
-    ];
+    test("a newest row that is a chat is the landing, in one request", async () => {
+      listRows = [{ id: "newest" }, { id: "older" }];
 
-    renderColdBoot(new QueryClient());
+      renderColdBoot(new QueryClient());
 
-    expect(await landedOn()).toContain("page-two-chat");
-  });
+      expect(await landedOn()).toContain("newest");
+      expect(requests.filter((u) => u.endsWith("/conversations"))).toHaveLength(
+        1,
+      );
+    });
 
-  test("an appended pin newer than everything past the window wins", async () => {
-    pinnedExtras = [{ id: "newer-pin", isPinned: true, lastMessageAt: 40 }];
-    listRows = [
-      ...Array.from({ length: 50 }, (_, i) => ({
-        id: `bg-${i}`,
-        conversationType: "background" as const,
-        groupId: "grp-1",
-        lastMessageAt: 100 - i,
-      })),
-      { id: "page-two-chat", lastMessageAt: 30 },
-    ];
+    test("a newest row that is not a chat proves the filter was ignored, and the loader pages", async () => {
+      listRows = [
+        { id: "bg-in-group", conversationType: "background", groupId: "grp-1" },
+        { id: "first-chat" },
+      ];
 
-    renderColdBoot(new QueryClient());
+      renderColdBoot(new QueryClient());
 
-    expect(await landedOn()).toContain("newer-pin");
+      expect(await landedOn()).toContain("first-chat");
+      /* The one-row read, then page one of the unfiltered list. */
+      expect(listQueries).toEqual([
+        { foregroundOnly: "true", limit: 1, offset: 0 },
+        { limit: 50, offset: 0 },
+      ]);
+    });
+
+    test("keeps looking past page one when it has no chat, and stops after the 200 newest rows", async () => {
+      /* 60 background runs in a custom group lead the list; the first chat
+         sits on page two. The stub pages by the server's own offset
+         arithmetic. Request counts include the one-row read that detected
+         the older assistant. */
+      listRows = [
+        ...Array.from({ length: 60 }, (_, i) => ({
+          id: `bg-${i}`,
+          conversationType: "background" as const,
+          groupId: "grp-1",
+        })),
+        { id: "first-chat" },
+      ];
+      renderColdBoot(new QueryClient());
+      expect(await landedOn()).toContain("first-chat");
+      expect(requests.filter((u) => u.endsWith("/conversations"))).toHaveLength(
+        3,
+      );
+
+      cleanup();
+      navigateMock.mockClear();
+      requests = [];
+      useConversationStore.setState({ activeConversationId: null });
+
+      /* 300 unselectable rows before the first chat: the search stops after
+         four pages and lands on the assistant itself rather than scanning
+         on. */
+      listRows = [
+        ...Array.from({ length: 300 }, (_, i) => ({
+          id: `bg-${i}`,
+          conversationType: "background" as const,
+          groupId: "grp-1",
+        })),
+        { id: "deep-chat" },
+      ];
+      renderColdBoot(new QueryClient());
+      const landing = await landedOn();
+      expect(landing).toContain(ASSISTANT_ID);
+      expect(landing).not.toContain("deep-chat");
+      expect(requests.filter((u) => u.endsWith("/conversations"))).toHaveLength(
+        5,
+      );
+    });
+
+    test("pages by the server's page size, not by rows received, so appended pinned rows skip nothing", async () => {
+      /* Page one is 50 rows plus 2 appended pinned rows, all unselectable;
+         the first chat is row 51 in server order, so an offset advanced by
+         rows received (52) would skip it. */
+      pinnedExtras = [
+        { id: "pin-a", conversationType: "background", groupId: "grp-1" },
+        { id: "pin-b", conversationType: "background", groupId: "grp-1" },
+      ];
+      listRows = [
+        ...Array.from({ length: 50 }, (_, i) => ({
+          id: `bg-${i}`,
+          conversationType: "background" as const,
+          groupId: "grp-1",
+        })),
+        { id: "row-51-chat" },
+      ];
+      renderColdBoot(new QueryClient());
+      expect(await landedOn()).toContain("row-51-chat");
+    });
+
+    test("an appended pin older than the window does not pre-empt a newer chat on page two", async () => {
+      /* The window's 50 newest rows are all unselectable; the daemon appends
+         an old pinned chat beyond the window; a newer (still selectable)
+         chat leads page two. Recency order: bg rows (100..51), the page-two
+         chat (30), the appended pin (1). */
+      pinnedExtras = [{ id: "old-pin", isPinned: true, lastMessageAt: 1 }];
+      listRows = [
+        ...Array.from({ length: 50 }, (_, i) => ({
+          id: `bg-${i}`,
+          conversationType: "background" as const,
+          groupId: "grp-1",
+          lastMessageAt: 100 - i,
+        })),
+        { id: "page-two-chat", lastMessageAt: 30 },
+      ];
+
+      renderColdBoot(new QueryClient());
+
+      expect(await landedOn()).toContain("page-two-chat");
+    });
+
+    test("an appended pin newer than everything past the window wins", async () => {
+      pinnedExtras = [{ id: "newer-pin", isPinned: true, lastMessageAt: 40 }];
+      listRows = [
+        ...Array.from({ length: 50 }, (_, i) => ({
+          id: `bg-${i}`,
+          conversationType: "background" as const,
+          groupId: "grp-1",
+          lastMessageAt: 100 - i,
+        })),
+        { id: "page-two-chat", lastMessageAt: 30 },
+      ];
+
+      renderColdBoot(new QueryClient());
+
+      expect(await landedOn()).toContain("newer-pin");
+    });
   });
 
   test("retries a transient failure before falling back", async () => {

--- a/clients/web/src/domains/chat/utils/landing-conversation.ts
+++ b/clients/web/src/domains/chat/utils/landing-conversation.ts
@@ -5,12 +5,21 @@
  * A cold load with nothing selected (no conversation in the URL, no
  * in-memory selection, no draft) resumes the last-viewed conversation if it
  * is still selectable, else lands on the newest selectable foreground
- * conversation. The last-viewed row is read by id; the newest is the first
- * selectable row of the foreground list's page one, read through the app's
+ * conversation. The last-viewed row is read by id; the newest is one row
+ * from the daemon (`limit=1`, `foregroundOnly=true`), read through the app's
  * own page fetcher so nothing lands in the query cache under the list prefix
  * (every `conversationsGet` key is a list cache to the prefix scanners, and
  * this read is not one). Neither waits on the drained foreground list, whose
  * length grows with the account and whose readers are elsewhere.
+ *
+ * An assistant that predates `foregroundOnly` ignores it and answers with
+ * the newest row of the unfiltered listing, which may be a background run.
+ * That is detectable: the row was asked for as foreground, so one that fails
+ * the client's selectability rule proves the filter was not applied, and the
+ * newest-row search then pages through the unfiltered list itself
+ * ({@link walkForNewestSelectable}). No version gate: the response carries
+ * the evidence, and a gate read before the identity fetch hydrates would
+ * send every cold boot down the paged path.
  *
  * The drained list is still consulted when it already holds rows (a warm
  * cache from an earlier mount), because reading it costs nothing; the same
@@ -35,6 +44,7 @@ import type { Conversation } from "@/types/conversation-types";
 import {
   CONVERSATION_LIST_PAGE_SIZE,
   type ConversationListPage,
+  fetchNewestForegroundConversation,
   listConversationsFirstPage,
   listConversationsPage,
 } from "@/utils/conversation-list-fetchers";
@@ -102,7 +112,7 @@ function newerOf(
 }
 
 /**
- * How far past page one the newest-row search looks: the 200 newest rows.
+ * How far past page one the paged search looks: the 200 newest rows.
  * Beyond that the landing is the assistant itself (a new chat is one click
  * away), so cold boot stays bounded on an account whose newest rows are all
  * background runs filed in custom groups, rather than scanning to the first
@@ -114,11 +124,11 @@ const LANDING_MAX_PAGES = 4;
  * The newest selectable foreground conversation's id.
  *
  * Reads the drained foreground cache when it already holds rows (free), else
- * page one of the foreground list, and later pages only while page one held
- * no selectable row and the server has more, up to {@link LANDING_MAX_PAGES}:
- * the route's standard listing admits background runs filed in custom
- * groups, so the first row is not always a chat. One request in the
- * ordinary case, never more than four.
+ * asks the daemon for its newest foreground row and takes it. A row that is
+ * not selectable means the assistant ignored `foregroundOnly` (it predates
+ * the parameter), so the search pages through the unfiltered list instead
+ * ({@link walkForNewestSelectable}). One request against a current
+ * assistant; against an older one, that request plus the paged search.
  */
 async function fetchLatestForegroundId(
   queryClient: QueryClient,
@@ -130,6 +140,27 @@ async function fetchLatestForegroundId(
   if (cached && cached.conversations.length > 0) {
     return firstSelectable(cached.conversations)?.conversationId ?? null;
   }
+  const newest = await fetchNewestForegroundConversation(assistantId);
+  if (newest === null) {
+    return null;
+  }
+  if (isStoredConversationSelectable(newest)) {
+    return newest.conversationId;
+  }
+  return walkForNewestSelectable(assistantId);
+}
+
+/**
+ * The newest selectable row of the unfiltered foreground list, found by
+ * paging: page one, and later pages only while page one held no selectable
+ * row and the server has more, up to {@link LANDING_MAX_PAGES}. The
+ * standard listing admits background runs filed in custom groups, so the
+ * first row is not always a chat. For assistants that do not filter to
+ * foreground rows themselves.
+ */
+async function walkForNewestSelectable(
+  assistantId: string,
+): Promise<string | null> {
   const first = await listConversationsFirstPage(assistantId, {}, "landing");
   /* An unfiltered page one is the paginated window plus every pinned row
      the daemon appends beyond it, sorted together by recency. An appended

--- a/clients/web/src/utils/conversation-list-fetchers.ts
+++ b/clients/web/src/utils/conversation-list-fetchers.ts
@@ -3,10 +3,11 @@
  * non-list reads (unread count, section index).
  *
  * Every list read is the daemon's paginated `conversationsGet()` scoped by a
- * {@link ConversationListFilter}; three primitives cover them all: a drain
+ * {@link ConversationListFilter}; four primitives cover them all: a drain
  * ({@link drainConversationList}), the newest page
- * ({@link listConversationsFirstPage}), and a page at an offset
- * ({@link listConversationsPage}). Rows come back as `Conversation`
+ * ({@link listConversationsFirstPage}), a page at an offset
+ * ({@link listConversationsPage}), and the newest foreground row
+ * ({@link fetchNewestForegroundConversation}). Rows come back as `Conversation`
  * (`toConversation` runs here, in the fetch), shaped per bucket by
  * {@link shapeListRows}. Keys live in `conversation-list-keys.ts` and the
  * list `queryOptions` in `conversation-list-options.ts`.
@@ -259,11 +260,12 @@ async function fetchConversationListPage(
   offset: number,
   source: ListFetchSource,
   filter: ConversationListFilter = {},
+  limit: number = CONVERSATION_LIST_PAGE_SIZE,
 ): Promise<TimedConversationListPage> {
   const startedAt = performance.now();
   const { data, error, response } = await conversationsGet({
     path: { assistant_id: assistantId },
-    query: { ...filter, limit: CONVERSATION_LIST_PAGE_SIZE, offset },
+    query: { ...filter, limit, offset },
     throwOnError: false,
   });
   assertHasResponse(response, error, "Failed to list conversations.");
@@ -413,6 +415,38 @@ export async function hasAnyActiveConversation(
     "existence_probe",
   );
   return conversations.length > 0;
+}
+
+/**
+ * The newest conversation the user can open, as one row: `limit=1` on the
+ * foreground list with `foregroundOnly=true`, so the daemon applies its own
+ * "not an unsurfaced background or scheduled run" predicate and its own
+ * order, and the first row is the answer. `null` when the daemon has none.
+ *
+ * An assistant that predates the parameter ignores it and answers with the
+ * newest row of the unfiltered listing (plus its appended pinned rows, which
+ * this read drops). That row is not necessarily openable, and the caller
+ * decides what to do about it: `landing-conversation.ts` checks the row
+ * against the client's selectability rule and falls back to a paged search
+ * when it fails, which is how it detects the older assistant without a
+ * version gate.
+ *
+ * Reported to the diagnostics ring as a `landing` first-page read of the
+ * foreground list; the label set is closed, and this is that read at a
+ * smaller limit.
+ */
+export async function fetchNewestForegroundConversation(
+  assistantId: string,
+): Promise<Conversation | null> {
+  const page = await fetchConversationListPage(
+    assistantId,
+    0,
+    "landing",
+    { foregroundOnly: "true" },
+    1,
+  );
+  recordFirstPageFetch(assistantId, page, "foreground", "landing");
+  return page.conversations[0] ?? null;
 }
 
 /**

--- a/clients/web/src/utils/conversation-list-keys.ts
+++ b/clients/web/src/utils/conversation-list-keys.ts
@@ -219,6 +219,7 @@ export function isPinnedInjectedFilter(
     (filter.archiveStatus === undefined || filter.archiveStatus === "active") &&
     filter.originChannel === undefined &&
     filter.groupId === undefined &&
-    filter.needsAttention === undefined
+    filter.needsAttention === undefined &&
+    filter.foregroundOnly === undefined
   );
 }


### PR DESCRIPTION
Fixes LUM-3323 (parent LUM-2443). Follow-up to #40852, which added the daemon filter.

## TL;DR

The cold-boot landing's "newest conversation the user can open" lookup is now one request: `GET /v1/conversations?foregroundOnly=true&limit=1`, and the daemon's first row is the answer. The client no longer walks up to four pages or reconstructs how the daemon's appended pinned rows sort against later pages (the mirror LUM-3322 found could disagree with the daemon on ties). Older assistants that ignore the parameter are detected from the response and get today's paged search unchanged.

## How an older assistant is handled, and why not a version gate

An assistant that predates `foregroundOnly` ignores it and answers 200 with the newest row of the unfiltered listing. That row was asked for as a foreground row, so the client checks it against `isStoredConversationSelectable`:

- passes: it is the newest listed row and it is openable, which is exactly what today's walk lands on; take it.
- fails: only an assistant that ignored the filter can return that, so run today's paged search.
- no rows: nothing to land on either way; assistant home, as today.

This is capability detection from the response, the seam `BACKWARDS_COMPAT.md` already lists for the Electron bridge, and it is documented there. A version gate was the first design and was dropped for two reasons found in the code: the identity fetch that hydrates the version runs concurrently with the landing on cold boot, so a snapshot gate reads "unknown" and takes the paged path on most cold boots (the case the new path exists for); and awaiting the version puts that round trip, or a 5s timeout when a waking pod returned a transient null, back on the landing's critical path that LUM-3309 just took it off. Detection has neither cost and lights up on same-source self-hosted builds that report an old `package.json` version.

## What changed

- `fetchNewestForegroundConversation` in `conversation-list-fetchers.ts`: `limit=1` + `foregroundOnly=true`, first row or `null`; the internal page fetcher takes a `limit`.
- `landing-conversation.ts`: `fetchLatestForegroundId` uses it; the former body becomes `walkForNewestSelectable`, reached only when the returned row fails the selectability check.
- `isPinnedInjectedFilter` mirrors the daemon's injection guard for the new parameter.
- Cold-boot tests: the daemon stub honors `foregroundOnly` (default) or ignores it (an "assistant that predates foregroundOnly" block that carries the paged-search cases, request counts adjusted for the detecting read); a new case lands on a chat 300 rows deep in one request; the request's query is asserted.
- `BACKWARDS_COMPAT.md`: new bullet under "Related compatibility seams".

## Before / after

| | Before | After |
| --- | --- | --- |
| Cold boot, stored conversation gone, current assistant | Up to 4 list requests of 50 rows; client picks the first selectable row and reconciles appended pins against page 2 by timestamp | 1 request of 1 row; the daemon's newest foreground row |
| Same, but the first chat is past the 200 newest rows | Lands on the assistant home | Lands on that chat |
| Same, older assistant (ignores the parameter) | As before | As before, plus one extra 1-row request when the newest listed row is a background run |
| Stored conversation still selectable; warm drained cache | Unchanged | Unchanged |

## Why it is safe

On current assistants the answer is the daemon's, by the same predicate the unread count uses (`notBackgroundVisibilitySql`) and the daemon's own order; the client also re-checks the row it lands on. On older assistants every path degrades to the exact code that runs today. Nothing new lands in the query cache (the read stays a plain fetch, as before). Typecheck and lint pass locally; the test suite runs in CI (local runs are blocked in this environment).

The paged search is kept as the older-assistant fallback; it is the legacy branch to delete once no supported assistant predates the parameter (noted in the doc bullet).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40854" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->