### PR TITLE
fix(web): agree the section bulk actions with the conversations they act on

### DIFF
--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -220,12 +220,12 @@
     "failed": "No se pudo descargar el archivo"
   },
   "groupActions": {
-    "archiveAll": "Archivar todo…",
+    "archiveAll": "Archivar todas…",
     "copyGroupId": "Copiar ID del grupo",
     "deleteGroup": "Eliminar grupo",
     "deleteGroupWithConversations": "Eliminar grupo…",
     "groupByChannel": "Agrupar por canal",
-    "markAllRead": "Marcar todo como leído",
+    "markAllRead": "Marcar todas como leídas",
     "moveSectionDown": "Bajar sección",
     "moveSectionUp": "Subir sección",
     "rename": "Cambiar nombre",


### PR DESCRIPTION
## TL;DR

Two Spanish strings added in #40892 disagree in gender and number with every string beside them. What a sidebar section's bulk commands act on is *conversaciones*, so they take the feminine plural.

## Before / after

| Key | Before | After |
| --- | --- | --- |
| `chat:groupActions.markAllRead` | Marcar todo como leído | Marcar todas como leídas |
| `chat:groupActions.archiveAll` | Archivar todo… | Archivar todas… |

English is untouched.

## Why these are the right forms

The surrounding catalog is consistent, and both of these were the odd ones out:

| Key | Spanish |
| --- | --- |
| `home:actions.markAllAsRead` | Marcar todas como leídas |
| `home:actions.clearAll` | Borrar todas |
| `chat:conversationActions.markRead` | Marcar como leída |
| `chat:conversationActions.markUnread` | Marcar como no leída |

Found by comparing every string I added in the read-state work against existing translations of the same English elsewhere in the catalogs. The only other pair that differs is `Rename`, where `chat:conversationActions.rename` says "Cambiar nombre" and `workspace:workspaceTree.rename` says "Cambiar el nombre". Both are correct, that pair predates this work, and the new key matches the sibling in its own menu, so it is left alone.

## Why it is safe

Two values in one locale file. No key names, no English, no code.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40911" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->