### PR TITLE
refactor(trust): move the personal-memory gate into effective-capabilities

### DIFF
--- a/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
+++ b/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
@@ -99,7 +99,6 @@ const BASELINE: Record<string, readonly string[]> = {
     "../../../../../security/untrusted-content.js",
     "../../../../api/events/memory-recalled.js",
     "../../../../api/responses/memory-v3-selection-log.js",
-    "../../../../channels/types.js",
     "../../../../config/assistant-feature-flags.js",
     "../../../../config/default-profile-catalog.js",
     "../../../../config/loader.js",

--- a/assistant/src/__tests__/plugin-import-boundary-reverse-guard.test.ts
+++ b/assistant/src/__tests__/plugin-import-boundary-reverse-guard.test.ts
@@ -99,7 +99,6 @@ const BASELINE: Record<string, readonly string[]> = {
     "src/daemon/handlers/skills.ts",
     "src/daemon/skill-memory-refresh.ts",
     "src/daemon/tool-side-effects.ts",
-    "src/daemon/trust-context.ts",
     "src/home/feed-source-enrichment.ts",
     "src/permissions/checker.ts",
     "src/persistence/conversation-crud.ts",

--- a/assistant/src/daemon/trust-context.ts
+++ b/assistant/src/daemon/trust-context.ts
@@ -7,7 +7,7 @@
 import type { ChannelConversationType } from "@vellumai/gateway-client";
 
 import { isHttpAuthDisabled } from "../config/env.js";
-import { shouldExposePersonalMemory } from "../plugins/defaults/memory/substrate/static-context.js";
+import { canSeePersonalMemory } from "../runtime/effective-capabilities.js";
 import type { TrustClass } from "../runtime/trust-class.js";
 import type { TrustContext } from "./trust-context-types.js";
 
@@ -67,21 +67,26 @@ export function resolveTrustClass(
  * Whether personal-memory content may be surfaced for the actor described by
  * `trustContext`: the gate admits guardian-class actors and internal/local
  * flows (including turns with no trust context), and blocks remote untrusted
- * actors — see {@link shouldExposePersonalMemory} for the rationale.
+ * actors.
  *
  * This is THE personal-memory trust gate. Every surface that exposes private
  * user content — the v2 dynamic/static `<memory>` layers, PKB context, NOW.md,
  * memory-v3 cards/spotlight, and the `loadFromDb` rehydration of persisted
  * memory blocks — must call this one helper so the exposure rule cannot drift
- * between copies. It folds in {@link resolveTrustClass} so the dev-bypass
- * (HTTP auth disabled → guardian) applies uniformly at every call site.
+ * between copies.
+ *
+ * The trust-context binding lives here; the policy itself is
+ * {@link canSeePersonalMemory}, alongside the other capability-plus-context
+ * compositions. This adapter folds in {@link resolveTrustClass} so the
+ * dev-bypass (HTTP auth disabled → guardian) applies uniformly at every call
+ * site.
  */
 export function isPersonalMemoryAllowed(
   trustContext: TrustContext | undefined,
 ): boolean {
-  return shouldExposePersonalMemory({
-    sourceChannel: trustContext?.sourceChannel,
-    isTrustedActor: resolveTrustClass(trustContext) === "guardian",
+  return canSeePersonalMemory({
+    trustClass: resolveTrustClass(trustContext),
+    executionChannel: trustContext?.sourceChannel,
   });
 }
 

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-tier-boundary-guard.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-tier-boundary-guard.test.ts
@@ -151,7 +151,6 @@ const HOST_TIER_IMPORT_ALLOWLIST: readonly HostTierImportExemption[] = [
   { path: "src/daemon/embedding-reconcile.ts", tiers: ["substrate", "v3"] },
   { path: "src/daemon/skill-memory-refresh.ts", tiers: ["substrate"] },
   { path: "src/daemon/tool-side-effects.ts", tiers: ["substrate"] },
-  { path: "src/daemon/trust-context.ts", tiers: ["substrate"] },
   { path: "src/persistence/steps.ts", tiers: ["v1"] },
   { path: "src/runtime/routes/consolidation-routes.ts", tiers: ["substrate"] },
   {

--- a/assistant/src/plugins/defaults/memory/substrate/__tests__/static-context.test.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/__tests__/static-context.test.ts
@@ -50,8 +50,7 @@ mock.module("../../config.js", () => ({
   }),
 }));
 
-const { readMemoryV2StaticContent, shouldExposePersonalMemory } =
-  await import("../static-context.js");
+const { readMemoryV2StaticContent } = await import("../static-context.js");
 
 const MEMORY_FILES = [
   "essentials.md",
@@ -359,64 +358,5 @@ describe("readMemoryV2StaticContent Buffer cap", () => {
     expect(lines.filter((line) => line === "line-0")).toHaveLength(3);
     expect(lines.filter((line) => line === "line-29")).toHaveLength(3);
     expect(lines.some((line) => line.endsWith("entry-0"))).toBe(false);
-  });
-});
-
-describe("shouldExposePersonalMemory", () => {
-  test("allows guardian-trusted local conversations", () => {
-    expect(
-      shouldExposePersonalMemory({
-        sourceChannel: "vellum",
-        isTrustedActor: true,
-      }),
-    ).toBe(true);
-  });
-
-  test("allows local-channel conversations even when trust class is unknown (analyze runs, dev)", () => {
-    expect(
-      shouldExposePersonalMemory({
-        sourceChannel: "vellum",
-        isTrustedActor: false,
-      }),
-    ).toBe(true);
-  });
-
-  test("allows turns with no trust context (work-item task runs, internal background)", () => {
-    expect(
-      shouldExposePersonalMemory({
-        sourceChannel: undefined,
-        isTrustedActor: false,
-      }),
-    ).toBe(true);
-  });
-
-  const REMOTE_CHANNELS = [
-    "phone",
-    "slack",
-    "telegram",
-    "whatsapp",
-    "email",
-  ] as const;
-
-  test("allows guardian-trusted remote channels (user's own phone/Slack)", () => {
-    for (const channel of REMOTE_CHANNELS) {
-      expect(
-        shouldExposePersonalMemory({
-          sourceChannel: channel,
-          isTrustedActor: true,
-        }),
-      ).toBe(true);
-    }
-  });
-
-  test("blocks non-guardian remote-channel actors (the leak this gate exists to prevent)", () => {
-    for (const channel of REMOTE_CHANNELS) {
-      expect(
-        shouldExposePersonalMemory({
-          sourceChannel: channel,
-          isTrustedActor: false,
-        }),
-      ).toBe(false);
-    }
   });
 });

--- a/assistant/src/plugins/defaults/memory/substrate/static-context.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/static-context.ts
@@ -26,7 +26,6 @@
 // bounded only by how far behind consolidation has fallen. The injected
 // Buffer section is therefore capped: see `capBufferSection`.
 
-import type { ChannelId } from "../../../../channels/types.js";
 import { usesConceptPageMemory } from "../../../../config/memory-v3-gate.js";
 import { readPromptFile } from "../../../../prompts/system-prompt.js";
 import { type BufferEntryLines, splitBufferEntries } from "../buffer-format.js";
@@ -226,32 +225,4 @@ export function readMemoryV2StaticContent(
     );
   }
   return sections.length > 0 ? sections.join("\n\n") : null;
-}
-
-/**
- * Trust-class predicate for personal-memory injection. Personal memory
- * spans v2 static blocks (essentials/threads/recent/buffer), the PKB
- * context, and NOW.md — all of which can hold private user content. Block
- * injection when a non-guardian actor reaches the assistant over a remote
- * channel — otherwise the model can be prompt-injected into reciting
- * private memory. Internal flows (`sourceChannel: "vellum"`) and turns
- * with no trust context pass through unchanged; this gate exists only to
- * keep remote untrusted actors out.
- *
- * This is the trust-only gate. Cadence (first-turn / post-compaction) is
- * applied separately by the caller so that the freshest content remains
- * available for re-injection after a mid-turn reducer-triggered compaction
- * — the initial-injection turn may not have been a `shouldInjectNowAndPkb`
- * turn, but compaction strips the existing personal-memory blocks and we
- * still need the freshest content to re-inject.
- */
-export function shouldExposePersonalMemory(args: {
-  sourceChannel: ChannelId | undefined;
-  isTrustedActor: boolean;
-}): boolean {
-  const isRemoteUntrustedActor =
-    args.sourceChannel !== undefined &&
-    args.sourceChannel !== "vellum" &&
-    !args.isTrustedActor;
-  return !isRemoteUntrustedActor;
 }

--- a/assistant/src/runtime/effective-capabilities.test.ts
+++ b/assistant/src/runtime/effective-capabilities.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   canActOnPrivilegedDocuments,
+  canSeePersonalMemory,
   isArchiveBySenderAuthorized,
 } from "./effective-capabilities.js";
 
@@ -88,5 +89,47 @@ describe("isArchiveBySenderAuthorized", () => {
         userApproved: false,
       }),
     ).toBe(false);
+  });
+});
+
+describe("canSeePersonalMemory", () => {
+  test("guardian keeps memory on every channel", () => {
+    for (const executionChannel of [undefined, "vellum", "slack", "phone"]) {
+      expect(
+        canSeePersonalMemory({ trustClass: "guardian", executionChannel }),
+      ).toBe(true);
+    }
+  });
+
+  test("no channel means no actor was resolved, which is a local/native turn", () => {
+    // A resolved actor always carries a channel, so absence is a signal rather
+    // than a permissive default.
+    expect(canSeePersonalMemory({ trustClass: undefined })).toBe(true);
+    expect(canSeePersonalMemory({ trustClass: "unknown" })).toBe(true);
+  });
+
+  test("a non-guardian is denied memory on remote channels", () => {
+    for (const executionChannel of ["slack", "phone", "email", "telegram"]) {
+      expect(
+        canSeePersonalMemory({
+          trustClass: "unverified_contact",
+          executionChannel,
+        }),
+      ).toBe(false);
+    }
+  });
+
+  test("a non-guardian on the first-party console currently keeps memory", () => {
+    // Pins today's channel override so a change to it is a deliberate,
+    // visible edit rather than a silent drift.
+    for (const trustClass of [
+      "trusted_contact",
+      "unverified_contact",
+      "unknown",
+    ]) {
+      expect(
+        canSeePersonalMemory({ trustClass, executionChannel: "vellum" }),
+      ).toBe(true);
+    }
   });
 });

--- a/assistant/src/runtime/effective-capabilities.ts
+++ b/assistant/src/runtime/effective-capabilities.ts
@@ -45,6 +45,33 @@ export function canActOnPrivilegedDocuments(actor: {
 }
 
 /**
+ * Channels whose actors see personal memory regardless of trust class. The
+ * `vellum` first-party console is the operator's own surface rather than an
+ * external contact channel, mirroring {@link PRIVILEGED_DOCUMENT_CHANNELS}.
+ */
+const PERSONAL_MEMORY_CHANNELS = new Set<string>(["vellum"]);
+
+/**
+ * Whether personal-memory content (memory pages, PKB, matched v3 card
+ * sections, the v2 static block) may be surfaced to an actor.
+ *
+ * True when the trust class grants it, when the request arrived on a personal
+ * memory channel, or when no channel is present at all -- a resolved actor
+ * always carries one, so its absence means no actor was resolved, which is how
+ * local/native turns arrive.
+ */
+export function canSeePersonalMemory(actor: {
+  trustClass: RawTrustClass;
+  executionChannel?: string;
+}): boolean {
+  return (
+    resolveCapabilities(actor.trustClass).canAccessMemory ||
+    actor.executionChannel == null ||
+    PERSONAL_MEMORY_CHANNELS.has(actor.executionChannel)
+  );
+}
+
+/**
  * Whether an archive-by-sender invocation is authorized. Any one of a surface
  * action, a task-batch authorization, or an explicit prompt approval suffices.
  * Absent those, the actor's own `user_approved` flag only counts when its trust


### PR DESCRIPTION
> **NO BEHAVIOUR CHANGE.** This is a pure relocation. Every actor sees exactly what it saw before, on every channel. Verified by evaluating the old and new predicates across the full cross product of trust classes and channels: **36 combinations, 0 differ** — run, not reasoned about. Nothing about who can see personal memory changes in this PR.

## TL;DR

The personal-memory gate is a trust-class capability composed with the request's channel — exactly what `effective-capabilities.ts` exists for. It predates that module and lived in the memory substrate instead. This moves it into that layer and deletes the leftover copy. No behaviour change.

## Why

`assistant/src/runtime/capabilities.ts` (#35223) resolves a `TrustClass` to a `CapabilitySet` and is deliberately pure: "the single fail-closed trust boundary". `assistant/src/runtime/effective-capabilities.ts` (#35232) is the layer above it, "the single home for decisions that compose a pure trust-class capability with runtime context... rather than re-derived inline at each call site (which scatters a single policy across the codebase)". That commit migrated three such compositions.

`isPersonalMemoryAllowed` is a fourth, and it was missed — it was written in May 2026, about five weeks before that layer existed, and it delegates to `shouldExposePersonalMemory` inside the memory substrate, so it was not an inline composition for #35232 to find.

Living outside the layer cost two things:

- It re-derives the class check as `resolveTrustClass(...) === "guardian"`, which is precisely the pattern #35223 introduced the resolver to eliminate ("so the ~40 inline trust-class conditionals can later read named capabilities instead of re-deriving from the raw class").
- Written as a negated channel conjunction rather than `capability || privilegedChannel`, it drifted out of step with `canAccessMemory` invisibly. `loadFromDb` consults **both**: `resolveCapabilities(trustClass).canAccessMemory` at `conversation.ts:1056` decides which rows load, `isPersonalMemoryAllowed` at `:1127` decides whether persisted personal-memory blocks splice in. For a non-guardian on the `vellum` channel they disagree, so one load can exclude an actor's rows and splice their memory blocks.

## What this does

`canSeePersonalMemory` moves into `effective-capabilities.ts` beside `canActOnPrivilegedDocuments`, which is the same shape: the capability, or a named privileged channel. It reads `resolveCapabilities(...).canAccessMemory` instead of re-deriving the class, and states its two overrides as named arms.

`isPersonalMemoryAllowed` stays put as the trust-context binding — it still folds in `resolveTrustClass` so the dev-bypass applies uniformly — and now delegates the policy. Every existing call site is untouched.

`shouldExposePersonalMemory` had no callers left afterwards and is deleted with its tests, rather than left as a second definition of the same rule.

## Why this is safe

**No behaviour change — this is the load-bearing claim of the PR.** Both predicates were evaluated across the full cross product of trust classes (`guardian`, `trusted_contact`, `unverified_contact`, `unknown`, an unrecognized string, `undefined`) and channels (`vellum`, `slack`, `phone`, `email`, `telegram`, `undefined`): **36 combinations, 0 differ.** That was run, not reasoned about.

The channel override is now pinned by a test asserting today's behaviour, so changing it later has to be a visible, deliberate edit rather than silent drift.

## What this is prep for

Two follow-ups, kept separate so each is reviewable on its own:

- The `vellum` channel override looks obsolete. The test that pinned it named its own rationale — "analyze runs, dev" — and analyze-conversation was removed in #37757, while "dev" is covered by the unresolved-actor arm scoped in #36834. Removing it is a behaviour change and belongs in its own PR.
- Longer term, `loadFromDb` scopes a shared, mutable transcript to an actor and remembers who it was scoped for, while `conversation-runtime-assembly.ts` already does the same job as a pure function of rows plus actor. The second shape makes a whole family of races unrepresentable.

## Verification

`tsc --noEmit`, eslint, pinned prettier. Cross-product equivalence run directly. Local `bun test` is hook-blocked; CI runs the suites.
