### PR TITLE
fix: resource banner spacer regression and stale per-assistant dismissal

### DIFF
--- a/clients/web/src/domains/chat/components/composer-notices.tsx
+++ b/clients/web/src/domains/chat/components/composer-notices.tsx
@@ -153,9 +153,10 @@ export function ComposerNotices({
       {diskPressureBanner ? (
         <div className="mb-2">{diskPressureBanner}</div>
       ) : null}
-      {resourcePressureBanner ? (
-        <div className="mb-2">{resourcePressureBanner}</div>
-      ) : null}
+      {/* Rendered bare: the slot is always a truthy element and decides for
+          itself whether it has a banner, so a wrapper here would stand in the
+          stack even when it renders nothing. It brings its own spacing. */}
+      {resourcePressureBanner}
       {billingBannerSlot}
       {showMissingApiKeyBanner && (
         <div className="mb-2">

--- a/clients/web/src/domains/chat/components/resource-pressure-banner-slot.test.tsx
+++ b/clients/web/src/domains/chat/components/resource-pressure-banner-slot.test.tsx
@@ -69,12 +69,13 @@ function monitorResult(
 function slot(
   status: ResourcePressureStatus | null,
   assistantStateKind = "active",
+  assistantId: string | null = "assistant-1",
 ) {
   return (
     <MemoryRouter>
       <ResourcePressureBannerSlot
         resourcePressure={monitorResult(status)}
-        assistantId="assistant-1"
+        assistantId={assistantId}
         assistantStateKind={assistantStateKind}
       />
     </MemoryRouter>
@@ -159,6 +160,63 @@ describe("ResourcePressureBannerSlot", () => {
     render(slot(elevatedStatus));
 
     expect(queryBanner()).toBeTruthy();
+  });
+
+  test("cpu-only elevation shows the CPU body", () => {
+    render(
+      slot({
+        ...elevatedStatus,
+        memoryElevated: false,
+        memoryPercent: 40,
+      }),
+    );
+
+    expect(
+      screen.getByText("CPU usage has stayed high for an extended period."),
+    ).toBeTruthy();
+  });
+
+  test("memory-only elevation shows the memory body", () => {
+    render(
+      slot({
+        ...elevatedStatus,
+        cpuElevated: false,
+        cpuPercent: 20,
+      }),
+    );
+
+    expect(
+      screen.getByText("Memory usage has stayed high for an extended period."),
+    ).toBeTruthy();
+  });
+
+  test("switching assistants re-derives dismissal from the new keys", () => {
+    // GIVEN assistant-1's banner was just dismissed in memory, and
+    // assistant-2 carries a stored permanent suppress
+    localStorage.setItem(
+      "vellum:resourcePressureSuppressed:assistant-2",
+      "true",
+    );
+    const view = render(slot(elevatedStatus));
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+    expect(queryBanner()).toBeNull();
+
+    // THEN assistant-2's stored suppress governs after the switch
+    view.rerender(slot(elevatedStatus, "active", "assistant-2"));
+    expect(queryBanner()).toBeNull();
+
+    // AND assistant-3, with no stored state, does not inherit assistant-1's
+    // in-memory dismiss
+    view.rerender(slot(elevatedStatus, "active", "assistant-3"));
+    expect(queryBanner()).toBeTruthy();
+  });
+
+  test("a stored suppress applies once a null assistant id resolves", () => {
+    localStorage.setItem(SUPPRESSED_KEY, "true");
+    const view = render(slot(elevatedStatus, "active", null));
+
+    view.rerender(slot(elevatedStatus, "active", "assistant-1"));
+    expect(queryBanner()).toBeNull();
   });
 
   test("permanent suppress persists and always hides the banner", () => {

--- a/clients/web/src/domains/chat/components/resource-pressure-banner-slot.tsx
+++ b/clients/web/src/domains/chat/components/resource-pressure-banner-slot.tsx
@@ -10,7 +10,7 @@
  * "Don't show again" persists permanently and is never auto-cleared.
  */
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { useNavigate } from "react-router";
 
@@ -26,6 +26,20 @@ import { useIsNativeAndroid } from "@/runtime/platform-detection";
 import { routes } from "@/utils/routes";
 
 const DISMISS_COOLDOWN_MS = 7 * 24 * 60 * 60 * 1000;
+
+function readCooldownActive(dismissedUntilKey: string | null): boolean {
+  if (!dismissedUntilKey) {
+    return false;
+  }
+  return Date.now() < getLocalNumber(dismissedUntilKey, 0);
+}
+
+function readSuppressed(suppressedKey: string | null): boolean {
+  if (!suppressedKey) {
+    return false;
+  }
+  return getLocalBool(suppressedKey, false);
+}
 
 // ---------------------------------------------------------------------------
 // Props
@@ -59,18 +73,23 @@ export function ResourcePressureBannerSlot({
 
   // Evaluated lazily at mount; a cooldown that expires while the slot stays
   // mounted is picked up on the next mount, which is fine for a 7-day window.
-  const [cooldownActive, setCooldownActive] = useState(() => {
-    if (!dismissedUntilKey) {
-      return false;
-    }
-    return Date.now() < getLocalNumber(dismissedUntilKey, 0);
-  });
-  const [suppressed, setSuppressed] = useState(() => {
-    if (!suppressedKey) {
-      return false;
-    }
-    return getLocalBool(suppressedKey, false);
-  });
+  const [cooldownActive, setCooldownActive] = useState(() =>
+    readCooldownActive(dismissedUntilKey),
+  );
+  const [suppressed, setSuppressed] = useState(() =>
+    readSuppressed(suppressedKey),
+  );
+
+  // The slot stays mounted across assistant switches, and the first render
+  // can happen before the assistant id resolves. Re-seed both flags from
+  // storage whenever the keys change so one assistant's in-memory dismissal
+  // never bleeds into the next and a late-resolving id picks up its stored
+  // suppress / cooldown state. (`Date.now()` is impure, so the re-read lives
+  // in an effect rather than in render.)
+  useEffect(() => {
+    setCooldownActive(readCooldownActive(dismissedUntilKey));
+    setSuppressed(readSuppressed(suppressedKey));
+  }, [dismissedUntilKey, suppressedKey]);
 
   const dismiss = useCallback(
     (permanent: boolean) => {
@@ -96,15 +115,20 @@ export function ResourcePressureBannerSlot({
     return null;
   }
 
+  // The spacer lives with the banner, not around the slot: a wrapper on the
+  // caller's side outlives every `return null` above and leaves an empty
+  // element in the composer's banner stack, which reads there as a banner.
   return (
-    <ResourcePressureBanner
-      status={resourcePressure.status}
-      onDismiss={dismiss}
-      onUpgrade={
-        assistantStateKind === "active" && !isNativeAndroid
-          ? () => void navigate(routes.plans)
-          : null
-      }
-    />
+    <div className="mb-2">
+      <ResourcePressureBanner
+        status={resourcePressure.status}
+        onDismiss={dismiss}
+        onUpgrade={
+          assistantStateKind === "active" && !isNativeAndroid
+            ? () => void navigate(routes.plans)
+            : null
+        }
+      />
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for resource-pressure-upgrade-banner.md.

**Gap:** composer spacer regression vs main #40877; stale dismiss/suppress across assistant switches; missing body-variant coverage
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40889" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->