### PR TITLE
fix(assistant): put tools on the wire for plugin-driven conversation turns

### DIFF
--- a/assistant/src/__tests__/run-conversation-turn-persistence.test.ts
+++ b/assistant/src/__tests__/run-conversation-turn-persistence.test.ts
@@ -40,13 +40,11 @@ import { getBindingByConversation } from "../persistence/external-conversation-s
 import { createConnection } from "../providers/inference/connections.js";
 import * as providerRegistry from "../providers/registry.js";
 import type { Provider, ProviderResponse } from "../providers/types.js";
-import { initializeTools } from "../tools/registry.js";
 import { createMockProvider, textResponse } from "./helpers/mock-provider.js";
 import { setConfig } from "./helpers/set-config.js";
 import { waitFor } from "./helpers/wait-for.js";
 
 await initializeDb();
-await initializeTools();
 
 // A conversation is built against the default provider, which resolves from
 // config through a connection row. Both are seeded for real so the store takes
@@ -421,7 +419,8 @@ describe("runConversationTurn channel binding", () => {
     // Plugin-driven iMessage turns are non-interactive, so host tools stay
     // off, but sandbox tools (bash, web_search, ...) have to remain on the
     // request. Missing them is what makes the model dump `to=bash code:`
-    // into the SMS as prose.
+    // into the SMS as prose. getOrCreateConversation initializes the
+    // registry before constructing the Conversation that snapshots it.
     await runConversationTurn({
       channel: CHANNEL,
       content: [{ type: "text", text: "hello" }],

--- a/assistant/src/__tests__/run-conversation-turn-persistence.test.ts
+++ b/assistant/src/__tests__/run-conversation-turn-persistence.test.ts
@@ -40,11 +40,13 @@ import { getBindingByConversation } from "../persistence/external-conversation-s
 import { createConnection } from "../providers/inference/connections.js";
 import * as providerRegistry from "../providers/registry.js";
 import type { Provider, ProviderResponse } from "../providers/types.js";
+import { initializeTools } from "../tools/registry.js";
 import { createMockProvider, textResponse } from "./helpers/mock-provider.js";
 import { setConfig } from "./helpers/set-config.js";
 import { waitFor } from "./helpers/wait-for.js";
 
 await initializeDb();
+await initializeTools();
 
 // A conversation is built against the default provider, which resolves from
 // config through a connection row. Both are seeded for real so the store takes
@@ -110,9 +112,12 @@ function holdTheTurnOpen(): void {
 // gate it never opened.
 afterEach(() => releaseGate?.());
 
+const providerCalls: { tools?: { name: string }[] }[] = [];
+
 const provider: Provider = {
   name: "scripted",
   async sendMessage(messages, options): Promise<ProviderResponse> {
+    providerCalls.push({ tools: options?.tools });
     await gate;
     return scriptedProvider.sendMessage(messages, options);
   },
@@ -169,6 +174,7 @@ function resetDb(): void {
   db.run("DELETE FROM conversation_keys");
   db.run("DELETE FROM conversations");
   broadcasts.length = 0;
+  providerCalls.length = 0;
 }
 
 describe("runConversationTurn persistence", () => {
@@ -399,12 +405,31 @@ describe("runConversationTurn channel binding", () => {
     expect(metadataOf(rows[0])).toMatchObject({
       userMessageChannel: "plugin",
       assistantMessageChannel: "plugin",
+      userMessageInterface: "plugin",
+      assistantMessageInterface: "plugin",
     });
     expect(rows[1].role).toBe("assistant");
     expect(metadataOf(rows[1])).toMatchObject({
       userMessageChannel: "plugin",
       assistantMessageChannel: "plugin",
+      userMessageInterface: "plugin",
+      assistantMessageInterface: "plugin",
     });
+  });
+
+  test("puts core tools on the wire for a plugin-channel turn", async () => {
+    // Plugin-driven iMessage turns are non-interactive, so host tools stay
+    // off, but sandbox tools (bash, web_search, ...) have to remain on the
+    // request. Missing them is what makes the model dump `to=bash code:`
+    // into the SMS as prose.
+    await runConversationTurn({
+      channel: CHANNEL,
+      content: [{ type: "text", text: "hello" }],
+    });
+
+    const names = providerCalls[0]?.tools?.map((tool) => tool.name) ?? [];
+    expect(names.length).toBeGreaterThan(0);
+    expect(names).toContain("bash");
   });
 
   test("a queued turn carries its own channel rather than inheriting one", async () => {
@@ -441,6 +466,8 @@ describe("runConversationTurn channel binding", () => {
     expect(metadataOf(userRows(conversationId)[1])).toMatchObject({
       userMessageChannel: "plugin",
       assistantMessageChannel: "plugin",
+      userMessageInterface: "plugin",
+      assistantMessageInterface: "plugin",
     });
   }, 20_000);
 
@@ -466,7 +493,7 @@ describe("runConversationTurn channel binding", () => {
       userMessageChannel: "vellum",
       assistantMessageChannel: "vellum",
     });
-  });
+  }, 20_000);
 
   test("keeps a known sender when a later turn omits it", async () => {
     // A plugin that knows only the chat coordinates this time is silent about

--- a/assistant/src/__tests__/run-conversation-turn-persistence.test.ts
+++ b/assistant/src/__tests__/run-conversation-turn-persistence.test.ts
@@ -419,8 +419,8 @@ describe("runConversationTurn channel binding", () => {
     // Plugin-driven iMessage turns are non-interactive, so host tools stay
     // off, but sandbox tools (bash, web_search, ...) have to remain on the
     // request. Missing them is what makes the model dump `to=bash code:`
-    // into the SMS as prose. getOrCreateConversation initializes the
-    // registry before constructing the Conversation that snapshots it.
+    // into the SMS as prose. The create path initializes the registry
+    // before constructing the Conversation that snapshots it.
     await runConversationTurn({
       channel: CHANNEL,
       content: [{ type: "text", text: "hello" }],

--- a/assistant/src/daemon/conversation-store.ts
+++ b/assistant/src/daemon/conversation-store.ts
@@ -154,7 +154,8 @@ function applyTransportMetadata(
  *
  * The in-memory Conversation snapshots the tool registry at construction.
  * An empty snapshot is an empty tool list on the wire for the life of the
- * instance, so this load path initializes the registry first.
+ * instance, so the create path initializes the registry before that
+ * constructor runs. A hit in `findConversation` already has its snapshot.
  * `initializeTools` is idempotent: a process that already initialized at
  * boot awaits the settled promise.
  */
@@ -162,9 +163,6 @@ export async function getOrCreateConversation(
   conversationId: string,
   options?: ConversationCreateOptions,
 ): Promise<Conversation> {
-  const { initializeTools } = await import("../tools/registry.js");
-  await initializeTools();
-
   let conversation = findConversation(conversationId);
 
   // `taskRunId` and `ephemeral` are per-call scopes, not durable conversation
@@ -236,6 +234,9 @@ export async function getOrCreateConversation(
 
       const systemPrompt = await resolveInitialSystemPrompt(storedOptions);
       const maxTokens = storedOptions?.maxResponseTokens;
+
+      const { initializeTools } = await import("../tools/registry.js");
+      await initializeTools();
 
       const newConversation = new Conversation(
         conversationId,

--- a/assistant/src/daemon/conversation-store.ts
+++ b/assistant/src/daemon/conversation-store.ts
@@ -151,11 +151,20 @@ function applyTransportMetadata(
  *
  * Handles provider setup, rate limiting, system prompt, memory policy,
  * and conversation hydration.
+ *
+ * The in-memory Conversation snapshots the tool registry at construction.
+ * An empty snapshot is an empty tool list on the wire for the life of the
+ * instance, so this load path initializes the registry first.
+ * `initializeTools` is idempotent: a process that already initialized at
+ * boot awaits the settled promise.
  */
 export async function getOrCreateConversation(
   conversationId: string,
   options?: ConversationCreateOptions,
 ): Promise<Conversation> {
+  const { initializeTools } = await import("../tools/registry.js");
+  await initializeTools();
+
   let conversation = findConversation(conversationId);
 
   // `taskRunId` and `ephemeral` are per-call scopes, not durable conversation

--- a/assistant/src/plugin-api/conversation-turn.ts
+++ b/assistant/src/plugin-api/conversation-turn.ts
@@ -283,12 +283,6 @@ export async function runConversationTurn(
   const { parseInterfaceId } = await import("../channels/types.js");
   const { resolveChannelCapabilities } =
     await import("../daemon/conversation-runtime-assembly.js");
-  const { initializeTools } = await import("../tools/registry.js");
-  // Idempotent. A process that can drive a turn (the daemon, a route-host,
-  // a sidecar) must have the core tool registry populated before the
-  // conversation snapshots it at construction. Missing this is an empty
-  // tool list on the wire, and the model writes tool calls as prose.
-  await initializeTools();
 
   // Plugin-driven turns run as the guardian: plugins are installed by the
   // guardian, so their conversations inherit guardian trust. This lets the

--- a/assistant/src/plugin-api/conversation-turn.ts
+++ b/assistant/src/plugin-api/conversation-turn.ts
@@ -280,6 +280,15 @@ export async function runConversationTurn(
     await import("../persistence/conversation-crud.js");
   const { publishConversationListAndMetadataChanged } =
     await import("../runtime/sync/resource-sync-events.js");
+  const { parseInterfaceId } = await import("../channels/types.js");
+  const { resolveChannelCapabilities } =
+    await import("../daemon/conversation-runtime-assembly.js");
+  const { initializeTools } = await import("../tools/registry.js");
+  // Idempotent. A process that can drive a turn (the daemon, a route-host,
+  // a sidecar) must have the core tool registry populated before the
+  // conversation snapshots it at construction. Missing this is an empty
+  // tool list on the wire, and the model writes tool calls as prose.
+  await initializeTools();
 
   // Plugin-driven turns run as the guardian: plugins are installed by the
   // guardian, so their conversations inherit guardian trust. This lets the
@@ -351,6 +360,28 @@ export async function runConversationTurn(
         assistantMessageChannel: options.channel.sourceChannel,
       }
     : null;
+  // The interface the message arrived on. `plugin` is in both the channel
+  // and interface unions, matching gateway inbound. Tool gating reads this
+  // as `transportInterface`; unset, the loop falls back to `web`.
+  const turnInterfaceContext = options.channel
+    ? (() => {
+        const iface = parseInterfaceId(options.channel.sourceChannel);
+        return iface
+          ? {
+              userMessageInterface: iface,
+              assistantMessageInterface: iface,
+            }
+          : null;
+      })()
+    : null;
+  if (options.channel) {
+    conversation.setChannelCapabilities(
+      resolveChannelCapabilities(
+        options.channel.sourceChannel,
+        turnInterfaceContext?.userMessageInterface,
+      ),
+    );
+  }
   // Carried on the metadata as well, because a queued turn is drained after
   // this call returns and reads its channel from there. Without it the drain
   // inherits whichever turn was in flight, which on a shared conversation is
@@ -358,6 +389,7 @@ export async function runConversationTurn(
   const metadata = {
     ...PLUGIN_TURN_MESSAGE_METADATA,
     ...(turnChannelContext ?? {}),
+    ...(turnInterfaceContext ?? {}),
   };
 
   // Build the event emitter: fan out to SSE/event-hub subscribers via
@@ -398,6 +430,7 @@ export async function runConversationTurn(
   }
 
   conversation.setTurnChannelContext(turnChannelContext);
+  conversation.setTurnInterfaceContext(turnInterfaceContext);
 
   const userMessageId = await conversation.processMessage({
     content: text,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

Photon live iMessage QA showed the model dumping `to=bash code:` into the SMS as prose. Plugin-driven turns were reaching the agent loop with an empty tool list and with no interface context (the loop then falls back to `web`).

A conversation snapshots `getAllToolDefinitions()` at construction. If the registry has not been initialized, `createResolveToolsCallback` gets an empty list and returns `undefined`, so the LLM never sees `bash` (or anything else) and writes tool-call syntax as text.

## What changed

- `getOrCreateConversation`'s create path (`createPromise`, immediately before `new Conversation`) initializes the tool registry. `findConversation` is a memory hit and already has its snapshot, so it does not wait on init. `initializeTools` is idempotent, so a daemon that already ran it at boot just awaits the settled promise.
- Stamp `turnInterfaceContext` from `parseInterfaceId(channel.sourceChannel)`. `plugin` is both a ChannelId and an InterfaceId, matching gateway inbound.
- Set channel capabilities for that channel + interface.
- Carry the interface on message metadata so a queued drain reads the same context.

Plugin turns stay non-interactive (`isInteractive: false`) with guardian trust. Sandbox tools including `bash` stay on; host tools stay off.

## Companion

The imessage plugin PR (`vellum-ai/imessage` `cursor/live-turn-ux-e9a8`) sends only the last `type: text` block and starts Photon's typing indicator.

## Test plan

- `cd assistant && bun test src/__tests__/run-conversation-turn-persistence.test.ts`
- Asserts plugin turns stamp `userMessageInterface` / `assistantMessageInterface: "plugin"`.
- Asserts core tools including `bash` are on the provider request for a plugin-channel turn.

## CLI verb checklist

No new HTTP/IPC routes. `runConversationTurn` is the existing plugin-api facade.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09030aa5-c6fd-4408-be6c-0f9fb7d2e9a8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09030aa5-c6fd-4408-be6c-0f9fb7d2e9a8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

