### PR TITLE
feat(web): resource-pressure monitor hook and SSE plumbing

### DIFF
--- a/clients/web/src/assistant/api.ts
+++ b/clients/web/src/assistant/api.ts
@@ -1,6 +1,8 @@
 import {
   type DiskPressureStatusResponse,
   DiskPressureStatusResponseSchema,
+  type ResourcePressureStatusResponse,
+  ResourcePressureStatusResponseSchema,
 } from "@vellumai/assistant-api";
 
 import {
@@ -26,6 +28,7 @@ import {
   diskpressureAcknowledgePost,
   diskpressureStatusGet,
   healthzGet,
+  resourcepressureStatusGet,
 } from "@/generated/daemon/sdk.gen";
 import type { HealthzGetResponse } from "@/generated/daemon/types.gen";
 import { assertHasResponse, toErrorObject } from "@/utils/api-errors";
@@ -57,6 +60,10 @@ export type GetAssistantDiskPressureStatusResult =
 
 export type AcknowledgeAssistantDiskPressureResult =
   | { ok: true; status: number; data: DiskPressureStatusResponse }
+  | { ok: false; status: number; error: Record<string, unknown> };
+
+export type GetAssistantResourcePressureStatusResult =
+  | { ok: true; status: number; data: ResourcePressureStatusResponse }
   | { ok: false; status: number; error: Record<string, unknown> };
 
 /**
@@ -257,6 +264,44 @@ export async function getAssistantDiskPressureStatus(
 
   if (response.ok) {
     const parsed = DiskPressureStatusResponseSchema.safeParse(data);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        status: response.status,
+        error: toErrorObject(parsed.error.message, response),
+      };
+    }
+
+    return {
+      ok: true,
+      status: response.status,
+      data: parsed.data,
+    };
+  }
+
+  return {
+    ok: false,
+    status: response.status,
+    error: toErrorObject(error, response),
+  };
+}
+
+export async function getAssistantResourcePressureStatus(
+  assistantId: string,
+): Promise<GetAssistantResourcePressureStatusResult> {
+  const { data, error, response } = await resourcepressureStatusGet({
+    path: { assistant_id: assistantId },
+    throwOnError: false,
+  });
+
+  assertHasResponse(
+    response,
+    error,
+    "Failed to get assistant resource pressure status.",
+  );
+
+  if (response.ok) {
+    const parsed = ResourcePressureStatusResponseSchema.safeParse(data);
     if (!parsed.success) {
       return {
         ok: false,

--- a/clients/web/src/assistant/resource-pressure.ts
+++ b/clients/web/src/assistant/resource-pressure.ts
@@ -1,0 +1,41 @@
+import type { ResourcePressureStatus } from "@vellumai/assistant-api";
+
+export type ResourcePressureMonitorMode = "inactive" | "warning";
+
+export const RESOURCE_PRESSURE_POLL_INTERVAL_MS = 60_000;
+
+export function getResourcePressureMonitorMode(
+  status: ResourcePressureStatus | null | undefined,
+): ResourcePressureMonitorMode {
+  if (status?.enabled && status.state === "elevated") {
+    return "warning";
+  }
+
+  return "inactive";
+}
+
+export function areResourcePressureStatusesEqual(
+  left: ResourcePressureStatus | null,
+  right: ResourcePressureStatus | null,
+): boolean {
+  if (left === right) {
+    return true;
+  }
+
+  if (!left || !right) {
+    return false;
+  }
+
+  return (
+    left.enabled === right.enabled &&
+    left.state === right.state &&
+    left.cpuPercent === right.cpuPercent &&
+    left.memoryPercent === right.memoryPercent &&
+    left.cpuElevated === right.cpuElevated &&
+    left.memoryElevated === right.memoryElevated &&
+    left.cpuThresholdPercent === right.cpuThresholdPercent &&
+    left.memoryThresholdPercent === right.memoryThresholdPercent &&
+    left.lastCheckedAt === right.lastCheckedAt &&
+    left.error === right.error
+  );
+}

--- a/clients/web/src/assistant/use-resource-pressure-monitor.ts
+++ b/clients/web/src/assistant/use-resource-pressure-monitor.ts
@@ -1,0 +1,224 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import type { ResourcePressureStatus } from "@vellumai/assistant-api";
+
+import { getAssistantResourcePressureStatus } from "@/assistant/api";
+import {
+  RESOURCE_PRESSURE_POLL_INTERVAL_MS,
+  areResourcePressureStatusesEqual,
+  getResourcePressureMonitorMode,
+  type ResourcePressureMonitorMode,
+} from "@/assistant/resource-pressure";
+import { useBusSubscription } from "@/hooks/use-bus-subscription";
+
+export interface UseResourcePressureMonitorOptions {
+  assistantId: string | null;
+  enabled: boolean;
+  refreshKey?: unknown;
+  cadenceMs?: number;
+}
+
+export type ResourcePressureStatusEventPayload = ResourcePressureStatus | null;
+
+export interface UseResourcePressureMonitorResult {
+  status: ResourcePressureStatus | null;
+  mode: ResourcePressureMonitorMode;
+  hasResolvedStatus: boolean;
+  applyStatusEvent: (payload: ResourcePressureStatusEventPayload) => void;
+  refresh: () => Promise<void>;
+}
+
+interface ResourcePressureMonitorSnapshot {
+  assistantId: string | null;
+  status: ResourcePressureStatus | null;
+  hasResolvedStatus: boolean;
+}
+
+const EMPTY_RESOURCE_PRESSURE_MONITOR_SNAPSHOT: ResourcePressureMonitorSnapshot =
+  {
+    assistantId: null,
+    status: null,
+    hasResolvedStatus: false,
+  };
+
+export function useResourcePressureMonitor({
+  assistantId,
+  enabled,
+  refreshKey,
+  cadenceMs = RESOURCE_PRESSURE_POLL_INTERVAL_MS,
+}: UseResourcePressureMonitorOptions): UseResourcePressureMonitorResult {
+  const [snapshot, setSnapshot] = useState<ResourcePressureMonitorSnapshot>(
+    EMPTY_RESOURCE_PRESSURE_MONITOR_SNAPSHOT,
+  );
+  const activeAssistantIdRef = useRef<string | null>(assistantId);
+  const enabledRef = useRef(enabled);
+  const generationRef = useRef(0);
+  const pollRequestIdRef = useRef(0);
+
+  useLayoutEffect(() => {
+    activeAssistantIdRef.current = assistantId;
+    enabledRef.current = enabled;
+  });
+
+  useEffect(() => {
+    generationRef.current += 1;
+    setSnapshot(EMPTY_RESOURCE_PRESSURE_MONITOR_SNAPSHOT);
+  }, [assistantId, enabled]);
+
+  const isCurrentRequest = useCallback(
+    (requestedAssistantId: string, generation: number) =>
+      enabledRef.current &&
+      activeAssistantIdRef.current === requestedAssistantId &&
+      generationRef.current === generation,
+    [],
+  );
+
+  const applyStatusForAssistant = useCallback(
+    (
+      requestedAssistantId: string,
+      nextStatus: ResourcePressureStatus | null,
+      hasResolvedStatus: boolean,
+      generation: number,
+    ) => {
+      if (!isCurrentRequest(requestedAssistantId, generation)) {
+        return;
+      }
+
+      setSnapshot((current) => {
+        if (
+          current.assistantId === requestedAssistantId &&
+          current.hasResolvedStatus === hasResolvedStatus &&
+          areResourcePressureStatusesEqual(current.status, nextStatus)
+        ) {
+          return current;
+        }
+
+        return {
+          assistantId: requestedAssistantId,
+          status: nextStatus,
+          hasResolvedStatus,
+        };
+      });
+    },
+    [isCurrentRequest],
+  );
+
+  const clearStatus = useCallback(() => {
+    generationRef.current += 1;
+    setSnapshot(EMPTY_RESOURCE_PRESSURE_MONITOR_SNAPSHOT);
+  }, []);
+
+  const refresh = useCallback(async () => {
+    const requestedAssistantId = assistantId;
+
+    if (!enabled || !requestedAssistantId) {
+      clearStatus();
+      return;
+    }
+
+    const generation = generationRef.current;
+    const pollRequestId = pollRequestIdRef.current + 1;
+    pollRequestIdRef.current = pollRequestId;
+
+    try {
+      const result =
+        await getAssistantResourcePressureStatus(requestedAssistantId);
+      if (pollRequestIdRef.current !== pollRequestId) {
+        return;
+      }
+
+      if (!result.ok) {
+        applyStatusForAssistant(requestedAssistantId, null, false, generation);
+        return;
+      }
+
+      applyStatusForAssistant(
+        requestedAssistantId,
+        result.data.status,
+        true,
+        generation,
+      );
+    } catch {
+      if (pollRequestIdRef.current !== pollRequestId) {
+        return;
+      }
+
+      applyStatusForAssistant(requestedAssistantId, null, false, generation);
+    }
+  }, [assistantId, applyStatusForAssistant, clearStatus, enabled]);
+
+  useEffect(() => {
+    if (!enabled || !assistantId) {
+      return;
+    }
+
+    void refresh();
+
+    const intervalId = window.setInterval(() => {
+      void refresh();
+    }, cadenceMs);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [assistantId, cadenceMs, enabled, refresh, refreshKey]);
+
+  // The bus's `"app.resume"` channel fans in browser visibility,
+  // Capacitor foreground, and `window.online`, so a single
+  // subscription drives the focus-style refetch. `refresh` guards
+  // on `enabled` and `assistantId` internally.
+  useBusSubscription("app.resume", () => {
+    void refresh();
+  });
+
+  const applyStatusEvent = useCallback(
+    (payload: ResourcePressureStatusEventPayload) => {
+      if (!enabled || !assistantId) {
+        clearStatus();
+        return;
+      }
+
+      const generation = generationRef.current + 1;
+      generationRef.current = generation;
+      applyStatusForAssistant(assistantId, payload, true, generation);
+    },
+    [assistantId, applyStatusForAssistant, clearStatus, enabled],
+  );
+
+  // React to daemon-pushed resource pressure events via the event bus.
+  // Complements the polling interval and resume-refresh above so
+  // status changes are reflected immediately without waiting for
+  // the next poll tick.
+  useBusSubscription("sse.event", (envelope) => {
+    const event = envelope.message;
+    if (event.type !== "resource_pressure_status_changed") {
+      return;
+    }
+    applyStatusEvent(event.status);
+  });
+
+  const status =
+    enabled && snapshot.assistantId === assistantId ? snapshot.status : null;
+  const hasResolvedStatus = Boolean(
+    enabled &&
+    assistantId &&
+    snapshot.assistantId === assistantId &&
+    snapshot.hasResolvedStatus,
+  );
+  const mode = useMemo(() => getResourcePressureMonitorMode(status), [status]);
+
+  return {
+    status,
+    mode,
+    hasResolvedStatus,
+    applyStatusEvent,
+    refresh,
+  };
+}

--- a/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -463,8 +463,9 @@ export function useStreamEventHandler(
         // Cross-domain events handled by bus subscribers mounted in
         // RootLayout (useAssistantResourceSync, useConversationSync,
         // useNotificationIntentSync, useDocumentEditorSync, useBookmarksSync)
-        // or ChatPage-scoped hooks (useDiskPressureMonitor). The chat
-        // handler is intentionally a no-op for these.
+        // or ChatPage-scoped hooks (useDiskPressureMonitor,
+        // useResourcePressureMonitor). The chat handler is intentionally
+        // a no-op for these.
         case "bookmark.created":
         case "bookmark.deleted":
         case "sync_changed":


### PR DESCRIPTION
## Summary
- Adds resource-pressure helpers, the polling+SSE monitor hook, and the typed daemon API wrapper
- Event plumbing for resource_pressure_status_changed verified in the chat domain

Part of plan: resource-pressure-upgrade-banner.md (PR 5 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40872" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->