### PR TITLE
feat(companion): free the surface from the top of the screen, and let it resize

### DIFF
--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
 
+import { COMPANION_SIZES } from "@vellumai/ipc-contract";
+
 // The module under test reaches `main-window.ts` to hand Talk to the renderer
 // that owns the live-voice session, and that chain loads `electron-store`, a
 // real module that imports the Electron binary's default export and cannot
@@ -19,7 +21,10 @@ mock.module("electron-store", () => ({
 // static imports hoist above it.
 const {
   growthFor,
-  clampCanvasOrigin,
+  cardGrowthFor,
+  avatarOffsetFor,
+  geometryFor,
+  placeCanvas,
   callOnUpdate,
   shouldShowCompanionSurface,
 } = await import("./companion-window");
@@ -52,39 +57,39 @@ const NEEDED = 316;
 
 describe("growthFor", () => {
   test("grows rightward with room to the right", () => {
-    expect(growthFor(720, DISPLAY)).toBe("right");
+    expect(growthFor(720, DISPLAY, GEOMETRY)).toBe("right");
   });
 
   test("still grows rightward hard against the left edge", () => {
     // Growth runs away from the edge here, so there is nothing to flip.
-    expect(growthFor(40, DISPLAY)).toBe("right");
+    expect(growthFor(40, DISPLAY, GEOMETRY)).toBe("right");
   });
 
   test("flips leftward when the right runs out", () => {
-    expect(growthFor(1400, DISPLAY)).toBe("left");
+    expect(growthFor(1400, DISPLAY, GEOMETRY)).toBe("left");
   });
 
   test("exactly enough room on the right still grows rightward", () => {
-    expect(growthFor(DISPLAY.width - NEEDED, DISPLAY)).toBe("right");
+    expect(growthFor(DISPLAY.width - NEEDED, DISPLAY, GEOMETRY)).toBe("right");
   });
 
   test("one pixel short on the right flips", () => {
-    expect(growthFor(DISPLAY.width - NEEDED + 1, DISPLAY)).toBe("left");
+    expect(growthFor(DISPLAY.width - NEEDED + 1, DISPLAY, GEOMETRY)).toBe("left");
   });
 
   test("measures against the display's own origin, not the screen's", () => {
     // A second display to the right of the primary. Its right edge is 2880, so
     // an avatar near it has no room even though its absolute x is large.
     const secondary = { x: 1440, width: 1440 };
-    expect(growthFor(2840, secondary)).toBe("left");
-    expect(growthFor(1600, secondary)).toBe("right");
+    expect(growthFor(2840, secondary, GEOMETRY)).toBe("left");
+    expect(growthFor(1600, secondary, GEOMETRY)).toBe("right");
   });
 
   test("a display too narrow for either direction still grows right", () => {
     // The clipping is unavoidable, and the user can drag the surface somewhere
     // it fits. Flipping would only move which end is cut off.
     const narrow = { x: 0, width: 200 };
-    expect(growthFor(100, narrow)).toBe("right");
+    expect(growthFor(100, narrow, GEOMETRY)).toBe("right");
   });
 });
 
@@ -100,53 +105,50 @@ describe("growthFor", () => {
  * dragged back, because there is nothing left on screen to grab.
  */
 
-// The canvas the avatar is centred in, from the constants the module derives
-// them from: 360 wide at most, a 44 avatar, 24 of shadow padding.
-const CANVAS_WIDTH = (360 - 44 / 2) * 2 + 24 * 2;
-const CANVAS_HEIGHT = (290 - 44 / 2 + 24) * 2;
+/**
+ * The size the placement cases are written against, which is the one the
+ * renderer's layout is authored at. Every other size is the same arithmetic
+ * scaled, which `geometryFor` has its own cases for.
+ */
+const GEOMETRY = geometryFor("small");
+const CANVAS_WIDTH = GEOMETRY.canvasWidth;
+const RISE_ABOVE = GEOMETRY.riseAbove;
+const DROP_BELOW = GEOMETRY.dropBelow;
 
 /** A 1440x900 display with the menu bar taken off the top. */
 const WORK_AREA = { x: 0, y: 25, width: 1440, height: 875 };
 
-/** The canvas origin that puts the avatar's centre exactly here. */
-const originFor = (centreX: number, centreY: number) => ({
-  x: centreX - CANVAS_WIDTH / 2,
-  y: centreY - CANVAS_HEIGHT / 2,
+/** Where the avatar's centre ends up for a given placement. */
+const centreOf = (
+  placed: ReturnType<typeof placeCanvas>,
+  geometry = GEOMETRY,
+) => ({
+  x: placed.origin.x + geometry.canvasWidth / 2,
+  y: placed.origin.y + avatarOffsetFor(placed.cardGrowth, geometry),
 });
 
-/** Where the avatar's centre ends up for a given canvas origin. */
-const centreOf = (origin: { x: number; y: number }) => ({
-  x: origin.x + CANVAS_WIDTH / 2,
-  y: origin.y + CANVAS_HEIGHT / 2,
-});
-
-describe("clampCanvasOrigin", () => {
-  test("leaves a position inside the work area alone", () => {
-    const origin = originFor(700, 500);
-    expect(clampCanvasOrigin(origin, WORK_AREA)).toEqual({
-      x: Math.round(origin.x),
-      y: Math.round(origin.y),
+describe("placeCanvas", () => {
+  test("puts the avatar exactly where a position inside the work area asks", () => {
+    expect(centreOf(placeCanvas({ x: 700, y: 500 }, WORK_AREA, GEOMETRY))).toEqual({
+      x: 700,
+      y: 500,
     });
   });
 
   test("holds the avatar at the right edge rather than past it", () => {
-    const flung = originFor(9000, 500);
-    expect(centreOf(clampCanvasOrigin(flung, WORK_AREA)).x).toBe(1440 - 22);
+    expect(centreOf(placeCanvas({ x: 9000, y: 500 }, WORK_AREA, GEOMETRY)).x).toBe(
+      1440 - 22,
+    );
   });
 
   test("holds the avatar at the left edge rather than past it", () => {
-    const flung = originFor(-9000, 500);
-    expect(centreOf(clampCanvasOrigin(flung, WORK_AREA)).x).toBe(22);
-  });
-
-  test("keeps the avatar below the menu bar", () => {
-    const flung = originFor(700, -9000);
-    expect(centreOf(clampCanvasOrigin(flung, WORK_AREA)).y).toBe(25 + 22);
+    expect(centreOf(placeCanvas({ x: -9000, y: 500 }, WORK_AREA, GEOMETRY)).x).toBe(22);
   });
 
   test("holds the avatar at the bottom edge rather than past it", () => {
-    const flung = originFor(700, 9000);
-    expect(centreOf(clampCanvasOrigin(flung, WORK_AREA)).y).toBe(900 - 22);
+    expect(centreOf(placeCanvas({ x: 700, y: 9000 }, WORK_AREA, GEOMETRY)).y).toBe(
+      900 - 22,
+    );
   });
 
   /**
@@ -155,26 +157,104 @@ describe("clampCanvasOrigin", () => {
    * corner is exactly where the surface is meant to rest.
    */
   test("lets the avatar reach the corner the surface opens in", () => {
-    const corner = originFor(1440 - 22, 900 - 22);
-    expect(centreOf(clampCanvasOrigin(corner, WORK_AREA))).toEqual({
-      x: 1440 - 22,
-      y: 900 - 22,
-    });
+    expect(
+      centreOf(placeCanvas({ x: 1440 - 22, y: 900 - 22 }, WORK_AREA, GEOMETRY)),
+    ).toEqual({ x: 1440 - 22, y: 900 - 22 });
   });
 
   test("clamps against the display it is given, not the primary one", () => {
     const secondary = { x: 1440, y: 0, width: 1920, height: 1080 };
-    const flung = originFor(99999, 500);
-    expect(centreOf(clampCanvasOrigin(flung, secondary)).x).toBe(
+    expect(centreOf(placeCanvas({ x: 99999, y: 500 }, secondary, GEOMETRY)).x).toBe(
       1440 + 1920 - 22,
     );
   });
 
-  test("stays inside a work area too small for the avatar", () => {
+  /**
+   * A work area smaller than the canvas cannot hold the avatar inside it and
+   * keep the origin on screen, and the origin is the one macOS enforces. So the
+   * honest guarantee is bounded, not exact: the surface does not fly off to
+   * where the fling asked, and it asks for nothing the window server will
+   * quietly rewrite. Asserting the avatar lands inside a 10pt display would be
+   * asserting arithmetic that never survives contact with AppKit.
+   */
+  test("stays near a work area too small to hold the canvas", () => {
     const tiny = { x: 0, y: 0, width: 10, height: 10 };
-    const centre = centreOf(clampCanvasOrigin(originFor(9000, 9000), tiny));
-    expect(centre.x).toBeLessThanOrEqual(10);
-    expect(centre.y).toBeLessThanOrEqual(10);
+    const placed = placeCanvas({ x: 9000, y: 9000 }, tiny, GEOMETRY);
+    expect(placed.origin.y).toBeGreaterThanOrEqual(tiny.y);
+    expect(centreOf(placed).x).toBeLessThanOrEqual(10);
+    expect(centreOf(placed).y).toBeLessThanOrEqual(tiny.y + DROP_BELOW);
+  });
+
+  /**
+   * JARVIS-1548. macOS refuses a window origin above the top of the work area
+   * and hands back one flush with it, so an origin asked for any higher moves
+   * the avatar somewhere neither side chose. Every position this returns has to
+   * be one the window server will actually honour.
+   */
+  test("never asks for an origin above the work area", () => {
+    for (const y of [-9000, -100, 0, 25, 40, 70, 71, 200, 400]) {
+      expect(placeCanvas({ x: 700, y }, WORK_AREA, GEOMETRY).origin.y).toBeGreaterThanOrEqual(
+        WORK_AREA.y,
+      );
+    }
+  });
+
+  /**
+   * The bug as the user met it: the avatar stopped hundreds of points short of
+   * the top for no visible reason. It was the canvas's upper half, which the
+   * old symmetric canvas spent on a card that had nowhere to grow.
+   */
+  test("brings the avatar within a shadow's width of the top", () => {
+    const centre = centreOf(placeCanvas({ x: 700, y: -9000 }, WORK_AREA, GEOMETRY));
+    expect(centre.y).toBe(WORK_AREA.y + DROP_BELOW);
+    // Where it used to stop: the old canvas's half-height below the work area.
+    expect(centre.y).toBeLessThan(WORK_AREA.y + RISE_ABOVE);
+  });
+});
+
+describe("cardGrowthFor", () => {
+  test("grows up with room for the card above the avatar", () => {
+    expect(cardGrowthFor(500, WORK_AREA, GEOMETRY)).toBe("up");
+  });
+
+  test("grows down when the card would not fit above", () => {
+    expect(cardGrowthFor(WORK_AREA.y + 40, WORK_AREA, GEOMETRY)).toBe("down");
+  });
+
+  test("flips exactly where the card stops fitting", () => {
+    expect(cardGrowthFor(WORK_AREA.y + RISE_ABOVE, WORK_AREA, GEOMETRY)).toBe("up");
+    expect(cardGrowthFor(WORK_AREA.y + RISE_ABOVE - 1, WORK_AREA, GEOMETRY)).toBe("down");
+  });
+
+  /**
+   * Deliberately *not* the twin of "a display too narrow for either direction
+   * still grows right". A canvas may hang off the sides of a display but not
+   * off the top, so falling back to `up` here would reserve 292pt above an
+   * avatar that has nowhere to put it and fence the mascot out of the top of a
+   * short display. The card is already lost either way; the reach is not.
+   */
+  test("grows down on a display too short for the card either way", () => {
+    const short = { y: 0, height: 100 };
+    expect(cardGrowthFor(50, short, GEOMETRY)).toBe("down");
+  });
+
+  test("does not flip near the bottom, which is where the surface lives", () => {
+    expect(cardGrowthFor(900 - 22, WORK_AREA, GEOMETRY)).toBe("up");
+  });
+});
+
+describe("avatarOffsetFor", () => {
+  /**
+   * The avatar's offset is what converts a window origin into an avatar
+   * position on both sides of the bridge. Growing up reserves the card's height
+   * above it; growing down reserves only the avatar and its shadow.
+   */
+  test("reserves the card's height above the avatar when growing up", () => {
+    expect(avatarOffsetFor("up", GEOMETRY)).toBe(RISE_ABOVE);
+  });
+
+  test("reserves only the shadow above it when growing down", () => {
+    expect(avatarOffsetFor("down", GEOMETRY)).toBe(DROP_BELOW);
   });
 });
 
@@ -225,5 +305,118 @@ describe("shouldShowCompanionSurface", () => {
   // wrote last time, and a fresh install has none.
   test("stays away when nothing is known yet", () => {
     expect(shouldShowCompanionSurface(false, false)).toBe(false);
+  });
+});
+
+/**
+ * The canvas as a function of the size the user picked (JARVIS-1549).
+ *
+ * The avatar's box is not a style: the pill's reach, the card's height and the
+ * canvas sized to hold them all come off it. So the sizes are named steps, and
+ * each one is a layout that can be stated rather than a point on a slider that
+ * nobody ever looked at.
+ */
+describe("geometryFor", () => {
+  test("draws `small` at the size the renderer's layout is authored at", () => {
+    const small = geometryFor("small");
+    expect(small.avatarBox).toBe(44);
+    expect(small.canvasWidth).toBe(724);
+    expect(small.canvasHeight).toBe(338);
+  });
+
+  /**
+   * The whole surface is one layout multiplied, so every length has to move
+   * together. A canvas that scaled while the pill's reach did not would clip
+   * the controls; the reverse would swallow clicks over empty desktop.
+   */
+  test("scales every length by the same factor", () => {
+    const small = geometryFor("small");
+    const large = geometryFor("large");
+    const scale = large.avatarBox / small.avatarBox;
+    expect(scale).toBe(2);
+    expect(large.canvasWidth).toBe(small.canvasWidth * scale);
+    expect(large.canvasHeight).toBe(small.canvasHeight * scale);
+    expect(large.riseAbove).toBe(small.riseAbove * scale);
+    expect(large.dropBelow).toBe(small.dropBelow * scale);
+    expect(large.maxPillWidth).toBe(small.maxPillWidth * scale);
+  });
+
+  test("grows monotonically through the named steps", () => {
+    const boxes = COMPANION_SIZES.map((size) => geometryFor(size).avatarBox);
+    expect(boxes).toEqual([...boxes].sort((a, b) => a - b));
+    expect(new Set(boxes).size).toBe(boxes.length);
+  });
+
+  /**
+   * The canvas is a window size, and a window cannot be a fraction of a point.
+   * The offsets are not rounded, because they are arithmetic on the way to a
+   * position that is.
+   */
+  test("gives every size a whole-point canvas", () => {
+    for (const size of COMPANION_SIZES) {
+      const geometry = geometryFor(size);
+      expect(Number.isInteger(geometry.canvasWidth)).toBe(true);
+      expect(Number.isInteger(geometry.canvasHeight)).toBe(true);
+    }
+  });
+
+  /**
+   * The asymmetry that JARVIS-1548 bought has to survive being scaled: the card
+   * side reserves its height, the other side reserves the avatar and its
+   * shadow, and the second stays much the smaller of the two at every size.
+   */
+  test("keeps the canvas asymmetric about the avatar at every size", () => {
+    for (const size of COMPANION_SIZES) {
+      const geometry = geometryFor(size);
+      expect(geometry.dropBelow).toBeLessThan(geometry.riseAbove);
+      expect(geometry.riseAbove + geometry.dropBelow).toBe(
+        geometry.canvasHeight,
+      );
+    }
+  });
+});
+
+/**
+ * The placement rules against a size other than the one they were written for.
+ *
+ * A bigger avatar makes the top-of-screen limit worse rather than better, since
+ * the canvas grows with it — which is exactly why JARVIS-1548 had to land
+ * first. What must hold is that the rules still bind on the avatar rather than
+ * the canvas, at whatever size.
+ */
+describe("placing a larger companion", () => {
+  const LARGE = geometryFor("large");
+
+  test("holds the avatar at the edges by its own box, not the canvas", () => {
+    const placed = placeCanvas({ x: 9000, y: 500 }, WORK_AREA, LARGE);
+    expect(centreOf(placed, LARGE).x).toBe(1440 - LARGE.avatarBox / 2);
+  });
+
+  test("still never asks for an origin above the work area", () => {
+    for (const y of [-9000, 0, 25, 100, 400]) {
+      expect(
+        placeCanvas({ x: 700, y }, WORK_AREA, LARGE).origin.y,
+      ).toBeGreaterThanOrEqual(WORK_AREA.y);
+    }
+  });
+
+  /**
+   * The gap left at the top is the shadow's room, so it scales with everything
+   * else. Bigger is a worse ceiling than `small` and still nothing like the
+   * canvas half-height the bug was.
+   */
+  test("reaches the top, short by its own scaled shadow", () => {
+    const centre = centreOf(placeCanvas({ x: 700, y: -9000 }, WORK_AREA, LARGE), LARGE);
+    expect(centre.y).toBe(WORK_AREA.y + LARGE.dropBelow);
+    expect(centre.y).toBeLessThan(WORK_AREA.y + LARGE.riseAbove);
+  });
+
+  test("flips the card at its own threshold, not the small one", () => {
+    expect(cardGrowthFor(WORK_AREA.y + LARGE.riseAbove, WORK_AREA, LARGE)).toBe(
+      "up",
+    );
+    expect(
+      cardGrowthFor(WORK_AREA.y + LARGE.riseAbove - 1, WORK_AREA, LARGE),
+    ).toBe("down");
   });
 });

--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -380,7 +380,7 @@ describe("geometryFor", () => {
  * The placement rules against a size other than the one they were written for.
  *
  * A bigger avatar makes the top-of-screen limit worse rather than better, since
- * the canvas grows with it — which is exactly why JARVIS-1548 had to land
+ * the canvas grows with it, which is exactly why JARVIS-1548 had to land
  * first. What must hold is that the rules still bind on the avatar rather than
  * the canvas, at whatever size.
  */

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -6,8 +6,11 @@ import {
   voiceActivityContentSchema,
   voiceActivityControlSchema,
   voiceActivityStartSchema,
+  COMPANION_SIZE_BOXES,
+  type CompanionCardGrowth,
   type CompanionGrowth,
   type CompanionContext,
+  type CompanionSize,
   type CompanionSurfaceState,
   type VellumCommand,
   type VoiceActivityState,
@@ -18,6 +21,8 @@ import {
 } from "@vellumai/electron-desktop/settings";
 import {
   readCompanionHidden,
+  readCompanionSize,
+  writeCompanionSize,
   writeCompanionHidden,
 } from "@vellumai/electron-desktop/window-state";
 
@@ -103,72 +108,128 @@ export const shouldShowCompanionSurface = (
 const COMPANION_KIND = "companion";
 const COMPANION_ROUTE = "/floating/companion";
 
-/** The avatar's resting footprint, matching `CompanionSurface`. */
-const AVATAR_BOX = 44;
+/**
+ * The avatar's resting footprint at `small`, which is the size the renderer's
+ * layout is authored at and the size everything else here is stated in.
+ *
+ * A larger companion is the same layout multiplied: the renderer scales itself
+ * by the published box over this one, so every constant below scales with it
+ * rather than being restated per size (JARVIS-1549).
+ */
+const BASE_AVATAR_BOX = 44;
 
 /**
- * The widest the pill gets, matching `FALLBACK_WIDTHS.call` in the renderer.
+ * The widest the pill gets at {@link BASE_AVATAR_BOX}, matching
+ * `FALLBACK_WIDTHS.call` in the renderer.
  *
  * A ceiling rather than a width: the pill measures its own content, so this is
  * what the canvas is sized to hold, and content wider than it is clipped by the
  * window. The call's approval row is the widest thing the surface renders.
  */
-const MAX_PILL_WIDTH = 360;
-
-/**
- * How far the pill reaches from the avatar's centre.
- *
- * The avatar holds its place and the body runs off one side of it, so the reach
- * is almost the pill's whole width. The canvas has to hold it in whichever
- * direction main later picks, so it is sized for that reach on both sides.
- */
-const MAX_REACH = MAX_PILL_WIDTH - AVATAR_BOX / 2;
+const BASE_MAX_PILL_WIDTH = 360;
 
 /** Room for the pill's shadow, which paints outside its box. */
-const CANVAS_PAD = 24;
+const BASE_CANVAS_PAD = 24;
 
 /**
  * The tallest the surface gets, which is the typing card.
  *
- * Every other state is a pill exactly {@link AVATAR_BOX} tall. The card stacks
- * the conversation on top of that row, in a viewport that scrolls once it is
- * full, so the card has a ceiling rather than growing with the exchange: the
- * renderer's `TURNS_MAX_HEIGHT` (220) and its padding, over the composer.
+ * Every other state is a pill exactly {@link BASE_AVATAR_BOX} tall. The card
+ * stacks the conversation on top of that row, in a viewport that scrolls once
+ * it is full, so the card has a ceiling rather than growing with the exchange:
+ * the renderer's `TURNS_MAX_HEIGHT` (220) and its padding, over the composer.
  * Rounded up from what that comes to, because the text is laid out in the
  * renderer and a canvas a few points short clips the top of the card off.
  *
  * Matched to `CompanionSurface`'s card in `companion-surface.tsx`, the way
- * {@link MAX_PILL_WIDTH} is matched to its widths.
+ * {@link BASE_MAX_PILL_WIDTH} is matched to its widths.
  */
-const MAX_CARD_HEIGHT = 290;
+const BASE_MAX_CARD_HEIGHT = 290;
 
 /**
- * How far the surface reaches above the avatar's centre.
+ * Everything the window's placement depends on, for one companion size.
  *
- * The card grows upward out of the composer row, which holds the line the pill
- * occupied, so the avatar stays exactly where it was when Type was pressed. It
- * has to: the surface is parked by the Dock, where a card growing downward
- * grows off the bottom of the screen.
+ * A record rather than a set of module constants because it is no longer fixed:
+ * the user picks the size and the whole canvas follows. Passed to the placement
+ * rules explicitly rather than read off the module, so they stay pure functions
+ * of their inputs and every size is a case a test can state.
  */
-const MAX_RISE = MAX_CARD_HEIGHT - AVATAR_BOX / 2;
-
-const CANVAS_WIDTH = MAX_REACH * 2 + CANVAS_PAD * 2;
+export interface CompanionGeometry {
+  /** The avatar's box, and the scale: this over {@link BASE_AVATAR_BOX}. */
+  avatarBox: number;
+  /** The canvas, sized to hold the largest state in either direction. */
+  canvasWidth: number;
+  canvasHeight: number;
+  /** How much canvas the card's side of the avatar needs, shadow included. */
+  riseAbove: number;
+  /** How much the other side needs: the avatar and its shadow, and no more. */
+  dropBelow: number;
+  /** What {@link growthFor} measures the room against. */
+  maxPillWidth: number;
+}
 
 /**
- * Sized for the tallest state rather than resized on the phase, the same
- * bargain the width makes: the avatar is pinned to the centre of this canvas,
- * so the height it can reach upward is height it also spends downward. A canvas
- * that grew with the card would move the window under the pointer mid-press and
- * put the expansion back on the main process, which is what the fixed canvas
- * exists to avoid.
+ * The canvas for a named size.
+ *
+ * The asymmetry between {@link CompanionGeometry.riseAbove} and `dropBelow` is
+ * the point of the shape. Sizing both sides for the card, which is what pinning
+ * the avatar to the canvas's centre amounts to, spends the card's whole height
+ * on a side that never draws anything taller than the avatar — and macOS
+ * refuses a window origin above the top of the work area, so that spend is
+ * exactly how far short of the top the surface used to stop (JARVIS-1548).
+ *
+ * The canvas is sized for the tallest state rather than resized on the phase,
+ * the same bargain the width makes. A canvas that grew with the card would move
+ * the window under the pointer mid-press and put the expansion back on the main
+ * process, which is what the fixed canvas exists to avoid. It *is* resized when
+ * the user picks a different size, which is a deliberate, one-off event rather
+ * than something that happens mid-gesture.
  */
-const CANVAS_HEIGHT = (MAX_RISE + CANVAS_PAD) * 2;
+export const geometryFor = (size: CompanionSize): CompanionGeometry => {
+  const avatarBox = COMPANION_SIZE_BOXES[size];
+  const scale = avatarBox / BASE_AVATAR_BOX;
+  const pad = BASE_CANVAS_PAD * scale;
+  const maxPillWidth = BASE_MAX_PILL_WIDTH * scale;
+  // The avatar holds its place and the body runs off one side of it, so the
+  // reach is almost the pill's whole width. The canvas has to hold it in
+  // whichever direction main later picks, so it is sized for both sides.
+  const maxReach = maxPillWidth - avatarBox / 2;
+  const riseAbove = BASE_MAX_CARD_HEIGHT * scale - avatarBox / 2 + pad;
+  const dropBelow = avatarBox / 2 + pad;
+  return {
+    avatarBox,
+    canvasWidth: Math.round(maxReach * 2 + pad * 2),
+    canvasHeight: Math.round(riseAbove + dropBelow),
+    riseAbove,
+    dropBelow,
+    maxPillWidth,
+  };
+};
 
 /** Gap from the work area's bottom-right on the first ever launch. */
 const DEFAULT_MARGIN = 24;
 
 
 let growth: CompanionGrowth = "right";
+
+/**
+ * Which way the card unfurls, and so where the avatar sits inside the canvas.
+ *
+ * Held beside {@link growth} and for the same reason: it is a fact about the
+ * window's position, which is main's to know, and the renderer has to be told
+ * it to draw the avatar where the window was actually put.
+ */
+let cardGrowth: CompanionCardGrowth = "up";
+
+/**
+ * The canvas the surface is currently drawn in.
+ *
+ * Read from the store at startup and replaced when the user picks a different
+ * size. Held rather than derived per call because it is what every position
+ * computed here is measured in, and reading the store on each mouse-move of a
+ * drag would be a file read per frame.
+ */
+let geometry: CompanionGeometry = geometryFor(readCompanionSize());
 
 /**
  * The running live-voice session, or `null` when none is.
@@ -206,6 +267,8 @@ const currentState = (): CompanionSurfaceState => {
   const character = getCharacter();
   return {
     growth,
+    cardGrowth,
+    avatarBox: geometry.avatarBox,
     character: character === null ? undefined : character,
     avatarBase64: png === null ? undefined : png.toString("base64"),
     call,
@@ -232,7 +295,7 @@ export const callOnUpdate = (
 /**
  * Which way the pill grows, from where the avatar actually sits.
  *
- * The body needs `MAX_PILL_WIDTH - AVATAR_BOX` of clearance on the side it
+ * The body needs `maxPillWidth - avatarBox` of clearance on the side it
  * grows into. Rightward is the default and leftward is what it flips to when
  * the right edge is too close, so the avatar stays exactly where the user put
  * it instead of the controls running off the display.
@@ -244,8 +307,9 @@ export const callOnUpdate = (
 export const growthFor = (
   avatarCentreX: number,
   workArea: { x: number; width: number },
+  geometry: CompanionGeometry,
 ): CompanionGrowth => {
-  const needed = MAX_PILL_WIDTH - AVATAR_BOX;
+  const needed = geometry.maxPillWidth - geometry.avatarBox;
   const roomRight = workArea.x + workArea.width - avatarCentreX;
   const roomLeft = avatarCentreX - workArea.x;
   if (roomRight < needed && roomLeft >= needed) {
@@ -255,42 +319,95 @@ export const growthFor = (
 };
 
 /**
- * Keep the avatar on screen, whatever the drag asks for.
+ * Which way the card unfurls, from the room the display has above the avatar.
  *
- * A drag arrives as a delta and is applied blind, so nothing in the gesture
- * itself stops the surface being pushed past the edge of the display. It has to
- * be stopped here, because there is no way back: the canvas is transparent and
- * mostly empty, so a surface pushed off screen leaves nothing to grab and
- * nothing to see, and the position is not persisted, so the only recovery is
- * relaunching the app.
+ * The vertical {@link growthFor}, and the fix for JARVIS-1548. Growing upward
+ * needs `riseAbove` of canvas above the avatar's centre, and macOS will
+ * not put that canvas above the top of the work area, so near the top of a
+ * display the card has to grow the other way instead.
  *
- * The avatar is what is kept inside the work area, not the canvas. The canvas
- * reaches hundreds of points past the avatar in every direction to hold a pill
- * that is usually not drawn, and clamping that box would fence the avatar into
- * the middle of the display, unable to reach the corner it is meant to rest in.
+ * Where {@link growthFor} falls back to its designed direction when neither
+ * fits, this falls back to the other one, because the two are not paying the
+ * same price. A canvas may hang off the left and right of a display freely, so
+ * a bad horizontal guess only clips the card. It may not hang off the top, so a
+ * bad vertical guess pushes the *avatar* down by the whole reserved height and
+ * fences it out of the top of the screen — which is the bug this exists to fix,
+ * in miniature. On a display too short for the card either way the card is
+ * already lost, and what is worth saving is the mascot's reach.
+ */
+export const cardGrowthFor = (
+  avatarCentreY: number,
+  workArea: { y: number; height: number },
+  geometry: CompanionGeometry,
+): CompanionCardGrowth =>
+  avatarCentreY - workArea.y >= geometry.riseAbove ? "up" : "down";
+
+/**
+ * Where the avatar's centre sits inside the canvas, measured from its top.
+ *
+ * The one number the renderer and main have to agree on for the surface to be
+ * drawn where the window was put. Published with the direction rather than
+ * recomputed on the other side, so there is one derivation of it.
+ */
+export const avatarOffsetFor = (
+  cardGrowth: CompanionCardGrowth,
+  geometry: CompanionGeometry,
+): number => (cardGrowth === "up" ? geometry.riseAbove : geometry.dropBelow);
+
+/**
+ * Where to put the canvas so the avatar lands on a given point, and which way
+ * the card unfurls once it is there.
+ *
+ * Everything is computed in the avatar's coordinates and converted to a window
+ * origin at the last step. Working the other way round — nudging the origin and
+ * reading the avatar out of it — is what made the direction flip impossible to
+ * do mid-drag: the avatar's offset inside the canvas changes with the
+ * direction, so the same origin means two different avatar positions, and a
+ * drag that crossed the threshold would teleport the mascot by the difference.
+ *
+ * **The avatar is what is kept on screen, not the canvas.** The canvas reaches
+ * hundreds of points past the avatar to hold a pill that is usually not drawn,
+ * and clamping that box would fence the avatar into the middle of the display,
+ * unable to reach the corner it is meant to rest in.
+ *
+ * **The origin is never asked for above the work area.** macOS silently refuses
+ * such a position and hands back one flush with the work area's top, which
+ * moves the avatar somewhere neither side chose. Asking only for positions the
+ * window server will honour is what keeps main's idea of where the avatar is
+ * equal to where it actually is.
  *
  * Exported for its tests, as {@link growthFor} is, and pure for the same
  * reason: it is the rule that decides whether the surface can be lost.
  */
-export const clampCanvasOrigin = (
-  origin: { x: number; y: number },
+export const placeCanvas = (
+  avatarCentre: { x: number; y: number },
   workArea: { x: number; y: number; width: number; height: number },
-): { x: number; y: number } => {
-  const centreX = origin.x + CANVAS_WIDTH / 2;
-  const centreY = origin.y + CANVAS_HEIGHT / 2;
+  geometry: CompanionGeometry,
+): { origin: { x: number; y: number }; cardGrowth: CompanionCardGrowth } => {
   // Half the avatar may hang past the edge, so the clamp is to its centre plus
   // a half box. A work area smaller than the avatar would put the maximum below
   // the minimum, which `Math.min` then resolves toward the top-left corner
   // rather than producing a position outside the display.
-  const minCentreX = workArea.x + AVATAR_BOX / 2;
-  const maxCentreX = workArea.x + workArea.width - AVATAR_BOX / 2;
-  const minCentreY = workArea.y + AVATAR_BOX / 2;
-  const maxCentreY = workArea.y + workArea.height - AVATAR_BOX / 2;
-  const clampedX = Math.min(Math.max(centreX, minCentreX), maxCentreX);
-  const clampedY = Math.min(Math.max(centreY, minCentreY), maxCentreY);
+  const half = geometry.avatarBox / 2;
+  const minCentreX = workArea.x + half;
+  const maxCentreX = workArea.x + workArea.width - half;
+  const minCentreY = workArea.y + half;
+  const maxCentreY = workArea.y + workArea.height - half;
+  const centreX = Math.min(Math.max(avatarCentre.x, minCentreX), maxCentreX);
+  const wantedY = Math.min(Math.max(avatarCentre.y, minCentreY), maxCentreY);
+
+  const cardGrowth = cardGrowthFor(wantedY, workArea, geometry);
+  const offset = avatarOffsetFor(cardGrowth, geometry);
+  // The last of the three bounds, and the one macOS would otherwise apply
+  // itself: the canvas above the avatar has to fit under the work area's top.
+  const centreY = Math.max(wantedY, workArea.y + offset);
+
   return {
-    x: Math.round(clampedX - CANVAS_WIDTH / 2),
-    y: Math.round(clampedY - CANVAS_HEIGHT / 2),
+    origin: {
+      x: Math.round(centreX - geometry.canvasWidth / 2),
+      y: Math.round(centreY - offset),
+    },
+    cardGrowth,
   };
 };
 
@@ -306,14 +423,17 @@ export const clampCanvasOrigin = (
 const defaultCanvasOrigin = (): { x: number; y: number } => {
   const cursor = screen.getCursorScreenPoint();
   const { workArea } = screen.getDisplayNearestPoint(cursor);
-  const avatarCentreX =
-    workArea.x + workArea.width - DEFAULT_MARGIN - AVATAR_BOX / 2;
-  const avatarCentreY =
-    workArea.y + workArea.height - DEFAULT_MARGIN - AVATAR_BOX / 2;
-  return {
-    x: Math.round(avatarCentreX - CANVAS_WIDTH / 2),
-    y: Math.round(avatarCentreY - CANVAS_HEIGHT / 2),
-  };
+  const half = geometry.avatarBox / 2;
+  const placed = placeCanvas(
+    {
+      x: workArea.x + workArea.width - DEFAULT_MARGIN - half,
+      y: workArea.y + workArea.height - DEFAULT_MARGIN - half,
+    },
+    workArea,
+    geometry,
+  );
+  cardGrowth = placed.cardGrowth;
+  return placed.origin;
 };
 
 const pushState = (): void => {
@@ -323,23 +443,53 @@ const pushState = (): void => {
   }
 };
 
-/** Recompute the growth direction from where the window currently is. */
+/**
+ * Where the avatar's centre currently is, in screen coordinates.
+ *
+ * Read from the window rather than remembered, because the window is moved by
+ * the drag, by a display change, and by the window server, and only one of
+ * those three goes through this module.
+ */
+const avatarCentre = (win: {
+  getPosition: () => number[];
+}): { x: number; y: number } => {
+  const [x, y] = win.getPosition();
+  return {
+    x: x + geometry.canvasWidth / 2,
+    y: y + avatarOffsetFor(cardGrowth, geometry),
+  };
+};
+
+/**
+ * Recompute both growth directions from where the window currently is.
+ *
+ * The vertical one can change without a drag: a display arriving or leaving, or
+ * the menu bar's height changing, moves the work area under a surface that
+ * never moved.
+ */
 const refreshGrowth = (): void => {
   const win = getFloatingWindow(COMPANION_KIND);
   if (!win) {
     return;
   }
-  const [x, y] = win.getPosition();
-  const avatarCentreX = x + CANVAS_WIDTH / 2;
+  const centre = avatarCentre(win);
   const { workArea } = screen.getDisplayNearestPoint({
-    x: Math.round(avatarCentreX),
-    y: Math.round(y + CANVAS_HEIGHT / 2),
+    x: Math.round(centre.x),
+    y: Math.round(centre.y),
   });
-  const next = growthFor(avatarCentreX, workArea);
-  if (next === growth) {
+  const nextGrowth = growthFor(centre.x, workArea, geometry);
+  const nextCardGrowth = cardGrowthFor(centre.y, workArea, geometry);
+  if (nextGrowth === growth && nextCardGrowth === cardGrowth) {
     return;
   }
-  growth = next;
+  growth = nextGrowth;
+  if (nextCardGrowth !== cardGrowth) {
+    // The offset moved, so the same origin now means a different avatar
+    // position. Put the window back where the avatar was.
+    cardGrowth = nextCardGrowth;
+    const placed = placeCanvas(centre, workArea, geometry);
+    win.setPosition(placed.origin.x, placed.origin.y);
+  }
   pushState();
 };
 
@@ -410,7 +560,7 @@ export const installCompanionWindow = (): void => {
   // The delta is clamped rather than trusted. A drag that outruns the window,
   // or one whose release this window never saw, arrives here as a single huge
   // jump, and unclamped that jump puts the surface somewhere the user cannot
-  // reach it. See `clampCanvasOrigin`.
+  // reach it. See `placeCanvas`.
   on(
     "vellum:companion:moveBy",
     z.tuple([z.number(), z.number()]),
@@ -419,18 +569,33 @@ export const installCompanionWindow = (): void => {
       if (!win || win.isDestroyed()) {
         return;
       }
-      const [x, y] = win.getPosition();
-      const wanted = { x: x + dx, y: y + dy };
+      // In the avatar's coordinates, not the window's. The avatar is what the
+      // hand is holding, and its offset inside the canvas changes when the card
+      // direction flips, so a delta applied to the origin would drag the mascot
+      // out from under the pointer at the threshold.
+      const centre = avatarCentre(win);
+      const wanted = { x: centre.x + dx, y: centre.y + dy };
       // Measured against the display the drag is heading for rather than the
       // one it started on, so a surface dragged onto a second display is
       // clamped to that display's edges instead of being held back at the
       // first one's.
       const { workArea } = screen.getDisplayNearestPoint({
-        x: Math.round(wanted.x + CANVAS_WIDTH / 2),
-        y: Math.round(wanted.y + CANVAS_HEIGHT / 2),
+        x: Math.round(wanted.x),
+        y: Math.round(wanted.y),
       });
-      const next = clampCanvasOrigin(wanted, workArea);
-      win.setPosition(next.x, next.y);
+      const placed = placeCanvas(wanted, workArea, geometry);
+      // Before the move, not after. `setPosition` fires `move`, which runs
+      // `refreshGrowth`, which reads the avatar's position back out of the
+      // window using this exact variable — so it has to already say which
+      // offset the new origin was computed against, or the refresh measures the
+      // avatar somewhere it is not and moves the window a second time. The
+      // renderer cannot see the intervening frame: the push is a message and
+      // the move is immediate.
+      if (placed.cardGrowth !== cardGrowth) {
+        cardGrowth = placed.cardGrowth;
+        pushState();
+      }
+      win.setPosition(placed.origin.x, placed.origin.y);
     },
   );
 
@@ -641,8 +806,8 @@ export const openCompanionWindow = (): void => {
   const win = createFloatingWindow({
     kind: COMPANION_KIND,
     route: COMPANION_ROUTE,
-    width: CANVAS_WIDTH,
-    height: CANVAS_HEIGHT,
+    width: geometry.canvasWidth,
+    height: geometry.canvasHeight,
     // The canvas is a click-through sheet until the pointer reaches the pill.
     ignoreMouseEvents: { forward: true },
     position: defaultCanvasOrigin,
@@ -702,6 +867,53 @@ export const setCompanionSurfaceVisible = (visible: boolean): void => {
   } else {
     closeCompanionWindow();
   }
+};
+
+/** Which size the surface is currently drawn at, for the tray's radio items. */
+export const readCompanionSurfaceSize = (): CompanionSize => readCompanionSize();
+
+/**
+ * Draw the surface at a different size, keeping the avatar where it is.
+ *
+ * The canvas is derived from the size, so this is the one moment it resizes.
+ * That is safe here in a way it would not be mid-gesture: a menu pick is a
+ * deliberate, isolated event, where a canvas that grew during a drag would move
+ * the window out from under the pointer.
+ *
+ * **The avatar's position is preserved, not the window's.** They are not the
+ * same point and the difference is most of the canvas: keeping the origin would
+ * slide the mascot by the change in its offset, which at the extremes is
+ * hundreds of points, and the user would watch the thing they were trying to
+ * enlarge walk off across the desktop. So the centre is read in the old
+ * geometry, and the window placed in the new one around the same point.
+ */
+export const setCompanionSurfaceSize = (size: CompanionSize): void => {
+  writeCompanionSize(size);
+  const next = geometryFor(size);
+  const win = getFloatingWindow(COMPANION_KIND);
+  if (!win || win.isDestroyed()) {
+    geometry = next;
+    return;
+  }
+  const centre = avatarCentre(win);
+  geometry = next;
+  const { workArea } = screen.getDisplayNearestPoint({
+    x: Math.round(centre.x),
+    y: Math.round(centre.y),
+  });
+  const placed = placeCanvas(centre, workArea, geometry);
+  cardGrowth = placed.cardGrowth;
+  growth = growthFor(centre.x, workArea, geometry);
+  // Bounds rather than size then position: two calls would put the window at
+  // the new size in the old place for a frame, which on the largest step is a
+  // visible jump of most of a canvas.
+  win.setBounds({
+    x: placed.origin.x,
+    y: placed.origin.y,
+    width: geometry.canvasWidth,
+    height: geometry.canvasHeight,
+  });
+  pushState();
 };
 
 /**

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -6,6 +6,9 @@ import {
   voiceActivityContentSchema,
   voiceActivityControlSchema,
   voiceActivityStartSchema,
+  COMPANION_BASE_AVATAR_BOX,
+  COMPANION_BASE_CANVAS_PAD,
+  COMPANION_NEAR_EDGE,
   COMPANION_SIZE_BOXES,
   type CompanionCardGrowth,
   type CompanionGrowth,
@@ -109,17 +112,7 @@ const COMPANION_KIND = "companion";
 const COMPANION_ROUTE = "/floating/companion";
 
 /**
- * The avatar's resting footprint at `small`, which is the size the renderer's
- * layout is authored at and the size everything else here is stated in.
- *
- * A larger companion is the same layout multiplied: the renderer scales itself
- * by the published box over this one, so every constant below scales with it
- * rather than being restated per size (JARVIS-1549).
- */
-const BASE_AVATAR_BOX = 44;
-
-/**
- * The widest the pill gets at {@link BASE_AVATAR_BOX}, matching
+ * The widest the pill gets at {@link COMPANION_BASE_AVATAR_BOX}, matching
  * `FALLBACK_WIDTHS.call` in the renderer.
  *
  * A ceiling rather than a width: the pill measures its own content, so this is
@@ -128,13 +121,10 @@ const BASE_AVATAR_BOX = 44;
  */
 const BASE_MAX_PILL_WIDTH = 360;
 
-/** Room for the pill's shadow, which paints outside its box. */
-const BASE_CANVAS_PAD = 24;
-
 /**
  * The tallest the surface gets, which is the typing card.
  *
- * Every other state is a pill exactly {@link BASE_AVATAR_BOX} tall. The card
+ * Every other state is a pill exactly {@link COMPANION_BASE_AVATAR_BOX} tall. The card
  * stacks the conversation on top of that row, in a viewport that scrolls once
  * it is full, so the card has a ceiling rather than growing with the exchange:
  * the renderer's `TURNS_MAX_HEIGHT` (220) and its padding, over the composer.
@@ -149,13 +139,13 @@ const BASE_MAX_CARD_HEIGHT = 290;
 /**
  * Everything the window's placement depends on, for one companion size.
  *
- * A record rather than a set of module constants because it is no longer fixed:
- * the user picks the size and the whole canvas follows. Passed to the placement
+ * A record rather than a set of module constants because the user picks the
+ * size and the whole canvas follows it. Passed to the placement
  * rules explicitly rather than read off the module, so they stay pure functions
  * of their inputs and every size is a case a test can state.
  */
 export interface CompanionGeometry {
-  /** The avatar's box, and the scale: this over {@link BASE_AVATAR_BOX}. */
+  /** The avatar's box, and the scale: this over {@link COMPANION_BASE_AVATAR_BOX}. */
   avatarBox: number;
   /** The canvas, sized to hold the largest state in either direction. */
   canvasWidth: number;
@@ -174,9 +164,9 @@ export interface CompanionGeometry {
  * The asymmetry between {@link CompanionGeometry.riseAbove} and `dropBelow` is
  * the point of the shape. Sizing both sides for the card, which is what pinning
  * the avatar to the canvas's centre amounts to, spends the card's whole height
- * on a side that never draws anything taller than the avatar — and macOS
+ * on a side that never draws anything taller than the avatar, and macOS
  * refuses a window origin above the top of the work area, so that spend is
- * exactly how far short of the top the surface used to stop (JARVIS-1548).
+ * exactly how far short of the top the avatar would stop.
  *
  * The canvas is sized for the tallest state rather than resized on the phase,
  * the same bargain the width makes. A canvas that grew with the card would move
@@ -187,15 +177,17 @@ export interface CompanionGeometry {
  */
 export const geometryFor = (size: CompanionSize): CompanionGeometry => {
   const avatarBox = COMPANION_SIZE_BOXES[size];
-  const scale = avatarBox / BASE_AVATAR_BOX;
-  const pad = BASE_CANVAS_PAD * scale;
+  const scale = avatarBox / COMPANION_BASE_AVATAR_BOX;
+  const pad = COMPANION_BASE_CANVAS_PAD * scale;
   const maxPillWidth = BASE_MAX_PILL_WIDTH * scale;
   // The avatar holds its place and the body runs off one side of it, so the
   // reach is almost the pill's whole width. The canvas has to hold it in
   // whichever direction main later picks, so it is sized for both sides.
   const maxReach = maxPillWidth - avatarBox / 2;
   const riseAbove = BASE_MAX_CARD_HEIGHT * scale - avatarBox / 2 + pad;
-  const dropBelow = avatarBox / 2 + pad;
+  // The invariant the renderer anchors by, at this size. Scaled rather than
+  // recomputed, so the formula lives in one place for both processes.
+  const dropBelow = COMPANION_NEAR_EDGE * scale;
   return {
     avatarBox,
     canvasWidth: Math.round(maxReach * 2 + pad * 2),
@@ -321,7 +313,7 @@ export const growthFor = (
 /**
  * Which way the card unfurls, from the room the display has above the avatar.
  *
- * The vertical {@link growthFor}, and the fix for JARVIS-1548. Growing upward
+ * The vertical {@link growthFor}. Growing upward
  * needs `riseAbove` of canvas above the avatar's centre, and macOS will
  * not put that canvas above the top of the work area, so near the top of a
  * display the card has to grow the other way instead.
@@ -331,7 +323,7 @@ export const growthFor = (
  * same price. A canvas may hang off the left and right of a display freely, so
  * a bad horizontal guess only clips the card. It may not hang off the top, so a
  * bad vertical guess pushes the *avatar* down by the whole reserved height and
- * fences it out of the top of the screen — which is the bug this exists to fix,
+ * fences it out of the top of the screen, which is the bug this exists to fix,
  * in miniature. On a display too short for the card either way the card is
  * already lost, and what is worth saving is the mascot's reach.
  */
@@ -359,8 +351,8 @@ export const avatarOffsetFor = (
  * the card unfurls once it is there.
  *
  * Everything is computed in the avatar's coordinates and converted to a window
- * origin at the last step. Working the other way round — nudging the origin and
- * reading the avatar out of it — is what made the direction flip impossible to
+ * origin at the last step. Working the other way round (nudging the origin and
+ * reading the avatar out of it) is what made the direction flip impossible to
  * do mid-drag: the avatar's offset inside the canvas changes with the
  * direction, so the same origin means two different avatar positions, and a
  * drag that crossed the threshold would teleport the mascot by the difference.
@@ -586,7 +578,7 @@ export const installCompanionWindow = (): void => {
       const placed = placeCanvas(wanted, workArea, geometry);
       // Before the move, not after. `setPosition` fires `move`, which runs
       // `refreshGrowth`, which reads the avatar's position back out of the
-      // window using this exact variable — so it has to already say which
+      // window using this exact variable, so it has to already say which
       // offset the new origin was computed against, or the refresh measures the
       // avatar somewhere it is not and moves the window a second time. The
       // renderer cannot see the intervening frame: the push is a message and

--- a/clients/macos/src/main/tray.client.ts
+++ b/clients/macos/src/main/tray.client.ts
@@ -24,6 +24,8 @@ import {
 import { acceleratorOption } from "./commands.client";
 import {
   isCompanionSurfaceEnabled,
+  readCompanionSurfaceSize,
+  setCompanionSurfaceSize,
   setCompanionSurfaceVisible,
 } from "./companion-window";
 import { getWatchedLockfile } from "./lockfile-watcher.client";
@@ -49,6 +51,7 @@ export const installTray = (handlers: TrayHandlers): void => {
     accelerator: acceleratorOption,
     companionEnabled: isCompanionSurfaceEnabled,
     companionHidden: readCompanionHidden,
+    companionSize: readCompanionSurfaceSize,
     dispatch: dispatchToMain,
     featureEnabled: (flag) => readSetting("featureFlags")?.[flag] === true,
     getLockfile: getWatchedLockfile,
@@ -58,6 +61,7 @@ export const installTray = (handlers: TrayHandlers): void => {
       void shell.openExternal("http://localhost:6007");
     },
     removePairedLabel: "Remove from this Mac…",
+    setCompanionSize: setCompanionSurfaceSize,
     setCompanionVisible: setCompanionSurfaceVisible,
   });
   installSharedTray(handlers);

--- a/clients/web/src/components/companion-surface-page.test.tsx
+++ b/clients/web/src/components/companion-surface-page.test.tsx
@@ -9,6 +9,8 @@ const activateMock = mock(() => undefined);
 
 const STATE: CompanionSurfaceState = {
   growth: "right",
+  cardGrowth: "up",
+  avatarBox: 44,
   call: null,
   assistantName: "Ziggy",
   turns: [],

--- a/clients/web/src/components/companion-surface-page.tsx
+++ b/clients/web/src/components/companion-surface-page.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/runtime/companion-surface";
 import { sendVoiceActivityControl } from "@/runtime/desktop-voice-activity";
 import type {
+  CompanionCardGrowth,
   CompanionCharacter,
   CompanionGrowth,
   CompanionSurfaceState,
@@ -31,6 +32,15 @@ import type {
  * turn "take me back to Vellum" into a one-pixel nudge that does nothing.
  */
 const DRAG_SLOP = 3;
+
+/**
+ * The avatar's box the surface's layout is authored at.
+ *
+ * Matches `BASE_AVATAR_BOX` in `companion-window.ts`. Main publishes the box it
+ * actually sized the window for, and the ratio between the two is the scale:
+ * one number, and the surface below is the same layout multiplied.
+ */
+const BASE_AVATAR_BOX = 44;
 
 /**
  * The companion surface inside its Electron canvas
@@ -55,6 +65,14 @@ const DRAG_SLOP = 3;
  */
 export function CompanionSurfacePage() {
   const [growth, setGrowth] = useState<CompanionGrowth>("right");
+  // Which way the card unfurls, and so which canvas edge the avatar is anchored
+  // to. Main's call: it owns the window position and is the only side that
+  // knows how much room the display has above the surface.
+  const [cardGrowth, setCardGrowth] = useState<CompanionCardGrowth>("up");
+  // The avatar's box in points, which is the surface's whole scale. Main sizes
+  // the window from it, so it arrives with the state rather than being a
+  // setting this window reads for itself.
+  const [avatarBox, setAvatarBox] = useState(BASE_AVATAR_BOX);
   const [avatarSrc, setAvatarSrc] = useState<string | undefined>();
   const [character, setCharacter] = useState<CompanionCharacter | undefined>();
   const [call, setCall] = useState<VoiceActivityState | null>(null);
@@ -95,6 +113,8 @@ export function CompanionSurfacePage() {
   useEffect(() => {
     const apply = (state: CompanionSurfaceState) => {
       setGrowth(state.growth);
+      setCardGrowth(state.cardGrowth);
+      setAvatarBox(state.avatarBox);
       setAvatarSrc(
         state.avatarBase64 === undefined
           ? undefined
@@ -279,82 +299,105 @@ export function CompanionSurfacePage() {
         setInteractive(false);
       }}
     >
-      <CompanionSurface
-        phase={phase}
-        growth={growth}
-        avatarSrc={avatarSrc}
-        character={character}
-        // The creature notices the hand, in every state including mid-call.
-        hovered={hovered}
-        accentHex={accentHex}
-        // The conversation, as far as the card shows it. Held by main and
-        // pushed with the rest of the state, so it survives this window
-        // reloading mid-exchange.
-        //
-        // Nothing at all until this composer has sent something: what main is
-        // holding until then belongs to whatever conversation the app has open,
-        // and showing it would promise that the message about to be typed joins
-        // it, which is exactly what pressing Type no longer does.
-        turns={started ? turns : []}
-        // The assistant's own name in the composer's placeholder. Undefined
-        // rather than empty, so the component's fallback is what fills the gap
-        // before the app's window has published one.
-        assistantName={assistantName === "" ? undefined : assistantName}
-        call={call ?? undefined}
-        // Unlike the turns, this is drawn whether or not the exchange on the
-        // card is this surface's own: the question it answers is whether the
-        // assistant is busy, and it is busy on someone else's conversation just
-        // as much as on this one.
-        working={working}
-        rootRef={pillRef}
-        onSurfaceMouseDown={(event) => {
-          dragRef.current = { x: event.screenX, y: event.screenY };
-          pressOriginRef.current = { x: event.screenX, y: event.screenY };
-          draggedRef.current = false;
+      {/* The surface at whatever size the user picked, as the one layout
+          multiplied rather than a second set of dimensions.
+
+          The box is the base canvas: the window divided by the scale, blown
+          back up about its own top-left corner, so it covers the window exactly
+          and every length inside — the `100%` the surface anchors to, its
+          paddings, its type — resolves in the units the layout was written in.
+          The alternative was scaling forty hard-coded dimensions and keeping
+          them in step with main's arithmetic, which is the drift this avoids
+          rather than manages.
+
+          Nothing else has to know. Hit-testing reads `getBoundingClientRect`,
+          which is post-transform, and the drag is in screen deltas. */}
+      <div
+        className="absolute top-0 left-0 origin-top-left"
+        style={{
+          width: `${(100 * BASE_AVATAR_BOX) / avatarBox}%`,
+          height: `${(100 * BASE_AVATAR_BOX) / avatarBox}%`,
+          transform: `scale(${avatarBox / BASE_AVATAR_BOX})`,
         }}
-        // A press that never became a drag. The window comes forward on the
-        // conversation this surface belongs to; main decides what that means.
-        onAvatarClick={() => {
-          if (draggedRef.current) {
-            return;
-          }
-          activateCompanionApp();
-        }}
-        // The press leaves this window immediately: the session lives in the
-        // renderer holding the chat layout, and this page only asks for one.
-        // What comes back is `call`, once that renderer has a session to
-        // report.
-        onTalk={startCompanionVoice}
-        // Type opens the composer here rather than leaving this window, since
-        // the field it opens is on this surface. What leaves is the message.
-        onType={() => {
-          setTyping(true);
-        }}
-        // Out through main and into whichever renderer holds a conversation to
-        // put it in. **The card stays open**, because this is where the answer
-        // arrives: the turns mirror pushes the sent message back within the
-        // frame and the reply behind it, so the whole exchange reads here
-        // rather than in an app the user deliberately did not go back to.
-        onSubmit={(message) => {
-          // The first message of a composer's life starts the conversation and
-          // the rest continue it. The old tail is dropped on the way out rather
-          // than left to be replaced, so the card never shows the previous
-          // conversation's words underneath the one just sent.
-          if (!started) {
-            setTurns([]);
-            setStarted(true);
-          }
-          submitCompanionMessage(message, !started);
-        }}
-        onCancelTyping={closeComposer}
-        // Out through main and back down into whichever renderer holds the
-        // session. This page has no session to act on: it draws one.
-        onControl={(action, requestId) => {
-          sendVoiceActivityControl(
-            requestId === undefined ? { action } : { action, requestId },
-          );
-        }}
-      />
+      >
+        <CompanionSurface
+          phase={phase}
+          growth={growth}
+          cardGrowth={cardGrowth}
+          avatarSrc={avatarSrc}
+          character={character}
+          // The creature notices the hand, in every state including mid-call.
+          hovered={hovered}
+          accentHex={accentHex}
+          // The conversation, as far as the card shows it. Held by main and
+          // pushed with the rest of the state, so it survives this window
+          // reloading mid-exchange.
+          //
+          // Nothing at all until this composer has sent something: what main is
+          // holding until then belongs to whatever conversation the app has open,
+          // and showing it would promise that the message about to be typed joins
+          // it, which is exactly what pressing Type no longer does.
+          turns={started ? turns : []}
+          // The assistant's own name in the composer's placeholder. Undefined
+          // rather than empty, so the component's fallback is what fills the gap
+          // before the app's window has published one.
+          assistantName={assistantName === "" ? undefined : assistantName}
+          call={call ?? undefined}
+          // Unlike the turns, this is drawn whether or not the exchange on the
+          // card is this surface's own: the question it answers is whether the
+          // assistant is busy, and it is busy on someone else's conversation just
+          // as much as on this one.
+          working={working}
+          rootRef={pillRef}
+          onSurfaceMouseDown={(event) => {
+            dragRef.current = { x: event.screenX, y: event.screenY };
+            pressOriginRef.current = { x: event.screenX, y: event.screenY };
+            draggedRef.current = false;
+          }}
+          // A press that never became a drag. The window comes forward on the
+          // conversation this surface belongs to; main decides what that means.
+          onAvatarClick={() => {
+            if (draggedRef.current) {
+              return;
+            }
+            activateCompanionApp();
+          }}
+          // The press leaves this window immediately: the session lives in the
+          // renderer holding the chat layout, and this page only asks for one.
+          // What comes back is `call`, once that renderer has a session to
+          // report.
+          onTalk={startCompanionVoice}
+          // Type opens the composer here rather than leaving this window, since
+          // the field it opens is on this surface. What leaves is the message.
+          onType={() => {
+            setTyping(true);
+          }}
+          // Out through main and into whichever renderer holds a conversation to
+          // put it in. **The card stays open**, because this is where the answer
+          // arrives: the turns mirror pushes the sent message back within the
+          // frame and the reply behind it, so the whole exchange reads here
+          // rather than in an app the user deliberately did not go back to.
+          onSubmit={(message) => {
+            // The first message of a composer's life starts the conversation and
+            // the rest continue it. The old tail is dropped on the way out rather
+            // than left to be replaced, so the card never shows the previous
+            // conversation's words underneath the one just sent.
+            if (!started) {
+              setTurns([]);
+              setStarted(true);
+            }
+            submitCompanionMessage(message, !started);
+          }}
+          onCancelTyping={closeComposer}
+          // Out through main and back down into whichever renderer holds the
+          // session. This page has no session to act on: it draws one.
+          onControl={(action, requestId) => {
+            sendVoiceActivityControl(
+              requestId === undefined ? { action } : { action, requestId },
+            );
+          }}
+        />
+      </div>
     </div>
   );
 }

--- a/clients/web/src/components/companion-surface-page.tsx
+++ b/clients/web/src/components/companion-surface-page.tsx
@@ -304,8 +304,8 @@ export function CompanionSurfacePage() {
 
           The box is the base canvas: the window divided by the scale, blown
           back up about its own top-left corner, so it covers the window exactly
-          and every length inside — the `100%` the surface anchors to, its
-          paddings, its type — resolves in the units the layout was written in.
+          and every length inside (the `100%` the surface anchors to, its
+          paddings, its type) resolves in the units the layout was written in.
           The alternative was scaling forty hard-coded dimensions and keeping
           them in step with main's arithmetic, which is the drift this avoids
           rather than manages.

--- a/clients/web/src/components/companion-surface.stories.tsx
+++ b/clients/web/src/components/companion-surface.stories.tsx
@@ -280,7 +280,7 @@ export const TypingEmpty: Story = {
  *
  * The vertical twin of `AgainstTheRightEdge`, and the fix for JARVIS-1548. The
  * host's canvas reserves the card's height on whichever side it grows into, and
- * macOS will not put a window frame above the top of the work area — so an
+ * macOS will not put a window frame above the top of the work area, so an
  * avatar that always reserved that height *above* itself could not be dragged
  * into the top of the screen at all. It stopped 270pt short, for no reason the
  * user could see.

--- a/clients/web/src/components/companion-surface.stories.tsx
+++ b/clients/web/src/components/companion-surface.stories.tsx
@@ -87,6 +87,10 @@ const meta: Meta<StoryArgs> = {
       control: "inline-radio",
       options: ["right", "left"],
     },
+    cardGrowth: {
+      control: "inline-radio",
+      options: ["up", "down"],
+    },
     accentHex: { control: "color" },
     glow: { control: "boolean" },
   },
@@ -269,6 +273,44 @@ export const Typing: Story = {
 /** The card before anything has been said. */
 export const TypingEmpty: Story = {
   args: { phase: "typing", assistantName: "Ziggy", turns: [] },
+};
+
+/**
+ * The card at the top of a display, where it has to unfurl downward.
+ *
+ * The vertical twin of `AgainstTheRightEdge`, and the fix for JARVIS-1548. The
+ * host's canvas reserves the card's height on whichever side it grows into, and
+ * macOS will not put a window frame above the top of the work area — so an
+ * avatar that always reserved that height *above* itself could not be dragged
+ * into the top of the screen at all. It stopped 270pt short, for no reason the
+ * user could see.
+ *
+ * **Set `cardGrowth` to `up` to see the shape this replaces.** The card runs
+ * straight off the top of the stage. The avatar holds its line either way,
+ * which is the property this protects, exactly as the horizontal flip does.
+ */
+export const AgainstTheTopEdge: Story = {
+  args: {
+    phase: "typing",
+    cardGrowth: "down",
+    assistantName: "Ziggy",
+    turns: [
+      { role: "user", text: "what did the deploy do" },
+      {
+        role: "assistant",
+        text: "Rolled back on its own after the health check failed twice, then went through clean at 09:31.",
+      },
+    ],
+  },
+  decorators: [
+    (Story) => (
+      // The avatar's own line, pinned near the top of the stage with the screen
+      // ending just above it.
+      <div className="absolute top-0 left-1/2 h-11 w-11 -translate-x-1/2">
+        <Story />
+      </div>
+    ),
+  ],
 };
 
 /**

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -43,8 +43,9 @@ describe("the companion surface's working ring", () => {
     const { container } = render(
       <CompanionSurface phase="resting" working accentHex="#ff8800" />,
     );
-    expect(ringOf(container)?.style.getPropertyValue("--companion-ring-accent"))
-      .toBe("#ff8800");
+    expect(
+      ringOf(container)?.style.getPropertyValue("--companion-ring-accent"),
+    ).toBe("#ff8800");
   });
 
   /**
@@ -155,5 +156,95 @@ describe("the companion surface's custom avatar", () => {
       />,
     );
     expect(imageOf(container)).toBeNull();
+  });
+});
+
+/**
+ * Where the avatar sits inside the canvas.
+ *
+ * The canvas is not symmetric about the avatar: the card's height is reserved
+ * on whichever side it grows into, and only the avatar's own box and its shadow
+ * on the other. So the surface anchors to the *near* edge, and `100%` names the
+ * canvas without this side knowing how tall the host made it. That is what lets
+ * main flip the direction near the top of a display without the renderer
+ * learning the canvas's height (JARVIS-1548).
+ */
+describe("the companion surface's anchor in the canvas", () => {
+  /** The pill itself, which is also the surface's drag handle. */
+  const surfaceOf = (container: HTMLElement): HTMLElement => {
+    const found = container.querySelector<HTMLElement>(".cursor-grab");
+    if (!found) {
+      throw new Error("Expected the surface to render");
+    }
+    return found;
+  };
+
+  test("hangs off the canvas's bottom edge while the card grows up", () => {
+    const { container } = render(<CompanionSurface phase="resting" />);
+    expect(surfaceOf(container).style.top).toBe("calc(100% - 46px)");
+  });
+
+  test("sits against the canvas's top edge while the card grows down", () => {
+    const { container } = render(
+      <CompanionSurface phase="resting" cardGrowth="down" />,
+    );
+    expect(surfaceOf(container).style.top).toBe("46px");
+  });
+
+  test("grows up by default, which is where the surface normally lives", () => {
+    const { container } = render(<CompanionSurface phase="resting" />);
+    const { container: explicit } = render(
+      <CompanionSurface phase="resting" cardGrowth="up" />,
+    );
+    expect(surfaceOf(container).style.top).toBe(surfaceOf(explicit).style.top);
+  });
+
+  /**
+   * The avatar's line is the fixed point in both directions. Growing up, the
+   * card's bottom row sits on it; growing down, its top row does. Either way
+   * the mascot is where it was before Type was pressed.
+   */
+  test("hangs the card off the avatar's line when it grows up", () => {
+    const { container } = render(<CompanionSurface phase="typing" />);
+    expect(surfaceOf(container).style.transform).toBe(
+      "translateY(calc(-100% + 22px))",
+    );
+  });
+
+  test("drops the card from the avatar's line when it grows down", () => {
+    const { container } = render(
+      <CompanionSurface phase="typing" cardGrowth="down" />,
+    );
+    expect(surfaceOf(container).style.transform).toBe("translateY(-22px)");
+  });
+
+  /**
+   * The column reverses for the reason the row does when the pill grows left:
+   * the row holding the avatar's line has to end up against the avatar, and the
+   * conversation stacks away from it.
+   */
+  test("reverses the card's column when it grows down", () => {
+    const { container } = render(
+      <CompanionSurface phase="typing" cardGrowth="down" />,
+    );
+    expect(surfaceOf(container).className).toContain("flex-col-reverse");
+  });
+
+  test("stacks the card upward in the ordinary direction", () => {
+    const { container } = render(<CompanionSurface phase="typing" />);
+    const className = surfaceOf(container).className;
+    expect(className).toContain("flex-col");
+    expect(className).not.toContain("flex-col-reverse");
+  });
+
+  /** The pill is centred on the avatar's line whichever way the card would go. */
+  test("centres the resting pill on the avatar's line either way", () => {
+    for (const cardGrowth of ["up", "down"] as const) {
+      const { container } = render(
+        <CompanionSurface phase="resting" cardGrowth={cardGrowth} />,
+      );
+      expect(surfaceOf(container).style.transform).toBe("translateY(-50%)");
+      cleanup();
+    }
   });
 });

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -92,6 +92,20 @@ export type CompanionSurfacePhase =
  */
 export type CompanionSurfaceGrowth = "right" | "left";
 
+/**
+ * Which way the typing card unfurls out of the composer row, which holds the
+ * line the pill occupied.
+ *
+ * `up` is where the surface normally opens: it lives by the Dock, where a card
+ * growing downward would grow off the bottom of the screen. `down` is what it
+ * flips to near the top of a display, and the reason it has to exist at all is
+ * the host's, not the layout's — macOS refuses to place a window frame above
+ * the top of the work area, so an avatar that always reserved the card's height
+ * above itself could never be dragged into the top of the screen at all
+ * (JARVIS-1548). Main decides, for the same reason it decides the other one.
+ */
+export type CompanionSurfaceCardGrowth = "up" | "down";
+
 /** Fallback accent, used until the assistant's own avatar colour is known. */
 const DEFAULT_ACCENT = "#5eead4";
 
@@ -112,6 +126,26 @@ const ASSISTANT_TURN_PHASES = new Set(["transcribing", "thinking", "speaking"]);
 // surfaces that happen to share a colour, and it is the property to protect as
 // the states gain content.
 const AVATAR_BOX = 44;
+
+/**
+ * Room for the pill's shadow, matching `CANVAS_PAD` in `companion-window.ts`.
+ *
+ * Duplicated across the bridge the way {@link AVATAR_BOX} is: both sides derive
+ * their geometry from the same primitives rather than one side sending the
+ * other pixel positions.
+ */
+const CANVAS_PAD = 24;
+
+/**
+ * How far the avatar's centre sits from the canvas edge the card does *not*
+ * grow into: its own half-box, plus the shadow's room.
+ *
+ * The other edge is however far away the canvas is, which the surface never
+ * needs to know — `100%` is the canvas, so anchoring to the near edge places
+ * the avatar without either side stating the canvas's height. Main sizes the
+ * canvas and picks the direction; this is the only number the two agree on.
+ */
+const NEAR_EDGE = AVATAR_BOX / 2 + CANVAS_PAD;
 
 /**
  * The avatar artwork inside that box, which is inset by {@link INNER_GAP} on
@@ -248,6 +282,11 @@ export interface CompanionSurfaceProps {
   /** Which way the pill grows. See {@link CompanionSurfaceGrowth}. */
   growth?: CompanionSurfaceGrowth;
   /**
+   * Which way the card grows, and with it which edge of the canvas the avatar
+   * is anchored to. See {@link CompanionSurfaceCardGrowth}.
+   */
+  cardGrowth?: CompanionSurfaceCardGrowth;
+  /**
    * The pill's own element.
    *
    * The Electron host needs to hit-test the pointer against the pill rather
@@ -347,6 +386,7 @@ export function CompanionSurface({
   onHoverStart,
   onHoverEnd,
   growth = "right",
+  cardGrowth = "up",
   rootRef,
   onSurfaceMouseDown,
   spotlight,
@@ -406,12 +446,12 @@ export function CompanionSurface({
         ? 0
         : (contentWidth ?? FALLBACK_WIDTHS[phase] - AVATAR_BOX) + INNER_GAP);
 
-  // **The avatar never moves.** It is pinned to the centre of the canvas, which
-  // is the spot the host positions this window around, and the body runs off
-  // one side of it. Growing from the pill's centre instead would slide the
-  // mascot to a different x-position in every state, so the surface would read
-  // as a series of different objects rather than one object changing shape, and
-  // the user's eye and cursor would have no fixed target to aim at.
+  // **The avatar never moves.** It holds one spot in the canvas, which is the
+  // spot the host positions this window around, and the body runs off one side
+  // of it. Growing from the pill's centre instead would slide the mascot to a
+  // different x-position in every state, so the surface would read as a series
+  // of different objects rather than one object changing shape, and the user's
+  // eye and cursor would have no fixed target to aim at.
   //
   // Each direction therefore fixes the avatar's own edge to the centre and lets
   // the body run the other way. Growing left also reverses the row, because the
@@ -421,16 +461,30 @@ export function CompanionSurface({
       ? { right: "50%", marginRight: -(AVATAR_BOX / 2) }
       : { left: "50%", marginLeft: -(AVATAR_BOX / 2) };
 
+  // The vertical half of the same idea, against a canvas that is *not*
+  // symmetric about the avatar. The card's height is reserved on whichever side
+  // it grows into, so the avatar sits `NEAR_EDGE` from the other edge — and
+  // that edge is the one worth anchoring to, since `100%` names the canvas
+  // without this side having to know how tall main made it.
+  const anchor: CSSProperties =
+    cardGrowth === "up"
+      ? { top: `calc(100% - ${NEAR_EDGE}px)` }
+      : { top: NEAR_EDGE };
+
   const style: CSSProperties = {
     width,
     ...placement,
+    ...anchor,
     // The composer row holds the line the pill occupied and the conversation
-    // stacks upward off it, so the avatar never moves when Type is pressed and
-    // never moves again as turns arrive. It is also the only direction that
-    // works where this surface lives: parked by the Dock, a card growing down
-    // grows off the bottom of the screen.
+    // stacks off it, so the avatar never moves when Type is pressed and never
+    // moves again as turns arrive. Which way it stacks is the host's call:
+    // parked by the Dock a card growing down would grow off the bottom of the
+    // screen, and at the top of the display a card growing up has nowhere to be
+    // (see `CompanionSurfaceCardGrowth`).
     transform: typing
-      ? `translateY(calc(-100% + ${AVATAR_BOX / 2}px))`
+      ? cardGrowth === "up"
+        ? `translateY(calc(-100% + ${AVATAR_BOX / 2}px))`
+        : `translateY(-${AVATAR_BOX / 2}px)`
       : "translateY(-50%)",
     // Settles rather than overshoots. A surface on screen all day should not
     // bounce every time the pointer crosses it.
@@ -443,14 +497,19 @@ export function CompanionSurface({
     // press, so everything that is not a button can be grabbed, which at rest
     // means the avatar and when expanded means the pill around the controls.
     <div
-      className={`absolute top-1/2 cursor-grab transition-[width] duration-300 will-change-[width] active:cursor-grabbing ${
+      className={`absolute cursor-grab transition-[width] duration-300 will-change-[width] active:cursor-grabbing ${
         typing
-          ? "flex flex-col rounded-[22px]"
+          ? // The composer row is the column's last child, so a card growing
+            // downward reverses the column for the same reason a pill growing
+            // leftward reverses the row: the row that holds the avatar's line
+            // has to end up against the avatar, and the turns stack away from
+            // it.
+            `flex rounded-[22px] ${cardGrowth === "up" ? "flex-col" : "flex-col-reverse"}`
           : "flex h-11 items-center rounded-full"
       } ${
         // The avatar is the row's first child, so growing leftward means
-        // reversing the row rather than repositioning it. The card is a column
-        // and grows upward instead, so it never wants this.
+        // reversing the row rather than repositioning it. The card is a column,
+        // so it never wants this.
         growth === "left" && !typing ? "flex-row-reverse" : ""
       }`}
       style={style}

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -17,6 +17,7 @@ import type {
   Ref,
 } from "react";
 
+import { COMPANION_NEAR_EDGE } from "@vellumai/ipc-contract";
 import type {
   CompanionCharacter,
   CompanionTurn,
@@ -99,7 +100,7 @@ export type CompanionSurfaceGrowth = "right" | "left";
  * `up` is where the surface normally opens: it lives by the Dock, where a card
  * growing downward would grow off the bottom of the screen. `down` is what it
  * flips to near the top of a display, and the reason it has to exist at all is
- * the host's, not the layout's — macOS refuses to place a window frame above
+ * the host's, not the layout's: macOS refuses to place a window frame above
  * the top of the work area, so an avatar that always reserved the card's height
  * above itself could never be dragged into the top of the screen at all
  * (JARVIS-1548). Main decides, for the same reason it decides the other one.
@@ -126,26 +127,6 @@ const ASSISTANT_TURN_PHASES = new Set(["transcribing", "thinking", "speaking"]);
 // surfaces that happen to share a colour, and it is the property to protect as
 // the states gain content.
 const AVATAR_BOX = 44;
-
-/**
- * Room for the pill's shadow, matching `CANVAS_PAD` in `companion-window.ts`.
- *
- * Duplicated across the bridge the way {@link AVATAR_BOX} is: both sides derive
- * their geometry from the same primitives rather than one side sending the
- * other pixel positions.
- */
-const CANVAS_PAD = 24;
-
-/**
- * How far the avatar's centre sits from the canvas edge the card does *not*
- * grow into: its own half-box, plus the shadow's room.
- *
- * The other edge is however far away the canvas is, which the surface never
- * needs to know — `100%` is the canvas, so anchoring to the near edge places
- * the avatar without either side stating the canvas's height. Main sizes the
- * canvas and picks the direction; this is the only number the two agree on.
- */
-const NEAR_EDGE = AVATAR_BOX / 2 + CANVAS_PAD;
 
 /**
  * The avatar artwork inside that box, which is inset by {@link INNER_GAP} on
@@ -463,13 +444,13 @@ export function CompanionSurface({
 
   // The vertical half of the same idea, against a canvas that is *not*
   // symmetric about the avatar. The card's height is reserved on whichever side
-  // it grows into, so the avatar sits `NEAR_EDGE` from the other edge — and
-  // that edge is the one worth anchoring to, since `100%` names the canvas
+  // it grows into, so the avatar sits `COMPANION_NEAR_EDGE` from the other
+  // edge, and that edge is the one worth anchoring to: `100%` names the canvas
   // without this side having to know how tall main made it.
   const anchor: CSSProperties =
     cardGrowth === "up"
-      ? { top: `calc(100% - ${NEAR_EDGE}px)` }
-      : { top: NEAR_EDGE };
+      ? { top: `calc(100% - ${COMPANION_NEAR_EDGE}px)` }
+      : { top: COMPANION_NEAR_EDGE };
 
   const style: CSSProperties = {
     width,

--- a/clients/windows/src/main/tray.ts
+++ b/clients/windows/src/main/tray.ts
@@ -9,7 +9,10 @@ import {
   configureTrayModel,
   installTray,
 } from "@vellumai/electron-desktop/tray-model";
-import type { VellumCommand } from "@vellumai/ipc-contract";
+import {
+  DEFAULT_COMPANION_SIZE,
+  type VellumCommand,
+} from "@vellumai/ipc-contract";
 
 import { current, ensureVisible, toggleVisibility } from "./main-window";
 
@@ -47,8 +50,13 @@ export const installWindowsTray = (
   configureStatusIconFallback(icon.isEmpty() ? null : icon);
   configureTrayModel({
     accelerator: () => ({}),
+    // Windows has no companion surface, so every companion field here is the
+    // inert answer rather than an implementation. The size still has to be a
+    // real one: the tray model reads it to mark a radio item, and the menu it
+    // would appear in is gated off by `companionEnabled` anyway.
     companionEnabled: () => false,
     companionHidden: () => true,
+    companionSize: () => DEFAULT_COMPANION_SIZE,
     dispatch,
     featureEnabled,
     getLockfile: getWatchedLockfile,
@@ -58,6 +66,7 @@ export const installWindowsTray = (
       void shell.openExternal("http://localhost:6007");
     },
     removePairedLabel: "Remove from this PC\u2026",
+    setCompanionSize: () => undefined,
     setCompanionVisible: () => undefined,
   });
   installTray({

--- a/packages/electron-desktop/src/tray-model.test.ts
+++ b/packages/electron-desktop/src/tray-model.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { CompanionSize } from "@vellumai/ipc-contract";
 import type { Lockfile } from "@vellumai/local-mode/contract";
 
 // Tray stub: records constructions, event listeners, and image swaps.
@@ -96,6 +97,8 @@ let watchedLockfile: {
 let featureFlags: Record<string, boolean> | null = null;
 let companionHidden = false;
 const setCompanionSurfaceVisibleMock = mock((_visible: boolean) => undefined);
+let companionSize: CompanionSize = "large";
+const setCompanionSizeMock = mock((_size: CompanionSize) => undefined);
 
 const dispatchToMainMock = mock((_command: unknown) => undefined);
 
@@ -182,6 +185,8 @@ beforeEach(() => {
     onboardingActive: () => false,
     openComponentGallery: () => undefined,
     removePairedLabel: "Remove from this Mac\u2026",
+    companionSize: () => companionSize,
+    setCompanionSize: setCompanionSizeMock,
     setCompanionVisible: setCompanionSurfaceVisibleMock,
   });
   trays.length = 0;
@@ -191,7 +196,9 @@ beforeEach(() => {
   watchedLockfile = { assistants: [], activeAssistant: null };
   featureFlags = null;
   companionHidden = false;
+  companionSize = "large";
   setCompanionSurfaceVisibleMock.mockClear();
+  setCompanionSizeMock.mockClear();
   dispatchToMainMock.mockClear();
   buildFromTemplateMock.mockClear();
   statusFramesMock.mockClear();
@@ -531,7 +538,9 @@ describe("floating companion toggle", () => {
     label?: string;
     type?: string;
     checked?: boolean;
+    enabled?: boolean;
     click?: (item: { checked: boolean }) => void;
+    submenu?: MenuItem[];
   };
 
   const popCompanionItem = (): MenuItem | undefined => {
@@ -543,6 +552,19 @@ describe("floating companion toggle", () => {
     const calls = buildFromTemplateMock.mock.calls;
     const template = calls[calls.length - 1]?.[0] as MenuItem[];
     return template.find((i) => i.label === "Show Floating Companion");
+  };
+
+  /**
+   * The size picker, which lives beside the toggle and is gated with it: with
+   * the surface off there is nothing to size.
+   */
+  const popSizeItem = (): MenuItem | undefined => {
+    featureFlags = { "companion-surface": true };
+    installTray(handlers);
+    handlerFor(trays[0], "right-click")?.();
+    const calls = buildFromTemplateMock.mock.calls;
+    const template = calls[calls.length - 1]?.[0] as MenuItem[];
+    return template.find((i) => i.label === "Companion Size");
   };
 
   test("renders as a checked checkbox while the surface is shown", () => {
@@ -564,6 +586,58 @@ describe("floating companion toggle", () => {
     expect(setCompanionSurfaceVisibleMock).toHaveBeenLastCalledWith(false);
     item?.click?.({ checked: true });
     expect(setCompanionSurfaceVisibleMock).toHaveBeenLastCalledWith(true);
+  });
+
+  /**
+   * Named steps rather than a slider (JARVIS-1549). The avatar's box is the
+   * geometry both processes derive from, so the sizes are a fixed set of
+   * layouts and the menu is where one is chosen.
+   */
+  test("offers a size for each named step", () => {
+    expect(popSizeItem()?.submenu?.map((i) => i.label)).toEqual([
+      "Small",
+      "Medium",
+      "Large",
+      "Huge",
+    ]);
+  });
+
+  test("marks the size in effect, since radio items have to show one", () => {
+    companionSize = "medium";
+    const checked = popSizeItem()
+      ?.submenu?.filter((i) => i.checked)
+      .map((i) => i.label);
+    expect(checked).toEqual(["Medium"]);
+  });
+
+  test("renders the sizes as one radio group", () => {
+    expect(popSizeItem()?.submenu?.every((i) => i.type === "radio")).toBe(true);
+  });
+
+  test("applies the size that was picked", () => {
+    popSizeItem()?.submenu?.[3]?.click?.({ checked: true });
+    expect(setCompanionSizeMock).toHaveBeenLastCalledWith("huge");
+  });
+
+  /**
+   * Disabled rather than dropped while the surface is hidden. The size is still
+   * something the companion has, and an item that comes and goes with the
+   * checkbox above it reads as a bug rather than as a state.
+   */
+  test("stands down while the surface is hidden, without disappearing", () => {
+    companionHidden = true;
+    const item = popSizeItem();
+    expect(item).toBeDefined();
+    expect(item?.enabled).toBe(false);
+  });
+
+  test("is absent entirely for someone the surface is off for", () => {
+    featureFlags = {};
+    installTray(handlers);
+    handlerFor(trays[0], "right-click")?.();
+    const calls = buildFromTemplateMock.mock.calls;
+    const template = calls[calls.length - 1]?.[0] as MenuItem[];
+    expect(template.find((i) => i.label === "Companion Size")).toBeUndefined();
   });
 });
 

--- a/packages/electron-desktop/src/tray-model.ts
+++ b/packages/electron-desktop/src/tray-model.ts
@@ -135,7 +135,7 @@ export interface TrayHandlers {
  *
  * Here rather than in the contract: the contract carries what the two processes
  * send each other, and these are words on a menu. The point sizes are not in
- * the labels — "88pt" means nothing next to a floating avatar, and the sizes
+ * the labels: "88pt" means nothing next to a floating avatar, and the sizes
  * are meant to be picked by looking at the result.
  */
 const COMPANION_SIZE_LABELS: Record<CompanionSize, string> = {

--- a/packages/electron-desktop/src/tray-model.ts
+++ b/packages/electron-desktop/src/tray-model.ts
@@ -12,7 +12,11 @@ import {
   type Lockfile,
   type LockfileAssistant,
 } from "@vellumai/local-mode/contract";
-import type { VellumCommand } from "@vellumai/ipc-contract";
+import {
+  COMPANION_SIZES,
+  type CompanionSize,
+  type VellumCommand,
+} from "@vellumai/ipc-contract";
 
 import { onAvatarChange } from "./avatar";
 import { getName, onNameChange } from "./identity";
@@ -41,6 +45,8 @@ export interface TrayModelRuntime {
   ) => Pick<MenuItemConstructorOptions, "accelerator">;
   companionEnabled: () => boolean;
   companionHidden: () => boolean;
+  /** Which named size the companion surface is drawn at. */
+  companionSize: () => CompanionSize;
   dispatch: (command: VellumCommand) => void;
   featureEnabled: (flag: string) => boolean;
   getLockfile: () => Lockfile;
@@ -49,6 +55,7 @@ export interface TrayModelRuntime {
   openComponentGallery: () => void;
   removePairedLabel: string;
   setCompanionVisible: (visible: boolean) => void;
+  setCompanionSize: (size: CompanionSize) => void;
 }
 
 let runtime: TrayModelRuntime | null = null;
@@ -123,6 +130,21 @@ export interface TrayHandlers {
  * Resolve a user-facing display title for a lockfile assistant. Uses the
  * assistant name when present, falling back to a truncated id.
  */
+/**
+ * Menu wording for each companion size.
+ *
+ * Here rather than in the contract: the contract carries what the two processes
+ * send each other, and these are words on a menu. The point sizes are not in
+ * the labels — "88pt" means nothing next to a floating avatar, and the sizes
+ * are meant to be picked by looking at the result.
+ */
+const COMPANION_SIZE_LABELS: Record<CompanionSize, string> = {
+  small: "Small",
+  medium: "Medium",
+  large: "Large",
+  huge: "Huge",
+};
+
 const assistantDisplayTitle = (assistant: LockfileAssistant): string => {
   if (assistant.name) {
     return assistant.name;
@@ -357,6 +379,27 @@ const buildTrayMenu = (
             click: (item: Electron.MenuItem) => {
               trayRuntime.setCompanionVisible(item.checked);
             },
+          },
+          {
+            // Named steps rather than a slider, because the avatar's box is not
+            // a style: the canvas, the pill's reach and the card's height are
+            // all derived from it, so a continuous scale would be a layout
+            // nobody had ever looked at. Radio items, since the sizes are one
+            // choice and the menu has to show which one is in effect.
+            //
+            // Disabled rather than hidden while the surface is hidden: the item
+            // says the size is still something the companion has, and an item
+            // that comes and goes with the checkbox above it reads as a bug.
+            label: "Companion Size",
+            enabled: !trayRuntime.companionHidden(),
+            submenu: COMPANION_SIZES.map((size) => ({
+              label: COMPANION_SIZE_LABELS[size],
+              type: "radio" as const,
+              checked: trayRuntime.companionSize() === size,
+              click: () => {
+                trayRuntime.setCompanionSize(size);
+              },
+            })),
           },
         ]
       : []),

--- a/packages/electron-desktop/src/window-state.ts
+++ b/packages/electron-desktop/src/window-state.ts
@@ -108,7 +108,7 @@ export const writeCompanionHidden = (hidden: boolean): void => {
  *
  * Validated on the way out rather than trusted. This file is a JSON store a
  * user can edit and an older build can have written, and the value indexes a
- * table of geometry — an unknown one would size the window from `undefined` and
+ * table of geometry, and an unknown one would size the window from `undefined`
  * put a canvas of `NaN` on screen.
  */
 export const readCompanionSize = (): CompanionSize => {

--- a/packages/electron-desktop/src/window-state.ts
+++ b/packages/electron-desktop/src/window-state.ts
@@ -1,6 +1,12 @@
 import { BrowserWindow, screen, type Rectangle } from "electron";
 import Store from "electron-store";
 
+import {
+  COMPANION_SIZES,
+  DEFAULT_COMPANION_SIZE,
+  type CompanionSize,
+} from "@vellumai/ipc-contract";
+
 /**
  * Window-geometry persistence. Kept in its own `electron-store` instance
  * (`window-state.json`) so it doesn't collide with the renderer-facing
@@ -33,6 +39,11 @@ interface StoreSchema {
   // before any renderer loads. Optional: absent means shown, so the flag
   // records only the opt-out (see `readCompanionHidden`).
   companionHidden?: boolean;
+  // Which named size the companion surface is drawn at. A main-process concern
+  // for the same reason the opt-out is: the window is built at a size derived
+  // from this before any renderer loads. Optional: absent means the default
+  // (see `readCompanionSize`).
+  companionSize?: CompanionSize;
 }
 
 let instance: Store<StoreSchema> | null = null;
@@ -90,6 +101,29 @@ export const writeCompanionHidden = (hidden: boolean): void => {
     return;
   }
   store().set("companionHidden", hidden);
+};
+
+/**
+ * Which named size the companion surface is drawn at.
+ *
+ * Validated on the way out rather than trusted. This file is a JSON store a
+ * user can edit and an older build can have written, and the value indexes a
+ * table of geometry — an unknown one would size the window from `undefined` and
+ * put a canvas of `NaN` on screen.
+ */
+export const readCompanionSize = (): CompanionSize => {
+  const stored = store().get("companionSize");
+  return stored !== undefined && COMPANION_SIZES.includes(stored)
+    ? stored
+    : DEFAULT_COMPANION_SIZE;
+};
+
+/** Persist the companion's size. No-op when unchanged, as the opt-out is. */
+export const writeCompanionSize = (size: CompanionSize): void => {
+  if (readCompanionSize() === size) {
+    return;
+  }
+  store().set("companionSize", size);
 };
 
 /**

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -615,13 +615,12 @@ export type CompanionGrowth = (typeof COMPANION_GROWTHS)[number];
  * work area, so the canvas cannot hang off the top of the display the way it
  * hangs off the bottom. With the avatar pinned to the canvas's centre the
  * avatar could therefore never get closer to the top of the screen than half
- * the canvas, which is where the surface used to stop dead for no visible
- * reason (JARVIS-1548).
+ * the canvas, which fences it out of the top of the display entirely.
  *
  * So the avatar's offset inside the canvas is not fixed: `up` puts it low in
  * the canvas with the card's height reserved above it, `down` puts it high with
  * that height reserved below. Main picks from the room the display actually
- * has, and the avatar still does not move — the canvas moves around it.
+ * has, and the avatar still does not move: the canvas moves around it.
  *
  * `up` is the shape the surface is designed around, since it lives by the Dock
  * where a card growing downward would grow off the bottom of the screen.
@@ -633,14 +632,14 @@ export type CompanionCardGrowth = (typeof COMPANION_CARD_GROWTHS)[number];
 /**
  * How big the companion is drawn, as a named step rather than a number.
  *
- * Named rather than free, because the avatar's box is not a style — it is the
+ * Named rather than free, because the avatar's box is not a style: it is the
  * geometry both sides of the bridge agree on, and everything derives from it:
  * the pill's reach, the card's height, and the canvas sized to hold the largest
  * state. A continuous scale would be a layout nobody had ever looked at; four
  * steps are four layouts, each checkable in Storybook.
  *
- * `large` is the default. The surface shipped at `small`, which is the size the
- * pill was designed at and too small to find on a busy desktop (JARVIS-1549).
+ * `large` is the default. `small` is the size the surface's layout is authored
+ * at, which every other step scales from.
  */
 export const COMPANION_SIZES = ["small", "medium", "large", "huge"] as const;
 
@@ -656,6 +655,35 @@ export const COMPANION_SIZE_BOXES: Record<CompanionSize, number> = {
 
 /** What the surface is drawn at when nothing has been chosen. */
 export const DEFAULT_COMPANION_SIZE: CompanionSize = "large";
+
+/**
+ * The avatar's box the companion's layout is authored at, and the size every
+ * other length in that layout is stated in.
+ *
+ * The scale is the box in {@link COMPANION_SIZE_BOXES} over this one. The
+ * renderer draws at this size and scales the whole surface by that factor, so
+ * the two processes never hold two sets of dimensions.
+ */
+export const COMPANION_BASE_AVATAR_BOX = COMPANION_SIZE_BOXES.small;
+
+/** Room the pill's shadow paints outside its box, at the base size. */
+export const COMPANION_BASE_CANVAS_PAD = 24;
+
+/**
+ * How far the avatar's centre sits from the canvas edge the card does *not*
+ * grow into: its own half-box, plus the shadow's room.
+ *
+ * **The cross-process invariant.** Main places the window by it and the
+ * renderer anchors the avatar by it, so the two agreeing is what makes the
+ * avatar appear where the window was put. Derived once here rather than on each
+ * side, because two copies of this formula drifting is the avatar drawn
+ * somewhere other than where main believes it is.
+ *
+ * The far edge is however far away the canvas is, which neither side has to
+ * state: `100%` names the canvas in the renderer, and main sizes it.
+ */
+export const COMPANION_NEAR_EDGE =
+  COMPANION_BASE_AVATAR_BOX / 2 + COMPANION_BASE_CANVAS_PAD;
 
 /**
  * The assistant's character, as the three trait ids it is composed from.

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -607,6 +607,57 @@ export const COMPANION_GROWTHS = ["right", "left"] as const;
 export type CompanionGrowth = (typeof COMPANION_GROWTHS)[number];
 
 /**
+ * Which way the typing card grows out of the composer row, which holds the line
+ * the pill occupied.
+ *
+ * The vertical half of {@link CompanionGrowth}, decided the same way and for a
+ * sharper reason. macOS refuses to place a window frame above the top of the
+ * work area, so the canvas cannot hang off the top of the display the way it
+ * hangs off the bottom. With the avatar pinned to the canvas's centre the
+ * avatar could therefore never get closer to the top of the screen than half
+ * the canvas, which is where the surface used to stop dead for no visible
+ * reason (JARVIS-1548).
+ *
+ * So the avatar's offset inside the canvas is not fixed: `up` puts it low in
+ * the canvas with the card's height reserved above it, `down` puts it high with
+ * that height reserved below. Main picks from the room the display actually
+ * has, and the avatar still does not move — the canvas moves around it.
+ *
+ * `up` is the shape the surface is designed around, since it lives by the Dock
+ * where a card growing downward would grow off the bottom of the screen.
+ */
+export const COMPANION_CARD_GROWTHS = ["up", "down"] as const;
+
+export type CompanionCardGrowth = (typeof COMPANION_CARD_GROWTHS)[number];
+
+/**
+ * How big the companion is drawn, as a named step rather than a number.
+ *
+ * Named rather than free, because the avatar's box is not a style — it is the
+ * geometry both sides of the bridge agree on, and everything derives from it:
+ * the pill's reach, the card's height, and the canvas sized to hold the largest
+ * state. A continuous scale would be a layout nobody had ever looked at; four
+ * steps are four layouts, each checkable in Storybook.
+ *
+ * `large` is the default. The surface shipped at `small`, which is the size the
+ * pill was designed at and too small to find on a busy desktop (JARVIS-1549).
+ */
+export const COMPANION_SIZES = ["small", "medium", "large", "huge"] as const;
+
+export type CompanionSize = (typeof COMPANION_SIZES)[number];
+
+/** The avatar's box in points, per named size. The scale is this over `small`. */
+export const COMPANION_SIZE_BOXES: Record<CompanionSize, number> = {
+  small: 44,
+  medium: 66,
+  large: 88,
+  huge: 110,
+};
+
+/** What the surface is drawn at when nothing has been chosen. */
+export const DEFAULT_COMPANION_SIZE: CompanionSize = "large";
+
+/**
  * The assistant's character, as the three trait ids it is composed from.
  *
  * Structurally the fields of the web layer's `CharacterTraits` that
@@ -675,6 +726,21 @@ export interface CompanionContext {
 /** What main tells the companion renderer. */
 export interface CompanionSurfaceState {
   growth: CompanionGrowth;
+  /**
+   * Which way the typing card unfurls, and with it where the avatar sits inside
+   * the canvas. See {@link CompanionCardGrowth}: main owns the window position,
+   * so main is the only side that can decide this.
+   */
+  cardGrowth: CompanionCardGrowth;
+  /**
+   * The avatar's box in points, which is the whole of the surface's scale.
+   *
+   * One number rather than the named size, because the name is a lookup both
+   * sides would then have to hold the same copy of. Everything the surface
+   * draws derives from this, so the renderer scales itself by this over the
+   * size the layout is authored at. See {@link COMPANION_SIZE_BOXES}.
+   */
+  avatarBox: number;
   /**
    * The assistant's display name, for the composer's placeholder.
    *


### PR DESCRIPTION
Replaces #40893 and #40901, which were stacked. One PR against `main`, one branch cut from current `main`, no merge commits — both changes are to the same piece of geometry and reviewing them apart cost more than it bought.

## 1. The surface could not be dragged into the top of the screen (JARVIS-1548)

Confirmed against the window server rather than guessed — a headless Electron probe with the companion's exact window options, setting a position and reading it back:

```
display workArea: x0 y33 1728x1084

  asked ->   got   | avatar centre y
   -237 ->    33   |      325          <-- refused
      0 ->    33   |      325          <-- refused
    100 ->   100   |      392
```

macOS refuses any window origin above **the top of the work area**. `clampCanvasOrigin` asked for `-237` — correct, it wants the avatar's centre at `workArea.y + 22` = 55 — and AppKit handed back 33, putting the avatar, pinned at the canvas's centre, at **325**. That is 270pt short on a 1117pt display.

This rules out two things: the clamp from JARVIS-1539 is innocent (it asks correctly and is overruled), and no window flag escapes it — all seven always-on-top levels floor identically, `setBounds` behaves as `setPosition`, and a plain `BrowserWindow` behaves as a panel.

**The fix.** The canvas only ever needed the card's height on the side the card grows into (`riseAbove`) and the avatar's box plus its shadow on the other (`dropBelow`). Pinning the avatar to the centre is what bought the dead band. The canvas is asymmetric now, and which end the avatar sits at is chosen from the room the display has, mirroring `growthFor`.

`placeCanvas` replaces `clampCanvasOrigin` and works in the **avatar's** coordinates, not the window's. That is not cosmetic: once the offset can change, the same origin means two different avatar positions, so a delta applied to the origin would tear the mascot out from under the pointer at the threshold.

`cardGrowthFor` deliberately does **not** mirror `growthFor`'s fallback. A canvas may hang off the sides of a display but not off the top, so falling back to `up` when neither fits would push the avatar down by the whole reserved height — this same bug in miniature on a short display. The card is already lost there; the reach is not.

Verified against the real window server after the change: the avatar reaches **79 instead of 325**, the direction flips at exactly 325 with the avatar landing where asked on both sides (324 to 324, 325 to 325, so no jump mid-drag), and macOS rewrites **none** of the origins main asks for.

## 2. The avatar was too small, and should be resizable (JARVIS-1549)

Four named steps in the tray, persisted by main, defaulting to **large**.

```
small   box  44   canvas  724x338   (what shipped)
medium  box  66   canvas 1086x507
large   box  88   canvas 1448x676   (default)
huge    box 110   canvas 1810x845
```

Named steps rather than a slider, which is the ticket's own reasoning: the avatar's box is not a style, it is the geometry both processes derive from. A continuous scale would be a layout nobody had ever looked at.

- `geometryFor(size)` replaces the module's fixed constants, and the placement rules take it as a parameter rather than reading it off the module, so they stay pure and every size is a case a test can state.
- `setCompanionSurfaceSize` resizes in one `setBounds`, preserving **the avatar's position, not the window's** — they are not the same point and the difference is most of the canvas, so keeping the origin would walk the mascot across the desktop.
- **The renderer scales a base-sized wrapper** rather than restating its dimensions: the window divided by the scale, blown back up about its top-left, so every length inside resolves in the units the layout was authored in. `CompanionSurface`'s own layout is untouched. The alternative was scaling ~40 hard-coded dimensions and keeping them in step with main's arithmetic by hand.
- The stored size is validated on read — `window-state.json` is editable and an older build can have written it; an unknown value would index the geometry table with `undefined`.
- Windows stubs the two new `TrayModelRuntime` fields; it has no companion surface.

**Why they ship together:** a bigger avatar makes the top-of-screen ceiling *worse*, since the canvas grows with it. At `large` the dead band would have been 584pt. The `placing a larger companion` suite exists for exactly this — it re-asserts 1548's invariants at 2x rather than trusting they scale.

## Testing

- `clients/macos` — `bun run test:ci` 44 + 40 files, 0 failed; `companion-window.test.ts` 39 pass
- `clients/windows` — `bun scripts/run-tests.ts` 29 files, 0 failed
- `clients/web` — `companion-surface.test.tsx` 22, `companion-surface-page.test.tsx` 7, `runtime/companion-surface.test.ts` 6
- `tsc --noEmit` clean in `clients/macos`, `clients/windows`, `clients/web`, `packages/electron-desktop`
- New `AgainstTheTopEdge` story, the vertical twin of `AgainstTheRightEdge`

**Driven in the real app**: the size picker works end to end, the avatar holds its position through a size change, and the scaled surface renders correctly. Not covered by any test: how type looks at 2x and above, since it is rasterized through the transform.

## Open

- **Is `large` the right default?** JARVIS-1549 says the avatar "could plausibly be three times the size". `large` is 2x; `huge` is 2.5x.
- **No 3x step.** The set stops at 110 where the ticket points at 132. One entry in `COMPANION_SIZE_BOXES` plus a label; geometry, tray and tests all derive.
- No per-size Storybook story yet.

Closes JARVIS-1548
Closes JARVIS-1549

🤖 Generated with [Claude Code](https://claude.com/claude-code)