### PR TITLE
fix(conversations): title a channel conversation when it is created, not when a turn runs (LUM-2872)

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -64,7 +64,10 @@ mock.module("../daemon/approval-generators.js", () => ({
   createApprovalConversationGenerator: () => _testApprovalConversationGenerator,
 }));
 
+import { eq } from "drizzle-orm";
+
 import type { Conversation } from "../daemon/conversation.js";
+import { getConversationByKey } from "../persistence/conversation-key-store.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import * as deliveryChannels from "../persistence/delivery-channels.js";
@@ -832,6 +835,23 @@ describe("stale callback handling", () => {
 
     expect(body.accepted).toBe(true);
     expect(body.approval).toBe("stale_ignored");
+
+    // A stale button press mints the chat's conversation and runs no turn, so
+    // it carries the deterministic mint title rather than the placeholder.
+    const mapping = getConversationByKey("asst:self:telegram:chat-123");
+    expect(mapping).not.toBeNull();
+    const minted = getDb()
+      .select({
+        title: conversations.title,
+        isAutoTitle: conversations.isAutoTitle,
+      })
+      .from(conversations)
+      .where(eq(conversations.id, mapping!.conversationId))
+      .get();
+    expect(minted).toEqual({
+      title: "Message from telegram-user-default",
+      isAutoTitle: 2,
+    });
   });
 
   test("callback with non-empty content but no pending approval returns stale_ignored", async () => {

--- a/assistant/src/__tests__/channel-delivery-store.test.ts
+++ b/assistant/src/__tests__/channel-delivery-store.test.ts
@@ -147,10 +147,8 @@ describe("channel-delivery-store", () => {
     const minted = resolveInboundConversation("slack", channelId, null);
     const again = resolveInboundConversation("slack", channelId, null);
     expect(minted.created).toBe(true);
-    expect(again).toEqual({
-      conversationId: minted.conversationId,
-      created: false,
-    });
+    expect(again.conversationId).toBe(minted.conversationId);
+    expect(again.created).toBe(false);
 
     // A threaded key aliased onto the flat conversation is an existing
     // conversation, not a new one.
@@ -158,10 +156,8 @@ describe("channel-delivery-store", () => {
       sourceMessageId: threadTs,
     });
     const aliased = resolveInboundConversation("slack", channelId, threadTs);
-    expect(aliased).toEqual({
-      conversationId: minted.conversationId,
-      created: false,
-    });
+    expect(aliased.conversationId).toBe(minted.conversationId);
+    expect(aliased.created).toBe(false);
 
     const separate = resolveInboundConversation(
       "slack",

--- a/assistant/src/__tests__/channel-delivery-store.test.ts
+++ b/assistant/src/__tests__/channel-delivery-store.test.ts
@@ -13,6 +13,7 @@ import {
   findMessageBySourceId,
   linkMessage,
   recordInbound,
+  resolveInboundConversation,
   storePayload,
 } from "../persistence/delivery-crud.js";
 import {
@@ -127,6 +128,48 @@ describe("channel-delivery-store", () => {
     const r2 = recordInbound("telegram", "chat-1", "msg-2");
 
     expect(r1.conversationId).toBe(r2.conversationId);
+  });
+
+  test("reports created only on the event that mints the conversation", () => {
+    const first = recordInbound("telegram", "chat-1", "msg-1");
+    const second = recordInbound("telegram", "chat-1", "msg-2");
+    const replay = recordInbound("telegram", "chat-1", "msg-1");
+
+    expect(first.created).toBe(true);
+    expect(second.created).toBe(false);
+    expect(replay.duplicate).toBe(true);
+    expect(replay.created).toBe(false);
+  });
+
+  test("resolveInboundConversation reports created on the mint and never on an alias", () => {
+    const channelId = "C0123ABCDEF";
+    const threadTs = "1710000000.000100";
+    const minted = resolveInboundConversation("slack", channelId, null);
+    const again = resolveInboundConversation("slack", channelId, null);
+    expect(minted.created).toBe(true);
+    expect(again).toEqual({
+      conversationId: minted.conversationId,
+      created: false,
+    });
+
+    // A threaded key aliased onto the flat conversation is an existing
+    // conversation, not a new one.
+    recordInbound("slack", channelId, "legacy-event", {
+      sourceMessageId: threadTs,
+    });
+    const aliased = resolveInboundConversation("slack", channelId, threadTs);
+    expect(aliased).toEqual({
+      conversationId: minted.conversationId,
+      created: false,
+    });
+
+    const separate = resolveInboundConversation(
+      "slack",
+      channelId,
+      "1710000000.000200",
+    );
+    expect(separate.created).toBe(true);
+    expect(separate.conversationId).not.toBe(minted.conversationId);
   });
 
   test("same Slack channel and thread reuses the same conversation", () => {
@@ -488,6 +531,41 @@ describe("channel-delivery-store", () => {
       getConversationByKey(`asst:self:slack:${channelId}:thread:${threadTs}`)
         ?.conversationId,
     ).toBe(afterReset.conversationId);
+  });
+
+  test("Slack thread reset titles the eagerly re-minted conversation", async () => {
+    const channelId = "C0123ABCDEF";
+    const threadTs = "1710000000.000100";
+    recordInbound("slack", channelId, "thread-reply", {
+      sourceThreadId: threadTs,
+      sourceMessageId: "1710000001.000100",
+    });
+
+    const req = new Request("http://localhost/channels/conversation", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sourceChannel: "slack",
+        conversationExternalId: channelId,
+        sourceThreadId: threadTs,
+      }),
+    });
+    const res = await handleDeleteConversation(req);
+    expect(res.status).toBe(200);
+
+    const fresh = getConversationByKey(
+      `asst:self:slack:${channelId}:thread:${threadTs}`,
+    );
+    expect(fresh).not.toBeNull();
+    const row = getDb()
+      .select({
+        title: conversations.title,
+        isAutoTitle: conversations.isAutoTitle,
+      })
+      .from(conversations)
+      .where(eq(conversations.id, fresh!.conversationId))
+      .get();
+    expect(row).toEqual({ title: "New Slack message", isAutoTitle: 2 });
   });
 
   test("different chats get different conversations", () => {

--- a/assistant/src/__tests__/channel-inbound-disk-pressure.test.ts
+++ b/assistant/src/__tests__/channel-inbound-disk-pressure.test.ts
@@ -55,7 +55,11 @@ mock.module("../daemon/disk-pressure-guard.js", () => ({
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import * as deliveryCrud from "../persistence/delivery-crud.js";
-import { channelInboundEvents, messages } from "../persistence/schema/index.js";
+import {
+  channelInboundEvents,
+  conversations,
+  messages,
+} from "../persistence/schema/index.js";
 import { sweepFailedEvents } from "../runtime/channel-retry-sweep.js";
 import {
   handleChannelInbound,
@@ -159,6 +163,21 @@ describe("channel inbound disk pressure gate", () => {
     expect(event?.messageId).toBeNull();
     expect(event?.rawPayload).toBeNull();
     expect(db.select().from(messages).all()).toHaveLength(0);
+
+    // The block runs no turn, so the minted conversation carries the
+    // deterministic mint title rather than the placeholder.
+    const minted = db
+      .select({
+        title: conversations.title,
+        isAutoTitle: conversations.isAutoTitle,
+      })
+      .from(conversations)
+      .where(eq(conversations.id, event!.conversationId))
+      .get();
+    expect(minted).toEqual({
+      title: "Message from telegram-user-1",
+      isAutoTitle: 2,
+    });
   });
 
   test("preserves retryable duplicate ingress without re-sending block replies", async () => {

--- a/assistant/src/__tests__/channel-inbound-mint-title.test.ts
+++ b/assistant/src/__tests__/channel-inbound-mint-title.test.ts
@@ -1,0 +1,177 @@
+/**
+ * A channel conversation is titled at the moment `recordInbound` mints it, so
+ * no lane that returns without a turn can leave it on the "Generating title..."
+ * placeholder. These cases drive the handler end to end against the real
+ * database and read the title back.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { eq } from "drizzle-orm";
+
+mock.module("../runtime/gateway-client.js", () => ({
+  deliverChannelReply: async () => {},
+}));
+
+import { getConversationByKey } from "../persistence/conversation-key-store.js";
+import {
+  AUTO_TITLE_DETERMINISTIC,
+  GENERATING_TITLE,
+} from "../persistence/conversation-title-service.js";
+import { getDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import {
+  channelInboundEvents,
+  conversations,
+} from "../persistence/schema/index.js";
+import {
+  handleChannelInbound,
+  seedContactChannel,
+  setAdapterProcessMessage,
+} from "./helpers/channel-test-adapter.js";
+import { bridgeState } from "./helpers/gateway-guardian-requests-store-bridge.js";
+import { setConfig } from "./helpers/set-config.js";
+
+await initializeDb();
+
+const CHAT_KEY = "asst:self:telegram:chat-123";
+
+function resetTables(): void {
+  bridgeState.reset();
+  const db = getDb();
+  db.run("DELETE FROM channel_inbound_events");
+  db.run("DELETE FROM conversation_keys");
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+  db.run("DELETE FROM external_conversation_bindings");
+  db.run("DELETE FROM contact_channels");
+  db.run("DELETE FROM contacts");
+}
+
+function makeInboundRequest(overrides: Record<string, unknown> = {}): Request {
+  return new Request("http://localhost/channels/inbound", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Gateway-Origin": "test-token",
+    },
+    body: JSON.stringify({
+      sourceChannel: "telegram",
+      interface: "telegram",
+      conversationExternalId: "chat-123",
+      externalMessageId: `msg-${Date.now()}-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`,
+      content: "hello",
+      actorExternalId: "telegram-user-1",
+      actorDisplayName: "Alice Example",
+      actorUsername: "alice",
+      replyCallbackUrl: "https://gateway.test/deliver/telegram",
+      ...overrides,
+    }),
+  });
+}
+
+function readTitle(): { title: string | null; isAutoTitle: number } {
+  const mapping = getConversationByKey(CHAT_KEY);
+  expect(mapping).not.toBeNull();
+  const row = getDb()
+    .select({
+      title: conversations.title,
+      isAutoTitle: conversations.isAutoTitle,
+    })
+    .from(conversations)
+    .where(eq(conversations.id, mapping!.conversationId))
+    .get();
+  expect(row).toBeDefined();
+  return row!;
+}
+
+describe("channel inbound mint title", () => {
+  beforeEach(() => {
+    resetTables();
+    seedContactChannel({
+      sourceChannel: "telegram",
+      externalUserId: "telegram-user-1",
+      displayName: "Alice Example",
+      status: "active",
+      policy: "allow",
+    });
+    setAdapterProcessMessage(async () => ({ messageId: "msg-1" }));
+    setConfig("secretDetection", { enabled: false, blockIngress: false });
+  });
+
+  test("a first message mints the conversation with a sender title", async () => {
+    const res = await handleChannelInbound(makeInboundRequest());
+    expect(res.status).toBe(200);
+
+    expect(readTitle()).toEqual({
+      title: "Message from Alice Example",
+      isAutoTitle: AUTO_TITLE_DETERMINISTIC,
+    });
+  });
+
+  test("falls back to the username, then the external id, then the channel", async () => {
+    await handleChannelInbound(
+      makeInboundRequest({ actorDisplayName: undefined }),
+    );
+    expect(readTitle().title).toBe("Message from alice");
+
+    resetTables();
+    seedContactChannel({
+      sourceChannel: "telegram",
+      externalUserId: "telegram-user-1",
+      displayName: "Alice Example",
+      status: "active",
+      policy: "allow",
+    });
+    await handleChannelInbound(
+      makeInboundRequest({
+        actorDisplayName: undefined,
+        actorUsername: undefined,
+      }),
+    );
+    expect(readTitle().title).toBe("Message from telegram-user-1");
+  });
+
+  test("a message blocked for containing a secret still leaves a titled conversation", async () => {
+    setConfig("secretDetection", { enabled: true, blockIngress: true });
+    const processMessage = mock(async () => {
+      throw new Error("processMessage should not run");
+    });
+    setAdapterProcessMessage(processMessage);
+
+    const res = await handleChannelInbound(
+      makeInboundRequest({
+        content: "My key is GOCSPX-abcdefghijklmnopqrstuvwxyz12",
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(processMessage).not.toHaveBeenCalled();
+    const event = getDb().select().from(channelInboundEvents).get();
+    expect(event?.processingStatus).toBe("processed");
+    expect(event?.rawPayload).toBeNull();
+
+    const row = readTitle();
+    expect(row.title).not.toBe(GENERATING_TITLE);
+    expect(row).toEqual({
+      title: "Message from Alice Example",
+      isAutoTitle: AUTO_TITLE_DETERMINISTIC,
+    });
+  });
+
+  test("a later message in the same chat never retitles the conversation", async () => {
+    await handleChannelInbound(makeInboundRequest());
+    const mapping = getConversationByKey(CHAT_KEY);
+    getDb()
+      .update(conversations)
+      .set({ title: "Lunch plans", isAutoTitle: 0 })
+      .where(eq(conversations.id, mapping!.conversationId))
+      .run();
+
+    await handleChannelInbound(
+      makeInboundRequest({ actorDisplayName: "Bob Example" }),
+    );
+
+    expect(readTitle()).toEqual({ title: "Lunch plans", isAutoTitle: 0 });
+  });
+});

--- a/assistant/src/__tests__/conversation-title-service.test.ts
+++ b/assistant/src/__tests__/conversation-title-service.test.ts
@@ -98,8 +98,10 @@ mock.module("../runtime/sync/resource-sync-events.js", () => ({
 }));
 
 import {
+  applyDeterministicTitleIfReplaceable,
   AUTO_TITLE_DETERMINISTIC,
   AUTO_TITLE_LLM,
+  deriveChannelInboundMintTitle,
   generateAndPersistConversationTitle,
   queueGenerateConversationTitle,
   regenerateConversationTitle,
@@ -564,5 +566,153 @@ describe("conversation-title-service", () => {
       mockUpdateConversationTitle.mock.calls as unknown as string[][]
     ).find((c) => c[0] === "conv-2" && c[1] === "Recovery Title");
     expect(secondUpdate).toBeTruthy();
+  });
+});
+
+describe("channel inbound mint title", () => {
+  beforeEach(() => {
+    mockGetConversation.mockClear();
+    mockGetConversation.mockImplementation(
+      (_conversationId: string) =>
+        ({
+          title: "Generating title...",
+          isAutoTitle: 1,
+        }) as {
+          title: string;
+          isAutoTitle: number;
+        },
+    );
+    mockUpdateConversationTitle.mockClear();
+    mockPublishConversationTitleChanged.mockClear();
+  });
+
+  test("names the sender: display name, then username, then external id", () => {
+    expect(
+      deriveChannelInboundMintTitle({
+        sourceChannel: "slack",
+        actorDisplayName: "Alice Example",
+        actorUsername: "alice",
+        actorExternalId: "U0123ABCDEF",
+      }),
+    ).toBe("Message from Alice Example");
+    expect(
+      deriveChannelInboundMintTitle({
+        sourceChannel: "slack",
+        actorUsername: "alice",
+        actorExternalId: "U0123ABCDEF",
+      }),
+    ).toBe("Message from alice");
+    expect(
+      deriveChannelInboundMintTitle({
+        sourceChannel: "slack",
+        actorExternalId: "U0123ABCDEF",
+      }),
+    ).toBe("Message from U0123ABCDEF");
+  });
+
+  test("names the channel when no sender label is known", () => {
+    expect(deriveChannelInboundMintTitle({ sourceChannel: "slack" })).toBe(
+      "New Slack message",
+    );
+    expect(deriveChannelInboundMintTitle({ sourceChannel: "telegram" })).toBe(
+      "New Telegram message",
+    );
+    expect(deriveChannelInboundMintTitle({ sourceChannel: "whatsapp" })).toBe(
+      "New WhatsApp message",
+    );
+    expect(deriveChannelInboundMintTitle({ sourceChannel: "discord" })).toBe(
+      "New Discord message",
+    );
+    expect(
+      deriveChannelInboundMintTitle({
+        sourceChannel: "slack",
+        actorDisplayName: "   ",
+        actorUsername: null,
+        actorExternalId: "",
+      }),
+    ).toBe("New Slack message");
+  });
+
+  test("collapses whitespace and truncates like other deterministic titles", () => {
+    expect(
+      deriveChannelInboundMintTitle({
+        sourceChannel: "slack",
+        actorDisplayName: "  Alice \n  Example  ",
+      }),
+    ).toBe("Message from Alice Example");
+    expect(
+      deriveChannelInboundMintTitle({
+        sourceChannel: "slack",
+        actorDisplayName: "Alexandra Montgomery-Wellington Example",
+      }),
+    ).toBe("Message from Alexandra");
+    // A single token that cannot fit beside the prefix falls back to the
+    // channel form rather than a bare "Message from".
+    expect(
+      deriveChannelInboundMintTitle({
+        sourceChannel: "slack",
+        actorExternalId: "x".repeat(60),
+      }),
+    ).toBe("New Slack message");
+  });
+
+  test("applies the mint title over the placeholder as deterministic and broadcasts", () => {
+    mockGetConversation.mockReturnValueOnce({
+      title: "Generating title...",
+      isAutoTitle: 1,
+    });
+
+    const changed = applyDeterministicTitleIfReplaceable(
+      "conv-1",
+      "Message from Alice",
+    );
+
+    expect(changed).toBe(true);
+    expect(mockUpdateConversationTitle).toHaveBeenCalledWith(
+      "conv-1",
+      "Message from Alice",
+      AUTO_TITLE_DETERMINISTIC,
+    );
+    expect(mockPublishConversationTitleChanged).toHaveBeenCalledWith(
+      "conv-1",
+      "Message from Alice",
+    );
+  });
+
+  test("never overwrites a user or LLM title", () => {
+    mockGetConversation.mockReturnValueOnce({
+      title: "Lunch plans",
+      isAutoTitle: 0,
+    });
+
+    const changed = applyDeterministicTitleIfReplaceable(
+      "conv-1",
+      "Message from Alice",
+    );
+
+    expect(changed).toBe(false);
+    expect(mockUpdateConversationTitle).not.toHaveBeenCalled();
+    expect(mockPublishConversationTitleChanged).not.toHaveBeenCalled();
+  });
+
+  test("the first genuine turn upgrades a mint title to an LLM title", async () => {
+    mockGetConversation.mockImplementation(() => ({
+      title: "Message from Alice",
+      isAutoTitle: AUTO_TITLE_DETERMINISTIC,
+    }));
+    const provider = makeProvider(async () => toolResponse("Lunch Plans"));
+
+    const result = await generateAndPersistConversationTitle({
+      conversationId: "conv-1",
+      provider,
+      userMessage: "want to grab lunch tomorrow?",
+    });
+
+    expect(result).toEqual({ title: "Lunch Plans", updated: true });
+    expect(mockUpdateConversationTitle).toHaveBeenCalledWith(
+      "conv-1",
+      "Lunch Plans",
+      AUTO_TITLE_LLM,
+    );
   });
 });

--- a/assistant/src/__tests__/guardian-verification-voice-binding.test.ts
+++ b/assistant/src/__tests__/guardian-verification-voice-binding.test.ts
@@ -64,8 +64,13 @@ mock.module("../runtime/channel-verification-service.js", () => ({
   isGuardian: () => false,
 }));
 
+const applyDeterministicTitleIfReplaceableMock = mock(
+  (_conversationId: string, _title: string): boolean => true,
+);
 mock.module("../persistence/conversation-title-service.js", () => ({
   queueGenerateConversationTitle: () => {},
+  applyDeterministicTitleIfReplaceable:
+    applyDeterministicTitleIfReplaceableMock,
 }));
 
 import { startVerificationCall } from "../calls/call-domain.js";
@@ -104,6 +109,12 @@ describe("startVerificationCall — voice binding", () => {
     const binding = getBindingByConversation(conversationId);
     expect(binding).not.toBeNull();
     expect(binding!.sourceChannel).toBe("phone");
+
+    // No turn ever titles this conversation, so the mint names it.
+    expect(applyDeterministicTitleIfReplaceableMock).toHaveBeenCalledWith(
+      conversationId,
+      "Guardian verification call",
+    );
   });
 
   test("fails with 503 when voice ingress preflight fails", async () => {

--- a/assistant/src/__tests__/inbound-trust-verdict.test.ts
+++ b/assistant/src/__tests__/inbound-trust-verdict.test.ts
@@ -19,11 +19,13 @@ mock.module("../runtime/gateway-client.js", () => ({
 }));
 
 import type { TrustVerdict } from "@vellumai/gateway-client";
+import { eq } from "drizzle-orm";
 
 import type { TrustContext } from "../daemon/trust-context-types.js";
+import { getConversationByKey } from "../persistence/conversation-key-store.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
-import { messages } from "../persistence/schema/index.js";
+import { conversations, messages } from "../persistence/schema/index.js";
 import {
   handleChannelInbound,
   setAdapterProcessMessage,
@@ -167,15 +169,35 @@ describe("inbound trust verdict → TrustContext", () => {
 
   test("trusted_contact denied under a guardian_only floor", async () => {
     const res = await handleChannelInbound(
-      makeInboundRequest({
-        trustVerdict: memberVerdict("trusted_contact"),
-        admissionPolicy: "guardian_only",
-      }),
+      makeInboundRequest(
+        {
+          trustVerdict: memberVerdict("trusted_contact"),
+          admissionPolicy: "guardian_only",
+        },
+        { actorDisplayName: "Member One" },
+      ),
     );
     const body = (await res.json()) as Record<string, unknown>;
     expect(body.accepted).toBe(true);
     expect(body.denied).toBe(true);
     expect(body.reason).toBe("admission_policy_guardian_only");
+
+    // The deny lane runs no turn, so the conversation carries the
+    // deterministic mint title rather than the placeholder.
+    const mapping = getConversationByKey("asst:self:telegram:chat-123");
+    expect(mapping).not.toBeNull();
+    const minted = getDb()
+      .select({
+        title: conversations.title,
+        isAutoTitle: conversations.isAutoTitle,
+      })
+      .from(conversations)
+      .where(eq(conversations.id, mapping!.conversationId))
+      .get();
+    expect(minted).toEqual({
+      title: "Message from Member One",
+      isAutoTitle: 2,
+    });
   });
 
   test("present unknown (stranger) verdict admitted under a strangers floor", async () => {

--- a/assistant/src/__tests__/secret-ingress-channel.test.ts
+++ b/assistant/src/__tests__/secret-ingress-channel.test.ts
@@ -18,6 +18,7 @@ mock.module("../persistence/delivery-crud.js", () => ({
     conversationId: "conv-test",
     accepted: true,
     duplicate: false,
+    created: false,
   }),
 }));
 

--- a/assistant/src/__tests__/title-generate-hook.test.ts
+++ b/assistant/src/__tests__/title-generate-hook.test.ts
@@ -294,6 +294,27 @@ describe("title-generate stop hook", () => {
     });
   });
 
+  test("retries a channel mint title after the first successful turn", async () => {
+    // A channel conversation is titled deterministically at the mint
+    // ("Message from <sender>", isAutoTitle 2); a real first turn must still
+    // upgrade it to an LLM title.
+    mockGetConversation.mockReturnValueOnce({
+      title: "Message from Alice",
+      isAutoTitle: 2,
+      conversationType: "standard",
+    });
+    const ctx = makeStopCtx({ messages: historyWithUserTurns(1) });
+
+    await stop(ctx);
+    await flushMacrotasks();
+
+    expect(queueRegenerateConversationTitleMock).toHaveBeenCalledTimes(1);
+    expect(queueRegenerateConversationTitleMock).toHaveBeenCalledWith({
+      conversationId: "conv-1",
+      onlyIfReplaceable: true,
+    });
+  });
+
   test("preserves the third-turn retitle when the title is still replaceable", async () => {
     mockGetConversation.mockReturnValueOnce({
       title: "Untitled Conversation",

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -16,7 +16,10 @@ import {
 } from "../inbound/public-ingress-urls.js";
 import { getConversation } from "../persistence/conversation-crud.js";
 import { getOrCreateConversation } from "../persistence/conversation-key-store.js";
-import { queueGenerateConversationTitle } from "../persistence/conversation-title-service.js";
+import {
+  applyDeterministicTitleIfReplaceable,
+  queueGenerateConversationTitle,
+} from "../persistence/conversation-title-service.js";
 import { upsertBinding } from "../persistence/external-conversation-store.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { isGuardian } from "../runtime/channel-verification-service.js";
@@ -925,9 +928,15 @@ export async function startVerificationCall(
 
     // Create a minimal conversation so the call session has a valid FK,
     // and bind it to the voice channel so it never appears as an unbound
-    // desktop conversation.
+    // desktop conversation. No turn ever titles it, so title it at the mint.
     const convKey = `guardian-verify:${verificationSessionId}`;
-    const { conversationId } = getOrCreateConversation(convKey);
+    const { conversationId, created } = getOrCreateConversation(convKey);
+    if (created) {
+      applyDeterministicTitleIfReplaceable(
+        conversationId,
+        "Guardian verification call",
+      );
+    }
 
     upsertBinding({
       conversationId,
@@ -1057,10 +1066,13 @@ export async function startInviteCall(
 
     // Create a minimal conversation so the call session has a valid FK,
     // and bind it to the voice channel so it never appears as an unbound
-    // desktop conversation.
+    // desktop conversation. No turn ever titles it, so title it at the mint.
     const timestamp = Date.now();
     const convKey = `invite-call:${phoneNumber}:${timestamp}`;
-    const { conversationId } = getOrCreateConversation(convKey);
+    const { conversationId, created } = getOrCreateConversation(convKey);
+    if (created) {
+      applyDeterministicTitleIfReplaceable(conversationId, "Invite call");
+    }
 
     upsertBinding({
       conversationId,

--- a/assistant/src/messaging/providers/telegram-bot/adapter.ts
+++ b/assistant/src/messaging/providers/telegram-bot/adapter.ts
@@ -7,6 +7,10 @@
 import type { OAuthConnection } from "../../../oauth/connection.js";
 import { getConnectionByProvider } from "../../../oauth/oauth-store.js";
 import { getOrCreateConversation } from "../../../persistence/conversation-key-store.js";
+import {
+  applyDeterministicTitleIfReplaceable,
+  deriveChannelInboundMintTitle,
+} from "../../../persistence/conversation-title-service.js";
 import { upsertOutboundBinding } from "../../../persistence/external-conversation-store.js";
 import { credentialKey } from "../../../security/credential-key.js";
 import { getSecureKeyAsync } from "../../../security/secure-keys.js";
@@ -108,8 +112,14 @@ export const telegramBotMessagingProvider: MessagingProvider = {
     try {
       const sourceChannel = "telegram";
       const conversationKey = `asst:self:${sourceChannel}:${conversationId}`;
-      const { conversationId: internalId } =
+      const { conversationId: internalId, created } =
         getOrCreateConversation(conversationKey);
+      if (created) {
+        applyDeterministicTitleIfReplaceable(
+          internalId,
+          deriveChannelInboundMintTitle({ sourceChannel }),
+        );
+      }
       upsertOutboundBinding({
         conversationId: internalId,
         sourceChannel,

--- a/assistant/src/messaging/providers/whatsapp/adapter.ts
+++ b/assistant/src/messaging/providers/whatsapp/adapter.ts
@@ -6,6 +6,10 @@
 
 import type { OAuthConnection } from "../../../oauth/connection.js";
 import { getOrCreateConversation } from "../../../persistence/conversation-key-store.js";
+import {
+  applyDeterministicTitleIfReplaceable,
+  deriveChannelInboundMintTitle,
+} from "../../../persistence/conversation-title-service.js";
 import { upsertOutboundBinding } from "../../../persistence/external-conversation-store.js";
 import { credentialKey } from "../../../security/credential-key.js";
 import { getSecureKeyAsync } from "../../../security/secure-keys.js";
@@ -89,8 +93,14 @@ export const whatsappMessagingProvider: MessagingProvider = {
     try {
       const sourceChannel = "whatsapp";
       const conversationKey = `asst:${assistantId ?? "self"}:${sourceChannel}:${conversationId}`;
-      const { conversationId: internalId } =
+      const { conversationId: internalId, created } =
         getOrCreateConversation(conversationKey);
+      if (created) {
+        applyDeterministicTitleIfReplaceable(
+          internalId,
+          deriveChannelInboundMintTitle({ sourceChannel }),
+        );
+      }
       if (!assistantId || assistantId === "self") {
         upsertOutboundBinding({
           conversationId: internalId,

--- a/assistant/src/persistence/conversation-title-service.ts
+++ b/assistant/src/persistence/conversation-title-service.ts
@@ -7,6 +7,7 @@
  * overwritten, never user-provided custom titles.
  */
 
+import { CHANNEL_METADATA, isChannelId } from "../channels/types.js";
 import {
   createTimeout,
   extractAllText,
@@ -138,15 +139,70 @@ export function deriveDeterministicTitle(context: TitleContext): string {
   return truncateTitle(base.replace(/\s+/g, " ").trim());
 }
 
+export interface ChannelInboundMintTitleInput {
+  sourceChannel: string;
+  actorDisplayName?: string | null;
+  actorUsername?: string | null;
+  actorExternalId?: string | null;
+}
+
+/**
+ * Human-readable channel name for title copy: the channel card label where
+ * one exists (`Slack`, `Telegram`, `WhatsApp`), otherwise the id capitalized.
+ */
+function channelDisplayLabel(sourceChannel: string): string {
+  const label = isChannelId(sourceChannel)
+    ? CHANNEL_METADATA[sourceChannel]?.label
+    : undefined;
+  if (label) {
+    return label;
+  }
+  const trimmed = sourceChannel.trim();
+  return trimmed.charAt(0).toUpperCase() + trimmed.slice(1);
+}
+
+/**
+ * Title a channel conversation carries from the moment it is minted, before
+ * any turn has run: `Message from <sender>` when the inbound named its
+ * sender, else `New <Channel> message`. Names only the sender, never the
+ * channel or chat, because clients render channel context beside the title
+ * already. Persist it with `AUTO_TITLE_DETERMINISTIC` (see
+ * `applyDeterministicTitleIfReplaceable`) so the first genuine turn upgrades
+ * it to an LLM title.
+ */
+export function deriveChannelInboundMintTitle(
+  input: ChannelInboundMintTitleInput,
+): string {
+  const actorLabel = [
+    input.actorDisplayName,
+    input.actorUsername,
+    input.actorExternalId,
+  ]
+    .map((value) => value?.replace(/\s+/g, " ").trim())
+    .find((value) => value);
+  if (actorLabel) {
+    const prefix = "Message from ";
+    const title = truncateTitle(`${prefix}${actorLabel}`);
+    // A single token too long to fit truncates to the bare prefix; the
+    // channel form reads better than "Message from".
+    if (title.length > prefix.length) {
+      return title;
+    }
+  }
+  return truncateTitle(
+    `New ${channelDisplayLabel(input.sourceChannel)} message`,
+  );
+}
+
 /**
  * Apply a deterministic title to a conversation, but only while its current
- * title is still a replaceable placeholder — never clobbering a user or LLM
- * title. For conversations that will never run an agent turn (so neither the
- * `user-prompt-submit` nor `stop` title hook ever fires), e.g. a floor-denied
- * inbound whose only content is a guardian access-request card: without this
- * the sidebar shows a permanent "Generating title…". Persisted as
- * `AUTO_TITLE_DETERMINISTIC` so a later genuine turn can still upgrade it, and
- * broadcast so connected clients converge. Returns whether the title changed.
+ * title is still a replaceable placeholder, never clobbering a user or LLM
+ * title. This is the mint-seam title: a conversation created by a channel
+ * inbound or a call session gets one immediately so it never sits on
+ * "Generating title..." when the inbound is denied, blocked, intercepted, or
+ * dead-lettered before a turn runs. Persisted as `AUTO_TITLE_DETERMINISTIC`
+ * so the first genuine turn still upgrades it to an LLM title, and broadcast
+ * so connected clients converge. Returns whether the title changed.
  */
 export function applyDeterministicTitleIfReplaceable(
   conversationId: string,

--- a/assistant/src/persistence/delivery-crud.ts
+++ b/assistant/src/persistence/delivery-crud.ts
@@ -28,6 +28,12 @@ export interface InboundResult {
   eventId: string;
   conversationId: string;
   duplicate: boolean;
+  /**
+   * Whether this call minted `conversationId`: false for a duplicate event and
+   * for an address that already resolved to a conversation. Once-per-
+   * conversation work (the deterministic mint title) keys on it.
+   */
+  created: boolean;
 }
 
 export interface RecordInboundOptions {
@@ -141,12 +147,17 @@ export interface ResolveInboundConversationOptions {
   origin?: ChannelId;
 }
 
+/**
+ * Resolve the conversation an inbound (channel, chat, thread) address lands
+ * in, minting one when nothing is bound yet. `created` is true only on that
+ * mint; an alias onto an existing conversation is not a creation.
+ */
 export function resolveInboundConversation(
   sourceChannel: string,
   externalChatId: string,
   sourceThreadId?: string | null,
   opts?: ResolveInboundConversationOptions,
-): { conversationId: string } {
+): { conversationId: string; created: boolean } {
   const threadedKey = buildScopedConversationKey(
     sourceChannel,
     externalChatId,
@@ -165,7 +176,7 @@ export function resolveInboundConversation(
 
   const threadedMapping = getConversationByKey(threadedKey);
   if (threadedMapping) {
-    return { conversationId: threadedMapping.conversationId };
+    return { conversationId: threadedMapping.conversationId, created: false };
   }
 
   const legacyKey = buildScopedConversationKey(
@@ -185,7 +196,7 @@ export function resolveInboundConversation(
     setConversationKeyIfAbsent(threadedKey, legacyMapping.conversationId);
     const aliasedMapping = getConversationByKey(threadedKey);
     if (aliasedMapping) {
-      return { conversationId: aliasedMapping.conversationId };
+      return { conversationId: aliasedMapping.conversationId, created: false };
     }
   }
 
@@ -277,6 +288,7 @@ export function recordInbound(
       eventId: existing.id,
       conversationId: existing.conversationId,
       duplicate: true,
+      created: false,
     };
   }
 
@@ -313,6 +325,7 @@ export function recordInbound(
     eventId,
     conversationId: mapping.conversationId,
     duplicate: false,
+    created: mapping.created,
   };
 }
 

--- a/assistant/src/persistence/migrations/367-retitle-stuck-channel-placeholders.test.ts
+++ b/assistant/src/persistence/migrations/367-retitle-stuck-channel-placeholders.test.ts
@@ -1,0 +1,291 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import * as schema from "../schema.js";
+import { migrateRetitleStuckChannelPlaceholders } from "./367-retitle-stuck-channel-placeholders.js";
+
+const PLACEHOLDER = "Generating title...";
+const HOUR_MS = 60 * 60 * 1000;
+const STALE_CREATED_AT = Date.now() - 2 * HOUR_MS;
+const FRESH_CREATED_AT = Date.now() - 5 * 60 * 1000;
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec(/*sql*/ `
+    CREATE TABLE conversations (
+      id            TEXT PRIMARY KEY,
+      title         TEXT,
+      created_at    INTEGER NOT NULL,
+      updated_at    INTEGER NOT NULL,
+      is_auto_title INTEGER NOT NULL DEFAULT 1,
+      archived_at   INTEGER
+    );
+    CREATE TABLE messages (
+      id              TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL,
+      role            TEXT NOT NULL,
+      content         TEXT NOT NULL,
+      created_at      INTEGER NOT NULL
+    );
+    CREATE TABLE channel_inbound_events (
+      id                  TEXT PRIMARY KEY,
+      source_channel      TEXT NOT NULL,
+      external_chat_id    TEXT NOT NULL,
+      external_message_id TEXT NOT NULL,
+      conversation_id     TEXT NOT NULL,
+      created_at          INTEGER NOT NULL
+    );
+    CREATE TABLE conversation_keys (
+      id               TEXT PRIMARY KEY,
+      conversation_key TEXT NOT NULL,
+      conversation_id  TEXT NOT NULL,
+      created_at       INTEGER NOT NULL
+    );
+  `);
+  return { sqlite, db: drizzle(sqlite, { schema }) };
+}
+
+interface ConversationRow {
+  title: string | null;
+  is_auto_title: number;
+  archived_at: number | null;
+  updated_at: number;
+}
+
+function insertConversation(
+  sqlite: Database,
+  id: string,
+  opts: { title?: string; createdAt?: number; isAutoTitle?: number } = {},
+): void {
+  const createdAt = opts.createdAt ?? STALE_CREATED_AT;
+  sqlite
+    .query(
+      /*sql*/ `INSERT INTO conversations (id, title, created_at, updated_at, is_auto_title)
+       VALUES (?, ?, ?, ?, ?)`,
+    )
+    .run(
+      id,
+      opts.title ?? PLACEHOLDER,
+      createdAt,
+      createdAt,
+      opts.isAutoTitle ?? 1,
+    );
+}
+
+function insertKey(sqlite: Database, conversationId: string, key: string) {
+  sqlite
+    .query(
+      /*sql*/ `INSERT INTO conversation_keys (id, conversation_key, conversation_id, created_at)
+       VALUES (?, ?, ?, ?)`,
+    )
+    .run(`key-${conversationId}-${key}`, key, conversationId, STALE_CREATED_AT);
+}
+
+function insertInboundEvent(
+  sqlite: Database,
+  conversationId: string,
+  sourceChannel: string,
+) {
+  sqlite
+    .query(
+      /*sql*/ `INSERT INTO channel_inbound_events
+         (id, source_channel, external_chat_id, external_message_id, conversation_id, created_at)
+       VALUES (?, ?, 'chat-1', ?, ?, ?)`,
+    )
+    .run(
+      `evt-${conversationId}-${sourceChannel}`,
+      sourceChannel,
+      `msg-${conversationId}`,
+      conversationId,
+      STALE_CREATED_AT,
+    );
+}
+
+function insertMessage(
+  sqlite: Database,
+  conversationId: string,
+  content: string,
+  id = `msg-${conversationId}-${content.length}-${Math.random()}`,
+) {
+  sqlite
+    .query(
+      /*sql*/ `INSERT INTO messages (id, conversation_id, role, content, created_at)
+       VALUES (?, ?, 'user', ?, ?)`,
+    )
+    .run(id, conversationId, content, STALE_CREATED_AT);
+}
+
+function readConversation(sqlite: Database, id: string): ConversationRow {
+  return sqlite
+    .query(
+      `SELECT title, is_auto_title, archived_at, updated_at FROM conversations WHERE id = ?`,
+    )
+    .get(id) as ConversationRow;
+}
+
+describe("migration 367: retitle stuck channel placeholders", () => {
+  test("retitles a real-message channel conversation without archiving it", () => {
+    const { sqlite, db } = createTestDb();
+    insertConversation(sqlite, "conv-slack");
+    insertKey(sqlite, "conv-slack", "asst:self:slack:C0123ABCDEF");
+    insertInboundEvent(sqlite, "conv-slack", "slack");
+    insertMessage(sqlite, "conv-slack", "hello there");
+
+    migrateRetitleStuckChannelPlaceholders(db);
+
+    const row = readConversation(sqlite, "conv-slack");
+    expect(row.title).toBe("New Slack message");
+    expect(row.is_auto_title).toBe(2);
+    expect(row.archived_at).toBeNull();
+    expect(row.updated_at).toBe(STALE_CREATED_AT);
+  });
+
+  test("retitles and archives a reaction-only conversation", () => {
+    const { sqlite, db } = createTestDb();
+    insertConversation(sqlite, "conv-react");
+    insertKey(
+      sqlite,
+      "conv-react",
+      "asst:self:slack:C0123ABCDEF:thread:1710000000.000100",
+    );
+    insertInboundEvent(sqlite, "conv-react", "slack");
+    insertMessage(sqlite, "conv-react", "[reaction]", "m1");
+    insertMessage(sqlite, "conv-react", "[reaction]", "m2");
+
+    migrateRetitleStuckChannelPlaceholders(db);
+
+    const row = readConversation(sqlite, "conv-react");
+    expect(row.title).toBe("Slack reaction");
+    expect(row.is_auto_title).toBe(2);
+    expect(row.archived_at).not.toBeNull();
+  });
+
+  test("a reaction row beside a real message counts as real content", () => {
+    const { sqlite, db } = createTestDb();
+    insertConversation(sqlite, "conv-mixed");
+    insertInboundEvent(sqlite, "conv-mixed", "slack");
+    insertMessage(sqlite, "conv-mixed", "[reaction]", "m1");
+    insertMessage(sqlite, "conv-mixed", "real text", "m2");
+
+    migrateRetitleStuckChannelPlaceholders(db);
+
+    const row = readConversation(sqlite, "conv-mixed");
+    expect(row.title).toBe("New Slack message");
+    expect(row.archived_at).toBeNull();
+  });
+
+  test("retitles and archives a message-less channel conversation", () => {
+    const { sqlite, db } = createTestDb();
+    insertConversation(sqlite, "conv-empty");
+    insertInboundEvent(sqlite, "conv-empty", "telegram");
+
+    migrateRetitleStuckChannelPlaceholders(db);
+
+    const row = readConversation(sqlite, "conv-empty");
+    expect(row.title).toBe("New Telegram message");
+    expect(row.is_auto_title).toBe(2);
+    expect(row.archived_at).not.toBeNull();
+  });
+
+  test("derives the channel from the key when no inbound event exists", () => {
+    const { sqlite, db } = createTestDb();
+    insertConversation(sqlite, "conv-wa");
+    insertKey(sqlite, "conv-wa", "asst:self:whatsapp:15550100");
+
+    migrateRetitleStuckChannelPlaceholders(db);
+
+    expect(readConversation(sqlite, "conv-wa").title).toBe(
+      "New WhatsApp message",
+    );
+  });
+
+  test("respects the one-hour age fence", () => {
+    const { sqlite, db } = createTestDb();
+    insertConversation(sqlite, "conv-fresh", { createdAt: FRESH_CREATED_AT });
+    insertInboundEvent(sqlite, "conv-fresh", "slack");
+
+    migrateRetitleStuckChannelPlaceholders(db);
+
+    const row = readConversation(sqlite, "conv-fresh");
+    expect(row.title).toBe(PLACEHOLDER);
+    expect(row.is_auto_title).toBe(1);
+    expect(row.archived_at).toBeNull();
+  });
+
+  test("leaves non-channel and already-titled conversations untouched", () => {
+    const { sqlite, db } = createTestDb();
+    // Web conversation on the placeholder: no channel evidence.
+    insertConversation(sqlite, "conv-web");
+    insertKey(sqlite, "conv-web", "web-draft-key");
+    // Voice key under the scope prefix but not a channel.
+    insertConversation(sqlite, "conv-voice");
+    insertKey(sqlite, "conv-voice", "asst:self:voice:call:session-1");
+    // Channel conversation that already has a title.
+    insertConversation(sqlite, "conv-titled", {
+      title: "Lunch plans",
+      isAutoTitle: 1,
+    });
+    insertInboundEvent(sqlite, "conv-titled", "slack");
+
+    migrateRetitleStuckChannelPlaceholders(db);
+
+    expect(readConversation(sqlite, "conv-web").title).toBe(PLACEHOLDER);
+    expect(readConversation(sqlite, "conv-voice").title).toBe(PLACEHOLDER);
+    expect(readConversation(sqlite, "conv-titled").title).toBe("Lunch plans");
+    expect(readConversation(sqlite, "conv-titled").is_auto_title).toBe(1);
+  });
+
+  test("is idempotent", () => {
+    const { sqlite, db } = createTestDb();
+    insertConversation(sqlite, "conv-react");
+    insertInboundEvent(sqlite, "conv-react", "slack");
+    insertMessage(sqlite, "conv-react", "[reaction]", "m1");
+    insertConversation(sqlite, "conv-real");
+    insertInboundEvent(sqlite, "conv-real", "slack");
+    insertMessage(sqlite, "conv-real", "hello", "m2");
+
+    migrateRetitleStuckChannelPlaceholders(db);
+    const firstReact = readConversation(sqlite, "conv-react");
+    const firstReal = readConversation(sqlite, "conv-real");
+    migrateRetitleStuckChannelPlaceholders(db);
+
+    expect(readConversation(sqlite, "conv-react")).toEqual(firstReact);
+    expect(readConversation(sqlite, "conv-real")).toEqual(firstReal);
+  });
+
+  test("processes more rows than one batch", () => {
+    const { sqlite, db } = createTestDb();
+    for (let i = 0; i < 1203; i++) {
+      const id = `conv-${String(i).padStart(5, "0")}`;
+      insertConversation(sqlite, id);
+      insertInboundEvent(sqlite, id, "slack");
+    }
+
+    migrateRetitleStuckChannelPlaceholders(db);
+
+    const remaining = sqlite
+      .query(`SELECT COUNT(*) AS n FROM conversations WHERE title = ?`)
+      .get(PLACEHOLDER) as { n: number };
+    expect(remaining.n).toBe(0);
+  });
+
+  test("no-ops without the tables or the columns", () => {
+    const bare = new Database(":memory:");
+    expect(() =>
+      migrateRetitleStuckChannelPlaceholders(drizzle(bare, { schema })),
+    ).not.toThrow();
+
+    const partial = new Database(":memory:");
+    partial.exec(/*sql*/ `
+      CREATE TABLE conversations (id TEXT PRIMARY KEY, title TEXT, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);
+      CREATE TABLE messages (id TEXT PRIMARY KEY, conversation_id TEXT NOT NULL, role TEXT NOT NULL, content TEXT NOT NULL, created_at INTEGER NOT NULL);
+      CREATE TABLE channel_inbound_events (id TEXT PRIMARY KEY, source_channel TEXT NOT NULL, external_chat_id TEXT NOT NULL, external_message_id TEXT NOT NULL, conversation_id TEXT NOT NULL, created_at INTEGER NOT NULL);
+      CREATE TABLE conversation_keys (id TEXT PRIMARY KEY, conversation_key TEXT NOT NULL, conversation_id TEXT NOT NULL, created_at INTEGER NOT NULL);
+    `);
+    expect(() =>
+      migrateRetitleStuckChannelPlaceholders(drizzle(partial, { schema })),
+    ).not.toThrow();
+  });
+});

--- a/assistant/src/persistence/migrations/367-retitle-stuck-channel-placeholders.ts
+++ b/assistant/src/persistence/migrations/367-retitle-stuck-channel-placeholders.ts
@@ -1,0 +1,236 @@
+import { getLogger } from "../../util/logger.js";
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+import { tableExists, tableHasColumn } from "./schema-introspection.js";
+
+const log = getLogger("migration-367");
+
+/** Title every conversation is minted with until something replaces it. */
+const PLACEHOLDER_TITLE = "Generating title...";
+
+/** `conversations.is_auto_title` value for a deterministic, upgradeable title. */
+const AUTO_TITLE_DETERMINISTIC = 2;
+
+/**
+ * A placeholder younger than this may still be mid-flight: its first turn or
+ * its LLM title call has not landed yet. Only older rows are treated as stuck.
+ */
+const STUCK_MIN_AGE_MS = 60 * 60 * 1000;
+
+/** Rows examined per pass; keyset-paginated on `conversations.id`. */
+const BATCH_SIZE = 500;
+
+/** Content the Slack reaction persister writes; never shown to the model. */
+const REACTION_SENTINEL = "[reaction]";
+
+/**
+ * Prefix of every channel conversation key
+ * (`asst:self:<channel>:<chat>[:thread:<id>]`). Frozen copy of the format
+ * `buildScopedConversationKey` writes.
+ */
+const CHANNEL_KEY_PREFIX = "asst:self:";
+
+/**
+ * Display labels for the channels that mint conversations through the inbound
+ * pipeline. Frozen copy of the channel card labels; a key segment that is not
+ * listed here (for example `voice`) is not channel evidence.
+ */
+const CHANNEL_LABELS: Record<string, string> = {
+  slack: "Slack",
+  telegram: "Telegram",
+  whatsapp: "WhatsApp",
+  discord: "Discord",
+  email: "Email",
+  a2a: "A2A",
+  plugin: "Plugin",
+};
+
+interface CandidateRow {
+  id: string;
+  event_channel: string | null;
+  channel_key: string | null;
+}
+
+interface MessageShape {
+  has_content: number;
+  has_reaction: number;
+}
+
+function channelFromKey(key: string | null): string | null {
+  if (!key || !key.startsWith(CHANNEL_KEY_PREFIX)) {
+    return null;
+  }
+  const segment = key.slice(CHANNEL_KEY_PREFIX.length).split(":")[0] ?? "";
+  return segment in CHANNEL_LABELS ? segment : null;
+}
+
+function channelLabel(channel: string): string {
+  const label = CHANNEL_LABELS[channel];
+  if (label) {
+    return label;
+  }
+  return channel.charAt(0).toUpperCase() + channel.slice(1);
+}
+
+/**
+ * Give every stuck channel conversation a deterministic title.
+ *
+ * A channel conversation is minted with the "Generating title..." placeholder
+ * and only an agent turn's title hooks replace it. Inbounds that end before a
+ * turn (admission deny, disk-pressure block, stale button, secret block,
+ * intercepted guardian reply, dead-letter, reactions) leave the placeholder
+ * in place forever, so the sidebar fills with rows named "Generating
+ * title...". The live pipeline titles a conversation at the mint; this
+ * migration repairs the rows minted before that.
+ *
+ * Scope: rows still on the placeholder, older than {@link STUCK_MIN_AGE_MS},
+ * with channel-origin evidence (an inbound event row, or a conversation key
+ * naming a known channel). Everything else, including web and background
+ * conversations on the placeholder, is left alone.
+ *
+ * Classification by the conversation's messages:
+ * - only reaction sentinel rows: `<Channel> reaction`, archived (nothing to
+ *   read in it);
+ * - no rows at all: `New <Channel> message`, archived;
+ * - anything else: `New <Channel> message`, left in place.
+ *
+ * Every retitle writes `is_auto_title = 2` so the next genuine turn's title
+ * hook still upgrades it to an LLM title. `updated_at` is deliberately not
+ * bumped: these are old rows and a retitle must not resurface them at the top
+ * of the sidebar. Never deletes.
+ *
+ * Idempotent: a retitled row no longer matches the placeholder predicate, so
+ * a re-run finds nothing. Guards on every table and column it touches so a
+ * database that predates any of them no-ops.
+ */
+export function migrateRetitleStuckChannelPlaceholders(
+  database: DrizzleDb,
+): void {
+  if (
+    !tableExists(database, "conversations") ||
+    !tableExists(database, "messages") ||
+    !tableExists(database, "channel_inbound_events") ||
+    !tableExists(database, "conversation_keys") ||
+    !tableHasColumn(database, "conversations", "is_auto_title") ||
+    !tableHasColumn(database, "conversations", "archived_at")
+  ) {
+    return;
+  }
+
+  const raw = getSqliteFrom(database);
+  const cutoff = Date.now() - STUCK_MIN_AGE_MS;
+
+  const selectCandidates = raw.query(/*sql*/ `
+    SELECT
+      c.id AS id,
+      (
+        SELECT e.source_channel FROM channel_inbound_events e
+        WHERE e.conversation_id = c.id
+        ORDER BY e.created_at ASC
+        LIMIT 1
+      ) AS event_channel,
+      (
+        SELECT k.conversation_key FROM conversation_keys k
+        WHERE k.conversation_id = c.id AND k.conversation_key LIKE ?
+        ORDER BY k.created_at ASC
+        LIMIT 1
+      ) AS channel_key
+    FROM conversations c
+    WHERE c.title = ?
+      AND c.created_at < ?
+      AND c.id > ?
+      AND (
+        EXISTS (
+          SELECT 1 FROM channel_inbound_events e WHERE e.conversation_id = c.id
+        )
+        OR EXISTS (
+          SELECT 1 FROM conversation_keys k
+          WHERE k.conversation_id = c.id AND k.conversation_key LIKE ?
+        )
+      )
+    ORDER BY c.id ASC
+    LIMIT ?
+  `);
+  const selectMessageShape = raw.query(/*sql*/ `
+    SELECT
+      EXISTS (
+        SELECT 1 FROM messages m
+        WHERE m.conversation_id = ? AND m.content <> ?
+      ) AS has_content,
+      EXISTS (
+        SELECT 1 FROM messages m
+        WHERE m.conversation_id = ? AND m.content = ?
+      ) AS has_reaction
+  `);
+  const retitle = raw.prepare(/*sql*/ `
+    UPDATE conversations SET title = ?, is_auto_title = ? WHERE id = ?
+  `);
+  const retitleAndArchive = raw.prepare(/*sql*/ `
+    UPDATE conversations
+    SET title = ?, is_auto_title = ?, archived_at = COALESCE(archived_at, ?)
+    WHERE id = ?
+  `);
+  const keyPattern = `${CHANNEL_KEY_PREFIX}%`;
+
+  let retitled = 0;
+  let archived = 0;
+  let skipped = 0;
+  const applyBatch = raw.transaction((rows: CandidateRow[]) => {
+    for (const row of rows) {
+      const channel = channelFromKey(row.channel_key) ?? row.event_channel;
+      if (!channel) {
+        skipped++;
+        continue;
+      }
+      const label = channelLabel(channel);
+      const shape = selectMessageShape.get(
+        row.id,
+        REACTION_SENTINEL,
+        row.id,
+        REACTION_SENTINEL,
+      ) as MessageShape;
+      if (shape.has_content) {
+        retitle.run(`New ${label} message`, AUTO_TITLE_DETERMINISTIC, row.id);
+        retitled++;
+        continue;
+      }
+      const title = shape.has_reaction
+        ? `${label} reaction`
+        : `New ${label} message`;
+      retitleAndArchive.run(
+        title,
+        AUTO_TITLE_DETERMINISTIC,
+        Date.now(),
+        row.id,
+      );
+      retitled++;
+      archived++;
+    }
+  });
+
+  let lastId = "";
+  for (;;) {
+    const rows = selectCandidates.all(
+      keyPattern,
+      PLACEHOLDER_TITLE,
+      cutoff,
+      lastId,
+      keyPattern,
+      BATCH_SIZE,
+    ) as CandidateRow[];
+    if (rows.length === 0) {
+      break;
+    }
+    lastId = rows[rows.length - 1]!.id;
+    applyBatch(rows);
+    if (rows.length < BATCH_SIZE) {
+      break;
+    }
+  }
+
+  if (retitled > 0 || skipped > 0) {
+    log.info(
+      { retitled, archived, skipped },
+      "Retitled stuck channel conversation placeholders",
+    );
+  }
+}

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -474,6 +474,7 @@ import { migrateBackfillScheduleInferenceProfile } from "./migrations/363-backfi
 import { migrateAddScheduleSourceKey } from "./migrations/364-add-schedule-source-key.js";
 import { migrateAddConversationForkStrategy } from "./migrations/365-add-conversation-fork-strategy.js";
 import { migrateChatgptSubscriptionRowIdentity } from "./migrations/366-chatgpt-subscription-row-identity.js";
+import { migrateRetitleStuckChannelPlaceholders } from "./migrations/367-retitle-stuck-channel-placeholders.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1581,5 +1582,19 @@ export const migrationSteps: MigrationStep[] = [
     // creating migration must be checkpointed first or a repair flow could
     // permanently checkpoint the no-op.
     dependsOn: ["migrateCreateProviderConnections"],
+  },
+  {
+    name: "migrateRetitleStuckChannelPlaceholders",
+    run: migrateRetitleStuckChannelPlaceholders,
+    // The table/column guards treat missing schema as nothing-to-do, so the
+    // migrations that create the tables and the `is_auto_title` /
+    // `archived_at` columns must be checkpointed first or a repair flow could
+    // permanently checkpoint the no-op.
+    dependsOn: [
+      "migrateCoreTables",
+      "createWatchersAndLogsTables",
+      "addCoreColumns",
+      "migrateConversationsArchivedAt",
+    ],
   },
 ];

--- a/assistant/src/plugin-api/conversation-turn.ts
+++ b/assistant/src/plugin-api/conversation-turn.ts
@@ -193,24 +193,12 @@ async function resolveChannelConversation(
   channel: ConversationChannelAddress,
   conversationType?: "standard" | "background",
 ): Promise<{ conversationId: string; created: boolean }> {
-  const { findInboundConversationId, resolveInboundConversation } =
+  const { resolveInboundConversation } =
     await import("../persistence/delivery-crud.js");
   const { upsertBinding } =
     await import("../persistence/external-conversation-store.js");
 
-  // Asked before resolving, because resolving is what creates it: once the id
-  // is in hand a new conversation is indistinguishable from an existing one,
-  // and the caller announces only the new. `findInboundConversationId` is the
-  // read-only mirror of the resolution below, so the two agree on what
-  // "already bound" means, including the Slack flat-key alias.
-  const created =
-    findInboundConversationId(
-      channel.sourceChannel,
-      channel.externalChatId,
-      channel.externalThreadId,
-    ) === null;
-
-  const { conversationId } = resolveInboundConversation(
+  const { conversationId, created } = resolveInboundConversation(
     channel.sourceChannel,
     channel.externalChatId,
     channel.externalThreadId,

--- a/assistant/src/runtime/routes/inbound-conversation.ts
+++ b/assistant/src/runtime/routes/inbound-conversation.ts
@@ -17,6 +17,10 @@ import {
   deleteConversationKey,
   getOrCreateConversation,
 } from "../../persistence/conversation-key-store.js";
+import {
+  applyDeterministicTitleIfReplaceable,
+  deriveChannelInboundMintTitle,
+} from "../../persistence/conversation-title-service.js";
 import { buildScopedConversationKey } from "../../persistence/delivery-crud.js";
 import {
   deleteBindingByChannelChatNullThread,
@@ -53,11 +57,19 @@ export function handleDeleteConversation({ body = {} }: RouteHandlerArgs) {
     deleteBindingByChannelChatNullThread(sourceChannel, conversationExternalId);
   } else {
     // Slack adapter: eagerly re-mint a fresh conversation for the threaded
-    // key so mid-thread turns racing the reset land in the new conversation.
-    // Telegram deliberately skips this — a reset topic simply creates its
-    // fresh conversation on the next inbound message.
+    // key. The fresh key is what keeps the next inbound from re-aliasing the
+    // thread onto the flat channel conversation it was reset away from, and
+    // gives mid-thread turns racing the reset a home. Titled at the mint like
+    // any channel conversation. Telegram deliberately skips this: a reset
+    // topic simply creates its fresh conversation on the next inbound message.
     if (sourceChannel === "slack") {
-      getOrCreateConversation(scopedKey);
+      const { conversationId, created } = getOrCreateConversation(scopedKey);
+      if (created) {
+        applyDeterministicTitleIfReplaceable(
+          conversationId,
+          deriveChannelInboundMintTitle({ sourceChannel }),
+        );
+      }
     }
     deleteBindingByChannelChatThread(
       sourceChannel,

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -81,7 +81,10 @@ import {
   updateMessageContent,
   updateMessageMetadata,
 } from "../../persistence/conversation-crud.js";
-import { applyDeterministicTitleIfReplaceable } from "../../persistence/conversation-title-service.js";
+import {
+  applyDeterministicTitleIfReplaceable,
+  deriveChannelInboundMintTitle,
+} from "../../persistence/conversation-title-service.js";
 import {
   clearPayload,
   findMessageBySourceId,
@@ -713,6 +716,22 @@ export async function handleChannelInbound({
     },
   );
 
+  // Title the conversation at the mint, before any lane can return without a
+  // turn (admission deny, disk-pressure block, bootstrap or guardian-reply
+  // intercept, stale callback, secret block, dead-letter). Deterministic and
+  // upgradeable: the first genuine turn replaces it with an LLM title.
+  if (result.created) {
+    applyDeterministicTitleIfReplaceable(
+      result.conversationId,
+      deriveChannelInboundMintTitle({
+        sourceChannel,
+        actorDisplayName: body.actorDisplayName,
+        actorUsername: body.actorUsername,
+        actorExternalId: canonicalSenderId ?? rawSenderId,
+      }),
+    );
+  }
+
   const replyCallbackUrl = body.replyCallbackUrl;
 
   // `external_conversation_bindings` is assistant-agnostic: one row per chat,
@@ -874,22 +893,6 @@ export async function handleChannelInbound({
           "Failed to notify guardian of access request (admission policy)",
         );
       }
-    }
-
-    // recordInbound created this conversation, but a floor-denied inbound never
-    // runs an agent turn, so neither title-generation hook fires and the
-    // conversation would sit on the "Generating title…" placeholder forever.
-    // Give it a deterministic title (the access-request card is its content).
-    // Only for the access-request path — a callback interaction seeds no card.
-    if (!isCallbackInteraction) {
-      const requesterLabel =
-        body.actorDisplayName ?? body.actorUsername ?? floorSenderId;
-      applyDeterministicTitleIfReplaceable(
-        result.conversationId,
-        requesterLabel
-          ? `Access request — ${requesterLabel}`
-          : "Access request",
-      );
     }
 
     // Canned reply mirrors the not_a_member surface. §8.2: no upgrade

--- a/assistant/src/runtime/routes/inbound-stages/reaction-intercept.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/reaction-intercept.test.ts
@@ -78,6 +78,7 @@ mock.module("../../../persistence/delivery-crud.js", () => ({
       conversationId: "conv-1",
       accepted: true,
       duplicate: false,
+      created: false,
     };
   },
   clearPayload: () => {},


### PR DESCRIPTION
Fixes LUM-2872
Part of LUM-3329

## TL;DR

A conversation created by a channel inbound gets a real title at the moment it is created, instead of only when an agent turn runs. Every lane that returns without a turn (admission deny, disk-pressure block, secret block, bootstrap or guardian-reply intercept, stale callback, dead-letter) used to leave the conversation sitting on `Generating title...` forever. A migration retitles the ones already stuck.

## What was there

`getOrCreateConversation` writes the `Generating title...` placeholder for every conversation it mints. Only two things ever replace it: the `user-prompt-submit` and `stop` title hooks, both of which require an agent turn.

Channel ingress mints through `recordInbound`, and then eight separate lanes can return before any turn runs. One of them, the floor-denied access request, had a hand-placed `applyDeterministicTitleIfReplaceable` call added when it was noticed (#38960); the other seven did not. That is the shape of the bug: a per-lane patch for a problem that lives at the seam, and the third time it has been reported.

Four more conversation minters outside the inbound path had the same gap: the guardian-verification and invite call sessions, the Telegram and WhatsApp outbound adapters, and the eager re-mint on a Slack thread reset.

## What this does

- `resolveInboundConversation` and `recordInbound` report `created`. It is true only on an actual mint: an alias onto an existing conversation is not a creation, and neither is a duplicate event.
- One call site, immediately after `recordInbound`, applies `deriveChannelInboundMintTitle`. The per-lane call is deleted, so the deny lane is now titled by the same seam as everything else.
- Copy is `Message from <sender>`, falling back to `New Slack message` / `New Telegram message` / etc. when the inbound named no sender. It never repeats the channel or chat, because clients already render that context beside the title.
- The call-session and outbound-adapter minters pass their own deterministic titles. The eager Slack thread re-mint on reset is removed: the next inbound resolves through the seam and is titled there, so the re-mint only ever produced an empty untitled conversation.
- Migration 367 retitles conversations already stuck on the placeholder, fenced to rows older than an hour so it cannot race a live creation, and only for conversations with channel origin evidence. Reaction-only and empty ones are also archived so they leave Recents. It never deletes a row.

## Why this is safe

- The title is written with `AUTO_TITLE_DETERMINISTIC`, which `canReplaceTitle` treats as replaceable, so the first genuine turn still upgrades it to an LLM title exactly as before. A conversation that goes on to run a turn is unaffected in its final state.
- `applyDeterministicTitleIfReplaceable` still refuses to overwrite a user title or an LLM title, so nothing that already has a real title is touched.
- The migration is idempotent, time-fenced, scoped by origin evidence, and additive: it sets titles and archive flags, never deletes.
- No change to when or whether LLM titling runs.

## Before and after

| Scenario | Before | After |
| --- | --- | --- |
| Floor-denied inbound (access request) | `Access request - <name>` | `Message from <name>` |
| Floor-denied button press | `Generating title...` forever | `Message from <name>` |
| Disk-pressure block | `Generating title...` forever | `Message from <name>` |
| Secret detected at ingress | `Generating title...` forever | `Message from <name>` |
| Telegram bootstrap deep link | `Generating title...` forever | `Message from <name>` |
| Guardian reply intercept in a fresh chat | `Generating title...` forever | `Message from <name>` |
| Stale button press | `Generating title...` forever | `Message from <name>` |
| Turn dead-lettered on a fatal error | `Generating title...` forever | `Message from <name>` |
| Guardian verification / invite call | `Generating title...` forever | `Guardian verification call` / `Invite call` |
| Slack thread reset with no follow-up | empty conversation, `Generating title...` | no conversation until the next message |
| Ordinary Slack mention that runs a turn | `Generating title...` then LLM title | mint title then LLM title |
| Conversations already stuck | `Generating title...` | retitled, empty ones archived |

## Verification

- New `channel-inbound-mint-title.test.ts` covers the mint title across the deny, block, intercept and stale lanes, and that a following real turn upgrades it.
- New migration test `367-retitle-stuck-channel-placeholders.test.ts` covers the age fence, the origin-evidence filter, reaction-only archival, and idempotency on re-run.
- `conversation-title-service.test.ts` covers the copy, the actor fallback order, and the truncation edge case.
- `channel-delivery-store.test.ts` covers `created` being false for a duplicate event and for an aliased address.
- Typecheck, eslint and prettier clean. Local test runs are hook-blocked in this environment; CI runs the suite.

## Not in this PR

- Reactions and edits that mint orphan conversations are the other half of this problem and are LUM-3330: a reaction resolves to the message it was attached to instead of minting. That PR is what removes the largest source of stuck rows going forward.
- The SSE subscribe path can materialize a conversation from a draft key before any message is sent. That is client-owned draft semantics, left alone deliberately.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40873" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->