### PR TITLE
docs(web): describe the i18n rule as it reads code now, and who writes the translated value

### DIFF
--- a/clients/web/docs/I18N.md
+++ b/clients/web/docs/I18N.md
@@ -60,6 +60,15 @@ back to English, which is degraded but not broken. A key present in a
 translated catalog but absent from English is a test failure, because nothing
 can read it.
 
+The author writes the translated value, so before writing one, look at how the
+same English is already translated elsewhere in the catalogs and reuse that
+wording when the surface is the same. Where it is not the same, expect the
+wording to differ: a translation agrees with the thing it acts on, so a bulk
+action over conversaciones reads "Marcar todas como leídas" while the same
+English over one conversation reads "Marcar como leída". `catalogs.test.ts`
+checks that a message parses and keeps its placeholders. Nothing checks that it
+is worded well, which is why the surrounding catalog is the reference.
+
 **4. Read it with `t()`,** naming the namespace unless it is `common`:
 
 ```tsx
@@ -149,14 +158,33 @@ literal copy do need escaping.
 prop that is not structural whose value reads as copy rather than an enum.
 
 That last part is a denylist, not an allowlist: `className`, `href`, `data-*`,
-handlers, and SVG geometry are structural, and everything else is checked. A
-value counts as copy when it has a space or starts with a capital, so
-`label="Save changes"` and `submitLabel="Complete signup"` are caught while
-`variant="primary"` and `tone="error"` stay quiet. An allowlist of prop names
+handlers, SVG geometry, and the ARIA attributes that hold element ids are
+structural, and everything else is checked. A value counts as copy when it has
+a space or starts with a capital, so `label="Save changes"` and
+`submitLabel="Complete signup"` are caught while `variant="primary"` and
+`tone="error"` stay quiet. An allowlist of prop names
 could only ever cover props someone had thought of, and three converted domains
 kept shipping English through bespoke props like `toggleAriaLabel`. It is enabled **only for the paths in
 `i18nEnforcedPaths`** in [`eslint.config.mjs`](../eslint.config.mjs), and that
 list grows as areas are converted.
+
+**A string the component assembles is read differently,** whether it was built
+with a template or with `+`, because that is the shape this guide calls the
+worst one. It is reported when its fragments hold words at all, rather than
+when they read as copy: `` `${label} actions` `` leaves one lowercase word
+behind, which passes the test above and is still a sentence a translator cannot
+reorder. A fragment gives up whatever is glued to the interpolation first, so
+`` `${count}-day trial` `` keeps "trial" and is reported while
+`` `${name}.vellum` `` and `` `${id}-opt` `` build identifiers and stay quiet.
+The values between the fragments are read in turn, since
+`${draft ? "Draft" : "Live"}` puts its copy where the fragments are not.
+
+**A toast is read whole,** not just its message: the fields of its options bag
+that the toast renders (`description`, and the `label` on an `action`) are copy
+on sight, since `description: "saved"` is one lowercase word that the prop test
+would let through and a toast renders it either way. Those field names come
+from `ToastOptions` in the design library, which is the only toast this app
+has.
 
 To convert an area: move its copy into the right namespace, read it with `t()`,
 add the glob, and run `bun run lint` until it is quiet.

--- a/clients/web/docs/I18N.md
+++ b/clients/web/docs/I18N.md
@@ -179,12 +179,17 @@ reorder. A fragment gives up whatever is glued to the interpolation first, so
 The values between the fragments are read in turn, since
 `${draft ? "Draft" : "Live"}` puts its copy where the fragments are not.
 
-**A toast is read whole,** not just its message: the fields of its options bag
-that the toast renders (`description`, and the `label` on an `action`) are copy
-on sight, since `description: "saved"` is one lowercase word that the prop test
-would let through and a toast renders it either way. Those field names come
+**A toast is read past its message,** into the fields of its options bag that
+the toast renders (`description`, and the `label` on an `action`). Those are
+copy on sight, since `description: "saved"` is one lowercase word that the prop
+test would let through and a toast renders it either way. The field names come
 from `ToastOptions` in the design library, which is the only toast this app
 has.
+
+The bag is read where it is written out at the call: `{ ...base, description:
+"saved" }` is reported, and so is an `action` written inline. A bag handed over
+as a variable is not, and neither is an `action` that is one, since the rule
+reads the call rather than following values to where they were built.
 
 To convert an area: move its copy into the right namespace, read it with `t()`,
 add the glob, and run `bun run lint` until it is quiet.
@@ -195,8 +200,8 @@ add the glob, and run `bun run lint` until it is quiet.
 **A clean lint run is not proof a domain is fully translated.** The rule reads
 JSX, so copy that reaches the screen from somewhere else is invisible to it:
 string literals in `.ts` data modules (channel metadata, option lists, enum
-labels), messages passed to `setError()` or returned by a helper, and arrays of
-literals. Adding a glob records that the JSX is converted, nothing more. When
+labels), messages passed to `setError()` or returned by a helper, arrays of
+literals, and any toast options assembled somewhere other than the call. Adding a glob records that the JSX is converted, nothing more. When
 you convert a domain, read its non-JSX modules too.
 
 The list is the record of how far the cutover has reached. Scoping it this way


### PR DESCRIPTION
## TL;DR

`docs/I18N.md` described `local/no-untranslated-strings` as it behaved two changes ago, and never said who writes the value for the non-English catalog. Both fixed here. Docs only.

## The stale half, which is on me

#40896 and #40908 taught the rule to read assembled strings and toast option bags. Neither updated the guide, so it still described the version before them. It now covers:

- **Assembled strings** are judged on whether their fragments hold words at all, not on whether a fragment reads as copy. `` `${label} actions` `` leaves one lowercase word behind, which the prop test lets through and which is still a sentence a translator cannot reorder. The same treatment applies to `+`.
- **A fragment gives up whatever is glued to the interpolation**, which is what separates `` `${count}-day trial` `` (reported, "trial" survives) from `` `${name}.vellum` `` and `` `${id}-opt` `` (identifiers, quiet).
- **The values between fragments are read in turn**, since `${draft ? "Draft" : "Live"}` puts its copy where the fragments are not.
- **A toast is read whole**: the option fields it renders (`description`, and an `action`'s `label`) are copy on sight, with the field names taken from `ToastOptions` in the design library rather than invented.
- The ARIA attributes holding element ids are named as structural.

## The missing half

Step 3 said "add it to every locale" and stopped there. It never said who writes the translated value or what to aim for, although every catalog PR has done the same thing: the author writes it, in the same commit as the English.

It now says that, plus the two things that actually keep a catalog coherent: seed from how the same English already reads elsewhere when the surface matches, and expect it to differ when the grammar does, because a translation agrees with the thing it acts on. The worked pair is a bulk action over conversaciones ("Marcar todas como leídas") against the same English over one conversation ("Marcar como leída").

It also says plainly that `catalogs.test.ts` checks that a message parses and keeps its placeholders, and that nothing checks the wording, so the surrounding catalog is the reference.

## A test I wrote and threw away

The obvious guard is to assert that identical English gets an identical translation, with an allowlist for deliberate divergences. I wrote it, then ran it across the catalogs before proposing it: **82 pairs would fail**, and reading them, most are correct. Spanish agrees with its subject, so `failed` is "Fallida" for a call and "Fallido" for a status, `high` is "Alto" for risk and "Alta" for sensitivity, and `(leave blank to keep current)` is "la actual" for a key and "el actual" for a token. Narrowing to one namespace still leaves 26.

An allowlist of 82 entries on day one is not a guard, it is noise, and this guide already says what happens to a noisy rule. The real check for wording is a reader who speaks the language, which is what the doc now points at.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40913" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->