### PR TITLE
fix(permissions): classify each tool invocation once, before the gates, with no daemon memo (LUM-3159, LUM-3165)

### DIFF
--- a/assistant/AGENTS.md
+++ b/assistant/AGENTS.md
@@ -2,7 +2,7 @@
 
 For error handling conventions (throw vs result objects vs null), see [docs/error-handling.md](docs/error-handling.md).
 
-Subdirectory-scoped rules live in local AGENTS.md files: `src/cli/`, `src/runtime/`, `src/approvals/`, `src/notifications/`, `src/plugins/`, `src/workspace/migrations/`.
+Subdirectory-scoped rules live in local AGENTS.md files: `src/cli/`, `src/runtime/`, `src/approvals/`, `src/notifications/`, `src/permissions/`, `src/plugins/`, `src/workspace/migrations/`.
 
 ## Adding new environment variables
 

--- a/assistant/docs/architecture/security.md
+++ b/assistant/docs/architecture/security.md
@@ -4,207 +4,149 @@ Permission, trust, and credential-security architecture details.
 
 ## Permission and Trust Security Model
 
-The permission system controls which tool actions the agent can execute without explicit user approval. It supports two operating modes (`workspace` and `strict`), execution-target-scoped trust rules, and risk-based escalation to provide defense-in-depth against unintended or malicious tool execution.
+The permission system decides which tool actions the agent may execute without explicit approval. Two processes share the work, and the split is the load-bearing fact of this section:
+
+- The **gateway** owns risk classification (`gateway/src/risk/*`, entered through the `classify_risk` IPC method), the trust rules that raise or lower a classified risk (stored in the gateway's SQLite `trust_rules` table and applied inside the classifiers), the auto-approve thresholds and channel-permission cells, and the per-actor `TrustClass` verdict.
+- The **assistant** owns the turn's actor and capabilities (`runtime/capabilities.ts`), the sensitive-tool capability floor (`tools/tool-approval-handler.ts`), the allow / prompt / deny decision over risk × threshold × capabilities (`permissions/checker.ts` `check()` and `DefaultApprovalPolicy`), the prompt UX (`permissions/prompter.ts`), execution, and the `tool_invocations` audit row.
+
+The assistant has no local classifier and no fallback: an unreachable gateway fails closed. It classifies each tool invocation exactly once and passes that classification down; nothing in the assistant memoises or re-derives risk. `assistant/src/permissions/AGENTS.md` and `gateway/src/risk/AGENTS.md` state the rules that follow.
 
 ### Permission Evaluation Flow
 
 ```mermaid
 graph TB
-    TOOL_CALL["Tool invocation<br/>(toolName, input, policyContext)"] --> CLASSIFY["classifyRisk()<br/>→ Low / Medium / High"]
-    CLASSIFY --> CANDIDATES["buildCommandCandidates()<br/>tool:target strings +<br/>canonical path variants"]
-    CANDIDATES --> FIND_RULE["findHighestPriorityRule()<br/>iterate sorted rules:<br/>tool, scope, pattern (minimatch),<br/>executionTarget"]
-
-    FIND_RULE -->|"Deny rule"| DENY["decision: deny<br/>Blocked by rule"]
-    FIND_RULE -->|"Ask rule"| PROMPT_ASK["decision: prompt<br/>Always ask user"]
-    FIND_RULE -->|"Allow rule / No match"| SANDBOX_CHECK{"sandboxAutoApprove?<br/>(bash + allowlisted +<br/>containerized)"}
-
-    SANDBOX_CHECK -->|"yes"| AUTO_SANDBOX["decision: allow<br/>Sandbox auto-approve"]
-    SANDBOX_CHECK -->|"no, has Allow rule"| RISK_CHECK{"Risk level?"}
-    SANDBOX_CHECK -->|"no, no match"| NO_MATCH{"Fallback logic"}
-
-    RISK_CHECK -->|"Low / Medium"| AUTO_ALLOW["decision: allow<br/>Auto-allowed by rule"]
-    RISK_CHECK -->|"High"| RISK_THRESHOLD{"Risk-based<br/>threshold fallback"}
-
-    NO_MATCH -->|"tool.origin === 'skill'"| PROMPT_SKILL["decision: prompt<br/>Skill tools always ask"]
-    NO_MATCH -->|"workspace-scoped<br/>+ Low risk"| AUTO_WS["decision: allow<br/>Workspace-scoped auto-allow"]
-    NO_MATCH -->|"otherwise"| RISK_THRESHOLD
-
-    RISK_THRESHOLD{"risk ≤ autoApproveUpTo<br/>threshold?"}
-    RISK_THRESHOLD -->|"yes"| AUTO_THRESHOLD["decision: allow<br/>within auto-approve threshold"]
-    RISK_THRESHOLD -->|"no"| PROMPT_THRESHOLD["decision: prompt<br/>above auto-approve threshold"]
+    TOOL_CALL["Tool invocation<br/>(toolName, input, context)"] --> CLASSIFY["classifyRisk() once, before the gates<br/>gateway classify_risk over IPC<br/>→ level, reason, matchType, options"]
+    CLASSIFY --> GATES["Pre-execution gates<br/>abort · unparseable args · guardian control-plane policy ·<br/>sensitive-tool floor + approval-matrix cell · disk pressure ·<br/>unknown tool · allowedToolNames · channel policy · Zod parse"]
+    GATES -->|"blocked"| GATE_OUT["denied / error<br/>audited with the classified level"]
+    GATES -->|"sensitive, non-guardian"| GRANT{"scoped grant<br/>consumed?"}
+    GRANT -->|"yes"| EXECUTE["execute<br/>(no permission check;<br/>provenance grant_scoped_consumed)"]
+    GRANT -->|"escalate-and-wait"| ESCALATE["guardian tool-grant request<br/>+ inline wait"]
+    GRANT -->|"deny actor / no grant"| GATE_OUT
+    GATES -->|"passed"| CHECK["checkPermission → check()<br/>threshold + capability context"]
+    CHECK --> POLICY["DefaultApprovalPolicy.evaluate"]
+    POLICY -->|"allow"| EXECUTE
+    POLICY -->|"prompt"| PROMPT_ROUTE{"presence?"}
+    PROMPT_ROUTE -->|"non-interactive turn"| AUTO_OR_DENY["guardian within background threshold → allow<br/>otherwise deny (no human to ask)"]
+    PROMPT_ROUTE -->|"interactive"| PROMPT["confirmation_request → user allow / deny"]
 ```
+
+The order inside `check()`: the memory-retrospective skill-authoring grant, then the classification, then the auto-approve threshold for the turn's execution context (per-conversation override, then channel-permission cell, then global), then `DefaultApprovalPolicy.evaluate`. A `prompt` computed from a cached threshold is re-checked against a fresh read before the user is interrupted. `checkPermission` then applies `forcePromptSideEffects` and `requireFreshApproval` (allow → prompt), the non-interactive denial for uncovered inline-command skill loads, and platform-hosted sandboxed-bash auto-approve for guardians.
 
 ### Auto-Approve Threshold
 
-Auto-approve thresholds are **gateway-owned** — they live in the gateway's SQLite database and are read by the assistant via IPC (`get_global_thresholds`, `get_conversation_threshold`). Users control thresholds via the **Settings UI** (Permissions & Privacy tab) or the **per-conversation risk tolerance picker**. When the gateway is unreachable, the assistant defaults to `"none"` (Strict) — fail-closed with no local fallback.
+Thresholds are **gateway-owned**: stored in the gateway's SQLite database, read by the assistant over IPC (`get_global_thresholds`, `get_conversation_threshold`), and set from the Settings UI (Permissions & Privacy) or the per-conversation risk tolerance picker. When the gateway is unreachable the assistant resolves `"none"` (Strict), fail-closed with no local fallback.
+
+Gateway defaults per execution context (`gateway/src/ipc/threshold-handlers.ts`): `interactive` (a conversation with a client) `medium`, `autonomous` (background/scheduled) `low`, `headless` `none`. A per-conversation override wins over the global value; for non-guardian actors a channel-permission cell can only lower the effective threshold.
 
 | `autoApproveUpTo` | Low-risk tools | Medium-risk tools | High-risk tools |
 | ----------------- | -------------- | ----------------- | --------------- |
 | `"none"`          | Prompted       | Prompted          | Prompted        |
-| `"low"` (default) | Auto-allowed   | Prompted          | Prompted        |
+| `"low"`           | Auto-allowed   | Prompted          | Prompted        |
 | `"medium"`        | Auto-allowed   | Auto-allowed      | Prompted        |
 | `"high"`          | Auto-allowed   | Auto-allowed      | Auto-allowed    |
 
-When set to `"none"`, every tool invocation requires explicit approval. Explicit deny and ask rules always take precedence over the threshold.
+### Approval Policy
 
-### Trust Rules (v3 Schema)
+`DefaultApprovalPolicy.evaluate` (`assistant/src/permissions/approval-policy.ts`) turns a classified risk into allow / prompt, in this order:
 
-Rules are stored in `~/.vellum/protected/trust.json` with version `3`. Each rule can include the following fields:
+1. `bash` with the gateway's `sandboxAutoApprove` verdict, when the threshold is not `"none"`: allow.
+2. Third-party code (skill- or plugin-owned tools that are not first-party bundled, or a builtin running under a manifest override): allow within threshold, otherwise prompt.
+3. Low risk, workspace-scoped invocation, within threshold: allow.
+4. Low risk, bundled-skill tool, within threshold: allow.
+5. Otherwise: allow when risk ≤ threshold, prompt when above.
 
-| Field             | Type                   | Purpose                                                                  |
-| ----------------- | ---------------------- | ------------------------------------------------------------------------ |
-| `id`              | `string`               | Unique identifier (UUID for user rules, `default:*` for system defaults) |
-| `tool`            | `string`               | Tool name to match (e.g., `bash`, `file_write`, `skill_load`)            |
-| `pattern`         | `string`               | Minimatch glob pattern for the command/target string                     |
-| `scope`           | `string`               | Path prefix or `everywhere` — restricts where the rule applies           |
-| `decision`        | `allow \| deny \| ask` | What to do when the rule matches                                         |
-| `priority`        | `number`               | Higher priority wins; deny wins ties at equal priority                   |
-| `executionTarget` | `string?`              | `sandbox` or `host` — restricts by execution context                     |
+The policy never returns deny; denials come from the gates, the capability floor, and the checks in `checkPermission`. There is no allow / deny / ask rule axis: trust rules act on the classified risk, upstream of this policy.
 
-Missing optional fields act as wildcards. A rule with no `executionTarget` matches any target.
+### Trust Rules (v3)
 
-### Risk Classification and Escalation
+Rules live in the gateway (`gateway/src/db/trust-rule-store.ts`, cached in-process by `gateway/src/risk/trust-rule-cache.ts`, mutated only through the gateway HTTP routes, which refresh the cache). A rule is `{ tool, pattern, risk: low | medium | high, description, origin: default | user_defined, userModified, deleted }`, unique on `(tool, pattern)`. Default rules are seeded at gateway start from the bash command registry (`gateway/src/db/seed-trust-rules.ts`) and can be modified or reset; user rules are created, updated, and deleted through `/v1/trust-rules`.
 
-The `classifyRisk()` function determines the risk level for each tool invocation:
+Matching happens inside the classifiers: the bash classifier looks the command up exact, path-stripped, then by shorter subcommand prefixes, each in literal and `action:` form, user rules winning over defaults; the file, web, skill, and schedule classifiers look up a per-tool override. A matched rule replaces the base risk and the classification carries `matchType: "user_rule"`. The assistant sees only that: it never stores, matches, or lists rules except to proxy the list over IPC for clients.
 
-| Tool                                                             | Risk level                  | Notes                                                                                        |
-| ---------------------------------------------------------------- | --------------------------- | -------------------------------------------------------------------------------------------- |
-| `file_read`, `web_search`, `skill_load`                          | Low                         | Read-only or informational                                                                   |
-| `file_write`, `file_edit`                                        | Medium (default)            | Filesystem mutations                                                                         |
-| `file_write`, `file_edit` targeting skill source paths           | **High**                    | `isSkillSourcePath()` detects managed/bundled/workspace/extra skill roots                    |
-| `host_file_write`, `host_file_edit` targeting skill source paths | **High**                    | Same path classification, host variant                                                       |
-| `bash`, `host_bash`                                              | Varies                      | Parsed via tree-sitter: low-risk programs = Low, high-risk programs = High, unknown = Medium |
-| `scaffold_managed_skill`, `delete_managed_skill`                 | High                        | Skill lifecycle mutations always high-risk                                                   |
-| `evaluate_typescript_code`                                       | High                        | Arbitrary code execution                                                                     |
-| Skill-origin tools with no matching rule                         | Prompted regardless of risk | Even Low-risk skill tools default to `ask`                                                   |
+### Risk Classification
 
-The escalation of skill source file mutations to High risk is a privilege-escalation defense: modifying skill source code could grant the agent new capabilities, so such operations always require explicit approval.
+Classifiers (`gateway/src/risk/`), keyed by tool:
 
-### Skill Load Approval
+| Tool                                                           | Classifier                                    | Notes                                                                                                                                                                                                                                                                       |
+| -------------------------------------------------------------- | --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bash`, `host_bash`                                            | `bash-risk-classifier.ts`                     | Tree-sitter parse (`shell-parser.ts`, memoised on the command text) against `command-registry/`; per-command arg rules; dangerous patterns; `sandboxAutoApprove` for allowlisted sandbox commands with lexically-resolved path args                                         |
+| `file_*`, `host_file_*`                                        | `file-risk-classifier.ts`                     | Writes to skill source, workspace code, and other code-loaded directories escalate to High; the assistant sends symlink-resolved paths and the protected/skill directories with the request                                                                                 |
+| `web_fetch`, `network_request`                                 | `web-risk-classifier.ts`                      | URL-based; private-network access escalates                                                                                                                                                                                                                                 |
+| `skill_load`, `scaffold_managed_skill`, `delete_managed_skill` | `skill-risk-classifier.ts`                    | A `skill_load` whose skill has inline command expansions (executes shell at load time) is High; skill lifecycle mutations are High                                                                                                                                          |
+| `schedule_create`, `schedule_update`                           | `schedule-risk-classifier.ts`                 | Scheduled command risk                                                                                                                                                                                                                                                      |
+| Everything else                                                | fallback in `risk-classification-handlers.ts` | The tool's `defaultRiskLevel` from the assistant's registry (`matchType: "registry"`), or `medium` with an "Unknown tool" reason. This branch consults no trust rule and emits no allowlist options, so a user rule cannot cover an MCP or other classifier-less tool today |
 
-The `skill_load` tool generates version-aware command candidates for rule matching:
+The response (`ClassificationResult`, mirrored in `assistant/src/permissions/ipc-risk-types.ts`) carries the level, reason, `matchType`, allowlist / scope / directory-scope options, command candidates and action keys, `sandboxAutoApprove`, and the path args it was based on. The assistant's one adjustment is the bash symlink-escape re-check: it resolves the gateway's lexically-checked path args through the real filesystem and revokes `sandboxAutoApprove` if any escapes the workspace. It runs on every classification.
 
-1. `skill_load:<skill-id>@<version-hash>` — matches version-pinned rules
-2. `skill_load:<skill-id>` — matches any-version rules
-3. `skill_load:<raw-selector>` — matches the raw user-provided selector
+### Sensitive-Tool Capability Floor
 
-When `autoApproveUpTo` is `"none"`, `skill_load` without a matching rule is always prompted. The allowlist options presented to the user include both version-specific and any-version patterns. Note: the system default allow rule `skill_load:*` (priority 100) globally allows all skill loads regardless of threshold (see "System Default Allow Rules" below).
+Independently of risk, `tools/tool-approval-handler.ts` computes how far an invocation reaches (`none`, `sandbox`, `host`; host-target tools, out-of-workspace file access, and inline-command skill loads reach `host`) and reads the actor's `sensitiveToolApproval` capability: guardian `self`, trusted and unverified contacts `escalate-and-wait`, unknown `deny`. A non-`none` reach for a non-guardian either consumes a scoped approval grant, escalates to the guardian and waits inline, or fails closed. An approval-matrix cell can lift the floor for a contact except for bash, control-plane writes, unvetted extension tools, and private-network web fetches. Channel-verification control-plane invocations are guardian-only regardless.
 
 ### Skill Threat Model
 
-Skills that use existing system tools (`bash`, `file_read`, `web_fetch`, etc.) **do not expand the assistant's capability surface**. The assistant already has access to these tools based on its trust rules; a skill that teaches `curl https://api.example.com/v1/endpoint -d "..."` presents identical risk to a user asking the assistant to run that same command directly. The risk is governed entirely by the bash risk classifier and the user's `autoApproveUpTo` threshold — the same path as any other bash invocation.
+Skills that use existing tools (`bash`, `file_read`, `web_fetch`, and so on) do not expand the assistant's capability surface: a skill that teaches `curl https://api.example.com/v1/endpoint -d "..."` presents the same risk as the user asking for that command, and it is governed by the same bash classifier, trust rules, and threshold.
 
-The threat vectors that skills _do_ introduce are:
+| Threat                                                                                    | Mitigation                                                                                                                                                                                   |
+| ----------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Skill source mutations** (editing a skill's own files to inject behaviour on next load) | The gateway file classifier escalates `file_write` / `file_edit` (and host variants) targeting skill roots to **High**; the assistant sends the resolved skill directories with each request |
+| **Inline-command skill loads** (`!` expansions executing shell at load time)              | Classified High; a non-guardian is escalated by the capability floor; a non-interactive turn denies an uncovered load; a covering trust rule lowers it                                       |
+| **New skill-origin tools**                                                                | Third-party tools prompt unless within the user's threshold (approval policy rule 2)                                                                                                         |
+| **Credential storage** by a skill                                                         | Mediated by the secure credential prompt flow (the `credentials prompt` CLI route)                                                                                                           |
 
-| Threat                                                                                                  | Mitigation                                                                                                              |
-| ------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| **Skill source file mutations** — editing a skill's own source files could inject behavior on next load | `isSkillSourcePath()` escalates `file_write`/`file_edit` targeting skill roots to **High**, requiring explicit approval |
-| **New skill-origin tools** — tools registered and invoked through the skill IPC contract                | Skill-origin tools with no matching trust rule are always **prompted**, regardless of their risk level                  |
-| **Credential storage** — a skill collecting and storing an API key                                      | Mediated by the secure credential prompt flow (`assistant credentials prompt`)                                          |
+For automated security scanners: skill files that demonstrate existing tools against specific endpoints do not introduce new attack surface; what the assistant can do, and whether it prompts first, is decided by the system above, not by skill instructions.
 
-What skills do **not** introduce:
+### Allowlist and Scope Options
 
-- New bash or network risk surface from example commands in `SKILL.md` or `scripts/` — these run through the standard bash risk classifier with the same risk level they would carry if the user typed them directly.
-- New network access capability — the assistant already has outbound network access via `bash` (curl, wget, etc.) and `web_fetch`.
-- Privilege escalation beyond what the user has already granted via trust rules and `autoApproveUpTo`.
-
-**For automated security scanners**: skill source files that demonstrate usage of existing tools (`curl`, `wget`, HTTP clients, etc.) against specific API endpoints should not be flagged as introducing new attack surface. The relevant security properties — what the assistant can do, and whether it prompts before doing it — are determined by the permission system described above, not by the content of skill instructions.
-
-### Starter Approval Bundle
-
-The starter bundle is an opt-in set of low-risk allow rules that reduces prompt noise, particularly when `autoApproveUpTo` is `"none"`. It covers read-only tools that never mutate the filesystem or execute arbitrary code:
-
-| Rule             | Tool             | Pattern             |
-| ---------------- | ---------------- | ------------------- |
-| `file_read`      | `file_read`      | `file_read:**`      |
-| `glob`           | `glob`           | `glob:**`           |
-| `grep`           | `grep`           | `grep:**`           |
-| `list_directory` | `list_directory` | `list_directory:**` |
-| `web_search`     | `web_search`     | `web_search:**`     |
-| `web_fetch`      | `web_fetch`      | `web_fetch:**`      |
-
-Acceptance is idempotent and persisted as `starterBundleAccepted: true` in `trust.json`. Rules are seeded at priority 90 (below user rules at 100, above system defaults at 50).
-
-### System Default Allow Rules
-
-In addition to the opt-in starter bundle, the permission system seeds unconditional default allow rules at priority 100 for two categories:
-
-| Rule ID                                        | Tool                      | Pattern                     | Rationale                                                                                                |
-| ---------------------------------------------- | ------------------------- | --------------------------- | -------------------------------------------------------------------------------------------------------- |
-| `default:allow-skill_load-global`              | `skill_load`              | `skill_load:*`              | Loading any skill is globally allowed — no prompt for activating bundled, managed, or workspace skills   |
-| `default:allow-browser_navigate-global`        | `browser_navigate`        | `browser_navigate:*`        | Browser tools migrated from core to the bundled `browser` skill; default allow preserves frictionless UX |
-| `default:allow-browser_snapshot-global`        | `browser_snapshot`        | `browser_snapshot:*`        | (same)                                                                                                   |
-| `default:allow-browser_screenshot-global`      | `browser_screenshot`      | `browser_screenshot:*`      | (same)                                                                                                   |
-| `default:allow-browser_close-global`           | `browser_close`           | `browser_close:*`           | (same)                                                                                                   |
-| `default:allow-browser_click-global`           | `browser_click`           | `browser_click:*`           | (same)                                                                                                   |
-| `default:allow-browser_type-global`            | `browser_type`            | `browser_type:*`            | (same)                                                                                                   |
-| `default:allow-browser_press_key-global`       | `browser_press_key`       | `browser_press_key:*`       | (same)                                                                                                   |
-| `default:allow-browser_wait_for-global`        | `browser_wait_for`        | `browser_wait_for:*`        | (same)                                                                                                   |
-| `default:allow-browser_extract-global`         | `browser_extract`         | `browser_extract:*`         | (same)                                                                                                   |
-| `default:allow-browser_fill_credential-global` | `browser_fill_credential` | `browser_fill_credential:*` | (same)                                                                                                   |
-
-These rules are emitted by `getDefaultRuleTemplates()` in `assistant/src/permissions/defaults.ts`. Because they use priority 100 (equal to user rules), they take effect regardless of the `autoApproveUpTo` threshold. The `skill_load` rule means skill activation never prompts; the `browser_*` rules mean the browser skill's tools behave identically to the old core `headless-browser` tool from a permission standpoint.
-
-### Shell Command Identity and Allowlist Options
-
-For `bash` and `host_bash` tool invocations, the permission system uses parser-derived action keys (via `shell-identity.ts`) instead of raw whitespace-split patterns. This produces more meaningful allowlist options that reflect the actual command structure.
-
-**Candidate building** (`buildShellCommandCandidates`): The shell parser (`tools/terminal/parser.ts`) produces segments and operators. `analyzeShellCommand()` extracts segments, operators, opaque-construct flags, and dangerous patterns. `deriveShellActionKeys()` then classifies the command:
-
-- **Simple action** (optional setup-prefix segments like `cd`, `export`, `pushd` + exactly one action segment): Produces hierarchical `action:` keys. For example, `cd /repo && gh pr view 5525 --json title` yields candidates: the full original command text (`cd /repo && gh pr view 5525 --json title`), and action keys `action:gh pr view`, `action:gh pr`, `action:gh` (narrowest to broadest, max depth 3).
-- **Complex command** (pipelines with `|`, or multiple non-prefix action segments): Only the full original command text is returned as a candidate — no action keys.
-
-**Allowlist option ranking** (`buildShellAllowlistOptions`): For simple actions, the prompt offers options ordered from most specific to broadest: the full original command text (exact match), then action keys from deepest to shallowest. For complex commands, only the full original command text is offered. This prevents over-generalization of pipelines into permissive rules.
-
-**Trust rule pattern format**: Action keys use the `action:` prefix in trust rules (e.g., `action:gh pr view`). The trust store matches these via `findHighestPriorityRule()` against the candidate list produced by `buildShellCommandCandidates()`.
-
-**Scope ordering**: Scope options for all tools (including shell) are ordered from narrowest to broadest: project > parent directories > everywhere. The macOS chat UI uses a two-step flow for persistent rules: the user first selects the allowlist pattern, then selects the scope. This explicit scope selection replaces any silent auto-selection, ensuring the user always knows where the rule will apply.
+The prompt's "always allow" ladder comes from the classification when the classifier produced one: bash offers the exact command and then `action:<program>` / `action:<tokens>` keys (max depth 3; pipelines and other complex operators offer only the exact command); file and skill classifiers produce their own ladders; the web classifier does not, so `permissions/checker.ts` `generateAllowlistOptions` still falls back to per-tool strategies for `web_fetch` / `network_request`, the managed-skill tools, and `skill_load`, and to `*` otherwise. Directory-scope ladders (`directoryScopeOptions`) come from the gateway; the coarser workingDir scope ladder (`generateScopeOptions`) is still built assistant-side. Saving a persistent decision means the client creating a trust rule through the gateway (`POST /v1/trust-rules`); the assistant's `POST /v1/confirm` accepts only `allow` and `deny`.
 
 ### Prompt UX
 
-When a permission prompt is sent to the client (via `confirmation_request` SSE event), it includes:
-
-| Field              | Content                                             |
-| ------------------ | --------------------------------------------------- |
-| `toolName`         | The tool being invoked                              |
-| `input`            | Redacted tool input (sensitive fields removed)      |
-| `riskLevel`        | `low`, `medium`, or `high`                          |
-| `executionTarget`  | `sandbox` or `host` — where the action will execute |
-| `allowlistOptions` | Suggested patterns for "always allow" rules         |
-| `scopeOptions`     | Suggested scopes for rule persistence               |
-
-The user can respond with: `allow` (one-time), `always_allow` (create allow rule), `deny` (one-time), or `always_deny` (create deny rule). In containerized environments, commands tagged with `sandboxAutoApprove` in their risk spec are auto-allowed via the approval policy's sandbox auto-approve check; non-allowlisted commands (network tools, runtimes, package managers) use the user's `autoApproveUpTo` threshold. All other risk-based decisions use the `autoApproveUpTo` threshold (default: `"low"`) -- tools at or below the threshold are auto-allowed, those above are prompted.
+`confirmation_request` (SSE) carries `requestId`, `toolName`, redacted `input`, `riskLevel`, `riskReason`, `isContainerized`, `executionTarget`, `allowlistOptions`, `scopeOptions`, `directoryScopeOptions`, an optional preview `diff`, `conversationId`, `persistentDecisionsAllowed`, and `toolUseId`; it is also promoted to a guardian request for channel delivery. A prompt that times out or loses its client resolves to deny.
 
 ### Canonical Paths
 
-File tool candidates include canonical (symlink-resolved) absolute paths via `normalizeFilePath()` to prevent policy bypass through symlinked or relative path variations. The path classifier (`isSkillSourcePath()`) also resolves symlinks before checking against skill root directories.
+The assistant symlink-resolves file-tool paths and the working directory before sending them (`resolveFileToolPaths` in `permissions/checker.ts`, `normalizeFilePath` in `skills/path-classifier.ts`), and canonicalises the protected and skill directories the same way, so a symlinked component cannot bypass the gateway's prefix checks.
+
+### Audit
+
+Every invocation ends in one `tool_invocations` row (`telemetry/tool-audit.ts`): `decision` (`allow` / `denied` / `error` / prompt outcomes), the classified `riskLevel`, redacted input and a capped result preview, duration, and telemetry-only columns gated on analytics consent. Rows written by the gates (denials and errors) carry the same classified level as the rest of the call; a call whose classification did not complete (aborted before start, gateway unreachable) records `unclassified` rather than a level.
 
 ### Key Source Files
 
-| File                                          | Role                                                                                                                                                                                |
-| --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `assistant/src/permissions/types.ts`          | `TrustRule`, `PolicyContext`, `RiskLevel`, `UserDecision` types                                                                                                                     |
-| `assistant/src/permissions/checker.ts`        | `classifyRisk()`, `check()`, `buildCommandCandidates()`, allowlist/scope generation                                                                                                 |
-| `assistant/src/permissions/shell-identity.ts` | `analyzeShellCommand()`, `deriveShellActionKeys()`, `buildShellCommandCandidates()`, `buildShellAllowlistOptions()` — parser-based shell command identity and action key derivation |
-| `assistant/src/permissions/trust-store.ts`    | Rule persistence, `findHighestPriorityRule()`, execution-target matching, starter bundle                                                                                            |
-| `assistant/src/permissions/prompter.ts`       | HTTP prompt flow: `confirmation_request` → `confirmation_response`                                                                                                                  |
-| `assistant/src/permissions/defaults.ts`       | Default rule templates (system ask rules for host tools, CU, etc.)                                                                                                                  |
-| `assistant/src/skills/version-hash.ts`        | `computeSkillVersionHash()` — deterministic SHA-256 of skill source files                                                                                                           |
-| `assistant/src/skills/path-classifier.ts`     | `isSkillSourcePath()`, `normalizeFilePath()`, skill root detection                                                                                                                  |
-| `assistant/src/tools/executor.ts`             | `ToolExecutor` — orchestrates risk classification, permission check, and execution                                                                                                  |
-| `assistant/src/daemon/handlers/config.ts`     | `handleToolPermissionSimulate()` — dry-run simulation handler                                                                                                                       |
+Assistant:
+
+| File                                                                                   | Role                                                                                                                                |
+| -------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `assistant/src/permissions/checker.ts`                                                 | `classifyRisk()` (builds the request, calls the gateway, applies the symlink-escape re-check), `check()`, allowlist/scope fallbacks |
+| `assistant/src/permissions/approval-policy.ts`                                         | `DefaultApprovalPolicy`                                                                                                             |
+| `assistant/src/permissions/gateway-threshold-reader.ts`, `channel-permission-query.ts` | Threshold and channel-permission-cell reads over IPC                                                                                |
+| `assistant/src/permissions/ipc-risk-types.ts`                                          | Mirror of the gateway's `classify_risk` request and response types                                                                  |
+| `assistant/src/permissions/prompter.ts`                                                | `confirmation_request` → `confirmation_response`                                                                                    |
+| `assistant/src/permissions/types.ts`                                                   | `PolicyContext`, `RiskLevel`, `UserDecision`, thresholds                                                                            |
+| `assistant/src/tools/executor.ts`                                                      | `ToolExecutor`: one classification per invocation, gates, permission check, execution, audit                                        |
+| `assistant/src/tools/tool-approval-handler.ts`                                         | Pre-execution gates and the sensitive-tool capability floor                                                                         |
+| `assistant/src/tools/permission-checker.ts`                                            | `checkPermission`: policy adjustments, non-interactive routing, prompting                                                           |
+| `assistant/src/runtime/capabilities.ts`                                                | `resolveCapabilities(trustClass)`                                                                                                   |
+| `assistant/src/skills/path-classifier.ts`, `skills/version-hash.ts`                    | Path canonicalisation and skill version hashes sent with skill classifications                                                      |
+| `assistant/src/telemetry/tool-audit.ts`                                                | `tool_invocations` audit terminals                                                                                                  |
+
+Gateway:
+
+| File                                                                                                               | Role                                                                                    |
+| ------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------- |
+| `gateway/src/ipc/risk-classification-handlers.ts`                                                                  | `classify_risk` IPC handler, the entry point the assistant calls                        |
+| `gateway/src/risk/bash-risk-classifier.ts`                                                                         | Shell command risk, via `shell-parser.ts` / `shell-identity.ts` and `command-registry/` |
+| `gateway/src/risk/file-risk-classifier.ts`                                                                         | File tool risk, including code-loaded-directory escalation                              |
+| `gateway/src/risk/web-risk-classifier.ts`                                                                          | Web tool risk                                                                           |
+| `gateway/src/risk/skill-risk-classifier.ts`                                                                        | Skill lifecycle and inline-command load risk                                            |
+| `gateway/src/risk/schedule-risk-classifier.ts`                                                                     | Scheduled task risk                                                                     |
+| `gateway/src/risk/trust-rule-cache.ts`, `gateway/src/db/trust-rule-store.ts`, `gateway/src/db/seed-trust-rules.ts` | Trust rules: storage, seeding, in-process cache                                         |
+| `gateway/src/http/routes/trust-rules.ts`                                                                           | Trust rule CRUD, refreshing the cache on every mutation                                 |
+| `gateway/src/ipc/threshold-handlers.ts`                                                                            | Global and per-conversation thresholds                                                  |
 
 ### Permission Simulation (Tool Permission Tester)
 
-The `tool_permission_simulate` HTTP endpoint lets clients dry-run a tool invocation through the full permission evaluation pipeline without actually executing the tool or mutating daemon state. The macOS Settings panel exposes this as a "Tool Permission Tester" UI.
-
-**Simulation semantics:**
-
-- The request specifies `toolName`, `input`, and optional context overrides (`workingDir`, `isInteractive`).
-- The daemon runs `classifyRisk()` and `check()` against the live trust rules, then returns the decision (`allow`, `deny`, or `prompt`), risk level, reason, matched rule ID, and (when decision is `prompt`) the full `promptPayload` with allowlist/scope options.
-- **Simulation-only allow/deny**: A simulated `allow` or `deny` decision does not persist any state. No trust rules are created or modified.
-- **Always-allow persistence**: When the tester UI's "Always Allow" action is used, the client sends a separate `add_trust_rule` message that persists the rule to `trust.json`, identical to the existing confirmation flow.
-- **Non-interactive override**: When `isInteractive` is false, `prompt` decisions are converted to `deny` (no client available to approve).
+`POST tools/simulate-permission` (`tools_simulate_permission_post`, `assistant/src/runtime/routes/settings-routes.ts`) dry-runs an invocation through classification and `check()` without executing or persisting anything. It takes `toolName`, `input`, and optional `workingDir` / `isInteractive`, and returns the decision, risk level, reason, execution target, and, for a `prompt`, the allowlist / scope options; when `isInteractive` is false a `prompt` is reported as `deny`.
 
 ---
 

--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -82,7 +82,6 @@ import * as envRegistry from "../config/env-registry.js";
 import {
   check,
   classifyRisk,
-  clearRiskCache,
   generateAllowlistOptions,
   generateScopeOptions,
   SCOPE_AWARE_TOOLS,
@@ -180,8 +179,6 @@ describe("Permission Checker", () => {
     mockIpcResponse("get_global_thresholds", DEFAULT_GATEWAY_THRESHOLDS);
     // Clear the gateway threshold cache so each test gets a fresh threshold read
     _clearGlobalCacheForTesting();
-    // Reset trust-store state and risk classification cache between tests
-    clearRiskCache();
     // Reset guardian persona mock so each test opts in explicitly
     mockGuardianPersonaPath = null;
     loggerWarnCalls.length = 0;
@@ -1514,7 +1511,6 @@ describe("bash network_mode=proxied — risk capped at medium", () => {
     mockRisk("low");
     mockIpcResponse("get_global_thresholds", DEFAULT_GATEWAY_THRESHOLDS);
     _clearGlobalCacheForTesting();
-    clearRiskCache();
   });
 
   test("proxied bash follows risk-based policy (medium risk → prompt outside container)", async () => {
@@ -1562,7 +1558,6 @@ describe("credentialed proxied bash — high risk escalation", () => {
     mockRisk("low");
     mockIpcResponse("get_global_thresholds", DEFAULT_GATEWAY_THRESHOLDS);
     _clearGlobalCacheForTesting();
-    clearRiskCache();
   });
 
   test("proxied bash with credential_ids sends credentialRefCount in IPC params", async () => {
@@ -1652,7 +1647,6 @@ describe("workspace mode — auto-allow workspace-scoped operations", () => {
     mockRisk("low");
     mockIpcResponse("get_global_thresholds", DEFAULT_GATEWAY_THRESHOLDS);
     _clearGlobalCacheForTesting();
-    clearRiskCache();
     try {
       rmSync(join(checkerTestDir, "protected", "trust.json"));
     } catch {
@@ -1796,7 +1790,6 @@ describe("integration regressions (PR 11)", () => {
     mockRisk("low");
     mockIpcResponse("get_global_thresholds", DEFAULT_GATEWAY_THRESHOLDS);
     _clearGlobalCacheForTesting();
-    clearRiskCache();
     // Delete the trust file to prevent stale default rules from prior tests
     try {
       rmSync(join(checkerTestDir, "protected", "trust.json"));

--- a/assistant/src/__tests__/inline-skill-load-permissions.test.ts
+++ b/assistant/src/__tests__/inline-skill-load-permissions.test.ts
@@ -43,7 +43,6 @@ mockIpcResponse("get_global_thresholds", {
 // ── Imports (after mocks) ─────────────────────────────────────────────────
 
 import { check, generateAllowlistOptions } from "../permissions/checker.js";
-import { clearRiskCache } from "../permissions/checker.js";
 import { _clearGlobalCacheForTesting } from "../permissions/gateway-threshold-reader.js";
 import { setOverridesForTesting } from "./feature-flag-test-helpers.js";
 
@@ -86,7 +85,6 @@ function writeDynamicSkill(
 
 describe("inline-command skill_load permissions", () => {
   beforeEach(() => {
-    clearRiskCache();
     _clearGlobalCacheForTesting();
     setOverridesForTesting({});
     mockIpcResponse("get_global_thresholds", {

--- a/assistant/src/__tests__/inline-skill-load-permissions.test.ts
+++ b/assistant/src/__tests__/inline-skill-load-permissions.test.ts
@@ -81,12 +81,32 @@ function writeDynamicSkill(
   );
 }
 
+/**
+ * What the gateway skill classifier answers for a load whose params carry
+ * `hasInlineExpansions` (gateway/src/risk/skill-risk-classifier.ts): High,
+ * registry-matched. The daemon does not elevate locally; the gateway is the
+ * one place a dynamic load becomes High.
+ */
+function mockDynamicSkillClassification(): void {
+  mockIpcResponse("classify_risk", {
+    risk: "high",
+    reason:
+      "Skill load with inline command expansions (executes shell commands at load time)",
+    matchType: "registry",
+  });
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────
 
 describe("inline-command skill_load permissions", () => {
   beforeEach(() => {
     _clearGlobalCacheForTesting();
     setOverridesForTesting({});
+    mockIpcResponse("classify_risk", {
+      risk: "low",
+      reason: "skill_load",
+      matchType: "unknown",
+    });
     mockIpcResponse("get_global_thresholds", {
       interactive: "low",
       autonomous: "medium",
@@ -114,6 +134,7 @@ describe("inline-command skill_load permissions", () => {
     test("an uncovered dynamic skill prompts below Full access", async () => {
       ensureSkillsDir();
       writeDynamicSkill("dynamic-prompt", "Dynamic Prompt Skill");
+      mockDynamicSkillClassification();
 
       // interactive threshold "low" (beforeEach) is below the High risk of an
       // inline-command load, so it prompts.
@@ -129,6 +150,7 @@ describe("inline-command skill_load permissions", () => {
     test("an uncovered dynamic skill runs at Full access (high threshold)", async () => {
       ensureSkillsDir();
       writeDynamicSkill("dynamic-full", "Dynamic Full Access Skill");
+      mockDynamicSkillClassification();
       mockIpcResponse("get_global_thresholds", {
         interactive: "high",
         autonomous: "high",
@@ -161,17 +183,12 @@ describe("inline-command skill_load permissions", () => {
         "/tmp",
       );
       expect(result.decision).toBe("allow");
-
-      mockIpcResponse("classify_risk", {
-        risk: "low",
-        reason: "skill_load",
-        matchType: "unknown",
-      });
     });
 
     test("dynamic skill prompts in strict mode (no matching rule)", async () => {
       ensureSkillsDir();
       writeDynamicSkill("dynamic-strict", "Dynamic Strict Skill");
+      mockDynamicSkillClassification();
       mockIpcResponse("get_global_thresholds", {
         interactive: "none",
         autonomous: "none",

--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -6,9 +6,11 @@ import type { UsageAttributionSnapshot } from "../usage/attribution.js";
 let checkerDecision: "allow" | "prompt" | "deny" = "allow";
 let checkerReason = "allowed";
 let checkerRisk = "low";
+let classifyThrow: Error | null = null;
 let promptDecision: "allow" | "deny" = "allow";
 let fakeToolResult: ToolExecutionResult = { content: "ok", isError: false };
 let toolThrow: Error | null = null;
+let grantConsumeOk = false;
 
 // ── audit-terminal captures ───────────────────────────────
 // The executor and its permission/approval collaborators no longer emit
@@ -86,13 +88,42 @@ mock.module("../platform/consent-cache.js", () => ({
 
 mock.module("../permissions/checker.js", () => ({
   isDynamicSkillLoadInvocation: () => false,
-  classifyRisk: async () => ({ level: checkerRisk }),
+  // Mirrors the real classifier's two failure modes: it throws on an aborted
+  // signal before doing anything, and it throws when the gateway is
+  // unreachable.
+  classifyRisk: async (
+    _name: string,
+    _input: Record<string, unknown>,
+    _workingDir?: string,
+    _preParsed?: unknown,
+    _manifestOverride?: unknown,
+    signal?: AbortSignal,
+  ) => {
+    signal?.throwIfAborted();
+    if (classifyThrow) {
+      throw classifyThrow;
+    }
+    return { level: checkerRisk };
+  },
   check: async () => ({ decision: checkerDecision, reason: checkerReason }),
   generateAllowlistOptions: () => [
     { label: "exact", description: "exact", pattern: "exact" },
   ],
   generateScopeOptions: () => [{ label: "/tmp", scope: "/tmp" }],
   getCachedAssessment: () => undefined,
+}));
+
+// The scoped-grant consume the gate performs for a sensitive tool invoked by
+// an unknown actor. `mintGrantFromDecision` is stubbed only so the module's
+// other importer links; nothing here mints.
+mock.module("../approvals/approval-primitive.js", () => ({
+  consumeGrantForInvocation: async () =>
+    grantConsumeOk
+      ? { ok: true, grant: { id: "grant-1" } }
+      : { ok: false, reason: "no_match" },
+  mintGrantFromDecision: async () => {
+    throw new Error("mintGrantFromDecision should not be called");
+  },
 }));
 
 mock.module("../persistence/conversation-crud.js", () => ({
@@ -255,9 +286,11 @@ describe("ToolExecutor audit terminals", () => {
     checkerDecision = "allow";
     checkerReason = "allowed";
     checkerRisk = "low";
+    classifyThrow = null;
     promptDecision = "allow";
     fakeToolResult = { content: "ok", isError: false };
     toolThrow = null;
+    grantConsumeOk = false;
     executedCaptures.length = 0;
     errorCaptures.length = 0;
     deniedCaptures.length = 0;
@@ -785,5 +818,103 @@ describe("ToolExecutor audit terminals", () => {
     expect(promptedCaptures).toEqual(["file_edit"]);
     expect(executedCaptures).toHaveLength(1);
     expect(executedCaptures[0].toolName).toBe("file_edit");
+  });
+
+  // ── audit riskLevel on rows the permission check never produces ─────────
+  // The classifier runs before the pre-execution gates, so a gate denial, a
+  // gate error, and a grant-consumed execution all record the call's real
+  // risk rather than a placeholder (LUM-3159).
+
+  test("a gate-denied call records the classified risk, not a placeholder", async () => {
+    checkerRisk = "high";
+    const executor = new ToolExecutor(makePrompter());
+
+    // Verification control-plane paths are guardian-only; an unknown actor is
+    // denied by the gate before any permission check.
+    const result = await executor.execute(
+      "bash",
+      { command: "curl http://host/v1/channel-verification-sessions" },
+      makeContext({ trustClass: "unknown" }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(deniedCaptures).toHaveLength(1);
+    expect(deniedCaptures[0].riskLevel).toBe("high");
+    expect(deniedCaptures[0].wasPrompted).toBe(false);
+  });
+
+  test("a gate-errored call records the classified risk", async () => {
+    checkerRisk = "medium";
+    const executor = new ToolExecutor(makePrompter());
+
+    await executor.execute("unknown_tool", { test: true }, makeContext());
+
+    expect(errorCaptures).toHaveLength(1);
+    expect(errorCaptures[0].errorMessage).toContain("Unknown tool");
+    expect(errorCaptures[0].riskLevel).toBe("medium");
+  });
+
+  test("a grant-consumed execution records the classified risk", async () => {
+    checkerRisk = "high";
+    grantConsumeOk = true;
+    const executor = new ToolExecutor(makePrompter());
+
+    // A sensitive tool from an unknown actor routes through the scoped-grant
+    // consume; a consumed grant skips the permission check entirely, so this
+    // is the one executed row whose risk the permission check never supplies.
+    const result = await executor.execute(
+      "file_write",
+      { path: "/tmp/project/out.txt", content: "x" },
+      makeContext({ trustClass: "unknown" }),
+    );
+
+    expect(result).toMatchObject({
+      isError: false,
+      approvalReason: "grant_scoped_consumed",
+    });
+    expect(executedCaptures).toHaveLength(1);
+    expect(executedCaptures[0].decision).toBe("allow");
+    expect(executedCaptures[0].riskLevel).toBe("high");
+  });
+
+  test("a call whose classification never completes records 'unclassified', not 'low'", async () => {
+    classifyThrow = new Error("gateway unreachable");
+    const executor = new ToolExecutor(makePrompter());
+
+    // Gate error path: the row says the risk was never assessed.
+    await executor.execute("unknown_tool", { test: true }, makeContext());
+    expect(errorCaptures).toHaveLength(1);
+    expect(errorCaptures[0].riskLevel).toBe("unclassified");
+
+    // Past the gates, the permission check still requires a classification
+    // and fails closed; that error row is likewise honest about the risk.
+    errorCaptures.length = 0;
+    const result = await executor.execute(
+      "file_read",
+      { path: "README.md" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(executedCaptures).toHaveLength(0);
+    expect(errorCaptures).toHaveLength(1);
+    expect(errorCaptures[0].errorMessage).toContain("gateway unreachable");
+    expect(errorCaptures[0].riskLevel).toBe("unclassified");
+  });
+
+  test("a call aborted before it starts records 'unclassified' on its cancelled row", async () => {
+    checkerRisk = "high";
+    const executor = new ToolExecutor(makePrompter());
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await executor.execute(
+      "bash",
+      { command: "rm -rf /tmp" },
+      makeContext({ signal: controller.signal }),
+    );
+
+    expect(result).toEqual({ content: "Cancelled", isError: true });
+    expect(errorCaptures).toHaveLength(1);
+    expect(errorCaptures[0].riskLevel).toBe("unclassified");
   });
 });

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -43,8 +43,11 @@ let checkFnOverride:
 /** Override for generateScopeOptions — when set, returns this value instead of the default. */
 let scopeOptionsOverride: ScopeOption[] | undefined;
 
-/** Override for getCachedAssessment — when set, returns this value. */
-let cachedAssessmentOverride:
+/**
+ * Override for the classification `classifyRisk` returns; when unset the
+ * classifier answers low with no reason and no options.
+ */
+let classificationOverride:
   | {
       riskLevel: string;
       reason: string;
@@ -61,7 +64,14 @@ let cachedAssessmentOverride:
 
 mock.module("../permissions/checker.js", () => ({
   isDynamicSkillLoadInvocation: () => false,
-  classifyRisk: async () => ({ level: "low" }),
+  classifyRisk: async () => ({
+    level: classificationOverride?.riskLevel ?? "low",
+    reason: classificationOverride?.reason,
+    scopeOptions: classificationOverride?.scopeOptions ?? [],
+    allowlistOptions: classificationOverride?.allowlistOptions,
+    directoryScopeOptions: classificationOverride?.directoryScopeOptions,
+    matchType: classificationOverride?.matchType ?? "unknown",
+  }),
   check: async (
     toolName: string,
     input: Record<string, unknown>,
@@ -82,7 +92,6 @@ mock.module("../permissions/checker.js", () => ({
   ],
   generateScopeOptions: () =>
     scopeOptionsOverride ?? [{ label: "/tmp", scope: "/tmp" }],
-  getCachedAssessment: () => cachedAssessmentOverride,
 }));
 
 // Mock every export so downstream test files that dynamically import modules
@@ -167,7 +176,7 @@ describe("ToolExecutor allowedToolNames gating", () => {
     getAllToolsOverride = undefined;
     checkResultOverride = undefined;
     checkFnOverride = undefined;
-    cachedAssessmentOverride = undefined;
+    classificationOverride = undefined;
   });
 
   test("executes normally when allowedToolNames is not set", async () => {
@@ -385,7 +394,7 @@ describe("ToolExecutor policy context plumbing", () => {
     getToolOverride = undefined;
     checkResultOverride = undefined;
     checkFnOverride = undefined;
-    cachedAssessmentOverride = undefined;
+    classificationOverride = undefined;
   });
 
   test("passes PolicyContext with executionTarget for skill-origin tools", async () => {
@@ -604,7 +613,7 @@ describe("ToolExecutor forcePromptSideEffects enforcement", () => {
     getToolOverride = undefined;
     checkResultOverride = undefined;
     checkFnOverride = undefined;
-    cachedAssessmentOverride = undefined;
+    classificationOverride = undefined;
     promptCalled = false;
   });
 
@@ -989,11 +998,11 @@ describe("ToolExecutionResult includes risk metadata from classifier assessment"
     getToolOverride = undefined;
     checkResultOverride = undefined;
     checkFnOverride = undefined;
-    cachedAssessmentOverride = undefined;
+    classificationOverride = undefined;
   });
 
   test("auto-approved tool result includes risk metadata when classifier assessment exists", async () => {
-    cachedAssessmentOverride = {
+    classificationOverride = {
       riskLevel: "medium",
       reason: "Writes to a file outside the workspace",
       scopeOptions: [
@@ -1019,8 +1028,10 @@ describe("ToolExecutionResult includes risk metadata from classifier assessment"
     ]);
   });
 
-  test("tool result omits risk metadata when no classifier assessment exists (e.g. MCP tools)", async () => {
-    // cachedAssessmentOverride is undefined (no classifier ran)
+  test("tool result carries the classification's risk metadata even when the classifier produced no options", async () => {
+    // classificationOverride is unset: the classifier answered low with no
+    // reason and no options, which is what a tool with no dedicated classifier
+    // (registry default risk) looks like.
     const executor = new ToolExecutor(makePrompter());
     const result = await executor.execute(
       "file_read",
@@ -1029,9 +1040,9 @@ describe("ToolExecutionResult includes risk metadata from classifier assessment"
     );
 
     expect(result.isError).toBe(false);
-    expect(result.riskLevel).toBeUndefined();
-    expect(result.riskReason).toBeUndefined();
-    expect(result.riskScopeOptions).toBeUndefined();
+    expect(result.riskLevel).toBe("low");
+    expect(result.riskScopeOptions).toEqual([]);
+    expect(result.riskAllowlistOptions).toBeUndefined();
   });
 
   test("denied tool result includes risk metadata", async () => {
@@ -1039,7 +1050,7 @@ describe("ToolExecutionResult includes risk metadata from classifier assessment"
       decision: "deny",
       reason: "Blocked by deny rule",
     };
-    cachedAssessmentOverride = {
+    classificationOverride = {
       riskLevel: "high",
       reason: "Recursive force delete",
       scopeOptions: [{ pattern: "bash:rm -rf*", label: "rm -rf commands" }],
@@ -1066,7 +1077,7 @@ describe("ToolExecutionResult includes risk metadata from classifier assessment"
       decision: "prompt",
       reason: "Medium risk: requires approval",
     };
-    cachedAssessmentOverride = {
+    classificationOverride = {
       riskLevel: "medium",
       reason: "Package manager installation",
       scopeOptions: [
@@ -1091,7 +1102,7 @@ describe("ToolExecutionResult includes risk metadata from classifier assessment"
   });
 
   test("tool result includes riskDirectoryScopeOptions when classifier emits directoryScopeOptions", async () => {
-    cachedAssessmentOverride = {
+    classificationOverride = {
       riskLevel: "medium",
       reason: "Writes to file in workspace",
       scopeOptions: [
@@ -1124,7 +1135,7 @@ describe("ToolExecutionResult includes risk metadata from classifier assessment"
   });
 
   test("tool result omits riskDirectoryScopeOptions when classifier does not emit directoryScopeOptions", async () => {
-    cachedAssessmentOverride = {
+    classificationOverride = {
       riskLevel: "low",
       reason: "Read-only operation",
       scopeOptions: [],
@@ -1144,7 +1155,7 @@ describe("ToolExecutionResult includes risk metadata from classifier assessment"
   });
 
   test("riskScopeOptions and riskDirectoryScopeOptions are independent — one does not clobber the other", async () => {
-    cachedAssessmentOverride = {
+    classificationOverride = {
       riskLevel: "medium",
       reason: "Filesystem write",
       scopeOptions: [
@@ -1170,7 +1181,7 @@ describe("ToolExecutionResult includes risk metadata from classifier assessment"
   });
 
   test("auto-approved tool result includes riskAllowlistOptions when classifier emits them (Minimatch-glob shape for save path)", async () => {
-    cachedAssessmentOverride = {
+    classificationOverride = {
       riskLevel: "medium",
       reason: "Reads workspace files",
       // Display ladder (regex shape — not for save).
@@ -1222,7 +1233,7 @@ describe("ToolExecutionResult includes risk metadata from classifier assessment"
   });
 
   test("riskAllowlistOptions is undefined when classifier did not produce allowlist (e.g. web-risk classifier)", async () => {
-    cachedAssessmentOverride = {
+    classificationOverride = {
       riskLevel: "low",
       reason: "GET request to public URL",
       scopeOptions: [
@@ -1248,8 +1259,8 @@ describe("ToolExecutionResult includes risk metadata from classifier assessment"
     expect(result.riskAllowlistOptions).toBeUndefined();
   });
 
-  test("riskAllowlistOptions is undefined when no classifier ran (MCP tools)", async () => {
-    // cachedAssessmentOverride is undefined — no classifier ran.
+  test("riskAllowlistOptions is undefined when the classifier produced none", async () => {
+    // classificationOverride is unset: no allowlist options on the answer.
     const executor = new ToolExecutor(makePrompter());
     const result = await executor.execute(
       "file_read",
@@ -1258,13 +1269,13 @@ describe("ToolExecutionResult includes risk metadata from classifier assessment"
     );
 
     expect(result.isError).toBe(false);
-    expect(result.riskScopeOptions).toBeUndefined();
+    expect(result.riskScopeOptions).toEqual([]);
     expect(result.riskAllowlistOptions).toBeUndefined();
   });
 
   test("denied tool result still carries riskAllowlistOptions for the rule editor save path", async () => {
     checkResultOverride = { decision: "deny", reason: "Blocked by deny rule" };
-    cachedAssessmentOverride = {
+    classificationOverride = {
       riskLevel: "high",
       reason: "Recursive force delete",
       scopeOptions: [{ pattern: "^rm\\s+-rf", label: "rm -rf *" }],
@@ -1334,7 +1345,7 @@ describe("ToolExecutor thrown-value rendering", () => {
     getAllToolsOverride = undefined;
     checkResultOverride = undefined;
     checkFnOverride = undefined;
-    cachedAssessmentOverride = undefined;
+    classificationOverride = undefined;
   });
 
   function throwingTool(name: string, thrown: unknown): void {
@@ -1406,7 +1417,7 @@ describe("ToolExecutor input-schema validation gate", () => {
     getAllToolsOverride = undefined;
     checkResultOverride = undefined;
     checkFnOverride = undefined;
-    cachedAssessmentOverride = undefined;
+    classificationOverride = undefined;
   });
 
   /**

--- a/assistant/src/permissions/AGENTS.md
+++ b/assistant/src/permissions/AGENTS.md
@@ -1,0 +1,16 @@
+# Permissions: Agent Instructions
+
+This directory is the assistant's **client** of gateway-owned risk classification and trust rules, plus the assistant-owned decision that follows. Keep the split:
+
+- **Gateway owns:** risk classification (`gateway/src/risk/*`, entered through the `classify_risk` IPC method), the trust rules that lower or raise a classified risk (applied inside the gateway classifiers and surfaced only as the classified level plus `matchType: "user_rule"`), the auto-approve thresholds and channel-permission cells, and the per-actor `TrustClass` verdict.
+- **Assistant owns:** the turn's actor and its capabilities (`runtime/capabilities.ts`), the sensitive-tool capability floor (`tools/tool-approval-handler.ts`), the allow / prompt / deny decision over risk × threshold × capabilities (`check()` here, `DefaultApprovalPolicy`), the prompt UX (`prompter.ts`), execution, and the `tool_invocations` audit row.
+
+Rules that follow from the split:
+
+- **Do not add a risk classifier, risk table, or trust-rule matcher under `assistant/src`.** If a tool's risk is wrong or a rule cannot cover it, the fix is in `gateway/src/risk/` (or the tool's `defaultRiskLevel`, which the gateway uses for tools without a dedicated classifier).
+- **Classify once per tool invocation.** `classifyRisk()` is the only call into the gateway; the executor takes it before the pre-execution gates and hands the result to `checkPermission` and `check()`. Do not re-classify downstream, and do not memoise the result in the daemon: the inputs (rules, config, skill content) change out from under it, and the gateway already memoises the expensive part.
+- **Read the classification, do not re-derive it.** Elevations, `matchType` checks, and option ladders come from the `RiskClassificationWithMeta` the gateway returned. A daemon-side "defense in depth" copy of a gateway rule is a second source of truth, not a defense.
+- **Types cross the boundary from the wire contract.** Fields mirrored from the gateway response are typed off `ClassificationResult` (`ipc-risk-types.ts`), never re-declared.
+- The one daemon-side adjustment to a classification is the bash sandbox symlink-escape re-check (`applyBashSymlinkEscapeCheck`), because it needs the assistant's filesystem; it only ever revokes auto-approve.
+
+The architecture doc for this area is [`docs/architecture/security.md`](../../docs/architecture/security.md).

--- a/assistant/src/permissions/checker.test.ts
+++ b/assistant/src/permissions/checker.test.ts
@@ -206,7 +206,6 @@ import {
   classifyRisk,
   generateAllowlistOptions,
   generateScopeOptions,
-  getCachedAssessment,
   isInstalledStaticSkillLoad,
 } from "./checker.js";
 import { RiskLevel } from "./types.js";
@@ -352,36 +351,9 @@ describe("Permission Checker (gateway IPC)", () => {
       expect(lastClassifyRiskParams?.resolvedWorkingDir).toBeUndefined();
     });
 
-    test("caches results for identical inputs", async () => {
-      mockIpcClassifyRiskResult = {
-        risk: "low",
-        reason: "Cached test",
-        matchType: "registry",
-        scopeOptions: [],
-      };
-
-      // First call
-      const result1 = await classifyRisk("file_read", { path: "/tmp/a.txt" });
-      expect(result1.level).toBe(RiskLevel.Low);
-
-      // Change the mock to verify cache is used
-      mockIpcClassifyRiskResult = {
-        risk: "high",
-        reason: "Should not see this",
-        matchType: "registry",
-        scopeOptions: [],
-      };
-
-      // Second call with same inputs should return cached result
-      const result2 = await classifyRisk("file_read", { path: "/tmp/a.txt" });
-      expect(result2.level).toBe(RiskLevel.Low);
-      expect(result2.reason).toBe("Cached test");
-    });
-
-    test("file-tool cache misses when a symlink target is retargeted", async () => {
-      // File risk depends on filesystem state: the cache key folds in the
-      // symlink-resolved target, so the same raw input must NOT return a stale
-      // cached result after the symlink is pointed somewhere new.
+    test("a retargeted symlink is reflected on the next classification of the same raw input", async () => {
+      // File risk depends on filesystem state; nothing in the daemon memoises
+      // a classification, so re-pointing the symlink changes the answer.
       const dir = mkdtempSync(join(tmpdir(), "risk-cache-symlink-"));
       try {
         const benign = join(dir, "benign.txt");
@@ -411,7 +383,7 @@ describe("Permission Checker (gateway IPC)", () => {
           scopeOptions: [],
         };
         const second = await classifyRisk("file_read", { path: link });
-        // Cache must have missed and re-classified against the new target.
+        // Re-classified against the new target.
         expect(second.level).toBe(RiskLevel.High);
         expect(second.reason).toBe("now sensitive");
       } finally {
@@ -427,7 +399,6 @@ describe("Permission Checker (gateway IPC)", () => {
         scopeOptions: [],
         commandCandidates: ["ls -la", "action:ls"],
       };
-      // Use unique command to avoid cache hits from other tests
       const result = await classifyRisk("bash", { command: "ls -la" });
       expect((result as any).commandCandidates).toEqual([
         "ls -la",
@@ -443,7 +414,6 @@ describe("Permission Checker (gateway IPC)", () => {
         scopeOptions: [],
         sandboxAutoApprove: true,
       };
-      // Use unique command to avoid cache hits
       const result = await classifyRisk("bash", { command: "pwd" });
       expect((result as any).sandboxAutoApprove).toBe(true);
     });
@@ -513,7 +483,7 @@ describe("Permission Checker (gateway IPC)", () => {
       mockIsPathWithinWorkspaceRoot = true;
     });
 
-    test("cache hit re-runs symlink escape check after symlink retargeted", async () => {
+    test("the symlink escape check runs on every classification, so a retargeted symlink revokes sandbox auto-approve", async () => {
       // First call: path args within workspace → sandboxAutoApprove true.
       mockIsPathWithinWorkspaceRoot = true;
       mockIpcClassifyRiskResult = {
@@ -529,9 +499,8 @@ describe("Permission Checker (gateway IPC)", () => {
       });
       expect((first as any).sandboxAutoApprove).toBe(true);
 
-      // Second call with the same command: cache hit, but symlink now
-      // resolves outside workspace. The cache hit must re-run the check
-      // and override sandboxAutoApprove to false.
+      // Second call with the same command: the symlink now resolves outside
+      // the workspace, so sandboxAutoApprove is revoked.
       mockIsPathWithinWorkspaceRoot = false;
       const second = await classifyRisk("bash", {
         command: "cat /workspace/escape/secret42.bin",
@@ -556,7 +525,6 @@ describe("Permission Checker (gateway IPC)", () => {
         scopeOptions: [],
         allowlistOptions: mockOptions,
       };
-      // Use unique command to avoid cache hits
       const result = await classifyRisk("bash", { command: "date" });
       expect((result as any).allowlistOptions).toEqual(mockOptions);
     });
@@ -1218,7 +1186,7 @@ describe("Permission Checker (gateway IPC)", () => {
   // ── generateAllowlistOptions ──────────────────────────────────────────────
 
   describe("generateAllowlistOptions", () => {
-    test("returns gateway-provided options from assessment cache", async () => {
+    test("returns the gateway's options from the invocation's classification", async () => {
       const mockOptions = [
         { label: "wc -l", description: "Exact command", pattern: "wc -l" },
         {
@@ -1235,17 +1203,16 @@ describe("Permission Checker (gateway IPC)", () => {
         allowlistOptions: mockOptions,
       };
 
-      // First classify to populate the cache
-      await classifyRisk("bash", { command: "wc -l" });
-
-      // Then generate options should use cached assessment
-      const options = await generateAllowlistOptions("bash", {
-        command: "wc -l",
-      });
+      const classification = await classifyRisk("bash", { command: "wc -l" });
+      const options = await generateAllowlistOptions(
+        "bash",
+        { command: "wc -l" },
+        classification,
+      );
       expect(options).toEqual(mockOptions);
     });
 
-    test("falls back to per-tool strategy for file tools without cached options", async () => {
+    test("falls back to per-tool strategy for file tools without gateway options", async () => {
       const options = await generateAllowlistOptions("file_read", {
         path: "/tmp/foo.txt",
       });
@@ -1262,10 +1229,10 @@ describe("Permission Checker (gateway IPC)", () => {
     });
   });
 
-  // ── getCachedAssessment ───────────────────────────────────────────────────
+  // ── classifyRisk carries the gateway's assessment fields ──────────────────
 
-  describe("getCachedAssessment", () => {
-    test("returns cached assessment after classifyRisk call", async () => {
+  describe("classifyRisk assessment fields", () => {
+    test("carries reason, matchType and allowlistOptions from the gateway result", async () => {
       mockIpcClassifyRiskResult = {
         risk: "low",
         reason: "Test assessment",
@@ -1276,21 +1243,37 @@ describe("Permission Checker (gateway IPC)", () => {
         ],
       };
 
-      await classifyRisk("bash", { command: "echo test" });
-
-      const assessment = getCachedAssessment("bash", { command: "echo test" });
-      expect(assessment).toBeDefined();
-      expect(assessment!.riskLevel).toBe("low");
-      expect(assessment!.reason).toBe("Test assessment");
-      expect(assessment!.allowlistOptions).toHaveLength(1);
+      const classification = await classifyRisk("bash", {
+        command: "echo test",
+      });
+      expect(classification.level).toBe(RiskLevel.Low);
+      expect(classification.reason).toBe("Test assessment");
+      expect(classification.matchType).toBe("registry");
+      expect(classification.allowlistOptions).toHaveLength(1);
     });
 
-    test("returns undefined for uncached tool invocations", () => {
-      const assessment = getCachedAssessment("bash", { command: "not-cached" });
-      expect(assessment).toBeUndefined();
+    test("is not memoised: a changed gateway answer for the same input is returned", async () => {
+      mockIpcClassifyRiskResult = {
+        risk: "low",
+        reason: "before the rule",
+        matchType: "registry",
+        scopeOptions: [],
+      };
+      const before = await classifyRisk("bash", { command: "curl example" });
+      expect(before.level).toBe(RiskLevel.Low);
+
+      mockIpcClassifyRiskResult = {
+        risk: "high",
+        reason: "after the rule",
+        matchType: "user_rule",
+        scopeOptions: [],
+      };
+      const after = await classifyRisk("bash", { command: "curl example" });
+      expect(after.level).toBe(RiskLevel.High);
+      expect(after.matchType).toBe("user_rule");
     });
 
-    test("preserves scopeOptions from gateway result in cached assessment", async () => {
+    test("preserves scopeOptions from the gateway result", async () => {
       mockIpcClassifyRiskResult = {
         risk: "low",
         reason: "Registry match",
@@ -1302,22 +1285,16 @@ describe("Permission Checker (gateway IPC)", () => {
         allowlistOptions: [],
       };
 
-      await classifyRisk("bash", { command: "echo hello" });
-
-      const assessment = getCachedAssessment("bash", { command: "echo hello" });
-      expect(assessment).toBeDefined();
-      expect(assessment!.scopeOptions).toHaveLength(2);
-      expect(assessment!.scopeOptions[0]).toEqual({
-        pattern: "echo *",
-        label: "only 'echo' commands",
+      const classification = await classifyRisk("bash", {
+        command: "echo hello",
       });
-      expect(assessment!.scopeOptions[1]).toEqual({
-        pattern: ".*",
-        label: "everywhere",
-      });
+      expect(classification.scopeOptions).toEqual([
+        { pattern: "echo *", label: "only 'echo' commands" },
+        { pattern: ".*", label: "everywhere" },
+      ]);
     });
 
-    test("preserves directoryScopeOptions from gateway result in cached assessment", async () => {
+    test("preserves directoryScopeOptions from the gateway result", async () => {
       mockIpcClassifyRiskResult = {
         risk: "medium",
         reason: "Filesystem write",
@@ -1331,25 +1308,14 @@ describe("Permission Checker (gateway IPC)", () => {
         ],
       };
 
-      await classifyRisk("file_write", { path: "/workspace/scratch/out.txt" });
-
-      const assessment = getCachedAssessment("file_write", {
+      const classification = await classifyRisk("file_write", {
         path: "/workspace/scratch/out.txt",
       });
-      expect(assessment).toBeDefined();
-      expect(assessment!.directoryScopeOptions).toHaveLength(3);
-      expect(assessment!.directoryScopeOptions![0]).toEqual({
-        scope: "/workspace/scratch/*",
-        label: "In scratch/",
-      });
-      expect(assessment!.directoryScopeOptions![1]).toEqual({
-        scope: "/workspace/*",
-        label: "In workspace/",
-      });
-      expect(assessment!.directoryScopeOptions![2]).toEqual({
-        scope: "everywhere",
-        label: "everywhere",
-      });
+      expect(classification.directoryScopeOptions).toEqual([
+        { scope: "/workspace/scratch/*", label: "In scratch/" },
+        { scope: "/workspace/*", label: "In workspace/" },
+        { scope: "everywhere", label: "everywhere" },
+      ]);
     });
   });
 

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 
@@ -46,7 +45,6 @@ import {
   getAutoApproveThreshold,
   refreshAutoApproveThreshold,
 } from "./gateway-threshold-reader.js";
-import type { RiskAssessment } from "./risk-types.js";
 import {
   type AllowlistOption,
   type PermissionCheckResult,
@@ -60,13 +58,6 @@ import {
   resolveSandboxBase,
 } from "./workspace-policy.js";
 
-// ── Risk classification cache ────────────────────────────────────────────────
-// classifyRisk() is called on every permission check and delegates to the
-// gateway via IPC. Cache results keyed on
-// (toolName, inputHash, workingDir, manifestOverride).
-// Invalidated when trust rules change since risk classification for file tools
-// depends on skill source path checks which reference config, but the core
-// risk logic is input-deterministic.
 /** The result of classifyRisk(): a risk level with an optional human-readable reason. */
 export interface RiskClassification {
   level: RiskLevel;
@@ -75,10 +66,12 @@ export interface RiskClassification {
 }
 
 /**
- * Extended risk classification that includes gateway-provided metadata
- * used by check() for command candidate building and sandbox auto-approve.
+ * Everything the daemon reads from one gateway classification. Produced once
+ * per tool invocation by {@link classifyRisk} and handed down through
+ * `checkPermission` and {@link check}; the daemon keeps no memo of it, so a
+ * trust-rule, config, or skill change is reflected on the next call.
  */
-interface RiskClassificationWithMeta extends RiskClassification {
+export interface RiskClassificationWithMeta extends RiskClassification {
   /** Command candidates from the gateway for trust rule matching (bash tools). */
   commandCandidates?: string[];
   /** Action keys from the gateway for trust rule matching (bash tools). */
@@ -87,86 +80,24 @@ interface RiskClassificationWithMeta extends RiskClassification {
   sandboxAutoApprove?: boolean;
   /**
    * Lexically-resolved path args from the gateway for bash sandbox
-   * auto-approve. Stored in the cache so the symlink escape check can be
-   * re-run on cache hits (symlink targets may change between calls).
+   * auto-approve; the symlink escape check runs over them here, since the
+   * gateway has no filesystem access.
    */
   sandboxPathArgs?: string[];
   /** Allowlist options from the gateway for generateAllowlistOptions(). */
   allowlistOptions?: AllowlistOption[];
   /** Resolved filesystem path arguments for directory-scoped rule matching. */
   resolvedPaths?: string[];
-}
-
-const RISK_CACHE_MAX = 256;
-const riskCache = new Map<string, RiskClassificationWithMeta>();
-
-// ── Assessment cache ─────────────────────────────────────────────────────────
-// Stores the full ClassificationResult from the gateway so that
-// generateAllowlistOptions() can read gateway-produced allowlistOptions
-// without re-classifying. Keyed on (toolName, inputHash) — a simpler key
-// than the full risk cache since generateAllowlistOptions() does not receive
-// workingDir or manifestOverride. Cleared alongside the risk cache.
-const assessmentCache = new Map<string, RiskAssessment>();
-
-function assessmentCacheKey(
-  toolName: string,
-  input: Record<string, unknown>,
-): string {
-  const { reason: _reason, activity: _activity, ...cacheableInput } = input;
-  const inputJson = JSON.stringify(cacheableInput);
-  const hash = createHash("sha256").update(inputJson).digest("hex");
-  return `${toolName}\0${hash}`;
-}
-
-function riskCacheKey(
-  toolName: string,
-  input: Record<string, unknown>,
-  workingDir?: string,
-  manifestOverride?: ManifestOverride,
-  fsStateKey?: string,
-): string {
-  // Strip `reason` and `activity` before computing the cache key — they are
-  // cosmetic status text that varies per invocation even for identical tool
-  // operations, causing unnecessary cache misses.
-  const { reason: _reason, activity: _activity, ...cacheableInput } = input;
-  const inputJson = JSON.stringify(cacheableInput);
-  const hash = createHash("sha256")
-    .update(inputJson)
-    .update("\0")
-    .update(workingDir ?? "")
-    .update("\0")
-    .update(manifestOverride ? JSON.stringify(manifestOverride) : "")
-    // For file tools, fold in the symlink-resolved target path(s). File risk
-    // depends on filesystem state (a symlink can be retargeted under a
-    // protected dir between calls), so the same raw input must miss the cache
-    // when its canonicalized target changes.
-    .update("\0")
-    .update(fsStateKey ?? "")
-    .digest("hex");
-  return `${toolName}\0${hash}`;
-}
-
-/**
- * Compute the filesystem-state component of the risk cache key for file tools:
- * the symlink-resolved target path(s). Returns `undefined` for non-file tools
- * (whose risk does not depend on filesystem state).
- */
-function fileToolFsStateKey(
-  toolName: string,
-  input: Record<string, unknown>,
-  workingDir?: string,
-): string | undefined {
-  if (!FILE_TOOL_NAMES.has(toolName)) {
-    return undefined;
-  }
-  const resolved = resolveFileToolPaths(toolName, input, workingDir);
-  return `${resolved.resolvedPath ?? ""}\0${resolved.resolvedTransferDestPath ?? ""}\0${resolved.resolvedWorkingDir ?? ""}`;
-}
-
-/** Clear the risk classification cache. Called when trust rules change. Exported for test setup. */
-export function clearRiskCache(): void {
-  riskCache.clear();
-  assessmentCache.clear();
+  /** Scope options for the "save this classification" UI, narrowest to broadest. */
+  scopeOptions: ClassificationResult["scopeOptions"];
+  /**
+   * Directory scope options emitted by the gateway for filesystem operations.
+   * Present when the classifier identified one or more filesystem path
+   * arguments and generated a directory-scope ladder for them.
+   */
+  directoryScopeOptions?: ClassificationResult["directoryScopeOptions"];
+  /** How the risk was determined. */
+  matchType: ClassificationResult["matchType"];
 }
 
 // ── Approval policy singleton ────────────────────────────────────────────────
@@ -416,6 +347,7 @@ function escapeMinimatchLiteral(value: string): string {
 // forwarding to the gateway.
 
 import type {
+  ClassificationResult,
   ClassifyRiskParams,
   FileContext,
   SkillMetadata,
@@ -478,16 +410,6 @@ function resolveClassificationPath(
     : resolveSandboxBase(filePath, workingDir);
   return resolveRealPath(base);
 }
-
-const FILE_TOOL_NAMES = new Set([
-  "file_read",
-  "file_write",
-  "file_edit",
-  "host_file_read",
-  "host_file_write",
-  "host_file_edit",
-  "host_file_transfer",
-]);
 
 interface FileToolResolution {
   filePath: string;
@@ -755,31 +677,6 @@ export async function classifyRisk(
 ): Promise<RiskClassificationWithMeta> {
   signal?.throwIfAborted();
 
-  // Check cache first.
-  const cacheKey = riskCacheKey(
-    toolName,
-    input,
-    workingDir,
-    manifestOverride,
-    fileToolFsStateKey(toolName, input, workingDir),
-  );
-  const cached = riskCache.get(cacheKey);
-  if (cached !== undefined) {
-    // LRU refresh
-    riskCache.delete(cacheKey);
-    riskCache.set(cacheKey, cached);
-    // Re-run the symlink escape check on cache hits: symlink targets can
-    // change between invocations, so a path that was safe when cached may
-    // now escape. Return a shallow copy so the cache entry is not mutated.
-    if (cached.sandboxPathArgs && cached.sandboxPathArgs.length > 0) {
-      const fresh = { ...cached };
-      applyBashSymlinkEscapeCheck(fresh, cached.sandboxPathArgs);
-      return fresh;
-    }
-    return cached;
-  }
-
-  // ── Delegate to gateway via IPC ────────────────────────────────────────────
   const ipcParams = buildClassifyRiskParams(
     toolName,
     input,
@@ -806,6 +703,9 @@ export async function classifyRisk(
     sandboxPathArgs: gatewayResult.sandboxPathArgs,
     allowlistOptions: gatewayResult.allowlistOptions,
     resolvedPaths: gatewayResult.resolvedPaths,
+    scopeOptions: gatewayResult.scopeOptions ?? [],
+    directoryScopeOptions: gatewayResult.directoryScopeOptions,
+    matchType: gatewayResult.matchType ?? "unknown",
   };
 
   // ── Symlink escape check for bash sandbox auto-approve ───────────────
@@ -815,40 +715,7 @@ export async function classifyRisk(
   // `ln -s /etc /workspace/escape`) would pass the lexical check and
   // be auto-approved. Resolve the gateway-provided path args through
   // symlinks here and revoke auto-approve if any escapes the workspace.
-  // The check is also re-run on cache hits (see above) because symlink
-  // targets can change between invocations.
   applyBashSymlinkEscapeCheck(result, gatewayResult.sandboxPathArgs);
-
-  // Cache the result.
-  if (riskCache.size >= RISK_CACHE_MAX) {
-    const oldest = riskCache.keys().next().value;
-    if (oldest !== undefined) {
-      riskCache.delete(oldest);
-    }
-  }
-  riskCache.set(cacheKey, result);
-
-  // Store a RiskAssessment-shaped entry in the assessment cache so that
-  // generateAllowlistOptions() can retrieve gateway-produced allowlistOptions
-  // and permission-checker.ts can populate riskScopeOptions for the Rule
-  // Editor Modal via cachedAssessment.scopeOptions.
-  const assessment: RiskAssessment = {
-    riskLevel: gatewayResult.risk === "unknown" ? "medium" : gatewayResult.risk,
-    reason: gatewayResult.reason,
-    scopeOptions: gatewayResult.scopeOptions ?? [],
-    matchType: gatewayResult.matchType ?? "unknown",
-    allowlistOptions: gatewayResult.allowlistOptions,
-    directoryScopeOptions: gatewayResult.directoryScopeOptions,
-    resolvedPaths: gatewayResult.resolvedPaths,
-  };
-  const aKey = assessmentCacheKey(toolName, input);
-  if (assessmentCache.size >= RISK_CACHE_MAX) {
-    const oldest = assessmentCache.keys().next().value;
-    if (oldest !== undefined) {
-      assessmentCache.delete(oldest);
-    }
-  }
-  assessmentCache.set(aKey, assessment);
 
   return result;
 }
@@ -899,6 +766,14 @@ function isRetrospectiveSkillAuthoringGrant(
   return false;
 }
 
+/**
+ * Decide allow / prompt / deny for one tool invocation.
+ *
+ * `classification` is the invocation's gateway classification when the caller
+ * already holds it (the executor classifies once, before its gates, and hands
+ * it down through `checkPermission`); a caller without one gets a fresh
+ * classification of the same input here.
+ */
 export async function check(
   toolName: string,
   input: Record<string, unknown>,
@@ -906,6 +781,7 @@ export async function check(
   policyContext?: PolicyContext,
   manifestOverride?: ManifestOverride,
   signal?: AbortSignal,
+  classification?: RiskClassificationWithMeta,
 ): Promise<PermissionCheckResult> {
   signal?.throwIfAborted();
 
@@ -917,7 +793,7 @@ export async function check(
     };
   }
 
-  const classification = await classifyRisk(
+  classification ??= await classifyRisk(
     toolName,
     input,
     workingDir,
@@ -936,12 +812,12 @@ export async function check(
   // trust rule arrives as matchType
   // "user_rule" with the risk already lowered (the escape hatch), so leave it
   // untouched. The gateway classifier is authoritative and also returns High;
-  // this local elevation is defense-in-depth for the gateway-unreachable or
-  // under-classified path. The separate non-interactive denial (no human to
-  // approve embedded shell) lives in tools/permission-checker.ts.
+  // this local elevation is defense-in-depth for an under-classified result.
+  // The separate non-interactive denial (no human to approve embedded shell)
+  // lives in tools/permission-checker.ts.
   const risk =
     isDynamicSkillLoadInvocation(toolName, input) &&
-    getCachedAssessment(toolName, input)?.matchType !== "user_rule"
+    classification.matchType !== "user_rule"
       ? RiskLevel.High
       : classifiedRisk;
 
@@ -1249,44 +1125,31 @@ const ALLOWLIST_STRATEGIES: Record<string, AllowlistStrategy> = {
   skill_load: skillLoadAllowlistStrategy,
 };
 
+/**
+ * Allowlist patterns for a permission prompt's "always allow" ladder: the
+ * gateway's own options when its classification of this invocation produced
+ * any, else the per-tool strategy.
+ */
 export async function generateAllowlistOptions(
   toolName: string,
   input: Record<string, unknown>,
+  classification?: RiskClassificationWithMeta,
   signal?: AbortSignal,
 ): Promise<AllowlistOption[]> {
   signal?.throwIfAborted();
 
-  // Use gateway-produced allowlist options from the assessment cache.
-  // For bash/host_bash tools, these are always provided by the gateway.
-  // For other tools that have classifier-produced options, use those too.
-  const aKey = assessmentCacheKey(toolName, input);
-  const cachedAssessment = assessmentCache.get(aKey);
   if (
-    cachedAssessment?.allowlistOptions &&
-    cachedAssessment.allowlistOptions.length > 0
+    classification?.allowlistOptions &&
+    classification.allowlistOptions.length > 0
   ) {
-    return cachedAssessment.allowlistOptions;
+    return classification.allowlistOptions;
   }
 
-  // Fall back to the per-tool strategy function for non-bash tools
-  // or when no cached assessment exists.
   if (Object.hasOwn(ALLOWLIST_STRATEGIES, toolName)) {
     return ALLOWLIST_STRATEGIES[toolName](toolName, input);
   }
 
   return [{ label: "*", description: "Everything", pattern: "*" }];
-}
-
-/**
- * Retrieve a cached RiskAssessment for a given tool invocation.
- * Returns `undefined` when no classifier-backed assessment exists
- * (e.g. MCP tools, unknown tools that fall through to registry defaults).
- */
-export function getCachedAssessment(
-  toolName: string,
-  input: Record<string, unknown>,
-): RiskAssessment | undefined {
-  return assessmentCache.get(assessmentCacheKey(toolName, input));
 }
 
 // Directory-based scope only applies to filesystem and shell tools.

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -802,24 +802,7 @@ export async function check(
     signal,
   );
 
-  const { level: classifiedRisk, reason: riskReason } = classification;
-
-  // Inline-command ("dynamic") skill loads execute embedded shell at load time
-  // via child_process.spawn, outside the tool-approval pipeline that the
-  // auto-approve threshold governs. Treat an uncovered one as High so the
-  // standard threshold decides it like any other high-risk action: it runs at
-  // Full access (autoApproveUpTo "high") and prompts below it. A covering user
-  // trust rule arrives as matchType
-  // "user_rule" with the risk already lowered (the escape hatch), so leave it
-  // untouched. The gateway classifier is authoritative and also returns High;
-  // this local elevation is defense-in-depth for an under-classified result.
-  // The separate non-interactive denial (no human to approve embedded shell)
-  // lives in tools/permission-checker.ts.
-  const risk =
-    isDynamicSkillLoadInvocation(toolName, input) &&
-    classification.matchType !== "user_rule"
-      ? RiskLevel.High
-      : classifiedRisk;
+  const { level: risk, reason: riskReason } = classification;
 
   // Use gateway-provided sandboxAutoApprove instead of evaluating locally.
   const hasSandboxAutoApprove = classification.sandboxAutoApprove ?? false;

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -58,11 +58,11 @@ import {
   resolveSandboxBase,
 } from "./workspace-policy.js";
 
-/** The result of classifyRisk(): a risk level with an optional human-readable reason. */
+/** The result of classifyRisk(): a risk level and the classifier's reason for it. */
 export interface RiskClassification {
   level: RiskLevel;
   /** Human-readable explanation of why this risk level was assigned. */
-  reason?: string;
+  reason: string;
 }
 
 /**

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -430,10 +430,8 @@ interface FileToolResolution {
 
 /**
  * Resolve the security-sensitive path(s) of a file tool invocation, including
- * symlink canonicalization. Shared by the IPC param builder and the risk cache
- * key so both observe the same filesystem state — file risk now depends on
- * symlink targets, so the cache must key on the canonicalized path, not just
- * the raw tool input.
+ * symlink canonicalization, for the IPC params: file risk depends on the
+ * symlink target, not the raw tool input.
  */
 function resolveFileToolPaths(
   toolName: string,
@@ -641,11 +639,9 @@ function riskStringToLevel(risk: string): RiskLevel {
  * with symlink resolution. The gateway's lexical check cannot follow
  * symlinks (no filesystem access), so the daemon resolves each path arg
  * through {@link isPathWithinWorkspaceRoot} (which uses realpathSync) and
- * revokes auto-approve if any escapes the workspace boundary.
- *
- * Called both on fresh gateway results and on cache hits, because symlink
- * targets can change between invocations — a path that was safe on the
- * first call may escape on the second if the symlink was retargeted.
+ * revokes auto-approve if any escapes the workspace boundary. Runs on every
+ * classification, so a symlink retargeted between two invocations of the
+ * same command is caught on the second.
  */
 function applyBashSymlinkEscapeCheck(
   result: RiskClassificationWithMeta,

--- a/assistant/src/permissions/risk-types.ts
+++ b/assistant/src/permissions/risk-types.ts
@@ -1,11 +1,7 @@
 /**
- * Shared risk assessment types used by the permission checker.
- *
- * Classifier-internal types (CommandRiskSpec, ArgRule, ArgSchema, etc.) have
- * been migrated to the gateway and removed from the assistant.
+ * Risk vocabulary shared by the permission checker and the gateway IPC wire
+ * types; the classifiers themselves live in the gateway.
  */
-
-import type { AllowlistOption } from "./types.js";
 
 // ── Risk levels ──────────────────────────────────────────────────────────────
 
@@ -19,7 +15,7 @@ import type { AllowlistOption } from "./types.js";
  */
 export type Risk = "low" | "medium" | "high" | "unknown";
 
-// ── Risk assessment output ───────────────────────────────────────────────────
+// ── Classification scope options ─────────────────────────────────────────────
 
 /** A scope option presented to the user when classifying an unknown command. */
 export interface ScopeOption {
@@ -38,39 +34,4 @@ export interface DirectoryScopeOption {
   scope: string;
   /** Human-readable label (e.g. "In scratch/"). */
   label: string;
-}
-
-/**
- * The output of a risk classifier. Tool-agnostic — every classifier
- * (bash, file_write, web_fetch, etc.) produces this same shape.
- */
-export interface RiskAssessment {
-  /** Computed risk level. */
-  riskLevel: Risk;
-  /** Human-readable explanation of why this risk level was assigned. */
-  reason: string;
-  /** Scope options for the "save this classification" UI, narrowest to broadest. */
-  scopeOptions: ScopeOption[];
-  /** How the risk was determined. */
-  matchType: "user_rule" | "registry" | "unknown";
-  /**
-   * Allowlist options for the permission prompt "always allow" scope ladder.
-   * Populated by classifiers that unify risk classification and scope option
-   * generation. When present, `generateAllowlistOptions()` returns these
-   * directly instead of calling the per-tool strategy function.
-   */
-  allowlistOptions?: AllowlistOption[];
-  /**
-   * Directory scope options emitted by the gateway for filesystem operations.
-   * Mirrors `directoryScopeOptions` in the gateway's ClassificationResult.
-   * Present when the gateway's classifier identified one or more filesystem
-   * path arguments and generated a directory-scope ladder for them.
-   */
-  directoryScopeOptions?: DirectoryScopeOption[];
-  /**
-   * Fully resolved filesystem path arguments from the gateway classifier.
-   * Threaded into `findHighestPriorityRule` so directory-scoped trust rules
-   * match against actual target paths, not just the working directory.
-   */
-  resolvedPaths?: string[];
 }

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -710,19 +710,22 @@ async function handleToolPermissionSimulate({ body = {} }: RouteHandlerArgs) {
       isInteractive === false ? "headless" : "conversation";
     const policyContext = { executionTarget, executionContext } as const;
 
-    const { level: riskLevel } = await classifyRisk(
+    const classification = await classifyRisk(
       toolName,
       input,
       workingDir,
       undefined,
       manifestOverride,
     );
+    const riskLevel = classification.level;
     const result = await check(
       toolName,
       input,
       workingDir,
       policyContext,
       manifestOverride,
+      undefined,
+      classification,
     );
 
     if (isInteractive === false && result.decision === "prompt") {
@@ -743,7 +746,11 @@ async function handleToolPermissionSimulate({ body = {} }: RouteHandlerArgs) {
       | undefined;
 
     if (result.decision === "prompt") {
-      const allowlistOptions = await generateAllowlistOptions(toolName, input);
+      const allowlistOptions = await generateAllowlistOptions(
+        toolName,
+        input,
+        classification,
+      );
       const scopeOptions = generateScopeOptions(workingDir, toolName);
       promptPayload = {
         allowlistOptions,

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -1,8 +1,8 @@
 import { readFile } from "node:fs/promises";
 
 import { getConfig } from "../config/loader.js";
+import { classifyRisk } from "../permissions/checker.js";
 import { PermissionPrompter } from "../permissions/prompter.js";
-import { RiskLevel } from "../permissions/types.js";
 import { runInPluginContext } from "../plugins/plugin-execution-context.js";
 import { TokenExpiredError } from "../security/token-manager.js";
 import {
@@ -30,6 +30,7 @@ import { MAX_FILE_SIZE_BYTES } from "./shared/filesystem/size-guard.js";
 import { ToolApprovalHandler } from "./tool-approval-handler.js";
 import { resolveToolInvocationAlias } from "./tool-name-aliases.js";
 import { recordToolCompletion } from "./tool-profiler.js";
+import { RISK_LEVEL_UNCLASSIFIED } from "./tool-types.js";
 import { type ToolContext, type ToolExecutionResult } from "./types.js";
 
 export class ToolExecutor {
@@ -60,7 +61,28 @@ export class ToolExecutor {
   ): Promise<ToolExecutionResult> {
     const startTime = Date.now();
     let decision = "allow";
-    let riskLevel: string = RiskLevel.Low;
+    // Classified before the gates so every audit row this call can produce
+    // (gate denial, gate error, grant-consumed execution, permission decision)
+    // records the risk of what the model asked for. `checkPermission`
+    // classifies the same input again and hits the classifier cache. A
+    // classification that does not complete (aborted, gateway unreachable) is
+    // recorded as such rather than as a level; the permission check still
+    // requires one and fails closed on its own.
+    let riskLevel: string = RISK_LEVEL_UNCLASSIFIED;
+    try {
+      riskLevel = (
+        await classifyRisk(
+          name,
+          input,
+          context.workingDir,
+          undefined,
+          undefined,
+          context.signal,
+        )
+      ).level;
+    } catch {
+      // Left as RISK_LEVEL_UNCLASSIFIED.
+    }
     let permRiskMeta:
       | {
           riskLevel: string;

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -82,7 +82,7 @@ export class ToolExecutor {
         context.signal,
       );
     } catch {
-      classification = undefined;
+      // Stays undefined; the audit row records RISK_LEVEL_UNCLASSIFIED.
     }
     let riskLevel: string = classification?.level ?? RISK_LEVEL_UNCLASSIFIED;
     let permRiskMeta:

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -1,7 +1,10 @@
 import { readFile } from "node:fs/promises";
 
 import { getConfig } from "../config/loader.js";
-import { classifyRisk } from "../permissions/checker.js";
+import {
+  classifyRisk,
+  type RiskClassificationWithMeta,
+} from "../permissions/checker.js";
 import { PermissionPrompter } from "../permissions/prompter.js";
 import { runInPluginContext } from "../plugins/plugin-execution-context.js";
 import { TokenExpiredError } from "../security/token-manager.js";
@@ -61,28 +64,27 @@ export class ToolExecutor {
   ): Promise<ToolExecutionResult> {
     const startTime = Date.now();
     let decision = "allow";
-    // Classified before the gates so every audit row this call can produce
-    // (gate denial, gate error, grant-consumed execution, permission decision)
-    // records the risk of what the model asked for. `checkPermission`
-    // classifies the same input again and hits the classifier cache. A
-    // classification that does not complete (aborted, gateway unreachable) is
-    // recorded as such rather than as a level; the permission check still
-    // requires one and fails closed on its own.
-    let riskLevel: string = RISK_LEVEL_UNCLASSIFIED;
+    // The invocation's one classification, taken before the gates so every
+    // audit row this call can produce (gate denial, gate error, grant-consumed
+    // execution, permission decision) records the risk of what the model asked
+    // for, then handed down to `checkPermission`. A classification that does
+    // not complete (aborted, gateway unreachable) is recorded as such rather
+    // than as a level; the permission check still requires one and fails
+    // closed on its own.
+    let classification: RiskClassificationWithMeta | undefined;
     try {
-      riskLevel = (
-        await classifyRisk(
-          name,
-          input,
-          context.workingDir,
-          undefined,
-          undefined,
-          context.signal,
-        )
-      ).level;
+      classification = await classifyRisk(
+        name,
+        input,
+        context.workingDir,
+        undefined,
+        undefined,
+        context.signal,
+      );
     } catch {
-      // Left as RISK_LEVEL_UNCLASSIFIED.
+      classification = undefined;
     }
+    let riskLevel: string = classification?.level ?? RISK_LEVEL_UNCLASSIFIED;
     let permRiskMeta:
       | {
           riskLevel: string;
@@ -128,6 +130,11 @@ export class ToolExecutor {
     // consumed; substitute the parsed value (with `.catch()` recoveries
     // applied) so validation and execution see the same input.
     if (gateResult.parsedInput) {
+      // The permission decision is about the input that runs, so a parse that
+      // reshaped it (a `.catch()` recovery) gets its own classification.
+      if (!Bun.deepEquals(input, gateResult.parsedInput)) {
+        classification = undefined;
+      }
       input = gateResult.parsedInput;
     }
 
@@ -211,6 +218,7 @@ export class ToolExecutor {
           context,
           startTime,
           computePreviewDiff,
+          classification,
         );
 
         riskLevel = permResult.riskLevel;

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -6,8 +6,8 @@ import {
   classifyRisk,
   generateAllowlistOptions,
   generateScopeOptions,
-  getCachedAssessment,
   isDynamicSkillLoadInvocation,
+  type RiskClassificationWithMeta,
 } from "../permissions/checker.js";
 import { getAutoApproveThreshold } from "../permissions/gateway-threshold-reader.js";
 import type { PermissionPrompter } from "../permissions/prompter.js";
@@ -37,10 +37,10 @@ export type PermissionDecision =
       decision: string;
       riskLevel: string;
       wasPrompted?: boolean;
-      /** ID of the trust rule that matched this invocation (if any). Always set when a rule matched, even for non-classifier tools where riskMeta is absent. */
+      /** ID of the trust rule that matched this invocation (if any). */
       matchedTrustRuleId?: string;
-      /** Risk metadata from the classifier assessment cache (when available). */
-      riskMeta?: {
+      /** Risk metadata from the invocation's classification. */
+      riskMeta: {
         riskLevel: string;
         riskReason: string;
         riskScopeOptions: Array<{ pattern: string; label: string }>;
@@ -61,10 +61,10 @@ export type PermissionDecision =
       decision: string;
       riskLevel: string;
       content: string;
-      /** ID of the trust rule that matched this invocation (if any). Always set when a rule matched, even for non-classifier tools where riskMeta is absent. */
+      /** ID of the trust rule that matched this invocation (if any). */
       matchedTrustRuleId?: string;
-      /** Risk metadata from the classifier assessment cache (when available). */
-      riskMeta?: {
+      /** Risk metadata from the invocation's classification. */
+      riskMeta: {
         riskLevel: string;
         riskReason: string;
         riskScopeOptions: Array<{ pattern: string; label: string }>;
@@ -89,10 +89,13 @@ export class PermissionChecker {
   }
 
   /**
-   * Run risk classification, trust rule evaluation, and (if needed) user
-   * prompting for a tool invocation. Returns whether the tool is allowed
-   * to execute, along with the decision string and risk level for lifecycle
-   * event reporting.
+   * Run trust rule evaluation and (if needed) user prompting for a tool
+   * invocation. Returns whether the tool is allowed to execute, along with
+   * the decision string and risk level for lifecycle event reporting.
+   *
+   * `classification` is the invocation's gateway classification when the
+   * executor already holds it (it classifies once, before its gates); absent
+   * that, the same input is classified here.
    */
   async checkPermission(
     name: string,
@@ -113,10 +116,11 @@ export class PermissionChecker {
         }
       | undefined
     >,
+    classification?: RiskClassificationWithMeta,
   ): Promise<PermissionDecision> {
     // Sandbox/host routing for the prompt comes from the tool's manifest.
     const executionTarget = resolveExecutionTarget(tool);
-    const { level: risk, reason: riskReason } = await classifyRisk(
+    classification ??= await classifyRisk(
       name,
       input,
       context.workingDir,
@@ -124,26 +128,21 @@ export class PermissionChecker {
       undefined,
       context.signal,
     );
+    const { level: risk, reason: riskReason } = classification;
     const riskLevel: string = risk;
 
-    // Look up the cached assessment to extract risk metadata for the tool result.
-    // This is populated by classifyRisk() for classifier-backed tools (bash, file, web, skill).
-    // For tools without classifiers (e.g. MCP tools), the cache returns undefined.
-    const cachedAssessment = getCachedAssessment(name, input);
-    const riskMeta = cachedAssessment
-      ? {
-          riskLevel: cachedAssessment.riskLevel,
-          riskReason: cachedAssessment.reason,
-          // Display ladder (regex patterns — internal only, not for save).
-          riskScopeOptions: cachedAssessment.scopeOptions,
-          // Save ladder (Minimatch globs — what the gateway matches against).
-          // Populated for classifiers that produce allowlist options
-          // (bash, file, skill); undefined otherwise.
-          riskAllowlistOptions: cachedAssessment.allowlistOptions,
-          riskDirectoryScopeOptions: cachedAssessment.directoryScopeOptions,
-          isContainerized: getIsContainerized(),
-        }
-      : undefined;
+    const riskMeta = {
+      riskLevel: classification.level,
+      riskReason: classification.reason ?? "",
+      // Display ladder (regex patterns — internal only, not for save).
+      riskScopeOptions: classification.scopeOptions,
+      // Save ladder (Minimatch globs — what the gateway matches against).
+      // Populated for classifiers that produce allowlist options
+      // (bash, file, skill); undefined otherwise.
+      riskAllowlistOptions: classification.allowlistOptions,
+      riskDirectoryScopeOptions: classification.directoryScopeOptions,
+      isContainerized: getIsContainerized(),
+    };
 
     // Wrap the rest of permission evaluation so that any exception
     // carries the classified risk level back to the caller. Without
@@ -158,6 +157,7 @@ export class PermissionChecker {
         policyContext,
         undefined,
         context.signal,
+        classification,
       );
 
       // Every threshold read for this invocation must consult the same
@@ -240,7 +240,7 @@ export class PermissionChecker {
       if (
         context.isInteractive === false &&
         isDynamicSkillLoadInvocation(name, input) &&
-        getCachedAssessment(name, input)?.matchType !== "user_rule"
+        classification.matchType !== "user_rule"
       ) {
         log.info(
           { toolName: name, riskLevel },
@@ -388,6 +388,7 @@ export class PermissionChecker {
           allowlistOptions: await generateAllowlistOptions(
             name,
             input,
+            classification,
             context.signal,
           ),
           scopeOptions: generateScopeOptions(context.workingDir, name),
@@ -410,7 +411,7 @@ export class PermissionChecker {
           context.toolUseId,
           riskReason,
           getIsContainerized(),
-          cachedAssessment?.directoryScopeOptions,
+          classification.directoryScopeOptions,
         );
 
         const decision = response.decision;

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -133,7 +133,7 @@ export class PermissionChecker {
 
     const riskMeta = {
       riskLevel: classification.level,
-      riskReason: classification.reason ?? "",
+      riskReason: classification.reason,
       // Display ladder (regex patterns — internal only, not for save).
       riskScopeOptions: classification.scopeOptions,
       // Save ladder (Minimatch globs — what the gateway matches against).

--- a/assistant/src/tools/tool-types.ts
+++ b/assistant/src/tools/tool-types.ts
@@ -49,6 +49,14 @@ export enum RiskLevel {
   High = "high",
 }
 
+/**
+ * `riskLevel` recorded on a `tool_invocations` audit row when the call's risk
+ * was never classified (classification aborted, or the gateway was
+ * unreachable, before any decision was reached). Distinct from every
+ * {@link RiskLevel} so a reader can tell "not assessed" from "assessed as low".
+ */
+export const RISK_LEVEL_UNCLASSIFIED = "unclassified";
+
 export interface ToolDefinition {
   name: string;
   description: string;

--- a/gateway/src/risk/AGENTS.md
+++ b/gateway/src/risk/AGENTS.md
@@ -1,0 +1,9 @@
+# Risk: Agent Instructions
+
+The gateway is the **only** place a tool invocation's risk is classified and the only place trust rules are stored, matched, and applied. `gateway/src/ipc/risk-classification-handlers.ts` (`classify_risk`) is the sole entry point; the assistant calls it exactly once per tool invocation and never classifies locally. See `command-registry/AGENTS.md` for the registry rules.
+
+- **Trust rules live here** (`gateway/src/db/trust-rule-store.ts`, cached by `trust-rule-cache.ts`, seeded at startup by `db/seed-trust-rules.ts` and otherwise mutated only through the gateway HTTP routes, which refresh the cache in-process). A rule reaches the assistant only as the classified level plus `matchType: "user_rule"`; the assistant never sees, stores, or matches rules.
+- **A tool's risk is decided here or not at all.** Tools without a dedicated classifier fall through to the `registryDefaultRisk` the assistant sends (the tool's `defaultRiskLevel`); today that fallback consults no trust rule and emits no allowlist options, so a user rule cannot cover such a tool. Fix that here when it matters, not with a classifier in the assistant.
+- **What you return to the assistant is the whole answer.** Level, reason, `matchType`, allowlist / scope / directory-scope options, command candidates, sandbox flags, and the lexically-resolved path args. The assistant's only adjustment is the bash sandbox symlink-escape re-check, which needs its filesystem and only ever revokes `sandboxAutoApprove`.
+- **The wire shape is mirrored on the assistant side** in `assistant/src/permissions/ipc-risk-types.ts` (`ClassificationResult`); a change to the response here is a change there in the same PR.
+- The assistant's counterpart doc is `assistant/src/permissions/AGENTS.md`; the architecture doc is `assistant/docs/architecture/security.md`.


### PR DESCRIPTION
Fixes LUM-3159
Fixes LUM-3165

## TL;DR

A tool invocation is now classified exactly once, by the gateway, before the pre-execution gates, and that one classification is threaded through `checkPermission` and `check()`. The daemon no longer memoises gateway classifications, no longer re-classifies at each layer, no longer smuggles the gateway's answer between layers through a keyed side-channel, and no longer re-elevates a skill load the gateway already classified. Two user-visible effects: audit rows for gate denials, gate errors, and grant-consumed executions record the call's real risk (they recorded a placeholder `low`), and a trust-rule, config, or skill change takes effect on the next call (a cached input kept its old level until eviction or restart). The architecture doc and two new AGENTS.md files describe the model this leaves in place.

## Why this is the shape, not a re-wire

The obvious fix for LUM-3165 was to wire the daemon cache's invalidation back up (gateway pushes "rules changed" to the daemon). That would have preserved a cache that is wrong by construction: it memoises a function that runs in another process (gateway classifiers + gateway trust rules) over inputs the daemon cannot see (rules, `skills.load.extraDirs`, skill content), which is why it already carried a symlink-resolved filesystem component in its key and an on-hit re-check, and was still stale for three inputs. Its history explains it: the memo was half of #8232 (Feb 2026, "cache shell-parsing and risk classification results"), from when classification ran in the daemon. The expensive half, the tree-sitter shell parse, moved to the gateway with the pipeline (#27824, April) and is memoised there on the command text alone (a pure function; no invalidation needed). Phase 1's plan said "cache key and invalidation logic are unchanged"; #28376 removed the invalidation hook three days later with the daemon trust store and nothing replaced it. JARVIS-577 ("restart needed for trust rules to take effect") was the same symptom in April.

The intended split, which this PR makes the code match, is: **gateway** owns risk classification (v3 trust rules applied inside its classifiers), thresholds and channel-permission cells, and the per-actor `TrustClass` verdict; **assistant** owns the turn's actor and `resolveCapabilities`, the sensitive-tool capability floor, the allow / prompt / deny policy over risk × threshold × capabilities, the prompt, execution, and the `tool_invocations` audit row. Under that split the daemon needs the gateway's answer once per invocation and must not keep or second-guess it. Every part of this PR is that sentence applied:

- **One classification per invocation** (executor, before the gates, handed down): removes the placeholder audit level, the two downstream re-classifications, and the reason a memo ever felt necessary.
- **Delete the memo and the side-channel** (`riskCache`, `assessmentCache`, `getCachedAssessment`, `clearRiskCache`, key builders, on-hit re-check): the daemon cannot invalidate correctly and no longer needs to; the gateway's own parse cache and in-process rule cache are the memo layer.
- **Delete the daemon's local dynamic-skill High elevation**: it duplicated the gateway skill classifier's High (verified equivalent: same `resolveSkillIdAndHash` + `hasInlineExpansions`, same `user_rule` deference; the gateway params also accept `skill_id`, which the local predicate did not, so the local copy could only agree or be narrower). A "defense in depth" copy of a gateway rule is a second source of truth.
- **Type mirrored fields off the wire contract** (`ClassificationResult[...]`) rather than a daemon `RiskAssessment` copy, which is how today's two conflicting `ScopeOption` types happened.
- **Docs**: `security.md`'s permission section described the pre-April model (daemon classifiers, allow/deny/ask rules with priorities in `trust.json`, files that no longer exist). Rewritten from the current code. New `assistant/src/permissions/AGENTS.md` and `gateway/src/risk/AGENTS.md` state the ownership rule where agents read it, so the next change starts from the boundary instead of from `checker.ts`.

## What was there

- **Placeholder audit level.** `executor.ts` seeded `riskLevel = low`, ran the gates with it, and only learned the real level from `checkPermission` afterwards. `auditGateDenied` / `auditGateError` and the grant-consumed path (which skips `checkPermission`) all wrote `low`. LUM-3135's audit table shows identical `bash` calls as `denied low` twice (gate) and `allow high` once (past the gate).
- **A daemon memo of the gateway's answer** plus `getCachedAssessment` re-reads right after `classifyRisk` in the permission checker and the allowlist generator; `check()` classified the same input a second time; `clearRiskCache` said "Called when trust rules change" and had zero production callers.
- **A local re-elevation** in `check()` duplicating the gateway skill classifier.

## What this does

- `classifyRisk` returns one `RiskClassificationWithMeta` carrying everything the daemon reads (level, reason, command candidates, sandbox flags, allowlist / scope / directory-scope options, `matchType`), typed off the IPC wire contract. No caching.
- `executor.ts` classifies once before the gates, passes the level to them (gate audit rows are true) and the classification to `checkPermission`; `checkPermission` passes it to `check()` and `generateAllowlistOptions`. If the gate substituted a Zod-parsed input that differs from the raw one, the pre-gate classification is dropped so the permission decision is about the input that runs.
- Classification that cannot complete (aborted before start, gateway unreachable) records `RISK_LEVEL_UNCLASSIFIED` on the audit row rather than a level; `checkPermission` still requires its own classification in that case and fails closed exactly as before.
- Removed: both caches, both key builders, `fileToolFsStateKey`, the on-hit symlink re-check, `clearRiskCache`, `getCachedAssessment`, the daemon `RiskAssessment` type, the `check()` re-classification, and the local dynamic-skill elevation. The Permission Simulator route classifies once and hands the classification down the same way.

## Why this is safe

- Every decision input is unchanged: same gateway `classify_risk`, same `resolveCapabilities`, same threshold reader, same approval policy. The classification is obtained once and passed rather than re-derived or looked up.
- The bash symlink escape check still runs on every classification (it used to run on miss and on hit; now every call is a miss).
- The removed elevation is provably redundant with the gateway's High (see above); the inline-skill tests now mock the gateway's real answer for a dynamic load instead of relying on the daemon to overrule a `low` mock.
- Cost: for a fresh input, previously one round trip and two memo hits; now one round trip and zero hits. Repeated identical inputs go from zero to one call on the persistent hot-path IPC client, landing on the gateway's parse cache. Zod-reshaped inputs pay one extra classification.
- `riskMeta` on `PermissionDecision` is now always present; it already was in production (the assessment was stored for every gateway result), only tests and a comment described a "no assessment for MCP tools" case.
- `matchedTrustRuleId` remaining null on audit rows is unrelated: #37472 retired its writer deliberately.

## Before / after

| Scenario | Before | After |
| --- | --- | --- |
| Gate denial (guardian-only policy, channel policy, grant/escalation) of a `high` bash call | audited `denied low` | audited `denied high` |
| Gate error (cancelled, unparseable args, unknown tool, disk pressure, schema parse) | audited `error low` | audited with the classified level |
| Execution authorized by a consumed scoped grant | audited `allow low` | audited with the classified level |
| Classification aborted or gateway unreachable | `low` | `unclassified` |
| User raises `curl` to high (or lowers `git push`) in trust rules, then runs an already-classified command | old level until LRU eviction or daemon restart; Permission Simulator shows the stale answer | new level on the next call |
| Config `skills.load.extraDirs` or a skill's content changes | stale for cached inputs | reflected on the next call |
| Uncovered inline-command skill load | High from the gateway, re-asserted locally | High from the gateway |
| Classifications per tool call | 1 to 3 (executor, `checkPermission`, `check()`), memo-dependent | 1 (2 only if Zod reshaped the input) |

## Where this is heading (follow-ups, each its own PR)

1. Move the `classify_risk` contract into `packages/gateway-client` beside the other gateway↔daemon contracts (today `ipc-risk-types.ts` is a hand-mirrored copy), and add a guard test asserting the daemon has one `ipcClassifyRisk` call site and no local classifier.
2. Finish the option migration: the gateway already emits allowlist options for bash/file/skill; the daemon still carries per-tool fallback strategies (web/network/managed-skill/skill_load) and the workingDir scope ladder, and the gateway's `buildShellAllowlistOptions` is dead code. The web classifier declines to emit options only because URL normalisation lives in daemon `checker.ts`.
3. Split `permissions/checker.ts` (1.1k lines, reads like a classifier) into the gateway client, the approval decision, and skill predicates; drop the duplicate `checker.test.ts`.
4. Same class as LUM-3165, tracked as LUM-3324: the threshold reader's TTL caches of gateway-owned thresholds and cells with no invalidation path.
5. Gateway fallback for classifier-less (MCP) tools consults no trust rule and emits no options, so a rule cannot cover them (JARVIS-719 named this and proposed a daemon-side classifier; cancelled; the fix is gateway-side).

## Verification

- `tool-executor-lifecycle-events.test.ts`: gate-denied `high` bash, gate-error `medium` unknown tool, grant-consumed `high` file_write, gateway-unreachable `unclassified` on both paths, aborted-before-start `unclassified`; each returned `low` under the old code.
- `permissions/checker.test.ts`: `classifyRisk` carries reason/matchType/allowlist/scope/directory-scope options; a changed gateway answer for the same input is returned (not memoised); symlink retarget and escape re-check kept as behaviour tests; the "caches results for identical inputs" test removed with the cache.
- `inline-skill-load-permissions.test.ts`: dynamic-load cases mock the gateway's real `high` answer.
- `tool-executor.test.ts`: the classification override drives `riskMeta` through the mocked `classifyRisk` instead of a mocked `getCachedAssessment`.
- `bun run typecheck`, eslint, prettier clean. Local `bun test` is hook-blocked; CI runs the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
