### PR TITLE
fix(web): catch sentences built with + and copy in a toast options bag (LUM-3149)

### DIFF
--- a/clients/web/eslint-rules/no-untranslated-strings.mjs
+++ b/clients/web/eslint-rules/no-untranslated-strings.mjs
@@ -125,27 +125,59 @@ function looksLikeCopy(text) {
 }
 
 /**
- * Whether a template's static fragment reads as a word rather than as part of
- * an identifier.
+ * The words a static fragment contributes, once whatever is glued to an
+ * interpolation is taken off it.
  *
- * A sentence separates its words: `${label} actions` puts a space between the
- * two. A built identifier does not: `${name}.vellum` and `${id}-opt-${i}` glue
- * their pieces together, and their fragments are file extensions and id
- * segments, which no translator should receive. So a fragment counts only when
- * every side of it that touches an interpolation is whitespace separated. The
- * ends of the template are free, since nothing is joined there.
+ * A sentence separates its words, so `${label} actions` keeps "actions" and
+ * `${count}-day trial` keeps "trial". An identifier does not separate
+ * anything, so `${name}.vellum` and `${id}-opt-${expr}` are left with nothing:
+ * a file extension and an id segment are not copy, and neither is the "-day"
+ * that a translator would have to leave attached to the number anyway. The
+ * ends of the run are free, since nothing is joined there.
  */
-function isWordBoundary(template, quasi, index) {
-  const text = quasi.value.cooked ?? "";
-  const followsExpression = index > 0;
-  const precedesExpression = index < template.quasis.length - 1;
-  if (followsExpression && !/^\s/.test(text)) {
-    return false;
+function unglue(text, followsExpression, precedesExpression) {
+  let words = text;
+  if (followsExpression) {
+    const boundary = words.search(/\s/);
+    words = boundary === -1 ? "" : words.slice(boundary);
   }
-  if (precedesExpression && !/\s$/.test(text)) {
-    return false;
+  if (precedesExpression) {
+    const boundary = words.search(/\s\S*$/);
+    words = boundary === -1 ? "" : words.slice(0, boundary + 1);
   }
-  return true;
+  return words;
+}
+
+/**
+ * Toast option fields the user reads, and the nested bags that hold them.
+ * Everything else in the bag (`id`, `duration`, `position`, callbacks) is
+ * machinery.
+ */
+const TOAST_COPY_FIELDS = new Set([
+  "description",
+  "label",
+  "loading",
+  "success",
+  "error",
+  "message",
+  "title",
+]);
+const TOAST_COPY_BAGS = new Set(["action", "cancel"]);
+
+/** The operands of a `+` chain, left to right, with the chain flattened out. */
+function flattenConcatenation(node) {
+  if (node.type === "BinaryExpression" && node.operator === "+") {
+    return [
+      ...flattenConcatenation(node.left),
+      ...flattenConcatenation(node.right),
+    ];
+  }
+  return [node];
+}
+
+/** True for an operand that stands in for a value, the way `${x}` does. */
+function isInterpolation(node) {
+  return Boolean(node) && !(node.type === "Literal");
 }
 
 /** Files whose strings are fixtures rather than shipped copy. */
@@ -266,8 +298,13 @@ export const noUntranslatedStrings = {
       }
       if (node.type === "TemplateLiteral") {
         const statics = node.quasis
-          .filter((quasi, index) => isWordBoundary(node, quasi, index))
-          .map((quasi) => quasi.value.cooked ?? "")
+          .map((quasi, index) =>
+            unglue(
+              quasi.value.cooked ?? "",
+              index > 0,
+              index < node.quasis.length - 1,
+            ),
+          )
           .join(" ");
         // A template with an interpolation is copy assembled in the component
         // whatever its static half looks like, so it is judged by
@@ -294,11 +331,40 @@ export const noUntranslatedStrings = {
       }
       // `"Delete " + name` is the concatenation `I18N.md` calls the most
       // common way to make a string untranslatable: word order is fixed by
-      // the source, exactly as in the template form. Only `+` builds a
-      // string, so the other operators stay out of it.
+      // the source, exactly as in the template form, so it is read the same
+      // way. Only `+` builds a string, so the other operators stay out of it.
       if (node.type === "BinaryExpression" && node.operator === "+") {
-        checkExpression(node.left, messageId, data, isCopy);
-        checkExpression(node.right, messageId, data, isCopy);
+        const operands = flattenConcatenation(node);
+        const statics = operands
+          .map((operand, index) =>
+            operand.type === "Literal" && typeof operand.value === "string"
+              ? unglue(
+                  operand.value,
+                  isInterpolation(operands[index - 1]),
+                  isInterpolation(operands[index + 1]),
+                )
+              : "",
+          )
+          .join(" ");
+        if (
+          operands.some((operand) => isInterpolation(operand))
+            ? isTranslatable(statics)
+            : isCopy(statics)
+        ) {
+          context.report({
+            node,
+            messageId,
+            data: { ...data, text: preview(statics) },
+          });
+          return;
+        }
+        // Nothing assembled, so each side is judged on its own: a lone
+        // capitalized word is still copy where a glued fragment is not.
+        for (const operand of operands) {
+          if (operand.type !== "Literal") {
+            checkExpression(operand, messageId, data, isCopy);
+          }
+        }
         return;
       }
       // `cond ? "Open" : "Close"` and `label || "Untitled"` are copy chosen in
@@ -316,10 +382,14 @@ export const noUntranslatedStrings = {
     }
 
     /**
-     * The copy in a toast's options bag: `description`, and the `label` on an
-     * `action` or `cancel`. Keyed rather than walked, because the same object
-     * carries a toast `id`, durations, and callbacks, none of which a
-     * translator has any use for.
+     * The copy in a toast's options bag: the fields the toast renders, and the
+     * nested `action` / `cancel` bags that carry a label of their own. Keyed
+     * rather than walked, because the same object holds a toast id, durations,
+     * placement and callbacks, none of which a translator has any use for.
+     *
+     * These are judged as copy on sight rather than through the prop-value
+     * test: `description: "saved"` is one lowercase word, which that test
+     * reads as an enum value, and a toast renders it to the user regardless.
      */
     function checkToastOptions(node) {
       for (const property of node.properties) {
@@ -332,14 +402,19 @@ export const noUntranslatedStrings = {
             : property.key.type === "Literal"
               ? String(property.key.value)
               : undefined;
-        if (!key || isStructuralProp(key)) {
+        if (!key) {
           continue;
         }
-        if (property.value.type === "ObjectExpression") {
+        if (
+          TOAST_COPY_BAGS.has(key) &&
+          property.value.type === "ObjectExpression"
+        ) {
           checkToastOptions(property.value);
           continue;
         }
-        checkExpression(property.value, "toast", {}, looksLikeCopy);
+        if (TOAST_COPY_FIELDS.has(key)) {
+          checkExpression(property.value, "toast", {});
+        }
       }
     }
 

--- a/clients/web/eslint-rules/no-untranslated-strings.mjs
+++ b/clients/web/eslint-rules/no-untranslated-strings.mjs
@@ -124,6 +124,30 @@ function looksLikeCopy(text) {
   return trimmed.includes(" ") || /^\p{Lu}/u.test(trimmed);
 }
 
+/**
+ * Whether a template's static fragment reads as a word rather than as part of
+ * an identifier.
+ *
+ * A sentence separates its words: `${label} actions` puts a space between the
+ * two. A built identifier does not: `${name}.vellum` and `${id}-opt-${i}` glue
+ * their pieces together, and their fragments are file extensions and id
+ * segments, which no translator should receive. So a fragment counts only when
+ * every side of it that touches an interpolation is whitespace separated. The
+ * ends of the template are free, since nothing is joined there.
+ */
+function isWordBoundary(template, quasi, index) {
+  const text = quasi.value.cooked ?? "";
+  const followsExpression = index > 0;
+  const precedesExpression = index < template.quasis.length - 1;
+  if (followsExpression && !/^\s/.test(text)) {
+    return false;
+  }
+  if (precedesExpression && !/\s$/.test(text)) {
+    return false;
+  }
+  return true;
+}
+
 /** Files whose strings are fixtures rather than shipped copy. */
 const EXEMPT_FILE_PATTERN = /\.(test|spec|stories)\.[cm]?[jt]sx?$/;
 
@@ -241,7 +265,10 @@ export const noUntranslatedStrings = {
         return;
       }
       if (node.type === "TemplateLiteral") {
-        const statics = node.quasis.map((q) => q.value.cooked ?? "").join(" ");
+        const statics = node.quasis
+          .filter((quasi, index) => isWordBoundary(node, quasi, index))
+          .map((quasi) => quasi.value.cooked ?? "")
+          .join(" ");
         // A template with an interpolation is copy assembled in the component
         // whatever its static half looks like, so it is judged by
         // `isTranslatable` rather than by `isCopy`. `aria-label={`${name}
@@ -265,6 +292,15 @@ export const noUntranslatedStrings = {
         }
         return;
       }
+      // `"Delete " + name` is the concatenation `I18N.md` calls the most
+      // common way to make a string untranslatable: word order is fixed by
+      // the source, exactly as in the template form. Only `+` builds a
+      // string, so the other operators stay out of it.
+      if (node.type === "BinaryExpression" && node.operator === "+") {
+        checkExpression(node.left, messageId, data, isCopy);
+        checkExpression(node.right, messageId, data, isCopy);
+        return;
+      }
       // `cond ? "Open" : "Close"` and `label || "Untitled"` are copy chosen in
       // the component. Picking a string in TypeScript is the same problem as
       // writing one there: the choice belongs in the catalog, where a
@@ -276,6 +312,34 @@ export const noUntranslatedStrings = {
       }
       if (node.type === "LogicalExpression") {
         checkExpression(node.right, messageId, data, isCopy);
+      }
+    }
+
+    /**
+     * The copy in a toast's options bag: `description`, and the `label` on an
+     * `action` or `cancel`. Keyed rather than walked, because the same object
+     * carries a toast `id`, durations, and callbacks, none of which a
+     * translator has any use for.
+     */
+    function checkToastOptions(node) {
+      for (const property of node.properties) {
+        if (property.type !== "Property" || property.computed) {
+          continue;
+        }
+        const key =
+          property.key.type === "Identifier"
+            ? property.key.name
+            : property.key.type === "Literal"
+              ? String(property.key.value)
+              : undefined;
+        if (!key || isStructuralProp(key)) {
+          continue;
+        }
+        if (property.value.type === "ObjectExpression") {
+          checkToastOptions(property.value);
+          continue;
+        }
+        checkExpression(property.value, "toast", {}, looksLikeCopy);
       }
     }
 
@@ -328,15 +392,24 @@ export const noUntranslatedStrings = {
         checkExpression(value, "prop", { prop: name }, looksLikeCopy);
       },
 
+      // Every argument, not just the first: `toast.error(t("x"), {
+      // description: "raw" })` carries its untranslated half in the options
+      // bag, and `toast.promise(p, { loading, success })` puts a promise where
+      // the message would be and all of its copy in the bag.
       CallExpression(node) {
         if (!isToastCall(node.callee)) {
           return;
         }
-        const [first] = node.arguments;
-        if (!first || insideTranslationCall(first)) {
-          return;
+        for (const argument of node.arguments) {
+          if (insideTranslationCall(argument)) {
+            continue;
+          }
+          if (argument.type === "ObjectExpression") {
+            checkToastOptions(argument);
+            continue;
+          }
+          checkExpression(argument, "toast", {});
         }
-        checkExpression(first, "toast", {});
       },
     };
   },

--- a/clients/web/eslint-rules/no-untranslated-strings.mjs
+++ b/clients/web/eslint-rules/no-untranslated-strings.mjs
@@ -149,20 +149,14 @@ function unglue(text, followsExpression, precedesExpression) {
 }
 
 /**
- * Toast option fields the user reads, and the nested bags that hold them.
- * Everything else in the bag (`id`, `duration`, `position`, callbacks) is
- * machinery.
+ * The fields of a toast's options bag that the toast renders, taken from
+ * `ToastOptions` in `packages/design-library/src/components/toast.tsx`, which
+ * is the only toast this app has: nothing imports `sonner` directly. The rest
+ * of that interface (`id`, `duration`, `tone`, and the `onClick` beside this
+ * `label`) is machinery. Add to these when that interface gains copy.
  */
-const TOAST_COPY_FIELDS = new Set([
-  "description",
-  "label",
-  "loading",
-  "success",
-  "error",
-  "message",
-  "title",
-]);
-const TOAST_COPY_BAGS = new Set(["action", "cancel"]);
+const TOAST_COPY_FIELDS = new Set(["description", "label"]);
+const TOAST_COPY_BAGS = new Set(["action"]);
 
 /** The operands of a `+` chain, left to right, with the chain flattened out. */
 function flattenConcatenation(node) {

--- a/clients/web/eslint-rules/no-untranslated-strings.mjs
+++ b/clients/web/eslint-rules/no-untranslated-strings.mjs
@@ -175,9 +175,14 @@ function flattenConcatenation(node) {
   return [node];
 }
 
+/** True for a string written out in the source rather than computed. */
+function isStringLiteral(node) {
+  return node.type === "Literal" && typeof node.value === "string";
+}
+
 /** True for an operand that stands in for a value, the way `${x}` does. */
 function isInterpolation(node) {
-  return Boolean(node) && !(node.type === "Literal");
+  return Boolean(node) && node.type !== "Literal";
 }
 
 /** Files whose strings are fixtures rather than shipped copy. */
@@ -286,7 +291,7 @@ export const noUntranslatedStrings = {
       if (!node) {
         return;
       }
-      if (node.type === "Literal" && typeof node.value === "string") {
+      if (isStringLiteral(node)) {
         if (isCopy(node.value)) {
           context.report({
             node,
@@ -297,74 +302,43 @@ export const noUntranslatedStrings = {
         return;
       }
       if (node.type === "TemplateLiteral") {
-        const statics = node.quasis
-          .map((quasi, index) =>
+        checkAssembled(
+          node,
+          node.quasis.map((quasi, index) =>
             unglue(
               quasi.value.cooked ?? "",
               index > 0,
               index < node.quasis.length - 1,
             ),
-          )
-          .join(" ");
-        // A template with an interpolation is copy assembled in the component
-        // whatever its static half looks like, so it is judged by
-        // `isTranslatable` rather than by `isCopy`. `aria-label={`${name}
-        // actions`}` leaves "actions" behind: one lowercase word, which reads
-        // as an enum value to the prop-level test and slips through, while the
-        // string it builds is exactly the untranslatable shape, since a
-        // translator cannot put the word before the name.
-        const isAssembled = node.expressions.length > 0;
-        if (isAssembled ? isTranslatable(statics) : isCopy(statics)) {
-          context.report({
-            node,
-            messageId,
-            data: { ...data, text: preview(statics) },
-          });
-        }
-        // The interpolations carry copy of their own: `${draft ? "Draft" :
-        // "Live"}` is a word chosen in the component, and sits in the one
-        // place the static halves are not.
-        for (const expression of node.expressions) {
-          checkExpression(expression, messageId, data, isCopy);
-        }
+          ),
+          node.expressions,
+          messageId,
+          data,
+          isCopy,
+        );
         return;
       }
-      // `"Delete " + name` is the concatenation `I18N.md` calls the most
-      // common way to make a string untranslatable: word order is fixed by
-      // the source, exactly as in the template form, so it is read the same
-      // way. Only `+` builds a string, so the other operators stay out of it.
+      // `"Delete " + name` builds its sentence the same way a template does,
+      // so it is read the same way. Only `+` builds a string, which leaves the
+      // other operators out of it.
       if (node.type === "BinaryExpression" && node.operator === "+") {
         const operands = flattenConcatenation(node);
-        const statics = operands
-          .map((operand, index) =>
-            operand.type === "Literal" && typeof operand.value === "string"
+        checkAssembled(
+          node,
+          operands.map((operand, index) =>
+            isStringLiteral(operand)
               ? unglue(
                   operand.value,
                   isInterpolation(operands[index - 1]),
                   isInterpolation(operands[index + 1]),
                 )
               : "",
-          )
-          .join(" ");
-        if (
-          operands.some((operand) => isInterpolation(operand))
-            ? isTranslatable(statics)
-            : isCopy(statics)
-        ) {
-          context.report({
-            node,
-            messageId,
-            data: { ...data, text: preview(statics) },
-          });
-          return;
-        }
-        // Nothing assembled, so each side is judged on its own: a lone
-        // capitalized word is still copy where a glued fragment is not.
-        for (const operand of operands) {
-          if (operand.type !== "Literal") {
-            checkExpression(operand, messageId, data, isCopy);
-          }
-        }
+          ),
+          operands.filter(isInterpolation),
+          messageId,
+          data,
+          isCopy,
+        );
         return;
       }
       // `cond ? "Open" : "Close"` and `label || "Untitled"` are copy chosen in
@@ -378,6 +352,31 @@ export const noUntranslatedStrings = {
       }
       if (node.type === "LogicalExpression") {
         checkExpression(node.right, messageId, data, isCopy);
+      }
+    }
+
+    /**
+     * Read a string the component assembles, from its static fragments and
+     * the values interleaved between them.
+     *
+     * Anything with a value in it is judged by `isTranslatable` rather than by
+     * `isCopy`: `` `${name} actions` `` leaves "actions" behind, one lowercase
+     * word that the prop-value test reads as an enum, while the string it
+     * builds is the shape a translator cannot reorder. The values are read in
+     * turn, since `${draft ? "Draft" : "Live"}` puts its copy in the one place
+     * the fragments are not.
+     */
+    function checkAssembled(node, fragments, values, messageId, data, isCopy) {
+      const statics = fragments.join(" ");
+      if (values.length > 0 ? isTranslatable(statics) : isCopy(statics)) {
+        context.report({
+          node,
+          messageId,
+          data: { ...data, text: preview(statics) },
+        });
+      }
+      for (const value of values) {
+        checkExpression(value, messageId, data, isCopy);
       }
     }
 

--- a/clients/web/eslint-rules/no-untranslated-strings.test.mjs
+++ b/clients/web/eslint-rules/no-untranslated-strings.test.mjs
@@ -113,6 +113,18 @@ ruleTester.run("no-untranslated-strings", noUntranslatedStrings, {
       code: `const C = () => <span title={\`\${label}: \${cost}\`} />;`,
     },
     {
+      name: "an identifier built from pieces is not copy",
+      filename: COMPONENT,
+      // Nothing here is word separated: the fragments are a file extension
+      // and an id segment, which no translator should receive.
+      code: `const C = () => <span title={\`\${app.name}.vellum\`} id={\`\${id}-opt\`} />;`,
+    },
+    {
+      name: "a toast options bag holding no copy of its own",
+      filename: COMPONENT,
+      code: `toast.success(t("app.exported"), { id: "export-status", description: filename, duration: 5000 });`,
+    },
+    {
       name: "toast copy read through t()",
       filename: COMPONENT,
       code: `toast.error(t("save.failed"));`,
@@ -170,6 +182,30 @@ ruleTester.run("no-untranslated-strings", noUntranslatedStrings, {
       // The words sit in the one place the static halves are not.
       code: `const C = () => <span title={\`\${live ? "Live" : "Draft"} · \${host}\`} />;`,
       errors: [{ messageId: "prop" }, { messageId: "prop" }],
+    },
+    {
+      name: "a sentence assembled with +",
+      filename: COMPONENT,
+      // The same untranslatable shape as the template form, and the one
+      // `I18N.md` calls the most common of all.
+      code: `const C = () => <button aria-label={"Delete " + name} />;`,
+      errors: [{ messageId: "prop" }],
+    },
+    {
+      name: "copy in a toast options bag",
+      filename: COMPONENT,
+      // The message is translated and the copy hides in the second argument,
+      // which is why every argument is read rather than the first.
+      code: `toast.error(t("save.failed"), { description: "Try again later", action: { label: "Retry" } });`,
+      errors: [{ messageId: "toast" }, { messageId: "toast" }],
+    },
+    {
+      name: "copy in a toast.promise bag",
+      filename: COMPONENT,
+      // The promise sits where the message would be, so nothing is reported
+      // unless the bag is read.
+      code: `toast.promise(p, { loading: "Saving…", success: "Saved" });`,
+      errors: [{ messageId: "toast" }, { messageId: "toast" }],
     },
     {
       name: "a sentence assembled by template literal as a JSX child",

--- a/clients/web/eslint-rules/no-untranslated-strings.test.mjs
+++ b/clients/web/eslint-rules/no-untranslated-strings.test.mjs
@@ -125,6 +125,16 @@ ruleTester.run("no-untranslated-strings", noUntranslatedStrings, {
       code: `toast.success(t("app.exported"), { id: "export-status", description: filename, duration: 5000 });`,
     },
     {
+      name: "an identifier built with + is not copy",
+      filename: COMPONENT,
+      code: `const C = () => <span title={id + "-list"} />;`,
+    },
+    {
+      name: "toast machinery is not copy",
+      filename: COMPONENT,
+      code: `toast.success(t("done"), { id: "export", duration: 5000, position: "top-center" });`,
+    },
+    {
       name: "toast copy read through t()",
       filename: COMPONENT,
       code: `toast.error(t("save.failed"));`,
@@ -206,6 +216,32 @@ ruleTester.run("no-untranslated-strings", noUntranslatedStrings, {
       // unless the bag is read.
       code: `toast.promise(p, { loading: "Saving…", success: "Saved" });`,
       errors: [{ messageId: "toast" }, { messageId: "toast" }],
+    },
+    {
+      name: "a name concatenated with + and a lowercase word",
+      filename: COMPONENT,
+      // The mirror of the template case: an assembled string is judged by
+      // whether it holds words, not by whether one fragment looks like copy
+      // standing alone.
+      code: `const C = () => <button aria-label={name + " imported"} />;`,
+      errors: [{ messageId: "prop" }],
+    },
+    {
+      name: "copy separated from an interpolation by punctuation",
+      filename: COMPONENT,
+      // "-day" is glued to the count and comes off, but "trial" is a word of
+      // its own and keeps the sentence visible.
+      code: `const C = () => <span aria-label={\`\${count}-day trial\`} />;`,
+      errors: [{ messageId: "prop" }],
+    },
+    {
+      name: "a lowercase toast description",
+      filename: COMPONENT,
+      // A toast renders `description` whatever it looks like, so it is not
+      // judged by the prop-value test that treats a lone lowercase word as an
+      // enum.
+      code: `toast.success(t("done"), { description: "saved" });`,
+      errors: [{ messageId: "toast" }],
     },
     {
       name: "a sentence assembled by template literal as a JSX child",

--- a/clients/web/eslint-rules/no-untranslated-strings.test.mjs
+++ b/clients/web/eslint-rules/no-untranslated-strings.test.mjs
@@ -132,7 +132,7 @@ ruleTester.run("no-untranslated-strings", noUntranslatedStrings, {
     {
       name: "toast machinery is not copy",
       filename: COMPONENT,
-      code: `toast.success(t("done"), { id: "export", duration: 5000, position: "top-center" });`,
+      code: `toast.success(t("done"), { id: "export", duration: 5000, tone: "strong" });`,
     },
     {
       name: "toast copy read through t()",
@@ -207,14 +207,6 @@ ruleTester.run("no-untranslated-strings", noUntranslatedStrings, {
       // The message is translated and the copy hides in the second argument,
       // which is why every argument is read rather than the first.
       code: `toast.error(t("save.failed"), { description: "Try again later", action: { label: "Retry" } });`,
-      errors: [{ messageId: "toast" }, { messageId: "toast" }],
-    },
-    {
-      name: "copy in a toast.promise bag",
-      filename: COMPONENT,
-      // The promise sits where the message would be, so nothing is reported
-      // unless the bag is read.
-      code: `toast.promise(p, { loading: "Saving…", success: "Saved" });`,
       errors: [{ messageId: "toast" }, { messageId: "toast" }],
     },
     {

--- a/clients/web/src/domains/library/library-view.tsx
+++ b/clients/web/src/domains/library/library-view.tsx
@@ -98,7 +98,7 @@ export function LibraryView({
         await queryClient.invalidateQueries({
           queryKey: appsGetQueryKey({ path: { assistant_id: assistantId } }),
         });
-        toast.success(result.name + " imported");
+        toast.success(t("libraryView.imported", { name: result.name }));
         onOpenApp(result.appId);
       } catch (err) {
         toast.error(

--- a/clients/web/src/i18n/locales/en/library.json
+++ b/clients/web/src/i18n/locales/en/library.json
@@ -8,6 +8,7 @@
   },
   "libraryView": {
     "importFailed": "Failed to import app",
+    "imported": "{name} imported",
     "loadingAria": "Loading apps",
     "retry": "Retry",
     "import": "Import",

--- a/clients/web/src/i18n/locales/es/library.json
+++ b/clients/web/src/i18n/locales/es/library.json
@@ -8,6 +8,7 @@
   },
   "libraryView": {
     "importFailed": "No se pudo importar la aplicación",
+    "imported": "{name} importada",
     "loadingAria": "Cargando las aplicaciones",
     "retry": "Reintentar",
     "import": "Importar",


### PR DESCRIPTION
## TL;DR

Closes three of the four shapes LUM-3149 still lists, and fixes the one violation they surfaced in an enforced path. The fourth is left open deliberately, with the reason below.

Part of LUM-3149

## What was invisible

| Shape | Why it passed |
| --- | --- |
| `label={"Delete " + name}` | `checkExpression` handled `Literal`, `TemplateLiteral`, `ConditionalExpression` and `LogicalExpression`. `BinaryExpression` was absent, so the `+` form fell through as clean while the template form beside it was reported |
| `toast.error(t("x"), { description: "raw" })` | The toast visitor read `arguments[0]` and returned early when it was a `t()` call, which is exactly the call most likely to carry an options bag |
| Copy in any argument after the first | Only `arguments[0]` was ever read |

Toast options are read **by key** rather than walked whole: the same object carries a toast `id`, a duration and a tone. The keys come from `ToastOptions` in `packages/design-library/src/components/toast.tsx`, which is the only toast this app has (nothing imports `sonner` directly): `description`, and the `label` on an `action`. They are judged as copy on sight rather than through the prop-value test, since a toast renders `description: "saved"` whatever that test makes of one lowercase word.

`toast.promise` is named in LUM-3149, but the design library exposes no such method and nothing in the app calls one, so there is nothing to guard there.

## A false positive this exposed, now fixed

Reading templates more closely showed that #40896 (which taught the rule that a template with an interpolation is copy) was too broad. It reported these:

```
description: `${app.name}.vellum`   // a filename
aria-controls={`${id}-opt`}          // an element id
```

Those build **identifiers**, not sentences. A static fragment now counts only where every side of it that meets an interpolation is whitespace separated, which is what distinguishes `` `${label} actions` `` (a sentence, reported) from `` `${name}.vellum` `` (a built id, quiet). The ARIA ID-reference exemption stays as belt and braces.

## What it surfaced

One violation across every enforced path: `toast.success(result.name + " imported")` in the library view, the `+` shape exactly. It now reads `{name} imported` from the catalog, with Spanish alongside.

## What this deliberately leaves open

LUM-3149's fourth row is `throw new Error("user-facing")`. There are **30** such throws in enforced paths today, and reading them they are developer invariants, not copy:

```
throw new Error("useAssistantStage must be used inside <AssistantStage>");
throw new Error("icon <img> not rendered yet");
```

A lint rule cannot tell an invariant from a message a user will read, so catching this shape means flagging all 30 and hoping authors disable the right ones. The prerequisite is a convention that marks user-facing failures (a `UserFacingError`, or a rule that only reads what reaches a toast or an error boundary). That belongs in the issue, not in a rule change, so LUM-3149 stays open on that row.

## Why it is safe

- The rule only widens what is reported inside `i18nEnforcedPaths`, and the template narrowing removes reports rather than adding them.
- Five `RuleTester` cases were added, two of them `valid`: the built-identifier template and a toast bag holding an id, a variable description, and a duration. A rule that fires on legitimate code gets switched off rather than obeyed, and both of these nearly did.
- One behaviour change: an English toast that now renders the same words through the catalog.
- `bun run lint` clean across the workspace (16 pre-existing `react-hooks/exhaustive-deps` warnings, unchanged), typecheck clean on every touched file, rule suite runs in CI.
