### PR TITLE
fix(slack): an edit or button press no longer inherits a thread id from its own message (LUM-3340)

### DIFF
--- a/assistant/src/__tests__/edit-propagation.test.ts
+++ b/assistant/src/__tests__/edit-propagation.test.ts
@@ -171,6 +171,8 @@ describe("Slack edit propagation", () => {
     expect(slackMeta!.editedAt!).toBeGreaterThanOrEqual(t0);
   });
 
+  // Times out on the default budget: an unresolvable target pays the full
+  // `EDIT_LOOKUP_RETRIES` window before it is dropped.
   test("an edit of a message the assistant never stored creates no conversation", async () => {
     // Keying a conversation off the edit's own address made every edit of an
     // unseen message mint one, permanently titled with the loading placeholder.
@@ -196,7 +198,7 @@ describe("Slack edit propagation", () => {
     expect(countRows("conversations")).toBe(0);
     expect(countRows("channel_inbound_events")).toBe(0);
     expect(countRows("messages")).toBe(0);
-  });
+  }, 30_000);
 
   test("an edit records against the edited message's conversation, not a new one", async () => {
     const seeded = await seedSlackMessage({

--- a/assistant/src/__tests__/edit-propagation.test.ts
+++ b/assistant/src/__tests__/edit-propagation.test.ts
@@ -262,7 +262,7 @@ describe("Slack edit propagation", () => {
     expect(second.eventId).toBe(first.eventId);
   });
 
-  test("threaded Slack edits use the threaded conversation key and preserve thread metadata", async () => {
+  test("a threaded edit stays in the edited message's conversation and preserves thread metadata", async () => {
     const conversationExternalId = "C0123CHANNEL";
     const threadTs = "1234.0000";
     const seeded = await seedSlackMessage({
@@ -270,6 +270,14 @@ describe("Slack edit propagation", () => {
       channelTs: "1234.5678",
       initialContent: "original text",
     });
+    const db = getDb();
+    const conversationCount = (): number =>
+      (
+        db.$client.prepare("SELECT COUNT(*) AS n FROM conversations").get() as {
+          n: number;
+        }
+      ).n;
+    const before = conversationCount();
 
     const resp = await handleEditIntercept({
       sourceChannel: "slack",
@@ -282,10 +290,12 @@ describe("Slack edit propagation", () => {
     });
 
     expect((resp as Record<string, unknown>).accepted).toBe(true);
+
+    // The thread id names where the reply goes, not a conversation of the
+    // edit's own. Keying one off it is what minted a conversation per edit.
     const threadedKey = `asst:self:slack:${conversationExternalId}:thread:${threadTs}`;
-    const editConversation = getConversationByKey(threadedKey);
-    expect(editConversation).not.toBeNull();
-    expect(editConversation!.conversationId).not.toBe(seeded.conversationId);
+    expect(getConversationByKey(threadedKey)).toBeNull();
+    expect(conversationCount()).toBe(before);
 
     const after = readMessageRow(seeded.messageId);
     const outer = JSON.parse(after.metadata!) as Record<string, unknown>;

--- a/assistant/src/__tests__/edit-propagation.test.ts
+++ b/assistant/src/__tests__/edit-propagation.test.ts
@@ -171,6 +171,97 @@ describe("Slack edit propagation", () => {
     expect(slackMeta!.editedAt!).toBeGreaterThanOrEqual(t0);
   });
 
+  test("an edit of a message the assistant never stored creates no conversation", async () => {
+    // Keying a conversation off the edit's own address made every edit of an
+    // unseen message mint one, permanently titled with the loading placeholder.
+    const db = getDb();
+    const countRows = (table: string): number =>
+      (
+        db.$client.prepare(`SELECT COUNT(*) AS n FROM ${table}`).get() as {
+          n: number;
+        }
+      ).n;
+
+    const resp = (await handleEditIntercept({
+      sourceChannel: "slack",
+      conversationExternalId: "C0NEVERSEEN",
+      externalMessageId: nextEditEventId(),
+      sourceMessageId: "1999.0001",
+      assistantId: "self",
+      content: "edited text",
+    })) as Record<string, unknown>;
+
+    expect(resp.accepted).toBe(true);
+    expect(resp.edited).toBe(false);
+    expect(countRows("conversations")).toBe(0);
+    expect(countRows("channel_inbound_events")).toBe(0);
+    expect(countRows("messages")).toBe(0);
+  });
+
+  test("an edit records against the edited message's conversation, not a new one", async () => {
+    const seeded = await seedSlackMessage({
+      conversationExternalId: "C0123CHANNEL",
+      channelTs: "1234.5678",
+      initialContent: "original text",
+    });
+    const db = getDb();
+    const conversationsBefore = (
+      db.$client.prepare("SELECT COUNT(*) AS n FROM conversations").get() as {
+        n: number;
+      }
+    ).n;
+
+    await handleEditIntercept({
+      sourceChannel: "slack",
+      conversationExternalId: seeded.conversationExternalId,
+      externalMessageId: nextEditEventId(),
+      sourceMessageId: seeded.channelTs,
+      assistantId: "self",
+      content: "new text",
+    });
+
+    const conversationsAfter = (
+      db.$client.prepare("SELECT COUNT(*) AS n FROM conversations").get() as {
+        n: number;
+      }
+    ).n;
+    expect(conversationsAfter).toBe(conversationsBefore);
+
+    const editEvents = db.$client
+      .prepare(
+        `SELECT conversation_id AS conversationId FROM channel_inbound_events
+         WHERE external_message_id LIKE 'edit-event-%'`,
+      )
+      .all() as Array<{ conversationId: string }>;
+    expect(editEvents).toHaveLength(1);
+    expect(editEvents[0].conversationId).toBe(seeded.conversationId);
+  });
+
+  test("a redelivered edit is answered without repeating the lookup window", async () => {
+    const seeded = await seedSlackMessage({
+      conversationExternalId: "C0123CHANNEL",
+      channelTs: "1234.5678",
+      initialContent: "original text",
+    });
+    const editEventId = nextEditEventId();
+    const send = () =>
+      handleEditIntercept({
+        sourceChannel: "slack",
+        conversationExternalId: seeded.conversationExternalId,
+        externalMessageId: editEventId,
+        sourceMessageId: seeded.channelTs,
+        assistantId: "self",
+        content: "new text",
+      }) as Promise<Record<string, unknown>>;
+
+    const first = await send();
+    const second = await send();
+
+    expect(first.duplicate).toBe(false);
+    expect(second.duplicate).toBe(true);
+    expect(second.eventId).toBe(first.eventId);
+  });
+
   test("threaded Slack edits use the threaded conversation key and preserve thread metadata", async () => {
     const conversationExternalId = "C0123CHANNEL";
     const threadTs = "1234.0000";

--- a/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
@@ -142,7 +142,7 @@ export async function handleEditIntercept(
         "Could not find original message for edit after retries, ignoring",
       );
     }
-    return { accepted: true, edited: false };
+    return { accepted: true, duplicate: false, edited: false };
   }
 
   // The edit belongs to the conversation of the message it changes. Resolving

--- a/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
@@ -25,6 +25,7 @@ import {
   updateMessageContentAndMetadata,
 } from "../../../persistence/conversation-crud.js";
 import {
+  findInboundEvent,
   findMessageBySourceId,
   recordInbound,
 } from "../../../persistence/delivery-crud.js";
@@ -71,19 +72,19 @@ export async function handleEditIntercept(
     content,
   } = params;
 
-  // Dedup the edit event itself (retried edited_message webhooks)
-  const editResult = recordInbound(
+  // Dedup the edit event itself (retried edited_message webhooks) before the
+  // lookup below, so a redelivery answers immediately instead of waiting out
+  // the retry window a second time.
+  const alreadyRecorded = findInboundEvent(
     sourceChannel,
     conversationExternalId,
     externalMessageId,
-    { sourceMessageId, sourceThreadId },
   );
-
-  if (editResult.duplicate) {
+  if (alreadyRecorded) {
     return {
       accepted: true,
       duplicate: true,
-      eventId: editResult.eventId,
+      eventId: alreadyRecorded.eventId,
     };
   }
 
@@ -117,81 +118,92 @@ export async function handleEditIntercept(
     }
   }
 
-  if (original) {
-    const newContent = content ?? "";
-    // Short-circuit no-op edits: Slack fires `message_changed` for link
-    // unfurls and other decorations where the text is identical to the
-    // previous revision. Skipping the DB write here covers that case and
-    // also drops trivially-redundant edit webhooks. We only have the
-    // authoritative previous text once the original row is located, so
-    // this check lives after the lookup.
-    const existingRow = getMessageById(original.messageId);
-    if (
-      existingRow &&
-      stringifyMessageContent(existingRow.content) === newContent
-    ) {
-      log.debug(
-        {
-          assistantId,
-          sourceChannel,
-          sourceMessageId,
-          messageId: original.messageId,
-        },
-        "Edit text unchanged; skipping update",
-      );
-      return {
-        accepted: true,
-        duplicate: false,
-        noop: true,
-        eventId: editResult.eventId,
-      };
-    }
+  if (!original) {
+    // Nothing to edit, and nothing to record it against. Recording it anyway
+    // is what created a conversation per edited message.
+    //
+    // Slack keeps this at `debug`: the row may have been compacted, never
+    // stored, or predate this behaviour. Other channels keep the louder
+    // `warn`, since their edit pipelines expect the row to exist.
+    const missingTarget = {
+      assistantId,
+      sourceChannel,
+      conversationExternalId,
+      sourceMessageId,
+    };
     if (sourceChannel === "slack") {
-      // Slack edits stamp `slackMeta.editedAt` so the chronological
-      // transcript renderer can surface the edited marker. The merge
-      // tolerates rows that lack slackMeta enrichment by synthesizing
-      // the minimum-required fields from the lookup data.
-      applySlackEditMetadata({
-        messageId: original.messageId,
-        conversationExternalId,
-        sourceMessageId,
-        sourceThreadId,
-        newContent,
-      });
-    } else {
-      updateMessageContent(original.messageId, newContent);
-    }
-    // The edit changed searchable text (the no-op guard above already returned
-    // for identical content) and this path bypasses the `addMessage` persist
-    // path, so reindex the message into the lexical index — the idempotent
-    // upsert replaces the stale Qdrant point with the edited content.
-    enqueueLexicalIndexForMessage(original.messageId);
-    log.info(
-      { assistantId, sourceMessageId, messageId: original.messageId },
-      "Updated message content from edited_message",
-    );
-  } else {
-    // For Slack, treat missing-target edits as `debug` (the row may have
-    // been compacted, never stored, or pre-date this upgrade); for other
-    // channels, retain the louder `warn` since their edit pipelines
-    // historically expect the row to exist.
-    if (sourceChannel === "slack") {
-      log.debug(
-        {
-          assistantId,
-          sourceChannel,
-          channelId: conversationExternalId,
-          externalMessageId: sourceMessageId,
-        },
-        "Slack edit target not found, ignoring",
-      );
+      log.debug(missingTarget, "Slack edit target not found, ignoring");
     } else {
       log.warn(
-        { assistantId, sourceChannel, conversationExternalId, sourceMessageId },
+        missingTarget,
         "Could not find original message for edit after retries, ignoring",
       );
     }
+    return { accepted: true, edited: false };
   }
+
+  // The edit belongs to the conversation of the message it changes. Resolving
+  // one from the edit's own address would key it on the edited message's
+  // timestamp and create a conversation there.
+  const editResult = recordInbound(
+    sourceChannel,
+    conversationExternalId,
+    externalMessageId,
+    { sourceMessageId, conversationId: original.conversationId },
+  );
+
+  const newContent = content ?? "";
+  // Short-circuit no-op edits: Slack fires `message_changed` for link
+  // unfurls and other decorations where the text is identical to the
+  // previous revision. Skipping the DB write here covers that case and
+  // also drops trivially-redundant edit webhooks. We only have the
+  // authoritative previous text once the original row is located, so
+  // this check lives after the lookup.
+  const existingRow = getMessageById(original.messageId);
+  if (
+    existingRow &&
+    stringifyMessageContent(existingRow.content) === newContent
+  ) {
+    log.debug(
+      {
+        assistantId,
+        sourceChannel,
+        sourceMessageId,
+        messageId: original.messageId,
+      },
+      "Edit text unchanged; skipping update",
+    );
+    return {
+      accepted: true,
+      duplicate: false,
+      noop: true,
+      eventId: editResult.eventId,
+    };
+  }
+  if (sourceChannel === "slack") {
+    // Slack edits stamp `slackMeta.editedAt` so the chronological
+    // transcript renderer can surface the edited marker. The merge
+    // tolerates rows that lack slackMeta enrichment by synthesizing
+    // the minimum-required fields from the lookup data.
+    applySlackEditMetadata({
+      messageId: original.messageId,
+      conversationExternalId,
+      sourceMessageId,
+      sourceThreadId,
+      newContent,
+    });
+  } else {
+    updateMessageContent(original.messageId, newContent);
+  }
+  // The edit changed searchable text (the no-op guard above already returned
+  // for identical content) and this path bypasses the `addMessage` persist
+  // path, so reindex the message into the lexical index — the idempotent
+  // upsert replaces the stale Qdrant point with the edited content.
+  enqueueLexicalIndexForMessage(original.messageId);
+  log.info(
+    { assistantId, sourceMessageId, messageId: original.messageId },
+    "Updated message content from edited_message",
+  );
 
   return {
     accepted: true,

--- a/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
@@ -154,6 +154,12 @@ export async function handleEditIntercept(
     externalMessageId,
     { sourceMessageId, conversationId: original.conversationId },
   );
+  if (editResult.duplicate) {
+    // Two deliveries of one edit raced through the probe above while neither
+    // had recorded yet. The first owns the write; applying it twice would
+    // re-enqueue lexical indexing for no change.
+    return { accepted: true, duplicate: true, eventId: editResult.eventId };
+  }
 
   const newContent = content ?? "";
   // Short-circuit no-op edits: Slack fires `message_changed` for link

--- a/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
@@ -11,14 +11,16 @@
  * the message's metadata via a single transactional content+metadata update,
  * so downstream renderers can surface the edited marker.
  *
- * Extracted from inbound-message-handler.ts to keep the top-level handler
- * focused on orchestration.
+ * An edit belongs to the conversation of the message it changes, so the stage
+ * resolves that message before it records anything, and an edit with no
+ * resolvable target is dropped.
  */
 import type { ChannelId } from "../../../channels/types.js";
 import {
   mergeSlackMetadata,
   readSlackMetadata,
 } from "../../../messaging/providers/slack/message-metadata.js";
+import type { MessageRow } from "../../../persistence/conversation-crud.js";
 import {
   getMessageById,
   updateMessageContent,
@@ -119,12 +121,13 @@ export async function handleEditIntercept(
   }
 
   if (!original) {
-    // Nothing to edit, and nothing to record it against. Recording it anyway
-    // is what created a conversation per edited message.
+    // Nothing to edit, and nothing to record it against: recording it anyway
+    // would resolve a conversation from the edit's own address and create one
+    // there.
     //
-    // Slack keeps this at `debug`: the row may have been compacted, never
-    // stored, or predate this behaviour. Other channels keep the louder
-    // `warn`, since their edit pipelines expect the row to exist.
+    // Slack keeps this at `debug`, since the row may have been compacted or
+    // never stored. Other channels keep the louder `warn`, since their edit
+    // pipelines expect the row to exist.
     const missingTarget = {
       assistantId,
       sourceChannel,
@@ -187,6 +190,7 @@ export async function handleEditIntercept(
     // the minimum-required fields from the lookup data.
     applySlackEditMetadata({
       messageId: original.messageId,
+      existingRow,
       conversationExternalId,
       sourceMessageId,
       sourceThreadId,
@@ -229,6 +233,8 @@ export async function handleEditIntercept(
  */
 function applySlackEditMetadata(params: {
   messageId: string;
+  /** The stored row, already read by the caller's no-op guard. */
+  existingRow: MessageRow | null;
   conversationExternalId: string;
   sourceMessageId: string;
   sourceThreadId?: string;
@@ -236,13 +242,13 @@ function applySlackEditMetadata(params: {
 }): void {
   const {
     messageId,
+    existingRow: row,
     conversationExternalId,
     sourceMessageId,
     sourceThreadId,
     newContent,
   } = params;
 
-  const row = getMessageById(messageId);
   const outerMetadata: Record<string, unknown> =
     row?.metadata != null ? safeParseRecord(row.metadata) : {};
   const existingSlackMeta =

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1,5 +1,6 @@
 process.title = "vellum-gateway";
 
+import { buildSlackSourceMetadata } from "./slack/source-metadata.js";
 import { randomBytes } from "node:crypto";
 
 import {
@@ -2360,19 +2361,13 @@ async function main() {
         const origMessageTs = normalized.event.source.messageId;
         if (!threadTs && origMessageTs) params.set("messageTs", origMessageTs);
         const replyCallbackUrl = `${config.gatewayInternalBaseUrl}/deliver/slack?${params}`;
-        const slackSourceMetadata = {
-          ...(normalized.event.raw.type === "app_mention"
-            ? { slackBotMentioned: true }
-            : {}),
-          ...(threadTs && !normalized.event.source.threadId
-            ? { threadId: threadTs }
-            : {}),
-        };
 
         // Whether this event represents an edit or callback action — these
-        // never carry attachments to upload.
+        // never carry attachments to upload, and neither names a thread.
         const isEdit = !!normalized.event.message.isEdit;
         const isCallback = !!normalized.event.message.callbackData;
+
+        const slackSourceMetadata = buildSlackSourceMetadata(normalized);
 
         // Handle /new command — reset conversation before it reaches the runtime
         if (isNewCommand(normalized.event.message.content)) {

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1,5 +1,6 @@
 process.title = "vellum-gateway";
 
+import { slackEventRefersToAnotherMessage } from "./slack/event-kind.js";
 import { buildSlackSourceMetadata } from "./slack/source-metadata.js";
 import { randomBytes } from "node:crypto";
 
@@ -2362,11 +2363,9 @@ async function main() {
         if (!threadTs && origMessageTs) params.set("messageTs", origMessageTs);
         const replyCallbackUrl = `${config.gatewayInternalBaseUrl}/deliver/slack?${params}`;
 
-        // Whether this event represents an edit or callback action — these
-        // never carry attachments to upload, and neither names a thread.
-        const isEdit = !!normalized.event.message.isEdit;
-        const isCallback = !!normalized.event.message.callbackData;
-
+        const refersToAnotherMessage = slackEventRefersToAnotherMessage(
+          normalized.event.message,
+        );
         const slackSourceMetadata = buildSlackSourceMetadata(normalized);
 
         // Handle /new command — reset conversation before it reaches the runtime
@@ -2422,16 +2421,15 @@ async function main() {
           }
 
           try {
-            // Download and upload attachments if present (skip for edits and
-            // callback actions — edits only update text, callbacks have no media)
+            // Download and upload attachments if present. An event that acts
+            // on another message brings no media of its own.
             let attachmentIds: string[] | undefined;
             const eventAttachments = normalized.event.message.attachments;
             if (
               eventAttachments &&
               eventAttachments.length > 0 &&
               normalized.slackFiles &&
-              !isEdit &&
-              !isCallback
+              !refersToAnotherMessage
             ) {
               attachmentIds = [];
               const failedAttachmentNames: string[] = [];

--- a/gateway/src/slack/event-kind.ts
+++ b/gateway/src/slack/event-kind.ts
@@ -1,0 +1,17 @@
+import type { SlackInboundEvent } from "../channels/inbound-event.js";
+
+type SlackInboundMessage = SlackInboundEvent["message"];
+
+/**
+ * Whether the event acts on a message rather than being one: an edit, a
+ * delete, a reaction, or a button press.
+ *
+ * Two things follow from it. Such an event carries no media of its own, and it
+ * names no thread: it replies where the message it refers to lives, without
+ * creating a thread there.
+ */
+export function slackEventRefersToAnotherMessage(
+  message: SlackInboundMessage,
+): boolean {
+  return message.isEdit === true || typeof message.callbackData === "string";
+}

--- a/gateway/src/slack/source-metadata.test.ts
+++ b/gateway/src/slack/source-metadata.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "bun:test";
+
+import type { NormalizedSlackEvent } from "./message-schemas.js";
+import { buildSlackSourceMetadata } from "./source-metadata.js";
+
+const CHANNEL = "C0123CHANNEL";
+const MESSAGE_TS = "1700000000.000100";
+
+function normalized(overrides: {
+  rawType?: string;
+  threadTs?: string;
+  sourceThreadId?: string;
+  isEdit?: boolean;
+  callbackData?: string;
+}): NormalizedSlackEvent {
+  return {
+    event: {
+      version: "v1",
+      sourceChannel: "slack",
+      receivedAt: new Date().toISOString(),
+      message: {
+        content: "hello",
+        conversationExternalId: CHANNEL,
+        externalMessageId: MESSAGE_TS,
+        ...(overrides.isEdit ? { isEdit: true } : {}),
+        ...(overrides.callbackData
+          ? { callbackData: overrides.callbackData }
+          : {}),
+      },
+      actor: { actorExternalId: "U0123" },
+      source: {
+        updateId: "Ev123",
+        messageId: MESSAGE_TS,
+        ...(overrides.sourceThreadId
+          ? { threadId: overrides.sourceThreadId }
+          : {}),
+      },
+      raw: { type: overrides.rawType ?? "message" },
+    },
+    routing: { assistantId: "self" } as NormalizedSlackEvent["routing"],
+    ...(overrides.threadTs ? { threadTs: overrides.threadTs } : {}),
+    channel: CHANNEL,
+  } as NormalizedSlackEvent;
+}
+
+describe("buildSlackSourceMetadata", () => {
+  it("gives a message with no thread of its own the thread its reply will create", () => {
+    // The assistant replies in a thread rooted here, so keying the
+    // conversation on it is correct.
+    expect(
+      buildSlackSourceMetadata(normalized({ threadTs: MESSAGE_TS })),
+    ).toEqual({ threadId: MESSAGE_TS });
+  });
+
+  it("passes through a real thread the message is already in", () => {
+    const meta = buildSlackSourceMetadata(
+      normalized({
+        threadTs: "1699999999.000001",
+        sourceThreadId: "1699999999.000001",
+      }),
+    );
+    // Already on `source.threadId`, so nothing is added here.
+    expect(meta.threadId).toBeUndefined();
+  });
+
+  it("gives an edit no thread id, so it cannot key a conversation on one", () => {
+    expect(
+      buildSlackSourceMetadata(
+        normalized({ threadTs: MESSAGE_TS, isEdit: true }),
+      ),
+    ).toEqual({});
+  });
+
+  it("gives a button press no thread id", () => {
+    expect(
+      buildSlackSourceMetadata(
+        normalized({
+          threadTs: MESSAGE_TS,
+          callbackData: "apr:req-1:approve_once",
+        }),
+      ),
+    ).toEqual({});
+  });
+
+  it("keeps a real thread on an edit made inside one", () => {
+    // `source.threadId` is Slack's own answer, not a fallback, so it survives.
+    const meta = buildSlackSourceMetadata(
+      normalized({
+        threadTs: "1699999999.000001",
+        sourceThreadId: "1699999999.000001",
+        isEdit: true,
+      }),
+    );
+    expect(meta.threadId).toBeUndefined();
+  });
+
+  it("marks an app mention", () => {
+    expect(
+      buildSlackSourceMetadata(
+        normalized({ rawType: "app_mention", threadTs: MESSAGE_TS }),
+      ),
+    ).toEqual({ slackBotMentioned: true, threadId: MESSAGE_TS });
+  });
+});

--- a/gateway/src/slack/source-metadata.ts
+++ b/gateway/src/slack/source-metadata.ts
@@ -1,14 +1,13 @@
+import type { SourceMetadata } from "@vellumai/gateway-client";
+
+import { slackEventRefersToAnotherMessage } from "./event-kind.js";
 import type { NormalizedSlackEvent } from "./message-schemas.js";
 
-/**
- * Slack-specific fields added to a forwarded event's `sourceMetadata`. Indexed
- * so it composes with the wider `SourceMetadata` the gateway forwards.
- */
-export interface SlackSourceMetadata {
-  [key: string]: unknown;
-  slackBotMentioned?: true;
-  threadId?: string;
-}
+/** The `sourceMetadata` fields the Slack ingress path sets. */
+export type SlackSourceMetadata = Pick<
+  SourceMetadata,
+  "slackBotMentioned" | "threadId"
+>;
 
 /**
  * Build the Slack fields the runtime reads off `sourceMetadata`.
@@ -31,12 +30,12 @@ export function buildSlackSourceMetadata(
   normalized: NormalizedSlackEvent,
 ): SlackSourceMetadata {
   const { message, source, raw } = normalized.event;
-  const refersToAnotherMessage =
-    message.isEdit === true || typeof message.callbackData === "string";
 
   return {
-    ...(raw.type === "app_mention" ? { slackBotMentioned: true as const } : {}),
-    ...(normalized.threadTs && !source.threadId && !refersToAnotherMessage
+    ...(raw.type === "app_mention" ? { slackBotMentioned: true } : {}),
+    ...(normalized.threadTs &&
+    !source.threadId &&
+    !slackEventRefersToAnotherMessage(message)
       ? { threadId: normalized.threadTs }
       : {}),
   };

--- a/gateway/src/slack/source-metadata.ts
+++ b/gateway/src/slack/source-metadata.ts
@@ -1,0 +1,43 @@
+import type { NormalizedSlackEvent } from "./message-schemas.js";
+
+/**
+ * Slack-specific fields added to a forwarded event's `sourceMetadata`. Indexed
+ * so it composes with the wider `SourceMetadata` the gateway forwards.
+ */
+export interface SlackSourceMetadata {
+  [key: string]: unknown;
+  slackBotMentioned?: true;
+  threadId?: string;
+}
+
+/**
+ * Build the Slack fields the runtime reads off `sourceMetadata`.
+ *
+ * `threadTs` answers "where does a reply go". For a message with no thread of
+ * its own that is a thread rooted at the message itself, and the runtime is
+ * right to key the conversation there, because the assistant's reply is what
+ * creates that thread.
+ *
+ * An edit or a button press replies into the same place but creates no thread.
+ * Passing them the same value as `threadId` keys a conversation on a thread
+ * that will never exist, so the runtime mints one per edited message and one
+ * per card tapped. They get none, and resolve against the conversation the
+ * message they refer to already lives in.
+ *
+ * Reply targeting is unaffected either way: it travels in the delivery
+ * callback URL, not here.
+ */
+export function buildSlackSourceMetadata(
+  normalized: NormalizedSlackEvent,
+): SlackSourceMetadata {
+  const { message, source, raw } = normalized.event;
+  const refersToAnotherMessage =
+    message.isEdit === true || typeof message.callbackData === "string";
+
+  return {
+    ...(raw.type === "app_mention" ? { slackBotMentioned: true as const } : {}),
+    ...(normalized.threadTs && !source.threadId && !refersToAnotherMessage
+      ? { threadId: normalized.threadTs }
+      : {}),
+  };
+}


### PR DESCRIPTION
Fixes LUM-3340

## TL;DR

A Slack edit and a Slack button press each created a conversation keyed on their own message's timestamp. Guardian approval cards sit at the root of the guardian's DM, so **every approval tap left an orphan conversation behind**, permanently titled `Generating title...`. Same for every edit of a top-level message.

## Root cause, shared by both

The gateway backfills `sourceMetadata.threadId` from `normalized.threadTs` whenever an event carries no thread of its own.

For a message that is correct. Slack sends no `thread_ts` on a top-level message, so `threadTs` falls back to the message's own ts, the reply is posted into a thread rooted there, and that thread genuinely becomes the conversation. The fallback is doing real work.

An edit or a button press replies into that same place but creates no thread. Handing them the same value keys a conversation on a thread that will never exist, and `recordInbound` creates it.

One value, two meanings. That is the whole bug, and it is the same fabrication behind the reaction orphans fixed in LUM-3330.

## What this does

**Gateway.** The fallback is gated on the event being a message, in a new `buildSlackSourceMetadata` where the reasoning lives next to the rule rather than inline in a socket callback.

"Acts on another message" is one fact with two consequences, so it is one predicate (`slack/event-kind.ts`): such an event names no thread, and it carries no media of its own. The attachment-upload guard already tested the same thing as `!isEdit && !isCallback` and now reads the predicate. The two spellings differed only on an empty-string `callbackData`, which no Slack normalizer can produce: block actions return null on a falsy value, a delete sets a literal, and a reaction builds `prefix:emoji`.

Reply targeting is unaffected. It travels in the delivery callback URL (`/deliver/slack?threadTs=…`), not in `sourceMetadata`, so where a reply is posted does not change. Only which conversation the event is keyed to changes. That is the single fact that makes this safe.

**Daemon.** A gated edit resolves the flat channel key, which still creates that conversation when nothing is bound there yet, so `edit-intercept` now finds the message it changes before recording anything, and records against that message's conversation via the `conversationId` option added in LUM-3330. An edit of a message that was never stored has nothing to change and is dropped.

Its redelivery check also moves ahead of the lookup, so a retried edit answers immediately instead of waiting out the six-attempt retry window a second time.

## Before and after

| Scenario | Before | After |
| --- | --- | --- |
| Guardian taps a button on a card at DM root | new orphan conversation per tap, plus a binding row for a thread that does not exist | decision applies, nothing created |
| Button press inside a real thread | correct conversation | unchanged |
| Edit of a top-level message | new orphan conversation | edit lands on the message, in its conversation |
| Edit inside a real thread | correct conversation | unchanged |
| Edit of a message that was never stored | new empty conversation | dropped |
| Redelivered edit | waits out the full retry window again | answered immediately |
| Ordinary message, threaded or not | unchanged | unchanged |

## Why this is safe

- Reply delivery does not read `sourceMetadata.threadId`, so no reply moves.
- A real thread still arrives on `source.threadId`, which Slack itself supplies. Only the *fallback* is gated, so an edit or a press inside a genuine thread keeps its thread.
- Dedup is unchanged: same `(source_channel, external_chat_id, external_message_id)` triple.
- The edit's own event row is never linked to a message, so recording it with `sourceMessageId` cannot compete with the real message's row in `findMessageBySourceId`.
- Reactions are untouched. They set `source.threadId` directly in their normalizer, never used the fallback, and no longer key a conversation from it at all after LUM-3330.

## Verification

- `gateway/src/slack/source-metadata.test.ts` (new): a plain message still gets the thread its reply will create; an edit and a button press get none; a real thread on `source.threadId` survives on all of them; an app mention is still marked.
- `assistant/src/__tests__/edit-propagation.test.ts`: an edit of a never-stored message creates zero conversations, zero inbound events and zero messages; an edit records against the edited message's conversation and adds no conversation; a redelivered edit is answered without repeating the lookup window. Existing edit cases keep their assertions.
- Typecheck, eslint and prettier clean in both packages. Local test runs are blocked in this environment; CI runs the suite.

`SlackSourceMetadata` is a `Pick` of `SourceMetadata` from the wire contract, which already declares both fields, rather than a second hand-written copy of that shape.

## Not in this PR

- The remaining lanes that create a conversation without running a turn (floor deny, disk-pressure block, secret block, dead-letter). Tracked in LUM-2872, and independent of this.
- Conversations already stuck from this bug. They are unreachable orphans nothing will route to again; anything that does receive activity heals itself, because `canReplaceTitle` already treats the placeholder as replaceable.
