### PR TITLE
fix(web): one read-state glyph for notifications and conversations (LUM-3336)

### DIFF
--- a/clients/web/eslint.config.mjs
+++ b/clients/web/eslint.config.mjs
@@ -191,6 +191,7 @@ const authBoundaryAllowedPaths = [
  */
 const i18nEnforcedPaths = [
   "src/components/not-found.tsx",
+  "src/components/section-actions-button.tsx",
   "src/domains/chat/components/allow-options-menu.tsx",
   "src/domains/chat/components/chat-composer/add-to-chat-sheet.tsx",
   "src/domains/chat/components/conversation-actions-menu.tsx",

--- a/clients/web/eslint.config.mjs
+++ b/clients/web/eslint.config.mjs
@@ -195,6 +195,7 @@ const i18nEnforcedPaths = [
   "src/domains/chat/components/chat-composer/add-to-chat-sheet.tsx",
   "src/domains/chat/components/conversation-actions-menu.tsx",
   "src/domains/chat/components/conversation-assets-pill.tsx",
+  "src/domains/chat/components/group-actions-menu.tsx",
   "src/domains/chat/components/pinned-app-color-swatches.tsx",
   "src/domains/chat/components/sidebar-conversation-error.tsx",
   "src/domains/schedules/**/*.{ts,tsx}",

--- a/clients/web/src/components/section-actions-button.tsx
+++ b/clients/web/src/components/section-actions-button.tsx
@@ -16,6 +16,7 @@
 import { MoreHorizontal } from "lucide-react";
 import type { ComponentProps, MouseEvent } from "react";
 
+import { useTranslation } from "@/i18n";
 import { cn } from "@vellumai/design-library/utils/cn";
 
 const BUTTON_CLASSES = [
@@ -39,11 +40,13 @@ export function SectionActionsButton({
   onClick,
   ...rest
 }: SectionActionsButtonProps) {
+  const { t } = useTranslation("common");
+
   return (
     <button
       {...rest}
       type="button"
-      aria-label={`${label} actions`}
+      aria-label={t("sectionActionsButton.ariaLabel", { name: label })}
       aria-haspopup="menu"
       onClick={(event: MouseEvent<HTMLButtonElement>) => {
         event.stopPropagation();

--- a/clients/web/src/components/section-actions-button.tsx
+++ b/clients/web/src/components/section-actions-button.tsx
@@ -28,10 +28,8 @@ const BUTTON_CLASSES = [
   "max-md:h-[30px] max-md:w-[30px]",
 ].join(" ");
 
-export interface SectionActionsButtonProps extends Omit<
-  ComponentProps<"button">,
-  "children" | "aria-label"
-> {
+export interface SectionActionsButtonProps
+  extends Omit<ComponentProps<"button">, "children" | "aria-label"> {
   /** Section name, which names the control for assistive tech. */
   label: string;
 }

--- a/clients/web/src/components/section-actions-button.tsx
+++ b/clients/web/src/components/section-actions-button.tsx
@@ -28,8 +28,10 @@ const BUTTON_CLASSES = [
   "max-md:h-[30px] max-md:w-[30px]",
 ].join(" ");
 
-export interface SectionActionsButtonProps
-  extends Omit<ComponentProps<"button">, "children" | "aria-label"> {
+export interface SectionActionsButtonProps extends Omit<
+  ComponentProps<"button">,
+  "children" | "aria-label"
+> {
   /** Section name, which names the control for assistive tech. */
   label: string;
 }

--- a/clients/web/src/domains/chat/components/conversation-actions-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/conversation-actions-menu.test.tsx
@@ -293,12 +293,14 @@ describe("renderConversationMenuItems", () => {
   test("renders Copy conversation ID in both variants when wired", () => {
     for (const variant of ["sidebar", "header"] as const) {
       const html = renderToStaticMarkup(
-        <>{renderConversationMenuItems({
-          Primitive: Menu as unknown as ConversationMenuPrimitive,
-          t,
-          variant,
-          onCopyConversationId: () => {},
-        })}</>,
+        <>
+          {renderConversationMenuItems({
+            Primitive: Menu as unknown as ConversationMenuPrimitive,
+            t,
+            variant,
+            onCopyConversationId: () => {},
+          })}
+        </>,
       );
       expect(html).toContain("Copy conversation ID");
     }
@@ -306,11 +308,13 @@ describe("renderConversationMenuItems", () => {
 
   test("omits Copy conversation ID when not wired", () => {
     const html = renderToStaticMarkup(
-      <>{renderConversationMenuItems({
-        Primitive: Menu as unknown as ConversationMenuPrimitive,
+      <>
+        {renderConversationMenuItems({
+          Primitive: Menu as unknown as ConversationMenuPrimitive,
           t,
-        onRename: () => {},
-      })}</>,
+          onRename: () => {},
+        })}
+      </>,
     );
     expect(html).not.toContain("Copy conversation ID");
   });
@@ -478,7 +482,7 @@ describe("renderConversationMenuItems — mark read/unread exclusivity", () => {
   });
 });
 
-describe("renderConversationMenuItems — read-state iconography", () => {
+describe("renderConversationMenuItems: read-state iconography", () => {
   // The glyph names the conversation's current state: a conversation offering
   // "Mark as read" is unread, so it shows the sealed envelope. `lucide-mail`
   // is a prefix of `lucide-mail-open`, so that case rules the open glyph out

--- a/clients/web/src/domains/chat/components/conversation-actions-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/conversation-actions-menu.test.tsx
@@ -478,6 +478,37 @@ describe("renderConversationMenuItems — mark read/unread exclusivity", () => {
   });
 });
 
+describe("renderConversationMenuItems — read-state iconography", () => {
+  // The glyph names the conversation's current state: a conversation offering
+  // "Mark as read" is unread, so it shows the sealed envelope. `lucide-mail`
+  // is a prefix of `lucide-mail-open`, so that case rules the open glyph out
+  // explicitly.
+  function menuHtml(props: Parameters<typeof renderConversationMenuItems>[0]) {
+    return renderToStaticMarkup(<>{renderConversationMenuItems(props)}</>);
+  }
+
+  test("an unread conversation shows the sealed envelope", () => {
+    const html = menuHtml({
+      Primitive: Menu as unknown as ConversationMenuPrimitive,
+      t,
+      onMarkRead: () => {},
+    });
+    expect(html).toContain("Mark as read");
+    expect(html).toContain('lucide-mail"');
+    expect(html).not.toContain("lucide-mail-open");
+  });
+
+  test("a read conversation shows the opened envelope", () => {
+    const html = menuHtml({
+      Primitive: Menu as unknown as ConversationMenuPrimitive,
+      t,
+      onMarkUnread: () => {},
+    });
+    expect(html).toContain("Mark as unread");
+    expect(html).toContain("lucide-mail-open");
+  });
+});
+
 describe("ConversationActionsMenu — mobile panel details", () => {
   test("isMarkUnreadDisabled renders disabled panel item on mobile", () => {
     mockIsTouchMobile = true;

--- a/clients/web/src/domains/chat/components/conversation-actions-menu.tsx
+++ b/clients/web/src/domains/chat/components/conversation-actions-menu.tsx
@@ -1,8 +1,6 @@
 import {
   Archive,
   ArchiveRestore,
-  Circle,
-  CircleCheck,
   Copy,
   ExternalLink,
   FolderInput,
@@ -29,6 +27,7 @@ import { useTouchMobile } from "@/hooks/use-touch-mobile";
 import { useTranslation, type TFunction } from "@/i18n";
 import { openExternalUrl } from "@/runtime/browser";
 import { useIsNativePlatform } from "@/runtime/native-auth";
+import { READ_ICON, UNREAD_ICON } from "@/utils/read-state-icon";
 import { BottomSheet, ContextMenu, Menu } from "@vellumai/design-library";
 import { cn } from "@vellumai/design-library/utils/cn";
 
@@ -245,14 +244,14 @@ export function renderConversationMenuItems({
   const markReadUnreadItem =
     !isReadonly && onMarkRead ? (
       <Primitive.Item
-        leftIcon={<CircleCheck size={14} />}
+        leftIcon={<UNREAD_ICON size={14} />}
         onSelect={onMarkRead}
       >
         {t("conversationActions.markRead")}
       </Primitive.Item>
     ) : !isReadonly && onMarkUnread ? (
       <Primitive.Item
-        leftIcon={<Circle size={14} />}
+        leftIcon={<READ_ICON size={14} />}
         onSelect={onMarkUnread}
         disabled={isMarkUnreadDisabled}
       >
@@ -552,7 +551,7 @@ export function renderConversationMenuItemsAsPanelItems({
     !isReadonly && onMarkRead
       ? buildSheetMenuItem({
           key: "mark-read",
-          icon: CircleCheck,
+          icon: UNREAD_ICON,
           label: t("conversationActions.markRead"),
           run: onMarkRead,
           onClose,
@@ -560,7 +559,7 @@ export function renderConversationMenuItemsAsPanelItems({
       : !isReadonly && onMarkUnread
         ? buildSheetMenuItem({
             key: "mark-unread",
-            icon: Circle,
+            icon: READ_ICON,
             label: t("conversationActions.markUnread"),
             disabled: isMarkUnreadDisabled,
             run: onMarkUnread,

--- a/clients/web/src/domains/chat/components/conversation-nav-section.tsx
+++ b/clients/web/src/domains/chat/components/conversation-nav-section.tsx
@@ -52,6 +52,7 @@ import {
   renderGroupMenuItemsAsPanelItems,
   type GroupMenuItemsProps,
 } from "@/domains/chat/components/group-actions-menu";
+import { useTranslation } from "@/i18n";
 import type { Conversation } from "@/types/conversation-types";
 
 /**
@@ -218,6 +219,7 @@ export function ConversationNavSection({
 }: ConversationNavSectionProps) {
   const hasMenu = groupMenu != null && hasAnyGroupMenuAction(groupMenu);
   const { overlayCards } = useConversationListContext();
+  const { t } = useTranslation("chat");
 
   return (
     <CollapsibleNavSection.Section
@@ -228,13 +230,17 @@ export function ConversationNavSection({
       trailing={trailing}
       contextMenuContent={
         hasMenu
-          ? renderGroupMenuItems({ Primitive: ContextMenu, ...groupMenu })
+          ? renderGroupMenuItems({ Primitive: ContextMenu, ...groupMenu, t })
           : undefined
       }
       touchMenuContent={
         hasMenu
           ? (close) =>
-              renderGroupMenuItemsAsPanelItems({ ...groupMenu, onClose: close })
+              renderGroupMenuItemsAsPanelItems({
+                ...groupMenu,
+                onClose: close,
+                t,
+              })
           : undefined
       }
       collapsedIndicator={collapsedIndicator}

--- a/clients/web/src/domains/chat/components/group-actions-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/group-actions-menu.test.tsx
@@ -22,6 +22,11 @@ import {
   hasAnyGroupMenuAction,
   renderGroupMenuItemsAsPanelItems,
 } from "@/domains/chat/components/group-actions-menu";
+import { fixedT } from "@/i18n";
+
+// The renderers take a namespace-bound `t`, the same thing
+// `useTranslation("chat")` hands their component callers.
+const t = fixedT("chat");
 
 const allActions = {
   onMarkAllRead: () => {},
@@ -146,6 +151,7 @@ describe("renderGroupMenuItemsAsPanelItems", () => {
           },
           hasUnreadConversations: false,
           onClose: () => {},
+          t,
         }),
       ),
     );

--- a/clients/web/src/domains/chat/components/group-actions-menu.tsx
+++ b/clients/web/src/domains/chat/components/group-actions-menu.tsx
@@ -22,7 +22,6 @@ import {
   Archive,
   ArrowDown,
   ArrowUp,
-  CircleCheck,
   Copy,
   Layers,
   Pencil,
@@ -36,6 +35,7 @@ import {
   buildPanelMenuItem,
   PanelMenuDivider,
 } from "@/domains/chat/components/panel-menu-item";
+import { READ_ICON } from "@/utils/read-state-icon";
 import {
   BottomSheet,
   ContextMenu,
@@ -160,7 +160,7 @@ export function renderGroupMenuItems({
       ) : null}
       {onMarkAllRead ? (
         <Primitive.Item
-          leftIcon={<CircleCheck size={14} />}
+          leftIcon={<READ_ICON size={14} />}
           onSelect={onMarkAllRead}
           disabled={!hasUnreadConversations}
         >
@@ -256,7 +256,7 @@ export function renderGroupMenuItemsAsPanelItems({
       {onMarkAllRead
         ? buildPanelMenuItem({
             key: "mark-all-read",
-            icon: CircleCheck,
+            icon: READ_ICON,
             label: "Mark All as Read",
             disabled: !hasUnreadConversations,
             run: onMarkAllRead,

--- a/clients/web/src/domains/chat/components/group-actions-menu.tsx
+++ b/clients/web/src/domains/chat/components/group-actions-menu.tsx
@@ -30,12 +30,13 @@ import {
 import { type ReactNode, useState } from "react";
 
 import { useTouchMobile } from "@/hooks/use-touch-mobile";
+import { useTranslation, type TFunction } from "@/i18n";
 import { SectionActionsButton } from "@/components/section-actions-button";
 import {
   buildPanelMenuItem,
   PanelMenuDivider,
 } from "@/domains/chat/components/panel-menu-item";
-import { READ_ICON } from "@/utils/read-state-icon";
+import { MARK_ALL_READ_ICON } from "@/utils/read-state-icon";
 import {
   BottomSheet,
   ContextMenu,
@@ -128,7 +129,11 @@ export function renderGroupMenuItems({
   isGroupedByChannel = false,
   onMoveUp,
   onMoveDown,
-}: GroupMenuItemsProps & { Primitive: GroupMenuPrimitive }): ReactNode {
+  t,
+}: GroupMenuItemsProps & {
+  Primitive: GroupMenuPrimitive;
+  t: TFunction<"chat">;
+}): ReactNode {
   const hasBulkActions = onMarkAllRead != null || onArchiveAll != null;
   const hasIndividualActions =
     onRename != null ||
@@ -144,7 +149,7 @@ export function renderGroupMenuItems({
           section (no rename/delete) and a custom group. */}
       {onMoveUp ? (
         <Primitive.Item leftIcon={<ArrowUp size={14} />} onSelect={onMoveUp}>
-          Move Section Up
+          {t("groupActions.moveSectionUp")}
         </Primitive.Item>
       ) : null}
       {onMoveDown ? (
@@ -152,7 +157,7 @@ export function renderGroupMenuItems({
           leftIcon={<ArrowDown size={14} />}
           onSelect={onMoveDown}
         >
-          Move Section Down
+          {t("groupActions.moveSectionDown")}
         </Primitive.Item>
       ) : null}
       {hasMoveActions && (hasBulkActions || hasIndividualActions) ? (
@@ -160,11 +165,11 @@ export function renderGroupMenuItems({
       ) : null}
       {onMarkAllRead ? (
         <Primitive.Item
-          leftIcon={<READ_ICON size={14} />}
+          leftIcon={<MARK_ALL_READ_ICON size={14} />}
           onSelect={onMarkAllRead}
           disabled={!hasUnreadConversations}
         >
-          Mark All as Read
+          {t("groupActions.markAllRead")}
         </Primitive.Item>
       ) : null}
       {onArchiveAll ? (
@@ -173,23 +178,25 @@ export function renderGroupMenuItems({
           onSelect={onArchiveAll}
           disabled={!hasConversations}
         >
-          Archive All…
+          {t("groupActions.archiveAll")}
         </Primitive.Item>
       ) : null}
       {hasBulkActions && hasIndividualActions ? <Primitive.Separator /> : null}
       {onRename ? (
         <Primitive.Item leftIcon={<Pencil size={14} />} onSelect={onRename}>
-          Rename
+          {t("groupActions.rename")}
         </Primitive.Item>
       ) : null}
       {onDelete ? (
         <Primitive.Item leftIcon={<Trash2 size={14} />} onSelect={onDelete}>
-          {hasConversations ? "Delete group…" : "Delete group"}
+          {hasConversations
+            ? t("groupActions.deleteGroupWithConversations")
+            : t("groupActions.deleteGroup")}
         </Primitive.Item>
       ) : null}
       {onCopyGroupId ? (
         <Primitive.Item leftIcon={<Copy size={14} />} onSelect={onCopyGroupId}>
-          Copy group ID
+          {t("groupActions.copyGroupId")}
         </Primitive.Item>
       ) : null}
       {onToggleGroupByChannel ? (
@@ -197,7 +204,9 @@ export function renderGroupMenuItems({
           leftIcon={<Layers size={14} />}
           onSelect={onToggleGroupByChannel}
         >
-          {isGroupedByChannel ? "Ungroup" : "Group by channel"}
+          {isGroupedByChannel
+            ? t("groupActions.ungroup")
+            : t("groupActions.groupByChannel")}
         </Primitive.Item>
       ) : null}
     </>
@@ -221,7 +230,11 @@ export function renderGroupMenuItemsAsPanelItems({
   onMoveUp,
   onMoveDown,
   onClose,
-}: GroupMenuItemsProps & { onClose: () => void }): ReactNode {
+  t,
+}: GroupMenuItemsProps & {
+  onClose: () => void;
+  t: TFunction<"chat">;
+}): ReactNode {
   const hasBulkActions = onMarkAllRead != null || onArchiveAll != null;
   const hasIndividualActions =
     onRename != null ||
@@ -236,7 +249,7 @@ export function renderGroupMenuItemsAsPanelItems({
         ? buildPanelMenuItem({
             key: "move-section-up",
             icon: ArrowUp,
-            label: "Move Section Up",
+            label: t("groupActions.moveSectionUp"),
             run: onMoveUp,
             onClose,
           })
@@ -245,7 +258,7 @@ export function renderGroupMenuItemsAsPanelItems({
         ? buildPanelMenuItem({
             key: "move-section-down",
             icon: ArrowDown,
-            label: "Move Section Down",
+            label: t("groupActions.moveSectionDown"),
             run: onMoveDown,
             onClose,
           })
@@ -256,8 +269,8 @@ export function renderGroupMenuItemsAsPanelItems({
       {onMarkAllRead
         ? buildPanelMenuItem({
             key: "mark-all-read",
-            icon: READ_ICON,
-            label: "Mark All as Read",
+            icon: MARK_ALL_READ_ICON,
+            label: t("groupActions.markAllRead"),
             disabled: !hasUnreadConversations,
             run: onMarkAllRead,
             onClose,
@@ -267,7 +280,7 @@ export function renderGroupMenuItemsAsPanelItems({
         ? buildPanelMenuItem({
             key: "archive-all",
             icon: Archive,
-            label: "Archive All…",
+            label: t("groupActions.archiveAll"),
             disabled: !hasConversations,
             run: onArchiveAll,
             onClose,
@@ -278,7 +291,7 @@ export function renderGroupMenuItemsAsPanelItems({
         ? buildPanelMenuItem({
             key: "rename",
             icon: Pencil,
-            label: "Rename",
+            label: t("groupActions.rename"),
             run: onRename,
             onClose,
           })
@@ -287,7 +300,9 @@ export function renderGroupMenuItemsAsPanelItems({
         ? buildPanelMenuItem({
             key: "delete",
             icon: Trash2,
-            label: hasConversations ? "Delete group…" : "Delete group",
+            label: hasConversations
+              ? t("groupActions.deleteGroupWithConversations")
+              : t("groupActions.deleteGroup"),
             run: onDelete,
             onClose,
           })
@@ -296,7 +311,7 @@ export function renderGroupMenuItemsAsPanelItems({
         ? buildPanelMenuItem({
             key: "copy-group-id",
             icon: Copy,
-            label: "Copy group ID",
+            label: t("groupActions.copyGroupId"),
             run: onCopyGroupId,
             onClose,
           })
@@ -305,7 +320,9 @@ export function renderGroupMenuItemsAsPanelItems({
         ? buildPanelMenuItem({
             key: "toggle-group-by-channel",
             icon: Layers,
-            label: isGroupedByChannel ? "Ungroup" : "Group by channel",
+            label: isGroupedByChannel
+              ? t("groupActions.ungroup")
+              : t("groupActions.groupByChannel"),
             run: onToggleGroupByChannel,
             onClose,
           })
@@ -335,6 +352,7 @@ export function GroupActionsMenu({
 }: GroupActionsMenuProps) {
   const [open, setOpen] = useState(false);
   const isTouchMobile = useTouchMobile();
+  const { t } = useTranslation("chat");
   const closeMenu = () => setOpen(false);
   const hasItems = hasAnyGroupMenuAction(menuProps);
 
@@ -345,6 +363,7 @@ export function GroupActionsMenu({
   const items = renderGroupMenuItemsAsPanelItems({
     ...menuProps,
     onClose: closeMenu,
+    t,
   });
 
   const trigger = <SectionActionsButton label={label} />;
@@ -355,7 +374,9 @@ export function GroupActionsMenu({
         <BottomSheet.Trigger asChild>{trigger}</BottomSheet.Trigger>
         <BottomSheet.Content aria-describedby={undefined}>
           <BottomSheet.Header className="sr-only">
-            <BottomSheet.Title>{label} actions</BottomSheet.Title>
+            <BottomSheet.Title>
+              {t("groupActionsSheet.title", { name: label })}
+            </BottomSheet.Title>
           </BottomSheet.Header>
           <BottomSheet.Body className="pt-0">{items}</BottomSheet.Body>
         </BottomSheet.Content>

--- a/clients/web/src/domains/home/read-toggle.ts
+++ b/clients/web/src/domains/home/read-toggle.ts
@@ -1,6 +1,7 @@
-import { Mail, MailOpen, type LucideIcon } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 
 import type { TFunction } from "@/i18n";
+import { readStateIcon } from "@/utils/read-state-icon";
 import type { FeedItemStatus } from "@vellumai/assistant-api";
 
 /**
@@ -10,13 +11,7 @@ import type { FeedItemStatus } from "@vellumai/assistant-api";
  * notification bell's detail header.
  */
 export interface ReadToggle {
-  /**
-   * Names the item's *current* state, not the command: a sealed envelope for
-   * unread, an opened one for read. It sits beside the unread dot and the
-   * unread emphasis on the same row, so a glyph naming the command instead
-   * would put an open envelope on every item the rest of the row calls
-   * unread.
-   */
+  /** Names the item's current state, per `readStateIcon`. */
   icon: LucideIcon;
   /** Names the command, which is the opposite of the state the glyph shows. */
   label: string;
@@ -29,7 +24,7 @@ export function buildReadToggle(
   t: TFunction<"home">,
 ): ReadToggle {
   return {
-    icon: isUnread ? Mail : MailOpen,
+    icon: readStateIcon(isUnread),
     label: isUnread ? t("actions.markAsRead") : t("actions.markAsUnread"),
     nextStatus: isUnread ? "seen" : "new",
   };

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -219,6 +219,21 @@
   "fileDownload": {
     "failed": "Failed to download file"
   },
+  "groupActions": {
+    "archiveAll": "Archive All…",
+    "copyGroupId": "Copy group ID",
+    "deleteGroup": "Delete group",
+    "deleteGroupWithConversations": "Delete group…",
+    "groupByChannel": "Group by channel",
+    "markAllRead": "Mark All as Read",
+    "moveSectionDown": "Move Section Down",
+    "moveSectionUp": "Move Section Up",
+    "rename": "Rename",
+    "ungroup": "Ungroup"
+  },
+  "groupActionsSheet": {
+    "title": "{name} actions"
+  },
   "inspectPage": {
     "accessDenied": "Inspector is available to Vellum staff, or when the settings-developer-nav developer flag is enabled.",
     "allMessages": "All messages",

--- a/clients/web/src/i18n/locales/en/common.json
+++ b/clients/web/src/i18n/locales/en/common.json
@@ -5,5 +5,8 @@
     "body": "The page you're looking for doesn't exist or may have moved.",
     "backToAssistant": "Back to your assistant",
     "goBack": "Go back"
+  },
+  "sectionActionsButton": {
+    "ariaLabel": "{name} actions"
   }
 }

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -219,6 +219,21 @@
   "fileDownload": {
     "failed": "No se pudo descargar el archivo"
   },
+  "groupActions": {
+    "archiveAll": "Archivar todo…",
+    "copyGroupId": "Copiar ID del grupo",
+    "deleteGroup": "Eliminar grupo",
+    "deleteGroupWithConversations": "Eliminar grupo…",
+    "groupByChannel": "Agrupar por canal",
+    "markAllRead": "Marcar todo como leído",
+    "moveSectionDown": "Bajar sección",
+    "moveSectionUp": "Subir sección",
+    "rename": "Cambiar nombre",
+    "ungroup": "Desagrupar"
+  },
+  "groupActionsSheet": {
+    "title": "Acciones de {name}"
+  },
   "inspectPage": {
     "accessDenied": "El inspector está disponible para el personal de Vellum o cuando la marca de desarrollador settings-developer-nav está habilitada.",
     "allMessages": "Todos los mensajes",

--- a/clients/web/src/i18n/locales/es/common.json
+++ b/clients/web/src/i18n/locales/es/common.json
@@ -5,5 +5,8 @@
     "body": "La página que buscas no existe o puede haberse movido.",
     "backToAssistant": "Volver a tu asistente",
     "goBack": "Atrás"
+  },
+  "sectionActionsButton": {
+    "ariaLabel": "Acciones de {name}"
   }
 }

--- a/clients/web/src/utils/read-state-icon.ts
+++ b/clients/web/src/utils/read-state-icon.ts
@@ -1,0 +1,27 @@
+/**
+ * Read-state iconography: the single source of truth for the glyph any
+ * read/unread control shows, across notifications and conversations.
+ *
+ * One envelope pair carries the meaning everywhere. The glyph names the
+ * state an item is in, never the command the control runs: a sealed
+ * envelope for unread, an opened one for read. That keeps it agreeing with
+ * the unread dot beside it on the same row, where a glyph naming the command
+ * would put an opened envelope on every item the rest of the row calls
+ * unread. The control's label ("Mark as read") names what it does.
+ *
+ * A bulk command has no single item state to name, so it takes the glyph of
+ * the state it leaves everything in: `READ_ICON` for "Mark all as read".
+ */
+
+import { Mail, MailOpen, type LucideIcon } from "lucide-react";
+
+/** An item nobody has read yet: still sealed. */
+export const UNREAD_ICON: LucideIcon = Mail;
+
+/** An item that has been read: opened. */
+export const READ_ICON: LucideIcon = MailOpen;
+
+/** The glyph naming the state an item is currently in. */
+export function readStateIcon(isUnread: boolean): LucideIcon {
+  return isUnread ? UNREAD_ICON : READ_ICON;
+}

--- a/clients/web/src/utils/read-state-icon.ts
+++ b/clients/web/src/utils/read-state-icon.ts
@@ -9,17 +9,22 @@
  * would put an opened envelope on every item the rest of the row calls
  * unread. The control's label ("Mark as read") names what it does.
  *
- * A bulk command has no single item state to name, so it takes the glyph of
- * the state it leaves everything in: `READ_ICON` for "Mark all as read".
+ * A bulk command names no single item's state, and reusing a state glyph for
+ * it puts two envelopes with opposite meanings a row apart in the same menu.
+ * It gets the check-marked envelope instead, which reads as a command in the
+ * same family.
  */
 
-import { Mail, MailOpen, type LucideIcon } from "lucide-react";
+import { Mail, MailCheck, MailOpen, type LucideIcon } from "lucide-react";
 
 /** An item nobody has read yet: still sealed. */
 export const UNREAD_ICON: LucideIcon = Mail;
 
 /** An item that has been read: opened. */
 export const READ_ICON: LucideIcon = MailOpen;
+
+/** A command that reads everything at once, rather than a state. */
+export const MARK_ALL_READ_ICON: LucideIcon = MailCheck;
 
 /** The glyph naming the state an item is currently in. */
 export function readStateIcon(isUnread: boolean): LucideIcon {


### PR DESCRIPTION
## TL;DR

Follow-up to #40882, which fixed the inverted envelopes on notifications. Conversations expressed the same read/unread state with a **different icon family** (`CircleCheck` / `Circle`) that named the command rather than the state. One module now owns read-state iconography for the whole client, and every read/unread control reads from it. The group menu's copy moves into the chat catalog in the same pass, since it was the last hardcoded menu sitting beside a converted one.

Part of LUM-3336

## Before / after

| Surface | Control | Before | After |
| --- | --- | --- | --- |
| Conversation menu (sidebar, header, mobile sheet) | "Mark as read" (conversation is unread) | Filled check circle | Sealed envelope |
| Conversation menu | "Mark as unread" (conversation is read) | Empty circle | Opened envelope |
| Sidebar section menu | "Mark All as Read" | Filled check circle | Check-marked envelope |
| Sidebar section menu | Every label, plus the mobile sheet title | Hardcoded English | Same English, from the catalog |
| Notifications (feed, detail panels, bell) | Read/unread toggle | Envelope pair (fixed in #40882) | unchanged |

No behaviour, wiring, or English copy changes. Only glyphs and where the strings come from.

## The rule, in one place

`clients/web/src/utils/read-state-icon.ts` states it and exports it:

- A per-item read/unread glyph names **the state the item is in**, never the command: sealed for unread, opened for read. That is what keeps it agreeing with the unread dot on the same row, which is the confusion the original report hit.
- The control's **label** names the command ("Mark as read").
- A **bulk** command names no single item's state, and reusing a state glyph for it would put two envelopes with opposite meanings a row apart in the same sidebar. It takes the check-marked envelope (`MailCheck`), which reads as a command in the same family.

`buildReadToggle` in the home domain reads from the same module, so notifications and conversations cannot drift apart again. It lives in `utils/` beside `channel-presentation.tsx`, the existing top-level icon-mapping module, because chat and home cannot import each other (`local/no-cross-domain-imports`).

## Group menu copy

`group-actions-menu.tsx` held ten hardcoded labels and a concatenated sheet title (`{label} actions`) while `conversation-actions-menu.tsx` next to it already went through `t()`. Both renderers now take a namespace-bound `t` (the pattern the conversation menu uses), `GroupActionsMenu` and `ConversationNavSection` supply it, the strings live in `chat.json` for `en` and `es`, and the file is added to `i18nEnforcedPaths` so `local/no-untranslated-strings` holds the line.

## Why it is safe

- Presentation and copy plumbing only: no state shape, predicate, or mutation changed. Which read/unread branch renders is still decided by `onMarkRead` vs `onMarkUnread`, wired from `hasUnseenLatestAssistantMessage` (header) and `canMarkRead` (row), both verified to mean "unread" on the mark-read branch.
- English copy is byte-identical to what was hardcoded, so the existing group-menu tests assert the same strings through the catalog.
- Verified live in Storybook: an unread conversation's menu renders `lucide-mail` on "Mark as read", a read one renders `lucide-mail-open` on "Mark as unread", and the section menu renders `lucide-mail-check` on "Mark All as Read" with every label resolving through the catalog.
- New tests in `conversation-actions-menu.test.tsx` pin both per-item cases (the unread case also rules out the open glyph explicitly, since `lucide-mail` is a prefix of `lucide-mail-open`). `read-toggle.test.ts` still pins the notification side.
- Typecheck and lint clean, including the newly enforced i18n path. Suites run in CI.

## Swept for the same class of mistake

Every state-conditional icon in the client was reviewed. The rest name commands next to a text label with no adjacent state indicator to contradict (`isPinned ? PinOff : Pin` across five call sites, archive/unarchive, fullscreen, play/stop), or already name state (`isDirectory ? Folder : FileText`, `isInbound ? Inbox : Send`). Read/unread was the only pair naming the command while sitting beside a state dot, and it is now the only pair with a shared definition.
