### PR TITLE
fix(providers): omit tool_choice in thinking mode for strict OpenAI-compatible endpoints

### DIFF
--- a/assistant/src/providers/inference/__tests__/adapter-factory-openai-compatible.test.ts
+++ b/assistant/src/providers/inference/__tests__/adapter-factory-openai-compatible.test.ts
@@ -43,6 +43,10 @@ describe("adapter factory", () => {
       useNativeWebSearch: false,
     });
     expect(adapter).toBeInstanceOf(OpenAIChatCompletionsProvider);
+    expect(
+      (adapter as unknown as { omitToolChoiceWhenReasoning: boolean })
+        .omitToolChoiceWhenReasoning,
+    ).toBe(true);
   });
 
   test("createAdapterFromConnection wires baseURL from ResolvedAuth", () => {

--- a/assistant/src/providers/inference/adapter-factory.ts
+++ b/assistant/src/providers/inference/adapter-factory.ts
@@ -139,6 +139,9 @@ const ADAPTER_FACTORIES: Record<string, AdapterFactory> = {
       providerName: "openai-compatible",
       providerLabel: "OpenAI-compatible",
       streamTimeoutMs,
+      // Custom OpenAI-compatible endpoints may front strict reasoning
+      // models (DeepSeek thinking) that 400 on any explicit tool_choice.
+      omitToolChoiceWhenReasoning: true,
       ...(baseURL ? { baseURL } : {}),
     }),
   minimax: ({ apiKey, model, streamTimeoutMs }) =>

--- a/assistant/src/providers/openai/__tests__/chat-completions-provider-reasoning.test.ts
+++ b/assistant/src/providers/openai/__tests__/chat-completions-provider-reasoning.test.ts
@@ -537,50 +537,47 @@ describe("OpenAIChatCompletionsProvider reasoning parsing", () => {
   });
 });
 
-describe("reasoning opt-out rejection fallback", () => {
-  function stubProviderWithErrors(
-    errors: unknown[],
-    chunks: MockChunk[],
-  ): { provider: OpenAIChatCompletionsProvider; requests: unknown[] } {
-    const provider = new OpenAIChatCompletionsProvider(
-      "test-key",
-      "test-model",
-    );
-    const requests: unknown[] = [];
-    const pending = [...errors];
-    (provider as unknown as { client: unknown }).client = {
-      chat: {
-        completions: {
-          create: async (params: unknown) => {
-            // Snapshot: the fallback mutates `params` between attempts.
-            requests.push(JSON.parse(JSON.stringify(params)));
-            const error = pending.shift();
-            if (error !== undefined) {
-              throw error;
-            }
-            return makeStream(chunks);
-          },
+function stubProviderWithErrors(
+  errors: unknown[],
+  chunks: MockChunk[],
+): { provider: OpenAIChatCompletionsProvider; requests: unknown[] } {
+  const provider = new OpenAIChatCompletionsProvider("test-key", "test-model");
+  const requests: unknown[] = [];
+  const pending = [...errors];
+  (provider as unknown as { client: unknown }).client = {
+    chat: {
+      completions: {
+        create: async (params: unknown) => {
+          // Snapshot: the fallback mutates `params` between attempts.
+          requests.push(JSON.parse(JSON.stringify(params)));
+          const error = pending.shift();
+          if (error !== undefined) {
+            throw error;
+          }
+          return makeStream(chunks);
         },
       },
-    };
-    return { provider, requests };
-  }
-
-  const okChunks: MockChunk[] = [
-    {
-      choices: [{ delta: { content: "ok" }, finish_reason: "stop" }],
-      usage: { prompt_tokens: 1, completion_tokens: 1 },
     },
-  ];
+  };
+  return { provider, requests };
+}
 
-  function rejection(message: string, status = 400): Error {
-    return Object.assign(new Error(message), { status });
-  }
+const OK_CHUNKS: MockChunk[] = [
+  {
+    choices: [{ delta: { content: "ok" }, finish_reason: "stop" }],
+    usage: { prompt_tokens: 1, completion_tokens: 1 },
+  },
+];
 
+function rejection(message: string, status = 400): Error {
+  return Object.assign(new Error(message), { status });
+}
+
+describe("reasoning opt-out rejection fallback", () => {
   test("retries once without reasoning params when a model rejects the explicit opt-out", async () => {
     const { provider, requests } = stubProviderWithErrors(
       [rejection("reasoning_effort 'none' is not supported for this model")],
-      okChunks,
+      OK_CHUNKS,
     );
 
     const response = await provider.sendMessage(
@@ -626,7 +623,7 @@ describe("reasoning opt-out rejection fallback", () => {
     // can only fire off the normalized upstream detail.
     expect(/reasoning/i.test(wrapped.message)).toBe(false);
 
-    const { provider, requests } = stubProviderWithErrors([wrapped], okChunks);
+    const { provider, requests } = stubProviderWithErrors([wrapped], OK_CHUNKS);
 
     const response = await provider.sendMessage(
       [{ role: "user", content: [{ type: "text", text: "hi" }] }],
@@ -651,7 +648,7 @@ describe("reasoning opt-out rejection fallback", () => {
   test("does not retry when the request did not opt out of reasoning", async () => {
     const { provider, requests } = stubProviderWithErrors(
       [rejection("reasoning_effort is invalid")],
-      okChunks,
+      OK_CHUNKS,
     );
 
     await expect(
@@ -666,7 +663,7 @@ describe("reasoning opt-out rejection fallback", () => {
   test("does not retry a 4xx that does not name reasoning", async () => {
     const { provider, requests } = stubProviderWithErrors(
       [rejection("invalid api key")],
-      okChunks,
+      OK_CHUNKS,
     );
 
     await expect(
@@ -681,13 +678,139 @@ describe("reasoning opt-out rejection fallback", () => {
   test("does not retry server errors", async () => {
     const { provider, requests } = stubProviderWithErrors(
       [rejection("reasoning backend unavailable", 500)],
-      okChunks,
+      OK_CHUNKS,
     );
 
     await expect(
       provider.sendMessage(
         [{ role: "user", content: [{ type: "text", text: "hi" }] }],
         { config: { effort: "none" } },
+      ),
+    ).rejects.toThrow();
+    expect(requests).toHaveLength(1);
+  });
+});
+
+describe("thinking-mode tool_choice rejection fallback", () => {
+  test("retries once without tool_choice when thinking mode rejects it", async () => {
+    const { provider, requests } = stubProviderWithErrors(
+      [rejection("Thinking mode does not support this tool_choice")],
+      OK_CHUNKS,
+    );
+
+    const response = await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      {
+        tools: [
+          {
+            name: "bash",
+            description: "Run a shell command",
+            input_schema: { type: "object", properties: {} },
+          },
+        ],
+        config: { tool_choice: { type: "none" }, effort: "high" },
+      },
+    );
+
+    expect(requests).toHaveLength(2);
+    const first = requests[0] as {
+      tool_choice?: string;
+      reasoning_effort?: string;
+    };
+    const second = requests[1] as {
+      tool_choice?: string;
+      reasoning_effort?: string;
+    };
+    expect(first.tool_choice).toBe("none");
+    expect(first.reasoning_effort).toBe("high");
+    expect(second.tool_choice).toBeUndefined();
+    expect(second.reasoning_effort).toBe("high");
+    const text = response.content.find((b) => b.type === "text") as
+      | { type: "text"; text: string }
+      | undefined;
+    expect(text?.text).toBe("ok");
+  });
+
+  test("retries once for an OpenRouter-wrapped thinking-mode tool_choice rejection", async () => {
+    const wrapped = new OpenAI.APIError(
+      400,
+      {
+        code: 400,
+        message: "Provider returned error",
+        metadata: {
+          raw: "[invalid_request_error] Thinking mode does not support this tool_choice",
+          provider_name: "deepseek",
+        },
+      },
+      undefined,
+      new Headers(),
+    );
+    expect(/tool_choice/i.test(wrapped.message)).toBe(false);
+
+    const { provider, requests } = stubProviderWithErrors([wrapped], OK_CHUNKS);
+
+    await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      {
+        tools: [
+          {
+            name: "bash",
+            description: "Run a shell command",
+            input_schema: { type: "object", properties: {} },
+          },
+        ],
+        config: { tool_choice: { type: "none" }, effort: "high" },
+      },
+    );
+
+    expect(requests).toHaveLength(2);
+    expect((requests[0] as { tool_choice?: string }).tool_choice).toBe("none");
+    expect((requests[1] as { tool_choice?: string }).tool_choice).toBeUndefined();
+  });
+
+  test("does not retry a 4xx that does not name tool_choice", async () => {
+    const { provider, requests } = stubProviderWithErrors(
+      [rejection("invalid api key")],
+      OK_CHUNKS,
+    );
+
+    await expect(
+      provider.sendMessage(
+        [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+        {
+          tools: [
+            {
+              name: "bash",
+              description: "Run a shell command",
+              input_schema: { type: "object", properties: {} },
+            },
+          ],
+          config: { tool_choice: { type: "none" }, effort: "high" },
+        },
+      ),
+    ).rejects.toThrow();
+    expect(requests).toHaveLength(1);
+  });
+
+  test("does not retry thinking-mode tool_choice 500s", async () => {
+    const { provider, requests } = stubProviderWithErrors(
+      [rejection("Thinking mode does not support this tool_choice", 500)],
+      OK_CHUNKS,
+    );
+
+    await expect(
+      provider.sendMessage(
+        [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+        {
+          tools: [
+            {
+              name: "bash",
+              description: "Run a shell command",
+              input_schema: { type: "object", properties: {} },
+            },
+          ],
+          config: { tool_choice: { type: "none" }, effort: "high" },
+        },
       ),
     ).rejects.toThrow();
     expect(requests).toHaveLength(1);

--- a/assistant/src/providers/openai/__tests__/tool-choice-mapping.test.ts
+++ b/assistant/src/providers/openai/__tests__/tool-choice-mapping.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import type { Message, ToolDefinition } from "../../types.js";
 import {
+  isThinkingEnabledOnWire,
   mapNeutralToolChoice,
   OpenAIChatCompletionsProvider,
 } from "../chat-completions-provider.js";
@@ -23,11 +24,17 @@ const USER_MESSAGE: Message[] = [
  * Stub the SDK client so we can capture the outgoing chat.completions.create
  * params without hitting the network.
  */
-function stubChatProvider(): {
+function stubChatProvider(
+  options?: ConstructorParameters<typeof OpenAIChatCompletionsProvider>[2],
+): {
   provider: OpenAIChatCompletionsProvider;
   requests: Array<Record<string, unknown>>;
 } {
-  const provider = new OpenAIChatCompletionsProvider("test-key", "test-model");
+  const provider = new OpenAIChatCompletionsProvider(
+    "test-key",
+    "test-model",
+    options,
+  );
   const requests: Array<Record<string, unknown>> = [];
   (provider as unknown as { client: unknown }).client = {
     chat: {
@@ -48,6 +55,23 @@ function stubChatProvider(): {
   };
   return { provider, requests };
 }
+
+describe("isThinkingEnabledOnWire", () => {
+  test("detects flat reasoning_effort and nested reasoning flags", () => {
+    expect(isThinkingEnabledOnWire({})).toBe(false);
+    expect(isThinkingEnabledOnWire({ reasoning_effort: "none" })).toBe(false);
+    expect(isThinkingEnabledOnWire({ reasoning_effort: "high" })).toBe(true);
+    expect(isThinkingEnabledOnWire({ reasoning: { effort: "none" } })).toBe(
+      false,
+    );
+    expect(isThinkingEnabledOnWire({ reasoning: { effort: "medium" } })).toBe(
+      true,
+    );
+    expect(isThinkingEnabledOnWire({ reasoning: { enabled: true } })).toBe(
+      true,
+    );
+  });
+});
 
 describe("mapNeutralToolChoice (chat-completions wire format)", () => {
   // Each neutral tool_choice variant maps to its OpenAI-compatible form.
@@ -143,5 +167,104 @@ describe("OpenAIChatCompletionsProvider tool_choice wiring", () => {
     // THEN the request omits both tools and tool_choice
     expect(requests[0].tools).toBeUndefined();
     expect(requests[0].tool_choice).toBeUndefined();
+  });
+
+  // `"auto"` is the chat-completions default when tools are present. Sending it
+  // alongside reasoning_effort 400s DeepSeek thinking mode, so it is omitted.
+  test("omits redundant tool_choice auto when thinking is on the wire", async () => {
+    const { provider, requests } = stubChatProvider();
+
+    await provider.sendMessage(USER_MESSAGE, {
+      tools: TOOLS,
+      config: { tool_choice: { type: "auto" }, effort: "high" },
+    });
+
+    expect(requests[0].reasoning_effort).toBe("high");
+    expect(requests[0].tool_choice).toBeUndefined();
+    expect(requests[0].tools).toBeDefined();
+  });
+
+  test("omits redundant tool_choice auto when nested reasoning.enabled is set", async () => {
+    const { provider, requests } = stubChatProvider({
+      extraCreateParams: { reasoning: { enabled: true } },
+    });
+
+    await provider.sendMessage(USER_MESSAGE, {
+      tools: TOOLS,
+      config: { tool_choice: { type: "auto" } },
+    });
+
+    expect(requests[0].tool_choice).toBeUndefined();
+  });
+
+  test("forwards tool_choice auto when thinking is off", async () => {
+    const { provider, requests } = stubChatProvider();
+
+    await provider.sendMessage(USER_MESSAGE, {
+      tools: TOOLS,
+      config: { tool_choice: { type: "auto" } },
+    });
+
+    expect(requests[0].tool_choice).toBe("auto");
+  });
+
+  // Catalog providers (Fireworks, Together) honor `none` with thinking.
+  test("forwards tool_choice none with thinking when omitToolChoiceWhenReasoning is off", async () => {
+    const { provider, requests } = stubChatProvider();
+
+    await provider.sendMessage(USER_MESSAGE, {
+      tools: TOOLS,
+      config: { tool_choice: { type: "none" }, effort: "high" },
+    });
+
+    expect(requests[0].reasoning_effort).toBe("high");
+    expect(requests[0].tool_choice).toBe("none");
+  });
+
+  test("forwards a forced tool_choice with thinking when omitToolChoiceWhenReasoning is off", async () => {
+    const { provider, requests } = stubChatProvider();
+
+    await provider.sendMessage(USER_MESSAGE, {
+      tools: TOOLS,
+      config: { tool_choice: { type: "tool", name: "bash" }, effort: "high" },
+    });
+
+    expect(requests[0].tool_choice).toEqual({
+      type: "function",
+      function: { name: "bash" },
+    });
+  });
+
+  test("omits every tool_choice in thinking mode when omitToolChoiceWhenReasoning is on", async () => {
+    const { provider, requests } = stubChatProvider({
+      omitToolChoiceWhenReasoning: true,
+    });
+
+    await provider.sendMessage(USER_MESSAGE, {
+      tools: TOOLS,
+      config: { tool_choice: { type: "none" }, effort: "high" },
+    });
+    await provider.sendMessage(USER_MESSAGE, {
+      tools: TOOLS,
+      config: { tool_choice: { type: "tool", name: "bash" }, effort: "high" },
+    });
+
+    expect(requests[0].reasoning_effort).toBe("high");
+    expect(requests[0].tool_choice).toBeUndefined();
+    expect(requests[1].tool_choice).toBeUndefined();
+  });
+
+  test("still forwards tool_choice when omitToolChoiceWhenReasoning is on but thinking is off", async () => {
+    const { provider, requests } = stubChatProvider({
+      omitToolChoiceWhenReasoning: true,
+    });
+
+    await provider.sendMessage(USER_MESSAGE, {
+      tools: TOOLS,
+      config: { tool_choice: { type: "none" } },
+    });
+
+    expect(requests[0].reasoning_effort).toBeUndefined();
+    expect(requests[0].tool_choice).toBe("none");
   });
 });

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -177,6 +177,13 @@ export interface OpenAIChatCompletionsProviderOptions {
    *  with minimax-m3 on Fireworks). Off by default; scalars/arrays unaffected.
    *  See {@link coerceObjectParamsToJsonString}. */
   coerceObjectArgsToJsonString?: boolean;
+  /** Drop `tool_choice` when thinking/reasoning is on the wire. Strict
+   *  OpenAI-compatible reasoning upstreams (DeepSeek thinking mode) reject any
+   *  explicit `tool_choice` with `Thinking mode does not support this
+   *  tool_choice`. Off by default so catalog providers that honor the combo
+   *  (Fireworks, Together) keep sending `none` / forced choices. Enabled for
+   *  the generic `openai-compatible` adapter, whose upstream is unknown. */
+  omitToolChoiceWhenReasoning?: boolean;
 }
 
 const log = getLogger("chat-completions");
@@ -219,12 +226,29 @@ export function clampReasoningEffort(
     : value;
 }
 
+/** Human-readable text from an OpenAI-compatible error, including wrapped
+ *  upstream detail (OpenRouter `metadata.raw`). Used by the one-shot
+ *  compatibility retries so a generic SDK wrapper message cannot hide the
+ *  real reason. */
+function openaiCompatErrorHaystack(error: unknown): string {
+  return error instanceof OpenAI.APIError
+    ? normalizedErrorText(normalizeOpenAIAPIError(error))
+    : error instanceof Error
+      ? error.message
+      : String(error);
+}
+
+function isClientErrorStatus(error: unknown): boolean {
+  const status = (error as { status?: unknown }).status;
+  return typeof status === "number" && status >= 400 && status < 500;
+}
+
 /**
  * True when the request carried an explicit reasoning opt-out (`"none"` sent
  * as flat `reasoning_effort` or nested `reasoning.effort`) and the provider
  * rejected it with a 4xx that names the reasoning field. Reasoning-only
  * models (e.g. DeepSeek R1) reject the opt-out rather than ignore it; that
- * one case is worth a single retry with the reasoning params stripped —
+ * one case is worth a single retry with the reasoning params stripped:
  * model-default reasoning beats a hard failure.
  */
 function isReasoningOptOutRejection(error: unknown, params: unknown): boolean {
@@ -240,22 +264,58 @@ function isReasoningOptOutRejection(error: unknown, params: unknown): boolean {
   if (!optedOut) {
     return false;
   }
-  const status = (error as { status?: unknown }).status;
-  if (typeof status !== "number" || status < 400 || status >= 500) {
+  if (!isClientErrorStatus(error)) {
     return false;
   }
-  // OpenRouter wraps upstream 4xxs in a generic "Provider returned error" and
-  // stashes the real reason under `metadata.raw`, which `normalizeOpenAIAPIError`
-  // promotes into the normalized fields. Scan those, not just `error.message` —
-  // otherwise the wrapped reasoning rejection is missed and this one-shot
-  // fallback never fires.
-  const haystack =
-    error instanceof OpenAI.APIError
-      ? normalizedErrorText(normalizeOpenAIAPIError(error))
-      : error instanceof Error
-        ? error.message
-        : String(error);
-  return /reasoning/i.test(haystack);
+  return /reasoning/i.test(openaiCompatErrorHaystack(error));
+}
+
+/**
+ * True when thinking/reasoning is active on the outbound chat-completions
+ * body: a non-`"none"` `reasoning_effort`, a nested `reasoning.effort`, or
+ * `reasoning.enabled: true` (OpenRouter / Vercel AI Gateway).
+ */
+export function isThinkingEnabledOnWire(params: unknown): boolean {
+  const p = params as {
+    reasoning_effort?: unknown;
+    reasoning?: { effort?: unknown; enabled?: unknown } | null;
+  };
+  const nested = p.reasoning;
+  if (nested && typeof nested === "object") {
+    if (nested.enabled === true) {
+      return true;
+    }
+    if (typeof nested.effort === "string" && nested.effort !== "none") {
+      return true;
+    }
+  }
+  return (
+    typeof p.reasoning_effort === "string" && p.reasoning_effort !== "none"
+  );
+}
+
+/**
+ * True when the request sent an explicit `tool_choice` and the provider
+ * rejected it because thinking/reasoning mode forbids that parameter.
+ * DeepSeek thinking mode 400s with `Thinking mode does not support this
+ * tool_choice` for any explicit value, including `"auto"` and `"none"`.
+ * One retry without `tool_choice` lets the same provider succeed instead of
+ * failing over to a different backend.
+ */
+function isThinkingModeToolChoiceRejection(
+  error: unknown,
+  params: unknown,
+): boolean {
+  const p = params as { tool_choice?: unknown };
+  if (p.tool_choice === undefined) {
+    return false;
+  }
+  if (!isClientErrorStatus(error)) {
+    return false;
+  }
+  return /does not support this tool_choice/i.test(
+    openaiCompatErrorHaystack(error),
+  );
 }
 
 /**
@@ -334,6 +394,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
     | undefined;
   private backfillEmptyAssistantContent: boolean;
   private coerceObjectArgsToJsonString: boolean;
+  private omitToolChoiceWhenReasoning: boolean;
 
   constructor(
     apiKey: string,
@@ -363,6 +424,8 @@ export class OpenAIChatCompletionsProvider implements Provider {
       options.backfillEmptyAssistantContent ?? false;
     this.coerceObjectArgsToJsonString =
       options.coerceObjectArgsToJsonString ?? false;
+    this.omitToolChoiceWhenReasoning =
+      options.omitToolChoiceWhenReasoning ?? false;
   }
 
   get defaultModel(): string {
@@ -469,11 +532,24 @@ export class OpenAIChatCompletionsProvider implements Provider {
 
         // Honor a caller-supplied tool_choice (e.g. `{ type: "none" }` to force
         // a text-only answer, or `{ type: "tool", name }` for a forced call).
-        // Only meaningful when tools are present — OpenAI rejects a named or
+        // Only meaningful when tools are present: OpenAI rejects a named or
         // "required" choice with no tools.
+        //
+        // Strict reasoning upstreams (DeepSeek thinking mode) reject any
+        // explicit tool_choice, including `"auto"` (the API default when tools
+        // are present) and `"none"`. Omit `"auto"` whenever thinking is on the
+        // wire. Catalog providers that honor `none` / forced choices still
+        // receive them; the generic openai-compatible adapter drops every
+        // explicit value in thinking mode via `omitToolChoiceWhenReasoning`.
         const toolChoice = mapNeutralToolChoice(configObj?.tool_choice);
         if (toolChoice !== undefined) {
-          params.tool_choice = toolChoice;
+          const thinkingOn = isThinkingEnabledOnWire(params);
+          const skipAutoDefault = thinkingOn && toolChoice === "auto";
+          const skipAllChoices =
+            thinkingOn && this.omitToolChoiceWhenReasoning;
+          if (!skipAutoDefault && !skipAllChoices) {
+            params.tool_choice = toolChoice;
+          }
         }
       }
 
@@ -573,20 +649,32 @@ export class OpenAIChatCompletionsProvider implements Provider {
         try {
           stream = await createStream();
         } catch (error) {
-          if (!isReasoningOptOutRejection(error, params)) {
+          if (isReasoningOptOutRejection(error, params)) {
+            log.warn(
+              {
+                provider: this.name,
+                model: modelOverride ?? this.model,
+                error: error instanceof Error ? error.message : String(error),
+              },
+              "Model rejected the explicit reasoning opt-out; retrying without reasoning params",
+            );
+            delete params.reasoning_effort;
+            delete (params as unknown as Record<string, unknown>).reasoning;
+            stream = await createStream();
+          } else if (isThinkingModeToolChoiceRejection(error, params)) {
+            log.warn(
+              {
+                provider: this.name,
+                model: modelOverride ?? this.model,
+                error: error instanceof Error ? error.message : String(error),
+              },
+              "Upstream rejected tool_choice in thinking mode; retrying without tool_choice",
+            );
+            delete params.tool_choice;
+            stream = await createStream();
+          } else {
             throw error;
           }
-          log.warn(
-            {
-              provider: this.name,
-              model: modelOverride ?? this.model,
-              error: error instanceof Error ? error.message : String(error),
-            },
-            "Model rejected the explicit reasoning opt-out; retrying without reasoning params",
-          );
-          delete params.reasoning_effort;
-          delete (params as unknown as Record<string, unknown>).reasoning;
-          stream = await createStream();
         }
 
         for await (const chunk of stream) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan
Fix https://github.com/vellum-ai/vellum-assistant/issues/40689 (EPD-2907). DeepSeek thinking mode rejects any explicit `tool_choice` (including `"auto"` and `"none"`), so custom OpenAI-compatible providers 400 during compaction (`tool_choice: none`) and main-agent turns (`tool_choice: auto`) instead of succeeding on the primary provider.

## Summary
- Omit redundant `tool_choice: "auto"` whenever thinking/reasoning is on the chat-completions wire (it is the API default when tools are present).
- Enable `omitToolChoiceWhenReasoning` on the generic `openai-compatible` adapter so thinking-mode requests do not send `none` / forced choices either. Catalog providers (Fireworks, Together) keep sending those values.
- If a strict upstream still 400s with `Thinking mode does not support this tool_choice`, retry once on the same provider without `tool_choice` (covers default-on thinking models such as R1, and wrapped OpenRouter errors).

Closes #40689
Closes EPD-2907

## Test plan
- [x] `cd assistant && bun test src/providers/openai/__tests__/tool-choice-mapping.test.ts`
- [x] `cd assistant && bun test src/providers/openai/__tests__/chat-completions-provider-reasoning.test.ts`
- [x] `cd assistant && bun test src/providers/inference/__tests__/adapter-factory-openai-compatible.test.ts`
- [x] `cd assistant && bun run typecheck:fast`

49 tests passed. Typecheck passed.

## Risk
- Compaction on custom OpenAI-compatible reasoning endpoints can no longer force `tool_choice: none`. The model may attempt tool calls during compaction; that is already treated as a failed summary, and is better than a hard 400.
- Fireworks/Together DeepSeek paths are unchanged: they still send `none` / forced `tool_choice` with thinking.
- No migrations, feature flags, or platform companion PR.

## CLI verb checklist
Not applicable: no new routes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-388c5c44-9afb-4310-954f-c0743cc4f427?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-388c5c44-9afb-4310-954f-c0743cc4f427&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

