### PR TITLE
feat(web): show resource-pressure banner in chat

### DIFF
--- a/clients/web/src/domains/chat/active-chat-view.tsx
+++ b/clients/web/src/domains/chat/active-chat-view.tsx
@@ -34,6 +34,7 @@ import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import { useAssistantReachability } from "@/assistant/use-assistant-reachability";
 import { useDiskPressureMonitor } from "@/assistant/use-disk-pressure-monitor";
 import { getDiskPressureChatBlockReason } from "@/assistant/disk-pressure";
+import { useResourcePressureMonitor } from "@/assistant/use-resource-pressure-monitor";
 import { useActiveAssistantIsPlatformHosted } from "@/hooks/use-platform-gate";
 import { useComposerStore } from "@/domains/chat/composer-store";
 
@@ -180,6 +181,10 @@ export function ActiveChatView() {
     monitorEnabled: diskPressure.mode !== null,
     hasResolvedStatus: diskPressure.hasResolvedStatus,
     status: diskPressure.status,
+  });
+  const resourcePressure = useResourcePressureMonitor({
+    assistantId,
+    enabled: isPlatformHosted,
   });
 
   // -------------------------------------------------------------------------
@@ -576,6 +581,9 @@ export function ActiveChatView() {
 
     // Disk pressure (single instance — avoids duplicate polling/subscriptions)
     diskPressure,
+
+    // Resource pressure (single instance, same reasoning as disk pressure)
+    resourcePressure,
 
     // Upward signals
     setRefreshEpoch,

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -42,6 +42,7 @@ import { useComposerSubmit } from "@/domains/chat/hooks/use-composer-submit";
 import { useDraftSecretDetection } from "@/domains/chat/hooks/use-draft-secret-detection";
 import type { SendChatMessageOptions } from "@/domains/chat/hooks/use-send-message";
 import { DiskPressureBannerSlot } from "@/domains/chat/components/disk-pressure-banner-slot";
+import { ResourcePressureBannerSlot } from "@/domains/chat/components/resource-pressure-banner-slot";
 import { useRuleEditorBridge } from "@/domains/chat/hooks/use-rule-editor-bridge";
 import { useChatBannerSlots } from "@/domains/chat/hooks/use-chat-banner-slots";
 import { QuoteReplyBubble } from "@/domains/chat/components/quote-reply-bubble";
@@ -135,6 +136,7 @@ import { lifecycleService } from "@/assistant/lifecycle-service";
 import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
 
 import type { UseDiskPressureMonitorResult } from "@/assistant/use-disk-pressure-monitor";
+import type { UseResourcePressureMonitorResult } from "@/assistant/use-resource-pressure-monitor";
 import { useAppNudges } from "@/domains/chat/hooks/use-app-nudges";
 import { useGhostTextSuggestion } from "@/domains/chat/hooks/use-ghost-text-suggestion";
 import {
@@ -200,6 +202,9 @@ export interface ChatMainPanelProps {
   // Disk pressure (single instance lives in ActiveChatView; passed down to
   // avoid duplicate polling intervals and bus subscriptions)
   diskPressure: UseDiskPressureMonitorResult;
+
+  // Resource pressure (single instance, same reasoning as disk pressure)
+  resourcePressure: UseResourcePressureMonitorResult;
 
   // Upward signals to ActiveChatView local state
   setRefreshEpoch: Dispatch<SetStateAction<number>>;
@@ -282,6 +287,7 @@ export function ChatMainPanel({
   handleInspectMessage,
   historyPagination,
   diskPressure,
+  resourcePressure,
   setRefreshEpoch,
   inputRef,
   sanitizedMessagesRef,
@@ -1119,6 +1125,17 @@ export function ChatMainPanel({
   );
 
   // -------------------------------------------------------------------------
+  // Resource pressure banner (localStorage-backed dismiss/cooldown)
+  // -------------------------------------------------------------------------
+  const resourcePressureBannerSlot = (
+    <ResourcePressureBannerSlot
+      resourcePressure={resourcePressure}
+      assistantId={assistantId}
+      assistantStateKind={assistantState.kind}
+    />
+  );
+
+  // -------------------------------------------------------------------------
   // Empty state (greeting, starters, avatar)
   // -------------------------------------------------------------------------
   const {
@@ -1363,6 +1380,14 @@ export function ChatMainPanel({
               ) : null
             }
             diskPressureBanner={diskPressureBannerSlot}
+            // A storage warning is actionable-critical and must not stack
+            // with or compete against an upsell banner, so the resource
+            // slot yields whenever the disk-pressure slot is active.
+            resourcePressureBanner={
+              diskPressure.mode !== "inactive"
+                ? null
+                : resourcePressureBannerSlot
+            }
             showMissingApiKeyBanner={error?.code === "PROVIDER_NOT_CONFIGURED"}
             onOpenAiSettings={pushToAiSettings}
             onDismissApiKeyError={handleDismissApiKeyError}

--- a/clients/web/src/domains/chat/components/composer-notices.tsx
+++ b/clients/web/src/domains/chat/components/composer-notices.tsx
@@ -49,6 +49,12 @@ export interface ComposerNoticesProps {
   diskPressureBanner?: ReactNode | null;
 
   /**
+   * Pre-rendered resource-pressure banner from the chat page, or `null`
+   * when resource pressure is inactive or yielding to disk pressure.
+   */
+  resourcePressureBanner?: ReactNode | null;
+
+  /**
    * Pre-rendered provider-billing banner, or `null` when no billing
    * banner should be shown. Passed as a slot because billing-banner
    * visibility depends on multiple data sources (plan, usage, provider).
@@ -87,6 +93,7 @@ export function ComposerNotices({
   onOpenMicSettings,
   onOpenTextInsertionSettings,
   diskPressureBanner,
+  resourcePressureBanner,
   billingBannerSlot,
   showMissingApiKeyBanner,
   onOpenAiSettings,
@@ -145,6 +152,9 @@ export function ComposerNotices({
       )}
       {diskPressureBanner ? (
         <div className="mb-2">{diskPressureBanner}</div>
+      ) : null}
+      {resourcePressureBanner ? (
+        <div className="mb-2">{resourcePressureBanner}</div>
       ) : null}
       {billingBannerSlot}
       {showMissingApiKeyBanner && (


### PR DESCRIPTION
## Summary
- Mounts the resource-pressure monitor for platform-hosted assistants and threads it through the chat surface
- Renders the banner in composer notices with disk-pressure taking precedence

Part of plan: resource-pressure-upgrade-banner.md (PR 8 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40876" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->