### PR TITLE
feat(api): add resource_pressure_status_changed wire contract

### DIFF
--- a/assistant/src/api/events/resource-pressure-status-changed.ts
+++ b/assistant/src/api/events/resource-pressure-status-changed.ts
@@ -1,0 +1,53 @@
+/**
+ * `resource_pressure_status_changed` SSE event.
+ *
+ * Global broadcast pushed when the daemon's resource-pressure snapshot
+ * changes. Mirrors the REST `GET /resource-pressure/status` shape so the
+ * client's monitor can apply stream updates and polled fetches through
+ * the same code path. Carries no `conversationId`: it is workspace-wide.
+ *
+ * Canonical wire-contract source. Daemon code imports the type
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+export const ResourcePressureStateSchema = z.enum([
+  "disabled",
+  "ok",
+  "elevated",
+  "unknown",
+]);
+
+export type ResourcePressureState = z.infer<typeof ResourcePressureStateSchema>;
+
+export const ResourcePressureStatusSchema = z.object({
+  enabled: z.boolean(),
+  state: ResourcePressureStateSchema,
+  /** Latest CPU sample as a percent of the CPU allocation. */
+  cpuPercent: z.number().nullable(),
+  /** Working set as a percent of the memory limit. */
+  memoryPercent: z.number().nullable(),
+  /** Whether the CPU signal is holding the `elevated` state. */
+  cpuElevated: z.boolean(),
+  /** Whether the memory signal is holding the `elevated` state. */
+  memoryElevated: z.boolean(),
+  cpuThresholdPercent: z.number(),
+  memoryThresholdPercent: z.number(),
+  lastCheckedAt: z.string().nullable(),
+  error: z.string().nullable(),
+});
+
+export type ResourcePressureStatus = z.infer<
+  typeof ResourcePressureStatusSchema
+>;
+
+export const ResourcePressureStatusChangedEventSchema = z.object({
+  type: z.literal("resource_pressure_status_changed"),
+  status: ResourcePressureStatusSchema,
+});
+
+export type ResourcePressureStatusChangedEvent = z.infer<
+  typeof ResourcePressureStatusChangedEventSchema
+>;

--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -102,6 +102,7 @@ import {
   RecordingStopEventSchema,
 } from "./events/recording.js";
 import { RelationshipStateUpdatedEventSchema } from "./events/relationship-state-updated.js";
+import { ResourcePressureStatusChangedEventSchema } from "./events/resource-pressure-status-changed.js";
 import { ScheduleConversationCreatedEventSchema } from "./events/schedule-conversation-created.js";
 import { SecretRequestEventSchema } from "./events/secret-request.js";
 import { ServiceGroupUpdateCompleteEventSchema } from "./events/service-group-update-complete.js";
@@ -537,6 +538,14 @@ export {
   RelationshipStateUpdatedEventSchema,
 } from "./events/relationship-state-updated.js";
 export {
+  type ResourcePressureState,
+  ResourcePressureStateSchema,
+  type ResourcePressureStatus,
+  type ResourcePressureStatusChangedEvent,
+  ResourcePressureStatusChangedEventSchema,
+  ResourcePressureStatusSchema,
+} from "./events/resource-pressure-status-changed.js";
+export {
   type ScheduleConversationCreatedEvent,
   ScheduleConversationCreatedEventSchema,
 } from "./events/schedule-conversation-created.js";
@@ -803,6 +812,10 @@ export {
   MemoryV3SelectionRowSchema,
 } from "./responses/memory-v3-selection-log.js";
 export {
+  type ResourcePressureStatusResponse,
+  ResourcePressureStatusResponseSchema,
+} from "./responses/resource-pressure-status.js";
+export {
   type SubagentDetailEvent,
   SubagentDetailEventSchema,
   type SubagentDetailResponse,
@@ -987,6 +1000,7 @@ export const AssistantEventSchema = z.discriminatedUnion("type", [
   RecordingStartEventSchema,
   RecordingStopEventSchema,
   RelationshipStateUpdatedEventSchema,
+  ResourcePressureStatusChangedEventSchema,
   ScheduleConversationCreatedEventSchema,
   SecretRequestEventSchema,
   ServiceGroupUpdateCompleteEventSchema,

--- a/assistant/src/api/responses/resource-pressure-status.ts
+++ b/assistant/src/api/responses/resource-pressure-status.ts
@@ -1,0 +1,25 @@
+/**
+ * Wire contract for the resource-pressure REST endpoint
+ * (`GET /resource-pressure/status`). Returns the current snapshot
+ * wrapped as `{ status }`.
+ *
+ * Reuses the canonical `ResourcePressureStatusSchema` defined alongside
+ * the `resource_pressure_status_changed` SSE event so the polled REST
+ * fetch and the streamed update share a single shape.
+ *
+ * Canonical wire-contract source. Assistant code imports the types
+ * directly from this file via relative paths; external consumers
+ * (web client, gateway, evals) import via `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+import { ResourcePressureStatusSchema } from "../events/resource-pressure-status-changed.js";
+
+export const ResourcePressureStatusResponseSchema = z.object({
+  status: ResourcePressureStatusSchema,
+});
+
+export type ResourcePressureStatusResponse = z.infer<
+  typeof ResourcePressureStatusResponseSchema
+>;

--- a/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -473,6 +473,7 @@ export function useStreamEventHandler(
         case "identity_changed":
         case "avatar_updated":
         case "disk_pressure_status_changed":
+        case "resource_pressure_status_changed":
         case "notification_intent":
         case "document_editor_show":
         case "document_editor_update":


### PR DESCRIPTION
## Summary
- Adds the resource-pressure status/event/response zod wire contract mirroring the disk-pressure shapes
- Registers resource_pressure_status_changed in the AssistantEventSchema union and re-exports via @vellumai/assistant-api

Part of plan: resource-pressure-upgrade-banner.md (PR 1 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40861" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->