### PR TITLE
refactor(assistant): extract rolling container CPU sampler into a shared util

### DIFF
--- a/assistant/src/__tests__/container-cpu-sampler.test.ts
+++ b/assistant/src/__tests__/container-cpu-sampler.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  computeCpuPercent,
+  getCachedContainerCpuPercent,
+} from "../util/container-cpu-sampler.js";
+
+describe("computeCpuPercent", () => {
+  test("computes percent of the full allocation from a CPU-time delta", () => {
+    // 2.5s of CPU over a 5s window on 1 core is 50% of the allocation.
+    expect(computeCpuPercent(2_500_000, 5_000, 1)).toBe(50);
+    // The same delta on 2 cores is half the utilization.
+    expect(computeCpuPercent(2_500_000, 5_000, 2)).toBe(25);
+    // Fully saturating 4 cores for the whole window is 100%.
+    expect(computeCpuPercent(20_000_000, 5_000, 4)).toBe(100);
+  });
+
+  test("rounds to 2 decimal places", () => {
+    expect(computeCpuPercent(123_456, 5_000, 2)).toBe(1.23);
+    expect(computeCpuPercent(123_999, 5_000, 2)).toBe(1.24);
+    expect(computeCpuPercent(0, 5_000, 1)).toBe(0);
+  });
+
+  test("yields a non-finite result for zero cores, which callers must guard", () => {
+    expect(Number.isFinite(computeCpuPercent(1_000_000, 5_000, 0))).toBe(false);
+    expect(Number.isFinite(computeCpuPercent(0, 5_000, 0))).toBe(false);
+  });
+});
+
+describe("getCachedContainerCpuPercent", () => {
+  test("returns a finite number", () => {
+    expect(Number.isFinite(getCachedContainerCpuPercent())).toBe(true);
+  });
+});

--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -19,6 +19,7 @@ import {
   getContainerMemoryLimitBytes,
   getContainerMemoryUsageBytes,
 } from "../../util/cgroup-memory.js";
+import { getCachedContainerCpuPercent } from "../../util/container-cpu-sampler.js";
 import { getDiskUsageInfo } from "../../util/disk-usage.js";
 import { getWorkspacePromptPath } from "../../util/platform.js";
 import { APP_VERSION } from "../../version.js";
@@ -93,128 +94,11 @@ interface CpuInfo {
   maxCores: number;
 }
 
-/**
- * Read the container's CPU usage from cgroup accounting files.
- *
- * Returns total CPU microseconds consumed by the container since boot.
- * We use the delta between two samples to compute percentage.
- */
-function getContainerCpuUsageUs(): number | null {
-  // cgroups v2: cpu.stat has a "usage_usec" line.
-  try {
-    const stat = readFileSync("/sys/fs/cgroup/cpu.stat", "utf-8");
-    for (const line of stat.split("\n")) {
-      if (line.startsWith("usage_usec")) {
-        const val = parseInt(line.split(/\s+/)[1], 10);
-        if (!isNaN(val) && val > 0) {
-          return val;
-        }
-      }
-    }
-  } catch {
-    /* not available */
-  }
-
-  // cgroups v1: cpuacct.usage is in nanoseconds.
-  try {
-    const ns = parseInt(
-      readFileSync("/sys/fs/cgroup/cpuacct/cpuacct.usage", "utf-8").trim(),
-      10,
-    );
-    if (!isNaN(ns) && ns > 0) {
-      return ns / 1000;
-    } // convert ns → µs
-  } catch {
-    /* not available */
-  }
-
-  return null;
-}
-
-// Track CPU usage over a rolling window so /v1/health reports near-real-time
-// utilization instead of a lifetime average (total CPU time / total uptime).
-const CPU_SAMPLE_INTERVAL_MS = 5_000;
-
-/**
- * Sample this process's cumulative CPU time, returning null when the
- * underlying syscall fails (mirroring {@link sampleProcessRssBytes}).
- */
-function sampleProcessCpuUsage(): NodeJS.CpuUsage | null {
-  try {
-    return process.cpuUsage();
-  } catch {
-    return null;
-  }
-}
-
-let _lastProcessCpuUsage: NodeJS.CpuUsage | null = sampleProcessCpuUsage();
-let _lastCgroupCpuUs: number | null = getContainerCpuUsageUs();
-let _lastCpuTime: number = Date.now();
-let _cachedCpuPercent = 0;
-
-// Kick off the background sampler. unref() so it never prevents process exit.
-setInterval(() => {
-  const now = Date.now();
-  const elapsedMs = now - _lastCpuTime;
-  if (elapsedMs <= 0) {
-    return;
-  }
-
-  const numCores = getContainerCpuCores();
-  if (numCores <= 0) {
-    _lastCpuTime = now;
-    return;
-  }
-
-  // Always sample process-level CPU so the baseline stays fresh. This
-  // prevents a spike if the platform cgroup path later falls back to
-  // process.cpuUsage() after cgroup stats were previously available.
-  const newProcessUsage = sampleProcessCpuUsage();
-  const processDeltaUs =
-    newProcessUsage !== null && _lastProcessCpuUsage !== null
-      ? newProcessUsage.user -
-        _lastProcessCpuUsage.user +
-        (newProcessUsage.system - _lastProcessCpuUsage.system)
-      : null;
-  if (newProcessUsage !== null) {
-    _lastProcessCpuUsage = newProcessUsage;
-  }
-
-  if (getIsPlatform()) {
-    // In platform mode, prefer cgroup-level CPU usage so we see the full
-    // container footprint, not just this process.
-    const cgroupUs = getContainerCpuUsageUs();
-    if (cgroupUs !== null && _lastCgroupCpuUs !== null) {
-      const deltaCpuUs = cgroupUs - _lastCgroupCpuUs;
-      const deltaCpuMs = deltaCpuUs / 1000;
-      _cachedCpuPercent =
-        Math.round((deltaCpuMs / (elapsedMs * numCores)) * 10000) / 100;
-    } else if (processDeltaUs !== null) {
-      // cgroup CPU stats unavailable (e.g. gVisor) – fall back to process-level.
-      const deltaCpuMs = processDeltaUs / 1000;
-      _cachedCpuPercent =
-        Math.round((deltaCpuMs / (elapsedMs * numCores)) * 10000) / 100;
-    }
-    _lastCgroupCpuUs = cgroupUs;
-  } else if (processDeltaUs !== null) {
-    // Non-platform: use process.cpuUsage() (accurate for single-process mode).
-    const deltaCpuMs = processDeltaUs / 1000;
-    _cachedCpuPercent =
-      Math.round((deltaCpuMs / (elapsedMs * numCores)) * 10000) / 100;
-  }
-
-  _lastCpuTime = now;
-}, CPU_SAMPLE_INTERVAL_MS).unref();
-
 function getCpuInfo(): CpuInfo {
-  try {
-    return {
-      currentPercent: _cachedCpuPercent,
-      maxCores: Math.ceil(getContainerCpuCores()),
-    };
-  } catch {
-    return { currentPercent: 0, maxCores: 0 };
-  }
+  return {
+    currentPercent: getCachedContainerCpuPercent(),
+    maxCores: Math.ceil(getContainerCpuCores()),
+  };
 }
 
 /**

--- a/assistant/src/util/container-cpu-sampler.ts
+++ b/assistant/src/util/container-cpu-sampler.ts
@@ -1,0 +1,147 @@
+/**
+ * Rolling container CPU sampler.
+ *
+ * Tracks CPU usage over a rolling window so consumers (e.g. /v1/health) report
+ * near-real-time utilization instead of a lifetime average (total CPU time /
+ * total uptime). The sampler starts on module import and runs on an unref'd
+ * interval, so it never prevents process exit.
+ */
+
+import { readFileSync } from "node:fs";
+
+import { getIsPlatform } from "../config/env-registry.js";
+import { getContainerCpuCores } from "./cgroup-cpu.js";
+
+/**
+ * Read the container's CPU usage from cgroup accounting files.
+ *
+ * Returns total CPU microseconds consumed by the container since boot.
+ * We use the delta between two samples to compute percentage.
+ */
+function getContainerCpuUsageUs(): number | null {
+  // cgroups v2: cpu.stat has a "usage_usec" line.
+  try {
+    const stat = readFileSync("/sys/fs/cgroup/cpu.stat", "utf-8");
+    for (const line of stat.split("\n")) {
+      if (line.startsWith("usage_usec")) {
+        const val = parseInt(line.split(/\s+/)[1], 10);
+        if (!isNaN(val) && val > 0) {
+          return val;
+        }
+      }
+    }
+  } catch {
+    /* not available */
+  }
+
+  // cgroups v1: cpuacct.usage is in nanoseconds.
+  try {
+    const ns = parseInt(
+      readFileSync("/sys/fs/cgroup/cpuacct/cpuacct.usage", "utf-8").trim(),
+      10,
+    );
+    if (!isNaN(ns) && ns > 0) {
+      return ns / 1000;
+    } // convert ns → µs
+  } catch {
+    /* not available */
+  }
+
+  return null;
+}
+
+const CPU_SAMPLE_INTERVAL_MS = 5_000;
+
+/**
+ * Sample this process's cumulative CPU time, returning null when the
+ * underlying syscall fails.
+ */
+function sampleProcessCpuUsage(): NodeJS.CpuUsage | null {
+  try {
+    return process.cpuUsage();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Convert a CPU-time delta into a percent of the container's full allocation,
+ * rounded to 2 decimal places. Callers must guard `numCores > 0` and
+ * `elapsedMs > 0`; a zero divisor yields a non-finite result.
+ */
+export function computeCpuPercent(
+  deltaCpuUs: number,
+  elapsedMs: number,
+  numCores: number,
+): number {
+  const deltaCpuMs = deltaCpuUs / 1000;
+  return Math.round((deltaCpuMs / (elapsedMs * numCores)) * 10000) / 100;
+}
+
+let _lastProcessCpuUsage: NodeJS.CpuUsage | null = sampleProcessCpuUsage();
+let _lastCgroupCpuUs: number | null = getContainerCpuUsageUs();
+let _lastCpuTime: number = Date.now();
+let _cachedCpuPercent = 0;
+
+// Kick off the background sampler. unref() so it never prevents process exit.
+setInterval(() => {
+  const now = Date.now();
+  const elapsedMs = now - _lastCpuTime;
+  if (elapsedMs <= 0) {
+    return;
+  }
+
+  const numCores = getContainerCpuCores();
+  if (numCores <= 0) {
+    _lastCpuTime = now;
+    return;
+  }
+
+  // Always sample process-level CPU so the baseline stays fresh. This
+  // prevents a spike if the platform cgroup path later falls back to
+  // process.cpuUsage() after cgroup stats were previously available.
+  const newProcessUsage = sampleProcessCpuUsage();
+  const processDeltaUs =
+    newProcessUsage !== null && _lastProcessCpuUsage !== null
+      ? newProcessUsage.user -
+        _lastProcessCpuUsage.user +
+        (newProcessUsage.system - _lastProcessCpuUsage.system)
+      : null;
+  if (newProcessUsage !== null) {
+    _lastProcessCpuUsage = newProcessUsage;
+  }
+
+  if (getIsPlatform()) {
+    // In platform mode, prefer cgroup-level CPU usage so we see the full
+    // container footprint, not just this process.
+    const cgroupUs = getContainerCpuUsageUs();
+    if (cgroupUs !== null && _lastCgroupCpuUs !== null) {
+      _cachedCpuPercent = computeCpuPercent(
+        cgroupUs - _lastCgroupCpuUs,
+        elapsedMs,
+        numCores,
+      );
+    } else if (processDeltaUs !== null) {
+      // cgroup CPU stats unavailable (e.g. gVisor) – fall back to process-level.
+      _cachedCpuPercent = computeCpuPercent(
+        processDeltaUs,
+        elapsedMs,
+        numCores,
+      );
+    }
+    _lastCgroupCpuUs = cgroupUs;
+  } else if (processDeltaUs !== null) {
+    // Non-platform: use process.cpuUsage() (accurate for single-process mode).
+    _cachedCpuPercent = computeCpuPercent(processDeltaUs, elapsedMs, numCores);
+  }
+
+  _lastCpuTime = now;
+}, CPU_SAMPLE_INTERVAL_MS).unref();
+
+/**
+ * Near-real-time CPU utilization as a percent of the container's full
+ * allocation, refreshed every {@link CPU_SAMPLE_INTERVAL_MS}.
+ */
+export function getCachedContainerCpuPercent(): number {
+  return _cachedCpuPercent;
+}


### PR DESCRIPTION
## Summary
- Moves the rolling cgroup/process CPU sampler out of identity-routes into util/container-cpu-sampler.ts with no behavior change
- Exposes getCachedContainerCpuPercent() and a pure computeCpuPercent() helper with unit tests

Part of plan: resource-pressure-upgrade-banner.md (PR 2 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40862" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->