### PR TITLE
fix(web): stop an empty spacer reading as a chat banner

### DIFF
--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -1436,6 +1436,25 @@ describe("ChatComposer: a banner standing over the card", () => {
     );
   });
 
+  test("a slot that renders nothing is not a banner", () => {
+    // GIVEN a shell composer whose notices slot is mounted but quiet, the way
+    // the disk-pressure slot sits there holding its dismiss flags while the
+    // disk is healthy
+    mockIsNativeMobile = true;
+    const Quiet = () => null;
+    const { container } = renderPhoneComposer({
+      ...SETTINGS_SLOTS,
+      noticesAboveFormSlot: <Quiet />,
+    });
+
+    // THEN the row stands: what the stack renders decides this, not what is
+    // mounted in it
+    expect(pillsRow(container)?.hasAttribute("hidden")).toBe(false);
+    expect(composerShell(container)?.hasAttribute("data-banner-above")).toBe(
+      false,
+    );
+  });
+
   test("a banner mounted with the composer takes the row down", () => {
     // GIVEN the same shell composer, with a banner in the stack above the card
     mockIsNativeMobile = true;

--- a/clients/web/src/domains/chat/components/composer-notices.test.tsx
+++ b/clients/web/src/domains/chat/components/composer-notices.test.tsx
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+
+import { ComposerNotices } from "@/domains/chat/components/composer-notices";
+
+afterEach(cleanup);
+
+/**
+ * Stands in for `DiskPressureBannerSlot`, which is always mounted so it can
+ * keep its dismiss flags in step with the monitor, and renders nothing for as
+ * long as the disk is healthy.
+ */
+function QuietSlot() {
+  return null;
+}
+
+const REQUIRED = {
+  showMissingApiKeyBanner: false,
+  onOpenAiSettings: () => {},
+  onDismissApiKeyError: () => {},
+  showMaintenanceBanner: false,
+};
+
+describe("ComposerNotices", () => {
+  test("a slot that renders nothing leaves no element behind", () => {
+    // GIVEN a composer with no banner to show, whose disk-pressure slot is
+    // mounted all the same
+    const { container } = render(
+      <ComposerNotices {...REQUIRED} diskPressureBanner={<QuietSlot />} />,
+    );
+
+    // THEN the stack is empty. `ChatComposer` counts the elements above its
+    // card to decide whether a banner is standing there, and an empty spacer
+    // left by a quiet slot would take the settings pills and the avatar peek
+    // down with it for the whole session.
+    expect(container.childElementCount).toBe(0);
+  });
+
+  test("a slot with a banner in it still renders", () => {
+    // GIVEN the same composer, with the slot showing something
+    const { container } = render(
+      <ComposerNotices
+        {...REQUIRED}
+        diskPressureBanner={<div data-testid="disk-banner">Running low</div>}
+      />,
+    );
+
+    // THEN it reaches the stack, and counts
+    expect(container.querySelector('[data-testid="disk-banner"]')).not.toBe(
+      null,
+    );
+    expect(container.childElementCount).toBeGreaterThan(0);
+  });
+});

--- a/clients/web/src/domains/chat/components/composer-notices.tsx
+++ b/clients/web/src/domains/chat/components/composer-notices.tsx
@@ -143,9 +143,10 @@ export function ComposerNotices({
           </Notice>
         </div>
       )}
-      {diskPressureBanner ? (
-        <div className="mb-2">{diskPressureBanner}</div>
-      ) : null}
+      {/* Rendered bare: the slot is always a truthy element and decides for
+          itself whether it has a banner, so a wrapper here would stand in the
+          stack even when it renders nothing. It brings its own spacing. */}
+      {diskPressureBanner}
       {billingBannerSlot}
       {showMissingApiKeyBanner && (
         <div className="mb-2">

--- a/clients/web/src/domains/chat/components/disk-pressure-banner-slot.tsx
+++ b/clients/web/src/domains/chat/components/disk-pressure-banner-slot.tsx
@@ -111,22 +111,27 @@ export function DiskPressureBannerSlot({
     return null;
   }
 
+  // The spacer lives with the banner, not around the slot: a wrapper on the
+  // caller's side outlives every `return null` above and leaves an empty
+  // element in the composer's banner stack, which reads there as a banner.
   return (
-    <DiskPressureBanner
-      status={diskPressure.status}
-      mode={mode}
-      isAcknowledging={diskPressure.isAcknowledging}
-      acknowledgeError={diskPressure.acknowledgeError?.message ?? null}
-      onAcknowledge={() => void diskPressure.acknowledge()}
-      onDismissWarning={dismissWarning}
-      onReviewWorkspaceData={() =>
-        void navigate(`${routes.workspace}?sort=size`)
-      }
-      onUpgradeStorage={
-        assistantStateKind === "active" && !isNativeAndroid
-          ? () => void navigate(routes.plans)
-          : null
-      }
-    />
+    <div className="mb-2">
+      <DiskPressureBanner
+        status={diskPressure.status}
+        mode={mode}
+        isAcknowledging={diskPressure.isAcknowledging}
+        acknowledgeError={diskPressure.acknowledgeError?.message ?? null}
+        onAcknowledge={() => void diskPressure.acknowledge()}
+        onDismissWarning={dismissWarning}
+        onReviewWorkspaceData={() =>
+          void navigate(`${routes.workspace}?sort=size`)
+        }
+        onUpgradeStorage={
+          assistantStateKind === "active" && !isNativeAndroid
+            ? () => void navigate(routes.plans)
+            : null
+        }
+      />
+    </div>
   );
 }


### PR DESCRIPTION
## What

`ChatComposer` decides whether a banner is standing over its card by counting the elements in the watched stack above it:

```js
setHasBannerAboveCard(node.childElementCount > 0);
```

and stands the mobile settings pills and the `ComposerPeek` avatar down while one is there.

`DiskPressureBannerSlot` is mounted for the whole session so it can keep its localStorage dismiss flags in step with the monitor, and returns `null` on three separate branches while the disk is healthy. `ComposerNotices` wrapped it on the truthiness of the **element**, not of what the element renders:

```jsx
{diskPressureBanner ? (
  <div className="mb-2">{diskPressureBanner}</div>
) : null}
```

A React element is always truthy, so that spacer div stood in the stack forever. `childElementCount` never reached zero, `hasBannerAboveCard` was permanently `true`, and:

- `settingsPillsVisible` was permanently `false`, so the assistant-access and model-profile pills never came up on a phone
- the shell carried `data-banner-above` permanently, so `ComposerPeek`'s avatar stayed retracted

The spacer now moves in with the banner, so it leaves with it, and `ComposerNotices` renders the slot bare the way it already renders `billingBannerSlot`.

## Impact

Every mobile surface on current main: the iOS and Android shells and mobile web. Desktop is unaffected, since those pickers sit inline in the composer's action row and never consult this flag.

## Verification

- `bun scripts/run-tests.ts` on `composer-notices`, `chat-composer`, `disk-pressure-banner-slot` and `disk-pressure-banner` — 4 files pass
- new `composer-notices.test.tsx` was confirmed to fail against the old wrapper and pass with the fix
- `bun run typecheck`, `prettier --check`, `eslint` clean on the changed files

Device QA on a phone still wants doing: mount a chat with a healthy disk and confirm the two pills stand and the avatar peeks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)