### PR TITLE
fix(daemon): stop a mid-turn send repointing the conversation's actor

### DIFF
--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -1828,6 +1828,13 @@ export interface ProcessMessageOptions {
   /** JWT-verified committer principal for turn-scoped host-proxy authorization. */
   sourceActorPrincipalId?: string;
   /**
+   * The actor this turn is being started for. Stamped onto the conversation
+   * before history is scoped, so the run hydrates as its committer rather
+   * than as whoever last left the resting slot set. Callers with no actor of
+   * their own (internal dispatch) omit it and the resting actor stands.
+   */
+  trustContext?: TrustContext;
+  /**
    * True when this turn was auto-sent on the user's behalf rather than typed
    * (see `PersistMessageOptions.scripted`). Forwarded to persistence so the
    * turn is excluded from activation counts. Defaults to false. A caller
@@ -1873,7 +1880,11 @@ export async function processMessage(
     sourceActorPrincipalId,
     scripted,
     metadata: callerMetadata,
+    trustContext: committingTrustContext,
   } = options;
+  if (committingTrustContext) {
+    conversation.setTrustContext(committingTrustContext);
+  }
   await conversation.ensureActorScopedHistory();
   // Snapshot persona context at turn start so later tool turns can't pick up
   // a different actor's context if a concurrent request mutates the live fields.

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -85,6 +85,7 @@ import type {
 } from "./message-protocol.js";
 import { INTERACTIVE_SURFACE_TYPES } from "./message-protocol.js";
 import { isRowVisibleToUntrustedActor } from "./message-provenance.js";
+import type { TrustContext } from "./trust-context-types.js";
 export {
   buildSurfaceShowPair,
   type CurrentTurnSurface,
@@ -1904,7 +1905,13 @@ export async function handleSurfaceAction(
   // reconstruct the same-user binding for host proxies (CU / app-control),
   // mirroring the normal message path.
   sourceActorPrincipalId?: string,
+  // Trust of the actor committing this action, resolved by the route from the
+  // verified requester. Passed rather than read back off the conversation so a
+  // click that lands mid-turn is attributed to its clicker instead of to
+  // whoever occupies the resting slot.
+  requesterTrustContext?: TrustContext,
 ): Promise<SurfaceActionResult> {
+  const actionTrustContext = requesterTrustContext ?? ctx.trustContext;
   // ── Standalone surface interception ──────────────────────────────
   // Daemon-driven surfaces (from `requestInteractiveUi`) register a
   // pending entry in `pendingStandaloneSurfaces`. When the user clicks
@@ -2050,7 +2057,7 @@ export async function handleSurfaceAction(
     // `await` resolves as soon as the conversation is created + titled +
     // published to the event hub. The HTTP POST /v1/surface-actions
     // response returns promptly — the seed turn runs in the background.
-    const originTrustContext = ctx.trustContext;
+    const originTrustContext = actionTrustContext;
     const { conversationId } = await launchConversation({
       title,
       seedPrompt,
@@ -2069,14 +2076,11 @@ export async function handleSurfaceAction(
     return { accepted: true, conversationId };
   }
 
-  // Trust of the actor committing THIS action. `POST /v1/surface-actions`
-  // stamps the verified requester's trust onto the conversation before
-  // dispatching here, and `loadFromDb` derives the live history filter from
-  // the same value, so the completion path's persisted read stays scoped to
-  // exactly what this actor's live view would have held. Unresolvable trust
-  // fails closed to the untrusted filter.
+  // Trust of the actor committing THIS action, so the completion path's
+  // persisted read stays scoped to exactly what this actor's live view would
+  // have held. Unresolvable trust fails closed to the untrusted filter.
   const requesterCanAccessMemory = resolveCapabilities(
-    ctx.trustContext?.trustClass,
+    actionTrustContext?.trustClass,
   ).canAccessMemory;
 
   const pending = ctx.pendingSurfaceActions.get(surfaceId);
@@ -2222,6 +2226,7 @@ export async function handleSurfaceAction(
       activeSurfaceId: surfaceId,
       displayContent,
       sourceActorPrincipalId,
+      trustContext: actionTrustContext,
       isInteractive: SURFACE_ACTION_TURN_IS_INTERACTIVE,
       // Rides the metadata bag rather than a typed option: the queue
       // round-trips `metadata` but not `PersistMessageOptions`.
@@ -2472,6 +2477,7 @@ export async function handleSurfaceAction(
     activeSurfaceId: surfaceId,
     displayContent,
     sourceActorPrincipalId,
+    trustContext: actionTrustContext,
     isInteractive: SURFACE_ACTION_TURN_IS_INTERACTIVE,
     // Rides the metadata bag rather than a typed option: the queue
     // round-trips `metadata` but not `PersistMessageOptions`.

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -86,6 +86,7 @@ import type {
 import { INTERACTIVE_SURFACE_TYPES } from "./message-protocol.js";
 import { isRowVisibleToUntrustedActor } from "./message-provenance.js";
 import type { TrustContext } from "./trust-context-types.js";
+import { restingTrust } from "./trust-context-types.js";
 export {
   buildSurfaceShowPair,
   type CurrentTurnSurface,
@@ -1911,7 +1912,7 @@ export async function handleSurfaceAction(
   // whoever occupies the resting slot.
   requesterTrustContext?: TrustContext,
 ): Promise<SurfaceActionResult> {
-  const actionTrustContext = requesterTrustContext ?? ctx.trustContext;
+  const actionTrustContext = requesterTrustContext ?? restingTrust(ctx);
   // ── Standalone surface interception ──────────────────────────────
   // Daemon-driven surfaces (from `requestInteractiveUi`) register a
   // pending entry in `pendingStandaloneSurfaces`. When the user clicks
@@ -2281,6 +2282,12 @@ export async function handleSurfaceAction(
       { surfaceId, actionId, requestId, attachmentCount: attachments.length },
       "Processing surface action immediately (history-restored) with attachments",
     );
+    // Reached only when `enqueueMessage` declined to queue, i.e. the
+    // conversation is idle and this click is starting the turn. Stamp the
+    // committing actor so the run it kicks off hydrates and scopes to them.
+    if (actionTrustContext) {
+      ctx.setTrustContext(actionTrustContext);
+    }
     ctx
       .processMessage({
         content,
@@ -2542,6 +2549,11 @@ export async function handleSurfaceAction(
     },
     "Processing surface action as follow-up with attachments",
   );
+  // Same commitment point as the history-restored branch above: the enqueue
+  // declined, so this click is the turn that is about to run.
+  if (actionTrustContext) {
+    ctx.setTrustContext(actionTrustContext);
+  }
   ctx
     .processMessage({
       content,

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -2282,12 +2282,6 @@ export async function handleSurfaceAction(
       { surfaceId, actionId, requestId, attachmentCount: attachments.length },
       "Processing surface action immediately (history-restored) with attachments",
     );
-    // Reached only when `enqueueMessage` declined to queue, i.e. the
-    // conversation is idle and this click is starting the turn. Stamp the
-    // committing actor so the run it kicks off hydrates and scopes to them.
-    if (actionTrustContext) {
-      ctx.setTrustContext(actionTrustContext);
-    }
     ctx
       .processMessage({
         content,
@@ -2297,6 +2291,9 @@ export async function handleSurfaceAction(
         activeSurfaceId: surfaceId,
         displayContent,
         sourceActorPrincipalId,
+        // Reached only when `enqueueMessage` declined to queue: the click is
+        // starting this turn, so it is the actor the run belongs to.
+        trustContext: actionTrustContext,
         isInteractive: SURFACE_ACTION_TURN_IS_INTERACTIVE,
         scripted: isSyntheticSurfaceActionContent(content),
       })
@@ -2549,11 +2546,6 @@ export async function handleSurfaceAction(
     },
     "Processing surface action as follow-up with attachments",
   );
-  // Same commitment point as the history-restored branch above: the enqueue
-  // declined, so this click is the turn that is about to run.
-  if (actionTrustContext) {
-    ctx.setTrustContext(actionTrustContext);
-  }
   ctx
     .processMessage({
       content,
@@ -2563,6 +2555,9 @@ export async function handleSurfaceAction(
       activeSurfaceId: surfaceId,
       displayContent,
       sourceActorPrincipalId,
+      // Same as the history-restored branch: the enqueue declined, so this
+      // click is the turn about to run.
+      trustContext: actionTrustContext,
       isInteractive: SURFACE_ACTION_TURN_IS_INTERACTIVE,
       scripted: isSyntheticSurfaceActionContent(content),
     })

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -2829,6 +2829,7 @@ export class Conversation {
     actionId: string,
     data?: Record<string, unknown>,
     sourceActorPrincipalId?: string,
+    requesterTrustContext?: TrustContext,
   ): Promise<SurfaceActionResult> {
     return handleSurfaceActionImpl(
       this,
@@ -2836,6 +2837,7 @@ export class Conversation {
       actionId,
       data,
       sourceActorPrincipalId,
+      requesterTrustContext,
     );
   }
 

--- a/assistant/src/runtime/routes/__tests__/surface-action-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/surface-action-routes.test.ts
@@ -26,11 +26,14 @@ interface StubConversation {
   handleSurfaceUndoCalled?: boolean;
   handleSurfaceUndoThrows?: Error;
   trustContext?: { trustClass: string; sourceChannel: string };
+  /** Drives `isProcessing()`, the resting-slot write guard. */
+  processing?: boolean;
   surfaceActionCalls: Array<{
     surfaceId: string;
     actionId: string;
     data: unknown;
     sourceActorPrincipalId?: string;
+    requesterTrustContext?: { trustClass: string; sourceChannel: string };
   }>;
 }
 
@@ -160,12 +163,14 @@ function makeStub(id: string): StubConversation {
       actionId: string,
       data: unknown,
       sourceActorPrincipalId?: string,
+      requesterTrustContext?: { trustClass: string; sourceChannel: string },
     ) => {
       stub.surfaceActionCalls.push({
         surfaceId,
         actionId,
         data,
         sourceActorPrincipalId,
+        requesterTrustContext,
       });
       if (stub.handleSurfaceActionThrows) {
         throw stub.handleSurfaceActionThrows;
@@ -181,6 +186,7 @@ function makeStub(id: string): StubConversation {
     setTrustContext: (ctx: { trustClass: string; sourceChannel: string }) => {
       stub.trustContext = ctx;
     },
+    isProcessing: () => stub.processing === true,
   });
   return stub;
 }
@@ -560,6 +566,53 @@ describe("triggerSurfaceAction trust context", () => {
     });
 
     expect(live.trustContext?.trustClass).toBe("unknown");
+  });
+
+  test("idle conversation: the requester's trust is bound to the resting slot and passed to the action", async () => {
+    mockGuardianList = [guardianDelivery(GUARDIAN_PRINCIPAL)];
+    const live = makeStub("conv-idle");
+    live.processing = false;
+    memoryBySurface = live;
+
+    const handler = findHandler("triggerSurfaceAction");
+    await handler({
+      body: { surfaceId: "surf-idle", actionId: "act-idle" },
+      headers: { "x-vellum-actor-principal-id": GUARDIAN_PRINCIPAL },
+    });
+
+    expect(live.trustContext?.trustClass).toBe("guardian");
+    expect(live.surfaceActionCalls).toHaveLength(1);
+    expect(live.surfaceActionCalls[0]?.requesterTrustContext?.trustClass).toBe(
+      "guardian",
+    );
+  });
+
+  test("busy conversation: the running turn's resting actor is left alone, and the click still travels as its own actor", async () => {
+    mockGuardianList = [guardianDelivery(GUARDIAN_PRINCIPAL)];
+    const live = makeStub("conv-busy");
+    // A turn is already running under a different actor.
+    const runningTurnActor = {
+      trustClass: "untrusted",
+      sourceChannel: "sms",
+    };
+    live.trustContext = runningTurnActor;
+    live.processing = true;
+    memoryBySurface = live;
+
+    const handler = findHandler("triggerSurfaceAction");
+    await handler({
+      body: { surfaceId: "surf-busy", actionId: "act-busy" },
+      headers: { "x-vellum-actor-principal-id": GUARDIAN_PRINCIPAL },
+    });
+
+    // The slot is the identical object it was before the request: the
+    // in-flight turn keeps authorizing tools as the actor it started as.
+    expect(live.trustContext).toBe(runningTurnActor);
+    // The clicker is not dropped — it rides the call instead of the slot.
+    expect(live.surfaceActionCalls).toHaveLength(1);
+    expect(live.surfaceActionCalls[0]?.requesterTrustContext?.trustClass).toBe(
+      "guardian",
+    );
   });
 });
 

--- a/assistant/src/runtime/routes/__tests__/surface-action-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/surface-action-routes.test.ts
@@ -26,14 +26,15 @@ interface StubConversation {
   handleSurfaceUndoCalled?: boolean;
   handleSurfaceUndoThrows?: Error;
   trustContext?: { trustClass: string; sourceChannel: string };
-  /** Drives `isProcessing()`, the resting-slot write guard. */
+  /** Drives `isProcessing()`; the route must not stamp trust either way. */
   processing?: boolean;
+  /** Trust the route threaded into `handleSurfaceAction`. */
+  lastRequesterTrustContext?: { trustClass: string; sourceChannel: string };
   surfaceActionCalls: Array<{
     surfaceId: string;
     actionId: string;
     data: unknown;
     sourceActorPrincipalId?: string;
-    requesterTrustContext?: { trustClass: string; sourceChannel: string };
   }>;
 }
 
@@ -165,12 +166,12 @@ function makeStub(id: string): StubConversation {
       sourceActorPrincipalId?: string,
       requesterTrustContext?: { trustClass: string; sourceChannel: string },
     ) => {
+      stub.lastRequesterTrustContext = requesterTrustContext;
       stub.surfaceActionCalls.push({
         surfaceId,
         actionId,
         data,
         sourceActorPrincipalId,
-        requesterTrustContext,
       });
       if (stub.handleSurfaceActionThrows) {
         throw stub.handleSurfaceActionThrows;
@@ -493,8 +494,8 @@ describe("triggerSurfaceAction trust context", () => {
       headers: { "x-vellum-actor-principal-id": GUARDIAN_PRINCIPAL },
     });
 
-    expect(live.trustContext?.trustClass).toBe("guardian");
-    expect(live.trustContext?.sourceChannel).toBe("vellum");
+    expect(live.lastRequesterTrustContext?.trustClass).toBe("guardian");
+    expect(live.lastRequesterTrustContext?.sourceChannel).toBe("vellum");
     // First-pass resolve already granted guardian, so the drift helper is skipped.
     expect(reResolveCalls).toEqual([]);
   });
@@ -512,7 +513,7 @@ describe("triggerSurfaceAction trust context", () => {
     });
 
     expect(reResolveCalls).toEqual([VELLUM_PRINCIPAL_OLD]);
-    expect(live.trustContext?.trustClass).toBe("unknown");
+    expect(live.lastRequesterTrustContext?.trustClass).toBe("unknown");
   });
 
   test("reset drift: helper returns guardian → route adopts it", async () => {
@@ -528,7 +529,7 @@ describe("triggerSurfaceAction trust context", () => {
     });
 
     expect(reResolveCalls).toEqual([VELLUM_PRINCIPAL_OLD]);
-    expect(live.trustContext?.trustClass).toBe("guardian");
+    expect(live.lastRequesterTrustContext?.trustClass).toBe("guardian");
   });
 
   test("dev-bypass resolves the real guardian principal from the gateway, helper not called", async () => {
@@ -545,7 +546,7 @@ describe("triggerSurfaceAction trust context", () => {
 
     // The synthetic dev-bypass principal is translated to the real guardian,
     // yielding a guardian trust context without consulting the drift helper.
-    expect(live.trustContext?.trustClass).toBe("guardian");
+    expect(live.lastRequesterTrustContext?.trustClass).toBe("guardian");
     expect(reResolveCalls).toEqual([]);
   });
 
@@ -565,10 +566,10 @@ describe("triggerSurfaceAction trust context", () => {
       headers: { "x-vellum-actor-principal-id": "dev-bypass" },
     });
 
-    expect(live.trustContext?.trustClass).toBe("unknown");
+    expect(live.lastRequesterTrustContext?.trustClass).toBe("unknown");
   });
 
-  test("idle conversation: the requester's trust is bound to the resting slot and passed to the action", async () => {
+  test("idle conversation: the requester is threaded to the action and the slot is left to the dispatch", async () => {
     mockGuardianList = [guardianDelivery(GUARDIAN_PRINCIPAL)];
     const live = makeStub("conv-idle");
     live.processing = false;
@@ -580,14 +581,14 @@ describe("triggerSurfaceAction trust context", () => {
       headers: { "x-vellum-actor-principal-id": GUARDIAN_PRINCIPAL },
     });
 
-    expect(live.trustContext?.trustClass).toBe("guardian");
-    expect(live.surfaceActionCalls).toHaveLength(1);
-    expect(live.surfaceActionCalls[0]?.requesterTrustContext?.trustClass).toBe(
-      "guardian",
-    );
+    expect(live.lastRequesterTrustContext?.trustClass).toBe("guardian");
+    // The route resolves; `handleSurfaceAction` stamps, and only where it
+    // commits to running the turn. Stamping here would repoint the actor of a
+    // turn that starts between this call and the dispatch.
+    expect(live.trustContext).toBeUndefined();
   });
 
-  test("busy conversation: the running turn's resting actor is left alone, and the click still travels as its own actor", async () => {
+  test("busy conversation: the running turn's actor is left alone and the click still travels as its own actor", async () => {
     mockGuardianList = [guardianDelivery(GUARDIAN_PRINCIPAL)];
     const live = makeStub("conv-busy");
     // A turn is already running under a different actor.
@@ -605,14 +606,9 @@ describe("triggerSurfaceAction trust context", () => {
       headers: { "x-vellum-actor-principal-id": GUARDIAN_PRINCIPAL },
     });
 
-    // The slot is the identical object it was before the request: the
-    // in-flight turn keeps authorizing tools as the actor it started as.
+    // Identical object, so a re-write of an equal value still fails this.
     expect(live.trustContext).toBe(runningTurnActor);
-    // The clicker is not dropped — it rides the call instead of the slot.
-    expect(live.surfaceActionCalls).toHaveLength(1);
-    expect(live.surfaceActionCalls[0]?.requesterTrustContext?.trustClass).toBe(
-      "guardian",
-    );
+    expect(live.lastRequesterTrustContext?.trustClass).toBe("guardian");
   });
 });
 

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -691,17 +691,16 @@ async function handleRetryLastAssistantTurn({
   const conversation = await getOrCreateConversationInstance(conversationId);
   touchConversation(conversationId);
 
-  // Bind the requesting actor's trust before the turn. A freshly hydrated
-  // conversation has no trust context, and `loadFromDb` under an unset
-  // context filters guardian-provenance history — the re-run would see an
-  // empty transcript.
+  // Resolved before the busy gate so the awaits stay outside the
+  // check-then-claim window below, but bound only once the claim succeeds: a
+  // retry that loses the race is rejected, and a rejected request must not
+  // repoint the conversation's actor at its requester.
   const actorPrincipalId = headers?.["x-vellum-actor-principal-id"];
-  conversation.setTrustContext(
-    await resolveVellumActorTrustContext(actorPrincipalId, {
-      healResetDrift: true,
-    }),
+  const retryTrustContext = await resolveVellumActorTrustContext(
+    actorPrincipalId,
+    { healResetDrift: true },
   );
-  conversation.currentTurnSourceActorPrincipalId =
+  const retrySourceActorPrincipalId =
     await resolveActorPrincipalIdForLocalGuardian(actorPrincipalId);
 
   // Synchronous check-then-claim (no await between them) so a concurrent
@@ -713,6 +712,13 @@ async function handleRetryLastAssistantTurn({
     );
   }
   conversation.setProcessing(true);
+
+  // Bind the requesting actor's trust for the turn we just claimed. A freshly
+  // hydrated conversation has no trust context, and `loadFromDb` under an
+  // unset context filters guardian-provenance history — the re-run would see
+  // an empty transcript.
+  conversation.setTrustContext(retryTrustContext);
+  conversation.currentTurnSourceActorPrincipalId = retrySourceActorPrincipalId;
 
   const requestId = uuidv7();
   const abortController = new AbortController();

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1850,10 +1850,9 @@ export async function handleSendMessage(
   // Resolve guardian context from the AuthContext's actorPrincipalId via the
   // gateway guardian binding: a vellum principal is the guardian or nobody.
   //
-  // Resolved into a local first, and written to the conversation only if no
-  // turn is running (below). The slot is the conversation's *resting* actor;
-  // a turn that recorded no actor of its own reads it live, so writing it
-  // here would change what an in-flight turn authorizes tools as.
+  // Resolved into a local; the conversation's slot is stamped only where this
+  // request commits to running a turn, since that write is what supplies the
+  // acting actor for a run and must not fire for a send that merely queues.
   let resolvedTrustCtx: TrustContext;
   if (actorPrincipalId) {
     // Dev bypass (HTTP auth disabled): the synthetic "dev-bypass" principal
@@ -1926,15 +1925,6 @@ export async function handleSendMessage(
   // writable by paths that do not own this turn (channel ingress for another
   // actor, live-voice hydration, pointer elevation, the voice bridge).
   const turnTrustContext = resolvedTrustCtx;
-
-  // Publish the sender as the conversation's resting actor only when no turn
-  // is running. A turn that recorded no actor of its own resolves this slot
-  // live for tool authorization, provenance and reply routing, so a send
-  // landing mid-turn must not move it; the queued message carries its own
-  // trust to the drain instead (see `enqueueMessage` below).
-  if (!conversation.isProcessing()) {
-    conversation.setTrustContext(resolvedTrustCtx);
-  }
 
   const isInteractive = isInteractiveInterface(sourceInterface);
   // Translate the dev-bypass actor principal to the real guardian principal
@@ -2065,6 +2055,9 @@ export async function handleSendMessage(
         requestId: uuidv7(),
         metadata: greetingMeta,
         clientMessageId,
+        // This path answers and returns without starting a turn, so it never
+        // reaches the stamp below; name the sender on the row directly.
+        trustContext: resolvedTrustCtx,
         ...(clientOs ? { requestClientOs: clientOs } : {}),
       });
 
@@ -2355,7 +2348,15 @@ export async function handleSendMessage(
   // matching in-memory pending interaction (e.g. prompter timeouts).
   await expireOrphanedGuardianRequests(mapping.conversationId);
 
-  // Conversation is idle — persist and fire agent loop immediately
+  // Conversation is idle — persist and fire agent loop immediately.
+  //
+  // Stamping the sender here rather than at resolution is what keeps the two
+  // in step: the slot hydrates and scopes the turn started just below
+  // (`ensureActorScopedHistory`, persisted provenance, the loop's own trust),
+  // so it must name whoever this request is about to run as. A request that
+  // queues instead returns above without stamping — it is not starting a run,
+  // and its actor rides the queue item to the drain.
+  conversation.setTrustContext(resolvedTrustCtx);
   conversation.setTurnChannelContext({
     userMessageChannel: sourceChannel,
     assistantMessageChannel: sourceChannel,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1849,6 +1849,12 @@ export async function handleSendMessage(
 
   // Resolve guardian context from the AuthContext's actorPrincipalId via the
   // gateway guardian binding: a vellum principal is the guardian or nobody.
+  //
+  // Resolved into a local first, and written to the conversation only if no
+  // turn is running (below). The slot is the conversation's *resting* actor;
+  // a turn that recorded no actor of its own reads it live, so writing it
+  // here would change what an in-flight turn authorizes tools as.
+  let resolvedTrustCtx: TrustContext;
   if (actorPrincipalId) {
     // Dev bypass (HTTP auth disabled): the synthetic "dev-bypass" principal
     // won't match any guardian binding. Resolve the real guardian principal and
@@ -1874,7 +1880,7 @@ export async function handleSendMessage(
           trustCtx = healed;
         }
       }
-      conversation.setTrustContext(trustCtx);
+      resolvedTrustCtx = trustCtx;
     } else {
       let trustCtx = withSourceChannel(
         sourceChannel,
@@ -1907,22 +1913,28 @@ export async function handleSendMessage(
           );
         }
       }
-      conversation.setTrustContext(trustCtx);
+      resolvedTrustCtx = trustCtx;
     }
   } else {
     // Service principals (svc_gateway) or tokens without an actor ID
     // get a minimal guardian context so downstream code has something.
-    conversation.setTrustContext({ trustClass: "guardian", sourceChannel });
+    resolvedTrustCtx = { trustClass: "guardian", sourceChannel };
   }
 
-  // The trust this request's turn runs under, captured here rather than read
-  // back at the agent loop below. Every branch above has just written it and
-  // nothing awaits in between, so this is the resolved sender. Between here
-  // and the loop the conversation slot is writable by paths that do not own
-  // this turn (channel ingress for another actor, live-voice hydration,
-  // pointer elevation, the voice bridge), and the loop would otherwise
-  // re-read it and run this turn as whoever wrote last.
-  const turnTrustContext = conversation.trustContext;
+  // The trust this request's turn runs under: the sender resolved above,
+  // never a read of the shared slot. Between here and the loop that slot is
+  // writable by paths that do not own this turn (channel ingress for another
+  // actor, live-voice hydration, pointer elevation, the voice bridge).
+  const turnTrustContext = resolvedTrustCtx;
+
+  // Publish the sender as the conversation's resting actor only when no turn
+  // is running. A turn that recorded no actor of its own resolves this slot
+  // live for tool authorization, provenance and reply routing, so a send
+  // landing mid-turn must not move it; the queued message carries its own
+  // trust to the drain instead (see `enqueueMessage` below).
+  if (!conversation.isProcessing()) {
+    conversation.setTrustContext(resolvedTrustCtx);
+  }
 
   const isInteractive = isInteractiveInterface(sourceInterface);
   // Translate the dev-bypass actor principal to the real guardian principal
@@ -2058,7 +2070,7 @@ export async function handleSendMessage(
 
       const conversationId = mapping.conversationId;
       const channelMeta = buildChannelMetadata(sourceChannel, sourceInterface, {
-        trustContext: conversation.trustContext,
+        trustContext: resolvedTrustCtx,
       });
 
       const assistantMsg = createAssistantMessage(cannedGreeting);
@@ -2165,10 +2177,9 @@ export async function handleSendMessage(
 
   // Resolve the verified actor's external user ID and principal for inline
   // approval routing from the conversation's guardian context.
-  const verifiedActorExternalUserId =
-    conversation.trustContext?.guardianExternalUserId;
+  const verifiedActorExternalUserId = resolvedTrustCtx.guardianExternalUserId;
   const verifiedActorPrincipalId =
-    conversation.trustContext?.guardianPrincipalId ?? undefined;
+    resolvedTrustCtx.guardianPrincipalId ?? undefined;
 
   // Try to consume the message as a guardian approval/rejection reply.
   // On failure, degrade to the existing queue/auto-deny path rather than
@@ -2242,6 +2253,10 @@ export async function handleSendMessage(
       sourceActorPrincipalId,
       transport,
       clientMessageId,
+      // The sender's own trust, so the drain runs this message as the actor
+      // who sent it rather than as whoever the slot happens to hold when the
+      // queue is worked.
+      trustContext: resolvedTrustCtx,
     });
     if (enqueueResult.rejected) {
       return new RouteResponse(

--- a/assistant/src/runtime/routes/surface-action-routes.ts
+++ b/assistant/src/runtime/routes/surface-action-routes.ts
@@ -44,25 +44,18 @@ const log = getLogger("surface-action-routes");
  * {@link resolveVellumActorTrustContext} so the surface content route's
  * read-only requester scoping cannot drift from it.
  *
- * The resting slot is only rewritten while the conversation is idle. A click
- * that lands mid-turn belongs to its clicker, not to the running turn, so it
- * travels as an argument; repointing the slot underneath a turn already in
- * flight would hand that turn a different actor's capabilities partway through.
+ * Resolution only: the requester travels to `handleSurfaceAction` as an
+ * argument, and the conversation's slot is stamped there, at the point the
+ * click is committed to starting a turn. Stamping here instead would repoint
+ * the actor of a turn already in flight, or of a turn that starts between this
+ * call and the dispatch.
  */
-async function resolveAndBindTrustContext(
-  conversation: {
-    setTrustContext(ctx: TrustContext): void;
-    isProcessing(): boolean;
-  },
+async function resolveRequesterTrustContext(
   actorPrincipalId: string | undefined,
 ): Promise<TrustContext> {
-  const trustContext = await resolveVellumActorTrustContext(actorPrincipalId, {
+  return resolveVellumActorTrustContext(actorPrincipalId, {
     healResetDrift: true,
   });
-  if (!conversation.isProcessing()) {
-    conversation.setTrustContext(trustContext);
-  }
-  return trustContext;
 }
 
 // ---------------------------------------------------------------------------
@@ -160,10 +153,8 @@ async function handleSurfaceAction({
   }
 
   const actorPrincipalId = headers?.["x-vellum-actor-principal-id"];
-  const requesterTrustContext = await resolveAndBindTrustContext(
-    conversation,
-    actorPrincipalId,
-  );
+  const requesterTrustContext =
+    await resolveRequesterTrustContext(actorPrincipalId);
 
   // Translate dev-bypass → real guardian so the surface turn's principal matches
   // the SSE host-proxy client's registered principal; otherwise CU/app-control

--- a/assistant/src/runtime/routes/surface-action-routes.ts
+++ b/assistant/src/runtime/routes/surface-action-routes.ts
@@ -37,26 +37,32 @@ const log = getLogger("surface-action-routes");
 
 /**
  * Resolve trust context for the actor principal from the gateway guardian
- * binding and set it on the conversation. A vellum principal is the guardian or
- * nobody, so the mapper yields guardian or unknown. Resolution (including the
- * dev-bypass principal translation and the mutating reset-drift repair) lives
- * in the shared {@link resolveVellumActorTrustContext} so the surface content
- * route's read-only requester scoping cannot drift from it.
+ * binding, and return it for the caller to attribute this action with. A vellum
+ * principal is the guardian or nobody, so the mapper yields guardian or
+ * unknown. Resolution (including the dev-bypass principal translation and the
+ * mutating reset-drift repair) lives in the shared
+ * {@link resolveVellumActorTrustContext} so the surface content route's
+ * read-only requester scoping cannot drift from it.
+ *
+ * The resting slot is only rewritten while the conversation is idle. A click
+ * that lands mid-turn belongs to its clicker, not to the running turn, so it
+ * travels as an argument; repointing the slot underneath a turn already in
+ * flight would hand that turn a different actor's capabilities partway through.
  */
-async function applyTrustContext(
+async function resolveAndBindTrustContext(
   conversation: {
-    setTrustContext?(ctx: TrustContext): void;
+    setTrustContext(ctx: TrustContext): void;
+    isProcessing(): boolean;
   },
   actorPrincipalId: string | undefined,
-): Promise<void> {
-  if (!conversation.setTrustContext) {
-    return;
+): Promise<TrustContext> {
+  const trustContext = await resolveVellumActorTrustContext(actorPrincipalId, {
+    healResetDrift: true,
+  });
+  if (!conversation.isProcessing()) {
+    conversation.setTrustContext(trustContext);
   }
-  conversation.setTrustContext(
-    await resolveVellumActorTrustContext(actorPrincipalId, {
-      healResetDrift: true,
-    }),
-  );
+  return trustContext;
 }
 
 // ---------------------------------------------------------------------------
@@ -154,7 +160,10 @@ async function handleSurfaceAction({
   }
 
   const actorPrincipalId = headers?.["x-vellum-actor-principal-id"];
-  await applyTrustContext(conversation, actorPrincipalId);
+  const requesterTrustContext = await resolveAndBindTrustContext(
+    conversation,
+    actorPrincipalId,
+  );
 
   // Translate dev-bypass → real guardian so the surface turn's principal matches
   // the SSE host-proxy client's registered principal; otherwise CU/app-control
@@ -170,6 +179,7 @@ async function handleSurfaceAction({
       actionId,
       data,
       resolvedActorPrincipalId,
+      requesterTrustContext,
     );
     const result =
       raw && typeof raw === "object" && "accepted" in raw


### PR DESCRIPTION
Fixes LUM-3220

## TL;DR

Three request paths stamped the conversation's trust slot on arrival, before knowing whether they were going to run a turn at all. A request that queued behind a live turn, or was rejected as busy, still repointed the conversation's actor. Each path now stamps at the point it commits to running, and a request that does not start a run does not stamp.

## Why

`assistant/docs/architecture/turn-actor.md` defines the slot as the **resting actor**: who the conversation belongs to when no turn is running, "used to hydrate a new turn, to scope history". Its "Writers that stamp for a run" section makes stamping it before a run the documented pattern, not a violation, and `ensureActorScopedHistory`, the persisted user-row provenance and `processMessageImpl` all read it for exactly that purpose.

So the defect is not "the slot gets written while a turn is in flight". It is that a write was happening for runs that never started:

- a send that lands mid-turn is **queued**, so it is not starting a run now, but it repointed the actor anyway;
- a retry rejected with `ConflictError` had already repointed the actor and the turn principal before the busy check;
- a surface click that lands mid-turn is queued the same way.

In each case the running turn's authorization, history scoping and reply routing moved to an actor who is not the one executing.

## What this does

Every path resolves the requester into a local and stamps only where it commits to running a turn.

- **Send route** — the stamp sits in the `// Conversation is idle — persist and fire agent loop immediately` block, beside the `setTurnChannelContext` / `currentTurnSourceActorPrincipalId` setup already there, immediately before `ensureActorScopedHistory()`. The queue branch returns above it, and the queued message carries `trustContext` to the drain. The turn's own trust, the greeting metadata and the guardian reply-router lookups read the local rather than the slot.
- **Retry last turn** — resolution stays before the busy gate, because the surrounding check-then-claim must remain synchronous and the resolver awaits. Both bindings move to just after `setProcessing(true)`, so a rejected retry no longer mutates anything.
- **Surface actions** — the route resolves without touching the conversation and threads the requester into `handleSurfaceAction`, which passes it to `processMessage` on both inline branches. Those are reached only when `enqueueMessage` declined to queue, so they are the commitment points; the two enqueue paths carry the requester on the queue item instead. `handleSurfaceAction` no longer writes to the conversation at all.
- **`processMessage`** — takes the committing actor as an option and stamps it before `ensureActorScopedHistory()`. This is where the stamp belongs: it is the function that starts the turn, and it already scopes history and captures the turn trust. Callers with no actor of their own omit it and the resting actor stands.

Putting the stamp in the call sites instead was the other wrong turn worth recording. Doing so crashed thirteen test doubles that model a `Conversation` without `setTrustContext`; patching thirteen stubs would have been treating the symptom, since what the failures actually showed is that turn-starting call sites should not be reaching for the slot themselves.
- **Canned greeting** — answers and returns without starting a turn, so it never reaches a stamp. It passes `trustContext` to `persistQueuedMessageBody` so the row still names the sender.

`handleSurfaceAction`'s fallback reads `restingTrust(ctx)` rather than a raw slot read, per the doc's rule that call sites name which actor they are asking for.

## Why this is safe

The slot's value at every point a run begins is identical to before. The only behavioural change is the intended one: a request that queues or is rejected no longer stamps.

That property is what the first cut got wrong, and it is worth being explicit about. Stamping early behind an `isProcessing()` guard left a check-then-use gap: both routes await between the guard and the dispatch decision, so a request that arrived busy and became idle took the inline branch with the slot still naming the previous actor. Stamping at the commitment point closes the window rather than narrowing it, because the same synchronous check that decides to run inline is the one that stamps.

No trust is widened anywhere; every value written is the one the same resolver already produced.

## Before / after

| Situation | Before | After |
| --- | --- | --- |
| Send while a turn runs | slot repointed to sender; running turn re-authorizes as them | slot untouched; sender rides the queue to the drain |
| Send while idle | slot set to sender | unchanged |
| Retry rejected as busy | actor and turn principal already mutated | untouched; bound only after the claim succeeds |
| Surface click while a turn runs | slot repointed to clicker | slot untouched; clicker rides the queue item |
| Surface click while idle | slot set at route entry | slot set where the click commits to running |
| Canned greeting row | provenance from the slot | sender named on the row |

## Tests

`surface-action-routes.test.ts` covers both sides: busy leaves the slot as the identical object it was (`toBe`, so re-writing an equal value still fails) while the click still travels as its own actor; idle threads the requester and leaves the slot to the dispatch. The five existing trust-resolution tests now observe the threaded argument, since the route no longer stamps. The stub gained `isProcessing`, which the tightened parameter type forces it to model.

Not added: direct regression tests for the send and retry routes. Neither has a harness and `handleSendMessage`'s module has 72 imports, so one would have to be written blind against a hook-blocked local runner. Called out rather than skipped quietly; the shared rule is covered where a harness exists.

## Found but deliberately not fixed here

**Queued turns never re-scope history.** `ensureActorScopedHistory` is called only from `processMessage`; neither `drainSingleMessage` nor `drainBatch` calls it. A queued message from a differently trusted actor therefore runs against history loaded for the previous actor. This predates the PR and is independent of the slot, since no drain path reads the slot for scoping. Fixing it means a mid-drain `loadFromDb`, which is a behavioural change to core drain machinery and does not belong in a change about where routes stamp.

**Raw slot reads in the agent loop.** Several `conversation-agent-loop.ts` call sites read `ctx.trustContext` directly, which `turn-actor.md` explicitly forbids in favour of the named accessors. Not load-bearing for this change; a separate cleanup.

## Verification

`tsc --noEmit`, eslint and the pinned prettier over the touched files. Local `bun test` is hook-blocked; CI runs the suites.
