### PR TITLE
feat(runtime): expose GET resource-pressure/status

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -25300,6 +25300,74 @@ paths:
       responses:
         "200":
           description: Successful response
+  /v1/resource-pressure/status:
+    get:
+      operationId: resourcepressure_status_get
+      summary: Get resource pressure status
+      description:
+        Return the current resource pressure status snapshot. Off-platform the guard does not run, so a disabled
+        status is returned.
+      tags:
+        - resource-pressure
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: object
+                    properties:
+                      enabled:
+                        type: boolean
+                      state:
+                        type: string
+                        enum:
+                          - disabled
+                          - ok
+                          - elevated
+                          - unknown
+                      cpuPercent:
+                        anyOf:
+                          - type: number
+                          - type: "null"
+                      memoryPercent:
+                        anyOf:
+                          - type: number
+                          - type: "null"
+                      cpuElevated:
+                        type: boolean
+                      memoryElevated:
+                        type: boolean
+                      cpuThresholdPercent:
+                        type: number
+                      memoryThresholdPercent:
+                        type: number
+                      lastCheckedAt:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                      error:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                    required:
+                      - enabled
+                      - state
+                      - cpuPercent
+                      - memoryPercent
+                      - cpuElevated
+                      - memoryElevated
+                      - cpuThresholdPercent
+                      - memoryThresholdPercent
+                      - lastCheckedAt
+                      - error
+                    additionalProperties: false
+                required:
+                  - status
+                additionalProperties: false
   /v1/retrospective/config:
     get:
       operationId: retrospective_config_get

--- a/assistant/src/__tests__/resource-pressure-routes.test.ts
+++ b/assistant/src/__tests__/resource-pressure-routes.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { ResourcePressureStatusResponseSchema } from "../api/responses/resource-pressure-status.js";
+
+mock.module("../runtime/assistant-event-hub.js", () => ({
+  AssistantEventHub: class {},
+  broadcastMessage: () => {},
+  capabilityForMessageType: () => undefined,
+  assistantEventHub: {
+    publish: async () => {},
+  },
+}));
+
+mock.module("../util/container-cpu-sampler.js", () => ({
+  getCachedContainerCpuPercent: () => 0,
+}));
+
+mock.module("../util/cgroup-cpu.js", () => ({
+  getContainerCpuCores: () => 0,
+}));
+
+mock.module("../util/cgroup-memory.js", () => ({
+  getContainerMemoryLimitBytes: () => null,
+  getContainerMemoryUsageBytes: () => null,
+  getContainerMemoryStat: () => null,
+}));
+
+const {
+  __resetResourcePressureGuardForTests,
+  evaluateResourcePressureNow,
+  getResourcePressureStatus,
+} = await import("../daemon/resource-pressure-guard.js");
+const { ROUTES } =
+  await import("../runtime/routes/resource-pressure-routes.js");
+
+const statusRoute = ROUTES.find(
+  (route) =>
+    route.endpoint === "resource-pressure/status" && route.method === "GET",
+);
+
+async function callStatusRoute() {
+  if (!statusRoute) {
+    throw new Error("GET resource-pressure/status route not registered");
+  }
+  return ResourcePressureStatusResponseSchema.parse(
+    await statusRoute.handler({}),
+  );
+}
+
+const originalIsPlatform = process.env.IS_PLATFORM;
+
+function restoreIsPlatform(): void {
+  if (originalIsPlatform === undefined) {
+    delete process.env.IS_PLATFORM;
+  } else {
+    process.env.IS_PLATFORM = originalIsPlatform;
+  }
+}
+
+beforeEach(() => {
+  __resetResourcePressureGuardForTests();
+});
+
+afterEach(() => {
+  __resetResourcePressureGuardForTests();
+  restoreIsPlatform();
+});
+
+describe("resource pressure routes", () => {
+  test("registers the status route with a read-scoped auth policy", () => {
+    expect(statusRoute).toBeDefined();
+    expect(statusRoute?.policy?.requiredScopes).toEqual(["settings.read"]);
+    expect(statusRoute?.policy?.allowedPrincipalTypes?.length).toBeGreaterThan(
+      0,
+    );
+  });
+
+  test("returns the disabled snapshot when the guard never started", async () => {
+    delete process.env.IS_PLATFORM;
+
+    const result = await callStatusRoute();
+
+    expect(result.status.enabled).toBe(false);
+    expect(result.status.state).toBe("disabled");
+    expect(result.status.cpuPercent).toBeNull();
+    expect(result.status.memoryPercent).toBeNull();
+    expect(result.status.lastCheckedAt).toBeNull();
+    expect(result.status.error).toBeNull();
+  });
+
+  test("returns the guard's current snapshot on platform", async () => {
+    process.env.IS_PLATFORM = "true";
+    evaluateResourcePressureNow({
+      sampleCpuPercent: () => 42,
+      sampleMemory: () => ({
+        usageBytes: 500,
+        limitBytes: 1000,
+        reclaimableBytes: 100,
+      }),
+    });
+
+    const result = await callStatusRoute();
+
+    expect(result.status).toEqual(getResourcePressureStatus());
+    expect(result.status.enabled).toBe(true);
+    expect(result.status.state).toBe("ok");
+    expect(result.status.cpuPercent).toBe(42);
+    expect(result.status.memoryPercent).toBe(40);
+    expect(result.status.lastCheckedAt).toBeTruthy();
+  });
+});

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -127,6 +127,7 @@ import { ROUTES as PUBLISH_ROUTES } from "./publish-routes.js";
 import { ROUTES as QUESTION_ROUTES } from "./question-routes.js";
 import { ROUTES as RECORDING_ROUTES } from "./recording-routes.js";
 import { ROUTES as RENAME_CONVERSATION_ROUTES } from "./rename-conversation-routes.js";
+import { ROUTES as RESOURCE_PRESSURE_ROUTES } from "./resource-pressure-routes.js";
 import { ROUTES as RETROSPECTIVE_ROUTES } from "./retrospective-routes.js";
 import { ROUTES as ROUTE_HOST_WORKER_ROUTES } from "./route-host-worker-routes.js";
 import { ROUTES as SANITY_ROUTES } from "./sanity-routes.js";
@@ -210,6 +211,7 @@ export const ROUTES: RouteDefinition[] = [
   ...DEFAULT_PROVIDER_ROUTES,
   ...DIAGNOSTICS_ROUTES,
   ...DISK_PRESSURE_ROUTES,
+  ...RESOURCE_PRESSURE_ROUTES,
   ...DOMAIN_ROUTES,
   ...DOCUMENT_COMMENT_ROUTES,
   ...DOCUMENT_ROUTES,

--- a/assistant/src/runtime/routes/resource-pressure-routes.ts
+++ b/assistant/src/runtime/routes/resource-pressure-routes.ts
@@ -1,0 +1,22 @@
+import { ResourcePressureStatusResponseSchema } from "../../api/responses/resource-pressure-status.js";
+import { getResourcePressureStatus } from "../../daemon/resource-pressure-guard.js";
+import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import type { RouteDefinition } from "./types.js";
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "getResourcePressureStatus",
+    endpoint: "resource-pressure/status",
+    method: "GET",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Get resource pressure status",
+    description:
+      "Return the current resource pressure status snapshot. Off-platform the guard does not run, so a disabled status is returned.",
+    tags: ["resource-pressure"],
+    responseBody: ResourcePressureStatusResponseSchema,
+    handler: () => ({ status: getResourcePressureStatus() }),
+  },
+];


### PR DESCRIPTION
## Summary
- Adds the read-only resource-pressure status route to the shared ROUTES array (dual HTTP/IPC exposure)
- Regenerates the tracked assistant/openapi.yaml with the new operation

Part of plan: resource-pressure-upgrade-banner.md (PR 4 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40870" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->