### PR TITLE
fix(web): show a sealed envelope on unread notifications (LUM-3336)

### DIFF
--- a/clients/web/src/domains/home/components/notifications-bell-detail.tsx
+++ b/clients/web/src/domains/home/components/notifications-bell-detail.tsx
@@ -1,4 +1,4 @@
-import { ChevronLeft, Mail, MailOpen, RotateCcw, Trash2 } from "lucide-react";
+import { ChevronLeft } from "lucide-react";
 
 import { useTranslation } from "@/i18n";
 import {
@@ -10,6 +10,7 @@ import { Button, Typography } from "@vellumai/design-library";
 
 import { HomeGenericDetail } from "../detail-panel/home-generic-detail";
 import { HomeToolPermissionCard } from "../detail-panel/home-tool-permission-card";
+import { FeedItemStatusActions } from "../feed-item-status-actions";
 import type { FeedItemEntityLink } from "../hooks/use-feed-item-entity-links";
 import { resolveFeedItemTitle } from "../utils";
 
@@ -93,11 +94,6 @@ export function NotificationsBellDetail({
 }: NotificationsBellDetailProps) {
   const { t } = useTranslation("home");
   const conversationId = item.conversationId ?? null;
-  const isUnread = item.status === "new";
-  const readToggleLabel = isUnread
-    ? t("actions.markAsRead")
-    : t("actions.markAsUnread");
-  const isDismissed = item.status === "dismissed";
   const actions = item.actions ?? [];
 
   // Same rule as the Activity page's detail panel, plus a pending case the
@@ -153,30 +149,11 @@ export function NotificationsBellDetail({
           header onto a second line.
         */}
         <div className="flex shrink-0 items-center gap-[var(--app-spacing-xs)]">
-          <Button
-            variant="ghost"
-            iconOnly={isUnread ? <MailOpen /> : <Mail />}
-            onClick={() => onUpdateStatus(item.id, isUnread ? "seen" : "new")}
-            aria-label={readToggleLabel}
-            tooltip={readToggleLabel}
+          <FeedItemStatusActions
+            item={item}
+            onUpdateStatus={onUpdateStatus}
+            onDismiss={onDismiss}
           />
-          {isDismissed ? (
-            <Button
-              variant="ghost"
-              iconOnly={<RotateCcw />}
-              onClick={() => onUpdateStatus(item.id, "seen")}
-              aria-label={t("actions.restore")}
-              tooltip={t("actions.restore")}
-            />
-          ) : (
-            <Button
-              variant="ghost"
-              iconOnly={<Trash2 />}
-              onClick={() => onDismiss(item.id)}
-              aria-label={t("actions.dismiss")}
-              tooltip={t("actions.dismiss")}
-            />
-          )}
         </div>
       </div>
 

--- a/clients/web/src/domains/home/detail-panel/home-detail-panel.tsx
+++ b/clients/web/src/domains/home/detail-panel/home-detail-panel.tsx
@@ -1,12 +1,14 @@
-import { ArrowLeft, Mail, MailOpen, RotateCcw, Trash2 } from "lucide-react";
+import { ArrowLeft } from "lucide-react";
 
 import { DetailShell } from "@/components/detail-shell";
 import { useTranslation } from "@/i18n";
 import { formatFullLocalDate, formatRelativeDate } from "@/utils/format-date";
 import type { FeedItem, FeedItemStatus } from "@vellumai/assistant-api";
 import { Button, Tag, Typography } from "@vellumai/design-library";
+import { FeedItemStatusActions } from "../feed-item-status-actions";
 import { resolveCategoryStyle } from "../home-feed-filter-bar";
 import type { FeedItemEntityLink } from "../hooks/use-feed-item-entity-links";
+import { buildReadToggle } from "../read-toggle";
 import { HomeGenericDetail } from "./home-generic-detail";
 import { HomeToolPermissionCard } from "./home-tool-permission-card";
 
@@ -57,9 +59,8 @@ export function HomeDetailPanel({
       : t("homeDetailPanel.untitled");
   const CategoryIcon = categoryStyle.icon;
   const isUnread = item.status === "new";
-  const readToggleLabel = isUnread
-    ? t("actions.markAsRead")
-    : t("actions.markAsUnread");
+  const { label: readToggleLabel, nextStatus: readToggleStatus } =
+    buildReadToggle(isUnread, t);
   const isDismissed = item.status === "dismissed";
   const hasValidConversation =
     !!item.conversationId && validConversationIds.has(item.conversationId);
@@ -85,30 +86,11 @@ export function HomeDetailPanel({
           </Typography>
 
           <div className="ml-auto flex items-center gap-2">
-            <Button
-              variant="ghost"
-              iconOnly={isUnread ? <MailOpen /> : <Mail />}
-              onClick={() => onUpdateStatus(item.id, isUnread ? "seen" : "new")}
-              aria-label={readToggleLabel}
-              tooltip={readToggleLabel}
+            <FeedItemStatusActions
+              item={item}
+              onUpdateStatus={onUpdateStatus}
+              onDismiss={onDismiss}
             />
-            {isDismissed ? (
-              <Button
-                variant="ghost"
-                iconOnly={<RotateCcw />}
-                onClick={() => onUpdateStatus(item.id, "seen")}
-                aria-label={t("actions.restore")}
-                tooltip={t("actions.restore")}
-              />
-            ) : (
-              <Button
-                variant="ghost"
-                iconOnly={<Trash2 />}
-                onClick={() => onDismiss(item.id)}
-                aria-label={t("actions.dismiss")}
-                tooltip={t("actions.dismiss")}
-              />
-            )}
           </div>
         </div>
 
@@ -233,9 +215,7 @@ export function HomeDetailPanel({
               <>
                 <Button
                   variant="outlined"
-                  onClick={() =>
-                    onUpdateStatus(item.id, isUnread ? "seen" : "new")
-                  }
+                  onClick={() => onUpdateStatus(item.id, readToggleStatus)}
                 >
                   {readToggleLabel}
                 </Button>

--- a/clients/web/src/domains/home/feed-item-status-actions.tsx
+++ b/clients/web/src/domains/home/feed-item-status-actions.tsx
@@ -1,0 +1,63 @@
+import { RotateCcw, Trash2 } from "lucide-react";
+
+import { useTranslation } from "@/i18n";
+import type { FeedItem, FeedItemStatus } from "@vellumai/assistant-api";
+import { Button } from "@vellumai/design-library";
+
+import { buildReadToggle } from "./read-toggle";
+
+export interface FeedItemStatusActionsProps {
+  item: FeedItem;
+  onUpdateStatus: (itemId: string, status: FeedItemStatus) => void;
+  onDismiss: (itemId: string) => void;
+}
+
+/**
+ * The status controls a notification's detail header carries: the read/unread
+ * toggle, then dismiss (or restore, for an item already dismissed). Rendered
+ * by the Activity page's detail panel and by the notification bell's detail,
+ * which drew the same pair of buttons from two copies of this markup.
+ *
+ * A fragment rather than a row: the two headers seat the pair differently
+ * (the bell holds its width opposite a back control, the panel pushes it to
+ * the trailing edge of a nav bar), so the container stays with each of them
+ * and only the controls are shared.
+ */
+export function FeedItemStatusActions({
+  item,
+  onUpdateStatus,
+  onDismiss,
+}: FeedItemStatusActionsProps) {
+  const { t } = useTranslation("home");
+  const readToggle = buildReadToggle(item.status === "new", t);
+  const ReadToggleIcon = readToggle.icon;
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        iconOnly={<ReadToggleIcon />}
+        onClick={() => onUpdateStatus(item.id, readToggle.nextStatus)}
+        aria-label={readToggle.label}
+        tooltip={readToggle.label}
+      />
+      {item.status === "dismissed" ? (
+        <Button
+          variant="ghost"
+          iconOnly={<RotateCcw />}
+          onClick={() => onUpdateStatus(item.id, "seen")}
+          aria-label={t("actions.restore")}
+          tooltip={t("actions.restore")}
+        />
+      ) : (
+        <Button
+          variant="ghost"
+          iconOnly={<Trash2 />}
+          onClick={() => onDismiss(item.id)}
+          aria-label={t("actions.dismiss")}
+          tooltip={t("actions.dismiss")}
+        />
+      )}
+    </>
+  );
+}

--- a/clients/web/src/domains/home/feed-item-status-actions.tsx
+++ b/clients/web/src/domains/home/feed-item-status-actions.tsx
@@ -15,8 +15,7 @@ export interface FeedItemStatusActionsProps {
 /**
  * The status controls a notification's detail header carries: the read/unread
  * toggle, then dismiss (or restore, for an item already dismissed). Rendered
- * by the Activity page's detail panel and by the notification bell's detail,
- * which drew the same pair of buttons from two copies of this markup.
+ * by the Activity page's detail panel and by the notification bell's detail.
  *
  * A fragment rather than a row: the two headers seat the pair differently
  * (the bell holds its width opposite a back control, the panel pushes it to

--- a/clients/web/src/domains/home/home-recap-actions.tsx
+++ b/clients/web/src/domains/home/home-recap-actions.tsx
@@ -1,7 +1,5 @@
 import {
   Ellipsis,
-  Mail,
-  MailOpen,
   MessageSquare,
   RotateCcw,
   Trash2,
@@ -14,6 +12,8 @@ import type { SwipeAction } from "@/hooks/use-swipe-to-reveal";
 import type { TFunction } from "@/i18n";
 import type { FeedItem, FeedItemStatus } from "@vellumai/assistant-api";
 import { ActionMenu, cn, Tooltip } from "@vellumai/design-library";
+
+import { buildReadToggle } from "./read-toggle";
 
 /**
  * The commands a recap row offers, in one list that every surface reaching them
@@ -89,11 +89,12 @@ export function buildRecapActions({
   const actions: RecapAction[] = [];
 
   if (onToggleRead) {
+    const readToggle = buildReadToggle(isUnread, t);
     actions.push({
       id: "toggle-read",
-      label: isUnread ? t("actions.markAsRead") : t("actions.markAsUnread"),
-      icon: isUnread ? MailOpen : Mail,
-      onSelect: () => onToggleRead(item.id, isUnread ? "seen" : "new"),
+      label: readToggle.label,
+      icon: readToggle.icon,
+      onSelect: () => onToggleRead(item.id, readToggle.nextStatus),
       swipeEdge: "trailing",
     });
   }

--- a/clients/web/src/domains/home/read-toggle.test.ts
+++ b/clients/web/src/domains/home/read-toggle.test.ts
@@ -1,11 +1,9 @@
 /**
  * Tests for `buildReadToggle`.
  *
- * The glyph names the item's current state, so these assert the pairing that
- * was inverted (LUM-3336): an unread notification showed an opened envelope
- * beside its unread dot, and a read one showed a sealed envelope. Comparing
- * against the icon components themselves rather than rendering them keeps the
- * check on the mapping, which is the thing that flipped.
+ * The glyph names the item's current state: a sealed envelope for unread, an
+ * opened one for read. Comparing against the icon components themselves rather
+ * than rendering them keeps the check on that mapping.
  */
 
 import { describe, expect, test } from "bun:test";

--- a/clients/web/src/domains/home/read-toggle.test.ts
+++ b/clients/web/src/domains/home/read-toggle.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Tests for `buildReadToggle`.
+ *
+ * The glyph names the item's current state, so these assert the pairing that
+ * was inverted (LUM-3336): an unread notification showed an opened envelope
+ * beside its unread dot, and a read one showed a sealed envelope. Comparing
+ * against the icon components themselves rather than rendering them keeps the
+ * check on the mapping, which is the thing that flipped.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { Mail, MailOpen } from "lucide-react";
+
+import { fixedT } from "@/i18n";
+
+import { buildReadToggle } from "./read-toggle";
+
+// The builder takes a namespace-bound `t`, the same thing
+// `useTranslation("home")` hands its component callers.
+const t = fixedT("home");
+
+describe("buildReadToggle", () => {
+  test("an unread item shows a sealed envelope and offers to mark it read", () => {
+    const toggle = buildReadToggle(true, t);
+
+    expect(toggle.icon).toBe(Mail);
+    expect(toggle.icon).not.toBe(MailOpen);
+    expect(toggle.label).toBe("Mark as read");
+    expect(toggle.nextStatus).toBe("seen");
+  });
+
+  test("a read item shows an opened envelope and offers to mark it unread", () => {
+    const toggle = buildReadToggle(false, t);
+
+    expect(toggle.icon).toBe(MailOpen);
+    expect(toggle.icon).not.toBe(Mail);
+    expect(toggle.label).toBe("Mark as unread");
+    expect(toggle.nextStatus).toBe("new");
+  });
+});

--- a/clients/web/src/domains/home/read-toggle.ts
+++ b/clients/web/src/domains/home/read-toggle.ts
@@ -1,0 +1,36 @@
+import { Mail, MailOpen, type LucideIcon } from "lucide-react";
+
+import type { TFunction } from "@/i18n";
+import type { FeedItemStatus } from "@vellumai/assistant-api";
+
+/**
+ * The read/unread toggle a notification offers, in one definition every
+ * surface renders from: the recap row's action list (its inline buttons,
+ * swipe, and long-press sheet), the Activity page's detail panel, and the
+ * notification bell's detail header.
+ */
+export interface ReadToggle {
+  /**
+   * Names the item's *current* state, not the command: a sealed envelope for
+   * unread, an opened one for read. It sits beside the unread dot and the
+   * unread emphasis on the same row, so a glyph naming the command instead
+   * would put an open envelope on every item the rest of the row calls
+   * unread.
+   */
+  icon: LucideIcon;
+  /** Names the command, which is the opposite of the state the glyph shows. */
+  label: string;
+  /** The status the command writes. */
+  nextStatus: FeedItemStatus;
+}
+
+export function buildReadToggle(
+  isUnread: boolean,
+  t: TFunction<"home">,
+): ReadToggle {
+  return {
+    icon: isUnread ? Mail : MailOpen,
+    label: isUnread ? t("actions.markAsRead") : t("actions.markAsUnread"),
+    nextStatus: isUnread ? "seen" : "new",
+  };
+}


### PR DESCRIPTION
## TL;DR

Notification read/unread envelopes were inverted on every surface: an unread notification showed an **opened** envelope next to its unread dot, a read one showed a **sealed** envelope. The glyph now names the item's state, and the one place that decides it is shared by all three surfaces that offer the toggle.

Fixes LUM-3336

## What the user saw

Reported from the iOS app, but the surface is the shared web client, so the same inversion showed on desktop and web. In the reporter's screenshot an unread item (amber dot, bold title) carried an opened envelope labelled "Mark as read"; after opening it, the same row showed a sealed envelope.

## Before / after

| Notification state | Before | After |
| --- | --- | --- |
| Unread (has the amber dot) | Opened envelope | Sealed envelope |
| Read | Sealed envelope | Opened envelope |
| Tooltip / accessible name | "Mark as read" / "Mark as unread" | unchanged |
| What clicking it does | Toggles read state | unchanged |

Only the glyph changes. Labels, tooltips, accessible names, and the status each control writes are untouched.

## Root cause

The glyph came from three hand-copied ternaries, one per surface, and each named the *command* (open the envelope to mark it read) rather than the item's *state*. Beside an unread dot and unread emphasis on the same row, that reads as the opposite of what the row says. `home-recap-row.stories.tsx` already documented the intended pairing ("Mail becomes MailOpen" on the read story), so all three copies had drifted from it together.

`buildReadToggle` (`read-toggle.ts`) now owns the glyph, the label, and the status the control writes, for:

- the recap row's inline buttons, its swipe action, and its long-press sheet (via `buildRecapActions`)
- the Activity page's detail panel
- the notification bell's detail header

## Consolidation

The two notification detail headers drew an identical pair of status buttons (read toggle, then dismiss or restore) from two copies of the same markup, one of which said in a comment that it was copying the other. Both now render `FeedItemStatusActions`. It returns a fragment rather than a row, so each header keeps its own container and spacing while the controls live in one place.

## Why it is safe

- Presentation only. No state shape, wire field, or mutation changed: the toggle writes `seen` from unread and `new` from read exactly as before.
- Verified live in Storybook against all three surfaces: the unread recap row renders `lucide-mail` under "Mark as read", the read row renders `lucide-mail-open` under "Mark as unread", and both detail headers render the shared pair with the same labels as before.
- `read-toggle.test.ts` pins the pairing that flipped, comparing against the icon components themselves so a re-inversion fails the test rather than passing a presence check.
- Typecheck and lint are clean on the touched files. Test suites run in CI (local runs are blocked in this environment).

## Checked for the same mistake elsewhere

- No other surface picks a read/unread glyph: after this change, one expression in the codebase chooses between the two envelopes.
- The native shells (iOS, Android, macOS, Windows) have no read/unread iconography of their own, so the web fix covers the reported iOS case.
- The unread dots (bell badge, recap row, sidebar sections) and the bulk `markAllRead` / `clearAll` payloads were checked and are correct.
- The conversation actions menu uses a different pair (`CircleCheck` for "Mark as read", `Circle` for "Mark as unread"). Those are text-labelled menu items where the icon reads as the command, and no unread dot sits beside them, so they are left alone.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40882" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->