### PR TITLE
feat(web): give Earlier activity a timeline, and GA its flag

### DIFF
--- a/clients/web/src/domains/chat/components/single-activity/single-activity.tsx
+++ b/clients/web/src/domains/chat/components/single-activity/single-activity.tsx
@@ -27,8 +27,11 @@
  * (label + trailing chevron, no leading glyph) and toggle
  * the shared tool-detail side drawer — clicking an already-open link closes it
  * (toggle). The trailing `ChevronRight` signals "opens a drawer" (vs the card's
- * expand-in-place up/down chevron). Consistent padding lets the active highlight
- * fill behind the content without shifting layout.
+ * expand-in-place up/down chevron), and it is an affordance rather than a
+ * status: it fades in on hover / keyboard focus, or stays lit while this row's
+ * drawer is open, so a settled run of rows reads as labels instead of a column
+ * of glyphs. Consistent padding lets the active highlight fill behind the
+ * content without shifting layout.
  *
  * This is the single-step counterpart to `MultiActivityGroup`, which renders a
  * contiguous run of interleaved thinking + tool steps as one combined card.
@@ -309,8 +312,12 @@ export function SingleActivity(props: SingleActivityProps) {
           view.label
         )}
       </span>
+      {/* The chevron is an affordance, not a status: it appears when the row is
+          reachable (hover / keyboard focus) or already showing its drawer, so a
+          settled run of rows reads as labels instead of a column of glyphs.
+          Faded rather than unmounted so the label never shifts. */}
       <ChevronRight
-        className="size-3.5 shrink-0 text-[var(--content-tertiary)]"
+        className="size-3.5 shrink-0 text-[var(--content-tertiary)] opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100 group-data-[active=true]:opacity-100 motion-reduce:transition-none"
         aria-hidden
       />
     </button>

--- a/clients/web/src/domains/chat/transcript/assistant-content-disclosure.stories.tsx
+++ b/clients/web/src/domains/chat/transcript/assistant-content-disclosure.stories.tsx
@@ -1,0 +1,200 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { userEvent, within } from "storybook/test";
+
+import { MultiActivityGroup } from "@/domains/chat/components/multi-activity-group/multi-activity-group";
+import { SingleActivity } from "@/domains/chat/components/single-activity/single-activity";
+import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
+
+import {
+  AssistantContentDisclosure,
+  type AssistantContentDisclosureItem,
+} from "./assistant-content-disclosure";
+
+/**
+ * Build a realistic completed {@link ChatMessageToolCall} with a 2s window so
+ * durations resolve in the steps panel.
+ */
+function makeToolCall(
+  overrides: Partial<ChatMessageToolCall> = {},
+): ChatMessageToolCall {
+  const startedAt = 1_717_000_000_000;
+  return {
+    id: `tc-${overrides.name ?? "bash"}-${startedAt}`,
+    name: "bash",
+    input: { command: "date", activity: "Checking the current time" },
+    riskLevel: "low",
+    startedAt,
+    completedAt: startedAt + 2_000,
+    ...overrides,
+  };
+}
+
+const REASONING =
+  "The user wants five agents on the same prompt. I'll spawn them in " +
+  "parallel rather than in sequence so the whole sweep finishes in one " +
+  "round trip, then collect the transcripts.";
+
+/**
+ * Collapsed prose, styled the way `TranscriptMessageBody` renders a text group
+ * inside the disclosure (`COLLAPSED_MARKDOWN_CLASS`): down at the size of the
+ * activity rows around it and in the secondary tone, so the revealed run reads
+ * as context rather than a second answer.
+ */
+function CollapsedProse({ children }: { children: string }) {
+  return (
+    <div className="w-full break-words text-[13px] leading-[20px] text-[var(--content-secondary)]">
+      {children}
+    </div>
+  );
+}
+
+/**
+ * The "Earlier activity" disclosure that collapses the intermediate work of a
+ * settled assistant response. Stories render it in the same column geometry as
+ * the transcript (`items-start`, `gap-2`) so the timeline gutter lines up the
+ * way it does in chat.
+ */
+const meta: Meta<typeof AssistantContentDisclosure> = {
+  title: "Chat/AssistantContentDisclosure",
+  component: AssistantContentDisclosure,
+  parameters: {
+    layout: "padded",
+  },
+  decorators: [
+    (Story) => (
+      <div className="flex w-full max-w-[640px] flex-col items-start gap-2">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof AssistantContentDisclosure>;
+
+/** Opens the disclosure so the story lands on the revealed run. */
+const openDisclosure: Story["play"] = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  const trigger = canvas.getByRole("button", { name: "Earlier activity" });
+  await userEvent.click(trigger);
+};
+
+const MIXED_RUN: AssistantContentDisclosureItem[] = [
+  {
+    key: "prose",
+    node: (
+      <CollapsedProse>
+        on it. i&apos;ll spin up five parallel agents with a simple test prompt.
+      </CollapsedProse>
+    ),
+  },
+  {
+    key: "thinking",
+    iconName: "brain",
+    node: <SingleActivity variant="thinking" content={REASONING} />,
+  },
+  {
+    key: "multi",
+    iconName: "terminal",
+    node: (
+      <div className="w-full">
+        <MultiActivityGroup
+          toolCalls={[
+            makeToolCall({
+              id: "tc-spawn",
+              input: {
+                command: "agents spawn --count 5",
+                activity: "Spawning five agents",
+              },
+            }),
+            makeToolCall({
+              id: "tc-collect",
+              input: {
+                command: "agents collect",
+                activity: "Collecting transcripts",
+              },
+            }),
+          ]}
+        />
+      </div>
+    ),
+  },
+  {
+    key: "tool",
+    iconName: "file",
+    node: (
+      <SingleActivity
+        variant="tool"
+        toolCall={makeToolCall({
+          id: "tc-read",
+          name: "read_file",
+          input: { path: "results.md", activity: "Reading results.md" },
+        })}
+      />
+    ),
+  },
+];
+
+/**
+ * Settled and closed — the whole run sits behind one trigger styled as another
+ * inline activity link, so the response reads as its final answer plus a single
+ * line of chrome.
+ */
+export const Collapsed: Story = {
+  args: {
+    items: MIXED_RUN,
+  },
+};
+
+/**
+ * Open — each collapsed group takes a glyph in the timeline gutter (from the
+ * same `ICON_MAP` the steps panel reads), with a connector segment running
+ * between consecutive glyphs. Collapsed prose renders in the muted content
+ * tone; the rows' labels sit indented under the trigger's text.
+ */
+export const Expanded: Story = {
+  args: {
+    items: MIXED_RUN,
+  },
+  play: openDisclosure,
+};
+
+/**
+ * The case the gutter exists for: a lone thinking row directly under the
+ * trigger. Flush against it, the trigger's trailing chevron and the row's own
+ * trailing "opens the drawer" chevron read as the same control.
+ */
+export const ThinkingRunOnly: Story = {
+  args: {
+    items: [
+      {
+        key: "thinking",
+        iconName: "brain",
+        node: <SingleActivity variant="thinking" content={REASONING} />,
+      },
+      {
+        key: "prose",
+        node: (
+          <CollapsedProse>
+            on it. i&apos;ll spin up five parallel agents with a simple test
+            prompt.
+          </CollapsedProse>
+        ),
+      },
+    ],
+  },
+  play: openDisclosure,
+};
+
+/**
+ * Streaming — the trigger is hidden and the content is pinned open, because
+ * nothing has been collapsed yet: this is the live turn's own work, which stays
+ * flush with the response. The timeline arrives with the trigger when the turn
+ * settles, under cover of the collapse animation.
+ */
+export const Streaming: Story = {
+  args: {
+    isStreaming: true,
+    items: MIXED_RUN,
+  },
+};

--- a/clients/web/src/domains/chat/transcript/assistant-content-disclosure.tsx
+++ b/clients/web/src/domains/chat/transcript/assistant-content-disclosure.tsx
@@ -1,20 +1,48 @@
 import { type ReactNode, useEffect, useState } from "react";
-import { ChevronRight } from "lucide-react";
+import { Bolt, ChevronRight } from "lucide-react";
 import { Collapsible } from "@vellumai/design-library";
+
+import type { IconName } from "@/domains/chat/components/tool-progress-card/derive-step-label";
+import { ICON_MAP } from "@/domains/chat/components/tool-progress-card/phase-grouped-step-list";
+import { cn } from "@/utils/misc";
 
 const EARLIER_ACTIVITY_VALUE = "earlier-activity";
 
+/** One collapsed group, plus the glyph that marks it on the timeline. */
+export interface AssistantContentDisclosureItem {
+  key: string;
+  node: ReactNode;
+  /**
+   * Timeline glyph for this row, from the same `ICON_MAP` the steps panel and
+   * step pills read, so a collapsed run and its expanded drawer never drift.
+   * Omitted for prose, which keeps the gutter slot but shows no glyph.
+   */
+  iconName?: IconName;
+}
+
 export interface AssistantContentDisclosureProps {
-  children: ReactNode;
+  items: AssistantContentDisclosureItem[];
   isStreaming?: boolean;
 }
 
 /**
  * Collapses the intermediate work in a completed assistant response while
  * keeping it available on demand.
+ *
+ * The trigger is styled as one more inline activity link — same 13px medium
+ * label, same `--content-secondary` tone, same trailing `ChevronRight` as
+ * `SingleActivity` — so the row that turns the section reads as a peer of the
+ * rows it reveals rather than a second kind of control.
+ *
+ * The revealed run is a *branch* of the response, so it renders as a timeline:
+ * each activity group takes a glyph in a fixed gutter, with a connector segment
+ * running between consecutive glyphs. The gutter both nests those rows (their
+ * labels sit ~22px in, under the trigger's text) and separates the trigger's
+ * chevron from the rows' own trailing "opens the drawer" chevrons. Prose has no
+ * glyph, so it spans the gutter too and starts flush with the glyph column.
  */
 export function AssistantContentDisclosure({
-  children,
+  items,
   isStreaming = false,
 }: AssistantContentDisclosureProps) {
   const [animateOnSettle] = useState(isStreaming);
@@ -39,22 +67,114 @@ export function AssistantContentDisclosure({
       <Collapsible.Item value={EARLIER_ACTIVITY_VALUE}>
         <Collapsible.Trigger
           hidden={isStreaming}
-          className={`group w-fit flex-none gap-1 py-1 text-body-small-default text-[var(--content-secondary)] transition-[color,opacity] [animation-duration:var(--anim-standard)] duration-[var(--anim-standard)] ease-[var(--anim-spring)] hover:text-[var(--content-default)] motion-reduce:animate-none motion-reduce:transition-none ${!isStreaming && animateOnSettle ? "animate-in fade-in" : ""}`}
+          className={cn(
+            "group -mx-1.5 w-fit flex-none items-center gap-2 rounded-md px-1.5 py-1 text-left text-[13px] font-medium",
+            "text-[var(--content-secondary)] transition-colors hover:bg-[var(--surface-hover)] hover:text-[var(--content-default)]",
+            // Open IS the active state, and it wears the hover treatment: the
+            // trigger stays lit for as long as the run it opened is showing,
+            // the same way a `MultiActivityGroup` header holds `surface-hover`
+            // while its panel is up.
+            "data-[state=open]:bg-[var(--surface-hover)] data-[state=open]:text-[var(--content-default)]",
+            "[animation-duration:var(--anim-standard)] motion-reduce:animate-none motion-reduce:transition-none",
+            !isStreaming && animateOnSettle && "animate-in fade-in",
+          )}
         >
+          <span>Earlier activity</span>
+          {/* Same rule as the inline activity rows: the chevron shows when the
+              trigger is reachable (hover / keyboard focus) or already open, so
+              a settled response carries a label rather than a glyph. */}
           <ChevronRight
             aria-hidden
-            className="size-3.5 shrink-0 transition-transform duration-[var(--anim-standard)] ease-[var(--anim-spring)] group-data-[state=open]:rotate-90 motion-reduce:transition-none"
+            className="size-3.5 shrink-0 text-[var(--content-tertiary)] opacity-0 transition-[transform,opacity] duration-[var(--anim-standard)] ease-[var(--anim-spring)] group-hover:opacity-100 group-focus-visible:opacity-100 group-data-[state=open]:rotate-90 group-data-[state=open]:opacity-100 motion-reduce:transition-none"
           />
-          <span>Earlier activity</span>
         </Collapsible.Trigger>
         <Collapsible.Content
           data-testid="assistant-earlier-activity"
           style={{
             animationDuration: "var(--anim-standard)",
           }}
-          className="flex origin-top flex-col gap-2 pb-2 transition-[opacity,transform] ease-[var(--anim-spring)] data-[state=closed]:-translate-y-1 data-[state=closed]:opacity-0 data-[state=open]:translate-y-0 data-[state=open]:opacity-100 motion-reduce:translate-y-0 motion-reduce:animate-none motion-reduce:transition-none"
+          className="origin-top pb-2 transition-[opacity,transform] ease-[var(--anim-spring)] data-[state=closed]:-translate-y-1 data-[state=closed]:opacity-0 data-[state=open]:translate-y-0 data-[state=open]:opacity-100 motion-reduce:translate-y-0 motion-reduce:animate-none motion-reduce:transition-none"
         >
-          {children}
+          {/* While streaming there is no trigger and nothing has been collapsed
+              yet: this is the live turn's own work, which stays flush with the
+              response. The timeline arrives with the trigger when the turn
+              settles, under cover of the collapse animation. */}
+          {isStreaming ? (
+            <div className="flex flex-col gap-2">
+              {items.map((item) => (
+                <div key={item.key} className="w-full">
+                  {item.node}
+                </div>
+              ))}
+            </div>
+          ) : (
+            // 2px of daylight between the trigger's text and the glyph column
+            // below it, so the timeline reads as nested under the trigger
+            // rather than hanging off the same edge. `pt-1.5` sets the run off
+            // from the trigger — the first row's own glyph slot is centered, so
+            // without it the two rows crowd each other.
+            <div className="flex flex-col pl-[2px] pt-1.5">
+              {items.map((item, index) => {
+                const Glyph = item.iconName
+                  ? (ICON_MAP[item.iconName] ?? Bolt)
+                  : null;
+                const isLast = index === items.length - 1;
+                // A row with no glyph (prose) takes the gutter's width too, so
+                // it starts at the same x as the glyphs rather than at the
+                // labels beside them — its own left edge is the alignment cue.
+                if (!Glyph) {
+                  return (
+                    <div
+                      key={item.key}
+                      data-testid="earlier-activity-row"
+                      className="w-full min-w-0"
+                    >
+                      {item.node}
+                      {/* The row owns the gutter, so its connector cannot run
+                          beside it — it runs under it instead, in the same
+                          centered column the glyph rows use, keeping the
+                          timeline unbroken across prose. */}
+                      {isLast ? null : (
+                        <div
+                          aria-hidden
+                          className="flex h-2 w-3.5 justify-center"
+                        >
+                          <span className="w-px bg-[var(--border-subtle)]" />
+                        </div>
+                      )}
+                    </div>
+                  );
+                }
+                return (
+                  <div
+                    key={item.key}
+                    data-testid="earlier-activity-row"
+                    className="flex gap-2"
+                  >
+                    <div className="flex w-3.5 shrink-0 flex-col items-center">
+                      {/* Fixed-height slot centers the glyph on the row's first
+                          line — a `SingleActivity` link is 28px tall. */}
+                      <span className="flex h-7 shrink-0 items-center justify-center">
+                        <Glyph
+                          aria-hidden
+                          className="size-3.5 shrink-0 text-[var(--content-tertiary)]"
+                        />
+                      </span>
+                      {isLast ? null : (
+                        <span
+                          aria-hidden
+                          className="w-px flex-1 bg-[var(--border-subtle)]"
+                        />
+                      )}
+                    </div>
+                    <div className={cn("min-w-0 flex-1", !isLast && "pb-2")}>
+                      {item.node}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
         </Collapsible.Content>
       </Collapsible.Item>
     </Collapsible.Root>

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -310,7 +310,6 @@ import type { DisplayMessage, Surface } from "@/domains/chat/types/types";
 import { TranscriptMessageBody } from "@/domains/chat/transcript/transcript-message-body";
 import { MIN_VERSION as REDACTED_CHIPS_MIN_VERSION } from "@/lib/backwards-compat/use-supports-redacted-credential-chips";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
-import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 
 const noop = () => {};
 
@@ -366,16 +365,8 @@ function surfaceBlock(surfaceId: string): ConversationContentBlock {
 afterAll(() => {
   mock.restore();
 });
-beforeEach(() => {
-  useClientFeatureFlagStore.setState({
-    collapseAssistantIntermediates: true,
-  });
-});
 afterEach(() => {
   cleanup();
-  useClientFeatureFlagStore.setState({
-    collapseAssistantIntermediates: false,
-  });
 });
 
 function renderMessage(
@@ -691,6 +682,32 @@ describe("TranscriptMessageBody", () => {
     ).toBe(true);
   });
 
+  test("gives no timeline row to a collapsed group that renders nothing", () => {
+    // A settled thinking run with no reasoning text renders nothing at all
+    // (`SingleActivity` collapses it), so a row for it would put a lone glyph
+    // against blank space — the group still belongs to the run, keeping the
+    // disclosure whole, but claims no slot.
+    const { getAllByTestId, getByRole } = render(
+      <TranscriptMessageBody
+        message={{
+          id: "empty-thinking-response",
+          role: "assistant",
+          contentBlocks: [
+            textBlock("I will check that."),
+            thinkingBlock(""),
+            textBlock("Here is the final answer."),
+          ],
+        }}
+        onSurfaceAction={noop}
+      />,
+    );
+
+    fireEvent.click(getByRole("button", { name: "Earlier activity" }));
+    const rows = getAllByTestId("earlier-activity-row");
+    expect(rows.length).toBe(1);
+    expect(rows[0]!.textContent).toBe("I will check that.");
+  });
+
   test("collapses completed assistant activity before the final text response", () => {
     const { getByRole, queryByText } = render(
       <TranscriptMessageBody
@@ -803,36 +820,6 @@ describe("TranscriptMessageBody", () => {
 
     expect(queryByTestId("answered-question-card")).toBeNull();
     expect(queryByTestId("inline-tool-link")).not.toBeNull();
-  });
-
-  test("keeps completed assistant activity visible when the flag is disabled", () => {
-    useClientFeatureFlagStore.setState({
-      collapseAssistantIntermediates: false,
-    });
-
-    const { queryByRole, queryByText } = render(
-      <TranscriptMessageBody
-        message={{
-          id: "ungated-response",
-          role: "assistant",
-          contentBlocks: [
-            textBlock("I will check that."),
-            toolUseBlock({
-              id: "tc-ungated-check",
-              name: "bash",
-              input: {},
-              completedAt: 1,
-            }),
-            textBlock("Here is the final answer."),
-          ],
-        }}
-        onSurfaceAction={noop}
-      />,
-    );
-
-    expect(queryByText("I will check that.")).not.toBeNull();
-    expect(queryByText("Here is the final answer.")).not.toBeNull();
-    expect(queryByRole("button", { name: "Earlier activity" })).toBeNull();
   });
 
   test("keeps all assistant activity visible while the response is streaming", () => {

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -36,6 +36,10 @@ import { SingleActivity } from "@/domains/chat/components/single-activity/single
 import { MultiActivityGroup } from "@/domains/chat/components/multi-activity-group/multi-activity-group";
 import { WEB_TOOL_NAMES } from "@/domains/chat/utils/tool-call-card-utils";
 import {
+  deriveStepLabel,
+  type IconName,
+} from "@/domains/chat/components/tool-progress-card/derive-step-label";
+import {
   activityItemsToCardData,
   type ContentBlockActivityItem,
   groupContentBlocks,
@@ -66,7 +70,6 @@ import { useWorkflowStore } from "@/domains/chat/workflow-store";
 import { useAcpRunStore } from "@/domains/chat/acp-run-store";
 import { useBackgroundTaskStore } from "@/domains/chat/background-task-store";
 import { useInteractionStore } from "@/domains/chat/interaction-store";
-import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { useViewerStore } from "@/stores/viewer-store";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type { ConversationMessageSurface } from "@vellumai/assistant-api";
@@ -98,6 +101,17 @@ import { saveFile } from "@/runtime/native-file";
  * applies), trading polish for headroom on outlier-length messages.
  */
 const STREAM_WORD_FADE_MAX_CHARS = 12000;
+
+/**
+ * Prose inside the "Earlier activity" disclosure. It is superseded by the final
+ * response, so it drops to the size of the activity rows around it (they are
+ * off-scale 13px too) and to the secondary tone — the revealed run reads as
+ * context rather than a second answer.
+ *
+ * typography: off-scale — matches `SingleActivity`'s 13px inline rows.
+ */
+const COLLAPSED_MARKDOWN_CLASS =
+  "text-[13px] leading-[20px] text-[var(--content-secondary)]";
 
 /** Percent-decodes `value`, returning it unchanged on malformed encoding. */
 function safeDecodeURIComponent(value: string): string {
@@ -144,8 +158,6 @@ export function TranscriptMessageBody({
   isStreaming = false,
   isLatestMessage = false,
 }: TranscriptMessageBodyProps) {
-  const collapseAssistantIntermediates =
-    useClientFeatureFlagStore.use.collapseAssistantIntermediates();
   const isSlackMessage = Boolean(message.slackMessage);
   const isSlackReaction = message.slackMessage?.eventKind === "reaction";
   const isUser = message.role === "user";
@@ -178,9 +190,13 @@ export function TranscriptMessageBody({
 
   const isTouch = isPointerCoarse();
 
-  const textBubbleClass = isSlackMessage
-    ? "max-w-[80%] text-[var(--content-default)] sm:max-w-[640px]"
-    : "w-full text-[var(--content-default)]";
+  // Width and color are split so the collapsed variant below can restate the
+  // color without the two arbitrary-value `text-[…]` utilities racing on
+  // stylesheet order.
+  const textBubbleWidthClass = isSlackMessage
+    ? "max-w-[80%] sm:max-w-[640px]"
+    : "w-full";
+  const textBubbleClass = `${textBubbleWidthClass} text-[var(--content-default)]`;
   // On touch devices, the long-press gesture opens the message actions sheet.
   // iOS's native text selection (blue highlight + callout bar) otherwise races
   // the 500ms long-press timer, so both surface at once. Suppress native
@@ -192,6 +208,9 @@ export function TranscriptMessageBody({
   const segmentClass = isUser
     ? "break-words text-[15px]"
     : `break-words text-[15px] ${textBubbleClass}`;
+  // The collapsed variant leaves size and color to `COLLAPSED_MARKDOWN_CLASS`
+  // on the markdown container itself (see `renderTextWithInlineSurfaces`).
+  const collapsedSegmentClass = `break-words ${textBubbleWidthClass}`;
 
   const forkMessageId = message.id;
   const forkHandler =
@@ -526,7 +545,14 @@ export function TranscriptMessageBody({
     text: string,
     key: string,
     streamWordFade?: "revealing" | "caughtUp",
+    collapsed = false,
   ) => {
+    const textClass = collapsed ? collapsedSegmentClass : segmentClass;
+    // `MarkdownMessage` sets its own `text-chat text-[var(--content-default)]`
+    // on its container, so a color on the wrapper alone never reaches the
+    // prose. The override rides the component's own `className` (merged via
+    // `cn`, so it drops the base size and color).
+    const markdownClass = collapsed ? COLLAPSED_MARKDOWN_CLASS : undefined;
     const inlineSegments = parseInlineSurfaces(text);
     if (inlineSegments) {
       return (
@@ -552,10 +578,11 @@ export function TranscriptMessageBody({
               <div
                 key={`inline-text-${si}`}
                 data-message-text=""
-                className={segmentClass}
+                className={textClass}
               >
                 <ChatMarkdownMessage
                   content={seg.content}
+                  className={markdownClass}
                   hardLineBreaks
                   onVellumLinkClick={handleVellumLinkClick}
                   attachments={message.attachments}
@@ -573,9 +600,10 @@ export function TranscriptMessageBody({
       );
     }
     return (
-      <div key={key} data-message-text="" className={segmentClass}>
+      <div key={key} data-message-text="" className={textClass}>
         <ChatMarkdownMessage
           content={text}
+          className={markdownClass}
           hardLineBreaks
           onVellumLinkClick={handleVellumLinkClick}
           attachments={message.attachments}
@@ -927,10 +955,62 @@ export function TranscriptMessageBody({
     );
   };
 
+  /**
+   * Whether a group renders a visible row at all. A thinking run whose
+   * reasoning never arrived renders nothing once settled (`SingleActivity`
+   * collapses an empty, settled thought), and a timeline slot for it would show
+   * a lone glyph against blank space. While streaming, the trailing group still
+   * renders the shimmering "Thinking" row before any text lands.
+   */
+  const groupRendersRow = (
+    group: (typeof groups)[number],
+    groupIndex: number,
+  ): boolean => {
+    if (group.type === "text") {
+      return group.text.trim().length > 0;
+    }
+    if (group.type === "surface") {
+      return true;
+    }
+    const { cardItems, toolCalls } = activityItemsToCardData(group.items);
+    if (toolCalls.some((tc) => !isSubagentSpawnCall(tc) && !isCardBacked(tc))) {
+      return true;
+    }
+    const hasThinking = cardItems.some(
+      (it) => it.kind === "thinking" && it.text.length > 0,
+    );
+    return hasThinking || (isStreaming && groupIndex === groups.length - 1);
+  };
+
+  /**
+   * Timeline glyph for one group inside an "Earlier activity" disclosure: the
+   * first renderable step's icon, a globe for a web run (`deriveStepLabel`
+   * covers non-web tools only), a brain for a thinking-only run, and none for
+   * prose — which keeps its gutter slot but shows no glyph.
+   */
+  const disclosureIconForGroup = (
+    group: (typeof groups)[number],
+  ): IconName | undefined => {
+    if (group.type !== "activity") {
+      return undefined;
+    }
+    const { toolCalls } = activityItemsToCardData(group.items);
+    const leadCall = toolCalls.find(
+      (tc) => !isSubagentSpawnCall(tc) && !isCardBacked(tc),
+    );
+    if (!leadCall) {
+      return "brain";
+    }
+    return WEB_TOOL_NAMES.has(leadCall.name)
+      ? "globe"
+      : deriveStepLabel(leadCall).iconName;
+  };
+
   const lastGroupIndex = groups.length - 1;
   const renderGroupNode = (
     group: (typeof groups)[number],
     gi: number,
+    collapsed = false,
   ): ReactNode => {
     if (group.type === "text") {
       const isSmoothedTrailing =
@@ -948,6 +1028,7 @@ export function TranscriptMessageBody({
         isSmoothedTrailing ? smoothedTrailingText : group.text,
         `b-text-${gi}`,
         fadeMode,
+        collapsed,
       );
     }
     if (group.type === "surface") {
@@ -1049,39 +1130,36 @@ export function TranscriptMessageBody({
   const finalResponseGroupIndex = groups.findLastIndex(
     (group) => group.type === "text" && group.text.trim().length > 0,
   );
-  const renderedGroups = groups.map((group, gi) => renderGroupNode(group, gi));
-  const collapsibleGroupIndexes = collapseAssistantIntermediates
-    ? groups.flatMap((group, groupIndex) => {
-        if (groupIndex >= finalResponseGroupIndex) {
-          return [];
-        }
-        if (group.type === "surface") {
-          return [];
-        }
-        if (group.type === "text") {
-          const isSurfaceAdjacent =
-            groups[groupIndex - 1]?.type === "surface" ||
-            groups[groupIndex + 1]?.type === "surface";
-          return parseInlineSurfaces(group.text) || isSurfaceAdjacent
-            ? []
-            : [groupIndex];
-        }
+  const collapsibleGroupIndexes = groups.flatMap((group, groupIndex) => {
+    if (groupIndex >= finalResponseGroupIndex) {
+      return [];
+    }
+    if (group.type === "surface") {
+      return [];
+    }
+    if (group.type === "text") {
+      const isSurfaceAdjacent =
+        groups[groupIndex - 1]?.type === "surface" ||
+        groups[groupIndex + 1]?.type === "surface";
+      return parseInlineSurfaces(group.text) || isSurfaceAdjacent
+        ? []
+        : [groupIndex];
+    }
 
-        const { toolCalls } = activityItemsToCardData(group.items);
-        const hasVisibleOutputOrControl =
-          hasToolResultImages(toolCalls) ||
-          toolCalls.some(
-            (toolCall) =>
-              isToolCallRunning(toolCall) ||
-              toolCall.pendingConfirmation !== undefined ||
-              isSubagentSpawnCall(toolCall) ||
-              isCardBacked(toolCall) ||
-              acpConnectToolUseId === toolCall.id ||
-              unknownNudgeToolCallIds?.has(toolCall.id) === true,
-          );
-        return hasVisibleOutputOrControl ? [] : [groupIndex];
-      })
-    : [];
+    const { toolCalls } = activityItemsToCardData(group.items);
+    const hasVisibleOutputOrControl =
+      hasToolResultImages(toolCalls) ||
+      toolCalls.some(
+        (toolCall) =>
+          isToolCallRunning(toolCall) ||
+          toolCall.pendingConfirmation !== undefined ||
+          isSubagentSpawnCall(toolCall) ||
+          isCardBacked(toolCall) ||
+          acpConnectToolUseId === toolCall.id ||
+          unknownNudgeToolCallIds?.has(toolCall.id) === true,
+      );
+    return hasVisibleOutputOrControl ? [] : [groupIndex];
+  });
   // One entry per contiguous run a single disclosure would cover. Relies on
   // `collapsibleGroupIndexes` being ascending (it is built by walking `groups`
   // in order), so a gap means a new run. `end` is exclusive, matching `slice`.
@@ -1094,18 +1172,44 @@ export function TranscriptMessageBody({
       collapsibleRuns.push({ start: groupIndex, end: groupIndex + 1 });
     }
   }
-  // A run that is one lone activity group does not earn a disclosure. Every
-  // activity rendering is already a single one-line row (`SingleActivity`'s
-  // bare "Thinking" / tool link, or `MultiActivityGroup`'s header) that keeps
-  // its reasoning and step timeline in a drawer rather than inline. Collapsing
-  // one swaps a one-line row for the one-line "Earlier activity" trigger:
-  // chrome with no text wall removed. Runs spanning two or more groups, and
-  // any run containing prose, still collapse.
-  const disclosedRuns = collapsibleRuns.filter(
-    (run) => run.end - run.start > 1 || groups[run.start]?.type !== "activity",
-  );
-  const disclosedRunByStart = new Map(
-    disclosedRuns.map((run) => [run.start, run.end]),
+  // Per disclosed run: where it ends, and which of its groups render a row.
+  // A group that renders nothing stays *inside* the run — dropping it would
+  // split one disclosure into two — but claims no timeline slot, which would
+  // otherwise put a lone glyph against blank space.
+  //
+  // `disclosedGroupIndexes` is every group a disclosure will swallow, resolved
+  // before the render pass so a group knows it is collapsed while it renders —
+  // prose reads that to drop to the muted, smaller collapsed tone.
+  const disclosedRunByStart = new Map<number, number>();
+  const disclosedRunRows = new Map<number, number[]>();
+  const disclosedGroupIndexes = new Set<number>();
+  for (const run of collapsibleRuns) {
+    const rowIndexes: number[] = [];
+    for (let index = run.start; index < run.end; index += 1) {
+      if (groupRendersRow(groups[index]!, index)) {
+        rowIndexes.push(index);
+      }
+    }
+    // A run that renders one lone activity row does not earn a disclosure. That
+    // row is already a single one-line link (`SingleActivity`'s bare "Thinking"
+    // / tool link, or `MultiActivityGroup`'s header) whose reasoning and step
+    // timeline live in a drawer, so collapsing it swaps one line of chrome for
+    // another. Runs rendering two or more rows, and any run containing prose,
+    // still collapse.
+    const earnsDisclosure =
+      rowIndexes.length > 1 ||
+      (rowIndexes.length === 1 && groups[rowIndexes[0]!]?.type !== "activity");
+    if (!earnsDisclosure) {
+      continue;
+    }
+    disclosedRunByStart.set(run.start, run.end);
+    disclosedRunRows.set(run.start, rowIndexes);
+    for (let index = run.start; index < run.end; index += 1) {
+      disclosedGroupIndexes.add(index);
+    }
+  }
+  const renderedGroups = groups.map((group, gi) =>
+    renderGroupNode(group, gi, disclosedGroupIndexes.has(gi)),
   );
   const assistantContent: ReactNode[] = [];
   for (let groupIndex = 0; groupIndex < renderedGroups.length; ) {
@@ -1119,9 +1223,12 @@ export function TranscriptMessageBody({
       <AssistantContentDisclosure
         key={`earlier-activity-${groupIndex}`}
         isStreaming={isStreaming}
-      >
-        {renderedGroups.slice(groupIndex, runEndIndex)}
-      </AssistantContentDisclosure>,
+        items={(disclosedRunRows.get(groupIndex) ?? []).map((rowIndex) => ({
+          key: `earlier-activity-item-${rowIndex}`,
+          node: renderedGroups[rowIndex],
+          iconName: disclosureIconForGroup(groups[rowIndex]!),
+        }))}
+      />,
     );
     // The disclosure renders the rest of its run, so resume past it.
     groupIndex = runEndIndex;

--- a/clients/web/src/lib/feature-flags/feature-flag-catalog.test.ts
+++ b/clients/web/src/lib/feature-flags/feature-flag-catalog.test.ts
@@ -23,11 +23,13 @@ describe("feature flag catalog", () => {
     expect(ASSISTANT_FLAG_DEFAULTS.selfIntroGreeting).toBe(false);
   });
 
-  test("exposes collapse assistant intermediates as a client flag defaulted off", () => {
-    expect(CLIENT_FLAG_DEFAULTS.collapseAssistantIntermediates).toBe(false);
-    expect(
-      "collapseAssistantIntermediates" in ASSISTANT_FLAG_DEFAULTS,
-    ).toBe(false);
+  test("does not expose GA collapsed assistant intermediates as a feature flag", () => {
+    expect("collapseAssistantIntermediates" in CLIENT_FLAG_DEFAULTS).toBe(
+      false,
+    );
+    expect("collapseAssistantIntermediates" in ASSISTANT_FLAG_DEFAULTS).toBe(
+      false,
+    );
   });
 
   test("exposes the activation flow experiment as a client string flag", () => {

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -109,14 +109,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "collapse-assistant-intermediates",
-      "scope": "client",
-      "key": "collapse-assistant-intermediates",
-      "label": "Collapse Assistant Intermediates",
-      "description": "Collapse completed intermediary assistant activity behind Earlier activity while keeping the final response visible",
-      "defaultEnabled": false
-    },
-    {
       "id": "backward-releases",
       "scope": "assistant",
       "key": "backward-releases",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -109,14 +109,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "collapse-assistant-intermediates",
-      "scope": "client",
-      "key": "collapse-assistant-intermediates",
-      "label": "Collapse Assistant Intermediates",
-      "description": "Collapse completed intermediary assistant activity behind Earlier activity while keeping the final response visible",
-      "defaultEnabled": false
-    },
-    {
       "id": "backward-releases",
       "scope": "assistant",
       "key": "backward-releases",


### PR DESCRIPTION
## Why

"Earlier activity" — the disclosure that collapses a settled response's intermediate work — had no visual hierarchy. Its trigger sat flush against the rows it revealed, and the trigger's *leading* chevron stacked in the same column as each row's *trailing* "opens the drawer" chevron, so the two read as one control. There was also no indentation marking the collapsed run as subordinate to the response.

## What changed

**The trigger is one more inline activity link.** Same 13px medium label, same `--content-secondary` tone, same trailing `ChevronRight` as `SingleActivity`, so it reads as a peer of the rows it turns rather than a second kind of control. Open is its active state and wears the hover treatment — the same convention as a `MultiActivityGroup` header holding `surface-hover` while its panel is up.

**The revealed run is a timeline.** Each activity group takes a glyph in a fixed 14px gutter, with a connector segment running between consecutive glyphs. Glyphs resolve through the same `ICON_MAP` / `deriveStepLabel` the steps panel and step pills read, so a collapsed run and its expanded drawer can't drift. Prose has no glyph, so it spans the gutter, starts flush with the glyph column, and draws its connector underneath — keeping the line unbroken across a paragraph.

**Collapsed prose is muted.** It drops to the size of the activity rows around it and to the secondary tone, so the run reads as context rather than a second answer. The override rides `ChatMarkdownMessage`'s own `className`: `MarkdownMessage` sets `text-chat text-[var(--content-default)]` on its container, so a color on the wrapper alone never reached the prose. `text-[13px]` is used rather than a `text-body-*` token because tailwind-merge misclassifies those as colors and drops them.

**A group that renders nothing no longer claims a timeline slot.** A settled thinking run with no reasoning text renders nothing (`SingleActivity` collapses it), which left a lone glyph against blank space. It still belongs to the run — dropping it would split one disclosure into two — and the "earns a disclosure" rule now counts *rendered rows* rather than raw groups. Covered by a regression test.

**Chevrons are affordances, not status.** On the trigger and on `SingleActivity`'s thinking/tool rows, the chevron fades in on hover / keyboard focus, or stays lit while the drawer it opened is showing. Faded rather than unmounted so labels never shift; `motion-reduce` respected.

**`collapse-assistant-intermediates` is GA'd out.** Fully released, so it comes out of the registry (synced via `meta/sync-bundled-copies.ts`) and the render path collapses unconditionally. Follows the same shape as the empty-state-greetings GA (c14eb583a0): registry entry removed, catalog test flipped to the "not a flag" assertion. The LaunchDarkly flag can be archived platform-side.

## Scope calls worth a look

- The chevron rule lands on the shared `SingleActivity` button, so it covers **both** thinking and tool rows — they render through the same path and sit adjacent in the timeline, and changing only one would look broken. This affects those rows outside "Earlier activity" too.
- The **web search** variant's up/down chevron is untouched: it expands in place and its direction is live state, not an affordance.
- Prose rows get no glyph. Every row in the reference design is a tool step, and giving a paragraph an icon would read as a step that never ran.

## Testing

- New Storybook stories: `Chat/AssistantContentDisclosure` — `Collapsed`, `Expanded`, `ThinkingRunOnly`, `Streaming`.
- New regression test for the empty-group case; existing transcript tests updated for the flag removal.
- `bunx tsc --noEmit`, `bun run lint` (0 errors), `bun run test:ci`, `bun run build` all clean.
- QA'd visually in Storybook across several rounds of design feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
