### PR TITLE
fix(inbound): a Slack reaction lands on the message it was attached to, not a conversation of its own (LUM-3330)

### DIFF
--- a/assistant/src/__tests__/channel-inbound-disk-pressure.test.ts
+++ b/assistant/src/__tests__/channel-inbound-disk-pressure.test.ts
@@ -250,7 +250,7 @@ describe("channel inbound disk pressure gate", () => {
 
     expect(body).toMatchObject({
       accepted: true,
-      duplicate: false,
+      reaction: "dropped_disk_pressure",
       diskPressure: "blocked",
       reason: "trusted-contact",
     });
@@ -268,9 +268,9 @@ describe("channel inbound disk pressure gate", () => {
         eq(channelInboundEvents.externalMessageId, "slack-reaction-blocked"),
       )
       .get();
-    expect(event?.processingStatus).toBe("processed");
-    expect(event?.messageId).toBeNull();
-    expect(event?.rawPayload).toBeNull();
+    // A blocked reaction writes nothing at all: it is dropped before the
+    // reacted message is resolved, so no event row is opened either.
+    expect(event).toBeUndefined();
     expect(db.select().from(messages).all()).toHaveLength(0);
   });
 

--- a/assistant/src/__tests__/reaction-persistence.test.ts
+++ b/assistant/src/__tests__/reaction-persistence.test.ts
@@ -320,7 +320,8 @@ describe("Slack reaction event persistence", () => {
     expect(slackMeta!.eventKind).toBe("reaction");
     expect(slackMeta!.channelId).toBe(SLACK_CHANNEL_ID);
     expect(slackMeta!.channelTs).toBe("1700000000.111111");
-    expect(slackMeta!.threadTs).toBe("1700000000.111111");
+    // Slack sends no thread on a reaction, so the row claims none.
+    expect(slackMeta!.threadTs).toBeUndefined();
     expect(slackMeta!.displayName).toBe(SLACK_DISPLAY_NAME);
     expect(slackMeta!.reaction).toEqual({
       emoji: "thumbsup",
@@ -361,6 +362,25 @@ describe("Slack reaction event persistence", () => {
 
     const rows = readPersistedMessages();
     expect(rows.length).toBe(0);
+  });
+
+  test("a reaction never claims a thread, so it is not thread evidence", async () => {
+    // Storing the gateway's fabricated thread id here made the row look like
+    // proof that a thread belongs to this conversation.
+    seedStoredMessage("1700000000.111111");
+    await handleChannelInbound(
+      buildReactionRequest("reaction:thumbsup"),
+      undefined,
+      TEST_BEARER_TOKEN,
+    );
+    const rows = readPersistedMessages().filter(
+      (r) => r.content === "[reaction]",
+    );
+    const meta = readSlackMetadata(
+      (JSON.parse(rows[0].metadata!) as Record<string, unknown>)
+        .slackMeta as string,
+    );
+    expect(meta?.threadTs).toBeUndefined();
   });
 
   test("reaction without threadId omits threadTs in metadata", async () => {

--- a/assistant/src/__tests__/reaction-persistence.test.ts
+++ b/assistant/src/__tests__/reaction-persistence.test.ts
@@ -433,7 +433,9 @@ describe("Slack reaction event persistence", () => {
     const j2 = (await r2.json()) as Record<string, unknown>;
     expect(j2.duplicate).toBe(true);
 
-    const rows = readPersistedMessages();
+    const rows = readPersistedMessages().filter(
+      (r) => r.content === "[reaction]",
+    );
     expect(rows.length).toBe(1);
   });
 
@@ -503,7 +505,11 @@ describe("Slack reaction event persistence", () => {
     const eventId = json.eventId as string;
 
     const db = getDb();
-    const messageRows = db.select().from(messages).all();
+    const messageRows = db
+      .select()
+      .from(messages)
+      .all()
+      .filter((row) => row.content === "[reaction]");
     expect(messageRows.length).toBe(1);
 
     const { channelInboundEvents } =

--- a/assistant/src/__tests__/reaction-persistence.test.ts
+++ b/assistant/src/__tests__/reaction-persistence.test.ts
@@ -439,6 +439,50 @@ describe("Slack reaction event persistence", () => {
     expect(rows.length).toBe(1);
   });
 
+  test("reaction on the assistant's own post lands in that conversation", async () => {
+    // An outbound post opens no inbound event, so the only record of its ts
+    // is the `slackMeta` on the assistant row. Seeded here the way the
+    // outbound reconciler writes it.
+    const botTs = "1700000000.999999";
+    const conversationId = seedStoredMessage("1700000000.111111");
+    const db = getDb();
+    db.$client
+      .prepare(
+        `INSERT INTO messages (id, conversation_id, role, content, created_at, metadata)
+         VALUES (?, ?, 'assistant', '"posted"', ?, ?)`,
+      )
+      .run(
+        "msg-bot-post",
+        conversationId,
+        Date.now(),
+        JSON.stringify({
+          slackMeta: JSON.stringify({
+            source: "slack",
+            channelId: SLACK_CHANNEL_ID,
+            channelTs: botTs,
+            eventKind: "message",
+          }),
+        }),
+      );
+
+    const resp = await handleChannelInbound(
+      buildReactionRequest("reaction:tada", {
+        externalMessageId: `${SLACK_CHANNEL_ID}:${botTs}:reactor`,
+        sourceMetadata: { messageId: botTs, chatType: "channel" },
+      }),
+      undefined,
+      TEST_BEARER_TOKEN,
+    );
+    expect(resp.status).toBe(200);
+
+    const reactionRow = db.$client
+      .prepare(
+        "SELECT conversation_id AS conversationId FROM messages WHERE content = '[reaction]'",
+      )
+      .get() as { conversationId: string } | null;
+    expect(reactionRow?.conversationId).toBe(conversationId);
+  });
+
   test("reaction on a message the assistant never stored creates no conversation", async () => {
     // The reported bug: Slack sends no `thread_ts` on a reaction, so keying a
     // conversation off the reaction's own address minted one per reacted

--- a/assistant/src/__tests__/reaction-persistence.test.ts
+++ b/assistant/src/__tests__/reaction-persistence.test.ts
@@ -76,6 +76,7 @@ import type { Conversation } from "../daemon/conversation.js";
 import { readSlackMetadata } from "../messaging/providers/slack/message-metadata.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
+import { linkMessage, recordInbound } from "../persistence/delivery-crud.js";
 import { messages } from "../persistence/schema/conversations.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import {
@@ -156,6 +157,29 @@ function buildReactionRequest(
     },
     body: JSON.stringify(body),
   });
+}
+
+/**
+ * Store the message a reaction will be attached to. A reaction resolves its
+ * conversation through this row, so without one there is nothing to annotate.
+ */
+function seedStoredMessage(reactedTs: string): string {
+  const event = recordInbound(
+    "slack",
+    SLACK_CHANNEL_ID,
+    `${SLACK_CHANNEL_ID}:${reactedTs}:seed`,
+    { sourceMessageId: reactedTs },
+  );
+  const db = getDb();
+  const messageId = `msg-${reactedTs}`;
+  db.$client
+    .prepare(
+      `INSERT INTO messages (id, conversation_id, role, content, created_at)
+       VALUES (?, ?, 'user', '"hello"', ?)`,
+    )
+    .run(messageId, event.conversationId, Date.now());
+  linkMessage(event.eventId, messageId);
+  return event.conversationId;
 }
 
 function readPersistedMessages(): Array<{
@@ -257,6 +281,7 @@ describe("Slack reaction event persistence", () => {
   });
 
   test("reaction:thumbsup is persisted with slackMeta.eventKind=reaction", async () => {
+    seedStoredMessage("1700000000.111111");
     let agentDispatched = false;
     const processMessage = async (): Promise<{ messageId: string }> => {
       agentDispatched = true;
@@ -276,7 +301,9 @@ describe("Slack reaction event persistence", () => {
 
     expect(agentDispatched).toBe(false);
 
-    const rows = readPersistedMessages();
+    const rows = readPersistedMessages().filter(
+      (r) => r.content === "[reaction]",
+    );
     expect(rows.length).toBe(1);
 
     const row = rows[0];
@@ -304,11 +331,14 @@ describe("Slack reaction event persistence", () => {
   });
 
   test("reaction_removed:eyes records op === removed", async () => {
+    seedStoredMessage("1700000000.111111");
     const req = buildReactionRequest("reaction_removed:eyes");
     const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
     expect(resp.status).toBe(200);
 
-    const rows = readPersistedMessages();
+    const rows = readPersistedMessages().filter(
+      (r) => r.content === "[reaction]",
+    );
     expect(rows.length).toBe(1);
 
     const envelope = JSON.parse(rows[0].metadata!) as Record<string, unknown>;
@@ -325,12 +355,16 @@ describe("Slack reaction event persistence", () => {
     });
     const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
     expect(resp.status).toBe(200);
+    expect(((await resp.json()) as Record<string, unknown>).reaction).toBe(
+      "dropped_unknown_target",
+    );
 
     const rows = readPersistedMessages();
     expect(rows.length).toBe(0);
   });
 
   test("reaction without threadId omits threadTs in metadata", async () => {
+    seedStoredMessage("1700000000.222222");
     const req = buildReactionRequest("reaction:wave", {
       sourceMetadata: {
         messageId: "1700000000.222222",
@@ -340,7 +374,9 @@ describe("Slack reaction event persistence", () => {
     const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
     expect(resp.status).toBe(200);
 
-    const rows = readPersistedMessages();
+    const rows = readPersistedMessages().filter(
+      (r) => r.content === "[reaction]",
+    );
     expect(rows.length).toBe(1);
 
     const envelope = JSON.parse(rows[0].metadata!) as Record<string, unknown>;
@@ -352,6 +388,7 @@ describe("Slack reaction event persistence", () => {
   });
 
   test("agent loop is never dispatched for reaction events", async () => {
+    seedStoredMessage("1700000000.111111");
     let dispatchCount = 0;
     const processMessage = async (): Promise<{ messageId: string }> => {
       dispatchCount++;
@@ -373,6 +410,7 @@ describe("Slack reaction event persistence", () => {
   });
 
   test("duplicate reaction events do not double-persist", async () => {
+    seedStoredMessage("1700000000.111111");
     const sharedExternalMessageId = `${SLACK_CHANNEL_ID}:1700000000.555555:alice`;
     const makeReq = () =>
       buildReactionRequest("reaction:tada", {
@@ -399,7 +437,66 @@ describe("Slack reaction event persistence", () => {
     expect(rows.length).toBe(1);
   });
 
+  test("reaction on a message the assistant never stored creates no conversation", async () => {
+    // The reported bug: Slack sends no `thread_ts` on a reaction, so keying a
+    // conversation off the reaction's own address minted one per reacted
+    // message, each holding a single "[reaction]" row and a permanent
+    // "Generating title..." placeholder.
+    const db = getDb();
+    const countRows = (table: string): number =>
+      (
+        db.$client.prepare(`SELECT COUNT(*) AS n FROM ${table}`).get() as {
+          n: number;
+        }
+      ).n;
+
+    const resp = await handleChannelInbound(
+      buildReactionRequest("reaction:thumbsup"),
+      undefined,
+      TEST_BEARER_TOKEN,
+    );
+    const json = (await resp.json()) as Record<string, unknown>;
+
+    expect(json.accepted).toBe(true);
+    expect(json.reaction).toBe("dropped_unknown_target");
+    expect(countRows("conversations")).toBe(0);
+    expect(countRows("channel_inbound_events")).toBe(0);
+    expect(readPersistedMessages().length).toBe(0);
+  });
+
+  test("reaction lands in the conversation of the reacted message, not a new one", async () => {
+    const targetConversationId = seedStoredMessage("1700000000.111111");
+    const db = getDb();
+    const conversationsBefore = (
+      db.$client.prepare("SELECT COUNT(*) AS n FROM conversations").get() as {
+        n: number;
+      }
+    ).n;
+
+    const resp = await handleChannelInbound(
+      buildReactionRequest("reaction:thumbsup"),
+      undefined,
+      TEST_BEARER_TOKEN,
+    );
+    expect(resp.status).toBe(200);
+
+    const conversationsAfter = (
+      db.$client.prepare("SELECT COUNT(*) AS n FROM conversations").get() as {
+        n: number;
+      }
+    ).n;
+    expect(conversationsAfter).toBe(conversationsBefore);
+
+    const reactionRow = db.$client
+      .prepare(
+        "SELECT conversation_id AS conversationId FROM messages WHERE content = '[reaction]'",
+      )
+      .get() as { conversationId: string } | null;
+    expect(reactionRow?.conversationId).toBe(targetConversationId);
+  });
+
   test("link to channel_inbound_events is created", async () => {
+    seedStoredMessage("1700000000.111111");
     const req = buildReactionRequest("reaction:thumbsup");
     const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
     const json = (await resp.json()) as Record<string, unknown>;
@@ -707,6 +804,7 @@ describe("reaction access control (no verification handshake)", () => {
       displayName: "Pending Contact",
     });
 
+    seedStoredMessage("1700000000.111111");
     const req = buildReactionRequest("reaction:tada", {
       actorExternalId: CONTACT_USER_ID,
       actorDisplayName: "Pending Contact",
@@ -718,7 +816,9 @@ describe("reaction access control (no verification handshake)", () => {
     expect(json.denied).not.toBe(true);
     expect(json.reason).not.toBe("verification_challenge_sent");
 
-    const rows = readPersistedMessages();
+    const rows = readPersistedMessages().filter(
+      (r) => r.content === "[reaction]",
+    );
     expect(rows.length).toBe(1);
     const envelope = JSON.parse(rows[0].metadata!) as Record<string, unknown>;
     const slackMeta = readSlackMetadata(envelope.slackMeta as string);

--- a/assistant/src/__tests__/reaction-persistence.test.ts
+++ b/assistant/src/__tests__/reaction-persistence.test.ts
@@ -483,6 +483,29 @@ describe("Slack reaction event persistence", () => {
     expect(reactionRow?.conversationId).toBe(conversationId);
   });
 
+  test("a reaction leaves the reacted message resolvable by its own id", async () => {
+    // Two linked rows on one provider id would let a later edit or delete of
+    // the message resolve to the reaction instead.
+    const reactedTs = "1700000000.111111";
+    seedStoredMessage(reactedTs);
+    await handleChannelInbound(
+      buildReactionRequest("reaction:thumbsup"),
+      undefined,
+      TEST_BEARER_TOKEN,
+    );
+
+    const db = getDb();
+    const claimants = (
+      db.$client
+        .prepare(
+          `SELECT COUNT(*) AS n FROM channel_inbound_events
+           WHERE source_message_id = ? AND message_id IS NOT NULL`,
+        )
+        .get(reactedTs) as { n: number }
+    ).n;
+    expect(claimants).toBe(1);
+  });
+
   test("reaction on a message the assistant never stored creates no conversation", async () => {
     // The reported bug: Slack sends no `thread_ts` on a reaction, so keying a
     // conversation off the reaction's own address minted one per reacted

--- a/assistant/src/persistence/delivery-crud.ts
+++ b/assistant/src/persistence/delivery-crud.ts
@@ -255,6 +255,34 @@ export function findInboundConversationId(
  * the conversation and tracks the reply. Both must key on the same three
  * fields for either to mean anything.
  */
+/**
+ * The inbound event already recorded for this address, if any. Read-only twin
+ * of the dedup check inside {@link recordInbound}, for callers that must know
+ * an event is a redelivery before doing work that recording would otherwise
+ * gate (routing a guardian decision, for one).
+ */
+export function findInboundEvent(
+  sourceChannel: string,
+  externalChatId: string,
+  externalMessageId: string,
+): { eventId: string; conversationId: string } | null {
+  const row = getDb()
+    .select({
+      id: channelInboundEvents.id,
+      conversationId: channelInboundEvents.conversationId,
+    })
+    .from(channelInboundEvents)
+    .where(
+      and(
+        eq(channelInboundEvents.sourceChannel, sourceChannel),
+        eq(channelInboundEvents.externalChatId, externalChatId),
+        eq(channelInboundEvents.externalMessageId, externalMessageId),
+      ),
+    )
+    .get();
+  return row ? { eventId: row.id, conversationId: row.conversationId } : null;
+}
+
 export function recordInbound(
   sourceChannel: string,
   externalChatId: string,

--- a/assistant/src/persistence/delivery-crud.ts
+++ b/assistant/src/persistence/delivery-crud.ts
@@ -5,7 +5,7 @@
  * finding messages by source identifiers, and managing raw payload storage.
  */
 
-import { and, desc, eq, isNotNull, ne, or, sql } from "drizzle-orm";
+import { and, desc, eq, isNotNull, like, ne, or, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import type { ChannelId } from "../channels/types.js";
@@ -21,7 +21,12 @@ import {
 } from "./conversation-key-store.js";
 import type { NonScheduledConversationType } from "./conversation-types.js";
 import { getDb } from "./db-connection.js";
-import { channelInboundEvents, conversations } from "./schema.js";
+import {
+  channelInboundEvents,
+  conversationKeys,
+  conversations,
+  messages,
+} from "./schema.js";
 
 export interface InboundResult {
   accepted: boolean;
@@ -44,6 +49,14 @@ export interface RecordInboundOptions {
 
 const SLACK_LEGACY_THREAD_EVIDENCE_BATCH_SIZE = 50;
 const SLACK_LEGACY_THREAD_EVIDENCE_MAX_SCAN = 500;
+
+/**
+ * Rows examined when locating a Slack message the assistant itself posted.
+ * Bounded on purpose: the scan runs on the inbound path while the gateway
+ * waits for its ack, and reactions land on recent messages, so a cap costs
+ * almost no recall and keeps the cost flat as the database grows.
+ */
+const SLACK_OUTBOUND_TS_MAX_SCAN = 400;
 
 /**
  * Channels where an inbound thread id scopes the conversation: a Slack thread
@@ -281,6 +294,61 @@ export function findInboundEvent(
     )
     .get();
   return row ? { eventId: row.id, conversationId: row.conversationId } : null;
+}
+
+/**
+ * The conversation holding the Slack message with this `ts`, found by reading
+ * the `slackMeta` the assistant's own posts carry.
+ *
+ * `findMessageBySourceId` covers every message that arrived as an inbound
+ * event. It cannot see what the assistant posted, because an outbound reply
+ * opens no inbound event, so a reaction on the assistant's own message needs
+ * this. The search is confined to conversations already bound to the same
+ * Slack channel and to the most recent {@link SLACK_OUTBOUND_TS_MAX_SCAN}
+ * rows among them; beyond that it gives up and the caller drops the
+ * annotation, which is the same outcome as never finding it at all.
+ */
+export function findSlackConversationByMessageTs(
+  externalChatId: string,
+  channelTs: string,
+): string | null {
+  const db = getDb();
+  const keyPrefix = `${CONVERSATION_KEY_SCOPE}:slack:${externalChatId}`;
+  const rows = db
+    .select({
+      conversationId: messages.conversationId,
+      metadata: messages.metadata,
+    })
+    .from(messages)
+    .innerJoin(
+      conversationKeys,
+      eq(conversationKeys.conversationId, messages.conversationId),
+    )
+    .where(
+      and(
+        or(
+          eq(conversationKeys.conversationKey, keyPrefix),
+          like(conversationKeys.conversationKey, `${keyPrefix}:thread:%`),
+        ),
+        like(messages.metadata, '%"slackMeta"%'),
+      ),
+    )
+    .orderBy(desc(messages.createdAt))
+    .limit(SLACK_OUTBOUND_TS_MAX_SCAN)
+    .all();
+
+  for (const row of rows) {
+    const slackMeta = readSlackMetadataFromMessageMetadata(row.metadata, {
+      allowFlatLegacy: true,
+    });
+    if (
+      slackMeta?.channelId === externalChatId &&
+      slackMeta.channelTs === channelTs
+    ) {
+      return row.conversationId;
+    }
+  }
+  return null;
 }
 
 export function recordInbound(

--- a/assistant/src/persistence/delivery-crud.ts
+++ b/assistant/src/persistence/delivery-crud.ts
@@ -33,6 +33,13 @@ export interface InboundResult {
 export interface RecordInboundOptions {
   sourceMessageId?: string;
   sourceThreadId?: string;
+  /**
+   * Record the event against this conversation instead of resolving one from
+   * the address. For events that belong to a message rather than to a chat: a
+   * reaction lives in the conversation of the message it was attached to, and
+   * resolving from its own address would mint a second one.
+   */
+  conversationId?: string;
 }
 
 const SLACK_LEGACY_THREAD_EVIDENCE_BATCH_SIZE = 50;
@@ -280,11 +287,13 @@ export function recordInbound(
     };
   }
 
-  const mapping = resolveInboundConversation(
-    sourceChannel,
-    externalChatId,
-    options?.sourceThreadId,
-  );
+  const mapping = options?.conversationId
+    ? { conversationId: options.conversationId }
+    : resolveInboundConversation(
+        sourceChannel,
+        externalChatId,
+        options?.sourceThreadId,
+      );
   const now = Date.now();
   const eventId = uuid();
 

--- a/assistant/src/runtime/guardian-reply-router.ts
+++ b/assistant/src/runtime/guardian-reply-router.ts
@@ -97,8 +97,12 @@ export interface GuardianReplyContext {
   channel: string;
   /** Actor identity context for the sender. */
   actor: ActorContext;
-  /** Conversation ID for this message (may be the guardian's conversation). */
-  conversationId: string;
+  /**
+   * Conversation the message arrived in (may be the guardian's own). Only the
+   * text and NL paths read it; reactions and `apr:` callbacks resolve their
+   * target by card address or embedded request id and may pass none.
+   */
+  conversationId?: string;
   /** Callback data from button presses (e.g. `apr:<requestId>:<action>`). */
   callbackData?: string;
   /**

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -417,9 +417,10 @@ export async function handleChannelInbound({
   // 👍 never triggers a verification handshake or an access-request
   // notification, and a stranger's reaction creates no conversation/binding.
   // The interceptor drops strangers, records known contacts' reactions as
-  // transcript signals, and routes a guardian's reaction on an approval card
-  // through the guardian decision pipeline. Reactions never drive an
-  // agent turn.
+  // transcript signals in the conversation of the reacted message, and routes
+  // a guardian's reaction on an approval card through the guardian decision
+  // pipeline. Reactions never mint a conversation and never drive an agent
+  // turn.
   if (isSlackReactionEvent(body)) {
     return handleSlackReactionIntercept({
       callbackData: body.callbackData!,
@@ -433,7 +434,6 @@ export async function handleChannelInbound({
       actorUsername: body.actorUsername,
       replyCallbackUrl: body.replyCallbackUrl,
       sourceMetadata: body.sourceMetadata,
-      slackChannelName,
       approvalConversationGenerator,
     });
   }

--- a/assistant/src/runtime/routes/inbound-stages/guardian-reply-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-reply-intercept.ts
@@ -44,8 +44,14 @@ export interface GuardianReplyInterceptParams {
   canonicalSenderId: string | null;
   sourceChannel: ChannelId;
   conversationExternalId: string;
-  conversationId: string;
-  eventId: string;
+  /**
+   * Conversation the message arrived in. Reactions resolve their target by the
+   * reacted card's own address and are routed before any conversation is
+   * known, so they pass none.
+   */
+  conversationId?: string;
+  /** Inbound event id, echoed on the consumed response when the caller has one. */
+  eventId?: string;
   replyCallbackUrl: string | undefined;
   trustClass: string;
   guardianPrincipalId: string | null | undefined;
@@ -209,7 +215,7 @@ export async function handleGuardianReplyIntercept(
       response: {
         accepted: true,
         duplicate: false,
-        eventId,
+        ...(eventId ? { eventId } : {}),
         canonicalRouter: routerResult.type,
         requestId: routerResult.requestId,
       },

--- a/assistant/src/runtime/routes/inbound-stages/reaction-intercept.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/reaction-intercept.test.ts
@@ -70,6 +70,7 @@ mock.module("../../../contacts/contact-store.js", () => ({
 // ---------------------------------------------------------------------------
 
 let recordInboundCalls: Array<{ conversationId?: string }> = [];
+let recordedEvent: { eventId: string; conversationId: string } | null = null;
 let storedTarget: { messageId: string; conversationId: string } | null = null;
 mock.module("../../../persistence/delivery-crud.js", () => ({
   recordInbound: (
@@ -87,6 +88,7 @@ mock.module("../../../persistence/delivery-crud.js", () => ({
     };
   },
   findMessageBySourceId: () => storedTarget,
+  findInboundEvent: () => recordedEvent,
   clearPayload: () => {},
   linkMessage: () => {},
 }));
@@ -211,6 +213,7 @@ describe("reaction intercept consumes the stamped verdict directly", () => {
     setMemberVerdictCalls = 0;
     contactLookups = 0;
     recordInboundCalls = [];
+    recordedEvent = null;
     addMessageCalls = 0;
     guardianReplyCalls = [];
     guardianReplyResponse = undefined;
@@ -268,6 +271,26 @@ describe("reaction intercept consumes the stamped verdict directly", () => {
     expect(result.reaction).toBe("dropped_unknown_target");
     expect(recordInboundCalls.length).toBe(0);
     expect(addMessageCalls).toBe(0);
+  });
+
+  test("a redelivered reaction never reaches the guardian rail twice", async () => {
+    recordedEvent = { eventId: "evt-1", conversationId: "conv-target" };
+
+    const result = await handleSlackReactionIntercept(
+      buildParams({
+        rawSenderId: GUARDIAN_USER_ID,
+        trustVerdict: GUARDIAN_VERDICT,
+      }),
+    );
+
+    expect(result).toEqual({
+      accepted: true,
+      duplicate: true,
+      eventId: "evt-1",
+    });
+    expect(guardianReplyCalls.length).toBe(0);
+    expect(addMessageCalls).toBe(0);
+    expect(recordInboundCalls.length).toBe(0);
   });
 
   test("a guardian card reaction still applies when the card is not a stored message", async () => {

--- a/assistant/src/runtime/routes/inbound-stages/reaction-intercept.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/reaction-intercept.test.ts
@@ -69,17 +69,24 @@ mock.module("../../../contacts/contact-store.js", () => ({
 // Downstream side-effect stubs
 // ---------------------------------------------------------------------------
 
-let recordInboundCalls = 0;
+let recordInboundCalls: Array<{ conversationId?: string }> = [];
+let storedTarget: { messageId: string; conversationId: string } | null = null;
 mock.module("../../../persistence/delivery-crud.js", () => ({
-  recordInbound: () => {
-    recordInboundCalls++;
+  recordInbound: (
+    _channel: string,
+    _chat: string,
+    _externalMessageId: string,
+    options?: { conversationId?: string },
+  ) => {
+    recordInboundCalls.push({ conversationId: options?.conversationId });
     return {
       eventId: "evt-1",
-      conversationId: "conv-1",
+      conversationId: options?.conversationId ?? "conv-minted",
       accepted: true,
       duplicate: false,
     };
   },
+  findMessageBySourceId: () => storedTarget,
   clearPayload: () => {},
   linkMessage: () => {},
 }));
@@ -184,7 +191,6 @@ function buildParams(overrides: {
         ? { trustVerdict: overrides.trustVerdict }
         : {}),
     } as never,
-    slackChannelName: "general",
     approvalConversationGenerator: undefined,
   };
 }
@@ -193,7 +199,7 @@ function expectDropped(result: Record<string, unknown>): void {
   expect(result.reaction).toBe("dropped_unknown_actor");
   // Dropped before any write or routing: no dedup record, no transcript row,
   // no approval-pipeline dispatch.
-  expect(recordInboundCalls).toBe(0);
+  expect(recordInboundCalls.length).toBe(0);
   expect(addMessageCalls).toBe(0);
   expect(guardianReplyCalls.length).toBe(0);
 }
@@ -204,10 +210,11 @@ describe("reaction intercept consumes the stamped verdict directly", () => {
     guardianDeliveryReads = 0;
     setMemberVerdictCalls = 0;
     contactLookups = 0;
-    recordInboundCalls = 0;
+    recordInboundCalls = [];
     addMessageCalls = 0;
     guardianReplyCalls = [];
     guardianReplyResponse = undefined;
+    storedTarget = { messageId: "msg-target", conversationId: "conv-target" };
   });
 
   test("guardian verdict routes the reaction into the approval decision pipeline", async () => {
@@ -244,6 +251,38 @@ describe("reaction intercept consumes the stamped verdict directly", () => {
     expect(result.accepted).toBe(true);
     expect(result.reaction).toBeUndefined();
     expect(addMessageCalls).toBe(1);
+    // Recorded into the reacted message's conversation, never a fresh one.
+    expect(recordInboundCalls).toEqual([{ conversationId: "conv-target" }]);
+  });
+
+  test("a reaction on a message that is not stored is dropped without minting", async () => {
+    storedTarget = null;
+
+    const result = await handleSlackReactionIntercept(
+      buildParams({
+        rawSenderId: MEMBER_USER_ID,
+        trustVerdict: MEMBER_VERDICT,
+      }),
+    );
+
+    expect(result.reaction).toBe("dropped_unknown_target");
+    expect(recordInboundCalls.length).toBe(0);
+    expect(addMessageCalls).toBe(0);
+  });
+
+  test("a guardian card reaction still applies when the card is not a stored message", async () => {
+    storedTarget = null;
+    guardianReplyResponse = { accepted: true, canonicalRouter: "applied" };
+
+    const result = await handleSlackReactionIntercept(
+      buildParams({
+        rawSenderId: GUARDIAN_USER_ID,
+        trustVerdict: GUARDIAN_VERDICT,
+      }),
+    );
+
+    expect(result).toEqual(guardianReplyResponse);
+    expect(recordInboundCalls.length).toBe(0);
   });
 
   test("unknown verdict is dropped before any write", async () => {

--- a/assistant/src/runtime/routes/inbound-stages/reaction-intercept.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/reaction-intercept.test.ts
@@ -71,6 +71,7 @@ mock.module("../../../contacts/contact-store.js", () => ({
 
 let recordInboundCalls: Array<{ conversationId?: string }> = [];
 let recordedEvent: { eventId: string; conversationId: string } | null = null;
+let outboundTargetConversationId: string | null = null;
 let storedTarget: { messageId: string; conversationId: string } | null = null;
 mock.module("../../../persistence/delivery-crud.js", () => ({
   recordInbound: (
@@ -88,6 +89,7 @@ mock.module("../../../persistence/delivery-crud.js", () => ({
     };
   },
   findMessageBySourceId: () => storedTarget,
+  findSlackConversationByMessageTs: () => outboundTargetConversationId,
   findInboundEvent: () => recordedEvent,
   clearPayload: () => {},
   linkMessage: () => {},
@@ -214,6 +216,7 @@ describe("reaction intercept consumes the stamped verdict directly", () => {
     contactLookups = 0;
     recordInboundCalls = [];
     recordedEvent = null;
+    outboundTargetConversationId = null;
     addMessageCalls = 0;
     guardianReplyCalls = [];
     guardianReplyResponse = undefined;
@@ -256,6 +259,25 @@ describe("reaction intercept consumes the stamped verdict directly", () => {
     expect(addMessageCalls).toBe(1);
     // Recorded into the reacted message's conversation, never a fresh one.
     expect(recordInboundCalls).toEqual([{ conversationId: "conv-target" }]);
+  });
+
+  test("a reaction on the assistant's own post resolves through slackMeta", async () => {
+    // Outbound posts open no inbound event, so the ts is only on the row.
+    storedTarget = null;
+    outboundTargetConversationId = "conv-assistant-post";
+
+    const result = await handleSlackReactionIntercept(
+      buildParams({
+        rawSenderId: MEMBER_USER_ID,
+        trustVerdict: MEMBER_VERDICT,
+      }),
+    );
+
+    expect(recordInboundCalls).toEqual([
+      { conversationId: "conv-assistant-post" },
+    ]);
+    expect(addMessageCalls).toBe(1);
+    expect(result).toMatchObject({ accepted: true, duplicate: false });
   });
 
   test("a reaction on a message that is not stored is dropped without minting", async () => {

--- a/assistant/src/runtime/routes/inbound-stages/reaction-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/reaction-intercept.ts
@@ -268,10 +268,11 @@ export async function handleSlackReactionIntercept(
     sourceChannel,
     conversationExternalId,
     externalMessageId,
-    {
-      sourceMessageId: reactedMessageTs,
-      conversationId: targetConversationId,
-    },
+    // No `sourceMessageId`: that column names the provider id of the event's
+    // own message, and a reaction is not one. Claiming the reacted message's
+    // id here would put two linked rows on that id, leaving a later edit or
+    // delete of it free to resolve to the reaction instead.
+    { conversationId: targetConversationId },
   );
 
   // Record the reaction as an inline transcript signal.

--- a/assistant/src/runtime/routes/inbound-stages/reaction-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/reaction-intercept.ts
@@ -165,12 +165,6 @@ export async function handleSlackReactionIntercept(
     typeof sourceMetadata?.messageId === "string"
       ? sourceMetadata.messageId
       : undefined;
-  const threadTs =
-    typeof sourceMetadata?.threadId === "string" &&
-    sourceMetadata.threadId.trim().length > 0
-      ? sourceMetadata.threadId.trim()
-      : undefined;
-
   // Respect disk-pressure cleanup so reactions don't bypass storage
   // protection. Guardians resolve to `allow-cleanup-mode` (not `block`), so a
   // guardian's approval-by-reaction still flows. Blocked silently and before
@@ -283,7 +277,6 @@ export async function handleSlackReactionIntercept(
       eventId: result.eventId,
       callbackData,
       actorDisplayName,
-      threadTs,
       reactedMessageTs,
       duplicate: result.duplicate,
     });
@@ -317,7 +310,6 @@ async function persistSlackReactionAsMessage(params: {
   eventId: string;
   callbackData: string;
   actorDisplayName?: string;
-  threadTs?: string;
   reactedMessageTs: string;
   duplicate: boolean;
 }): Promise<void> {
@@ -342,7 +334,11 @@ async function persistSlackReactionAsMessage(params: {
     channelId: params.conversationExternalId,
     channelTs: params.reactedMessageTs,
     eventKind: "reaction",
-    ...(params.threadTs ? { threadTs: params.threadTs } : {}),
+    // No `threadTs`: Slack sends none on a reaction, so the gateway's thread
+    // id here is the reacted message's own ts. It equals `channelTs`, which
+    // every reader treats as "not in a thread" anyway, and storing it makes
+    // the row false evidence that a thread belongs to this conversation
+    // (`legacySlackConversationHasThreadEvidence`).
     ...(params.actorDisplayName
       ? { displayName: params.actorDisplayName }
       : {}),

--- a/assistant/src/runtime/routes/inbound-stages/reaction-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/reaction-intercept.ts
@@ -9,7 +9,8 @@
  *     or an access-request notification (LUM-2489),
  *   - a stranger's reaction creates no conversation, binding, or transcript
  *     row — it is dropped as channel noise,
- *   - a known contact's reaction is recorded as an inline transcript signal,
+ *   - a known contact's reaction is recorded as an inline transcript signal in
+ *     the conversation of the message it was attached to,
  *   - a guardian's reaction on an approval card is routed through the guardian
  *     decision pipeline (the same path as buttons and text replies).
  *
@@ -28,12 +29,11 @@ import {
 } from "../../../messaging/providers/slack/message-metadata.js";
 import { addMessage } from "../../../persistence/conversation-crud.js";
 import {
-  clearPayload,
+  findMessageBySourceId,
   linkMessage,
   recordInbound,
 } from "../../../persistence/delivery-crud.js";
 import { markProcessed } from "../../../persistence/delivery-status.js";
-import { upsertBinding } from "../../../persistence/external-conversation-store.js";
 import { getLogger } from "../../../util/logger.js";
 import type { ApprovalConversationGenerator } from "../../http-types.js";
 import {
@@ -105,8 +105,6 @@ export interface ReactionInterceptParams {
   actorUsername: string | undefined;
   replyCallbackUrl: string | undefined;
   sourceMetadata: SourceMetadata | undefined;
-  /** Slack channel display name, for the conversation binding. */
-  slackChannelName: string | null;
   approvalConversationGenerator: ApprovalConversationGenerator | undefined;
 }
 
@@ -130,7 +128,6 @@ export async function handleSlackReactionIntercept(
     actorUsername,
     replyCallbackUrl,
     sourceMetadata,
-    slackChannelName,
     approvalConversationGenerator,
   } = params;
 
@@ -171,21 +168,11 @@ export async function handleSlackReactionIntercept(
       ? sourceMetadata.threadId.trim()
       : undefined;
 
-  // Record for dedup + conversation resolution (known contacts only — strangers
-  // were dropped above).
-  const result = recordInbound(
-    sourceChannel,
-    conversationExternalId,
-    externalMessageId,
-    {
-      sourceMessageId: reactedMessageTs,
-      sourceThreadId: threadTs,
-    },
-  );
-
   // Respect disk-pressure cleanup so reactions don't bypass storage
   // protection. Guardians resolve to `allow-cleanup-mode` (not `block`), so a
-  // guardian's approval-by-reaction still flows.
+  // guardian's approval-by-reaction still flows. Blocked silently and before
+  // any write: a reaction is a passive signal, so the message pipeline's
+  // "storage is low, try again" notice is meaningless for an emoji.
   const diskPressure = classifyDiskPressureTurnPolicy(getDiskPressureStatus(), {
     sourceChannel,
     sourceInterface,
@@ -195,44 +182,23 @@ export async function handleSlackReactionIntercept(
     },
   });
   if (diskPressure.action === "block") {
-    // Block silently: a reaction is a passive signal, so the message
-    // pipeline's "storage is low, try again" notice is meaningless for an
-    // emoji — there is nothing to retry. Mark the event processed and stop
-    // before binding/persistence.
-    if (!result.duplicate) {
-      clearPayload(result.eventId);
-      markProcessed(result.eventId);
-    }
     return {
       accepted: true,
-      duplicate: result.duplicate,
-      eventId: result.eventId,
+      reaction: "dropped_disk_pressure",
       diskPressure: "blocked",
       reason: diskPressure.reason,
     };
   }
 
-  // Maintain the conversation binding, matching the message pipeline.
-  upsertBinding({
-    conversationId: result.conversationId,
-    sourceChannel,
-    externalChatId: conversationExternalId,
-    externalChatName: slackChannelName,
-    externalThreadId: threadTs ?? null,
-    externalUserId: canonicalSenderId ?? rawSenderId ?? null,
-    displayName: actorDisplayName ?? null,
-    username: actorUsername ?? null,
-  });
-
-  // Guardian approval-by-reaction → guardian decision pipeline, exactly like
-  // buttons and text replies. Only `reaction:` (added) expresses intent;
+  // Guardian approval-by-reaction runs before the reacted message is resolved:
+  // an approval card is addressed by its own message id and is not always a
+  // stored message. Only `reaction:` (added) expresses intent;
   // `reaction_removed:` never does. `handleGuardianReplyIntercept` self-gates
-  // on `trustClass === "guardian"`, so a contact's reaction returns no response
-  // and falls through to persistence.
-  const isReactionAdded = callbackData.startsWith("reaction:");
-  if (isReactionAdded && replyCallbackUrl && !result.duplicate) {
+  // on `trustClass === "guardian"`, so a contact's reaction returns no
+  // response and falls through to persistence.
+  if (callbackData.startsWith("reaction:") && replyCallbackUrl) {
     const reactionIntercept = await handleGuardianReplyIntercept({
-      isDuplicate: result.duplicate,
+      isDuplicate: false,
       trimmedContent: "",
       hasCallbackData: true,
       callbackData,
@@ -241,35 +207,48 @@ export async function handleSlackReactionIntercept(
       canonicalSenderId,
       sourceChannel,
       conversationExternalId,
-      conversationId: result.conversationId,
-      eventId: result.eventId,
       replyCallbackUrl,
       trustClass: trustCtx.trustClass,
       guardianPrincipalId: trustCtx.guardianPrincipalId,
       approvalConversationGenerator,
     });
-    // Consumed as a guardian decision (applied, or a surfaced failure delivered
-    // as an ephemeral reply). Short-circuit so we do not also persist a
-    // transcript row.
     if (reactionIntercept.response) {
       return reactionIntercept.response;
     }
   }
 
-  // Record the reaction as an inline transcript signal. Requires the reacted
-  // message ts to anchor the rendering.
-  if (!reactedMessageTs) {
+  // The reaction belongs to the conversation of the message it was attached
+  // to. Slack sends no `thread_ts` on a reaction, so resolving a conversation
+  // from the reaction's own address keys one on the reacted message instead of
+  // finding the one that message lives in, minting an orphan per reaction.
+  // A message the assistant never stored has nothing to annotate, so the
+  // reaction is dropped rather than given a conversation of its own.
+  const target = reactedMessageTs
+    ? findMessageBySourceId(
+        sourceChannel,
+        conversationExternalId,
+        reactedMessageTs,
+      )
+    : null;
+  if (!target || !reactedMessageTs) {
     log.debug(
-      { conversationId: result.conversationId, eventId: result.eventId },
-      "Skipping reaction persistence: missing sourceMetadata.messageId",
+      { sourceChannel, conversationExternalId, reactedMessageTs },
+      "Dropping reaction: reacted message is not stored",
     );
-    return {
-      accepted: result.accepted,
-      duplicate: result.duplicate,
-      eventId: result.eventId,
-    };
+    return { accepted: true, reaction: "dropped_unknown_target" };
   }
 
+  const result = recordInbound(
+    sourceChannel,
+    conversationExternalId,
+    externalMessageId,
+    {
+      sourceMessageId: reactedMessageTs,
+      conversationId: target.conversationId,
+    },
+  );
+
+  // Record the reaction as an inline transcript signal.
   try {
     await persistSlackReactionAsMessage({
       conversationId: result.conversationId,

--- a/assistant/src/runtime/routes/inbound-stages/reaction-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/reaction-intercept.ts
@@ -10,7 +10,8 @@
  *   - a stranger's reaction creates no conversation, binding, or transcript
  *     row — it is dropped as channel noise,
  *   - a known contact's reaction is recorded as an inline transcript signal in
- *     the conversation of the message it was attached to,
+ *     the conversation of the message it was attached to, whether that message
+ *     arrived from the channel or the assistant posted it,
  *   - a guardian's reaction on an approval card is routed through the guardian
  *     decision pipeline (the same path as buttons and text replies).
  *
@@ -31,6 +32,7 @@ import { addMessage } from "../../../persistence/conversation-crud.js";
 import {
   findInboundEvent,
   findMessageBySourceId,
+  findSlackConversationByMessageTs,
   linkMessage,
   recordInbound,
 } from "../../../persistence/delivery-crud.js";
@@ -240,14 +242,21 @@ export async function handleSlackReactionIntercept(
   // finding the one that message lives in, minting an orphan per reaction.
   // A message the assistant never stored has nothing to annotate, so the
   // reaction is dropped rather than given a conversation of its own.
-  const target = reactedMessageTs
-    ? findMessageBySourceId(
+  // Inbound messages carry their provider id on the event that delivered
+  // them. The assistant's own posts open no inbound event, so a reaction on
+  // one is resolved through the `slackMeta` those rows carry.
+  const targetConversationId = reactedMessageTs
+    ? (findMessageBySourceId(
         sourceChannel,
         conversationExternalId,
         reactedMessageTs,
-      )
+      )?.conversationId ??
+      findSlackConversationByMessageTs(
+        conversationExternalId,
+        reactedMessageTs,
+      ))
     : null;
-  if (!target || !reactedMessageTs) {
+  if (!targetConversationId || !reactedMessageTs) {
     log.debug(
       { sourceChannel, conversationExternalId, reactedMessageTs },
       "Dropping reaction: reacted message is not stored",
@@ -261,7 +270,7 @@ export async function handleSlackReactionIntercept(
     externalMessageId,
     {
       sourceMessageId: reactedMessageTs,
-      conversationId: target.conversationId,
+      conversationId: targetConversationId,
     },
   );
 

--- a/assistant/src/runtime/routes/inbound-stages/reaction-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/reaction-intercept.ts
@@ -29,6 +29,7 @@ import {
 } from "../../../messaging/providers/slack/message-metadata.js";
 import { addMessage } from "../../../persistence/conversation-crud.js";
 import {
+  findInboundEvent,
   findMessageBySourceId,
   linkMessage,
   recordInbound,
@@ -187,6 +188,22 @@ export async function handleSlackReactionIntercept(
       reaction: "dropped_disk_pressure",
       diskPressure: "blocked",
       reason: diskPressure.reason,
+    };
+  }
+
+  // A redelivery is answered before anything acts on it. Recording the event
+  // is what dedups a reaction, and that happens after the guardian rail, so
+  // without this probe the same emoji could drive a decision twice.
+  const alreadyRecorded = findInboundEvent(
+    sourceChannel,
+    conversationExternalId,
+    externalMessageId,
+  );
+  if (alreadyRecorded) {
+    return {
+      accepted: true,
+      duplicate: true,
+      eventId: alreadyRecorded.eventId,
     };
   }
 


### PR DESCRIPTION
Fixes LUM-3330

## TL;DR

A Slack reaction now lands in the conversation of the message it was attached to, and is dropped when that message was never stored. It used to create a conversation of its own: one orphan per reacted message, each holding a single "[reaction]" row and a permanent `Generating title...` in the sidebar.

## What was there

Slack's reaction payload carries no `thread_ts`. It carries `item.ts`, the timestamp of the message that was reacted to, and the gateway forwards that as the thread id.

The daemon then treated the reaction like any other inbound: `recordInbound` resolved a conversation from the reaction's own address, which for Slack is `slack:<chat>:thread:<item.ts>`, and created one when nothing matched. That address only matches an existing conversation when the reacted message happens to be a thread root. React to a reply, or to one of the assistant's own replies, and the reaction minted a conversation for itself.

Those conversations never run an agent turn, so neither title hook ever fires and they sit on the placeholder forever. That is what the sidebar was showing.

## What this does

- The reaction resolves the message it annotates with `findMessageBySourceId`, which already maps `(channel, chat, provider message id)` to the stored row and its conversation. That lookup already existed for edit and delete propagation.
- An assistant post opens no inbound event, so that lookup cannot see one. A reaction on something the assistant posted falls back to reading the `slackMeta.channelTs` its row already carries, bounded to conversations on the same Slack channel and to the most recent 400 rows among them. No new table, no new index, no migration.
- `recordInbound` accepts the conversation to record against instead of resolving one from the address. Same function, same dedup, one option.
- A reaction on a message the assistant has never stored is acked and dropped. There is nothing to annotate, and inventing a conversation for it is the bug.

## Why this is safe

- Dedup is unchanged: still the `(source_channel, external_chat_id, external_message_id)` triple, still `recordInbound`.
- The stranger drop (LUM-2489) is unchanged and still happens before any write.
- The guardian rail is unchanged, and now runs before the message lookup. An approval card is addressed by its own message id through the delivery record, and is not always a stored message, so approval-by-reaction must not depend on resolving one. `conversationId` becomes optional on that path; the router only reads it on the text and NL paths, which a reaction never takes.
- Reactions still never run an agent turn.

## Before and after

| Scenario | Before | After |
| --- | --- | --- |
| Reaction on a stored thread reply | new orphan conversation, `Generating title...` | lands in that thread's conversation |
| Reaction on a stored top-level message | correct conversation | unchanged |
| Reaction on the assistant's own reply or proactive post | new orphan conversation | lands in that conversation |
| Reaction on a message the assistant never saw | new orphan conversation | dropped, nothing created |
| Guardian reaction on an approval card | decision applied | unchanged |
| Stranger's reaction | dropped | unchanged |
| Reaction during disk pressure | event row opened, then marked processed | dropped before any write |

## Three behaviour changes worth calling out

1. **A reaction on a message the assistant has no record of is dropped rather than stored.** Previously it was stored, in a conversation invented for it. Nobody could reach that conversation, and each one added a row to the sidebar.
2. **Reactions no longer write `external_conversation_bindings`.** The binding names the conversation's counterparty, and a reaction was overwriting it with whoever reacted last, along with the reacted message's ts as the thread id. Under this change the reaction has no conversation of its own to bind, and the target conversation's binding is already correct.
3. **A reaction event no longer sets `source_message_id`.** That column names the provider id of the event's own message, and a reaction is not one. Claiming the reacted message's id put two linked rows on a single id, so a later edit or delete of that message could resolve to the reaction instead. The collision predates this PR; the fix belongs with it.

## Verification

- `reaction-persistence.test.ts`: a reaction on an unstored message creates zero conversations, zero inbound events and zero messages; a reaction on a stored message adds no conversation and its row lands in the target's conversation. Existing persistence, dedup, ordering and access-control cases keep their assertions and seed the reacted message.
- `reaction-intercept.test.ts`: the recorded conversation is the target's; a reaction on an assistant post resolves through `slackMeta`; an unresolved target records nothing; a redelivered reaction never reaches the guardian rail twice; a guardian card reaction still applies with no stored target.
- A reaction leaves exactly one linked event claiming the reacted message's provider id.
- `channel-inbound-disk-pressure.test.ts`: a blocked reaction now writes nothing at all.
- Typecheck, eslint and prettier clean. Local test runs are blocked in this environment; CI runs the suite.

## Not in this PR

- An index over outbound provider message ids. It would make the assistant-post lookup exact rather than bounded, and it needs schema. The bounded read closes the gap without any, and the index stays a strictly additive change if the drop rate ever shows up.
- Edits and deletes, which have the same "annotation on a message" shape and are tracked under LUM-3329.
- The remaining lanes that can create a conversation without running a turn (floor deny, disk-pressure block, stale button). They are rarer than this one and are tracked in LUM-2872.
