### PR TITLE
feat(companion): drop the call timer from the Talk state

### DIFF
--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -20,12 +20,11 @@ mock.module("electron-store", () => ({
 const {
   growthFor,
   clampCanvasOrigin,
-  callOnStart,
   callOnUpdate,
   shouldShowCompanionSurface,
 } = await import("./companion-window");
 
-/** A session as the mirror publishes one, before main stamps its clock. */
+/** A session as the mirror publishes one, which is what main then holds. */
 const START = {
   phase: "listening",
   label: "Listening",
@@ -180,19 +179,8 @@ describe("clampCanvasOrigin", () => {
 });
 
 describe("the session main holds", () => {
-  test("start stamps the clock", () => {
-    expect(callOnStart(null, START, 1_000).startedAt).toBe(1_000);
-  });
-
-  test("a redundant start updates the session without restarting its clock", () => {
-    const running = callOnStart(null, START, 1_000);
-    const again = callOnStart(running, { ...START, phase: "thinking" }, 9_000);
-    expect(again.startedAt).toBe(1_000);
-    expect(again.phase).toBe("thinking");
-  });
-
   test("update merges content and leaves the fixed fields alone", () => {
-    const running = callOnStart(null, START, 1_000);
+    const running = { ...START };
     const next = callOnUpdate(running, { phase: "speaking", detail: "Reading" });
     expect(next).toEqual({
       ...running,
@@ -208,7 +196,7 @@ describe("the session main holds", () => {
   });
 
   test("carries the pending approval through", () => {
-    const running = callOnStart(null, START, 1_000);
+    const running = { ...START };
     expect(
       callOnUpdate(running, { approvalRequestId: "req-1" })?.approvalRequestId,
     ).toBe("req-1");

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -57,7 +57,7 @@ export const isCompanionSurfaceEnabled = (): boolean =>
  * choice from the tray.
  *
  * The flag is a floor and the tray preference is a veto, so both have to say
- * yes. Exported for its tests, as `callOnStart` is: it is the rule that decides
+ * yes. Exported for its tests, as `callOnUpdate` is: it is the rule that decides
  * whether the most conspicuous window this app has appears at all.
  */
 export const shouldShowCompanionSurface = (
@@ -214,26 +214,6 @@ const currentState = (): CompanionSurfaceState => {
     working: context.working,
   };
 };
-
-/**
- * The session after a `start`, which is not always a new session.
- *
- * A redundant start updates the running call rather than restarting its clock.
- * The mirror re-syncs on mount and the session controller remounts across
- * layout-level route changes while the store persists, so a second start for a
- * call already on screen is expected traffic, and an elapsed timer that jumped
- * back to zero on a route change would be a visible lie about a session that
- * never stopped.
- *
- * Exported for its tests, which is also why it takes `now` rather than reading
- * the clock.
- */
-export const callOnStart = (
-  current: VoiceActivityState | null,
-  start: Omit<VoiceActivityState, "startedAt">,
-  now: number,
-): VoiceActivityState =>
-  current === null ? { ...start, startedAt: now } : { ...current, ...start };
 
 /**
  * The session after an `update`, or `null` when there is nothing to update.
@@ -570,7 +550,12 @@ export const installCompanionWindow = (): void => {
     "vellum:voiceActivity:start",
     z.tuple([voiceActivityStartSchema]),
     ([start]) => {
-      call = callOnStart(call, start, Date.now());
+      // Taken whole, redundant or not. The mirror re-syncs on mount and the
+      // session controller remounts across layout-level route changes while the
+      // store persists, so a second start for a call already on screen is
+      // expected traffic; every field it carries is current, so there is
+      // nothing on the running call worth preserving against it.
+      call = start;
       pushState();
     },
   );

--- a/clients/web/src/components/companion-surface.stories.tsx
+++ b/clients/web/src/components/companion-surface.stories.tsx
@@ -10,8 +10,7 @@ import { composeSvg } from "@/utils/avatar-svg-compositor";
 import type { VoiceActivityState } from "@vellumai/ipc-contract";
 
 /**
- * A session for the demo reel to draw. `startedAt` is restamped on every run,
- * so it is the one field the player overrides.
+ * A session for the demo reel to draw.
  *
  * Listening and unmuted with nothing waiting on a decision: the ordinary middle
  * of a call, which is what the reel is showing.
@@ -25,7 +24,6 @@ const DEMO_CALL: VoiceActivityState = {
   detail: "",
   approvalRequestId: "",
   assistantName: "Ziggy",
-  startedAt: 0,
 };
 
 /**
@@ -203,7 +201,6 @@ export const PendingApproval: Story = {
       label: "Thinking…",
       detail: "Read package.json",
       approvalRequestId: "req-1",
-      startedAt: Date.now() - 14_000,
     },
   },
 };
@@ -222,7 +219,6 @@ export const InCallAssistantTurn: Story = {
       ...DEMO_CALL,
       phase: "thinking",
       label: "Thinking\u2026",
-      startedAt: Date.now() - 9_000,
     },
   },
 };
@@ -235,7 +231,6 @@ export const InCallMuted: Story = {
       ...DEMO_CALL,
       muted: true,
       outputMuted: true,
-      startedAt: Date.now() - 14_000,
     },
   },
 };
@@ -459,7 +454,6 @@ function DemoReelPlayer(args: StoryArgs) {
   // Trails `step`. The backdrop is switched by `step` directly; the surface
   // waits out the lag before catching up, so the two never cut together.
   const [phaseStep, setPhaseStep] = useState(0);
-  const [callStartedAt, setCallStartedAt] = useState<number | undefined>();
 
   // The whole timeline up front, so playback is one timer walking an array
   // rather than two phases with their own bookkeeping. Built once: it is a
@@ -497,9 +491,6 @@ function DemoReelPlayer(args: StoryArgs) {
     }
     const timer = setTimeout(() => {
       setPhaseStep(step);
-      if (timeline[step].phase === "call") {
-        setCallStartedAt(Date.now());
-      }
     }, timeline[step].lag);
     return () => {
       clearTimeout(timer);
@@ -560,13 +551,7 @@ function DemoReelPlayer(args: StoryArgs) {
           {...args}
           phase={phase}
           spotlight={active?.spotlight}
-          // Restamped whenever the call step is entered, so the clock starts
-          // from zero on every run rather than from whenever the page loaded.
-          call={
-            phase === "call" && callStartedAt !== undefined
-              ? { ...DEMO_CALL, startedAt: callStartedAt }
-              : undefined
-          }
+          call={phase === "call" ? DEMO_CALL : undefined}
           // No turns: Type opens on the empty composer, which is the same
           // elongated single line as the states either side of it. Opening onto
           // a card of history would make this the one step that changes the

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -79,7 +79,6 @@ describe("the companion surface's working ring", () => {
           detail: "",
           approvalRequestId: "",
           assistantName: "Ziggy",
-          startedAt: 0,
         }}
       />,
     );
@@ -99,7 +98,6 @@ describe("the companion surface's working ring", () => {
           detail: "",
           approvalRequestId: "",
           assistantName: "Ziggy",
-          startedAt: 0,
         }}
       />,
     );

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -876,9 +876,6 @@ function CallBody({
       <span className="ml-1 max-w-[120px] shrink-0 truncate text-[12px] text-white/85">
         {line}
       </span>
-      <span className="ml-1 shrink-0 font-mono text-[11px] tabular-nums text-white/60">
-        <Elapsed startedAt={call?.startedAt} />
-      </span>
       <PillButton
         icon={
           muted ? <MicOff className="size-4" /> : <Mic className="size-4" />
@@ -963,38 +960,6 @@ function ApprovalBody({
         }}
       />
     </>
-  );
-}
-
-/**
- * Elapsed call time.
- *
- * Ticks from a timestamp the caller owns rather than one of its own, because
- * the session started before this component mounted and will outlive it: the
- * surface that renders this can reload mid-call. With no timestamp it holds a
- * fixed sample, which is what a static story wants.
- */
-function Elapsed({ startedAt }: { startedAt?: number }) {
-  const [now, setNow] = useState(() => Date.now());
-
-  useEffect(() => {
-    if (startedAt === undefined) {
-      return;
-    }
-    const timer = setInterval(() => {
-      setNow(Date.now());
-    }, 1000);
-    return () => {
-      clearInterval(timer);
-    };
-  }, [startedAt]);
-
-  if (startedAt === undefined) {
-    return <>0:14</>;
-  }
-  const seconds = Math.max(0, Math.floor((now - startedAt) / 1000));
-  return (
-    <>{`${Math.floor(seconds / 60)}:${String(seconds % 60).padStart(2, "0")}`}</>
   );
 }
 

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -350,17 +350,17 @@ export interface VoiceActivityStart extends VoiceActivityContent {
 }
 
 /**
- * What the surface's own renderer receives: everything the session sent, plus
- * `startedAt`, which main stamps.
+ * What the surface's own renderer receives, which is exactly what the session
+ * sent.
  *
- * `startedAt` is main's rather than the sender's because the surface is a
- * separate renderer that can load, reload, or be recreated mid-session, and an
- * elapsed clock anchored in either renderer would restart when that happened.
+ * The same shape as {@link VoiceActivityStart} under a name that says which end
+ * is holding it: a `start` is an event a renderer publishes, and this is the
+ * session main keeps and pushes down. Main once added `startedAt` here to
+ * anchor an elapsed clock outside a renderer that can reload mid-session, and
+ * dropped it with the clock (JARVIS-1546): a timestamp nothing reads is a
+ * timestamp that quietly rots.
  */
-export interface VoiceActivityState extends VoiceActivityStart {
-  /** Epoch ms when main first saw this session. */
-  startedAt: number;
-}
+export type VoiceActivityState = VoiceActivityStart;
 
 /**
  * What a control on the session surface asks of the session.


### PR DESCRIPTION
## What

The companion's running-call pill drew an elapsed clock next to the status line. It made the surface read like a phone call that was costing something — anxiety, and a reason not to leave the companion enabled, tolerable only if you knew internally that the clock didn't mean anything was being consumed.

The status line and the working ring (JARVIS-1540, #40833) already say what is happening. The clock only said how long you'd been on the hook for it.

```
before   [ ◉ ] Reading a file   1:47   [mic] [spkr] [end]
after    [ ◉ ] Reading a file          [mic] [spkr] [end]
```

## How

The removal follows the now-unread field out rather than stopping at the display:

- `Elapsed` and its `<span>` deleted from `companion-surface.tsx`.
- `startedAt` off `VoiceActivityState`. Nothing else read it.
- `callOnStart` deleted from `companion-window.ts`. It existed only to keep a redundant `start` from restarting the clock — with no clock to protect, `{...current, ...start}` is the identity function, since `start` carries every field. The handler now assigns what it was sent, with the redundant-start reasoning kept as a comment where it still applies.
- The demo reel's `callStartedAt` restamping, and `startedAt` from the story and test fixtures.

`VoiceActivityState` is left as a `type` alias of `VoiceActivityStart`. The shapes are now identical, but the two names mark which end is holding one: a `start` is an event a renderer publishes, and the state is what main keeps and pushes down. Collapsing to a single name would leave the surface's prop reading `call?: VoiceActivityStart`, which describes an event, not a session.

**A note on the ticket:** JARVIS-1546 says the main-process anchor is "worth keeping if a timer is ever wanted back". Alex chose the fuller scope after that was raised — a timestamp nothing reads is one that rots, and the anchor is eight lines to restore from this diff if a timer ever returns.

**iOS is untouched.** The ticket asks whether this is the same call everywhere. The Live Activity and Dynamic Island clock reads `VoiceSessionAttributes.startedAt` (`VoiceSessionIslandViews.swift:568`), a separate Swift type that never shared this contract, so nothing here reaches it. Whether the island loses its timer too is a separate decision.

`MAX_PILL_WIDTH` is unchanged: the widest state is `PendingApproval`, whose approval body returns before the status row and never drew the clock.

## Testing

- `cd clients/macos && bun run test:ci` — 44 + 40 files, 0 failed
- `cd clients/web && bun test src/components/companion-surface.test.tsx` — 10 pass
- `cd clients/web && bun test src/components/companion-surface-page.test.tsx` — 7 pass
- `tsc --noEmit` clean in `clients/web` and `clients/macos`; lint clean

Two main-process cases went with `callOnStart` ("start stamps the clock", "a redundant start updates the session without restarting its clock"); the remaining `callOnUpdate` cases build their running session from the fixture directly.

Depends on nothing unmerged — the working ring it leans on is #40833, still in review.

Closes JARVIS-1546

🤖 Generated with [Claude Code](https://claude.com/claude-code)