### PR TITLE
feat(web): resource-pressure warning banner component

### DIFF
--- a/clients/web/src/components/resource-pressure-banner.tsx
+++ b/clients/web/src/components/resource-pressure-banner.tsx
@@ -1,0 +1,95 @@
+import { Activity } from "lucide-react";
+import { useState } from "react";
+
+import type { ResourcePressureStatus } from "@vellumai/assistant-api";
+import { Button, Checkbox, Notice } from "@vellumai/design-library";
+
+import { useTranslation } from "@/i18n";
+
+export interface ResourcePressureBannerProps {
+  status: ResourcePressureStatus;
+  /**
+   * Called when the user dismisses the banner. The `permanent` flag is true
+   * when the user also checked "Don't show again"; in that case the caller
+   * should suppress the banner permanently, not just for the cooldown period.
+   */
+  onDismiss: (permanent: boolean) => void;
+  /**
+   * Navigates to the plans page. Null hides the Upgrade button and its hint
+   * (native Android and non-active assistants).
+   */
+  onUpgrade: (() => void) | null;
+}
+
+export function ResourcePressureBanner(props: ResourcePressureBannerProps) {
+  const { status, onDismiss, onUpgrade } = props;
+  const { t } = useTranslation();
+  const [dontShowAgain, setDontShowAgain] = useState(false);
+
+  const body =
+    status.cpuElevated && status.memoryElevated
+      ? t("resourcePressureBanner.bodyBoth")
+      : status.memoryElevated
+        ? t("resourcePressureBanner.bodyMemory")
+        : t("resourcePressureBanner.bodyCpu");
+
+  const readouts: string[] = [];
+  if (status.cpuPercent != null && Number.isFinite(status.cpuPercent)) {
+    readouts.push(
+      t("resourcePressureBanner.cpuLabel", {
+        value: Math.round(status.cpuPercent),
+      }),
+    );
+  }
+  if (status.memoryPercent != null && Number.isFinite(status.memoryPercent)) {
+    readouts.push(
+      t("resourcePressureBanner.memoryLabel", {
+        value: Math.round(status.memoryPercent),
+      }),
+    );
+  }
+
+  return (
+    <Notice
+      tone="warning"
+      title={t("resourcePressureBanner.title")}
+      icon={<Activity className="h-4 w-4" aria-hidden="true" />}
+      onDismiss={() => onDismiss(dontShowAgain)}
+      className="p-4"
+      data-testid="resource-pressure-banner"
+    >
+      <div className="flex flex-col gap-3">
+        {readouts.length > 0 ? (
+          <div className="flex items-center gap-3">
+            {readouts.map((readout) => (
+              <span
+                key={readout}
+                className="text-body-medium-default shrink-0 tabular-nums text-[color:var(--system-mid-strong)]"
+              >
+                {readout}
+              </span>
+            ))}
+          </div>
+        ) : null}
+        <p className="m-0">{body}</p>
+        {onUpgrade ? (
+          <p className="m-0">{t("resourcePressureBanner.upgradeHint")}</p>
+        ) : null}
+        <div className="flex flex-wrap items-center gap-2">
+          {onUpgrade ? (
+            <Button variant="outlined" size="compact" onClick={onUpgrade}>
+              {t("resourcePressureBanner.upgrade")}
+            </Button>
+          ) : null}
+          <Checkbox
+            className="ml-auto"
+            checked={dontShowAgain}
+            onCheckedChange={(next) => setDontShowAgain(next === true)}
+            label={t("resourcePressureBanner.dontShowAgain")}
+            data-testid="resource-pressure-banner-dont-show-again"
+          />
+        </div>
+      </div>
+    </Notice>
+  );
+}

--- a/clients/web/src/domains/chat/utils/chat.ts
+++ b/clients/web/src/domains/chat/utils/chat.ts
@@ -43,6 +43,8 @@ const GLOBAL_STREAM_EVENT_TYPE_NAMES = [
   "avatar_updated",
   "sync_changed",
   "disk_pressure_status_changed",
+  // Workspace-wide resource-pressure broadcast, no `conversationId`.
+  "resource_pressure_status_changed",
   // App source-file change broadcast — carries an `appId`, not a
   // `conversationId`; clients re-read the app on receipt.
   "app_files_changed",

--- a/clients/web/src/i18n/locales/en/common.json
+++ b/clients/web/src/i18n/locales/en/common.json
@@ -5,5 +5,16 @@
     "body": "The page you're looking for doesn't exist or may have moved.",
     "backToAssistant": "Back to your assistant",
     "goBack": "Go back"
+  },
+  "resourcePressureBanner": {
+    "title": "Your assistant is using a lot of resources",
+    "bodyCpu": "CPU usage has stayed high for an extended period.",
+    "bodyMemory": "Memory usage has stayed high for an extended period.",
+    "bodyBoth": "CPU and memory usage have stayed high for an extended period.",
+    "upgradeHint": "Upgrading your plan gives your assistant more headroom.",
+    "upgrade": "Upgrade",
+    "dontShowAgain": "Don't show again",
+    "cpuLabel": "CPU {value, number}%",
+    "memoryLabel": "Memory {value, number}%"
   }
 }

--- a/clients/web/src/i18n/locales/es/common.json
+++ b/clients/web/src/i18n/locales/es/common.json
@@ -5,5 +5,16 @@
     "body": "La página que buscas no existe o puede haberse movido.",
     "backToAssistant": "Volver a tu asistente",
     "goBack": "Atrás"
+  },
+  "resourcePressureBanner": {
+    "title": "Tu asistente está usando muchos recursos",
+    "bodyCpu": "El uso de CPU se ha mantenido alto durante un periodo prolongado.",
+    "bodyMemory": "El uso de memoria se ha mantenido alto durante un periodo prolongado.",
+    "bodyBoth": "El uso de CPU y de memoria se ha mantenido alto durante un periodo prolongado.",
+    "upgradeHint": "Mejorar tu plan le da a tu asistente más margen.",
+    "upgrade": "Mejorar plan",
+    "dontShowAgain": "No mostrar de nuevo",
+    "cpuLabel": "CPU {value, number} %",
+    "memoryLabel": "Memoria {value, number} %"
   }
 }


### PR DESCRIPTION
## Summary
- Adds the resource-pressure warning banner component with CPU/memory/both body variants and an optional Upgrade CTA
- All strings translated via the common i18n namespace (en + es)
- Also registers resource_pressure_status_changed in the chat global (non-conversation-gated) event list: PR 1 added the union member and the exhaustive-switch case, but without the global-list entry the event was typed conversation-scoped with no conversationId, which broke the web typecheck on the base branch

Part of plan: resource-pressure-upgrade-banner.md (PR 6 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40863" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->