### PR TITLE
fix(companion): let a custom avatar drag the surface

### DIFF
--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -106,3 +106,56 @@ describe("the companion surface's working ring", () => {
     expect(ringOf(container)).toBeNull();
   });
 });
+
+/**
+ * The avatar is the surface's drag handle, and it renders as one of two very
+ * different things: a composed creature of SVG and divs, or a bare `<img>` for
+ * a custom uploaded avatar. Only the image is natively draggable, so only the
+ * image can hand the press to the platform's own HTML5 drag and starve the
+ * surface of the `mousemove` stream its drag runs on.
+ *
+ * jsdom implements no native image drag, so what a test can hold is the opt
+ * out itself rather than its effect: the attribute, and the WebKit-only CSS
+ * that covers the paths where WebKit ignores the attribute.
+ */
+describe("the companion surface's custom avatar", () => {
+  const imageOf = (container: HTMLElement): HTMLImageElement | null =>
+    container.querySelector("img");
+
+  test("renders for an assistant with no traits to compose", () => {
+    const { container } = render(
+      <CompanionSurface phase="resting" avatarSrc="data:image/png;base64,AA" />,
+    );
+    expect(imageOf(container)?.getAttribute("src")).toBe(
+      "data:image/png;base64,AA",
+    );
+  });
+
+  test("refuses the browser's own image drag", () => {
+    const { container } = render(
+      <CompanionSurface phase="resting" avatarSrc="data:image/png;base64,AA" />,
+    );
+    expect(imageOf(container)?.getAttribute("draggable")).toBe("false");
+  });
+
+  test("refuses it in WebKit, which reads the CSS and not the attribute", () => {
+    const { container } = render(
+      <CompanionSurface phase="resting" avatarSrc="data:image/png;base64,AA" />,
+    );
+    expect(imageOf(container)?.className).toContain("[-webkit-user-drag:none]");
+  });
+
+  /**
+   * The creature branch has no image at all, which is why the bug reached the
+   * custom avatars alone.
+   */
+  test("is not what a composed creature renders", () => {
+    const { container } = render(
+      <CompanionSurface
+        phase="resting"
+        character={{ bodyShape: "blob", eyeStyle: "curious", color: "teal" }}
+      />,
+    );
+    expect(imageOf(container)).toBeNull();
+  });
+});

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -769,10 +769,18 @@ function Avatar({
       ) : (
         // A custom uploaded image, which has no traits to compose and so no
         // eyes to animate.
+        //
+        // Undraggable, because the avatar is the surface's drag handle. An
+        // image is natively draggable, and the platform's own HTML5 image drag
+        // takes the pointer and ends the `mousemove` stream the surface's drag
+        // runs on, so pressing a custom avatar would move nothing where
+        // pressing a composed creature moves the window. WebKit honours the CSS
+        // on paths where it ignores the attribute, so both are needed.
         <img
           src={avatarSrc}
           alt=""
-          className="relative size-7 rounded-full object-contain drop-shadow-[0_1px_3px_rgba(0,0,0,0.55)]"
+          draggable={false}
+          className="relative size-7 rounded-full object-contain drop-shadow-[0_1px_3px_rgba(0,0,0,0.55)] [-webkit-user-drag:none]"
         />
       )}
     </div>


### PR DESCRIPTION
## What

The companion surface's avatar is the drag handle for the whole window, but the two avatar branches render very different things: a composed creature (`AnimatedAvatar` — SVG and divs) or a bare `<img>` for a custom uploaded avatar.

An image is natively draggable. Pressing one started the platform's own HTML5 image drag, which took the pointer and ended the `mousemove` stream the surface's drag runs on — so a custom avatar moved nothing where a creature moved the window, and a ghost image followed the cursor. Nothing was wrong with the drag logic; the press never reached it.

## How

`draggable={false}` on the image, plus `[-webkit-user-drag:none]` — WebKit honours the CSS on paths where it ignores the attribute. The arbitrary-property utility matches the existing `[-webkit-app-region:...]` usage elsewhere in the app, and it keeps the opt-out assertable from a test (jsdom implements no native image drag, so the attribute and the class are what a test can hold).

## Testing

Four cases added to `companion-surface.test.tsx` pressing the image branch specifically, since the two branches diverge exactly here: the image renders for a traitless assistant, carries `draggable="false"`, carries the WebKit class, and is absent entirely on the creature branch.

- `cd clients/web && bun test src/components/companion-surface.test.tsx` — 14 pass
- `cd clients/web && bun test src/components/companion-surface-page.test.tsx` — 7 pass (drag suite unaffected)
- lint + `tsc --noEmit` clean

Follow-on to JARVIS-1539 (#40832), which made the whole surface a drag handle and was verified against the creature.

Closes JARVIS-1547

🤖 Generated with [Claude Code](https://claude.com/claude-code)