### PR TITLE
fix(providers): resume pause_turn server-tool turns in the Anthropic client

### DIFF
--- a/assistant/src/providers/anthropic/__tests__/pause-turn-continuation.test.ts
+++ b/assistant/src/providers/anthropic/__tests__/pause-turn-continuation.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, test } from "bun:test";
+
+import type Anthropic from "@anthropic-ai/sdk";
+
+import { AnthropicProvider, MAX_PAUSE_TURN_CONTINUATIONS } from "../client.js";
+
+function makeMessage(overrides: {
+  stop_reason: Anthropic.Message["stop_reason"];
+  content: Anthropic.ContentBlock[];
+  usage?: Partial<Anthropic.Usage>;
+}): Anthropic.Message {
+  return {
+    id: "msg_test",
+    type: "message",
+    role: "assistant",
+    model: "claude-opus-4-6",
+    stop_sequence: null,
+    content: overrides.content,
+    stop_reason: overrides.stop_reason,
+    usage: {
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_creation_input_tokens: null,
+      cache_read_input_tokens: null,
+      ...overrides.usage,
+    } as Anthropic.Usage,
+  } as Anthropic.Message;
+}
+
+function textBlock(text: string): Anthropic.ContentBlock {
+  return { type: "text", text, citations: null } as Anthropic.ContentBlock;
+}
+
+function serverToolUseBlock(id: string): Anthropic.ContentBlock {
+  return {
+    type: "server_tool_use",
+    id,
+    name: "web_search",
+    input: { query: "test" },
+  } as Anthropic.ContentBlock;
+}
+
+/**
+ * Stub the SDK client on a provider instance. Every stream call records its
+ * params and resolves to the next response in `responses` (repeating the last
+ * one once exhausted). Both the plain and beta endpoints share the recorder —
+ * which endpoint fires depends on the model's beta set.
+ */
+function stubProvider(responses: Anthropic.Message[]): {
+  provider: AnthropicProvider;
+  calls: Anthropic.MessageStreamParams[];
+} {
+  const provider = new AnthropicProvider("test-key", "claude-opus-4-6");
+  const calls: Anthropic.MessageStreamParams[] = [];
+  const stream = (params: Anthropic.MessageStreamParams) => {
+    calls.push(params);
+    const response =
+      responses[Math.min(calls.length - 1, responses.length - 1)];
+    return {
+      on() {
+        return this;
+      },
+      async finalMessage() {
+        return response;
+      },
+    };
+  };
+  (provider as unknown as { client: unknown }).client = {
+    baseURL: "https://api.anthropic.com",
+    messages: { stream },
+    beta: { messages: { stream } },
+  };
+  return { provider, calls };
+}
+
+describe("pause_turn continuation", () => {
+  test("resends the paused assistant content as-is and merges the segments", async () => {
+    const pausedContent = [
+      textBlock("Searching..."),
+      serverToolUseBlock("srvtoolu_1"),
+    ];
+    const { provider, calls } = stubProvider([
+      makeMessage({
+        stop_reason: "pause_turn",
+        content: pausedContent,
+        usage: { input_tokens: 10, output_tokens: 5 },
+      }),
+      makeMessage({
+        stop_reason: "end_turn",
+        content: [textBlock("Done")],
+        usage: {
+          input_tokens: 20,
+          output_tokens: 7,
+          cache_creation_input_tokens: 3,
+          cache_read_input_tokens: 4,
+        },
+      }),
+    ]);
+
+    const result = await provider.sendMessage([
+      { role: "user", content: [{ type: "text", text: "search something" }] },
+    ]);
+
+    expect(calls.length).toBe(2);
+    // The continuation appends the paused assistant message unchanged.
+    expect(calls[1].messages.length).toBe(calls[0].messages.length + 1);
+    const appended = calls[1].messages[calls[1].messages.length - 1];
+    expect(appended.role).toBe("assistant");
+    expect(appended.content).toBe(pausedContent);
+
+    // Content is the concatenation of the paused segment and the final one.
+    expect(result.content).toEqual([
+      { type: "text", text: "Searching..." },
+      {
+        type: "server_tool_use",
+        id: "srvtoolu_1",
+        name: "web_search",
+        input: { query: "test" },
+      },
+      { type: "text", text: "Done" },
+    ]);
+    expect(result.stopReason).toBe("end_turn");
+
+    // Usage sums across both billed requests (input includes cache tokens).
+    expect(result.usage.inputTokens).toBe(10 + 20 + 3 + 4);
+    expect(result.usage.outputTokens).toBe(12);
+    expect(result.usage.cacheCreationInputTokens).toBe(3);
+    expect(result.usage.cacheReadInputTokens).toBe(4);
+  });
+
+  test("a turn that never pauses issues a single request", async () => {
+    const { provider, calls } = stubProvider([
+      makeMessage({
+        stop_reason: "end_turn",
+        content: [textBlock("Hi")],
+        usage: { input_tokens: 8, output_tokens: 2 },
+      }),
+    ]);
+
+    const result = await provider.sendMessage([
+      { role: "user", content: [{ type: "text", text: "hello" }] },
+    ]);
+
+    expect(calls.length).toBe(1);
+    expect(result.content).toEqual([{ type: "text", text: "Hi" }]);
+    expect(result.stopReason).toBe("end_turn");
+    expect(result.usage.inputTokens).toBe(8);
+    expect(result.usage.cacheCreationInputTokens).toBeUndefined();
+    expect(result.usage.cacheReadInputTokens).toBeUndefined();
+  });
+
+  test("stops resending at the continuation cap and returns the paused response", async () => {
+    const { provider, calls } = stubProvider([
+      makeMessage({
+        stop_reason: "pause_turn",
+        content: [serverToolUseBlock("srvtoolu_stuck")],
+        usage: { input_tokens: 1, output_tokens: 1 },
+      }),
+    ]);
+
+    const result = await provider.sendMessage([
+      { role: "user", content: [{ type: "text", text: "search forever" }] },
+    ]);
+
+    expect(calls.length).toBe(1 + MAX_PAUSE_TURN_CONTINUATIONS);
+    expect(result.stopReason).toBe("pause_turn");
+    // Every billed request's usage is accounted for.
+    expect(result.usage.inputTokens).toBe(1 + MAX_PAUSE_TURN_CONTINUATIONS);
+  });
+});

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -48,6 +48,18 @@ const log = getLogger("anthropic-client");
 const VALIDATION_TIMEOUT_MS = 10_000;
 
 /**
+ * Cap on `pause_turn` continuations within one `sendMessage` call. The API
+ * pauses a long-running server-tool turn (e.g. web search) with
+ * `stop_reason: "pause_turn"`; the client resumes it by re-sending the paused
+ * assistant content as-is. The cap bounds pathological pause loops; web
+ * search allows `max_uses: 5` per turn, so 6 leaves headroom for one pause
+ * per search. On cap-out the response is returned as-is and the deferred-tail
+ * preservation in `analyzeServerToolPairing` keeps any unresolved
+ * `server_tool_use` blocks intact for a later request.
+ */
+export const MAX_PAUSE_TURN_CONTINUATIONS = 6;
+
+/**
  * Detect Anthropic's `prompt_too_long` context-overflow signal.
  *
  * Anthropic returns HTTP 400 with a body shaped as
@@ -1357,6 +1369,10 @@ export class AnthropicProvider implements Provider {
       }
 
       let response: Anthropic.Message;
+      // Paused segments accumulated by the `pause_turn` continuation loop,
+      // in stream order, excluding the final response. Empty for the normal
+      // single-request case.
+      const pausedSegments: Anthropic.Message[] = [];
       try {
         recordProviderRequestDiagnostics({ model_id: params.model });
         const requestHeaders = {
@@ -1369,284 +1385,359 @@ export class AnthropicProvider implements Provider {
             ? { headers: requestHeaders }
             : {}),
         };
-        const stream: UnifiedStream = useFastMode
-          ? (this.client.beta.messages.stream(
-              {
-                ...(params as Record<string, unknown>),
-                speed: "fast" as const,
-                betas,
-              } as Anthropic.Beta.Messages.MessageCreateParamsNonStreaming &
-                Anthropic.Beta.Messages.MessageCreateParamsStreaming,
-              requestOptions,
-            ) as unknown as UnifiedStream)
-          : betas.length > 0
+        // Issue one streaming request and return its final message. A local
+        // helper so `pause_turn` continuations get fresh listener state per
+        // request (content shadow, text sentinel buffer, tool-input
+        // accumulators) instead of inheriting a prior segment's buffers.
+        const streamOnce = async (
+          streamParams: Anthropic.MessageStreamParams,
+        ): Promise<Anthropic.Message> => {
+          const stream: UnifiedStream = useFastMode
             ? (this.client.beta.messages.stream(
                 {
-                  ...(params as Record<string, unknown>),
+                  ...(streamParams as Record<string, unknown>),
+                  speed: "fast" as const,
                   betas,
                 } as Anthropic.Beta.Messages.MessageCreateParamsNonStreaming &
                   Anthropic.Beta.Messages.MessageCreateParamsStreaming,
                 requestOptions,
               ) as unknown as UnifiedStream)
-            : (this.client.messages.stream(
-                params,
-                requestOptions,
-              ) as unknown as UnifiedStream);
+            : betas.length > 0
+              ? (this.client.beta.messages.stream(
+                  {
+                    ...(streamParams as Record<string, unknown>),
+                    betas,
+                  } as Anthropic.Beta.Messages.MessageCreateParamsNonStreaming &
+                    Anthropic.Beta.Messages.MessageCreateParamsStreaming,
+                  requestOptions,
+                ) as unknown as UnifiedStream)
+              : (this.client.messages.stream(
+                  streamParams,
+                  requestOptions,
+                ) as unknown as UnifiedStream);
 
-        // Shadow the streamed content blocks so a mid-stream SDK accumulator
-        // failure on malformed tool-argument JSON can be salvaged instead of
-        // discarding the whole response (see StreamContentShadow).
-        const contentShadow = new StreamContentShadow();
+          // Shadow the streamed content blocks so a mid-stream SDK accumulator
+          // failure on malformed tool-argument JSON can be salvaged instead of
+          // discarding the whole response (see StreamContentShadow).
+          const contentShadow = new StreamContentShadow();
 
-        // Buffer streaming text until it's clear the accumulated text isn't
-        // going to form a placeholder sentinel. Sentinels are injected into
-        // outbound requests for role alternation and are sometimes echoed by
-        // the model — including an echo whose `\x00` guard arrived as a leading
-        // space — so the prefix and completion checks normalize edge whitespace
-        // and control bytes (the same normalization cleanAssistantContent and
-        // the display serializer use). Holding back partial prefixes keeps them
-        // off the live UI before they are stripped at completion. The buffer
-        // resets on every content_block_start.
-        let textBuffer = "";
+          // Buffer streaming text until it's clear the accumulated text isn't
+          // going to form a placeholder sentinel. Sentinels are injected into
+          // outbound requests for role alternation and are sometimes echoed by
+          // the model — including an echo whose `\x00` guard arrived as a leading
+          // space — so the prefix and completion checks normalize edge whitespace
+          // and control bytes (the same normalization cleanAssistantContent and
+          // the display serializer use). Holding back partial prefixes keeps them
+          // off the live UI before they are stripped at completion. The buffer
+          // resets on every content_block_start.
+          let textBuffer = "";
 
-        stream.on("text", (text) => {
-          textBuffer += text;
-          if (couldBePlaceholderSentinelPrefix(textBuffer)) {
-            return;
-          }
-          onEvent?.({ type: "text_delta", text: textBuffer });
-          textBuffer = "";
-        });
-
-        stream.on("thinking", (thinking) => {
-          onEvent?.({ type: "thinking_delta", thinking });
-        });
-
-        // Track which tool is currently streaming so we can attribute inputJson deltas.
-        let currentStreamingToolName: string | undefined;
-        let currentStreamingToolUseId: string | undefined;
-        let accumulatedInputJson = "";
-        let lastInputJsonEmitMs = 0;
-        let pendingInputJsonFlush: ReturnType<typeof setTimeout> | undefined;
-
-        // Anthropic streams `server_tool_use` block input via `input_json_delta`
-        // events (the block's own `input` field is `{}` at content_block_start).
-        // We accumulate the JSON separately from regular `tool_use` blocks so
-        // the daemon can read the resolved query when the paired
-        // `web_search_tool_result` arrives — without this, downstream activity
-        // metadata sees an empty query.
-        let currentServerToolUseId: string | undefined;
-        let accumulatedServerToolInputJson = "";
-        const resolvedServerToolInputs = new Map<
-          string,
-          Record<string, unknown>
-        >();
-
-        stream.on("streamEvent", (event) => {
-          contentShadow.handleEvent(event as ShadowStreamEvent);
-          // Reset the text sentinel buffer at each content-block boundary.
-          // A new block starts fresh; at the end of a block, flush any
-          // buffered text that is NOT a complete sentinel, and drop it if
-          // it is one.
-          if (event.type === "content_block_start") {
-            textBuffer = "";
-          }
-          if (
-            event.type === "content_block_start" &&
-            event.content_block.type === "tool_use"
-          ) {
-            currentStreamingToolName = event.content_block.name;
-            currentStreamingToolUseId = event.content_block.id;
-            accumulatedInputJson = "";
-            lastInputJsonEmitMs = 0;
-            onEvent?.({
-              type: "tool_use_preview_start",
-              toolUseId: event.content_block.id,
-              toolName: event.content_block.name,
-            });
-          }
-          if (
-            event.type === "content_block_start" &&
-            event.content_block.type === "server_tool_use"
-          ) {
-            currentServerToolUseId = event.content_block.id;
-            accumulatedServerToolInputJson = "";
-            onEvent?.({
-              type: "server_tool_start",
-              name: event.content_block.name,
-              toolUseId: event.content_block.id,
-              input:
-                (event.content_block as { input?: Record<string, unknown> })
-                  .input ?? {},
-            });
-          }
-          if (
-            event.type === "content_block_start" &&
-            event.content_block.type === "web_search_tool_result"
-          ) {
-            const block = event.content_block as {
-              tool_use_id: string;
-              content?:
-                | { type: "web_search_tool_result_error"; error_code?: string }
-                | unknown[];
-            };
-            const isError =
-              !Array.isArray(block.content) &&
-              block.content?.type === "web_search_tool_result_error";
-            const errorCode =
-              isError && !Array.isArray(block.content)
-                ? block.content?.error_code
-                : undefined;
-            const resolvedInput = resolvedServerToolInputs.get(
-              block.tool_use_id,
-            );
-            resolvedServerToolInputs.delete(block.tool_use_id);
-            onEvent?.({
-              type: "server_tool_complete",
-              toolUseId: block.tool_use_id,
-              isError: !!isError,
-              ...(Array.isArray(block.content)
-                ? { content: block.content }
-                : {}),
-              ...(resolvedInput ? { resolvedInput } : {}),
-              ...(errorCode ? { errorCode } : {}),
-            });
-          }
-          if (event.type === "content_block_stop") {
-            if (pendingInputJsonFlush) {
-              clearTimeout(pendingInputJsonFlush);
-              pendingInputJsonFlush = undefined;
+          stream.on("text", (text) => {
+            textBuffer += text;
+            if (couldBePlaceholderSentinelPrefix(textBuffer)) {
+              return;
             }
-            if (currentStreamingToolName && accumulatedInputJson) {
+            onEvent?.({ type: "text_delta", text: textBuffer });
+            textBuffer = "";
+          });
+
+          stream.on("thinking", (thinking) => {
+            onEvent?.({ type: "thinking_delta", thinking });
+          });
+
+          // Track which tool is currently streaming so we can attribute inputJson deltas.
+          let currentStreamingToolName: string | undefined;
+          let currentStreamingToolUseId: string | undefined;
+          let accumulatedInputJson = "";
+          let lastInputJsonEmitMs = 0;
+          let pendingInputJsonFlush: ReturnType<typeof setTimeout> | undefined;
+
+          // Anthropic streams `server_tool_use` block input via `input_json_delta`
+          // events (the block's own `input` field is `{}` at content_block_start).
+          // We accumulate the JSON separately from regular `tool_use` blocks so
+          // the daemon can read the resolved query when the paired
+          // `web_search_tool_result` arrives — without this, downstream activity
+          // metadata sees an empty query.
+          let currentServerToolUseId: string | undefined;
+          let accumulatedServerToolInputJson = "";
+          const resolvedServerToolInputs = new Map<
+            string,
+            Record<string, unknown>
+          >();
+
+          stream.on("streamEvent", (event) => {
+            contentShadow.handleEvent(event as ShadowStreamEvent);
+            // Reset the text sentinel buffer at each content-block boundary.
+            // A new block starts fresh; at the end of a block, flush any
+            // buffered text that is NOT a complete sentinel, and drop it if
+            // it is one.
+            if (event.type === "content_block_start") {
+              textBuffer = "";
+            }
+            if (
+              event.type === "content_block_start" &&
+              event.content_block.type === "tool_use"
+            ) {
+              currentStreamingToolName = event.content_block.name;
+              currentStreamingToolUseId = event.content_block.id;
+              accumulatedInputJson = "";
+              lastInputJsonEmitMs = 0;
+              onEvent?.({
+                type: "tool_use_preview_start",
+                toolUseId: event.content_block.id,
+                toolName: event.content_block.name,
+              });
+            }
+            if (
+              event.type === "content_block_start" &&
+              event.content_block.type === "server_tool_use"
+            ) {
+              currentServerToolUseId = event.content_block.id;
+              accumulatedServerToolInputJson = "";
+              onEvent?.({
+                type: "server_tool_start",
+                name: event.content_block.name,
+                toolUseId: event.content_block.id,
+                input:
+                  (event.content_block as { input?: Record<string, unknown> })
+                    .input ?? {},
+              });
+            }
+            if (
+              event.type === "content_block_start" &&
+              event.content_block.type === "web_search_tool_result"
+            ) {
+              const block = event.content_block as {
+                tool_use_id: string;
+                content?:
+                  | {
+                      type: "web_search_tool_result_error";
+                      error_code?: string;
+                    }
+                  | unknown[];
+              };
+              const isError =
+                !Array.isArray(block.content) &&
+                block.content?.type === "web_search_tool_result_error";
+              const errorCode =
+                isError && !Array.isArray(block.content)
+                  ? block.content?.error_code
+                  : undefined;
+              const resolvedInput = resolvedServerToolInputs.get(
+                block.tool_use_id,
+              );
+              resolvedServerToolInputs.delete(block.tool_use_id);
+              onEvent?.({
+                type: "server_tool_complete",
+                toolUseId: block.tool_use_id,
+                isError: !!isError,
+                ...(Array.isArray(block.content)
+                  ? { content: block.content }
+                  : {}),
+                ...(resolvedInput ? { resolvedInput } : {}),
+                ...(errorCode ? { errorCode } : {}),
+              });
+            }
+            if (event.type === "content_block_stop") {
+              if (pendingInputJsonFlush) {
+                clearTimeout(pendingInputJsonFlush);
+                pendingInputJsonFlush = undefined;
+              }
+              if (currentStreamingToolName && accumulatedInputJson) {
+                onEvent?.({
+                  type: "input_json_delta",
+                  toolName: currentStreamingToolName,
+                  toolUseId: currentStreamingToolUseId!,
+                  accumulatedJson: accumulatedInputJson,
+                });
+              }
+              currentStreamingToolName = undefined;
+              currentStreamingToolUseId = undefined;
+              accumulatedInputJson = "";
+              // Finalize the resolved input for a `server_tool_use` block (e.g.
+              // the actual web-search query) so the paired `web_search_tool_result`
+              // emits `server_tool_complete` with `resolvedInput` populated.
+              if (currentServerToolUseId && accumulatedServerToolInputJson) {
+                try {
+                  const parsed = JSON.parse(accumulatedServerToolInputJson);
+                  if (parsed && typeof parsed === "object") {
+                    resolvedServerToolInputs.set(
+                      currentServerToolUseId,
+                      parsed as Record<string, unknown>,
+                    );
+                  }
+                } catch {
+                  // Malformed partial JSON — drop silently; downstream falls
+                  // back to whatever was captured at server_tool_start.
+                }
+              }
+              currentServerToolUseId = undefined;
+              accumulatedServerToolInputJson = "";
+              // Flush residual text buffer unless it is a sentinel.
+              if (
+                textBuffer.length > 0 &&
+                !isPlaceholderSentinelText(textBuffer)
+              ) {
+                onEvent?.({ type: "text_delta", text: textBuffer });
+              }
+              textBuffer = "";
+            }
+          });
+
+          stream.on("inputJson", (partialJson) => {
+            if (currentServerToolUseId) {
+              // Server-tool input (e.g. `web_search` query) — accumulate without
+              // emitting `input_json_delta`; the daemon only consumes the
+              // finalized value from `server_tool_complete.resolvedInput`.
+              accumulatedServerToolInputJson += partialJson;
+              return;
+            }
+            if (!currentStreamingToolName) {
+              return;
+            }
+            accumulatedInputJson += partialJson;
+            const now = Date.now();
+            if (now - lastInputJsonEmitMs >= 150) {
+              lastInputJsonEmitMs = now;
+              if (pendingInputJsonFlush) {
+                clearTimeout(pendingInputJsonFlush);
+                pendingInputJsonFlush = undefined;
+              }
               onEvent?.({
                 type: "input_json_delta",
                 toolName: currentStreamingToolName,
                 toolUseId: currentStreamingToolUseId!,
                 accumulatedJson: accumulatedInputJson,
               });
-            }
-            currentStreamingToolName = undefined;
-            currentStreamingToolUseId = undefined;
-            accumulatedInputJson = "";
-            // Finalize the resolved input for a `server_tool_use` block (e.g.
-            // the actual web-search query) so the paired `web_search_tool_result`
-            // emits `server_tool_complete` with `resolvedInput` populated.
-            if (currentServerToolUseId && accumulatedServerToolInputJson) {
-              try {
-                const parsed = JSON.parse(accumulatedServerToolInputJson);
-                if (parsed && typeof parsed === "object") {
-                  resolvedServerToolInputs.set(
-                    currentServerToolUseId,
-                    parsed as Record<string, unknown>,
-                  );
+            } else if (!pendingInputJsonFlush) {
+              const toolName = currentStreamingToolName;
+              const toolUseId = currentStreamingToolUseId!;
+              pendingInputJsonFlush = setTimeout(() => {
+                pendingInputJsonFlush = undefined;
+                lastInputJsonEmitMs = Date.now();
+                if (currentStreamingToolName === toolName) {
+                  onEvent?.({
+                    type: "input_json_delta",
+                    toolName,
+                    toolUseId,
+                    accumulatedJson: accumulatedInputJson,
+                  });
                 }
-              } catch {
-                // Malformed partial JSON — drop silently; downstream falls
-                // back to whatever was captured at server_tool_start.
-              }
+              }, 150);
             }
-            currentServerToolUseId = undefined;
-            accumulatedServerToolInputJson = "";
-            // Flush residual text buffer unless it is a sentinel.
-            if (
-              textBuffer.length > 0 &&
-              !isPlaceholderSentinelText(textBuffer)
-            ) {
-              onEvent?.({ type: "text_delta", text: textBuffer });
-            }
-            textBuffer = "";
-          }
-        });
+          });
 
-        stream.on("inputJson", (partialJson) => {
-          if (currentServerToolUseId) {
-            // Server-tool input (e.g. `web_search` query) — accumulate without
-            // emitting `input_json_delta`; the daemon only consumes the
-            // finalized value from `server_tool_complete.resolvedInput`.
-            accumulatedServerToolInputJson += partialJson;
-            return;
-          }
-          if (!currentStreamingToolName) {
-            return;
-          }
-          accumulatedInputJson += partialJson;
-          const now = Date.now();
-          if (now - lastInputJsonEmitMs >= 150) {
-            lastInputJsonEmitMs = now;
-            if (pendingInputJsonFlush) {
-              clearTimeout(pendingInputJsonFlush);
-              pendingInputJsonFlush = undefined;
+          try {
+            return await stream.finalMessage();
+          } catch (error) {
+            // The SDK rejects finalMessage() the moment a tool_use block's
+            // argument JSON stops parsing, discarding everything it streamed.
+            // Salvage the observed prefix instead: completed blocks plus the
+            // malformed call wrapped under `_raw`, which the tool layer bounces
+            // back to the model as an error tool_result so it can self-correct
+            // in the next iteration. Any other rejection rethrows untouched.
+            const salvaged = contentShadow.salvage(error);
+            if (salvaged === undefined) {
+              throw error;
             }
-            onEvent?.({
-              type: "input_json_delta",
-              toolName: currentStreamingToolName,
-              toolUseId: currentStreamingToolUseId!,
-              accumulatedJson: accumulatedInputJson,
-            });
-          } else if (!pendingInputJsonFlush) {
-            const toolName = currentStreamingToolName;
-            const toolUseId = currentStreamingToolUseId!;
-            pendingInputJsonFlush = setTimeout(() => {
-              pendingInputJsonFlush = undefined;
-              lastInputJsonEmitMs = Date.now();
-              if (currentStreamingToolName === toolName) {
-                onEvent?.({
-                  type: "input_json_delta",
-                  toolName,
-                  toolUseId,
-                  accumulatedJson: accumulatedInputJson,
-                });
-              }
-            }, 150);
+            log.warn(
+              {
+                model: streamParams.model,
+                toolName: salvaged.toolName,
+                rawArgsLength: salvaged.rawArgsLength,
+              },
+              "Salvaged stream with unparseable tool-call arguments; returning _raw-wrapped tool call",
+            );
+            return {
+              ...salvaged.message,
+              model: streamParams.model,
+            } as unknown as Anthropic.Message;
           }
-        });
+        };
 
-        try {
-          response = await stream.finalMessage();
-        } catch (error) {
-          // The SDK rejects finalMessage() the moment a tool_use block's
-          // argument JSON stops parsing, discarding everything it streamed.
-          // Salvage the observed prefix instead: completed blocks plus the
-          // malformed call wrapped under `_raw`, which the tool layer bounces
-          // back to the model as an error tool_result so it can self-correct
-          // in the next iteration. Any other rejection rethrows untouched.
-          const salvaged = contentShadow.salvage(error);
-          if (salvaged === undefined) {
-            throw error;
-          }
-          log.warn(
+        response = await streamOnce(params);
+
+        // `pause_turn`: the API paused a long-running server-tool turn (e.g.
+        // web search) mid-execution. The documented resume flow is to re-send
+        // the paused assistant content as-is in a follow-up request; the
+        // model then continues the same turn. Each paused segment is kept so
+        // the returned response carries the full turn's content and summed
+        // usage. On cap-out the paused response returns as-is — downstream
+        // deferred-tail preservation keeps its unresolved `server_tool_use`
+        // blocks intact.
+        while (
+          response.stop_reason === "pause_turn" &&
+          pausedSegments.length < MAX_PAUSE_TURN_CONTINUATIONS
+        ) {
+          pausedSegments.push(response);
+          log.info(
             {
               model: params.model,
-              toolName: salvaged.toolName,
-              rawArgsLength: salvaged.rawArgsLength,
+              continuation: pausedSegments.length,
+              contentBlocks: response.content.length,
             },
-            "Salvaged stream with unparseable tool-call arguments; returning _raw-wrapped tool call",
+            "Anthropic pause_turn — re-sending paused assistant content to resume the turn",
           );
-          response = {
-            ...salvaged.message,
-            model: params.model,
-          } as unknown as Anthropic.Message;
+          params = {
+            ...params,
+            messages: [
+              ...params.messages,
+              { role: "assistant" as const, content: response.content },
+            ],
+          };
+          // Keep the 400-diagnostics dump in the catch block accurate for
+          // continuation requests.
+          sentMessages = params.messages;
+          response = await streamOnce(params);
+        }
+        if (response.stop_reason === "pause_turn") {
+          log.warn(
+            { model: params.model, continuations: pausedSegments.length },
+            "Anthropic pause_turn continuation cap reached; returning paused response as-is",
+          );
         }
       } finally {
         cleanupTimeout();
       }
 
+      // A paused turn spans several billed requests: the assistant content is
+      // every paused segment's content followed by the final response's, and
+      // usage sums across all of them. With no paused segments this reduces
+      // to the single response.
+      const segments = [...pausedSegments, response];
+      const sumOptional = (
+        values: Array<number | null | undefined>,
+      ): number | undefined =>
+        values.some((v) => typeof v === "number")
+          ? values.reduce<number>((acc, v) => acc + (v ?? 0), 0)
+          : undefined;
       return {
-        content: response.content.map((block) =>
-          this.fromAnthropicBlock(block),
-        ),
+        content: segments
+          .flatMap((segment) => segment.content)
+          .map((block) => this.fromAnthropicBlock(block)),
         model: response.model,
         resolvedEndpoint: this.client.baseURL,
         usage: {
-          inputTokens:
-            response.usage.input_tokens +
-            (response.usage.cache_creation_input_tokens ?? 0) +
-            (response.usage.cache_read_input_tokens ?? 0),
-          outputTokens: response.usage.output_tokens,
-          cacheCreationInputTokens:
-            response.usage.cache_creation_input_tokens ?? undefined,
-          cacheReadInputTokens:
-            response.usage.cache_read_input_tokens ?? undefined,
+          inputTokens: segments.reduce(
+            (acc, segment) =>
+              acc +
+              segment.usage.input_tokens +
+              (segment.usage.cache_creation_input_tokens ?? 0) +
+              (segment.usage.cache_read_input_tokens ?? 0),
+            0,
+          ),
+          outputTokens: segments.reduce(
+            (acc, segment) => acc + segment.usage.output_tokens,
+            0,
+          ),
+          cacheCreationInputTokens: sumOptional(
+            segments.map(
+              (segment) => segment.usage.cache_creation_input_tokens,
+            ),
+          ),
+          cacheReadInputTokens: sumOptional(
+            segments.map((segment) => segment.usage.cache_read_input_tokens),
+          ),
         },
         stopReason: response.stop_reason ?? "unknown",
         rawRequest: params,


### PR DESCRIPTION
## Summary
- Handle `stop_reason: "pause_turn"` in `AnthropicProvider.sendMessage`: re-send the paused assistant content as-is in a continuation request (the documented resume flow for long-running server tools like web search), in a loop bounded by `MAX_PAUSE_TURN_CONTINUATIONS` (6) and the existing per-call stream timeout.
- The single-request streaming section is factored into a local `streamOnce` helper so each continuation gets fresh listener state (content shadow, text sentinel buffer, tool-input accumulators); the returned `ProviderResponse` concatenates every paused segment's content and sums usage across all billed requests, reducing to the previous behavior when no pause occurs.
- On cap-out the paused response is returned as-is; the deferred-tail preservation from #40137 keeps unresolved `server_tool_use` blocks intact for a later request. Tests cover the resume flow (content merge, as-is re-send, usage summing), the no-pause baseline, and the cap.

## Original prompt
Follow-up to #40137 (deferred server-tool execution): the daemon had no handling for Anthropic's `pause_turn` stop reason, so a paused server-tool turn was treated as finished — partial response persisted, no continuation, and the in-flight search never resumed. The exposure grew once #40137 went live and searches actually execute. The ask was to recognize `pause_turn`, re-send the paused assistant message as-is with bounded retries per Anthropic's server-tools documentation, and add tests.

Closes #40145

🤖 Generated with [Claude Code](https://claude.com/claude-code)