### PR TITLE
fix(web): catch copy assembled around an interpolation (LUM-3336)

### DIFF
--- a/clients/web/eslint-rules/no-untranslated-strings.mjs
+++ b/clients/web/eslint-rules/no-untranslated-strings.mjs
@@ -60,6 +60,13 @@ const STRUCTURAL_PROPS = new Set([
   "stroke",
   "transform",
   "viewBox",
+  // ARIA relationships hold element ids, not copy: `aria-labelledby` points at
+  // the node holding the label rather than spelling one out.
+  "aria-activedescendant",
+  "aria-controls",
+  "aria-describedby",
+  "aria-labelledby",
+  "aria-owns",
   "as",
   "autoComplete",
   "charSet",
@@ -231,12 +238,26 @@ export const noUntranslatedStrings = {
       }
       if (node.type === "TemplateLiteral") {
         const statics = node.quasis.map((q) => q.value.cooked ?? "").join(" ");
-        if (isCopy(statics)) {
+        // A template with an interpolation is copy assembled in the component
+        // whatever its static half looks like, so it is judged by
+        // `isTranslatable` rather than by `isCopy`. `aria-label={`${name}
+        // actions`}` leaves "actions" behind: one lowercase word, which reads
+        // as an enum value to the prop-level test and slips through, while the
+        // string it builds is exactly the untranslatable shape, since a
+        // translator cannot put the word before the name.
+        const isAssembled = node.expressions.length > 0;
+        if (isAssembled ? isTranslatable(statics) : isCopy(statics)) {
           context.report({
             node,
             messageId,
             data: { ...data, text: preview(statics) },
           });
+        }
+        // The interpolations carry copy of their own: `${draft ? "Draft" :
+        // "Live"}` is a word chosen in the component, and sits in the one
+        // place the static halves are not.
+        for (const expression of node.expressions) {
+          checkExpression(expression, messageId, data, isCopy);
         }
         return;
       }

--- a/clients/web/eslint-rules/no-untranslated-strings.mjs
+++ b/clients/web/eslint-rules/no-untranslated-strings.mjs
@@ -61,10 +61,14 @@ const STRUCTURAL_PROPS = new Set([
   "transform",
   "viewBox",
   // ARIA relationships hold element ids, not copy: `aria-labelledby` points at
-  // the node holding the label rather than spelling one out.
+  // the node holding the label rather than spelling one out. This is every
+  // attribute WAI-ARIA types as an ID reference or ID reference list.
   "aria-activedescendant",
   "aria-controls",
   "aria-describedby",
+  "aria-details",
+  "aria-errormessage",
+  "aria-flowto",
   "aria-labelledby",
   "aria-owns",
   "as",

--- a/clients/web/eslint-rules/no-untranslated-strings.test.mjs
+++ b/clients/web/eslint-rules/no-untranslated-strings.test.mjs
@@ -88,7 +88,22 @@ ruleTester.run("no-untranslated-strings", noUntranslatedStrings, {
     {
       name: "ARIA relationships holding element ids are not copy",
       filename: COMPONENT,
-      code: `const C = () => <input aria-activedescendant={\`\${id}-opt-\${i}\`} aria-controls={\`\${id}-list\`} />;`,
+      // Every attribute WAI-ARIA types as an ID reference, since the
+      // tightened template test would otherwise read the id suffix as a word.
+      code: [
+        "const C = () => (",
+        "  <input",
+        "    aria-activedescendant={`${id}-opt-${i}`}",
+        "    aria-controls={`${id}-list`}",
+        "    aria-describedby={`${id}-hint`}",
+        "    aria-details={`${id}-details`}",
+        "    aria-errormessage={`${id}-error`}",
+        "    aria-flowto={`${id}-next`}",
+        "    aria-labelledby={`${id}-label`}",
+        "    aria-owns={`${id}-popup`}",
+        "  />",
+        ");",
+      ].join("\n"),
     },
     {
       name: "values joined by punctuation carry no copy of their own",

--- a/clients/web/eslint-rules/no-untranslated-strings.test.mjs
+++ b/clients/web/eslint-rules/no-untranslated-strings.test.mjs
@@ -86,6 +86,18 @@ ruleTester.run("no-untranslated-strings", noUntranslatedStrings, {
       code: `const C = () => <Button variant="primary" tone="error" size="compact" />;`,
     },
     {
+      name: "ARIA relationships holding element ids are not copy",
+      filename: COMPONENT,
+      code: `const C = () => <input aria-activedescendant={\`\${id}-opt-\${i}\`} aria-controls={\`\${id}-list\`} />;`,
+    },
+    {
+      name: "values joined by punctuation carry no copy of their own",
+      filename: COMPONENT,
+      // Both halves come from elsewhere and the statics are a separator, so
+      // there is nothing here for a translator to receive.
+      code: `const C = () => <span title={\`\${label}: \${cost}\`} />;`,
+    },
+    {
       name: "toast copy read through t()",
       filename: COMPONENT,
       code: `toast.error(t("save.failed"));`,
@@ -128,6 +140,21 @@ ruleTester.run("no-untranslated-strings", noUntranslatedStrings, {
       // the source, so no translator can move the count or the noun.
       code: `const C = () => <span aria-label={\`\${n} files selected\`} />;`,
       errors: [{ messageId: "prop" }],
+    },
+    {
+      name: "a name concatenated with a single lowercase word",
+      filename: COMPONENT,
+      // The static half is one lowercase word, which reads as an enum value
+      // on its own. The string it builds is still assembled in the component.
+      code: `const C = () => <button aria-label={\`\${label} actions\`} />;`,
+      errors: [{ messageId: "prop" }],
+    },
+    {
+      name: "copy chosen inside an interpolation",
+      filename: COMPONENT,
+      // The words sit in the one place the static halves are not.
+      code: `const C = () => <span title={\`\${live ? "Live" : "Draft"} · \${host}\`} />;`,
+      errors: [{ messageId: "prop" }, { messageId: "prop" }],
     },
     {
       name: "a sentence assembled by template literal as a JSX child",

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -1268,12 +1268,16 @@ function RemoteOriginCard({
   /** Opens the remove-from-this-device confirmation, when there is one. */
   onRemove?: () => void;
 }) {
+  const { t } = useTranslation("onboarding");
   const label = originLabel(origin);
+  const subtitleKey = current
+    ? "selectAssistantScreen.currentWithHost"
+    : "selectAssistantScreen.remoteWithHost";
   return (
     <ChooserCard
       icon={icon ?? <Globe className="h-5 w-5" />}
       title={label}
-      subtitle={`${current ? "Current" : "Remote"} · ${originHostname(origin)}`}
+      subtitle={t(subtitleKey, { host: originHostname(origin) })}
       selected={selected}
       tabStop={tabStop}
       onSelect={onSelect}

--- a/clients/web/src/i18n/locales/en/onboarding.json
+++ b/clients/web/src/i18n/locales/en/onboarding.json
@@ -62,7 +62,9 @@
     "rowActionsAriaLabel": "Actions for {name}",
     "removeFromDevice": "Remove from this device…",
     "selfHosted": "Self-hosted",
-    "selfHostedWithHost": "Self-hosted · {host}"
+    "selfHostedWithHost": "Self-hosted · {host}",
+    "currentWithHost": "Current · {host}",
+    "remoteWithHost": "Remote · {host}"
   },
   "hatchingScreen": {
     "apiKeyFailed": "Your API key didn't work",

--- a/clients/web/src/i18n/locales/es/onboarding.json
+++ b/clients/web/src/i18n/locales/es/onboarding.json
@@ -62,7 +62,9 @@
     "rowActionsAriaLabel": "Acciones de {name}",
     "removeFromDevice": "Quitar de este dispositivo…",
     "selfHosted": "Autoalojado",
-    "selfHostedWithHost": "Autoalojado · {host}"
+    "selfHostedWithHost": "Autoalojado · {host}",
+    "currentWithHost": "Actual · {host}",
+    "remoteWithHost": "Remoto · {host}"
   },
   "hatchingScreen": {
     "apiKeyFailed": "Tu clave de API no ha funcionado",


### PR DESCRIPTION
## TL;DR

While converting the sidebar group menu in #40892 I hit an `aria-label` built as `` `${label} actions` `` in an area the i18n ratchet was supposed to be holding. The ratchet was not holding it: `local/no-untranslated-strings` judged a template literal by its static halves using the same test it applies to a plain prop value, so a lone lowercase word left beside an interpolation read as an enum and passed. Copy sitting inside the interpolations was not read at all.

This closes both gaps and fixes the one real violation that surfaced across every enforced path.

## The two gaps

| Shape | Before | After |
| --- | --- | --- |
| `` aria-label={`${label} actions`} `` | Passed. "actions" is one lowercase word, which the prop-level test reads as an enum value | Reported. A template with an interpolation is copy whenever its statics hold letters |
| `` subtitle={`${current ? "Current" : "Remote"} · ${host}`} `` | Passed. Only the statics were read, never the expressions | Reported, once per branch, the same as a ternary written directly on the prop |
| `` title={`${label}: ${cost}`} `` | Passed | Still passes. The statics are a separator, so there is nothing to translate |
| `` aria-activedescendant={`${id}-opt-${i}`} `` | Passed | Still passes, explicitly: the ARIA relationship props join the structural list, since they carry element ids rather than copy |

Four cases were added to `no-untranslated-strings.test.mjs`, two of them `valid`: a rule that fires on legitimate code gets switched off rather than obeyed, and the tightened template test is exactly the kind that could.

## What it surfaced

Exactly one violation across every path in `i18nEnforcedPaths`: the remote-assistant card on the assistant chooser, whose subtitle picked between "Current" and "Remote" and joined the result to a hostname. It now reads a phrase-per-key, the shape the same screen's `selfHostedWithHost` subtitle already uses, so word order and the separator belong to the translator. Spanish is filled in alongside English.

## What this deliberately does not do

There are roughly 77 more concatenated `aria-label` / `title` / `alt` / `placeholder` values in files **outside** the ratchet, across six domains. They are the pre-existing conversion backlog the ratchet exists to work through area by area, and converting a file means converting all of its copy, not just its concatenations. Sweeping them here would put a six-domain mechanical change, and 80-odd new Spanish strings needing real review, in the same PR as a lint rule.

What matters is that they can no longer arrive quietly: each area that joins the ratchet now has these caught at the door, which is what the rule was already meant to do.

## Why it is safe

- The rule change only widens what is reported inside `i18nEnforcedPaths`; unenforced files are untouched by it.
- The single behaviour change is one subtitle, rendering the same English through the catalog.
- `bun run lint` is clean across the workspace (the 16 pre-existing `react-hooks/exhaustive-deps` warnings are unrelated and unchanged), and typecheck is clean on every touched file. The rule's own `RuleTester` cases run in CI.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40896" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->