### PR TITLE
feat(web): resource-pressure banner slot with dismiss cooldown

### DIFF
--- a/clients/web/src/domains/chat/components/resource-pressure-banner-slot.test.tsx
+++ b/clients/web/src/domains/chat/components/resource-pressure-banner-slot.test.tsx
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+
+import type { UseResourcePressureMonitorResult } from "@/assistant/use-resource-pressure-monitor";
+import type { ResourcePressureStatus } from "@vellumai/assistant-api";
+
+let nativeAndroid = false;
+
+mock.module("@/runtime/platform-detection", () => ({
+  useIsNativeAndroid: () => nativeAndroid,
+}));
+
+const navigateMock = mock((_to: string) => {});
+const actualReactRouter = await import("react-router");
+
+mock.module("react-router", () => ({
+  ...actualReactRouter,
+  useNavigate: () => navigateMock,
+}));
+
+const { ResourcePressureBannerSlot } = await import(
+  "@/domains/chat/components/resource-pressure-banner-slot"
+);
+const { routes } = await import("@/utils/routes");
+const { getResourcePressureMonitorMode } = await import(
+  "@/assistant/resource-pressure"
+);
+
+const DISMISSED_UNTIL_KEY =
+  "vellum:resourcePressureDismissedUntil:assistant-1";
+const SUPPRESSED_KEY = "vellum:resourcePressureSuppressed:assistant-1";
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+const elevatedStatus: ResourcePressureStatus = {
+  enabled: true,
+  state: "elevated",
+  cpuPercent: 96,
+  memoryPercent: 91,
+  cpuElevated: true,
+  memoryElevated: true,
+  cpuThresholdPercent: 90,
+  memoryThresholdPercent: 90,
+  lastCheckedAt: null,
+  error: null,
+};
+
+const okStatus: ResourcePressureStatus = {
+  ...elevatedStatus,
+  state: "ok",
+  cpuElevated: false,
+  memoryElevated: false,
+  cpuPercent: 12,
+  memoryPercent: 35,
+};
+
+function monitorResult(
+  status: ResourcePressureStatus | null,
+): UseResourcePressureMonitorResult {
+  return {
+    status,
+    mode: getResourcePressureMonitorMode(status),
+    hasResolvedStatus: status !== null,
+    applyStatusEvent: () => {},
+    refresh: async () => {},
+  };
+}
+
+function slot(
+  status: ResourcePressureStatus | null,
+  assistantStateKind = "active",
+) {
+  return (
+    <MemoryRouter>
+      <ResourcePressureBannerSlot
+        resourcePressure={monitorResult(status)}
+        assistantId="assistant-1"
+        assistantStateKind={assistantStateKind}
+      />
+    </MemoryRouter>
+  );
+}
+
+function queryBanner() {
+  return screen.queryByTestId("resource-pressure-banner");
+}
+
+beforeEach(() => {
+  nativeAndroid = false;
+  navigateMock.mockClear();
+  localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ResourcePressureBannerSlot", () => {
+  test("renders nothing while the monitor is inactive", () => {
+    render(slot(okStatus));
+
+    expect(queryBanner()).toBeNull();
+  });
+
+  test("shows the banner with an Upgrade action for an active assistant", () => {
+    render(slot(elevatedStatus));
+
+    expect(queryBanner()).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Upgrade" }));
+    expect(navigateMock).toHaveBeenCalledWith(routes.plans);
+  });
+
+  test("hides the Upgrade action on native Android", () => {
+    nativeAndroid = true;
+    render(slot(elevatedStatus));
+
+    expect(queryBanner()).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Upgrade" })).toBeNull();
+  });
+
+  test("hides the Upgrade action for non-active assistant states", () => {
+    render(slot(elevatedStatus, "retired"));
+
+    expect(queryBanner()).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Upgrade" })).toBeNull();
+  });
+
+  test("dismiss hides the banner and persists a 7-day cooldown", () => {
+    render(slot(elevatedStatus));
+
+    const before = Date.now();
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+    const after = Date.now();
+
+    expect(queryBanner()).toBeNull();
+    const storedUntil = Number(localStorage.getItem(DISMISSED_UNTIL_KEY));
+    expect(storedUntil).toBeGreaterThanOrEqual(before + WEEK_MS);
+    expect(storedUntil).toBeLessThanOrEqual(after + WEEK_MS);
+    expect(localStorage.getItem(SUPPRESSED_KEY)).toBeNull();
+  });
+
+  test("a still-valid cooldown suppresses a fresh elevated episode", () => {
+    const view = render(slot(elevatedStatus));
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+
+    view.rerender(slot(okStatus));
+    view.rerender(slot(elevatedStatus));
+
+    expect(queryBanner()).toBeNull();
+
+    // The cooldown also survives a reload (a fresh mount).
+    cleanup();
+    render(slot(elevatedStatus));
+    expect(queryBanner()).toBeNull();
+  });
+
+  test("an expired cooldown shows the banner again", () => {
+    localStorage.setItem(DISMISSED_UNTIL_KEY, String(Date.now() - 1000));
+    render(slot(elevatedStatus));
+
+    expect(queryBanner()).toBeTruthy();
+  });
+
+  test("permanent suppress persists and always hides the banner", () => {
+    render(slot(elevatedStatus));
+
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: "Don't show again" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+
+    expect(queryBanner()).toBeNull();
+    expect(localStorage.getItem(SUPPRESSED_KEY)).toBe("true");
+    expect(localStorage.getItem(DISMISSED_UNTIL_KEY)).toBeNull();
+
+    cleanup();
+    render(slot(elevatedStatus));
+    expect(queryBanner()).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/components/resource-pressure-banner-slot.tsx
+++ b/clients/web/src/domains/chat/components/resource-pressure-banner-slot.tsx
@@ -1,0 +1,110 @@
+/**
+ * Resource-pressure banner slot. Owns the per-assistant localStorage-backed
+ * dismiss / suppress flags and renders {@link ResourcePressureBanner} while
+ * the monitor reports an elevated episode.
+ *
+ * Unlike the disk-pressure slot's episode-scoped dismiss, a plain dismiss
+ * here starts a 7-day cooldown that also suppresses new elevated episodes.
+ * Resource pressure recurs for busy-but-healthy workloads, so an
+ * episode-scoped dismiss would nag; the timestamp cooldown is the anti-nag.
+ * "Don't show again" persists permanently and is never auto-cleared.
+ */
+
+import { useCallback, useState } from "react";
+
+import { useNavigate } from "react-router";
+
+import { ResourcePressureBanner } from "@/components/resource-pressure-banner";
+import type { UseResourcePressureMonitorResult } from "@/assistant/use-resource-pressure-monitor";
+import {
+  getLocalBool,
+  getLocalNumber,
+  setLocalBool,
+  setLocalNumber,
+} from "@/utils/local-settings";
+import { useIsNativeAndroid } from "@/runtime/platform-detection";
+import { routes } from "@/utils/routes";
+
+const DISMISS_COOLDOWN_MS = 7 * 24 * 60 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface ResourcePressureBannerSlotProps {
+  resourcePressure: UseResourcePressureMonitorResult;
+  assistantId: string | null;
+  /** `"active"` for platform-hosted assistants that have an upgrade path. */
+  assistantStateKind: string;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function ResourcePressureBannerSlot({
+  resourcePressure,
+  assistantId,
+  assistantStateKind,
+}: ResourcePressureBannerSlotProps) {
+  const navigate = useNavigate();
+  const isNativeAndroid = useIsNativeAndroid();
+
+  const dismissedUntilKey = assistantId
+    ? `vellum:resourcePressureDismissedUntil:${assistantId}`
+    : null;
+  const suppressedKey = assistantId
+    ? `vellum:resourcePressureSuppressed:${assistantId}`
+    : null;
+
+  // Evaluated lazily at mount; a cooldown that expires while the slot stays
+  // mounted is picked up on the next mount, which is fine for a 7-day window.
+  const [cooldownActive, setCooldownActive] = useState(() => {
+    if (!dismissedUntilKey) {
+      return false;
+    }
+    return Date.now() < getLocalNumber(dismissedUntilKey, 0);
+  });
+  const [suppressed, setSuppressed] = useState(() => {
+    if (!suppressedKey) {
+      return false;
+    }
+    return getLocalBool(suppressedKey, false);
+  });
+
+  const dismiss = useCallback(
+    (permanent: boolean) => {
+      if (permanent) {
+        if (suppressedKey) {
+          setLocalBool(suppressedKey, true);
+        }
+        setSuppressed(true);
+        return;
+      }
+      if (dismissedUntilKey) {
+        setLocalNumber(dismissedUntilKey, Date.now() + DISMISS_COOLDOWN_MS);
+      }
+      setCooldownActive(true);
+    },
+    [dismissedUntilKey, suppressedKey],
+  );
+
+  if (resourcePressure.mode !== "warning" || !resourcePressure.status) {
+    return null;
+  }
+  if (suppressed || cooldownActive) {
+    return null;
+  }
+
+  return (
+    <ResourcePressureBanner
+      status={resourcePressure.status}
+      onDismiss={dismiss}
+      onUpgrade={
+        assistantStateKind === "active" && !isNativeAndroid
+          ? () => void navigate(routes.plans)
+          : null
+      }
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- Adds the chat-domain slot for the resource-pressure banner with a 7-day dismiss cooldown and permanent suppress
- Gates the Upgrade CTA to active platform assistants off native Android

Part of plan: resource-pressure-upgrade-banner.md (PR 7 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40874" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->