### PR TITLE
fix(daemon): re-scope history to the queued sender before running their turn

### DIFF
--- a/assistant/src/__tests__/drain-actor-rescope.test.ts
+++ b/assistant/src/__tests__/drain-actor-rescope.test.ts
@@ -1,0 +1,137 @@
+/**
+ * A queued turn runs as its own sender, against that sender's history.
+ *
+ * History is scoped to the conversation's resting actor: `loadFromDb` splices
+ * persisted personal-memory blocks into the transcript only for actors allowed
+ * to see them. A queued message is frequently not from whoever the previous
+ * turn ran as, so the drain has to stamp the sender and re-scope before the
+ * turn reads that history. Without it a contact's queued turn inherits the
+ * guardian's view, and the reply can reflect the guardian's personal memory
+ * back to them.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { drainQueue } from "../daemon/conversation-process.js";
+import {
+  MessageQueue,
+  type QueuedMessage,
+} from "../daemon/conversation-queue-manager.js";
+import type { TrustContext } from "../daemon/trust-context-types.js";
+
+const GUARDIAN: TrustContext = {
+  trustClass: "guardian",
+  sourceChannel: "vellum",
+};
+// Non-guardian, so `isPersonalMemoryAllowed` is false for it while it is true
+// for the guardian: the exact axis `loadFromDb` gates memory blocks on.
+const CONTACT: TrustContext = {
+  trustClass: "unverified_contact",
+  sourceChannel: "slack",
+};
+
+function makeQueued(
+  content: string,
+  requestId: string,
+  trustContext?: TrustContext,
+): QueuedMessage {
+  return {
+    content,
+    attachments: [],
+    requestId,
+    onEvent: () => {},
+    sentAt: Date.now(),
+    ...(trustContext ? { trustContext } : {}),
+  } as unknown as QueuedMessage;
+}
+
+function makeFakeConversation(restingTrust: TrustContext) {
+  const queue = new MessageQueue();
+  // Ordered, because "re-scoped" only means anything if it happened before the
+  // turn read the history.
+  const calls: string[] = [];
+  const conversation = {
+    conversationId: "conv-drain-rescope",
+    queue,
+    pendingSteerRepair: false,
+    preactivatedSkillIds: undefined as string[] | undefined,
+    messages: [] as unknown[],
+    surfaceActionRequestIds: new Set<string>(),
+    activeSurfaceId: undefined,
+    trustContext: restingTrust,
+    currentTurnTrustContext: undefined as TrustContext | undefined,
+    usageStats: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
+    ensureHostProxiesForTurn: () => {},
+    getTurnChannelContext: () => null,
+    setTurnChannelContext: () => {},
+    getTurnInterfaceContext: () => null,
+    setTurnInterfaceContext: () => {},
+    setTransportHints: () => {},
+    emitActivityState: () => {},
+    isProcessing: () => false,
+    setTrustContext: (ctx: TrustContext | null) => {
+      calls.push(`setTrustContext:${ctx?.trustClass}`);
+      conversation.trustContext = ctx as TrustContext;
+    },
+    ensureActorScopedHistory: async () => {
+      calls.push(
+        `ensureActorScopedHistory:${conversation.trustContext?.trustClass}`,
+      );
+    },
+    persistUserMessage: async (opts: { content: string }) => {
+      calls.push(`persistUserMessage:${opts.content}`);
+      return { id: "msg-1", deduplicated: true };
+    },
+  };
+  return { conversation, queue, calls };
+}
+
+describe("queued turns re-scope history to their own sender", () => {
+  test("a contact's message queued behind a guardian turn re-scopes before the turn reads history", async () => {
+    const { conversation, queue, calls } = makeFakeConversation(GUARDIAN);
+    queue.push(makeQueued("what did we decide?", "r1", CONTACT));
+
+    await drainQueue(conversation as never);
+
+    // The sender is stamped, history is re-scoped under that stamp, and only
+    // then does the turn persist. Asserting the order is the point: re-scoping
+    // after the read would leave the guardian's memory blocks in the
+    // transcript this turn runs against.
+    expect(calls).toEqual([
+      "setTrustContext:unverified_contact",
+      "ensureActorScopedHistory:unverified_contact",
+      "persistUserMessage:what did we decide?",
+    ]);
+    // The resting actor now names whoever the running turn belongs to.
+    expect(conversation.trustContext).toEqual(CONTACT);
+    expect(conversation.currentTurnTrustContext).toEqual(CONTACT);
+  });
+
+  test("a same-actor queue still re-scopes, which the conversation resolves to a no-op", async () => {
+    const { conversation, queue, calls } = makeFakeConversation(GUARDIAN);
+    queue.push(makeQueued("and another thing", "r1", GUARDIAN));
+
+    await drainQueue(conversation as never);
+
+    expect(calls).toEqual([
+      "setTrustContext:guardian",
+      "ensureActorScopedHistory:guardian",
+      "persistUserMessage:and another thing",
+    ]);
+    expect(conversation.trustContext).toEqual(GUARDIAN);
+  });
+
+  test("a queued message with no trust of its own leaves the resting actor in place", async () => {
+    const { conversation, queue, calls } = makeFakeConversation(GUARDIAN);
+    queue.push(makeQueued("internal dispatch", "r1"));
+
+    await drainQueue(conversation as never);
+
+    // No stamp: nothing claimed this message for a different actor, so the
+    // owner stands rather than being overwritten with a guess.
+    expect(calls).toEqual([
+      "ensureActorScopedHistory:guardian",
+      "persistUserMessage:internal dispatch",
+    ]);
+    expect(conversation.trustContext).toEqual(GUARDIAN);
+  });
+});

--- a/assistant/src/__tests__/drain-actor-rescope.test.ts
+++ b/assistant/src/__tests__/drain-actor-rescope.test.ts
@@ -1,137 +1,166 @@
 /**
- * A queued turn runs as its own sender, against that sender's history.
+ * A persisted turn is scoped to the actor the row is attributed to.
  *
  * History is scoped to the conversation's resting actor: `loadFromDb` splices
  * persisted personal-memory blocks into the transcript only for actors allowed
- * to see them. A queued message is frequently not from whoever the previous
- * turn ran as, so the drain has to stamp the sender and re-scope before the
- * turn reads that history. Without it a contact's queued turn inherits the
- * guardian's view, and the reply can reflect the guardian's personal memory
- * back to them.
+ * to see them. A queue drain hands `persistUserMessage` the sender it captured
+ * at enqueue time, but the resting slot is mutable and another request can
+ * have stamped it since. Scoping off the slot therefore let a contact's queued
+ * turn run against the guardian's transcript, personal memory included.
+ *
+ * Exercised against `Conversation.prototype.persistUserMessage` directly: the
+ * drain-level fakes elsewhere stub `persistUserMessage` wholesale, so a test
+ * driven through `drainQueue` would bypass the code under test entirely.
  */
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 
-import { drainQueue } from "../daemon/conversation-process.js";
-import {
-  MessageQueue,
-  type QueuedMessage,
-} from "../daemon/conversation-queue-manager.js";
 import type { TrustContext } from "../daemon/trust-context-types.js";
+
+const persistCalls: Array<{ content: string }> = [];
+let persistThrows: Error | undefined;
+
+mock.module("../daemon/conversation-messaging.js", () => ({
+  persistUserMessage: async (_ctx: unknown, options: { content: string }) => {
+    persistCalls.push({ content: options.content });
+    if (persistThrows) {
+      throw persistThrows;
+    }
+    return { id: "msg-1", deduplicated: false };
+  },
+  enqueueMessage: () => ({ queued: false }),
+  redirectToSecurePrompt: () => {},
+  persistQueuedMessageBody: async () => ({ id: "msg-1" }),
+  restingTrust: (c: { trustContext?: TrustContext }) => c?.trustContext,
+}));
+
+const { Conversation } = await import("../daemon/conversation.js");
 
 const GUARDIAN: TrustContext = {
   trustClass: "guardian",
   sourceChannel: "vellum",
 };
-// Non-guardian, so `isPersonalMemoryAllowed` is false for it while it is true
-// for the guardian: the exact axis `loadFromDb` gates memory blocks on.
+// Non-guardian, so `isPersonalMemoryAllowed` is false for it while true for
+// the guardian: the axis `loadFromDb` gates personal-memory blocks on.
 const CONTACT: TrustContext = {
   trustClass: "unverified_contact",
   sourceChannel: "slack",
 };
 
-function makeQueued(
-  content: string,
-  requestId: string,
-  trustContext?: TrustContext,
-): QueuedMessage {
-  return {
-    content,
-    attachments: [],
-    requestId,
-    onEvent: () => {},
-    sentAt: Date.now(),
-    ...(trustContext ? { trustContext } : {}),
-  } as unknown as QueuedMessage;
-}
-
-function makeFakeConversation(restingTrust: TrustContext) {
-  const queue = new MessageQueue();
-  // Ordered, because "re-scoped" only means anything if it happened before the
-  // turn read the history.
+/**
+ * Minimal receiver for `persistUserMessage.call(...)`. Records the order of
+ * stamp and re-scope, because "re-scoped" only means anything if it happened
+ * before the transcript was read.
+ */
+function makeReceiver(restingTrust: TrustContext, processing = false) {
   const calls: string[] = [];
-  const conversation = {
-    conversationId: "conv-drain-rescope",
-    queue,
-    pendingSteerRepair: false,
-    preactivatedSkillIds: undefined as string[] | undefined,
-    messages: [] as unknown[],
-    surfaceActionRequestIds: new Set<string>(),
-    activeSurfaceId: undefined,
-    trustContext: restingTrust,
-    currentTurnTrustContext: undefined as TrustContext | undefined,
-    usageStats: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
-    ensureHostProxiesForTurn: () => {},
-    getTurnChannelContext: () => null,
-    setTurnChannelContext: () => {},
-    getTurnInterfaceContext: () => null,
-    setTurnInterfaceContext: () => {},
-    setTransportHints: () => {},
-    emitActivityState: () => {},
-    isProcessing: () => false,
-    setTrustContext: (ctx: TrustContext | null) => {
-      calls.push(`setTrustContext:${ctx?.trustClass}`);
-      conversation.trustContext = ctx as TrustContext;
+  const receiver = {
+    _processing: processing,
+    trustContext: restingTrust as TrustContext | null,
+    setTrustContext(ctx: TrustContext | null) {
+      calls.push(`stamp:${ctx?.trustClass ?? "null"}`);
+      receiver.trustContext = ctx;
     },
-    ensureActorScopedHistory: async () => {
-      calls.push(
-        `ensureActorScopedHistory:${conversation.trustContext?.trustClass}`,
-      );
-    },
-    persistUserMessage: async (opts: { content: string }) => {
-      calls.push(`persistUserMessage:${opts.content}`);
-      return { id: "msg-1", deduplicated: true };
+    async ensureActorScopedHistory() {
+      calls.push(`scope:${receiver.trustContext?.trustClass ?? "none"}`);
     },
   };
-  return { conversation, queue, calls };
+  return { receiver, calls };
 }
 
-describe("queued turns re-scope history to their own sender", () => {
-  test("a contact's message queued behind a guardian turn re-scopes before the turn reads history", async () => {
-    const { conversation, queue, calls } = makeFakeConversation(GUARDIAN);
-    queue.push(makeQueued("what did we decide?", "r1", CONTACT));
+const persist = Conversation.prototype.persistUserMessage;
 
-    await drainQueue(conversation as never);
+describe("persistUserMessage scopes history to the row's actor", () => {
+  test("a contact's queued row re-scopes away from the guardian before persisting", async () => {
+    persistThrows = undefined;
+    persistCalls.length = 0;
+    const { receiver, calls } = makeReceiver(GUARDIAN);
 
-    // The sender is stamped, history is re-scoped under that stamp, and only
-    // then does the turn persist. Asserting the order is the point: re-scoping
-    // after the read would leave the guardian's memory blocks in the
-    // transcript this turn runs against.
+    await persist.call(
+      receiver as never,
+      {
+        content: "what did we decide?",
+        trustContext: CONTACT,
+      } as never,
+    );
+
     expect(calls).toEqual([
-      "setTrustContext:unverified_contact",
-      "ensureActorScopedHistory:unverified_contact",
-      "persistUserMessage:what did we decide?",
+      "stamp:unverified_contact",
+      "scope:unverified_contact",
     ]);
-    // The resting actor now names whoever the running turn belongs to.
-    expect(conversation.trustContext).toEqual(CONTACT);
-    expect(conversation.currentTurnTrustContext).toEqual(CONTACT);
+    expect(persistCalls).toEqual([{ content: "what did we decide?" }]);
+    expect(receiver.trustContext).toEqual(CONTACT);
   });
 
-  test("a same-actor queue still re-scopes, which the conversation resolves to a no-op", async () => {
-    const { conversation, queue, calls } = makeFakeConversation(GUARDIAN);
-    queue.push(makeQueued("and another thing", "r1", GUARDIAN));
+  test("a row with no actor of its own leaves the owner in place", async () => {
+    persistThrows = undefined;
+    persistCalls.length = 0;
+    const { receiver, calls } = makeReceiver(GUARDIAN);
 
-    await drainQueue(conversation as never);
+    await persist.call(receiver as never, { content: "internal" } as never);
 
-    expect(calls).toEqual([
-      "setTrustContext:guardian",
-      "ensureActorScopedHistory:guardian",
-      "persistUserMessage:and another thing",
-    ]);
-    expect(conversation.trustContext).toEqual(GUARDIAN);
+    // No stamp: nothing claimed this row for a different actor, so the owner
+    // stands rather than being overwritten with a guess.
+    expect(calls).toEqual(["scope:guardian"]);
+    expect(receiver.trustContext).toEqual(GUARDIAN);
   });
 
-  test("a queued message with no trust of its own leaves the resting actor in place", async () => {
-    const { conversation, queue, calls } = makeFakeConversation(GUARDIAN);
-    queue.push(makeQueued("internal dispatch", "r1"));
+  test("a persist that loses the lock restores the actor it displaced", async () => {
+    persistCalls.length = 0;
+    persistThrows = new Error("The assistant is currently responding");
+    const { receiver, calls } = makeReceiver(GUARDIAN);
 
-    await drainQueue(conversation as never);
+    await expect(
+      persist.call(
+        receiver as never,
+        {
+          content: "queued behind a turn",
+          trustContext: CONTACT,
+        } as never,
+      ),
+    ).rejects.toThrow("currently responding");
 
-    // No stamp: nothing claimed this message for a different actor, so the
-    // owner stands rather than being overwritten with a guess.
+    // The contact's turn never runs, so its actor must not outlive the
+    // attempt: the guardian is put back and history re-scoped to them.
     expect(calls).toEqual([
-      "ensureActorScopedHistory:guardian",
-      "persistUserMessage:internal dispatch",
+      "stamp:unverified_contact",
+      "scope:unverified_contact",
+      "stamp:guardian",
+      "scope:guardian",
     ]);
-    expect(conversation.trustContext).toEqual(GUARDIAN);
+    expect(receiver.trustContext).toEqual(GUARDIAN);
+  });
+
+  test("the restore leaves a stamp made by whoever took the lock alone", async () => {
+    persistCalls.length = 0;
+    const { receiver, calls } = makeReceiver(GUARDIAN);
+    const lockHolder: TrustContext = {
+      trustClass: "trusted_contact",
+      sourceChannel: "phone",
+    };
+    persistThrows = new Error("The assistant is currently responding");
+    // Whoever took the lock re-stamps the slot while the reload is in flight.
+    const originalScope = receiver.ensureActorScopedHistory;
+    receiver.ensureActorScopedHistory = async () => {
+      await originalScope.call(receiver);
+      receiver.trustContext = lockHolder;
+    };
+
+    await expect(
+      persist.call(
+        receiver as never,
+        {
+          content: "queued",
+          trustContext: CONTACT,
+        } as never,
+      ),
+    ).rejects.toThrow("currently responding");
+
+    // Guarded restore: our stamp is no longer the one in the slot, so it is
+    // left as the lock holder set it rather than clobbered back.
+    expect(calls).toEqual([
+      "stamp:unverified_contact",
+      "scope:unverified_contact",
+    ]);
+    expect(receiver.trustContext).toEqual(lockHolder);
   });
 });

--- a/assistant/src/__tests__/drain-kick-guard.test.ts
+++ b/assistant/src/__tests__/drain-kick-guard.test.ts
@@ -85,6 +85,9 @@ function makeFakeConversation(
         throw new Error("activity emit exploded");
       }
     },
+    // The drain re-scopes history to the queued sender before running.
+    ensureActorScopedHistory: async () => {},
+    setTrustContext: () => {},
     isProcessing: () => false,
     persistUserMessage: async (opts: { content: string }) => {
       persistCalls.push(opts.content);

--- a/assistant/src/__tests__/drain-requeue-on-contention.test.ts
+++ b/assistant/src/__tests__/drain-requeue-on-contention.test.ts
@@ -81,6 +81,11 @@ function makeFakeConversation(options: {
     emitActivityState: () => {
       mutationCalls.push("emitActivityState");
     },
+    // The drain re-scopes history to the queued sender before running.
+    ensureActorScopedHistory: async () => {
+      mutationCalls.push("ensureActorScopedHistory");
+    },
+    setTrustContext: () => {},
     isProcessing: () => options.processing ?? false,
     persistUserMessage: async (opts: { content: string }) => {
       persistCalls.push(opts.content);

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -812,6 +812,18 @@ async function drainSingleMessage(
   conversation.currentTurnChannelCapabilities =
     conversation.channelCapabilities;
 
+  // History is scoped to the resting actor: `loadFromDb` splices persisted
+  // personal-memory blocks into the transcript only for actors allowed to see
+  // them. A queued sender is frequently not who the previous turn ran as, so
+  // stamp them and re-scope before this turn reads that history, or it
+  // inherits the previous actor's view of it. `ensureActorScopedHistory`
+  // early-returns unless the trust class or personal-memory gate actually
+  // changed, so a same-actor queue costs nothing.
+  if (next.trustContext) {
+    conversation.setTrustContext(next.trustContext);
+  }
+  await conversation.ensureActorScopedHistory();
+
   // Resolve slash commands for queued messages
   const slashResult = await resolveSlash(
     next.content,
@@ -1414,6 +1426,18 @@ async function drainBatch(
     head.trustContext ?? conversation.trustContext;
   conversation.currentTurnChannelCapabilities =
     conversation.channelCapabilities;
+
+  // History is scoped to the resting actor: `loadFromDb` splices persisted
+  // personal-memory blocks into the transcript only for actors allowed to see
+  // them. A queued sender is frequently not who the previous turn ran as, so
+  // stamp them and re-scope before this turn reads that history, or it
+  // inherits the previous actor's view of it. `ensureActorScopedHistory`
+  // early-returns unless the trust class or personal-memory gate actually
+  // changed, so a same-actor queue costs nothing.
+  if (head.trustContext) {
+    conversation.setTrustContext(head.trustContext);
+  }
+  await conversation.ensureActorScopedHistory();
 
   // Single activity-state transition for the batched turn. Per-message
   // emissions would publish N "thinking" phase transitions to every

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -2714,10 +2714,35 @@ export class Conversation {
   async persistUserMessage(
     options: PersistMessageOptions,
   ): Promise<{ id: string; deduplicated: boolean }> {
-    if (!this._processing) {
-      await this.ensureActorScopedHistory();
+    if (this._processing) {
+      return persistUserMessageImpl(this, options);
     }
-    return persistUserMessageImpl(this, options);
+    // Scope to the actor this row is attributed to, not to whoever occupies
+    // the slot. A queue drain hands us the sender it captured at enqueue time,
+    // and another request can have stamped the slot since -- scoping off the
+    // slot would then give a contact's queued turn the guardian's transcript,
+    // personal memory included. Stamped rather than passed down because
+    // `loadFromDb` reads the slot directly.
+    const priorTrust = this.trustContext;
+    const stampedTrust = options.trustContext;
+    if (stampedTrust) {
+      this.setTrustContext(stampedTrust);
+    }
+    try {
+      await this.ensureActorScopedHistory();
+      return await persistUserMessageImpl(this, options);
+    } catch (err) {
+      // The persist can fail because another turn took the lock while we were
+      // reloading, in which case this row's actor never runs and must not
+      // outlive the attempt. Guarded like `agent-wake`'s restore: only our own
+      // stamp is undone, so a trust re-set by whoever now holds the lock is
+      // left alone.
+      if (stampedTrust && this.trustContext === stampedTrust) {
+        this.setTrustContext(priorTrust ?? null);
+        await this.ensureActorScopedHistory();
+      }
+      throw err;
+    }
   }
 
   // ── Agent Loop ───────────────────────────────────────────────────


### PR DESCRIPTION
Fixes LUM-3344

## TL;DR

A queued message ran against whoever the *previous* turn loaded history for. A contact's message queued behind a guardian turn therefore ran with the guardian's personal memory sitting in the transcript, and the reply could reflect it back to them. Both drain paths now re-scope history to the queued sender before the turn reads it.

## What the user hits

You are mid-reply to the guardian. A contact sends into the same conversation over Slack or SMS, so their message queues. When it drains:

- `loadFromDb` had spliced the guardian's persisted personal-memory blocks into the transcript (v3 memory cards, PKB and matched sections, the v2 static memory block) because it gates them on `isPersonalMemoryAllowed(this.trustContext)` (`conversation.ts:1235`, `:1262`), and the slot named the guardian when history was loaded.
- Nothing re-scoped, so those blocks were still in `this.messages` for the contact's turn.

The reply to the contact can therefore contain the guardian's private memory. The inverse is the same defect in the other direction: a guardian message queued behind a contact's turn runs with memory stripped, and the assistant appears to have forgotten things it should know.

## Why it happened

`ensureActorScopedHistory()` is the mechanism for this and `processMessage` calls it. Neither `drainSingleMessage` nor `drainBatch` did. Both already knew the queued sender was a different actor -- each sets `currentTurnTrustContext` from the queued item precisely because, in the drain's own words, "the slot holds whichever actor sent most recently, which is this sender only when nobody else sent while this message waited." They set the turn's actor and then read history scoped to someone else.

This is not hypothetical. `conversation-process.ts` refuses to coalesce a queued message whose trust identity differs from the batch head, commented "or a tail executes with the head's privileges", so mixed-actor queues are a case the drain already models. `ensureActorScopedHistory`'s own comment names this leak: stale personal-memory blocks reaching an untrusted remote turn.

## What this does

`Conversation.persistUserMessage` stamps the actor the row is attributed to, scopes history to it, and restores the displaced actor if the persist fails.

That is where the fix belongs rather than in the drains. The captured sender already arrives there as `PersistMessageOptions.trustContext` -- both drains pass it, and its own docstring says why it exists: "Queue drains pass the sender's captured trust so persisted provenance names the same actor the turn executes as; the conversation slot may by then hold someone else." The method was already re-scoping history off `this.trustContext` while holding the row's real actor in its hand. It is also where the processing lock is already consulted, via the existing `!this._processing` guard.

The restore uses the same identity guard `agent-wake` uses (`conversation.trustContext === opts.trustContext`), so a trust re-set by whoever took the lock is left alone rather than clobbered back.

## Why this is safe

`ensureActorScopedHistory` early-returns unless the trust class or the personal-memory gate actually changed, so a same-actor persist -- nearly every persist -- does no extra work and reloads nothing.

A row with no actor of its own does not stamp: nothing claimed it for a different actor, so the owner stands rather than being overwritten with a guess.

A persist that loses the lock puts the displaced actor back and re-scopes to them, so a turn that never ran cannot leave the conversation pointed at its sender.

## Before / after

| Situation | Before | After |
| --- | --- | --- |
| Contact's message queued behind a guardian turn | runs with the guardian's memory blocks in the transcript | history re-scoped to the contact first |
| Guardian's message queued behind a contact's turn | runs with memory stripped | history re-scoped to the guardian first |
| Same-actor queue | no re-scope | re-scope call that early-returns; no reload |
| Queued message with no trust | resting actor stands | unchanged |

## Tests

`drain-actor-rescope.test.ts` exercises `Conversation.prototype.persistUserMessage` directly, because the drain-level fakes elsewhere stub `persistUserMessage` wholesale -- a test driven through `drainQueue` would bypass the code under test and pass for the wrong reason.

It asserts the **ordering** of stamp and scope, since "re-scoped" only means anything if it happened before the transcript was read, and covers four cases: a contact's row re-scoping away from the guardian, a row with no actor leaving the owner alone, a lost lock restoring the displaced actor, and the guarded restore declining to clobber a stamp made by whoever took the lock.

`unverified_contact` / `phone` are used rather than invented values, because `isPersonalMemoryAllowed` is true only for `guardian` -- that pairing is the actual axis the memory blocks are gated on. Two of my first-draft literals (`"untrusted"`, `"sms"`) were not real union members and `tsc` caught both.

## Considered, not done here

`processMessage`'s preamble follows its stamp with `mergeConversationOptions(...)`, which a later stale-conversation rebuild re-applies. This path stamps the live conversation only, so after a queued cross-actor turn the in-memory resting trust and the persisted options map can disagree until the next turn re-derives it. Raised by review; left alone because making persistence mirror the merge is a separate decision about what the options map is for, not a fix to the leak this closes.

## Relationship to LUM-3220

Found while doing that one, but independent of it and branched from `main`: no drain path reads the resting slot for history scoping, so this predates that change and neither causes nor is affected by it. They touch different functions in `conversation-process.ts`.

## Verification

`tsc --noEmit`, eslint and the pinned prettier over the touched files. Local `bun test` is hook-blocked; CI runs the suites.
