### PR TITLE
fix(providers): string-content fallback for OpenAI-compatible endpoints that reject content-parts arrays

### DIFF
--- a/assistant/src/providers/openai/__tests__/chat-completions-provider-reasoning.test.ts
+++ b/assistant/src/providers/openai/__tests__/chat-completions-provider-reasoning.test.ts
@@ -8,42 +8,11 @@ import {
   OpenAIChatCompletionsProvider,
   type OpenAIChatCompletionsProviderOptions,
 } from "../chat-completions-provider.js";
-
-type ReasoningDetail = {
-  type?: string;
-  summary?: string | null;
-  text?: string | null;
-};
-
-type MockChunkDelta = {
-  content?: string | null;
-  reasoning?: string | null;
-  reasoning_content?: string | null;
-  reasoning_details?: ReasoningDetail[] | null;
-};
-
-type MockChunk = {
-  choices: Array<{ delta: MockChunkDelta; finish_reason?: string | null }>;
-  model?: string;
-  usage?: {
-    prompt_tokens: number;
-    completion_tokens: number;
-    prompt_tokens_details?: {
-      cached_tokens?: number;
-      cache_write_tokens?: number;
-    };
-  };
-};
-
-function makeStream(chunks: MockChunk[]): AsyncIterable<MockChunk> {
-  return {
-    async *[Symbol.asyncIterator]() {
-      for (const c of chunks) {
-        yield c;
-      }
-    },
-  };
-}
+import {
+  type MockChunk,
+  rejection,
+  stubClient,
+} from "./chat-completions-stub.js";
 
 function stubProvider(
   chunks: MockChunk[],
@@ -58,19 +27,7 @@ function stubProvider(
     "test-model",
     options,
   );
-  const requests: unknown[] = [];
-  // Swap the SDK client for a stub whose chat.completions.create returns our
-  // canned async iterable.
-  (provider as unknown as { client: unknown }).client = {
-    chat: {
-      completions: {
-        create: async (params: unknown) => {
-          requests.push(params);
-          return makeStream(chunks);
-        },
-      },
-    },
-  };
+  const requests = stubClient(provider, chunks);
   const events: Array<{ type: string; thinking?: string; text?: string }> = [];
   (provider as unknown as { __events: typeof events }).__events = events;
   return { provider, events, requests };
@@ -542,23 +499,7 @@ function stubProviderWithErrors(
   chunks: MockChunk[],
 ): { provider: OpenAIChatCompletionsProvider; requests: unknown[] } {
   const provider = new OpenAIChatCompletionsProvider("test-key", "test-model");
-  const requests: unknown[] = [];
-  const pending = [...errors];
-  (provider as unknown as { client: unknown }).client = {
-    chat: {
-      completions: {
-        create: async (params: unknown) => {
-          // Snapshot: the fallback mutates `params` between attempts.
-          requests.push(JSON.parse(JSON.stringify(params)));
-          const error = pending.shift();
-          if (error !== undefined) {
-            throw error;
-          }
-          return makeStream(chunks);
-        },
-      },
-    },
-  };
+  const requests = stubClient(provider, chunks, errors);
   return { provider, requests };
 }
 
@@ -568,10 +509,6 @@ const OK_CHUNKS: MockChunk[] = [
     usage: { prompt_tokens: 1, completion_tokens: 1 },
   },
 ];
-
-function rejection(message: string, status = 400): Error {
-  return Object.assign(new Error(message), { status });
-}
 
 describe("reasoning opt-out rejection fallback", () => {
   test("retries once without reasoning params when a model rejects the explicit opt-out", async () => {
@@ -765,7 +702,9 @@ describe("thinking-mode tool_choice rejection fallback", () => {
 
     expect(requests).toHaveLength(2);
     expect((requests[0] as { tool_choice?: string }).tool_choice).toBe("none");
-    expect((requests[1] as { tool_choice?: string }).tool_choice).toBeUndefined();
+    expect(
+      (requests[1] as { tool_choice?: string }).tool_choice,
+    ).toBeUndefined();
   });
 
   test("does not retry a 4xx that does not name tool_choice", async () => {

--- a/assistant/src/providers/openai/__tests__/chat-completions-string-content.test.ts
+++ b/assistant/src/providers/openai/__tests__/chat-completions-string-content.test.ts
@@ -1,57 +1,24 @@
 import { describe, expect, test } from "bun:test";
 
 import { OpenAIChatCompletionsProvider } from "../chat-completions-provider.js";
-
-type MockChunk = {
-  choices: Array<{
-    delta: { content?: string | null };
-    finish_reason?: string | null;
-  }>;
-  usage?: { prompt_tokens: number; completion_tokens: number };
-};
-
-function makeStream(chunks: MockChunk[]): AsyncIterable<MockChunk> {
-  return {
-    async *[Symbol.asyncIterator]() {
-      for (const c of chunks) {
-        yield c;
-      }
-    },
-  };
-}
+import { rejection, stubClient } from "./chat-completions-stub.js";
 
 function stubProviderWithErrors(errors: unknown[]): {
   provider: OpenAIChatCompletionsProvider;
   requests: unknown[];
 } {
   const provider = new OpenAIChatCompletionsProvider("test-key", "test-model");
-  const requests: unknown[] = [];
-  const pending = [...errors];
-  (provider as unknown as { client: unknown }).client = {
-    chat: {
-      completions: {
-        create: async (params: unknown) => {
-          // Snapshot: the fallback mutates `params` between attempts.
-          requests.push(JSON.parse(JSON.stringify(params)));
-          const error = pending.shift();
-          if (error !== undefined) {
-            throw error;
-          }
-          return makeStream([
-            {
-              choices: [{ delta: { content: "ok" }, finish_reason: "stop" }],
-              usage: { prompt_tokens: 1, completion_tokens: 1 },
-            },
-          ]);
-        },
+  const requests = stubClient(
+    provider,
+    [
+      {
+        choices: [{ delta: { content: "ok" }, finish_reason: "stop" }],
+        usage: { prompt_tokens: 1, completion_tokens: 1 },
       },
-    },
-  };
+    ],
+    errors,
+  );
   return { provider, requests };
-}
-
-function rejection(message: string, status = 400): Error {
-  return Object.assign(new Error(message), { status });
 }
 
 // A user message with text + image serializes to a content-parts array.

--- a/assistant/src/providers/openai/__tests__/chat-completions-string-content.test.ts
+++ b/assistant/src/providers/openai/__tests__/chat-completions-string-content.test.ts
@@ -123,6 +123,42 @@ describe("string-only content rejection fallback", () => {
     expect(requests).toHaveLength(1);
   });
 
+  test("does not retry a tool-schema error about a param named content", async () => {
+    // Not a message-content rejection: flattening would silently drop
+    // attachments without fixing anything.
+    const { provider, requests } = stubProviderWithErrors([
+      rejection(
+        "tools.0.function.parameters.properties.content: Input should be a valid string",
+      ),
+    ]);
+
+    await expect(provider.sendMessage(multiPartMessages)).rejects.toThrow();
+    expect(requests).toHaveLength(1);
+  });
+
+  test("removes two independent incompatibilities in one call", async () => {
+    const { provider, requests } = stubProviderWithErrors([
+      rejection("reasoning_effort 'none' is not supported for this model"),
+      rejection("body/messages/0/content must be string"),
+    ]);
+
+    const response = await provider.sendMessage(multiPartMessages, {
+      config: { effort: "none" },
+    });
+
+    expect(requests).toHaveLength(3);
+    const last = requests[2] as {
+      reasoning_effort?: string;
+      messages: Array<{ content: unknown }>;
+    };
+    expect(last.reasoning_effort).toBeUndefined();
+    expect(typeof last.messages[0].content).toBe("string");
+    const text = response.content.find((b) => b.type === "text") as
+      | { type: "text"; text: string }
+      | undefined;
+    expect(text?.text).toBe("ok");
+  });
+
   test("does not retry an unrelated 400", async () => {
     const { provider, requests } = stubProviderWithErrors([
       rejection("invalid api key"),
@@ -134,7 +170,7 @@ describe("string-only content rejection fallback", () => {
 
   test("does not retry server errors", async () => {
     const { provider, requests } = stubProviderWithErrors([
-      rejection("content must be string", 500),
+      rejection("body/messages/1/content must be string", 500),
     ]);
 
     await expect(provider.sendMessage(multiPartMessages)).rejects.toThrow();

--- a/assistant/src/providers/openai/__tests__/chat-completions-string-content.test.ts
+++ b/assistant/src/providers/openai/__tests__/chat-completions-string-content.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from "bun:test";
+
+import { OpenAIChatCompletionsProvider } from "../chat-completions-provider.js";
+
+type MockChunk = {
+  choices: Array<{
+    delta: { content?: string | null };
+    finish_reason?: string | null;
+  }>;
+  usage?: { prompt_tokens: number; completion_tokens: number };
+};
+
+function makeStream(chunks: MockChunk[]): AsyncIterable<MockChunk> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const c of chunks) {
+        yield c;
+      }
+    },
+  };
+}
+
+function stubProviderWithErrors(errors: unknown[]): {
+  provider: OpenAIChatCompletionsProvider;
+  requests: unknown[];
+} {
+  const provider = new OpenAIChatCompletionsProvider("test-key", "test-model");
+  const requests: unknown[] = [];
+  const pending = [...errors];
+  (provider as unknown as { client: unknown }).client = {
+    chat: {
+      completions: {
+        create: async (params: unknown) => {
+          // Snapshot: the fallback mutates `params` between attempts.
+          requests.push(JSON.parse(JSON.stringify(params)));
+          const error = pending.shift();
+          if (error !== undefined) {
+            throw error;
+          }
+          return makeStream([
+            {
+              choices: [{ delta: { content: "ok" }, finish_reason: "stop" }],
+              usage: { prompt_tokens: 1, completion_tokens: 1 },
+            },
+          ]);
+        },
+      },
+    },
+  };
+  return { provider, requests };
+}
+
+function rejection(message: string, status = 400): Error {
+  return Object.assign(new Error(message), { status });
+}
+
+// A user message with text + image serializes to a content-parts array.
+const multiPartMessages = [
+  {
+    role: "user" as const,
+    content: [
+      { type: "text" as const, text: "what is this?" },
+      {
+        type: "image" as const,
+        source: {
+          type: "base64" as const,
+          media_type: "image/png",
+          data: "aGk=",
+        },
+      },
+    ],
+  },
+];
+
+describe("string-only content rejection fallback", () => {
+  test("retries once with content flattened to strings", async () => {
+    const { provider, requests } = stubProviderWithErrors([
+      rejection("body/messages/1/content must be string"),
+    ]);
+
+    const response = await provider.sendMessage(multiPartMessages);
+
+    expect(requests).toHaveLength(2);
+    const first = requests[0] as {
+      messages: Array<{ content: unknown }>;
+    };
+    const second = requests[1] as {
+      messages: Array<{ content: unknown }>;
+    };
+    expect(Array.isArray(first.messages[0].content)).toBe(true);
+    const flattened = second.messages[0].content;
+    expect(typeof flattened).toBe("string");
+    expect(flattened).toContain("what is this?");
+    expect(flattened).toContain("[image_url omitted");
+    const text = response.content.find((b) => b.type === "text") as
+      | { type: "text"; text: string }
+      | undefined;
+    expect(text?.text).toBe("ok");
+  });
+
+  test("retries for a pydantic-style rejection (vLLM shape)", async () => {
+    const { provider, requests } = stubProviderWithErrors([
+      rejection("messages.0.content: Input should be a valid string"),
+    ]);
+
+    await provider.sendMessage(multiPartMessages);
+
+    expect(requests).toHaveLength(2);
+  });
+
+  test("does not retry when no message carried array content", async () => {
+    // A single text block serializes to a plain string already, so a retry
+    // would resend an identical request.
+    const { provider, requests } = stubProviderWithErrors([
+      rejection("body/messages/1/content must be string"),
+    ]);
+
+    await expect(
+      provider.sendMessage([
+        { role: "user", content: [{ type: "text", text: "hi" }] },
+      ]),
+    ).rejects.toThrow();
+    expect(requests).toHaveLength(1);
+  });
+
+  test("does not retry an unrelated 400", async () => {
+    const { provider, requests } = stubProviderWithErrors([
+      rejection("invalid api key"),
+    ]);
+
+    await expect(provider.sendMessage(multiPartMessages)).rejects.toThrow();
+    expect(requests).toHaveLength(1);
+  });
+
+  test("does not retry server errors", async () => {
+    const { provider, requests } = stubProviderWithErrors([
+      rejection("content must be string", 500),
+    ]);
+
+    await expect(provider.sendMessage(multiPartMessages)).rejects.toThrow();
+    expect(requests).toHaveLength(1);
+  });
+});

--- a/assistant/src/providers/openai/__tests__/chat-completions-stub.ts
+++ b/assistant/src/providers/openai/__tests__/chat-completions-stub.ts
@@ -47,9 +47,8 @@ export function rejection(message: string, status = 400): Error {
 /**
  * Swap the provider's SDK client for a stub whose chat.completions.create
  * throws the queued `errors` in order (one per call) before streaming the
- * canned `chunks`. Returns the per-call request snapshots — snapshots, not
- * references, because the compatibility fallbacks mutate `params` between
- * attempts.
+ * canned `chunks`. Returns the per-call request snapshots (not references,
+ * because the compatibility fallbacks mutate `params` between attempts).
  */
 export function stubClient(
   provider: object,

--- a/assistant/src/providers/openai/__tests__/chat-completions-stub.ts
+++ b/assistant/src/providers/openai/__tests__/chat-completions-stub.ts
@@ -1,0 +1,76 @@
+/**
+ * Shared stub harness for OpenAIChatCompletionsProvider suites. The provider
+ * instance is passed in by the test file so this helper never imports from
+ * `src/` (see the test-machinery isolation rule in the root AGENTS.md).
+ */
+
+export type ReasoningDetail = {
+  type?: string;
+  summary?: string | null;
+  text?: string | null;
+};
+
+export type MockChunkDelta = {
+  content?: string | null;
+  reasoning?: string | null;
+  reasoning_content?: string | null;
+  reasoning_details?: ReasoningDetail[] | null;
+};
+
+export type MockChunk = {
+  choices: Array<{ delta: MockChunkDelta; finish_reason?: string | null }>;
+  model?: string;
+  usage?: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    prompt_tokens_details?: {
+      cached_tokens?: number;
+      cache_write_tokens?: number;
+    };
+  };
+};
+
+export function makeStream(chunks: MockChunk[]): AsyncIterable<MockChunk> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const c of chunks) {
+        yield c;
+      }
+    },
+  };
+}
+
+export function rejection(message: string, status = 400): Error {
+  return Object.assign(new Error(message), { status });
+}
+
+/**
+ * Swap the provider's SDK client for a stub whose chat.completions.create
+ * throws the queued `errors` in order (one per call) before streaming the
+ * canned `chunks`. Returns the per-call request snapshots — snapshots, not
+ * references, because the compatibility fallbacks mutate `params` between
+ * attempts.
+ */
+export function stubClient(
+  provider: object,
+  chunks: MockChunk[],
+  errors: unknown[] = [],
+): unknown[] {
+  const requests: unknown[] = [];
+  const pending = [...errors];
+  (provider as { client: unknown }).client = {
+    chat: {
+      completions: {
+        create: async (params: unknown) => {
+          requests.push(JSON.parse(JSON.stringify(params)));
+          const error = pending.shift();
+          if (error !== undefined) {
+            throw error;
+          }
+          return makeStream(chunks);
+        },
+      },
+    },
+  };
+  return requests;
+}

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -319,6 +319,51 @@ function isThinkingModeToolChoiceRejection(
 }
 
 /**
+ * True when the provider rejected the request because a message's `content`
+ * was a content-parts array and the endpoint only accepts plain strings
+ * (e.g. `body/messages/1/content must be string`, or pydantic-style
+ * `messages.1.content: Input should be a valid string`). The official OpenAI
+ * spec allows array content, but string-only backends are common among
+ * "OpenAI-compatible" endpoints; one retry with content flattened to strings
+ * beats a hard failure the user cannot configure around.
+ */
+function isStringContentRejection(error: unknown, params: unknown): boolean {
+  const p = params as { messages?: Array<{ content?: unknown }> };
+  if (!p.messages?.some((m) => Array.isArray(m.content))) {
+    return false;
+  }
+  if (!isClientErrorStatus(error)) {
+    return false;
+  }
+  return /content[\s\S]{0,80}?(?:must|should)\s+be\s+(?:a\s+)?(?:valid\s+)?str(?:ing)?\b/i.test(
+    openaiCompatErrorHaystack(error),
+  );
+}
+
+/**
+ * Flatten content-parts arrays to plain strings for string-only backends.
+ * Non-text parts (images, audio) cannot survive the flattening; they are
+ * replaced with a bracketed placeholder naming the dropped part type.
+ */
+function coerceContentPartsToStrings(
+  messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[],
+): OpenAI.Chat.Completions.ChatCompletionMessageParam[] {
+  return messages.map((m) => {
+    if (!Array.isArray(m.content)) {
+      return m;
+    }
+    const content = (m.content as Array<{ type: string; text?: string }>)
+      .map((part) =>
+        typeof part.text === "string"
+          ? part.text
+          : `[${part.type} omitted: this endpoint only accepts plain-text message content]`,
+      )
+      .join("\n");
+    return { ...m, content } as typeof m;
+  });
+}
+
+/**
  * Translate the neutral (Anthropic-shaped) `tool_choice` carried on the call
  * config into the OpenAI chat-completions wire format. Callers express
  * `tool_choice` once in the Anthropic union — `{ type: "auto" | "any" | "none"
@@ -545,8 +590,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
         if (toolChoice !== undefined) {
           const thinkingOn = isThinkingEnabledOnWire(params);
           const skipAutoDefault = thinkingOn && toolChoice === "auto";
-          const skipAllChoices =
-            thinkingOn && this.omitToolChoiceWhenReasoning;
+          const skipAllChoices = thinkingOn && this.omitToolChoiceWhenReasoning;
           if (!skipAutoDefault && !skipAllChoices) {
             params.tool_choice = toolChoice;
           }
@@ -671,6 +715,17 @@ export class OpenAIChatCompletionsProvider implements Provider {
               "Upstream rejected tool_choice in thinking mode; retrying without tool_choice",
             );
             delete params.tool_choice;
+            stream = await createStream();
+          } else if (isStringContentRejection(error, params)) {
+            log.warn(
+              {
+                provider: this.name,
+                model: modelOverride ?? this.model,
+                error: error instanceof Error ? error.message : String(error),
+              },
+              "Endpoint rejected content-parts array; retrying with string message content",
+            );
+            params.messages = coerceContentPartsToStrings(params.messages);
             stream = await createStream();
           } else {
             throw error;

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -335,7 +335,11 @@ function isStringContentRejection(error: unknown, params: unknown): boolean {
   if (!isClientErrorStatus(error)) {
     return false;
   }
-  return /content[\s\S]{0,80}?(?:must|should)\s+be\s+(?:a\s+)?(?:valid\s+)?str(?:ing)?\b/i.test(
+  // Anchored to a `messages` path so a tool-schema validation error about a
+  // parameter that happens to be named `content` (e.g. `tools.0.function.
+  // parameters.properties.content: Input should be a valid string`) cannot
+  // trigger the flattening and silently drop attachments.
+  return /messages[\s\S]{0,40}?content[\s\S]{0,80}?(?:must|should)\s+be\s+(?:a\s+)?(?:valid\s+)?str(?:ing)?\b/i.test(
     openaiCompatErrorHaystack(error),
   );
 }
@@ -689,46 +693,59 @@ export class OpenAIChatCompletionsProvider implements Provider {
               ? { headers: requestHeaders }
               : {}),
           });
-        let stream: Awaited<ReturnType<typeof createStream>>;
-        try {
-          stream = await createStream();
-        } catch (error) {
-          if (isReasoningOptOutRejection(error, params)) {
-            log.warn(
-              {
-                provider: this.name,
-                model: modelOverride ?? this.model,
-                error: error instanceof Error ? error.message : String(error),
-              },
+        // One-shot compatibility adjustments. Each can fire at most once, and
+        // a retry's error is re-classified against the remaining adjustments,
+        // so a request tripping several independent incompatibilities (e.g.
+        // a reasoning opt-out plus array content) still succeeds in one call.
+        const compatAdjustments = [
+          {
+            matches: isReasoningOptOutRejection,
+            warning:
               "Model rejected the explicit reasoning opt-out; retrying without reasoning params",
-            );
-            delete params.reasoning_effort;
-            delete (params as unknown as Record<string, unknown>).reasoning;
-            stream = await createStream();
-          } else if (isThinkingModeToolChoiceRejection(error, params)) {
-            log.warn(
-              {
-                provider: this.name,
-                model: modelOverride ?? this.model,
-                error: error instanceof Error ? error.message : String(error),
-              },
+            apply: () => {
+              delete params.reasoning_effort;
+              delete (params as unknown as Record<string, unknown>).reasoning;
+            },
+          },
+          {
+            matches: isThinkingModeToolChoiceRejection,
+            warning:
               "Upstream rejected tool_choice in thinking mode; retrying without tool_choice",
-            );
-            delete params.tool_choice;
+            apply: () => {
+              delete params.tool_choice;
+            },
+          },
+          {
+            matches: isStringContentRejection,
+            warning:
+              "Endpoint rejected content-parts array; retrying with string message content",
+            apply: () => {
+              params.messages = coerceContentPartsToStrings(params.messages);
+            },
+          },
+        ];
+        let stream: Awaited<ReturnType<typeof createStream>>;
+        for (;;) {
+          try {
             stream = await createStream();
-          } else if (isStringContentRejection(error, params)) {
+            break;
+          } catch (error) {
+            const index = compatAdjustments.findIndex((a) =>
+              a.matches(error, params),
+            );
+            if (index < 0) {
+              throw error;
+            }
+            const [adjustment] = compatAdjustments.splice(index, 1);
             log.warn(
               {
                 provider: this.name,
                 model: modelOverride ?? this.model,
                 error: error instanceof Error ? error.message : String(error),
               },
-              "Endpoint rejected content-parts array; retrying with string message content",
+              adjustment.warning,
             );
-            params.messages = coerceContentPartsToStrings(params.messages);
-            stream = await createStream();
-          } else {
-            throw error;
+            adjustment.apply();
           }
         }
 


### PR DESCRIPTION
## Summary
- Adds a one-shot retry to `OpenAIChatCompletionsProvider`: when an OpenAI-compatible endpoint 4xxs with a `content ... must be string` / `Input should be a valid string` validation error and the request carried content-parts arrays, the request is retried once with each message's parts flattened to a plain string (non-text parts become a bracketed placeholder).
- Mirrors the existing reasoning-opt-out and thinking-mode tool_choice retry branches, reusing `isClientErrorStatus` / `openaiCompatErrorHaystack`.
- Covers the fallback with tests for the observed error shape, the pydantic/vLLM shape, and the no-array / unrelated-400 / 5xx non-retry cases.

## Original prompt
A user's correctly configured custom profile failed against a string-only "OpenAI-compatible" endpoint: the assistant serialized user content as a content-parts array and the endpoint rejected it with `body/messages/1/content must be string`. The official OpenAI spec allows array content, but string-only backends are common among compatible providers, and there was no profile setting or fallback the user could use to get around it. The fix requested was the missing product-side fallback: coerce message content to plain strings and retry when this rejection is seen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTmUzEPHVwy4LxaqWmAkv7
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40916" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->