### PR TITLE
chore(slack): drop unused now option from transcript renderer

### DIFF
--- a/assistant/src/messaging/providers/slack/render-transcript.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.ts
@@ -6,8 +6,7 @@
  * `{role, content}[]` chronologically ordered with compact Slack tags so the
  * model can reason across sibling threads in one channel.
  *
- * The function is pure: no I/O, no implicit clock reads. Time is taken from
- * `opts.now` only when needed for relative formatting. Sort and tag rendering
+ * The function is pure: no I/O, no implicit clock reads. Sort and tag rendering
  * are deterministic.
  *
  * Consumers wire this into inbound history rendering and the compaction
@@ -63,8 +62,6 @@ export interface RenderableSlackMessage {
 }
 
 export interface RenderOptions {
-  /** Reserved for future relative-time rendering; currently unused. */
-  now?: Date;
   /** Cap rendered reactions per parent message; default 5. */
   maxReactionsPerMessage?: number;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan
Small cleanup so the Slack transcript renderer only exposes options it actually uses. `RenderOptions.now` was documented as reserved for future relative-time formatting, but `renderSlackTranscript` never reads it and no caller passes it. Removing the dead option keeps the purity claim honest: times come from stored message timestamps, not a clock argument.

## Summary
- Drop unused `now?: Date` from `RenderOptions`.
- Remove the module comment that claimed `opts.now` was used for relative formatting.

## Test plan
- [x] `cd assistant && bun test src/messaging/providers/slack/render-transcript.test.ts` — 79 pass, 0 fail
- [x] `cd assistant && bun run typecheck:fast` — pass

## Risk
Low. Optional unused field only; `maxReactionsPerMessage` is unchanged. No persistence, API, or client contract changes.

## CLI verb checklist
Not applicable: no new IPC/HTTP routes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b62b13db-7ce3-44ee-93be-5bea4c8da937?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b62b13db-7ce3-44ee-93be-5bea4c8da937&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

