### PR TITLE
test(web): cold-boot stub keeps surfaced runs, as the daemon filter does (LUM-3323)

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-conversation-loader-cold-boot.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-loader-cold-boot.test.tsx
@@ -118,11 +118,15 @@ let failNextRequests = 0;
  */
 let daemonFiltersForeground = true;
 
-/** The stub's foreground rule: the run types the daemon's filter drops. */
+/**
+ * The stub's foreground rule, the daemon's `notBackgroundVisibilitySql`: an
+ * unsurfaced background or scheduled run is dropped; a surfaced one stays.
+ */
 function isForegroundFixture(row: RawConversationFixture): boolean {
   return (
-    row.conversationType !== "background" &&
-    row.conversationType !== "scheduled"
+    row.surfacedAt != null ||
+    (row.conversationType !== "background" &&
+      row.conversationType !== "scheduled")
   );
 }
 
@@ -320,6 +324,28 @@ describe("useConversationLoader cold-boot landing", () => {
     renderColdBoot(new QueryClient());
 
     expect(await landedOn()).toContain("deep-chat");
+    expect(requests.filter((u) => u.endsWith("/conversations"))).toHaveLength(
+      1,
+    );
+  });
+
+  test("a surfaced background run is a landing, not evidence of an older assistant", async () => {
+    /* The daemon's filter keeps surfaced runs and so does the client's
+       selectability rule; the two have to agree here, or a current
+       assistant's honest first row would send the loader down the paged
+       search. */
+    listRows = [
+      {
+        id: "surfaced-run",
+        conversationType: "background",
+        surfacedAt: 1704067200000,
+      },
+      { id: "older-chat" },
+    ];
+
+    renderColdBoot(new QueryClient());
+
+    expect(await landedOn()).toContain("surfaced-run");
     expect(requests.filter((u) => u.endsWith("/conversations"))).toHaveLength(
       1,
     );


### PR DESCRIPTION
Related to LUM-3323. Test-only follow-up to #40854, which merged a minute before this commit reached its branch.

## TL;DR

The cold-boot daemon stub now keeps surfaced background/scheduled rows, the shape of the daemon's `notBackgroundVisibilitySql`, and one new case lands on a surfaced background run in one request.

## Why

#40854 detects an assistant that predates `foregroundOnly` by checking the returned first row against the client's selectability rule. That only works if the daemon's filter and the client's rule agree on every row the daemon can return; a surfaced run is the one row both admit that looks like a run. This case pins that agreement, so a current assistant's honest first row can never be misread as an older assistant and sent down the paged search. Vex raised the gap as an optional note on #40854.

## Before / after

| | Before | After |
| --- | --- | --- |
| Product behavior | unchanged | unchanged |
| Test stub | drops every background/scheduled fixture | drops only unsurfaced ones, like the daemon |

## Why it is safe

Test-only. Typecheck and lint pass; the suite runs in CI.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40860" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->