### PR TITLE
fix(web): stop the file picker summoning a keyboard nobody asked for

### DIFF
--- a/clients/web/src/domains/chat/components/chat-attachments/use-attachment-file-picker.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/use-attachment-file-picker.test.tsx
@@ -13,8 +13,33 @@ import { cleanup, fireEvent, render } from "@testing-library/react";
 // Mock the focus seam so we can assert the request without mounting the whole
 // composer/keyboard machinery.
 const requestComposerFocusMock = mock(() => {});
+// Whether a text entry held focus when the picker opened, which is what says
+// there is a keyboard to put back. Stubbed rather than driven through real
+// focus so each case states its own answer.
+let textEntryFocused = false;
 mock.module("@/domains/chat/composer-focus", () => ({
   requestComposerFocus: requestComposerFocusMock,
+  isTextEntryFocused: () => textEntryFocused,
+}));
+
+// The dismissal WebKit is going to perform anyway, brought forward to the tap.
+const hideNativeKeyboardMock = mock(async () => {});
+mock.module("@/runtime/native-keyboard", () => ({
+  hideNativeKeyboard: hideNativeKeyboardMock,
+}));
+
+// The native shell, where `cancel` is guaranteed and the window-focus fallback
+// is not armed. Defaults to the browser, so the existing cases keep it.
+let nativeIOS = false;
+mock.module("@/runtime/platform-detection", () => ({
+  isNativeIOS: () => nativeIOS,
+}));
+
+// A phone versus a pointing device. Defaults to a mouse, which is always owed
+// its caret back, so the cases predating the focus gate stay as they were.
+let pointerCoarse = false;
+mock.module("@/utils/pointer", () => ({
+  isPointerCoarse: () => pointerCoarse,
 }));
 
 import { selectFiles } from "@/domains/chat/components/chat-attachments/attachment-test-helpers";
@@ -28,10 +53,15 @@ afterEach(() => {
 });
 beforeEach(() => {
   requestComposerFocusMock.mockClear();
+  hideNativeKeyboardMock.mockClear();
+  textEntryFocused = false;
+  nativeIOS = false;
+  pointerCoarse = false;
 });
 
 function PickerProbe(props: {
   onFiles: (files: FileList) => void;
+  alwaysRestoreFocus?: boolean;
   multiple?: boolean;
   accept?: string;
   capture?: boolean | "user" | "environment";
@@ -155,6 +185,98 @@ describe("useAttachmentFilePicker", () => {
 
     // THEN the flag follows that path out as well
     expect(openState()).toBe("false");
+  });
+
+  test("a phone picker opened from a resting composer restores nothing", () => {
+    // GIVEN a phone whose composer was not focused when the plus was pressed,
+    // so no keyboard was taken and none is owed
+    pointerCoarse = true;
+    textEntryFocused = false;
+    const { input, open } = renderPicker({ onFiles: () => {} });
+    open();
+
+    // WHEN the picker is dismissed
+    fireEvent(input, new Event("cancel"));
+
+    // THEN the composer is left alone. Focusing it here would summon a
+    // keyboard the user never asked for, which the shell allows without a
+    // gesture.
+    expect(requestComposerFocusMock).not.toHaveBeenCalled();
+  });
+
+  test("a phone picker opened from a focused composer restores it", () => {
+    // GIVEN a phone whose composer held the keyboard when the plus was pressed
+    pointerCoarse = true;
+    textEntryFocused = true;
+    const { input, open } = renderPicker({ onFiles: () => {} });
+    open();
+
+    // WHEN the picker is dismissed
+    fireEvent(input, new Event("cancel"));
+
+    // THEN the keyboard the picker took comes back
+    expect(requestComposerFocusMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("a pointing device is always owed its caret back", () => {
+    // GIVEN a desktop picker, where the button itself takes the focus on the
+    // way in so nothing reads as focused
+    pointerCoarse = false;
+    textEntryFocused = false;
+    const { input, open } = renderPicker({ onFiles: () => {} });
+    open();
+
+    // WHEN a file is picked
+    selectFile(input);
+
+    // THEN the caret returns to the composer, as it always has
+    expect(requestComposerFocusMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("alwaysRestoreFocus overrides the sample for a caller that traps focus", () => {
+    // GIVEN the add-to-chat sheet's case: a phone, and a sheet holding focus
+    // by the time its row launches the picker
+    pointerCoarse = true;
+    textEntryFocused = false;
+    const { input, open } = renderPicker({
+      onFiles: () => {},
+      alwaysRestoreFocus: true,
+    });
+    open();
+
+    // WHEN the picker closes
+    fireEvent(input, new Event("cancel"));
+
+    // THEN the keyboard still returns, the way it does today
+    expect(requestComposerFocusMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("the native shell leaves the window-focus fallback unarmed", () => {
+    // GIVEN the iOS shell, which builds against an OS whose WKWebView always
+    // fires `cancel`
+    nativeIOS = true;
+    pointerCoarse = true;
+    textEntryFocused = true;
+    const { open } = renderPicker({ onFiles: () => {} });
+    open();
+
+    // WHEN the app is merely foregrounded, with the picker still on screen
+    fireEvent(window, new Event("focus"));
+
+    // THEN nothing treats that as the picker closing
+    expect(requestComposerFocusMock).not.toHaveBeenCalled();
+  });
+
+  test("the picker asks the keyboard to go before it opens", () => {
+    // GIVEN any picker
+    const { open } = renderPicker({ onFiles: () => {} });
+
+    // WHEN it opens
+    open();
+
+    // THEN the dismissal starts with the tap rather than landing a beat later
+    // out of the picker's own presentation animation
+    expect(hideNativeKeyboardMock).toHaveBeenCalledTimes(1);
   });
 
   test("mirrors accept, capture, and multiple onto the input", () => {

--- a/clients/web/src/domains/chat/components/chat-attachments/use-attachment-file-picker.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/use-attachment-file-picker.tsx
@@ -8,7 +8,13 @@ import {
   useState,
 } from "react";
 
-import { requestComposerFocus } from "@/domains/chat/composer-focus";
+import {
+  isTextEntryFocused,
+  requestComposerFocus,
+} from "@/domains/chat/composer-focus";
+import { hideNativeKeyboard } from "@/runtime/native-keyboard";
+import { isNativeIOS } from "@/runtime/platform-detection";
+import { isPointerCoarse } from "@/utils/pointer";
 
 interface UseAttachmentFilePickerOptions {
   /** Receives the picked files. Not called when the picker closes empty. */
@@ -19,6 +25,14 @@ interface UseAttachmentFilePickerOptions {
   accept?: string;
   /** `capture` attribute, e.g. `"environment"` for the rear camera. */
   capture?: boolean | "user" | "environment";
+  /**
+   * Restore the composer's focus on close whatever held it when the picker
+   * opened. For a caller that takes focus itself on the way to the picker: the
+   * add-to-chat sheet traps focus, so the open-time sample would always read
+   * "nothing to put back" and the sheet would stop returning a keyboard it
+   * returns today.
+   */
+  alwaysRestoreFocus?: boolean;
 }
 
 interface UseAttachmentFilePickerResult {
@@ -41,35 +55,41 @@ interface UseAttachmentFilePickerResult {
  * `openPicker()` from their own trigger.
  *
  * On iOS (Capacitor WKWebView), clicking the hidden `<input type="file">`
- * presents the native document/photo picker, which resigns the web view's
- * first responder, dismissing the soft keyboard and collapsing the
- * keyboard-aware layout (`root-layout.tsx` sizes the shell from
- * `visualViewport`). The native picker and the keyboard are mutually
- * exclusive first responders, so the keyboard cannot stay up *during* the
- * picker. Instead we re-focus the composer the moment the picker closes,
- * keyed off the file input's own events so the signal is tied to the picker
- * (not to app foregrounding, which also fires when the app is backgrounded
- * and returned to while the picker is still open):
+ * presents the native document/photo picker, and WebKit resigns the web
+ * view's first responder to do it: `WKFileUploadPanel.mm` resigns in the
+ * completion handlers of both the file menu's display animation and the
+ * picker's presentation. The keyboard therefore cannot stay up during the
+ * picker, and no input attribute, plugin call or config reaches that decision.
+ * `hideNativeKeyboard()` only brings the dismissal forward to the tap, so it
+ * reads as part of pressing the button rather than as the picker taking
+ * something a beat later.
+ *
+ * The way back is a DOM focus: `Keyboard.show()` is Android only, while the
+ * Capacitor shell disables `keyboardShouldRequireUserInteraction`, so
+ * focusing the textarea raises the keyboard with no gesture. Which is also why
+ * that focus is gated. It restores a keyboard the picker took; it must not
+ * conjure one for a composer that was resting when the plus was pressed, so
+ * `openPicker` samples who held focus before the click and the close paths
+ * honour the answer. See `alwaysRestoreFocus` for the caller that has to
+ * override it.
+ *
+ * Close signals, in order of precision:
  *
  * - `change`: a file was selected.
  * - `cancel`: the picker was dismissed without a selection (WebKit / Safari
  *   16.4+). Precise: tied to the picker dismissal itself.
- * - one-shot `window` `focus`: fallback for iOS 15 through 16.3 WKWebViews
- *   (the app's deployment target is iOS 15) that predate the `cancel` event.
- *   Armed on picker open and removed after firing once, so a later real
- *   `cancel` on newer engines still works and the fallback can't linger.
- *   `focus` fires when the web view regains first responder as the picker
- *   closes.
- *
- * `requestComposerFocus()` is idempotent and a no-op on desktop (the textarea
- * is already focused there and the OS file dialog doesn't steal focus), so
- * running it from more than one of these paths is harmless.
+ * - one-shot `window` `focus`: for engines predating `cancel`, and armed off
+ *   the native iOS shell only. That shell builds against iOS 17 and WKWebView
+ *   tracks the OS, so `cancel` is always there; arming this too would add a
+ *   close signal that also fires on plain app foregrounding, ending the
+ *   session while the picker is still on screen.
  */
 export function useAttachmentFilePicker({
   onFiles,
   multiple = false,
   accept,
   capture,
+  alwaysRestoreFocus = false,
 }: UseAttachmentFilePickerOptions): UseAttachmentFilePickerResult {
   const inputRef = useRef<HTMLInputElement | null>(null);
   // The picker's own lifetime, which outlives the composer's focus: presenting
@@ -88,13 +108,20 @@ export function useAttachmentFilePicker({
   // Held in a ref so every picker-close path (change, cancel, unmount) can
   // disarm it, not just a window focus event.
   const disarmFocusFallbackRef = useRef<(() => void) | null>(null);
+  // Whether the close paths owe the composer a keyboard, answered when the
+  // picker opens. Restoring focus is only restoring when something had it:
+  // a plus pressed on a resting composer never had a keyboard, and focusing
+  // the textarea on the way out summons one nobody asked for.
+  const shouldRestoreFocusRef = useRef(true);
 
   const refocusComposer = useCallback(() => {
     // Any picker-close path lands here: disarm the pending focus fallback so it
     // can't fire on a later unrelated window focus, then restore the keyboard.
     disarmFocusFallbackRef.current?.();
     disarmFocusFallbackRef.current = null;
-    requestComposerFocus();
+    if (shouldRestoreFocusRef.current) {
+      requestComposerFocus();
+    }
     setPickerOpen(false);
   }, []);
 
@@ -105,13 +132,32 @@ export function useAttachmentFilePicker({
     // `cancel`/`change` paths fire first and disarm this via refocusComposer,
     // so it never lingers past the picker session.
     disarmFocusFallbackRef.current?.();
-    const onFocus = () => refocusComposer();
-    window.addEventListener("focus", onFocus, { once: true });
-    disarmFocusFallbackRef.current = () =>
-      window.removeEventListener("focus", onFocus);
+    // Sampled before the click, since presenting the picker is what takes the
+    // focus being asked about. A pointing device focuses the control it
+    // presses, so a desktop picker reads as unfocused and is always owed its
+    // caret back.
+    shouldRestoreFocusRef.current =
+      alwaysRestoreFocus || !isPointerCoarse() || isTextEntryFocused();
+    if (!isNativeIOS()) {
+      // Only where the `cancel` event cannot be counted on. The native shell
+      // is built against iOS 17, and WKWebView tracks the OS, so `cancel`
+      // (Safari 16.4) always arrives there; arming this as well would add a
+      // second close signal that also fires on plain app foregrounding, which
+      // ends the session with the picker still on screen.
+      const onFocus = () => refocusComposer();
+      window.addEventListener("focus", onFocus, { once: true });
+      disarmFocusFallbackRef.current = () =>
+        window.removeEventListener("focus", onFocus);
+    }
     setPickerOpen(true);
+    // Ahead of the click: WebKit resigns the web view's first responder in the
+    // completion handler of the presentation animation, so left alone the
+    // keyboard drops a beat after the picker is already up. Asking first makes
+    // the dismissal part of the tap. `hide()` is iOS-supported; `show()` is
+    // not, which is why the way back is a DOM focus.
+    void hideNativeKeyboard();
     inputRef.current?.click();
-  }, [refocusComposer]);
+  }, [alwaysRestoreFocus, refocusComposer]);
 
   const handleChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {

--- a/clients/web/src/domains/chat/components/chat-composer/add-to-chat-sheet.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/add-to-chat-sheet.tsx
@@ -33,6 +33,14 @@ function AddToChatRow({ icon: Icon, label, onSelect }: AddToChatRowProps) {
   );
 }
 
+/**
+ * The sheet traps focus, so by the time a row launches a picker the composer
+ * has already lost it and the picker's own open-time sample would read "no
+ * keyboard owed". The rows opt out of that sample to keep returning the
+ * keyboard they have always returned.
+ */
+const RESTORE_FOCUS = { alwaysRestoreFocus: true } as const;
+
 interface AddToChatSheetProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -62,15 +70,18 @@ export function AddToChatSheet({
     onFiles: onAttachFiles,
     accept: "image/*",
     capture: "environment",
+    ...RESTORE_FOCUS,
   });
   const gallery = useAttachmentFilePicker({
     onFiles: onAttachFiles,
     accept: "image/*,video/*",
     multiple: true,
+    ...RESTORE_FOCUS,
   });
   const files = useAttachmentFilePicker({
     onFiles: onAttachFiles,
     multiple: true,
+    ...RESTORE_FOCUS,
   });
 
   const closeThenPick = (openPicker: () => void) => () => {

--- a/clients/web/src/domains/chat/composer-focus.ts
+++ b/clients/web/src/domains/chat/composer-focus.ts
@@ -60,6 +60,18 @@ function isTextEntryElement(element: Element | null): boolean {
   return Boolean(element?.closest(TEXT_ENTRY_SELECTOR));
 }
 
+/**
+ * Whether focus currently sits in something the soft keyboard serves. Exported
+ * so callers deciding whether they are owed a keyboard back share this
+ * selector rather than growing one of their own.
+ */
+export function isTextEntryFocused(): boolean {
+  if (typeof document === "undefined") {
+    return false;
+  }
+  return isTextEntryElement(document.activeElement);
+}
+
 function isKeyboardActivationElement(element: Element | null): boolean {
   return Boolean(element?.closest("a[href], button, summary"));
 }

--- a/clients/web/src/runtime/native-keyboard.ts
+++ b/clients/web/src/runtime/native-keyboard.ts
@@ -28,6 +28,31 @@ export async function initNativeKeyboard(): Promise<void> {
 }
 
 /**
+ * Start the keyboard's dismissal now, ahead of a native modal that is going to
+ * cause it anyway.
+ *
+ * WebKit resigns the web view's first responder to present a file picker, and
+ * it does so in the completion handler of the presentation animation
+ * (`WKFileUploadPanel.mm`), so the keyboard drops a beat after the picker is
+ * already on screen. Asking first turns that ambush into part of the tap.
+ *
+ * `hide()` is one of the few keyboard calls iOS supports; `show()` is Android
+ * only, which is why nothing here tries to put the keyboard back. Restoring it
+ * is a DOM `focus()`, which the Capacitor shell allows without a gesture.
+ */
+export async function hideNativeKeyboard(): Promise<void> {
+  if (!isNativeIOS()) {
+    return;
+  }
+  try {
+    const { Keyboard } = await import("@capacitor/keyboard");
+    await Keyboard.hide();
+  } catch {
+    // Plugin absent from this native build; WebKit dismisses it regardless.
+  }
+}
+
+/**
  * Coerce a reported keyboard height into a value layout can use.
  *
  * The bridge payload is untyped at runtime, so anything that is not a finite,


### PR DESCRIPTION
Fixes the two keyboard behaviors seen on a device: the plus raising the keyboard when nothing was focused, and the keyboard vanishing a beat after the picker is already up.

## Flow 1: the keyboard opened by itself. This one was ours.

Tap the plus on a **resting** composer, dismiss the picker, and the keyboard rises. `refocusComposer` asked for the composer's focus on every close path with no memory of what held focus when the picker opened:

```ts
requestComposerFocus();   // restoring, or conjuring? it could not tell
```

Capacitor calls `setKeyboardShouldRequireUserInteraction(false)` at bridge init, so that DOM focus summons the keyboard with no gesture behind it.

`openPicker` now samples who held focus **before the click** (presenting the picker is what takes the focus being asked about) and the close paths honour the answer:

```ts
shouldRestoreFocusRef.current =
  alwaysRestoreFocus || !isPointerCoarse() || isTextEntryFocused();
```

A pointing device is always owed its caret back: the button it presses takes the focus, so a bare "was a text entry focused" read would come back empty on a desktop pick that has always ended at the composer.

**Android keeps today's behavior.** The add-to-chat sheet opts out via `alwaysRestoreFocus`. Its focus trap already holds focus by the time a row launches a picker, so the sample would read empty there too and the sheet would stop returning a keyboard it returns today.

## Flow 2: the keyboard closing is WebKit's, not ours

It cannot be prevented. `WKFileUploadPanel.mm` resigns the web view's first responder in the completion handlers of **both** the file menu's display animation and the picker's presentation:

```objc
if ([view isFirstResponder]) [view resignFirstResponder];
```

That completion-handler placement is exactly why it drops a beat *after* the picker is on screen. No input attribute, plugin call, or config reaches it, and native picker plugins present fullScreen, which [removes the presenting view hierarchy](https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/fullscreen) and takes the keyboard anyway.

What we can do is stop it ambushing the user: `hideNativeKeyboard()` runs ahead of the click so the dismissal starts with the tap. `Keyboard.hide()` [is iOS-supported](https://capacitorjs.com/docs/apis/keyboard); `show()` is documented "only supported on Android", which is why the way back is a DOM focus rather than a plugin call.

The layout reflow behind the picker is the other half of this and is handled separately by #40885.

## Also: the fallback was armed on a stale premise

The one-shot window-`focus` listener is documented as covering "iOS 15 through 16.3 ... the app's deployment target is iOS 15". `clients/ios/App/App/Config/Base.xcconfig:26` sets `IPHONEOS_DEPLOYMENT_TARGET = 17.0`, and WKWebView tracks the OS, so [`cancel` (Safari 16.4)](https://developer.apple.com/documentation/safari-release-notes/safari-16_4-release-notes) always arrives on the native shell. Arming it there only added a second close signal that **also fires on plain app foregrounding**, ending the picker session with the picker still on screen. Now armed off the native shell only, where engines predating `cancel` still exist.

## Verification

- 6 new cases: resting phone composer restores nothing, focused one restores, pointing device always restores, `alwaysRestoreFocus` overrides, the native shell ignores a bare window focus, and the keyboard is asked to leave on open
- The gate case was confirmed to **fail** against the old unconditional `requestComposerFocus()` and pass with the fix
- 8 suites pass: `use-attachment-file-picker`, `add-to-chat-sheet`, `chat-composer`, `attach-file-button`, `conversation-navigation`, `composer-notices`, `use-ghost-text-suggestion`, `use-visible-viewport`
- `typecheck`, `eslint`, `prettier` clean

Device QA outstanding: on iPhone, that the plus on a resting composer no longer raises the keyboard on dismiss, that a focused composer still gets it back, and that the Android sheet is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)