### PR TITLE
fix(web): keep unlisted openai-compatible model ids in the profile editor

### DIFF
--- a/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -1429,6 +1429,35 @@ describe("ProfileEditorModal edit mode — catalog-absent bound model", () => {
     expect(optionLabels).toContain("openrouter/fusion");
   });
 
+  test("renders a bound openai-compatible model the connection list omits, and keeps Save enabled", () => {
+    // An openai-compatible profile can be bound to a pass-through id
+    // (gateway alias, unrefreshed model) that the connection's returned
+    // list does not include. The Model field still shows that id, and
+    // Save stays enabled.
+    const lmStudio = {
+      ...makeConnection("lm-studio", "openai-compatible"),
+      models: [{ id: "llama-3.1", displayName: "Llama 3.1" }],
+    } as unknown as ProviderConnection;
+
+    renderEdit(
+      {
+        name: "local-llm",
+        label: "Local LLM",
+        provider: "openai-compatible",
+        model: "gateway-alias",
+        provider_connection: "lm-studio",
+        status: "active",
+      },
+      lmStudio,
+    );
+
+    const triggerLabels = selectTriggers().map((t) => t.textContent?.trim());
+    expect(triggerLabels).toContain("gateway-alias");
+    expect(triggerLabels).not.toContain("Select a model");
+    expect(document.body.textContent).not.toContain("Select a model.");
+    expect(getSaveBtn().disabled).toBe(false);
+  });
+
   test("clears a catalog model the connection's subscription filters out, rather than offering it", async () => {
     // A ChatGPT-subscription OpenAI connection only accepts the Codex-compatible
     // model set, so a profile pinned to an in-catalog but non-Codex model

--- a/clients/web/src/domains/settings/ai/profile-editor-provider-section.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-provider-section.test.tsx
@@ -98,3 +98,42 @@ describe("ProfileEditorProviderSection with a ChatGPT subscription", () => {
     );
   });
 });
+
+describe("ProfileEditorProviderSection with an openai-compatible connection", () => {
+  const connection = {
+    name: "lm-studio",
+    provider: "openai-compatible",
+    auth: { type: "api_key", credential: "credential/openai-compatible/api_key" },
+    models: [{ id: "llama-3.1", displayName: "Llama 3.1" }],
+  };
+
+  test("keeps a bound model the connection list omits instead of clearing it", () => {
+    const onModelChange = mock(() => {});
+    renderSection({
+      provider: "openai-compatible",
+      model: "gateway-alias",
+      providerConnection: "lm-studio",
+      connections: [connection],
+      availableConnectionsForProvider: [connection],
+      onModelChange,
+    });
+
+    expect(onModelChange).not.toHaveBeenCalled();
+    expect(screen.getByLabelText("Model").textContent?.trim()).toBe(
+      "gateway-alias",
+    );
+  });
+
+  test("offers the unlisted bound model in the Model dropdown", () => {
+    renderSection({
+      provider: "openai-compatible",
+      model: "gateway-alias",
+      providerConnection: "lm-studio",
+      connections: [connection],
+      availableConnectionsForProvider: [connection],
+    });
+
+    fireEvent.click(screen.getByLabelText("Model"));
+    expect(optionLabels()).toContain("gateway-alias");
+  });
+});

--- a/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
@@ -309,30 +309,29 @@ export function ProfileEditorProviderSection({
     }
   }, [modelEmptyState, t]);
 
-  // Clear the bound model when it isn't selectable for the current connection.
-  // Per-connection providers (openai-compatible) derive their model list from
-  // the connection, so a binding the connection doesn't offer must clear. For a
-  // catalog-backed provider a model that's entirely absent from the catalog is a
-  // newer/cloaked model the build doesn't list — keep it, clearing it would wipe
-  // a working profile. But a model that IS in the catalog yet filtered out of
-  // availableModels (e.g. a non-Codex model under a ChatGPT subscription
-  // connection) is a known-incompatible binding and still clears. The parent's
-  // handleProviderChange resets the model on provider switch, so this never
-  // strands a cross-provider binding.
+  // Clear only a catalog model the current connection has filtered out
+  // (e.g. a non-Codex model under a ChatGPT subscription). Pass-through ids
+  // stay: connection lists are advisory (gateway aliases, unrefreshed models),
+  // and a catalog-backed id this build doesn't list is a newer/cloaked model.
+  // `modelOptions` already offers those ids. The parent's handleProviderChange
+  // resets the model on provider switch, so this never strands a
+  // cross-provider binding.
   useEffect(() => {
     if (!provider) {
       return;
     }
     // While the user is typing a custom id it won't match the catalog or
-    // connection lists — leave it untouched instead of clearing every keystroke.
+    // connection lists, so leave it untouched instead of clearing every keystroke.
     if (isEnteringCustomModel) {
       return;
     }
     const catalogModels = getModelsForProvider(provider);
-    if (
-      catalogModels.length > 0 &&
-      !catalogModels.some((m) => m.id === model)
-    ) {
+    // Connection-derived providers (openai-compatible) have an empty catalog.
+    // An id the connection does not list is still a valid bound model.
+    if (catalogModels.length === 0) {
+      return;
+    }
+    if (!catalogModels.some((m) => m.id === model)) {
       return;
     }
     if (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan
Fix https://github.com/vellum-ai/vellum-assistant/issues/40697 (EPD-2911). Opening an openai-compatible profile whose bound model is absent from the connection's returned list was clearing the Model field, showing the placeholder, and disabling Save. The profile itself was healthy: the CLI and config still carried the id, and requests dispatched normally.

The editor already appends that bound id to `modelOptions`. The effect that "clears the bound model when it isn't selectable" still treated a connection-derived (empty-catalog) provider as a must-clear case. Connection lists are advisory: pass-through ids such as gateway aliases and unrefreshed models remain valid. Catalog-backed providers keep the existing behavior, including clearing a known-incompatible Codex-filtered model.

Closes #40697
Closes EPD-2911

## Summary
- Skip auto-clear for connection-derived providers (`openai-compatible`), whose catalog is empty.
- Keep clearing catalog models that the current connection has filtered out (ChatGPT subscription / Codex).
- Cover the keep path in unit and modal tests.

## Test plan
- [x] `cd clients/web && bun test src/domains/settings/ai/profile-editor-provider-section.test.tsx src/domains/settings/ai/profile-editor-modal.test.tsx` (76 pass, 0 fail)
- [x] ChatGPT-subscription incompatible-model clear case still passes

## Risk
Low. Edit-mode UI only. Subscription-restricted catalog filtering is unchanged. Switching openai-compatible connections still clears a model the new connection does not list (`handleConnectionChange`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4bd86594-d05d-43b1-ac18-d57e36eb9b02?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4bd86594-d05d-43b1-ac18-d57e36eb9b02&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

