### PR TITLE
feat(daemon): sustained CPU/memory pressure guard for platform-hosted assistants

### DIFF
--- a/assistant/src/__tests__/resource-pressure-guard.test.ts
+++ b/assistant/src/__tests__/resource-pressure-guard.test.ts
@@ -1,0 +1,319 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { ResourcePressureStatusChangedEventSchema } from "../api/events/resource-pressure-status-changed.js";
+import type { ResourcePressureStatus } from "../daemon/resource-pressure-guard.js";
+
+const broadcasts: unknown[] = [];
+
+mock.module("../runtime/assistant-event-hub.js", () => ({
+  AssistantEventHub: class {},
+  broadcastMessage: (message: unknown) => {
+    broadcasts.push(message);
+  },
+  capabilityForMessageType: () => undefined,
+  assistantEventHub: {
+    publish: async () => {},
+  },
+}));
+
+// Default readers report no container accounting, so tests that exercise the
+// default samplers see both signals unavailable.
+mock.module("../util/container-cpu-sampler.js", () => ({
+  getCachedContainerCpuPercent: () => 0,
+}));
+
+mock.module("../util/cgroup-cpu.js", () => ({
+  getContainerCpuCores: () => 0,
+}));
+
+mock.module("../util/cgroup-memory.js", () => ({
+  getContainerMemoryLimitBytes: () => null,
+  getContainerMemoryUsageBytes: () => null,
+  getContainerMemoryStat: () => null,
+}));
+
+const {
+  RESOURCE_PRESSURE_CLEAR_CONSECUTIVE_SAMPLES,
+  RESOURCE_PRESSURE_ENTER_SAMPLES,
+  RESOURCE_PRESSURE_WINDOW_SAMPLES,
+  __getResourcePressureGuardTimerForTests,
+  __resetResourcePressureGuardForTests,
+  evaluateResourcePressureNow,
+  getResourcePressureStatus,
+  startResourcePressureGuard,
+  stopResourcePressureGuard,
+} = await import("../daemon/resource-pressure-guard.js");
+
+function evaluateCpu(percent: number): ResourcePressureStatus {
+  return evaluateResourcePressureNow({
+    sampleCpuPercent: () => percent,
+    sampleMemory: () => null,
+  });
+}
+
+function driveCpu(count: number, percent: number): ResourcePressureStatus {
+  let status: ResourcePressureStatus | null = null;
+  for (let i = 0; i < count; i += 1) {
+    status = evaluateCpu(percent);
+  }
+  return status!;
+}
+
+function driveMemory(
+  count: number,
+  sample: { usageBytes: number; limitBytes: number; reclaimableBytes: number },
+): ResourcePressureStatus {
+  let status: ResourcePressureStatus | null = null;
+  for (let i = 0; i < count; i += 1) {
+    status = evaluateResourcePressureNow({
+      sampleCpuPercent: () => null,
+      sampleMemory: () => sample,
+    });
+  }
+  return status!;
+}
+
+function enterCpuElevated(): ResourcePressureStatus {
+  const idleSamples =
+    RESOURCE_PRESSURE_WINDOW_SAMPLES - RESOURCE_PRESSURE_ENTER_SAMPLES;
+  driveCpu(idleSamples, 10);
+  const status = driveCpu(RESOURCE_PRESSURE_ENTER_SAMPLES, 95);
+  expect(status.state).toBe("elevated");
+  return status;
+}
+
+const originalIsPlatform = process.env.IS_PLATFORM;
+
+beforeEach(() => {
+  __resetResourcePressureGuardForTests();
+  broadcasts.length = 0;
+  process.env.IS_PLATFORM = "true";
+});
+
+afterEach(() => {
+  __resetResourcePressureGuardForTests();
+  broadcasts.length = 0;
+  if (originalIsPlatform === undefined) {
+    delete process.env.IS_PLATFORM;
+  } else {
+    process.env.IS_PLATFORM = originalIsPlatform;
+  }
+});
+
+describe("resource pressure guard", () => {
+  test("stays disabled off-platform: no timer, no samples, no broadcasts", () => {
+    delete process.env.IS_PLATFORM;
+
+    const started = startResourcePressureGuard();
+
+    expect(started.enabled).toBe(false);
+    expect(started.state).toBe("disabled");
+    expect(__getResourcePressureGuardTimerForTests()).toBeNull();
+
+    const evaluated = evaluateCpu(99);
+    expect(evaluated.enabled).toBe(false);
+    expect(evaluated.state).toBe("disabled");
+
+    const status = getResourcePressureStatus();
+    expect(status.enabled).toBe(false);
+    expect(status.state).toBe("disabled");
+
+    expect(broadcasts.length).toBe(0);
+  });
+
+  test("17 of 20 samples over the CPU threshold stays ok", () => {
+    driveCpu(3, 10);
+    const status = driveCpu(17, 95);
+
+    expect(status.state).toBe("ok");
+    expect(status.cpuElevated).toBe(false);
+    expect(status.cpuPercent).toBe(95);
+  });
+
+  test("18 of 20 samples over the CPU threshold enters elevated", () => {
+    const status = enterCpuElevated();
+
+    expect(status.cpuElevated).toBe(true);
+    expect(status.memoryElevated).toBe(false);
+    expect(status.enabled).toBe(true);
+  });
+
+  test("does not enter elevated before the window is full", () => {
+    let status = evaluateCpu(95);
+    for (let i = 1; i < RESOURCE_PRESSURE_WINDOW_SAMPLES - 1; i += 1) {
+      status = evaluateCpu(95);
+      expect(status.state).toBe("ok");
+    }
+
+    status = evaluateCpu(95);
+    expect(status.state).toBe("elevated");
+  });
+
+  test("a 10-sample spike inside an otherwise idle window never enters elevated", () => {
+    const statuses: ResourcePressureStatus[] = [];
+    for (let i = 0; i < 5; i += 1) {
+      statuses.push(evaluateCpu(10));
+    }
+    for (let i = 0; i < 10; i += 1) {
+      statuses.push(evaluateCpu(95));
+    }
+    for (let i = 0; i < 10; i += 1) {
+      statuses.push(evaluateCpu(10));
+    }
+
+    for (const status of statuses) {
+      expect(status.state).toBe("ok");
+      expect(status.cpuElevated).toBe(false);
+    }
+  });
+
+  test("holds elevated between the clear and enter thresholds, clears after 10 consecutive below clear", () => {
+    enterCpuElevated();
+
+    // 75% is below the 85% enter threshold but above the 70% clear threshold:
+    // hysteresis holds the elevated state.
+    for (let i = 0; i < 15; i += 1) {
+      expect(evaluateCpu(75).state).toBe("elevated");
+    }
+
+    // Below the clear threshold, but not yet for long enough.
+    let status = driveCpu(RESOURCE_PRESSURE_CLEAR_CONSECUTIVE_SAMPLES - 1, 60);
+    expect(status.state).toBe("elevated");
+
+    // The 10th consecutive sample below the clear threshold clears it.
+    status = evaluateCpu(60);
+    expect(status.state).toBe("ok");
+    expect(status.cpuElevated).toBe(false);
+  });
+
+  test("a dip above the clear threshold resets the consecutive clear count", () => {
+    enterCpuElevated();
+
+    for (
+      let i = 0;
+      i < RESOURCE_PRESSURE_CLEAR_CONSECUTIVE_SAMPLES - 1;
+      i += 1
+    ) {
+      expect(evaluateCpu(60).state).toBe("elevated");
+    }
+    // Back above clear: the run restarts.
+    expect(evaluateCpu(75).state).toBe("elevated");
+    for (
+      let i = 0;
+      i < RESOURCE_PRESSURE_CLEAR_CONSECUTIVE_SAMPLES - 1;
+      i += 1
+    ) {
+      expect(evaluateCpu(60).state).toBe("elevated");
+    }
+    expect(evaluateCpu(60).state).toBe("ok");
+  });
+
+  test("reclaimable file cache is subtracted from the memory working set", () => {
+    // Usage at 95% of the limit, but 20% of the limit is reclaimable page
+    // cache: the working set is 75%, under the 90% threshold.
+    const status = driveMemory(RESOURCE_PRESSURE_WINDOW_SAMPLES + 5, {
+      usageBytes: 950,
+      limitBytes: 1000,
+      reclaimableBytes: 200,
+    });
+
+    expect(status.state).toBe("ok");
+    expect(status.memoryElevated).toBe(false);
+    expect(status.memoryPercent).toBe(75);
+  });
+
+  test("unreclaimable memory over the threshold enters elevated", () => {
+    const status = driveMemory(RESOURCE_PRESSURE_WINDOW_SAMPLES, {
+      usageBytes: 950,
+      limitBytes: 1000,
+      reclaimableBytes: 0,
+    });
+
+    expect(status.state).toBe("elevated");
+    expect(status.memoryElevated).toBe(true);
+    expect(status.cpuElevated).toBe(false);
+    expect(status.memoryPercent).toBe(95);
+  });
+
+  test("broadcasts exactly on ok to elevated and elevated to ok transitions", () => {
+    enterCpuElevated();
+    expect(broadcasts.length).toBe(1);
+
+    // More elevated samples do not re-broadcast.
+    driveCpu(5, 95);
+    expect(broadcasts.length).toBe(1);
+
+    driveCpu(RESOURCE_PRESSURE_CLEAR_CONSECUTIVE_SAMPLES, 60);
+    expect(broadcasts.length).toBe(2);
+
+    const elevatedEvent = ResourcePressureStatusChangedEventSchema.parse(
+      broadcasts[0],
+    );
+    expect(elevatedEvent.status.state).toBe("elevated");
+    expect(elevatedEvent.status.cpuElevated).toBe(true);
+
+    const clearedEvent = ResourcePressureStatusChangedEventSchema.parse(
+      broadcasts[1],
+    );
+    expect(clearedEvent.status.state).toBe("ok");
+    expect(clearedEvent.status.cpuElevated).toBe(false);
+
+    // Further ok samples stay silent.
+    driveCpu(5, 10);
+    expect(broadcasts.length).toBe(2);
+  });
+
+  test("missing memory limit and zero CPU cores yield unknown, never elevated", () => {
+    let status: ResourcePressureStatus | null = null;
+    for (let i = 0; i < RESOURCE_PRESSURE_WINDOW_SAMPLES + 5; i += 1) {
+      // No injected samplers: the mocked default readers report zero cores
+      // and a null memory limit.
+      status = evaluateResourcePressureNow();
+      expect(status.state).toBe("unknown");
+      expect(status.cpuElevated).toBe(false);
+      expect(status.memoryElevated).toBe(false);
+    }
+
+    expect(status!.enabled).toBe(true);
+    expect(status!.cpuPercent).toBeNull();
+    expect(status!.memoryPercent).toBeNull();
+    expect(status!.error).toBeTruthy();
+    expect(status!.lastCheckedAt).toBeTruthy();
+  });
+
+  test("an unavailable signal resets its window and drops its elevated flag", () => {
+    enterCpuElevated();
+
+    // CPU sample becomes unavailable: the signal cannot hold elevated.
+    const status = evaluateResourcePressureNow({
+      sampleCpuPercent: () => null,
+      sampleMemory: () => ({
+        usageBytes: 100,
+        limitBytes: 1000,
+        reclaimableBytes: 0,
+      }),
+    });
+
+    expect(status.state).toBe("ok");
+    expect(status.cpuElevated).toBe(false);
+    expect(status.cpuPercent).toBeNull();
+    expect(status.memoryPercent).toBe(10);
+  });
+
+  test("timer start and stop are idempotent on platform", () => {
+    expect(__getResourcePressureGuardTimerForTests()).toBeNull();
+
+    startResourcePressureGuard();
+    const firstTimer = __getResourcePressureGuardTimerForTests();
+    expect(firstTimer).toBeTruthy();
+
+    startResourcePressureGuard();
+    expect(__getResourcePressureGuardTimerForTests()).toBe(firstTimer);
+
+    stopResourcePressureGuard();
+    expect(__getResourcePressureGuardTimerForTests()).toBeNull();
+
+    stopResourcePressureGuard();
+    expect(__getResourcePressureGuardTimerForTests()).toBeNull();
+  });
+});

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -98,6 +98,7 @@ import {
   registerMessagingProviders,
   registerWatcherProviders,
 } from "./providers-setup.js";
+import { startResourcePressureGuardForLifecycle } from "./resource-pressure-guard-lifecycle.js";
 import { installShutdownHandlers } from "./shutdown-handlers.js";
 import { broadcastDaemonStatus } from "./status.js";
 
@@ -700,6 +701,7 @@ export async function runDaemon(): Promise<void> {
 
   startUsageTelemetryReporter();
   startDiskPressureGuardForLifecycle();
+  startResourcePressureGuardForLifecycle();
   startOrphanReaper();
   startEventLoopWatchdog();
 

--- a/assistant/src/daemon/resource-pressure-guard-lifecycle.ts
+++ b/assistant/src/daemon/resource-pressure-guard-lifecycle.ts
@@ -1,0 +1,66 @@
+/**
+ * Resource-pressure guard wiring for the daemon lifecycle.
+ *
+ * Starts the guard at boot and defers the first sample onto a macrotask so it
+ * never blocks startup, and stops the guard (cancelling any pending deferred
+ * sample) on shutdown. When the guard is disabled (non-platform), no deferred
+ * sample is scheduled.
+ */
+import { getLogger } from "../util/logger.js";
+import {
+  evaluateResourcePressureNow,
+  startResourcePressureGuard,
+  stopResourcePressureGuard,
+} from "./resource-pressure-guard.js";
+
+const log = getLogger("resource-pressure-guard-lifecycle");
+
+let resourcePressureStartupSampleTimer: ReturnType<typeof setTimeout> | null =
+  null;
+
+function runDeferredResourcePressureStartupSample(): void {
+  resourcePressureStartupSampleTimer = null;
+  try {
+    const status = evaluateResourcePressureNow();
+    if (status.error) {
+      log.warn(
+        { error: status.error },
+        "Resource pressure guard sample failed during startup, continuing",
+      );
+    }
+  } catch (err) {
+    log.warn(
+      { err },
+      "Resource pressure guard failed during startup, continuing",
+    );
+  }
+}
+
+export function startResourcePressureGuardForLifecycle(): void {
+  try {
+    const startedStatus = startResourcePressureGuard();
+    if (!startedStatus.enabled) {
+      return;
+    }
+    if (!resourcePressureStartupSampleTimer) {
+      resourcePressureStartupSampleTimer = setTimeout(
+        runDeferredResourcePressureStartupSample,
+        0,
+      );
+      (resourcePressureStartupSampleTimer as { unref?: () => void }).unref?.();
+    }
+  } catch (err) {
+    log.warn(
+      { err },
+      "Resource pressure guard failed during startup, continuing",
+    );
+  }
+}
+
+export function stopResourcePressureGuardForLifecycle(): void {
+  if (resourcePressureStartupSampleTimer) {
+    clearTimeout(resourcePressureStartupSampleTimer);
+    resourcePressureStartupSampleTimer = null;
+  }
+  stopResourcePressureGuard();
+}

--- a/assistant/src/daemon/resource-pressure-guard.ts
+++ b/assistant/src/daemon/resource-pressure-guard.ts
@@ -1,0 +1,349 @@
+/**
+ * Sustained CPU/memory pressure guard for platform-hosted assistants.
+ *
+ * Samples container CPU utilization and working-set memory against the
+ * container's allocation on a fixed cadence and reports an `elevated` state
+ * only when a signal stays over its threshold for nearly the whole sampling
+ * window (so a single heavy agent task never trips it). Clearing requires a
+ * sustained run of samples below a lower clear threshold (hysteresis), so the
+ * state never flaps while usage hovers near a threshold.
+ *
+ * The guard is platform-gated: off-platform there is no plan allocation to
+ * measure against, so the guard stays disabled and samples nothing.
+ */
+import {
+  type ResourcePressureState,
+  type ResourcePressureStatus,
+} from "../api/events/resource-pressure-status-changed.js";
+import { getIsPlatform } from "../config/env-registry.js";
+import { broadcastMessage } from "../runtime/assistant-event-hub.js";
+import { getContainerCpuCores } from "../util/cgroup-cpu.js";
+import {
+  getContainerMemoryLimitBytes,
+  getContainerMemoryStat,
+  getContainerMemoryUsageBytes,
+} from "../util/cgroup-memory.js";
+import { getCachedContainerCpuPercent } from "../util/container-cpu-sampler.js";
+
+export const RESOURCE_PRESSURE_SAMPLE_INTERVAL_MS = 30_000;
+// 20 samples at a 30s cadence: 10 minutes of history.
+export const RESOURCE_PRESSURE_WINDOW_SAMPLES = 20;
+// A signal must exceed its threshold in at least this many of the last
+// RESOURCE_PRESSURE_WINDOW_SAMPLES samples, with the window full, to enter
+// `elevated`.
+export const RESOURCE_PRESSURE_ENTER_SAMPLES = 18;
+// Consecutive samples below the clear threshold (5 minutes) required to leave
+// `elevated`.
+export const RESOURCE_PRESSURE_CLEAR_CONSECUTIVE_SAMPLES = 10;
+export const CPU_PRESSURE_THRESHOLD_PERCENT = 85;
+export const CPU_PRESSURE_CLEAR_THRESHOLD_PERCENT = 70;
+export const MEMORY_PRESSURE_THRESHOLD_PERCENT = 90;
+export const MEMORY_PRESSURE_CLEAR_THRESHOLD_PERCENT = 80;
+
+export { type ResourcePressureState, type ResourcePressureStatus };
+
+export interface ResourcePressureMemorySample {
+  usageBytes: number;
+  limitBytes: number;
+  reclaimableBytes: number;
+}
+
+export interface ResourcePressureSamplers {
+  sampleCpuPercent?: () => number | null;
+  sampleMemory?: () => ResourcePressureMemorySample | null;
+}
+
+interface SignalWindow {
+  /** Ring buffer of over-threshold results, oldest first. */
+  overThreshold: boolean[];
+  consecutiveBelowClear: number;
+  elevated: boolean;
+}
+
+interface ResourcePressureGuardState {
+  timer: ReturnType<typeof setInterval> | null;
+  status: ResourcePressureStatus;
+  cpuWindow: SignalWindow;
+  memoryWindow: SignalWindow;
+}
+
+const DISABLED_STATUS: ResourcePressureStatus = {
+  enabled: false,
+  state: "disabled",
+  cpuPercent: null,
+  memoryPercent: null,
+  cpuElevated: false,
+  memoryElevated: false,
+  cpuThresholdPercent: CPU_PRESSURE_THRESHOLD_PERCENT,
+  memoryThresholdPercent: MEMORY_PRESSURE_THRESHOLD_PERCENT,
+  lastCheckedAt: null,
+  error: null,
+};
+
+const OK_STATUS: ResourcePressureStatus = {
+  ...DISABLED_STATUS,
+  enabled: true,
+  state: "ok",
+};
+
+function emptySignalWindow(): SignalWindow {
+  return { overThreshold: [], consecutiveBelowClear: 0, elevated: false };
+}
+
+const state: ResourcePressureGuardState = {
+  timer: null,
+  status: cloneStatus(DISABLED_STATUS),
+  cpuWindow: emptySignalWindow(),
+  memoryWindow: emptySignalWindow(),
+};
+
+function cloneStatus(status: ResourcePressureStatus): ResourcePressureStatus {
+  return { ...status };
+}
+
+// The raw percents and timestamp change on every sample; broadcasting each
+// tick would spam the SSE hub, so only substantive fields participate.
+function statusFingerprint(status: ResourcePressureStatus): string {
+  const {
+    lastCheckedAt: _lastCheckedAt,
+    cpuPercent: _cpuPercent,
+    memoryPercent: _memoryPercent,
+    ...substantiveStatus
+  } = status;
+  return JSON.stringify(substantiveStatus);
+}
+
+function publishStatusChangedIfNeeded(previous: ResourcePressureStatus): void {
+  if (statusFingerprint(previous) === statusFingerprint(state.status)) {
+    return;
+  }
+  const status = cloneStatus(state.status);
+  broadcastMessage({
+    type: "resource_pressure_status_changed",
+    status,
+  });
+}
+
+function replaceStatus(next: ResourcePressureStatus): ResourcePressureStatus {
+  const previous = cloneStatus(state.status);
+  state.status = cloneStatus(next);
+  publishStatusChangedIfNeeded(previous);
+  return cloneStatus(state.status);
+}
+
+function ensureEnabledStatus(): void {
+  if (!state.status.enabled) {
+    state.status = cloneStatus(OK_STATUS);
+  }
+}
+
+function roundPercent(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function sampleFailureStatus(error: unknown): ResourcePressureStatus {
+  return {
+    ...OK_STATUS,
+    state: "unknown",
+    lastCheckedAt: new Date().toISOString(),
+    error: formatError(error),
+  };
+}
+
+function resetSignalWindow(window: SignalWindow): void {
+  window.overThreshold = [];
+  window.consecutiveBelowClear = 0;
+  window.elevated = false;
+}
+
+/**
+ * Feed one sample into a signal's window and derive its elevated flag.
+ *
+ * An unavailable sample (null percent) resets the window: the signal cannot
+ * hold `elevated` without data, and a fresh full window is required before it
+ * can enter again.
+ */
+function updateSignal(
+  window: SignalWindow,
+  percent: number | null,
+  thresholdPercent: number,
+  clearThresholdPercent: number,
+): boolean {
+  if (percent === null) {
+    resetSignalWindow(window);
+    return false;
+  }
+
+  window.overThreshold.push(percent >= thresholdPercent);
+  if (window.overThreshold.length > RESOURCE_PRESSURE_WINDOW_SAMPLES) {
+    window.overThreshold.shift();
+  }
+  if (percent < clearThresholdPercent) {
+    window.consecutiveBelowClear += 1;
+  } else {
+    window.consecutiveBelowClear = 0;
+  }
+
+  if (window.elevated) {
+    // Hysteresis: hold until enough consecutive samples land below the clear
+    // threshold.
+    if (
+      window.consecutiveBelowClear >=
+      RESOURCE_PRESSURE_CLEAR_CONSECUTIVE_SAMPLES
+    ) {
+      window.elevated = false;
+    }
+  } else {
+    const overCount = window.overThreshold.filter(Boolean).length;
+    window.elevated =
+      window.overThreshold.length >= RESOURCE_PRESSURE_WINDOW_SAMPLES &&
+      overCount >= RESOURCE_PRESSURE_ENTER_SAMPLES;
+  }
+
+  return window.elevated;
+}
+
+function defaultSampleCpuPercent(): number | null {
+  if (getContainerCpuCores() <= 0) {
+    return null;
+  }
+  return getCachedContainerCpuPercent();
+}
+
+function defaultSampleMemory(): ResourcePressureMemorySample | null {
+  const limitBytes = getContainerMemoryLimitBytes();
+  const usageBytes = getContainerMemoryUsageBytes();
+  if (limitBytes === null || limitBytes <= 0 || usageBytes === null) {
+    return null;
+  }
+  return {
+    usageBytes,
+    limitBytes,
+    // Raw usage includes page cache the kernel can drop under pressure;
+    // counting it would false-positive, so the working set subtracts it.
+    reclaimableBytes: getContainerMemoryStat()?.reclaimableBytes ?? 0,
+  };
+}
+
+export function startResourcePressureGuard(): ResourcePressureStatus {
+  if (!getIsPlatform()) {
+    return cloneStatus(state.status);
+  }
+
+  ensureEnabledStatus();
+
+  if (!state.timer) {
+    state.timer = setInterval(() => {
+      evaluateResourcePressureNow();
+    }, RESOURCE_PRESSURE_SAMPLE_INTERVAL_MS);
+    (state.timer as { unref?: () => void }).unref?.();
+  }
+
+  return cloneStatus(state.status);
+}
+
+export function stopResourcePressureGuard(): void {
+  if (!state.timer) {
+    return;
+  }
+  clearInterval(state.timer);
+  state.timer = null;
+}
+
+export function evaluateResourcePressureNow(
+  deps?: ResourcePressureSamplers,
+): ResourcePressureStatus {
+  if (!getIsPlatform()) {
+    return cloneStatus(state.status);
+  }
+
+  ensureEnabledStatus();
+
+  const sampleCpuPercent = deps?.sampleCpuPercent ?? defaultSampleCpuPercent;
+  const sampleMemory = deps?.sampleMemory ?? defaultSampleMemory;
+
+  let sampleError: unknown = null;
+
+  let cpuPercent: number | null = null;
+  try {
+    cpuPercent = sampleCpuPercent();
+  } catch (error) {
+    sampleError = error;
+  }
+
+  let memoryPercent: number | null = null;
+  try {
+    const memorySample = sampleMemory();
+    if (memorySample && memorySample.limitBytes > 0) {
+      const workingSetBytes = Math.max(
+        0,
+        memorySample.usageBytes - memorySample.reclaimableBytes,
+      );
+      memoryPercent = roundPercent(
+        (workingSetBytes / memorySample.limitBytes) * 100,
+      );
+    }
+  } catch (error) {
+    sampleError = error;
+  }
+
+  if (cpuPercent === null && memoryPercent === null) {
+    resetSignalWindow(state.cpuWindow);
+    resetSignalWindow(state.memoryWindow);
+    return replaceStatus(
+      sampleFailureStatus(
+        sampleError ?? "Resource pressure samples unavailable",
+      ),
+    );
+  }
+
+  const cpuElevated = updateSignal(
+    state.cpuWindow,
+    cpuPercent,
+    CPU_PRESSURE_THRESHOLD_PERCENT,
+    CPU_PRESSURE_CLEAR_THRESHOLD_PERCENT,
+  );
+  const memoryElevated = updateSignal(
+    state.memoryWindow,
+    memoryPercent,
+    MEMORY_PRESSURE_THRESHOLD_PERCENT,
+    MEMORY_PRESSURE_CLEAR_THRESHOLD_PERCENT,
+  );
+
+  return replaceStatus({
+    ...OK_STATUS,
+    state: cpuElevated || memoryElevated ? "elevated" : "ok",
+    cpuPercent,
+    memoryPercent,
+    cpuElevated,
+    memoryElevated,
+    lastCheckedAt: new Date().toISOString(),
+  });
+}
+
+export function getResourcePressureStatus(): ResourcePressureStatus {
+  if (!getIsPlatform()) {
+    return cloneStatus(DISABLED_STATUS);
+  }
+  if (!state.status.enabled) {
+    return cloneStatus(OK_STATUS);
+  }
+  return cloneStatus(state.status);
+}
+
+export function __resetResourcePressureGuardForTests(): void {
+  stopResourcePressureGuard();
+  state.status = cloneStatus(DISABLED_STATUS);
+  resetSignalWindow(state.cpuWindow);
+  resetSignalWindow(state.memoryWindow);
+}
+
+export function __getResourcePressureGuardTimerForTests(): ReturnType<
+  typeof setInterval
+> | null {
+  return state.timer;
+}

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -38,6 +38,7 @@ import { isStartupComplete } from "./daemon-readiness.js";
 import { stopDiskPressureGuardForLifecycle } from "./disk-pressure-guard-lifecycle.js";
 import { stopEventLoopWatchdog } from "./event-loop-watchdog.js";
 import { stopOrphanReaper } from "./orphan-reaper.js";
+import { stopResourcePressureGuardForLifecycle } from "./resource-pressure-guard-lifecycle.js";
 
 const log = getLogger("lifecycle");
 
@@ -49,6 +50,7 @@ const log = getLogger("lifecycle");
 function stopBackgroundServicesAndCleanupPidFile(): void {
   stopGatewayFlagListener();
   stopDiskPressureGuardForLifecycle();
+  stopResourcePressureGuardForLifecycle();
   stopOrphanReaper();
   stopEventLoopWatchdog();
   cleanupPidFile();


### PR DESCRIPTION
## Summary
- Adds a platform-gated resource-pressure guard sampling CPU and working-set memory against container limits with sustained-window enter and hysteresis clear rules
- Broadcasts resource_pressure_status_changed only on substantive transitions and wires start/stop into the daemon lifecycle

Part of plan: resource-pressure-upgrade-banner.md (PR 3 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40865" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->